### PR TITLE
Adding ROOT-based GDML parsing

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -194,3 +194,41 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
 endif()
 
 #-----------------------------------------------------------------------------#
+# Utility: single-track geometry debugging
+#-----------------------------------------------------------------------------#
+
+if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
+  # Since the demo kernel links against VecGeom, which requires CUDA separable
+  # compilation, it cannot be linked directly into an executable.
+  add_library(geo_check_cuda
+    geo-check/GCheckRunner.cc
+    geo-check/GCheckKernel.cc
+    geo-check/GCheckKernel.cu
+  )
+  set_target_properties(geo_check_cuda PROPERTIES
+    LINKER_LANGUAGE CUDA
+    CUDA_SEPARABLE_COMPILATION ON
+    POSITION_INDEPENDENT_CODE ON
+  )
+  target_link_libraries(geo_check_cuda
+    PRIVATE
+    celeritas
+    VecGeom::vecgeomcuda
+    VecGeom::vecgeomcuda_static
+    nlohmann_json::nlohmann_json
+  )
+
+  # Add the executable
+  add_executable(geo-check
+    geo-check/geo-check.cc
+  )
+  target_link_libraries(geo-check
+    celeritas
+    VecGeom::vecgeom
+    geo_check_cuda
+    nlohmann_json::nlohmann_json
+  )
+
+endif()
+
+#-----------------------------------------------------------------------------#

--- a/app/geo-check/GCheckKernel.cc
+++ b/app/geo-check/GCheckKernel.cc
@@ -1,0 +1,54 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file GCheckKernel.cc
+//---------------------------------------------------------------------------//
+#include "GCheckKernel.hh"
+
+#include "geometry/LinearPropagator.hh"
+
+namespace geo_check
+{
+using namespace celeritas;
+
+/*!
+ *  Run tracking on the CPU
+ */
+void run_cpu(GeoParamsPointers const&   params_view,
+             GeoStatePointers const&    track,
+             GeoStateInitializer const* init,
+             int                        max_steps)
+{
+    GeoTrackView geo(params_view, track, ThreadId(0));
+    geo = GeoStateInitializer{init->pos, init->dir};
+    LinearPropagator propagate(&geo); // one propagator per track
+
+    printf("Initial track: pos=(%f, %f, %f), dir=(%f, %f, %f), outside=%i\n",
+           geo.pos()[0],
+           geo.pos()[1],
+           geo.pos()[2],
+           geo.dir()[0],
+           geo.dir()[1],
+           geo.dir()[2],
+           geo.is_outside());
+
+    // Track from outside detector, moving right
+    for (int istep = 0; istep < max_steps; ++istep)
+    {
+        if (geo.is_outside())
+            break;
+
+        auto step = propagate(); // to next boundary
+        printf("step=%i: volid=%i dist=%f, curpos=(%f, %f, %f)\n",
+               istep,
+               (geo.is_outside() ? -1 : step.volume.get()),
+               step.distance,
+               geo.pos()[0],
+               geo.pos()[1],
+               geo.pos()[2]);
+    }
+}
+
+} // namespace geo_check

--- a/app/geo-check/GCheckKernel.cu
+++ b/app/geo-check/GCheckKernel.cu
@@ -1,0 +1,86 @@
+//---------------------------------*-CUDA-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file GCheckKernel.cu
+//---------------------------------------------------------------------------//
+#include "GCheckKernel.hh"
+
+#include "base/Assert.hh"
+#include "base/KernelParamCalculator.cuda.hh"
+#include "geometry/GeoInterface.hh"
+#include "geometry/GeoTrackView.hh"
+#include "geometry/LinearPropagator.hh"
+#include <cmath>
+
+using namespace celeritas;
+
+namespace geo_check
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+// KERNELS
+//---------------------------------------------------------------------------//
+
+__global__ void gcheck_kernel(const GeoParamsPointers   geo_params,
+                              const GeoStatePointers    geo_state,
+                              const GeoStateInitializer init,
+                              int                       ntrks,
+                              int                       max_steps)
+{
+    auto tid = celeritas::KernelParamCalculator::thread_id();
+    if (tid.get() >= ntrks)
+        return;
+
+    GeoTrackView     geo(geo_params, geo_state, tid);
+    LinearPropagator propagate(&geo);
+
+    // Start track at the leftmost point in the requested direction
+    geo = GeoStateInitializer{init};
+
+    real_type geo_dist = geo.next_step();
+
+    // Track along each pixel
+    for (int istep = 0; istep < max_steps; ++istep)
+    {
+        if (geo.is_outside())
+            break;
+
+        // Save current ID and distance to travel
+        auto step = propagate();
+        printf("tid=%i step=%i: volid=%i, dist=%f\n",
+               tid.get(),
+               istep,
+               (geo.is_outside() ? -1 : (int)step.volume.get()),
+               step.distance);
+    }
+}
+} // namespace
+
+//---------------------------------------------------------------------------//
+// KERNEL INTERFACE
+//---------------------------------------------------------------------------//
+/*!
+ *  Run tracking on the GPU
+ */
+void run_gpu(const GeoParamsPointers&   geo_params,
+             const GeoStatePointers&    geo_state,
+             const GeoStateInitializer& init,
+             int                        max_steps)
+{
+    // CELER_EXPECT(init);
+
+    // static const KernelParamCalculator calc_kernel_params(trace_kernel,
+    //                                                       "trace");
+
+    // auto params = calc_kernel_params(init);
+    gcheck_kernel<<<1, 1>>>(geo_params, geo_state, init, 1, max_steps);
+    CELER_CUDA_CHECK_ERROR();
+
+    CELER_CUDA_CALL(cudaDeviceSynchronize());
+}
+
+//---------------------------------------------------------------------------//
+} // namespace geo_check

