### PR TITLE
Line propagation updates

### DIFF
--- a/app/demo-rasterizer/RDemoKernel.cu
+++ b/app/demo-rasterizer/RDemoKernel.cu
@@ -45,8 +45,7 @@ __global__ void trace_kernel(const GeoParamsPointers geo_params,
     geo = GeoStateInitializer{image.start_pos(), image.start_dir()};
 
     int cur_id = geo_id(geo);
-    geo.find_next_step();
-    real_type geo_dist = geo.next_step();
+    real_type geo_dist = fmin(geo.next_step(), image_state.dims[1] * image_state.pixel_width);
 
     // Track along each pixel
     for (unsigned int i = 0; i < image_state.dims[1]; ++i)
@@ -72,8 +71,7 @@ __global__ void trace_kernel(const GeoParamsPointers geo_params,
             // Cross surface
             geo.move_next_step();
             cur_id = geo_id(geo);
-            geo.find_next_step();
-            geo_dist = geo.next_step();
+            geo_dist = fmin( geo.next_step(), image_state.dims[1] * image_state.pixel_width);
         }
 
         // Move to pixel boundary

--- a/app/demo-rasterizer/RDemoKernel.cu
+++ b/app/demo-rasterizer/RDemoKernel.cu
@@ -44,8 +44,9 @@ __global__ void trace_kernel(const GeoParamsPointers geo_params,
     // Start track at the leftmost point in the requested direction
     geo = GeoStateInitializer{image.start_pos(), image.start_dir()};
 
-    int cur_id = geo_id(geo);
-    real_type geo_dist = fmin(geo.next_step(), image_state.dims[1] * image_state.pixel_width);
+    int       cur_id = geo_id(geo);
+    real_type geo_dist
+        = fmin(geo.next_step(), image_state.dims[1] * image_state.pixel_width);
 
     // Track along each pixel
     for (unsigned int i = 0; i < image_state.dims[1]; ++i)
@@ -70,8 +71,9 @@ __global__ void trace_kernel(const GeoParamsPointers geo_params,
 
             // Cross surface
             geo.move_next_step();
-            cur_id = geo_id(geo);
-            geo_dist = fmin( geo.next_step(), image_state.dims[1] * image_state.pixel_width);
+            cur_id   = geo_id(geo);
+            geo_dist = fmin(geo.next_step(),
+                            image_state.dims[1] * image_state.pixel_width);
         }
 
         // Move to pixel boundary

--- a/app/demo-rasterizer/RDemoKernel.cu
+++ b/app/demo-rasterizer/RDemoKernel.cu
@@ -11,6 +11,7 @@
 #include "base/KernelParamCalculator.cuda.hh"
 #include "geometry/GeoTrackView.hh"
 #include "ImageTrackView.hh"
+#include <cmath>
 
 using namespace celeritas;
 using namespace demo_rasterizer;
@@ -45,8 +46,8 @@ __global__ void trace_kernel(const GeoParamsPointers geo_params,
     geo = GeoStateInitializer{image.start_pos(), image.start_dir()};
 
     int       cur_id = geo_id(geo);
-    real_type geo_dist
-        = fmin(geo.next_step(), image_state.dims[1] * image_state.pixel_width);
+    real_type geo_dist = std::fmin(
+        geo.next_step(), image_state.dims[1] * image_state.pixel_width);
 
     // Track along each pixel
     for (unsigned int i = 0; i < image_state.dims[1]; ++i)
@@ -72,8 +73,8 @@ __global__ void trace_kernel(const GeoParamsPointers geo_params,
             // Cross surface
             geo.move_next_step();
             cur_id   = geo_id(geo);
-            geo_dist = fmin(geo.next_step(),
-                            image_state.dims[1] * image_state.pixel_width);
+            geo_dist = std::fmin(geo.next_step(),
+                                 image_state.dims[1] * image_state.pixel_width);
         }
 
         // Move to pixel boundary

--- a/src/geometry/GeoTrackView.hh
+++ b/src/geometry/GeoTrackView.hh
@@ -51,10 +51,13 @@ class GeoTrackView
     // Initialize the state from a parent state and new direction
     inline CELER_FUNCTION GeoTrackView&
                           operator=(const DetailedInitializer& init);
+
     // Find the distance to the next boundary
     inline CELER_FUNCTION void find_next_step();
     // Move to the next boundary
-    inline CELER_FUNCTION void move_next_step();
+    inline CELER_FUNCTION real_type move_to_boundary();
+    inline CELER_FUNCTION real_type move_next_step();
+    inline CELER_FUNCTION real_type move_by(real_type step);
 
     // Update current volume, called whenever move reaches boundary
     inline CELER_FUNCTION void move_next_volume();
@@ -63,14 +66,25 @@ class GeoTrackView
     //! State accessors
     CELER_FUNCTION const Real3& pos() const { return pos_; }
     CELER_FUNCTION const Real3& dir() const { return dir_; }
-    CELER_FUNCTION real_type    next_step() const { return next_step_; }
+    CELER_FUNCTION real_type    next_step() const
+    {
+        CELER_ASSERT(valid_);
+        return next_step_;
+    }
     //!@}
 
     //!@{
-    //! State modifiers via non-const references
-    CELER_FUNCTION Real3& pos() { return pos_; }
-    CELER_FUNCTION Real3& dir() { return dir_; }
-    CELER_FUNCTION real_type& next_step() { return next_step_; }
+    //! State modifiers will force state update before next step
+    CELER_FUNCTION void set_pos(const Real3& newpos)
+    {
+        pos_   = newpos;
+        valid_ = false;
+    }
+    CELER_FUNCTION void set_dir(const Real3& newdir)
+    {
+        dir_   = newdir;
+        valid_ = false;
+    }
     //!@}
 
     //! Get the volume ID in the current cell.
@@ -99,6 +113,7 @@ class GeoTrackView
     Real3&     pos_;
     Real3&     dir_;
     real_type& next_step_;
+    bool       valid_;
     //!@}
 
   private:

--- a/src/geometry/GeoTrackView.hh
+++ b/src/geometry/GeoTrackView.hh
@@ -122,6 +122,10 @@ class GeoTrackView
     static inline CELER_FUNCTION NavState&
     get_nav_state(void* state, int vgmaxdepth, ThreadId thread);
 
+    // Find the distance to the next boundary
+    inline CELER_FUNCTION void
+    find_next_step(const vecgeom::LogicalVolume* volume);
+
   public:
     //! Get a reference to the current volume
     inline CELER_FUNCTION const Volume& volume() const;

--- a/src/geometry/GeoTrackView.hh
+++ b/src/geometry/GeoTrackView.hh
@@ -68,7 +68,7 @@ class GeoTrackView
     CELER_FUNCTION const Real3& dir() const { return dir_; }
     CELER_FUNCTION real_type    next_step() const
     {
-        CELER_ASSERT(valid_);
+        CELER_ASSERT(!dirty_);
         return next_step_;
     }
     //!@}
@@ -78,12 +78,12 @@ class GeoTrackView
     CELER_FUNCTION void set_pos(const Real3& newpos)
     {
         pos_   = newpos;
-        valid_ = false;
+        dirty_ = true;
     }
     CELER_FUNCTION void set_dir(const Real3& newdir)
     {
         dir_   = newdir;
-        valid_ = false;
+        dirty_ = true;
     }
     //!@}
 
@@ -113,7 +113,8 @@ class GeoTrackView
     Real3&     pos_;
     Real3&     dir_;
     real_type& next_step_;
-    bool       valid_;
+    // Flag to trigger update of geometry information if and only if needed
+    bool       dirty_;
     //!@}
 
   private:

--- a/src/geometry/GeoTrackView.hh
+++ b/src/geometry/GeoTrackView.hh
@@ -53,11 +53,7 @@ class GeoTrackView
                           operator=(const DetailedInitializer& init);
 
     // Find the distance to the next boundary
-    CELER_FORCEINLINE_FUNCTION void find_next_step()
-    {
-        this->find_next_step(&this->volume());
-    }
-    inline CELER_FUNCTION void find_next_step(vecgeom::VPlacedVolume const* pv);
+    inline CELER_FUNCTION void find_next_step();
 
     // Move to the next boundary
     inline CELER_FUNCTION real_type move_to_boundary();
@@ -128,8 +124,7 @@ class GeoTrackView
     get_nav_state(void* state, int vgmaxdepth, ThreadId thread);
 
     // Find the distance to the next boundary
-    inline CELER_FUNCTION void
-    find_next_step(const vecgeom::LogicalVolume* volume);
+    inline CELER_FUNCTION void find_next_step_outside();
 
   public:
     //! Get a reference to the current volume

--- a/src/geometry/GeoTrackView.hh
+++ b/src/geometry/GeoTrackView.hh
@@ -53,7 +53,12 @@ class GeoTrackView
                           operator=(const DetailedInitializer& init);
 
     // Find the distance to the next boundary
-    inline CELER_FUNCTION void find_next_step();
+    CELER_FORCEINLINE_FUNCTION void find_next_step()
+    {
+        this->find_next_step(&this->volume());
+    }
+    inline CELER_FUNCTION void find_next_step(vecgeom::VPlacedVolume const* pv);
+
     // Move to the next boundary
     inline CELER_FUNCTION real_type move_to_boundary();
     inline CELER_FUNCTION real_type move_next_step();

--- a/src/geometry/GeoTrackView.hh
+++ b/src/geometry/GeoTrackView.hh
@@ -119,7 +119,7 @@ class GeoTrackView
     Real3&     dir_;
     real_type& next_step_;
     // Flag to trigger update of geometry information if and only if needed
-    bool       dirty_;
+    bool dirty_;
     //!@}
 
   private:

--- a/src/geometry/GeoTrackView.i.hh
+++ b/src/geometry/GeoTrackView.i.hh
@@ -56,7 +56,8 @@ CELER_FUNCTION GeoTrackView& GeoTrackView::operator=(const Initializer_t& init)
         volume, detail::to_vector(pos_), vgstate_, contains_point);
 
     // Prepare next step
-    this->find_next_step();
+    this->find_next_step(this->is_outside() ? volume->LogicalVolume()
+                                            : vgstate_->Top());
     return *this;
 }
 
@@ -84,9 +85,15 @@ GeoTrackView& GeoTrackView::operator=(const DetailedInitializer& init)
 //! Find the distance to the next geometric boundary.
 CELER_FUNCTION void GeoTrackView::find_next_step()
 {
-    const vecgeom::LogicalVolume* logical_vol
-        = this->volume().GetLogicalVolume();
-    CELER_ASSERT(logical_vol);
+    return this->find_next_step(this->volume().LogicalVolume());
+}
+
+//---------------------------------------------------------------------------//
+//! Find the distance to the next geometric boundary.
+CELER_FUNCTION void
+GeoTrackView::find_next_step(const vecgeom::LogicalVolume* volume)
+{
+    CELER_EXPECT(logical_vol);
     const vecgeom::VNavigator* navigator
         = this->volume().GetLogicalVolume()->GetNavigator();
     CELER_ASSERT(navigator);
@@ -115,6 +122,7 @@ CELER_FUNCTION real_type GeoTrackView::move_to_boundary()
     return dist;
 }
 
+//---------------------------------------------------------------------------//
 //! Move to the next boundary and update volume accordingly
 CELER_FUNCTION real_type GeoTrackView::move_next_step()
 {
@@ -127,6 +135,7 @@ CELER_FUNCTION real_type GeoTrackView::move_next_step()
     return dist;
 }
 
+//---------------------------------------------------------------------------//
 //! Move to the next boundary and update volume accordingly
 CELER_FUNCTION real_type GeoTrackView::move_by(real_type dist)
 {

--- a/src/geometry/GeoTrackView.i.hh
+++ b/src/geometry/GeoTrackView.i.hh
@@ -120,8 +120,7 @@ CELER_FUNCTION void GeoTrackView::move_next_volume()
 //! Get the volume ID in the current cell.
 CELER_FUNCTION VolumeId GeoTrackView::volume_id() const
 {
-    CELER_EXPECT(!this->is_outside());
-    return VolumeId{this->volume().id()};
+    return (this->is_outside() ? VolumeId{} : VolumeId{this->volume().id()});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/GeoTrackView.i.hh
+++ b/src/geometry/GeoTrackView.i.hh
@@ -75,7 +75,7 @@ GeoTrackView& GeoTrackView::operator=(const DetailedInitializer& init)
         pos_ = init.other.pos_;
     }
     // Set up the next state and initialize the direction
-    dir_       = init.dir;
+    dir_ = init.dir;
 
     this->find_next_step();
     return *this;
@@ -89,27 +89,29 @@ GeoTrackView::find_next_step(vecgeom::VPlacedVolume const* pplvol)
     CELER_ASSERT(pplvol);
 
     const vecgeom::VNavigator* navigator
-      = pplvol->GetLogicalVolume()->GetNavigator();
+        = pplvol->GetLogicalVolume()->GetNavigator();
     CELER_ASSERT(navigator);
 
-    if(this->is_outside()) {
-      // handling points outside of world volume
-      real_type step = 1.e+10;
-      next_step_     = pplvol->DistanceToIn(detail::to_vector(pos_),
-					    detail::to_vector(dir_),
-					    step);
-      vgnext_.Clear();
-      if (next_step_ < step) {
-	vgnext_.Push(pplvol);
-      }
+    if (this->is_outside())
+    {
+        // handling points outside of world volume
+        real_type step = 1.e+10;
+        next_step_     = pplvol->DistanceToIn(
+            detail::to_vector(pos_), detail::to_vector(dir_), step);
+        vgnext_.Clear();
+        if (next_step_ < step)
+        {
+            vgnext_.Push(pplvol);
+        }
     }
-    else {
-      next_step_
-          = navigator->ComputeStepAndPropagatedState(detail::to_vector(pos_),
-                                                     detail::to_vector(dir_),
-                                                     vecgeom::kInfLength,
-                                                     vgstate_,
-                                                     vgnext_);
+    else
+    {
+        next_step_
+            = navigator->ComputeStepAndPropagatedState(detail::to_vector(pos_),
+                                                       detail::to_vector(dir_),
+                                                       vecgeom::kInfLength,
+                                                       vgstate_,
+                                                       vgnext_);
     }
     dirty_ = false;
 }

--- a/src/geometry/GeoTrackView.i.hh
+++ b/src/geometry/GeoTrackView.i.hh
@@ -26,6 +26,7 @@ GeoTrackView::GeoTrackView(const GeoParamsPointers& data,
     , pos_(stateview.pos[id.get()])
     , dir_(stateview.dir[id.get()])
     , next_step_(stateview.next_step[id.get()])
+    , dirty_(true)
 {
 }
 
@@ -96,14 +97,14 @@ CELER_FUNCTION void GeoTrackView::find_next_step()
                                                    vecgeom::kInfLength,
                                                    vgstate_,
                                                    vgnext_);
-    valid_ = true;
+    dirty_ = false;
 }
 
 //---------------------------------------------------------------------------//
 //! Move to the next boundary and update volume accordingly
 CELER_FUNCTION real_type GeoTrackView::move_to_boundary()
 {
-    if (!valid_)
+    if (dirty_)
         find_next_step();
 
     // Move the next step plus an extra fudge distance
@@ -117,7 +118,7 @@ CELER_FUNCTION real_type GeoTrackView::move_to_boundary()
 //! Move to the next boundary and update volume accordingly
 CELER_FUNCTION real_type GeoTrackView::move_next_step()
 {
-    if (!valid_)
+    if (dirty_)
         find_next_step();
     real_type dist = next_step_;
     axpy(next_step_, dir_, &pos_);
@@ -131,7 +132,7 @@ CELER_FUNCTION real_type GeoTrackView::move_by(real_type dist)
 {
     CELER_EXPECT(dist > 0.);
 
-    if (!valid_)
+    if (dirty_)
         find_next_step();
 
     // do not move beyond next boundary!
@@ -152,10 +153,11 @@ CELER_FUNCTION void GeoTrackView::move_next_volume()
     this->find_next_step();
 }
 
-//---------------------------------------------------------------------------//1
+//---------------------------------------------------------------------------//
 //! Get the volume ID in the current cell.
 CELER_FUNCTION VolumeId GeoTrackView::volume_id() const
 {
+    CELER_EXPECT(!dirty_);
     return (this->is_outside() ? VolumeId{} : VolumeId{this->volume().id()});
 }
 

--- a/src/geometry/GeoTrackView.i.hh
+++ b/src/geometry/GeoTrackView.i.hh
@@ -95,11 +95,11 @@ GeoTrackView::find_next_step(vecgeom::VPlacedVolume const* pplvol)
     if (this->is_outside())
     {
         // handling points outside of world volume
-        real_type step = 1.e+10;
-        next_step_     = pplvol->DistanceToIn(
-            detail::to_vector(pos_), detail::to_vector(dir_), step);
+        const real_type large = vecgeom::kInfLength;
+        next_step_            = pplvol->DistanceToIn(
+            detail::to_vector(pos_), detail::to_vector(dir_), large);
         vgnext_.Clear();
-        if (next_step_ < step)
+        if (next_step_ < large)
         {
             vgnext_.Push(pplvol);
         }
@@ -121,7 +121,7 @@ GeoTrackView::find_next_step(vecgeom::VPlacedVolume const* pplvol)
 CELER_FUNCTION real_type GeoTrackView::move_to_boundary()
 {
     if (dirty_)
-        find_next_step();
+        this->find_next_step();
 
     // Move the next step plus an extra fudge distance
     real_type dist = next_step_ + this->extra_push();
@@ -136,7 +136,7 @@ CELER_FUNCTION real_type GeoTrackView::move_to_boundary()
 CELER_FUNCTION real_type GeoTrackView::move_next_step()
 {
     if (dirty_)
-        find_next_step();
+        this->find_next_step();
     real_type dist = next_step_;
     axpy(next_step_, dir_, &pos_);
     next_step_ = 0.;
@@ -151,7 +151,7 @@ CELER_FUNCTION real_type GeoTrackView::move_by(real_type dist)
     CELER_EXPECT(dist > 0.);
 
     if (dirty_)
-        find_next_step();
+        this->find_next_step();
 
     // do not move beyond next boundary!
     if (dist >= next_step_)

--- a/src/geometry/LinearPropagator.hh
+++ b/src/geometry/LinearPropagator.hh
@@ -31,7 +31,7 @@ class LinearPropagator
     //! Construct from persistent and state data
     inline CELER_FUNCTION LinearPropagator(GeoTrackView* track);
 
-    // Move track by next_step(), which takes it to next volume boundary.
+    //! Move track to next volume boundary.
     inline CELER_FUNCTION result_type operator()();
 
     /*! Move track by a user-provided distance, or to the next boundary if

--- a/src/geometry/LinearPropagator.hh
+++ b/src/geometry/LinearPropagator.hh
@@ -20,19 +20,28 @@ class LinearPropagator
 {
     using Initializer_t = GeoStateInitializer;
 
+    //! Output results
+    struct result_type
+    {
+        real_type distance; //!< Distance traveled
+        VolumeId  volume;   //!< Post-propagation volume
+    };
+
   public:
-    // Construct from persistent and state data
+    //! Construct from persistent and state data
     inline CELER_FUNCTION LinearPropagator(GeoTrackView* track);
 
     // Move track by next_step(), which takes it to next volume boundary.
-    inline CELER_FUNCTION void operator()();
+    inline CELER_FUNCTION result_type operator()();
 
-    // Move track by a user-provided distance.
-    inline CELER_FUNCTION void operator()(real_type dist);
+    /*! Move track by a user-provided distance, or to the next boundary if
+     *  distance goes beyond it.
+     */
+    inline CELER_FUNCTION result_type operator()(real_type dist);
 
   private:
     // Fast move, update only the position.
-    inline CELER_FUNCTION void apply_linear_step(real_type step);
+    inline CELER_FUNCTION real_type apply_linear_step(real_type step);
 
   private:
     GeoTrackView& track_;

--- a/src/geometry/LinearPropagator.hh
+++ b/src/geometry/LinearPropagator.hh
@@ -34,9 +34,7 @@ class LinearPropagator
     //! Move track to next volume boundary.
     inline CELER_FUNCTION result_type operator()();
 
-    /*! Move track by a user-provided distance, or to the next boundary if
-     *  distance goes beyond it.
-     */
+    //! Move track by a user-provided distance, or to the next boundary
     inline CELER_FUNCTION result_type operator()(real_type dist);
 
   private:

--- a/src/geometry/LinearPropagator.hh
+++ b/src/geometry/LinearPropagator.hh
@@ -40,10 +40,6 @@ class LinearPropagator
     inline CELER_FUNCTION result_type operator()(real_type dist);
 
   private:
-    // Fast move, update only the position.
-    inline CELER_FUNCTION real_type apply_linear_step(real_type step);
-
-  private:
     GeoTrackView& track_;
 };
 

--- a/src/geometry/LinearPropagator.i.hh
+++ b/src/geometry/LinearPropagator.i.hh
@@ -39,8 +39,8 @@ LinearPropagator::result_type LinearPropagator::operator()()
 
 //---------------------------------------------------------------------------//
 /*!
- * Move track by a user-provided distance, or to next boundary if distance is
- * large enough.
+ * Move track by a user-provided distance, or to next boundary if distance
+ * requested goes beyond a volume boundary.
  */
 CELER_FUNCTION
 LinearPropagator::result_type LinearPropagator::operator()(real_type dist)

--- a/src/geometry/LinearPropagator.i.hh
+++ b/src/geometry/LinearPropagator.i.hh
@@ -26,7 +26,7 @@ CELER_FUNCTION LinearPropagator::LinearPropagator(GeoTrackView* track)
 
 //---------------------------------------------------------------------------//
 /*!
- * Move track by next_step(), which takes it to next volume boundary.
+ * Move track to next volume boundary.
  */
 CELER_FUNCTION
 LinearPropagator::result_type LinearPropagator::operator()()
@@ -39,11 +39,8 @@ LinearPropagator::result_type LinearPropagator::operator()()
 
 //---------------------------------------------------------------------------//
 /*!
- * Move track by a user-provided distance.
- *
- * Step must be positive. track_ will check for boundaries to be crossed.
- *
- * \pre Assumes that next_step() has been properly called by client
+ * Move track by a user-provided distance, or to next boundary if distance is
+ * large enough.
  */
 CELER_FUNCTION
 LinearPropagator::result_type LinearPropagator::operator()(real_type dist)

--- a/test/geometry/GeoTrackView.test.cc
+++ b/test/geometry/GeoTrackView.test.cc
@@ -95,7 +95,7 @@ TEST_F(GeoTrackViewHostTest, track_line)
     {
         // Track from outside edge fails
         CELER_LOG(info) << "Init a track with a pointer outside work "
-	                   "volume...";
+                           "volume...";
         geo = {{24, 0, 0}, {-1, 0, 0}};
         EXPECT_EQ(geo.is_outside(), true);
     }
@@ -149,16 +149,14 @@ TEST_F(GeoTrackViewDeviceTest, track_lines)
 
     // Set up test input
     VGGTestInput input;
-    input.init = {
-        {{10, 10, 10}, {1, 0, 0}},
-        {{10, 10, -10}, {1, 0, 0}},
-        {{10, -10, 10}, {1, 0, 0}},
-        {{10, -10, -10}, {1, 0, 0}},
-        {{-10, 10, 10}, {-1, 0, 0}},
-        {{-10, 10, -10}, {-1, 0, 0}},
-        {{-10, -10, 10}, {-1, 0, 0}},
-        {{-10, -10, -10}, {-1, 0, 0}}
-    };
+    input.init         = {{{10, 10, 10}, {1, 0, 0}},
+                  {{10, 10, -10}, {1, 0, 0}},
+                  {{10, -10, 10}, {1, 0, 0}},
+                  {{10, -10, -10}, {1, 0, 0}},
+                  {{-10, 10, 10}, {-1, 0, 0}},
+                  {{-10, 10, -10}, {-1, 0, 0}},
+                  {{-10, -10, 10}, {-1, 0, 0}},
+                  {{-10, -10, -10}, {-1, 0, 0}}};
     input.max_segments = 3;
     input.shared       = this->params()->device_pointers();
 
@@ -168,6 +166,7 @@ TEST_F(GeoTrackViewDeviceTest, track_lines)
     // Run kernel
     auto output = vgg_test(input);
 
+    // clang-format off
     static const int expected_ids[] = {
         0, 1, 2, 0, 1, 5, 0, 1, 4, 0, 1, 8,
         0, 1, 3, 0, 1, 7, 0, 1, 6, 0, 1, 9};
@@ -175,6 +174,7 @@ TEST_F(GeoTrackViewDeviceTest, track_lines)
     static const double expected_distances[]
         = {5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1,
            5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1};
+    // clang-format on
 
     // Check results
     EXPECT_VEC_EQ(expected_ids, output.ids);

--- a/test/geometry/GeoTrackView.test.cc
+++ b/test/geometry/GeoTrackView.test.cc
@@ -11,6 +11,7 @@
 #include "geometry/GeoParams.hh"
 #include "geometry/GeoStateStore.hh"
 #include "comm/Device.hh"
+#include "comm/Logger.hh"
 
 #include "GeoParamsTest.hh"
 #ifdef CELERITAS_USE_CUDA
@@ -91,10 +92,17 @@ TEST_F(GeoTrackViewHostTest, track_line)
         EXPECT_EQ(false, geo.is_outside()); // leaving World
     }
 
+    try
     {
         // Track from outside edge fails
+        CELER_LOG(info) << "Init a track with a pointer outside work "
+                           "volume...";
         geo = {{24, 0, 0}, {-1, 0, 0}};
         EXPECT_EQ(true, geo.is_outside());
+    }
+    catch (const std::exception& e)
+    {
+        // std::cerr<<"caught exception: "<< e.what() << std::endl;
     }
 
     {

--- a/test/geometry/GeoTrackView.test.cc
+++ b/test/geometry/GeoTrackView.test.cc
@@ -92,17 +92,12 @@ TEST_F(GeoTrackViewHostTest, track_line)
         EXPECT_EQ(false, geo.is_outside()); // leaving World
     }
 
-    try
     {
         // Track from outside edge fails
         CELER_LOG(info) << "Init a track with a pointer outside work "
-                           "volume...";
-        geo = {{24, 0, 0}, {-1, 0, 0}};
-        EXPECT_EQ(true, geo.is_outside());
-    }
-    catch (const std::exception& e)
-    {
-        // std::cerr<<"caught exception: "<< e.what() << std::endl;
+	                   "volume...";
+        EXPECT_THROW( (geo = {{24, 0, 0}, {-1, 0, 0}}), celeritas::DebugError );
+        EXPECT_EQ(geo.is_outside(), true);
     }
 
     {

--- a/test/geometry/GeoTrackView.test.cc
+++ b/test/geometry/GeoTrackView.test.cc
@@ -143,9 +143,10 @@ TEST_F(GeoTrackViewDeviceTest, track_lines)
 
     CELER_ASSERT(this->params());
 
+    // clang-format off
     // Set up test input
     VGGTestInput input;
-    input.init         = {{{10, 10, 10}, {1, 0, 0}},
+    input.init = {{{10, 10, 10}, {1, 0, 0}},
                   {{10, 10, -10}, {1, 0, 0}},
                   {{10, -10, 10}, {1, 0, 0}},
                   {{10, -10, -10}, {1, 0, 0}},
@@ -153,6 +154,7 @@ TEST_F(GeoTrackViewDeviceTest, track_lines)
                   {{-10, 10, -10}, {-1, 0, 0}},
                   {{-10, -10, 10}, {-1, 0, 0}},
                   {{-10, -10, -10}, {-1, 0, 0}}};
+    // clang-format on
     input.max_segments = 3;
     input.shared       = this->params()->device_pointers();
 
@@ -164,8 +166,8 @@ TEST_F(GeoTrackViewDeviceTest, track_lines)
 
     // clang-format off
     static const int expected_ids[] = {
-        0, 1, 2, 0, 1, 5, 0, 1, 4, 0, 1, 8,
-        0, 1, 3, 0, 1, 7, 0, 1, 6, 0, 1, 9};
+        1, 2,10, 1, 5,10, 1, 4,10, 1, 8,10,
+        1, 3,10, 1, 7,10, 1, 6,10, 1, 9,10};
 
     static const double expected_distances[]
         = {5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1,

--- a/test/geometry/GeoTrackView.test.cc
+++ b/test/geometry/GeoTrackView.test.cc
@@ -84,29 +84,25 @@ TEST_F(GeoTrackViewHostTest, track_line)
         EXPECT_SOFT_EQ(1, geo.next_step());
         geo.move_next_step();
         EXPECT_EQ(VolumeId{9}, geo.volume_id()); // Shape1 -> Envelope
-        EXPECT_EQ(false, geo.is_outside());
+        EXPECT_FALSE(geo.is_outside());
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(1, geo.next_step());
         geo.move_next_step();
-        EXPECT_EQ(false, geo.is_outside()); // leaving World
+        EXPECT_EQ(VolumeId{10}, geo.volume_id()); // Shape1 -> Envelope
+        EXPECT_FALSE(geo.is_outside());
     }
 
     {
-        // Track from outside edge fails
-        CELER_LOG(info) << "Init a track with a pointer outside work "
-                           "volume...";
-        geo = {{24, 0, 0}, {-1, 0, 0}};
-        EXPECT_EQ(geo.is_outside(), true);
-    }
+        // Track from outside edge used to fail
+        CELER_LOG(info) << "Init a track just outside of world volume...";
+        geo = {{-24, 6.5, 6.5}, {1, 0, 0}};
+        EXPECT_TRUE(geo.is_outside());
 
-    {
-        // But it works when you move juuust inside
-        geo = {{-24 + 1e-3, 6.5, 6.5}, {1, 0, 0}};
-        EXPECT_EQ(false, geo.is_outside());
+        geo.move_next_step();
         EXPECT_EQ(VolumeId{10}, geo.volume_id()); // World
         geo.find_next_step();
-        EXPECT_SOFT_EQ(7. - 1e-3, geo.next_step());
+        EXPECT_SOFT_EQ(7., geo.next_step());
         geo.move_next_step();
         EXPECT_EQ(VolumeId{3}, geo.volume_id()); // World -> Envelope
     }
@@ -120,12 +116,12 @@ TEST_F(GeoTrackViewHostTest, track_line)
         geo.move_next_step();
         EXPECT_SOFT_EQ(5.0, geo.pos()[1]);
         EXPECT_EQ(VolumeId{1}, geo.volume_id()); // Shape1 -> Shape2
-        EXPECT_EQ(false, geo.is_outside());
+        EXPECT_FALSE(geo.is_outside());
 
         geo.find_next_step();
         EXPECT_SOFT_EQ(1.0, geo.next_step());
         geo.move_next_step();
-        EXPECT_EQ(false, geo.is_outside());
+        EXPECT_FALSE(geo.is_outside());
     }
 }
 

--- a/test/geometry/GeoTrackView.test.cc
+++ b/test/geometry/GeoTrackView.test.cc
@@ -96,7 +96,7 @@ TEST_F(GeoTrackViewHostTest, track_line)
         // Track from outside edge fails
         CELER_LOG(info) << "Init a track with a pointer outside work "
 	                   "volume...";
-        EXPECT_THROW( (geo = {{24, 0, 0}, {-1, 0, 0}}), celeritas::DebugError );
+        geo = {{24, 0, 0}, {-1, 0, 0}};
         EXPECT_EQ(geo.is_outside(), true);
     }
 

--- a/test/geometry/GeoTrackView.test.cu
+++ b/test/geometry/GeoTrackView.test.cu
@@ -38,14 +38,13 @@ __global__ void vgg_test_kernel(const GeoParamsPointers shared,
     {
         if (geo.is_outside())
             break;
-        geo.find_next_step();
+
+        // Move next step
+        real_type dist = geo.move_next_step();
 
         // Save current ID and distance to travel
         ids[tid.get() * max_segments + seg]       = geo.volume_id();
-        distances[tid.get() * max_segments + seg] = geo.next_step();
-
-        // Move next step
-        geo.move_next_step();
+        distances[tid.get() * max_segments + seg] = dist;
     }
 }
 

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -217,9 +217,9 @@ TEST_F(LinearPropagatorDeviceTest, track_lines)
     // Run kernel
     auto output = linProp_test(input);
 
-    static const int expected_ids[] = {0, 1, 2, 0, 1, 8, 0, 1, 7, 10, 2, 1};
+    static const int    expected_ids[] = {0, 1, 2, 0, 1, 8, 0, 1, 7, 10, 2, 1};
     static const double expected_distances[]
-        = {5, 1, 1, 5, 1, 2, 5, 1, 3, 3, 1, 2.47582530373998 };
+        = {5, 1, 1, 5, 1, 2, 5, 1, 3, 3, 1, 2.47582530373998};
 
     // Check results
     EXPECT_VEC_EQ(expected_ids, output.ids);

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -94,30 +94,25 @@ TEST_F(LinearPropagatorHostTest, track_line)
         step = propagate(1.e10);
         EXPECT_SOFT_EQ(1, step.distance);
         EXPECT_EQ(VolumeId{3}, step.volume); // Shape1 -> Envelope
-        EXPECT_EQ(false, geo.is_outside());
+        EXPECT_FALSE(geo.is_outside());
 
         step = propagate();
         EXPECT_SOFT_EQ(1, step.distance);
-        EXPECT_EQ(false, geo.is_outside()); // leaving World
+        EXPECT_FALSE(geo.is_outside()); // leaving World
     }
 
     {
-        // Track from outside edge fails
-        CELER_LOG(info) << "Init a track with a pointer outside work "
-                           "volume...";
-        geo = {{24, 0, 0}, {-1, 0, 0}};
-        EXPECT_EQ(true, geo.is_outside());
-    }
-
-    {
-        // But it works when you move juuust inside
-        real_type eps = 1e-6;
-        geo           = {{-24 + eps, 6.5, 6.5}, {1, 0, 0}};
-        EXPECT_EQ(false, geo.is_outside());
-        EXPECT_EQ(VolumeId{10}, geo.volume_id()); // World
+        // Track from outside edge used to fail
+        CELER_LOG(info) << "Init a track just outside of world volume...";
+        geo = {{-24, 6.5, 6.5}, {1, 0, 0}};
+        EXPECT_TRUE(geo.is_outside());
 
         auto step = propagate();
-        EXPECT_SOFT_EQ(7. - eps, step.distance);
+        EXPECT_FALSE(geo.is_outside());
+        EXPECT_EQ(VolumeId{10}, geo.volume_id()); // World
+
+        step = propagate();
+        EXPECT_SOFT_EQ(7., step.distance);
         EXPECT_EQ(VolumeId{3}, step.volume); // World -> Envelope
     }
     {
@@ -129,11 +124,11 @@ TEST_F(LinearPropagatorHostTest, track_line)
         EXPECT_SOFT_EQ(5.0, step.distance);
         EXPECT_SOFT_EQ(5.0, geo.pos()[1]);
         EXPECT_EQ(VolumeId{1}, step.volume); // Shape1 -> Shape2
-        EXPECT_EQ(false, geo.is_outside());
+        EXPECT_FALSE(geo.is_outside());
 
         step = propagate();
         EXPECT_SOFT_EQ(1.0, step.distance);
-        EXPECT_EQ(false, geo.is_outside());
+        EXPECT_FALSE(geo.is_outside());
     }
 }
 

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -105,7 +105,7 @@ TEST_F(LinearPropagatorHostTest, track_line)
         // Track from outside edge fails
         CELER_LOG(info) << "Init a track with a pointer outside work "
                            "volume...";
-        EXPECT_THROW((geo = {{24, 0, 0}, {-1, 0, 0}}), celeritas::DebugError);
+        geo = {{24, 0, 0}, {-1, 0, 0}};
         EXPECT_EQ(true, geo.is_outside());
     }
 

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -101,16 +101,12 @@ TEST_F(LinearPropagatorHostTest, track_line)
         EXPECT_EQ(false, geo.is_outside()); // leaving World
     }
 
