### PR TITLE
Add positron correction for SB sampling

### DIFF
--- a/src/base/Algorithms.hh
+++ b/src/base/Algorithms.hh
@@ -7,30 +7,13 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <type_traits>
 #include "Macros.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-/*!
- * Return the lower of two values.
- */
-template<class T>
-CELER_CONSTEXPR_FUNCTION const T& min(const T& a, const T& b)
-{
-    return (b < a) ? b : a;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Return the higher of two values.
- */
-template<class T>
-CELER_CONSTEXPR_FUNCTION const T& max(const T& a, const T& b)
-{
-    return (b > a) ? b : a;
-}
-
+// Replace/extend <algorithm>
 //---------------------------------------------------------------------------//
 /*!
  * Return the value or (if it's negative) then zero.
@@ -38,42 +21,26 @@ CELER_CONSTEXPR_FUNCTION const T& max(const T& a, const T& b)
  * This is constructed to correctly propagate NaN.
  */
 template<class T>
-CELER_CONSTEXPR_FUNCTION T clamp_to_nonneg(T v)
+CELER_CONSTEXPR_FUNCTION T clamp_to_nonneg(T v) noexcept
 {
     return (v < 0) ? 0 : v;
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Return an integer power of the input value.
- *
- * Example: \code
-  assert(9.0 == ipow<2>(3.0));
-  assert(256 == ipow<8>(2));
- \endcode
- */
-template<unsigned int N, class T>
-CELER_CONSTEXPR_FUNCTION T ipow(T v)
-{
-    return (N == 0)       ? 1
-           : (N % 2 == 0) ? ipow<N / 2>(v) * ipow<N / 2>(v)
-                          : v * ipow<(N - 1) / 2>(v) * ipow<(N - 1) / 2>(v);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Find the insertion point for a value.
+ * Find the insertion point for a value in a sorted list.
  *
  * \todo Define an iterator adapter that dereferences using `__ldg` in
  * device code.
  * \todo Add a template on comparator if needed.
  * \todo Add a "lower_bound_index" that will use the native pointer difference
- * type instead of iterator arithmetic, for potential speedup on CUDA.
+ * type instead of iterator arithmetic, for potential speedup on CUDA. Or
+ * define an iterator adapter to Collections.
  */
 template<class ForwardIt, class T>
 inline CELER_FUNCTION ForwardIt lower_bound(ForwardIt first,
                                             ForwardIt last,
-                                            const T&  value)
+                                            const T&  value) noexcept
 {
     auto count = last - first;
     while (count > 0)
@@ -91,6 +58,58 @@ inline CELER_FUNCTION ForwardIt lower_bound(ForwardIt first,
         }
     }
     return first;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return the lower of two values.
+ */
+template<class T>
+CELER_CONSTEXPR_FUNCTION const T& min(const T& a, const T& b) noexcept
+{
+    return (b < a) ? b : a;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return the higher of two values.
+ */
+template<class T>
+CELER_CONSTEXPR_FUNCTION const T& max(const T& a, const T& b) noexcept
+{
+    return (b > a) ? b : a;
+}
+
+//---------------------------------------------------------------------------//
+// Replace/extend <cmath>
+//---------------------------------------------------------------------------//
+/*!
+ * Return an integer power of the input value.
+ *
+ * Example: \code
+  assert(9.0 == ipow<2>(3.0));
+  assert(256 == ipow<8>(2));
+ \endcode
+ */
+template<unsigned int N, class T>
+CELER_CONSTEXPR_FUNCTION T ipow(T v) noexcept
+{
+    return (N == 0)       ? 1
+           : (N % 2 == 0) ? ipow<N / 2>(v) * ipow<N / 2>(v)
+                          : v * ipow<(N - 1) / 2>(v) * ipow<(N - 1) / 2>(v);
+}
+
+//---------------------------------------------------------------------------//
+// Replace/extend <utility>
+//---------------------------------------------------------------------------//
+/*!
+ * Cast a value as an rvalue reference to allow move construction.
+ */
+template<class T>
+CELER_CONSTEXPR_FUNCTION auto move(T&& v) noexcept ->
+    typename std::remove_reference<T>::type&&
+{
+    return static_cast<typename std::remove_reference<T>::type&&>(v);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/SBEnergyDistHelper.hh
+++ b/src/physics/em/detail/SBEnergyDistHelper.hh
@@ -1,0 +1,110 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file SBEnergyDistHelper.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "physics/base/Units.hh"
+#include "physics/grid/TwodSubgridCalculator.hh"
+#include "random/distributions/ReciprocalDistribution.hh"
+#include "SeltzerBerger.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Help sample exiting photon energy from Bremsstrahlung.
+ *
+ * This class simply preprocesses the input data needed for the
+ * SBEnergyDistribution, which is templated on a dynamic cross section
+ * correction factor.
+ *
+ * The cross section units are immaterial since the cross section merely acts
+ * as a shape function for rejection: the sampled energy's cross section is
+ * always divided by the maximium cross section.
+ *
+ * Note that the *energy* of the maximum cross section is only needed for the
+ * cross section scaling function used to correct the exiting energy
+ * distribution for positrons.
+ */
+class SBEnergyDistHelper
+{
+  public:
+    //!@{
+    //! Type aliases
+    using SBData
+        = SeltzerBergerData<Ownership::const_reference, MemSpace::native>;
+    using Xs       = Quantity<SBElementTableData::XsUnits>;
+    using Energy   = units::MevEnergy;
+    using EnergySq = Quantity<UnitProduct<units::Mev, units::Mev>>;
+    //!@}
+
+  public:
+    // Construct from data
+    inline CELER_FUNCTION SBEnergyDistHelper(const SBData& data,
+                                             Energy        inc_energy,
+                                             ElementId     element,
+                                             EnergySq      density_correction,
+                                             Energy        min_gamma_energy);
+
+    // Sample scaled energy (analytic component of exiting distribution)
+    template<class Engine>
+    inline CELER_FUNCTION Energy sample_exit_energy(Engine& rng) const;
+
+    // Calculate tabulated cross section for a given energy
+    inline CELER_FUNCTION Xs calc_xs(Energy energy) const;
+
+    //! Energy of maximum cross section
+    CELER_FUNCTION Energy max_xs_energy() const
+    {
+        return Energy{max_xs_.energy};
+    }
+
+    //! Maximum cross section calculated for rejection
+    CELER_FUNCTION Xs max_xs() const { return Xs{max_xs_.xs}; }
+
+  private:
+    //// IMPLEMENTATION TYPES ////
+
+    using SBTables
+        = SeltzerBergerTableData<Ownership::const_reference, MemSpace::native>;
+    using ReciprocalSampler = ReciprocalDistribution<real_type>;
+
+    struct MaxXs
+    {
+        real_type energy;
+        real_type xs;
+    };
+
+    //// IMPLEMENTATION DATA ////
+
+    const TwodSubgridCalculator calc_xs_;
+    const MaxXs                 max_xs_;
+
+    const real_type         inv_inc_energy_;
+    const real_type   dens_corr_;
+    const ReciprocalSampler sample_exit_esq_;
+
+    //// CONSTRUCTION HELPER FUNCTIONS ////
+
+    inline CELER_FUNCTION TwodSubgridCalculator make_xs_calc(
+        const SBTables&, real_type inc_energy, ElementId element) const;
+
+    inline CELER_FUNCTION MaxXs calc_max_xs(const SBTables& xs_params,
+                                            real_type       inc_energy,
+                                            ElementId       element) const;
+
+    inline CELER_FUNCTION ReciprocalSampler
+    make_esq_sampler(real_type inc_energy, real_type min_gamma_energy) const;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas
+
+#include "SBEnergyDistHelper.i.hh"

--- a/src/physics/em/detail/SBEnergyDistHelper.hh
+++ b/src/physics/em/detail/SBEnergyDistHelper.hh
@@ -87,7 +87,7 @@ class SBEnergyDistHelper
     const MaxXs                 max_xs_;
 
     const real_type         inv_inc_energy_;
-    const real_type   dens_corr_;
+    const real_type         dens_corr_;
     const ReciprocalSampler sample_exit_esq_;
 
     //// CONSTRUCTION HELPER FUNCTIONS ////

--- a/src/physics/em/detail/SBEnergyDistHelper.i.hh
+++ b/src/physics/em/detail/SBEnergyDistHelper.i.hh
@@ -1,0 +1,174 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file SBEnergyDistHelper.i.hh
+//---------------------------------------------------------------------------//
+#include <cmath>
+
+#include "base/Algorithms.hh"
+#include "physics/grid/TwodGridCalculator.hh"
+#include "random/distributions/ReciprocalDistribution.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from incident particle and energy.
+ *
+ * The incident energy *must* be within the bounds of the SB table data, so the
+ * Model's applicability must be consistent with the table data.
+ */
+CELER_FUNCTION
+SBEnergyDistHelper::SBEnergyDistHelper(const SBData& data,
+                                       Energy        inc_energy,
+                                       ElementId     element,
+                                       EnergySq      density_correction,
+                                       Energy        min_gamma_energy)
+    : calc_xs_{this->make_xs_calc(
+        data.differential_xs, inc_energy.value(), element)}
+    , max_xs_{this->calc_max_xs(
+          data.differential_xs, inc_energy.value(), element)}
+    , inv_inc_energy_(1 / inc_energy.value())
+    , dens_corr_(density_correction.value())
+    , sample_exit_esq_{
+          this->make_esq_sampler(inc_energy.value(), min_gamma_energy.value())}
+{
+    CELER_EXPECT(inc_energy > min_gamma_energy);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample an exit energy on a scaled and adjusted reciprocal distribution.
+ */
+template<class Engine>
+CELER_FUNCTION auto SBEnergyDistHelper::sample_exit_energy(Engine& rng) const
+    -> Energy
+{
+    // Sample scaled energy and subtract correction factor
+    real_type esq = sample_exit_esq_(rng) - dens_corr_;
+    CELER_ASSERT(esq >= 0);
+    return Energy{std::sqrt(esq)};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate tabulated cross section for a given energy.
+ */
+CELER_FUNCTION auto SBEnergyDistHelper::calc_xs(Energy e) const -> Xs
+{
+    CELER_EXPECT(e > zero_quantity());
+    // Interpolate the differential cross setion at the given exit energy
+    return Xs{calc_xs_(e.value() * inv_inc_energy_)};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct the differential cross section calculator for exit energy.
+ */
+CELER_FUNCTION TwodSubgridCalculator SBEnergyDistHelper::make_xs_calc(
+    const SBTables& xs_params, real_type inc_energy, ElementId element) const
+{
+    CELER_EXPECT(element < xs_params.elements.size());
+    CELER_EXPECT(inc_energy > 0);
+
+    const TwodGridData& grid = xs_params.elements[element].grid;
+    CELER_ASSERT(inc_energy >= std::exp(xs_params.reals[grid.x.front()])
+                 && inc_energy < std::exp(xs_params.reals[grid.x.back()]));
+
+    static_assert(
+        std::is_same<Energy::unit_type, units::Mev>::value
+            && std::is_same<SBElementTableData::EnergyUnits, units::LogMev>::value,
+        "Inconsistent energy units");
+    return TwodGridCalculator(grid, xs_params.reals)(std::log(inc_energy));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate a bounding maximum of the differential cross section.
+ *
+ * This interpolates the maximum cross section for the given incident energy
+ * by using the pre-calculated cross section maxima. The interpolated value is
+ * typically exactly the
+ * maximum (since the two \em y points are usually adjacent, and therefore the
+ * linear interpolation between them is exact) but at worst (e.g. for the
+ * double-peaked function of brems at lower energies) an upper bound which can
+ * be proven by the triangle inequality.
+ *
+ * The corresponding exiting energy is only needed for cross section scaling
+ * (an adjustment needed for the positron emission spectrum). determined by
+ * linearly interpolating along the "x" axis (which
+ * is a nonuniform grid in log-energy space).
+ *
+ * \note This is called during construction, so \c calc_xs_ must be initialized
+ * before whatever calls this.
+ */
+CELER_FUNCTION auto SBEnergyDistHelper::calc_max_xs(const SBTables& xs_params,
+                                                    real_type       inc_energy,
+                                                    ElementId element) const
+    -> MaxXs
+{
+    CELER_EXPECT(element);
+    const SBElementTableData& el = xs_params.elements[element];
+
+    const size_type x_idx  = calc_xs_.x_index();
+    const real_type x_frac = calc_xs_.x_fraction();
+    MaxXs           result;
+
+    // Calc xs
+    {
+        auto get_value = [&xs_params, &el](size_type ix) -> real_type {
+            // Index of the largest xs for exiting energy for the given
+            // incident grid point
+            size_type iy = xs_params.sizes[el.argmax[ix]];
+            // Value of the maximum cross section
+            return xs_params.reals[el.grid.at(ix, iy)];
+        };
+
+        result.xs = (1 - x_frac) * get_value(x_idx)
+                    + x_frac * get_value(x_idx + 1);
+    }
+
+    // Calc energy
+    {
+        // The 'y' grid is fractional exiting energy
+        const NonuniformGrid<real_type> ee_grid{el.grid.y, xs_params.reals};
+
+        auto get_value = [&xs_params, &el, &ee_grid](size_type ix) -> real_type {
+            // Index of the largest xs for exiting energy for the given
+            // incident grid point
+            size_type iy = xs_params.sizes[el.argmax[ix]];
+            // Value of the exiting energy grid
+            return ee_grid[iy];
+        };
+
+        real_type efrac = (1 - x_frac) * get_value(x_idx)
+                          + x_frac * get_value(x_idx + 1);
+        result.energy = efrac * inc_energy;
+    }
+
+    CELER_ENSURE(result.xs > 0);
+    CELER_ENSURE(result.energy > 0);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a sampler for scaled exiting energy.
+ */
+CELER_FUNCTION auto
+SBEnergyDistHelper::make_esq_sampler(real_type inc_energy,
+                                     real_type min_gamma_energy) const
+    -> ReciprocalSampler
+{
+    CELER_EXPECT(min_gamma_energy > 0);
+    return ReciprocalSampler(ipow<2>(min_gamma_energy) + dens_corr_,
+                             ipow<2>(inc_energy) + dens_corr_);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/physics/em/detail/SBEnergyDistribution.i.hh
+++ b/src/physics/em/detail/SBEnergyDistribution.i.hh
@@ -8,9 +8,7 @@
 #include <cmath>
 
 #include "base/Algorithms.hh"
-#include "physics/grid/TwodGridCalculator.hh"
 #include "random/distributions/BernoulliDistribution.hh"
-#include "random/distributions/ReciprocalDistribution.hh"
 
 namespace celeritas
 {
@@ -23,120 +21,41 @@ namespace detail
  * The incident energy *must* be within the bounds of the SB table data, so the
  * Model's applicability must be consistent with the table data.
  */
+template<class X>
 CELER_FUNCTION
-SBEnergyDistribution::SBEnergyDistribution(const SBData& data,
-                                           Energy        inc_energy,
-                                           ElementId     element,
-                                           EnergySq      density_correction,
-                                           Energy        min_gamma_energy)
-    : inc_energy_{inc_energy.value()}
-    , calc_xs_{this->make_xs_calc(data.differential_xs, element)}
-    , inv_max_xs_{1 / this->calc_max_xs(data.differential_xs, element)}
-    , dens_corr_(density_correction.value())
-    , sample_exit_esq_{this->make_esq_sampler(min_gamma_energy.value())}
+SBEnergyDistribution<X>::SBEnergyDistribution(const SBEnergyDistHelper& helper,
+                                              X scale_xs)
+    : helper_(helper)
+    , inv_max_xs_{1
+                  / (helper.max_xs().value() * scale_xs(helper.max_xs_energy()))}
+    , scale_xs_(move(scale_xs))
 {
-    CELER_EXPECT(inc_energy > min_gamma_energy);
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Sample the exiting energy by doing a table lookup and rejection.
  */
+template<class X>
 template<class Engine>
-CELER_FUNCTION auto SBEnergyDistribution::operator()(Engine& rng) -> Energy
+CELER_FUNCTION auto SBEnergyDistribution<X>::operator()(Engine& rng) -> Energy
 {
-    const real_type inv_inc_energy = 1 / inc_energy_;
-
     // Sampled energy
-    real_type exit_energy{};
+    Energy exit_energy;
     // Calculated cross section used inside rejection sampling
     real_type xs{};
     do
     {
         // Sample scaled energy and subtract correction factor
-        real_type esq = sample_exit_esq_(rng) - dens_corr_;
-        CELER_ASSERT(esq >= 0);
-        exit_energy = std::sqrt(esq);
+        exit_energy = helper_.sample_exit_energy(rng);
 
         // Interpolate the differential cross setion at the sampled exit energy
-        xs = calc_xs_(exit_energy * inv_inc_energy);
+        xs = helper_.calc_xs(exit_energy).value() * scale_xs_(exit_energy);
         CELER_ASSERT(xs >= 0 && xs <= 1 / inv_max_xs_);
     } while (!BernoulliDistribution(xs * inv_max_xs_)(rng));
-    return Energy{exit_energy};
+    return exit_energy;
 }
 
-//---------------------------------------------------------------------------//
-/*!
- * Construct the differential cross section calculator for exit energy.
- *
- * Note that this is done during construction so the initialization order for
- * member variables really matters!!
- */
-CELER_FUNCTION TwodSubgridCalculator SBEnergyDistribution::make_xs_calc(
-    const SBTables& xs_params, ElementId element) const
-{
-    CELER_EXPECT(element < xs_params.elements.size());
-    CELER_EXPECT(inc_energy_ > 0);
-
-    const TwodGridData& grid = xs_params.elements[element].grid;
-    CELER_ASSERT(inc_energy_ >= std::exp(xs_params.reals[grid.x.front()])
-                 && inc_energy_ < std::exp(xs_params.reals[grid.x.back()]));
-
-    static_assert(
-        std::is_same<Energy::unit_type, units::Mev>::value
-            && std::is_same<SBElementTableData::EnergyUnits, units::LogMev>::value,
-        "Inconsistent energy units");
-    return TwodGridCalculator(grid, xs_params.reals)(std::log(inc_energy_));
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Calculate a bounding maximum of the differential cross section.
- *
- * This interpolates the maximum cross section for the given incident energy
- * by using the pre-calculated cross section maxima. The interpolated value is
- * typically exactly the
- * maximum (since the two \em y points are usually adjacent, and therefore the
- * linear interpolation between them is exact) but at worst (e.g. for the
- * double-peaked function of brems at lower energies) an upper bound which can
- * be proven by the triangle inequality.
- */
-CELER_FUNCTION real_type SBEnergyDistribution::calc_max_xs(
-    const SBTables& xs_params, ElementId element) const
-{
-    CELER_EXPECT(element);
-    const SBElementTableData& el = xs_params.elements[element];
-
-    auto get_value = [&xs_params, &el](size_type ix) -> real_type {
-        // Index of the largest xs for exiting energy for the given incident
-        // grid point
-        size_type iy = xs_params.sizes[el.argmax[ix]];
-        // Value of the maximum cross section
-        return xs_params.reals[el.grid.at(ix, iy)];
-    };
-
-    const size_type x_idx  = calc_xs_.x_index();
-    const real_type x_frac = calc_xs_.x_fraction();
-
-    real_type xs_max = (1 - x_frac) * get_value(x_idx)
-                       + x_frac * get_value(x_idx + 1);
-
-    CELER_ENSURE(xs_max > 0);
-    return xs_max;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct a sampler for scaled exiting energy.
- */
-CELER_FUNCTION auto
-SBEnergyDistribution::make_esq_sampler(real_type min_gamma_energy) const
-    -> ReciprocalSampler
-{
-    CELER_EXPECT(min_gamma_energy > 0);
-    return ReciprocalSampler(ipow<2>(min_gamma_energy) + dens_corr_,
-                             ipow<2>(inc_energy_) + dens_corr_);
-}
 
 //---------------------------------------------------------------------------//
 } // namespace detail

--- a/src/physics/em/detail/SBEnergyDistribution.i.hh
+++ b/src/physics/em/detail/SBEnergyDistribution.i.hh
@@ -56,7 +56,6 @@ CELER_FUNCTION auto SBEnergyDistribution<X>::operator()(Engine& rng) -> Energy
     return exit_energy;
 }
 
-
 //---------------------------------------------------------------------------//
 } // namespace detail
 } // namespace celeritas

--- a/src/physics/em/detail/SeltzerBerger.cu
+++ b/src/physics/em/detail/SeltzerBerger.cu
@@ -55,7 +55,7 @@ __global__ void seltzer_berger_interact_kernel(
         return;
 
     // Assume only a single element in the material, for now
-    MaterialView    material_view = material.material_view();
+    MaterialView material_view = material.material_view();
     CELER_ASSERT(material_view.num_elements() == 1);
     const ElementComponentId selected_element{0};
 

--- a/src/physics/em/detail/SeltzerBerger.cu
+++ b/src/physics/em/detail/SeltzerBerger.cu
@@ -57,7 +57,7 @@ __global__ void seltzer_berger_interact_kernel(
     // Assume only a single element in the material, for now
     MaterialView    material_view = material.material_view();
     CELER_ASSERT(material_view.num_elements() == 1);
-    const ElementId element_id{0};
+    const ElementComponentId selected_element{0};
 
     CutoffView cutoffs(interaction.params.cutoffs, material.material_id());
     StackAllocator<Secondary> allocate_secondaries(
@@ -68,7 +68,7 @@ __global__ void seltzer_berger_interact_kernel(
                                      cutoffs,
                                      allocate_secondaries,
                                      material_view,
-                                     element_id);
+                                     selected_element);
 
     RngEngine rng(interaction.states.rng, tid);
     interaction.states.interactions[tid] = interact(rng);

--- a/src/physics/em/detail/SeltzerBergerInteractor.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.hh
@@ -58,7 +58,7 @@ class SeltzerBergerInteractor
                             const CutoffView&             cutoffs,
                             StackAllocator<Secondary>&    allocate,
                             const MaterialView&           material,
-                            const ElementId&              element_id);
+                            const ElementComponentId&     elcomp_id);
 
     // Sample an interaction with the given RNG
     template<class Engine>
@@ -67,14 +67,14 @@ class SeltzerBergerInteractor
   private:
     // Device (host CPU or GPU device) references
     const SeltzerBergerNativeRef& shared_;
-    // Type of particle
-    const ParticleId particle_id_;
     // Incident particle energy
     const Energy inc_energy_;
     // Incident particle direction
     const Momentum inc_momentum_;
     // Incident particle direction
     const Real3& inc_direction_;
+    // Incident particle flag for selecting XS correction factor
+    const bool inc_particle_is_electron_;
     // Interactor thresholds
     const CutoffView& cutoffs_;
     // Allocate space for a secondary particle
@@ -82,7 +82,7 @@ class SeltzerBergerInteractor
     // Material in which interaction occurs
     const MaterialView& material_;
     // Element in which interaction occurs
-    const ElementId& element_id_;
+    const ElementComponentId& elcomp_id_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/SeltzerBergerInteractor.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.hh
@@ -82,7 +82,7 @@ class SeltzerBergerInteractor
     // Material in which interaction occurs
     const MaterialView& material_;
     // Element in which interaction occurs
-    const ElementComponentId& elcomp_id_;
+    const ElementComponentId elcomp_id_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/SeltzerBergerInteractor.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.hh
@@ -75,8 +75,8 @@ class SeltzerBergerInteractor
     const Real3& inc_direction_;
     // Incident particle flag for selecting XS correction factor
     const bool inc_particle_is_electron_;
-    // Interactor thresholds
-    const CutoffView& cutoffs_;
+    // Production cutoff for gammas
+    const Energy gamma_cutoff_;
     // Allocate space for a secondary particle
     StackAllocator<Secondary>& allocate_;
     // Material in which interaction occurs

--- a/src/physics/em/detail/SeltzerBergerInteractor.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.hh
@@ -8,18 +8,16 @@
 #pragma once
 
 #include "base/Macros.hh"
+#include "base/StackAllocator.hh"
 #include "base/Types.hh"
 #include "physics/base/CutoffView.hh"
 #include "physics/base/Interaction.hh"
 #include "physics/base/ParticleTrackView.hh"
 #include "physics/base/Secondary.hh"
-#include "base/StackAllocator.hh"
 #include "physics/base/Units.hh"
 #include "physics/material/ElementView.hh"
 #include "physics/material/MaterialView.hh"
 #include "SeltzerBerger.hh"
-#include "SBEnergyDistribution.hh"
-#include "SBPositronXsCorrector.hh"
 
 namespace celeritas
 {
@@ -48,7 +46,6 @@ class SeltzerBergerInteractor
     //!@{
     //! Type aliases
     using Energy   = units::MevEnergy;
-    using EnergySq = SBEnergyDistribution::EnergySq;
     using Momentum = units::MevMomentum;
     //!@}
 

--- a/src/physics/em/detail/SeltzerBergerInteractor.i.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.i.hh
@@ -38,7 +38,7 @@ SeltzerBergerInteractor::SeltzerBergerInteractor(
     , inc_momentum_(particle.momentum())
     , inc_direction_(inc_direction)
     , inc_particle_is_electron_(particle.particle_id() == shared_.ids.electron)
-    , gamma_cutoff_(cutoffs_.energy(shared_.ids.gamma))
+    , gamma_cutoff_(cutoffs.energy(shared.ids.gamma))
     , allocate_(allocate)
     , material_(material)
     , elcomp_id_(elcomp_id)

--- a/src/physics/em/detail/SeltzerBergerInteractor.i.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.i.hh
@@ -38,7 +38,7 @@ SeltzerBergerInteractor::SeltzerBergerInteractor(
     , inc_momentum_(particle.momentum())
     , inc_direction_(inc_direction)
     , inc_particle_is_electron_(particle.particle_id() == shared_.ids.electron)
-    , cutoffs_(cutoffs)
+    , gamma_cutoff_(cutoffs_.energy(shared_.ids.gamma))
     , allocate_(allocate)
     , material_(material)
     , elcomp_id_(elcomp_id)
@@ -56,11 +56,10 @@ SeltzerBergerInteractor::SeltzerBergerInteractor(
 template<class Engine>
 CELER_FUNCTION Interaction SeltzerBergerInteractor::operator()(Engine& rng)
 {
-    const Energy gamma_cutoff = cutoffs_.energy(shared_.ids.gamma);
     // Check if secondary can be produced. If not, this interaction cannot
     // happen and the incident particle must undergo an energy loss process
     // instead.
-    if (gamma_cutoff > inc_energy_)
+    if (gamma_cutoff_ > inc_energy_)
     {
         return Interaction::from_unchanged(inc_energy_, inc_direction_);
     }
@@ -91,7 +90,7 @@ CELER_FUNCTION Interaction SeltzerBergerInteractor::operator()(Engine& rng)
             inc_energy_,
             material_.element_id(elcomp_id_),
             SBEnergyDistHelper::EnergySq{density_correction},
-            gamma_cutoff);
+            gamma_cutoff_);
 
         if (inc_particle_is_electron_)
         {
@@ -105,8 +104,8 @@ CELER_FUNCTION Interaction SeltzerBergerInteractor::operator()(Engine& rng)
             SBEnergyDistribution<SBPositronXsCorrector> sample_gamma_energy(
                 sb_helper,
                 {shared_.electron_mass,
-                 material_.element_view(ElementComponentId{0}),
-                 gamma_cutoff,
+                 material_.element_view(elcomp_id_),
+                 gamma_cutoff_,
                  inc_energy_});
             gamma_exit_energy = sample_gamma_energy(rng);
         }

--- a/src/physics/em/detail/SeltzerBergerInteractor.i.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.i.hh
@@ -8,8 +8,10 @@
 
 #include "base/ArrayUtils.hh"
 #include "base/Constants.hh"
-#include "TsaiUrbanDistribution.hh"
 #include "random/distributions/UniformRealDistribution.hh"
+#include "SBEnergyDistribution.hh"
+#include "SBPositronXsCorrector.hh"
+#include "TsaiUrbanDistribution.hh"
 
 namespace celeritas
 {
@@ -78,6 +80,7 @@ CELER_FUNCTION Interaction SeltzerBergerInteractor::operator()(Engine& rng)
     real_type density_correction = density_factor * ipow<2>(total_energy_val);
 
     // Outgoing photon secondary energy sampler
+    using EnergySq = SBEnergyDistribution::EnergySq;
     SBEnergyDistribution sample_gamma_energy(
         shared_,
         inc_energy_,

--- a/src/physics/em/detail/SeltzerBergerInteractor.i.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.i.hh
@@ -9,6 +9,7 @@
 #include "base/ArrayUtils.hh"
 #include "base/Constants.hh"
 #include "random/distributions/UniformRealDistribution.hh"
+#include "SBEnergyDistHelper.hh"
 #include "SBEnergyDistribution.hh"
 #include "SBPositronXsCorrector.hh"
 #include "TsaiUrbanDistribution.hh"
@@ -31,19 +32,19 @@ SeltzerBergerInteractor::SeltzerBergerInteractor(
     const CutoffView&             cutoffs,
     StackAllocator<Secondary>&    allocate,
     const MaterialView&           material,
-    const ElementId&              element_id)
+    const ElementComponentId&     elcomp_id)
     : shared_(shared)
-    , particle_id_(particle.particle_id())
     , inc_energy_(particle.energy())
     , inc_momentum_(particle.momentum())
     , inc_direction_(inc_direction)
+    , inc_particle_is_electron_(particle.particle_id() == shared_.ids.electron)
     , cutoffs_(cutoffs)
     , allocate_(allocate)
     , material_(material)
-    , element_id_(element_id)
+    , elcomp_id_(elcomp_id)
 {
-    CELER_EXPECT(particle_id_ == shared_.ids.electron
-                 || particle_id_ == shared_.ids.positron);
+    CELER_EXPECT(particle.particle_id() == shared_.ids.electron
+                 || particle.particle_id() == shared_.ids.positron);
 }
 
 //---------------------------------------------------------------------------//
@@ -55,10 +56,11 @@ SeltzerBergerInteractor::SeltzerBergerInteractor(
 template<class Engine>
 CELER_FUNCTION Interaction SeltzerBergerInteractor::operator()(Engine& rng)
 {
+    const Energy gamma_cutoff = cutoffs_.energy(shared_.ids.gamma);
     // Check if secondary can be produced. If not, this interaction cannot
     // happen and the incident particle must undergo an energy loss process
     // instead.
-    if (cutoffs_.energy(shared_.ids.gamma).value() > inc_energy_.value())
+    if (gamma_cutoff > inc_energy_)
     {
         return Interaction::from_unchanged(inc_energy_, inc_direction_);
     }
@@ -80,25 +82,34 @@ CELER_FUNCTION Interaction SeltzerBergerInteractor::operator()(Engine& rng)
     real_type density_correction = density_factor * ipow<2>(total_energy_val);
 
     // Outgoing photon secondary energy sampler
-    using EnergySq = SBEnergyDistribution::EnergySq;
-    SBEnergyDistribution sample_gamma_energy(
-        shared_,
-        inc_energy_,
-        element_id_,
-        EnergySq{density_correction},
-        cutoffs_.energy(shared_.ids.gamma));
-    Energy gamma_exit_energy = sample_gamma_energy(rng);
-
-    // Cross-section scaling for positrons
-    if (particle_id_ == shared_.ids.positron)
+    Energy gamma_exit_energy;
     {
-        SBPositronXsCorrector scale_xs(
-            shared_.electron_mass,
-            material_.element_view(ElementComponentId{0}),
-            cutoffs_.energy(shared_.ids.gamma),
-            inc_energy_);
-        /// TODO: integrate XSCorrector into energy distribution sampler
-        /// For now, just keep gamma energy unmodified (i.e. do nothing).
+        // Helper class preprocesses cross section bounds and calculates
+        // distribution
+        SBEnergyDistHelper sb_helper(
+            shared_,
+            inc_energy_,
+            material_.element_id(elcomp_id_),
+            SBEnergyDistHelper::EnergySq{density_correction},
+            gamma_cutoff);
+
+        if (inc_particle_is_electron_)
+        {
+            // Rejection sample without modifying cross section
+            SBEnergyDistribution<SBElectronXsCorrector> sample_gamma_energy(
+                sb_helper, {});
+            gamma_exit_energy = sample_gamma_energy(rng);
+        }
+        else
+        {
+            SBEnergyDistribution<SBPositronXsCorrector> sample_gamma_energy(
+                sb_helper,
+                {shared_.electron_mass,
+                 material_.element_view(ElementComponentId{0}),
+                 gamma_cutoff,
+                 inc_energy_});
+            gamma_exit_energy = sample_gamma_energy(rng);
+        }
     }
 
     // Construct interaction for change to parent (incoming) particle

--- a/src/random/distributions/ReciprocalDistribution.hh
+++ b/src/random/distributions/ReciprocalDistribution.hh
@@ -46,7 +46,7 @@ class ReciprocalDistribution
 
     // Sample a random number according to the distribution
     template<class Generator>
-    inline CELER_FUNCTION result_type operator()(Generator& rng);
+    inline CELER_FUNCTION result_type operator()(Generator& rng) const;
 
   private:
     RealType a_;

--- a/src/random/distributions/ReciprocalDistribution.i.hh
+++ b/src/random/distributions/ReciprocalDistribution.i.hh
@@ -53,7 +53,8 @@ ReciprocalDistribution<RealType>::ReciprocalDistribution(real_type a,
 template<class RealType>
 template<class Generator>
 CELER_FUNCTION auto
-ReciprocalDistribution<RealType>::operator()(Generator& rng) -> result_type
+ReciprocalDistribution<RealType>::operator()(Generator& rng) const
+    -> result_type
 {
     return a_ * std::exp(logratio_ * generate_canonical<RealType>(rng));
 }

--- a/test/physics/em/SeltzerBerger.test.cc
+++ b/test/physics/em/SeltzerBerger.test.cc
@@ -304,8 +304,8 @@ TEST_F(SeltzerBergerTest, basic)
     this->resize_secondaries(num_samples);
 
     // Production cuts
-    const MaterialView& material_view = this->material_track().material_view();
-    auto                cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto material_view = this->material_track().material_view();
+    auto cutoffs       = this->cutoff_params()->get(MaterialId{0});
 
     // Create the interactor
     SeltzerBergerInteractor interact(model_->host_pointers(),
@@ -367,9 +367,9 @@ TEST_F(SeltzerBergerTest, stress_test)
     const int           num_samples = 1e4;
     std::vector<double> avg_engine_samples;
 
-    // Production cuts
-    auto                cutoffs = this->cutoff_params()->get(MaterialId{0});
-    const MaterialView& material_view = this->material_track().material_view();
+    // Views
+    auto cutoffs       = this->cutoff_params()->get(MaterialId{0});
+    auto material_view = this->material_track().material_view();
 
     // Loop over a set of incident gamma energies
     for (auto particle : {pdg::electron(), pdg::positron()})

--- a/test/physics/em/SeltzerBerger.test.cc
+++ b/test/physics/em/SeltzerBerger.test.cc
@@ -23,10 +23,13 @@
 #include "../InteractorHostTestBase.hh"
 #include "../InteractionIO.hh"
 
+using celeritas::ElementComponentId;
 using celeritas::ElementId;
 using celeritas::ElementView;
 using celeritas::SeltzerBergerModel;
 using celeritas::SeltzerBergerReader;
+using celeritas::detail::SBElectronXsCorrector;
+using celeritas::detail::SBEnergyDistHelper;
 using celeritas::detail::SBEnergyDistribution;
 using celeritas::detail::SBPositronXsCorrector;
 using celeritas::detail::SeltzerBergerInteractor;
@@ -36,7 +39,7 @@ namespace constants = celeritas::constants;
 namespace pdg       = celeritas::pdg;
 
 using Energy   = celeritas::units::MevEnergy;
-using EnergySq = SBEnergyDistribution::EnergySq;
+using EnergySq = SBEnergyDistHelper::EnergySq;
 
 //---------------------------------------------------------------------------//
 // TEST HARNESS
@@ -193,29 +196,13 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
 
     const int           num_samples = 8192;
     std::vector<double> max_xs;
+    std::vector<double> max_xs_energy;
     std::vector<double> avg_exit_frac;
     std::vector<double> avg_engine_samples;
 
-    // Note: the first point has a very low cross section compared to
-    // ionization so won't be encountered in practice. The differential cross
-    // section distribution is much flatter there, so there should be lower
-    // rejection. The second point is where the maximum of the differential SB
-    // data switches between a high-exit-energy peak and a low-exit-energy
-    // peak, which should result in a higher rejection rate. The remaining
-    // points are arbitrary.
-    for (real_type inc_energy : {0.001, 0.0045, 0.567, 7.89, 89.0, 901.})
-    {
-        SBEnergyDistribution sample_energy(
-            model_->host_pointers(),
-            Energy{inc_energy},
-            ElementId{0},
-            this->density_correction(MaterialId{0}, Energy{inc_energy}),
-            gamma_cutoff);
-        max_xs.push_back(sample_energy.max_xs());
-        double total_exit_energy = 0;
-
-        // Loop over many particles
-        RandomEngine& rng_engine = this->rng();
+    auto sample_many = [&](real_type inc_energy, auto& sample_energy) {
+        double        total_exit_energy = 0;
+        RandomEngine& rng_engine        = this->rng();
         for (int i = 0; i < num_samples; ++i)
         {
             Energy exit_gamma = sample_energy(rng_engine);
@@ -226,18 +213,84 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
 
         avg_exit_frac.push_back(total_exit_energy / (num_samples * inc_energy));
         avg_engine_samples.push_back(double(rng_engine.count()) / num_samples);
+    };
+
+    // Note: the first point has a very low cross section compared to
+    // ionization so won't be encountered in practice. The differential cross
+    // section distribution is much flatter there, so there should be lower
+    // rejection. The second point is where the maximum of the differential SB
+    // data switches between a high-exit-energy peak and a low-exit-energy
+    // peak, which should result in a higher rejection rate. The remaining
+    // points are arbitrary.
+    for (real_type inc_energy : {0.001, 0.0045, 0.567, 7.89, 89.0, 901.})
+    {
+        SBEnergyDistHelper edist_helper(
+            model_->host_pointers(),
+            Energy{inc_energy},
+            ElementId{0},
+            this->density_correction(MaterialId{0}, Energy{inc_energy}),
+            gamma_cutoff);
+        max_xs.push_back(edist_helper.max_xs().value());
+        max_xs_energy.push_back(edist_helper.max_xs_energy().value());
+
+        SBEnergyDistribution<SBElectronXsCorrector> sample_energy(edist_helper,
+                                                                  {});
+        // Loop over many particles
+        sample_many(inc_energy, sample_energy);
+    }
+
+    {
+        real_type inc_energy = 7.89;
+
+        SBEnergyDistHelper edist_helper(
+            model_->host_pointers(),
+            Energy{inc_energy},
+            ElementId{0},
+            this->density_correction(MaterialId{0}, Energy{inc_energy}),
+            gamma_cutoff);
+
+        // Sample with a "correction" that's constant, which shouldn't change
+        // sampling efficiency or expected value correction
+        {
+            auto scale_xs = [](Energy) { return 2.0; };
+            SBEnergyDistribution<decltype(scale_xs)> sample_energy(
+                edist_helper, scale_xs);
+
+            // Loop over many particles
+            sample_many(inc_energy, sample_energy);
+        }
+
+        // Sample with the positron XS correction
+        {
+            const ParticleParams& pp = *this->particle_params();
+
+            SBEnergyDistribution<SBPositronXsCorrector> sample_energy(
+                edist_helper,
+                {pp.get(pp.find(pdg::positron())).mass(),
+                 this->material_params()->get(ElementId{0}),
+                 gamma_cutoff,
+                 Energy{inc_energy}});
+
+            // Loop over many particles
+            sample_many(inc_energy, sample_energy);
+        }
     }
 
     // clang-format off
     const double expected_max_xs[] = {2.866525852195, 4.72696244794,
         12.18911946078, 13.93366489719, 13.85758694967, 13.3353235437};
+    const double expected_max_xs_energy[] = {0.001, 0.002718394312008,
+        5.67e-13, 7.89e-12, 8.9e-11, 9.01e-10};
     const double expected_avg_exit_frac[] = {0.9491159324044, 0.4974867596411,
-        0.08235370866815, 0.0719988569368, 0.08780979490539, 0.1003040929175};
+        0.08235370866815, 0.0719988569368, 0.08780979490539, 0.1003040929175,
+        0.0728392571092988, 0.0693741457539784};
     const double expected_avg_engine_samples[] = {4.0791015625, 4.06005859375,
-        5.13916015625, 4.71923828125, 4.48486328125, 4.40869140625};
+        5.13916015625, 4.71923828125, 4.48486328125, 4.40869140625,
+        4.728515625, 4.7353515625};
     // clang-format on
 
     EXPECT_VEC_SOFT_EQ(expected_max_xs, max_xs);
+    EXPECT_VEC_SOFT_EQ(expected_max_xs_energy, max_xs_energy);
     EXPECT_VEC_SOFT_EQ(expected_avg_exit_frac, avg_exit_frac);
     EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
 }
@@ -250,12 +303,9 @@ TEST_F(SeltzerBergerTest, basic)
     const int num_samples = 4;
     this->resize_secondaries(num_samples);
 
-    // Sampled element
-    const ElementId element{0};
-
     // Production cuts
-    auto                cutoffs = this->cutoff_params()->get(MaterialId{0});
     const MaterialView& material_view = this->material_track().material_view();
+    auto                cutoffs = this->cutoff_params()->get(MaterialId{0});
 
     // Create the interactor
     SeltzerBergerInteractor interact(model_->host_pointers(),
@@ -264,7 +314,7 @@ TEST_F(SeltzerBergerTest, basic)
                                      cutoffs,
                                      this->secondary_allocator(),
                                      material_view,
-                                     element);
+                                     ElementComponentId{0});
     RandomEngine&           rng_engine = this->rng();
 
     // Produce two samples from the original/incident photon
@@ -338,12 +388,8 @@ TEST_F(SeltzerBergerTest, stress_test)
                                          Real3{1e-9, 0, 1},
                                          Real3{1, 1, 1}})
             {
-                SCOPED_TRACE("Incident direction: " + to_string(inc_dir));
                 this->set_inc_direction(inc_dir);
                 this->resize_secondaries(num_samples);
-
-                // Sampled element
-                const ElementId element{0};
 
                 // Create interactor
                 this->set_inc_particle(particle, MevEnergy{inc_e});
@@ -353,13 +399,12 @@ TEST_F(SeltzerBergerTest, stress_test)
                                                  cutoffs,
                                                  this->secondary_allocator(),
                                                  material_view,
-                                                 element);
+                                                 ElementComponentId{0});
 
                 // Loop over many particles
                 for (unsigned int i = 0; i < num_samples; ++i)
                 {
                     Interaction result = interact(rng_engine);
-                    SCOPED_TRACE(result);
                     this->sanity_check(result);
                 }
                 EXPECT_EQ(num_samples,
@@ -377,10 +422,10 @@ TEST_F(SeltzerBergerTest, stress_test)
                                                   13.8325,
                                                   13.2383,
                                                   13.02995,
-                                                  15.029,
-                                                  14.18235,
-                                                  13.82015,
-                                                  13.23295,
-                                                  13.0292};
+                                                  15.05335,
+                                                  14.18465,
+                                                  13.81935,
+                                                  13.2331,
+                                                  13.02855};
     EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
 }


### PR DESCRIPTION
This refactors the SB energy distribution into two parts:
- a non-templated component that sets up the energy sampling function and calculates the bounding cross section; and
- a component templated on a "correction factor" that samples an energy, gets the cross section at that energy from the non-template component and multiplies by a scaling factor (1 for electrons, the result of `SBPositronXsCorrector` for positrons), and rejects based on a random number and the maximum (scaled) cross section.

I added tests that demonstrate:
- nothing about the electron sampling changes
- the sampling efficiency does not change for a constant non-unity value for the scaling factor
- the sampling efficiency decreases slightly for positrons (since the scaled cross section shape is more pronounced/less flat)