### PR TITLE
ORANGE: implement distance-to-boundary calculation

### DIFF
--- a/src/orange/Data.hh
+++ b/src/orange/Data.hh
@@ -206,7 +206,10 @@ struct OrangeStateData
     StateItems<Sense>     sense;
 
     // Scratch space
-    Items<Sense> temp_senses; // [track][max_faces]
+    Items<Sense>     temp_sense;    // [track][max_faces]
+    Items<FaceId>    temp_face;     // [track][max_intersections]
+    Items<real_type> temp_distance; // [track][max_intersections]
+    Items<size_type> temp_isect;    // [track][max_intersections]
 
     //// METHODS ////
 
@@ -219,7 +222,10 @@ struct OrangeStateData
             && vol.size() == pos.size()
             && surf.size() == pos.size()
             && sense.size() == pos.size()
-            && !temp_senses.empty();
+            && !temp_sense.empty()
+            && !temp_face.empty()
+            && temp_distance.size() == temp_face.size()
+            && temp_isect.size() == temp_face.size();
         // clang-format on
     }
 
@@ -238,7 +244,10 @@ struct OrangeStateData
         surf  = other.surf;
         sense = other.sense;
 
-        temp_senses = other.temp_senses;
+        temp_sense    = other.temp_sense;
+        temp_face     = other.temp_face;
+        temp_distance = other.temp_distance;
+        temp_isect    = other.temp_isect;
 
         CELER_ENSURE(*this);
         return *this;
@@ -264,7 +273,12 @@ resize(OrangeStateData<Ownership::value, M>* data,
     make_builder(&data->sense).resize(size);
 
     size_type face_states = params.scalars.max_faces * size;
-    make_builder(&data->temp_senses).resize(face_states);
+    make_builder(&data->temp_sense).resize(face_states);
+
+    size_type isect_states = params.scalars.max_intersections * size;
+    make_builder(&data->temp_face).resize(isect_states);
+    make_builder(&data->temp_distance).resize(isect_states);
+    make_builder(&data->temp_isect).resize(isect_states);
 
     CELER_ENSURE(*data);
 }

--- a/src/orange/universes/SimpleUnitTracker.hh
+++ b/src/orange/universes/SimpleUnitTracker.hh
@@ -11,6 +11,7 @@
 #include "orange/surfaces/Surfaces.hh"
 #include "detail/LogicEvaluator.hh"
 #include "detail/SenseCalculator.hh"
+#include "detail/SurfaceFunctors.hh"
 #include "detail/Types.hh"
 #include "detail/Utils.hh"
 
@@ -33,6 +34,7 @@ class SimpleUnitTracker
     using ParamsRef
         = OrangeParamsData<Ownership::const_reference, MemSpace::native>;
     using Initialization = detail::Initialization;
+    using Intersection   = detail::Intersection;
     using LocalState     = detail::LocalState;
     //!@}
 
@@ -43,8 +45,18 @@ class SimpleUnitTracker
     // Find the local cell and possibly surface ID.
     inline CELER_FUNCTION Initialization initialize(LocalState state) const;
 
+    // Calculate the distance to an exiting face for the current volume.
+    inline CELER_FUNCTION Intersection intersect(LocalState state) const;
+
   private:
+    //// DATA ////
     const ParamsRef& params_;
+
+    //// METHODS ////
+    inline CELER_FUNCTION
+        Intersection simple_intersect(LocalState, VolumeView) const;
+    inline CELER_FUNCTION
+        Intersection complex_intersect(LocalState, VolumeView) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -76,7 +88,7 @@ CELER_FUNCTION auto SimpleUnitTracker::initialize(LocalState state) const
     CELER_EXPECT(params_);
 
     detail::SenseCalculator calc_senses(
-        Surfaces{params_.surfaces}, state.pos, state.temp_senses);
+        Surfaces{params_.surfaces}, state.pos, state.temp_sense);
 
     for (VolumeId volid : range(VolumeId{params_.volumes.size()}))
     {
@@ -110,6 +122,183 @@ CELER_FUNCTION auto SimpleUnitTracker::initialize(LocalState state) const
     }
 
     // Failed to find a valid volume containing the point
