### PR TITLE
Add reciprocal distribution

### DIFF
--- a/src/physics/em/detail/SBEnergyDistribution.hh
+++ b/src/physics/em/detail/SBEnergyDistribution.hh
@@ -9,7 +9,7 @@
 
 #include "physics/base/Units.hh"
 #include "physics/grid/TwodSubgridCalculator.hh"
-#include "random/distributions/UniformRealDistribution.hh"
+#include "random/distributions/ReciprocalDistribution.hh"
 #include "SeltzerBerger.hh"
 
 namespace celeritas
@@ -113,14 +113,14 @@ class SBEnergyDistribution
 
     using SBTables
         = SeltzerBergerTableData<Ownership::const_reference, MemSpace::native>;
-    using UniformSampler = UniformRealDistribution<>;
+    using ReciprocalSampler = ReciprocalDistribution<real_type>;
 
     const real_type             inc_energy_;
     const TwodSubgridCalculator calc_xs_;
     const real_type             inv_max_xs_;
 
     const real_type dens_corr_;
-    UniformSampler  sample_log_exit_efrac_;
+    ReciprocalSampler sample_exit_esq_;
 
     //// CONSTRUCTION HELPER FUNCTIONS ////
 
@@ -130,8 +130,8 @@ class SBEnergyDistribution
     inline CELER_FUNCTION real_type calc_max_xs(const SBTables&,
                                                 ElementId element) const;
 
