### PR TITLE
Extend user defined magnetic field tests

### DIFF
--- a/test/field/FieldPropagator.test.cu
+++ b/test/field/FieldPropagator.test.cu
@@ -59,20 +59,20 @@ __global__ void fp_test_kernel(const int                       size,
     ParticleTrackView particle_track(particle_params, particle_states, tid);
     particle_track = init_track[tid.get()];
 
-    // Construct the RK stepper adnd propagator in a field
+    // Construct the field propagator with UniformMagField
     UniformMagField field({0, 0, test.field_value});
-    using RKTraits = MagFieldTraits<UniformMagField, DormandPrinceStepper>;
-    RKTraits::Equation_t   equation(field, units::ElementaryCharge{-1});
-    RKTraits::Stepper_t    rk4(equation);
-    RKTraits::Driver_t     driver(field_params, &rk4);
-    RKTraits::Propagator_t propagator(particle_track, &geo_track, &driver);
+    using MFTraits = MagFieldTraits<UniformMagField, DormandPrinceStepper>;
+    MFTraits::Equation_t   equation(field, units::ElementaryCharge{-1});
+    MFTraits::Stepper_t    stepper(equation);
+    MFTraits::Driver_t     driver(field_params, &stepper);
+    MFTraits::Propagator_t propagator(particle_track, &geo_track, &driver);
 
     // Tests with input parameters of a electron in a uniform magnetic field
     double hstep = (2.0 * constants::pi * test.radius) / test.nsteps;
 
     real_type curved_length = 0;
 
-    RKTraits::Propagator_t::result_type result;
+    MFTraits::Propagator_t::result_type result;
 
     for (CELER_MAYBE_UNUSED int i : celeritas::range(test.revolutions))
     {
@@ -116,13 +116,13 @@ __global__ void bc_test_kernel(const int                       size,
     ParticleTrackView particle_track(particle_params, particle_states, tid);
     particle_track = init_track[tid.get()];
 
-    // Construct the RK stepper and propagator in a field
+    // Construct the field propagator with UniformMagField
     UniformMagField field({0, 0, test.field_value});
-    using RKTraits = MagFieldTraits<UniformMagField, DormandPrinceStepper>;
-    RKTraits::Equation_t   equation(field, units::ElementaryCharge{-1});
-    RKTraits::Stepper_t    rk4(equation);
-    RKTraits::Driver_t     driver(field_params, &rk4);
-    RKTraits::Propagator_t propagator(particle_track, &geo_track, &driver);
+    using MFTraits = MagFieldTraits<UniformMagField, DormandPrinceStepper>;
+    MFTraits::Equation_t   equation(field, units::ElementaryCharge{-1});
+    MFTraits::Stepper_t    stepper(equation);
+    MFTraits::Driver_t     driver(field_params, &stepper);
+    MFTraits::Propagator_t propagator(particle_track, &geo_track, &driver);
 
     // Tests with input parameters of a electron in a uniform magnetic field
     double hstep = (2.0 * constants::pi * test.radius) / test.nsteps;
@@ -140,7 +140,7 @@ __global__ void bc_test_kernel(const int                       size,
 
     real_type delta = celeritas::numeric_limits<real_type>::max();
 
-    RKTraits::Propagator_t::result_type result;
+    MFTraits::Propagator_t::result_type result;
 
     for (CELER_MAYBE_UNUSED int ir : celeritas::range(test.revolutions))
     {

--- a/test/field/FieldPropagatorTestBase.hh
+++ b/test/field/FieldPropagatorTestBase.hh
@@ -1,0 +1,90 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020-2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file FieldPropagatorTestBase.hh
+//---------------------------------------------------------------------------//
+
+#include "base/CollectionStateStore.hh"
+#include "geometry/GeoData.hh"
+#include "geometry/GeoParams.hh"
+#include "geometry/GeoTestBase.hh"
+#include "geometry/GeoTrackView.hh"
+#include "physics/base/ParticleData.hh"
+#include "physics/base/ParticleParams.hh"
+#include "physics/base/ParticleTrackView.hh"
+#include "physics/base/Units.hh"
+
+#include "FieldTestParams.hh"
+#include "celeritas_test.hh"
+
+using namespace celeritas;
+using namespace celeritas_test;
+using celeritas::units::MevEnergy;
+
+//---------------------------------------------------------------------------//
+/*!
+ * TestBase harness.
+ *
+ * The test geometry is 1-cm thick slabs normal to y, with 1-cm gaps in
+ * between. We fire off electrons (TODO: also test positrons!) that end up
+ * running circles around the z axis (along which the magnetic field points).
+ */
+class FieldPropagatorTestBase : public GeoTestBase<celeritas::GeoParams>
+{
+  public:
+    const char* dirname() const override { return "field"; }
+    const char* filebase() const override { return "field-test"; }
+
+    void SetUp() override
+    {
+        using namespace celeritas::units;
+        namespace pdg = celeritas::pdg;
+
+        // Create particle defs
+        constexpr auto        stable = ParticleRecord::stable_decay_constant();
+        ParticleParams::Input defs;
+        defs.push_back({"electron",
+                        pdg::electron(),
+                        MevMass{0.5109989461},
+                        ElementaryCharge{-1},
+                        stable});
+        defs.push_back({"positron",
+                        pdg::positron(),
+                        MevMass{0.5109989461},
+                        ElementaryCharge{1},
+                        stable});
+
+        particle_params = std::make_shared<ParticleParams>(std::move(defs));
+
+        // Construct views
+        resize(&state_value, particle_params->host_ref(), 1);
+        state_ref = state_value;
+
+        // Set values of FieldParamsData;
+        field_params.delta_intersection = 1.0e-4 * units::millimeter;
+
+        // Input parameters of an electron in a uniform magnetic field
+        test.nstates     = 128;
+        test.nsteps      = 100;
+        test.revolutions = 10;
+        test.field_value = 1.0 * units::tesla;
+        test.radius      = 3.8085386036;
+        test.delta_z     = 6.7003310629;
+        test.energy      = 10.9181415106;
+        test.momentum_y  = 11.4177114158018;
+        test.momentum_z  = 0.0;
+        test.epsilon     = 1.0e-5;
+    }
+
+  protected:
+    std::shared_ptr<ParticleParams>                         particle_params;
+    ParticleStateData<Ownership::value, MemSpace::host>     state_value;
+    ParticleStateData<Ownership::reference, MemSpace::host> state_ref;
+
+    FieldParamsData field_params;
+
+    // Test parameters
+    FieldTestParams test;
+};

--- a/test/field/UserField.test.hh
+++ b/test/field/UserField.test.hh
@@ -12,6 +12,7 @@
 #include "base/Macros.hh"
 #include "base/Types.hh"
 
+#include "FieldPropagator.test.hh"
 #include "detail/FieldMapData.hh"
 
 namespace celeritas_test
@@ -20,6 +21,9 @@ using namespace celeritas;
 
 using celeritas::MemSpace;
 using celeritas::Ownership;
+using celeritas::detail::FieldMapDeviceRef;
+
+using UserFieldTestVector = std::vector<double>;
 
 //---------------------------------------------------------------------------//
 // TESTING INTERFACE
@@ -45,24 +49,43 @@ struct UserFieldTestOutput
 
 //---------------------------------------------------------------------------//
 //! Run on device and return results
+UserFieldTestOutput parameterized_field_test(UserFieldTestParams test_param);
+
+UserFieldTestVector par_fp_test(FPTestInput input);
+
+UserFieldTestVector par_bc_test(FPTestInput input);
+
 UserFieldTestOutput fieldmap_test(UserFieldTestParams test_param,
                                   celeritas::detail::FieldMapDeviceRef data);
 
+UserFieldTestVector map_fp_test(FPTestInput input, FieldMapDeviceRef data);
+
+UserFieldTestVector map_bc_test(FPTestInput input, FieldMapDeviceRef data);
+
 #if !CELER_USE_DEVICE
+inline UserFieldTestOutput parameterized_field_test(UserFieldTestParams)
+{
+    CELER_NOT_CONFIGURED("CUDA or HIP");
+}
+inline UserFieldTestVector par_fp_test(FPTestInput)
+{
+    CELER_NOT_CONFIGURED("CUDA or HIP");
+}
+inline UserFieldTestVector par_bc_test(FPTestInput)
+{
+    CELER_NOT_CONFIGURED("CUDA or HIP");
+}
 inline UserFieldTestOutput
 fieldmap_test(UserFieldTestParams,
               CELER_MAYBE_UNUSED celeritas::detail::FieldMapDeviceRef data)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }
-#endif
-
-//---------------------------------------------------------------------------//
-//! Run on device and return results
-UserFieldTestOutput parameterized_field_test(UserFieldTestParams test_param);
-
-#if !CELER_USE_DEVICE
-inline UserFieldTestOutput parameterized_field_test(UserFieldTestParams)
+inline UserFieldTestVector map_fp_test(FPTestInput, FieldMapDeviceRef data)
+{
+    CELER_NOT_CONFIGURED("CUDA or HIP");
+}
+inline UserFieldTestVector map_bc_test(FPTestInput, FieldMapDeviceRef data)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/test/field/UserMapField.test.cc
+++ b/test/field/UserMapField.test.cc
@@ -7,13 +7,19 @@
 //---------------------------------------------------------------------------//
 #include "base/ArrayUtils.hh"
 #include "base/Range.hh"
-#include "field/detail/FieldMapData.hh"
-#include "field/detail/MagFieldMap.hh"
+#include "field/DormandPrinceStepper.hh"
+#include "field/FieldDriver.hh"
+#include "field/FieldParamsData.hh"
+#include "field/MagFieldEquation.hh"
+#include "field/MagFieldTraits.hh"
 
+#include "FieldPropagatorTestBase.hh"
 #include "UserField.test.hh"
 #include "celeritas_test.hh"
 #include "detail/CMSFieldMapReader.hh"
 #include "detail/CMSMapField.hh"
+#include "detail/FieldMapData.hh"
+#include "detail/MagFieldMap.hh"
 
 using celeritas::detail::CMSMapField;
 using celeritas::detail::MagFieldMap;
@@ -25,11 +31,22 @@ using namespace celeritas_test;
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class UserMapFieldTest : public Test
+class UserMapFieldTest : public FieldPropagatorTestBase
 {
+  public:
+    using Initializer_t = ParticleTrackView::Initializer_t;
+    using GeoStateStore = CollectionStateStore<GeoStateData, MemSpace::host>;
+
   protected:
     void SetUp() override
     {
+        FieldPropagatorTestBase::SetUp();
+        geo_state_ = GeoStateStore(*this->geometry(), 1);
+
+        // Scale the test radius with the approximated center value of the
+        // test field map (3.8 units::tesla)
+        test.radius /= 3.8;
+
         // Construct MagFieldMap and save a reference to the host data
         std::string test_file
             = celeritas::Test::test_data_path("field", "cmsFieldMap.tiny");
@@ -62,16 +79,18 @@ class UserMapFieldTest : public Test
                                       {16.6149, 16.6149, 3757.2}};
 
   protected:
-    UserFieldTestParams                  test_param_;
-    std::shared_ptr<MagFieldMap>         map_;
-    celeritas::detail::FieldMapRef       ref_;
+    // Test parameters and input
+    GeoStateStore                  geo_state_;
+    UserFieldTestParams            test_param_;
+    std::shared_ptr<MagFieldMap>   map_;
+    celeritas::detail::FieldMapRef ref_;
 };
 
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST_F(UserMapFieldTest, host_map_field)
+TEST_F(UserMapFieldTest, host_umf_value)
 {
     // Create the magnetic field with a mapped field
     CMSMapField field(this->ref_);
@@ -87,26 +106,204 @@ TEST_F(UserMapFieldTest, host_map_field)
     }
 }
 
+TEST_F(UserMapFieldTest, host_umf_propagator)
+{
+    // Construct GeoTrackView and ParticleTrackView
+    GeoTrackView geo_track = GeoTrackView(
+        this->geometry()->host_ref(), geo_state_.ref(), ThreadId(0));
+    ParticleTrackView particle_track(
+        particle_params->host_ref(), state_ref, ThreadId(0));
+
+    // Construct FieldDriver with a user CMSMapField
+    CMSMapField field(this->ref_);
+
+    using MFTraits = MagFieldTraits<CMSMapField, DormandPrinceStepper>;
+    MFTraits::Equation_t equation(field, units::ElementaryCharge{-1});
+    MFTraits::Stepper_t  stepper(equation);
+    MFTraits::Driver_t   driver(field_params, &stepper);
+
+    // Test parameters and the sub-step size
+    double step = (2.0 * constants::pi * test.radius) / test.nsteps;
+
+    particle_track = Initializer_t{ParticleId{0}, MevEnergy{test.energy}};
+    OdeState beg_state;
+    beg_state.mom                   = {0, test.momentum_y, 0};
+    real_type expected_total_length = 2 * constants::pi * test.radius
+                                      * test.revolutions;
+
+    for (unsigned int i : celeritas::range(test.nstates).step(128u))
+    {
+        // Initial state and the expected state after each revolution
+        geo_track     = {{test.radius, -10, i * 1.0e-6}, {0, 1, 0}};
+        beg_state.pos = {test.radius, -10, i * 1.0e-6};
+
+        // Check GeoTrackView
+        EXPECT_SOFT_EQ(5.5, geo_track.find_next_step().distance);
+
+        // Construct FieldPropagator
+        MFTraits::Propagator_t propagate(particle_track, &geo_track, &driver);
+
+        real_type                           total_length = 0;
+        MFTraits::Propagator_t::result_type result;
+
+        for (CELER_MAYBE_UNUSED int ir : celeritas::range(test.revolutions))
+        {
+            for (CELER_MAYBE_UNUSED int j : celeritas::range(test.nsteps))
+            {
+                result = propagate(step);
+                EXPECT_FALSE(result.boundary);
+                EXPECT_DOUBLE_EQ(step, result.distance);
+                total_length += result.distance;
+            }
+        }
+
+        // Check input after num_revolutions
+        EXPECT_SOFT_NEAR(total_length, expected_total_length, test.epsilon);
+    }
+}
+
+TEST_F(UserMapFieldTest, host_umf_geolimited)
+{
+    // Construct GeoTrackView and ParticleTrackView
+    GeoTrackView geo_track = GeoTrackView(
+        this->geometry()->host_ref(), geo_state_.ref(), ThreadId(0));
+    ParticleTrackView particle_track(
+        particle_params->host_ref(), state_ref, ThreadId(0));
+
+    // Construct FieldDriver with a user CMSMapField
+    CMSMapField field(this->ref_);
+    using MFTraits = MagFieldTraits<CMSMapField, DormandPrinceStepper>;
+    MFTraits::Equation_t equation(field, units::ElementaryCharge{-1});
+    MFTraits::Stepper_t  stepper(equation);
+    MFTraits::Driver_t   driver(field_params, &stepper);
+
+    static const real_type expected_y[] = {0.5, 0.5, -0.5, -0.5};
+    const int num_boundary = sizeof(expected_y) / sizeof(real_type);
+
+    // Test parameters and the sub-step size
+    double step = (2.0 * constants::pi * test.radius) / test.nsteps;
+
+    for (auto i : celeritas::range(test.nstates).step(128u))
+    {
+        // Initialize GeoTrackView and ParticleTrackView
+        geo_track      = {{test.radius, 0, i * 1.0e-6}, {0, 1, 0}};
+        particle_track = Initializer_t{ParticleId{0}, MevEnergy{test.energy}};
+
+        EXPECT_SOFT_EQ(0.5, geo_track.find_next_step().distance);
+
+        // Construct FieldPropagator
+        MFTraits::Propagator_t propagate(particle_track, &geo_track, &driver);
+
+        int                                 icross       = 0;
+        real_type                           total_length = 0;
+        MFTraits::Propagator_t::result_type result;
+
+        for (CELER_MAYBE_UNUSED int ir : celeritas::range(test.revolutions))
+        {
+            for (CELER_MAYBE_UNUSED auto k : celeritas::range(test.nsteps))
+            {
+                result = propagate(step);
+                total_length += result.distance;
+
+                if (result.boundary)
+                {
+                    icross++;
+                    int j = (icross - 1) % num_boundary;
+                    EXPECT_DOUBLE_EQ(expected_y[j], geo_track.pos()[1]);
+                    geo_track.cross_boundary();
+                }
+            }
+        }
+
+        // Check stepper results with boundary crossings
+        EXPECT_SOFT_NEAR(61.557571992378342, total_length, test.epsilon);
+    }
+}
+
 //---------------------------------------------------------------------------//
 // DEVICE TESTS
 //---------------------------------------------------------------------------//
-
+#define UserMapFieldDeviceTest TEST_IF_CELER_DEVICE(UserMapFieldDeviceTest)
 class UserMapFieldDeviceTest : public UserMapFieldTest
 {
   public:
-    celeritas::detail::FieldMapDeviceRef device_ref_;
+    using GeoStateStore = CollectionStateStore<GeoStateData, MemSpace::device>;
 };
 
-TEST_F(UserMapFieldDeviceTest, TEST_IF_CELER_DEVICE(device_map_field))
+TEST_F(UserMapFieldDeviceTest, TEST_IF_CELER_DEVICE(device_umf_value))
 {
     // Run kernel for the magnetic field with a mapped field
-    this->device_ref_ = this->map_->device_ref();
-
-    auto output = fieldmap_test(this->test_param_, this->device_ref_);
+    auto output = fieldmap_test(this->test_param_, this->map_->device_ref());
 
     for (unsigned int i : celeritas::range(this->test_param_.nsamples))
     {
         Real3 value{output.value_x[i], output.value_y[i], output.value_z[i]};
         EXPECT_VEC_NEAR(this->expected_by_map[i], value, 1.0e-6);
+    }
+}
+
+TEST_F(UserMapFieldDeviceTest, TEST_IF_CELER_DEVICE(device_umf_propagator))
+{
+    // Set up test input
+    FPTestInput input;
+    for (unsigned int i : celeritas::range(test.nstates))
+    {
+        input.init_geo.push_back({{test.radius, -10, i * 1.0e-6}, {0, 1, 0}});
+        input.init_track.push_back({ParticleId{0}, MevEnergy{test.energy}});
+    }
+    input.geo_params = this->geometry()->device_ref();
+    GeoStateStore device_states(*this->geometry(), input.init_geo.size());
+    input.geo_states = device_states.ref();
+
+    CollectionStateStore<ParticleStateData, MemSpace::device> pstates(
+        *particle_params, input.init_track.size());
+
+    input.particle_params = particle_params->device_ref();
+    input.particle_states = pstates.ref();
+
+    input.field_params = this->field_params;
+    input.test         = this->test;
+
+    // Run kernel
+    auto step = map_fp_test(input, this->map_->device_ref());
+
+    // Check stepper results
+    real_type step_length = 2 * constants::pi * test.radius * test.revolutions;
+    for (unsigned int i = 0; i < step.size(); ++i)
+    {
+        EXPECT_SOFT_NEAR(step[i], step_length, test.epsilon);
+    }
+}
+
+TEST_F(UserMapFieldDeviceTest, TEST_IF_CELER_DEVICE(device_umf_geolimited))
+{
+    // Set up test input
+    FPTestInput input;
+    for (unsigned int i : celeritas::range(test.nstates))
+    {
+        input.init_geo.push_back({{test.radius, 0, i * 1.0e-6}, {0, 1, 0}});
+        input.init_track.push_back({ParticleId{0}, MevEnergy{test.energy}});
+    }
+
+    input.geo_params = this->geometry()->device_ref();
+    GeoStateStore device_states(*this->geometry(), input.init_geo.size());
+    input.geo_states = device_states.ref();
+
+    CollectionStateStore<ParticleStateData, MemSpace::device> pstates(
+        *particle_params, input.init_track.size());
+
+    input.particle_params = particle_params->device_ref();
+    input.particle_states = pstates.ref();
+
+    input.field_params = this->field_params;
+    input.test         = this->test;
+
+    // Run kernel
+    auto step = map_bc_test(input, this->map_->device_ref());
+
+    // Check stepper results
+    for (unsigned int i = 0; i < step.size(); ++i)
+    {
+        EXPECT_SOFT_NEAR(step[i], 61.557571977595295, test.epsilon);
     }
 }

--- a/test/field/UserMapField.test.cu
+++ b/test/field/UserMapField.test.cu
@@ -13,12 +13,23 @@
 #include "base/Range.hh"
 #include "base/Types.hh"
 #include "comm/Device.hh"
+#include "field/DormandPrinceStepper.hh"
+#include "field/FieldDriver.hh"
+#include "field/FieldParamsData.hh"
+#include "field/FieldPropagator.hh"
+#include "field/MagFieldEquation.hh"
+#include "field/MagFieldTraits.hh"
+#include "geometry/GeoTrackView.hh"
+#include "physics/base/ParticleTrackView.hh"
 
+#include "FieldPropagator.test.hh"
+#include "FieldTestParams.hh"
 #include "UserField.test.hh"
 #include "detail/CMSMapField.hh"
 #include "detail/FieldMapData.hh"
 #include "detail/MagFieldMap.hh"
 
+using namespace celeritas;
 using thrust::raw_pointer_cast;
 
 namespace celeritas_test
@@ -52,12 +63,147 @@ __global__ void fieldmap_test_kernel(UserFieldTestParams       param,
     value_z[tid.get()] = value[2];
 }
 
+__global__ void map_fp_test_kernel(const int                  size,
+                                   const GeoParamsCRefDevice  shared,
+                                   const GeoStateRefDevice    state,
+                                   const GeoTrackInitializer* start,
+                                   const ParticleParamsRef    particle_params,
+                                   ParticleStateRef           particle_states,
+                                   const FieldMapDeviceRef    field_data,
+                                   FieldParamsData            field_params,
+                                   FieldTestParams            test,
+                                   const ParticleTrackInitializer* init_track,
+                                   double*                         pos,
+                                   double*                         dir,
+                                   double*                         step)
+{
+    auto tid = celeritas::KernelParamCalculator::thread_id();
+    if (tid.get() >= size)
+        return;
+
+    // Initialize GeoTrackView and ParticleTrackView
+    GeoTrackView geo_track(shared, state, tid);
+    geo_track = start[tid.get()];
+    if (!geo_track.is_outside())
+        geo_track.find_next_step();
+
+    ParticleTrackView particle_track(particle_params, particle_states, tid);
+    particle_track = init_track[tid.get()];
+
+    // Construct the field propagator with a user CMSMapField
+    detail::CMSMapField field(field_data);
+
+    using MFTraits = MagFieldTraits<detail::CMSMapField, DormandPrinceStepper>;
+    MFTraits::Equation_t   equation(field, units::ElementaryCharge{-1});
+    MFTraits::Stepper_t    stepper(equation);
+    MFTraits::Driver_t     driver(field_params, &stepper);
+    MFTraits::Propagator_t propagator(particle_track, &geo_track, &driver);
+
+    // Tests with input parameters of a electron in a uniform magnetic field
+    double hstep = (2.0 * constants::pi * test.radius) / test.nsteps;
+
+    real_type curved_length = 0;
+
+    MFTraits::Propagator_t::result_type result;
+
+    for (CELER_MAYBE_UNUSED int i : celeritas::range(test.revolutions))
+    {
+        for (CELER_MAYBE_UNUSED int j : celeritas::range(test.nsteps))
+        {
+            result = propagator(hstep);
+            curved_length += result.distance;
+            CELER_ASSERT(!result.boundary);
+        }
+    }
+
+    // output
+    step[tid.get()] = curved_length;
+}
+
+__global__ void map_bc_test_kernel(const int                  size,
+                                   const GeoParamsCRefDevice  shared,
+                                   const GeoStateRefDevice    state,
+                                   const GeoTrackInitializer* start,
+                                   ParticleParamsRef          particle_params,
+                                   ParticleStateRef           particle_states,
+                                   const FieldMapDeviceRef    field_data,
+                                   FieldParamsData            field_params,
+                                   FieldTestParams            test,
+                                   const ParticleTrackInitializer* init_track,
+                                   double*                         pos,
+                                   double*                         dir,
+                                   double*                         step)
+{
+    auto tid = celeritas::KernelParamCalculator::thread_id();
+    if (tid.get() >= size)
+        return;
+
+    // Initialize GeoTrackView and ParticleTrackView
+    GeoTrackView geo_track(shared, state, tid);
+    geo_track = start[tid.get()];
+    if (!geo_track.is_outside())
+        geo_track.find_next_step();
+
+    ParticleTrackView particle_track(particle_params, particle_states, tid);
+    particle_track = init_track[tid.get()];
+
+    // Construct the field propagator with a user CMSMapField
+    detail::CMSMapField field(field_data);
+
+    using MFTraits = MagFieldTraits<detail::CMSMapField, DormandPrinceStepper>;
+    MFTraits::Equation_t   equation(field, units::ElementaryCharge{-1});
+    MFTraits::Stepper_t    stepper(equation);
+    MFTraits::Driver_t     driver(field_params, &stepper);
+    MFTraits::Propagator_t propagator(particle_track, &geo_track, &driver);
+
+    // Tests with input parameters of a electron in a uniform magnetic field
+    double hstep = (2.0 * constants::pi * test.radius) / test.nsteps;
+
+    real_type curved_length = 0;
+
+    constexpr int num_boundary = 4;
+    int           icross       = 0;
+
+    constexpr real_type expected_y[num_boundary] = {0.5, 0.5, -0.5, -0.5};
+
+    real_type delta = celeritas::numeric_limits<real_type>::max();
+
+    MFTraits::Propagator_t::result_type result;
+
+    for (CELER_MAYBE_UNUSED int ir : celeritas::range(test.revolutions))
+    {
+        for (CELER_MAYBE_UNUSED int i : celeritas::range(test.nsteps))
+        {
+            result = propagator(hstep);
+            curved_length += result.distance;
+
+            if (result.boundary)
+            {
+                icross++;
+                int j = (icross - 1) % num_boundary;
+                delta = expected_y[j] - geo_track.pos()[1];
+                if (delta != 0)
+                {
+                    printf("Intersection Finding Failed on GPU: ");
+                    printf("Expected = %f Actual = %f\n",
+                           expected_y[j],
+                           geo_track.pos()[1]);
+                }
+                geo_track.cross_boundary();
+            }
+        }
+    }
+
+    // output
+    step[tid.get()] = curved_length;
+}
+
 //---------------------------------------------------------------------------//
 // TESTING INTERFACE
 //---------------------------------------------------------------------------//
 //! Run on device and return results
-UserFieldTestOutput fieldmap_test(UserFieldTestParams       test_param,
-                                  detail::FieldMapDeviceRef field_data)
+UserFieldTestOutput fieldmap_test(UserFieldTestParams     test_param,
+                                  const FieldMapDeviceRef field_data)
 {
     // Output data for kernel
     thrust::device_vector<real_type> value_x(test_param.nsamples, 0.0);
@@ -86,6 +232,98 @@ UserFieldTestOutput fieldmap_test(UserFieldTestParams       test_param,
 
     result.value_z.resize(value_z.size());
     thrust::copy(value_z.begin(), value_z.end(), result.value_z.begin());
+
+    return result;
+}
+
+//! Run on device and return results
+UserFieldTestVector
+map_fp_test(FPTestInput input, const FieldMapDeviceRef field_data)
+{
+    CELER_ASSERT(input.init_geo.size() == input.init_track.size());
+    CELER_ASSERT(input.geo_params);
+    CELER_ASSERT(input.geo_states);
+
+    // Temporary device data for kernel
+    thrust::device_vector<GeoTrackInitializer> in_geo(input.init_geo.begin(),
+                                                      input.init_geo.end());
+    thrust::device_vector<ParticleTrackInitializer> in_track = input.init_track;
+
+    // Output data for kernel
+    thrust::device_vector<double> step(input.init_geo.size(), -1.0);
+    thrust::device_vector<double> pos(input.init_geo.size(), -1.0);
+    thrust::device_vector<double> dir(input.init_geo.size(), -1.0);
+
+    // Run kernel
+    CELER_LAUNCH_KERNEL(map_fp_test,
+                        celeritas::device().default_block_size(),
+                        in_geo.size(),
+                        in_geo.size(),
+                        input.geo_params,
+                        input.geo_states,
+                        raw_pointer_cast(in_geo.data()),
+                        input.particle_params,
+                        input.particle_states,
+                        field_data,
+                        input.field_params,
+                        input.test,
+                        raw_pointer_cast(in_track.data()),
+                        raw_pointer_cast(pos.data()),
+                        raw_pointer_cast(dir.data()),
+                        raw_pointer_cast(step.data()));
+    CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
+
+    // Copy result back to CPU
+    UserFieldTestVector result;
+
+    result.resize(step.size());
+    thrust::copy(step.begin(), step.end(), result.begin());
+
+    return result;
+}
+
+//! Run a boundary crossing test on device and return results
+UserFieldTestVector
+map_bc_test(FPTestInput input, detail::FieldMapDeviceRef field_data)
+{
+    CELER_ASSERT(input.init_geo.size() == input.init_track.size());
+    CELER_ASSERT(input.geo_params);
+    CELER_ASSERT(input.geo_states);
+
+    // Temporary device data for kernel
+    thrust::device_vector<GeoTrackInitializer> in_geo(input.init_geo.begin(),
+                                                      input.init_geo.end());
+    thrust::device_vector<ParticleTrackInitializer> in_track = input.init_track;
+
+    // Output data for kernel
+    thrust::device_vector<double> step(input.init_geo.size(), -1.0);
+    thrust::device_vector<double> pos(input.init_geo.size(), -1.0);
+    thrust::device_vector<double> dir(input.init_geo.size(), -1.0);
+
+    // Run kernel
+    CELER_LAUNCH_KERNEL(map_bc_test,
+                        celeritas::device().default_block_size(),
+                        in_geo.size(),
+                        in_geo.size(),
+                        input.geo_params,
+                        input.geo_states,
+                        raw_pointer_cast(in_geo.data()),
+                        input.particle_params,
+                        input.particle_states,
+                        field_data,
+                        input.field_params,
+                        input.test,
+                        raw_pointer_cast(in_track.data()),
+                        raw_pointer_cast(pos.data()),
+                        raw_pointer_cast(dir.data()),
+                        raw_pointer_cast(step.data()));
+    CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
+
+    // Copy result back to CPU
+    UserFieldTestVector result;
+
+    result.resize(step.size());
+    thrust::copy(step.begin(), step.end(), result.begin());
 
     return result;
 }

--- a/test/field/UserParamField.test.cu
+++ b/test/field/UserParamField.test.cu
@@ -13,10 +13,21 @@
 #include "base/Range.hh"
 #include "base/Types.hh"
 #include "comm/Device.hh"
+#include "field/DormandPrinceStepper.hh"
+#include "field/FieldDriver.hh"
+#include "field/FieldParamsData.hh"
+#include "field/FieldPropagator.hh"
+#include "field/MagFieldEquation.hh"
+#include "field/MagFieldTraits.hh"
+#include "geometry/GeoTrackView.hh"
+#include "physics/base/ParticleTrackView.hh"
 
+#include "FieldPropagator.test.hh"
+#include "FieldTestParams.hh"
 #include "UserField.test.hh"
 #include "detail/CMSParameterizedField.hh"
 
+using celeritas::detail::CMSParameterizedField;
 using thrust::raw_pointer_cast;
 
 namespace celeritas_test
@@ -45,6 +56,139 @@ __global__ void parameterized_field_test_kernel(UserFieldTestParams param,
     value_x[tid.get()] = value[0];
     value_y[tid.get()] = value[1];
     value_z[tid.get()] = value[2];
+}
+
+__global__ void par_fp_test_kernel(const int                  size,
+                                   const GeoParamsCRefDevice  shared,
+                                   const GeoStateRefDevice    state,
+                                   const GeoTrackInitializer* start,
+                                   const ParticleParamsRef    particle_params,
+                                   ParticleStateRef           particle_states,
+                                   FieldParamsData            field_params,
+                                   FieldTestParams            test,
+                                   const ParticleTrackInitializer* init_track,
+                                   double*                         pos,
+                                   double*                         dir,
+                                   double*                         step)
+{
+    auto tid = celeritas::KernelParamCalculator::thread_id();
+    if (tid.get() >= size)
+        return;
+
+    // Initialize GeoTrackView and ParticleTrackView
+    GeoTrackView geo_track(shared, state, tid);
+    geo_track = start[tid.get()];
+    if (!geo_track.is_outside())
+        geo_track.find_next_step();
+
+    ParticleTrackView particle_track(particle_params, particle_states, tid);
+    particle_track = init_track[tid.get()];
+
+    // Construct the field propagator with a user CMSParameterizedField
+    CMSParameterizedField field;
+    using MFTraits
+        = MagFieldTraits<CMSParameterizedField, DormandPrinceStepper>;
+    MFTraits::Equation_t   equation(field, units::ElementaryCharge{-1});
+    MFTraits::Stepper_t    stepper(equation);
+    MFTraits::Driver_t     driver(field_params, &stepper);
+    MFTraits::Propagator_t propagator(particle_track, &geo_track, &driver);
+
+    // Tests with input parameters of a electron in a uniform magnetic field
+    double hstep = (2.0 * constants::pi * test.radius) / test.nsteps;
+
+    real_type curved_length = 0;
+
+    MFTraits::Propagator_t::result_type result;
+
+    for (CELER_MAYBE_UNUSED int i : celeritas::range(test.revolutions))
+    {
+        for (CELER_MAYBE_UNUSED int j : celeritas::range(test.nsteps))
+        {
+            result = propagator(hstep);
+            curved_length += result.distance;
+            CELER_ASSERT(!result.boundary);
+        }
+    }
+
+    // output
+    step[tid.get()] = curved_length;
+}
+
+__global__ void par_bc_test_kernel(const int                  size,
+                                   const GeoParamsCRefDevice  shared,
+                                   const GeoStateRefDevice    state,
+                                   const GeoTrackInitializer* start,
+                                   ParticleParamsRef          particle_params,
+                                   ParticleStateRef           particle_states,
+                                   FieldParamsData            field_params,
+                                   FieldTestParams            test,
+                                   const ParticleTrackInitializer* init_track,
+                                   double*                         pos,
+                                   double*                         dir,
+                                   double*                         step)
+{
+    auto tid = celeritas::KernelParamCalculator::thread_id();
+    if (tid.get() >= size)
+        return;
+
+    // Initialize GeoTrackView and ParticleTrackView
+    GeoTrackView geo_track(shared, state, tid);
+    geo_track = start[tid.get()];
+    if (!geo_track.is_outside())
+        geo_track.find_next_step();
+
+    ParticleTrackView particle_track(particle_params, particle_states, tid);
+    particle_track = init_track[tid.get()];
+
+    // Construct the field propagator with a user CMSParameterizedField
+    CMSParameterizedField field;
+    using MFTraits
+        = MagFieldTraits<CMSParameterizedField, DormandPrinceStepper>;
+    MFTraits::Equation_t   equation(field, units::ElementaryCharge{-1});
+    MFTraits::Stepper_t    stepper(equation);
+    MFTraits::Driver_t     driver(field_params, &stepper);
+    MFTraits::Propagator_t propagator(particle_track, &geo_track, &driver);
+
+    // Tests with input parameters of a electron in a uniform magnetic field
+    double hstep = (2.0 * constants::pi * test.radius) / test.nsteps;
+
+    real_type curved_length = 0;
+
+    constexpr int num_boundary = 4;
+    int           icross       = 0;
+
+    constexpr real_type expected_y[num_boundary] = {0.5, 0.5, -0.5, -0.5};
+
+    real_type delta = celeritas::numeric_limits<real_type>::max();
+
+    MFTraits::Propagator_t::result_type result;
+
+    for (CELER_MAYBE_UNUSED int ir : celeritas::range(test.revolutions))
+    {
+        for (CELER_MAYBE_UNUSED int i : celeritas::range(test.nsteps))
+        {
+            result = propagator(hstep);
+            curved_length += result.distance;
+
+            if (result.boundary)
+            {
+                icross++;
+                int j = (icross - 1) % num_boundary;
+                delta = expected_y[j] - geo_track.pos()[1];
+                if (delta != 0)
+                {
+                    printf("Intersection Finding Failed on GPU: ");
+                    printf("Expected = %f Actual = %f\n",
+                           expected_y[j],
+                           geo_track.pos()[1]);
+                }
+                geo_track.cross_boundary();
+            }
+        }
+    }
+
+    // output
+    step[tid.get()] = curved_length;
 }
 
 //---------------------------------------------------------------------------//
@@ -79,6 +223,94 @@ UserFieldTestOutput parameterized_field_test(UserFieldTestParams test_param)
 
     result.value_z.resize(value_z.size());
     thrust::copy(value_z.begin(), value_z.end(), result.value_z.begin());
+
+    return result;
+}
+
+//! Run on device and return results
+UserFieldTestVector par_fp_test(FPTestInput input)
+{
+    CELER_ASSERT(input.init_geo.size() == input.init_track.size());
+    CELER_ASSERT(input.geo_params);
+    CELER_ASSERT(input.geo_states);
+
+    // Temporary device data for kernel
+    thrust::device_vector<GeoTrackInitializer> in_geo(input.init_geo.begin(),
+                                                      input.init_geo.end());
+    thrust::device_vector<ParticleTrackInitializer> in_track = input.init_track;
+
+    // Output data for kernel
+    thrust::device_vector<double> step(input.init_geo.size(), -1.0);
+    thrust::device_vector<double> pos(input.init_geo.size(), -1.0);
+    thrust::device_vector<double> dir(input.init_geo.size(), -1.0);
+
+    // Run kernel
+    CELER_LAUNCH_KERNEL(par_fp_test,
+                        celeritas::device().default_block_size(),
+                        in_geo.size(),
+                        in_geo.size(),
+                        input.geo_params,
+                        input.geo_states,
+                        raw_pointer_cast(in_geo.data()),
+                        input.particle_params,
+                        input.particle_states,
+                        input.field_params,
+                        input.test,
+                        raw_pointer_cast(in_track.data()),
+                        raw_pointer_cast(pos.data()),
+                        raw_pointer_cast(dir.data()),
+                        raw_pointer_cast(step.data()));
+    CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
+
+    // Copy result back to CPU
+    UserFieldTestVector result;
+
+    result.resize(step.size());
+    thrust::copy(step.begin(), step.end(), result.begin());
+
+    return result;
+}
+
+//! Run a boundary crossing test on device and return results
+UserFieldTestVector par_bc_test(FPTestInput input)
+{
+    CELER_ASSERT(input.init_geo.size() == input.init_track.size());
+    CELER_ASSERT(input.geo_params);
+    CELER_ASSERT(input.geo_states);
+
+    // Temporary device data for kernel
+    thrust::device_vector<GeoTrackInitializer> in_geo(input.init_geo.begin(),
+                                                      input.init_geo.end());
+    thrust::device_vector<ParticleTrackInitializer> in_track = input.init_track;
+
+    // Output data for kernel
+    thrust::device_vector<double> step(input.init_geo.size(), -1.0);
+    thrust::device_vector<double> pos(input.init_geo.size(), -1.0);
+    thrust::device_vector<double> dir(input.init_geo.size(), -1.0);
+
+    // Run kernel
+    CELER_LAUNCH_KERNEL(par_bc_test,
+                        celeritas::device().default_block_size(),
+                        in_geo.size(),
+                        in_geo.size(),
+                        input.geo_params,
+                        input.geo_states,
+                        raw_pointer_cast(in_geo.data()),
+                        input.particle_params,
+                        input.particle_states,
+                        input.field_params,
+                        input.test,
+                        raw_pointer_cast(in_track.data()),
+                        raw_pointer_cast(pos.data()),
+                        raw_pointer_cast(dir.data()),
+                        raw_pointer_cast(step.data()));
+    CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
+
+    // Copy result back to CPU
+    UserFieldTestVector result;
+
+    result.resize(step.size());
+    thrust::copy(step.begin(), step.end(), result.begin());
 
     return result;
 }


### PR DESCRIPTION
This MR extends existing tests for field propagation and boundary crossing with user defined non-uniform magnetic fields:  
- UserParamField.test with CMSParameterizedField.
- UserMapField.test with CMSMapField.
and
- Move FieldPropagatorTestBase in a separate header in order to reuse it for other tests.

Both tests may be compactified further as they are using similar codes with minor variations from FieldPropagator.test, which may be done in a separate MR later.

