### PR TITLE
Add output manager

### DIFF
--- a/app/demo-loop/Transporter.hh
+++ b/app/demo-loop/Transporter.hh
@@ -95,6 +95,7 @@ struct TransporterTiming
 
     VecReal   steps;   //!< Real time per step
     real_type total{}; //!< Total simulation time
+    real_type setup{}; //!< One-time initialization cost
 
     // Finer-grained timing information within a step
     real_type initialize_tracks{};

--- a/app/demo-loop/Transporter.json.hh
+++ b/app/demo-loop/Transporter.json.hh
@@ -19,6 +19,7 @@ inline void to_json(nlohmann::json& j, const TransporterTiming& v)
 {
     j = nlohmann::json{{"steps", v.steps},
                        {"total", v.total},
+                       {"setup", v.setup},
                        {"initialize_tracks", v.initialize_tracks},
                        {"pre_step", v.pre_step},
                        {"along_step", v.along_step},

--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -168,7 +168,7 @@ int main(int argc, char* argv[])
         return_code = EXIT_FAILURE;
     }
 
-    // Write system properties even though results aren't available
+    // Write system properties and (if available) results
     CELER_LOG(status) << "Saving output";
     output.output(&cout);
     cout << endl;

--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -16,6 +16,7 @@
 
 #include "celeritas_version.h"
 #include "base/Stopwatch.hh"
+#include "comm/BuildOutput.hh"
 #include "comm/Communicator.hh"
 #include "comm/Device.hh"
 #include "comm/DeviceIO.json.hh"
@@ -25,6 +26,9 @@
 #include "comm/KernelDiagnosticsIO.json.hh"
 #include "comm/Logger.hh"
 #include "comm/ScopedMpiInit.hh"
+#include "physics/base/PhysicsParamsOutput.hh"
+#include "sim/OutputInterfaceAdapter.hh"
+#include "sim/OutputManager.hh"
 
 #include "LDemoIO.hh"
 #include "Transporter.hh"
@@ -34,33 +38,18 @@ using std::cerr;
 using std::cout;
 using std::endl;
 using namespace demo_loop;
-using celeritas::TransporterBase;
+using namespace celeritas;
 
 namespace
 {
 //---------------------------------------------------------------------------//
-nlohmann::json get_system_json()
-{
-    return {
-        {"version", std::string(celeritas_version)},
-        {"device", celeritas::device()},
-        {"kernels", celeritas::kernel_diagnostics()},
-        {"environ", celeritas::environment()},
-    };
-}
-
-//---------------------------------------------------------------------------//
 /*!
  * Run, launch, and output.
  */
-void run(std::istream& is)
+void run(std::istream* is, OutputManager* output)
 {
-    using celeritas::Stopwatch;
-    using celeritas::TrackInitParams;
-    using celeritas::TransporterResult;
-
     // Read input options
-    auto inp = nlohmann::json::parse(is);
+    auto inp = nlohmann::json::parse(*is);
 
     if (inp.contains("cuda_stack_size"))
     {
@@ -75,6 +64,10 @@ void run(std::istream& is)
     // For now, only do a single run
     auto run_args = inp.get<LDemoArgs>();
     CELER_EXPECT(run_args);
+    output->insert(std::make_shared<OutputInterfaceAdapter<LDemoArgs>>(
+        OutputInterface::Category::input,
+        "*",
+        std::make_shared<LDemoArgs>(run_args)));
 
     // Start timer for overall execution
     Stopwatch get_setup_time;
@@ -83,19 +76,21 @@ void run(std::istream& is)
     auto         transport_ptr = build_transporter(run_args);
     const double setup_time    = get_setup_time();
 
+    {
+        // Save diagnostic information
+        const auto& tinp = transport_ptr->input();
+        output->insert(std::make_shared<PhysicsParamsOutput>(tinp.physics));
+    }
+
     // Run all the primaries
     auto primaries = load_primaries(transport_ptr->input().particles, run_args);
     auto result    = (*transport_ptr)(*primaries);
 
-    CELER_LOG(status) << "Saving output";
-    // Save output
-    nlohmann::json outp = {
-        {"input", run_args},
-        {"result", result},
-        {"system", get_system_json()},
-    };
-    outp["result"]["time"]["setup"] = setup_time;
-    cout << outp.dump() << endl;
+    result.time.setup = setup_time;
+    // TODO: convert individual results into OutputInterface so we don't have
+    // to use this ugly "global" hack
+    output->insert(OutputInterfaceAdapter<TransporterResult>::from_rvalue_ref(
+        OutputInterface::Category::result, "*", std::move(result)));
 }
 } // namespace
 
@@ -105,9 +100,6 @@ void run(std::istream& is)
  */
 int main(int argc, char* argv[])
 {
-    using celeritas::Communicator;
-    using celeritas::ScopedMpiInit;
-
     ScopedMpiInit scoped_mpi(&argc, &argv);
 
     Communicator comm
@@ -152,20 +144,34 @@ int main(int argc, char* argv[])
         instream = &infile;
     }
 
+    // Set up output
+    OutputManager output;
+    output.insert(OutputInterfaceAdapter<Device>::from_const_ref(
+        OutputInterface::Category::system, "device", celeritas::device()));
+    output.insert(OutputInterfaceAdapter<KernelDiagnostics>::from_const_ref(
+        OutputInterface::Category::system,
+        "kernels",
+        celeritas::kernel_diagnostics()));
+    output.insert(OutputInterfaceAdapter<Environment>::from_const_ref(
+        OutputInterface::Category::system, "environ", celeritas::environment()));
+    output.insert(std::make_shared<BuildOutput>());
+
+    int return_code = EXIT_SUCCESS;
     try
     {
-        run(*instream);
+        run(instream, &output);
     }
     catch (const std::exception& e)
     {
         CELER_LOG(critical)
             << "While running input at  " << filename << ": " << e.what();
-
-        // Write system properties even though results aren't available
-        cout << nlohmann::json{{"system", get_system_json()}}.dump() << endl;
-
-        return EXIT_FAILURE;
+        return_code = EXIT_FAILURE;
     }
 
-    return EXIT_SUCCESS;
+    // Write system properties even though results aren't available
+    CELER_LOG(status) << "Saving output";
+    output.output(&cout);
+    cout << endl;
+
+    return return_code;
 }

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -107,7 +107,7 @@ except json.decoder.JSONDecodeError as e:
 
 outfilename = f'{run_name}.out.json'
 with open(outfilename, 'w') as f:
-    json.dump(result, f)
+    json.dump(result, f, indent=1)
 print("Results written to", outfilename)
 
 time = result['result']['time'].copy()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,6 +129,7 @@ list(APPEND SOURCES
   physics/base/ImportedProcessAdapter.cc
   physics/base/ParticleParams.cc
   physics/base/PhysicsParams.cc
+  physics/base/PhysicsParamsOutput.cc
   physics/base/Process.cc
   physics/em/AtomicRelaxationParams.cc
   physics/em/BetheHeitlerModel.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@
 #----------------------------------------------------------------------------#
 
 #----------------------------------------------------------------------------#
-# CONFIGURE FILE
+# CONFIGURE FILES
 #----------------------------------------------------------------------------#
 set(CELERITAS_USE_GEANT4  ${CELERITAS_USE_Geant4})
 set(CELERITAS_USE_HEPMC3  ${CELERITAS_USE_HepMC3})
@@ -29,8 +29,25 @@ string(JOIN "\n" CELERITAS_RNG_MACROS
   "#define CELERITAS_RNG CELERITAS_RNG_${CELERITAS_RNG}"
 )
 configure_file("celeritas_config.h.in" "celeritas_config.h" @ONLY)
+
+#----------------------------------------------------------------------------#
+
+# TODO: add build flags
+set(CELERITAS_CMAKE_STRINGS)
+set(CELERITAS_BUILD_TYPE ${CMAKE_BUILD_TYPE})
+foreach(_var CELERITAS_RNG CELERITAS_BUILD_TYPE)
+  string(TOLOWER "${_var}" _lower)
+  list(APPEND CELERITAS_CMAKE_STRINGS
+    "static const char ${_lower}[] = \"${${_var}}\";"
+  )
+endforeach()
+configure_file("celeritas_cmake_strings.h.in" "celeritas_cmake_strings.h" @ONLY)
+
+#----------------------------------------------------------------------------#
+
 install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/celeritas_config.h"
+  "${CMAKE_CURRENT_BINARY_DIR}/celeritas_config.h"
+  "${CMAKE_CURRENT_BINARY_DIR}/celeritas_cmake_strings.h"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
@@ -105,6 +122,7 @@ list(APPEND SOURCES
   base/TypeDemangler.cc
   base/VectorUtils.cc
   base/detail/ReprImpl.cc
+  comm/BuildOutput.cc
   comm/Communicator.cc
   comm/Device.cc
   comm/Environment.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,8 +37,8 @@ set(CELERITAS_CMAKE_STRINGS)
 set(CELERITAS_BUILD_TYPE ${CMAKE_BUILD_TYPE})
 foreach(_var CELERITAS_RNG CELERITAS_BUILD_TYPE)
   string(TOLOWER "${_var}" _lower)
-  list(APPEND CELERITAS_CMAKE_STRINGS
-    "static const char ${_lower}[] = \"${${_var}}\";"
+  string(APPEND CELERITAS_CMAKE_STRINGS
+    "static const char ${_lower}[] = \"${${_var}}\";\n"
   )
 endforeach()
 configure_file("celeritas_cmake_strings.h.in" "celeritas_cmake_strings.h" @ONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,6 +162,7 @@ list(APPEND SOURCES
   random/detail/CuHipRngStateInit.cc
   sim/ActionInterface.cc
   sim/ActionManager.cc
+  sim/ActionManagerOutput.cc
   sim/OutputInterface.cc
   sim/OutputManager.cc
   sim/TrackInitParams.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,6 +162,8 @@ list(APPEND SOURCES
   random/detail/CuHipRngStateInit.cc
   sim/ActionInterface.cc
   sim/ActionManager.cc
+  sim/OutputInterface.cc
+  sim/OutputManager.cc
   sim/TrackInitParams.cc
   sim/detail/TrackInitAlgorithms.cc
 )

--- a/src/base/EnumArray.hh
+++ b/src/base/EnumArray.hh
@@ -15,27 +15,25 @@
 
 namespace celeritas
 {
-#define CEL_FIF_ CELER_FORCEINLINE_FUNCTION
+#define CFIF_ CELER_FORCEINLINE_FUNCTION
 
 //---------------------------------------------------------------------------//
 /*!
  * Thin wrapper for an array of enums for accessing by enum instead of int.
+ *
+ * The enum *must* be a zero-indexed contiguous enumeration with a \c size_
+ * enumeration as its last value.
  */
 template<class E, class T>
 struct EnumArray
 {
-    enum
-    {
-        N = static_cast<int>(E::size_)
-    };
-
     static_assert(std::is_enum<E>::value, "Template parameter must be an enum");
 
     //!@{
     //! Type aliases
     using key_type        = E;
     using value_type      = T;
-    using size_type       = ::celeritas::size_type;
+    using size_type       = std::underlying_type_t<E>;
     using pointer         = value_type*;
     using const_pointer   = const value_type*;
     using reference       = value_type&;
@@ -44,42 +42,45 @@ struct EnumArray
     using const_iterator  = const_pointer;
     //!@}
 
+    enum
+    {
+        N = static_cast<size_type>(key_type::size_)
+    };
+
     //// DATA ////
 
-    T data_[static_cast<int>(key_type::size_)]; //!< Storage
+    T data_[N]; //!< Storage
 
     //! Get an element
-    CELER_FUNCTION reference operator[](const key_type& k)
+    CFIF_ reference operator[](const key_type& k)
     {
-        CELER_EXPECT(k < key_type::size_);
-        return data_[static_cast<int>(k)];
+        return data_[static_cast<size_type>(k)];
     }
 
     //! Get an element (const)
-    CELER_FUNCTION const_reference operator[](const key_type& k) const
+    CFIF_ const_reference operator[](const key_type& k) const
     {
-        CELER_EXPECT(k < key_type::size_);
-        return data_[static_cast<int>(k)];
+        return data_[static_cast<size_type>(k)];
     }
 
     //!@{
     //! Element access
-    CEL_FIF_ const_reference front() const { return data_[0]; }
-    CEL_FIF_ reference       front() { return data_[0]; }
-    CEL_FIF_ const_reference back() const { return data_[N - 1]; }
-    CEL_FIF_ reference       back() { return data_[N - 1]; }
-    CEL_FIF_ const_pointer   data() const { return data_; }
-    CEL_FIF_ pointer         data() { return data_; }
+    CFIF_ const_reference front() const { return data_[0]; }
+    CFIF_ reference       front() { return data_[0]; }
+    CFIF_ const_reference back() const { return data_[N - 1]; }
+    CFIF_ reference       back() { return data_[N - 1]; }
+    CFIF_ const_pointer   data() const { return data_; }
+    CFIF_ pointer         data() { return data_; }
     //!@}
 
     //!@{
     //! Iterator acces
-    CEL_FIF_ iterator       begin() { return data_; }
-    CEL_FIF_ iterator       end() { return data_ + N; }
-    CEL_FIF_ const_iterator begin() const { return data_; }
-    CEL_FIF_ const_iterator end() const { return data_ + N; }
-    CEL_FIF_ const_iterator cbegin() const { return data_; }
-    CEL_FIF_ const_iterator cend() const { return data_ + N; }
+    CFIF_ iterator       begin() { return data_; }
+    CFIF_ iterator       end() { return data_ + N; }
+    CFIF_ const_iterator begin() const { return data_; }
+    CFIF_ const_iterator end() const { return data_ + N; }
+    CFIF_ const_iterator cbegin() const { return data_; }
+    CFIF_ const_iterator cend() const { return data_ + N; }
     //!@}
 
     //!@{
@@ -89,7 +90,7 @@ struct EnumArray
     //!@}
 };
 
-#undef CEL_FIF_
+#undef CFIF_
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/celeritas_cmake_strings.h.in
+++ b/src/celeritas_cmake_strings.h.in
@@ -10,5 +10,4 @@
 #define celeritas_cmake_strings_h
 
 @CELERITAS_CMAKE_STRINGS@
-
 #endif /* celeritas_cmake_strings_h */

--- a/src/celeritas_cmake_strings.h.in
+++ b/src/celeritas_cmake_strings.h.in
@@ -1,0 +1,14 @@
+/*----------------------------------*-C-*------------------------------------*
+ * Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+ * See the top-level COPYRIGHT file for details.
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ *---------------------------------------------------------------------------*/
+/*! \file celeritas_cmake_strings.h
+ * Detailed CMake configuration information.
+ *---------------------------------------------------------------------------*/
+#ifndef celeritas_cmake_strings_h
+#define celeritas_cmake_strings_h
+
+@CELERITAS_CMAKE_STRINGS@
+
+#endif /* celeritas_cmake_strings_h */

--- a/src/comm/BuildOutput.cc
+++ b/src/comm/BuildOutput.cc
@@ -1,0 +1,57 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BuildOutput.cc
+//---------------------------------------------------------------------------//
+#include "BuildOutput.hh"
+
+#include "celeritas_config.h"
+#include "celeritas_version.h"
+#include "celeritas_cmake_strings.h"
+
+#include "sim/JsonPimpl.hh"
+#if CELERITAS_USE_JSON
+#    include <nlohmann/json.hpp>
+#endif
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void BuildOutput::output(JsonPimpl* j) const
+{
+#if CELERITAS_USE_JSON
+    auto obj = nlohmann::json::object();
+
+    obj["version"] = std::string(celeritas_version);
+
+    {
+        auto cfg = nlohmann::json::object();
+#    define CO_SAVE_CFG(NAME) cfg[#    NAME] = bool(NAME)
+        CO_SAVE_CFG(CELERITAS_USE_CUDA);
+        CO_SAVE_CFG(CELERITAS_USE_GEANT4);
+        CO_SAVE_CFG(CELERITAS_USE_HIP);
+        CO_SAVE_CFG(CELERITAS_USE_MPI);
+        CO_SAVE_CFG(CELERITAS_USE_ROOT);
+        CO_SAVE_CFG(CELERITAS_USE_VECGEOM);
+        CO_SAVE_CFG(CELERITAS_DEBUG);
+        CO_SAVE_CFG(CELERITAS_LAUNCH_BOUNDS);
+#    undef CO_SAVE_CFG
+        cfg["CELERITAS_BUILD_TYPE"] = celeritas_build_type;
+        cfg["CELERITAS_RNG"]        = celeritas_rng;
+
+        obj["config"]               = std::move(cfg);
+    }
+
+    j->obj = std::move(obj);
+#else
+    (void)sizeof(j);
+#endif
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/comm/BuildOutput.hh
+++ b/src/comm/BuildOutput.hh
@@ -1,0 +1,32 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file BuildOutput.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "sim/OutputInterface.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Save build configuration information to JSON.
+ */
+class BuildOutput final : public OutputInterface
+{
+  public:
+    //! Category of data to write
+    Category category() const final { return Category::system; };
+
+    //! Key for the entry inside the category.
+    std::string label() const final { return "build"; }
+
+    // Write output to the given JSON object
+    void output(JsonPimpl*) const final;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/base/PhysicsParams.cc
+++ b/src/physics/base/PhysicsParams.cc
@@ -135,18 +135,7 @@ PhysicsParams::PhysicsParams(Input inp) : processes_(std::move(inp.processes))
         fixed_step_action_                   = std::move(fixed_step_action);
     }
 
-    // TODO: move to diagnostic output
-    CELER_LOG(debug)
-        << "Constructed physics sizes:"
-        << "\n  reals: " << host_data.reals.size()
-        << "\n  model_ids: " << host_data.model_ids.size()
-        << "\n  value_grids: " << host_data.value_grids.size()
-        << "\n  value_grid_ids: " << host_data.value_grid_ids.size()
-        << "\n  process_ids: " << host_data.process_ids.size()
-        << "\n  value_tables: " << host_data.value_tables.size()
-        << "\n  model_groups: " << host_data.model_groups.size()
-        << "\n  process_groups: " << host_data.process_groups.size();
-
+    // Copy data to device
     data_ = CollectionMirror<PhysicsParamsData>{std::move(host_data)};
 
     CELER_ENSURE(range_action_->action_id()

--- a/src/physics/base/PhysicsParamsOutput.cc
+++ b/src/physics/base/PhysicsParamsOutput.cc
@@ -1,0 +1,116 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file PhysicsParamsOutput.cc
+//---------------------------------------------------------------------------//
+#include "PhysicsParamsOutput.hh"
+
+#include <utility>
+
+#include "celeritas_config.h"
+#include "base/Assert.hh"
+#include "base/Range.hh"
+#include "physics/base/Model.hh"
+#include "sim/JsonPimpl.hh"
+
+#include "PhysicsParams.hh"
+#if CELERITAS_USE_JSON
+#    include <nlohmann/json.hpp>
+#endif
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a shared action manager.
+ */
+PhysicsParamsOutput::PhysicsParamsOutput(SPConstPhysicsParams physics)
+    : physics_(std::move(physics))
+{
+    CELER_EXPECT(physics_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void PhysicsParamsOutput::output(JsonPimpl* j) const
+{
+#if CELERITAS_USE_JSON
+    using json = nlohmann::json;
+
+    auto obj = json::object();
+
+    // Save models
+    {
+        auto models = json::array();
+
+        for (auto id : range(ModelId{physics_->num_models()}))
+        {
+            const Model& m = physics_->model(id);
+
+            models.push_back(
+                {{"label", m.label()},
+                 {"process", physics_->process_id(id).unchecked_get()}});
+        }
+        obj["models"] = std::move(models);
+    }
+
+    // Save processes
+    {
+        auto processes = json::array();
+
+        for (auto id : range(ProcessId{physics_->num_processes()}))
+        {
+            const Process& p = physics_->process(id);
+
+            processes.push_back({{"label", p.label()}});
+        }
+        obj["processes"] = std::move(processes);
+    }
+
+    // Save options
+    {
+        const auto& scalars = physics_->host_ref().scalars;
+
+        auto options = json::object();
+#    define PPO_SAVE_OPTION(NAME) options[#    NAME] = scalars.NAME
+        PPO_SAVE_OPTION(scaling_min_range);
+        PPO_SAVE_OPTION(scaling_fraction);
+        PPO_SAVE_OPTION(energy_fraction);
+        PPO_SAVE_OPTION(linear_loss_limit);
+        PPO_SAVE_OPTION(fixed_step_limiter);
+        PPO_SAVE_OPTION(enable_fluctuation);
+#    undef PPO_SAVE_OPTION
+        obj["options"] = std::move(options);
+    }
+
+    // Save sizes
+    {
+        const auto& data = physics_->host_ref();
+
+        auto sizes = json::object();
+#    define PPO_SAVE_SIZE(NAME) sizes[#    NAME] = data.NAME.size()
+        PPO_SAVE_SIZE(reals);
+        PPO_SAVE_SIZE(model_ids);
+        PPO_SAVE_SIZE(value_grids);
+        PPO_SAVE_SIZE(value_grid_ids);
+        PPO_SAVE_SIZE(process_ids);
+        PPO_SAVE_SIZE(value_tables);
+        PPO_SAVE_SIZE(integral_xs);
+        PPO_SAVE_SIZE(model_groups);
+        PPO_SAVE_SIZE(process_groups);
+#    undef PPO_SAVE_SIZE
+        obj["sizes"] = std::move(sizes);
+    }
+
+    j->obj = std::move(obj);
+#else
+    (void)sizeof(j);
+#endif
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/physics/base/PhysicsParamsOutput.hh
+++ b/src/physics/base/PhysicsParamsOutput.hh
@@ -1,0 +1,46 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file PhysicsParamsOutput.hh
+//---------------------------------------------------------------------------//
+#pragma once
+#include <memory>
+
+#include "sim/OutputInterface.hh"
+
+namespace celeritas
+{
+class PhysicsParams;
+//---------------------------------------------------------------------------//
+/*!
+ * Save detailed debugging information about the physics in use.
+ */
+class PhysicsParamsOutput final : public OutputInterface
+{
+  public:
+    //!@{
+    //! Type aliases
+    using SPConstPhysicsParams = std::shared_ptr<const PhysicsParams>;
+    //!@}
+
+  public:
+    // Construct from shared physics data
+    explicit PhysicsParamsOutput(SPConstPhysicsParams physics);
+
+    //! Category of data to write
+    Category category() const final { return Category::internal; }
+
+    //! Name of the entry inside the category.
+    std::string label() const final { return "physics"; }
+
+    // Write output to the given JSON object
+    void output(JsonPimpl*) const final;
+
+  private:
+    SPConstPhysicsParams physics_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/sim/ActionManager.cc
+++ b/src/sim/ActionManager.cc
@@ -32,7 +32,11 @@ void ActionManager::insert(SPConstExplicit action)
 }
 
 //---------------------------------------------------------------------------//
-// Call the given action ID with host or device data.
+/*!
+ * Call the given action ID with host or device data.
+ *
+ * The given action ID \em must be an explicit action.
+ */
 template<MemSpace M>
 void ActionManager::invoke(ActionId id, const CoreRef<M>& data) const
 {

--- a/src/sim/ActionManager.hh
+++ b/src/sim/ActionManager.hh
@@ -28,7 +28,19 @@ struct CoreRef;
 /*!
  * Construct and store metadata about end-of-step actions.
  *
- * Registering an action checks its ID.
+ * The action manager helps create and retain access to "actions" (possible
+ * control paths for a track) over the program's lifetime. "Implicit" actions
+ * are primarily for debugging, but "explicit" actions indicate that a kernel
+ * will change the state of a track on device.
+ *
+ * Associated actions use the \c ActionInterface class to provide debugging
+ * information, and the \c ExplicitActionInterface is used to invoke kernels
+ * with core data.
+ *
+ * New actions should be created with an action ID corresponding to \c
+ * next_id . Registering an action checks its ID.
+ *
+ * \todo Add options for post-kernel device sync and timer accumulation.
  */
 class ActionManager
 {

--- a/src/sim/ActionManagerOutput.cc
+++ b/src/sim/ActionManagerOutput.cc
@@ -1,0 +1,63 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ActionManagerOutput.cc
+//---------------------------------------------------------------------------//
+#include "ActionManagerOutput.hh"
+
+#include <utility>
+
+#include "celeritas_config.h"
+#include "base/Assert.hh"
+#include "base/Range.hh"
+
+#include "ActionManager.hh"
+#include "JsonPimpl.hh"
+#if CELERITAS_USE_JSON
+#    include <nlohmann/json.hpp>
+#endif
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a shared action manager.
+ */
+ActionManagerOutput::ActionManagerOutput(SPConstActionManager actions)
+    : actions_(std::move(actions))
+{
+    CELER_EXPECT(actions_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void ActionManagerOutput::output(JsonPimpl* j) const
+{
+#if CELERITAS_USE_JSON
+    auto obj = nlohmann::json::array();
+    for (auto id : range(ActionId{actions_->num_actions()}))
+    {
+        nlohmann::json entry{
+            {"label", actions_->id_to_label(id)},
+        };
+
+        const ActionInterface& action = actions_->action(id);
+        std::string            desc   = action.description();
+        if (!desc.empty())
+        {
+            entry["description"] = std::move(desc);
+        }
+        obj.push_back(entry);
+    }
+    j->obj = std::move(obj);
+#else
+    (void)sizeof(j);
+#endif
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/sim/ActionManagerOutput.hh
+++ b/src/sim/ActionManagerOutput.hh
@@ -1,0 +1,47 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ActionManagerOutput.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+
+#include "OutputInterface.hh"
+
+namespace celeritas
+{
+class ActionManager;
+//---------------------------------------------------------------------------//
+/*!
+ * Save action manager data.
+ */
+class ActionManagerOutput final : public OutputInterface
+{
+  public:
+    //!@{
+    //! Type aliases
+    using SPConstActionManager = std::shared_ptr<const ActionManager>;
+    //!@}
+
+  public:
+    // Construct from a shared action manager
+    explicit ActionManagerOutput(SPConstActionManager actions);
+
+    //! Category of data to write
+    Category category() const final { return Category::internal; }
+
+    //! Name of the entry inside the category.
+    std::string label() const final { return "actions"; }
+
+    // Write output to the given JSON object
+    void output(JsonPimpl*) const final;
+
+  private:
+    SPConstActionManager actions_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/sim/JsonPimpl.hh
+++ b/src/sim/JsonPimpl.hh
@@ -1,0 +1,46 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file JsonPimpl.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "celeritas_config.h"
+
+#if CELERITAS_USE_JSON
+#    include <nlohmann/json.hpp>
+#endif
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Wrapper class for exporting JSON output.
+ *
+ * The caller is expected to use the value directly, so replace \c obj with the
+ * JSON object.
+ *
+ * \code
+    void output(JsonPimpl* json) const
+    {
+#if CELERITAS_USE_JSON
+        json->obj = value_;
+#else
+        (void)sizeof(json);
+#endif
+    }
+ * \endcode
+ */
+struct JsonPimpl
+{
+#if CELERITAS_USE_JSON
+    nlohmann::json obj;
+#else
+    JsonPimpl() = delete;
+#endif
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/sim/OutputInterface.cc
+++ b/src/sim/OutputInterface.cc
@@ -1,0 +1,61 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file OutputInterface.cc
+//---------------------------------------------------------------------------//
+#include "OutputInterface.hh"
+
+#include "celeritas_config.h"
+#include "base/Assert.hh"
+
+#include "JsonPimpl.hh"
+#if CELERITAS_USE_JSON
+#    include <nlohmann/json.hpp>
+#endif
+
+using Category = celeritas::OutputInterface::Category;
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Get a string corresponding to a category.
+ */
+const char* to_cstring(Category value)
+{
+    CELER_EXPECT(value != Category::size_);
+
+    static const char* const strings[] = {
+        "input",
+        "result",
+        "system",
+        "internal",
+    };
+    static_assert(
+        static_cast<unsigned int>(Category::size_) * sizeof(const char*)
+            == sizeof(strings),
+        "Enum strings are incorrect");
+
+    return strings[static_cast<unsigned int>(value)];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the JSON representation of a single output (mostly for testing).
+ */
+std::string to_string(const OutputInterface& output)
+{
+#if CELERITAS_USE_JSON
+    JsonPimpl json_wrap;
+    output.output(&json_wrap);
+    return json_wrap.obj.dump();
+#else
+    (void)sizeof(output);
+    return "\"output unavailable\"";
+#endif
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/sim/OutputInterface.hh
+++ b/src/sim/OutputInterface.hh
@@ -1,0 +1,66 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file OutputInterface.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+//! PIMPL class that holds a pointer to an NLJSON object
+struct JsonPimpl;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Pure abstract interface for writing metadata output to JSON.
+ *
+ * At the end of the program/run, the OutputManager will call the "output"
+ * method on all interfaces.
+ *
+ * \todo Perhaps another output method for saving a schema?
+ */
+class OutputInterface
+{
+  public:
+    //! Output category (TODO: could replace with string/cstring?)
+    enum class Category
+    {
+        input,
+        result,
+        system,
+        internal,
+        size_
+    };
+
+  public:
+    //! Category of data to write
+    virtual Category category() const = 0;
+
+    //! Key for the entry inside the category.
+    virtual std::string label() const = 0;
+
+    // Write output to the given JSON object
+    virtual void output(JsonPimpl*) const = 0;
+
+  protected:
+    // Protected destructor prevents direct deletion of pointer-to-interface
+    ~OutputInterface() = default;
+};
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+
+// Get a string representation of the category
+const char* to_cstring(OutputInterface::Category value);
+
+// Get the JSON representation of a single output (mostly for testing)
+std::string to_string(const OutputInterface& output);
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/sim/OutputInterfaceAdapter.hh
+++ b/src/sim/OutputInterfaceAdapter.hh
@@ -1,0 +1,103 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file OutputInterfaceAdapter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "base/Assert.hh"
+
+#include "JsonPimpl.hh"
+#include "OutputInterface.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Adapter class for writing a JSON-serializable data to output.
+ *
+ * This class is to be used only when JSON is available and when a \c to_json
+ * free function has been defined for \c T.
+ */
+template<class T>
+class OutputInterfaceAdapter final : public OutputInterface
+{
+  public:
+    //!@{
+    //! Type aliases
+    using SPConstT = std::shared_ptr<const T>;
+    using SPThis   = std::shared_ptr<OutputInterfaceAdapter<T>>;
+    //!@}
+
+  public:
+    // DANGEROUS helper function
+    static inline SPThis
+    from_const_ref(Category cat, std::string label, const T& obj);
+
+    // Construct from category, label, and shared pointer
+    inline OutputInterfaceAdapter(Category cat, std::string label, SPConstT obj);
+
+    //! Category of data to write
+    Category category() const final { return cat_; }
+
+    //! label of the entry inside the category.
+    std::string label() const { return label_; }
+
+    //! Write output to the given JSON object
+    void output(JsonPimpl* jp) { to_json(jp->obj, *obj_); }
+
+  private:
+    Category    cat_;
+    std::string label_;
+    SPConstT    obj_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a long-lived const reference.
+ *
+ * This is a dangerous but sometimes necessary way to make an interface
+ * adapter. The object's lifespan *must be guaranteed* to exceed that of the
+ * \c OutputManager.
+ *
+ * Example: \code
+ * output_manager.insert(OutputInterfaceAdapter<Device>::from_const_ref(
+ *      OutputInterface::Category::system,
+ *      "device",
+ *      celeritas::device()));
+ * \endcode
+ */
+template<class T>
+auto OutputInterfaceAdapter::from_const_ref(Category    cat,
+                                            std::string label,
+                                            const T&    obj) -> SPThis
+{
+    auto null_deleter = [](const T*) {};
+
+    return std::make_shared<OutputInterfaceAdapter<T>>(
+        cat, std::move(label), std::shared_ptr<const T>(&obj, null_deleter));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from category, label, and shared pointer.
+ */
+template<class T>
+OutputInterfaceAdapter::OutputInterfaceAdapter(Category    cat,
+                                               std::string label,
+                                               SPConstT    obj)
+    : cat_(cat), label_(std::move(label)), obj_(std::move(obj))
+{
+    CELER_EXPECT(cat != Category::size_);
+    CELER_EXPECT(obj_);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/sim/OutputManager.cc
+++ b/src/sim/OutputManager.cc
@@ -1,0 +1,75 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file OutputManager.cc
+//---------------------------------------------------------------------------//
+#include "OutputManager.hh"
+
+#include "celeritas_config.h"
+#if CELERITAS_USE_JSON
+#    include <nlohmann/json.hpp>
+#endif
+
+#include "base/Assert.hh"
+#include "base/Range.hh"
+#include "comm/Logger.hh"
+
+#include "JsonPimpl.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Add an interface for writing.
+ */
+void OutputManager::insert(SPConstInterface interface)
+{
+    CELER_EXPECT(interface);
+    CELER_EXPECT(interface->category() != Category::size_);
+
+    Category cat = interface->category();
+    auto     iter_inserted
+        = interfaces_[cat].insert({interface->label(), std::move(interface)});
+    CELER_VALIDATE(iter_inserted.second,
+                   << "duplicate output entry '" << iter_inserted.first->first
+                   << "' for category '" << to_cstring(cat) << "'");
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Output all classes to a JSON object that's written to the given stream.
+ */
+void OutputManager::output(std::ostream* os) const
+{
+#if CELERITAS_USE_JSON
+    nlohmann::json result;
+
+    for (auto cat : range(Category::size_))
+    {
+        nlohmann::json cat_result;
+        for (const auto& kv : interfaces_[cat])
+        {
+            JsonPimpl json_wrap;
+            kv.second->output(&json_wrap);
+            cat_result[kv.first] = std::move(json_wrap.obj);
+        }
+        if (!cat_result.empty())
+        {
+            // Add category to the final output
+            result[to_cstring(cat)] = std::move(cat_result);
+        }
+    }
+
+    *os << result.dump();
+#else
+    // Write a JSON-compatible string showing why output is unavailable
+    CELER_LOG(error) << "Cannot write output to JSON: nljson is not enabled "
+                        "in the current build configuration";
+    *os << "\"output unavailable\"";
+#endif
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/sim/OutputManager.cc
+++ b/src/sim/OutputManager.cc
@@ -29,9 +29,12 @@ void OutputManager::insert(SPConstInterface interface)
     CELER_EXPECT(interface);
     CELER_EXPECT(interface->category() != Category::size_);
 
+    auto label = interface->label();
+    CELER_VALIDATE(!label.empty(), << "empty label for output interface");
+
     Category cat = interface->category();
     auto     iter_inserted
-        = interfaces_[cat].insert({interface->label(), std::move(interface)});
+        = interfaces_[cat].insert({std::move(label), std::move(interface)});
     CELER_VALIDATE(iter_inserted.second,
                    << "duplicate output entry '" << iter_inserted.first->first
                    << "' for category '" << to_cstring(cat) << "'");
@@ -51,9 +54,24 @@ void OutputManager::output(std::ostream* os) const
         nlohmann::json cat_result;
         for (const auto& kv : interfaces_[cat])
         {
+            // Hack for inlining input/result outputs in Transporter: to be
+            // removed when the individual interfaces are converted to
+            // OutputInterface
+            bool      is_global = (kv.first == "*");
             JsonPimpl json_wrap;
+            if (is_global)
+            {
+                json_wrap.obj = std::move(cat_result);
+            }
             kv.second->output(&json_wrap);
-            cat_result[kv.first] = std::move(json_wrap.obj);
+            if (is_global)
+            {
+                cat_result = std::move(json_wrap.obj);
+            }
+            else
+            {
+                cat_result[kv.first] = std::move(json_wrap.obj);
+            }
         }
         if (!cat_result.empty())
         {

--- a/src/sim/OutputManager.hh
+++ b/src/sim/OutputManager.hh
@@ -1,0 +1,57 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file OutputManager.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <iosfwd>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "base/EnumArray.hh"
+
+#include "OutputInterface.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Store classes that can output data at the end of the run.
+ *
+ * Each output interface defines a category (e.g. input, result, system) and a
+ * name. The output manager then writes the JSON output from that entry into a
+ * nested database:
+ * \verbatim
+   {"category": {"label": "data"}}
+ * \endverbatim
+ */
+class OutputManager
+{
+  public:
+    //!@{
+    //! Type aliases
+    using SPConstInterface = std::shared_ptr<const OutputInterface>;
+    //!@}
+
+  public:
+    // Add an interface for writing
+    void insert(SPConstInterface);
+
+    // Write all outputs as JSON to the given stream
+    void output(std::ostream* os) const;
+
+  private:
+    using Category = OutputInterface::Category;
+
+    // Interfaces by category
+    EnumArray<Category, std::map<std::string, SPConstInterface>> interfaces_;
+};
+
+// TODO: potentially add a global instance here?
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -335,4 +335,5 @@ celeritas_add_test(random/distributions/UniformRealDistribution.test.cc)
 celeritas_setup_tests(SERIAL PREFIX sim)
 
 celeritas_add_test(sim/ActionManager.test.cc)
+celeritas_add_test(sim/OutputManager.test.cc)
 celeritas_device_test(sim/TrackInit ${_needs_cuda})

--- a/test/physics/base/Physics.test.cc
+++ b/test/physics/base/Physics.test.cc
@@ -11,6 +11,7 @@
 #include "base/Range.hh"
 #include "physics/base/ParticleParams.hh"
 #include "physics/base/PhysicsParams.hh"
+#include "physics/base/PhysicsParamsOutput.hh"
 #include "physics/base/PhysicsTrackView.hh"
 #include "physics/em/EPlusAnnihilationProcess.hh"
 #include "physics/grid/RangeCalculator.hh"
@@ -106,6 +107,19 @@ TEST_F(PhysicsParamsTest, accessors)
                                                 "anti-celeriton:meows",
                                                 "electron:barks"};
     EXPECT_VEC_EQ(expected_process_map, process_map);
+}
+
+TEST_F(PhysicsParamsTest, output)
+{
+    PhysicsParamsOutput out(this->physics());
+    EXPECT_EQ("physics", out.label());
+
+    if (CELERITAS_USE_JSON)
+    {
+        EXPECT_EQ(
+            R"json({"models":[{"label":"mock-model-5","process":0},{"label":"mock-model-6","process":0},{"label":"mock-model-7","process":1},{"label":"mock-model-8","process":2},{"label":"mock-model-9","process":2},{"label":"mock-model-10","process":2},{"label":"mock-model-11","process":3},{"label":"mock-model-12","process":3},{"label":"mock-model-13","process":4},{"label":"mock-model-14","process":4},{"label":"mock-model-15","process":5}],"options":{"enable_fluctuation":true,"energy_fraction":0.8,"fixed_step_limiter":0.0,"linear_loss_limit":0.01,"scaling_fraction":0.2,"scaling_min_range":0.1},"processes":[{"label":"scattering"},{"label":"absorption"},{"label":"purrs"},{"label":"hisses"},{"label":"meows"},{"label":"barks"}],"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":4,"process_ids":8,"reals":124,"value_grid_ids":42,"value_grids":42,"value_tables":32}})json",
+            to_string(out));
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/test/sim/ActionManager.test.cc
+++ b/test/sim/ActionManager.test.cc
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #include "sim/ActionManager.hh"
 
+#include "sim/ActionManagerOutput.hh"
+
 #include "celeritas_test.hh"
 
 using namespace celeritas;
@@ -100,6 +102,21 @@ TEST_F(ActionManagerTest, accessors)
     // Access an action
     EXPECT_EQ("explicit action test", mgr.action(expl_id).description());
     EXPECT_EQ("explicit", mgr.id_to_label(expl_id));
+}
+
+TEST_F(ActionManagerTest, output)
+{
+    // Create output handler from a shared pointer (with a null deleter)
+    ActionManagerOutput out(std::shared_ptr<const ActionManager>(
+        &mgr, [](const ActionManager*) {}));
+    EXPECT_EQ("actions", out.label());
+
+    if (CELERITAS_USE_JSON)
+    {
+        EXPECT_EQ(
+            R"json([{"label":"impl1"},{"description":"explicit action test","label":"explicit"},{"description":"the second implicit action","label":"impl2"}])json",
+            to_string(out));
+    }
 }
 
 TEST_F(ActionManagerTest, invocation)

--- a/test/sim/OutputManager.test.cc
+++ b/test/sim/OutputManager.test.cc
@@ -1,0 +1,99 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file OutputManager.test.cc
+//---------------------------------------------------------------------------//
+#include "sim/OutputManager.hh"
+
+#include <sstream>
+
+#include "sim/JsonPimpl.hh"
+
+#include "celeritas_test.hh"
+
+using celeritas::JsonPimpl;
+using celeritas::OutputManager;
+
+class TestInterface final : public celeritas::OutputInterface
+{
+  public:
+    TestInterface(Category cat, std::string lab, int value)
+        : cat_(cat), label_(lab), value_(value)
+    {
+    }
+
+    Category    category() const final { return cat_; }
+    std::string label() const final { return label_; }
+
+    void output(JsonPimpl* json) const final
+    {
+#if CELERITAS_USE_JSON
+        json->obj = value_;
+#else
+        (void)sizeof(json);
+#endif
+    }
+
+  private:
+    Category    cat_{};
+    std::string label_{};
+    int         value_{};
+};
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class OutputManagerTest : public celeritas::Test
+{
+  protected:
+    using Category = celeritas::OutputInterface::Category;
+
+    std::string to_string(const OutputManager& om)
+    {
+        std::ostringstream os;
+        om.output(&os);
+        return os.str();
+    }
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(OutputManagerTest, empty)
+{
+    OutputManager om;
+
+    std::string result = this->to_string(om);
+#if CELERITAS_USE_JSON
+    EXPECT_EQ("null", result);
+#else
+    EXPECT_EQ("\"output unavailable\"", result);
+#endif
+}
+
+TEST_F(OutputManagerTest, minimal)
+{
+    auto first
+        = std::make_shared<TestInterface>(Category::input, "input_value", 42);
+    auto second = std::make_shared<TestInterface>(Category::result, "out", 1);
+    auto third = std::make_shared<TestInterface>(Category::result, "timing", 2);
+
+    OutputManager om;
+    om.insert(first);
+    om.insert(second);
+    om.insert(third);
+
+    EXPECT_THROW(om.insert(first), celeritas::RuntimeError);
+
+    std::string result = this->to_string(om);
+#if CELERITAS_USE_JSON
+    EXPECT_EQ(R"({"input":{"input_value":42},"result":{"out":1,"timing":2}})",
+              result);
+#else
+    EXPECT_EQ("\"output unavailable\"", result);
+#endif
+}


### PR DESCRIPTION
This defines an interface for saving certain output to JSON. It's sort of an abstraction of what we output in the demo loop, and it can be extended to other system diagnostic data and outputs. The integration into the demo loop is hacky at the moment, but as the loop gets refactored into the main source code I think it will be cleaner.