### PR TITLE
Workaround nvlink bug

### DIFF
--- a/scripts/build/emmet.cmake
+++ b/scripts/build/emmet.cmake
@@ -35,6 +35,7 @@ set_cache_var(CMAKE_CXX_FLAGS STRING
 # MPI flags
 set_cache_var(MPI_CXX_SKIP_MPICXX BOOL TRUE)
 if(CELERITAS_USE_MPI)
-  # In CMake 3.18, these break the CUDA link line...
-  set_cache_var(MPI_CXX_LINK_FLAGS STRING "")
+  # In CMake 3.18, MPI flags get incorrectly passed to the CUDA build command,
+  # and empty CXX flags get overwritten
+  set_cache_var(MPI_CXX_LINK_FLAGS STRING "-pthread")
 endif()

--- a/src/physics/base/Secondary.hh
+++ b/src/physics/base/Secondary.hh
@@ -21,28 +21,16 @@ namespace celeritas
  */
 struct Secondary
 {
-    ParticleDefId    def_id;    //!< New particle type
-    units::MevEnergy energy;    //!< New kinetic energy
-    Real3            direction; //!< New direction
+    ParticleDefId    def_id{};                //!< New particle type
+    units::MevEnergy energy{zero_quantity()}; //!< New kinetic energy
+    Real3            direction;               //!< New direction
 
-    // Default to invalid state
-    CELER_FUNCTION
-    Secondary() : def_id(ParticleDefId{}), energy(zero_quantity()) {}
-
-    // Whether the secondary survived cutoffs
-    explicit inline CELER_FUNCTION operator bool() const;
+    //! Whether the secondary survived cutoffs
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return static_cast<bool>(this->def_id);
+    }
 };
-
-//---------------------------------------------------------------------------//
-// INLINE FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- * Whether the Secondary succeeded.
- */
-CELER_FUNCTION Secondary::operator bool() const
-{
-    return static_cast<bool>(this->def_id);
-}
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/physics/em/detail/BetheHeitler.cu
+++ b/src/physics/em/detail/BetheHeitler.cu
@@ -7,13 +7,14 @@
 //---------------------------------------------------------------------------//
 #include "BetheHeitler.hh"
 
+#include "base/Assert.hh"
 #include "base/KernelParamCalculator.cuda.hh"
-#include "physics/base/SecondaryAllocatorView.hh"
+#include "random/cuda/RngEngine.hh"
 #include "physics/base/ModelInterface.hh"
 #include "physics/base/ParticleTrackView.hh"
 #include "physics/base/PhysicsTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
 #include "physics/material/MaterialTrackView.hh"
-#include "random/cuda/RngEngine.hh"
 #include "BetheHeitlerInteractor.hh"
 
 namespace celeritas

--- a/src/physics/em/detail/KleinNishina.cu
+++ b/src/physics/em/detail/KleinNishina.cu
@@ -7,12 +7,13 @@
 //---------------------------------------------------------------------------//
 #include "KleinNishina.hh"
 
+#include "base/Assert.hh"
 #include "base/KernelParamCalculator.cuda.hh"
-#include "physics/base/SecondaryAllocatorView.hh"
+#include "random/cuda/RngEngine.hh"
 #include "physics/base/ModelInterface.hh"
 #include "physics/base/ParticleTrackView.hh"
 #include "physics/base/PhysicsTrackView.hh"
-#include "random/cuda/RngEngine.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
 #include "KleinNishinaInteractor.hh"
 
 namespace celeritas

--- a/src/physics/em/detail/LivermorePE.cu
+++ b/src/physics/em/detail/LivermorePE.cu
@@ -8,13 +8,13 @@
 #include "LivermorePE.hh"
 
 #include "base/KernelParamCalculator.cuda.hh"
-#include "physics/base/SecondaryAllocatorView.hh"
+#include "random/cuda/RngEngine.hh"
 #include "physics/base/ModelInterface.hh"
 #include "physics/base/ParticleTrackView.hh"
 #include "physics/base/PhysicsTrackView.hh"
+#include "physics/base/SecondaryAllocatorView.hh"
 #include "physics/material/ElementSelector.hh"
 #include "physics/material/MaterialTrackView.hh"
-#include "random/cuda/RngEngine.hh"
 #include "LivermorePEInteractor.hh"
 #include "LivermorePEMicroXsCalculator.hh"
 


### PR DESCRIPTION
@amandalund @pcanal

---

On emmet we saw the following error (which didn't appear on the CI, which runs CUDA 11.1):
```
nvlink error   : Size doesn't match for '_ZN9celeritas9SecondaryC1Ev$53' in 'CMakeFiles/celeritas.dir/physics/em/detail/EPlusGG.cu.o', first specified in 'CMakeFiles/celeritas.dir/physics/em/detail/BetheHeitler.cu.o'
nvlink fatal   : merge_elf failed
```

A bug report for LLVM hinted at a bug in `nvlink` regarding weak symbols: https://bugs.llvm.org/show_bug.cgi?id=40893 . Using the nvcc `-keep` flag led to finding the Secondary's constructor was defined as a weak symbol, and internally it stores two values (for the initialization values of def_id and energy), which are defined internally in BetheHeitler as
```
.weak .global .align 4 .b8 _ZN9celeritas9SecondaryC1Ev$53[4] = {255, 255, 255, 255};
.weak .global .align 8 .b8 _ZN9celeritas9SecondaryC1Ev$54[8];
```

However, the constructor's private variables show up with a different suffix in the EPlusGG kernel:
```
.weak .global .align 4 .b8 _ZN9celeritas9SecondaryC1Ev$52[4] = {255, 255, 255, 255};
.weak .global .align 8 .b8 _ZN9celeritas9SecondaryC1Ev$53[8];
```
so the suffixes are off by one and end up causing a collision.

I'm not sure how the suffixes are created, but changing the include order changes their value, so rearranging the includes causes the collision to disappear.