### PR TITLE
Fix a few missing includes and typos

### DIFF
--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -14,7 +14,7 @@ try:
     geometry_filename = argv[1]
     hepmc3_filename = argv[2]
 except TypeError:
-    print("usage: {} inp.gdml inp.hepmc3".format(sys.argv[0]))
+    print("usage: {} inp.gdml inp.hepmc3".format(argv[0]))
     exit(2)
 
 geant_exp_exe = environ.get('CELERITAS_GEANT_EXPORTER_EXE', './geant-exporter')

--- a/src/base/Span.hh
+++ b/src/base/Span.hh
@@ -30,8 +30,8 @@ constexpr std::size_t dynamic_extent = detail::dynamic_extent;
  * for the use cases needed by Celeritas (and, as a bonus, it will be
  * device-compatible).
  *
- * Notably, only a subset of the functions (those having to with size) are \c
- * constexpr. This is to allow debug assertions.
+ * Notably, only a subset of the functions (those having to do with size) are
+ * \c constexpr. This is to allow debug assertions.
  */
 template<class T, std::size_t Extent = dynamic_extent>
 class Span

--- a/src/comm/Device.hh
+++ b/src/comm/Device.hh
@@ -82,7 +82,7 @@ class Device
 // Global active device (default is inactive/false)
 const Device& device();
 
-// Activate the devie
+// Activate the device
 void activate_device(Device&& device);
 
 // Print device info

--- a/test/base/StackAllocator.test.cu
+++ b/test/base/StackAllocator.test.cu
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
 #include "base/KernelParamCalculator.cuda.hh"
 #include "base/StackAllocator.hh"
 

--- a/test/geometry/Geo.test.cu
+++ b/test/geometry/Geo.test.cu
@@ -8,6 +8,7 @@
 #include "geometry/GeoTrackView.hh"
 
 #include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
 #include "base/KernelParamCalculator.cuda.hh"
 
 #include "Geo.test.hh"

--- a/test/geometry/LinearPropagator.test.cu
+++ b/test/geometry/LinearPropagator.test.cu
@@ -8,6 +8,7 @@
 #include "geometry/LinearPropagator.hh"
 
 #include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
 #include "base/KernelParamCalculator.cuda.hh"
 #include "geometry/GeoTrackView.hh"
 


### PR DESCRIPTION
A few of the CUDA tests use `thrust::host_vector`. In previous versions of CUDA, `host_vector` was forward declared in `thrust/device_vector.h`, so including that was sufficient, but in the latest CUDA this is no longer true so an explicit `#include <thrust/host_vector.h>` is needed to avoid build errors. I also fixed a few typos I came upon.