### PR TITLE
Allow number of primaries to exceed track initializer capacity for demo-loop app

### DIFF
--- a/app/demo-loop/LDemoRun.cc
+++ b/app/demo-loop/LDemoRun.cc
@@ -128,48 +128,49 @@ LDemoResult run_gpu(LDemoArgs args)
            args.max_num_tracks);
     StateDeviceRef states_ref = make_ref(state_storage);
 
-    // Copy primaries to device and create track initializers
-    // TODO: for now this assumes we can initialize all primaries at once, but
-    // we should also handle the case where we have more primaries than trackss
-    CELER_ASSERT(params.track_inits->host_pointers().primaries.size()
-                 <= state_storage.track_inits.initializers.capacity());
-    extend_from_primaries(params.track_inits->host_pointers(),
-                          &state_storage.track_inits);
-
-    size_type num_alive       = 0;
-    size_type num_inits       = state_storage.track_inits.initializers.size();
-    size_type remaining_steps = args.max_steps;
-
-    while (num_alive > 0 || num_inits > 0)
+    while (state_storage.track_inits.num_primaries > 0)
     {
-        // Create new tracks from primaries or secondaries
-        initialize_tracks(params_ref, states_ref, &state_storage.track_inits);
+        // Copy primaries to device and create track initializers
+        extend_from_primaries(params.track_inits->host_pointers(),
+                              &state_storage.track_inits,
+                              args.max_num_tracks);
 
-        demo_loop::pre_step(params_ref, states_ref);
-        demo_loop::along_and_post_step(params_ref, states_ref);
+        size_type num_alive = 0;
+        size_type num_inits = state_storage.track_inits.initializers.size();
+        size_type remaining_steps = args.max_steps;
 
-        // Launch the interaction kernels for all applicable models
-        launch_models(params, params_ref, states_ref);
-
-        // Postprocess secondaries and interaction results
-        demo_loop::process_interactions(params_ref, states_ref);
-
-        // Create track initializers from surviving secondaries
-        extend_from_secondaries(
-            params_ref, states_ref, &state_storage.track_inits);
-
-        // Clear secondaries
-        demo_loop::cleanup(params_ref, states_ref);
-
-        // Get the number of track initializers and active tracks
-        num_alive = args.max_num_tracks
-                    - state_storage.track_inits.vacancies.size();
-        num_inits = state_storage.track_inits.initializers.size();
-
-        if (--remaining_steps == 0)
+        while (num_alive > 0 || num_inits > 0)
         {
-            // Exceeded step count
-            break;
+            // Create new tracks from primaries or secondaries
+            initialize_tracks(
+                params_ref, states_ref, &state_storage.track_inits);
+
+            demo_loop::pre_step(params_ref, states_ref);
+            demo_loop::along_and_post_step(params_ref, states_ref);
+
+            // Launch the interaction kernels for all applicable models
+            launch_models(params, params_ref, states_ref);
+
+            // Postprocess secondaries and interaction results
+            demo_loop::process_interactions(params_ref, states_ref);
+
+            // Create track initializers from surviving secondaries
+            extend_from_secondaries(
+                params_ref, states_ref, &state_storage.track_inits);
+
+            // Clear secondaries
+            demo_loop::cleanup(params_ref, states_ref);
+
+            // Get the number of track initializers and active tracks
+            num_alive = args.max_num_tracks
+                        - state_storage.track_inits.vacancies.size();
+            num_inits = state_storage.track_inits.initializers.size();
+
+            if (--remaining_steps == 0)
+            {
+                // Exceeded step count
+                break;
+            }
         }
     }
 

