### PR TITLE
Make sure init_tracks kernel initializes material state

### DIFF
--- a/src/sim/detail/InitializeTracks.cu
+++ b/src/sim/detail/InitializeTracks.cu
@@ -15,9 +15,11 @@
 #include "base/Atomics.hh"
 #include "base/DeviceVector.hh"
 #include "base/KernelParamCalculator.cuda.hh"
+#include "geometry/GeoMaterialView.hh"
 #include "geometry/GeoTrackView.hh"
 #include "physics/base/ParticleTrackView.hh"
 #include "physics/base/PhysicsTrackView.hh"
+#include "physics/material/MaterialTrackView.hh"
 #include "sim/SimTrackView.hh"
 
 namespace celeritas
@@ -92,6 +94,11 @@ __global__ void init_tracks_kernel(const ParamsDeviceRef         params,
             // Initialize it from the position (more expensive)
             geo = init.geo;
         }
+
+        // Initialize the material
+        GeoMaterialView   geo_mat(params.geo_mats, geo.volume_id());
+        MaterialTrackView mat(params.materials, states.materials, tid);
+        mat = {geo_mat.material_id()};
     }
 
     // Initialize the physics state

--- a/src/sim/detail/InitializeTracks.cu
+++ b/src/sim/detail/InitializeTracks.cu
@@ -97,7 +97,7 @@ __global__ void init_tracks_kernel(const ParamsDeviceRef         params,
 
         // Initialize the material
         GeoMaterialView   geo_mat(params.geo_mats, geo.volume_id());
-        MaterialTrackView mat(params.materials, states.materials, tid);
+        MaterialTrackView mat(params.materials, states.materials, vac_id);
         mat = {geo_mat.material_id()};
     }
 


### PR DESCRIPTION
While working on the CPU demo loop, I ran across what I believe to be a bug. In the `init_tracks` kernel, we initialize the geometry state but never use the result to initialize the material state. When later kernel calls try to access the material state, the following behavior is observed:
- On GPU, the material states (material IDs, to be specific) are never set and default to zero by virtue of being backed by a `DeviceVector`. Thus, the demo loop continues fine with particles appearing to always be in the material with ID 0.
- On CPU, the material states are backed by a `std::vector`, so the default constructor of `MaterialId` is called, which sets the values to `OpaqueId::invalid_value()`. Once the demo loop gets to a kernel that requires material states, it correctly aborts at this point because the material state is invalid.

Thanks to @amandalund for tracking down why things inadvertently work on GPU. The solution to fix this is pretty straightforward: use `GeoMaterialView` and `MaterialTrackView` to set the material state corresponding to the geometry state that was found.