### PR TITLE
Add optional, hard-coded fixed step limiter

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -113,6 +113,10 @@ void to_json(nlohmann::json& j, const LDemoArgs& v)
     {
         j["energy_diag"] = v.energy_diag;
     }
+    if (v.step_limiter > 0)
+    {
+        j["step_limiter"] = v.step_limiter;
+    }
 }
 
 void from_json(const nlohmann::json& j, LDemoArgs& v)
@@ -120,12 +124,7 @@ void from_json(const nlohmann::json& j, LDemoArgs& v)
     j.at("geometry_filename").get_to(v.geometry_filename);
     j.at("physics_filename").get_to(v.physics_filename);
     j.at("hepmc3_filename").get_to(v.hepmc3_filename);
-    j.at("rayleigh").get_to(v.rayleigh);
-    j.at("eloss_fluctuation").get_to(v.eloss_fluctuation);
-    j.at("brem_combined").get_to(v.brem_combined);
-    j.at("brem_lpm").get_to(v.brem_lpm);
-    j.at("conv_lpm").get_to(v.conv_lpm);
-    j.at("enable_msc").get_to(v.enable_msc);
+
     j.at("seed").get_to(v.seed);
     j.at("max_num_tracks").get_to(v.max_num_tracks);
     if (j.contains("max_steps"))
@@ -137,6 +136,17 @@ void from_json(const nlohmann::json& j, LDemoArgs& v)
     j.at("enable_diagnostics").get_to(v.enable_diagnostics);
     j.at("use_device").get_to(v.use_device);
     j.at("sync").get_to(v.sync);
+    if (j.contains("step_limiter"))
+    {
+        j.at("step_limiter").get_to(v.step_limiter);
+    }
+
+    j.at("rayleigh").get_to(v.rayleigh);
+    j.at("eloss_fluctuation").get_to(v.eloss_fluctuation);
+    j.at("brem_combined").get_to(v.brem_combined);
+    j.at("brem_lpm").get_to(v.brem_lpm);
+    j.at("conv_lpm").get_to(v.conv_lpm);
+    j.at("enable_msc").get_to(v.enable_msc);
 
     if (j.contains("energy_diag"))
     {
@@ -234,6 +244,7 @@ TransporterInput load_input(const LDemoArgs& args)
         input.particles                  = result.particles;
         input.materials                  = result.materials;
         input.options.enable_fluctuation = args.eloss_fluctuation;
+        input.options.fixed_step_limiter = args.step_limiter;
         input.action_manager             = result.actions.get();
 
         BremsstrahlungProcess::Options brem_options;

--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -48,6 +48,10 @@ struct LDemoArgs
     bool         use_device{};
     bool         sync{};
 
+    // Optional fixed-size step limiter for charged particles
+    // (non-positive for unused)
+    real_type step_limiter{};
+
     // Options for physics
     bool rayleigh{true};
     bool eloss_fluctuation{true};

--- a/src/physics/base/PhysicsData.hh
+++ b/src/physics/base/PhysicsData.hh
@@ -209,7 +209,11 @@ struct PhysicsParamsScalars
     real_type scaling_fraction{};   //!< alpha [unitless]
     real_type energy_fraction{};    //!< xi [unitless]
     real_type linear_loss_limit{};  //!< For scaled range calculation
+    real_type fixed_step_limiter{}; //!< Global charged step size limit [cm]
     bool      enable_fluctuation{}; //!< Enable energy loss fluctuations
+
+    // When fixed step limiter is used, this is the corresponding action ID
+    ActionId fixed_step_action{};
 
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const
@@ -217,7 +221,9 @@ struct PhysicsParamsScalars
         return max_particle_processes > 0 && model_to_action >= 3
                && num_models > 0 && scaling_min_range > 0
                && scaling_fraction > 0 && energy_fraction > 0
-               && linear_loss_limit > 0;
+               && linear_loss_limit > 0
+               && ((fixed_step_limiter > 0)
+                   == static_cast<bool>(fixed_step_action));
     }
 
     //! Stop early due to range limitation

--- a/src/physics/base/PhysicsParams.hh
+++ b/src/physics/base/PhysicsParams.hh
@@ -89,6 +89,7 @@ class PhysicsParams
         real_type min_range           = 1 * units::millimeter;
         real_type max_step_over_range = 0.2;
         real_type min_eprime_over_e   = 0.8;
+        real_type fixed_step_limiter  = 0;
         real_type linear_loss_limit   = 0.01;
         bool      use_integral_xs     = true;
         bool      enable_fluctuation  = true;
@@ -157,6 +158,7 @@ class PhysicsParams
     SPAction discrete_action_;
     SPAction integral_rejection_action_;
     SPAction failure_action_;
+    SPAction fixed_step_action_;
 
     // Host metadata/access
     VecProcess processes_;

--- a/src/physics/base/PhysicsStepUtils.hh
+++ b/src/physics/base/PhysicsStepUtils.hh
@@ -117,6 +117,14 @@ calc_physics_step_limit(const MaterialTrackView& material,
                 limit.step   = eloss_step;
                 limit.action = physics.scalars().range_action();
             }
+
+            // Limit charged particle step size
+            real_type fixed_limit = physics.scalars().fixed_step_limiter;
+            if (fixed_limit > 0 && fixed_limit < limit.step)
+            {
+                limit.step   = fixed_limit;
+                limit.action = physics.scalars().fixed_step_action;
+            }
         }
     }
 


### PR DESCRIPTION
To test MSC and to improve simulation accuracy in special cases, it's useful to be able to limit step sizes to a constant distance (per logical volume, per particle type). For now as a simplification, I've implemented a single, global step limit that applies to all particle types with slowing down physics. When the `step_limiter` input argument is provided and set to a positive value, the step sizes of electrons and positrons will not exceed that value. Step-limited particles get a `physics-fixed-step` action ID, distinct from range-limited `eloss-range` and MSC-limited action.