### PR TITLE
Use Collection for atomic relaxation backend

### DIFF
--- a/src/physics/base/ModelInterface.hh
+++ b/src/physics/base/ModelInterface.hh
@@ -13,6 +13,7 @@
 #include "random/RngInterface.hh"
 #include "physics/material/MaterialInterface.hh"
 #include "physics/base/CutoffInterface.hh"
+#include "physics/em/AtomicRelaxationInterface.hh"
 #include "sim/SimInterface.hh"
 #include "Secondary.hh"
 #include "ParticleInterface.hh"
@@ -35,10 +36,11 @@ struct ModelInteractParamsRefs
 
     //// DATA ////
 
-    ParamsCRef<ParticleParamsData> particle;
-    ParamsCRef<MaterialParamsData> material;
-    ParamsCRef<PhysicsParamsData>  physics;
-    ParamsCRef<CutoffParamsData>   cutoffs;
+    ParamsCRef<ParticleParamsData>    particle;
+    ParamsCRef<MaterialParamsData>    material;
+    ParamsCRef<PhysicsParamsData>     physics;
+    ParamsCRef<CutoffParamsData>      cutoffs;
+    ParamsCRef<AtomicRelaxParamsData> relaxation;
 
     //// METHODS ////
 
@@ -70,11 +72,12 @@ struct ModelInteractStateRefs
 
     //// DATA ////
 
-    StateRef<ParticleStateData> particle;
-    StateRef<MaterialStateData> material;
-    StateRef<PhysicsStateData>  physics;
-    StateRef<RngStateData>      rng;
-    StateRef<SimStateData>      sim;
+    StateRef<ParticleStateData>    particle;
+    StateRef<MaterialStateData>    material;
+    StateRef<PhysicsStateData>     physics;
+    StateRef<RngStateData>         rng;
+    StateRef<SimStateData>         sim;
+    StateRef<AtomicRelaxStateData> relaxation;
 
     StateItems<Real3>       direction;
     StateItems<Interaction> interactions;

--- a/src/physics/base/PhysicsParams.cc
+++ b/src/physics/base/PhysicsParams.cc
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <map>
 #include <tuple>
+#include "base/Algorithms.hh"
 #include "base/Assert.hh"
 #include "base/Range.hh"
 #include "base/VectorUtils.hh"

--- a/src/physics/em/AtomicRelaxation.hh
+++ b/src/physics/em/AtomicRelaxation.hh
@@ -40,12 +40,13 @@ class AtomicRelaxation
 
   public:
     // Construct with shared and state data
-    inline CELER_FUNCTION AtomicRelaxation(const AtomicRelaxPointers& shared,
-                                           const CutoffView&          cutoffs,
-                                           ElementId                  el_id,
-                                           SubshellId                 shell_id,
-                                           Span<Secondary>  secondaries,
-                                           Span<SubshellId> vacancies);
+    inline CELER_FUNCTION
+    AtomicRelaxation(const AtomicRelaxParamsPointers& shared,
+                     const CutoffView&                cutoffs,
+                     ElementId                        el_id,
+                     SubshellId                       shell_id,
+                     Span<Secondary>                  secondaries,
+                     Span<SubshellId>                 vacancies);
 
     // Simulate atomic relaxation with an initial vacancy in the given shell ID
     template<class Engine>
@@ -53,7 +54,7 @@ class AtomicRelaxation
 
   private:
     // Shared EADL atomic relaxation data
-    const AtomicRelaxPointers& shared_;
+    const AtomicRelaxParamsPointers& shared_;
     // Photon production threshold [MeV]
     real_type gamma_cutoff_;
     // Electron production threshold [MeV]

--- a/src/physics/em/AtomicRelaxation.hh
+++ b/src/physics/em/AtomicRelaxation.hh
@@ -40,13 +40,12 @@ class AtomicRelaxation
 
   public:
     // Construct with shared and state data
-    inline CELER_FUNCTION
-    AtomicRelaxation(const AtomicRelaxParamsPointers& shared,
-                     const CutoffView&                cutoffs,
-                     ElementId                        el_id,
-                     SubshellId                       shell_id,
-                     Span<Secondary>                  secondaries,
-                     Span<SubshellId>                 vacancies);
+    inline CELER_FUNCTION AtomicRelaxation(const AtomicRelaxPointers& shared,
+                                           const CutoffView&          cutoffs,
+                                           ElementId                  el_id,
+                                           SubshellId                 shell_id,
+                                           Span<Secondary>  secondaries,
+                                           Span<SubshellId> vacancies);
 
     // Simulate atomic relaxation with an initial vacancy in the given shell ID
     template<class Engine>
@@ -54,7 +53,7 @@ class AtomicRelaxation
 
   private:
     // Shared EADL atomic relaxation data
-    const AtomicRelaxParamsPointers& shared_;
+    const AtomicRelaxPointers& shared_;
     // Photon production threshold [MeV]
     real_type gamma_cutoff_;
     // Electron production threshold [MeV]

--- a/src/physics/em/AtomicRelaxation.i.hh
+++ b/src/physics/em/AtomicRelaxation.i.hh
@@ -24,12 +24,12 @@ namespace celeritas
  * emitted.
  */
 CELER_FUNCTION
-AtomicRelaxation::AtomicRelaxation(const AtomicRelaxPointers& shared,
-                                   const CutoffView&          cutoffs,
-                                   ElementId                  el_id,
-                                   SubshellId                 shell_id,
-                                   Span<Secondary>            secondaries,
-                                   Span<SubshellId>           vacancies)
+AtomicRelaxation::AtomicRelaxation(const AtomicRelaxParamsPointers& shared,
+                                   const CutoffView&                cutoffs,
+                                   ElementId                        el_id,
+                                   SubshellId                       shell_id,
+                                   Span<Secondary>  secondaries,
+                                   Span<SubshellId> vacancies)
     : shared_(shared)
     , gamma_cutoff_(cutoffs.energy(shared_.gamma_id).value())
     , electron_cutoff_(cutoffs.energy(shared_.electron_id).value())

--- a/src/physics/em/AtomicRelaxation.i.hh
+++ b/src/physics/em/AtomicRelaxation.i.hh
@@ -55,13 +55,8 @@ AtomicRelaxation::operator()(Engine& rng)
     const auto&               shells = shared_.shells[el.shells];
     MiniStack<SubshellId>     vacancies(vacancies_);
 
-    // The sampled shell ID might be outside the available data, in which case
-    // the loop below will immediately exit with no secondaries created.
-    if (shell_id_ < shells.size())
-    {
-        // Push the vacancy created by the primary process onto a stack.
-        vacancies.push(shell_id_);
-    }
+    // Push the vacancy created by the primary process onto a stack.
+    vacancies.push(shell_id_);
 
     // Total number of secondaries
     size_type count      = 0;
