### PR TITLE
[em/physics] Add Bethe-Heitler process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Note: 3.13 is the first CMake version that natively supports CUDA+MPI
 cmake_minimum_required(VERSION 3.12)
 project(Celeritas VERSION 0.0.1 LANGUAGES CXX)
-cmake_policy(VERSION 3.12...3.16)
+cmake_policy(VERSION 3.12...3.18)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 if(CMAKE_VERSION VERSION_LESS 3.18)

--- a/src/physics/em/BetheHeitlerInteractor.hh
+++ b/src/physics/em/BetheHeitlerInteractor.hh
@@ -1,0 +1,132 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BetheHeitlerInteractor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/base/Interaction.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/base/Units.hh"
+#include "BetheHeitlerInteractorPointers.hh"
+
+#include "Material.mock.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Bethe-Heitler model for gamma -> e+e- (electron-pair production).
+ *
+ * Give an incident gamma, it adds a two pair-produced secondary electrons to
+ * the secondary stack. No cutoffs are performed on the incident gamma energy.
+ *
+ * \note This performs the same sampling routine as in Geant4's
+ *  G4BetheHeitlerModel, as documented in section 6.5 of the Geant4 Physics
+ *  Reference (release 10.6), applicable to incident gammas with energy
+ *  E_gamma \leq 100 GeV. For E_gamma \gt 100 GeV, the cross section is
+ * constant.
+ */
+class BetheHeitlerInteractor
+{
+  public:
+    //! Construct sampler from shared and state data
+    //! TODO: Handle Material through `shared`?
+    inline CELER_FUNCTION
+    BetheHeitlerInteractor(const BetheHeitlerInteractorPointers& shared,
+                           const ParticleTrackView&              particle,
+                           const Real3&                          inc_direction,
+                           SecondaryAllocatorView&               allocate,
+                           const MaterialMock&                   material);
+
+    // Sample an interaction with the given RNG
+    template<class Engine>
+    inline CELER_FUNCTION Interaction operator()(Engine& rng);
+
+    // >>> COMMON PROPERTIES
+
+    // Minimum incident gamma energy for this model
+    // (used for the parameterization in the
+    // cross-section calculation).
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
+    {
+        return units::MevEnergy{1.5}; // 1.5 MeV
+    }
+
+    // Maximum incident gamma energy for this mode (used for the
+    // parameterization in the cross-section calculation). Above this energy,
+    // the cross section is constant.
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
+    {
+        return units::MevEnergy{100000.0}; // 100 GeV
+    }
+
+  private:
+    // Calculates the screening variable, \deta, which is a function of
+    // \epsilon. This is a measure of the "impact parameter" of the incident
+    // photon.
+    inline CELER_FUNCTION real_type delta(size_type Z, real_type eps) const;
+
+    // Screening function, Phi1(), for the corrected Bethe-Heitler
+    // cross-section calculation.
+    inline CELER_FUNCTION real_type Phi1(real_type delta) const;
+
+    // Screening function, Phi2(), for the corrected Bethe-Heitler
+    // cross-section calculation.
+    inline CELER_FUNCTION real_type Phi2(real_type delta) const;
+
+    // Screening function for the case that the screening variable \delta > 1;
+    // in this case, \Phi1(\delta) = \Phi2(\delta) = \Phi12(delta).
+    inline CELER_FUNCTION real_type Phi12(real_type delta) const;
+
+    // Born approximation -- Coulomb correction function, F(Z), instead of
+    // plane waves. When E_gamma >= 50 MeV, calculated to fourth-order in the
+    // fine-structure constant, \alpha.
+    inline CELER_FUNCTION real_type CoulombCorr(size_type Z) const;
+
+    // "Auxiliary" Coulomb correction function.
+    inline CELER_FUNCTION real_type CoulombCorr_aux(size_type Z) const;
+
+    // Auxiliary screening function, Phi1, for the "composition+rejection"
+    // technique for sampling.
+    inline CELER_FUNCTION real_type Phi1_aux(real_type delta,
+                                             size_type Z) const;
+
+    // Auxiliary screening function, Phi2, for the "composition+rejection"
+    // technique for sampling.
+    inline CELER_FUNCTION real_type Phi2_aux(real_type delta,
+                                             size_type Z) const;
+
+    // Density function for sampling the polar angle of the electron/positron.
+    // The angle is defiend with respect to the direction of the parent photon.
+    // inline CELER_FUNCTION real_type polar_angle_density() const;
+
+    // Gamma energy divided by electron mass * csquared
+    const BetheHeitlerInteractorPointers& shared_;
+
+    // Incident gamma energy
+    const units::MevEnergy inc_energy_;
+
+    // Incident direction
+    const Real3& inc_direction_;
+
+    // Allocate space for a secondary particle
+    SecondaryAllocatorView& allocate_;
+
+    // Material atomic number, Z, needed for screening functions and variables
+    const MaterialMock& material_;
+
+    // Cached minimum epsilon, m_e*c^2/E_gamma; kinematical limit for Y -> e+e-
+    real_type epsilon0_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "BetheHeitlerInteractor.i.hh"

--- a/src/physics/em/BetheHeitlerInteractor.i.hh
+++ b/src/physics/em/BetheHeitlerInteractor.i.hh
@@ -1,0 +1,242 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BetheHeitlerInteractor.i.hh
+//---------------------------------------------------------------------------//
+
+#include "base/ArrayUtils.hh"
+#include "base/Constants.hh"
+#include "random/distributions/BernoulliDistribution.hh"
+#include "random/distributions/GenerateCanonical.hh"
+#include "random/distributions/UniformRealDistribution.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared and state data.
+ *
+ * The incident particle must be above the energy threshold: this should be
+ * handled in code *before* the interactor is constructed.
+ */
+BetheHeitlerInteractor::BetheHeitlerInteractor(
+    const BetheHeitlerInteractorPointers& shared,
+    const ParticleTrackView&              particle,
+    const Real3&                          inc_direction,
+    SecondaryAllocatorView&               allocate,
+    const MaterialMock&                   material)
+    : shared_(shared)
+    , inc_energy_(particle.energy().value())
+    , inc_direction_(inc_direction)
+    , allocate_(allocate)
+    , material_(material)
+{
+    REQUIRE(particle.def_id() == shared_.gamma_id);
+    REQUIRE(inc_energy_ >= this->min_incident_energy()
+            && inc_energy_ <= this->max_incident_energy());
+
+    epsilon0_ = 1 / (shared_.inv_electron_mass * inc_energy_.value());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Pair-production using the Bethe-Heitler model.
+ *
+ * See section 6.5 of the Geant physics reference 10.6.
+ */
+template<class Engine>
+CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
+{
+    // Allocate space for the pair-produced electrons
+    Secondary* electron_pair = this->allocate_(2);
+    if (electron_pair == nullptr)
+    {
+        // Failed to allocate space for a secondary
+        return Interaction::from_failure();
+    }
+
+    // Minimum (\epsilon = 0.5) and maximum (\epsilon = \epsilon_1) values of
+    // screening variable, \delta.
+    real_type delta_min = 136.0 * std::pow(material_.Z(), -1 / 3) * 4.0
+                          * epsilon0_;
+    real_type delta_max = std::exp((42.24 - material_.Z()) / 8.368) - 0.952;
+
+    // Determine kinematical limits on \epsilon.
+    real_type epsilon_1   = 0.5 - 0.5 * std::sqrt(1 - delta_min / delta_max);
+    real_type epsilon_min = std::max(epsilon0_, epsilon_1);
+
+    // Decide to choose f1, g1 or f2, g2 based on N1, N2 (factors from
+    // corrected Bethe-Heitler cross section; c.f. Eq. 6.6 of Geant4 Physics
+    // Reference 10.6)
+    BernoulliDistribution choose_f1g1(
+        (epsilon_min * epsilon_min - epsilon_min
+         + 0.25 * this->Phi1_aux(delta_min, material_.Z()))
+        / (1.5 * this->Phi2_aux(delta_min, material_.Z())));
+
+    // Sample epsilon
+    real_type epsilon;
+    // Temporary sample values used in rejection
+    real_type reject_threshold;
+    do
+    {
+        if (choose_f1g1(rng))
+        {
+            // Used to sample from f1
+            epsilon = 0.5
+                      - (0.5 - epsilon_min)
+                            * std::pow(generate_canonical(rng), 1 / 3);
+            real_type epsilon_sq = epsilon * epsilon;
+            // Calculate f1 density function
+            real_type f1 = 3 / std::pow(0.5 - epsilon_min, 3)
+                           * (epsilon_sq - epsilon + 0.25);
+            // Calculate delta from material Z and sampled epsilon
+            real_type d = this->delta(material_.Z(), epsilon);
+            // Calculate g1 "rejection" function
+            reject_threshold = this->Phi1_aux(d, material_.Z())
+                               / this->Phi1_aux(delta_min, material_.Z());
+        }
+        else
+        {
+            // Used to sample from f2
+            epsilon = epsilon_min + (0.5 - epsilon_min) * rnd_b(rng);
+            // Calculate f2 density function (constant)
+            real_type f2 = 1 / (0.5 - epsilon_min);
+            // Calculate delta given the material Z and sampled epsilon
+            real_type d = this->delta(material_.Z(), epsilon);
+            // Calculate g2 "rejection" function
+            reject_threshold = this->Phi2_aux(d, material_.Z())
+                               / this->Phi2_aux(delta_min, material_.Z());
+        }
+        CHECK(epsilon >= epsilon_min && epsilon <= 0.5);
+    } while (generate_canonical(rng) > reject_threshold);
+
+    // Construct interaction for change to primary (incident) particle
+    Interaction result;
+    result.action      = Action::absorbed;
+    result.energy      = units::MevEnergy{0};
+    result.direction   = {0, 0, 0};
+    result.secondaries = {electron_pair, 2};
+
+    // Argument to density function for polar angle
+    real_type density_arg;
+    real_type log_r2r3
+        = std::log(generate_canonical(rng) * generate_canonical(rng));
+    if (generate_canonical(rng) < 0.25)
+    {
+        density_arg = log_r2r3 * 1.6;
+    }
+    else
+    {
+        density_arg = log_r2r3 / 1.875;
+    }
+
+    // Polar angle from the density function
+    real_type theta = 0.0977
+                      * (density_arg * std::exp(-log_r2r3)
+                         + 27 * density_arg * std::exp(-log_r2r3));
+
+    // Azimuthal angle sampled isotropically
+    UniformRealDistribution<real_type> sample_phi(0, 2 * constants::pi);
+    electron_pair[0].direction = rotate(
+        from_spherical(std::cos(theta), sample_phi(rng)), inc_direction_);
+    electron_pair[1].direction = rotate(
+        from_spherical(-std::cos(theta), sample_phi(rng)), inc_direction_);
+
+    // Outgoing secondaries are electron and positron
+    electron_pair[0].def_id = shared_.electron_id;
+    electron_pair[1].def_id = shared_.positron_id;
+    // Energies of secondaries shared equally
+    electron_pair[0].energy
+        = units::MevEnergy{0.5 * epsilon * inc_energy_.value()};
+    electron_pair[1].def_id
+        = units::MevEnergy{0.5 * epsilon * inc_energy_.value()};
+    // Calculate produced pair directions via conservation of momentum
+    for (unsigned int p = 0; p < allocate_.capacity(); p++)
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            electron_pair[p].direction[i]
+                = inc_direction_[i] * inc_energy_.value()
+                  - electron_pair[p].direction[i]
+                        * electron_pair[p].energy.value();
+        }
+        normalize_direction(&electron_pair[p].direction);
+    }
+
+    return result;
+}
+
+CELER_FUNCTION real_type BetheHeitlerInteractor::delta(size_type Z,
+                                                       real_type eps) const
+{
+    return 136 * std::pow(Z, -1 / 3) * epsilon0_ * epsilon0_
+           / (eps * (1 - eps));
+}
+
+CELER_FUNCTION real_type BetheHeitlerInteractor::Phi1(real_type delta) const
+{
+    if (delta <= 1)
+    {
+        return 20.867 - 3.242 * delta + 0.625 * delta * delta;
+    }
+    return Phi12(delta);
+}
+
+CELER_FUNCTION real_type BetheHeitlerInteractor::Phi2(real_type delta) const
+{
+    if (delta <= 1)
+    {
+        return 20.209 - 1.930 * delta - 0.086 * delta * delta;
+    }
+    return Phi12(delta);
+}
+
+CELER_FUNCTION real_type BetheHeitlerInteractor::Phi12(real_type delta) const
+{
+    return 21.12 - 4.184 * std::log(delta + 0.952);
+}
+
+CELER_FUNCTION real_type BetheHeitlerInteractor::CoulombCorr(size_type Z) const
+{
+    real_type term1 = 8 / 3 * std::log(Z);
+
+    if (inc_energy_.value() < 50.0) // 50 MeV
+    {
+        return term1;
+    }
+
+    return term1 + 8 * this->CoulombCorr_aux(Z);
+}
+
+CELER_FUNCTION real_type BetheHeitlerInteractor::CoulombCorr_aux(size_type Z) const
+{
+    real_type alphaZ_sq = constants::alpha_fine_structure
+                          * constants::alpha_fine_structure * Z * Z;
+    real_type alphaZ_sqsq = alphaZ_sq * alphaZ_sq;
+    return alphaZ_sq
+           * (1 / (1 + alphaZ_sq) + 0.20206 - 0.0369 * alphaZ_sq
+              + 0.0083 * alphaZ_sqsq - 0.0020 * alphaZ_sq * alphaZ_sqsq);
+}
+
+CELER_FUNCTION real_type BetheHeitlerInteractor::Phi1_aux(real_type delta,
+                                                          size_type Z) const
+{
+    return (3 * this->Phi1(delta) - this->Phi2(delta) - this->CoulombCorr(Z));
+}
+
+CELER_FUNCTION real_type BetheHeitlerInteractor::Phi2_aux(real_type delta,
+                                                          size_type Z) const
+{
+    return (3 / 2 * this->Phi1(delta) - 0.5 * this->Phi2(delta)
+            - this->CoulombCorr(Z));
+}
+
+// CELER_FUNCTION real_type BetheHeitler::polar_angle_density() const
+// {
+//     return 0 .0;
+// }
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/BetheHeitlerInteractorPointers.hh
+++ b/src/physics/em/BetheHeitlerInteractorPointers.hh
@@ -1,0 +1,40 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BetheHeitlerInteractorPointers.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "Material.mock.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Device data for creating a BetheHeitlerInteractor.
+ */
+struct BetheHeitlerInteractorPointers
+{
+    //! Inverse of electron mass [1 / MevMass]
+    real_type inv_electron_mass;
+    //! ID of an electron
+    ParticleDefId electron_id;
+    //! ID of an electron
+    ParticleDefId positron_id;
+    //! ID of a gamma
+    ParticleDefId gamma_id;
+
+    //! Check whether the view is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        return (inv_electron_mass > 0) && electron_id && positron_id
+               && gamma_id;
+    }
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/Material.mock.hh
+++ b/src/physics/em/Material.mock.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Material.mocl.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Mock (single) material class.
+ * 
+ * This is a temporary, extremely bare-bones mock class, used currently only
+ * for Bethe-Heitler model. To be replaced.
+ */
+class MaterialMock
+{
+  public:
+    inline CELER_FUNCTION
+    MaterialMock(const std::string name,
+                 size_type Z,
+                 real_type A) :
+                 name_(name),
+                 Z_(Z),
+                 A_(A) {}
+
+    //@{
+    //! Accessors
+    inline CELER_FUNCTION size_type Z() const { return Z_; };
+    inline CELER_FUNCTION real_type A() const { return A_; };
+    //@}
+
+  private:
+    std::string name_;  //!< Material name
+    size_type Z_;       //!< Atomic number
+    real_type A_;       //!< Atomic mass
+};
+
+
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -166,6 +166,7 @@ add_cudaoptional_test(physics/base/Particle)
 celeritas_setup_tests(SERIAL PREFIX physics/em)
 
 celeritas_add_test(physics/em/BetheBlochInteractor.test.cc)
