### PR TITLE
Optimize geometry tracking

### DIFF
--- a/scripts/cmake-presets/yuri.json
+++ b/scripts/cmake-presets/yuri.json
@@ -47,8 +47,10 @@
       "name": "vecgeom",
       "displayName": "Enable vecgeom",
       "description": "VecGeom and MPI are disabled",
-      "inherits": ["base"],
+      "inherits": [".base"],
       "cacheVariables": {
+        "CELERITAS_USE_MPI":     {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_SWIG":    {"type": "BOOL",   "value": "OFF"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "ON"}
       }
     }

--- a/src/geometry/LinearPropagator.hh
+++ b/src/geometry/LinearPropagator.hh
@@ -55,10 +55,12 @@ CELER_FUNCTION LinearPropagator::LinearPropagator(GeoTrackView* track)
 CELER_FUNCTION
 LinearPropagator::result_type LinearPropagator::operator()()
 {
-    result_type result;
-    result.distance = track_.find_next_step();
-    result.boundary = true;
+    CELER_EXPECT(!track_.is_outside());
+
+    result_type result = track_.find_next_step();
+    CELER_ASSERT(result.boundary);
     track_.move_to_boundary();
+
     return result;
 }
 
@@ -71,18 +73,14 @@ LinearPropagator::result_type LinearPropagator::operator()(real_type dist)
 {
     CELER_EXPECT(dist > 0);
 
-    result_type result;
-    result.boundary = true;
-    result.distance = track_.find_next_step();
+    result_type result = track_.find_next_step(dist);
 
-    if (dist >= result.distance)
+    if (result.boundary)
     {
         track_.move_to_boundary();
     }
     else
     {
-        result.boundary = false;
-        result.distance = dist;
         track_.move_internal(dist);
     }
 

--- a/src/orange/Data.hh
+++ b/src/orange/Data.hh
@@ -75,7 +75,7 @@ struct VolumeRecord
     ItemRange<SurfaceId> faces;
     ItemRange<logic_int> logic;
 
-    logic_int num_intersections{0};
+    logic_int max_intersections{0};
     logic_int flags{0};
 
     //! Flag values (bit field)

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -167,7 +167,7 @@ OrangeParams::OrangeParams(Input input)
         const VolumeRecord& def = host_data.volumes.defs[vol_id];
         max_faces = std::max<size_type>(max_faces, def.faces.size());
         max_intersections
-            = std::max<size_type>(max_intersections, def.num_intersections);
+            = std::max<size_type>(max_intersections, def.max_intersections);
     }
     host_data.scalars.max_faces         = max_faces;
     host_data.scalars.max_intersections = max_intersections;

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -44,8 +44,6 @@ class OrangeTrackView
     inline CELER_FUNCTION OrangeTrackView(const ParamsRef& params,
                                           const StateRef&  states,
                                           ThreadId         tid);
-    // Write out state on destruction
-    inline CELER_FUNCTION ~OrangeTrackView();
 
     // Initialize the state
     inline CELER_FUNCTION OrangeTrackView& operator=(const Initializer_t& init);
@@ -56,13 +54,16 @@ class OrangeTrackView
     //// ACCESSORS ////
 
     //! The current position
-    CELER_FUNCTION const Real3& pos() const { return local_.pos; }
+    CELER_FUNCTION const Real3& pos() const { return states_.pos[thread_]; }
     //! The current direction
-    CELER_FUNCTION const Real3& dir() const { return local_.dir; }
+    CELER_FUNCTION const Real3& dir() const { return states_.dir[thread_]; }
     //! The current volume ID (null if outside)
-    CELER_FUNCTION VolumeId volume_id() const { return local_.volume; }
+    CELER_FUNCTION VolumeId volume_id() const { return states_.vol[thread_]; }
     //! The current surface ID
-    CELER_FUNCTION SurfaceId surface_id() const { return local_.surface.id(); }
+    CELER_FUNCTION SurfaceId surface_id() const
+    {
+        return states_.surf[thread_];
+    }
     // Whether the track is outside the valid geometry region
     CELER_FORCEINLINE_FUNCTION bool is_outside() const;
 
@@ -96,15 +97,16 @@ class OrangeTrackView
     const StateRef&  states_;
     ThreadId         thread_;
 
-    detail::LocalState local_;          //!< Temporary local state
     real_type          next_step_{0};   //!< Temporary next step
     detail::OnSurface  next_surface_{}; //!< Temporary next surface
-    bool dirty_{false}; //!< Whether global params is updated in destructor
 
     //// HELPER FUNCTIONS ////
 
-    // Create local state
-    inline CELER_FUNCTION detail::LocalState make_local() const;
+    // Create local sense reference
+    inline CELER_FUNCTION Span<Sense> make_temp_sense() const;
+
+    // Create local distance
+    inline CELER_FUNCTION detail::TempNextFace make_temp_next() const;
 
     // Whether the next distance-to-boundary has been found
     CELER_FORCEINLINE_FUNCTION bool has_next_step() const;