--- a/src/sim/TrackInitUtils.cc
+++ b/src/sim/TrackInitUtils.cc
@@ -22,7 +22,8 @@ namespace celeritas
  * initializer vector, whichever is smaller).
  */
 void extend_from_primaries(const TrackInitParamsHostRef& params,
-                           TrackInitStateDeviceVal*      data)
+                           TrackInitStateDeviceVal*      data,
+                           size_type                     max_num_tracks)
 {
     CELER_EXPECT(params);
     CELER_EXPECT(data && *data);
@@ -30,6 +31,7 @@ void extend_from_primaries(const TrackInitParamsHostRef& params,
     // Number of primaries to copy to device
     auto count = min(data->initializers.capacity() - data->initializers.size(),
                      data->num_primaries);
+    count      = min(count, max_num_tracks);
     if (count)
     {
         data->initializers.resize(data->initializers.size() + count);

--- a/src/sim/TrackInitUtils.hh
+++ b/src/sim/TrackInitUtils.hh
@@ -17,7 +17,8 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 // Create track initializers on device from primary particles
 void extend_from_primaries(const TrackInitParamsHostRef& params,
-                           TrackInitStateDeviceVal*      data);
+                           TrackInitStateDeviceVal*      data,
+                           size_type                     max_num_tracks);
 
 // Create track initializers on device from secondary particles.
 void extend_from_secondaries(const ParamsDeviceRef&   params,

--- a/test/sim/TrackInit.test.cc
+++ b/test/sim/TrackInit.test.cc
@@ -59,8 +59,8 @@ class TrackInitTest : public celeritas::Test
         // Set up shared geometry data
         std::string test_file
             = celeritas::Test::test_data_path("geometry", "twoBoxes.gdml");
-        geometry            = std::make_shared<GeoParams>(test_file.c_str());
-        params.geometry     = geometry->device_pointers();
+        geometry        = std::make_shared<GeoParams>(test_file.c_str());
+        params.geometry = geometry->device_pointers();
 
         // Set up shared material data
         materials = std::make_shared<MaterialParams>(
@@ -94,8 +94,8 @@ class TrackInitTest : public celeritas::Test
         params.cutoffs = cutoffs->device_pointers();
 
         // Set up shared RNG data
-        rng            = std::make_shared<RngParams>(12345);
-        params.rng     = rng->device_pointers();
+        rng        = std::make_shared<RngParams>(12345);
+        params.rng = rng->device_pointers();
 
         // Add dummy physics data
         PhysicsParamsData<Ownership::value, MemSpace::host> host_physics;
@@ -191,7 +191,8 @@ TEST_F(TrackInitTest, run)
 
     // Create track initializers on device from primary particles
     extend_from_primaries(track_inits->host_pointers(),
-                          &device_states.track_inits);
+                          &device_states.track_inits,
+                          num_primaries);
 
     // Check the track IDs of the track initializers created from primaries
     output.init_id   = initializers_test(make_ref(device_states.track_inits));
@@ -268,7 +269,8 @@ TEST_F(TrackInitTest, primaries)
 
         // Create track initializers on device from primary particles
         extend_from_primaries(track_inits->host_pointers(),
-                              &device_states.track_inits);
+                              &device_states.track_inits,
+                              num_primaries);
 
         for (auto j = capacity; j > 0; j -= num_tracks)
         {
@@ -322,7 +324,8 @@ TEST_F(TrackInitTest, secondaries)
 
     // Create track initializers on device from primary particles
     extend_from_primaries(track_inits->host_pointers(),
-                          &device_states.track_inits);
+                          &device_states.track_inits,
+                          num_primaries);
     EXPECT_EQ(device_states.track_inits.num_primaries, 0);
     EXPECT_EQ(device_states.track_inits.initializers.size(), num_primaries);
 


### PR DESCRIPTION
In preparation for the CPU demo loop, this PR adds an outer loop in `run_gpu` to handle cases where the number of primaries exceeds the number of tracks. As discussed in #263, on CPU we are currently limited to a single track, so in order to handle all 15 primaries an outer loop is necessary. The approach here is pretty simple — the outer loop checks how many primaries are remaining, and when we call `extend_from_primaries`, the number of primaries that are turned into track initializers is limited by the maximum number of tracks. Everything else seems to work seamlessly (kudos all for laying such a robust infrastructure!).

@sethrj The # primaries > # tracks case is as of yet untested. Let me know if you have thoughts about how we should test this. The easiest thing  in my mind would be to have simple-driver.py run two cases, the current one with max_num_tracks = 128*32 and another with max_num_tracks < 15.