### PR TITLE
Add OpenMP threading for CPU demo loop

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -222,6 +222,10 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_VecGeom)
       VecGeom::vecgeom
     )
   endif()
+  find_package(OpenMP)
+  if(OpenMP_FOUND)
+    celeritas_target_link_libraries(celeritas_demo_loop PRIVATE OpenMP::OpenMP_CXX)
+  endif()
 
   # Add the executable
   add_executable(demo-loop
@@ -234,6 +238,9 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_VecGeom)
     VecGeom::vecgeom
     nlohmann_json::nlohmann_json
   )
+  if(OpenMP_FOUND)
+    celeritas_target_link_libraries(demo-loop OpenMP::OpenMP_CXX)
+  endif()
 
   if (CELERITAS_BUILD_TESTS)
     set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/demo-loop/simple-driver.py")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -227,6 +227,8 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_VecGeom)
   find_package(OpenMP)
   if(OpenMP_FOUND)
     celeritas_target_link_libraries(celeritas_demo_loop PRIVATE OpenMP::OpenMP_CXX)
+  else()
+    celeritas_target_compile_options(celeritas_demo_loop PRIVATE -Wno-unknown-pragmas)
   endif()
 
   # Add the executable

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -240,9 +240,6 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_VecGeom)
     VecGeom::vecgeom
     nlohmann_json::nlohmann_json
   )
-  if(OpenMP_FOUND)
-    celeritas_target_link_libraries(demo-loop OpenMP::OpenMP_CXX)
-  endif()
 
   if (CELERITAS_BUILD_TESTS)
     set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/demo-loop/simple-driver.py")

