### PR TITLE
Add value grid construction and storage

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ list(APPEND SOURCES
   physics/em/GammaAnnihilationProcess.cc
   physics/em/KleinNishinaModel.cc
   physics/grid/ValueGridBuilder.cc
+  physics/grid/ValueGridStore.cc
   physics/material/MaterialParams.cc
   physics/material/MaterialStateStore.cc
   physics/material/detail/Utils.cc

--- a/src/base/DeviceVector.hh
+++ b/src/base/DeviceVector.hh
@@ -17,9 +17,14 @@ namespace celeritas
 /*!
  * Host-compiler-friendly vector for uninitialized device-storage data.
  *
- * This class does *not* perform initialization on the data. The host code
- * must define and copy over suitable data. For more complex data usage
- * (dynamic resizing and assignment without memory reallocation) uses \c
+ * The device vector's allocation is fixed on construction, but can be resized
+ * to a logically smaller space, or assigned (replaced) by a new DeviceVector.
+ * As a consequence, no \c resize operation will invalidate \c Span references
+ * to device data.
+ *
+ * This class does *not* perform initialization on the data. The host code must
+ * define and copy over suitable data. For more complex data usage (dynamic
+ * size increases and assignment without memory reallocation), use \c
  * thrust::device_vector.
  *
  * \code

--- a/src/base/DeviceVector.i.hh
+++ b/src/base/DeviceVector.i.hh
@@ -33,8 +33,10 @@ void DeviceVector<T>::swap(DeviceVector& other) noexcept
 
 //---------------------------------------------------------------------------//
 /*!
- * Change the size without changing capacity. There is no reallocation of
- * storage: the vector can only shrink or grow up to the container capacity.
+ * Change the size without changing capacity.
+ *
+ * There is no reallocation of storage: the vector can only shrink or grow up
+ * to the container capacity.
  */
 template<class T>
 void DeviceVector<T>::resize(size_type size)

--- a/src/base/VectorUtils.hh
+++ b/src/base/VectorUtils.hh
@@ -1,0 +1,34 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file VectorUtils.hh
+//! \brief Helper functions for std::vector
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+#include "Span.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+// Move the given span to the end of another vector.
+template<class T, std::size_t N, class U>
+inline Span<U> extend(Span<T, N> ext, std::vector<U>* base);
+
+//---------------------------------------------------------------------------//
+// Move the given extension to the end of another vector.
+template<class T>
+inline Span<T> extend(const std::vector<T>& ext, std::vector<T>* base);
+
+//---------------------------------------------------------------------------//
+// Move the given extension to the end of another vector.
+template<class T>
+inline Span<T> move_extend(std::vector<T>&& ext, std::vector<T>* base);
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "VectorUtils.i.hh"

--- a/src/base/VectorUtils.i.hh
+++ b/src/base/VectorUtils.i.hh
@@ -1,0 +1,60 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file VectorUtils.i.hh
+//---------------------------------------------------------------------------//
+
+#include <iterator>
+#include "Assert.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Copy the given extension to the end of a preallocated vector.
+ */
+template<class T, std::size_t N, class U>
+Span<U> extend(Span<T, N> ext, std::vector<U>* base)
+{
+    CELER_EXPECT(base);
+    CELER_EXPECT(base->size() + ext.size() <= base->capacity());
+
+    auto start = base->size();
+    base->insert(base->end(), ext.begin(), ext.end());
+    return {base->data() + start, base->data() + base->size()};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Copy the given extension to the end of a preallocated vector.
+ */
+template<class T>
+Span<T> extend(const std::vector<T>& ext, std::vector<T>* base)
+{
+    return extend(make_span(ext), base);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Move the given extension to the end of a vector.
+ *
+ * The vector does not have to be preallocated. The given data's elements will
+ * be moved, and the extension vector will be erased on completion.
+ */
+template<class T>
+Span<T> move_extend(std::vector<T>&& ext, std::vector<T>* base)
+{
+    CELER_EXPECT(base);
+
+    auto start = base->size();
+    base->insert(base->end(),
+                 std::make_move_iterator(ext.begin()),
+                 std::make_move_iterator(ext.end()));
+    ext.clear();
+    return {base->data() + start, base->data() + base->size()};
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/base/PhysicsParams.cc
+++ b/src/physics/base/PhysicsParams.cc
@@ -8,8 +8,8 @@
 #include "PhysicsParams.hh"
 
 #include <algorithm>
-#include <iterator>
 #include "base/Range.hh"
+#include "base/VectorUtils.hh"
 #include "ParticleParams.hh"
 #include "physics/material/MaterialParams.hh"
 
@@ -50,9 +50,7 @@ PhysicsParams::PhysicsParams(Input inp) : processes_(std::move(inp.processes))
         // tables
 
         // Move models to the end of the vector
-        models_.insert(models_.end(),
-                       std::make_move_iterator(new_models.begin()),
-                       std::make_move_iterator(new_models.end()));
+        celeritas::move_extend(std::move(new_models), &models_);
     }
 
     CELER_NOT_IMPLEMENTED("constructing physics params");

--- a/src/physics/em/LivermorePEParams.cc
+++ b/src/physics/em/LivermorePEParams.cc
@@ -12,6 +12,7 @@
 #include "base/Range.hh"
 #include "base/SoftEqual.hh"
 #include "base/SpanRemapper.hh"
+#include "base/VectorUtils.hh"
 #include "comm/Device.hh"
 
 namespace celeritas
@@ -183,12 +184,7 @@ LivermorePEParams::extend_shells(const ElementInput& inp)
 Span<real_type>
 LivermorePEParams::extend_data(const std::vector<real_type>& data)
 {
-    CELER_EXPECT(host_data_.size() + data.size() <= host_data_.capacity());
-
-    // Allocate data
-    host_data_.insert(host_data_.end(), data.begin(), data.end());
-    return Span<real_type>{host_data_.data() + host_data_.size() - data.size(),
-                           data.size()};
+    return celeritas::extend(data, &host_data_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/MockXsCalculator.hh
+++ b/src/physics/em/MockXsCalculator.hh
@@ -17,7 +17,7 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Storage for energy and cross sections.
- * TODO: temporary
+ * TODO: replace with GenericGridPointers
  */
 struct ValueGrid
 {

--- a/src/physics/grid/PhysicsGridCalculator.hh
+++ b/src/physics/grid/PhysicsGridCalculator.hh
@@ -12,7 +12,6 @@
 
 namespace celeritas
 {
-
 //---------------------------------------------------------------------------//
 /*!
  * Find and interpolate physics data based on a track's energy.
@@ -41,7 +40,8 @@ class PhysicsGridCalculator
 
   public:
     // Construct from state-independent data
-    inline explicit CELER_FUNCTION PhysicsGridCalculator(const XsGridPointers& data);
+    inline explicit CELER_FUNCTION
+    PhysicsGridCalculator(const XsGridPointers& data);
 
     // Find and interpolate from the energy
     inline CELER_FUNCTION real_type operator()(Energy energy) const;

--- a/src/physics/grid/PhysicsGridCalculator.i.hh
+++ b/src/physics/grid/PhysicsGridCalculator.i.hh
@@ -16,7 +16,8 @@ namespace celeritas
 /*!
  * Construct from cross section data.
  */
-CELER_FUNCTION PhysicsGridCalculator::PhysicsGridCalculator(const XsGridPointers& data)
+CELER_FUNCTION
+PhysicsGridCalculator::PhysicsGridCalculator(const XsGridPointers& data)
     : data_(data)
 {
     CELER_EXPECT(data);
@@ -40,12 +41,12 @@ CELER_FUNCTION real_type PhysicsGridCalculator::operator()(Energy energy) const
     if (loge <= loge_grid.front())
     {
         lower_idx = 0;
-        result = data_.value.front();
+        result    = data_.value.front();
     }
     else if (loge >= loge_grid.back())
     {
         lower_idx = data_.value.size() - 1;
-        result = data_.value.back();
+        result    = data_.value.back();
     }
     else
     {

--- a/src/physics/grid/ValueGridBuilder.cc
+++ b/src/physics/grid/ValueGridBuilder.cc
@@ -10,6 +10,8 @@
 #include <cmath>
 #include "base/SoftEqual.hh"
 #include "physics/grid/UniformGrid.hh"
+#include "physics/grid/XsGridInterface.hh"
+#include "physics/grid/ValueGridStore.hh"
 
 namespace celeritas
 {
@@ -31,7 +33,8 @@ bool has_same_log_spacing(SpanConstReal first, SpanConstReal second)
     auto calc_log_delta = [](SpanConstReal vec) {
         return vec.back() / (vec.front() * (vec.size() - 1));
     };
-    return soft_equal(calc_log_delta(first), calc_log_delta(second));
+    real_type delta[] = {calc_log_delta(first), calc_log_delta(second)};
+    return soft_equal(delta[0], delta[1]);
 }
 
 bool is_nonnegative(SpanConstReal vec)
@@ -67,16 +70,16 @@ ValueGridXsBuilder::from_geant(SpanConstReal lambda_energy,
                                SpanConstReal lambda_prim)
 {
     CELER_EXPECT(is_contiguous_increasing(lambda_energy, lambda_prim_energy));
-    CELER_EXPECT(has_same_log_spacing(lambda_prim, lambda_prim_energy));
+    CELER_EXPECT(has_same_log_spacing(lambda_energy, lambda_prim_energy));
     CELER_EXPECT(lambda.size() == lambda_energy.size());
     CELER_EXPECT(lambda_prim.size() == lambda_prim_energy.size());
     CELER_EXPECT(soft_equal(lambda.back(),
-                            lambda_prim.front() * lambda_prim_energy.front()));
+                            lambda_prim.front() / lambda_prim_energy.front()));
     CELER_EXPECT(is_nonnegative(lambda) && is_nonnegative(lambda_prim));
 
     // Concatenate the two XS vectors: store the scaled (lambda_prim) value at
     // the coincident point.
-    std::vector<real_type> xs(lambda.size() + lambda_prim.size() - 1);
+    VecReal xs(lambda.size() + lambda_prim.size() - 1);
     auto dst = std::copy(lambda.begin(), lambda.end() - 1, xs.begin());
     dst      = std::copy(lambda_prim.begin(), lambda_prim.end(), dst);
     CELER_ASSERT(dst == xs.end());
@@ -92,10 +95,10 @@ ValueGridXsBuilder::from_geant(SpanConstReal lambda_energy,
 /*!
  * Construct from raw data.
  */
-ValueGridXsBuilder::ValueGridXsBuilder(real_type              emin,
-                                       real_type              eprime,
-                                       real_type              emax,
-                                       std::vector<real_type> xs)
+ValueGridXsBuilder::ValueGridXsBuilder(real_type emin,
+                                       real_type eprime,
+                                       real_type emax,
+                                       VecReal   xs)
     : log_emin_(std::log(emin))
     , log_eprime_(std::log(eprime))
     , log_emax_(std::log(emax))
@@ -111,46 +114,44 @@ ValueGridXsBuilder::ValueGridXsBuilder(real_type              emin,
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the storage type and requirements for the energy grid.
- */
-auto ValueGridXsBuilder::energy_storage() const -> EnergyStorage
-{
-    return {EnergyLookup::uniform_log, 0};
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Get the storage type and requirements for the value grid.
  */
-auto ValueGridXsBuilder::value_storage() const -> ValueStorage
+auto ValueGridXsBuilder::storage() const -> Storage
 {
-    return {ValueCalculation::linear_scaled, xs_.size()};
+    return {ValueGridType::xs, xs_.size()};
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct on device.
  */
-void ValueGridXsBuilder::build(ValueGridStore*) const
+void ValueGridXsBuilder::build(ValueGridStore* store) const
 {
-    // Set up log grid
-    auto log_energy
+    XsGridPointers ptrs;
+    // Construct log(energy) grid
+    ptrs.log_energy
         = UniformGridPointers::from_bounds(log_emin_, log_emax_, xs_.size());
-    UniformGrid grid(log_energy);
-    size_type   prime_index = grid.find(log_eprime_);
-    CELER_ASSERT(soft_equal(grid[prime_index], log_eprime_));
+    {
+        // Find and check prime energy index
+        UniformGrid grid{ptrs.log_energy};
+        ptrs.prime_index = grid.find(log_eprime_);
+        CELER_ASSERT(soft_equal(grid[ptrs.prime_index], log_eprime_));
+    }
 
-    // TODO: finish implementation
-    CELER_NOT_IMPLEMENTED("value grid construction");
+    // Provide reference to values
+    ptrs.value = make_span(xs_);
+
+    // Copy data to store
+    store->push_back(ptrs);
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct from raw data.
  */
-ValueGridLogBuilder::ValueGridLogBuilder(real_type              emin,
-                                         real_type              emax,
-                                         std::vector<real_type> xs)
+ValueGridLogBuilder::ValueGridLogBuilder(real_type emin,
+                                         real_type emax,
+                                         VecReal   xs)
     : log_emin_(std::log(emin)), log_emax_(std::log(emax)), xs_(std::move(xs))
 {
     CELER_EXPECT(emin > 0);
@@ -162,33 +163,28 @@ ValueGridLogBuilder::ValueGridLogBuilder(real_type              emin,
 /*!
  * Get the storage type and requirements for the energy grid.
  */
-auto ValueGridLogBuilder::energy_storage() const -> EnergyStorage
+auto ValueGridLogBuilder::storage() const -> Storage
 {
-    return {EnergyLookup::uniform_log, 0};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the storage type and requirements for the value grid.
- */
-auto ValueGridLogBuilder::value_storage() const -> ValueStorage
-{
-    return {ValueCalculation::linear, xs_.size()};
+    return {ValueGridType::xs, xs_.size()};
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct on device.
  */
-void ValueGridLogBuilder::build(ValueGridStore*) const
+void ValueGridLogBuilder::build(ValueGridStore* store) const
 {
-    // Set up log grid
-    auto log_energy
-        = UniformGridPointers::from_bounds(log_emin_, log_emax_, xs_.size());
-    UniformGrid grid(log_energy);
+    XsGridPointers ptrs;
 
-    // TODO: finish implementation
-    CELER_NOT_IMPLEMENTED("value grid construction");
+    // Construct log(energy) grid
+    ptrs.log_energy
+        = UniformGridPointers::from_bounds(log_emin_, log_emax_, xs_.size());
+
+    // Provide reference to values
+    ptrs.value = make_span(xs_);
+
+    // Copy data to store
+    store->push_back(ptrs);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/grid/ValueGridBuilder.cc
+++ b/src/physics/grid/ValueGridBuilder.cc
@@ -98,8 +98,8 @@ ValueGridXsBuilder::from_geant(SpanConstReal lambda_energy,
     // Concatenate the two XS vectors: store the scaled (lambda_prim) value at
     // the coincident point.
     VecReal xs(lambda.size() + lambda_prim.size() - 1);
-    auto dst = std::copy(lambda.begin(), lambda.end() - 1, xs.begin());
-    dst      = std::copy(lambda_prim.begin(), lambda_prim.end(), dst);
+    auto    dst = std::copy(lambda.begin(), lambda.end() - 1, xs.begin());
+    dst         = std::copy(lambda_prim.begin(), lambda_prim.end(), dst);
     CELER_ASSERT(dst == xs.end());
 
     // Construct the grid

--- a/src/physics/grid/ValueGridBuilder.hh
+++ b/src/physics/grid/ValueGridBuilder.hh
@@ -82,6 +82,7 @@ class ValueGridXsBuilder final : public ValueGridBuilder
     // Get the storage type and requirements
     Storage storage() const final;
 
+    // Construct in the given store
     void build(ValueGridStore*) const final;
 
   private:
@@ -109,15 +110,51 @@ class ValueGridLogBuilder final : public ValueGridBuilder
     // Construct
     ValueGridLogBuilder(real_type emin, real_type emax, VecReal value);
 
-    // Get the storage type and requirements for the energy grid.
+    // Get the storage type and requirements
     Storage storage() const final;
 
+    // Construct in the given store
     void build(ValueGridStore*) const final;
 
   private:
     real_type              log_emin_;
     real_type              log_emax_;
     VecReal                xs_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build a physics vector for quantities that are nonuniform in energy.
+ */
+class ValueGridGenericBuilder final : public ValueGridBuilder
+{
+  public:
+    //!@{
+    //! Type aliases
+    using VecReal = std::vector<real_type>;
+    //!@}
+
+  public:
+    // Construct
+    ValueGridGenericBuilder(VecReal grid,
+                            VecReal value,
+                            Interp  grid_interp,
+                            Interp  value_interp);
+
+    // Construct with linear interpolation
+    ValueGridGenericBuilder(VecReal grid, VecReal value);
+
+    // Get the storage type and requirements
+    Storage storage() const final;
+
+    // Construct in the given store
+    void build(ValueGridStore*) const final;
+
+  private:
+    VecReal grid_;
+    VecReal value_;
+    Interp  grid_interp_;
+    Interp  value_interp_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/grid/ValueGridBuilder.hh
+++ b/src/physics/grid/ValueGridBuilder.hh
@@ -46,8 +46,8 @@ class ValueGridBuilder
   public:
     virtual ~ValueGridBuilder() = 0;
 
-    virtual Storage       storage() const              = 0;
-    virtual void          build(ValueGridStore*) const = 0;
+    virtual Storage storage() const              = 0;
+    virtual void    build(ValueGridStore*) const = 0;
 };
 
 //---------------------------------------------------------------------------//
@@ -117,9 +117,9 @@ class ValueGridLogBuilder final : public ValueGridBuilder
     void build(ValueGridStore*) const final;
 
   private:
-    real_type              log_emin_;
-    real_type              log_emax_;
-    VecReal                xs_;
+    real_type log_emin_;
+    real_type log_emax_;
+    VecReal   xs_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/grid/ValueGridStore.cc
+++ b/src/physics/grid/ValueGridStore.cc
@@ -17,8 +17,8 @@ namespace celeritas
 /*!
  * Construct with storage space requirements.
  *
- * This allocates device data and resizes it to empty (so that the vector can
- * keep track of its actual size).
+ * This allocates the required amount of data on the host so that the vector
+ * can keep track of its actual size.
  */
 ValueGridStore::ValueGridStore(size_type num_grids, size_type num_values)
     : capacity_(num_grids)

--- a/src/physics/grid/ValueGridStore.cc
+++ b/src/physics/grid/ValueGridStore.cc
@@ -83,7 +83,7 @@ void ValueGridStore::copy_to_device()
 /*!
  * Get host data.
  */
-auto ValueGridStore::host_pointers()  const -> ValueGridPointers
+auto ValueGridStore::host_pointers() const -> ValueGridPointers
 {
     return make_span(host_xsgrids_);
 }

--- a/src/physics/grid/ValueGridStore.cc
+++ b/src/physics/grid/ValueGridStore.cc
@@ -1,0 +1,82 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ValueGridStore.cc
+//---------------------------------------------------------------------------//
+#include "ValueGridStore.hh"
+
+#include "base/SpanRemapper.hh"
+#include "base/VectorUtils.hh"
+#include "comm/Device.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with storage space requirements.
+ *
+ * This allocates device data and resizes it to empty (so that the vector can
+ * keep track of its actual size).
+ */
+ValueGridStore::ValueGridStore(size_type num_grids, size_type num_values)
+{
+    CELER_EXPECT(num_grids > 0);
+    CELER_EXPECT(num_values > 0);
+    host_grids_.reserve(num_grids);
+    host_values_.reserve(num_values);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add a grid of host pointer data.
+ */
+void ValueGridStore::push_back(const XsGridPointers& inp)
+{
+    CELER_EXPECT(inp);
+    CELER_EXPECT(this->size() != this->capacity());
+    CELER_EXPECT(host_values_.size() + inp.value.size()
+                 <= host_values_.capacity());
+
+    host_grids_.push_back(inp);
+    host_grids_.back().value = celeritas::extend(inp.value, &host_values_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Copy all data to device.
+ */
+void ValueGridStore::copy_to_device()
+{
+    CELER_EXPECT(!host_grids_.empty());
+    CELER_EXPECT(celeritas::is_device_enabled());
+
+    device_grids_  = DeviceVector<XsGridPointers>(host_grids_.size());
+    device_values_ = DeviceVector<real_type>(host_values_.size());
+
+    device_grids_.copy_to_device(make_span(host_grids_));
+    device_values_.copy_to_device(make_span(host_values_));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get host data.
+ */
+auto ValueGridStore::host_pointers()  const -> ValueGridPointers
+{
+    return make_span(host_grids_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get device data.
+ */
+auto ValueGridStore::device_pointers() const -> ValueGridPointers
+{
+    CELER_EXPECT(!device_grids_.empty());
+    return device_grids_.device_pointers();
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/grid/ValueGridStore.hh
+++ b/src/physics/grid/ValueGridStore.hh
@@ -46,8 +46,11 @@ class ValueGridStore
     // Construct with storage space requirements
     ValueGridStore(size_type num_grids, size_type num_values);
 
-    // Add a grid of host pointer data, copying data to device.
+    // Add a grid of host pointer data
     void push_back(const XsGridPointers& host_pointers);
+
+    // Add a grid of generic data
+    void push_back(const GenericGridPointers& host_pointers);
 
     // Copy the data to device
     void copy_to_device();
@@ -55,10 +58,10 @@ class ValueGridStore
     //// HOST ACCESSORS ////
 
     //! Number of constructed grids
-    size_type size() { return host_grids_.size(); }
+    size_type size() { return host_xsgrids_.size() + host_grids_.size(); }
 
     //! Number of allocated grids
-    size_type capacity() { return host_grids_.capacity(); }
+    size_type capacity() { return capacity_; }
 
     //! Get host data
     ValueGridPointers host_pointers() const;
@@ -68,7 +71,9 @@ class ValueGridStore
     ValueGridPointers device_pointers() const;
 
   private:
-    std::vector<XsGridPointers> host_grids_;
+    size_type                        capacity_{};
+    std::vector<XsGridPointers>      host_xsgrids_;
+    std::vector<GenericGridPointers> host_grids_;
     std::vector<real_type>      host_values_;
 
     DeviceVector<XsGridPointers> device_grids_;

--- a/src/physics/grid/ValueGridStore.hh
+++ b/src/physics/grid/ValueGridStore.hh
@@ -1,0 +1,79 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ValueGridStore.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+#include "base/DeviceVector.hh"
+#include "base/Span.hh"
+#include "base/Types.hh"
+#include "XsGridInterface.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Manage data and help construction of physics value grids.
+ *
+ * Currently this only constructs a single value grid datatype, the
+ * XsGridPointers, but with this framework (virtual \c
+ * ValueGridXsBuilder::build method taking an instance of this class) it can be
+ * extended to build additional grid types as well.
+ *
+ * \code
+    ValueGridStore store(2, 100);
+    store.push_back(host_ptrs);
+    store.push_back(host_ptrs);
+    store.copy_to_device();
+   \endcode
+ */
+class ValueGridStore
+{
+  public:
+    //!@{
+    //! Type aliases
+    using ValueGridPointers = Span<const XsGridPointers>;
+    //!@}
+
+  public:
+    // Construct without any capacity
+    ValueGridStore() = default;
+
+    // Construct with storage space requirements
+    ValueGridStore(size_type num_grids, size_type num_values);
+
+    // Add a grid of host pointer data, copying data to device.
+    void push_back(const XsGridPointers& host_pointers);
+
+    // Copy the data to device
+    void copy_to_device();
+
+    //// HOST ACCESSORS ////
+
+    //! Number of constructed grids
+    size_type size() { return host_grids_.size(); }
+
+    //! Number of allocated grids
+    size_type capacity() { return host_grids_.capacity(); }
+
+    //! Get host data
+    ValueGridPointers host_pointers() const;
+
+    //// DEVICE ACCESSORS ////
+
+    ValueGridPointers device_pointers() const;
+
+  private:
+    std::vector<XsGridPointers> host_grids_;
+    std::vector<real_type>      host_values_;
+
+    DeviceVector<XsGridPointers> device_grids_;
+    DeviceVector<real_type>      device_values_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/grid/ValueGridStore.hh
+++ b/src/physics/grid/ValueGridStore.hh
@@ -74,7 +74,7 @@ class ValueGridStore
     size_type                        capacity_{};
     std::vector<XsGridPointers>      host_xsgrids_;
     std::vector<GenericGridPointers> host_grids_;
-    std::vector<real_type>      host_values_;
+    std::vector<real_type>           host_values_;
 
     DeviceVector<XsGridPointers> device_grids_;
     DeviceVector<real_type>      device_values_;

--- a/src/physics/grid/XsGridInterface.hh
+++ b/src/physics/grid/XsGridInterface.hh
@@ -21,10 +21,8 @@ namespace celeritas
  * For all  \code i >= prime_index \endcode, the \code value[i] \endcode is
  * expected to be pre-scaled by a factor of \code energy[i] \endcode.
  *
- * \todo Later we will support multiple parameterizations of the x grid, and
- * possibly different interpolations on x and y. Currently interpolation is
- * linear-linear after transforming to log-E space and before scaling the value
- * by E (if the grid point is above prime_index).
+ * Interpolation is linear-linear after transforming to log-E space and before
+ * scaling the value by E (if the grid point is above prime_index).
  */
 struct XsGridPointers
 {

--- a/src/physics/grid/XsGridInterface.hh
+++ b/src/physics/grid/XsGridInterface.hh
@@ -38,7 +38,7 @@ struct XsGridPointers
     //! Whether the interface is initialized and valid
     explicit CELER_FUNCTION operator bool() const
     {
-        return log_energy && !value.empty()
+        return log_energy && (value.size() >= 2)
                && (prime_index < log_energy.size
                    || prime_index == size_type(-1))
                && log_energy.size == value.size();

--- a/src/physics/grid/XsGridInterface.hh
+++ b/src/physics/grid/XsGridInterface.hh
@@ -44,4 +44,22 @@ struct XsGridPointers
 };
 
 //---------------------------------------------------------------------------//
+/*!
+ * A generic grid of 1D data with arbitrary interpolation.
+ */
+struct GenericGridPointers
+{
+    Span<const real_type> grid;         //!< X coordinate
+    Span<const real_type> value;        //!< Y coordinate
+    Interp                grid_interp;  //!< Interpolation along X axis
+    Interp                value_interp; //!< Interpolation along Y axis
+
+    //! Whether the interface is initialized and valid
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return (value.size() >= 2) && grid.size() == value.size();
+    }
+};
+
+//---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,7 @@ celeritas_add_test(base/Span.test.cc)
 celeritas_add_test(base/SpanRemapper.test.cc)
 celeritas_add_test(base/Stopwatch.test.cc)
 celeritas_add_test(base/TypeDemangler.test.cc)
+celeritas_add_test(base/VectorUtils.test.cc)
 
 if(CELERITAS_USE_CUDA)
   celeritas_add_test(base/NumericLimits.test.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -175,6 +175,7 @@ celeritas_add_test(physics/base/Physics.test.cc ${_not_impl})
 celeritas_setup_tests(SERIAL PREFIX physics/grid)
 celeritas_add_test(physics/grid/PhysicsGridCalculator.test.cc)
 celeritas_add_test(physics/grid/UniformGrid.test.cc)
+celeritas_add_test(physics/grid/ValueGridBuilder.test.cc)
 celeritas_add_test(physics/grid/ValueGridStore.test.cc)
 
 celeritas_setup_tests(SERIAL PREFIX physics/material)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -175,6 +175,7 @@ celeritas_add_test(physics/base/Physics.test.cc ${_not_impl})
 celeritas_setup_tests(SERIAL PREFIX physics/grid)
 celeritas_add_test(physics/grid/PhysicsGridCalculator.test.cc)
 celeritas_add_test(physics/grid/UniformGrid.test.cc)
+celeritas_add_test(physics/grid/ValueGridStore.test.cc)
 
 celeritas_setup_tests(SERIAL PREFIX physics/material)
 celeritas_add_test(physics/material/ElementSelector.test.cc)

--- a/test/base/VectorUtils.test.cc
+++ b/test/base/VectorUtils.test.cc
@@ -1,0 +1,114 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file VectorUtils.test.cc
+//---------------------------------------------------------------------------//
+#include "base/VectorUtils.hh"
+
+#include "celeritas_test.hh"
+
+//---------------------------------------------------------------------------//
+// HELPER CLASSES
+//---------------------------------------------------------------------------//
+
+struct Moveable
+{
+    int  value;
+    int* counter;
+
+    Moveable(int v, int* c) : value(v), counter(c) { CELER_EXPECT(counter); }
+
+    Moveable(Moveable&& rhs) noexcept : value(rhs.value), counter(rhs.counter)
+    {
+        ++(*counter);
+    }
+
+    Moveable& operator=(Moveable&& rhs) noexcept
+    {
+        value   = rhs.value;
+        counter = rhs.counter;
+        ++(*counter);
+        return *this;
+    }
+
+    // Delete copy and copy assign
+    Moveable(const Moveable& rhs) = delete;
+    Moveable& operator=(const Moveable& rhs) = delete;
+};
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class VectorUtilsTest : public celeritas::Test
+{
+  protected:
+    void SetUp() override {}
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(VectorUtilsTest, extend)
+{
+    std::vector<int> dst;
+    dst.reserve(4);
+    {
+        // Span of same type
+        const int src[] = {3};
+        auto inserted   = celeritas::extend(celeritas::make_span(src), &dst);
+        EXPECT_EQ(1, inserted.size());
+        EXPECT_EQ(dst.data(), inserted.data());
+    }
+    {
+        // Span with type conversion
+        const unsigned long src[] = {2};
+        auto inserted = celeritas::extend(celeritas::make_span(src), &dst);
+        EXPECT_EQ(1, inserted.size());
+        EXPECT_EQ(dst.data() + 1, inserted.data());
+    }
+    {
+        // Vector of same type
+        auto inserted = celeritas::extend(std::vector<int>({1, 0}), &dst);
+        EXPECT_EQ(2, inserted.size());
+        EXPECT_EQ(dst.data() + 2, inserted.data());
+    }
+
+    const int expected_dst[] = {3, 2, 1, 0};
+    EXPECT_VEC_EQ(expected_dst, dst);
+}
+
+TEST_F(VectorUtilsTest, move_extend)
+{
+    using VecMov = std::vector<Moveable>;
+    VecMov dst;
+    int    ctr = 0;
+
+    VecMov src;
+    src.emplace_back(1, &ctr);
+    src.emplace_back(2, &ctr);
+    ctr = 0;
+
+    // NOTE: the move_extend function intentionally will not compile without
+    // the std::move -- the caller needs to pass an rvalue.
+    celeritas::move_extend(std::move(src), &dst);
+    EXPECT_EQ(2, ctr);
+    EXPECT_EQ(0, src.size());
+    ASSERT_EQ(2, dst.size());
+    EXPECT_EQ(1, dst[0].value);
+    EXPECT_EQ(2, dst[1].value);
+}
+
+TEST_F(VectorUtilsTest, TEST_IF_CELERITAS_DEBUG(error_checking))
+{
+    std::vector<int> dst;
+    dst.reserve(3);
+    EXPECT_THROW(celeritas::extend(std::vector<int>(4), &dst),
+                 celeritas::DebugError);
+    EXPECT_NO_THROW(celeritas::extend(std::vector<int>(3), &dst));
+    EXPECT_THROW(celeritas::extend(std::vector<int>(1), &dst),
+                 celeritas::DebugError);
+}

--- a/test/physics/grid/ValueGridBuilder.test.cc
+++ b/test/physics/grid/ValueGridBuilder.test.cc
@@ -1,0 +1,128 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ValueGridBuilder.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/grid/ValueGridBuilder.hh"
+
+#include <memory>
+#include <vector>
+#include "physics/grid/PhysicsGridCalculator.hh"
+#include "physics/grid/ValueGridStore.hh"
+#include "celeritas_test.hh"
+
+using namespace celeritas;
+using std::make_shared;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class ValueGridBuilderTest : public celeritas::Test
+{
+  public:
+    using SPConstBuilder = std::shared_ptr<const ValueGridBuilder>;
+    using VecBuilder     = std::vector<SPConstBuilder>;
+    using Energy         = PhysicsGridCalculator ::Energy;
+
+  protected:
+    ValueGridStore build(const VecBuilder& entries) const
+    {
+        CELER_EXPECT(!entries.empty());
+
+        // Construct sizes
+        size_type num_values = 0;
+        for (const SPConstBuilder& b : entries)
+        {
+            CELER_EXPECT(b);
+            auto required_storage = b->storage();
+            EXPECT_GT(required_storage.second, 0);
+            num_values += required_storage.second;
+        }
+
+        // Build store
+        ValueGridStore store(entries.size(), num_values);
+        for (const SPConstBuilder& b : entries)
+        {
+            b->build(&store);
+        }
+
+        CELER_ENSURE(store.size() == store.capacity());
+        return store;
+    }
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(ValueGridBuilderTest, xs_grid)
+{
+    using Builder_t = ValueGridXsBuilder;
+    using VecReal   = std::vector<real_type>;
+
+    VecBuilder entries;
+
+    {
+        entries.push_back(make_shared<Builder_t>(
+            1e1, 1e2, 1e3, VecReal{.1, .2 * 1e2, .3 * 1e3}));
+    }
+    {
+        const real_type lambda_energy[]      = {1e-3, 1e-2, 1e-1};
+        const real_type lambda[]             = {10, 1, .1};
+        const real_type lambda_prim_energy[] = {1e-1, 1e0, 10};
+        const real_type lambda_prim[]        = {.1 * 1e-1, .01 * 1, .001 * 10};
+
+        entries.push_back(make_shared<Builder_t>(Builder_t::from_geant(
+            lambda_energy, lambda, lambda_prim_energy, lambda_prim)));
+    }
+
+    // Build
+    ValueGridStore store = this->build(entries);
+    auto           ptrs  = store.host_pointers();
+
+    // Test results using the physics calculator
+    ASSERT_EQ(2, ptrs.size());
+    {
+        PhysicsGridCalculator calc_xs(ptrs[0]);
+        EXPECT_SOFT_EQ(0.1, calc_xs(Energy{1e1}));
+        EXPECT_SOFT_EQ(0.2, calc_xs(Energy{1e2}));
+        EXPECT_SOFT_EQ(0.3, calc_xs(Energy{1e3}));
+    }
+    {
+        PhysicsGridCalculator calc_xs(ptrs[1]);
+        EXPECT_SOFT_EQ(10., calc_xs(Energy{1e-3}));
+        EXPECT_SOFT_EQ(1., calc_xs(Energy{1e-2}));
+        EXPECT_SOFT_EQ(0.1, calc_xs(Energy{1e-1}));
+        EXPECT_SOFT_EQ(0.01, calc_xs(Energy{1e0}));
+        EXPECT_SOFT_EQ(0.001, calc_xs(Energy{1e1}));
+    }
+}
+
+TEST_F(ValueGridBuilderTest, log_grid)
+{
+    using Builder_t = ValueGridLogBuilder;
+    using VecReal   = std::vector<real_type>;
+
+    VecBuilder entries;
+
+    {
+        entries.push_back(
+            make_shared<Builder_t>(1e1, 1e3, VecReal{.1, .2, .3}));
+    }
+
+    // Build
+    ValueGridStore store = this->build(entries);
+    auto           ptrs  = store.host_pointers();
+
+    // Test results using the physics calculator
+    ASSERT_EQ(1, ptrs.size());
+    {
+        PhysicsGridCalculator calc_xs(ptrs[0]);
+        EXPECT_SOFT_EQ(0.1, calc_xs(Energy{1e1}));
+        EXPECT_SOFT_EQ(0.2, calc_xs(Energy{1e2}));
+        EXPECT_SOFT_EQ(0.3, calc_xs(Energy{1e3}));
+    }
+}

--- a/test/physics/grid/ValueGridStore.test.cc
+++ b/test/physics/grid/ValueGridStore.test.cc
@@ -1,0 +1,82 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ValueGridStore.test.cc
+//---------------------------------------------------------------------------//
+#include "physics/grid/ValueGridStore.hh"
+
+#include <algorithm>
+#include "celeritas_test.hh"
+#include "base/Range.hh"
+
+using celeritas::ValueGridStore;
+using celeritas::real_type;
+using celeritas::size_type;
+using celeritas::XsGridPointers;
+using celeritas::UniformGridPointers;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class ValueGridStoreTest : public celeritas::Test
+{
+  protected:
+    XsGridPointers make_xsgrid(size_type count)
+    {
+        CELER_EXPECT(count > 0);
+        XsGridPointers result;
+        result.log_energy = UniformGridPointers::from_bounds(0.0, 1.0, count);
+        result.prime_index = count / 2;
+        temp_real.resize(count);
+        for (auto i : celeritas::range(temp_real.size()))
+        {
+            temp_real[i] = i + 1;
+        }
+        result.value = celeritas::make_span(temp_real);
+
+        CELER_ENSURE(result);
+        return result;
+    }
+
+    std::vector<real_type> temp_real;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(ValueGridStoreTest, all)
+{
+    ValueGridStore vgs;
+    EXPECT_EQ(0, vgs.size());
+    EXPECT_EQ(0, vgs.capacity());
+
+    // Allocate for two grids, one with three values and one with four
+    vgs = ValueGridStore(2, 3 + 4);
+    EXPECT_EQ(0, vgs.size());
+    EXPECT_EQ(2, vgs.capacity());
+
+    vgs.push_back(make_xsgrid(3));
+    vgs.push_back(make_xsgrid(4));
+    EXPECT_EQ(2, vgs.size());
+
+    auto ptrs = vgs.host_pointers();
+    ASSERT_EQ(2, ptrs.size());
+
+    {
+        const XsGridPointers& xs = ptrs[0];
+        EXPECT_TRUE(bool(xs));
+        const real_type expected[] = {1, 2, 3};
+        EXPECT_VEC_EQ(expected, xs.value);
+    }
+
+    {
+        const XsGridPointers& xs = ptrs[1];
+        EXPECT_TRUE(bool(xs));
+        const real_type expected[] = {1, 2, 3, 4};
+        EXPECT_VEC_EQ(expected, xs.value);
+    }
+}


### PR DESCRIPTION
Add support code to construct lots of cross section grids. I implemented the grid construction needed for cross section, slowing down, and range tables; but not the generic ones by the livermore cross section lookups.