### PR TITLE
Enable ORANGE field test

### DIFF
--- a/src/base/Collection.hh
+++ b/src/base/Collection.hh
@@ -230,16 +230,16 @@ class Collection
     //// ACCESS ////
 
     // Access a single element
-    inline CELER_FUNCTION reference_type       operator[](ItemIdT i);
-    inline CELER_FUNCTION const_reference_type operator[](ItemIdT i) const;
+    CELER_FORCEINLINE_FUNCTION reference_type       operator[](ItemIdT i);
+    CELER_FORCEINLINE_FUNCTION const_reference_type operator[](ItemIdT i) const;
 
     // Access a subset of the data with a slice
-    inline CELER_FUNCTION SpanT      operator[](ItemRangeT ps);
-    inline CELER_FUNCTION SpanConstT operator[](ItemRangeT ps) const;
+    CELER_FORCEINLINE_FUNCTION SpanT      operator[](ItemRangeT ps);
+    CELER_FORCEINLINE_FUNCTION SpanConstT operator[](ItemRangeT ps) const;
 
     // Access all data.
-    inline CELER_FUNCTION SpanT      operator[](AllItemsT);
-    inline CELER_FUNCTION SpanConstT operator[](AllItemsT) const;
+    CELER_FORCEINLINE_FUNCTION SpanT      operator[](AllItemsT);
+    CELER_FORCEINLINE_FUNCTION SpanConstT operator[](AllItemsT) const;
 
     //!@{
     //! Direct accesors to underlying data

--- a/src/base/Range.hh
+++ b/src/base/Range.hh
@@ -74,13 +74,15 @@ class Range
     //// CONSTRUCTORS ////
 
     //! Empty constructor for empty range
-    CELER_FUNCTION Range() : begin_{}, end_{} {}
+    CELER_FORCEINLINE_FUNCTION Range() : begin_{}, end_{} {}
 
     //! Construct from stop
-    CELER_FUNCTION Range(T end) : begin_{}, end_(end) {}
+    CELER_FORCEINLINE_FUNCTION Range(T end) : begin_{}, end_(end) {}
 
     //! Construct from start/stop
-    CELER_FUNCTION Range(T begin, T end) : begin_(begin), end_(end) {}
+    CELER_FORCEINLINE_FUNCTION Range(T begin, T end) : begin_(begin), end_(end)
+    {
+    }
 
     //// CONTAINER-LIKE ACCESS ////
 

--- a/src/base/Span.hh
+++ b/src/base/Span.hh
@@ -60,11 +60,11 @@ class Span
     constexpr Span() = default;
 
     //! Construct from data and size
-    CELER_FUNCTION Span(pointer d, size_type s) : s_(d, s) {}
+    CELER_FORCEINLINE_FUNCTION Span(pointer d, size_type s) : s_(d, s) {}
 
     //! Construct from two contiguous random-access iterators
     template<class Iter>
-    CELER_FUNCTION Span(Iter first, Iter last)
+    CELER_FORCEINLINE_FUNCTION Span(Iter first, Iter last)
         : s_(&(*first), static_cast<size_type>(last - first))
     {
     }

--- a/src/base/detail/RangeImpl.hh
+++ b/src/base/detail/RangeImpl.hh
@@ -158,7 +158,7 @@ class range_iter : public std::iterator<std::input_iterator_tag, T>
   public:
     //// CONSTRUCTOR ////
 
