### PR TITLE
Add "not implemented" assertion macro

### DIFF
--- a/src/base/Assert.cc
+++ b/src/base/Assert.cc
@@ -40,6 +40,8 @@ const char* to_cstring(DebugErrorType which)
             return "unreachable code point";
         case DebugErrorType::unconfigured:
             return "required dependency is disabled in this build";
+        case DebugErrorType::unimplemented:
+            return "feature is not yet implemented";
         case DebugErrorType::postcondition:
             return "postcondition failed";
     }

--- a/src/base/Assert.hh
+++ b/src/base/Assert.hh
@@ -123,6 +123,7 @@
 #ifndef __CUDA_ARCH__
 #    define CELER_VALIDATE(COND, MSG) CELER_RUNTIME_ASSERT_(COND, MSG)
 #    define CELER_NOT_CONFIGURED(WHAT) CELER_DEBUG_FAIL_(WHAT, unconfigured)
+#    define CELER_NOT_IMPLEMENTED(WHAT) CELER_DEBUG_FAIL_(WHAT, unimplemented)
 #else
 #    define CELER_VALIDATE(COND, MSG)                                          \
         ::celeritas::throw_debug_error(::celeritas::DebugErrorType::assertion, \
@@ -131,6 +132,7 @@
                                        __FILE__,                               \
                                        __LINE__)
 #    define CELER_NOT_CONFIGURED(WHAT) CELER_ASSERT(0)
+#    define CELER_NOT_IMPLEMENTED(WHAT) CELER_ASSERT(0)
 #endif
 
 /*!
@@ -180,6 +182,7 @@ enum class DebugErrorType
     internal,      //!< Internal assertion check failure
     unreachable,   //!< Internal assertion: unreachable code path
     unconfigured,  //!< Internal assertion: required feature not enabled
+    unimplemented, //!< Internal assertion: not yet implemented
     postcondition, //!< Postcondition contract violation
 };
 

--- a/src/physics/em/BetheBlochInteractor.i.hh
+++ b/src/physics/em/BetheBlochInteractor.i.hh
@@ -25,6 +25,7 @@ CELER_FUNCTION BetheBlochInteractor::BetheBlochInteractor(
     CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
                  && inc_energy_ <= this->max_incident_energy());
     CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_NOT_IMPLEMENTED("Bethe-Bloch ionization");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/BremRelInteractor.i.hh
+++ b/src/physics/em/BremRelInteractor.i.hh
@@ -6,6 +6,8 @@
 //! \file BremRelInteractor.i.hh
 //---------------------------------------------------------------------------//
 
+#include "base/Assert.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -25,6 +27,7 @@ BremRelInteractor::BremRelInteractor(const BremRelInteractorPointers& shared,
     CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
                  && inc_energy_ <= this->max_incident_energy());
     CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_NOT_IMPLEMENTED("relativistic Bremsstrahlung");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/MollerBhabhaInteractor.i.hh
+++ b/src/physics/em/MollerBhabhaInteractor.i.hh
@@ -25,6 +25,7 @@ CELER_FUNCTION MollerBhabhaInteractor::MollerBhabhaInteractor(
     CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
                  && inc_energy_ <= this->max_incident_energy());
     CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_NOT_IMPLEMENTED("Moller-Bhabha ionization");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/RayleighInteractor.i.hh
+++ b/src/physics/em/RayleighInteractor.i.hh
@@ -25,6 +25,7 @@ RayleighInteractor::RayleighInteractor(const RayleighInteractorPointers& shared,
     CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
                  && inc_energy_ <= this->max_incident_energy());
     CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_NOT_IMPLEMENTED("Rayleigh scattering");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/UrbanInteractor.i.hh
+++ b/src/physics/em/UrbanInteractor.i.hh
@@ -25,6 +25,7 @@ UrbanInteractor::UrbanInteractor(const UrbanInteractorPointers& shared,
     CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
                  && inc_energy_ <= this->max_incident_energy());
     CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_NOT_IMPLEMENTED("Urban multiple scattering");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/WentzelInteractor.i.hh
+++ b/src/physics/em/WentzelInteractor.i.hh
@@ -25,6 +25,7 @@ WentzelInteractor::WentzelInteractor(const WentzelInteractorPointers& shared,
     CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
                  && inc_energy_ <= this->max_incident_energy());
     CELER_EXPECT(particle.def_id() == shared_.gamma_id); // XXX
+    CELER_NOT_IMPLEMENTED("Wentzel multiple scattering");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/grid/ValueGridBuilder.cc
+++ b/src/physics/grid/ValueGridBuilder.cc
@@ -141,7 +141,7 @@ void ValueGridXsBuilder::build(ValueGridStore*) const
     CELER_ASSERT(soft_equal(grid[prime_index], log_eprime_));
 
     // TODO: finish implementation
-    CELER_ASSERT_UNREACHABLE();
+    CELER_NOT_IMPLEMENTED("value grid construction");
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Another bit of granularity for assertion messages. This will make it easier to grep the code for missing features rather than for code paths that are expected to be unreachable.