### PR TITLE
Housekeeping

### DIFF
--- a/app/demo-interactor/HostStackAllocatorStore.hh
+++ b/app/demo-interactor/HostStackAllocatorStore.hh
@@ -26,7 +26,6 @@ class HostStackAllocatorStore
     using value_type      = T;
     using Pointers        = StackAllocatorPointers<T>;
     using size_type       = typename Pointers::size_type;
-    using const_span_type = celeritas::Span<const value_type>;
     //!@}
 
   public:

--- a/app/demo-interactor/PhysicsArrayCalculator.i.hh
+++ b/app/demo-interactor/PhysicsArrayCalculator.i.hh
@@ -16,6 +16,15 @@ namespace celeritas
  * Calculate the cross section.
  *
  * Assumes that the energy grid has the same units as particle.energy.
+ *
+ * XXX also this breaks if prime_energy != 1, since the
+ * value of "xs" is actually xs*E above E' but the stored value at the lower
+ * grid point is just xs.
+ *
+ * To fix that, we can change 'prime_energy' to 'prime_energy_index' since it
+ * should always be on a grid point. If `bin == prime_energy_index`, then scale
+ * the lower xs value by E. If bin >= prime_energy_index, scale the result by
+ * 1/E.
  */
 CELER_FUNCTION real_type
 PhysicsArrayCalculator::operator()(const ParticleTrackView& particle) const

