### PR TITLE
Normalize type aliases in DeviceAllocation/DeviceVector and add data()

### DIFF
--- a/src/base/DeviceAllocation.cuda.cc
+++ b/src/base/DeviceAllocation.cuda.cc
@@ -30,7 +30,7 @@ DeviceAllocation::DeviceAllocation(size_type bytes) : size_(bytes)
 /*!
  * Copy data to device.
  */
-void DeviceAllocation::copy_to_device(constSpanBytes bytes)
+void DeviceAllocation::copy_to_device(SpanConstBytes bytes)
 {
     CELER_EXPECT(!this->empty());
     CELER_EXPECT(bytes.size() == this->size());

--- a/src/base/DeviceAllocation.hh
+++ b/src/base/DeviceAllocation.hh
@@ -29,7 +29,7 @@ class DeviceAllocation
     //!@{
     //! Type aliases
     using SpanBytes      = Span<Byte>;
-    using constSpanBytes = Span<const Byte>;
+    using SpanConstBytes = Span<const Byte>;
     //!@}
 
   public:
@@ -56,10 +56,10 @@ class DeviceAllocation
     inline SpanBytes device_pointers();
 
     // Get the device pointer
-    inline constSpanBytes device_pointers() const;
+    inline SpanConstBytes device_pointers() const;
 
     // Copy data to device
-    void copy_to_device(constSpanBytes bytes);
+    void copy_to_device(SpanConstBytes bytes);
 
     // Copy data to host
     void copy_to_host(SpanBytes bytes) const;

--- a/src/base/DeviceAllocation.i.hh
+++ b/src/base/DeviceAllocation.i.hh
@@ -34,7 +34,7 @@ auto DeviceAllocation::device_pointers() -> SpanBytes
 /*!
  * Get a view to the owned device memory.
  */
-auto DeviceAllocation::device_pointers() const -> constSpanBytes
+auto DeviceAllocation::device_pointers() const -> SpanConstBytes
 {
     return {data_.get(), size_};
 }

--- a/src/base/DeviceAllocation.nocuda.cc
+++ b/src/base/DeviceAllocation.nocuda.cc
@@ -30,7 +30,7 @@ void DeviceAllocation::CudaFreeDeleter::operator()(Byte*) const
 /*!
  * Copy data to device (not implemented when cuda is disabled).
  */
-void DeviceAllocation::copy_to_device(constSpanBytes)
+void DeviceAllocation::copy_to_device(SpanConstBytes)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/base/DeviceVector.hh
+++ b/src/base/DeviceVector.hh
@@ -9,6 +9,7 @@
 
 #include <type_traits>
 #include "DeviceAllocation.hh"
+#include "Span.hh"
 #include "detail/InitializedValue.hh"
 
 namespace celeritas
@@ -45,9 +46,9 @@ class DeviceVector
   public:
     //!@{
     //! Type aliases
-    using value_type  = T;
-    using Span_t      = Span<T>;
-    using constSpan_t = Span<const T>;
+    using value_type = T;
+    using SpanT      = Span<T>;
+    using SpanConstT = Span<const T>;
     //!@}
 
   public:
@@ -77,16 +78,22 @@ class DeviceVector
     //// DEVICE ACCESSORS ////
 
     // Copy data to device
-    inline void copy_to_device(constSpan_t host_data);
+    inline void copy_to_device(SpanConstT host_data);
 
     // Copy data to host
-    inline void copy_to_host(Span_t host_data) const;
+    inline void copy_to_host(SpanT host_data) const;
 
     // Get a mutable view to device data
-    inline Span_t device_pointers();
+    SpanT device_pointers() { return {this->data(), this->size()}; }
 
     // Get a const view to device data
-    inline constSpan_t device_pointers() const;
+    SpanConstT device_pointers() const { return {this->data(), this->size()}; }
+
+    // Raw pointer to device data (dangerous!)
+    inline T* data();
+
+    // Raw pointer to device data (dangerous!)
+    inline const T* data() const;
 
   private:
     DeviceAllocation                    allocation_;
@@ -97,6 +104,28 @@ class DeviceVector
 // Swap two vectors
 template<class T>
 inline void swap(DeviceVector<T>&, DeviceVector<T>&) noexcept;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Prevent accidental construction of Span from a device vector.
+ *
+ * Use \c dv.device_pointers() to get a span.
+ */
+template<class T>
+CELER_FUNCTION Span<const T> make_span(const DeviceVector<T>& dv)
+{
+    static_assert(sizeof(T) == 0, "Cannot 'make_span' from a device vector");
+    return {dv.data(), dv.size()};
+}
+
+//---------------------------------------------------------------------------//
+//! Prevent accidental construction of Span from a device vector.
+template<class T>
+CELER_FUNCTION Span<T> make_span(DeviceVector<T>& dv)
+{
+    static_assert(sizeof(T) == 0, "Cannot 'make_span' from a device vector");
+    return {dv.data(), dv.size()};
+}
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/base/DeviceVector.i.hh
+++ b/src/base/DeviceVector.i.hh
@@ -50,7 +50,7 @@ void DeviceVector<T>::resize(size_type size)
  * Copy data to device.
  */
 template<class T>
-void DeviceVector<T>::copy_to_device(constSpan_t data)
+void DeviceVector<T>::copy_to_device(SpanConstT data)
 {
     CELER_EXPECT(data.size() == this->size());
     allocation_.copy_to_device(
@@ -62,7 +62,7 @@ void DeviceVector<T>::copy_to_device(constSpan_t data)
  * Copy data to host.
  */
 template<class T>
-void DeviceVector<T>::copy_to_host(Span_t data) const
+void DeviceVector<T>::copy_to_host(SpanT data) const
 {
     CELER_EXPECT(data.size() == this->size());
     allocation_.copy_to_host(
@@ -71,24 +71,22 @@ void DeviceVector<T>::copy_to_host(Span_t data) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Get an on-device view to the data.
+ * Get a device data pointer.
  */
 template<class T>
-auto DeviceVector<T>::device_pointers() -> Span_t
+T* DeviceVector<T>::data()
 {
-    return {reinterpret_cast<T*>(allocation_.device_pointers().data()),
-            this->size()};
+    return reinterpret_cast<T*>(allocation_.device_pointers().data());
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Get an on-device view to the data.
+ * Get a device data pointer.
  */
 template<class T>
-auto DeviceVector<T>::device_pointers() const -> constSpan_t
+const T* DeviceVector<T>::data() const
 {
-    return {reinterpret_cast<const T*>(allocation_.device_pointers().data()),
-            this->size()};
+    return reinterpret_cast<const T*>(allocation_.device_pointers().data());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/base/DeviceVector.test.cc
+++ b/test/base/DeviceVector.test.cc
@@ -81,3 +81,21 @@ TEST_F(DeviceVectorTest, all)
         EXPECT_EQ(orig_vec, other.device_pointers().data());
     }
 }
+
+/*!
+ * The following test code is intentionally commented out. Define
+ * CELERITAS_SHOULD_NOT_COMPILE to check that the enclosed code results in
+ * the expected build errors.
+ */
+#ifdef CELERITAS_SHOULD_NOT_COMPILE
+TEST_F(DeviceVectorTest, should_not_compile)
+{
+    DeviceVector<int>    dv(123);
+    celeritas::Span<int> s = make_span(dv);
+    EXPECT_EQ(123, s.size());
+
+    const auto&                dv_cref = dv;
+    celeritas::Span<const int> s2      = make_span(dv_cref);
+    EXPECT_EQ(123, s2.size());
+}
+#endif


### PR DESCRIPTION
I've pulled out this interstitial commit from #131 .

thrust::device_vector has a raw `data()` pointer, and we know that `data()` (messing around with pointers) is always potentially dangerous. To make this safer, I've added function overloads that prevent `make_span`
from accidentally returning a Span to device memory.