### PR TITLE
Enable ORANGE demo loop

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -69,6 +69,7 @@ endif()
 #-----------------------------------------------------------------------------#
 # DEMO: physics interactions
 #-----------------------------------------------------------------------------#
+
 if(CELERITAS_BUILD_DEMOS AND NOT CELERITAS_USE_JSON)
   message(SEND_ERROR "JSON support is required for demos")
 endif()
@@ -261,7 +262,7 @@ if(CELERITAS_BUILD_DEMOS)
     set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/demo-loop/simple-driver.py")
     set(_gdml_inp "${PROJECT_SOURCE_DIR}/app/demo-loop/simple-cms.gdml")
     set(_hepmc3_inp "${PROJECT_SOURCE_DIR}/app/demo-loop/input.hepmc3")
-    if (TARGET geant-exporter)
+    if(TARGET geant-exporter)
       set(_geant_exporter_env
         "CELERITAS_GEANT_EXPORTER_EXE=$<TARGET_FILE:geant-exporter>")
     endif()
@@ -274,6 +275,9 @@ if(CELERITAS_BUILD_DEMOS)
       "${_geant_exporter_env}"
       "CELER_DISABLE_PARALLEL=1"
     )
+    if(NOT CELERITAS_USE_VecGeom)
+      list(APPEND _env "CELER_DISABLE_VECGEOM=1")
+    endif()
     set_tests_properties("app/demo-loop" PROPERTIES
       ENVIRONMENT "${_env};${_geant_test_env}"
       RESOURCE_LOCK gpu
@@ -304,14 +308,16 @@ if(CELERITAS_BUILD_DEMOS)
       "CELER_DISABLE_DEVICE=1"
       "CELER_DISABLE_PARALLEL=1"
     )
+    if(NOT CELERITAS_USE_VecGeom)
+      list(APPEND _env "CELER_DISABLE_VECGEOM=1")
+    endif()
     set_tests_properties("app/demo-loop-cpu" PROPERTIES
       ENVIRONMENT "${_env};${_geant_test_env}"
       REQUIRED_FILES "${_driver};${_gdml_inp};${_hepmc3_inp}"
     )
     if(NOT CELERITAS_USE_Geant4
        OR NOT CELERITAS_USE_ROOT
-       OR NOT CELERITAS_USE_HepMC3
-       OR NOT CELERITAS_USE_VecGeom)
+       OR NOT CELERITAS_USE_HepMC3)
       set_tests_properties("app/demo-loop-cpu" PROPERTIES
         DISABLED true
       )

--- a/app/demo-loop/KernelUtils.i.hh
+++ b/app/demo-loop/KernelUtils.i.hh
@@ -93,7 +93,9 @@ CELER_FUNCTION void move_and_select_model(const CutoffView&      cutoffs,
             {
                 // Update the material if it's inside
                 result->action = Action::entered_volume;
-                mat            = {geo_mat.material_id(geo.volume_id())};
+                auto matid     = geo_mat.material_id(geo.volume_id());
+                CELER_ASSERT(matid);
+                mat = {matid};
             }
         }
     }

--- a/app/demo-loop/simple-cms.gdml
+++ b/app/demo-loop/simple-cms.gdml
@@ -4,190 +4,228 @@
   <define/>
 
   <materials>
