### PR TITLE
Fix TrackInit test

### DIFF
--- a/test/sim/TrackInit.test.cu
+++ b/test/sim/TrackInit.test.cu
@@ -36,16 +36,13 @@ __global__ void interact_kernel(StateDeviceRef states, ITTestInputData input)
                                 input.alloc_size[thread_id.get()],
                                 input.alive[thread_id.get()]);
             states.interactions[thread_id] = interact();
+            CELER_ASSERT(states.interactions[thread_id]);
 
             // Kill the selected tracks
             if (!input.alive[thread_id.get()])
             {
                 sim.alive(false);
             }
-        }
-        else
-        {
-            states.interactions[thread_id] = Interaction::from_absorption();
         }
     }
 }

--- a/test/sim/TrackInit.test.hh
+++ b/test/sim/TrackInit.test.hh
@@ -36,6 +36,7 @@ struct Interactor
     CELER_FUNCTION Interaction operator()()
     {
         Interaction result;
+        result.action = Action::unchanged;
 
         // Kill the particle
         if (!alive)


### PR DESCRIPTION
The loop in the TrackInit secondaries test currently terminates when there are no queued initializers, but since secondaries are produced at each iteration there will _always_ be initializers. The loop was actually exiting when there was no space left in the `StackAllocator` to create new secondaries (I ran into this when preallocating one of the secondaries in the `Interaction` -- this resulted in an infinite loop because the `StackAllocator` was never used). This updates the test so the loop will terminate after a fixed number of iterations.