### PR TITLE
Update LinearPropagator stepping

### DIFF
--- a/src/geometry/GeoTrackView.i.hh
+++ b/src/geometry/GeoTrackView.i.hh
@@ -100,8 +100,7 @@ CELER_FUNCTION void GeoTrackView::move_next_volume()
 //! Get the volume ID in the current cell.
 CELER_FUNCTION VolumeId GeoTrackView::volume_id() const
 {
-    REQUIRE(!this->is_outside());
-    return VolumeId{this->volume().id()};
+    return (this->is_outside() ? VolumeId{} : VolumeId{ this->volume().id() } );
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/LinearPropagator.hh
+++ b/src/geometry/LinearPropagator.hh
@@ -25,10 +25,11 @@ class LinearPropagator
     inline CELER_FUNCTION LinearPropagator(GeoTrackView& track);
 
     // Move track by next_step(), which takes it to next volume boundary.
-    inline CELER_FUNCTION void operator()();
+    inline CELER_FUNCTION real_type operator()();
 
-    // Move track by a user-provided distance.
-    inline CELER_FUNCTION void operator()(real_type dist);
+    // Move track by a user-provided distance, or to the next boundary if distance is large enough.
+    // @return distance travelled along straight line
+    inline CELER_FUNCTION real_type operator()(real_type dist);
 
   private:
     // Fast move, update only the position.

--- a/src/geometry/LinearPropagator.hh
+++ b/src/geometry/LinearPropagator.hh
@@ -21,19 +21,26 @@ class LinearPropagator
     using Initializer_t = GeoStateInitializer;
 
   public:
+    //! Output results
+    struct OutputType
+    {
+        real_type distance; //!< Distance traveled to min (input limit, boundary)
+        VolumeId  volume;   //!< Post-propagation volume
+    };
+
     // Construct from persistent and state data
     inline CELER_FUNCTION LinearPropagator(GeoTrackView& track);
 
-    // Move track by next_step(), which takes it to next volume boundary.
-    inline CELER_FUNCTION real_type operator()();
+    // Move track by next_step(), which takes it just across the next volume boundary.
+    inline CELER_FUNCTION OutputType operator()();
 
     // Move track by a user-provided distance, or to the next boundary if distance is large enough.
     // @return distance travelled along straight line
-    inline CELER_FUNCTION real_type operator()(real_type dist);
+    inline CELER_FUNCTION OutputType operator()(real_type dist);
 
   private:
     // Fast move, update only the position.
-    inline CELER_FUNCTION void apply_linear_step(real_type step);
+    inline CELER_FUNCTION real_type apply_linear_step(real_type step);
 
   private:
     GeoTrackView& track_;

--- a/src/geometry/LinearPropagator.i.hh
+++ b/src/geometry/LinearPropagator.i.hh
@@ -28,12 +28,14 @@ CELER_FUNCTION LinearPropagator::LinearPropagator(GeoTrackView& track)
  * Move track by next_step(), which takes it to next volume boundary.
  */
 CELER_FUNCTION
-void LinearPropagator::operator()()
+real_type LinearPropagator::operator()()
 {
+    real_type moved = track_.next_step();
     this->apply_linear_step(track_.next_step() + track_.tolerance());
 
     // Update state
     track_.move_next_volume();
+    return moved;
 }
 
 //---------------------------------------------------------------------------//
@@ -46,16 +48,19 @@ void LinearPropagator::operator()()
  * \pre Assumes that next_step() has been properly called by client
  */
 CELER_FUNCTION
-void LinearPropagator::operator()(real_type dist)
+real_type LinearPropagator::operator()(real_type dist)
 {
     REQUIRE(dist > 0.);
-    REQUIRE(dist <= track_.next_step());
-    this->apply_linear_step(dist);
+    real_type moved = std::min(dist, track_.next_step());
+
+    this->apply_linear_step( moved );
 
     if (std::fabs(track_.next_step()) < track_.tolerance())
     {
         track_.move_next_volume();
     }
+
+    return moved;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -82,21 +82,26 @@ TEST_F(LinearPropagatorHostTest, track_line)
         geo = {{-6, 0, 0}, {1, 0, 0}};
         EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
 
+        real_type travelled = 0;
         geo.find_next_step();
         EXPECT_SOFT_EQ(1.0, geo.next_step());
-        propagate();
+
+        travelled = propagate(1.e10); // very large proposed step
+        EXPECT_SOFT_EQ(1.0, travelled);
         EXPECT_SOFT_EQ(-5.0, geo.pos()[0]);
         EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Detector
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(10.0, geo.next_step());
-        propagate();
+        travelled = propagate(1.0e+10);
+        EXPECT_SOFT_EQ(10.0, travelled);
         EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
         EXPECT_EQ(false, geo.is_outside());
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(45.0, geo.next_step());
-        propagate();
+        travelled = propagate();
+        EXPECT_SOFT_EQ(45.0, travelled);
         EXPECT_EQ(true, geo.is_outside());
     }
 
@@ -111,9 +116,11 @@ TEST_F(LinearPropagatorHostTest, track_line)
         geo = {{50 - 1e-6, 0, 0}, {-1, 0, 0}};
         EXPECT_EQ(false, geo.is_outside());
         EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
+
         geo.find_next_step();
         EXPECT_SOFT_EQ(45.0 - 1e-6, geo.next_step());
-        propagate();
+        auto travelled = propagate();
+        EXPECT_SOFT_EQ(45.0 - 1.e-6, travelled);
         EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Detector
     }
     {
@@ -123,14 +130,16 @@ TEST_F(LinearPropagatorHostTest, track_line)
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(5.0, geo.next_step());
-        propagate();
+        auto travelled = propagate();
         EXPECT_SOFT_EQ(5.0, geo.pos()[0]);
+        EXPECT_SOFT_EQ(5.0, travelled);
         EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
         EXPECT_EQ(false, geo.is_outside());
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(45.0, geo.next_step());
-        propagate();
+        travelled = propagate();
+        EXPECT_SOFT_EQ(45.0, travelled);
         EXPECT_EQ(true, geo.is_outside());
     }
 }
