### PR TITLE
Follow "pass-by-pointer" for mutable reference.

### DIFF
--- a/src/geometry/LinearPropagator.hh
+++ b/src/geometry/LinearPropagator.hh
@@ -22,7 +22,7 @@ class LinearPropagator
 
   public:
     // Construct from persistent and state data
-    inline CELER_FUNCTION LinearPropagator(GeoTrackView& track);
+    inline CELER_FUNCTION LinearPropagator(GeoTrackView* track);
 
     // Move track by next_step(), which takes it to next volume boundary.
     inline CELER_FUNCTION void operator()();

--- a/src/geometry/LinearPropagator.i.hh
+++ b/src/geometry/LinearPropagator.i.hh
@@ -18,9 +18,10 @@ namespace celeritas
 /*!
  * Construct from persistent and state data.
  */
-CELER_FUNCTION LinearPropagator::LinearPropagator(GeoTrackView& track)
-    : track_(track)
+CELER_FUNCTION LinearPropagator::LinearPropagator(GeoTrackView* track)
+    : track_(*track)
 {
+    CELER_EXPECT(track);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/TrackInitializerStore.hh
+++ b/src/sim/TrackInitializerStore.hh
@@ -45,10 +45,10 @@ class TrackInitializerStore
     void extend_from_primaries();
 
     // Create track initializers on device from secondary particles.
-    void extend_from_secondaries(StateStore& states, ParamStore& params);
+    void extend_from_secondaries(StateStore* states, ParamStore* params);
 
     // Initialize track states on device.
-    void initialize_tracks(StateStore& states, ParamStore& params);
+    void initialize_tracks(StateStore* states, ParamStore* params);
 
   private:
     // Track initializers created from primaries or secondaries

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -75,7 +75,7 @@ TEST_F(LinearPropagatorHostTest, accessors)
 TEST_F(LinearPropagatorHostTest, track_line)
 {
     GeoTrackView     geo(params_view, state_view, ThreadId(0));
-    LinearPropagator propagate(geo); // one propagator per track
+    LinearPropagator propagate(&geo); // one propagator per track
 
     {
         // Track from outside detector, moving right
@@ -140,7 +140,7 @@ TEST_F(LinearPropagatorHostTest, track_line)
 TEST_F(LinearPropagatorHostTest, track_intraVolume)
 {
     GeoTrackView     geo(params_view, state_view, ThreadId(0));
-    LinearPropagator propagate(geo); // one propagator per track
+    LinearPropagator propagate(&geo); // one propagator per track
 
     {
         // Track from outside detector, moving right

--- a/test/geometry/LinearPropagator.test.cu
+++ b/test/geometry/LinearPropagator.test.cu
@@ -46,7 +46,7 @@ __global__ void linProp_test_kernel(const GeoParamsPointers shared,
         geo.dir()[1],
         geo.dir()[2]);
 
-    LinearPropagator propagate(geo);
+    LinearPropagator propagate(&geo);
     for (int seg = 0; seg < max_segments; ++seg)
     {
         if (geo.is_outside())

--- a/test/sim/TrackInitializerStore.test.cc
+++ b/test/sim/TrackInitializerStore.test.cc
@@ -132,7 +132,7 @@ TEST_F(TrackInitTest, run)
     EXPECT_VEC_EQ(expected.initializer_id, output.initializer_id);
 
     // Initialize the primary tracks on device
-    track_init.initialize_tracks(states, params);
+    track_init.initialize_tracks(&states, &params);
 
     // Check the IDs of the initialized tracks
     output.track_id   = tracks_test(states.device_pointers());
@@ -151,7 +151,7 @@ TEST_F(TrackInitTest, run)
              input.device_pointers());
 
     // Launch a kernel to create track initializers from secondaries
-    track_init.extend_from_secondaries(states, params);
+    track_init.extend_from_secondaries(&states, &params);
 
     // Check the vacancies
     output.vacancy   = vacancies_test(track_init.device_pointers());
@@ -167,7 +167,7 @@ TEST_F(TrackInitTest, run)
     EXPECT_VEC_EQ(expected.initializer_id, output.initializer_id);
 
     // Initialize secondaries on device
-    track_init.initialize_tracks(states, params);
+    track_init.initialize_tracks(&states, &params);
 
     // Check the track IDs of the initialized tracks
     // Output is sorted as TrackInitializerStore does not calculate IDs
@@ -209,7 +209,7 @@ TEST_F(TrackInitTest, primaries)
             EXPECT_EQ(track_init.size(), j);
 
             // Initialize tracks on device
-            track_init.initialize_tracks(states, params);
+            track_init.initialize_tracks(&states, &params);
 
             // Launch kernel that will kill all trackss
             interact(states.device_pointers(),
@@ -217,7 +217,7 @@ TEST_F(TrackInitTest, primaries)
                      input.device_pointers());
 
             // Launch a kernel to create track initializers from secondaries
-            track_init.extend_from_secondaries(states, params);
+            track_init.extend_from_secondaries(&states, &params);
         }
     }
 
@@ -266,7 +266,7 @@ TEST_F(TrackInitTest, secondaries)
     while (track_init.size())
     {
         // Initialize the primary tracks on device
-        track_init.initialize_tracks(states, params);
+        track_init.initialize_tracks(&states, &params);
 
         // Launch kernel to process interactions
         interact(states.device_pointers(),
@@ -274,7 +274,7 @@ TEST_F(TrackInitTest, secondaries)
                  input.device_pointers());
 
         // Launch a kernel to create track initializers from secondaries
-        track_init.extend_from_secondaries(states, params);
+        track_init.extend_from_secondaries(&states, &params);
     }
 }
 


### PR DESCRIPTION
In addition we have 4 categories of exceptions:

* `to/from_json` where the signature is imposed by the `nlohmann` library
* `swap` to match the usual signature from the C++ standard.
* Passing random number generator and engine  to match the usual signature from the C++ standard?

and the potentially updatable:

* make_span ... maybe because taking the address of an array is not easy

```
app/demo-interactor/KNDemoIO.hh:void to_json(nlohmann::json& j, const CudaGridParams& value);
app/demo-interactor/KNDemoIO.hh:void from_json(const nlohmann::json& j, CudaGridParams& value);
app/demo-interactor/KNDemoIO.hh:void to_json(nlohmann::json& j, const KNDemoRunArgs& value);
app/demo-interactor/KNDemoIO.hh:void from_json(const nlohmann::json& j, KNDemoRunArgs& value);
app/demo-interactor/KNDemoIO.hh:void to_json(nlohmann::json& j, const KNDemoResult& value);
app/demo-interactor/KNDemoIO.hh:void from_json(const nlohmann::json& j, KNDemoResult& value);
app/demo-interactor/KNDemoIO.hh:void to_json(nlohmann::json& j, const UniformGridPointers& value);
app/demo-interactor/KNDemoIO.hh:void from_json(const nlohmann::json& j, UniformGridPointers& value);
app/demo-rasterizer/ImageIO.hh:void to_json(nlohmann::json& j, const ImageRunArgs& value);
app/demo-rasterizer/ImageIO.hh:void from_json(const nlohmann::json& j, ImageRunArgs& value);
app/demo-rasterizer/ImageIO.hh:void to_json(nlohmann::json& j, const ImageStore& value);
app/demo-rasterizer/ImageIO.hh:void from_json(const nlohmann::json& j, Array<T, N>& value)
app/demo-rasterizer/ImageIO.hh:void to_json(nlohmann::json& j, const Array<T, N>& value)
```

```
src/base/DeviceVector.hh:    inline void swap(DeviceVector& other) noexcept;
src/base/DeviceVector.hh:inline void swap(DeviceVector<T>&, DeviceVector<T>&) noexcept;
src/base/Quantity.hh:swap(Quantity<U, V>& a, Quantity<U, V>& b) noexcept
src/base/DeviceAllocation.hh:    inline void swap(DeviceAllocation& other) noexcept;
src/base/DeviceAllocation.hh:inline void swap(DeviceAllocation& a, DeviceAllocation& b) noexcept;
```

```
src/random/distributions/RadialDistribution.hh:    inline CELER_FUNCTION result_type operator()(Generator& rng);
src/random/distributions/IsotropicDistribution.hh:    inline CELER_FUNCTION result_type operator()(Generator& rng);
src/random/distributions/ExponentialDistribution.hh:    inline CELER_FUNCTION result_type operator()(Generator& g);
src/random/distributions/GenerateCanonical.hh:inline CELER_FUNCTION RealType generate_canonical(Generator& g);
src/random/distributions/GenerateCanonical.hh:inline CELER_FUNCTION real_type generate_canonical(Generator& g);
src/random/distributions/GenerateCanonical.hh:    result_type operator()(Generator& rng);
src/random/distributions/UniformRealDistribution.hh:    inline CELER_FUNCTION result_type operator()(Generator& rng);
src/random/distributions/BernoulliDistribution.hh:    inline CELER_FUNCTION result_type operator()(Generator& rng);
```

```
src/random/cuda/RngEngine.hh:    inline CELER_FUNCTION result_type operator()(RngEngine& rng);
src/random/cuda/RngEngine.hh:    inline CELER_FUNCTION result_type operator()(RngEngine& rng);
src/physics/material/ElementSelector.hh:    inline CELER_FUNCTION ElementComponentId operator()(Engine& rng) const;
src/physics/em/RayleighInteractor.hh:    inline CELER_FUNCTION Interaction operator()(Engine& rng);
src/physics/em/WentzelInteractor.hh:    inline CELER_FUNCTION Interaction operator()(Engine& rng);
src/physics/em/BetheBlochInteractor.hh:    inline CELER_FUNCTION Interaction operator()(Engine& rng);
src/physics/em/detail/EPlusGGInteractor.hh:    inline CELER_FUNCTION Interaction operator()(Engine& rng);
src/physics/em/MollerBhabhaInteractor.hh:    inline CELER_FUNCTION Interaction operator()(Engine& rng);
src/physics/em/UrbanInteractor.hh:    inline CELER_FUNCTION Interaction operator()(Engine& rng);
src/physics/em/detail/LivermorePEInteractor.hh:    inline CELER_FUNCTION Interaction operator()(Engine& rng);
src/physics/em/detail/LivermorePEInteractor.hh:    inline CELER_FUNCTION Real3 sample_direction(Engine& rng) const;
src/physics/em/detail/KleinNishinaInteractor.hh:    inline CELER_FUNCTION Interaction operator()(Engine& rng);
src/physics/em/detail/BetheHeitlerInteractor.hh:    inline CELER_FUNCTION Interaction operator()(Engine& rng);
src/physics/em/BremRelInteractor.hh:    inline CELER_FUNCTION Interaction operator()(Engine& rng);
src/base/StackAllocatorView.hh:    Interaction operator()(Engine&)
```

```
src/base/Span.hh:CELER_CONSTEXPR_FUNCTION Span<T, N> make_span(Array<T, N>& x)
src/base/Span.hh:CELER_FUNCTION Span<typename T::value_type> make_span(T& cont)
src/base/detail/SpanImpl.hh:    SpanImpl(const SpanImpl<T, dynamic_extent>& other) : data(other.data)
```
