### PR TITLE
Add Dockerfile and enable Jenkins CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,0 +1,34 @@
+pipeline {
+    triggers {
+        issueCommentTrigger('.*do: test')
+    }
+    agent none
+
+    environment {
+        CTEST_ARGS = '--timeout 180 --no-compress-output -T Test --test-output-size-passed=65536 --test-output-size-failed=1048576'
+    }
+    stages {
+        stage('Build') {
+            parallel {
+                stage('cuda-11') {
+                    agent {
+                        docker {
+                            image 'celeritas/ci-cuda11:latest'
+                            label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
+                        }
+                    }
+                    steps {
+                        sh 'rm -rf build && mkdir -p build'
+                        sh 'SOURCE_DIR=. BUILD_DIR=build entrypoint-shell ./scripts/build/docker.sh'
+                    }
+                    post {
+                        always {
+                            xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/scripts/build/docker.sh
+++ b/scripts/build/docker.sh
@@ -1,0 +1,42 @@
+#!/bin/sh -e
+
+if [ -z "${SOURCE_DIR}" ]; then
+  BUILDSCRIPT_DIR="$(cd "$(dirname $BASH_SOURCE[0])" && pwd)"
+  SOURCE_DIR="$(cd "${BUILDSCRIPT_DIR}" && git rev-parse --show-toplevel)"
+else
+  SOURCE_DIR="$(cd "${SOURCE_DIR}" && pwd)"
+fi
+if [ -z "${BUILD_DIR}" ]; then
+  : ${BUILD_SUBDIR:=build}
+  BUILD_DIR=${SOURCE_DIR}/${BUILD_SUBDIR}
+fi
+: ${CTEST_ARGS:=--output-on-failure}
+
+printf "\e[2;37mBuilding in ${BUILD_DIR}\e[0m\n"
+mkdir ${BUILD_DIR} 2>/dev/null \
+  || printf "\e[2;37m... from existing cache\e[0m\n"
+cd ${BUILD_DIR}
+
+set -x
+export CXXFLAGS="-Wall -Wextra -pedantic -Werror"
+
+# Note: cuda_arch must match the spack.yaml file for the docker image, which
+# must match the hardware being used.
+cmake -G Ninja \
+  -DCELERITAS_BUILD_DEMOS:BOOL=ON \
+  -DCELERITAS_BUILD_TESTS:BOOL=ON \
+  -DCELERITAS_USE_CUDA:BOOL=ON \
+  -DCELERITAS_USE_Geant4:BOOL=ON \
+  -DCELERITAS_USE_HepMC3:BOOL=ON \
+  -DCELERITAS_USE_MPI:BOOL=ON \
+  -DCELERITAS_USE_ROOT:BOOL=ON \
+  -DCELERITAS_USE_VecGeom:BOOL=ON \
+  -DCELERITAS_DEBUG:BOOL=ON \
+  -DCMAKE_BUILD_TYPE:STRING="RelWithDebInfo" \
+  -DCMAKE_CUDA_ARCHITECTURES:STRING="70" \
+  -DCMAKE_SHARED_LINKER_FLAGS:STRING="-Wl,--no-as-needed" \
+  -DMPIEXEC_PREFLAGS:STRING="--allow-run-as-root" \
+  -DMPI_CXX_LINK_FLAGS:STRING="-pthread" \
+  ${SOURCE_DIR}
+ninja -v -k0
+ctest $CTEST_ARGS

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,0 +1,87 @@
+FROM  nvidia/cuda:11.1-devel-ubuntu20.04 as builder
+LABEL maintainer="Seth Johnson <johnsonsr@ornl.gov>" \
+      description="Celeritas prerequisites built with Spack"
+# Run `docker build -t celeritas/dev:prereq .` to set up
+
+###############################################################################
+# From spack dockerfile:
+# https://hub.docker.com/r/spack/ubuntu-bionic/dockerfile
+# BUT replacing "COPY" commands with curl (and hard-wiring version)
+###############################################################################
+
+# General environment for docker
+ENV DEBIAN_FRONTEND=noninteractive    \
+    SPACK_ROOT=/opt/spack             \
+    DEBIAN_FRONTEND=noninteractive    \
+    CURRENTLY_BUILDING_DOCKER_IMAGE=1 \
+    container=docker
+
+RUN apt-get -yqq update \
+ && apt-get -yqq install --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        file \
+        g++ \
+        gcc \
+        gfortran \
+        git \
+        gnupg2 \
+        iproute2 \
+        lmod \
+        locales \
+        lua-posix \
+        make \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        tcl \
+        unzip \
+        vim \
+ && locale-gen en_US.UTF-8 \
+ && pip3 install boto3 \
+ && rm -rf /var/lib/apt/lists/*
+
+# XXX replaced COPY commands with this
+RUN mkdir -p $SPACK_ROOT \
+    && curl -s -L https://api.github.com/repos/spack/spack/tarball/v0.16.0 \
+    | tar xzC $SPACK_ROOT --strip 1
+
+RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/docker-shell \
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/interactive-shell \
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-env
+
+# Add LANG default to en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+RUN mkdir -p /root/.spack \
+ && cp $SPACK_ROOT/share/spack/docker/modules.yaml \
+        /root/.spack/modules.yaml \
+ && rm -rf /root/*.* /run/nologin $SPACK_ROOT/.git
+
+WORKDIR /root
+SHELL ["docker-shell"]
+
+ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]
+CMD ["interactive-shell"]
+
+###############################################################################
+# Install
+###############################################################################
+
+COPY env.yaml /opt/spack-environment/spack.yaml
+RUN cd /opt/spack-environment && spack env activate . \
+    && spack install --fail-fast
+
+# Modifications to the environment that are necessary to run
+RUN cd /opt/spack-environment && \
+    spack env activate --sh -d . >> /etc/profile.d/celeritas_spack_env.sh
+
+# TODO: revert to default entrypoint so that commands
+# (e.g. `docker run celeritas/dev:prereq bash`) work correctly
+ENTRYPOINT ["/bin/bash", "--rcfile", "/etc/profile", "-l"]

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -1,0 +1,49 @@
+# Docker images
+
+These docker images use [spack](https://github.com/spack/spack) to build a
+CUDA-enabled development environment for Celeritas. There are two images:
+- `celeritas:dev` (this directory) which leaves spack fully installed and
+  debug symbols intact; and
+- `celeritas:ci-cuda11` (`ci` subdirectory) which only copies the
+  necessary software stack.
+
+Both images are based on `nvidia` Ubuntu installations.
+
+## Building
+
+From inside this directory, you can build and tag both versions:
+
+```console
+$ docker build -t celeritas/dev:latest .
+$ docker build -t celeritas/ci-cuda11:latest ci
+```
+
+## Pushing
+
+The CI docker images should be pushed upstream to enable continuous
+integration. This is a one-line command:
+```console
+$ docker push celeritas/dev:latest
+$ docker push celeritas/ci-cuda11:latest ci
+```
+but it requires that you log in with your `docker.io` credentials first:
+```console
+$ docker login -u sethrj
+```
+
+## Running
+
+The development image is (in color) run with:
+```console
+$ docker run --rm -ti -e "TERM=xterm-256color" celeritas/ci-cuda11
+```
+Note that the `--rm` option automatically deletes the state of the container
+after you exit the docker client. This means all of your work will be
+destroyed.
+
+The `dev` image runs as root, but the `ci-cuda11` runs as a user "celeritas".
+This is the best way to [make OpenMPI happy](https://github.com/open-mpi/ompi/issues/4451).
+
+Note that the Jenkins CI runs as root regardless of the `run` command, so it
+defines `MPIEXEC_PREFLAGS=--allow-run-as-root` for CMake.
+

--- a/scripts/docker/ci/Dockerfile
+++ b/scripts/docker/ci/Dockerfile
@@ -1,0 +1,72 @@
+FROM  celeritas/dev:latest as builder
+
+LABEL maintainer="Seth Johnson <johnsonsr@ornl.gov>" \
+      description="Celeritas CI build"
+# Run `docker build -t celeritas/ci:cuda11 .` to set up
+
+###############################################################################
+# Export environment
+###############################################################################
+
+# Remove unneeded build deps
+RUN cd /opt/spack-environment && \
+    spack gc -y
+
+# Strip binaries
+RUN find -L /opt/view/* -type f -exec readlink -f '{}' \; | \
+    xargs file -i | \
+    grep 'charset=binary' | \
+    grep 'x-executable\|x-archive\|x-sharedlib' | \
+    awk -F: '{print $1}' | xargs strip -s
+
+# Set up initialization
+# XXX : change from >> to > since this is a duplicate
+RUN cd /opt/spack-environment && \
+    spack env activate --sh -d . >> /etc/profile.d/celeritas_spack_env.sh
+
+###############################################################################
+# Finalize
+###############################################################################
+
+# Bare OS image to run the installed executables
+FROM nvidia/cuda:11.1-devel-ubuntu20.04
+
+# Copy spack environment
+COPY --from=builder /opt/spack-environment /opt/spack-environment
+COPY --from=builder /opt/software /opt/software
+COPY --from=builder /opt/view /opt/view
+COPY --from=builder /etc/profile.d/celeritas_spack_env.sh /etc/profile.d/celeritas_spack_env.sh
+
+# Add core files
+RUN apt-get -yqq update \
+ && apt-get -yqq install --no-install-recommends \
+        build-essential \
+        g++ \
+        gcc \
+        ssh \
+        vim \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install updated vecgeom (XXX: merge into spack install)
+RUN . /etc/profile.d/celeritas_spack_env.sh \
+  && cd /opt \
+  && git clone --depth=1 https://gitlab.cern.ch/VecGeom/VecGeom.git vecgeom-src \
+  && mkdir vecgeom-build \
+  && cd vecgeom-build \
+  && cmake -DBACKEND:STRING=Scalar -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILTIN_VECCORE:BOOL=OFF -DNO_SPECIALIZATION:BOOL=ON -DVECGEOM_VECTOR:STRING=empty -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_STANDARD:STRING=14 -DCUDA:BOOL=ON -DGDML:BOOL=ON -DGEANT4:BOOL=OFF -DROOT:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DCTEST:BOOL=OFF -DGDMLTESTING:BOOL=OFF -DCUDA_ARCH:STRING=70 -DCMAKE_INSTALL_PREFIX:STRING=/opt/vecgeom -G Ninja ../vecgeom-src \
+  && ninja install \
+  && rm -rf /opt/vecgeom-build /opt/vecgeom-src \
+  && echo "export CMAKE_PREFIX_PATH=/opt/vecgeom:${CMAKE_PREFIX_PATH}" >> /etc/profile.d/celeritas_spack_env.sh
+
+# Set up entrypoint and group
+RUN groupadd -g 999 celeritas \
+ && useradd -r -u 999 -g celeritas -d /home/celeritas -m celeritas \
+ && ln -s /opt/docker/entrypoint.bash /usr/local/bin/entrypoint-shell \
+ && ln -s /opt/docker/entrypoint.bash /usr/local/bin/entrypoint-cmd
+COPY entrypoint.bash /opt/docker/entrypoint.bash
+
+USER celeritas
+WORKDIR /home/celeritas
+ENTRYPOINT ["/bin/bash", "/opt/docker/entrypoint.bash"]
+SHELL ["entrypoint-shell"]
+CMD ["entrypoint-cmd"]

--- a/scripts/docker/ci/entrypoint.bash
+++ b/scripts/docker/ci/entrypoint.bash
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+mode=exec
+
+if [ "$(basename "$0")" == 'entrypoint-shell' ] ; then
+  mode=shell
+elif [ "$(basename "$0")" == 'entrypoint-cmd' ] ; then
+  mode=cmd
+elif [ "$1" == 'entrypoint-shell' ] ; then
+  mode=shell
+  shift
+elif [ "$1" == 'entrypoint-cmd' ] ; then
+  mode=cmd
+  shift
+fi
+
+case "$mode" in
+  exec)
+    source /etc/profile
+    exec "$@"
+    ;;
+  shell)
+    source /etc/profile
+    exec bash -c "$*"
+    ;;
+  cmd)
+    if [ ! -t 0 ] ; then
+      echo "error: no pseudo-TTY allocated: try 'docker run -it'" >&2
+      exit 1
+    fi
+    exec bash -l
+    ;;
+esac

--- a/scripts/docker/env.yaml
+++ b/scripts/docker/env.yaml
@@ -1,0 +1,38 @@
+spack:
+  specs:
+  - cmake
+  - cuda
+  - geant4
+  - git
+  - googletest
+  - hepmc3
+  - ninja
+  - nlohmann-json
+  - openmpi
+  - python
+  - root
+  - veccore
+  - vecgeom
+  concretization: together
+  packages:
+    cuda:
+      buildable: false
+      externals:
+      - spec: cuda@11.1.0
+        prefix: /usr/local/cuda
+    root:
+      variants: ~davix ~examples ~x ~opengl ~tbb ~rootfit ~python ~math ~gsl cxxstd=14
+    all:
+      target:
+      - x86_64
+      variants: +cuda cuda_arch=70 cxxstd=14
+      providers:
+        blas:
+        - openblas
+        lapack:
+        - openblas
+        mpi:
+        - openmpi
+  config:
+    install_tree: /opt/software
+  view: /opt/view

--- a/test/gtest/detail/TestMain.cc
+++ b/test/gtest/detail/TestMain.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "TestMain.hh"
 
+#include <stdexcept>
 #include "celeritas_config.h"
 #include "base/ColorUtils.hh"
 #include "comm/Communicator.hh"
@@ -27,7 +28,20 @@ int test_main(int argc, char** argv)
     Communicator  comm = Communicator::comm_world();
 
     // Initialize device
-    celeritas::initialize_device(comm);
+    try
+    {
+        celeritas::initialize_device(comm);
+    }
+    catch (const std::exception& e)
+    {
+        if (comm.rank() == 0)
+        {
+            std::cout << color_code('r') << "[  FAILED  ]" << color_code(' ')
+                      << " CUDA failed to initialize: " << e.what()
+                      << std::endl;
+        }
+        return 1;
+    }
 
     // Initialize google test
     ::testing::InitGoogleTest(&argc, argv);
@@ -66,7 +80,7 @@ int test_main(int argc, char** argv)
         if (comm.rank() == 0)
         {
             std::cout << color_code('r') << "[  FAILED  ]" << color_code(' ')
-                      << "No tests are written/enabled!" << std::endl;
+                      << " No tests are written/enabled!" << std::endl;
         }
 
         global_failed = 1;


### PR DESCRIPTION
This defines a dockerfile with the full Celeritas toolchain on Ubuntu 20 with CUDA 11.1 and Spack 0.16 for CUDA sm_70 capabilities. The CI integration clones the image and builds with the included script, posting the results to a [Celeritas Jenkins status page](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/Celeritas/activity/) and marking the PR as passing/failing.