### PR TITLE
Provide an imported target for HepMC3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,16 @@ endif()
 
 if(CELERITAS_USE_HepMC3)
   find_package(HepMC3 REQUIRED)
+  # HepMC3's cmake config file does not provide an imported target yet
+  # Anticipate that it will, and create if not present. HepMC3 is
+  # a private dep of Celeritas, so no need to re-export this.
+  if(NOT TARGET HepMC3::HepMC3)
+    add_library(HepMC3::HepMC3 UNKNOWN IMPORTED)
+    set_target_properties(HepMC3::HepMC3 PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${HEPMC3_INCLUDE_DIR}"
+      IMPORTED_LOCATION "${HEPMC3_LIB}"
+    )
+  endif()
 endif()
 
 if(CELERITAS_USE_MPI)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,7 @@ if(CELERITAS_USE_HepMC3)
   list(APPEND SOURCES
     io/EventReader.cc
   )
-  list(APPEND PRIVATE_DEPS ${HEPMC3_LIB})
+  list(APPEND PRIVATE_DEPS HepMC3::HepMC3)
 else()
   list(APPEND SOURCES
     io/EventReader.nohepmc.cc


### PR DESCRIPTION
HepMC3's cmake config file does not provide imported targets for its libraries. This caused build errors between spack view and module builds. Celeritas does not add the include directory for HepMC3 directly, resulting in view-based builds finding HepMC3 headers incidently due to the view holding all used packages. Module based builds exposed this issue due to the separate include directories for each module.

When using HepMC3, create a "HepMC3::HepMC3" imported target if one does not exist, allowing for future supply of the target by HepMC3 itself (I'll put a MR request in upstream when I get a chance). Use this target to link in place of the "HEPMC3_LIB" variable to propagate the include path.

NB: I've only tested this in a spack-view setup, but the basic linking and path propagation is working...