### PR TITLE
Implement EPlusGGInteractor

### DIFF
--- a/src/physics/base/Interaction.hh
+++ b/src/physics/base/Interaction.hh
@@ -32,6 +32,9 @@ struct Interaction
     // Return an interaction representing a recoverable error
     static inline CELER_FUNCTION Interaction from_failure();
 
+    // Return an interaction representing an absorbed process
+    static inline CELER_FUNCTION Interaction from_absorption();
+
     // Whether the interaction succeeded
     explicit inline CELER_FUNCTION operator bool() const;
 };
@@ -46,6 +49,18 @@ CELER_FUNCTION Interaction Interaction::from_failure()
 {
     Interaction result;
     result.action = Action::failed;
+    return result;
+}
+
+/*!
+ * An interaction with an absorbed process.
+ */
+CELER_FUNCTION Interaction Interaction::from_absorption()
+{
+    Interaction result;
+    result.action    = Action::absorbed;
+    result.energy    = units::MevEnergy{0};
+    result.direction = {0, 0, 0};
     return result;
 }
 

--- a/src/physics/em/EPlusGGInteractor.hh
+++ b/src/physics/em/EPlusGGInteractor.hh
@@ -22,11 +22,14 @@ namespace celeritas
 /*!
  * Brief class description.
  *
- * This is a model for XXXX process. Additional description
+ * This is a model for the discrete positron-electron Annihilation process 
+ * which simulates the in-flight annihilation of a positron with an atomic 
+ * electron and produces into two photons. It is assumed that the atomic 
+ * electron is initially free and at rest.  
  *
  * \note This performs the same sampling routine as in Geant4's
- * XXXX class, as documented in section XXX of the Geant4 Physics
- * Reference (release 10.6).
+ * G4eeToTwoGammaModel class, as documented in section 10.3 of the Geant4 
+ * Physics Reference (release 10.6).
  */
 class EPlusGGInteractor
 {
@@ -47,23 +50,23 @@ class EPlusGGInteractor
     //! Minimum incident energy for this model to be valid
     static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
     {
-        return units::MevEnergy{0}; // XXX
+        return units::MevEnergy{0}; // at rest
     }
 
     //! Maximum incident energy for this model to be valid
     static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
     {
-        return units::MevEnergy{0}; // XXX
+        return units::MevEnergy{100000000}; // 100 TeV
     }
 
   private:
     // Shared constant physics properties
     const EPlusGGInteractorPointers& shared_;
-    // Incident gamma energy
+    // Incident positron energy
     const units::MevEnergy inc_energy_;
     // Incident direction
     const Real3& inc_direction_;
-    // Allocate space for one or more secondary particles
+    // Allocate space for secondary particles (two photons)
     SecondaryAllocatorView& allocate_;
 };
 

--- a/src/physics/em/EPlusGGInteractor.i.hh
+++ b/src/physics/em/EPlusGGInteractor.i.hh
@@ -6,6 +6,13 @@
 //! \file EPlusGGInteractor.i.hh
 //---------------------------------------------------------------------------//
 
