### PR TITLE
Use BVH navigator by default

### DIFF
--- a/app/demo-rasterizer/RDemoKernel.cu
+++ b/app/demo-rasterizer/RDemoKernel.cu
@@ -71,7 +71,7 @@ __global__ void trace_kernel(const GeoParamsCRefDevice geo_params,
             }
 
             // Cross surface
-            geo.move_next_step();
+            geo.move_to_boundary();
             cur_id   = geo_id(geo);
             geo_dist = std::fmin(geo.next_step(),
                                  image_state.dims[1] * image_state.pixel_width);

--- a/app/demo-rasterizer/RDemoRunner.cc
+++ b/app/demo-rasterizer/RDemoRunner.cc
@@ -34,7 +34,7 @@ RDemoRunner::RDemoRunner(SPConstGeo geometry)
 /*!
  * Trace an image.
  */
-void RDemoRunner::operator()(ImageStore* image) const
+void RDemoRunner::operator()(ImageStore* image, int ntimes) const
 {
     CELER_EXPECT(image);
 
@@ -42,11 +42,28 @@ void RDemoRunner::operator()(ImageStore* image) const
         *geo_params_, image->dims()[0]);
 
     CELER_LOG(status) << "Tracing geometry";
-    Stopwatch get_time;
-    trace(
-        geo_params_->device_ref(), geo_state.ref(), image->device_interface());
-    CELER_LOG(diagnostic) << color_code('x') << "... " << get_time() << " s"
-                          << color_code(' ');
+    // do it ntimes+1 as first one tends to be a warm-up run (slightly longer)
+    double sum = 0, time = 0;
+    for (int i = 0; i <= ntimes; ++i)
+    {
+        Stopwatch get_time;
+        trace(geo_params_->device_ref(),
+              geo_state.ref(),
+              image->device_interface());
+        time = get_time();
+        CELER_LOG(info) << color_code('x') << "Elapsed " << i << ": " << time
+                        << " s" << color_code(' ');
+        if (i > 0)
+        {
+            sum += time;
+        }
+    }
+    if (ntimes > 0)
+    {
+        CELER_LOG(info) << color_code('x')
+                        << "\tAverage time: " << sum / ntimes << " s"
+                        << color_code(' ');
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-rasterizer/RDemoRunner.hh
+++ b/app/demo-rasterizer/RDemoRunner.hh
@@ -31,7 +31,7 @@ class RDemoRunner
     explicit RDemoRunner(SPConstGeo geometry);
 
     // Trace an image
-    void operator()(ImageStore* image) const;
+    void operator()(ImageStore* image, int ntimes = 0) const;
 
   private:
     SPConstGeo geo_params_;

--- a/app/demo-rasterizer/demo-rasterizer.cc
+++ b/app/demo-rasterizer/demo-rasterizer.cc
@@ -56,6 +56,7 @@ void run(std::istream& is)
     // Construct runner
     RDemoRunner run(geo_params);
     run(&image);
+    // run(&image, 10); // Ntimes for performance measurement
 
     // Get geometry names
     std::vector<std::string> vol_names;

--- a/src/geometry/GeoParams.cc
+++ b/src/geometry/GeoParams.cc
@@ -50,6 +50,9 @@ GeoParams::GeoParams(const char* gdml_filename)
     host_ref_.world_volume = vecgeom::GeoManager::Instance().GetWorld();
     host_ref_.max_depth    = vecgeom::GeoManager::Instance().getMaxDepth();
 
+    // init the BVH structure
+    vecgeom::cxx::BVHManager::Init();
+
 #if CELERITAS_USE_CUDA
     if (celeritas::device())
     {
@@ -73,14 +76,10 @@ GeoParams::GeoParams(const char* gdml_filename)
             CELER_CUDA_CHECK_ERROR();
         }
         CELER_ENSURE(device_ref_);
-    }
-#endif
 
-    // init the BVH structure
-    vecgeom::cxx::BVHManager::Init();
-#if CELERITAS_USE_CUDA
-    // init the BVH structure
-    vecgeom::cxx::BVHManager::DeviceInit();
+        // init the BVH structure
+        vecgeom::cxx::BVHManager::DeviceInit();
+    }
 #endif
 
     CELER_ENSURE(num_volumes_ > 0);

