### PR TITLE
Add abstraction for environment variables to support JSON I/O

### DIFF
--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -18,6 +18,8 @@
 #include "comm/Communicator.hh"
 #include "comm/Device.hh"
 #include "comm/DeviceIO.json.hh"
+#include "comm/Environment.hh"
+#include "comm/EnvironmentIO.json.hh"
 #include "comm/KernelDiagnostics.hh"
 #include "comm/KernelDiagnosticsIO.json.hh"
 #include "comm/Logger.hh"
@@ -51,6 +53,11 @@ void run(std::istream& is)
     {
         celeritas::set_cuda_stack_size(inp.at("cuda_stack_size").get<int>());
     }
+    if (inp.count("environ"))
+    {
+        // Specify env variables
+        inp["environ"].get_to(celeritas::environment());
+    }
 
     // For now, only do a single run
     auto run_args = inp.at("run").get<LDemoArgs>();
@@ -73,6 +80,7 @@ void run(std::istream& is)
                 {"version", std::string(celeritas_version)},
                 {"device", celeritas::device()},
                 {"kernels", celeritas::kernel_diagnostics()},
+                {"environ", celeritas::environment()},
             },
         },
     };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,7 @@ list(APPEND SOURCES
   base/detail/ReprImpl.cc
   comm/Communicator.cc
   comm/Device.cc
+  comm/Environment.cc
   comm/Logger.cc
   comm/LoggerTypes.cc
   comm/ScopedMpiInit.cc

--- a/src/base/Assert.cc
+++ b/src/base/Assert.cc
@@ -27,7 +27,7 @@ bool determine_verbose_message()
     return true;
 #else
     // Verbose if the CELER_LOG environment variable is defined
-    return celeritas::getenv("CELER_LOG") != nullptr;
+    return !celeritas::getenv("CELER_LOG").empty();
 #endif
 }
 

--- a/src/base/Assert.cc
+++ b/src/base/Assert.cc
@@ -11,9 +11,9 @@
 #    include <mpi.h>
 #endif
 
-#include <cstdlib>
 #include <sstream>
 #include "ColorUtils.hh"
+#include "comm/Environment.hh"
 
 namespace celeritas
 {
@@ -27,7 +27,7 @@ bool determine_verbose_message()
     return true;
 #else
     // Verbose if the CELER_LOG environment variable is defined
-    return std::getenv("CELER_LOG") != nullptr;
+    return celeritas::getenv("CELER_LOG") != nullptr;
 #endif
 }
 

--- a/src/base/ColorUtils.cc
+++ b/src/base/ColorUtils.cc
@@ -7,10 +7,9 @@
 //---------------------------------------------------------------------------//
 #include "ColorUtils.hh"
 
-#include <cstdlib>
-#include <cstring>
 #include <cstdio>
 #include <unistd.h>
