### PR TITLE
Update copyright year in stub file generator

### DIFF
--- a/scripts/dev/celeritas-gen.py
+++ b/scripts/dev/celeritas-gen.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-###############################################################################
-# File: scripts/dev/celeritas-gen.py
-###############################################################################
-"""Generate class file stubs for Celeritas.
+# Copyright 2021 UT-Battelle, LLC and other Celeritas Developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""\
+Generate file stubs for Celeritas.
 """
-from __future__ import (division, absolute_import, print_function)
+
+from datetime import datetime
 import os
 import os.path
 import re
 import subprocess
 import stat
 import sys
+
 ###############################################################################
 
 CLIKE_TOP = '''\
@@ -242,7 +245,7 @@ PYTHON_FILE = '''\
 
 '''
 
-YEAR = "2020"
+YEAR = datetime.today().year
 
 TEMPLATES = {
     'hh': HEADER_FILE,
@@ -362,10 +365,5 @@ def main():
     for fn in args.filename:
         generate(basedir, fn, args.namespace)
 
-#-----------------------------------------------------------------------------#
 if __name__ == '__main__':
     main()
-
-###############################################################################
-# end of scripts/dev/celeritas-gen.py
-###############################################################################

--- a/scripts/dev/celeritas-gen.py
+++ b/scripts/dev/celeritas-gen.py
@@ -36,9 +36,9 @@ HEADER_FILE = '''\
  * Brief class description.
  *
  * Optional detailed class description, and possibly example usage:
- * \code
+ * \\code
     {name} ...;
-   \endcode
+   \\endcode
  */
 class {name}
 {{
@@ -287,6 +287,7 @@ HEXT = {
     'CUDA': "cuh",
 }
 
+
 def generate(root, filename, namespace):
     if os.path.exists(filename):
         print("Skipping existing file " + filename)
@@ -337,7 +338,7 @@ def generate(root, filename, namespace):
         'capabbr': capabbr,
         'lowabbr': capabbr.lower(),
         'year': YEAR,
-        }
+    }
     with open(filename, 'w') as f:
         f.write((top + template).format(**variables))
         if top.startswith('#!'):
@@ -350,20 +351,24 @@ def generate(root, filename, namespace):
 def main():
     import argparse
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('filename', nargs='+',
-                        help='file names to generate')
-    parser.add_argument('--basedir',
-                        help='root source directory for file naming')
-    parser.add_argument('--namespace', '-n',
-                        default='celeritas',
-                        help='root source directory for file naming')
+    parser.add_argument(
+        'filename', nargs='+',
+        help='file names to generate')
+    parser.add_argument(
+        '--basedir',
+        help='root source directory for file naming')
+    parser.add_argument(
+        '--namespace', '-n',
+        default='celeritas',
+        help='root source directory for file naming')
     args = parser.parse_args()
     basedir = args.basedir or os.path.join(
-            subprocess.check_output(['git', 'rev-parse', '--show-toplevel'])
-                .decode().strip(),
-            'src')
+        subprocess.check_output(['git', 'rev-parse', '--show-toplevel'])
+        .decode().strip(),
+        'src')
     for fn in args.filename:
         generate(basedir, fn, args.namespace)
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/dev/rename-macros.py
+++ b/scripts/dev/rename-macros.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2020 UT-Battelle, LLC and other Celeritas Developers.
+# Copyright 2021 UT-Battelle, LLC and other Celeritas Developers.
 # See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""
+"""\
 Recursively modify files.
 """
 
@@ -12,23 +12,24 @@ import os
 import os.path
 import re
 
