### PR TITLE
Add always-on INSIST macro

### DIFF
--- a/src/base/Assert.cc
+++ b/src/base/Assert.cc
@@ -7,11 +7,27 @@
 //---------------------------------------------------------------------------//
 #include "Assert.hh"
 
+#include <cstdlib>
 #include <sstream>
 #include "ColorUtils.hh"
 
 namespace celeritas
 {
+namespace
+{
+//---------------------------------------------------------------------------//
+bool determine_verbose_message()
+{
+#if CELERITAS_DEBUG
+    // Always verbose if debug flags are enabled
+    return true;
+#else
+    // Verbose if the CELER_LOG environment variable is defined
+    return std::getenv("CELER_LOG") != nullptr;
+#endif
+}
+} // namespace
+
 //---------------------------------------------------------------------------//
 //!@{
 //! Delegating constructor
@@ -41,7 +57,7 @@ throw_debug_error(const char* condition, const char* file, int line)
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct a debug assertion message and throw.
+ * Construct a message and throw an error from a runtime CUDA failure.
  */
 [[noreturn]] void throw_cuda_call_error(const char* error_string,
                                         const char* code,
@@ -57,6 +73,40 @@ throw_debug_error(const char* condition, const char* file, int line)
         << color_code('x') << code
         << color_code(' ');
     // clang-format on
+    throw RuntimeError(msg.str());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a runtime assertion message.
+ */
+[[noreturn]] void throw_runtime_error(std::string detail,
+                                      const char* condition,
+                                      const char* file,
+                                      int         line)
+{
+    static const bool verbose_message = determine_verbose_message();
+
+    std::ostringstream msg;
+
+    if (verbose_message)
+    {
+        msg << color_code('W') << file << ':' << line << ':' << color_code(' ')
+            << '\n';
+    }
+
+    msg << "celeritas: " << color_code('R') << "runtime error: ";
+    if (verbose_message)
+    {
+        msg << color_code('x') << condition << color_code(' ')
+            << " failed:\n    ";
+    }
+    else
+    {
+        msg << color_code(' ');
+    }
+    msg << detail;
+
     throw RuntimeError(msg.str());
 }
 

--- a/src/base/Assert.hh
+++ b/src/base/Assert.hh
@@ -10,7 +10,9 @@
 #include "celeritas_config.h"
 #include "Macros.hh"
 #ifndef __CUDA_ARCH__
+#    include <sstream>
 #    include <stdexcept>
+#    include <string>
 #endif
 
 //---------------------------------------------------------------------------//
@@ -34,6 +36,13 @@
  * side effects are as expected when leaving a function.
  */
 /*!
+ * \def INSIST
+ *
+ * Always-on runtime assertion macro. This can check user input and input data
+ * consistency, and will raise RuntimeError on failure with a descriptive error
+ * message. This should not be used on device.
+ */
+/*!
  * \def CHECK_UNREACHABLE
  *
  * Assert if the code point is reached. When debug assertions are turned off,
@@ -46,11 +55,22 @@
     {                            \
         assert(COND);            \
     } while (0)
-#define CELER_ASSERT_(COND)                                            \
+#define CELER_DEBUG_ASSERT_(COND)                                      \
     do                                                                 \
     {                                                                  \
         if (CELER_UNLIKELY(!(COND)))                                   \
             ::celeritas::throw_debug_error(#COND, __FILE__, __LINE__); \
+    } while (0)
+#define CELER_RUNTIME_ASSERT_(COND, MSG)                              \
+    do                                                                \
+    {                                                                 \
+        if (CELER_UNLIKELY(!(COND)))                                  \
+        {                                                             \
+            std::ostringstream celer_runtime_msg_;                    \
+            celer_runtime_msg_ << MSG;                                \
+            ::celeritas::throw_runtime_error(                         \
+                celer_runtime_msg_.str(), #COND, __FILE__, __LINE__); \
+        }                                                             \
     } while (0)
 #define CELER_NOASSERT_(COND)   \
     do                          \
@@ -60,20 +80,28 @@
 //! \endcond
 
 #if CELERITAS_DEBUG && defined(__CUDA_ARCH__)
-#    define REQUIRE(x) CELER_CUDA_ASSERT_(x)
-#    define CHECK(x) CELER_CUDA_ASSERT_(x)
-#    define ENSURE(x) CELER_CUDA_ASSERT_(x)
+#    define REQUIRE(COND) CELER_CUDA_ASSERT_(COND)
+#    define CHECK(COND) CELER_CUDA_ASSERT_(COND)
+#    define ENSURE(COND) CELER_CUDA_ASSERT_(COND)
 #    define CHECK_UNREACHABLE CELER_CUDA_ASSERT_(false)
 #elif CELERITAS_DEBUG && !defined(__CUDA_ARCH__)
-#    define REQUIRE(x) CELER_ASSERT_(x)
-#    define CHECK(x) CELER_ASSERT_(x)
-#    define ENSURE(x) CELER_ASSERT_(x)
-#    define CHECK_UNREACHABLE CELER_ASSERT_(false)
+#    define REQUIRE(COND) CELER_DEBUG_ASSERT_(COND)
+#    define CHECK(COND) CELER_DEBUG_ASSERT_(COND)
+#    define ENSURE(COND) CELER_DEBUG_ASSERT_(COND)
+#    define CHECK_UNREACHABLE CELER_DEBUG_ASSERT_(false)
 #else
-#    define REQUIRE(x) CELER_NOASSERT_(x)
-#    define CHECK(x) CELER_NOASSERT_(x)
-#    define ENSURE(x) CELER_NOASSERT_(x)
+#    define REQUIRE(COND) CELER_NOASSERT_(COND)
+#    define CHECK(COND) CELER_NOASSERT_(COND)
+#    define ENSURE(COND) CELER_NOASSERT_(COND)
 #    define CHECK_UNREACHABLE CELER_UNREACHABLE
+#endif
+
+#ifndef __CUDA_ARCH__
+#    define INSIST(COND, MSG) CELER_RUNTIME_ASSERT_(COND, MSG)
+#else
+#    define INSIST(COND, MSG)           \
+        ::celeritas::throw_debug_error( \
+            "Insist cannot be called from device code", __FILE__, __LINE__)
 #endif
 
 /*!
@@ -126,6 +154,14 @@ throw_debug_error(const char* condition, const char* file, int line);
                                         const char* code,
                                         const char* file,
                                         int         line);
+
+#ifndef __CUDA_ARCH__
+// Construct and throw a RuntimeError.
+[[noreturn]] void throw_runtime_error(std::string msg,
+                                      const char* condition,
+                                      const char* file,
+                                      int         line);
+#endif
 
 #ifndef __CUDA_ARCH__
 //---------------------------------------------------------------------------//

--- a/src/comm/Logger.hh
+++ b/src/comm/Logger.hh
@@ -22,9 +22,13 @@
  * regular \c CELER_LOG call is for code paths that happen uniformly in
  * parallel.
  *
+ * The logger will only format and print messages. It is not responsible
+ * for cleaning up the state or exiting an app.
+ *
  * \code
  CELER_LOG(debug) << "Don't print this in general";
- CELER_LOG(warning) << "Oh shiiiiit";
+ CELER_LOG(warning) << "You may want to reconsider your life choices";
+ CELER_LOG(critical) << "Caught a fatal exception: " << e.what();
  * \endcode
  */
 #define CELER_LOG(LEVEL)                              \

--- a/src/comm/LoggerTypes.hh
+++ b/src/comm/LoggerTypes.hh
@@ -24,8 +24,8 @@ enum class LogLevel
     status,     //!< Program execution status (what stage is beginning)
     info,       //!< Important informational messages
     warning,    //!< Warnings about unusual events
-    error,      //!< Something went wrong, but execution continues
-    critical,   //!< Something went terribly wrong; we're aborting now! Bye!
+    error,      //!< Something went wrong, but execution can continue
+    critical,   //!< Something went terribly wrong, should probably abort
     size_       //!< Sentinel value for looping over log levels
 };
 

--- a/src/sim/TrackInitializerStore.cc
+++ b/src/sim/TrackInitializerStore.cc
@@ -178,9 +178,12 @@ void TrackInitializerStore::extend_from_secondaries(StateStore& states,
     // buffer the current track initializers to create room
     size_type num_secondaries
         = detail::reduce_counts(secondary_counts_.device_pointers());
-    // TODO: CHECK --> INSIST
-    CHECK(num_secondaries + initializers_.size() <= initializers_.capacity());
-
+    INSIST(num_secondaries + initializers_.size() <= initializers_.capacity(),
+           "Insufficient capacity ("
+               << initializers_.capacity()
+               << ") for track initializers: created " << num_secondaries
+               << " new secondaries for a total capacity requirement of "
+               << num_secondaries + initializers_.size());
     // The exclusive prefix sum of the number of secondaries produced by each
     // track is used to get the start index in the vector of track initializers
     // for each thread. Starting at that index, each thread creates track


### PR DESCRIPTION
Add an
```c++
INSIST(condition, "description " << with_streamable << " user-facing error message");
```
macro for runtime conditions that should always be enabled (because they depend on the runtime environment and not on the correctness of the code).