### PR TITLE
Atomic relaxation updates

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ list(APPEND SOURCES
   physics/em/GammaConversionProcess.cc
   physics/em/KleinNishinaModel.cc
   physics/em/MollerBhabhaModel.cc
+  physics/em/detail/Utils.cc
   physics/grid/ValueGridBuilder.cc
   physics/grid/ValueGridInserter.cc
   physics/material/MaterialParams.cc

--- a/src/base/StackAllocatorView.i.hh
+++ b/src/base/StackAllocatorView.i.hh
@@ -24,7 +24,7 @@ CELER_FUNCTION StackAllocatorView<T>::StackAllocatorView(const Pointers& shared)
 
 //---------------------------------------------------------------------------//
 /*!
- * Allocate space for a given number of itemss.
+ * Allocate space for a given number of items.
  *
  * Returns NULL if allocation failed due to out-of-memory. Ensures that the
  * shared size reflects the amount of data allocated

--- a/src/physics/em/AtomicRelaxation.hh
+++ b/src/physics/em/AtomicRelaxation.hh
@@ -60,7 +60,7 @@ class AtomicRelaxation
     SubshellId shell_id_;
     // Fluorescence photons and Auger electrons
     Span<Secondary> secondaries_;
-    // Stack to store unprocessed subshell vacancies
+    // Storage for stack of unprocessed subshell vacancies
     Span<SubshellId> vacancies_;
     // The number of secondaries already created by the primary process
     size_type base_size_;

--- a/src/physics/em/AtomicRelaxation.hh
+++ b/src/physics/em/AtomicRelaxation.hh
@@ -44,6 +44,7 @@ class AtomicRelaxation
                      ElementId                        el_id,
                      SubshellId                       shell_id,
                      Span<Secondary>                  secondaries,
+                     Span<SubshellId>                 vacancies,
                      size_type                        base_size = 0);
 
     // Simulate atomic relaxation with an initial vacancy in the given shell ID
@@ -59,6 +60,8 @@ class AtomicRelaxation
     SubshellId shell_id_;
     // Fluorescence photons and Auger electrons
     Span<Secondary> secondaries_;
+    // Stack to store unprocessed subshell vacancies
+    Span<SubshellId> vacancies_;
     // The number of secondaries already created by the primary process
     size_type base_size_;
     // Angular distribution of secondaries

--- a/src/physics/em/AtomicRelaxation.i.hh
+++ b/src/physics/em/AtomicRelaxation.i.hh
@@ -21,12 +21,14 @@ CELER_FUNCTION
 AtomicRelaxation::AtomicRelaxation(const AtomicRelaxParamsPointers& shared,
                                    ElementId                        el_id,
                                    SubshellId                       shell_id,
-                                   Span<Secondary> secondaries,
-                                   size_type       base_size)
+                                   Span<Secondary>  secondaries,
+                                   Span<SubshellId> vacancies,
+                                   size_type        base_size)
     : shared_(shared)
     , el_id_(el_id)
     , shell_id_(shell_id)
     , secondaries_(secondaries)
+    , vacancies_(vacancies)
     , base_size_(base_size)
 {
     CELER_EXPECT(!shared_ || el_id_ < shared_.elements.size());
@@ -61,8 +63,7 @@ AtomicRelaxation::operator()(Engine& rng)
     // transition data for a given element (19 for Z = 100). But in practice
     // that won't happen, and we could probably bound it closer to 5 for even
     // the highest Z.
-    Array<SubshellId, 10> vacancy_storage;
-    MiniStack<SubshellId> vacancies(make_span(vacancy_storage));
+    MiniStack<SubshellId> vacancies(vacancies_);
     vacancies.push(shell_id_);
 
     // Total number of secondaries

--- a/src/physics/em/AtomicRelaxationHelper.i.hh
+++ b/src/physics/em/AtomicRelaxationHelper.i.hh
@@ -55,7 +55,7 @@ Span<Secondary> AtomicRelaxationHelper::allocate_secondaries() const
 CELER_FUNCTION
 Span<SubshellId> AtomicRelaxationHelper::allocate_vacancies() const
 {
-    size_type   size;
+    size_type   size      = 0;
     SubshellId* vacancies = nullptr;
     if (*this)
     {
@@ -63,10 +63,9 @@ Span<SubshellId> AtomicRelaxationHelper::allocate_vacancies() const
         SubshellIdAllocatorView allocate(vacancies_);
         size      = shared_.elements[el_id_.get()].max_stack_size;
         vacancies = allocate(size);
+        if (vacancies == nullptr)
+            size = 0;
     }
-
-    if (vacancies == nullptr)
-        size = 0;
 
     return {vacancies, size};
 }

--- a/src/physics/em/AtomicRelaxationHelper.i.hh
+++ b/src/physics/em/AtomicRelaxationHelper.i.hh
@@ -14,11 +14,16 @@ namespace celeritas
  */
 CELER_FUNCTION
 AtomicRelaxationHelper::AtomicRelaxationHelper(
-    const AtomicRelaxParamsPointers& shared,
-    ElementId                        el_id,
-    SecondaryAllocatorView&          allocate,
-    size_type                        base_size)
-    : shared_(shared), el_id_(el_id), allocate_(allocate), base_size_(base_size)
+    const AtomicRelaxParamsPointers&   shared,
+    const SubshellIdAllocatorPointers& vacancies,
+    ElementId                          el_id,
+    SecondaryAllocatorView&            allocate,
+    size_type                          base_size)
+    : shared_(shared)
+    , vacancies_(vacancies)
+    , el_id_(el_id)
+    , allocate_(allocate)
+    , base_size_(base_size)
 {
     CELER_EXPECT(!shared_ || el_id_ < shared_.elements.size());
 }
