### PR TITLE
Explicitly declare Thread to avoid Geant4 conflict

### DIFF
--- a/src/base/OpaqueId.hh
+++ b/src/base/OpaqueId.hh
@@ -15,6 +15,10 @@
 
 namespace celeritas
 {
+// Forward declare meaningless struct to avoid conflict with globally
+// namespaced PTL::Thread class when defining ThreadId type.
+struct Thread;
+
 //---------------------------------------------------------------------------//
 /*!
  * Type-safe index for accessing an array.

--- a/src/base/OpaqueId.hh
+++ b/src/base/OpaqueId.hh
@@ -28,6 +28,8 @@ namespace celeritas
 template<class ValueT, class SizeT = ::celeritas::size_type>
 class OpaqueId
 {
+    static_assert(static_cast<SizeT>(-1) > 0, "SizeT must be unsigned.");
+
   public:
     //!@{
     //! Type aliases

--- a/test/base/OpaqueId.test.cc
+++ b/test/base/OpaqueId.test.cc
@@ -57,19 +57,19 @@ TEST(OpaqueIdTest, operations)
 
 TEST(OpaqueIdTest, multi_int)
 {
-    using SId8     = OpaqueId<TestInstantiator, std::int_least8_t>;
+    using UId8     = OpaqueId<TestInstantiator, std::uint_least8_t>;
     using Uint32   = std::uint_least32_t;
     using limits_t = std::numeric_limits<Uint32>;
 
     // Unassigned is always out-of-range
-    EXPECT_FALSE(SId8{} < 0);
-    EXPECT_FALSE(SId8{} < Uint32(limits_t::max()));
-    EXPECT_FALSE(SId8{} < Uint32(127));
-    EXPECT_FALSE(SId8{} < Uint32(128));
-    EXPECT_FALSE(SId8{10} < Uint32(5));
+    EXPECT_FALSE(UId8{} < 0);
+    EXPECT_FALSE(UId8{} < Uint32(limits_t::max()));
+    EXPECT_FALSE(UId8{} < Uint32(255));
+    EXPECT_FALSE(UId8{} < Uint32(256));
+    EXPECT_FALSE(UId8{10} < Uint32(5));
 
     // Check 'true' conditions
-    EXPECT_TRUE(SId8{127} < Uint32(limits_t::max()));
-    EXPECT_TRUE(SId8{127} < Uint32(128));
-    EXPECT_TRUE(SId8{10} < Uint32(15));
+    EXPECT_TRUE(UId8{254} < Uint32(limits_t::max()));
+    EXPECT_TRUE(UId8{254} < Uint32(255));
+    EXPECT_TRUE(UId8{10} < Uint32(15));
 }


### PR DESCRIPTION
This is an attempted workaround for a conflict with `PTL::Thread` when including both Celeritas and Geant4 (v11b) that looks like it results from an errant `using` bringing that typedef into the global scope.

```
from acceleritas/app/g4hpc/src/UserTaskManager.cc:10:
acceleritas/external/celeritas/src/base/OpaqueId.hh:121:34: error: using typedef-name ‘PTL::Thread’ after ‘struct’
 using ThreadId = OpaqueId<struct Thread>;
                                  ^~~~~~
In file included from geant4.11.beta/source/externals/ptl/include/PTL/AutoLock.hh:246,
                 from geant4.11.beta/source/externals/ptl/include/PTL/VTask.hh:32,
                 from geant4.11.beta/source/externals/ptl/include/PTL/Task.hh:34,
                 from geant4.11.beta/source/externals/ptl/include/PTL/TaskGroup.hh:35,
                 from acceleritas/app/g4hpc/include/UserTaskManager.hh:10,
                 from acceleritas/app/g4hpc/src/UserTaskManager.cc:8:
geant4.11.beta/source/externals/ptl/include/PTL/Threading.hh:128:41: note: ‘PTL::Thread’ has a previous declaration here
 typedef std::thread                     Thread;
                                         ^~~~~~
In file included from acceleritas/external/celeritas/src/physics/base/Applicability.hh:14,
                 from acceleritas/external/celeritas/src/physics/base/Model.hh:14,
                 from acceleritas/external/celeritas/src/physics/base/PhysicsParams.hh:15,
                 from acceleritas/app/g4hpc/src/UserTaskManager.cc:10:
acceleritas/external/celeritas/src/base/OpaqueId.hh:121:40: error: template argument 1 is invalid
 using ThreadId = OpaqueId<struct Thread>;
```