--- a/app/geo-check/GCheckKernel.hh
+++ b/app/geo-check/GCheckKernel.hh
@@ -1,0 +1,29 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file GCheckKernel.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "geometry/GeoInterface.hh"
+
+namespace geo_check
+{
+//---------------------------------------------------------------------------//
+//! Run tracking on the CPU
+void run_cpu(celeritas::GeoParamsPointers const&   params_view,
+             celeritas::GeoStatePointers const&    track,
+             celeritas::GeoStateInitializer const* init,
+             int                                   max_steps);
+
+//---------------------------------------------------------------------------//
+//! Run tracking on the GPU
+void run_gpu(const celeritas::GeoParamsPointers&   geo_params,
+             const celeritas::GeoStatePointers&    geo_state,
+             const celeritas::GeoStateInitializer& track_init,
+             int                                   max_steps);
+
+//---------------------------------------------------------------------------//
+} // namespace geo_check

--- a/app/geo-check/GCheckRunner.cc
+++ b/app/geo-check/GCheckRunner.cc
@@ -1,0 +1,71 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file GCheckRunner.cc
+//---------------------------------------------------------------------------//
+#include "GCheckRunner.hh"
+
+//#include "base/Range.hh"
+#include "base/Stopwatch.hh"
+#include "base/ColorUtils.hh"
+#include "comm/Logger.hh"
+#include "geometry/GeoParams.hh"
+#include "geometry/GeoStateStore.hh"
+#include "geometry/GeoInterface.hh"
+#include "geometry/GeoTrackView.hh"
+#include "geometry/LinearPropagator.hh"
+#include "GCheckKernel.hh"
+#include "VecGeom/navigation/NavigationState.h"
+
+using namespace celeritas;
+
+namespace geo_check
+{
+using NavState = vecgeom::NavigationState;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with image parameters
+ */
+GCheckRunner::GCheckRunner(SPConstGeo geometry, int max_steps)
+    : geo_params_(std::move(geometry)), max_steps_(max_steps)
+{
+    CELER_EXPECT(geo_params_);
+    CELER_EXPECT(max_steps > 0);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Propagate a track for debugging purposes
+ */
+void GCheckRunner::operator()(const GeoStateInitializer* init, int ntrks) const
+{
+    CELER_EXPECT(init);
+
+    GeoStatePointers state_view;
+    state_view.size       = ntrks;
+    state_view.vgmaxdepth = geo_params_->max_depth();
+    state_view.pos        = new Real3;
+    state_view.dir        = new Real3;
+    state_view.next_step  = new real_type{0.0};
+    state_view.vgstate    = NavState::MakeInstance(state_view.vgmaxdepth);
+    state_view.vgnext     = NavState::MakeInstance(state_view.vgmaxdepth);
+
+    // run on the CPU
+    CELER_LOG(status) << "Propagating track(s) on CPU";
+    run_cpu(geo_params_->host_pointers(), state_view, init, max_steps_);
+
+    // run on the GPU device
+    GeoStateStore geo_state(*geo_params_, ntrks);
+
+    CELER_LOG(status) << "Propagating track(s) on GPU";
+    run_gpu(geo_params_->device_pointers(),
+            geo_state.device_pointers(),
+            *init,
+            max_steps_);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace geo_check

--- a/app/geo-check/GCheckRunner.hh
+++ b/app/geo-check/GCheckRunner.hh
@@ -1,0 +1,45 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file GCheckRunner.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include "geometry/GeoParams.hh"
+#include "geometry/GeoInterface.hh"
+
+using namespace celeritas;
+
+namespace geo_check
+{
+using SPConstGeo = std::shared_ptr<const celeritas::GeoParams>;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set up and run rasterization of the given device image.
+ */
+class GCheckRunner
+{
+  public:
+    //!@{
+    //! Type aliases
+    using SPConstGeo = std::shared_ptr<const celeritas::GeoParams>;
+    //!@}
+
+  public:
+    // Construct with geometry
+    explicit GCheckRunner(SPConstGeo geometry, int max_steps);
+
+    // Run over some tracks
+    void operator()(const celeritas::GeoStateInitializer* init, int ntk) const;
+
+  private:
+    SPConstGeo geo_params_;
+    int        max_steps_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace geo_check

--- a/app/geo-check/geo-check.cc
+++ b/app/geo-check/geo-check.cc
@@ -1,0 +1,132 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geo-check.cc
+//---------------------------------------------------------------------------//
+
+#include "base/Units.hh"
+#include "base/Range.hh"
+#include "comm/Device.hh"
+#include "comm/DeviceIO.json.hh"
+// #include "comm/KernelDiagnostics.hh"
+// #include "comm/KernelDiagnosticsIO.json.hh"
+#include "comm/Logger.hh"
+
+#include "GCheckRunner.hh"
+
+using namespace celeritas;
+
+namespace geo_check
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Run, launch, and output.
+ */
+void run(std::istream& is)
+{
+    // Read input options
+    auto inp = nlohmann::json::parse(is);
+
+    // Load geometry
+    auto geo_params = std::make_shared<GeoParams>(
+        inp.at("input").get<std::string>().c_str());
+
+    if (inp.count("cuda_stack_size"))
+    {
+        GeoParams::set_cuda_stack_size(inp.at("cuda_stack_size").get<int>());
+    }
+
+    int max_steps = inp.at("max_steps").get<int>();
+
+    // define track(s)
+    int ntracks = 1;
+
+    // constexpr real_type cm = celeritas::units::centimeter;
+    // constexpr real_type mm = 0.1 * cm;
+    // GeoStateInitializer init{{3441.4*cm, 0, -10860*cm}, {0, 0, 1}};
+
+    Real3 pos, dir;
+    for (int i = 0; i < 3; ++i)
+    {
+        pos[i] = inp.at("track_origin")[i].get<real_type>();
+        dir[i] = inp.at("track_direction")[i].get<real_type>();
+#if CELERITAS_USE_ROOT and defined(VECGEOM_ROOT)
+        pos[i] = 10.0 * pos[i];
+#endif
+    }
+    GeoStateInitializer init{pos, dir};
+
+    // Construct runner
+    GCheckRunner run(geo_params, max_steps);
+    CELER_ASSERT(geo_params);
+    run(&init, ntracks);
+
+    // Get geometry names
+    std::vector<std::string> vol_names;
+    for (auto vol_id : celeritas::range(geo_params->num_volumes()))
+    {
+        vol_names.push_back(
+            geo_params->id_to_label(celeritas::VolumeId(vol_id)));
+    }
+}
+
+} // namespace geo_check
+
+//---------------------------------------------------------------------------//
+/*!
+ * Execute and run.
+ *
+ * \todo This is copied from the other demo apps; move these to a shared driver
+ * at some point.
+ */
+int main(int argc, char* argv[])
+{
+    // Process input arguments
+    std::vector<std::string> args(argv, argv + argc);
+    if (args.size() != 2 || args[1] == "--help" || args[1] == "-h")
+    {
+        std::cerr << "usage: " << args[0] << " {input}.json" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::ifstream infile;
+    std::istream* instream_ptr = nullptr;
+    if (args[1] != "-")
+    {
+        infile.open(args[1]);
+        if (!infile)
+        {
+            CELER_LOG(critical) << "Failed to open '" << args[1] << "'";
+            return EXIT_FAILURE;
+        }
+        instream_ptr = &infile;
+    }
+    else
+    {
+        // Read input from STDIN
+        instream_ptr = &std::cin;
+    }
+
+    // Initialize GPU
+    celeritas::activate_device(Device(0));
+    if (!celeritas::device())
+    {
+        CELER_LOG(critical) << "CUDA capability is disabled";
+        return EXIT_FAILURE;
+    }
+
+    try
+    {
+        CELER_ASSERT(instream_ptr);
+        geo_check::run(*instream_ptr);
+    }
+    catch (const std::exception& e)
+    {
+        CELER_LOG(critical) << "caught exception: " << e.what();
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/app/geo-check/geocheck.json
+++ b/app/geo-check/geocheck.json
@@ -1,0 +1,7 @@
+{
+    "input": "../test/geometry/data/cms2018.gdml",
+    "max_steps": 500,
+    "track_origin": [-1012.5, 10, -856.25],
+    "track_direction": [1, 0, 0],
+    "cuda_stack_size": 65536
+}

--- a/app/geo-check/index.md
+++ b/app/geo-check/index.md
@@ -1,0 +1,6 @@
+
+# geo-check: a single-track geometry debugger #
+
+Usage: app/geo-check geocheck.json
+
+The input .json file provides geometry, and track origin,direction.

--- a/src/geometry/GeoParams.cc
+++ b/src/geometry/GeoParams.cc
@@ -23,10 +23,8 @@
 #include "GeoInterface.hh"
 #include "detail/ScopedTimeAndRedirect.hh"
 
-#ifdef CELERITAS_USE_ROOT
+#if CELERITAS_USE_ROOT && defined(VECGEOM_ROOT)
 #    include "TGeoManager.h"
-#endif
-#ifdef VECGEOM_ROOT
 #    include "VecGeom/management/RootGeoManager.h"
 #endif
 

--- a/src/geometry/GeoParams.cc
+++ b/src/geometry/GeoParams.cc
@@ -41,37 +41,17 @@ GeoParams::GeoParams(const char* gdml_filename)
     {
         detail::ScopedTimeAndRedirect time_and_output_;
 
-#ifndef CELERITAS_USE_ROOT
-        CELER_LOG(info) << "VecGeom parsing: Loading from GDML at "
-                        << gdml_filename;
-        constexpr bool                validate_xml_schema = false;
-        vgdml::Frontend::Load(gdml_filename, validate_xml_schema);
-#else
-
-#    ifdef VECGEOM_ROOT
+#if CELERITAS_USE_ROOT && defined(VECGEOM_ROOT)
         // use Root available from VecGeom
         CELER_LOG(info) << "RootGeoManager parsing: Loading from GDML at "
                         << gdml_filename;
         vecgeom::RootGeoManager::Instance().set_verbose(1);
         vecgeom::RootGeoManager::Instance().LoadRootGeometry(gdml_filename);
-
-#    else
-        // use Root available from VecGeom
-        CELER_LOG(info) << "Root TGeoManager parsing: Loading from GDML at "
+#else
+        CELER_LOG(info) << "VecGeom parsing: Loading from GDML at "
                         << gdml_filename;
-        TGeoManager::Import(gdml_filename);
-
-        vecgeom::GeoManager::Instance().Clear();
-        TGeoNode const* const world_root = ::gGeoManager->GetTopNode();
-        // Convert() will recursively convert daughters
-        Stopwatch timer;
-        timer.Start();
-        auto fWorld = Convert(world_root);
-        timer.Stop();
-        std::cout << "*** Conversion of ROOT -> VecGeom finished ("
-                  << timer.Elapsed() << " s) ***\n";
-#    endif
-
+        constexpr bool validate_xml_schema = false;
+        vgdml::Frontend::Load(gdml_filename, validate_xml_schema);
 #endif
     }
 

--- a/src/geometry/GeoParams.cc
+++ b/src/geometry/GeoParams.cc
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #include "GeoParams.hh"
 
-#include <VecGeom/gdml/Frontend.h>
 #include <VecGeom/management/ABBoxManager.h>
 #include <VecGeom/management/GeoManager.h>
 #include <VecGeom/volumes/PlacedVolume.h>
@@ -26,6 +25,8 @@
 #if CELERITAS_USE_ROOT && defined(VECGEOM_ROOT)
 #    include "TGeoManager.h"
 #    include "VecGeom/management/RootGeoManager.h"
+#else
+#    include <VecGeom/gdml/Frontend.h>
 #endif
 
 namespace celeritas
@@ -49,7 +50,8 @@ GeoParams::GeoParams(const char* gdml_filename)
         CELER_LOG(info) << "VecGeom parsing: Loading from GDML at "
                         << gdml_filename;
         constexpr bool validate_xml_schema = false;
-        vgdml::Frontend::Load(gdml_filename, validate_xml_schema);
+	real_type mm_scale = 1.0;    // indirectly sets default VecGeom units
+        vgdml::Frontend::Load(gdml_filename, validate_xml_schema, mm_scale);
 #endif
     }
 

--- a/test/geometry/GeoParams.test.cc
+++ b/test/geometry/GeoParams.test.cc
@@ -41,13 +41,23 @@ TEST_F(GeoParamsHostTest, accessors)
     EXPECT_EQ(11, geom.num_volumes());
     EXPECT_EQ(4, geom.max_depth());
 
+    unsigned int nvols = geom.num_volumes();
+
+#ifdef VECGEOM_ROOT
+    EXPECT_EQ("World_1", geom.id_to_label(VolumeId{0}));
+    EXPECT_EQ("env1", geom.id_to_label(VolumeId{1}));
+    EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{2}));
+
+    EXPECT_EQ("env7", geom.id_to_label(VolumeId{nvols - 2}));
+    EXPECT_EQ("env8", geom.id_to_label(VolumeId{nvols - 1}));
+#else
     EXPECT_EQ("Shape2", geom.id_to_label(VolumeId{0}));
     EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{1}));
     EXPECT_EQ("Envelope", geom.id_to_label(VolumeId{2}));
 
-    unsigned int nvols = geom.num_volumes();
     EXPECT_EQ("Envelope", geom.id_to_label(VolumeId{nvols - 2}));
     EXPECT_EQ("World", geom.id_to_label(VolumeId{nvols - 1}));
+#endif
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geometry/GeoParams.test.cc
+++ b/test/geometry/GeoParams.test.cc
@@ -43,7 +43,7 @@ TEST_F(GeoParamsHostTest, accessors)
 
     unsigned int nvols = geom.num_volumes();
 
-#ifdef VECGEOM_ROOT
+#if CELERITAS_USE_ROOT && defined(VECGEOM_ROOT)
     EXPECT_EQ("World_1", geom.id_to_label(VolumeId{0}));
     EXPECT_EQ("env1", geom.id_to_label(VolumeId{1}));
     EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{2}));

