### PR TITLE
Add status messages and improve diagnostics to demo loop

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -80,7 +80,10 @@ void from_json(const nlohmann::json& j, LDemoArgs& v)
     j.at("hepmc3_filename").get_to(v.hepmc3_filename);
     j.at("seed").get_to(v.seed);
     j.at("max_num_tracks").get_to(v.max_num_tracks);
-    j.at("max_steps").get_to(v.max_steps);
+    if (j.count("max_steps"))
+    {
+        j.at("max_steps").get_to(v.max_steps);
+    }
     j.at("initializer_capacity").get_to(v.initializer_capacity);
     j.at("secondary_stack_factor").get_to(v.secondary_stack_factor);
     j.at("enable_diagnostics").get_to(v.enable_diagnostics);

--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -91,7 +91,7 @@ void from_json(const nlohmann::json& j, LDemoArgs& v)
 //---------------------------------------------------------------------------//
 TransporterInput load_input(const LDemoArgs& args)
 {
-    CELER_LOG(status) << "Loading input files";
+    CELER_LOG(status) << "Loading input and initializing problem data";
     TransporterInput result;
 
     // Load imported_data from ROOT file

--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -80,7 +80,7 @@ void from_json(const nlohmann::json& j, LDemoArgs& v)
     j.at("hepmc3_filename").get_to(v.hepmc3_filename);
     j.at("seed").get_to(v.seed);
     j.at("max_num_tracks").get_to(v.max_num_tracks);
-    if (j.count("max_steps"))
+    if (j.contains("max_steps"))
     {
         j.at("max_steps").get_to(v.max_steps);
     }

--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -39,7 +39,7 @@ struct LDemoArgs
     // Control
     unsigned int seed{};
     size_type    max_num_tracks{};
-    size_type    max_steps = celeritas::numeric_limits<size_type>::max();
+    size_type    max_steps = celeritas::TransporterInput::no_max_steps();
     size_type    initializer_capacity{};
     real_type    secondary_stack_factor{};
     bool         enable_diagnostics{};

--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -10,6 +10,7 @@
 #include <memory>
 #include <vector>
 #include <nlohmann/json.hpp>
+#include "base/NumericLimits.hh"
 #include "base/Types.hh"
 #include "sim/TrackInitParams.hh"
 #include "Transporter.hh"
@@ -38,7 +39,7 @@ struct LDemoArgs
     // Control
     unsigned int seed{};
     size_type    max_num_tracks{};
-    size_type    max_steps{};
+    size_type    max_steps = celeritas::numeric_limits<size_type>::max();
     size_type    initializer_capacity{};
     real_type    secondary_stack_factor{};
     bool         enable_diagnostics{};

--- a/app/demo-loop/Transporter.cc
+++ b/app/demo-loop/Transporter.cc
@@ -300,7 +300,8 @@ TransporterResult Transporter<M>::operator()(const TrackInitParams& primaries)
 
         if (CELER_UNLIKELY(--remaining_steps == 0))
         {
-            CELER_LOG(warning) << "Exceeded step count of " << input_.max_steps;
+            CELER_LOG(error) << "Exceeded step count of " << input_.max_steps
+                             << ": aborting transport loop";
             break;
         }
     }

--- a/app/demo-loop/Transporter.cc
+++ b/app/demo-loop/Transporter.cc
@@ -216,9 +216,12 @@ TransporterResult Transporter<M>::operator()(const TrackInitParams& primaries)
     Stopwatch get_transport_time;
     // Initialize results
     TransporterResult result;
-    result.time.steps.reserve(input_.max_steps);
-    result.initializers.reserve(input_.max_steps);
-    result.active.reserve(input_.max_steps);
+    if (input_.max_steps != input_.no_max_steps())
+    {
+        result.time.steps.reserve(input_.max_steps);
+        result.initializers.reserve(input_.max_steps);
+        result.active.reserve(input_.max_steps);
+    }
 
     // Construct diagnostics
     auto diagnostics = build_diagnostics(input_, params_);

