### PR TITLE
Clang and documentation fixes

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -207,6 +207,7 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_VecGeom)
     PRIVATE
     celeritas
     nlohmann_json::nlohmann_json
+    Celeritas::ROOT
   )
   if(CELERITAS_USE_CUDA)
     celeritas_link_vecgeom_cuda(celeritas_demo_loop)
@@ -218,7 +219,6 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_VecGeom)
   )
   target_link_libraries(demo-loop
     celeritas
-    Celeritas::ROOT
     VecGeom::vecgeom
     celeritas_demo_loop
     nlohmann_json::nlohmann_json

--- a/app/demo-loop/LDemoParams.cc
+++ b/app/demo-loop/LDemoParams.cc
@@ -39,7 +39,7 @@ LDemoParams load_params(const LDemoArgs& args)
 
     // Load materials
     {
-        result.materials = std::move(MaterialParams::from_import(data));
+        result.materials = MaterialParams::from_import(data);
     }
 
     // Create geometry/material coupling
@@ -63,7 +63,7 @@ LDemoParams load_params(const LDemoArgs& args)
 
     // Construct particle params
     {
-        result.particles = std::move(ParticleParams::from_import(data));
+        result.particles = ParticleParams::from_import(data);
     }
 
     // Construct cutoffs

--- a/interface/celeritas.i
+++ b/interface/celeritas.i
@@ -106,11 +106,25 @@ namespace celeritas
 %template(VecImportPhysicsVector) std::vector<celeritas::ImportPhysicsVector>;
 
 %include "io/ImportPhysicsTable.hh"
-
 %template(VecImportPhysicsTable) std::vector<celeritas::ImportPhysicsTable>;
-%include "io/ImportProcess.hh"
 
+%include "io/ImportProcess.hh"
 %template(VecImportProcess) std::vector<celeritas::ImportProcess>;
+
+%include "io/ImportParticle.hh"
+%template(VecImportParticle) std::vector<celeritas::ImportParticle>;
+
+%include "io/ImportElement.hh"
+%template(VecImportElement) std::vector<celeritas::ImportElement>;
+
+%include "io/ImportMaterial.hh"
+%template(VecImportMaterial) std::vector<celeritas::ImportMaterial>;
+
+%include "io/ImportVolume.hh"
+%template(VecImportVolume) std::vector<celeritas::ImportVolume>;
+
+%include "io/ImportData.hh"
+
 %rename(RootImportResult) celeritas::RootImporter::result_type;
 %include "io/RootImporter.hh"
 

--- a/src/io/ImportParticle.hh
+++ b/src/io/ImportParticle.hh
@@ -24,7 +24,7 @@ struct ImportParticle
     int         pdg;
     double      mass;     //!< [MeV]
     double      charge;   //!< [Multiple of electron charge]
-    double      spin;     //!< [Multiple of \hbar]
+    double      spin;     //!< [Multiple of hbar]
     double      lifetime; //!< [s]
     bool        is_stable;
 };

--- a/src/physics/base/PhysicsTrackView.i.hh
+++ b/src/physics/base/PhysicsTrackView.i.hh
@@ -266,7 +266,7 @@ PhysicsTrackView::energy_max_xs(ParticleProcessId ppid) const
  * If this is an energy loss process, this returns the estimate of the maximum
  * cross section over the step. If the energy of the global maximum of the
  * cross section (calculated at initialization) is in the interval \f$ [\xi
- * E_0, E_0) \f$, where \f$ \E_0 \f$ is the pre-step energy and \f$ \xi \f$ is
+ * E_0, E_0) \f$, where \f$ E_0 \f$ is the pre-step energy and \f$ \xi \f$ is
  * \c energy_fraction, \f$ \sigma_{\max} \f$ is set to the global maximum.
  * Otherwise, \f$ \sigma_{\max} = \max( \sigma(E_0), \sigma(\xi E_0) ) \f$.
  */

--- a/test/geometry/GeoMaterial.test.cc
+++ b/test/geometry/GeoMaterial.test.cc
@@ -33,7 +33,7 @@ class GeoMaterialTest : public celeritas_test::GeoTestBase
         const auto data = RootImporter(root_file.c_str())();
 
         // Set up shared material data
-        material_ = std::move(MaterialParams::from_import(data));
+        material_ = MaterialParams::from_import(data);
 
         // Create geometry/material coupling
         GeoMaterialParams::Input input;

--- a/test/io/RootImporter.test.cc
+++ b/test/io/RootImporter.test.cc
@@ -132,7 +132,7 @@ TEST_F(RootImporterTest, materials)
     std::vector<double> densities, num_densities, e_densities, temperatures,
         rad_lengths, nuc_int_lenghts;
 
-    for (const auto material : materials)
+    for (const auto& material : materials)
     {
         names.push_back(material.name);
         states.push_back((int)material.state);
@@ -143,14 +143,14 @@ TEST_F(RootImporterTest, materials)
         rad_lengths.push_back(material.radiation_length);
         temperatures.push_back(material.temperature);
 
-        for (const auto key : material.pdg_cutoffs)
+        for (const auto& key : material.pdg_cutoffs)
         {
             pdgs.push_back(key.first);
             cutoff_energies.push_back(key.second.energy);
             cutoff_ranges.push_back(key.second.range);
         }
 
-        for (const auto el_comp : material.elements)
+        for (const auto& el_comp : material.elements)
         {
             el_comps_ids.push_back(el_comp.element_id);
             el_comps_mass_frac.push_back(el_comp.mass_fraction);

--- a/test/physics/em/ImportedProcesses.test.cc
+++ b/test/physics/em/ImportedProcesses.test.cc
@@ -36,8 +36,8 @@ class ImportedProcessesTest : public celeritas::Test
 
         auto data = import_from_root();
 
-        particles_ = std::move(ParticleParams::from_import(data));
-        materials_ = std::move(MaterialParams::from_import(data));
+        particles_ = ParticleParams::from_import(data);
+        materials_ = MaterialParams::from_import(data);
         processes_
             = std::make_shared<ImportedProcesses>(std::move(data.processes));
 


### PR DESCRIPTION
Apple-clang on my mac pointed out some misuses of `std::move`, and there were a few other minor issues stemming from recent merges.