### PR TITLE
Fix ROOT autoloading and add RootImporter to the dict.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,6 +176,7 @@ if(CELERITAS_USE_ROOT)
     io/ImportPhysicsVector.hh
     io/ImportProcess.hh
     io/ImportVolume.hh
+    MODULE celeritas_root
     LINKDEF io/RootInterfaceLinkDef.h
   )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,6 +176,7 @@ if(CELERITAS_USE_ROOT)
     io/ImportPhysicsVector.hh
     io/ImportProcess.hh
     io/ImportVolume.hh
+    io/RootImporter.hh
     MODULE celeritas_root
     LINKDEF io/RootInterfaceLinkDef.h
   )

--- a/src/io/RootInterfaceLinkDef.h
+++ b/src/io/RootInterfaceLinkDef.h
@@ -17,6 +17,7 @@
 #pragma link C++ class celeritas::ImportMaterial+;
 #pragma link C++ class celeritas::ImportElement+;
 #pragma link C++ class celeritas::ImportVolume+;
+#pragma link C++ class celeritas::RootImporter+;
 // clang-format on
 
 #endif


### PR DESCRIPTION
With these change one can do (with the script below):
```
LD_LIBRARY_PATH=${PWD}/src:${LD_LIBRARY_PATH} CELER_DISABLE_PARALLEL=true python celeritas/example.py
status: Opening ROOT file
status: Loading particle data
/wclustre/g4p/pcanal/geant/sources/celeritas/src/comm/Device.cuda.cc:35: warning: Disabling GPU support since no CUDA devices are present
status: Loading physics processes
status: Loading geometry data
status: Loading material data
['annihilation', 'conversion', 'rayleigh', 'e_ioni', 'compton', 'e_brem', 'coulomb_scat', 'photoelectric', 'msc']
['lambda_prim']
```
and in C++
```
LD_LIBRARY_PATH=${PWD}/src:${LD_LIBRARY_PATH} CELER_DISABLE_PARALLEL=true root.exe -b -l celeritas/example.C -q

Processing celeritas/example.C...
status: Opening ROOT file
status: Loading particle data
/wclustre/g4p/pcanal/geant/sources/celeritas/src/comm/Device.cuda.cc:35: warning: Disabling GPU support since no CUDA devices are present
status: Loading physics processes
status: Loading geometry data
status: Loading material data
'annihilation' ,'compton' ,'conversion' ,'coulomb_scat' ,'e_brem' ,'e_ioni' ,'msc' ,'photoelectric' ,'rayleigh' ,
'lambda_prim' ,
```

After telling the script where to find the library then setting LD_LIBRARY_PATH can be omitted:
```
CELER_DISABLE_PARALLEL=true python celeritas/example.py
CELER_DISABLE_PARALLEL=true root.exe -b -l celeritas/example.C -q
```
will lead to the same results.

The scripts are:
> example.py
```
import ROOT
import sys

# Udpate with the correct path and uncomment the next line if build_dir/src is not on the LD_LIBRARY_PATH
# ROOT.gSystem.Load("src/libceleritas_root")

import_root = ROOT.celeritas.RootImporter("./celeritas/test/io/data/geant-exporter-data.root")

data = import_root()

# This is (temporary) work-around ROOT issue #7077 (weak overload resolution when using enums classes)
ROOT.gInterpreter.Declare("namespace celeritas { const char *ipc_to_cstring(int value) { return to_cstring((ImportProcessClass)value); } }")
ROOT.gInterpreter.Declare("namespace celeritas { const char *itt_to_cstring(int value) { return to_cstring((ImportTableType)value); } }")

processes = {ROOT.celeritas.ipc_to_cstring(p.process_class): p for p in data.processes}

print processes.keys()

def get_tables(process):
   return { ROOT.celeritas.itt_to_cstring(t.table_type): t for t in process.tables}

print get_tables(processes['photoelectric']).keys()
```
and
> example.C
```
//Udpate with the correct path and uncomment the next 2 lines if build_dir/src is not on the LD_LIBRARY_PATH
//R__LOAD_LIBRARY(src/libceleritas_root)
//void example()

{
   celeritas::RootImporter import_root("./celeritas/test/io/data/geant-exporter-data.root");
   auto data = import_root();

   std::map<std::string, celeritas::ImportProcess*> processes;
   for (auto &p : data.processes) {
      processes.insert( {celeritas::to_cstring(p.process_class), &p} );
   }

   for (auto &k : processes)
      std::cout << "\'" << k.first << "' ,";
   std::cout << '\n';
   
   auto get_tables = [](celeritas::ImportProcess &process) {
      std::map<std::string, celeritas::ImportPhysicsTable> tables;
      for (auto &t : process.tables)
         tables.insert( {celeritas::to_cstring(t.table_type), t} );
      return tables;
   };

   for (const auto &k : get_tables(*processes["photoelectric"]))
      std::cout << "\'" << k.first << "' ,";
   std::cout << '\n';
}
```