-    <isotope N="28" Z="14" name="Si280x7fac9903aff0">
-      <atom unit="g/mole" value="27.9769"/>
-    </isotope>
-    <isotope N="29" Z="14" name="Si290x7fac9903b030">
-      <atom unit="g/mole" value="28.9765"/>
-    </isotope>
-    <isotope N="30" Z="14" name="Si300x7fac9903b5d0">
-      <atom unit="g/mole" value="29.9738"/>
-    </isotope>
-    <element name="Si0x7fac9903b650">
-      <fraction n="0.922296077703922" ref="Si280x7fac9903aff0"/>
-      <fraction n="0.0468319531680468" ref="Si290x7fac9903b030"/>
-      <fraction n="0.0308719691280309" ref="Si300x7fac9903b5d0"/>
-    </element>
-    <material name="G4_Si0x7fac9903b4d0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="173"/>
-      <D unit="g/cm3" value="2.33"/>
-      <fraction n="1" ref="Si0x7fac9903b650"/>
-    </material>
-    <isotope N="204" Z="82" name="Pb2040x7fac9903b9c0">
-      <atom unit="g/mole" value="203.973"/>
-    </isotope>
-    <isotope N="206" Z="82" name="Pb2060x7fac9903bdb0">
-      <atom unit="g/mole" value="205.974"/>
-    </isotope>
-    <isotope N="207" Z="82" name="Pb2070x7fac9903bdf0">
-      <atom unit="g/mole" value="206.976"/>
-    </isotope>
-    <isotope N="208" Z="82" name="Pb2080x7fac9903be50">
-      <atom unit="g/mole" value="207.977"/>
-    </isotope>
-    <element name="Pb0x7fac9903bf10">
-      <fraction n="0.014" ref="Pb2040x7fac9903b9c0"/>
-      <fraction n="0.241" ref="Pb2060x7fac9903bdb0"/>
-      <fraction n="0.221" ref="Pb2070x7fac9903bdf0"/>
-      <fraction n="0.524" ref="Pb2080x7fac9903be50"/>
-    </element>
-    <material name="G4_Pb0x7fac9903bcb0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="823"/>
-      <D unit="g/cm3" value="11.35"/>
-      <fraction n="1" ref="Pb0x7fac9903bf10"/>
-    </material>
-    <isotope N="12" Z="6" name="C120x7fac9903c310">
-      <atom unit="g/mole" value="12"/>
-    </isotope>
-    <isotope N="13" Z="6" name="C130x7fac9903c940">
-      <atom unit="g/mole" value="13.0034"/>
-    </isotope>
-    <element name="C0x7fac9903c980">
-      <fraction n="0.9893" ref="C120x7fac9903c310"/>
-      <fraction n="0.0107" ref="C130x7fac9903c940"/>
-    </element>
-    <material name="G4_C0x7fac9903c840" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="81"/>
-      <D unit="g/cm3" value="2"/>
-      <fraction n="1" ref="C0x7fac9903c980"/>
-    </material>
-    <isotope N="46" Z="22" name="Ti460x7fac9903cc20">
-      <atom unit="g/mole" value="45.9526"/>
-    </isotope>
-    <isotope N="47" Z="22" name="Ti470x7fac9903cc60">
-      <atom unit="g/mole" value="46.9518"/>
-    </isotope>
-    <isotope N="48" Z="22" name="Ti480x7fac9903d1f0">
-      <atom unit="g/mole" value="47.9479"/>
-    </isotope>
-    <isotope N="49" Z="22" name="Ti490x7fac9903d230">
-      <atom unit="g/mole" value="48.9479"/>
-    </isotope>
-    <isotope N="50" Z="22" name="Ti500x7fac9903d270">
-      <atom unit="g/mole" value="49.9448"/>
-    </isotope>
-    <element name="Ti0x7fac9903d2f0">
-      <fraction n="0.0825" ref="Ti460x7fac9903cc20"/>
-      <fraction n="0.0744" ref="Ti470x7fac9903cc60"/>
-      <fraction n="0.7372" ref="Ti480x7fac9903d1f0"/>
-      <fraction n="0.0541" ref="Ti490x7fac9903d230"/>
-      <fraction n="0.0518" ref="Ti500x7fac9903d270"/>
-    </element>
-    <material name="G4_Ti0x7fac9903d0f0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="233"/>
-      <D unit="g/cm3" value="4.54"/>
-      <fraction n="1" ref="Ti0x7fac9903d2f0"/>
-    </material>
-    <isotope N="54" Z="26" name="Fe540x7fac9903da50">
-      <atom unit="g/mole" value="53.9396"/>
-    </isotope>
-    <isotope N="56" Z="26" name="Fe560x7fac9903d6e0">
-      <atom unit="g/mole" value="55.9349"/>
-    </isotope>
-    <isotope N="57" Z="26" name="Fe570x7fac9903be90">
-      <atom unit="g/mole" value="56.9354"/>
-    </isotope>
-    <isotope N="58" Z="26" name="Fe580x7fac9903db90">
-      <atom unit="g/mole" value="57.9333"/>
-    </isotope>
-    <element name="Fe0x7fac9903dbd0">
-      <fraction n="0.05845" ref="Fe540x7fac9903da50"/>
-      <fraction n="0.91754" ref="Fe560x7fac9903d6e0"/>
-      <fraction n="0.02119" ref="Fe570x7fac9903be90"/>
-      <fraction n="0.00282" ref="Fe580x7fac9903db90"/>
-    </element>
-    <material name="G4_Fe0x7fac9903d950" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="286"/>
-      <D unit="g/cm3" value="7.874"/>
-      <fraction n="1" ref="Fe0x7fac9903dbd0"/>
-    </material>
-    <isotope N="1" Z="1" name="H10x7fac9903a770">
+    <isotope N="1" Z="1" name="H1">
       <atom unit="g/mole" value="1.00782503081372"/>
     </isotope>
-    <isotope N="2" Z="1" name="H20x7fac9903aa60">
+    <isotope N="2" Z="1" name="H2">
       <atom unit="g/mole" value="2.01410199966617"/>
     </isotope>
-    <element name="H0x7fac9903aaa0">
-      <fraction n="0.999885" ref="H10x7fac9903a770"/>
-      <fraction n="0.000115" ref="H20x7fac9903aa60"/>
+    <element name="H">
+      <fraction n="0.999885" ref="H1"/>
+      <fraction n="0.000115" ref="H2"/>
     </element>
