### PR TITLE
Add features and fixes for testem3 comparison

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -99,6 +99,7 @@ void to_json(nlohmann::json& j, const LDemoArgs& v)
                        {"enable_diagnostics", v.enable_diagnostics},
                        {"use_device", v.use_device},
                        {"sync", v.sync},
+                       {"rayleigh", v.rayleigh},
                        {"eloss_fluctuation", v.eloss_fluctuation},
                        {"brem_combined", v.brem_combined},
                        {"brem_lpm", v.brem_lpm}};
@@ -113,6 +114,7 @@ void from_json(const nlohmann::json& j, LDemoArgs& v)
     j.at("geometry_filename").get_to(v.geometry_filename);
     j.at("physics_filename").get_to(v.physics_filename);
     j.at("hepmc3_filename").get_to(v.hepmc3_filename);
+    j.at("rayleigh").get_to(v.rayleigh);
     j.at("eloss_fluctuation").get_to(v.eloss_fluctuation);
     j.at("brem_combined").get_to(v.brem_combined);
     j.at("brem_lpm").get_to(v.brem_lpm);
@@ -214,8 +216,11 @@ TransporterInput load_input(const LDemoArgs& args)
             std::make_shared<ComptonProcess>(result.particles, process_data));
         input.processes.push_back(std::make_shared<PhotoelectricProcess>(
             result.particles, result.materials, process_data));
-        input.processes.push_back(std::make_shared<RayleighProcess>(
-            result.particles, result.materials, process_data));
+        if (args.rayleigh)
+        {
+            input.processes.push_back(std::make_shared<RayleighProcess>(
+                result.particles, result.materials, process_data));
+        }
         input.processes.push_back(std::make_shared<GammaConversionProcess>(
             result.particles, process_data));
         input.processes.push_back(

--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -8,6 +8,7 @@
 #include "LDemoIO.hh"
 
 #include <algorithm>
+#include <string>
 
 #include "comm/Logger.hh"
 #include "geometry/GeoMaterialParams.hh"
@@ -31,6 +32,33 @@
 #include "random/RngParams.hh"
 
 using namespace celeritas;
+
+namespace celeritas
+{
+//!@{
+//! I/O routines for JSON
+void to_json(nlohmann::json& j, const EnergyDiagInput& v)
+{
+    j = nlohmann::json{{"axis", std::string(1, v.axis)},
+                       {"min", v.min},
+                       {"max", v.max},
+                       {"num_bins", v.num_bins}};
+}
+
+void from_json(const nlohmann::json& j, EnergyDiagInput& v)
+{
+    std::string temp_axis;
+    j.at("axis").get_to(temp_axis);
+    CELER_VALIDATE(temp_axis.size() == 1,
+                   << "axis spec has length " << temp_axis.size()
+                   << " (must be a single character)");
+    v.axis = temp_axis.front();
+    j.at("min").get_to(v.min);
+    j.at("max").get_to(v.max);
+    j.at("num_bins").get_to(v.num_bins);
+}
+//!@}
+} // namespace celeritas
 
 namespace demo_loop
 {
@@ -70,7 +98,14 @@ void to_json(nlohmann::json& j, const LDemoArgs& v)
                        {"secondary_stack_factor", v.secondary_stack_factor},
                        {"enable_diagnostics", v.enable_diagnostics},
                        {"use_device", v.use_device},
-                       {"sync", v.sync}};
+                       {"sync", v.sync},
+                       {"eloss_fluctuation", v.eloss_fluctuation},
+                       {"brem_combined", v.brem_combined},
+                       {"brem_lpm", v.brem_lpm}};
+    if (v.enable_diagnostics)
+    {
+        j["energy_diag"] = v.energy_diag;
+    }
 }
 
 void from_json(const nlohmann::json& j, LDemoArgs& v)
@@ -78,6 +113,9 @@ void from_json(const nlohmann::json& j, LDemoArgs& v)
     j.at("geometry_filename").get_to(v.geometry_filename);
     j.at("physics_filename").get_to(v.physics_filename);
     j.at("hepmc3_filename").get_to(v.hepmc3_filename);
