### PR TITLE
A few more demo loop fixes

### DIFF
--- a/app/demo-loop/KernelUtils.hh
+++ b/app/demo-loop/KernelUtils.hh
@@ -28,7 +28,9 @@ inline CELER_FUNCTION void calc_step_limits(const MaterialTrackView& mat,
                                             Rng&                     rng);
 
 template<class Rng>
-inline CELER_FUNCTION void move_and_select_model(GeoTrackView&      geo,
+inline CELER_FUNCTION void move_and_select_model(const GeoMaterialView& geo_mat,
+                                                 GeoTrackView&          geo,
+                                                 MaterialTrackView&     mat,
                                                  ParticleTrackView& particle,
                                                  PhysicsTrackView&  phys,
                                                  SimTrackView&      sim,

--- a/app/demo-loop/LDemoKernel.cu
+++ b/app/demo-loop/LDemoKernel.cu
@@ -39,12 +39,12 @@ pre_step_kernel(ParamsDeviceRef const params, StateDeviceRef const states)
 
     ParticleTrackView particle(params.particles, states.particles, tid);
     GeoTrackView      geo(params.geometry, states.geometry, tid);
-    GeoMaterialView   geo_mat(params.geo_mats, geo.volume_id());
+    GeoMaterialView   geo_mat(params.geo_mats);
     MaterialTrackView mat(params.materials, states.materials, tid);
     PhysicsTrackView  phys(params.physics,
                           states.physics,
                           particle.particle_id(),
-                          geo_mat.material_id(),
+                          geo_mat.material_id(geo.volume_id()),
                           tid);
     RngEngine         rng(states.rng, ThreadId(tid));
 
@@ -76,16 +76,19 @@ __global__ void along_and_post_step_kernel(ParamsDeviceRef const params,
 
     ParticleTrackView particle(params.particles, states.particles, tid);
     GeoTrackView      geo(params.geometry, states.geometry, tid);
-    GeoMaterialView   geo_mat(params.geo_mats, geo.volume_id());
+    GeoMaterialView   geo_mat(params.geo_mats);
+    MaterialTrackView mat(params.materials, states.materials, tid);
     PhysicsTrackView  phys(params.physics,
                           states.physics,
                           particle.particle_id(),
-                          geo_mat.material_id(),
+                          geo_mat.material_id(geo.volume_id()),
                           tid);
     RngEngine         rng(states.rng, ThreadId(tid));
 
     // Propagate, calculate energy loss, and select model
-    demo_loop::move_and_select_model(geo,
+    demo_loop::move_and_select_model(geo_mat,
+                                     geo,
+                                     mat,
                                      particle,
                                      phys,
                                      sim,
@@ -112,11 +115,11 @@ __global__ void process_interactions_kernel(ParamsDeviceRef const params,
     ParticleTrackView particle(params.particles, states.particles, tid);
     GeoTrackView      geo(params.geometry, states.geometry, tid);
     MaterialTrackView mat(params.materials, states.materials, tid);
-    GeoMaterialView   geo_mat(params.geo_mats, geo.volume_id());
+    GeoMaterialView   geo_mat(params.geo_mats);
     PhysicsTrackView  phys(params.physics,
                           states.physics,
                           particle.particle_id(),
-                          geo_mat.material_id(),
+                          geo_mat.material_id(geo.volume_id()),
                           tid);
     CutoffView        cutoffs(params.cutoffs, mat.material_id());
 

--- a/src/geometry/GeoMaterialView.hh
+++ b/src/geometry/GeoMaterialView.hh
@@ -25,32 +25,39 @@ class GeoMaterialView
     //!@}
 
   public:
-    // Construct for the given particle and material ids
-    inline CELER_FUNCTION
-    GeoMaterialView(const GeoMaterialPointers& params, VolumeId volume);
+    // Construct from shared data
+    inline CELER_FUNCTION GeoMaterialView(const GeoMaterialPointers& params);
 
-    //! Return material
-    CELER_FORCEINLINE_FUNCTION MaterialId material_id() const { return mat_; }
+    // Return material for the given volume
+    inline CELER_FUNCTION MaterialId material_id(VolumeId volume) const;
 
   private:
-    MaterialId mat_;
+    const GeoMaterialPointers& params_;
 };
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Construct from shared data and current volume.
+ * Construct from shared data.
+ */
+CELER_FUNCTION
+GeoMaterialView::GeoMaterialView(const GeoMaterialPointers& params)
+    : params_(params)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return material for the given volume.
  *
  * Note that this will *fail* if the particle is outside -- the volume ID will
  * be false.
  */
-CELER_FUNCTION
-GeoMaterialView::GeoMaterialView(const GeoMaterialPointers& params,
-                                 VolumeId                   volume)
+CELER_FUNCTION MaterialId GeoMaterialView::material_id(VolumeId volume) const
 {
-    CELER_EXPECT(volume < params.materials.size());
-    mat_ = params.materials[volume];
+    CELER_EXPECT(volume < params_.materials.size());
+    return params_.materials[volume];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/base/Interaction.hh
+++ b/src/physics/base/Interaction.hh
@@ -39,6 +39,9 @@ struct Interaction
     static inline CELER_FUNCTION Interaction
     from_unchanged(units::MevEnergy energy, const Real3& direction);
 
+    // Return an interaction indicating all state changes have been applied
+    static inline CELER_FUNCTION Interaction from_processed();
+
     // Whether the interaction succeeded
     explicit inline CELER_FUNCTION operator bool() const;
 };
@@ -83,6 +86,17 @@ CELER_FUNCTION Interaction Interaction::from_unchanged(units::MevEnergy energy,
     result.action    = Action::unchanged;
     result.energy    = energy;
     result.direction = direction;
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct for end of step when all interaction data has been processed.
+ */
+CELER_FUNCTION Interaction Interaction::from_processed()
+{
+    Interaction result;
+    result.action = Action::processed;
     return result;
 }
 

--- a/src/sim/Action.hh
+++ b/src/sim/Action.hh
@@ -25,6 +25,7 @@ enum class Action
     scattered, //!< Scattering interaction
     entered_volume, //!< Propagated to a new region of space
     unchanged,      //!< Edge cases where an interactor returns no change
+    processed,      //!< State change and secondaries have been processed
     // KILLING ACTIONS BELOW
     begin_killed_,
     absorbed = begin_killed_, //!< Absorbed (killed)
@@ -64,7 +65,7 @@ inline CELER_FUNCTION bool action_killed(Action a)
 inline CELER_FUNCTION bool action_unchanged(Action a)
 {
     return a == Action::unchanged || a == Action::entered_volume
-           || a == Action::spawned;
+           || a == Action::spawned || a == Action::processed;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/detail/InitializeTracks.cu
+++ b/src/sim/detail/InitializeTracks.cu
@@ -183,12 +183,6 @@ __global__ void locate_alive_kernel(const ParamsDeviceRef         params,
         PhysicsTrackView phys(params.physics, states.physics, {}, {}, tid);
         phys = {};
 
-        // Interaction representing creation of a new track
-        Interaction& result = states.interactions[tid];
-        result.action       = Action::spawned;
-        result.energy       = secondary.energy;
-        result.direction    = secondary.direction;
-
         // Mark the secondary as processed and the track as active
         --inits.secondary_counts[tid];
         secondary            = Secondary{};
@@ -278,8 +272,9 @@ __global__ void process_secondaries_kernel(const ParamsDeviceRef params,
             init.particle.energy      = secondary.energy;
         }
     }
-    // Clear the secondaries from the interaction
-    result.secondaries = {};
+    // Clear the interaction
+    result = {};
+    result.action = Action::unchanged;
 }
 } // end namespace
 

--- a/src/sim/detail/InitializeTracks.cu
+++ b/src/sim/detail/InitializeTracks.cu
@@ -96,9 +96,9 @@ __global__ void init_tracks_kernel(const ParamsDeviceRef         params,
         }
 
         // Initialize the material
-        GeoMaterialView   geo_mat(params.geo_mats, geo.volume_id());
+        GeoMaterialView   geo_mat(params.geo_mats);
         MaterialTrackView mat(params.materials, states.materials, vac_id);
-        mat = {geo_mat.material_id()};
+        mat = {geo_mat.material_id(geo.volume_id())};
     }
 
     // Initialize the physics state

--- a/src/sim/detail/InitializeTracks.cu
+++ b/src/sim/detail/InitializeTracks.cu
@@ -109,10 +109,7 @@ __global__ void init_tracks_kernel(const ParamsDeviceRef         params,
 
     // Interaction representing creation of a new track
     {
-        Interaction& result = states.interactions[vac_id];
-        result.action       = Action::spawned;
-        result.energy       = init.particle.energy;
-        result.direction    = init.geo.dir;
+        states.interactions[vac_id].action = Action::spawned;
     }
 }
 
@@ -273,8 +270,7 @@ __global__ void process_secondaries_kernel(const ParamsDeviceRef params,
         }
     }
     // Clear the interaction
-    result = {};
-    result.action = Action::unchanged;
+    result = Interaction::from_processed();
 }
 } // end namespace
 

--- a/test/geometry/GeoMaterial.test.cc
+++ b/test/geometry/GeoMaterial.test.cc
@@ -67,11 +67,12 @@ TEST_F(GeoMaterialTest, host)
     const unsigned int expected_mat_id[] = {1, 1, 1, 1, 0};
 
     const auto& geo = *this->geo_params();
-    ;
     EXPECT_EQ(5, geo.num_volumes());
+
+    GeoMaterialView geo_mat_view(geo_mat_->host_pointers());
     for (auto i : range(geo.num_volumes()))
     {
-        GeoMaterialView geo_mat_view(geo_mat_->host_pointers(), VolumeId{i});
-        EXPECT_EQ(MaterialId{expected_mat_id[i]}, geo_mat_view.material_id());
+        EXPECT_EQ(MaterialId{expected_mat_id[i]},
+                  geo_mat_view.material_id(VolumeId{i}));
     }
 }


### PR DESCRIPTION
This fixes a few more bugs in the demo loop/track initialization:
- The physics state was not being initialized when a new track was created from a secondary in the parent track's slot in `locate_alive_kernel()`.
- The material state was not being updated when a particle entered a new volume in `move_and_select_model()`. To simplify this fix I modified the `GeoMaterialView` interface so the volume ID is passed as an argument to the `material_id()` method instead of to the constructor.
- The `Interaction` was not being reset at the end of a step after the state change and secondaries had been processed. In most cases (boundary crossings, discrete interactions, spawned tracks) the `action` would be updated correctly in the next step and this wouldn't matter. However, in a couple cases (range limits the step, discrete interaction is rejected in the integral approach) the `action` would be retained from the previous step. If the particle scattered in the previous step, this resulted in the energy and direction being reset to the pre-step values in post-processing, causing the tracks to keep stepping endlessly. With this fix the app runs to completion after a reasonable number of steps.