### PR TITLE
Tweak RNG engine interface

### DIFF
--- a/src/random/GenerateCanonical.i.hh
+++ b/src/random/GenerateCanonical.i.hh
@@ -28,7 +28,7 @@ CELER_FUNCTION auto GenerateCanonical<Generator, T>::operator()(Generator& rng)
  */
 __device__ float GenerateCanonical<RngEngine, float>::operator()(RngEngine& rng)
 {
-    return curand_uniform(rng.state());
+    return curand_uniform(rng.state_);
 }
 
 //---------------------------------------------------------------------------//
@@ -38,7 +38,7 @@ __device__ float GenerateCanonical<RngEngine, float>::operator()(RngEngine& rng)
 __device__ double
 GenerateCanonical<RngEngine, double>::operator()(RngEngine& rng)
 {
-    return curand_uniform_double(rng.state());
+    return curand_uniform_double(rng.state_);
 }
 
 #endif

--- a/src/random/RngEngine.cuh
+++ b/src/random/RngEngine.cuh
@@ -12,6 +12,9 @@
 
 namespace celeritas
 {
+template<class Generator, class RealType>
+class GenerateCanonical;
+
 //---------------------------------------------------------------------------//
 /*!
  * Sample random numbers on device.
@@ -24,25 +27,31 @@ class RngEngine
     using result_type = unsigned int;
     //@}
 
+    struct RngSeed
+    {
+        unsigned long long seed;
+    };
+
   public:
     // Construct from state
     __device__ inline RngEngine(const RngStatePointers& view,
                                 const ThreadId&         id);
 
+    // Initialize state from seed
+    __device__ RngEngine& operator=(RngSeed s)
+    {
+        curand_init(s.seed, 0, 0, state_);
+        return *this;
+    }
+
     // Sample a random number
     __device__ inline result_type operator()();
 
-    // RNG state; use for implementation only!
-    __device__ inline RngState* state() { return state_; }
-
-    // Initialize state from seed
-    __device__ void initialize_state(seed_type seed)
-    {
-        curand_init(seed, 0, 0, state_);
-    }
-
   private:
     RngState* state_ = nullptr;
+
+    template<class Generator, class RealType>
+    friend class GenerateCanonical;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/random/RngStateStore.hh
+++ b/src/random/RngStateStore.hh
@@ -14,7 +14,7 @@
 
 namespace celeritas
 {
-struct RngStateContainerPimpl;
+struct RngStateStorePimpl;
 struct RngStatePointers;
 //---------------------------------------------------------------------------//
 /*!
@@ -26,14 +26,6 @@ class RngStateStore
     // Construct with the number of RNG states
     RngStateStore(ssize_type size, seed_type host_seed = 12345);
 
-    //@{
-    //! Defaults that cause thrust to launch kernels
-    RngStateStore();
-    ~RngStateStore();
-    RngStateStore(RngStateStore&&);
-    RngStateStore& operator=(RngStateStore&&);
-    //@}
-
     //! Number of states
     ssize_type size() const { return size_; }
 
@@ -44,6 +36,11 @@ class RngStateStore
     RngStatePointers device_pointers() const;
 
   private:
+    struct StateStoreDeleter
+    {
+        void operator()(RngStateStorePimpl*);
+    };
+
     // Host-side RNG for seeding device RNG
     std::mt19937                             host_rng_;
     std::uniform_int_distribution<seed_type> sample_uniform_int_;
@@ -52,7 +49,7 @@ class RngStateStore
     ssize_type size_ = 0;
 
     // Stored RNG states on device
-    std::unique_ptr<RngStateContainerPimpl> data_;
+    std::unique_ptr<RngStateStorePimpl, StateStoreDeleter> data_;
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
A few minor tweaks to the RNG based on some of the other recent code changes:
- Use `operator=` for initialization
- Use friend class for GenerateCanonical specialization, it seems more appropriate
- Use custom deleter for `unique_ptr` to eliminate need for explicitly defaulting destructor/move