### PR TITLE
Fix designation of ElementSelector test as a host test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -167,7 +167,7 @@ celeritas_setup_tests(SERIAL PREFIX physics/base)
 add_cudaoptional_test(physics/base/Particle)
 
 celeritas_setup_tests(SERIAL PREFIX physics/material)
-add_cudaoptional_test(physics/material/ElementSelector)
+celeritas_add_test(physics/material/ElementSelector.test.cc)
 add_cudaoptional_test(physics/material/Material)
 
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
`ElementSelector` was set in CMake as a Cuda test instead of a host-side test.