### PR TITLE
Complete positron annihilation and gamma conversion processes

### DIFF
--- a/src/base/DeviceAllocation.cc
+++ b/src/base/DeviceAllocation.cc
@@ -23,7 +23,6 @@ namespace celeritas
  */
 DeviceAllocation::DeviceAllocation(size_type bytes) : size_(bytes)
 {
-    CELER_EXPECT(bytes > 0);
     CELER_EXPECT(celeritas::device());
     void* ptr = nullptr;
     CELER_CUDA_CALL(cudaMalloc(&ptr, bytes));
@@ -36,7 +35,6 @@ DeviceAllocation::DeviceAllocation(size_type bytes) : size_(bytes)
  */
 void DeviceAllocation::copy_to_device(SpanConstBytes bytes)
 {
-    CELER_EXPECT(!this->empty());
     CELER_EXPECT(bytes.size() == this->size());
     CELER_CUDA_CALL(cudaMemcpy(
         data_.get(), bytes.data(), bytes.size(), cudaMemcpyHostToDevice));
@@ -48,7 +46,6 @@ void DeviceAllocation::copy_to_device(SpanConstBytes bytes)
  */
 void DeviceAllocation::copy_to_host(SpanBytes bytes) const
 {
-    CELER_EXPECT(!this->empty());
     CELER_EXPECT(bytes.size() == this->size());
     CELER_CUDA_CALL(cudaMemcpy(
         bytes.data(), data_.get(), this->size(), cudaMemcpyDeviceToHost));

--- a/src/physics/base/PhysicsParams.cc
+++ b/src/physics/base/PhysicsParams.cc
@@ -175,7 +175,7 @@ void PhysicsParams::build_ids(const ParticleParams& particles,
         {
             CELER_LOG(warning)
                 << "No processes are defined for particle '"
-                << particles.id_to_label(ParticleId{particle_idx});
+                << particles.id_to_label(ParticleId{particle_idx}) << '\'';
             continue;
         }
         data->max_particle_processes = std::max<ProcessId::size_type>(

--- a/src/physics/em/ComptonProcess.hh
+++ b/src/physics/em/ComptonProcess.hh
@@ -9,8 +9,8 @@
 
 #include "physics/base/Process.hh"
 
-#include "physics/base/ParticleParams.hh"
 #include "physics/base/ImportedProcessAdapter.hh"
+#include "physics/base/ParticleParams.hh"
 
 namespace celeritas
 {

--- a/src/physics/em/EPlusAnnihilationProcess.cc
+++ b/src/physics/em/EPlusAnnihilationProcess.cc
@@ -7,8 +7,10 @@
 //---------------------------------------------------------------------------//
 #include "EPlusAnnihilationProcess.hh"
 
+#include <memory>
 #include <utility>
 #include "EPlusGGModel.hh"
+#include "physics/grid/ValueGridBuilder.hh"
 
 namespace celeritas
 {
@@ -21,6 +23,7 @@ EPlusAnnihilationProcess::EPlusAnnihilationProcess(SPConstParticles particles)
     , positron_id_(particles_->find(pdg::positron()))
 {
     CELER_EXPECT(particles_);
+    CELER_ENSURE(positron_id_);
 }
 
 //---------------------------------------------------------------------------//
@@ -42,10 +45,10 @@ auto EPlusAnnihilationProcess::step_limits(Applicability range) const
 {
     CELER_EXPECT(range.particle == positron_id_);
 
-    // Not implemented
-    CELER_ASSERT_UNREACHABLE();
+    StepLimitBuilders builders;
+    builders[ValueGridType::macro_xs] = std::make_unique<ValueGridOTFBuilder>();
 
-    return {};
+    return builders;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/EPlusAnnihilationProcess.hh
+++ b/src/physics/em/EPlusAnnihilationProcess.hh
@@ -17,7 +17,7 @@ namespace celeritas
 /*!
  * Annihiliation process for positrons.
  */
-class EPlusAnnihilationProcess : public Process
+class EPlusAnnihilationProcess final : public Process
 {
   public:
     //!@{

--- a/src/physics/em/EPlusGGModel.cc
+++ b/src/physics/em/EPlusGGModel.cc
@@ -24,8 +24,7 @@ EPlusGGModel::EPlusGGModel(ModelId id, const ParticleParams& particles)
     interface_.gamma_id    = particles.find(pdg::gamma());
 
     CELER_VALIDATE(interface_.positron_id && interface_.gamma_id,
-                   << "missing electron, positron and/or gamma particles "
-                      "(required for "
+                   << "missing positron and/or gamma particles (required for "
                    << this->label() << ")");
     interface_.electron_mass
         = particles.get(interface_.positron_id).mass().value();

--- a/src/physics/em/GammaConversionProcess.cc
+++ b/src/physics/em/GammaConversionProcess.cc
@@ -14,11 +14,15 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct from host data.
+ * Construct from particles and imported Geant data.
  */
-GammaConversionProcess::GammaConversionProcess(SPConstParticles particles)
+GammaConversionProcess::GammaConversionProcess(SPConstParticles particles,
+                                               SPConstImported  process_data)
     : particles_(std::move(particles))
-    , positron_id_(particles_->find(pdg::positron()))
+    , imported_(process_data,
+                particles_,
+                ImportProcessClass::conversion,
+                {pdg::gamma()})
 {
     CELER_EXPECT(particles_);
 }
@@ -37,14 +41,10 @@ auto GammaConversionProcess::build_models(ModelIdGenerator next_id) const
 /*!
  * Get the interaction cross sections for the given energy range.
  */
-auto GammaConversionProcess::step_limits(Applicability range) const
+auto GammaConversionProcess::step_limits(Applicability applic) const
     -> StepLimitBuilders
 {
-    CELER_EXPECT(range.particle == particles_->find(pdg::gamma()));
-
-    // TODO
-    StepLimitBuilders builders;
-    return builders;
+    return imported_.step_limits(std::move(applic));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/GammaConversionProcess.hh
+++ b/src/physics/em/GammaConversionProcess.hh
@@ -9,13 +9,14 @@
 
 #include "physics/base/Process.hh"
 
+#include "physics/base/ImportedProcessAdapter.hh"
 #include "physics/base/ParticleParams.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Annihiliation process for photons.
+ * Conversion of gammas to electrons and positrons.
  */
 class GammaConversionProcess : public Process
 {
@@ -23,24 +24,26 @@ class GammaConversionProcess : public Process
     //!@{
     //! Type aliases
     using SPConstParticles = std::shared_ptr<const ParticleParams>;
+    using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
     //!@}
 
   public:
     // Construct from particle data
-    explicit GammaConversionProcess(SPConstParticles particles);
+    GammaConversionProcess(SPConstParticles particles,
+                           SPConstImported  process_data);
 
     // Construct the models associated with this process
     VecModel build_models(ModelIdGenerator next_id) const final;
 
     // Get the interaction cross sections for the given energy range
-    StepLimitBuilders step_limits(Applicability range) const final;
+    StepLimitBuilders step_limits(Applicability applic) const final;
 
     // Name of the process
     std::string label() const final;
 
   private:
     SPConstParticles particles_;
-    ParticleId       positron_id_;
+    ImportedProcessAdapter imported_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/grid/ValueGridBuilder.cc
+++ b/src/physics/grid/ValueGridBuilder.cc
@@ -298,4 +298,15 @@ auto ValueGridGenericBuilder::build(ValueGridInserter insert) const
 }
 
 //---------------------------------------------------------------------------//
+// ON-THE-FLY
+//---------------------------------------------------------------------------//
+/*!
+ * Always return an 'invalid' ID.
+ */
+auto ValueGridOTFBuilder::build(ValueGridInserter) const -> ValueGridId
+{
+    return {};
+}
+
+//---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/physics/grid/ValueGridBuilder.hh
+++ b/src/physics/grid/ValueGridBuilder.hh
@@ -17,6 +17,7 @@
 namespace celeritas
 {
 class ValueGridInserter;
+
 //---------------------------------------------------------------------------//
 /*!
  * Helper class for constructing on-device physics data for a single material.
@@ -154,6 +155,24 @@ class ValueGridGenericBuilder final : public ValueGridBuilder
     VecReal value_;
     Interp  grid_interp_;
     Interp  value_interp_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Special cases for indicating *only* on-the-fly cross sections.
+ *
+ * Currently this should be thrown just for processes and models specified in
+ * \c HardwiredModels as needed for EPlusAnnihilationProcess, which has *only*
+ * on-the-fly cross section calculation.
+ *
+ * This class is needed so that the process has at least one "builder"; but it
+ * always returns an invalid ValueGridId.
+ */
+class ValueGridOTFBuilder final : public ValueGridBuilder
+{
+  public:
+    // Don't construct anything
+    ValueGridId build(ValueGridInserter) const final;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -193,7 +193,7 @@ celeritas_setup_tests(SERIAL PREFIX physics/base
   LINK_LIBRARIES CeleritasPhysicsTest)
 celeritas_add_test(physics/base/CutoffParams.test.cc
   LINK_LIBRARIES Celeritas::ROOT)
-celeritas_cudaoptional_test(physics/base/Particle 
+celeritas_cudaoptional_test(physics/base/Particle
   LINK_LIBRARIES Celeritas::ROOT)
 celeritas_cudaoptional_test(physics/base/Physics)
 celeritas_add_test(physics/base/PhysicsStepUtils.test.cc)

--- a/test/base/DeviceAllocation.test.cc
+++ b/test/base/DeviceAllocation.test.cc
@@ -130,3 +130,15 @@ TEST_F(DeviceAllocationTest, TEST_IF_CELERITAS_CUDA(device))
         EXPECT_EQ(orig_ptr, other.device_pointers().data());
     }
 }
+
+TEST_F(DeviceAllocationTest, TEST_IF_CELERITAS_CUDA(empty))
+{
+    DeviceAllocation alloc{0};
+    EXPECT_TRUE(alloc.empty());
+    EXPECT_EQ(0, alloc.size());
+    EXPECT_EQ(nullptr, alloc.device_pointers().data());
+
+    std::vector<Byte> newdata(alloc.size());
+    alloc.copy_to_device(celeritas::make_span(newdata));
+    alloc.copy_to_host(celeritas::make_span(newdata));
+}

--- a/test/physics/em/BetheHeitler.test.cc
+++ b/test/physics/em/BetheHeitler.test.cc
@@ -238,27 +238,3 @@ TEST_F(BetheHeitlerInteractorTest, stress_test)
         = {18.375, 23.125, 22.75, 23.3125, 22.5625};
     EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
 }
-
-// TODO: Test all models for a given process?
-TEST_F(BetheHeitlerInteractorTest, model)
-{
-    GammaConversionProcess process(this->particle_params());
-    ModelIdGenerator       next_id;
-
-    // Construct the models associated with gamma annihilation
-    auto models = process.build_models(next_id);
-    EXPECT_EQ(1, models.size());
-
-    auto bh = models.front();
-    EXPECT_EQ(ModelId{0}, bh->model_id());
-
-    // Get the particle types and energy ranges this model applies to
-    auto set_applic = bh->applicability();
-    EXPECT_EQ(1, set_applic.size());
-
-    auto applic = *set_applic.begin();
-    EXPECT_EQ(MaterialId{}, applic.material);
-    EXPECT_EQ(ParticleId{2}, applic.particle);
-    EXPECT_EQ(celeritas::units::MevEnergy{1.5}, applic.lower);
-    EXPECT_EQ(celeritas::units::MevEnergy{1e5}, applic.upper);
-}

--- a/test/physics/em/ImportedProcesses.test.cc
+++ b/test/physics/em/ImportedProcesses.test.cc
@@ -9,11 +9,11 @@
 
 #include "physics/base/Model.hh"
 #include "physics/em/ComptonProcess.hh"
+#include "physics/em/EIonizationProcess.hh"
+#include "physics/em/EPlusAnnihilationProcess.hh"
 #include "physics/em/GammaConversionProcess.hh"
 #include "physics/em/PhotoelectricProcess.hh"
 #include "physics/em/RayleighProcess.hh"
-#include "physics/em/EPlusAnnihilationProcess.hh"
-#include "physics/em/EIonizationProcess.hh"
 #include "io/RootImporter.hh"
 #include "io/ImportData.hh"
 #include "celeritas_test.hh"
@@ -82,7 +82,7 @@ TEST_F(ImportedProcessesTest, compton)
     }
 }
 
-TEST_F(ImportedProcessesTest, eionization)
+TEST_F(ImportedProcessesTest, e_ionization)
 {
     // Create photoelectric process
     auto process = std::make_shared<EIonizationProcess>(particles_, processes_);
@@ -105,6 +105,33 @@ TEST_F(ImportedProcessesTest, eionization)
             EXPECT_TRUE(builders[VGT::macro_xs]);
             EXPECT_TRUE(builders[VGT::energy_loss]);
             EXPECT_TRUE(builders[VGT::range]);
+        }
+    }
+}
+
+TEST_F(ImportedProcessesTest, eplus_annihilation)
+{
+    // Create photoelectric process
+    auto process = std::make_shared<EPlusAnnihilationProcess>(particles_);
+
+    // Test model
+    auto models = process->build_models(ModelIdGenerator{});
+    ASSERT_EQ(1, models.size());
+    ASSERT_TRUE(models.front());
+    EXPECT_EQ("Positron annihilation (2g)", models.front()->label());
+    auto all_applic = models.front()->applicability();
+    ASSERT_EQ(2, all_applic.size());
+
+    // Test step limits
+    for (auto mat_id : range(MaterialId{materials_->num_materials()}))
+    {
+        for (auto applic : all_applic)
+        {
+            applic.material = mat_id;
+            auto builders   = process->step_limits(applic);
+            EXPECT_TRUE(builders[VGT::macro_xs]);
+            EXPECT_FALSE(builders[VGT::energy_loss]);
+            EXPECT_FALSE(builders[VGT::range]);
         }
     }
 }


### PR DESCRIPTION
The annihilation/conversion processes were basically stub files. This adds a new "value grid builder" to support the OTF-only positron annihilation process, and couples the gamma conversion to the import data.