--- a/app/demo-loop/LDemoKernel.cc
+++ b/app/demo-loop/LDemoKernel.cc
@@ -25,8 +25,11 @@ namespace demo_loop
  */
 void pre_step(const ParamsHostRef& params, const StateHostRef& states)
 {
-    for (auto tid : range(ThreadId{states.size()}))
+#pragma omp parallel for
+    for (size_type i = 0; i < states.size(); ++i)
     {
+        ThreadId tid{i};
+
         // Clear out energy deposition
         states.energy_deposition[tid] = 0;
 
@@ -58,8 +61,10 @@ void pre_step(const ParamsHostRef& params, const StateHostRef& states)
 void along_and_post_step(const ParamsHostRef& params,
                          const StateHostRef&  states)
 {
-    for (auto tid : range(ThreadId{states.size()}))
+#pragma omp parallel for
+    for (size_type i = 0; i < states.size(); ++i)
     {
+        ThreadId     tid{i};
         SimTrackView sim(states.sim, tid);
         if (!sim.alive())
         {
@@ -103,8 +108,10 @@ void along_and_post_step(const ParamsHostRef& params,
 void process_interactions(const ParamsHostRef& params,
                           const StateHostRef&  states)
 {
-    for (auto tid : range(ThreadId{states.size()}))
+#pragma omp parallel for
+    for (size_type i = 0; i < states.size(); ++i)
     {
+        ThreadId     tid{i};
         SimTrackView sim(states.sim, tid);
         if (!sim.alive())
             continue;

--- a/cmake/CeleritasUtils.cmake
+++ b/cmake/CeleritasUtils.cmake
@@ -311,6 +311,35 @@ function(celeritas_target_include_directories target)
 
 endfunction()
 
+# Replacement for target_compile_options that is aware of
+# the 4 libraries (objects, static, middle, final) libraries needed
+# for a separatable CUDA library
+function(celeritas_target_compile_options target)
+  if(NOT CELERITAS_USE_CUDA)
+    target_compile_options(${ARGV})
+  else()
+
+    celeritas_strip_alias(target ${target})
+    celeritas_lib_contains_cuda(_contains_cuda ${target})
+
+    if (_contains_cuda)
+      get_target_property(_targettype ${target} CELERITAS_CUDA_LIBRARY_TYPE)
+      if(_targettype)
+        get_target_property(_target_middle ${target} CELERITAS_CUDA_MIDDLE_LIBRARY)
+        get_target_property(_target_object ${target} CELERITAS_CUDA_OBJECT_LIBRARY)
+      endif()
+    endif()
+    if(_target_object)
+      target_compile_options(${_target_object} ${ARGN})
+    endif()
+    if(_target_middle)
+      target_compile_options(${_target_middle} ${ARGN})
+    else()
+      target_compile_options(${ARGV})
+    endif()
+  endif()
+endfunction()
+
 #
 # Replacement for the install function that is aware of the 3 libraries
 # (static, middle, final) libraries needed for a separatable CUDA library

--- a/scripts/dev/gen-interactor.py
+++ b/scripts/dev/gen-interactor.py
@@ -74,8 +74,10 @@ void {func}_interact(
     CELER_EXPECT(model);
 
     detail::{class}Launcher<MemSpace::host> launch({func}_data, model);
-    for (auto tid : range(ThreadId{{model.states.size()}}))
+    #pragma omp parallel for
+    for (size_type i = 0; i < model.states.size(); ++i)
     {{
+        ThreadId tid{{i}};
         launch(tid);
     }}
 }}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,6 +173,11 @@ celeritas_add_library(celeritas ${SOURCES})
 celeritas_strip_alias(celeritas_target celeritas)
 add_library(Celeritas::Core ALIAS ${celeritas_target})
 
+find_package(OpenMP)
+if(OPENMP_FOUND)
+  celeritas_target_link_libraries(celeritas PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
 celeritas_target_link_libraries(celeritas
   PRIVATE ${PRIVATE_DEPS}
   PUBLIC ${PUBLIC_DEPS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,6 +176,8 @@ add_library(Celeritas::Core ALIAS ${celeritas_target})
 find_package(OpenMP)
 if(OPENMP_FOUND)
   celeritas_target_link_libraries(celeritas PRIVATE OpenMP::OpenMP_CXX)
+else()
+  celeritas_target_compile_options(celeritas PRIVATE -Wno-unknown-pragmas)
 endif()
 
 celeritas_target_link_libraries(celeritas

--- a/src/base/Atomics.hh
+++ b/src/base/Atomics.hh
@@ -25,8 +25,12 @@ CELER_FORCEINLINE_FUNCTION T atomic_add(T* address, T value)
     return atomicAdd(address, value);
 #else
     CELER_EXPECT(address);
-    T initial = *address;
-    *address += value;
+    T initial;
+#    pragma omp atomic capture
+    {
+        initial = *address;
+        *address += value;
+    }
     return initial;
 #endif
 }

--- a/src/base/Atomics.hh
+++ b/src/base/Atomics.hh
@@ -23,7 +23,7 @@ CELER_FORCEINLINE_FUNCTION T atomic_add(T* address, T value)
 {
 #ifdef __CUDA_ARCH__
     return atomicAdd(address, value);
-#else
+#elif defined(_OPENMP)
     CELER_EXPECT(address);
     T initial;
 #    pragma omp atomic capture
@@ -31,6 +31,11 @@ CELER_FORCEINLINE_FUNCTION T atomic_add(T* address, T value)
         initial = *address;
         *address += value;
     }
+    return initial;
+#else
+    CELER_EXPECT(address);
+    T initial = *address;
+    *address += value;
     return initial;
 #endif
 }

--- a/src/comm/Device.cc
+++ b/src/comm/Device.cc
@@ -82,10 +82,6 @@ Device& global_device()
         }
     }
 
-#if CELERITAS_USE_CUDA && defined(_OPENMP)
-    CELER_NOT_IMPLEMENTED("OpenMP support with CUDA");
-#endif
-
     return device;
 }
 

--- a/src/comm/Device.cc
+++ b/src/comm/Device.cc
@@ -11,6 +11,9 @@
 #if CELERITAS_USE_CUDA
 #    include <cuda_runtime_api.h>
 #endif
+#ifdef _OPENMP
+#    include <omp.h>
+#endif
 
 #include <cstdlib>
 #include <iostream>
@@ -81,6 +84,13 @@ Device& global_device()
             device = Device(cur_id);
         }
     }
+
+#if CELERITAS_USE_CUDA && defined(_OPENMP)
+    if (omp_get_num_threads() > 1)
+    {
+        CELER_NOT_IMPLEMENTED("OpenMP support with CUDA");
+    }
+#endif
 
     return device;
 }

--- a/src/physics/em/generated/BetheHeitlerInteract.cc
+++ b/src/physics/em/generated/BetheHeitlerInteract.cc
@@ -23,8 +23,10 @@ void bethe_heitler_interact(
     CELER_EXPECT(model);
 
     detail::BetheHeitlerLauncher<MemSpace::host> launch(bethe_heitler_data, model);
-    for (auto tid : range(ThreadId{model.states.size()}))
+    #pragma omp parallel for
+    for (size_type i = 0; i < model.states.size(); ++i)
     {
+        ThreadId tid{i};
         launch(tid);
     }
 }

--- a/src/physics/em/generated/EPlusGGInteract.cc
+++ b/src/physics/em/generated/EPlusGGInteract.cc
@@ -23,8 +23,10 @@ void eplusgg_interact(
     CELER_EXPECT(model);
 
     detail::EPlusGGLauncher<MemSpace::host> launch(eplusgg_data, model);
-    for (auto tid : range(ThreadId{model.states.size()}))
+    #pragma omp parallel for
+    for (size_type i = 0; i < model.states.size(); ++i)
     {
+        ThreadId tid{i};
         launch(tid);
     }
 }

--- a/src/physics/em/generated/KleinNishinaInteract.cc
+++ b/src/physics/em/generated/KleinNishinaInteract.cc
@@ -23,8 +23,10 @@ void klein_nishina_interact(
     CELER_EXPECT(model);
 
     detail::KleinNishinaLauncher<MemSpace::host> launch(klein_nishina_data, model);
-    for (auto tid : range(ThreadId{model.states.size()}))
+    #pragma omp parallel for
+    for (size_type i = 0; i < model.states.size(); ++i)
     {
+        ThreadId tid{i};
         launch(tid);
     }
 }

--- a/src/physics/em/generated/LivermorePEInteract.cc
+++ b/src/physics/em/generated/LivermorePEInteract.cc
@@ -23,8 +23,10 @@ void livermore_pe_interact(
     CELER_EXPECT(model);
 
     detail::LivermorePELauncher<MemSpace::host> launch(livermore_pe_data, model);
-    for (auto tid : range(ThreadId{model.states.size()}))
+    #pragma omp parallel for
+    for (size_type i = 0; i < model.states.size(); ++i)
     {
+        ThreadId tid{i};
         launch(tid);
     }
 }

--- a/src/physics/em/generated/MollerBhabhaInteract.cc
+++ b/src/physics/em/generated/MollerBhabhaInteract.cc
@@ -23,8 +23,10 @@ void moller_bhabha_interact(
     CELER_EXPECT(model);
 
     detail::MollerBhabhaLauncher<MemSpace::host> launch(moller_bhabha_data, model);
-    for (auto tid : range(ThreadId{model.states.size()}))
+    #pragma omp parallel for
+    for (size_type i = 0; i < model.states.size(); ++i)
     {
+        ThreadId tid{i};
         launch(tid);
     }
 }

--- a/src/physics/em/generated/MuBremsstrahlungInteract.cc
+++ b/src/physics/em/generated/MuBremsstrahlungInteract.cc
@@ -23,8 +23,10 @@ void mu_bremsstrahlung_interact(
     CELER_EXPECT(model);
 
     detail::MuBremsstrahlungLauncher<MemSpace::host> launch(mu_bremsstrahlung_data, model);
-    for (auto tid : range(ThreadId{model.states.size()}))
+    #pragma omp parallel for
+    for (size_type i = 0; i < model.states.size(); ++i)
     {
+        ThreadId tid{i};
         launch(tid);
     }
 }

--- a/src/physics/em/generated/RayleighInteract.cc
+++ b/src/physics/em/generated/RayleighInteract.cc
@@ -23,8 +23,10 @@ void rayleigh_interact(
     CELER_EXPECT(model);
 
     detail::RayleighLauncher<MemSpace::host> launch(rayleigh_data, model);
-    for (auto tid : range(ThreadId{model.states.size()}))
+    #pragma omp parallel for
+    for (size_type i = 0; i < model.states.size(); ++i)
     {
+        ThreadId tid{i};
         launch(tid);
     }
 }

--- a/src/physics/em/generated/SeltzerBergerInteract.cc
+++ b/src/physics/em/generated/SeltzerBergerInteract.cc
@@ -23,8 +23,10 @@ void seltzer_berger_interact(
     CELER_EXPECT(model);
 
     detail::SeltzerBergerLauncher<MemSpace::host> launch(seltzer_berger_data, model);
-    for (auto tid : range(ThreadId{model.states.size()}))
+    #pragma omp parallel for
+    for (size_type i = 0; i < model.states.size(); ++i)
     {
+        ThreadId tid{i};
         launch(tid);
     }
 }


### PR DESCRIPTION
This PR adds OpenMP threading for most steps of the demo loop: `pre_step`, `along_and_post_step`, `launch_models` (or rather, the individual interactors), and `process_interactions`. On our small test problem with only 15 primaries, the runtime is not long enough to notice any difference. I used @stognini's nifty hepmc3 generator to create a hepmc3 file with 100 events each having 10 primaries and then ran it to completion. I placed some stopwatches in the main demo loop just to get some timing data and obtain the following with OMP_NUM_THREADS=1:
```
status: init_tracks             = 0.831755 s
status: pre_step                = 9.20099 s
status: along_and_post_step     = 6.06276 s
status: interactors             = 3.54098 s
status: process                 = 0.986288 s
status: extend_from_secondaries = 1.49109 s
status: cleanup                 = 0.000386078 s
```
Using 6 threads on my six-core laptop, I get:
```
status: init_tracks             = 0.91393 s
status: pre_step                = 1.83678 s
status: along_and_post_step     = 1.42564 s
status: interactors             = 0.96519 s
status: process                 = 0.21168 s
status: extend_from_secondaries = 1.62631 s
status: cleanup                 = 0.000418989 s
```

What I added to the CMake files works, although I wish there were a better way to handle it. The problem is that we have a `#pragma omp` in Atomics.hh, so any library that contains a source file that includes Atomics.hh needs to link against OpenMP.