### PR TITLE
Initialize interactions on device

### DIFF
--- a/src/sim/TrackData.hh
+++ b/src/sim/TrackData.hh
@@ -169,7 +169,13 @@ resize(StateData<Ownership::value, M>*                               data,
 
     resize(&data->step_length, size);
     resize(&data->energy_deposition, size);
-    resize(&data->interactions, size);
+
+    // Initialize empty interactions
+    StateCollection<Interaction, Ownership::value, MemSpace::host> interactions;
+    std::vector<Interaction> initial_state(size, Interaction{});
+    make_builder(&interactions)
+        .insert_back(initial_state.begin(), initial_state.end());
+    data->interactions = interactions;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/detail/InitTracksLauncher.hh
+++ b/src/sim/detail/InitTracksLauncher.hh
@@ -123,7 +123,7 @@ CELER_FUNCTION void InitTracksLauncher<M>::operator()(ThreadId tid) const
 
     // Interaction representing creation of a new track
     {
-        states_.interactions[vac_id].action = Action::spawned;
+        states_.interactions[vac_id] = Interaction::from_spawned();
     }
 }
 


### PR DESCRIPTION
This makes sure the `Interaction`s are initialized at the start of the simulation, as some members (`secondaries`) might otherwise be used uninitialized. This could possibly be the cause of the demo-loop error seen in #374.