### PR TITLE
Reduce track initialization memory and remove reduction

### DIFF
--- a/src/sim/TrackInitUtils.hh
+++ b/src/sim/TrackInitUtils.hh
@@ -168,11 +168,16 @@ extend_from_secondaries(const ParamsData<Ownership::const_reference, M>& params,
     size_type num_vac = detail::remove_if_alive<M>(data->vacancies.data());
     data->vacancies.resize(num_vac);
 
-    // Sum the total number secondaries produced in all interactions
+    // The exclusive prefix sum of the number of secondaries produced by each
+    // track is used to get the start index in the vector of track initializers
+    // for each thread. Starting at that index, each thread creates track
+    // initializers from all surviving secondaries produced in its
+    // interaction.
+    data->num_secondaries = detail::exclusive_scan_counts<M>(
+        data->secondary_counts[AllItems<size_type, M>{}]);
+
     // TODO: if we don't have space for all the secondaries, we will need to
     // buffer the current track initializers to create room
-    data->num_secondaries = detail::reduce_counts<M>(
-        data->secondary_counts[AllItems<size_type, M>{}]);
     CELER_VALIDATE(
         data->num_secondaries + data->initializers.size()
             <= data->initializers.capacity(),
@@ -180,14 +185,6 @@ extend_from_secondaries(const ParamsData<Ownership::const_reference, M>& params,
         << ") for track initializers (created " << data->num_secondaries
         << " new secondaries for a total capacity requirement of "
         << data->num_secondaries + data->initializers.size() << ")");
-
-    // The exclusive prefix sum of the number of secondaries produced by each
-    // track is used to get the start index in the vector of track initializers
-    // for each thread. Starting at that index, each thread creates track
-    // initializers from all surviving secondaries produced in its
-    // interaction.
-    detail::exclusive_scan_counts<M>(
-        data->secondary_counts[AllItems<size_type, M>{}]);
 
     // Launch a kernel to create track initializers from secondaries
     data->initializers.resize(data->initializers.size()

--- a/src/sim/TrackInitUtils.hh
+++ b/src/sim/TrackInitUtils.hh
@@ -171,14 +171,15 @@ extend_from_secondaries(const ParamsData<Ownership::const_reference, M>& params,
     // Sum the total number secondaries produced in all interactions
     // TODO: if we don't have space for all the secondaries, we will need to
     // buffer the current track initializers to create room
-    size_type num_secondaries = detail::reduce_counts<M>(
+    data->num_secondaries = detail::reduce_counts<M>(
         data->secondary_counts[AllItems<size_type, M>{}]);
-    CELER_VALIDATE(num_secondaries + data->initializers.size()
-                       <= data->initializers.capacity(),
-                   << "insufficient capacity (" << data->initializers.capacity()
-                   << ") for track initializers (created " << num_secondaries
-                   << " new secondaries for a total capacity requirement of "
-                   << num_secondaries + data->initializers.size() << ")");
+    CELER_VALIDATE(
+        data->num_secondaries + data->initializers.size()
+            <= data->initializers.capacity(),
+        << "insufficient capacity (" << data->initializers.capacity()
+        << ") for track initializers (created " << data->num_secondaries
+        << " new secondaries for a total capacity requirement of "
+        << data->num_secondaries + data->initializers.size() << ")");
 
     // The exclusive prefix sum of the number of secondaries produced by each
     // track is used to get the start index in the vector of track initializers
@@ -189,8 +190,8 @@ extend_from_secondaries(const ParamsData<Ownership::const_reference, M>& params,
         data->secondary_counts[AllItems<size_type, M>{}]);
 
     // Launch a kernel to create track initializers from secondaries
-    data->parents.resize(num_secondaries);
-    data->initializers.resize(data->initializers.size() + num_secondaries);
+    data->initializers.resize(data->initializers.size()
+                              + data->num_secondaries);
     detail::process_secondaries(params, states, make_ref(*data));
 }
 

--- a/src/sim/detail/InitTracksLauncher.hh
+++ b/src/sim/detail/InitTracksLauncher.hh
@@ -94,7 +94,7 @@ CELER_FUNCTION void InitTracksLauncher<M>::operator()(ThreadId tid) const
     // Initialize the geometry
     {
         GeoTrackView geo(params_.geometry, states_.geometry, vac_id);
-        if (tid < data_.parents.size())
+        if (tid < data_.num_secondaries)
         {
             // Copy the geometry state from the parent for improved
             // performance

--- a/src/sim/detail/InitializeTracks.cc
+++ b/src/sim/detail/InitializeTracks.cc
@@ -101,24 +101,16 @@ size_type remove_if_alive<MemSpace::host>(Span<size_type> vacancies)
 
 //---------------------------------------------------------------------------//
 /*!
- * Sum the total number of surviving secondaries.
- */
-template<>
-size_type reduce_counts<MemSpace::host>(Span<size_type> counts)
-{
-    return std::accumulate(counts.begin(), counts.end(), size_type(0));
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Do an exclusive scan of the number of surviving secondaries from each track.
+ * Do an exclusive scan of the number of secondaries produced by each track.
  *
  * For an input array x, this calculates the exclusive prefix sum y of the
  * array elements, i.e., \f$ y_i = \sum_{j=0}^{i-1} x_j \f$,
  * where \f$ y_0 = 0 \f$, and stores the result in the input array.
+ *
+ * The return value is the sum of all elements in the input array.
  */
 template<>
-void exclusive_scan_counts<MemSpace::host>(Span<size_type> counts)
+size_type exclusive_scan_counts<MemSpace::host>(Span<size_type> counts)
 {
     // TODO: Use std::exclusive_scan when C++17 is adopted
     size_type acc = 0;
@@ -128,6 +120,7 @@ void exclusive_scan_counts<MemSpace::host>(Span<size_type> counts)
         count_i           = acc;
         acc += current;
     }
+    return acc;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/detail/InitializeTracks.cu
+++ b/src/sim/detail/InitializeTracks.cu
@@ -8,7 +8,6 @@
 #include "InitializeTracks.hh"
 
 #include <thrust/device_ptr.h>
-#include <thrust/reduce.h>
 #include <thrust/remove.h>
 #include <thrust/scan.h>
 #include "base/KernelParamCalculator.cuda.hh"
@@ -178,39 +177,35 @@ size_type remove_if_alive<MemSpace::device>(Span<size_type> vacancies)
 
 //---------------------------------------------------------------------------//
 /*!
- * Sum the total number of surviving secondaries.
- */
-template<>
-size_type reduce_counts<MemSpace::device>(Span<size_type> counts)
-{
-    size_type result = thrust::reduce(
-        thrust::device_pointer_cast(counts.data()),
-        thrust::device_pointer_cast(counts.data()) + counts.size(),
-        size_type(0),
-        thrust::plus<size_type>());
-
-    CELER_CUDA_CHECK_ERROR();
-    return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Do an exclusive scan of the number of surviving secondaries from each track.
+ * Do an exclusive scan of the number of secondaries produced by each track.
  *
  * For an input array x, this calculates the exclusive prefix sum y of the
  * array elements, i.e., \f$ y_i = \sum_{j=0}^{i-1} x_j \f$,
  * where \f$ y_0 = 0 \f$, and stores the result in the input array.
+ *
+ * The return value is the sum of all elements in the input array.
  */
 template<>
-void exclusive_scan_counts<MemSpace::device>(Span<size_type> counts)
+size_type exclusive_scan_counts<MemSpace::device>(Span<size_type> counts)
 {
+    // Copy the last element to the host
+    Copier<size_type, MemSpace::device> copy{
+        {counts.data() + counts.size() - 1, 1}};
+    size_type partial1{};
+    copy(MemSpace::host, {&partial1, 1});
+
     thrust::exclusive_scan(
         thrust::device_pointer_cast(counts.data()),
-        thrust::device_pointer_cast(counts.data()) + counts.size(),
-        counts.data(),
+        thrust::device_pointer_cast(counts.data() + counts.size()),
+        thrust::device_pointer_cast(counts.data()),
         size_type(0));
-
     CELER_CUDA_CHECK_ERROR();
+
+    // Copy the last element (the sum of all elements but the last) to the host
+    size_type partial2{};
+    copy(MemSpace::host, {&partial2, 1});
+
+    return partial1 + partial2;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/detail/InitializeTracks.hh
+++ b/src/sim/detail/InitializeTracks.hh
@@ -62,24 +62,14 @@ template<>
 size_type remove_if_alive<MemSpace::device>(Span<size_type> vacancies);
 
 //---------------------------------------------------------------------------//
-// Sum the total number of surviving secondaries.
-template<MemSpace M>
-size_type reduce_counts(Span<size_type> counts);
-
-template<>
-size_type reduce_counts<MemSpace::host>(Span<size_type> counts);
-template<>
-size_type reduce_counts<MemSpace::device>(Span<size_type> counts);
-
-//---------------------------------------------------------------------------//
 // Calculate the exclusive prefix sum of the number of surviving secondaries
 template<MemSpace M>
-void exclusive_scan_counts(Span<size_type> counts);
+size_type exclusive_scan_counts(Span<size_type> counts);
 
 template<>
-void exclusive_scan_counts<MemSpace::host>(Span<size_type> counts);
+size_type exclusive_scan_counts<MemSpace::host>(Span<size_type> counts);
 template<>
-void exclusive_scan_counts<MemSpace::device>(Span<size_type> counts);
+size_type exclusive_scan_counts<MemSpace::device>(Span<size_type> counts);
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
@@ -113,19 +103,13 @@ inline void process_secondaries(const ParamsDeviceRef&,
 }
 
 template<>
-size_type reduce_counts<MemSpace::device>(Span<size_type>)
-{
-    CELER_NOT_CONFIGURED("CUDA");
-}
-
-template<>
 size_type remove_if_alive<MemSpace::device>(Span<size_type>)
 {
     CELER_NOT_CONFIGURED("CUDA");
 }
 
 template<>
-void exclusive_scan_counts<MemSpace::device>(Span<size_type>)
+size_type exclusive_scan_counts<MemSpace::device>(Span<size_type>)
 {
     CELER_NOT_CONFIGURED("CUDA");
 }


### PR DESCRIPTION
A couple small changes:

- Reduce the track initializer `parents` size: storage for the thread IDs of the initializers' parent tracks currently has the same capacity as `initializers`, but only needs to be as large as the number of track states
- Leverage the prefix sum to get the total number of secondaries produced in a step and remove the reduction in `extend_from_secondaries`