### PR TITLE
Document and improve failure mode for collections in cu code

### DIFF
--- a/src/base/Collection.hh
+++ b/src/base/Collection.hh
@@ -151,6 +151,9 @@ struct AllItems
  * we always want to build host code in C++ files for development ease and to
  * allow testing when CUDA is disabled.)
  *
+ * To avoid propagating C++ library headers into CUDA kernels, "value"
+ * collections are unable to compile when \c __CUDA_ARCH__ is defined.
+ *
  * \todo It would be easy to specialize the traits for the const_reference
  * ownership so that for device primitive data types (int, double) we access
  * via __ldg -- speeding up everywhere in the code without any invasive

--- a/src/base/CollectionStateStore.hh
+++ b/src/base/CollectionStateStore.hh
@@ -28,7 +28,7 @@ namespace celeritas
  *
  * The state store is designed to be usable only from host code. Because C++
  * code in .cu files is still processed by the device compilation phase, this
- * restricts its use to .cc files currently. The embededd collection references
+ * restricts its use to .cc files currently. The embedded collection references
  * can be passed to CUDA kernels, of course. This restriction is designed to
  * reduce propagation of C++ management classes into kernel compilation to
  * improve performance of NVCC build times, and not due to a fundamental

--- a/src/base/detail/CollectionImpl.hh
+++ b/src/base/detail/CollectionImpl.hh
@@ -186,15 +186,15 @@ template<class T, MemSpace M>
 struct CollectionStorage<T, Ownership::value, M>
 {
     static_assert(sizeof(T) == 0,
-                  "Value collections cannot be used from the NVCC devic e "
+                  "Value collections cannot be used from the NVCC device "
                   "compilation phase");
 };
 
 template<MemSpace M>
 struct CollectionAssigner<Ownership::value, M>
 {
-    static_assert(false,
-                  "Collections cannot be assigned from the NVCC devic e "
+    static_assert(static_cast<int>(M) == -1,
+                  "Collections cannot be assigned from the NVCC device "
                   "compilation phase");
 };
 

--- a/src/base/detail/CollectionImpl.hh
+++ b/src/base/detail/CollectionImpl.hh
@@ -111,11 +111,21 @@ struct CollectionStorageValidator
     template<class Size, class OtherSize>
     void operator()(Size, OtherSize)
     {
+        /* No validation needed */
     }
 };
 
 template<>
-struct CollectionStorageValidator<Ownership::value>;
+struct CollectionStorageValidator<Ownership::value>
+{
+    template<class Size, class OtherSize>
+    void operator()(Size dst, OtherSize src)
+    {
+        CELER_VALIDATE(dst == src,
+                       << "collection is too large (" << sizeof(Size)
+                       << "-byte int cannot hold " << src << " elements)");
+    }
+};
 
 #ifndef __CUDA_ARCH__
 //---------------------------------------------------------------------------//
@@ -169,18 +179,23 @@ struct CollectionAssigner<Ownership::value, MemSpace::device>
     }
 };
 
-//---------------------------------------------------------------------------//
-//! Check that sizes are acceptable when taking references
-template<>
-struct CollectionStorageValidator<Ownership::value>
+#else
+// Give a useful error message when trying to use "value" collections when
+// building device code
+template<class T, MemSpace M>
+struct CollectionStorage<T, Ownership::value, M>
 {
-    template<class Size, class OtherSize>
-    void operator()(Size dst, OtherSize src)
-    {
-        CELER_VALIDATE(dst == src,
-                       << "collection is too large (" << sizeof(Size)
-                       << "-byte int cannot hold " << src << " elements)");
-    }
+    static_assert(sizeof(T) == 0,
+                  "Value collections cannot be used from the NVCC devic e "
+                  "compilation phase");
+};
+
+template<MemSpace M>
+struct CollectionAssigner<Ownership::value, M>
+{
+    static_assert(false,
+                  "Collections cannot be assigned from the NVCC devic e "
+                  "compilation phase");
 };
 
 #endif


### PR DESCRIPTION
@mrguilima encountered wacky build errors as a result of instantiating a `CollectionStateStore` inside a `.cu` file, which isn't a capability I'd intended or anticipated. (It runs afoul of my use of `#ifndef __CUDA_ARCH__` which is designed just to keep C++ headers from propagating into the NVCC device kernel and slow builds down.) Although we might remove those preprocess definitions in the future, this will at least give nice failure messages (static assertions rather than "declared but not defined"  classes).