### PR TITLE
Scope and rename assertion/error checking macross

### DIFF
--- a/app/demo-interactor/DetectorStore.cc
+++ b/app/demo-interactor/DetectorStore.cc
@@ -52,7 +52,7 @@ void DetectorStore::bin_buffer()
  */
 std::vector<real_type> DetectorStore::finalize(real_type norm)
 {
-    REQUIRE(norm > 0);
+    CELER_EXPECT(norm > 0);
     detail::normalize(this->device_pointers(), norm);
     std::vector<real_type> result(tally_deposition_.size());
     tally_deposition_.copy_to_host(make_span(result));

--- a/app/demo-interactor/DetectorView.i.hh
+++ b/app/demo-interactor/DetectorView.i.hh
@@ -26,13 +26,13 @@ CELER_FUNCTION DetectorView::DetectorView(const DetectorPointers& pointers)
  */
 CELER_FUNCTION void DetectorView::operator()(const Hit& hit)
 {
-    REQUIRE(hit.thread);
-    REQUIRE(hit.time > 0);
-    REQUIRE(hit.energy_deposited > zero_quantity());
+    CELER_EXPECT(hit.thread);
+    CELER_EXPECT(hit.time > 0);
+    CELER_EXPECT(hit.energy_deposited > zero_quantity());
 
     // Allocate and assign the given hit
     Hit* allocated = this->allocate_(1);
-    CHECK(allocated);
+    CELER_ASSERT(allocated);
     *allocated = hit;
 }
 

--- a/app/demo-interactor/HostDetectorStore.cc
+++ b/app/demo-interactor/HostDetectorStore.cc
@@ -44,7 +44,7 @@ void HostDetectorStore::bin_buffer()
 {
     UniformGrid grid(tally_grid_);
     auto hits = StackAllocatorView<Hit>(hit_buffer_.host_pointers()).get();
-    CHECK(hits.size() > 0);
+    CELER_ASSERT(hits.size() > 0);
 
     // Iterate through hits and add them to grid
     for (const auto& hit : hits)
@@ -63,7 +63,7 @@ void HostDetectorStore::bin_buffer()
         {
             bin = grid.find(z_pos);
         }
-        CHECK(bin < tally_deposition_.size());
+        CELER_ASSERT(bin < tally_deposition_.size());
 
         tally_deposition_[bin] += hit.energy_deposited.value();
     }
@@ -78,7 +78,7 @@ void HostDetectorStore::bin_buffer()
  */
 std::vector<real_type> HostDetectorStore::finalize(real_type norm)
 {
-    REQUIRE(norm > 0.0);
+    CELER_EXPECT(norm > 0.0);
     for (auto& v : tally_deposition_)
     {
         v *= norm;

--- a/app/demo-interactor/KNDemoKernel.cu
+++ b/app/demo-interactor/KNDemoKernel.cu
@@ -132,8 +132,8 @@ __global__ void iterate_kernel(ParamPointers const              params,
 
         // Perform interaction: should emit a single particle (an electron)
         Interaction interaction = interact(rng);
-        CHECK(interaction);
-        CHECK(interaction.secondaries.size() == 1);
+        CELER_ASSERT(interaction);
+        CELER_ASSERT(interaction.secondaries.size() == 1);
 
         // Deposit energy from the secondary (effectively, an infinite energy
         // cutoff)
@@ -162,8 +162,8 @@ void initialize(const CudaGridParams&  grid,
                 const StatePointers&   states,
                 const InitialPointers& initial)
 {
-    REQUIRE(states.alive.size() == states.size());
-    REQUIRE(states.rng.size() == states.size());
+    CELER_EXPECT(states.alive.size() == states.size());
+    CELER_EXPECT(states.rng.size() == states.size());
     initialize_kernel<<<grid.grid_size, grid.block_size>>>(
         params, states, initial);
 }

--- a/app/demo-interactor/KNDemoRunner.cc
+++ b/app/demo-interactor/KNDemoRunner.cc
@@ -30,10 +30,10 @@ KNDemoRunner::KNDemoRunner(constSPParticleParams     particles,
     , xsparams_(std::move(xs))
     , launch_params_(std::move(solver))
 {
-    REQUIRE(pparams_);
-    REQUIRE(xsparams_);
-    REQUIRE(launch_params_.block_size > 0);
-    REQUIRE(launch_params_.grid_size > 0);
+    CELER_EXPECT(pparams_);
+    CELER_EXPECT(xsparams_);
+    CELER_EXPECT(launch_params_.block_size > 0);
+    CELER_EXPECT(launch_params_.grid_size > 0);
 
     // Set up KN interactor data;
     namespace pdg            = celeritas::pdg;
@@ -42,7 +42,7 @@ KNDemoRunner::KNDemoRunner(constSPParticleParams     particles,
     kn_pointers_.gamma_id    = pparams_->find(pdg::gamma());
     kn_pointers_.inv_electron_mass
         = 1 / pparams_->get(kn_pointers_.electron_id).mass.value();
-    ENSURE(kn_pointers_);
+    CELER_ENSURE(kn_pointers_);
 }
 
 //---------------------------------------------------------------------------//
@@ -51,8 +51,8 @@ KNDemoRunner::KNDemoRunner(constSPParticleParams     particles,
  */
 auto KNDemoRunner::operator()(KNDemoRunArgs args) -> result_type
 {
-    REQUIRE(args.energy > 0);
-    REQUIRE(args.num_tracks > 0);
+    CELER_EXPECT(args.energy > 0);
+    CELER_EXPECT(args.num_tracks > 0);
 
     // Initialize results
     result_type result;

--- a/app/demo-interactor/PhysicsArrayCalculator.i.hh
+++ b/app/demo-interactor/PhysicsArrayCalculator.i.hh
@@ -47,7 +47,7 @@ PhysicsArrayCalculator::operator()(const ParticleTrackView& particle) const
     {
         // Get the energy bin
         auto bin = loge_grid.find(loge);
-        CHECK(bin + 1 < data_.xs.size());
+        CELER_ASSERT(bin + 1 < data_.xs.size());
 
         // Interpolate *linearly* on energy using the bin data.
         LinearInterpolator<real_type> interpolate_xs(

--- a/app/demo-interactor/PhysicsArrayParams.cc
+++ b/app/demo-interactor/PhysicsArrayParams.cc
@@ -24,14 +24,15 @@ PhysicsArrayParams::PhysicsArrayParams(const Input& input)
     , prime_energy_(input.prime_energy)
     , host_xs_(input.xs)
 {
-    REQUIRE(input.energy.size() >= 2);
-    REQUIRE(input.energy.front() > 0);
-    REQUIRE(std::is_sorted(input.energy.begin(), input.energy.end()));
-    REQUIRE(input.xs.size() == input.energy.size());
-    REQUIRE(std::all_of(
+    CELER_EXPECT(input.energy.size() >= 2);
+    CELER_EXPECT(input.energy.front() > 0);
+    CELER_EXPECT(std::is_sorted(input.energy.begin(), input.energy.end()));
+    CELER_EXPECT(input.xs.size() == input.energy.size());
+    CELER_EXPECT(std::all_of(
         input.xs.begin(), input.xs.end(), [](real_type v) { return v >= 0; }));
-    REQUIRE(std::find(input.energy.begin(), input.energy.end(), prime_energy_)
-            != input.energy.end());
+    CELER_EXPECT(
+        std::find(input.energy.begin(), input.energy.end(), prime_energy_)
+        != input.energy.end());
 
     // Calculate uniform-in-logspace energy grid
     log_energy_.size  = input.energy.size();
@@ -46,7 +47,7 @@ PhysicsArrayParams::PhysicsArrayParams(const Input& input)
         celeritas::UniformGrid log_energy(log_energy_);
         for (auto i : range(input.energy.size()))
         {
-            REQUIRE(soft_eq(std::log(input.energy[i]), log_energy[i]));
+            CELER_EXPECT(soft_eq(std::log(input.energy[i]), log_energy[i]));
         }
     }
 #endif

--- a/app/demo-interactor/demo-interactor.cc
+++ b/app/demo-interactor/demo-interactor.cc
@@ -67,9 +67,9 @@ void run(std::istream& is)
 
     // For now, only do a single run
     auto run_args = inp.at("run").get<KNDemoRunArgs>();
-    REQUIRE(run_args.energy > 0);
-    REQUIRE(run_args.num_tracks > 0);
-    REQUIRE(run_args.max_steps > 0);
+    CELER_EXPECT(run_args.energy > 0);
+    CELER_EXPECT(run_args.num_tracks > 0);
+    CELER_EXPECT(run_args.max_steps > 0);
     auto result = run(run_args);
 
     nlohmann::json outp = {

--- a/app/demo-interactor/host-demo-interactor.cc
+++ b/app/demo-interactor/host-demo-interactor.cc
@@ -62,9 +62,9 @@ void run(std::istream& is)
 
     // For now, only do a single run
     auto run_args = inp.at("run").get<demo_interactor::KNDemoRunArgs>();
-    REQUIRE(run_args.energy > 0);
-    REQUIRE(run_args.num_tracks > 0);
-    REQUIRE(run_args.max_steps > 0);
+    CELER_EXPECT(run_args.energy > 0);
+    CELER_EXPECT(run_args.num_tracks > 0);
+    CELER_EXPECT(run_args.max_steps > 0);
     auto result = run(run_args);
 
     nlohmann::json outp = {

--- a/app/demo-rasterizer/ImageIO.hh
+++ b/app/demo-rasterizer/ImageIO.hh
@@ -39,7 +39,7 @@ namespace celeritas
 template<class T, std::size_t N>
 void from_json(const nlohmann::json& j, Array<T, N>& value)
 {
-    REQUIRE(j.size() == N);
+    CELER_EXPECT(j.size() == N);
     for (std::size_t i = 0; i != N; ++i)
     {
         value[i] = j[i].get<T>();

--- a/app/demo-rasterizer/ImageStore.cc
+++ b/app/demo-rasterizer/ImageStore.cc
@@ -20,10 +20,10 @@ namespace demo_rasterizer
  */
 ImageStore::ImageStore(ImageRunArgs params)
 {
-    REQUIRE(celeritas::is_soft_unit_vector(params.rightward_ax,
-                                           celeritas::SoftEqual<real_type>{}));
-    REQUIRE(params.lower_left != params.upper_right);
-    REQUIRE(params.vertical_pixels > 0);
+    CELER_EXPECT(celeritas::is_soft_unit_vector(
+        params.rightward_ax, celeritas::SoftEqual<real_type>{}));
+    CELER_EXPECT(params.lower_left != params.upper_right);
+    CELER_EXPECT(params.vertical_pixels > 0);
 
     // Normalize rightward axis
     right_ax_ = params.rightward_ax;
@@ -49,7 +49,7 @@ ImageStore::ImageStore(ImageRunArgs params)
     real_type width_x = celeritas::dot_product(diagonal, right_ax_);
     real_type width_y = -celeritas::dot_product(diagonal, down_ax_);
 
-    CHECK(width_x > 0 && width_y > 0);
+    CELER_ASSERT(width_x > 0 && width_y > 0);
 
     // Set number of pixels in each direction.
     auto num_y   = params.vertical_pixels;
@@ -65,7 +65,7 @@ ImageStore::ImageStore(ImageRunArgs params)
     // Allocate storage
     dims_  = {num_y, num_x};
     image_ = celeritas::DeviceVector<int>(num_y * num_x);
-    ENSURE(!image_.empty());
+    CELER_ENSURE(!image_.empty());
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-rasterizer/ImageTrackView.i.hh
+++ b/app/demo-rasterizer/ImageTrackView.i.hh
@@ -17,7 +17,7 @@ CELER_FUNCTION
 ImageTrackView::ImageTrackView(const ImagePointers& shared, ThreadId tid)
     : shared_(shared), j_index_(tid.get())
 {
-    REQUIRE(j_index_ < shared_.dims[0]);
+    CELER_EXPECT(j_index_ < shared_.dims[0]);
 }
 
 //---------------------------------------------------------------------------//
@@ -41,10 +41,10 @@ CELER_FUNCTION auto ImageTrackView::start_pos() const -> Real3
  */
 CELER_FUNCTION void ImageTrackView::set_pixel(unsigned int i, int value)
 {
-    REQUIRE(i < shared_.dims[1]);
+    CELER_EXPECT(i < shared_.dims[1]);
     unsigned int idx = j_index_ * shared_.dims[1] + i;
 
-    CHECK(idx < shared_.image.size());
+    CELER_ASSERT(idx < shared_.image.size());
     shared_.image[idx] = value;
 }
 

--- a/app/demo-rasterizer/RDemoKernel.cu
+++ b/app/demo-rasterizer/RDemoKernel.cu
@@ -95,7 +95,7 @@ void trace(const GeoParamsPointers& geo_params,
            const GeoStatePointers&  geo_state,
            const ImagePointers&     image)
 {
-    REQUIRE(image);
+    CELER_EXPECT(image);
 
     KernelParamCalculator calc_kernel_params;
     auto                  params = calc_kernel_params(image.dims[0]);

--- a/app/demo-rasterizer/RDemoRunner.cc
+++ b/app/demo-rasterizer/RDemoRunner.cc
@@ -27,7 +27,7 @@ namespace demo_rasterizer
 RDemoRunner::RDemoRunner(SPConstGeo geometry)
     : geo_params_(std::move(geometry))
 {
-    REQUIRE(geo_params_);
+    CELER_EXPECT(geo_params_);
 }
 
 //---------------------------------------------------------------------------//
@@ -36,7 +36,7 @@ RDemoRunner::RDemoRunner(SPConstGeo geometry)
  */
 void RDemoRunner::operator()(ImageStore* image) const
 {
-    REQUIRE(image);
+    CELER_EXPECT(image);
 
     GeoStateStore geo_state(*geo_params_, image->dims()[0]);
 

--- a/app/demo-rasterizer/demo-rasterizer.cc
+++ b/app/demo-rasterizer/demo-rasterizer.cc
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
 
     try
     {
-        CHECK(instream_ptr);
+        CELER_ASSERT(instream_ptr);
         demo_rasterizer::run(*instream_ptr);
     }
     catch (const std::exception& e)

--- a/app/geant-exporter/DetectorConstruction.cc
+++ b/app/geant-exporter/DetectorConstruction.cc
@@ -25,7 +25,7 @@ DetectorConstruction::DetectorConstruction(G4String gdmlInput)
     constexpr bool validate_gdml_schema = false;
     gdml_parser.Read(gdmlInput, validate_gdml_schema);
     phys_vol_world_.reset(gdml_parser.GetWorldVolume());
-    ENSURE(phys_vol_world_);
+    CELER_ENSURE(phys_vol_world_);
 }
 
 //---------------------------------------------------------------------------//
@@ -40,7 +40,7 @@ DetectorConstruction::~DetectorConstruction() = default;
  */
 G4VPhysicalVolume* DetectorConstruction::Construct()
 {
-    REQUIRE(phys_vol_world_);
+    CELER_EXPECT(phys_vol_world_);
     return phys_vol_world_.release();
 }
 
@@ -53,7 +53,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
  */
 const G4VPhysicalVolume* DetectorConstruction::get_world_volume() const
 {
-    REQUIRE(phys_vol_world_);
+    CELER_EXPECT(phys_vol_world_);
     return phys_vol_world_.get();
 }
 

--- a/app/geant-exporter/GeantExceptionHandler.cc
+++ b/app/geant-exporter/GeantExceptionHandler.cc
@@ -22,8 +22,8 @@ G4bool GeantExceptionHandler::Notify(const char*         origin_of_exception,
                                      G4ExceptionSeverity severity,
                                      const char*         description)
 {
-    REQUIRE(origin_of_exception);
-    REQUIRE(exception_code);
+    CELER_EXPECT(origin_of_exception);
+    CELER_EXPECT(exception_code);
 
     // Construct message
     std::ostringstream os;
@@ -44,7 +44,7 @@ G4bool GeantExceptionHandler::Notify(const char*         origin_of_exception,
             CELER_LOG(warning) << msg;
             break;
         default:
-            CHECK_UNREACHABLE;
+            CELER_ASSERT_UNREACHABLE();
     }
 
     // Return "true" to cause Geant4 to crash the program, or "false" to let it

--- a/app/geant-exporter/GeantPhysicsTableWriter.cc
+++ b/app/geant-exporter/GeantPhysicsTableWriter.cc
@@ -86,7 +86,7 @@ ImportProcessType to_import_process_type(G4ProcessType g4_process_type)
         case G4ProcessType::fUCN:
             return ImportProcessType::ucn;
     }
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//
@@ -188,7 +188,7 @@ to_import_physics_vector_type(G4PhysicsVectorType g4_vector_type)
         case T_G4LPhysicsFreeVector:
             return ImportPhysicsVectorType::free;
     }
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//
@@ -212,7 +212,7 @@ real_type units_to_scaling(ImportUnits units)
         case ImportUnits::cm:
             return 1 / cm;
     }
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 } // namespace
@@ -225,10 +225,10 @@ GeantPhysicsTableWriter::GeantPhysicsTableWriter(TFile*         root_file,
                                                  TableSelection which_tables)
     : root_file_(root_file), which_tables_(which_tables)
 {
-    REQUIRE(root_file);
+    CELER_EXPECT(root_file);
     this->tree_process_ = std::make_unique<TTree>("processes", "processes");
     auto* tbranch       = tree_process_->Branch("ImportProcess", &process_);
-    ENSURE(tbranch);
+    CELER_ENSURE(tbranch);
 }
 
 //---------------------------------------------------------------------------//
@@ -240,7 +240,7 @@ GeantPhysicsTableWriter::~GeantPhysicsTableWriter()
     try
     {
         int err_code = root_file_->Write();
-        ENSURE(err_code >= 0);
+        CELER_ENSURE(err_code >= 0);
     }
     catch (const std::exception& e)
     {

--- a/app/geant-exporter/PrimaryGeneratorAction.cc
+++ b/app/geant-exporter/PrimaryGeneratorAction.cc
@@ -27,7 +27,7 @@ PrimaryGeneratorAction::PrimaryGeneratorAction()
     // Selecting the particle
     G4ParticleDefinition* particle;
     particle = G4ParticleTable::GetParticleTable()->FindParticle("e-");
-    CHECK(particle);
+    CELER_ASSERT(particle);
 
     // Setting up the particle gun
     G4ThreeVector pos(0, 0, 0);

--- a/app/geant-exporter/geant-exporter-cat.cc
+++ b/app/geant-exporter/geant-exporter-cat.cc
@@ -123,7 +123,7 @@ void print_processes(const std::vector<ImportProcess>& processes,
     for (const ImportProcess& proc : processes)
     {
         auto pdef_id = particles.find(PDGNumber{proc.particle_pdg});
-        CHECK(pdef_id);
+        CELER_ASSERT(pdef_id);
 
         cout << "| " << setw(14) << to_cstring(proc.process_class) << " | "
              << setw(13) << particles.id_to_label(pdef_id) << " | " << setw(24)

--- a/app/geant-exporter/geant-exporter.cc
+++ b/app/geant-exporter/geant-exporter.cc
@@ -65,8 +65,8 @@ using std::endl;
  */
 void store_particles(TFile* root_file, G4ParticleTable* particle_table)
 {
-    REQUIRE(root_file);
-    REQUIRE(particle_table);
+    CELER_EXPECT(root_file);
+    CELER_EXPECT(particle_table);
 
     CELER_LOG(status) << "Exporting particles";
     TTree tree_particles("particles", "particles");
@@ -74,7 +74,7 @@ void store_particles(TFile* root_file, G4ParticleTable* particle_table)
     // Create temporary particle
     ImportParticle particle;
     TBranch*       branch = tree_particles.Branch("ImportParticle", &particle);
-    CHECK(branch);
+    CELER_ASSERT(branch);
 
     G4ParticleTable::G4PTblDicIterator& particle_iterator
         = *(G4ParticleTable::GetParticleTable()->GetIterator());
@@ -110,7 +110,7 @@ void store_particles(TFile* root_file, G4ParticleTable* particle_table)
 
     CELER_LOG(info) << "Added " << num_particles << " particles";
     int err_code = root_file->Write();
-    ENSURE(err_code >= 0);
+    CELER_ENSURE(err_code >= 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -121,8 +121,8 @@ void store_particles(TFile* root_file, G4ParticleTable* particle_table)
  */
 void store_physics_tables(TFile* root_file, G4ParticleTable* particle_table)
 {
-    REQUIRE(root_file);
-    REQUIRE(particle_table);
+    CELER_EXPECT(root_file);
+    CELER_EXPECT(particle_table);
 
     CELER_LOG(status) << "Exporting physics tables";
 
@@ -222,7 +222,7 @@ ImportMaterialState to_material_state(const G4State& g4_material_state)
         case G4State::kStateGas:
             return ImportMaterialState::gas;
     }
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//
@@ -235,7 +235,7 @@ void store_geometry(TFile*                       root_file,
                     const G4ProductionCutsTable& g4production_cuts,
                     const G4VPhysicalVolume&     world_volume)
 {
-    REQUIRE(root_file);
+    CELER_EXPECT(root_file);
 
     CELER_LOG(status) << "Exporting material and volume information";
 
@@ -244,13 +244,13 @@ void store_geometry(TFile*                       root_file,
     // Create geometry map and ROOT branch
     GdmlGeometryMap geometry;
     TBranch* branch = tree_materials.Branch("GdmlGeometryMap", &geometry);
-    CHECK(branch);
+    CELER_ASSERT(branch);
 
     // Populate global element map
     const auto g4element_table = *G4Element::GetElementTable();
     for (const auto& g4element : g4element_table)
     {
-        CHECK(g4element);
+        CELER_ASSERT(g4element);
         ImportElement element;
         elem_id       elid            = g4element->GetIndex();
         element.name                  = g4element->GetName();
@@ -272,9 +272,9 @@ void store_geometry(TFile*                       root_file,
         const auto& g4material = g4material_cuts->GetMaterial();
         const auto& g4elements = g4material->GetElementVector();
 
-        CHECK(g4material_cuts);
-        CHECK(g4material);
-        CHECK(g4elements);
+        CELER_ASSERT(g4material_cuts);
+        CELER_ASSERT(g4material);
+        CELER_ASSERT(g4elements);
 
         // Populate material information
         ImportMaterial material;
@@ -293,7 +293,7 @@ void store_geometry(TFile*                       root_file,
         for (auto j : celeritas::range(g4elements->size()))
         {
             const auto& g4element = g4elements->at(j);
-            CHECK(g4element);
+            CELER_ASSERT(g4element);
             elem_id   elid               = g4element->GetIndex();
             real_type elem_mass_fraction = g4material->GetFractionVector()[j];
             real_type elem_num_density
@@ -317,7 +317,7 @@ void store_geometry(TFile*                       root_file,
 
     tree_materials.Fill();
     int err_code = root_file->Write();
-    ENSURE(err_code >= 0);
+    CELER_ENSURE(err_code >= 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -392,7 +392,7 @@ int main(int argc, char* argv[])
     CELER_LOG(status) << "Creating ROOT file";
     std::unique_ptr<TFile> root_output(
         TFile::Open(root_output_filename.c_str(), "recreate"));
-    CHECK(root_output && !root_output->IsZombie());
+    CELER_ASSERT(root_output && !root_output->IsZombie());
     CELER_LOG(info) << "Created ROOT output file '" << root_output_filename
                     << "'";
 

--- a/scripts/dev/celeritas-gen.py
+++ b/scripts/dev/celeritas-gen.py
@@ -6,9 +6,11 @@
 """Generate class file stubs for Celeritas.
 """
 from __future__ import (division, absolute_import, print_function)
+import os
 import os.path
 import re
 import subprocess
+import stat
 import sys
 ###############################################################################
 
@@ -335,6 +337,12 @@ def generate(root, filename, namespace):
         }
     with open(filename, 'w') as f:
         f.write((top + template).format(**variables))
+        if top.startswith('#!'):
+            # Set executable bits
+            mode = os.fstat(f.fileno()).st_mode
+            mode |= 0o111
+            os.fchmod(f.fileno(), stat.S_IMODE(mode))
+
 
 def main():
     import argparse

--- a/scripts/dev/rename-macros.py
+++ b/scripts/dev/rename-macros.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2020 UT-Battelle, LLC and other Celeritas Developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""
+Recursively modify files.
+"""
+
+import logging as log
+import os
+import os.path
+import re
+
+MACROS = {
+    'REQUIRE': 'CELER_EXPECT',
+    'CHECK': 'CELER_ASSERT',
+    'ENSURE': 'CELER_ENSURE',
+    'CHECK_UNREACHABLE': 'CELER_ASSERT_UNREACHABLE()',
+    'INSIST': 'CELER_VALIDATE',
+}
+RE_MACRO_NAMES = re.compile(r'\b(' + '|'.join(MACROS.keys()) + r')\b')
+def replace_macro_names(matchobj):
+    return MACROS[matchobj.group(1)]
+
+def update_macros(filename):
+    with ReWriter(filename) as rewriter:
+        (old, new) = rewriter.files
+        for line in old:
+            orig_line = line
+            line = RE_MACRO_NAMES.sub(replace_macro_names, line)
+            if line != orig_line:
+                rewriter.dirty = True
+            new.write(line)
+
+class HasExtension(object):
+    """Helper class that says "yes the extension is valid" for any non-empty
+    extension.
+    """
+    def __init__(self):
+        pass
+
+    def __contains__(self, val):
+        # return val != ""
+        return bool(val)
+
+
+def walk_filtered_paths(paths, invisibles=False, extensions=None):
+    """Walk the entire directory hierarchy for files to process."""
+    if extensions is None:
+        # By default, parse anything with an extension.
+        extensions = HasExtension()
+
+    for path in paths:
+        for (root, dirs, files) in os.walk(path):
+            # Don't look in invisible dirs like .hg or .git
+            dirs[:] = [d for d in dirs if not d.startswith(".")]
+
+            for filepath in files:
+                # Don't apply to invisibles if applicable
+                if not invisibles and filepath.startswith("."):
+                    continue
+
+                # Don't apply if not in the given extensions
+                (_, ext) = os.path.splitext(filepath)
+                if extensions and ext not in extensions:
+                    continue
+
+                filepath = os.path.join(root, filepath)
+
+                # Don't apply if it's a symlink
+                if os.path.islink(filepath):
+                    log.info("Skipping symlink %s", filepath)
+                    continue
+
+                yield filepath
+
+
+class ReWriter(object):
+    """Handle safe writing of new files.
+
+    This takes care of error conditions as well as being graceful about not
+    touching files that don't get changed.
+    """
+    def __init__(self, filename, preserve=False):
+        (base, ext) = os.path.splitext(filename)
+
+        self.filename     = filename
+        self.tempfilename = base + ".temp" + ext
+        self.origfilename = base + ".orig" + ext
+
+        # New and original files
+        self.infile  = open(filename, "r")
+        self.outfile = open(self.tempfilename, "w")
+
+        # Whether we've changed the file
+        self.dirty    = False
+        # Whether to preserve the original
+        self.preserve = preserve
+
+    def close(self, did_error=False):
+        self.infile.close()
+        self.outfile.close()
+
+        if did_error:
+            log.error("ERROR while processing %s" % self.filename)
+            if not self.preserve:
+                # Failure and we want to delete the temp file
+                os.unlink(self.tempfilename)
+        elif self.dirty:
+            log.info("CHANGED file %s" % self.filename)
+            # Swap original and temp
+            os.rename(self.filename, self.origfilename)
+            os.rename(self.tempfilename, self.filename)
+
+            # Delete the old file
+            if not self.preserve:
+                os.unlink(self.origfilename)
+        else:
+            log.info("No changes to %s" % self.filename)
+            # No changes, no errors; delete the temp file
+            os.unlink(self.tempfilename)
+
+    def __enter__(self):
+        "Called when entering context using 'with'"
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        "Called when leaving context"
+        self.close(did_error=(exc_type is not None))
+        return False
+
+    @property
+    def files(self):
+        """Get the list of in/out files.
+
+        This is for setting:
+        >>> (infile, outfile) = rewriter.files
+        """
+        return (self.infile, self.outfile)
+
+
+def run(argv=None):
+    from argparse import ArgumentParser
+    parser = ArgumentParser(
+            description="Update macros"
+            )
+    parser.add_argument('-r', dest="recursive",
+            help="Recursive",
+            action='store_true')
+    parser.add_argument('-x', '--extensions',
+            help="Comma-separated extensions to use when searching recursively",
+            default=".hh,.cc,.cu")
+    parser.add_argument('path', nargs='+',
+            help="Files/dirs to process")
+
+    args = parser.parse_args(argv)
+
+    log.basicConfig(level=log.INFO)
+
+    if args.recursive:
+        extensions = None
+        if args.extensions:
+            extensions = args.extensions.split(',')
+            log.info("Recursively searching for %s files",
+                     ", ".join(extensions))
+        paths = walk_filtered_paths(args.path, extensions=extensions)
+    else:
+        paths = iter(args.path)
+
+    for filename in paths:
+        try:
+            update_macros(filename)
+        except Exception as e:
+            log.error("While processing %s:", filename)
+            log.exception(e)
+
+    log.info("Done.")
+
+if __name__ == '__main__':
+    run()

--- a/src/base/ArrayUtils.i.hh
+++ b/src/base/ArrayUtils.i.hh
@@ -85,7 +85,7 @@ CELER_FUNCTION void normalize_direction(Real3* direction)
  */
 inline CELER_FUNCTION Real3 from_spherical(real_type costheta, real_type phi)
 {
-    REQUIRE(costheta >= -1 && costheta <= 1);
+    CELER_EXPECT(costheta >= -1 && costheta <= 1);
 
     const real_type sintheta = std::sqrt(1 - costheta * costheta);
     return {sintheta * std::cos(phi), sintheta * std::sin(phi), costheta};
@@ -132,8 +132,8 @@ inline CELER_FUNCTION Real3 from_spherical(real_type costheta, real_type phi)
 inline CELER_FUNCTION Real3 rotate(const Real3& dir, const Real3& rot)
 {
     constexpr real_type sqrt_eps = 1e-6;
-    REQUIRE(is_soft_unit_vector(dir, SoftEqual<real_type>(sqrt_eps)));
-    REQUIRE(is_soft_unit_vector(rot, SoftEqual<real_type>(sqrt_eps)));
+    CELER_EXPECT(is_soft_unit_vector(dir, SoftEqual<real_type>(sqrt_eps)));
+    CELER_EXPECT(is_soft_unit_vector(rot, SoftEqual<real_type>(sqrt_eps)));
 
     // Direction enumeration
     enum
@@ -174,7 +174,7 @@ inline CELER_FUNCTION Real3 rotate(const Real3& dir, const Real3& rot)
            (rot[Z] * dir[X] + sintheta * dir[Z]) * sinphi + cosphi * dir[Y],
            -sintheta * dir[X] + rot[Z] * dir[Z]};
 
-    ENSURE(is_soft_unit_vector(result, SoftEqual<real_type>(sqrt_eps)));
+    CELER_ENSURE(is_soft_unit_vector(result, SoftEqual<real_type>(sqrt_eps)));
     return result;
 }
 
@@ -184,7 +184,7 @@ inline CELER_FUNCTION Real3 rotate(const Real3& dir, const Real3& rot)
  *
  * Example:
  * \code
-  REQUIRE(is_soft_unit_vector(v, SoftEqual(1e-12)))
+  CELER_EXPECT(is_soft_unit_vector(v, SoftEqual(1e-12)))
   \endcode
  */
 template<class T, std::size_t N, class SoftEq>

--- a/src/base/Assert.hh
+++ b/src/base/Assert.hh
@@ -45,10 +45,12 @@
  * message. This should not be used on device.
  */
 /*!
- * \def CELER_ASSERT_UNREACHABLE()
+ * \def CELER_ASSERT_UNREACHABLE
  *
- * Assert if the code point is reached. When debug assertions are turned off,
- * this changes to a compiler hint that improves optimization.
+ * Throw an assertion if the code point is reached. When debug assertions are
+ * turned off, this changes to a compiler hint that improves optimization (and
+ * may force the coded to exit uncermoniously if the point is encountered,
+ * rather than continuing on with undefined behavior).
  */
 /*!
  * \def CELER_NOT_CONFIGURED
@@ -125,7 +127,7 @@
 #    define CELER_VALIDATE(COND, MSG)                                          \
         ::celeritas::throw_debug_error(::celeritas::DebugErrorType::assertion, \
                                        "Insist cannot be called from device "  \
-                                       "code",                                 \
+                                       "from device code",                     \
                                        __FILE__,                               \
                                        __LINE__)
 #    define CELER_NOT_CONFIGURED(WHAT) CELER_ASSERT(0)

--- a/src/base/Assert.hh
+++ b/src/base/Assert.hh
@@ -21,31 +21,31 @@
 // MACROS
 //---------------------------------------------------------------------------//
 /*!
- * \def REQUIRE
+ * \def CELER_EXPECT
  *
  * Precondition debug assertion macro. It is to "require" that the input values
  * or initial state satisfy a precondition.
  */
 /*!
- * \def CHECK
+ * \def CELER_ASSERT
  *
  * Internal debug assertion macro. This replaces standard \c assert usage.
  */
 /*!
- * \def ENSURE
+ * \def CELER_ENSURE
  *
  * Postcondition debug assertion macro. Use to "ensure" that return values or
  * side effects are as expected when leaving a function.
  */
 /*!
- * \def INSIST
+ * \def CELER_VALIDATE
  *
  * Always-on runtime assertion macro. This can check user input and input data
  * consistency, and will raise RuntimeError on failure with a descriptive error
  * message. This should not be used on device.
  */
 /*!
- * \def CHECK_UNREACHABLE
+ * \def CELER_ASSERT_UNREACHABLE()
  *
  * Assert if the code point is reached. When debug assertions are turned off,
  * this changes to a compiler hint that improves optimization.
@@ -102,33 +102,33 @@
 //! \endcond
 
 #if CELERITAS_DEBUG && defined(__CUDA_ARCH__)
-#    define REQUIRE(COND) CELER_CUDA_ASSERT_(COND)
-#    define CHECK(COND) CELER_CUDA_ASSERT_(COND)
-#    define ENSURE(COND) CELER_CUDA_ASSERT_(COND)
-#    define CHECK_UNREACHABLE CELER_CUDA_ASSERT_(false)
+#    define CELER_EXPECT(COND) CELER_CUDA_ASSERT_(COND)
+#    define CELER_ASSERT(COND) CELER_CUDA_ASSERT_(COND)
+#    define CELER_ENSURE(COND) CELER_CUDA_ASSERT_(COND)
+#    define CELER_ASSERT_UNREACHABLE() CELER_CUDA_ASSERT_(false)
 #elif CELERITAS_DEBUG && !defined(__CUDA_ARCH__)
-#    define REQUIRE(COND) CELER_DEBUG_ASSERT_(COND, precondition)
-#    define CHECK(COND) CELER_DEBUG_ASSERT_(COND, internal)
-#    define ENSURE(COND) CELER_DEBUG_ASSERT_(COND, postcondition)
-#    define CHECK_UNREACHABLE CELER_DEBUG_FAIL_("", unreachable)
+#    define CELER_EXPECT(COND) CELER_DEBUG_ASSERT_(COND, precondition)
+#    define CELER_ASSERT(COND) CELER_DEBUG_ASSERT_(COND, internal)
+#    define CELER_ENSURE(COND) CELER_DEBUG_ASSERT_(COND, postcondition)
+#    define CELER_ASSERT_UNREACHABLE() CELER_DEBUG_FAIL_("", unreachable)
 #else
-#    define REQUIRE(COND) CELER_NOASSERT_(COND)
-#    define CHECK(COND) CELER_NOASSERT_(COND)
-#    define ENSURE(COND) CELER_NOASSERT_(COND)
-#    define CHECK_UNREACHABLE CELER_UNREACHABLE
+#    define CELER_EXPECT(COND) CELER_NOASSERT_(COND)
+#    define CELER_ASSERT(COND) CELER_NOASSERT_(COND)
+#    define CELER_ENSURE(COND) CELER_NOASSERT_(COND)
+#    define CELER_ASSERT_UNREACHABLE() CELER_UNREACHABLE
 #endif
 
 #ifndef __CUDA_ARCH__
-#    define INSIST(COND, MSG) CELER_RUNTIME_ASSERT_(COND, MSG)
+#    define CELER_VALIDATE(COND, MSG) CELER_RUNTIME_ASSERT_(COND, MSG)
 #    define CELER_NOT_CONFIGURED(WHAT) CELER_DEBUG_FAIL_(WHAT, unconfigured)
 #else
-#    define INSIST(COND, MSG)                                                  \
+#    define CELER_VALIDATE(COND, MSG)                                          \
         ::celeritas::throw_debug_error(::celeritas::DebugErrorType::assertion, \
                                        "Insist cannot be called from device "  \
                                        "code",                                 \
                                        __FILE__,                               \
                                        __LINE__)
-#    define CELER_NOT_CONFIGURED(WHAT) CHECK(0)
+#    define CELER_NOT_CONFIGURED(WHAT) CELER_ASSERT(0)
 #endif
 
 /*!

--- a/src/base/Assert.hh
+++ b/src/base/Assert.hh
@@ -126,7 +126,7 @@
 #else
 #    define CELER_VALIDATE(COND, MSG)                                          \
         ::celeritas::throw_debug_error(::celeritas::DebugErrorType::assertion, \
-                                       "Insist cannot be called from device "  \
+                                       "CELER_VALIDATE cannot be called "      \
                                        "from device code",                     \
                                        __FILE__,                               \
                                        __LINE__)

--- a/src/base/Atomics.hh
+++ b/src/base/Atomics.hh
@@ -24,7 +24,7 @@ CELER_FORCEINLINE_FUNCTION T atomic_add(T* address, T value)
 #ifdef __CUDA_ARCH__
     return atomicAdd(address, value);
 #else
-    REQUIRE(address);
+    CELER_EXPECT(address);
     T initial = *address;
     *address += value;
     return initial;
@@ -67,7 +67,7 @@ CELER_FORCEINLINE_FUNCTION T atomic_min(T* address, T value)
 #ifdef __CUDA_ARCH__
     return atomicMin(address, value);
 #else
-    REQUIRE(address);
+    CELER_EXPECT(address);
     T initial = *address;
     *address  = celeritas::min(initial, value);
     return initial;
@@ -84,7 +84,7 @@ CELER_FORCEINLINE_FUNCTION T atomic_max(T* address, T value)
 #ifdef __CUDA_ARCH__
     return atomicMax(address, value);
 #else
-    REQUIRE(address);
+    CELER_EXPECT(address);
     T initial = *address;
     *address  = celeritas::max(initial, value);
     return initial;

--- a/src/base/DeviceAllocation.cuda.cc
+++ b/src/base/DeviceAllocation.cuda.cc
@@ -19,8 +19,8 @@ namespace celeritas
  */
 DeviceAllocation::DeviceAllocation(size_type bytes) : size_(bytes)
 {
-    REQUIRE(bytes > 0);
-    REQUIRE(is_device_enabled());
+    CELER_EXPECT(bytes > 0);
+    CELER_EXPECT(is_device_enabled());
     void* ptr = nullptr;
     CELER_CUDA_CALL(cudaMalloc(&ptr, bytes));
     data_.reset(static_cast<Byte*>(ptr));
@@ -32,8 +32,8 @@ DeviceAllocation::DeviceAllocation(size_type bytes) : size_(bytes)
  */
 void DeviceAllocation::copy_to_device(constSpanBytes bytes)
 {
-    REQUIRE(!this->empty());
-    REQUIRE(bytes.size() == this->size());
+    CELER_EXPECT(!this->empty());
+    CELER_EXPECT(bytes.size() == this->size());
     CELER_CUDA_CALL(cudaMemcpy(
         data_.get(), bytes.data(), bytes.size(), cudaMemcpyHostToDevice));
 }
@@ -44,8 +44,8 @@ void DeviceAllocation::copy_to_device(constSpanBytes bytes)
  */
 void DeviceAllocation::copy_to_host(SpanBytes bytes) const
 {
-    REQUIRE(!this->empty());
-    REQUIRE(bytes.size() == this->size());
+    CELER_EXPECT(!this->empty());
+    CELER_EXPECT(bytes.size() == this->size());
     CELER_CUDA_CALL(cudaMemcpy(
         bytes.data(), data_.get(), this->size(), cudaMemcpyDeviceToHost));
 }

--- a/src/base/DeviceAllocation.nocuda.cc
+++ b/src/base/DeviceAllocation.nocuda.cc
@@ -23,7 +23,7 @@ DeviceAllocation::DeviceAllocation(size_type)
 //! Deleter should never be called on CPU
 void DeviceAllocation::CudaFreeDeleter::operator()(Byte*) const
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//
@@ -32,7 +32,7 @@ void DeviceAllocation::CudaFreeDeleter::operator()(Byte*) const
  */
 void DeviceAllocation::copy_to_device(constSpanBytes)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//
@@ -41,7 +41,7 @@ void DeviceAllocation::copy_to_device(constSpanBytes)
  */
 void DeviceAllocation::copy_to_host(SpanBytes) const
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/base/DeviceVector.i.hh
+++ b/src/base/DeviceVector.i.hh
@@ -39,7 +39,7 @@ void DeviceVector<T>::swap(DeviceVector& other) noexcept
 template<class T>
 void DeviceVector<T>::resize(size_type size)
 {
-    REQUIRE(size <= this->capacity());
+    CELER_EXPECT(size <= this->capacity());
     size_ = size;
 }
 
@@ -50,7 +50,7 @@ void DeviceVector<T>::resize(size_type size)
 template<class T>
 void DeviceVector<T>::copy_to_device(constSpan_t data)
 {
-    REQUIRE(data.size() == this->size());
+    CELER_EXPECT(data.size() == this->size());
     allocation_.copy_to_device(
         {reinterpret_cast<const Byte*>(data.data()), data.size() * sizeof(T)});
 }
@@ -62,7 +62,7 @@ void DeviceVector<T>::copy_to_device(constSpan_t data)
 template<class T>
 void DeviceVector<T>::copy_to_host(Span_t data) const
 {
-    REQUIRE(data.size() == this->size());
+    CELER_EXPECT(data.size() == this->size());
     allocation_.copy_to_host(
         {reinterpret_cast<Byte*>(data.data()), data.size() * sizeof(T)});
 }

--- a/src/base/Interpolator.i.hh
+++ b/src/base/Interpolator.i.hh
@@ -25,11 +25,11 @@ CELER_FUNCTION Interpolator<XI, YI, T>::Interpolator(Point left, Point right)
         Y = 1
     };
 
-    REQUIRE(left[X] != right[X]);
-    REQUIRE(XTraits_t::valid_domain(left[X]));
-    REQUIRE(XTraits_t::valid_domain(right[X]));
-    REQUIRE(YTraits_t::valid_domain(left[Y]));
-    REQUIRE(YTraits_t::valid_domain(right[Y]));
+    CELER_EXPECT(left[X] != right[X]);
+    CELER_EXPECT(XTraits_t::valid_domain(left[X]));
+    CELER_EXPECT(XTraits_t::valid_domain(right[X]));
+    CELER_EXPECT(YTraits_t::valid_domain(left[Y]));
+    CELER_EXPECT(YTraits_t::valid_domain(right[Y]));
 
     intercept_ = YTraits_t::transform(left[Y]);
     slope_     = (YTraits_t::add_transformed(
@@ -37,8 +37,8 @@ CELER_FUNCTION Interpolator<XI, YI, T>::Interpolator(Point left, Point right)
               / XTraits_t::add_transformed(
                   XTraits_t::negate_transformed(left[X]), right[X]));
     offset_    = XTraits_t::negate_transformed(left[X]);
-    ENSURE(!std::isnan(intercept_) && !std::isnan(slope_)
-           && !std::isnan(offset_));
+    CELER_ENSURE(!std::isnan(intercept_) && !std::isnan(slope_)
+                 && !std::isnan(offset_));
 }
 
 //---------------------------------------------------------------------------//
@@ -49,11 +49,11 @@ template<Interp XI, Interp YI, class T>
 CELER_FUNCTION auto Interpolator<XI, YI, T>::operator()(real_type x) const
     -> real_type
 {
-    REQUIRE(XTraits_t::valid_domain(x));
+    CELER_EXPECT(XTraits_t::valid_domain(x));
     real_type result = YTraits_t::transform_inv(
         intercept_ + slope_ * (XTraits_t::add_transformed(offset_, x)));
 
-    ENSURE(!std::isnan(result));
+    CELER_ENSURE(!std::isnan(result));
     return result;
 }
 

--- a/src/base/KernelParamCalculator.cuda.cc
+++ b/src/base/KernelParamCalculator.cuda.cc
@@ -33,8 +33,8 @@ namespace celeritas
  */
 KernelParamCalculator::KernelParamCalculator(dim_type size) : block_size_(size)
 {
-    REQUIRE(size >= 64);
-    REQUIRE(size % 32 == 0);
+    CELER_EXPECT(size >= 64);
+    CELER_EXPECT(size % 32 == 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -44,9 +44,9 @@ KernelParamCalculator::KernelParamCalculator(dim_type size) : block_size_(size)
 KernelParamCalculator::LaunchParams
 KernelParamCalculator::operator()(size_type min_num_threads) const
 {
-    REQUIRE(min_num_threads > 0);
-    REQUIRE(min_num_threads
-            <= static_cast<size_type>(std::numeric_limits<dim_type>::max()));
+    CELER_EXPECT(min_num_threads > 0);
+    CELER_EXPECT(min_num_threads <= static_cast<size_type>(
+                     std::numeric_limits<dim_type>::max()));
 
     // Ceiling integer division
     dim_type grid_size = ceil_div<dim_type>(min_num_threads, this->block_size_);
@@ -54,7 +54,7 @@ KernelParamCalculator::operator()(size_type min_num_threads) const
     LaunchParams result;
     result.grid_size.x  = grid_size;
     result.block_size.x = this->block_size_;
-    ENSURE(result.grid_size.x * result.block_size.x >= min_num_threads);
+    CELER_ENSURE(result.grid_size.x * result.block_size.x >= min_num_threads);
     return result;
 }
 

--- a/src/base/Macros.hh
+++ b/src/base/Macros.hh
@@ -94,8 +94,8 @@
  * or https://msdn.microsoft.com/en-us/library/1b3fsfxw.aspx=
  *
  * \note This macro is usually unused; instead, the macro \c
- * CHECK_UNREACHABLE defined in DBC.hh should be used instead (to provide
- * a more detailed error message in case the point *is* reached).
+ * CELER_ASSERT_UNREACHABLE() defined in DBC.hh should be used instead (to
+ * provide a more detailed error message in case the point *is* reached).
  */
 #if defined(__clang__) || defined(__GNUC__)
 #    define CELER_UNREACHABLE __builtin_unreachable()

--- a/src/base/Macros.hh
+++ b/src/base/Macros.hh
@@ -93,9 +93,9 @@
  * See https://clang.llvm.org/docs/LanguageExtensions.html#builtin-unreachable
  * or https://msdn.microsoft.com/en-us/library/1b3fsfxw.aspx=
  *
- * \note This macro is usually unused; instead, the macro \c
- * CELER_ASSERT_UNREACHABLE() defined in DBC.hh should be used instead (to
- * provide a more detailed error message in case the point *is* reached).
+ * \note This macro should not generally be used; instead, the macro \c
+ * CELER_ASSERT_UNREACHABLE() defined in base/Assert.hh should be used instead
+ * (to provide a more detailed error message in case the point *is* reached).
  */
 #if defined(__clang__) || defined(__GNUC__)
 #    define CELER_UNREACHABLE __builtin_unreachable()

--- a/src/base/Memory.cu
+++ b/src/base/Memory.cu
@@ -23,8 +23,8 @@ namespace celeritas
  */
 void device_memset(void* data, int fill_value, size_type count)
 {
-    REQUIRE(fill_value >= 0
-            && fill_value <= std::numeric_limits<unsigned char>::max());
+    CELER_EXPECT(fill_value >= 0
+                 && fill_value <= std::numeric_limits<unsigned char>::max());
     auto* data_char = static_cast<unsigned char*>(data);
 
     thrust::uninitialized_fill_n(

--- a/src/base/Memory.nocuda.cc
+++ b/src/base/Memory.nocuda.cc
@@ -18,7 +18,7 @@ namespace celeritas
  */
 void device_memset(void*, int, size_type)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/base/OpaqueId.hh
+++ b/src/base/OpaqueId.hh
@@ -55,7 +55,7 @@ class OpaqueId
     //! Get the ID's value
     CELER_FORCEINLINE_FUNCTION value_type get() const
     {
-        REQUIRE(*this);
+        CELER_EXPECT(*this);
         return value_;
     }
 
@@ -113,8 +113,8 @@ CELER_CONSTEXPR_FUNCTION bool operator<(OpaqueId<I, T> lhs, U rhs)
 template<class I, class T>
 inline CELER_FUNCTION T operator-(OpaqueId<I, T> self, OpaqueId<I, T> other)
 {
-    REQUIRE(self);
-    REQUIRE(other);
+    CELER_EXPECT(self);
+    CELER_EXPECT(other);
     return self.unchecked_get() - other.unchecked_get();
 }
 

--- a/src/base/SoftEqual.i.hh
+++ b/src/base/SoftEqual.i.hh
@@ -28,7 +28,7 @@ template<class RealType>
 CELER_FUNCTION SoftEqual<RealType>::SoftEqual(value_type rel)
     : SoftEqual(rel, rel * (traits_t::abs_thresh() / traits_t::rel_prec()))
 {
-    REQUIRE(rel > 0);
+    CELER_EXPECT(rel > 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -39,8 +39,8 @@ template<class RealType>
 CELER_FUNCTION SoftEqual<RealType>::SoftEqual(value_type rel, value_type abs)
     : rel_(rel), abs_(abs)
 {
-    REQUIRE(rel > 0);
-    REQUIRE(abs > 0);
+    CELER_EXPECT(rel > 0);
+    CELER_EXPECT(abs > 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -105,7 +105,7 @@ CELER_FUNCTION SoftZero<RealType>::SoftZero()
 template<class RealType>
 CELER_FUNCTION SoftZero<RealType>::SoftZero(value_type abs) : abs_(abs)
 {
-    REQUIRE(abs > 0);
+    CELER_EXPECT(abs > 0);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/base/SpanRemapper.i.hh
+++ b/src/base/SpanRemapper.i.hh
@@ -18,7 +18,7 @@ template<class T, class U>
 SpanRemapper<T, U>::SpanRemapper(src_type src_span, dst_type dst_span)
     : src_(src_span), dst_(dst_span)
 {
-    REQUIRE(src_span.size() == dst_span.size());
+    CELER_EXPECT(src_span.size() == dst_span.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -29,9 +29,9 @@ template<class T, class U>
 template<class V>
 auto SpanRemapper<T, U>::operator()(Span<V> src_subspan) const -> dst_type
 {
-    REQUIRE(src_subspan.empty()
-            || (src_subspan.begin() >= src_.begin()
-                && src_subspan.end() <= src_.end()));
+    CELER_EXPECT(src_subspan.empty()
+                 || (src_subspan.begin() >= src_.begin()
+                     && src_subspan.end() <= src_.end()));
 
     if (src_subspan.empty())
         return {};

--- a/src/base/StackAllocatorPointers.hh
+++ b/src/base/StackAllocatorPointers.hh
@@ -45,7 +45,7 @@ struct StackAllocatorPointers
 template<class T>
 CELER_FUNCTION StackAllocatorPointers<T>::operator bool() const
 {
-    REQUIRE(storage.empty() || size);
+    CELER_EXPECT(storage.empty() || size);
     return !storage.empty();
 }
 

--- a/src/base/StackAllocatorStore.t.hh
+++ b/src/base/StackAllocatorStore.t.hh
@@ -20,9 +20,9 @@ template<class T>
 StackAllocatorStore<T>::StackAllocatorStore(size_type capacity)
     : allocation_(capacity), size_allocation_(1)
 {
-    REQUIRE(capacity > 0);
+    CELER_EXPECT(capacity > 0);
     this->clear();
-    ENSURE(this->get_size() == 0);
+    CELER_ENSURE(this->get_size() == 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -32,7 +32,7 @@ StackAllocatorStore<T>::StackAllocatorStore(size_type capacity)
 template<class T>
 auto StackAllocatorStore<T>::device_pointers() -> Pointers
 {
-    REQUIRE(!allocation_.empty());
+    CELER_EXPECT(!allocation_.empty());
     Pointers ptrs;
     ptrs.storage = allocation_.device_pointers();
     ptrs.size    = size_allocation_.device_pointers().data();
@@ -49,7 +49,7 @@ auto StackAllocatorStore<T>::device_pointers() -> Pointers
 template<class T>
 void StackAllocatorStore<T>::clear()
 {
-    REQUIRE(!size_allocation_.empty());
+    CELER_EXPECT(!size_allocation_.empty());
     device_memset_zero(size_allocation_.device_pointers());
 }
 
@@ -64,7 +64,7 @@ void StackAllocatorStore<T>::clear()
 template<class T>
 auto StackAllocatorStore<T>::get_size() -> size_type
 {
-    REQUIRE(!size_allocation_.empty());
+    CELER_EXPECT(!size_allocation_.empty());
     size_type result;
     size_allocation_.copy_to_host({&result, 1});
     return result;

--- a/src/base/StackAllocatorView.i.hh
+++ b/src/base/StackAllocatorView.i.hh
@@ -19,7 +19,7 @@ template<class T>
 CELER_FUNCTION StackAllocatorView<T>::StackAllocatorView(const Pointers& shared)
     : shared_(shared)
 {
-    REQUIRE(shared);
+    CELER_EXPECT(shared);
 }
 
 //---------------------------------------------------------------------------//
@@ -93,7 +93,7 @@ CELER_FUNCTION auto StackAllocatorView<T>::capacity() const -> size_type
 template<class T>
 CELER_FUNCTION auto StackAllocatorView<T>::get() -> Span<value_type>
 {
-    REQUIRE(*shared_.size <= this->capacity());
+    CELER_EXPECT(*shared_.size <= this->capacity());
     return {shared_.storage.data(), *shared_.size};
 }
 
@@ -107,7 +107,7 @@ template<class T>
 CELER_FUNCTION auto StackAllocatorView<T>::get() const
     -> Span<const value_type>
 {
-    REQUIRE(*shared_.size <= this->capacity());
+    CELER_EXPECT(*shared_.size <= this->capacity());
     return {shared_.storage.data(), *shared_.size};
 }
 //---------------------------------------------------------------------------//

--- a/src/base/UniformGrid.i.hh
+++ b/src/base/UniformGrid.i.hh
@@ -17,8 +17,8 @@ namespace celeritas
 CELER_FUNCTION
 UniformGrid::UniformGrid(const Params& data) : data_(data)
 {
-    REQUIRE(data_.size >= 2);
-    REQUIRE(data_.delta > 0);
+    CELER_EXPECT(data_.size >= 2);
+    CELER_EXPECT(data_.delta > 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -45,7 +45,7 @@ CELER_FUNCTION auto UniformGrid::back() const -> value_type
  */
 CELER_FUNCTION auto UniformGrid::operator[](size_type i) const -> value_type
 {
-    REQUIRE(i < data_.size);
+    CELER_EXPECT(i < data_.size);
     return data_.front + data_.delta * i;
 }
 
@@ -60,9 +60,9 @@ CELER_FUNCTION auto UniformGrid::operator[](size_type i) const -> value_type
  */
 CELER_FUNCTION size_type UniformGrid::find(value_type value) const
 {
-    REQUIRE(value >= this->front() && value < this->back());
+    CELER_EXPECT(value >= this->front() && value < this->back());
     auto bin = static_cast<size_type>((value - data_.front) / data_.delta);
-    ENSURE(bin + 1 < this->size());
+    CELER_ENSURE(bin + 1 < this->size());
     return bin;
 }
 

--- a/src/base/detail/SpanImpl.hh
+++ b/src/base/detail/SpanImpl.hh
@@ -58,14 +58,14 @@ struct SpanImpl
     CELER_FORCEINLINE_FUNCTION
     SpanImpl(const SpanImpl<T, dynamic_extent>& other) : data(other.data)
     {
-        REQUIRE(other.size == Extent);
+        CELER_EXPECT(other.size == Extent);
     }
 
     //! Construct from data and size
     CELER_FORCEINLINE_FUNCTION SpanImpl(T* d, std::size_t s) : data(d)
     {
-        REQUIRE(d != nullptr);
-        REQUIRE(s == Extent);
+        CELER_EXPECT(d != nullptr);
+        CELER_EXPECT(s == Extent);
     }
 };
 
@@ -89,7 +89,7 @@ struct SpanImpl<T, 0>
     //! Construct from data (any) and size (must be zero)
     CELER_FORCEINLINE_FUNCTION SpanImpl(T* d, std::size_t s) : data(d)
     {
-        REQUIRE(s == 0);
+        CELER_EXPECT(s == 0);
     }
 };
 
@@ -113,7 +113,7 @@ struct SpanImpl<T, dynamic_extent>
     //! Construct from data and size
     CELER_FORCEINLINE_FUNCTION SpanImpl(T* d, std::size_t s) : data(d), size(s)
     {
-        REQUIRE(d != nullptr || size == 0);
+        CELER_EXPECT(d != nullptr || size == 0);
     }
 };
 

--- a/src/comm/Communicator.mpi.cc
+++ b/src/comm/Communicator.mpi.cc
@@ -18,17 +18,17 @@ namespace celeritas
  */
 Communicator::Communicator(MpiComm comm) : comm_(comm)
 {
-    REQUIRE(comm != detail::MpiCommNull());
-    REQUIRE(ScopedMpiInit::status() == ScopedMpiInit::Status::initialized);
+    CELER_EXPECT(comm != detail::MpiCommNull());
+    CELER_EXPECT(ScopedMpiInit::status() == ScopedMpiInit::Status::initialized);
 
     // Save rank and size
     int err;
     err = MPI_Comm_rank(comm_, &rank_);
-    CHECK(err == MPI_SUCCESS);
+    CELER_ASSERT(err == MPI_SUCCESS);
     err = MPI_Comm_size(comm_, &size_);
-    CHECK(err == MPI_SUCCESS);
+    CELER_ASSERT(err == MPI_SUCCESS);
 
-    ENSURE(this->rank() >= 0 && this->rank() < this->size());
+    CELER_ENSURE(this->rank() >= 0 && this->rank() < this->size());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/comm/Device.cuda.cc
+++ b/src/comm/Device.cuda.cc
@@ -70,7 +70,7 @@ void initialize_device(const Communicator& comm)
     // Get number of devices
     int num_devices = -1;
     CELER_CUDA_CALL(cudaGetDeviceCount(&num_devices));
-    CHECK(num_devices > 0);
+    CELER_ASSERT(num_devices > 0);
 
     // Set device based on communicator, and call cudaFree to wake up the
     // device

--- a/src/comm/Logger.cc
+++ b/src/comm/Logger.cc
@@ -45,7 +45,7 @@ void default_global_handler(Provenance prov, LogLevel lev, std::string msg)
         case LogLevel::warning:    c = 'y'; break;
         case LogLevel::error:      c = 'r'; break;
         case LogLevel::critical:   c = 'R'; break;
-        default: CHECK_UNREACHABLE;
+        default: CELER_ASSERT_UNREACHABLE();
     };
     // clang-format on
     std::cerr << color_code(c) << to_cstring(lev) << ": " << color_code(' ')

--- a/src/comm/LoggerTypes.cc
+++ b/src/comm/LoggerTypes.cc
@@ -27,7 +27,7 @@ const char* to_cstring(LogLevel lev)
         "critical",
     };
     int idx = static_cast<int>(lev);
-    ENSURE(idx * sizeof(const char*) < sizeof(levels));
+    CELER_ENSURE(idx * sizeof(const char*) < sizeof(levels));
     return levels[idx];
 }
 

--- a/src/comm/Operations.i.hh
+++ b/src/comm/Operations.i.hh
@@ -40,7 +40,7 @@ void allreduce(const Communicator& comm,
                Span<const T, N>    src,
                Span<T, N>          dst)
 {
-    REQUIRE(src.size() == dst.size());
+    CELER_EXPECT(src.size() == dst.size());
 
     if (!comm)
     {

--- a/src/comm/ScopedMpiInit.mpi.cc
+++ b/src/comm/ScopedMpiInit.mpi.cc
@@ -27,7 +27,7 @@ ScopedMpiInit::Status ScopedMpiInit::status_
  */
 ScopedMpiInit::ScopedMpiInit(int* argc, char*** argv)
 {
-    REQUIRE((argc == nullptr) == (argv == nullptr));
+    CELER_EXPECT((argc == nullptr) == (argv == nullptr));
 
     switch (ScopedMpiInit::status())
     {
@@ -40,7 +40,7 @@ ScopedMpiInit::ScopedMpiInit(int* argc, char*** argv)
         case Status::uninitialized: {
             Stopwatch get_time;
             int       err = MPI_Init(argc, argv);
-            CHECK(err == MPI_SUCCESS);
+            CELER_ASSERT(err == MPI_SUCCESS);
             status_ = Status::initialized;
             CELER_LOG(debug) << "MPI initialization took " << get_time() << "s";
             break;
@@ -51,9 +51,9 @@ ScopedMpiInit::ScopedMpiInit(int* argc, char*** argv)
             break;
         }
         default:
-            CHECK_UNREACHABLE;
+            CELER_ASSERT_UNREACHABLE();
     }
-    ENSURE(status_ != Status::uninitialized);
+    CELER_ENSURE(status_ != Status::uninitialized);
 }
 
 //---------------------------------------------------------------------------//
@@ -66,7 +66,7 @@ ScopedMpiInit::~ScopedMpiInit()
     {
         status_ = Status::uninitialized;
         int err = MPI_Finalize();
-        ENSURE(err == MPI_SUCCESS);
+        CELER_ENSURE(err == MPI_SUCCESS);
     }
 }
 
@@ -90,7 +90,7 @@ auto ScopedMpiInit::status() -> Status
             // initialized MPI.
             int result = -1;
             int err    = MPI_Initialized(&result);
-            CHECK(err == MPI_SUCCESS);
+            CELER_ASSERT(err == MPI_SUCCESS);
             status_ = result ? Status::initialized : Status::uninitialized;
         }
     }

--- a/src/comm/detail/LoggerMessage.cc
+++ b/src/comm/detail/LoggerMessage.cc
@@ -21,13 +21,13 @@ namespace detail
 LoggerMessage::LoggerMessage(LogHandler* handle, Provenance prov, LogLevel lev)
     : handle_(handle), prov_(prov), lev_(lev)
 {
-    REQUIRE(!handle_ || *handle_);
+    CELER_EXPECT(!handle_ || *handle_);
     if (handle_)
     {
         // std::function is defined, so create the output stream
         os_ = std::make_unique<std::ostringstream>();
     }
-    ENSURE(bool(handle_) == bool(os_));
+    CELER_ENSURE(bool(handle_) == bool(os_));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/comm/detail/Operations.mpi.hh
+++ b/src/comm/detail/Operations.mpi.hh
@@ -28,7 +28,7 @@ inline MPI_Op to_mpi(Operation op)
         case Operation::prod: return MPI_PROD;
             // clang-format on
     }
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 } // namespace
 
@@ -38,9 +38,9 @@ inline MPI_Op to_mpi(Operation op)
  */
 inline void barrier(const Communicator& comm)
 {
-    REQUIRE(comm);
+    CELER_EXPECT(comm);
     int err = MPI_Barrier(comm.mpi_comm());
-    ENSURE(err == MPI_SUCCESS);
+    CELER_ENSURE(err == MPI_SUCCESS);
 }
 
 //---------------------------------------------------------------------------//
@@ -51,8 +51,8 @@ template<class T>
 inline void
 allreduce(const Communicator& comm, Operation op, Span<const T> src, Span<T> dst)
 {
-    REQUIRE(comm);
-    REQUIRE(src.size() == dst.size());
+    CELER_EXPECT(comm);
+    CELER_EXPECT(src.size() == dst.size());
 
     int err = MPI_Allreduce(src.data(),
                             dst.data(),
@@ -60,7 +60,7 @@ allreduce(const Communicator& comm, Operation op, Span<const T> src, Span<T> dst
                             detail::MpiType<T>::get(),
                             to_mpi(op),
                             comm.mpi_comm());
-    ENSURE(err == MPI_SUCCESS);
+    CELER_ENSURE(err == MPI_SUCCESS);
 }
 
 //---------------------------------------------------------------------------//
@@ -70,7 +70,7 @@ allreduce(const Communicator& comm, Operation op, Span<const T> src, Span<T> dst
 template<class T>
 inline void allreduce(const Communicator& comm, Operation op, Span<T> data)
 {
-    REQUIRE(comm);
+    CELER_EXPECT(comm);
 
     int err = MPI_Allreduce(MPI_IN_PLACE,
                             data.data(),
@@ -78,7 +78,7 @@ inline void allreduce(const Communicator& comm, Operation op, Span<T> data)
                             detail::MpiType<T>::get(),
                             to_mpi(op),
                             comm.mpi_comm());
-    ENSURE(err == MPI_SUCCESS);
+    CELER_ENSURE(err == MPI_SUCCESS);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/GeoParams.cc
+++ b/src/geometry/GeoParams.cc
@@ -78,16 +78,16 @@ GeoParams::GeoParams(const char* gdml_filename)
         CELER_LOG(status) << "Transferring geometry to GPU";
         get_time              = {};
         auto world_top_devptr = cuda_manager.Synchronize();
-        CHECK(world_top_devptr != nullptr);
+        CELER_ASSERT(world_top_devptr != nullptr);
         device_world_volume_ = world_top_devptr.GetPtr();
         CELER_CUDA_CHECK_ERROR();
         print_time(get_time());
 
-        ENSURE(device_world_volume_);
+        CELER_ENSURE(device_world_volume_);
     }
 #endif
-    ENSURE(num_volumes_ > 0);
-    ENSURE(max_depth_ > 0);
+    CELER_ENSURE(num_volumes_ > 0);
+    CELER_ENSURE(max_depth_ > 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -111,10 +111,10 @@ GeoParams::~GeoParams()
  */
 const std::string& GeoParams::id_to_label(VolumeId vol_id) const
 {
-    REQUIRE(vol_id.get() < num_volumes_);
+    CELER_EXPECT(vol_id.get() < num_volumes_);
     const auto* vol
         = vecgeom::GeoManager::Instance().FindPlacedVolume(vol_id.get());
-    CHECK(vol);
+    CELER_ASSERT(vol);
     return vol->GetLabel();
 }
 
@@ -126,8 +126,8 @@ auto GeoParams::label_to_id(const std::string& label) const -> VolumeId
 {
     const auto* vol
         = vecgeom::GeoManager::Instance().FindPlacedVolume(label.c_str());
-    CHECK(vol);
-    CHECK(vol->id() < num_volumes_);
+    CELER_ASSERT(vol);
+    CELER_ASSERT(vol->id() < num_volumes_);
     return VolumeId{vol->id()};
 }
 
@@ -148,11 +148,11 @@ GeoParamsPointers GeoParams::host_pointers() const
  */
 GeoParamsPointers GeoParams::device_pointers() const
 {
-    REQUIRE(celeritas::is_device_enabled());
+    CELER_EXPECT(celeritas::is_device_enabled());
     GeoParamsPointers result;
     result.world_volume
         = static_cast<const vecgeom::VPlacedVolume*>(device_world_volume_);
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 
@@ -165,8 +165,8 @@ GeoParamsPointers GeoParams::device_pointers() const
  */
 void GeoParams::set_cuda_stack_size(int limit)
 {
-    REQUIRE(limit > 0);
-    REQUIRE(celeritas::is_device_enabled());
+    CELER_EXPECT(limit > 0);
+    CELER_EXPECT(celeritas::is_device_enabled());
 #if CELERITAS_USE_CUDA
     CELER_CUDA_CALL(cudaDeviceSetLimit(cudaLimitStackSize, limit));
 #endif

--- a/src/geometry/GeoStateStore.cc
+++ b/src/geometry/GeoStateStore.cc
@@ -26,7 +26,7 @@ namespace celeritas
 GeoStateStore::GeoStateStore(const GeoParams& geom, size_type size)
     : max_depth_(geom.max_depth())
 {
-    REQUIRE(celeritas::is_device_enabled());
+    CELER_EXPECT(celeritas::is_device_enabled());
     vgstate_   = detail::VGNavStateStore(size, max_depth_);
     vgnext_    = detail::VGNavStateStore(size, max_depth_);
     pos_       = DeviceVector<Real3>(size);
@@ -49,7 +49,7 @@ GeoStatePointers GeoStateStore::device_pointers()
     result.dir        = dir_.device_pointers().data();
     result.next_step  = next_step_.device_pointers().data();
 
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 

--- a/src/geometry/GeoTrackView.i.hh
+++ b/src/geometry/GeoTrackView.i.hh
@@ -86,10 +86,10 @@ CELER_FUNCTION void GeoTrackView::find_next_step()
 {
     const vecgeom::LogicalVolume* logical_vol
         = this->volume().GetLogicalVolume();
-    CHECK(logical_vol);
+    CELER_ASSERT(logical_vol);
     const vecgeom::VNavigator* navigator
         = this->volume().GetLogicalVolume()->GetNavigator();
-    CHECK(navigator);
+    CELER_ASSERT(navigator);
 
     next_step_
         = navigator->ComputeStepAndPropagatedState(detail::to_vector(pos_),
@@ -120,7 +120,7 @@ CELER_FUNCTION void GeoTrackView::move_next_volume()
 //! Get the volume ID in the current cell.
 CELER_FUNCTION VolumeId GeoTrackView::volume_id() const
 {
-    REQUIRE(!this->is_outside());
+    CELER_EXPECT(!this->is_outside());
     return VolumeId{this->volume().id()};
 }
 
@@ -138,15 +138,15 @@ GeoTrackView::get_nav_state(void*                  state,
                             CELER_MAYBE_UNUSED int vgmaxdepth,
                             ThreadId               thread) -> NavState&
 {
-    REQUIRE(state);
+    CELER_EXPECT(state);
     char* ptr = reinterpret_cast<char*>(state);
 #ifdef __NVCC__
     ptr += vecgeom::cuda::NavigationState::SizeOfInstanceAlignAware(vgmaxdepth)
            * thread.get();
 #else
-    REQUIRE(thread.get() == 0);
+    CELER_EXPECT(thread.get() == 0);
 #endif
-    ENSURE(ptr);
+    CELER_ENSURE(ptr);
     return *reinterpret_cast<NavState*>(ptr);
 }
 
@@ -155,7 +155,7 @@ GeoTrackView::get_nav_state(void*                  state,
 CELER_FUNCTION const vecgeom::VPlacedVolume& GeoTrackView::volume() const
 {
     const vecgeom::VPlacedVolume* vol_ptr = vgstate_.Top();
-    ENSURE(vol_ptr);
+    CELER_ENSURE(vol_ptr);
     return *vol_ptr;
 }
 

--- a/src/geometry/LinearPropagator.i.hh
+++ b/src/geometry/LinearPropagator.i.hh
@@ -48,8 +48,8 @@ void LinearPropagator::operator()()
 CELER_FUNCTION
 void LinearPropagator::operator()(real_type dist)
 {
-    REQUIRE(dist > 0.);
-    REQUIRE(dist <= track_.next_step());
+    CELER_EXPECT(dist > 0.);
+    CELER_EXPECT(dist <= track_.next_step());
     this->apply_linear_step(dist);
 
     if (std::fabs(track_.next_step()) < track_.tolerance())

--- a/src/geometry/detail/VGNavStateStore.cuda.cc
+++ b/src/geometry/detail/VGNavStateStore.cuda.cc
@@ -30,8 +30,8 @@ VGNavStateStore::VGNavStateStore(size_type size, int depth)
  */
 void VGNavStateStore::copy_to_device()
 {
-    REQUIRE(*this);
-    REQUIRE(celeritas::is_device_enabled());
+    CELER_EXPECT(*this);
+    CELER_EXPECT(celeritas::is_device_enabled());
     pool_->CopyToGpu();
     CELER_CUDA_CHECK_ERROR();
 }
@@ -45,9 +45,9 @@ void VGNavStateStore::copy_to_device()
  */
 void* VGNavStateStore::device_pointers() const
 {
-    REQUIRE(*this);
+    CELER_EXPECT(*this);
     void* ptr = pool_->GetGPUPointer();
-    ENSURE(ptr);
+    CELER_ENSURE(ptr);
     return ptr;
 }
 

--- a/src/geometry/detail/VGNavStateStore.hh
+++ b/src/geometry/detail/VGNavStateStore.hh
@@ -60,7 +60,7 @@ class VGNavStateStore
     // Access the host pool (TODO: delete once cuda::GlobalLocator works)
     NavStatePool& get()
     {
-        REQUIRE(*this);
+        CELER_EXPECT(*this);
         return *pool_;
     }
 

--- a/src/geometry/detail/VGNavStateStore.nocuda.cc
+++ b/src/geometry/detail/VGNavStateStore.nocuda.cc
@@ -28,7 +28,7 @@ VGNavStateStore::VGNavStateStore(size_type, int)
  */
 void VGNavStateStore::copy_to_device()
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//
@@ -37,14 +37,14 @@ void VGNavStateStore::copy_to_device()
  */
 void* VGNavStateStore::device_pointers() const
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//
 //! Deleter should never be called on CPU
 void VGNavStateStore::NavStatePoolDeleter::operator()(NavStatePool*) const
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/io/EventReader.cc
+++ b/src/io/EventReader.cc
@@ -21,10 +21,10 @@ namespace celeritas
 EventReader::EventReader(const char* filename, SPConstParticles params)
     : params_(std::move(params))
 {
-    REQUIRE(params_);
+    CELER_EXPECT(params_);
     // Determine the input file format and construct the appropriate reader
     input_file_ = HepMC3::deduce_reader(filename);
-    ENSURE(input_file_);
+    CELER_ENSURE(input_file_);
 }
 
 //---------------------------------------------------------------------------//
@@ -64,7 +64,7 @@ EventReader::result_type EventReader::operator()()
             // the current physics
             PDGNumber     pdg{gen_particle->pid()};
             ParticleDefId def_id{params_->find(pdg)};
-            CHECK(def_id);
+            CELER_ASSERT(def_id);
 
             Primary primary;
 

--- a/src/io/EventReader.nohepmc.cc
+++ b/src/io/EventReader.nohepmc.cc
@@ -19,7 +19,7 @@ EventReader::~EventReader() = default;
 
 EventReader::result_type EventReader::operator()()
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/io/GdmlGeometryMap.cc
+++ b/src/io/GdmlGeometryMap.cc
@@ -27,7 +27,7 @@ GdmlGeometryMap::~GdmlGeometryMap() = default;
 mat_id GdmlGeometryMap::get_matid(vol_id volume_id) const
 {
     auto iter = volid_to_matid_.find(volume_id);
-    REQUIRE(iter != volid_to_matid_.end());
+    CELER_EXPECT(iter != volid_to_matid_.end());
     return iter->second;
 }
 
@@ -38,7 +38,7 @@ mat_id GdmlGeometryMap::get_matid(vol_id volume_id) const
 const ImportVolume& GdmlGeometryMap::get_volume(vol_id volume_id) const
 {
     auto iter = volid_to_volume_.find(volume_id);
-    REQUIRE(iter != volid_to_volume_.end());
+    CELER_EXPECT(iter != volid_to_volume_.end());
     return iter->second;
 }
 
@@ -49,7 +49,7 @@ const ImportVolume& GdmlGeometryMap::get_volume(vol_id volume_id) const
 const ImportMaterial& GdmlGeometryMap::get_material(mat_id material_id) const
 {
     auto iter = matid_to_material_.find(material_id);
-    REQUIRE(iter != matid_to_material_.end());
+    CELER_EXPECT(iter != matid_to_material_.end());
     return iter->second;
 }
 //---------------------------------------------------------------------------//
@@ -59,7 +59,7 @@ const ImportMaterial& GdmlGeometryMap::get_material(mat_id material_id) const
 const ImportElement& GdmlGeometryMap::get_element(elem_id element_id) const
 {
     auto iter = elemid_to_element_.find(element_id);
-    REQUIRE(iter != elemid_to_element_.end());
+    CELER_EXPECT(iter != elemid_to_element_.end());
     return iter->second;
 }
 
@@ -127,7 +127,7 @@ const std::map<vol_id, mat_id>& GdmlGeometryMap::volid_to_matid_map() const
 void GdmlGeometryMap::add_material(mat_id id, const ImportMaterial& material)
 {
     auto result = matid_to_material_.insert({id, material});
-    CHECK(result.second);
+    CELER_ASSERT(result.second);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/io/ImportPhysicsTable.cc
+++ b/src/io/ImportPhysicsTable.cc
@@ -31,7 +31,8 @@ const char* to_cstring(ImportTableType value)
         "sublambda",
         "lambda_prim",
     };
-    REQUIRE(static_cast<int>(value) * sizeof(const char*) < sizeof(strings));
+    CELER_EXPECT(static_cast<int>(value) * sizeof(const char*)
+                 < sizeof(strings));
     return strings[static_cast<int>(value)];
 }
 
@@ -49,7 +50,8 @@ const char* to_cstring(ImportUnits value)
         "1/cm",
         "1/cm-MeV",
     };
-    REQUIRE(static_cast<int>(value) * sizeof(const char*) < sizeof(strings));
+    CELER_EXPECT(static_cast<int>(value) * sizeof(const char*)
+                 < sizeof(strings));
     return strings[static_cast<int>(value)];
 }
 

--- a/src/io/ImportPhysicsVector.cc
+++ b/src/io/ImportPhysicsVector.cc
@@ -18,7 +18,8 @@ namespace celeritas
 const char* to_cstring(ImportPhysicsVectorType value)
 {
     static const char* const strings[] = {"unknown", "linear", "log", "free"};
-    REQUIRE(static_cast<int>(value) * sizeof(const char*) < sizeof(strings));
+    CELER_EXPECT(static_cast<int>(value) * sizeof(const char*)
+                 < sizeof(strings));
     return strings[static_cast<int>(value)];
 }
 

--- a/src/io/ImportProcess.cc
+++ b/src/io/ImportProcess.cc
@@ -30,7 +30,8 @@ const char* to_cstring(ImportProcessType value)
                                           "parallel",
                                           "phonon",
                                           "ucn"};
-    REQUIRE(static_cast<int>(value) * sizeof(const char*) < sizeof(strings));
+    CELER_EXPECT(static_cast<int>(value) * sizeof(const char*)
+                 < sizeof(strings));
     return strings[static_cast<int>(value)];
 }
 
@@ -60,7 +61,8 @@ const char* to_cstring(ImportProcessClass value)
                                           "mu_brems",
                                           "mu_pair_prod",
                                           "transportation"};
-    REQUIRE(static_cast<int>(value) * sizeof(const char*) < sizeof(strings));
+    CELER_EXPECT(static_cast<int>(value) * sizeof(const char*)
+                 < sizeof(strings));
     return strings[static_cast<int>(value)];
 }
 
@@ -80,7 +82,8 @@ const char* to_cstring(ImportModelClass value)
            "e_brem_lpm",     "e_plus_to_gg",      "livermore_photoelectric",
            "klein_nishina",  "bethe_heitler_lpm", "livermore_rayleigh",
            "mu_bethe_bloch", "mu_brem",           "mu_pair_prod"};
-    REQUIRE(static_cast<int>(value) * sizeof(const char*) < sizeof(strings));
+    CELER_EXPECT(static_cast<int>(value) * sizeof(const char*)
+                 < sizeof(strings));
     return strings[static_cast<int>(value)];
 }
 

--- a/src/io/LivermoreParamsReader.cc
+++ b/src/io/LivermoreParamsReader.cc
@@ -20,7 +20,7 @@ namespace celeritas
 LivermoreParamsReader::LivermoreParamsReader()
 {
     const char* env_var = std::getenv("G4LEDATA");
-    INSIST(env_var, "Environment variable G4LEDATA is not defined.");
+    CELER_VALIDATE(env_var, "Environment variable G4LEDATA is not defined.");
     std::ostringstream os;
     os << env_var << "/livermore/phot_epics2014";
     path_ = os.str();
@@ -32,7 +32,7 @@ LivermoreParamsReader::LivermoreParamsReader()
  */
 LivermoreParamsReader::LivermoreParamsReader(const char* path) : path_(path)
 {
-    REQUIRE(!path_.empty());
+    CELER_EXPECT(!path_.empty());
     if (path_.back() == '/')
     {
         path_.pop_back();
@@ -46,7 +46,7 @@ LivermoreParamsReader::LivermoreParamsReader(const char* path) : path_(path)
 LivermoreParamsReader::result_type
 LivermoreParamsReader::operator()(int atomic_number) const
 {
-    REQUIRE(atomic_number > 0 && atomic_number < 101);
+    CELER_EXPECT(atomic_number > 0 && atomic_number < 101);
 
     result_type result;
     std::string Z = std::to_string(atomic_number);
@@ -56,7 +56,7 @@ LivermoreParamsReader::operator()(int atomic_number) const
     {
         std::string   filename = path_ + "/pe-cs-" + Z + ".dat";
         std::ifstream infile(filename);
-        INSIST(infile, "Couldn't open '" << filename << "'");
+        CELER_VALIDATE(infile, "Couldn't open '" << filename << "'");
 
         // Set the physics vector type and the data type
         result.xs_high.vector_type = ImportPhysicsVectorType::free;
@@ -70,7 +70,7 @@ LivermoreParamsReader::operator()(int atomic_number) const
         result.xs_high.y.resize(size);
         for (size_type i = 0; i < size; ++i)
         {
-            CHECK(infile);
+            CELER_ASSERT(infile);
             infile >> result.xs_high.x[i] >> result.xs_high.y[i];
         }
     }
@@ -79,7 +79,7 @@ LivermoreParamsReader::operator()(int atomic_number) const
     {
         std::string   filename = path_ + "/pe-le-cs-" + Z + ".dat";
         std::ifstream infile(filename);
-        INSIST(infile, "Couldn't open '" << filename << "'");
+        CELER_VALIDATE(infile, "Couldn't open '" << filename << "'");
 
         // Set the physics vector type and the data type
         result.xs_low.vector_type = ImportPhysicsVectorType::free;
@@ -96,7 +96,7 @@ LivermoreParamsReader::operator()(int atomic_number) const
             result.xs_low.y.resize(size);
             for (size_type i = 0; i < size; ++i)
             {
-                CHECK(infile);
+                CELER_ASSERT(infile);
                 infile >> result.xs_low.x[i] >> result.xs_low.y[i];
             }
         }
@@ -106,7 +106,7 @@ LivermoreParamsReader::operator()(int atomic_number) const
     {
         std::string   filename = path_ + "/pe-low-" + Z + ".dat";
         std::ifstream infile(filename);
-        INSIST(infile, "Couldn't open '" << filename << "'");
+        CELER_VALIDATE(infile, "Couldn't open '" << filename << "'");
 
         // Read the number of subshells and energy threshold
         constexpr size_type num_param  = 6;
@@ -119,7 +119,7 @@ LivermoreParamsReader::operator()(int atomic_number) const
         // Read the binding energies and fit parameters
         for (auto& shell : result.shells)
         {
-            CHECK(infile);
+            CELER_ASSERT(infile);
             real_type binding_energy;
             infile >> binding_energy;
             shell.binding_energy = units::MevEnergy{binding_energy};
@@ -135,7 +135,7 @@ LivermoreParamsReader::operator()(int atomic_number) const
     {
         std::string   filename = path_ + "/pe-high-" + Z + ".dat";
         std::ifstream infile(filename);
-        INSIST(infile, "Couldn't open '" << filename << "'");
+        CELER_VALIDATE(infile, "Couldn't open '" << filename << "'");
 
         // Read the number of subshells and energy threshold
         constexpr size_type num_param  = 6;
@@ -143,15 +143,15 @@ LivermoreParamsReader::operator()(int atomic_number) const
         real_type           threshold  = 0.;
         infile >> num_shells >> num_shells >> threshold;
         result.thresh_high = units::MevEnergy{threshold};
-        CHECK(num_shells == result.shells.size());
+        CELER_ASSERT(num_shells == result.shells.size());
 
         // Read the binding energies and fit parameters
         for (auto& shell : result.shells)
         {
-            CHECK(infile);
+            CELER_ASSERT(infile);
             real_type binding_energy;
             infile >> binding_energy;
-            CHECK(binding_energy == shell.binding_energy.value());
+            CELER_ASSERT(binding_energy == shell.binding_energy.value());
             shell.param_high.resize(num_param);
             for (size_type i = 0; i < num_param; ++i)
             {
@@ -164,7 +164,7 @@ LivermoreParamsReader::operator()(int atomic_number) const
     {
         std::string   filename = path_ + "/pe-ss-cs-" + Z + ".dat";
         std::ifstream infile(filename);
-        INSIST(infile, "Couldn't open '" << filename << "'");
+        CELER_VALIDATE(infile, "Couldn't open '" << filename << "'");
 
         for (auto& shell : result.shells)
         {
@@ -177,7 +177,7 @@ LivermoreParamsReader::operator()(int atomic_number) const
             shell.xs.resize(size);
             for (size_type i = 0; i < size; ++i)
             {
-                CHECK(infile);
+                CELER_ASSERT(infile);
                 infile >> shell.energy[i] >> shell.xs[i];
             }
         }

--- a/src/io/RootImporter.cc
+++ b/src/io/RootImporter.cc
@@ -47,7 +47,7 @@ MatterState to_matter_state(const ImportMaterialState state)
         case ImportMaterialState::gas:
             return MatterState::gas;
     }
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 } // namespace
 
@@ -59,7 +59,7 @@ RootImporter::RootImporter(const char* filename)
 {
     CELER_LOG(status) << "Opening ROOT file";
     root_input_.reset(TFile::Open(filename, "read"));
-    ENSURE(root_input_ && !root_input_->IsZombie());
+    CELER_ENSURE(root_input_ && !root_input_->IsZombie());
 }
 
 //---------------------------------------------------------------------------//
@@ -93,9 +93,9 @@ RootImporter::result_type RootImporter::operator()()
                   });
     }
 
-    ENSURE(geant_data.particle_params);
-    ENSURE(geant_data.geometry);
-    ENSURE(geant_data.material_params);
+    CELER_ENSURE(geant_data.particle_params);
+    CELER_ENSURE(geant_data.geometry);
+    CELER_ENSURE(geant_data.material_params);
     return geant_data;
 }
 
@@ -109,10 +109,10 @@ std::shared_ptr<ParticleParams> RootImporter::load_particle_data()
     // Open the 'particles' branch and reserve size for the converted data
     std::unique_ptr<TTree> tree_particles(
         root_input_->Get<TTree>("particles"));
-    CHECK(tree_particles);
+    CELER_ASSERT(tree_particles);
 
     ParticleParams::Input defs(tree_particles->GetEntries());
-    CHECK(!defs.empty());
+    CELER_ASSERT(!defs.empty());
 
     // Load the particle data
     ImportParticle  particle;
@@ -120,19 +120,19 @@ std::shared_ptr<ParticleParams> RootImporter::load_particle_data()
 
     int err_code = tree_particles->SetBranchAddress("ImportParticle",
                                                     &temp_particle_ptr);
-    CHECK(err_code >= 0);
+    CELER_ASSERT(err_code >= 0);
 
     for (auto i : range(defs.size()))
     {
         // Load a single entry into particle
         particle.name.clear();
         tree_particles->GetEntry(i);
-        CHECK(!particle.name.empty());
+        CELER_ASSERT(!particle.name.empty());
 
         // Convert metadata
         defs[i].name     = particle.name;
         defs[i].pdg_code = PDGNumber{particle.pdg};
-        CHECK(defs[i].pdg_code);
+        CELER_ASSERT(defs[i].pdg_code);
 
         // Convert data
         defs[i].mass           = units::MevMass{particle.mass};
@@ -171,8 +171,8 @@ std::vector<ImportProcess> RootImporter::load_processes()
     CELER_LOG(status) << "Loading physics processes";
     std::unique_ptr<TTree> tree_processes(
         root_input_->Get<TTree>("processes"));
-    CHECK(tree_processes);
-    CHECK(tree_processes->GetEntries());
+    CELER_ASSERT(tree_processes);
+    CELER_ASSERT(tree_processes->GetEntries());
 
     // Load branch
     ImportProcess  process;
@@ -180,7 +180,7 @@ std::vector<ImportProcess> RootImporter::load_processes()
 
     int err_code
         = tree_processes->SetBranchAddress("ImportProcess", &process_ptr);
-    CHECK(err_code >= 0);
+    CELER_ASSERT(err_code >= 0);
 
     std::vector<ImportProcess> processes;
 
@@ -207,8 +207,8 @@ std::shared_ptr<GdmlGeometryMap> RootImporter::load_geometry_data()
     CELER_LOG(status) << "Loading geometry data";
     // Open geometry branch
     std::unique_ptr<TTree> tree_geometry(root_input_->Get<TTree>("geometry"));
-    CHECK(tree_geometry);
-    CHECK(tree_geometry->GetEntries()); // Must be 1
+    CELER_ASSERT(tree_geometry);
+    CELER_ASSERT(tree_geometry->GetEntries()); // Must be 1
 
     // Load branch and fetch data
     GdmlGeometryMap  geometry;
@@ -216,7 +216,7 @@ std::shared_ptr<GdmlGeometryMap> RootImporter::load_geometry_data()
 
     int err_code
         = tree_geometry->SetBranchAddress("GdmlGeometryMap", &geometry_ptr);
-    CHECK(err_code >= 0);
+    CELER_ASSERT(err_code >= 0);
     tree_geometry->GetEntry(0);
 
     return std::make_shared<GdmlGeometryMap>(std::move(geometry));
@@ -231,8 +231,8 @@ std::shared_ptr<MaterialParams> RootImporter::load_material_data()
     CELER_LOG(status) << "Loading material data";
     // Open geometry branch
     std::unique_ptr<TTree> tree_geometry(root_input_->Get<TTree>("geometry"));
-    CHECK(tree_geometry);
-    CHECK(tree_geometry->GetEntries()); // Must be 1
+    CELER_ASSERT(tree_geometry);
+    CELER_ASSERT(tree_geometry->GetEntries()); // Must be 1
 
     // Load branch and fetch data
     GdmlGeometryMap  geometry;
@@ -240,7 +240,7 @@ std::shared_ptr<MaterialParams> RootImporter::load_material_data()
 
     int err_code
         = tree_geometry->SetBranchAddress("GdmlGeometryMap", &geometry_ptr);
-    CHECK(err_code >= 0);
+    CELER_ASSERT(err_code >= 0);
     tree_geometry->GetEntry(0);
 
     // Create MaterialParams input for its constructor

--- a/src/io/RootImporter.noroot.cc
+++ b/src/io/RootImporter.noroot.cc
@@ -27,7 +27,7 @@ RootImporter::~RootImporter() = default;
 
 auto RootImporter::operator()() -> result_type
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/Applicability.hh
+++ b/src/physics/base/Applicability.hh
@@ -42,7 +42,7 @@ struct Applicability
     //! Range for a particle at rest
     static inline Applicability at_rest(ParticleDefId id)
     {
-        REQUIRE(id);
+        CELER_EXPECT(id);
         Applicability result;
         result.particle = id;
         result.lower    = neg_max_quantity();

--- a/src/physics/base/ModelInterface.hh
+++ b/src/physics/base/ModelInterface.hh
@@ -61,7 +61,7 @@ struct ModelInteractState
     //! Number of particle tracks
     CELER_FUNCTION size_type size() const
     {
-        REQUIRE(*this);
+        CELER_EXPECT(*this);
         return particle.size();
     }
 };

--- a/src/physics/base/ParticleParams.cc
+++ b/src/physics/base/ParticleParams.cc
@@ -23,20 +23,20 @@ ParticleParams::ParticleParams(const Input& defs)
     host_defs_.reserve(defs.size());
     for (const auto& particle : defs)
     {
-        REQUIRE(!particle.name.empty());
-        REQUIRE(particle.pdg_code);
-        REQUIRE(particle.mass >= zero_quantity());
-        REQUIRE(particle.decay_constant >= 0);
+        CELER_EXPECT(!particle.name.empty());
+        CELER_EXPECT(particle.pdg_code);
+        CELER_EXPECT(particle.mass >= zero_quantity());
+        CELER_EXPECT(particle.decay_constant >= 0);
 
         // Add host metadata
         ParticleDefId id(name_to_id_.size());
         bool          inserted;
         std::tie(std::ignore, inserted)
             = name_to_id_.insert({particle.name, id});
-        CHECK(inserted);
+        CELER_ASSERT(inserted);
         std::tie(std::ignore, inserted)
             = pdg_to_id_.insert({particle.pdg_code, id});
-        CHECK(inserted);
+        CELER_ASSERT(inserted);
 
         // Save the metadata on the host
         md_.push_back({particle.name, particle.pdg_code});
@@ -53,13 +53,13 @@ ParticleParams::ParticleParams(const Input& defs)
     {
         device_defs_ = DeviceVector<ParticleDef>{host_defs_.size()};
         device_defs_.copy_to_device(make_span(host_defs_));
-        ENSURE(device_defs_.size() == defs.size());
+        CELER_ENSURE(device_defs_.size() == defs.size());
     }
 
-    ENSURE(md_.size() == defs.size());
-    ENSURE(name_to_id_.size() == defs.size());
-    ENSURE(pdg_to_id_.size() == defs.size());
-    ENSURE(host_defs_.size() == defs.size());
+    CELER_ENSURE(md_.size() == defs.size());
+    CELER_ENSURE(name_to_id_.size() == defs.size());
+    CELER_ENSURE(pdg_to_id_.size() == defs.size());
+    CELER_ENSURE(host_defs_.size() == defs.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -72,7 +72,7 @@ ParticleParamsPointers ParticleParams::host_pointers() const
 {
     ParticleParamsPointers result;
     result.defs = make_span(host_defs_);
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 
@@ -82,10 +82,10 @@ ParticleParamsPointers ParticleParams::host_pointers() const
  */
 ParticleParamsPointers ParticleParams::device_pointers() const
 {
-    REQUIRE(!device_defs_.empty());
+    CELER_EXPECT(!device_defs_.empty());
     ParticleParamsPointers result;
     result.defs = device_defs_.device_pointers();
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 

--- a/src/physics/base/ParticleParams.i.hh
+++ b/src/physics/base/ParticleParams.i.hh
@@ -16,7 +16,7 @@ namespace celeritas
  */
 const std::string& ParticleParams::id_to_label(ParticleDefId id) const
 {
-    REQUIRE(id < this->size());
+    CELER_EXPECT(id < this->size());
     return md_[id.get()].first;
 }
 
@@ -26,7 +26,7 @@ const std::string& ParticleParams::id_to_label(ParticleDefId id) const
  */
 PDGNumber ParticleParams::id_to_pdg(ParticleDefId id) const
 {
-    REQUIRE(id < this->size());
+    CELER_EXPECT(id < this->size());
     return md_[id.get()].second;
 }
 
@@ -64,7 +64,7 @@ ParticleDefId ParticleParams::find(PDGNumber pdg_code) const
  */
 const ParticleDef& ParticleParams::get(ParticleDefId defid) const
 {
-    REQUIRE(defid < host_defs_.size());
+    CELER_EXPECT(defid < host_defs_.size());
     return host_defs_[defid.get()];
 }
 

--- a/src/physics/base/ParticleStateStore.cc
+++ b/src/physics/base/ParticleStateStore.cc
@@ -18,8 +18,8 @@ namespace celeritas
  */
 ParticleStateStore::ParticleStateStore(size_type size) : vars_(size)
 {
-    REQUIRE(size > 0);
-    ENSURE(!vars_.empty());
+    CELER_EXPECT(size > 0);
+    CELER_ENSURE(!vars_.empty());
 }
 
 //---------------------------------------------------------------------------//
@@ -40,7 +40,7 @@ ParticleStatePointers ParticleStateStore::device_pointers()
     ParticleStatePointers result;
     result.vars = vars_.device_pointers();
 
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 

--- a/src/physics/base/ParticleTrackView.i.hh
+++ b/src/physics/base/ParticleTrackView.i.hh
@@ -23,7 +23,7 @@ ParticleTrackView::ParticleTrackView(const ParticleParamsPointers& params,
                                      ThreadId                      id)
     : params_(params), state_(states.vars[id.get()])
 {
-    REQUIRE(id < states.vars.size());
+    CELER_EXPECT(id < states.vars.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -33,8 +33,8 @@ ParticleTrackView::ParticleTrackView(const ParticleParamsPointers& params,
 CELER_FUNCTION ParticleTrackView&
 ParticleTrackView::operator=(const Initializer_t& other)
 {
-    REQUIRE(other.def_id < params_.defs.size());
-    REQUIRE(other.energy >= zero_quantity());
+    CELER_EXPECT(other.def_id < params_.defs.size());
+    CELER_EXPECT(other.energy >= zero_quantity());
     state_ = other;
     return *this;
 }
@@ -49,8 +49,8 @@ ParticleTrackView::operator=(const Initializer_t& other)
 CELER_FUNCTION
 void ParticleTrackView::energy(units::MevEnergy quantity)
 {
-    REQUIRE(this->def_id());
-    REQUIRE(quantity >= zero_quantity());
+    CELER_EXPECT(this->def_id());
+    CELER_EXPECT(quantity >= zero_quantity());
     state_.energy = quantity;
 }
 
@@ -170,7 +170,7 @@ CELER_FUNCTION units::LightSpeed ParticleTrackView::speed() const
  */
 CELER_FUNCTION real_type ParticleTrackView::lorentz_factor() const
 {
-    REQUIRE(this->mass() > zero_quantity());
+    CELER_EXPECT(this->mass() > zero_quantity());
 
     real_type k_over_mc2 = this->energy().value() / this->mass().value();
     return 1 + k_over_mc2;
@@ -201,7 +201,7 @@ CELER_FUNCTION units::MevMomentumSq ParticleTrackView::momentum_sq() const
 {
     const real_type energy = this->energy().value();
     real_type result = energy * energy + 2 * this->mass().value() * energy;
-    ENSURE(result > 0);
+    CELER_ENSURE(result > 0);
     return units::MevMomentumSq{result};
 }
 
@@ -224,7 +224,7 @@ CELER_FUNCTION units::MevMomentum ParticleTrackView::momentum() const
  */
 CELER_FUNCTION const ParticleDef& ParticleTrackView::particle_def() const
 {
-    REQUIRE(state_.def_id < params_.defs.size());
+    CELER_EXPECT(state_.def_id < params_.defs.size());
     return params_.defs[state_.def_id.get()];
 }
 

--- a/src/physics/base/PhysicsTrackView.i.hh
+++ b/src/physics/base/PhysicsTrackView.i.hh
@@ -20,7 +20,7 @@ PhysicsTrackView::PhysicsTrackView(const PhysicsParamsPointers& params,
                                    ThreadId tid)
     : params_(params), states_(states), tid_(tid)
 {
-    REQUIRE(tid_);
+    CELER_EXPECT(tid_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/ValueGridBuilder.cc
+++ b/src/physics/base/ValueGridBuilder.cc
@@ -66,15 +66,15 @@ ValueGridXsBuilder::from_geant(SpanConstReal lambda_energy,
                                SpanConstReal lambda_prim_energy,
                                SpanConstReal lambda_prim)
 {
-    REQUIRE(is_contiguous_increasing(lambda_energy, lambda_prim_energy));
-    REQUIRE(has_same_log_spacing(lambda_prim, lambda_prim_energy));
-    REQUIRE(lambda.size() == lambda_energy.size());
-    REQUIRE(lambda_prim.size() == lambda_prim_energy.size());
-    REQUIRE(soft_equal(lambda.back(),
-                       lambda_prim.front() * lambda_prim_energy.front()));
-    REQUIRE(is_nonnegative(lambda) && is_nonnegative(lambda_prim));
+    CELER_EXPECT(is_contiguous_increasing(lambda_energy, lambda_prim_energy));
+    CELER_EXPECT(has_same_log_spacing(lambda_prim, lambda_prim_energy));
+    CELER_EXPECT(lambda.size() == lambda_energy.size());
+    CELER_EXPECT(lambda_prim.size() == lambda_prim_energy.size());
+    CELER_EXPECT(soft_equal(lambda.back(),
+                            lambda_prim.front() * lambda_prim_energy.front()));
+    CELER_EXPECT(is_nonnegative(lambda) && is_nonnegative(lambda_prim));
 
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 
     // Construct the grid
     return {0, 0, 0, {}};
@@ -93,11 +93,11 @@ ValueGridXsBuilder::ValueGridXsBuilder(real_type              emin,
     , log_emax_(std::log(emax))
     , xs_(std::move(xs))
 {
-    REQUIRE(emin > 0);
-    REQUIRE(eprime > emin);
-    REQUIRE(emax > eprime);
-    REQUIRE(xs_.size() >= 2);
-    REQUIRE(
+    CELER_EXPECT(emin > 0);
+    CELER_EXPECT(eprime > emin);
+    CELER_EXPECT(emax > eprime);
+    CELER_EXPECT(xs_.size() >= 2);
+    CELER_EXPECT(
         is_on_grid_point(log_eprime_, log_emin_, log_emax_, xs_.size() - 1));
 }
 
@@ -126,7 +126,7 @@ auto ValueGridXsBuilder::value_storage() const -> ValueStorage
 void ValueGridXsBuilder::build(ValueGridStore*) const
 {
     // TODO: finish implementation
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/BetheBlochInteractor.i.hh
+++ b/src/physics/em/BetheBlochInteractor.i.hh
@@ -22,9 +22,9 @@ CELER_FUNCTION BetheBlochInteractor::BetheBlochInteractor(
     , inc_direction_(inc_direction)
     , allocate_(allocate)
 {
-    REQUIRE(inc_energy_ >= this->min_incident_energy()
-            && inc_energy_ <= this->max_incident_energy());
-    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
+                 && inc_energy_ <= this->max_incident_energy());
+    CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/BetheHeitlerInteractor.i.hh
+++ b/src/physics/em/BetheHeitlerInteractor.i.hh
@@ -33,13 +33,13 @@ BetheHeitlerInteractor::BetheHeitlerInteractor(
     , allocate_(allocate)
     , element_(element)
 {
-    REQUIRE(particle.def_id() == shared_.gamma_id);
-    REQUIRE(inc_energy_ >= this->min_incident_energy()
-            && inc_energy_ <= this->max_incident_energy());
+    CELER_EXPECT(particle.def_id() == shared_.gamma_id);
+    CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
+                 && inc_energy_ <= this->max_incident_energy());
 
     epsilon0_ = 1.0 / (shared_.inv_electron_mass * inc_energy_.value());
     // Gamma energy must be at least 2x electron rest mass
-    CHECK(epsilon0_ < 0.5);
+    CELER_ASSERT(epsilon0_ < 0.5);
     static_assert(sizeof(real_type) == sizeof(double),
                   "Embedded constants are hardcoded to double precision.");
 }
@@ -75,7 +75,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         real_type delta_min = 136.0 / element_.cbrt_z() * 4.0 * epsilon0_;
         real_type delta_max
             = std::exp((42.24 - element_.coulomb_correction()) / 8.368) - 0.952;
-        CHECK(delta_min <= delta_max);
+        CELER_ASSERT(delta_min <= delta_max);
 
         // Limits on epsilon
         real_type epsilon1 = 0.5 - 0.5 * std::sqrt(1.0 - delta_min / delta_max);
@@ -99,32 +99,32 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
                 epsilon = 0.5
                           - (0.5 - epsilon_min)
                                 * std::cbrt(generate_canonical(rng));
-                CHECK(epsilon >= epsilon_min && epsilon <= 0.5);
+                CELER_ASSERT(epsilon >= epsilon_min && epsilon <= 0.5);
                 // Calculate delta from element atomic number and sampled
                 // epsilon
                 real_type delta = this->impact_parameter(epsilon);
-                CHECK(delta <= delta_max && delta >= delta_min);
+                CELER_ASSERT(delta <= delta_max && delta >= delta_min);
                 // Calculate g1 "rejection" function
                 reject_threshold
                     = celeritas::max(this->screening_phi1_aux(delta), 0.0)
                       / celeritas::max(f10, 0.0);
-                CHECK(reject_threshold > 0.0 && reject_threshold <= 1.0);
+                CELER_ASSERT(reject_threshold > 0.0 && reject_threshold <= 1.0);
             }
             else
             {
                 // Used to sample from f2
                 epsilon = epsilon_min
                           + (0.5 - epsilon_min) * generate_canonical(rng);
-                CHECK(epsilon >= epsilon_min && epsilon <= 0.5);
+                CELER_ASSERT(epsilon >= epsilon_min && epsilon <= 0.5);
                 // Calculate delta given the element atomic number and sampled
                 // epsilon
                 real_type delta = this->impact_parameter(epsilon);
-                CHECK(delta <= delta_max && delta >= delta_min);
+                CELER_ASSERT(delta <= delta_max && delta >= delta_min);
                 // Calculate g2 "rejection" function
                 reject_threshold
                     = celeritas::max(this->screening_phi2_aux(delta), 0.0)
                       / celeritas::max(f20, 0.0);
-                CHECK(reject_threshold > 0.0 && reject_threshold <= 1.0);
+                CELER_ASSERT(reject_threshold > 0.0 && reject_threshold <= 1.0);
             }
         } while (BernoulliDistribution(1.0 - reject_threshold)(rng));
     }

--- a/src/physics/em/BremRelInteractor.i.hh
+++ b/src/physics/em/BremRelInteractor.i.hh
@@ -22,9 +22,9 @@ BremRelInteractor::BremRelInteractor(const BremRelInteractorPointers& shared,
     , inc_direction_(inc_direction)
     , allocate_(allocate)
 {
-    REQUIRE(inc_energy_ >= this->min_incident_energy()
-            && inc_energy_ <= this->max_incident_energy());
-    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
+                 && inc_energy_ <= this->max_incident_energy());
+    CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/ComptonProcess.cc
+++ b/src/physics/em/ComptonProcess.cc
@@ -23,11 +23,12 @@ ComptonProcess::ComptonProcess(SPConstParticles   particles,
     , xs_lo_(std::move(xs_lo))
     , xs_hi_(std::move(xs_hi))
 {
-    REQUIRE(particles_);
-    REQUIRE(xs_lo_.table_type == ImportTableType::lambda);
-    REQUIRE(xs_hi_.table_type == ImportTableType::lambda_prim);
-    REQUIRE(!xs_lo_.physics_vectors.empty());
-    REQUIRE(xs_lo_.physics_vectors.size() == xs_hi_.physics_vectors.size());
+    CELER_EXPECT(particles_);
+    CELER_EXPECT(xs_lo_.table_type == ImportTableType::lambda);
+    CELER_EXPECT(xs_hi_.table_type == ImportTableType::lambda_prim);
+    CELER_EXPECT(!xs_lo_.physics_vectors.empty());
+    CELER_EXPECT(xs_lo_.physics_vectors.size()
+                 == xs_hi_.physics_vectors.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -45,13 +46,13 @@ auto ComptonProcess::build_models(ModelIdGenerator next_id) const -> VecModel
  */
 auto ComptonProcess::step_limits(Applicability range) const -> StepLimitBuilders
 {
-    REQUIRE(range.material < xs_lo_.physics_vectors.size());
-    REQUIRE(range.particle == particles_->find(pdg::gamma()));
+    CELER_EXPECT(range.material < xs_lo_.physics_vectors.size());
+    CELER_EXPECT(range.particle == particles_->find(pdg::gamma()));
 
     const auto& lo = xs_lo_.physics_vectors[range.material.get()];
     const auto& hi = xs_hi_.physics_vectors[range.material.get()];
-    CHECK(lo.vector_type == ImportPhysicsVectorType::log);
-    CHECK(hi.vector_type == ImportPhysicsVectorType::log);
+    CELER_ASSERT(lo.vector_type == ImportPhysicsVectorType::log);
+    CELER_ASSERT(hi.vector_type == ImportPhysicsVectorType::log);
 
     // The only Compton model we use is Klein-Nishina. In the case of more
     // refined energies, switch based on the given applicability or hope that

--- a/src/physics/em/EPlusAnnihilationProcess.cc
+++ b/src/physics/em/EPlusAnnihilationProcess.cc
@@ -20,7 +20,7 @@ EPlusAnnihilationProcess::EPlusAnnihilationProcess(SPConstParticles particles)
     : particles_(std::move(particles))
     , positron_id_(particles_->find(pdg::positron()))
 {
-    REQUIRE(particles_);
+    CELER_EXPECT(particles_);
 }
 
 //---------------------------------------------------------------------------//
@@ -40,10 +40,10 @@ auto EPlusAnnihilationProcess::build_models(ModelIdGenerator next_id) const
 auto EPlusAnnihilationProcess::step_limits(Applicability range) const
     -> StepLimitBuilders
 {
-    REQUIRE(range.particle == positron_id_);
+    CELER_EXPECT(range.particle == positron_id_);
 
     // Not implemented
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 
     return {};
 }

--- a/src/physics/em/EPlusGGModel.cc
+++ b/src/physics/em/EPlusGGModel.cc
@@ -18,17 +18,17 @@ namespace celeritas
  */
 EPlusGGModel::EPlusGGModel(ModelId id, const ParticleParams& particles)
 {
-    REQUIRE(id);
+    CELER_EXPECT(id);
     interface_.model_id    = id;
     interface_.positron_id = particles.find(pdg::positron());
     interface_.gamma_id    = particles.find(pdg::gamma());
 
-    INSIST(interface_.positron_id && interface_.gamma_id,
-           "Positron and gamma particles must be enabled to use the "
-           "EPlusGG Model.");
+    CELER_VALIDATE(interface_.positron_id && interface_.gamma_id,
+                   "Positron and gamma particles must be enabled to use the "
+                   "EPlusGG Model.");
     interface_.electron_mass
         = particles.get(interface_.positron_id).mass.value();
-    ENSURE(interface_);
+    CELER_ENSURE(interface_);
 }
 
 //---------------------------------------------------------------------------//
@@ -58,7 +58,7 @@ void EPlusGGModel::interact(
     CELER_MAYBE_UNUSED const ModelInteractPointers& pointers) const
 {
     // TODO: implement me
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/KleinNishinaModel.cc
+++ b/src/physics/em/KleinNishinaModel.cc
@@ -19,17 +19,17 @@ namespace celeritas
 KleinNishinaModel::KleinNishinaModel(ModelId               id,
                                      const ParticleParams& particles)
 {
-    REQUIRE(id);
+    CELER_EXPECT(id);
     interface_.model_id    = id;
     interface_.electron_id = particles.find(pdg::electron());
     interface_.gamma_id    = particles.find(pdg::gamma());
 
-    INSIST(interface_.electron_id && interface_.gamma_id,
-           "Electron and gamma particles must be enabled to use the "
-           "Klein-Nishina Model.");
+    CELER_VALIDATE(interface_.electron_id && interface_.gamma_id,
+                   "Electron and gamma particles must be enabled to use the "
+                   "Klein-Nishina Model.");
     interface_.inv_electron_mass
         = 1 / particles.get(interface_.electron_id).mass.value();
-    ENSURE(interface_);
+    CELER_ENSURE(interface_);
 }
 
 //---------------------------------------------------------------------------//
@@ -56,7 +56,7 @@ void KleinNishinaModel::interact(
 #if CELERITAS_USE_CUDA
     detail::klein_nishina_interact(interface_, pointers);
 #else
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 #endif
 }
 

--- a/src/physics/em/LivermoreParams.cc
+++ b/src/physics/em/LivermoreParams.cc
@@ -22,7 +22,7 @@ namespace celeritas
  */
 LivermoreParams::LivermoreParams(const Input& inp)
 {
-    REQUIRE(!inp.elements.empty());
+    CELER_EXPECT(!inp.elements.empty());
 
     // Reserve host space (MUST reserve subshells and cross section data to
     // avoid invalidating spans).
@@ -89,9 +89,9 @@ LivermoreParams::LivermoreParams(const Input& inp)
         device_data_.copy_to_device(make_span(host_data_));
     }
 
-    ENSURE(host_elements_.size() == inp.elements.size());
-    ENSURE(host_shells_.size() <= host_shells_.capacity());
-    ENSURE(host_data_.size() <= host_data_.capacity());
+    CELER_ENSURE(host_elements_.size() == inp.elements.size());
+    CELER_ENSURE(host_shells_.size() <= host_shells_.capacity());
+    CELER_ENSURE(host_data_.size() <= host_data_.capacity());
 }
 
 //---------------------------------------------------------------------------//
@@ -103,7 +103,7 @@ LivermoreParamsPointers LivermoreParams::host_pointers() const
     LivermoreParamsPointers result;
     result.elements = make_span(host_elements_);
 
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 
@@ -116,7 +116,7 @@ LivermoreParamsPointers LivermoreParams::device_pointers() const
     LivermoreParamsPointers result;
     result.elements = device_elements_.device_pointers();
 
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 
@@ -151,7 +151,8 @@ void LivermoreParams::append_livermore_element(const ElementInput& inp)
  */
 Span<LivermoreSubshell> LivermoreParams::extend_shells(const ElementInput& inp)
 {
-    REQUIRE(host_shells_.size() + inp.shells.size() <= host_shells_.capacity());
+    CELER_EXPECT(host_shells_.size() + inp.shells.size()
+                 <= host_shells_.capacity());
 
     // Allocate subshells
     auto start_size = host_shells_.size();
@@ -179,7 +180,7 @@ Span<LivermoreSubshell> LivermoreParams::extend_shells(const ElementInput& inp)
  */
 Span<real_type> LivermoreParams::extend_data(const std::vector<real_type>& data)
 {
-    REQUIRE(host_data_.size() + data.size() <= host_data_.capacity());
+    CELER_EXPECT(host_data_.size() + data.size() <= host_data_.capacity());
 
     // Allocate data
     host_data_.insert(host_data_.end(), data.begin(), data.end());

--- a/src/physics/em/MockXsCalculator.i.hh
+++ b/src/physics/em/MockXsCalculator.i.hh
@@ -17,8 +17,8 @@ namespace celeritas
  */
 CELER_FUNCTION XsCalculator::XsCalculator(const ValueGrid& data) : data_(data)
 {
-    REQUIRE(data_.energy.size() > 0);
-    REQUIRE(data_.xs.size() > 0);
+    CELER_EXPECT(data_.energy.size() > 0);
+    CELER_EXPECT(data_.xs.size() > 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -44,7 +44,7 @@ CELER_FUNCTION real_type XsCalculator::operator()(const real_type energy) const
         // placeholder anyway.
         auto bin = data_.energy.size();
         while (data_.energy[--bin] >= energy) {}
-        CHECK(bin + 1 < data_.xs.size());
+        CELER_ASSERT(bin + 1 < data_.xs.size());
 
         // Interpolate *linearly* on energy using the bin data.
         LinearInterpolator<real_type> interpolate_xs(

--- a/src/physics/em/MollerBhabhaInteractor.i.hh
+++ b/src/physics/em/MollerBhabhaInteractor.i.hh
@@ -22,9 +22,9 @@ CELER_FUNCTION MollerBhabhaInteractor::MollerBhabhaInteractor(
     , inc_direction_(inc_direction)
     , allocate_(allocate)
 {
-    REQUIRE(inc_energy_ >= this->min_incident_energy()
-            && inc_energy_ <= this->max_incident_energy());
-    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
+                 && inc_energy_ <= this->max_incident_energy());
+    CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/PhotoelectricInteractor.hh
+++ b/src/physics/em/PhotoelectricInteractor.hh
@@ -25,8 +25,13 @@ namespace celeritas
  * Livermore model for the photoelectric effect.
  *
  * A parameterization of the photoelectric cross sections in two different
- * energy intervals, formulated as \sigma(E) = a_1 / E + a_2 / E^2 + a_3 / E^3
- * + a_4 / E^4 + a_5 / E^5 + a_6 / E^6, is used. The coefficients for this
+ * energy intervals, formulated as
+ * \f[
+ * \sigma(E)
+     = a_1 / E + a_2 / E^2 + a_3 / E^3 + a_4 / E^4 + a_5 / E^5 + a_6 / E^6
+     \: ,
+ * \f]
+ * is used. The coefficients for this
  * model are calculated by fitting the tabulated EPICS2014 subshell cross
  * sections. The parameterized model applies above approximately 5 keV; below
  * this limit (which depends on the atomic number) the tabulated cross sections

--- a/src/physics/em/PhotoelectricInteractor.i.hh
+++ b/src/physics/em/PhotoelectricInteractor.i.hh
@@ -31,9 +31,9 @@ CELER_FUNCTION PhotoelectricInteractor::PhotoelectricInteractor(
     , allocate_(allocate)
     , calc_micro_xs_(shared, data, particle)
 {
-    REQUIRE(inc_energy_ > this->min_incident_energy()
-            && inc_energy_ <= this->max_incident_energy());
-    REQUIRE(particle.def_id() == shared_.gamma_id);
+    CELER_EXPECT(inc_energy_ > this->min_incident_energy()
+                 && inc_energy_ <= this->max_incident_energy());
+    CELER_EXPECT(particle.def_id() == shared_.gamma_id);
 
     inv_energy_ = 1. / inc_energy_.value();
 }

--- a/src/physics/em/PhotoelectricMicroXsCalculator.i.hh
+++ b/src/physics/em/PhotoelectricMicroXsCalculator.i.hh
@@ -21,7 +21,7 @@ CELER_FUNCTION PhotoelectricMicroXsCalculator::PhotoelectricMicroXsCalculator(
     const ParticleTrackView&               particle)
     : shared_(shared), data_(data), inc_energy_(particle.energy().value())
 {
-    REQUIRE(particle.def_id() == shared_.gamma_id);
+    CELER_EXPECT(particle.def_id() == shared_.gamma_id);
 }
 
 //---------------------------------------------------------------------------//
@@ -31,7 +31,7 @@ CELER_FUNCTION PhotoelectricMicroXsCalculator::PhotoelectricMicroXsCalculator(
 CELER_FUNCTION
 real_type PhotoelectricMicroXsCalculator::operator()(ElementDefId el_id) const
 {
-    REQUIRE(el_id);
+    CELER_EXPECT(el_id);
     const LivermoreElement& el = data_.elements[el_id.get()];
 
     // In Geant4, if the incident gamma energy is below the lowest binding

--- a/src/physics/em/RayleighInteractor.i.hh
+++ b/src/physics/em/RayleighInteractor.i.hh
@@ -22,9 +22,9 @@ RayleighInteractor::RayleighInteractor(const RayleighInteractorPointers& shared,
     , inc_direction_(inc_direction)
     , allocate_(allocate)
 {
-    REQUIRE(inc_energy_ >= this->min_incident_energy()
-            && inc_energy_ <= this->max_incident_energy());
-    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
+                 && inc_energy_ <= this->max_incident_energy());
+    CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/UrbanInteractor.i.hh
+++ b/src/physics/em/UrbanInteractor.i.hh
@@ -22,9 +22,9 @@ UrbanInteractor::UrbanInteractor(const UrbanInteractorPointers& shared,
     , inc_direction_(inc_direction)
     , allocate_(allocate)
 {
-    REQUIRE(inc_energy_ >= this->min_incident_energy()
-            && inc_energy_ <= this->max_incident_energy());
-    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
+                 && inc_energy_ <= this->max_incident_energy());
+    CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/WentzelInteractor.i.hh
+++ b/src/physics/em/WentzelInteractor.i.hh
@@ -22,9 +22,9 @@ WentzelInteractor::WentzelInteractor(const WentzelInteractorPointers& shared,
     , inc_direction_(inc_direction)
     , allocate_(allocate)
 {
-    REQUIRE(inc_energy_ >= this->min_incident_energy()
-            && inc_energy_ <= this->max_incident_energy());
-    REQUIRE(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
+                 && inc_energy_ <= this->max_incident_energy());
+    CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/EPlusGGInteractor.i.hh
+++ b/src/physics/em/detail/EPlusGGInteractor.i.hh
@@ -31,7 +31,7 @@ EPlusGGInteractor::EPlusGGInteractor(const EPlusGGPointers&   shared,
     , inc_direction_(inc_direction)
     , allocate_(allocate)
 {
-    REQUIRE(particle.def_id() == shared_.positron_id);
+    CELER_EXPECT(particle.def_id() == shared_.positron_id);
 }
 
 //---------------------------------------------------------------------------//
@@ -95,7 +95,7 @@ CELER_FUNCTION Interaction EPlusGGInteractor::operator()(Engine& rng)
         // Scattered Gamma angles
         const real_type cost = (epsil * tau2 - 1)
                                / (epsil * std::sqrt(tau * tau2));
-        CHECK(std::fabs(cost) <= 1);
+        CELER_ASSERT(std::fabs(cost) <= 1);
 
         // Kinematic of the gamma pair
         const real_type total_energy = inc_energy_ + 2 * shared_.electron_mass;

--- a/src/physics/em/detail/KleinNishina.cu
+++ b/src/physics/em/detail/KleinNishina.cu
@@ -52,7 +52,7 @@ __global__ void klein_nishina_interact_kernel(const KleinNishinaPointers  kn,
 
     RngEngine rng(ptrs.states.rng, tid);
     ptrs.result[tid.get()] = interact(rng);
-    ENSURE(ptrs.result[tid.get()]);
+    CELER_ENSURE(ptrs.result[tid.get()]);
 }
 
 } // namespace
@@ -66,8 +66,8 @@ __global__ void klein_nishina_interact_kernel(const KleinNishinaPointers  kn,
 void klein_nishina_interact(const KleinNishinaPointers&  kn,
                             const ModelInteractPointers& model)
 {
-    REQUIRE(kn);
-    REQUIRE(model);
+    CELER_EXPECT(kn);
+    CELER_EXPECT(model);
 
     KernelParamCalculator calc_kernel_params;
     auto                  params = calc_kernel_params(model.states.size());

--- a/src/physics/em/detail/KleinNishinaInteractor.i.hh
+++ b/src/physics/em/detail/KleinNishinaInteractor.i.hh
@@ -32,7 +32,7 @@ CELER_FUNCTION KleinNishinaInteractor::KleinNishinaInteractor(
     , inc_direction_(inc_direction)
     , allocate_(allocate)
 {
-    REQUIRE(particle.def_id() == shared_.gamma_id);
+    CELER_EXPECT(particle.def_id() == shared_.gamma_id);
 }
 
 //---------------------------------------------------------------------------//
@@ -87,11 +87,11 @@ CELER_FUNCTION Interaction KleinNishinaInteractor::operator()(Engine& rng)
             epsilon_sq = sample_f2_sq(rng);
             epsilon    = std::sqrt(epsilon_sq);
         }
-        CHECK(epsilon >= epsilon_0 && epsilon <= 1);
+        CELER_ASSERT(epsilon >= epsilon_0 && epsilon <= 1);
 
         // Calculate angles: need sin^2 \theta for rejection
         one_minus_costheta = (1 - epsilon) / (epsilon * inc_energy_per_mecsq);
-        CHECK(one_minus_costheta >= 0 && one_minus_costheta <= 2);
+        CELER_ASSERT(one_minus_costheta >= 0 && one_minus_costheta <= 2);
         real_type sintheta_sq = one_minus_costheta * (2 - one_minus_costheta);
         acceptance_prob       = epsilon * sintheta_sq / (1 + epsilon_sq);
     } while (BernoulliDistribution(acceptance_prob)(rng));

--- a/src/physics/material/ElementSelector.i.hh
+++ b/src/physics/material/ElementSelector.i.hh
@@ -24,18 +24,18 @@ CELER_FUNCTION ElementSelector::ElementSelector(const MaterialView& material,
     , material_xs_(0)
     , elemental_xs_(storage.data())
 {
-    REQUIRE(!elements_.empty());
-    REQUIRE(storage.size() >= material.num_elements());
+    CELER_EXPECT(!elements_.empty());
+    CELER_EXPECT(storage.size() >= material.num_elements());
     for (auto i : range<unsigned int>(elements_.size()))
     {
         const real_type micro_xs = calc_micro_xs(elements_[i].element);
-        CHECK(micro_xs >= 0);
+        CELER_ASSERT(micro_xs >= 0);
         const real_type frac = elements_[i].fraction;
 
         elemental_xs_[i] = micro_xs;
         material_xs_ += micro_xs * frac;
     }
-    ENSURE(material_xs_ >= 0);
+    CELER_ENSURE(material_xs_ >= 0);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/material/ElementView.i.hh
+++ b/src/physics/material/ElementView.i.hh
@@ -17,7 +17,7 @@ ElementView::ElementView(const MaterialParamsPointers& params,
                          ElementDefId                  el_id)
     : def_(params.elements[el_id.get()])
 {
-    REQUIRE(el_id < params.elements.size());
+    CELER_EXPECT(el_id < params.elements.size());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/material/MaterialParams.i.hh
+++ b/src/physics/material/MaterialParams.i.hh
@@ -14,7 +14,7 @@ namespace celeritas
  */
 const std::string& MaterialParams::id_to_label(ElementDefId el) const
 {
-    REQUIRE(el < elnames_.size());
+    CELER_EXPECT(el < elnames_.size());
     return elnames_[el.get()];
 }
 
@@ -24,7 +24,7 @@ const std::string& MaterialParams::id_to_label(ElementDefId el) const
  */
 const std::string& MaterialParams::id_to_label(MaterialDefId mat) const
 {
-    REQUIRE(mat < matnames_.size());
+    CELER_EXPECT(mat < matnames_.size());
     return matnames_[mat.get()];
 }
 

--- a/src/physics/material/MaterialStateStore.cc
+++ b/src/physics/material/MaterialStateStore.cc
@@ -21,7 +21,7 @@ MaterialStateStore::MaterialStateStore(const MaterialParams& mats,
     , states_(size)
     , element_scratch_(size * max_el_)
 {
-    REQUIRE(size > 0);
+    CELER_EXPECT(size > 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -34,7 +34,7 @@ MaterialStatePointers MaterialStateStore::device_pointers()
     result.state           = states_.device_pointers();
     result.element_scratch = element_scratch_.device_pointers();
 
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 

--- a/src/physics/material/MaterialTrackView.i.hh
+++ b/src/physics/material/MaterialTrackView.i.hh
@@ -23,7 +23,7 @@ MaterialTrackView::MaterialTrackView(const MaterialParamsPointers& params,
                                      ThreadId                      id)
     : params_(params), states_(states), tid_(id)
 {
-    REQUIRE(id < states.state.size());
+    CELER_EXPECT(id < states.state.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -33,7 +33,7 @@ MaterialTrackView::MaterialTrackView(const MaterialParamsPointers& params,
 CELER_FUNCTION MaterialTrackView&
 MaterialTrackView::operator=(const Initializer_t& other)
 {
-    REQUIRE(other.def_id < params_.materials.size());
+    CELER_EXPECT(other.def_id < params_.materials.size());
     this->state() = other;
     return *this;
 }
@@ -63,8 +63,8 @@ CELER_FORCEINLINE_FUNCTION MaterialView MaterialTrackView::material_view() const
 CELER_FUNCTION Span<real_type> MaterialTrackView::element_scratch()
 {
     auto offset = tid_.get() * params_.max_element_components;
-    ENSURE(offset + params_.max_element_components
-           <= states_.element_scratch.size());
+    CELER_ENSURE(offset + params_.max_element_components
+                 <= states_.element_scratch.size());
     return {states_.element_scratch.data() + offset,
             params_.max_element_components};
 }

--- a/src/physics/material/MaterialView.i.hh
+++ b/src/physics/material/MaterialView.i.hh
@@ -17,7 +17,7 @@ MaterialView::MaterialView(const MaterialParamsPointers& params,
                            MaterialDefId                 id)
     : params_(params), id_(id)
 {
-    REQUIRE(id < params.materials.size());
+    CELER_EXPECT(id < params.materials.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -62,7 +62,7 @@ CELER_FUNCTION ElementComponentId::value_type MaterialView::num_elements() const
  */
 CELER_FUNCTION ElementView MaterialView::element_view(ElementComponentId id) const
 {
-    REQUIRE(id < this->material_def().elements.size());
+    CELER_EXPECT(id < this->material_def().elements.size());
     const MatElementComponent& c = this->elements()[id.get()];
     return ElementView(params_, c.element);
 }
@@ -74,7 +74,7 @@ CELER_FUNCTION ElementView MaterialView::element_view(ElementComponentId id) con
 CELER_FUNCTION real_type
 MaterialView::get_element_density(ElementComponentId id) const
 {
-    REQUIRE(id < this->material_def().elements.size());
+    CELER_EXPECT(id < this->material_def().elements.size());
     return this->number_density() * this->elements()[id.get()].fraction;
 }
 

--- a/src/physics/material/detail/Utils.cc
+++ b/src/physics/material/detail/Utils.cc
@@ -33,7 +33,7 @@ namespace detail
  */
 real_type calc_coulomb_correction(int atomic_number)
 {
-    REQUIRE(atomic_number > 0);
+    CELER_EXPECT(atomic_number > 0);
     using constants::alpha_fine_structure;
 
     const real_type alphazsq = ipow<2>(alpha_fine_structure * atomic_number);
@@ -62,7 +62,7 @@ real_type calc_coulomb_correction(int atomic_number)
         azpow *= -alphazsq;
     }
 
-    ENSURE(fz > 0);
+    CELER_ENSURE(fz > 0);
     return alphazsq * fz;
 }
 
@@ -75,9 +75,9 @@ real_type calc_coulomb_correction(int atomic_number)
  */
 real_type calc_mass_rad_coeff(const ElementDef& el)
 {
-    REQUIRE(el.atomic_number > 0);
-    REQUIRE(el.atomic_mass > zero_quantity());
-    REQUIRE(el.coulomb_correction > 0);
+    CELER_EXPECT(el.atomic_number > 0);
+    CELER_EXPECT(el.atomic_mass > zero_quantity());
+    CELER_EXPECT(el.coulomb_correction > 0);
     using constants::alpha_fine_structure;
     using constants::re_electron;
 

--- a/src/random/cuda/RngEngine.i.hh
+++ b/src/random/cuda/RngEngine.i.hh
@@ -18,7 +18,7 @@ CELER_FUNCTION
 RngEngine::RngEngine(const RngStatePointers& view, const ThreadId& id)
     : state_(view.rng[id.get()])
 {
-    REQUIRE(id < view.rng.size());
+    CELER_EXPECT(id < view.rng.size());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/random/cuda/RngStateStore.cc
+++ b/src/random/cuda/RngStateStore.cc
@@ -24,8 +24,8 @@ namespace celeritas
 RngStateStore::RngStateStore(size_type size, unsigned long host_seed)
     : data_(size)
 {
-    REQUIRE(celeritas::is_device_enabled());
-    REQUIRE(size > 0);
+    CELER_EXPECT(celeritas::is_device_enabled());
+    CELER_EXPECT(size > 0);
 
     // Host-side RNG for seeding device RNG
     using seed_type = RngSeed::value_type;
@@ -49,7 +49,7 @@ RngStateStore::RngStateStore(size_type size, unsigned long host_seed)
  */
 RngStatePointers RngStateStore::device_pointers()
 {
-    REQUIRE(!data_.empty());
+    CELER_EXPECT(!data_.empty());
 
     RngStatePointers result;
     result.rng = data_.device_pointers();

--- a/src/random/cuda/curand.nocuda.cc
+++ b/src/random/cuda/curand.nocuda.cc
@@ -17,22 +17,22 @@ void curand_init(unsigned long long,
                  unsigned long long,
                  curandState_t*)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 unsigned int curand(curandState_t*)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 float curand_uniform(curandState_t*)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 double curand_uniform_double(curandState_t*)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/random/cuda/detail/RngStateInit.cu
+++ b/src/random/cuda/detail/RngStateInit.cu
@@ -45,7 +45,7 @@ __global__ void rng_init_kernel(const RngStatePointers           state,
 void rng_state_init_device(const RngStatePointers&         device_ptrs,
                            Span<const RngSeed::value_type> device_seeds)
 {
-    REQUIRE(device_ptrs.size() == device_seeds.size());
+    CELER_EXPECT(device_ptrs.size() == device_seeds.size());
 
     // Launch kernel to build RNG states on device
     celeritas::KernelParamCalculator calc_launch_params;

--- a/src/random/cuda/detail/RngStateInit.nocuda.cc
+++ b/src/random/cuda/detail/RngStateInit.nocuda.cc
@@ -20,7 +20,7 @@ namespace detail
 void rng_state_init_device(const RngStatePointers&,
                            Span<const RngSeed::value_type>)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/random/distributions/BernoulliDistribution.i.hh
+++ b/src/random/distributions/BernoulliDistribution.i.hh
@@ -18,7 +18,7 @@ namespace celeritas
 CELER_FUNCTION BernoulliDistribution::BernoulliDistribution(real_type p_true)
     : p_true_(p_true)
 {
-    REQUIRE(p_true >= 0.0 && p_true <= 1.0);
+    CELER_EXPECT(p_true >= 0.0 && p_true <= 1.0);
 }
 
 //---------------------------------------------------------------------------//
@@ -30,8 +30,8 @@ BernoulliDistribution::BernoulliDistribution(real_type scaled_true,
                                              real_type scaled_false)
     : p_true_(scaled_true / (scaled_true + scaled_false))
 {
-    REQUIRE(scaled_true > 0 || scaled_false > 0);
-    REQUIRE(scaled_true >= 0.0 && scaled_false >= 0.0);
+    CELER_EXPECT(scaled_true > 0 || scaled_false > 0);
+    CELER_EXPECT(scaled_true >= 0.0 && scaled_false >= 0.0);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/random/distributions/ExponentialDistribution.i.hh
+++ b/src/random/distributions/ExponentialDistribution.i.hh
@@ -20,7 +20,7 @@ CELER_FUNCTION
 ExponentialDistribution<RT>::ExponentialDistribution(real_type lambda)
     : neg_inv_lambda_(real_type{-1} / lambda)
 {
-    REQUIRE(lambda > real_type{0});
+    CELER_EXPECT(lambda > real_type{0});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/random/distributions/RadialDistribution.i.hh
+++ b/src/random/distributions/RadialDistribution.i.hh
@@ -21,7 +21,7 @@ CELER_FUNCTION
 RadialDistribution<RealType>::RadialDistribution(real_type radius)
     : radius_(radius)
 {
-    REQUIRE(radius_ > 0);
+    CELER_EXPECT(radius_ > 0);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/random/distributions/UniformRealDistribution.i.hh
+++ b/src/random/distributions/UniformRealDistribution.i.hh
@@ -21,7 +21,7 @@ UniformRealDistribution<RealType>::UniformRealDistribution(real_type a,
                                                            real_type b)
     : a_(a), delta_(b - a)
 {
-    REQUIRE(a < b);
+    CELER_EXPECT(a < b);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/Action.hh
+++ b/src/sim/Action.hh
@@ -52,7 +52,7 @@ inline CELER_FUNCTION bool action_completed(Action a)
  */
 inline CELER_FUNCTION bool action_killed(Action a)
 {
-    REQUIRE(int(a) < int(Action::end_killed_));
+    CELER_EXPECT(int(a) < int(Action::end_killed_));
     return int(a) >= int(Action::begin_killed_);
 }
 

--- a/src/sim/ParamStore.cc
+++ b/src/sim/ParamStore.cc
@@ -22,9 +22,9 @@ ParamStore::ParamStore(SPConstGeo      geo,
     , material_params_(std::move(mat))
     , particle_params_(std::move(particle))
 {
-    REQUIRE(geo_params_);
-    REQUIRE(material_params_);
-    REQUIRE(particle_params_);
+    CELER_EXPECT(geo_params_);
+    CELER_EXPECT(material_params_);
+    CELER_EXPECT(particle_params_);
 }
 
 //---------------------------------------------------------------------------//
@@ -37,7 +37,7 @@ ParamPointers ParamStore::device_pointers()
     result.geo      = geo_params_->device_pointers();
     result.material = material_params_->device_pointers();
     result.particle = particle_params_->device_pointers();
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 

--- a/src/sim/SimStateStore.cc
+++ b/src/sim/SimStateStore.cc
@@ -20,7 +20,7 @@ namespace celeritas
  */
 SimStateStore::SimStateStore(size_type size) : vars_(size)
 {
-    REQUIRE(size > 0);
+    CELER_EXPECT(size > 0);
 
     detail::sim_state_init_device(this->device_pointers());
 }
@@ -43,7 +43,7 @@ SimStatePointers SimStateStore::device_pointers()
     SimStatePointers result;
     result.vars = vars_.device_pointers();
 
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 

--- a/src/sim/SimTrackView.i.hh
+++ b/src/sim/SimTrackView.i.hh
@@ -16,7 +16,7 @@ CELER_FUNCTION
 SimTrackView::SimTrackView(const SimStatePointers& states, ThreadId id)
     : state_(states.vars[id.get()])
 {
-    REQUIRE(id < states.vars.size());
+    CELER_EXPECT(id < states.vars.size());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/StateStore.cc
+++ b/src/sim/StateStore.cc
@@ -36,7 +36,7 @@ StatePointers StateStore::device_pointers()
     result.sim          = sim_states_.device_pointers();
     result.rng          = rng_states_.device_pointers();
     result.interactions = interactions_.device_pointers();
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 

--- a/src/sim/TrackInitializerStore.cc
+++ b/src/sim/TrackInitializerStore.cc
@@ -65,7 +65,7 @@ TrackInitializerPointers TrackInitializerStore::device_pointers()
     result.secondary_counts = secondary_counts_.device_pointers();
     result.track_counter    = track_counter_.device_pointers();
 
-    ENSURE(result);
+    CELER_ENSURE(result);
     return result;
 }
 
@@ -178,12 +178,13 @@ void TrackInitializerStore::extend_from_secondaries(StateStore& states,
     // buffer the current track initializers to create room
     size_type num_secondaries
         = detail::reduce_counts(secondary_counts_.device_pointers());
-    INSIST(num_secondaries + initializers_.size() <= initializers_.capacity(),
-           "Insufficient capacity ("
-               << initializers_.capacity()
-               << ") for track initializers: created " << num_secondaries
-               << " new secondaries for a total capacity requirement of "
-               << num_secondaries + initializers_.size());
+    CELER_VALIDATE(
+        num_secondaries + initializers_.size() <= initializers_.capacity(),
+        "Insufficient capacity ("
+            << initializers_.capacity() << ") for track initializers: created "
+            << num_secondaries
+            << " new secondaries for a total capacity requirement of "
+            << num_secondaries + initializers_.size());
     // The exclusive prefix sum of the number of secondaries produced by each
     // track is used to get the start index in the vector of track initializers
     // for each thread. Starting at that index, each thread creates track

--- a/src/sim/detail/InitializeTracks.cu
+++ b/src/sim/detail/InitializeTracks.cu
@@ -142,7 +142,7 @@ __global__ void locate_alive_kernel(const StatePointers            states,
             // Calculate the track ID of the secondary
             // TODO: This is nondeterministic; we need to calculate the track
             // ID in a reproducible way.
-            CHECK(sim.event_id() < inits.track_counter.size());
+            CELER_ASSERT(sim.event_id() < inits.track_counter.size());
             TrackId::value_type track_id
                 = atomic_add(&inits.track_counter[sim.event_id().get()], 1u);
 
@@ -223,17 +223,17 @@ __global__ void process_secondaries_kernel(const StatePointers states,
             if (secondary)
             {
                 // The secondary survived cutoffs: convert to a track
-                CHECK(offset_id < inits.initializers.size());
+                CELER_ASSERT(offset_id < inits.initializers.size());
                 TrackInitializer& init = inits.initializers[offset_id];
 
                 // Store the thread ID of the secondary's parent
-                CHECK(offset_id < inits.parent.size());
+                CELER_ASSERT(offset_id < inits.parent.size());
                 inits.parent[offset_id++] = thread_id.get();
 
                 // Calculate the track ID of the secondary
                 // TODO: This is nondeterministic; we need to calculate the
                 // track ID in a reproducible way.
-                CHECK(sim.event_id() < inits.track_counter.size());
+                CELER_ASSERT(sim.event_id() < inits.track_counter.size());
                 TrackId::value_type track_id = atomic_add(
                     &inits.track_counter[sim.event_id().get()], 1u);
 
@@ -301,12 +301,12 @@ void locate_alive(const StatePointers&            states,
 void process_primaries(Span<const Primary>             primaries,
                        const TrackInitializerPointers& inits)
 {
-    REQUIRE(primaries.size() <= inits.initializers.size());
+    CELER_EXPECT(primaries.size() <= inits.initializers.size());
 
     // Get a view to the last primaries.size() initializers
     auto initializers = inits.initializers.subspan(inits.initializers.size()
                                                    - primaries.size());
-    CHECK(initializers.size() == primaries.size());
+    CELER_ASSERT(initializers.size() == primaries.size());
 
     KernelParamCalculator calc_launch_params;
     auto                  lparams = calc_launch_params(primaries.size());
@@ -324,8 +324,8 @@ void process_secondaries(const StatePointers&     states,
                          const ParamPointers&     params,
                          TrackInitializerPointers inits)
 {
-    REQUIRE(states.size() <= inits.secondary_counts.size());
-    REQUIRE(states.size() <= states.interactions.size());
+    CELER_EXPECT(states.size() <= inits.secondary_counts.size());
+    CELER_EXPECT(states.size() <= states.interactions.size());
 
     // Get a view to the last num_secondaries initializers
     inits.initializers = inits.initializers.subspan(inits.initializers.size()

--- a/src/sim/detail/InitializeTracks.nocuda.cc
+++ b/src/sim/detail/InitializeTracks.nocuda.cc
@@ -18,41 +18,41 @@ void init_tracks(const StatePointers&,
                  const ParamPointers&,
                  const TrackInitializerPointers&)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 void locate_alive(const StatePointers&,
                   const ParamPointers&,
                   const TrackInitializerPointers&)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 void process_primaries(Span<const Primary>, const TrackInitializerPointers&)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 void process_secondaries(const StatePointers&,
                          const ParamPointers&,
                          TrackInitializerPointers)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 size_type remove_if_alive(Span<size_type>)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 size_type reduce_counts(Span<size_type>)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 void exclusive_scan_counts(Span<size_type>)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/detail/SimStateInit.nocuda.cc
+++ b/src/sim/detail/SimStateInit.nocuda.cc
@@ -19,7 +19,7 @@ namespace detail
  */
 void sim_state_init_device(const SimStatePointers&)
 {
-    CHECK_UNREACHABLE;
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/base/Join.test.cc
+++ b/test/base/Join.test.cc
@@ -25,7 +25,7 @@ struct Moveable
 
     Moveable(std::string m, int* c) : msg(std::move(m)), counter(c)
     {
-        REQUIRE(counter);
+        CELER_EXPECT(counter);
     }
 
     Moveable(Moveable&& rhs) : msg(std::move(rhs.msg)), counter(rhs.counter)

--- a/test/base/Range.test.cu
+++ b/test/base/Range.test.cu
@@ -28,7 +28,7 @@ rangedev_test_kernel(int a, int* x, int* y, int* z, unsigned int n)
 
 RangeTestOutput rangedev_test(RangeTestInput input)
 {
-    REQUIRE(input.x.size() == input.y.size());
+    CELER_EXPECT(input.x.size() == input.y.size());
 
     // Local device vectors for working data
     thrust::device_vector<int> x_dev(input.x.begin(), input.x.end());

--- a/test/geometry/GeoParams.test.cc
+++ b/test/geometry/GeoParams.test.cc
@@ -26,7 +26,7 @@ class GeoParamsHostTest : public GeoParamsTest
     void SetUp() override
     {
         host_view = this->params()->host_pointers();
-        CHECK(host_view.world_volume);
+        CELER_ASSERT(host_view.world_volume);
     }
 
     // Views

--- a/test/geometry/GeoParamsTest.hh
+++ b/test/geometry/GeoParamsTest.hh
@@ -31,7 +31,7 @@ class GeoParamsTest : public celeritas::Test
 
     const SPConstGeo& params()
     {
-        ENSURE(geom_);
+        CELER_ENSURE(geom_);
         return geom_;
     }
 

--- a/test/geometry/GeoTrackView.test.cc
+++ b/test/geometry/GeoTrackView.test.cc
@@ -43,7 +43,7 @@ class GeoTrackViewHostTest : public GeoParamsTest
         state_view.vgnext     = this->next_state.get();
 
         params_view = this->params()->host_pointers();
-        CHECK(params_view.world_volume);
+        CELER_ASSERT(params_view.world_volume);
     }
 
   protected:
@@ -134,7 +134,7 @@ class GeoTrackViewDeviceTest : public GeoParamsTest
 
 TEST_F(GeoTrackViewDeviceTest, track_lines)
 {
-    CHECK(this->params());
+    CELER_ASSERT(this->params());
 
     // Set up test input
     VGGTestInput input;

--- a/test/geometry/GeoTrackView.test.cu
+++ b/test/geometry/GeoTrackView.test.cu
@@ -55,10 +55,10 @@ __global__ void vgg_test_kernel(const GeoParamsPointers shared,
 //! Run on device and return results
 VGGTestOutput vgg_test(VGGTestInput input)
 {
-    REQUIRE(input.shared);
-    REQUIRE(input.state);
-    REQUIRE(input.init.size() == input.state.size);
-    REQUIRE(input.max_segments > 0);
+    CELER_EXPECT(input.shared);
+    CELER_EXPECT(input.state);
+    CELER_EXPECT(input.init.size() == input.state.size);
+    CELER_EXPECT(input.max_segments > 0);
 
     // Temporary device data for kernel
     thrust::device_vector<VGGTestInit> init(input.init.begin(),

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -41,7 +41,7 @@ class LinearPropagatorHostTest : public GeoParamsTest
         state_view.vgnext     = this->next_state.get();
 
         params_view = this->params()->host_pointers();
-        CHECK(params_view.world_volume);
+        CELER_ASSERT(params_view.world_volume);
     }
 
   protected:
@@ -195,7 +195,7 @@ class LinearPropagatorDeviceTest : public GeoParamsTest
 
 TEST_F(LinearPropagatorDeviceTest, track_lines)
 {
-    CHECK(this->params());
+    CELER_ASSERT(this->params());
 
     // Set up test input
     LinPropTestInput input;

--- a/test/geometry/LinearPropagator.test.cu
+++ b/test/geometry/LinearPropagator.test.cu
@@ -68,10 +68,10 @@ __global__ void linProp_test_kernel(const GeoParamsPointers shared,
 //! Run on device and return results
 LinPropTestOutput linProp_test(LinPropTestInput input)
 {
-    REQUIRE(input.shared);
-    REQUIRE(input.state);
-    REQUIRE(input.init.size() == input.state.size);
-    REQUIRE(input.max_segments > 0);
+    CELER_EXPECT(input.shared);
+    CELER_EXPECT(input.state);
+    CELER_EXPECT(input.init.size() == input.state.size);
+    CELER_EXPECT(input.max_segments > 0);
 
     // Temporary device data for kernel
     thrust::device_vector<LinPropTestInit> init(input.init.begin(),

--- a/test/gtest/Test.cc
+++ b/test/gtest/Test.cc
@@ -27,7 +27,7 @@ std::string Test::test_data_path(const char* subdir, const char* filename)
     os << detail::source_dir << "/test/" << subdir << "/data/" << filename;
 
     std::string result = os.str();
-    ENSURE(std::ifstream(result).good());
+    CELER_ENSURE(std::ifstream(result).good());
     return result;
 }
 
@@ -37,12 +37,12 @@ std::string Test::test_data_path(const char* subdir, const char* filename)
  */
 std::string Test::make_unique_filename(const char* ext)
 {
-    REQUIRE(ext);
+    CELER_EXPECT(ext);
 
     // Get filename based on unit test name
     const ::testing::TestInfo* const test_info
         = ::testing::UnitTest::GetInstance()->current_test_info();
-    CHECK(test_info);
+    CELER_ASSERT(test_info);
 
     // Convert test case to lowercase
     std::string case_name = test_info->test_case_name();

--- a/test/gtest/detail/Utils.cc
+++ b/test/gtest/detail/Utils.cc
@@ -72,9 +72,9 @@ std::string char_to_hex_string(unsigned char value)
 const char*
 trunc_string(unsigned int digits, const char* str, const char* trunc)
 {
-    REQUIRE(str && trunc);
-    REQUIRE(digits > 0);
-    REQUIRE(std::strlen(trunc) <= digits);
+    CELER_EXPECT(str && trunc);
+    CELER_EXPECT(digits > 0);
+    CELER_EXPECT(std::strlen(trunc) <= digits);
 
     if (std::strlen(str) > digits)
     {

--- a/test/physics/InteractorHostTestBase.cc
+++ b/test/physics/InteractorHostTestBase.cc
@@ -42,7 +42,7 @@ InteractorHostTestBase::~InteractorHostTestBase() = default;
  */
 void InteractorHostTestBase::set_material_params(MaterialParams::Input inp)
 {
-    REQUIRE(!inp.materials.empty());
+    CELER_EXPECT(!inp.materials.empty());
 
     material_params_ = std::make_shared<MaterialParams>(std::move(inp));
     mp_pointers_     = material_params_->host_pointers();
@@ -56,7 +56,7 @@ void InteractorHostTestBase::set_material_params(MaterialParams::Input inp)
  */
 void InteractorHostTestBase::set_material(const std::string& name)
 {
-    REQUIRE(material_params_);
+    CELER_EXPECT(material_params_);
 
     mat_state_.def_id = material_params_->find(name);
     mt_view_          = std::make_shared<MaterialTrackView>(
@@ -69,7 +69,7 @@ void InteractorHostTestBase::set_material(const std::string& name)
  */
 const MaterialParams& InteractorHostTestBase::material_params() const
 {
-    REQUIRE(material_params_);
+    CELER_EXPECT(material_params_);
     return *material_params_;
 }
 
@@ -79,7 +79,7 @@ const MaterialParams& InteractorHostTestBase::material_params() const
  */
 void InteractorHostTestBase::set_particle_params(ParticleParams::Input inp)
 {
-    REQUIRE(!inp.empty());
+    CELER_EXPECT(!inp.empty());
     particle_params_ = std::make_shared<ParticleParams>(std::move(inp));
     pp_pointers_     = particle_params_->host_pointers();
 }
@@ -90,7 +90,7 @@ void InteractorHostTestBase::set_particle_params(ParticleParams::Input inp)
  */
 const ParticleParams& InteractorHostTestBase::particle_params() const
 {
-    REQUIRE(particle_params_);
+    CELER_EXPECT(particle_params_);
     return *particle_params_;
 }
 
@@ -100,9 +100,9 @@ const ParticleParams& InteractorHostTestBase::particle_params() const
  */
 void InteractorHostTestBase::set_inc_particle(PDGNumber pdg, MevEnergy energy)
 {
-    REQUIRE(particle_params_);
-    REQUIRE(pdg);
-    REQUIRE(energy >= zero_quantity());
+    CELER_EXPECT(particle_params_);
+    CELER_EXPECT(pdg);
+    CELER_EXPECT(energy >= zero_quantity());
 
     particle_state_.def_id = particle_params_->find(pdg);
     particle_state_.energy = energy;
@@ -117,7 +117,7 @@ void InteractorHostTestBase::set_inc_particle(PDGNumber pdg, MevEnergy energy)
  */
 void InteractorHostTestBase::set_inc_direction(const Real3& dir)
 {
-    REQUIRE(celeritas::norm(dir) > 0);
+    CELER_EXPECT(celeritas::norm(dir) > 0);
 
     inc_direction_ = dir;
     normalize_direction(&inc_direction_);
@@ -129,7 +129,7 @@ void InteractorHostTestBase::set_inc_direction(const Real3& dir)
  */
 void InteractorHostTestBase::resize_secondaries(int count)
 {
-    REQUIRE(count > 0);
+    CELER_EXPECT(count > 0);
     secondaries_.resize(count);
     sa_view_ = std::make_shared<SecondaryAllocatorView>(
         secondaries_.host_pointers());

--- a/test/physics/InteractorHostTestBase.hh
+++ b/test/physics/InteractorHostTestBase.hh
@@ -95,7 +95,7 @@ class InteractorHostTestBase : public celeritas::Test
     void               set_material(const std::string& name);
     MaterialTrackView& material_track()
     {
-        REQUIRE(mt_view_);
+        CELER_EXPECT(mt_view_);
         return *mt_view_;
     }
     //!@}
@@ -107,7 +107,7 @@ class InteractorHostTestBase : public celeritas::Test
     const Real3&             direction() const { return inc_direction_; }
     const ParticleTrackView& particle_track() const
     {
-        REQUIRE(pt_view_);
+        CELER_EXPECT(pt_view_);
         return *pt_view_;
     }
     //!@}
@@ -118,7 +118,7 @@ class InteractorHostTestBase : public celeritas::Test
     const HostSecondaryStore& secondaries() const { return secondaries_; }
     SecondaryAllocatorView& secondary_allocator()
     {
-        REQUIRE(sa_view_);
+        CELER_EXPECT(sa_view_);
         return *sa_view_;
     }
     //!@}

--- a/test/physics/base/Particle.test.cc
+++ b/test/physics/base/Particle.test.cc
@@ -97,7 +97,7 @@ class ParticleTrackViewTestHost : public ParticleTrackViewTest
     void SetUp() override
     {
         Base::SetUp();
-        CHECK(particle_params);
+        CELER_ASSERT(particle_params);
 
         // Construct views
         params_view     = particle_params->host_pointers();

--- a/test/physics/base/Particle.test.cu
+++ b/test/physics/base/Particle.test.cu
@@ -37,7 +37,7 @@ __global__ void ptv_test_kernel(unsigned int              size,
     result += local_thread_id.get() * PTVTestOutput::props_per_thread();
 
     // Calculate/write values from the track view
-    CHECK(p.def_id() == init[local_thread_id.get()].def_id);
+    CELER_ASSERT(p.def_id() == init[local_thread_id.get()].def_id);
     *result++ = p.energy().value();
     *result++ = p.mass().value();
     *result++ = p.charge().value();

--- a/test/physics/em/PhotoelectricInteractor.test.cc
+++ b/test/physics/em/PhotoelectricInteractor.test.cc
@@ -35,7 +35,7 @@ class PhotoelectricInteractorTest
   protected:
     void set_livermore_params(LivermoreParams::Input inp)
     {
-        REQUIRE(!inp.elements.empty());
+        CELER_EXPECT(!inp.elements.empty());
 
         livermore_params_ = std::make_shared<LivermoreParams>(std::move(inp));
         data_             = livermore_params_->host_pointers();

--- a/test/physics/material/ElementSelector.test.cc
+++ b/test/physics/material/ElementSelector.test.cc
@@ -79,7 +79,7 @@ class ElementSelectorTest : public celeritas::Test
 // Return cross section proportional to the element ID offset by 1.
 real_type mock_micro_xs(ElementDefId el_id)
 {
-    REQUIRE(el_id < 4);
+    CELER_EXPECT(el_id < 4);
     return static_cast<real_type>(el_id.get() + 1);
 }
 
@@ -95,7 +95,7 @@ struct CalcFancyMicroXs
 
     real_type operator()(ElementDefId el_id) const
     {
-        REQUIRE(el_id);
+        CELER_EXPECT(el_id);
         ElementView el(mats_, el_id);
         return el.cbrt_z() * inv_energy_;
     }

--- a/test/physics/material/Material.test.cu
+++ b/test/physics/material/Material.test.cu
@@ -36,7 +36,7 @@ __global__ void m_test_kernel(unsigned int const           size,
 
     // Initialize state
     mat_track = init[tid.get()];
-    CHECK(mat_track.def_id() == init[tid.get()].def_id);
+    CELER_ASSERT(mat_track.def_id() == init[tid.get()].def_id);
 
     // Get material properties
     const auto& mat         = mat_track.material_view();

--- a/test/physics/material/Material.test.hh
+++ b/test/physics/material/Material.test.hh
@@ -25,7 +25,7 @@ struct MTestInput
 
     size_type size() const
     {
-        REQUIRE(states.size() == init.size());
+        CELER_EXPECT(states.size() == init.size());
         return states.size();
     }
 };

--- a/test/sim/TrackInitializerStore.test.cc
+++ b/test/sim/TrackInitializerStore.test.cc
@@ -30,7 +30,7 @@ ITTestInput::ITTestInput(std::vector<size_type>& host_alloc_size,
                          std::vector<char>&      host_alive)
     : alloc_size(host_alloc_size.size()), alive(host_alive.size())
 {
-    REQUIRE(host_alloc_size.size() == host_alive.size());
+    CELER_EXPECT(host_alloc_size.size() == host_alive.size());
     alloc_size.copy_to_device(make_span(host_alloc_size));
     alive.copy_to_device(make_span(host_alive));
 }

--- a/test/sim/TrackInitializerStore.test.cu
+++ b/test/sim/TrackInitializerStore.test.cu
@@ -92,8 +92,8 @@ void interact(StatePointers              states,
               SecondaryAllocatorPointers secondaries,
               ITTestInputPointers        input)
 {
-    REQUIRE(states.size() > 0);
-    REQUIRE(states.size() == input.alloc_size.size());
+    CELER_EXPECT(states.size() > 0);
+    CELER_EXPECT(states.size() == input.alloc_size.size());
 
     KernelParamCalculator calc_launch_params;
     auto                  lparams = calc_launch_params(states.size());


### PR DESCRIPTION
See https://github.com/celeritas-project/celeritas/discussions/97, our slack vote, and our resolution of the discussion in today's meeting. I ported a utility script from Exnihilo to make the renaming operation  simple and reproducible in case there are outdated branches with error checking.