### PR TITLE
Magnetic Field Driver

### DIFF
--- a/src/field/FieldDriver.hh
+++ b/src/field/FieldDriver.hh
@@ -35,13 +35,13 @@ class FieldDriver
                 RungeKuttaStepper<MagFieldEquation>& stepper);
 
     // For a given trial step, advance by a sub_step within a tolerance error
-    CELER_FUNCTION real_type operator()(real_type step, OdeState* state);
+    inline CELER_FUNCTION real_type operator()(real_type step, OdeState* state);
 
     // An adaptive step size control from G4MagIntegratorDriver
     // Move this to private after all tests with non-uniform field are done
-    CELER_FUNCTION real_type accurate_advance(real_type step,
-                                              OdeState* state,
-                                              real_type hinitial);
+    inline CELER_FUNCTION real_type accurate_advance(real_type step,
+                                                     OdeState* state,
+                                                     real_type hinitial);
 
   private:
     // A helper output for private member functions
@@ -57,20 +57,20 @@ class FieldDriver
     };
 
     // Find the next acceptable chord of with the miss-distance
-    CELER_FUNCTION auto find_next_chord(real_type step, const OdeState& state)
-        -> FieldOutput;
+    inline CELER_FUNCTION auto
+    find_next_chord(real_type step, const OdeState& state) -> FieldOutput;
 
     // Advance for a given step and  evaluate the next predicted step.
-    CELER_FUNCTION auto integrate_step(real_type step, const OdeState& state)
-        -> FieldOutput;
+    inline CELER_FUNCTION auto
+    integrate_step(real_type step, const OdeState& state) -> FieldOutput;
 
     // Advance within the truncated error and estimate a good next step size
-    CELER_FUNCTION auto one_good_step(real_type step, const OdeState& state)
-        -> FieldOutput;
+    inline CELER_FUNCTION auto
+    one_good_step(real_type step, const OdeState& state) -> FieldOutput;
 
     // Propose a next step size from a given step size and associated error
-    CELER_FUNCTION real_type new_step_size(real_type step,
-                                           real_type error) const;
+    inline CELER_FUNCTION real_type new_step_size(real_type step,
+                                                  real_type error) const;
 
     // >>> COMMON PROPERTIES
 

