### PR TITLE
Klein-Nishina CPU performance application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ cmake_minimum_required(VERSION 3.12)
 project(Celeritas VERSION 0.0.1 LANGUAGES CXX)
 cmake_policy(VERSION 3.12...3.18)
 
+# Set Policies
+if(POLICY CMP0104)
+  cmake_policy(SET CMP0104 NEW)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 if(CMAKE_VERSION VERSION_LESS 3.18)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/backport/3.18")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,6 @@ cmake_minimum_required(VERSION 3.12)
 project(Celeritas VERSION 0.0.1 LANGUAGES CXX)
 cmake_policy(VERSION 3.12...3.18)
 
-# Set Policies
-if(POLICY CMP0104)
-  cmake_policy(SET CMP0104 NEW)
-endif()
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 if(CMAKE_VERSION VERSION_LESS 3.18)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/backport/3.18")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -81,13 +81,13 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA)
   )
 
   if(CELERITAS_BUILD_TESTS)
-  add_test(NAME "app/demo-interactor"
-    COMMAND "${Python_EXECUTABLE}"
-      "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py"
-  )
-  set_tests_properties("app/demo-interactor" PROPERTIES
-    ENVIRONMENT "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-interactor>"
-  )
+    add_test(NAME "app/demo-interactor"
+      COMMAND "${Python_EXECUTABLE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py"
+    )
+    set_tests_properties("app/demo-interactor" PROPERTIES
+      ENVIRONMENT "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-interactor>"
+    )
   endif()
 
   # Build CPU version

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -59,6 +59,9 @@ endif()
 #-----------------------------------------------------------------------------#
 # DEMO: physics interactions
 #-----------------------------------------------------------------------------#
+# The CPU version still requires CUDA because some of the data parameters will do
+# a copy to device (even though this isn't used by the CPU app) and that copy will
+# fail in the DeviceAllocator if CUDA is disabled
 
 if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA)
   add_executable(demo-interactor
@@ -71,21 +74,36 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA)
     demo-interactor/KNDemoKernel.cu
     demo-interactor/PhysicsArrayParams.cc
     demo-interactor/detail/DetectorUtils.cu
-    )
+  )
   target_link_libraries(demo-interactor celeritas
     CUDA::cudart
     nlohmann_json::nlohmann_json
   )
 
   if(CELERITAS_BUILD_TESTS)
-    add_test(NAME "app/demo-interactor"
-      COMMAND "${Python_EXECUTABLE}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py"
-    )
-    set_tests_properties("app/demo-interactor" PROPERTIES
-      ENVIRONMENT "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-interactor>"
-    )
+  add_test(NAME "app/demo-interactor"
+    COMMAND "${Python_EXECUTABLE}"
+      "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py"
+  )
+  set_tests_properties("app/demo-interactor" PROPERTIES
+    ENVIRONMENT "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-interactor>"
+  )
   endif()