@@ -27,23 +32,43 @@ AtomicRelaxationHelper::AtomicRelaxationHelper(
 /*!
  * Allocate space for secondaries
  */
-CELER_FUNCTION Span<Secondary> AtomicRelaxationHelper::allocate() const
+CELER_FUNCTION
+Span<Secondary> AtomicRelaxationHelper::allocate_secondaries() const
 {
+    // Maxiumum number of secondaries that could be produced in both atomic
+    // relaxation and the primary process
     size_type size = base_size_;
     if (*this)
-    {
-        // Maxiumum number of secondaries that could be produced in both
-        // atomic relaxation and the primary process
         size += shared_.elements[el_id_.get()].max_secondary;
-    }
 
-    Secondary* secondaries = this->allocate_(size);
+    Secondary* secondaries = allocate_(size);
     if (secondaries == nullptr)
-    {
         size = 0;
-    }
 
     return {secondaries, size};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Allocate space for the unprocessed subshell vacancies
+ */
+CELER_FUNCTION
+Span<SubshellId> AtomicRelaxationHelper::allocate_vacancies() const
+{
+    size_type   size;
+    SubshellId* vacancies = nullptr;
+    if (*this)
+    {
+        CELER_ASSERT(vacancies_);
+        SubshellIdAllocatorView allocate(vacancies_);
+        size      = shared_.elements[el_id_.get()].max_stack_size;
+        vacancies = allocate(size);
+    }
+
+    if (vacancies == nullptr)
+        size = 0;
+
+    return {vacancies, size};
 }
 
 //---------------------------------------------------------------------------//
@@ -51,10 +76,13 @@ CELER_FUNCTION Span<Secondary> AtomicRelaxationHelper::allocate() const
  * Create the sampling distribution from preallocated storage for secondaries
  * and the shell ID of the initial vacancy
  */
-CELER_FUNCTION AtomicRelaxation AtomicRelaxationHelper::build_distribution(
-    Span<Secondary> secondaries, SubshellId shell_id) const
+CELER_FUNCTION AtomicRelaxation
+AtomicRelaxationHelper::build_distribution(Span<Secondary>  secondaries,
+                                           Span<SubshellId> vacancies,
+                                           SubshellId       shell_id) const
 {
-    return AtomicRelaxation{shared_, el_id_, shell_id, secondaries, base_size_};
+    return AtomicRelaxation{
+        shared_, el_id_, shell_id, secondaries, vacancies, base_size_};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/AtomicRelaxationHelper.i.hh
+++ b/src/physics/em/AtomicRelaxationHelper.i.hh
@@ -74,7 +74,7 @@ Span<SubshellId> AtomicRelaxationHelper::allocate_vacancies() const
 //---------------------------------------------------------------------------//
 /*!
  * Create the sampling distribution from preallocated storage for secondaries
- * and the shell ID of the initial vacancy
+ * and vacancies and the shell ID of the initial vacancy
  */
 CELER_FUNCTION AtomicRelaxation
 AtomicRelaxationHelper::build_distribution(Span<Secondary>  secondaries,

--- a/src/physics/em/AtomicRelaxationInterface.hh
+++ b/src/physics/em/AtomicRelaxationInterface.hh
@@ -74,6 +74,8 @@ struct AtomicRelaxParamsPointers
     Span<const AtomicRelaxElement> elements;
     ParticleId                     electron_id;
     ParticleId                     gamma_id;
+    units::MevEnergy               electron_cut; //!< Production thresholds
+    units::MevEnergy               gamma_cut;
 
     //! Check whether the interface is assigned.
     explicit inline CELER_FUNCTION operator bool() const

--- a/src/physics/em/AtomicRelaxationInterface.hh
+++ b/src/physics/em/AtomicRelaxationInterface.hh
@@ -9,12 +9,22 @@
 
 #include "base/Macros.hh"
 #include "base/Span.hh"
+#include "base/StackAllocatorStore.t.hh"
+#include "base/StackAllocatorView.hh"
 #include "base/Types.hh"
 #include "physics/base/Types.hh"
 #include "physics/base/Units.hh"
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+//!@{
+//! Type aliases for subshell ID allocation
+using SubshellIdAllocatorPointers = StackAllocatorPointers<SubshellId>;
+using SubshellIdAllocatorStore    = StackAllocatorStore<SubshellId>;
+using SubshellIdAllocatorView     = StackAllocatorView<SubshellId>;
+//!@}
+
 //---------------------------------------------------------------------------//
 /*!
  * Atomic relaxation transition data. The transition probabilities describe
@@ -45,7 +55,8 @@ struct AtomicRelaxElement
 {
     Span<const AtomicRelaxSubshell> shells;
 
-    size_type max_secondary; //!< Maximum number of secondaries possible
+    size_type max_secondary;  //!< Maximum number of secondaries possible
+    size_type max_stack_size; //!< Maximum size of the subshell vacancy stack
 
     //! Check whether the element is assigned (false for Z < 6).
     explicit inline CELER_FUNCTION operator bool() const

--- a/src/physics/em/AtomicRelaxationParams.cc
+++ b/src/physics/em/AtomicRelaxationParams.cc
@@ -29,6 +29,8 @@ namespace celeritas
  */
 AtomicRelaxationParams::AtomicRelaxationParams(const Input& inp)
     : is_auger_enabled_(inp.is_auger_enabled)
+    , electron_cut_(inp.electron_cut)
+    , gamma_cut_(inp.gamma_cut)
     , electron_id_(inp.electron_id)
     , gamma_id_(inp.gamma_id)
 {
@@ -106,9 +108,11 @@ AtomicRelaxationParams::AtomicRelaxationParams(const Input& inp)
 AtomicRelaxParamsPointers AtomicRelaxationParams::host_pointers() const
 {
     AtomicRelaxParamsPointers result;
-    result.elements    = make_span(host_elements_);
-    result.electron_id = electron_id_;
-    result.gamma_id    = gamma_id_;
+    result.elements     = make_span(host_elements_);
+    result.electron_id  = electron_id_;
+    result.gamma_id     = gamma_id_;
+    result.electron_cut = electron_cut_;
+    result.gamma_cut    = gamma_cut_;
 
     CELER_ENSURE(result);
     return result;
@@ -123,9 +127,11 @@ AtomicRelaxParamsPointers AtomicRelaxationParams::device_pointers() const
     CELER_EXPECT(celeritas::device());
 
     AtomicRelaxParamsPointers result;
-    result.elements    = device_elements_.device_pointers();
-    result.electron_id = electron_id_;
-    result.gamma_id    = gamma_id_;
+    result.elements     = device_elements_.device_pointers();
+    result.electron_id  = electron_id_;
+    result.gamma_id     = gamma_id_;
+    result.electron_cut = electron_cut_;
+    result.gamma_cut    = gamma_cut_;
 
     CELER_ENSURE(result);
     return result;
@@ -146,7 +152,8 @@ void AtomicRelaxationParams::append_element(const ElementInput& inp)
 
     // Calculate the maximum possible number of secondaries that could be
     // created in atomic relaxation.
-    detail::MaxSecondariesCalculator calc_max_secondaries(result);
+    detail::MaxSecondariesCalculator calc_max_secondaries(
+        result, electron_cut_, gamma_cut_);
     result.max_secondary = calc_max_secondaries();
 
     // Maximum size of the stack used to store unprocessed vacancy subshell

--- a/src/physics/em/AtomicRelaxationParams.cc
+++ b/src/physics/em/AtomicRelaxationParams.cc
@@ -140,24 +140,12 @@ void AtomicRelaxationParams::append_element(const ElementInput& inp)
 {
     AtomicRelaxElement result;
 
-    // TODO: For an element Z with n shells of transition data, you can bound
-    // this worst case as n for radiative transitions and 2^n - 1 for
-    // non-radiative transitions if for a given vacancy the transitions always
-    // originate from the next subshell up. Physically this won't happen, so
-    // can we bound this tighter (maybe O(100) for non-radiative transitions,
-    // but that's still a lot)? Can we impose an energy cut below which we
-    // won't create secondaries in the relaxation cascade to reduce it further?
-    if (is_auger_enabled_)
-    {
-        result.max_secondary = std::exp2(inp.shells.size()) - 1;
-    }
-    else
-    {
-        result.max_secondary = inp.shells.size();
-    }
-
     // Copy subshell transition data
     result.shells = this->extend_shells(inp);
+
+    // Calculate the maximum possible number of secondaries that could be
+    // created in atomic relaxation
+    result.max_secondary = this->max_secondaries(result);
 
     // Add to host vector
     host_elements_.push_back(result);
@@ -245,5 +233,69 @@ Span<AtomicRelaxTransition> AtomicRelaxationParams::extend_transitions(
     return {host_transitions_.data() + start, transitions.size()};
 }
 
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the maximum number of secondaries that could be produced in atomic
+ * relaxation for the given element from the subshell transition data.
+ */
+size_type
+AtomicRelaxationParams::max_secondaries(const AtomicRelaxElement& el) const
+{
+    // No atomic relaxation data for this element
+    if (!el)
+        return 0;
+
+    // For an element with n shells of transition data, the maximum number of
+    // secondaries created can be upper-bounded as n if there are only
+    // radiative transitions and 2^n - 1 if there are non-radiative transitions
+    // for the worst (though generally not possible) case where for a given
+    // vacancy the transitions always originate from the next subshell up
+    size_type upper_bound = is_auger_enabled_ ? std::exp2(el.shells.size()) - 1
+                                              : el.shells.size();
+
+    // Store the results for subproblems that have already been calculated
+    std::unordered_map<SubshellId, size_type> visited;
+
+    // Find the maximum number of secondaries created, starting with the
+    // initial vacancy in the innermost subshell
+    size_type result = max_secondaries_helper(el, visited, SubshellId{0}, 0);
+    CELER_ENSURE(result <= upper_bound);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Helper function for calculating the maximum possible number of secondaries
+ * produced when the initial vacancy is in the given subshell.
+ */
+size_type AtomicRelaxationParams::max_secondaries_helper(
+    const AtomicRelaxElement&                  el,
+    std::unordered_map<SubshellId, size_type>& visited,
+    SubshellId                                 vacancy_shell,
+    size_type                                  count) const
+{
+    // No transitions for this subshell, so no secondaries produced
+    if (!vacancy_shell || vacancy_shell.get() >= el.shells.size())
+        return 0;
+
+    auto iter = visited.find(vacancy_shell);
+    if (iter == visited.end())
+    {
+        size_type sub_count = 0;
+        for (const auto& tr : el.shells[vacancy_shell.get()].transitions)
+        {
+            sub_count = std::max(
+                max_secondaries_helper(el, visited, tr.initial_shell, count) + 1
+                    + max_secondaries_helper(el, visited, tr.auger_shell, count),
+                sub_count);
+        }
+        visited[vacancy_shell] = sub_count;
+        return count + sub_count;
+    }
+    else
+    {
+        return count + iter->second;
+    }
+}
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/physics/em/AtomicRelaxationParams.cc
+++ b/src/physics/em/AtomicRelaxationParams.cc
@@ -149,6 +149,12 @@ void AtomicRelaxationParams::append_element(const ElementInput& inp)
     detail::MaxSecondariesCalculator calc_max_secondaries(result);
     result.max_secondary = calc_max_secondaries();
 
+    // Maximum size of the stack used to store unprocessed vacancy subshell
+    // IDs. For radiative transitions, there is only ever one vacancy waiting
+    // to be processed. For non-radiative transitions, the upper bound on the
+    // stack size is the number of shells that have transition data.
+    result.max_stack_size = is_auger_enabled_ ? result.shells.size() : 1;
+
     // Add to host vector
     host_elements_.push_back(result);
 }

--- a/src/physics/em/AtomicRelaxationParams.cc
+++ b/src/physics/em/AtomicRelaxationParams.cc
@@ -152,9 +152,8 @@ void AtomicRelaxationParams::append_element(const ElementInput& inp)
 
     // Calculate the maximum possible number of secondaries that could be
     // created in atomic relaxation.
-    detail::MaxSecondariesCalculator calc_max_secondaries(
-        result, electron_cut_, gamma_cut_);
-    result.max_secondary = calc_max_secondaries();
+    result.max_secondary
+        = detail::calc_max_secondaries(result, electron_cut_, gamma_cut_);
 
     // Maximum size of the stack used to store unprocessed vacancy subshell
     // IDs. For radiative transitions, there is only ever one vacancy waiting

--- a/src/physics/em/AtomicRelaxationParams.hh
+++ b/src/physics/em/AtomicRelaxationParams.hh
@@ -53,6 +53,8 @@ class AtomicRelaxationParams
         std::vector<ElementInput> elements;
         ParticleId                electron_id{};
         ParticleId                gamma_id{};
+        MevEnergy electron_cut{0};    //!< Production threshold for electrons
+        MevEnergy gamma_cut{0};       //!< Production threshold for photons
         bool is_auger_enabled{false}; //!< Whether to produce Auger electrons
     };
 
@@ -70,6 +72,8 @@ class AtomicRelaxationParams
     //// HOST DATA ////
 
     bool                                is_auger_enabled_;
+    MevEnergy                           electron_cut_;
+    MevEnergy                           gamma_cut_;
     ParticleId                          electron_id_;
     ParticleId                          gamma_id_;
     std::unordered_map<int, SubshellId> des_to_id_;

--- a/src/physics/em/AtomicRelaxationParams.hh
+++ b/src/physics/em/AtomicRelaxationParams.hh
@@ -89,12 +89,6 @@ class AtomicRelaxationParams
     Span<AtomicRelaxSubshell> extend_shells(const ElementInput& inp);
     Span<AtomicRelaxTransition>
     extend_transitions(const std::vector<TransitionInput>& transitions);
-    size_type max_secondaries(const AtomicRelaxElement& el) const;
-    size_type
-    max_secondaries_helper(const AtomicRelaxElement&                  el,
-                           std::unordered_map<SubshellId, size_type>& visited,
-                           SubshellId vacancy_shell,
-                           size_type  count) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/AtomicRelaxationParams.hh
+++ b/src/physics/em/AtomicRelaxationParams.hh
@@ -89,6 +89,12 @@ class AtomicRelaxationParams
     Span<AtomicRelaxSubshell> extend_shells(const ElementInput& inp);
     Span<AtomicRelaxTransition>
     extend_transitions(const std::vector<TransitionInput>& transitions);
+    size_type max_secondaries(const AtomicRelaxElement& el) const;
+    size_type
+    max_secondaries_helper(const AtomicRelaxElement&                  el,
+                           std::unordered_map<SubshellId, size_type>& visited,
+                           SubshellId vacancy_shell,
+                           size_type  count) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/LivermorePEMacroXsCalculator.i.hh
+++ b/src/physics/em/LivermorePEMacroXsCalculator.i.hh
@@ -12,7 +12,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with material and micro xs calculator.
+ * Construct with shared model and material data.
  */
 CELER_FUNCTION LivermorePEMacroXsCalculator::LivermorePEMacroXsCalculator(
     const LivermorePEPointers& shared, const MaterialView& material)

--- a/src/physics/em/LivermorePEModel.cc
+++ b/src/physics/em/LivermorePEModel.cc
@@ -40,13 +40,18 @@ LivermorePEModel::LivermorePEModel(ModelId                  id,
  * Construct with transition data for atomic relaxation.
  */
 LivermorePEModel::LivermorePEModel(
-    ModelId                       id,
-    const ParticleParams&         particles,
-    const LivermorePEParams&      data,
-    const AtomicRelaxationParams& atomic_relaxation)
+    ModelId                         id,
+    const ParticleParams&           particles,
+    const LivermorePEParams&        data,
+    const AtomicRelaxationParams&   atomic_relaxation,
+    SPConstSubshellIdAllocatorStore vacancies)
     : LivermorePEModel(id, particles, data)
 {
+    CELER_EXPECT(vacancies);
+    vacancies_                   = std::move(vacancies);
     interface_.atomic_relaxation = atomic_relaxation.device_pointers();
+    interface_.vacancies         = vacancies_->device_pointers();
+    CELER_ENSURE(interface_);
 }
 
 //---------------------------------------------------------------------------//
@@ -71,7 +76,7 @@ void LivermorePEModel::interact(
     CELER_MAYBE_UNUSED const ModelInteractPointers& pointers) const
 {
 #if CELERITAS_USE_CUDA
-    detail::livermore_pe_interact(interface_, pointers);
+    detail::livermore_pe_interact(this->device_pointers(), pointers);
 #else
     CELER_ASSERT_UNREACHABLE();
 #endif
@@ -84,6 +89,20 @@ void LivermorePEModel::interact(
 ModelId LivermorePEModel::model_id() const
 {
     return interface_.model_id;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access data on device
+ */
+detail::LivermorePEPointers LivermorePEModel::device_pointers() const
+{
+    detail::LivermorePEPointers result = interface_;
+    if (result.atomic_relaxation)
+        result.vacancies = vacancies_->device_pointers();
+
+    CELER_ENSURE(result);
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/LivermorePEModel.hh
+++ b/src/physics/em/LivermorePEModel.hh
@@ -22,16 +22,24 @@ namespace celeritas
 class LivermorePEModel final : public Model
 {
   public:
+    //!@{
+    //! Type aliases
+    using SPConstSubshellIdAllocatorStore
+        = std::shared_ptr<SubshellIdAllocatorStore>;
+    //!@}
+
+  public:
     // Construct from model ID and other necessary data
     LivermorePEModel(ModelId                  id,
                      const ParticleParams&    particles,
                      const LivermorePEParams& data);
 
     // Construct with transition data for atomic relaxation
-    LivermorePEModel(ModelId                       id,
-                     const ParticleParams&         particles,
-                     const LivermorePEParams&      data,
-                     const AtomicRelaxationParams& atomic_relaxation);
+    LivermorePEModel(ModelId                         id,
+                     const ParticleParams&           particles,
+                     const LivermorePEParams&        data,
+                     const AtomicRelaxationParams&   atomic_relaxation,
+                     SPConstSubshellIdAllocatorStore vacancies);
 
     // Particle types and energy ranges that this model applies to
     SetApplicability applicability() const final;
@@ -46,10 +54,11 @@ class LivermorePEModel final : public Model
     std::string label() const final { return "Livermore photoelectric"; }
 
     // Access data on device
-    detail::LivermorePEPointers device_pointers() const { return interface_; }
+    detail::LivermorePEPointers device_pointers() const;
 
   private:
-    detail::LivermorePEPointers interface_;
+    detail::LivermorePEPointers     interface_;
+    SPConstSubshellIdAllocatorStore vacancies_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/PhotoelectricProcess.cc
+++ b/src/physics/em/PhotoelectricProcess.cc
@@ -38,18 +38,22 @@ PhotoelectricProcess::PhotoelectricProcess(SPConstParticles   particles,
 /*!
  * Construct with atomic relaxation data.
  */
-PhotoelectricProcess::PhotoelectricProcess(SPConstParticles   particles,
-                                           ImportPhysicsTable xs_lo,
-                                           ImportPhysicsTable xs_hi,
-                                           SPConstData        data,
-                                           SPConstAtomicRelax atomic_relaxation)
+PhotoelectricProcess::PhotoelectricProcess(
+    SPConstParticles                particles,
+    ImportPhysicsTable              xs_lo,
+    ImportPhysicsTable              xs_hi,
+    SPConstData                     data,
+    SPConstAtomicRelax              atomic_relaxation,
+    SPConstSubshellIdAllocatorStore vacancies)
     : PhotoelectricProcess(std::move(particles),
                            std::move(xs_lo),
                            std::move(xs_hi),
                            std::move(data))
 {
     atomic_relaxation_ = std::move(atomic_relaxation);
+    vacancies_         = std::move(vacancies);
     CELER_ENSURE(atomic_relaxation_);
+    CELER_ENSURE(vacancies_);
 }
 
 //---------------------------------------------------------------------------//
@@ -63,7 +67,7 @@ auto PhotoelectricProcess::build_models(ModelIdGenerator next_id) const
     {
         // Construct model with atomic relaxation enabled
         return {std::make_shared<LivermorePEModel>(
-            next_id(), *particles_, *data_, *atomic_relaxation_)};
+            next_id(), *particles_, *data_, *atomic_relaxation_, vacancies_)};
     }
     else
     {

--- a/src/physics/em/PhotoelectricProcess.hh
+++ b/src/physics/em/PhotoelectricProcess.hh
@@ -28,6 +28,8 @@ class PhotoelectricProcess : public Process
     using SPConstParticles   = std::shared_ptr<const ParticleParams>;
     using SPConstData        = std::shared_ptr<const LivermorePEParams>;
     using SPConstAtomicRelax = std::shared_ptr<const AtomicRelaxationParams>;
+    using SPConstSubshellIdAllocatorStore
+        = std::shared_ptr<SubshellIdAllocatorStore>;
     //!@}
 
   public:
@@ -38,11 +40,12 @@ class PhotoelectricProcess : public Process
                          SPConstData        data);
 
     // Construct from Livermore data and EADL atomic relaxation data
-    PhotoelectricProcess(SPConstParticles   particles,
-                         ImportPhysicsTable xs_lo,
-                         ImportPhysicsTable xs_hi,
-                         SPConstData        data,
-                         SPConstAtomicRelax atomic_relaxation);
+    PhotoelectricProcess(SPConstParticles                particles,
+                         ImportPhysicsTable              xs_lo,
+                         ImportPhysicsTable              xs_hi,
+                         SPConstData                     data,
+                         SPConstAtomicRelax              atomic_relaxation,
+                         SPConstSubshellIdAllocatorStore vacancies);
 
     // Construct the models associated with this process
     VecModel build_models(ModelIdGenerator next_id) const final;
@@ -54,11 +57,12 @@ class PhotoelectricProcess : public Process
     std::string label() const final;
 
   private:
-    SPConstParticles   particles_;
-    ImportPhysicsTable xs_lo_;
-    ImportPhysicsTable xs_hi_;
-    SPConstData        data_;
-    SPConstAtomicRelax atomic_relaxation_;
+    SPConstParticles                particles_;
+    ImportPhysicsTable              xs_lo_;
+    ImportPhysicsTable              xs_hi_;
+    SPConstData                     data_;
+    SPConstAtomicRelax              atomic_relaxation_;
+    SPConstSubshellIdAllocatorStore vacancies_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/LivermorePE.hh
+++ b/src/physics/em/detail/LivermorePE.hh
@@ -38,12 +38,14 @@ struct LivermorePEPointers
     LivermorePEParamsPointers data;
     //! EADL transition data used for atomic relaxation
     AtomicRelaxParamsPointers atomic_relaxation;
+    //! Storage for the stack of vacancy subshell IDs
+    SubshellIdAllocatorPointers vacancies;
 
     //! Check whether the data is assigned
     explicit CELER_FUNCTION operator bool() const
     {
         return model_id && inv_electron_mass > 0 && electron_id && gamma_id
-               && data;
+               && data && (!atomic_relaxation == !vacancies);
     }
 };
 

--- a/src/physics/em/detail/Utils.cc
+++ b/src/physics/em/detail/Utils.cc
@@ -17,6 +17,18 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Calculate the maximum possible number of secondaries produced in atomic
+ * relaxation.
+ */
+size_type calc_max_secondaries(const AtomicRelaxElement& el,
+                               units::MevEnergy          electron_cut,
+                               units::MevEnergy          gamma_cut)
+{
+    return MaxSecondariesCalculator(el, electron_cut, gamma_cut)();
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct with EADL transition data and production thresholds.
  */
 MaxSecondariesCalculator::MaxSecondariesCalculator(const AtomicRelaxElement& el,

--- a/src/physics/em/detail/Utils.cc
+++ b/src/physics/em/detail/Utils.cc
@@ -1,0 +1,82 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Utils.cc
+//---------------------------------------------------------------------------//
+#include "Utils.hh"
+
+#include <cmath>
+#include "base/Algorithms.hh"
+#include "base/Range.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with EADL transition data.
+ */
+MaxSecondariesCalculator::MaxSecondariesCalculator(const AtomicRelaxElement& el)
+    : shells_(el.shells)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the maximum possible number of secondaries produced in atomic
+ * relaxation.
+ */
+size_type MaxSecondariesCalculator::operator()()
+{
+    // No atomic relaxation data for this element
+    if (shells_.empty())
+        return 0;
+
+    // Find the maximum number of secondaries created, checking over every
+    // possible subshell the initial vacancy could be in
+    size_type result = 0;
+    for (SubshellId::value_type shell_idx : range(shells_.size()))
+    {
+        result = max(result, this->calc(SubshellId{shell_idx}, 0));
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Helper function for calculating the maximum possible number of secondaries
+ * when the initial vacancy is in the given subshell.
+ */
+size_type
+MaxSecondariesCalculator::calc(SubshellId vacancy_shell, size_type count)
+{
+    // No transitions for this subshell, so no secondaries produced
+    if (!vacancy_shell || vacancy_shell.get() >= shells_.size())
+        return 0;
+
+    auto it = visited_.find(vacancy_shell);
+    if (it == visited_.end())
+    {
+        size_type sub_count = 0;
+        for (const auto& transition : shells_[vacancy_shell.get()].transitions)
+        {
+            sub_count
+                = std::max(1 + this->calc(transition.initial_shell, count)
+                               + this->calc(transition.auger_shell, count),
+                           sub_count);
+        }
+        visited_[vacancy_shell] = sub_count;
+        return count + sub_count;
+    }
+    else
+    {
+        return count + it->second;
+    }
+}
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/physics/em/detail/Utils.cc
+++ b/src/physics/em/detail/Utils.cc
@@ -39,9 +39,7 @@ size_type MaxSecondariesCalculator::operator()()
     // possible subshell the initial vacancy could be in
     size_type result = 0;
     for (SubshellId::value_type shell_idx : range(shells_.size()))
-    {
         result = max(result, this->calc(SubshellId{shell_idx}, 0));
-    }
     return result;
 }
 
@@ -58,23 +56,18 @@ MaxSecondariesCalculator::calc(SubshellId vacancy_shell, size_type count)
         return 0;
 
     auto it = visited_.find(vacancy_shell);
-    if (it == visited_.end())
-    {
-        size_type sub_count = 0;
-        for (const auto& transition : shells_[vacancy_shell.get()].transitions)
-        {
-            sub_count
-                = std::max(1 + this->calc(transition.initial_shell, count)
-                               + this->calc(transition.auger_shell, count),
-                           sub_count);
-        }
-        visited_[vacancy_shell] = sub_count;
-        return count + sub_count;
-    }
-    else
-    {
+    if (it != visited_.end())
         return count + it->second;
+
+    size_type sub_count = 0;
+    for (const auto& transition : shells_[vacancy_shell.get()].transitions)
+    {
+        sub_count = std::max(1 + this->calc(transition.initial_shell, count)
+                                 + this->calc(transition.auger_shell, count),
+                             sub_count);
     }
+    visited_[vacancy_shell] = sub_count;
+    return count + sub_count;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/Utils.hh
+++ b/src/physics/em/detail/Utils.hh
@@ -19,20 +19,30 @@ namespace detail
 //---------------------------------------------------------------------------//
 /*!
  * Helper class for calculating the maximum possible number of secondaries
- * produced in atomic relaxation when the initial vacancy is in the given
- * subshell.
+ * produced in atomic relaxation for a given element and electron/photon
+ * production threshold.
  */
 class MaxSecondariesCalculator
 {
   public:
-    // Construct with EADL transition data
-    MaxSecondariesCalculator(const AtomicRelaxElement& el);
+    //!@{
+    //! Type aliases
+    using MevEnergy = units::MevEnergy;
+    //!@}
 
-    // Calculate the maximum possible secondaries produced
+  public:
+    // Construct with EADL transition data and production thresholds
+    MaxSecondariesCalculator(const AtomicRelaxElement& el,
+                             MevEnergy                 electron_cut,
+                             MevEnergy                 gamma_cut);
+
+    // Calculate the maximum possible number of secondaries produced
     size_type operator()();
 
   private:
     Span<const AtomicRelaxSubshell>           shells_;
+    const real_type                           electron_cut_;
+    const real_type                           gamma_cut_;
     std::unordered_map<SubshellId, size_type> visited_;
 
     // HELPER FUNCTIONS

--- a/src/physics/em/detail/Utils.hh
+++ b/src/physics/em/detail/Utils.hh
@@ -17,6 +17,12 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
+// Calculate the maximum possible secondaries produced in atomic relaxation
+size_type calc_max_secondaries(const AtomicRelaxElement& el,
+                               units::MevEnergy          electron_cut,
+                               units::MevEnergy          gamma_cut);
+
+//---------------------------------------------------------------------------//
 /*!
  * Helper class for calculating the maximum possible number of secondaries
  * produced in atomic relaxation for a given element and electron/photon

--- a/src/physics/em/detail/Utils.hh
+++ b/src/physics/em/detail/Utils.hh
@@ -1,0 +1,45 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Utils.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <unordered_map>
+#include "base/Macros.hh"
+#include "base/Types.hh"
+#include "physics/em/AtomicRelaxationInterface.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Helper class for calculating the maximum possible number of secondaries
+ * produced in atomic relaxation when the initial vacancy is in the given
+ * subshell.
+ */
+class MaxSecondariesCalculator
+{
+  public:
+    // Construct with EADL transition data
+    MaxSecondariesCalculator(const AtomicRelaxElement& el);
+
+    // Calculate the maximum possible secondaries produced
+    size_type operator()();
+
+  private:
+    Span<const AtomicRelaxSubshell>           shells_;
+    std::unordered_map<SubshellId, size_type> visited_;
+
+    // HELPER FUNCTIONS
+
+    size_type calc(SubshellId vacancy_shell, size_type count);
+};
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/test/physics/em/LivermorePE.test.cc
+++ b/test/physics/em/LivermorePE.test.cc
@@ -281,7 +281,6 @@ TEST_F(LivermorePEInteractorTest, distributions_all)
     const int num_samples   = 1000;
     Real3     inc_direction = {0, 0, 1};
     this->set_inc_direction(inc_direction);
-    this->resize_secondaries(16 * num_samples);
 
     // Sampled element
     ElementId el_id{0};
@@ -290,6 +289,11 @@ TEST_F(LivermorePEInteractorTest, distributions_all)
     relax_inp_.is_auger_enabled = true;
     set_relaxation_params(relax_inp_);
     pointers_.atomic_relaxation = relax_params_->host_pointers();
+
+    // Allocate storage for secondaries (atomic relaxation + photoelectron)
+    auto max_secondary
+        = pointers_.atomic_relaxation.elements[el_id.get()].max_secondary + 1;
+    this->resize_secondaries(max_secondary * num_samples);
 
     // Create the interactor
     LivermorePEInteractor interact(pointers_,
@@ -329,7 +333,8 @@ TEST_F(LivermorePEInteractorTest, distributions_all)
             energy_to_count[secondary.energy.value()]++;
         }
     }
-    EXPECT_EQ(16 * num_samples, this->secondary_allocator().get().size());
+    EXPECT_EQ(max_secondary * num_samples,
+              this->secondary_allocator().get().size());
     EXPECT_EQ(2180, num_secondaries);
 
     for (const auto& it : energy_to_count)
@@ -360,7 +365,6 @@ TEST_F(LivermorePEInteractorTest, distributions_radiative)
     RandomEngine& rng_engine = this->rng();
 
     const int num_samples = 10000;
-    this->resize_secondaries(5 * num_samples);
 
     // Sampled element
     ElementId el_id{0};
@@ -369,6 +373,11 @@ TEST_F(LivermorePEInteractorTest, distributions_radiative)
     relax_inp_.is_auger_enabled = false;
     set_relaxation_params(relax_inp_);
     pointers_.atomic_relaxation = relax_params_->host_pointers();
+
+    // Allocate storage for secondaries (atomic relaxation + photoelectron)
+    auto max_secondary
+        = pointers_.atomic_relaxation.elements[el_id.get()].max_secondary + 1;
+    this->resize_secondaries(max_secondary * num_samples);
 
     // Create the interactor
     LivermorePEInteractor interact(pointers_,
@@ -397,7 +406,8 @@ TEST_F(LivermorePEInteractorTest, distributions_radiative)
             energy_to_count[secondary.energy.value()]++;
         }
     }
-    EXPECT_EQ(5 * num_samples, this->secondary_allocator().get().size());
+    EXPECT_EQ(max_secondary * num_samples,
+              this->secondary_allocator().get().size());
     EXPECT_EQ(10007, num_secondaries);
 
     for (const auto& it : energy_to_count)

--- a/test/physics/em/LivermorePE.test.cc
+++ b/test/physics/em/LivermorePE.test.cc
@@ -569,7 +569,6 @@ TEST_F(LivermorePEInteractorTest, max_secondaries)
     using celeritas::AtomicRelaxElement;
     using celeritas::AtomicRelaxSubshell;
     using celeritas::AtomicRelaxTransition;
-    using celeritas::detail::MaxSecondariesCalculator;
 
     // For an element with n shells of transition data, the maximum number of
     // secondaries created can be upper-bounded as n if there are only
@@ -579,7 +578,6 @@ TEST_F(LivermorePEInteractorTest, max_secondaries)
     unsigned int num_shells        = 20;
     unsigned int upper_bound_fluor = num_shells;
     unsigned int upper_bound_auger = std::exp2(num_shells) - 1;
-    MevEnergy    e_cut             = MevEnergy{0};
 
     AtomicRelaxElement                   el;
     std::vector<AtomicRelaxSubshell>     shell_storage(num_shells);
@@ -595,9 +593,9 @@ TEST_F(LivermorePEInteractorTest, max_secondaries)
                 {SubshellId{i + 1}, SubshellId{}, 1, 1});
             shells[i].transitions = {transition_storage.data() + i, 1};
         }
-        el.shells = shells;
-        MaxSecondariesCalculator calc_max_secondaries(el, e_cut, e_cut);
-        auto                     result = calc_max_secondaries();
+        el.shells   = shells;
+        auto result = celeritas::detail::calc_max_secondaries(
+            el, MevEnergy{0}, MevEnergy{0});
         EXPECT_EQ(upper_bound_fluor, result);
     }
     {
@@ -619,9 +617,9 @@ TEST_F(LivermorePEInteractorTest, max_secondaries)
                 = {transition_storage.data() + start,
                    transition_storage.data() + transition_storage.size()};
         }
-        el.shells = shells;
-        MaxSecondariesCalculator calc_max_secondaries(el, e_cut, e_cut);
-        auto                     result = calc_max_secondaries();
+        el.shells   = shells;
+        auto result = celeritas::detail::calc_max_secondaries(
+            el, MevEnergy{0}, MevEnergy{0});
         EXPECT_EQ(upper_bound_auger, result);
     }
     {


### PR DESCRIPTION
A few additions to atomic relaxation:
- Use a `Stackallocator` to allocate storage for the unprocessed vacancy subshell stack based on the maximum possible size the stack could grow to for each element.
- Add a helper class to bound the maximum possible number of secondaries created based on the actual transition data rather than a hypothetical worst case. On average the number of secondaries produced is closer to 10, so we're usually still allocating much more storage than we need.
- Add the option to set an energy threshold for the production of fluorescence photons and Auger electrons, which can greatly reduce the maximum possible number of secondaries, e.g.:

![max_secondaries](https://user-images.githubusercontent.com/6426426/109435543-8d963a00-79e0-11eb-93c4-021b25dd0ce1.png)