### PR TITLE
Add signal handler to transport loop

### DIFF
--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -53,9 +53,9 @@ else:
     max_steps = 128
 
 if not use_device:
-    # Way more steps are needed since we're not tracking in parallel, so
-    # shorten to an even more unreasonably small number to reduce test time.
-    max_steps = 64
+    # Way more steps are needed since we're not tracking in parallel, but
+    # shorten to an unreasonably small number to reduce test time.
+    max_steps = 256
 
 inp = {
     'use_device': use_device,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ list(APPEND SOURCES
   comm/Logger.cc
   comm/LoggerTypes.cc
   comm/ScopedMpiInit.cc
+  comm/ScopedSignalHandler.cc
   comm/detail/LoggerMessage.cc
   geometry/GeoMaterialParams.cc
   orange/OrangeParams.cc

--- a/src/comm/ScopedSignalHandler.cc
+++ b/src/comm/ScopedSignalHandler.cc
@@ -1,0 +1,157 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ScopedSignalHandler.cc
+//---------------------------------------------------------------------------//
+#include "ScopedSignalHandler.hh"
+
+#include <csignal>
+
+#include "base/Assert.hh"
+
+#include "Environment.hh"
+#include "Logger.hh"
+
+namespace
+{
+//---------------------------------------------------------------------------//
+// Use an environment variable to disable signals
+bool determine_allow_signals()
+{
+    if (!celeritas::getenv("CELER_DISABLE_SIGNALS").empty())
+    {
+        CELER_LOG(info)
+            << "Disabling signal support since the 'CELER_DISABLE_SIGNALS' "
+               "environment variable is present and non-empty";
+        return false;
+    }
+    return true;
+}
+
+//---------------------------------------------------------------------------//
+// Bitset of signals that have been called
+volatile sig_atomic_t celer_signal_bits = 0;
+
+//---------------------------------------------------------------------------//
+//! Set the bit corresponding to a signal
+extern "C" void celer_set_signal(int signal)
+{
+    CELER_ASSERT(signal >= 0 && signal < static_cast<int>(sizeof(int) * 8 - 1));
+    celer_signal_bits |= (1 << signal);
+}
+
+//---------------------------------------------------------------------------//
+//! Clear the bit corresponding to a signal
+void celer_clr_signal(int signal)
+{
+    celer_signal_bits &= ~(1 << signal);
+}
+
+//---------------------------------------------------------------------------//
+//! Set the bit corresponding to a signal
+bool celer_chk_signal(int signal)
+{
+    return celer_signal_bits & (1 << signal);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Whether signal handling is enabled.
+ */
+bool ScopedSignalHandler::allow_signals()
+{
+    static bool result = determine_allow_signals();
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Handle the given signal type.
+ */
+ScopedSignalHandler::ScopedSignalHandler(signal_type sig)
+{
+    CELER_EXPECT(sig >= 0);
+
+    if (!ScopedSignalHandler::allow_signals())
+    {
+        // Signal handling is disabled and an info message has already been
+        // displayed
+        return;
+    }
+
+    CELER_VALIDATE(!celer_chk_signal(sig),
+                   << "unhandled signal " << sig
+                   << " when creating new signal handler");
+
+    // Register signal
+    signal_      = sig;
+    prev_handle_ = std::signal(signal_, celer_set_signal);
+
+    CELER_ENSURE(prev_handle_ != SIG_ERR);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Release the given signal.
+ */
+ScopedSignalHandler::~ScopedSignalHandler()
+{
+    if (signal_ >= 0)
+    {
+        // Clear signal bit
+        celer_clr_signal(signal_);
+        // Restore signal handler
+        std::signal(signal_, prev_handle_);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Move construct.
+ */
+ScopedSignalHandler::ScopedSignalHandler(ScopedSignalHandler&& other) noexcept
+{
+    this->swap(other);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Move assign.
+ */
+ScopedSignalHandler&
+ScopedSignalHandler::operator=(ScopedSignalHandler&& other) noexcept
+{
+    ScopedSignalHandler temp(std::move(other));
+    this->swap(temp);
+    return *this;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Swap.
+ */
+void ScopedSignalHandler::swap(ScopedSignalHandler& other) noexcept
+{
+    using std::swap;
+    swap(signal_, other.signal_);
+    swap(prev_handle_, other.prev_handle_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * True if signal was intercepted.
+ */
+bool ScopedSignalHandler::check_signal() const
+{
+    return celer_chk_signal(signal_);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -142,6 +142,7 @@ celeritas_add_test(comm/Environment.test.cc
   ENVIRONMENT "ENVTEST_ONE=1;ENVTEST_ZERO=0;ENVTEST_EMPTY="
 )
 celeritas_add_test(comm/Logger.test.cc)
+celeritas_add_test(comm/ScopedSignalHandler.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Field

--- a/test/comm/ScopedSignalHandler.test.cc
+++ b/test/comm/ScopedSignalHandler.test.cc
@@ -1,0 +1,88 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ScopedSignalHandler.test.cc
+//---------------------------------------------------------------------------//
+#include "comm/ScopedSignalHandler.hh"
+
+#include <csignal>
+
+#include "celeritas_test.hh"
+
+using celeritas::ScopedSignalHandler;
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST(ScopedSignalHandlerTest, single)
+{
+    {
+        ScopedSignalHandler interrupted(SIGINT);
+        EXPECT_TRUE(interrupted);
+        EXPECT_FALSE(interrupted());
+        std::raise(SIGINT);
+        EXPECT_TRUE(interrupted());
+    }
+    {
+        ScopedSignalHandler interrupted(SIGINT);
+        EXPECT_TRUE(interrupted);
+        EXPECT_FALSE(interrupted());
+        std::raise(SIGINT);
+        EXPECT_TRUE(interrupted());
+        interrupted = {};
+        EXPECT_FALSE(interrupted());
+        EXPECT_FALSE(interrupted);
+    }
+}
+
+TEST(ScopedSignalHandlerTest, nested)
+{
+    {
+        ScopedSignalHandler interrupted(SIGINT);
+        EXPECT_FALSE(interrupted());
+        {
+            // Nested of different type
+            ScopedSignalHandler terminating(SIGTERM);
+            EXPECT_FALSE(terminating());
+            std::raise(SIGINT);
+            EXPECT_TRUE(interrupted());
+            EXPECT_FALSE(terminating());
+            std::raise(SIGTERM);
+            EXPECT_TRUE(interrupted());
+            EXPECT_TRUE(terminating());
+        }
+
+        // Cannot create a new handler while an interrupt is unhandled for
+        // that type
+        EXPECT_THROW(ScopedSignalHandler(SIGINT), celeritas::RuntimeError);
+
+        // Clear outer interrupt
+        interrupted = {};
+        {
+            ScopedSignalHandler also_interrupted(SIGINT);
+            EXPECT_FALSE(also_interrupted());
+            std::raise(SIGINT);
+            EXPECT_TRUE(also_interrupted());
+        }
+    }
+    {
+        ScopedSignalHandler outer(SIGINT);
+        EXPECT_FALSE(outer());
+        {
+            ScopedSignalHandler inner(SIGINT);
+            EXPECT_FALSE(inner());
+            std::raise(SIGINT);
+            EXPECT_TRUE(inner());
+            EXPECT_TRUE(outer());
+        }
+        // Inner destructor clears signal
+        EXPECT_FALSE(outer());
+
+        // Outer should still be able to handle signals though
+        std::raise(SIGINT);
+        EXPECT_TRUE(outer());
+    }
+}


### PR DESCRIPTION
I'm trying to debug a stuck GPU loop (!) and it would be good to know if it's unable to kill the last tracks or if it's stuck inside a kernel. This signal handler is a way of breaking out of the loop and returning available diagnostic information.