--- a/app/demo-loop/Transporter.hh
+++ b/app/demo-loop/Transporter.hh
@@ -34,6 +34,12 @@ class TrackInitParams;
 //! Input parameters to the transporter.
 struct TransporterInput
 {
+    //! Arbitrarily high number for not stopping the simulation short
+    static constexpr size_type no_max_steps()
+    {
+        return celeritas::numeric_limits<size_type>::max();
+    }
+
     // Geometry and materials
     std::shared_ptr<const GeoParams>         geometry;
     std::shared_ptr<const MaterialParams>    materials;

--- a/app/demo-loop/Transporter.hh
+++ b/app/demo-loop/Transporter.hh
@@ -95,8 +95,9 @@ struct TransporterResult
 
     //// DATA ////
 
-    VecCount          alive;        //!< Num living tracks per step
-    VecCount          initializers; //!< Num track initializers per step
+    VecCount          initializers; //!< Num starting track initializers
+    VecCount          active;       //!< Num tracks active at beginning of step
+    VecCount          alive;        //!< Num living tracks at end of step
     VecReal           edep;         //!< Energy deposition along the grid
     MapStringCount    process;      //!< Count of particle/process interactions
     MapStringVecCount steps;        //!< Distribution of steps

--- a/app/demo-loop/Transporter.json.hh
+++ b/app/demo-loop/Transporter.json.hh
@@ -28,8 +28,9 @@ inline void to_json(nlohmann::json& j, const TransporterTiming& v)
 
 inline void to_json(nlohmann::json& j, const TransporterResult& v)
 {
-    j = nlohmann::json{{"alive", v.alive},
-                       {"initializers", v.initializers},
+    j = nlohmann::json{{"initializers", v.initializers},
+                       {"active", v.active},
+                       {"alive", v.alive},
                        {"edep", v.edep},
                        {"process", v.process},
                        {"steps", v.steps},

--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -62,11 +62,11 @@ void run(std::istream& is)
     // Read input options
     auto inp = nlohmann::json::parse(is);
 
-    if (inp.count("cuda_stack_size"))
+    if (inp.contains("cuda_stack_size"))
     {
         celeritas::set_cuda_stack_size(inp.at("cuda_stack_size").get<int>());
     }
-    if (inp.count("environ"))
+    if (inp.contains("environ"))
     {
         // Specify env variables
         inp["environ"].get_to(celeritas::environment());

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -43,19 +43,17 @@ num_tracks = 128*32 if use_device else 4
 num_primaries = 3 * 15 # assuming test hepmc input
 
 inp = {
-    'run': {
-        'use_device': use_device,
-        'geometry_filename': geometry_filename,
-        'physics_filename': physics_filename,
-        'hepmc3_filename': hepmc3_filename,
-        'seed': 12345,
-        'max_num_tracks': num_tracks,
-        'max_steps': 128,
-        'initializer_capacity': 10 * max([num_tracks, num_primaries]),
-        'secondary_stack_factor': 3,
-        'enable_diagnostics': True,
-        'sync': False
-    }
+    'use_device': use_device,
+    'geometry_filename': geometry_filename,
+    'physics_filename': physics_filename,
+    'hepmc3_filename': hepmc3_filename,
+    'seed': 12345,
+    'max_num_tracks': num_tracks,
+    'max_steps': 128*128*32 // num_tracks,
+    'initializer_capacity': 10 * max([num_tracks, num_primaries]),
+    'secondary_stack_factor': 3,
+    'enable_diagnostics': True,
+    'sync': True
 }
 
 
@@ -85,6 +83,11 @@ except json.decoder.JSONDecodeError as e:
     print("fatal:", str(e))
     exit(1)
 
-print(json.dumps(result, indent=1))
-with open(f'{run_name}.out.json', 'w') as f:
+outfilename = f'{run_name}.out.json'
+with open(outfilename, 'w') as f:
     json.dump(result, f)
+print("Results written to", outfilename)
+
+time = result['result']['time'].copy()
+time.pop('steps')
+print(json.dumps(time, indent=1))

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -39,7 +39,7 @@ if strtobool(environ.get('CELER_DISABLE_VECGEOM', 'false')):
     print("Replacing .gdml extension since VecGeom is disabled")
     geometry_filename = re.sub(r"\.gdml$", ".org.json", geometry_filename)
 
-num_tracks = 128*32 if use_device else 4
+num_tracks = 128*32 if use_device else 32
 num_primaries = 3 * 15 # assuming test hepmc input
 
 inp = {
@@ -49,8 +49,8 @@ inp = {
     'hepmc3_filename': hepmc3_filename,
     'seed': 12345,
     'max_num_tracks': num_tracks,
-    'max_steps': 128*128*32 // num_tracks,
-    'initializer_capacity': 10 * max([num_tracks, num_primaries]),
+    'max_steps': 128 if use_device else 64, # Just for sake of test time!
+    'initializer_capacity': 100 * max([num_tracks, num_primaries]),
     'secondary_stack_factor': 3,
     'enable_diagnostics': True,
     'sync': True

--- a/app/demo-rasterizer/demo-rasterizer.cc
+++ b/app/demo-rasterizer/demo-rasterizer.cc
@@ -49,7 +49,7 @@ void run(std::istream& is)
         inp.at("input").get<std::string>().c_str());
     timers["load"] = get_time();
 
-    if (inp.count("cuda_stack_size"))
+    if (inp.contains("cuda_stack_size"))
     {
         set_cuda_stack_size(inp.at("cuda_stack_size").get<int>());
     }

--- a/scripts/docker/ci/run-ci.sh
+++ b/scripts/docker/ci/run-ci.sh
@@ -23,5 +23,5 @@ cd build
 ctest -T Test ${_ctest_args}
 # Valgrind
 if [ "${CMAKE_PRESET}" = "valgrind" ]; then
-  ctest -T MemCheck -E 'demo-' ${_ctest_args}
+  ctest -T MemCheck -E 'demo-' --output-on-failure ${_ctest_args}
 fi


### PR DESCRIPTION
- Add 'active' for post-initialize alive count
- Total time is just for transport; additional 'setup' time for problem  creation (VecGeom, ROOT)
- Fix early termination of cpu-demo-loop due to step count
- Rename output keys from demo loop
- Un-nest input parameters