### PR TITLE
Unify kernel namespaces and error checking

### DIFF
--- a/app/demo-interactor/detail/DetectorUtils.cu
+++ b/app/demo-interactor/detail/DetectorUtils.cu
@@ -11,11 +11,15 @@
 #include "base/KernelParamCalculator.cuda.hh"
 #include "base/StackAllocatorView.hh"
 
+namespace celeritas
+{
+namespace detail
+{
 namespace
 {
 //---------------------------------------------------------------------------//
-using namespace celeritas;
-
+// KERNELS
+//---------------------------------------------------------------------------//
 __global__ void bin_buffer_kernel(DetectorPointers const detector)
 {
     auto        hits = StackAllocatorView<Hit>(detector.hit_buffer).get();
@@ -56,10 +60,8 @@ normalize_kernel(DetectorPointers const detector, real_type norm)
 //---------------------------------------------------------------------------//
 } // namespace
 
-namespace celeritas
-{
-namespace detail
-{
+//---------------------------------------------------------------------------//
+// KERNEL INTERFACES
 //---------------------------------------------------------------------------//
 /*!
  * Bin the buffer into the tally grid.

--- a/app/demo-rasterizer/RDemoKernel.cu
+++ b/app/demo-rasterizer/RDemoKernel.cu
@@ -15,8 +15,14 @@
 using namespace celeritas;
 using namespace demo_rasterizer;
 
+namespace demo_rasterizer
+{
 namespace
 {
+//---------------------------------------------------------------------------//
+// KERNELS
+//---------------------------------------------------------------------------//
+
 __device__ int geo_id(const GeoTrackView& geo)
 {
     if (geo.is_outside())
@@ -82,8 +88,8 @@ __global__ void trace_impl(const GeoParamsPointers geo_params,
 }
 } // namespace
 
-namespace demo_rasterizer
-{
+//---------------------------------------------------------------------------//
+// KERNEL INTERFACE
 //---------------------------------------------------------------------------//
 void trace(const GeoParamsPointers& geo_params,
            const GeoStatePointers&  geo_state,

--- a/src/base/Memory.cu
+++ b/src/base/Memory.cu
@@ -32,6 +32,7 @@ void device_memset(void* data, int fill_value, size_type count)
         thrust::device_pointer_cast<unsigned char>(data_char),
         count,
         static_cast<unsigned char>(fill_value));
+    CELER_CUDA_CHECK_ERROR();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/detail/VGNavStateStore.cuda.cc
+++ b/src/geometry/detail/VGNavStateStore.cuda.cc
@@ -33,7 +33,7 @@ void VGNavStateStore::copy_to_device()
     REQUIRE(*this);
     REQUIRE(celeritas::is_device_enabled());
     pool_->CopyToGpu();
-    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    CELER_CUDA_CHECK_ERROR();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/random/cuda/detail/RngStateInit.cu
+++ b/src/random/cuda/detail/RngStateInit.cu
@@ -7,20 +7,24 @@
 //---------------------------------------------------------------------------//
 #include "RngStateInit.hh"
 
+#include "base/Assert.hh"
 #include "base/KernelParamCalculator.cuda.hh"
 #include "random/cuda/RngEngine.hh"
 
+namespace celeritas
+{
+namespace detail
+{
 namespace
 {
-using namespace celeritas;
 //---------------------------------------------------------------------------//
 // KERNELS
 //---------------------------------------------------------------------------//
 /*!
  * Initialize the RNG states on device from seeds randomly generated on host.
  */
-__global__ void
-init_impl(const RngStatePointers state, const RngSeed::value_type* const seeds)
+__global__ void rng_init_kernel(const RngStatePointers           state,
+                                const RngSeed::value_type* const seeds)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (tid.get() < state.size())
@@ -32,10 +36,6 @@ init_impl(const RngStatePointers state, const RngSeed::value_type* const seeds)
 //---------------------------------------------------------------------------//
 } // namespace
 
-namespace celeritas
-{
-namespace detail
-{
 //---------------------------------------------------------------------------//
 // KERNEL INTERFACE
 //---------------------------------------------------------------------------//
@@ -50,9 +50,9 @@ void rng_state_init_device(const RngStatePointers&         device_ptrs,
     // Launch kernel to build RNG states on device
     celeritas::KernelParamCalculator calc_launch_params;
     auto params = calc_launch_params(device_seeds.size());
-    init_impl<<<params.grid_size, params.block_size>>>(device_ptrs,
-                                                       device_seeds.data());
-    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    rng_init_kernel<<<params.grid_size, params.block_size>>>(
+        device_ptrs, device_seeds.data());
+    CELER_CUDA_CHECK_ERROR();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/StatePointers.hh
+++ b/src/sim/StatePointers.hh
@@ -35,10 +35,7 @@ struct StatePointers
     }
 
     //! Number of tracks
-    CELER_FUNCTION celeritas::size_type size() const
-    {
-        return particle.size();
-    }
+    CELER_FUNCTION size_type size() const { return particle.size(); }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/sim/detail/InitializeTracks.cu
+++ b/src/sim/detail/InitializeTracks.cu
@@ -19,10 +19,12 @@
 #include "physics/base/ParticleTrackView.hh"
 #include "sim/SimTrackView.hh"
 
+namespace celeritas
+{
+namespace detail
+{
 namespace
 {
-using namespace celeritas;
-using celeritas::detail::flag_id;
 //---------------------------------------------------------------------------//
 // HELPER CLASSES
 //---------------------------------------------------------------------------//
@@ -253,12 +255,6 @@ __global__ void process_secondaries_kernel(const StatePointers states,
 } // end namespace
 
 //---------------------------------------------------------------------------//
-
-namespace celeritas
-{
-namespace detail
-{
-//---------------------------------------------------------------------------//
 // KERNEL INTERFACE
 //---------------------------------------------------------------------------//
 /*!
@@ -278,7 +274,7 @@ void init_tracks(const StatePointers&            states,
     init_tracks_kernel<<<lparams.grid_size, lparams.block_size>>>(
         states, params, inits, num_vacancies);
 
-    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    CELER_CUDA_CHECK_ERROR();
 }
 
 //---------------------------------------------------------------------------//
@@ -295,7 +291,7 @@ void locate_alive(const StatePointers&            states,
     locate_alive_kernel<<<lparams.grid_size, lparams.block_size>>>(
         states, params, inits);
 
-    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    CELER_CUDA_CHECK_ERROR();
 }
 
 //---------------------------------------------------------------------------//
@@ -317,7 +313,7 @@ void process_primaries(Span<const Primary>             primaries,
     process_primaries_kernel<<<lparams.grid_size, lparams.block_size>>>(
         primaries, initializers);
 
-    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    CELER_CUDA_CHECK_ERROR();
 }
 
 //---------------------------------------------------------------------------//
@@ -339,7 +335,7 @@ void process_secondaries(const StatePointers&     states,
     process_secondaries_kernel<<<lparams.grid_size, lparams.block_size>>>(
         states, params, inits);
 
-    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    CELER_CUDA_CHECK_ERROR();
 }
 
 //---------------------------------------------------------------------------//
@@ -354,7 +350,7 @@ size_type remove_if_alive(Span<size_type> vacancies)
         thrust::device_pointer_cast(vacancies.data() + vacancies.size()),
         IsEqual{flag_id()});
 
-    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    CELER_CUDA_CHECK_ERROR();
 
     // New size of the vacancy vector
     size_type result = thrust::raw_pointer_cast(end) - vacancies.data();
@@ -373,7 +369,7 @@ size_type reduce_counts(Span<size_type> counts)
         size_type(0),
         thrust::plus<size_type>());
 
-    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    CELER_CUDA_CHECK_ERROR();
     return result;
 }
 
@@ -393,7 +389,7 @@ void exclusive_scan_counts(Span<size_type> counts)
         counts.data(),
         size_type(0));
 
-    CELER_CUDA_CALL(cudaDeviceSynchronize());
+    CELER_CUDA_CHECK_ERROR();
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
- Move anonymous namespace inside celeritas namespace
- Suffix with `kernel` instead of `impl` or nothing
- Change "device synchronize" to "peek error"