### PR TITLE
Add DeviceValue/HostValue

### DIFF
--- a/src/base/DeviceAllocation.cuda.cc
+++ b/src/base/DeviceAllocation.cuda.cc
@@ -28,24 +28,24 @@ DeviceAllocation::DeviceAllocation(size_type bytes) : size_(bytes)
 /*!
  * Copy data to device.
  */
-void DeviceAllocation::copy_to_device(constSpanBytes bytes)
+void DeviceAllocation::copy_to_device(constHostPointers bytes)
 {
     REQUIRE(!this->empty());
-    REQUIRE(bytes.size() == this->size());
+    REQUIRE(bytes.value.size() == this->size());
     CELER_CUDA_CALL(cudaMemcpy(
-        data_.get(), bytes.data(), bytes.size(), cudaMemcpyHostToDevice));
+        data_.get(), bytes.value.data(), bytes.size(), cudaMemcpyHostToDevice));
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Copy data to host.
  */
-void DeviceAllocation::copy_to_host(SpanBytes bytes) const
+void DeviceAllocation::copy_to_host(HostPointers bytes) const
 {
     REQUIRE(!this->empty());
-    REQUIRE(bytes.size() == this->size());
+    REQUIRE(bytes.value.size() == this->size());
     CELER_CUDA_CALL(cudaMemcpy(
-        bytes.data(), data_.get(), this->size(), cudaMemcpyDeviceToHost));
+        bytes.value.data(), data_.get(), this->size(), cudaMemcpyDeviceToHost));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/base/DeviceAllocation.hh
+++ b/src/base/DeviceAllocation.hh
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <memory>
+#include "DeviceValue.hh"
+#include "HostValue.hh"
 #include "Span.hh"
 #include "Types.hh"
 #include "detail/InitializedValue.hh"

--- a/src/base/DeviceAllocation.hh
+++ b/src/base/DeviceAllocation.hh
@@ -31,8 +31,10 @@ class DeviceAllocation
   public:
     //@{
     //! Type aliases
-    using SpanBytes      = span<byte>;
-    using constSpanBytes = span<const byte>;
+    using DevicePointers      = DeviceValue<span<byte>>;
+    using HostPointers        = HostValue<span<byte>>;
+    using constDevicePointers = DeviceValue<span<const byte>>;
+    using constHostPointers   = HostValue<span<const byte>>;
     //@}
 
   public:
@@ -56,16 +58,16 @@ class DeviceAllocation
     // >>> DEVICE ACCESSORS
 
     // Get the device pointer
-    inline SpanBytes device_pointers();
+    inline DevicePointers device_pointers();
 
     // Get the device pointer
-    inline constSpanBytes device_pointers() const;
+    inline constDevicePointers device_pointers() const;
 
     // Copy data to device
-    void copy_to_device(constSpanBytes bytes);
+    void copy_to_device(constHostPointers bytes);
 
     // Copy data to host
-    void copy_to_host(SpanBytes bytes) const;
+    void copy_to_host(HostPointers bytes) const;
 
   private:
     struct CudaFreeDeleter

--- a/src/base/DeviceAllocation.i.hh
+++ b/src/base/DeviceAllocation.i.hh
@@ -25,18 +25,18 @@ void DeviceAllocation::swap(DeviceAllocation& other) noexcept
 /*!
  * Get a view to the owned device memory.
  */