+    return {};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate distance-to-intercept for the next surface
+ */
+CELER_FUNCTION auto SimpleUnitTracker::intersect(LocalState state) const
+    -> Intersection
+{
+    CELER_EXPECT(state.volume && !state.temp_sense.empty());
+
+    // Resize temporaries based on volume properties
+    VolumeView vol{params_.volumes, state.volume};
+    CELER_ASSERT(state.temp_next.size >= vol.num_intersections());
+    state.temp_next.size = vol.num_intersections();
+    const bool is_simple = !(vol.flags() & VolumeView::internal_surfaces);
+
+    // Find all surface intersection distances inside this volume
+    {
+        auto calc_intersections = make_surface_action(
+            Surfaces{params_.surfaces},
+            detail::CalcIntersections{
+                state.pos,
+                state.dir,
+                state.surface ? vol.find_face(state.surface.id()) : FaceId{},
+                is_simple,
+                state.temp_next});
+        for (SurfaceId surface : vol.faces())
+        {
+            calc_intersections(surface);
+        }
+        CELER_ASSERT(calc_intersections.action().face_idx() == vol.num_faces());
+        CELER_ASSERT(calc_intersections.action().isect_idx()
+                     == vol.num_intersections());
+    }
+
+    if (is_simple)
+    {
+        // No interior surfaces: closest distance is next boundary
+        return this->simple_intersect(state, vol);
+    }
+    else
+    {
+        return this->complex_intersect(state, vol);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate distance to the next boundary for nonreentrant cells
+ */
+CELER_FUNCTION auto
+SimpleUnitTracker::simple_intersect(LocalState state, VolumeView vol) const
+    -> Intersection
+{
+    CELER_EXPECT(state.temp_next && vol.num_intersections() > 0);
+
+    // Crossing any surface will leave the cell; perform a linear search for
+    // the smallest (but nonzero) distance
+    size_type distance_idx;
+    {
+        const real_type* distance_ptr = celeritas::min_element(
+            state.temp_next.distance,
+            state.temp_next.distance + state.temp_next.size,
+            detail::CloserNonzeroDistance{});
+        CELER_ASSERT(*distance_ptr > 0);
+        distance_idx = distance_ptr - state.temp_next.distance;
+    }
+
+    if (state.temp_next.distance[distance_idx] == no_intersection())
+        return {};
+
+    // Determine the crossing surface
+    SurfaceId surface;
+    {
+        FaceId face = state.temp_next.face[distance_idx];
+        CELER_ASSERT(face);
+        surface = vol.get_surface(face);
+        CELER_ASSERT(surface);
+    }
+
+    Sense cur_sense;
+    if (surface == state.surface.id())
+    {
+        // Crossing the same surface that we're currently on and inside (e.g.
+        // on the inside surface of a sphere, and the next intersection is the
+        // other side)
+        cur_sense = state.surface.sense();
+    }
+    else
+    {
+        auto calc_sense = make_surface_action(Surfaces{params_.surfaces},
+                                              detail::CalcSense{state.pos});
+
+        SignedSense ss = calc_sense(surface);
+        CELER_ASSERT(ss != SignedSense::on);
+        cur_sense = to_sense(ss);
+    }
+
+    // Post-surface sense will be on the other side of the surface
+    Intersection result;
+    result.surface  = {surface, flip_sense(cur_sense)};
+    result.distance = state.temp_next.distance[distance_idx];
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate boundary distance if internal surfaces are present.
+ *
+ * In "complex" cells, crossing a surface can still leave the particle in an
+ * "inside" state.
+ *
+ * We have to iteratively track through all surfaces, in order of minimum
+ * distance, to determine whether crossing them in sequence will cause us to
+ * exit the cell.
+ */
+CELER_FUNCTION auto
+SimpleUnitTracker::complex_intersect(LocalState state, VolumeView vol) const
+    -> Intersection
+{
+    // Partition intersections (enumerated from 0 as the `idx` array) into
+    // valid (finite nonzero) and invalid (infinite-or-zero) groups.
+    size_type num_isect = celeritas::partition(
+                              state.temp_next.isect,
+                              state.temp_next.isect + state.temp_next.size,
+                              detail::IntersectionPartitioner{state.temp_next})
+                          - state.temp_next.isect;
+    CELER_ASSERT(num_isect <= state.temp_next.size);
+
+    // Sort these finite distances in ascending order
+    celeritas::sort(state.temp_next.isect,
+                    state.temp_next.isect + num_isect,
+                    [&state](size_type a, size_type b) {
+                        return state.temp_next.distance[a]
+                               < state.temp_next.distance[b];
+                    });
+
+    // Calculate local senses, taking current face into account
+    auto logic_state = detail::SenseCalculator(
+        Surfaces{params_.surfaces}, state.pos, state.temp_sense)(
+        vol, detail::find_face(vol, state.surface));
+
+    // Current senses should put us inside the cell
+    detail::LogicEvaluator is_inside(vol.logic());
+    CELER_ASSERT(is_inside(logic_state.senses));
+
+    // Loop over distances and surface indices to cross by iterating over
+    // temp_next.isect[:num_isect].
+    // Evaluate the logic expression at each crossing to determine whether
+    // we're actually leaving the cell.
+    for (size_type isect_idx = 0; isect_idx != num_isect; ++isect_idx)
+    {
+        // Index into the distance/face arrays
+        const size_type isect = state.temp_next.isect[isect_idx];
+        // Face being crossed in this ordered intersection
+        FaceId face = state.temp_next.face[isect];
+        // Flip the sense of the face being crossed
+        Sense new_sense = flip_sense(logic_state.senses[face.get()]);
+        logic_state.senses[face.unchecked_get()] = new_sense;
+        if (!is_inside(logic_state.senses))
+        {
+            // Flipping this sense puts us outside the current volume: in
+            // other words, only after crossing all the internal surfaces along
+            // this direction do we hit a surface that actually puts us
+            // outside.
+            Intersection result;
+            result.surface  = {vol.get_surface(face), new_sense};
+            result.distance = state.temp_next.distance[isect];
+            CELER_ENSURE(result.distance > 0 && !std::isinf(result.distance));
+            return result;
+        }
+    }
+
+    // No intersection: perhaps leaving an exterior cell? Perhaps geometry
+    // error.
     return {};
 }
 

--- a/src/orange/universes/SimpleUnitTracker.hh
+++ b/src/orange/universes/SimpleUnitTracker.hh
@@ -181,13 +181,13 @@ SimpleUnitTracker::simple_intersect(LocalState state, VolumeView vol) const
     CELER_EXPECT(state.temp_next && vol.num_intersections() > 0);
 
     // Crossing any surface will leave the cell; perform a linear search for
-    // the smallest (but nonzero) distance
+    // the smallest (but positive) distance
     size_type distance_idx;
     {
         const real_type* distance_ptr = celeritas::min_element(
             state.temp_next.distance,
             state.temp_next.distance + state.temp_next.size,
-            detail::CloserNonzeroDistance{});
+            detail::CloserPositiveDistance{});
         CELER_ASSERT(*distance_ptr > 0);
         distance_idx = distance_ptr - state.temp_next.distance;
     }
@@ -245,7 +245,7 @@ SimpleUnitTracker::complex_intersect(LocalState state, VolumeView vol) const
     -> Intersection
 {
     // Partition intersections (enumerated from 0 as the `idx` array) into
-    // valid (finite nonzero) and invalid (infinite-or-zero) groups.
+    // valid (finite positive) and invalid (infinite-or-negative) groups.
     size_type num_isect = celeritas::partition(
                               state.temp_next.isect,
                               state.temp_next.isect + state.temp_next.size,

--- a/src/orange/universes/SimpleUnitTracker.hh
+++ b/src/orange/universes/SimpleUnitTracker.hh
@@ -127,7 +127,7 @@ CELER_FUNCTION auto SimpleUnitTracker::initialize(LocalState state) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate distance-to-intercept for the next surface
+ * Calculate distance-to-intercept for the next surface.
  */
 CELER_FUNCTION auto SimpleUnitTracker::intersect(LocalState state) const
     -> Intersection
@@ -172,7 +172,7 @@ CELER_FUNCTION auto SimpleUnitTracker::intersect(LocalState state) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate distance to the next boundary for nonreentrant cells
+ * Calculate distance to the next boundary for nonreentrant cells.
  */
 CELER_FUNCTION auto
 SimpleUnitTracker::simple_intersect(LocalState state, VolumeView vol) const

--- a/src/orange/universes/detail/Types.hh
+++ b/src/orange/universes/detail/Types.hh
@@ -132,11 +132,15 @@ struct Initialization
 
 //---------------------------------------------------------------------------//
 /*!
- * Next face ID and the distance to it.
+ * Local face IDs, distances, and ordering.
  *
- * The index vector should be initialized with "iota" (or equivalent) before
- * sorting operations are performed. It allows indirect sorting of the
- * face/distance simultaneously.
+ * This is temporary space for calculating the distance-to-intersection within
+ * a volume. The faces and distances are effectively pairs, up to index \c
+ * size.
+ *
+ * The index vector \c isect is initialized with the sequence `[0, size)` to
+ * allow indirect sorting of the intersections stored in the face/distance
+ * pairs.
  */
 struct TempNextFace
 {

--- a/src/orange/universes/detail/Utils.hh
+++ b/src/orange/universes/detail/Utils.hh
@@ -20,9 +20,13 @@ namespace detail
 // FUNCTION-LIKE CLASSES
 //---------------------------------------------------------------------------//
 /*!
- * Predicate for finding closest valid distance.
+ * Predicate for finding the closest valid (strictly positive) distance.
+ *
+ * \todo Changing the QuadraticSolver class to return only positive
+ * intersections should allow us to replace this with a simple less-than
+ * comparator.
  */
-struct CloserNonzeroDistance
+struct CloserPositiveDistance
 {
     CELER_CONSTEXPR_FUNCTION bool operator()(real_type a, real_type b) const
     {
@@ -32,7 +36,10 @@ struct CloserNonzeroDistance
 
 //---------------------------------------------------------------------------//
 /*!
- * Predicate for partitioning valid (finite nonzero) from invalid distances.
+ * Predicate for partitioning valid (finite positive) from invalid distances.
+ *
+ * \todo See above, and if we add a "maximum distance" to the intersection
+ * lookup, then we can perhaps change to `return distance < max_dist`.
  */
 struct IntersectionPartitioner
 {

--- a/src/orange/universes/detail/Utils.hh
+++ b/src/orange/universes/detail/Utils.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <cmath>
 #include "base/Macros.hh"
 #include "Types.hh"
 #include "../VolumeView.hh"
@@ -15,6 +16,38 @@ namespace celeritas
 {
 namespace detail
 {
+//---------------------------------------------------------------------------//
+// FUNCTION-LIKE CLASSES
+//---------------------------------------------------------------------------//
+/*!
+ * Predicate for finding closest valid distance.
+ */
+struct CloserNonzeroDistance
+{
+    CELER_CONSTEXPR_FUNCTION bool operator()(real_type a, real_type b) const
+    {
+        return a > 0 && (b <= 0 || a < b);
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Predicate for partitioning valid (finite nonzero) from invalid distances.
+ */
+struct IntersectionPartitioner
+{
+    const TempNextFace& temp_next;
+
+    CELER_FUNCTION bool operator()(size_type isect) const
+    {
+        CELER_ASSERT(isect < temp_next.size);
+        const real_type distance = temp_next.distance[isect];
+        return distance > 0 && !std::isinf(distance);
+    }
+};
+
+//---------------------------------------------------------------------------//
+// INLINE FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!
  * Convert an OnSurface (may be null) to an OnFace using a volume view.

--- a/test/orange/OrangeGeoTestBase.hh
+++ b/test/orange/OrangeGeoTestBase.hh
@@ -35,9 +35,11 @@ class OrangeGeoTestBase : public celeritas::Test
     //!@{
     //! Type aliases
     using real_type = celeritas::real_type;
+    using size_type = celeritas::size_type;
     using Real3     = celeritas::Real3;
     using Sense     = celeritas::Sense;
     using VolumeId  = celeritas::VolumeId;
+    using FaceId    = celeritas::FaceId;
     using SurfaceId = celeritas::SurfaceId;
     using ParamsHostRef
         = celeritas::OrangeParamsData<celeritas::Ownership::const_reference,
@@ -51,7 +53,9 @@ class OrangeGeoTestBase : public celeritas::Test
     //! On-the-fly construction inputs
     struct OneVolInput
     {
+        bool complex_tracking = true;
     };
+
     struct TwoVolInput
     {
         real_type radius = 1;
@@ -97,6 +101,24 @@ class OrangeGeoTestBase : public celeritas::Test
         return celeritas::make_span(sense_storage_);
     }
 
+    //! Access the shared CPU storage space for faces
+    celeritas::Span<FaceId> face_storage()
+    {
+        return celeritas::make_span(face_storage_);
+    }
+
+    //! Access the shared CPU storage space for distances
+    celeritas::Span<real_type> distance_storage()
+    {
+        return celeritas::make_span(distance_storage_);
+    }
+
+    //! Access the shared CPU storage space for intersection indices
+    celeritas::Span<size_type> isect_storage()
+    {
+        return celeritas::make_span(isect_storage_);
+    }
+
     //// QUERYING ////
 
     // Find the volume from its label (nullptr allowed)
@@ -130,9 +152,17 @@ class OrangeGeoTestBase : public celeritas::Test
                                       celeritas::MemSpace::host>;
 
     //// DATA ////
+
+    // Param data
     celeritas::CollectionMirror<celeritas::OrangeParamsData> params_;
 
-    std::vector<Sense>                         sense_storage_;
+    // State data
+    std::vector<Sense>     sense_storage_;
+    std::vector<FaceId>    face_storage_;
+    std::vector<real_type> distance_storage_;
+    std::vector<size_type> isect_storage_;
+
+    // Metadata
     std::vector<std::string>                   surf_names_;
     std::vector<std::string>                   vol_names_;
     std::unordered_map<std::string, VolumeId>  vol_ids_;

--- a/test/orange/universes/SimpleUnitTracker.test.cc
+++ b/test/orange/universes/SimpleUnitTracker.test.cc
@@ -53,11 +53,6 @@ class SimpleUnitTrackerTest : public celeritas_test::OrangeGeoTestBase
         void print_expected() const;
     };
 
-    struct HeuristicTrackInput
-    {
-        real_type sigma;
-    };
-
   protected:
     // Initialization without any logical state
     LocalState make_state(Real3 pos, Real3 dir);

--- a/test/orange/universes/SimpleUnitTracker.test.cc
+++ b/test/orange/universes/SimpleUnitTracker.test.cc
@@ -341,7 +341,7 @@ class UtilsTest : public celeritas::Test
 
 TEST_F(UtilsTest, closer_nonzero_distance)
 {
-    detail::CloserNonzeroDistance is_closer;
+    detail::CloserPositiveDistance is_closer;
 
     // Equal
     EXPECT_FALSE(is_closer(0.0, 0.0));

--- a/test/orange/universes/SimpleUnitTracker.test.cc
+++ b/test/orange/universes/SimpleUnitTracker.test.cc
@@ -53,6 +53,11 @@ class SimpleUnitTrackerTest : public celeritas_test::OrangeGeoTestBase
         void print_expected() const;
     };
 
+    struct HeuristicTrackInput
+    {
+        real_type sigma;
+    };
+
   protected:
     // Initialization without any logical state
     LocalState make_state(Real3 pos, Real3 dir);
@@ -234,7 +239,7 @@ auto SimpleUnitTrackerTest::run_heuristic_init_device(size_type num_tracks) cons
     auto state_host = this->setup_heuristic_states(num_tracks);
     OrangeStateData<Ownership::value, MemSpace::device> state_device;
     state_device = state_host;
-    StateDeviceRef state_device_ref;
+    StateRef<MemSpace::device> state_device_ref;
     state_device_ref = state_device;
 
     // Run on device

--- a/test/orange/universes/SimpleUnitTracker.test.cu
+++ b/test/orange/universes/SimpleUnitTracker.test.cu
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "SimpleUnitTracker.test.hh"
 
+#include <thrust/reduce.h>
 #include "base/KernelParamCalculator.cuda.hh"
 
 namespace celeritas_test
@@ -17,8 +18,8 @@ namespace
 // KERNELS
 //---------------------------------------------------------------------------//
 
-__global__ void
-initialize_kernel(const ParamsDeviceRef params, const StateDeviceRef states)
+__global__ void initialize_kernel(const ParamsRef<MemSpace::device> params,
+                                  const StateRef<MemSpace::device>  states)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (tid.get() >= states.size())
@@ -33,7 +34,8 @@ initialize_kernel(const ParamsDeviceRef params, const StateDeviceRef states)
 // TESTING INTERFACE
 //---------------------------------------------------------------------------//
 //! Run on device and return results
-void test_initialize(const ParamsDeviceRef& params, const StateDeviceRef& state)
+void test_initialize(const ParamsRef<MemSpace::device>& params,
+                     const StateRef<MemSpace::device>&  state)
 {
     static const celeritas::KernelParamCalculator calc_launch_params(
         initialize_kernel, "initialize");

--- a/test/orange/universes/SimpleUnitTracker.test.cu
+++ b/test/orange/universes/SimpleUnitTracker.test.cu
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #include "SimpleUnitTracker.test.hh"
 
-#include <thrust/reduce.h>
 #include "base/KernelParamCalculator.cuda.hh"
 
 namespace celeritas_test

--- a/test/orange/universes/SimpleUnitTracker.test.hh
+++ b/test/orange/universes/SimpleUnitTracker.test.hh
@@ -13,53 +13,122 @@ namespace celeritas_test
 {
 using celeritas::MemSpace;
 using celeritas::Ownership;
-using ParamsDeviceRef
-    = celeritas::OrangeParamsData<Ownership::const_reference, MemSpace::device>;
-using StateDeviceRef
-    = celeritas::OrangeStateData<Ownership::reference, MemSpace::device>;
+using celeritas::ThreadId;
+using LocalState = celeritas::detail::LocalState;
+
+template<MemSpace M>
+using ParamsRef = celeritas::OrangeParamsData<Ownership::const_reference, M>;
+template<MemSpace M>
+using StateRef = celeritas::OrangeStateData<Ownership::reference, M>;
+
+//---------------------------------------------------------------------------//
+// Track step data for stepping heuristic
+//---------------------------------------------------------------------------//
+template<Ownership W, MemSpace M>
+struct TrackStepData
+{
+    //// TYPES ////
+
+    template<class T>
+    using StateItems = celeritas::StateCollection<T, W, M>;
+
+    StateItems<celeritas::real_type> distance; // [track]
+    StateItems<celeritas::size_type> vol;      // [track]
+
+    //! True if sizes are consistent and nonzero
+    explicit CELER_FUNCTION operator bool() const
+    {
+        // clang-format off
+        return !distance.empty()
+            && distance.size() == vol.size();
+    }
+
+    //! State size
+    CELER_FUNCTION ThreadId::size_type size() const { return distance.size(); }
+
+    //! Assign from another set of data
+    template<Ownership W2, MemSpace M2>
+    TrackStepData& operator=(TrackStepData<W2, M2>& other)
+    {
+        CELER_EXPECT(other);
+        distance   = other.distance;
+        vol   = other.vol;
+    }
+};
+
+template<MemSpace M> using StepResultRef = TrackStepData<Ownership::reference, M>;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Resize particle states in host code.
+ */
+template<MemSpace M>
+inline void
+resize(TrackStepData<Ownership::value, M>* data,
+       celeritas::size_type size)
+{
+    CELER_EXPECT(data);
+
+    make_builder(&data->distance).resize(size);
+    make_builder(&data->vol).resize(size);
+}
 
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS
 //---------------------------------------------------------------------------//
 
-//! Initialize
+template<class T>
+CELER_CONSTEXPR_FUNCTION celeritas::ItemRange<T> build_range(
+    celeritas::size_type stride,
+    ThreadId tid)
+{
+    CELER_EXPECT(tid);
+    using IdT = celeritas::ItemId<T>;
+    auto t = tid.unchecked_get();
+    return {IdT{t * stride}, IdT{(t + 1) * stride}};
+}
+
+template<MemSpace M = MemSpace::native>
+inline LocalState build_local_state(
+    ParamsRef<M> params,
+    StateRef<M>        states,
+    ThreadId tid)
+{
+    using namespace celeritas;
+
+    // Create local state from global memory
+    LocalState lstate;
+    lstate.pos     = states.pos[tid];
+    lstate.dir     = states.dir[tid];
+    lstate.volume  = states.vol[tid];
+    lstate.surface = {states.surf[tid], states.sense[tid]};
+
+    const size_type max_faces = params.scalars.max_faces;
+    lstate.temp_sense = states.temp_sense[build_range<Sense>(max_faces, tid)];
+
+    const size_type max_isect = params.scalars.max_intersections;
+    lstate.temp_next.face
+        = states.temp_face[build_range<FaceId>(max_isect, tid)].data();
+    lstate.temp_next.distance
+        = states.temp_distance[build_range<real_type>(max_isect, tid)].data();
+    lstate.temp_next.isect
+        = states.temp_isect[build_range<size_type>(max_isect, tid)].data();
+    lstate.temp_next.size = max_isect;
+    return lstate;
+}
+
+//! Initialization heuristic
 template<MemSpace M = MemSpace::native>
 struct InitializingLauncher
 {
-    using ThreadId = celeritas::ThreadId;
-    using SenseId  = celeritas::ItemId<celeritas::Sense>;
-
-    celeritas::OrangeParamsData<Ownership::const_reference, M> params;
-    celeritas::OrangeStateData<Ownership::reference, M>        states;
-
-    CELER_CONSTEXPR_FUNCTION SenseId begin_sense_id(ThreadId tid) const
-    {
-        return SenseId(params.scalars.max_faces * tid.unchecked_get());
-    }
-
-    CELER_CONSTEXPR_FUNCTION ThreadId next_thread(ThreadId tid) const
-    {
-        return ThreadId{tid.unchecked_get() + 1};
-    }
+    ParamsRef<M> params;
+    StateRef<M>        states;
 
     CELER_FUNCTION void operator()(ThreadId tid) const
     {
-        using celeritas::ItemRange;
-        using celeritas::Sense;
-        using celeritas::SimpleUnitTracker;
-
-        // Create local state from global memory
-        celeritas::detail::LocalState lstate;
-        lstate.pos         = states.pos[tid];
-        lstate.dir         = states.dir[tid];
-        lstate.volume      = states.vol[tid];
-        lstate.surface     = {states.surf[tid], states.sense[tid]};
-        lstate.temp_sense  = states.temp_sense[ItemRange<Sense>(
-            begin_sense_id(tid), begin_sense_id(next_thread(tid)))];
-
         // Instantiate tracker and initialize
-        SimpleUnitTracker tracker(this->params);
-        auto              init = tracker.initialize(lstate);
+        celeritas::SimpleUnitTracker tracker(this->params);
+        auto init = tracker.initialize(build_local_state(params, states, tid));
 
         // Update state with post-initialization result
         states.vol[tid]   = init.volume;
@@ -68,17 +137,60 @@ struct InitializingLauncher
     }
 };
 
+//! Initialization heuristic
+template<MemSpace M = MemSpace::native>
+struct TraceStepLauncher
+{
+    ParamsRef<M> params;
+    StateRef<M>        states;
+    StepResultRef<M> steps;
+
+    CELER_FUNCTION void operator()(ThreadId tid) const
+    {
+        // Instantiate tracker and initialize
+        celeritas::SimpleUnitTracker tracker(this->params);
+
+        auto lstate = build_local_state(params, states, tid);
+        auto isect = tracker.intersect(lstate);
+
+        // Add distance/intersect
+        if (isect)
+        {
+            steps.distance[tid] = isect.distance;
+            steps.vol[tid] = lstate.volume;
+        }
+        else
+        {
+            steps.distance[tid] = 0;
+            steps.vol[tid] = 0;
+        }
+
+        // Update state with post-crossing result
+        states.surf[tid]  = isect.surface.id();
+        states.sense[tid] = isect.surface.unchecked_sense();
+    }
+};
+
 //---------------------------------------------------------------------------//
 // TESTING INTERFACE
 //---------------------------------------------------------------------------//
 //! Run on device
-void test_initialize(const ParamsDeviceRef&, const StateDeviceRef&);
+void test_initialize(const ParamsRef<MemSpace::device>&, const StateRef<MemSpace::device>&);
+
+//! Run on device
+void test_distance(const ParamsRef<MemSpace::device>&, const StateRef<MemSpace::device>&, const StepResultRef<MemSpace::device>&);
 
 #if !CELERITAS_USE_CUDA
-void test_initialize(const ParamsDeviceRef&, const StateDeviceRef&)
+inline void test_initialize(const ParamsRef<MemSpace::device>&, const StateRef<MemSpace::device>&)
 {
     CELER_NOT_CONFIGURED("CUDA");
 }
+
+inline void test_distance(const ParamsRef<MemSpace::device>&, const StateRef<MemSpace::device>&, const StepResultRef<MemSpace::device>&)
+{
+    CELER_NOT_CONFIGURED("CUDA");
+}
+
 #endif
 
 //---------------------------------------------------------------------------//

--- a/test/orange/universes/SimpleUnitTracker.test.hh
+++ b/test/orange/universes/SimpleUnitTracker.test.hh
@@ -54,7 +54,7 @@ struct InitializingLauncher
         lstate.dir         = states.dir[tid];
         lstate.volume      = states.vol[tid];
         lstate.surface     = {states.surf[tid], states.sense[tid]};
-        lstate.temp_senses = states.temp_senses[ItemRange<Sense>(
+        lstate.temp_sense  = states.temp_sense[ItemRange<Sense>(
             begin_sense_id(tid), begin_sense_id(next_thread(tid)))];
 
         // Instantiate tracker and initialize

--- a/test/orange/universes/SimpleUnitTracker.test.hh
+++ b/test/orange/universes/SimpleUnitTracker.test.hh
@@ -22,58 +22,6 @@ template<MemSpace M>
 using StateRef = celeritas::OrangeStateData<Ownership::reference, M>;
 
 //---------------------------------------------------------------------------//
-// Track step data for stepping heuristic
-//---------------------------------------------------------------------------//
-template<Ownership W, MemSpace M>
-struct TrackStepData
-{
-    //// TYPES ////
-
-    template<class T>
-    using StateItems = celeritas::StateCollection<T, W, M>;
-
-    StateItems<celeritas::real_type> distance; // [track]
-    StateItems<celeritas::size_type> vol;      // [track]
-
-    //! True if sizes are consistent and nonzero
-    explicit CELER_FUNCTION operator bool() const
-    {
-        // clang-format off
-        return !distance.empty()
-            && distance.size() == vol.size();
-    }
-
-    //! State size
-    CELER_FUNCTION ThreadId::size_type size() const { return distance.size(); }
-
-    //! Assign from another set of data
-    template<Ownership W2, MemSpace M2>
-    TrackStepData& operator=(TrackStepData<W2, M2>& other)
-    {
-        CELER_EXPECT(other);
-        distance   = other.distance;
-        vol   = other.vol;
-    }
-};
-
-template<MemSpace M> using StepResultRef = TrackStepData<Ownership::reference, M>;
-
-//---------------------------------------------------------------------------//
-/*!
- * Resize particle states in host code.
- */
-template<MemSpace M>
-inline void
-resize(TrackStepData<Ownership::value, M>* data,
-       celeritas::size_type size)
-{
-    CELER_EXPECT(data);
-
-    make_builder(&data->distance).resize(size);
-    make_builder(&data->vol).resize(size);
-}
-
-//---------------------------------------------------------------------------//
 // HELPER FUNCTIONS
 //---------------------------------------------------------------------------//
 


### PR DESCRIPTION
This implements distance-to-boundary calculations for single universes. There are two algorithms for finding the nearest surface crossing. The first is the "simple" one, where crossing any boundary exits the volume. In that case, the closest nonzero distance points to the target surface. The second "complex" algorithm effectively tracks through the internal surfaces in order (by sorting) until outside the volume. Unlike the CPU implementation of ORANGE in SCALE, this implementation sorts surfaces using an intermediate indirection array of face IDs.

We should consider as an optimization the option of specifying a "maximum" intersection distance, allowing us to reduce the number of surfaces considered in the sort and in the boundary crossing.