### PR TITLE
Correct the sampling of discrete interactions for energy loss

### DIFF
--- a/src/physics/base/PhysicsInterface.hh
+++ b/src/physics/base/PhysicsInterface.hh
@@ -187,6 +187,7 @@ struct PhysicsParamsData
     // User-configurable constants
     real_type scaling_min_range{}; //!< rho [cm]
     real_type scaling_fraction{};  //!< alpha [unitless]
+    real_type energy_fraction{};   //!< xi [unitless]
     real_type linear_loss_limit{}; //!< For scaled range calculation
 
     //// METHODS ////
@@ -196,7 +197,7 @@ struct PhysicsParamsData
     {
         return !process_groups.empty() && max_particle_processes
                && scaling_min_range > 0 && scaling_fraction > 0
-               && linear_loss_limit > 0;
+               && energy_fraction > 0 && linear_loss_limit > 0;
     }
 
     //! Assign from another set of data
@@ -219,6 +220,7 @@ struct PhysicsParamsData
 
         scaling_min_range = other.scaling_min_range;
         scaling_fraction  = other.scaling_fraction;
+        energy_fraction   = other.energy_fraction;
         linear_loss_limit = other.linear_loss_limit;
 
         return *this;

--- a/src/physics/base/PhysicsInterface.hh
+++ b/src/physics/base/PhysicsInterface.hh
@@ -60,11 +60,13 @@ struct ModelGroup
  * It is allowable for this to be "false" (i.e. no materials assigned)
  * indicating that the value table doesn't apply in the context -- for
  * example, an empty ValueTable macro_xs means that the process doesn't have a
- * discrete interaction.
+ * discrete interaction. Only macro_xs ValueTables will have energy_max
+ * assigned, and only for processes that also have an energy_loss ValueTable.
  */
 struct ValueTable
 {
-    ItemRange<ValueGridId> material; //!< Value grid by material index
+    ItemRange<ValueGridId> material;   //!< Value grid by material index
+    ItemRange<real_type>   energy_max; //!< Energy of the largest xs [material]
 
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const { return !material.empty(); }
@@ -78,7 +80,7 @@ struct ValueTable
  * a fixed-size number of ItemRange references to ValueTables. The first index
  * of the table (hard-coded) corresponds to ValueGridType; the second index is
  * a ParticleProcessId. So the cross sections for ParticleProcessId{2} would
- * be \code tables[size_type(ValueGridType::macro_xs)][2] \endcode. This
+ * be \code tables[ValueGridType::macro_xs][2] \endcode. This
  * awkward access is encapsulated by the PhysicsTrackView.
  */
 struct ProcessGroup

--- a/src/physics/base/PhysicsParams.cc
+++ b/src/physics/base/PhysicsParams.cc
@@ -107,6 +107,9 @@ void PhysicsParams::build_options(const Options& opts, HostValue* data) const
     CELER_VALIDATE(opts.max_step_over_range > 0,
                    << "invalid max_step_over_range="
                    << opts.max_step_over_range << " (should be positive)");
+    CELER_VALIDATE(opts.min_eprime_over_e > 0 && opts.min_eprime_over_e < 1,
+                   << "invalid min_eprime_over_e=" << opts.min_eprime_over_e
+                   << " (should be be within 0 < limit < 1)");
     CELER_VALIDATE(opts.min_range > 0,
                    << "invalid min_range=" << opts.min_range
                    << " (should be positive)");
@@ -115,6 +118,7 @@ void PhysicsParams::build_options(const Options& opts, HostValue* data) const
                    << " (should be be within 0 <= limit <= 1)");
     data->scaling_min_range = opts.min_range;
     data->scaling_fraction  = opts.max_step_over_range;
+    data->energy_fraction   = opts.min_eprime_over_e;
     data->linear_loss_limit = opts.linear_loss_limit;
 }
 
@@ -352,6 +356,7 @@ void PhysicsParams::build_xs(const Options&        opts,
 
                     // Find the energy of the largest cross section
                     real_type xs_max = 0;
+                    real_type e_max  = 0;
                     for (auto i : range(loge_grid.size()))
                     {
                         real_type energy = std::exp(loge_grid[i]);
@@ -361,11 +366,12 @@ void PhysicsParams::build_xs(const Options&        opts,
 
                         if (xs > xs_max)
                         {
-                            xs_max                   = xs;
-                            energy_max[mat_id.get()] = energy;
+                            xs_max = xs;
+                            e_max  = energy;
                         }
                     }
-                    CELER_ASSERT(energy_max[mat_id.get()] > 0);
+                    CELER_ASSERT(e_max > 0);
+                    energy_max[mat_id.get()] = e_max;
                 }
             }
 

