### PR TITLE
Apply clang-format

### DIFF
--- a/app/demo-interactor/HostKNDemoRunner.cc
+++ b/app/demo-interactor/HostKNDemoRunner.cc
@@ -75,8 +75,8 @@ auto HostKNDemoRunner::operator()(demo_interactor::KNDemoRunArgs args)
     auto pp_host_ptrs = pparams_->host_pointers();
 
     // Physics calculator
-    auto                   xs_host_ptrs = xsparams_->host_pointers();
-    PhysicsGridCalculator  calc_xs(xs_host_ptrs);
+    auto                  xs_host_ptrs = xsparams_->host_pointers();
+    PhysicsGridCalculator calc_xs(xs_host_ptrs);
 
     // Make secondary store
     HostStackAllocatorStore<Secondary> secondaries(args.max_steps);

--- a/app/demo-interactor/HostKNDemoRunner.hh
+++ b/app/demo-interactor/HostKNDemoRunner.hh
@@ -53,9 +53,9 @@ class HostKNDemoRunner
     result_type operator()(demo_interactor::KNDemoRunArgs args);
 
   private:
-    constSPParticleParams                     pparams_;
-    constSPXsGridParams                       xsparams_;
-    celeritas::detail::KleinNishinaPointers   kn_pointers_;
+    constSPParticleParams                   pparams_;
+    constSPXsGridParams                     xsparams_;
+    celeritas::detail::KleinNishinaPointers kn_pointers_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/demo-interactor/HostStackAllocatorStore.hh
+++ b/app/demo-interactor/HostStackAllocatorStore.hh
@@ -23,9 +23,9 @@ class HostStackAllocatorStore
   public:
     //!@{
     //! Type aliases
-    using value_type      = T;
-    using Pointers        = StackAllocatorPointers<T>;
-    using size_type       = typename Pointers::size_type;
+    using value_type = T;
+    using Pointers   = StackAllocatorPointers<T>;
+    using size_type  = typename Pointers::size_type;
     //!@}
 
   public:

--- a/app/demo-interactor/KNDemoRunner.hh
+++ b/app/demo-interactor/KNDemoRunner.hh
@@ -46,10 +46,10 @@ class KNDemoRunner
     result_type operator()(KNDemoRunArgs args);
 
   private:
-    constSPParticleParams                     pparams_;
-    constSPXsGridParams                       xsparams_;
-    CudaGridParams                            launch_params_;
-    celeritas::detail::KleinNishinaPointers   kn_pointers_;
+    constSPParticleParams                   pparams_;
+    constSPXsGridParams                     xsparams_;
+    CudaGridParams                          launch_params_;
+    celeritas::detail::KleinNishinaPointers kn_pointers_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/geant-exporter/DetectorConstruction.hh
+++ b/app/geant-exporter/DetectorConstruction.hh
@@ -22,7 +22,7 @@ class DetectorConstruction : public G4VUserDetectorConstruction
     explicit DetectorConstruction(G4String gdmlInput);
     ~DetectorConstruction();
 
-    G4VPhysicalVolume* Construct() override;
+    G4VPhysicalVolume*       Construct() override;
     const G4VPhysicalVolume* get_world_volume() const;
 
   private:

--- a/app/geant-exporter/geant-exporter.cc
+++ b/app/geant-exporter/geant-exporter.cc
@@ -354,7 +354,7 @@ int main(int argc, char* argv[])
     // Constructing the run manager resets the global log/exception handlers,
     // so it must be done first. The stupid version banner cannot be
     // suppressed.
-    G4RunManager run_manager;
+    G4RunManager          run_manager;
     GeantLoggerAdapter    scoped_logger;
     GeantExceptionHandler scoped_exception_handler;
 

--- a/scripts/dev/celeritas-gen.py
+++ b/scripts/dev/celeritas-gen.py
@@ -254,6 +254,17 @@ PYTHON_FILE = '''\
 
 '''
 
