### PR TITLE
Increase max policy range for CMake to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Note: 3.13 is the first CMake version that natively supports CUDA+MPI
 cmake_minimum_required(VERSION 3.12)
 project(Celeritas VERSION 0.0.1 LANGUAGES CXX)
-cmake_policy(VERSION 3.12...3.16)
+cmake_policy(VERSION 3.12...3.18)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 if(CMAKE_VERSION VERSION_LESS 3.18)


### PR DESCRIPTION
CMake 3.18 introduced policy [`CMP0104`](https://cmake.org/cmake/help/v3.18/policy/CMP0104.html) on the initialization of the new [`CMAKE_CUDA_ARCHITECTURES`](https://cmake.org/cmake/help/v3.18/variable/CMAKE_CUDA_ARCHITECTURES.html#variable:CMAKE_CUDA_ARCHITECTURES) variable and subsequent use of code generation flags. Without this policy being set to `NEW`, warnings are emitted at CMake generation time about `CUDA_ARCHITECTURES` not being set for targets.

Bump max CMake policy range to 3.18 to set a default for `CMAKE_CUDA_ARCHITECTURES` if not supplied by the user.

This can still result in `nvlink` errors when linking `vecgeom_static` if that was compiled with architectures incompatible(?) with that for Celeritas. Not sure how to check that yet.