### PR TITLE
Add logger

### DIFF
--- a/app/demo-interactor/demo-interactor.cc
+++ b/app/demo-interactor/demo-interactor.cc
@@ -14,6 +14,7 @@
 #include <vector>
 #include <nlohmann/json.hpp>
 #include "comm/Communicator.hh"
+#include "comm/Logger.hh"
 #include "comm/ScopedMpiInit.hh"
 #include "comm/Utils.hh"
 #include "physics/base/ParticleParams.hh"
@@ -85,14 +86,9 @@ void run(std::istream& is)
 int main(int argc, char* argv[])
 {
     ScopedMpiInit scoped_mpi(&argc, &argv);
-    Communicator  comm = Communicator::comm_world();
-    if (comm.size() != 1)
+    if (Communicator::comm_world().size() != 1)
     {
-        if (comm.rank() == 0)
-        {
-            cerr << "This app is currently serial-only. Run with 1 proc."
-                 << endl;
-        }
+        CELER_LOG(critical) << "This app cannot run in parallel";
         return EXIT_FAILURE;
     }
 
@@ -109,7 +105,7 @@ int main(int argc, char* argv[])
         std::ifstream infile(args[1]);
         if (!infile)
         {
-            cerr << "fatal: failed to open '" << args[1] << "'" << endl;
+            CELER_LOG(critical) << "Failed to open '" << args[1] << "'";
             return EXIT_FAILURE;
         }
         run(infile);

--- a/app/demo-interactor/host-demo-interactor.cc
+++ b/app/demo-interactor/host-demo-interactor.cc
@@ -14,6 +14,7 @@
 #include <vector>
 #include <nlohmann/json.hpp>
 #include "comm/Communicator.hh"
+#include "comm/Logger.hh"
 #include "comm/ScopedMpiInit.hh"
 #include "comm/Utils.hh"
 #include "physics/base/ParticleParams.hh"
@@ -80,14 +81,9 @@ void run(std::istream& is)
 int main(int argc, char* argv[])
 {
     ScopedMpiInit scoped_mpi(&argc, &argv);
-    Communicator  comm = Communicator::comm_world();
-    if (comm.size() != 1)
+    if (Communicator::comm_world().size() != 1)
     {
-        if (comm.rank() == 0)
-        {
-            cerr << "This app is currently serial-only. Run with 1 proc."
-                 << endl;
-        }
+        CELER_LOG(critical) << "This app cannot run in parallel";
         return EXIT_FAILURE;
     }
 
@@ -104,7 +100,7 @@ int main(int argc, char* argv[])
         std::ifstream infile(args[1]);
         if (!infile)
         {
-            cerr << "fatal: failed to open '" << args[1] << "'" << endl;
+            CELER_LOG(critical) << "Failed to open '" << args[1] << "'";
             return EXIT_FAILURE;
         }
         run(infile);

--- a/app/demo-rasterizer/RDemoRunner.cc
+++ b/app/demo-rasterizer/RDemoRunner.cc
@@ -10,14 +10,13 @@
 #include "base/Range.hh"
 #include "base/Stopwatch.hh"
 #include "base/ColorUtils.hh"
+#include "comm/Logger.hh"
 #include "geometry/GeoParams.hh"
 #include "geometry/GeoStateStore.hh"
 #include "ImageTrackView.hh"
 #include "RDemoKernel.hh"
 
 using namespace celeritas;
-using std::cerr;
-using std::endl;
 
 namespace demo_rasterizer
 {
@@ -41,13 +40,13 @@ void RDemoRunner::operator()(ImageStore* image) const
 
     GeoStateStore geo_state(*geo_params_, image->dims()[0]);
 
-    cerr << "::: Tracing geometry..." << std::flush;
+    CELER_LOG(status) << "Tracing geometry";
     Stopwatch get_time;
     trace(geo_params_->device_pointers(),
           geo_state.device_pointers(),
           image->device_interface());
-    cerr << color_code('x') << " (" << get_time() << " s)" << color_code(' ')
-         << endl;
+    CELER_LOG(diagnostic) << color_code('x') << "... " << get_time() << " s"
+                          << color_code(' ');
 }
 
 //---------------------------------------------------------------------------//

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,10 @@ set(PUBLIC_DEPS)
 list(APPEND SOURCES
   base/Assert.cc
   base/ColorUtils.cc
+  comm/Logger.cc
+  comm/LoggerTypes.cc
   comm/Utils.cc
+  comm/detail/LoggerMessage.cc
   physics/base/ParticleParams.cc
   physics/base/ParticleStateStore.cc
   physics/base/SecondaryAllocatorStore.cc

--- a/src/base/Assert.hh
+++ b/src/base/Assert.hh
@@ -13,6 +13,9 @@
 #    include <stdexcept>
 #endif
 
+//---------------------------------------------------------------------------//
+// MACROS
+//---------------------------------------------------------------------------//
 /*!
  * \def REQUIRE
  *
@@ -103,6 +106,8 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+// FUNCTIONS
+//---------------------------------------------------------------------------//
 // Construct and throw a DebugError.
 [[noreturn]] void
 throw_debug_error(const char* condition, const char* file, int line);
@@ -114,6 +119,8 @@ throw_debug_error(const char* condition, const char* file, int line);
                                         int         line);
 
 #ifndef __CUDA_ARCH__
+//---------------------------------------------------------------------------//
+// TYPES
 //---------------------------------------------------------------------------//
 /*!
  * Error thrown by celeritas assertions.

--- a/src/base/ColorUtils.cc
+++ b/src/base/ColorUtils.cc
@@ -49,8 +49,9 @@ bool use_color()
 /*!
  * Get an ANSI color codes if colors are enabled.
  *
- *  - [y]ellow
+ *  - [b]lue
  *  - [g]reen
+ *  - [y]ellow
  *  - [r]ed
  *  - [x] gray
  *  - [R]ed bold
@@ -66,6 +67,8 @@ const char* color_code(char abbrev)
     {
         case 'g':
             return "\033[32m";
+        case 'b':
+            return "\033[34m";
         case 'r':
             return "\033[31m";
         case 'x':

--- a/src/comm/Communicator.hh
+++ b/src/comm/Communicator.hh
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "Types.hh"
+#include "MpiTypes.hh"
 
 namespace celeritas
 {
@@ -39,18 +39,17 @@ class Communicator
     //! Get the number of total processors
     int size() const { return size_; };
 
-    /// FUNCTIONS ///
-
-    // Wait for all processes in this communicator to reach the barrier
-    void barrier() const;
-
-    // TODO: Nemesis HDF5-like interface for send/recv/reduce/etc.
-
   private:
     MpiComm comm_;
     int     rank_;
     int     size_;
 };
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+// Wait for all processes in this communicator to reach the barrier
+void barrier(const Communicator& comm);
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/comm/Communicator.mpi.cc
+++ b/src/comm/Communicator.mpi.cc
@@ -49,12 +49,14 @@ Communicator::Communicator(MpiComm comm) : comm_(comm), rank_(-1), size_(-1)
 }
 
 //---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
 /*!
  * Wait for all processes in this communicator to reach the barrier.
  */
-void Communicator::barrier() const
+void barrier(const Communicator& comm)
 {
-    int err = MPI_Barrier(comm_);
+    int err = MPI_Barrier(comm.mpi_comm());
     CHECK(err == MPI_SUCCESS);
 }
 

--- a/src/comm/Communicator.nompi.cc
+++ b/src/comm/Communicator.nompi.cc
@@ -42,10 +42,12 @@ Communicator::Communicator(MpiComm comm) : comm_(comm), rank_(0), size_(1)
 }
 
 //---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
 /*!
  * Wait for all processes in this communicator to reach the barrier.
  */
-void Communicator::barrier() const {}
+void barrier(const Communicator&) {}
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/comm/Logger.cc
+++ b/src/comm/Logger.cc
@@ -1,0 +1,113 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Logger.cc
+//---------------------------------------------------------------------------//
+#include "Logger.hh"
+
+#include <iostream>
+#include <sstream>
+#include "base/ColorUtils.hh"
+#include "Communicator.hh"
+
+namespace
+{
+using namespace celeritas;
+//---------------------------------------------------------------------------//
+// HELPER CLASSES
+//---------------------------------------------------------------------------//
+//! Default global logger prints the error message with basic colors
+void default_global_handler(Provenance prov, LogLevel lev, std::string msg)
+{
+    if (lev == LogLevel::debug || lev >= LogLevel::warning)
+    {
+        // Output problem line/file for debugging or high level
+        std::cerr << color_code('x') << prov.file << ':' << prov.line
+                  << color_code(' ') << ": ";
+    }
+
+    // clang-format off
+    char c = ' ';
+    switch (lev)
+    {
+        case LogLevel::debug:      c = 'x'; break;
+        case LogLevel::diagnostic: c = 'x'; break;
+        case LogLevel::status:     c = 'b'; break;
+        case LogLevel::info:       c = 'g'; break;
+        case LogLevel::warning:    c = 'y'; break;
+        case LogLevel::error:      c = 'r'; break;
+        case LogLevel::critical:   c = 'R'; break;
+    };
+    // clang-format on
+    std::cerr << color_code(c) << to_cstring(lev) << ": " << color_code(' ')
+              << msg << std::endl;
+}
+
+//---------------------------------------------------------------------------//
+//! Log the local node number as well as the message
+class LocalHandler
+{
+  public:
+    explicit LocalHandler(const Communicator& comm) : rank_(comm.rank()) {}
+
+    void operator()(Provenance prov, LogLevel lev, std::string msg)
+    {
+        // To avoid multiple process output stepping on each other, write into
+        // a buffer and then print with a single call.
+        std::ostringstream os;
+        os << color_code('x') << prov.file << ':' << prov.line
+           << color_code(' ') << ": " << color_code('W') << "rank " << rank_
+           << ": " << color_code('x') << to_cstring(lev) << ": "
+           << color_code(' ') << msg << '\n';
+        std::cerr << os.str();
+    }
+
+  private:
+    int rank_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with communicator (only rank zero is active) and handler.
+ */
+Logger::Logger(const Communicator& comm, LogHandler handle)
+{
+    if (comm.rank() == 0)
+    {
+        // Accept handler, otherwise it is a "null" function pointer.
+        handle_ = std::move(handle);
+    }
+}
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Parallel-enabled logger: print only on "main" process.
+ */
+Logger& world_logger()
+{
+    static Logger logger(Communicator::comm_world(), &default_global_handler);
+    return logger;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Serial logger: print on *every* process that calls it.
+ */
+Logger& self_logger()
+{
+    static Logger logger(Communicator::comm_self(),
+                         LocalHandler{Communicator::comm_world()});
+    return logger;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/comm/Logger.hh
+++ b/src/comm/Logger.hh
@@ -1,0 +1,105 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Logger.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <functional>
+#include <string>
+#include "LoggerTypes.hh"
+#include "detail/LoggerMessage.hh"
+
+//---------------------------------------------------------------------------//
+// MACROS
+//---------------------------------------------------------------------------//
+/*!
+ * \def CELER_LOG
+ *
+ * Return a LogMessage object for streaming into at the given level. The
+ * regular \c CELER_LOG call is for code paths that happen uniformly in
+ * parallel.
+ *
+ * \code
+ CELER_LOG(debug) << "Don't print this in general";
+ CELER_LOG(warning) << "Oh shiiiiit";
+ * \endcode
+ */
+#define CELER_LOG(LEVEL)                              \
+    ::celeritas::world_logger()({__FILE__, __LINE__}, \
+                                ::celeritas::LogLevel::LEVEL)
+
+//---------------------------------------------------------------------------//
+/*!
+ * \def CELER_LOG_LOCAL
+ *
+ * Like \c CELER_LOG but for code paths that may only happen on a single
+ * process. Use sparingly.
+ */
+#define CELER_LOG_LOCAL(LEVEL)                       \
+    ::celeritas::self_logger()({__FILE__, __LINE__}, \
+                               ::celeritas::LogLevel::LEVEL)
+
+namespace celeritas
+{
+class Communicator;
+//---------------------------------------------------------------------------//
+/*!
+ * Manage logging in serial and parallel.
+ *
+ * This should generally be called by the \c world_logger and \c
+ * self_logger functions below. The call \c operator() returns an object that
+ * should be streamed into in order to create a log message.
+ *
+ * This object \em is assignable, so to replace the default log handler with a
+ * different one, you can call \code
+   world_logger = Logger(Communicator::comm_world(), my_handler);
+ * \endcode
+ */
+class Logger
+{
+  public:
+    // Construct with communicator (only rank zero is active) and handler
+    Logger(const Communicator& comm, LogHandler handle);
+
+    // Create a logger that flushes its contents when it destructs
+    inline detail::LoggerMessage operator()(Provenance prov, LogLevel lev);
+
+    //! Set the minimum logging verbosity
+    void level(LogLevel lev) { min_level_ = lev; }
+
+    //! Get the current logging verbosity
+    LogLevel level() const { return min_level_; }
+
+  private:
+    LogHandler handle_;
+    LogLevel   min_level_ = LogLevel::status;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE FUNCTION DEFINITIONS
+//---------------------------------------------------------------------------//
+//! Create a logger that flushes its contents when it destructs
+detail::LoggerMessage Logger::operator()(Provenance prov, LogLevel lev)
+{
+    LogHandler* handle = nullptr;
+    if (handle_ && lev >= min_level_)
+    {
+        handle = &handle_;
+    }
+    return {handle, std::move(prov), lev};
+}
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+// Parallel logger (print only on "main" process)
+Logger& world_logger();
+
+// Serial logger (print on *every* process)
+Logger& self_logger();
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/comm/LoggerTypes.cc
+++ b/src/comm/LoggerTypes.cc
@@ -1,0 +1,32 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file LoggerTypes.cc
+//---------------------------------------------------------------------------//
+#include "LoggerTypes.hh"
+
+#include "base/Assert.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+const char* to_cstring(LogLevel lev)
+{
+    static const char* const levels[] = {
+        "debug",
+        "diagnostic",
+        "status",
+        "info",
+        "warning",
+        "error",
+        "critical",
+    };
+    int idx = static_cast<int>(lev);
+    ENSURE(idx * sizeof(const char*) < sizeof(levels));
+    return levels[idx];
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/comm/LoggerTypes.hh
+++ b/src/comm/LoggerTypes.hh
@@ -1,0 +1,46 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file LoggerTypes.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <functional>
+#include <string>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Enumeration for how important a log message is.
+ */
+enum class LogLevel
+{
+    debug,      //!< Debugging messages
+    diagnostic, //!< Diagnostics about current program execution
+    status,     //!< Program execution status (what stage is beginning)
+    info,       //!< Important informational messages
+    warning,    //!< Warnings about unusual events
+    error,      //!< Something went wrong, but execution continues
+    critical    //!< Something went terribly wrong; we're aborting now! Bye!
+};
+
+//---------------------------------------------------------------------------//
+// Get the plain text equivalent of the log level above
+const char* to_cstring(LogLevel);
+
+//---------------------------------------------------------------------------//
+//! Stand-in for a more complex class for the "provenance" of data
+struct Provenance
+{
+    std::string file;
+    int         line = 0;
+};
+
+//! Type for handling a log message
+using LogHandler = std::function<void(Provenance, LogLevel, std::string)>;
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/comm/MpiTypes.hh
+++ b/src/comm/MpiTypes.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file Types.hh
+//! \file MpiTypes.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -14,6 +14,8 @@
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+// MPI TYPES
 //---------------------------------------------------------------------------//
 #if CELERITAS_USE_MPI
 using MpiComm = MPI_Comm;

--- a/src/comm/detail/LoggerMessage.cc
+++ b/src/comm/detail/LoggerMessage.cc
@@ -1,0 +1,59 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file LoggerMessage.cc
+//---------------------------------------------------------------------------//
+#include "LoggerMessage.hh"
+
+#include <sstream>
+#include "base/Assert.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with reference to function object, etc.
+ */
+LoggerMessage::LoggerMessage(LogHandler* handle, Provenance prov, LogLevel lev)
+    : handle_(handle), prov_(prov), lev_(lev)
+{
+    REQUIRE(!handle_ || *handle_);
+    if (handle_)
+    {
+        // std::function is defined, so create the output stream
+        os_ = std::make_unique<std::ostringstream>();
+    }
+    ENSURE(bool(handle_) == bool(os_));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Flush message on destruction.
+ */
+LoggerMessage::~LoggerMessage()
+{
+    if (os_)
+    {
+        try
+        {
+            auto& os = dynamic_cast<std::ostringstream&>(*os_);
+
+            // Write to the handler
+            (*handle_)(prov_, lev_, os.str());
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr
+                << "An error occurred writing a log message: " << e.what()
+                << std::endl;
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/comm/detail/LoggerMessage.hh
+++ b/src/comm/detail/LoggerMessage.hh
@@ -1,0 +1,105 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file LoggerMessage.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include "../LoggerTypes.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Helper class for writing log messages.
+ *
+ * This class should only be created by a Logger instance. When it destructs,
+ * the handler is called.
+ * \code
+    LoggerMessage ...;
+   \endcode
+ */
+class LoggerMessage
+{
+  public:
+    //@{
+    //! Type aliases
+    using StreamManip = std::ostream& (*)(std::ostream&);
+    //@}
+
+  public:
+    // Construct with reference to function object, etc.
+    LoggerMessage(LogHandler* handle, Provenance prov, LogLevel lev);
+
+    // Flush message on destruction
+    ~LoggerMessage();
+
+    // Default move construct and assignment
+    LoggerMessage(LoggerMessage&&) = default;
+    LoggerMessage& operator=(LoggerMessage&&) = default;
+
+    // Write the object to the stream if applicable
+    template<class T>
+    inline LoggerMessage& operator<<(T&& rhs);
+
+    // Accept manipulators such as std::endl, std::setw
+    inline LoggerMessage& operator<<(StreamManip manip);
+
+    // Update the steam state
+    inline void setstate(std::ostream::iostate state);
+
+  private:
+    LogHandler*                   handle_;
+    Provenance                    prov_;
+    LogLevel                      lev_;
+    std::unique_ptr<std::ostream> os_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write the object to the stream if applicable.
+ */
+template<class T>
+LoggerMessage& LoggerMessage::operator<<(T&& rhs)
+{
+    if (os_)
+    {
+        *os_ << std::forward<T>(rhs);
+    }
+    return *this;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Accept a stream manipulator.
+ */
+LoggerMessage& LoggerMessage::operator<<(StreamManip manip)
+{
+    if (os_)
+    {
+        manip(*os_);
+    }
+    return *this;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Update the steam state (needed by some manipulators).
+ */
+void LoggerMessage::setstate(std::ostream::iostate state)
+{
+    if (os_)
+    {
+        os_->setstate(state);
+    }
+}
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,6 +103,7 @@ add_cudaoptional_test(base/StackAllocator)
 celeritas_setup_tests(PREFIX comm)
 
 celeritas_add_test(comm/Communicator.test.cc)
+celeritas_add_test(comm/Logger.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Geometry

--- a/test/comm/Communicator.test.cc
+++ b/test/comm/Communicator.test.cc
@@ -9,6 +9,7 @@
 
 #include "celeritas_test.hh"
 
+using celeritas::barrier;
 using celeritas::Communicator;
 
 //---------------------------------------------------------------------------//
@@ -25,7 +26,7 @@ class CommunicatorTest : public celeritas::Test
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST_F(CommunicatorTest, rank)
+TEST_F(CommunicatorTest, world)
 {
     Communicator comm = Communicator::comm_world();
 
@@ -42,9 +43,16 @@ TEST_F(CommunicatorTest, rank)
     EXPECT_EQ(expected_size, comm.size());
 #endif
 
-    comm.barrier();
+    barrier(comm);
+}
 
-    Communicator comm_self = Communicator::comm_self();
-    EXPECT_NE(comm.mpi_comm(), comm_self.mpi_comm());
-    comm_self.barrier();
+TEST_F(CommunicatorTest, self)
+{
+    Communicator comm = Communicator::comm_self();
+    EXPECT_NE(Communicator::comm_world().mpi_comm(), comm.mpi_comm());
+    barrier(comm);
+
+    // "self" comm always acts like it's running in serial
+    EXPECT_EQ(1, comm.size());
+    EXPECT_EQ(0, comm.rank());
 }

--- a/test/comm/Logger.test.cc
+++ b/test/comm/Logger.test.cc
@@ -1,0 +1,139 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Logger.test.cc
+//---------------------------------------------------------------------------//
+#include "comm/Logger.hh"
+
+#include <iomanip>
+#include <thread>
+#include "celeritas_test.hh"
+#include "base/Range.hh"
+#include "base/Stopwatch.hh"
+#include "comm/Communicator.hh"
+
+using celeritas::Logger;
+using celeritas::LogLevel;
+using celeritas::Provenance;
+// using namespace celeritas_test;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class LoggerTest : public celeritas::Test
+{
+  protected:
+    void SetUp() override {}
+};
+
+//---------------------------------------------------------------------------//
+// HELPER CLASSES
+//---------------------------------------------------------------------------//
+
+struct ExpensiveToPrint
+{
+};
+
+std::ostream& operator<<(std::ostream& os, const ExpensiveToPrint&)
+{
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(2s);
+    return os;
+}
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(LoggerTest, global_handlers)
+{
+    CELER_LOG(status) << "This is a status message #" << 1;
+    CELER_LOG(warning) << "This is a warning message";
+    CELER_LOG(debug) << "This should be hidden by default";
+    std::cerr << "[regular cerr]" << std::endl;
+    ::celeritas::world_logger().level(LogLevel::debug);
+    CELER_LOG(debug) << "This should be shown now";
+
+    CELER_LOG_LOCAL(warning) << "Warning from rank "
+                             << celeritas::Communicator::comm_world().rank();
+
+    // Replace 'local' with a null-op logger, so the log message will never
+    // show
+    ::celeritas::self_logger()
+        = Logger(celeritas::Communicator::comm_self(), nullptr);
+    CELER_LOG_LOCAL(critical) << "the last enemy that shall be destroyed is "
+                                 "death";
+}
+
+TEST_F(LoggerTest, null)
+{
+    Logger log(celeritas::Communicator::comm_self(), nullptr);
+
+    log({"<file>", 0}, LogLevel::info) << "This should be fine!";
+}
+
+TEST_F(LoggerTest, custom_log)
+{
+    Provenance  last_prov;
+    LogLevel    last_lev = LogLevel::debug;
+    std::string last_msg;
+
+    Logger log(celeritas::Communicator::comm_self(),
+               [&](Provenance prov, LogLevel lev, std::string msg) {
+                   last_prov = prov;
+                   last_lev  = lev;
+                   last_msg  = std::move(msg);
+               });
+
+    // Update level
+    EXPECT_EQ(LogLevel::status, log.level());
+    log.level(LogLevel::warning);
+    EXPECT_EQ(LogLevel::warning, log.level());
+
+    // Call (won't be shown)
+    log({"file", 0}, LogLevel::info) << "Shouldn't be shown";
+    EXPECT_EQ("", last_msg);
+
+    // Call at higher level
+    log({"derp", 1}, LogLevel::warning) << "Danger Will Robinson";
+    EXPECT_EQ("derp", last_prov.file);
+    EXPECT_EQ(1, last_prov.line);
+    EXPECT_EQ("Danger Will Robinson", last_msg);
+
+    // Fancy: use local scoping
+    {
+        auto msg = log({"yo", 2}, LogLevel::error);
+        msg << "Things failed because:";
+        msg << std::setw(3) << 1;
+        msg << " is the loneliest number";
+        // Message should not have yet flushed
+        EXPECT_EQ(1, last_prov.line);
+    }
+    // Message should flush
+    EXPECT_EQ(2, last_prov.line);
+    EXPECT_EQ("Things failed because:  1 is the loneliest number", last_msg);
+}
+
+TEST_F(LoggerTest, performance)
+{
+    // Construct a logger with an expensive output routine that will never be
+    // called
+    Logger log(celeritas::Communicator::comm_self(),
+               [&](Provenance prov, LogLevel lev, std::string msg) {
+                   cout << prov.file << prov.line << static_cast<int>(lev)
+                        << msg << endl;
+               });
+    log.level(LogLevel::critical);
+
+    // Even in debug this takes only 26ms
+    celeritas::Stopwatch get_time;
+    for (auto i : celeritas::range(100000))
+    {
+        log({"<file>", 0}, LogLevel::info)
+            << "Never printed: " << i << ExpensiveToPrint{};
+    }
+    EXPECT_GT(0.1, get_time());
+}

--- a/test/gtest/detail/ParallelHandler.cc
+++ b/test/gtest/detail/ParallelHandler.cc
@@ -52,7 +52,7 @@ void ParallelHandler::OnTestProgramEnd(const ::testing::UnitTest&) {}
  */
 void ParallelHandler::OnTestStart(const ::testing::TestInfo&)
 {
-    comm_.barrier();
+    celeritas::barrier(comm_);
 }
 
 //---------------------------------------------------------------------------//
@@ -62,7 +62,7 @@ void ParallelHandler::OnTestStart(const ::testing::TestInfo&)
 void ParallelHandler::OnTestEnd(const ::testing::TestInfo&)
 {
     std::cout << std::flush;
-    comm_.barrier();
+    celeritas::barrier(comm_);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Add a low-overhead, parallel-enabled, extensible logger utility that looks like `cout` but is more clever.

The logger here is based off the logger in Shift (which is inspired in terminology by the python logging utilities).
- There are two global loggers: one standard logger (where all processes are presumed to be running the same code segment), and a "local" logger which is for a condition that's expected to vary between processes.
- If the runtime requested logging level is above the log statement, the `operator<<` is not evaluated for the object being streamed. (The same is true for the cases for the standard logger on all non-master processes.)
- The logging handler and log levels can be changed arbitrarily. The log handler is just a simple functor that takes the source file/line, the severity, and the message as a string, so it can be adapted to any other logging framework.
- The default handler uses colors to make messages pretty (when printing to terminal) and sends to stderr .

Closes #75 .