-    try
     {
         // Track from outside edge fails
         CELER_LOG(info) << "Init a track with a pointer outside work "
                            "volume...";
-        geo = {{24, 0, 0}, {-1, 0, 0}};
+        EXPECT_THROW((geo = {{24, 0, 0}, {-1, 0, 0}}), celeritas::DebugError);
         EXPECT_EQ(true, geo.is_outside());
-    }
-    catch (const std::exception& e)
-    {
     }
 
     {

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -195,14 +195,18 @@ TEST_F(LinearPropagatorDeviceTest, track_lines)
 
     CELER_ASSERT(this->params());
 
+    // clang-format off
     // Set up test input
     LinPropTestInput input;
-    input.init = {
-        {{10, 10, 10}, {-1, 0, 0}},
-        {{10, -10, -10}, {0, 1, 0}},
-        {{-10, 10, -10}, {0, 0, 1}},
-        {{0, 0, 0}, {1, 1, 1}},
-    };
+    input.init = {{{10, 10, 10}, {1, 0, 0}},
+                  {{10, 10, -10}, {1, 0, 0}},
+                  {{10, -10, 10}, {1, 0, 0}},
+                  {{10, -10, -10}, {1, 0, 0}},
+                  {{-10, 10, 10}, {-1, 0, 0}},
+                  {{-10, 10, -10}, {-1, 0, 0}},
+                  {{-10, -10, 10}, {-1, 0, 0}},
+                  {{-10, -10, -10}, {-1, 0, 0}}};
+    // clang-format on
     input.max_segments = 3;
     input.shared       = this->params()->device_pointers();
 
@@ -212,11 +216,17 @@ TEST_F(LinearPropagatorDeviceTest, track_lines)
     // Run kernel
     auto output = linProp_test(input);
 
-    static const int    expected_ids[] = {0, 1, 2, 0, 1, 8, 0, 1, 7, 10, 2, 1};
-    static const double expected_distances[]
-        = {5, 1, 1, 5, 1, 2, 5, 1, 3, 3, 1, 2.47582530373998};
-
     // Check results
+    // clang-format off
+    static const int expected_ids[] = {
+        1, 2,10, 1, 5,10, 1, 4,10, 1, 8,10,
+        1, 3,10, 1, 7,10, 1, 6,10, 1, 9,10};
+
+    static const double expected_distances[]
+        = {5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1,
+           5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1};
+    // clang-format on
+
     EXPECT_VEC_EQ(expected_ids, output.ids);
     EXPECT_VEC_SOFT_EQ(output.distances, expected_distances);
 }