+SHELL_TOP = '''\
+#!/bin/sh -ex
+# Copyright {year} UT-Battelle, LLC and other Celeritas Developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+'''
+
+SHELL_FILE = '''\
+
+'''
+
 YEAR = datetime.today().year
 
 TEMPLATES = {
@@ -272,6 +283,7 @@ TEMPLATES = {
     'cmake': CMAKE_FILE,
     'CMakeLists.txt': CMAKELISTS_FILE,
     'py': PYTHON_FILE,
+    'sh': SHELL_FILE,
 }
 
 LANG = {
@@ -284,6 +296,7 @@ LANG = {
     'i': "SWIG",
     'CMakeLists.txt': "CMake",
     'py': "Python",
+    'sh': "Shell",
 }
 
 TOPS = {
@@ -292,6 +305,7 @@ TOPS = {
     'SWIG': CLIKE_TOP,
     'CMake': CMAKE_TOP,
     'Python': PYTHON_TOP,
+    'Shell': SHELL_TOP,
 }
 
 HEXT = {

--- a/scripts/dev/clang-reformat-everything.sh
+++ b/scripts/dev/clang-reformat-everything.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -ex
+# Copyright 2021 UT-Battelle, LLC and other Celeritas Developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+GIT_WORK_TREE="$(git rev-parse --show-toplevel)"
+find $GIT_WORK_TREE \( -name '*.hh' -or -name '*.cc' -or -name '*.cu' \) \
+  -exec clang-format -i {} +

--- a/src/base/DeviceAllocation.hh
+++ b/src/base/DeviceAllocation.hh
@@ -74,7 +74,7 @@ class DeviceAllocation
     //// DATA ////
 
     detail::InitializedValue<size_type> size_;
-    DeviceUniquePtr data_;
+    DeviceUniquePtr                     data_;
 };
 
 // Swap two allocations

--- a/src/base/DeviceVector.hh
+++ b/src/base/DeviceVector.hh
@@ -89,7 +89,7 @@ class DeviceVector
     inline constSpan_t device_pointers() const;
 
   private:
-    DeviceAllocation allocation_;
+    DeviceAllocation                    allocation_;
     detail::InitializedValue<size_type> size_;
     detail::InitializedValue<size_type> capacity_;
 };

--- a/src/base/StackAllocatorView.hh
+++ b/src/base/StackAllocatorView.hh
@@ -65,10 +65,10 @@ class StackAllocatorView
   public:
     //!@{
     //! Type aliases
-    using value_type      = T;
-    using size_type       = ull_int;
-    using result_type     = value_type*;
-    using Pointers        = StackAllocatorPointers<T>;
+    using value_type  = T;
+    using size_type   = ull_int;
+    using result_type = value_type*;
+    using Pointers    = StackAllocatorPointers<T>;
     //!@}
 
   public:

--- a/src/geometry/GeoTrackView.hh
+++ b/src/geometry/GeoTrackView.hh
@@ -104,7 +104,7 @@ class GeoTrackView
   private:
     //! Get a reference to the state from a NavStatePool's pointer
     static inline CELER_FUNCTION NavState&
-                                 get_nav_state(void* state, int vgmaxdepth, ThreadId thread);
+    get_nav_state(void* state, int vgmaxdepth, ThreadId thread);
 
     //! Get a reference to the current volume
     inline CELER_FUNCTION const Volume& volume() const;

--- a/src/geometry/detail/VGNavStateStore.hh
+++ b/src/geometry/detail/VGNavStateStore.hh
@@ -71,7 +71,6 @@ class VGNavStateStore
     void* device_pointers() const;
 
   private:
-
     struct NavStatePoolDeleter
     {
         void operator()(NavStatePool*) const;

--- a/src/io/EventReader.cc
+++ b/src/io/EventReader.cc
@@ -62,8 +62,8 @@ EventReader::result_type EventReader::operator()()
         {
             // Get the PDG code and check if this particle type is defined for
             // the current physics
-            PDGNumber     pdg{gen_particle->pid()};
-            ParticleId    particle_id{params_->find(pdg)};
+            PDGNumber  pdg{gen_particle->pid()};
+            ParticleId particle_id{params_->find(pdg)};
             CELER_ASSERT(particle_id);
 
             Primary primary;

--- a/src/io/EventReader.hh
+++ b/src/io/EventReader.hh
@@ -29,8 +29,8 @@ class EventReader
   public:
     //!@{
     //! Type aliases
-    using SPConstParticles      = std::shared_ptr<const ParticleParams>;
-    using result_type           = std::vector<Primary>;
+    using SPConstParticles = std::shared_ptr<const ParticleParams>;
+    using result_type      = std::vector<Primary>;
     //!@}
 
   public:

--- a/src/io/RootImporter.hh
+++ b/src/io/RootImporter.hh
@@ -87,7 +87,6 @@ class RootImporter
     std::shared_ptr<GdmlGeometryMap> load_geometry_data();
     // Populate the shared_ptr<MaterialParams> with material information
     std::shared_ptr<MaterialParams> load_material_data();
-
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/Interaction.hh
+++ b/src/physics/base/Interaction.hh
@@ -21,10 +21,10 @@ namespace celeritas
  */
 struct Interaction
 {
-    Action           action;      //!< Failure, scatter, absorption, ...
-    units::MevEnergy energy;      //!< Post-interaction energy
-    Real3            direction;   //!< Post-interaction direction
-    Span<Secondary>  secondaries; //!< Emitted secondaries
+    Action           action;            //!< Failure, scatter, absorption, ...
+    units::MevEnergy energy;            //!< Post-interaction energy
+    Real3            direction;         //!< Post-interaction direction
+    Span<Secondary>  secondaries;       //!< Emitted secondaries
     units::MevEnergy energy_deposition; //!< Energy loss locally to material
 
     // Return an interaction representing a recoverable error

--- a/src/physics/base/ParticleParams.cc
+++ b/src/physics/base/ParticleParams.cc
@@ -29,8 +29,8 @@ ParticleParams::ParticleParams(const Input& defs)
         CELER_EXPECT(particle.decay_constant >= 0);
 
         // Add host metadata
-        ParticleId    id(name_to_id_.size());
-        bool          inserted;
+        ParticleId id(name_to_id_.size());
+        bool       inserted;
         std::tie(std::ignore, inserted)
             = name_to_id_.insert({particle.name, id});
         CELER_ASSERT(inserted);

--- a/src/physics/em/BetheBlochInteractor.i.hh
+++ b/src/physics/em/BetheBlochInteractor.i.hh
@@ -55,8 +55,8 @@ CELER_FUNCTION Interaction BetheBlochInteractor::operator()(Engine& rng)
 
     // Save outgoing secondary data
     secondaries[0].particle_id = shared_.electron_id; // XXX
-    secondaries[0].energy    = units::MevEnergy{0}; // XXX
-    secondaries[0].direction = {0, 0, 0};           // XXX
+    secondaries[0].energy      = units::MevEnergy{0}; // XXX
+    secondaries[0].direction   = {0, 0, 0};           // XXX
 
     return result;
 }

--- a/src/physics/em/BremRelInteractor.i.hh
+++ b/src/physics/em/BremRelInteractor.i.hh
@@ -57,8 +57,8 @@ CELER_FUNCTION Interaction BremRelInteractor::operator()(Engine& rng)
 
     // Save outgoing secondary data
     secondaries[0].particle_id = shared_.electron_id; // XXX
-    secondaries[0].energy    = units::MevEnergy{0}; // XXX
-    secondaries[0].direction = {0, 0, 0};           // XXX
+    secondaries[0].energy      = units::MevEnergy{0}; // XXX
+    secondaries[0].direction   = {0, 0, 0};           // XXX
 
     return result;
 }

--- a/src/physics/em/MollerBhabhaInteractor.i.hh
+++ b/src/physics/em/MollerBhabhaInteractor.i.hh
@@ -55,8 +55,8 @@ CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
 
     // Save outgoing secondary data
     secondaries[0].particle_id = shared_.electron_id; // XXX
-    secondaries[0].energy    = units::MevEnergy{0}; // XXX
-    secondaries[0].direction = {0, 0, 0};           // XXX
+    secondaries[0].energy      = units::MevEnergy{0}; // XXX
+    secondaries[0].direction   = {0, 0, 0};           // XXX
 
     return result;
 }

--- a/src/physics/em/RayleighInteractor.i.hh
+++ b/src/physics/em/RayleighInteractor.i.hh
@@ -55,8 +55,8 @@ CELER_FUNCTION Interaction RayleighInteractor::operator()(Engine& rng)
 
     // Save outgoing secondary data
     secondaries[0].particle_id = shared_.electron_id; // XXX
-    secondaries[0].energy    = units::MevEnergy{0}; // XXX
-    secondaries[0].direction = {0, 0, 0};           // XXX
+    secondaries[0].energy      = units::MevEnergy{0}; // XXX
+    secondaries[0].direction   = {0, 0, 0};           // XXX
 
     return result;
 }

--- a/src/physics/em/UrbanInteractor.i.hh
+++ b/src/physics/em/UrbanInteractor.i.hh
@@ -55,8 +55,8 @@ CELER_FUNCTION Interaction UrbanInteractor::operator()(Engine& rng)
 
     // Save outgoing secondary data
     secondaries[0].particle_id = shared_.electron_id; // XXX
-    secondaries[0].energy    = units::MevEnergy{0}; // XXX
-    secondaries[0].direction = {0, 0, 0};           // XXX
+    secondaries[0].energy      = units::MevEnergy{0}; // XXX
+    secondaries[0].direction   = {0, 0, 0};           // XXX
 
     return result;
 }

