### PR TITLE
Store local energy deposition

### DIFF
--- a/src/physics/base/Interaction.hh
+++ b/src/physics/base/Interaction.hh
@@ -17,10 +17,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Change in state to a particle during an interaction.
- *
- * TODO: we might also need local energy deposition for some inelastic
- * processes/models. (?)
+ * Change in state due to an interaction.
  */
 struct Interaction
 {
@@ -28,6 +25,7 @@ struct Interaction
     units::MevEnergy energy;      //!< Post-interaction energy
     Real3            direction;   //!< Post-interaction direction
     Span<Secondary>  secondaries; //!< Emitted secondaries
+    units::MevEnergy energy_deposition; //!< Energy loss locally to material
 
     // Return an interaction representing a recoverable error
     static inline CELER_FUNCTION Interaction from_failure();

--- a/src/physics/em/PhotoelectricInteractor.i.hh
+++ b/src/physics/em/PhotoelectricInteractor.i.hh
@@ -98,8 +98,10 @@ CELER_FUNCTION Interaction PhotoelectricInteractor::operator()(Engine& rng)
     // If the binding energy of the sampled shell is greater than the incident
     // photon energy, no secondaries are produced and the energy is deposited
     // locally.
-    if (el_.shells[shell_id].binding_energy > inc_energy_)
+    MevEnergy binding_energy = el_.shells[shell_id].binding_energy;
+    if (binding_energy > inc_energy_)
     {
+        result.energy_deposition = inc_energy_;
         return result;
     }
 
@@ -109,14 +111,15 @@ CELER_FUNCTION Interaction PhotoelectricInteractor::operator()(Engine& rng)
 
     // Electron kinetic energy is the difference between the incident photon
     // energy and the binding energy of the shell
-    photoelectron->energy = MevEnergy{
-        inc_energy_.value() - el_.shells[shell_id].binding_energy.value()};
+    photoelectron->energy
+        = MevEnergy{inc_energy_.value() - binding_energy.value()};
 
     // Direction of the emitted photoelectron is sampled from the
     // Sauter-Gavrila distribution
     photoelectron->direction = this->sample_direction(rng);
 
-    // TODO: Atomic relaxation
+    // TODO: Atomic relaxation. For now assume the energy is deposited locally
+    result.energy_deposition = binding_energy;
 
     return result;
 }

--- a/test/physics/InteractorHostTestBase.cc
+++ b/test/physics/InteractorHostTestBase.cc
@@ -146,7 +146,7 @@ void InteractorHostTestBase::check_conservation(const Interaction& interaction) 
     local_state_ptrs.vars = {&local_state, 1};
 
     // Sum of exiting kinetic energy and momentum
-    real_type exit_energy   = 0;
+    real_type exit_energy   = interaction.energy_deposition.value();
     Real3     exit_momentum = {0, 0, 0};
 
     // Subtract contribution from exiting particle state

--- a/test/physics/em/PhotoelectricInteractor.test.cc
+++ b/test/physics/em/PhotoelectricInteractor.test.cc
@@ -113,10 +113,8 @@ class PhotoelectricInteractorTest
         }
 
         // Check conservation between primary and secondaries
-        // TODO: atomic relaxation has not been implemented. If the binding
-        // energy of the sampled shell is larger than the incident photon
-        // energy, or there is an energy balance following atomic deexcitation,
-        // the energy will be deposited locally.
+        // Since momentum is transferred to the atom, we don't expect it to be
+        // conserved between the incoming and outgoing particles
         // this->check_conservation(interaction);
     }
 

--- a/test/physics/em/PhotoelectricInteractor.test.cc
+++ b/test/physics/em/PhotoelectricInteractor.test.cc
@@ -147,6 +147,7 @@ TEST_F(PhotoelectricInteractorTest, basic)
 
     std::vector<double> energy_electron;
     std::vector<double> costheta_electron;
+    std::vector<double> energy_deposition;
 
     // Produce four samples from the original incident energy/dir
     for (int i : celeritas::range(4))
@@ -161,6 +162,7 @@ TEST_F(PhotoelectricInteractorTest, basic)
         energy_electron.push_back(result.secondaries.front().energy.value());
         costheta_electron.push_back(celeritas::dot_product(
             result.secondaries.front().direction, this->direction()));
+        energy_deposition.push_back(result.energy_deposition.value());
     }
 
     EXPECT_EQ(4, this->secondary_allocator().get().size());
@@ -170,8 +172,11 @@ TEST_F(PhotoelectricInteractorTest, basic)
         = {0.00062884, 0.00062884, 0.00070136, 0.00069835};
     const double expected_costheta_electron[] = {
         0.1217302869581, 0.8769397871407, -0.1414717733267, -0.2414106440617};
+    const double expected_energy_deposition[]
+        = {0.00037116, 0.00037116, 0.00029864, 0.00030165};
     EXPECT_VEC_SOFT_EQ(expected_energy_electron, energy_electron);
     EXPECT_VEC_SOFT_EQ(expected_costheta_electron, costheta_electron);
+    EXPECT_VEC_SOFT_EQ(expected_energy_deposition, energy_deposition);
 
     // Next sample should fail because we're out of secondary buffer space
     {


### PR DESCRIPTION
Small addition based on our discussion at today’s physics meeting and on #89: this lets us to keep track of local energy deposition in an interaction.