### PR TITLE
Qualify Range types and functions for host and device

### DIFF
--- a/src/base/Range.hh
+++ b/src/base/Range.hh
@@ -174,9 +174,20 @@ class step_range_iter : public range_iter<T>
         return copy;
     }
 
-    CELER_FUNCTION bool operator==(step_range_iter const& other) const
+    template<typename U = T>
+    CELER_FUNCTION
+        typename std::enable_if_t<std::is_signed<U>::value, bool>
+        operator==(step_range_iter const& other) const
     {
-        return step_ > 0 ? value_ >= other.value_ : value_ < other.value_;
+        return step_ >= 0 ? value_ >= other.value_ : value_ < other.value_;
+    }
+
+    template<typename U = T>
+    CELER_FUNCTION
+        typename std::enable_if_t<std::is_unsigned<U>::value, bool>
+        operator==(step_range_iter const& other) const
+    {
+        return value_ >= other.value_;
     }
 
     CELER_FUNCTION bool operator!=(step_range_iter const& other) const
@@ -290,7 +301,7 @@ class FiniteRange
     CELER_FUNCTION FiniteRange(T begin, T end) : begin_(begin), end_(end) {}
 
     //! Return a stepped range using a different integer type
-    template<typename U>
+    template<typename U, std::enable_if_t<std::is_signed<U>::value, U> = 0>
     CELER_FUNCTION StepRange<typename std::common_type<T, U>::type> step(U step)
     {
         if (step < 0)
@@ -300,6 +311,13 @@ class FiniteRange
             return {*end_ + step, *begin_, step};
         }
 
+        return {*begin_, *end_, step};
+    }
+
+    //! Return a stepped range using a different integer type
+    template<typename U, std::enable_if_t<std::is_unsigned<U>::value, U> = 0>
+    CELER_FUNCTION StepRange<typename std::common_type<T, U>::type> step(U step)
+    {
         return {*begin_, *end_, step};
     }
 

--- a/src/base/Range.hh
+++ b/src/base/Range.hh
@@ -10,6 +10,7 @@
 #include <iterator>
 #include <type_traits>
 #include <utility>
+#include "Macros.hh"
 
 namespace celeritas
 {
@@ -76,40 +77,46 @@ class range_iter : public std::iterator<std::input_iterator_tag, T>
     counter_type value_;
 
   public:
-    /// CONSTRUCTOR ///
+    // >>> CONSTRUCTOR
 
-    range_iter(value_type value) : value_(static_cast<counter_type>(value)) {}
+    CELER_FUNCTION range_iter(value_type value)
+        : value_(static_cast<counter_type>(value))
+    {
+    }
 
     /// ACCESSORS ///
 
-    value_type operator*() const { return static_cast<value_type>(value_); }
+    CELER_FUNCTION value_type operator*() const
+    {
+        return static_cast<value_type>(value_);
+    }
 
-    value_type const* operator->() const
+    CELER_FUNCTION value_type const* operator->() const
     {
         return static_cast<const value_type*>(&value_);
     }
 
-    /// ARITHMETIC ///
+    // >>> ARITHMETIC
 
-    range_iter& operator++()
+    CELER_FUNCTION range_iter& operator++()
     {
         ++value_;
         return *this;
     }
 
-    range_iter operator++(int)
+    CELER_FUNCTION range_iter operator++(int)
     {
         auto copy = *this;
         ++*this;
         return copy;
     }
 
-    bool operator==(range_iter const& other) const
+    CELER_FUNCTION bool operator==(range_iter const& other) const
     {
         return value_ == other.value_;
     }
 
-    bool operator!=(range_iter const& other) const
+    CELER_FUNCTION bool operator!=(range_iter const& other) const
     {
         return !(*this == other);
     }
@@ -127,10 +134,17 @@ class inf_range_iter : public range_iter<T>
     using Base = range_iter<T>;
 
   public:
-    inf_range_iter(T value_ = T()) : Base(value_) {}
+    CELER_FUNCTION inf_range_iter(T value_ = T()) : Base(value_) {}
 
-    bool operator==(inf_range_iter const&) const { return false; }
-    bool operator!=(inf_range_iter const&) const { return true; }
+    CELER_FUNCTION bool operator==(inf_range_iter const&) const
+    {
+        return false;
+    }
+
+    CELER_FUNCTION bool operator!=(inf_range_iter const&) const
+    {
+        return true;
+    }
 };
 
 //---------------------------------------------------------------------------//
