### PR TITLE
Hotfix: conflict between #293 and #289

### DIFF
--- a/app/demo-loop/EnergyDiagnostic.hh
+++ b/app/demo-loop/EnergyDiagnostic.hh
@@ -13,7 +13,7 @@
 #include "base/CollectionMirror.hh"
 #include "base/Macros.hh"
 #include "base/Types.hh"
-#include "sim/TrackInterface.hh"
+#include "sim/TrackData.hh"
 
 namespace demo_loop
 {


### PR DESCRIPTION
The renaming of files in #293 introduced an "implicit" merge conflict that didn't get caught by the CI.