-    inline CELER_FUNCTION UniformSampler
-    make_lee_sampler(real_type min_gamma_energy) const;
+    inline CELER_FUNCTION ReciprocalSampler
+    make_esq_sampler(real_type min_gamma_energy) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/random/distributions/ReciprocalDistribution.hh
+++ b/src/random/distributions/ReciprocalDistribution.hh
@@ -1,0 +1,61 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ReciprocalDistribution.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Macros.hh"
+#include "base/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Reciprocal or log-uniform distribution.
+ *
+ * This distribution is defined on a positive range \f$ [a, b) \f$ and has the
+ * normalized PDF:
+ * \f[
+   f(x; a, b) = \frac{1}{x (\ln b - \ln a)} \quad \mathrm{for} a \le x < b
+   \f]
+ * which integrated into a CDF and inverted gives a sample:
+ * \f[
+  x = a \left( \frac{b}{a} \right)^{\xi}
+    = a \exp\!\left(\xi \log \frac{b}{a} \right)
+   \f]
+ */
+template<class RealType = ::celeritas::real_type>
+class ReciprocalDistribution
+{
+  public:
+    //!@{
+    //! Type aliases
+    using real_type   = RealType;
+    using result_type = real_type;
+    //!@}
+
+  public:
+    // Construct on an the interval [a, 1]
+    explicit inline CELER_FUNCTION
+    ReciprocalDistribution(real_type a);
+
+    // Construct on an arbitrary interval
+    inline CELER_FUNCTION
+    ReciprocalDistribution(real_type a, real_type b);
+
+    // Sample a random number according to the distribution
+    template<class Generator>
+    inline CELER_FUNCTION result_type operator()(Generator& rng);
+
+  private:
+    RealType a_;
+    RealType logratio_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas
+
+#include "ReciprocalDistribution.i.hh"

--- a/src/random/distributions/ReciprocalDistribution.i.hh
+++ b/src/random/distributions/ReciprocalDistribution.i.hh
@@ -1,0 +1,62 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ReciprocalDistribution.i.hh
+//---------------------------------------------------------------------------//
+
+#include <cmath>
+#include "base/Assert.hh"
+#include "GenerateCanonical.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct on the interval [a, 1).
+ *
+ * The distribution is equivalent to switching a and b, and using
+ * \f$ \xi' = 1 - \xi \f$.
+ */
+template<class RealType>
+CELER_FUNCTION
+ReciprocalDistribution<RealType>::ReciprocalDistribution(real_type a)
+    : ReciprocalDistribution(1, a)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct on the interval [a, b).
+ *
+ * As with UniformRealDistribution, it is allowable for the two bounds to be
+ * out of order.
+ *
+ * Note that writing as \code (1/a) * b \endcode allows the compiler to
+ * optimize better for the constexpr case a=1.
+ */
+template<class RealType>
+CELER_FUNCTION
+ReciprocalDistribution<RealType>::ReciprocalDistribution(real_type a,
+                                                         real_type b)
+    : a_(a), logratio_(std::log((1/a) * b))
+{
+    CELER_EXPECT(a > 0);
+    CELER_EXPECT(b > 0);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample a random number according to the distribution.
+ */
+template<class RealType>
+template<class Generator>
+CELER_FUNCTION auto
+ReciprocalDistribution<RealType>::operator()(Generator& rng) -> result_type
+{
+    return a_ * std::exp(logratio_ * generate_canonical<RealType>(rng));
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/random/distributions/UniformRealDistribution.hh
+++ b/src/random/distributions/UniformRealDistribution.hh
@@ -15,6 +15,10 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Sample from a uniform distribution.
+ *
+ * This distribution is defined between two arbitrary real numbers \em a and
+ * \em b , and has a flat PDF between the two values. It *is* allowable for the
+ * two numbers to have reversed order.
  */
 template<class RealType = ::celeritas::real_type>
 class UniformRealDistribution
@@ -27,9 +31,13 @@ class UniformRealDistribution
     //!@}
 
   public:
-    // Constructor
+    // Construct on [0, 1)
+    inline CELER_FUNCTION
+    UniformRealDistribution();
+
+    // Construct on an arbitrary interval
     explicit inline CELER_FUNCTION
-    UniformRealDistribution(real_type a = 0, real_type b = 1);
+    UniformRealDistribution(real_type a, real_type b = 1);
 
     // Sample a random number according to the distribution
     template<class Generator>

--- a/src/random/distributions/UniformRealDistribution.i.hh
+++ b/src/random/distributions/UniformRealDistribution.i.hh
@@ -13,7 +13,18 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with defaults.
+ * Construct on the interval [0, 1).
+ */
+template<class RealType>
+CELER_FUNCTION
+UniformRealDistribution<RealType>::UniformRealDistribution()
+    : UniformRealDistribution(0)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct on the interval [a, b).
  */
 template<class RealType>
 CELER_FUNCTION

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -219,6 +219,7 @@ celeritas_add_test(random/distributions/BernoulliDistribution.test.cc)
 celeritas_add_test(random/distributions/ExponentialDistribution.test.cc)
 celeritas_add_test(random/distributions/IsotropicDistribution.test.cc)
 celeritas_add_test(random/distributions/RadialDistribution.test.cc)
+celeritas_add_test(random/distributions/ReciprocalDistribution.test.cc)
 celeritas_add_test(random/distributions/UniformRealDistribution.test.cc)
 
 # Note: this test should compile fine without CUDA but currently doesn't have

--- a/test/random/distributions/ReciprocalDistribution.test.cc
+++ b/test/random/distributions/ReciprocalDistribution.test.cc
@@ -1,0 +1,54 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ReciprocalDistribution.test.cc
+//---------------------------------------------------------------------------//
+#include "random/distributions/ReciprocalDistribution.hh"
+
+#include "base/Range.hh"
+#include "celeritas_test.hh"
+
+using celeritas::ReciprocalDistribution;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class ReciprocalDistributionTest : public celeritas::Test
+{
+  protected:
+    void SetUp() override {}
+
+    std::mt19937 rng;
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(ReciprocalDistributionTest, bin)
+{
+    int num_samples = 10000;
+
+    double   min = 0.1;
+    double   max = 0.9;
+
+    ReciprocalDistribution<double> sample_recip{min, max};
+
+    std::vector<int> counters(10);
+    for (CELER_MAYBE_UNUSED int i : celeritas::range(num_samples))
+    {
+        double r = sample_recip(rng);
+        ASSERT_GE(r, min);
+        ASSERT_LE(r, max);
+        int bin = int(1.0 / r);
+        CELER_ASSERT(bin >= 0 && bin < static_cast<int>(counters.size()));
+        counters[bin] += 1;
+    }
+
+    const int expected_counters[]
+        = {0, 2601, 1905, 1324, 974, 771, 747, 630, 582, 466};
+    EXPECT_VEC_EQ(expected_counters, counters);
+}


### PR DESCRIPTION
Adds a new distribution for sampling `1/x` on a closed positive interval and replaces three places where hand-rolled versions were previously used.

I verified that the CUDA complier is able to effectively optimize the distribution -- the KN interactor superficially requires an extra `log`, but NVCC reproduces identical PTX code to before the change. The (e+, γγ) kernel changes by replacing a division with a reciprocal+multiplication, potentially offering higher throughput.

Overall this change makes the physics clearer and should not cause any performance regressions.