### PR TITLE
Allow for non-deterministic IDs in TrackInitializerStore test

### DIFF
--- a/test/sim/TrackInitializerStore.test.cc
+++ b/test/sim/TrackInitializerStore.test.cc
@@ -158,7 +158,10 @@ TEST_F(TrackInitTest, run)
     EXPECT_VEC_EQ(expected.vacancy, output.vacancy);
 
     // Check the track IDs of the track initializers created from secondaries
+    // Output is sorted as TrackInitializerStore does not calculate IDs
+    // deterministically
     output.initializer_id   = initializers_test(track_init.device_pointers());
+    std::sort(std::begin(output.initializer_id), std::end(output.initializer_id));
     expected.initializer_id = {0, 1, 15, 16, 17};
     EXPECT_VEC_EQ(expected.initializer_id, output.initializer_id);
 
@@ -166,8 +169,11 @@ TEST_F(TrackInitTest, run)
     track_init.initialize_tracks(states, params);
 
     // Check the track IDs of the initialized tracks
+    // Output is sorted as TrackInitializerStore does not calculate IDs
+    // deterministically
     output.track_id   = tracks_test(states.device_pointers());
-    expected.track_id = {12, 3, 16, 5, 13, 7, 17, 9, 14, 11};
+    std::sort(std::begin(output.track_id), std::end(output.track_id));
+    expected.track_id = {3, 5, 7, 9, 11, 12, 13, 14, 16, 17};
     EXPECT_VEC_EQ(expected.track_id, output.track_id);
 }
 

--- a/test/sim/TrackInitializerStore.test.cc
+++ b/test/sim/TrackInitializerStore.test.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "sim/TrackInitializerStore.hh"
 
+#include <algorithm>
 #include <numeric>
 #include "celeritas_test.hh"
 #include "geometry/GeoParams.hh"


### PR DESCRIPTION
Running on a local system with gcc9, CUDA 11 and a Quadro P400, I found a couple of failures in the `sim/TrackInitializerStore` test, the sections failing being:

```
52: [ RUN      ] TrackInitTest.run
52: info: Loading from GDML at <path>/celeritas.git/test/geometry/data/twoBoxes.gdml
52: status: Initializing tracking information
52: status: Converting to CUDA geometry
52: status: Transferring geometry to GPU
52: <path>/celeritas.git/test/sim/TrackInitializerStore.test.cc:163: Failure
52: Values in: output.initializer_id
52:  Expected: expected.initializer_id
52: 2 of 5 elements differ
52: i         EXPECTED           ACTUAL
52: 3               16u               17u
52: 4               17u               16u
52: 
52: <path>/celeritas.git/test/sim/TrackInitializerStore.test.cc:171: Failure
52: Values in: output.track_id
52:  Expected: expected.track_id
52: 4 of 10 elements differ
52: i         EXPECTED  output.track_id
52: 2               16u               17u
52: 4               13u               14u
52: 6               17u               16u
52: 8               14u               13u
52: 
52: [  FAILED  ] TrackInitTest.run (19 ms)
```

From @amandalund and @sethrj's diagnosis, this looks to be due to the current implementation of TrackInitializerStore not calculating new track IDs in a deterministic way. 

It was suggested to sort the offending returned host vectors before the test comparison, and that's implemented here and resolves the issue locally. I'm not sure if there are other places where this can/may occur, but at least this ticks off one location.