--- a/src/physics/base/PhysicsParams.hh
+++ b/src/physics/base/PhysicsParams.hh
@@ -40,13 +40,16 @@ class ParticleParams;
  * - \c max_step_over_range: at higher energy (longer range), gradually
  *   decrease the maximum step length until it's this fraction of the tabulated
  *   range.
+ * - \c min_eprime_over_e: Energy scaling fraction used to estimate the maximum
+ *   cross section over the step in the integral approach for energy loss
+ *   processes.
  * - \c linear_loss_limit: if the mean energy loss along a step is greater than
  *   this fractional value of the pre-step kinetic energy, recalculate the
  *   energy loss.
  * - \c use_integral: for energy loss processes, the particle energy changes
  *   over the step, so the assumption that the cross section is constant is no
- *   longer valid. Use MC integration to sample the discrete interaction with
- *   the correct probability.
+ *   longer valid. Use MC integration to sample the discrete interaction length
+ *   with the correct probability.
  */
 class PhysicsParams
 {
@@ -69,7 +72,8 @@ class PhysicsParams
     {
         real_type min_range           = 1 * units::millimeter; //!< rho_R
         real_type max_step_over_range = 0.2;                   //!< alpha_r
-        real_type linear_loss_limit   = 0.01;                  //!< xi
+        real_type min_eprime_over_e   = 0.8;                   //!< xi
+        real_type linear_loss_limit   = 0.01;                  //!< also xi
         bool      use_integral        = true;
     };
 

--- a/src/physics/base/PhysicsParams.hh
+++ b/src/physics/base/PhysicsParams.hh
@@ -46,7 +46,7 @@ class ParticleParams;
  * - \c linear_loss_limit: if the mean energy loss along a step is greater than
  *   this fractional value of the pre-step kinetic energy, recalculate the
  *   energy loss.
- * - \c use_integral: for energy loss processes, the particle energy changes
+ * - \c use_integral_xs: for energy loss processes, the particle energy changes
  *   over the step, so the assumption that the cross section is constant is no
  *   longer valid. Use MC integration to sample the discrete interaction length
  *   with the correct probability.
@@ -70,11 +70,11 @@ class PhysicsParams
     //! Global physics configuration options
     struct Options
     {
-        real_type min_range           = 1 * units::millimeter; //!< rho_R
-        real_type max_step_over_range = 0.2;                   //!< alpha_r
-        real_type min_eprime_over_e   = 0.8;                   //!< xi
-        real_type linear_loss_limit   = 0.01;                  //!< also xi
-        bool      use_integral        = true;
+        real_type min_range           = 1 * units::millimeter;
+        real_type max_step_over_range = 0.2;
+        real_type min_eprime_over_e   = 0.8;
+        real_type linear_loss_limit   = 0.01;
+        bool      use_integral_xs     = true;
     };
 
     //! Physics parameter construction arguments

--- a/src/physics/base/PhysicsParams.hh
+++ b/src/physics/base/PhysicsParams.hh
@@ -43,6 +43,10 @@ class ParticleParams;
  * - \c linear_loss_limit: if the mean energy loss along a step is greater than
  *   this fractional value of the pre-step kinetic energy, recalculate the
  *   energy loss.
+ * - \c use_integral: for energy loss processes, the particle energy changes
+ *   over the step, so the assumption that the cross section is constant is no
+ *   longer valid. Use MC integration to sample the discrete interaction with
+ *   the correct probability.
  */
 class PhysicsParams
 {
@@ -66,6 +70,7 @@ class PhysicsParams
         real_type min_range           = 1 * units::millimeter; //!< rho_R
         real_type max_step_over_range = 0.2;                   //!< alpha_r
         real_type linear_loss_limit   = 0.01;                  //!< xi
+        bool      use_integral        = true;
     };
 
     //! Physics parameter construction arguments
@@ -127,7 +132,9 @@ class PhysicsParams
     VecModel build_models() const;
     void     build_options(const Options& opts, HostValue* data) const;
     void     build_ids(const ParticleParams& particles, HostValue* data) const;
-    void     build_xs(const MaterialParams& mats, HostValue* data) const;
+    void     build_xs(const Options&        opts,
+                      const MaterialParams& mats,
+                      HostValue*            data) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/PhysicsStepUtils.hh
+++ b/src/physics/base/PhysicsStepUtils.hh
@@ -31,6 +31,9 @@ struct ProcessIdModelId
 {
     ParticleProcessId ppid;
     ModelId           model;
+
+    //! True if assigned
+    explicit CELER_FUNCTION operator bool() const { return ppid && model; }
 };
 
 template<class Engine>

--- a/src/physics/base/PhysicsStepUtils.i.hh
+++ b/src/physics/base/PhysicsStepUtils.i.hh
@@ -205,8 +205,8 @@ CELER_FUNCTION ParticleTrackView::Energy
  *   determine the interacting process ID.
  * - From the process ID and (post-slowing-down) particle energy, we obtain the
  *   applicable model ID.
- * - For continuous-discrete interactions, the post-step energy will be
- *   different from the pre-step energy, so the assumption that the cross
+ * - For energy loss (continuous-discrete) processes, the post-step energy will
+ *   be different from the pre-step energy, so the assumption that the cross
  *   section is constant along the step is no longer valid. Use the "integral
  *   approach" to sample the discrete interaction from the correct probability
  *   distribution (section 7.4 of the Geant4 Physics Reference release 10.6).

--- a/src/physics/base/PhysicsStepUtils.i.hh
+++ b/src/physics/base/PhysicsStepUtils.i.hh
@@ -10,6 +10,7 @@
 #include "base/Algorithms.hh"
 #include "base/NumericLimits.hh"
 #include "base/Range.hh"
+#include "random/distributions/BernoulliDistribution.hh"
 #include "random/distributions/GenerateCanonical.hh"
 #include "physics/grid/EnergyLossCalculator.hh"
 #include "physics/grid/InverseRangeCalculator.hh"
@@ -233,7 +234,7 @@ select_process_and_model(const ParticleTrackView& particle,
         {
             // Determine if the discrete interaction occurs for energy loss
             // processes
-            if (physics.use_integral(ppid))
+            if (physics.use_integral_xs(ppid))
             {
                 // This is an energy loss process that was sampled for a
                 // discrete interaction, so it will have macro xs tables
@@ -248,7 +249,8 @@ select_process_and_model(const ParticleTrackView& particle,
 
                 // The discrete interaction occurs with probability \f$
                 // \sigma(E_1) / \sigma_{\max} \f$
-                if (xs < generate_canonical(rng) * physics.per_process_xs(ppid))
+                if (!BernoulliDistribution(xs / physics.per_process_xs(ppid))(
+                        rng))
                     return {};
             }
             // Select the model and return; See doc above for details.

--- a/src/physics/base/PhysicsStepUtils.i.hh
+++ b/src/physics/base/PhysicsStepUtils.i.hh
@@ -14,8 +14,8 @@
 #include "physics/grid/EnergyLossCalculator.hh"
 #include "physics/grid/InverseRangeCalculator.hh"
 #include "physics/grid/RangeCalculator.hh"
-#include "physics/grid/XsCalculator.hh"
 #include "physics/grid/ValueGridInterface.hh"
+#include "physics/grid/XsCalculator.hh"
 #include "Types.hh"
 
 namespace celeritas
@@ -55,8 +55,7 @@ calc_tabulated_physics_step(const MaterialTrackView& material,
             // Calculate macroscopic cross section for this process, then
             // accumulate it into the total cross section and save the cross
             // section for later.
-            auto calc_xs = physics.make_calculator<XsCalculator>(grid_id);
-            process_xs   = calc_xs(particle.energy());
+            process_xs = physics.calc_xs(ppid, grid_id, particle.energy());
             total_macro_xs += process_xs;
         }
         physics.per_process_xs(ppid) = process_xs;
@@ -108,7 +107,7 @@ calc_tabulated_physics_step(const MaterialTrackView& material,
  *
  * Both Celeritas and Geant4 approximate the range limit as the minimum range
  * over all processes, rather than the range as a result from integrating all
- * energy loss processes over the allowed energy range. This is usuallly not
+ * energy loss processes over the allowed energy range. This is usually not
  * a problem in practice because the range will get automatically decreased by
  * \c range_to_step , and the above range calculation neglects energy loss by
  * discrete processes.
@@ -206,30 +205,11 @@ CELER_FUNCTION ParticleTrackView::Energy
  *   determine the interacting process ID.
  * - From the process ID and (post-slowing-down) particle energy, we obtain the
  *   applicable model ID.
- *
- * Does the energy change between the time the per_process_xs was
- * calculated and now?  Does the energy enters in the calculation
- * of the cross-section? What happens to the cross section per
- * process if there no model covering that energy range?
- * See
- * https://github.com/celeritas-project/celeritas/pull/165#issuecomment-790214691
- * for some discussion, including this:
- *
- * Look up the model for the selected process at the reduced
- * energy E'. If there's not one -- i.e. the along-step energy
- * loss causes us to go below the lower threshold for the selected
- * process -- we could simply zero out the cross section for that
- * process and jump back up to the step above (resampling
- * available processes). If we did the cutoff step correctly then
- * there should be at least one process with a valid model.
- *
- * but
- *
- * Some of the glue pieces (cutoff testing, at rest) aren't yet in
- * place, and I think for the moment we can skip the "resample if
- * below process energy threshold" since I don't think there are
- * any processes that have thresholds (aside from gamma, which has
- * no continuous energy loss processes).
+ * - For continuous-discrete interactions, the post-step energy will be
+ *   different from the pre-step energy, so the assumption that the cross
+ *   section is constant along the step is no longer valid. Use the "integral
+ *   approach" to sample the discrete interaction from the correct probability
+ *   distribution (section 7.4 of the Geant4 Physics Reference release 10.6).
  */
 template<class Engine>
 CELER_FUNCTION ProcessIdModelId
@@ -244,17 +224,35 @@ select_process_and_model(const ParticleTrackView& particle,
 
     auto      total_macro_xs = physics.macro_xs();
     real_type prob           = generate_canonical(rng) * total_macro_xs;
-    real_type accum          = 0.0;
+    real_type accum          = 0;
 
     for (auto ppid : range(ParticleProcessId{physics.num_particle_processes()}))
     {
         accum += physics.per_process_xs(ppid);
         if (accum >= prob)
         {
-            // Select the model and return; See doc above for
-            // details.
-            auto find_model = physics.make_model_finder(ppid);
+            // Determine if the discrete interaction occurs for energy loss
+            // processes
+            if (physics.use_integral(ppid))
+            {
+                // This is an energy loss process that was sampled for a
+                // discrete interaction, so it will have macro xs tables
+                auto grid_id
+                    = physics.value_grid(ValueGridType::macro_xs, ppid);
+                CELER_ASSERT(grid_id);
 
+                // Recalculate the cross section at the post-step energy \f$
+                // E_1 \f$
+                auto calc_xs = physics.make_calculator<XsCalculator>(grid_id);
+                real_type xs = calc_xs(particle.energy());
+
+                // The discrete interaction occurs with probability \f$
+                // \sigma(E_1) / \sigma_{\max} \f$
+                if (xs < generate_canonical(rng) * physics.per_process_xs(ppid))
+                    return {};
+            }
+            // Select the model and return; See doc above for details.
+            auto find_model = physics.make_model_finder(ppid);
             return ProcessIdModelId{ppid, find_model(particle.energy())};
         }
     }

--- a/src/physics/base/PhysicsTrackView.hh
+++ b/src/physics/base/PhysicsTrackView.hh
@@ -92,6 +92,17 @@ class PhysicsTrackView
     inline CELER_FUNCTION ValueGridId value_grid(ValueGridType table,
                                                  ParticleProcessId) const;
 
+    // Whether to use integral approach to sample interaction probability
+    inline CELER_FUNCTION bool use_integral(ParticleProcessId ppid) const;
+
+    // Energy corresponding to the maximum cross section for the material
+    inline CELER_FUNCTION real_type energy_max(ParticleProcessId ppid) const;
+
+    // Calculate macroscopic cross section for the process
+    inline CELER_FUNCTION real_type calc_xs(ParticleProcessId ppid,
+                                            ValueGridId       grid_id,
+                                            MevEnergy         energy) const;
+
     // Get hardwired model, null if not present
     inline CELER_FUNCTION ModelId hardwired_model(ParticleProcessId ppid,
                                                   MevEnergy energy) const;
@@ -108,10 +119,13 @@ class PhysicsTrackView
     // Fractional energy loss allowed before post-step recalculation
     inline CELER_FUNCTION real_type linear_loss_limit() const;
 
+    // Energy scaling fraction used to estimate maximum xs over the step
+    inline CELER_FUNCTION real_type energy_fraction() const;
+
     // Calculate macroscopic cross section on the fly for the given model
-    inline CELER_FUNCTION real_type calc_xs_otf(ModelId       model,
-                                                MaterialView& material,
-                                                MevEnergy     energy) const;
+    inline CELER_FUNCTION real_type calc_xs_otf(ModelId             model,
+                                                const MaterialView& material,
+                                                MevEnergy energy) const;
 
     // Construct a grid calculator from a physics table
     template<class T>

--- a/src/physics/base/PhysicsTrackView.hh
+++ b/src/physics/base/PhysicsTrackView.hh
@@ -92,11 +92,11 @@ class PhysicsTrackView
     inline CELER_FUNCTION ValueGridId value_grid(ValueGridType table,
                                                  ParticleProcessId) const;
 
-    // Whether to use integral approach to sample interaction probability
-    inline CELER_FUNCTION bool use_integral(ParticleProcessId ppid) const;
+    // Whether to use integral approach to sample the discrete interaction
+    inline CELER_FUNCTION bool use_integral_xs(ParticleProcessId ppid) const;
 
     // Energy corresponding to the maximum cross section for the material
-    inline CELER_FUNCTION real_type energy_max(ParticleProcessId ppid) const;
+    inline CELER_FUNCTION real_type energy_max_xs(ParticleProcessId ppid) const;
 
     // Calculate macroscopic cross section for the process
     inline CELER_FUNCTION real_type calc_xs(ParticleProcessId ppid,

--- a/src/physics/base/PhysicsTrackView.i.hh
+++ b/src/physics/base/PhysicsTrackView.i.hh
@@ -8,6 +8,7 @@
 #include "base/Assert.hh"
 #include "physics/em/EPlusGGMacroXsCalculator.hh"
 #include "physics/em/LivermorePEMacroXsCalculator.hh"
+#include "physics/grid/XsCalculator.hh"
 
 namespace celeritas
 {
@@ -202,6 +203,94 @@ CELER_FUNCTION auto PhysicsTrackView::value_grid(ValueGridType     table_type,
 
 //---------------------------------------------------------------------------//
 /*!
+ * Whether to use integral approach to sample the discrete interaction.
+ *
+ * For energy loss processes, the particle will have a different energy at the
+ * pre- and post-step points. This means the assumption that the cross section
+ * is constant along the step is no longer valid. Instead, Monte Carlo
+ * integration can be used to sample the interaction for the discrete
+ * process with the correct probability from the exact distribution,
+ * \f[
+     p = 1 - \exp \left( -\int_{E_0}^{E_1} n \sigma(E) \dif s \right),
+ * \f]
+ * where \f$ E_0 \f$ is the pre-step energy, \f$ E_1 \f$ is the post-step
+ * energy, \em n is the atom density, and \em s is the interaction length.
+ *
+ * At the start of the step, the maximum value of the cross section over the
+ * step \f$ \sigma_{max} \f$ is estimated and used as the macroscopic cross
+ * section for the process rather than \f$ \sigma_{E_0} \f$. After the step,
+ * the new value of the cross section \f$ \sigma(E_1) \f$ is calculated, and
+ * the discrete interaction for the process occurs with probability
+ * \f[
+     p = \frac{\sigma(E_1)}{\sigma_{\max}}.
+ * \f]
+ *
+ * See section 7.4 of the Geant4 Physics Reference (release 10.6) for details.
+ */
+CELER_FUNCTION bool PhysicsTrackView::use_integral(ParticleProcessId ppid) const
+{
+    CELER_EXPECT(ppid < this->num_particle_processes());
+    return this->energy_max(ppid) > 0;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Energy corresponding to the maximum cross section for the material.
+ *
+ * If for this particle process the macro_xs \c ValueTable is "true" and \c
+ * energy_max is assigned, the process also has energy loss tables and the
+ * integral approach is being used. If \c energy_max[material] is nonzero,
+ * those tables are present for this material.
+ */
+CELER_FUNCTION real_type PhysicsTrackView::energy_max(ParticleProcessId ppid) const
+{
+    CELER_EXPECT(ppid < this->num_particle_processes());
+    ValueTableId table_id
+        = this->process_group().tables[ValueGridType::macro_xs][ppid.get()];
+
+    CELER_ASSERT(table_id);
+    const ValueTable& table = params_.value_tables[table_id];
+
+    real_type result = 0;
+    if (table && !table.energy_max.empty())
+    {
+        CELER_ASSERT(material_ < table.energy_max.size());
+        result = params_.reals[table.energy_max[material_.get()]];
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate macroscopic cross section for the process.
+ *
+ * If this is an energy loss process, this returns the estimate of the maximum
+ * cross section over the step. If the energy of the global maximum of the
+ * cross section (calculated at initialization) is in the interval \f$ [\xi
+ * E_0, E_0) \f$, where \f$ \E_0 \f$ is the pre-step energy and \f$ \xi \f$ is
+ * \c energy_fraction, \f$ \sigma_{\max} \f$ is set to the global maximum.
+ * Otherwise, \f$ \sigma_{\max} = \max( \sigma(E_0), \sigma(\xi E_0) ) \f$.
+ */
+CELER_FUNCTION real_type PhysicsTrackView::calc_xs(ParticleProcessId ppid,
+                                                   ValueGridId       grid_id,
+                                                   MevEnergy energy) const
+{
+    auto      calc_xs    = this->make_calculator<XsCalculator>(grid_id);
+    real_type energy_max = this->energy_max(ppid);
+    if (energy_max > 0)
+    {
+        // Use the integral approach for energy loss processes
+        real_type energy_xi = energy.value() * this->energy_fraction();
+        if (energy_max >= energy_xi && energy_max < energy.value())
+            return calc_xs(MevEnergy{energy_max});
+        else
+            return max(calc_xs(energy), calc_xs(MevEnergy{energy_xi}));
+    }
+    return calc_xs(energy);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Return the model ID that applies to the given process ID and energy if the
  * process is hardwired to calculate macroscopic cross sections on the fly. If
  * the result is null, tables should be used for this process/energy.
@@ -273,11 +362,23 @@ CELER_FUNCTION real_type PhysicsTrackView::linear_loss_limit() const
 
 //---------------------------------------------------------------------------//
 /*!
+ * Energy scaling fraction used to estimate maximum cross section over a step.
+ *
+ * This parameter is defined as \f$ \xi = 1 - \alpha \f$, where \f$ \alpha \f$
+ * is \c scaling_fraction.
+ */
+CELER_FUNCTION real_type PhysicsTrackView::energy_fraction() const
+{
+    CELER_EXPECT(params_.scaling_fraction <= 1);
+    return 1 - params_.scaling_fraction;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Calculate macroscopic cross section on the fly.
  */
-CELER_FUNCTION real_type PhysicsTrackView::calc_xs_otf(ModelId       model,
-                                                       MaterialView& material,
-                                                       MevEnergy energy) const
+CELER_FUNCTION real_type PhysicsTrackView::calc_xs_otf(
+    ModelId model, const MaterialView& material, MevEnergy energy) const
 {
     real_type result = 0.;
     if (model == params_.hardwired.livermore_pe)

--- a/src/physics/grid/XsCalculator.hh
+++ b/src/physics/grid/XsCalculator.hh
@@ -48,6 +48,9 @@ class XsCalculator
     // Find and interpolate from the energy
     inline CELER_FUNCTION real_type operator()(Energy energy) const;
 
+    // Get the cross section at the given index
+    inline CELER_FUNCTION real_type operator[](size_type index) const;
+
   private:
     const XsGridData& data_;
     const Values&     reals_;

--- a/src/physics/grid/XsCalculator.i.hh
+++ b/src/physics/grid/XsCalculator.i.hh
@@ -79,6 +79,23 @@ CELER_FUNCTION real_type XsCalculator::operator()(Energy energy) const
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get the cross section at the given index.
+ */
+CELER_FUNCTION real_type XsCalculator::operator[](size_type index) const
+{
+    const UniformGrid loge_grid(data_.log_energy);
+    real_type         energy = std::exp(loge_grid[index]);
+    real_type         result = this->get(index);
+
+    if (index >= data_.prime_index)
+    {
+        result /= energy;
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Get the raw cross section data at a particular index.
  */
 CELER_FUNCTION real_type XsCalculator::get(size_type index) const

--- a/test/physics/base/MockProcess.hh
+++ b/test/physics/base/MockProcess.hh
@@ -43,6 +43,7 @@ class MockProcess : public celeritas::Process
     using Applicability    = celeritas::Applicability;
     using ModelIdGenerator = celeritas::ModelIdGenerator;
     using VecApplicability = std::vector<Applicability>;
+    using VecMicroXs       = std::vector<BarnMicroXs>;
     using SPConstMaterials = std::shared_ptr<const celeritas::MaterialParams>;
     using ModelCallback    = std::function<void(celeritas::ModelId)>;
     //!@}
@@ -53,7 +54,7 @@ class MockProcess : public celeritas::Process
         std::string      label;
         VecApplicability applic;        //!< Applicablity per model
         ModelCallback    interact;      //!< MockModel::interact callback
-        BarnMicroXs      xs{};          //!< Constant per atom [bn]
+        VecMicroXs       xs;            //!< Constant per atom [bn]
         real_type        energy_loss{}; //!< Constant per atom [MeV/cm / cm^-3]
     };
 

--- a/test/physics/base/Physics.test.cc
+++ b/test/physics/base/Physics.test.cc
@@ -327,7 +327,7 @@ TEST_F(PhysicsTrackViewHostTest, use_integral)
             = this->make_track_view("celeriton", MaterialId{2});
         auto ppid = this->find_ppid(phys, "scattering");
         ASSERT_TRUE(ppid);
-        EXPECT_FALSE(phys.use_integral(ppid));
+        EXPECT_FALSE(phys.use_integral_xs(ppid));
         auto id = phys.value_grid(ValueGridType::macro_xs, ppid);
         ASSERT_TRUE(id);
         EXPECT_SOFT_EQ(0.1, phys.calc_xs(ppid, id, MevEnergy{1.0}));
@@ -339,9 +339,9 @@ TEST_F(PhysicsTrackViewHostTest, use_integral)
             = this->make_track_view("electron", MaterialId{2});
         auto ppid = this->find_ppid(phys, "barks");
         ASSERT_TRUE(ppid);
-        EXPECT_TRUE(phys.use_integral(ppid));
+        EXPECT_TRUE(phys.use_integral_xs(ppid));
         EXPECT_SOFT_EQ(0.8, phys.energy_fraction());
-        EXPECT_SOFT_EQ(0.1, phys.energy_max(ppid));
+        EXPECT_SOFT_EQ(0.1, phys.energy_max_xs(ppid));
         auto id = phys.value_grid(ValueGridType::macro_xs, ppid);
         ASSERT_TRUE(id);
         for (real_type energy : {0.001, 0.01, 0.1, 0.11, 10.0})

--- a/test/physics/base/PhysicsStepUtils.test.cc
+++ b/test/physics/base/PhysicsStepUtils.test.cc
@@ -296,7 +296,7 @@ TEST_F(PhysicsStepUtilsTest, select_process_and_model)
                                                      "electron",
                                                      MevEnergy{inc_energy[i]});
             ParticleProcessId ppid{0};
-            EXPECT_TRUE(phys.use_integral(ppid));
+            EXPECT_TRUE(phys.use_integral_xs(ppid));
             auto grid_id = phys.value_grid(ValueGridType::macro_xs, ppid);
             CELER_ASSERT(grid_id);
 

--- a/test/physics/base/PhysicsStepUtils.test.cc
+++ b/test/physics/base/PhysicsStepUtils.test.cc
@@ -283,11 +283,10 @@ TEST_F(PhysicsStepUtilsTest, select_process_and_model)
     }
     {
         // Test the integral approach
-        const real_type expected_acceptance_rate[] = {11. / 12, 0.5, 1};
-
-        unsigned int           num_samples   = 20000;
-        std::vector<real_type> inc_energy    = {0.01, 0.1, 10};
-        std::vector<real_type> scaled_energy = {0.001, 0.001, 8};
+        unsigned int           num_samples   = 10000;
+        std::vector<real_type> inc_energy    = {0.01, 0.01, 0.1, 10};
+        std::vector<real_type> scaled_energy = {0.001, 0.00999, 0.001, 8};
+        std::vector<real_type> acceptance_rate;
 
         for (auto i : range(inc_energy.size()))
         {
@@ -315,12 +314,10 @@ TEST_F(PhysicsStepUtilsTest, select_process_and_model)
                 if (select_process_and_model(particle, phys, this->rng()))
                     ++count;
             }
-            // Note that if the cross section is larger at the post-step
-            // energy, the interaction should always occur and the acceptance
-            // rate will be exactly 1.
-            real_type acceptance_rate = real_type(count) / num_samples;
-            EXPECT_SOFT_NEAR(
-                expected_acceptance_rate[i], acceptance_rate, 1e-2);
+            acceptance_rate.push_back(real_type(count) / num_samples);
         }
+        const real_type expected_acceptance_rate[]
+            = {0.9204, 0.9999, 0.4972, 1};
+        EXPECT_VEC_EQ(expected_acceptance_rate, acceptance_rate);
     }
 }

--- a/test/physics/base/PhysicsTestBase.cc
+++ b/test/physics/base/PhysicsTestBase.cc
@@ -69,6 +69,11 @@ auto PhysicsTestBase::build_particles() const -> SPConstParticles
                    MevMass{1},
                    ElementaryCharge{-1},
                    stable});
+    inp.push_back({"electron",
+                   pdg::electron(),
+                   MevMass{0.5109989461},
+                   ElementaryCharge{-1},
+                   stable});
     return std::make_shared<ParticleParams>(std::move(inp));
 }
 
@@ -95,14 +100,14 @@ auto PhysicsTestBase::build_physics() const -> SPConstPhysics
         inp.label       = "scattering";
         inp.applic      = {make_applicability("gamma", 1e-6, 100),
                       make_applicability("celeriton", 1, 100)};
-        inp.xs          = Barn{1.0};
+        inp.xs          = {Barn{1.0}, Barn{1.0}};
         inp.energy_loss = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
         inp.label       = "absorption";
         inp.applic      = {make_applicability("gamma", 1e-6, 100)};
-        inp.xs          = Barn{2.0};
+        inp.xs          = {Barn{2.0}, Barn{2.0}};
         inp.energy_loss = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
@@ -112,7 +117,7 @@ auto PhysicsTestBase::build_physics() const -> SPConstPhysics
         inp.applic      = {make_applicability("celeriton", 1e-3, 1),
                       make_applicability("celeriton", 1, 10),
                       make_applicability("celeriton", 10, 100)};
-        inp.xs          = Barn{3.0};
+        inp.xs          = {Barn{3.0}, Barn{3.0}};
         inp.energy_loss = 0.2 * 1e-20; // 0.2 MeV/cm in celerogen
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
@@ -121,7 +126,7 @@ auto PhysicsTestBase::build_physics() const -> SPConstPhysics
         inp.label       = "hisses";
         inp.applic      = {make_applicability("anti-celeriton", 1e-3, 1),
                       make_applicability("anti-celeriton", 1, 100)};
-        inp.xs          = Barn{4.0};
+        inp.xs          = {Barn{4.0}, Barn{4.0}};
         inp.energy_loss = 0.3 * 1e-20;
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
@@ -129,8 +134,16 @@ auto PhysicsTestBase::build_physics() const -> SPConstPhysics
         inp.label       = "meows";
         inp.applic      = {make_applicability("celeriton", 1e-3, 10),
                       make_applicability("anti-celeriton", 1e-3, 10)};
-        inp.xs          = Barn{5.0};
+        inp.xs          = {Barn{5.0}, Barn{5.0}};
         inp.energy_loss = 0.4 * 1e-20;
+        physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
+    }
+    {
+        // Energy-dependent cross section
+        inp.label       = "barks";
+        inp.applic      = {make_applicability("electron", 1e-3, 10)};
+        inp.xs          = {Barn{6.0}, Barn{12.0}, Barn{6.0}};
+        inp.energy_loss = 0.5 * 1e-20;
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     return std::make_shared<PhysicsParams>(std::move(physics_inp));

--- a/test/physics/grid/XsCalculator.test.cc
+++ b/test/physics/grid/XsCalculator.test.cc
@@ -44,6 +44,11 @@ TEST_F(XsCalculatorTest, simple)
     EXPECT_SOFT_EQ(1e5 - 1e-6, calc(Energy{1e5 - 1e-6}));
     EXPECT_SOFT_EQ(1e5, calc(Energy{1e5}));
 
+    // Test access by index
+    EXPECT_SOFT_EQ(1.0, calc[0]);
+    EXPECT_SOFT_EQ(1e2, calc[2]);
+    EXPECT_SOFT_EQ(1e5, calc[5]);
+
     // Test between grid points
     EXPECT_SOFT_EQ(5, calc(Energy{5}));
 
@@ -66,6 +71,11 @@ TEST_F(XsCalculatorTest, scaled_lowest)
     EXPECT_SOFT_EQ(1, calc(Energy{1e2}));
     EXPECT_SOFT_EQ(1, calc(Energy{1e4 - 1e-6}));
     EXPECT_SOFT_EQ(1, calc(Energy{1e4}));
+
+    // Test access by index
+    EXPECT_SOFT_EQ(1, calc[0]);
+    EXPECT_SOFT_EQ(1, calc[2]);
+    EXPECT_SOFT_EQ(1, calc[5]);
 
     // Test between grid points
     EXPECT_SOFT_EQ(1, calc(Energy{0.2}));
@@ -100,6 +110,11 @@ TEST_F(XsCalculatorTest, scaled_middle)
     EXPECT_SOFT_EQ(3, calc(Energy{1e4 - 1e-6}));
     EXPECT_SOFT_EQ(3, calc(Energy{1e4}));
 
+    // Test access by index
+    EXPECT_SOFT_EQ(3, calc[0]);
+    EXPECT_SOFT_EQ(3, calc[2]);
+    EXPECT_SOFT_EQ(3, calc[5]);
+
     // Test between grid points
     EXPECT_SOFT_EQ(3, calc(Energy{0.2}));
     EXPECT_SOFT_EQ(3, calc(Energy{5}));
@@ -121,6 +136,11 @@ TEST_F(XsCalculatorTest, scaled_highest)
     EXPECT_SOFT_EQ(1, calc(Energy{1}));
     EXPECT_SOFT_EQ(10, calc(Energy{10}));
     EXPECT_SOFT_EQ(2.0, calc(Energy{90}));
+
+    // Test access by index
+    EXPECT_SOFT_EQ(1, calc[0]);
+    EXPECT_SOFT_EQ(10, calc[1]);
+    EXPECT_SOFT_EQ(1, calc[2]);
 
     // Final point and higher are scaled by 1/E
     EXPECT_SOFT_EQ(1, calc(Energy{100}));


### PR DESCRIPTION
For energy loss processes the post-step energy will be different from the pre-step energy, so the assumption that the cross section is constant along the step is no longer valid. To correctly sample the interaction length, Geant4 uses the "integral approach", which uses MC integration to sample from the exact distribution. At the start of the step, the maximum cross section over the step `xs_max` is estimated and used for the process instead of the cross section at the pre-step energy `E`. At the end of the step, if that process is selected, the cross section is recalculated at the post-step energy `E'` and the discrete interaction occurs with probability `xs(E') / xs_max`.