-    CELER_FUNCTION range_iter(value_type value = TraitsT::zero())
+    CELER_FORCEINLINE_FUNCTION range_iter(value_type value = TraitsT::zero())
         : value_(value)
     {
         CELER_EXPECT(TraitsT::is_valid(value_));
@@ -238,7 +238,10 @@ class inf_range_iter : public range_iter<T>
   public:
     using TraitsT = typename Base::TraitsT;
 
-    CELER_FUNCTION inf_range_iter(T value = TraitsT::zero()) : Base(value) {}
+    CELER_FORCEINLINE_FUNCTION inf_range_iter(T value = TraitsT::zero())
+        : Base(value)
+    {
+    }
 
     CELER_FORCEINLINE_FUNCTION bool operator==(inf_range_iter const&) const
     {
@@ -261,7 +264,7 @@ class step_range_iter : public range_iter<T>
     using TraitsT      = typename Base::TraitsT;
     using counter_type = typename TraitsT::counter_type;
 
-    CELER_FUNCTION step_range_iter(T value, counter_type step)
+    CELER_FORCEINLINE_FUNCTION step_range_iter(T value, counter_type step)
         : Base(value), step_(step)
     {
     }

--- a/src/orange/surfaces/Surfaces.hh
+++ b/src/orange/surfaces/Surfaces.hh
@@ -86,11 +86,13 @@ CELER_FUNCTION T Surfaces::make_surface(SurfaceId sid) const
     CELER_EXPECT(sid < this->num_surfaces());
     CELER_EXPECT(this->surface_type(sid) == T::surface_type());
 
-    OpaqueId<real_type> start = data_.offsets[sid];
-    OpaqueId<real_type> end{start.get()
-                            + static_cast<size_type>(T::Storage::extent)};
-    CELER_ASSERT(end.unchecked_get() <= data_.reals.size());
-    return T{data_.reals[ItemRange<real_type>{start, end}]};
+    const real_type* data = data_.reals[AllItems<real_type>{}].data();
+
+    auto start_offset = data_.offsets[sid].unchecked_get();
+    auto stop_offset  = start_offset
+                       + static_cast<size_type>(T::Storage::extent);
+    CELER_ASSERT(stop_offset <= data_.reals.size());
+    return T{Span<const real_type>{data + start_offset, data + stop_offset}};
 }
 
 //---------------------------------------------------------------------------//

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,9 +51,6 @@ endif()
 if(NOT CELERITAS_USE_ROOT)
   set(_needs_root DISABLE)
 endif()
-if(NOT CELERITAS_USE_VecGeom)
-  set(_needs_vecgeom DISABLE)
-endif()
 
 if(NOT CELERITAS_USE_Geant4)
   set(_needs_geant4 DISABLE)
@@ -119,7 +116,7 @@ celeritas_setup_tests(SERIAL PREFIX field)
 
 celeritas_cudaoptional_test(field/RungeKutta)
 celeritas_cudaoptional_test(field/FieldDriver)
-celeritas_cudaoptional_test(field/FieldPropagator ${_needs_vecgeom})
+celeritas_cudaoptional_test(field/FieldPropagator)
 
 ### User field ###
 

--- a/test/field/data/field-test.org.json
+++ b/test/field/data/field-test.org.json
@@ -1,0 +1,248 @@
+{
+"_format": "SCALE ORANGE",
+"_version": 0,
+"materials": {
+"cell_to_mat": [
+-1,
+1,
+1,
+1,
+1,
+1,
+0
+],
+"names": [
+"0",
+"1"
+]
+},
+"universes": [
+{
+"_type": "simple unit",
+"bbox": [
+[
+-10.0,
+-20.0,
+-10.0
+],
+[
+10.0,
+20.0,
+10.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"layer0",
+"layer1",
+"layer2",
+"layer3",
+"layer4",
+"world"
+],
+"cells": [
+{
+"faces": [
+0,
+1,
+2,
+3,
+4,
+5
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ & ~",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+6,
+7,
+8,
+9,
+10,
+11
+],
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ &",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+6,
+7,
+10,
+11,
+12,
+13
+],
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ &",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+6,
+7,
+10,
+11,
+14,
+15
+],
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ &",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+6,
+7,
+10,
+11,
+16,
+17
+],
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ &",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+6,
+7,
+10,
+11,
+18,
+19
+],
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ &",
+"num_intersections": 6,
+"zorder": 1
+},
+{
+"faces": [
+0,
+1,
+2,
+3,
+4,
+5,
+6,
+7,
+8,
+9,
+10,
+11,
+12,
+13,
+14,
+15,
+16,
+17,
+18,
+19
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ & 6 7 ~ & 8 & 9 ~ & 10 & 11 ~ & ~ & 6 7 ~ & 10 & 11 ~ & 12 & 13 ~ & ~ & 6 7 ~ & 10 & 11 ~ & 14 & 15 ~ & ~ & 6 7 ~ & 10 & 11 ~ & 16 & 17 ~ & ~ & 6 7 ~ & 10 & 11 ~ & 18 & 19 ~ & ~ &",
+"num_intersections": 20,
+"zorder": 1
+}
+],
+"md": {
+"name": "world",
+"provenance": "<unknown>"
+},
+"surface_names": [
+"worldbox.mx",
+"worldbox.px",
+"worldbox.my",
+"worldbox.py",
+"worldbox.mz",
+"worldbox.pz",
+"layerbox0.mx",
+"layerbox0.px",
+"layerbox0.my",
+"layerbox0.py",
+"layerbox0.mz",
+"layerbox0.pz",
+"layerbox1.my",
+"layerbox1.py",
+"layerbox2.my",
+"layerbox2.py",
+"layerbox3.my",
+"layerbox3.py",
+"layerbox4.my",
+"layerbox4.py"
+],
+"surfaces": {
+"data": [
+-10.0,
+10.0,
+-20.0,
+20.0,
+-10.0,
+10.0,
+-9.0,
+9.0,
+-4.5,
+-3.5,
+-9.0,
+9.0,
+-2.5,
+-1.5,
+-0.5,
+0.5,
+1.5,
+2.5,
+3.5,
+4.5
+],
+"sizes": [
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1
+],
+"types": [
+"px",
+"px",
+"py",
+"py",
+"pz",
+"pz",
+"px",
+"px",
+"py",
+"py",
+"pz",
+"pz",
+"py",
+"py",
+"py",
+"py",
+"py",
+"py",
+"py",
+"py"
+]
+}
+}
+]
+}

