### PR TITLE
Fix parent ID assignment

### DIFF
--- a/src/base/detail/CollectionImpl.hh
+++ b/src/base/detail/CollectionImpl.hh
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include "base/Assert.hh"
+#include "base/Copier.hh"
 #include "base/DeviceVector.hh"
 #include "base/Span.hh"
 #include "base/Types.hh"
@@ -159,7 +160,9 @@ struct CollectionAssigner<Ownership::value, MemSpace::host>
     {
         CollectionStorage<T, Ownership::value, MemSpace::host> result{
             std::vector<T>(source.data.size())};
-        source.data.copy_to_host({result.data.data(), result.data.size()});
+        Copier<T, MemSpace::device> copy{
+            {source.data.data(), source.data.size()}};
+        copy(MemSpace::host, {result.data.data(), result.data.size()});
         return result;
     }
 };

--- a/src/physics/base/Interaction.hh
+++ b/src/physics/base/Interaction.hh
@@ -43,6 +43,9 @@ struct Interaction
     // Return an interaction indicating all state changes have been applied
     static inline CELER_FUNCTION Interaction from_processed();
 
+    // Return an interaction representing the creation of a new track
+    static inline CELER_FUNCTION Interaction from_spawned();
+
     // Whether the interaction succeeded
     explicit inline CELER_FUNCTION operator bool() const;
 };
