### PR TITLE
Integration of multiple bremsstrahlung models

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -118,7 +118,7 @@ TransporterInput load_input(const LDemoArgs& args)
         input.particles = result.particles;
         input.materials = result.materials;
 
-        BremsstrahlungOptions brem_options;
+        BremsstrahlungProcess::Options brem_options;
         brem_options.combined_model = args.combined_brem;
         brem_options.enable_lpm     = args.enable_lpm;
 

--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -118,6 +118,10 @@ TransporterInput load_input(const LDemoArgs& args)
         input.particles = result.particles;
         input.materials = result.materials;
 
+        BremsstrahlungOptions brem_options;
+        brem_options.combined_model = args.combined_brem;
+        brem_options.enable_lpm     = args.enable_lpm;
+
         auto process_data
             = std::make_shared<ImportedProcesses>(std::move(data.processes));
         input.processes.push_back(
@@ -133,7 +137,7 @@ TransporterInput load_input(const LDemoArgs& args)
         input.processes.push_back(std::make_shared<EIonizationProcess>(
             result.particles, process_data));
         input.processes.push_back(std::make_shared<BremsstrahlungProcess>(
-            result.particles, result.materials, process_data));
+            result.particles, result.materials, process_data, brem_options));
 
         result.physics = std::make_shared<PhysicsParams>(std::move(input));
     }

--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -43,6 +43,10 @@ struct LDemoArgs
     real_type    secondary_stack_factor{};
     bool         use_device{};
 