--- a/src/geometry/GeoParams.cc
+++ b/src/geometry/GeoParams.cc
@@ -10,6 +10,7 @@
 #include <VecGeom/gdml/Frontend.h>
 #include <VecGeom/management/ABBoxManager.h>
 #include <VecGeom/management/GeoManager.h>
+#include <VecGeom/management/BVHManager.h>
 #include <VecGeom/volumes/PlacedVolume.h>
 
 #include <celeritas_config.h>
@@ -74,6 +75,14 @@ GeoParams::GeoParams(const char* gdml_filename)
         CELER_ENSURE(device_ref_);
     }
 #endif
+
+    // init the BVH structure
+    vecgeom::cxx::BVHManager::Init();
+#if CELERITAS_USE_CUDA
+    // init the BVH structure
+    vecgeom::cxx::BVHManager::DeviceInit();
+#endif
+
     CELER_ENSURE(num_volumes_ > 0);
     CELER_ENSURE(host_ref_);
 }

--- a/src/geometry/GeoTrackView.hh
+++ b/src/geometry/GeoTrackView.hh
@@ -34,6 +34,7 @@ class GeoTrackView
     using GeoParamsRef
         = GeoParamsData<Ownership::const_reference, MemSpace::native>;
     using GeoStateRef = GeoStateData<Ownership::reference, MemSpace::native>;
+    using Vec3D       = vecgeom::Vector3D<real_type>;
     //!@}
 
     //! Helper struct for initializing from an existing geometry state
@@ -58,13 +59,11 @@ class GeoTrackView
     // Find the distance to the next boundary
     inline CELER_FUNCTION void find_next_step();
 
-    // Move to the next boundary
+    // Move to the next boundary along straight line
     inline CELER_FUNCTION real_type move_to_boundary();
-    inline CELER_FUNCTION real_type move_next_step();
-    inline CELER_FUNCTION real_type move_by(real_type step);
 
-    // Update current volume, called whenever move reaches boundary
-    inline CELER_FUNCTION void move_next_volume();
+    // Move by a user-provided step length
+    inline CELER_FUNCTION real_type move_by(real_type step);
 
     //!@{
     //! State accessors
@@ -122,6 +121,9 @@ class GeoTrackView
     //!@}
 
   private:
+    // Update current volume, called whenever move reaches boundary
+    inline CELER_FUNCTION void relocate();
+
     // Find the distance to the next boundary
     inline CELER_FUNCTION void find_next_step_outside();
 