@@ -98,6 +101,17 @@ CELER_FUNCTION Interaction Interaction::from_processed()
 {
     Interaction result;
     result.action = Action::processed;
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct an interaction for the creation of a new track.
+ */
+CELER_FUNCTION Interaction Interaction::from_spawned()
+{
+    Interaction result;
+    result.action = Action::spawned;
     return result;
 }
 

--- a/src/sim/detail/ProcessSecondariesLauncher.hh
+++ b/src/sim/detail/ProcessSecondariesLauncher.hh
@@ -93,6 +93,7 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
             init.sim.parent_id        = parent_id;
             init.sim.event_id         = sim.event_id();
             init.sim.alive            = true;
+            init.geo.pos              = geo.pos();
             init.geo.dir              = secondary.direction;
             init.particle.particle_id = secondary.particle_id;
             init.particle.energy      = secondary.energy;
@@ -117,7 +118,6 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
             else
             {
                 // Store the track initializer
-                init.geo.pos = geo.pos();
                 ThreadId init_id(data_.initializers.size()
                                  - data_.parents.size() + offset);
                 CELER_ASSERT(init_id < data_.initializers.size());

--- a/src/sim/detail/ProcessSecondariesLauncher.hh
+++ b/src/sim/detail/ProcessSecondariesLauncher.hh
@@ -66,21 +66,20 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
     SimTrackView sim(states_.sim, tid);
 
     // Offset in the vector of track initializers
-    size_type offset_id = data_.secondary_counts[tid];
+    size_type offset = data_.secondary_counts[tid];
+
+    // A new track was initialized from a secondary in the parent's track slot
+    bool initialized = false;
+
+    // Save the parent ID since it will be overwritten if a secondary is
+    // initialized in this slot
+    const TrackId parent_id(sim.track_id());
 
     Interaction& result = states_.interactions[tid];
     for (const auto& secondary : result.secondaries)
     {
         if (secondary)
         {
-            // The secondary survived cutoffs: convert to a track
-            CELER_ASSERT(offset_id < data_.parents.size());
-            TrackInitializer& init = data_.initializers[ThreadId(
-                data_.initializers.size() - data_.parents.size() + offset_id)];
-
-            // Store the thread ID of the secondary's parent
-            data_.parents[ThreadId{offset_id++}] = tid;
-
             // Calculate the track ID of the secondary
             // TODO: This is nondeterministic; we need to calculate the
             // track ID in a reproducible way.
@@ -88,19 +87,51 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
             TrackId::size_type track_id = atomic_add(
                 &data_.track_counters[sim.event_id()], size_type{1});
 
-            // Construct a track initializer from a secondary
+            // Create a track initializer from the secondary
+            TrackInitializer init;
             init.sim.track_id         = TrackId{track_id};
-            init.sim.parent_id        = sim.track_id();
+            init.sim.parent_id        = parent_id;
             init.sim.event_id         = sim.event_id();
             init.sim.alive            = true;
-            init.geo.pos              = geo.pos();
             init.geo.dir              = secondary.direction;
             init.particle.particle_id = secondary.particle_id;
             init.particle.energy      = secondary.energy;
+
+            if (!initialized && !sim.alive())
+            {
+                ParticleTrackView particle(
+                    params_.particles, states_.particles, tid);
+                PhysicsTrackView phys(
+                    params_.physics, states_.physics, {}, {}, tid);
+
+                // The parent was killed, so initialize the first secondary in
+                // the parent's track slot. Keep the parent's geometry state
+                // but get the direction from the secondary. The material state
+                // will be the same as the parent's.
+                sim = init.sim;
+                geo = GeoTrackView::DetailedInitializer{geo, init.geo.dir};
+                particle    = init.particle;
+                phys        = {};
+                initialized = true;
+            }
+            else
+            {
+                // Store the track initializer
+                init.geo.pos = geo.pos();
+                ThreadId init_id(data_.initializers.size()
+                                 - data_.parents.size() + offset);
+                CELER_ASSERT(init_id < data_.initializers.size());
+                data_.initializers[init_id] = init;
+
+                // Store the thread ID of the secondary's parent
+                CELER_ASSERT(offset < data_.parents.size());
+                data_.parents[ThreadId(offset++)] = tid;
+            }
         }
     }
     // Clear the interaction
-    result = Interaction::from_processed();
+    result = initialized ? Interaction::from_spawned()
+                         : Interaction::from_processed();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/sim/TrackInit.test.cc
+++ b/test/sim/TrackInit.test.cc
@@ -231,7 +231,7 @@ TEST_F(TrackInitTest, run)
     // deterministically
     output.init_id = initializers_test(make_ref(track_init_states));
     std::sort(std::begin(output.init_id), std::end(output.init_id));
-    expected.init_id = {0, 1, 15, 16, 17};
+    expected.init_id = {0, 1, 13, 15, 17};
     EXPECT_VEC_EQ(expected.init_id, output.init_id);
 
     // Initialize secondaries on device
@@ -241,7 +241,7 @@ TEST_F(TrackInitTest, run)
     // Output is sorted as TrackInitializerStore does not calculate IDs
     // deterministically
     output.track_id   = tracks_test(states);
-    expected.track_id = {12, 3, 16, 5, 13, 7, 17, 9, 14, 11};
+    expected.track_id = {12, 3, 15, 5, 14, 7, 17, 9, 16, 11};
     std::sort(std::begin(output.track_id), std::end(output.track_id));
     std::sort(std::begin(expected.track_id), std::end(expected.track_id));
     EXPECT_VEC_EQ(expected.track_id, output.track_id);

--- a/test/sim/TrackInit.test.hh
+++ b/test/sim/TrackInit.test.hh
@@ -92,9 +92,10 @@ struct ITTestInput
 //! Output data
 struct ITTestOutput
 {
-    std::vector<unsigned int> track_id;
-    std::vector<unsigned int> init_id;
-    std::vector<size_type>    vacancy;
+    std::vector<unsigned int> track_ids;
+    std::vector<unsigned int> parent_ids;
+    std::vector<unsigned int> init_ids;
+    std::vector<size_type>    vacancies;
 };
 
 using SecondaryAllocatorData
@@ -105,19 +106,6 @@ using SecondaryAllocatorData
 //---------------------------------------------------------------------------//
 //! Launch a kernel to produce secondaries and apply cutoffs
 void interact(StateDeviceRef states, ITTestInputData input);
-
-//---------------------------------------------------------------------------//
-//! Launch a kernel to get the track IDs of the initialized tracks
-std::vector<unsigned int> tracks_test(StateDeviceRef states);
-
-//---------------------------------------------------------------------------//
-//! Launch a kernel to get the track IDs of the track initializers created from
-//! primaries or secondaries
-std::vector<unsigned int> initializers_test(TrackInitStateDeviceRef inits);
-
-//---------------------------------------------------------------------------//
-//! Launch a kernel to get the indices of the vacant slots in the track vector
-std::vector<size_type> vacancies_test(TrackInitStateDeviceRef inits);
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas_test

--- a/test/sim/TrackInit.test.hh
+++ b/test/sim/TrackInit.test.hh
@@ -93,7 +93,7 @@ struct ITTestInput
 struct ITTestOutput
 {
     std::vector<unsigned int> track_ids;
-    std::vector<unsigned int> parent_ids;
+    std::vector<int>          parent_ids;
     std::vector<unsigned int> init_ids;
     std::vector<size_type>    vacancies;
 };


### PR DESCRIPTION
The parent IDs of the tracks are currently not set correctly: because a secondary is immediately initialized in the parent track’s slot if the parent was killed, any other secondaries produced by that track actually have a "sibling" ID as their parent ID. This fixes the parent IDs and moves the immediate initialization of a secondary to the same kernel where the track initializers are created. All newly initialized tracks now also have the correction "spawned" `Action`. I added a check for the parent IDs in the track initialization test and simplified the collection of results (use `Collection`s to copy state data from device to host instead of launching kernels to extract the data).