### PR TITLE
Add host/device compatible RNG

### DIFF
--- a/src/random/cuda/RngEngine.cuh
+++ b/src/random/cuda/RngEngine.cuh
@@ -14,7 +14,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Generate random data on device.
+ * Generate random data on device and host.
  *
  * The RngEngine uses a C++11-like interface to generate random data. The
  * sampling of uniform floating point data is done with specializations to the
@@ -31,14 +31,13 @@ class RngEngine
 
   public:
     // Construct from state
-    __device__ inline RngEngine(const RngStatePointers& view,
-                                const ThreadId&         id);
+    CELER_FUNCTION RngEngine(const RngStatePointers& view, const ThreadId& id);
 
     // Initialize state from seed
-    __device__ inline RngEngine& operator=(Initializer_t s);
+    CELER_FUNCTION RngEngine& operator=(Initializer_t s);
 
     // Sample a random number
-    __device__ inline result_type operator()();
+    CELER_FUNCTION result_type operator()();
 
   private:
     RngState& state_;
@@ -63,7 +62,7 @@ class GenerateCanonical<RngEngine, float>
 
   public:
     // Sample a random number
-    inline __device__ result_type operator()(RngEngine& rng);
+    CELER_FUNCTION result_type operator()(RngEngine& rng);
 };
 
 //---------------------------------------------------------------------------//
@@ -82,7 +81,7 @@ class GenerateCanonical<RngEngine, double>
 
   public:
     // Sample a random number
-    inline __device__ result_type operator()(RngEngine& rng);
+    CELER_FUNCTION result_type operator()(RngEngine& rng);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/random/cuda/RngEngine.i.cuh
+++ b/src/random/cuda/RngEngine.i.cuh
@@ -6,15 +6,13 @@
 //! \file RngEngine.i.cuh
 //---------------------------------------------------------------------------//
 
-#include <curand_kernel.h>
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
  * Construct from state.
  */
-__device__
+CELER_FUNCTION
 RngEngine::RngEngine(const RngStatePointers& view, const ThreadId& id)
     : state_(view.rng[id.get()])
 {
@@ -25,7 +23,7 @@ RngEngine::RngEngine(const RngStatePointers& view, const ThreadId& id)
 /*!
  * Initialize the RNG engine with a seed value.
  */
-__device__ RngEngine& RngEngine::operator=(RngSeed s)
+CELER_FUNCTION RngEngine& RngEngine::operator=(RngSeed s)
 {
     curand_init(s.seed, 0, 0, &state_);
     return *this;
@@ -35,7 +33,7 @@ __device__ RngEngine& RngEngine::operator=(RngSeed s)
 /*!
  * Sample a random number
  */
-__device__ auto RngEngine::operator()() -> result_type
+CELER_FUNCTION auto RngEngine::operator()() -> result_type
 {
     return curand(&state_);
 }
@@ -46,7 +44,8 @@ __device__ auto RngEngine::operator()() -> result_type
 /*!
  * Specialization for RngEngine, float
  */
-__device__ float GenerateCanonical<RngEngine, float>::operator()(RngEngine& rng)
+CELER_FUNCTION float
+GenerateCanonical<RngEngine, float>::operator()(RngEngine& rng)
 {
     return curand_uniform(&rng.state_);
 }
@@ -55,7 +54,7 @@ __device__ float GenerateCanonical<RngEngine, float>::operator()(RngEngine& rng)
 /*!
  * Specialization for RngEngine, double
  */
-__device__ double
+CELER_FUNCTION double
 GenerateCanonical<RngEngine, double>::operator()(RngEngine& rng)
 {
     return curand_uniform_double(&rng.state_);

--- a/src/random/cuda/RngStatePointers.hh
+++ b/src/random/cuda/RngStatePointers.hh
@@ -7,6 +7,16 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+/*!
+ * \def QUALIFIERS
+ *
+ * Define NVCC QUALIFIERS so as to make curand functions work on both host
+ * and device. Note that QUALIFIERS defined in curand_kernel.h is only for
+ * device functions and re-definition of the macro with the host extension
+ * is a limited scope for the random module of celeritas.
+ */
+#define QUALIFIERS static __forceinline__ __host__ __device__
+
 #include <curand_kernel.h>
 #include "base/Span.hh"
 #include "base/Types.hh"

--- a/test/random/cuda/RngEngine.test.cu
+++ b/test/random/cuda/RngEngine.test.cu
@@ -18,6 +18,7 @@
 
 using celeritas::generate_canonical;
 using celeritas::RngEngine;
+using celeritas::RngState;
 using celeritas::RngStatePointers;
 using celeritas::RngStateStore;
 
@@ -151,4 +152,26 @@ TYPED_TEST(RngEngineFloatTest, generate_canonical)
     }
 
     check_expected_float_samples(host_samples);
+}
+
+//---------------------------------------------------------------------------//
+// TEST on CPU
+//---------------------------------------------------------------------------//
+TEST(RngEngineCPUTest, generate_on_cpu)
+{
+    int           num_samples = 1024 * 1000;
+    unsigned long seed        = 12345u;
+
+    RngState         host_state[1];
+    RngStatePointers host_pointers{celeritas::make_span(host_state)};
+    RngEngine        rng(host_pointers, celeritas::ThreadId{0});
+    rng = RngEngine::Initializer_t{seed};
+
+    double mean = 0;
+    for (int i = 0; i < num_samples; ++i)
+    {
+        mean += generate_canonical<double>(rng);
+    }
+    mean /= num_samples;
+    EXPECT_NEAR(0.5, mean, 0.0001);
 }


### PR DESCRIPTION
Make RngEngine work on both host and device.  This PR addresses and replaces the issue #19.
After merged, need to add options to use other generators/random states such as 
MRG32k3a/curandStateMRG32k3a_t, Random123/curandStatePhilox4_32_10_t and etc, which
should work out of box.  Also, generalize RngEngine.test.cu which currently works only for curandStateXORWOW.