### PR TITLE
Add element scratch space and add to interactor test

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ list(APPEND SOURCES
   physics/base/ParticleStateStore.cc
   physics/base/SecondaryAllocatorStore.cc
   physics/material/MaterialParams.cc
+  physics/material/MaterialStateStore.cc
   physics/material/detail/Utils.cc
 )
 

--- a/src/physics/material/MaterialParams.cc
+++ b/src/physics/material/MaterialParams.cc
@@ -88,6 +88,8 @@ MaterialParamsPointers MaterialParams::host_pointers() const
     MaterialParamsPointers result;
     result.elements  = make_span(host_elements_);
     result.materials = make_span(host_materials_);
+    result.max_element_components = this->max_element_components();
+
     ENSURE(result);
     return result;
 }
@@ -102,6 +104,8 @@ MaterialParamsPointers MaterialParams::device_pointers() const
     MaterialParamsPointers result;
     result.elements  = device_elements_.device_pointers();
     result.materials = device_materials_.device_pointers();
+    result.max_element_components = this->max_element_components();
+
     ENSURE(result);
     return result;
 }

--- a/src/physics/material/MaterialParamsPointers.hh
+++ b/src/physics/material/MaterialParamsPointers.hh
@@ -28,6 +28,7 @@ struct MaterialParamsPointers
 {
     span<const ElementDef>  elements;
     span<const MaterialDef> materials;
+    size_type               max_element_components;
 
     //! Check whether the interface is assigned
     explicit inline CELER_FUNCTION operator bool() const

--- a/src/physics/material/MaterialStatePointers.hh
+++ b/src/physics/material/MaterialStatePointers.hh
@@ -30,12 +30,18 @@ struct MaterialTrackState
  * The size of the view will be the size of the vector of tracks. Each particle
  * track state corresponds to the thread ID (\c ThreadId).
  *
+ * The "element scratch space" is a 2D array of reals, indexed with
+ * [track_id][el_component_id], where the fast-moving dimension has the
+ * greatest number of element components of any material in the problem. This
+ * can be used for the physics to calculate microscopic cross sections.
+ *
  * \sa MaterialStateStore (owns the pointed-to data)
  * \sa MaterialTrackView (uses the pointed-to data in a kernel)
  */
 struct MaterialStatePointers
 {
     span<MaterialTrackState> state;
+    span<real_type> element_scratch; // 2D array: [num states][max components]
 
     //! Check whether the view is assigned
     explicit CELER_FUNCTION operator bool() const { return !state.empty(); }

--- a/src/physics/material/MaterialStateStore.cc
+++ b/src/physics/material/MaterialStateStore.cc
@@ -1,0 +1,42 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file MaterialStateStore.cc
+//---------------------------------------------------------------------------//
+#include "MaterialStateStore.hh"
+
+#include "MaterialParams.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from material params and number of track states.
+ */
+MaterialStateStore::MaterialStateStore(const MaterialParams& mats,
+                                       size_type             size)
+    : max_el_(mats.max_element_components())
+    , states_(size)
+    , element_scratch_(size * max_el_)
+{
+    REQUIRE(size > 0);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the interface to on-device states.
+ */
+MaterialStatePointers MaterialStateStore::device_pointers()
+{
+    MaterialStatePointers result;
+    result.state           = states_.device_pointers();
+    result.element_scratch = element_scratch_.device_pointers();
+
+    ENSURE(result);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/material/MaterialStateStore.hh
+++ b/src/physics/material/MaterialStateStore.hh
@@ -1,0 +1,44 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file MaterialStateStore.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/DeviceVector.hh"
+#include "base/Types.hh"
+#include "MaterialStatePointers.hh"
+
+namespace celeritas
+{
+class MaterialParams;
+//---------------------------------------------------------------------------//
+/*!
+ * Manage on-device VecGeom states.
+ *
+ * \note Construction on a build without a GPU (or CUDA) will raise an error.
+ */
+class MaterialStateStore
+{
+  public:
+    // Construct from material params and number of track states
+    MaterialStateStore(const MaterialParams& mats, size_type size);
+
+    /// ACCESSORS ///
+
+    // Number of states
+    size_type size() const { return states_.size(); }
+
+    // View on-device states
+    MaterialStatePointers device_pointers();
+
+  private:
+    size_type                        max_el_;
+    DeviceVector<MaterialTrackState> states_;
+    DeviceVector<real_type>          element_scratch_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/material/MaterialTrackView.hh
+++ b/src/physics/material/MaterialTrackView.hh
@@ -26,6 +26,10 @@ namespace celeritas
  * the results rather than calling the function repeatedly. If any of the
  * calculations prove to be hot spots we will experiment with cacheing some of
  * the variables.
+ *
+ * The element scratch space is "thread-private" data with a fixed size
+ * *greater than or equal to* the number of elemental components in the current
+ * material.
  */
 class MaterialTrackView
 {
@@ -46,15 +50,21 @@ class MaterialTrackView
     inline CELER_FUNCTION MaterialTrackView&
                           operator=(const Initializer_t& other);
 
-    //! Current material identifier
-    CELER_FUNCTION MaterialDefId def_id() const { return state_.def_id; }
+    // Current material identifier
+    inline CELER_FUNCTION MaterialDefId def_id() const;
 
     // Get a view to material properties
     inline CELER_FUNCTION MaterialView material_view() const;
 
+    // Access scratch space with at least one real per element component
+    inline CELER_FUNCTION span<real_type> element_scratch();
+
   private:
     const MaterialParamsPointers& params_;
-    MaterialTrackState&           state_;
+    const MaterialStatePointers&  states_;
+    ThreadId                      tid_;
+
+    inline CELER_FUNCTION MaterialTrackState& state() const;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/physics/InteractorHostTestBase.hh
+++ b/test/physics/InteractorHostTestBase.hh
@@ -20,6 +20,8 @@
 #include "physics/base/ParticleStatePointers.hh"
 #include "physics/base/Secondary.hh"
 #include "physics/base/Units.hh"
+#include "physics/material/MaterialParams.hh"
+#include "physics/material/MaterialStatePointers.hh"
 #include "base/HostStackAllocatorStore.hh"
 
 namespace celeritas
@@ -27,6 +29,7 @@ namespace celeritas
 template<class T>
 class StackAllocatorView;
 class ParticleTrackView;
+class MaterialTrackView;
 struct Interaction;
 struct Secondary;
 } // namespace celeritas
@@ -51,6 +54,9 @@ class InteractorHostTestBase : public celeritas::Test
     using PDGNumber              = celeritas::PDGNumber;
     using MevEnergy              = celeritas::units::MevEnergy;
 
+    using MaterialParams    = celeritas::MaterialParams;
+    using MaterialTrackView = celeritas::MaterialTrackView;
+
     using Interaction            = celeritas::Interaction;
     using ParticleParams         = celeritas::ParticleParams;
     using ParticleTrackView      = celeritas::ParticleTrackView;
@@ -70,9 +76,25 @@ class InteractorHostTestBase : public celeritas::Test
     //@}
 
     //@{
+    //! Set and get material properties
+    void                  set_material_params(MaterialParams::Input inp);
+    const MaterialParams& material_params() const;
+    //@}
+
+    //@{
     //! Set and get particle params
     void set_particle_params(const ParticleParams::VecAnnotatedDefs& defs);
     const ParticleParams& particle_params() const;
+    //@}
+
+    //@{
+    //! Material properties
+    void               set_material(const std::string& name);
+    MaterialTrackView& material_track()
+    {
+        REQUIRE(mt_view_);
+        return *mt_view_;
+    }
     //@}
 
     //@{
@@ -107,16 +129,23 @@ class InteractorHostTestBase : public celeritas::Test
     void check_conservation(const Interaction& interaction) const;
 
   private:
+    std::shared_ptr<MaterialParams> material_params_;
     std::shared_ptr<ParticleParams> particle_params_;
     RandomEngine                    rng_;
+
+    celeritas::MaterialTrackState     mat_state_;
+    std::vector<real_type>            mat_element_scratch_;
+    celeritas::MaterialParamsPointers mp_pointers_;
+    celeritas::MaterialStatePointers  ms_pointers_;
 
     celeritas::ParticleTrackState     particle_state_;
     celeritas::ParticleParamsPointers pp_pointers_;
     celeritas::ParticleStatePointers  ps_pointers_;
-    Real3                     inc_direction_ = {0, 0, 1};
+    Real3                             inc_direction_ = {0, 0, 1};
     HostSecondaryStore                secondaries_;
 
     // Views
+    std::shared_ptr<MaterialTrackView>      mt_view_;
     std::shared_ptr<ParticleTrackView>      pt_view_;
     std::shared_ptr<SecondaryAllocatorView> sa_view_;
 };

--- a/test/physics/material/Material.test.cc
+++ b/test/physics/material/Material.test.cc
@@ -10,6 +10,7 @@
 #include "physics/material/MaterialParams.hh"
 #include "physics/material/MaterialTrackView.hh"
 #include "physics/material/MaterialStatePointers.hh"
+#include "physics/material/MaterialStateStore.hh"
 #include "physics/material/detail/Utils.hh"
 
 #include <limits>
@@ -210,9 +211,15 @@ TEST_F(MaterialDeviceTest, all)
     MTestInput input;
     input.init = {{MaterialDefId{0}}, {MaterialDefId{1}}, {MaterialDefId{2}}};
 
-    DeviceVector<MaterialTrackState> states(input.init.size());
-    input.params       = params->device_pointers();
-    input.states.state = states.device_pointers();
+    MaterialStateStore states(*params, input.init.size());
+    input.params = params->device_pointers();
+    input.states = states.device_pointers();
+
+    EXPECT_EQ(params->max_element_components(),
+              input.params.max_element_components);
+    EXPECT_EQ(3, input.states.state.size());
+    EXPECT_EQ(3 * params->max_element_components(),
+              input.states.element_scratch.size());
 
     // Run GPU test
     auto result = m_test(input);


### PR DESCRIPTION
- Add material params and material track view to the interactor test (will be needed for models that sample cross sections and use other material properties)
- Add device scratch space for cross section storage (or anything else that scales with the number of elements in a material)