--- a/test/geometry/GeoTrackView.test.cc
+++ b/test/geometry/GeoTrackView.test.cc
@@ -71,55 +71,55 @@ TEST_F(GeoTrackViewHostTest, track_line)
 
     {
         // Track from outside detector, moving right
-        geo = {{-10, -10, -10}, {1, 0, 0}};
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape2 center
+        geo = {{-100, -100, -100}, {1, 0, 0}};
+        EXPECT_EQ(VolumeId{3}, geo.volume_id()); // Shape2 center
 
         geo.find_next_step();
-        EXPECT_SOFT_EQ(5, geo.next_step());
+        EXPECT_SOFT_EQ(50, geo.next_step());
         geo.move_next_step();
-        EXPECT_SOFT_EQ(-5, geo.pos()[0]);
-        EXPECT_EQ(VolumeId{1}, geo.volume_id()); // Shape2 -> Shape1
+        EXPECT_SOFT_EQ(-50, geo.pos()[0]);
+        EXPECT_EQ(VolumeId{2}, geo.volume_id()); // Shape2 -> Shape1
 
         geo.find_next_step();
-        EXPECT_SOFT_EQ(1, geo.next_step());
+        EXPECT_SOFT_EQ(10, geo.next_step());
         geo.move_next_step();
-        EXPECT_EQ(VolumeId{9}, geo.volume_id()); // Shape1 -> Envelope
+        EXPECT_EQ(VolumeId{10}, geo.volume_id()); // Shape1 -> Envelope
         EXPECT_FALSE(geo.is_outside());
 
         geo.find_next_step();
-        EXPECT_SOFT_EQ(1, geo.next_step());
+        EXPECT_SOFT_EQ(10, geo.next_step());
         geo.move_next_step();
-        EXPECT_EQ(VolumeId{10}, geo.volume_id()); // Shape1 -> Envelope
+        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape1 -> Envelope
         EXPECT_FALSE(geo.is_outside());
     }
 
     {
         // Track from outside edge used to fail
         CELER_LOG(info) << "Init a track just outside of world volume...";
-        geo = {{-24, 6.5, 6.5}, {1, 0, 0}};
+        geo = {{-240, 65, 65}, {1, 0, 0}};
         EXPECT_TRUE(geo.is_outside());
 
         geo.move_next_step();
-        EXPECT_EQ(VolumeId{10}, geo.volume_id()); // World
+        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // World
         geo.find_next_step();
-        EXPECT_SOFT_EQ(7., geo.next_step());
+        EXPECT_SOFT_EQ(70., geo.next_step());
         geo.move_next_step();
-        EXPECT_EQ(VolumeId{3}, geo.volume_id()); // World -> Envelope
+        EXPECT_EQ(VolumeId{4}, geo.volume_id()); // World -> Envelope
     }
     {
         // Track from inside detector
-        geo = {{-10, 10, 10}, {0, -1, 0}};
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape1 center
+        geo = {{-100, 100, 100}, {0, -1, 0}};
+        EXPECT_EQ(VolumeId{3}, geo.volume_id()); // Shape1 center
 
         geo.find_next_step();
-        EXPECT_SOFT_EQ(5.0, geo.next_step());
+        EXPECT_SOFT_EQ(50.0, geo.next_step());
         geo.move_next_step();
-        EXPECT_SOFT_EQ(5.0, geo.pos()[1]);
-        EXPECT_EQ(VolumeId{1}, geo.volume_id()); // Shape1 -> Shape2
+        EXPECT_SOFT_EQ(50.0, geo.pos()[1]);
+        EXPECT_EQ(VolumeId{2}, geo.volume_id()); // Shape1 -> Shape2
         EXPECT_FALSE(geo.is_outside());
 
         geo.find_next_step();
-        EXPECT_SOFT_EQ(1.0, geo.next_step());
+        EXPECT_SOFT_EQ(10.0, geo.next_step());
         geo.move_next_step();
         EXPECT_FALSE(geo.is_outside());
     }
