### PR TITLE
Extend non-numeric quantity, enable tests and tweak annihilation process

### DIFF
--- a/app/demo-interactor/demo-interactor.cc
+++ b/app/demo-interactor/demo-interactor.cc
@@ -36,8 +36,8 @@ namespace demo_interactor
 std::shared_ptr<ParticleParams> load_params()
 {
     using namespace celeritas::units;
-    celeritas::ZeroQuantity zero;
-    auto                    stable = ParticleDef::stable_decay_constant();
+    constexpr auto zero   = zero_quantity();
+    constexpr auto stable = ParticleDef::stable_decay_constant();
 
     ParticleParams::VecAnnotatedDefs defs
         = {{{"electron", pdg::electron()},

--- a/app/demo-interactor/host-demo-interactor.cc
+++ b/app/demo-interactor/host-demo-interactor.cc
@@ -36,8 +36,8 @@ namespace demo_interactor
 std::shared_ptr<ParticleParams> load_params()
 {
     using namespace celeritas::units;
-    ZeroQuantity zero;
-    auto         stable = ParticleDef::stable_decay_constant();
+    constexpr auto zero   = zero_quantity();
+    constexpr auto stable = ParticleDef::stable_decay_constant();
 
     ParticleParams::VecAnnotatedDefs defs
         = {{{"electron", pdg::electron()},

--- a/scripts/dev/celeritas-gen-hackathon.py
+++ b/scripts/dev/celeritas-gen-hackathon.py
@@ -188,8 +188,8 @@ class {name}Test : public celeritas_test::InteractorHostTestBase
     {{
         using celeritas::ParticleDef;
         using namespace celeritas::units;
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         // XXX Update these based on particles needed by interactor
         Base::set_particle_params(

--- a/src/physics/base/Interaction.hh
+++ b/src/physics/base/Interaction.hh
@@ -60,7 +60,7 @@ CELER_FUNCTION Interaction Interaction::from_absorption()
 {
     Interaction result;
     result.action    = Action::absorbed;
-    result.energy    = ZeroQuantity();
+    result.energy    = zero_quantity();
     result.direction = {0, 0, 0};
     return result;
 }

--- a/src/physics/em/EPlusGGInteractor.hh
+++ b/src/physics/em/EPlusGGInteractor.hh
@@ -50,13 +50,13 @@ class EPlusGGInteractor
     //! Minimum incident energy for this model to be valid
     static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_incident_energy()
     {
-        return units::MevEnergy{0}; // at rest
+        return zero_quantity(); // at rest
     }
 
     //! Maximum incident energy for this model to be valid
     static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
     {
-        return units::MevEnergy{100000000}; // 100 TeV
+        return max_quantity();
     }
 
   private:

--- a/src/physics/em/EPlusGGInteractor.hh
+++ b/src/physics/em/EPlusGGInteractor.hh
@@ -20,16 +20,17 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Brief class description.
+ * Annihilate a positron to create two gammas.
  *
- * This is a model for the discrete positron-electron Annihilation process
+ * This is a model for the discrete positron-electron annihilation process
  * which simulates the in-flight annihilation of a positron with an atomic
  * electron and produces into two photons. It is assumed that the atomic
  * electron is initially free and at rest.
  *
  * \note This performs the same sampling routine as in Geant4's
  * G4eeToTwoGammaModel class, as documented in section 10.3 of the Geant4
- * Physics Reference (release 10.6).
+ * Physics Reference (release 10.6). The maximum energy for the model is
+ * specified in Geant4.
  */
 class EPlusGGInteractor
 {
@@ -56,14 +57,14 @@ class EPlusGGInteractor
     //! Maximum incident energy for this model to be valid
     static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_incident_energy()
     {
-        return max_quantity();
+        return units::MevEnergy{1e8}; // 100 TeV
     }
 
   private:
     // Shared constant physics properties
     const EPlusGGInteractorPointers& shared_;
     // Incident positron energy
-    const units::MevEnergy inc_energy_;
+    const real_type inc_energy_;
     // Incident direction
     const Real3& inc_direction_;
     // Allocate space for secondary particles (two photons)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -180,7 +180,7 @@ set(_not_impl DISABLE)
 # NOTE: Remove '${_not_impl}' below at the start of developing each class.
 celeritas_add_test(physics/em/BetheBlochInteractor.test.cc ${_not_impl})
 celeritas_add_test(physics/em/BremRelInteractor.test.cc ${_not_impl})
-celeritas_add_test(physics/em/EPlusGGInteractor.test.cc ${_not_impl})
+celeritas_add_test(physics/em/EPlusGGInteractor.test.cc)
 celeritas_add_test(physics/em/KleinNishinaInteractor.test.cc)
 celeritas_add_test(physics/em/LivermoreInteractor.test.cc ${_not_impl})
 celeritas_add_test(physics/em/MollerBhabhaInteractor.test.cc ${_not_impl})

--- a/test/base/Quantity.test.cc
+++ b/test/base/Quantity.test.cc
@@ -83,3 +83,13 @@ TEST(QuantityTest, comparators)
     EXPECT_TRUE(Revolution{5} >= Revolution{4});
     EXPECT_FALSE(Revolution{5} == Revolution{4});
 }
+
+TEST(QuantityTest, infinities)
+{
+    using celeritas::max_quantity;
+    using celeritas::neg_max_quantity;
+    EXPECT_TRUE(neg_max_quantity() < Revolution{-1e300});
+    EXPECT_TRUE(neg_max_quantity() < zero_quantity());
+    EXPECT_TRUE(zero_quantity() < max_quantity());
+    EXPECT_TRUE(max_quantity() > Revolution{1e300});
+}

--- a/test/physics/InteractorHostTestBase.cc
+++ b/test/physics/InteractorHostTestBase.cc
@@ -64,7 +64,7 @@ void InteractorHostTestBase::set_inc_particle(PDGNumber pdg, MevEnergy energy)
 {
     REQUIRE(particle_params_);
     REQUIRE(pdg);
-    REQUIRE(energy > zero_quantity());
+    REQUIRE(energy >= zero_quantity());
 
     particle_state_.def_id = particle_params_->find(pdg);
     particle_state_.energy = energy;

--- a/test/physics/base/Particle.test.cc
+++ b/test/physics/base/Particle.test.cc
@@ -45,8 +45,8 @@ class ParticleTrackViewTest : public celeritas::Test
         using celeritas::ParticleDef;
         using namespace celeritas::units;
 
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         // Create particle defs, initialize on device
         ParticleParams::VecAnnotatedDefs defs;

--- a/test/physics/em/BetheBlochInteractor.test.cc
+++ b/test/physics/em/BetheBlochInteractor.test.cc
@@ -30,8 +30,8 @@ class BetheBlochInteractorTest : public celeritas_test::InteractorHostTestBase
     {
         using celeritas::ParticleDef;
         using namespace celeritas::units;
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         // XXX Update these based on particles needed by interactor
         Base::set_particle_params(

--- a/test/physics/em/BremRelInteractor.test.cc
+++ b/test/physics/em/BremRelInteractor.test.cc
@@ -30,8 +30,8 @@ class BremRelInteractorTest : public celeritas_test::InteractorHostTestBase
     {
         using celeritas::ParticleDef;
         using namespace celeritas::units;
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         // XXX Update these based on particles needed by interactor
         Base::set_particle_params(

--- a/test/physics/em/EPlusGGInteractor.test.cc
+++ b/test/physics/em/EPlusGGInteractor.test.cc
@@ -30,8 +30,8 @@ class EPlusGGInteractorTest : public celeritas_test::InteractorHostTestBase
     {
         using celeritas::ParticleDef;
         using namespace celeritas::units;
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         Base::set_particle_params(
             {{{"electron", pdg::electron()},

--- a/test/physics/em/EPlusGGInteractor.test.cc
+++ b/test/physics/em/EPlusGGInteractor.test.cc
@@ -152,19 +152,52 @@ TEST_F(EPlusGGInteractorTest, basic)
     }
 }
 
+TEST_F(EPlusGGInteractorTest, at_rest)
+{
+    this->set_inc_direction({1, 0, 0});
+    this->set_inc_particle(pdg::positron(), celeritas::zero_quantity());
+    const int num_samples = 4;
+
+    // Reserve  num_samples*2 secondaries;
+    this->resize_secondaries(num_samples * 2);
+
+    // Create the interactor
+    EPlusGGInteractor interact(pointers_,
+                               this->particle_track(),
+                               this->direction(),
+                               this->secondary_allocator());
+    RandomEngine&     rng_engine = this->rng();
+
+    for (CELER_MAYBE_UNUSED int i : celeritas::range(num_samples))
+    {
+        Interaction result = interact(rng_engine);
+        SCOPED_TRACE(result);
+        this->sanity_check(result);
+
+        ASSERT_EQ(2, result.secondaries.size());
+        EXPECT_SOFT_EQ(-1,
+                       celeritas::dot_product(result.secondaries[0].direction,
+                                              result.secondaries[1].direction));
+
+        EXPECT_SOFT_EQ(pointers_.electron_mass,
+                       result.secondaries[0].energy.value());
+        EXPECT_SOFT_EQ(pointers_.electron_mass,
+                       result.secondaries[1].energy.value());
+    }
+}
+
 TEST_F(EPlusGGInteractorTest, stress_test)
 {
     RandomEngine& rng_engine = this->rng();
 
     const int num_samples = 8192;
 
-    for (double inc_e : {0.01, 1.0, 10.0, 1000.0})
+    for (double inc_e : {0.0, 0.01, 1.0, 10.0, 1000.0})
     {
         SCOPED_TRACE("Incident energy: " + std::to_string(inc_e));
         this->set_inc_particle(pdg::positron(), MevEnergy{inc_e});
 
-        // Loop over several incident directions (shouldn't affect anything
-        // substantial, but scattering near Z axis loses precision)
+        // Loop over several incident directions
         for (const Real3& inc_dir :
              {Real3{0, 0, 1}, Real3{1, 0, 0}, Real3{1e-9, 0, 1}, Real3{1, 1, 1}})
         {
@@ -182,7 +215,7 @@ TEST_F(EPlusGGInteractorTest, stress_test)
             for (int i = 0; i < num_samples; ++i)
             {
                 Interaction result = interact(rng_engine);
-                SCOPED_TRACE(result);
+                // SCOPED_TRACE(result);
                 this->sanity_check(result);
             }
             EXPECT_EQ(2 * num_samples,

--- a/test/physics/em/KleinNishinaInteractor.test.cc
+++ b/test/physics/em/KleinNishinaInteractor.test.cc
@@ -30,8 +30,8 @@ class KleinNishinaInteractorTest : public celeritas_test::InteractorHostTestBase
     {
         using celeritas::ParticleDef;
         using namespace celeritas::units;
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         Base::set_particle_params(
             {{{"electron", pdg::electron()},

--- a/test/physics/em/LivermoreInteractor.test.cc
+++ b/test/physics/em/LivermoreInteractor.test.cc
@@ -30,8 +30,8 @@ class LivermoreInteractorTest : public celeritas_test::InteractorHostTestBase
     {
         using celeritas::ParticleDef;
         using namespace celeritas::units;
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         // XXX Update these based on particles needed by interactor
         Base::set_particle_params(

--- a/test/physics/em/MollerBhabhaInteractor.test.cc
+++ b/test/physics/em/MollerBhabhaInteractor.test.cc
@@ -30,8 +30,8 @@ class MollerBhabhaInteractorTest : public celeritas_test::InteractorHostTestBase
     {
         using celeritas::ParticleDef;
         using namespace celeritas::units;
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         // XXX Update these based on particles needed by interactor
         Base::set_particle_params(

--- a/test/physics/em/RayleighInteractor.test.cc
+++ b/test/physics/em/RayleighInteractor.test.cc
@@ -30,8 +30,8 @@ class RayleighInteractorTest : public celeritas_test::InteractorHostTestBase
     {
         using celeritas::ParticleDef;
         using namespace celeritas::units;
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         // XXX Update these based on particles needed by interactor
         Base::set_particle_params(

--- a/test/physics/em/UrbanInteractor.test.cc
+++ b/test/physics/em/UrbanInteractor.test.cc
@@ -30,8 +30,8 @@ class UrbanInteractorTest : public celeritas_test::InteractorHostTestBase
     {
         using celeritas::ParticleDef;
         using namespace celeritas::units;
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         // XXX Update these based on particles needed by interactor
         Base::set_particle_params(

--- a/test/physics/em/WentzelInteractor.test.cc
+++ b/test/physics/em/WentzelInteractor.test.cc
@@ -30,8 +30,8 @@ class WentzelInteractorTest : public celeritas_test::InteractorHostTestBase
     {
         using celeritas::ParticleDef;
         using namespace celeritas::units;
-        celeritas::ZeroQuantity zero;
-        auto                    stable = ParticleDef::stable_decay_constant();
+        constexpr auto zero   = celeritas::zero_quantity();
+        constexpr auto stable = ParticleDef::stable_decay_constant();
 
         // XXX Update these based on particles needed by interactor
         Base::set_particle_params(


### PR DESCRIPTION
While doing some preparatory work for the multiple models/processes, I noticed the EPlusGG test wasn't enabled, and the "at rest" portion wasn't being tested.

- Added an "infinite" quantity so that models with no upper energy bound don't have to choose an arbitrary number
- Replaced hard-coded double-precision math with `real_type` and implicit conversions in case we ever want to experiment with single-precision
- Delayed evaluation of expressions until they're used, reducing register pressure

See https://github.com/celeritas-project/cuda-test-snippets/commit/109392ddb7c247b55e6942b7c0a82f7efbfc1b92 for the changes in register usage/spill due to the minor tweaks.