### PR TITLE
Add Coulomb correction to element view and increase accuracy

### DIFF
--- a/src/base/Algorithms.hh
+++ b/src/base/Algorithms.hh
@@ -32,12 +32,25 @@ CELER_CONSTEXPR_FUNCTION const T& max(const T& a, const T& b)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Return an integer power of the input value.
+ */
+template<unsigned int N, class T>
+CELER_CONSTEXPR_FUNCTION T ipow(T v)
+{
+    return (N == 0)       ? 1
+           : (N % 2 == 0) ? ipow<N / 2>(v) * ipow<N / 2>(v)
+                          : v * ipow<(N - 1) / 2>(v) * ipow<(N - 1) / 2>(v);
+}
 
+//---------------------------------------------------------------------------//
 /*!
  * Return the cube of the input value.
  */
 template<class T>
-CELER_CONSTEXPR_FUNCTION T cube(const T& a)
+[[deprecated(
+    "Replace with celeritas::ipow<3>(value)")]] CELER_CONSTEXPR_FUNCTION T
+cube(const T& a)
 {
     return a * a * a;
 }

--- a/src/physics/base/ParticleMd.hh
+++ b/src/physics/base/ParticleMd.hh
@@ -21,8 +21,7 @@ using PDGNumber = OpaqueId<struct ParticleMd, int>;
  * The PDG Monte Carlo number is a unique "standard model" identifier for a
  * particle. See "Monte Carlo Particle Numbering Scheme" in the "Review of
  * Particle Physics":
