### PR TITLE
Klein-Nishina demo app

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/googletest"]
 	path = external/googletest
 	url = https://github.com/google/googletest.git
+[submodule "external/nlohmann_json"]
+	path = external/nlohmann_json
+	url = https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ include(CeleritasUtils)
 #---------------------------------------------------------------------------##
 
 # Tests
+option(CELERITAS_BUILD_DEMOS "Build Celeritas demonstration mini-apps" ON)
 option(CELERITAS_BUILD_TESTS "Build Celeritas unit tests" ON)
 
 # TPLs
@@ -54,7 +55,8 @@ endif()
 option(CELERITAS_DEBUG "Enable runtime assertions" ON)
 if(NOT CMAKE_BUILD_TYPE AND (CMAKE_GENERATOR STREQUAL "Ninja"
     OR CMAKE_GENERATOR STREQUAL "Unix Makefiles"))
-  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type" FORCE)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING
+    "Build type set to default by Celeritas CMakeLists" FORCE)
 endif()
 
 set(CMAKE_CXX_STANDARD 14)
@@ -66,9 +68,11 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(CELERITAS_USE_CUDA)
   # Use host compiler by default to ensure ABI consistency
-  set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE STRING "")
+  set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE STRING
+    "Set to CMAKE_CXX_COMPILER by Celeritas CMakeLists")
   # Default to building device debug code
-  set(CMAKE_CUDA_FLAGS_DEBUG "-g -G" CACHE STRING "")
+  set(CMAKE_CUDA_FLAGS_DEBUG "-g -G" CACHE STRING
+    "Set by Celeritas CMakeLists")
 
   enable_language(CUDA)
   set(CMAKE_CUDA_STANDARD 14)
@@ -104,9 +108,27 @@ if(CELERITAS_USE_VecGeom)
   endif()
 endif()
 
+if(CELERITAS_BUILD_TESTS AND CELERITAS_BUILD_DEMOS)
+  find_package(Python 3.6 COMPONENTS Interpreter REQUIRED)
+endif()
+
+#---------------------------------------------------------------------------##
+# EXTERNALS
+#---------------------------------------------------------------------------##
+include(CeleritasLoadSubmodule)
+
+if(NOT CELERITAS_GIT_SUBMODULE)
+  set(_required_when_no_git REQUIRED)
+else()
+  set(_required_when_no_git QUIET)
+endif()
+
+if(CELERITAS_BUILD_DEMOS)
+  find_package(nlohmann_json 3.7.0 ${_required_when_no_git})
+endif()
+
 if(CELERITAS_BUILD_TESTS)
-  # Use external gtest if available
-  find_package(GTest)
+  find_package(GTest ${_required_when_no_git})
 endif()
 
 add_subdirectory(external)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,11 @@ if(CELERITAS_USE_VecGeom)
   endif()
 endif()
 
+if(CELERITAS_BUILD_TESTS)
+  # Use external gtest if available
+  find_package(GTest)
+endif()
+
 add_subdirectory(external)
 
 #---------------------------------------------------------------------------##

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -57,3 +57,28 @@ if(CELERITAS_USE_Geant4 AND CELERITAS_USE_ROOT)
 endif()
 
 #-----------------------------------------------------------------------------#
+
+if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA)
+  add_executable(demo-interactor
+    demo-interactor/demo-interactor.cc
+    demo-interactor/KNDemoIO.cc
+    demo-interactor/KNDemoRunner.cc
+    demo-interactor/KNDemoKernel.cu
+  )
+  target_link_libraries(demo-interactor celeritas
+    CUDA::cudart
+    nlohmann_json::nlohmann_json
+  )
+
+  if(CELERITAS_BUILD_TESTS)
+    add_test(NAME "app/demo-interactor"
+      COMMAND "${Python_EXECUTABLE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py"
+    )
+    set_tests_properties("app/demo-interactor" PROPERTIES
+      ENVIRONMENT "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-interactor>"
+    )
+  endif()
+endif()
+
+#-----------------------------------------------------------------------------#