--- a/src/field/FieldDriver.hh
+++ b/src/field/FieldDriver.hh
@@ -1,0 +1,88 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file FieldDriver.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+#include "RungeKuttaStepper.hh"
+#include "MagFieldEquation.hh"
+#include "FieldParamsPointers.hh"
+#include "FieldInterface.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Brief class description.
+ *
+ *  This is a driver to control the quality of the field integration stepper
+ *  and provides the integration with a given field stepper
+ *
+ * \note This class is based on G4ChordFinder and G4MagIntegratorDriver
+ */
+class FieldDriver
+{
+  public:
+    // Construct with shared data and the stepper
+    inline CELER_FUNCTION
+    FieldDriver(const FieldParamsPointers&           shared,
+                RungeKuttaStepper<MagFieldEquation>& stepper);
+
+    // For a given trial step, advance by a sub_step within a tolerance error
+    CELER_FUNCTION real_type operator()(real_type step, OdeState* state);
+
+    // An adaptive step size control from G4MagIntegratorDriver
+    // TODO: move this method to private after all tests are done
+    CELER_FUNCTION real_type accurate_advance(real_type step,
+                                              OdeState* state,
+                                              real_type hinitial);
+
+  private:
+    // A helper output for private member functions
+    struct FieldOutput
+    {
+        real_type step_taken; //!< Step length taken
+        real_type value;      //!< A helper variable
+        OdeState  state;      //!< OdeState
+    };
+
+    // Find the next acceptable chord of with the miss-distance
+    CELER_FUNCTION auto find_next_chord(real_type step, const OdeState& state)
+        -> FieldOutput;
+
+    // Advance for a given step and  evaluate the next predicted step.
+    CELER_FUNCTION auto integrate_step(real_type step, const OdeState& state)
+        -> FieldOutput;
+
+    // Advance within the truncated error and estimate a good next step size
+    CELER_FUNCTION auto one_good_step(real_type step, const OdeState& state)
+        -> FieldOutput;
+
+    // Evaluate the next proposed step for a give step and associated error
+    CELER_FUNCTION real_type new_step_size(real_type step,
+                                           real_type error) const;
+
+    // >>> COMMON PROPERTIES
+
+    static CELER_CONSTEXPR_FUNCTION real_type half() { return 0.5; }
+
+    static CELER_CONSTEXPR_FUNCTION real_type rel_tolerance() { return 1e-6; }
+
+  private:
+    // Shared constant properties
+    const FieldParamsPointers& shared_;
+
+    // Stepper for this field driver
+    RungeKuttaStepper<MagFieldEquation>& stepper_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "FieldDriver.i.hh"

--- a/src/field/FieldDriver.hh
+++ b/src/field/FieldDriver.hh
@@ -76,7 +76,7 @@ class FieldDriver
 
     static CELER_CONSTEXPR_FUNCTION real_type half() { return 0.5; }
 
-    static CELER_CONSTEXPR_FUNCTION real_type rel_tolerance() { return 1e-6; }
+    static CELER_CONSTEXPR_FUNCTION real_type tolerance() { return 1e-6; }
 
   private:
     // Shared constant properties

--- a/src/field/FieldDriver.hh
+++ b/src/field/FieldDriver.hh
@@ -21,10 +21,9 @@ namespace celeritas
 /*!
  * Brief class description.
  *
- *  This is a driver to control the quality of the field integration stepper
- *  and provides the integration with a given field stepper
+ *  Integrate with and control the quality of the field integration stepper.
  *
- * \note This class is based on G4ChordFinder and G4MagIntegratorDriver
+ * \note This class is based on G4ChordFinder and G4MagIntegratorDriver.
  */
 class FieldDriver
 {

--- a/src/field/FieldDriver.hh
+++ b/src/field/FieldDriver.hh
@@ -76,7 +76,7 @@ class FieldDriver
 
     static CELER_CONSTEXPR_FUNCTION real_type half() { return 0.5; }
 
-    static CELER_CONSTEXPR_FUNCTION real_type tolerance() { return 1e-6; }
+    static CELER_CONSTEXPR_FUNCTION real_type ppm() { return 1e-6; }
 
   private:
     // Shared constant properties

--- a/src/field/FieldDriver.hh
+++ b/src/field/FieldDriver.hh
@@ -48,8 +48,12 @@ class FieldDriver
     struct FieldOutput
     {
         real_type step_taken; //!< Step length taken
-        real_type value;      //!< A helper variable
         OdeState  state;      //!< OdeState
+        union
+        {
+            real_type error;     //!< Stepper error
+            real_type next_step; //!< Proposed next step size
+        };
     };
 
     // Find the next acceptable chord of with the miss-distance
@@ -64,7 +68,7 @@ class FieldDriver
     CELER_FUNCTION auto one_good_step(real_type step, const OdeState& state)
         -> FieldOutput;
 
-    // Evaluate the next proposed step for a give step and associated error
+    // Propose a next step size from a given step size and associated error
     CELER_FUNCTION real_type new_step_size(real_type step,
                                            real_type error) const;
 

--- a/src/field/FieldDriver.hh
+++ b/src/field/FieldDriver.hh
@@ -38,7 +38,7 @@ class FieldDriver
     CELER_FUNCTION real_type operator()(real_type step, OdeState* state);
 
     // An adaptive step size control from G4MagIntegratorDriver
-    // TODO: move this method to private after all tests are done
+    // Move this to private after all tests with non-uniform field are done
     CELER_FUNCTION real_type accurate_advance(real_type step,
                                               OdeState* state,
                                               real_type hinitial);

--- a/src/field/FieldDriver.i.hh
+++ b/src/field/FieldDriver.i.hh
@@ -85,7 +85,7 @@ FieldDriver::find_next_chord(real_type step, const OdeState& state)
         real_type dchord
             = distance_chord(state, result.mid_state, result.end_state);
 
-        if (dchord <= (shared_.delta_chord + FieldDriver::rel_tolerance()))
+        if (dchord <= (shared_.delta_chord + FieldDriver::tolerance()))
         {
             converged    = true;
             output.error = truncation_error(
@@ -124,10 +124,10 @@ CELER_FUNCTION real_type FieldDriver::accurate_advance(real_type step,
     // Set an initial proposed step and evaluate the minimum threshold
     real_type end_curve_length = step;
 
-    real_type h = ((hinitial > FieldDriver::rel_tolerance() * step)
-                   && (hinitial < step))
-                      ? hinitial
-                      : step;
+    real_type h
+        = ((hinitial > FieldDriver::tolerance() * step) && (hinitial < step))
+              ? hinitial
+              : step;
     real_type h_threshold = shared_.epsilon_step * step;
 
     // Output with the next good step

--- a/src/field/FieldDriver.i.hh
+++ b/src/field/FieldDriver.i.hh
@@ -124,6 +124,10 @@ CELER_FUNCTION real_type FieldDriver::accurate_advance(real_type step,
     // Set an initial proposed step and evaluate the minimum threshold
     real_type end_curve_length = step;
 
+    // Use a pre-defined initial step size if it is smaller than the input
+    // step length and larger than the permillion fraction of the step length.
+    // Otherwise, use the input step length for the first trial.
+    // TODO: review whether this approach is an efficient bootstrapping.
     real_type h = ((hinitial > FieldDriver::ppm() * step) && (hinitial < step))
                       ? hinitial
                       : step;

--- a/src/field/FieldDriver.i.hh
+++ b/src/field/FieldDriver.i.hh
@@ -42,20 +42,18 @@ real_type FieldDriver::operator()(real_type step, OdeState* state)
     real_type step_taken = output.step_taken;
 
     // Evaluate the relative error
-    real_type ratio = output.value / (shared_.epsilon_step * step_taken);
+    real_type rel_error = output.value / (shared_.epsilon_step * step_taken);
 
-    if (ratio < 1)
-    {
-        // Accept this accuracy and update the current state
-        *state = output.state;
-    }
-    else
+    if (rel_error > 1)
     {
         // Advance more accurately with a newly proposed step
-        real_type next_step = this->new_step_size(step, ratio);
+        real_type next_step = this->new_step_size(step, rel_error);
         step_taken
             = this->accurate_advance(step_taken, &output.state, next_step);
     }
+
+    // Accept this accuracy and update the current state
+    *state = output.state;
 
     return step_taken;
 }

--- a/src/field/FieldDriver.i.hh
+++ b/src/field/FieldDriver.i.hh
@@ -1,0 +1,271 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file FieldDriver.i.hh
+//---------------------------------------------------------------------------//
+
+#include "base/NumericLimits.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared data and the stepper.
+ */
+CELER_FUNCTION
+FieldDriver::FieldDriver(const FieldParamsPointers&           shared,
+                         RungeKuttaStepper<MagFieldEquation>& stepper)
+    : shared_(shared), stepper_(stepper)
+{
+    CELER_ENSURE(shared_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Adaptive step control based on G4ChordFinder and G4MagIntegratorDriver:
+ * For a given trial step, advance by a sub-step within a required tolerance
+ * and update the current state (position and momentum).  For an efficient
+ * adaptive integration, the proposed chord of which the miss-distance (the
+ * closest distance from the curved trajectory to the chord) is smaller than
+ * a reference distance (dist_chord) will be accepted if its stepping error is
+ * within a reference accuracy. Otherwise, the more accurate step integration
+ * (advance_accurate) will be performed.
+ */
+CELER_FUNCTION
+real_type FieldDriver::operator()(real_type step, OdeState* state)
+{
+    // Output with a step control error
+    FieldOutput output = this->find_next_chord(step, *state);
+
+    real_type step_taken = output.step_taken;
+
+    // Evaluate the relative error
+    real_type ratio = output.value / (shared_.epsilon_step * step_taken);
+
+    if (ratio < 1)
+    {
+        // Accept this accuracy and update the current state
+        *state = output.state;
+    }
+    else
+    {
+        // Advance more accurately with a newly proposed step
+        real_type next_step = this->new_step_size(step, ratio);
+        step_taken
+            = this->accurate_advance(step_taken, &output.state, next_step);
+    }
+
+    return step_taken;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Find the next acceptable chord of which the miss-distance is smaller than
+ * a given reference (delta_chord) and evaluate the associated error.
+ */
+CELER_FUNCTION auto
+FieldDriver::find_next_chord(real_type step, const OdeState& state)
+    -> FieldOutput
+{
+    // Output with a step control error
+    FieldOutput output;
+
+    // Try with the proposed step
+    output.step_taken = step;
+
+    bool          converged       = false;
+    unsigned int  remaining_steps = shared_.max_nsteps;
+    StepperResult result;
+
+    do
+    {
+        result = stepper_(step, state);
+
+        // Check whether the distance to the chord is small than the reference
+        real_type dchord
+            = distance_chord(state, result.mid_state, result.end_state);
+
+        if (dchord <= shared_.delta_chord + rel_tolerance())
+        {
+            converged    = true;
+            output.value = truncation_error(
+                step, shared_.epsilon_rel_max, state, result.err_state);
+        }
+        else
+        {
+            // Estimate a new trial chord with a relative scale
+            output.step_taken
+                *= std::fmax(std::sqrt(shared_.delta_chord / dchord), half());
+        }
+    } while (!converged && (--remaining_steps > 0));
+
+    CELER_ASSERT(converged);
+
+    // Update new position and momentum
+    output.state = result.end_state;
+
+    return output;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Accurate_advance for an adaptive step control: Perform an adaptive step
+ * integration for a proposed step or a series of sub-steps within a required
+ * tolerance until the the accumulated curved path is equal to the input step
+ * length.
+ */
+CELER_FUNCTION real_type FieldDriver::accurate_advance(real_type step,
+                                                       OdeState* state,
+                                                       real_type hinitial)
+{
+    CELER_ASSERT(step > 0);
+
+    // Set an initial proposed step and evaluate the minimum threshold
+    real_type end_curve_length = step;
+
+    real_type h = ((hinitial > rel_tolerance() * step) && (hinitial < step))
+                      ? hinitial
+                      : step;
+    real_type h_threshold = shared_.epsilon_step * step;
+
+    // Output with the next good step
+    FieldOutput output;
+
+    // Performance integration
+    bool         succeeded       = false;
+    real_type    curve_length    = 0;
+    unsigned int remaining_steps = shared_.max_nsteps;
+
+    do
+    {
+        output = this->integrate_step(h, *state);
+
+        curve_length += output.step_taken;
+
+        if (h < h_threshold || curve_length >= end_curve_length)
+        {
+            succeeded = true;
+        }
+        else
+        {
+            h = std::fmax(output.value, shared_.minimum_step);
+            if (curve_length + h > end_curve_length)
+            {
+                h = end_curve_length - curve_length;
+            }
+        }
+        *state = output.state;
+    } while (!succeeded && --remaining_steps > 0);
+
+    CELER_ASSERT(succeeded);
+
+    return curve_length;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Helper function for accurate_advance: advance for a given step and
+ * evaluate the next predicted step.
+ */
+CELER_FUNCTION auto
+FieldDriver::integrate_step(real_type step, const OdeState& state)
+    -> FieldOutput
+{
+    // Output with a next proposed step
+    FieldOutput output;
+
+    if (step > shared_.minimum_step)
+    {
+        output = this->one_good_step(step, state);
+    }
+    else
+    {
+        // Do an integration step for a small step (a.k.a quick advance)
+        StepperResult result = stepper_(step, state);
+
+        // Update position and momentum
+        output.state = result.end_state;
+
+        real_type dyerr = truncation_error(
+            step, shared_.epsilon_rel_max, state, result.err_state);
+        output.step_taken = step;
+
+        // Compute a proposed new step
+        CELER_ASSERT(output.step_taken != 0);
+        output.value
+            = this->new_step_size(step, dyerr / (step * shared_.epsilon_step));
+    }
+
+    return output;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Advance within a relative truncation error and estimate a good step size
+ * for the next integration.
+ */
+CELER_FUNCTION auto
+FieldDriver::one_good_step(real_type step, const OdeState& state)
+    -> FieldOutput
+{
+    // Output with a proposed next step
+    FieldOutput output;
+
+    // Perform integration for adaptive step control with the trunction error
+    bool          condition       = false;
+    unsigned int  remaining_steps = shared_.max_nsteps;
+    real_type     errmax2 = celeritas::numeric_limits<real_type>::max();
+    StepperResult result;
+
+    do
+    {
+        result  = stepper_(step, state);
+        errmax2 = truncation_error(
+            step, shared_.epsilon_rel_max, state, result.err_state);
+
+        if (errmax2 <= 1)
+        {
+            condition = true;
+        }
+        else
+        {
+            // Step failed; compute the size of re-trial step.
+            real_type htemp = shared_.safety * step
+                              * std::pow(errmax2, half() * shared_.pshrink);
+
+            // Truncation error too large, reduce stepsize with a low bound
+            step = std::fmax(htemp, shared_.max_stepping_decrease * step);
+        }
+    } while (!condition && --remaining_steps > 0);
+
+    // TODO: loop check and handle rare cases if happen
+    CELER_ASSERT(condition);
+
+    // Update state, step taken by this trial and the next predicted step
+    output.state      = result.end_state;
+    output.step_taken = step;
+    output.value      = (errmax2 > ipow<2>(shared_.errcon))
+                       ? shared_.safety * step
+                             * std::pow(errmax2, half() * shared_.pgrow)
+                       : shared_.max_stepping_increase * step;
+
+    return output;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ *  Estimate the new predicted step size based on the error estimate
+ */
+CELER_FUNCTION
+real_type FieldDriver::new_step_size(real_type step, real_type error) const
+{
+    CELER_ASSERT(error > 0);
+    real_type scale_factor = (error > 1) ? std::pow(error, shared_.pshrink)
+                                         : std::pow(error, shared_.pgrow);
+    return shared_.safety * step * scale_factor;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/field/FieldDriver.i.hh
+++ b/src/field/FieldDriver.i.hh
@@ -85,7 +85,7 @@ FieldDriver::find_next_chord(real_type step, const OdeState& state)
         real_type dchord
             = distance_chord(state, result.mid_state, result.end_state);
 
-        if (dchord <= (shared_.delta_chord + FieldDriver::tolerance()))
+        if (dchord <= (shared_.delta_chord + FieldDriver::ppm()))
         {
             converged    = true;
             output.error = truncation_error(
@@ -125,7 +125,7 @@ CELER_FUNCTION real_type FieldDriver::accurate_advance(real_type step,
     real_type end_curve_length = step;
 
     real_type h
-        = ((hinitial > FieldDriver::tolerance() * step) && (hinitial < step))
+        = ((hinitial > FieldDriver::ppm() * step) && (hinitial < step))
               ? hinitial
               : step;
     real_type h_threshold = shared_.epsilon_step * step;

--- a/src/field/FieldInterface.hh
+++ b/src/field/FieldInterface.hh
@@ -24,9 +24,9 @@ struct OdeState
 
 //---------------------------------------------------------------------------//
 /*!
- * The result of the operator RungeKuttaStepper
+ * The result of the integration stepper
  */
-struct RungeKuttaResult
+struct StepperResult
 {
     OdeState end_state; //!< OdeState at the end
     OdeState mid_state; //!< OdeState at the middle

--- a/src/field/FieldParamsPointers.hh
+++ b/src/field/FieldParamsPointers.hh
@@ -56,22 +56,22 @@ struct FieldParamsPointers
     //! the maximum number of steps (or trials)
     size_type max_nsteps = 100;
 
-    //! Check whether the data is assigned
+    //! Check whether data are assigned appropriately
     explicit inline CELER_FUNCTION operator bool() const
     {
         // clang-format off
-        return    minimum_step
-               && delta_chord 
-               && delta_intersection 
-               && epsilon_step 
-               && epsilon_rel_max 
-               && errcon 
-               && pgrow 
-               && pshrink 
-               && safety 
-               && max_stepping_increase
-               && max_stepping_decrease 
-               && max_nsteps;
+      return      (minimum_step > 0)
+	       && (delta_chord > 0) 
+	       && (delta_intersection > 0) 
+	       && (epsilon_step > 0 && epsilon_step < 1)
+	       && (epsilon_rel_max > 0) 
+	       && (errcon > 0) 
+	       && (pgrow < 0) 
+	       && (pshrink < 0) 
+	       && (safety > 0 && safety < 1) 
+	       && (max_stepping_increase > 1)
+	       && (max_stepping_decrease > 0 && max_stepping_decrease < 1)
+	       && (max_nsteps > 0);
         // clang-format on
     }
 };

--- a/src/field/FieldParamsPointers.hh
+++ b/src/field/FieldParamsPointers.hh
@@ -9,6 +9,7 @@
 
 #include "base/Macros.hh"
 #include "base/Types.hh"
+#include "base/Units.hh"
 
 namespace celeritas
 {
@@ -19,41 +20,41 @@ namespace celeritas
  */
 struct FieldParamsPointers
 {
-    //! the minimum length of the field step = 1.0e-5 [mm]
-    real_type minimum_step;
+    //! the minimum length of the field step
+    real_type minimum_step = 1.0e-5 * units::millimeter;
 
-    //! the closest miss distrance = 0.25 [mm]
-    real_type delta_chord;
+    //! the closest miss distrance
+    real_type delta_chord = 0.25 * units::millimeter;
 
-    //! accuracy of intersection of the boundary crossing  = 1.0e-4 [mm]
-    real_type delta_intersection;
+    //! accuracy of intersection of the boundary crossing
+    real_type delta_intersection = 1.0e-4 * units::millimeter;
 
-    //! the relative error scale on the step length = 1.0e-5
-    real_type epsilon_step;
+    //! the relative error scale on the step length
+    real_type epsilon_step = 1.0e-5;
 
-    //! the maximum of the error ratio = 1.0e-3
-    real_type epsilon_rel_max;
+    //! the maximum of the error ratio
+    real_type epsilon_rel_max = 1.0e-3;
 
-    //! the truncation error tolerance = 1.0e-4
-    real_type errcon;
+    //! the truncation error tolerance
+    real_type errcon = 1.0e-4;
 
-    //! pgrow (the exponent to increase a stepsiz) = -0.20
-    real_type pgrow;
+    //! pgrow (the exponent to increase a stepsiz)
+    real_type pgrow = -0.20;
 
-    //! pshrink (the exponent to decrease a stepsiz) = -0.25
-    real_type pshrink;
+    //! pshrink (the exponent to decrease a stepsiz)
+    real_type pshrink = -0.25;
 
-    //! safety (a scale factor for the predicted step size) = 0.9
-    real_type safety;
+    //! safety (a scale factor for the predicted step size)
+    real_type safety = 0.9;
 
-    //! the maximum scale to increase a step size = 5
-    real_type max_stepping_increase;
+    //! the maximum scale to increase a step size
+    real_type max_stepping_increase = 5;
 
-    //! the maximum scale factor to decrease a step size = 0.1
-    real_type max_stepping_decrease;
+    //! the maximum scale factor to decrease a step size
+    real_type max_stepping_decrease = 0.1;
 
-    //! the maximum number of steps (or trials) = 100
-    size_type max_nsteps;
+    //! the maximum number of steps (or trials)
+    size_type max_nsteps = 100;
 
     //! Check whether the data is assigned
     explicit inline CELER_FUNCTION operator bool() const

--- a/src/field/FieldParamsPointers.hh
+++ b/src/field/FieldParamsPointers.hh
@@ -1,0 +1,79 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file FieldParamsPointers.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Host and device parameters for propagation in a magnetic field and
+ * suggested default values
+ */
+struct FieldParamsPointers
+{
+    //! the minimum length of the field step = 1.0e-5 [mm]
+    real_type minimum_step;
+
+    //! the closest miss distrance = 0.25 [mm]
+    real_type delta_chord;
+
+    //! accuracy of intersection of the boundary crossing  = 1.0e-4 [mm]
+    real_type delta_intersection;
+
+    //! the relative error scale on the step length = 1.0e-5
+    real_type epsilon_step;
+
+    //! the maximum of the error ratio = 1.0e-3
+    real_type epsilon_rel_max;
+
+    //! the truncation error tolerance = 1.0e-4
+    real_type errcon;
+
+    //! pgrow (the exponent to increase a stepsiz) = -0.20
+    real_type pgrow;
+
+    //! pshrink (the exponent to decrease a stepsiz) = -0.25
+    real_type pshrink;
+
+    //! safety (a scale factor for the predicted step size) = 0.9
+    real_type safety;
+
+    //! the maximum scale to increase a step size = 5
+    real_type max_stepping_increase;
+
+    //! the maximum scale factor to decrease a step size = 0.1
+    real_type max_stepping_decrease;
+
+    //! the maximum number of steps (or trials) = 100
+    size_type max_nsteps;
+
+    //! Check whether the data is assigned
+    explicit inline CELER_FUNCTION operator bool() const
+    {
+        // clang-format off
+        return    minimum_step
+               && delta_chord 
+               && delta_intersection 
+               && epsilon_step 
+               && epsilon_rel_max 
+               && errcon 
+               && pgrow 
+               && pshrink 
+               && safety 
+               && max_stepping_increase
+               && max_stepping_decrease 
+               && max_nsteps;
+        // clang-format on
+    }
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/field/RungeKuttaStepper.hh
+++ b/src/field/RungeKuttaStepper.hh
@@ -32,7 +32,7 @@ class RungeKuttaStepper
   public:
     //!@{
     //! Type aliases
-    using Result = RungeKuttaResult;
+    using Result = StepperResult;
     //!@}
 
   public:
@@ -41,9 +41,8 @@ class RungeKuttaStepper
     RungeKuttaStepper(const FieldEquation_T& eq) : equation_(eq) {}
 
     // Adaptive step size control
-    CELER_FUNCTION auto operator()(real_type       step,
-                                   const OdeState& beg_state,
-                                   const OdeState& beg_slope) -> Result;
+    CELER_FUNCTION auto operator()(real_type step, const OdeState& beg_state)
+        -> Result;
 
   private:
     // Return the final state by the 4th order Runge-Kutta method

--- a/src/field/RungeKuttaStepper.i.hh
+++ b/src/field/RungeKuttaStepper.i.hh
@@ -35,14 +35,14 @@ namespace celeritas
  */
 template<class T>
 CELER_FUNCTION auto RungeKuttaStepper<T>::
-                    operator()(real_type step, const OdeState& beg_state, const OdeState& beg_slope)
-    -> Result
+                    operator()(real_type step, const OdeState& beg_state) -> Result
 {
     using celeritas::axpy;
     real_type           half_step               = step / real_type(2);
     constexpr real_type fourth_order_correction = 1 / real_type(15);
 
-    Result result;
+    Result   result;
+    OdeState beg_slope = equation_(beg_state);
 
     // Do two half steps
     result.mid_state = do_step(half_step, beg_state, beg_slope);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -249,5 +249,13 @@ celeritas_setup_tests(SERIAL PREFIX field)
 
 celeritas_cudaoptional_test(field/RungeKutta)
 
+if(CELERITAS_USE_CUDA)
+  add_library(celeritas_field_test field/FieldDriver.test.cu)
+  target_link_libraries(celeritas_field_test PRIVATE celeritas)
+  list(APPEND CELERITASTEST_LINK_LIBRARIES celeritas_field_test)
+endif()
+
+celeritas_add_test(field/FieldDriver.test.cc GPU)
+
 #-----------------------------------------------------------------------------#
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -248,14 +248,7 @@ endif()
 celeritas_setup_tests(SERIAL PREFIX field)
 
 celeritas_cudaoptional_test(field/RungeKutta)
-
-if(CELERITAS_USE_CUDA)
-  add_library(celeritas_field_test field/FieldDriver.test.cu)
-  target_link_libraries(celeritas_field_test PRIVATE celeritas)
-  list(APPEND CELERITASTEST_LINK_LIBRARIES celeritas_field_test)
-endif()
-
-celeritas_add_test(field/FieldDriver.test.cc GPU)
+celeritas_cudaoptional_test(field/FieldDriver)
 
 #-----------------------------------------------------------------------------#
 

--- a/test/field/FieldDriver.test.cc
+++ b/test/field/FieldDriver.test.cc
@@ -36,20 +36,6 @@ class FieldDriverTest : public Test
   protected:
     void SetUp() override
     {
-        // Set values of FieldParamsPointers;
-        field_params.minimum_step          = 1.0e-5 * units::millimeter;
-        field_params.delta_chord           = 0.25 * units::millimeter;
-        field_params.delta_intersection    = 1.0e-4 * units::millimeter;
-        field_params.epsilon_step          = 1.0e-5;
-        field_params.epsilon_rel_max       = 1.0e-3;
-        field_params.errcon                = 1.0e-4;
-        field_params.pgrow                 = -0.20;
-        field_params.pshrink               = -0.25;
-        field_params.safety                = 0.9;
-        field_params.max_stepping_increase = 5;
-        field_params.max_stepping_decrease = 0.1;
-        field_params.max_nsteps            = 100;
-
         // Input parameters of an electron in a uniform magnetic field
         test_params.nstates     = 128 * 512;
         test_params.nsteps      = 100;

--- a/test/field/FieldDriver.test.cc
+++ b/test/field/FieldDriver.test.cc
@@ -179,7 +179,7 @@ class FieldDriverDeviceTest : public FieldDriverTest
 {
 };
 
-TEST_F(FieldDriverDeviceTest, field_driver_device)
+TEST_F(FieldDriverDeviceTest, TEST_IF_CELERITAS_CUDA(field_driver_device))
 {
     // Run kernel
     auto output = driver_test(field_params, test_params);
@@ -201,7 +201,7 @@ TEST_F(FieldDriverDeviceTest, field_driver_device)
     }
 }
 
-TEST_F(FieldDriverDeviceTest, accurate_advance_device)
+TEST_F(FieldDriverDeviceTest, TEST_IF_CELERITAS_CUDA(accurate_advance_device))
 {
     // Run kernel
     auto output = accurate_advance_test(field_params, test_params);

--- a/test/field/FieldDriver.test.cc
+++ b/test/field/FieldDriver.test.cc
@@ -37,9 +37,9 @@ class FieldDriverTest : public Test
     void SetUp() override
     {
         // Set values of FieldParamsPointers;
-        field_params.minimum_step          = 1.0e-5;
-        field_params.delta_chord           = 0.25;
-        field_params.delta_intersection    = 1.0e-4;
+        field_params.minimum_step          = 1.0e-5 * units::millimeter;
+        field_params.delta_chord           = 0.25 * units::millimeter;
+        field_params.delta_intersection    = 1.0e-4 * units::millimeter;
         field_params.epsilon_step          = 1.0e-5;
         field_params.epsilon_rel_max       = 1.0e-3;
         field_params.errcon                = 1.0e-4;
@@ -55,8 +55,8 @@ class FieldDriverTest : public Test
         test_params.nsteps      = 100;
         test_params.revolutions = 10;
         test_params.field_value = 1.0 * units::tesla;
-        test_params.radius      = 3.8085386036;
-        test_params.delta_z     = 6.7003310629;
+        test_params.radius      = 3.8085386036 * units::centimeter;
+        test_params.delta_z     = 6.7003310629 * units::centimeter;
         test_params.energy      = 10.9181415106;
         test_params.momentum_y  = 10.9610028286;
         test_params.momentum_z  = 3.1969591583;

--- a/test/field/FieldDriver.test.cc
+++ b/test/field/FieldDriver.test.cc
@@ -1,0 +1,227 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file FieldDriver.test.cc
+//---------------------------------------------------------------------------//
+
+#include "field/FieldDriver.hh"
+#include "field/FieldParamsPointers.hh"
+#include "field/FieldInterface.hh"
+
+#include "field/RungeKuttaStepper.hh"
+#include "field/MagField.hh"
+#include "field/MagFieldEquation.hh"
+
+#include "base/Range.hh"
+#include "base/Types.hh"
+#include "base/Constants.hh"
+
+#include "celeritas_test.hh"
+
+#ifdef CELERITAS_USE_CUDA
+#    include "FieldDriver.test.hh"
+#endif
+
+using namespace celeritas;
+using namespace celeritas_test;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class FieldDriverTest : public Test
+{
+  protected:
+    void SetUp() override
+    {
+        // Set values of FieldParamsPointers;
+        field_params.minimum_step          = 1.0e-5;
+        field_params.delta_chord           = 0.25;
+        field_params.delta_intersection    = 1.0e-4;
+        field_params.epsilon_step          = 1.0e-5;
+        field_params.epsilon_rel_max       = 1.0e-3;
+        field_params.errcon                = 1.0e-4;
+        field_params.pgrow                 = -0.20;
+        field_params.pshrink               = -0.25;
+        field_params.safety                = 0.9;
+        field_params.max_stepping_increase = 5;
+        field_params.max_stepping_decrease = 0.1;
+        field_params.max_nsteps            = 100;
+
+        // Input parameters of an electron in a uniform magnetic field
+        test_params.nstates     = 128 * 512;
+        test_params.nsteps      = 100;
+        test_params.revolutions = 10;
+        test_params.field_value = 1.0 * units::tesla;
+        test_params.radius      = 3.8085386036;
+        test_params.delta_z     = 6.7003310629;
+        test_params.energy      = 10.9181415106;
+        test_params.momentum_y  = 10.9610028286;
+        test_params.momentum_z  = 3.1969591583;
+        test_params.epsilon     = 1.0e-5;
+    }
+
+  protected:
+    // Field parameters
+    FieldParamsPointers field_params;
+
+    // Test parameters
+    FieldTestParams test_params;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(FieldDriverTest, field_driver_host)
+{
+    // Construct FieldDriver
+    MagField         field({0, 0, test_params.field_value});
+    MagFieldEquation equation(field, units::ElementaryCharge{-1});
+    RungeKuttaStepper<MagFieldEquation> rk4(equation);
+    FieldDriver                         driver(field_params, rk4);
+
+    // Test parameters and the sub-step size
+    real_type circumference = 2 * constants::pi * test_params.radius;
+    real_type hstep         = circumference / test_params.nsteps;
+
+    // Only test every 128 states to reduce debug runtime
+    for (unsigned int i : celeritas::range(test_params.nstates).step(128u))
+    {
+        // Initial state and the epected state after revolutions
+        OdeState y;
+        y.pos = {test_params.radius, 0, i * 1.0e-6};
+        y.mom = {0, test_params.momentum_y, test_params.momentum_z};
+
+        OdeState y_expected = y;
+
+        real_type total_step_length{0};
+
+        // Try the stepper by hstep for (num_revolutions * num_steps) times
+        real_type delta = field_params.errcon;
+        for (int nr = 0; nr < test_params.revolutions; ++nr)
+        {
+            y_expected.pos = {test_params.radius,
+                              0,
+                              (nr + 1) * test_params.delta_z + i * 1.0e-6};
+
+            // Travel hstep for num_steps times in the field
+            for (CELER_MAYBE_UNUSED int j : range(test_params.nsteps))
+            {
+                total_step_length += driver(hstep, &y);
+            }
+
+            // Check the total error and the state (position, momentum)
+            EXPECT_VEC_NEAR(y_expected.pos, y.pos, delta);
+        }
+
+        // Check the total error, step/curve length
+        EXPECT_SOFT_NEAR(
+            total_step_length, circumference * test_params.revolutions, delta);
+    }
+}
+
+TEST_F(FieldDriverTest, accurate_advance_host)
+{
+    // Construct FieldDriver
+    MagField         field({0, 0, test_params.field_value});
+    MagFieldEquation equation(field, units::ElementaryCharge{-1});
+    RungeKuttaStepper<MagFieldEquation> rk4(equation);
+    FieldDriver                         driver(field_params, rk4);
+
+    // Test parameters and the sub-step size
+    real_type circumference = 2 * constants::pi * test_params.radius;
+    real_type hstep         = circumference / test_params.nsteps;
+
+    // Only test every 128 states to reduce debug runtime
+    for (unsigned int i : celeritas::range(test_params.nstates).step(128u))
+    {
+        // Initial state and the epected state after revolutions
+        OdeState y;
+        y.pos = {test_params.radius, 0, i * 1.0e-6};
+        y.mom = {0, test_params.momentum_y, test_params.momentum_z};
+
+        OdeState y_expected = y;
+
+        // Try the stepper by hstep for (num_revolutions * num_steps) times
+        real_type total_curved_length{0};
+        real_type delta = field_params.errcon;
+
+        for (int nr = 0; nr < test_params.revolutions; ++nr)
+        {
+            // test one_good_step
+            OdeState y_accurate = y;
+
+            // Travel hstep for num_steps times in the field
+            for (CELER_MAYBE_UNUSED int j : range(test_params.nsteps))
+            {
+                total_curved_length
+                    += driver.accurate_advance(hstep, &y_accurate, .001);
+            }
+            // Check the total error and the state (position, momentum)
+            EXPECT_VEC_NEAR(y_expected.pos, y.pos, delta);
+        }
+
+        // Check the total error, step/curve length
+        EXPECT_LT(total_curved_length - circumference * test_params.revolutions,
+                  delta);
+    }
+}
+
+#if CELERITAS_USE_CUDA
+//---------------------------------------------------------------------------//
+// DEVICE TESTS
+//---------------------------------------------------------------------------//
+
+class FieldDriverDeviceTest : public FieldDriverTest
+{
+};
+
+TEST_F(FieldDriverDeviceTest, field_driver_device)
+{
+    // Run kernel
+    auto output = driver_test(field_params, test_params);
+
+    // Check stepper results
+    real_type zstep = test_params.delta_z * test_params.revolutions;
+    real_type delta = field_params.errcon;
+
+    real_type circumference = 2 * constants::pi * test_params.radius;
+
+    for (auto i : range(test_params.nstates))
+    {
+        EXPECT_SOFT_NEAR(output.pos_x[i], test_params.radius, delta);
+        EXPECT_SOFT_NEAR(output.pos_z[i], zstep + i * 1.0e-6, delta);
+        EXPECT_SOFT_NEAR(output.mom_y[i], test_params.momentum_y, delta);
+        EXPECT_SOFT_NEAR(output.mom_z[i], test_params.momentum_z, delta);
+        EXPECT_SOFT_NEAR(
+            output.error[i], circumference * test_params.revolutions, delta);
+    }
+}
+
+TEST_F(FieldDriverDeviceTest, accurate_advance_device)
+{
+    // Run kernel
+    auto output = accurate_advance_test(field_params, test_params);
+
+    // Check stepper results
+    real_type zstep = test_params.delta_z;
+    real_type delta = field_params.errcon;
+
+    real_type circumference = 2 * constants::pi * test_params.radius;
+
+    for (auto i : range(test_params.nstates))
+    {
+        EXPECT_SOFT_NEAR(output.pos_x[i], test_params.radius, delta);
+        EXPECT_SOFT_NEAR(output.pos_z[i], zstep + i * 1.0e-6, delta);
+        EXPECT_SOFT_NEAR(output.mom_y[i], test_params.momentum_y, delta);
+        EXPECT_SOFT_NEAR(output.mom_z[i], test_params.momentum_z, delta);
+        EXPECT_SOFT_NEAR(
+            output.length[i], circumference * test_params.revolutions, delta);
+    }
+}
+
+//---------------------------------------------------------------------------//
+#endif

--- a/test/field/FieldDriver.test.cu
+++ b/test/field/FieldDriver.test.cu
@@ -197,8 +197,8 @@ OneGoodStepOutput accurate_advance_test(const FieldParamsPointers& fd_pointers,
     thrust::device_vector<double> length(test_params.nstates, 0.0);
 
     // Run kernel
-    celeritas::KernelParamCalculator calc_launch_params(driver_test_kernel,
-                                                        "driver_test");
+    celeritas::KernelParamCalculator calc_launch_params(
+        accurate_advance_kernel, "accurate_advance_test");
     auto params = calc_launch_params(test_params.nstates);
 
     accurate_advance_kernel<<<params.grid_size, params.block_size>>>(

--- a/test/field/FieldDriver.test.cu
+++ b/test/field/FieldDriver.test.cu
@@ -1,0 +1,235 @@
+//---------------------------------*-CUDA-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file FieldDriver.test.cu
+//---------------------------------------------------------------------------//
+#include "FieldDriver.test.hh"
+#include "FieldTestParams.hh"
+
+#include "base/KernelParamCalculator.cuda.hh"
+#include <thrust/device_vector.h>
+
+#include "field/FieldDriver.hh"
+#include "field/FieldParamsPointers.hh"
+#include "field/RungeKuttaStepper.hh"
+#include "field/MagField.hh"
+#include "field/MagFieldEquation.hh"
+
+#include "base/Range.hh"
+#include "base/Types.hh"
+#include "base/Constants.hh"
+
+using thrust::raw_pointer_cast;
+
+namespace celeritas_test
+{
+using namespace celeritas;
+//---------------------------------------------------------------------------//
+// KERNELS
+//---------------------------------------------------------------------------//
+
+__global__ void driver_test_kernel(const FieldParamsPointers pointers,
+                                   FieldTestParams           test_params,
+                                   double*                   pos_x,
+                                   double*                   pos_z,
+                                   double*                   mom_y,
+                                   double*                   mom_z,
+                                   double*                   error)
+{
+    auto tid = celeritas::KernelParamCalculator::thread_id();
+    if (tid.get() >= test_params.nstates)
+        return;
+
+    // Construct the driver
+    MagField         field({0, 0, test_params.field_value});
+    MagFieldEquation equation(field, units::ElementaryCharge{-1});
+    RungeKuttaStepper<MagFieldEquation> rk4(equation);
+    FieldDriver                         driver(pointers, rk4);
+
+    // Test parameters and the sub-step size
+    real_type hstep = 2 * constants::pi * test_params.radius
+                      / test_params.nsteps;
+
+    // Initial state and the epected state after revolutions
+    OdeState y;
+    y.pos = {test_params.radius, 0, tid.get() * 1.0e-6};
+    y.mom = {0, test_params.momentum_y, test_params.momentum_z};
+
+    // The rhs of the equation and a temporary array
+
+    real_type total_step_length{0};
+
+    for (CELER_MAYBE_UNUSED int i : celeritas::range(test_params.revolutions))
+    {
+        // Travel hstep for num_steps times in the field
+        for (CELER_MAYBE_UNUSED int j : celeritas::range(test_params.nsteps))
+        {
+            total_step_length += driver(hstep, &y);
+        }
+        // Check the total length
+    }
+
+    // output for validation
+    pos_x[tid.get()] = y.pos[0];
+    pos_z[tid.get()] = y.pos[2];
+    mom_y[tid.get()] = y.mom[1];
+    mom_z[tid.get()] = y.mom[2];
+    error[tid.get()] = total_step_length;
+}
+
+__global__ void accurate_advance_kernel(const FieldParamsPointers pointers,
+                                        FieldTestParams           test_params,
+                                        double*                   pos_x,
+                                        double*                   pos_z,
+                                        double*                   mom_y,
+                                        double*                   mom_z,
+                                        double*                   length)
+{
+    auto tid = celeritas::KernelParamCalculator::thread_id();
+    if (tid.get() >= test_params.nstates)
+        return;
+
+    // Construct the driver
+    MagField         field({0, 0, test_params.field_value});
+    MagFieldEquation equation(field, units::ElementaryCharge{-1});
+    RungeKuttaStepper<MagFieldEquation> rk4(equation);
+    FieldDriver                         driver(pointers, rk4);
+
+    // Test parameters and the sub-step size
+    real_type circumference = 2 * constants::pi * test_params.radius;
+    real_type hstep         = circumference / test_params.nsteps;
+
+    // Initial state and the epected state after revolutions
+    OdeState y;
+    y.pos = {test_params.radius, 0, tid.get() * 1.0e-6};
+    y.mom = {0, test_params.momentum_y, test_params.momentum_z};
+
+    // The rhs of the equation and a temporary array
+    OdeState y_accurate;
+
+    real_type total_curved_length{0};
+
+    for (CELER_MAYBE_UNUSED int i : celeritas::range(test_params.revolutions))
+    {
+        // test quick_advance
+        y_accurate = y;
+
+        // Travel hstep for num_steps times in the field
+        for (CELER_MAYBE_UNUSED int j : celeritas::range(test_params.nsteps))
+        {
+            total_curved_length
+                += driver.accurate_advance(hstep, &y_accurate, 0.001);
+        }
+        // Check the total error
+    }
+
+    // output for validation
+    pos_x[tid.get()]  = y_accurate.pos[0];
+    pos_z[tid.get()]  = y_accurate.pos[2];
+    mom_y[tid.get()]  = y_accurate.mom[1];
+    mom_z[tid.get()]  = y_accurate.mom[2];
+    length[tid.get()] = total_curved_length;
+}
+
+//---------------------------------------------------------------------------//
+// TESTING INTERFACE
+//---------------------------------------------------------------------------//
+//! Run on device and return results
+FITestOutput driver_test(const FieldParamsPointers& fd_pointers,
+                         FieldTestParams            test_params)
+{
+    // Input/Output data for kernel
+
+    // Output data for kernel
+    thrust::device_vector<double> pos_x(test_params.nstates, 0.0);
+    thrust::device_vector<double> pos_z(test_params.nstates, 0.0);
+    thrust::device_vector<double> mom_y(test_params.nstates, 0.0);
+    thrust::device_vector<double> mom_z(test_params.nstates, 0.0);
+    thrust::device_vector<double> error(test_params.nstates, 0.0);
+
+    // Run kernel
+    celeritas::KernelParamCalculator calc_launch_params(driver_test_kernel,
+                                                        "driver_test");
+    auto params = calc_launch_params(test_params.nstates);
+
+    driver_test_kernel<<<params.grid_size, params.block_size>>>(
+        fd_pointers,
+        test_params,
+        raw_pointer_cast(pos_x.data()),
+        raw_pointer_cast(pos_z.data()),
+        raw_pointer_cast(mom_y.data()),
+        raw_pointer_cast(mom_z.data()),
+        raw_pointer_cast(error.data()));
+    CELER_CUDA_CALL(cudaDeviceSynchronize());
+
+    // Copy result back to CPU
+    FITestOutput result;
+
+    result.pos_x.resize(pos_x.size());
+    thrust::copy(pos_x.begin(), pos_x.end(), result.pos_x.begin());
+
+    result.pos_z.resize(pos_z.size());
+    thrust::copy(pos_z.begin(), pos_z.end(), result.pos_z.begin());
+
+    result.mom_y.resize(mom_y.size());
+    thrust::copy(mom_y.begin(), mom_y.end(), result.mom_y.begin());
+
+    result.mom_z.resize(mom_z.size());
+    thrust::copy(mom_z.begin(), mom_z.end(), result.mom_z.begin());
+
+    result.error.resize(error.size());
+    thrust::copy(error.begin(), error.end(), result.error.begin());
+    return result;
+}
+
+OneGoodStepOutput accurate_advance_test(const FieldParamsPointers& fd_pointers,
+                                        FieldTestParams            test_params)
+{
+    // Input/Output data for kernel
+
+    // Output data for kernel
+    thrust::device_vector<double> pos_x(test_params.nstates, 0.0);
+    thrust::device_vector<double> pos_z(test_params.nstates, 0.0);
+    thrust::device_vector<double> mom_y(test_params.nstates, 0.0);
+    thrust::device_vector<double> mom_z(test_params.nstates, 0.0);
+    thrust::device_vector<double> length(test_params.nstates, 0.0);
+
+    // Run kernel
+    celeritas::KernelParamCalculator calc_launch_params(driver_test_kernel,
+                                                        "driver_test");
+    auto params = calc_launch_params(test_params.nstates);
+
+    accurate_advance_kernel<<<params.grid_size, params.block_size>>>(
+        fd_pointers,
+        test_params,
+        raw_pointer_cast(pos_x.data()),
+        raw_pointer_cast(pos_z.data()),
+        raw_pointer_cast(mom_y.data()),
+        raw_pointer_cast(mom_z.data()),
+        raw_pointer_cast(length.data()));
+    CELER_CUDA_CALL(cudaDeviceSynchronize());
+
+    // Copy result back to CPU
+    OneGoodStepOutput result;
+
+    result.pos_x.resize(pos_x.size());
+    thrust::copy(pos_x.begin(), pos_x.end(), result.pos_x.begin());
+
+    result.pos_z.resize(pos_z.size());
+    thrust::copy(pos_z.begin(), pos_z.end(), result.pos_z.begin());
+
+    result.mom_y.resize(mom_y.size());
+    thrust::copy(mom_y.begin(), mom_y.end(), result.mom_y.begin());
+
+    result.mom_z.resize(mom_z.size());
+    thrust::copy(mom_z.begin(), mom_z.end(), result.mom_z.begin());
+
+    result.length.resize(length.size());
+    thrust::copy(length.begin(), length.end(), result.length.begin());
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/field/FieldDriver.test.hh
+++ b/test/field/FieldDriver.test.hh
@@ -47,14 +47,13 @@ accurate_advance_test(const celeritas::FieldParamsPointers& fd_ptr,
                       FieldTestParams                       tp);
 
 #if !CELERITAS_USE_CUDA
-inline driver_test(const celeritas::FieldParamsPointers& fd_ptr,
-                   FieldTestParams                       tp)
+inline driver_test(const celeritas::FieldParamsPointers&, FieldTestParams)
 {
     CELER_NOT_CONFIGURED("CUDA");
 }
 
-inline accurate_advance_test(const celeritas::FieldParamsPointers& fd_ptr,
-                             FieldTestParams                       tp)
+inline accurate_advance_test(const celeritas::FieldParamsPointers&,
+                             FieldTestParams)
 {
     CELER_NOT_CONFIGURED("CUDA");
 }

--- a/test/field/FieldDriver.test.hh
+++ b/test/field/FieldDriver.test.hh
@@ -46,5 +46,19 @@ OneGoodStepOutput
 accurate_advance_test(const celeritas::FieldParamsPointers& fd_ptr,
                       FieldTestParams                       tp);
 
+#if !CELERITAS_USE_CUDA
+inline driver_test(const celeritas::FieldParamsPointers& fd_ptr,
+                   FieldTestParams                       tp)
+{
+    CELER_NOT_CONFIGURED("CUDA");
+}
+
+inline accurate_advance_test(const celeritas::FieldParamsPointers& fd_ptr,
+                             FieldTestParams                       tp)
+{
+    CELER_NOT_CONFIGURED("CUDA");
+}
+#endif
+
 //---------------------------------------------------------------------------//
 } // namespace celeritas_test

--- a/test/field/FieldDriver.test.hh
+++ b/test/field/FieldDriver.test.hh
@@ -47,13 +47,14 @@ accurate_advance_test(const celeritas::FieldParamsPointers& fd_ptr,
                       FieldTestParams                       tp);
 
 #if !CELERITAS_USE_CUDA
-inline driver_test(const celeritas::FieldParamsPointers&, FieldTestParams)
+inline FITestOutput
+driver_test(const celeritas::FieldParamsPointers&, FieldTestParams)
 {
     CELER_NOT_CONFIGURED("CUDA");
 }
 
-inline accurate_advance_test(const celeritas::FieldParamsPointers&,
-                             FieldTestParams)
+inline OneGoodStepOutput
+accurate_advance_test(const celeritas::FieldParamsPointers&, FieldTestParams)
 {
     CELER_NOT_CONFIGURED("CUDA");
 }

--- a/test/field/FieldDriver.test.hh
+++ b/test/field/FieldDriver.test.hh
@@ -1,0 +1,50 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file FieldDriver.test.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "FieldTestParams.hh"
+#include "field/FieldParamsPointers.hh"
+#include <vector>
+
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+// TESTING INTERFACE
+//---------------------------------------------------------------------------//
+
+//---------------------------------------------------------------------------//
+//! Output results
+struct FITestOutput
+{
+    std::vector<double> pos_x;
+    std::vector<double> pos_z;
+    std::vector<double> mom_y;
+    std::vector<double> mom_z;
+    std::vector<double> error;
+};
+
+struct OneGoodStepOutput
+{
+    std::vector<double> pos_x;
+    std::vector<double> pos_z;
+    std::vector<double> mom_y;
+    std::vector<double> mom_z;
+    std::vector<double> length;
+};
+
+//---------------------------------------------------------------------------//
+//! Run on device and return results
+FITestOutput
+driver_test(const celeritas::FieldParamsPointers& fd_ptr, FieldTestParams tp);
+
+OneGoodStepOutput
+accurate_advance_test(const celeritas::FieldParamsPointers& fd_ptr,
+                      FieldTestParams                       tp);
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/field/FieldTestParams.hh
+++ b/test/field/FieldTestParams.hh
@@ -20,16 +20,16 @@ struct FieldTestParams
     using size_type = celeritas::size_type;
     using real_type = celeritas::real_type;
 
-    size_type nstates;
-    int       nsteps;
-    int       revolutions;
-    real_type field_value;
-    real_type radius;
-    real_type delta_z;
-    real_type energy;
-    real_type momentum_y;
-    real_type momentum_z;
-    real_type epsilon;
+    size_type nstates;     //! number of states (tracks)
+    int       nsteps;      //! number of steps/revolution
+    int       revolutions; //! number of revolutions
+    real_type field_value; //! field value along z [tesla]
+    real_type radius;      //! radius of curvature [cm]
+    real_type delta_z;     //! z-change/revolution [cm]
+    real_type energy;      //! energy of the test particle
+    real_type momentum_y;  //! initial momentum_y [MeV/c]
+    real_type momentum_z;  //! initial momentum_z [MeV/c]
+    real_type epsilon;     //! tolerance error
 };
 
 //---------------------------------------------------------------------------//

--- a/test/field/RungeKutta.test.cc
+++ b/test/field/RungeKutta.test.cc
@@ -83,7 +83,6 @@ TEST_F(RungeKuttaTest, host)
         y.mom = {0.0, param.momentum_y, param.momentum_z};
 
         OdeState expected_y = y;
-        OdeState dydx;
 
         // Try the stepper by hstep for (num_revolutions * num_steps) times
         real_type total_err2 = 0;
@@ -93,9 +92,8 @@ TEST_F(RungeKuttaTest, host)
             expected_y.pos[2] = param.delta_z * (nr + 1) + i * 1.0e-6;
             for (CELER_MAYBE_UNUSED int j : celeritas::range(param.nsteps))
             {
-                dydx                    = equation(y);
-                RungeKuttaResult result = rk4(hstep, y, dydx);
-                y                       = result.end_state;
+                StepperResult result = rk4(hstep, y);
+                y                    = result.end_state;
                 total_err2
                     += truncation_error(hstep, 0.001, y, result.err_state);
             }

--- a/test/field/RungeKutta.test.cu
+++ b/test/field/RungeKutta.test.cu
@@ -51,9 +51,6 @@ __global__ void rk4_test_kernel(FieldTestParams param,
     y.pos = {param.radius, 0.0, tid.get() * 1.0e-6};
     y.mom = {0.0, param.momentum_y, param.momentum_z};
 
-    // The rhs of the equation and a temporary array
-    OdeState dydx;
-
     // Test parameters and the sub-step size
     real_type hstep       = 2.0 * constants::pi * param.radius / param.nsteps;
     real_type total_error = 0;
@@ -63,9 +60,8 @@ __global__ void rk4_test_kernel(FieldTestParams param,
         // Travel hstep for nsteps times in the field
         for (CELER_MAYBE_UNUSED int i : celeritas::range(param.nsteps))
         {
-            dydx                    = equation(y);
-            RungeKuttaResult result = rk4(hstep, y, dydx);
-            y                       = result.end_state;
+            StepperResult result = rk4(hstep, y);
+            y                    = result.end_state;
             total_error += truncation_error(hstep, 0.001, y, result.err_state);
         }
     }


### PR DESCRIPTION
This MR, field-driver, 
1) add a magnetic field driver and 
2) update the algorithm to calculate the closest distance between a point and a line-segment
3) evaluate the right hand side of the field equation inside the stepper operator to drop the derivative of the state argument from private methods of the field driver