-MACROS = {
+REPLACE = {
+    'Copyright 2020': 'Copyright 2021',
     'REQUIRE': 'CELER_EXPECT',
     'CHECK': 'CELER_ASSERT',
     'ENSURE': 'CELER_ENSURE',
     'CHECK_UNREACHABLE': 'CELER_ASSERT_UNREACHABLE()',
     'INSIST': 'CELER_VALIDATE',
 }
-RE_MACRO_NAMES = re.compile(r'\b(' + '|'.join(MACROS.keys()) + r')\b')
+RE_REPLACE = re.compile(r'\b(' + '|'.join(REPLACE.keys()) + r')\b')
 def replace_macro_names(matchobj):
-    return MACROS[matchobj.group(1)]
+    return REPLACE[matchobj.group(1)]
 
 def update_macros(filename):
     with ReWriter(filename) as rewriter:
         (old, new) = rewriter.files
         for line in old:
             orig_line = line
-            line = RE_MACRO_NAMES.sub(replace_macro_names, line)
+            line = RE_REPLACE.sub(replace_macro_names, line)
             if line != orig_line:
                 rewriter.dirty = True
             new.write(line)
@@ -140,10 +141,10 @@ class ReWriter(object):
         return (self.infile, self.outfile)
 
 
-def run(argv=None):
+def main(argv=None):
     from argparse import ArgumentParser
     parser = ArgumentParser(
-            description="Update macros"
+            description="Update assertion macros"
             )
     parser.add_argument('-r', dest="recursive",
             help="Recursive",
@@ -178,4 +179,4 @@ def run(argv=None):
     log.info("Done.")
 
 if __name__ == '__main__':
-    run()
+    main()

--- a/scripts/dev/rename-macros.py
+++ b/scripts/dev/rename-macros.py
@@ -21,8 +21,11 @@ REPLACE = {
     'INSIST': 'CELER_VALIDATE',
 }
 RE_REPLACE = re.compile(r'\b(' + '|'.join(REPLACE.keys()) + r')\b')
+
+
 def replace_macro_names(matchobj):
     return REPLACE[matchobj.group(1)]
+
 
 def update_macros(filename):
     with ReWriter(filename) as rewriter:
@@ -34,10 +37,12 @@ def update_macros(filename):
                 rewriter.dirty = True
             new.write(line)
 
+
 class HasExtension(object):
     """Helper class that says "yes the extension is valid" for any non-empty
     extension.
     """
+
     def __init__(self):
         pass
 
@@ -83,19 +88,20 @@ class ReWriter(object):
     This takes care of error conditions as well as being graceful about not
     touching files that don't get changed.
     """
+
     def __init__(self, filename, preserve=False):
         (base, ext) = os.path.splitext(filename)
 
-        self.filename     = filename
+        self.filename = filename
         self.tempfilename = base + ".temp" + ext
         self.origfilename = base + ".orig" + ext
 
         # New and original files
-        self.infile  = open(filename, "r")
+        self.infile = open(filename, "r")
         self.outfile = open(self.tempfilename, "w")
 
         # Whether we've changed the file
-        self.dirty    = False
+        self.dirty = False
         # Whether to preserve the original
         self.preserve = preserve
 
@@ -144,16 +150,19 @@ class ReWriter(object):
 def main(argv=None):
     from argparse import ArgumentParser
     parser = ArgumentParser(
-            description="Update assertion macros"
-            )
-    parser.add_argument('-r', dest="recursive",
-            help="Recursive",
-            action='store_true')
-    parser.add_argument('-x', '--extensions',
-            help="Comma-separated extensions to use when searching recursively",
-            default=".hh,.cc,.cu")
-    parser.add_argument('path', nargs='+',
-            help="Files/dirs to process")
+        description="Update assertion macros"
+    )
+    parser.add_argument(
+        '-r', dest="recursive",
+        help="Recursive",
+        action='store_true')
+    parser.add_argument(
+        '-x', '--extensions',
+        help="Comma-separated extensions to use when searching recursively",
+        default=".hh,.cc,.cu")
+    parser.add_argument(
+        'path', nargs='+',
+        help="Files/dirs to process")
 
     args = parser.parse_args(argv)
 
@@ -177,6 +186,7 @@ def main(argv=None):
             log.exception(e)
 
     log.info("Done.")
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I was lazy when I created the `celeritas-gen.py` and hardcoded the year to 2020, so even now new files have been showing up with that year (oops). This updates the script to use the actual current year. I don't plan on any global find-replaces for copyright year.