### PR TITLE
Add CLHEP/Celeritas constant conversion tests

### DIFF
--- a/src/base/Constants.hh
+++ b/src/base/Constants.hh
@@ -20,8 +20,8 @@ namespace constants
  *
  * Mathematical, numerical, and physical constants. Some of the physical
  * constants listed here are *exact* numerical values: see the International
- * System of Units, 9th ed., for definition of constants and how they relate to
- * the different units.
+ * System of Units, 9th ed. (2019), for definition of constants and how they
+ * relate to the different units.
  *
  * Celeritas            | CLHEP                   | Notes
  * -------------------- | ---------------------   | ------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,10 +87,13 @@ if(NOT CELERITAS_USE_Geant4)
 else()
   # Optional dependence on low-energy EM data
   set(_ds G4EMLOW)
-  set(_optional_geant4
+  set(_optional_geant4_env
      ENVIRONMENT "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
   )
-  set(_needs_geant4 ${_optional_geant4})
+  set(_optional_geant4_link
+    LINK_LIBRARIES ${Geant4_LIBRARIES}
+  )
+  set(_needs_geant4 ${_optional_geant4_env})
 endif()
 
 #-----------------------------------------------------------------------------#
@@ -107,7 +110,7 @@ celeritas_setup_tests(SERIAL PREFIX base)
 celeritas_add_test(base/Algorithms.test.cc)
 celeritas_add_test(base/Array.test.cc)
 celeritas_add_test(base/ArrayUtils.test.cc)
-celeritas_add_test(base/Constants.test.cc)
+celeritas_add_test(base/Constants.test.cc ${_optional_geant4_link})
 celeritas_add_test(base/Copier.test.cc GPU)
 celeritas_add_test(base/DeviceAllocation.test.cc GPU)
 celeritas_add_test(base/DeviceVector.test.cc GPU)
@@ -295,11 +298,11 @@ celeritas_add_test(physics/em/SeltzerBerger.test.cc)
 celeritas_add_test(physics/em/TsaiUrbanDistribution.test.cc)
 
 celeritas_add_test(physics/em/ImportedProcesses.test.cc ${_needs_root}
-  ${_optional_geant4}
+  ${_optional_geant4_env}
   LINK_LIBRARIES Celeritas::IO)
 
 celeritas_add_test(physics/em/UrbanMsc.test.cc ${_needs_root}
-  ${_optional_geant4}
+  ${_optional_geant4_env}
   LINK_LIBRARIES Celeritas::IO)
 
 #-----------------------------------------------------------------------------#

--- a/test/base/Constants.test.cc
+++ b/test/base/Constants.test.cc
@@ -9,9 +9,14 @@
 
 #include <cmath>
 
+#include "celeritas_config.h"
 #include "base/Units.hh"
 
 #include "celeritas_test.hh"
+
+#if CELERITAS_USE_GEANT4
+#    include "CLHEP/Units/PhysicalConstants.h"
+#endif
 
 using namespace celeritas::units;
 using namespace celeritas::constants;
@@ -80,3 +85,21 @@ TEST(ConstantsTest, derivative)
                      atomic_mass * c_light * c_light,
                      1e-11);
 }
+
+#if CELERITAS_USE_GEANT4
+TEST(ConstantsTest, clhep)
+{
+    EXPECT_SOFT_NEAR(a0_bohr, CLHEP::Bohr_radius / CLHEP::cm, 1e-7);
+    EXPECT_SOFT_NEAR(alpha_fine_structure, CLHEP::fine_structure_const, 1e-7);
+    // EXPECT_SOFT_NEAR(atomic_mass, CLHEP::amu, 1e-7);
+    // EXPECT_SOFT_NEAR(eps_electric, CLHEP::epsilon0, 1e-7);
+    EXPECT_SOFT_NEAR(h_planck, CLHEP::h_Planck, 1e-7);
+    EXPECT_SOFT_NEAR(k_boltzmann, CLHEP::k_Boltzmann, 1e-7);
+    // EXPECT_SOFT_NEAR(mu_magnetic, CLHEP::mu0, 1e-7);
+    EXPECT_SOFT_NEAR(na_avogadro, CLHEP::Avogadro, 1e-7);
+    EXPECT_SOFT_NEAR(
+        r_electron, CLHEP::classic_electr_radius / CLHEP::cm, 1e-7);
+    EXPECT_SOFT_NEAR(
+        lambdabar_electron, CLHEP::electron_Compton_length / CLHEP::cm, 1e-7);
+}
+#endif

