### PR TITLE
Allow arbitrary number of tracks on CPU

### DIFF
--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -33,9 +33,6 @@ if result_ge.returncode:
     print("fatal: geant-exporter failed with error", result_ge.returncode)
     exit(result_ge.returncode)
 
-storage_factor = 10 if use_device else 100
-max_num_tracks = 128*32 if use_device else 15
-
 inp = {
     'run': {
         'use_device': use_device,
@@ -43,9 +40,9 @@ inp = {
         'physics_filename': physics_filename,
         'hepmc3_filename': hepmc3_filename,
         'seed': 12345,
-        'max_num_tracks': max_num_tracks,
+        'max_num_tracks': 128*32,
         'max_steps': 128,
-        'storage_factor': storage_factor
+        'storage_factor': 10
     }
 }
 

--- a/src/physics/em/detail/BetheHeitlerLauncher.hh
+++ b/src/physics/em/detail/BetheHeitlerLauncher.hh
@@ -36,8 +36,8 @@ struct BetheHeitlerLauncher
     {
     }
 
-    const BetheHeitlerData&     bh;    //!< Shared data for interactor
-    const ModelInteractRef<M>&  model; //!< State data needed to interact
+    const BetheHeitlerData&    bh;    //!< Shared data for interactor
+    const ModelInteractRef<M>& model; //!< State data needed to interact
 
     //! Create track views and launch interactor
     inline CELER_FUNCTION void operator()(ThreadId tid) const;
@@ -53,9 +53,6 @@ CELER_FUNCTION void BetheHeitlerLauncher<M>::operator()(ThreadId tid) const
     // Setup for ElementView access
     MaterialTrackView material(
         model.params.material, model.states.material, tid);
-    // Cache the associated MaterialView as function calls to
-    // MaterialTrackView are expensive
-    MaterialView material_view = material.material_view();
 
     PhysicsTrackView physics(model.params.physics,
                              model.states.physics,
@@ -67,6 +64,10 @@ CELER_FUNCTION void BetheHeitlerLauncher<M>::operator()(ThreadId tid) const
     // selected
     if (physics.model_id() != bh.model_id)
         return;
+
+    // Cache the associated MaterialView as function calls to
+    // MaterialTrackView are expensive
+    MaterialView material_view = material.material_view();
 
     // Assume only a single element in the material, for now
     CELER_ASSERT(material_view.num_elements() == 1);

--- a/src/physics/em/detail/LivermorePELauncher.hh
+++ b/src/physics/em/detail/LivermorePELauncher.hh
@@ -56,13 +56,13 @@ CELER_FUNCTION void LivermorePELauncher<M>::operator()(ThreadId tid) const
                              particle.particle_id(),
                              material.material_id(),
                              tid);
-    CutoffView       cutoffs(model.params.cutoffs, material.material_id());
 
     // This interaction only applies if the Livermore PE model was selected
     if (physics.model_id() != pe.ids.model)
         return;
 
-    RngEngine rng(model.states.rng, tid);
+    CutoffView cutoffs(model.params.cutoffs, material.material_id());
+    RngEngine  rng(model.states.rng, tid);
 
     // Sample an element
     ElementSelector select_el(

--- a/src/physics/em/detail/MollerBhabhaLauncher.hh
+++ b/src/physics/em/detail/MollerBhabhaLauncher.hh
@@ -37,8 +37,8 @@ struct MollerBhabhaLauncher
     {
     }
 
-    const MollerBhabhaData&     mb;    //!< Shared data for interactor
-    const ModelInteractRef<M>&  model; //!< State data needed to interact
+    const MollerBhabhaData&    mb;    //!< Shared data for interactor
+    const ModelInteractRef<M>& model; //!< State data needed to interact
 
     //! Create track views and launch interactor
     inline CELER_FUNCTION void operator()(ThreadId tid) const;
@@ -60,11 +60,11 @@ CELER_FUNCTION void MollerBhabhaLauncher<M>::operator()(ThreadId tid) const
                              material.material_id(),
                              tid);
 
-    CutoffView cutoff(model.params.cutoffs, material.material_id());
-
     // This interaction only applies if the MB model was selected
     if (physics.model_id() != mb.model_id)
         return;
+
+    CutoffView cutoff(model.params.cutoffs, material.material_id());
 
     MollerBhabhaInteractor interact(
         mb, particle, cutoff, model.states.direction[tid], allocate_secondaries);


### PR DESCRIPTION
Right now, the CPU solver crashes if you use more track states than we have primaries. After some debugging, I found that this was a result of some of the interactors trying to create `CutoffView` with an invalid material (because the track was not active). Just making sure that we check for a matching physics model before instantiating `CutoffView` fixes this. With an arbitrary number of tracks allowed on CPU now, I've changed simple-driver.py to use the same number of tracks and storage factor for CPU and GPU. Everything agrees nicely — with max_num_tracks=4096, they both take 102 steps to finish and result in 15 GeV of energy deposition.