### PR TITLE
Refactor transporter construction and fix comments

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -166,4 +166,34 @@ load_primaries(const std::shared_ptr<const celeritas::ParticleParams>& particles
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Construct parameters, input, and transporter from the given run arguments.
+ */
+std::unique_ptr<TransporterBase> build_transporter(const LDemoArgs& run_args)
+{
+    using celeritas::MemSpace;
+    using celeritas::Transporter;
+    using celeritas::TransporterInput;
+
+    TransporterInput                 input = load_input(run_args);
+    std::unique_ptr<TransporterBase> result;
+
+    if (run_args.use_device)
+    {
+        CELER_VALIDATE(celeritas::device(),
+                       << "CUDA device is unavailable but GPU run was "
+                          "requested");
+        result = std::make_unique<Transporter<MemSpace::device>>(
+            std::move(input));
+    }
+    else
+    {
+        result
+            = std::make_unique<Transporter<MemSpace::host>>(std::move(input));
+    }
+    CELER_ENSURE(result);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
 } // namespace demo_loop

--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -53,8 +53,14 @@ struct LDemoArgs
 // Load params from input arguments
 celeritas::TransporterInput load_input(const LDemoArgs& args);
 std::shared_ptr<celeritas::TrackInitParams>
+
+// Load primary particles from an input HepMC3 event file
 load_primaries(const std::shared_ptr<const celeritas::ParticleParams>& particles,
                const LDemoArgs&                                        args);
+
+// Build transporter from input arguments
+std::unique_ptr<celeritas::TransporterBase>
+build_transporter(const LDemoArgs& run_args);
 
 void to_json(nlohmann::json& j, const LDemoArgs& value);
 void from_json(const nlohmann::json& j, LDemoArgs& value);

--- a/app/demo-loop/LDemoKernel.cu
+++ b/app/demo-loop/LDemoKernel.cu
@@ -120,7 +120,6 @@ __global__ void process_interactions_kernel(ParamsDeviceRef const params,
 
     ParticleTrackView particle(params.particles, states.particles, tid);
     GeoTrackView      geo(params.geometry, states.geometry, tid);
-    MaterialTrackView mat(params.materials, states.materials, tid);
     GeoMaterialView   geo_mat(params.geo_mats);
     PhysicsTrackView  phys(params.physics,
                           states.physics,

--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -37,36 +37,6 @@ namespace
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct parameters, input, and transporter from the given run arguments.
- */
-std::unique_ptr<TransporterBase> build_transporter(const LDemoArgs& run_args)
-{
-    using celeritas::MemSpace;
-    using celeritas::Transporter;
-    using celeritas::TransporterInput;
-
-    TransporterInput                 input = load_input(run_args);
-    std::unique_ptr<TransporterBase> result;
-
-    if (run_args.use_device)
-    {
-        CELER_VALIDATE(celeritas::device(),
-                       << "CUDA device is unavailable but GPU run was "
-                          "requested");
-        result = std::make_unique<Transporter<MemSpace::device>>(
-            std::move(input));
-    }
-    else
-    {
-        result
-            = std::make_unique<Transporter<MemSpace::host>>(std::move(input));
-    }
-    CELER_ENSURE(result);
-    return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Run, launch, and output.
  */
 void run(std::istream& is)

--- a/src/physics/em/BremsstrahlungProcess.hh
+++ b/src/physics/em/BremsstrahlungProcess.hh
@@ -17,7 +17,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Photoelectric effect process for gammas.
+ * Bremsstrahlung process for electrons and positrons.
  */
 class BremsstrahlungProcess : public Process
 {
@@ -30,7 +30,7 @@ class BremsstrahlungProcess : public Process
     //!@}
 
   public:
-    // Construct from Livermore photoelectric data
+    // Construct from Bremsstrahlung data
     BremsstrahlungProcess(SPConstParticles particles,
                           SPConstMaterials materials,
                           SPConstImported  process_data);

--- a/src/physics/em/RelativisticBremModel.cc
+++ b/src/physics/em/RelativisticBremModel.cc
@@ -169,10 +169,6 @@ auto RelativisticBremModel::compute_element_data(const ElementView& elem,
     real_type z13 = elem.cbrt_z();
     real_type z23 = ipow<2>(z13);
 
-    // XXX: TODO
-    //    units::MevMass electron_mass = units::MevMass{0.5109989461};
-    //    units::MevMass electron_mass = data_.host().electron_mass;
-
     data.factor1        = (ff_el - fc) + ff_inel / iz;
     data.factor2        = (1 + real_type(1) / iz) / 12;
     data.s1             = z23 / ipow<2>(184.15);


### PR DESCRIPTION
This MR includes several minor updates:
- Moved build_transporter from demo-loop.cc to LDemoIO which helps to reuse the function from acceleritas
- Corrected and removed comment lines
- Removed a unused variable