### PR TITLE
Updates for Field Propagation

### DIFF
--- a/src/field/FieldDriver.i.hh
+++ b/src/field/FieldDriver.i.hh
@@ -74,15 +74,13 @@ FieldDriver<StepperT>::find_next_chord(real_type step, const OdeState& state)
     // Output with a step control error
     FieldOutput output;
 
-    // Try with the proposed step
-    output.step_taken = step;
-
     bool          succeeded       = false;
     unsigned int  remaining_steps = shared_.max_nsteps;
     StepperResult result;
 
     do
     {
+        // Try with the proposed step
         result = stepper_(step, state);
 
         // Check whether the distance to the chord is small than the reference
@@ -98,16 +96,16 @@ FieldDriver<StepperT>::find_next_chord(real_type step, const OdeState& state)
         else
         {
             // Estimate a new trial chord with a relative scale
-            output.step_taken
-                *= std::fmax(std::sqrt(shared_.delta_chord / dchord), half());
+            step *= std::fmax(std::sqrt(shared_.delta_chord / dchord), half());
         }
     } while (!succeeded && (--remaining_steps > 0));
 
     // TODO: loop check and handle rare cases if happen
     CELER_ASSERT(succeeded);
 
-    // Update new position and momentum
-    output.state = result.end_state;
+    // Update step, position and momentum
+    output.step_taken = step;
+    output.state      = result.end_state;
 
     return output;
 }

--- a/test/field/FieldPropagator.test.cc
+++ b/test/field/FieldPropagator.test.cc
@@ -148,8 +148,8 @@ TEST_F(FieldPropagatorHostTest, boundary_crossing_host)
         }
 
         // Check stepper results with boundary crossings
-        EXPECT_SOFT_NEAR(geo_track.pos()[0], -0.13151242, test.epsilon);
-        EXPECT_SOFT_NEAR(geo_track.dir()[1], -0.03452005, test.epsilon);
+        EXPECT_SOFT_NEAR(geo_track.pos()[0], -0.13150565, test.epsilon);
+        EXPECT_SOFT_NEAR(geo_track.dir()[1], -0.03453068, test.epsilon);
         EXPECT_SOFT_NEAR(total_length, 221.48171708, test.epsilon);
     }
 }
@@ -233,8 +233,8 @@ TEST_F(FieldPropagatorDeviceTest, boundary_crossing_device)
     // Check stepper results
     for (unsigned int i = 0; i < output.pos.size(); ++i)
     {
-        EXPECT_SOFT_NEAR(output.pos[i], -0.13151242, test.epsilon);
-        EXPECT_SOFT_NEAR(output.dir[i], -0.03452005, test.epsilon);
+        EXPECT_SOFT_NEAR(output.pos[i], -0.13150565, test.epsilon);
+        EXPECT_SOFT_NEAR(output.dir[i], -0.03453068, test.epsilon);
         EXPECT_SOFT_NEAR(output.step[i], 221.48171708, test.epsilon);
     }
 }

--- a/test/field/FieldTestBase.hh
+++ b/test/field/FieldTestBase.hh
@@ -75,7 +75,7 @@ class FieldTestBase : public celeritas::Test
         state_ref = state_value;
 
         // Set values of FieldParamsPointers;
-        field_params.delta_intersection = 1.0e-3 * units::millimeter;
+        field_params.delta_intersection = 1.0e-4 * units::millimeter;
 
         // Input parameters of an electron in a uniform magnetic field
         test.nstates     = 128;

--- a/test/field/detail/CMSParameterizedField.hh
+++ b/test/field/detail/CMSParameterizedField.hh
@@ -36,16 +36,16 @@ class CMSParameterizedField
 
     // Return the magnetic field for the given position
     CELER_FUNCTION
-    inline Real3 operator()(const Real3& pos);
+    inline Real3 operator()(const Real3& pos) const;
 
   private:
     // Evaluate the magnetic field for the given r and z
     CELER_FUNCTION
-    inline Real3 evaluate_field(real_type r, real_type z);
+    inline Real3 evaluate_field(real_type r, real_type z) const;
 
     // Evaluate the parameterized function and its derivatives
     CELER_FUNCTION
-    inline Real4 evaluate_parameters(real_type x);
+    inline Real4 evaluate_parameters(real_type x) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/field/detail/CMSParameterizedField.i.hh
+++ b/test/field/detail/CMSParameterizedField.i.hh
@@ -22,7 +22,7 @@ namespace detail
  * with the CMS detector geometry.
  */
 CELER_FUNCTION
-Real3 CMSParameterizedField::operator()(const Real3& pos)
+Real3 CMSParameterizedField::operator()(const Real3& pos) const
 {
     Real3 value{0., 0., 0.};
 
@@ -45,7 +45,7 @@ Real3 CMSParameterizedField::operator()(const Real3& pos)
  * TODO: simplify and optimize
  */
 CELER_FUNCTION
-Real3 CMSParameterizedField::evaluate_field(real_type r, real_type z)
+Real3 CMSParameterizedField::evaluate_field(real_type r, real_type z) const
 {
     const real_type prm[9] = {4.24326,
                               15.0201,
@@ -100,7 +100,7 @@ Real3 CMSParameterizedField::evaluate_field(real_type r, real_type z)
  */
 CELER_FUNCTION
 CMSParameterizedField::Real4
-CMSParameterizedField::evaluate_parameters(real_type x)
+CMSParameterizedField::evaluate_parameters(real_type x) const
 {
     real_type a = 1 / (1 + ipow<2>(x));
     real_type b = std::sqrt(a);


### PR DESCRIPTION
This MR includes
- Improved the logic to find the intersection point and associated updates for boundary crossing tests with a smaller delta_intersection
- Fixed the logic to find the next chord in the FieldDriver class
- Added function const qualifier in CMSParameterizedField