+    // Options for physics processes and models
+    bool combined_brem{true};
+    bool enable_lpm{true};
+
     //! Whether the run arguments are valid
     explicit operator bool() const
     {

--- a/src/physics/em/BremsstrahlungProcess.hh
+++ b/src/physics/em/BremsstrahlungProcess.hh
@@ -17,6 +17,16 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Options for Bremsstrahlung process
+ */
+struct BremsstrahlungOptions
+{
+    bool combined_model{true}; //!> flag for model choices
+    bool enable_lpm{true};     //!> flag for the LPM effect
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Bremsstrahlung process for electrons and positrons.
  */
 class BremsstrahlungProcess : public Process
@@ -27,13 +37,15 @@ class BremsstrahlungProcess : public Process
     using SPConstParticles = std::shared_ptr<const ParticleParams>;
     using SPConstMaterials = std::shared_ptr<const MaterialParams>;
     using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
+    using Options          = const BremsstrahlungOptions;
     //!@}
 
   public:
     // Construct from Bremsstrahlung data
     BremsstrahlungProcess(SPConstParticles particles,
                           SPConstMaterials materials,
-                          SPConstImported  process_data);
+                          SPConstImported  process_data,
+                          Options          options);
 
     // Construct the models associated with this process
     VecModel build_models(ModelIdGenerator next_id) const final;
@@ -51,6 +63,7 @@ class BremsstrahlungProcess : public Process
     SPConstParticles       particles_;
     SPConstMaterials       materials_;
     ImportedProcessAdapter imported_;
+    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/BremsstrahlungProcess.hh
+++ b/src/physics/em/BremsstrahlungProcess.hh
@@ -17,16 +17,6 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Options for Bremsstrahlung process
- */
-struct BremsstrahlungOptions
-{
-    bool combined_model{true}; //!> flag for model choices
-    bool enable_lpm{true};     //!> flag for the LPM effect
-};
-
-//---------------------------------------------------------------------------//
-/*!
  * Bremsstrahlung process for electrons and positrons.
  */
 class BremsstrahlungProcess : public Process
@@ -37,8 +27,16 @@ class BremsstrahlungProcess : public Process
     using SPConstParticles = std::shared_ptr<const ParticleParams>;
     using SPConstMaterials = std::shared_ptr<const MaterialParams>;
     using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
-    using Options          = const BremsstrahlungOptions;
     //!@}
+
+    // Options for the Bremsstrahlung process
+    struct Options
+    {
+        bool combined_model{true}; //!> Use a unified relativistic/SB
+                                   //!interactor
+        bool enable_lpm{true};     //!> Account for LPM effect at very high
+                                   //!energies
+    };
 
   public:
     // Construct from Bremsstrahlung data

--- a/src/physics/em/CombinedBremModel.cc
+++ b/src/physics/em/CombinedBremModel.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "CombinedBremModel.hh"
 
+#include "physics/em/detail/PhysicsConstants.hh"
 #include "physics/em/generated/CombinedBremInteract.hh"
 
 namespace celeritas
@@ -50,7 +51,7 @@ auto CombinedBremModel::applicability() const -> SetApplicability
     Applicability electron_brem;
     electron_brem.particle = this->host_ref().rb_data.ids.electron;
     electron_brem.lower    = zero_quantity();
-    electron_brem.upper    = this->host_ref().rb_data.high_energy_limit();
+    electron_brem.upper    = detail::high_energy_limit();
 
     Applicability positron_brem = electron_brem;
     positron_brem.particle      = this->host_ref().rb_data.ids.positron;

--- a/src/physics/em/RelativisticBremModel.cc
+++ b/src/physics/em/RelativisticBremModel.cc
@@ -15,6 +15,7 @@
 #include "base/CollectionBuilder.hh"
 #include "physics/base/PDGNumber.hh"
 #include "physics/base/ParticleParams.hh"
+#include "physics/em/detail/PhysicsConstants.hh"
 #include "physics/em/detail/RelativisticBremData.hh"
 #include "physics/em/generated/RelativisticBremInteract.hh"
 
@@ -65,8 +66,8 @@ auto RelativisticBremModel::applicability() const -> SetApplicability
 {
     Applicability electron_brem;
     electron_brem.particle = this->host_ref().ids.electron;
-    electron_brem.lower    = this->host_ref().low_energy_limit();
-    electron_brem.upper    = this->host_ref().high_energy_limit();
+    electron_brem.lower    = detail::seltzer_berger_limit();
+    electron_brem.upper    = detail::high_energy_limit();
 
     Applicability positron_brem = electron_brem;
     positron_brem.particle      = this->host_ref().ids.positron;

--- a/src/physics/em/SeltzerBergerModel.cc
+++ b/src/physics/em/SeltzerBergerModel.cc
@@ -16,6 +16,7 @@
 #include "physics/base/ParticleParams.hh"
 #include "physics/base/PDGNumber.hh"
 #include "physics/material/MaterialParams.hh"
+#include "physics/em/detail/PhysicsConstants.hh"
 #include "physics/em/generated/SeltzerBergerInteract.hh"
 
 namespace celeritas
@@ -76,7 +77,7 @@ auto SeltzerBergerModel::applicability() const -> SetApplicability
     Applicability electron_applic;
     electron_applic.particle = this->host_ref().ids.electron;
     electron_applic.lower    = zero_quantity();
-    electron_applic.upper    = units::MevEnergy{1e8};
+    electron_applic.upper    = detail::seltzer_berger_limit();
 
     Applicability positron_applic = electron_applic;
     positron_applic.particle      = this->host_ref().ids.positron;

--- a/src/physics/em/detail/CombinedBremInteractor.i.hh
+++ b/src/physics/em/detail/CombinedBremInteractor.i.hh
@@ -11,6 +11,7 @@
 #include "base/Constants.hh"
 #include "random/distributions/GenerateCanonical.hh"
 
+#include "PhysicsConstants.hh"
 #include "SBEnergyDistHelper.hh"
 #include "SBEnergyDistribution.hh"
 #include "SBPositronXsCorrector.hh"
@@ -41,7 +42,7 @@ CombinedBremInteractor::CombinedBremInteractor(
     , material_(material)
     , elcomp_id_(elcomp_id)
     , is_electron_(particle.particle_id() == shared.rb_data.ids.electron)
-    , is_relativistic_(particle.energy() > shared.rb_data.low_energy_limit())
+    , is_relativistic_(particle.energy() > seltzer_berger_limit())
     , rb_energy_sampler_(shared.rb_data, particle, cutoffs, material, elcomp_id)
     , sb_energy_sampler_(shared.sb_differential_xs,
                          particle,

--- a/src/physics/em/detail/PhysicsConstants.hh
+++ b/src/physics/em/detail/PhysicsConstants.hh
@@ -59,6 +59,22 @@ CELER_CONSTEXPR_FUNCTION MevPerCm lpm_constant()
 }
 //!@}
 
+//!@{
+//! Constant functions for model limits
+
+//! Maximum energy for the SeltzerBerger model to be valid
+CELER_CONSTEXPR_FUNCTION units::MevEnergy seltzer_berger_limit()
+{
+    return units::MevEnergy{1e3}; //! 1 GeV
+}
+
+//! Maximum energy for EM models to be valid
+CELER_CONSTEXPR_FUNCTION units::MevEnergy high_energy_limit()
+{
+    return units::MevEnergy{1e8}; //! 100 TeV
+}
+//!@}
+
 //---------------------------------------------------------------------------//
 } // namespace detail
 } // namespace celeritas

--- a/src/physics/em/detail/PhysicsConstants.hh
+++ b/src/physics/em/detail/PhysicsConstants.hh
@@ -62,7 +62,7 @@ CELER_CONSTEXPR_FUNCTION MevPerCm lpm_constant()
 //!@{
 //! Constant functions for model limits
 
-//! Maximum energy for the SeltzerBerger model to be valid
+//! Maximum energy for the SeltzerBerger model - TODO: make this configurable 
 CELER_CONSTEXPR_FUNCTION units::MevEnergy seltzer_berger_limit()
 {
     return units::MevEnergy{1e3}; //! 1 GeV

--- a/src/physics/em/detail/RBEnergySampler.i.hh
+++ b/src/physics/em/detail/RBEnergySampler.i.hh
@@ -9,6 +9,7 @@
 
 #include "base/Algorithms.hh"
 #include "random/distributions/BernoulliDistribution.hh"
+#include "PhysicsConstants.hh"
 
 namespace celeritas
 {
@@ -41,7 +42,7 @@ CELER_FUNCTION auto RBEnergySampler::operator()(Engine& rng) -> Energy
 {
     // Min and max kinetic energy limits for sampling the secondary photon
     Energy tmin = min(gamma_cutoff_, inc_energy_);
-    Energy tmax = min(shared_.high_energy_limit(), inc_energy_);
+    Energy tmax = min(high_energy_limit(), inc_energy_);
 
     real_type density_corr = dxsec_.density_correction();
 

--- a/src/physics/em/detail/RelativisticBremData.hh
+++ b/src/physics/em/detail/RelativisticBremData.hh
@@ -110,18 +110,6 @@ struct RelativisticBremData
     //! The upper limit of the LPM variable for evaluating LPM functions
     static CELER_CONSTEXPR_FUNCTION real_type limit_s_lpm() { return 2.0; }
 
-    //! Minimum electron/positron energy for this model to be valid
-    static CELER_CONSTEXPR_FUNCTION units::MevEnergy low_energy_limit()
-    {
-        return units::MevEnergy{1e3}; //! 1 GeV
-    }
-
-    //! Maximum electron/positron energy for this model to be valid
-    static CELER_CONSTEXPR_FUNCTION units::MevEnergy high_energy_limit()
-    {
-        return units::MevEnergy{1e8}; //! 100 TeV
-    }
-
     //! Check whether the data is assigned
     explicit inline CELER_FUNCTION operator bool() const
     {

--- a/src/physics/em/detail/RelativisticBremInteractor.i.hh
+++ b/src/physics/em/detail/RelativisticBremInteractor.i.hh
@@ -45,7 +45,7 @@ RelativisticBremInteractor::RelativisticBremInteractor(
     CELER_EXPECT(gamma_cutoff_ > zero_quantity());
 
     // Valid energy region of the relativistic e-/e+ Bremsstrahlung model
-    CELER_EXPECT(inc_energy_ > shared_.low_energy_limit());
+    CELER_EXPECT(inc_energy_ > seltzer_berger_limit());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/physics/em/ImportedProcesses.test.cc
+++ b/test/physics/em/ImportedProcesses.test.cc
@@ -200,11 +200,12 @@ TEST_F(ImportedProcessesTest, photoelectric)
 TEST_F(ImportedProcessesTest, bremsstrahlung)
 {
     // Create bremsstrahlung process (requires Geant4 environment variables)
+    BremsstrahlungOptions                  options;
     std::shared_ptr<BremsstrahlungProcess> process;
     try
     {
         process = std::make_shared<BremsstrahlungProcess>(
-            particles_, materials_, processes_);
+            particles_, materials_, processes_, options);
     }
     catch (const RuntimeError& e)
     {

--- a/test/physics/em/ImportedProcesses.test.cc
+++ b/test/physics/em/ImportedProcesses.test.cc
@@ -216,7 +216,14 @@ TEST_F(ImportedProcessesTest, bremsstrahlung)
     auto models = process->build_models(ModelIdGenerator{});
     ASSERT_EQ(1, models.size());
     ASSERT_TRUE(models.front());
-    EXPECT_EQ("Seltzer-Berger bremsstrahlung", models.front()->label());
+    if (options.combined_model)
+    {
+        EXPECT_EQ("Combined Bremsstrahlung", models.front()->label());
+    }
+    else
+    {
+        EXPECT_EQ("Seltzer-Berger bremsstrahlung", models.front()->label());
+    }
     auto all_applic = models.front()->applicability();
     ASSERT_EQ(2, all_applic.size());
     Applicability applic = *all_applic.begin();

--- a/test/physics/em/ImportedProcesses.test.cc
+++ b/test/physics/em/ImportedProcesses.test.cc
@@ -200,7 +200,7 @@ TEST_F(ImportedProcessesTest, photoelectric)
 TEST_F(ImportedProcessesTest, bremsstrahlung)
 {
     // Create bremsstrahlung process (requires Geant4 environment variables)
-    BremsstrahlungOptions                  options;
+    BremsstrahlungProcess::Options         options;
     std::shared_ptr<BremsstrahlungProcess> process;
     try
     {


### PR DESCRIPTION
The MR includes
- add RelativisticBremModel and CombinedBremModel to BremsstrahlungProcess with BremsstrahlungOptions
- use energy limits of Bremsstrahlung models consistently for their applicability
- use the combined Bremsstrahlung model and the LPM effect as the default option
but does not include the run-time argument setting in the python driver for the demo-loop as there may have a centralized control for different physics options later.