--- a/src/physics/em/WentzelInteractor.i.hh
+++ b/src/physics/em/WentzelInteractor.i.hh
@@ -55,8 +55,8 @@ CELER_FUNCTION Interaction WentzelInteractor::operator()(Engine& rng)
 
     // Save outgoing secondary data
     secondaries[0].particle_id = shared_.electron_id; // XXX
-    secondaries[0].energy    = units::MevEnergy{0}; // XXX
-    secondaries[0].direction = {0, 0, 0};           // XXX
+    secondaries[0].energy      = units::MevEnergy{0}; // XXX
+    secondaries[0].direction   = {0, 0, 0};           // XXX
 
     return result;
 }

--- a/src/physics/em/detail/LivermorePE.cu
+++ b/src/physics/em/detail/LivermorePE.cu
@@ -54,8 +54,8 @@ __global__ void livermore_pe_interact_kernel(const LivermorePEPointers   pe,
 
     // Sample an element
     ElementSelector    select_el(material.material_view(),
-                                 LivermorePEMicroXsCalculator{pe, particle},
-                                 material.element_scratch());
+                              LivermorePEMicroXsCalculator{pe, particle},
+                              material.element_scratch());
     ElementComponentId comp_id = select_el(rng);
     ElementId          el_id   = material.material_view().element_id(comp_id);
 