@@ -151,11 +160,13 @@ TEST_F(LinearPropagatorHostTest, track_intraVolume)
         EXPECT_SOFT_EQ(1.0, geo.next_step());
 
         // break next step into two
-        propagate(0.5 * geo.next_step());
+        auto travelled = propagate(0.5 * geo.next_step());
+        EXPECT_SOFT_EQ(0.5, travelled);
         EXPECT_SOFT_EQ(-5.5, geo.pos()[0]);
         EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
 
-        propagate(geo.next_step()); // all remaining
+        travelled = propagate(geo.next_step()); // all remaining
+        EXPECT_SOFT_EQ(0.5, travelled);
         EXPECT_SOFT_EQ(-5.0, geo.pos()[0]);
         EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Detector
 
@@ -164,21 +175,24 @@ TEST_F(LinearPropagatorHostTest, track_intraVolume)
         geo.find_next_step();
         EXPECT_SOFT_EQ(10.0, geo.next_step());
 
-        propagate(0.3 * geo.next_step()); // step 1 inside Detector
+        travelled = propagate(0.3 * geo.next_step()); // step 1 inside Detector
+        EXPECT_SOFT_EQ(3.0, travelled);
         EXPECT_SOFT_EQ(-2.0, geo.pos()[0]);
         EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Detector
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(7.0, geo.next_step());
 
-        propagate(0.5 * geo.next_step()); // step 2 inside Detector
+        travelled = propagate(0.5 * geo.next_step()); // step 2 inside Detector
+        EXPECT_SOFT_EQ(3.5, travelled);
         EXPECT_SOFT_EQ(1.5, geo.pos()[0]);
         EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Detector
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(3.5, geo.next_step());
 
-        propagate(geo.next_step()); // last step inside Detector
+        travelled = propagate(geo.next_step()); // last step inside Detector
+        EXPECT_SOFT_EQ(3.5, travelled);
         EXPECT_SOFT_EQ(5.0, geo.pos()[0]);
         EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
     }

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -82,26 +82,25 @@ TEST_F(LinearPropagatorHostTest, track_line)
         geo = {{-6, 0, 0}, {1, 0, 0}};
         EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
 
-        real_type travelled = 0;
         geo.find_next_step();
         EXPECT_SOFT_EQ(1.0, geo.next_step());
 
-        travelled = propagate(1.e10); // very large proposed step
-        EXPECT_SOFT_EQ(1.0, travelled);
+        auto step = propagate(1.e10); // very large proposed step
+        EXPECT_SOFT_NEAR(1.0, step.distance, 1.0e-11);
         EXPECT_SOFT_EQ(-5.0, geo.pos()[0]);
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Detector
+        EXPECT_EQ(VolumeId{0}, step.volume); // Detector
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(10.0, geo.next_step());
-        travelled = propagate(1.0e+10);
-        EXPECT_SOFT_EQ(10.0, travelled);
-        EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
+        step = propagate(1.0e+10);
+        EXPECT_SOFT_EQ(10.0, step.distance);
+        EXPECT_EQ(VolumeId{1}, step.volume); // World
         EXPECT_EQ(false, geo.is_outside());
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(45.0, geo.next_step());
-        travelled = propagate();
-        EXPECT_SOFT_EQ(45.0, travelled);
+        step = propagate();
+        EXPECT_SOFT_EQ(45.0, step.distance);
         EXPECT_EQ(true, geo.is_outside());
     }
 
