### PR TITLE
Add ctest labels, minor tweaks

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -63,8 +63,7 @@
       "cacheVariables": {
         "CELERITAS_USE_CUDA":       {"type": "BOOL",   "value": "ON"},
         "CMAKE_CUDA_ARCHITECTURES": {"type": "STRING", "value": "70"},
-        "CMAKE_CUDA_FLAGS": "-Werror all-warnings",
-        "CMAKE_CUDA_FLAGS_RELEASE": "--use_fast_math -O3 -DNDEBUG"
+        "CMAKE_CUDA_FLAGS": "-Werror all-warnings"
       }
     },
     {
@@ -73,7 +72,9 @@
       "description": "Disable debug mode",
       "cacheVariables": {
         "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "OFF"},
-        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "Release"}
+        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "Release"},
+        "CMAKE_CUDA_FLAGS_RELEASE": "--use_fast_math -O3 -DNDEBUG",
+        "CMAKE_HIP_FLAGS_RELEASE": "-ffast-math -O3 -DNDEBUG"
       }
     },
     {

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -68,6 +68,7 @@ if(CELERITAS_USE_Geant4 AND CELERITAS_USE_ROOT)
     set_tests_properties("app/geant-exporter" PROPERTIES
       ENVIRONMENT "${_geant_test_env}"
       REQUIRED_FILES "${_geant_test_inp}"
+      LABELS "app"
     )
 
     add_test(NAME "app/geant-exporter-cat"
@@ -77,6 +78,7 @@ if(CELERITAS_USE_Geant4 AND CELERITAS_USE_ROOT)
     set_tests_properties("app/geant-exporter-cat" PROPERTIES
       DEPENDS "app/geant-exporter"
       REQUIRED_FILES "test-data.root"
+      LABELS "app"
     )
   endif()
 endif()
@@ -134,6 +136,7 @@ if(CELERITAS_BUILD_DEMOS)
         ENVIRONMENT "${_env}"
         RESOURCE_LOCK gpu
         REQUIRED_FILES "${_driver}"
+        LABELS "app;nomemcheck;gpu"
         ${_disabled_unless_python}
       )
     endif()
@@ -163,6 +166,7 @@ if(CELERITAS_BUILD_DEMOS)
       ENVIRONMENT "${_env}"
       REQUIRED_FILES "${_driver}"
       ${_disabled_unless_python}
+      LABELS "app;nomemcheck"
     )
   endif()
 endif()
@@ -199,6 +203,7 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
       ENVIRONMENT "${_env}"
       RESOURCE_LOCK gpu
       REQUIRED_FILES "${_driver};${_gdml_inp}"
+      LABELS "app;nomemcheck;gpu"
     )
   endif()
 endif()
@@ -285,6 +290,7 @@ if(CELERITAS_BUILD_DEMOS)
       ENVIRONMENT "${_env};${_geant_test_env}"
       RESOURCE_LOCK gpu
       REQUIRED_FILES "${_driver};${_gdml_inp};${_hepmc3_inp}"
+      LABELS "app;nomemcheck;gpu"
     )
 
     # Disable test when prereqs are not available or for debug builds
@@ -319,6 +325,7 @@ if(CELERITAS_BUILD_DEMOS)
     set_tests_properties("app/demo-loop-cpu" PROPERTIES
       ENVIRONMENT "${_env};${_geant_test_env}"
       REQUIRED_FILES "${_driver};${_gdml_inp};${_hepmc3_inp}"
+      LABELS "app;nomemcheck"
     )
     if(NOT (CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
        OR NOT CELERITAS_USE_Geant4

--- a/scripts/cmake-presets/ci.json
+++ b/scripts/cmake-presets/ci.json
@@ -115,6 +115,6 @@
     {"name": "full-novg-ndebug", "configurePreset": "full-novg-ndebug", "inherits": "base"},
     {"name": "valgrind"        , "configurePreset": "valgrind"        , "inherits": "base"},
     {"name": "vecgeom-tests"   , "configurePreset": "vecgeom-tests"   , "inherits": "base"},
-    {"name": "vecgeom-demos"   , "configurePreset": "vecgeom-demos"   , "inherits": "base", "filter": {"include": {"name": "app/"}}}
+    {"name": "vecgeom-demos"   , "configurePreset": "vecgeom-demos"   , "inherits": "base", "filter": {"include": {"label": "app"}}}
   ]
 }

