### PR TITLE
Noexcept/cxx17 fixes

### DIFF
--- a/test/corecel/sys/ScopedSignalHandler.test.cc
+++ b/test/corecel/sys/ScopedSignalHandler.test.cc
@@ -40,7 +40,10 @@ TEST(ScopedSignalHandlerTest, single)
 
 TEST(ScopedSignalHandlerTest, multiple)
 {
-    for (auto* raise : {ScopedSignalHandler::raise, std::raise})
+    using FuncPtr = int (*)(int);
+
+    for (auto* raise :
+         {FuncPtr(&ScopedSignalHandler::raise), FuncPtr(&std::raise)})
     {
         {
             ScopedSignalHandler interrupted{SIGINT, SIGUSR1};


### PR DESCRIPTION
- Fixes a "conflicting type deduction" issue due to a `noexcept` specifier for `std::raise` on some systems/compilers
- Replace `result_of` with `invoke_result` for C++17