### PR TITLE
Use a non-OpaqueId class for PDGNumber

### DIFF
--- a/app/geant-exporter/geant-exporter.cc
+++ b/app/geant-exporter/geant-exporter.cc
@@ -144,8 +144,8 @@ void store_physics_tables(TFile* root_file, G4ParticleTable* particle_table)
         const G4ParticleDefinition& g4_particle_def
             = *(particle_iterator.value());
 
-        celeritas::PDGNumber pdg(g4_particle_def.GetPDGEncoding());
-        if (pdg.get() == 0)
+        celeritas::PDGNumber pdg{g4_particle_def.GetPDGEncoding()};
+        if (!pdg)
         {
             // Skip "dummy" particles: generic ion and geantino
             continue;

--- a/src/physics/base/PDGNumber.hh
+++ b/src/physics/base/PDGNumber.hh
@@ -7,14 +7,74 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "base/OpaqueId.hh"
+#include <cstddef>
+#include <iostream>
+#include <functional>
+#include "base/Assert.hh"
+
+#ifdef __CUDA_ARCH__
+#    warning "This file should not be included by device code"
+#endif
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+/*!
+ * Type-safe particle identifier.
+ *
+ * PDG-coded numbers should generally not be treated like numbers, so this
+ * prevents unintentional arithmetic and conversion.
+ *
+ * PDG numbers should only be used in host setup code (they should be converted
+ * to ParticleId for use during runtime) so these functions have fewer
+ * decorators.
+ */
+class PDGNumber
+{
+  public:
+    //! Construct with an invalid/unassigned value of zero
+    explicit constexpr PDGNumber() = default;
 
-//! Opaque type used for PDG particle definition codes (can be negative!)
-using PDGNumber = OpaqueId<struct PDG, int>;
+    //! Construct with the PDG value
+    explicit constexpr PDGNumber(int val) : value_(val) {}
+
+    //! True if value is nonzero
+    explicit constexpr operator bool() const { return value_ != 0; }
+
+    //! Get the PDG value
+    constexpr int unchecked_get() const { return value_; }
+
+    //! Get the PDG value
+    inline int get() const;
+
+  private:
+    int value_{0};
+};
+
+//! Get the PDG value
+inline int PDGNumber::get() const
+{
+    CELER_ENSURE(*this);
+    return value_;
+}
+
+//! Test equality
+inline constexpr bool operator==(PDGNumber lhs, PDGNumber rhs)
+{
+    return lhs.unchecked_get() == rhs.get();
+}
+
+//! Test inequality
+inline constexpr bool operator!=(PDGNumber lhs, PDGNumber rhs)
+{
+    return !(lhs == rhs);
+}
+
+//! Allow less-than comparison for sorting
+inline constexpr bool operator<(PDGNumber lhs, PDGNumber rhs)
+{
+    return lhs.unchecked_get() < rhs.get();
+}
 
 //---------------------------------------------------------------------------//
 /*!
@@ -61,3 +121,23 @@ CELER_DEFINE_PDGNUMBER(anti_triton, -1000010030)
 //---------------------------------------------------------------------------//
 } // namespace pdg
 } // namespace celeritas
+
+//---------------------------------------------------------------------------//
+// STD::HASH SPECIALIZATION FOR HOST CODE
+//---------------------------------------------------------------------------//
+//! \cond
+namespace std
+{
+//! Specialization for std::hash for unordered storage.
+template<>
+struct hash<celeritas::PDGNumber>
+{
+    using argument_type = celeritas::PDGNumber;
+    using result_type   = std::size_t;
+    result_type operator()(const argument_type& pdg) const noexcept
+    {
+        return std::hash<int>()(pdg.unchecked_get());
+    }
+};
+} // namespace std
+//! \endcond

--- a/src/physics/base/PDGNumber.hh
+++ b/src/physics/base/PDGNumber.hh
@@ -61,7 +61,7 @@ inline int PDGNumber::get() const
 //! Test equality
 inline constexpr bool operator==(PDGNumber lhs, PDGNumber rhs)
 {
-    return lhs.unchecked_get() == rhs.get();
+    return lhs.unchecked_get() == rhs.unchecked_get();
 }
 
 //! Test inequality
@@ -73,7 +73,7 @@ inline constexpr bool operator!=(PDGNumber lhs, PDGNumber rhs)
 //! Allow less-than comparison for sorting
 inline constexpr bool operator<(PDGNumber lhs, PDGNumber rhs)
 {
-    return lhs.unchecked_get() < rhs.get();
+    return lhs.unchecked_get() < rhs.unchecked_get();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/ParticleParams.cc
+++ b/src/physics/base/ParticleParams.cc
@@ -28,7 +28,6 @@ ParticleParams::ParticleParams(const Input& input)
     for (const auto& particle : input)
     {
         CELER_EXPECT(!particle.name.empty());
-        CELER_EXPECT(particle.pdg_code);
         CELER_EXPECT(particle.mass >= zero_quantity());
         CELER_EXPECT(particle.decay_constant >= 0);
 


### PR DESCRIPTION
Opaque IDs are used as "type-safe indices" everywhere except for PDG code, and are unsigned except for PDG code. We could consider renaming `OpaqueId` after this point.