--- a/scripts/cmake-presets/crusher.json
+++ b/scripts/cmake-presets/crusher.json
@@ -61,6 +61,16 @@
       "cacheVariables": {
         "BUILD_SHARED_LIBS":    {"type": "BOOL",   "value": "OFF"}
       }
+    },
+    {
+      "name": "ndebug-serial",
+      "displayName": "Release mode",
+      "inherits": [".ndebug", ".base"],
+      "cacheVariables": {
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_OpenMP": {"type": "BOOL", "value": "OFF"},
+        "BUILD_SHARED_LIBS": {"type": "BOOL",   "value": "OFF"}
+      }
     }
   ],
   "buildPresets": [

--- a/scripts/dev/run-cloc.sh
+++ b/scripts/dev/run-cloc.sh
@@ -12,8 +12,12 @@ if ! hash cloc ; then
   exit 1
 fi
 
+function run_cloc() {
+  cloc --git HEAD --fullpath --force-lang=CUDA,hip $@
+}
+
 cd $SOURCE_DIR
 echo "Source/utility code:"
-cloc --git HEAD --fullpath --not-match-d='/test/' $@
+run_cloc --not-match-d='/generated/'  --not-match-d='/test/' $@
 echo "Test code:"
-cloc --git HEAD --fullpath --match-d='/test/' $@
+run_cloc --match-d='/test/' $@

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -50,13 +50,13 @@ where `${SOURCE}` is your local Celeritas source directory and `${DATE}` is the
 date time stamp of the desired image. If you just built locally, you can
 replace that last argument with the tag `ci-focal-cuda11`:
 ```console
-$ docker run --rm -ti -e "TERM=xterm-256color" -v /rnsdhpc/code/celeritas:/home/celeritas/src ci-focal-cuda11
+$ docker run --rm -ti -e "TERM=xterm-256color" -v /rnsdhpc/code/celeritas-docker:/home/celeritas/src ci-bionic-minimal
 ```
 
 After mounting, use the build scripts to configure and go:
 ```console
 celeritas@abcd1234:~$ cd src
-celeritas@abcd1234:~/src$ BUILD_DIR=$PWD/build-docker ./scripts/build/docker-cuda.sh
+celeritas@abcd1234:~/src$ ./scripts/docker/ci/run-ci.sh valgrind
 ```
 
 The `dev` image runs as root, but the `ci-focal-cuda11` runs as a user

--- a/scripts/docker/ci/launch-local-test.sh
+++ b/scripts/docker/ci/launch-local-test.sh
@@ -9,6 +9,10 @@ if [ -z "${CONFIG}" ]; then
   CONFIG=focal-cuda11
   echo "Set default CONFIG=${CONFIG}"
 fi
+if [ -z "${BUILD}" ]; then
+  BUILD=full-novg
+  echo "Set default BUILD=${BUILD}"
+fi
 
 CONTAINER=$(docker run -t -d ci-${CONFIG})
 echo "Launched container: ${CONTAINER}"
@@ -18,7 +22,7 @@ git clone https://github.com/celeritas-project/celeritas src
 cd src
 git fetch origin pull/$1/head:mr/$1
 git checkout mr/$1
-entrypoint-shell ./scripts/docker/ci/run-ci.sh full-novg
+entrypoint-shell ./scripts/docker/ci/run-ci.sh ${BUILD}
 EOF
 docker stop --time=0 $CONTAINER
 echo "To resume: docker start $CONTAINER \\"

--- a/scripts/docker/ci/run-ci.sh
+++ b/scripts/docker/ci/run-ci.sh
@@ -5,7 +5,7 @@ shift
 
 _ctest_args="-j16 --timeout 180 --no-compress-output --test-output-size-passed=65536 --test-output-size-failed=1048576"
 if [ "${CMAKE_PRESET}" = "vecgeom-demos" ]; then
-  _ctest_args="-R '^app/' ${_ctest_args}"
+  _ctest_args="-L 'app' ${_ctest_args}"
 fi
 
 set -x
@@ -23,5 +23,7 @@ cd build
 ctest -T Test ${_ctest_args}
 # Valgrind
 if [ "${CMAKE_PRESET}" = "valgrind" ]; then
-  ctest -T MemCheck -E 'demo-' --output-on-failure ${_ctest_args}
+  # Don't run apps that are launched through python drivers
+  ctest -T MemCheck -LE nomemcheck --output-on-failure \
+    ${_ctest_args}
 fi

--- a/src/base/Assert.hh
+++ b/src/base/Assert.hh
@@ -14,16 +14,18 @@
 
 #include <stdexcept>
 #include <string>
+#if defined(__HIP_DEVICE_COMPILE__)
+#    include <assert.h>
+#    include <hip/hip_runtime.h>
+#elif defined(__CUDA_ARCH__)
+// No assert header needed for CUDA
+#else
+#    include <sstream>
+#endif
 
 #include "celeritas_config.h"
 
 #include "Macros.hh"
-#ifndef CELER_DEVICE_COMPILE
-#    include <sstream>
-#elif __HIP_DEVICE_COMPILE__
-#    include <assert.h>
-#    include <hip/hip_runtime.h>
-#endif
 
 //---------------------------------------------------------------------------//
 // MACROS

--- a/src/base/KernelParamCalculator.device.hh
+++ b/src/base/KernelParamCalculator.device.hh
@@ -97,13 +97,13 @@ class KernelParamCalculator
 
     // Construct with the default block size
     template<class F>
-    KernelParamCalculator(F* kernel_func_ptr, const char* name);
+    inline KernelParamCalculator(F* kernel_func_ptr, const char* name);
 
     // Construct with an explicit number of threads per block
     template<class F>
-    KernelParamCalculator(F*          kernel_func_ptr,
-                          const char* name,
-                          dim_type    block_size);
+    inline KernelParamCalculator(F*          kernel_func_ptr,
+                                 const char* name,
+                                 dim_type    block_size);
 
     // Get launch parameters
     LaunchParams operator()(size_type min_num_threads) const;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,9 +118,15 @@ celeritas_add_test(base/Repr.test.cc)
 celeritas_add_test(base/ScopedStreamRedirect.test.cc)
 celeritas_add_test(base/SoftEqual.test.cc)
 celeritas_add_test(base/Span.test.cc)
-celeritas_add_test(base/Stopwatch.test.cc)
 celeritas_add_test(base/TypeDemangler.test.cc)
 celeritas_add_test(base/VectorUtils.test.cc)
+
+celeritas_add_test(base/Stopwatch.test.cc ADDED_TESTS _test_name)
+set_tests_properties(${_test_name} PROPERTIES
+  ENVIRONMENT "${_geant_test_env}"
+  REQUIRED_FILES "${_geant_test_inp}"
+  LABELS "nomemcheck"
+)
 
 celeritas_device_test(base/Collection)
 celeritas_device_test(base/NumericLimits)


### PR DESCRIPTION
Splitting out some non-kernel-related changes from #380 since @tmdelellis and I are trying to understand what those launch parameters are doing...

The main change here is that Stopwatch no longer runs under valgrind because of timing issues (the "pause" time can be more than 10% of the requested pause time).