### PR TITLE
Improve InitializedValue and Quantity

### DIFF
--- a/src/base/detail/InitializedValue.hh
+++ b/src/base/detail/InitializedValue.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <utility>
+
 namespace celeritas
 {
 namespace detail
@@ -19,8 +21,10 @@ template<class T>
 class InitializedValue
 {
   public:
-    //! Construct with default value
-    InitializedValue(T value = {}) : value_(value) {}
+    //! Construct implicitly with default value
+    InitializedValue() = default;
+    //! Implicit construct from value type
+    InitializedValue(T value) : value_(std::move(value)) {}
 
     //!@{
     //! Default copy assign and construct
@@ -29,16 +33,15 @@ class InitializedValue
     //!@}
 
     //! Clear other value on move construct
-    InitializedValue(InitializedValue&& other) noexcept : value_(other.value_)
+    InitializedValue(InitializedValue&& other) noexcept
+        : value_(std::exchange(other.value_, {}))
     {
-        other.value_ = {};
     }
 
     //! Clear other value on move assign
     InitializedValue& operator=(InitializedValue&& other) noexcept
     {
-        value_       = other.value_;
-        other.value_ = {};
+        value_ = std::exchange(other.value_, {});
         return *this;
     }
 
@@ -53,7 +56,7 @@ class InitializedValue
     operator T() const { return value_; }
 
   private:
-    T value_;
+    T value_{};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/GeoParams.cc
+++ b/src/geometry/GeoParams.cc
@@ -148,10 +148,11 @@ GeoParamsPointers GeoParams::host_pointers() const
  */
 GeoParamsPointers GeoParams::device_pointers() const
 {
-    REQUIRE(device_world_volume_);
+    REQUIRE(celeritas::is_device_enabled());
     GeoParamsPointers result;
     result.world_volume
         = static_cast<const vecgeom::VPlacedVolume*>(device_world_volume_);
+    ENSURE(result);
     return result;
 }
 

--- a/test/base/DeviceAllocation.test.cc
+++ b/test/base/DeviceAllocation.test.cc
@@ -7,11 +7,62 @@
 //---------------------------------------------------------------------------//
 #include "base/DeviceAllocation.hh"
 
+#include <algorithm>
 #include "celeritas_test.hh"
 #include "base/Span.hh"
 
 using celeritas::Byte;
 using celeritas::DeviceAllocation;
+
+TEST(InitializedValue, semantics)
+{
+    using InitValueInt = celeritas::detail::InitializedValue<int>;
+    static_assert(sizeof(InitValueInt) == sizeof(int), "Bad size");
+
+    // Use operator new to test that the int is being initialized properly by
+    // constructing into data space that's been set to a different value
+    alignas(int) Byte buf[sizeof(int)];
+    std::fill(std::begin(buf), std::end(buf), Byte(-1));
+    InitValueInt* ival = new (buf) InitValueInt{};
+    EXPECT_EQ(0, *ival);
+
+    InitValueInt other = 345;
+    EXPECT_EQ(345, other);
+    *ival = other;
+    EXPECT_EQ(345, *ival);
+    EXPECT_EQ(345, other);
+    other = 1000;
+    *ival = std::move(other);
+    EXPECT_EQ(1000, *ival);
+    EXPECT_EQ(0, other);
+
+    InitValueInt third(std::move(*ival));
+    EXPECT_EQ(0, *ival);
+    EXPECT_EQ(1000, third);
+
+    // Test const T& constructor
+    const int cint = 1234;
+    other          = InitValueInt(cint);
+    EXPECT_EQ(1234, other);
+
+    // Test implicit conversion
+    int tempint;
+    tempint = third;
+    EXPECT_EQ(1000, tempint);
+    tempint = 1;
+#if 0
+    // NOTE: this will not work because template matching will not
+    // search for implicit constructors
+    EXPECT_EQ(1000, std::max(tempint, third));
+#else
+    EXPECT_EQ(1000, std::max(tempint, static_cast<int>(third)));
+#endif
+    auto passthrough_int = [](int i) -> int { return i; };
+    EXPECT_EQ(1000, passthrough_int(third));
+
+    // Destroy
+    ival->~InitializedValue();
+}
 
 //---------------------------------------------------------------------------//
 // TEST HARNESS

--- a/test/base/Quantity.test.cc
+++ b/test/base/Quantity.test.cc
@@ -22,6 +22,11 @@ struct RevolutionUnit
 };
 using Revolution = Quantity<RevolutionUnit, double>;
 
+struct DozenUnit
+{
+    static int value() { return 12; }
+};
+
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
@@ -92,4 +97,25 @@ TEST(QuantityTest, infinities)
     EXPECT_TRUE(neg_max_quantity() < zero_quantity());
     EXPECT_TRUE(zero_quantity() < max_quantity());
     EXPECT_TRUE(max_quantity() > Revolution{1e300});
+}
+
+TEST(QuantityTest, swappiness)
+{
+    using Dozen = Quantity<DozenUnit, int>;
+    Dozen dozen{1}, gross{12};
+    {
+        // ADL should prefer celeritas::swap
+        using std::swap;
+        swap(dozen, gross);
+        EXPECT_EQ(1, gross.value());
+        EXPECT_EQ(12, dozen.value());
+    }
+    {
+        // Should still work without std
+        swap(dozen, gross);
+        EXPECT_EQ(12, gross.value());
+        EXPECT_EQ(1, dozen.value());
+    }
+    EXPECT_EQ(12, unit_cast(dozen));
+    EXPECT_EQ(144, unit_cast(gross));
 }

--- a/test/gtest/detail/Macros.hh
+++ b/test/gtest/detail/Macros.hh
@@ -49,4 +49,13 @@
 #    define TEST_IF_CELERITAS_DEBUG(name) DISABLED_##name
 #endif
 
+//! Skip the remainder of the test (only run from the main function!!)
+#define SKIP(msg)                                                      \
+    do                                                                 \
+    {                                                                  \
+        std::cout << ::celeritas::detail::skip_cstring() << " " << msg \
+                  << std::endl;                                        \
+        return;                                                        \
+    } while (0)
+
 #include "Macros.i.hh"


### PR DESCRIPTION
- Use  `std::exchange` in `InitializedValue` and make its arguments move-friendly
- Add `swap` for `Quantity` needed for #72 
- Improve failure mode for GeoParams when CUDA is disabled
- Add `SKIP` macro to test macros