### PR TITLE
Infrastructure: improved GPU and MPI granularity

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,34 +1,50 @@
 pipeline {
-    triggers {
-        issueCommentTrigger('.*do: test')
-    }
-    agent none
-
-    environment {
-        CTEST_ARGS = '--timeout 180 --no-compress-output -T Test --test-output-size-passed=65536 --test-output-size-failed=1048576'
-    }
-    stages {
-        stage('Build') {
-            parallel {
-                stage('cuda-11') {
-                    agent {
-                        docker {
-                            image 'celeritas/ci-cuda11:latest'
-                            label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
-                        }
-                    }
-                    steps {
-                        sh 'rm -rf build && mkdir -p build'
-                        sh 'SOURCE_DIR=. BUILD_DIR=build entrypoint-shell ./scripts/build/docker.sh'
-                    }
-                    post {
-                        always {
-                            xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
-                        }
-                    }
-                }
+  triggers {
+    issueCommentTrigger('.*do: test')
+  }
+  agent none
+  environment {
+    CTEST_ARGS = '--timeout 180 --no-compress-output -T Test --test-output-size-passed=65536 --test-output-size-failed=1048576'
+  }
+  stages {
+    stage('Build') {
+      parallel {
+        stage('minimal') {
+          agent {
+            docker {
+              image 'celeritas/ci-cuda11:latest'
+              // Note: this image does not require CUDA
             }
+          }
+          steps {
+            sh 'rm -rf build && mkdir -p build'
+            sh 'SOURCE_DIR=. BUILD_DIR=build entrypoint-shell ./scripts/build/docker-minimal.sh'
+          }
+          post {
+            always {
+              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
+            }
+          }
         }
+        stage('cuda-11') {
+          agent {
+            docker {
+              image 'celeritas/ci-cuda11:latest'
+              label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
+            }
+          }
+          steps {
+            sh 'rm -rf build && mkdir -p build'
+            sh 'SOURCE_DIR=. BUILD_DIR=build entrypoint-shell ./scripts/build/docker.sh'
+          }
+          post {
+            always {
+              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
+            }
+          }
+        }
+      }
     }
+  }
 }
-
+// vim: set ft=groovy ts=2 sw=2 :

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -87,8 +87,13 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA)
       COMMAND "${Python_EXECUTABLE}"
         "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py"
     )
+    set(_env
+      "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-interactor>"
+      "CELER_DISABLE_PARALLEL=1"
+    )
     set_tests_properties("app/demo-interactor" PROPERTIES
-      ENVIRONMENT "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-interactor>"
+      ENVIRONMENT "${_env}"
+      RESOURCE_LOCK gpu
     )
   endif()
 
@@ -150,8 +155,13 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
       COMMAND "${Python_EXECUTABLE}"
         "${CMAKE_CURRENT_SOURCE_DIR}/demo-rasterizer/simple-driver.py"
     )
+    set(_env
+      "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-rasterizer>"
+      "CELER_DISABLE_PARALLEL=1"
+    )
     set_tests_properties("app/demo-rasterizer" PROPERTIES
-      ENVIRONMENT "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-rasterizer>"
+      ENVIRONMENT "${_env}"
+      RESOURCE_LOCK gpu
     )
   endif()
 endif()

--- a/app/demo-interactor/KNDemoKernel.cu
+++ b/app/demo-interactor/KNDemoKernel.cu
@@ -14,7 +14,7 @@
 #include "physics/base/ParticleTrackView.hh"
 #include "physics/base/SecondaryAllocatorView.hh"
 #include "physics/em/KleinNishinaInteractor.hh"
-#include "random/cuda/RngEngine.cuh"
+#include "random/cuda/RngEngine.hh"
 #include "random/distributions/ExponentialDistribution.hh"
 #include "PhysicsArrayCalculator.hh"
 #include "DetectorView.hh"

--- a/app/demo-interactor/demo-interactor.cc
+++ b/app/demo-interactor/demo-interactor.cc
@@ -57,7 +57,7 @@ void run(std::istream& is)
     auto inp = nlohmann::json::parse(is);
 
     // Initialize GPU
-    celeritas::initialize_device(Communicator::comm_world());
+    celeritas::initialize_device(Communicator{});
 
     // Construct runner
     auto         grid_params = inp.at("grid_params").get<CudaGridParams>();
