### PR TITLE
Fix tolerance and missing move

### DIFF
--- a/src/base/Algorithms.hh
+++ b/src/base/Algorithms.hh
@@ -51,13 +51,13 @@ CELER_CONSTEXPR_FUNCTION auto move(T&& v) noexcept ->
 template<class T>
 CELER_FORCEINLINE_FUNCTION void trivial_swap(T& a, T& b) noexcept
 {
-    static_assert(std::is_trivially_copy_constructible<T>::value,
+    static_assert(std::is_trivially_move_constructible<T>::value,
                   "Value is not trivially copyable");
     static_assert(std::is_trivially_move_assignable<T>::value,
                   "Value is not trivially movable");
     static_assert(std::is_trivially_destructible<T>::value,
                   "Value is not trivially destructible");
-    T temp{a};
+    T temp{::celeritas::move(a)};
     a = ::celeritas::move(b);
     b = ::celeritas::move(temp);
 }

--- a/test/physics/em/RelativisticBrem.test.cc
+++ b/test/physics/em/RelativisticBrem.test.cc
@@ -346,8 +346,8 @@ TEST_F(RelativisticBremTest, stress_with_lpm)
     }
     EXPECT_EQ(num_samples, this->secondary_allocator().get().size());
 
-    EXPECT_DOUBLE_EQ(average_energy / num_samples, 2932.1072998587733);
-    EXPECT_DOUBLE_EQ(average_angle[0] / num_samples, 3.3286986548662216e-06);
-    EXPECT_DOUBLE_EQ(average_angle[1] / num_samples, 1.3067055198983571e-06);
-    EXPECT_DOUBLE_EQ(average_angle[2] / num_samples, 0.99999999899845182);
+    EXPECT_SOFT_EQ(average_energy / num_samples, 2932.1072998587733);
+    EXPECT_SOFT_EQ(average_angle[0] / num_samples, 3.3286986548662216e-06);
+    EXPECT_SOFT_EQ(average_angle[1] / num_samples, 1.3067055198983571e-06);
+    EXPECT_SOFT_EQ(average_angle[2] / num_samples, 0.99999999899845182);
 }


### PR DESCRIPTION
Fixes the error @pcanal pointed out in #325 and a small precision difference in the brems test when running with `-march=native` in highly optimized mode on CPU. Happy Christmas!