@@ -143,27 +157,29 @@ class step_range_iter : public range_iter<T>
     using Base = range_iter<T>;
 
   public:
-    step_range_iter(T value, T step) : Base(value), step_(step) {}
+    CELER_FUNCTION step_range_iter(T value, T step) : Base(value), step_(step)
+    {
+    }
 
-    step_range_iter& operator++()
+    CELER_FUNCTION step_range_iter& operator++()
     {
         value_ += step_;
         return *this;
     }
 
-    step_range_iter operator++(int)
+    CELER_FUNCTION step_range_iter operator++(int)
     {
         auto copy = *this;
         ++*this;
         return copy;
     }
 
-    bool operator==(step_range_iter const& other) const
+    CELER_FUNCTION bool operator==(step_range_iter const& other) const
     {
         return step_ > 0 ? value_ >= other.value_ : value_ < other.value_;
     }
 
-    bool operator!=(step_range_iter const& other) const
+    CELER_FUNCTION bool operator!=(step_range_iter const& other) const
     {
         return !(*this == other);
     }
@@ -185,10 +201,20 @@ class inf_step_range_iter : public step_range_iter<T>
     using Base = step_range_iter<T>;
 
   public:
-    inf_step_range_iter(T current = T(), T step = T()) : Base(current, step) {}
+    CELER_FUNCTION inf_step_range_iter(T current = T(), T step = T())
+        : Base(current, step)
+    {
+    }
 
-    bool operator==(inf_step_range_iter const&) const { return false; }
-    bool operator!=(inf_step_range_iter const&) const { return true; }
+    CELER_FUNCTION bool operator==(inf_step_range_iter const&) const
+    {
+        return false;
+    }
+
+    CELER_FUNCTION bool operator!=(inf_step_range_iter const&) const
+    {
+        return true;
+    }
 };
 
 } // namespace internal
@@ -206,10 +232,14 @@ class StepRange
   public:
     using IterT = internal::step_range_iter<T>;
 
-    StepRange(T begin, T end, T step) : begin_(begin, step), end_(end, step) {}
+    CELER_FUNCTION StepRange(T begin, T end, T step)
+        : begin_(begin, step), end_(end, step)
+    {
+    }
 
-    IterT begin() const { return begin_; }
-    IterT end() const { return end_; }
+    CELER_FUNCTION IterT begin() const { return begin_; }
+
+    CELER_FUNCTION IterT end() const { return end_; }
 
   private:
     IterT begin_;
@@ -230,10 +260,11 @@ class InfStepRange
     using IterT = internal::inf_step_range_iter<T>;
 
     //! Construct from start/stop
-    InfStepRange(T begin, T step) : begin_(begin, step) {}
+    CELER_FUNCTION InfStepRange(T begin, T step) : begin_(begin, step) {}
 
-    IterT begin() const { return begin_; }
-    IterT end() const { return IterT(); }
+    CELER_FUNCTION IterT begin() const { return begin_; }
+
+    CELER_FUNCTION IterT end() const { return IterT(); }
 
   private:
     IterT begin_;
@@ -253,14 +284,14 @@ class FiniteRange
     using counter_type = typename internal::range_type_traits<T>::counter_type;
 
     //! Empty constructor for empty range
-    FiniteRange() : begin_(T()), end_(T()) {}
+    CELER_FUNCTION FiniteRange() : begin_(T()), end_(T()) {}
 
     //! Construct from start/stop
-    FiniteRange(T begin, T end) : begin_(begin), end_(end) {}
+    CELER_FUNCTION FiniteRange(T begin, T end) : begin_(begin), end_(end) {}
 
     //! Return a stepped range using a different integer type
     template<typename U>