-    <material name="G4_Galactic0x7fac9903a960" state="gas">
+    <material name="vacuum" state="gas">
       <T unit="K" value="2.73"/>
       <P unit="pascal" value="3e-18"/>
       <MEE unit="eV" value="21.8"/>
       <D unit="g/cm3" value="1e-25"/>
-      <fraction n="1" ref="H0x7fac9903aaa0"/>
+      <fraction n="1" ref="H"/>
+    </material>
+    <isotope N="28" Z="14" name="Si28">
+      <atom unit="g/mole" value="27.9769"/>
+    </isotope>
+    <isotope N="29" Z="14" name="Si29">
+      <atom unit="g/mole" value="28.9765"/>
+    </isotope>
+    <isotope N="30" Z="14" name="Si30">
+      <atom unit="g/mole" value="29.9738"/>
+    </isotope>
+    <element name="Si">
+      <fraction n="0.922296077703922" ref="Si28"/>
+      <fraction n="0.0468319531680468" ref="Si29"/>
+      <fraction n="0.0308719691280309" ref="Si30"/>
+    </element>
+    <material name="Si" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="173"/>
+      <D unit="g/cm3" value="2.33"/>
+      <fraction n="1" ref="Si"/>
+    </material>
+    <isotope N="204" Z="82" name="Pb204">
+      <atom unit="g/mole" value="203.973"/>
+    </isotope>
+    <isotope N="206" Z="82" name="Pb206">
+      <atom unit="g/mole" value="205.974"/>
+    </isotope>
+    <isotope N="207" Z="82" name="Pb207">
+      <atom unit="g/mole" value="206.976"/>
+    </isotope>
+    <isotope N="208" Z="82" name="Pb208">
+      <atom unit="g/mole" value="207.977"/>
+    </isotope>
+    <element name="Pb">
+      <fraction n="0.014" ref="Pb204"/>
+      <fraction n="0.241" ref="Pb206"/>
+      <fraction n="0.221" ref="Pb207"/>
+      <fraction n="0.524" ref="Pb208"/>
+    </element>
+    <material name="Pb" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="823"/>
+      <D unit="g/cm3" value="11.35"/>
+      <fraction n="1" ref="Pb"/>
+    </material>
+    <isotope N="12" Z="6" name="C12">
+      <atom unit="g/mole" value="12"/>
+    </isotope>
+    <isotope N="13" Z="6" name="C13">
+      <atom unit="g/mole" value="13.0034"/>
+    </isotope>
+    <element name="C">
+      <fraction n="0.9893" ref="C12"/>
+      <fraction n="0.0107" ref="C13"/>
+    </element>
+    <material name="C" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="81"/>
+      <D unit="g/cm3" value="2"/>
+      <fraction n="1" ref="C"/>
+    </material>
+    <isotope N="46" Z="22" name="Ti46">
+      <atom unit="g/mole" value="45.9526"/>
+    </isotope>
+    <isotope N="47" Z="22" name="Ti47">
+      <atom unit="g/mole" value="46.9518"/>
+    </isotope>
+    <isotope N="48" Z="22" name="Ti48">
+      <atom unit="g/mole" value="47.9479"/>
+    </isotope>
+    <isotope N="49" Z="22" name="Ti49">
+      <atom unit="g/mole" value="48.9479"/>
+    </isotope>
+    <isotope N="50" Z="22" name="Ti50">
+      <atom unit="g/mole" value="49.9448"/>
+    </isotope>
+    <element name="Ti">
+      <fraction n="0.0825" ref="Ti46"/>
+      <fraction n="0.0744" ref="Ti47"/>
+      <fraction n="0.7372" ref="Ti48"/>
+      <fraction n="0.0541" ref="Ti49"/>
+      <fraction n="0.0518" ref="Ti50"/>
+    </element>
+    <material name="Ti" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="233"/>
+      <D unit="g/cm3" value="4.54"/>
+      <fraction n="1" ref="Ti"/>
+    </material>
+    <isotope N="54" Z="26" name="Fe54">
+      <atom unit="g/mole" value="53.9396"/>
+    </isotope>
+    <isotope N="56" Z="26" name="Fe56">
+      <atom unit="g/mole" value="55.9349"/>
+    </isotope>
+    <isotope N="57" Z="26" name="Fe57">
+      <atom unit="g/mole" value="56.9354"/>
+    </isotope>
+    <isotope N="58" Z="26" name="Fe58">
+      <atom unit="g/mole" value="57.9333"/>
+    </isotope>
+    <element name="Fe">
+      <fraction n="0.05845" ref="Fe54"/>
+      <fraction n="0.91754" ref="Fe56"/>
+      <fraction n="0.02119" ref="Fe57"/>
+      <fraction n="0.00282" ref="Fe58"/>
+    </element>
+    <material name="Fe" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="286"/>
+      <D unit="g/cm3" value="7.874"/>
+      <fraction n="1" ref="Fe"/>
     </material>
   </materials>
 
   <solids>
