### PR TITLE
Store the number of steps per track

### DIFF
--- a/app/demo-loop/LDemoLauncher.hh
+++ b/app/demo-loop/LDemoLauncher.hh
@@ -328,6 +328,10 @@ ProcessInteractionsLauncher<M>::operator()(ThreadId tid) const
     states_.energy_deposition[tid]
         += value_as<Energy>(result.energy_deposition);
 
+    // Increment the step count
+    auto num_steps = sim.steps() + 1;
+    sim.steps(num_steps);
+
     // Reset the physics state if a discrete interaction occured
     if (phys.model_id())
     {

--- a/app/demo-loop/LDemoLauncher.hh
+++ b/app/demo-loop/LDemoLauncher.hh
@@ -294,6 +294,8 @@ template<MemSpace M>
 CELER_FUNCTION void
 ProcessInteractionsLauncher<M>::operator()(ThreadId tid) const
 {
+    using Energy = celeritas::ParticleTrackView::Energy;
+
     celeritas::SimTrackView sim(states_.sim, tid);
     if (!sim.alive())
         return;
@@ -301,15 +303,7 @@ ProcessInteractionsLauncher<M>::operator()(ThreadId tid) const
 
     celeritas::ParticleTrackView particle(
         params_.particles, states_.particles, tid);
-    celeritas::GeoTrackView     geo(params_.geometry, states_.geometry, tid);
-    celeritas::GeoMaterialView  geo_mat(params_.geo_mats);
-    celeritas::PhysicsTrackView phys(params_.physics,
-                                     states_.physics,
-                                     particle.particle_id(),
-                                     geo_mat.material_id(geo.volume_id()),
-                                     tid);
-
-    using Energy = celeritas::ParticleTrackView::Energy;
+    celeritas::GeoTrackView geo(params_.geometry, states_.geometry, tid);
 
     // Update the track state from the interaction
     // TODO: handle recoverable errors
@@ -331,12 +325,6 @@ ProcessInteractionsLauncher<M>::operator()(ThreadId tid) const
     // Increment the step count
     auto num_steps = sim.steps() + 1;
     sim.steps(num_steps);
-
-    // Reset the physics state if a discrete interaction occured
-    if (phys.model_id())
-    {
-        phys = {};
-    }
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-loop/LDemoLauncher.hh
+++ b/app/demo-loop/LDemoLauncher.hh
@@ -300,7 +300,7 @@ ProcessInteractionsLauncher<M>::operator()(ThreadId tid) const
 
     // Increment the step count before checking if the track is alive as some
     // active tracks might have been killed earlier in the step.
-    sim.increment_steps();
+    sim.increment_num_steps();
 
     if (!sim.alive())
     {

--- a/app/demo-loop/LDemoLauncher.hh
+++ b/app/demo-loop/LDemoLauncher.hh
@@ -300,8 +300,7 @@ ProcessInteractionsLauncher<M>::operator()(ThreadId tid) const
 
     // Increment the step count before checking if the track is alive as some
     // active tracks might have been killed earlier in the step.
-    auto num_steps = sim.steps() + 1;
-    sim.steps(num_steps);
+    sim.increment_steps();
 
     if (!sim.alive())
     {

--- a/app/demo-loop/Transporter.cc
+++ b/app/demo-loop/Transporter.cc
@@ -270,16 +270,16 @@ TransporterResult Transporter<M>::operator()(const TrackInitParams& primaries)
         launch_models(input_, params_, states_.ref());
         accum_time<M>(input_, get_time, &result.time.launch_models);
 
+        // Postprocess interaction results
+        get_time = {};
+        generated::process_interactions(params_, states_.ref());
+        accum_time<M>(input_, get_time, &result.time.process_interactions);
+
         // Mid-step diagnostics
         for (auto& diagnostic : diagnostics)
         {
             diagnostic->mid_step(states_.ref());
         }
-
-        // Postprocess interaction results
-        get_time = {};
-        generated::process_interactions(params_, states_.ref());
-        accum_time<M>(input_, get_time, &result.time.process_interactions);
 
         // Create track initializers from surviving secondaries
         get_time = {};

--- a/app/demo-loop/diagnostic/ParticleProcessDiagnostic.hh
+++ b/app/demo-loop/diagnostic/ParticleProcessDiagnostic.hh
@@ -147,9 +147,10 @@ ParticleProcessDiagnostic<M>::ParticleProcessDiagnostic(
 //---------------------------------------------------------------------------//
 /*!
  * Tally the particle/process combinations that occur at each step.
-
- * This must be called after the post-step kernel and before the
- * post-processing.
+ *
+ * This must be called after the post-step kernel (when the discrete
+ * interaction is sampled) and before extend_from_secondaries, which clears the
+ * physics state if a discrete interaction occurred.
  */
 template<MemSpace M>
 void ParticleProcessDiagnostic<M>::mid_step(const StateDataRef& states)

--- a/app/demo-loop/diagnostic/StepDiagnostic.hh
+++ b/app/demo-loop/diagnostic/StepDiagnostic.hh
@@ -297,8 +297,9 @@ CELER_FUNCTION void StepLauncher<M>::operator()(ThreadId tid) const
             return data_.counts[BinId(index)];
         };
 
-        size_type num_steps = sim.steps() < data_.num_bins ? sim.steps()
-                                                           : data_.num_bins;
+        size_type num_steps = sim.num_steps() < data_.num_bins
+                                  ? sim.num_steps()
+                                  : data_.num_bins;
 
         // Increment the bin corresponding to the given particle and step count
         auto& bin = get(particle.particle_id().get(), num_steps);

--- a/app/demo-loop/diagnostic/StepDiagnostic.hh
+++ b/app/demo-loop/diagnostic/StepDiagnostic.hh
@@ -32,23 +32,20 @@ struct StepDiagnosticData
 
     using size_type = celeritas::size_type;
     template<class T>
-    using StateItems = celeritas::StateCollection<T, W, M>;
-    template<class T>
     using Items = celeritas::Collection<T, W, M>;
 
     //// DATA ////
 
-    StateItems<size_type> steps;  //!< Current step count for each track
-    Items<size_type>      counts; //!< Bin tracks by particle and step count
-    size_type             num_bins;
-    size_type             num_particles;
+    Items<size_type> counts; //!< Bin tracks by particle and step count
+    size_type        num_bins;
+    size_type        num_particles;
 
     //// METHODS ////
 
     //! Whether the data is initialized
     explicit CELER_FUNCTION operator bool() const
     {
-        return !steps.empty() && num_bins > 0 && num_particles > 0
+        return num_bins > 0 && num_particles > 0
                && counts.size() == num_bins * num_particles;
     }
 
@@ -57,7 +54,6 @@ struct StepDiagnosticData
     StepDiagnosticData& operator=(StepDiagnosticData<W2, M2>& other)
     {
         CELER_EXPECT(other);
-        steps         = other.steps;
         counts        = other.counts;
         num_bins      = other.num_bins;
         num_particles = other.num_particles;
@@ -185,14 +181,9 @@ StepDiagnostic<M>::StepDiagnostic(const ParamsDataRef& params,
     host_data.num_bins      = max_steps + 2;
     host_data.num_particles = particles_->size();
 
-    // Initialize current number of steps in active tracks to zero
-    std::vector<size_type> zeros(num_tracks);
-    celeritas::make_builder(&host_data.steps)
-        .insert_back(zeros.begin(), zeros.end());
-
     // Tracks binned by number of steps and particle type (indexed as
     // particle_id * num_bins + num_steps). The final bin is for overflow.
-    zeros.resize(host_data.num_bins * host_data.num_particles);
+    std::vector<size_type> zeros(host_data.num_bins * host_data.num_particles);
     celeritas::make_builder(&host_data.counts)
         .insert_back(zeros.begin(), zeros.end());
 
@@ -204,8 +195,10 @@ StepDiagnostic<M>::StepDiagnostic(const ParamsDataRef& params,
 /*!
  * Get the distribution of steps per track.
  *
- * This must be called after the interactors have been launched but before the
- * post-processing.
+ * This must be called after the interactions have been processed (when the
+ * step count is incremented) and before extend_from_secondaries, which can
+ * initialize new tracks immediately in the parent track's slot and overwrite
+ * the original track data.
  */
 template<MemSpace M>
 void StepDiagnostic<M>::mid_step(const StateDataRef& states)
@@ -282,11 +275,6 @@ CELER_FUNCTION StepLauncher<M>::StepLauncher(const ParamsDataRef&     params,
 //---------------------------------------------------------------------------//
 /*!
  * Increment step count and tally number of steps for tracks that were killed.
- *
- * At this point, active tracks will either be marked "alive" in the sim state
- * or will have a killing action in their interaction result. Tracks that were
- * killed in a discrete interaction will still be marked as alive (these are
- * killed in post-processing), but their action will be killing.
  */
 template<MemSpace M>
 CELER_FUNCTION void StepLauncher<M>::operator()(ThreadId tid) const
@@ -299,12 +287,6 @@ CELER_FUNCTION void StepLauncher<M>::operator()(ThreadId tid) const
 
     const auto& interaction = states_.interactions[tid];
 
-    // Increment the step count if this is an active track
-    if (sim.alive() || celeritas::action_killed(interaction.action))
-    {
-        ++data_.steps[tid];
-    }
-
     // Tally the number of steps if the track was killed
     if (celeritas::action_killed(interaction.action))
     {
@@ -315,16 +297,12 @@ CELER_FUNCTION void StepLauncher<M>::operator()(ThreadId tid) const
             return data_.counts[BinId(index)];
         };
 
-        size_type num_steps = data_.steps[tid] < data_.num_bins
-                                  ? data_.steps[tid]
-                                  : data_.num_bins;
+        size_type num_steps = sim.steps() < data_.num_bins ? sim.steps()
+                                                           : data_.num_bins;
 
         // Increment the bin corresponding to the given particle and step count
         auto& bin = get(particle.particle_id().get(), num_steps);
         celeritas::atomic_add(&bin, size_type{1});
-
-        // Reset the track's step counter
-        data_.steps[tid] = 0;
     }
 }
 

--- a/src/sim/SimData.hh
+++ b/src/sim/SimData.hh
@@ -27,7 +27,7 @@ struct SimTrackState
     TrackId   track_id;      //!< Unique ID for this track
     TrackId   parent_id;     //!< ID of parent that created it
     EventId   event_id;      //!< ID of originating event
-    size_type steps = 0;     //!< Total number of steps taken
+    size_type num_steps = 0; //!< Total number of steps taken
     bool      alive = false; //!< Whether this track is alive
 };
 

--- a/src/sim/SimData.hh
+++ b/src/sim/SimData.hh
@@ -27,7 +27,7 @@ struct SimTrackState
     TrackId   track_id;      //!< Unique ID for this track
     TrackId   parent_id;     //!< ID of parent that created it
     EventId   event_id;      //!< ID of originating event
-    size_type steps;         //!< Total number of steps taken
+    size_type steps = 0;     //!< Total number of steps taken
     bool      alive = false; //!< Whether this track is alive
 };
 

--- a/src/sim/SimData.hh
+++ b/src/sim/SimData.hh
@@ -24,10 +24,11 @@ namespace celeritas
  */
 struct SimTrackState
 {
-    TrackId track_id;      //!< Unique ID for this track
-    TrackId parent_id;     //!< ID of parent that created it
-    EventId event_id;      //!< ID of originating event
-    bool    alive = false; //!< Whether this track is alive
+    TrackId   track_id;      //!< Unique ID for this track
+    TrackId   parent_id;     //!< ID of parent that created it
+    EventId   event_id;      //!< ID of originating event
+    size_type steps;         //!< Total number of steps taken
+    bool      alive = false; //!< Whether this track is alive
 };
 
 using SimTrackInitializer = SimTrackState;

--- a/src/sim/SimTrackView.hh
+++ b/src/sim/SimTrackView.hh
@@ -35,6 +35,12 @@ class SimTrackView
     // Initialize the sim state
     inline CELER_FUNCTION SimTrackView& operator=(const Initializer_t& other);
 
+    // Set the total number of steps
+    CELER_FORCEINLINE_FUNCTION void steps(size_type);
+
+    // Set whether the track is alive
+    CELER_FORCEINLINE_FUNCTION void alive(bool);
+
     //// DYNAMIC PROPERTIES ////
 
     // Unique track identifier
@@ -46,11 +52,11 @@ class SimTrackView
     // Event ID
     CELER_FORCEINLINE_FUNCTION EventId event_id() const;
 
+    // Total number of steps taken by the track
+    CELER_FORCEINLINE_FUNCTION size_type steps() const;
+
     // Whether the track is alive
     CELER_FORCEINLINE_FUNCTION bool alive() const;
-
-    // Set whether the track is alive
-    CELER_FORCEINLINE_FUNCTION void alive(bool);
 
   private:
     const SimStateRef& states_;
@@ -78,6 +84,24 @@ CELER_FUNCTION SimTrackView& SimTrackView::operator=(const Initializer_t& other)
 {
     states_.state[thread_] = other;
     return *this;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set the total number of steps.
+ */
+CELER_FUNCTION void SimTrackView::steps(size_type count)
+{
+    states_.state[thread_].steps = count;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set whether the track is alive.
+ */
+CELER_FUNCTION void SimTrackView::alive(bool is_alive)
+{
+    states_.state[thread_].alive = is_alive;
 }
 
 //---------------------------------------------------------------------------//
@@ -111,20 +135,20 @@ CELER_FUNCTION EventId SimTrackView::event_id() const
 
 //---------------------------------------------------------------------------//
 /*!
+ * Total number of steps taken by the track.
+ */
+CELER_FUNCTION size_type SimTrackView::steps() const
+{
+    return states_.state[thread_].steps;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Whether the track is alive.
  */
 CELER_FUNCTION bool SimTrackView::alive() const
 {
     return states_.state[thread_].alive;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Set whether the track is alive.
- */
-CELER_FUNCTION void SimTrackView::alive(bool is_alive)
-{
-    states_.state[thread_].alive = is_alive;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/SimTrackView.hh
+++ b/src/sim/SimTrackView.hh
@@ -36,7 +36,7 @@ class SimTrackView
     inline CELER_FUNCTION SimTrackView& operator=(const Initializer_t& other);
 
     // Increment the total number of steps
-    CELER_FORCEINLINE_FUNCTION void increment_steps();
+    CELER_FORCEINLINE_FUNCTION void increment_num_steps();
 
     // Set whether the track is alive
     CELER_FORCEINLINE_FUNCTION void alive(bool);
@@ -53,7 +53,7 @@ class SimTrackView
     CELER_FORCEINLINE_FUNCTION EventId event_id() const;
 
     // Total number of steps taken by the track
-    CELER_FORCEINLINE_FUNCTION size_type steps() const;
+    CELER_FORCEINLINE_FUNCTION size_type num_steps() const;
 
     // Whether the track is alive
     CELER_FORCEINLINE_FUNCTION bool alive() const;
@@ -90,9 +90,9 @@ CELER_FUNCTION SimTrackView& SimTrackView::operator=(const Initializer_t& other)
 /*!
  * Increment the total number of steps.
  */
-CELER_FUNCTION void SimTrackView::increment_steps()
+CELER_FUNCTION void SimTrackView::increment_num_steps()
 {
-    ++states_.state[thread_].steps;
+    ++states_.state[thread_].num_steps;
 }
 
 //---------------------------------------------------------------------------//
@@ -137,9 +137,9 @@ CELER_FUNCTION EventId SimTrackView::event_id() const
 /*!
  * Total number of steps taken by the track.
  */
-CELER_FUNCTION size_type SimTrackView::steps() const
+CELER_FUNCTION size_type SimTrackView::num_steps() const
 {
-    return states_.state[thread_].steps;
+    return states_.state[thread_].num_steps;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/SimTrackView.hh
+++ b/src/sim/SimTrackView.hh
@@ -35,8 +35,8 @@ class SimTrackView
     // Initialize the sim state
     inline CELER_FUNCTION SimTrackView& operator=(const Initializer_t& other);
 
-    // Set the total number of steps
-    CELER_FORCEINLINE_FUNCTION void steps(size_type);
+    // Increment the total number of steps
+    CELER_FORCEINLINE_FUNCTION void increment_steps();
 
     // Set whether the track is alive
     CELER_FORCEINLINE_FUNCTION void alive(bool);
@@ -88,11 +88,11 @@ CELER_FUNCTION SimTrackView& SimTrackView::operator=(const Initializer_t& other)
 
 //---------------------------------------------------------------------------//
 /*!
- * Set the total number of steps.
+ * Increment the total number of steps.
  */
-CELER_FUNCTION void SimTrackView::steps(size_type count)
+CELER_FUNCTION void SimTrackView::increment_steps()
 {
-    states_.state[thread_].steps = count;
+    ++states_.state[thread_].steps;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/sim/detail/ProcessSecondariesLauncher.hh
+++ b/src/sim/detail/ProcessSecondariesLauncher.hh
@@ -97,6 +97,7 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
             init.sim.track_id         = TrackId{track_id};
             init.sim.parent_id        = parent_id;
             init.sim.event_id         = sim.event_id();
+            init.sim.steps            = 0;
             init.sim.alive            = true;
             init.geo.pos              = geo.pos();
             init.geo.dir              = secondary.direction;

--- a/src/sim/detail/ProcessSecondariesLauncher.hh
+++ b/src/sim/detail/ProcessSecondariesLauncher.hh
@@ -62,8 +62,9 @@ CELER_FUNCTION void
 ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
 {
     // Construct the state accessors
-    GeoTrackView geo(params_.geometry, states_.geometry, tid);
-    SimTrackView sim(states_.sim, tid);
+    GeoTrackView     geo(params_.geometry, states_.geometry, tid);
+    SimTrackView     sim(states_.sim, tid);
+    PhysicsTrackView phys(params_.physics, states_.physics, {}, {}, tid);
 
     // Offset in the vector of track initializers
     CELER_ASSERT(data_.secondary_counts[tid] <= data_.num_secondaries);
@@ -108,8 +109,6 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
             {
                 ParticleTrackView particle(
                     params_.particles, states_.particles, tid);
-                PhysicsTrackView phys(
-                    params_.physics, states_.physics, {}, {}, tid);
 
                 // The parent was killed, so initialize the first secondary in
                 // the parent's track slot. Keep the parent's geometry state
@@ -139,6 +138,13 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
             }
         }
     }
+
+    // Reset the physics state if a discrete interaction occured
+    if (phys.model_id())
+    {
+        phys = {};
+    }
+
     // Clear the interaction
     result = initialized ? Interaction::from_spawned()
                          : Interaction::from_processed();

--- a/src/sim/detail/ProcessSecondariesLauncher.hh
+++ b/src/sim/detail/ProcessSecondariesLauncher.hh
@@ -139,7 +139,7 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
         }
     }
 
-    // Reset the physics state if a discrete interaction occured
+    // Reset the physics state if a discrete interaction occurred
     if (phys.model_id())
     {
         phys = {};

--- a/src/sim/detail/ProcessSecondariesLauncher.hh
+++ b/src/sim/detail/ProcessSecondariesLauncher.hh
@@ -98,7 +98,7 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
             init.sim.track_id         = TrackId{track_id};
             init.sim.parent_id        = parent_id;
             init.sim.event_id         = sim.event_id();
-            init.sim.steps            = 0;
+            init.sim.num_steps        = 0;
             init.sim.alive            = true;
             init.geo.pos              = geo.pos();
             init.geo.dir              = secondary.direction;


### PR DESCRIPTION
This adds a step counter to the sim state data. The multiple scattering step limitation algorithm treats the first step of a track differently; this change will allow us to determine if a track was just initialized.

I also modified the `StepDiagnostic` to use this step count and rearranged the demo loop diagnostics slightly (`Diagnostic::mid_step` is now called after `process_interactions`, which will also be necessary for the MC truth diagnostic). I verified that the diagnostic results for the medium input are unchanged.