### PR TITLE
Fix for energy sampling in BetheHeithlerInteractor

### DIFF
--- a/scripts/dev/install-spack.sh
+++ b/scripts/dev/install-spack.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 ###############################################################################
-# File  :  ci/admin/install-spack.sh
+# File  :  scripts/dev/install-spack.sh
 ###############################################################################
 
 function cecho()
@@ -29,7 +29,7 @@ info "This script is running from ${SCRIPT_DIR}"
 # Clone Spack and repositories
 ###############################################################################
 
-if [ -n "${SPACK_ROOT}" ]; then
+if [ ! -n "${SPACK_ROOT}" ]; then
   if [ -n "${CODE}" ]; then
     : # do nothing
   elif [ -d "/rnsdhpc" ]; then
@@ -173,7 +173,7 @@ function update_rc() {
   local ENV=$1
   local ENVVIEW=$2
   local SENTINEL="# >>> $1 environment >>>"
-  
+
   local BASHRC="${HOME}/.bashrc"
   local DO_UPDATE=false
   if [ ! -e "${HOME}/.bashrc" ]; then

--- a/scripts/dev/install-spack.sh
+++ b/scripts/dev/install-spack.sh
@@ -29,7 +29,7 @@ info "This script is running from ${SCRIPT_DIR}"
 # Clone Spack and repositories
 ###############################################################################
 
-if [ ! -n "${SPACK_ROOT}" ]; then
+if [ -z "${SPACK_ROOT}" ]; then
   if [ -n "${CODE}" ]; then
     : # do nothing
   elif [ -d "/rnsdhpc" ]; then

--- a/src/physics/em/BetheHeitlerInteractor.i.hh
+++ b/src/physics/em/BetheHeitlerInteractor.i.hh
@@ -84,10 +84,10 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         // Decide to choose f1, g1 or f2, g2 based on N1, N2 (factors from
         // corrected Bethe-Heitler cross section; c.f. Eq. 6.6 of Geant4
         // Physics Reference 10.6)
-        BernoulliDistribution choose_f1g1(
-            (ipow<2>(0.5 - epsilon_min) - epsilon_min
-             + 0.25 * this->screening_phi1_aux(delta_min))
-            / (1.5 * this->screening_phi2_aux(delta_min)));
+        real_type             f10 = this->screening_phi1_aux(delta_min);
+        real_type             f20 = this->screening_phi2_aux(delta_min);
+        BernoulliDistribution choose_f1g1(ipow<2>(0.5 - epsilon_min) * f10,
+                                          1.5 * f20);
 
         // Temporary sample values used in rejection
         real_type reject_threshold;
@@ -107,8 +107,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
                 // Calculate g1 "rejection" function
                 reject_threshold
                     = celeritas::max(this->screening_phi1_aux(delta), 0.0)
-                      / celeritas::max(this->screening_phi1_aux(delta_min),
-                                       0.0);
+                      / celeritas::max(f10, 0.0);
                 CHECK(reject_threshold > 0.0 && reject_threshold <= 1.0);
             }
             else
@@ -124,8 +123,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
                 // Calculate g2 "rejection" function
                 reject_threshold
                     = celeritas::max(this->screening_phi2_aux(delta), 0.0)
-                      / celeritas::max(this->screening_phi2_aux(delta_min),
-                                       0.0);
+                      / celeritas::max(f20, 0.0);
                 CHECK(reject_threshold > 0.0 && reject_threshold <= 1.0);
             }
         } while (BernoulliDistribution(1.0 - reject_threshold)(rng));


### PR DESCRIPTION
Based on the discussion on slack, the probability for selecting the f1/g1 and f2/g2 functions in the BetheHeitlerInteractor is not correct. This PR uses the two-argument form of `BernoulliDistribution` with the values N1 and N2 from the Geant4 physics reference manual (so that the probability of selecting f1/g1 is N1/(N1 + N2)). I also put in a small fix in install-spack.sh.