### PR TITLE
Add EPlusGG interactor kernel

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,8 +61,8 @@ if(CELERITAS_USE_CUDA)
     base/KernelParamCalculator.cuda.cc
     base/Memory.cu
     comm/Device.cuda.cc
-    physics/em/detail/KleinNishina.cu
     physics/em/detail/EPlusGG.cu
+    physics/em/detail/KleinNishina.cu
     random/cuda/detail/RngStateInit.cu
     sim/detail/SimStateInit.cu
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,7 @@ if(CELERITAS_USE_CUDA)
     base/Memory.cu
     comm/Device.cuda.cc
     physics/em/detail/KleinNishina.cu
+    physics/em/detail/EPlusGG.cu
     random/cuda/detail/RngStateInit.cu
     sim/detail/SimStateInit.cu
   )

--- a/src/physics/em/EPlusGGModel.cc
+++ b/src/physics/em/EPlusGGModel.cc
@@ -57,8 +57,11 @@ auto EPlusGGModel::applicability() const -> SetApplicability
 void EPlusGGModel::interact(
     CELER_MAYBE_UNUSED const ModelInteractPointers& pointers) const
 {
-    // TODO: implement me
+#if CELERITAS_USE_CUDA
+    detail::eplusgg_interact(interface_, pointers);
+#else
     CELER_ASSERT_UNREACHABLE();
+#endif
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/EPlusGG.cu
+++ b/src/physics/em/detail/EPlusGG.cu
@@ -1,0 +1,88 @@
+//---------------------------------*-CUDA-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file EPlusGG.cu
+//---------------------------------------------------------------------------//
+#include "EPlusGG.hh"
+
+#include "base/Assert.hh"
+#include "base/KernelParamCalculator.cuda.hh"
+#include "random/cuda/RngEngine.hh"
+#include "physics/base/ModelInterface.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/PhysicsTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
+#include "EPlusGGInteractor.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+// KERNELS
+//---------------------------------------------------------------------------//
+/*!
+ * Interact using the EPlusGG model on applicable tracks.
+ */
+__global__ void eplusgg_interact_kernel(const EPlusGGPointers       epgg,
+                                        const ModelInteractPointers model)
+{
+    // Get the thread id
+    auto tid = celeritas::KernelParamCalculator::thread_id();
+    if (tid.get() >= model.states.size())
+        return;
+
+    // Get views to this Secondary, Particle, and Physics
+    SecondaryAllocatorView allocate_secondaries(model.secondaries);
+    ParticleTrackView      particle(
+        model.params.particle, model.states.particle, tid);
+    PhysicsTrackView physics(model.params.physics,
+                             model.states.physics,
+                             particle.def_id(),
+                             MaterialDefId{},
+                             tid);
+
+    // This interaction only applies if the EPlusGG model was selected
+    if (physics.model_id() != epgg.model_id)
+        return;
+
+    // Do the interaction
+    EPlusGGInteractor interact(
+        epgg, particle, model.states.direction[tid.get()], allocate_secondaries);
+    RngEngine rng(model.states.rng, tid);
+    model.result[tid.get()] = interact(rng);
+
+    CELER_ENSURE(model.result[tid.get()]);
+}
+
+} // namespace
+
+//---------------------------------------------------------------------------//
+// LAUNCHERS
+//---------------------------------------------------------------------------//
+/*!
+ * Launch the EPlusGG interaction.
+ */
+void eplusgg_interact(const EPlusGGPointers&       eplusgg,
+                      const ModelInteractPointers& model)
+{
+    CELER_EXPECT(eplusgg);
+    CELER_EXPECT(model);
+
+    // Calculate kernel launch params
+    auto params = KernelParamCalculator()(model.states.size());
+
+    // Launch the kernel
+    eplusgg_interact_kernel<<<params.grid_size, params.block_size>>>(eplusgg,
+                                                                     model);
+
+    CELER_CUDA_CHECK_ERROR();
+}
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/physics/em/detail/EPlusGG.hh
+++ b/src/physics/em/detail/EPlusGG.hh
@@ -41,5 +41,13 @@ struct EPlusGGPointers
 };
 
 //---------------------------------------------------------------------------//
+// KERNEL LAUNCHERS
+//---------------------------------------------------------------------------//
+
+// Launch the EPlusGG interaction
+void eplusgg_interact(const EPlusGGPointers&       eplusgg,
+                      const ModelInteractPointers& model);
+
+//---------------------------------------------------------------------------//
 } // namespace detail
 } // namespace celeritas


### PR DESCRIPTION
This add a kernel for the EPlusGG interactor and adds the kernel call to the `EPlusGGModel::interact()` function call.