+    j.at("eloss_fluctuation").get_to(v.eloss_fluctuation);
+    j.at("brem_combined").get_to(v.brem_combined);
+    j.at("brem_lpm").get_to(v.brem_lpm);
     j.at("seed").get_to(v.seed);
     j.at("max_num_tracks").get_to(v.max_num_tracks);
     if (j.contains("max_steps"))
@@ -89,7 +127,13 @@ void from_json(const nlohmann::json& j, LDemoArgs& v)
     j.at("enable_diagnostics").get_to(v.enable_diagnostics);
     j.at("use_device").get_to(v.use_device);
     j.at("sync").get_to(v.sync);
+
+    if (j.contains("energy_diag"))
+    {
+        j.at("energy_diag").get_to(v.energy_diag);
+    }
 }
+//!@}
 
 //---------------------------------------------------------------------------//
 TransporterInput load_input(const LDemoArgs& args)
@@ -156,12 +200,13 @@ TransporterInput load_input(const LDemoArgs& args)
     // Load physics: create individual processes with make_shared
     {
         PhysicsParams::Input input;
-        input.particles = result.particles;
-        input.materials = result.materials;
+        input.particles                  = result.particles;
+        input.materials                  = result.materials;
+        input.options.enable_fluctuation = args.eloss_fluctuation;
 
         BremsstrahlungProcess::Options brem_options;
-        brem_options.combined_model = args.combined_brem;
-        brem_options.enable_lpm     = args.enable_lpm;
+        brem_options.combined_model = args.brem_combined;
+        brem_options.enable_lpm     = args.brem_lpm;
 
         auto process_data = std::make_shared<ImportedProcesses>(
             std::move(imported_data.processes));
@@ -194,6 +239,9 @@ TransporterInput load_input(const LDemoArgs& args)
     result.secondary_stack_factor = args.secondary_stack_factor;
     result.enable_diagnostics     = args.enable_diagnostics;
     result.sync                   = args.sync;
+
+    // Propagate diagnosics
+    result.energy_diag = args.energy_diag;
 
     CELER_ENSURE(result);
     return result;

--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -49,6 +49,7 @@ struct LDemoArgs
     bool         sync{};
 
     // Options for physics
+    bool rayleigh{true};
     bool eloss_fluctuation{true};
     bool brem_combined{true};
     bool brem_lpm{true};

--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -48,9 +48,13 @@ struct LDemoArgs
     bool         use_device{};
     bool         sync{};
 
-    // Options for physics processes and models
-    bool combined_brem{true};
-    bool enable_lpm{true};
+    // Options for physics
+    bool eloss_fluctuation{true};
+    bool brem_combined{true};
+    bool brem_lpm{true};
+
+    // Diagnostic input
+    celeritas::EnergyDiagInput energy_diag;
 
     //! Whether the run arguments are valid
     explicit operator bool() const

--- a/app/demo-loop/LDemoLauncher.hh
+++ b/app/demo-loop/LDemoLauncher.hh
@@ -284,6 +284,7 @@ CELER_FUNCTION void AlongAndPostStepLauncher<M>::operator()(ThreadId tid) const
     }
     phys.model_id(result_model);
     states_.interactions[tid].action = result_action;
+    states_.step_length[tid]         = step;
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-loop/Transporter.cc
+++ b/app/demo-loop/Transporter.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "Transporter.hh"
 
+#include "base/Assert.hh"
 #include "base/Stopwatch.hh"
 #include "base/VectorUtils.hh"
 #include "comm/Logger.hh"
@@ -115,8 +116,14 @@ build_diagnostics(const TransporterInput&                    inp,
             params, inp.particles, inp.max_num_tracks, 200));
         result.push_back(std::make_unique<ParticleProcessDiagnostic<M>>(
             params, inp.particles, inp.physics));
+
+        const auto& ediag = inp.energy_diag;
+        CELER_VALIDATE(ediag.axis >= 'x' && ediag.axis <= 'z',
+                       << "Invalid axis '" << ediag.axis
+                       << "' (must be x, y, or z)");
         result.push_back(std::make_unique<EnergyDiagnostic<M>>(
-            linspace(-700.0, 700.0, 1024 + 1)));
+            linspace(ediag.min, ediag.max, ediag.num_bins + 1),
+            static_cast<Axis>(ediag.axis - 'x')));
     }
     return result;
 }

