### PR TITLE
Improve ROOT compatibility and ability to build without TPLs

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CELERITAS_USE_Geant4 AND CELERITAS_USE_ROOT)
   )
   target_link_libraries(geant-exporter
     Celeritas::Core
-    Celeritas::IO
+    Celeritas::ROOT
     ROOT::Core
     ROOT::Tree
     XercesC::XercesC
@@ -29,7 +29,7 @@ if(CELERITAS_USE_Geant4 AND CELERITAS_USE_ROOT)
   add_executable(geant-exporter-cat geant-exporter/geant-exporter-cat.cc)
   target_link_libraries(geant-exporter-cat
     Celeritas::Core
-    Celeritas::IO
+    Celeritas::ROOT
   )
 
   if(CELERITAS_BUILD_TESTS)

--- a/app/geant-exporter/GeantPhysicsTableWriter.cc
+++ b/app/geant-exporter/GeantPhysicsTableWriter.cc
@@ -227,7 +227,8 @@ GeantPhysicsTableWriter::GeantPhysicsTableWriter(TFile*         root_file,
 {
     REQUIRE(root_file);
     this->tree_process_ = std::make_unique<TTree>("processes", "processes");
-    tree_process_->Branch("ImportProcess", &process_);
+    auto* tbranch       = tree_process_->Branch("ImportProcess", &process_);
+    ENSURE(tbranch);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/geant-exporter/GeantPhysicsTableWriter.cc
+++ b/app/geant-exporter/GeantPhysicsTableWriter.cc
@@ -239,7 +239,8 @@ GeantPhysicsTableWriter::~GeantPhysicsTableWriter()
 {
     try
     {
-        root_file_->Write();
+        int err_code = root_file_->Write();
+        ENSURE(err_code >= 0);
     }
     catch (const std::exception& e)
     {

--- a/app/geant-exporter/geant-exporter.cc
+++ b/app/geant-exporter/geant-exporter.cc
@@ -73,7 +73,8 @@ void store_particles(TFile* root_file, G4ParticleTable* particle_table)
 
     // Create temporary particle
     ImportParticle particle;
-    tree_particles.Branch("ImportParticle", &particle);
+    TBranch*       branch = tree_particles.Branch("ImportParticle", &particle);
+    CHECK(branch);
 
     G4ParticleTable::G4PTblDicIterator& particle_iterator
         = *(G4ParticleTable::GetParticleTable()->GetIterator());
@@ -241,7 +242,8 @@ void store_geometry(TFile*                       root_file,
 
     // Create geometry map and ROOT branch
     GdmlGeometryMap geometry;
-    tree_materials.Branch("GdmlGeometryMap", &geometry);
+    TBranch* branch = tree_materials.Branch("GdmlGeometryMap", &geometry);
+    CHECK(branch);
 
     // Populate global element map
     const auto g4element_table = *G4Element::GetElementTable();

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -12,8 +12,10 @@
 set(DOXYGEN_EXCLUDE_PATTERNS
   "*.nocuda.hh"
   "*.nocuda.cc"
+  "*.nohepmc.cc"
   "*.nompi.cc"
   "*.nompi.i.hh"
+  "*.noroot.cc"
   "*/detail/*"
 )
 set(DOXYGEN_FILE_PATTERNS

--- a/scripts/build/docker.sh
+++ b/scripts/build/docker.sh
@@ -35,6 +35,7 @@ cmake -G Ninja \
   -DCELERITAS_DEBUG:BOOL=ON \
   -DCMAKE_BUILD_TYPE:STRING="RelWithDebInfo" \
   -DCMAKE_CUDA_ARCHITECTURES:STRING="70" \
+  -DCMAKE_EXE_LINKER_FLAGS:STRING="-Wl,--no-as-needed" \
   -DCMAKE_SHARED_LINKER_FLAGS:STRING="-Wl,--no-as-needed" \
   -DMPIEXEC_PREFLAGS:STRING="--allow-run-as-root" \
   -DMPI_CXX_LINK_FLAGS:STRING="-pthread" \

--- a/scripts/docker/ci/launch-testing.sh
+++ b/scripts/docker/ci/launch-testing.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -ex
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 pull-request-id" 1>&2
+  exit 2;
+fi
+
+CONTAINER=$(docker run -t -d celeritas/ci-cuda11:latest)
+echo "Launched container: ${CONTAINER}"
+docker exec -i $CONTAINER bash -l <<EOF || echo "*BUILD FAILED*"
+set -e
+git clone https://github.com/celeritas-project/celeritas src
+cd src
+git fetch origin pull/$1/head:mr/$1
+git checkout mr/$1
+SOURCE_DIR=. BUILD_DIR=build entrypoint-shell ./scripts/build/docker.sh
+EOF
+docker stop --time=0 $CONTAINER
+echo "To resume:  docker exec -i -e 'TERM=xterm-256color' $CONTAINER bash -l"
+echo "To delete:  docker rm -f $CONTAINER"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,10 @@ list(APPEND SOURCES
   comm/Logger.cc
   comm/LoggerTypes.cc
   comm/detail/LoggerMessage.cc
+  io/GdmlGeometryMap.cc
+  io/ImportProcess.cc
+  io/ImportPhysicsTable.cc
+  io/ImportPhysicsVector.cc
   io/LivermoreParamsReader.cc
   physics/base/Model.cc
   physics/base/ParticleParams.cc
@@ -78,6 +82,10 @@ if(CELERITAS_USE_HepMC3)
     io/EventReader.cc
   )
   list(APPEND PRIVATE_DEPS ${HEPMC3_LIB})
+else()
+  list(APPEND SOURCES
+    io/EventReader.nohepmc.cc
+  )
 endif()
 
 if(CELERITAS_USE_MPI)
@@ -171,20 +179,25 @@ if(CELERITAS_USE_ROOT)
     LINKDEF io/RootInterfaceLinkDef.h
   )
 
-  # Note that ROOT requires *shared* libraries due to runtime initialization.
-  # Tests that use ROOT to load the data will have to link against this library.
-  add_library(CeleritasIO SHARED
-    io/GdmlGeometryMap.cc
-    io/ImportProcess.cc
-    io/ImportPhysicsTable.cc
-    io/ImportPhysicsVector.cc
+  # Note that ROOT requires *shared* libraries due to runtime initialization,
+  # *and* it must be forcibly linked into any ROOT-using application by ensuring
+  # `-Wl,--no-as-needed` for executables (on Ubuntu, which defaults to linking
+  # only as needed).
+  add_library(celeritas_root SHARED
+    ${CMAKE_CURRENT_BINARY_DIR}/CeleritasRootInterface.cxx
     io/RootImporter.cc
-    CeleritasRootInterface.cxx
   )
-  add_library(Celeritas::IO ALIAS CeleritasIO)
-  target_link_libraries(CeleritasIO
+  target_link_libraries(celeritas_root
     PRIVATE celeritas ROOT::Core ROOT::Tree
   )
+else()
+  # ROOT is disabled: add an importer that
+  add_library(celeritas_root
+    io/RootImporter.noroot.cc
+  )
+  target_link_libraries(celeritas_root PRIVATE celeritas)
 endif()
+
+add_library(Celeritas::ROOT ALIAS celeritas_root)
 
 #---------------------------------------------------------------------------##

--- a/src/base/Assert.cc
+++ b/src/base/Assert.cc
@@ -38,6 +38,8 @@ const char* to_cstring(DebugErrorType which)
             return "internal assertion failed";
         case DebugErrorType::unreachable:
             return "unreachable code point";
+        case DebugErrorType::unconfigured:
+            return "required dependency is disabled in this build";
         case DebugErrorType::postcondition:
             return "postcondition failed";
     }

--- a/src/base/DeviceAllocation.nocuda.cc
+++ b/src/base/DeviceAllocation.nocuda.cc
@@ -16,7 +16,7 @@ namespace celeritas
  */
 DeviceAllocation::DeviceAllocation(size_type)
 {
-    throw DebugError("Cannot allocate device memory because CUDA is disabled");
+    CELER_NOT_CONFIGURED("CUDA");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/comm/Communicator.nompi.cc
+++ b/src/comm/Communicator.nompi.cc
@@ -17,7 +17,7 @@ namespace celeritas
  */
 Communicator::Communicator(MpiComm)
 {
-    throw DebugError("Cannot build a communicator because MPI is disabled");
+    CELER_NOT_CONFIGURED("MPI");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/detail/VGNavStateStore.nocuda.cc
+++ b/src/geometry/detail/VGNavStateStore.nocuda.cc
@@ -19,7 +19,7 @@ namespace detail
  */
 VGNavStateStore::VGNavStateStore(size_type, int)
 {
-    throw DebugError("Cannot allocate device memory because CUDA is disabled");
+    CELER_NOT_CONFIGURED("CUDA");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/io/EventReader.cc
+++ b/src/io/EventReader.cc
@@ -10,6 +10,7 @@
 #include "base/ArrayUtils.hh"
 #include "physics/base/Units.hh"
 #include "HepMC3/GenEvent.h"
+#include "HepMC3/ReaderFactory.h"
 
 namespace celeritas
 {
@@ -24,6 +25,10 @@ EventReader::EventReader(const char* filename, SPConstParticles params)
     input_file_ = HepMC3::deduce_reader(filename);
     ENSURE(input_file_);
 }
+
+//---------------------------------------------------------------------------//
+//! Default destructor
+EventReader::~EventReader() = default;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/io/EventReader.cc
+++ b/src/io/EventReader.cc
@@ -21,6 +21,7 @@ namespace celeritas
 EventReader::EventReader(const char* filename, SPConstParticles params)
     : params_(std::move(params))
 {
+    REQUIRE(params_);
     // Determine the input file format and construct the appropriate reader
     input_file_ = HepMC3::deduce_reader(filename);
     ENSURE(input_file_);

--- a/src/io/EventReader.hh
+++ b/src/io/EventReader.hh
@@ -7,9 +7,14 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "HepMC3/ReaderFactory.h"
+#include <memory>
 #include "physics/base/ParticleParams.hh"
 #include "physics/base/Primary.hh"
+
+namespace HepMC3
+{
+class Reader;
+}
 
 namespace celeritas
 {
@@ -31,6 +36,9 @@ class EventReader
   public:
     // Construct from a filename
     explicit EventReader(const char* filename, SPConstParticles params);
+
+    // Default destructor in .cc
+    ~EventReader();
 
     // Generate primary particles from the event record
     result_type operator()();

--- a/src/io/EventReader.nohepmc.cc
+++ b/src/io/EventReader.nohepmc.cc
@@ -1,0 +1,26 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file EventReader.nohepmc.cc
+//---------------------------------------------------------------------------//
+#include "EventReader.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+EventReader::EventReader(const char*, SPConstParticles)
+{
+    CELER_NOT_CONFIGURED("HepMC3");
+}
+
+EventReader::~EventReader() = default;
+
+EventReader::result_type EventReader::operator()()
+{
+    CHECK_UNREACHABLE;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/io/RootImporter.cc
+++ b/src/io/RootImporter.cc
@@ -117,7 +117,11 @@ std::shared_ptr<ParticleParams> RootImporter::load_particle_data()
     // Load the particle data
     ImportParticle  particle;
     ImportParticle* temp_particle_ptr = &particle;
-    tree_particles->SetBranchAddress("ImportParticle", &temp_particle_ptr);
+
+    int err_code = tree_particles->SetBranchAddress("ImportParticle",
+                                                    &temp_particle_ptr);
+    CHECK(err_code >= 0);
+
     for (auto i : range(defs.size()))
     {
         // Load a single entry into particle
@@ -173,7 +177,10 @@ std::vector<ImportProcess> RootImporter::load_processes()
     // Load branch
     ImportProcess  process;
     ImportProcess* process_ptr = &process;
-    tree_processes->SetBranchAddress("ImportProcess", &process_ptr);
+
+    int err_code
+        = tree_processes->SetBranchAddress("ImportProcess", &process_ptr);
+    CHECK(err_code >= 0);
 
     std::vector<ImportProcess> processes;
 
@@ -206,7 +213,10 @@ std::shared_ptr<GdmlGeometryMap> RootImporter::load_geometry_data()
     // Load branch and fetch data
     GdmlGeometryMap  geometry;
     GdmlGeometryMap* geometry_ptr = &geometry;
-    tree_geometry->SetBranchAddress("GdmlGeometryMap", &geometry_ptr);
+
+    int err_code
+        = tree_geometry->SetBranchAddress("GdmlGeometryMap", &geometry_ptr);
+    CHECK(err_code >= 0);
     tree_geometry->GetEntry(0);
 
     return std::make_shared<GdmlGeometryMap>(std::move(geometry));
@@ -227,7 +237,10 @@ std::shared_ptr<MaterialParams> RootImporter::load_material_data()
     // Load branch and fetch data
     GdmlGeometryMap  geometry;
     GdmlGeometryMap* geometry_ptr = &geometry;
-    tree_geometry->SetBranchAddress("GdmlGeometryMap", &geometry_ptr);
+
+    int err_code
+        = tree_geometry->SetBranchAddress("GdmlGeometryMap", &geometry_ptr);
+    CHECK(err_code >= 0);
     tree_geometry->GetEntry(0);
 
     // Create MaterialParams input for its constructor

--- a/src/io/RootImporter.cc
+++ b/src/io/RootImporter.cc
@@ -21,6 +21,7 @@
 #include "base/Range.hh"
 #include "comm/Logger.hh"
 #include "physics/base/Units.hh"
+#include "ImportParticle.hh"
 
 namespace celeritas
 {

--- a/src/io/RootImporter.cc
+++ b/src/io/RootImporter.cc
@@ -59,7 +59,7 @@ RootImporter::RootImporter(const char* filename)
 {
     CELER_LOG(status) << "Opening ROOT file";
     root_input_.reset(TFile::Open(filename, "read"));
-    ENSURE(root_input_);
+    ENSURE(root_input_ && !root_input_->IsZombie());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/io/RootImporter.cc
+++ b/src/io/RootImporter.cc
@@ -24,9 +24,35 @@
 
 namespace celeritas
 {
+namespace
+{
+//---------------------------------------------------------------------------//
+// HELPER FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!
- * Constructor
+ * Safely switch between MatterState [MaterialParams.hh] and
+ * ImportMaterialState [ImportMaterial.hh].
+ */
+MatterState to_matter_state(const ImportMaterialState state)
+{
+    switch (state)
+    {
+        case ImportMaterialState::not_defined:
+            return MatterState::unspecified;
+        case ImportMaterialState::solid:
+            return MatterState::solid;
+        case ImportMaterialState::liquid:
+            return MatterState::liquid;
+        case ImportMaterialState::gas:
+            return MatterState::gas;
+    }
+    CHECK_UNREACHABLE;
+}
+} // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from path to ROOT file.
  */
 RootImporter::RootImporter(const char* filename)
 {
@@ -41,7 +67,7 @@ RootImporter::~RootImporter() = default;
 
 //---------------------------------------------------------------------------//
 /*!
- * Load all data from the input file
+ * Load all data from the input file.
  */
 RootImporter::result_type RootImporter::operator()()
 {
@@ -188,7 +214,6 @@ std::shared_ptr<GdmlGeometryMap> RootImporter::load_geometry_data()
 //---------------------------------------------------------------------------//
 /*!
  * Load GdmlGeometryMap from the ROOT file and populate MaterialParams
- *
  */
 std::shared_ptr<MaterialParams> RootImporter::load_material_data()
 {
@@ -226,8 +251,7 @@ std::shared_ptr<MaterialParams> RootImporter::load_material_data()
         material_params.name           = mat_key.second.name;
         material_params.temperature    = mat_key.second.temperature;
         material_params.number_density = mat_key.second.number_density;
-        material_params.matter_state
-            = this->to_matter_state(mat_key.second.state);
+        material_params.matter_state   = to_matter_state(mat_key.second.state);
 
         for (const auto& elem_key : mat_key.second.elements_num_fractions)
         {
@@ -243,27 +267,6 @@ std::shared_ptr<MaterialParams> RootImporter::load_material_data()
     // Construct MaterialParams and return it as a shared_ptr
     MaterialParams materials(input);
     return std::make_shared<MaterialParams>(std::move(materials));
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Safely switch between MatterState [MaterialParams.hh] and
- * ImportMaterialState [ImportMaterial.hh].
- */
-MatterState RootImporter::to_matter_state(const ImportMaterialState state)
-{
-    switch (state)
-    {
-        case ImportMaterialState::not_defined:
-            return MatterState::unspecified;
-        case ImportMaterialState::solid:
-            return MatterState::solid;
-        case ImportMaterialState::liquid:
-            return MatterState::liquid;
-        case ImportMaterialState::gas:
-            return MatterState::gas;
-    }
-    CHECK_UNREACHABLE;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/io/RootImporter.hh
+++ b/src/io/RootImporter.hh
@@ -16,7 +16,6 @@
 #include "physics/base/ParticleDef.hh"
 #include "physics/base/ParticleParams.hh"
 #include "physics/material/MaterialParams.hh"
-#include "ImportParticle.hh"
 #include "ImportProcess.hh"
 #include "GdmlGeometryMap.hh"
 
@@ -75,6 +74,11 @@ class RootImporter
     result_type operator()();
 
   private:
+    //// DATA ////
+    std::unique_ptr<TFile> root_input_;
+
+    //// HELPER FUNCTIONS ////
+
     // Populate the shared_ptr<ParticleParams> with particle information
     std::shared_ptr<ParticleParams> load_particle_data();
     // Populate a vector of ImportPhysicsTable objects
@@ -84,8 +88,6 @@ class RootImporter
     // Populate the shared_ptr<MaterialParams> with material information
     std::shared_ptr<MaterialParams> load_material_data();
 
-  public:
-    std::unique_ptr<TFile> root_input_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/io/RootImporter.hh
+++ b/src/io/RootImporter.hh
@@ -83,8 +83,6 @@ class RootImporter
     std::shared_ptr<GdmlGeometryMap> load_geometry_data();
     // Populate the shared_ptr<MaterialParams> with material information
     std::shared_ptr<MaterialParams> load_material_data();
-    // Safely switch between state enums
-    MatterState to_matter_state(const ImportMaterialState state);
 
   public:
     std::unique_ptr<TFile> root_input_;

--- a/src/io/RootImporter.noroot.cc
+++ b/src/io/RootImporter.noroot.cc
@@ -1,0 +1,34 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file RootImporter.noroot.cc
+//---------------------------------------------------------------------------//
+#include "RootImporter.hh"
+
+#include "base/Assert.hh"
+
+// We're not linking against ROOT: declare a TFile so that its null-op
+// destructor can be called by the unique_ptr destructor.
+class TFile
+{
+};
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+RootImporter::RootImporter(const char*)
+{
+    CELER_NOT_CONFIGURED("ROOT");
+}
+
+RootImporter::~RootImporter() = default;
+
+auto RootImporter::operator()() -> result_type
+{
+    CHECK_UNREACHABLE;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -147,8 +147,7 @@ if(CELERITAS_USE_ROOT)
     LINK_LIBRARIES Celeritas::IO)
 endif()
 if(CELERITAS_USE_HepMC3)
-  celeritas_add_test(io/EventReader.test.cc
-    LINK_LIBRARIES ${HEPMC3_LIB})
+  celeritas_add_test(io/EventReader.test.cc)
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -142,13 +142,16 @@ endif()
 
 celeritas_setup_tests(SERIAL PREFIX io)
 
-if(CELERITAS_USE_ROOT)
-  celeritas_add_test(io/RootImporter.test.cc
-    LINK_LIBRARIES Celeritas::IO)
+if(NOT CELERITAS_USE_HepMC3)
+  set(_needs_hepmc DISABLE)
 endif()
-if(CELERITAS_USE_HepMC3)
-  celeritas_add_test(io/EventReader.test.cc)
+if(NOT CELERITAS_USE_ROOT)
+  set(_needs_root DISABLE)
 endif()
+
+celeritas_add_test(io/RootImporter.test.cc ${_needs_root}
+  LINK_LIBRARIES Celeritas::ROOT)
+celeritas_add_test(io/EventReader.test.cc ${_needs_hepmc})
 
 #-----------------------------------------------------------------------------#
 # Physics


### PR DESCRIPTION
I'm adding SWIG wrappers to celeritas (primarily for my own personal debugging/data exploration, could be useful elsewhere though), and it's better to not have to conditionally wrap files and objects based on what's configured. With this change, all the classes are defined and their headers can be included (aside from vecgeom, which we can't forward declare due to  inline namespaces and macros). Tests that rely on disabled configuration issues now build but are "disabled" when running through cmake, and invoking them manually explains why they're disabled:
```
../src/io/RootImporter.noroot.cc:21:
celeritas: required dependency is disabled in this build: ROOT
```