### PR TITLE
Add random selector helper class

### DIFF
--- a/src/base/Range.hh
+++ b/src/base/Range.hh
@@ -37,6 +37,10 @@ namespace celeritas
  * \endcode
  */
 
+//! Publicly expose traits for countable (OpaqueId, enum, init) type T
+template<class T>
+using RangeIter = detail::range_iter<T>;
+
 //---------------------------------------------------------------------------//
 /*!
  * Proxy container for iterating over a range of integral values.

--- a/src/base/detail/RangeImpl.hh
+++ b/src/base/detail/RangeImpl.hh
@@ -44,6 +44,12 @@ struct RangeTypeTraits
         v += i;
         return v;
     }
+    static CELER_FORCEINLINE_FUNCTION value_type decrement(value_type   v,
+                                                           counter_type i)
+    {
+        v -= i;
+        return v;
+    }
 };
 
 template<class T, class Enable = void>
@@ -90,6 +96,13 @@ struct RangeTypeTraits<T, typename std::enable_if<std::is_enum<T>::value>::type>
         temp += i;
         return to_value(temp);
     }
+    static CELER_FORCEINLINE_FUNCTION value_type decrement(value_type   v,
+                                                           counter_type i)
+    {
+        counter_type temp = to_counter(v);
+        temp -= i;
+        return to_value(temp);
+    }
 };
 
 //! Specialization for Opaque ID
@@ -119,6 +132,13 @@ struct RangeTypeTraits<OpaqueId<I, T>, void>
     {
         counter_type temp = to_counter(v);
         temp += i;
+        return to_value(temp);
+    }
+    static CELER_FORCEINLINE_FUNCTION value_type decrement(value_type   v,
+                                                           counter_type i)
+    {
+        counter_type temp = to_counter(v);
+        temp -= i;
         return to_value(temp);
     }
 };
@@ -170,6 +190,24 @@ class range_iter : public std::iterator<std::input_iterator_tag, T>
     CELER_FORCEINLINE_FUNCTION range_iter operator+(counter_type inc) const
     {
         return {TraitsT::increment(value_, inc)};
+    }
+
+    CELER_FORCEINLINE_FUNCTION range_iter& operator--()
+    {
+        value_ = TraitsT::decrement(value_, 1);
+        return *this;
+    }
+
+    CELER_FORCEINLINE_FUNCTION range_iter operator--(int)
+    {
+        auto copy = *this;
+        value_    = TraitsT::decrement(value_, 1);
+        return copy;
+    }
+
+    CELER_FORCEINLINE_FUNCTION range_iter operator-(counter_type inc) const
+    {
+        return {TraitsT::decrement(value_, inc)};
     }
 
     CELER_FORCEINLINE_FUNCTION bool operator==(range_iter const& other) const

--- a/src/physics/em/AtomicRelaxation.hh
+++ b/src/physics/em/AtomicRelaxation.hh
@@ -69,6 +69,13 @@ class AtomicRelaxation
     Span<SubshellId> vacancies_;
     // Angular distribution of secondaries
     IsotropicDistribution<real_type> sample_direction_;
+
+  private:
+    using TransitionId = OpaqueId<AtomicRelaxTransition>;
+
+    template<class Engine>
+    inline CELER_FUNCTION TransitionId
+    sample_transition(const AtomicRelaxSubshell& shell, Engine& rng);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/Rayleigh.cu
+++ b/src/physics/em/detail/Rayleigh.cu
@@ -58,7 +58,8 @@ __global__ void rayleigh_interact_kernel(const RayleighDeviceRef     rayleigh,
 
     RngEngine rng(model.states.rng, tid);
 
-    // Sample an element
+    // Assume only a single element in the material, for now
+    CELER_ASSERT(material.material_view().num_elements() == 1);
     ElementId el_id{0};
 
     // Do the interaction

--- a/src/physics/em/detail/RayleighInteractor.i.hh
+++ b/src/physics/em/detail/RayleighInteractor.i.hh
@@ -10,6 +10,7 @@
 #include "base/Algorithms.hh"
 #include "random/distributions/GenerateCanonical.hh"
 #include "random/distributions/IsotropicDistribution.hh"
+#include "random/Selector.hh"
 
 namespace celeritas
 {
@@ -59,15 +60,10 @@ CELER_FUNCTION Interaction RayleighInteractor::operator()(Engine& rng)
 
     do
     {
-        unsigned int index = 0;
         // Sample index from input.prob
-        {
-            real_type u = generate_canonical(rng);
-            if (u > input.prob[0])
-            {
-                index = (u <= input.prob[0] + input.prob[1]) ? 1 : 2;
-            }
-        }
+        const unsigned int index = celeritas::make_selector(
+            [&input](unsigned int i) { return input.prob[i]; },
+            input.prob.size())(rng);
 
         real_type w = input.weight[index];
         real_type n = pn[index];

--- a/src/physics/material/ElementSelector.hh
+++ b/src/physics/material/ElementSelector.hh
@@ -47,6 +47,8 @@ namespace celeritas
  * identical to the units returned by `calc_micro_xs`. The macroscopic cross
  * section units (micro times \c mat.number_density() ) will be 1/cm if and
  * only if calc_micro units are cm^2.
+ *
+ * \todo Refactor to use Selector.
  */
 class ElementSelector
 {

--- a/src/physics/material/ElementSelector.i.hh
+++ b/src/physics/material/ElementSelector.i.hh
@@ -54,7 +54,7 @@ CELER_FUNCTION ElementComponentId ElementSelector::operator()(Engine& rng) const
     for (; i != imax; ++i)
     {
         accum_xs += elements_[i].fraction * elemental_xs_[i];
-        if (accum_xs >= 0)
+        if (accum_xs > 0)
             break;
     }
     return ElementComponentId{i};

--- a/src/random/Selector.hh
+++ b/src/random/Selector.hh
@@ -1,0 +1,77 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Selector.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <type_traits>
+#include "base/Range.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * On-the-fly selection of a weighted discrete distribution.
+ *
+ * This algorithm encapsulates the loop for sampling from distributions by
+ * integer index or by OpaqueId. Edge cases are thoroughly tested (it will
+ * never iterate off the end, even for incorrect values of the "total"
+ * probability/xs), and it uses one fewer register than the typical
+ * accumulation algorithm. A "debug" version can check that the provided
+ "total"
+ * value isn't higher than the sum.
+ * \code
+    auto select_el = make_selector(
+        [](ElementId i) { return xs[i.get()]; },
+        ElementId{num_elements()},
+        tot_xs);
+    ElementId el = select_el(rng);
+   \endcode
+ * or
+ * \code
+    auto select_val = make_selector([](size_type i) { return pdf[i]; },
+                                    pdf.size());
+    size_type idx = select_val(rng);
+   \endcode
+ */
+template<class F, class T, bool D = CELERITAS_DEBUG>
+class Selector
+{
+  public:
+    //!@{
+    //! Type aliases
+    using value_type = T;
+    using real_type  = typename std::result_of<F(value_type)>::type;
+    //!@}
+
+    constexpr static bool use_debug_sampling = D;
+
+  public:
+    // Construct with function, size, and accumulated value
+    inline CELER_FUNCTION Selector(F&& eval, value_type size, real_type total);
+
+    // Sample from the distribution
+    template<class Engine>
+    inline CELER_FUNCTION T operator()(Engine& rng) const;
+
+  private:
+    using IterT = RangeIter<T>;
+
+    F         eval_;
+    IterT     last_;
+    real_type total_;
+};
+
+//---------------------------------------------------------------------------//
+// Create a selector object from a function and total accumulated value
+template<class F, class T>
+inline CELER_FUNCTION Selector<F, T>
+make_selector(F&& func, T size, decltype(func(size)) total = 1);
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "Selector.i.hh"

--- a/src/random/Selector.hh
+++ b/src/random/Selector.hh
@@ -20,9 +20,12 @@ namespace celeritas
  * integer index or by OpaqueId. Edge cases are thoroughly tested (it will
  * never iterate off the end, even for incorrect values of the "total"
  * probability/xs), and it uses one fewer register than the typical
- * accumulation algorithm. A "debug" version can check that the provided
- "total"
- * value isn't higher than the sum.
+ * accumulation algorithm. When building with debug checking, the constructor
+ * asserts that the provided "total" value is consistent.
+ *
+ * The given function *must* return a consistent value for the same given
+ * argument.
+ *
  * \code
     auto select_el = make_selector(
         [](ElementId i) { return xs[i.get()]; },
@@ -37,7 +40,7 @@ namespace celeritas
     size_type idx = select_val(rng);
    \endcode
  */
-template<class F, class T, bool D = CELERITAS_DEBUG>
+template<class F, class T>
 class Selector
 {
   public:
@@ -46,8 +49,6 @@ class Selector
     using value_type = T;
     using real_type  = typename std::result_of<F(value_type)>::type;
     //!@}
-
-    constexpr static bool use_debug_sampling = D;
 
   public:
     // Construct with function, size, and accumulated value
@@ -63,6 +64,9 @@ class Selector
     F         eval_;
     IterT     last_;
     real_type total_;
+
+    // Total value, for debug checking
+    inline CELER_FUNCTION real_type debug_accumulated_total() const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/random/Selector.i.hh
+++ b/src/random/Selector.i.hh
@@ -1,0 +1,80 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Selector.i.hh
+//---------------------------------------------------------------------------//
+
+#include "random/distributions/GenerateCanonical.hh"
+#include "base/SoftEqual.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with function, size, and accumulated value.
+ */
+template<class F, class T, bool D>
+CELER_FUNCTION
+Selector<F, T, D>::Selector(F&& eval, value_type size, real_type total)
+    : eval_{std::forward<F>(eval)}, last_{size}, total_{total}
+{
+    CELER_EXPECT(last_ != IterT{});
+    CELER_EXPECT(total_ >= 0);
+
+    // Don't accumulate the last value except to assert that the 'total'
+    // isn't out-of-bounds
+    --last_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample from the distribution.
+ */
+template<class F, class T, bool D>
+template<class Engine>
+CELER_FUNCTION T Selector<F, T, D>::operator()(Engine& rng) const
+{
+    if (!use_debug_sampling)
+    {
+        real_type accum = -total_ * generate_canonical(rng);
+        for (IterT iter{}; iter != last_; ++iter)
+        {
+            accum += eval_(*iter);
+            if (accum > 0)
+                return *iter;
+        }
+    }
+    else
+    {
+        // Equivalent to opt, but uses one more register and checks final value
+        real_type accum = 0;
+        real_type stop  = total_ * generate_canonical(rng);
+        for (IterT iter{}; iter != last_; ++iter)
+        {
+            accum += eval_(*iter);
+            if (accum > stop)
+                return *iter;
+        }
+
+        // Check that the final value works and sums up to the expected total
+        accum += eval_(*last_);
+        CELER_ENSURE(celeritas::soft_equal(accum, total_));
+    }
+    return *last_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create a selector object from a function and total accumulated value.
+ */
+template<class F, class T>
+CELER_FUNCTION Selector<F, T>
+               make_selector(F&& func, T size, decltype(func(size)) total)
+{
+    return {std::forward<F>(func), size, total};
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -222,13 +222,15 @@ celeritas_add_test(physics/em/ImportedProcesses.test.cc ${_needs_root}
 
 celeritas_setup_tests(SERIAL PREFIX random)
 
+celeritas_cudaoptional_test(random/RngEngine)
+celeritas_add_test(random/Selector.test.cc)
+
 celeritas_add_test(random/distributions/BernoulliDistribution.test.cc)
 celeritas_add_test(random/distributions/ExponentialDistribution.test.cc)
 celeritas_add_test(random/distributions/IsotropicDistribution.test.cc)
 celeritas_add_test(random/distributions/RadialDistribution.test.cc)
 celeritas_add_test(random/distributions/UniformRealDistribution.test.cc)
 
-celeritas_cudaoptional_test(random/RngEngine)
 
 #-----------------------------------------------------------------------------#
 # Sim

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -228,9 +228,7 @@ celeritas_add_test(random/distributions/IsotropicDistribution.test.cc)
 celeritas_add_test(random/distributions/RadialDistribution.test.cc)
 celeritas_add_test(random/distributions/UniformRealDistribution.test.cc)
 
-# Note: this test should compile fine without CUDA but currently doesn't have
-# any # tests that run because the RngEngine is CUDA-only.
-celeritas_cudaoptional_test(random/RngEngine ${_needs_cuda})
+celeritas_cudaoptional_test(random/RngEngine)
 
 #-----------------------------------------------------------------------------#
 # Sim

--- a/test/random/RngEngine.test.cc
+++ b/test/random/RngEngine.test.cc
@@ -6,21 +6,158 @@
 //! \file RngEngine.test.cc
 //---------------------------------------------------------------------------//
 #include "random/RngParams.hh"
+#include "DiagnosticRngEngine.hh"
+#include "SequenceEngine.hh"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
 #include "celeritas_test.hh"
 #include "RngEngine.test.hh"
 #include "base/CollectionStateStore.hh"
+#include "random/distributions/GenerateCanonical.hh"
 
 using celeritas::CollectionStateStore;
+using celeritas::generate_canonical;
 using celeritas::RngParams;
 using celeritas::RngStateData;
 using namespace celeritas_test;
 
 //---------------------------------------------------------------------------//
-// TEST HARNESS
+// SEQUENCE ENGINE
 //---------------------------------------------------------------------------//
 
-class RngEngineTest : public celeritas::Test
+class SequenceEngineTest : public celeritas::Test
+{
+  public:
+    void SetUp() override
+    {
+        const double inv_32 = std::ldexp(1.0, -32.0);
+        const double inv_64 = std::ldexp(1.0, -64.0);
+        /*!
+         * Note: even the lowest *normalized* float value (1e-38) is below
+         * 2**-64, so the "min" values for both double and float are
+         * rounded up to 2**-64, which results in a value of 5e-20 for
+         * double.
+         *
+         * Also note that the follwing two values are ommited because they're
+         * accurate to only 1e-10 for doubles -- so our "promise" of
+         * reproducibility isn't quite right.
+         * \code
+         * std::nextafter(float(inv_64), 1.0f),
+         * std::nextafter(inv_32, 0.0),
+         * \endcode
+         */
+        values_ = {
+            0.0,
+            inv_64,
+            std::nextafter(inv_64, 1.0),
+            12345678u * inv_64,
+            0xffff0000u * inv_64,
+            // Note: the following two values are
+            std::nextafter(float(inv_32), 0.0f),
+            inv_32,
+            std::nextafter(inv_32, 1.0),
+            std::nextafter(float(inv_32), 1.0f),
+            std::nextafter(0.5f, 0.0f), // .5f - epsf
+            0x7fffffffu * inv_32,       // not exactly representable by float
+            std::nextafter(0.5, 0.0),   // .5 - eps
+            0.5,
+            std::nextafter(0.5, 1.0),   // .5 + eps
+            std::nextafter(0.5f, 1.0f), // .5f + epsf
+            std::nextafter(1.0f, 0.0f), // 1 - float eps
+            std::nextafter(1.0, 0.0),   // 1 - double eps
+        };
+    }
+    std::vector<double> values_;
+};
+
+TEST_F(SequenceEngineTest, manual)
+{
+    SequenceEngine::VecResult raw_vals{0x00000000u, 0x20210408u, 0xffffffffu};
+    SequenceEngine            engine(raw_vals);
+    EXPECT_EQ(0, engine.count());
+    EXPECT_EQ(3, engine.max_count());
+
+    // Call the engine operator for actual values
+    SequenceEngine::VecResult actual(raw_vals.size());
+    std::generate(actual.begin(), actual.end(), std::ref(engine));
+    EXPECT_EQ(3, engine.count());
+    EXPECT_VEC_EQ(raw_vals, actual);
+
+    // Past the end
+    EXPECT_THROW(engine(), celeritas::DebugError);
+}
+
+TEST_F(SequenceEngineTest, from_reals)
+{
+    auto engine = SequenceEngine::from_reals(celeritas::make_span(values_));
+    EXPECT_EQ(values_.size() * 2, engine.max_count());
+    SequenceEngine::VecResult actual(engine.max_count());
+    std::generate(actual.begin(), actual.end(), std::ref(engine));
+
+    const unsigned int expected[]
+        = {0u,          0u,          1u,          0u,          1u,
+           0u,          12345678u,   0u,          4294901760u, 0u,
+           4294967040u, 0u,          0u,          1u,          0u,
+           1u,          512u,        1u,          0u,          2147483520u,
+           0u,          2147483647u, 4294966272u, 2147483647u, 0u,
+           2147483648u, 2048u,       2147483648u, 0u,          2147483904u,
+           0u,          4294967040u, 4294965248u, 4294967295u};
+    EXPECT_VEC_EQ(expected, actual);
+
+    // Past the end
+    EXPECT_THROW(engine(), celeritas::DebugError);
+}
+
+TEST_F(SequenceEngineTest, double_canonical)
+{
+    auto engine = SequenceEngine::from_reals(celeritas::make_span(values_));
+    for (double expected : values_)
+    {
+        double actual = generate_canonical<double>(engine);
+        // Test within 2 ulp
+        EXPECT_DOUBLE_EQ(expected, actual)
+            << "for i=" << (engine.count() / 2 - 1);
+        EXPECT_LT(actual, 1.0);
+    }
+}
+
+TEST_F(SequenceEngineTest, float_canonical)
+{
+    auto engine = SequenceEngine::from_reals(celeritas::make_span(values_));
+    for (double expected : values_)
+    {
+        float actual = generate_canonical<float>(engine);
+        // Test within 2 ulp
+        EXPECT_FLOAT_EQ(static_cast<float>(expected), actual);
+        EXPECT_LT(actual, 1.0f);
+    }
+}
+
+//---------------------------------------------------------------------------//
+// DIAGNOSTIC ENGINE
+//---------------------------------------------------------------------------//
+
+TEST(DiagnosticEngineTest, from_reals)
+{
+    auto rng = DiagnosticRngEngine<std::mt19937>();
+    EXPECT_EQ(0, rng.count());
+    EXPECT_EQ(3499211612u, rng());
+    EXPECT_EQ(1, rng.count());
+    generate_canonical<double>(rng);
+    EXPECT_EQ(3, rng.count());
+    generate_canonical<float>(rng);
+    EXPECT_EQ(4, rng.count());
+    rng.reset_count();
+    EXPECT_EQ(0, rng.count());
+}
+
+//---------------------------------------------------------------------------//
+// CUDA RNG
+//---------------------------------------------------------------------------//
+
+class CudaRngEngineTest : public celeritas::Test
 {
   public:
     using RngDeviceStore = CollectionStateStore<RngStateData, MemSpace::device>;
@@ -30,7 +167,7 @@ class RngEngineTest : public celeritas::Test
     std::shared_ptr<RngParams> params;
 };
 
-TEST_F(RngEngineTest, TEST_IF_CELERITAS_CUDA(device))
+TEST_F(CudaRngEngineTest, TEST_IF_CELERITAS_CUDA(device))
 {
     // Create and initialize states
     RngDeviceStore rng_store(*params, 1024);
@@ -63,7 +200,7 @@ TEST_F(RngEngineTest, TEST_IF_CELERITAS_CUDA(device))
 //---------------------------------------------------------------------------//
 
 template<typename T>
-class RngEngineFloatTest : public RngEngineTest
+class CudaRngEngineFloatTest : public CudaRngEngineTest
 {
 };
 
@@ -82,12 +219,12 @@ void check_expected_float_samples(const std::vector<double>& v)
 }
 
 using FloatTypes = ::testing::Types<float, double>;
-TYPED_TEST_SUITE(RngEngineFloatTest, FloatTypes, );
+TYPED_TEST_SUITE(CudaRngEngineFloatTest, FloatTypes, );
 
 #if CELERITAS_USE_CUDA
-TYPED_TEST(RngEngineFloatTest, device)
+TYPED_TEST(CudaRngEngineFloatTest, device)
 #else
-TYPED_TEST(RngEngineFloatTest, DISABLED_device)
+TYPED_TEST(CudaRngEngineFloatTest, DISABLED_device)
 #endif
 {
     using RngDeviceStore = typename TestFixture::RngDeviceStore;

--- a/test/random/Selector.test.cc
+++ b/test/random/Selector.test.cc
@@ -1,0 +1,174 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Selector.test.cc
+//---------------------------------------------------------------------------//
+#include "random/Selector.hh"
+#include "SequenceEngine.hh"
+
+#include "base/OpaqueId.hh"
+#include "celeritas_test.hh"
+
+using celeritas::make_selector;
+using celeritas_test::SequenceEngine;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+template<class T>
+class PdfSelectorTest : public celeritas::Test
+{
+  public:
+    using PdfSelector
+        = celeritas::Selector<std::function<double(int)>, int, T::value>;
+};
+
+using BoolValueTypes = ::testing::Types<std::true_type, std::false_type>;
+TYPED_TEST_SUITE(PdfSelectorTest, BoolValueTypes, );
+
+SequenceEngine make_rng(double select_val)
+{
+    return SequenceEngine::from_reals({&select_val, 1});
+}
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TYPED_TEST(PdfSelectorTest, typical)
+{
+    using SelectorT = typename TestFixture::PdfSelector;
+
+    static const double prob[] = {0.1, 0.3, 0.5, 0.1};
+
+    SelectorT sample_prob{[](int i) { return prob[i]; }, 4, 1.0};
+    auto      rng = make_rng(0.0);
+    EXPECT_TRUE((std::is_same<decltype(sample_prob(rng)), int>::value));
+
+    rng = make_rng(0.0);
+    EXPECT_EQ(0, sample_prob(rng));
+
+    rng = make_rng(0.0999);
+    EXPECT_EQ(0, sample_prob(rng));
+
+    rng = make_rng(0.1001);
+    EXPECT_EQ(1, sample_prob(rng));
+
+    rng = make_rng(0.4001);
+    EXPECT_EQ(2, sample_prob(rng));
+
+    rng = make_rng(0.9001);
+    EXPECT_EQ(3, sample_prob(rng));
+
+    // Check that highest representable value doesn't go off the end
+    rng = SequenceEngine{{0xffffffffu, 0xffffffffu}};
+    EXPECT_EQ(3, sample_prob(rng));
+}
+
+TYPED_TEST(PdfSelectorTest, zeros)
+{
+    using SelectorT            = typename TestFixture::PdfSelector;
+    static const double prob[] = {0.0, 0.0, 0.4, 0.6};
+
+    SelectorT sample_prob{[](int i) { return prob[i]; }, 4, 1.0};
+
+    auto rng = make_rng(0.0);
+    EXPECT_EQ(2, sample_prob(rng));
+
+    rng = make_rng(1e-15);
+    EXPECT_EQ(2, sample_prob(rng));
+}
+
+TYPED_TEST(PdfSelectorTest, invalid_total)
+{
+    using SelectorT             = typename TestFixture::PdfSelector;
+    static const double prob[]  = {0.1, 0.3, 0.5, 0.1};
+    auto                get_val = [](int i) { return prob[i]; };
+
+    {
+        // Too high
+        SelectorT sample_prob{get_val, 4, 1.1};
+
+        // Not checked since last entry isn't reached; answer is biased
+        auto rng = make_rng(0.75);
+        EXPECT_EQ(2, sample_prob(rng));
+
+        rng = make_rng(0.95);
+        if (CELERITAS_DEBUG && sample_prob.use_debug_sampling)
+        {
+            // Should be checked on final value
+            EXPECT_THROW(sample_prob(rng), celeritas::DebugError);
+        }
+        else
+        {
+            EXPECT_EQ(3, sample_prob(rng));
+        }
+    }
+    {
+        // Too low (last value isn't accounted for)
+        SelectorT sample_prob{get_val, 4, 0.9};
+
+        // Error checking won't catch too-low total unless we always loop over
+        // all values
+        auto rng = make_rng(0.9999);
+        EXPECT_EQ(2, sample_prob(rng));
+    }
+}
+
+TEST(SelectorTest, make_selector)
+{
+    static const double prob[] = {0.1, 0.3, 0.5, 0.1};
+
+    auto sample_prob = make_selector([](int i) { return prob[i]; }, 4);
+
+    auto rng = make_rng(0.0);
+    EXPECT_EQ(0, sample_prob(rng));
+
+    rng = make_rng(0.999999);
+    EXPECT_EQ(3, sample_prob(rng));
+}
+
+TEST(SelectorTest, selector_element)
+{
+    using ElementId                = celeritas::OpaqueId<struct Element>;
+    static const double macro_xs[] = {1.0, 2.0, 4.0};
+    std::vector<int>    evaluated;
+    auto                get_xs = [&evaluated](ElementId el) {
+        CELER_EXPECT(el < 3);
+        evaluated.push_back(el.get());
+        return macro_xs[el.get()];
+    };
+
+    auto sample_el = make_selector(get_xs, ElementId{3}, 1 + 2 + 4);
+    auto rng       = make_rng(0.0);
+    EXPECT_TRUE((std::is_same<decltype(sample_el(rng)), ElementId>::value));
+
+    rng = make_rng(0.0);
+    EXPECT_EQ(0, sample_el(rng).unchecked_get());
+
+    rng = make_rng(0.9999 / 7.0);
+    EXPECT_EQ(0, sample_el(rng).unchecked_get());
+
+    rng = make_rng(1.000000001 / 7.0);
+    EXPECT_EQ(1, sample_el(rng).unchecked_get());
+    const int expected_evaluated[] = {0, 0, 0, 1};
+    EXPECT_VEC_EQ(expected_evaluated, evaluated);
+
+    rng = make_rng(3.0001 / 7.0);
+    EXPECT_EQ(2, sample_el(rng).unchecked_get());
+
+    // In debug, extra error checking evaluates the "last" one
+    if (sample_el.use_debug_sampling)
+    {
+        const int expected_evaluated_final[] = {0, 0, 0, 1, 0, 1, 2};
+        EXPECT_VEC_EQ(expected_evaluated_final, evaluated);
+    }
+    else
+    {
+        const int expected_evaluated_final[] = {0, 0, 0, 1, 0, 1};
+        EXPECT_VEC_EQ(expected_evaluated_final, evaluated);
+    }
+}

--- a/test/random/Selector.test.cc
+++ b/test/random/Selector.test.cc
@@ -26,7 +26,7 @@ class PdfSelectorTest : public celeritas::Test
 
 SequenceEngine make_rng(double select_val)
 {
-    return SequenceEngine::from_reals({&select_val, 1});
+    return SequenceEngine::from_reals({select_val});
 }
 
 //---------------------------------------------------------------------------//

--- a/test/random/SequenceEngine.hh
+++ b/test/random/SequenceEngine.hh
@@ -1,0 +1,95 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file SequenceEngine.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <utility>
+#include <vector>
+#include "random/distributions/GenerateCanonical.hh"
+#include "base/Span.hh"
+
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * "Random" number generator that returns a sequence of values.
+ *
+ * This is useful for testing algorithms that expect a random stream on the
+ * host: you can specify the sequence of values to return. When the sequence is
+ * used up, the next operator call will raise an exception.
+ *
+ * The factory function SequenceEngine::from_reals will create an integer
+ * sequence that exactly reproduces the given real numbers (which must be in
+ * the half-open interval \f$ [0, 1) \f$) using the \c generate_canonical
+ * function.
+ */
+class SequenceEngine
+{
+  public:
+    //@{
+    //! Typedefs
+    using result_type = std::uint32_t;
+    using VecResult   = std::vector<result_type>;
+    using LimitsT     = std::numeric_limits<result_type>;
+    using size_type   = VecResult::size_type;
+    //!@}
+
+  public:
+    // Nearly reproduce the given stream of reals with generate_canonical
+    inline static SequenceEngine
+    from_reals(celeritas::Span<const double> values);
+
+    // Construct from a sequence of integers (the sequence to reproduce)
+    explicit inline SequenceEngine(VecResult values);
+
+    // Get the next random number in the sequence; throw if past the end
+    inline result_type operator()();
+
+    size_type count() const { return iter_ - values_.begin(); }
+    size_type max_count() const { return values_.size(); }
+
+    //!@{
+    //! Engine limits
+    static constexpr result_type min() { return LimitsT::min(); }
+    static constexpr result_type max() { return LimitsT::max(); }
+    //!@}
+
+  private:
+    VecResult                 values_;
+    VecResult::const_iterator iter_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Specialization of GenerateCanonical for SequenceEngine.
+ */
+template<class T>
+class GenerateCanonical<celeritas_test::SequenceEngine, T>
+{
+  public:
+    //!@{
+    //! Type aliases
+    using real_type   = T;
+    using result_type = real_type;
+    //!@}
+
+  public:
+    // Sample a random number
+    inline result_type operator()(celeritas_test::SequenceEngine& rng);
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "SequenceEngine.i.hh"

--- a/test/random/SequenceEngine.hh
+++ b/test/random/SequenceEngine.hh
@@ -45,6 +45,10 @@ class SequenceEngine
     inline static SequenceEngine
     from_reals(celeritas::Span<const double> values);
 
+    // Nearly reproduce the given stream of reals with generate_canonical
+    inline static SequenceEngine
+    from_reals(std::initializer_list<double> values);
+
     // Construct from a sequence of integers (the sequence to reproduce)
     explicit inline SequenceEngine(VecResult values);
 

--- a/test/random/SequenceEngine.i.hh
+++ b/test/random/SequenceEngine.i.hh
@@ -50,6 +50,15 @@ SequenceEngine SequenceEngine::from_reals(celeritas::Span<const double> values)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Construct a sequence to nearly reproduce the given stream of reals.
+ */
+SequenceEngine SequenceEngine::from_reals(std::initializer_list<double> values)
+{
+    return SequenceEngine::from_reals({values.begin(), values.end()});
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct from a sequence of integers (the sequence to reproduce).
  */
 SequenceEngine::SequenceEngine(VecResult values)

--- a/test/random/SequenceEngine.i.hh
+++ b/test/random/SequenceEngine.i.hh
@@ -1,0 +1,120 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file SequenceEngine.i.hh
+//---------------------------------------------------------------------------//
+
+#include <cmath>
+#include "base/Algorithms.hh"
+
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a sequence to nearly reproduce the given stream of reals.
+ *
+ * Values below 1e-64 will not be represented. Furthermore, some other values
+ * (see the RngEngine unit test) will not be exactly reproduced. All input
+ * values must be bounded in  \f$ [0, 1) \f$ .
+ */
+SequenceEngine SequenceEngine::from_reals(celeritas::Span<const double> values)
+{
+    using real_type = double;
+
+    CELER_EXPECT(!values.empty());
+    const real_type range = SequenceEngine::max() + real_type(1);
+
+    SequenceEngine::VecResult elements(values.size() * 2);
+    auto                      dst = elements.begin();
+    for (double v : values)
+    {
+        CELER_EXPECT(v >= 0 && v < 1);
+        // Calculate first (big end) value
+        v *= range;
+        result_type second = std::floor(v);
+
+        // Calculate second (little end) value
+        v -= second;
+        v *= range;
+
+        // Store values
+        *dst++ = std::floor(v);
+        *dst++ = second;
+    }
+    CELER_ENSURE(dst == elements.end());
+
+    return SequenceEngine(std::move(elements));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a sequence of integers (the sequence to reproduce).
+ */
+SequenceEngine::SequenceEngine(VecResult values)
+    : values_(std::move(values)), iter_(values_.cbegin())
+{
+    CELER_EXPECT(!values_.empty());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the next random value in the sequence.
+ *
+ * This is designed to throw an error rather than dereference an off-the-end
+ * iterator even when debugging is disabled, since this class is only used
+ * inside of tests.
+ */
+auto SequenceEngine::operator()() -> result_type
+{
+    CELER_EXPECT(iter_ != values_.cend());
+    if (CELER_UNLIKELY(iter_ == values_.cend()))
+    {
+        // Always throw a debug error rather than letting the test crash
+        celeritas::throw_debug_error(celeritas::DebugErrorType::precondition,
+                                     "SequenceEngine RNG stream exceeded",
+                                     __FILE__,
+                                     __LINE__);
+    }
+    return *iter_++;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Specialization for sequence RNG.
+ *
+ * This should reproduce double exactly, and give the same "single precision"
+ * approximation for floats. It will be inaccurate for higher-precision
+ * numbers.
+ *
+ * Some RNGs always consume 64 bits from the RNG, and can thus provide
+ * single-precision values that are lower than 2^{-32} -- this reproduces that
+ * behavior for small values.
+ */
+template<class T>
+T GenerateCanonical<celeritas_test::SequenceEngine, T>::operator()(
+    celeritas_test::SequenceEngine& rng)
+{
+    // Range for sequence engine should be [0, 2^32 - 1) = 2^32
+    const real_type range = celeritas_test::SequenceEngine::max()
+                            + real_type(1);
+    real_type result = rng();
+    result += rng() * range;
+    result *= 1 / celeritas::ipow<2>(range);
+    if (CELER_UNLIKELY(result == real_type(1)))
+    {
+        // Change to nearest point value closer to zero
+        result = std::nextafter(result, real_type(0));
+    }
+    CELER_ENSURE(result >= 0 && result < 1);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas


### PR DESCRIPTION
This may be a bit over-engineered, but it abstracts the selection of a discrete PDF that's calculated on-the-fly. I'd intended to use it for the ElementSelector, Livermore, and AtomicRelaxation; but the element selector would be ugly (either re-instantiating the Selector at each sample, or requiring ugly templates to make it class data, or rephrasing it to be a function), and the Livermore/Atomic cases allow a "remainder" for the PDFs -- it's OK if they don't add up to one.

Regardless of those absences, I've implemented the selector in PhysicsStepUtils (which makes the code much cleaner) and replaced the awkward construction in the Rayleigh sampler with the simpler Selector. It is slightly less efficient (requiring one more subtraction) but I can't imagine that being a big deal.

For the purpose of testing, I wrote a SequenceEngine that allows us to use an arbitrary "random" number sequence that enables fine-grained testing of random distributions, and could also be used in our Interactor tests to make sure all of the rejection cases behave exactly as expected.