### PR TITLE
Add diagnostic RNG engine to test sampling efficiency

### DIFF
--- a/test/physics/InteractorHostTestBase.hh
+++ b/test/physics/InteractorHostTestBase.hh
@@ -10,7 +10,6 @@
 #include <memory>
 #include <random>
 #include <vector>
-#include "gtest/Test.hh"
 #include "base/Array.hh"
 #include "base/ArrayIO.hh"
 #include "base/Span.hh"
@@ -22,7 +21,11 @@
 #include "physics/base/Units.hh"
 #include "physics/material/MaterialParams.hh"
 #include "physics/material/MaterialStatePointers.hh"
+
+// Test helpers
 #include "base/HostStackAllocatorStore.hh"
+#include "gtest/Test.hh"
+#include "random/DiagnosticRngEngine.hh"
 
 namespace celeritas
 {
@@ -48,7 +51,7 @@ class InteractorHostTestBase : public celeritas::Test
   public:
     //!@{
     //! Type aliases
-    using RandomEngine = std::mt19937;
+    using RandomEngine = DiagnosticRngEngine<std::mt19937>;
 
     using real_type              = celeritas::real_type;
     using PDGNumber              = celeritas::PDGNumber;

--- a/test/physics/em/EPlusGGInteractor.test.cc
+++ b/test/physics/em/EPlusGGInteractor.test.cc
@@ -191,11 +191,13 @@ TEST_F(EPlusGGInteractorTest, stress_test)
     RandomEngine& rng_engine = this->rng();
 
     const int num_samples = 8192;
+    std::vector<double> avg_engine_samples;
 
     for (double inc_e : {0.0, 0.01, 1.0, 10.0, 1000.0})
     {
         SCOPED_TRACE("Incident energy: " + std::to_string(inc_e));
         this->set_inc_particle(pdg::positron(), MevEnergy{inc_e});
+        RandomEngine::size_type num_particles_sampled = 0;
 
         // Loop over several incident directions
         for (const Real3& inc_dir :
@@ -220,6 +222,16 @@ TEST_F(EPlusGGInteractorTest, stress_test)
             }
             EXPECT_EQ(2 * num_samples,
                       this->secondary_allocator().get().size());
+            num_particles_sampled += num_samples;
         }
+        avg_engine_samples.push_back(double(rng_engine.count())
+                                     / double(num_particles_sampled));
+        rng_engine.reset_count();
     }
+
+    // PRINT_EXPECTED(avg_engine_samples);
+    // Gold values for average number of calls to RNG
+    const double expected_avg_engine_samples[]
+        = {4, 10.08703613281, 19.54248046875, 22.75891113281, 35.08276367188};
+    EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
 }

--- a/test/random/DiagnosticRngEngine.hh
+++ b/test/random/DiagnosticRngEngine.hh
@@ -1,0 +1,63 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file DiagnosticRngEngine.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cstddef>
+
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Diagnostic wrapper that counts the number of calls to operator().
+ *
+ * This wraps a low-level pseudorandom generator's call function. It can be
+ * used to determine the efficiency of rejection algorithms without changing
+ * any implementations.
+ */
+template<class Engine>
+class DiagnosticRngEngine
+{
+  public:
+    //!@{
+    //! Type aliases
+    using result_type = typename Engine::result_type;
+    using size_type   = std::size_t;
+    //!@}
+
+  public:
+    //! Forward construction arguments to the original engine
+    template<class... Args>
+    DiagnosticRngEngine(Args&&... args) : engine_(std::forward<Args>(args)...)
+    {
+    }
+
+    //! Get a random number and increment the sample counter
+    result_type operator()()
+    {
+        ++num_samples_;
+        return engine_();
+    }
+
+    //! Get the number of samples
+    size_type count() const { return num_samples_; }
+    //! Reset the sample counter
+    void reset_count() { num_samples_ = 0; }
+
+    //!@{
+    //! Forwarded functions
+    static constexpr result_type min() { return Engine::min(); }
+    static constexpr result_type max() { return Engine::max(); }
+    //!@}
+
+  private:
+    Engine    engine_;
+    size_type num_samples_ = 0;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/random/distributions/ExponentialDistribution.test.cc
+++ b/test/random/distributions/ExponentialDistribution.test.cc
@@ -10,6 +10,7 @@
 #include <random>
 #include "base/Range.hh"
 #include "celeritas_test.hh"
+#include "../DiagnosticRngEngine.hh"
 
 using celeritas::ExponentialDistribution;
 
@@ -22,7 +23,7 @@ class ExponentialDistributionTest : public celeritas::Test
   protected:
     void SetUp() override {}
 
-    std::mt19937 rng;
+    celeritas_test::DiagnosticRngEngine<std::mt19937> rng;
 };
 
 //---------------------------------------------------------------------------//
@@ -55,4 +56,5 @@ TEST_F(ExponentialDistributionTest, all)
     // PRINT_EXPECTED(counters);
     const int expected_counters[] = {2180, 1717, 2411, 2265, 1427};
     EXPECT_VEC_EQ(expected_counters, counters);
+    EXPECT_EQ(2 * num_samples, rng.count());
 }


### PR DESCRIPTION
This adds a thin wrapper to the testing infrastructure so that our physics (and RNG) tests can query how many times the RNG sampler is called, which is a useful noninvasive diagnostic tool for understanding rejection rates in some of our physics samplers.