--- a/app/demo-loop/Transporter.hh
+++ b/app/demo-loop/Transporter.hh
@@ -31,6 +31,15 @@ class RngParams;
 class TrackInitParams;
 
 //---------------------------------------------------------------------------//
+struct EnergyDiagInput
+{
+    char      axis{'z'};
+    real_type min{-700};
+    real_type max{700};
+    size_type num_bins{1024};
+};
+
+//---------------------------------------------------------------------------//
 //! Input parameters to the transporter.
 struct TransporterInput
 {
@@ -59,7 +68,10 @@ struct TransporterInput
     size_type max_steps{};
     real_type secondary_stack_factor{};
     bool      enable_diagnostics{true};
-    bool      sync{};
+    bool      sync{false};
+
+    // Diagnostic setup
+    EnergyDiagInput energy_diag;
 
     //! True if all params are assigned
     explicit operator bool() const

--- a/app/demo-loop/diagnostic/EnergyDiagnostic.hh
+++ b/app/demo-loop/diagnostic/EnergyDiagnostic.hh
@@ -202,6 +202,13 @@ CELER_FUNCTION void EnergyDiagnosticLauncher<M>::operator()(ThreadId tid) const
     celeritas::NonuniformGrid<real_type> grid(pointers_.bounds);
 
     real_type pos = states_.geometry.pos[tid][static_cast<int>(pointers_.axis)];
+    {
+        // Bump particle to mid-step point to avoid grid edges coincident with
+        // geometry boundaries
+        real_type dir
+            = states_.geometry.dir[tid][static_cast<int>(pointers_.axis)];
+        pos -= real_type(0.5) * states_.step_length[tid] * dir;
+    }
     real_type energy_deposition = states_.energy_deposition[tid];
 
     using BinId = celeritas::ItemId<real_type>;

--- a/app/demo-loop/diagnostic/EnergyDiagnostic.hh
+++ b/app/demo-loop/diagnostic/EnergyDiagnostic.hh
@@ -145,6 +145,7 @@ EnergyDiagnostic<M>::EnergyDiagnostic(const std::vector<real_type>& bounds,
 
     // Resize bin data
     resize(&energy_per_bin_, bounds_.size() - 1);
+    celeritas::fill(real_type(0), &energy_per_bin_);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -55,6 +55,7 @@ inp = {
     'enable_diagnostics': True,
     'sync': True,
     # Physics options
+    'rayleigh': True,
     'eloss_fluctuation': True,
     'brem_combined': True,
     'brem_lpm': True,

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -53,7 +53,11 @@ inp = {
     'initializer_capacity': 100 * max([num_tracks, num_primaries]),
     'secondary_stack_factor': 3,
     'enable_diagnostics': True,
-    'sync': True
+    'sync': True,
+    # Physics options
+    'eloss_fluctuation': True,
+    'brem_combined': True,
+    'brem_lpm': True,
 }
 
 

--- a/src/sim/detail/InitTracksLauncher.hh
+++ b/src/sim/detail/InitTracksLauncher.hh
@@ -18,6 +18,10 @@
 
 #include "Utils.hh"
 
+#if !CELER_DEVICE_COMPILE
+#    include "base/ArrayIO.hh"
+#endif
+
 namespace celeritas
 {
 namespace detail
@@ -108,6 +112,12 @@ CELER_FUNCTION void InitTracksLauncher<M>::operator()(ThreadId tid) const
         {
             // Initialize it from the position (more expensive)
             geo = init.geo;
+#if !CELER_DEVICE_COMPILE
+            // TODO: kill particle with 'error' state if this happens
+            CELER_VALIDATE(!geo.is_outside(),
+                           << "track started outside the geometry at "
+                           << init.geo.pos);
+#endif
         }
 
         // Initialize the material


### PR DESCRIPTION
- Ability to disable Rayleigh
- Ability to switch energy deposition axis and change grid via input
- Fix for energy deposition when the end point is coincident with the edep grid (moving back half a step because energy would be placed in the wrong bin at the end of a geometry-limited step)
- Optimization for energy deposition (we're atomic-adding zeroes to a bunch of never-alive tracks)