### PR TITLE
Fix non-constexpr numeric limits on CUDA device

### DIFF
--- a/src/base/NumericLimits.hh
+++ b/src/base/NumericLimits.hh
@@ -7,62 +7,80 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <cfloat>
+#include <climits>
 #ifdef __CUDA_ARCH__
-#    include <cfloat>
-#    include <climits>
 #    include <math_constants.h>
 #else
 #    include <limits>
 #endif
+#include "Macros.hh"
 
 namespace celeritas
 {
-#ifdef __CUDA_ARCH__
+/*!
+ */
 template<class Numeric>
 struct numeric_limits;
 
 template<>
 struct numeric_limits<float>
 {
-    static constexpr __device__ float epsilon() { return FLT_EPSILON; }
-    static constexpr __device__ float quiet_NaN() { return CUDART_NAN_F; }
-    static constexpr __device__ float infinity() { return CUDART_INF_F; }
-    static constexpr __device__ float max() { return FLT_MAX; }
+    static CELER_CONSTEXPR_FUNCTION float epsilon() { return FLT_EPSILON; }
+    static CELER_CONSTEXPR_FUNCTION float max() { return FLT_MAX; }
+
+#ifndef __CUDA_ARCH__
+    static float quiet_NaN()
+    {
+        return std::numeric_limits<float>::quiet_NaN();
+    }
+    static float infinity() { return std::numeric_limits<float>::infinity(); }
+#else
+    static CELER_FUNCTION float  quiet_NaN() { return CUDART_NAN_F; }
+    static CELER_FUNCTION float  infinity() { return CUDART_INF_F; }
+#endif
 };
 
 template<>
 struct numeric_limits<double>
 {
-    static constexpr __device__ double epsilon() { return DBL_EPSILON; }
-    static constexpr __device__ double quiet_NaN() { return CUDART_NAN; }
-    static constexpr __device__ double infinity() { return CUDART_INF; }
-    static constexpr __device__ double max() { return DBL_MAX; }
+    static CELER_CONSTEXPR_FUNCTION double epsilon() { return DBL_EPSILON; }
+    static CELER_CONSTEXPR_FUNCTION double max() { return DBL_MAX; }
+
+#ifndef __CUDA_ARCH__
+    static double quiet_NaN()
+    {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    static double infinity()
+    {
+        return std::numeric_limits<double>::infinity();
+    }
+#else
+    static CELER_FUNCTION double quiet_NaN() { return CUDART_NAN; }
+    static CELER_FUNCTION double infinity() { return CUDART_INF; }
+#endif
 };
 
 template<>
 struct numeric_limits<unsigned int>
 {
-    static constexpr __device__ unsigned int max() { return UINT_MAX; }
+    static CELER_CONSTEXPR_FUNCTION unsigned int max() { return UINT_MAX; }
 };
 
 template<>
 struct numeric_limits<unsigned long>
 {
-    static constexpr __device__ unsigned long max() { return ULONG_MAX; }
+    static CELER_CONSTEXPR_FUNCTION unsigned long max() { return ULONG_MAX; }
 };
 
 template<>
 struct numeric_limits<unsigned long long>
 {
-    static constexpr __device__ unsigned long long max() { return ULLONG_MAX; }
+    static CELER_CONSTEXPR_FUNCTION unsigned long long max()
+    {
+        return ULLONG_MAX;
+    }
 };
-
-#else // not __CUDA_ARCH__
-
-//! Alias to standard library numeric limits
-template<class Numeric>
-using numeric_limits = std::numeric_limits<Numeric>;
-
-#endif // __CUDA_ARCH__
 
 } // namespace celeritas

--- a/src/base/Quantity.hh
+++ b/src/base/Quantity.hh
@@ -176,7 +176,7 @@ CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type> zero_quantity()
 /*!
  * Get a quantitity greater than any other numeric quantity.
  */
-CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type> max_quantity()
+inline CELER_FUNCTION detail::UnitlessQuantity<real_type> max_quantity()
 {
     return {numeric_limits<real_type>::infinity()};
 }
@@ -185,7 +185,7 @@ CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type> max_quantity()
 /*!
  * Get a quantitity less than any other numeric quantity.
  */
-CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type> neg_max_quantity()
+inline CELER_FUNCTION detail::UnitlessQuantity<real_type> neg_max_quantity()
 {
     return {-numeric_limits<real_type>::infinity()};
 }

--- a/src/physics/base/PhysicsStepUtils.i.hh
+++ b/src/physics/base/PhysicsStepUtils.i.hh
@@ -31,8 +31,8 @@ calc_tabulated_physics_step(const MaterialTrackView& material,
 {
     CELER_EXPECT(physics.has_interaction_mfp());
 
-    constexpr real_type inf = numeric_limits<real_type>::infinity();
-    using VGT               = ValueGridType;
+    const real_type inf = numeric_limits<real_type>::infinity();
+    using VGT           = ValueGridType;
 
     // Loop over all processes that apply to this track (based on particle
     // type) and calculate cross section and particle range.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,14 +64,16 @@ endif()
 if(NOT CELERITAS_USE_ROOT)
   set(_needs_root DISABLE)
 endif()
+
 if(NOT CELERITAS_USE_Geant4)
   set(_needs_geant4 DISABLE)
 else()
   # Optional dependence on low-energy EM data
   set(_ds G4EMLOW)
-  set(_geant_emlow
+  set(_optional_geant4
      ENVIRONMENT "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
   )
+  set(_needs_geant4 ${_optional_geant4})
 endif()
 
 #-----------------------------------------------------------------------------#
@@ -218,7 +220,7 @@ celeritas_add_test(physics/em/Urban.test.cc ${_not_impl})
 celeritas_add_test(physics/em/Wentzel.test.cc ${_not_impl})
 
 celeritas_add_test(physics/em/ImportedProcesses.test.cc ${_needs_root}
-  ${_geant_emlow}
+  ${_optional_geant4}
   GPU # TODO: delete when device pointers are no longer directly accessed
   LINK_LIBRARIES Celeritas::ROOT)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,13 +102,8 @@ celeritas_add_test(base/Stopwatch.test.cc)
 celeritas_add_test(base/TypeDemangler.test.cc)
 celeritas_add_test(base/VectorUtils.test.cc)
 
-if(CELERITAS_USE_CUDA)
-  celeritas_add_test(base/NumericLimits.test.cc
-    SOURCES base/NumericLimits.test.cu
-    GPU)
-endif()
-
 celeritas_cudaoptional_test(base/Collection)
+celeritas_cudaoptional_test(base/NumericLimits)
 celeritas_cudaoptional_test(base/Range)
 celeritas_cudaoptional_test(base/StackAllocator)
 

--- a/test/base/NumericLimits.test.cc
+++ b/test/base/NumericLimits.test.cc
@@ -23,7 +23,7 @@ class RealNumericLimitsTest : public celeritas::Test
 {
 };
 using RealTypes = ::testing::Types<float, double>;
-TYPED_TEST_SUITE(RealNumericLimitsTest, RealTypes);
+TYPED_TEST_SUITE(RealNumericLimitsTest, RealTypes, );
 
 TYPED_TEST(RealNumericLimitsTest, host)
 {
@@ -36,7 +36,11 @@ TYPED_TEST(RealNumericLimitsTest, host)
     EXPECT_TRUE(std::isnan(celer_limits_t::quiet_NaN()));
 }
 
+#if CELERITAS_USE_CUDA
 TYPED_TEST(RealNumericLimitsTest, device)
+#else
+TYPED_TEST(RealNumericLimitsTest, DISABLED_device)
+#endif
 {
     using celer_limits_t = celeritas::numeric_limits<TypeParam>;
     auto result          = nl_test<TypeParam>();
@@ -58,7 +62,7 @@ class UIntNumericLimitsTest : public celeritas::Test
 
 using UIntTypes
     = ::testing::Types<unsigned int, unsigned long, unsigned long long>;
-TYPED_TEST_SUITE(UIntNumericLimitsTest, UIntTypes);
+TYPED_TEST_SUITE(UIntNumericLimitsTest, UIntTypes, );
 
 TYPED_TEST(UIntNumericLimitsTest, host)
 {

--- a/test/base/NumericLimits.test.cc
+++ b/test/base/NumericLimits.test.cc
@@ -15,31 +15,55 @@
 using namespace celeritas_test;
 
 //---------------------------------------------------------------------------//
-// TEST HARNESS
+// REAL TYPES
 //---------------------------------------------------------------------------//
 
 template<class T>
-class NumericLimitsTest : public celeritas::Test
+class RealNumericLimitsTest : public celeritas::Test
 {
-  protected:
-    void SetUp() override {}
+};
+using RealTypes = ::testing::Types<float, double>;
+TYPED_TEST_SUITE(RealNumericLimitsTest, RealTypes);
+
+TYPED_TEST(RealNumericLimitsTest, host)
+{
+    using std_limits_t   = std::numeric_limits<TypeParam>;
+    using celer_limits_t = celeritas::numeric_limits<TypeParam>;
+
+    EXPECT_EQ(std_limits_t::epsilon(), celer_limits_t::epsilon());
+    EXPECT_EQ(std_limits_t::infinity(), celer_limits_t::infinity());
+    EXPECT_EQ(std_limits_t::max(), celer_limits_t::max());
+    EXPECT_TRUE(std::isnan(celer_limits_t::quiet_NaN()));
+}
+
+TYPED_TEST(RealNumericLimitsTest, device)
+{
+    using celer_limits_t = celeritas::numeric_limits<TypeParam>;
+    auto result          = nl_test<TypeParam>();
+
+    EXPECT_EQ(celer_limits_t::epsilon(), result.eps);
+    EXPECT_TRUE(std::isnan(result.nan));
+    EXPECT_EQ(celer_limits_t::infinity(), result.inf);
+    EXPECT_EQ(celer_limits_t::max(), result.max);
+}
+
+//---------------------------------------------------------------------------//
+// UNSIGNED INT TYPES
+//---------------------------------------------------------------------------//
+
+template<class T>
+class UIntNumericLimitsTest : public celeritas::Test
+{
 };
 
-using RealTypes = ::testing::Types<float, double>;
-TYPED_TEST_SUITE(NumericLimitsTest, RealTypes);
+using UIntTypes
+    = ::testing::Types<unsigned int, unsigned long, unsigned long long>;
+TYPED_TEST_SUITE(UIntNumericLimitsTest, UIntTypes);
 
-//---------------------------------------------------------------------------//
-// TESTS
-//---------------------------------------------------------------------------//
-
-// Test that on-device and on-host values are equivalent
-TYPED_TEST(NumericLimitsTest, all)
+TYPED_TEST(UIntNumericLimitsTest, host)
 {
-    using limits_t = celeritas::numeric_limits<TypeParam>;
-    auto result    = nl_test<TypeParam>();
+    using std_limits_t   = std::numeric_limits<TypeParam>;
+    using celer_limits_t = celeritas::numeric_limits<TypeParam>;
 
-    EXPECT_EQ(limits_t::epsilon(), result.eps);
-    EXPECT_TRUE(std::isnan(result.nan));
-    EXPECT_EQ(limits_t::infinity(), result.inf);
-    EXPECT_EQ(limits_t::max(), result.max);
+    EXPECT_EQ(std_limits_t::max(), celer_limits_t::max());
 }

--- a/test/base/NumericLimits.test.hh
+++ b/test/base/NumericLimits.test.hh
@@ -6,6 +6,8 @@
 //! \file NumericLimits.test.hh
 //---------------------------------------------------------------------------//
 
+#include "base/Assert.hh"
+
 namespace celeritas_test
 {
 //---------------------------------------------------------------------------//
@@ -25,6 +27,14 @@ struct NLTestOutput
 //! Run on device and return results
 template<class T>
 NLTestOutput<T> nl_test();
+
+#if !CELERITAS_USE_CUDA
+template<class T>
+inline NLTestOutput<T> nl_test()
+{
+    CELER_NOT_CONFIGURED("CUDA");
+}
+#endif
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas_test


### PR DESCRIPTION
The on-device "inf" and NaN expression are defined by on-device non-constexpr functions and integer constants:
```
./math_constants.h:54:#define CUDART_INF_F            __int_as_float(0x7f800000)
./math_constants.h:91:#define CUDART_INF              __longlong_as_double(0x7ff0000000000000ULL)
```
this meant that the `static constexpr __device__ double infinity()` failed. Thus we cannot label infinity as `constexpr`, which will affect any code that expects to call infinity on device.

I also have sneaked a fix to the geant4 data variables ;)