### PR TITLE
Use CutoffView in atomic relaxation

### DIFF
--- a/src/io/AtomicRelaxationReader.cc
+++ b/src/io/AtomicRelaxationReader.cc
@@ -58,7 +58,7 @@ AtomicRelaxationReader::AtomicRelaxationReader(const char* fluor_path,
  * Read the data for the given element.
  */
 AtomicRelaxationReader::result_type
-AtomicRelaxationReader::operator()(int atomic_number) const
+AtomicRelaxationReader::operator()(AtomicNumber atomic_number) const
 {
     CELER_EXPECT(atomic_number > 0 && atomic_number < 101);
 
@@ -85,9 +85,9 @@ AtomicRelaxationReader::operator()(int atomic_number) const
                        << "failed to open '" << filename
                        << "' (should contain fluorescence data)");
 
-        int       des    = 0;
-        real_type energy = 0.;
-        real_type prob   = 0.;
+        int    des    = 0;
+        double energy = 0;
+        double prob   = 0;
 
         // Get the designator for the first section of shell data
         infile >> des >> des >> des;
@@ -131,10 +131,10 @@ AtomicRelaxationReader::operator()(int atomic_number) const
                        << "failed to open '" << filename
                        << "' (should contain Auger transition data)");
 
-        int       des       = 0;
-        int       auger_des = 0;
-        real_type energy    = 0.;
-        real_type prob      = 0.;
+        int    des       = 0;
+        int    auger_des = 0;
+        double energy    = 0;
+        double prob      = 0;
 
         // Get the designator for the first section of shell data
         infile >> des >> des >> des >> des;
