### PR TITLE
Add skeleton EM physics classes

### DIFF
--- a/cmake/CeleritasAddTest.cmake
+++ b/cmake/CeleritasAddTest.cmake
@@ -380,13 +380,11 @@ function(celeritas_add_test SOURCE_FILE)
       endif()
 
       if(PARSE_TIMEOUT)
-        # Extend test timeout
-        set_property(TEST "${_TEST_NAME}"
+        set_property(TEST ${_TEST_NAME}
           PROPERTY TIMEOUT ${PARSE_TIMEOUT})
       endif()
-      if(PARSE_DISABLED)
-        # Extend test timeout
-        set_property(TEST "${_TEST_NAME}"
+      if(PARSE_DISABLE)
+        set_property(TEST ${_TEST_NAME}
           PROPERTY DISABLED True)
       endif()
       set_property(TEST ${_TEST_NAME}

--- a/scripts/dev/celeritas-gen-hackathon.py
+++ b/scripts/dev/celeritas-gen-hackathon.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+###############################################################################
+# File: scripts/dev/celeritas-gen.py
+###############################################################################
+"""Generate class file stubs for Celeritas.
+"""
+from __future__ import (division, absolute_import, print_function)
+import os.path
+import re
+import subprocess
+import sys
+###############################################################################
+
+CLIKE_TOP = '''\
+//{modeline:-^75s}//
+// Copyright {year} UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \\file {filename}
+//---------------------------------------------------------------------------//
+'''
+
+HEADER_FILE = '''\
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/base/Interaction.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/Units.hh"
+#include "{name}Pointers.hh"
+
+namespace {namespace}
+{{
+//---------------------------------------------------------------------------//
+/*!
+ * Brief class description.
+ *
+ * This is a model for XXXX process. Additional description
+ *
+ * \\note This performs the same sampling routine as in Geant4's
+ * XXXX class, as documented in section XXX of the Geant4 Physics
+ * Reference (release 10.6).
+ */
+class {name}
+{{
+  public:
+    // Construct with shared and state data
+    inline CELER_FUNCTION {name}(
+            const {name}Pointers&    shared,
+            const ParticleTrackView& particle,
+            const Real3&             inc_direction,
+            SecondaryAllocatorView&  allocate);
+
+
+    // Sample an interaction with the given RNG
+    template<class Engine>
+    inline CELER_FUNCTION Interaction operator()(Engine& rng);
+
+    // >>> COMMON PROPERTIES
+
+    //! Minimum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
+    {{
+        return units::MevEnergy{{0}}; // XXX
+    }}
+
+    //! Maximum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
+    {{
+        return units::MevEnergy{{0}}; // XXX
+    }}
+
+  private:
+    // Shared constant physics properties
+    const {name}Pointers& shared_;
+    // Incident gamma energy
+    const units::MevEnergy inc_energy_;
+    // Incident direction
+    const Real3& inc_direction_;
+    // Allocate space for one or more secondary particles
+    SecondaryAllocatorView& allocate_;
+}};
+
+//---------------------------------------------------------------------------//
+}} // namespace {namespace}
+
+#include "{name}.i.{hext}"
+'''
+
+INLINE_FILE = '''\
+
+namespace {namespace}
+{{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared and state data.
+ */
+CELER_FUNCTION {name}::{name}(
+        const {name}Pointers& shared,
+        const ParticleTrackView& particle,
+        const Real3&             inc_direction,
+        SecondaryAllocatorView&  allocate)
+    : shared_(shared)
+    , inc_energy_(particle.energy().value())
+    , inc_direction_(inc_direction)
+    , allocate_(allocate)
+{{
+    REQUIRE(inc_energy_ >= this->min_incident_energy()
+            && inc_energy_ <= this->max_incident_energy());
+    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+}}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample using the XXX model.
+ */
+template<class Engine>
+CELER_FUNCTION Interaction {name}::operator()(Engine& rng)
+{{
+    // Allocate space for XXX (electron, multiple particles, ...)
+    Secondary* secondaries = this->allocate_(0); // XXX
+    if (secondaries == nullptr)
+    {{
+        // Failed to allocate space for a secondary
+        return Interaction::from_failure();
+    }}
+
+    // XXX sample
+    (void)sizeof(rng);
+
+    // Construct interaction for change to primary (incident) particle
+    Interaction result;
+    result.action      = Action::scattered; // XXX
+    result.energy      = units::MevEnergy{{inc_energy_.value()}}; // XXX
+    result.direction   = inc_direction_;
+    result.secondaries = {{secondaries, 1}}; // XXX
+
+    // Save outgoing secondary data
+    secondaries[0].def_id = shared_.electron_id; // XXX
+    secondaries[0].energy = units::MevEnergy{{0}}; // XXX
+    secondaries[0].direction = {{0, 0, 0}}; // XXX
+
+    return result;
+}}
+
+//---------------------------------------------------------------------------//
+}}  // namespace {namespace}
+'''
+
+CODE_FILE = '''\
+#include "{name}.{hext}"
+
+namespace {namespace}
+{{
+//---------------------------------------------------------------------------//
+
+//---------------------------------------------------------------------------//
+}} // namespace {namespace}
+'''
+
+TEST_HARNESS_FILE = '''\
+#include "physics/em/{name}.{hext}"
+
+#include "gtest/Main.hh"
+#include "base/ArrayUtils.hh"
+#include "base/Range.hh"
+#include "physics/base/Units.hh"
+#include "../InteractorHostTestBase.hh"
+#include "../InteractionIO.hh"
+
+using {namespace}::{name};
+namespace pdg = celeritas::pdg;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class {name}Test : public celeritas_test::InteractorHostTestBase
+{{
+    using Base = celeritas_test::InteractorHostTestBase;
+  protected:
+    void SetUp() override
+    {{
+        using celeritas::ParticleDef;
+        using namespace celeritas::units;
+        celeritas::ZeroQuantity zero;
+        auto                    stable = ParticleDef::stable_decay_constant();
+
+        // XXX Update these based on particles needed by interactor
+        Base::set_particle_params(
+            {{{{{{"electron", pdg::electron()}},
+              {{MevMass{{0.5109989461}}, ElementaryCharge{{-1}}, stable}}}},
+             {{{{"gamma", pdg::gamma()}}, {{zero, zero, stable}}}}}});
+        const auto& params    = this->particle_params();
+        pointers_.electron_id = params.find(pdg::electron());
+        pointers_.gamma_id    = params.find(pdg::gamma());
+
+        // Set default particle to incident XXX MeV photon
+        this->set_inc_particle(pdg::gamma(), MevEnergy{{10}});
+        this->set_inc_direction({{0, 0, 1}});
+    }}
+
+    void sanity_check(const Interaction& interaction) const
+    {{
+        ASSERT_TRUE(interaction);
+
+        // Check change to parent track
+        EXPECT_GT(this->particle_track().energy().value(),
+                  interaction.energy.value());
+        EXPECT_LT(0, interaction.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(interaction.direction));
+        EXPECT_EQ(celeritas::Action::scattered, interaction.action);
+
+        // XXX Check secondaries
+
+        // Check conservation between primary and secondaries
+        this->check_conservation(interaction);
+    }}
+
+  protected:
+    celeritas::{name}Pointers pointers_;
+}};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F({name}Test, basic)
+{{
+}}
+'''
+
+TEST_HEADER_FILE = '''
+namespace celeritas_test
+{{
+using namespace {namespace};
+//---------------------------------------------------------------------------//
+// TESTING INTERFACE
+//---------------------------------------------------------------------------//
+//! Input data
+struct {capabbr}TestInput
+{{
+    int num_threads;
+}};
+
+//---------------------------------------------------------------------------//
+//! Output results
+struct {capabbr}TestOutput
+{{
+}};
+
+//---------------------------------------------------------------------------//
+//! Run on device and return results
+{capabbr}TestOutput {lowabbr}_test({capabbr}TestInput);
+
+//---------------------------------------------------------------------------//
+}} // namespace celeritas_test
+'''
+
+TEST_CODE_FILE = '''\
+#include "{name}.test.hh"
+
+#include <thrust/device_vector.h>
+#include "base/KernelParamCalculator.cuda.hh"
+
+using thrust::raw_pointer_cast;
+
+namespace celeritas_test
+{{
+//---------------------------------------------------------------------------//
+// KERNELS
+//---------------------------------------------------------------------------//
+
+__global__ void {lowabbr}_test_kernel(unsigned int size)
+{{
+    auto local_thread_id = celeritas::KernelParamCalculator::thread_id();
+    if (local_thread_id.get() >= size)
+        return;
+}}
+
+//---------------------------------------------------------------------------//
+// TESTING INTERFACE
+//---------------------------------------------------------------------------//
+//! Run on device and return results
+{capabbr}TestOutput {lowabbr}_test({capabbr}TestInput input)
+{{
+    celeritas::KernelParamCalculator calc_launch_params;
+    auto params = calc_launch_params(input.num_threads);
+    {lowabbr}_test_kernel<<<params.grid_size, params.block_size>>>(
+        input.num_threads);
+
+    {capabbr}TestOutput result;
+    return result;
+}}
+
+//---------------------------------------------------------------------------//
+}} // namespace celeritas_test
+'''
+
+
+CMAKE_TOP = '''\
+#{modeline:-^77s}#
+# Copyright {year} UT-Battelle, LLC and other Celeritas Developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+'''
+
+CMAKELISTS_FILE = '''\
+#-----------------------------------------------------------------------------#
+
+'''
+
+
+CMAKE_FILE = '''\
+#[=======================================================================[.rst:
+
+{name}
+-------------------
+
+Description of overall module contents goes here.
+
+.. command:: my_command_name
+
+  Pass the given compiler-dependent warning flags to a library target::
+
+    my_command_name(<target>
+                    <INTERFACE|PUBLIC|PRIVATE>
+                    LANGUAGE <lang> [<lang>...]
+                    [CACHE_VARIABLE <name>])
+
+  ``target``
+    Name of the library target.
+
+  ``scope``
+    One of ``INTERFACE``, ``PUBLIC``, or ``PRIVATE``. ...
+
+#]=======================================================================]
+
+function(my_command_name)
+endfunction()
+
+'''
+
+PYTHON_TOP = '''\
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright {year} UT-Battelle, LLC and other Celeritas Developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+'''
+
+PYTHON_FILE = '''\
+"""
+"""
+
+'''
+
+YEAR = "2020"
+
+TEMPLATES = {
+    'hh': HEADER_FILE,
+    'i.hh': INLINE_FILE,
+    'cc': CODE_FILE,
+    'cu': CODE_FILE,
+    'cuh': HEADER_FILE,
+    'test.cc': TEST_HARNESS_FILE,
+    'test.cu': TEST_CODE_FILE,
+    'test.hh': TEST_HEADER_FILE,
+    'k.cuh': INLINE_FILE,
+    'i.cuh': INLINE_FILE,
+    't.cuh': INLINE_FILE,
+    'cmake': CMAKE_FILE,
+    'CMakeLists.txt': CMAKELISTS_FILE,
+    'py': PYTHON_FILE,
+}
+
+LANG = {
+    'h': "C++",
+    'hh': "C++",
+    'cc': "C++",
+    'cu': "CUDA",
+    'cuh': "CUDA",
+    'cmake': "CMake",
+    'CMakeLists.txt': "CMake",
+    'py': "Python",
+}
+
+TOPS = {
+    'C++': CLIKE_TOP,
+    'CUDA': CLIKE_TOP,
+    'CMake': CMAKE_TOP,
+    'Python': PYTHON_TOP,
+}
+
+HEXT = {
+    'C++': "hh",
+    'CUDA': "cuh",
+}
+
+def generate(root, filename, namespace):
+    if os.path.exists(filename):
+        print("Skipping existing file " + filename)
+        return
+
+    relpath = os.path.relpath(filename, start=root)
+    dirname = os.path.dirname(relpath)
+    basename = os.path.basename(filename)
+    (name, _, longext) = basename.partition('.')
+
+    lang = None
+    template = None
+    ext = longext.split('.')[-1]
+    for check_lang in [basename, longext, ext]:
+        if not lang:
+            lang = LANG.get(check_lang, None)
+        if not template:
+            template = TEMPLATES.get(check_lang, None)
+    if not lang:
+        print(f"No known language for '.{ext}' files")
+    if not template:
+        print(f"No configured template for '.{ext}' files")
+    if not lang or not template:
+        sys.exit(1)
+
+    top = TOPS[lang]
+
+    relpath = re.sub(r'^[./]+', '', relpath)
+    capabbr = re.sub(r'[^A-Z]+', '', name)
+    dirfromtest = re.sub(r'^test/', '', relpath)
+    variables = {
+        'longext': longext,
+        'ext': ext,
+        'hext': HEXT.get(lang, ext),
+        'modeline': "-*-{}-*-".format(lang),
+        'name': name,
+        'namespace': namespace,
+        'filename': filename,
+        'basename': basename,
+        'dirfromtest': dirfromtest,
+        'capabbr': capabbr,
+        'lowabbr': capabbr.lower(),
+        'year': YEAR,
+        }
+    with open(filename, 'w') as f:
+        f.write((top + template).format(**variables))
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('filename', nargs='+',
+                        help='file names to generate')
+    parser.add_argument('--basedir',
+                        help='root source directory for file naming')
+    parser.add_argument('--namespace', '-n',
+                        default='celeritas',
+                        help='root source directory for file naming')
+    args = parser.parse_args()
+    basedir = args.basedir or os.path.join(
+            subprocess.check_output(['git', 'rev-parse', '--show-toplevel'])
+                .decode().strip(),
+            'src')
+    for fn in args.filename:
+        generate(basedir, fn, args.namespace)
+
+#-----------------------------------------------------------------------------#
+if __name__ == '__main__':
+    main()
+
+###############################################################################
+# end of scripts/dev/celeritas-gen.py
+###############################################################################

--- a/src/physics/em/BetheBlochInteractor.hh
+++ b/src/physics/em/BetheBlochInteractor.hh
@@ -1,0 +1,73 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BetheBlochInteractor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/base/Interaction.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/Units.hh"
+#include "BetheBlochInteractorPointers.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Brief class description.
+ *
+ * This is a model for XXXX process. Additional description
+ *
+ * \note This performs the same sampling routine as in Geant4's
+ * XXXX class, as documented in section XXX of the Geant4 Physics
+ * Reference (release 10.6).
+ */
+class BetheBlochInteractor
+{
+  public:
+    // Construct with shared and state data
+    inline CELER_FUNCTION
+    BetheBlochInteractor(const BetheBlochInteractorPointers& shared,
+                         const ParticleTrackView&            particle,
+                         const Real3&                        inc_direction,
+                         SecondaryAllocatorView&             allocate);
+
+    // Sample an interaction with the given RNG
+    template<class Engine>
+    inline CELER_FUNCTION Interaction operator()(Engine& rng);
+
+    // >>> COMMON PROPERTIES
+
+    //! Minimum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+    //! Maximum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+  private:
+    // Shared constant physics properties
+    const BetheBlochInteractorPointers& shared_;
+    // Incident gamma energy
+    const units::MevEnergy inc_energy_;
+    // Incident direction
+    const Real3& inc_direction_;
+    // Allocate space for one or more secondary particles
+    SecondaryAllocatorView& allocate_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "BetheBlochInteractor.i.hh"

--- a/src/physics/em/BetheBlochInteractor.i.hh
+++ b/src/physics/em/BetheBlochInteractor.i.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BetheBlochInteractor.i.hh
+//---------------------------------------------------------------------------//
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared and state data.
+ */
+CELER_FUNCTION BetheBlochInteractor::BetheBlochInteractor(
+    const BetheBlochInteractorPointers& shared,
+    const ParticleTrackView&            particle,
+    const Real3&                        inc_direction,
+    SecondaryAllocatorView&             allocate)
+    : shared_(shared)
+    , inc_energy_(particle.energy().value())
+    , inc_direction_(inc_direction)
+    , allocate_(allocate)
+{
+    REQUIRE(inc_energy_ >= this->min_incident_energy()
+            && inc_energy_ <= this->max_incident_energy());
+    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample using the XXX model.
+ */
+template<class Engine>
+CELER_FUNCTION Interaction BetheBlochInteractor::operator()(Engine& rng)
+{
+    // Allocate space for XXX (electron, multiple particles, ...)
+    Secondary* secondaries = this->allocate_(0); // XXX
+    if (secondaries == nullptr)
+    {
+        // Failed to allocate space for a secondary
+        return Interaction::from_failure();
+    }
+
+    // XXX sample
+    (void)sizeof(rng);
+
+    // Construct interaction for change to primary (incident) particle
+    Interaction result;
+    result.action      = Action::scattered;                     // XXX
+    result.energy      = units::MevEnergy{inc_energy_.value()}; // XXX
+    result.direction   = inc_direction_;
+    result.secondaries = {secondaries, 1}; // XXX
+
+    // Save outgoing secondary data
+    secondaries[0].def_id    = shared_.electron_id; // XXX
+    secondaries[0].energy    = units::MevEnergy{0}; // XXX
+    secondaries[0].direction = {0, 0, 0};           // XXX
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/BetheBlochInteractorPointers.hh
+++ b/src/physics/em/BetheBlochInteractorPointers.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BetheBlochInteractorPointers.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Device data for creating an interactor.
+ */
+struct BetheBlochInteractorPointers
+{
+    //! ID of an electron
+    ParticleDefId electron_id;
+    //! ID of a gamma
+    ParticleDefId gamma_id;
+    // XXX additional data
+
+    //! Check whether the data is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        return electron_id && gamma_id; // XXX
+    }
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/BremRelInteractor.hh
+++ b/src/physics/em/BremRelInteractor.hh
@@ -1,0 +1,73 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BremRelInteractor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/base/Interaction.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/Units.hh"
+#include "BremRelInteractorPointers.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Brief class description.
+ *
+ * This is a model for XXXX process. Additional description
+ *
+ * \note This performs the same sampling routine as in Geant4's
+ * XXXX class, as documented in section XXX of the Geant4 Physics
+ * Reference (release 10.6).
+ */
+class BremRelInteractor
+{
+  public:
+    // Construct with shared and state data
+    inline CELER_FUNCTION
+    BremRelInteractor(const BremRelInteractorPointers& shared,
+                      const ParticleTrackView&         particle,
+                      const Real3&                     inc_direction,
+                      SecondaryAllocatorView&          allocate);
+
+    // Sample an interaction with the given RNG
+    template<class Engine>
+    inline CELER_FUNCTION Interaction operator()(Engine& rng);
+
+    // >>> COMMON PROPERTIES
+
+    //! Minimum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+    //! Maximum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+  private:
+    // Shared constant physics properties
+    const BremRelInteractorPointers& shared_;
+    // Incident gamma energy
+    const units::MevEnergy inc_energy_;
+    // Incident direction
+    const Real3& inc_direction_;
+    // Allocate space for one or more secondary particles
+    SecondaryAllocatorView& allocate_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "BremRelInteractor.i.hh"

--- a/src/physics/em/BremRelInteractor.i.hh
+++ b/src/physics/em/BremRelInteractor.i.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BremRelInteractor.i.hh
+//---------------------------------------------------------------------------//
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared and state data.
+ */
+CELER_FUNCTION
+BremRelInteractor::BremRelInteractor(const BremRelInteractorPointers& shared,
+                                     const ParticleTrackView&         particle,
+                                     const Real3&            inc_direction,
+                                     SecondaryAllocatorView& allocate)
+    : shared_(shared)
+    , inc_energy_(particle.energy().value())
+    , inc_direction_(inc_direction)
+    , allocate_(allocate)
+{
+    REQUIRE(inc_energy_ >= this->min_incident_energy()
+            && inc_energy_ <= this->max_incident_energy());
+    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample using the XXX model.
+ */
+template<class Engine>
+CELER_FUNCTION Interaction BremRelInteractor::operator()(Engine& rng)
+{
+    // Allocate space for XXX (electron, multiple particles, ...)
+    Secondary* secondaries = this->allocate_(0); // XXX
+    if (secondaries == nullptr)
+    {
+        // Failed to allocate space for a secondary
+        return Interaction::from_failure();
+    }
+
+    // XXX sample
+    (void)sizeof(rng);
+
+    // Construct interaction for change to primary (incident) particle
+    Interaction result;
+    result.action      = Action::scattered;                     // XXX
+    result.energy      = units::MevEnergy{inc_energy_.value()}; // XXX
+    result.direction   = inc_direction_;
+    result.secondaries = {secondaries, 1}; // XXX
+
+    // Save outgoing secondary data
+    secondaries[0].def_id    = shared_.electron_id; // XXX
+    secondaries[0].energy    = units::MevEnergy{0}; // XXX
+    secondaries[0].direction = {0, 0, 0};           // XXX
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/BremRelInteractorPointers.hh
+++ b/src/physics/em/BremRelInteractorPointers.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BremRelInteractorPointers.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Device data for creating an interactor.
+ */
+struct BremRelInteractorPointers
+{
+    //! ID of an electron
+    ParticleDefId electron_id;
+    //! ID of a gamma
+    ParticleDefId gamma_id;
+    // XXX additional data
+
+    //! Check whether the data is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        return electron_id && gamma_id; // XXX
+    }
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/EPlusGGInteractor.hh
+++ b/src/physics/em/EPlusGGInteractor.hh
@@ -1,0 +1,73 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file EPlusGGInteractor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/base/Interaction.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/Units.hh"
+#include "EPlusGGInteractorPointers.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Brief class description.
+ *
+ * This is a model for XXXX process. Additional description
+ *
+ * \note This performs the same sampling routine as in Geant4's
+ * XXXX class, as documented in section XXX of the Geant4 Physics
+ * Reference (release 10.6).
+ */
+class EPlusGGInteractor
+{
+  public:
+    // Construct with shared and state data
+    inline CELER_FUNCTION
+    EPlusGGInteractor(const EPlusGGInteractorPointers& shared,
+                      const ParticleTrackView&         particle,
+                      const Real3&                     inc_direction,
+                      SecondaryAllocatorView&          allocate);
+
+    // Sample an interaction with the given RNG
+    template<class Engine>
+    inline CELER_FUNCTION Interaction operator()(Engine& rng);
+
+    // >>> COMMON PROPERTIES
+
+    //! Minimum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+    //! Maximum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+  private:
+    // Shared constant physics properties
+    const EPlusGGInteractorPointers& shared_;
+    // Incident gamma energy
+    const units::MevEnergy inc_energy_;
+    // Incident direction
+    const Real3& inc_direction_;
+    // Allocate space for one or more secondary particles
+    SecondaryAllocatorView& allocate_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "EPlusGGInteractor.i.hh"

--- a/src/physics/em/EPlusGGInteractor.i.hh
+++ b/src/physics/em/EPlusGGInteractor.i.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file EPlusGGInteractor.i.hh
+//---------------------------------------------------------------------------//
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared and state data.
+ */
+CELER_FUNCTION
+EPlusGGInteractor::EPlusGGInteractor(const EPlusGGInteractorPointers& shared,
+                                     const ParticleTrackView&         particle,
+                                     const Real3&            inc_direction,
+                                     SecondaryAllocatorView& allocate)
+    : shared_(shared)
+    , inc_energy_(particle.energy().value())
+    , inc_direction_(inc_direction)
+    , allocate_(allocate)
+{
+    REQUIRE(inc_energy_ >= this->min_incident_energy()
+            && inc_energy_ <= this->max_incident_energy());
+    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample using the XXX model.
+ */
+template<class Engine>
+CELER_FUNCTION Interaction EPlusGGInteractor::operator()(Engine& rng)
+{
+    // Allocate space for XXX (electron, multiple particles, ...)
+    Secondary* secondaries = this->allocate_(0); // XXX
+    if (secondaries == nullptr)
+    {
+        // Failed to allocate space for a secondary
+        return Interaction::from_failure();
+    }
+
+    // XXX sample
+    (void)sizeof(rng);
+
+    // Construct interaction for change to primary (incident) particle
+    Interaction result;
+    result.action      = Action::scattered;                     // XXX
+    result.energy      = units::MevEnergy{inc_energy_.value()}; // XXX
+    result.direction   = inc_direction_;
+    result.secondaries = {secondaries, 1}; // XXX
+
+    // Save outgoing secondary data
+    secondaries[0].def_id    = shared_.electron_id; // XXX
+    secondaries[0].energy    = units::MevEnergy{0}; // XXX
+    secondaries[0].direction = {0, 0, 0};           // XXX
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/EPlusGGInteractorPointers.hh
+++ b/src/physics/em/EPlusGGInteractorPointers.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file EPlusGGInteractorPointers.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Device data for creating an interactor.
+ */
+struct EPlusGGInteractorPointers
+{
+    //! ID of an electron
+    ParticleDefId electron_id;
+    //! ID of a gamma
+    ParticleDefId gamma_id;
+    // XXX additional data
+
+    //! Check whether the data is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        return electron_id && gamma_id; // XXX
+    }
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/KleinNishinaInteractor.hh
+++ b/src/physics/em/KleinNishinaInteractor.hh
@@ -35,7 +35,7 @@ namespace celeritas
 class KleinNishinaInteractor
 {
   public:
-    // Construct sampler from shared and state data
+    // Construct from shared and state data
     inline CELER_FUNCTION
     KleinNishinaInteractor(const KleinNishinaInteractorPointers& shared,
                            const ParticleTrackView&              particle,
@@ -56,7 +56,7 @@ class KleinNishinaInteractor
     }
 
   private:
-    // Gamma energy divided by electron mass * csquared
+    // Constant data
     const KleinNishinaInteractorPointers& shared_;
     // Incident gamma energy
     const units::MevEnergy inc_energy_;

--- a/src/physics/em/KleinNishinaInteractor.i.hh
+++ b/src/physics/em/KleinNishinaInteractor.i.hh
@@ -21,7 +21,7 @@ namespace celeritas
  * The incident particle must be above the energy threshold: this should be
  * handled in code *before* the interactor is constructed.
  */
-KleinNishinaInteractor::KleinNishinaInteractor(
+CELER_FUNCTION KleinNishinaInteractor::KleinNishinaInteractor(
     const KleinNishinaInteractorPointers& shared,
     const ParticleTrackView&              particle,
     const Real3&                          inc_direction,

--- a/src/physics/em/LivermoreInteractor.hh
+++ b/src/physics/em/LivermoreInteractor.hh
@@ -1,0 +1,73 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file LivermoreInteractor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/base/Interaction.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/Units.hh"
+#include "LivermoreInteractorPointers.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Brief class description.
+ *
+ * This is a model for XXXX process. Additional description
+ *
+ * \note This performs the same sampling routine as in Geant4's
+ * XXXX class, as documented in section XXX of the Geant4 Physics
+ * Reference (release 10.6).
+ */
+class LivermoreInteractor
+{
+  public:
+    // Construct with shared and state data
+    inline CELER_FUNCTION
+    LivermoreInteractor(const LivermoreInteractorPointers& shared,
+                        const ParticleTrackView&           particle,
+                        const Real3&                       inc_direction,
+                        SecondaryAllocatorView&            allocate);
+
+    // Sample an interaction with the given RNG
+    template<class Engine>
+    inline CELER_FUNCTION Interaction operator()(Engine& rng);
+
+    // >>> COMMON PROPERTIES
+
+    //! Minimum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+    //! Maximum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+  private:
+    // Shared constant physics properties
+    const LivermoreInteractorPointers& shared_;
+    // Incident gamma energy
+    const units::MevEnergy inc_energy_;
+    // Incident direction
+    const Real3& inc_direction_;
+    // Allocate space for one or more secondary particles
+    SecondaryAllocatorView& allocate_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "LivermoreInteractor.i.hh"

--- a/src/physics/em/LivermoreInteractor.i.hh
+++ b/src/physics/em/LivermoreInteractor.i.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file LivermoreInteractor.i.hh
+//---------------------------------------------------------------------------//
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared and state data.
+ */
+CELER_FUNCTION LivermoreInteractor::LivermoreInteractor(
+    const LivermoreInteractorPointers& shared,
+    const ParticleTrackView&           particle,
+    const Real3&                       inc_direction,
+    SecondaryAllocatorView&            allocate)
+    : shared_(shared)
+    , inc_energy_(particle.energy().value())
+    , inc_direction_(inc_direction)
+    , allocate_(allocate)
+{
+    REQUIRE(inc_energy_ >= this->min_incident_energy()
+            && inc_energy_ <= this->max_incident_energy());
+    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample using the XXX model.
+ */
+template<class Engine>
+CELER_FUNCTION Interaction LivermoreInteractor::operator()(Engine& rng)
+{
+    // Allocate space for XXX (electron, multiple particles, ...)
+    Secondary* secondaries = this->allocate_(0); // XXX
+    if (secondaries == nullptr)
+    {
+        // Failed to allocate space for a secondary
+        return Interaction::from_failure();
+    }
+
+    // XXX sample
+    (void)sizeof(rng);
+
+    // Construct interaction for change to primary (incident) particle
+    Interaction result;
+    result.action      = Action::scattered;                     // XXX
+    result.energy      = units::MevEnergy{inc_energy_.value()}; // XXX
+    result.direction   = inc_direction_;
+    result.secondaries = {secondaries, 1}; // XXX
+
+    // Save outgoing secondary data
+    secondaries[0].def_id    = shared_.electron_id; // XXX
+    secondaries[0].energy    = units::MevEnergy{0}; // XXX
+    secondaries[0].direction = {0, 0, 0};           // XXX
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/LivermoreInteractorPointers.hh
+++ b/src/physics/em/LivermoreInteractorPointers.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file LivermoreInteractorPointers.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Device data for creating an interactor.
+ */
+struct LivermoreInteractorPointers
+{
+    //! ID of an electron
+    ParticleDefId electron_id;
+    //! ID of a gamma
+    ParticleDefId gamma_id;
+    // XXX additional data
+
+    //! Check whether the data is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        return electron_id && gamma_id; // XXX
+    }
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/MollerBhabhaInteractor.hh
+++ b/src/physics/em/MollerBhabhaInteractor.hh
@@ -1,0 +1,73 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file MollerBhabhaInteractor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/base/Interaction.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/Units.hh"
+#include "MollerBhabhaInteractorPointers.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Brief class description.
+ *
+ * This is a model for XXXX process. Additional description
+ *
+ * \note This performs the same sampling routine as in Geant4's
+ * XXXX class, as documented in section XXX of the Geant4 Physics
+ * Reference (release 10.6).
+ */
+class MollerBhabhaInteractor
+{
+  public:
+    // Construct with shared and state data
+    inline CELER_FUNCTION
+    MollerBhabhaInteractor(const MollerBhabhaInteractorPointers& shared,
+                           const ParticleTrackView&              particle,
+                           const Real3&                          inc_direction,
+                           SecondaryAllocatorView&               allocate);
+
+    // Sample an interaction with the given RNG
+    template<class Engine>
+    inline CELER_FUNCTION Interaction operator()(Engine& rng);
+
+    // >>> COMMON PROPERTIES
+
+    //! Minimum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+    //! Maximum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+  private:
+    // Shared constant physics properties
+    const MollerBhabhaInteractorPointers& shared_;
+    // Incident gamma energy
+    const units::MevEnergy inc_energy_;
+    // Incident direction
+    const Real3& inc_direction_;
+    // Allocate space for one or more secondary particles
+    SecondaryAllocatorView& allocate_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "MollerBhabhaInteractor.i.hh"

--- a/src/physics/em/MollerBhabhaInteractor.i.hh
+++ b/src/physics/em/MollerBhabhaInteractor.i.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file MollerBhabhaInteractor.i.hh
+//---------------------------------------------------------------------------//
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared and state data.
+ */
+CELER_FUNCTION MollerBhabhaInteractor::MollerBhabhaInteractor(
+    const MollerBhabhaInteractorPointers& shared,
+    const ParticleTrackView&              particle,
+    const Real3&                          inc_direction,
+    SecondaryAllocatorView&               allocate)
+    : shared_(shared)
+    , inc_energy_(particle.energy().value())
+    , inc_direction_(inc_direction)
+    , allocate_(allocate)
+{
+    REQUIRE(inc_energy_ >= this->min_incident_energy()
+            && inc_energy_ <= this->max_incident_energy());
+    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample using the XXX model.
+ */
+template<class Engine>
+CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
+{
+    // Allocate space for XXX (electron, multiple particles, ...)
+    Secondary* secondaries = this->allocate_(0); // XXX
+    if (secondaries == nullptr)
+    {
+        // Failed to allocate space for a secondary
+        return Interaction::from_failure();
+    }
+
+    // XXX sample
+    (void)sizeof(rng);
+
+    // Construct interaction for change to primary (incident) particle
+    Interaction result;
+    result.action      = Action::scattered;                     // XXX
+    result.energy      = units::MevEnergy{inc_energy_.value()}; // XXX
+    result.direction   = inc_direction_;
+    result.secondaries = {secondaries, 1}; // XXX
+
+    // Save outgoing secondary data
+    secondaries[0].def_id    = shared_.electron_id; // XXX
+    secondaries[0].energy    = units::MevEnergy{0}; // XXX
+    secondaries[0].direction = {0, 0, 0};           // XXX
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/MollerBhabhaInteractorPointers.hh
+++ b/src/physics/em/MollerBhabhaInteractorPointers.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file MollerBhabhaInteractorPointers.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Device data for creating an interactor.
+ */
+struct MollerBhabhaInteractorPointers
+{
+    //! ID of an electron
+    ParticleDefId electron_id;
+    //! ID of a gamma
+    ParticleDefId gamma_id;
+    // XXX additional data
+
+    //! Check whether the data is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        return electron_id && gamma_id; // XXX
+    }
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/RayleighInteractor.hh
+++ b/src/physics/em/RayleighInteractor.hh
@@ -1,0 +1,73 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file RayleighInteractor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/base/Interaction.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/Units.hh"
+#include "RayleighInteractorPointers.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Brief class description.
+ *
+ * This is a model for XXXX process. Additional description
+ *
+ * \note This performs the same sampling routine as in Geant4's
+ * XXXX class, as documented in section XXX of the Geant4 Physics
+ * Reference (release 10.6).
+ */
+class RayleighInteractor
+{
+  public:
+    // Construct with shared and state data
+    inline CELER_FUNCTION
+    RayleighInteractor(const RayleighInteractorPointers& shared,
+                       const ParticleTrackView&          particle,
+                       const Real3&                      inc_direction,
+                       SecondaryAllocatorView&           allocate);
+
+    // Sample an interaction with the given RNG
+    template<class Engine>
+    inline CELER_FUNCTION Interaction operator()(Engine& rng);
+
+    // >>> COMMON PROPERTIES
+
+    //! Minimum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+    //! Maximum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+  private:
+    // Shared constant physics properties
+    const RayleighInteractorPointers& shared_;
+    // Incident gamma energy
+    const units::MevEnergy inc_energy_;
+    // Incident direction
+    const Real3& inc_direction_;
+    // Allocate space for one or more secondary particles
+    SecondaryAllocatorView& allocate_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "RayleighInteractor.i.hh"

--- a/src/physics/em/RayleighInteractor.i.hh
+++ b/src/physics/em/RayleighInteractor.i.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file RayleighInteractor.i.hh
+//---------------------------------------------------------------------------//
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared and state data.
+ */
+CELER_FUNCTION
+RayleighInteractor::RayleighInteractor(const RayleighInteractorPointers& shared,
+                                       const ParticleTrackView& particle,
+                                       const Real3&             inc_direction,
+                                       SecondaryAllocatorView&  allocate)
+    : shared_(shared)
+    , inc_energy_(particle.energy().value())
+    , inc_direction_(inc_direction)
+    , allocate_(allocate)
+{
+    REQUIRE(inc_energy_ >= this->min_incident_energy()
+            && inc_energy_ <= this->max_incident_energy());
+    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample using the XXX model.
+ */
+template<class Engine>
+CELER_FUNCTION Interaction RayleighInteractor::operator()(Engine& rng)
+{
+    // Allocate space for XXX (electron, multiple particles, ...)
+    Secondary* secondaries = this->allocate_(0); // XXX
+    if (secondaries == nullptr)
+    {
+        // Failed to allocate space for a secondary
+        return Interaction::from_failure();
+    }
+
+    // XXX sample
+    (void)sizeof(rng);
+
+    // Construct interaction for change to primary (incident) particle
+    Interaction result;
+    result.action      = Action::scattered;                     // XXX
+    result.energy      = units::MevEnergy{inc_energy_.value()}; // XXX
+    result.direction   = inc_direction_;
+    result.secondaries = {secondaries, 1}; // XXX
+
+    // Save outgoing secondary data
+    secondaries[0].def_id    = shared_.electron_id; // XXX
+    secondaries[0].energy    = units::MevEnergy{0}; // XXX
+    secondaries[0].direction = {0, 0, 0};           // XXX
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/RayleighInteractorPointers.hh
+++ b/src/physics/em/RayleighInteractorPointers.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file RayleighInteractorPointers.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Device data for creating an interactor.
+ */
+struct RayleighInteractorPointers
+{
+    //! ID of an electron
+    ParticleDefId electron_id;
+    //! ID of a gamma
+    ParticleDefId gamma_id;
+    // XXX additional data
+
+    //! Check whether the data is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        return electron_id && gamma_id; // XXX
+    }
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/UrbanInteractor.hh
+++ b/src/physics/em/UrbanInteractor.hh
@@ -1,0 +1,72 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file UrbanInteractor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/base/Interaction.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/Units.hh"
+#include "UrbanInteractorPointers.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Brief class description.
+ *
+ * This is a model for XXXX process. Additional description
+ *
+ * \note This performs the same sampling routine as in Geant4's
+ * XXXX class, as documented in section XXX of the Geant4 Physics
+ * Reference (release 10.6).
+ */
+class UrbanInteractor
+{
+  public:
+    // Construct with shared and state data
+    inline CELER_FUNCTION UrbanInteractor(const UrbanInteractorPointers& shared,
+                                          const ParticleTrackView& particle,
+                                          const Real3& inc_direction,
+                                          SecondaryAllocatorView& allocate);
+
+    // Sample an interaction with the given RNG
+    template<class Engine>
+    inline CELER_FUNCTION Interaction operator()(Engine& rng);
+
+    // >>> COMMON PROPERTIES
+
+    //! Minimum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+    //! Maximum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+  private:
+    // Shared constant physics properties
+    const UrbanInteractorPointers& shared_;
+    // Incident gamma energy
+    const units::MevEnergy inc_energy_;
+    // Incident direction
+    const Real3& inc_direction_;
+    // Allocate space for one or more secondary particles
+    SecondaryAllocatorView& allocate_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "UrbanInteractor.i.hh"

--- a/src/physics/em/UrbanInteractor.i.hh
+++ b/src/physics/em/UrbanInteractor.i.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file UrbanInteractor.i.hh
+//---------------------------------------------------------------------------//
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared and state data.
+ */
+CELER_FUNCTION
+UrbanInteractor::UrbanInteractor(const UrbanInteractorPointers& shared,
+                                 const ParticleTrackView&       particle,
+                                 const Real3&                   inc_direction,
+                                 SecondaryAllocatorView&        allocate)
+    : shared_(shared)
+    , inc_energy_(particle.energy().value())
+    , inc_direction_(inc_direction)
+    , allocate_(allocate)
+{
+    REQUIRE(inc_energy_ >= this->min_incident_energy()
+            && inc_energy_ <= this->max_incident_energy());
+    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample using the XXX model.
+ */
+template<class Engine>
+CELER_FUNCTION Interaction UrbanInteractor::operator()(Engine& rng)
+{
+    // Allocate space for XXX (electron, multiple particles, ...)
+    Secondary* secondaries = this->allocate_(0); // XXX
+    if (secondaries == nullptr)
+    {
+        // Failed to allocate space for a secondary
+        return Interaction::from_failure();
+    }
+
+    // XXX sample
+    (void)sizeof(rng);
+
+    // Construct interaction for change to primary (incident) particle
+    Interaction result;
+    result.action      = Action::scattered;                     // XXX
+    result.energy      = units::MevEnergy{inc_energy_.value()}; // XXX
+    result.direction   = inc_direction_;
+    result.secondaries = {secondaries, 1}; // XXX
+
+    // Save outgoing secondary data
+    secondaries[0].def_id    = shared_.electron_id; // XXX
+    secondaries[0].energy    = units::MevEnergy{0}; // XXX
+    secondaries[0].direction = {0, 0, 0};           // XXX
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/UrbanInteractorPointers.hh
+++ b/src/physics/em/UrbanInteractorPointers.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file UrbanInteractorPointers.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Device data for creating an interactor.
+ */
+struct UrbanInteractorPointers
+{
+    //! ID of an electron
+    ParticleDefId electron_id;
+    //! ID of a gamma
+    ParticleDefId gamma_id;
+    // XXX additional data
+
+    //! Check whether the data is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        return electron_id && gamma_id; // XXX
+    }
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/WentzelInteractor.hh
+++ b/src/physics/em/WentzelInteractor.hh
@@ -1,0 +1,73 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file WentzelInteractor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/base/Interaction.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "physics/base/Secondary.hh"
+#include "physics/base/Units.hh"
+#include "WentzelInteractorPointers.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Brief class description.
+ *
+ * This is a model for XXXX process. Additional description
+ *
+ * \note This performs the same sampling routine as in Geant4's
+ * XXXX class, as documented in section XXX of the Geant4 Physics
+ * Reference (release 10.6).
+ */
+class WentzelInteractor
+{
+  public:
+    // Construct with shared and state data
+    inline CELER_FUNCTION
+    WentzelInteractor(const WentzelInteractorPointers& shared,
+                      const ParticleTrackView&         particle,
+                      const Real3&                     inc_direction,
+                      SecondaryAllocatorView&          allocate);
+
+    // Sample an interaction with the given RNG
+    template<class Engine>
+    inline CELER_FUNCTION Interaction operator()(Engine& rng);
+
+    // >>> COMMON PROPERTIES
+
+    //! Minimum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+    //! Maximum incident energy for this model to be valid
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
+    {
+        return units::MevEnergy{0}; // XXX
+    }
+
+  private:
+    // Shared constant physics properties
+    const WentzelInteractorPointers& shared_;
+    // Incident gamma energy
+    const units::MevEnergy inc_energy_;
+    // Incident direction
+    const Real3& inc_direction_;
+    // Allocate space for one or more secondary particles
+    SecondaryAllocatorView& allocate_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "WentzelInteractor.i.hh"

--- a/src/physics/em/WentzelInteractor.i.hh
+++ b/src/physics/em/WentzelInteractor.i.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file WentzelInteractor.i.hh
+//---------------------------------------------------------------------------//
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared and state data.
+ */
+CELER_FUNCTION
+WentzelInteractor::WentzelInteractor(const WentzelInteractorPointers& shared,
+                                     const ParticleTrackView&         particle,
+                                     const Real3&            inc_direction,
+                                     SecondaryAllocatorView& allocate)
+    : shared_(shared)
+    , inc_energy_(particle.energy().value())
+    , inc_direction_(inc_direction)
+    , allocate_(allocate)
+{
+    REQUIRE(inc_energy_ >= this->min_incident_energy()
+            && inc_energy_ <= this->max_incident_energy());
+    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample using the XXX model.
+ */
+template<class Engine>
+CELER_FUNCTION Interaction WentzelInteractor::operator()(Engine& rng)
+{
+    // Allocate space for XXX (electron, multiple particles, ...)
+    Secondary* secondaries = this->allocate_(0); // XXX
+    if (secondaries == nullptr)
+    {
+        // Failed to allocate space for a secondary
+        return Interaction::from_failure();
+    }
+
+    // XXX sample
+    (void)sizeof(rng);
+
+    // Construct interaction for change to primary (incident) particle
+    Interaction result;
+    result.action      = Action::scattered;                     // XXX
+    result.energy      = units::MevEnergy{inc_energy_.value()}; // XXX
+    result.direction   = inc_direction_;
+    result.secondaries = {secondaries, 1}; // XXX
+
+    // Save outgoing secondary data
+    secondaries[0].def_id    = shared_.electron_id; // XXX
+    secondaries[0].energy    = units::MevEnergy{0}; // XXX
+    secondaries[0].direction = {0, 0, 0};           // XXX
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/WentzelInteractorPointers.hh
+++ b/src/physics/em/WentzelInteractorPointers.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file WentzelInteractorPointers.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Device data for creating an interactor.
+ */
+struct WentzelInteractorPointers
+{
+    //! ID of an electron
+    ParticleDefId electron_id;
+    //! ID of a gamma
+    ParticleDefId gamma_id;
+    // XXX additional data
+
+    //! Check whether the data is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        return electron_id && gamma_id; // XXX
+    }
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,15 +170,17 @@ add_cudaoptional_test(physics/base/Particle)
 
 celeritas_setup_tests(SERIAL PREFIX physics/em)
 
-celeritas_add_test(physics/em/BetheBlochInteractor.test.cc)
-celeritas_add_test(physics/em/BremRelInteractor.test.cc)
-celeritas_add_test(physics/em/EPlusGGInteractor.test.cc)
+set(_not_impl DISABLE)
+# NOTE: Remove '${_not_impl}' below at the start of developing each class.
+celeritas_add_test(physics/em/BetheBlochInteractor.test.cc ${_not_impl})
+celeritas_add_test(physics/em/BremRelInteractor.test.cc ${_not_impl})
+celeritas_add_test(physics/em/EPlusGGInteractor.test.cc ${_not_impl})
 celeritas_add_test(physics/em/KleinNishinaInteractor.test.cc)
-celeritas_add_test(physics/em/LivermoreInteractor.test.cc)
-celeritas_add_test(physics/em/MollerBhabhaInteractor.test.cc)
-celeritas_add_test(physics/em/RayleighInteractor.test.cc)
-celeritas_add_test(physics/em/UrbanInteractor.test.cc)
-celeritas_add_test(physics/em/WentzelInteractor.test.cc)
+celeritas_add_test(physics/em/LivermoreInteractor.test.cc ${_not_impl})
+celeritas_add_test(physics/em/MollerBhabhaInteractor.test.cc ${_not_impl})
+celeritas_add_test(physics/em/RayleighInteractor.test.cc ${_not_impl})
+celeritas_add_test(physics/em/UrbanInteractor.test.cc ${_not_impl})
+celeritas_add_test(physics/em/WentzelInteractor.test.cc ${_not_impl})
 
 # END PHYSICS TESTS
 set(CELERITASTEST_LINK_LIBRARIES)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,7 +170,15 @@ add_cudaoptional_test(physics/base/Particle)
 
 celeritas_setup_tests(SERIAL PREFIX physics/em)
 
+celeritas_add_test(physics/em/BetheBlochInteractor.test.cc)
+celeritas_add_test(physics/em/BremRelInteractor.test.cc)
+celeritas_add_test(physics/em/EPlusGGInteractor.test.cc)
 celeritas_add_test(physics/em/KleinNishinaInteractor.test.cc)
+celeritas_add_test(physics/em/LivermoreInteractor.test.cc)
+celeritas_add_test(physics/em/MollerBhabhaInteractor.test.cc)
+celeritas_add_test(physics/em/RayleighInteractor.test.cc)
+celeritas_add_test(physics/em/UrbanInteractor.test.cc)
+celeritas_add_test(physics/em/WentzelInteractor.test.cc)
 
 # END PHYSICS TESTS
 set(CELERITASTEST_LINK_LIBRARIES)

--- a/test/physics/em/BetheBlochInteractor.test.cc
+++ b/test/physics/em/BetheBlochInteractor.test.cc
@@ -1,0 +1,75 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BetheBlochInteractor.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/em/BetheBlochInteractor.hh"
+
+#include "gtest/Main.hh"
+#include "base/ArrayUtils.hh"
+#include "base/Range.hh"
+#include "physics/base/Units.hh"
+#include "../InteractorHostTestBase.hh"
+#include "../InteractionIO.hh"
+
+using celeritas::BetheBlochInteractor;
+namespace pdg = celeritas::pdg;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class BetheBlochInteractorTest : public celeritas_test::InteractorHostTestBase
+{
+    using Base = celeritas_test::InteractorHostTestBase;
+
+  protected:
+    void SetUp() override
+    {
+        using celeritas::ParticleDef;
+        using namespace celeritas::units;
+        celeritas::ZeroQuantity zero;
+        auto                    stable = ParticleDef::stable_decay_constant();
+
+        // XXX Update these based on particles needed by interactor
+        Base::set_particle_params(
+            {{{"electron", pdg::electron()},
+              {MevMass{0.5109989461}, ElementaryCharge{-1}, stable}},
+             {{"gamma", pdg::gamma()}, {zero, zero, stable}}});
+        const auto& params    = this->particle_params();
+        pointers_.electron_id = params.find(pdg::electron());
+        pointers_.gamma_id    = params.find(pdg::gamma());
+
+        // Set default particle to incident XXX MeV photon
+        this->set_inc_particle(pdg::gamma(), MevEnergy{10});
+        this->set_inc_direction({0, 0, 1});
+    }
+
+    void sanity_check(const Interaction& interaction) const
+    {
+        ASSERT_TRUE(interaction);
+
+        // Check change to parent track
+        EXPECT_GT(this->particle_track().energy().value(),
+                  interaction.energy.value());
+        EXPECT_LT(0, interaction.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(interaction.direction));
+        EXPECT_EQ(celeritas::Action::scattered, interaction.action);
+
+        // XXX Check secondaries
+
+        // Check conservation between primary and secondaries
+        this->check_conservation(interaction);
+    }
+
+  protected:
+    celeritas::BetheBlochInteractorPointers pointers_;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(BetheBlochInteractorTest, basic) {}

--- a/test/physics/em/BremRelInteractor.test.cc
+++ b/test/physics/em/BremRelInteractor.test.cc
@@ -1,0 +1,75 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BremRelInteractor.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/em/BremRelInteractor.hh"
+
+#include "gtest/Main.hh"
+#include "base/ArrayUtils.hh"
+#include "base/Range.hh"
+#include "physics/base/Units.hh"
+#include "../InteractorHostTestBase.hh"
+#include "../InteractionIO.hh"
+
+using celeritas::BremRelInteractor;
+namespace pdg = celeritas::pdg;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class BremRelInteractorTest : public celeritas_test::InteractorHostTestBase
+{
+    using Base = celeritas_test::InteractorHostTestBase;
+
+  protected:
+    void SetUp() override
+    {
+        using celeritas::ParticleDef;
+        using namespace celeritas::units;
+        celeritas::ZeroQuantity zero;
+        auto                    stable = ParticleDef::stable_decay_constant();
+
+        // XXX Update these based on particles needed by interactor
+        Base::set_particle_params(
+            {{{"electron", pdg::electron()},
+              {MevMass{0.5109989461}, ElementaryCharge{-1}, stable}},
+             {{"gamma", pdg::gamma()}, {zero, zero, stable}}});
+        const auto& params    = this->particle_params();
+        pointers_.electron_id = params.find(pdg::electron());
+        pointers_.gamma_id    = params.find(pdg::gamma());
+
+        // Set default particle to incident XXX MeV photon
+        this->set_inc_particle(pdg::gamma(), MevEnergy{10});
+        this->set_inc_direction({0, 0, 1});
+    }
+
+    void sanity_check(const Interaction& interaction) const
+    {
+        ASSERT_TRUE(interaction);
+
+        // Check change to parent track
+        EXPECT_GT(this->particle_track().energy().value(),
+                  interaction.energy.value());
+        EXPECT_LT(0, interaction.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(interaction.direction));
+        EXPECT_EQ(celeritas::Action::scattered, interaction.action);
+
+        // XXX Check secondaries
+
+        // Check conservation between primary and secondaries
+        this->check_conservation(interaction);
+    }
+
+  protected:
+    celeritas::BremRelInteractorPointers pointers_;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(BremRelInteractorTest, basic) {}

--- a/test/physics/em/EPlusGGInteractor.test.cc
+++ b/test/physics/em/EPlusGGInteractor.test.cc
@@ -1,0 +1,75 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file EPlusGGInteractor.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/em/EPlusGGInteractor.hh"
+
+#include "gtest/Main.hh"
+#include "base/ArrayUtils.hh"
+#include "base/Range.hh"
+#include "physics/base/Units.hh"
+#include "../InteractorHostTestBase.hh"
+#include "../InteractionIO.hh"
+
+using celeritas::EPlusGGInteractor;
+namespace pdg = celeritas::pdg;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class EPlusGGInteractorTest : public celeritas_test::InteractorHostTestBase
+{
+    using Base = celeritas_test::InteractorHostTestBase;
+
+  protected:
+    void SetUp() override
+    {
+        using celeritas::ParticleDef;
+        using namespace celeritas::units;
+        celeritas::ZeroQuantity zero;
+        auto                    stable = ParticleDef::stable_decay_constant();
+
+        // XXX Update these based on particles needed by interactor
+        Base::set_particle_params(
+            {{{"electron", pdg::electron()},
+              {MevMass{0.5109989461}, ElementaryCharge{-1}, stable}},
+             {{"gamma", pdg::gamma()}, {zero, zero, stable}}});
+        const auto& params    = this->particle_params();
+        pointers_.electron_id = params.find(pdg::electron());
+        pointers_.gamma_id    = params.find(pdg::gamma());
+
+        // Set default particle to incident XXX MeV photon
+        this->set_inc_particle(pdg::gamma(), MevEnergy{10});
+        this->set_inc_direction({0, 0, 1});
+    }
+
+    void sanity_check(const Interaction& interaction) const
+    {
+        ASSERT_TRUE(interaction);
+
+        // Check change to parent track
+        EXPECT_GT(this->particle_track().energy().value(),
+                  interaction.energy.value());
+        EXPECT_LT(0, interaction.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(interaction.direction));
+        EXPECT_EQ(celeritas::Action::scattered, interaction.action);
+
+        // XXX Check secondaries
+
+        // Check conservation between primary and secondaries
+        this->check_conservation(interaction);
+    }
+
+  protected:
+    celeritas::EPlusGGInteractorPointers pointers_;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(EPlusGGInteractorTest, basic) {}

--- a/test/physics/em/LivermoreInteractor.test.cc
+++ b/test/physics/em/LivermoreInteractor.test.cc
@@ -1,0 +1,75 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file LivermoreInteractor.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/em/LivermoreInteractor.hh"
+
+#include "gtest/Main.hh"
+#include "base/ArrayUtils.hh"
+#include "base/Range.hh"
+#include "physics/base/Units.hh"
+#include "../InteractorHostTestBase.hh"
+#include "../InteractionIO.hh"
+
+using celeritas::LivermoreInteractor;
+namespace pdg = celeritas::pdg;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class LivermoreInteractorTest : public celeritas_test::InteractorHostTestBase
+{
+    using Base = celeritas_test::InteractorHostTestBase;
+
+  protected:
+    void SetUp() override
+    {
+        using celeritas::ParticleDef;
+        using namespace celeritas::units;
+        celeritas::ZeroQuantity zero;
+        auto                    stable = ParticleDef::stable_decay_constant();
+
+        // XXX Update these based on particles needed by interactor
+        Base::set_particle_params(
+            {{{"electron", pdg::electron()},
+              {MevMass{0.5109989461}, ElementaryCharge{-1}, stable}},
+             {{"gamma", pdg::gamma()}, {zero, zero, stable}}});
+        const auto& params    = this->particle_params();
+        pointers_.electron_id = params.find(pdg::electron());
+        pointers_.gamma_id    = params.find(pdg::gamma());
+
+        // Set default particle to incident XXX MeV photon
+        this->set_inc_particle(pdg::gamma(), MevEnergy{10});
+        this->set_inc_direction({0, 0, 1});
+    }
+
+    void sanity_check(const Interaction& interaction) const
+    {
+        ASSERT_TRUE(interaction);
+
+        // Check change to parent track
+        EXPECT_GT(this->particle_track().energy().value(),
+                  interaction.energy.value());
+        EXPECT_LT(0, interaction.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(interaction.direction));
+        EXPECT_EQ(celeritas::Action::scattered, interaction.action);
+
+        // XXX Check secondaries
+
+        // Check conservation between primary and secondaries
+        this->check_conservation(interaction);
+    }
+
+  protected:
+    celeritas::LivermoreInteractorPointers pointers_;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(LivermoreInteractorTest, basic) {}

--- a/test/physics/em/MollerBhabhaInteractor.test.cc
+++ b/test/physics/em/MollerBhabhaInteractor.test.cc
@@ -1,0 +1,75 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file MollerBhabhaInteractor.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/em/MollerBhabhaInteractor.hh"
+
+#include "gtest/Main.hh"
+#include "base/ArrayUtils.hh"
+#include "base/Range.hh"
+#include "physics/base/Units.hh"
+#include "../InteractorHostTestBase.hh"
+#include "../InteractionIO.hh"
+
+using celeritas::MollerBhabhaInteractor;
+namespace pdg = celeritas::pdg;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class MollerBhabhaInteractorTest : public celeritas_test::InteractorHostTestBase
+{
+    using Base = celeritas_test::InteractorHostTestBase;
+
+  protected:
+    void SetUp() override
+    {
+        using celeritas::ParticleDef;
+        using namespace celeritas::units;
+        celeritas::ZeroQuantity zero;
+        auto                    stable = ParticleDef::stable_decay_constant();
+
+        // XXX Update these based on particles needed by interactor
+        Base::set_particle_params(
+            {{{"electron", pdg::electron()},
+              {MevMass{0.5109989461}, ElementaryCharge{-1}, stable}},
+             {{"gamma", pdg::gamma()}, {zero, zero, stable}}});
+        const auto& params    = this->particle_params();
+        pointers_.electron_id = params.find(pdg::electron());
+        pointers_.gamma_id    = params.find(pdg::gamma());
+
+        // Set default particle to incident XXX MeV photon
+        this->set_inc_particle(pdg::gamma(), MevEnergy{10});
+        this->set_inc_direction({0, 0, 1});
+    }
+
+    void sanity_check(const Interaction& interaction) const
+    {
+        ASSERT_TRUE(interaction);
+
+        // Check change to parent track
+        EXPECT_GT(this->particle_track().energy().value(),
+                  interaction.energy.value());
+        EXPECT_LT(0, interaction.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(interaction.direction));
+        EXPECT_EQ(celeritas::Action::scattered, interaction.action);
+
+        // XXX Check secondaries
+
+        // Check conservation between primary and secondaries
+        this->check_conservation(interaction);
+    }
+
+  protected:
+    celeritas::MollerBhabhaInteractorPointers pointers_;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(MollerBhabhaInteractorTest, basic) {}

--- a/test/physics/em/RayleighInteractor.test.cc
+++ b/test/physics/em/RayleighInteractor.test.cc
@@ -1,0 +1,75 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file RayleighInteractor.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/em/RayleighInteractor.hh"
+
+#include "gtest/Main.hh"
+#include "base/ArrayUtils.hh"
+#include "base/Range.hh"
+#include "physics/base/Units.hh"
+#include "../InteractorHostTestBase.hh"
+#include "../InteractionIO.hh"
+
+using celeritas::RayleighInteractor;
+namespace pdg = celeritas::pdg;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class RayleighInteractorTest : public celeritas_test::InteractorHostTestBase
+{
+    using Base = celeritas_test::InteractorHostTestBase;
+
+  protected:
+    void SetUp() override
+    {
+        using celeritas::ParticleDef;
+        using namespace celeritas::units;
+        celeritas::ZeroQuantity zero;
+        auto                    stable = ParticleDef::stable_decay_constant();
+
+        // XXX Update these based on particles needed by interactor
+        Base::set_particle_params(
+            {{{"electron", pdg::electron()},
+              {MevMass{0.5109989461}, ElementaryCharge{-1}, stable}},
+             {{"gamma", pdg::gamma()}, {zero, zero, stable}}});
+        const auto& params    = this->particle_params();
+        pointers_.electron_id = params.find(pdg::electron());
+        pointers_.gamma_id    = params.find(pdg::gamma());
+
+        // Set default particle to incident XXX MeV photon
+        this->set_inc_particle(pdg::gamma(), MevEnergy{10});
+        this->set_inc_direction({0, 0, 1});
+    }
+
+    void sanity_check(const Interaction& interaction) const
+    {
+        ASSERT_TRUE(interaction);
+
+        // Check change to parent track
+        EXPECT_GT(this->particle_track().energy().value(),
+                  interaction.energy.value());
+        EXPECT_LT(0, interaction.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(interaction.direction));
+        EXPECT_EQ(celeritas::Action::scattered, interaction.action);
+
+        // XXX Check secondaries
+
+        // Check conservation between primary and secondaries
+        this->check_conservation(interaction);
+    }
+
+  protected:
+    celeritas::RayleighInteractorPointers pointers_;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(RayleighInteractorTest, basic) {}

--- a/test/physics/em/UrbanInteractor.test.cc
+++ b/test/physics/em/UrbanInteractor.test.cc
@@ -1,0 +1,75 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file UrbanInteractor.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/em/UrbanInteractor.hh"
+
+#include "gtest/Main.hh"
+#include "base/ArrayUtils.hh"
+#include "base/Range.hh"
+#include "physics/base/Units.hh"
+#include "../InteractorHostTestBase.hh"
+#include "../InteractionIO.hh"
+
+using celeritas::UrbanInteractor;
+namespace pdg = celeritas::pdg;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class UrbanInteractorTest : public celeritas_test::InteractorHostTestBase
+{
+    using Base = celeritas_test::InteractorHostTestBase;
+
+  protected:
+    void SetUp() override
+    {
+        using celeritas::ParticleDef;
+        using namespace celeritas::units;
+        celeritas::ZeroQuantity zero;
+        auto                    stable = ParticleDef::stable_decay_constant();
+
+        // XXX Update these based on particles needed by interactor
+        Base::set_particle_params(
+            {{{"electron", pdg::electron()},
+              {MevMass{0.5109989461}, ElementaryCharge{-1}, stable}},
+             {{"gamma", pdg::gamma()}, {zero, zero, stable}}});
+        const auto& params    = this->particle_params();
+        pointers_.electron_id = params.find(pdg::electron());
+        pointers_.gamma_id    = params.find(pdg::gamma());
+
+        // Set default particle to incident XXX MeV photon
+        this->set_inc_particle(pdg::gamma(), MevEnergy{10});
+        this->set_inc_direction({0, 0, 1});
+    }
+
+    void sanity_check(const Interaction& interaction) const
+    {
+        ASSERT_TRUE(interaction);
+
+        // Check change to parent track
+        EXPECT_GT(this->particle_track().energy().value(),
+                  interaction.energy.value());
+        EXPECT_LT(0, interaction.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(interaction.direction));
+        EXPECT_EQ(celeritas::Action::scattered, interaction.action);
+
+        // XXX Check secondaries
+
+        // Check conservation between primary and secondaries
+        this->check_conservation(interaction);
+    }
+
+  protected:
+    celeritas::UrbanInteractorPointers pointers_;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(UrbanInteractorTest, basic) {}

--- a/test/physics/em/WentzelInteractor.test.cc
+++ b/test/physics/em/WentzelInteractor.test.cc
@@ -1,0 +1,75 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file WentzelInteractor.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/em/WentzelInteractor.hh"
+
+#include "gtest/Main.hh"
+#include "base/ArrayUtils.hh"
+#include "base/Range.hh"
+#include "physics/base/Units.hh"
+#include "../InteractorHostTestBase.hh"
+#include "../InteractionIO.hh"
+
+using celeritas::WentzelInteractor;
+namespace pdg = celeritas::pdg;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class WentzelInteractorTest : public celeritas_test::InteractorHostTestBase
+{
+    using Base = celeritas_test::InteractorHostTestBase;
+
+  protected:
+    void SetUp() override
+    {
+        using celeritas::ParticleDef;
+        using namespace celeritas::units;
+        celeritas::ZeroQuantity zero;
+        auto                    stable = ParticleDef::stable_decay_constant();
+
+        // XXX Update these based on particles needed by interactor
+        Base::set_particle_params(
+            {{{"electron", pdg::electron()},
+              {MevMass{0.5109989461}, ElementaryCharge{-1}, stable}},
+             {{"gamma", pdg::gamma()}, {zero, zero, stable}}});
+        const auto& params    = this->particle_params();
+        pointers_.electron_id = params.find(pdg::electron());
+        pointers_.gamma_id    = params.find(pdg::gamma());
+
+        // Set default particle to incident XXX MeV photon
+        this->set_inc_particle(pdg::gamma(), MevEnergy{10});
+        this->set_inc_direction({0, 0, 1});
+    }
+
+    void sanity_check(const Interaction& interaction) const
+    {
+        ASSERT_TRUE(interaction);
+
+        // Check change to parent track
+        EXPECT_GT(this->particle_track().energy().value(),
+                  interaction.energy.value());
+        EXPECT_LT(0, interaction.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(interaction.direction));
+        EXPECT_EQ(celeritas::Action::scattered, interaction.action);
+
+        // XXX Check secondaries
+
+        // Check conservation between primary and secondaries
+        this->check_conservation(interaction);
+    }
+
+  protected:
+    celeritas::WentzelInteractorPointers pointers_;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(WentzelInteractorTest, basic) {}


### PR DESCRIPTION
These are the classes we started working on during the hackathon last week. As per today's discussion, we will merge the skeleton classes in (compiling but disabling the associated tests for now) so that development on them can continue in parallel.