### PR TITLE
Fix allocation of zero elements with StackAllocatorView

### DIFF
--- a/src/base/StackAllocatorView.i.hh
+++ b/src/base/StackAllocatorView.i.hh
@@ -33,6 +33,7 @@ template<class T>
 CELER_FUNCTION auto StackAllocatorView<T>::operator()(size_type count)
     -> result_type
 {
+    CELER_EXPECT(count > 0);
     static_assert(std::is_default_constructible<T>::value,
                   "Value must be default constructible");
 

--- a/src/physics/em/AtomicRelaxationHelper.i.hh
+++ b/src/physics/em/AtomicRelaxationHelper.i.hh
@@ -37,13 +37,19 @@ Span<Secondary> AtomicRelaxationHelper::allocate_secondaries() const
 {
     // Maxiumum number of secondaries that could be produced in both atomic
     // relaxation and the primary process
-    size_type size = base_size_;
+    size_type  size        = base_size_;
+    Secondary* secondaries = nullptr;
     if (*this)
+    {
         size += shared_.elements[el_id_.get()].max_secondary;
+    }
 
-    Secondary* secondaries = allocate_(size);
-    if (secondaries == nullptr)
-        size = 0;
+    if (size > 0)
+    {
+        secondaries = allocate_(size);
+        if (secondaries == nullptr)
+            size = 0;
+    }
 
     return {secondaries, size};
 }

--- a/test/sim/TrackInitializerStore.test.hh
+++ b/test/sim/TrackInitializerStore.test.hh
@@ -35,13 +35,6 @@ struct Interactor
 
     CELER_FUNCTION Interaction operator()()
     {
-        // Create secondary particles
-        Secondary* allocated = this->allocate_secondaries(alloc_size);
-        if (!allocated)
-        {
-            return Interaction::from_failure();
-        }
-
         Interaction result;
 
         // Kill the particle
@@ -50,13 +43,22 @@ struct Interactor
             result = Interaction::from_absorption();
         }
 
-        // Initialize secondaries
-        result.secondaries = {allocated, alloc_size};
-        for (auto& secondary : result.secondaries)
+        // Create secondaries
+        if (alloc_size > 0)
         {
-            secondary.particle_id = ParticleId(0);
-            secondary.energy      = units::MevEnergy(5.);
-            secondary.direction   = {1., 0., 0.};
+            Secondary* allocated = this->allocate_secondaries(alloc_size);
+            if (!allocated)
+            {
+                return Interaction::from_failure();
+            }
+
+            result.secondaries = {allocated, alloc_size};
+            for (auto& secondary : result.secondaries)
+            {
+                secondary.particle_id = ParticleId(0);
+                secondary.energy      = units::MevEnergy(5.);
+                secondary.direction   = {1., 0., 0.};
+            }
         }
 
         return result;


### PR DESCRIPTION
Attempting to allocate zero elements using the `StackAllocatorView` was causing the track initializer test to crash (#156). This adds an assertion that the allocation size is greater than zero and fixes the test that was erroneously allocating space for nothing.