### PR TITLE
Preallocate one secondary per interaction

### DIFF
--- a/app/demo-interactor/KNDemoKernel.hh
+++ b/app/demo-interactor/KNDemoKernel.hh
@@ -13,7 +13,6 @@
 #include "base/Types.hh"
 #include "physics/base/ParticleData.hh"
 #include "physics/base/Secondary.hh"
-#include "base/StackAllocator.hh"
 #include "physics/em/detail/KleinNishinaData.hh"
 #include "physics/grid/XsGridData.hh"
 #include "random/RngData.hh"
@@ -65,10 +64,10 @@ struct TableData
 template<Ownership W, MemSpace M>
 struct ParamsData
 {
-    celeritas::ParticleParamsData<W, M>     particle;
-    TableData<W, M>                         tables;
-    celeritas::detail::KleinNishinaData     kn_interactor;
-    DetectorParamsData                      detector;
+    celeritas::ParticleParamsData<W, M> particle;
+    TableData<W, M>                     tables;
+    celeritas::detail::KleinNishinaData kn_interactor;
+    DetectorParamsData                  detector;
 
     explicit CELER_FUNCTION operator bool() const
     {
@@ -101,9 +100,6 @@ struct InitialData
 template<Ownership W, MemSpace M>
 struct StateData
 {
-    using SecondaryAllocatorData
-        = celeritas::StackAllocatorData<celeritas::Secondary, W, M>;
-
     celeritas::ParticleStateData<W, M>                              particle;
     celeritas::RngStateData<Ownership::reference, MemSpace::device> rng;
     celeritas::Span<celeritas::Real3>                               position;
@@ -111,12 +107,11 @@ struct StateData
     celeritas::Span<celeritas::real_type>                           time;
     celeritas::Span<bool>                                           alive;
 
-    SecondaryAllocatorData  secondaries;
     DetectorStateData<W, M> detector;
 
     explicit CELER_FUNCTION operator bool() const
     {
-        return particle && rng && secondaries && detector && !position.empty()
+        return particle && rng && detector && !position.empty()
                && !direction.empty() && !time.empty() && !alive.empty();
     }
 

--- a/app/demo-interactor/KNDemoRunner.cc
+++ b/app/demo-interactor/KNDemoRunner.cc
@@ -73,10 +73,6 @@ auto KNDemoRunner::operator()(KNDemoRunArgs args) -> result_type
     rng_params.seed = args.seed;
     resize(&rng_states, make_const_ref(rng_params), args.num_tracks);
 
-    // Secondary data
-    StackAllocatorData<Secondary, Ownership::value, MemSpace::device> secondaries;
-    resize(&secondaries, args.num_tracks);
-
     // Detector data
     DetectorParamsData detector_params;
     detector_params.tally_grid = args.tally_grid;
@@ -102,8 +98,7 @@ auto KNDemoRunner::operator()(KNDemoRunArgs args) -> result_type
     state.time      = time.device_ref();
     state.alive     = alive.device_ref();
 
-    state.secondaries = secondaries;
-    state.detector    = detector_states;
+    state.detector = detector_states;
 
     // Initialize particle states
     initialize(launch_params_, params, state, initial);

--- a/src/physics/base/Interaction.hh
+++ b/src/physics/base/Interaction.hh
@@ -27,7 +27,8 @@ struct Interaction
     Action           action;            //!< Failure, scatter, absorption, ...
     units::MevEnergy energy;            //!< Post-interaction energy
     Real3            direction;         //!< Post-interaction direction
-    Span<Secondary>  secondaries;       //!< Emitted secondaries
+    Secondary        secondary;         //!< First secondary is preallocated
+    Span<Secondary>  secondaries;       //!< Remaining emitted secondaries
     units::MevEnergy energy_deposition; //!< Energy loss locally to material
 
     // Return an interaction representing a recoverable error
@@ -48,6 +49,9 @@ struct Interaction
 
     // Whether the interaction succeeded
     explicit inline CELER_FUNCTION operator bool() const;
+
+    // Total number of secondaries
+    inline CELER_FUNCTION size_type num_secondaries() const;
 };
 
 //---------------------------------------------------------------------------//
@@ -122,6 +126,15 @@ CELER_FUNCTION Interaction Interaction::from_spawned()
 CELER_FUNCTION Interaction::operator bool() const
 {
     return action_completed(this->action);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Total number of secondaries.
+ */
+CELER_FUNCTION size_type Interaction::num_secondaries() const
+{
+    return (secondary ? 1 : 0) + secondaries.size();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/BremFinalStateHelper.hh
+++ b/src/physics/em/detail/BremFinalStateHelper.hh
@@ -42,8 +42,7 @@ class BremFinalStateHelper
     // Update the final state for the given RNG and the photon energy
     template<class Engine>
     inline CELER_FUNCTION Interaction operator()(Engine&      rng,
-                                                 const Energy gamma_energy,
-                                                 Secondary*   secondaries);
+                                                 const Energy gamma_energy);
 
   private:
     // Incident particle energy
@@ -83,32 +82,31 @@ BremFinalStateHelper::BremFinalStateHelper(const Energy&     inc_energy,
  * Update the final state of the primary particle and the secondary photon
  */
 template<class Engine>
-CELER_FUNCTION Interaction BremFinalStateHelper::operator()(
-    Engine& rng, const Energy gamma_energy, Secondary* secondaries)
+CELER_FUNCTION Interaction
+BremFinalStateHelper::operator()(Engine& rng, const Energy gamma_energy)
 {
     // Construct interaction for change to parent (incoming) particle
     Interaction result;
     result.action = Action::scattered;
     result.energy
         = units::MevEnergy{inc_energy_.value() - gamma_energy.value()};
-    result.secondaries         = {secondaries, 1};
-    secondaries[0].particle_id = gamma_id_;
-    secondaries[0].energy      = gamma_energy;
+    result.secondary.particle_id = gamma_id_;
+    result.secondary.energy      = gamma_energy;
 
     // Generate exiting gamma direction from isotropic azimuthal angle and
     // TsaiUrbanDistribution for polar angle (based on G4ModifiedTsai)
     UniformRealDistribution<real_type> sample_phi(0, 2 * constants::pi);
     TsaiUrbanDistribution sample_gamma_angle(inc_energy_, inc_mass_);
     real_type             cost = sample_gamma_angle(rng);
-    secondaries[0].direction
+    result.secondary.direction
         = rotate(from_spherical(cost, sample_phi(rng)), inc_direction_);
 
     // Update parent particle direction
     for (unsigned int i : range(3))
     {
         real_type inc_momentum_i   = inc_momentum_.value() * inc_direction_[i];
-        real_type gamma_momentum_i = result.secondaries[0].energy.value()
-                                     * result.secondaries[0].direction[i];
+        real_type gamma_momentum_i = result.secondary.energy.value()
+                                     * result.secondary.direction[i];
         result.direction[i] = inc_momentum_i - gamma_momentum_i;
     }
     normalize_direction(&result.direction);

--- a/src/physics/em/detail/CombinedBremLauncher.hh
+++ b/src/physics/em/detail/CombinedBremLauncher.hh
@@ -9,7 +9,6 @@
 
 #include "base/Assert.hh"
 #include "base/Macros.hh"
-#include "base/StackAllocator.hh"
 #include "base/Types.hh"
 #include "physics/base/ModelData.hh"
 #include "physics/base/ParticleTrackView.hh"
@@ -70,12 +69,10 @@ CELER_FUNCTION void CombinedBremLauncher<M>::operator()(ThreadId tid) const
     const ElementComponentId selected_element{0};
 
     CutoffView cutoffs(model.params.cutoffs, material.material_id());
-    StackAllocator<Secondary> allocate_secondaries(model.states.secondaries);
-    CombinedBremInteractor    interact(shared,
+    CombinedBremInteractor interact(shared,
                                     particle,
                                     model.states.direction[tid],
                                     cutoffs,
-                                    allocate_secondaries,
                                     material_view,
                                     selected_element);
 

--- a/src/physics/em/detail/EPlusGGInteractor.hh
+++ b/src/physics/em/detail/EPlusGGInteractor.hh
@@ -19,9 +19,6 @@
 #include "random/distributions/IsotropicDistribution.hh"
 #include "random/distributions/ReciprocalDistribution.hh"
 #include "EPlusGGData.hh"
-#include "random/distributions/BernoulliDistribution.hh"
-#include "random/distributions/IsotropicDistribution.hh"
-#include "random/distributions/ReciprocalDistribution.hh"
 
 namespace celeritas
 {

--- a/src/physics/em/detail/EPlusGGInteractor.hh
+++ b/src/physics/em/detail/EPlusGGInteractor.hh
@@ -19,6 +19,9 @@
 #include "random/distributions/IsotropicDistribution.hh"
 #include "random/distributions/ReciprocalDistribution.hh"
 #include "EPlusGGData.hh"
+#include "random/distributions/BernoulliDistribution.hh"
+#include "random/distributions/IsotropicDistribution.hh"
+#include "random/distributions/ReciprocalDistribution.hh"
 
 namespace celeritas
 {
@@ -91,9 +94,10 @@ EPlusGGInteractor::EPlusGGInteractor(const EPlusGGData&         shared,
 template<class Engine>
 CELER_FUNCTION Interaction EPlusGGInteractor::operator()(Engine& rng)
 {
-    // Allocate space for two gammas
-    Secondary* secondaries = this->allocate_(2);
-    if (secondaries == nullptr)
+    // Allocate space for one of the photons (the other is preallocated in the
+    // interaction)
+    Secondary* gamma2 = this->allocate_(1);
+    if (gamma2 == nullptr)
     {
         // Failed to allocate space for two secondaries
         return Interaction::from_failure();
@@ -101,22 +105,23 @@ CELER_FUNCTION Interaction EPlusGGInteractor::operator()(Engine& rng)
 
     // Construct an interaction with an absorbed process
     Interaction result = Interaction::from_absorption();
-    result.secondaries = {secondaries, 2};
+    result.secondaries = {gamma2, 1};
+    Secondary* gamma1  = &result.secondary;
 
     // Sample two gammas
-    secondaries[0].particle_id = secondaries[1].particle_id = shared_.gamma_id;
+    gamma1->particle_id = gamma2->particle_id = shared_.gamma_id;
 
     if (inc_energy_ == 0)
     {
         // Save outgoing secondary data
-        secondaries[0].energy = secondaries[1].energy
+        gamma1->energy = gamma2->energy
             = units::MevEnergy{shared_.electron_mass};
 
         IsotropicDistribution<real_type> gamma_dir;
-        secondaries[0].direction = gamma_dir(rng);
+        gamma1->direction = gamma_dir(rng);
         for (int i = 0; i < 3; ++i)
         {
-            secondaries[1].direction[i] = -secondaries[0].direction[i];
+            gamma2->direction[i] = -gamma1->direction[i];
         }
     }
     else
@@ -152,17 +157,17 @@ CELER_FUNCTION Interaction EPlusGGInteractor::operator()(Engine& rng)
         // Sample and save outgoing secondary data
         UniformRealDistribution<real_type> sample_phi(0, 2 * constants::pi);
 
-        secondaries[0].energy = units::MevEnergy{gamma_energy};
-        secondaries[0].direction
+        gamma1->energy = units::MevEnergy{gamma_energy};
+        gamma1->direction
             = rotate(from_spherical(cost, sample_phi(rng)), inc_direction_);
 
-        secondaries[1].energy = units::MevEnergy{total_energy - gamma_energy};
+        gamma2->energy = units::MevEnergy{total_energy - gamma_energy};
         for (int i = 0; i < 3; ++i)
         {
-            secondaries[1].direction[i] = eplus_moment * inc_direction_[i]
-                                          - inc_energy_ * inc_direction_[i];
+            gamma2->direction[i] = eplus_moment * inc_direction_[i]
+                                   - inc_energy_ * inc_direction_[i];
         }
-        normalize_direction(&secondaries[1].direction);
+        normalize_direction(&gamma2->direction);
     }
 
     return result;

--- a/src/physics/em/detail/KleinNishinaLauncher.hh
+++ b/src/physics/em/detail/KleinNishinaLauncher.hh
@@ -45,8 +45,7 @@ struct KleinNishinaLauncher
 template<MemSpace M>
 CELER_FUNCTION void KleinNishinaLauncher<M>::operator()(ThreadId tid) const
 {
-    StackAllocator<Secondary> allocate_secondaries(model.states.secondaries);
-    ParticleTrackView         particle(
+    ParticleTrackView particle(
         model.params.particle, model.states.particle, tid);
 
     PhysicsTrackView physics(model.params.physics,
@@ -59,8 +58,7 @@ CELER_FUNCTION void KleinNishinaLauncher<M>::operator()(ThreadId tid) const
     if (physics.model_id() != kn.model_id)
         return;
 
-    KleinNishinaInteractor interact(
-        kn, particle, model.states.direction[tid], allocate_secondaries);
+    KleinNishinaInteractor interact(kn, particle, model.states.direction[tid]);
 
     RngEngine rng(model.states.rng, tid);
     model.states.interactions[tid] = interact(rng);

--- a/src/physics/em/detail/LivermorePEInteractor.hh
+++ b/src/physics/em/detail/LivermorePEInteractor.hh
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "base/ArrayUtils.hh"
 #include "base/Algorithms.hh"
 #include "base/ArrayUtils.hh"
 #include "base/Macros.hh"

--- a/src/physics/em/detail/MollerBhabhaLauncher.hh
+++ b/src/physics/em/detail/MollerBhabhaLauncher.hh
@@ -9,7 +9,6 @@
 
 #include "base/Assert.hh"
 #include "base/Macros.hh"
-#include "base/StackAllocator.hh"
 #include "base/Types.hh"
 #include "physics/base/CutoffView.hh"
 #include "physics/base/ModelData.hh"
@@ -47,8 +46,7 @@ struct MollerBhabhaLauncher
 template<MemSpace M>
 CELER_FUNCTION void MollerBhabhaLauncher<M>::operator()(ThreadId tid) const
 {
-    StackAllocator<Secondary> allocate_secondaries(model.states.secondaries);
-    ParticleTrackView         particle(
+    ParticleTrackView particle(
         model.params.particle, model.states.particle, tid);
 
     MaterialTrackView material(
@@ -67,7 +65,7 @@ CELER_FUNCTION void MollerBhabhaLauncher<M>::operator()(ThreadId tid) const
     CutoffView cutoff(model.params.cutoffs, material.material_id());
 
     MollerBhabhaInteractor interact(
-        mb, particle, cutoff, model.states.direction[tid], allocate_secondaries);
+        mb, particle, cutoff, model.states.direction[tid]);
 
     RngEngine rng(model.states.rng, tid);
     model.states.interactions[tid] = interact(rng);

--- a/src/physics/em/detail/MuBremsstrahlungLauncher.hh
+++ b/src/physics/em/detail/MuBremsstrahlungLauncher.hh
@@ -9,7 +9,6 @@
 
 #include "base/Assert.hh"
 #include "base/Macros.hh"
-#include "base/StackAllocator.hh"
 #include "base/Types.hh"
 #include "physics/base/ModelData.hh"
 #include "physics/base/ParticleTrackView.hh"
@@ -37,8 +36,8 @@ struct MuBremsstrahlungLauncher
     {
     }
 
-    const MuBremsstrahlungData&     mb;    //!< Shared data for interactor
-    const ModelInteractRef<M>&      model; //!< State data needed to interact
+    const MuBremsstrahlungData& mb;    //!< Shared data for interactor
+    const ModelInteractRef<M>&  model; //!< State data needed to interact
 
     //! Create track views and launch interactor
     inline CELER_FUNCTION void operator()(ThreadId tid) const;
@@ -47,8 +46,7 @@ struct MuBremsstrahlungLauncher
 template<MemSpace M>
 CELER_FUNCTION void MuBremsstrahlungLauncher<M>::operator()(ThreadId tid) const
 {
-    StackAllocator<Secondary> allocate_secondaries(model.states.secondaries);
-    ParticleTrackView         particle(
+    ParticleTrackView particle(
         model.params.particle, model.states.particle, tid);
 
     // Setup for MaterialView access
@@ -71,12 +69,8 @@ CELER_FUNCTION void MuBremsstrahlungLauncher<M>::operator()(ThreadId tid) const
 
     // TODO: sample an element. For now assume one element per material
     const ElementComponentId   elcomp_id{0};
-    MuBremsstrahlungInteractor interact(mb,
-                                        particle,
-                                        model.states.direction[tid],
-                                        allocate_secondaries,
-                                        material_view,
-                                        elcomp_id);
+    MuBremsstrahlungInteractor interact(
+        mb, particle, model.states.direction[tid], material_view, elcomp_id);
 
     RngEngine rng(model.states.rng, tid);
     model.states.interactions[tid] = interact(rng);

--- a/src/physics/em/detail/RelativisticBremLauncher.hh
+++ b/src/physics/em/detail/RelativisticBremLauncher.hh
@@ -9,7 +9,6 @@
 
 #include "base/Assert.hh"
 #include "base/Macros.hh"
-#include "base/StackAllocator.hh"
 #include "base/Types.hh"
 #include "physics/base/ModelData.hh"
 #include "physics/base/ParticleTrackView.hh"
@@ -70,12 +69,10 @@ CELER_FUNCTION void RelativisticBremLauncher<M>::operator()(ThreadId tid) const
     const ElementComponentId selected_element{0};
 
     CutoffView cutoffs(model.params.cutoffs, material.material_id());
-    StackAllocator<Secondary>  allocate_secondaries(model.states.secondaries);
     RelativisticBremInteractor interact(shared,
                                         particle,
                                         model.states.direction[tid],
                                         cutoffs,
-                                        allocate_secondaries,
                                         material_view,
                                         selected_element);
 

--- a/src/physics/em/detail/SeltzerBergerLauncher.hh
+++ b/src/physics/em/detail/SeltzerBergerLauncher.hh
@@ -9,7 +9,6 @@
 
 #include "base/Assert.hh"
 #include "base/Macros.hh"
-#include "base/StackAllocator.hh"
 #include "base/Types.hh"
 #include "physics/base/ModelData.hh"
 #include "physics/base/ParticleTrackView.hh"
@@ -70,12 +69,10 @@ CELER_FUNCTION void SeltzerBergerLauncher<M>::operator()(ThreadId tid) const
     const ElementComponentId selected_element{0};
 
     CutoffView cutoffs(model.params.cutoffs, material.material_id());
-    StackAllocator<Secondary> allocate_secondaries(model.states.secondaries);
-    SeltzerBergerInteractor   interact(sb,
+    SeltzerBergerInteractor interact(sb,
                                      particle,
                                      model.states.direction[tid],
                                      cutoffs,
-                                     allocate_secondaries,
                                      material_view,
                                      selected_element);
 

--- a/src/sim/TrackData.hh
+++ b/src/sim/TrackData.hh
@@ -169,7 +169,13 @@ resize(StateData<Ownership::value, M>*                               data,
 
     resize(&data->step_length, size);
     resize(&data->energy_deposition, size);
-    resize(&data->interactions, size);
+
+    // Initialize empty interactions
+    StateCollection<Interaction, Ownership::value, MemSpace::host> interactions;
+    std::vector<Interaction> initial_state(size, Interaction{});
+    make_builder(&interactions)
+        .insert_back(initial_state.begin(), initial_state.end());
+    data->interactions = interactions;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/detail/LocateAliveLauncher.hh
+++ b/src/sim/detail/LocateAliveLauncher.hh
@@ -70,6 +70,10 @@ CELER_FUNCTION void LocateAliveLauncher<M>::operator()(ThreadId tid) const
 {
     // Count how many secondaries survived cutoffs for each track
     data_.secondary_counts[tid] = 0;
+    if (states_.interactions[tid].secondary)
+    {
+        ++data_.secondary_counts[tid];
+    }
     for (const auto& secondary : states_.interactions[tid].secondaries)
     {
         if (secondary)

--- a/test/physics/InteractorHostTestBase.cc
+++ b/test/physics/InteractorHostTestBase.cc
@@ -154,7 +154,7 @@ void InteractorHostTestBase::check_energy_conservation(
         exit_energy += interaction.energy.value();
     }
 
-    auto accum_secondary = [&exit_energy, this](const Secondary& s) {
+    auto accum_secondary = [&](const Secondary& s) {
         exit_energy += s.energy.value();
 
         // Account for positron production

--- a/test/physics/em/CombinedBrem.test.cc
+++ b/test/physics/em/CombinedBrem.test.cc
@@ -158,9 +158,7 @@ TEST_F(CombinedBremTest, basic_seltzer_berger)
 {
     using celeritas::MaterialView;
 
-    // Reserve 4 secondaries, one for each sample
     const int num_samples = 4;
-    this->resize_secondaries(num_samples);
 
     // Production cuts
     auto material_view = this->material_track().material_view();
@@ -171,7 +169,6 @@ TEST_F(CombinedBremTest, basic_seltzer_berger)
                                     this->particle_track(),
                                     this->direction(),
                                     cutoffs,
-                                    this->secondary_allocator(),
                                     material_view,
                                     ElementComponentId{0});
     RandomEngine&          rng_engine = this->rng();
@@ -181,22 +178,16 @@ TEST_F(CombinedBremTest, basic_seltzer_berger)
     std::vector<double> energy;
 
     // Loop number of samples
-    for (int i : celeritas::range(num_samples))
+    for (CELER_MAYBE_UNUSED int i : celeritas::range(num_samples))
     {
         Interaction result = interact(rng_engine);
         SCOPED_TRACE(result);
         this->sanity_check(result);
 
-        EXPECT_EQ(result.secondaries.data(),
-                  this->secondary_allocator().get().data()
-                      + result.secondaries.size() * i);
-
-        energy.push_back(result.secondaries[0].energy.value());
-        angle.push_back(celeritas::dot_product(
-            result.direction, result.secondaries.front().direction));
+        energy.push_back(result.secondary.energy.value());
+        angle.push_back(celeritas::dot_product(result.direction,
+                                               result.secondary.direction));
     }
-
-    EXPECT_EQ(num_samples, this->secondary_allocator().get().size());
 
     // Note: these are "gold" values based on the host RNG.
     const double expected_angle[] = {0.959441513277674,
@@ -210,21 +201,11 @@ TEST_F(CombinedBremTest, basic_seltzer_berger)
                                       0.106195186929141};
     EXPECT_VEC_SOFT_EQ(expected_energy, energy);
     EXPECT_VEC_SOFT_EQ(expected_angle, angle);
-
-    // Next sample should fail because we're out of secondary buffer space
-    {
-        Interaction result = interact(rng_engine);
-        EXPECT_EQ(0, result.secondaries.size());
-        EXPECT_EQ(celeritas::Action::failed, result.action);
-    }
 }
 
 TEST_F(CombinedBremTest, basic_relativistic_brem)
 {
     const int num_samples = 4;
-
-    // Reserve  num_samples secondaries;
-    this->resize_secondaries(num_samples);
 
     // Production cuts
     auto material_view = this->material_track().material_view();
@@ -238,7 +219,6 @@ TEST_F(CombinedBremTest, basic_relativistic_brem)
                                     this->particle_track(),
                                     this->direction(),
                                     cutoffs,
-                                    this->secondary_allocator(),
                                     material_view,
                                     ElementComponentId{0});
 
@@ -248,22 +228,16 @@ TEST_F(CombinedBremTest, basic_relativistic_brem)
     std::vector<double> angle;
     std::vector<double> energy;
 
-    for (int i : celeritas::range(num_samples))
+    for (CELER_MAYBE_UNUSED int i : celeritas::range(num_samples))
     {
         Interaction result = interact(rng_engine);
         SCOPED_TRACE(result);
         this->sanity_check(result);
 
-        EXPECT_EQ(result.secondaries.data(),
-                  this->secondary_allocator().get().data()
-                      + result.secondaries.size() * i);
-
-        energy.push_back(result.secondaries[0].energy.value());
-        angle.push_back(celeritas::dot_product(
-            result.direction, result.secondaries.back().direction));
+        energy.push_back(result.secondary.energy.value());
+        angle.push_back(celeritas::dot_product(result.direction,
+                                               result.secondary.direction));
     }
-
-    EXPECT_EQ(num_samples, this->secondary_allocator().get().size());
 
     // Note: these are "gold" values based on the host RNG.
 
@@ -277,13 +251,6 @@ TEST_F(CombinedBremTest, basic_relativistic_brem)
 
     EXPECT_VEC_SOFT_EQ(expected_energy, energy);
     EXPECT_VEC_SOFT_EQ(expected_angle, angle);
-
-    // Next sample should fail because we're out of secondary buffer space
-    {
-        Interaction result = interact(rng_engine);
-        EXPECT_EQ(0, result.secondaries.size());
-        EXPECT_EQ(celeritas::Action::failed, result.action);
-    }
 }
 
 TEST_F(CombinedBremTest, stress_test_combined)
@@ -320,7 +287,6 @@ TEST_F(CombinedBremTest, stress_test_combined)
                                          Real3{1, 1, 1}})
             {
                 this->set_inc_direction(inc_dir);
-                this->resize_secondaries(num_samples);
 
                 // Create interactor
                 this->set_inc_particle(particle, MevEnergy{inc_e});
@@ -328,7 +294,6 @@ TEST_F(CombinedBremTest, stress_test_combined)
                                                 this->particle_track(),
                                                 this->direction(),
                                                 cutoffs,
-                                                this->secondary_allocator(),
                                                 material_view,
                                                 ElementComponentId{0});
 
@@ -337,10 +302,8 @@ TEST_F(CombinedBremTest, stress_test_combined)
                 {
                     Interaction result = interact(rng_engine);
                     this->sanity_check(result);
-                    tot_energy_sampled += result.secondaries[0].energy.value();
+                    tot_energy_sampled += result.secondary.energy.value();
                 }
-                EXPECT_EQ(num_samples,
-                          this->secondary_allocator().get().size());
                 num_particles_sampled += num_samples;
             }
             avg_engine_samples.push_back(double(rng_engine.count())

--- a/test/physics/em/EPlusGG.test.cc
+++ b/test/physics/em/EPlusGG.test.cc
@@ -119,7 +119,7 @@ TEST_F(EPlusGGInteractorTest, basic)
 {
     const int num_samples = 4;
 
-    // Reserve  num_samples secondaries;
+    // Reserve num_samples secondaries;
     this->resize_secondaries(num_samples);
 
     // Create the interactor
@@ -182,7 +182,7 @@ TEST_F(EPlusGGInteractorTest, at_rest)
     this->set_inc_particle(pdg::positron(), celeritas::zero_quantity());
     const int num_samples = 4;
 
-    // Reserve  num_samples secondaries;
+    // Reserve num_samples secondaries;
     this->resize_secondaries(num_samples);
 
     // Create the interactor

--- a/test/sim/TrackInit.test.hh
+++ b/test/sim/TrackInit.test.hh
@@ -45,21 +45,30 @@ struct Interactor
         }
 
         // Create secondaries
-        if (alloc_size > 0)
+        if (alloc_size > 1)
         {
-            Secondary* allocated = this->allocate_secondaries(alloc_size);
+            Secondary* allocated = this->allocate_secondaries(alloc_size - 1);
             if (!allocated)
             {
                 return Interaction::from_failure();
             }
 
-            result.secondaries = {allocated, alloc_size};
-            for (auto& secondary : result.secondaries)
-            {
-                secondary.particle_id = ParticleId(0);
-                secondary.energy      = units::MevEnergy(5.);
-                secondary.direction   = {1., 0., 0.};
-            }
+            result.secondaries = {allocated, alloc_size - 1};
+        }
+
+        auto init_secondary = [](Secondary& s) {
+            s.particle_id = ParticleId(0);
+            s.energy      = units::MevEnergy(5.);
+            s.direction   = {1., 0., 0.};
+        };
+
+        if (alloc_size > 0)
+        {
+            init_secondary(result.secondary);
+        }
+        for (Secondary& s : result.secondaries)
+        {
+            init_secondary(s);
         }
 
         return result;


### PR DESCRIPTION
To start exploring performance optimizations for the demo loop (see #284), this preallocates a single secondary for each interaction rather than dynamically allocating all secondaries using the `StackAllocator` with atomic add. While preallocating a secondary improved performance of the demo interactor quite a bit, it seems to have a negative impact overall on the demo loop. It'd be good to have another pair of eyes on this in any case to make sure everything looks correct and perhaps get some more timing results. These are the results for the large hepmc3 input (1000 events, 1000 1 GeV photon primaries per event) on a V100:

![prealloc_secondary](https://user-images.githubusercontent.com/6426426/155074232-4cc18fbd-4906-4232-b562-e9e7f5aba8f0.png)