### PR TITLE
Add "not reachable" macros

### DIFF
--- a/app/geant-exporter/GeantPhysicsTableWriterHelper.hh
+++ b/app/geant-exporter/GeantPhysicsTableWriterHelper.hh
@@ -85,7 +85,7 @@ to_geant_physics_vector_type(const G4PhysicsVectorType g4_vector_type)
         case G4PhysicsVectorType::T_G4LPhysicsFreeVector:
             return ImportPhysicsVectorType::low_energy_free;
     }
-    CHECK(false);
+    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//
@@ -124,7 +124,7 @@ ImportProcessType to_geant_process_type(const G4ProcessType g4_process_type)
         case G4ProcessType::fUCN:
             return ImportProcessType::ucn;
     }
-    CHECK(false);
+    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//

--- a/app/geant-exporter/geant-exporter.cc
+++ b/app/geant-exporter/geant-exporter.cc
@@ -196,7 +196,7 @@ ImportMaterialState to_material_state(const G4State& g4_material_state)
         case G4State::kStateGas:
             return ImportMaterialState::gas;
     }
-    CHECK(false);
+    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/base/Assert.hh
+++ b/src/base/Assert.hh
@@ -51,14 +51,17 @@
 #    define REQUIRE(x) CELER_CUDA_ASSERT_(x)
 #    define CHECK(x) CELER_CUDA_ASSERT_(x)
 #    define ENSURE(x) CELER_CUDA_ASSERT_(x)
+#    define CHECK_UNREACHABLE CELER_CUDA_ASSERT_(false)
 #elif CELERITAS_DEBUG && !defined(__CUDA_ARCH__)
 #    define REQUIRE(x) CELER_ASSERT_(x)
 #    define CHECK(x) CELER_ASSERT_(x)
 #    define ENSURE(x) CELER_ASSERT_(x)
+#    define CHECK_UNREACHABLE CELER_ASSERT_(false)
 #else
 #    define REQUIRE(x) CELER_NOASSERT_(x)
 #    define CHECK(x) CELER_NOASSERT_(x)
 #    define ENSURE(x) CELER_NOASSERT_(x)
+#    define CHECK_UNREACHABLE CELER_UNREACHABLE
 #endif
 
 /*!

--- a/src/base/DeviceAllocation.nocuda.cc
+++ b/src/base/DeviceAllocation.nocuda.cc
@@ -23,7 +23,7 @@ DeviceAllocation::DeviceAllocation(size_type)
 //! Deleter should never be called on CPU
 void DeviceAllocation::CudaFreeDeleter::operator()(byte*) const
 {
-    REQUIRE(false);
+    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//
@@ -32,7 +32,7 @@ void DeviceAllocation::CudaFreeDeleter::operator()(byte*) const
  */
 void DeviceAllocation::copy_to_device(constSpanBytes)
 {
-    REQUIRE(false);
+    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//
@@ -41,7 +41,7 @@ void DeviceAllocation::copy_to_device(constSpanBytes)
  */
 void DeviceAllocation::copy_to_host(SpanBytes) const
 {
-    REQUIRE(false);
+    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/base/Macros.hh
+++ b/src/base/Macros.hh
@@ -1,4 +1,4 @@
-//---------------------------------*-CUDA-*----------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 // Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -47,7 +47,6 @@
  * instructions, improving instruction locality. It should be used primarily
  * for error checking conditions.
  */
-
 #if defined(__clang__) || defined(__GNUC__)
 // GCC and Clang support the same builtin
 #    define CELER_UNLIKELY(COND) __builtin_expect(!!(COND), 0)
@@ -70,7 +69,6 @@
    }
    \endcode
  */
-
 #if __cplusplus >= 201710L
 #    define CELER_MAYBE_UNUSED [[maybe_unused]]
 #elif defined(__GNUC__)
@@ -78,4 +76,24 @@
 #    define CELER_MAYBE_UNUSED [[gnu::unused]]
 #else
 #    define CELER_MAYBE_UNUSED
+#endif
+
+/*!
+ * \def CELER_UNREACHABLE
+ *
+ * Mark a point in code as being impossible to reach in normal execution.
+ *
+ * See https://clang.llvm.org/docs/LanguageExtensions.html#builtin-unreachable
+ * or https://msdn.microsoft.com/en-us/library/1b3fsfxw.aspx=
+ *
+ * \note This macro is usually unused; instead, the macro \c
+ * CELER_CHECK_UNREACHABLE defined in DBC.hh should be used instead (to provide
+ * a more detailed error message in case the point *is* reached).
+ */
+#if defined(__clang__) || defined(__GNUC__)
+#    define CELER_UNREACHABLE __builtin_unreachable()
+#elif defined(_MSC_VER)
+#    define CELER_UNREACHABLE __assume(false)
+#else
+#    define CELER_UNREACHABLE
 #endif

--- a/src/base/Memory.nocuda.cc
+++ b/src/base/Memory.nocuda.cc
@@ -16,7 +16,7 @@ namespace celeritas
  */
 void device_memset(void*, int, size_type)
 {
-    REQUIRE(0);
+    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/detail/VGNavStateStore.nocuda.cc
+++ b/src/geometry/detail/VGNavStateStore.nocuda.cc
@@ -28,7 +28,7 @@ VGNavStateStore::VGNavStateStore(size_type, int)
  */
 void VGNavStateStore::copy_to_device()
 {
-    REQUIRE(false);
+    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//
@@ -37,15 +37,14 @@ void VGNavStateStore::copy_to_device()
  */
 void* VGNavStateStore::device_pointers() const
 {
-    REQUIRE(*this);
-    return nullptr;
+    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//
 //! Deleter should never be called on CPU
 void VGNavStateStore::NavStatePoolDeleter::operator()(NavStatePool*) const
 {
-    REQUIRE(false);
+    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
I discovered that celeritas generates warnings when Geant4 is enabled in opt mode, due to the "Check(0)" I asked @stognini to put in since I hadn't added a "not reachable" macro. With the addition of this macro, not-reachable shows the expected failure modes and builds correctly.