### PR TITLE
Print HEP package versions during configure, and update CI VecGeom

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -12,7 +12,7 @@ pipeline {
         stage('minimal') {
           agent {
             docker {
-              image 'celeritas/ci-cuda11:latest'
+              image 'celeritas/ci-cuda11:2021-02-12'
               // Note: this image does not require CUDA
             }
           }
@@ -29,7 +29,7 @@ pipeline {
         stage('cuda-11') {
           agent {
             docker {
-              image 'celeritas/ci-cuda11:latest'
+              image 'celeritas/ci-cuda11:2021-02-12'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
             }
           }

--- a/.jenkins
+++ b/.jenkins
@@ -12,7 +12,7 @@ pipeline {
         stage('minimal') {
           agent {
             docker {
-              image 'celeritas/ci-cuda11:2021-02-12'
+              image 'celeritas/ci-cuda11:2021-01-27'
               // Note: this image does not require CUDA
             }
           }
@@ -29,7 +29,7 @@ pipeline {
         stage('cuda-11') {
           agent {
             docker {
-              image 'celeritas/ci-cuda11:2021-02-12'
+              image 'celeritas/ci-cuda11:2021-01-27'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
             }
           }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,11 +96,11 @@ if(CELERITAS_USE_CUDA)
 endif()
 
 if(CELERITAS_USE_Geant4)
-  find_package(Geant4 REQUIRED)
+  celeritas_find_package(Geant4 REQUIRED)
 endif()
 
 if(CELERITAS_USE_HepMC3)
-  find_package(HepMC3 REQUIRED)
+  celeritas_find_package(HepMC3 REQUIRED)
   # HepMC3's cmake config file does not provide an imported target yet
   # Anticipate that it will, and create if not present. HepMC3 is
   # a private dep of Celeritas, so no need to re-export this.
@@ -118,7 +118,7 @@ if(CELERITAS_USE_MPI)
 endif()
 
 if(CELERITAS_USE_ROOT)
-  find_package(ROOT REQUIRED)
+  celeritas_find_package_config(ROOT REQUIRED)
 endif()
 
 if(CELERITAS_USE_SWIG_Python)
@@ -131,7 +131,7 @@ if(CELERITAS_USE_SWIG_Python)
 endif()
 
 if(CELERITAS_USE_VecGeom)
-  find_package(VecGeom REQUIRED) # Minimum 1.1.7
+  celeritas_find_package_config(VecGeom REQUIRED)
 
   if((CELERITAS_USE_CUDA AND NOT VecGeom_CUDA_FOUND)
       OR (NOT CELERITAS_USE_CUDA AND VecGeom_CUDA_FOUND))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,11 +96,11 @@ if(CELERITAS_USE_CUDA)
 endif()
 
 if(CELERITAS_USE_Geant4)
-  celeritas_find_package(Geant4 REQUIRED)
+  celeritas_find_package_config(Geant4 REQUIRED)
 endif()
 
 if(CELERITAS_USE_HepMC3)
-  celeritas_find_package(HepMC3 REQUIRED)
+  celeritas_find_package_config(HepMC3 REQUIRED)
   # HepMC3's cmake config file does not provide an imported target yet
   # Anticipate that it will, and create if not present. HepMC3 is
   # a private dep of Celeritas, so no need to re-export this.

--- a/cmake/CeleritasUtils.cmake
+++ b/cmake/CeleritasUtils.cmake
@@ -9,27 +9,28 @@ CeleritasUtils
 
 CMake utility functions for Celeritas.
 
-.. command:: set_required
+.. command:: celeritas_find_package_config
 
-  Pass the given compiler-dependent warning flags to a library target::
+  ::
 
-    set_required(<OUTPUT_VAR>
-                 <OPTION_VAR>)
+    celeritas_find_package_config(<package> [...])
 
-  ``OUTPUT_VAR``
-    Set variable in the parent scope to "REQUIRED" or empty.
+  Find the given package specified by a config file, but print location and
+  version information while loading. A well-behaved package Config.cmake file
+  should already include this, but several of the HEP packages (ROOT, Geant4,
+  VecGeom do not, so this helps debug system configuration issues.
 
-  ``OPTION_VAR``
-    Variable to test.
+  The "Found" message should only display the first time a package is found and
+  should be silent on subsequent CMake reconfigures.
+
+  Once upstream packages are updated, this can be replaced by ``find_package``.
 
 #]=======================================================================]
+include(FindPackageHandleStandardArgs)
 
-function(set_required OUTPUT_VAR INPUT_VAR)
-  if (INPUT_VAR)
-    set(OUTPUT_VAR REQUIRED PARENT_SCOPE)
-  else()
-    set(OUTPUT_VAR "" PARENT_SCOPE)
-  endif()
-endfunction()
+macro(celeritas_find_package_config _package)
+  find_package(${_package} CONFIG ${ARGN})
+  find_package_handle_standard_args(${_package} CONFIG_MODE)
+endmacro()
 
 #-----------------------------------------------------------------------------#

--- a/scripts/build/docker-minimal.sh
+++ b/scripts/build/docker-minimal.sh
@@ -25,6 +25,7 @@ export CXXFLAGS="-Wall -Wextra -pedantic -Werror"
 export PATH\
 =${_sw}/cmake-3.18.4-liggd6utlx54xhzls3uypu3adngo6xe5/bin\
 :${_sw}/ninja-1.10.1-757xwyeqsyltrq4cuvnqzoe72dvtbuhr/bin\
+:${_sw}/git-2.29.0-m4hws3mtwtyelepfuzznwf6syoorbfra/bin\
 :/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export CMAKE_PREFIX_PATH\
 =${_sw}/googletest-1.10.0-wd3am66hewqoxavcg66hoezbbmhtcgi5
@@ -35,6 +36,8 @@ export C_INCLUDE_PATH=
 export INCLUDE_PATH=
 export LIBRARY_PATH=
 export LD_LIBRARY_PATH=
+
+git -C ${SOURCE_DIR} fetch -f --tags
 
 # Note: cuda_arch must match the spack.yaml file for the docker image, which
 # must match the hardware being used.

--- a/scripts/build/docker.sh
+++ b/scripts/build/docker.sh
@@ -21,6 +21,8 @@ cd ${BUILD_DIR}
 set -x
 export CXXFLAGS="-Wall -Wextra -pedantic -Werror"
 
+git -C ${SOURCE_DIR} fetch -f --tags
+
 # Note: cuda_arch must match the spack.yaml file for the docker image, which
 # must match the hardware being used.
 cmake -G Ninja \

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -14,8 +14,8 @@ Both images are based on `nvidia` Ubuntu installations.
 From inside this directory, you can build and tag both versions:
 
 ```console
-$ docker build -t celeritas/dev:latest .
-$ docker build -t celeritas/ci-cuda11:latest ci
+$ docker build -t celeritas/dev:$(date '+%Y-%m-%d') .
+$ docker build -t celeritas/ci-cuda11:$(date '+%Y-%m-%d') ci
 ```
 
 ## Pushing
@@ -23,8 +23,8 @@ $ docker build -t celeritas/ci-cuda11:latest ci
 The CI docker images should be pushed upstream to enable continuous
 integration. This is a one-line command:
 ```console
-$ docker push celeritas/dev:latest
-$ docker push celeritas/ci-cuda11:latest ci
+$ docker push celeritas/dev:$(date '+%Y-%m-%d')
+$ docker push celeritas/ci-cuda11:$(date '+%Y-%m-%d') ci
 ```
 but it requires that you log in with your `docker.io` credentials first:
 ```console

--- a/scripts/docker/ci/Dockerfile
+++ b/scripts/docker/ci/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get -yqq update \
 # Install updated vecgeom (XXX: merge into spack install)
 RUN . /etc/profile.d/celeritas_spack_env.sh \
   && cd /opt \
-  && git clone --depth=1 https://gitlab.cern.ch/VecGeom/VecGeom.git vecgeom-src \
+  && git clone --depth=1 --branch v1.1.11 https://gitlab.cern.ch/VecGeom/VecGeom.git vecgeom-src \
   && mkdir vecgeom-build \
   && cd vecgeom-build \
   && cmake -DBACKEND:STRING=Scalar -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILTIN_VECCORE:BOOL=OFF -DNO_SPECIALIZATION:BOOL=ON -DVECGEOM_VECTOR:STRING=empty -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_STANDARD:STRING=14 -DCUDA:BOOL=ON -DGDML:BOOL=ON -DGEANT4:BOOL=OFF -DROOT:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DCTEST:BOOL=OFF -DGDMLTESTING:BOOL=OFF -DCUDA_ARCH:STRING=70 -DCMAKE_INSTALL_PREFIX:STRING=/opt/vecgeom -G Ninja ../vecgeom-src \

--- a/scripts/docker/ci/Dockerfile
+++ b/scripts/docker/ci/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get -yqq update \
 # Install updated vecgeom (XXX: merge into spack install)
 RUN . /etc/profile.d/celeritas_spack_env.sh \
   && cd /opt \
-  && git clone --depth=1 --branch v1.1.11 https://gitlab.cern.ch/VecGeom/VecGeom.git vecgeom-src \
+  && git clone --depth=1 --branch v1.1.9 https://gitlab.cern.ch/VecGeom/VecGeom.git vecgeom-src \
   && mkdir vecgeom-build \
   && cd vecgeom-build \
   && cmake -DBACKEND:STRING=Scalar -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILTIN_VECCORE:BOOL=OFF -DNO_SPECIALIZATION:BOOL=ON -DVECGEOM_VECTOR:STRING=empty -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_STANDARD:STRING=14 -DCUDA:BOOL=ON -DGDML:BOOL=ON -DGEANT4:BOOL=OFF -DROOT:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DCTEST:BOOL=OFF -DGDMLTESTING:BOOL=OFF -DCUDA_ARCH:STRING=70 -DCMAKE_INSTALL_PREFIX:STRING=/opt/vecgeom -G Ninja ../vecgeom-src \


### PR DESCRIPTION
- Add `find_package_handle_standard_args` call for package config files (Geant4, ROOT, VecGeom) that don't do that themselves
- Update docker image to use VecGeom 1.1.11

Needed to fix tests for #90 .