--- a/app/demo-rasterizer/ImageIO.hh
+++ b/app/demo-rasterizer/ImageIO.hh
@@ -36,7 +36,7 @@ void to_json(nlohmann::json& j, const ImageStore& value);
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 void from_json(const nlohmann::json& j, Array<T, N>& value)
 {
     REQUIRE(j.size() == N);
@@ -47,7 +47,7 @@ void from_json(const nlohmann::json& j, Array<T, N>& value)
 }
 
 //---------------------------------------------------------------------------//
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 void to_json(nlohmann::json& j, const Array<T, N>& value)
 {
     j = nlohmann::json::array();

--- a/scripts/build/yuri.cmake
+++ b/scripts/build/yuri.cmake
@@ -2,6 +2,8 @@ macro(set_cache_var var type val)
   set(${var} "${val}" CACHE "${type}" "yuri.sh")
 endmacro()
 
+set_cache_var(CELERITAS_BUILD_DOCS BOOL ON)
+
 # Dependency options
 set_cache_var(CELERITAS_USE_CUDA BOOL OFF)
 set_cache_var(CELERITAS_USE_Geant4 BOOL OFF)

--- a/scripts/build/yuri.sh
+++ b/scripts/build/yuri.sh
@@ -7,6 +7,8 @@ cd $SOURCE_DIR
 mkdir build 2>/dev/null || true
 cd build
 
+module load doxygen
+
 CELERITAS_ENV=${SPACK_ROOT}/var/spack/environments/celeritas/.spack-env/view
 export PATH=$CELERITAS_ENV/bin:${PATH}
 export CMAKE_PREFIX_PATH=$CELERITAS_ENV:${CMAKE_PREFIX_PATH}

--- a/src/base/Array.hh
+++ b/src/base/Array.hh
@@ -19,7 +19,7 @@ namespace celeritas
  * This isn't fully standards-compliant with std::array: there's no support for
  * N=0 for example.
  */
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 struct Array
 {
     //!@{
@@ -99,7 +99,7 @@ struct Array
 /*!
  * Test equality of two arrays.
  */
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 inline CELER_FUNCTION bool
 operator==(const Array<T, N>& lhs, const Array<T, N>& rhs)
 {
@@ -115,7 +115,7 @@ operator==(const Array<T, N>& lhs, const Array<T, N>& rhs)
 /*!
  * Test inequality of two arrays.
  */
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 CELER_FORCEINLINE_FUNCTION bool
 operator!=(const Array<T, N>& lhs, const Array<T, N>& rhs)
 {

--- a/src/base/ArrayUtils.hh
+++ b/src/base/ArrayUtils.hh
@@ -14,23 +14,23 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 // Perform y <- ax + y
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 inline CELER_FUNCTION void axpy(T a, const Array<T, N>& x, Array<T, N>* y);
 
 //---------------------------------------------------------------------------//
 // Calculate product of two vectors
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 inline CELER_FUNCTION T dot_product(const Array<T, N>& x, const Array<T, N>& y);
 
 //---------------------------------------------------------------------------//
 // Calculate product of two vectors
-template<typename T>
+template<class T>
 inline CELER_FUNCTION Array<T, 3>
 cross_product(const Array<T, 3>& x, const Array<T, 3>& y);
 
 //---------------------------------------------------------------------------//
 // Calculate the Euclidian (2) norm of a vector
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 inline CELER_FUNCTION T norm(const Array<T, N>& vec);
 
 //---------------------------------------------------------------------------//
@@ -47,7 +47,7 @@ inline CELER_FUNCTION Real3 rotate(const Real3& dir, const Real3& rot);
 
 //---------------------------------------------------------------------------//
 // Test for being approximately a unit vector
-template<typename T, std::size_t N, class SoftEq>
+template<class T, std::size_t N, class SoftEq>
 inline CELER_FUNCTION bool
 is_soft_unit_vector(const Array<T, N>& v, SoftEq cmp);
 

--- a/src/base/ArrayUtils.i.hh
+++ b/src/base/ArrayUtils.i.hh
@@ -16,7 +16,7 @@ namespace celeritas
 /*!
  * Increment a vector by another vector multiplied by a scalar.
  */
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 CELER_FUNCTION void axpy(T a, const Array<T, N>& x, Array<T, N>* y)
 {
     for (std::size_t i = 0; i != N; ++i)
@@ -29,7 +29,7 @@ CELER_FUNCTION void axpy(T a, const Array<T, N>& x, Array<T, N>* y)
 /*!
  * Dot product of two vectors.
  */
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 CELER_FUNCTION T dot_product(const Array<T, N>& x, const Array<T, N>& y)
 {
     T result{};
@@ -44,7 +44,7 @@ CELER_FUNCTION T dot_product(const Array<T, N>& x, const Array<T, N>& y)
 /*!
  * Cross product of two space vectors.
  */
-template<typename T>
+template<class T>
 CELER_FUNCTION Array<T, 3>
                cross_product(const Array<T, 3>& A, const Array<T, 3>& B)
 {
@@ -57,7 +57,7 @@ CELER_FUNCTION Array<T, 3>
 /*!
  * Calculate the Euclidian (2) norm of a vector.
  */
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 CELER_FUNCTION T norm(const Array<T, N>& v)
 {
     return std::sqrt(dot_product(v, v));
@@ -187,7 +187,7 @@ inline CELER_FUNCTION Real3 rotate(const Real3& dir, const Real3& rot)
   REQUIRE(is_soft_unit_vector(v, SoftEqual(1e-12)))
   \endcode
  */
-template<typename T, std::size_t N, class SoftEq>
+template<class T, std::size_t N, class SoftEq>
 CELER_FUNCTION bool is_soft_unit_vector(const Array<T, N>& v, SoftEq cmp)
 {
     return cmp(T(1), dot_product(v, v));

--- a/src/base/Assert.hh
+++ b/src/base/Assert.hh
@@ -3,7 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file Assert.hh
+/*! \file Assert.hh
+ *  \brief Macros, exceptions, and helpers for assertions and error handling.
+ */
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -190,11 +192,9 @@ enum class DebugErrorType
 class DebugError : public std::logic_error
 {
   public:
-    //!@{
-    //! Delegating constructor
+    // Delegating constructors
     explicit DebugError(const char* msg);
     explicit DebugError(const std::string& msg);
-    //!@}
 };
 
 //---------------------------------------------------------------------------//
@@ -204,11 +204,9 @@ class DebugError : public std::logic_error
 class RuntimeError : public std::runtime_error
 {
   public:
-    //!@{
-    //! Delegating constructor
+    // Delegating constructor
     explicit RuntimeError(const char* msg);
     explicit RuntimeError(const std::string& msg);
-    //!@}
 };
 
 #endif //__CUDA_ARCH__

--- a/src/base/Interpolator.i.hh
+++ b/src/base/Interpolator.i.hh
@@ -16,7 +16,7 @@ namespace celeritas
 /*!
  * Construct with left and right values for x and y.
  */
-template<Interp XI, Interp YI, typename T>
+template<Interp XI, Interp YI, class T>
 CELER_FUNCTION Interpolator<XI, YI, T>::Interpolator(Point left, Point right)
 {
     enum
@@ -45,7 +45,7 @@ CELER_FUNCTION Interpolator<XI, YI, T>::Interpolator(Point left, Point right)
 /*!
  * Interpolate linearly on the transformed type.
  */
-template<Interp XI, Interp YI, typename T>
+template<Interp XI, Interp YI, class T>
 CELER_FUNCTION auto Interpolator<XI, YI, T>::operator()(real_type x) const
     -> real_type
 {

--- a/src/base/NumericLimits.hh
+++ b/src/base/NumericLimits.hh
@@ -18,7 +18,7 @@
 namespace celeritas
 {
 #ifdef __CUDA_ARCH__
-template<typename Numeric>
+template<class Numeric>
 struct numeric_limits;
 
 template<>

--- a/src/base/Range.hh
+++ b/src/base/Range.hh
@@ -41,7 +41,7 @@ namespace celeritas
 /*!
  * Return a range over fixed beginning and end values.
  */
-template<typename T>
+template<class T>
 CELER_FUNCTION detail::FiniteRange<T> range(T begin, T end)
 {
     return {begin, end};
@@ -51,7 +51,7 @@ CELER_FUNCTION detail::FiniteRange<T> range(T begin, T end)
 /*!
  * Return a range with the default start value (0 for numeric types)
  */
-template<typename T>
+template<class T>
 CELER_FUNCTION detail::FiniteRange<T> range(T end)
 {
     return {T(), end};
@@ -61,7 +61,7 @@ CELER_FUNCTION detail::FiniteRange<T> range(T end)
 /*!
  * Count upward from zero.
  */
-template<typename T>
+template<class T>
 CELER_FUNCTION detail::InfiniteRange<T> count()
 {
     return {T()};
@@ -71,7 +71,7 @@ CELER_FUNCTION detail::InfiniteRange<T> count()
 /*!
  * Count upward from a value.
  */
-template<typename T>
+template<class T>
 CELER_FUNCTION detail::InfiniteRange<T> count(T begin)
 {
     return {begin};

--- a/src/base/SoftEqual.hh
+++ b/src/base/SoftEqual.hh
@@ -25,13 +25,13 @@ namespace celeritas
  * \param abs threshold for absolute error when comparing to zero
  *           (default 1.0e-14 for doubles)
  */
-template<class T = ::celeritas::real_type>
+template<class RealType = ::celeritas::real_type>
 class SoftEqual
 {
   public:
     //!@{
     //! Type aliases
-    using value_type = T;
+    using value_type = RealType;
     //!@}
 
   public:
@@ -72,14 +72,14 @@ class SoftEqual
  * \param abs threshold for absolute error when comparing to zero
  *           (default 1.0e-14 for doubles)
  */
-template<class T = ::celeritas::real_type>
+template<class RealType = ::celeritas::real_type>
 class SoftZero
 {
   public:
     //!@{
     //! Type aliases
-    using argument_type = T;
-    using value_type    = T;
+    using argument_type = RealType;
+    using value_type    = RealType;
     //!@}
 
   public:
@@ -107,18 +107,18 @@ class SoftZero
 
 //---------------------------------------------------------------------------//
 //! Soft equivalence with default tolerance
-template<class T>
-inline CELER_FUNCTION bool soft_equal(T expected, T actual)
+template<class RealType>
+inline CELER_FUNCTION bool soft_equal(RealType expected, RealType actual)
 {
-    return SoftEqual<T>()(expected, actual);
+    return SoftEqual<RealType>()(expected, actual);
 }
 
 //---------------------------------------------------------------------------//
 //! Soft equivalence to zero, with default tolerance
-template<class T>
-inline CELER_FUNCTION bool soft_zero(T actual)
+template<class RealType>
+inline CELER_FUNCTION bool soft_zero(RealType actual)
 {
-    return SoftZero<T>()(actual);
+    return SoftZero<RealType>()(actual);
 }
 
 } // namespace celeritas

--- a/src/base/SoftEqual.hh
+++ b/src/base/SoftEqual.hh
@@ -25,17 +25,13 @@ namespace celeritas
  * \param abs threshold for absolute error when comparing to zero
  *           (default 1.0e-14 for doubles)
  */
-template<typename T1 = real_type, typename T2 = T1>
+template<class T = ::celeritas::real_type>
 class SoftEqual
 {
   public:
     //!@{
     //! Type aliases
-    using first_argument_type  = T1;
-    using second_argument_type = T2;
-    using value_type =
-        typename detail::SoftPrecisionType<first_argument_type,
-                                           second_argument_type>::type;
+    using value_type = T;
     //!@}
 
   public:
@@ -76,7 +72,7 @@ class SoftEqual
  * \param abs threshold for absolute error when comparing to zero
  *           (default 1.0e-14 for doubles)
  */
-template<typename T>
+template<class T = ::celeritas::real_type>
 class SoftZero
 {
   public:
@@ -84,7 +80,6 @@ class SoftZero
     //! Type aliases
     using argument_type = T;
     using value_type    = T;
-    using traits_t      = detail::SoftEqualTraits<value_type>;
     //!@}
 
   public:
@@ -106,9 +101,26 @@ class SoftZero
 
   private:
     value_type abs_;
+
+    using traits_t = detail::SoftEqualTraits<value_type>;
 };
 
 //---------------------------------------------------------------------------//
+//! Soft equivalence with default tolerance
+template<class T>
+inline CELER_FUNCTION bool soft_equal(T expected, T actual)
+{
+    return SoftEqual<T>()(expected, actual);
+}
+
+//---------------------------------------------------------------------------//
+//! Soft equivalence to zero, with default tolerance
+template<class T>
+inline CELER_FUNCTION bool soft_zero(T actual)
+{
+    return SoftZero<T>()(actual);
+}
+
 } // namespace celeritas
 
 #include "SoftEqual.i.hh"

--- a/src/base/SoftEqual.i.hh
+++ b/src/base/SoftEqual.i.hh
@@ -5,7 +5,6 @@
 //---------------------------------------------------------------------------//
 //! \file SoftEqual.i.hh
 //---------------------------------------------------------------------------//
-
 #include <cmath>
 #include "Assert.hh"
 
@@ -13,20 +12,20 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with default relative/absolute precision
+ * Construct with default relative/absolute precision.
  */
-template<typename T1, typename T2>
-CELER_FUNCTION SoftEqual<T1, T2>::SoftEqual()
+template<class T>
+CELER_FUNCTION SoftEqual<T>::SoftEqual()
     : SoftEqual(traits_t::rel_prec(), traits_t::abs_thresh())
 {
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct with scaled absolute precision
+ * Construct with scaled absolute precision.
  */
-template<typename T1, typename T2>
-CELER_FUNCTION SoftEqual<T1, T2>::SoftEqual(value_type rel)
+template<class T>
+CELER_FUNCTION SoftEqual<T>::SoftEqual(value_type rel)
     : SoftEqual(rel, rel * (traits_t::abs_thresh() / traits_t::rel_prec()))
 {
     REQUIRE(rel > 0);
@@ -34,10 +33,10 @@ CELER_FUNCTION SoftEqual<T1, T2>::SoftEqual(value_type rel)
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct with both relative and absolute precision
+ * Construct with both relative and absolute precision.
  */
-template<typename T1, typename T2>
-CELER_FUNCTION SoftEqual<T1, T2>::SoftEqual(value_type rel, value_type abs)
+template<class T>
+CELER_FUNCTION SoftEqual<T>::SoftEqual(value_type rel, value_type abs)
     : rel_(rel), abs_(abs)
 {
     REQUIRE(rel > 0);
@@ -54,11 +53,11 @@ CELER_FUNCTION SoftEqual<T1, T2>::SoftEqual(value_type rel, value_type abs)
  * \param expected scalar floating point reference to which value is compared
  * \param actual   scalar floating point value
  */
-template<typename T1, typename T2>
+template<class T>
 CELER_FUNCTION bool
-SoftEqual<T1, T2>::operator()(value_type expected, value_type actual) const
+SoftEqual<T>::operator()(value_type expected, value_type actual) const
 {
-    value_type abs_e = std::fabs(expected);
+    const value_type abs_e = std::fabs(expected);
 
     // Typical case: relative error comparison to reference
     if (std::fabs(actual - expected) < rel_ * abs_e)
@@ -66,8 +65,8 @@ SoftEqual<T1, T2>::operator()(value_type expected, value_type actual) const
         return true;
     }
 
-    value_type eps_abs = abs_;
-    value_type abs_a   = std::fabs(actual);
+    const value_type eps_abs = abs_;
+    const value_type abs_a   = std::fabs(actual);
     // If one is within the absolute threshold of zero, and the other within
     // relative of zero, they're equal
     if ((abs_e < eps_abs) && (abs_a < rel_))
@@ -91,18 +90,18 @@ SoftEqual<T1, T2>::operator()(value_type expected, value_type actual) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct with default relative/absolute precision
+ * Construct with default relative/absolute precision.
  */
-template<typename T>
+template<class T>
 CELER_FUNCTION SoftZero<T>::SoftZero() : SoftZero(traits_t::abs_thresh())
 {
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct with default absolute precision
+ * Construct with default absolute precision.
  */
-template<typename T>
+template<class T>
 CELER_FUNCTION SoftZero<T>::SoftZero(value_type abs) : abs_(abs)
 {
     REQUIRE(abs > 0);
@@ -110,14 +109,13 @@ CELER_FUNCTION SoftZero<T>::SoftZero(value_type abs) : abs_(abs)
 
 //---------------------------------------------------------------------------//
 /*!
- * Compare value against zero
+ * See if the value is within absolute tolerance of zero.
  *
- * \param actual   scalar floating point value
+ * \param actual scalar floating point value
  */
-template<typename T>
+template<class T>
 CELER_FUNCTION bool SoftZero<T>::operator()(value_type actual) const
 {
-    // Return whether the absolute value is within tolerance
     return std::fabs(actual) < abs_;
 }
 

--- a/src/base/SoftEqual.i.hh
+++ b/src/base/SoftEqual.i.hh
@@ -14,8 +14,8 @@ namespace celeritas
 /*!
  * Construct with default relative/absolute precision.
  */
-template<class T>
-CELER_FUNCTION SoftEqual<T>::SoftEqual()
+template<class RealType>
+CELER_FUNCTION SoftEqual<RealType>::SoftEqual()
     : SoftEqual(traits_t::rel_prec(), traits_t::abs_thresh())
 {
 }
@@ -24,8 +24,8 @@ CELER_FUNCTION SoftEqual<T>::SoftEqual()
 /*!
  * Construct with scaled absolute precision.
  */
-template<class T>
-CELER_FUNCTION SoftEqual<T>::SoftEqual(value_type rel)
+template<class RealType>
+CELER_FUNCTION SoftEqual<RealType>::SoftEqual(value_type rel)
     : SoftEqual(rel, rel * (traits_t::abs_thresh() / traits_t::rel_prec()))
 {
     REQUIRE(rel > 0);
@@ -35,8 +35,8 @@ CELER_FUNCTION SoftEqual<T>::SoftEqual(value_type rel)
 /*!
  * Construct with both relative and absolute precision.
  */
-template<class T>
-CELER_FUNCTION SoftEqual<T>::SoftEqual(value_type rel, value_type abs)
+template<class RealType>
+CELER_FUNCTION SoftEqual<RealType>::SoftEqual(value_type rel, value_type abs)
     : rel_(rel), abs_(abs)
 {
     REQUIRE(rel > 0);
@@ -53,9 +53,9 @@ CELER_FUNCTION SoftEqual<T>::SoftEqual(value_type rel, value_type abs)
  * \param expected scalar floating point reference to which value is compared
  * \param actual   scalar floating point value
  */
-template<class T>
+template<class RealType>
 CELER_FUNCTION bool
-SoftEqual<T>::operator()(value_type expected, value_type actual) const
+SoftEqual<RealType>::operator()(value_type expected, value_type actual) const
 {
     const value_type abs_e = std::fabs(expected);
 
@@ -92,8 +92,9 @@ SoftEqual<T>::operator()(value_type expected, value_type actual) const
 /*!
  * Construct with default relative/absolute precision.
  */
-template<class T>
-CELER_FUNCTION SoftZero<T>::SoftZero() : SoftZero(traits_t::abs_thresh())
+template<class RealType>
+CELER_FUNCTION SoftZero<RealType>::SoftZero()
+    : SoftZero(traits_t::abs_thresh())
 {
 }
 
@@ -101,8 +102,8 @@ CELER_FUNCTION SoftZero<T>::SoftZero() : SoftZero(traits_t::abs_thresh())
 /*!
  * Construct with default absolute precision.
  */
-template<class T>
-CELER_FUNCTION SoftZero<T>::SoftZero(value_type abs) : abs_(abs)
+template<class RealType>
+CELER_FUNCTION SoftZero<RealType>::SoftZero(value_type abs) : abs_(abs)
 {
     REQUIRE(abs > 0);
 }
@@ -113,8 +114,8 @@ CELER_FUNCTION SoftZero<T>::SoftZero(value_type abs) : abs_(abs)
  *
  * \param actual scalar floating point value
  */
-template<class T>
-CELER_FUNCTION bool SoftZero<T>::operator()(value_type actual) const
+template<class RealType>
+CELER_FUNCTION bool SoftZero<RealType>::operator()(value_type actual) const
 {
     return std::fabs(actual) < abs_;
 }

--- a/src/base/SpanRemapper.hh
+++ b/src/base/SpanRemapper.hh
@@ -43,7 +43,7 @@ namespace celeritas
  * between const and non-const types, as well as (potentially) device pointers
  * and non-device.
  */
-template<typename T, typename U>
+template<class T, class U>
 class SpanRemapper
 {
   public:
@@ -58,7 +58,7 @@ class SpanRemapper
     inline SpanRemapper(src_type src_span, dst_type dst_span);
 
     // Convert a subspan of the "source" to a corresponding subspan in "dst"
-    template<typename V>
+    template<class V>
     inline auto operator()(Span<V> src_subspan) const -> dst_type;
 
   private:
@@ -68,7 +68,7 @@ class SpanRemapper
 
 //---------------------------------------------------------------------------//
 //! Helper function for creating a span mapper.
-template<typename T, typename U>
+template<class T, class U>
 inline SpanRemapper<T, U> make_span_remapper(Span<T> src, Span<U> dst)
 {
     return SpanRemapper<T, U>{src, dst};

--- a/src/base/SpanRemapper.i.hh
+++ b/src/base/SpanRemapper.i.hh
@@ -14,7 +14,7 @@ namespace celeritas
 /*!
  * Construct with source and destination ranges.
  */
-template<typename T, typename U>
+template<class T, class U>
 SpanRemapper<T, U>::SpanRemapper(src_type src_span, dst_type dst_span)
     : src_(src_span), dst_(dst_span)
 {
@@ -25,8 +25,8 @@ SpanRemapper<T, U>::SpanRemapper(src_type src_span, dst_type dst_span)
 /*!
  * Convert a subspan of the "source" to a corresponding subspan in "dst".
  */
-template<typename T, typename U>
-template<typename V>
+template<class T, class U>
+template<class V>
 auto SpanRemapper<T, U>::operator()(Span<V> src_subspan) const -> dst_type
 {
     REQUIRE(src_subspan.empty()

--- a/src/base/StackAllocatorView.hh
+++ b/src/base/StackAllocatorView.hh
@@ -68,8 +68,6 @@ class StackAllocatorView
     using value_type      = T;
     using size_type       = ull_int;
     using result_type     = value_type*;
-    using const_span_type = Span<const value_type>;
-    using span_type       = Span<value_type>;
     using Pointers        = StackAllocatorPointers<T>;
     //!@}
 
@@ -84,8 +82,8 @@ class StackAllocatorView
     inline CELER_FUNCTION size_type capacity() const;
 
     // View all allocated data
-    inline CELER_FUNCTION span_type       get();
-    inline CELER_FUNCTION const_span_type get() const;
+    inline CELER_FUNCTION Span<value_type> get();
+    inline CELER_FUNCTION Span<const value_type> get() const;
 
   private:
     const Pointers& shared_;

--- a/src/base/StackAllocatorView.i.hh
+++ b/src/base/StackAllocatorView.i.hh
@@ -91,7 +91,7 @@ CELER_FUNCTION auto StackAllocatorView<T>::capacity() const -> size_type
  * This cannot be called while any running kernel could be modifiying the size.
  */
 template<class T>
-CELER_FUNCTION auto StackAllocatorView<T>::get() -> span_type
+CELER_FUNCTION auto StackAllocatorView<T>::get() -> Span<value_type>
 {
     REQUIRE(*shared_.size <= this->capacity());
     return {shared_.storage.data(), *shared_.size};
@@ -104,7 +104,8 @@ CELER_FUNCTION auto StackAllocatorView<T>::get() -> span_type
  * This cannot be called while any running kernel could be modifiying the size.
  */
 template<class T>
-CELER_FUNCTION auto StackAllocatorView<T>::get() const -> const_span_type
+CELER_FUNCTION auto StackAllocatorView<T>::get() const
+    -> Span<const value_type>
 {
     REQUIRE(*shared_.size <= this->capacity());
     return {shared_.storage.data(), *shared_.size};

--- a/src/base/detail/InterpolatorTraits.hh
+++ b/src/base/detail/InterpolatorTraits.hh
@@ -18,10 +18,10 @@ namespace detail
 /*!
  * Traits class for interpolating with linear/logarithmic scaling.
  */
-template<Interp I, typename T>
+template<Interp I, class T>
 struct InterpolatorTraits;
 
-template<typename T>
+template<class T>
 struct InterpolatorTraits<Interp::linear, T>
 {
     static CELER_CONSTEXPR_FUNCTION T transform(T value) { return value; }
@@ -37,7 +37,7 @@ struct InterpolatorTraits<Interp::linear, T>
     static CELER_CONSTEXPR_FUNCTION bool valid_domain(T) { return true; }
 };
 
-template<typename T>
+template<class T>
 struct InterpolatorTraits<Interp::log, T>
 {
     static CELER_CONSTEXPR_FUNCTION T transform(T value)

--- a/src/base/detail/RangeImpl.hh
+++ b/src/base/detail/RangeImpl.hh
@@ -17,14 +17,14 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
-template<typename T, typename Enable = void>
+template<class T, class Enable = void>
 struct range_type_traits
 {
     using value_type   = T;
     using counter_type = T;
 };
 
-template<typename T>
+template<class T>
 struct range_type_traits<T, typename std::enable_if<std::is_enum<T>::value>::type>
 {
     using value_type   = T;
@@ -32,7 +32,7 @@ struct range_type_traits<T, typename std::enable_if<std::is_enum<T>::value>::typ
 };
 
 //---------------------------------------------------------------------------//
-template<typename T>
+template<class T>
 class range_iter : public std::iterator<std::input_iterator_tag, T>
 {
   public:
@@ -93,7 +93,7 @@ class range_iter : public std::iterator<std::input_iterator_tag, T>
 };
 
 //---------------------------------------------------------------------------//
-template<typename T>
+template<class T>
 class inf_range_iter : public range_iter<T>
 {
     using Base = range_iter<T>;
@@ -113,7 +113,7 @@ class inf_range_iter : public range_iter<T>
 };
 
 //---------------------------------------------------------------------------//
-template<typename T>
+template<class T>
 class step_range_iter : public range_iter<T>
 {
     using Base = range_iter<T>;
@@ -136,14 +136,14 @@ class step_range_iter : public range_iter<T>
         return copy;
     }
 
-    template<typename U = T>
+    template<class U = T>
     CELER_FUNCTION typename std::enable_if_t<std::is_signed<U>::value, bool>
     operator==(step_range_iter const& other) const
     {
         return step_ >= 0 ? value_ >= other.value_ : value_ < other.value_;
     }
 
-    template<typename U = T>
+    template<class U = T>
     CELER_FUNCTION typename std::enable_if_t<std::is_unsigned<U>::value, bool>
     operator==(step_range_iter const& other) const
     {
@@ -161,7 +161,7 @@ class step_range_iter : public range_iter<T>
 };
 
 //---------------------------------------------------------------------------//
-template<typename T>
+template<class T>
 class inf_step_range_iter : public step_range_iter<T>
 {
     using Base = step_range_iter<T>;
@@ -187,7 +187,7 @@ class inf_step_range_iter : public step_range_iter<T>
 /*!
  * Proxy container for iterating over a finite range with a non-unit step
  */
-template<typename T>
+template<class T>
 class StepRange
 {
   public:
@@ -211,7 +211,7 @@ class StepRange
 /*!
  * Proxy container for iterating over an infinite range with a non-unit step
  */
-template<typename T>
+template<class T>
 class InfStepRange
 {
   public:
@@ -232,7 +232,7 @@ class InfStepRange
 /*!
  * Proxy container for iterating over a range of integral values.
  */
-template<typename T>
+template<class T>
 class FiniteRange
 {
   public:
@@ -246,7 +246,7 @@ class FiniteRange
     CELER_FUNCTION FiniteRange(T begin, T end) : begin_(begin), end_(end) {}
 
     //! Return a stepped range using a different integer type
-    template<typename U, std::enable_if_t<std::is_signed<U>::value, U> = 0>
+    template<class U, std::enable_if_t<std::is_signed<U>::value, U> = 0>
     CELER_FUNCTION StepRange<typename std::common_type<T, U>::type> step(U step)
     {
         if (step < 0)
@@ -260,7 +260,7 @@ class FiniteRange
     }
 
     //! Return a stepped range using a different integer type
-    template<typename U, std::enable_if_t<std::is_unsigned<U>::value, U> = 0>
+    template<class U, std::enable_if_t<std::is_unsigned<U>::value, U> = 0>
     CELER_FUNCTION StepRange<typename std::common_type<T, U>::type> step(U step)
     {
         return {*begin_, *end_, step};
@@ -280,7 +280,7 @@ class FiniteRange
 /*!
  * Proxy container for iterating over a range of integral values.
  */
-template<typename T>
+template<class T>
 class InfiniteRange
 {
   public:

--- a/src/base/detail/SoftEqualTraits.hh
+++ b/src/base/detail/SoftEqualTraits.hh
@@ -19,7 +19,7 @@ namespace detail
  *
  * This also gives compile-time checking for bad values.
  */
-template<typename T>
+template<class T>
 struct SoftEqualTraits
 {
     using value_type = T;

--- a/src/base/detail/SoftEqualTraits.hh
+++ b/src/base/detail/SoftEqualTraits.hh
@@ -56,30 +56,5 @@ struct SoftEqualTraits<float>
 };
 
 //---------------------------------------------------------------------------//
-/*!
- * \struct SoftPrecisionType
- * Get a "least common denominator" for soft comparisons.
- */
-template<typename T1, typename T2>
-struct SoftPrecisionType
-{
-    // Equivalent to std::common_type<T1,T2>::type
-    using type = decltype(true ? T1() : T2());
-};
-
-// When comparing doubles to floats, use the floating point epsilon for
-// comparison
-template<>
-struct SoftPrecisionType<double, float>
-{
-    using type = float;
-};
-template<>
-struct SoftPrecisionType<float, double>
-{
-    using type = float;
-};
-
-//---------------------------------------------------------------------------//
 } // namespace detail
 } // namespace celeritas

--- a/src/geometry/GeoStatePointers.hh
+++ b/src/geometry/GeoStatePointers.hh
@@ -34,15 +34,12 @@ struct GeoStatePointers
     Real3*     dir       = nullptr;
     real_type* next_step = nullptr;
 
-    //! Check whether the interface is initialized
+    //! True if assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        REQUIRE(this->valid());
-        return bool(size);
+        return bool(size) && bool(vgmaxdepth) && bool(vgstate) && bool(vgnext)
+               && bool(pos) && bool(dir) && bool(next_step);
     }
-
-    // Whether the interface is valid
-    inline CELER_FUNCTION bool valid() const;
 };
 
 //! Data required to initialize a geometry state
@@ -51,28 +48,6 @@ struct GeoStateInitializer
     Real3 pos;
     Real3 dir;
 };
-
-//---------------------------------------------------------------------------//
-// MEMBER FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- * Check whether the state is consistently assigned.
- *
- * This is called as part of the bool operator, which should be checked as part
- * of an assertion immediately before launching a kernel and when returning a
- * state.
- */
-CELER_FUNCTION bool GeoStatePointers::valid() const
-{
-    // clang-format off
-    return    bool(size) == bool(vgmaxdepth)
-           && bool(size) == bool(vgstate)
-           && bool(size) == bool(vgnext)
-           && bool(size) == bool(pos)
-           && bool(size) == bool(dir)
-           && bool(size) == bool(next_step);
-    // clang-format on
-}
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/io/EventReader.cc
+++ b/src/io/EventReader.cc
@@ -17,7 +17,7 @@ namespace celeritas
 /*!
  * Construct from a filename.
  */
-EventReader::EventReader(const char* filename, constSPParticleParams params)
+EventReader::EventReader(const char* filename, SPConstParticles params)
     : params_(std::move(params))
 {
     // Determine the input file format and construct the appropriate reader

--- a/src/io/EventReader.hh
+++ b/src/io/EventReader.hh
@@ -24,20 +24,20 @@ class EventReader
   public:
     //!@{
     //! Type aliases
-    using constSPParticleParams = std::shared_ptr<const ParticleParams>;
+    using SPConstParticles      = std::shared_ptr<const ParticleParams>;
     using result_type           = std::vector<Primary>;
     //!@}
 
   public:
     // Construct from a filename
-    explicit EventReader(const char* filename, constSPParticleParams params);
+    explicit EventReader(const char* filename, SPConstParticles params);
 
     // Generate primary particles from the event record
     result_type operator()();
 
   private:
     // Shared standard model particle data
-    constSPParticleParams params_;
+    SPConstParticles params_;
 
     // HepMC3 event record reader
     std::shared_ptr<HepMC3::Reader> input_file_;

--- a/src/physics/material/MaterialParams.cc
+++ b/src/physics/material/MaterialParams.cc
@@ -181,7 +181,7 @@ MaterialParams::extend_elcomponents(const MaterialInput& inp)
     }
 
     // Renormalize component fractions that are not unity and log them
-    if (!inp.elements_fractions.empty() && !SoftEqual<>()(norm, 1.0))
+    if (!inp.elements_fractions.empty() && !soft_equal(norm, 1.0))
     {
         CELER_LOG(warning) << "Element component fractions for `" << inp.name
                            << "` should sum to 1 but instead sum to " << norm
@@ -195,7 +195,7 @@ MaterialParams::extend_elcomponents(const MaterialInput& inp)
             comp.fraction *= norm;
             total_fractions += comp.fraction;
         }
-        CHECK(SoftEqual<>()(total_fractions, 1.0));
+        CHECK(soft_equal(total_fractions, 1.0));
     }
 
     // Sort elements by increasing element ID for improved access

--- a/src/physics/material/MaterialTrackView.hh
+++ b/src/physics/material/MaterialTrackView.hh
@@ -50,8 +50,12 @@ class MaterialTrackView
     inline CELER_FUNCTION MaterialTrackView&
                           operator=(const Initializer_t& other);
 
+    //// DYNAMIC PROPERTIES (pure accessors, free) ////
+
     // Current material identifier
     inline CELER_FUNCTION MaterialDefId def_id() const;
+
+    //// STATIC PROPERTIES ////
 
     // Get a view to material properties
     inline CELER_FUNCTION MaterialView material_view() const;
@@ -62,7 +66,7 @@ class MaterialTrackView
   private:
     const MaterialParamsPointers& params_;
     const MaterialStatePointers&  states_;
-    ThreadId                      tid_;
+    const ThreadId                tid_;
 
     inline CELER_FUNCTION MaterialTrackState& state() const;
 };

--- a/src/random/cuda/RngEngine.hh
+++ b/src/random/cuda/RngEngine.hh
@@ -35,13 +35,14 @@ class RngEngine
 
   public:
     // Construct from state
-    CELER_FUNCTION RngEngine(const RngStatePointers& view, const ThreadId& id);
+    inline CELER_FUNCTION
+    RngEngine(const RngStatePointers& view, const ThreadId& id);
 
     // Initialize state from seed
-    CELER_FUNCTION RngEngine& operator=(Initializer_t s);
+    inline CELER_FUNCTION RngEngine& operator=(Initializer_t s);
 
     // Sample a random number
-    CELER_FUNCTION result_type operator()();
+    inline CELER_FUNCTION result_type operator()();
 
   private:
     RngState& state_;
@@ -66,7 +67,7 @@ class GenerateCanonical<RngEngine, float>
 
   public:
     // Sample a random number
-    CELER_FUNCTION result_type operator()(RngEngine& rng);
+    inline CELER_FUNCTION result_type operator()(RngEngine& rng);
 };
 
 //---------------------------------------------------------------------------//
@@ -85,7 +86,7 @@ class GenerateCanonical<RngEngine, double>
 
   public:
     // Sample a random number
-    CELER_FUNCTION result_type operator()(RngEngine& rng);
+    inline CELER_FUNCTION result_type operator()(RngEngine& rng);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/random/distributions/IsotropicDistribution.i.hh
+++ b/src/random/distributions/IsotropicDistribution.i.hh
@@ -15,7 +15,7 @@ namespace celeritas
 /*!
  * Construct with defaults.
  */
-template<typename RealType>
+template<class RealType>
 CELER_FUNCTION IsotropicDistribution<RealType>::IsotropicDistribution()
     : sample_costheta_(-1, 1), sample_phi_(0, 2 * constants::pi)
 {

--- a/test/base/HostStackAllocatorStore.hh
+++ b/test/base/HostStackAllocatorStore.hh
@@ -25,7 +25,6 @@ class HostStackAllocatorStore
     using value_type      = T;
     using Pointers        = celeritas::StackAllocatorPointers<T>;
     using size_type       = typename Pointers::size_type;
-    using const_span_type = celeritas::Span<const value_type>;
     //!@}
 
   public:
@@ -41,7 +40,10 @@ class HostStackAllocatorStore
     }
 
     //! Access allocated data
-    const_span_type get() const { return {storage_.data(), size_}; }
+    celeritas::Span<const value_type> get() const
+    {
+        return {storage_.data(), size_};
+    }
 
     //! Access host pointers
     const Pointers& host_pointers() const { return pointers_; }

--- a/test/base/SoftEqual.test.cc
+++ b/test/base/SoftEqual.test.cc
@@ -15,9 +15,10 @@ using celeritas::SoftEqual;
 using celeritas::SoftZero;
 
 //---------------------------------------------------------------------------//
+
 TEST(SoftEqual, default_precisions)
 {
-    using Comp_t = SoftEqual<double, double>;
+    using Comp_t = SoftEqual<>;
 
     EXPECT_DOUBLE_EQ(1e-12, Comp_t().rel());
     EXPECT_DOUBLE_EQ(1e-14, Comp_t().abs());
@@ -46,11 +47,12 @@ TYPED_TEST_SUITE(FloatingTest, FloatTypes, );
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
+
 TYPED_TEST(FloatingTest, soft_equal)
 {
     using value_type = typename TestFixture::value_type;
     using Limits_t   = typename TestFixture::Limits_t;
-    using Comp_t     = SoftEqual<value_type, value_type>;
+    using Comp_t     = SoftEqual<value_type>;
 
     Comp_t comp;
 
@@ -94,7 +96,6 @@ TYPED_TEST(FloatingTest, soft_equal)
     EXPECT_FALSE(comp(inf, maxval));
 }
 
-//---------------------------------------------------------------------------//
 TYPED_TEST(FloatingTest, soft_zero)
 {
     using value_type = typename TestFixture::value_type;
@@ -125,35 +126,4 @@ TYPED_TEST(FloatingTest, soft_zero)
     const value_type inf = Limits_t::infinity();
     EXPECT_FALSE(comp(inf));
     EXPECT_FALSE(comp(-inf));
-}
-
-//---------------------------------------------------------------------------//
-// Test fixture
-//---------------------------------------------------------------------------//
-template<typename PairT>
-class MixedTest : public celeritas::Test
-{
-  protected:
-    using Comp_t
-        = SoftEqual<typename PairT::first_type, typename PairT::second_type>;
-    using value_type = typename Comp_t::value_type;
-    using Limits_t   = std::numeric_limits<value_type>;
-};
-
-using MixedTypes
-    = ::testing::Types<std::pair<float, double>, std::pair<double, float>>;
-TYPED_TEST_SUITE(MixedTest, MixedTypes, );
-
-//---------------------------------------------------------------------------//
-TYPED_TEST(MixedTest, comparison)
-{
-    using value_type = typename TestFixture::value_type;
-    using Comp_t     = typename TestFixture::Comp_t;
-
-    Comp_t comp;
-
-    // Check types
-    EXPECT_STREQ(typeid(float).name(), typeid(value_type).name());
-    EXPECT_FLOAT_EQ(1.e-6, comp.rel());
-    EXPECT_FLOAT_EQ(1.e-8, comp.abs());
 }

--- a/test/base/SoftEqual.test.cc
+++ b/test/base/SoftEqual.test.cc
@@ -33,7 +33,7 @@ TEST(SoftEqual, default_precisions)
 //---------------------------------------------------------------------------//
 // Test fixture
 //---------------------------------------------------------------------------//
-template<typename T>
+template<class T>
 class FloatingTest : public celeritas::Test
 {
   protected:

--- a/test/geometry/GeoParams.test.cc
+++ b/test/geometry/GeoParams.test.cc
@@ -13,7 +13,7 @@
 #    include <VecGeom/management/CudaManager.h>
 #endif
 
-// using namespace celeritas;
+using celeritas::VolumeId;
 using namespace celeritas_test;
 
 //---------------------------------------------------------------------------//
@@ -30,7 +30,7 @@ class GeoParamsHostTest : public GeoParamsTest
     }
 
     // Views
-    GeoParamsPointers host_view;
+    celeritas::GeoParamsPointers host_view;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/geometry/GeoParamsTest.cc
+++ b/test/geometry/GeoParamsTest.cc
@@ -8,5 +8,11 @@
 
 #include "GeoParamsTest.hh"
 
-celeritas_test::GeoParamsTest::SptrConstParams celeritas_test::GeoParamsTest::geom_
-    = nullptr;
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+
+GeoParamsTest::SPConstGeo GeoParamsTest::geom_ = nullptr;
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/geometry/GeoParamsTest.hh
+++ b/test/geometry/GeoParamsTest.hh
@@ -11,36 +11,33 @@
 
 #include "geometry/GeoParams.hh"
 
-//---------------------------------------------------------------------------//
-// TEST HARNESS
-//---------------------------------------------------------------------------//
-
 namespace celeritas_test
 {
-using namespace celeritas;
+//---------------------------------------------------------------------------//
 
 class GeoParamsTest : public celeritas::Test
 {
   protected:
-    using SptrConstParams = std::shared_ptr<const GeoParams>;
+    using SPConstGeo = std::shared_ptr<const celeritas::GeoParams>;
 
     static void SetUpTestCase()
     {
         std::string test_file
             = celeritas::Test::test_data_path("geometry", "twoBoxes.gdml");
-        geom_ = std::make_shared<GeoParams>(test_file.c_str());
+        geom_ = std::make_shared<celeritas::GeoParams>(test_file.c_str());
     }
 
     static void TearDownTestCase() { geom_.reset(); }
 
-    const SptrConstParams& params()
+    const SPConstGeo& params()
     {
         ENSURE(geom_);
         return geom_;
     }
 
   private:
-    static SptrConstParams geom_;
+    static SPConstGeo geom_;
 };
 
+//---------------------------------------------------------------------------//
 } // namespace celeritas_test

--- a/test/gtest/Test.cc
+++ b/test/gtest/Test.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "Test.hh"
 
+#include <algorithm>
 #include <cctype>
 #include <fstream>
 #include "base/Assert.hh"

--- a/test/gtest/detail/Macros.i.hh
+++ b/test/gtest/detail/Macros.i.hh
@@ -20,7 +20,7 @@ namespace detail
 // SOFT EQUIVALENCE
 //---------------------------------------------------------------------------//
 //! Whether soft equivalence can be performed on the given types.
-template<typename T1, typename T2>
+template<class T1, class T2>
 constexpr bool can_soft_equiv()
 {
     return (std::is_floating_point<T1>::value
@@ -33,7 +33,7 @@ constexpr bool can_soft_equiv()
  * \struct SoftPrecisionType
  * Get a "least common denominator" for soft comparisons.
  */
-template<typename T1, typename T2>
+template<class T1, class T2>
 struct SoftPrecisionType
 {
     // Equivalent to std::common_type<T1,T2>::type
@@ -141,7 +141,7 @@ template<class Value_E, class Value_A>
 // CONTAINER EQUIVALENCE
 //---------------------------------------------------------------------------//
 //! A single index/expected/actual value
-template<typename T1, typename T2>
+template<class T1, class T2>
 struct FailedValue
 {
     using size_type   = std::size_t;
@@ -170,7 +170,7 @@ struct TCT
 };
 
 // Failed value iterator traits
-template<typename Iter1, typename Iter2>
+template<class Iter1, class Iter2>
 struct FVIT
 {
     using first_type = typename std::remove_const<
@@ -184,7 +184,7 @@ struct FVIT
 
 //---------------------------------------------------------------------------//
 //! Compare a range of values
-template<typename Iter1, typename Iter2, class BinaryOp>
+template<class Iter1, class Iter2, class BinaryOp>
 ::testing::AssertionResult
 IsRangeEqImpl(Iter1                               e_iter,
               Iter1                               e_end,

--- a/test/gtest/detail/Macros.i.hh
+++ b/test/gtest/detail/Macros.i.hh
@@ -29,6 +29,32 @@ constexpr bool can_soft_equiv()
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * \struct SoftPrecisionType
+ * Get a "least common denominator" for soft comparisons.
+ */
+template<typename T1, typename T2>
+struct SoftPrecisionType
+{
+    // Equivalent to std::common_type<T1,T2>::type
+    using type = decltype(true ? T1() : T2());
+};
+
+// When comparing doubles to floats, use the floating point epsilon for
+// comparison
+template<>
+struct SoftPrecisionType<double, float>
+{
+    using type = float;
+};
+
+template<>
+struct SoftPrecisionType<float, double>
+{
+    using type = float;
+};
+
+//---------------------------------------------------------------------------//
 //! Compare a range of values.
 template<class BinaryOp>
 ::testing::AssertionResult
@@ -48,16 +74,9 @@ IsSoftEquivImpl(typename BinaryOp::value_type expected,
     // Failed: print nice error message
     ::testing::AssertionResult result = ::testing::AssertionFailure();
 
-    result << "Value of: " << actual_expr
-           << "\n"
-              "  Actual: "
-           << actual
-           << "\n"
-              "Expected: "
-           << expected_expr
-           << "\n"
-              "Which is: "
-           << expected << '\n';
+    result << "Value of: " << actual_expr << "\n  Actual: " << actual
+           << "\nExpected: " << expected_expr << "\nWhich is: " << expected
+           << '\n';
 
     SoftZero<value_type> is_soft_zero(comp.abs());
     if (is_soft_zero(expected))
@@ -88,7 +107,8 @@ template<class Value_E, class Value_A>
                   "Invalid types for soft equivalence");
 
     // Construct with automatic or specified tolerances
-    using BinaryOp = celeritas::SoftEqual<Value_E, Value_A>;
+    using ValueT   = typename SoftPrecisionType<Value_E, Value_A>::type;
+    using BinaryOp = celeritas::SoftEqual<ValueT>;
 
     return IsSoftEquivImpl(
         expected, expected_expr, actual, actual_expr, BinaryOp());
@@ -110,7 +130,8 @@ template<class Value_E, class Value_A>
                   "Invalid types for soft equivalence");
 
     // Construct with automatic or specified tolerances
-    using BinaryOp = celeritas::SoftEqual<Value_E, Value_A>;
+    using ValueT   = typename SoftPrecisionType<Value_E, Value_A>::type;
+    using BinaryOp = celeritas::SoftEqual<ValueT>;
 
     return IsSoftEquivImpl(
         expected, expected_expr, actual, actual_expr, BinaryOp(rel));
@@ -183,16 +204,9 @@ IsRangeEqImpl(Iter1                               e_iter,
     {
         ::testing::AssertionResult failure = ::testing::AssertionFailure();
 
-        failure << " Size of: " << actual_expr
-                << "\n"
-                   "  Actual: "
-                << actual_size
-                << "\n"
-                   "Expected: "
-                << expected_expr
-                << ".size()\n"
-                   "Which is: "
-                << expected_size << '\n';
+        failure << " Size of: " << actual_expr << "\n  Actual: " << actual_size
+                << "\nExpected: " << expected_expr
+                << ".size()\nWhich is: " << expected_size << '\n';
         return failure;
     }
 
@@ -214,12 +228,8 @@ IsRangeEqImpl(Iter1                               e_iter,
     }
 
     ::testing::AssertionResult result = ::testing::AssertionFailure();
-    result << "Values in: " << actual_expr
-           << "\n"
-              " Expected: "
-           << expected_expr
-           << "\n"
-              ""
+    result << "Values in: " << actual_expr << "\n Expected: " << expected_expr
+           << '\n'
            << failures.size() << " of " << expected_size << " elements differ";
     if (failures.size() > 40)
     {
@@ -244,8 +254,9 @@ template<class ContainerE, class ContainerA, class BinaryOp>
                                               const char*       actual_expr,
                                               BinaryOp          comp)
 {
-    using Failed_t = FailedValue<typename BinaryOp::first_argument_type,
-                                 typename BinaryOp::second_argument_type>;
+    using Traits_t = TCT<ContainerE, ContainerA>;
+    using Failed_t = FailedValue<typename Traits_t::first_type,
+                                 typename Traits_t::second_type>;
     std::vector<Failed_t>      failures;
     ::testing::AssertionResult result = IsRangeEqImpl(std::begin(expected),
                                                       std::end(expected),
@@ -444,7 +455,8 @@ template<class ContainerE, class ContainerA>
     static_assert(can_soft_equiv<value_type_E, value_type_A>(),
                   "Invalid types for soft equivalence");
 
-    using BinaryOp = celeritas::SoftEqual<value_type_E, value_type_A>;
+    using ValueT = typename SoftPrecisionType<value_type_E, value_type_A>::type;
+    using BinaryOp = celeritas::SoftEqual<ValueT>;
 
     // Construct with automatic or specified tolerances
     return IsVecSoftEquivImpl(
@@ -473,7 +485,8 @@ template<class ContainerE, class ContainerA>
     static_assert(can_soft_equiv<value_type_E, value_type_A>(),
                   "Invalid types for soft equivalence");
 
-    using BinaryOp = celeritas::SoftEqual<value_type_E, value_type_A>;
+    using ValueT = typename SoftPrecisionType<value_type_E, value_type_A>::type;
+    using BinaryOp = celeritas::SoftEqual<ValueT>;
 
     // Construct with given tolerance
     return IsVecSoftEquivImpl(
@@ -503,7 +516,8 @@ template<class ContainerE, class ContainerA>
     static_assert(can_soft_equiv<value_type_E, value_type_A>(),
                   "Invalid types for soft equivalence");
 
-    using BinaryOp = celeritas::SoftEqual<value_type_E, value_type_A>;
+    using ValueT = typename SoftPrecisionType<value_type_E, value_type_A>::type;
+    using BinaryOp = celeritas::SoftEqual<ValueT>;
 
     // Construct with given tolerance
     return IsVecSoftEquivImpl(

--- a/test/gtest/detail/PrintableValueTraits.hh
+++ b/test/gtest/detail/PrintableValueTraits.hh
@@ -69,7 +69,7 @@ struct ContTraits
         typename std::decay<typename Container::value_type>::type;
 };
 
-template<typename T, std::size_t N>
+template<class T, std::size_t N>
 struct ContTraits<T[N]>
 {
     using size_type  = std::size_t;
@@ -235,7 +235,7 @@ struct PrintableValueTraits<const char*>
 };
 
 //! Specialization for printing std::pairs
-template<typename T1, typename T2>
+template<class T1, class T2>
 struct PrintableValueTraits<std::pair<T1, T2>>
 {
     using PVT1 = PrintableValueTraits<T1>;

--- a/test/physics/InteractorHostTestBase.cc
+++ b/test/physics/InteractorHostTestBase.cc
@@ -180,10 +180,12 @@ void InteractorHostTestBase::check_conservation(const Interaction& interaction) 
 
         Real3 delta_momentum = exit_momentum;
         axpy(-parent_track.momentum().value(), inc_direction_, &delta_momentum);
-        EXPECT_SOFT_EQ(0.0, dot_product(delta_momentum, delta_momentum))
+        EXPECT_SOFT_NEAR(0.0,
+                         dot_product(delta_momentum, delta_momentum),
+                         parent_track.momentum().value() * 1e-12)
             << "Incident: " << inc_direction_
             << " with p = " << parent_track.momentum().value()
-            << "* MeV^2/c^2; exiting p = " << exit_momentum;
+            << "* MeV/c; exiting p = " << exit_momentum;
     }
 }
 


### PR DESCRIPTION
Several minor changes to the codebase 

- Add `soft_equal(...)` and `soft_zero(...)` functions are equivalent of the default template and construction arguments for  `SoftEqual<>()(...)` and `SoftZero(...)`
- Use a single value type for the soft equal template (mixed precision comparison isn't used in practice)
- Unify usage of `Foo<const Bar>` to `FooConstBar`
- Fix the reported  units in momentum comparison (@vrpascuzzi )
- Remove `valid()` accessors for `Pointers` classes