### PR TITLE
Computing performance tests of curand generators

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -258,6 +258,7 @@ celeritas_add_test(physics/em/ImportedProcesses.test.cc ${_needs_root}
 celeritas_setup_tests(SERIAL PREFIX random)
 
 celeritas_cudaoptional_test(random/RngEngine)
+celeritas_cudaoptional_test(random/curand/CurandPerformance)
 celeritas_add_test(random/Selector.test.cc)
 
 celeritas_add_test(random/distributions/BernoulliDistribution.test.cc)
@@ -266,7 +267,6 @@ celeritas_add_test(random/distributions/IsotropicDistribution.test.cc)
 celeritas_add_test(random/distributions/RadialDistribution.test.cc)
 celeritas_add_test(random/distributions/ReciprocalDistribution.test.cc)
 celeritas_add_test(random/distributions/UniformRealDistribution.test.cc)
-
 
 #-----------------------------------------------------------------------------#
 # Sim

--- a/test/random/curand/CurandPerformance.test.cc
+++ b/test/random/curand/CurandPerformance.test.cc
@@ -1,0 +1,165 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file CurandPerformance.test.cc
+//---------------------------------------------------------------------------//
+#include "CurandPerformance.test.hh"
+
+#include "base/Range.hh"
+#include "random/RngInterface.hh"
+
+#include "random/DiagnosticRngEngine.hh"
+#include "random/distributions/GenerateCanonical.hh"
+
+#include "celeritas_test.hh"
+
+using namespace celeritas_test;
+
+using celeritas::range;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class CurandTest : public celeritas::Test
+{
+  protected:
+    void SetUp() override
+    {
+        // Test parameters on the host
+        test_params.nsamples  = 1.e+7;
+        test_params.nblocks   = 1;
+        test_params.nthreads  = 1;
+        test_params.seed      = 12345u;
+        test_params.tolerance = 1.0e-3;
+    }
+
+    template<typename T>
+    void check_mean_host()
+    {
+        T devStates;
+        curand_init(test_params.seed, 0, 0, &devStates);
+
+        double sum  = 0;
+        double sum2 = 0;
+        for (CELER_MAYBE_UNUSED auto i : range(test_params.nsamples))
+        {
+            double u01 = curand_uniform(&devStates);
+            sum += u01;
+            sum2 += u01 * u01;
+        }
+
+        double mean     = sum / test_params.nsamples;
+        double variance = sum2 / test_params.nsamples - mean * mean;
+        EXPECT_SOFT_NEAR(mean, 0.5, test_params.tolerance);
+        EXPECT_SOFT_NEAR(variance, 1 / 12., test_params.tolerance);
+    }
+
+  protected:
+    // Test parameters
+    TestParams test_params;
+};
+
+//---------------------------------------------------------------------------//
+// HOST TESTS
+//---------------------------------------------------------------------------//
+TEST_F(CurandTest, TEST_IF_CELERITAS_CUDA(curand_xorwow_host))
+{
+    // XORWOW (default) generator
+    this->check_mean_host<curandState>();
+}
+
+TEST_F(CurandTest, TEST_IF_CELERITAS_CUDA(curand_mrg32k3a_host))
+{
+    // MRG32k3a generator
+    this->check_mean_host<curandStateMRG32k3a>();
+}
+
+TEST_F(CurandTest, TEST_IF_CELERITAS_CUDA(curand_philox4_32_10_host))
+{
+    // Philox4_32_10 generator
+    this->check_mean_host<curandStatePhilox4_32_10_t>();
+}
+
+TEST_F(CurandTest, TEST_IF_CELERITAS_CUDA(std_mt19937_host))
+{
+    // Mersenne Twister generator
+    auto rng = DiagnosticRngEngine<std::mt19937>();
+
+    double sum  = 0;
+    double sum2 = 0;
+    for (CELER_MAYBE_UNUSED auto i : range(test_params.nsamples))
+    {
+        double u01 = celeritas::generate_canonical<double>(rng);
+        sum += u01;
+        sum2 += u01 * u01;
+    }
+
+    double mean     = sum / test_params.nsamples;
+    double variance = sum2 / test_params.nsamples - mean * mean;
+    EXPECT_SOFT_NEAR(mean, 0.5, test_params.tolerance);
+    EXPECT_SOFT_NEAR(variance, 1 / 12., test_params.tolerance);
+}
+
+//---------------------------------------------------------------------------//
+// DEVICE TESTS
+//---------------------------------------------------------------------------//
+
+class CurandDeviceTest : public CurandTest
+{
+    void SetUp() override
+    {
+        // Test parameters on the device (100 * host nsamples)
+        test_params.nsamples  = 1.e+9;
+        test_params.nblocks   = 64;
+        test_params.nthreads  = 256;
+        test_params.seed      = 12345u;
+        test_params.tolerance = 1.0e-3;
+    }
+
+  public:
+    void check_mean_device(TestOutput result)
+    {
+        double sum_total  = 0;
+        double sum2_total = 0;
+        for (auto i : range(test_params.nblocks * test_params.nthreads))
+        {
+            sum_total += result.sum[i];
+            sum2_total += result.sum2[i];
+        }
+        double mean     = sum_total / test_params.nsamples;
+        double variance = sum2_total / test_params.nsamples - mean * mean;
+        EXPECT_SOFT_NEAR(mean, 0.5, test_params.tolerance);
+        EXPECT_SOFT_NEAR(variance, 1 / 12., test_params.tolerance);
+    }
+};
+
+TEST_F(CurandDeviceTest, TEST_IF_CELERITAS_CUDA(curand_xorwow_device))
+{
+    // XORWOW (default) generator
+    auto output = curand_test<curandState>(test_params);
+    this->check_mean_device(output);
+}
+
+TEST_F(CurandDeviceTest, TEST_IF_CELERITAS_CUDA(curand_mrg32k3a_device))
+{
+    // MRG32k3a generator
+    auto output = curand_test<curandStateMRG32k3a>(test_params);
+    this->check_mean_device(output);
+}
+
+TEST_F(CurandDeviceTest, TEST_IF_CELERITAS_CUDA(curand_philox4_32_10_t_device))
+{
+    // Philox4_32_10 generator
+    auto output = curand_test<curandStatePhilox4_32_10_t>(test_params);
+    this->check_mean_device(output);
+}
+
+TEST_F(CurandDeviceTest, TEST_IF_CELERITAS_CUDA(curand_mtgp32_device))
+{
+    // MTGP32-11213 (Mersenne Twister RNG for the GPU)
+    auto output = curand_test<curandStateMtgp32>(test_params);
+    this->check_mean_device(output);
+}

--- a/test/random/curand/CurandPerformance.test.cc
+++ b/test/random/curand/CurandPerformance.test.cc
@@ -65,25 +65,27 @@ class CurandTest : public celeritas::Test
 //---------------------------------------------------------------------------//
 // HOST TESTS
 //---------------------------------------------------------------------------//
-TEST_F(CurandTest, TEST_IF_CELERITAS_CUDA(curand_xorwow_host))
+#if CELERITAS_USE_CUDA
+TEST_F(CurandTest, curand_xorwow_host)
 {
     // XORWOW (default) generator
     this->check_mean_host<curandState>();
 }
 
-TEST_F(CurandTest, TEST_IF_CELERITAS_CUDA(curand_mrg32k3a_host))
+TEST_F(CurandTest, curand_mrg32k3a_host)
 {
     // MRG32k3a generator
     this->check_mean_host<curandStateMRG32k3a>();
 }
 
-TEST_F(CurandTest, TEST_IF_CELERITAS_CUDA(curand_philox4_32_10_host))
+TEST_F(CurandTest, curand_philox4_32_10_host)
 {
     // Philox4_32_10 generator
     this->check_mean_host<curandStatePhilox4_32_10_t>();
 }
+#endif
 
-TEST_F(CurandTest, TEST_IF_CELERITAS_CUDA(std_mt19937_host))
+TEST_F(CurandTest, std_mt19937_host)
 {
     // Mersenne Twister generator
     auto rng = DiagnosticRngEngine<std::mt19937>();
@@ -107,6 +109,7 @@ TEST_F(CurandTest, TEST_IF_CELERITAS_CUDA(std_mt19937_host))
 // DEVICE TESTS
 //---------------------------------------------------------------------------//
 
+#if CELERITAS_USE_CUDA
 class CurandDeviceTest : public CurandTest
 {
     void SetUp() override
@@ -136,30 +139,31 @@ class CurandDeviceTest : public CurandTest
     }
 };
 
-TEST_F(CurandDeviceTest, TEST_IF_CELERITAS_CUDA(curand_xorwow_device))
+TEST_F(CurandDeviceTest, curand_xorwow_device)
 {
     // XORWOW (default) generator
     auto output = curand_test<curandState>(test_params);
     this->check_mean_device(output);
 }
 
-TEST_F(CurandDeviceTest, TEST_IF_CELERITAS_CUDA(curand_mrg32k3a_device))
+TEST_F(CurandDeviceTest, curand_mrg32k3a_device)
 {
     // MRG32k3a generator
     auto output = curand_test<curandStateMRG32k3a>(test_params);
     this->check_mean_device(output);
 }
 
-TEST_F(CurandDeviceTest, TEST_IF_CELERITAS_CUDA(curand_philox4_32_10_t_device))
+TEST_F(CurandDeviceTest, curand_philox4_32_10_t_device)
 {
     // Philox4_32_10 generator
     auto output = curand_test<curandStatePhilox4_32_10_t>(test_params);
     this->check_mean_device(output);
 }
 
-TEST_F(CurandDeviceTest, TEST_IF_CELERITAS_CUDA(curand_mtgp32_device))
+TEST_F(CurandDeviceTest, curand_mtgp32_device)
 {
     // MTGP32-11213 (Mersenne Twister RNG for the GPU)
     auto output = curand_test<curandStateMtgp32>(test_params);
     this->check_mean_device(output);
 }
+#endif

--- a/test/random/curand/CurandPerformance.test.cu
+++ b/test/random/curand/CurandPerformance.test.cu
@@ -1,0 +1,166 @@
+//---------------------------------*-CUDA-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file CurandPerformance.test.cu
+//---------------------------------------------------------------------------//
+#include "CurandPerformance.test.hh"
+
+#include "base/Assert.hh"
+
+#include <curand_kernel.h>
+#include <curand_mtgp32.h>
+#include <curand_mtgp32_host.h>
+#include <curand_mtgp32dc_p_11213.h>
+
+#include <thrust/device_vector.h>
+
+using thrust::raw_pointer_cast;
+
+namespace celeritas_test
+{
+using namespace celeritas;
+
+//---------------------------------------------------------------------------//
+// KERNELS
+//---------------------------------------------------------------------------//
+template<class T>
+__global__ void curand_setup_kernel(T* devStates, unsigned long seed)
+{
+    unsigned int tid = threadIdx.x + blockIdx.x * blockDim.x;
+    curand_init(seed, tid, 0, &devStates[tid]);
+}
+
+template<class T>
+__global__ void curand_test_kernel(unsigned int nsamples,
+                                   T*           devStates,
+                                   double*      sum,
+                                   double*      sum2)
+{
+    unsigned int tid = threadIdx.x + blockIdx.x * blockDim.x;
+    unsigned int sid = tid;
+
+    T localState = devStates[sid];
+
+    while (tid < nsamples)
+    {
+        double u01 = curand_uniform(&localState);
+        sum[sid] += u01;
+        sum2[sid] += u01 * u01;
+        tid += blockDim.x * gridDim.x;
+    }
+
+    devStates[sid] = localState;
+}
+
+__global__ void curand_test_mtgp32_kernel(unsigned int       nsamples,
+                                          curandStateMtgp32* devStates,
+                                          double*            sum,
+                                          double*            sum2)
+{
+    unsigned int tid = threadIdx.x + blockIdx.x * blockDim.x;
+    unsigned int sid = tid;
+
+    while (tid < nsamples)
+    {
+        double u01 = curand_uniform(&devStates[blockIdx.x]);
+        sum[sid] += u01;
+        sum2[sid] += u01 * u01;
+        tid += blockDim.x * gridDim.x;
+    }
+}
+
+//---------------------------------------------------------------------------//
+// TESTING INTERFACE
+//---------------------------------------------------------------------------//
+//! Run on device and return results
+template<class T>
+TestOutput curand_test(TestParams params)
+{
+    // Initialize curand states
+    T* devStates = nullptr;
+    cudaMalloc(&devStates, params.nthreads * params.nblocks * sizeof(T));
+
+    curand_setup_kernel<<<params.nblocks, params.nthreads>>>(devStates,
+                                                             time(NULL));
+    CELER_CUDA_CALL(cudaThreadSynchronize());
+
+    // Output data for kernel
+    thrust::device_vector<double> sum(params.nthreads * params.nblocks, 0.0);
+    thrust::device_vector<double> sum2(params.nthreads * params.nblocks, 0.0);
+
+    curand_test_kernel<<<params.nblocks, params.nthreads>>>(
+        params.nsamples,
+        devStates,
+        raw_pointer_cast(sum.data()),
+        raw_pointer_cast(sum2.data()));
+    CELER_CUDA_CALL(cudaDeviceSynchronize());
+
+    // Clean up
+    CELER_CUDA_CALL(cudaFree(devStates));
+
+    // Copy result back to CPU
+    TestOutput result;
+
+    result.sum.resize(sum.size());
+    thrust::copy(sum.begin(), sum.end(), result.sum.begin());
+
+    result.sum2.resize(sum2.size());
+    thrust::copy(sum2.begin(), sum2.end(), result.sum2.begin());
+
+    return result;
+}
+
+//! Mersenne Twister RNG
+template<>
+TestOutput curand_test<curandStateMtgp32>(TestParams params)
+{
+    // Initialize curand states
+    curandStateMtgp32*    devStates = nullptr;
+    mtgp32_kernel_params* kp        = nullptr;
+
+    CELER_CUDA_CALL(cudaMalloc((void**)&devStates,
+                               params.nblocks * sizeof(curandStateMtgp32)));
+
+    CELER_CUDA_CALL(cudaMalloc((void**)&kp, sizeof(mtgp32_kernel_params)));
+    curandMakeMTGP32Constants(mtgp32dc_params_fast_11213, kp);
+    curandMakeMTGP32KernelState(
+        devStates, mtgp32dc_params_fast_11213, kp, params.nblocks, time(NULL));
+
+    // Output data for kernel
+    thrust::device_vector<double> sum(params.nthreads * params.nblocks, 0.0);
+    thrust::device_vector<double> sum2(params.nthreads * params.nblocks, 0.0);
+
+    curand_test_mtgp32_kernel<<<params.nblocks, params.nthreads>>>(
+        params.nsamples,
+        devStates,
+        raw_pointer_cast(sum.data()),
+        raw_pointer_cast(sum2.data()));
+    CELER_CUDA_CALL(cudaDeviceSynchronize());
+
+    // Clean up
+    CELER_CUDA_CALL(cudaFree(devStates));
+
+    // Copy result back to CPU
+    TestOutput result;
+
+    result.sum.resize(sum.size());
+    thrust::copy(sum.begin(), sum.end(), result.sum.begin());
+
+    result.sum2.resize(sum2.size());
+    thrust::copy(sum2.begin(), sum2.end(), result.sum2.begin());
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+// EXPLICIT INSTANTIATION
+//---------------------------------------------------------------------------//
+template TestOutput curand_test<curandState>(TestParams);
+template TestOutput curand_test<curandStateMRG32k3a>(TestParams);
+template TestOutput curand_test<curandStatePhilox4_32_10_t>(TestParams);
+template TestOutput curand_test<curandStateMtgp32>(TestParams);
+
+//---------------------------------------------------------------------------//
+} // Namespace celeritas_test

--- a/test/random/curand/CurandPerformance.test.hh
+++ b/test/random/curand/CurandPerformance.test.hh
@@ -1,0 +1,52 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file CurandPerformance.test.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Types.hh"
+
+#include <vector>
+
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+// TESTING INTERFACE
+//---------------------------------------------------------------------------//
+struct TestParams
+{
+    using size_type = celeritas::size_type;
+    using real_type = celeritas::real_type;
+
+    size_type     nsamples;  //! number of samples
+    size_type     nthreads;  //! number of threads per blocks
+    size_type     nblocks;   //! number of blocks per grids
+    unsigned long seed;      //! seed
+    real_type     tolerance; //! tolerance of random errors
+};
+
+//! Output results
+struct TestOutput
+{
+    std::vector<double> sum;
+    std::vector<double> sum2;
+};
+
+//---------------------------------------------------------------------------//
+//! Run on device and return results
+template<class T>
+TestOutput curand_test(TestParams params);
+
+#if !CELERITAS_USE_CUDA
+template<class T>
+inline TestOutput curand_test(TestParams)
+{
+    CELER_NOT_CONFIGURED("CUDA");
+}
+#endif
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/random/curand/CurandPerformance.test.hh
+++ b/test/random/curand/CurandPerformance.test.hh
@@ -40,13 +40,5 @@ struct TestOutput
 template<class T>
 TestOutput curand_test(TestParams params);
 
-#if !CELERITAS_USE_CUDA
-template<class T>
-inline TestOutput curand_test(TestParams)
-{
-    CELER_NOT_CONFIGURED("CUDA");
-}
-#endif
-
 //---------------------------------------------------------------------------//
 } // namespace celeritas_test


### PR DESCRIPTION
Added a simple test to compare computing performance of popular cuda random number generators on both CPU and GPU -
the test was used to measure performance of curand generators summarized in Issues #183 (Examine 
RNG quality and performance).
