### PR TITLE
Reduce cmake duplication for linking against vecgeom

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -145,22 +145,16 @@ endif()
 if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
   # Since the demo kernel links against VecGeom, which requires CUDA separable
   # compilation, it cannot be linked directly into an executable.
-  add_library(demo_rasterizer_cuda
+  add_library(celeritas_demo_rasterizer
     demo-rasterizer/RDemoRunner.cc
     demo-rasterizer/RDemoKernel.cu
   )
-  set_target_properties(demo_rasterizer_cuda PROPERTIES
-    LINKER_LANGUAGE CUDA
-    CUDA_SEPARABLE_COMPILATION ON
-    POSITION_INDEPENDENT_CODE ON
-  )
-  target_link_libraries(demo_rasterizer_cuda
+  target_link_libraries(celeritas_demo_rasterizer
     PRIVATE
-    celeritas
-    VecGeom::vecgeomcuda
-    VecGeom::vecgeomcuda_static
-    nlohmann_json::nlohmann_json
+      celeritas
+      nlohmann_json::nlohmann_json
   )
+  celeritas_link_vecgeom_cuda(celeritas_demo_rasterizer)
 
   # Add the executable
   add_executable(demo-rasterizer
@@ -171,7 +165,7 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
   target_link_libraries(demo-rasterizer
     celeritas
     VecGeom::vecgeom
-    demo_rasterizer_cuda
+    celeritas_demo_rasterizer
     nlohmann_json::nlohmann_json
   )
 

--- a/cmake/CeleritasUtils.cmake
+++ b/cmake/CeleritasUtils.cmake
@@ -25,6 +25,15 @@ CMake utility functions for Celeritas.
 
   Once upstream packages are updated, this can be replaced by ``find_package``.
 
+
+.. command:: celeritas_link_vecgeom_cuda
+
+  Link the given target privately against VecGeom with CUDA support.
+
+  ::
+
+    celeritas_link_vecgeom_cuda(<target>)
+
 #]=======================================================================]
 include(FindPackageHandleStandardArgs)
 
@@ -32,5 +41,17 @@ macro(celeritas_find_package_config _package)
   find_package(${_package} CONFIG ${ARGN})
   find_package_handle_standard_args(${_package} CONFIG_MODE)
 endmacro()
+
+function(celeritas_link_vecgeom_cuda target)
+  set_target_properties(${target} PROPERTIES
+    LINKER_LANGUAGE CUDA
+    CUDA_SEPARABLE_COMPILATION ON
+  )
+  target_link_libraries(${target}
+    PRIVATE
+    VecGeom::vecgeomcuda
+    VecGeom::vecgeomcuda_static
+  )
+endfunction()
 
 #-----------------------------------------------------------------------------#

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,7 +140,6 @@ if(CELERITAS_USE_VecGeom)
       geometry/detail/VGNavStateStore.cuda.cc
       sim/detail/InitializeTracks.cu
     )
-    list(APPEND PRIVATE_DEPS VecGeom::vecgeomcuda VecGeom::vecgeomcuda_static)
   else()
     list(APPEND SOURCES
       geometry/detail/VGNavStateStore.nocuda.cc
@@ -152,17 +151,13 @@ endif()
 add_library(celeritas ${SOURCES})
 add_library(Celeritas::Core ALIAS celeritas)
 
-if(CELERITAS_USE_VecGeom AND CELERITAS_USE_CUDA)
-  set_target_properties(celeritas PROPERTIES
-    LINKER_LANGUAGE CUDA
-    CUDA_SEPARABLE_COMPILATION ON
-  )
-endif()
-
 target_link_libraries(celeritas
   PRIVATE ${PRIVATE_DEPS}
   PUBLIC ${PUBLIC_DEPS}
 )
+if(CELERITAS_USE_VecGeom AND CELERITAS_USE_CUDA)
+  celeritas_link_vecgeom_cuda(celeritas)
+endif()
 
 target_include_directories(celeritas
   PUBLIC

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,13 +137,11 @@ if(CELERITAS_USE_VecGeom)
       geometry/GeoTrackView.test.cu
       geometry/LinearPropagator.test.cu
     )
-    # NOTE: changing link order causes segfault at runtime:
-    # must be celeritas, then vg, then vg_static
     target_link_libraries(celeritas_vgtest
       PRIVATE
+      celeritas
       VecGeom::vecgeomcuda
       VecGeom::vecgeomcuda_static
-      celeritas
     )
     set_target_properties(celeritas_vgtest PROPERTIES
       LINKER_LANGUAGE CUDA

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,11 +137,13 @@ if(CELERITAS_USE_VecGeom)
       geometry/GeoTrackView.test.cu
       geometry/LinearPropagator.test.cu
     )
+    # NOTE: changing link order causes segfault at runtime:
+    # must be celeritas, then vg, then vg_static
     target_link_libraries(celeritas_vgtest
       PRIVATE
-      celeritas
       VecGeom::vecgeomcuda
       VecGeom::vecgeomcuda_static
+      celeritas
     )
     set_target_properties(celeritas_vgtest PROPERTIES
       LINKER_LANGUAGE CUDA

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -132,28 +132,21 @@ if(CELERITAS_USE_VecGeom)
     # See https://github.com/celeritas-project/celeritas/pull/10 for a
     # discussion of the failures from trying to directly build an executable
     # from code with CUDA separable compilation. This extra test library is
-    # necessary.
+    # necessary. Furthermore, celeritas must be linked *before* vecgeom.
     add_library(celeritas_vgtest
       geometry/GeoTrackView.test.cu
       geometry/LinearPropagator.test.cu
     )
-    target_link_libraries(celeritas_vgtest
-      PRIVATE
-      celeritas
-      VecGeom::vecgeomcuda
-      VecGeom::vecgeomcuda_static
-    )
-    set_target_properties(celeritas_vgtest PROPERTIES
-      LINKER_LANGUAGE CUDA
-      CUDA_SEPARABLE_COMPILATION ON
-      POSITION_INDEPENDENT_CODE ON
-    )
+    target_link_libraries(celeritas_vgtest PRIVATE celeritas)
+    celeritas_link_vecgeom_cuda(celeritas_vgtest)
     list(APPEND CELERITASTEST_LINK_LIBRARIES celeritas_vgtest)
   endif()
 
   celeritas_add_test(geometry/GeoParams.test.cc GPU)
   celeritas_add_test(geometry/GeoTrackView.test.cc GPU)
   celeritas_add_test(geometry/LinearPropagator.test.cc GPU)
+
+  set(CELERITASTEST_LINK_LIBRARIES)
 endif()
 
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
The first commit is just to ensure and document that the geometry tests fail when changing the vecgeom link order.