-    <tube aunit="deg" deltaphi="360" lunit="mm" name="silicon_tracker0x7fac9903e610" rmax="1249.9999999999" rmin="300" startphi="0" z="14000"/>
-    <tube aunit="deg" deltaphi="360" lunit="mm" name="crystal_em_calorimeter0x7fac9903e710" rmax="1749.9999999999" rmin="1250" startphi="0" z="14000"/>
-    <tube aunit="deg" deltaphi="360" lunit="mm" name="hadron_calorimeter0x7fac9903e810" rmax="2749.9999999999" rmin="1750" startphi="0" z="14000"/>
-    <tube aunit="deg" deltaphi="360" lunit="mm" name="superconducting_solenoid0x7fac9903e910" rmax="3749.9999999999" rmin="2750" startphi="0" z="14000"/>
-    <tube aunit="deg" deltaphi="360" lunit="mm" name="iron_muon_chambers0x7fac9903ea10" rmax="7000" rmin="3750" startphi="0" z="14000"/>
-    <box lunit="mm" name="world_box0x7fac9903e280" x="20000" y="20000" z="40000"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="lhc_vacuum_tube" rmax="299.9999999999" rmin="0" startphi="0" z="14000"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="silicon_tracker" rmax="1249.9999999999" rmin="300" startphi="0" z="14000"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="crystal_em_calorimeter" rmax="1749.9999999999" rmin="1250" startphi="0" z="14000"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="hadron_calorimeter" rmax="2749.9999999999" rmin="1750" startphi="0" z="14000"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="superconducting_solenoid" rmax="3749.9999999999" rmin="2750" startphi="0" z="14000"/>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="iron_muon_chambers" rmax="7000" rmin="3750" startphi="0" z="14000"/>
+    <box lunit="mm" name="world_box" x="20000" y="20000" z="40000"/>
   </solids>
 
   <structure>
-    <volume name="si_tracker_lv0x7fac9903eed0">
-      <materialref ref="G4_Si0x7fac9903b4d0"/>
-      <solidref ref="silicon_tracker0x7fac9903e610"/>
+    <volume name="vacuum_tube">
+      <materialref ref="vacuum"/>
+      <solidref ref="lhc_vacuum_tube"/>
+      <auxiliary auxtype="gammaECut" auxunit="MeV" auxvalue="0.00099"/>
+      <auxiliary auxtype="electronECut" auxunit="MeV" auxvalue="0.00099"/>
+      <auxiliary auxtype="positronECut" auxunit="MeV" auxvalue="0.00099"/>
+      <auxiliary auxtype="protonECut" auxunit="MeV" auxvalue="-1"/>
     </volume>
-    <volume name="em_calorimeter_lv0x7fac9903efa0">
-      <materialref ref="G4_Pb0x7fac9903bcb0"/>
-      <solidref ref="crystal_em_calorimeter0x7fac9903e710"/>
+    <volume name="si_tracker">
+      <materialref ref="Si"/>
+      <solidref ref="silicon_tracker"/>
+      <auxiliary auxtype="gammaECut" auxunit="MeV" auxvalue="0.00695018"/>
+      <auxiliary auxtype="electronECut" auxunit="MeV" auxvalue="0.548291"/>
+      <auxiliary auxtype="positronECut" auxunit="MeV" auxvalue="0.526624"/>
+      <auxiliary auxtype="protonECut" auxunit="MeV" auxvalue="-1"/>
+      <auxiliary auxtype="SensDet" auxvalue="si_tracker_sd"/>
     </volume>
-    <volume name="had_calorimeter_lv0x7fac9903f070">
-      <materialref ref="G4_C0x7fac9903c840"/>
-      <solidref ref="hadron_calorimeter0x7fac9903e810"/>
+    <volume name="em_calorimeter">
+      <materialref ref="Pb"/>
+      <solidref ref="crystal_em_calorimeter"/>
+      <auxiliary auxtype="gammaECut" auxunit="MeV" auxvalue="0.101843"/>
+      <auxiliary auxtype="electronECut" auxunit="MeV" auxvalue="1.36749"/>
+      <auxiliary auxtype="positronECut" auxunit="MeV" auxvalue="1.27862"/>
+      <auxiliary auxtype="protonECut" auxunit="MeV" auxvalue="-1"/>
+      <auxiliary auxtype="SensDet" auxvalue="em_calorimeter_sd"/>
     </volume>