--- a/src/geometry/detail/BVHNavigator.hh
+++ b/src/geometry/detail/BVHNavigator.hh
@@ -1,0 +1,414 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file BVHNavigator.h
+ * @brief Navigation methods for geometry.
+ */
+
+#ifndef RT_NAVIGATOR_H_
+#define RT_NAVIGATOR_H_
+
+#include <CopCore/Global.h>
+
+#include <VecGeom/base/Global.h>
+#include <VecGeom/base/Vector3D.h>
+#include <VecGeom/management/BVHManager.h>
+#include <VecGeom/navigation/NavStateIndex.h>
+
+#ifdef VECGEOM_ENABLE_CUDA
+#    include <VecGeom/backend/cuda/Interface.h>
+#endif
+
+inline namespace COPCORE_IMPL
+{
+class BVHNavigator
+{
+  public:
+    using VPlacedVolumePtr_t = vecgeom::VPlacedVolume const*;
+
+    __host__ __device__ static VPlacedVolumePtr_t
+    LocatePointIn(vecgeom::VPlacedVolume const*                vol,
+                  vecgeom::Vector3D<vecgeom::Precision> const& point,
+                  vecgeom::NavStateIndex&                      path,
+                  bool                                         top,
+                  vecgeom::VPlacedVolume const* exclude = nullptr)
+    {
+        if (top)
+        {
+            assert(vol != nullptr);
+            if (!vol->UnplacedContains(point))
+                return nullptr;
+        }
+
+        path.Push(vol);
+
+        vecgeom::Vector3D<vecgeom::Precision> currentpoint(point);
+        vecgeom::Vector3D<vecgeom::Precision> daughterlocalpoint;
+
+        for (auto v = vol; v->GetDaughters().size() > 0;)
+        {
+            auto bvh = vecgeom::BVHManager::GetBVH(v->GetLogicalVolume()->id());
+
+            if (!bvh->LevelLocate(exclude, currentpoint, v, daughterlocalpoint))
+                break;
+
+            currentpoint = daughterlocalpoint;
+            path.Push(v);
+            // Only exclude the placed volume once since we could enter it
+            // again via a different volume history.
+            exclude = nullptr;
+        }
+
+        return path.Top();
+    }
+
+    __host__ __device__ static VPlacedVolumePtr_t
+    RelocatePoint(vecgeom::Vector3D<vecgeom::Precision> const& localpoint,
+                  vecgeom::NavStateIndex&                      path)
+    {
+        vecgeom::VPlacedVolume const*         currentmother = path.Top();
+        vecgeom::Vector3D<vecgeom::Precision> transformed   = localpoint;
+        do
+        {
+            path.Pop();
+            transformed = currentmother->GetTransformation()->InverseTransform(
+                transformed);
+            currentmother = path.Top();
+        } while (currentmother
+                 && (currentmother->IsAssembly()
+                     || !currentmother->UnplacedContains(transformed)));
+
+        if (currentmother)
+        {
+            path.Pop();
+            return LocatePointIn(currentmother, transformed, path, false);
+        }
+        return currentmother;
+    }
+
+  private:
+    // Computes a step in the current volume from the localpoint into localdir,
+    // taking step_limit into account. If a volume is hit, the function calls
+    // out_state.SetBoundaryState(true) and hitcandidate is set to the hit
+    // daughter volume, or kept unchanged if the current volume is left.
+    __host__ __device__ static double
+    ComputeStepAndHit(vecgeom::Vector3D<vecgeom::Precision> const& localpoint,
+                      vecgeom::Vector3D<vecgeom::Precision> const& localdir,
+                      vecgeom::Precision                           step_limit,
+                      vecgeom::NavStateIndex const&                in_state,
+                      vecgeom::NavStateIndex&                      out_state,
+                      VPlacedVolumePtr_t& hitcandidate)
+    {
+        vecgeom::Precision step = step_limit;
+        VPlacedVolumePtr_t pvol = in_state.Top();
+
+        // need to calc DistanceToOut first
+        step = pvol->DistanceToOut(localpoint, localdir, step_limit);
+
+        if (step < 0)
+            step = 0;
+
+        if (pvol->GetDaughters().size() > 0)
+        {
+            auto bvh
+                = vecgeom::BVHManager::GetBVH(pvol->GetLogicalVolume()->id());
+            bvh->CheckDaughterIntersections(
+                localpoint, localdir, step, pvol, hitcandidate);
+        }
+
+        // now we have the candidates and we prepare the out_state
+        in_state.CopyTo(&out_state);
+        if (step == vecgeom::kInfLength && step_limit > 0.)
+        {
+            out_state.SetBoundaryState(true);
+            do
+            {
+                out_state.Pop();
+            } while (out_state.Top()->IsAssembly());
+
+            return vecgeom::kTolerance;
+        }
+
+        // Is geometry further away than physics step?
+        if (step > step_limit)
+        {
+            // Then this is a phyics step and we don't need to do anything.
+            out_state.SetBoundaryState(false);
+            return step_limit;
+        }
+
+        // Otherwise it is a geometry step and we push the point to the
+        // boundary.
+        out_state.SetBoundaryState(true);
+
+        if (step < 0.)
+        {
+            step = 0.;
+        }
+
+        return step;
+    }
+
+    // Computes a step in the current volume from the localpoint into localdir,
+    // until the next daughter bounding box, taking step_limit into account.
+    __host__ __device__ static double
+    ApproachNextVolume(vecgeom::Vector3D<vecgeom::Precision> const& localpoint,
+                       vecgeom::Vector3D<vecgeom::Precision> const& localdir,
+                       vecgeom::Precision                           step_limit,
+                       vecgeom::NavStateIndex const&                in_state)
+    {
+        vecgeom::Precision step = step_limit;
+        VPlacedVolumePtr_t pvol = in_state.Top();
+
+        if (pvol->GetDaughters().size() > 0)
+        {
+            auto bvh
+                = vecgeom::BVHManager::GetBVH(pvol->GetLogicalVolume()->id());
+            // bvh->CheckDaughterIntersections(localpoint, localdir, step,
+            // pvol, hitcandidate);
+            bvh->ApproachNextDaughter(localpoint, localdir, step, pvol);
+            // Make sure we don't "step" on next boundary
+            step -= 10. * vecgeom::kTolerance;
+        }
+
+        if (step == vecgeom::kInfLength && step_limit > 0.)
+            return 0.;
+
+        // Is geometry further away than physics step?
+        if (step > step_limit)
+        {
+            // Then this is a phyics step and we don't need to do anything.
+            return step_limit;
+        }
+
+        if (step < 0.)
+        {
+            step = 0.;
+        }
+
+        return step;
+    }
+
+  public:
+    // Computes the isotropic safety from the globalpoint.
+    __host__ __device__ static double
+    ComputeSafety(vecgeom::Vector3D<vecgeom::Precision> const& globalpoint,
+                  vecgeom::NavStateIndex const&                state)
+    {
+        VPlacedVolumePtr_t        pvol = state.Top();
+        vecgeom::Transformation3D m;
+        state.TopMatrix(m);
+        vecgeom::Vector3D<vecgeom::Precision> localpoint
+            = m.Transform(globalpoint);
+
+        // need to calc DistanceToOut first
+        vecgeom::Precision safety = pvol->SafetyToOut(localpoint);
+
+        if (safety > 0 && pvol->GetDaughters().size() > 0)
+        {
+            auto bvh
+                = vecgeom::BVHManager::GetBVH(pvol->GetLogicalVolume()->id());
+            safety = bvh->ComputeSafety(localpoint, safety);
+        }
+
+        return safety;
+    }
+
+    // Computes a step from the globalpoint (which must be in the current
+    // volume) into globaldir, taking step_limit into account. If a volume is
+    // hit, the function calls out_state.SetBoundaryState(true) and relocates
+    // the state to the next volume.
+    __host__ __device__ static double ComputeStepAndPropagatedState(
+        vecgeom::Vector3D<vecgeom::Precision> const& globalpoint,
+        vecgeom::Vector3D<vecgeom::Precision> const& globaldir,
+        vecgeom::Precision                           step_limit,
+        vecgeom::NavStateIndex const&                in_state,
+        vecgeom::NavStateIndex&                      out_state,
+        vecgeom::Precision                           push = 0.)
+    {
+        constexpr vecgeom::Precision kPush = 10. * vecgeom::kTolerance;
+        // calculate local point/dir from global point/dir
+        vecgeom::Vector3D<vecgeom::Precision> localpoint;
+        vecgeom::Vector3D<vecgeom::Precision> localdir;
+        // Impl::DoGlobalToLocalTransformation(in_state, globalpoint,
+        // globaldir, localpoint, localdir);
+        vecgeom::Transformation3D m;
+        in_state.TopMatrix(m);
+        localpoint = m.Transform(globalpoint);
+        localdir   = m.TransformDirection(globaldir);
+        // The user may want to move point from boundary before computing the
+        // step
+        localpoint += push * localdir;
+
+        VPlacedVolumePtr_t hitcandidate = nullptr;
+        vecgeom::Precision step         = ComputeStepAndHit(
+            localpoint, localdir, step_limit, in_state, out_state, hitcandidate);
+        if (step < step_limit)
+            step += push;
+
+        if (out_state.IsOnBoundary())
+        {
+            // Relocate the point after the step to refine out_state.
+            localpoint += (step + kPush) * localdir;
+
+            if (!hitcandidate)
+            {
+                // We didn't hit a daughter but instead we're exiting the
+                // current volume.
+                RelocatePoint(localpoint, out_state);
+            }
+            else
+            {
+                // Otherwise check if we're directly entering other daughters
+                // transitively.
+                localpoint
+                    = hitcandidate->GetTransformation()->Transform(localpoint);
+                LocatePointIn(hitcandidate, localpoint, out_state, false);
+            }
+
+            if (out_state.Top() != nullptr)
+            {
+                while (out_state.Top()->IsAssembly()
+                       || out_state.GetNavIndex() == in_state.GetNavIndex())
+                {
+                    out_state.Pop();
+                }
+                assert(!out_state.Top()
+                            ->GetLogicalVolume()
+                            ->GetUnplacedVolume()
+                            ->IsAssembly());
+            }
+        }
+
+        return step;
+    }
+
+    // Computes a step from the globalpoint (which must be in the current
+    // volume) into globaldir, taking step_limit into account. If a volume is
+    // hit, the function calls out_state.SetBoundaryState(true) and
+    //  - removes all volumes from out_state if the current volume is left, or
+    //  - adds the hit daughter volume to out_state if one is hit.
+    // However the function does _NOT_ relocate the state to the next volume,
+    // that is entering multiple volumes that share a boundary.
+    __host__ __device__ static double ComputeStepAndNextVolume(
+        vecgeom::Vector3D<vecgeom::Precision> const& globalpoint,
+        vecgeom::Vector3D<vecgeom::Precision> const& globaldir,
+        vecgeom::Precision                           step_limit,
+        vecgeom::NavStateIndex const&                in_state,
+        vecgeom::NavStateIndex&                      out_state,
+        vecgeom::Precision                           push = 0.)
+    {
+        // calculate local point/dir from global point/dir
+        vecgeom::Vector3D<vecgeom::Precision> localpoint;
+        vecgeom::Vector3D<vecgeom::Precision> localdir;
+        // Impl::DoGlobalToLocalTransformation(in_state, globalpoint,
+        // globaldir, localpoint, localdir);
+        vecgeom::Transformation3D m;
+        in_state.TopMatrix(m);
+        localpoint = m.Transform(globalpoint);
+        localdir   = m.TransformDirection(globaldir);
+        // The user may want to move point from boundary before computing the
+        // step
+        localpoint += push * localdir;
+
+        VPlacedVolumePtr_t hitcandidate = nullptr;
+        vecgeom::Precision step         = ComputeStepAndHit(
+            localpoint, localdir, step_limit, in_state, out_state, hitcandidate);
+        if (step < step_limit)
+            step += push;
+
+        if (out_state.IsOnBoundary())
+        {
+            if (!hitcandidate)
+            {
+                vecgeom::VPlacedVolume const* currentmother = out_state.Top();
+                vecgeom::Vector3D<vecgeom::Precision> transformed = localpoint;
+                // Push the point inside the next volume.
+                static constexpr double kPush = 10. * vecgeom::kTolerance;
+                transformed += (step + kPush) * localdir;
+
+                do
+                {
+                    out_state.SetLastExited();
+                    out_state.Pop();
+                    transformed
+                        = currentmother->GetTransformation()->InverseTransform(
+                            transformed);
+                    currentmother = out_state.Top();
+                } while (currentmother
+                         && (currentmother->IsAssembly()
+                             || !currentmother->UnplacedContains(transformed)));
+            }
+            else
+            {
+                out_state.Push(hitcandidate);
+            }
+        }
+
+        return step;
+    }
+
+    // Computes a step from the globalpoint (which must be in the current
+    // volume) into globaldir, taking step_limit into account.
+    __host__ __device__ static vecgeom::Precision
+             ComputeStepToApproachNextVolume(
+                 vecgeom::Vector3D<vecgeom::Precision> const& globalpoint,
+                 vecgeom::Vector3D<vecgeom::Precision> const& globaldir,
+                 vecgeom::Precision                           step_limit,
+                 vecgeom::NavStateIndex const&                in_state)
+    {
+        // calculate local point/dir from global point/dir
+        vecgeom::Vector3D<vecgeom::Precision> localpoint;
+        vecgeom::Vector3D<vecgeom::Precision> localdir;
+        // Impl::DoGlobalToLocalTransformation(in_state, globalpoint,
+        // globaldir, localpoint, localdir);
+        vecgeom::Transformation3D m;
+        in_state.TopMatrix(m);
+        localpoint = m.Transform(globalpoint);
+        localdir   = m.TransformDirection(globaldir);
+
+        vecgeom::Precision step
+            = ApproachNextVolume(localpoint, localdir, step_limit, in_state);
+
+        return step;
+    }
+
+    // Relocate a state that was returned from ComputeStepAndNextVolume: It
+    // recursively locates the pushed point in the containing volume.
+    __host__ __device__ static void
+    RelocateToNextVolume(vecgeom::Vector3D<vecgeom::Precision>& globalpoint,
+                         vecgeom::Vector3D<vecgeom::Precision> const& globaldir,
+                         vecgeom::NavStateIndex&                      state)
+    {
+        // Push the point inside the next volume.
+        static constexpr double kPush = 10. * vecgeom::kTolerance;
+        globalpoint += kPush * globaldir;
+
+        // Calculate local point from global point.
+        vecgeom::Transformation3D m;
+        state.TopMatrix(m);
+        vecgeom::Vector3D<vecgeom::Precision> localpoint
+            = m.Transform(globalpoint);
+
+        VPlacedVolumePtr_t pvol = state.Top();
+
+        state.Pop();
+        LocatePointIn(pvol, localpoint, state, false, state.GetLastExited());
+
+        if (state.Top() != nullptr)
+        {
+            while (state.Top()->IsAssembly())
+            {
+                state.Pop();
+            }
+            assert(!state.Top()
+                        ->GetLogicalVolume()
+                        ->GetUnplacedVolume()
+                        ->IsAssembly());
+        }
+    }
+};
+
+} // End namespace COPCORE_IMPL
+#endif // RT_LOOP_NAVIGATOR_H_

