### PR TITLE
Simplify RNG counter reset for physics unit tests

### DIFF
--- a/test/physics/InteractorHostTestBase.hh
+++ b/test/physics/InteractorHostTestBase.hh
@@ -41,10 +41,10 @@ namespace celeritas_test
 {
 //---------------------------------------------------------------------------//
 /*!
- * Test harness base class for a host-side Interactor.
+ * Test harness base class for EM physics models.
  *
- * This class initializes host versions of some of the common inputs to an
- * Interactor. It \b cannot be used for testing device instantiations.
+ * \todo Since this now uses Collection objects it's generally safe to use this
+ * to test Models as well as device code -- think about renaming it.
  */
 class InteractorHostTestBase : public celeritas::Test
 {
@@ -146,8 +146,12 @@ class InteractorHostTestBase : public celeritas::Test
     //!@}
 
     //!@{
-    //! Random number generator
-    RandomEngine& rng() { return rng_; }
+    //! Get random number generator with clean counter
+    RandomEngine& rng()
+    {
+        rng_.reset_count();
+        return rng_;
+    }
     //!@}
 
     // Check for energy and momentum conservation

--- a/test/physics/em/BetheHeitler.test.cc
+++ b/test/physics/em/BetheHeitler.test.cc
@@ -188,8 +188,6 @@ TEST_F(BetheHeitlerInteractorTest, basic)
 
 TEST_F(BetheHeitlerInteractorTest, stress_test)
 {
-    RandomEngine& rng_engine = this->rng();
-
     const unsigned int  num_samples = 8;
     std::vector<double> avg_engine_samples;
 
@@ -198,6 +196,8 @@ TEST_F(BetheHeitlerInteractorTest, stress_test)
     {
         SCOPED_TRACE("Incident energy: " + std::to_string(inc_e));
         this->set_inc_particle(pdg::gamma(), MevEnergy{inc_e});
+
+        RandomEngine&           rng_engine            = this->rng();
         RandomEngine::size_type num_particles_sampled = 0;
 
         // Loop over several incident directions
@@ -233,7 +233,6 @@ TEST_F(BetheHeitlerInteractorTest, stress_test)
         }
         avg_engine_samples.push_back(double(rng_engine.count())
                                      / double(num_particles_sampled));
-        rng_engine.reset_count();
     }
     // Gold values for average number of calls to RNG
     const double expected_avg_engine_samples[]

--- a/test/physics/em/EPlusGG.test.cc
+++ b/test/physics/em/EPlusGG.test.cc
@@ -213,8 +213,6 @@ TEST_F(EPlusGGInteractorTest, at_rest)
 
 TEST_F(EPlusGGInteractorTest, stress_test)
 {
-    RandomEngine& rng_engine = this->rng();
-
     const int           num_samples = 8192;
     std::vector<double> avg_engine_samples;
 
@@ -222,6 +220,8 @@ TEST_F(EPlusGGInteractorTest, stress_test)
     {
         SCOPED_TRACE("Incident energy: " + std::to_string(inc_e));
         this->set_inc_particle(pdg::positron(), MevEnergy{inc_e});
+
+        RandomEngine&           rng_engine            = this->rng();
         RandomEngine::size_type num_particles_sampled = 0;
 
         // Loop over several incident directions
@@ -251,7 +251,6 @@ TEST_F(EPlusGGInteractorTest, stress_test)
         }
         avg_engine_samples.push_back(double(rng_engine.count())
                                      / double(num_particles_sampled));
-        rng_engine.reset_count();
     }
 
     // PRINT_EXPECTED(avg_engine_samples);

--- a/test/physics/em/KleinNishina.test.cc
+++ b/test/physics/em/KleinNishina.test.cc
@@ -148,8 +148,6 @@ TEST_F(KleinNishinaInteractorTest, ten_mev)
 
 TEST_F(KleinNishinaInteractorTest, stress_test)
 {
-    RandomEngine& rng_engine = this->rng();
-
     const int           num_samples = 8192;
     std::vector<double> avg_engine_samples;
 
@@ -157,6 +155,8 @@ TEST_F(KleinNishinaInteractorTest, stress_test)
     {
         SCOPED_TRACE("Incident energy: " + std::to_string(inc_e));
         this->set_inc_particle(pdg::gamma(), MevEnergy{inc_e});
+
+        RandomEngine&           rng_engine            = this->rng();
         RandomEngine::size_type num_particles_sampled = 0;
 
         // Loop over several incident directions (shouldn't affect anything
@@ -186,7 +186,6 @@ TEST_F(KleinNishinaInteractorTest, stress_test)
         }
         avg_engine_samples.push_back(double(rng_engine.count())
                                      / double(num_particles_sampled));
-        rng_engine.reset_count();
     }
 
     // PRINT_EXPECTED(avg_engine_samples);

--- a/test/physics/em/LivermorePE.test.cc
+++ b/test/physics/em/LivermorePE.test.cc
@@ -224,8 +224,6 @@ TEST_F(LivermorePETest, basic)
 
 TEST_F(LivermorePETest, stress_test)
 {
-    RandomEngine& rng_engine = this->rng();
-
     const int           num_samples = 8192;
     std::vector<double> avg_engine_samples;
 
@@ -235,6 +233,8 @@ TEST_F(LivermorePETest, stress_test)
     {
         SCOPED_TRACE("Incident energy: " + std::to_string(inc_e));
         this->set_inc_particle(pdg::gamma(), MevEnergy{inc_e});
+
+        RandomEngine&           rng_engine            = this->rng();
         RandomEngine::size_type num_particles_sampled = 0;
 
         // Loop over several incident directions (shouldn't affect anything
@@ -266,8 +266,8 @@ TEST_F(LivermorePETest, stress_test)
         }
         avg_engine_samples.push_back(double(rng_engine.count())
                                      / double(num_particles_sampled));
-        rng_engine.reset_count();
     }
+
     // PRINT_EXPECTED(avg_engine_samples);
     // Gold values for average number of calls to RNG
     const double expected_avg_engine_samples[]

--- a/test/physics/em/MollerBhabha.test.cc
+++ b/test/physics/em/MollerBhabha.test.cc
@@ -331,8 +331,6 @@ TEST_F(MollerBhabhaInteractorTest, cutoff_1MeV)
 //---------------------------------------------------------------------------//
 TEST_F(MollerBhabhaInteractorTest, stress_test)
 {
-    RandomEngine& rng = this->rng();
-
     const int           num_samples = 1e4;
     std::vector<double> avg_engine_samples;
 
@@ -348,6 +346,7 @@ TEST_F(MollerBhabhaInteractorTest, stress_test)
     {
         for (double inc_e : {5e-3, 1.0, 10.0, 100.0, 1000.0})
         {
+            RandomEngine&           rng_engine            = this->rng();
             RandomEngine::size_type num_particles_sampled = 0;
 
             // Loop over several incident directions (shouldn't affect anything
@@ -371,7 +370,7 @@ TEST_F(MollerBhabhaInteractorTest, stress_test)
                 // Loop over half the sample size
                 for (int i = 0; i < num_samples; ++i)
                 {
-                    Interaction result = mb_interact(rng);
+                    Interaction result = mb_interact(rng_engine);
                     this->sanity_check(result);
                 }
 
@@ -379,9 +378,8 @@ TEST_F(MollerBhabhaInteractorTest, stress_test)
                           this->secondary_allocator().get().size());
                 num_particles_sampled += num_samples;
             }
-            avg_engine_samples.push_back(double(rng.count())
+            avg_engine_samples.push_back(double(rng_engine.count())
                                          / double(num_particles_sampled));
-            rng.reset_count();
         }
     }
     // Gold values for average number of calls to rng

--- a/test/physics/em/Rayleigh.test.cc
+++ b/test/physics/em/Rayleigh.test.cc
@@ -107,15 +107,12 @@ TEST_F(RayleighInteractorTest, basic)
     std::vector<unsigned long int> rng_counts;
 
     // Sample scattering angle and count rng used for each incident energy
-    RandomEngine& rng_engine = this->rng();
-
     for (double inc_e : {1e-5, 1e-4, 0.001, 0.01, 0.1, 1., 10., 100., 1000.})
     {
+        RandomEngine& rng_engine = this->rng();
+
         // Set the incident particle energy
         this->set_inc_particle(pdg::gamma(), MevEnergy{inc_e});
-
-        // Reset rng count
-        rng_engine.reset_count();
 
         // Create the interactor
         RayleighInteractor interact(this->model_->host_group(),
@@ -127,7 +124,6 @@ TEST_F(RayleighInteractorTest, basic)
         celeritas::Interaction result = interact(rng_engine);
         SCOPED_TRACE(result);
         this->sanity_check(result);
-        rng_engine.count();
 
         angle.push_back(dot_product(result.direction, this->direction()));
         rng_counts.push_back(rng_engine.count());
@@ -161,15 +157,13 @@ TEST_F(RayleighInteractorTest, stress_test)
     std::vector<real_type> average_rng_counts;
 
     // Sample scattering angle and count rng used for each incident energy
-    RandomEngine& rng_engine = this->rng();
-
     for (double inc_e : {1e-5, 1e-4, 0.001, 0.01, 0.1, 1., 10., 100., 1000.})
     {
         // Set the incident particle energy
         this->set_inc_particle(pdg::gamma(), MevEnergy{inc_e});
 
         // Reset the rng counter
-        rng_engine.reset_count();
+        RandomEngine& rng_engine = this->rng();
 
         // Create the interactor
         RayleighInteractor interact(this->model_->host_group(),

--- a/test/physics/em/SeltzerBerger.test.cc
+++ b/test/physics/em/SeltzerBerger.test.cc
@@ -163,7 +163,6 @@ TEST_F(SeltzerBergerTest, sb_positron_xs_scaling)
 
 TEST_F(SeltzerBergerTest, sb_energy_dist)
 {
-    RandomEngine&   rng_engine = this->rng();
     const MevEnergy gamma_cutoff{0.0009};
 
     const int           num_samples = 8192;
@@ -190,6 +189,7 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
         double total_exit_energy = 0;
 
         // Loop over many particles
+        RandomEngine& rng_engine = this->rng();
         for (int i = 0; i < num_samples; ++i)
         {
             Energy exit_gamma = sample_energy(rng_engine);
@@ -200,7 +200,6 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
 
         avg_exit_frac.push_back(total_exit_energy / (num_samples * inc_energy));
         avg_engine_samples.push_back(double(rng_engine.count()) / num_samples);
-        rng_engine.reset_count();
     }
 
     // clang-format off


### PR DESCRIPTION
This implements @whokion 's suggestion of simplifying the diagnostic RNG counters, being more foolproof by resetting the counter when calling `rng()`. (Note though that the RNG stream state itself isn't reset when calling rng.)