### PR TITLE
Fix bug in element use in BetheHeitlerInteractor

### DIFF
--- a/src/physics/em/detail/BetheHeitler.cu
+++ b/src/physics/em/detail/BetheHeitler.cu
@@ -60,12 +60,13 @@ bethe_heitler_interact_kernel(const BetheHeitlerPointers                bh,
 
     // Assume only a single element in the material, for now
     CELER_ASSERT(material_view.num_elements() == 1);
-    BetheHeitlerInteractor interact(
-        bh,
-        particle,
-        model.states.direction[tid],
-        allocate_secondaries,
-        material_view.element_view(celeritas::ElementComponentId{0}));
+    ElementView element
+        = material_view.element_view(celeritas::ElementComponentId{0});
+    BetheHeitlerInteractor interact(bh,
+                                    particle,
+                                    model.states.direction[tid],
+                                    allocate_secondaries,
+                                    element);
 
     RngEngine rng(model.states.rng, tid);
     model.states.interactions[tid] = interact(rng);


### PR DESCRIPTION
Right now, we are passing an `ElementView` temporary to the constructor of `BetheHeitlerInteractor`, where it is bound to a const reference member variable. Binding a temporary to a const reference member variable does not extend the lifetime of the temporary, which means that by the time we reach `operator()`, that temporary may no longer exist. This is why the CPU demo loop test is [failing](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/Celeritas/detail/PR-273/1/tests) with an error in `BetheHeitlerInteractor::operator()`.