-auto DeviceAllocation::device_pointers() -> SpanBytes
+auto DeviceAllocation::device_pointers() -> DevicePointers
 {
-    return {data_.get(), size_};
+    return {{data_.get(), size_}};
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Get a view to the owned device memory.
  */
-auto DeviceAllocation::device_pointers() const -> constSpanBytes
+auto DeviceAllocation::device_pointers() const -> constDevicePointers
 {
-    return {data_.get(), size_};
+    return {{data_.get(), size_}};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/base/DeviceAllocation.nocuda.cc
+++ b/src/base/DeviceAllocation.nocuda.cc
@@ -30,7 +30,7 @@ void DeviceAllocation::CudaFreeDeleter::operator()(byte*) const
 /*!
  * Copy data to device (not implemented when cuda is disabled).
  */
-void DeviceAllocation::copy_to_device(constSpanBytes)
+void DeviceAllocation::copy_to_device(constHostPointers)
 {
     REQUIRE(false);
 }
@@ -39,7 +39,7 @@ void DeviceAllocation::copy_to_device(constSpanBytes)
 /*!
  * Copy data to host (not implemented when cuda is disabled).
  */
-void DeviceAllocation::copy_to_host(SpanBytes) const
+void DeviceAllocation::copy_to_host(HostPointers) const
 {
     REQUIRE(false);
 }

--- a/src/base/DeviceValue.hh
+++ b/src/base/DeviceValue.hh
@@ -1,0 +1,42 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file DeviceValue.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Type-safe wrapper to indicate GPU/device storage.
+ *
+ * This should be used primarily to wrap \c Pointers classes returned from host
+ * utility code (e.g. from a \c Store class).
+ * \code
+   struct FooStore
+   {
+      DeviceValue<FooPointers> device_pointers();
+      DeviceValue<const FooPointers> device_pointers() const;
+   };
+   \endcode
+ * used like
+ * \code
+   __global__ void do_stuff(const FooPointers pointers);
+
+   void launch_kernel(const FooStore& foo)
+   {
+       do_stuff<<<...>>>(foo.device_pointers().value);
+   }
+   \endcode
+ */
+template<class T>
+struct DeviceValue
+{
+    T value;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/base/DeviceVector.hh
+++ b/src/base/DeviceVector.hh
@@ -36,8 +36,10 @@ class DeviceVector
     //@{
     //! Type aliases
     using value_type  = T;
-    using Span_t      = span<T>;
-    using constSpan_t = span<const T>;
+    using DevicePointers      = DeviceValue<span<value_type>>;
+    using HostPointers        = HostValue<span<value_type>>;
+    using constDevicePointers = DeviceValue<span<const value_type>>;
+    using constHostPointers   = HostValue<span<const value_type>>;
     //@}
 
   public:
@@ -61,16 +63,16 @@ class DeviceVector
     // >>> DEVICE ACCESSORS
 
     // Copy data to device
-    inline void copy_to_device(constSpan_t host_data);
+    inline void copy_to_device(constHostPointers host_data);
 
     // Copy data to host
-    inline void copy_to_host(Span_t host_data) const;
+    inline void copy_to_host(HostPointers host_data) const;
 
     // Get a mutable view to device data
-    inline Span_t device_pointers();
+    inline DevicePointers device_pointers();
 
     // Get a const view to device data
-    inline constSpan_t device_pointers() const;
+    inline constDevicePointers device_pointers() const;
 
   private:
     DeviceAllocation allocation_;

--- a/src/base/DeviceVector.i.hh
+++ b/src/base/DeviceVector.i.hh
@@ -35,11 +35,12 @@ void DeviceVector<T>::swap(DeviceVector& other) noexcept
  * Copy data to device.
  */
 template<class T>
-void DeviceVector<T>::copy_to_device(constSpan_t data)
+void DeviceVector<T>::copy_to_device(constHostPointers data)
 {
-    REQUIRE(data.size() == this->size());
+    REQUIRE(data.value.size() == this->size());
     allocation_.copy_to_device(
-        {reinterpret_cast<const byte*>(data.data()), data.size() * sizeof(T)});
+        {reinterpret_cast<const byte*>(data.value.data()),
+         data.value.size() * sizeof(T)});
 }
 
 //---------------------------------------------------------------------------//
@@ -47,11 +48,11 @@ void DeviceVector<T>::copy_to_device(constSpan_t data)
  * Copy data to host.
  */
 template<class T>
-void DeviceVector<T>::copy_to_host(Span_t data) const
+void DeviceVector<T>::copy_to_host(HostPointers data) const
 {
-    REQUIRE(data.size() == this->size());
-    allocation_.copy_to_host(
-        {reinterpret_cast<byte*>(data.data()), data.size() * sizeof(T)});
+    REQUIRE(data.value.size() == this->size());
+    allocation_.copy_to_host({{reinterpret_cast<byte*>(data.value.data()),
+                               data.value.size() * sizeof(T)}});
 }
 
 //---------------------------------------------------------------------------//
@@ -59,10 +60,10 @@ void DeviceVector<T>::copy_to_host(Span_t data) const
  * Get an on-device view to the data.
  */
 template<class T>
-auto DeviceVector<T>::device_pointers() -> Span_t
+auto DeviceVector<T>::device_pointers() -> DevicePointers
 {
-    return {reinterpret_cast<T*>(allocation_.device_pointers().data()),
-            this->size()};
+    return {{reinterpret_cast<T*>(allocation_.device_pointers().value.data()),
+             this->size()}};
 }
 
 //---------------------------------------------------------------------------//
@@ -70,10 +71,11 @@ auto DeviceVector<T>::device_pointers() -> Span_t
  * Get an on-device view to the data.
  */
 template<class T>
-auto DeviceVector<T>::device_pointers() const -> constSpan_t
+auto DeviceVector<T>::device_pointers() const -> constDevicePointers
 {
-    return {reinterpret_cast<const T*>(allocation_.device_pointers().data()),
-            this->size()};
+    return {
+        {reinterpret_cast<const T*>(allocation_.device_pointers().value.data()),
+         this->size()}};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/base/HostValue.hh
+++ b/src/base/HostValue.hh
@@ -1,0 +1,28 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file HostValue.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Type-safe wrapper to indicate CPU/host storage.
+ *
+ * This should be used primarily to wrap \c Pointers classes returned from host
+ * utility code (e.g. from a \c Store class).
+ *
+ * \sa DeviceValue
+ */
+template<class T>
+struct HostValue
+{
+    T value;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/base/ParticleParams.cc
+++ b/src/physics/base/ParticleParams.cc
@@ -72,7 +72,7 @@ ParticleParamsPointers ParticleParams::device_pointers() const
 {
     REQUIRE(!device_defs_.empty());
     ParticleParamsPointers result;
-    result.defs = device_defs_.device_pointers();
+    result.defs = device_defs_.device_pointers().value;
     ENSURE(result);
     return result;
 }

--- a/src/physics/base/ParticleStateStore.cc
+++ b/src/physics/base/ParticleStateStore.cc
@@ -35,12 +35,12 @@ size_type ParticleStateStore::size() const
 /*!
  * View to on-device state data.
  */
-DevicePointers<ParticleStatePointers> ParticleStateStore::device_pointers()
+auto ParticleStateStore::device_pointers() -> DevicePointers
 {
     ParticleStatePointers pointers;
     pointers.vars = vars_.device_pointers().value;
 
-    ENSURE(result);
+    ENSURE(pointers);
     return {std::move(pointers)};
 }
 

--- a/src/physics/base/ParticleStateStore.cc
+++ b/src/physics/base/ParticleStateStore.cc
@@ -35,13 +35,13 @@ size_type ParticleStateStore::size() const
 /*!
  * View to on-device state data.
  */
-ParticleStatePointers ParticleStateStore::device_pointers()
+DevicePointers<ParticleStatePointers> ParticleStateStore::device_pointers()
 {
-    ParticleStatePointers result;
-    result.vars = vars_.device_pointers();
+    ParticleStatePointers pointers;
+    pointers.vars = vars_.device_pointers().value;
 
     ENSURE(result);
-    return result;
+    return {std::move(pointers)};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/ParticleStateStore.hh
+++ b/src/physics/base/ParticleStateStore.hh
@@ -20,6 +20,12 @@ namespace celeritas
 class ParticleStateStore
 {
   public:
+    //@{
+    //! Type aliases
+    using DevicePointers = DeviceValue<ParticleStatePointers>;
+    //@}
+
+  public:
     // Construct from number of track states
     explicit ParticleStateStore(size_type size);
 
@@ -29,7 +35,7 @@ class ParticleStateStore
     size_type size() const;
 
     // View on-device states
-    ParticleStatePointers device_pointers();
+    DevicePointers device_pointers();
 
   private:
     DeviceVector<ParticleTrackState> vars_;

--- a/src/physics/base/SecondaryAllocatorStore.cc
+++ b/src/physics/base/SecondaryAllocatorStore.cc
@@ -29,13 +29,13 @@ SecondaryAllocatorStore::SecondaryAllocatorStore(size_type capacity)
 /*!
  * Get a view to the managed data.
  */
-SecondaryAllocatorPointers SecondaryAllocatorStore::device_pointers()
+auto SecondaryAllocatorStore::device_pointers() -> DevicePointers
 {
     REQUIRE(!allocation_.empty());
     SecondaryAllocatorPointers view;
-    view.storage = allocation_.device_pointers();
-    view.size    = size_allocation_.device_pointers().data();
-    return view;
+    view.storage = allocation_.device_pointers().value;
+    view.size    = size_allocation_.device_pointers().value.data();
+    return {view};
 }
 
 //---------------------------------------------------------------------------//
@@ -48,7 +48,7 @@ SecondaryAllocatorPointers SecondaryAllocatorStore::device_pointers()
 void SecondaryAllocatorStore::clear()
 {
     REQUIRE(!size_allocation_.empty());
-    device_memset_zero(size_allocation_.device_pointers());
+    device_memset_zero(size_allocation_.device_pointers().value);
 }
 
 //---------------------------------------------------------------------------//
@@ -63,7 +63,7 @@ auto SecondaryAllocatorStore::get_size() -> size_type
 {
     REQUIRE(!size_allocation_.empty());
     size_type result;
-    size_allocation_.copy_to_host({&result, 1});
+    size_allocation_.copy_to_host({{&result, 1}});
     return result;
 }
 

--- a/src/physics/base/SecondaryAllocatorStore.hh
+++ b/src/physics/base/SecondaryAllocatorStore.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "base/DeviceValue.hh"
 #include "base/DeviceVector.hh"
 #include "SecondaryAllocatorPointers.hh"
 #include "Secondary.hh"
@@ -26,6 +27,7 @@ class SecondaryAllocatorStore
     //@{
     //! Type aliases
     using size_type = SecondaryAllocatorPointers::size_type;
+    using DevicePointers = DeviceValue<SecondaryAllocatorPointers>;
     //@}
 
   public:
@@ -49,7 +51,7 @@ class SecondaryAllocatorStore
     // >>> DEVICE ACCESSORS
 
     // Get a view to the managed data
-    SecondaryAllocatorPointers device_pointers();
+    DevicePointers device_pointers();
 
   private:
     DeviceVector<Secondary> allocation_;


### PR DESCRIPTION
@pcanal @tmdelellis I'm making a new branch (after merging physics-base) for the DeviceValue code because I think it'll need some iteration to get right. Right now with a simple struct, I don't think it's adding much value and it's adding a LOT of boilerplate code that clutters up the usage. Basically I have to add `{}` around everything to implicitly convert to a `XValue`, and add `.value` all over the place to get the pointed-to data. Because the struct allows implict construction and direct access of the data, I'm not sure it's doing much in that sense -- it's not like `thrust::device_ptr` which forces you to call `device_ptr_cast` wherever you use it.

Please take a quick look at some of the changes and you'll hopefully see what I mean about this first attempt being clumsy -- any suggestions on improvements? 