### PR TITLE
Remove unused variables

### DIFF
--- a/src/physics/em/detail/CombinedBremInteractor.hh
+++ b/src/physics/em/detail/CombinedBremInteractor.hh
@@ -64,8 +64,6 @@ class CombinedBremInteractor
 
   private:
     //// DATA ////
-    // Shared constant physics properties
-    const CombinedBremNativeRef& shared_;
     // Incident particle energy
     const Energy inc_energy_;
     // Incident particle direction
@@ -76,8 +74,6 @@ class CombinedBremInteractor
     const Energy gamma_cutoff_;
     // Allocate space for a secondary particle
     StackAllocator<Secondary>& allocate_;
-    // Material in which interaction occurs
-    const MaterialView& material_;
     // Element in which interaction occurs
     const ElementComponentId elcomp_id_;
     // Incident particle flag for selecting XS correction factor

--- a/src/physics/em/detail/CombinedBremInteractor.i.hh
+++ b/src/physics/em/detail/CombinedBremInteractor.i.hh
@@ -33,13 +33,11 @@ CombinedBremInteractor::CombinedBremInteractor(
     StackAllocator<Secondary>&   allocate,
     const MaterialView&          material,
     const ElementComponentId&    elcomp_id)
-    : shared_(shared)
-    , inc_energy_(particle.energy())
+    : inc_energy_(particle.energy())
     , inc_momentum_(particle.momentum())
     , inc_direction_(direction)
     , gamma_cutoff_(cutoffs.energy(shared.rb_data.ids.gamma))
     , allocate_(allocate)
-    , material_(material)
     , elcomp_id_(elcomp_id)
     , is_electron_(particle.particle_id() == shared.rb_data.ids.electron)
     , is_relativistic_(particle.energy() > seltzer_berger_limit())
@@ -54,11 +52,11 @@ CombinedBremInteractor::CombinedBremInteractor(
     , final_state_interaction_(inc_energy_,
                                inc_direction_,
                                inc_momentum_,
-                               shared_.rb_data.electron_mass,
-                               shared_.rb_data.ids.gamma)
+                               shared.rb_data.electron_mass,
+                               shared.rb_data.ids.gamma)
 {
     CELER_EXPECT(is_electron_
-                 || particle.particle_id() == shared_.rb_data.ids.positron);
+                 || particle.particle_id() == shared.rb_data.ids.positron);
     CELER_EXPECT(gamma_cutoff_.value() > 0);
 }
 

--- a/src/physics/em/detail/RBEnergySampler.hh
+++ b/src/physics/em/detail/RBEnergySampler.hh
@@ -53,8 +53,6 @@ class RBEnergySampler
     using ReciprocalSampler = ReciprocalDistribution<real_type>;
 
     //// DATA ////
-    // Shared data
-    const RelativisticBremNativeRef& shared_;
     // Incident particle energy
     const Energy inc_energy_;
     // Production cutoff for gammas

--- a/src/physics/em/detail/RBEnergySampler.i.hh
+++ b/src/physics/em/detail/RBEnergySampler.i.hh
@@ -25,8 +25,7 @@ RBEnergySampler::RBEnergySampler(const RelativisticBremNativeRef& shared,
                                  const CutoffView&                cutoffs,
                                  const MaterialView&              material,
                                  const ElementComponentId&        elcomp_id)
-    : shared_(shared)
-    , inc_energy_(particle.energy())
+    : inc_energy_(particle.energy())
     , gamma_cutoff_(cutoffs.energy(shared.ids.gamma))
     , dxsec_(shared, particle, material, elcomp_id)
 {

--- a/src/physics/em/detail/SeltzerBergerInteractor.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.hh
@@ -84,8 +84,6 @@ class SeltzerBergerInteractor
     const Energy gamma_cutoff_;
     // Allocate space for a secondary particle
     StackAllocator<Secondary>& allocate_;
-    // Material in which interaction occurs
-    const MaterialView& material_;
     // Element in which interaction occurs
     const ElementComponentId elcomp_id_;
 

--- a/src/physics/em/detail/SeltzerBergerInteractor.i.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.i.hh
@@ -39,7 +39,6 @@ SeltzerBergerInteractor::SeltzerBergerInteractor(
     , inc_particle_is_electron_(particle.particle_id() == shared_.ids.electron)
     , gamma_cutoff_(cutoffs.energy(shared.ids.gamma))
     , allocate_(allocate)
-    , material_(material)
     , elcomp_id_(elcomp_id)
     , sb_energy_sampler_(shared.differential_xs,
                          particle,


### PR DESCRIPTION
Found a few unused variables during PR #326 that prevent Celeritas from compiling when cmake warnings are treated as errors. These changes are being resolved here as a separate PR.