@@ -146,15 +146,15 @@ TEST_F(GeoTrackViewDeviceTest, track_lines)
     // clang-format off
     // Set up test input
     VGGTestInput input;
-    input.init = {{{10, 10, 10}, {1, 0, 0}},
-                  {{10, 10, -10}, {1, 0, 0}},
-                  {{10, -10, 10}, {1, 0, 0}},
-                  {{10, -10, -10}, {1, 0, 0}},
-                  {{-10, 10, 10}, {-1, 0, 0}},
-                  {{-10, 10, -10}, {-1, 0, 0}},
-                  {{-10, -10, 10}, {-1, 0, 0}},
-                  {{-10, -10, -10}, {-1, 0, 0}}};
-    // clang-format on
+    input.init = {{{100, 100, 100}, {1, 0, 0}},
+                  {{100, 100, -100}, {1, 0, 0}},
+                  {{100, -100, 100}, {1, 0, 0}},
+                  {{100, -100, -100}, {1, 0, 0}},
+                  {{-100, 100, 100}, {-1, 0, 0}},
+                  {{-100, 100, -100}, {-1, 0, 0}},
+                  {{-100, -100, 100}, {-1, 0, 0}},
+                  {{-100, -100, -100}, {-1, 0, 0}}};
+
     input.max_segments = 3;
     input.shared       = this->params()->device_pointers();
 