--- a/app/demo-interactor/KNDemoIO.cc
+++ b/app/demo-interactor/KNDemoIO.cc
@@ -1,0 +1,63 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file KNDemoIO.cc
+//---------------------------------------------------------------------------//
+#include "KNDemoIO.hh"
+
+#include <nlohmann/json.hpp>
+
+namespace demo_interactor
+{
+//---------------------------------------------------------------------------//
+//@{
+//! I/O routines for JSON
+void to_json(nlohmann::json& j, const CudaGridParams& v)
+{
+    j = nlohmann::json{{"block_size", v.block_size},
+                       {"grid_size", v.grid_size}};
+}
+
+void from_json(const nlohmann::json& j, CudaGridParams& v)
+{
+    j.at("block_size").get_to(v.block_size);
+    j.at("grid_size").get_to(v.grid_size);
+}
+
+void to_json(nlohmann::json& j, const KNDemoRunArgs& v)
+{
+    j = nlohmann::json{{"energy", v.energy},
+                       {"seed", v.seed},
+                       {"num_tracks", v.num_tracks},
+                       {"max_steps", v.max_steps}};
+}
+
+void from_json(const nlohmann::json& j, KNDemoRunArgs& v)
+{
+    j.at("energy").get_to(v.energy);
+    j.at("seed").get_to(v.seed);
+    j.at("num_tracks").get_to(v.num_tracks);
+    j.at("max_steps").get_to(v.max_steps);
+}
+
+void to_json(nlohmann::json& j, const KNDemoResult& v)
+{
+    j = nlohmann::json{{"time", v.time},
+                       {"edep", v.edep},
+                       {"alive", v.alive},
+                       {"total_time", v.total_time}};
+}
+
+void from_json(const nlohmann::json& j, KNDemoResult& v)
+{
+    j.at("time").get_to(v.time);
+    j.at("edep").get_to(v.edep);
+    j.at("alive").get_to(v.alive);
+    j.at("total_time").get_to(v.total_time);
+}
+//@}
+
+//---------------------------------------------------------------------------//
+} // namespace demo_interactor

--- a/app/demo-interactor/KNDemoIO.hh
+++ b/app/demo-interactor/KNDemoIO.hh
@@ -1,0 +1,56 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file KNDemoIO.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+#include "KNDemoKernel.hh"
+#include "base/Types.hh"
+#include <nlohmann/json.hpp>
+
+namespace demo_interactor
+{
+//---------------------------------------------------------------------------//
+// Classes
+//---------------------------------------------------------------------------//
+//! Input for a single run
+struct KNDemoRunArgs
+{
+    using size_type = celeritas::size_type;
+
+    double        energy;
+    unsigned long seed;
+    size_type     num_tracks;
+    size_type     max_steps;
+};
+
+//! Output from a single run
+struct KNDemoResult
+{
+    using size_type = celeritas::size_type;
+
+    std::vector<double>    time;           //!< Real time per step
+    std::vector<double>    edep;           //!< Energy deposition per step
+    std::vector<size_type> alive;          //!< Num living tracks
+    double                 total_time = 0; //!< All time
+};
+
+//---------------------------------------------------------------------------//
+// JSON I/O functions
+//---------------------------------------------------------------------------//
+
+void to_json(nlohmann::json& j, const CudaGridParams& value);
+void from_json(const nlohmann::json& j, CudaGridParams& value);
+
+void to_json(nlohmann::json& j, const KNDemoRunArgs& value);
+void from_json(const nlohmann::json& j, KNDemoRunArgs& value);
+
+void to_json(nlohmann::json& j, const KNDemoResult& value);
+void from_json(const nlohmann::json& j, KNDemoResult& value);
+
+//---------------------------------------------------------------------------//
+} // namespace demo_interactor

