### PR TITLE
Add CMake-derived version metadata to build system and output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.* export-ignore
 *.bin filter=lfs diff=lfs merge=lfs -text
 *.graffle filter=lfs diff=lfs merge=lfs -text
 *.h5 filter=lfs diff=lfs merge=lfs -text

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 #----------------------------------------------------------------------------#
 
-# Note: 3.13 is the first CMake version that natively supports CUDA+MPI
 cmake_minimum_required(VERSION 3.12)
-project(Celeritas VERSION 0.0.1 LANGUAGES CXX)
+
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/CgvFindVersion.cmake")
+cgv_find_version(Celeritas)
+project(Celeritas VERSION "${Celeritas_VERSION}" LANGUAGES CXX)
 cmake_policy(VERSION 3.12...3.18)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")

--- a/app/demo-interactor/demo-interactor.cc
+++ b/app/demo-interactor/demo-interactor.cc
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 #include <nlohmann/json.hpp>
+#include "celeritas_version.h"
 #include "comm/Communicator.hh"
 #include "comm/Device.hh"
 #include "comm/Logger.hh"
@@ -76,6 +77,7 @@ void run(std::istream& is)
         {"grid_params", grid_params},
         {"run", run_args},
         {"result", result},
+        {"version", std::string(celeritas_version)},
     };
     cout << outp.dump() << endl;
 }

--- a/app/demo-interactor/host-demo-interactor.cc
+++ b/app/demo-interactor/host-demo-interactor.cc
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 #include <nlohmann/json.hpp>
+#include "celeritas_version.h"
 #include "comm/Communicator.hh"
 #include "comm/Logger.hh"
 #include "comm/ScopedMpiInit.hh"
@@ -70,6 +71,7 @@ void run(std::istream& is)
     nlohmann::json outp = {
         {"run", run_args},
         {"result", result},
+        {"version", std::string(celeritas_version)},
     };
     cout << outp.dump() << endl;
 }

--- a/app/demo-rasterizer/demo-rasterizer.cc
+++ b/app/demo-rasterizer/demo-rasterizer.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include <nlohmann/json.hpp>
+#include "celeritas_version.h"
 #include "base/ColorUtils.hh"
 #include "base/Range.hh"
 #include "comm/Communicator.hh"
@@ -73,7 +74,11 @@ void run(std::istream& is)
     // Construct json output
     CELER_LOG(status) << "Exporting JSON metadata";
     nlohmann::json outp = {
-        {"metadata", image}, {"data", out_filename}, {"volumes", vol_names}};
+        {"metadata", image},
+        {"data", out_filename},
+        {"volumes", vol_names},
+        {"version", std::string(celeritas_version)},
+    };
     cout << outp.dump() << endl;
     CELER_LOG(info) << "Exported image to " << out_filename;
 }

--- a/cmake/.gitattributes
+++ b/cmake/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/CgvFindVersion.cmake export-subst

