### PR TITLE
Interactor tweaks

### DIFF
--- a/src/base/Algorithms.hh
+++ b/src/base/Algorithms.hh
@@ -33,6 +33,18 @@ CELER_CONSTEXPR_FUNCTION const T& max(const T& a, const T& b)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Return the value or (if it's negative) then zero.
+ *
+ * This is constructed to correctly propagate NaN.
+ */
+template<class T>
+CELER_CONSTEXPR_FUNCTION T clamp_to_nonneg(T v)
+{
+    return (v < 0) ? 0 : v;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Return an integer power of the input value.
  *
  * Example: \code

--- a/src/physics/em/RayleighModel.cc
+++ b/src/physics/em/RayleighModel.cc
@@ -30,9 +30,8 @@ RayleighModel::RayleighModel(ModelId               id,
     host_group.model_id = id;
     host_group.gamma_id = particles.find(pdg::gamma());
     CELER_VALIDATE(host_group.gamma_id,
-                   << "missing gamma particles "
-                      "(required for "
-                   << this->label() << ")");
+                   << "missing gamma particles (required for " << this->label()
+                   << ")");
 
     this->build_data(&host_group, materials);
 

--- a/src/physics/em/detail/BetheHeitlerInteractor.i.hh
+++ b/src/physics/em/detail/BetheHeitlerInteractor.i.hh
@@ -20,8 +20,7 @@ namespace detail
 /*!
  * Construct with shared and state data.
  *
- * The incident particle must be above the energy threshold: this should be
- * handled in code *before* the interactor is constructed.
+ * The incident gamma energy must be at least twice the electron rest mass.
  */
 BetheHeitlerInteractor::BetheHeitlerInteractor(
     const BetheHeitlerPointers& shared,
@@ -36,12 +35,10 @@ BetheHeitlerInteractor::BetheHeitlerInteractor(
     , element_(element)
 {
     CELER_EXPECT(particle.particle_id() == shared_.gamma_id);
+    CELER_EXPECT(inc_energy_.value() > 2 / shared_.inv_electron_mass);
 
-    epsilon0_ = 1.0 / (shared_.inv_electron_mass * inc_energy_.value());
-    // Gamma energy must be at least 2x electron rest mass
-    CELER_ASSERT(epsilon0_ < 0.5);
-    static_assert(sizeof(real_type) == sizeof(double),
-                  "Embedded constants are hardcoded to double precision.");
+    epsilon0_ = 1 / (shared_.inv_electron_mass * inc_energy_.value());
+    CELER_ENSURE(epsilon0_ < real_type(0.5));
 }
 
 //---------------------------------------------------------------------------//
@@ -61,33 +58,42 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         return Interaction::from_failure();
     }
 
+    constexpr real_type half = 0.5;
+
     // If E_gamma < 2 MeV, rejection not needed -- just sample uniformly
     real_type epsilon;
-    if (inc_energy_.value() < 2.0)
+    if (inc_energy_ < units::MevEnergy{2.0})
     {
-        UniformRealDistribution<real_type> sample_eps(epsilon0_, 0.5);
+        UniformRealDistribution<real_type> sample_eps(epsilon0_, half);
         epsilon = sample_eps(rng);
     }
     else
     {
-        // Minimum (\epsilon = 0.5) and maximum (\epsilon = \epsilon1) values
+        // Minimum (\epsilon = 1/2) and maximum (\epsilon = \epsilon1) values
         // of screening variable, \delta.
-        real_type delta_min = 136.0 / element_.cbrt_z() * 4.0 * epsilon0_;
-        real_type delta_max
-            = std::exp((42.24 - element_.coulomb_correction()) / 8.368) - 0.952;
+        const real_type delta_min = 4 * 136 / element_.cbrt_z() * epsilon0_;
+        const real_type delta_max
+            = std::exp((real_type(42.24) - element_.coulomb_correction())
+                       / real_type(8.368))
+              - real_type(0.952);
         CELER_ASSERT(delta_min <= delta_max);
 
         // Limits on epsilon
-        real_type epsilon1 = 0.5 - 0.5 * std::sqrt(1.0 - delta_min / delta_max);
-        real_type epsilon_min = celeritas::max(epsilon0_, epsilon1);
+        const real_type epsilon1
+            = half - half * std::sqrt(1 - delta_min / delta_max);
+        const real_type epsilon_min = celeritas::max(epsilon0_, epsilon1);
 
         // Decide to choose f1, g1 or f2, g2 based on N1, N2 (factors from
         // corrected Bethe-Heitler cross section; c.f. Eq. 6.6 of Geant4
         // Physics Reference 10.6)
         real_type             f10 = this->screening_phi1_aux(delta_min);
         real_type             f20 = this->screening_phi2_aux(delta_min);
-        BernoulliDistribution choose_f1g1(ipow<2>(0.5 - epsilon_min) * f10,
-                                          1.5 * f20);
+        BernoulliDistribution choose_f1g1(ipow<2>(half - epsilon_min) * f10,
+                                          real_type(1.5) * f20);
+
+        auto clamp_nonneg = [](real_type value) {
+            return celeritas::max(value, real_type(0));
+        };
 
         // Temporary sample values used in rejection
         real_type reject_threshold;
@@ -96,37 +102,35 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
             if (choose_f1g1(rng))
             {
                 // Used to sample from f1
-                epsilon = 0.5
-                          - (0.5 - epsilon_min)
+                epsilon = half
+                          - (half - epsilon_min)
                                 * std::cbrt(generate_canonical(rng));
-                CELER_ASSERT(epsilon >= epsilon_min && epsilon <= 0.5);
+                CELER_ASSERT(epsilon >= epsilon_min && epsilon <= half);
                 // Calculate delta from element atomic number and sampled
                 // epsilon
                 real_type delta = this->impact_parameter(epsilon);
                 CELER_ASSERT(delta <= delta_max && delta >= delta_min);
                 // Calculate g1 "rejection" function
-                reject_threshold
-                    = celeritas::max(this->screening_phi1_aux(delta), 0.0)
-                      / celeritas::max(f10, 0.0);
-                CELER_ASSERT(reject_threshold > 0.0 && reject_threshold <= 1.0);
+                reject_threshold = clamp_nonneg(this->screening_phi1_aux(delta))
+                                   / clamp_nonneg(f10);
+                CELER_ASSERT(reject_threshold > 0 && reject_threshold <= 1);
             }
             else
             {
                 // Used to sample from f2
                 epsilon = epsilon_min
-                          + (0.5 - epsilon_min) * generate_canonical(rng);
-                CELER_ASSERT(epsilon >= epsilon_min && epsilon <= 0.5);
+                          + (half - epsilon_min) * generate_canonical(rng);
+                CELER_ASSERT(epsilon >= epsilon_min && epsilon <= half);
                 // Calculate delta given the element atomic number and sampled
                 // epsilon
                 real_type delta = this->impact_parameter(epsilon);
                 CELER_ASSERT(delta <= delta_max && delta >= delta_min);
                 // Calculate g2 "rejection" function
-                reject_threshold
-                    = celeritas::max(this->screening_phi2_aux(delta), 0.0)
-                      / celeritas::max(f20, 0.0);
-                CELER_ASSERT(reject_threshold > 0.0 && reject_threshold <= 1.0);
+                reject_threshold = clamp_nonneg(this->screening_phi2_aux(delta))
+                                   / clamp_nonneg(f20);
+                CELER_ASSERT(reject_threshold > 0 && reject_threshold <= 1);
             }
-        } while (BernoulliDistribution(1.0 - reject_threshold)(rng));
+        } while (BernoulliDistribution(1 - reject_threshold)(rng));
     }
 
     // Construct interaction for change to primary (incident) particle (gamma)
@@ -137,10 +141,10 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
     secondaries[0].particle_id = shared_.electron_id;
     secondaries[1].particle_id = shared_.positron_id;
     secondaries[0].energy
-        = units::MevEnergy{(1.0 - epsilon) * inc_energy_.value()};
+        = units::MevEnergy{(1 - epsilon) * inc_energy_.value()};
     secondaries[1].energy = units::MevEnergy{epsilon * inc_energy_.value()};
     // Select charges for child particles (e-, e+) randomly
-    if (BernoulliDistribution(0.5)(rng))
+    if (BernoulliDistribution(half)(rng))
     {
         swap(secondaries[0].energy, secondaries[1].energy);
     }
@@ -168,50 +172,57 @@ template<class Engine>
 CELER_FUNCTION real_type
 BetheHeitlerInteractor::sample_cos_theta(real_type kinetic_energy, Engine& rng)
 {
-    real_type umax = 2.0 * (1.0 + kinetic_energy * shared_.inv_electron_mass);
+    real_type umax = 2 * (1 + kinetic_energy * shared_.inv_electron_mass);
     real_type u;
     do
     {
         real_type uu
             = -std::log(generate_canonical(rng) * generate_canonical(rng));
-        u = BernoulliDistribution(0.25)(rng) ? uu * 1.6 : uu * (1.6 / 3.0);
+        u = uu
+            * (BernoulliDistribution(0.25)(rng) ? real_type(1.6)
+                                                : real_type(1.6 / 3));
     } while (u > umax);
 
-    return 1.0 - 2.0 * ipow<2>(u / umax);
+    return 1 - 2 * ipow<2>(u / umax);
 }
 
 CELER_FUNCTION real_type
 BetheHeitlerInteractor::impact_parameter(real_type eps) const
 {
-    return 136.0 / element_.cbrt_z() * epsilon0_ / (eps * (1.0 - eps));
+    return 136 / element_.cbrt_z() * epsilon0_ / (eps * (1 - eps));
 }
 
 CELER_FUNCTION real_type
 BetheHeitlerInteractor::screening_phi1(real_type delta) const
 {
-    return delta <= 1.4 ? 20.867 - 3.242 * delta + 0.625 * ipow<2>(delta)
-                        : 21.12 - 4.184 * std::log(delta + 0.952);
+    using R = real_type;
+    return delta <= R(1.4)
+               ? R(20.867) - R(3.242) * delta + R(0.625) * ipow<2>(delta)
+               : R(21.12) - R(4.184) * std::log(delta + R(0.952));
 }
 
-CELER_FUNCTION real_type
-BetheHeitlerInteractor::screening_phi2(real_type delta) const
+CELER_FUNCTION
+real_type BetheHeitlerInteractor::screening_phi2(real_type delta) const
 {
-    return delta <= 1.4 ? 20.209 - 1.930 * delta - 0.086 * ipow<2>(delta)
-                        : 21.12 - 4.184 * std::log(delta + 0.952);
+    using R = real_type;
+    return delta <= R(1.4)
+               ? R(20.209) - R(1.930) * delta - R(0.086) * ipow<2>(delta)
+               : R(21.12) - R(4.184) * std::log(delta + R(0.952));
 }
 
 CELER_FUNCTION real_type
 BetheHeitlerInteractor::screening_phi1_aux(real_type delta) const
 {
-    return (3.0 * this->screening_phi1(delta) - this->screening_phi2(delta)
+    return (3 * this->screening_phi1(delta) - this->screening_phi2(delta)
             - element_.coulomb_correction());
 }
 
 CELER_FUNCTION real_type
 BetheHeitlerInteractor::screening_phi2_aux(real_type delta) const
 {
-    return (1.5 * this->screening_phi1(delta)
-            - 0.5 * this->screening_phi2(delta)
+    using R = real_type;
+    return (R(1.5) * this->screening_phi1(delta)
+            - R(0.5) * this->screening_phi2(delta)
             - element_.coulomb_correction());
 }
 

--- a/src/physics/em/detail/KleinNishinaInteractor.i.hh
+++ b/src/physics/em/detail/KleinNishinaInteractor.i.hh
@@ -58,10 +58,11 @@ CELER_FUNCTION Interaction KleinNishinaInteractor::operator()(Engine& rng)
                                            * shared_.inv_electron_mass;
     const real_type epsilon_0     = 1 / (1 + 2 * inc_energy_per_mecsq);
     const real_type log_epsilon_0 = std::log(epsilon_0);
+    constexpr real_type half          = 0.5;
 
     // Probability of alpha_1 to choose f1 (sample epsilon)
     BernoulliDistribution choose_f1(-log_epsilon_0,
-                                    0.5 * (1 - epsilon_0 * epsilon_0));
+                                    half * (1 - epsilon_0 * epsilon_0));
     // Sample square of f_2(\eps) \propto \eps on [\eps_0, 1]
     UniformRealDistribution<real_type> sample_f2_sq(epsilon_0 * epsilon_0, 1);
 

--- a/src/physics/em/detail/LivermorePEInteractor.i.hh
+++ b/src/physics/em/detail/LivermorePEInteractor.i.hh
@@ -41,7 +41,7 @@ LivermorePEInteractor::LivermorePEInteractor(const LivermorePEPointers& shared,
     CELER_EXPECT(inc_energy_.value() > 0);
     CELER_EXPECT(!shared_.atomic_relaxation || scratch_.vacancies);
 
-    inv_energy_ = 1. / inc_energy_.value();
+    inv_energy_ = 1 / inc_energy_.value();
 }
 
 //---------------------------------------------------------------------------//
@@ -88,7 +88,7 @@ CELER_FUNCTION Interaction LivermorePEInteractor::operator()(Engine& rng)
 
     // Sample the shell from which the photoelectron is emitted
     real_type cutoff = generate_canonical(rng) * calc_micro_xs_(el_id_);
-    real_type xs     = 0.;
+    real_type xs               = 0;
     const LivermoreElement& el = shared_.xs_data.elements[el_id_];
     const auto&             shells = shared_.xs_data.shells[el.shells];
     SubshellId::size_type   shell_id;
@@ -216,16 +216,17 @@ CELER_FUNCTION Real3 LivermorePEInteractor::sample_direction(Engine& rng) const
     }
 
     // Calculate Lorentz factors of the photoelectron
-    real_type gamma = energy_per_mecsq + 1.;
-    real_type beta  = std::sqrt(energy_per_mecsq * (gamma + 1.)) / gamma;
-    real_type a     = (1. - beta) / beta;
+    real_type gamma = energy_per_mecsq + 1;
+    real_type beta  = std::sqrt(energy_per_mecsq * (gamma + 1)) / gamma;
+    real_type a     = (1 - beta) / beta;
 
     // Second term inside the brackets in Eq. 2.8 in the Penelope manual
-    real_type b = 0.5 * beta * gamma * energy_per_mecsq * (gamma - 2.);
+    constexpr real_type half = 0.5;
+    real_type b = half * beta * gamma * energy_per_mecsq * (gamma - 2);
 
     // Maximum of the rejection function g(1 - cos \theta) given in Eq. 2.8,
     // which is attained when 1 - cos \theta = 0
-    real_type g_max = 2. * (1. / a + b);
+    real_type g_max = 2 * (1 / a + b);
 
     // Rejection loop: sample 1 - cos \theta
     real_type g;
@@ -235,17 +236,17 @@ CELER_FUNCTION Real3 LivermorePEInteractor::sample_direction(Engine& rng) const
         // Sample 1 - cos \theta from the distribution given in Eq. 2.9 using
         // the inverse function (Eq. 2.11)
         real_type u = generate_canonical(rng);
-        nu          = 2. * a * (2. * u + (a + 2.) * std::sqrt(u))
-             / ((a + 2.) * (a + 2.) - 4. * u);
+        nu          = 2 * a * (2 * u + (a + 2) * std::sqrt(u))
+             / ((a + 2) * (a + 2) - 4 * u);
 
         // Calculate the rejection function (Eq 2.8) at the sampled value
-        g = (2. - nu) * (1. / (a + nu) + b);
+        g = (2 - nu) * (1 / (a + nu) + b);
     } while (g < g_max * generate_canonical(rng));
 
     // Sample the azimuthal angle and calculate the direction of the
     // photoelectron
     UniformRealDistribution<real_type> sample_phi(0, 2 * constants::pi);