@@ -86,7 +86,8 @@ void run(std::istream& is)
 int main(int argc, char* argv[])
 {
     ScopedMpiInit scoped_mpi(&argc, &argv);
-    if (Communicator::comm_world().size() != 1)
+    if (ScopedMpiInit::status() == ScopedMpiInit::Status::initialized
+        && Communicator::comm_world().size() > 1)
     {
         CELER_LOG(critical) << "This app cannot run in parallel";
         return EXIT_FAILURE;

--- a/app/demo-interactor/demo-interactor.cc
+++ b/app/demo-interactor/demo-interactor.cc
@@ -14,9 +14,9 @@
 #include <vector>
 #include <nlohmann/json.hpp>
 #include "comm/Communicator.hh"
+#include "comm/Device.hh"
 #include "comm/Logger.hh"
 #include "comm/ScopedMpiInit.hh"
-#include "comm/Utils.hh"
 #include "physics/base/ParticleParams.hh"
 #include "KNDemoIO.hh"
 #include "KNDemoRunner.hh"
@@ -97,6 +97,12 @@ int main(int argc, char* argv[])
     if (args.size() != 2 || args[1] == "--help" || args[1] == "-h")
     {
         cerr << "usage: " << args[0] << " {input}.json" << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (!celeritas::is_device_enabled())
+    {
+        CELER_LOG(critical) << "CUDA capability is disabled";
         return EXIT_FAILURE;
     }
 

--- a/app/demo-interactor/host-demo-interactor.cc
+++ b/app/demo-interactor/host-demo-interactor.cc
@@ -16,7 +16,6 @@
 #include "comm/Communicator.hh"
 #include "comm/Logger.hh"
 #include "comm/ScopedMpiInit.hh"
-#include "comm/Utils.hh"
 #include "physics/base/ParticleParams.hh"
 #include "LoadXs.hh"
 #include "KNDemoIO.hh"

--- a/app/demo-rasterizer/demo-rasterizer.cc
+++ b/app/demo-rasterizer/demo-rasterizer.cc
@@ -14,9 +14,9 @@
 #include "base/ColorUtils.hh"
 #include "base/Range.hh"
 #include "comm/Communicator.hh"
+#include "comm/Device.hh"
 #include "comm/Logger.hh"
 #include "comm/ScopedMpiInit.hh"
-#include "comm/Utils.hh"
 #include "RDemoRunner.hh"
 
 using namespace celeritas;
@@ -120,6 +120,12 @@ int main(int argc, char* argv[])
     {
         // Read input from STDIN
         instream_ptr = &std::cin;
+    }
+
+    if (!celeritas::is_device_enabled())
+    {
+        CELER_LOG(critical) << "CUDA capability is disabled";
+        return EXIT_FAILURE;
     }
 
     try

--- a/app/demo-rasterizer/demo-rasterizer.cc
+++ b/app/demo-rasterizer/demo-rasterizer.cc
@@ -36,7 +36,7 @@ void run(std::istream& is)
     auto inp = nlohmann::json::parse(is);
 
     // Initialize GPU
-    celeritas::initialize_device(Communicator::comm_world());
+    celeritas::initialize_device(Communicator{});
 
     // Load geometry
     auto geo_params = std::make_shared<GeoParams>(
@@ -90,7 +90,8 @@ void run(std::istream& is)
 int main(int argc, char* argv[])
 {
     ScopedMpiInit scoped_mpi(&argc, &argv);
-    if (Communicator::comm_world().size() != 1)
+    if (ScopedMpiInit::status() == ScopedMpiInit::Status::initialized
+        && Communicator::comm_world().size() > 1)
     {
         CELER_LOG(critical) << "This app cannot run in parallel";
         return EXIT_FAILURE;

--- a/app/geant-exporter/geant-exporter-cat.cc
+++ b/app/geant-exporter/geant-exporter-cat.cc
@@ -45,8 +45,8 @@ int main(int argc, char* argv[])
     }
     catch (const DebugError& e)
     {
-        cout << "Exception while read ROOT file'" << argv[1] << "':\n"
-             << e.what();
+        cout << "Exception while reading ROOT file'" << argv[1] << "':\n"
+             << e.what() << endl;
         return EXIT_FAILURE;
     }
 

--- a/app/geant-exporter/geant-exporter.cc
+++ b/app/geant-exporter/geant-exporter.cc
@@ -303,8 +303,10 @@ void store_geometry(TFile*                       root_file,
  */
 int main(int argc, char* argv[])
 {
-    celeritas::ScopedMpiInit scoped_mpi(&argc, &argv);
-    if (celeritas::Communicator::comm_world().size() != 1)
+    using namespace celeritas;
+    ScopedMpiInit scoped_mpi(&argc, &argv);
+    if (ScopedMpiInit::status() == ScopedMpiInit::Status::initialized
+        && Communicator::comm_world().size() > 1)
     {
         CELER_LOG(critical) << "This app cannot run in parallel";
         return EXIT_FAILURE;

--- a/cmake/CeleritasAddTest.cmake
+++ b/cmake/CeleritasAddTest.cmake
@@ -323,6 +323,13 @@ function(celeritas_add_test SOURCE_FILE)
     list(APPEND PARSE_ENVIRONMENT "PYTHONPATH=${CELERITASTEST_PYTHONPATH}")
   endif()
 
+  if(CELERITAS_DEBUG)
+    list(APPEND PARSE_ENVIRONMENT
+      "CELER_LOG=debug"
+      "CELER_LOG_LOCAL=diagnostic"
+    )
+  endif()
+
   if(NOT PARSE_FILTER)
     # Set to a non-empty but false value
     set(PARSE_FILTER "OFF")

--- a/cmake/CeleritasAddTest.cmake
+++ b/cmake/CeleritasAddTest.cmake
@@ -49,10 +49,10 @@ Add a CUDA/C++ GoogleTest test::
       <filename>
       [TIMEOUT seconds]
       [NP n1 [n2 ...]]
-      [DEPLIBS lib1 [lib2 ...]]
+      [LINK_LIBRARIES lib1 [lib2 ...]]
       [DEPTEST deptest]
       [SUFFIX text]
-      [DEPENDS target1 [target2 ...]]
+      [ADD_DEPENDENCIES target1 [target2 ...]]
       [ARGS arg1 [arg2 ...]]
       [ENVIRONMENT VAR=value [VAR2=value2 ...]]
       [FILTER test1 [test2 ...]]
@@ -72,11 +72,11 @@ Add a CUDA/C++ GoogleTest test::
       is to use CELERITASTEST_NP (1, 2, and 4) for MPI builds and 1 for
       serial builds.
 
-    ``DEPLIBS``
+    ``LINK_LIBRARIES``
       Extra libraries to link to. By default, unit tests will link against the
       package's current library.
 
-    ``DEPENDS``
+    ``ADD_DEPENDENCIES``
       Extra dependencies for building the execuatable, e.g.  preprocessing data
       or copying files.
 
@@ -243,7 +243,7 @@ function(celeritas_add_test SOURCE_FILE)
   cmake_parse_arguments(PARSE
     "ISOLATE;DISABLE;DRIVER;REUSE_EXE"
     "TIMEOUT;DEPTEST;SUFFIX"
-    "DEPLIBS;DEPENDS;NP;ENVIRONMENT;ARGS;INPUTS;FILTER;SOURCES"
+    "LINK_LIBRARIES;ADD_DEPENDENCIES;NP;ENVIRONMENT;ARGS;INPUTS;FILTER;SOURCES"
     ${ARGN}
   )
 
@@ -308,12 +308,12 @@ function(celeritas_add_test SOURCE_FILE)
     add_executable(${_TARGET} "${SOURCE_FILE}" ${PARSE_SOURCES})
     target_link_libraries(${_TARGET}
       ${CELERITASTEST_LINK_LIBRARIES}
-      ${PARSE_DEPLIBS}
+      ${PARSE_LINK_LIBRARIES}
       Celeritas::Test)
 
-    if(PARSE_DEPENDS OR CELERITASTEST_ADD_DEPENDENCIES)
+    if(PARSE_ADD_DEPENDENCIES OR CELERITASTEST_ADD_DEPENDENCIES)
       # Add additional dependencies
-      add_dependencies(${_TARGET} ${PARSE_DEPENDS}
+      add_dependencies(${_TARGET} ${PARSE_ADD_DEPENDENCIES}
         ${CELERITASTEST_ADD_DEPENDENCIES})
     endif()
   endif()
@@ -366,7 +366,7 @@ function(celeritas_add_test SOURCE_FILE)
         _celeritasaddtest_test_name(_deptest_name
           "${PARSE_DEPTEST}" "${_np}" "${_suffix}")
         set_property(TEST "${_TEST_NAME}"
-          PROPERTY DEPENDS "${_deptest_name}")
+          PROPERTY ADD_DEPENDENCIES "${_deptest_name}")
       endif()
 
       if(PARSE_ISOLATE)

--- a/scripts/build/docker-minimal.sh
+++ b/scripts/build/docker-minimal.sh
@@ -1,0 +1,55 @@
+#!/bin/sh -e
+
+if [ -z "${SOURCE_DIR}" ]; then
+  BUILDSCRIPT_DIR="$(cd "$(dirname $BASH_SOURCE[0])" && pwd)"
+  SOURCE_DIR="$(cd "${BUILDSCRIPT_DIR}" && git rev-parse --show-toplevel)"
+else
+  SOURCE_DIR="$(cd "${SOURCE_DIR}" && pwd)"
+fi
+if [ -z "${BUILD_DIR}" ]; then
+  : ${BUILD_SUBDIR:=build}
+  BUILD_DIR=${SOURCE_DIR}/${BUILD_SUBDIR}
+fi
+: ${CTEST_ARGS:=--output-on-failure}
+CTEST_ARGS="-j$(grep -c processor /proc/cpuinfo) ${CTEST_ARGS}"
+
+printf "\e[2;37mBuilding in ${BUILD_DIR}\e[0m\n"
+mkdir ${BUILD_DIR} 2>/dev/null \
+  || printf "\e[2;37m... from existing cache\e[0m\n"
+cd ${BUILD_DIR}
+
+_sw=/opt/software/linux-ubuntu20.04-x86_64/gcc-9.3.0
+
+set -x
+export CXXFLAGS="-Wall -Wextra -pedantic -Werror"
+export PATH\
+=${_sw}/cmake-3.18.4-liggd6utlx54xhzls3uypu3adngo6xe5/bin\
+:${_sw}/ninja-1.10.1-757xwyeqsyltrq4cuvnqzoe72dvtbuhr/bin\
+:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export CMAKE_PREFIX_PATH\
+=${_sw}/googletest-1.10.0-wd3am66hewqoxavcg66hoezbbmhtcgi5
+
+# Clear automatic include/link to catch unintentional use of `/opt/view` etc
+export CPLUS_INCLUDE_PATH=
+export C_INCLUDE_PATH=
+export INCLUDE_PATH=
+export LIBRARY_PATH=
+export LD_LIBRARY_PATH=
+
+# Note: cuda_arch must match the spack.yaml file for the docker image, which
+# must match the hardware being used.
+cmake -G Ninja \
+  -DCELERITAS_BUILD_DEMOS:BOOL=OFF \
+  -DCELERITAS_BUILD_TESTS:BOOL=ON \
+  -DCELERITAS_GIT_SUBMODULE:BOOL=OFF \
+  -DCELERITAS_USE_CUDA:BOOL=OFF \
+  -DCELERITAS_USE_Geant4:BOOL=OFF \
+  -DCELERITAS_USE_HepMC3:BOOL=OFF \
+  -DCELERITAS_USE_MPI:BOOL=OFF \
+  -DCELERITAS_USE_ROOT:BOOL=OFF \
+  -DCELERITAS_USE_VecGeom:BOOL=OFF \
+  -DCELERITAS_DEBUG:BOOL=ON \
+  -DCMAKE_BUILD_TYPE:STRING="Debug" \
+  ${SOURCE_DIR}
+ninja -v -k0
+ctest $CTEST_ARGS

--- a/scripts/build/docker.sh
+++ b/scripts/build/docker.sh
@@ -11,6 +11,7 @@ if [ -z "${BUILD_DIR}" ]; then
   BUILD_DIR=${SOURCE_DIR}/${BUILD_SUBDIR}
 fi
 : ${CTEST_ARGS:=--output-on-failure}
+CTEST_ARGS="-j$(grep -c processor /proc/cpuinfo) ${CTEST_ARGS}"
 
 printf "\e[2;37mBuilding in ${BUILD_DIR}\e[0m\n"
 mkdir ${BUILD_DIR} 2>/dev/null \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,6 @@ list(APPEND SOURCES
   base/ColorUtils.cc
   comm/Logger.cc
   comm/LoggerTypes.cc
-  comm/Utils.cc
   comm/detail/LoggerMessage.cc
   physics/base/ParticleParams.cc
   physics/base/ParticleStateStore.cc
@@ -46,6 +45,7 @@ if(CELERITAS_USE_CUDA)
     base/DeviceAllocation.cuda.cc
     base/KernelParamCalculator.cuda.cc
     base/Memory.cu
+    comm/Device.cuda.cc
     random/cuda/detail/RngStateInit.cu
   )
   list(APPEND PRIVATE_DEPS CUDA::cudart)
@@ -53,6 +53,7 @@ else()
   list(APPEND SOURCES
     base/DeviceAllocation.nocuda.cc
     base/Memory.nocuda.cc
+    comm/Device.nocuda.cc
     random/cuda/curand.nocuda.cc
     random/cuda/detail/RngStateInit.nocuda.cc
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND SOURCES
   physics/material/MaterialParams.cc
   physics/material/MaterialStateStore.cc
   physics/material/detail/Utils.cc
+  random/cuda/RngStateStore.cc
 )
 
 if(CELERITAS_USE_CUDA)
@@ -45,14 +46,15 @@ if(CELERITAS_USE_CUDA)
     base/DeviceAllocation.cuda.cc
     base/KernelParamCalculator.cuda.cc
     base/Memory.cu
-    random/cuda/RngStateInit.cu
-    random/cuda/RngStateStore.cc
+    random/cuda/detail/RngStateInit.cu
   )
   list(APPEND PRIVATE_DEPS CUDA::cudart)
 else()
   list(APPEND SOURCES
     base/DeviceAllocation.nocuda.cc
     base/Memory.nocuda.cc
+    random/cuda/curand.nocuda.cc
+    random/cuda/detail/RngStateInit.nocuda.cc
   )
 endif()
 
@@ -96,6 +98,7 @@ endif()
 
 add_library(celeritas ${SOURCES})
 add_library(Celeritas::Core ALIAS celeritas)
+
 target_link_libraries(celeritas
   PRIVATE ${PRIVATE_DEPS}
   PUBLIC ${PUBLIC_DEPS}

--- a/src/base/DeviceAllocation.cuda.cc
+++ b/src/base/DeviceAllocation.cuda.cc
@@ -9,6 +9,7 @@
 
 #include <cuda_runtime_api.h>
 #include "Assert.hh"
+#include "comm/Device.hh"
 
 namespace celeritas
 {
@@ -19,6 +20,7 @@ namespace celeritas
 DeviceAllocation::DeviceAllocation(size_type bytes) : size_(bytes)
 {
     REQUIRE(bytes > 0);
+    REQUIRE(is_device_enabled());
     void* ptr = nullptr;
     CELER_CUDA_CALL(cudaMalloc(&ptr, bytes));
     data_.reset(static_cast<byte*>(ptr));

--- a/src/base/Macros.hh
+++ b/src/base/Macros.hh
@@ -87,7 +87,7 @@
  * or https://msdn.microsoft.com/en-us/library/1b3fsfxw.aspx=
  *
  * \note This macro is usually unused; instead, the macro \c
- * CELER_CHECK_UNREACHABLE defined in DBC.hh should be used instead (to provide
+ * CHECK_UNREACHABLE defined in DBC.hh should be used instead (to provide
  * a more detailed error message in case the point *is* reached).
  */
 #if defined(__clang__) || defined(__GNUC__)

--- a/src/comm/Communicator.hh
+++ b/src/comm/Communicator.hh
@@ -7,23 +7,37 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "MpiTypes.hh"
+#include "detail/MpiTypes.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
  * Abstraction of an MPI communicator.
+ *
+ * A "null" communicator (the default) does not use MPI calls and can be
+ * constructed without calling \c MPI_Init or having MPI compiled. It will act
+ * like MPI_Comm_Self but will not actually use MPI calls.
  */
 class Communicator
 {
   public:
+    //@{
+    //! Type aliases
+    using MpiComm = detail::MpiComm;
+    //@}
+
+  public:
     // Construct a communicator with MPI_COMM_SELF
-    static Communicator comm_self();
+    inline static Communicator comm_self();
+
     // Construct a communicator with MPI_COMM_WORLD
-    static Communicator comm_world();
+    inline static Communicator comm_world();
 
     /// CONSTRUCTORS ///
+
+    // Construct with a null communicator (MPI is disabled)
+    Communicator() = default;
 
     // Construct with a native MPI communicator
     explicit Communicator(MpiComm comm);
@@ -36,20 +50,33 @@ class Communicator
     //! Get the local process ID
     int rank() const { return rank_; }
 
-    //! Get the number of total processors
-    int size() const { return size_; };
+    // Get the number of total processors
+    int size() const { return size_; }
+
+    //! True if non-null communicator
+    explicit operator bool() const { return comm_ != detail::MpiCommNull(); }
 
   private:
-    MpiComm comm_;
-    int     rank_;
-    int     size_;
+    MpiComm comm_ = detail::MpiCommNull();
+    int     rank_ = 0;
+    int     size_ = 1;
 };
 
 //---------------------------------------------------------------------------//
-// FREE FUNCTIONS
+// INLINE FUNCTION DEFINITIONS
 //---------------------------------------------------------------------------//
-// Wait for all processes in this communicator to reach the barrier
-void barrier(const Communicator& comm);
+//! Construct a communicator with MPI_COMM_SELF
+Communicator Communicator::comm_self()
+{
+    return Communicator{detail::MpiCommSelf()};
+}
+
+//---------------------------------------------------------------------------//
+//! Construct a communicator with MPI_COMM_WORLD
+Communicator Communicator::comm_world()
+{
+    return Communicator{detail::MpiCommWorld()};
+}
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/comm/Communicator.mpi.cc
+++ b/src/comm/Communicator.mpi.cc
@@ -14,29 +14,12 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with a "self" MPI communicator: always world size of 1
+ * Construct with a native MPI communicator.
  */
-Communicator Communicator::comm_self()
+Communicator::Communicator(MpiComm comm) : comm_(comm)
 {
-    return Communicator(MPI_COMM_SELF);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct with a "world" MPI communicator: always global size
- */
-Communicator Communicator::comm_world()
-{
-    return Communicator(MPI_COMM_WORLD);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct with a native MPI communicator
- */
-Communicator::Communicator(MpiComm comm) : comm_(comm), rank_(-1), size_(-1)
-{
-    REQUIRE(ScopedMpiInit::initialized());
+    REQUIRE(comm != detail::MpiCommNull());
+    REQUIRE(ScopedMpiInit::status() == ScopedMpiInit::Status::initialized);
 
     // Save rank and size
     int err;
@@ -46,18 +29,6 @@ Communicator::Communicator(MpiComm comm) : comm_(comm), rank_(-1), size_(-1)
     CHECK(err == MPI_SUCCESS);
 
     ENSURE(this->rank() >= 0 && this->rank() < this->size());
-}
-
-//---------------------------------------------------------------------------//
-// FREE FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- * Wait for all processes in this communicator to reach the barrier.
- */
-void barrier(const Communicator& comm)
-{
-    int err = MPI_Barrier(comm.mpi_comm());
-    CHECK(err == MPI_SUCCESS);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/comm/Communicator.nompi.cc
+++ b/src/comm/Communicator.nompi.cc
@@ -8,46 +8,17 @@
 #include "Communicator.hh"
 
 #include "base/Assert.hh"
-#include "ScopedMpiInit.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with a "self" MPI communicator: always world size of 1
- */
-Communicator Communicator::comm_self()
-{
-    return Communicator(MpiComm{1});
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct with a "world" MPI communicator: always global size
- */
-Communicator Communicator::comm_world()
-{
-    return Communicator(MpiComm{2});
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Construct with a native MPI communicator
  */
-Communicator::Communicator(MpiComm comm) : comm_(comm), rank_(0), size_(1)
+Communicator::Communicator(MpiComm)
 {
-    REQUIRE(ScopedMpiInit::initialized());
-
-    ENSURE(this->rank() >= 0 && this->rank() < this->size());
+    throw DebugError("Cannot build a communicator because MPI is disabled");
 }
-
-//---------------------------------------------------------------------------//
-// FREE FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- * Wait for all processes in this communicator to reach the barrier.
- */
-void barrier(const Communicator&) {}
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/comm/Device.cuda.cc
+++ b/src/comm/Device.cuda.cc
@@ -1,0 +1,80 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Device.cc
+//---------------------------------------------------------------------------//
+#include "Device.hh"
+
+#include <cstdlib>
+#include <cuda_runtime_api.h>
+#include "base/Assert.hh"
+#include "comm/Logger.hh"
+
+namespace
+{
+//---------------------------------------------------------------------------//
+// HELPER FUNCTIONS
+//---------------------------------------------------------------------------//
+bool determine_device_enable()
+{
+    const char* disable = std::getenv("CELER_DISABLE_DEVICE");
+    if (disable && disable[0] != '\0')
+    {
+        CELER_LOG(info)
+            << "Disabling GPU support since the 'CELER_DISABLE_DEVICE' "
+               "environment variable is present and non-empty";
+        return false;
+    }
+    int num_devices = -1;
+    cudaGetDeviceCount(&num_devices);
+    if (num_devices <= 0)
+    {
+        CELER_LOG(warning) << "Disabling GPU support since no CUDA devices "
+                              "are present";
+        return false;
+    }
+    return true;
+}
+} // namespace
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Determine whether the CUDA device is enabled.
+ *
+ * This is true if and only if CUDA support is built-in, if at least one
+ * CUDA-capable device is present, and if the 'CELER_DISABLE_DEVICE'
+ * environment variable is not set.
+ */
+bool is_device_enabled()
+{
+    static const bool result = determine_device_enable();
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Initialize device in a round-robin fashion from a communicator.
+ */
+void initialize_device(const Communicator& comm)
+{
+    if (!is_device_enabled())
+        return;
+
+    // Get number of devices
+    int num_devices = -1;
+    CELER_CUDA_CALL(cudaGetDeviceCount(&num_devices));
+    CHECK(num_devices > 0);
+
+    // Set device based on communicator
+    int device_id = comm.rank() % num_devices;
+    CELER_LOG_LOCAL(debug) << "Initializing device ID " << device_id << " of "
+                           << num_devices;
+    CELER_CUDA_CALL(cudaSetDevice(device_id));
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/comm/Device.hh
+++ b/src/comm/Device.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file Utils.hh
+//! \file Device.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -11,6 +11,10 @@
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+// Whether device code should be used
+bool is_device_enabled();
+
 //---------------------------------------------------------------------------//
 // Initialize device in a round-robin fashion from a communicator
 void initialize_device(const Communicator& comm);

--- a/src/comm/Device.nocuda.cc
+++ b/src/comm/Device.nocuda.cc
@@ -3,34 +3,25 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file Utils.cuda.cc
+//! \file Device.nocuda.cc
 //---------------------------------------------------------------------------//
-#include "Utils.hh"
-
-#include "celeritas_config.h"
-#if CELERITAS_USE_CUDA
-#    include <cuda_runtime_api.h>
-#endif
-#include "base/Assert.hh"
+#include "Device.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-// Initialize device in a round-robin fashion from a communicator
-void initialize_device(const Communicator& comm)
-{
-#if CELERITAS_USE_CUDA
-    // Get number of devices
-    int num_devices = -1;
-    CELER_CUDA_CALL(cudaGetDeviceCount(&num_devices));
-    CHECK(num_devices > 0);
+/*!
+ * No device initialization takes place since CUDA is disabled.
+ */
+void initialize_device(const Communicator&) {}
 
-    // Set device based on communicator
-    int device_id = comm.rank() % num_devices;
-    CELER_CUDA_CALL(cudaSetDevice(device_id));
-#else
-    (void)sizeof(comm);
-#endif
+//---------------------------------------------------------------------------//
+/*!
+ * CUDA is not enabled.
+ */
+bool is_device_enabled()
+{
+    return false;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/comm/Logger.hh
+++ b/src/comm/Logger.hh
@@ -62,7 +62,9 @@ class Logger
 {
   public:
     // Construct with communicator (only rank zero is active) and handler
-    Logger(const Communicator& comm, LogHandler handle);
+    Logger(const Communicator& comm,
+           LogHandler          handle,
+           const char*         level_env = NULL);
 
     // Create a logger that flushes its contents when it destructs
     inline detail::LoggerMessage operator()(Provenance prov, LogLevel lev);

--- a/src/comm/LoggerTypes.hh
+++ b/src/comm/LoggerTypes.hh
@@ -24,7 +24,8 @@ enum class LogLevel
     info,       //!< Important informational messages
     warning,    //!< Warnings about unusual events
     error,      //!< Something went wrong, but execution continues
-    critical    //!< Something went terribly wrong; we're aborting now! Bye!
+    critical,   //!< Something went terribly wrong; we're aborting now! Bye!
+    size_       //!< Sentinel value for looping over log levels
 };
 
 //---------------------------------------------------------------------------//

--- a/src/comm/Operations.hh
+++ b/src/comm/Operations.hh
@@ -1,0 +1,54 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Operations.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <type_traits>
+#include "base/Span.hh"
+#include "Communicator.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+// TYPES
+//---------------------------------------------------------------------------//
+enum class Operation
+{
+    min,
+    max,
+    sum,
+    prod,
+};
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+// Wait for all processes in this communicator to reach the barrier
+inline void barrier(const Communicator& comm);
+
+//---------------------------------------------------------------------------//
+// All-to-all reduction on the data from src to dst
+template<class T, std::size_t N>
+inline void allreduce(const Communicator& comm,
+                      Operation           op,
+                      span<const T, N>    src,
+                      span<T, N>          dst);
+
+//---------------------------------------------------------------------------//
+// All-to-all reduction on the data, in place
+template<class T, std::size_t N>
+inline void allreduce(const Communicator& comm, Operation op, span<T, N> data);
+
+//---------------------------------------------------------------------------//
+// Perform reduction on a fundamental scalar and return the result
+template<class T, std::enable_if_t<std::is_fundamental<T>::value, T*> = nullptr>
+inline T allreduce(const Communicator& comm, Operation op, const T src);
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "Operations.i.hh"

--- a/src/comm/Operations.i.hh
+++ b/src/comm/Operations.i.hh
@@ -1,0 +1,89 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Operations.mpi.i.hh
+//---------------------------------------------------------------------------//
+#include "Operations.hh"
+
+#include <algorithm>
+#include "celeritas_config.h"
+#include "base/Assert.hh"
+#if CELERITAS_USE_MPI
+#    include "detail/Operations.mpi.hh"
+#endif
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Wait for all processes in this communicator to reach the barrier.
+ */
+void barrier(const Communicator& comm)
+{
+    if (!comm)
+        return;
+
+#if CELERITAS_USE_MPI
+    return detail::barrier(comm);
+#endif
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * All-to-all reduction on the data from src to dst.
+ */
+template<class T, std::size_t N>
+void allreduce(const Communicator& comm,
+               Operation           op,
+               span<const T, N>    src,
+               span<T, N>          dst)
+{
+    REQUIRE(src.size() == dst.size());
+
+    if (!comm)
+    {
+        std::copy(src.begin(), src.end(), dst.begin());
+        return;
+    }
+
+#if CELERITAS_USE_MPI
+    return detail::allreduce(comm, op, span<const T>(src), span<T>(dst));
+#else
+    (void)sizeof(op);
+#endif
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * All-to-all reduction on the data, in place.
+ */
+template<class T, std::size_t N>
+void allreduce(const Communicator& comm, Operation op, span<T, N> data)
+{
+    if (!comm)
+        return;
+
+#if CELERITAS_USE_MPI
+    return detail::allreduce(comm, op, span<T>(data));
+#else
+    (void)sizeof(data);
+    (void)sizeof(op);
+#endif
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Perform reduction on a fundamental scalar and return the result.
+ */
+template<class T, std::enable_if_t<std::is_fundamental<T>::value, T*>>
+T allreduce(const Communicator& comm, Operation op, const T src)
+{
+    T dst{};
+    allreduce(comm, op, span<const T, 1>{&src, 1}, span<T, 1>{&dst, 1});
+    return dst;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/comm/ScopedMpiInit.hh
+++ b/src/comm/ScopedMpiInit.hh
@@ -16,6 +16,18 @@ namespace celeritas
 class ScopedMpiInit
 {
   public:
+    //! Status of initialization
+    enum class Status
+    {
+        disabled      = -1, //!< Not compiled *or* disabled via environment
+        uninitialized = 0,  //!< MPI_Init has not been called anywhere
+        initialized   = 1   //!< MPI_Init has been called somewhere
+    };
+
+    // Whether MPI has been initialized
+    static Status status();
+
+  public:
     // Construct with argc/argv references
     ScopedMpiInit(int* argc, char*** argv);
 
@@ -25,8 +37,8 @@ class ScopedMpiInit
     // Call MPI finalize on destruction
     ~ScopedMpiInit();
 
-    // Whether MPI has been initialized
-    static bool initialized();
+  private:
+    static Status status_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/comm/ScopedMpiInit.mpi.cc
+++ b/src/comm/ScopedMpiInit.mpi.cc
@@ -11,6 +11,8 @@
 #include <mpi.h>
 #include "base/Assert.hh"
 #include "base/Macros.hh"
+#include "base/Stopwatch.hh"
+#include "Logger.hh"
 #include "Logger.hh"
 
 namespace celeritas
@@ -36,10 +38,11 @@ ScopedMpiInit::ScopedMpiInit(int* argc, char*** argv)
             break;
         }
         case Status::uninitialized: {
-            int err = MPI_Init(argc, argv);
+            Stopwatch get_time;
+            int       err = MPI_Init(argc, argv);
             CHECK(err == MPI_SUCCESS);
-
             status_ = Status::initialized;
+            CELER_LOG(debug) << "MPI initialization took " << get_time() << "s";
             break;
         }
         case Status::initialized: {

--- a/src/comm/ScopedMpiInit.mpi.cc
+++ b/src/comm/ScopedMpiInit.mpi.cc
@@ -7,16 +7,18 @@
 //---------------------------------------------------------------------------//
 #include "ScopedMpiInit.hh"
 
+#include <cstdlib>
 #include <mpi.h>
 #include "base/Assert.hh"
-
-namespace
-{
-bool g_initialized = false;
-}
+#include "base/Macros.hh"
+#include "Logger.hh"
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+ScopedMpiInit::Status ScopedMpiInit::status_
+    = ScopedMpiInit::Status::uninitialized;
+
 //---------------------------------------------------------------------------//
 /*!
  * Construct with argc/argv references.
@@ -24,13 +26,31 @@ namespace celeritas
 ScopedMpiInit::ScopedMpiInit(int* argc, char*** argv)
 {
     REQUIRE((argc == nullptr) == (argv == nullptr));
-    REQUIRE(!ScopedMpiInit::initialized());
 
-    int err = MPI_Init(argc, argv);
-    CHECK(err == MPI_SUCCESS);
+    switch (ScopedMpiInit::status())
+    {
+        case Status::disabled: {
+            CELER_LOG(info)
+                << "Disabling MPI support since the 'CELER_DISABLE_PARALLEL' "
+                   "environment variable is present and non-empty";
+            break;
+        }
+        case Status::uninitialized: {
+            int err = MPI_Init(argc, argv);
+            CHECK(err == MPI_SUCCESS);
 
-    g_initialized = true;
-    ENSURE(ScopedMpiInit::initialized());
+            status_ = Status::initialized;
+            break;
+        }
+        case Status::initialized: {
+            CELER_LOG(warning) << "MPI was initialized before calling "
+                                  "ScopedMpiInit";
+            break;
+        }
+        default:
+            CHECK_UNREACHABLE;
+    }
+    ENSURE(status_ != Status::uninitialized);
 }
 
 //---------------------------------------------------------------------------//
@@ -39,27 +59,39 @@ ScopedMpiInit::ScopedMpiInit(int* argc, char*** argv)
  */
 ScopedMpiInit::~ScopedMpiInit()
 {
-    g_initialized = false;
-    int err       = MPI_Finalize();
-    ENSURE(err == MPI_SUCCESS);
+    if (status_ == Status::initialized)
+    {
+        status_ = Status::uninitialized;
+        int err = MPI_Finalize();
+        ENSURE(err == MPI_SUCCESS);
+    }
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether MPI has been initialized.
+ * Whether MPI has been initialized or disabled.
  */
-bool ScopedMpiInit::initialized()
+auto ScopedMpiInit::status() -> Status
 {
-    if (!g_initialized)
+    if (CELER_UNLIKELY(status_ == Status::uninitialized))
     {
-        // Allow for the case where another application has already initialized
-        // MPI.
-        int result = -1;
-        int err    = MPI_Initialized(&result);
-        CHECK(err == MPI_SUCCESS);
-        g_initialized = static_cast<bool>(result);
+        const char* disable = std::getenv("CELER_DISABLE_PARALLEL");
+        if (disable && disable[0] != '\0')
+        {
+            // MPI is disabled via an environment variable.
+            status_ = Status::disabled;
+        }
+        else
+        {
+            // Allow for the case where another application has already
+            // initialized MPI.
+            int result = -1;
+            int err    = MPI_Initialized(&result);
+            CHECK(err == MPI_SUCCESS);
+            status_ = result ? Status::initialized : Status::uninitialized;
+        }
     }
-    return g_initialized;
+    return status_;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/comm/ScopedMpiInit.nompi.cc
+++ b/src/comm/ScopedMpiInit.nompi.cc
@@ -9,41 +9,27 @@
 
 #include "base/Assert.hh"
 
-namespace
-{
-bool g_initialized = false;
-}
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with argc/argv references.
+ * Constructor is a null-op
  */
-ScopedMpiInit::ScopedMpiInit(int* argc, char*** argv)
-{
-    REQUIRE((argc == nullptr) == (argv == nullptr));
-    REQUIRE(!ScopedMpiInit::initialized());
-    g_initialized = true;
-    ENSURE(ScopedMpiInit::initialized());
-}
+ScopedMpiInit::ScopedMpiInit(int*, char***) {}
 
 //---------------------------------------------------------------------------//
 /*!
  * Call MPI finalize on destruction.
  */
-ScopedMpiInit::~ScopedMpiInit()
-{
-    g_initialized = false;
-}
+ScopedMpiInit::~ScopedMpiInit() = default;
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether MPI has been initialized.
+ * MPI is disabled for this build.
  */
-bool ScopedMpiInit::initialized()
+auto ScopedMpiInit::status() -> Status
 {
-    return g_initialized;
+    return ScopedMpiInit::Status::disabled;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/comm/detail/MpiTypes.hh
+++ b/src/comm/detail/MpiTypes.hh
@@ -1,0 +1,16 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file MpiTypes.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "celeritas_config.h"
+
+#if CELERITAS_USE_MPI
+#    include "./MpiTypes.mpi.i.hh"
+#else
+#    include "./MpiTypes.nompi.i.hh"
+#endif

--- a/src/comm/detail/MpiTypes.mpi.i.hh
+++ b/src/comm/detail/MpiTypes.mpi.i.hh
@@ -1,0 +1,61 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file MpiTypes.mpi.i.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <mpi.h>
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+using MpiComm = MPI_Comm;
+
+inline MpiComm MpiCommNull()
+{
+    return MPI_COMM_NULL;
+}
+inline MpiComm MpiCommWorld()
+{
+    return MPI_COMM_WORLD;
+}
+inline MpiComm MpiCommSelf()
+{
+    return MPI_COMM_SELF;
+}
+
+template<class T>
+struct MpiType;
+
+#define CELER_DEFINE_MPITYPE(T, MPI_ENUM)              \
+    template<>                                         \
+    struct MpiType<T>                                  \
+    {                                                  \
+        static MPI_Datatype get() { return MPI_ENUM; } \
+    }
+
+CELER_DEFINE_MPITYPE(bool, MPI_CXX_BOOL);
+CELER_DEFINE_MPITYPE(char, MPI_CHAR);
+CELER_DEFINE_MPITYPE(unsigned char, MPI_UNSIGNED_CHAR);
+CELER_DEFINE_MPITYPE(short, MPI_SHORT);
+CELER_DEFINE_MPITYPE(unsigned short, MPI_UNSIGNED_SHORT);
+CELER_DEFINE_MPITYPE(int, MPI_INT);
+CELER_DEFINE_MPITYPE(unsigned int, MPI_UNSIGNED);
+CELER_DEFINE_MPITYPE(long, MPI_LONG);
+CELER_DEFINE_MPITYPE(unsigned long, MPI_UNSIGNED_LONG);
+CELER_DEFINE_MPITYPE(long long, MPI_LONG_LONG);
+CELER_DEFINE_MPITYPE(unsigned long long, MPI_UNSIGNED_LONG_LONG);
+CELER_DEFINE_MPITYPE(float, MPI_FLOAT);
+CELER_DEFINE_MPITYPE(double, MPI_DOUBLE);
+CELER_DEFINE_MPITYPE(long double, MPI_LONG_DOUBLE);
+
+#undef CELER_DEFINE_MPITYPE
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/comm/detail/MpiTypes.nompi.i.hh
+++ b/src/comm/detail/MpiTypes.nompi.i.hh
@@ -3,39 +3,43 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file MpiTypes.hh
+//! \file MpiTypes.nompi.i.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "celeritas_config.h"
-#if CELERITAS_USE_MPI
-#    include <mpi.h>
-#endif
-
 namespace celeritas
 {
+namespace detail
+{
 //---------------------------------------------------------------------------//
-// MPI TYPES
-//---------------------------------------------------------------------------//
-#if CELERITAS_USE_MPI
-using MpiComm = MPI_Comm;
-#else
-
 struct MpiComm
 {
     int value_;
 };
 
-inline bool operator==(MpiComm a, MpiComm b)
+constexpr inline bool operator==(MpiComm a, MpiComm b)
 {
     return a.value_ == b.value_;
 }
 
-inline bool operator!=(MpiComm a, MpiComm b)
+constexpr inline bool operator!=(MpiComm a, MpiComm b)
 {
     return !(a == b);
 }
-#endif
+
+constexpr inline MpiComm MpiCommNull()
+{
+    return {0};
+}
+constexpr inline MpiComm MpiCommSelf()
+{
+    return {-1};
+}
+constexpr inline MpiComm MpiCommWorld()
+{
+    return {1};
+}
 
 //---------------------------------------------------------------------------//
+} // namespace detail
 } // namespace celeritas

--- a/src/comm/detail/Operations.mpi.hh
+++ b/src/comm/detail/Operations.mpi.hh
@@ -1,0 +1,86 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Operations.mpi.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <mpi.h>
+#include "base/Assert.hh"
+#include "MpiTypes.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+namespace
+{
+inline MPI_Op to_mpi(Operation op)
+{
+    switch (op)
+    {
+        // clang-format off
+        case Operation::min:  return MPI_MIN;
+        case Operation::max:  return MPI_MAX;
+        case Operation::sum:  return MPI_SUM;
+        case Operation::prod: return MPI_PROD;
+            // clang-format on
+    }
+    CHECK_UNREACHABLE;
+}
+} // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Wait for all processes in this communicator to reach the barrier.
+ */
+inline void barrier(const Communicator& comm)
+{
+    REQUIRE(comm);
+    int err = MPI_Barrier(comm.mpi_comm());
+    ENSURE(err == MPI_SUCCESS);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * All-to-all reduction on the data from src to dst.
+ */
+template<class T>
+inline void
+allreduce(const Communicator& comm, Operation op, span<const T> src, span<T> dst)
+{
+    REQUIRE(comm);
+    REQUIRE(src.size() == dst.size());
+
+    int err = MPI_Allreduce(src.data(),
+                            dst.data(),
+                            dst.size(),
+                            detail::MpiType<T>::get(),
+                            to_mpi(op),
+                            comm.mpi_comm());
+    ENSURE(err == MPI_SUCCESS);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * All-to-all reduction on the data, in place.
+ */
+template<class T>
+inline void allreduce(const Communicator& comm, Operation op, span<T> data)
+{
+    REQUIRE(comm);
+
+    int err = MPI_Allreduce(MPI_IN_PLACE,
+                            data.data(),
+                            data.size(),
+                            detail::MpiType<T>::get(),
+                            to_mpi(op),
+                            comm.mpi_comm());
+    ENSURE(err == MPI_SUCCESS);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/geometry/GeoStateStore.cc
+++ b/src/geometry/GeoStateStore.cc
@@ -13,6 +13,7 @@
 #include "base/Range.hh"
 #include "base/NumericLimits.hh"
 #include "base/Types.hh"
+#include "comm/Device.hh"
 #include "GeoParams.hh"
 #include "detail/VGCompatibility.hh"
 
@@ -25,6 +26,7 @@ namespace celeritas
 GeoStateStore::GeoStateStore(const GeoParams& geom, size_type size)
     : max_depth_(geom.max_depth())
 {
+    REQUIRE(celeritas::is_device_enabled());
     vgstate_   = detail::VGNavStateStore(size, max_depth_);
     vgnext_    = detail::VGNavStateStore(size, max_depth_);
     pos_       = DeviceVector<Real3>(size);

--- a/src/geometry/detail/VGNavStateStore.cuda.cc
+++ b/src/geometry/detail/VGNavStateStore.cuda.cc
@@ -9,6 +9,7 @@
 
 #include <VecGeom/navigation/NavStatePool.h>
 #include "base/Assert.hh"
+#include "comm/Device.hh"
 
 namespace celeritas
 {
@@ -30,6 +31,7 @@ VGNavStateStore::VGNavStateStore(size_type size, int depth)
 void VGNavStateStore::copy_to_device()
 {
     REQUIRE(*this);
+    REQUIRE(celeritas::is_device_enabled());
     pool_->CopyToGpu();
     CELER_CUDA_CALL(cudaDeviceSynchronize());
 }

--- a/src/physics/base/ParticleParams.cc
+++ b/src/physics/base/ParticleParams.cc
@@ -8,6 +8,7 @@
 #include "ParticleParams.hh"
 
 #include "base/Macros.hh"
+#include "comm/Device.hh"
 #include "celeritas_config.h"
 
 namespace celeritas
@@ -43,11 +44,13 @@ ParticleParams::ParticleParams(const VecAnnotatedDefs& defs)
         host_defs_.push_back(md_def.second);
     }
 
-#if CELERITAS_USE_CUDA
-    device_defs_ = DeviceVector<ParticleDef>{host_defs_.size()};
-    device_defs_.copy_to_device(make_span(host_defs_));
-    ENSURE(device_defs_.size() == defs.size());
-#endif
+    if (celeritas::is_device_enabled())
+    {
+        device_defs_ = DeviceVector<ParticleDef>{host_defs_.size()};
+        device_defs_.copy_to_device(make_span(host_defs_));
+        ENSURE(device_defs_.size() == defs.size());
+    }
+
     ENSURE(name_to_id_.size() == defs.size());
     ENSURE(pdg_to_id_.size() == defs.size());
     ENSURE(host_defs_.size() == defs.size());

--- a/src/random/cuda/RngEngine.hh
+++ b/src/random/cuda/RngEngine.hh
@@ -1,9 +1,9 @@
-//---------------------------------*-CUDA-*----------------------------------//
+//---------------------------------*-C++-*-----------------------------------//
 // Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file RngEngine.cuh
+//! \file RngEngine.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -19,13 +19,17 @@ namespace celeritas
  * The RngEngine uses a C++11-like interface to generate random data. The
  * sampling of uniform floating point data is done with specializations to the
  * GenerateCanonical class.
+ *
+ * \todo The CUDA random documentation suggests loading the RNG into local
+ * memory and then storing back to global memory at the end of a kernel. This
+ * could be safely achieved with a custom destructor.
  */
 class RngEngine
 {
   public:
     //@{
     //! Type aliases
-    using result_type = unsigned int;
+    using result_type   = unsigned int;
     using Initializer_t = RngSeed;
     //@}
 
@@ -87,4 +91,4 @@ class GenerateCanonical<RngEngine, double>
 //---------------------------------------------------------------------------//
 } // namespace celeritas
 
-#include "RngEngine.i.cuh"
+#include "RngEngine.i.hh"

--- a/src/random/cuda/RngEngine.i.hh
+++ b/src/random/cuda/RngEngine.i.hh
@@ -1,10 +1,12 @@
-//---------------------------------*-CUDA-*----------------------------------//
+//---------------------------------*-C++-*-----------------------------------//
 // Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file RngEngine.i.cuh
+//! \file RngEngine.i.hh
 //---------------------------------------------------------------------------//
+
+#include "celeritas_config.h"
 
 namespace celeritas
 {
@@ -31,7 +33,7 @@ CELER_FUNCTION RngEngine& RngEngine::operator=(RngSeed s)
 
 //---------------------------------------------------------------------------//
 /*!
- * Sample a random number
+ * Sample a random number.
  */
 CELER_FUNCTION auto RngEngine::operator()() -> result_type
 {
@@ -42,7 +44,7 @@ CELER_FUNCTION auto RngEngine::operator()() -> result_type
 // Specializations for GenerateCanonical
 //---------------------------------------------------------------------------//
 /*!
- * Specialization for RngEngine, float
+ * Specialization for RngEngine (float).
  */
 CELER_FUNCTION float
 GenerateCanonical<RngEngine, float>::operator()(RngEngine& rng)
@@ -52,7 +54,7 @@ GenerateCanonical<RngEngine, float>::operator()(RngEngine& rng)
 
 //---------------------------------------------------------------------------//
 /*!
- * Specialization for RngEngine, double
+ * Specialization for RngEngine (double).
  */
 CELER_FUNCTION double
 GenerateCanonical<RngEngine, double>::operator()(RngEngine& rng)

--- a/src/random/cuda/RngStatePointers.hh
+++ b/src/random/cuda/RngStatePointers.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "celeritas_config.h"
+#if CELERITAS_USE_CUDA
 /*!
  * \def QUALIFIERS
  *
@@ -16,8 +18,12 @@
  * is a limited scope for the random module of celeritas.
  */
 #define QUALIFIERS static __forceinline__ __host__ __device__
-
 #include <curand_kernel.h>
+#else
+// CUDA is disabled
+#    include "curand.nocuda.hh"
+#endif
+
 #include "base/Span.hh"
 #include "base/Types.hh"
 

--- a/src/random/cuda/RngStateStore.cc
+++ b/src/random/cuda/RngStateStore.cc
@@ -10,7 +10,7 @@
 #include <random>
 #include <vector>
 #include "base/Assert.hh"
-#include "RngStateInit.hh"
+#include "detail/RngStateInit.hh"
 
 namespace celeritas
 {
@@ -37,8 +37,8 @@ RngStateStore::RngStateStore(size_type size, unsigned long host_seed)
 
     DeviceVector<seed_type> device_seeds(size);
     device_seeds.copy_to_device(make_span(host_seeds));
-    rng_state_init_device(this->device_pointers(),
-                          device_seeds.device_pointers());
+    detail::rng_state_init_device(this->device_pointers(),
+                                  device_seeds.device_pointers());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/random/cuda/RngStateStore.cc
+++ b/src/random/cuda/RngStateStore.cc
@@ -3,13 +3,14 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file RngStateStore.cu
+//! \file RngStateStore.cc
 //---------------------------------------------------------------------------//
 #include "RngStateStore.hh"
 
 #include <random>
 #include <vector>
 #include "base/Assert.hh"
+#include "comm/Device.hh"
 #include "detail/RngStateInit.hh"
 
 namespace celeritas
@@ -23,6 +24,7 @@ namespace celeritas
 RngStateStore::RngStateStore(size_type size, unsigned long host_seed)
     : data_(size)
 {
+    REQUIRE(celeritas::is_device_enabled());
     REQUIRE(size > 0);
 
     // Host-side RNG for seeding device RNG

--- a/src/random/cuda/curand.nocuda.cc
+++ b/src/random/cuda/curand.nocuda.cc
@@ -1,22 +1,36 @@
-//---------------------------------*-C++-*-----------------------------------//
+//----------------------------------*-C++-*----------------------------------//
 // Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file Memory.nocuda.cc
+//! \file curand.nocuda.cc
 //---------------------------------------------------------------------------//
-#include "Memory.hh"
+#include "curand.nocuda.hh"
 
-#include "Assert.hh"
+#include "base/Assert.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-/*!
- * This function should never be called when CUDA is disabled. It is
- * implemented with an assertion to allow linking as a nullop implementation.
- */
-void device_memset(void*, int, size_type)
+void curand_init(unsigned long long,
+                 unsigned long long,
+                 unsigned long long,
+                 curandState_t*)
+{
+    CHECK_UNREACHABLE;
+}
+
+unsigned int curand(curandState_t*)
+{
+    CHECK_UNREACHABLE;
+}
+
+float curand_uniform(curandState_t*)
+{
+    CHECK_UNREACHABLE;
+}
+
+double curand_uniform_double(curandState_t*)
 {
     CHECK_UNREACHABLE;
 }

--- a/src/random/cuda/curand.nocuda.hh
+++ b/src/random/cuda/curand.nocuda.hh
@@ -1,0 +1,39 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file curand.nocuda.hh
+//! \brief Support compiling/linking but raise runtime errors.
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "celeritas_config.h"
+#if CELERITAS_USE_CUDA
+#    error "This file should only be included when CUDA is unavailable."
+#endif
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+//! Placeholder for CUDA random state to allow compiling
+struct MockCurandState
+{
+};
+
+using curandState_t = MockCurandState;
+
+//---------------------------------------------------------------------------//
+//@{
+//! CUDA random functions.
+void         curand_init(unsigned long long seed,
+                         unsigned long long sequence,
+                         unsigned long long offset,
+                         curandState_t*     state);
+unsigned int curand(curandState_t* state);
+float        curand_uniform(curandState_t* state);
+double       curand_uniform_double(curandState_t* state);
+//@}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/random/cuda/detail/RngStateInit.cu
+++ b/src/random/cuda/detail/RngStateInit.cu
@@ -8,10 +8,11 @@
 #include "RngStateInit.hh"
 
 #include "base/KernelParamCalculator.cuda.hh"
-#include "RngEngine.cuh"
+#include "random/cuda/RngEngine.hh"
 
-namespace celeritas
+namespace
 {
+using namespace celeritas;
 //---------------------------------------------------------------------------//
 // KERNELS
 //---------------------------------------------------------------------------//
@@ -28,7 +29,13 @@ init_impl(RngStatePointers const state, const RngSeed::value_type* const seeds)
         rng = RngEngine::Initializer_t{seeds[tid.get()]};
     }
 }
+//---------------------------------------------------------------------------//
+} // namespace
 
+namespace celeritas
+{
+namespace detail
+{
 //---------------------------------------------------------------------------//
 // KERNEL INTERFACE
 //---------------------------------------------------------------------------//
@@ -49,4 +56,5 @@ void rng_state_init_device(const RngStatePointers&         device_ptrs,
 }
 
 //---------------------------------------------------------------------------//
+} // namespace detail
 } // namespace celeritas

--- a/src/random/cuda/detail/RngStateInit.hh
+++ b/src/random/cuda/detail/RngStateInit.hh
@@ -8,9 +8,11 @@
 #pragma once
 
 #include "base/Span.hh"
-#include "RngStatePointers.hh"
+#include "random/cuda/RngStatePointers.hh"
 
 namespace celeritas
+{
+namespace detail
 {
 //---------------------------------------------------------------------------//
 // Initialize the RNG state on device
@@ -18,4 +20,5 @@ void rng_state_init_device(const RngStatePointers&         device_ptrs,
                            span<const RngSeed::value_type> device_seeds);
 
 //---------------------------------------------------------------------------//
+} // namespace detail
 } // namespace celeritas

--- a/src/random/cuda/detail/RngStateInit.nocuda.cc
+++ b/src/random/cuda/detail/RngStateInit.nocuda.cc
@@ -3,23 +3,26 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file Memory.nocuda.cc
+//! \file RngStateInit.nocuda.cc
 //---------------------------------------------------------------------------//
-#include "Memory.hh"
+#include "RngStateInit.hh"
 
-#include "Assert.hh"
+#include "base/Assert.hh"
 
 namespace celeritas
 {
+namespace detail
+{
 //---------------------------------------------------------------------------//
 /*!
- * This function should never be called when CUDA is disabled. It is
- * implemented with an assertion to allow linking as a nullop implementation.
+ * Initialize the RNG states on device from seeds randomly generated on host.
  */
-void device_memset(void*, int, size_type)
+void rng_state_init_device(const RngStatePointers&,
+                           span<const RngSeed::value_type>)
 {
     CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//
+} // namespace detail
 } // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -112,10 +112,6 @@ if(CELERITAS_USE_VecGeom)
   celeritas_setup_tests(SERIAL PREFIX geometry
     LINK_LIBRARIES VecGeom::vecgeom)
 
-  celeritas_add_test(geometry/GeoParams.test.cc)
-  celeritas_add_test(geometry/GeoTrackView.test.cc)
-  celeritas_add_test(geometry/LinearPropagator.test.cc)
-
   # CUDA tests: link cuda sources as needed
   if(CELERITAS_USE_CUDA)
     # See https://github.com/celeritas-project/celeritas/pull/10 for a
@@ -134,10 +130,12 @@ if(CELERITAS_USE_VecGeom)
       CUDA_SEPARABLE_COMPILATION ON
       POSITION_INDEPENDENT_CODE ON
     )
-    target_link_libraries(geometry_GeoParams celeritas_vgtest)
-    target_link_libraries(geometry_GeoTrackView celeritas_vgtest)
-    target_link_libraries(geometry_LinearPropagator celeritas_vgtest)
+    list(APPEND CELERITASTEST_LINK_LIBRARIES celeritas_vgtest)
   endif()
+
+  celeritas_add_test(geometry/GeoParams.test.cc)
+  celeritas_add_test(geometry/GeoTrackView.test.cc)
+  celeritas_add_test(geometry/LinearPropagator.test.cc)
 endif()
 
 #-----------------------------------------------------------------------------#
@@ -146,12 +144,12 @@ endif()
 celeritas_setup_tests(SERIAL PREFIX io)
 
 if(CELERITAS_USE_ROOT)
-  celeritas_add_test(io/RootImporter.test.cc DISABLE)
-  target_link_libraries(io_RootImporter Celeritas::IO)
+  celeritas_add_test(io/RootImporter.test.cc
+    LINK_LIBRARIES Celeritas::IO DISABLE)
 endif()
 if(CELERITAS_USE_HepMC3)
-  celeritas_add_test(io/EventReader.test.cc)
-  target_link_libraries(io_EventReader ${HEPMC3_LIB})
+  celeritas_add_test(io/EventReader.test.cc
+    LINK_LIBRARIES ${HEPMC3_LIB})
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,15 +29,13 @@ add_library(CeleritasTest ${CELER_SOURCES})
 add_library(Celeritas::Test ALIAS CeleritasTest)
 target_link_libraries(CeleritasTest PUBLIC celeritas GTest::GTest)
 
-if(CELERITAS_USE_VecGeom)
-  if(CELERITAS_USE_CUDA)
-    target_link_libraries(CeleritasTest
-       PRIVATE
-          VecGeom::vecgeomcuda
-          VecGeom::vecgeomcuda_static
-    )
-  endif(CELERITAS_USE_CUDA)
-endif(CELERITAS_USE_VecGeom)
+if(CELERITAS_USE_VecGeom AND CELERITAS_USE_CUDA)
+  target_link_libraries(CeleritasTest
+    PRIVATE
+       VecGeom::vecgeomcuda
+       VecGeom::vecgeomcuda_static
+  )
+endif()
 
 target_include_directories(CeleritasTest
   PUBLIC
@@ -51,16 +49,12 @@ target_include_directories(CeleritasTest
 
 include(CeleritasAddTest)
 
-function(add_cudaoptional_test base)
+function(celeritas_cudaoptional_test base)
   if(CELERITAS_USE_CUDA)
-    set(_sources SOURCES "${base}.test.cu")
+    set(_cuda_args GPU SOURCES "${base}.test.cu")
   endif()
-  celeritas_add_test("${base}.test.cc" ${_sources} ${ARGN})
+  celeritas_add_test("${base}.test.cc" ${_cuda_args} ${ARGN})
 endfunction()
-
-if(NOT CELERITAS_USE_CUDA)
-  set(_needs_cuda DISABLE)
-endif()
 
 #-----------------------------------------------------------------------------#
 # Gtest additions
@@ -77,8 +71,8 @@ celeritas_add_test(base/Algorithms.test.cc)
 celeritas_add_test(base/Array.test.cc)
 celeritas_add_test(base/ArrayUtils.test.cc)
 celeritas_add_test(base/Constants.test.cc)
-celeritas_add_test(base/DeviceAllocation.test.cc)
-celeritas_add_test(base/DeviceVector.test.cc)
+celeritas_add_test(base/DeviceAllocation.test.cc GPU)
+celeritas_add_test(base/DeviceVector.test.cc GPU)
 celeritas_add_test(base/Interpolator.test.cc)
 celeritas_add_test(base/OpaqueId.test.cc)
 celeritas_add_test(base/Quantity.test.cc)
@@ -88,14 +82,14 @@ celeritas_add_test(base/SpanRemapper.test.cc)
 celeritas_add_test(base/Stopwatch.test.cc)
 celeritas_add_test(base/UniformGrid.test.cc)
 
-
 if(CELERITAS_USE_CUDA)
   celeritas_add_test(base/NumericLimits.test.cc
-    SOURCES base/NumericLimits.test.cu)
+    SOURCES base/NumericLimits.test.cu
+    GPU)
 endif()
 
-add_cudaoptional_test(base/Range)
-add_cudaoptional_test(base/StackAllocator)
+celeritas_cudaoptional_test(base/Range)
+celeritas_cudaoptional_test(base/StackAllocator)
 
 #-----------------------------------------------------------------------------#
 # Comm
@@ -118,7 +112,10 @@ if(CELERITAS_USE_VecGeom)
     # discussion of the failures from trying to directly build an executable
     # from code with CUDA separable compilation. This extra test library is
     # necessary.
-    add_library(celeritas_vgtest geometry/GeoTrackView.test.cu geometry/LinearPropagator.test.cu)
+    add_library(celeritas_vgtest
+      geometry/GeoTrackView.test.cu
+      geometry/LinearPropagator.test.cu
+    )
     target_link_libraries(celeritas_vgtest
       PRIVATE
       celeritas
@@ -133,9 +130,9 @@ if(CELERITAS_USE_VecGeom)
     list(APPEND CELERITASTEST_LINK_LIBRARIES celeritas_vgtest)
   endif()
 
-  celeritas_add_test(geometry/GeoParams.test.cc)
-  celeritas_add_test(geometry/GeoTrackView.test.cc)
-  celeritas_add_test(geometry/LinearPropagator.test.cc)
+  celeritas_add_test(geometry/GeoParams.test.cc GPU)
+  celeritas_add_test(geometry/GeoTrackView.test.cc GPU)
+  celeritas_add_test(geometry/LinearPropagator.test.cc GPU)
 endif()
 
 #-----------------------------------------------------------------------------#
@@ -164,11 +161,11 @@ target_link_libraries(CeleritasPhysicsTest PRIVATE celeritas CeleritasTest)
 set(CELERITASTEST_LINK_LIBRARIES CeleritasPhysicsTest)
 
 celeritas_setup_tests(SERIAL PREFIX physics/base)
-add_cudaoptional_test(physics/base/Particle)
+celeritas_cudaoptional_test(physics/base/Particle)
 
 celeritas_setup_tests(SERIAL PREFIX physics/material)
 celeritas_add_test(physics/material/ElementSelector.test.cc)
-add_cudaoptional_test(physics/material/Material)
+celeritas_cudaoptional_test(physics/material/Material)
 
 #-----------------------------------------------------------------------------#
 # Physics (EM)
@@ -202,7 +199,7 @@ celeritas_add_test(random/distributions/RadialDistribution.test.cc)
 celeritas_add_test(random/distributions/UniformRealDistribution.test.cc)
 
 if(CELERITAS_USE_CUDA)
-  celeritas_add_test(random/cuda/RngEngine.test.cu)
+  celeritas_add_test(random/cuda/RngEngine.test.cu GPU)
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/test/gtest/detail/ParallelHandler.cc
+++ b/test/gtest/detail/ParallelHandler.cc
@@ -10,6 +10,7 @@
 #include "Utils.hh"
 #include "base/ColorUtils.hh"
 #include "comm/Communicator.hh"
+#include "comm/Operations.hh"
 
 namespace celeritas
 {

--- a/test/gtest/detail/TestMain.cc
+++ b/test/gtest/detail/TestMain.cc
@@ -11,8 +11,8 @@
 #include "celeritas_config.h"
 #include "base/ColorUtils.hh"
 #include "comm/Communicator.hh"
+#include "comm/Device.hh"
 #include "comm/ScopedMpiInit.hh"
-#include "comm/Utils.hh"
 #include "NonMasterResultPrinter.hh"
 #include "ParallelHandler.hh"
 #include "Utils.hh"
@@ -67,7 +67,7 @@ int test_main(int argc, char** argv)
     int failed = RUN_ALL_TESTS();
 
     // Accumulate the result so that all processors will have the same result
-    // XXX replace with celeritas comm wrappers
+    // TODO: replace with celeritas comm wrappers
     int global_failed = failed;
 #if CELERITAS_USE_MPI
     MPI_Allreduce(

--- a/test/gtest/detail/TestMain.cc
+++ b/test/gtest/detail/TestMain.cc
@@ -12,6 +12,7 @@
 #include "base/ColorUtils.hh"
 #include "comm/Communicator.hh"
 #include "comm/Device.hh"
+#include "comm/Operations.hh"
 #include "comm/ScopedMpiInit.hh"
 #include "NonMasterResultPrinter.hh"
 #include "ParallelHandler.hh"
@@ -25,7 +26,10 @@ namespace detail
 int test_main(int argc, char** argv)
 {
     ScopedMpiInit scoped_mpi(&argc, &argv);
-    Communicator  comm = Communicator::comm_world();
+    Communicator  comm
+        = (ScopedMpiInit::status() == ScopedMpiInit::Status::disabled
+               ? Communicator{}
+               : Communicator::comm_world());
 
     // Initialize device
     try
@@ -66,13 +70,8 @@ int test_main(int argc, char** argv)
     // Run everything
     int failed = RUN_ALL_TESTS();
 
-    // Accumulate the result so that all processors will have the same result
-    // TODO: replace with celeritas comm wrappers
-    int global_failed = failed;
-#if CELERITAS_USE_MPI
-    MPI_Allreduce(
-        &failed, &global_failed, 1, MPI_INT, MPI_MAX, comm.mpi_comm());
-#endif
+    // Find out if any process failed
+    failed = allreduce(comm, Operation::max, failed);
 
     // If no tests were run, there's a problem.
     if (testing::UnitTest::GetInstance()->test_to_run_count() == 0)
@@ -83,19 +82,19 @@ int test_main(int argc, char** argv)
                       << " No tests are written/enabled!" << std::endl;
         }
 
-        global_failed = 1;
+        failed = 1;
     }
 
     // Print final results
     if (comm.rank() == 0)
     {
         std::cout << color_code('x') << (argc > 0 ? argv[0] : "UNKNOWN")
-                  << ": tests " << (global_failed ? "FAILED" : "PASSED")
+                  << ": tests " << (failed ? "FAILED" : "PASSED")
                   << color_code(' ') << std::endl;
     }
 
     // Return 1 if any failure, 0 if all success
-    return global_failed;
+    return failed;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/random/cuda/RngEngine.test.cu
+++ b/test/random/cuda/RngEngine.test.cu
@@ -6,7 +6,7 @@
 //! \file RngEngine.test.cu
 //---------------------------------------------------------------------------//
 #include "random/cuda/RngStateStore.hh"
-#include "random/cuda/RngEngine.cuh"
+#include "random/cuda/RngEngine.hh"
 
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>


### PR DESCRIPTION
- Move the restructuring commit from the `events` branch into this one (@amandalund)
- Add runtime environment switch to disable GPU support and reduce compiler macros in no-CUDA builds
- Add switch to optionally disable MPI for reduced testing time and improved compatibility
- Add runtime environment switch to change default logging level, and print debug level in tests when running debug build