--- a/cmake/CgvFindVersion.cmake
+++ b/cmake/CgvFindVersion.cmake
@@ -1,0 +1,171 @@
+#---------------------------------*-CMake-*----------------------------------#
+# SPDX-License-Identifier: Apache-2.0
+#
+# https://github.com/sethrj/cmake-git-version
+#
+#  Copyright 2021 UT-Battelle, LLC and Seth R Johnson
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#[=======================================================================[.rst:
+
+CgvFindVersion
+--------------
+
+.. command:: cgv_find_version
+
+  Get the project version using Git descriptions to ensure the version numbers
+  are always synchronized between Git and CMake::
+
+    cgv_find_version([<projname>])
+
+  ``<projname>``
+    Name of the project.
+
+  This command sets the following variables in the parent package::
+
+    ${projname}_VERSION
+    ${projname}_VERSION_STRING
+
+  It takes the project name and version file path as optional arguments to
+  support using it before the CMake ``project`` command.
+
+  The project version string uses an approximation to SemVer strings, appearing
+  as v0.1.2 if the version is actually a tagged release, or v0.1.3+abcdef if
+  it's not.
+
+  If a non-tagged version is exported, or an untagged shallow git clone is used,
+  it's impossible to determine the version from the tag, so a warning will be
+  issued and the version will be set to 0.0.0.
+
+  The exact regex used to match the version tag is::
+
+    v([0-9.]+)(-dev[0-9.]+)?
+
+
+  .. note:: In order for this script to work properly with archived git
+    repositories (generated with ``git-archive`` or GitHub's release tarball
+    feature), it's necessary to add to your ``.gitattributes`` file::
+
+      CgvFindVersion.cmake export-subst
+
+#]=======================================================================]
+
+if(CMAKE_SCRIPT_MODE_FILE)
+  cmake_minimum_required(VERSION 3.8)
+endif()
+
+function(cgv_find_version)
+  set(projname "${ARGV0}")
+  if(NOT projname)
+    set(projname "${CMAKE_PROJECT_NAME}")
+    if(NOT projname)
+      message(FATAL_ERROR "Project name is not defined")
+    endif()
+  endif()
+
+  # Get a possible Git version generated using git-archive (see the
+  # .gitattributes file)
+  set(_ARCHIVE_TAG "$Format:%D$")
+  set(_ARCHIVE_HASH "$Format:%h$")
+
+  set(_TAG_REGEX "v([0-9.]+)(-dev[0-9.]+)?")
+  set(_HASH_REGEX "([0-9a-f]+)")
+
+  if(_ARCHIVE_HASH MATCHES "%h")
+    # Not a "git archive": use live git information
+    set(_CACHE_VAR "${projname}_GIT_DESCRIBE")
+    set(_CACHED_VERSION "${${_CACHE_VAR}}")
+    if(NOT _CACHED_VERSION)
+      # Building from a git checkout rather than a distribution
+      if(NOT GIT_EXECUTABLE)
+        find_package(Git QUIET REQUIRED)
+      endif()
+      execute_process(
+        COMMAND "${GIT_EXECUTABLE}" "describe" "--tags" "--match" "v*"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+        ERROR_VARIABLE _GIT_ERR
+        OUTPUT_VARIABLE _VERSION_STRING
+        RESULT_VARIABLE _GIT_RESULT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+      if(_GIT_RESULT)
+        message(AUTHOR_WARNING "No git tags in ${projname} matched 'v*': "
+          "${_GIT_ERR}")
+      elseif(NOT _VERSION_STRING)
+        message(WARNING "Failed to get ${projname} version from git: "
+          "git describe returned an empty string")
+      else()
+        # Process description tag: e.g. v0.4.0-2-gc4af497 or v0.4.0
+        # or v2.0.0-dev2
+        string(REGEX MATCH "^${_TAG_REGEX}(-[0-9]+-g${_HASH_REGEX})?" _MATCH
+          "${_VERSION_STRING}"
+        )
+        if(_MATCH)
+          set(_VERSION_STRING "${CMAKE_MATCH_1}")
+          set(_VERSION_STRING_SUFFIX "${CMAKE_MATCH_2}")
+          if(CMAKE_MATCH_3)
+            # *not* a tagged release
+            set(_VERSION_HASH "${CMAKE_MATCH_4}")
+          endif()
+        endif()
+      endif()
+      if(NOT _VERSION_STRING)
+        execute_process(
+          COMMAND "${GIT_EXECUTABLE}" "log" "-1" "--format=%h" "HEAD"
+          WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+          OUTPUT_VARIABLE _VERSION_HASH
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+      endif()
+      set(_CACHED_VERSION "${_VERSION_STRING}" "${_VERSION_STRING_SUFFIX}" "${_VERSION_HASH}")
+      set("${_CACHE_VAR}" "${_CACHED_VERSION}" CACHE INTERNAL
+        "Version string and hash for ${projname}")
+    endif()
+    list(GET _CACHED_VERSION 0 _VERSION_STRING)
+    list(GET _CACHED_VERSION 1 _VERSION_STRING_SUFFIX)
+    list(GET _CACHED_VERSION 2 _VERSION_HASH)
+  else()
+    string(REGEX MATCH "tag: *${_TAG_REGEX}" _MATCH "${_ARCHIVE_TAG}")
+    if(_MATCH)
+      set(_VERSION_STRING "${CMAKE_MATCH_1}")
+      set(_VERSION_STRING_SUFFIX "${CMAKE_MATCH_2}")
+    else()
+      message(AUTHOR_WARNING "Could not match a version tag for "
+        "git description '${_ARCHIVE_TAG}': perhaps this archive was not "
+        "exported from a tagged commit?")
+      string(REGEX MATCH " *${_HASH_REGEX}" _MATCH "${_ARCHIVE_HASH}")
+      if(_MATCH)
+        set(_VERSION_HASH "${CMAKE_MATCH_1}")
+      endif()
+    endif()
+  endif()
+
+  if(NOT _VERSION_STRING)
+    set(_VERSION_STRING "0.0.0")
+  endif()
+
+  if(_VERSION_HASH)
+    set(_FULL_VERSION_STRING "v${_VERSION_STRING}${_VERSION_STRING_SUFFIX}+${_VERSION_HASH}")
+  else()
+    set(_FULL_VERSION_STRING "v${_VERSION_STRING}${_VERSION_STRING_SUFFIX}")
+  endif()
+
+  set(${projname}_VERSION "${_VERSION_STRING}" PARENT_SCOPE)
+  set(${projname}_VERSION_STRING "${_FULL_VERSION_STRING}" PARENT_SCOPE)
+endfunction()
+
+if(CMAKE_SCRIPT_MODE_FILE)
+  cgv_find_version(TEMP)
+  message("VERSION=\"${TEMP_VERSION}\"")
+  message("VERSION_STRING=\"${TEMP_VERSION_STRING}\"")
+endif()

--- a/cmake/CgvFindVersion.cmake
+++ b/cmake/CgvFindVersion.cmake
@@ -87,22 +87,26 @@ function(cgv_find_version)
     set(_CACHED_VERSION "${${_CACHE_VAR}}")
     if(NOT _CACHED_VERSION)
       # Building from a git checkout rather than a distribution
-      if(NOT GIT_EXECUTABLE)
-        find_package(Git QUIET REQUIRED)
+      if(NOT Git_FOUND)
+        find_package(Git QUIET)
       endif()
-      execute_process(
-        COMMAND "${GIT_EXECUTABLE}" "describe" "--tags" "--match" "v*"
-        WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
-        ERROR_VARIABLE _GIT_ERR
-        OUTPUT_VARIABLE _VERSION_STRING
-        RESULT_VARIABLE _GIT_RESULT
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-      )
+      if(Git_FOUND)
+        execute_process(
+          COMMAND "${GIT_EXECUTABLE}" "describe" "--tags" "--match" "v*"
+          WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+          ERROR_VARIABLE _GIT_ERR
+          OUTPUT_VARIABLE _VERSION_STRING
+          RESULT_VARIABLE _GIT_RESULT
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+      else()
+        message(AUTHOR_WARNING "Could not find Git")
+      endif()
       if(_GIT_RESULT)
         message(AUTHOR_WARNING "No git tags in ${projname} matched 'v*': "
           "${_GIT_ERR}")
       elseif(NOT _VERSION_STRING)
-        message(WARNING "Failed to get ${projname} version from git: "
+        message(AUTHOR_WARNING "Failed to get ${projname} version from git: "
           "git describe returned an empty string")
       else()
         # Process description tag: e.g. v0.4.0-2-gc4af497 or v0.4.0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,9 @@ set(CELERITAS_USE_GEANT4  ${CELERITAS_USE_Geant4})
 set(CELERITAS_USE_HEPMC3  ${CELERITAS_USE_HepMC3})
 set(CELERITAS_USE_VECGEOM ${CELERITAS_USE_VecGeom})
 
-set(_CONFIG_NAME "celeritas_config.h")
-configure_file("${_CONFIG_NAME}.in" "${_CONFIG_NAME}" @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${_CONFIG_NAME}"
+configure_file("celeritas_config.h.in" "celeritas_config.h" @ONLY)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/celeritas_config.h"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
@@ -25,6 +25,13 @@ set(SOURCES)
 set(PRIVATE_DEPS)
 set(PUBLIC_DEPS)
 
+# Version information
+configure_file("celeritas_version.cc.in" "celeritas_version.cc" @ONLY)
+list(APPEND SOURCES
+  "${CMAKE_CURRENT_BINARY_DIR}/celeritas_version.cc"
+)
+
+# Main library
 list(APPEND SOURCES
   base/Assert.cc
   base/ColorUtils.cc
@@ -162,9 +169,15 @@ install(TARGETS celeritas
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-foreach(_SUBDIR base geom)
+install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/celeritas_version.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+foreach(_SUBDIR base comm geometry io physics random sim
+    base/detail comm/detail geometry/detail sim/detail)
   file(GLOB _HEADERS
-    "${_SUBDIR}/*.h"
+    "${_SUBDIR}/*.hh"
   )
   install(FILES ${_HEADERS}
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${_SUBDIR}/"

--- a/src/celeritas_version.cc.in
+++ b/src/celeritas_version.cc.in
@@ -1,0 +1,17 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas_version.cc
+//---------------------------------------------------------------------------//
+#include "celeritas_version.h"
+
+extern "C" {
+
+const char celeritas_version[]    = "@Celeritas_VERSION_STRING@";
+const int celeritas_version_major = @PROJECT_VERSION_MAJOR@;
+const int celeritas_version_minor = @PROJECT_VERSION_MINOR@;
+const int celeritas_version_patch = @PROJECT_VERSION_PATCH@;
+
+}

--- a/src/celeritas_version.h
+++ b/src/celeritas_version.h
@@ -1,0 +1,25 @@
+/*----------------------------------*-C-*------------------------------------*
+ * Copyright 2020 UT-Battelle, LLC and other Celeritas Developers.
+ * See the top-level COPYRIGHT file for details.
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *---------------------------------------------------------------------------*/
+/*! \file celeritas_version.h
+ * Version metadata for Celeritas.
+ *---------------------------------------------------------------------------*/
+#ifndef celeritas_version_h
+#define celeritas_version_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const char celeritas_version[];
+extern const int  celeritas_version_major;
+extern const int  celeritas_version_minor;
+extern const int  celeritas_version_patch;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* celeritas_version_h */

--- a/test/gtest/detail/TestMain.cc
+++ b/test/gtest/detail/TestMain.cc
@@ -10,8 +10,10 @@
 #include <stdexcept>
 #include "celeritas_config.h"
 #include "base/ColorUtils.hh"
+#include "celeritas_version.h"
 #include "comm/Communicator.hh"
 #include "comm/Device.hh"
+#include "comm/Logger.hh"
 #include "comm/Operations.hh"
 #include "comm/ScopedMpiInit.hh"
 #include "NonMasterResultPrinter.hh"
@@ -45,6 +47,12 @@ int test_main(int argc, char** argv)
                       << std::endl;
         }
         return 1;
+    }
+
+    if (comm.rank() == 0)
+    {
+        std::cout << color_code('x') << "Celeritas version "
+                  << celeritas_version << std::endl;
     }
 
     // Initialize google test


### PR DESCRIPTION
This uses [a cmake helper script](https://github.com/sethrj/cmake-git-version) to pull git tag and hash information into a configure-time C++ file. Since it only updates the version on the first reconfigure, it's mainly useful for CI and exported releases, but it's a good first step toward versioning output files etc.