-    StepRange<typename std::common_type<T, U>::type> step(U step)
+    CELER_FUNCTION StepRange<typename std::common_type<T, U>::type> step(U step)
     {
         if (step < 0)
         {
@@ -272,10 +303,10 @@ class FiniteRange
         return {*begin_, *end_, step};
     }
 
-    IterT        begin() const { return begin_; }
-    IterT        end() const { return end_; }
-    counter_type size() const { return *end_ - *begin_; }
-    bool         empty() const { return end_ == begin_; }
+    CELER_FUNCTION IterT        begin() const { return begin_; }
+    CELER_FUNCTION IterT        end() const { return end_; }
+    CELER_FUNCTION counter_type size() const { return *end_ - *begin_; }
+    CELER_FUNCTION bool         empty() const { return end_ == begin_; }
 
   private:
     IterT begin_;
@@ -294,13 +325,13 @@ class InfiniteRange
   public:
     using IterT = internal::inf_range_iter<T>;
 
-    InfiniteRange(T begin) : begin_(begin) {}
+    CELER_FUNCTION InfiniteRange(T begin) : begin_(begin) {}
 
-    InfStepRange<T> step(T step) { return {*begin_, step}; }
+    CELER_FUNCTION InfStepRange<T> step(T step) { return {*begin_, step}; }
 
-    IterT begin() const { return begin_; }
-    IterT end() const { return IterT(); }
-    bool  empty() const { return false; }
+    CELER_FUNCTION IterT begin() const { return begin_; }
+    CELER_FUNCTION IterT end() const { return IterT(); }
+    CELER_FUNCTION bool  empty() const { return false; }
 
   private:
     IterT begin_;
@@ -313,7 +344,7 @@ class InfiniteRange
  * Return a range over fixed beginning and end values.
  */
 template<typename T>
-FiniteRange<T> range(T begin, T end)
+CELER_FUNCTION FiniteRange<T> range(T begin, T end)
 {
     return {begin, end};
 }
@@ -325,7 +356,7 @@ FiniteRange<T> range(T begin, T end)
  * Return a range over a pair of beginning and ending values.
  */
 template<typename T>
-FiniteRange<T> range(std::pair<T, T> begin_end)
+CELER_FUNCTION FiniteRange<T> range(std::pair<T, T> begin_end)
 {
     return {begin_end.first, begin_end.second};
 }
@@ -337,7 +368,7 @@ FiniteRange<T> range(std::pair<T, T> begin_end)
  * Return a range with the default start value (0 for numeric types)
  */
 template<typename T>
-FiniteRange<T> range(T end)
+CELER_FUNCTION FiniteRange<T> range(T end)
 {
     return {T(), end};
 }
@@ -349,7 +380,7 @@ FiniteRange<T> range(T end)
  * Count upward from zero.
  */
 template<typename T>
-InfiniteRange<T> count()
+CELER_FUNCTION InfiniteRange<T> count()
 {
     return {T()};
 }
@@ -361,7 +392,7 @@ InfiniteRange<T> count()
  * Count upward from a value.
  */
 template<typename T>
-InfiniteRange<T> count(T begin)
+CELER_FUNCTION InfiniteRange<T> count(T begin)
 {
     return {begin};
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,7 +81,6 @@ celeritas_add_test(base/DeviceVector.test.cc)
 celeritas_add_test(base/Interpolator.test.cc)
 celeritas_add_test(base/OpaqueId.test.cc)
 celeritas_add_test(base/Quantity.test.cc)
-celeritas_add_test(base/Range.test.cc)
 celeritas_add_test(base/SoftEqual.test.cc)
 celeritas_add_test(base/Span.test.cc)
 celeritas_add_test(base/SpanRemapper.test.cc)
@@ -94,6 +93,7 @@ if(CELERITAS_USE_CUDA)
     SOURCES base/NumericLimits.test.cu)
 endif()
 
+add_cudaoptional_test(base/Range)
 add_cudaoptional_test(base/StackAllocator)
 
 #-----------------------------------------------------------------------------#

--- a/test/base/Range.test.cc
+++ b/test/base/Range.test.cc
@@ -285,8 +285,8 @@ TEST(CountTest, backward)
 #if CELERITAS_USE_CUDA
 TEST(DeviceRangeTest, grid_stride)
 {
-    // ~1M elements for saxpy
-    unsigned int N = 1 << 20;
+    // next prime after 1<<20 elements to avoid multiples of block/stride
+    unsigned int N = 1048583;
 
     // Set Inputs
     RangeTestInput input;

--- a/test/base/Range.test.cc
+++ b/test/base/Range.test.cc
@@ -9,6 +9,7 @@
 
 #include "gtest/Main.hh"
 #include "gtest/Test.hh"
+#include "Range.test.hh"
 
 using celeritas::count;
 using celeritas::range;
@@ -277,3 +278,8 @@ TEST(CountTest, backward)
 }
 
 //---------------------------------------------------------------------------//
+// DEVICE TESTS
+//---------------------------------------------------------------------------//
+#if CELERITAS_USE_CUDA
+
+#endif

--- a/test/base/Range.test.cc
+++ b/test/base/Range.test.cc
@@ -11,6 +11,8 @@
 #include "gtest/Test.hh"
 #include "Range.test.hh"
 
+using namespace celeritas_test;
+
 using celeritas::count;
 using celeritas::range;
 
@@ -281,5 +283,34 @@ TEST(CountTest, backward)
 // DEVICE TESTS
 //---------------------------------------------------------------------------//
 #if CELERITAS_USE_CUDA
+TEST(DeviceRangeTest, grid_stride)
+{
+    // ~1M elements for saxpy
+    unsigned int N = 1 << 20;
+
+    // Set Inputs
+    RangeTestInput input;
+    input.a = 3;
+    input.x.assign(N, 1);
+    // y varies with index so we can verify common order on CPU vs Device
+    input.y.assign(N, 0);
+    for (auto i : range(N))
+    {
+        input.y[i] = i;
+    }
+    input.num_threads = 32;
+    input.num_blocks  = 256;
+
+    // Calculate saxpy using CPU
+    std::vector<int> z_cpu(N, 0.0);
+    for (auto i : range(N))
+    {
+        z_cpu[i] = input.a * input.x[i] + input.y[i];
+    }
+
+    // Calculate saxpy on Device
+    RangeTestOutput result = rangedev_test(input);
+    EXPECT_VEC_EQ(z_cpu, result.z);
+}
 
 #endif

--- a/test/base/Range.test.cu
+++ b/test/base/Range.test.cu
@@ -6,3 +6,50 @@
 //! \file Range.test.cu
 //---------------------------------------------------------------------------//
 #include "Range.test.hh"
+
+#include <thrust/device_vector.h>
+#include "base/Assert.hh"
+#include "base/Range.hh"
+
+using celeritas::range;
+
+namespace celeritas_test
+{
+__global__ void
+rangedev_test_kernel(int a, int* x, int* y, int* z, unsigned int n)
+{
+    // grid stride loop
+    for (auto i : range(blockIdx.x * blockDim.x + threadIdx.x, n)
+                      .step(gridDim.x * blockDim.x))
+    {
+        z[i] = a * x[i] + y[i];
+    }
+}
+
+RangeTestOutput rangedev_test(RangeTestInput input)
+{
+    REQUIRE(input.x.size() == input.y.size());
+
+    // Local device vectors for working data
+    thrust::device_vector<int> x_dev(input.x.begin(), input.x.end());
+    thrust::device_vector<int> y_dev(input.y.begin(), input.y.end());
+    thrust::device_vector<int> z_dev(input.x.size(), 0);
+
+    // Test kernel
+    rangedev_test_kernel<<<input.num_threads, input.num_blocks>>>(
+        input.a,
+        thrust::raw_pointer_cast(x_dev.data()),
+        thrust::raw_pointer_cast(y_dev.data()),
+        thrust::raw_pointer_cast(z_dev.data()),
+        z_dev.size());
+
+    // Copy result back to CPU
+    RangeTestOutput result;
+    result.z.assign(z_dev.size(), 0);
+    thrust::copy(z_dev.begin(), z_dev.end(), result.z.begin());
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/base/Range.test.cu
+++ b/test/base/Range.test.cu
@@ -1,0 +1,8 @@
+//---------------------------------*-CUDA-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Range.test.cu
+//---------------------------------------------------------------------------//
+#include "Range.test.hh"

--- a/test/base/Range.test.hh
+++ b/test/base/Range.test.hh
@@ -5,3 +5,32 @@
 //---------------------------------------------------------------------------//
 //! \file Range.test.hh
 //---------------------------------------------------------------------------//
+#include "base/Macros.hh"
+
+#include <cstdint>
+#include <vector>
+
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+// TESTING INTERFACE
+//---------------------------------------------------------------------------//
+//! Input data
+struct RangeTestInput {
+  int a;
+  std::vector<int> x;
+  std::vector<int> y;
+  unsigned int num_threads;
+  unsigned int num_blocks;
+};
+
+//! Output data
+struct RangeTestOutput {
+  std::vector<int> z;
+};
+
+//---------------------------------------------------------------------------//
+//! Run on device and return results
+RangeTestOutput rangedev_test(RangeTestInput);
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/base/Range.test.hh
+++ b/test/base/Range.test.hh
@@ -1,0 +1,7 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Range.test.hh
+//---------------------------------------------------------------------------//


### PR DESCRIPTION
To help device/kernel function authors write cleaner loops, qualify Range types and functions for host and device. The Range test is extended to provide an optional CUDA component when this is available, but is only stubbed in. It can be implemented once checks of PTX confirm any cost to implementing loops this way on the device.

As discussed on Slack, checks need to be done first to confirm the code is optimised well on the device side. If a basic test is needed to do that, let me know!