### PR TITLE
Add static surface actions for ORANGE

### DIFF
--- a/src/base/Array.hh
+++ b/src/base/Array.hh
@@ -38,9 +38,6 @@ struct Array
     using const_iterator  = const_pointer;
     //!@}
 
-    //! Static size (not in std::array)
-    static constexpr size_type extent = N;
-
     //// DATA ////
 
     T data_[N]; //!< Storage
@@ -84,9 +81,6 @@ struct Array
     }
     //!@}
 };
-
-template<class T, size_type N>
-constexpr size_type Array<T, N>::extent;
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/src/orange/surfaces/SurfaceAction.hh
+++ b/src/orange/surfaces/SurfaceAction.hh
@@ -8,20 +8,40 @@
 #pragma once
 
 #include "base/Macros.hh"
-#include "Surfaces.hh"
 #include "detail/SurfaceAction.hh"
 
 namespace celeritas
 {
+class Surfaces;
+
 //---------------------------------------------------------------------------//
 /*!
  * Helper function for creating a SurfaceAction instance.
+ *
+ * The function argument must have an \c operator() that takes a surface type.
  */
 template<class F>
 inline CELER_FUNCTION detail::SurfaceAction<F>
                       make_surface_action(const Surfaces& surfaces, F&& action)
 {
     return detail::SurfaceAction<F>{surfaces, std::forward<F>(action)};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Helper function for creating a StaticSurfaceAction instance.
+ *
+ * The template parameter must be a class templated on surface type that
+ * has an \c operator() for returning the desired value.
+ *
+ * The result takes a SurfaceType enum as an argument and returns the traits
+ * value for the given type.
+ */
+template<template<class> class T>
+inline CELER_FUNCTION detail::StaticSurfaceAction<T>
+                      make_static_surface_action()
+{
+    return detail::StaticSurfaceAction<T>{};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surfaces/detail/SurfaceAction.hh
+++ b/src/orange/surfaces/detail/SurfaceAction.hh
@@ -143,6 +143,7 @@ StaticSurfaceAction<T>::operator()(SurfaceType type) const
 #define ORANGE_SSA_GET(SURFACE) return T<SURFACE>()();
     ORANGE_SURF_DISPATCH_IMPL(ORANGE_SSA_GET, type);
 #undef ORANGE_SSA_GET
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surfaces/GeneralQuadric.test.cc
+++ b/test/orange/surfaces/GeneralQuadric.test.cc
@@ -44,7 +44,7 @@ TEST_F(GeneralQuadricTest, all)
 {
     EXPECT_EQ(celeritas::SurfaceType::gq, GeneralQuadric::surface_type());
     EXPECT_EQ(10, GeneralQuadric::Storage::extent);
-    EXPECT_EQ(2, GeneralQuadric::Intersections::extent);
+    EXPECT_EQ(2, GeneralQuadric::Intersections{}.size());
 
     const Real3 second{10.3125, 22.9375, 15.75};
     const Real3 cross{-21.867141445557, -20.25, 11.69134295109};

--- a/test/orange/surfaces/Sphere.test.cc
+++ b/test/orange/surfaces/Sphere.test.cc
@@ -47,7 +47,7 @@ TEST_F(SphereTest, all)
 {
     EXPECT_EQ(celeritas::SurfaceType::s, Sphere::surface_type());
     EXPECT_EQ(4, Sphere::Storage::extent);
-    EXPECT_EQ(2, Sphere::Intersections::extent);
+    EXPECT_EQ(2, Sphere::Intersections{}.size());
 
     const Real3 origin{-1.1, 2.2, -3.3};
     real_type   radius = 4.4;

--- a/test/orange/surfaces/SurfaceAction.test.cc
+++ b/test/orange/surfaces/SurfaceAction.test.cc
@@ -107,6 +107,10 @@ class SurfaceActionTest : public celeritas::Test
     std::mt19937      rng_;
 };
 
+class StaticSurfaceActionTest : public celeritas::Test
+{
+};
+
 //---------------------------------------------------------------------------//
 // HELPERS
 //---------------------------------------------------------------------------//
@@ -125,6 +129,25 @@ struct ToString
     ToString()                = default;
     ToString(const ToString&) = delete;
     ToString(ToString&&)      = default;
+};
+
+//---------------------------------------------------------------------------//
+//! Get the amount of storage
+template<class S>
+struct GetStorageSize
+{
+    constexpr size_type operator()() const noexcept
+    {
+        return S::Storage::extent * sizeof(typename S::Storage::value_type);
+    }
+};
+
+//---------------------------------------------------------------------------//
+//! Get the actual size of a surface instance
+template<class S>
+struct GetTypeSize
+{
+    constexpr size_type operator()() const noexcept { return sizeof(S); }
 };
 
 //---------------------------------------------------------------------------//
@@ -238,5 +261,18 @@ TEST_F(SurfaceActionTest, TEST_IF_CELERITAS_CUDA(device_distances))
                       senses_to_string(host_states.sense[test_threads]));
         EXPECT_VEC_SOFT_EQ(expected_distance,
                            host_states.distance[test_threads]);
+    }
+}
+
+//---------------------------------------------------------------------------//
+//! Loop through all surface types and ensure "storage" type is correctly sized
+TEST_F(StaticSurfaceActionTest, check_surface_sizes)
+{
+    auto get_expected_storage = make_static_surface_action<GetTypeSize>();
+    auto get_actual_storage   = make_static_surface_action<GetStorageSize>();
+
+    for (auto st : range(SurfaceType::size_))
+    {
+        EXPECT_EQ(get_expected_storage(st), get_actual_storage(st));
     }
 }


### PR DESCRIPTION
- Define new helper function that doesn't require a Surfaces instance
  (useful during construction)
- Refactor surface action to use C++14 decltype(auto)
- Remove nonstandard Array::extent