-    <volume name="sc_solenoid_lv0x7fac9903f140">
-      <materialref ref="G4_Ti0x7fac9903d0f0"/>
-      <solidref ref="superconducting_solenoid0x7fac9903e910"/>
+    <volume name="had_calorimeter">
+      <materialref ref="C"/>
+      <solidref ref="hadron_calorimeter"/>
+      <auxiliary auxtype="gammaECut" auxunit="MeV" auxvalue="0.00318751"/>
+      <auxiliary auxtype="electronECut" auxunit="MeV" auxvalue="0.526624"/>
+      <auxiliary auxtype="positronECut" auxunit="MeV" auxvalue="0.509223"/>
+      <auxiliary auxtype="protonECut" auxunit="MeV" auxvalue="-1"/>
     </volume>
-    <volume name="iron_muon_chambers_lv0x7fac9903f210">
-      <materialref ref="G4_Fe0x7fac9903d950"/>
-      <solidref ref="iron_muon_chambers0x7fac9903ea10"/>
+    <volume name="sc_solenoid">
+      <materialref ref="Ti"/>
+      <solidref ref="superconducting_solenoid"/>
+      <auxiliary auxtype="gammaECut" auxunit="MeV" auxvalue="0.0132486"/>
+      <auxiliary auxtype="electronECut" auxunit="MeV" auxvalue="0.815083"/>
+      <auxiliary auxtype="positronECut" auxunit="MeV" auxvalue="0.782873"/>
+      <auxiliary auxtype="protonECut" auxunit="MeV" auxvalue="-1"/>
     </volume>
-    <volume name="world_lv0x7fac9903eb10">
-      <materialref ref="G4_Galactic0x7fac9903a960"/>
-      <solidref ref="world_box0x7fac9903e280"/>
-      <physvol name="si_tracker_pv0x7fac9903f650">
-        <volumeref ref="si_tracker_lv0x7fac9903eed0"/>
+    <volume name="fe_muon_chambers">
+      <materialref ref="Fe"/>
+      <solidref ref="iron_muon_chambers"/>
+      <auxiliary auxtype="gammaECut" auxunit="MeV" auxvalue="0.0206438"/>
+      <auxiliary auxtype="electronECut" auxunit="MeV" auxvalue="1.29592"/>
+      <auxiliary auxtype="positronECut" auxunit="MeV" auxvalue="1.21169"/>
+      <auxiliary auxtype="protonECut" auxunit="MeV" auxvalue="-1"/>
+    </volume>
+    <volume name="world">
+      <materialref ref="vacuum"/>
+      <solidref ref="world_box"/>
+      <physvol name="vacuum_tube_pv">
+        <volumeref ref="vacuum_tube"/>
       </physvol>
-      <physvol name="em_calorimeter_pv0x7fac9903f6a0">
-        <volumeref ref="em_calorimeter_lv0x7fac9903efa0"/>
+      <physvol name="si_tracker_pv">
+        <volumeref ref="si_tracker"/>
       </physvol>
-      <physvol name="had_calorimeter_pv0x7fac9903f710">
-        <volumeref ref="had_calorimeter_lv0x7fac9903f070"/>
+      <physvol name="em_calorimeter_pv">
+        <volumeref ref="em_calorimeter"/>
       </physvol>
-      <physvol name="sc_solenoid_pv0x7fac9903f7a0">
-        <volumeref ref="sc_solenoid_lv0x7fac9903f140"/>
+      <physvol name="had_calorimeter_pv">
+        <volumeref ref="had_calorimeter"/>
       </physvol>
-      <physvol name="iron_muon_chambers_pv0x7fac9903f810">
-        <volumeref ref="iron_muon_chambers_lv0x7fac9903f210"/>
+      <physvol name="sc_solenoid_pv">
+        <volumeref ref="sc_solenoid"/>
       </physvol>
+      <physvol name="iron_muon_chambers_pv">
+        <volumeref ref="fe_muon_chambers"/>
+      </physvol>
+      <auxiliary auxtype="gammaECut" auxunit="MeV" auxvalue="0.00099"/>
+      <auxiliary auxtype="electronECut" auxunit="MeV" auxvalue="0.00099"/>
+      <auxiliary auxtype="positronECut" auxunit="MeV" auxvalue="0.00099"/>
+      <auxiliary auxtype="protonECut" auxunit="MeV" auxvalue="-1"/>
     </volume>
   </structure>
 
   <setup name="Default" version="1.0">
-    <world ref="world_lv0x7fac9903eb10"/>
+    <world ref="world"/>
   </setup>
 
 </gdml>

