### PR TITLE
Use logical instead of placed volumes for VolumeId

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -29,7 +29,7 @@ pipeline {
         stage('cuda-11-ndebug') {
           agent {
             docker {
-              image 'celeritas/ci-focal-cuda11:2021-04-28'
+              image 'celeritas/ci-focal-cuda11:2021-05-27'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
             }
           }
@@ -46,7 +46,7 @@ pipeline {
         stage('cuda-11') {
           agent {
             docker {
-              image 'celeritas/ci-focal-cuda11:2021-04-28'
+              image 'celeritas/ci-focal-cuda11:2021-05-27'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
             }
           }

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -27,7 +27,7 @@ case $CONFIG in
     ;;
   focal-cuda11)
     BASE_TAG=nvidia/cuda:11.1-devel-ubuntu20.04
-    VECGEOM=v1.1.13
+    VECGEOM=v1.1.15
     ;;
   *)
     echo "Invalid configure type: $1"

--- a/src/geometry/GeoParams.cc
+++ b/src/geometry/GeoParams.cc
@@ -44,7 +44,10 @@ GeoParams::GeoParams(const char* gdml_filename)
         vecgeom::ABBoxManager::Instance().InitABBoxesForCompleteGeometry();
     }
 
-    num_volumes_           = vecgeom::VPlacedVolume::GetIdCount();
+    std::vector<vecgeom::LogicalVolume*> temp;
+    vecgeom::GeoManager::Instance().GetAllLogicalVolumes(temp);
+    num_volumes_ = temp.size();
+
     host_ref_.world_volume = vecgeom::GeoManager::Instance().GetWorld();
     host_ref_.max_depth    = vecgeom::GeoManager::Instance().getMaxDepth();
 
@@ -102,7 +105,7 @@ const std::string& GeoParams::id_to_label(VolumeId vol_id) const
 {
     CELER_EXPECT(vol_id.get() < num_volumes_);
     const auto* vol
-        = vecgeom::GeoManager::Instance().FindPlacedVolume(vol_id.get());
+        = vecgeom::GeoManager::Instance().FindLogicalVolume(vol_id.get());
     CELER_ASSERT(vol);
     return vol->GetLabel();
 }
@@ -114,7 +117,7 @@ const std::string& GeoParams::id_to_label(VolumeId vol_id) const
 auto GeoParams::label_to_id(const std::string& label) const -> VolumeId
 {
     const auto* vol
-        = vecgeom::GeoManager::Instance().FindPlacedVolume(label.c_str());
+        = vecgeom::GeoManager::Instance().FindLogicalVolume(label.c_str());
     CELER_ASSERT(vol);
     CELER_ASSERT(vol->id() < num_volumes_);
     return VolumeId{vol->id()};

--- a/src/geometry/GeoParams.cc
+++ b/src/geometry/GeoParams.cc
@@ -44,9 +44,7 @@ GeoParams::GeoParams(const char* gdml_filename)
         vecgeom::ABBoxManager::Instance().InitABBoxesForCompleteGeometry();
     }
 
-    std::vector<vecgeom::LogicalVolume*> temp;
-    vecgeom::GeoManager::Instance().GetAllLogicalVolumes(temp);
-    num_volumes_ = temp.size();
+    num_volumes_ = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
 
     host_ref_.world_volume = vecgeom::GeoManager::Instance().GetWorld();
     host_ref_.max_depth    = vecgeom::GeoManager::Instance().getMaxDepth();
@@ -119,8 +117,9 @@ auto GeoParams::label_to_id(const std::string& label) const -> VolumeId
     const auto* vol
         = vecgeom::GeoManager::Instance().FindLogicalVolume(label.c_str());
     CELER_ASSERT(vol);
-    CELER_ASSERT(vol->id() < num_volumes_);
-    return VolumeId{vol->id()};
+    unsigned int volid = (unsigned int)vol->id();
+    CELER_ASSERT(volid < num_volumes_);
+    return VolumeId{volid};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/GeoParams.cc
+++ b/src/geometry/GeoParams.cc
@@ -117,9 +117,8 @@ auto GeoParams::label_to_id(const std::string& label) const -> VolumeId
     const auto* vol
         = vecgeom::GeoManager::Instance().FindLogicalVolume(label.c_str());
     CELER_ASSERT(vol);
-    unsigned int volid = (unsigned int)vol->id();
-    CELER_ASSERT(volid < num_volumes_);
-    return VolumeId{volid};
+    CELER_ASSERT(vol->id() < num_volumes_);
+    return VolumeId{vol->id()};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/GeoTrackView.hh
+++ b/src/geometry/GeoTrackView.hh
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <VecGeom/volumes/PlacedVolume.h>
+#include <VecGeom/volumes/LogicalVolume.h>
 #include <VecGeom/navigation/NavigationState.h>
 
 #include "base/Macros.hh"
@@ -103,7 +103,7 @@ class GeoTrackView
   private:
     //!@{
     //! Type aliases
-    using Volume   = vecgeom::VPlacedVolume;
+    using Volume   = vecgeom::LogicalVolume;
     using NavState = vecgeom::NavigationState;
     //!@}
 

--- a/src/geometry/GeoTrackView.i.hh
+++ b/src/geometry/GeoTrackView.i.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include <VecGeom/navigation/GlobalLocator.h>
 #include <VecGeom/navigation/VNavigator.h>
+#include <VecGeom/volumes/PlacedVolume.h>
 #include "base/ArrayUtils.hh"
 #include "detail/VGCompatibility.hh"
 
@@ -87,8 +88,7 @@ GeoTrackView& GeoTrackView::operator=(const DetailedInitializer& init)
 //! Find the distance to the next geometric boundary.
 CELER_FUNCTION void GeoTrackView::find_next_step()
 {
-    const vecgeom::VNavigator* navigator
-        = this->volume().GetLogicalVolume()->GetNavigator();
+    const vecgeom::VNavigator* navigator = this->volume().GetNavigator();
     CELER_ASSERT(navigator);
 
     next_step_
@@ -188,11 +188,11 @@ CELER_FUNCTION VolumeId GeoTrackView::volume_id() const
 // PRIVATE CLASS FUNCTIONS
 //---------------------------------------------------------------------------//
 //! Get a reference to the current volume, or to world volume if outside
-CELER_FUNCTION const vecgeom::VPlacedVolume& GeoTrackView::volume() const
+CELER_FUNCTION const vecgeom::LogicalVolume& GeoTrackView::volume() const
 {
-    const vecgeom::VPlacedVolume* vol_ptr = vgstate_.Top();
-    CELER_ENSURE(vol_ptr);
-    return *vol_ptr;
+    const vecgeom::VPlacedVolume* physvol_ptr = vgstate_.Top();
+    CELER_ENSURE(physvol_ptr);
+    return *physvol_ptr->GetLogicalVolume();
 }
 
 //---------------------------------------------------------------------------//
@@ -201,8 +201,7 @@ CELER_FUNCTION const vecgeom::VPlacedVolume& GeoTrackView::volume() const
 //! Find the safety to the closest geometric boundary.
 CELER_FUNCTION real_type GeoTrackView::find_safety(Real3 pos) const
 {
-    const vecgeom::VNavigator* navigator
-        = this->volume().GetLogicalVolume()->GetNavigator();
+    const vecgeom::VNavigator* navigator = this->volume().GetNavigator();
     CELER_ASSERT(navigator);
 
     return navigator->GetSafetyEstimator()->ComputeSafety(
@@ -218,8 +217,7 @@ CELER_FUNCTION real_type GeoTrackView::compute_step(Real3      pos,
                                                     Real3      dir,
                                                     real_type* safety) const
 {
-    const vecgeom::VNavigator* navigator
-        = this->volume().GetLogicalVolume()->GetNavigator();
+    const vecgeom::VNavigator* navigator = this->volume().GetNavigator();
     CELER_ASSERT(navigator);
 
     return navigator->ComputeStepAndSafety(detail::to_vector(pos),
@@ -238,8 +236,7 @@ CELER_FUNCTION real_type GeoTrackView::compute_step(Real3      pos,
  */
 CELER_FUNCTION void GeoTrackView::propagate_state(Real3 pos, Real3 dir) const
 {
-    const vecgeom::VNavigator* navigator
-        = this->volume().GetLogicalVolume()->GetNavigator();
+    const vecgeom::VNavigator* navigator = this->volume().GetNavigator();
     CELER_ASSERT(navigator);
 
     navigator->ComputeStepAndPropagatedState(detail::to_vector(pos),

--- a/src/geometry/GeoTrackView.i.hh
+++ b/src/geometry/GeoTrackView.i.hh
@@ -181,8 +181,7 @@ CELER_FUNCTION void GeoTrackView::move_next_volume()
 CELER_FUNCTION VolumeId GeoTrackView::volume_id() const
 {
     CELER_EXPECT(!dirty_);
-    return (this->is_outside() ? VolumeId{}
-                               : VolumeId{(unsigned int)this->volume().id()});
+    return (this->is_outside() ? VolumeId{} : VolumeId{this->volume().id()});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/GeoTrackView.i.hh
+++ b/src/geometry/GeoTrackView.i.hh
@@ -181,7 +181,8 @@ CELER_FUNCTION void GeoTrackView::move_next_volume()
 CELER_FUNCTION VolumeId GeoTrackView::volume_id() const
 {
     CELER_EXPECT(!dirty_);
-    return (this->is_outside() ? VolumeId{} : VolumeId{this->volume().id()});
+    return (this->is_outside() ? VolumeId{}
+                               : VolumeId{(unsigned int)this->volume().id()});
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geometry/Geo.test.cc
+++ b/test/geometry/Geo.test.cc
@@ -38,7 +38,7 @@ class GeoParamsHostTest : public GeoTestBase
 TEST_F(GeoParamsHostTest, accessors)
 {
     const auto& geom = *this->geo_params();
-    EXPECT_EQ(11, geom.num_volumes());
+    EXPECT_EQ(4, geom.num_volumes());
     EXPECT_EQ(4, geom.max_depth());
 
     EXPECT_EQ("Shape2", geom.id_to_label(VolumeId{0}));
@@ -86,13 +86,13 @@ TEST_F(GeoTrackViewHostTest, from_outside)
     geo.find_next_step();
     EXPECT_SOFT_EQ(1, geo.next_step());
     geo.move_next_step();
-    EXPECT_EQ(VolumeId{9}, geo.volume_id()); // Shape1 -> Envelope
+    EXPECT_EQ(VolumeId{2}, geo.volume_id()); // Shape1 -> Envelope
     EXPECT_FALSE(geo.is_outside());
 
     geo.find_next_step();
     EXPECT_SOFT_EQ(1, geo.next_step());
     geo.move_next_step();
-    EXPECT_EQ(VolumeId{10}, geo.volume_id()); // Shape1 -> Envelope
+    EXPECT_EQ(VolumeId{3}, geo.volume_id()); // Shape1 -> Envelope
     EXPECT_FALSE(geo.is_outside());
 }
 
@@ -103,11 +103,11 @@ TEST_F(GeoTrackViewHostTest, from_outside_edge)
     EXPECT_TRUE(geo.is_outside());
 
     geo.move_next_step();
-    EXPECT_EQ(VolumeId{10}, geo.volume_id()); // World
+    EXPECT_EQ(VolumeId{3}, geo.volume_id()); // World
     geo.find_next_step();
     EXPECT_SOFT_EQ(7., geo.next_step());
     geo.move_next_step();
-    EXPECT_EQ(VolumeId{3}, geo.volume_id()); // World -> Envelope
+    EXPECT_EQ(VolumeId{2}, geo.volume_id()); // World -> Envelope
 }
 
 TEST_F(GeoTrackViewHostTest, inside)
@@ -164,8 +164,8 @@ TEST_F(GEO_DEVICE_TEST, all)
 
     // clang-format off
     static const int expected_ids[] = {
-        1, 2,10, 1, 5,10, 1, 4,10, 1, 8,10,
-        1, 3,10, 1, 7,10, 1, 6,10, 1, 9,10};
+        1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+        1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
 
     static const double expected_distances[]
         = {5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1,

--- a/test/geometry/Geo.test.cc
+++ b/test/geometry/Geo.test.cc
@@ -73,54 +73,62 @@ class GeoTrackViewHostTest : public GeoTestBase
 
 TEST_F(GeoTrackViewHostTest, from_outside)
 {
+    const auto& geom = *this->geo_params();
+
     GeoTrackView geo = this->make_geo_track_view();
     geo              = {{-10, -10, -10}, {1, 0, 0}};
-    EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape2 center
+    EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape2");
 
     geo.find_next_step();
     EXPECT_SOFT_EQ(5, geo.next_step());
-    geo.move_next_step();
+    geo.move_next_step(); // Shape2 -> Shape1
     EXPECT_SOFT_EQ(-5, geo.pos()[0]);
-    EXPECT_EQ(VolumeId{1}, geo.volume_id()); // Shape2 -> Shape1
+    EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape1");
 
     geo.find_next_step();
     EXPECT_SOFT_EQ(1, geo.next_step());
-    geo.move_next_step();
-    EXPECT_EQ(VolumeId{2}, geo.volume_id()); // Shape1 -> Envelope
+    geo.move_next_step(); // Shape1 -> Envelope
+    EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Envelope");
     EXPECT_FALSE(geo.is_outside());
 
     geo.find_next_step();
     EXPECT_SOFT_EQ(1, geo.next_step());
-    geo.move_next_step();
-    EXPECT_EQ(VolumeId{3}, geo.volume_id()); // Shape1 -> Envelope
+    geo.move_next_step(); // Envelope -> World
+    EXPECT_EQ(geom.id_to_label(geo.volume_id()), "World");
+
     EXPECT_FALSE(geo.is_outside());
 }
 
 TEST_F(GeoTrackViewHostTest, from_outside_edge)
 {
+    const auto& geom = *this->geo_params();
+
     GeoTrackView geo = this->make_geo_track_view();
     geo              = {{-24, 6.5, 6.5}, {1, 0, 0}};
     EXPECT_TRUE(geo.is_outside());
 
-    geo.move_next_step();
-    EXPECT_EQ(VolumeId{3}, geo.volume_id()); // World
+    geo.move_next_step(); // outside -> World
+    EXPECT_EQ(geom.id_to_label(geo.volume_id()), "World");
+
     geo.find_next_step();
     EXPECT_SOFT_EQ(7., geo.next_step());
-    geo.move_next_step();
-    EXPECT_EQ(VolumeId{2}, geo.volume_id()); // World -> Envelope
+    geo.move_next_step(); // World -> Envelope
+    EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Envelope");
 }
 
 TEST_F(GeoTrackViewHostTest, inside)
 {
+    const auto& geom = *this->geo_params();
+
     GeoTrackView geo = this->make_geo_track_view();
     geo              = {{-10, 10, 10}, {0, -1, 0}};
-    EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape1 center
+    EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape2"); // Another Shape2
 
     geo.find_next_step();
     EXPECT_SOFT_EQ(5.0, geo.next_step());
-    geo.move_next_step();
+    geo.move_next_step(); // Shape2 -> Shape1
     EXPECT_SOFT_EQ(5.0, geo.pos()[1]);
-    EXPECT_EQ(VolumeId{1}, geo.volume_id()); // Shape1 -> Shape2
+    EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape1");
     EXPECT_FALSE(geo.is_outside());
 
     geo.find_next_step();

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -51,7 +51,7 @@ class LinearPropagatorHostTest : public GeoTestBase
 TEST_F(LinearPropagatorHostTest, accessors)
 {
     const auto& geom = *geo_params();
-    EXPECT_EQ(11, geom.num_volumes());
+    EXPECT_EQ(4, geom.num_volumes());
     EXPECT_EQ(4, geom.max_depth());
     EXPECT_EQ("Shape2", geom.id_to_label(VolumeId{0}));
     EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{1}));
@@ -76,7 +76,7 @@ TEST_F(LinearPropagatorHostTest, track_line)
 
         step = propagate(1.e10);
         EXPECT_SOFT_EQ(1, step.distance);
-        EXPECT_EQ(VolumeId{3}, step.volume); // Shape1 -> Envelope
+        EXPECT_EQ(VolumeId{2}, step.volume); // Shape1 -> Envelope
         EXPECT_FALSE(geo.is_outside());
 
         step = propagate();
@@ -92,11 +92,11 @@ TEST_F(LinearPropagatorHostTest, track_line)
 
         auto step = propagate();
         EXPECT_FALSE(geo.is_outside());
-        EXPECT_EQ(VolumeId{10}, geo.volume_id()); // World
+        EXPECT_EQ(VolumeId{3}, geo.volume_id()); // World
 
         step = propagate();
         EXPECT_SOFT_EQ(7., step.distance);
-        EXPECT_EQ(VolumeId{3}, step.volume); // World -> Envelope
+        EXPECT_EQ(VolumeId{2}, step.volume); // World -> Envelope
     }
     {
         // Track from inside detector
@@ -156,7 +156,7 @@ TEST_F(LinearPropagatorHostTest, track_intraVolume)
         step = propagate(geo.next_step()); // last step inside Detector
         EXPECT_SOFT_EQ(0.4, step.distance);
         EXPECT_SOFT_EQ(16, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{3}, step.volume); // Shape1 -> Envelope
+        EXPECT_EQ(VolumeId{2}, step.volume); // Shape1 -> Envelope
     }
 }
 
@@ -198,8 +198,8 @@ TEST_F(LP_DEVICE_TEST, track_lines)
 
     // clang-format off
     static const int expected_ids[] = {
-        1, 2,10, 1, 5,10, 1, 4,10, 1, 8,10,
-        1, 3,10, 1, 7,10, 1, 6,10, 1, 9,10};
+        1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+        1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
 
     static const double expected_distances[]
         = {5, 1, 1, 5, 1, 1, 5, 1, 1, 5, 1, 1,

--- a/test/geometry/LinearPropagator.test.cc
+++ b/test/geometry/LinearPropagator.test.cc
@@ -50,9 +50,10 @@ class LinearPropagatorHostTest : public GeoTestBase
 
 TEST_F(LinearPropagatorHostTest, accessors)
 {
-    const auto& geom = *geo_params();
+    const auto& geom = *this->geo_params();
     EXPECT_EQ(4, geom.num_volumes());
     EXPECT_EQ(4, geom.max_depth());
+
     EXPECT_EQ("Shape2", geom.id_to_label(VolumeId{0}));
     EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{1}));
 }
@@ -64,24 +65,25 @@ TEST_F(LinearPropagatorHostTest, track_line)
     GeoTrackView     geo = this->make_geo_track_view();
     LinearPropagator propagate(&geo); // one propagator per track
 
+    const auto& geom = *this->geo_params();
     {
         // Track from outside detector, moving right
         geo = {{-10, 10, 10}, {1, 0, 0}};
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape2 center
+        EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape2"); // in Shape2
 
         auto step = propagate(1.e10); // very large proposed step
         EXPECT_SOFT_EQ(5, step.distance);
-        EXPECT_EQ(VolumeId{1}, step.volume); // Shape2 -> Shape1
+        EXPECT_EQ(geom.id_to_label(step.volume), "Shape1");
         EXPECT_SOFT_EQ(-5, geo.pos()[0]);
 
         step = propagate(1.e10);
         EXPECT_SOFT_EQ(1, step.distance);
-        EXPECT_EQ(VolumeId{2}, step.volume); // Shape1 -> Envelope
+        EXPECT_EQ(geom.id_to_label(step.volume), "Envelope");
         EXPECT_FALSE(geo.is_outside());
 
         step = propagate();
         EXPECT_SOFT_EQ(1, step.distance);
-        EXPECT_FALSE(geo.is_outside()); // leaving World
+        EXPECT_FALSE(geo.is_outside());
     }
 
     {
@@ -92,25 +94,26 @@ TEST_F(LinearPropagatorHostTest, track_line)
 
         auto step = propagate();
         EXPECT_FALSE(geo.is_outside());
-        EXPECT_EQ(VolumeId{3}, geo.volume_id()); // World
+        EXPECT_EQ(geom.id_to_label(step.volume), "World");
 
-        step = propagate();
+        step = propagate(); // World -> Envelope
         EXPECT_SOFT_EQ(7., step.distance);
-        EXPECT_EQ(VolumeId{2}, step.volume); // World -> Envelope
+        EXPECT_EQ(geom.id_to_label(step.volume), "Envelope");
     }
     {
         // Track from inside detector
         geo = {{-10, 10, 10}, {0, -1, 0}};
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape1 center
+        EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape2"); // Shape2
 
-        auto step = propagate();
+        auto step = propagate(); // Shape2 -> Shape1
         EXPECT_SOFT_EQ(5.0, step.distance);
         EXPECT_SOFT_EQ(5.0, geo.pos()[1]);
-        EXPECT_EQ(VolumeId{1}, step.volume); // Shape1 -> Shape2
+        EXPECT_EQ(geom.id_to_label(step.volume), "Shape1");
         EXPECT_FALSE(geo.is_outside());
 
         step = propagate();
         EXPECT_SOFT_EQ(1.0, step.distance);
+        EXPECT_EQ(geom.id_to_label(step.volume), "Envelope");
         EXPECT_FALSE(geo.is_outside());
     }
 }
@@ -122,41 +125,42 @@ TEST_F(LinearPropagatorHostTest, track_intraVolume)
     GeoTrackView     geo = this->make_geo_track_view();
     LinearPropagator propagate(&geo); // one propagator per track
 
+    const auto& geom = *this->geo_params();
     {
         // Track from outside detector, moving right
         geo = {{-10, 10, 10}, {0, 0, 1}};
-        EXPECT_EQ(VolumeId{0}, geo.volume_id()); // Shape2
+        EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape2"); // Shape2
 
         // break next step into two
         auto step = propagate(0.5 * geo.next_step());
         EXPECT_SOFT_EQ(2.5, step.distance);
         EXPECT_SOFT_EQ(12.5, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{0}, step.volume); // still Shape2
+        EXPECT_EQ(geom.id_to_label(step.volume), "Shape2"); // still Shape2
 
         step = propagate(); // all remaining
         EXPECT_SOFT_EQ(2.5, step.distance);
         EXPECT_SOFT_EQ(15.0, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{1}, step.volume); // Shape2 -> Shape1
+        EXPECT_EQ(geom.id_to_label(step.volume), "Shape1"); // Shape2 -> Shape1
 
         // break next step into > 2 steps, re-calculating next_step each time
-        step = propagate(0.2 * geo.next_step()); // step 1 inside Detector
+        step = propagate(0.2 * geo.next_step()); // step 1 inside Shape1
         EXPECT_SOFT_EQ(0.2, step.distance);
         EXPECT_SOFT_EQ(15.2, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{1}, step.volume); // Shape1
+        EXPECT_EQ(geom.id_to_label(step.volume), "Shape1");
 
         EXPECT_SOFT_EQ(0.8, geo.next_step());
 
-        step = propagate(0.5 * geo.next_step()); // step 2 inside Detector
+        step = propagate(0.5 * geo.next_step()); // step 2 inside Shape1
         EXPECT_SOFT_EQ(0.4, step.distance);
         EXPECT_SOFT_EQ(15.6, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{1}, step.volume); // Shape1
+        EXPECT_EQ(geom.id_to_label(step.volume), "Shape1");
 
         EXPECT_SOFT_EQ(0.4, geo.next_step());
 
-        step = propagate(geo.next_step()); // last step inside Detector
+        step = propagate(geo.next_step()); // last step inside Shape1
         EXPECT_SOFT_EQ(0.4, step.distance);
         EXPECT_SOFT_EQ(16, geo.pos()[2]);
-        EXPECT_EQ(VolumeId{2}, step.volume); // Shape1 -> Envelope
+        EXPECT_EQ(geom.id_to_label(step.volume), "Envelope");
     }
 }
 


### PR DESCRIPTION
As discussed in today's (May 6) physics hackathon, the GeoParams and GeoTrackView interfaces are being modified to return logical volumes rather than physical volumes.  For example:
- GeoParams::num_volumes() now returns the number of logical volumes 
- GeoParams::id_to_label() and label_to_id() now return the label or id of that logical volume
- GeoTrackView::volume() and volume_id() now return the logical volume (and its ID) containing the current track

Geometry tests were adapted to the new volume IDs.
*Note:* updated version of VecGeom required - https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/816