### PR TITLE
Allow multiple VecGeom navigation states on host

### DIFF
--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -34,7 +34,7 @@ if result_ge.returncode:
     exit(result_ge.returncode)
 
 storage_factor = 10 if use_device else 100
-max_num_tracks = 128*32 if use_device else 1
+max_num_tracks = 128*32 if use_device else 15
 
 inp = {
     'run': {

--- a/src/base/CollectionBuilder.hh
+++ b/src/base/CollectionBuilder.hh
@@ -65,7 +65,8 @@ class CollectionBuilder
     inline ItemRangeT insert_back(std::initializer_list<value_type> init);
 
     // Append a single element
-    inline ItemIdT push_back(value_type element);
+    inline ItemIdT push_back(const value_type& element);
+    inline ItemIdT push_back(value_type&& element);
 
     //! Number of elements in the collection
     size_type size() const { return col_.size(); }

--- a/src/base/CollectionBuilder.i.hh
+++ b/src/base/CollectionBuilder.i.hh
@@ -53,13 +53,24 @@ auto CollectionBuilder<T, M, I>::insert_back(std::initializer_list<T> init)
  * Reserve space for the given number of elements.
  */
 template<class T, MemSpace M, class I>
-auto CollectionBuilder<T, M, I>::push_back(T el) -> ItemIdT
+auto CollectionBuilder<T, M, I>::push_back(const T& el) -> ItemIdT
 {
     CELER_EXPECT(this->storage().size() + 1 <= this->max_size());
     static_assert(M == MemSpace::host,
                   "Insertion currently works only for host memory");
     size_type idx = this->size();
     this->storage().push_back(el);
+    return ItemIdT{idx};
+}
+
+template<class T, MemSpace M, class I>
+auto CollectionBuilder<T, M, I>::push_back(T&& el) -> ItemIdT
+{
+    CELER_EXPECT(this->storage().size() + 1 <= this->max_size());
+    static_assert(M == MemSpace::host,
+                  "Insertion currently works only for host memory");
+    size_type idx = this->size();
+    this->storage().push_back(std::move(el));
     return ItemIdT{idx};
 }
 

--- a/src/geometry/detail/VGNavCollection.cc
+++ b/src/geometry/detail/VGNavCollection.cc
@@ -21,9 +21,13 @@ void VGNavCollection<Ownership::value, MemSpace::host>::resize(int max_depth,
                                                                size_type size)
 {
     CELER_EXPECT(max_depth > 0);
-    CELER_EXPECT(size == 1);
 
-    nav_state.reset(NavState::MakeInstance(max_depth));
+    nav_state.clear();
+    nav_state.reserve(size);
+    for (size_type i = 0; i < size; ++i)
+    {
+        nav_state.emplace_back(NavState::MakeInstance(max_depth));
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -35,7 +39,7 @@ void VGNavCollection<Ownership::value, MemSpace::host>::resize(int max_depth,
 void VGNavCollection<Ownership::reference, MemSpace::host>::operator=(
     VGNavCollection<Ownership::value, MemSpace::host>& other)
 {
-    ptr = other.nav_state.get();
+    ptr = &other.nav_state;
 }
 
 //---------------------------------------------------------------------------//
@@ -47,8 +51,7 @@ auto VGNavCollection<Ownership::reference, MemSpace::host>::at(int,
     -> NavState&
 {
     CELER_EXPECT(*this);
-    CELER_EXPECT(id.get() == 0);
-    return *ptr;
+    return *(*ptr)[id.get()];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/detail/VGNavCollection.hh
+++ b/src/geometry/detail/VGNavCollection.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 #include <VecGeom/navigation/NavigationState.h>
 #include <VecGeom/navigation/NavStatePool.h>
 #include "base/Assert.hh"
@@ -54,12 +55,12 @@ struct VGNavCollection<Ownership::value, MemSpace::host>
 {
     using NavState = vecgeom::cxx::NavigationState;
 
-    std::unique_ptr<NavState> nav_state;
+    std::vector<std::unique_ptr<NavState>> nav_state;
 
     // Resize with a number of states (must be 1)
     void resize(int max_depth, size_type size);
     // Whether the collection is assigned
-    explicit operator bool() const { return static_cast<bool>(nav_state); }
+    explicit operator bool() const { return !nav_state.empty(); }
 };
 
 //---------------------------------------------------------------------------//
@@ -71,14 +72,14 @@ struct VGNavCollection<Ownership::reference, MemSpace::host>
 {
     using NavState = vecgeom::cxx::NavigationState;
 
-    NavState* ptr = nullptr;
+    std::vector<std::unique_ptr<NavState>>* ptr = nullptr;
 
     // Obtain reference from host memory
     void operator=(VGNavCollection<Ownership::value, MemSpace::host>& other);
     // Get the navigation state for a given thread
     NavState& at(int, ThreadId id) const;
     //! True if the collection is assigned/valiid
-    explicit operator bool() const { return static_cast<bool>(ptr); }
+    explicit operator bool() const { return !ptr->empty(); }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/geometry/detail/VGNavCollection.hh
+++ b/src/geometry/detail/VGNavCollection.hh
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <VecGeom/navigation/NavigationState.h>
 #include <VecGeom/navigation/NavStatePool.h>
 #include "base/Assert.hh"
+#include "base/Collection.hh"
 #include "base/OpaqueId.hh"
 #include "base/Types.hh"
 
@@ -53,9 +53,10 @@ struct VGNavCollection<Ownership::reference, MemSpace::device>;
 template<>
 struct VGNavCollection<Ownership::value, MemSpace::host>
 {
-    using NavState = vecgeom::cxx::NavigationState;
+    using NavState   = vecgeom::cxx::NavigationState;
+    using UPNavState = std::unique_ptr<NavState>;
 
-    std::vector<std::unique_ptr<NavState>> nav_state;
+    StateCollection<UPNavState, Ownership::value, MemSpace::host> nav_state;
 
     // Resize with a number of states (must be 1)
     void resize(int max_depth, size_type size);
@@ -70,16 +71,17 @@ struct VGNavCollection<Ownership::value, MemSpace::host>
 template<>
 struct VGNavCollection<Ownership::reference, MemSpace::host>
 {
-    using NavState = vecgeom::cxx::NavigationState;
+    using NavState   = vecgeom::cxx::NavigationState;
+    using UPNavState = std::unique_ptr<NavState>;
 
-    std::vector<std::unique_ptr<NavState>>* ptr = nullptr;
+    StateCollection<UPNavState, Ownership::reference, MemSpace::host> nav_state;
 
     // Obtain reference from host memory
     void operator=(VGNavCollection<Ownership::value, MemSpace::host>& other);
     // Get the navigation state for a given thread
     NavState& at(int, ThreadId id) const;
     //! True if the collection is assigned/valiid
-    explicit operator bool() const { return !ptr->empty(); }
+    explicit operator bool() const { return !nav_state.empty(); }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/SeltzerBergerInteractor.i.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.i.hh
@@ -50,7 +50,7 @@ SeltzerBergerInteractor::SeltzerBergerInteractor(
 
 //---------------------------------------------------------------------------//
 /*!
- * Pair-production using the Seltzer-Berger model.
+ * Bremsstrahlung using the Seltzer-Berger model.
  *
  * See section 10.2.1 of the Geant physics reference 10.6.
  */


### PR DESCRIPTION
This PR changes `VGNavCollection<..., host>` to hold a collection of navigation states. I originally hoped to use NavStatePool directly from VecGeom but if I'm not mistaken, it looks like it's hardwired to be used on GPU. To build the collection of navigation states (each of which is a unique_ptr), I had to add an overload for `CollectionBuilder::push_back(T&&)`.

Now that CPU code can handle multiple primaries instead, I ran the demo loop to completion and get slightly below 15 GeV of energy deposited (as expected, accounting for the bug with positron production cutoff) with the same distribution as observed on GPU.