--- a/app/demo-loop/simple-cms.org.json
+++ b/app/demo-loop/simple-cms.org.json
@@ -1,0 +1,224 @@
+{
+"_format": "SCALE ORANGE",
+"_version": 0,
+"materials": {
+"cell_to_mat": [
+-1,
+5,
+0,
+1,
+2,
+3,
+4,
+5
+],
+"names": [
+"si",
+"pb",
+"c",
+"ti",
+"fe",
+"galactic"
+]
+},
+"universes": [
+{
+"_type": "simple unit",
+"bbox": [
+[
+-1000.0,
+-1000.0,
+-2000.0
+],
+[
+1000.0,
+1000.0,
+2000.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"vacuum_tube",
+"si_tracker",
+"em_calorimeter",
+"had_calorimeter",
+"sc_solenoid",
+"fe_muon_chambers",
+"world"
+],
+"cells": [
+{
+"faces": [
+0,
+1,
+2,
+3,
+4,
+5
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ & ~",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+6,
+7,
+8
+],
+"logic": "0 ~ 1 & 2 ~ &",
+"num_intersections": 4,
+"zorder": 1
+},
+{
+"faces": [
+6,
+7,
+8,
+9
+],
+"flags": 1,
+"logic": "0 ~ 1 & 2 ~ & ~ 1 2 ~ & 3 ~ & &",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+7,
+8,
+9,
+10
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 ~ & ~ 0 1 ~ & 3 ~ & &",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+7,
+8,
+10,
+11
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 ~ & ~ 0 1 ~ & 3 ~ & &",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+7,
+8,
+11,
+12
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 ~ & ~ 0 1 ~ & 3 ~ & &",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+7,
+8,
+12,
+13
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 ~ & ~ 0 1 ~ & 3 ~ & &",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+0,
+1,
+2,
+3,
+4,
+5,
+7,
+8,
+13
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ & 6 7 ~ & 8 ~ & ~ &",
+"num_intersections": 10,
+"zorder": 1
+}
+],
+"md": {
+"name": "global",
+"provenance": "simple-cms.org.omn:18"
+},
+"surface_names": [
+"world_box.mx",
+"world_box.px",
+"world_box.my",
+"world_box.py",
+"world_box.mz",
+"world_box.pz",
+"guide_tube.coz",
+"crystal_em_calorimeter_outer.mz",
+"crystal_em_calorimeter_outer.pz",
+"silicon_tracker_outer.coz",
+"crystal_em_calorimeter_outer.coz",
+"hadron_calorimeter_outer.coz",
+"superconducting_solenoid_outer.coz",
+"iron_muon_chambers_outer.coz"
+],
+"surfaces": {
+"data": [
+-1000.0,
+1000.0,
+-1000.0,
+1000.0,
+-2000.0,
+2000.0,
+900.0,
+-700.0,
+700.0,
+15625.0,
+30625.0,
+75625.0,
+140625.0,
+490000.0
+],
+"sizes": [
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1
+],
+"types": [
+"px",
+"px",
+"py",
+"py",
+"pz",
+"pz",
+"czc",
+"pz",
+"pz",
+"czc",
+"czc",
+"czc",
+"czc",
+"czc"
+]
+}
+}
+]
+}

--- a/app/demo-loop/simple-cms.org.omn
+++ b/app/demo-loop/simple-cms.org.omn
@@ -1,7 +1,8 @@
 !##############################################################################
-! File  : Geometria/orange/test/data/simple-cms.org.omn
+! File  : simple-cms.org.omn
 !
 ! Simplified Compact Muon Solenoid proxy geometry
+! Regenerate the JSON file with `orange2celeritas` from SCALE
 !##############################################################################
 
 [GEOMETRY]
@@ -58,30 +59,30 @@ widths 2000 2000 4000
 ! CELLS ("volumes")
 !##############################################################################
 
-[UNIVERSE][CELL guide_tube]
+[UNIVERSE][CELL vacuum_tube]
 comp galactic
 shapes guide_tube
 
-[UNIVERSE][CELL silicon_tracker]
+[UNIVERSE][CELL si_tracker]
 comp si
 shapes silicon_tracker_outer ~guide_tube
 
-[UNIVERSE][CELL crystal_em_calorimeter]
+[UNIVERSE][CELL em_calorimeter]
 comp pb
 shapes crystal_em_calorimeter_outer ~silicon_tracker_outer
 
-[UNIVERSE][CELL hadron_calorimeter]
+[UNIVERSE][CELL had_calorimeter]
 comp c
 shapes hadron_calorimeter_outer ~crystal_em_calorimeter_outer
 
-[UNIVERSE][CELL superconducting_solenoid]
+[UNIVERSE][CELL sc_solenoid]
 comp ti
 shapes superconducting_solenoid_outer ~hadron_calorimeter_outer
 
-[UNIVERSE][CELL iron_muon_chambers]
+[UNIVERSE][CELL fe_muon_chambers]
 comp fe
 shapes iron_muon_chambers_outer ~superconducting_solenoid_outer
 
-[UNIVERSE][CELL fill]
+[UNIVERSE][CELL world]
 comp galactic
 shapes -world_box +iron_muon_chambers_outer

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -5,16 +5,16 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """
 """
-from distutils.util import strtobool
 import json
+import re
 import subprocess
+from distutils.util import strtobool
 from os import environ, path
 from sys import exit, argv
 
 try:
-    geometry_filename = argv[1]
-    hepmc3_filename = argv[2]
-except (IndexError, TypeError):
+    (geometry_filename, hepmc3_filename) = argv[1:]
+except IndexError:
     print("usage: {} inp.gdml inp.hepmc3".format(argv[0]))
     exit(2)
 
@@ -34,6 +34,10 @@ result_ge = subprocess.run([geant_exp_exe,
 if result_ge.returncode:
     print("fatal: geant-exporter failed with error", result_ge.returncode)
     exit(result_ge.returncode)
+
+if strtobool(environ.get('CELER_DISABLE_VECGEOM', 'false')):
+    print("Replacing .gdml extension since VecGeom is disabled")
+    geometry_filename = re.sub(r"\.gdml$", ".org.json", geometry_filename)
 
 inp = {
     'run': {

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -14,9 +14,9 @@ from sys import exit, argv
 
 try:
     (geometry_filename, hepmc3_filename) = argv[1:]
-except IndexError:
+except ValueError:
     print("usage: {} inp.gdml inp.hepmc3".format(argv[0]))
-    exit(2)
+    exit(1)
 
 # We reuse the "disable device" environment variable, which prevents the GPU
 # from being initialized at runtime.

--- a/src/geometry/GeoMaterialParams.cc
+++ b/src/geometry/GeoMaterialParams.cc
@@ -19,6 +19,9 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Construct from geometry and material params.
+ *
+ * Missing material IDs may be allowed if they correspond to unreachable volume
+ * IDs.
  */
 GeoMaterialParams::GeoMaterialParams(Input input)
 {
@@ -37,9 +40,8 @@ GeoMaterialParams::GeoMaterialParams(Input input)
 
     if (!input.volume_names.empty())
     {
-        // Remap materials to volume IDs using given volume names
-
-        // Build a map of volume name -> matid
+        // Remap materials to volume IDs using given volume names:
+        // build a map of volume name -> matid
         std::unordered_map<std::string, MaterialId> name_to_id;
         for (auto idx : range(input.volume_to_mat.size()))
         {

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -261,6 +261,7 @@ CELER_FUNCTION void OrangeTrackView::move_across_boundary()
     CELER_ASSERT(init.volume);
     local_.volume  = init.volume;
     local_.surface = init.surface;
+    dirty_         = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -278,6 +279,7 @@ CELER_FUNCTION void OrangeTrackView::move_internal(real_type dist)
     // Move and update next_step_
     axpy(dist, local_.dir, &local_.pos);
     next_step_ -= dist;
+    dirty_ = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -291,6 +293,7 @@ CELER_FUNCTION void OrangeTrackView::move_internal(const Real3& pos)
 {
     local_.pos = pos;
     next_step_ = 0;
+    dirty_     = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -305,6 +308,7 @@ CELER_FUNCTION void OrangeTrackView::set_dir(const Real3& newdir)
     CELER_EXPECT(is_soft_unit_vector(newdir));
     local_.dir = newdir;
     next_step_ = 0;
+    dirty_     = true;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -279,6 +279,8 @@ CELER_FUNCTION void OrangeTrackView::move_internal(real_type dist)
     // Move and update next_step_
     axpy(dist, local_.dir, &local_.pos);
     next_step_ -= dist;
+    local_.surface = {};
+
     dirty_ = true;
 }
 
@@ -291,9 +293,10 @@ CELER_FUNCTION void OrangeTrackView::move_internal(real_type dist)
  */
 CELER_FUNCTION void OrangeTrackView::move_internal(const Real3& pos)
 {
-    local_.pos = pos;
-    next_step_ = 0;
-    dirty_     = true;
+    local_.pos     = pos;
+    local_.surface = {};
+    next_step_     = 0;
+    dirty_         = true;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -150,6 +150,9 @@ TEST_F(TwoVolumeTest, simple_track)
     // Advance toward the boundary
     geo.move_internal(1);
     EXPECT_VEC_SOFT_EQ(Real3({0.5, 0, 1}), geo.pos());
+    EXPECT_EQ(SurfaceId{}, geo.surface_id());
+    // Next step should still be cached
+    EXPECT_SOFT_EQ(sqrt_two - 1, geo.find_next_step());
 
     // Cross boundary
     geo.move_across_boundary();
@@ -157,6 +160,17 @@ TEST_F(TwoVolumeTest, simple_track)
     EXPECT_EQ(VolumeId{0}, geo.volume_id());
     EXPECT_EQ(SurfaceId{0}, geo.surface_id());
     EXPECT_TRUE(geo.is_outside());
+
+    // Move internally to an arbitrary position
+    geo.find_next_step();
+    geo.move_internal({2, 2, 0});
+    EXPECT_EQ(SurfaceId{}, geo.surface_id());
+    geo.set_dir({-sqrt_two / 2, -sqrt_two / 2, 0});
+
+    EXPECT_SOFT_EQ(1.3284271247461896, geo.find_next_step());
+    geo.move_across_boundary();
+    EXPECT_EQ(VolumeId{1}, geo.volume_id());
+    EXPECT_EQ(SurfaceId{0}, geo.surface_id());
 }
 
 TEST_F(TwoVolumeTest, persistence)
@@ -185,6 +199,7 @@ TEST_F(TwoVolumeTest, persistence)
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
         EXPECT_VEC_SOFT_EQ(Real3({-1.5, 0, 0}), geo.pos());
         geo.move_internal({-1.5, .5, .5});
+        EXPECT_EQ(SurfaceId{}, geo.surface_id());
     }
     {
         auto geo = this->make_track_view();
@@ -194,11 +209,14 @@ TEST_F(TwoVolumeTest, persistence)
     {
         auto geo = this->make_track_view();
         EXPECT_VEC_SOFT_EQ(Real3({1, 0, 0}), geo.dir());
-        EXPECT_SOFT_EQ(3.0, geo.find_next_step());
+        EXPECT_SOFT_EQ(0.17712434446770464, geo.find_next_step());
         geo.move_internal(0.1);
+        EXPECT_EQ(SurfaceId{}, geo.surface_id());
     }
     {
         auto geo = this->make_track_view();
         EXPECT_VEC_SOFT_EQ(Real3({-1.4, .5, .5}), geo.pos());
+        EXPECT_EQ(SurfaceId{}, geo.surface_id());
+        EXPECT_SOFT_EQ(0.07712434446770464, geo.find_next_step());
     }
 }

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -184,21 +184,21 @@ TEST_F(TwoVolumeTest, persistence)
         EXPECT_EQ(VolumeId{0}, geo.volume_id());
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
         EXPECT_VEC_SOFT_EQ(Real3({-1.5, 0, 0}), geo.pos());
+        geo.move_internal({-1.5, .5, .5});
+    }
+    {
+        auto geo = this->make_track_view();
+        EXPECT_VEC_SOFT_EQ(Real3({-1.5, .5, .5}), geo.pos());
         geo.set_dir({1, 0, 0});
     }
     {
         auto geo = this->make_track_view();
         EXPECT_VEC_SOFT_EQ(Real3({1, 0, 0}), geo.dir());
-        geo.find_next_step();
-        geo.move_across_boundary();
+        EXPECT_SOFT_EQ(3.0, geo.find_next_step());
+        geo.move_internal(0.1);
     }
     {
         auto geo = this->make_track_view();
-        EXPECT_EQ(VolumeId{1}, geo.volume_id());
-        geo.move_internal({-0.5, .5, .5});
-    }
-    {
-        auto geo = this->make_track_view();
-        EXPECT_VEC_SOFT_EQ(Real3({-0.5, .5, .5}), geo.pos());
+        EXPECT_VEC_SOFT_EQ(Real3({-1.4, .5, .5}), geo.pos());
     }
 }

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -179,4 +179,26 @@ TEST_F(TwoVolumeTest, persistence)
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
         EXPECT_VEC_SOFT_EQ(Real3({-1.5, 0, 0}), geo.pos());
     }
+    {
+        auto geo = this->make_track_view();
+        EXPECT_EQ(VolumeId{0}, geo.volume_id());
+        EXPECT_EQ(SurfaceId{0}, geo.surface_id());
+        EXPECT_VEC_SOFT_EQ(Real3({-1.5, 0, 0}), geo.pos());
+        geo.set_dir({1, 0, 0});
+    }
+    {
+        auto geo = this->make_track_view();
+        EXPECT_VEC_SOFT_EQ(Real3({1, 0, 0}), geo.dir());
+        geo.find_next_step();
+        geo.move_across_boundary();
+    }
+    {
+        auto geo = this->make_track_view();
+        EXPECT_EQ(VolumeId{1}, geo.volume_id());
+        geo.move_internal({-0.5, .5, .5});
+    }
+    {
+        auto geo = this->make_track_view();
+        EXPECT_VEC_SOFT_EQ(Real3({-0.5, .5, .5}), geo.pos());
+    }
 }


### PR DESCRIPTION
- Fix (and add tests for) missing write-on-destruct for ORANGE track view
- Fix material mapping in demo loop
- Update CMS model to remove pointer addresses, and add ORANGE JSON input
- Use JSON file instead of GDML if VecGeom is disabled

Closes #267