@@ -165,13 +165,13 @@ TEST_F(GeoTrackViewDeviceTest, track_lines)
     auto output = vgg_test(input);
 
     // clang-format off
-    static const int expected_ids[] = {
-        1, 2,10, 1, 5,10, 1, 4,10, 1, 8,10,
-        1, 3,10, 1, 7,10, 1, 6,10, 1, 9,10};
+    static const int expected_ids[]
+        = { 2, 1, 0, 2, 6, 0, 2, 5, 0, 2, 9, 0,
+            2, 4, 0, 2, 8, 0, 2, 7, 0, 2,10, 0};
 
     static const double expected_distances[]
-        = {5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1,
-           5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1};
+        = {50, 10, 10, 50, 10, 10, 50, 10, 10, 50, 10, 10,
+           50, 10, 10, 50, 10, 10, 50, 10, 10, 50, 10, 10};
     // clang-format on
 
     // Check results

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -70,8 +70,13 @@ TEST_F(LinearPropagatorHostTest, accessors)
     const auto& geom = *params();
     EXPECT_EQ(11, geom.num_volumes());
     EXPECT_EQ(4, geom.max_depth());
+#ifdef VECGEOM_ROOT
+    EXPECT_EQ("World_1", geom.id_to_label(VolumeId{0}));
+    EXPECT_EQ("env1", geom.id_to_label(VolumeId{1}));
+#else
     EXPECT_EQ("Shape2", geom.id_to_label(VolumeId{0}));
     EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{1}));