+#include "base/ArrayUtils.hh"
+#include "random/distributions/BernoulliDistribution.hh"
+#include "random/distributions/GenerateCanonical.hh"
+#include "random/distributions/IsotropicDistribution.hh"
+
+#include <iostream>
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -24,38 +31,96 @@ EPlusGGInteractor::EPlusGGInteractor(const EPlusGGInteractorPointers& shared,
 {
     REQUIRE(inc_energy_ >= this->min_incident_energy()
             && inc_energy_ <= this->max_incident_energy());
-    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+    REQUIRE(particle.def_id() == shared_.positron_id);
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Sample using the XXX model.
+ * Sample two gammas using the G4eeToTwoGammaModel model.
  */
 template<class Engine>
 CELER_FUNCTION Interaction EPlusGGInteractor::operator()(Engine& rng)
 {
-    // Allocate space for XXX (electron, multiple particles, ...)
-    Secondary* secondaries = this->allocate_(0); // XXX
+    // Allocate space for two gammas
+    Secondary* secondaries = this->allocate_(2);
     if (secondaries == nullptr)
     {
-        // Failed to allocate space for a secondary
+        // Failed to allocate space for two secondaries
         return Interaction::from_failure();
     }
 
-    // XXX sample
-    (void)sizeof(rng);
-
-    // Construct interaction for change to primary (incident) particle
+    // Construct interaction for change to the incident positron
     Interaction result;
-    result.action      = Action::scattered;                     // XXX
-    result.energy      = units::MevEnergy{inc_energy_.value()}; // XXX
-    result.direction   = inc_direction_;
-    result.secondaries = {secondaries, 1}; // XXX
+    result.action      = Action::absorbed;
+    result.energy      = units::MevEnergy{0}; 
+    result.direction   = {0, 0, 0};
+    result.secondaries = {secondaries, 2};
 
-    // Save outgoing secondary data
-    secondaries[0].def_id    = shared_.electron_id; // XXX
-    secondaries[0].energy    = units::MevEnergy{0}; // XXX
-    secondaries[0].direction = {0, 0, 0};           // XXX
+    // Sample two gammas
+    secondaries[0].def_id = secondaries[1].def_id = shared_.gamma_id;
+
+    const real_type inc_energy = inc_energy_.value();
+    IsotropicDistribution<real_type> gamma_dir;
+
+    if(inc_energy == 0) 
+    {
+        // Save outgoing secondary data
+        secondaries[0].energy = secondaries[1].energy 
+            = units::MevEnergy{shared_.electron_mass};
+
+        secondaries[0].direction = gamma_dir(rng); 
+        for(int i = 0 ; i < 3 ; ++i) {
+            secondaries[1].direction[i] = -secondaries[0].direction[i]; 
+        }
+
+	// Note: polarization is intentionally not implemented
+    }
+    else 
+    {
+        real_type tau     = inc_energy/shared_.electron_mass;
+        real_type gam     = tau + 1.0;
+        real_type tau2    = tau + 2.0;
+        real_type sqgrate = std::sqrt(tau/tau2)*0.5;
+        real_type sqg2m1  = std::sqrt(tau*tau2);
+
+        // Evaluate limits of the energy sampling
+        real_type epsilmin = 0.5 - sqgrate;
+        real_type epsilmax = 0.5 + sqgrate;
+        real_type epsilqot = epsilmax/epsilmin;
+
+        // Sample the energy rate of the created gammas
+        real_type epsil, acceptance_prob;
+        do 
+        {
+	    epsil = epsilmin
+                * std::exp(std::log(epsilqot)*generate_canonical(rng));
+            acceptance_prob = 1. - epsil + (2.*gam*epsil-1.)/(epsil*tau2*tau2);
+        } while (BernoulliDistribution(acceptance_prob)(rng));
+
+        // Scattered Gamma angles
+        real_type cost = (epsil*tau2-1.0)/(epsil*sqg2m1);
+        CHECK(fabs(cost) <= 1.0);
+
+	// Kinematic of the gamma pair
+	real_type total_energy = inc_energy + 2.0*shared_.electron_mass;
+        real_type gamma_energy = epsil*total_energy;
+	real_type eplus_moment = std::sqrt(inc_energy*(total_energy));
+
+        // Sample and save outgoing secondary data
+	UniformRealDistribution<real_type> sample_phi(0, 2 * constants::pi);
+
+        secondaries[0].energy = units::MevEnergy{gamma_energy};
+        secondaries[0].direction 
+             = rotate(from_spherical(cost, sample_phi(rng)), inc_direction_); 
+
+        secondaries[1].energy = units::MevEnergy{total_energy-gamma_energy};
+        for(int i = 0 ; i < 3 ; ++i) 
+        {
+            secondaries[1].direction[i] = eplus_moment*inc_direction_[i] 
+                - inc_energy*inc_direction_[i]; 
+	}
+	normalize_direction(&secondaries[1].direction);
+    }
 
     return result;
 }

--- a/src/physics/em/EPlusGGInteractorPointers.hh
+++ b/src/physics/em/EPlusGGInteractorPointers.hh
@@ -14,20 +14,21 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Device data for creating an interactor.
+ * Device data for creating an EPlusGGInteractor.
  */
 struct EPlusGGInteractorPointers
 {
-    //! ID of an electron
-    ParticleDefId electron_id;
+    //! electron mass [MevMass]
+    real_type electron_mass;
+    //! ID of an positron
+    ParticleDefId positron_id;
     //! ID of a gamma
     ParticleDefId gamma_id;
-    // XXX additional data
 
     //! Check whether the data is assigned
     explicit inline CELER_FUNCTION operator bool() const
     {
-        return electron_id && gamma_id; // XXX
+        return electron_mass > 0 && positron_id && gamma_id;
     }
 };
 

--- a/test/physics/em/EPlusGGInteractor.test.cc
+++ b/test/physics/em/EPlusGGInteractor.test.cc
@@ -33,17 +33,20 @@ class EPlusGGInteractorTest : public celeritas_test::InteractorHostTestBase
         celeritas::ZeroQuantity zero;
         auto                    stable = ParticleDef::stable_decay_constant();
 
-        // XXX Update these based on particles needed by interactor
         Base::set_particle_params(
             {{{"electron", pdg::electron()},
               {MevMass{0.5109989461}, ElementaryCharge{-1}, stable}},
+             {{"positron", pdg::positron()},
+              {MevMass{0.5109989461}, ElementaryCharge{1}, stable}},
              {{"gamma", pdg::gamma()}, {zero, zero, stable}}});
-        const auto& params    = this->particle_params();
-        pointers_.electron_id = params.find(pdg::electron());
-        pointers_.gamma_id    = params.find(pdg::gamma());
 
-        // Set default particle to incident XXX MeV photon
-        this->set_inc_particle(pdg::gamma(), MevEnergy{10});
+        const auto& params      = this->particle_params();
+        pointers_.positron_id   = params.find(pdg::positron());
+        pointers_.gamma_id      = params.find(pdg::gamma());
+        pointers_.electron_mass = 0.5109989461;
+
+        // Set default particle to incident 10 MeV positron
+        this->set_inc_particle(pdg::positron(), MevEnergy{10});
         this->set_inc_direction({0, 0, 1});
     }
 
@@ -52,16 +55,31 @@ class EPlusGGInteractorTest : public celeritas_test::InteractorHostTestBase
         ASSERT_TRUE(interaction);
 
         // Check change to parent track
-        EXPECT_GT(this->particle_track().energy().value(),
-                  interaction.energy.value());
-        EXPECT_LT(0, interaction.energy.value());
-        EXPECT_SOFT_EQ(1.0, celeritas::norm(interaction.direction));
-        EXPECT_EQ(celeritas::Action::scattered, interaction.action);
+        EXPECT_EQ(0, interaction.energy.value());
+        EXPECT_SOFT_EQ(0, celeritas::norm(interaction.direction));
+        EXPECT_EQ(celeritas::Action::absorbed, interaction.action);
 
-        // XXX Check secondaries
+        // Check secondaries (two photons)
+        ASSERT_EQ(2, interaction.secondaries.size());
 
-        // Check conservation between primary and secondaries
-        this->check_conservation(interaction);
+        const auto& gamma1 = interaction.secondaries.front();
+        EXPECT_TRUE(gamma1);
+        EXPECT_EQ(pointers_.gamma_id, gamma1.def_id);
+
+        EXPECT_GT(this->particle_track().energy().value()
+                      + 2 * pointers_.electron_mass,
+                  gamma1.energy.value());
+        EXPECT_LT(0, gamma1.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(gamma1.direction));
+
+        const auto& gamma2 = interaction.secondaries.back();
+        EXPECT_TRUE(gamma2);
+        EXPECT_EQ(pointers_.gamma_id, gamma2.def_id);
+        EXPECT_GT(this->particle_track().energy().value()
+                      + 2 * pointers_.electron_mass,
+                  gamma2.energy.value());
+        EXPECT_LT(0, gamma2.energy.value());
+        EXPECT_SOFT_EQ(1.0, celeritas::norm(gamma2.direction));
     }
 
   protected:
@@ -72,4 +90,103 @@ class EPlusGGInteractorTest : public celeritas_test::InteractorHostTestBase
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST_F(EPlusGGInteractorTest, basic) {}
+TEST_F(EPlusGGInteractorTest, basic)
+{
+    const int num_samples = 4;
+
+    // Reserve  num_samples*2 secondaries;
+    this->resize_secondaries(num_samples * 2);
+
+    // Create the interactor
+    EPlusGGInteractor interact(pointers_,
+                               this->particle_track(),
+                               this->direction(),
+                               this->secondary_allocator());
+    RandomEngine&     rng_engine = this->rng();
+
+    // Produce four samples from the original incident angle/energy
+    std::vector<double> angle;
+    std::vector<double> energy1;
+    std::vector<double> energy2;
+
+    for (int i : celeritas::range(num_samples))
+    {
+        Interaction result = interact(rng_engine);
+        SCOPED_TRACE(result);
+        this->sanity_check(result);
+
+        EXPECT_EQ(result.secondaries.data(),
+                  this->secondary_allocator().get().data()
+                      + result.secondaries.size() * i);
+
+        angle.push_back(
+            celeritas::dot_product(result.secondaries.front().direction,
+                                   result.secondaries.back().direction));
+        energy1.push_back(result.secondaries[0].energy.value());
+        energy2.push_back(result.secondaries[1].energy.value());
+    }
+
+    EXPECT_EQ(2 * num_samples, this->secondary_allocator().get().size());
+
+    // Note: these are "gold" values based on the host RNG.
+    const double expected_energy1[] = {
+        9.58465334147939, 10.4793460046007, 3.88444170212412, 2.82099830657521};
+
+    const double expected_energy2[] = {
+        1.43734455072061, 0.542651887599318, 7.13755619007588, 8.20099958562479};
+
+    const double expected_angle[] = {0.993884655017147,
+                                     0.998663395567878,
+                                     0.911748167069523,
+                                     0.859684696937321};
+
+    EXPECT_VEC_SOFT_EQ(expected_energy1, energy1);
+    EXPECT_VEC_SOFT_EQ(expected_energy2, energy2);
+    EXPECT_VEC_SOFT_EQ(expected_angle, angle);
+
+    // Next sample should fail because we're out of secondary buffer space
+    {
+        Interaction result = interact(rng_engine);
+        EXPECT_EQ(0, result.secondaries.size());
+        EXPECT_EQ(celeritas::Action::failed, result.action);
+    }
+}
+
+TEST_F(EPlusGGInteractorTest, stress_test)
+{
+    RandomEngine& rng_engine = this->rng();
+
+    const int num_samples = 8192;
+
+    for (double inc_e : {0.01, 1.0, 10.0, 1000.0})
+    {
+        SCOPED_TRACE("Incident energy: " + std::to_string(inc_e));
+        this->set_inc_particle(pdg::positron(), MevEnergy{inc_e});
+
+        // Loop over several incident directions (shouldn't affect anything
+        // substantial, but scattering near Z axis loses precision)
+        for (const Real3& inc_dir :
+             {Real3{0, 0, 1}, Real3{1, 0, 0}, Real3{1e-9, 0, 1}, Real3{1, 1, 1}})
+        {
+            SCOPED_TRACE("Incident direction: " + to_string(inc_dir));
+            this->set_inc_direction(inc_dir);
+            this->resize_secondaries(2 * num_samples);
+
+            // Create interactor
+            EPlusGGInteractor interact(pointers_,
+                                       this->particle_track(),
+                                       this->direction(),
+                                       this->secondary_allocator());
+
+            // Loop over many particles
+            for (int i = 0; i < num_samples; ++i)
+            {
+                Interaction result = interact(rng_engine);
+                SCOPED_TRACE(result);
+                this->sanity_check(result);
+            }
+            EXPECT_EQ(2 * num_samples,
+                      this->secondary_allocator().get().size());
+        }
+    }
+}


### PR DESCRIPTION
Introduce an initial version of EPlusGGInteractor:
- update EPlusGGInteractor based on G4eeToTwoGammaModel
- add a basic test and a stress test with 10MeV positrons