--- a/test/base/Constants.test.cc
+++ b/test/base/Constants.test.cc
@@ -90,12 +90,15 @@ TEST(ConstantsTest, derivative)
 TEST(ConstantsTest, clhep)
 {
     EXPECT_SOFT_NEAR(a0_bohr, CLHEP::Bohr_radius / CLHEP::cm, 1e-7);
-    EXPECT_SOFT_NEAR(alpha_fine_structure, CLHEP::fine_structure_const, 1e-7);
-    // EXPECT_SOFT_NEAR(atomic_mass, CLHEP::amu, 1e-7);
-    // EXPECT_SOFT_NEAR(eps_electric, CLHEP::epsilon0, 1e-7);
+    EXPECT_SOFT_NEAR(alpha_fine_structure, CLHEP::fine_structure_const, 1e-9);
+    EXPECT_SOFT_NEAR(atomic_mass, CLHEP::amu / CLHEP::gram, 1e-7);
+    EXPECT_SOFT_NEAR(
+        eps_electric, CLHEP::epsilon0 / (CLHEP::gram * CLHEP::cm), 1e-7);
     EXPECT_SOFT_NEAR(h_planck, CLHEP::h_Planck, 1e-7);
     EXPECT_SOFT_NEAR(k_boltzmann, CLHEP::k_Boltzmann, 1e-7);
-    // EXPECT_SOFT_NEAR(mu_magnetic, CLHEP::mu0, 1e-7);
+    EXPECT_SOFT_NEAR(mu_magnetic * ampere * ampere / newton,
+                     CLHEP::mu0 * CLHEP::ampere * CLHEP::ampere / CLHEP::newton,
+                     1e-7);
     EXPECT_SOFT_NEAR(na_avogadro, CLHEP::Avogadro, 1e-7);
     EXPECT_SOFT_NEAR(
         r_electron, CLHEP::classic_electr_radius / CLHEP::cm, 1e-7);


### PR DESCRIPTION
Inspired by https://github.com/celeritas-project/celeritas/pull/401#discussion_r843322695 I want to make sure the constants that we see in Geant4 don't have mysterious multipliers. There are three CLHEP constants that seem to have some unusual non-SI units built in:
```
/rnsdhpc/code/celeritas/test/base/Constants.test.cc:94: Failure
Value of: CLHEP::amu
  Actual: 0.010364268824678106
Expected: atomic_mass
Which is: 1.6605390666e-24
(Absolute error 0.010364268824678106 exceeds tolerance 1.0000000000000001e-09)
/rnsdhpc/code/celeritas/test/base/Constants.test.cc:95: Failure
Value of: CLHEP::epsilon0
  Actual: 55263493610.6576
Expected: eps_electric
Which is: 8.8541878128000001e-21
(Absolute error 55263493610.6576 exceeds tolerance 1.0000000000000001e-09)
/rnsdhpc/code/celeritas/test/base/Constants.test.cc:98: Failure
Value of: CLHEP::mu0
  Actual: 2.0133545372510489e-16
Expected: mu_magnetic
Which is: 0.12566370621199999
(Relative error -0.99999999999999845 exceeds tolerance 9.9999999999999995e-08)
```

so maybe we can make sure we're doing apples-to-apples when we implement our constants and avoid more errors like #401 :)