--- a/app/demo-interactor/KNDemoKernel.cu
+++ b/app/demo-interactor/KNDemoKernel.cu
@@ -1,0 +1,200 @@
+//---------------------------------*-CUDA-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file KNDemoKernel.cu
+//---------------------------------------------------------------------------//
+#include "KNDemoKernel.hh"
+
+#include <thrust/device_ptr.h>
+#include <thrust/reduce.h>
+#include "base/Assert.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/em/KleinNishinaInteractor.hh"
+#include "random/cuda/RngEngine.cuh"
+
+using namespace celeritas;
+
+namespace demo_interactor
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Kernel to initialize particle data.
+ *
+ * For testing purposes (this might not be the case for the final app) we use a
+ * grid-stride loop rather than requiring that each thread correspond exactly
+ * to a particle track. In other words, this method allows a single warp to
+ * operate on two 32-thread chunks of data.
+ *  https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/
+ */
+__global__ void initialize_kn(const ParticleParamsPointers params,
+                              const ParticleStatePointers  states,
+                              const ParticleTrackState     initial_state,
+                              Real3*                       direction,
+                              bool*                        alive)
+{
+    // Grid-stride loop, see
+    for (int tid = blockIdx.x * blockDim.x + threadIdx.x;
+         tid < static_cast<int>(states.vars.size());
+         tid += blockDim.x * gridDim.x)
+    {
+        ParticleTrackView particle(params, states, ThreadId(tid));
+        particle = initial_state;
+
+        // Particles begin alive and in the +z direction
+        direction[tid] = {0, 0, 1};
+        alive[tid]     = true;
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Perform a single interaction per particle track.
+ *
+ * The interaction:
+ * - Clears the energy deposition
+ * - Samples the KN interaction
+ * - Allocates and emits a secondary
+ * - Kills the secondary, depositing its local energy
+ * - Applies the interaction (updating track direction and energy)
+ */
+__global__ void iterate_kn(ParticleParamsPointers const         params,
+                           ParticleStatePointers const          states,
+                           KleinNishinaInteractorPointers const kn_params,
+                           SecondaryAllocatorPointers const     secondaries,
+                           RngStatePointers const               rng_states,
+                           Real3* const                         direction,
+                           bool* const                          alive,
+                           real_type* const energy_deposition)
+{
+    SecondaryAllocatorView allocate_secondaries(secondaries);
+
+    for (int tid = blockIdx.x * blockDim.x + threadIdx.x;
+         tid < static_cast<int>(states.vars.size());
+         tid += blockDim.x * gridDim.x)
+    {
+        // Zero energy deposition from this thread, before skipping
+        energy_deposition[tid] = 0;
+
+        // Skip loop if already dead
+        if (!alive[tid])
+        {
+            continue;
+        }
+
+        // Construct particle accessor from immutable and thread-local data
+        ParticleTrackView particle(params, states, ThreadId(tid));
+
+        if (particle.energy() < KleinNishinaInteractor::min_incident_energy())
+        {
+            // Particle is below interaction energy; kill and deposit energy
+            energy_deposition[tid] = particle.energy();
+            alive[tid]             = false;
+            continue;
+        }
+
+        // Construct RNG and interaction interfaces
+        RngEngine              rng(rng_states, ThreadId(tid));
+        KleinNishinaInteractor interact(
+            kn_params, particle, direction[tid], allocate_secondaries);
+
+        // Perform interaction: should emit a single particle (an electron)
+        Interaction interaction = interact(rng);
+        CHECK(interaction);
+        CHECK(interaction.secondaries.size() == 1);
+
+        // Deposit energy from the secondary (effectively, an infinite energy
+        // cutoff)
+        energy_deposition[tid] = interaction.secondaries.front().energy;
+
+        // Update post-interaction state (apply interaction)
+        direction[tid] = interaction.direction;
+        particle.energy(interaction.energy);
+    }
+}
+
+//---------------------------------------------------------------------------//
+// HOST INTERFACES
+//---------------------------------------------------------------------------//
+/*!
+ * Initialize particle states.
+ */
+void initialize(CudaGridParams         grid,
+                ParticleParamsPointers params,
+                ParticleStatePointers  states,
+                ParticleTrackState     initial_state,
+                RngStatePointers       rng_states,
+                span<Real3>            direction,
+                span<bool>             alive)
+{
+    REQUIRE(alive.size() == rng_states.rng.size());
+    REQUIRE(alive.size() == states.vars.size());
+    initialize_kn<<<grid.grid_size, grid.block_size>>>(
+        params, states, initial_state, direction.data(), alive.data());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Run an iteration.
+ */
+void iterate(CudaGridParams                 kernel_params,
+             ParticleParamsPointers         particle_params,
+             ParticleStatePointers          particle_states,
+             KleinNishinaInteractorPointers kn_params,
+             SecondaryAllocatorPointers     secondaries,
+             RngStatePointers               rng_states,
+             span<Real3>                    direction,
+             span<bool>                     alive,
+             span<real_type>                energy_deposition)
+{
+    iterate_kn<<<kernel_params.grid_size, kernel_params.block_size>>>(
+        particle_params,
+        particle_states,
+        kn_params,
+        secondaries,
+        rng_states,
+        direction.data(),
+        alive.data(),
+        energy_deposition.data());
+
+    // Note: the device synchronize is useful for debugging and necessary for
+    // timing diagnostics.
+    CELER_CUDA_CALL(cudaDeviceSynchronize());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sum the total energy deposition.
+ */
+real_type reduce_energy_dep(span<real_type> edep)
+{
+    real_type result = thrust::reduce(
+        thrust::device_pointer_cast(edep.data()),
+        thrust::device_pointer_cast(edep.data() + edep.size()),
+        real_type(0),
+        thrust::plus<real_type>());
+
+    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sum the total number of living particles.
+ */
+size_type reduce_alive(span<bool> alive)
+{
+    size_type result = thrust::reduce(
+        thrust::device_pointer_cast(alive.data()),
+        thrust::device_pointer_cast(alive.data() + alive.size()),
+        size_type(0),
+        thrust::plus<size_type>());
+
+    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace demo_interactor

--- a/app/demo-interactor/KNDemoKernel.hh
+++ b/app/demo-interactor/KNDemoKernel.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file KNDemoKernel.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Span.hh"
+#include "base/Types.hh"
+#include "physics/base/ParticleParamsPointers.hh"
+#include "physics/base/ParticleStatePointers.hh"
+#include "physics/base/SecondaryAllocatorPointers.hh"
+#include "physics/em/KleinNishinaInteractorPointers.hh"
+
+namespace celeritas
+{
+struct RngStatePointers;
+}
+
+namespace demo_interactor
+{
+//---------------------------------------------------------------------------//
+//! Kernel thread dimensions
+struct CudaGridParams
+{
+    unsigned int block_size = 256; //!< Threads per block
+    unsigned int grid_size  = 32;  //!< Blocks per grid
+};
+
+//---------------------------------------------------------------------------//
+// Initialize particle states
+void initialize(CudaGridParams                    grid,
+                celeritas::ParticleParamsPointers params,
+                celeritas::ParticleStatePointers  states,
+                celeritas::ParticleTrackState     initial_state,
+                celeritas::RngStatePointers       rng_states,
+                celeritas::span<celeritas::Real3> direction,
+                celeritas::span<bool>             alive);
+
+//---------------------------------------------------------------------------//
+// Run an iteration
+void iterate(CudaGridParams                            grid,
+             celeritas::ParticleParamsPointers         params,
+             celeritas::ParticleStatePointers          states,
+             celeritas::KleinNishinaInteractorPointers kn_params,
+             celeritas::SecondaryAllocatorPointers     secondaries,
+             celeritas::RngStatePointers               rng_states,
+             celeritas::span<celeritas::Real3>         direction,
+             celeritas::span<bool>                     alive,
+             celeritas::span<celeritas::real_type>     energy_deposition);
+
+//---------------------------------------------------------------------------//
+// Sum the total energy deposition
+celeritas::real_type
+reduce_energy_dep(celeritas::span<celeritas::real_type> edep);
+
+//---------------------------------------------------------------------------//
+// Sum the total number of living particles
+celeritas::size_type reduce_alive(celeritas::span<bool> alive);
+
+//---------------------------------------------------------------------------//
+} // namespace demo_interactor

--- a/app/demo-interactor/KNDemoRunner.cc
+++ b/app/demo-interactor/KNDemoRunner.cc
@@ -1,0 +1,124 @@
+//---------------------------------*-C++-*-----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file KNDemoRunner.cc
+//---------------------------------------------------------------------------//
+#include "KNDemoRunner.hh"
+
+#include "base/Range.hh"
+#include "base/Stopwatch.hh"
+#include "random/cuda/RngStateStore.hh"
+#include "physics/base/ParticleStateStore.hh"
+#include "physics/base/SecondaryAllocatorStore.hh"
+#include "physics/base/Units.hh"
+
+using namespace celeritas;
+
+namespace demo_interactor
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with parameters.
+ */
+KNDemoRunner::KNDemoRunner(constSPParticleParams particles,
+                           CudaGridParams        solver)
+    : pparams_(std::move(particles)), launch_params_(std::move(solver))
+{
+    REQUIRE(pparams_);
+    REQUIRE(launch_params_.block_size > 0);
+    REQUIRE(launch_params_.grid_size > 0);
+
+    // Set up KN interactor data;
+    using celeritas::units::speed_of_light_sq;
+    namespace pdg            = celeritas::pdg;
+    kn_pointers_.electron_id = pparams_->find(pdg::electron());
+    kn_pointers_.gamma_id    = pparams_->find(pdg::gamma());
+    kn_pointers_.inv_electron_mass_csq
+        = 1
+          / (pparams_->get(kn_pointers_.electron_id).mass * speed_of_light_sq);
+    ENSURE(kn_pointers_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Run with a given particle vector size and max iterations.
+ */
+auto KNDemoRunner::operator()(KNDemoRunArgs args) -> result_type
+{
+    REQUIRE(args.energy > 0);
+    REQUIRE(args.num_tracks > 0);
+
+    // Initialize results
+    result_type result;
+    result.time.reserve(args.max_steps);
+    result.alive.reserve(args.max_steps + 1);
+    result.edep.reserve(args.max_steps);
+
+    // Start timer for overall execution
+    Stopwatch total_time;
+
+    // Allocate device data
+    SecondaryAllocatorStore secondaries(args.num_tracks);
+    ParticleStateStore      track_states(args.num_tracks);
+    RngStateStore           rng_states(args.num_tracks, args.seed);
+    DeviceVector<Real3>     direction(args.num_tracks);
+    DeviceVector<double>    energy_deposition(args.num_tracks);
+    DeviceVector<bool>      alive(args.num_tracks);
+
+    // Initialize particle states
+    initialize(launch_params_,
+               pparams_->device_pointers(),
+               track_states.device_pointers(),
+               ParticleTrackState{kn_pointers_.gamma_id, args.energy},
+               rng_states.device_pointers(),
+               direction.device_pointers(),
+               alive.device_pointers());
+
+    result.alive.push_back(args.num_tracks);
+
+    size_type remaining_steps = args.max_steps;
+    while (result.alive.back())
+    {
+        // Launch the kernel
+        Stopwatch elapsed_time;
+        iterate(launch_params_,
+                pparams_->device_pointers(),
+                track_states.device_pointers(),
+                kn_pointers_,
+                secondaries.device_pointers(),
+                rng_states.device_pointers(),
+                direction.device_pointers(),
+                alive.device_pointers(),
+                energy_deposition.device_pointers());
+
+        // Save the time
+        result.time.push_back(elapsed_time());
+
+        // Calculate average energy deposition
+        result.edep.push_back(
+            reduce_energy_dep(energy_deposition.device_pointers()));
+
+        // Clear secondaries, which have all effectively been "killed" inside
+        // the `iterate` kernel (local energy deposited)
+        secondaries.clear();
+
+        // Calculate and save number of living particles
+        result.alive.push_back(reduce_alive(alive.device_pointers()));
+
+        if (--remaining_steps == 0)
+        {
+            // Exceeded step count
+            break;
+        }
+    }
+
+    // Store total time
+    result.total_time = total_time();
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace demo_interactor

--- a/app/demo-interactor/KNDemoRunner.hh
+++ b/app/demo-interactor/KNDemoRunner.hh
@@ -1,0 +1,51 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file KNDemoRunner.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "physics/base/ParticleParams.hh"
+#include "physics/em/KleinNishinaInteractorPointers.hh"
+#include "KNDemoKernel.hh"
+#include "KNDemoIO.hh"
+
+namespace demo_interactor
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Run a bunch of interactions.
+ *
+ * \code
+    KNDemoRunner run_demo(pparams, args);
+    auto diagnosticss = run_demo(1e6, 10);
+   \endcode
+ */
+class KNDemoRunner
+{
+  public:
+    //@{
+    //! Type aliases
+    using size_type   = celeritas::size_type;
+    using result_type = KNDemoResult;
+    using constSPParticleParams
+        = std::shared_ptr<const celeritas::ParticleParams>;
+    //@}
+
+  public:
+    // Construct with parameters
+    KNDemoRunner(constSPParticleParams particles, CudaGridParams solver);
+
+    // Run with a given particle vector size and max iterations
+    result_type operator()(KNDemoRunArgs args);
+
+  private:
+    constSPParticleParams                     pparams_;
+    CudaGridParams                            launch_params_;
+    celeritas::KleinNishinaInteractorPointers kn_pointers_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace demo_interactor

--- a/app/demo-interactor/demo-interactor.cc
+++ b/app/demo-interactor/demo-interactor.cc
@@ -1,0 +1,120 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file demo-interactor.cc
+//---------------------------------------------------------------------------//
+
+#include <cstddef>
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+#include <nlohmann/json.hpp>
+#include "comm/Communicator.hh"
+#include "comm/ScopedMpiInit.hh"
+#include "comm/Utils.hh"
+#include "physics/base/ParticleParams.hh"
+#include "KNDemoIO.hh"
+#include "KNDemoRunner.hh"
+
+using namespace celeritas;
+using namespace demo_interactor;
+using std::cerr;
+using std::cout;
+using std::endl;
+
+namespace demo_interactor
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct particle parameters and send to GPU.
+ */
+std::shared_ptr<ParticleParams> load_params()
+{
+    ParticleParams::VecAnnotatedDefs defs;
+    defs.push_back({{"gamma", pdg::gamma()},
+                    {0, 0, ParticleDef::stable_decay_constant()}});
+    defs.push_back({{"electron", pdg::electron()},
+                    {0.5109989461, -1, ParticleDef::stable_decay_constant()}});
+    return std::make_shared<ParticleParams>(std::move(defs));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Run, launch, and output.
+ */
+void run(std::istream& is)
+{
+    // Read input options
+    auto inp = nlohmann::json::parse(is);
+
+    // Initialize GPU
+    celeritas::initialize_device(Communicator::comm_world());
+
+    // Construct runner
+    auto         grid_params = inp.at("grid_params").get<CudaGridParams>();
+    KNDemoRunner run(load_params(), grid_params);
+
+    // For now, only do a single run
+    auto run_args = inp.at("run").get<KNDemoRunArgs>();
+    REQUIRE(run_args.energy > 0);
+    REQUIRE(run_args.num_tracks > 0);
+    REQUIRE(run_args.max_steps > 0);
+    auto result = run(run_args);
+
+    nlohmann::json outp = {
+        {"grid_params", grid_params},
+        {"run", run_args},
+        {"result", result},
+    };
+    cout << outp.dump() << endl;
+}
+} // namespace demo_interactor
+
+//---------------------------------------------------------------------------//
+/*!
+ * Execute and run.
+ */
+int main(int argc, char* argv[])
+{
+    ScopedMpiInit scoped_mpi(&argc, &argv);
+    Communicator  comm = Communicator::comm_world();
+    if (comm.size() != 1)
+    {
+        if (comm.rank() == 0)
+        {
+            cerr << "This app is currently serial-only. Run with 1 proc."
+                 << endl;
+        }
+        return EXIT_FAILURE;
+    }
+
+    // Process input arguments
+    std::vector<std::string> args(argv, argv + argc);
+    if (args.size() != 2 || args[1] == "--help" || args[1] == "-h")
+    {
+        cerr << "usage: " << args[0] << " {input}.json" << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (args[1] != "-")
+    {
+        std::ifstream infile(args[1]);
+        if (!infile)
+        {
+            cerr << "fatal: failed to open '" << args[1] << "'" << endl;
+            return EXIT_FAILURE;
+        }
+        run(infile);
+    }
+    else
+    {
+        // Read input from STDIN
+        run(std::cin);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/app/demo-interactor/simple-driver.py
+++ b/app/demo-interactor/simple-driver.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2020 UT-Battelle, LLC and other Celeritas Developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""
+"""
+import json
+from pprint import pprint
+import subprocess
+from os import environ
+
+inp = {
+    'grid_params': {
+        'block_size': 256,
+        'grid_size': 64,
+    },
+    'run': {
+        'seed': 12345,
+        'energy': 1e2, # MeV
+        'num_tracks': 256 * 256,
+        'max_steps': 128,
+    }
+}
+
+print("Input:")
+pprint(inp)
+
+exe = environ.get('CELERITAS_DEMO_EXE', './demo-interactor')
+print("Running", exe)
+with subprocess.Popen([exe, '-'],
+                      stdin=subprocess.PIPE,
+                      stdout=subprocess.PIPE) as proc:
+    (output, _) = proc.communicate(input=json.dumps(inp).encode())
+
+print("Received {} bytes of data".format(len(output)))
+result = json.loads(output.decode())['result']
+pprint(result)
+
+num_tracks = result['alive'][0]
+num_iters = len(result['edep'])
+num_track_steps = sum(result['alive'])
+print("Number of steps:", num_iters,
+      "(average", num_track_steps / num_tracks, " per track)")
+print("Fraction of time in kernel:", sum(result['time']) /
+        result['total_time'])

--- a/cmake/CeleritasLoadSubmodule.cmake
+++ b/cmake/CeleritasLoadSubmodule.cmake
@@ -115,7 +115,7 @@ function(celeritas_load_submodule SUBDIR)
       " ${SUBDIR} failed (cwd ${CMAKE_CURRENT_SOURCE_DIR}): "
       "error code ${GIT_SUBMOD_RESULT}${GIT_SUBMOD_ERR}); "
       "${_ERROR_MSG}${GIT_SUBMOD_MSG}")
-  else()
+  elseif(GIT_SUBMOD_MSG)
     message(STATUS
       "Successfully updated git submodule \"${SUBDIR}\"${GIT_SUBMOD_MSG}")
   endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -9,12 +9,21 @@
 #----------------------------------------------------------------------------#
 
 if(CELERITAS_BUILD_TESTS AND NOT TARGET GTest::GTest)
-  include(CeleritasLoadSubmodule)
-
   # Externally installed gtest is not in use: pull integrated googletest
   celeritas_load_submodule(googletest)
   # Compile googletest
   include(${CMAKE_CURRENT_LIST_DIR}/cmake/googletest.cmake)
+endif()
+
+#----------------------------------------------------------------------------#
+# NLOHMANN JSON
+#----------------------------------------------------------------------------#
+
+if(CELERITAS_BUILD_DEMOS AND NOT TARGET nlohmann_json::nlohmann_json)
+  # Externally installed gtest is not in use: pull integrated googletest
+  celeritas_load_submodule(nlohmann_json)
+  # Compile googletest
+  include(${CMAKE_CURRENT_LIST_DIR}/cmake/nlohmann_json.cmake)
 endif()
 
 #---------------------------------------------------------------------------##

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -4,14 +4,14 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 #----------------------------------------------------------------------------#
 
-include(CeleritasLoadSubmodule)
-
 #----------------------------------------------------------------------------#
 # GOOGLETEST
 #----------------------------------------------------------------------------#
 
-if (CELERITAS_BUILD_TESTS)
-  # Pull integrated googletest
+if(CELERITAS_BUILD_TESTS AND NOT TARGET GTest::GTest)
+  include(CeleritasLoadSubmodule)
+
+  # Externally installed gtest is not in use: pull integrated googletest
   celeritas_load_submodule(googletest)
   # Compile googletest
   include(${CMAKE_CURRENT_LIST_DIR}/cmake/googletest.cmake)

--- a/external/cmake/nlohmann_json.cmake
+++ b/external/cmake/nlohmann_json.cmake
@@ -1,0 +1,19 @@
+#----------------------------------*-CMake-*----------------------------------#
+# Copyright 2020 UT-Battelle, LLC and other Celeritas Developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#[=======================================================================[.rst:
+
+nlohmann_json
+-------------
+
+Include this file *directly* from the parent directory to set up JSON.
+
+#]=======================================================================]
+
+# Set up options
+set(JSON_BuildTests OFF CACHE INTERNAL "")
+
+add_subdirectory(nlohmann_json)
+
+#-----------------------------------------------------------------------------#

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,6 @@ list(APPEND SOURCES
   physics/base/ParticleParams.cc
   physics/base/ParticleStateStore.cc
   physics/base/SecondaryAllocatorStore.cc
-  random/cuda/RngStateStore.cc
 )
 
 if(CELERITAS_USE_CUDA)
@@ -40,6 +39,7 @@ if(CELERITAS_USE_CUDA)
     base/KernelParamCalculator.cuda.cc
     base/Memory.cu
     random/cuda/RngStateInit.cu
+    random/cuda/RngStateStore.cc
   )
   list(APPEND PRIVATE_DEPS CUDA::cudart)
 else()

--- a/src/physics/base/ParticleTrackView.hh
+++ b/src/physics/base/ParticleTrackView.hh
@@ -44,6 +44,9 @@ class ParticleTrackView
     inline CELER_FUNCTION ParticleTrackView&
                           operator=(const Initializer_t& other);
 
+    // Change the particle's energy
+    inline CELER_FUNCTION void energy(real_type);
+
     // >>> DYNAMIC PROPERTIES (pure accessors, free)
 
     // Unique particle type identifier

--- a/src/physics/base/ParticleTrackView.i.hh
+++ b/src/physics/base/ParticleTrackView.i.hh
@@ -28,7 +28,7 @@ ParticleTrackView::ParticleTrackView(const ParticleParamsPointers& params,
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Initialize the particle
+ * Initialize the particle.
  */
 CELER_FUNCTION ParticleTrackView&
 ParticleTrackView::operator=(const Initializer_t& other)
@@ -37,6 +37,21 @@ ParticleTrackView::operator=(const Initializer_t& other)
     REQUIRE(other.energy > 0);
     state_ = other;
     return *this;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Change the particle's kinetic energy.
+ *
+ * This should only be used when the particle is in a valid state. For HEP
+ * applications, the new energy should always be less than the starting energy.
+ */
+CELER_FUNCTION
+void ParticleTrackView::energy(real_type value)
+{
+    REQUIRE(this->def_id());
+    REQUIRE(value >= 0);
+    state_.energy = value;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/SecondaryAllocatorStore.hh
+++ b/src/physics/base/SecondaryAllocatorStore.hh
@@ -43,7 +43,7 @@ class SecondaryAllocatorStore
     // Get the actual size via a device->host copy
     size_type get_size();
 
-    // Clear allocated data
+    // Clear allocated data (kernel launch!)
     void clear();
 
     // >>> DEVICE ACCESSORS

--- a/src/physics/em/KleinNishinaInteractorPointers.hh
+++ b/src/physics/em/KleinNishinaInteractorPointers.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "base/Macros.hh"
 #include "base/Types.hh"
 
 namespace celeritas
@@ -23,6 +24,12 @@ struct KleinNishinaInteractorPointers
     ParticleDefId electron_id;
     //! ID of a gamma
     ParticleDefId gamma_id;
+
+    //! Check whether the view is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        return inv_electron_mass_csq > 0 && electron_id && gamma_id;
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/random/cuda/RngStatePointers.hh
+++ b/src/random/cuda/RngStatePointers.hh
@@ -7,21 +7,15 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "celeritas_config.h"
-#if CELERITAS_USE_CUDA
-#    include <curand_kernel.h>
-#endif
+#include <curand_kernel.h>
+#include "base/Span.hh"
 #include "base/Types.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 //! State data for a CUDA RNG
-#if CELERITAS_USE_CUDA
 using RngState = curandState_t;
-#else
-using RngState = int;
-#endif
 
 //---------------------------------------------------------------------------//
 //! Initializer for an RNG
@@ -42,5 +36,3 @@ struct RngStatePointers
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas
-
-//---------------------------------------------------------------------------//

--- a/src/random/cuda/RngStateStore.cc
+++ b/src/random/cuda/RngStateStore.cc
@@ -1,4 +1,4 @@
-//---------------------------------*-CUDA-*----------------------------------//
+//---------------------------------*-C++-*-----------------------------------//
 // Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -37,10 +37,8 @@ RngStateStore::RngStateStore(size_type size, unsigned long host_seed)
 
     DeviceVector<seed_type> device_seeds(size);
     device_seeds.copy_to_device(make_span(host_seeds));
-#if CELERITAS_USE_CUDA
     rng_state_init_device(this->device_pointers(),
                           device_seeds.device_pointers());
-#endif
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This is a simple demonstration app for physics.
- Only gamma transport with Klein-Nishina model for Compton scattering
- Instantly kills secondary electrons, and lower energy cutoff of model (10 keV) is used as cutoff for gammas
- Infinite medium with no internal simulation time; no XS calculation or step length sampling
- Basic problem input parameter is incident energy and solver parameters
- Outputs timing diagnostics, accumulated energy deposition per step, total number of living tracks

A future PR will extend this to using cross section calculation (sampling the interaction length) and tallying (accumulating Z-dependent energy deposition), allowing the first apples-to-apples performance and modeling comparison to Geant4.

Until then, this simple demo serves as a tool for rapidly exploring the parameter space of block/grid sizes for a simple physics kernel that contains "on-the-fly" memory allocation for secondaries using an atomic counter.