--- a/src/geometry/detail/BVHNavigator.hh
+++ b/src/geometry/detail/BVHNavigator.hh
@@ -1,15 +1,16 @@
+//----------------------------------*-C++-*----------------------------------//
 // SPDX-FileCopyrightText: 2020 CERN
 // SPDX-License-Identifier: Apache-2.0
-
-/**
- * @file BVHNavigator.h
- * @brief Navigation methods for geometry.
+//---------------------------------------------------------------------------//
+/*!
+ * \file BVHNavigator.hh
+ * \brief Bounding Volume Hierarchy navigator directly derived from AdePT
+ *
+ * Original source:
+ * https://github.com/apt-sim/AdePT/blob/586a9c43915818bdf764b7315c3dbde7e63a34b8/base/inc/AdePT/BVHNavigator.h
  */
-
-#ifndef RT_NAVIGATOR_H_
-#define RT_NAVIGATOR_H_
-
-#include <CopCore/Global.h>
+//---------------------------------------------------------------------------//
+#pragma once
 
 #include <VecGeom/base/Global.h>
 #include <VecGeom/base/Vector3D.h>
@@ -20,8 +21,11 @@
 #    include <VecGeom/backend/cuda/Interface.h>
 #endif
 
-inline namespace COPCORE_IMPL
+namespace celeritas
 {
+namespace detail
+{
+//---------------------------------------------------------------------------//
 class BVHNavigator
 {
   public:
@@ -410,5 +414,6 @@ class BVHNavigator
     }
 };
 
-} // End namespace COPCORE_IMPL
-#endif // RT_LOOP_NAVIGATOR_H_
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/test/geometry/Geo.test.cc
+++ b/test/geometry/Geo.test.cc
@@ -79,19 +79,16 @@ TEST_F(GeoTrackViewHostTest, from_outside)
     geo              = {{-10, -10, -10}, {1, 0, 0}};
     EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape2");
 