@@ -169,7 +169,7 @@ AtomicRelaxationReader::operator()(int atomic_number) const
     // radiative and non-radiative transitions for a given subshell is 1
     for (auto& shell : result.shells)
     {
-        real_type norm = 0.;
+        double norm = 0;
         for (const auto& transition : shell.fluor)
             norm += transition.probability;
         for (const auto& transition : shell.auger)

--- a/src/io/AtomicRelaxationReader.hh
+++ b/src/io/AtomicRelaxationReader.hh
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <string>
-#include "physics/em/AtomicRelaxationParams.hh"
+#include "ImportAtomicRelaxation.hh"
 
 namespace celeritas
 {
@@ -21,7 +21,8 @@ class AtomicRelaxationReader
   public:
     //!@{
     //! Type aliases
-    using result_type = AtomicRelaxationParams::ElementInput;
+    using AtomicNumber = int;
+    using result_type  = ImportAtomicRelaxation;
     //!@}
 
   public:
@@ -33,7 +34,7 @@ class AtomicRelaxationReader
                                     const char* auger_path);
 
     // Read the data for the given element
-    result_type operator()(int atomic_number) const;
+    result_type operator()(AtomicNumber atomic_number) const;
 
   private:
     // Directory containing the EADL radiative transition data

--- a/src/io/ImportAtomicRelaxation.hh
+++ b/src/io/ImportAtomicRelaxation.hh
@@ -1,0 +1,39 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ImportAtomicRelaxation.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * EADL transition data for atomic relaxation for a single element.
+ */
+struct ImportAtomicTransition
+{
+    int    initial_shell; //!< Originating shell designator
+    int    auger_shell;   //!< Auger shell designator
+    double probability;   //!< Transition probability
+    double energy;        //!< Transition energy
+};
+
+struct ImportAtomicSubshell
+{
+    int                                 designator; //!< Subshell designator
+    std::vector<ImportAtomicTransition> fluor;      //!< Radiative transitions
+    std::vector<ImportAtomicTransition> auger; //!< Non-radiative transitions
+};
+
+struct ImportAtomicRelaxation
+{
+    std::vector<ImportAtomicSubshell> shells;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/base/CutoffParams.hh
+++ b/src/physics/base/CutoffParams.hh
@@ -15,6 +15,7 @@
 #include "physics/base/ParticleParams.hh"
 #include "physics/material/MaterialParams.hh"
 #include "CutoffInterface.hh"
+#include "CutoffView.hh"
 
 namespace celeritas
 {
@@ -65,6 +66,9 @@ class CutoffParams
     // Construct with cutoff input data
     explicit CutoffParams(const Input& input);
 
+    // Access cutoffs on host
+    inline CutoffView get(MaterialId material) const;
+
     //! Access cutoff data on the host
     const HostRef& host_pointers() const { return data_.host(); }
 
@@ -76,6 +80,18 @@ class CutoffParams
     CollectionMirror<CutoffParamsData> data_;
     using HostValue = CutoffParamsData<Ownership::value, MemSpace::host>;
 };
+
+//---------------------------------------------------------------------------//
+// INLINE FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Access cutoffs on host.
+ */
+CutoffView CutoffParams::get(MaterialId material) const
+{
+    CELER_EXPECT(material < this->host_pointers().num_materials);
+    return CutoffView(this->host_pointers(), material);
+}
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/physics/base/CutoffView.hh
+++ b/src/physics/base/CutoffView.hh
@@ -20,9 +20,9 @@ namespace celeritas
  *
  * \code
  * CutoffParams cutoffs(input);
- * CutoffView cutoff_view(cutoffs.host_pointers(), particle_id, material_id);
- * cutoff_view.energy();
- * cutoff_view.range();
+ * CutoffView cutoff_view(cutoffs.host_pointers(), material_id);
+ * cutoff_view.energy(particle_id);
+ * cutoff_view.range(particle_id);
  * \endcode
  */
 class CutoffView
@@ -30,6 +30,7 @@ class CutoffView
   public:
     //!@{
     //! Type aliases
+    using CutoffId = OpaqueId<ParticleCutoff>;
     using CutoffPointers
         = CutoffParamsData<Ownership::const_reference, MemSpace::native>;
     using Energy = units::MevEnergy;
@@ -38,19 +39,17 @@ class CutoffView
   public:
     // Construct for the given particle and material ids
     inline CELER_FUNCTION CutoffView(const CutoffPointers& params,
-                                     ParticleId            particle,
                                      MaterialId            material);
 
     //! Return energy cutoff value
-    CELER_FORCEINLINE_FUNCTION Energy energy() const { return cutoff_.energy; }
+    inline CELER_FUNCTION Energy energy(ParticleId particle) const;
+
     //! Return range cutoff value
-    CELER_FORCEINLINE_FUNCTION real_type range() const
-    {
-        return cutoff_.range;
-    }
+    inline CELER_FUNCTION real_type range(ParticleId particle) const;
 
   private:
-    ParticleCutoff cutoff_;
+    const CutoffPointers& params_;
+    MaterialId            material_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/CutoffView.i.hh
+++ b/src/physics/base/CutoffView.i.hh
@@ -27,6 +27,7 @@ CutoffView::CutoffView(const CutoffPointers& params, MaterialId material)
 CELER_FUNCTION auto CutoffView::energy(ParticleId particle) const -> Energy
 {
     CutoffId id{params_.num_materials * particle.get() + material_.get()};
+    CELER_ASSERT(id < params_.cutoffs.size());
     return params_.cutoffs[id].energy;
 }
 
@@ -37,6 +38,7 @@ CELER_FUNCTION auto CutoffView::energy(ParticleId particle) const -> Energy
 CELER_FUNCTION real_type CutoffView::range(ParticleId particle) const
 {
     CutoffId id{params_.num_materials * particle.get() + material_.get()};
+    CELER_ASSERT(id < params_.cutoffs.size());
     return params_.cutoffs[id].range;
 }
 

--- a/src/physics/base/CutoffView.i.hh
+++ b/src/physics/base/CutoffView.i.hh
@@ -10,18 +10,34 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct view from host/device for the given particle and material ids.
+ * Construct view from host/device for the given material id.
  */
-CELER_FUNCTION CutoffView::CutoffView(const CutoffPointers& params,
-                                      ParticleId            particle,
-                                      MaterialId            material)
+CELER_FUNCTION
+CutoffView::CutoffView(const CutoffPointers& params, MaterialId material)
+    : params_(params), material_(material)
 {
-    CELER_EXPECT(particle < params.num_particles);
-    CELER_EXPECT(material < params.num_materials);
-    using CutoffId = OpaqueId<ParticleCutoff>;
-    CutoffId cutoff_id{params.num_materials * particle.get() + material.get()};
+    CELER_EXPECT(params_);
+    CELER_EXPECT(material_ < params_.num_materials);
+}
 
-    cutoff_ = params.cutoffs[cutoff_id];
+//---------------------------------------------------------------------------//
+/*!
+ * Return energy cutoff value.
+ */
+CELER_FUNCTION auto CutoffView::energy(ParticleId particle) const -> Energy
+{
+    CutoffId id{params_.num_materials * particle.get() + material_.get()};
+    return params_.cutoffs[id].energy;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return range cutoff value.
+ */
+CELER_FUNCTION real_type CutoffView::range(ParticleId particle) const
+{
+    CutoffId id{params_.num_materials * particle.get() + material_.get()};
+    return params_.cutoffs[id].range;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/CutoffView.i.hh
+++ b/src/physics/base/CutoffView.i.hh
@@ -38,7 +38,6 @@ CELER_FUNCTION auto CutoffView::energy(ParticleId particle) const -> Energy
 CELER_FUNCTION real_type CutoffView::range(ParticleId particle) const
 {
     CutoffId id{params_.num_materials * particle.get() + material_.get()};
-    CELER_ASSERT(id < params_.cutoffs.size());
     return params_.cutoffs[id].range;
 }
 

--- a/src/physics/em/AtomicRelaxation.hh
+++ b/src/physics/em/AtomicRelaxation.hh
@@ -9,6 +9,7 @@
 
 #include "base/Macros.hh"
 #include "base/Types.hh"
+#include "physics/base/CutoffView.hh"
 #include "physics/base/Units.hh"
 #include "random/distributions/IsotropicDistribution.hh"
 #include "AtomicRelaxationInterface.hh"
@@ -41,6 +42,7 @@ class AtomicRelaxation
     // Construct with shared and state data
     inline CELER_FUNCTION
     AtomicRelaxation(const AtomicRelaxParamsPointers& shared,
+                     const CutoffView&                cutoffs,
                      ElementId                        el_id,
                      SubshellId                       shell_id,
                      Span<Secondary>                  secondaries,
@@ -53,6 +55,10 @@ class AtomicRelaxation
   private:
     // Shared EADL atomic relaxation data
     const AtomicRelaxParamsPointers& shared_;
+    // Photon production threshold [MeV]
+    real_type gamma_cutoff_;
+    // Electron production threshold [MeV]
+    real_type electron_cutoff_;
     // Index in MaterialParams elements
     ElementId el_id_;
     // Shell ID of the initial vacancy

--- a/src/physics/em/AtomicRelaxation.i.hh
+++ b/src/physics/em/AtomicRelaxation.i.hh
@@ -25,11 +25,14 @@ namespace celeritas
  */
 CELER_FUNCTION
 AtomicRelaxation::AtomicRelaxation(const AtomicRelaxParamsPointers& shared,
+                                   const CutoffView&                cutoffs,
                                    ElementId                        el_id,
                                    SubshellId                       shell_id,
                                    Span<Secondary>  secondaries,
                                    Span<SubshellId> vacancies)
     : shared_(shared)
+    , gamma_cutoff_(cutoffs.energy(shared_.gamma_id).value())
+    , electron_cutoff_(cutoffs.energy(shared_.electron_id).value())
     , el_id_(el_id)
     , shell_id_(shell_id)
     , secondaries_(secondaries)
@@ -93,7 +96,7 @@ AtomicRelaxation::operator()(Engine& rng)
         {
             vacancies.push(transition.auger_shell);
 
-            if (transition.energy >= shared_.electron_cut.value())
+            if (transition.energy >= electron_cutoff_)
             {
                 // Sampled a non-radiative transition: create an Auger electron
                 CELER_ASSERT(count < secondaries_.size());
@@ -103,7 +106,7 @@ AtomicRelaxation::operator()(Engine& rng)
                 secondary.particle_id = shared_.electron_id;
             }
         }
-        else if (transition.energy >= shared_.gamma_cut.value())
+        else if (transition.energy >= gamma_cutoff_)
         {
             // Sampled a radiative transition: create a fluorescence photon
             CELER_ASSERT(count < secondaries_.size());

--- a/src/physics/em/AtomicRelaxationHelper.hh
+++ b/src/physics/em/AtomicRelaxationHelper.hh
@@ -68,9 +68,10 @@ class AtomicRelaxationHelper
 
     // Create the sampling distribution from sampled shell and allocated mem
     inline CELER_FUNCTION AtomicRelaxation
-    build_distribution(SubshellId       shell_id,
-                       Span<Secondary>  secondaries,
-                       Span<SubshellId> vacancies) const;
+    build_distribution(const CutoffView& cutoffs,
+                       SubshellId        shell_id,
+                       Span<Secondary>   secondaries,
+                       Span<SubshellId>  vacancies) const;
 
   private:
     // Shared EADL atomic relaxation data

--- a/src/physics/em/AtomicRelaxationHelper.i.hh
+++ b/src/physics/em/AtomicRelaxationHelper.i.hh
@@ -58,14 +58,16 @@ CELER_FUNCTION size_type AtomicRelaxationHelper::max_vacancies() const
  * Create the sampling distribution.
  */
 CELER_FUNCTION AtomicRelaxation
-AtomicRelaxationHelper::build_distribution(SubshellId       shell_id,
-                                           Span<Secondary>  secondaries,
-                                           Span<SubshellId> vacancies) const
+AtomicRelaxationHelper::build_distribution(const CutoffView& cutoffs,
+                                           SubshellId        shell_id,
+                                           Span<Secondary>   secondaries,
+                                           Span<SubshellId>  vacancies) const
 {
     CELER_EXPECT(*this);
     CELER_EXPECT(secondaries.size() == this->max_secondaries());
     CELER_EXPECT(vacancies.size() == this->max_vacancies());
-    return AtomicRelaxation{shared_, el_id_, shell_id, secondaries, vacancies};
+    return AtomicRelaxation{
+        shared_, cutoffs, el_id_, shell_id, secondaries, vacancies};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/AtomicRelaxationInterface.hh
+++ b/src/physics/em/AtomicRelaxationInterface.hh
@@ -64,8 +64,6 @@ struct AtomicRelaxParamsPointers
     Span<const AtomicRelaxElement> elements;
     ParticleId                     electron_id;
     ParticleId                     gamma_id;
-    units::MevEnergy               electron_cut; //!< Production thresholds
-    units::MevEnergy               gamma_cut;
 
     //! Check whether the interface is assigned.
     explicit inline CELER_FUNCTION operator bool() const

--- a/src/physics/em/detail/LivermorePE.cu
+++ b/src/physics/em/detail/LivermorePE.cu
@@ -47,6 +47,7 @@ livermore_pe_interact_kernel(const LivermorePEDeviceRef        pe,
                              particle.particle_id(),
                              material.material_id(),
                              tid);
+    CutoffView        cutoffs(ptrs.params.cutoffs, material.material_id());
 
     // This interaction only applies if the Livermore PE model was selected
     if (physics.model_id() != pe.ids.model)
@@ -66,6 +67,7 @@ livermore_pe_interact_kernel(const LivermorePEDeviceRef        pe,
                                    scratch,
                                    el_id,
                                    particle,
+                                   cutoffs,
                                    ptrs.states.direction[tid.get()],
                                    allocate_secondaries);
 

--- a/src/physics/em/detail/LivermorePEInteractor.hh
+++ b/src/physics/em/detail/LivermorePEInteractor.hh
@@ -10,6 +10,7 @@
 #include "base/Algorithms.hh"
 #include "base/Macros.hh"
 #include "base/Types.hh"
+#include "physics/base/CutoffView.hh"
 #include "physics/base/Interaction.hh"
 #include "physics/base/ParticleTrackView.hh"
 #include "base/StackAllocator.hh"
@@ -60,6 +61,7 @@ class LivermorePEInteractor
                           const Scratch&             scratch,
                           ElementId                  el_id,
                           const ParticleTrackView&   particle,
+                          const CutoffView&          cutoffs,
                           const Real3&               inc_direction,
                           StackAllocator<Secondary>& allocate);
 
@@ -74,6 +76,8 @@ class LivermorePEInteractor
     const Scratch& scratch_;
     // Index in MaterialParams elements
     ElementId el_id_;
+    // Production thresholds
+    const CutoffView& cutoffs_;
     // Incident direction
     const Real3& inc_direction_;
     // Incident gamma energy

--- a/src/physics/em/detail/LivermorePEInteractor.i.hh
+++ b/src/physics/em/detail/LivermorePEInteractor.i.hh
@@ -27,11 +27,13 @@ LivermorePEInteractor::LivermorePEInteractor(const LivermorePEPointers& shared,
                                              const Scratch&           scratch,
                                              ElementId                el_id,
                                              const ParticleTrackView& particle,
+                                             const CutoffView&        cutoffs,
                                              const Real3& inc_direction,
                                              StackAllocator<Secondary>& allocate)
     : shared_(shared)
     , scratch_(scratch)
     , el_id_(el_id)
+    , cutoffs_(cutoffs)
     , inc_direction_(inc_direction)
     , inc_energy_(particle.energy().value())
     , allocate_(allocate)
@@ -161,7 +163,7 @@ CELER_FUNCTION Interaction LivermorePEInteractor::operator()(Engine& rng)
         // Sample secondaries from atomic relaxation, into all but the initial
         // secondary position
         AtomicRelaxation sample_relaxation = relaxation.build_distribution(
-            SubshellId{shell_id}, secondaries.subspan(1), vacancies);
+            cutoffs_, SubshellId{shell_id}, secondaries.subspan(1), vacancies);
 
         auto outgoing = sample_relaxation(rng);
         secondaries   = {secondaries.data(), 1 + outgoing.count};

--- a/src/physics/em/detail/MollerBhabha.cu
+++ b/src/physics/em/detail/MollerBhabha.cu
@@ -48,8 +48,7 @@ __global__ void moller_bhabha_interact_kernel(const MollerBhabhaPointers  mb,
                              material.material_id(),
                              tid);
 
-    CutoffView cutoff(
-        ptrs.params.cutoffs, particle.particle_id(), material.material_id());
+    CutoffView cutoff(ptrs.params.cutoffs, material.material_id());
 
     // This interaction only applies if the MB model was selected
     if (physics.model_id() != mb.model_id)

--- a/src/physics/em/detail/MollerBhabhaInteractor.i.hh
+++ b/src/physics/em/detail/MollerBhabhaInteractor.i.hh
@@ -35,7 +35,7 @@ CELER_FUNCTION MollerBhabhaInteractor::MollerBhabhaInteractor(
     , inc_energy_(particle.energy().value())
     , inc_momentum_(particle.momentum().value())
     , inc_direction_(inc_direction)
-    , secondary_energy_cutoff_(cutoffs.energy().value())
+    , secondary_energy_cutoff_(cutoffs.energy(particle.particle_id()).value())
     , allocate_(allocate)
     , inc_particle_is_electron_(particle.particle_id() == shared_.electron_id)
 {

--- a/test/io/RootImporter.test.cc
+++ b/test/io/RootImporter.test.cc
@@ -266,9 +266,9 @@ TEST_F(RootImporterTest, import_cutoffs)
     {
         for (const auto matid : range(MaterialId{materials.size()}))
         {
-            CutoffView cutoff_view(cutoffs.host_pointers(), pid, matid);
-            energies.push_back(cutoff_view.energy().value());
-            ranges.push_back(cutoff_view.range());
+            CutoffView cutoff_view(cutoffs.host_pointers(), matid);
+            energies.push_back(cutoff_view.energy(pid).value());
+            ranges.push_back(cutoff_view.range(pid));
         }
     }
 

--- a/test/physics/base/CutoffParams.test.cc
+++ b/test/physics/base/CutoffParams.test.cc
@@ -104,9 +104,9 @@ TEST_F(CutoffParamsTest, empty_cutoffs)
     {
         for (const auto matid : range(MaterialId{material_params->size()}))
         {
-            CutoffView cutoff_view(cutoff_params.host_pointers(), pid, matid);
-            energies.push_back(cutoff_view.energy().value());
-            ranges.push_back(cutoff_view.range());
+            CutoffView cutoff_view(cutoff_params.host_pointers(), matid);
+            energies.push_back(cutoff_view.energy(pid).value());
+            ranges.push_back(cutoff_view.range(pid));
         }
     }
 
@@ -136,10 +136,10 @@ TEST_F(CutoffParamsTest, electron_cutoffs)
     {
         for (const auto matid : range(MaterialId{material_params->size()}))
         {
-            CutoffView cutoff_view(cutoff_params.host_pointers(), pid, matid);
+            CutoffView cutoff_view(cutoff_params.host_pointers(), matid);
 
-            energies.push_back(cutoff_view.energy().value());
-            ranges.push_back(cutoff_view.range());
+            energies.push_back(cutoff_view.energy(pid).value());
+            ranges.push_back(cutoff_view.range(pid));
         }
     }
 

--- a/test/physics/em/MollerBhabha.test.cc
+++ b/test/physics/em/MollerBhabha.test.cc
@@ -147,8 +147,8 @@ TEST_F(MollerBhabhaInteractorTest, basic)
                                   {1e5, {3, 7, -6}}};
     // clang-format on
 
-    CutoffView cutoff_view(
-        this->cutoff_params()->host_pointers(), ParticleId{0}, MaterialId{0});
+    CutoffView cutoff_view(this->cutoff_params()->host_pointers(),
+                           MaterialId{0});
 
     for (const SampleInit& init : samples)
     {
@@ -245,10 +245,11 @@ TEST_F(MollerBhabhaInteractorTest, cutoff_1MeV)
     cutoff_inp.materials = this->material_params();
     cutoff_inp.particles = this->particle_params();
     cutoff_inp.cutoffs.insert({pdg::electron(), material_cutoffs});
+    cutoff_inp.cutoffs.insert({pdg::positron(), material_cutoffs});
     this->set_cutoff_params(cutoff_inp);
 
-    CutoffView cutoff_view(
-        this->cutoff_params()->host_pointers(), ParticleId{0}, MaterialId{0});
+    CutoffView cutoff_view(this->cutoff_params()->host_pointers(),
+                           MaterialId{0});
 
     for (const SampleInit& init : samples)
     {
@@ -312,7 +313,8 @@ TEST_F(MollerBhabhaInteractorTest, cutoff_1MeV)
     for (const auto secondary_energy : m_results.sec_e)
     {
         // Verify if secondary is above the cutoff threshold
-        EXPECT_TRUE(secondary_energy > cutoff_view.energy().value());
+        EXPECT_TRUE(secondary_energy
+                    > cutoff_view.energy(ParticleId{0}).value());
     }
 
     //// Bhabha
@@ -324,7 +326,8 @@ TEST_F(MollerBhabhaInteractorTest, cutoff_1MeV)
     for (const auto secondary_energy : b_results.sec_e)
     {
         // Verify if secondary is above the cutoff threshold
-        EXPECT_TRUE(secondary_energy > cutoff_view.energy().value());
+        EXPECT_TRUE(secondary_energy
+                    > cutoff_view.energy(ParticleId{1}).value());
     }
 }
 
@@ -334,8 +337,8 @@ TEST_F(MollerBhabhaInteractorTest, stress_test)
     const int           num_samples = 1e4;
     std::vector<double> avg_engine_samples;
 
-    CutoffView cutoff_view(
-        this->cutoff_params()->host_pointers(), ParticleId{0}, MaterialId{0});
+    CutoffView cutoff_view(this->cutoff_params()->host_pointers(),
+                           MaterialId{0});
 
     // Moller's max energy fraction is 0.5, which leads to E_K > 2e-3
     // Bhabha's max energy fraction is 1.0, which leads to E_K > 1e-3


### PR DESCRIPTION
Now that we have production cuts, use `CutoffView` to get the electron and photon energy cutoffs for atomic relaxation. I made a minor change to the `CutoffView` interface so it now constructs the view with the material ID and accepts the particle ID as an argument in the `energy()` and `range()` methods -- this way we don't have to construct a separate view for each particle type. I also moved the structs for the raw imported EADL transition data from the `AtomicRelaxationParams` class to the io/ directory.

Right now on emmet I'm getting the same nvlink error that we saw in #118,
```
nvlink error   : Size doesn't match for '_ZN9celeritas9SecondaryC1Ev$146' in 'src/CMakeFiles/celeritas.dir/physics/em/detail/MollerBhabha.cu.o', first specified in 'src/CMakeFiles/celeritas.dir/physics/em/detail/BetheHeitler.cu.o'
nvlink fatal   : merge_elf failed
```
which I don't have a workaround for yet.