-    return rotate(from_spherical(1. - nu, sample_phi(rng)), inc_direction_);
+    return rotate(from_spherical(1 - nu, sample_phi(rng)), inc_direction_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/MollerBhabhaInteractor.i.hh
+++ b/src/physics/em/detail/MollerBhabhaInteractor.i.hh
@@ -93,9 +93,8 @@ CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
     const real_type secondary_energy = epsilon * inc_energy_;
 
     // Same equation as in ParticleTrackView::momentum_sq()
-    const real_type secondary_momentum
-        = std::sqrt(secondary_energy
-                    * (secondary_energy + 2.0 * shared_.electron_mass_c_sq));
+    const real_type secondary_momentum = std::sqrt(
+        secondary_energy * (secondary_energy + 2 * shared_.electron_mass_c_sq));
 
     const real_type total_energy = inc_energy_ + shared_.electron_mass_c_sq;
 
@@ -104,8 +103,8 @@ CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
         = secondary_energy * (total_energy + shared_.electron_mass_c_sq)
           / (secondary_momentum * inc_momentum_);
 
-    secondary_cos_theta = min(secondary_cos_theta, 1.0);
-    CELER_ASSERT(secondary_cos_theta >= -1.0 && secondary_cos_theta <= 1.0);
+    secondary_cos_theta = celeritas::min<real_type>(secondary_cos_theta, 1);
+    CELER_ASSERT(secondary_cos_theta >= -1 && secondary_cos_theta <= 1);
 
     // Sample phi isotropically
     UniformRealDistribution<real_type> sample_phi(0, 2 * constants::pi);

--- a/src/physics/em/detail/MollerEnergyDistribution.i.hh
+++ b/src/physics/em/detail/MollerEnergyDistribution.i.hh
@@ -64,13 +64,13 @@ CELER_FUNCTION real_type MollerEnergyDistribution::operator()(Engine& rng)
 CELER_FUNCTION real_type
 MollerEnergyDistribution::calc_g_fraction(real_type epsilon)
 {
-    const real_type two_gamma_term  = (2.0 * gamma_ - 1.0) / ipow<2>(gamma_);
-    const real_type complement_frac = 1.0 - epsilon;
+    const real_type two_gamma_term  = (2 * gamma_ - 1) / ipow<2>(gamma_);
+    const real_type complement_frac = 1 - epsilon;
 
-    return 1.0 - two_gamma_term * epsilon
+    return 1 - two_gamma_term * epsilon
            + ipow<2>(epsilon)
-                 * (1.0 - two_gamma_term
-                    + (1.0 - two_gamma_term * complement_frac)
+                 * (1 - two_gamma_term
+                    + (1 - two_gamma_term * complement_frac)
                           / ipow<2>(complement_frac));
 }
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/Rayleigh.hh
+++ b/src/physics/em/detail/Rayleigh.hh
@@ -11,6 +11,7 @@
 #include "base/Types.hh"
 #include "base/Collection.hh"
 #include "physics/base/Types.hh"
+#include "physics/material/Types.hh"
 
 namespace celeritas
 {
@@ -60,9 +61,6 @@ struct RayleighGroup
 
     //! ID of a gamma
     ParticleId gamma_id;
-
-    //! Rayleigh angular parameters
-    using ElementId = celeritas::ItemId<unsigned int>;
 
     template<class T>
     using ElementItems = celeritas::Collection<T, W, M, ElementId>;

--- a/src/physics/em/detail/RayleighInteractor.hh
+++ b/src/physics/em/detail/RayleighInteractor.hh
@@ -82,9 +82,7 @@ class RayleighInteractor
     };
 
     //! Evaluate weights and probabilities for the angular sampling algorithm
-    CELER_FUNCTION auto
-    evaluate_weight_and_prob(real_type energy, const ItemIdT& id) const
-        -> SampleInput;
+    CELER_FUNCTION auto evaluate_weight_and_prob() const -> SampleInput;
 
   private:
     // Shared constant physics properties

--- a/src/physics/em/detail/RayleighInteractor.i.hh
+++ b/src/physics/em/detail/RayleighInteractor.i.hh
@@ -33,6 +33,7 @@ RayleighInteractor::RayleighInteractor(const RayleighNativeRef& shared,
     CELER_EXPECT(inc_energy_ >= this->min_incident_energy()
                  && inc_energy_ <= this->max_incident_energy());
     CELER_EXPECT(particle.particle_id() == shared_.gamma_id);
+    CELER_EXPECT(element_id_ < shared_.params.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -43,20 +44,14 @@ RayleighInteractor::RayleighInteractor(const RayleighNativeRef& shared,
 template<class Engine>
 CELER_FUNCTION Interaction RayleighInteractor::operator()(Engine& rng)
 {
-    real_type energy = inc_energy_.value();
-
     // Construct interaction for change to primary (incident) particle
     Interaction result;
     result.action = Action::scattered;
-    result.energy = units::MevEnergy{inc_energy_.value()};
 
-    // Sample direction for a given atomic number: G4RayleighAngularGenerator
-    ItemIdT item_id = ItemIdT{element_id_.get()};
+    SampleInput input = this->evaluate_weight_and_prob();
 
-    SampleInput input = this->evaluate_weight_and_prob(energy, item_id);
-
-    Real3 pb = shared_.params[item_id].b;
-    Real3 pn = shared_.params[item_id].n;
+    const Real3& pb = shared_.params[element_id_].b;
+    const Real3& pn = shared_.params[element_id_].n;
 
     constexpr real_type half = 0.5;
     real_type           cost;
@@ -106,17 +101,15 @@ CELER_FUNCTION Interaction RayleighInteractor::operator()(Engine& rng)
 }
 
 CELER_FUNCTION
-auto RayleighInteractor::evaluate_weight_and_prob(real_type      energy,
-                                                  const ItemIdT& item_id) const
-    -> SampleInput
+auto RayleighInteractor::evaluate_weight_and_prob() const -> SampleInput
 {
+    const Real3& a = shared_.params[element_id_].a;
+    const Real3& b = shared_.params[element_id_].b;
+    const Real3& n = shared_.params[element_id_].n;
+
     SampleInput input;
-
-    Real3 a = shared_.params[item_id].a;
-    Real3 b = shared_.params[item_id].b;
-    Real3 n = shared_.params[item_id].n;
-
-    input.factor = ipow<2>(energy * RayleighInteractor::hc_factor());
+    input.factor = ipow<2>(units::centimeter * unit_cast(inc_energy_)
+                           / (constants::c_light * constants::h_planck));
 
     Real3 x = b;
     axpy(input.factor, b, &x);

--- a/test/base/Algorithms.test.cc
+++ b/test/base/Algorithms.test.cc
@@ -20,6 +20,16 @@ TEST(AlgorithmsTest, minmax)
     EXPECT_EQ(2, celeritas::max<int>(1, 2));
 }
 
+TEST(AlgorithmsTest, clamp)
+{
+    using celeritas::clamp_to_nonneg;
+    constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
+
+    EXPECT_DOUBLE_EQ(1.2345, clamp_to_nonneg(1.2345));
+    EXPECT_DOUBLE_EQ(0.0, clamp_to_nonneg(-123));
+    EXPECT_TRUE(std::isnan(celeritas::clamp_to_nonneg(nan)));
+}
+
 TEST(AlgorithmsTest, ipow)
 {
     EXPECT_DOUBLE_EQ(1, celeritas::ipow<0>(0.0));

--- a/test/physics/em/BetheHeitler.test.cc
+++ b/test/physics/em/BetheHeitler.test.cc
@@ -165,14 +165,12 @@ TEST_F(BetheHeitlerInteractorTest, basic)
     EXPECT_EQ(2 * num_samples, this->secondary_allocator().get().size());
 
     // Note: these are "gold" values based on the host RNG.
-    const double expected_energy1[] = {
-        3.39788055741559, 5.94794724941223, 93.5479251326247, 0.609041145240891};
-    const double expected_energy2[] = {
-        96.6021194425844, 94.0520527505878, 6.45207486737531, 99.3909588547591};
-    const double expected_angle[] = {0.987435394080014,
-                                     0.993539590873641,
-                                     0.998111731270319,
-                                     0.636300552842406};
+    const double expected_energy1[]
+        = {16.57248532448, 99.25227118843, 24.00633179151, 95.23685783041};
+    const double expected_energy2[]
+        = {83.42751467552, 0.7477288115688, 75.99366820849, 4.763142169585};
+    const double expected_angle[]
+        = {0.9999694782475, 0.9111977209393, 0.9997556894823, 0.9921593039016};
 
     EXPECT_VEC_SOFT_EQ(expected_energy1, energy1);
     EXPECT_VEC_SOFT_EQ(expected_energy2, energy2);
@@ -234,9 +232,10 @@ TEST_F(BetheHeitlerInteractorTest, stress_test)
         avg_engine_samples.push_back(double(rng_engine.count())
                                      / double(num_particles_sampled));
     }
+
     // Gold values for average number of calls to RNG
     const double expected_avg_engine_samples[]
-        = {18.375, 23.3125, 23.5, 22.9375, 22.75};
+        = {18.375, 23.125, 22.75, 23.3125, 22.5625};
     EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
 }
 


### PR DESCRIPTION
Revisit the interactors and ensure that all floating point values are either automatically promoted to `real_type` or wrapped with `real_type`  themselves.

The only change to the "gold" regression values is due to:
```diff
-        } while (BernoulliDistribution(1 - reject_threshold)(rng));
+        } while (!BernoulliDistribution(reject_threshold)(rng));
```
which while mathematically equivalent ends up changing the RNG stream.