+#endif
 }
 
 //----------------------------------------------------------------------------//
@@ -83,51 +88,51 @@ TEST_F(LinearPropagatorHostTest, track_line)
 
     {
         // Track from outside detector, moving right
-        geo = {{-10, 10, 10}, {1, 0, 0}};
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape2 center
+        geo = {{-100, 100, 100}, {1, 0, 0}};
+        EXPECT_EQ(VolumeId{3}, geo.volume_id()); // Shape2 center
 
         auto step = propagate(1.e10); // very large proposed step
-        EXPECT_SOFT_EQ(5, step.distance);
-        EXPECT_EQ(VolumeId{1}, step.volume); // Shape2 -> Shape1
-        EXPECT_SOFT_EQ(-5, geo.pos()[0]);
+        EXPECT_SOFT_EQ(50, step.distance);
+        EXPECT_EQ(VolumeId{2}, step.volume); // Shape2 -> Shape1
+        EXPECT_SOFT_EQ(-50, geo.pos()[0]);
 
         step = propagate(1.e10);
-        EXPECT_SOFT_EQ(1, step.distance);
-        EXPECT_EQ(VolumeId{3}, step.volume); // Shape1 -> Envelope
+        EXPECT_SOFT_EQ(10, step.distance);
+        EXPECT_EQ(VolumeId{4}, step.volume); // Shape1 -> Envelope
         EXPECT_FALSE(geo.is_outside());
 
         step = propagate();
-        EXPECT_SOFT_EQ(1, step.distance);
+        EXPECT_SOFT_EQ(10, step.distance);
         EXPECT_FALSE(geo.is_outside()); // leaving World
     }
 
     {
         // Track from outside edge used to fail
         CELER_LOG(info) << "Init a track just outside of world volume...";
-        geo = {{-24, 6.5, 6.5}, {1, 0, 0}};
+        geo = {{-240, 65, 65}, {1, 0, 0}};
         EXPECT_TRUE(geo.is_outside());
 
         auto step = propagate();
         EXPECT_FALSE(geo.is_outside());
-        EXPECT_EQ(VolumeId{10}, geo.volume_id()); // World
+        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // World
 
         step = propagate();
-        EXPECT_SOFT_EQ(7., step.distance);
-        EXPECT_EQ(VolumeId{3}, step.volume); // World -> Envelope
+        EXPECT_SOFT_EQ(70., step.distance);
+        EXPECT_EQ(VolumeId{4}, step.volume); // World -> Envelope
     }
     {
         // Track from inside detector
-        geo = {{-10, 10, 10}, {0, -1, 0}};
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape1 center
+        geo = {{-100, 100, 100}, {0, -1, 0}};
+        EXPECT_EQ(VolumeId{3}, geo.volume_id()); // Shape1 center
 
         auto step = propagate();
-        EXPECT_SOFT_EQ(5.0, step.distance);
-        EXPECT_SOFT_EQ(5.0, geo.pos()[1]);
-        EXPECT_EQ(VolumeId{1}, step.volume); // Shape1 -> Shape2
+        EXPECT_SOFT_EQ(50.0, step.distance);
+        EXPECT_SOFT_EQ(50.0, geo.pos()[1]);
+        EXPECT_EQ(VolumeId{2}, step.volume); // Shape1 -> Shape2
         EXPECT_FALSE(geo.is_outside());
 
         step = propagate();
-        EXPECT_SOFT_EQ(1.0, step.distance);
+        EXPECT_SOFT_EQ(10.0, step.distance);
         EXPECT_FALSE(geo.is_outside());
     }
 }
