### PR TITLE
Allow exactly zero energy loss in Urban model for energy loss fluctuation

### DIFF
--- a/src/physics/em/EnergyLossDistribution.i.hh
+++ b/src/physics/em/EnergyLossDistribution.i.hh
@@ -224,7 +224,7 @@ CELER_FUNCTION real_type EnergyLossDistribution::sample_urban(Engine& rng) const
           * (this->sample_excitation_loss(xs_exc, binding_energy, rng)
              + this->sample_ionization_loss(xs_ion, rng));
 
-    CELER_ENSURE(result > 0);
+    CELER_ENSURE(result >= 0);
     return result;
 }
 


### PR DESCRIPTION
When running the simple CMS problem on CPU with a debug build, I ran into a case where we were getting exactly zero energy loss in `EnergyLossDistribution::sample_urban`, and right now we have `CELER_ENSURE(result > 0)`. After some discussion with @amandalund, it sounds like exactly zero energy loss is possible and should be allowed.