--- a/test/geometry/LinearPropagator.test.cu
+++ b/test/geometry/LinearPropagator.test.cu
@@ -40,14 +40,11 @@ __global__ void linProp_test_kernel(const GeoParamsPointers shared,
     {
         if (geo.is_outside())
             break;
-        geo.find_next_step();
 
         // Save current ID and distance to travel
-        ids[tid.get() * max_segments + seg]       = geo.volume_id();
-        distances[tid.get() * max_segments + seg] = geo.next_step();
-
-        // Move next step
-        auto temp = propagate();
+        auto step                                 = propagate();
+        ids[tid.get() * max_segments + seg]       = step.volume;
+        distances[tid.get() * max_segments + seg] = step.distance;
     }
 }
 

--- a/test/geometry/LinearPropagator.test.cu
+++ b/test/geometry/LinearPropagator.test.cu
@@ -47,7 +47,7 @@ __global__ void linProp_test_kernel(const GeoParamsPointers shared,
         distances[tid.get() * max_segments + seg] = geo.next_step();
 
         // Move next step
-        propagate();
+        auto temp = propagate();
     }
 }
 


### PR DESCRIPTION
This is a continuation of PR #66, mostling address remaining suggestions from comments there.
- adding a struct to store results from propagation: distance traveled and volume at post-step point
- move all references to geometry away from the LinearPropagator and into GeoTrackView only
- simplify the LinearPropagator interface