--- a/src/physics/em/detail/LivermorePEInteractor.i.hh
+++ b/src/physics/em/detail/LivermorePEInteractor.i.hh
@@ -109,7 +109,7 @@ CELER_FUNCTION Interaction LivermorePEInteractor::operator()(Engine& rng)
     }
 
     // Outgoing secondary is an electron
-    result.secondaries    = {photoelectron, 1};
+    result.secondaries         = {photoelectron, 1};
     photoelectron->particle_id = shared_.electron_id;
 
     // Electron kinetic energy is the difference between the incident photon

--- a/src/physics/material/MaterialParams.hh
+++ b/src/physics/material/MaterialParams.hh
@@ -87,10 +87,10 @@ class MaterialParams
 
     MaterialParamsPointers host_pointers_;
 
-    std::vector<std::string>                       elnames_;
-    std::vector<std::string>                       matnames_;
-    std::unordered_map<std::string, MaterialId>    matname_to_id_;
-    size_type                                      max_el_;
+    std::vector<std::string>                    elnames_;
+    std::vector<std::string>                    matnames_;
+    std::unordered_map<std::string, MaterialId> matname_to_id_;
+    size_type                                   max_el_;
 
     // HELPER FUNCTIONS
     void                      append_element_def(const ElementInput& inp);