+
+  # Build CPU version
+  add_executable(host-demo-interactor
+    demo-interactor/LoadXs.cc
+    demo-interactor/KNDemoIO.cc
+    demo-interactor/PhysicsArrayParams.cc
+    demo-interactor/host-demo-interactor.cc
+    demo-interactor/HostDetectorStore.cc
+    demo-interactor/HostKNDemoRunner.cc
+  )
+  target_link_libraries(host-demo-interactor celeritas
+    CUDA::cudart
+    nlohmann_json::nlohmann_json
+  )
+
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/app/demo-interactor/HostDetectorStore.cc
+++ b/app/demo-interactor/HostDetectorStore.cc
@@ -1,0 +1,90 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file HostDetectorStore.cc
+//---------------------------------------------------------------------------//
+#include "HostDetectorStore.hh"
+
+#include "base/StackAllocatorView.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Constructor
+ */
+HostDetectorStore::HostDetectorStore(size_type buffer_capacity,
+                                     const UniformGrid::Params& grid)
+    : hit_buffer_(buffer_capacity)
+    , tally_grid_(grid)
+    , tally_deposition_(UniformGrid(grid).size())
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Get detector data
+ */
+DetectorPointers HostDetectorStore::host_pointers()
+{
+    DetectorPointers result;
+    result.hit_buffer       = hit_buffer_.host_pointers();
+    result.tally_grid       = tally_grid_;
+    result.tally_deposition = make_span(tally_deposition_);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Bin the buffer onto the grid
+ */
+void HostDetectorStore::bin_buffer()
+{
+    UniformGrid grid(tally_grid_);
+    auto hits = StackAllocatorView<Hit>(hit_buffer_.host_pointers()).get();
+    CHECK(hits.size() > 0);
+
+    // Iterate through hits and add them to grid
+    for (const auto& hit : hits)
+    {
+        real_type z_pos = hit.pos[2];
+        size_type bin   = 0;
+        if (z_pos <= grid.front())
+        {
+            bin = 0;
+        }
+        else if (z_pos >= grid.back())
+        {
+            bin = grid.size() - 1;
+        }
+        else
+        {
+            bin = grid.find(z_pos);
+        }
+        CHECK(bin < tally_deposition_.size());
+
+        tally_deposition_[bin] += hit.energy_deposited.value();
+    }
+
+    // Clear the hit buffer
+    hit_buffer_.clear();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Finalize the tally result
+ */
+std::vector<real_type> HostDetectorStore::finalize(real_type norm)
+{
+    REQUIRE(norm > 0.0);
+    for (auto& v : tally_deposition_)
+    {
+        v *= norm;
+    }
+    return tally_deposition_;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/app/demo-interactor/HostDetectorStore.hh
+++ b/app/demo-interactor/HostDetectorStore.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file HostDetectorStore.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+#include "base/Types.hh"
+#include "base/UniformGrid.hh"
+#include "DetectorPointers.hh"
+#include "HostStackAllocatorStore.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Host storage for a simple 'event-wise' detector.
+ */
+class HostDetectorStore
+{
+  public:
+    // Construct with defaults
+    HostDetectorStore(size_type                  buffer_capacity,
+                      const UniformGrid::Params& grid);
+
+    // Get detector data
+    DetectorPointers host_pointers();
+
+    // Bin the buffer onto the grid
+    void bin_buffer();
+
+    // Finalize the tally result
+    std::vector<real_type> finalize(real_type norm);
+
+  private:
+    // Host-side hit buffer
+    HostStackAllocatorStore<Hit> hit_buffer_;
+    // Uniform tally grid
+    UniformGrid::Params tally_grid_;
+    // Tallied data
+    std::vector<real_type> tally_deposition_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/app/demo-interactor/HostKNDemoRunner.cc
+++ b/app/demo-interactor/HostKNDemoRunner.cc
@@ -1,0 +1,213 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file HostKNDemoRunner.cc
+//---------------------------------------------------------------------------//
+#include "HostKNDemoRunner.hh"
+
+#include <iostream>
+#include <random>
+#include "base/Stopwatch.hh"
+#include "base/Range.hh"
+#include "base/ArrayUtils.hh"
+#include "random/distributions/ExponentialDistribution.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/Units.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/em/KleinNishinaInteractor.hh"
+#include "PhysicsArrayCalculator.hh"
+#include "DetectorView.hh"
+#include "HostStackAllocatorStore.hh"
+#include "HostDetectorStore.hh"
+
+namespace demo_interactor_cpu
+{
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Construct with parameters.
+ */
+HostKNDemoRunner::HostKNDemoRunner(constSPParticleParams     particles,
+                                   constSPPhysicsArrayParams xs)
+    : pparams_(std::move(particles)), xsparams_(std::move(xs))
+{
+    REQUIRE(pparams_);
+    REQUIRE(xsparams_);
+
+    // Set up KN interactor data;
+    namespace pdg            = celeritas::pdg;
+    kn_pointers_.electron_id = pparams_->find(pdg::electron());
+    kn_pointers_.gamma_id    = pparams_->find(pdg::gamma());
+    kn_pointers_.inv_electron_mass
+        = 1 / pparams_->get(kn_pointers_.electron_id).mass.value();
+    ENSURE(kn_pointers_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Run given number of particles each for max steps.
+ */
+
+auto HostKNDemoRunner::operator()(demo_interactor::KNDemoRunArgs args)
+    -> result_type
+{
+    REQUIRE(args.energy > 0);
+    REQUIRE(args.num_tracks > 0);
+
+    // Initialize results
+    result_type result;
+    result.time.reserve(args.max_steps);
+    result.alive.reserve(args.max_steps + 1);
+    result.edep.reserve(args.max_steps);
+
+    // Start timer for overall execution and transport-only time
+    celeritas::Stopwatch total_time;
+    double               transport_time = 0.0;
+
+    // Random number generations
+    std::mt19937 rng(args.seed);
+
+    // Particle param pointers
+    auto pp_host_ptrs = pparams_->host_pointers();
+
+    // Physics calculator
+    auto xs_host_ptrs = xsparams_->host_pointers();
+    celeritas::PhysicsArrayCalculator calc_xs(xs_host_ptrs);
+
+    // Make secondary store
+    celeritas::HostStackAllocatorStore<celeritas::Secondary> secondaries(
+        args.max_steps);
+    auto secondary_host_ptrs = secondaries.host_pointers();
+
+    // Make detector store
+    celeritas::HostDetectorStore detector(args.max_steps, args.tally_grid);
+    auto                         detector_host_ptrs = detector.host_pointers();
+
+    // Loop over particle tracks and events per track
+    for (CELER_MAYBE_UNUSED auto n : celeritas::range(args.num_tracks))
+    {
+        // Place cap on maximum number of steps
+        auto remaining_steps = args.max_steps;
+
+        // Make the initial track state
+        celeritas::ParticleTrackState init_state = {
+            kn_pointers_.gamma_id, celeritas::units::MevEnergy(args.energy)};
+
+        // Initialize particle state
+        StatePointers state;
+        state.particle.vars = {&init_state, 1};
+        state.position      = {0, 0, 0};
+        state.direction     = {0, 0, 1};
+        state.time          = 0;
+        state.alive         = true;
+
+        // Secondary pointers
+        celeritas::SecondaryAllocatorView allocate_secondaries(
+            secondary_host_ptrs);
+        CHECK(secondaries.capacity() == args.max_steps);
+        CHECK(allocate_secondaries.get().size() == 0);
+
+        // Detector hits
+        celeritas::DetectorView detector_hit(detector_host_ptrs);
+
+        // Step counter
+        CELER_MAYBE_UNUSED size_type num_steps = 0;
+
+        celeritas::Stopwatch elapsed_time;
+        while (state.alive && --remaining_steps > 0)
+        {
+            // Get a particle track view to a single particle
+            auto particle = celeritas::ParticleTrackView(
+                pp_host_ptrs, state.particle, celeritas::ThreadId(0));
+
+            // Move to collision
+            {
+                celeritas::real_type sigma = calc_xs(particle);
+                celeritas::ExponentialDistribution<celeritas::real_type>
+                                     sample_distance(sigma);
+                celeritas::real_type distance = sample_distance(rng);
+                celeritas::axpy(distance, state.direction, &state.position);
+                state.time += distance * celeritas::unit_cast(particle.speed());
+            }
+
+            // Update step counter
+            ++num_steps;
+
+            // Hit analysis
+            celeritas::Hit h;
+            h.pos    = state.position;
+            h.thread = celeritas::ThreadId(0);
+            h.time   = state.time;
+
+            // Check for below energy cutoff
+            if (particle.energy()
+                < celeritas::KleinNishinaInteractor::min_incident_energy())
+            {
+                // Particle is below interaction energy
+                h.dir              = state.direction;
+                h.energy_deposited = particle.energy();
+
+                // Deposit energy and kill
+                detector_hit(h);
+                state.alive = false;
+                continue;
+            }
+
+            // Construct the KN interactor
+            celeritas::KleinNishinaInteractor interact(
+                kn_pointers_, particle, state.direction, allocate_secondaries);
+
+            // Perform interactions - emits a single particle
+            auto interaction = interact(rng);
+            CHECK(interaction);
+            CHECK(interaction.secondaries.size() == 1);
+
+            // Deposit energy from the secondary (all local)
+            {
+                const auto& secondary = interaction.secondaries.front();
+                h.dir                 = secondary.direction;
+                h.energy_deposited    = secondary.energy;
+                detector_hit(h);
+            }
+
+            // Update the energy and direction in the state from the
+            // interaction
+            state.direction = interaction.direction;
+            particle.energy(interaction.energy);
+        }
+        CHECK(num_steps <= args.max_steps);
+        CHECK(num_steps < args.max_steps
+                  ? secondaries.get_size() == num_steps - 1
+                  : secondaries.get_size() == num_steps);
+        CHECK(secondaries.get_size() == allocate_secondaries.get().size());
+        CHECK(celeritas::StackAllocatorView<celeritas::Hit>(
+                  detector.host_pointers().hit_buffer)
+                  .get()
+                  .size()
+              == num_steps);
+
+        // Store transport time
+        transport_time += elapsed_time();
+
+        // Clear secondaries
+        secondaries.clear();
+        CHECK(secondaries.get_size() == 0);
+
+        // Bin the tally results from the buffer onto the grid
+        detector.bin_buffer();
+    }
+
+    // Copy integrated energy deposition
+    result.edep = detector.finalize(1 / celeritas::real_type(args.num_tracks));
+
+    // Store timings
+    result.time.push_back(transport_time);
+    result.total_time = total_time();
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace demo_interactor_cpu

--- a/app/demo-interactor/HostKNDemoRunner.hh
+++ b/app/demo-interactor/HostKNDemoRunner.hh
@@ -13,11 +13,11 @@
 #include "KNDemoIO.hh"
 #include "PhysicsArrayParams.hh"
 
-namespace demo_interactor_cpu
+namespace demo_interactor
 {
 //---------------------------------------------------------------------------//
 /*!
- * Run interactions on the host CPU
+ * Run interactions on the host CPU.
  *
  * This is an analog to the demo_interactor::KNDemoRunner for device simulation
  * but does all the transport directly on the CPU side.
@@ -61,4 +61,4 @@ class HostKNDemoRunner
 };
 
 //---------------------------------------------------------------------------//
-} // namespace demo_interactor_cpu
+} // namespace demo_interactor

--- a/app/demo-interactor/HostKNDemoRunner.hh
+++ b/app/demo-interactor/HostKNDemoRunner.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file HostKNDemoRunner.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "physics/base/ParticleParams.hh"
+#include "physics/base/ParticleStatePointers.hh"
+#include "physics/em/KleinNishinaInteractorPointers.hh"
+#include "KNDemoIO.hh"
+#include "PhysicsArrayParams.hh"
+
+namespace demo_interactor_cpu
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Run interactions on the host CPU
+ *
+ * This is an analog to the demo_interactor::KNDemoRunner for device simulation
+ * but does all the transport directly on the CPU side.
+ */
+class HostKNDemoRunner
+{
+  public:
+    //@{
+    //! Type aliases
+    using size_type   = celeritas::size_type;
+    using result_type = demo_interactor::KNDemoResult;
+    using constSPParticleParams
+        = std::shared_ptr<const celeritas::ParticleParams>;
+    using constSPPhysicsArrayParams
+        = std::shared_ptr<const celeritas::PhysicsArrayParams>;
+    //@}
+
+  private:
+    // CPU Version of the particle StatePointers
+    struct StatePointers
+    {
+        celeritas::ParticleStatePointers particle;
+        celeritas::Real3                 position;
+        celeritas::Real3                 direction;
+        celeritas::real_type             time;
+        bool                             alive;
+    };
+
+  public:
+    // Construct with parameters
+    HostKNDemoRunner(constSPParticleParams     particles,
+                     constSPPhysicsArrayParams xs);
+
+    // Run given number of particles
+    result_type operator()(demo_interactor::KNDemoRunArgs args);
+
+  private:
+    constSPParticleParams                     pparams_;
+    constSPPhysicsArrayParams                 xsparams_;
+    celeritas::KleinNishinaInteractorPointers kn_pointers_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace demo_interactor_cpu

--- a/app/demo-interactor/HostStackAllocatorStore.hh
+++ b/app/demo-interactor/HostStackAllocatorStore.hh
@@ -15,7 +15,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Host side version of StackAllocatorStore
+ * Host side version of StackAllocatorStore.
  */
 template<class T>
 class HostStackAllocatorStore

--- a/app/demo-interactor/HostStackAllocatorStore.hh
+++ b/app/demo-interactor/HostStackAllocatorStore.hh
@@ -1,0 +1,62 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file HostStackAllocatorStore.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+#include "base/Span.hh"
+#include "base/StackAllocatorPointers.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Host side version of StackAllocatorStore
+ */
+template<class T>
+class HostStackAllocatorStore
+{
+  public:
+    //@{
+    //! Type aliases
+    using value_type      = T;
+    using Pointers        = StackAllocatorPointers<T>;
+    using size_type       = typename Pointers::size_type;
+    using const_span_type = celeritas::span<const value_type>;
+    //@}
+
+  public:
+    // Construct with defaults
+    explicit HostStackAllocatorStore(size_type capacity)
+        : storage_(capacity), size_(0)
+    {
+        pointers_.storage = make_span(storage_);
+        pointers_.size    = &size_;
+    }
+
+    //! Size of the allocation
+    size_type capacity() const { return storage_.size(); }
+
+    //! Get the current size
+    size_type get_size() { return size_; }
+
+    //! Clear allocated data (as for StackAllocator, just sets size to 0)
+    void clear() { size_ = 0; }
+
+    // >>> HOST ACCESSORS
+
+    // Get a view to the stack pointers
+    Pointers host_pointers() { return pointers_; }
+
+  private:
+    std::vector<value_type> storage_;
+    size_type               size_;
+    Pointers                pointers_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/app/demo-interactor/PhysicsArrayParams.cc
+++ b/app/demo-interactor/PhysicsArrayParams.cc
@@ -20,7 +20,9 @@ namespace celeritas
  * Construct with input data.
  */
 PhysicsArrayParams::PhysicsArrayParams(const Input& input)
-    : xs_(input.xs.size()), prime_energy_(input.prime_energy)
+    : xs_(input.xs.size())
+    , prime_energy_(input.prime_energy)
+    , host_xs_(input.xs)
 {
     REQUIRE(input.energy.size() >= 2);
     REQUIRE(input.energy.front() > 0);
@@ -63,6 +65,20 @@ PhysicsArrayPointers PhysicsArrayParams::device_pointers() const
     result.log_energy   = log_energy_;
     result.xs           = xs_.device_pointers();
     result.prime_energy = prime_energy_;
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Access on-host data
+ */
+PhysicsArrayPointers PhysicsArrayParams::host_pointers() const
+{
+    PhysicsArrayPointers result;
+    result.log_energy   = log_energy_;
+    result.prime_energy = prime_energy_;
+    result.xs           = make_span(host_xs_);
+
     return result;
 }
 

--- a/app/demo-interactor/PhysicsArrayParams.hh
+++ b/app/demo-interactor/PhysicsArrayParams.hh
@@ -42,10 +42,16 @@ class PhysicsArrayParams
     // Access on-device data
     PhysicsArrayPointers device_pointers() const;
 
+    // Get host-side data
+    PhysicsArrayPointers host_pointers() const;
+
   private:
     UniformGrid::Params     log_energy_;
     DeviceVector<real_type> xs_;
     real_type               prime_energy_;
+
+    // Host side xs data
+    std::vector<real_type> host_xs_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/demo-interactor/detail/DetectorUtils.cu
+++ b/app/demo-interactor/detail/DetectorUtils.cu
@@ -20,7 +20,7 @@ __global__ void bin_buffer_kernel(DetectorPointers const detector)
 {
     auto        hits = StackAllocatorView<Hit>(detector.hit_buffer).get();
     UniformGrid grid(detector.tally_grid);
-    size_type thread_idx = KernelParamCalculator::thread_id().get();
+    size_type   thread_idx = KernelParamCalculator::thread_id().get();
 
     if (thread_idx < hits.size())
     {
@@ -38,9 +38,10 @@ __global__ void bin_buffer_kernel(DetectorPointers const detector)
         // Add energy deposition (NOTE: very slow on arch 600)
         atomic_add(&detector.tally_deposition[bin],
                    hit.energy_deposited.value());
-        // detector.tally_deposition[bin] += hit.energy_deposited.value();
     }
 }
+
+//---------------------------------------------------------------------------//
 
 __global__ void
 normalize_kernel(DetectorPointers const detector, real_type norm)
@@ -74,10 +75,7 @@ void bin_buffer(const DetectorPointers& detector)
 
 //---------------------------------------------------------------------------//
 /*!
- * Bin the buffer into the tally grid.
- *
- * The caller will have to clear the buffer after calling this. No
- * normalization is performed.
+ * Multiply the binned data by the given normalization.
  */
 void normalize(const DetectorPointers& device_ptrs, real_type norm)
 {

--- a/app/demo-interactor/host-demo-interactor.cc
+++ b/app/demo-interactor/host-demo-interactor.cc
@@ -22,12 +22,12 @@
 #include "HostKNDemoRunner.hh"
 
 using namespace celeritas;
-using namespace demo_interactor_cpu;
+using namespace demo_interactor;
 using std::cerr;
 using std::cout;
 using std::endl;
 
-namespace demo_interactor_cpu
+namespace demo_interactor
 {
 //---------------------------------------------------------------------------//
 /*!
@@ -36,8 +36,8 @@ namespace demo_interactor_cpu
 std::shared_ptr<ParticleParams> load_params()
 {
     using namespace celeritas::units;
-    celeritas::ZeroQuantity zero;
-    auto                    stable = ParticleDef::stable_decay_constant();
+    ZeroQuantity zero;
+    auto         stable = ParticleDef::stable_decay_constant();
 
     ParticleParams::VecAnnotatedDefs defs
         = {{{"electron", pdg::electron()},
@@ -71,7 +71,7 @@ void run(std::istream& is)
     };
     cout << outp.dump() << endl;
 }
-} // namespace demo_interactor_cpu
+} // namespace demo_interactor
 
 //---------------------------------------------------------------------------//
 /*!

--- a/app/demo-interactor/host-demo-interactor.cc
+++ b/app/demo-interactor/host-demo-interactor.cc
@@ -1,0 +1,119 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file demo-interactor.cc
+//---------------------------------------------------------------------------//
+
+#include <cstddef>
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+#include <nlohmann/json.hpp>
+#include "comm/Communicator.hh"
+#include "comm/ScopedMpiInit.hh"
+#include "comm/Utils.hh"
+#include "physics/base/ParticleParams.hh"
+#include "LoadXs.hh"
+#include "KNDemoIO.hh"
+#include "HostKNDemoRunner.hh"
+
+using namespace celeritas;
+using namespace demo_interactor_cpu;
+using std::cerr;
+using std::cout;
+using std::endl;
+
+namespace demo_interactor_cpu
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct particle parameters and send to GPU.
+ */
+std::shared_ptr<ParticleParams> load_params()
+{
+    using namespace celeritas::units;
+    celeritas::ZeroQuantity zero;
+    auto                    stable = ParticleDef::stable_decay_constant();
+
+    ParticleParams::VecAnnotatedDefs defs
+        = {{{"electron", pdg::electron()},
+            {MevMass{0.5109989461}, ElementaryCharge{-1}, stable}},
+           {{"gamma", pdg::gamma()}, {zero, zero, stable}}};
+    return std::make_shared<ParticleParams>(std::move(defs));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Run, launch, and output.
+ */
+void run(std::istream& is)
+{
+    // Read input options
+    auto inp = nlohmann::json::parse(is);
+
+    // Construct runner
+    HostKNDemoRunner run(load_params(), demo_interactor::load_xs());
+
+    // For now, only do a single run
+    auto run_args = inp.at("run").get<demo_interactor::KNDemoRunArgs>();
+    REQUIRE(run_args.energy > 0);
+    REQUIRE(run_args.num_tracks > 0);
+    REQUIRE(run_args.max_steps > 0);
+    auto result = run(run_args);
+
+    nlohmann::json outp = {
+        {"run", run_args},
+        {"result", result},
+    };
+    cout << outp.dump() << endl;
+}
+} // namespace demo_interactor_cpu
+
+//---------------------------------------------------------------------------//
+/*!
+ * Execute and run.
+ */
+int main(int argc, char* argv[])
+{
+    ScopedMpiInit scoped_mpi(&argc, &argv);
+    Communicator  comm = Communicator::comm_world();
+    if (comm.size() != 1)
+    {
+        if (comm.rank() == 0)
+        {
+            cerr << "This app is currently serial-only. Run with 1 proc."
+                 << endl;
+        }
+        return EXIT_FAILURE;
+    }
+
+    // Process input arguments
+    std::vector<std::string> args(argv, argv + argc);
+    if (args.size() != 2 || args[1] == "--help" || args[1] == "-h")
+    {
+        cerr << "usage: " << args[0] << " {input}.json" << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (args[1] != "-")
+    {
+        std::ifstream infile(args[1]);
+        if (!infile)
+        {
+            cerr << "fatal: failed to open '" << args[1] << "'" << endl;
+            return EXIT_FAILURE;
+        }
+        run(infile);
+    }
+    else
+    {
+        // Read input from STDIN
+        run(std::cin);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/scripts/build/wildstyle.cmake
+++ b/scripts/build/wildstyle.cmake
@@ -4,6 +4,14 @@ macro(set_cache_var var type val)
   set(${var} "${val}" CACHE "${type}" "wildstyle.sh" FORCE)
 endmacro()
 
+set_cache_var(CELERITAS_GIT_SUBMODULE BOOL ON)
+set_cache_var(CELERITAS_USE_VecGeom BOOL OFF)
+set_cache_var(CELERITAS_USE_ROOT BOOL OFF)
+set_cache_var(CELERITAS_USE_HepMC3 BOOL OFF)
+
+set_cache_var(CELERITAS_DEBUG BOOL OFF)
+set_cache_var(CMAKE_BUILD_TYPE STRING "Release")
+
 set_cache_var(CMAKE_CUDA_ARCHITECTURES STRING "70")
 set_cache_var(CMAKE_CXX_FLAGS_RELEASE STRING
   "-O3 -DNDEBUG -march=skylake-avx512 -mtune=skylake-avx512")


### PR DESCRIPTION
This adds a CPU version of the Klein Nishina application.  The same driver will work for both applications.  `CELERITAS_USE_CUDA` must still be enabled to use the app because it will do some spurious copies to the device during the cross section setup (this does not get factored into runtime comparisons).

The same driver code works for both applications except of course that the `grid_params` gets ignored.  To see an example and runtime comparisons between the CPU and GPU code see https://github.com/celeritas-project/benchmarks/blob/master/klein-nishina/celeritas-results-cpu/analysis.ipynb.

This app does a traditional loop-based (history) approach for the tracks.  It does not implement the same event loop algorithm as in the GPU case.  Generally, the history approach is more efficient on the CPU side than the event approach, so this gives a fairer optimal-to-optimal comparison of runtimes.