### PR TITLE
Add Geant4 v11 compatibility to geant-exporter

### DIFF
--- a/app/geant-exporter/CeleritasG4Version.hh
+++ b/app/geant-exporter/CeleritasG4Version.hh
@@ -1,0 +1,25 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file CeleritasG4Version.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <G4Version.hh>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Macro for differentiating between Geant4 v10 and v11.
+ */
+#if defined(G4VERSION_NUMBER) && G4VERSION_NUMBER < 1100
+#    define CELERITAS_G4_V10 1
+#else
+#    define CELERITAS_G4_V10 0
+#endif
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/app/geant-exporter/ImportProcessConverter.cc
+++ b/app/geant-exporter/ImportProcessConverter.cc
@@ -316,7 +316,13 @@ ImportProcessConverter::operator()(const G4ParticleDefinition& particle,
  */
 void ImportProcessConverter::store_em_tables(const G4VEmProcess& process)
 {
+#if defined(G4VERSION_NUMBER) && G4VERSION_NUMBER < 1100
+    // Geant4 v10
+    for (auto i : celeritas::range(process.GetNumberOfModels()))
+#else
+    // Geant4 v11
     for (auto i : celeritas::range(process.NumberOfModels()))
+#endif
     {
         process_.models.push_back(
             to_import_model(process.GetModelByIndex(i)->GetName()));

--- a/app/geant-exporter/ImportProcessConverter.cc
+++ b/app/geant-exporter/ImportProcessConverter.cc
@@ -169,8 +169,7 @@ ImportModelClass to_import_model(const std::string& g4_model_name)
  * Safely switch from \c G4PhysicsVectorType to \c ImportPhysicsVectorType .
  * [See G4PhysicsVectorType.hh]
  *
- * Geant4 v11 introduces a new enum list, which is included here. The Geant4
- * version numbering scheme is explained in G4Version.hh.
+ * Geant4 v11 has a different set of G4PhysicsVectorType enums.
  */
 ImportPhysicsVectorType
 to_import_physics_vector_type(G4PhysicsVectorType g4_vector_type)
@@ -399,8 +398,7 @@ void ImportProcessConverter::store_energy_loss_tables(
  * Whereas other EM processes combine the model tables into a single process
  * table, MSC keeps them independent.
  *
- * Starting on Geant4 v11, G4MultipleScattering provides a \c NumberOfModels()
- * method. For details on the Geant4 version numbering, see G4Version.hh.
+ * Starting on Geant4 v11, G4MultipleScattering provides \c NumberOfModels() .
  */
 void ImportProcessConverter::store_multiple_scattering_tables(
     const G4VMultipleScattering& process)

--- a/app/geant-exporter/ImportProcessConverter.cc
+++ b/app/geant-exporter/ImportProcessConverter.cc
@@ -22,6 +22,7 @@
 #include <G4PhysicsVectorType.hh>
 #include <G4ProcessType.hh>
 #include <G4Material.hh>
+#include <G4Version.hh>
 
 #include "io/ImportProcess.hh"
 #include "io/ImportPhysicsTable.hh"

--- a/app/geant-exporter/geant-exporter.cc
+++ b/app/geant-exporter/geant-exporter.cc
@@ -441,10 +441,10 @@ int main(int argc, char* argv[])
     std::unique_ptr<G4RunManager> run_manager;
 
 #if defined(G4VERSION_NUMBER) && G4VERSION_NUMBER < 1100
-    // Use Geant4 v10 Run Manager implementation
+    // Use Geant4 v10 RunManager
     run_manager.reset(new G4RunManager());
 #else
-    // Use Geant4 v11 Run Manager Factory
+    // Use Geant4 v11 RunManagerFactory
     run_manager.reset(
         G4RunManagerFactory::CreateRunManager(G4RunManagerType::Serial));
 #endif

--- a/app/geant-exporter/geant-exporter.cc
+++ b/app/geant-exporter/geant-exporter.cc
@@ -11,8 +11,8 @@
 #include <string>
 #include <vector>
 
-#include <G4Version.hh>
-#if defined(G4VERSION_NUMBER) && G4VERSION_NUMBER < 1100
+#include "CeleritasG4Version.hh"
+#if CELERITAS_G4_V10
 #    include <G4RunManager.hh>
 #else
 #    include <G4RunManagerFactory.hh>
@@ -441,11 +441,9 @@ int main(int argc, char* argv[])
     // suppressed.
     std::unique_ptr<G4RunManager> run_manager;
 
-#if defined(G4VERSION_NUMBER) && G4VERSION_NUMBER < 1100
-    // Use Geant4 v10 RunManager
-    run_manager.reset(new G4RunManager());
+#if CELERITAS_G4_V10
+    run_manager = std::make_unique<G4RunManager>();
 #else
-    // Use Geant4 v11 RunManagerFactory
     run_manager.reset(
         G4RunManagerFactory::CreateRunManager(G4RunManagerType::Serial));
 #endif

--- a/app/geant-exporter/geant-exporter.cc
+++ b/app/geant-exporter/geant-exporter.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include <G4Version.hh>
 #if defined(G4VERSION_NUMBER) && G4VERSION_NUMBER < 1100
 #    include <G4RunManager.hh>
 #else


### PR DESCRIPTION
This allows building _Celeritas_ with Geant4 v11, which is needed for _Acceleritas_.

Three main changes are added to the code to enable the compatibility between G4 versions and are selected via C++ macros:
- G4 v11 replaces `G4RunManager` by `G4RunManagerFactory`.
- `G4PhysicsVectorType` enum is simpler in G4 v11.
- A few physics tables are deleted in G4 v11.