### PR TITLE
More MSC refactoring

### DIFF
--- a/app/demo-loop/LDemoLauncher.hh
+++ b/app/demo-loop/LDemoLauncher.hh
@@ -149,7 +149,8 @@ along_and_post_step_track(celeritas::CoreTrackView const& track)
                 &geo,
                 phys,
                 mat.make_material_view(),
-                sim);
+                sim,
+                phys.step_length());
             auto msc_step_result = msc_step_limit(rng);
 
             // Limit geometry step

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -38,7 +38,8 @@ else:
     # Load directly from Geant4 rather than ROOT file
     physics_filename = geometry_filename
 
-if strtobool(environ.get('CELER_DISABLE_VECGEOM', 'false')):
+use_vecgeom = not strtobool(environ.get('CELER_DISABLE_VECGEOM', 'false'))
+if not use_vecgeom:
     print("Replacing .gdml extension since VecGeom is disabled")
     geometry_filename = re.sub(r"\.gdml$", ".org.json", geometry_filename)
 
@@ -63,7 +64,7 @@ inp = {
     'brem_combined': True,
     'brem_lpm': True,
     'conv_lpm': True,
-    'enable_msc': False,
+    'enable_msc': use_vecgeom,
 }
 
 

--- a/src/base/Algorithms.hh
+++ b/src/base/Algorithms.hh
@@ -97,6 +97,29 @@ struct Less<void>
 // Replace/extend <algorithm>
 //---------------------------------------------------------------------------//
 /*!
+ * Clamp the value between lo and hi values.
+ *
+ * If the value is between lo and hi, return the value. Otherwise, return lo if
+ * it's below it, or hi above it.
+ *
+ * This replaces:
+ * \code
+ *  min(hi, max(lo, v))
+ * \endcode
+ * or
+ * \code
+ *  max(v, min(v, lo))
+ * \endcode
+ */
+template<class T>
+inline CELER_FUNCTION T const& clamp(T const& v, T const& lo, T const& hi)
+{
+    CELER_EXPECT(!(hi < lo));
+    return v < lo ? lo : hi < v ? hi : v;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Return the value or (if it's negative) then zero.
  *
  * This is constructed to correctly propagate NaN.

--- a/src/physics/em/detail/UrbanMscData.hh
+++ b/src/physics/em/detail/UrbanMscData.hh
@@ -71,15 +71,15 @@ struct UrbanMscMaterialData
 {
     using Real4 = Array<real_type, 4>;
 
-    real_type zeff;        //!< effective atomic_number
-    real_type z23;         //!< zeff^(2/3)
-    real_type coeffth1;    //!< correction in theta_0 formula
-    real_type coeffth2;    //!< correction in theta_0 formula
-    Real4     d;           //!< coefficients of tail parameters
-    real_type stepmin_a;   //!< coefficient of the step minimum calculation
-    real_type stepmin_b;   //!< coefficient of the step minimum calculation
-    real_type d_over_r;    //!< the maximum distance/range for e-/e+
-    real_type d_over_r_mh; //!< the maximum distance/range for muon/h
+    real_type zeff{};        //!< effective atomic_number
+    real_type z23{};         //!< zeff^(2/3)
+    real_type coeffth1{};    //!< correction in theta_0 formula
+    real_type coeffth2{};    //!< correction in theta_0 formula
+    Real4     d{0, 0, 0, 0}; //!< coefficients of tail parameters
+    real_type stepmin_a{};   //!< coefficient of the step minimum calculation
+    real_type stepmin_b{};   //!< coefficient of the step minimum calculation
+    real_type d_over_r{};    //!< the maximum distance/range for e-/e+
+    real_type d_over_r_mh{}; //!< the maximum distance/range for muon/h
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/UrbanMscData.hh
+++ b/src/physics/em/detail/UrbanMscData.hh
@@ -36,6 +36,27 @@ struct UrbanMscParameters
     real_type safety_tol{0.01}; //!< safety tolerance
     real_type geom_limit{5e-8 * units::millimeter}; //!< minimum step
     Energy    energy_limit{1e-5};                   //!< 10 eV
+
+    //! A scale factor for the range
+    static CELER_CONSTEXPR_FUNCTION real_type dtrl() { return 5e-2; }
+
+    //! The minimum value of the true path length limit: 0.01 nm
+    static CELER_CONSTEXPR_FUNCTION real_type limit_min_fix()
+    {
+        return 1e-9 * units::centimeter;
+    }
+
+    //! For steps below this value, true = geometrical (no MSC to be applied)
+    static CELER_CONSTEXPR_FUNCTION real_type min_step()
+    {
+        return 100 * limit_min_fix();
+    }
+
+    //! Below this endpoint energy, don't sample scattering
+    static CELER_CONSTEXPR_FUNCTION Energy min_sampling_energy()
+    {
+        return units::MevEnergy{1e-9};
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/UrbanMscHelper.hh
+++ b/src/physics/em/detail/UrbanMscHelper.hh
@@ -16,7 +16,6 @@
 #include "physics/grid/InverseRangeCalculator.hh"
 #include "physics/grid/RangeCalculator.hh"
 #include "physics/material/Types.hh"
-#include "random/distributions/NormalDistribution.hh"
 
 #include "UrbanMscData.hh"
 
@@ -41,77 +40,36 @@ class UrbanMscHelper
     // Construct with shared and state data
     inline CELER_FUNCTION UrbanMscHelper(const UrbanMscRef&       shared,
                                          const ParticleTrackView& particle,
-                                         const PhysicsTrackView&  physics,
-                                         const MaterialView&      material);
-
-    //// COMMON PROPERTIES ////
-
-    //! A scale factor for the range
-    static CELER_CONSTEXPR_FUNCTION real_type dtrl() { return 5e-2; }
-
-    //! The lower bound of energy to scale the mininum true path length limit
-    static CELER_CONSTEXPR_FUNCTION Energy tlow() { return Energy(5e-3); }
-
-    //! The minimum value of the true path length limit: 0.01 nm
-    static CELER_CONSTEXPR_FUNCTION real_type limit_min_fix()
-    {
-        return 1e-9 * units::centimeter;
-    }
+                                         const PhysicsTrackView&  physics);
 
     //// HELPER FUNCTIONS ////
 
-    //! The step length from physics processes
-    CELER_FUNCTION real_type step_length() const
-    {
-        return physics_.step_length();
-    }
-
-    //! The range for a given particle energy
+    //! The slowing-down range for the starting particle energy
     CELER_FUNCTION real_type range() const { return range_; }
 
     // The mean free path of the multiple scattering for a given energy
     inline CELER_FUNCTION real_type msc_mfp(Energy energy) const;
 
+    // TODO: the following two methods are used only by MscStepLimit
+
     // The total energy loss over a given step length
-    inline CELER_FUNCTION Energy eloss(real_type step) const;
+    inline CELER_FUNCTION Energy calc_eloss(real_type step) const;
 
     // The kinetic energy at the end of a given step length corrected by dedx
-    inline CELER_FUNCTION Energy end_energy(real_type step) const;
-
-    // Calculate the minimum of the true path length limit
-    inline CELER_FUNCTION real_type calc_limit_min(Energy    energy,
-                                                   real_type step_min) const;
-
-    // Calculate the minimum of the step length for a given elastic mfp
-    inline CELER_FUNCTION real_type calc_step_min(Energy    energy,
-                                                  real_type lambda) const;
-
-    // Sample a random true path length limit
-    template<class Engine>
-    inline CELER_FUNCTION real_type randomize_limit(Engine&   rng,
-                                                    real_type limit,
-                                                    real_type limit_min) const;
-
-    // Calculate the true path length from the geom path length
-    inline CELER_FUNCTION real_type calc_true_path(real_type true_path,
-                                                   real_type geom_path,
-                                                   real_type alpha) const;
+    inline CELER_FUNCTION Energy calc_end_energy(real_type step) const;
 
   private:
     //// DATA ////
 
     // Incident particle energy
     const Energy inc_energy_;
-    // Incident particle flag for positron
-    const bool is_positron_;
     // PhysicsTrackView
     const PhysicsTrackView& physics_;
-    // Material dependent data
-    const MaterialData& msc_;
+    // Range scaling factor
+    const real_type dtrl_;
+
     // Shared value of range
     real_type range_;
-    // Shared value of small tau
-    real_type tau_small_;
     // Process ID of the eletromagnetic_msc process
     ParticleProcessId msc_pid_;
     // Grid ID of range value of the energy loss
@@ -131,13 +89,10 @@ class UrbanMscHelper
 CELER_FUNCTION
 UrbanMscHelper::UrbanMscHelper(const UrbanMscRef&       shared,
                                const ParticleTrackView& particle,
-                               const PhysicsTrackView&  physics,
-                               const MaterialView&      material)
+                               const PhysicsTrackView&  physics)
     : inc_energy_(particle.energy())
-    , is_positron_(particle.particle_id() == shared.ids.positron)
     , physics_(physics)
-    , msc_(shared.msc_data[material.material_id()])
-    , tau_small_(shared.params.tau_small)
+    , dtrl_(shared.params.dtrl())
 {
     CELER_EXPECT(particle.particle_id() == shared.ids.electron
                  || particle.particle_id() == shared.ids.positron);
@@ -150,8 +105,6 @@ UrbanMscHelper::UrbanMscHelper(const UrbanMscRef&       shared,
     range_ = physics.make_calculator<RangeCalculator>(range_gid_)(inc_energy_);
 }
 
-//// HELPER FUNCTIONS ////
-
 //---------------------------------------------------------------------------//
 /*!
  * Calculate the mean free path of the msc for a given particle energy.
@@ -160,17 +113,15 @@ CELER_FUNCTION real_type UrbanMscHelper::msc_mfp(Energy energy) const
 {
     real_type xsec = physics_.calc_xs(msc_pid_, mfp_gid_, energy)
                      / ipow<2>(energy.value());
-    // Return the mean free path
-    real_type mfp = (xsec > 0) ? 1 / xsec
-                               : numeric_limits<real_type>::infinity();
-    return mfp;
+    CELER_ENSURE(xsec >= 0);
+    return 1 / xsec;
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Calculate the total energy loss over a given step length.
  */
-CELER_FUNCTION auto UrbanMscHelper::eloss(real_type step) const -> Energy
+CELER_FUNCTION auto UrbanMscHelper::calc_eloss(real_type step) const -> Energy
 {
     auto calc_energy
         = physics_.make_calculator<InverseRangeCalculator>(range_gid_);
@@ -182,120 +133,22 @@ CELER_FUNCTION auto UrbanMscHelper::eloss(real_type step) const -> Energy
 /*!
  * Evaluate the kinetic energy at the end of a given msc step.
  */
-CELER_FUNCTION auto UrbanMscHelper::end_energy(real_type step) const -> Energy
+CELER_FUNCTION auto UrbanMscHelper::calc_end_energy(real_type step) const
+    -> Energy
 {
-    // The energy loss per unit length for a given particle energy
-    real_type dedx = physics_.make_calculator<EnergyLossCalculator>(
-        eloss_gid_)(inc_energy_);
-
-    return (step > range_ * this->dtrl())
-               ? this->eloss(range_ - step)
-               : Energy{inc_energy_.value() - step * dedx};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Define the minimum step using the ratio of lambda_elastic/lambda_transport.
- */
-CELER_FUNCTION real_type UrbanMscHelper::calc_step_min(Energy    energy,
-                                                       real_type lambda) const
-{
-    real_type re = energy.value();
-
-    return lambda
-           / (2 + real_type(1e3) * re * (msc_.stepmin_a + msc_.stepmin_b * re));
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Calculate the minimum of the true path length limit.
- */
-CELER_FUNCTION real_type UrbanMscHelper::calc_limit_min(Energy    energy,
-                                                        real_type step) const
-{
-    real_type xm = (is_positron_)
-                       ? real_type(0.70) * step * std::sqrt(msc_.zeff)
-                       : real_type(0.87) * step * msc_.z23;
-
-    if (energy.value() < this->tlow().value())
+    if (step <= range_ * dtrl_)
     {
-        // Energy is below a pre-defined limit
-        xm *= real_type(0.5) * (1 + energy.value() / this->tlow().value());
+        // Short step can be approximated with linear extrapolation.
+        real_type dedx = physics_.make_calculator<EnergyLossCalculator>(
+            eloss_gid_)(inc_energy_);
+
+        return Energy{inc_energy_.value() - step * dedx};
     }
-
-    return max<real_type>(xm, this->limit_min_fix());
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Sample a random true path length limit.
- */
-template<class Engine>
-CELER_FUNCTION real_type UrbanMscHelper::randomize_limit(
-    Engine& rng, real_type limit, real_type limit_min) const
-{
-    real_type result = limit_min;
-    if (limit > limit_min)
+    else
     {
-        NormalDistribution<real_type> gauss(
-            limit, real_type(0.1) * (limit - limit_min));
-        result = gauss(rng);
-        result = max<real_type>(result, limit_min);
+        // Longer step is calculated exactly with inverse range
+        return this->calc_eloss(range_ - step);
     }
-
-    return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Compute the true path length for a given geom path (the z -> t conversion).
- *
- * The transformation can be written as
- * \f[
- *     t(z) = \langle t \rangle = -\lambda_{1} \log(1 - \frac{z}{\lambda_{1}})
- * \f]
- * or \f$ t(z) = \frac{1}{\alpha} [ 1 - (1-\alpha w z)^{1/w}] \f$ if the
- * geom path is small, where \f$ w = 1 + \frac{1}{\alpha \lambda_{10}}\f$.
- *
- * @param true_path the proposed step before transportation.
- * @param geom_path the proposed step after transportation.
- * @param alpha variable from UrbanMscStepLimit.
- */
-CELER_FUNCTION
-real_type UrbanMscHelper::calc_true_path(real_type true_path,
-                                         real_type geom_path,
-                                         real_type alpha) const
-{
-    if (geom_path < 100 * this->limit_min_fix())
-    {
-        return geom_path;
-    }
-
-    // Recalculation
-    real_type lambda = msc_mfp(inc_energy_);
-    real_type length = geom_path;
-
-    // NOTE: add && !insideskin if the UseDistanceToBoundary algorithm is used
-    if (geom_path > lambda * tau_small_)
-    {
-        if (alpha < 0)
-        {
-            // For cases that the true path is very small compared to either
-            // the mean free path or the range
-            length = -lambda * std::log(1 - geom_path / lambda);
-        }
-        else
-        {
-            real_type w = 1 + 1 / (alpha * lambda);
-            real_type x = alpha * w * geom_path;
-            length      = (x < 1) ? (1 - fastpow(1 - x, 1 / w)) / alpha
-                                  : range_;
-        }
-
-        length = min<real_type>(true_path, max<real_type>(geom_path, length));
-    }
-
-    return length;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/physics/em/detail/UrbanMscStepLimit.hh
+++ b/src/physics/em/detail/UrbanMscStepLimit.hh
@@ -146,6 +146,9 @@ UrbanMscStepLimit::UrbanMscStepLimit(const UrbanMscRef&       shared,
     range_  = helper_.range();
     // Mean free path for MSC at current energy
     lambda_ = helper_.msc_mfp(inc_energy_);
+
+    // The slowing down range should already have been applied as a step limit
+    CELER_ENSURE(range_ >= phys_step_);
 }
 
 //---------------------------------------------------------------------------//
@@ -165,7 +168,7 @@ CELER_FUNCTION auto UrbanMscStepLimit::operator()(Engine& rng) -> MscStep
     MscStep result;
 
     result.phys_step = phys_step_;
-    result.true_path = min(phys_step_, range_);
+    result.true_path = phys_step_;
 
     // The case for a very small step or the lower limit for the linear
     // distance that e-/e+ can travel is far from the geometry boundary

--- a/test/base/Algorithms.test.cc
+++ b/test/base/Algorithms.test.cc
@@ -74,6 +74,17 @@ TEST(UtilityTest, trivial_swap)
 
 TEST(AlgorithmsTest, clamp)
 {
+    EXPECT_EQ(123, celeritas::clamp(123, 100, 200));
+    EXPECT_EQ(100, celeritas::clamp(99, 100, 200));
+    EXPECT_EQ(200, celeritas::clamp(999, 100, 200));
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(celeritas::clamp(150, 200, 100), celeritas::DebugError);
+    }
+}
+
+TEST(AlgorithmsTest, clamp_to_nonneg)
+{
     using celeritas::clamp_to_nonneg;
     constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
 
@@ -138,7 +149,6 @@ TEST(AlgorithmsTest, sort)
         EXPECT_VEC_EQ(expected_data, data);
     }
 }
-
 TEST(AlgorithmsTest, minmax)
 {
     EXPECT_EQ(1, celeritas::min<int>(1, 2));

--- a/test/base/NumericLimits.test.cc
+++ b/test/base/NumericLimits.test.cc
@@ -35,6 +35,7 @@ TYPED_TEST(RealNumericLimitsTest, host)
     EXPECT_EQ(std_limits_t::infinity(), celer_limits_t::infinity());
     EXPECT_EQ(std_limits_t::max(), celer_limits_t::max());
     EXPECT_TRUE(std::isnan(celer_limits_t::quiet_NaN()));
+    EXPECT_EQ(std_limits_t::infinity(), TypeParam(1) / TypeParam(0));
 }
 
 #if CELER_USE_DEVICE
@@ -50,6 +51,7 @@ TYPED_TEST(RealNumericLimitsTest, DISABLED_device)
     EXPECT_TRUE(std::isnan(result.nan));
     EXPECT_EQ(celer_limits_t::infinity(), result.inf);
     EXPECT_EQ(celer_limits_t::max(), result.max);
+    EXPECT_EQ(celer_limits_t::infinity(), result.inv_zero);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/base/NumericLimits.test.cu
+++ b/test/base/NumericLimits.test.cu
@@ -41,6 +41,10 @@ __global__ void nl_test_kernel(NLTestOutput<T>* data)
     {
         data->max = limits_t::max();
     }
+    else if (local_thread_id == 4)
+    {
+        data->inv_zero = T(1) / T(0);
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -56,7 +60,7 @@ NLTestOutput<T> nl_test()
 
     static const ::celeritas::KernelParamCalculator calc_launch_params(
         nl_test_kernel<T>, "nl_test", celeritas::device().threads_per_warp());
-    auto grid = calc_launch_params(3);
+    auto grid = calc_launch_params(4);
 
     CELER_LAUNCH_KERNEL_IMPL(nl_test_kernel<T>,
                              grid.blocks_per_grid,

--- a/test/base/NumericLimits.test.hh
+++ b/test/base/NumericLimits.test.hh
@@ -22,6 +22,7 @@ struct NLTestOutput
     T nan;
     T inf;
     T max;
+    T inv_zero; // Test for expected infinity
 };
 
 //---------------------------------------------------------------------------//

--- a/test/physics/em/UrbanMsc.test.cc
+++ b/test/physics/em/UrbanMsc.test.cc
@@ -261,14 +261,14 @@ TEST_F(UrbanMscTest, msc_scattering)
         geo_view    = {{r, r, r}, direction};
 
         this->set_inc_particle(pdg::electron(), MevEnergy{energy[i]});
-        phys.step_length(step[i]);
 
         UrbanMscStepLimit step_limiter(model->host_ref(),
                                        *part_view_,
                                        &geo_view,
                                        phys,
                                        material_view,
-                                       sim_track_view);
+                                       sim_track_view,
+                                       step[i]);
 
         step_result = step_limiter(rng_engine);
 

--- a/test/physics/em/UrbanMsc.test.cc
+++ b/test/physics/em/UrbanMsc.test.cc
@@ -214,25 +214,27 @@ TEST_F(UrbanMscTest, msc_scattering)
     MscInteraction sample_result;
 
     // Input
-    const unsigned int nsamples = 8;
+    static const real_type energy[] = {51.0231,
+                                       10.0564,
+                                       5.05808,
+                                       1.01162,
+                                       0.501328,
+                                       0.102364,
+                                       0.0465336,
+                                       0.00708839};
 
-    real_type energy[nsamples] = {51.0231,
-                                  10.0564,
-                                  5.05808,
-                                  1.01162,
-                                  0.501328,
-                                  0.102364,
-                                  0.0465336,
-                                  0.00708839};
+    static const real_type step[] = {0.00279169,
+                                     0.412343,
+                                     0.0376414,
+                                     0.078163296576415602,
+                                     0.031624394625545782,
+                                     0.002779271697902872,
+                                     0.00074215289000934838,
+                                     0.000031163160031423049};
 
-    real_type step[nsamples] = {0.00279169,
-                                0.412343,
-                                0.0376414,
-                                0.178529,
-                                0.0836231,
-                                0.125696,
-                                0.00143809,
-                                0.105187};
+    constexpr unsigned int nsamples = std::end(step) - std::begin(step);
+    static_assert(nsamples == std::end(energy) - std::begin(energy),
+                  "Input sizes do not match");
 
     // Mock SimStateData
     SimStateValue states_ref;


### PR DESCRIPTION
I got sidetracked while refactoring the `along_step` kernel trying to figure out the relationship between the various MSC step/path values.

- Move code from MSC helper class to the only place that it's used
- Move magic values to the MSC "user parameters" data routine
- Replace a `min` with an assertion for the range being greater than or equal to the physics step
- Add a `clamp` function to get rid of at least one confusing `min(max(a, b), c)` construction
- Remove redundant parameter `end_energy` that's already stored as member data