--- a/test/field/data/field-test.org.py
+++ b/test/field/data/field-test.org.py
@@ -1,10 +1,15 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2022 UT-Battelle, LLC and other Celeritas Developers.
 # See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """
 ORANGE input definition using python.
+
+Note that this file cannot be run standalone: it is merely an input to
+the ``orange2celeritas`` executable. The ``db`` variable is passed into this
+script as a global, then it's validated and written as an ORANGE XML input
+file. Finally, the ORANGE geometry is built from the XML and writes out the
+JSON file field-test.org.json.
 """
 
 layer_box = {

--- a/test/field/data/field-test.org.py
+++ b/test/field/data/field-test.org.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2022 UT-Battelle, LLC and other Celeritas Developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""
+ORANGE input definition using python.
+"""
+
+layer_box = {
+    '_type': 'box',
+    'widths': [18, 1, 18],
+}
+
+world_shapes = []
+shapes = []
+cells = []
+for (i, ymid) in enumerate([-4, -2, 0, 2, 4]):
+    box = dict(layer_box)
+    box['translate'] = [0, ymid, 0]
+    box['name'] = name = f"layerbox{i}"
+    shapes.append(box)
+    world_shapes.append("~" + name)
+    cells.append({
+        'name': f"layer{i}",
+        'comp': "1",
+        'shapes': [name],
+    })
+
+shapes.append({
+    '_type': "box",
+    'widths': [20, 40, 20],
+    'name': "worldbox",
+})
+cells.append({
+    'name': "world",
+    'comp': "0",
+    'shapes': ['worldbox'] + world_shapes,
+})
+
+world_univ = {
+    '_type': 'unit',
+    'name': "world",
+    'shape': shapes,
+    'cell': cells,
+    'interior': "worldbox",
+}
+
+db.update({
+    'geometry': {
+        'global': "world",
+    },
+    'universe': [world_univ]
+})


### PR DESCRIPTION
The bug @paulromano discovered in the OrangeTrackView in #343 was responsible for the failures in the ORANGE version of the Field propagator test. (Oops!) This PR adds the ORANGE geometry version of those problems.

Also, with some rudimentary profiling of the debug version of the code I found that force-inlining some of the low-level functions in Range, Span, and Collection improves the debug-build performance by 20% for the field test (1.2s -> 1s). I expect no performance change for the release build since presumably the compiler should inline those functions automatically. Since the primary changes are nearly-trivial constructors the force-inlines should not negatively impact the ability to debug the code.