### PR TITLE
Rename gamma annihilation to conversion

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,7 @@ list(APPEND SOURCES
   physics/em/LivermorePEParams.cc
   physics/em/EPlusAnnihilationProcess.cc
   physics/em/EPlusGGModel.cc
-  physics/em/GammaAnnihilationProcess.cc
+  physics/em/GammaConversionProcess.cc
   physics/em/KleinNishinaModel.cc
   physics/em/MollerBhabhaModel.cc
   physics/grid/ValueGridBuilder.cc

--- a/src/physics/em/GammaConversionProcess.cc
+++ b/src/physics/em/GammaConversionProcess.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file GammaAnnihilationProcess.cc
+//! \file GammaConversionProcess.cc
 //---------------------------------------------------------------------------//
-#include "GammaAnnihilationProcess.hh"
+#include "GammaConversionProcess.hh"
 
 #include <utility>
 #include "BetheHeitlerModel.hh"
@@ -16,7 +16,7 @@ namespace celeritas
 /*!
  * Construct from host data.
  */
-GammaAnnihilationProcess::GammaAnnihilationProcess(SPConstParticles particles)
+GammaConversionProcess::GammaConversionProcess(SPConstParticles particles)
     : particles_(std::move(particles))
     , positron_id_(particles_->find(pdg::positron()))
 {
@@ -27,7 +27,7 @@ GammaAnnihilationProcess::GammaAnnihilationProcess(SPConstParticles particles)
 /*!
  * Construct the models associated with this process.
  */
-auto GammaAnnihilationProcess::build_models(ModelIdGenerator next_id) const
+auto GammaConversionProcess::build_models(ModelIdGenerator next_id) const
     -> VecModel
 {
     return {std::make_shared<BetheHeitlerModel>(next_id(), *particles_)};
@@ -37,7 +37,7 @@ auto GammaAnnihilationProcess::build_models(ModelIdGenerator next_id) const
 /*!
  * Get the interaction cross sections for the given energy range.
  */
-auto GammaAnnihilationProcess::step_limits(Applicability range) const
+auto GammaConversionProcess::step_limits(Applicability range) const
     -> StepLimitBuilders
 {
     CELER_EXPECT(range.particle == particles_->find(pdg::gamma()));
@@ -51,7 +51,7 @@ auto GammaAnnihilationProcess::step_limits(Applicability range) const
 /*!
  * Name of the process.
  */
-std::string GammaAnnihilationProcess::label() const
+std::string GammaConversionProcess::label() const
 {
     return "Photon annihiliation";
 }

--- a/src/physics/em/GammaConversionProcess.hh
+++ b/src/physics/em/GammaConversionProcess.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file GammaAnnihilationProcess.hh
+//! \file GammaConversionProcess.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -17,7 +17,7 @@ namespace celeritas
 /*!
  * Annihiliation process for photons.
  */
-class GammaAnnihilationProcess : public Process
+class GammaConversionProcess : public Process
 {
   public:
     //!@{
@@ -27,7 +27,7 @@ class GammaAnnihilationProcess : public Process
 
   public:
     // Construct from particle data
-    explicit GammaAnnihilationProcess(SPConstParticles particles);
+    explicit GammaConversionProcess(SPConstParticles particles);
 
     // Construct the models associated with this process
     VecModel build_models(ModelIdGenerator next_id) const final;

--- a/test/physics/em/BetheHeitler.test.cc
+++ b/test/physics/em/BetheHeitler.test.cc
@@ -11,7 +11,7 @@
 #include "physics/material/Types.hh"
 #include "physics/base/Units.hh"
 #include "physics/em/BetheHeitlerModel.hh"
-#include "physics/em/GammaAnnihilationProcess.hh"
+#include "physics/em/GammaConversionProcess.hh"
 #include "physics/material/MaterialTrackView.hh"
 
 #include "celeritas_test.hh"
@@ -22,7 +22,7 @@
 #include "../InteractorHostTestBase.hh"
 #include "../InteractionIO.hh"
 
-using celeritas::GammaAnnihilationProcess;
+using celeritas::GammaConversionProcess;
 using celeritas::detail::BetheHeitlerInteractor;
 using celeritas::units::AmuMass;
 namespace constants = celeritas::constants;
@@ -244,8 +244,8 @@ TEST_F(BetheHeitlerInteractorTest, stress_test)
 // TODO: Test all models for a given process?
 TEST_F(BetheHeitlerInteractorTest, model)
 {
-    GammaAnnihilationProcess process(this->get_particle_params());
-    ModelIdGenerator         next_id;
+    GammaConversionProcess process(this->get_particle_params());
+    ModelIdGenerator       next_id;
 
     // Construct the models associated with gamma annihilation
     auto models = process.build_models(next_id);

--- a/test/physics/em/LivermorePE.test.cc
+++ b/test/physics/em/LivermorePE.test.cc
@@ -320,7 +320,7 @@ TEST_F(LivermorePEInteractorTest, distributions_all)
     EXPECT_EQ(16 * num_samples, this->secondary_allocator().get().size());
     EXPECT_EQ(2180, num_secondaries);
 
-    for (const auto it : energy_to_count)
+    for (const auto& it : energy_to_count)
     {
         energy.push_back(it.first);
         count.push_back(it.second);
@@ -388,7 +388,7 @@ TEST_F(LivermorePEInteractorTest, distributions_radiative)
     EXPECT_EQ(5 * num_samples, this->secondary_allocator().get().size());
     EXPECT_EQ(10007, num_secondaries);
 
-    for (const auto it : energy_to_count)
+    for (const auto& it : energy_to_count)
     {
         energy.push_back(it.first);
         count.push_back(it.second);


### PR DESCRIPTION
I missed this during the review for #111 -- the gammas are being produced as a result of annihilation, but the name is confusing next to the positron annihilation process (in which positrons are being annihilated). I suggest changing to "gamma conversion" for consistency with geant4.