--- a/src/sim/detail/InitializeTracks.cu
+++ b/src/sim/detail/InitializeTracks.cu
@@ -188,14 +188,14 @@ process_primaries_kernel(const Span<const Primary>    primaries,
         const Primary&    primary = primaries[thread_id.get()];
 
         // Construct a track initializer from a primary particle
-        init.sim.track_id    = primary.track_id;
-        init.sim.parent_id   = TrackId{};
-        init.sim.event_id    = primary.event_id;
-        init.sim.alive       = true;
-        init.geo.pos         = primary.position;
-        init.geo.dir         = primary.direction;
+        init.sim.track_id         = primary.track_id;
+        init.sim.parent_id        = TrackId{};
+        init.sim.event_id         = primary.event_id;
+        init.sim.alive            = true;
+        init.geo.pos              = primary.position;
+        init.geo.dir              = primary.direction;
         init.particle.particle_id = primary.particle_id;
-        init.particle.energy = primary.energy;
+        init.particle.energy      = primary.energy;
     }
 }
 
@@ -238,14 +238,14 @@ __global__ void process_secondaries_kernel(const StatePointers states,
                     &inits.track_counter[sim.event_id().get()], 1u);
 
                 // Construct a track initializer from a secondary
-                init.sim.track_id    = TrackId{track_id};
-                init.sim.parent_id   = sim.track_id();
-                init.sim.event_id    = sim.event_id();
-                init.sim.alive       = true;
-                init.geo.pos         = geo.pos();
-                init.geo.dir         = secondary.direction;
+                init.sim.track_id         = TrackId{track_id};
+                init.sim.parent_id        = sim.track_id();
+                init.sim.event_id         = sim.event_id();
+                init.sim.alive            = true;
+                init.geo.pos              = geo.pos();
+                init.geo.dir              = secondary.direction;
                 init.particle.particle_id = secondary.particle_id;
-                init.particle.energy = secondary.energy;
+                init.particle.energy      = secondary.energy;
             }
         }
         // Clear the secondaries from the interaction

