### PR TITLE
Rename safety to find_safety and add not-implemented ORANGE interface

### DIFF
--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -70,6 +70,9 @@ class OrangeTrackView
     // Find the distance to the next boundary
     inline CELER_FUNCTION real_type find_next_step();
 
+    // Find the nearest (any direction) boundary within the current volume
+    inline CELER_FUNCTION real_type find_safety(const Real3& pos);
+
     // Move to the boundary in preparation for crossing it
     inline CELER_FUNCTION void move_to_boundary();
 
@@ -241,6 +244,15 @@ CELER_FUNCTION real_type OrangeTrackView::find_next_step()
     }
 
     return next_step_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Find the nearest (any direction) boundary within the current volume.
+ */
+CELER_FUNCTION real_type OrangeTrackView::find_safety(const Real3&)
+{
+    CELER_NOT_IMPLEMENTED("safety distance in ORANGE");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -253,6 +253,7 @@ CELER_FUNCTION real_type OrangeTrackView::find_next_step()
 CELER_FUNCTION real_type OrangeTrackView::find_safety(const Real3&)
 {
     CELER_NOT_IMPLEMENTED("safety distance in ORANGE");
+    return 0;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/vecgeom/VecgeomTrackView.hh
+++ b/src/vecgeom/VecgeomTrackView.hh
@@ -70,8 +70,8 @@ class VecgeomTrackView
     // Find the distance to the next boundary
     inline CELER_FUNCTION real_type find_next_step();
 
-    // Find the safety at a given position within the current volumn
-    inline CELER_FUNCTION real_type safety(const Real3& pos) const;
+    // Find the safety at a given position within the current volume
+    inline CELER_FUNCTION real_type find_safety(const Real3& pos);
 
     // Move to the boundary in preparation for crossing it
     inline CELER_FUNCTION void move_to_boundary();
@@ -263,9 +263,9 @@ CELER_FUNCTION real_type VecgeomTrackView::find_next_step()
 
 //---------------------------------------------------------------------------//
 /*!
- * Find the new safety at a given position within the current volumn.
+ * Find the new safety at a given position within the current volume.
  */
-CELER_FUNCTION real_type VecgeomTrackView::safety(const Real3& pos) const
+CELER_FUNCTION real_type VecgeomTrackView::find_safety(const Real3& pos)
 {
 #ifdef VECGEOM_USE_NAVINDEX
     real_type safety = detail::BVHNavigator::ComputeSafety(

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -143,6 +143,11 @@ TEST_F(TwoVolumeTest, simple_track)
     EXPECT_EQ(SurfaceId{}, geo.surface_id());
     EXPECT_FALSE(geo.is_outside());
 
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(geo.find_safety({0.6, 0, 0}), celeritas::DebugError);
+    }
+
     // Try a boundary; second call should be cached
     EXPECT_SOFT_EQ(sqrt_two, geo.find_next_step());
     EXPECT_SOFT_EQ(sqrt_two, geo.find_next_step());

--- a/test/vecgeom/Vecgeom.test.cc
+++ b/test/vecgeom/Vecgeom.test.cc
@@ -244,7 +244,7 @@ TEST_F(FourLevelsTest, safety)
 
         if (!geo.is_outside())
         {
-            safeties.push_back(geo.safety(geo.pos()));
+            safeties.push_back(geo.find_safety(geo.pos()));
         }
     }
 


### PR DESCRIPTION
@whokion I saw you had to disable the UrbanMsc test when vecgeom is disabled, which reminded me that we didn't update the ORANGE interface to have a safety distance. I realized as I was modifying the class that the `safety` method now is really a `find_safety` since it's not a mere accessor, so I'd like to change it to that (and mark it as non-const since it could require the use of temporary state memory to calculate). With this change you should be able to keep your test as `GeoTrackView` but simply disable it from running when vecgeom is disabled (using a mechanism similar to the `_needs_hepmc` in the test/CMakeLists.txt).