### PR TITLE
Initialize states with garbage on host in debug mode

### DIFF
--- a/app/demo-interactor/DetectorData.hh
+++ b/app/demo-interactor/DetectorData.hh
@@ -93,7 +93,7 @@ inline void resize(DetectorStateData<celeritas::Ownership::value, M>* data,
     CELER_EXPECT(params);
     CELER_EXPECT(size > 0);
     resize(&data->hit_buffer, size);
-    make_builder(&data->tally_deposition).resize(params.tally_grid.size);
+    resize(&data->tally_deposition, params.tally_grid.size);
 }
 #endif
 

--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -199,6 +199,14 @@ TransporterInput load_input(const LDemoArgs& args)
     {
         params.geometry
             = std::make_shared<GeoParams>(args.geometry_filename.c_str());
+        if (!params.geometry->supports_safety())
+        {
+            CELER_LOG(warning)
+                << "Geometry contains surfaces that are "
+                   "incompatible with the current ORANGE simple "
+                   "safety algorithm: multiple scattering may "
+                   "result in arbitrarily small steps";
+        }
     }
 
     // Load materials

--- a/src/celeritas/em/data/AtomicRelaxationData.hh
+++ b/src/celeritas/em/data/AtomicRelaxationData.hh
@@ -156,7 +156,7 @@ resize(AtomicRelaxStateData<Ownership::value, M>* state,
        size_type size)
 {
     CELER_EXPECT(size > 0);
-    make_builder(&state->scratch).resize(size * params.max_stack_size);
+    resize(&state->scratch, size * params.max_stack_size);
     state->num_states = size;
 }
 