-    geo.find_next_step();
     EXPECT_SOFT_EQ(5, geo.next_step());
     geo.move_next_step(); // Shape2 -> Shape1
     EXPECT_SOFT_EQ(-5, geo.pos()[0]);
     EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape1");
 
-    geo.find_next_step();
     EXPECT_SOFT_EQ(1, geo.next_step());
     geo.move_next_step(); // Shape1 -> Envelope
     EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Envelope");
     EXPECT_FALSE(geo.is_outside());
 
-    geo.find_next_step();
     EXPECT_SOFT_EQ(1, geo.next_step());
     geo.move_next_step(); // Envelope -> World
     EXPECT_EQ(geom.id_to_label(geo.volume_id()), "World");
@@ -110,7 +107,6 @@ TEST_F(GeoTrackViewHostTest, from_outside_edge)
     geo.move_next_step(); // outside -> World
     EXPECT_EQ(geom.id_to_label(geo.volume_id()), "World");
 
-    geo.find_next_step();
     EXPECT_SOFT_EQ(7., geo.next_step());
     geo.move_next_step(); // World -> Envelope
     EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Envelope");
@@ -124,14 +120,12 @@ TEST_F(GeoTrackViewHostTest, inside)
     geo              = {{-10, 10, 10}, {0, -1, 0}};
     EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape2"); // Another Shape2
 