@@ -73,7 +68,7 @@ AtomicRelaxation::operator()(Engine& rng)
     {
         // Pop the vacancy off the stack and check if it has transition data
         SubshellId vacancy_id = vacancies.pop();
-        if (!vacancy_id)
+        if (vacancy_id.get() >= shells.size())
             continue;
 
         // Sample a transition (TODO: refactor to use Selector but with

--- a/src/physics/em/AtomicRelaxation.i.hh
+++ b/src/physics/em/AtomicRelaxation.i.hh
@@ -24,12 +24,12 @@ namespace celeritas
  * emitted.
  */
 CELER_FUNCTION
-AtomicRelaxation::AtomicRelaxation(const AtomicRelaxParamsPointers& shared,
-                                   const CutoffView&                cutoffs,
-                                   ElementId                        el_id,
-                                   SubshellId                       shell_id,
-                                   Span<Secondary>  secondaries,
-                                   Span<SubshellId> vacancies)
+AtomicRelaxation::AtomicRelaxation(const AtomicRelaxPointers& shared,
+                                   const CutoffView&          cutoffs,
+                                   ElementId                  el_id,
+                                   SubshellId                 shell_id,
+                                   Span<Secondary>            secondaries,
+                                   Span<SubshellId>           vacancies)
     : shared_(shared)
     , gamma_cutoff_(cutoffs.energy(shared_.gamma_id).value())
     , electron_cutoff_(cutoffs.energy(shared_.electron_id).value())
@@ -39,7 +39,7 @@ AtomicRelaxation::AtomicRelaxation(const AtomicRelaxParamsPointers& shared,
     , vacancies_(vacancies)
 {
     CELER_EXPECT(shared_ && el_id_ < shared_.elements.size()
-                 && shared_.elements[el_id_.get()]);
+                 && shared_.elements[el_id_]);
     CELER_EXPECT(shell_id);
 }
 
@@ -51,11 +51,13 @@ template<class Engine>
 CELER_FUNCTION AtomicRelaxation::result_type
 AtomicRelaxation::operator()(Engine& rng)
 {
-    MiniStack<SubshellId> vacancies(vacancies_);
+    const AtomicRelaxElement& el     = shared_.elements[el_id_];
+    const auto&               shells = shared_.shells[el.shells];
+    MiniStack<SubshellId>     vacancies(vacancies_);
 
     // The sampled shell ID might be outside the available data, in which case
     // the loop below will immediately exit with no secondaries created.
-    if (shell_id_ < shared_.elements[el_id_.get()].shells.size())
+    if (shell_id_ < shells.size())
     {
         // Push the vacancy created by the primary process onto a stack.
         vacancies.push(shell_id_);
@@ -76,15 +78,15 @@ AtomicRelaxation::operator()(Engine& rng)
 
         // Sample a transition (TODO: refactor to use Selector but with
         // "remainder")
-        const AtomicRelaxSubshell& shell
-            = shared_.elements[el_id_.get()].shells[vacancy_id.get()];
-        const TransitionId trans_id = this->sample_transition(shell, rng);
+        const AtomicRelaxSubshell& shell = shells[vacancy_id.get()];
+        const TransitionId trans_id      = this->sample_transition(shell, rng);
 
         if (!trans_id)
             continue;
 
         // Push the new vacancies onto the stack and create the secondary
-        const auto& transition = shell.transitions[trans_id.get()];
+        const auto& transition
+            = shared_.transitions[shell.transitions][trans_id.get()];
         vacancies.push(transition.initial_shell);
         if (transition.auger_shell)
         {
@@ -132,10 +134,12 @@ inline CELER_FUNCTION auto
 AtomicRelaxation::sample_transition(const AtomicRelaxSubshell& shell,
                                     Engine& rng) -> TransitionId
 {
+    const auto& transitions = shared_.transitions[shell.transitions];
+
     real_type accum = -generate_canonical(rng);
-    for (size_type i = 0; i < shell.transitions.size(); ++i)
+    for (size_type i = 0; i < transitions.size(); ++i)
     {
-        accum += shell.transitions[i].probability;
+        accum += transitions[i].probability;
         if (accum > 0)
             return TransitionId{i};
     }

--- a/src/physics/em/AtomicRelaxationHelper.hh
+++ b/src/physics/em/AtomicRelaxationHelper.hh
@@ -25,11 +25,14 @@ namespace celeritas
  * secondaries created in both relaxation and the primary process.
  *
  * \code
-    // Construct the helper for a model that produces a single secondary
-    AtomicRelaxationHelper relax_helper(shared, el_id, allocate, 1);
-    Span<Secondary>  secondaries = relax_helper.allocate_secondaries();
-    Span<SubshellId> vacancies   = relax_helper.allocate_vacancies();
-    if (secondaries.empty() || (secondaries.size() > 1 && vacancies.empty()))
+    // Allocate secondaries for a model that produces a single secondary
+    Span<Secondary> secondaries;
+    size_type       count = relax_helper.max_secondaries() + 1;
+    if (Secondary* ptr = allocate_secondaries(count))
+    {
+        secondaries = {ptr, count};
+    }
+    else
     {
         return Interaction::from_failure();
     }
@@ -37,24 +40,22 @@ namespace celeritas
 
     // ...
 
-    AtomicRelaxation sample_relaxation
-        = relax_helper.build_distribution(secondaries, vacancies, shell_id);
+    AtomicRelaxation sample_relaxation = relax_helper.build_distribution(
+        cutoffs, shell_id, secondaries.subspan(1));
     auto outgoing             = sample_relaxation(rng);
     result.secondaries        = outgoing.secondaries;
     result.energy_deposition -= outgoing.energy;
    \endcode
- *
- * If atomic relaxation is not enabled or does not apply to this element or
- * subshell, the helper will simply allocate space for secondaries created in
- * the primary process and no additional secondaries will be produced in
- * relaxation.
  */
 class AtomicRelaxationHelper
 {
   public:
     // Construct with the currently interacting element
     inline CELER_FUNCTION
-    AtomicRelaxationHelper(const AtomicRelaxPointers& shared, ElementId el_id);
+    AtomicRelaxationHelper(const AtomicRelaxParamsPointers& shared,
+                           const AtomicRelaxStatePointers&  states,
+                           ElementId                        el_id,
+                           ThreadId                         tid);
 
     // Whether atomic relaxation should be applied
     explicit inline CELER_FUNCTION operator bool() const;
@@ -62,21 +63,20 @@ class AtomicRelaxationHelper
     // Space needed for relaxation secondaries
     inline CELER_FUNCTION size_type max_secondaries() const;
 
-    // Space needed for subshell ID stack
-    inline CELER_FUNCTION size_type max_vacancies() const;
+    // Storage for subshell ID stack
+    inline CELER_FUNCTION Span<SubshellId> scratch() const;
 
     // Create the sampling distribution from sampled shell and allocated mem
     inline CELER_FUNCTION AtomicRelaxation
     build_distribution(const CutoffView& cutoffs,
                        SubshellId        shell_id,
-                       Span<Secondary>   secondaries,
-                       Span<SubshellId>  vacancies) const;
+                       Span<Secondary>   secondaries) const;
 
   private:
-    // Shared EADL atomic relaxation data
-    const AtomicRelaxPointers& shared_;
-    // Index in MaterialParams elements
-    ElementId el_id_;
+    const AtomicRelaxParamsPointers& shared_;
+    const AtomicRelaxStatePointers&  states_;
+    const ElementId                  el_id_;
+    const ThreadId                   thread_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/AtomicRelaxationHelper.hh
+++ b/src/physics/em/AtomicRelaxationHelper.hh
@@ -54,8 +54,7 @@ class AtomicRelaxationHelper
   public:
     // Construct with the currently interacting element
     inline CELER_FUNCTION
-    AtomicRelaxationHelper(const AtomicRelaxParamsPointers& shared,
-                           ElementId                        el_id);
+    AtomicRelaxationHelper(const AtomicRelaxPointers& shared, ElementId el_id);
 
     // Whether atomic relaxation should be applied
     explicit inline CELER_FUNCTION operator bool() const;
@@ -75,7 +74,7 @@ class AtomicRelaxationHelper
 
   private:
     // Shared EADL atomic relaxation data
-    const AtomicRelaxParamsPointers& shared_;
+    const AtomicRelaxPointers& shared_;
     // Index in MaterialParams elements
     ElementId el_id_;
 };

--- a/src/physics/em/AtomicRelaxationHelper.i.hh
+++ b/src/physics/em/AtomicRelaxationHelper.i.hh
@@ -13,8 +13,8 @@ namespace celeritas
  * Construct with shared and state data.
  */
 CELER_FUNCTION
-AtomicRelaxationHelper::AtomicRelaxationHelper(
-    const AtomicRelaxParamsPointers& shared, ElementId el_id)
+AtomicRelaxationHelper::AtomicRelaxationHelper(const AtomicRelaxPointers& shared,
+                                               ElementId el_id)
     : shared_(shared), el_id_(el_id)
 {
     CELER_EXPECT(!shared_ || el_id_ < shared_.elements.size());
@@ -27,7 +27,7 @@ AtomicRelaxationHelper::AtomicRelaxationHelper(
 CELER_FUNCTION AtomicRelaxationHelper::operator bool() const
 {
     // Atomic relaxation is enabled and the element has transition data
-    return shared_ && shared_.elements[el_id_.get()];
+    return shared_ && shared_.elements[el_id_];
 }
 
 //---------------------------------------------------------------------------//
@@ -37,7 +37,7 @@ CELER_FUNCTION AtomicRelaxationHelper::operator bool() const
 CELER_FUNCTION size_type AtomicRelaxationHelper::max_secondaries() const
 {
     CELER_EXPECT(*this);
-    return shared_.elements[el_id_.get()].max_secondary;
+    return shared_.elements[el_id_].max_secondary;
 }
 
 //---------------------------------------------------------------------------//
@@ -50,7 +50,7 @@ CELER_FUNCTION size_type AtomicRelaxationHelper::max_secondaries() const
 CELER_FUNCTION size_type AtomicRelaxationHelper::max_vacancies() const
 {
     CELER_EXPECT(*this);
-    return shared_.elements[el_id_.get()].max_stack_size;
+    return shared_.elements[el_id_].max_stack_size;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/AtomicRelaxationParams.cc
+++ b/src/physics/em/AtomicRelaxationParams.cc
@@ -72,7 +72,7 @@ AtomicRelaxationParams::AtomicRelaxationParams(const Input& inp)
     }
 
     // Move to mirrored data, copying to device
-    data_ = CollectionMirror<AtomicRelaxData>{std::move(host_data)};
+    data_ = CollectionMirror<AtomicRelaxParamsData>{std::move(host_data)};
     CELER_ENSURE(data_);
 }
 
@@ -153,7 +153,9 @@ void AtomicRelaxationParams::append_element(const ImportAtomicRelaxation& inp,
     // IDs. For radiative transitions, there is only ever one vacancy waiting
     // to be processed. For non-radiative transitions, the upper bound on the
     // stack size is the number of shells that have transition data.
-    el.max_stack_size = is_auger_enabled_ ? el.shells.size() : 1;
+    data->max_stack_size
+        = is_auger_enabled_ ? std::max(data->max_stack_size, el.shells.size())
+                            : 1;
 
     // Add the elemental data
     CELER_ASSERT(el);

--- a/src/physics/em/AtomicRelaxationParams.cc
+++ b/src/physics/em/AtomicRelaxationParams.cc
@@ -12,9 +12,6 @@
 #include <numeric>
 #include "base/Range.hh"
 #include "base/SoftEqual.hh"
-#include "base/SpanRemapper.hh"
-#include "base/VectorUtils.hh"
-#include "comm/Device.hh"
 #include "detail/Utils.hh"
 
 namespace celeritas
@@ -29,132 +26,51 @@ namespace celeritas
  */
 AtomicRelaxationParams::AtomicRelaxationParams(const Input& inp)
     : is_auger_enabled_(inp.is_auger_enabled)
-    , electron_id_(inp.particles->find(pdg::electron()))
-    , gamma_id_(inp.particles->find(pdg::gamma()))
 {
     CELER_EXPECT(inp.cutoffs);
     CELER_EXPECT(inp.materials);
     CELER_EXPECT(inp.particles);
     CELER_EXPECT(inp.elements.size() == inp.materials->num_elements());
-    CELER_EXPECT(electron_id_);
-    CELER_EXPECT(gamma_id_);
 
-    // Reserve host space (MUST reserve subshells and transitions to avoid
-    // invalidating spans).
-    size_type ss_size = 0;
-    size_type tr_size = 0;
-    for (const auto& el : inp.elements)
-    {
-        ss_size += el.shells.size();
-        for (const auto& shell : el.shells)
-        {
-            tr_size += shell.fluor.size();
-            if (is_auger_enabled_)
-            {
-                tr_size += shell.auger.size();
-            }
-        }
-    }
-    host_elements_.reserve(inp.elements.size());
-    host_shells_.reserve(ss_size);
-    host_transitions_.reserve(tr_size);
+    HostData host_data;
+
+    // Get particle IDs
+    host_data.electron_id = inp.particles->find(pdg::electron());
+    host_data.gamma_id    = inp.particles->find(pdg::gamma());
 
     // Find the minimum electron and photon cutoff energy for each element over
     // all materials. This is used to calculate the maximum number of
     // secondaries that could be created in atomic relaxation for each element.
-    size_type              num_elements = inp.materials->num_elements();
-    std::vector<MevEnergy> min_ecut(num_elements, max_quantity());
-    std::vector<MevEnergy> min_gcut(num_elements, max_quantity());
+    std::vector<MevEnergy> electron_cutoff(inp.elements.size(), max_quantity());
+    std::vector<MevEnergy> gamma_cutoff(inp.elements.size(), max_quantity());
     for (auto mat_id : range(MaterialId{inp.materials->num_materials()}))
     {
         // Electron and photon energy cutoffs for this material
-        auto cutoffs = inp.cutoffs->get(mat_id);
-        auto ecut    = cutoffs.energy(electron_id_);
-        auto gcut    = cutoffs.energy(gamma_id_);
-
+        auto cutoffs  = inp.cutoffs->get(mat_id);
         auto material = inp.materials->get(mat_id);
         for (auto comp_id : range(ElementComponentId{material.num_elements()}))
         {
-            auto el_idx      = material.element_id(comp_id).get();
-            min_ecut[el_idx] = min(min_ecut[el_idx], ecut);
-            min_gcut[el_idx] = min(min_gcut[el_idx], gcut);
+            auto el_idx             = material.element_id(comp_id).get();
+            electron_cutoff[el_idx] = min(
+                electron_cutoff[el_idx], cutoffs.energy(host_data.electron_id));
+            gamma_cutoff[el_idx] = min(gamma_cutoff[el_idx],
+                                       cutoffs.energy(host_data.gamma_id));
         }
     }
 
     // Build elements
-    for (auto el_idx : range(num_elements))
+    make_builder(&host_data.elements).reserve(inp.elements.size());
+    for (auto el_idx : range(inp.elements.size()))
     {
-        this->append_element(
-            inp.elements[el_idx], min_ecut[el_idx], min_gcut[el_idx]);
+        this->append_element(inp.elements[el_idx],
+                             &host_data,
+                             electron_cutoff[el_idx],
+                             gamma_cutoff[el_idx]);
     }
 
-    if (celeritas::device())
-    {
-        // Allocate device vectors
-        device_elements_
-            = DeviceVector<AtomicRelaxElement>(host_elements_.size());
-        device_shells_ = DeviceVector<AtomicRelaxSubshell>(host_shells_.size());
-        device_transitions_
-            = DeviceVector<AtomicRelaxTransition>(host_transitions_.size());
-
-        // Remap shell->transition spans
-        auto remap_transitions
-            = make_span_remapper(make_span(host_transitions_),
-                                 device_transitions_.device_pointers());
-        std::vector<AtomicRelaxSubshell> temp_device_shells = host_shells_;
-        for (AtomicRelaxSubshell& ss : temp_device_shells)
-        {
-            ss.transitions = remap_transitions(ss.transitions);
-        }
-
-        // Remap element->shell spans
-        auto remap_shells = make_span_remapper(
-            make_span(host_shells_), device_shells_.device_pointers());
-        std::vector<AtomicRelaxElement> temp_device_elements = host_elements_;
-        for (AtomicRelaxElement& el : temp_device_elements)
-        {
-            el.shells = remap_shells(el.shells);
-        }
-
-        // Copy vectors to device
-        device_elements_.copy_to_device(make_span(temp_device_elements));
-        device_shells_.copy_to_device(make_span(temp_device_shells));
-        device_transitions_.copy_to_device(make_span(host_transitions_));
-    }
-
-    CELER_ENSURE(host_elements_.size() == inp.elements.size());
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Access EADL data on the host.
- */
-AtomicRelaxParamsPointers AtomicRelaxationParams::host_pointers() const
-{
-    AtomicRelaxParamsPointers result;
-    result.elements    = make_span(host_elements_);
-    result.electron_id = electron_id_;
-    result.gamma_id    = gamma_id_;
-
-    CELER_ENSURE(result);
-    return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Access EADL data on the device.
- */
-AtomicRelaxParamsPointers AtomicRelaxationParams::device_pointers() const
-{
-    CELER_EXPECT(celeritas::device());
-
-    AtomicRelaxParamsPointers result;
-    result.elements    = device_elements_.device_pointers();
-    result.electron_id = electron_id_;
-    result.gamma_id    = gamma_id_;
-
-    CELER_ENSURE(result);
-    return result;
+    // Move to mirrored data, copying to device
+    data_ = CollectionMirror<AtomicRelaxData>{std::move(host_data)};
+    CELER_ENSURE(data_);
 }
 
 //---------------------------------------------------------------------------//
@@ -164,44 +80,12 @@ AtomicRelaxParamsPointers AtomicRelaxationParams::device_pointers() const
  * Convert an element input to a AtomicRelaxElement and store.
  */
 void AtomicRelaxationParams::append_element(const ImportAtomicRelaxation& inp,
+                                            HostData*                     data,
                                             MevEnergy electron_cutoff,
                                             MevEnergy gamma_cutoff)
 {
-    AtomicRelaxElement result;
-
-    // Copy subshell transition data
-    result.shells = this->extend_shells(inp);
-
-    // Calculate the maximum possible number of secondaries that could be
-    // created in atomic relaxation.
-    result.max_secondary
-        = detail::calc_max_secondaries(result, electron_cutoff, gamma_cutoff);
-
-    // Maximum size of the stack used to store unprocessed vacancy subshell
-    // IDs. For radiative transitions, there is only ever one vacancy waiting
-    // to be processed. For non-radiative transitions, the upper bound on the
-    // stack size is the number of shells that have transition data.
-    result.max_stack_size = is_auger_enabled_ ? result.shells.size() : 1;
-
-    // Add to host vector
-    host_elements_.push_back(result);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Process and store electron subshells to the internal list.
- */
-Span<AtomicRelaxSubshell>
-AtomicRelaxationParams::extend_shells(const ImportAtomicRelaxation& inp)
-{
-    CELER_EXPECT(host_shells_.size() + inp.shells.size()
-                 <= host_shells_.capacity());
-
-    // Allocate subshells
-    auto start = host_shells_.size();
-    host_shells_.resize(start + inp.shells.size());
-    Span<AtomicRelaxSubshell> result{host_shells_.data() + start,
-                                     inp.shells.size()};
+    CELER_EXPECT(!inp.shells.empty());
+    AtomicRelaxElement el;
 
     // Create a mapping of subshell designator to index in the shells array
     des_to_id_.clear();
@@ -211,6 +95,8 @@ AtomicRelaxationParams::extend_shells(const ImportAtomicRelaxation& inp)
     }
     CELER_ASSERT(des_to_id_.size() == inp.shells.size());
 
+    // Add subshell data
+    std::vector<AtomicRelaxSubshell> shells(inp.shells.size());
     for (auto i : range(inp.shells.size()))
     {
         // Check that for a given subshell vacancy EADL transition
@@ -223,50 +109,52 @@ AtomicRelaxationParams::extend_shells(const ImportAtomicRelaxation& inp)
             norm += transition.probability;
         CELER_ASSERT(soft_equal(1., norm));
 
-        // Store the radiative transitions
-        auto fluor = this->extend_transitions(inp.shells[i].fluor);
-
-        // Append the non-radiative transitions if Auger effect is enabled
+        // Get all the transitions for this subshell
+        std::vector<ImportAtomicTransition> import_transitions(
+            inp.shells[i].fluor.begin(), inp.shells[i].fluor.end());
         if (is_auger_enabled_)
         {
-            auto auger = this->extend_transitions(inp.shells[i].auger);
-            result[i].transitions = {fluor.begin(), auger.end()};
+            // Append the non-radiative transitions if Auger effect is enabled
+            import_transitions.insert(import_transitions.end(),
+                                      inp.shells[i].auger.begin(),
+                                      inp.shells[i].auger.end());
         }
-        else
+
+        // Add transition data
+        std::vector<AtomicRelaxTransition> transitions(
+            import_transitions.size());
+        for (auto i : range(import_transitions.size()))
         {
-            result[i].transitions = fluor;
+            // Find the index in the shells array given the shell designator.
+            // If the designator is not found, map it to an invalid value.
+            transitions[i].initial_shell
+                = des_to_id_[import_transitions[i].initial_shell];
+            transitions[i].auger_shell
+                = des_to_id_[import_transitions[i].auger_shell];
+            transitions[i].probability = import_transitions[i].probability;
+            transitions[i].energy      = import_transitions[i].energy;
         }
+        shells[i].transitions
+            = make_builder(&data->transitions)
+                  .insert_back(transitions.begin(), transitions.end());
     }
+    el.shells
+        = make_builder(&data->shells).insert_back(shells.begin(), shells.end());
 
-    return result;
-}
+    // Calculate the maximum possible number of secondaries that could be
+    // created in atomic relaxation.
+    el.max_secondary = detail::calc_max_secondaries(
+        make_const_ref(*data), el.shells, electron_cutoff, gamma_cutoff);
 
-//---------------------------------------------------------------------------//
-/*!
- * Process and store transition data to the internal list.
- */
-Span<AtomicRelaxTransition> AtomicRelaxationParams::extend_transitions(
-    const std::vector<ImportAtomicTransition>& transitions)
-{
-    CELER_EXPECT(host_transitions_.size() + transitions.size()
-                 <= host_transitions_.capacity());
+    // Maximum size of the stack used to store unprocessed vacancy subshell
+    // IDs. For radiative transitions, there is only ever one vacancy waiting
+    // to be processed. For non-radiative transitions, the upper bound on the
+    // stack size is the number of shells that have transition data.
+    el.max_stack_size = is_auger_enabled_ ? el.shells.size() : 1;
 
-    auto start = host_transitions_.size();
-    host_transitions_.resize(start + transitions.size());
-
-    for (auto i : range(transitions.size()))
-    {
-        auto& tr = host_transitions_[start + i];
-
-        // Find the index in the shells array given the shell designator. If
-        // the designator is not found, map it to an invalid value.
-        tr.initial_shell = des_to_id_[transitions[i].initial_shell];
-        tr.auger_shell   = des_to_id_[transitions[i].auger_shell];
-        tr.probability   = transitions[i].probability;
-        tr.energy        = transitions[i].energy;
-    }
-
-    return {host_transitions_.data() + start, transitions.size()};
+    // Add the elemental data
+    CELER_ASSERT(el);
+    make_builder(&data->elements).push_back(el);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/AtomicRelaxationParams.cc
+++ b/src/physics/em/AtomicRelaxationParams.cc
@@ -149,13 +149,10 @@ void AtomicRelaxationParams::append_element(const ImportAtomicRelaxation& inp,
     el.max_secondary = detail::calc_max_secondaries(
         make_const_ref(*data), el.shells, electron_cutoff, gamma_cutoff);
 
-    // Maximum size of the stack used to store unprocessed vacancy subshell
-    // IDs. For radiative transitions, there is only ever one vacancy waiting
-    // to be processed. For non-radiative transitions, the upper bound on the
-    // stack size is the number of shells that have transition data.
+    // Maximum size of the stack used to store unprocessed vacancy subshell IDs
     data->max_stack_size
-        = is_auger_enabled_ ? std::max(data->max_stack_size, el.shells.size())
-                            : 1;
+        = max(data->max_stack_size,
+              detail::calc_max_stack_size(make_const_ref(*data), el.shells));
 
     // Add the elemental data
     CELER_ASSERT(el);

--- a/src/physics/em/AtomicRelaxationParams.hh
+++ b/src/physics/em/AtomicRelaxationParams.hh
@@ -26,9 +26,10 @@ class AtomicRelaxationParams
   public:
     //@{
     //! Type aliases
-    using HostRef = AtomicRelaxData<Ownership::const_reference, MemSpace::host>;
+    using HostRef
+        = AtomicRelaxParamsData<Ownership::const_reference, MemSpace::host>;
     using DeviceRef
-        = AtomicRelaxData<Ownership::const_reference, MemSpace::device>;
+        = AtomicRelaxParamsData<Ownership::const_reference, MemSpace::device>;
     using MevEnergy        = units::MevEnergy;
     using SPConstCutoffs   = std::shared_ptr<const CutoffParams>;
     using SPConstMaterials = std::shared_ptr<const MaterialParams>;
@@ -58,10 +59,10 @@ class AtomicRelaxationParams
     std::unordered_map<int, SubshellId> des_to_id_;
 
     // Host/device storage and reference
-    CollectionMirror<AtomicRelaxData> data_;
+    CollectionMirror<AtomicRelaxParamsData> data_;
 
     // HELPER FUNCTIONS
-    using HostData = AtomicRelaxData<Ownership::value, MemSpace::host>;
+    using HostData = AtomicRelaxParamsData<Ownership::value, MemSpace::host>;
     void append_element(const ImportAtomicRelaxation& inp,
                         HostData*                     data,
                         MevEnergy                     electron_cutoff,

--- a/src/physics/em/AtomicRelaxationParams.hh
+++ b/src/physics/em/AtomicRelaxationParams.hh
@@ -29,8 +29,10 @@ class AtomicRelaxationParams
         = AtomicRelaxParamsData<Ownership::const_reference, MemSpace::host>;
     using DeviceRef
         = AtomicRelaxParamsData<Ownership::const_reference, MemSpace::device>;
-    using MevEnergy        = units::MevEnergy;
-    using SPConstCutoffs   = std::shared_ptr<const CutoffParams>;
+    using AtomicNumber   = int;
+    using MevEnergy      = units::MevEnergy;
+    using ReadData       = std::function<ImportAtomicRelaxation(AtomicNumber)>;
+    using SPConstCutoffs = std::shared_ptr<const CutoffParams>;
     using SPConstMaterials = std::shared_ptr<const MaterialParams>;
     using SPConstParticles = std::shared_ptr<const ParticleParams>;
     //@}
@@ -40,6 +42,7 @@ class AtomicRelaxationParams
         SPConstCutoffs   cutoffs;
         SPConstMaterials materials;
         SPConstParticles particles;
+        ReadData         load_data;
         bool is_auger_enabled{false}; //!< Whether to produce Auger electrons
     };
 
@@ -54,6 +57,7 @@ class AtomicRelaxationParams
     const DeviceRef& device_pointers() const { return data_.device(); }
 
   private:
+    // Whether to simulate non-radiative transitions
     bool is_auger_enabled_;
 
     // Host/device storage and reference

--- a/src/physics/em/AtomicRelaxationParams.hh
+++ b/src/physics/em/AtomicRelaxationParams.hh
@@ -41,7 +41,6 @@ class AtomicRelaxationParams
         SPConstMaterials materials;
         SPConstParticles particles;
         bool is_auger_enabled{false}; //!< Whether to produce Auger electrons
-        std::vector<ImportAtomicRelaxation> elements;
     };
 
   public:

--- a/src/physics/em/AtomicRelaxationParams.hh
+++ b/src/physics/em/AtomicRelaxationParams.hh
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <unordered_map>
 #include <vector>
 #include "base/Algorithms.hh"
 #include "base/CollectionMirror.hh"
@@ -55,8 +54,7 @@ class AtomicRelaxationParams
     const DeviceRef& device_pointers() const { return data_.device(); }
 
   private:
-    bool                                is_auger_enabled_;
-    std::unordered_map<int, SubshellId> des_to_id_;
+    bool is_auger_enabled_;
 
     // Host/device storage and reference
     CollectionMirror<AtomicRelaxParamsData> data_;

--- a/src/physics/em/LivermorePEModel.cc
+++ b/src/physics/em/LivermorePEModel.cc
@@ -58,7 +58,7 @@ LivermorePEModel::LivermorePEModel(ModelId               id,
         CELER_ASSERT(num_vacancies > 0);
         resize(&relax_scratch_.vacancies, num_vacancies);
         relax_scratch_ref_          = relax_scratch_;
-        host_data.atomic_relaxation = atomic_relaxation->device_pointers();
+        host_data.atomic_relaxation = atomic_relaxation->host_pointers();
     }
 
     // Move to mirrored data, copying to device

--- a/src/physics/em/LivermorePEModel.cc
+++ b/src/physics/em/LivermorePEModel.cc
@@ -21,9 +21,7 @@ namespace celeritas
 LivermorePEModel::LivermorePEModel(ModelId               id,
                                    const ParticleParams& particles,
                                    const MaterialParams& materials,
-                                   ReadData              load_data,
-                                   SPConstAtomicRelax    atomic_relaxation,
-                                   size_type             num_vacancies)
+                                   ReadData              load_data)
 {
     CELER_EXPECT(id);
     CELER_EXPECT(load_data);
@@ -52,15 +50,6 @@ LivermorePEModel::LivermorePEModel(ModelId               id,
     }
     CELER_ASSERT(host_data.xs.elements.size() == materials.num_elements());
 
-    // Add atomic relaxation data
-    if (atomic_relaxation)
-    {
-        CELER_ASSERT(num_vacancies > 0);
-        resize(&relax_scratch_.vacancies, num_vacancies);
-        relax_scratch_ref_          = relax_scratch_;
-        host_data.atomic_relaxation = atomic_relaxation->host_pointers();
-    }
-
     // Move to mirrored data, copying to device
     data_ = CollectionMirror<detail::LivermorePEData>{std::move(host_data)};
     CELER_ENSURE(this->data_);
@@ -88,8 +77,7 @@ void LivermorePEModel::interact(
     CELER_MAYBE_UNUSED const ModelInteractRefs<MemSpace::device>& pointers) const
 {
 #if CELERITAS_USE_CUDA
-    detail::livermore_pe_interact(
-        this->device_pointers(), relax_scratch_ref_, pointers);
+    detail::livermore_pe_interact(this->device_pointers(), pointers);
 #else
     CELER_ASSERT_UNREACHABLE();
 #endif

--- a/src/physics/em/LivermorePEModel.hh
+++ b/src/physics/em/LivermorePEModel.hh
@@ -13,7 +13,6 @@
 #include "base/CollectionMirror.hh"
 #include "io/ImportLivermorePE.hh"
 #include "physics/base/ParticleParams.hh"
-#include "physics/em/AtomicRelaxationParams.hh"
 #include "physics/material/MaterialParams.hh"
 #include "detail/LivermorePE.hh"
 
@@ -22,22 +21,16 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Set up and launch the Livermore photoelectric model interaction.
- *
- * \todo When multiple methods that use atomic relaxation are in place, we
- * should share AtomicRelaxationParams among them, and move
- * `RelaxationScratchData` into that class, to reduce fixed-size memory
- * allocations.
  */
 class LivermorePEModel final : public Model
 {
   public:
     //!@{
-    using AtomicNumber       = int;
-    using MevEnergy          = units::MevEnergy;
-    using SPConstAtomicRelax = std::shared_ptr<const AtomicRelaxationParams>;
-    using ReadData           = std::function<ImportLivermorePE(AtomicNumber)>;
-    using HostRef            = detail::LivermorePEHostRef;
-    using DeviceRef          = detail::LivermorePEDeviceRef;
+    using AtomicNumber = int;
+    using MevEnergy    = units::MevEnergy;
+    using ReadData     = std::function<ImportLivermorePE(AtomicNumber)>;
+    using HostRef      = detail::LivermorePEHostRef;
+    using DeviceRef    = detail::LivermorePEDeviceRef;
     //!@}
 
   public:
@@ -45,9 +38,7 @@ class LivermorePEModel final : public Model
     LivermorePEModel(ModelId               id,
                      const ParticleParams& particles,
                      const MaterialParams& materials,
-                     ReadData              load_data,
-                     SPConstAtomicRelax    atomic_relaxation = nullptr,
-                     size_type             num_vacancies     = 0);
+                     ReadData              load_data);
 
     // Particle types and energy ranges that this model applies to
     SetApplicability applicability() const final;
@@ -70,11 +61,6 @@ class LivermorePEModel final : public Model
   private:
     // Host/device storage and reference
     CollectionMirror<detail::LivermorePEData> data_;
-
-    detail::RelaxationScratchData<Ownership::value, MemSpace::device>
-        relax_scratch_;
-    detail::RelaxationScratchData<Ownership::reference, MemSpace::device>
-        relax_scratch_ref_;
 
     using HostXsData
         = detail::LivermorePEXsData<Ownership::value, MemSpace::host>;

--- a/src/physics/em/PhotoelectricProcess.cc
+++ b/src/physics/em/PhotoelectricProcess.cc
@@ -33,46 +33,14 @@ PhotoelectricProcess::PhotoelectricProcess(SPConstParticles particles,
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct with atomic relaxation data.
- */
-PhotoelectricProcess::PhotoelectricProcess(SPConstParticles   particles,
-                                           SPConstMaterials   materials,
-                                           SPConstImported    process_data,
-                                           SPConstAtomicRelax atomic_relaxation,
-                                           size_type vacancy_stack_size)
-    : PhotoelectricProcess(
-        std::move(particles), std::move(materials), std::move(process_data))
-{
-    atomic_relaxation_  = std::move(atomic_relaxation);
-    vacancy_stack_size_ = vacancy_stack_size;
-    CELER_ENSURE(atomic_relaxation_);
-    CELER_ENSURE(vacancy_stack_size_ > 0);
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Construct the models associated with this process.
  */
 auto PhotoelectricProcess::build_models(ModelIdGenerator next_id) const
     -> VecModel
 {
     LivermorePEModel::ReadData load_data = LivermorePEReader();
-    if (atomic_relaxation_)
-    {
-        // Construct model with atomic relaxation enabled
-        return {std::make_shared<LivermorePEModel>(next_id(),
-                                                   *particles_,
-                                                   *materials_,
-                                                   load_data,
-                                                   atomic_relaxation_,
-                                                   vacancy_stack_size_)};
-    }
-    else
-    {
-        // Construct model without atomic relaxation
-        return {std::make_shared<LivermorePEModel>(
-            next_id(), *particles_, *materials_, load_data)};
-    }
+    return {std::make_shared<LivermorePEModel>(
+        next_id(), *particles_, *materials_, load_data)};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/PhotoelectricProcess.hh
+++ b/src/physics/em/PhotoelectricProcess.hh
@@ -11,7 +11,6 @@
 
 #include "physics/base/ImportedProcessAdapter.hh"
 #include "physics/base/ParticleParams.hh"
-#include "physics/em/AtomicRelaxationParams.hh"
 #include "physics/material/MaterialParams.hh"
 
 namespace celeritas
@@ -28,7 +27,6 @@ class PhotoelectricProcess : public Process
     using SPConstParticles   = std::shared_ptr<const ParticleParams>;
     using SPConstMaterials   = std::shared_ptr<const MaterialParams>;
     using SPConstImported    = std::shared_ptr<const ImportedProcesses>;
-    using SPConstAtomicRelax = std::shared_ptr<const AtomicRelaxationParams>;
     //!@}
 
   public:
@@ -36,13 +34,6 @@ class PhotoelectricProcess : public Process
     PhotoelectricProcess(SPConstParticles particles,
                          SPConstMaterials materials,
                          SPConstImported  process_data);
-
-    // Construct from Livermore data and EADL atomic relaxation data
-    PhotoelectricProcess(SPConstParticles   particles,
-                         SPConstMaterials   materials,
-                         SPConstImported    process_data,
-                         SPConstAtomicRelax atomic_relaxation,
-                         size_type          vacancy_stack_size);
 
     // Construct the models associated with this process
     VecModel build_models(ModelIdGenerator next_id) const final;
@@ -60,8 +51,6 @@ class PhotoelectricProcess : public Process
     SPConstParticles       particles_;
     SPConstMaterials       materials_;
     ImportedProcessAdapter imported_;
-    SPConstAtomicRelax     atomic_relaxation_;
-    size_type              vacancy_stack_size_{};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/LivermorePE.hh
+++ b/src/physics/em/detail/LivermorePE.hh
@@ -169,7 +169,7 @@ struct LivermorePEData
     LivermorePEXsData<W, M> xs;
 
     //! EADL transition data used for atomic relaxation
-    AtomicRelaxParamsPointers atomic_relaxation;
+    AtomicRelaxData<W, M> atomic_relaxation;
 
     //// MEMBER FUNCTIONS ////
 

--- a/src/physics/em/detail/LivermorePE.hh
+++ b/src/physics/em/detail/LivermorePE.hh
@@ -168,9 +168,6 @@ struct LivermorePEData
     //! Livermore EPICS2014 photoelectric data
     LivermorePEXsData<W, M> xs;
 
-    //! EADL transition data used for atomic relaxation
-    AtomicRelaxData<W, M> atomic_relaxation;
-
     //// MEMBER FUNCTIONS ////
 
     //! Check whether the data is assigned
@@ -187,7 +184,6 @@ struct LivermorePEData
         ids               = other.ids;
         inv_electron_mass = other.inv_electron_mass;
         xs                = other.xs;
-        atomic_relaxation = other.atomic_relaxation;
         return *this;
     }
 };
@@ -200,38 +196,11 @@ using LivermorePEPointers
     = LivermorePEData<Ownership::const_reference, MemSpace::native>;
 
 //---------------------------------------------------------------------------//
-/*!
- * Temporary data needed during interaction.
- */
-template<Ownership W, MemSpace M>
-struct RelaxationScratchData
-{
-    //! Storage for the stack of vacancy subshell IDs
-    StackAllocatorData<SubshellId, W, M> vacancies;
-
-    //! True if assigned
-    explicit CELER_FUNCTION operator bool() const { return bool(vacancies); }
-
-    //! Assign from another set of states
-    template<Ownership W2, MemSpace M2>
-    RelaxationScratchData& operator=(RelaxationScratchData<W2, M2>& other)
-    {
-        CELER_EXPECT(other);
-        vacancies = other.vacancies;
-        return *this;
-    }
-};
-
-using RelaxationScratchDeviceRef
-    = RelaxationScratchData<Ownership::reference, MemSpace::device>;
-
-//---------------------------------------------------------------------------//
 // KERNEL LAUNCHERS
 //---------------------------------------------------------------------------//
 
 // Launch the Livermore photoelectric interaction
 void livermore_pe_interact(const LivermorePEDeviceRef&                pe,
-                           const RelaxationScratchDeviceRef&          scratch,
                            const ModelInteractRefs<MemSpace::device>& model);
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/LivermorePEInteractor.hh
+++ b/src/physics/em/detail/LivermorePEInteractor.hh
@@ -9,13 +9,14 @@
 
 #include "base/Algorithms.hh"
 #include "base/Macros.hh"
+#include "base/StackAllocator.hh"
 #include "base/Types.hh"
 #include "physics/base/CutoffView.hh"
 #include "physics/base/Interaction.hh"
 #include "physics/base/ParticleTrackView.hh"
-#include "base/StackAllocator.hh"
 #include "physics/base/Secondary.hh"
 #include "physics/base/Units.hh"
+#include "physics/em/AtomicRelaxationHelper.hh"
 #include "LivermorePE.hh"
 #include "LivermorePEMicroXsCalculator.hh"
 
@@ -50,20 +51,18 @@ class LivermorePEInteractor
     //!@{
     //! Type aliases
     using MevEnergy = units::MevEnergy;
-    using Scratch
-        = RelaxationScratchData<Ownership::reference, MemSpace::native>;
     //!@}
 
   public:
     // Construct with shared and state data
     inline CELER_FUNCTION
-    LivermorePEInteractor(const LivermorePEPointers& shared,
-                          const Scratch&             scratch,
-                          ElementId                  el_id,
-                          const ParticleTrackView&   particle,
-                          const CutoffView&          cutoffs,
-                          const Real3&               inc_direction,
-                          StackAllocator<Secondary>& allocate);
+    LivermorePEInteractor(const LivermorePEPointers&    shared,
+                          const AtomicRelaxationHelper& relaxation,
+                          ElementId                     el_id,
+                          const ParticleTrackView&      particle,
+                          const CutoffView&             cutoffs,
+                          const Real3&                  inc_direction,
+                          StackAllocator<Secondary>&    allocate);
 
     // Sample an interaction with the given RNG
     template<class Engine>
@@ -75,7 +74,7 @@ class LivermorePEInteractor
     // Shared constant physics properties
     const LivermorePEPointers& shared_;
     // Shared scratch space
-    const Scratch& scratch_;
+    const AtomicRelaxationHelper& relaxation_;
     // Index in MaterialParams elements
     ElementId el_id_;
     // Production thresholds

--- a/src/physics/em/detail/LivermorePEInteractor.i.hh
+++ b/src/physics/em/detail/LivermorePEInteractor.i.hh
@@ -23,15 +23,16 @@ namespace detail
  * handled in code *before* the interactor is constructed.
  */
 CELER_FUNCTION
-LivermorePEInteractor::LivermorePEInteractor(const LivermorePEPointers& shared,
-                                             const Scratch&           scratch,
-                                             ElementId                el_id,
-                                             const ParticleTrackView& particle,
-                                             const CutoffView&        cutoffs,
-                                             const Real3& inc_direction,
-                                             StackAllocator<Secondary>& allocate)
+LivermorePEInteractor::LivermorePEInteractor(
+    const LivermorePEPointers&    shared,
+    const AtomicRelaxationHelper& relaxation,
+    ElementId                     el_id,
+    const ParticleTrackView&      particle,
+    const CutoffView&             cutoffs,
+    const Real3&                  inc_direction,
+    StackAllocator<Secondary>&    allocate)
     : shared_(shared)
-    , scratch_(scratch)
+    , relaxation_(relaxation)
     , el_id_(el_id)
     , cutoffs_(cutoffs)
     , inc_direction_(inc_direction)
@@ -41,7 +42,6 @@ LivermorePEInteractor::LivermorePEInteractor(const LivermorePEPointers& shared,
 {
     CELER_EXPECT(particle.particle_id() == shared_.ids.gamma);
     CELER_EXPECT(inc_energy_.value() > 0);
-    CELER_EXPECT(!shared_.atomic_relaxation || scratch_.vacancies);
 
     inv_energy_ = 1 / inc_energy_.value();
 }
@@ -53,38 +53,15 @@ LivermorePEInteractor::LivermorePEInteractor(const LivermorePEPointers& shared,
 template<class Engine>
 CELER_FUNCTION Interaction LivermorePEInteractor::operator()(Engine& rng)
 {
-    AtomicRelaxationHelper relaxation(shared_.atomic_relaxation, el_id_);
-    Span<Secondary>        secondaries;
-    Span<SubshellId>       vacancies;
-    if (relaxation)
+    Span<Secondary> secondaries;
+    size_type count = relaxation_ ? 1 + relaxation_.max_secondaries() : 1;
+    if (Secondary* ptr = allocate_(count))
     {
-        StackAllocator<SubshellId> allocate_vacancies(scratch_.vacancies);
-        size_type                  count = 1 + relaxation.max_secondaries();
-        if (Secondary* ptr = allocate_(count))
-        {
-            secondaries = {ptr, count};
-        }
-        count = relaxation.max_vacancies();
-        if (SubshellId* ptr = allocate_vacancies(count))
-        {
-            vacancies = {ptr, count};
-        }
-        else
-        {
-            // Failed to allocate space for vacancy stack
-            return Interaction::from_failure();
-        }
+        secondaries = {ptr, count};
     }
-    else if (Secondary* ptr = allocate_(1))
+    else
     {
-        // No relaxation: emit a single electron, and no vacancy stack is
-        // needed.
-        secondaries = {ptr, 1};
-    }
-
-    if (secondaries.empty())
-    {
-        // Failed to allocate space for secondaries or stack
+        // Failed to allocate space for secondaries
         return Interaction::from_failure();
     }
 
@@ -126,12 +103,12 @@ CELER_FUNCTION Interaction LivermorePEInteractor::operator()(Engine& rng)
 
     // Construct interaction for change to primary (incident) particle
     Interaction result = Interaction::from_absorption();
-    if (relaxation)
+    if (relaxation_)
     {
         // Sample secondaries from atomic relaxation, into all but the initial
         // secondary position
-        AtomicRelaxation sample_relaxation = relaxation.build_distribution(
-            cutoffs_, shell_id, secondaries.subspan(1), vacancies);
+        AtomicRelaxation sample_relaxation = relaxation_.build_distribution(
+            cutoffs_, shell_id, secondaries.subspan(1));
 
         auto outgoing = sample_relaxation(rng);
         secondaries   = {secondaries.data(), 1 + outgoing.count};

--- a/src/physics/em/detail/Utils.cc
+++ b/src/physics/em/detail/Utils.cc
@@ -90,6 +90,70 @@ MaxSecondariesCalculator::calc(SubshellId vacancy_shell, size_type count)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Construct with EADL transition data.
+ */
+MaxStackSizeCalculator::MaxStackSizeCalculator(
+    const Values& data, const ItemRange<AtomicRelaxSubshell>& shells)
+    : data_(data), shells_(data.shells[shells])
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the maximum size of the vacancy stack in atomic relaxation.
+ */
+size_type MaxStackSizeCalculator::operator()()
+{
+    // No atomic relaxation data for this element
+    if (shells_.empty())
+        return 0;
+
+    // Find the maximum possible size of the stack, checking over every
+    // subshell the initial vacancy could be in
+    size_type result = 0;
+    for (auto shell_id : range(SubshellId(shells_.size())))
+        result = max(result, this->calc(shell_id));
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Helper function for calculating the maximum possible size the stack can grow
+ * to when the initial vacancy is in the given subshell.
+ */
+size_type MaxStackSizeCalculator::calc(SubshellId vacancy_shell)
+{
+    // No transitions for this subshell, so this is the only shell in the stack
+    if (!vacancy_shell || vacancy_shell.get() >= shells_.size())
+        return 1;
+
+    // Check the table to see if the maximum stack size has already been
+    // calculated for this shell
+    auto it = visited_.find(vacancy_shell);
+    if (it != visited_.end())
+        return it->second;
+
+    size_type max_depth = 0;
+    for (const auto& transition :
+         data_.transitions[shells_[vacancy_shell.get()].transitions])
+    {
+        // If this is a non-radiative transition two vacancies are created and
+        // the stack grows by one; if this is a radiative transition only one
+        // vacancy is created and the stack size stays the same
+        size_type depth = 0;
+        if (transition.auger_shell)
+        {
+            depth = this->calc(transition.auger_shell) + 1;
+        }
+        depth     = max(depth, this->calc(transition.initial_shell));
+        max_depth = max(max_depth, depth);
+    }
+    visited_[vacancy_shell] = max_depth;
+    return max_depth;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Calculate the maximum possible number of secondaries produced in atomic
  * relaxation.
  */
@@ -99,6 +163,17 @@ size_type calc_max_secondaries(const MaxSecondariesCalculator::Values& data,
                                units::MevEnergy gamma_cut)
 {
     return MaxSecondariesCalculator(data, shells, electron_cut, gamma_cut)();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the maximum size the stack of subshell vacancies can grow to in
+ * atomic relaxation.
+ */
+size_type calc_max_stack_size(const MaxSecondariesCalculator::Values& data,
+                              const ItemRange<AtomicRelaxSubshell>&   shells)
+{
+    return MaxStackSizeCalculator(data, shells)();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/Utils.cc
+++ b/src/physics/em/detail/Utils.cc
@@ -124,7 +124,7 @@ size_type MaxStackSizeCalculator::operator()()
 size_type MaxStackSizeCalculator::calc(SubshellId vacancy_shell)
 {
     // No transitions for this subshell, so this is the only shell in the stack
-    if (!vacancy_shell || vacancy_shell.get() >= shells_.size())
+    if (vacancy_shell.get() >= shells_.size())
         return 1;
 
     // Check the table to see if the maximum stack size has already been

--- a/src/physics/em/detail/Utils.cc
+++ b/src/physics/em/detail/Utils.cc
@@ -17,24 +17,15 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Calculate the maximum possible number of secondaries produced in atomic
- * relaxation.
- */
-size_type calc_max_secondaries(const AtomicRelaxElement& el,
-                               units::MevEnergy          electron_cut,
-                               units::MevEnergy          gamma_cut)
-{
-    return MaxSecondariesCalculator(el, electron_cut, gamma_cut)();
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Construct with EADL transition data and production thresholds.
  */
-MaxSecondariesCalculator::MaxSecondariesCalculator(const AtomicRelaxElement& el,
-                                                   MevEnergy electron_cut,
-                                                   MevEnergy gamma_cut)
-    : shells_(el.shells)
+MaxSecondariesCalculator::MaxSecondariesCalculator(
+    const Values&                         data,
+    const ItemRange<AtomicRelaxSubshell>& shells,
+    MevEnergy                             electron_cut,
+    MevEnergy                             gamma_cut)
+    : data_(data)
+    , shells_(data.shells[shells])
     , electron_cut_(electron_cut.value())
     , gamma_cut_(gamma_cut.value())
 {
@@ -76,7 +67,8 @@ MaxSecondariesCalculator::calc(SubshellId vacancy_shell, size_type count)
         return count + it->second;
 
     size_type sub_count = 0;
-    for (const auto& transition : shells_[vacancy_shell.get()].transitions)
+    for (const auto& transition :
+         data_.transitions[shells_[vacancy_shell.get()].transitions])
     {
         // If this is a non-radiative transition with an energy above the
         // electron production threshold, create an electron; if this is a
@@ -94,6 +86,19 @@ MaxSecondariesCalculator::calc(SubshellId vacancy_shell, size_type count)
     }
     visited_[vacancy_shell] = sub_count;
     return count + sub_count;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the maximum possible number of secondaries produced in atomic
+ * relaxation.
+ */
+size_type calc_max_secondaries(const MaxSecondariesCalculator::Values& data,
+                               const ItemRange<AtomicRelaxSubshell>&   shells,
+                               units::MevEnergy electron_cut,
+                               units::MevEnergy gamma_cut)
+{
+    return MaxSecondariesCalculator(data, shells, electron_cut, gamma_cut)();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/Utils.hh
+++ b/src/physics/em/detail/Utils.hh
@@ -17,12 +17,6 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
-// Calculate the maximum possible secondaries produced in atomic relaxation
-size_type calc_max_secondaries(const AtomicRelaxElement& el,
-                               units::MevEnergy          electron_cut,
-                               units::MevEnergy          gamma_cut);
-
-//---------------------------------------------------------------------------//
 /*!
  * Helper class for calculating the maximum possible number of secondaries
  * produced in atomic relaxation for a given element and electron/photon
@@ -34,18 +28,21 @@ class MaxSecondariesCalculator
     //!@{
     //! Type aliases
     using MevEnergy = units::MevEnergy;
+    using Values = AtomicRelaxData<Ownership::const_reference, MemSpace::host>;
     //!@}
 
   public:
     // Construct with EADL transition data and production thresholds
-    MaxSecondariesCalculator(const AtomicRelaxElement& el,
-                             MevEnergy                 electron_cut,
-                             MevEnergy                 gamma_cut);
+    MaxSecondariesCalculator(const Values&                         data,
+                             const ItemRange<AtomicRelaxSubshell>& shells,
+                             MevEnergy electron_cut,
+                             MevEnergy gamma_cut);
 
     // Calculate the maximum possible number of secondaries produced
     size_type operator()();
 
   private:
+    const Values&                             data_;
     Span<const AtomicRelaxSubshell>           shells_;
     const real_type                           electron_cut_;
     const real_type                           gamma_cut_;
@@ -55,6 +52,13 @@ class MaxSecondariesCalculator
 
     size_type calc(SubshellId vacancy_shell, size_type count);
 };
+
+//---------------------------------------------------------------------------//
+// Calculate the maximum possible secondaries produced in atomic relaxation
+size_type calc_max_secondaries(const MaxSecondariesCalculator::Values& data,
+                               const ItemRange<AtomicRelaxSubshell>&   shells,
+                               units::MevEnergy electron_cut,
+                               units::MevEnergy gamma_cut);
 
 //---------------------------------------------------------------------------//
 } // namespace detail

--- a/src/physics/em/detail/Utils.hh
+++ b/src/physics/em/detail/Utils.hh
@@ -55,11 +55,48 @@ class MaxSecondariesCalculator
 };
 
 //---------------------------------------------------------------------------//
+/*!
+ * Helper class for calculating the maximum size the stack of unprocessed
+ * subshell vacancies can grow to for a given element while simulating the
+ * cascade of photons and electrons in atomic relaxation.
+ */
+class MaxStackSizeCalculator
+{
+  public:
+    //!@{
+    //! Type aliases
+    using Values
+        = AtomicRelaxParamsData<Ownership::const_reference, MemSpace::host>;
+    //!@}
+
+  public:
+    // Construct with EADL transition data
+    MaxStackSizeCalculator(const Values&                         data,
+                           const ItemRange<AtomicRelaxSubshell>& shells);
+
+    // Calculate the maximum size of the stack
+    size_type operator()();
+
+  private:
+    const Values&                             data_;
+    Span<const AtomicRelaxSubshell>           shells_;
+    std::unordered_map<SubshellId, size_type> visited_;
+
+    // HELPER FUNCTIONS
+
+    size_type calc(SubshellId vacancy_shell);
+};
+
+//---------------------------------------------------------------------------//
 // Calculate the maximum possible secondaries produced in atomic relaxation
 size_type calc_max_secondaries(const MaxSecondariesCalculator::Values& data,
                                const ItemRange<AtomicRelaxSubshell>&   shells,
                                units::MevEnergy electron_cut,
                                units::MevEnergy gamma_cut);
+
+// Calculate the maximum size of the vacancy stack in atomic relaxation
+size_type calc_max_stack_size(const MaxStackSizeCalculator::Values& data,
+                              const ItemRange<AtomicRelaxSubshell>& shells);
 
 //---------------------------------------------------------------------------//
 } // namespace detail

--- a/src/physics/em/detail/Utils.hh
+++ b/src/physics/em/detail/Utils.hh
@@ -28,7 +28,8 @@ class MaxSecondariesCalculator
     //!@{
     //! Type aliases
     using MevEnergy = units::MevEnergy;
-    using Values = AtomicRelaxData<Ownership::const_reference, MemSpace::host>;
+    using Values
+        = AtomicRelaxParamsData<Ownership::const_reference, MemSpace::host>;
     //!@}
 
   public:

--- a/test/physics/em/LivermorePE.test.cc
+++ b/test/physics/em/LivermorePE.test.cc
@@ -16,6 +16,7 @@
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
 #include "comm/Device.hh"
+#include "io/AtomicRelaxationReader.hh"
 #include "io/ImportPhysicsTable.hh"
 #include "io/LivermorePEReader.hh"
 #include "physics/base/Units.hh"
@@ -32,6 +33,7 @@
 using celeritas::Applicability;
 using celeritas::AtomicRelaxationHelper;
 using celeritas::AtomicRelaxationParams;
+using celeritas::AtomicRelaxationReader;
 using celeritas::AtomicRelaxParamsData;
 using celeritas::AtomicRelaxStateData;
 using celeritas::ElementId;
@@ -109,9 +111,12 @@ class LivermorePETest : public celeritas_test::InteractorHostTestBase
             ModelId{0}, particles, *this->material_params(), read_element_data);
 
         // Set atomic relaxation data
+        AtomicRelaxationReader read_transition_data(data_path.c_str(),
+                                                    data_path.c_str());
         relax_inp_.cutoffs   = this->cutoff_params();
         relax_inp_.materials = this->material_params();
         relax_inp_.particles = this->particle_params();
+        relax_inp_.load_data = read_transition_data;
 
         // Set default particle to incident 1 keV photon
         this->set_inc_particle(pdg::gamma(), MevEnergy{0.001});

--- a/test/physics/em/LivermorePE.test.cc
+++ b/test/physics/em/LivermorePE.test.cc
@@ -59,7 +59,6 @@ class LivermorePETest : public celeritas_test::InteractorHostTestBase
   protected:
     void set_relaxation_params(AtomicRelaxationParams::Input inp)
     {
-        CELER_EXPECT(!inp.elements.empty());
         relax_params_
             = std::make_shared<AtomicRelaxationParams>(std::move(inp));
     }
@@ -110,7 +109,6 @@ class LivermorePETest : public celeritas_test::InteractorHostTestBase
         // Set atomic relaxation data
         AtomicRelaxationReader read_transition_data(data_path.c_str(),
                                                     data_path.c_str());
-        relax_inp_.elements.push_back(read_transition_data(19));
         relax_inp_.cutoffs   = this->cutoff_params();
         relax_inp_.materials = this->material_params();
         relax_inp_.particles = this->particle_params();

--- a/test/physics/em/LivermorePE.test.cc
+++ b/test/physics/em/LivermorePE.test.cc
@@ -105,7 +105,6 @@ class LivermorePETest : public celeritas_test::InteractorHostTestBase
         // Set Livermore photoelectric data
         std::string       data_path = this->test_data_path("physics/em", "");
         LivermorePEReader read_element_data(data_path.c_str());
-
         model_ = std::make_shared<LivermorePEModel>(
             ModelId{0}, particles, *this->material_params(), read_element_data);
 
@@ -348,7 +347,7 @@ TEST_F(LivermorePETest, distributions_all)
     // Load atomic relaxation data
     relax_inp_.is_auger_enabled = true;
     set_relaxation_params(relax_inp_);
-    EXPECT_EQ(4, relax_params_ref_.max_stack_size);
+    EXPECT_EQ(3, relax_params_ref_.max_stack_size);
 
     // Allocate scratch space for vacancy stack
     resize(&relax_states_, relax_params_ref_, 1);
@@ -629,10 +628,10 @@ TEST_F(LivermorePETest, utils)
         EXPECT_EQ(std::exp2(num_shells) - 1, max_secondaries);
 
         // With non-radiative transitions in every shell, the maximum stack
-        // size will be the number of shells with transition data
+        // size will be one more than the number of shells with transition data
         auto max_stack_size
             = calc_max_stack_size(make_const_ref(data), el.shells);
-        EXPECT_EQ(num_shells, max_stack_size);
+        EXPECT_EQ(num_shells + 1, max_stack_size);
     }
     {
         relax_inp_.is_auger_enabled = true;


### PR DESCRIPTION
This refactors the atomic relaxation implementation to use `Collection`s. There are a few other changes:

- Use a per-thread scratch space instead of a `StackAllocator` as storage for the subshell vacancy stack
- Add a helper function to calculate the maximum possible size of the stack given some transition data. The bounds `max_stack_size` a little tighter than what we had previously -- now guaranteed to be no more than 7 for every element.
- Decouple atomic relaxation from the photoelectric process/model/interface
- Fix the `SubshellId`s for shells with no transition data. Previously these were mapped to invalid IDs, but really only the Auger shell IDs for radiative transitions should be invalid; the rest will be valid IDs but outside the bounds of the `shells` array.