### PR TITLE
Complete the implementation of `calc_tabulated_physics_step`

### DIFF
--- a/src/physics/base/Model.hh
+++ b/src/physics/base/Model.hh
@@ -10,7 +10,6 @@
 #include <set>
 #include <string>
 #include "base/Span.hh"
-#include "physics/base/PhysicsInterface.hh"
 #include "physics/grid/UniformGrid.hh"
 #include "Applicability.hh"
 #include "Types.hh"
@@ -66,9 +65,6 @@ class Model
 
     //! Name of the model, for user interaction
     virtual std::string label() const = 0;
-
-    // Hardwire data for models that calculate macro xs on the fly
-    virtual void hardwire(HardwiredModels*) const {};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/Model.hh
+++ b/src/physics/base/Model.hh
@@ -10,6 +10,7 @@
 #include <set>
 #include <string>
 #include "base/Span.hh"
+#include "physics/base/PhysicsInterface.hh"
 #include "physics/grid/UniformGrid.hh"
 #include "Applicability.hh"
 #include "Types.hh"
@@ -65,6 +66,9 @@ class Model
 
     //! Name of the model, for user interaction
     virtual std::string label() const = 0;
+
+    // Hardwire data for models that calculate macro xs on the fly
+    virtual void hardwire(HardwiredModels*) const {};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/PhysicsInterface.hh
+++ b/src/physics/base/PhysicsInterface.hh
@@ -118,10 +118,16 @@ struct ProcessGroup
  */
 struct HardwiredModels
 {
-    ProcessId                          gamma_photoelectric;
-    const detail::LivermorePEPointers* livermore_params = nullptr;
-    ProcessId                          positron_annihilation;
-    const detail::EPlusGGPointers*     eplusgg_params = nullptr;
+    // Photoelectric effect
+    ProcessId                          photoelectric;
+    units::MevEnergy                   photoelectric_table_thresh;
+    ModelId                            livermore_pe;
+    const detail::LivermorePEPointers* livermore_pe_params = nullptr;
+
+    // Positron annihilation
+    ProcessId                      positron_annihilation;
+    ModelId                        eplusgg;
+    const detail::EPlusGGPointers* eplusgg_params = nullptr;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/PhysicsInterface.hh
+++ b/src/physics/base/PhysicsInterface.hh
@@ -119,15 +119,15 @@ struct ProcessGroup
 struct HardwiredModels
 {
     // Photoelectric effect
-    ProcessId                          photoelectric;
-    units::MevEnergy                   photoelectric_table_thresh;
-    ModelId                            livermore_pe;
-    const detail::LivermorePEPointers* livermore_pe_params = nullptr;
+    ProcessId                   photoelectric;
+    units::MevEnergy            photoelectric_table_thresh;
+    ModelId                     livermore_pe;
+    detail::LivermorePEPointers livermore_pe_params;
 
     // Positron annihilation
-    ProcessId                      positron_annihilation;
-    ModelId                        eplusgg;
-    const detail::EPlusGGPointers* eplusgg_params = nullptr;
+    ProcessId               positron_annihilation;
+    ModelId                 eplusgg;
+    detail::EPlusGGPointers eplusgg_params;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/PhysicsParams.cc
+++ b/src/physics/base/PhysicsParams.cc
@@ -15,6 +15,8 @@
 #include "base/VectorUtils.hh"
 #include "comm/Logger.hh"
 #include "ParticleParams.hh"
+#include "physics/em/EPlusGGModel.hh"
+#include "physics/em/LivermorePEModel.hh"
 #include "physics/grid/ValueGridInserter.hh"
 #include "physics/material/MaterialParams.hh"
 
@@ -244,17 +246,18 @@ void PhysicsParams::build_ids(const ParticleParams& particles,
     {
         const Model&    model      = *models_[model_idx].first;
         const ProcessId process_id = models_[model_idx].second;
-        const Process&  process    = *processes_[process_id.get()];
-        if (process.label() == "Photoelectric effect")
+        if (auto* pe_model = dynamic_cast<const LivermorePEModel*>(&model))
         {
             data->hardwired.photoelectric              = process_id;
             data->hardwired.photoelectric_table_thresh = units::MevEnergy{0.2};
-            model.hardwire(&data->hardwired);
+            data->hardwired.livermore_pe               = ModelId{model_idx};
+            data->hardwired.livermore_pe_params = pe_model->device_pointers();
         }
-        else if (process.label() == "Positron annihiliation")
+        else if (auto* epgg_model = dynamic_cast<const EPlusGGModel*>(&model))
         {
             data->hardwired.positron_annihilation = process_id;
-            model.hardwire(&data->hardwired);
+            data->hardwired.eplusgg               = ModelId{model_idx};
+            data->hardwired.eplusgg_params = epgg_model->device_pointers();
         }
     }
 

--- a/src/physics/base/PhysicsParams.cc
+++ b/src/physics/base/PhysicsParams.cc
@@ -239,7 +239,24 @@ void PhysicsParams::build_ids(const ParticleParams& particles,
         process_groups.push_back(pgroup);
     }
 
-    // TODO: hardwired models
+    // Assign hardwired models that do on-the-fly xs calculation
+    for (auto model_idx : range(this->num_models()))
+    {
+        const Model&    model      = *models_[model_idx].first;
+        const ProcessId process_id = models_[model_idx].second;
+        const Process&  process    = *processes_[process_id.get()];
+        if (process.label() == "Photoelectric effect")
+        {
+            data->hardwired.photoelectric              = process_id;
+            data->hardwired.photoelectric_table_thresh = units::MevEnergy{0.2};
+            model.hardwire(&data->hardwired);
+        }
+        else if (process.label() == "Positron annihiliation")
+        {
+            data->hardwired.positron_annihilation = process_id;
+            model.hardwire(&data->hardwired);
+        }
+    }
 
     CELER_ENSURE(*data);
 }

--- a/src/physics/base/PhysicsStepUtils.hh
+++ b/src/physics/base/PhysicsStepUtils.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "base/Types.hh"
+#include "physics/material/MaterialTrackView.hh"
 #include "ParticleTrackView.hh"
 #include "PhysicsTrackView.hh"
 
@@ -16,8 +17,10 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 // INLINE HELPER FUNCTIONS
 //---------------------------------------------------------------------------//
-inline CELER_FUNCTION real_type calc_tabulated_physics_step(
-    const ParticleTrackView& particle, PhysicsTrackView& physics);
+inline CELER_FUNCTION real_type
+calc_tabulated_physics_step(const MaterialTrackView& material,
+                            const ParticleTrackView& particle,
+                            PhysicsTrackView&        physics);
 
 inline CELER_FUNCTION real_type
 calc_energy_loss(const ParticleTrackView& particle,

--- a/src/physics/base/PhysicsStepUtils.i.hh
+++ b/src/physics/base/PhysicsStepUtils.i.hh
@@ -18,8 +18,10 @@ namespace celeritas
 /*!
  * Calculate physics steps based on cross sections and range limits.
  */
-CELER_FUNCTION real_type calc_tabulated_physics_step(
-    const ParticleTrackView& particle, PhysicsTrackView& physics)
+CELER_FUNCTION real_type
+calc_tabulated_physics_step(const MaterialTrackView& material,
+                            const ParticleTrackView& particle,
+                            PhysicsTrackView&        physics)
 {
     CELER_EXPECT(physics.has_interaction_mfp());
 
@@ -35,7 +37,16 @@ CELER_FUNCTION real_type calc_tabulated_physics_step(
     {
         const ParticleProcessId ppid{pp_idx};
         real_type               process_xs = 0;
-        if (auto grid_id = physics.value_grid(VGT::macro_xs, ppid))
+        if (auto model_id = physics.hardwired_model(particle.energy(), ppid))
+        {
+            // Calculate macroscopic cross section on the fly for special
+            // hardwired processes.
+            auto material_view = material.material_view();
+            process_xs         = physics.calc_xs_otf(
+                model_id, material_view, particle.energy());
+            total_macro_xs += process_xs;
+        }
+        else if (auto grid_id = physics.value_grid(VGT::macro_xs, ppid))
         {
             // Calculate macroscopic cross section for this process, then
             // accumulate it into the total cross section and save the cross
@@ -43,20 +54,6 @@ CELER_FUNCTION real_type calc_tabulated_physics_step(
             auto calc_xs = physics.make_calculator(grid_id);
             process_xs = calc_xs(particle.energy());
             total_macro_xs += process_xs;
-        }
-        else
-        {
-            // TODO: this won't work either because livermore does use
-            // tables above 200 keV.
-            ProcessId process = physics.process(ppid);
-            if (process == physics.photoelectric_process_id())
-            {
-                CELER_NOT_IMPLEMENTED("on-the-fly photoelectric xs");
-            }
-            else if (process == physics.eplusgg_process_id())
-            {
-                CELER_NOT_IMPLEMENTED("on-the-fly positron annihilation xs");
-            }
         }
         physics.per_process_xs(ppid) = process_xs;
 

--- a/src/physics/base/PhysicsStepUtils.i.hh
+++ b/src/physics/base/PhysicsStepUtils.i.hh
@@ -37,7 +37,7 @@ calc_tabulated_physics_step(const MaterialTrackView& material,
     {
         const ParticleProcessId ppid{pp_idx};
         real_type               process_xs = 0;
-        if (auto model_id = physics.hardwired_model(particle.energy(), ppid))
+        if (auto model_id = physics.hardwired_model(ppid, particle.energy()))
         {
             // Calculate macroscopic cross section on the fly for special
             // hardwired processes.

--- a/src/physics/base/PhysicsTrackView.hh
+++ b/src/physics/base/PhysicsTrackView.hh
@@ -94,8 +94,8 @@ class PhysicsTrackView
                                                  ParticleProcessId) const;
 
     // Get hardwired model, null if not present
-    inline CELER_FUNCTION ModelId hardwired_model(MevEnergy energy,
-                                                  ParticleProcessId) const;
+    inline CELER_FUNCTION ModelId hardwired_model(ParticleProcessId ppid,
+                                                  MevEnergy energy) const;
 
     // Models that apply to the given process ID
     inline CELER_FUNCTION

--- a/src/physics/base/PhysicsTrackView.hh
+++ b/src/physics/base/PhysicsTrackView.hh
@@ -13,6 +13,7 @@
 #include "physics/base/Units.hh"
 #include "physics/grid/GridIdFinder.hh"
 #include "physics/grid/PhysicsGridCalculator.hh"
+#include "physics/material/MaterialView.hh"
 #include "physics/material/Types.hh"
 #include "Types.hh"
 
@@ -35,8 +36,8 @@ class PhysicsTrackView
         = PhysicsParamsData<Ownership::const_reference, MemSpace::native>;
     using PhysicsStatePointers
         = PhysicsStateData<Ownership::reference, MemSpace::native>;
-
-    using ModelFinder = GridIdFinder<units::MevEnergy, ModelId>;
+    using MevEnergy   = units::MevEnergy;
+    using ModelFinder = GridIdFinder<MevEnergy, ModelId>;
     //!@}
 
   public:
@@ -92,6 +93,10 @@ class PhysicsTrackView
     inline CELER_FUNCTION ValueGridId value_grid(ValueGridType table,
                                                  ParticleProcessId) const;
 
+    // Get hardwired model, null if not present
+    inline CELER_FUNCTION ModelId hardwired_model(MevEnergy energy,
+                                                  ParticleProcessId) const;
+
     // Models that apply to the given process ID
     inline CELER_FUNCTION
         ModelFinder make_model_finder(ParticleProcessId) const;
@@ -100,6 +105,11 @@ class PhysicsTrackView
 
     // Calculate scaled step range
     inline CELER_FUNCTION real_type range_to_step(real_type range) const;
+
+    // Calculate macroscopic cross section on the fly for the given model
+    inline CELER_FUNCTION real_type calc_xs_otf(ModelId       model,
+                                                MaterialView& material,
+                                                MevEnergy     energy) const;
 
     // Construct a grid calculator from a physics table
     inline CELER_FUNCTION
@@ -113,7 +123,7 @@ class PhysicsTrackView
 
     //// HACKS ////
 
-    // Process ID for photoelectric effect if Livermore model is in use
+    // Process ID for photoelectric effect
     inline CELER_FUNCTION ProcessId photoelectric_process_id() const;
 
     // Process ID for positron annihilation

--- a/src/physics/base/PhysicsTrackView.i.hh
+++ b/src/physics/base/PhysicsTrackView.i.hh
@@ -6,6 +6,8 @@
 //! \file PhysicsTrackView.i.hh
 //---------------------------------------------------------------------------//
 #include "base/Assert.hh"
+#include "physics/em/EPlusGGMacroXsCalculator.hh"
+#include "physics/em/LivermorePEMacroXsCalculator.hh"
 
 namespace celeritas
 {
@@ -200,6 +202,25 @@ CELER_FUNCTION auto PhysicsTrackView::value_grid(ValueGridType     table_type,
 
 //---------------------------------------------------------------------------//
 /*!
+ * Return the model ID that applies to the given process ID and energy if the
+ * process is hardwired to calculate macroscopic cross sections on the fly. If
+ * the result is null, tables should be used for this process/energy.
+ */
+CELER_FUNCTION ModelId PhysicsTrackView::hardwired_model(
+    MevEnergy energy, ParticleProcessId ppid) const
+{
+    ProcessId process = this->process(ppid);
+    if (!(process == this->photoelectric_process_id()
+          && energy < params_.hardwired.photoelectric_table_thresh)
+        && process != this->eplusgg_process_id())
+        return {};
+
+    auto find_model = this->make_model_finder(ppid);
+    return find_model(energy);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Models that apply to the given process ID.
  */
 CELER_FUNCTION auto
@@ -237,6 +258,32 @@ CELER_FUNCTION real_type PhysicsTrackView::range_to_step(real_type range) const
     range = alpha * range + rho * (1 - alpha) * (2 - rho / range);
     CELER_ENSURE(range > 0);
     return range;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate macroscopic cross section on the fly.
+ */
+CELER_FUNCTION real_type PhysicsTrackView::calc_xs_otf(ModelId       model,
+                                                       MaterialView& material,
+                                                       MevEnergy energy) const
+{
+    real_type result = 0.;
+    if (model == params_.hardwired.livermore_pe)
+    {
+        auto calc_xs = LivermorePEMacroXsCalculator(
+            *params_.hardwired.livermore_pe_params, material);
+        result = calc_xs(energy);
+    }
+    else if (model == params_.hardwired.eplusgg)
+    {
+        auto calc_xs = EPlusGGMacroXsCalculator(
+            *params_.hardwired.eplusgg_params, material);
+        result = calc_xs(energy);
+    }
+
+    CELER_ENSURE(result >= 0);
+    return result;
 }
 
 //---------------------------------------------------------------------------//
@@ -280,11 +327,11 @@ real_type PhysicsTrackView::per_process_xs(ParticleProcessId ppid) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Process ID for photoelectric effect if Livermore model is in use.
+ * Process ID for photoelectric effect.
  */
 CELER_FUNCTION ProcessId PhysicsTrackView::photoelectric_process_id() const
 {
-    return params_.hardwired.gamma_photoelectric;
+    return params_.hardwired.photoelectric;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/EPlusGGMacroXsCalculator.hh
+++ b/src/physics/em/EPlusGGMacroXsCalculator.hh
@@ -1,0 +1,49 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file EPlusGGMacroXsCalculator.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Span.hh"
+#include "base/Types.hh"
+#include "physics/em/detail/EPlusGG.hh"
+#include "physics/material/MaterialView.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Calculates the macroscopic cross section.
+ */
+class EPlusGGMacroXsCalculator
+{
+  public:
+    //!@{
+    //! Type aliases
+    using MevEnergy       = units::MevEnergy;
+    using XsUnits         = units::NativeUnit;
+    using EPlusGGPointers = detail::EPlusGGPointers;
+    //!@}
+
+  public:
+    // Construct with shared data and material
+    inline CELER_FUNCTION
+    EPlusGGMacroXsCalculator(const EPlusGGPointers& shared,
+                             const MaterialView&    material);
+
+    // Compute cross section on the fly at the given energy
+    inline CELER_FUNCTION real_type operator()(MevEnergy energy) const;
+
+  private:
+    const real_type electron_mass_;
+    const real_type electron_density_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "EPlusGGMacroXsCalculator.i.hh"

--- a/src/physics/em/EPlusGGMacroXsCalculator.i.hh
+++ b/src/physics/em/EPlusGGMacroXsCalculator.i.hh
@@ -1,0 +1,52 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file EPlusGGPEMacroXsCalculator.i.hh
+//---------------------------------------------------------------------------//
+
+#include "base/Algorithms.hh"
+#include "base/Assert.hh"
+#include "base/Constants.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with material.
+ */
+CELER_FUNCTION EPlusGGMacroXsCalculator::EPlusGGMacroXsCalculator(
+    const EPlusGGPointers& shared, const MaterialView& material)
+    : electron_mass_(shared.electron_mass)
+    , electron_density_(material.electron_density())
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * The Heitler formula (section 10.3.2 of the Geant4 Physics Reference Manual,
+ * Release 10.6)  is used to compute the macroscopic cross section for positron
+ * annihilation on the fly at the given energy.
+ */
+CELER_FUNCTION real_type
+EPlusGGMacroXsCalculator::operator()(MevEnergy energy) const
+{
+    using constants::pi;
+    using constants::re_electron;
+
+    energy                 = max(MevEnergy{1.e-6}, energy);
+    const real_type gamma  = energy.value() / electron_mass_;
+    const real_type g1     = gamma + 1.;
+    const real_type g2     = gamma * (gamma + 2.);
+    real_type       result = electron_density_ * pi * re_electron * re_electron
+                       * ((g1 * (g1 + 4) + 1.) * std::log(g1 + std::sqrt(g2))
+                          - (g1 + 3.) * std::sqrt(g2))
+                       / (g2 * (g1 + 1.));
+
+    CELER_ENSURE(result >= 0);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/EPlusGGMacroXsCalculator.i.hh
+++ b/src/physics/em/EPlusGGMacroXsCalculator.i.hh
@@ -26,7 +26,7 @@ CELER_FUNCTION EPlusGGMacroXsCalculator::EPlusGGMacroXsCalculator(
 //---------------------------------------------------------------------------//
 /*!
  * The Heitler formula (section 10.3.2 of the Geant4 Physics Reference Manual,
- * Release 10.6)  is used to compute the macroscopic cross section for positron
+ * Release 10.6) is used to compute the macroscopic cross section for positron
  * annihilation on the fly at the given energy.
  */
 CELER_FUNCTION real_type

--- a/src/physics/em/EPlusGGModel.cc
+++ b/src/physics/em/EPlusGGModel.cc
@@ -74,14 +74,4 @@ ModelId EPlusGGModel::model_id() const
 }
 
 //---------------------------------------------------------------------------//
-/*!
- * Hardwire model data used for on-the-fly macro xs calculations.
- */
-void EPlusGGModel::hardwire(HardwiredModels* hardwired) const
-{
-    hardwired->eplusgg        = this->model_id();
-    hardwired->eplusgg_params = &interface_;
-}
-
-//---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/physics/em/EPlusGGModel.cc
+++ b/src/physics/em/EPlusGGModel.cc
@@ -74,4 +74,14 @@ ModelId EPlusGGModel::model_id() const
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Hardwire model data used for on-the-fly macro xs calculations.
+ */
+void EPlusGGModel::hardwire(HardwiredModels* hardwired) const
+{
+    hardwired->eplusgg        = this->model_id();
+    hardwired->eplusgg_params = &interface_;
+}
+
+//---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/physics/em/EPlusGGModel.hh
+++ b/src/physics/em/EPlusGGModel.hh
@@ -36,6 +36,9 @@ class EPlusGGModel final : public Model
     //! Name of the model, for user interaction
     std::string label() const final { return "Positron annihilation (2g)"; }
 
+    // Hardwire data for models that calculate macro xs on the fly
+    void hardwire(HardwiredModels* hardwired) const final;
+
   private:
     detail::EPlusGGPointers interface_;
 };

--- a/src/physics/em/EPlusGGModel.hh
+++ b/src/physics/em/EPlusGGModel.hh
@@ -36,8 +36,8 @@ class EPlusGGModel final : public Model
     //! Name of the model, for user interaction
     std::string label() const final { return "Positron annihilation (2g)"; }
 
-    // Hardwire data for models that calculate macro xs on the fly
-    void hardwire(HardwiredModels* hardwired) const final;
+    // Access data on device
+    detail::EPlusGGPointers device_pointers() const { return interface_; }
 
   private:
     detail::EPlusGGPointers interface_;

--- a/src/physics/em/LivermorePEInterface.hh
+++ b/src/physics/em/LivermorePEInterface.hh
@@ -21,8 +21,12 @@ namespace celeritas
  */
 struct LivermoreSubshell
 {
+    using EnergyUnits = units::Mev;
+    using XsUnits     = units::Barn;
+    using Energy      = Quantity<EnergyUnits>;
+
     // Binding energy of the electron
-    units::MevEnergy binding_energy;
+    Energy binding_energy;
 
     // Tabulated subshell photoionization cross section (used below 5 keV)
     // TODO: value grid
@@ -40,6 +44,8 @@ struct LivermoreSubshell
  */
 struct LivermoreElement
 {
+    using Energy = LivermoreSubshell::Energy;
+
     // TOTAL CROSS SECTIONS
 
     // Total cross section below the K-shell energy. Uses linear interpolation.
@@ -58,8 +64,8 @@ struct LivermoreElement
 
     // Energy threshold for using the parameterized subshell cross sections in
     // the lower and upper energy range
-    units::MevEnergy thresh_low;
-    units::MevEnergy thresh_high;
+    Energy thresh_low;
+    Energy thresh_high;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/LivermorePEMacroXsCalculator.hh
+++ b/src/physics/em/LivermorePEMacroXsCalculator.hh
@@ -1,0 +1,52 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file LivermorePEMacroXsCalculator.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Span.hh"
+#include "base/Types.hh"
+#include "physics/material/MaterialView.hh"
+#include "physics/em/detail/LivermorePE.hh"
+#include "physics/em/detail/LivermorePEMicroXsCalculator.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Calculates the macroscopic cross section.
+ */
+class LivermorePEMacroXsCalculator
+{
+  public:
+    //!@{
+    //! Type aliases
+    using Energy              = detail::LivermorePEMicroXsCalculator::Energy;
+    using MicroXsUnits        = detail::LivermorePEMicroXsCalculator::XsUnits;
+    using XsUnits             = units::NativeUnit;
+    using LivermorePEPointers = detail::LivermorePEPointers;
+    //!@}
+
+  public:
+    // Construct with shared data and material
+    inline CELER_FUNCTION
+    LivermorePEMacroXsCalculator(const LivermorePEPointers& shared,
+                                 const MaterialView&        material);
+
+    // Compute cross section on the fly at the given energy
+    inline CELER_FUNCTION real_type operator()(Energy energy) const;
+
+  private:
+    const LivermorePEPointers&      shared_;
+    Span<const MatElementComponent> elements_;
+    real_type                       number_density_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "LivermorePEMacroXsCalculator.i.hh"

--- a/src/physics/em/LivermorePEMacroXsCalculator.i.hh
+++ b/src/physics/em/LivermorePEMacroXsCalculator.i.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file LivermorePEMacroXsCalculator.i.hh
+//---------------------------------------------------------------------------//
+
+#include "base/Assert.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with material and micro xs calculator.
+ */
+CELER_FUNCTION LivermorePEMacroXsCalculator::LivermorePEMacroXsCalculator(
+    const LivermorePEPointers& shared, const MaterialView& material)
+    : shared_(shared)
+    , elements_(material.elements())
+    , number_density_(material.number_density())
+{
+    CELER_EXPECT(!elements_.empty());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Compute macroscopic cross section for the photoelectric effect on the fly at
+ * the given energy.
+ */
+CELER_FUNCTION real_type
+LivermorePEMacroXsCalculator::operator()(Energy energy) const
+{
+    real_type                            result = 0.;
+    detail::LivermorePEMicroXsCalculator calc_micro_xs(shared_, energy);
+    for (const auto& el_comp : elements_)
+    {
+        const real_type micro_xs = calc_micro_xs(el_comp.element);
+        CELER_ASSERT(micro_xs >= 0);
+        result += micro_xs * el_comp.fraction;
+    }
+    result *= MicroXsUnits::value() * number_density_;
+    CELER_ENSURE(result >= 0);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/em/LivermorePEModel.cc
+++ b/src/physics/em/LivermorePEModel.cc
@@ -87,14 +87,4 @@ ModelId LivermorePEModel::model_id() const
 }
 
 //---------------------------------------------------------------------------//
-/*!
- * Hardwire model data used for on-the-fly macro xs calculations.
- */
-void LivermorePEModel::hardwire(HardwiredModels* hardwired) const
-{
-    hardwired->livermore_pe        = this->model_id();
-    hardwired->livermore_pe_params = &interface_;
-}
-
-//---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/physics/em/LivermorePEModel.cc
+++ b/src/physics/em/LivermorePEModel.cc
@@ -46,9 +46,7 @@ LivermorePEModel::LivermorePEModel(
     const AtomicRelaxationParams& atomic_relaxation)
     : LivermorePEModel(id, particles, data)
 {
-    interface_.atomic_relaxation = celeritas::device()
-                                       ? atomic_relaxation.device_pointers()
-                                       : atomic_relaxation.host_pointers();
+    interface_.atomic_relaxation = atomic_relaxation.device_pointers();
 }
 
 //---------------------------------------------------------------------------//
@@ -86,6 +84,16 @@ void LivermorePEModel::interact(
 ModelId LivermorePEModel::model_id() const
 {
     return interface_.model_id;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Hardwire model data used for on-the-fly macro xs calculations.
+ */
+void LivermorePEModel::hardwire(HardwiredModels* hardwired) const
+{
+    hardwired->livermore_pe        = this->model_id();
+    hardwired->livermore_pe_params = &interface_;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/LivermorePEModel.hh
+++ b/src/physics/em/LivermorePEModel.hh
@@ -45,8 +45,8 @@ class LivermorePEModel final : public Model
     //! Name of the model, for user interaction
     std::string label() const final { return "Livermore photoelectric"; }
 
-    // Hardwire data for models that calculate macro xs on the fly
-    void hardwire(HardwiredModels* hardwired) const final;
+    // Access data on device
+    detail::LivermorePEPointers device_pointers() const { return interface_; }
 
   private:
     detail::LivermorePEPointers interface_;

--- a/src/physics/em/LivermorePEModel.hh
+++ b/src/physics/em/LivermorePEModel.hh
@@ -45,6 +45,9 @@ class LivermorePEModel final : public Model
     //! Name of the model, for user interaction
     std::string label() const final { return "Livermore photoelectric"; }
 
+    // Hardwire data for models that calculate macro xs on the fly
+    void hardwire(HardwiredModels* hardwired) const final;
+
   private:
     detail::LivermorePEPointers interface_;
 };

--- a/src/physics/em/LivermorePEParams.hh
+++ b/src/physics/em/LivermorePEParams.hh
@@ -24,12 +24,15 @@ class LivermorePEParams
   public:
     //@{
     //! Type aliases
-    using MevEnergy = units::MevEnergy;
     //@}
 
     struct SubshellInput
     {
-        MevEnergy              binding_energy; //!< Ionization energy
+        using EnergyUnits = units::Mev;
+        using XsUnits     = units::Barn;
+        using Energy      = Quantity<EnergyUnits>;
+
+        Energy                 binding_energy; //!< Ionization energy
         std::vector<real_type> param_low;  //!< Low energy xs fit parameters
         std::vector<real_type> param_high; //!< High energy xs fit parameters
         std::vector<real_type> xs;         //!< Tabulated cross sections
@@ -38,13 +41,12 @@ class LivermorePEParams
 
     struct ElementInput
     {
-        using EnergyUnits = units::Mev;
-        using XsUnits     = units::Barn;
+        using Energy = SubshellInput::Energy;
 
         ImportPhysicsVector xs_low;      //!< Low energy range tabulated xs
         ImportPhysicsVector xs_high;     //!< High energy range tabulated xs
-        MevEnergy           thresh_low;  //!< Threshold for low energy fit
-        MevEnergy           thresh_high; //!< Threshold for high energy fit
+        Energy              thresh_low;  //!< Threshold for low energy fit
+        Energy              thresh_high; //!< Threshold for high energy fit
         std::vector<SubshellInput> shells;
     };
 

--- a/src/physics/em/PhotoelectricProcess.hh
+++ b/src/physics/em/PhotoelectricProcess.hh
@@ -32,10 +32,15 @@ class PhotoelectricProcess : public Process
 
   public:
     // Construct from Livermore photoelectric data
-    PhotoelectricProcess(SPConstParticles particles, SPConstData data);
+    PhotoelectricProcess(SPConstParticles   particles,
+                         ImportPhysicsTable xs_lo,
+                         ImportPhysicsTable xs_hi,
+                         SPConstData        data);
 
     // Construct from Livermore data and EADL atomic relaxation data
     PhotoelectricProcess(SPConstParticles   particles,
+                         ImportPhysicsTable xs_lo,
+                         ImportPhysicsTable xs_hi,
                          SPConstData        data,
                          SPConstAtomicRelax atomic_relaxation);
 
@@ -50,6 +55,8 @@ class PhotoelectricProcess : public Process
 
   private:
     SPConstParticles   particles_;
+    ImportPhysicsTable xs_lo_;
+    ImportPhysicsTable xs_hi_;
     SPConstData        data_;
     SPConstAtomicRelax atomic_relaxation_;
 };

--- a/src/physics/em/detail/LivermorePE.cu
+++ b/src/physics/em/detail/LivermorePE.cu
@@ -53,9 +53,10 @@ __global__ void livermore_pe_interact_kernel(const LivermorePEPointers   pe,
     RngEngine rng(ptrs.states.rng, tid);
 
     // Sample an element
-    ElementSelector    select_el(material.material_view(),
-                              LivermorePEMicroXsCalculator{pe, particle},
-                              material.element_scratch());
+    ElementSelector select_el(
+        material.material_view(),
+        LivermorePEMicroXsCalculator{pe, particle.energy()},
+        material.element_scratch());
     ElementComponentId comp_id = select_el(rng);
     ElementId          el_id   = material.material_view().element_id(comp_id);
 

--- a/src/physics/em/detail/LivermorePEInteractor.i.hh
+++ b/src/physics/em/detail/LivermorePEInteractor.i.hh
@@ -33,7 +33,7 @@ LivermorePEInteractor::LivermorePEInteractor(const LivermorePEPointers& shared,
     , inc_direction_(inc_direction)
     , inc_energy_(particle.energy().value())
     , allocate_(allocate)
-    , calc_micro_xs_(shared, particle)
+    , calc_micro_xs_(shared, particle.energy())
 {
     CELER_EXPECT(particle.particle_id() == shared_.gamma_id);
     CELER_EXPECT(inc_energy_.value() > 0);
@@ -165,7 +165,7 @@ CELER_FUNCTION Real3 LivermorePEInteractor::sample_direction(Engine& rng) const
     }
     else if (inc_energy_ < min_energy)
     {
-        // If the incident energy is below 1 keV, set it to 1 keV.
+        // If the incident energy is below 1 eV, set it to 1 eV.
         energy_per_mecsq = min_energy.value() * shared_.inv_electron_mass;
     }
     else

--- a/src/physics/em/detail/LivermorePEMicroXsCalculator.hh
+++ b/src/physics/em/detail/LivermorePEMicroXsCalculator.hh
@@ -27,14 +27,15 @@ class LivermorePEMicroXsCalculator
   public:
     //!@{
     //! Type aliases
-    using MevEnergy = units::MevEnergy;
+    using XsUnits = LivermoreSubshell::XsUnits;
+    using Energy  = Quantity<LivermoreSubshell::EnergyUnits>;
     //!@}
 
   public:
     // Construct with shared and state data
     inline CELER_FUNCTION
     LivermorePEMicroXsCalculator(const LivermorePEPointers& shared,
-                                 const ParticleTrackView&   particle);
+                                 Energy                     energy);
 
     // Compute cross section
     inline CELER_FUNCTION real_type operator()(ElementId el_id) const;
@@ -43,7 +44,7 @@ class LivermorePEMicroXsCalculator
     // Shared constant physics properties
     const LivermorePEPointers& shared_;
     // Incident gamma energy
-    const MevEnergy inc_energy_;
+    const Energy inc_energy_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/LivermorePEMicroXsCalculator.i.hh
+++ b/src/physics/em/detail/LivermorePEMicroXsCalculator.i.hh
@@ -18,10 +18,9 @@ namespace detail
  * Construct with shared and state data.
  */
 CELER_FUNCTION LivermorePEMicroXsCalculator::LivermorePEMicroXsCalculator(
-    const LivermorePEPointers& shared, const ParticleTrackView& particle)
-    : shared_(shared), inc_energy_(particle.energy().value())
+    const LivermorePEPointers& shared, Energy energy)
+    : shared_(shared), inc_energy_(energy.value())
 {
-    CELER_EXPECT(particle.particle_id() == shared_.gamma_id);
 }
 
 //---------------------------------------------------------------------------//
@@ -37,7 +36,7 @@ real_type LivermorePEMicroXsCalculator::operator()(ElementId el_id) const
     // In Geant4, if the incident gamma energy is below the lowest binding
     // energy, it is set to the binding energy so that the photoelectric cross
     // section is constant rather than zero for low energy gammas.
-    MevEnergy energy     = max(inc_energy_, el.shells.back().binding_energy);
+    Energy    energy     = max(inc_energy_, el.shells.back().binding_energy);
     real_type inv_energy = 1. / energy.value();
 
     real_type result = 0.;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,7 +174,7 @@ set(CELERITASTEST_LINK_LIBRARIES CeleritasPhysicsTest)
 celeritas_setup_tests(SERIAL PREFIX physics/base)
 celeritas_cudaoptional_test(physics/base/Particle)
 celeritas_cudaoptional_test(physics/base/Physics)
-celeritas_add_test(physics/base/PhysicsStepUtils.test.cc ${_not_impl})
+celeritas_add_test(physics/base/PhysicsStepUtils.test.cc)
 
 celeritas_setup_tests(SERIAL PREFIX physics/grid)
 celeritas_add_test(physics/grid/GridIdFinder.test.cc)

--- a/test/physics/base/PhysicsStepUtils.test.cc
+++ b/test/physics/base/PhysicsStepUtils.test.cc
@@ -26,6 +26,7 @@ class PhysicsStepUtilsTest : public PhysicsTestBase
     using Base = PhysicsTestBase;
 
   protected:
+    using MaterialStateStore = PieStateStore<MaterialStateData, MemSpace::host>;
     using ParticleStateStore = PieStateStore<ParticleStateData, MemSpace::host>;
     using PhysicsStateStore  = PieStateStore<PhysicsStateData, MemSpace::host>;
 
@@ -34,10 +35,12 @@ class PhysicsStepUtilsTest : public PhysicsTestBase
         Base::SetUp();
 
         // Construct state for a single host thread
+        mat_state  = MaterialStateStore(*this->materials(), 1);
         par_state  = ParticleStateStore(*this->particles(), 1);
         phys_state = PhysicsStateStore(*this->physics(), 1);
     }
 
+    MaterialStateStore mat_state;
     ParticleStateStore par_state;
     PhysicsStateStore  phys_state;
 };
@@ -48,25 +51,83 @@ class PhysicsStepUtilsTest : public PhysicsTestBase
 
 TEST_F(PhysicsStepUtilsTest, calc_tabulated_physics_step)
 {
+    MaterialTrackView material(
+        this->materials()->host_pointers(), mat_state.ref(), ThreadId{0});
     ParticleTrackView particle(
         this->particles()->host_pointers(), par_state.ref(), ThreadId{0});
-    PhysicsTrackView                 phys(this->physics()->host_pointers(),
-                          phys_state.ref(),
-                          ParticleId{0},
-                          MaterialId{0},
-                          ThreadId{0});
+    MaterialTrackView::Initializer_t mat_init;
     ParticleTrackView::Initializer_t par_init;
-    PhysicsTrackView::Initializer_t  phys_init;
 
-    // XXX add tests for a variety of energy ranges and multiple material IDs
+    // Test a variety of energy ranges and multiple material IDs
     {
-        par_init.energy      = MevEnergy{1e3};
-        par_init.particle_id = particles()->find("celeriton");
+        mat_init.material_id = MaterialId{0};
+        par_init.energy      = MevEnergy{1};
+        par_init.particle_id = this->particles()->find("gamma");
+        material             = mat_init;
         particle             = par_init;
-        phys                 = phys_init;
+        PhysicsTrackView phys(this->physics()->host_pointers(),
+                              phys_state.ref(),
+                              par_init.particle_id,
+                              mat_init.material_id,
+                              ThreadId{0});
+        phys.interaction_mfp(1);
+        real_type step
+            = celeritas::calc_tabulated_physics_step(material, particle, phys);
+        EXPECT_SOFT_EQ(1. / 3.e-4, step);
+    }
+    {
+        mat_init.material_id = MaterialId{1};
+        par_init.energy      = MevEnergy{10};
+        par_init.particle_id = this->particles()->find("celeriton");
+        material             = mat_init;
+        particle             = par_init;
+        PhysicsTrackView phys(this->physics()->host_pointers(),
+                              phys_state.ref(),
+                              par_init.particle_id,
+                              mat_init.material_id,
+                              ThreadId{0});
+        phys.interaction_mfp(1e-2);
+        real_type step
+            = celeritas::calc_tabulated_physics_step(material, particle, phys);
+        EXPECT_SOFT_EQ(1.e-2 / 9.e-3, step);
 
-        real_type step = celeritas::calc_tabulated_physics_step(particle, phys);
-        EXPECT_EQ(0, step);
+        // Increase the distance to interaction so range limits the step length
+        phys.interaction_mfp(1);
+        step = celeritas::calc_tabulated_physics_step(material, particle, phys);
+        EXPECT_SOFT_EQ(4.1595999999999984, step);
+
+        // Decrease the particle energy
+        par_init.energy = MevEnergy{1e-2};
+        particle        = par_init;
+        step = celeritas::calc_tabulated_physics_step(material, particle, phys);
+        EXPECT_SOFT_EQ(2.e-2, step);
+    }
+    {
+        mat_init.material_id = MaterialId{2};
+        par_init.energy      = MevEnergy{1e-2};
+        par_init.particle_id = this->particles()->find("anti-celeriton");
+        material             = mat_init;
+        particle             = par_init;
+        PhysicsTrackView phys(this->physics()->host_pointers(),
+                              phys_state.ref(),
+                              par_init.particle_id,
+                              mat_init.material_id,
+                              ThreadId{0});
+        phys.interaction_mfp(1e-2);
+        real_type step
+            = celeritas::calc_tabulated_physics_step(material, particle, phys);
+        EXPECT_SOFT_EQ(1.e-2 / 9.e-1, step);
+
+        // Increase the distance to interaction so range limits the step length
+        phys.interaction_mfp(1);
+        step = celeritas::calc_tabulated_physics_step(material, particle, phys);
+        EXPECT_SOFT_EQ(0.03, step);
+
+        // Increase the particle energy so interaction limits the step length
+        par_init.energy = MevEnergy{10};
+        particle        = par_init;
+        step = celeritas::calc_tabulated_physics_step(material, particle, phys);
+        EXPECT_SOFT_EQ(1. / 9.e-1, step);
     }
 }
 

--- a/test/physics/em/EPlusGG.test.cc
+++ b/test/physics/em/EPlusGG.test.cc
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/detail/EPlusGGInteractor.hh"
 
-#include <fstream>
 #include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
@@ -269,17 +268,17 @@ TEST_F(EPlusGGInteractorTest, macro_xs)
     auto                     material = this->material_track().material_view();
     EPlusGGMacroXsCalculator calc_macro_xs(pointers_, material);
 
-    int    num_points = 20;
-    double loge_min   = std::log(1.e-4);
-    double loge_max   = std::log(1.e6);
-    double delta      = (loge_max - loge_min) / (num_points - 1);
-    double loge       = loge_min;
+    int    num_vals = 20;
+    double loge_min = std::log(1.e-4);
+    double loge_max = std::log(1.e6);
+    double delta    = (loge_max - loge_min) / (num_vals - 1);
+    double loge     = loge_min;
 
     std::vector<double> energy;
     std::vector<double> macro_xs;
 
-    // Loop over many energies
-    for (int i = 0; i < num_points; ++i)
+    // Loop over energies
+    for (int i = 0; i < num_vals; ++i)
     {
         double e = std::exp(loge);
         energy.push_back(e);

--- a/test/physics/em/EPlusGG.test.cc
+++ b/test/physics/em/EPlusGG.test.cc
@@ -7,13 +7,18 @@
 //---------------------------------------------------------------------------//
 #include "physics/em/detail/EPlusGGInteractor.hh"
 
+#include <fstream>
 #include "celeritas_test.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "physics/base/Units.hh"
+#include "physics/em/EPlusGGMacroXsCalculator.hh"
+#include "physics/material/MaterialTrackView.hh"
 #include "../InteractorHostTestBase.hh"
 #include "../InteractionIO.hh"
 
+using celeritas::ElementId;
+using celeritas::EPlusGGMacroXsCalculator;
 using celeritas::detail::EPlusGGInteractor;
 namespace pdg = celeritas::pdg;
 
@@ -28,8 +33,10 @@ class EPlusGGInteractorTest : public celeritas_test::InteractorHostTestBase
   protected:
     void SetUp() override
     {
+        using celeritas::MatterState;
         using celeritas::ParticleDef;
         using namespace celeritas::units;
+        using namespace celeritas::constants;
         constexpr auto zero   = celeritas::zero_quantity();
         constexpr auto stable = ParticleDef::stable_decay_constant();
 
@@ -50,6 +57,19 @@ class EPlusGGInteractorTest : public celeritas_test::InteractorHostTestBase
         pointers_.positron_id   = params.find(pdg::positron());
         pointers_.gamma_id      = params.find(pdg::gamma());
         pointers_.electron_mass = 0.5109989461;
+
+        // Set up shared material data
+        MaterialParams::Input mi;
+        mi.elements  = {{19, AmuMass{39.0983}, "K"}};
+        mi.materials = {{1e-5 * na_avogadro,
+                         293.,
+                         MatterState::solid,
+                         {{ElementId{0}, 1.0}},
+                         "K"}};
+
+        // Set default material to potassium
+        this->set_material_params(mi);
+        this->set_material("K");
 
         // Set default particle to incident 10 MeV positron
         this->set_inc_particle(pdg::positron(), MevEnergy{10});
@@ -240,4 +260,39 @@ TEST_F(EPlusGGInteractorTest, stress_test)
     const double expected_avg_engine_samples[]
         = {4, 10.08703613281, 19.54248046875, 22.75891113281, 35.08276367188};
     EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
+}
+
+TEST_F(EPlusGGInteractorTest, macro_xs)
+{
+    using celeritas::units::MevEnergy;
+
+    auto                     material = this->material_track().material_view();
+    EPlusGGMacroXsCalculator calc_macro_xs(pointers_, material);
+
+    int    num_points = 20;
+    double loge_min   = std::log(1.e-4);
+    double loge_max   = std::log(1.e6);
+    double delta      = (loge_max - loge_min) / (num_points - 1);
+    double loge       = loge_min;
+
+    std::vector<double> energy;
+    std::vector<double> macro_xs;
+
+    // Loop over many energies
+    for (int i = 0; i < num_points; ++i)
+    {
+        double e = std::exp(loge);
+        energy.push_back(e);
+        macro_xs.push_back(calc_macro_xs(MevEnergy{e}));
+        loge += delta;
+    }
+    const double expected_macro_xs[]
+        = {0.001443034416941,  0.0007875334997718, 0.0004301446502063,
+           0.0002355766377589, 0.0001301463511539, 7.376415204169e-05,
+           4.419813786948e-05, 2.746581269388e-05, 1.508499252627e-05,
+           6.80154666357e-06,  2.782643662379e-06, 1.083362674122e-06,
+           4.039064800964e-07, 1.451975852737e-07, 5.07363090171e-08,
+           1.734848791099e-08, 5.833443676789e-09, 1.93572917075e-09,
+           6.355265134801e-10, 2.068312058021e-10};
+    EXPECT_VEC_SOFT_EQ(expected_macro_xs, macro_xs);
 }

--- a/test/physics/em/LivermorePE.test.cc
+++ b/test/physics/em/LivermorePE.test.cc
@@ -14,6 +14,7 @@
 #include "base/Range.hh"
 #include "comm/Device.hh"
 #include "io/AtomicRelaxationReader.hh"
+#include "io/ImportPhysicsTable.hh"
 #include "io/LivermorePEParamsReader.hh"
 #include "physics/base/Units.hh"
 #include "physics/em/AtomicRelaxationParams.hh"
@@ -21,17 +22,25 @@
 #include "physics/em/LivermorePEParams.hh"
 #include "physics/em/PhotoelectricProcess.hh"
 #include "physics/em/LivermorePEMacroXsCalculator.hh"
+#include "physics/grid/PhysicsGridCalculator.hh"
+#include "physics/grid/ValueGridBuilder.hh"
+#include "physics/grid/ValueGridInserter.hh"
 #include "physics/material/MaterialTrackView.hh"
 #include "../InteractorHostTestBase.hh"
 #include "../InteractionIO.hh"
 
+using celeritas::Applicability;
 using celeritas::AtomicRelaxationParams;
 using celeritas::AtomicRelaxationReader;
 using celeritas::ElementId;
+using celeritas::ImportPhysicsTable;
+using celeritas::ImportPhysicsVectorType;
+using celeritas::ImportTableType;
 using celeritas::LivermorePEMacroXsCalculator;
 using celeritas::LivermorePEParams;
 using celeritas::LivermorePEParamsReader;
 using celeritas::PhotoelectricProcess;
+using celeritas::ValueGridInserter;
 using celeritas::detail::LivermorePEInteractor;
 namespace pdg = celeritas::pdg;
 
@@ -248,7 +257,7 @@ TEST_F(LivermorePEInteractorTest, stress_test)
             for (int i = 0; i < num_samples; ++i)
             {
                 Interaction result = interact(rng_engine);
-                // SCOPED_TRACE(result);
+                SCOPED_TRACE(result);
                 this->sanity_check(result);
             }
             EXPECT_EQ(num_samples, this->secondary_allocator().get().size());
@@ -418,17 +427,59 @@ TEST_F(LivermorePEInteractorTest, distributions_radiative)
 
 TEST_F(LivermorePEInteractorTest, model)
 {
+    using celeritas::MemSpace;
+    using celeritas::Ownership;
+    using celeritas::Pie;
+
     // Model is constructed with device pointers
     if (!celeritas::device())
     {
         SKIP("CUDA is disabled");
     }
 
-    PhotoelectricProcess process(
-        this->get_particle_params(), livermore_params_, relax_params_);
-    ModelIdGenerator     next_id;
+    // Create physics tables
+    ImportPhysicsTable xs_lo;
+    xs_lo.table_type = ImportTableType::lambda;
+    xs_lo.physics_vectors.push_back(
+        {ImportPhysicsVectorType::log, {1e-2, 1, 1e2}, {1e-1, 1e-3, 1e-5}});
+
+    ImportPhysicsTable xs_hi;
+    xs_hi.table_type = ImportTableType::lambda_prim;
+    xs_hi.physics_vectors.push_back(
+        {ImportPhysicsVectorType::log, {1e2, 1e4, 1e6}, {1e-3, 1e-3, 1e-3}});
+
+    // Add atomic relaxation data
+    relax_inp_.is_auger_enabled = true;
+    set_relaxation_params(relax_inp_);
+
+    PhotoelectricProcess process(this->get_particle_params(),
+                                 xs_lo,
+                                 xs_hi,
+                                 livermore_params_,
+                                 relax_params_);
+
+    Applicability range    = {MaterialId{0},
+                           this->particle_params().find(pdg::gamma()),
+                           celeritas::zero_quantity(),
+                           celeritas::max_quantity()};
+    auto          builders = process.step_limits(range);
+
+    Pie<double, Ownership::value, MemSpace::host>                real_storage;
+    Pie<celeritas::XsGridData, Ownership::value, MemSpace::host> grid_storage;
+
+    ValueGridInserter insert(&real_storage, &grid_storage);
+    builders[int(celeritas::ValueGridType::macro_xs)]->build(insert);
+    EXPECT_EQ(1, grid_storage.size());
+
+    // Test cross sections calculated from tables
+    celeritas::PhysicsGridCalculator calc_xs(
+        grid_storage[ValueGridInserter::XsIndex{0}], real_storage);
+    EXPECT_SOFT_EQ(0.1, calc_xs(MevEnergy{1e-3}));
+    EXPECT_SOFT_EQ(1e-5, calc_xs(MevEnergy{1e2}));
+    EXPECT_SOFT_EQ(1e-9, calc_xs(MevEnergy{1e6}));
 
     // Construct the models associated with the photoelectric effect
+    ModelIdGenerator next_id;
     auto models = process.build_models(next_id);
     EXPECT_EQ(1, models.size());
 
@@ -453,17 +504,17 @@ TEST_F(LivermorePEInteractorTest, macro_xs)
     auto material = this->material_track().material_view();
     LivermorePEMacroXsCalculator calc_macro_xs(pointers_, material);
 
-    int    num_points = 20;
-    double loge_min   = std::log(1.e-4);
-    double loge_max   = std::log(1.e6);
-    double delta      = (loge_max - loge_min) / (num_points - 1);
-    double loge       = loge_min;
+    int    num_vals = 20;
+    double loge_min = std::log(1.e-4);
+    double loge_max = std::log(1.e6);
+    double delta    = (loge_max - loge_min) / (num_vals - 1);
+    double loge     = loge_min;
 
     std::vector<double> energy;
     std::vector<double> macro_xs;
 
-    // Loop over many energies
-    for (int i = 0; i < num_points; ++i)
+    // Loop over energies
+    for (int i = 0; i < num_vals; ++i)
     {
         double e = std::exp(loge);
         energy.push_back(e);


### PR DESCRIPTION
This add the missing pieces to `calc_tabulated_physics_step` in PhysicsStepUtils.hh (for #125):
  * Add macroscopic cross section calculators for the photoelectric effect and positron annihilation models
  * Hardwire those processes to compute macro xs on the fly when calculating step length