+#include "comm/Environment.hh"
 
 namespace celeritas
 {
@@ -18,25 +17,26 @@ namespace
 {
 bool determine_use_color(FILE* stream)
 {
-    if (const char* color = std::getenv("GTEST_COLOR"))
+    const std::string& color_str = celeritas::getenv("GTEST_COLOR");
+    if (color_str == "0")
     {
-        if (std::strcmp("0", color) != 0)
-        {
-            // GTEST_COLOR environment is given and is not the string "0"
-            return true;
-        }
+        // GTEST_COLOR explicitly disables color
+        return false;
+    }
+    else if (!color_str.empty())
+    {
+        // GTEST_COLOR explicitly enables color
+        return true;
     }
 
     if (isatty(fileno(stream)))
     {
         // Given stream says it's a "terminal" i.e. user-facing
-        if (const char* term = std::getenv("TERM"))
+        const std::string& term_str = celeritas::getenv("TERM");
+        if (term_str.find("xterm") != std::string::npos)
         {
-            if (std::strstr("xterm", term) == nullptr)
-            {
-                // 'xterm' is in the TERM type, so assume it uses colors
-                return true;
-            }
+            // 'xterm' is in the TERM type, so assume it uses colors
+            return true;
         }
     }
 

--- a/src/comm/Device.cc
+++ b/src/comm/Device.cc
@@ -20,6 +20,7 @@
 #include "base/Assert.hh"
 #include "base/Stopwatch.hh"
 #include "Communicator.hh"
+#include "Environment.hh"
 #include "Logger.hh"
 
 namespace celeritas
@@ -37,8 +38,7 @@ int determine_num_devices()
         return 0;
     }
 
-    const char* disable = std::getenv("CELER_DISABLE_DEVICE");
-    if (disable && disable[0] != '\0')
+    if (!celeritas::getenv("CELER_DISABLE_DEVICE").empty())
     {
         CELER_LOG(info)
             << "Disabling GPU support since the 'CELER_DISABLE_DEVICE' "

--- a/src/comm/Environment.cc
+++ b/src/comm/Environment.cc
@@ -1,0 +1,78 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Environment.cc
+//---------------------------------------------------------------------------//
+#include "Environment.hh"
+
+#include <cstdlib>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include "base/Assert.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Access a static global environment variable.
+ *
+ * This static variable should be shared among Celeritas objects.
+ */
+Environment& environment()
+{
+    static Environment environ;
+    return environ;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Thread-safe access to global modified environment variables.
+ */
+const std::string& getenv(const std::string& key)
+{
+    static std::mutex           s_getenv_mutex;
+    std::lock_guard<std::mutex> scoped_lock{s_getenv_mutex};
+    return environment()[key];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write the accessed environment variables to a stream.
+ */
+std::ostream& operator<<(std::ostream& os, const Environment& env)
+{
+    os << "{\n";
+    for (const auto& kv : env)
+    {
+        os << "  " << kv.first << ": '" << kv.second << "',\n";
+    }
+    os << '}';
+    return os;
+}
+
+//---------------------------------------------------------------------------//
+// MEMBER FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Set a value from the system environment.
+ */
+auto Environment::load_from_getenv(const key_type& key) -> const mapped_type&
+{
+    std::string value;
+    if (const char* sys_value = std::getenv(key.c_str()))
+    {
+        // Variable is set in the user environment
+        value = sys_value;
+    }
+    auto iter_inserted = vars_.emplace(key, std::move(value));
+    CELER_ASSERT(iter_inserted.second);
+    return iter_inserted.first->second;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/comm/Environment.hh
+++ b/src/comm/Environment.hh
@@ -7,9 +7,11 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <functional>
 #include <iosfwd>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace celeritas
 {
@@ -42,6 +44,7 @@ class Environment
     using mapped_type    = Container::mapped_type;
     using value_type     = Container::value_type;
     using const_iterator = Container::const_iterator;
+    using VecKVRef       = std::vector<std::reference_wrapper<value_type>>;
     //!@}
 
   public:
@@ -52,18 +55,14 @@ class Environment
     inline const mapped_type& operator[](const key_type&);
 
     // Insert possibly new environment variables (not thread-safe)
-    inline void insert(const value_type& value);
+    void insert(const value_type& value);
 
-    //!@{
-    //! Iterator access to existing variables
-    const_iterator cbegin() const { return vars_.cbegin(); }
-    const_iterator cend() const { return vars_.cend(); }
-    const_iterator begin() const { return vars_.begin(); }
-    const_iterator end() const { return vars_.end(); }
-    //!@}
+    //! Get an ordered (by access) vector of key/value pairs
+    const VecKVRef& ordered_environment() const { return ordered_; }
 
   private:
     std::unordered_map<key_type, mapped_type> vars_;
+    VecKVRef                                  ordered_;
 
     const mapped_type& load_from_getenv(const key_type&);
 };
@@ -95,17 +94,6 @@ auto Environment::operator[](const key_type& env_var) -> const mapped_type&
         return this->load_from_getenv(env_var);
     }
     return iter->second;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Set environment variables en masse.
- *
- * Existing environment variables will *not* be overwritten.
- */
-void Environment::insert(const value_type& value)
-{
-    vars_.insert(value);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/comm/Environment.hh
+++ b/src/comm/Environment.hh
@@ -1,0 +1,112 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Environment.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <iosfwd>
+#include <string>
+#include <unordered_map>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Interrogate and extend environment variables.
+ *
+ * This makes it easier to generate reproducible runs or launch Celeritas
+ * remotely: the environment variables may be encoded as JSON input to
+ * supplement or override system environment variables. Later it can be
+ * interrogated to find which environment variables were accessed.
+ *
+ * Unlike the standard environment which returns a null pointer for an *unset*
+ * variable, this returns an empty string. When we switch to C++17 we can
+ * return a `std::optional<std::string>` if this behavior isn't appropriate.
+ *
+ * \note This class is not thread-safe on its own. The \c celeritas::getenv
+ * free function however is safe, although it should only be used in setup
+ * (single-thread) steps.
+ */
+class Environment
+{
+  private:
+    using Container = std::unordered_map<std::string, std::string>;
+
+  public:
+    //!@{
+    //! Type aliases
+    using key_type       = Container::key_type;
+    using mapped_type    = Container::mapped_type;
+    using value_type     = Container::value_type;
+    using const_iterator = Container::const_iterator;
+    //!@}
+
+  public:
+    // Construct with defaults
+    Environment() = default;
+
+    // Get an environment variable from current or system enviroments
+    inline const mapped_type& operator[](const key_type&);
+
+    // Insert possibly new environment variables (not thread-safe)
+    inline void insert(const value_type& value);
+
+    //!@{
+    //! Iterator access to existing variables
+    const_iterator cbegin() const { return vars_.cbegin(); }
+    const_iterator cend() const { return vars_.cend(); }
+    const_iterator begin() const { return vars_.begin(); }
+    const_iterator end() const { return vars_.end(); }
+    //!@}
+
+  private:
+    std::unordered_map<key_type, mapped_type> vars_;
+
+    const mapped_type& load_from_getenv(const key_type&);
+};
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+
+// Access a static global environment variable
+Environment& environment();
+
+// Thread-safe access to environment variables
+const std::string& getenv(const std::string& key);
+
+// Write the accessed environment variables to a stream
+std::ostream& operator<<(std::ostream&, const Environment&);
+
+//---------------------------------------------------------------------------//
+// INLINE MEMBER FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Get an environment variable from current or system enviroments.
+ */
+auto Environment::operator[](const key_type& env_var) -> const mapped_type&
+{
+    auto iter = vars_.find(env_var);
+    if (iter == vars_.end())
+    {
+        return this->load_from_getenv(env_var);
+    }
+    return iter->second;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set environment variables en masse.
+ *
+ * Existing environment variables will *not* be overwritten.
+ */
+void Environment::insert(const value_type& value)
+{
+    vars_.insert(value);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/comm/EnvironmentIO.json.hh
+++ b/src/comm/EnvironmentIO.json.hh
@@ -34,8 +34,9 @@ inline void from_json(const nlohmann::json& j, Environment& value)
 void to_json(nlohmann::json& j, const Environment& value)
 {
     j = nlohmann::json::object();
-    for (const auto& kv : value)
+    for (const auto& kvref : value.ordered_environment())
     {
+        const Environment::value_type& kv = kvref;
         j[kv.first] = kv.second;
     }
 }

--- a/src/comm/EnvironmentIO.json.hh
+++ b/src/comm/EnvironmentIO.json.hh
@@ -1,0 +1,44 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Environment.json.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "base/Assert.hh"
+#include "Environment.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Read an array from a JSON file.
+ */
+inline void from_json(const nlohmann::json& j, Environment& value)
+{
+    CELER_ASSERT(j.is_object());
+    for (const auto& el : j.items())
+    {
+        value.insert({el.key(), el.value().get<std::string>()});
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write an array to a JSON file.
+ */
+void to_json(nlohmann::json& j, const Environment& value)
+{
+    j = nlohmann::json::object();
+    for (const auto& kv : value)
+    {
+        j[kv.first] = kv.second;
+    }
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/comm/Logger.cc
+++ b/src/comm/Logger.cc
@@ -16,6 +16,7 @@
 #include "base/ColorUtils.hh"
 #include "base/Range.hh"
 #include "Communicator.hh"
+#include "Environment.hh"
 #include "ScopedMpiInit.hh"
 
 namespace
@@ -97,12 +98,13 @@ Logger::Logger(const Communicator& comm,
     {
         // Search for the provided environment variable to set the default
         // logging level using the `to_cstring` function in LoggerTypes.
-        if (const char* env_value = std::getenv(level_env))
+        const std::string& env_value = celeritas::getenv(level_env);
+        if (!env_value.empty())
         {
             auto levels = range(LogLevel::size_);
             auto iter   = std::find_if(
-                levels.begin(), levels.end(), [env_value](LogLevel lev) {
-                    return std::strcmp(env_value, to_cstring(lev)) == 0;
+                levels.begin(), levels.end(), [&env_value](LogLevel lev) {
+                    return env_value == to_cstring(lev);
                 });
             if (iter != levels.end())
             {

--- a/src/comm/ScopedMpiInit.cc
+++ b/src/comm/ScopedMpiInit.cc
@@ -17,6 +17,7 @@
 #include "base/Assert.hh"
 #include "base/Macros.hh"
 #include "base/Stopwatch.hh"
+#include "Environment.hh"
 #include "Logger.hh"
 
 namespace celeritas
@@ -88,10 +89,9 @@ auto ScopedMpiInit::status() -> Status
     }
     if (CELER_UNLIKELY(status_ == Status::uninitialized))
     {
-        const char* disable = std::getenv("CELER_DISABLE_PARALLEL");
-        if (disable && disable[0] != '\0')
+        if (!celeritas::getenv("CELER_DISABLE_PARALLEL").empty())
         {
-            // MPI is disabled via an environment variable.
+            // Environment variable is set: disable MPI
             status_ = Status::disabled;
         }
         else

--- a/src/io/AtomicRelaxationReader.cc
+++ b/src/io/AtomicRelaxationReader.cc
@@ -8,8 +8,8 @@
 #include "AtomicRelaxationReader.hh"
 
 #include <fstream>
-#include <sstream>
 #include "base/SoftEqual.hh"
+#include "comm/Environment.hh"
 
 namespace celeritas
 {
@@ -20,20 +20,12 @@ namespace celeritas
  */
 AtomicRelaxationReader::AtomicRelaxationReader()
 {
-    const char* env_var = std::getenv("G4LEDATA");
-    CELER_VALIDATE(env_var,
+    const std::string& dir = celeritas::getenv("G4LEDATA");
+    CELER_VALIDATE(!dir.empty(),
                    << "environment variable G4LEDATA is not defined (needed "
                       "to locate atomic relaxation data)");
-    {
-        std::ostringstream os;
-        os << env_var << "/fluor";
-        fluor_path_ = os.str();
-    }
-    {
-        std::ostringstream os;
-        os << env_var << "/auger";
-        auger_path_ = os.str();
-    }
+    fluor_path_ = dir + "/fluor";
+    auger_path_ = dir + "/auger";
 }
 
 //---------------------------------------------------------------------------//

--- a/src/io/LivermorePEReader.cc
+++ b/src/io/LivermorePEReader.cc
@@ -8,10 +8,10 @@
 #include "LivermorePEReader.hh"
 
 #include <fstream>
-#include <sstream>
 #include "base/Assert.hh"
 #include "base/Macros.hh"
 #include "base/Types.hh"
+#include "comm/Environment.hh"
 
 namespace celeritas
 {
@@ -22,13 +22,11 @@ namespace celeritas
  */
 LivermorePEReader::LivermorePEReader()
 {
-    const char* env_var = std::getenv("G4LEDATA");
-    CELER_VALIDATE(env_var,
+    const std::string& dir = celeritas::getenv("G4LEDATA");
+    CELER_VALIDATE(!dir.empty(),
                    << "environment variable G4LEDATA is not defined (needed "
                       "to locate Livermore data)");
-    std::ostringstream os;
-    os << env_var << "/livermore/phot_epics2014";
-    path_ = os.str();
+    path_ = dir + "/livermore/phot_epics2014";
 }
 
 //---------------------------------------------------------------------------//

--- a/src/io/SeltzerBergerReader.cc
+++ b/src/io/SeltzerBergerReader.cc
@@ -8,9 +8,9 @@
 #include "SeltzerBergerReader.hh"
 
 #include <fstream>
-#include <sstream>
 #include "base/Assert.hh"
 #include "base/Range.hh"
+#include "comm/Environment.hh"
 
 namespace celeritas
 {
@@ -20,13 +20,11 @@ namespace celeritas
  */
 SeltzerBergerReader::SeltzerBergerReader()
 {
-    const char* env_var = std::getenv("G4LEDATA");
-    CELER_VALIDATE(env_var,
+    const std::string& dir = celeritas::getenv("G4LEDATA");
+    CELER_VALIDATE(!dir.empty(),
                    << "environment variable G4LEDATA is not defined (needed "
                       "to locate Seltzer-Berger data)");
-    std::ostringstream os;
-    os << env_var << "/brem_SB";
-    path_ = os.str();
+    path_ = dir + "/brem_SB";
 }
 
 //---------------------------------------------------------------------------//

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -107,6 +107,9 @@ celeritas_cudaoptional_test(base/StackAllocator)
 celeritas_setup_tests(PREFIX comm)
 
 celeritas_add_test(comm/Communicator.test.cc)
+celeritas_add_test(comm/Environment.test.cc
+  ENVIRONMENT "ENVTEST_ONE=1;ENVTEST_ZERO=0;ENVTEST_EMPTY="
+)
 celeritas_add_test(comm/Logger.test.cc)
 
 #-----------------------------------------------------------------------------#

--- a/test/comm/Environment.test.cc
+++ b/test/comm/Environment.test.cc
@@ -1,0 +1,102 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file Environment.test.cc
+//---------------------------------------------------------------------------//
+#include "comm/Environment.hh"
+
+#include <vector>
+
+#include "celeritas_config.h"
+#if CELERITAS_USE_JSON
+#    include "comm/EnvironmentIO.json.hh"
+#endif
+
+#include "celeritas_test.hh"
+
+using celeritas::Environment;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class EnvironmentTest : public celeritas::Test
+{
+  protected:
+    void SetUp() override {}
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(EnvironmentTest, local)
+{
+    Environment env;
+    EXPECT_TRUE(env.begin() == env.end());
+    EXPECT_EQ("1", env["ENVTEST_ONE"]);
+    EXPECT_EQ("0", env["ENVTEST_ZERO"]);
+    EXPECT_EQ("", env["ENVTEST_EMPTY"]);
+    EXPECT_EQ("", env["ENVTEST_UNSET"]);
+
+    // Insert shouldn't override existing value
+    env.insert({"ENVTEST_ZERO", "2"});
+    EXPECT_EQ("0", env["ENVTEST_ZERO"]);
+
+    std::ostringstream os;
+    os << env;
+    EXPECT_EQ(R"({
+  ENVTEST_UNSET: '',
+  ENVTEST_EMPTY: '',
+  ENVTEST_ZERO: '0',
+  ENVTEST_ONE: '1',
+})",
+              os.str());
+}
+
+TEST_F(EnvironmentTest, global)
+{
+    Environment& env = celeritas::environment();
+
+    // Function to return whether a environment variable has been accessed
+    auto found_env = [&env](const std::string& s) -> bool {
+        return std::find_if(env.begin(),
+                            env.end(),
+                            [&s](const Environment::value_type& kv) {
+                                return s == kv.first;
+                            })
+               != env.end();
+    };
+
+    EXPECT_FALSE(found_env("ENVTEST_ONE"));
+    EXPECT_EQ("1", celeritas::getenv("ENVTEST_ONE"));
+    EXPECT_TRUE(found_env("ENVTEST_ONE"));
+}
+
+TEST_F(EnvironmentTest, json)
+{
+#if CELERITAS_USE_JSON
+    // Pre-set one environment variable
+    Environment env;
+    EXPECT_EQ("0", env["ENVTEST_ZERO"]);
+
+    {
+        // Update environment
+        nlohmann::json myenv{{"ENVTEST_ZERO", "000000"},
+                             {"ENVTEST_ONE", "111111"},
+                             {"ENVTEST_CUSTOM", "custom"}};
+        myenv.get_to(env);
+    }
+    {
+        // Save environment
+        nlohmann::json    out{env};
+        static const char expected[]
+            = R"json([{"ENVTEST_CUSTOM":"custom","ENVTEST_ONE":"111111","ENVTEST_ZERO":"0"}])json";
+        EXPECT_EQ(std::string(expected), std::string(out.dump()));
+    }
+#else
+    GTEST_SKIP() << "JSON is disabled";
+#endif
+}

--- a/test/comm/Environment.test.cc
+++ b/test/comm/Environment.test.cc
@@ -35,7 +35,6 @@ class EnvironmentTest : public celeritas::Test
 TEST_F(EnvironmentTest, local)
 {
     Environment env;
-    EXPECT_TRUE(env.begin() == env.end());
     EXPECT_EQ("1", env["ENVTEST_ONE"]);
     EXPECT_EQ("0", env["ENVTEST_ZERO"]);
     EXPECT_EQ("", env["ENVTEST_EMPTY"]);
@@ -48,31 +47,18 @@ TEST_F(EnvironmentTest, local)
     std::ostringstream os;
     os << env;
     EXPECT_EQ(R"({
-  ENVTEST_UNSET: '',
-  ENVTEST_EMPTY: '',
-  ENVTEST_ZERO: '0',
   ENVTEST_ONE: '1',
+  ENVTEST_ZERO: '0',
+  ENVTEST_EMPTY: '',
+  ENVTEST_UNSET: '',
 })",
               os.str());
 }
 
 TEST_F(EnvironmentTest, global)
 {
-    Environment& env = celeritas::environment();
-
-    // Function to return whether a environment variable has been accessed
-    auto found_env = [&env](const std::string& s) -> bool {
-        return std::find_if(env.begin(),
-                            env.end(),
-                            [&s](const Environment::value_type& kv) {
-                                return s == kv.first;
-                            })
-               != env.end();
-    };
-
-    EXPECT_FALSE(found_env("ENVTEST_ONE"));
+    EXPECT_EQ("1", celeritas::environment()["ENVTEST_ONE"]);
     EXPECT_EQ("1", celeritas::getenv("ENVTEST_ONE"));
-    EXPECT_TRUE(found_env("ENVTEST_ONE"));
 }
 
 TEST_F(EnvironmentTest, json)

--- a/test/field/detail/CMSFieldMapReader.cc
+++ b/test/field/detail/CMSFieldMapReader.cc
@@ -22,18 +22,6 @@ namespace detail
 //---------------------------------------------------------------------------//
 /*!
  * Construct the reader using an environment variable to get the volume-based
- * CMS magnetic field map data and its parameters.
- */
-CMSFieldMapReader::CMSFieldMapReader(const FieldMapParameters& params)
-    : params_(params)
-{
-    file_name_ = std::getenv("USER_FIELD_MAP");
-    CELER_VALIDATE(file_name_.c_str(), << "USER_FIELD_MAP is not defined");
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct the reader using an environment variable to get the volume-based
  * CMS magnetic field map data.
  */
 CMSFieldMapReader::CMSFieldMapReader(const FieldMapParameters& params,

--- a/test/field/detail/CMSFieldMapReader.hh
+++ b/test/field/detail/CMSFieldMapReader.hh
@@ -43,12 +43,8 @@ class CMSFieldMapReader
     };
 
   public:
-    // Construct the reader using the environment variable
-    explicit CMSFieldMapReader(const FieldMapParameters& params);
-
     // Construct the reader using the path of the map file
-    explicit CMSFieldMapReader(const FieldMapParameters& params,
-                               std::string               file_name);
+    CMSFieldMapReader(const FieldMapParameters& params, std::string file_name);
 
     // Read the volume-based CMS magnetic field map
     result_type operator()() const;


### PR DESCRIPTION
This lets us control environment variables as part of the input, and get a copy of the variables accessed by Celeritas for verification purposes.