### PR TITLE
Enable demo-loop app test in CI

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -248,7 +248,7 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_VecGeom)
     )
     if(NOT CELERITAS_USE_Geant4 OR NOT CELERITAS_USE_ROOT OR NOT CELERITAS_USE_HepMC3)
       set_tests_properties("app/demo-loop" PROPERTIES
-        DISABLED false
+        DISABLED true
       )
     endif()
   endif()

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -246,7 +246,10 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_VecGeom)
       RESOURCE_LOCK gpu
       REQUIRED_FILES "${_driver};${_gdml_inp};${_hepmc3_inp}"
     )
-    if(NOT CELERITAS_USE_Geant4 OR NOT CELERITAS_USE_ROOT OR NOT CELERITAS_USE_HepMC3)
+    # Disable test when prereqs are not available or for debug builds
+    # TODO: Get test working on debug builds
+    if(NOT CELERITAS_USE_Geant4 OR NOT CELERITAS_USE_ROOT OR NOT CELERITAS_USE_HepMC3
+       OR CMAKE_BUILD_TYPE STREQUAL "Debug")
       set_tests_properties("app/demo-loop" PROPERTIES
         DISABLED true
       )

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -228,8 +228,7 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_VecGeom)
     nlohmann_json::nlohmann_json
   )
 
-  # TODO: update input files and enable test
-  if(CELERITAS_BUILD_TESTS AND CELERITAS_USE_Geant4 AND CELERITAS_USE_ROOT)
+  if (CELERITAS_BUILD_TESTS)
     set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/demo-loop/simple-driver.py")
     set(_gdml_inp "${PROJECT_SOURCE_DIR}/app/demo-loop/simple_cms.gdml")
     set(_hepmc3_inp "${PROJECT_SOURCE_DIR}/app/demo-loop/input.hepmc3")
@@ -246,8 +245,12 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_VecGeom)
       ENVIRONMENT "${_env};${_geant_test_env}"
       RESOURCE_LOCK gpu
       REQUIRED_FILES "${_driver};${_gdml_inp};${_hepmc3_inp}"
-      DISABLED true
     )
+    if(NOT CELERITAS_USE_Geant4 OR NOT CELERITAS_USE_ROOT OR NOT CELERITAS_USE_HepMC3)
+      set_tests_properties("app/demo-loop" PROPERTIES
+        DISABLED false
+      )
+    endif()
   endif()
 endif()
 

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -13,7 +13,7 @@ from sys import exit, argv
 try:
     geometry_filename = argv[1]
     hepmc3_filename = argv[2]
-except TypeError:
+except (IndexError, TypeError):
     print("usage: {} inp.gdml inp.hepmc3".format(argv[0]))
     exit(2)
 
@@ -36,7 +36,7 @@ inp = {
         'seed': 12345,
         'max_num_tracks': 128 * 32,
         'max_steps': 128,
-        'storage_factor': 3
+        'storage_factor': 10
     }
 }
 

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -57,6 +57,8 @@ if result.returncode:
 
 print("Received {} bytes of data".format(len(result.stdout)))
 out_text = result.stdout.decode()
+# Filter out spurious HepMC3 output
+out_text = out_text[out_text.find('\n{') + 1:]
 try:
     result = json.loads(out_text)
 except json.decoder.JSONDecodeError as e:

--- a/src/base/ScopedStreamRedirect.hh
+++ b/src/base/ScopedStreamRedirect.hh
@@ -22,7 +22,7 @@ namespace celeritas
  * \code
     ScopedStreamRedirect silenced(&std::cout);
     LoadVecGeom();
-    CELER_LOG(diagnostic) << "Vecgeom said: " << silenced.get();
+    CELER_LOG(diagnostic) << "Vecgeom said: " << silenced.str();
    \endcode
  */
 class ScopedStreamRedirect

--- a/src/io/EventReader.cc
+++ b/src/io/EventReader.cc
@@ -8,7 +8,6 @@
 #include "EventReader.hh"
 
 #include "base/ArrayUtils.hh"
-#include "base/ScopedStreamRedirect.hh"
 #include "comm/Logger.hh"
 #include "physics/base/Units.hh"
 #include "HepMC3/GenEvent.h"
@@ -25,17 +24,11 @@ EventReader::EventReader(const char* filename, SPConstParticles params)
 {
     CELER_EXPECT(params_);
 
-    // Turn off/capture HepMC3 diagnostic output that pollutes our own output
+    // Turn off HepMC3 diagnostic output that pollutes our own output
     HepMC3::Setup::set_debug_level(-1);
-    ScopedStreamRedirect silenced(&std::cout);
 
     // Determine the input file format and construct the appropriate reader
     input_file_ = HepMC3::deduce_reader(filename);
-    std::string output = silenced.str();
-    if (!output.empty())
-    {
-        CELER_LOG(diagnostic) << "HepMC3 said: " << output;
-    }
     CELER_ENSURE(input_file_);
 }
 

--- a/src/io/EventReader.cc
+++ b/src/io/EventReader.cc
@@ -31,7 +31,11 @@ EventReader::EventReader(const char* filename, SPConstParticles params)
 
     // Determine the input file format and construct the appropriate reader
     input_file_ = HepMC3::deduce_reader(filename);
-    CELER_LOG(diagnostic) << "HepMC3 said: " << silenced.str();
+    std::string output = silenced.str();
+    if (!output.empty())
+    {
+        CELER_LOG(diagnostic) << "HepMC3 said: " << output;
+    }
     CELER_ENSURE(input_file_);
 }
 

--- a/src/io/EventReader.cc
+++ b/src/io/EventReader.cc
@@ -8,6 +8,8 @@
 #include "EventReader.hh"
 
 #include "base/ArrayUtils.hh"
+#include "base/ScopedStreamRedirect.hh"
+#include "comm/Logger.hh"
 #include "physics/base/Units.hh"
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/ReaderFactory.h"
@@ -22,8 +24,14 @@ EventReader::EventReader(const char* filename, SPConstParticles params)
     : params_(std::move(params))
 {
     CELER_EXPECT(params_);
+
+    // Turn off/capture HepMC3 diagnostic output that pollutes our own output
+    HepMC3::Setup::set_debug_level(-1);
+    ScopedStreamRedirect silenced(&std::cout);
+
     // Determine the input file format and construct the appropriate reader
     input_file_ = HepMC3::deduce_reader(filename);
+    CELER_LOG(diagnostic) << "HepMC3 said: " << silenced.str();
     CELER_ENSURE(input_file_);
 }
 


### PR DESCRIPTION
This PR enables the demo-loop app test to run in CI and fixes a few issues @vrpascuzzi and I have encountered with recent builds:
- HepMC3 spits out some diagnostic output that interferes with the expected JSON output in simple-driver.py.
- The storage factor for secondaries is not sufficiently high to complete all steps in the demo-loop app. Bumping it up to 10 seems to work on my setup :crossed_fingers: 
