### PR TITLE
Simplify and fix safety/MSC

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -269,15 +269,13 @@ if(CELERITAS_BUILD_DEMOS)
       LABELS "app;nomemcheck;gpu"
     )
 
-    # Disable test when prereqs are not available or for debug builds
-    # (debug failures seem limited to older architectures with debug assertions
-    # enabled)
+    # Disable test when prereqs are not available
+    # Note that this test has been known to fail for CUDA architecture 3.5
+    # when using VecGeom and a debug build
     if(NOT (CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
        OR NOT CELERITAS_USE_Geant4
        OR NOT CELERITAS_USE_HepMC3
        OR NOT CELERITAS_USE_Python
-       OR (CELERITAS_USE_VecGeom AND CELERITAS_DEBUG
-           AND CMAKE_BUILD_TYPE STREQUAL "Debug")
        )
       set_tests_properties("app/demo-loop" PROPERTIES
         DISABLED true

--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -47,6 +47,12 @@ struct UrbanMscParameters
         return 1e-9 * units::centimeter;
     }
 
+    //! Default minimum of the true path limit: 1e-8 cm
+    static CELER_CONSTEXPR_FUNCTION real_type limit_min()
+    {
+        return 10 * limit_min_fix();
+    }
+
     //! For steps below this value, true = geometrical (no MSC to be applied)
     static CELER_CONSTEXPR_FUNCTION real_type min_step()
     {

--- a/src/celeritas/em/distribution/UrbanMscScatter.hh
+++ b/src/celeritas/em/distribution/UrbanMscScatter.hh
@@ -548,8 +548,7 @@ CELER_FUNCTION real_type UrbanMscScatter::calc_displacement_scaling(
     real_type rho = multiplier * norm(displacement);
     if (rho > params_.geom_limit)
     {
-        real_type safety = (1 - params_.safety_tol)
-                           * geometry_.find_safety(geometry_.pos());
+        real_type safety = (1 - params_.safety_tol) * geometry_.find_safety();
         if (rho <= safety)
         {
             // No scaling needed

--- a/src/celeritas/em/distribution/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/distribution/UrbanMscStepLimit.hh
@@ -128,7 +128,7 @@ UrbanMscStepLimit::UrbanMscStepLimit(const UrbanMscRef&       shared,
     : shared_(shared)
     , inc_energy_(particle.energy())
     , is_positron_(particle.particle_id() == shared.ids.positron)
-    , safety_(geometry->find_safety(geometry->pos()))
+    , safety_(geometry->find_safety())
     , params_(shared.params)
     , msc_(shared_.msc_data[material.material_id()])
     , helper_(shared, particle, physics)

--- a/src/celeritas/em/distribution/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/distribution/UrbanMscStepLimit.hh
@@ -96,12 +96,7 @@ class UrbanMscStepLimit
     inline CELER_FUNCTION GeomPathAlpha calc_geom_path(real_type true_path) const;
 
     // Calculate the minimum of the true path length limit
-    inline CELER_FUNCTION real_type calc_limit_min(Energy    energy,
-                                                   real_type step_min) const;
-
-    // Calculate the minimum of the step length for a given elastic mfp
-    inline CELER_FUNCTION real_type calc_step_min(Energy    energy,
-                                                  real_type lambda) const;
+    inline CELER_FUNCTION real_type calc_limit_min() const;
 
     //! The lower bound of energy to scale the mininum true path length limit
     static CELER_CONSTEXPR_FUNCTION Energy tlow()
@@ -172,9 +167,8 @@ CELER_FUNCTION auto UrbanMscStepLimit::operator()(Engine& rng) -> MscStep
     // The case for a very small step or the lower limit for the linear
     // distance that e-/e+ can travel is far from the geometry boundary
     // NOTE: use d_over_r_mh for muons and charged hadrons
-    real_type distance = range_ * msc_.d_over_r;
     if (result.true_path < shared_.params.limit_min_fix()
-        || (safety_ > 0 && distance < safety_))
+        || range_ * msc_.d_over_r < safety_)
     {
         result.is_displaced = false;
         auto temp           = this->calc_geom_path(result.true_path);
@@ -198,8 +192,11 @@ CELER_FUNCTION auto UrbanMscStepLimit::operator()(Engine& rng) -> MscStep
             range_fact *= (real_type(0.75)
                            + real_type(0.25) * lambda_ / params_.lambda_limit);
         }
-        real_type step_min = this->calc_step_min(inc_energy_, lambda_);
-        result.limit_min   = this->calc_limit_min(inc_energy_, step_min);
+        result.limit_min = this->calc_limit_min();
+    }
+    else
+    {
+        result.limit_min = shared_.params.limit_min();
     }
 
     // The step limit
@@ -316,30 +313,28 @@ auto UrbanMscStepLimit::calc_geom_path(real_type true_path) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Define the minimum step using the ratio of lambda_elastic/lambda_transport.
+ * Calculate the minimum of the true path length limit.
  */
-CELER_FUNCTION real_type UrbanMscStepLimit::calc_step_min(Energy    energy,
-                                                          real_type lambda) const
+CELER_FUNCTION real_type UrbanMscStepLimit::calc_limit_min() const
 {
     using PolyQuad = PolyEvaluator<real_type, 2>;
 
-    return lambda / PolyQuad(2, msc_.stepmin_a, msc_.stepmin_b)(energy.value());
-}
+    // Calculate minimum step
+    real_type xm
+        = lambda_
+          / PolyQuad(2, msc_.stepmin_a, msc_.stepmin_b)(inc_energy_.value());
 
-//---------------------------------------------------------------------------//
-/*!
- * Calculate the minimum of the true path length limit.
- */
-CELER_FUNCTION real_type UrbanMscStepLimit::calc_limit_min(Energy    energy,
-                                                           real_type step) const
-{
-    real_type xm = is_positron_ ? real_type(0.70) * step * std::sqrt(msc_.zeff)
-                                : real_type(0.87) * step * msc_.z23;
+    // Scale based on particle type and effective atomic number:
+    // 0.7 * z^{1/2} for positrons, otherwise 0.87 * z^{2/3}
+    // TODO: tabulate these two values to avoid the sqrt?
+    xm *= is_positron_ ? real_type(0.70) * std::sqrt(msc_.zeff)
+                       : real_type(0.87) * msc_.z23;
 
-    if (energy < this->tlow())
+    if (inc_energy_ < this->tlow())
     {
         // Energy is below a pre-defined limit
-        xm *= real_type(0.5) * (1 + energy.value() / this->tlow().value());
+        xm *= (real_type(0.5)
+               + real_type(0.5) * inc_energy_.value() / this->tlow().value());
     }
 
     return max<real_type>(xm, shared_.params.limit_min_fix());

--- a/src/celeritas/em/distribution/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/distribution/UrbanMscStepLimit.hh
@@ -131,7 +131,7 @@ UrbanMscStepLimit::UrbanMscStepLimit(const UrbanMscRef&       shared,
     , params_(shared.params)
     , msc_(shared_.msc_data[matid])
     , helper_(shared, particle, physics)
-    , on_boundary_(is_first_step || safety_ == 0)
+    , on_boundary_(is_first_step || safety_ <= 0)
     , phys_step_(phys_step)
 {
     CELER_EXPECT(particle.particle_id() == shared.ids.electron
@@ -174,7 +174,7 @@ CELER_FUNCTION auto UrbanMscStepLimit::operator()(Engine& rng) -> MscStep
     // NOTE: use d_over_r_mh for muons and charged hadrons
     real_type distance = range_ * msc_.d_over_r;
     if (result.true_path < shared_.params.limit_min_fix()
-        || (safety_ > 0 && distance < safety_))
+        || (!on_boundary_ && distance < safety_))
     {
         result.is_displaced = false;
         auto temp           = this->calc_geom_path(result.true_path);

--- a/src/celeritas/em/distribution/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/distribution/UrbanMscStepLimit.hh
@@ -174,7 +174,7 @@ CELER_FUNCTION auto UrbanMscStepLimit::operator()(Engine& rng) -> MscStep
     // NOTE: use d_over_r_mh for muons and charged hadrons
     real_type distance = range_ * msc_.d_over_r;
     if (result.true_path < shared_.params.limit_min_fix()
-        || (!on_boundary_ && distance < safety_))
+        || (safety_ > 0 && distance < safety_))
     {
         result.is_displaced = false;
         auto temp           = this->calc_geom_path(result.true_path);

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -97,8 +97,8 @@ class VecgeomTrackView
     // Find the distance to the next boundary, up to and including a step
     inline CELER_FUNCTION Propagation find_next_step(real_type max_step);
 
-    // Find the safety at a given position within the current volume
-    inline CELER_FUNCTION real_type find_safety(const Real3& pos);
+    // Find the safety at a the current position within the current volume
+    inline CELER_FUNCTION real_type find_safety();
 
     // Move to the boundary in preparation for crossing it
     inline CELER_FUNCTION void move_to_boundary();
@@ -324,10 +324,10 @@ CELER_FUNCTION Propagation VecgeomTrackView::find_next_step(real_type max_step)
 /*!
  * Find the new safety at a given position within the current volume.
  */
-CELER_FUNCTION real_type VecgeomTrackView::find_safety(const Real3& pos)
+CELER_FUNCTION real_type VecgeomTrackView::find_safety()
 {
     real_type safety = detail::BVHNavigator::ComputeSafety(
-        detail::to_vector(pos), vgstate_);
+        detail::to_vector(this->pos()), vgstate_);
     return safety;
 }
 

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -97,7 +97,7 @@ class VecgeomTrackView
     // Find the distance to the next boundary, up to and including a step
     inline CELER_FUNCTION Propagation find_next_step(real_type max_step);
 
-    // Find the safety at a the current position within the current volume
+    // Find the safety at the current position
     inline CELER_FUNCTION real_type find_safety();
 
     // Move to the boundary in preparation for crossing it
@@ -322,12 +322,13 @@ CELER_FUNCTION Propagation VecgeomTrackView::find_next_step(real_type max_step)
 
 //---------------------------------------------------------------------------//
 /*!
- * Find the new safety at a given position within the current volume.
+ * Find the safety at the current position.
  */
 CELER_FUNCTION real_type VecgeomTrackView::find_safety()
 {
     real_type safety = detail::BVHNavigator::ComputeSafety(
         detail::to_vector(this->pos()), vgstate_);
+    CELER_ENSURE(safety >= 0);
     return safety;
 }
 

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -328,8 +328,10 @@ CELER_FUNCTION real_type VecgeomTrackView::find_safety()
 {
     real_type safety = detail::BVHNavigator::ComputeSafety(
         detail::to_vector(this->pos()), vgstate_);
-    CELER_ENSURE(safety >= 0);
-    return safety;
+
+    // TODO: ComputeSafety can return negative safety distances: clamp it to
+    // zero until we debug the underlying cause.
+    return max<real_type>(safety, 0);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/detail/AlongStepActionImpl.hh
+++ b/src/celeritas/global/detail/AlongStepActionImpl.hh
@@ -65,9 +65,6 @@ inline CELER_FUNCTION void along_step_track(CoreTrackView const& track)
         return;
     }
 
-    // Increment the step counter
-    sim.increment_num_steps();
-
     // True step is the actual path length traveled by the particle, including
     // within-step MSC
     StepLimit step_limit = sim.step_limit();
@@ -80,6 +77,10 @@ inline CELER_FUNCTION void along_step_track(CoreTrackView const& track)
         CELER_ASSERT(track.make_particle_view().is_stopped());
         CELER_ASSERT(step_limit.action
                      == track.make_physics_view().scalars().discrete_action());
+
+        // Increment the step counter for diagnostic purposes
+        sim.increment_num_steps();
+
         return;
     }
 
@@ -234,6 +235,9 @@ inline CELER_FUNCTION void along_step_track(CoreTrackView const& track)
 
     // Override step limit with whatever action/step changes we applied here
     sim.force_step_limit(step_limit);
+
+    // Increment the step counter
+    sim.increment_num_steps();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/detail/AlongStepActionImpl.hh
+++ b/src/celeritas/global/detail/AlongStepActionImpl.hh
@@ -94,16 +94,16 @@ inline CELER_FUNCTION void along_step_track(CoreTrackView const& track)
     bool      use_msc  = use_msc_track(particle, phys, geo_step);
     if (use_msc)
     {
-        auto mat = track.make_material_view();
         auto rng = track.make_rng_engine();
         // Sample multiple scattering step length
-        UrbanMscStepLimit msc_step_limit(phys.urban_data(),
-                                         particle,
-                                         &geo,
-                                         phys,
-                                         mat.make_material_view(),
-                                         sim.num_steps() == 0,
-                                         step_limit.step);
+        UrbanMscStepLimit msc_step_limit(
+            phys.urban_data(),
+            particle,
+            phys,
+            track.make_material_view().material_id(),
+            sim.num_steps() == 0,
+            geo.find_safety(),
+            step_limit.step);
 
         auto msc_step_result = msc_step_limit(rng);
         track.make_physics_step_view().msc_step(msc_step_result);

--- a/src/celeritas/phys/Interaction.hh
+++ b/src/celeritas/phys/Interaction.hh
@@ -76,7 +76,7 @@ struct MscStep
     real_type phys_step{};        //!< Step length from physics processes
     real_type true_path{};        //!< True path length due to the msc
     real_type geom_path{};        //!< Geometrical path length
-    real_type limit_min{1e-8};    //!< Minimum of the true path limit
+    real_type limit_min{};        //!< Minimum of the true path limit
     real_type alpha{-1};          //!< An effecive mfp rate by distance
 };
 

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -76,8 +76,8 @@ class OrangeTrackView
     // Find the distance to the next boundary, up to and including a step
     inline CELER_FUNCTION Propagation find_next_step(real_type max_step);
 
-    // Find the nearest (any direction) boundary within the current volume
-    inline CELER_FUNCTION real_type find_safety(const Real3& pos);
+    // Find the nearest (any direction) boundary
+    inline CELER_FUNCTION real_type find_safety();
 
     // Move to the boundary in preparation for crossing it
     inline CELER_FUNCTION void move_to_boundary();
@@ -291,7 +291,7 @@ CELER_FUNCTION Propagation OrangeTrackView::find_next_step(real_type max_step)
 /*!
  * Find the nearest (any direction) boundary within the current volume.
  */
-CELER_FUNCTION real_type OrangeTrackView::find_safety(const Real3& pos)
+CELER_FUNCTION real_type OrangeTrackView::find_safety()
 {
     if (states_.surf[thread_])
     {
@@ -300,7 +300,7 @@ CELER_FUNCTION real_type OrangeTrackView::find_safety(const Real3& pos)
     }
 
     SimpleUnitTracker tracker(params_);
-    return tracker.safety(pos, states_.vol[thread_]);
+    return tracker.safety(this->pos(), this->volume_id());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -76,7 +76,7 @@ class OrangeTrackView
     // Find the distance to the next boundary, up to and including a step
     inline CELER_FUNCTION Propagation find_next_step(real_type max_step);
 
-    // Find the nearest (any direction) boundary
+    // Find the distance to the nearest boundary in any direction
     inline CELER_FUNCTION real_type find_safety();
 
     // Move to the boundary in preparation for crossing it
@@ -289,7 +289,7 @@ CELER_FUNCTION Propagation OrangeTrackView::find_next_step(real_type max_step)
 
 //---------------------------------------------------------------------------//
 /*!
- * Find the nearest (any direction) boundary within the current volume.
+ * Find the distance to the nearest boundary in any direction.
  */
 CELER_FUNCTION real_type OrangeTrackView::find_safety()
 {

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -283,10 +283,10 @@ TEST_F(UrbanMscTest, msc_scattering)
 
         UrbanMscStepLimit step_limiter(model->host_ref(),
                                        *part_view_,
-                                       &geo_view,
                                        phys,
-                                       material_view,
+                                       material_view.material_id(),
                                        sim_track_view.num_steps() == 0,
+                                       geo_view.find_safety(),
                                        step[i]);
 
         step_result = step_limiter(rng_engine);

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -345,7 +345,7 @@ TEST_F(FourLevelsTest, safety)
 
         if (!geo.is_outside())
         {
-            safeties.push_back(geo.find_safety(geo.pos()));
+            safeties.push_back(geo.find_safety());
         }
     }
 

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -117,7 +117,7 @@ TEST_F(OneVolumeTest, track_view)
     EXPECT_FALSE(next.boundary);
 
     // Get safety distance
-    EXPECT_SOFT_EQ(inf, geo.find_safety({5.6, 4.1, 5.1}));
+    EXPECT_SOFT_EQ(inf, geo.find_safety());
 }
 
 //---------------------------------------------------------------------------//
@@ -172,21 +172,21 @@ TEST_F(TwoVolumeTest, simple_track)
     EXPECT_EQ(VolumeId{1}, geo.volume_id());
     EXPECT_EQ(SurfaceId{0}, geo.surface_id());
     EXPECT_FALSE(geo.is_outside());
-    EXPECT_DOUBLE_EQ(0.0, geo.find_safety(geo.pos()));
+    EXPECT_DOUBLE_EQ(0.0, geo.find_safety());
 
     // Logically flip the surface into the new volume
     geo.cross_boundary();
     EXPECT_EQ(VolumeId{0}, geo.volume_id());
     EXPECT_EQ(SurfaceId{0}, geo.surface_id());
     EXPECT_TRUE(geo.is_outside());
-    EXPECT_DOUBLE_EQ(0.0, geo.find_safety(geo.pos()));
+    EXPECT_DOUBLE_EQ(0.0, geo.find_safety());
 
     // Move internally to an arbitrary position
     geo.find_next_step();
     geo.move_internal({2, 2, 0});
     EXPECT_EQ(SurfaceId{}, geo.surface_id());
     geo.set_dir({0, 1, 0});
-    EXPECT_SOFT_EQ(2 * sqrt_two - 1.5, geo.find_safety(geo.pos()));
+    EXPECT_SOFT_EQ(2 * sqrt_two - 1.5, geo.find_safety());
     geo.set_dir({-sqrt_two / 2, -sqrt_two / 2, 0});
 
     next = geo.find_next_step();


### PR DESCRIPTION
As we discussed, the original `find_safety` track function was slightly over-engineered: we only ever calculate the safety from the current position. Simplify the interfaces for `find_safety` as well as the `UrbanMscStepLimit` class.

---

Additionally, prevent negative safety distances from VecGeom (this was apparently happening: we need more assertions!) and update `UrbanMscStepLimit` so that if we *do* get negatives they'll implicitly be treated like zeros.