+celeritas_add_test(physics/em/BetheHeitlerInteractor.test.cc)
 celeritas_add_test(physics/em/BremRelInteractor.test.cc)
 celeritas_add_test(physics/em/EPlusGGInteractor.test.cc)
 celeritas_add_test(physics/em/KleinNishinaInteractor.test.cc)

--- a/test/physics/em/BetheHeitlerInteractor.test.cc
+++ b/test/physics/em/BetheHeitlerInteractor.test.cc
@@ -1,0 +1,49 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BetheHeitlerInteractor.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/em/BetheHeitlerInteractor.hh"
+
+#include "gtest/Main.hh"
+#include "base/ArrayUtils.hh"
+#include "base/Range.hh"
+#include "physics/base/Units.hh"
+#include "../InteractorHostTestBase.hh"
+#include "../InteractionIO.hh"
+
+using celeritas::BetheHeitlerInteractor;
+namespace pdg = celeritas::pdg;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class BetheHeitlerInteractorTest : public celeritas_test::InteractorHostTestBase
+{
+    using Base = celeritas_test::InteractorHostTestBase;
+
+  protected:
+    void SetUp() override
+    {
+    }
+
+    void sanity_check(const Interaction& interaction) const
+    {
+        ASSERT_TRUE(interaction);
+    }
+
+  protected:
+    celeritas::BetheHeitlerInteractorPointers pointers_;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(BetheHeitlerInteractorTest, stress_test)
+{
+    
+}


### PR DESCRIPTION
This PR adds the Bethe-Heitler process for gamma -> e+e-, largely based on Sec. 6.5 of the Geant 4 Physics Reference v10.6.

The following new files have been added:
  - src/physics/em/BetheHeitlerInteractor.hh
  - src/physics/em/BetheHeitlerInteractor.i.hh
  - src/physics/em/BetheHeitlerInteractorPointers.hh
  - src/physics/em/Material.mock.hh
  - test/physics/em/BetheHeitlerInteractor.test.cc
    
and updates test/CMakeLists.txt to include the test (in progress).
    
Note that Material.mock.hh is an over simplification of a material type, and is used here simply for testing purposes.