### PR TITLE
Add expectations for pass-by-pointer mutable references

### DIFF
--- a/src/base/ArrayUtils.i.hh
+++ b/src/base/ArrayUtils.i.hh
@@ -19,6 +19,7 @@ namespace celeritas
 template<class T, std::size_t N>
 CELER_FUNCTION void axpy(T a, const Array<T, N>& x, Array<T, N>* y)
 {
+    CELER_EXPECT(y);
     for (std::size_t i = 0; i != N; ++i)
     {
         (*y)[i] = a * x[i] + (*y)[i];
@@ -69,6 +70,7 @@ CELER_FUNCTION T norm(const Array<T, N>& v)
  */
 CELER_FUNCTION void normalize_direction(Real3* direction)
 {
+    CELER_EXPECT(direction);
     const real_type scale_factor = 1 / norm(*direction);
     (*direction)[0] *= scale_factor;
     (*direction)[1] *= scale_factor;

--- a/src/base/Atomics.hh
+++ b/src/base/Atomics.hh
@@ -40,6 +40,7 @@ CELER_FORCEINLINE_FUNCTION T atomic_add(T* address, T value)
  */
 inline __device__ double atomic_add(double* address, double val)
 {
+    CELER_EXPECT(address);
     ull_int* address_as_ull = reinterpret_cast<ull_int*>(address);
     ull_int  old            = *address_as_ull;
     ull_int  assumed;
@@ -102,6 +103,7 @@ CELER_FORCEINLINE_FUNCTION T atomic_max(T* address, T value)
  */
 inline __device__ ull_int atomic_max(ull_int* address, ull_int val)
 {
+    CELER_EXPECT(address);
     ull_int old = *address;
     ull_int assumed;
     do

--- a/src/base/Memory.cu
+++ b/src/base/Memory.cu
@@ -23,6 +23,7 @@ namespace celeritas
  */
 void device_memset(void* data, int fill_value, size_type count)
 {
+    CELER_EXPECT(data);
     CELER_EXPECT(fill_value >= 0
                  && fill_value <= std::numeric_limits<unsigned char>::max());
     auto* data_char = static_cast<unsigned char*>(data);

--- a/src/base/TypeDemangler.cc
+++ b/src/base/TypeDemangler.cc
@@ -28,7 +28,7 @@ std::string demangled_typeid_name(const char* typeid_name)
     std::string result(status == 0 ? demangled : typeid_name);
 
     // Free the returned memory
-    free(demangled);
+    std::free(demangled);
 #else // __GNUG__
     std::string result(typeid_name);
 #endif // __GNUG__

--- a/src/comm/detail/LoggerMessage.cc
+++ b/src/comm/detail/LoggerMessage.cc
@@ -17,6 +17,9 @@ namespace detail
 //---------------------------------------------------------------------------//
 /*!
  * Construct with reference to function object, etc.
+ *
+ * The handle *may be* null, indicating that the output of this message will
+ * not be displayed.
  */
 LoggerMessage::LoggerMessage(LogHandler* handle, Provenance prov, LogLevel lev)
     : handle_(handle), prov_(prov), lev_(lev)

--- a/src/physics/grid/ValueGridBuilder.cc
+++ b/src/physics/grid/ValueGridBuilder.cc
@@ -146,6 +146,7 @@ auto ValueGridXsBuilder::storage() const -> Storage
  */
 void ValueGridXsBuilder::build(ValueGridStore* store) const
 {
+    CELER_EXPECT(store);
     XsGridPointers ptrs;
     // Construct log(energy) grid
     ptrs.log_energy
@@ -249,10 +250,11 @@ auto ValueGridGenericBuilder::storage() const -> Storage
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct on device.
+ * Construct grid data in the given mutable store.
  */
 void ValueGridGenericBuilder::build(ValueGridStore* store) const
 {
+    CELER_EXPECT(store);
     GenericGridPointers ptrs;
 
     // Provide reference to values

--- a/src/physics/grid/ValueGridBuilder.hh
+++ b/src/physics/grid/ValueGridBuilder.hh
@@ -44,10 +44,14 @@ class ValueGridBuilder
     //!@}
 
   public:
+    //! Virtual destructor for polymorphic deletion
     virtual ~ValueGridBuilder() = 0;
 
-    virtual Storage storage() const              = 0;
-    virtual void    build(ValueGridStore*) const = 0;
+    //! Get the storage requirements of a grid to be bulit
+    virtual Storage storage() const = 0;
+
+    //! Construct the grid given a mutable reference to a store
+    virtual void build(ValueGridStore*) const = 0;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/grid/XsGridInterface.hh
+++ b/src/physics/grid/XsGridInterface.hh
@@ -49,10 +49,10 @@ struct XsGridPointers
  */
 struct GenericGridPointers
 {
-    Span<const real_type> grid;         //!< X coordinate
-    Span<const real_type> value;        //!< Y coordinate
-    Interp                grid_interp;  //!< Interpolation along X axis
-    Interp                value_interp; //!< Interpolation along Y axis
+    Span<const real_type> grid;         //!< x grid
+    Span<const real_type> value;        //!< f(x) value
+    Interp                grid_interp;  //!< Interpolation along x
+    Interp                value_interp; //!< Interpolation along f(x)
 
     //! Whether the interface is initialized and valid
     explicit CELER_FUNCTION operator bool() const


### PR DESCRIPTION
Add `CELER_EXPECT(ptr)` for the pass-by-reference cases.