### PR TITLE
Work around Geant4 include propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,12 @@ if(CELERITAS_USE_Doxygen)
 endif()
 
 if(CELERITAS_USE_Geant4)
+  # Geant4 calls `include_directories` for CLHEP :( which is not what we want!
+  # Save and restore include directories around the call -- even though as a
+  # standalone project Celeritas will never have directory-level includes
+  get_directory_property(_include_dirs INCLUDE_DIRECTORIES)
   find_package(Geant4 REQUIRED)
+  set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES "${_include_dirs}")
 endif()
 
 if(CELERITAS_USE_HepMC3)

--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -18,7 +18,7 @@
         "CELERITAS_USE_SWIG":    {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
         "CMAKE_CXX_COMPILER": "/usr/bin/g++",
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always",
         "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=skylake-avx512 -mtune=skylake-avx512",
         "CMAKE_CUDA_FLAGS": "-Werror all-warnings  -Wno-deprecated-gpu-targets",
         "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"}


### PR DESCRIPTION
Geant4 forcibly adds `include_directories(CLHEP_INCLUDE_DIRS)` inside the FindGeant4 recipe. This results in code that *doesn't even link against Geant4* to include the CLHEP directories, which (see https://github.com/drbenmorgan/CLHEP/pull/1 ) use relative paths that result in bad diagnostic messages, since unrelated packages in a spack view look like they're coming from something related to CLHEP:
```
/spack/environments/celeritas/.spack-env/view/lib/CLHEP-2.4.5.1/../../include/gtest/gtest.h:299:9: error: no viable conversion from 'const celeritas::Interaction' to 'bool'
```

The guilty line:
https://github.com/Geant4/geant4/blob/de4f28d823f824725898d2ee37aaca96b10a1386/cmake/Templates/Geant4Config.cmake.in#L260