- * http://pdg.lbl.gov/2019/reviews/rpp2019-rev-monte-carlo-numbering.pdf
- *
+ * https://pdg.lbl.gov/2020/reviews/rpp2020-rev-monte-carlo-numbering.pdf
  */
 struct ParticleMd
 {

--- a/src/physics/material/ElementDef.hh
+++ b/src/physics/material/ElementDef.hh
@@ -27,17 +27,17 @@ namespace celeritas
  */
 struct ElementDef
 {
-    int            atomic_number; //!< Z number
-    units::AmuMass atomic_mass;   //!< Isotope-weighted average atomic mass
+    int            atomic_number = 0; //!< Z number
+    units::AmuMass atomic_mass;       //!< Isotope-weighted average atomic mass
 
     // COMPUTED PROPERTIES
 
-    real_type cbrt_z;   //!< Z^{1/3}
-    real_type cbrt_zzp; //!< (Z (Z + 1))^{1/3}
-    real_type log_z;    //!< log Z
+    real_type cbrt_z   = 0; //!< Z^{1/3}
+    real_type cbrt_zzp = 0; //!< (Z (Z + 1))^{1/3}
+    real_type log_z    = 0; //!< log Z
 
-    real_type coulomb_correction;   //!< f(Z)
-    real_type mass_radiation_coeff; //!< 1/X_0 (bremsstrahlung)
+    real_type coulomb_correction   = 0; //!< f(Z)
+    real_type mass_radiation_coeff = 0; //!< 1/X_0 (bremsstrahlung)
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/material/ElementDef.hh
+++ b/src/physics/material/ElementDef.hh
@@ -36,6 +36,7 @@ struct ElementDef
     real_type cbrt_zzp; //!< (Z (Z + 1))^{1/3}
     real_type log_z;    //!< log Z
 
+    real_type coulomb_correction;   //!< f(Z)
     real_type mass_radiation_coeff; //!< 1/X_0 (bremsstrahlung)
 };
 

--- a/src/physics/material/ElementView.hh
+++ b/src/physics/material/ElementView.hh
@@ -58,6 +58,10 @@ class ElementView
     CELER_FUNCTION real_type cbrt_zzp() const { return def_.cbrt_zzp; }
     //! log(z)
     CELER_FUNCTION real_type log_z() const { return def_.log_z; }
+
+    // Coulomb correction factor [unitless]
+    inline CELER_FUNCTION real_type coulomb_correction() const;
+
     // Mass radiation coefficient for Bremsstrahlung [cm^2/g]
     inline CELER_FUNCTION real_type mass_radiation_coeff() const;
 

--- a/src/physics/material/ElementView.i.hh
+++ b/src/physics/material/ElementView.i.hh
@@ -22,12 +22,25 @@ ElementView::ElementView(const MaterialParamsPointers& params,
 
 //---------------------------------------------------------------------------//
 /*!
- * Mass radiation coefficient for Bremsstrahlung [cm^2/g].
+ * Coulomb correction term [cm^2/g].
+ *
+ * Used by Bremsstrahlung and other physics processes, this constant is
+ * calculated with greater precision than in Geant4 (which is accurate to only
+ * 5 or 6 digits across the range of natural elements).
+ */
+CELER_FUNCTION real_type ElementView::coulomb_correction() const
+{
+    return def_.coulomb_correction;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Mass radiation coefficient 1/X_0 for Bremsstrahlung [cm^2/g].
  *
  * The "radiation length" X_0 is "the mean distance over which a high-energy
- * electron loses all but 1/e of its energy by bremsstrahlung".  [section
- * 33.4.2 (p452) of "Review of Particle Physics" (PDG group), Phys.  Rev. D 98
- * .]
+ * electron loses all but 1/e of its energy by bremsstrahlung". See Review of
+ * Particle Physics (2020), S34.4.2 (p541) for the semi-empirical calculation
+ * of 1/X0.
  *
  * This quantity 1/X_0 is normalized by material density and is equivalent to
  * Geant4's \c G4Element::GetfRadTsai.

--- a/src/physics/material/MaterialParams.cc
+++ b/src/physics/material/MaterialParams.cc
@@ -130,10 +130,12 @@ void MaterialParams::append_element_def(const ElementInput& inp)
     result.atomic_mass   = inp.atomic_mass;
 
     // Calculate various factors of the atomic number
-    const real_type z_real      = result.atomic_number;
-    result.cbrt_z               = std::cbrt(z_real);
-    result.cbrt_zzp             = std::cbrt(z_real * (z_real + 1));
-    result.log_z                = std::log(z_real);
+    const real_type z_real = result.atomic_number;
+    result.cbrt_z          = std::cbrt(z_real);
+    result.cbrt_zzp        = std::cbrt(z_real * (z_real + 1));
+    result.log_z           = std::log(z_real);
+    result.coulomb_correction
+        = detail::calc_coulomb_correction(result.atomic_number);
     result.mass_radiation_coeff = detail::calc_mass_rad_coeff(result);
 
     elnames_.push_back(inp.name);

--- a/src/physics/material/detail/Utils.cc
+++ b/src/physics/material/detail/Utils.cc
@@ -9,7 +9,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include "base/Algorithms.hh"
 #include "base/Constants.hh"
+#include "base/Range.hh"
 #include "base/Quantity.hh"
 #include "physics/material/ElementDef.hh"
 
@@ -20,22 +22,48 @@ namespace detail
 //---------------------------------------------------------------------------//
 /*!
  * Calculate Coulomb correction factor (unitless).
+ *
+ * This uses the formulation of arXiv:1204.3675 [hep-ph] of the correction
+ * factor presented in section 34.4.1 of the Review of Particle Physics (2020).
+ * The calculation of the values is in the celeritas-docs repo at
+ * https://github.com/celeritas-project/celeritas-docs/blob/master/notes/coulomb-correction/eval.py
+ *
+ * This is accurate to 16 digits of precision through Z=92, as compared to 5
+ * or 6 digits for equation 34.26 which appears in RPP.
  */
 real_type calc_coulomb_correction(int atomic_number)
 {
     REQUIRE(atomic_number > 0);
     using constants::alpha_fine_structure;
 
-    // Eq 33.27 for calculating f(Z), the coulomb correction factor
-    real_type alphazsq = alpha_fine_structure * std::min(atomic_number, 92);
-    alphazsq *= alphazsq;
-    const real_type fz = alphazsq
-                         * (1 / (1 + alphazsq) + 0.20206 - 0.0369 * alphazsq
-                            + 0.0083 * alphazsq * alphazsq
-                            - 0.002 * alphazsq * alphazsq * alphazsq);
+    const real_type alphazsq = ipow<2>(alpha_fine_structure * atomic_number);
+
+    static const double zeta[] = {2.0205690315959429e-01,
+                                  3.6927755143369927e-02,
+                                  8.3492773819228271e-03,
+                                  2.0083928260822143e-03,
+                                  4.9418860411946453e-04,
+                                  1.2271334757848915e-04,
+                                  3.0588236307020493e-05,
+                                  7.6371976378997626e-06,
+                                  1.9082127165539390e-06,
+                                  4.7693298678780645e-07,
+                                  1.1921992596531106e-07,
+                                  2.9803503514652279e-08,
+                                  7.4507117898354301e-09,
+                                  1.8626597235130491e-09,
+                                  4.6566290650337837e-10,
+                                  1.1641550172700519e-10};
+    real_type           fz     = 1 / (1 + alphazsq);
+    real_type           azpow  = 1;
+    for (double zeta_i : zeta)
+    {
+        fz += azpow * zeta_i;
+        azpow *= -alphazsq;
+    }
 
     ENSURE(fz > 0);
-    return fz;
+    return alphazsq * fz;
 }
 
 //---------------------------------------------------------------------------//
@@ -55,7 +83,7 @@ real_type calc_mass_rad_coeff(const ElementDef& el)
 
     const real_type z_real = el.atomic_number;
 
-    // Table 33.2 for calculating lrad/lrad prime
+    // Table 34.2 for calculating lrad/lrad prime
     real_type lrad, lrad_prime;
     switch (el.atomic_number)
     {
@@ -70,7 +98,7 @@ real_type calc_mass_rad_coeff(const ElementDef& el)
             lrad_prime = std::log(1194.0 * std::pow(z_real, -2.0 / 3));
     }
 
-    // Eq 33.26
+    // Eq 34.25
     constexpr real_type inv_x0_factor = 4 * alpha_fine_structure * re_electron
                                         * re_electron;
     return inv_x0_factor / unit_cast(el.atomic_mass)

--- a/src/physics/material/detail/Utils.hh
+++ b/src/physics/material/detail/Utils.hh
@@ -16,6 +16,7 @@ struct ElementDef;
 namespace detail
 {
 //---------------------------------------------------------------------------//
+real_type calc_coulomb_correction(int atomic_number);
 real_type calc_mass_rad_coeff(const ElementDef& el);
 
 //---------------------------------------------------------------------------//

--- a/test/base/Algorithms.test.cc
+++ b/test/base/Algorithms.test.cc
@@ -7,25 +7,26 @@
 //---------------------------------------------------------------------------//
 #include "base/Algorithms.hh"
 
-#include "gtest/Main.hh"
-#include "gtest/Test.hh"
-
-// using celeritas;
+#include "celeritas_test.hh"
 
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST(AlgorithmsTest, all)
+TEST(AlgorithmsTest, minmax)
 {
-    // Test min()
     EXPECT_EQ(1, celeritas::min<int>(1, 2));
     EXPECT_NE(0.2, celeritas::min<float>(0.1, 0.2));
-    // Test max()
     EXPECT_EQ(2, celeritas::max<int>(1, 2));
     EXPECT_NE(0.1, celeritas::max<float>(0.1, 0.2));
-    // Test cube()
-    EXPECT_EQ(8, celeritas::cube<int>(2));
-    EXPECT_EQ(0.001f, celeritas::cube<float>(0.1));
-    EXPECT_NE(125.000001, celeritas::cube<double>(5.0));
+}
+
+TEST(AlgorithmsTest, ipow)
+{
+    EXPECT_DOUBLE_EQ(1, celeritas::ipow<0>(0.0));
+    EXPECT_EQ(123.456, celeritas::ipow<1>(123.456));
+    EXPECT_EQ(8, (celeritas::ipow<3>(2)));
+    EXPECT_FLOAT_EQ(0.001f, celeritas::ipow<3>(0.1f));
+    EXPECT_EQ(1e4, celeritas::ipow<4>(10.0));
+    EXPECT_TRUE((std::is_same<int, decltype(celeritas::ipow<4>(5))>::value));
 }

--- a/test/physics/material/Material.test.cc
+++ b/test/physics/material/Material.test.cc
@@ -32,9 +32,9 @@ TEST(MaterialUtils, coulomb_correction)
 {
     using celeritas::detail::calc_coulomb_correction;
 
-    EXPECT_SOFT_EQ(6.4008383023028605e-5, calc_coulomb_correction(1));
-    EXPECT_SOFT_EQ(0.010734662857664759, calc_coulomb_correction(13));
-    EXPECT_SOFT_EQ(0.39494049800766201, calc_coulomb_correction(92));
+    EXPECT_SOFT_EQ(6.4008218033384263e-05, calc_coulomb_correction(1));
+    EXPECT_SOFT_EQ(0.010734632775699565, calc_coulomb_correction(13));
+    EXPECT_SOFT_EQ(0.39494589680653375, calc_coulomb_correction(92));
 }
 
 /*!
@@ -56,7 +56,6 @@ TEST(MaterialUtils, radiation_length)
     auto calc_inv_rad_coeff
         = [](int atomic_number, real_type amu_mass) -> real_type {
         ElementDef el;
-        std::memset(&el, 0, sizeof(el));
         el.atomic_number      = atomic_number;
         el.atomic_mass        = units::AmuMass{amu_mass};
         el.coulomb_correction = detail::calc_coulomb_correction(atomic_number);
@@ -146,14 +145,13 @@ TEST_F(MaterialTest, material_view)
     auto host_ptrs = params->host_pointers();
     {
         // NaI
-        // TODO: update density and check against geant4 values
         MaterialView mat(host_ptrs, MaterialDefId{0});
         EXPECT_SOFT_EQ(2.948915064677e+22, mat.number_density());
         EXPECT_SOFT_EQ(293.0, mat.temperature());
         EXPECT_EQ(MatterState::solid, mat.matter_state());
         EXPECT_SOFT_EQ(3.6700020622594716, mat.density());
         EXPECT_SOFT_EQ(9.4365282069663997e+23, mat.electron_density());
-        EXPECT_SOFT_EQ(3.5393299034472663, mat.radiation_length());
+        EXPECT_SOFT_EQ(3.5393292693170424, mat.radiation_length());
 
         // Test element view
         auto els = mat.elements();
@@ -186,7 +184,7 @@ TEST_F(MaterialTest, material_view)
         EXPECT_EQ(MatterState::gas, mat.matter_state());
         EXPECT_SOFT_EQ(0.00017976, mat.density());
         EXPECT_SOFT_EQ(1.0739484359044669e+20, mat.electron_density());
-        EXPECT_SOFT_EQ(350729.99844568834, mat.radiation_length());
+        EXPECT_SOFT_EQ(350729.99844063615, mat.radiation_length());
 
         // Test element view
         auto els = mat.elements();
@@ -205,8 +203,8 @@ TEST_F(MaterialTest, element_view)
         EXPECT_SOFT_EQ(std::pow(13.0, 1.0 / 3), el.cbrt_z());
         EXPECT_SOFT_EQ(std::pow(13.0 * 14.0, 1.0 / 3), el.cbrt_zzp());
         EXPECT_SOFT_EQ(std::log(13.0), el.log_z());
-        EXPECT_SOFT_EQ(0.010734662857664759, el.coulomb_correction());
-        EXPECT_SOFT_EQ(0.041647232662906583, el.mass_radiation_coeff());
+        EXPECT_SOFT_EQ(0.010734632775699565, el.coulomb_correction());
+        EXPECT_SOFT_EQ(0.04164723292591279, el.mass_radiation_coeff());
     }
 }
 
@@ -238,7 +236,8 @@ TEST_F(MaterialDeviceTest, all)
     auto result = m_test(input);
 
     const double expected_temperatures[] = {293, 0, 100};
-    const double expected_rad_len[] = {3.53932990344727, inf, 350729.998445688};
+    const double expected_rad_len[]
+        = {3.5393292693170424, inf, 350729.99844063615};
     const double expected_tot_z[]
         = {9.4365282069664e+23, 0, 1.07394843590447e+20};
 


### PR DESCRIPTION
The coulomb correction factor in the review of particle physics (and implemented in geant in multiple places) uses a couple of magic numbers which are actually values from an infinite series expansion as derived in https://arxiv.org/abs/1204.3675v3 . This MR adds the Coulomb correction factor to the element definition data and the ElementView, and then (in a separate commit) implements a more accurate form calculated in [this python script](https://github.com/celeritas-project/celeritas-docs/blob/master/notes/coulomb-correction/eval.py).