### PR TITLE
Improve rasterizer driver

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -124,9 +124,9 @@ if(CELERITAS_BUILD_DEMOS)
   )
 
   if(CELERITAS_BUILD_TESTS)
+    set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py")
     add_test(NAME "app/host-demo-interactor"
-      COMMAND "${Python_EXECUTABLE}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py"
+      COMMAND "${Python_EXECUTABLE}" "${_driver}"
     )
     set(_env
       "CELERITAS_DEMO_EXE=$<TARGET_FILE:host-demo-interactor>"
@@ -135,6 +135,7 @@ if(CELERITAS_BUILD_DEMOS)
     )
     set_tests_properties("app/host-demo-interactor" PROPERTIES
       ENVIRONMENT "${_env}"
+      REQUIRED_FILES "${_driver}"
     )
   endif()
 endif()
@@ -177,9 +178,10 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
   )
 
   if(CELERITAS_BUILD_TESTS)
+    set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/demo-rasterizer/simple-driver.py")
+    set(_gdml_inp "${PROJECT_SOURCE_DIR}/test/geometry/data/twoBoxes.gdml")
     add_test(NAME "app/demo-rasterizer"
-      COMMAND "${Python_EXECUTABLE}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/demo-rasterizer/simple-driver.py"
+      COMMAND "${Python_EXECUTABLE}" "${_driver}" "${_gdml_inp}"
     )
     set(_env
       "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-rasterizer>"
@@ -188,6 +190,7 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
     set_tests_properties("app/demo-rasterizer" PROPERTIES
       ENVIRONMENT "${_env}"
       RESOURCE_LOCK gpu
+      REQUIRED_FILES "${_driver};${_gdml_inp}"
     )
   endif()
 endif()

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -97,9 +97,9 @@ if(CELERITAS_BUILD_DEMOS)
     target_link_libraries(demo-interactor celeritas_demo_interactor CUDA::cudart)
 
     if(CELERITAS_BUILD_TESTS)
+      set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py")
       add_test(NAME "app/demo-interactor"
-        COMMAND "${Python_EXECUTABLE}"
-          "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py"
+        COMMAND "$<TARGET_FILE:Python::Interpreter>" "${_driver}"
       )
       set(_env
         "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-interactor>"
@@ -108,6 +108,7 @@ if(CELERITAS_BUILD_DEMOS)
       set_tests_properties("app/demo-interactor" PROPERTIES
         ENVIRONMENT "${_env}"
         RESOURCE_LOCK gpu
+        REQUIRED_FILES "${_driver}"
       )
     endif()
   endif()
@@ -126,7 +127,7 @@ if(CELERITAS_BUILD_DEMOS)
   if(CELERITAS_BUILD_TESTS)
     set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/demo-interactor/simple-driver.py")
     add_test(NAME "app/host-demo-interactor"
-      COMMAND "${Python_EXECUTABLE}" "${_driver}"
+      COMMAND "$<TARGET_FILE:Python::Interpreter>" "${_driver}"
     )
     set(_env
       "CELERITAS_DEMO_EXE=$<TARGET_FILE:host-demo-interactor>"
@@ -181,7 +182,7 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
     set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/demo-rasterizer/simple-driver.py")
     set(_gdml_inp "${PROJECT_SOURCE_DIR}/test/geometry/data/twoBoxes.gdml")
     add_test(NAME "app/demo-rasterizer"
-      COMMAND "${Python_EXECUTABLE}" "${_driver}" "${_gdml_inp}"
+      COMMAND "$<TARGET_FILE:Python::Interpreter>" "${_driver}" "${_gdml_inp}"
     )
     set(_env
       "CELERITAS_DEMO_EXE=$<TARGET_FILE:demo-rasterizer>"

--- a/app/demo-rasterizer/simple-driver.py
+++ b/app/demo-rasterizer/simple-driver.py
@@ -9,7 +9,13 @@ import json
 from pprint import pprint
 import subprocess
 from os import environ
-from sys import exit
+from sys import exit, argv
+
+try:
+    (gdml_filename,) = argv[1:]
+except TypeError:
+    print("usage: {} inp.gdml".format(sys.argv[0]))
+    exit(2)
 
 inp = {
     'image': {
@@ -18,7 +24,7 @@ inp = {
         'rightward_ax': [1, 0, 0],
         'vertical_pixels': 32
     },
-    'input': '../../test/geometry/data/twoBoxes.gdml',
+    'input': gdml_filename,
     'output': 'two-boxes.bin'
 }
 
@@ -46,5 +52,5 @@ except json.decoder.JSONDecodeError as e:
     print("fatal:", str(e))
     exit(1)
 pprint(result)
-with open('{exe}.out.json', 'w') as f:
+with open(f'{exe}.out.json', 'w') as f:
     json.dump(result, f)


### PR DESCRIPTION
Remove the assumption that the build directory is directly inside the source directory. Also fix a missing `f` that led to a bogus filename being written for the rasterizer's debug output.