### PR TITLE
Add a Helix stepper

### DIFF
--- a/src/field/HelixStepper.hh
+++ b/src/field/HelixStepper.hh
@@ -1,0 +1,164 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020-2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file HelixStepper.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "base/Types.hh"
+
+#include "Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * The Helix Stepper
+ *
+ * The analytical solution for the motion of a charged particle in a uniform
+ * magnetic field.
+ */
+template<class EquationT>
+class HelixStepper
+{
+  public:
+    //!@{
+    //! Type aliases
+    using Result = StepperResult;
+    //!@}
+
+  public:
+    // Construct with the equation of motion
+    CELER_FUNCTION
+    HelixStepper(const EquationT& eq) : equation_(eq) {}
+
+    // Adaptive step size control
+    CELER_FUNCTION auto operator()(real_type step, const OdeState& beg_state)
+        -> Result;
+
+  private:
+    //// DATA ////
+
+    // Equation of the motion
+    const EquationT& equation_;
+
+    //// HELPER FUNCTIONS ////
+
+    // Analytical solution for a given step along a helix trajectory
+    CELER_FUNCTION OdeState move(real_type       step,
+                                 real_type       radius,
+                                 real_type       helicity,
+                                 const OdeState& beg_state,
+                                 const OdeState& rhs);
+
+    //// COMMON PROPERTIES ////
+
+    static CELER_CONSTEXPR_FUNCTION real_type tolerance() { return 1e-10; }
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * An explicit helix stepper with analytical solutions at the end and the
+ * middle point for a given step.
+ *
+ * Assuming that the magnetic field is uniform and chosen to be parallel to
+ * the z-axis, \f$B = (0, 0, B_z)\f$, without loss of generality, the motion of
+ * a charged particle is described by a helix trajectory. For this algorithm,
+ * the radius of the helix, \f$R = m gamma v/(qB)\f$ and the helicity, defined
+ * as \f$ -sign(q B_z)\f$ are evaluated through the right hand side of the ODE
+ * equation where q is the charge of the particle.
+ */
+template<class E>
+CELER_FUNCTION auto
+HelixStepper<E>::operator()(real_type step, const OdeState& beg_state)
+    -> Result
+{
+    Result result;
+
+    // Evaluate the right hand side of the equation
+    OdeState rhs = equation_(beg_state);
+
+    // Calculate the radius of the helix
+    real_type radius
+        = sqrt(ipow<2>(norm(beg_state.mom)) - ipow<2>(beg_state.mom[2]))
+          / norm(rhs.mom);
+
+    // Set the helicity: 1(-1) for negative(positive) charge with Bz > 0
+    real_type helicity = (rhs.mom[0] / rhs.pos[1] < 0) ? 1 : -1;
+
+    // State after the half step
+    result.mid_state
+        = move(real_type(0.5) * step, radius, helicity, beg_state, rhs);
+
+    // State after the full step
+    result.end_state = move(step, radius, helicity, beg_state, rhs);
+
+    // Solution are exact, but assign a tolerance for numerical treatments
+    for (auto i : range(3))
+    {
+        result.err_state.pos[i] += HelixStepper::tolerance();
+        result.err_state.mom[i] += HelixStepper::tolerance();
+    }
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Equations of a charged particle motion in a uniform magnetic field,
+ * \f$B(0, 0, B_z)\f$ along the curved trajectory \f$ds = v dt\f$ are
+ * \f[
+ *  d^2 x/ds^2 =  q/p (dy/ds) B_z
+ *  d^2 y/ds^2 = -q/p (dx/ds) B_z
+ *  d^2 z/ds^2 =  0
+ * \f]
+ * where \q and \p are the charge and the absolute momentum of the particle,
+ * respectively. Since the motion in the perpendicular plane with respected to
+ * the to the magnetic field is circular with a constant \f$p_{\perp}\f$, the
+ * final ODE state of the perpendicular motion on the circle for a given step
+ * length \s is
+ * \f[
+ *  (x, y) = M(\phi) (x_0, y_0)^T
+ *  (px, py) = M(\phi) (px_0, py_0)^T
+ * \f]
+ * where \f$\phi = s/R\f$ is the azimuth angle of the particle position between
+ * the start and the end position and \f$M(\phi)\f$ is the rotational matrix.
+ * The solution for the parallel direction along the field is trivial.
+ */
+template<class E>
+CELER_FUNCTION OdeState HelixStepper<E>::move(real_type       step,
+                                              real_type       radius,
+                                              real_type       helicity,
+                                              const OdeState& beg_state,
+                                              const OdeState& rhs)
+{
+    OdeState end_state;
+
+    // Solution for position and momentum after moving delta_phi on the helix
+    real_type delta_phi = helicity * (step / radius);
+    real_type sin_phi   = std::sin(delta_phi);
+    real_type cos_phi   = std::cos(delta_phi);
+
+    end_state.pos = {(beg_state.pos[0] * cos_phi - beg_state.pos[1] * sin_phi),
+                     (beg_state.pos[0] * sin_phi + beg_state.pos[1] * cos_phi),
+                     beg_state.pos[2] + helicity * step * rhs.pos[2]};
+
+    end_state.mom = {rhs.pos[0] * cos_phi - rhs.pos[1] * sin_phi,
+                     rhs.pos[0] * sin_phi + rhs.pos[1] * cos_phi,
+                     rhs.pos[2]};
+
+    real_type momentum = norm(beg_state.mom);
+    for (auto i : range(3))
+    {
+        end_state.mom[i] *= momentum;
+    }
+
+    return end_state;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/field/MagFieldEquation.hh
+++ b/src/field/MagFieldEquation.hh
@@ -28,6 +28,12 @@ template<class FieldT>
 class MagFieldEquation
 {
   public:
+    //!@{
+    //! Type aliases
+    using field_type = FieldT;
+    //!@}
+
+  public:
     // Construct with a magnetic field
     inline CELER_FUNCTION
     MagFieldEquation(const FieldT& field, units::ElementaryCharge q);
@@ -36,7 +42,7 @@ class MagFieldEquation
     inline CELER_FUNCTION auto operator()(const OdeState& y) const -> OdeState;
 
   private:
-    const FieldT&           field_;
+    const field_type&       field_;
     units::ElementaryCharge charge_;
     real_type               coeffi_;
 };

--- a/src/field/UniformZMagField.hh
+++ b/src/field/UniformZMagField.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file UniformMagField.hh
+//! \file UniformZMagField.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -14,16 +14,16 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * A uniform magnetic field
+ * A uniform magnetic field along Z axis
  */
-class UniformMagField
+class UniformZMagField
 {
   public:
-    // Construct with a uniform magnetic field vector
+    // Construct with a scalar magnetic field value
     CELER_FUNCTION
-    explicit UniformMagField(Real3 value) : value_(value) {}
+    explicit UniformZMagField(real_type value) : value_({0, 0, value}) {}
 
-    // Return a const magnetic field value
+    // Return a constant magnetic field value along Z axis
     CELER_FUNCTION
     Real3 operator()(CELER_MAYBE_UNUSED const Real3& pos) const
     {

--- a/src/field/ZHelixStepper.hh
+++ b/src/field/ZHelixStepper.hh
@@ -24,6 +24,11 @@ namespace celeritas
 template<class EquationT>
 class ZHelixStepper
 {
+    // Check whether the field_type used in EquationT is UniformZMagField
+    static_assert(
+        std::is_same<typename EquationT::field_type, UniformZMagField>::value,
+        "ZHelix stepper only works with UniformZMagField");
+
   public:
     //!@{
     //! Type aliases
@@ -33,13 +38,7 @@ class ZHelixStepper
   public:
     // Construct with the equation of motion
     CELER_FUNCTION
-    ZHelixStepper(const EquationT& eq) : equation_(eq)
-    {
-        static_assert(
-            std::is_same<typename EquationT::field_type, UniformZMagField>::value,
-            "ZHelix stepper only works with uniform magnetic fields along "
-            "`z`");
-    }
+    ZHelixStepper(const EquationT& eq) : equation_(eq) {}
 
     // Adaptive step size control
     CELER_FUNCTION auto operator()(real_type step, const OdeState& beg_state)

--- a/src/field/ZHelixStepper.hh
+++ b/src/field/ZHelixStepper.hh
@@ -10,6 +10,7 @@
 #include "base/Types.hh"
 
 #include "Types.hh"
+#include "UniformZMagField.hh"
 
 namespace celeritas
 {
@@ -32,7 +33,13 @@ class ZHelixStepper
   public:
     // Construct with the equation of motion
     CELER_FUNCTION
-    ZHelixStepper(const EquationT& eq) : equation_(eq) {}
+    ZHelixStepper(const EquationT& eq) : equation_(eq)
+    {
+        static_assert(
+            std::is_same<typename EquationT::field_type, UniformZMagField>::value,
+            "ZHelix stepper only works with uniform magnetic fields along "
+            "`z`");
+    }
 
     // Adaptive step size control
     CELER_FUNCTION auto operator()(real_type step, const OdeState& beg_state)

--- a/src/field/ZHelixStepper.hh
+++ b/src/field/ZHelixStepper.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file HelixStepper.hh
+//! \file ZHelixStepper.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -21,7 +21,7 @@ namespace celeritas
  * magnetic field along the z-direction.
  */
 template<class EquationT>
-class HelixStepper
+class ZHelixStepper
 {
   public:
     //!@{
@@ -32,7 +32,7 @@ class HelixStepper
   public:
     // Construct with the equation of motion
     CELER_FUNCTION
-    HelixStepper(const EquationT& eq) : equation_(eq) {}
+    ZHelixStepper(const EquationT& eq) : equation_(eq) {}
 
     // Adaptive step size control
     CELER_FUNCTION auto operator()(real_type step, const OdeState& beg_state)
@@ -81,7 +81,7 @@ class HelixStepper
  */
 template<class E>
 CELER_FUNCTION auto
-HelixStepper<E>::operator()(real_type step, const OdeState& beg_state)
+ZHelixStepper<E>::operator()(real_type step, const OdeState& beg_state)
     -> Result
 {
     Result result;
@@ -107,8 +107,8 @@ HelixStepper<E>::operator()(real_type step, const OdeState& beg_state)
     // Solution are exact, but assign a tolerance for numerical treatments
     for (auto i : range(3))
     {
-        result.err_state.pos[i] += HelixStepper::tolerance();
-        result.err_state.mom[i] += HelixStepper::tolerance();
+        result.err_state.pos[i] += ZHelixStepper::tolerance();
+        result.err_state.mom[i] += ZHelixStepper::tolerance();
     }
 
     return result;
@@ -139,11 +139,11 @@ HelixStepper<E>::operator()(real_type step, const OdeState& beg_state)
  * The solution for the parallel direction along the field is trivial.
  */
 template<class E>
-CELER_FUNCTION OdeState HelixStepper<E>::move(real_type       step,
-                                              real_type       radius,
-                                              Helicity        helicity,
-                                              const OdeState& beg_state,
-                                              const OdeState& rhs)
+CELER_FUNCTION OdeState ZHelixStepper<E>::move(real_type       step,
+                                               real_type       radius,
+                                               Helicity        helicity,
+                                               const OdeState& beg_state,
+                                               const OdeState& rhs)
 {
     OdeState end_state;
 

--- a/test/field/FieldDriver.test.cc
+++ b/test/field/FieldDriver.test.cc
@@ -11,9 +11,9 @@
 #include "base/Constants.hh"
 #include "base/Range.hh"
 #include "base/Types.hh"
+#include "field/DormandPrinceStepper.hh"
 #include "field/FieldParamsData.hh"
 #include "field/MagFieldEquation.hh"
-#include "field/RungeKuttaStepper.hh"
 #include "field/Types.hh"
 #include "field/UniformMagField.hh"
 
@@ -62,7 +62,8 @@ TEST_F(FieldDriverTest, field_driver_host)
 {
     // Construct FieldDriver
     UniformMagField field({0, 0, test_params.field_value});
-    using RKTraits = detail::MagTestTraits<UniformMagField, RungeKuttaStepper>;
+    using RKTraits
+        = detail::MagTestTraits<UniformMagField, DormandPrinceStepper>;
     RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
     RKTraits::Stepper_t  rk4(equation);
     RKTraits::Driver_t   driver(field_params, &rk4);
@@ -113,7 +114,8 @@ TEST_F(FieldDriverTest, accurate_advance_host)
 {
     // Construct FieldDriver
     UniformMagField field({0, 0, test_params.field_value});
-    using RKTraits = detail::MagTestTraits<UniformMagField, RungeKuttaStepper>;
+    using RKTraits
+        = detail::MagTestTraits<UniformMagField, DormandPrinceStepper>;
     RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
     RKTraits::Stepper_t  rk4(equation);
     RKTraits::Driver_t   driver(field_params, &rk4);

--- a/test/field/FieldDriver.test.cu
+++ b/test/field/FieldDriver.test.cu
@@ -15,10 +15,10 @@
 #include "base/Range.hh"
 #include "base/Types.hh"
 #include "comm/Device.hh"
+#include "field/DormandPrinceStepper.hh"
 #include "field/FieldDriver.hh"
 #include "field/FieldParamsData.hh"
 #include "field/MagFieldEquation.hh"
-#include "field/RungeKuttaStepper.hh"
 #include "field/UniformMagField.hh"
 
 #include "FieldTestParams.hh"
@@ -47,7 +47,8 @@ __global__ void driver_test_kernel(const FieldParamsData data,
 
     // Construct the driver
     UniformMagField field({0, 0, test_params.field_value});
-    using RKTraits = detail::MagTestTraits<UniformMagField, RungeKuttaStepper>;
+    using RKTraits
+        = detail::MagTestTraits<UniformMagField, DormandPrinceStepper>;
     RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
     RKTraits::Stepper_t  rk4(equation);
     RKTraits::Driver_t   driver(data, &rk4);
@@ -98,7 +99,8 @@ __global__ void accurate_advance_kernel(const FieldParamsData data,
 
     // Construct the driver
     UniformMagField field({0, 0, test_params.field_value});
-    using RKTraits = detail::MagTestTraits<UniformMagField, RungeKuttaStepper>;
+    using RKTraits
+        = detail::MagTestTraits<UniformMagField, DormandPrinceStepper>;
     RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
     RKTraits::Stepper_t  rk4(equation);
     RKTraits::Driver_t   driver(data, &rk4);

--- a/test/field/FieldPropagator.test.cc
+++ b/test/field/FieldPropagator.test.cc
@@ -8,11 +8,11 @@
 #include "field/FieldPropagator.hh"
 
 #include "base/CollectionStateStore.hh"
+#include "field/DormandPrinceStepper.hh"
 #include "field/FieldDriver.hh"
 #include "field/FieldParamsData.hh"
 #include "field/MagFieldEquation.hh"
 #include "field/MagFieldTraits.hh"
-#include "field/RungeKuttaStepper.hh"
 #include "field/UniformMagField.hh"
 #include "geometry/GeoData.hh"
 #include "geometry/GeoParams.hh"
@@ -127,7 +127,7 @@ TEST_F(FieldPropagatorHostTest, field_propagator_host)
 
     // Construct FieldPropagator
     UniformMagField field({0, 0, test.field_value});
-    using RKTraits = MagFieldTraits<UniformMagField, RungeKuttaStepper>;
+    using RKTraits = MagFieldTraits<UniformMagField, DormandPrinceStepper>;
     RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
     RKTraits::Stepper_t  rk4(equation);
     RKTraits::Driver_t   driver(field_params, &rk4);
@@ -186,7 +186,7 @@ TEST_F(FieldPropagatorHostTest, boundary_crossing_host)
 
     // Construct FieldDriver
     UniformMagField field({0, 0, test.field_value});
-    using RKTraits = MagFieldTraits<UniformMagField, RungeKuttaStepper>;
+    using RKTraits = MagFieldTraits<UniformMagField, DormandPrinceStepper>;
     RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
     RKTraits::Stepper_t  rk4(equation);
     RKTraits::Driver_t   driver(field_params, &rk4);

--- a/test/field/FieldPropagator.test.cu
+++ b/test/field/FieldPropagator.test.cu
@@ -12,12 +12,12 @@
 #include "base/device_runtime_api.h"
 #include "base/KernelParamCalculator.device.hh"
 #include "comm/Device.hh"
+#include "field/DormandPrinceStepper.hh"
 #include "field/FieldDriver.hh"
 #include "field/FieldParamsData.hh"
 #include "field/FieldPropagator.hh"
 #include "field/MagFieldEquation.hh"
 #include "field/MagFieldTraits.hh"
-#include "field/RungeKuttaStepper.hh"
 #include "field/UniformMagField.hh"
 #include "geometry/GeoTrackView.hh"
 #include "physics/base/ParticleTrackView.hh"
@@ -61,7 +61,7 @@ __global__ void fp_test_kernel(const int                  size,
 
     // Construct the RK stepper adnd propagator in a field
     UniformMagField field({0, 0, test.field_value});
-    using RKTraits = MagFieldTraits<UniformMagField, RungeKuttaStepper>;
+    using RKTraits = MagFieldTraits<UniformMagField, DormandPrinceStepper>;
     RKTraits::Equation_t   equation(field, units::ElementaryCharge{-1});
     RKTraits::Stepper_t    rk4(equation);
     RKTraits::Driver_t     driver(field_params, &rk4);
@@ -118,7 +118,7 @@ __global__ void bc_test_kernel(const int                  size,
 
     // Construct the RK stepper and propagator in a field
     UniformMagField field({0, 0, test.field_value});
-    using RKTraits = MagFieldTraits<UniformMagField, RungeKuttaStepper>;
+    using RKTraits = MagFieldTraits<UniformMagField, DormandPrinceStepper>;
     RKTraits::Equation_t   equation(field, units::ElementaryCharge{-1});
     RKTraits::Stepper_t    rk4(equation);
     RKTraits::Driver_t     driver(field_params, &rk4);

--- a/test/field/Steppers.test.cc
+++ b/test/field/Steppers.test.cc
@@ -13,10 +13,10 @@
 #include "base/Types.hh"
 #include "base/Units.hh"
 #include "field/DormandPrinceStepper.hh"
-#include "field/HelixStepper.hh"
 #include "field/MagFieldEquation.hh"
 #include "field/RungeKuttaStepper.hh"
 #include "field/UniformMagField.hh"
+#include "field/ZHelixStepper.hh"
 #include "physics/base/Units.hh"
 
 #include "FieldTestParams.hh"
@@ -139,7 +139,7 @@ class SteppersTest : public Test
 TEST_F(SteppersTest, host_helix)
 {
     // Test the analytical Helix stepper
-    this->template run_stepper<HelixStepper>();
+    this->template run_stepper<ZHelixStepper>();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/field/Steppers.test.cc
+++ b/test/field/Steppers.test.cc
@@ -13,6 +13,7 @@
 #include "base/Types.hh"
 #include "base/Units.hh"
 #include "field/DormandPrinceStepper.hh"
+#include "field/HelixStepper.hh"
 #include "field/MagFieldEquation.hh"
 #include "field/RungeKuttaStepper.hh"
 #include "field/UniformMagField.hh"
@@ -40,10 +41,16 @@ class SteppersTest : public Test
           an electron in a uniform magnetic field along the z-direction with
           initial velocity (v0), position (pos_0) and direction (dir_0).
 
-          B     = {0.0, 0.0, 1.0*units::tesla};
-          v_0   = 0.999*units::c_light
-          pos_0 = {radius, 0.0, 0.0}
+          B     = {0.0, 0.0, 1.0 * units::tesla}
+          v_0   = 0.999 * constants::c_light
           dir_0 = {0.0, 0.96, 0.28}
+
+          gamma = 1.0/sqrt(1-ipow<2>(v0/constants::c_light))
+          radius = constants::electron_mass*gamma *v0/(constants::e_electron*B)
+          mass = constants::electron_mass*ipow<2>(constants::c_light)/MeV
+
+          pos_0 = {radius, 0.0, 0.0}
+          mom_0 = mass * sqrt(ipow<2>(gamma) - 1) * dir_0
         */
 
         param.field_value = 1.0 * units::tesla; //! field value along z [tesla]
@@ -57,138 +64,128 @@ class SteppersTest : public Test
         param.epsilon     = 1.0e-5;             //! tolerance error
     }
 
-  protected:
+    template<template<class> class TStepper>
+    void run_stepper()
+    {
+        // Construct a stepper for testing
+        UniformMagField field({0, 0, param.field_value});
+
+        using Traits =
+            typename detail::MagTestTraits<UniformMagField, TStepper>;
+
+        typename Traits::Equation_t equation(field,
+                                             units::ElementaryCharge{-1});
+        typename Traits::Stepper_t  stepper(equation);
+
+        // Test parameters and the sub-step size
+        real_type hstep = 2.0 * constants::pi * param.radius / param.nsteps;
+
+        // Only test every 128 states to reduce debug runtime
+        for (unsigned int i : celeritas::range(param.nstates).step(128u))
+        {
+            // Initial state and the epected state after revolutions
+            OdeState y;
+            y.pos = {param.radius, 0.0, i * 1.0e-6};
+            y.pos = {param.radius, 0.0, 0};
+            y.mom = {0.0, param.momentum_y, param.momentum_z};
+
+            OdeState expected_y = y;
+
+            // Try the stepper by hstep for (num_revolutions * num_steps) times
+            real_type total_err2 = 0;
+            for (int nr : range(param.revolutions))
+            {
+                // Travel hstep for num_steps times in the field
+                expected_y.pos[2] = param.delta_z * (nr + 1) + i * 1.0e-6;
+                expected_y.pos[2] = param.delta_z * (nr + 1);
+                for (CELER_MAYBE_UNUSED int j : celeritas::range(param.nsteps))
+                {
+                    StepperResult result = stepper(hstep, y);
+                    y                    = result.end_state;
+
+                    total_err2 += detail::truncation_error(
+                        hstep, 0.001, y, result.err_state);
+                }
+                // Check the state after each revolution and the total error
+                EXPECT_VEC_NEAR(expected_y.pos, y.pos, sqrt(total_err2));
+                EXPECT_VEC_NEAR(expected_y.mom, y.mom, sqrt(total_err2));
+                EXPECT_LT(total_err2, param.epsilon);
+            }
+        }
+    }
+
+    void check_result(StepperTestOutput output)
+    {
+        // Check gpu stepper results
+        real_type zstep = param.delta_z * param.revolutions;
+        for (auto i : celeritas::range(output.pos_x.size()))
+        {
+            real_type error = std::sqrt(output.error[i]);
+            EXPECT_SOFT_NEAR(output.pos_x[i], param.radius, error);
+            EXPECT_SOFT_NEAR(output.pos_z[i], zstep + i * 1.0e-6, error);
+            EXPECT_SOFT_NEAR(output.mom_y[i], param.momentum_y, error);
+            EXPECT_SOFT_NEAR(output.mom_z[i], param.momentum_z, error);
+            EXPECT_LT(output.error[i], param.epsilon);
+        }
+    }
+
     // Test parameters
     FieldTestParams param;
 };
 
 //---------------------------------------------------------------------------//
-// TESTS
+// HOST TESTS
 //---------------------------------------------------------------------------//
-
-TEST_F(SteppersTest, host_classical_rk4)
+TEST_F(SteppersTest, host_helix)
 {
-    // Construct the Runge-Kutta stepper
-    UniformMagField field({0, 0, param.field_value});
-
-    using RKTraits = detail::MagTestTraits<UniformMagField, RungeKuttaStepper>;
-    RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
-    RKTraits::Stepper_t  rk4(equation);
-
-    // Test parameters and the sub-step size
-    real_type hstep = 2.0 * constants::pi * param.radius / param.nsteps;
-
-    // Only test every 128 states to reduce debug runtime
-    for (unsigned int i : celeritas::range(param.nstates).step(128u))
-    {
-        // Initial state and the epected state after revolutions
-        OdeState y;
-        y.pos = {param.radius, 0.0, i * 1.0e-6};
-        y.mom = {0.0, param.momentum_y, param.momentum_z};
-
-        OdeState expected_y = y;
-
-        // Try the stepper by hstep for (num_revolutions * num_steps) times
-        real_type total_err2 = 0;
-        for (int nr : range(param.revolutions))
-        {
-            // Travel hstep for num_steps times in the field
-            expected_y.pos[2] = param.delta_z * (nr + 1) + i * 1.0e-6;
-            for (CELER_MAYBE_UNUSED int j : celeritas::range(param.nsteps))
-            {
-                StepperResult result = rk4(hstep, y);
-                y                    = result.end_state;
-                total_err2 += detail::truncation_error(
-                    hstep, 0.001, y, result.err_state);
-            }
-            // Check the state after each revolution and the total error
-            EXPECT_VEC_NEAR(expected_y.pos, y.pos, sqrt(total_err2));
-            EXPECT_VEC_NEAR(expected_y.mom, y.mom, sqrt(total_err2));
-            EXPECT_LT(total_err2, param.epsilon);
-        }
-    }
+    // Test the analytical Helix stepper
+    this->template run_stepper<HelixStepper>();
 }
 
+//---------------------------------------------------------------------------//
+TEST_F(SteppersTest, host_classical_rk4)
+{
+    // Test the classical 4th order Runge-Kutta stepper
+    this->template run_stepper<RungeKuttaStepper>();
+}
+
+//---------------------------------------------------------------------------//
 TEST_F(SteppersTest, host_dormand_prince_547)
 {
-    // Construct the Runge-Kutta stepper
-    UniformMagField field({0, 0, param.field_value});
+    // Test the Dormand-Prince 547(M) stepper
+    this->template run_stepper<DormandPrinceStepper>();
+}
 
-    using RKTraits
-        = detail::MagTestTraits<UniformMagField, DormandPrinceStepper>;
-    RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
-    RKTraits::Stepper_t  dp547(equation);
+//---------------------------------------------------------------------------//
+// DEVICE TESTS
+//---------------------------------------------------------------------------//
+TEST_F(SteppersTest, TEST_IF_CELER_DEVICE(device_helix))
+{
+    // Run the Helix kernel
+    auto output = helix_test(param);
 
-    // Test parameters and the sub-step size
-    real_type hstep = 2.0 * constants::pi * param.radius / param.nsteps;
-
-    // Only test every 128 states to reduce debug runtime
-    for (unsigned int i : celeritas::range(param.nstates).step(128u))
-    {
-        // Initial state and the epected state after revolutions
-        OdeState y;
-        y.pos = {param.radius, 0.0, i * 1.0e-6};
-        y.mom = {0.0, param.momentum_y, param.momentum_z};
-
-        OdeState expected_y = y;
-
-        // Try the stepper by hstep for (num_revolutions * num_steps) times
-        real_type total_err2 = 0;
-        for (int nr : range(param.revolutions))
-        {
-            // Travel hstep for num_steps times in the field
-            expected_y.pos[2] = param.delta_z * (nr + 1) + i * 1.0e-6;
-            for (CELER_MAYBE_UNUSED int j : celeritas::range(param.nsteps))
-            {
-                StepperResult result = dp547(hstep, y);
-                y                    = result.end_state;
-                total_err2 += detail::truncation_error(
-                    hstep, 0.001, y, result.err_state);
-            }
-            // Check the state after each revolution and the total error
-            EXPECT_VEC_NEAR(expected_y.pos, y.pos, sqrt(total_err2));
-            EXPECT_VEC_NEAR(expected_y.mom, y.mom, sqrt(total_err2));
-            EXPECT_LT(total_err2, param.epsilon);
-        }
-    }
+    // Check stepper results
+    check_result(output);
 }
 
 //---------------------------------------------------------------------------//
 TEST_F(SteppersTest, TEST_IF_CELER_DEVICE(device_classical_rk4))
 {
-    // Run the classical RungeKutta kernel
+    // Run the classical Runge-Kutta kernel
     auto output = rk4_test(param);
 
     // Check stepper results
-    real_type zstep = param.delta_z * param.revolutions;
-    for (auto i : celeritas::range(output.pos_x.size()))
-    {
-        real_type error = std::sqrt(output.error[i]);
-        EXPECT_SOFT_NEAR(output.pos_x[i], param.radius, error);
-        EXPECT_SOFT_NEAR(output.pos_z[i], zstep + i * 1.0e-6, error);
-        EXPECT_SOFT_NEAR(output.mom_y[i], param.momentum_y, error);
-        EXPECT_SOFT_NEAR(output.mom_z[i], param.momentum_z, error);
-        EXPECT_LT(output.error[i], param.epsilon);
-    }
+    check_result(output);
 }
 
 //---------------------------------------------------------------------------//
 TEST_F(SteppersTest, TEST_IF_CELER_DEVICE(device_dormand_prince_547))
 {
-    // Run the classical RungeKutta kernel
+    // Run the Dormand-Prince 547(M) kernel
     auto output = dp547_test(param);
 
     // Check stepper results
-    real_type zstep = param.delta_z * param.revolutions;
-    for (auto i : celeritas::range(output.pos_x.size()))
-    {
-        real_type error = std::sqrt(output.error[i]);
-        EXPECT_SOFT_NEAR(output.pos_x[i], param.radius, error);
-        EXPECT_SOFT_NEAR(output.pos_z[i], zstep + i * 1.0e-6, error);
-        EXPECT_SOFT_NEAR(output.mom_y[i], param.momentum_y, error);
-        EXPECT_SOFT_NEAR(output.mom_z[i], param.momentum_z, error);
-        EXPECT_LT(output.error[i], param.epsilon);
-    }
+    check_result(output);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/field/Steppers.test.cu
+++ b/test/field/Steppers.test.cu
@@ -7,14 +7,13 @@
 //---------------------------------------------------------------------------//
 #include "Steppers.test.hh"
 
-#include <thrust/device_vector.h>
-
 #include "base/Constants.hh"
 #include "base/KernelParamCalculator.device.hh"
 #include "base/Range.hh"
 #include "base/Types.hh"
 #include "base/Units.hh"
 #include "field/DormandPrinceStepper.hh"
+#include "field/HelixStepper.hh"
 #include "field/MagFieldEquation.hh"
 #include "field/RungeKuttaStepper.hh"
 #include "field/Types.hh"
@@ -30,25 +29,26 @@ using namespace celeritas;
 namespace celeritas_test
 {
 //---------------------------------------------------------------------------//
-// KERNELS
+// HELP FUNCTIONS
 //---------------------------------------------------------------------------//
-
-__global__ void rk4_test_kernel(FieldTestParams param,
-                                real_type*      pos_x,
-                                real_type*      pos_z,
-                                real_type*      mom_y,
-                                real_type*      mom_z,
-                                real_type*      error)
+template<template<class> class TStepper>
+__device__ inline void gpu_stepper(celeritas_test::FieldTestParams param,
+                                   real_type*                      pos_x,
+                                   real_type*                      pos_z,
+                                   real_type*                      mom_y,
+                                   real_type*                      mom_z,
+                                   real_type*                      error)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (tid.get() >= param.nstates)
         return;
 
-    // Construct the Runge-Kutta stepper
+    // Construct a TStepper for testing
     UniformMagField field({0, 0, param.field_value});
-    using RKTraits = detail::MagTestTraits<UniformMagField, RungeKuttaStepper>;
-    RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
-    RKTraits::Stepper_t  rk4(equation);
+
+    using RKTraits = detail::MagTestTraits<UniformMagField, TStepper>;
+    typename RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
+    typename RKTraits::Stepper_t  rk4(equation);
 
     // Initial state and the epected state after revolutions
     OdeState y;
@@ -69,13 +69,36 @@ __global__ void rk4_test_kernel(FieldTestParams param,
             total_error += truncation_error(hstep, 0.001, y, result.err_state);
         }
     }
-
     // Output for verification
     pos_x[tid.get()] = y.pos[0];
     pos_z[tid.get()] = y.pos[2];
     mom_y[tid.get()] = y.mom[1];
     mom_z[tid.get()] = y.mom[2];
     error[tid.get()] = total_error;
+}
+
+//---------------------------------------------------------------------------//
+// KERNELS
+//---------------------------------------------------------------------------//
+__global__ void helix_test_kernel(FieldTestParams param,
+                                  real_type*      pos_x,
+                                  real_type*      pos_z,
+                                  real_type*      mom_y,
+                                  real_type*      mom_z,
+                                  real_type*      error)
+{
+    gpu_stepper<RungeKuttaStepper>(param, pos_x, pos_z, mom_y, mom_z, error);
+}
+
+//---------------------------------------------------------------------------//
+__global__ void rk4_test_kernel(FieldTestParams param,
+                                real_type*      pos_x,
+                                real_type*      pos_z,
+                                real_type*      mom_y,
+                                real_type*      mom_z,
+                                real_type*      error)
+{
+    gpu_stepper<RungeKuttaStepper>(param, pos_x, pos_z, mom_y, mom_z, error);
 }
 
 //---------------------------------------------------------------------------//
@@ -86,50 +109,42 @@ __global__ void dp547_test_kernel(FieldTestParams param,
                                   real_type*      mom_z,
                                   real_type*      error)
 {
-    auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (tid.get() >= param.nstates)
-        return;
-
-    // Construct the DormandPrinceStepper stepper
-    UniformMagField field({0, 0, param.field_value});
-    using RKTraits
-        = detail::MagTestTraits<UniformMagField, DormandPrinceStepper>;
-    RKTraits::Equation_t equation(field, units::ElementaryCharge{-1});
-    RKTraits::Stepper_t  dp547(equation);
-
-    // Initial state and the epected state after revolutions
-    OdeState y;
-    y.pos = {param.radius, 0.0, tid.get() * 1.0e-6};
-    y.mom = {0.0, param.momentum_y, param.momentum_z};
-
-    // Test parameters and the sub-step size
-    real_type hstep       = 2.0 * constants::pi * param.radius / param.nsteps;
-    real_type total_error = 0;
-
-    for (auto nr : range(param.revolutions))
-    {
-        // Travel hstep for nsteps times in the field
-        for (CELER_MAYBE_UNUSED int i : celeritas::range(param.nsteps))
-        {
-            StepperResult result = dp547(hstep, y);
-            y                    = result.end_state;
-            total_error += truncation_error(hstep, 0.001, y, result.err_state);
-        }
-    }
-
-    // Output for verification
-    pos_x[tid.get()] = y.pos[0];
-    pos_z[tid.get()] = y.pos[2];
-    mom_y[tid.get()] = y.mom[1];
-    mom_z[tid.get()] = y.mom[2];
-    error[tid.get()] = total_error;
+    gpu_stepper<DormandPrinceStepper>(param, pos_x, pos_z, mom_y, mom_z, error);
 }
 
 //---------------------------------------------------------------------------//
 // TESTING INTERFACE
 //---------------------------------------------------------------------------//
+//! Run the Helix stepper on device and return results
+StepperTestOutput helix_test(FieldTestParams test_param)
+{
+    // Output data for kernel
+    thrust::device_vector<real_type> pos_x(test_param.nstates, 0.0);
+    thrust::device_vector<real_type> pos_z(test_param.nstates, 0.0);
+    thrust::device_vector<real_type> mom_y(test_param.nstates, 0.0);
+    thrust::device_vector<real_type> mom_z(test_param.nstates, 0.0);
+    thrust::device_vector<real_type> error(test_param.nstates, 0.0);
+
+    // Run kernel
+    celeritas::KernelParamCalculator calc_launch_params(helix_test_kernel,
+                                                        "helix_test");
+    auto params = calc_launch_params(test_param.nstates);
+
+    helix_test_kernel<<<params.blocks_per_grid, params.threads_per_block>>>(
+        test_param,
+        raw_pointer_cast(pos_x.data()),
+        raw_pointer_cast(pos_z.data()),
+        raw_pointer_cast(mom_y.data()),
+        raw_pointer_cast(mom_z.data()),
+        raw_pointer_cast(error.data()));
+    CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
+
+    // Copy result back to CPU
+    return copy_to_cpu(pos_x, pos_z, mom_y, mom_z, error);
+}
+
 //! Run the classical Runge-Kutta stepper on device and return results
-SteppersTestOutput rk4_test(FieldTestParams test_param)
+StepperTestOutput rk4_test(FieldTestParams test_param)
 {
     // Output data for kernel
     thrust::device_vector<real_type> pos_x(test_param.nstates, 0.0);
@@ -153,29 +168,12 @@ SteppersTestOutput rk4_test(FieldTestParams test_param)
     CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
 
     // Copy result back to CPU
-    SteppersTestOutput result;
-
-    result.pos_x.resize(pos_x.size());
-    thrust::copy(pos_x.begin(), pos_x.end(), result.pos_x.begin());
-
-    result.pos_z.resize(pos_z.size());
-    thrust::copy(pos_z.begin(), pos_z.end(), result.pos_z.begin());
-
-    result.mom_y.resize(mom_y.size());
-    thrust::copy(mom_y.begin(), mom_y.end(), result.mom_y.begin());
-
-    result.mom_z.resize(mom_z.size());
-    thrust::copy(mom_z.begin(), mom_z.end(), result.mom_z.begin());
-
-    result.error.resize(error.size());
-    thrust::copy(error.begin(), error.end(), result.error.begin());
-
-    return result;
+    return copy_to_cpu(pos_x, pos_z, mom_y, mom_z, error);
 }
 
 //---------------------------------------------------------------------------//
 //! Run the DormandPrince547 stepper on device and return results
-SteppersTestOutput dp547_test(FieldTestParams test_param)
+StepperTestOutput dp547_test(FieldTestParams test_param)
 {
     // Output data for kernel
     thrust::device_vector<real_type> pos_x(test_param.nstates, 0.0);
@@ -199,24 +197,7 @@ SteppersTestOutput dp547_test(FieldTestParams test_param)
     CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
 
     // Copy result back to CPU
-    SteppersTestOutput result;
-
-    result.pos_x.resize(pos_x.size());
-    thrust::copy(pos_x.begin(), pos_x.end(), result.pos_x.begin());
-
-    result.pos_z.resize(pos_z.size());
-    thrust::copy(pos_z.begin(), pos_z.end(), result.pos_z.begin());
-
-    result.mom_y.resize(mom_y.size());
-    thrust::copy(mom_y.begin(), mom_y.end(), result.mom_y.begin());
-
-    result.mom_z.resize(mom_z.size());
-    thrust::copy(mom_z.begin(), mom_z.end(), result.mom_z.begin());
-
-    result.error.resize(error.size());
-    thrust::copy(error.begin(), error.end(), result.error.begin());
-
-    return result;
+    return copy_to_cpu(pos_x, pos_z, mom_y, mom_z, error);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/field/Steppers.test.cu
+++ b/test/field/Steppers.test.cu
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #include "Steppers.test.hh"
 
+#include <thrust/device_vector.h>
+
 #include "base/Constants.hh"
 #include "base/KernelParamCalculator.device.hh"
 #include "base/Range.hh"
@@ -110,6 +112,35 @@ __global__ void dp547_test_kernel(FieldTestParams param,
                                   real_type*      error)
 {
     gpu_stepper<DormandPrinceStepper>(param, pos_x, pos_z, mom_y, mom_z, error);
+}
+
+//---------------------------------------------------------------------------//
+// HELP FUNCTIONS
+//---------------------------------------------------------------------------//
+using dvec = thrust::device_vector<celeritas::real_type>;
+
+inline StepperTestOutput
+copy_to_cpu(dvec pos_x, dvec pos_z, dvec mom_y, dvec mom_z, dvec error)
+{
+    // Copy result back to CPU
+    StepperTestOutput result;
+
+    result.pos_x.resize(pos_x.size());
+    thrust::copy(pos_x.begin(), pos_x.end(), result.pos_x.begin());
+
+    result.pos_z.resize(pos_z.size());
+    thrust::copy(pos_z.begin(), pos_z.end(), result.pos_z.begin());
+
+    result.mom_y.resize(mom_y.size());
+    thrust::copy(mom_y.begin(), mom_y.end(), result.mom_y.begin());
+
+    result.mom_z.resize(mom_z.size());
+    thrust::copy(mom_z.begin(), mom_z.end(), result.mom_z.begin());
+
+    result.error.resize(error.size());
+    thrust::copy(error.begin(), error.end(), result.error.begin());
+
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/field/Steppers.test.cu
+++ b/test/field/Steppers.test.cu
@@ -15,11 +15,11 @@
 #include "base/Types.hh"
 #include "base/Units.hh"
 #include "field/DormandPrinceStepper.hh"
-#include "field/HelixStepper.hh"
 #include "field/MagFieldEquation.hh"
 #include "field/RungeKuttaStepper.hh"
 #include "field/Types.hh"
 #include "field/UniformMagField.hh"
+#include "field/ZHelixStepper.hh"
 #include "physics/base/Units.hh"
 
 #include "detail/MagTestTraits.hh"

--- a/test/field/Steppers.test.hh
+++ b/test/field/Steppers.test.hh
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <vector>
-#include <thrust/device_vector.h>
 
 #include "celeritas_config.h"
 #include "base/Assert.hh"
@@ -57,33 +56,5 @@ inline StepperTestOutput dp547_test(FieldTestParams)
 }
 #endif
 
-//---------------------------------------------------------------------------//
-// HELP FUNCTIONS
-//---------------------------------------------------------------------------//
-using dvec = thrust::device_vector<celeritas::real_type>;
-
-inline StepperTestOutput
-copy_to_cpu(dvec pos_x, dvec pos_z, dvec mom_y, dvec mom_z, dvec error)
-{
-    // Copy result back to CPU
-    StepperTestOutput result;
-
-    result.pos_x.resize(pos_x.size());
-    thrust::copy(pos_x.begin(), pos_x.end(), result.pos_x.begin());
-
-    result.pos_z.resize(pos_z.size());
-    thrust::copy(pos_z.begin(), pos_z.end(), result.pos_z.begin());
-
-    result.mom_y.resize(mom_y.size());
-    thrust::copy(mom_y.begin(), mom_y.end(), result.mom_y.begin());
-
-    result.mom_z.resize(mom_z.size());
-    thrust::copy(mom_z.begin(), mom_z.end(), result.mom_z.begin());
-
-    result.error.resize(error.size());
-    thrust::copy(error.begin(), error.end(), result.error.begin());
-
-    return result;
-}
 //---------------------------------------------------------------------------//
 } // namespace celeritas_test


### PR DESCRIPTION
This MR includes:
- Add an explicit helix stepper (exact solution with a uniform magnetic field)
- Consolidate stepper tests
- Use DormandPrinceStepper for testing FieldPropagator and FieldDriver