--- a/src/celeritas/ext/VecgeomData.hh
+++ b/src/celeritas/ext/VecgeomData.hh
@@ -122,9 +122,9 @@ void resize(
     CELER_EXPECT(size > 0);
     CELER_EXPECT(params.max_depth > 0);
 
-    make_builder(&data->pos).resize(size);
-    make_builder(&data->dir).resize(size);
-    make_builder(&data->next_step).resize(size);
+    resize(&data->pos, size);
+    resize(&data->dir, size);
+    resize(&data->next_step, size);
     data->vgstate.resize(params.max_depth, size);
     data->vgnext.resize(params.max_depth, size);
 

--- a/src/celeritas/ext/VecgeomData.hh
+++ b/src/celeritas/ext/VecgeomData.hh
@@ -110,7 +110,7 @@ struct VecgeomStateData
 
 //---------------------------------------------------------------------------//
 /*!
- * Resize particle states in host code.
+ * Resize geometry states.
  */
 template<MemSpace M>
 void resize(

--- a/src/celeritas/ext/VecgeomParams.hh
+++ b/src/celeritas/ext/VecgeomParams.hh
@@ -57,11 +57,11 @@ class VecgeomParams
 
     //// DATA ACCESS ////
 
-    //! View in-host geometry data for CPU debugging
-    const HostRef& host_ref() const { return host_ref_; }
+    //! Access geometry data on host
+    inline const HostRef& host_ref() const;
 
-    //! Get a view to the managed on-device data
-    const DeviceRef& device_ref() const { return device_ref_; }
+    //! Access geometry data on host
+    inline const DeviceRef& device_ref() const;
 
   private:
     //// DATA ////
@@ -78,6 +78,28 @@ class VecgeomParams
 
     void build_md();
 };
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Access geometry data on host.
+ */
+auto VecgeomParams::host_ref() const -> const HostRef&
+{
+    CELER_ENSURE(host_ref_);
+    return host_ref_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access geometry data on device.
+ */
+auto VecgeomParams::device_ref() const -> const DeviceRef&
+{
+    CELER_ENSURE(device_ref_);
+    return device_ref_;
+}
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/celeritas/ext/VecgeomParams.hh
+++ b/src/celeritas/ext/VecgeomParams.hh
@@ -41,6 +41,9 @@ class VecgeomParams
     // Clean up VecGeom on destruction
     ~VecgeomParams();
 
+    //! Whether safety distance calculations are accurate and precise
+    bool supports_safety() const { return true; }
+
     //// VOLUMES ////
 
     //! Number of volumes

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -316,7 +316,7 @@ CELER_FUNCTION Propagation VecgeomTrackView::find_next_step(real_type max_step)
 
     CELER_ENSURE(this->has_next_step());
     CELER_ENSURE(result.distance > 0);
-    CELER_ENSURE(result.distance <= max_step);
+    CELER_ENSURE(result.distance <= max(max_step, this->extra_push()));
     return result;
 }
 

--- a/src/celeritas/global/CoreParams.hh
+++ b/src/celeritas/global/CoreParams.hh
@@ -87,11 +87,11 @@ class CoreParams
     const SPActionManager& action_mgr() const { return input_.action_mgr; }
     //!@}
 
-    //! Access properties on the host
-    const HostRef& host_ref() const { return host_ref_; }
+    // Access properties on the host
+    inline const HostRef& host_ref() const;
 
-    //! Access properties on the device
-    const DeviceRef& device_ref() const { return device_ref_; }
+    // Access properties on the device
+    inline const DeviceRef& device_ref() const;
 
   private:
     Input       input_;
@@ -99,6 +99,31 @@ class CoreParams
     HostRef     host_ref_;
     DeviceRef   device_ref_;
 };
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Access properties on the host.
+ */
+auto CoreParams::host_ref() const -> const HostRef&
+{
+    CELER_ENSURE(host_ref_);
+    return host_ref_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access properties on the device.
+ *
+ * This will raise an exception if \c celeritas::device is null (and device
+ * data wasn't set).
+ */
+auto CoreParams::device_ref() const -> const DeviceRef&
+{
+    CELER_ENSURE(device_ref_);
+    return device_ref_;
+}
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/celeritas/mat/MaterialData.hh
+++ b/src/celeritas/mat/MaterialData.hh
@@ -184,9 +184,8 @@ inline void resize(
     size_type                                                             size)
 {
     CELER_EXPECT(size > 0);
-    make_builder(&data->state).resize(size);
-    make_builder(&data->element_scratch)
-        .resize(size * params.max_element_components);
+    resize(&data->state, size);
+    resize(&data->element_scratch, size * params.max_element_components);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/ParticleData.hh
+++ b/src/celeritas/phys/ParticleData.hh
@@ -158,7 +158,7 @@ resize(ParticleStateData<Ownership::value, M>* data,
        size_type size)
 {
     CELER_EXPECT(size > 0);
-    make_builder(&data->state).resize(size);
+    resize(&data->state, size);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -451,14 +451,13 @@ inline void resize(
 {
     CELER_EXPECT(size > 0);
     CELER_EXPECT(params.scalars.max_particle_processes > 0);
-    make_builder(&state->state).resize(size);
+    resize(&state->state, size);
     if (params.hardwired.msc)
     {
-        make_builder(&state->msc_step).resize(size);
+        resize(&state->msc_step, size);
     }
-    make_builder(&state->per_process_xs)
-        .resize(size * params.scalars.max_particle_processes);
-
+    resize(&state->per_process_xs,
+           size * params.scalars.max_particle_processes);
     resize(&state->relaxation, params.hardwired.relaxation_data, size);
     resize(&state->secondaries, size * params.scalars.secondary_stack_factor);
 }

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -391,6 +391,7 @@ void PhysicsParams::build_xs(const Options&        opts,
     CELER_EXPECT(*data);
 
     using UPGridBuilder = Process::UPConstGridBuilder;
+    using Energy        = Applicability::Energy;
 
     ValueGridInserter insert_grid(&data->reals, &data->value_grids);
     auto              value_tables   = make_builder(&data->value_tables);
@@ -431,8 +432,8 @@ void PhysicsParams::build_xs(const Options&        opts,
             // Get energy bounds for this process
             Span<const real_type> energy_grid
                 = data->reals[model_groups[pp_idx].energy];
-            applic.lower = Applicability::Energy{energy_grid.front()};
-            applic.upper = Applicability::Energy{energy_grid.back()};
+            applic.lower = Energy{energy_grid.front()};
+            applic.upper = Energy{energy_grid.back()};
             CELER_ASSERT(applic.lower < applic.upper);
 
             const Process& proc = this->process(processes[pp_idx]);

--- a/src/celeritas/random/CuHipRngData.cc
+++ b/src/celeritas/random/CuHipRngData.cc
@@ -37,14 +37,14 @@ void resize(
 
     // Create seeds for device in host memory
     StateCollection<RngInit, Ownership::value, MemSpace::host> host_seeds;
-    make_builder(&host_seeds).resize(size);
+    resize(&host_seeds, size);
     for (RngInit& init : host_seeds[AllItems<RngInit>{}])
     {
         init.seed = sample_uniform_int(host_rng);
     }
 
     // Resize state data and assign
-    make_builder(&state->rng).resize(size);
+    resize(&state->rng, size);
     detail::CuHipRngInitData<Ownership::value, M> init_data;
     init_data.seeds = host_seeds;
     detail::rng_state_init(make_ref(*state), make_const_ref(init_data));

--- a/src/celeritas/random/XorwowRngData.cc
+++ b/src/celeritas/random/XorwowRngData.cc
@@ -38,7 +38,7 @@ void resize(
 
     // Create seeds for device in host memory
     XorwowRngStateData<Ownership::value, MemSpace::host> host_state;
-    make_builder(&host_state.state).resize(size);
+    resize(&host_state.state, size);
 
     // Fill all seeds with random data. The xorstate is never all
     // zeros, with probability 2^{-320}.

--- a/src/celeritas/track/TrackInitData.hh
+++ b/src/celeritas/track/TrackInitData.hh
@@ -251,16 +251,16 @@ void resize(
 
     // Allocate device data
     auto capacity = params.capacity;
-    make_builder(&data->initializers.storage).resize(capacity);
-    make_builder(&data->parents).resize(size);
-    make_builder(&data->secondary_counts).resize(size);
+    resize(&data->initializers.storage, capacity);
+    resize(&data->parents, size);
+    resize(&data->secondary_counts, size);
 
     // Start with an empty vector of track initializers
     data->initializers.resize(0);
 
     // Initialize vacancies to mark all track slots as empty
     StateCollection<size_type, Ownership::value, MemSpace::host> vacancies;
-    make_builder(&vacancies).resize(size);
+    resize(&vacancies, size);
     for (auto i : range(size))
     {
         vacancies[ThreadId{i}] = i;

--- a/src/celeritas/track/TrackInitUtils.hh
+++ b/src/celeritas/track/TrackInitUtils.hh
@@ -49,7 +49,7 @@ inline void extend_from_primaries(const TrackInitParamsHostRef& params,
 
         // Allocate memory and copy primaries
         Collection<Primary, Ownership::value, M> primaries;
-        make_builder(&primaries).resize(count);
+        resize(&primaries, count);
         Copier<Primary, MemSpace::host> copy{
             params.primaries[ItemRange<Primary>(
                 ItemId<Primary>(data->num_primaries - count),

--- a/src/corecel/data/CollectionMirror.hh
+++ b/src/corecel/data/CollectionMirror.hh
@@ -118,6 +118,9 @@ auto CollectionMirror<P>::host_ref() const -> const HostRef&
 //---------------------------------------------------------------------------//
 /*!
  * Get references to device data after construction.
+ *
+ * This will raise an exception if \c celeritas::device is null (and device
+ * data wasn't set).
  */
 template<template<Ownership, MemSpace> class P>
 auto CollectionMirror<P>::device_ref() const -> const DeviceRef&

--- a/src/corecel/data/StackAllocatorData.hh
+++ b/src/corecel/data/StackAllocatorData.hh
@@ -55,8 +55,8 @@ inline void
 resize(StackAllocatorData<T, Ownership::value, M>* data, size_type capacity)
 {
     CELER_EXPECT(capacity > 0);
-    make_builder(&data->storage).resize(capacity);
-    make_builder(&data->size).resize(1);
+    resize(&data->storage, capacity);
+    resize(&data->size, 1);
     celeritas::fill(size_type(0), &data->size);
 }
 

--- a/src/corecel/data/detail/FillInvalid.hh
+++ b/src/corecel/data/detail/FillInvalid.hh
@@ -21,6 +21,40 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
+template<class T, class Enable = void>
+struct TrivialInvalidValueTraits
+{
+    static_assert(std::is_trivial<T>::value,
+                  "Cannot legally memset non-trivial types");
+    static T value()
+    {
+        T result;
+        std::memset(&result, 0xd0, sizeof(T)); // 4*b"\xf0\x9f\xa6\xa4".decode()
+        return result;
+    }
+};
+
+//---------------------------------------------------------------------------//
+template<class T>
+struct TrivialInvalidValueTraits<
+    T,
+    typename std::enable_if<std::is_arithmetic<T>::value>::type>
+{
+    static constexpr T value() { return std::numeric_limits<T>::max() / 2; }
+};
+
+template<class T, size_type N>
+struct TrivialInvalidValueTraits<Array<T, N>, void>
+{
+    static Array<T, N> value()
+    {
+        Array<T, N> result;
+        result.fill(TrivialInvalidValueTraits<T>::value());
+        return result;
+    }
+};
+
+//---------------------------------------------------------------------------//
 /*!
  * Return an 'invalid' value.
  *
@@ -29,7 +63,7 @@ namespace detail
  *
  * Instead of assigning 'NaN', which may work automatically for sentinel logic
  * such as "valid if x > 0)", we assign large (half-max) values for numeric
- * types, and fill generic types with garbage values that look like
+ * types, and fill trivial types with garbage values that look like
  * `0xd0d0d0d0`.
  */
 template<class T, class Enable = void>
@@ -37,8 +71,21 @@ struct InvalidValueTraits
 {
     static T value()
     {
+#if !CELERITAS_USE_HIP
+        static_assert(std::is_trivially_copyable<T>::value,
+                      "Filling can only be done to trivially copyable "
+                      "classes");
+#endif
+        // BAD: we're assigning garbage data to a result with a *non-trivial
+        // type*, such as a struct of OpaqueIds. However, this is in essence
+        // what's going on when we allocate space for nontrivial types on
+        // device: whatever's there (whether memset on NVIDIA or uninitialized
+        // on AMD) is not going to have "placement new" applied since we're not
+        // using thrust or calling Filler to launch initialization kernels on
+        // all our datatypes. Reinterpret the data as bytes and assign garbage
+        // values.
         T result;
-        std::memset(&result, 0xd0, sizeof(T)); // 4*b"\xf0\x9f\xa6\xa4".decode()
+        std::memset(reinterpret_cast<unsigned char*>(&result), 0xd0, sizeof(T));
         return result;
     }
 };
@@ -53,22 +100,11 @@ struct InvalidValueTraits<OpaqueId<I, T>, void>
     }
 };
 
+//---------------------------------------------------------------------------//
 template<class T>
-struct InvalidValueTraits<T,
-                          typename std::enable_if<std::is_arithmetic<T>::value>::type>
+struct InvalidValueTraits<T, typename std::enable_if<std::is_trivial<T>::value>::type>
 {
-    static constexpr T value() { return std::numeric_limits<T>::max() / 2; }
-};
-
-template<class T, size_type N>
-struct InvalidValueTraits<Array<T, N>, void>
-{
-    static Array<T, N> value()
-    {
-        Array<T, N> result;
-        result.fill(InvalidValueTraits<T>::value());
-        return result;
-    }
+    static T value() { return TrivialInvalidValueTraits<T>::value(); }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/detail/FillInvalid.hh
+++ b/src/corecel/data/detail/FillInvalid.hh
@@ -1,0 +1,116 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/data/detail/InvalidValueTraits.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <type_traits>
+
+#include "corecel/OpaqueId.hh"
+#include "corecel/cont/Array.hh"
+
+#include "../Collection.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Return an 'invalid' value.
+ *
+ * This is used to reproducibly replicate construction on device, where
+ * {cuda,hip}Malloc doesn't call the default constructors on data.
+ *
+ * Instead of assigning 'NaN', which may work automatically for sentinel logic
+ * such as "valid if x > 0)", we assign large (half-max) values for numeric
+ * types, and fill generic types with garbage values that look like
+ * `0xd0d0d0d0`.
+ */
+template<class T, class Enable = void>
+struct InvalidValueTraits
+{
+    static T value()
+    {
+        T result;
+        std::memset(&result, 0xd0, sizeof(T)); // 4*b"\xf0\x9f\xa6\xa4".decode()
+        return result;
+    }
+};
+
+//---------------------------------------------------------------------------//
+template<class I, class T>
+struct InvalidValueTraits<OpaqueId<I, T>, void>
+{
+    static constexpr OpaqueId<I, T> value()
+    {
+        return OpaqueId<I, T>(std::numeric_limits<T>::max() / 2);
+    }
+};
+
+template<class T>
+struct InvalidValueTraits<T,
+                          typename std::enable_if<std::is_arithmetic<T>::value>::type>
+{
+    static constexpr T value() { return std::numeric_limits<T>::max() / 2; }
+};
+
+template<class T, size_type N>
+struct InvalidValueTraits<Array<T, N>, void>
+{
+    static Array<T, N> value()
+    {
+        Array<T, N> result;
+        result.fill(InvalidValueTraits<T>::value());
+        return result;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Fill a collection with an invalid value (host only).
+ */
+template<MemSpace M>
+struct InvalidFiller
+{
+    template<class T>
+    void operator()(T*)
+    {
+    }
+};
+
+template<>
+struct InvalidFiller<MemSpace::host>
+{
+    template<class T, Ownership W, class I>
+    void operator()(Collection<T, W, MemSpace::host, I>* c)
+    {
+        CELER_EXPECT(c);
+
+        T    val   = InvalidValueTraits<T>::value();
+        auto items = (*c)[AllItems<T>{}];
+        std::fill(items.begin(), items.end(), val);
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Fill a collection with an invalid value (host only).
+ *
+ * This can probably be removed once we switch to C++17 and \c
+ * CollectionBuilder::resize uses \code if constexpr \endcode .
+ */
+template<class T, Ownership W, MemSpace M, class I = ItemId<T>>
+void fill_invalid(Collection<T, W, M, I>* c)
+{
+    return InvalidFiller<M>{}(c);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/corecel/io/OutputManager.cc
+++ b/src/corecel/io/OutputManager.cc
@@ -42,9 +42,9 @@ void OutputManager::insert(SPConstInterface interface)
 
 //---------------------------------------------------------------------------//
 /*!
- * Output all classes to a JSON object that's written to the given stream.
+ * Output all classes to a JSON object.
  */
-void OutputManager::output(std::ostream* os) const
+void OutputManager::output(JsonPimpl* j) const
 {
 #if CELERITAS_USE_JSON
     nlohmann::json result;
@@ -80,9 +80,25 @@ void OutputManager::output(std::ostream* os) const
         }
     }
 
-    *os << result.dump();
+    j->obj = std::move(result);
 #else
-    // Write a JSON-compatible string showing why output is unavailable
+    (void)sizeof(j);
+    CELER_NOT_CONFIGURED("nljson");
+#endif
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Output all classes to a JSON object that's written to the given stream.
+ */
+void OutputManager::output(std::ostream* os) const
+{
+#if CELERITAS_USE_JSON
+    JsonPimpl json_wrap;
+    this->output(&json_wrap);
+    *os << json_wrap.obj.dump();
+#else
+    // Write a JSON-compatible string and print an explanation to stderr
     CELER_LOG(error) << "Cannot write output to JSON: nljson is not enabled "
                         "in the current build configuration";
     *os << "\"output unavailable\"";

--- a/src/corecel/io/OutputManager.hh
+++ b/src/corecel/io/OutputManager.hh
@@ -41,7 +41,10 @@ class OutputManager
     // Add an interface for writing
     void insert(SPConstInterface);
 
-    // Write all outputs as JSON to the given stream
+    // Write output to the given JSON object
+    void output(JsonPimpl*) const;
+
+    // Dump all outputs as JSON to the given stream
     void output(std::ostream* os) const;
 
   private:

--- a/src/orange/Data.hh
+++ b/src/orange/Data.hh
@@ -274,7 +274,7 @@ struct OrangeStateData
 
 //---------------------------------------------------------------------------//
 /*!
- * Resize particle states in host code.
+ * Resize geometry tracking states.
  */
 template<MemSpace M>
 inline void

--- a/src/orange/Data.hh
+++ b/src/orange/Data.hh
@@ -284,19 +284,19 @@ resize(OrangeStateData<Ownership::value, M>* data,
 {
     CELER_EXPECT(data);
     CELER_EXPECT(size > 0);
-    make_builder(&data->pos).resize(size);
-    make_builder(&data->dir).resize(size);
-    make_builder(&data->vol).resize(size);
-    make_builder(&data->surf).resize(size);
-    make_builder(&data->sense).resize(size);
+    resize(&data->pos, size);
+    resize(&data->dir, size);
+    resize(&data->vol, size);
+    resize(&data->surf, size);
+    resize(&data->sense, size);
 
     size_type face_states = params.scalars.max_faces * size;
-    make_builder(&data->temp_sense).resize(face_states);
+    resize(&data->temp_sense, face_states);
 
     size_type isect_states = params.scalars.max_intersections * size;
-    make_builder(&data->temp_face).resize(isect_states);
-    make_builder(&data->temp_distance).resize(isect_states);
-    make_builder(&data->temp_isect).resize(isect_states);
+    resize(&data->temp_face, isect_states);
+    resize(&data->temp_distance, isect_states);
+    resize(&data->temp_isect, isect_states);
 
     CELER_ENSURE(*data);
 }

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -218,13 +218,7 @@ OrangeParams::OrangeParams(Input input)
     host_data.scalars.max_faces         = max_faces;
     host_data.scalars.max_intersections = max_intersections;
 
-    if (!simple_safety)
-    {
-        CELER_LOG(warning) << "Geometry contains surfaces that are "
-                              "incompatible with the current ORANGE simple "
-                              "safety algorithm: multiple scattering may "
-                              "result in arbitrarily small steps";
-    }
+    supports_safety_ = simple_safety;
 
     // Construct device values and device/host references
     CELER_ASSERT(host_data);

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -58,6 +58,9 @@ class OrangeParams
     // ADVANCED usage: construct from explicit host data
     explicit OrangeParams(Input input);
 
+    //! Whether safety distance calculations are accurate and precise
+    bool supports_safety() const { return supports_safety_; }
+
     //// VOLUMES ////
 
     //! Number of volumes
@@ -98,6 +101,7 @@ class OrangeParams
     std::unordered_map<std::string, VolumeId>  vol_ids_;
     std::unordered_map<std::string, SurfaceId> surf_ids_;
     BoundingBox                                bbox_;
+    bool                                       supports_safety_{};
 
     // Host/device storage and reference
     CollectionMirror<OrangeParamsData> data_;

--- a/test/celeritas/GlobalTestBase.cc
+++ b/test/celeritas/GlobalTestBase.cc
@@ -9,6 +9,8 @@
 
 #include <fstream>
 
+#include "celeritas_config.h"
+#include "corecel/io/JsonPimpl.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/OutputManager.hh"
 #include "celeritas/geo/GeoParams.hh"
@@ -17,6 +19,9 @@
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/phys/PhysicsParamsOutput.hh"
 #include "celeritas/random/RngParams.hh"
+#if CELERITAS_USE_JSON
+#    include <nlohmann/json.hpp>
+#endif
 
 using namespace celeritas;
 
@@ -147,7 +152,15 @@ void GlobalTestBase::write_output()
 //---------------------------------------------------------------------------//
 void GlobalTestBase::write_output(std::ostream& os) const
 {
-    output_->output(&os);
+#if CELERITAS_USE_JSON
+    JsonPimpl json_wrap;
+    output_->output(&json_wrap);
+
+    // Print with pretty indentation
+    os << json_wrap.obj.dump(1) << '\n';
+#else
+    os << "\"output unavailable\"";
+#endif
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/em/LivermorePE.test.cc
+++ b/test/celeritas/em/LivermorePE.test.cc
@@ -572,7 +572,7 @@ TEST_F(LivermorePETest, utils)
     unsigned int num_shells = 20;
     {
         Values data;
-        make_builder(&data.elements).resize(1);
+        resize(&data.elements, 1);
         AtomicRelaxElement& el = data.elements[ElementId(0)];
 
         std::vector<AtomicRelaxSubshell> shells(num_shells);
@@ -601,7 +601,7 @@ TEST_F(LivermorePETest, utils)
     }
     {
         Values data;
-        make_builder(&data.elements).resize(1);
+        resize(&data.elements, 1);
         AtomicRelaxElement& el = data.elements[ElementId(0)];
 
         std::vector<AtomicRelaxSubshell> shells(num_shells);

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -152,6 +152,21 @@ class PhysicsTrackViewHostTest : public PhysicsParamsTest
         params_ref = this->physics()->host_ref();
         state      = StateStore(*this->physics(), state_size);
 
+        // Clear secondary data (done in pre-step kernel)
+        {
+            StackAllocator<Secondary> allocate(state.ref().secondaries);
+            allocate.clear();
+        }
+
+        // Clear out energy deposition and secondary pointers (done in pre-step
+        // kernel)
+        for (auto tid : range(ThreadId(state_size)))
+        {
+            auto step = this->make_step_view(tid);
+            step.reset_energy_deposition();
+            step.secondaries({});
+        }
+
         // Save mapping of process label -> ID
         for (auto id : range(ProcessId{this->physics()->num_processes()}))
         {

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -51,10 +51,16 @@ ITTestInputData ITTestInput::device_ref()
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
+#define TrackInitTest TEST_IF_CELER_DEVICE(TrackInitTest)
+
 class TrackInitTest : public celeritas_test::SimpleTestBase
 {
   protected:
-    void SetUp() override { core_data.params = this->core()->device_ref(); }
+    void SetUp() override
+    {
+        core_data.params = this->core()->device_ref();
+        CELER_ENSURE(core_data.params);
+    }
 
     //! Create primary particles
     std::vector<Primary> generate_primaries(size_type num_primaries)
@@ -293,6 +299,8 @@ TEST_F(TrackInitTest, primaries)
     EXPECT_EQ(track_init_states.num_primaries, 0);
     EXPECT_EQ(track_init_states.initializers.size(), 0);
 }
+
+#define TrackInitSecondaryTest TEST_IF_CELER_DEVICE(TrackInitSecondaryTest)
 
 class TrackInitSecondaryTest : public TrackInitTest
 {

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -159,7 +159,7 @@ TEST_F(SimpleCollectionTest, algo_host)
     Value<host> src;
 
     // Test 'fill'
-    make_builder(&src).resize(4);
+    resize(&src, 4);
     celeritas::fill(123, &src);
     EXPECT_EQ(123, src[IntId{0}]);
     EXPECT_EQ(123, src[IntId{3}]);
@@ -173,7 +173,7 @@ TEST_F(SimpleCollectionTest, algo_host)
 TEST_F(SimpleCollectionTest, TEST_IF_CELER_DEVICE(algo_device))
 {
     Value<device> src;
-    make_builder(&src).resize(2);
+    resize(&src, 2);
     celeritas::fill(123, &src);
 
     // Test 'copy_to_host'
@@ -273,7 +273,7 @@ inline void
 resize(MockStateData<Ownership::value, M>* data, celeritas::size_type size)
 {
     CELER_EXPECT(size > 0);
-    make_builder(&data->matid).resize(size);
+    resize(&data->matid, size);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/SurfaceAction.test.hh
+++ b/test/orange/surf/SurfaceAction.test.hh
@@ -79,10 +79,10 @@ resize(OrangeMiniStateData<Ownership::value, M>* data,
 {
     CELER_EXPECT(data);
     CELER_EXPECT(size > 0);
-    make_builder(&data->pos).resize(size);
-    make_builder(&data->dir).resize(size);
-    make_builder(&data->sense).resize(size);
-    make_builder(&data->distance).resize(size);
+    resize(&data->pos, size);
+    resize(&data->dir, size);
+    resize(&data->sense, size);
+    resize(&data->distance, size);
 
     CELER_ENSURE(*data);
 }

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -11,13 +11,12 @@
 #include <random>
 
 // Source includes
+#include "corecel/data/CollectionStateStore.hh"
 #include "corecel/io/Repr.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "corecel/sys/Stopwatch.hh"
-#include "celeritas/Constants.hh"
-
-// Test includes
 #include "orange/OrangeGeoTestBase.hh"
+#include "celeritas/Constants.hh"
 #include "celeritas/random/distribution/IsotropicDistribution.hh"
 #include "celeritas/random/distribution/UniformBoxDistribution.hh"
 
@@ -42,8 +41,10 @@ constexpr real_type sqrt_half = sqrt_two / 2;
 class SimpleUnitTrackerTest : public celeritas_test::OrangeGeoTestBase
 {
   protected:
-    using StateHostValue
-        = celeritas::OrangeStateData<Ownership::value, MemSpace::host>;
+    using StateHostValue = OrangeStateData<Ownership::value, MemSpace::host>;
+    using StateHostRef = OrangeStateData<Ownership::reference, MemSpace::host>;
+    using HostStateStore
+        = CollectionStateStore<OrangeStateData, MemSpace::host>;
 
     struct HeuristicInitResult
     {
@@ -74,7 +75,8 @@ class SimpleUnitTrackerTest : public celeritas_test::OrangeGeoTestBase
 
   private:
     StateHostValue      setup_heuristic_states(size_type num_tracks) const;
-    HeuristicInitResult reduce_heuristic_init(StateHostValue, double) const;
+    HeuristicInitResult
+    reduce_heuristic_init(const StateHostRef&, double) const;
 };
 
 class OneVolumeTest : public SimpleUnitTrackerTest
@@ -196,21 +198,19 @@ LocalState SimpleUnitTrackerTest::make_state_crossing(
 auto SimpleUnitTrackerTest::run_heuristic_init_host(size_type num_tracks) const
     -> HeuristicInitResult
 {
-    auto state_host = this->setup_heuristic_states(num_tracks);
+    HostStateStore states(this->setup_heuristic_states(num_tracks));
 
     // Set up for host run
-    OrangeStateData<Ownership::reference, MemSpace::host> host_state_ref;
-    host_state_ref = state_host;
-    InitializingLauncher<> calc_init{this->params().host_ref(), host_state_ref};
+    InitializingLauncher<> calc_init{this->params().host_ref(), states.ref()};
 
     // Loop over all threads
     Stopwatch get_time;
-    for (auto tid : range(ThreadId{state_host.size()}))
+    for (auto tid : range(ThreadId{states.size()}))
     {
         calc_init(tid);
     }
 
-    return this->reduce_heuristic_init(std::move(state_host), get_time());
+    return this->reduce_heuristic_init(states.ref(), get_time());
 }
 
 //---------------------------------------------------------------------------//
@@ -220,21 +220,17 @@ auto SimpleUnitTrackerTest::run_heuristic_init_host(size_type num_tracks) const
 auto SimpleUnitTrackerTest::run_heuristic_init_device(size_type num_tracks) const
     -> HeuristicInitResult
 {
-    // Construct on host and copy to device
-    auto state_host = this->setup_heuristic_states(num_tracks);
-    OrangeStateData<Ownership::value, MemSpace::device> state_device;
-    state_device = state_host;
-    StateRef<MemSpace::device> state_device_ref;
-    state_device_ref = state_device;
+    using DStateStore = CollectionStateStore<OrangeStateData, MemSpace::device>;
+    DStateStore states(this->setup_heuristic_states(num_tracks));
 
     // Run on device
     Stopwatch get_time;
-    test_initialize(this->params().device_ref(), state_device_ref);
+    test_initialize(this->params().device_ref(), states.ref());
     const double kernel_time = get_time();
 
     // Copy result back to host
-    state_host = state_device;
-    return this->reduce_heuristic_init(std::move(state_host), kernel_time);
+    HostStateStore state_host(std::move(states));
+    return this->reduce_heuristic_init(state_host.ref(), kernel_time);
 }
 
 //---------------------------------------------------------------------------//
@@ -261,6 +257,8 @@ auto SimpleUnitTrackerTest::setup_heuristic_states(size_type num_tracks) const
         pos_view[i] = sample_box(rng);
         dir_view[i] = sample_isotropic(rng);
     }
+
+    CELER_ENSURE(result);
     return result;
 }
 
@@ -268,7 +266,7 @@ auto SimpleUnitTrackerTest::setup_heuristic_states(size_type num_tracks) const
 /*!
  * Process "heuristic init" test results.
  */
-auto SimpleUnitTrackerTest::reduce_heuristic_init(StateHostValue host,
+auto SimpleUnitTrackerTest::reduce_heuristic_init(const StateHostRef& host,
                                                   double wall_time) const
     -> HeuristicInitResult
 {

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include <random>
 
-// Source includes
+#include "corecel/data/CollectionAlgorithms.hh"
 #include "corecel/data/CollectionStateStore.hh"
 #include "corecel/io/Repr.hh"
 #include "corecel/math/ArrayUtils.hh"
@@ -257,6 +257,10 @@ auto SimpleUnitTrackerTest::setup_heuristic_states(size_type num_tracks) const
         pos_view[i] = sample_box(rng);
         dir_view[i] = sample_isotropic(rng);
     }
+
+    // Clear other data
+    fill(VolumeId{}, &result.vol);
+    fill(SurfaceId{}, &result.surf);
 
     CELER_ENSURE(result);
     return result;


### PR DESCRIPTION
The main change here is to fill newly resized data (e.g. states) with garbage in host collections, rather than allowing the default initializer to assign the data to a nice pretty state. This better replicates the behavior on device, where the data is only *allocated* and not *initialized*. (To initialize at allocation, we'd have to add `Filler<device>` instantiations for all the types we care about.)