@@ -129,25 +131,7 @@ OrangeTrackView::OrangeTrackView(const ParamsRef& params,
     CELER_EXPECT(states_);
     CELER_EXPECT(thread < states.size());
 
-    local_ = this->make_local();
-
     CELER_ENSURE(!this->has_next_step());
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Write out state on destruction.
- */
-CELER_FUNCTION OrangeTrackView::~OrangeTrackView()
-{
-    if (dirty_)
-    {
-        states_.pos[thread_]   = local_.pos;
-        states_.dir[thread_]   = local_.dir;
-        states_.vol[thread_]   = local_.volume;
-        states_.surf[thread_]  = local_.surface.id();
-        states_.sense[thread_] = local_.surface.unchecked_sense();
-    }
 }
 
 //---------------------------------------------------------------------------//
@@ -163,19 +147,31 @@ OrangeTrackView::operator=(const Initializer_t& init)
 {
     CELER_EXPECT(is_soft_unit_vector(init.dir));
 
-    local_.pos     = init.pos;
-    local_.dir     = init.dir;
-    local_.volume  = {};
-    local_.surface = {};
+    // Save known data to global memory
+    states_.pos[thread_]   = init.pos;
+    states_.dir[thread_]   = init.dir;
+    states_.surf[thread_]  = {};
+    states_.sense[thread_] = {};
+
+    // Clear local data
     this->clear_next_step();
-    dirty_ = true;
+
+    // Create local state
+    detail::LocalState local;
+    local.pos        = init.pos;
+    local.dir        = init.dir;
+    local.volume     = {};
+    local.surface    = {};
+    local.temp_sense = this->make_temp_sense();
 
     // Initialize logical state
     SimpleUnitTracker tracker(params_);
-    auto              tinit = tracker.initialize(local_);
+    auto              tinit = tracker.initialize(local);
     // TODO: error correction/graceful failure if initialiation failured
     CELER_ASSERT(tinit.volume && !tinit.surface);
-    local_.volume = tinit.volume;
+
+    // Save local data
+    states_.vol[thread_] = tinit.volume;
 
     CELER_ENSURE(!this->has_next_step());
     return *this;
@@ -189,17 +185,17 @@ CELER_FUNCTION
 OrangeTrackView& OrangeTrackView::operator=(const DetailedInitializer& init)
 {
     CELER_EXPECT(is_soft_unit_vector(init.dir));
-    CELER_EXPECT(init.other.local_.volume);
+    CELER_EXPECT(states_.vol[init.other.thread_]);
 
-    // Copy other track's position but update the direction
-    local_.pos     = init.other.local_.pos;
-    local_.dir     = init.dir;
-    local_.volume  = init.other.local_.volume;
-    local_.surface = init.other.local_.surface;
+    // Copy init track's position but update the direction
+    states_.pos[thread_]   = states_.pos[init.other.thread_];
+    states_.dir[thread_]   = init.dir;
+    states_.vol[thread_]   = states_.vol[init.other.thread_];
+    states_.surf[thread_]  = states_.surf[init.other.thread_];
+    states_.sense[thread_] = states_.sense[init.other.thread_];
 
     // Clear step and surface info
     this->clear_next_step();
-    dirty_ = true;
 
     CELER_ENSURE(!this->has_next_step());
     return *this;
@@ -213,8 +209,16 @@ CELER_FUNCTION real_type OrangeTrackView::find_next_step()
 {
     if (!this->has_next_step())
     {
+        detail::LocalState local;
+        local.pos        = states_.pos[thread_];
+        local.dir        = states_.dir[thread_];
+        local.volume     = states_.vol[thread_];
+        local.surface    = {states_.surf[thread_], states_.sense[thread_]};
+        local.temp_sense = this->make_temp_sense();
+        local.temp_next  = this->make_temp_next();
+
         SimpleUnitTracker tracker(params_);
-        auto              isect = tracker.intersect(local_);
+        auto              isect = tracker.intersect(local);
         next_step_              = isect.distance;
         next_surface_           = isect.surface;
     }
@@ -242,11 +246,11 @@ CELER_FUNCTION void OrangeTrackView::move_to_boundary()
     CELER_EXPECT(next_surface_);
 
     // Physically move next step
-    axpy(next_step_, local_.dir, &local_.pos);
+    axpy(next_step_, states_.dir[thread_], &states_.pos[thread_]);
     // Move to the inside of the surface
-    local_.surface = next_surface_;
+    states_.surf[thread_]  = next_surface_.id();
+    states_.sense[thread_] = next_surface_.unchecked_sense();
     this->clear_next_step();
-    dirty_ = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -262,10 +266,9 @@ CELER_FUNCTION void OrangeTrackView::move_internal(real_type dist)
     CELER_EXPECT(dist > 0 && dist < next_step_);
 
     // Move and update next_step_
-    axpy(dist, local_.dir, &local_.pos);
+    axpy(dist, states_.dir[thread_], &states_.pos[thread_]);
     next_step_ -= dist;
-    local_.surface = {};
-    dirty_         = true;
+    states_.surf[thread_] = {};
 }
 
 //---------------------------------------------------------------------------//
@@ -277,10 +280,9 @@ CELER_FUNCTION void OrangeTrackView::move_internal(real_type dist)
  */
 CELER_FUNCTION void OrangeTrackView::move_internal(const Real3& pos)
 {
-    local_.pos     = pos;
-    local_.surface = {};
+    states_.pos[thread_]  = pos;
+    states_.surf[thread_] = {};
     this->clear_next_step();
-    dirty_ = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -291,20 +293,25 @@ CELER_FUNCTION void OrangeTrackView::move_internal(const Real3& pos)
  */
 CELER_FUNCTION void OrangeTrackView::cross_boundary()
 {
-    CELER_EXPECT(local_.surface);
+    CELER_EXPECT(this->surface_id());
     CELER_EXPECT(!this->has_next_step());
 
     // Flip current sense from "before crossing" to "after"
-    local_.surface.flip_sense();
+    detail::LocalState local;
+    local.pos     = this->pos();
+    local.dir     = this->dir();
+    local.volume  = states_.vol[thread_];
+    local.surface = {states_.surf[thread_], flip_sense(states_.sense[thread_])};
+    local.temp_sense = this->make_temp_sense();
 
     // Update the post-crossing volume
     SimpleUnitTracker tracker(params_);
-    auto              init = tracker.initialize(local_);
+    auto              init = tracker.initialize(local);
     // TODO: error correction/graceful failure if initialization failed
     CELER_ASSERT(init.volume);
-    local_.volume  = init.volume;
-    local_.surface = init.surface;
-    dirty_         = true;
+    states_.vol[thread_]   = init.volume;
+    states_.surf[thread_]  = init.surface.id();
+    states_.sense[thread_] = init.surface.unchecked_sense();
 }
 
 //---------------------------------------------------------------------------//
@@ -317,9 +324,8 @@ CELER_FUNCTION void OrangeTrackView::cross_boundary()
 CELER_FUNCTION void OrangeTrackView::set_dir(const Real3& newdir)
 {
     CELER_EXPECT(is_soft_unit_vector(newdir));
-    local_.dir = newdir;
+    states_.dir[thread_] = newdir;
     this->clear_next_step();
-    dirty_ = true;
 }
 
 //---------------------------------------------------------------------------//
@@ -330,7 +336,7 @@ CELER_FUNCTION bool OrangeTrackView::is_outside() const
 {
     // Zeroth volume in outermost universe is always the exterior by
     // construction in ORANGE
-    return local_.volume == VolumeId{0};
+    return states_.vol[thread_] == VolumeId{0};
 }
 
 //---------------------------------------------------------------------------//
@@ -339,46 +345,36 @@ CELER_FUNCTION bool OrangeTrackView::is_outside() const
 /*!
  * Get a reference to the current volume, or to world volume if outside.
  */
-CELER_FUNCTION detail::LocalState OrangeTrackView::make_local() const
+CELER_FUNCTION Span<Sense> OrangeTrackView::make_temp_sense() const
 {
-    detail::LocalState result;
+    const auto max_faces = params_.scalars.max_faces;
+    auto       offset    = thread_.get() * max_faces;
+    return states_.temp_sense[AllItems<Sense, MemSpace::native>{}].subspan(
+        offset, max_faces);
+}
 
-    // Set up basic local data
-    result.pos     = states_.pos[thread_];
-    result.dir     = states_.dir[thread_];
-    result.volume  = states_.vol[thread_];
-    result.surface = {states_.surf[thread_], states_.sense[thread_]};
+//---------------------------------------------------------------------------//
+/*!
+ * Set up intersection scratch space.
+ */
+CELER_FUNCTION detail::TempNextFace OrangeTrackView::make_temp_next() const
+{
+    const auto max_isect = params_.scalars.max_intersections;
+    auto       offset    = thread_.get() * max_isect;
 
-    // Set up sense scratch space
-    // TODO: experiment with making this 'lazy'?
-    {
-        const auto max_faces = params_.scalars.max_faces;
-        auto       offset    = thread_.get() * max_faces;
-        result.temp_sense
-            = states_.temp_sense[AllItems<Sense, MemSpace::native>{}].subspan(
-                offset, max_faces);
-    }
-
-    // Set up intersection scratch space
-    {
-        const auto max_isect = params_.scalars.max_intersections;
-        auto       offset    = thread_.get() * max_isect;
-
-        result.temp_next.face = states_.temp_face[AllItems<FaceId>{}].data()
-                                + offset;
-        result.temp_next.distance
-            = states_.temp_distance[AllItems<real_type>{}].data() + offset;
-        result.temp_next.isect
-            = states_.temp_isect[AllItems<size_type>{}].data() + offset;
-        result.temp_next.size = max_isect;
-    }
+    detail::TempNextFace result;
+    result.face     = states_.temp_face[AllItems<FaceId>{}].data() + offset;
+    result.distance = states_.temp_distance[AllItems<real_type>{}].data()
+                      + offset;
+    result.isect = states_.temp_isect[AllItems<size_type>{}].data() + offset;
+    result.size  = max_isect;
 
     return result;
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Get a reference to the current volume, or to world volume if outside.
+ * Whether the next step has been calculated.
  */
 CELER_FUNCTION bool OrangeTrackView::has_next_step() const
 {

--- a/src/orange/construct/VolumeInput.hh
+++ b/src/orange/construct/VolumeInput.hh
@@ -27,8 +27,8 @@ struct VolumeInput
     //! RPN region definition for this cell, using local surface index
     std::vector<logic_int> logic{};
 
-    //! Total number of surface intersections possible in this volume
-    logic_int num_intersections{0};
+    //! Maximum possible number of surface intersections in this volume
+    logic_int max_intersections{0};
     //! Special flags
     logic_int flags{0};
 

--- a/src/orange/construct/VolumeInputIO.json.cc
+++ b/src/orange/construct/VolumeInputIO.json.cc
@@ -98,7 +98,7 @@ void from_json(const nlohmann::json& j, VolumeInput& value)
     value.logic     = parse_logic(temp_logic.c_str());
 
     // Read scalars, including optional flags
-    j.at("num_intersections").get_to(value.num_intersections);
+    j.at("num_intersections").get_to(value.max_intersections);
     auto flag_iter = j.find("flags");
     value.flags    = (flag_iter == j.end() ? 0 : flag_iter->get<int>());
 }

--- a/src/orange/construct/VolumeInserter.cc
+++ b/src/orange/construct/VolumeInserter.cc
@@ -95,7 +95,7 @@ VolumeId VolumeInserter::operator()(const VolumeInput& input)
     VolumeRecord output;
     output.faces = faces.insert_back(input.faces.begin(), input.faces.end());
     output.logic = logic.insert_back(input.logic.begin(), input.logic.end());
-    output.num_intersections = input.num_intersections;
+    output.max_intersections = input.max_intersections;
     output.flags             = input.flags;
     defs.push_back(output);
 

--- a/src/orange/surfaces/detail/QuadraticSolver.hh
+++ b/src/orange/surfaces/detail/QuadraticSolver.hh
@@ -68,7 +68,7 @@ class QuadraticSolver
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Find all nonnegative roots for general quadric surfaces.
+ * Find all positive roots for general quadric surfaces.
  *
  * This is used for cones, simple quadrics, and general quadrics.
  */
@@ -112,7 +112,7 @@ CELER_FUNCTION QuadraticSolver::QuadraticSolver(real_type a, real_type half_b)
 
 //---------------------------------------------------------------------------//
 /*!
- * Find all nonnegative roots of x^2 + (b/a)*x + (c/a) = 0.
+ * Find all positive roots of x^2 + (b/a)*x + (c/a) = 0.
  *
  * In this case, the quadratic formula can be written as: \f[
    x = -b/2 \pm \sqrt{(b/2)^2 - c}.
@@ -139,15 +139,15 @@ CELER_FUNCTION auto QuadraticSolver::operator()(real_type c) const
         result[0]    = -hba_ - t2;
         result[1]    = -hba_ + t2;
 
-        if (result[1] < 0)
+        if (result[1] <= 0)
         {
-            // Both are negative
+            // Both are nonpositive
             result[0] = no_intersection();
             result[1] = no_intersection();
         }
-        else if (result[0] < 0)
+        else if (result[0] <= 0)
         {
-            // Only first is negative
+            // Only first is nonpositive
             result[0] = no_intersection();
         }
     }
@@ -157,7 +157,7 @@ CELER_FUNCTION auto QuadraticSolver::operator()(real_type c) const
         result[0] = -hba_;
         result[1] = no_intersection();
 
-        if (result[0] < 0)
+        if (result[0] <= 0)
         {
             result[0] = no_intersection();
         }
@@ -173,9 +173,10 @@ CELER_FUNCTION auto QuadraticSolver::operator()(real_type c) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Solve degenerate case (known to be on surface).
+ * Solve degenerate case (known to be "on" surface).
  *
- * Since x = 0 is a root, then c = 0 and x = -b is the other root.
+ * Since x = 0 is a root, then c = 0 and x = -b is the other root. This will be
+ * inaccurate if a particle is logically on a surface but not physically on it.
  */
 CELER_FUNCTION auto QuadraticSolver::operator()() const -> Intersections
 {

--- a/src/orange/universes/SimpleUnitTracker.hh
+++ b/src/orange/universes/SimpleUnitTracker.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "base/Algorithms.hh"
 #include "orange/Data.hh"
 #include "orange/surfaces/Surfaces.hh"
 
@@ -189,7 +190,7 @@ SimpleUnitTracker::simple_intersect(const LocalState& state,
         const real_type* distance_ptr = celeritas::min_element(
             state.temp_next.distance,
             state.temp_next.distance + vol.num_intersections(),
-            detail::CloserPositiveDistance{});
+            Less<real_type>{});
         CELER_ASSERT(*distance_ptr > 0);
         distance_idx = distance_ptr - state.temp_next.distance;
     }
@@ -249,11 +250,11 @@ SimpleUnitTracker::complex_intersect(const LocalState& state,
 {
     // Partition intersections (enumerated from 0 as the `idx` array) into
     // valid (finite positive) and invalid (infinite-or-negative) groups.
-    size_type num_isect = celeritas::partition(
-                              state.temp_next.isect,
-                              state.temp_next.isect + vol.num_intersections(),
-                              detail::IntersectionPartitioner{state.temp_next})
-                          - state.temp_next.isect;
+    size_type num_isect
+        = celeritas::partition(state.temp_next.isect,
+                               state.temp_next.isect + vol.num_intersections(),
+                               detail::IsIntersectionFinite{state.temp_next})
+          - state.temp_next.isect;
     CELER_ASSERT(num_isect <= vol.num_intersections());
 
     // Sort these finite distances in ascending order

--- a/src/orange/universes/SimpleUnitTracker.hh
+++ b/src/orange/universes/SimpleUnitTracker.hh
@@ -180,7 +180,12 @@ SimpleUnitTracker::intersect(const LocalState& state, real_type max_dist) const
  *   user-supplied maximum). The buffer contains the distances, the face
  *   indices, and an index used for sorting (if the volume has internal
  *   surfaes).
- * - If no valid surfaces are found,
+ * - If no intersecting surfaces are found, return immediately. (Rely on the
+ *   caller to set the "maximum distance" if we're not searching to infinity.)
+ * - If the volume has no internal surfaces, find the closest one by calling \c
+ *   simple_intersect.
+ * - Otherwise, the volume has internal surfaces and we call \c
+ *   complex_intersect.
  */
 template<class F>
 CELER_FUNCTION auto

--- a/src/orange/universes/VolumeView.hh
+++ b/src/orange/universes/VolumeView.hh
@@ -71,7 +71,7 @@ class VolumeView
     CELER_FORCEINLINE_FUNCTION logic_int flags() const;
 
     // Get the number of total intersections
-    CELER_FORCEINLINE_FUNCTION logic_int num_intersections() const;
+    CELER_FORCEINLINE_FUNCTION logic_int max_intersections() const;
 
   private:
     const VolumeDataRef& params_;
@@ -167,11 +167,11 @@ CELER_FUNCTION logic_int VolumeView::flags() const
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the number of total intersections.
+ * Get the maximum number of surface intersections.
  */
-CELER_FUNCTION logic_int VolumeView::num_intersections() const
+CELER_FUNCTION logic_int VolumeView::max_intersections() const
 {
-    return def_.num_intersections;
+    return def_.max_intersections;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/universes/detail/SurfaceFunctors.hh
+++ b/src/orange/universes/detail/SurfaceFunctors.hh
@@ -134,7 +134,7 @@ class CalcIntersections
         // Copy possible intersections and this surface to the output
         for (real_type dist : all_dist)
         {
-            CELER_ASSERT(dist >= 0);
+            CELER_ASSERT(dist > 0);
             face_[isect_idx_]     = FaceId{face_idx_};
             distance_[isect_idx_] = dist;
             if (fill_isect_)

--- a/src/orange/universes/detail/SurfaceFunctors.hh
+++ b/src/orange/universes/detail/SurfaceFunctors.hh
@@ -108,7 +108,7 @@ class CalcIntersections
     //! Construct from the particle point, direction, face ID, and temp storage
     CELER_FUNCTION CalcIntersections(const Real3&        pos,
                                      const Real3&        dir,
-                                     const IsValid&      is_valid_isect,
+                                     IsValid             is_valid_isect,
                                      FaceId              on_face,
                                      bool                is_simple,
                                      const TempNextFace& next_face)

--- a/src/orange/universes/detail/Types.hh
+++ b/src/orange/universes/detail/Types.hh
@@ -110,7 +110,10 @@ struct Intersection
     real_type distance = no_intersection();
 
     //! Whether a next surface has been found
-    explicit operator bool() const { return static_cast<bool>(surface); }
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return static_cast<bool>(surface);
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/universes/detail/Utils.hh
+++ b/src/orange/universes/detail/Utils.hh
@@ -27,12 +27,8 @@ namespace detail
  */
 struct IsIntersectionFinite
 {
-    const TempNextFace& temp_next;
-
-    CELER_FUNCTION bool operator()(size_type isect) const
+    CELER_FUNCTION bool operator()(real_type distance) const
     {
-        CELER_ASSERT(isect < temp_next.size);
-        const real_type distance = temp_next.distance[isect];
         return distance < numeric_limits<real_type>::max();
     }
 };

--- a/src/orange/universes/detail/Utils.hh
+++ b/src/orange/universes/detail/Utils.hh
@@ -10,6 +10,7 @@
 #include <cmath>
 
 #include "base/Macros.hh"
+#include "base/NumericLimits.hh"
 
 #include "../VolumeView.hh"
 #include "Types.hh"
@@ -22,28 +23,9 @@ namespace detail
 // FUNCTION-LIKE CLASSES
 //---------------------------------------------------------------------------//
 /*!
- * Predicate for finding the closest valid (strictly positive) distance.
- *
- * \todo Changing the QuadraticSolver class to return only positive
- * intersections should allow us to replace this with a simple less-than
- * comparator.
- */
-struct CloserPositiveDistance
-{
-    CELER_CONSTEXPR_FUNCTION bool operator()(real_type a, real_type b) const
-    {
-        return a > 0 && (b <= 0 || a < b);
-    }
-};
-
-//---------------------------------------------------------------------------//
-/*!
  * Predicate for partitioning valid (finite positive) from invalid distances.
- *
- * \todo See above, and if we add a "maximum distance" to the intersection
- * lookup, then we can perhaps change to `return distance < max_dist`.
  */
-struct IntersectionPartitioner
+struct IsIntersectionFinite
 {
     const TempNextFace& temp_next;
 
@@ -51,7 +33,7 @@ struct IntersectionPartitioner
     {
         CELER_ASSERT(isect < temp_next.size);
         const real_type distance = temp_next.distance[isect];
-        return distance > 0 && !std::isinf(distance);
+        return distance < numeric_limits<real_type>::max();
     }
 };
 

--- a/test/field/FieldPropagator.test.cc
+++ b/test/field/FieldPropagator.test.cc
@@ -148,7 +148,7 @@ TEST_F(FieldPropagatorHostTest, field_propagator_host)
         beg_state.pos = {test.radius, -10, i * 1.0e-6};
 
         // Check GeoTrackView
-        EXPECT_SOFT_EQ(5.5, geo_track.find_next_step());
+        EXPECT_SOFT_EQ(5.5, geo_track.find_next_step().distance);
 
         // Construct FieldPropagator
         RKTraits::Propagator_t propagate(particle_track, &geo_track, &driver);
@@ -207,7 +207,7 @@ TEST_F(FieldPropagatorHostTest, boundary_crossing_host)
         geo_track      = {{test.radius, 0, i * 1.0e-6}, {0, 1, 0}};
         particle_track = Initializer_t{ParticleId{0}, MevEnergy{test.energy}};
 
-        EXPECT_SOFT_EQ(0.5, geo_track.find_next_step());
+        EXPECT_SOFT_EQ(0.5, geo_track.find_next_step().distance);
 
         // Construct FieldPropagator
         RKTraits::Propagator_t propagate(particle_track, &geo_track, &driver);

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -126,7 +126,7 @@ void OrangeGeoTestBase::build_geometry(TwoVolInput inp)
         {
             VolumeInput vi;
             vi.faces             = {SurfaceId{0}};
-            vi.num_intersections = 2;
+            vi.max_intersections = 2;
 
             // Outside
             vi.logic = {0};

--- a/test/orange/universes/SimpleUnitTracker.test.cc
+++ b/test/orange/universes/SimpleUnitTracker.test.cc
@@ -318,55 +318,6 @@ void SimpleUnitTrackerTest::HeuristicInitResult::print_expected() const
 }
 
 //---------------------------------------------------------------------------//
-// UTILITY TESTS
-//---------------------------------------------------------------------------//
-
-class UtilsTest : public celeritas::Test
-{
-};
-
-TEST_F(UtilsTest, infinite_intersection_partitioner)
-{
-    std::vector<real_type> distance = {1.25, 3, no_intersection(), 5};
-    std::vector<FaceId>    face(distance.size(), FaceId{});
-    std::vector<size_type> isect(distance.size());
-
-    // Fill intersection IDs 0..N-1
-    std::iota(isect.begin(), isect.end(), 0);
-
-    // Construct temp next face
-    celeritas::detail::TempNextFace temp_next;
-    temp_next.face     = face.data();
-    temp_next.distance = distance.data();
-    temp_next.isect    = isect.data();
-    temp_next.size     = isect.size();
-
-    // Test on all entries
-    celeritas::detail::IsIntersectionFinite is_valid{temp_next};
-    {
-        std::vector<int> result;
-        for (size_type i : isect)
-        {
-            result.push_back(is_valid(i));
-        }
-        static const int expected_result[] = {1, 1, 0, 1};
-        EXPECT_VEC_EQ(expected_result, result);
-    }
-
-    // Partition so valid indices are first
-    {
-        auto iter = std::partition(isect.begin(), isect.end(), is_valid);
-        EXPECT_EQ(3, iter - isect.begin());
-
-        // Erase invalid and sort valid to avoid implementation dependence
-        isect.erase(iter, isect.end());
-        std::sort(isect.begin(), isect.end());
-        static const unsigned int expected_isect[] = {0, 1, 3};
-        EXPECT_VEC_EQ(expected_isect, isect);
-    }
-}
-
-//---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
 

--- a/test/orange/universes/SimpleUnitTracker.test.cc
+++ b/test/orange/universes/SimpleUnitTracker.test.cc
@@ -325,26 +325,9 @@ class UtilsTest : public celeritas::Test
 {
 };
 
-TEST_F(UtilsTest, closer_nonzero_distance)
+TEST_F(UtilsTest, infinite_intersection_partitioner)
 {
-    detail::CloserPositiveDistance is_closer;
-
-    // Equal
-    EXPECT_FALSE(is_closer(0.0, 0.0));
-    EXPECT_FALSE(is_closer(1.0, 1.0));
-
-    // Positive vs nonpositive
-    EXPECT_FALSE(is_closer(-0.0001, 1.0));
-    EXPECT_FALSE(is_closer(0.0, 1.0));
-    EXPECT_TRUE(is_closer(1.0, 0.0));
-
-    // Positive vs positive
-    EXPECT_TRUE(is_closer(1.0, 20.0));
-}
-
-TEST_F(UtilsTest, intersection_partitioner)
-{
-    std::vector<real_type> distance = {1.25, -1e-16, 3, 0, inf, 5};
+    std::vector<real_type> distance = {1.25, 3, no_intersection(), 5};
     std::vector<FaceId>    face(distance.size(), FaceId{});
     std::vector<size_type> isect(distance.size());
 
@@ -359,14 +342,14 @@ TEST_F(UtilsTest, intersection_partitioner)
     temp_next.size     = isect.size();
 
     // Test on all entries
-    celeritas::detail::IntersectionPartitioner is_valid{temp_next};
+    celeritas::detail::IsIntersectionFinite is_valid{temp_next};
     {
         std::vector<int> result;
         for (size_type i : isect)
         {
             result.push_back(is_valid(i));
         }
-        static const int expected_result[] = {1, 0, 1, 0, 0, 1};
+        static const int expected_result[] = {1, 1, 0, 1};
         EXPECT_VEC_EQ(expected_result, result);
     }
 
@@ -378,7 +361,7 @@ TEST_F(UtilsTest, intersection_partitioner)
         // Erase invalid and sort valid to avoid implementation dependence
         isect.erase(iter, isect.end());
         std::sort(isect.begin(), isect.end());
-        static const unsigned int expected_isect[] = {0, 2, 5};
+        static const unsigned int expected_isect[] = {0, 1, 3};
         EXPECT_VEC_EQ(expected_isect, isect);
     }
 }

--- a/test/orange/universes/SimpleUnitTracker.test.cc
+++ b/test/orange/universes/SimpleUnitTracker.test.cc
@@ -343,6 +343,10 @@ TEST_F(OneVolumeTest, intersect)
         auto isect = tracker.intersect(state);
         EXPECT_FALSE(isect);
         EXPECT_EQ(no_intersection(), isect.distance);
+
+        isect = tracker.intersect(state, 5.0);
+        EXPECT_FALSE(isect);
+        EXPECT_EQ(5.0, isect.distance);
     }
 }
 
@@ -432,6 +436,25 @@ TEST_F(TwoVolumeTest, intersect)
         EXPECT_EQ(SurfaceId{0}, isect.surface.id());
         EXPECT_EQ(Sense::inside, isect.surface.unchecked_sense());
         EXPECT_SOFT_EQ(1.0, isect.distance);
+
+        // Range limit: further than surface
+        isect = tracker.intersect(state, 10.0);
+        EXPECT_TRUE(isect);
+        EXPECT_EQ(SurfaceId{0}, isect.surface.id());
+        EXPECT_EQ(Sense::inside, isect.surface.unchecked_sense());
+        EXPECT_SOFT_EQ(1.0, isect.distance);
+
+        // Coincident
+        isect = tracker.intersect(state, 1.0);
+        EXPECT_TRUE(isect);
+        EXPECT_EQ(SurfaceId{0}, isect.surface.id());
+        EXPECT_EQ(Sense::inside, isect.surface.unchecked_sense());
+        EXPECT_SOFT_EQ(1.0, isect.distance);
+
+        // Range limit: less than
+        isect = tracker.intersect(state, 0.9);
+        EXPECT_FALSE(isect);
+        EXPECT_SOFT_EQ(0.9, isect.distance);
     }
     {
         SCOPED_TRACE("Outside");
@@ -661,6 +684,20 @@ TEST_F(FiveVolumesTest, intersect)
         EXPECT_EQ("outer.s", this->id_to_label(isect.surface.id()));
         EXPECT_EQ(Sense::inside, isect.surface.unchecked_sense());
         EXPECT_SOFT_EQ(101.04503395088592, isect.distance);
+
+        isect = tracker.intersect(state, 105.0);
+        EXPECT_TRUE(isect);
+        EXPECT_EQ("outer.s", this->id_to_label(isect.surface.id()));
+        EXPECT_EQ(Sense::inside, isect.surface.unchecked_sense());
+        EXPECT_SOFT_EQ(101.04503395088592, isect.distance);
+
+        isect = tracker.intersect(state, 100.0);
+        EXPECT_FALSE(isect);
+        EXPECT_SOFT_EQ(100.0, isect.distance);
+
+        isect = tracker.intersect(state, 1e-12);
+        EXPECT_FALSE(isect);
+        EXPECT_SOFT_EQ(1e-12, isect.distance);
     }
 }
 

--- a/test/vecgeom/Vecgeom.test.cc
+++ b/test/vecgeom/Vecgeom.test.cc
@@ -240,6 +240,9 @@ TEST_F(FourLevelsTest, tracking)
 
 TEST_F(FourLevelsTest, safety)
 {
+#ifndef VECGEOM_USE_NAVINDEX
+    GTEST_SKIP() << "Safety distances don't work";
+#endif
     VecgeomTrackView       geo = this->make_geo_track_view();
     std::vector<real_type> safeties;
 

--- a/test/vecgeom/Vecgeom.test.cc
+++ b/test/vecgeom/Vecgeom.test.cc
@@ -83,8 +83,9 @@ auto VecgeomTest::track(const Real3& pos, const Real3& dir) -> TrackingResult
     {
         // Initial step is outside but may approach insidfe
         result.volumes.push_back("[OUTSIDE]");
-        result.distances.push_back(geo.find_next_step());
-        if (result.distances.back() < 1e20)
+        auto next = geo.find_next_step();
+        result.distances.push_back(next.distance);
+        if (next.boundary)
         {
             geo.move_to_boundary();
             geo.cross_boundary();
@@ -94,7 +95,15 @@ auto VecgeomTest::track(const Real3& pos, const Real3& dir) -> TrackingResult
     while (!geo.is_outside())
     {
         result.volumes.push_back(params.id_to_label(geo.volume_id()));
-        result.distances.push_back(geo.find_next_step());
+        auto next = geo.find_next_step();
+        result.distances.push_back(next.distance);
+        if (!next.boundary)
+        {
+            // Failure to find the next boundary while inside the geomtery
+            ADD_FAILURE();
+            result.volumes.push_back("[NO INTERCEPT]");
+            break;
+        }
         geo.move_to_boundary();
         geo.cross_boundary();
     }
@@ -134,6 +143,41 @@ TEST_F(FourLevelsTest, accessors)
     EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{1}));
     EXPECT_EQ("Envelope", geom.id_to_label(VolumeId{2}));
     EXPECT_EQ("World", geom.id_to_label(VolumeId{3}));
+}
+
+//---------------------------------------------------------------------------//
+
+TEST_F(FourLevelsTest, detailed_track)
+{
+    VecgeomTrackView geo = this->make_geo_track_view();
+    geo                  = GeoTrackInitializer{{-10, -10, -10}, {1, 0, 0}};
+    EXPECT_EQ(VolumeId{0}, geo.volume_id());
+
+    // Check for surfaces up to a distance of 4 units away
+    auto next = geo.find_next_step(4.0);
+    EXPECT_SOFT_EQ(4.0, next.distance);
+    EXPECT_FALSE(next.boundary);
+    next = geo.find_next_step(4.0);
+    EXPECT_SOFT_EQ(4.0, next.distance);
+    EXPECT_FALSE(next.boundary);
+    geo.move_internal(3.5);
+
+    // Find one a bit further, then cross it
+    next = geo.find_next_step(4.0);
+    EXPECT_SOFT_EQ(1.5, next.distance);
+    EXPECT_TRUE(next.boundary);
+    geo.move_to_boundary();
+    EXPECT_EQ(VolumeId{0}, geo.volume_id());
+    geo.cross_boundary();
+    EXPECT_EQ(VolumeId{1}, geo.volume_id());
+
+    // Find the next boundary up to infinity
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(1.0, next.distance);
+    EXPECT_TRUE(next.boundary);
+    next = geo.find_next_step(0.5);
+    EXPECT_SOFT_EQ(0.5, next.distance);
+    EXPECT_FALSE(next.boundary);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/vecgeom/Vecgeom.test.cu
+++ b/test/vecgeom/Vecgeom.test.cu
@@ -41,8 +41,8 @@ __global__ void vgg_test_kernel(const GeoParamsCRefDevice  params,
     for (int seg = 0; seg < max_segments; ++seg)
     {
         // Move next step
-        real_type dist = geo.find_next_step();
-        if (dist < 1e20)
+        auto next = geo.find_next_step();
+        if (next.boundary)
         {
             geo.move_to_boundary();
             geo.cross_boundary();
@@ -53,7 +53,7 @@ __global__ void vgg_test_kernel(const GeoParamsCRefDevice  params,
             = (geo.is_outside()
                    ? -2
                    : static_cast<int>(geo.volume_id().unchecked_get()));
-        distances[tid.get() * max_segments + seg] = dist;
+        distances[tid.get() * max_segments + seg] = next.distance;
 
         if (geo.is_outside())
             break;


### PR DESCRIPTION
The key changes are:
- ORANGE no longer stores a local copy of the thread state; it accesses directly from global memory
- A new "find_distance" method with a maximum step length has been implemented for both VecGeom and ORANGE
- ORANGE quadrics no longer return intercepts of zero, simplifying some logic for removing invalid intersections
- In the ORANGE intersection method, instead of saving all distances and then later removing  the infinite ones, we now only save the finite (or "nearby" if calling with maximum step length) ones
- The find methods now return `Propagation` to indicate if a boundary was encountered.

Removing the local copy of the thread state substantially reduced register pressure (especially on Crusher) and improves occupancy on wildstyle's `process_interactions` and `process_secondaries`.

![kernel-mem-machine](https://user-images.githubusercontent.com/741229/155851825-0522d80b-7420-447d-a1d2-524b7eb00174.png)
![kernel-occupancy-machine](https://user-images.githubusercontent.com/741229/155851839-d9a04d0a-ca7c-4a24-ae4d-3d7d8d658524.png)

The `find_distance` method and ORANGE intersection improvement *substantially* improves geometry performance -- the field propagator test ran incredibly fast compared to master (up to a factor of 5 improvement but the test is so short). Although between these optimizations Wildstyle improved by overall only 6%, Crusher performance improved by 25%.

The change to the propagation interface removes a couple of goofy use cases like `if (distance < 1e20)` in tests.