@@ -141,39 +146,39 @@ TEST_F(LinearPropagatorHostTest, track_intraVolume)
 
     {
         // Track from outside detector, moving right
-        geo = {{-10, 10, 10}, {0, 0, 1}};
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape2
+        geo = {{-100, 100, 100}, {0, 0, 1}};
+        EXPECT_EQ(VolumeId{3}, geo.volume_id()); // Shape2
 
         // break next step into two
         auto step = propagate(0.5 * geo.next_step());
-        EXPECT_SOFT_EQ(2.5, step.distance);
-        EXPECT_SOFT_EQ(12.5, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{0}, step.volume); // still Shape2
+        EXPECT_SOFT_EQ(25, step.distance);
+        EXPECT_SOFT_EQ(125, geo.pos()[2]);
+        EXPECT_EQ(VolumeId{3}, step.volume); // still Shape2
 
         step = propagate(); // all remaining
-        EXPECT_SOFT_EQ(2.5, step.distance);
-        EXPECT_SOFT_EQ(15.0, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{1}, step.volume); // Shape2 -> Shape1
+        EXPECT_SOFT_EQ(25, step.distance);
+        EXPECT_SOFT_EQ(150, geo.pos()[2]);
+        EXPECT_EQ(VolumeId{2}, step.volume); // Shape2 -> Shape1
 
         // break next step into > 2 steps, re-calculating next_step each time
         step = propagate(0.2 * geo.next_step()); // step 1 inside Detector
-        EXPECT_SOFT_EQ(0.2, step.distance);
-        EXPECT_SOFT_EQ(15.2, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{1}, step.volume); // Shape1
+        EXPECT_SOFT_EQ(2, step.distance);
+        EXPECT_SOFT_EQ(152, geo.pos()[2]);
+        EXPECT_EQ(VolumeId{2}, step.volume); // Shape1
 
-        EXPECT_SOFT_EQ(0.8, geo.next_step());
+        EXPECT_SOFT_EQ(8, geo.next_step());
 
         step = propagate(0.5 * geo.next_step()); // step 2 inside Detector
-        EXPECT_SOFT_EQ(0.4, step.distance);
-        EXPECT_SOFT_EQ(15.6, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{1}, step.volume); // Shape1
+        EXPECT_SOFT_EQ(4, step.distance);
+        EXPECT_SOFT_EQ(156, geo.pos()[2]);
+        EXPECT_EQ(VolumeId{2}, step.volume); // Shape1
 
-        EXPECT_SOFT_EQ(0.4, geo.next_step());
+        EXPECT_SOFT_EQ(4, geo.next_step());
 
         step = propagate(geo.next_step()); // last step inside Detector
-        EXPECT_SOFT_EQ(0.4, step.distance);
-        EXPECT_SOFT_EQ(16, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{3}, step.volume); // Shape1 -> Envelope
+        EXPECT_SOFT_EQ(4, step.distance);
+        EXPECT_SOFT_EQ(160, geo.pos()[2]);
+        EXPECT_EQ(VolumeId{4}, step.volume); // Shape1 -> Envelope
     }
 }
 
