### PR TITLE
Add templated cube() to Algorithms.h

### DIFF
--- a/src/base/Algorithms.hh
+++ b/src/base/Algorithms.hh
@@ -32,4 +32,15 @@ CELER_CONSTEXPR_FUNCTION const T& max(const T& a, const T& b)
 }
 
 //---------------------------------------------------------------------------//
+
+/*!
+ * Return the cube of the input value.
+ */
+template<class T>
+CELER_CONSTEXPR_FUNCTION T cube(const T& a)
+{
+    return a * a * a;
+}
+
+//---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,7 @@ celeritas_add_test(gtest/detail/test/Macros.test.cc)
 
 celeritas_setup_tests(SERIAL PREFIX base)
 
+celeritas_add_test(base/Algorithms.test.cc)
 celeritas_add_test(base/Array.test.cc)
 celeritas_add_test(base/ArrayUtils.test.cc)
 celeritas_add_test(base/Constants.test.cc)

--- a/test/base/Algorithms.test.cc
+++ b/test/base/Algorithms.test.cc
@@ -1,0 +1,31 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Array.test.cc
+//---------------------------------------------------------------------------//
+#include "base/Algorithms.hh"
+
+#include "gtest/Main.hh"
+#include "gtest/Test.hh"
+
+// using celeritas;
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST(AlgorithmsTest, all)
+{
+    // Test min()
+    EXPECT_EQ(1, celeritas::min<int>(1, 2));
+    EXPECT_NE(0.2, celeritas::min<float>(0.1, 0.2));
+    // Test max()
+    EXPECT_EQ(2, celeritas::max<int>(1, 2));
+    EXPECT_NE(0.1, celeritas::max<float>(0.1, 0.2));
+    // Test cube()
+    EXPECT_EQ(8, celeritas::cube<int>(2));
+    EXPECT_EQ(0.001f, celeritas::cube<float>(0.1));
+    EXPECT_NE(125.000001, celeritas::cube<double>(5.0));
+}


### PR DESCRIPTION
`std::pow(a, 3)` takes some 245 operations. A templated function `cube(const T& a)` is added in this commit that instead uses `a * a * a` which takes only 9 operations.