-    geo.find_next_step();
     EXPECT_SOFT_EQ(5.0, geo.next_step());
     geo.move_next_step(); // Shape2 -> Shape1
     EXPECT_SOFT_EQ(5.0, geo.pos()[1]);
     EXPECT_EQ(geom.id_to_label(geo.volume_id()), "Shape1");
     EXPECT_FALSE(geo.is_outside());
 
-    geo.find_next_step();
     EXPECT_SOFT_EQ(1.0, geo.next_step());
     geo.move_next_step();
     EXPECT_FALSE(geo.is_outside());

--- a/test/geometry/Geo.test.cu
+++ b/test/geometry/Geo.test.cu
@@ -44,7 +44,7 @@ __global__ void vgg_test_kernel(const GeoParamsCRefDevice params,
             break;
 
         // Move next step
-        real_type dist = geo.move_next_step();
+        real_type dist = geo.move_to_boundary();
 
         // Save current ID and distance to travel
         ids[tid.get() * max_segments + seg]       = geo.volume_id();
@@ -67,7 +67,7 @@ VGGTestOutput vgg_test(VGGTestInput input)
     thrust::device_vector<VGGTestInit> init(input.init.begin(),
                                             input.init.end());
     thrust::device_vector<VolumeId> ids(input.init.size() * input.max_segments);
-    thrust::device_vector<double>   distances(ids.size(), -1.0);
+    thrust::device_vector<double>   distances(ids.size(), -2.0);
 
     // Run kernel
     static const celeritas::KernelParamCalculator calc_launch_params(
@@ -87,7 +87,7 @@ VGGTestOutput vgg_test(VGGTestInput input)
     VGGTestOutput result;
     for (auto id : thrust::host_vector<VolumeId>(ids))
     {
-        result.ids.push_back(id ? static_cast<int>(id.get()) : -1);
+        result.ids.push_back(id ? static_cast<int>(id.get()) : -3);
     }
     result.distances.resize(distances.size());
     thrust::copy(distances.begin(), distances.end(), result.distances.begin());


### PR DESCRIPTION
I have compared rasterizer processing times (cms2018 geometry), between VecGeom's SimpleNavigator and AdePT's BVHNavigator, and BVH is faster by a factor between 2x and 4x, depending on the rasterization plane.

* Summary for BVH navigator performance:
- xyview:  Average time: 0.285370 s
- xyview-off:  Average time: 0.441714 s
- xzview-off:  Average time: 0.313924 s
- yzview-off:  Average time: 0.313924 s

* Summary for vecgeom's SimpleNavigator:
- xyview-off:  Average time: 1.613710 s
- xzview-off:  Average time: 0.611025 s
- yzview-off:  Average time: 0.601223 s

The -off suffix means that an offset is applied to the third coordinate, otherwise there's a higher chance of some tracks getting stuck.