@@ -198,14 +203,14 @@ TEST_F(LinearPropagatorDeviceTest, track_lines)
     // clang-format off
     // Set up test input
     LinPropTestInput input;
-    input.init = {{{10, 10, 10}, {1, 0, 0}},
-                  {{10, 10, -10}, {1, 0, 0}},
-                  {{10, -10, 10}, {1, 0, 0}},
-                  {{10, -10, -10}, {1, 0, 0}},
-                  {{-10, 10, 10}, {-1, 0, 0}},
-                  {{-10, 10, -10}, {-1, 0, 0}},
-                  {{-10, -10, 10}, {-1, 0, 0}},
-                  {{-10, -10, -10}, {-1, 0, 0}}};
+    input.init = {{{100, 100, 100}, {1, 0, 0}},
+                  {{100, 100, -100}, {1, 0, 0}},
+                  {{100, -100, 100}, {1, 0, 0}},
+                  {{100, -100, -100}, {1, 0, 0}},
+                  {{-100, 100, 100}, {-1, 0, 0}},
+                  {{-100, 100, -100}, {-1, 0, 0}},
+                  {{-100, -100, 100}, {-1, 0, 0}},
+                  {{-100, -100, -100}, {-1, 0, 0}}};
     // clang-format on
     input.max_segments = 3;
     input.shared       = this->params()->device_pointers();
@@ -218,13 +223,12 @@ TEST_F(LinearPropagatorDeviceTest, track_lines)
 
     // Check results
     // clang-format off
-    static const int expected_ids[] = {
-        1, 2,10, 1, 5,10, 1, 4,10, 1, 8,10,
-        1, 3,10, 1, 7,10, 1, 6,10, 1, 9,10};
-
+    static const int expected_ids[]
+        = { 2, 1, 0, 2, 6, 0, 2, 5, 0, 2, 9, 0,
+            2, 4, 0, 2, 8, 0, 2, 7, 0, 2,10, 0};
     static const double expected_distances[]
-        = {5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1,
-           5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1};
+        = {50, 10, 10, 50, 10, 10, 50, 10, 10, 50, 10, 10,
+           50, 10, 10, 50, 10, 10, 50, 10, 10, 50, 10, 10};
     // clang-format on
 
     EXPECT_VEC_EQ(expected_ids, output.ids);


### PR DESCRIPTION
Root-based GDML parsing replaces VecGeom's parser if ROOT use in enabled (USE_ROOT=ON).