### PR TITLE
Add unified testing header

### DIFF
--- a/scripts/dev/celeritas-gen.py
+++ b/scripts/dev/celeritas-gen.py
@@ -85,8 +85,7 @@ namespace {namespace}
 TEST_HARNESS_FILE = '''\
 #include "{dirfromtest}/{name}.{hext}"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 // #include "{name}.test.hh"
 
 using {namespace}::{name};

--- a/test/base/Array.test.cc
+++ b/test/base/Array.test.cc
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "base/Array.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::array;
 

--- a/test/base/ArrayUtils.test.cc
+++ b/test/base/ArrayUtils.test.cc
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "base/ArrayUtils.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "base/Constants.hh"
 #include "base/ArrayIO.hh"
 

--- a/test/base/Constants.test.cc
+++ b/test/base/Constants.test.cc
@@ -8,8 +8,7 @@
 #include "base/Constants.hh"
 #include "base/Units.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using namespace celeritas::units;
 using namespace celeritas::constants;

--- a/test/base/DeviceAllocation.test.cc
+++ b/test/base/DeviceAllocation.test.cc
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "base/DeviceAllocation.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "base/Span.hh"
 
 using celeritas::byte;

--- a/test/base/DeviceVector.test.cc
+++ b/test/base/DeviceVector.test.cc
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "base/DeviceVector.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::DeviceVector;
 

--- a/test/base/Interpolator.test.cc
+++ b/test/base/Interpolator.test.cc
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "base/Interpolator.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::Interp;
 using celeritas::Interpolator;

--- a/test/base/NumericLimits.test.cc
+++ b/test/base/NumericLimits.test.cc
@@ -9,8 +9,7 @@
 
 #include <cmath>
 #include <limits>
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "NumericLimits.test.hh"
 
 using namespace celeritas_test;

--- a/test/base/OpaqueId.test.cc
+++ b/test/base/OpaqueId.test.cc
@@ -9,8 +9,7 @@
 
 #include <cstdint>
 #include <utility>
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::OpaqueId;
 struct TestInstantiator;

--- a/test/base/Quantity.test.cc
+++ b/test/base/Quantity.test.cc
@@ -9,8 +9,7 @@
 
 #include <type_traits>
 #include "base/Constants.hh"
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::Quantity;
 using celeritas::zero_quantity;

--- a/test/base/Range.test.cc
+++ b/test/base/Range.test.cc
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "base/Range.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "Range.test.hh"
 
 using namespace celeritas_test;

--- a/test/base/SoftEqual.test.cc
+++ b/test/base/SoftEqual.test.cc
@@ -8,8 +8,7 @@
 #include "base/SoftEqual.hh"
 
 #include <limits>
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "base/ColorUtils.hh"
 
 using celeritas::SoftEqual;

--- a/test/base/Span.test.cc
+++ b/test/base/Span.test.cc
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "base/Span.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::span;
 

--- a/test/base/SpanRemapper.test.cc
+++ b/test/base/SpanRemapper.test.cc
@@ -8,8 +8,7 @@
 #include "base/SpanRemapper.hh"
 
 #include <type_traits>
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::make_span;
 using celeritas::make_span_remapper;

--- a/test/base/StackAllocator.test.cc
+++ b/test/base/StackAllocator.test.cc
@@ -9,8 +9,7 @@
 #include "base/StackAllocatorView.hh"
 
 #include <cstdint>
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "StackAllocator.test.hh"
 #include "HostStackAllocatorStore.hh"
 #include "base/StackAllocatorStore.t.hh"

--- a/test/base/Stopwatch.test.cc
+++ b/test/base/Stopwatch.test.cc
@@ -8,8 +8,7 @@
 #include "base/Stopwatch.hh"
 
 #include <thread>
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::Stopwatch;
 

--- a/test/base/UniformGrid.test.cc
+++ b/test/base/UniformGrid.test.cc
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "base/UniformGrid.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::UniformGrid;
 

--- a/test/celeritas_test.hh
+++ b/test/celeritas_test.hh
@@ -3,14 +3,19 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file Main.hh
+//! \file celeritas_test.hh
+//! Meta-include to facilitate testing.
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "detail/TestMain.hh"
+#include "gtest/Main.hh"
+#include "gtest/Test.hh"
+#include "gtest/detail/Macros.hh"
+#include "celeritas_config.h"
 
-//! Define main
-int main(int argc, char** argv)
-{
-    return celeritas::detail::test_main(argc, argv);
-}
+#include <iostream>
+#include <string>
+#include <vector>
+
+using std::cout;
+using std::endl;

--- a/test/comm/Communicator.test.cc
+++ b/test/comm/Communicator.test.cc
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "comm/Communicator.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::Communicator;
 

--- a/test/geometry/GeoParamsTest.hh
+++ b/test/geometry/GeoParamsTest.hh
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 #include "geometry/GeoParams.hh"
 

--- a/test/gtest/detail/test/Macros.test.cc
+++ b/test/gtest/detail/test/Macros.test.cc
@@ -8,8 +8,7 @@
 #include "../Macros.hh"
 
 #include <limits>
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using namespace celeritas::detail;
 

--- a/test/io/EventReader.test.cc
+++ b/test/io/EventReader.test.cc
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "io/EventReader.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "base/Span.hh"
 #include "physics/base/ParticleParams.hh"
 #include "physics/base/Units.hh"

--- a/test/io/RootImporter.test.cc
+++ b/test/io/RootImporter.test.cc
@@ -14,8 +14,7 @@
 #include "base/Types.hh"
 #include "base/Range.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::elem_id;
 using celeritas::GdmlGeometryMap;

--- a/test/physics/base/Particle.test.cc
+++ b/test/physics/base/Particle.test.cc
@@ -8,8 +8,7 @@
 #include "physics/base/ParticleTrackView.hh"
 
 #include "celeritas_config.h"
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "base/Array.hh"
 #include "physics/base/ParticleParams.hh"
 #include "physics/base/ParticleStateStore.hh"

--- a/test/physics/em/BetheBlochInteractor.test.cc
+++ b/test/physics/em/BetheBlochInteractor.test.cc
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/BetheBlochInteractor.hh"
 
-#include "gtest/Main.hh"
+#include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "physics/base/Units.hh"

--- a/test/physics/em/BremRelInteractor.test.cc
+++ b/test/physics/em/BremRelInteractor.test.cc
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/BremRelInteractor.hh"
 
-#include "gtest/Main.hh"
+#include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "physics/base/Units.hh"

--- a/test/physics/em/EPlusGGInteractor.test.cc
+++ b/test/physics/em/EPlusGGInteractor.test.cc
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/EPlusGGInteractor.hh"
 
-#include "gtest/Main.hh"
+#include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "physics/base/Units.hh"

--- a/test/physics/em/KleinNishinaInteractor.test.cc
+++ b/test/physics/em/KleinNishinaInteractor.test.cc
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/KleinNishinaInteractor.hh"
 
-#include "gtest/Main.hh"
+#include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "physics/base/Units.hh"

--- a/test/physics/em/LivermoreInteractor.test.cc
+++ b/test/physics/em/LivermoreInteractor.test.cc
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/LivermoreInteractor.hh"
 
-#include "gtest/Main.hh"
+#include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "physics/base/Units.hh"

--- a/test/physics/em/MollerBhabhaInteractor.test.cc
+++ b/test/physics/em/MollerBhabhaInteractor.test.cc
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/MollerBhabhaInteractor.hh"
 
-#include "gtest/Main.hh"
+#include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "physics/base/Units.hh"

--- a/test/physics/em/RayleighInteractor.test.cc
+++ b/test/physics/em/RayleighInteractor.test.cc
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/RayleighInteractor.hh"
 
-#include "gtest/Main.hh"
+#include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "physics/base/Units.hh"

--- a/test/physics/em/UrbanInteractor.test.cc
+++ b/test/physics/em/UrbanInteractor.test.cc
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/UrbanInteractor.hh"
 
-#include "gtest/Main.hh"
+#include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "physics/base/Units.hh"

--- a/test/physics/em/WentzelInteractor.test.cc
+++ b/test/physics/em/WentzelInteractor.test.cc
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/WentzelInteractor.hh"
 
-#include "gtest/Main.hh"
+#include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "physics/base/Units.hh"

--- a/test/physics/material/ElementSelector.test.cc
+++ b/test/physics/material/ElementSelector.test.cc
@@ -9,8 +9,7 @@
 
 #include <memory>
 #include <random>
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "base/Range.hh"
 #include "physics/material/MaterialParams.hh"
 

--- a/test/physics/material/Material.test.cc
+++ b/test/physics/material/Material.test.cc
@@ -13,8 +13,7 @@
 #include "physics/material/detail/Utils.hh"
 
 #include <limits>
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "base/DeviceVector.hh"
 #include "physics/base/Units.hh"
 #include "physics/material/ElementDef.hh"

--- a/test/random/cuda/RngEngine.test.cu
+++ b/test/random/cuda/RngEngine.test.cu
@@ -12,8 +12,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 #include "base/Range.hh"
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "base/KernelParamCalculator.cuda.hh"
 
 using celeritas::generate_canonical;

--- a/test/random/distributions/BernoulliDistribution.test.cc
+++ b/test/random/distributions/BernoulliDistribution.test.cc
@@ -8,8 +8,7 @@
 #include "random/distributions/BernoulliDistribution.hh"
 
 #include <random>
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 #include "base/Range.hh"
 
 using celeritas::BernoulliDistribution;

--- a/test/random/distributions/ExponentialDistribution.test.cc
+++ b/test/random/distributions/ExponentialDistribution.test.cc
@@ -9,8 +9,7 @@
 
 #include <random>
 #include "base/Range.hh"
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::ExponentialDistribution;
 

--- a/test/random/distributions/IsotropicDistribution.test.cc
+++ b/test/random/distributions/IsotropicDistribution.test.cc
@@ -9,8 +9,7 @@
 
 #include <random>
 #include "base/Range.hh"
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::IsotropicDistribution;
 

--- a/test/random/distributions/RadialDistribution.test.cc
+++ b/test/random/distributions/RadialDistribution.test.cc
@@ -9,8 +9,7 @@
 
 #include <random>
 #include "base/Range.hh"
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::RadialDistribution;
 

--- a/test/random/distributions/UniformRealDistribution.test.cc
+++ b/test/random/distributions/UniformRealDistribution.test.cc
@@ -9,8 +9,7 @@
 
 #include <random>
 #include "base/Range.hh"
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
+#include "celeritas_test.hh"
 
 using celeritas::UniformRealDistribution;
 


### PR DESCRIPTION
Define a `"celeritas_test.hh"` header to simplify unit test includes.