@@ -119,9 +118,9 @@ TEST_F(LinearPropagatorHostTest, track_line)
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(45.0 - 1e-6, geo.next_step());
-        auto travelled = propagate();
-        EXPECT_SOFT_EQ(45.0 - 1.e-6, travelled);
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Detector
+        auto step = propagate();
+        EXPECT_SOFT_EQ(45.0 - 1.e-6, step.distance);
+        EXPECT_EQ(VolumeId{0}, step.volume); // Detector
     }
     {
         // Track from inside detector
@@ -130,16 +129,16 @@ TEST_F(LinearPropagatorHostTest, track_line)
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(5.0, geo.next_step());
-        auto travelled = propagate();
+        auto step = propagate();
         EXPECT_SOFT_EQ(5.0, geo.pos()[0]);
-        EXPECT_SOFT_EQ(5.0, travelled);
-        EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
+        EXPECT_SOFT_EQ(5.0, step.distance);
+        EXPECT_EQ(VolumeId{1}, step.volume); // World
         EXPECT_EQ(false, geo.is_outside());
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(45.0, geo.next_step());
-        travelled = propagate();
-        EXPECT_SOFT_EQ(45.0, travelled);
+        step = propagate();
+        EXPECT_SOFT_EQ(45.0, step.distance);
         EXPECT_EQ(true, geo.is_outside());
     }
 }
@@ -160,41 +159,41 @@ TEST_F(LinearPropagatorHostTest, track_intraVolume)
         EXPECT_SOFT_EQ(1.0, geo.next_step());
 
         // break next step into two
-        auto travelled = propagate(0.5 * geo.next_step());
-        EXPECT_SOFT_EQ(0.5, travelled);
+        auto step = propagate(0.5 * geo.next_step());
+        EXPECT_SOFT_EQ(0.5, step.distance);
         EXPECT_SOFT_EQ(-5.5, geo.pos()[0]);
-        EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
+        EXPECT_EQ(VolumeId{1}, step.volume); // World
 
-        travelled = propagate(geo.next_step()); // all remaining
-        EXPECT_SOFT_EQ(0.5, travelled);
+        step = propagate(geo.next_step()); // all remaining
+        EXPECT_SOFT_EQ(0.5, step.distance);
         EXPECT_SOFT_EQ(-5.0, geo.pos()[0]);
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Detector
+        EXPECT_EQ(VolumeId{0}, step.volume); // Detector
 
         // break next step into more than two, re-calculating next_step each
         // time
         geo.find_next_step();
         EXPECT_SOFT_EQ(10.0, geo.next_step());
 
-        travelled = propagate(0.3 * geo.next_step()); // step 1 inside Detector
-        EXPECT_SOFT_EQ(3.0, travelled);
+        step = propagate(0.3 * geo.next_step()); // step 1 inside Detector
+        EXPECT_SOFT_EQ(3.0, step.distance);
         EXPECT_SOFT_EQ(-2.0, geo.pos()[0]);
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Detector
+        EXPECT_EQ(VolumeId{0}, step.volume); // Detector
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(7.0, geo.next_step());
 
-        travelled = propagate(0.5 * geo.next_step()); // step 2 inside Detector
-        EXPECT_SOFT_EQ(3.5, travelled);
+        step = propagate(0.5 * geo.next_step()); // step 2 inside Detector
+        EXPECT_SOFT_EQ(3.5, step.distance);
         EXPECT_SOFT_EQ(1.5, geo.pos()[0]);
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Detector
+        EXPECT_EQ(VolumeId{0}, step.volume); // Detector
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(3.5, geo.next_step());
 
-        travelled = propagate(geo.next_step()); // last step inside Detector
-        EXPECT_SOFT_EQ(3.5, travelled);
+        step = propagate(geo.next_step()); // last step inside Detector
+        EXPECT_SOFT_EQ(3.5, step.distance);
         EXPECT_SOFT_EQ(5.0, geo.pos()[0]);
-        EXPECT_EQ(VolumeId{1}, geo.volume_id()); // World
+        EXPECT_EQ(VolumeId{1}, step.volume); // World
     }
 }
 

--- a/test/geometry/LinearPropagator.test.cu
+++ b/test/geometry/LinearPropagator.test.cu
@@ -58,7 +58,7 @@ __global__ void linProp_test_kernel(const GeoParamsPointers shared,
         distances[tid.get() * max_segments + seg] = geo.next_step();
 
         // Move next step
-	auto temp = propagate();
+        auto temp = propagate();
     }
 }
 

--- a/test/geometry/LinearPropagator.test.cu
+++ b/test/geometry/LinearPropagator.test.cu
@@ -58,7 +58,7 @@ __global__ void linProp_test_kernel(const GeoParamsPointers shared,
         distances[tid.get() * max_segments + seg] = geo.next_step();
 
         // Move next step
-        propagate();
+	auto temp = propagate();
     }
 }
 


### PR DESCRIPTION
Modify operator(dist) to take any distance (step length) as input.
If step is larger than distance to next boundary, track is moved to next boundary and navigated into next volume.
The functions return the distance travelled.
All enabled tests currently passing in my local builds (both CUDA=ON and OFF).