--- a/test/base/ArrayUtils.test.cc
+++ b/test/base/ArrayUtils.test.cc
@@ -58,8 +58,8 @@ TEST(ArrayUtilsTest, norm)
 
 TEST(ArrayUtilsTest, normalize_direction)
 {
-    Real3            direction{1, 2, 3};
-    double           norm = 1 / std::sqrt(1 + 4 + 9);
+    Real3  direction{1, 2, 3};
+    double norm = 1 / std::sqrt(1 + 4 + 9);
     celeritas::normalize_direction(&direction);
 
     static const double expected[] = {1 * norm, 2 * norm, 3 * norm};
@@ -76,8 +76,8 @@ TEST(ArrayUtilsTest, rotate)
     double sintheta = std::sqrt(1.0 - costheta * costheta);
     double phi      = 2 * celeritas::constants::pi / 3.0;
 
-    double           a = 1.0 / sqrt(1.0 - vec[Z] * vec[Z]);
-    Real3            expected
+    double a = 1.0 / sqrt(1.0 - vec[Z] * vec[Z]);
+    Real3  expected
         = {vec[X] * costheta + vec[Z] * vec[X] * sintheta * cos(phi) * a
                - vec[Y] * sintheta * sin(phi) * a,
            vec[Y] * costheta + vec[Z] * vec[Y] * sintheta * cos(phi) * a

--- a/test/base/HostStackAllocatorStore.hh
+++ b/test/base/HostStackAllocatorStore.hh
@@ -22,9 +22,9 @@ class HostStackAllocatorStore
 {
     //!@{
     //! Type aliases
-    using value_type      = T;
-    using Pointers        = celeritas::StackAllocatorPointers<T>;
-    using size_type       = typename Pointers::size_type;
+    using value_type = T;
+    using Pointers   = celeritas::StackAllocatorPointers<T>;
+    using size_type  = typename Pointers::size_type;
     //!@}
 
   public:

--- a/test/base/Range.test.hh
+++ b/test/base/Range.test.hh
@@ -16,17 +16,19 @@ namespace celeritas_test
 // TESTING INTERFACE
 //---------------------------------------------------------------------------//
 //! Input data
-struct RangeTestInput {
-  int a;
-  std::vector<int> x;
-  std::vector<int> y;
-  unsigned int num_threads;
-  unsigned int num_blocks;
+struct RangeTestInput
+{
+    int              a;
+    std::vector<int> x;
+    std::vector<int> y;
+    unsigned int     num_threads;
+    unsigned int     num_blocks;
 };
 
 //! Output data
-struct RangeTestOutput {
-  std::vector<int> z;
+struct RangeTestOutput
+{
+    std::vector<int> z;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/io/EventReader.test.cc
+++ b/test/io/EventReader.test.cc
@@ -31,7 +31,7 @@ class EventReaderTest : public celeritas::Test,
         using celeritas::PDGNumber;
         using celeritas::units::ElementaryCharge;
         using celeritas::units::MevMass;
-        auto zero = celeritas::zero_quantity();
+        auto           zero   = celeritas::zero_quantity();
         constexpr auto stable = celeritas::ParticleDef::stable_decay_constant();
 
         // Create shared standard model particle data

--- a/test/physics/InteractorHostTestBase.cc
+++ b/test/physics/InteractorHostTestBase.cc
@@ -58,7 +58,7 @@ void InteractorHostTestBase::set_material(const std::string& name)
     CELER_EXPECT(material_params_);
 
     mat_state_.material_id = material_params_->find(name);
-    mt_view_          = std::make_shared<MaterialTrackView>(
+    mt_view_               = std::make_shared<MaterialTrackView>(
         material_params_->host_pointers(), ms_pointers_, ThreadId{0});
 }
 
@@ -104,7 +104,7 @@ void InteractorHostTestBase::set_inc_particle(PDGNumber pdg, MevEnergy energy)
     CELER_EXPECT(energy >= zero_quantity());
 
     particle_state_.particle_id = particle_params_->find(pdg);
-    particle_state_.energy = energy;
+    particle_state_.energy      = energy;
 
     pt_view_ = std::make_shared<ParticleTrackView>(
         pp_pointers_, ps_pointers_, ThreadId{0});
@@ -162,7 +162,7 @@ void InteractorHostTestBase::check_energy_conservation(
     if (interaction && !action_killed(interaction.action))
     {
         local_state.particle_id = particle_state_.particle_id;
-        local_state.energy = interaction.energy;
+        local_state.energy      = interaction.energy;
         ParticleTrackView exiting_track(
             pp_pointers_, local_state_ptrs, ThreadId{0});
         exit_energy += exiting_track.energy().value();
@@ -172,7 +172,7 @@ void InteractorHostTestBase::check_energy_conservation(
     for (const Secondary& s : interaction.secondaries)
     {
         local_state.particle_id = s.particle_id;
-        local_state.energy = s.energy;
+        local_state.energy      = s.energy;
         ParticleTrackView secondary_track(
             pp_pointers_, local_state_ptrs, ThreadId{0});
         exit_energy += secondary_track.energy().value();
@@ -203,7 +203,7 @@ void InteractorHostTestBase::check_momentum_conservation(
     if (interaction && !action_killed(interaction.action))
     {
         local_state.particle_id = particle_state_.particle_id;
-        local_state.energy = interaction.energy;
+        local_state.energy      = interaction.energy;
         ParticleTrackView exiting_track(
             pp_pointers_, local_state_ptrs, ThreadId{0});
         axpy(exiting_track.momentum().value(),
@@ -215,7 +215,7 @@ void InteractorHostTestBase::check_momentum_conservation(
     for (const Secondary& s : interaction.secondaries)
     {
         local_state.particle_id = s.particle_id;
-        local_state.energy = s.energy;
+        local_state.energy      = s.energy;
         ParticleTrackView secondary_track(
             pp_pointers_, local_state_ptrs, ThreadId{0});
         axpy(secondary_track.momentum().value(), s.direction, &exit_momentum);

--- a/test/physics/InteractorHostTestBase.hh
+++ b/test/physics/InteractorHostTestBase.hh
@@ -152,9 +152,9 @@ class InteractorHostTestBase : public celeritas::Test
     std::shared_ptr<ParticleParams> particle_params_;
     RandomEngine                    rng_;
 
-    celeritas::MaterialTrackState     mat_state_;
-    std::vector<real_type>            mat_element_scratch_;
-    celeritas::MaterialStatePointers  ms_pointers_;
+    celeritas::MaterialTrackState    mat_state_;
+    std::vector<real_type>           mat_element_scratch_;
+    celeritas::MaterialStatePointers ms_pointers_;
 
     celeritas::ParticleTrackState     particle_state_;
     celeritas::ParticleParamsPointers pp_pointers_;

--- a/test/physics/grid/ValueGridStore.test.cc
+++ b/test/physics/grid/ValueGridStore.test.cc
@@ -11,11 +11,11 @@
 #include "celeritas_test.hh"
 #include "base/Range.hh"
 
-using celeritas::ValueGridStore;
 using celeritas::real_type;
 using celeritas::size_type;
-using celeritas::XsGridPointers;
 using celeritas::UniformGridPointers;
+using celeritas::ValueGridStore;
+using celeritas::XsGridPointers;
 
 //---------------------------------------------------------------------------//
 // TEST HARNESS
@@ -28,7 +28,7 @@ class ValueGridStoreTest : public celeritas::Test
     {
         CELER_EXPECT(count > 0);
         XsGridPointers result;
-        result.log_energy = UniformGridPointers::from_bounds(0.0, 1.0, count);
+        result.log_energy  = UniformGridPointers::from_bounds(0.0, 1.0, count);
         result.prime_index = count / 2;
         temp_real.resize(count);
         for (auto i : celeritas::range(temp_real.size()))

--- a/test/sim/TrackInitializerStore.test.cc
+++ b/test/sim/TrackInitializerStore.test.cc
@@ -161,8 +161,9 @@ TEST_F(TrackInitTest, run)
     // Check the track IDs of the track initializers created from secondaries
     // Output is sorted as TrackInitializerStore does not calculate IDs
     // deterministically
-    output.initializer_id   = initializers_test(track_init.device_pointers());
-    std::sort(std::begin(output.initializer_id), std::end(output.initializer_id));
+    output.initializer_id = initializers_test(track_init.device_pointers());
+    std::sort(std::begin(output.initializer_id),
+              std::end(output.initializer_id));
     expected.initializer_id = {0, 1, 15, 16, 17};
     EXPECT_VEC_EQ(expected.initializer_id, output.initializer_id);
 
@@ -172,7 +173,7 @@ TEST_F(TrackInitTest, run)
     // Check the track IDs of the initialized tracks
     // Output is sorted as TrackInitializerStore does not calculate IDs
     // deterministically
-    output.track_id   = tracks_test(states.device_pointers());
+    output.track_id = tracks_test(states.device_pointers());
     std::sort(std::begin(output.track_id), std::end(output.track_id));
     expected.track_id = {3, 5, 7, 9, 11, 12, 13, 14, 16, 17};
     EXPECT_VEC_EQ(expected.track_id, output.track_id);

--- a/test/sim/TrackInitializerStore.test.hh
+++ b/test/sim/TrackInitializerStore.test.hh
@@ -55,8 +55,8 @@ struct Interactor
         for (auto& secondary : result.secondaries)
         {
             secondary.particle_id = ParticleId(0);
-            secondary.energy    = units::MevEnergy(5.);
-            secondary.direction = {1., 0., 0.};
+            secondary.energy      = units::MevEnergy(5.);
+            secondary.direction   = {1., 0., 0.};
         }
 
         return result;


### PR DESCRIPTION
Some files are slightly unformatted with the latest clang version, causing state changes when merging master into topic branches. This ensures all files are formatted with the latest stable LLVM version.