### PR TITLE
Update CI to use vecgeom 1.1.18 and CUDA 11.4

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -12,7 +12,7 @@ pipeline {
         stage('minimal') {
           agent {
             docker {
-              image 'celeritas/ci-bionic-minimal:2021-03-09'
+              image 'celeritas/ci-bionic-minimal:2021-12-17'
               // Note: this image does not require CUDA
             }
           }
@@ -29,7 +29,7 @@ pipeline {
         stage('cuda-11-ndebug') {
           agent {
             docker {
-              image 'celeritas/ci-focal-cuda11:2021-05-27'
+              image 'celeritas/ci-focal-cuda11:2021-12-17'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && persistent-tmp'
               args '-v persistent-tmp:/tmp/persistent'
             }
@@ -47,7 +47,7 @@ pipeline {
         stage('cuda-11') {
           agent {
             docker {
-              image 'celeritas/ci-focal-cuda11:2021-05-27'
+              image 'celeritas/ci-focal-cuda11:2021-12-17'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
             }
           }

--- a/.jenkins
+++ b/.jenkins
@@ -29,7 +29,7 @@ pipeline {
         stage('cuda-11-ndebug') {
           agent {
             docker {
-              image 'celeritas/ci-focal-cuda11:2021-12-17'
+              image 'celeritas/ci-focal-cuda11:2021-12-18'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && persistent-tmp'
               args '-v persistent-tmp:/tmp/persistent'
             }
@@ -47,7 +47,7 @@ pipeline {
         stage('cuda-11') {
           agent {
             docker {
-              image 'celeritas/ci-focal-cuda11:2021-12-17'
+              image 'celeritas/ci-focal-cuda11:2021-12-18'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
             }
           }

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -34,7 +34,7 @@ Note that the `--rm` option automatically deletes the state of the container
 after you exit the docker client. This means all of your work will be
 destroyed.
 
-The `launch-testing` script will clone an active github pull request, build,
+The `launch-testing` script will clone an active GitHub pull request, build,
 and set up an image to use locally:
 ```console
 $ ./ci/launch-testing.sh 123
@@ -43,13 +43,22 @@ $ ./ci/launch-testing.sh 123
 To mount the image with your local source directory:
 ```console
 $ docker run --rm -ti -e "TERM=xterm-256color" \
-    -v /rnsdhpc/code/celeritas:src \
-    celeritas/ci-cuda11
+    -v ${SOURCE}:/home/celeritas/src \
+    celeritas/ci-focal-cuda11:${DATE}
+```
+where `${SOURCE}` is your local Celeritas source dir and `${DATE}` is the date
+time stamp of the desired image. If you just built locally, you can replace
+that last argument with the tag `ci-focal-cuda11`.
+
+After mounting, use the build scripts to configure and go:
+```console
+celeritas@abcd1234:~$ cd src
+celeritas@abcd1234:~/src$ BUILD_DIR=$PWD/build-docker ./scripts/build/docker-cuda.sh
 ```
 
-
-The `dev` image runs as root, but the `ci-cuda11` runs as a user `celeritas`.
-This is the best way to [make OpenMPI happy](https://github.com/open-mpi/ompi/issues/4451).
+The `dev` image runs as root, but the `ci-focal-cuda11` runs as a user
+`celeritas`.  This is the best way to [make OpenMPI
+happy](https://github.com/open-mpi/ompi/issues/4451).
 
 Note that the Jenkins CI runs as root regardless of the `run` command, so it
 defines `MPIEXEC_PREFLAGS=--allow-run-as-root` for CMake.

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -3,7 +3,7 @@
 These docker images use [spack](https://github.com/spack/spack) to build a
 CUDA-enabled development environment for Celeritas. There are two sets of
 images:
-- `dev` (this directory) which leaves spack fully installed and
+- `dev` (`dev` subdirectory) which leaves spack fully installed and
   debug symbols intact; and
 - `ci` (`ci` subdirectory) which only copies the necessary software stack (thus
   requiring lower bandwidth on the CI servers).

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -8,7 +8,7 @@ if [ -z "$1" ]; then
   exit 2
 fi
 
-SPACK_VERSION=v0.16.0
+SPACK_VERSION=v0.17.0
 CONFIG=$1
 
 case $CONFIG in 
@@ -22,12 +22,13 @@ esac
  
 case $CONFIG in 
   bionic-minimal)
-    BASE_TAG=ubuntu:bionic-20210428
+    BASE_TAG=ubuntu:bionic-20210930
     VECGEOM=
     ;;
   focal-cuda11)
-    BASE_TAG=nvidia/cuda:11.1-devel-ubuntu20.04
-    VECGEOM=v1.1.15
+    # ***IMPORTANT***: update cuda external version in dev/focal-cuda11!
+    BASE_TAG=nvidia/cuda:11.4.2-devel-ubuntu20.04
+    VECGEOM=v1.1.18
     ;;
   *)
     echo "Invalid configure type: $1"
@@ -35,6 +36,7 @@ case $CONFIG in
     ;;
 esac
 
+docker pull ${BASE_TAG}
 docker tag ${BASE_TAG} base-${CONFIG}
 
 docker build -t dev-${CONFIG} \

--- a/scripts/docker/dev/Dockerfile
+++ b/scripts/docker/dev/Dockerfile
@@ -71,6 +71,9 @@ SHELL ["docker-shell"]
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]
 CMD ["interactive-shell"]
 
+# Bootstrap spack
+RUN spack spec zlib
+
 ###############################################################################
 # Install
 ###############################################################################

--- a/scripts/docker/dev/bionic-minimal.yaml
+++ b/scripts/docker/dev/bionic-minimal.yaml
@@ -4,17 +4,13 @@ spack:
 
 
 
-
   - git
   - googletest
-
 
   - ninja
   - nlohmann-json
 
   - python
-
-
 
 
 

--- a/scripts/docker/dev/bionic-minimal.yaml
+++ b/scripts/docker/dev/bionic-minimal.yaml
@@ -13,8 +13,6 @@ spack:
   - python
 
 
-
-
   - valgrind
   concretization: together
   packages:

--- a/scripts/docker/dev/focal-cuda11.yaml
+++ b/scripts/docker/dev/focal-cuda11.yaml
@@ -24,7 +24,7 @@ spack:
     cuda:
       buildable: false
       externals:
-      - spec: cuda@11.1.0
+      - spec: cuda@11.4.2
         prefix: /usr/local/cuda
     root:
       variants: ~davix ~examples ~x ~opengl ~tbb ~rootfit ~python ~math ~gsl cxxstd=14

--- a/scripts/docker/dev/focal-cuda11.yaml
+++ b/scripts/docker/dev/focal-cuda11.yaml
@@ -4,19 +4,15 @@ spack:
   - cuda
   - doxygen
   - geant4
-
   - git
   - googletest
-
   - hepmc3
   - ninja
   - nlohmann-json
   - openmpi
   - python
-
   - root
   - swig
-
   - veccore
   - vecgeom +gdml
   concretization: together

--- a/scripts/docker/dev/focal-cuda11.yaml
+++ b/scripts/docker/dev/focal-cuda11.yaml
@@ -13,8 +13,6 @@ spack:
   - python
   - root
   - swig
-  - veccore
-  - vecgeom +gdml
   concretization: together
   packages:
     cuda:

--- a/src/physics/em/detail/BetheHeitlerInteractor.hh
+++ b/src/physics/em/detail/BetheHeitlerInteractor.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/BetheHeitlerInteractor.i.hh
+++ b/src/physics/em/detail/BetheHeitlerInteractor.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/BetheHeitlerLauncher.hh
+++ b/src/physics/em/detail/BetheHeitlerLauncher.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/CombinedBremInteractor.hh
+++ b/src/physics/em/detail/CombinedBremInteractor.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/CombinedBremInteractor.hh
+++ b/src/physics/em/detail/CombinedBremInteractor.hh
@@ -33,7 +33,9 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * A combined bremsstrahlung interactor consisted of the Seltzer-Berger
+ * Apply either Seltzer-Berger or Relativistic depending on energy.
+ *
+ * This is a combined bremsstrahlung interactor consisted of the Seltzer-Berger
  * interactor at the low energy (< 1 GeV) and the relativistic bremsstrahlung
  * interactor at the high energy for the e-/e+ bremsstrahlung process.
  */
@@ -64,6 +66,7 @@ class CombinedBremInteractor
 
   private:
     //// DATA ////
+
     // Incident particle energy
     const Energy inc_energy_;
     // Incident particle direction
@@ -82,6 +85,7 @@ class CombinedBremInteractor
     const bool is_relativistic_;
 
     //// HELPER CLASSES ////
+
     // A helper to Sample the photon energy from the relativistic model
     RBEnergySampler rb_energy_sampler_;
     // A helper to sample the photon energy from the SeltzerBerger model

--- a/src/physics/em/detail/CombinedBremInteractor.i.hh
+++ b/src/physics/em/detail/CombinedBremInteractor.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/CombinedBremLauncher.hh
+++ b/src/physics/em/detail/CombinedBremLauncher.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/EPlusGGInteractor.hh
+++ b/src/physics/em/detail/EPlusGGInteractor.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/EPlusGGInteractor.i.hh
+++ b/src/physics/em/detail/EPlusGGInteractor.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/EPlusGGLauncher.hh
+++ b/src/physics/em/detail/EPlusGGLauncher.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/KleinNishinaInteractor.hh
+++ b/src/physics/em/detail/KleinNishinaInteractor.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/KleinNishinaInteractor.i.hh
+++ b/src/physics/em/detail/KleinNishinaInteractor.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/KleinNishinaLauncher.hh
+++ b/src/physics/em/detail/KleinNishinaLauncher.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/LivermorePEInteractor.hh
+++ b/src/physics/em/detail/LivermorePEInteractor.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/LivermorePEInteractor.i.hh
+++ b/src/physics/em/detail/LivermorePEInteractor.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/LivermorePELauncher.hh
+++ b/src/physics/em/detail/LivermorePELauncher.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/LivermorePEMicroXsCalculator.hh
+++ b/src/physics/em/detail/LivermorePEMicroXsCalculator.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/LivermorePEMicroXsCalculator.i.hh
+++ b/src/physics/em/detail/LivermorePEMicroXsCalculator.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/MuBremsstrahlungInteractor.hh
+++ b/src/physics/em/detail/MuBremsstrahlungInteractor.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/MuBremsstrahlungInteractor.i.hh
+++ b/src/physics/em/detail/MuBremsstrahlungInteractor.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/MuBremsstrahlungLauncher.hh
+++ b/src/physics/em/detail/MuBremsstrahlungLauncher.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/PhysicsConstants.hh
+++ b/src/physics/em/detail/PhysicsConstants.hh
@@ -1,5 +1,5 @@
 //---------------------------------*-CUDA-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/PhysicsConstants.hh
+++ b/src/physics/em/detail/PhysicsConstants.hh
@@ -59,10 +59,12 @@ CELER_CONSTEXPR_FUNCTION MevPerCm lpm_constant()
 }
 //!@}
 
-//!@{
-//! Constant functions for model limits
+//---------------------------------------------------------------------------//
+// Constant functions for model limits
+//---------------------------------------------------------------------------//
 
-//! Maximum energy for the SeltzerBerger model - TODO: make this configurable 
+//!@{
+//! Maximum energy for the SeltzerBerger model - TODO: make this configurable
 CELER_CONSTEXPR_FUNCTION units::MevEnergy seltzer_berger_limit()
 {
     return units::MevEnergy{1e3}; //! 1 GeV

--- a/src/physics/em/detail/RBDiffXsCalculator.hh
+++ b/src/physics/em/detail/RBDiffXsCalculator.hh
@@ -24,59 +24,48 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Calculate differential cross sections with and without the LPM effect.
+ * Calculate differential cross sections for relativistic bremsstrahlung.
+ *
+ * This accounts for the LPM effect if the option is enabled and the
+ * electron energy is high enough.
+ *
+ * This is a shape function used for rejection, so as long as the resulting
+ * cross section is scaled by the maximum value the units do not matter.
  */
 class RBDiffXsCalculator
 {
   public:
     //!@{
     //! Type aliases
-    using R           = real_type;
     using Energy      = units::MevEnergy;
-    using ItemIdT     = celeritas::ItemId<unsigned int>;
     using ElementData = detail::RelBremElementData;
     //!@}
 
   public:
-    // Construct with shared and state data
+    // Construct with incident electron and current element
     inline CELER_FUNCTION
     RBDiffXsCalculator(const RelativisticBremNativeRef& shared,
                        const ParticleTrackView&         particle,
                        const MaterialView&              material,
                        const ElementComponentId&        elcomp_id);
 
-    // Compute cross section
-    inline CELER_FUNCTION real_type operator()(real_type energy);
+    // Compute cross section of exiting gamma energy
+    inline CELER_FUNCTION real_type operator()(Energy energy);
 
-    // Return the density correction
+    //! Density correction factor [Energy^2]
     CELER_FUNCTION real_type density_correction() const
     {
         return density_corr_;
     }
 
-    // Return the maximum value of the differential cross section
+    //! Return the maximum value of the differential cross section
     CELER_FUNCTION real_type maximum_value() const
     {
         return elem_data_.factor1 + elem_data_.factor2;
     }
 
   private:
-    //// DATA ////
-
-    // Shared constant physics properties
-    const RelativisticBremNativeRef& shared_;
-    // Element data of the current material
-    const ElementData& elem_data_;
-    // Total energy of the incident particle
-    real_type total_energy_;
-    // Density correction for the current material
-    real_type density_corr_;
-    // LPM energy for the current material
-    real_type lpm_energy_;
-    // Flag for the LPM effect
-    bool enable_lpm_;
-
-    //// HELPER TYPES ////
+    //// TYPES ////
 
     //! Intermediate data for screening functions
     struct ScreenFunctions
@@ -94,6 +83,24 @@ class RBDiffXsCalculator
         real_type gs{0};
         real_type phis{0};
     };
+
+    using R       = real_type;
+    using ItemIdT = celeritas::ItemId<unsigned int>;
+
+    //// DATA ////
+
+    // Shared constant physics properties
+    const RelativisticBremNativeRef& shared_;
+    // Element data of the current material
+    const ElementData& elem_data_;
+    // Total energy of the incident particle
+    real_type total_energy_;
+    // Density correction for the current material
+    real_type density_corr_;
+    // LPM energy for the current material
+    real_type lpm_energy_;
+    // Flag for the LPM effect
+    bool enable_lpm_;
 
     //// HELPER FUNCTIONS ////
 

--- a/src/physics/em/detail/RBDiffXsCalculator.hh
+++ b/src/physics/em/detail/RBDiffXsCalculator.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file RelativisticBremDXsection.hh
+//! \file RBDiffXsCalculator.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -24,9 +24,9 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Calculate the different cross sections with and without the LPM effect.
+ * Calculate differential cross sections with and without the LPM effect.
  */
-class RelativisticBremDXsection
+class RBDiffXsCalculator
 {
   public:
     //!@{
@@ -40,10 +40,10 @@ class RelativisticBremDXsection
   public:
     // Construct with shared and state data
     inline CELER_FUNCTION
-    RelativisticBremDXsection(const RelativisticBremNativeRef& shared,
-                              const ParticleTrackView&         particle,
-                              const MaterialView&              material,
-                              const ElementComponentId&        elcomp_id);
+    RBDiffXsCalculator(const RelativisticBremNativeRef& shared,
+                       const ParticleTrackView&         particle,
+                       const MaterialView&              material,
+                       const ElementComponentId&        elcomp_id);
 
     // Compute cross section
     inline CELER_FUNCTION real_type operator()(real_type energy);
@@ -105,7 +105,7 @@ class RelativisticBremDXsection
 
     //! Compute screening functions
     inline CELER_FUNCTION ScreenFunctions
-                          compute_screen_functions(real_type gamma, real_type epsilon);
+    compute_screen_functions(real_type gamma, real_type epsilon);
 
     //! Compute LPM functions
     inline CELER_FUNCTION LPMFunctions compute_lpm_functions(real_type ss);
@@ -115,4 +115,4 @@ class RelativisticBremDXsection
 } // namespace detail
 } // namespace celeritas
 
-#include "RelativisticBremDXsection.i.hh"
+#include "RBDiffXsCalculator.i.hh"

--- a/src/physics/em/detail/RBDiffXsCalculator.i.hh
+++ b/src/physics/em/detail/RBDiffXsCalculator.i.hh
@@ -3,13 +3,13 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file RelativisticBremDXsection.i.hh
+//! \file RBDiffXsCalculator.i.hh
 //---------------------------------------------------------------------------//
 
 #include <cmath>
 
 #include "base/Algorithms.hh"
-#include "RelativisticBremDXsection.hh"
+#include "RBDiffXsCalculator.hh"
 #include "PhysicsConstants.hh"
 
 namespace celeritas
@@ -20,11 +20,11 @@ namespace detail
 /*!
  * Construct with shared and state data.
  */
-CELER_FUNCTION RelativisticBremDXsection::RelativisticBremDXsection(
-    const RelativisticBremNativeRef& shared,
-    const ParticleTrackView&         particle,
-    const MaterialView&              material,
-    const ElementComponentId&        elcomp_id)
+CELER_FUNCTION
+RBDiffXsCalculator::RBDiffXsCalculator(const RelativisticBremNativeRef& shared,
+                                       const ParticleTrackView&  particle,
+                                       const MaterialView&       material,
+                                       const ElementComponentId& elcomp_id)
     : shared_(shared)
     , elem_data_(shared.elem_data[material.element_id(elcomp_id)])
     , total_energy_(particle.energy().value() + shared.electron_mass.value())
@@ -44,7 +44,7 @@ CELER_FUNCTION RelativisticBremDXsection::RelativisticBremDXsection(
  * bremsstrahlung photon energy in MeV.
  */
 CELER_FUNCTION
-real_type RelativisticBremDXsection::operator()(real_type energy)
+real_type RBDiffXsCalculator::operator()(real_type energy)
 {
     CELER_EXPECT(energy > 0);
     return enable_lpm_ ? this->dxsec_per_atom_lpm(energy)
@@ -56,7 +56,7 @@ real_type RelativisticBremDXsection::operator()(real_type energy)
  * Compute the differential cross section without the LPM effect.
  */
 CELER_FUNCTION
-real_type RelativisticBremDXsection::dxsec_per_atom(real_type gamma_energy)
+real_type RBDiffXsCalculator::dxsec_per_atom(real_type gamma_energy)
 {
     real_type dxsec{0};
 
@@ -95,7 +95,7 @@ real_type RelativisticBremDXsection::dxsec_per_atom(real_type gamma_energy)
  * Compute the differential cross section with the LPM effect.
  */
 CELER_FUNCTION
-real_type RelativisticBremDXsection::dxsec_per_atom_lpm(real_type gamma_energy)
+real_type RBDiffXsCalculator::dxsec_per_atom_lpm(real_type gamma_energy)
 {
     real_type y     = gamma_energy / total_energy_;
     real_type onemy = 1 - y;
@@ -116,8 +116,7 @@ real_type RelativisticBremDXsection::dxsec_per_atom_lpm(real_type gamma_energy)
  * incoherent screening function to the numerical screening functions computed
  * by using the Thomas-Fermi model: Y.-S.Tsai, Rev. Mod. Phys. 49 (1977) 421.
  */
-auto RelativisticBremDXsection::compute_screen_functions(real_type gam,
-                                                         real_type eps)
+auto RBDiffXsCalculator::compute_screen_functions(real_type gam, real_type eps)
     -> ScreenFunctions
 {
     ScreenFunctions func;
@@ -141,8 +140,7 @@ auto RelativisticBremDXsection::compute_screen_functions(real_type gam,
 /*!
  * Compute the LPM suppression functions.
  */
-auto RelativisticBremDXsection::compute_lpm_functions(real_type egamma)
-    -> LPMFunctions
+auto RBDiffXsCalculator::compute_lpm_functions(real_type egamma) -> LPMFunctions
 {
     LPMFunctions func;
 

--- a/src/physics/em/detail/RBEnergySampler.hh
+++ b/src/physics/em/detail/RBEnergySampler.hh
@@ -15,7 +15,7 @@
 #include "physics/material/Types.hh"
 
 #include "RelativisticBremData.hh"
-#include "RelativisticBremDXsection.hh"
+#include "RBDiffXsCalculator.hh"
 
 namespace celeritas
 {
@@ -54,7 +54,7 @@ class RBEnergySampler
     // Squaer of production cutoff for gammas
     real_type tmax_sq_;
     // Differential cross section calcuator
-    RelativisticBremDXsection dxsec_;
+    RBDiffXsCalculator dxsec_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RBEnergySampler.hh
+++ b/src/physics/em/detail/RBEnergySampler.hh
@@ -53,10 +53,11 @@ class RBEnergySampler
     using ReciprocalSampler = ReciprocalDistribution<real_type>;
 
     //// DATA ////
+
     // Incident particle energy
-    const Energy inc_energy_;
+    const real_type inc_energy_;
     // Production cutoff for gammas
-    const Energy gamma_cutoff_;
+    const real_type gamma_cutoff_;
     // Differential cross section calcuator
     RelativisticBremDXsection dxsec_;
 };

--- a/src/physics/em/detail/RBEnergySampler.hh
+++ b/src/physics/em/detail/RBEnergySampler.hh
@@ -51,10 +51,10 @@ class RBEnergySampler
 
     // Square of minimum of incident particle energy and cutoff
     real_type tmin_sq_;
-    // Squaer of production cutoff for gammas
+    // Square of production cutoff for gammas
     real_type tmax_sq_;
     // Differential cross section calcuator
-    RBDiffXsCalculator dxsec_;
+    RBDiffXsCalculator calc_dxsec_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RBEnergySampler.hh
+++ b/src/physics/em/detail/RBEnergySampler.hh
@@ -14,8 +14,6 @@
 #include "physics/material/MaterialView.hh"
 #include "physics/material/Types.hh"
 
-#include "random/distributions/ReciprocalDistribution.hh"
-
 #include "RelativisticBremData.hh"
 #include "RelativisticBremDXsection.hh"
 
@@ -26,7 +24,6 @@ namespace detail
 //---------------------------------------------------------------------------//
 /*!
  * Sample the bremsstrahlung photon energy from the relativistic model.
- *
  */
 class RBEnergySampler
 {
@@ -50,14 +47,12 @@ class RBEnergySampler
     inline CELER_FUNCTION Energy operator()(Engine& rng);
 
   private:
-    using ReciprocalSampler = ReciprocalDistribution<real_type>;
-
     //// DATA ////
 
-    // Incident particle energy
-    const real_type inc_energy_;
-    // Production cutoff for gammas
-    const real_type gamma_cutoff_;
+    // Square of minimum of incident particle energy and cutoff
+    real_type tmin_sq_;
+    // Squaer of production cutoff for gammas
+    real_type tmax_sq_;
     // Differential cross section calcuator
     RelativisticBremDXsection dxsec_;
 };

--- a/src/physics/em/detail/RBEnergySampler.i.hh
+++ b/src/physics/em/detail/RBEnergySampler.i.hh
@@ -26,14 +26,14 @@ RBEnergySampler::RBEnergySampler(const RelativisticBremNativeRef& shared,
                                  const CutoffView&                cutoffs,
                                  const MaterialView&              material,
                                  const ElementComponentId&        elcomp_id)
-    : dxsec_(shared, particle, material, elcomp_id)
+    : calc_dxsec_(shared, particle, material, elcomp_id)
 {
     // Min and max kinetic energy limits for sampling the secondary photon
     real_type gamma_cutoff = value_as<Energy>(cutoffs.energy(shared.ids.gamma));
     real_type inc_energy   = value_as<Energy>(particle.energy());
-    tmin_sq_               = ipow<2>(celeritas::min(gamma_cutoff, inc_energy));
-    tmax_sq_               = ipow<2>(
-        celeritas::min(value_as<Energy>(high_energy_limit()), inc_energy));
+
+    tmin_sq_ = ipow<2>(min(gamma_cutoff, inc_energy));
+    tmax_sq_ = ipow<2>(min(value_as<Energy>(high_energy_limit()), inc_energy));
 
     CELER_ENSURE(tmax_sq_ >= tmin_sq_);
 }
@@ -46,17 +46,19 @@ RBEnergySampler::RBEnergySampler(const RelativisticBremNativeRef& shared,
 template<class Engine>
 CELER_FUNCTION auto RBEnergySampler::operator()(Engine& rng) -> Energy
 {
-    real_type density_corr = dxsec_.density_correction();
+    real_type density_corr = calc_dxsec_.density_correction();
     ReciprocalDistribution<real_type> sample_exit_esq(tmin_sq_ + density_corr,
                                                       tmax_sq_ + density_corr);
+
+    // Sampled energy and corresponding cross section for rejection
     real_type gamma_energy{0};
     real_type dsigma{0};
 
     do
     {
         gamma_energy = std::sqrt(sample_exit_esq(rng) - density_corr);
-        dsigma       = dxsec_(gamma_energy);
-    } while (!BernoulliDistribution(dsigma / dxsec_.maximum_value())(rng));
+        dsigma       = calc_dxsec_(Energy{gamma_energy});
+    } while (!BernoulliDistribution(dsigma / calc_dxsec_.maximum_value())(rng));
 
     return Energy{gamma_energy};
 }

--- a/src/physics/em/detail/RayleighInteractor.hh
+++ b/src/physics/em/detail/RayleighInteractor.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RayleighInteractor.i.hh
+++ b/src/physics/em/detail/RayleighInteractor.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RayleighLauncher.hh
+++ b/src/physics/em/detail/RayleighLauncher.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RelativisticBremDXsection.hh
+++ b/src/physics/em/detail/RelativisticBremDXsection.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RelativisticBremDXsection.hh
+++ b/src/physics/em/detail/RelativisticBremDXsection.hh
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "base/Algorithms.hh"
 #include "base/Constants.hh"
 #include "base/Macros.hh"
 #include "base/Quantity.hh"

--- a/src/physics/em/detail/RelativisticBremDXsection.i.hh
+++ b/src/physics/em/detail/RelativisticBremDXsection.i.hh
@@ -47,8 +47,8 @@ CELER_FUNCTION
 real_type RelativisticBremDXsection::operator()(real_type energy)
 {
     CELER_EXPECT(energy > 0);
-    return (enable_lpm_) ? this->dxsec_per_atom_lpm(energy)
-                         : this->dxsec_per_atom(energy);
+    return enable_lpm_ ? this->dxsec_per_atom_lpm(energy)
+                       : this->dxsec_per_atom(energy);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RelativisticBremDXsection.i.hh
+++ b/src/physics/em/detail/RelativisticBremDXsection.i.hh
@@ -5,10 +5,12 @@
 //---------------------------------------------------------------------------//
 //! \file RelativisticBremDXsection.i.hh
 //---------------------------------------------------------------------------//
-#include "RelativisticBremDXsection.hh"
-#include "PhysicsConstants.hh"
 
 #include <cmath>
+
+#include "base/Algorithms.hh"
+#include "RelativisticBremDXsection.hh"
+#include "PhysicsConstants.hh"
 
 namespace celeritas
 {
@@ -85,7 +87,7 @@ real_type RelativisticBremDXsection::dxsec_per_atom(real_type gamma_energy)
               + R(0.125) * onemy * (sfunc.phi2 + sfunc.psi2 * invz);
     }
 
-    return max(dxsec, R(0));
+    return celeritas::max(dxsec, R(0));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RelativisticBremDXsection.i.hh
+++ b/src/physics/em/detail/RelativisticBremDXsection.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RelativisticBremInteractor.hh
+++ b/src/physics/em/detail/RelativisticBremInteractor.hh
@@ -33,10 +33,10 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Brief class description.
+ * Perform a high-energy Bremsstrahlung interaction.
  *
  * This is a relativistic Bremsstrahlung model for high-energy (> 1 GeV)
- * electrons and positorons.
+ * electrons and positrons.
  *
  * \note This performs the same sampling routine as in Geant4's
  * G4eBremsstrahlungRelModel class, as documented in section 10.2.2 of the
@@ -70,6 +70,7 @@ class RelativisticBremInteractor
 
   private:
     //// DATA ////
+
     // Shared constant physics properties
     const RelativisticBremNativeRef& shared_;
     // Incident particle energy
@@ -83,8 +84,9 @@ class RelativisticBremInteractor
     // Allocate space for a secondary particle
     StackAllocator<Secondary>& allocate_;
 
-    //// HELPER CLASSES //// // A helper to sample the photon energy from the
-    /// relativistic model
+    //// HELPER CLASSES ////
+
+    // A helper to sample the photon energy from the relativistic model
     RBEnergySampler rb_energy_sampler_;
     // A helper to update the final state of the primary and the secondary
     BremFinalStateHelper final_state_interaction_;

--- a/src/physics/em/detail/RelativisticBremInteractor.hh
+++ b/src/physics/em/detail/RelativisticBremInteractor.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RelativisticBremInteractor.i.hh
+++ b/src/physics/em/detail/RelativisticBremInteractor.i.hh
@@ -8,7 +8,7 @@
 
 #include "base/ArrayUtils.hh"
 #include "base/Algorithms.hh"
-#include "random/distributions/GenerateCanonical.hh"
+#include "PhysicsConstants.hh"
 
 namespace celeritas
 {

--- a/src/physics/em/detail/RelativisticBremInteractor.i.hh
+++ b/src/physics/em/detail/RelativisticBremInteractor.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/RelativisticBremLauncher.hh
+++ b/src/physics/em/detail/RelativisticBremLauncher.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/SeltzerBergerInteractor.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/SeltzerBergerInteractor.i.hh
+++ b/src/physics/em/detail/SeltzerBergerInteractor.i.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/SeltzerBergerLauncher.hh
+++ b/src/physics/em/detail/SeltzerBergerLauncher.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/TsaiUrbanDistribution.hh
+++ b/src/physics/em/detail/TsaiUrbanDistribution.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/Utils.cc
+++ b/src/physics/em/detail/Utils.cc
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/Utils.hh
+++ b/src/physics/em/detail/Utils.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2020 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2021 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/test/physics/em/CombinedBrem.test.cc
+++ b/test/physics/em/CombinedBrem.test.cc
@@ -9,7 +9,7 @@
 
 #include "physics/em/detail/SBPositronXsCorrector.hh"
 #include "physics/em/detail/SBEnergyDistribution.hh"
-#include "physics/em/detail/RelativisticBremDXsection.hh"
+#include "physics/em/detail/RBDiffXsCalculator.hh"
 
 #include "physics/em/CombinedBremModel.hh"
 
@@ -34,7 +34,7 @@ using celeritas::ElementId;
 using celeritas::ElementView;
 using celeritas::SeltzerBergerReader;
 using celeritas::detail::CombinedBremInteractor;
-using celeritas::detail::RelativisticBremDXsection;
+using celeritas::detail::RBDiffXsCalculator;
 using celeritas::detail::SBElectronXsCorrector;
 using celeritas::detail::SBEnergyDistHelper;
 using celeritas::detail::SBEnergyDistribution;

--- a/test/physics/em/RelativisticBrem.test.cc
+++ b/test/physics/em/RelativisticBrem.test.cc
@@ -148,10 +148,10 @@ TEST_F(RelativisticBremTest, dxsec)
 
     for (real_type energy : all_energy)
     {
-        real_type result = dxsec_lpm(energy);
+        real_type result = dxsec_lpm(MevEnergy{energy});
         dxsec_value_lpm.push_back(result);
 
-        result = dxsec(energy);
+        result = dxsec(MevEnergy{energy});
         dxsec_value.push_back(result);
     }
 

--- a/test/physics/em/RelativisticBrem.test.cc
+++ b/test/physics/em/RelativisticBrem.test.cc
@@ -6,7 +6,7 @@
 //! \file RelativisticBremTest.test.cc
 //---------------------------------------------------------------------------//
 #include "physics/em/RelativisticBremModel.hh"
-#include "physics/em/detail/RelativisticBremDXsection.hh"
+#include "physics/em/detail/RBDiffXsCalculator.hh"
 #include "physics/em/detail/RelativisticBremInteractor.hh"
 
 #include "celeritas_test.hh"
@@ -24,7 +24,7 @@ using celeritas::ElementComponentId;
 using celeritas::ElementId;
 using celeritas::ElementView;
 using celeritas::RelativisticBremModel;
-using celeritas::detail::RelativisticBremDXsection;
+using celeritas::detail::RBDiffXsCalculator;
 using celeritas::detail::RelativisticBremInteractor;
 
 namespace pdg = celeritas::pdg;
@@ -131,16 +131,16 @@ TEST_F(RelativisticBremTest, dxsec)
     auto material_view = this->material_track().material_view();
 
     // Create the differential cross section
-    RelativisticBremDXsection dxsec_lpm(model_lpm_->host_ref(),
-                                        this->particle_track(),
-                                        material_view,
-                                        ElementComponentId{0});
+    RBDiffXsCalculator dxsec_lpm(model_lpm_->host_ref(),
+                                 this->particle_track(),
+                                 material_view,
+                                 ElementComponentId{0});
 
     // Create the differential cross section
-    RelativisticBremDXsection dxsec(model_->host_ref(),
-                                    this->particle_track(),
-                                    material_view,
-                                    ElementComponentId{0});
+    RBDiffXsCalculator dxsec(model_->host_ref(),
+                             this->particle_track(),
+                             material_view,
+                             ElementComponentId{0});
 
     // Calculate cross section values at ten photon energy (MevEnergy) points
     std::vector<double> dxsec_value_lpm;


### PR DESCRIPTION
To support #328 I've upgraded VecGeom (since I didn't have the prior docker images on my laptop I rebuilt the whole toolchain).

The main issue that arose was a segfault inside NVCC (not in the compiled code, the compiler itself!) that happened when taking `celeritas::min` of const member data in the brems energy sampler. (I figured this out by bisecting the relativistic energy sample code, noting that the segfault appeared in the relativistic and combined interactor launchers but nowhere else.) I rewrote that part of code so that it stores the derived quantities (the distribution parameters rather than the input values) to work around the error. I also did a little cleanup of the relativistic brems class including renaming `DXsection` to `DifferentialXsCalculator`.

Finally I noticed a bunch of copyrights for code that we wrote this year still had 2020 on them so I changed those to 2021.