### PR TITLE
Allow duplicate names (with uniquifying extensions) for volumes and materials

### DIFF
--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -391,10 +391,14 @@ int main(int argc, char* argv[])
         RootImporter import(argv[1]);
         data = import();
     }
+    catch (const RuntimeError& e)
+    {
+        CELER_LOG(critical) << "Runtime error: " << e.what();
+        return EXIT_FAILURE;
+    }
     catch (const DebugError& e)
     {
-        CELER_LOG(critical) << "Exception while reading ROOT file '" << argv[1]
-                            << "': " << e.what();
+        CELER_LOG(critical) << "Assertion failure: " << e.what();
         return EXIT_FAILURE;
     }
 

--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -59,8 +59,6 @@ void print_particles(const ParticleParams& particles)
 //---------------------------------------------------------------------------//
 /*!
  * Print element properties.
- *
- * TODO: Use element params directly.
  */
 void print_elements(std::vector<ImportElement>& elements)
 {
@@ -89,8 +87,6 @@ void print_elements(std::vector<ImportElement>& elements)
 //---------------------------------------------------------------------------//
 /*!
  * Print material properties.
- *
- * TODO: Use material and cutoff params directly.
  */
 void print_materials(std::vector<ImportMaterial>& materials,
                      std::vector<ImportElement>&  elements,
@@ -312,8 +308,6 @@ void print_processes(const ImportData& data, const ParticleParams& particles)
 //---------------------------------------------------------------------------//
 /*!
  * Print volume properties.
- *
- * TODO: Use a volume params directly when avaliable.
  */
 void print_volumes(std::vector<ImportVolume>&   volumes,
                    std::vector<ImportMaterial>& materials)
@@ -322,8 +316,8 @@ void print_volumes(std::vector<ImportVolume>&   volumes,
     cout << R"gfm(
 # Volumes
 
-| Volume ID | Name                                 | Material ID |
-| --------- | ------------------------------------ | ----------- |
+| Volume ID | Volume name                          | Material ID | Material Name               |
+| --------- | ------------------------------------ | ----------- | --------------------------- |
 )gfm";
 
     for (unsigned int volume_id : range(volumes.size()))
@@ -335,7 +329,8 @@ void print_volumes(std::vector<ImportVolume>&   volumes,
         cout << "| "
              << setw(9) << std::left << volume_id << " | "
              << setw(36) << volume.name << " | "
-             << setw(11) << volume.material_id << " |\n";
+             << setw(11) << volume.material_id << " | "
+             << setw(27) << material.name << " |\n";
         // clang-format on
     }
     cout << endl;

--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -322,8 +322,8 @@ void print_volumes(std::vector<ImportVolume>&   volumes,
     cout << R"gfm(
 # Volumes
 
-| Volume ID | Material ID | Solid Name                           | Material Name               |
-| --------- | ----------- | ------------------------------------ | --------------------------- |
+| Volume ID | Name                                 | Material ID |
+| --------- | ------------------------------------ | ----------- |
 )gfm";
 
     for (unsigned int volume_id : range(volumes.size()))
@@ -334,9 +334,8 @@ void print_volumes(std::vector<ImportVolume>&   volumes,
         // clang-format off
         cout << "| "
              << setw(9) << std::left << volume_id << " | "
-             << setw(11) << volume.material_id << " | "
-             << setw(36) << volume.solid_name << " | "
-             << setw(27) << material.name << " |\n";
+             << setw(36) << volume.name << " | "
+             << setw(11) << volume.material_id << " |\n";
         // clang-format on
     }
     cout << endl;

--- a/app/celer-export-geant.cc
+++ b/app/celer-export-geant.cc
@@ -59,10 +59,14 @@ int main(int argc, char* argv[])
         // Read data from geant, write to ROOT
         export_root(import());
     }
+    catch (const RuntimeError& e)
+    {
+        CELER_LOG(critical) << "Runtime error: " << e.what();
+        return EXIT_FAILURE;
+    }
     catch (const DebugError& e)
     {
-        CELER_LOG(critical)
-            << "Exception while exporting Geant4 data to root: " << e.what();
+        CELER_LOG(critical) << "Assertion failure: " << e.what();
         return EXIT_FAILURE;
     }
 

--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -78,7 +78,7 @@ bool volumes_are_consistent(const GeoParams&                 geo,
                           RangeIter<VolumeId>(VolumeId{geo.num_volumes()}),
                           [&](VolumeId vol) {
                               return geo.id_to_label(vol)
-                                     == Label::from_geant4(
+                                     == Label::from_geant(
                                          imported[vol.unchecked_get()].name);
                           });
 }
@@ -239,7 +239,7 @@ TransporterInput load_input(const LDemoArgs& args)
             input.volume_labels.resize(imported_data.volumes.size());
             for (auto volume_idx : range(imported_data.volumes.size()))
             {
-                input.volume_labels[volume_idx] = Label::from_geant4(
+                input.volume_labels[volume_idx] = Label::from_geant(
                     imported_data.volumes[volume_idx].name);
             }
         }

--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -71,14 +71,15 @@ namespace
 //---------------------------------------------------------------------------//
 //! Check that volume names are consistent between the ROOT file and geometry
 bool volumes_are_consistent(const GeoParams&                 geo,
-                            const std::vector<ImportVolume>& imported_data)
+                            const std::vector<ImportVolume>& imported)
 {
-    return geo.num_volumes() == imported_data.size()
+    return geo.num_volumes() == imported.size()
            && std::all_of(RangeIter<VolumeId>(VolumeId{0}),
                           RangeIter<VolumeId>(VolumeId{geo.num_volumes()}),
                           [&](VolumeId vol) {
                               return geo.id_to_label(vol)
-                                     == imported_data[vol.unchecked_get()].name;
+                                     == Label::from_geant4(
+                                         imported[vol.unchecked_get()].name);
                           });
 }
 
@@ -235,11 +236,11 @@ TransporterInput load_input(const LDemoArgs& args)
             CELER_LOG(warning) << "Volume/material mapping is inconsistent "
                                   "between Geant4 data and geometry file: "
                                   "attempting to remap";
-            input.volume_names.resize(imported_data.volumes.size());
+            input.volume_labels.resize(imported_data.volumes.size());
             for (auto volume_idx : range(imported_data.volumes.size()))
             {
-                input.volume_names[volume_idx]
-                    = std::move(imported_data.volumes[volume_idx].name);
+                input.volume_labels[volume_idx] = Label::from_geant4(
+                    imported_data.volumes[volume_idx].name);
             }
         }
         params.geomaterial

--- a/app/demo-rasterizer/demo-rasterizer.cc
+++ b/app/demo-rasterizer/demo-rasterizer.cc
@@ -69,7 +69,7 @@ void run(std::istream& is)
     for (auto vol_id : celeritas::range(geo_params->num_volumes()))
     {
         vol_names.push_back(
-            geo_params->id_to_label(celeritas::VolumeId(vol_id)));
+            geo_params->id_to_label(celeritas::VolumeId(vol_id)).name);
     }
 
     // Write image

--- a/scripts/dev/celeritas-gen.py
+++ b/scripts/dev/celeritas-gen.py
@@ -89,7 +89,7 @@ using {namespace}::{name};
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class {name}Test : public celeritas::Test
+class {name}Test : public celeritas_test::Test
 {{
   protected:
     void SetUp() override {{}}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,7 @@ list(APPEND SOURCES ${_gen_sources})
 # Main library
 list(APPEND SOURCES
   corecel/Assert.cc
+  corecel/cont/Label.cc
   corecel/data/Copier.cc
   corecel/data/DeviceAllocation.cc
   corecel/io/BuildOutput.cc

--- a/src/celeritas/ext/GeantSetup.cc
+++ b/src/celeritas/ext/GeantSetup.cc
@@ -115,6 +115,7 @@ GeantSetup::GeantSetup(const std::string& gdml_filename, Options options)
 
         // Get world_volume for store_geometry() before releasing detector ptr
         world_ = detector->get_world_volume();
+        CELER_ASSERT(world_);
 
         run_manager_->SetUserInitialization(detector.release());
     }

--- a/src/celeritas/ext/VecgeomData.hh
+++ b/src/celeritas/ext/VecgeomData.hh
@@ -12,7 +12,6 @@
 #include "corecel/cont/Array.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/data/CollectionBuilder.hh"
-#include "orange/Types.hh"
 #include "celeritas/Types.hh"
 
 #include "detail/VecgeomNavCollection.hh"
@@ -20,6 +19,11 @@
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+
+//! Identifier for a geometry volume
+using VolumeId = OpaqueId<struct Volume>;
+
 //---------------------------------------------------------------------------//
 // PARAMS
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/VecgeomParams.cc
+++ b/src/celeritas/ext/VecgeomParams.cc
@@ -48,7 +48,7 @@ std::vector<Label> get_volume_labels()
         const vecgeom::LogicalVolume* vol
             = vg_manager.FindLogicalVolume(vol_idx);
         CELER_ASSERT(vol);
-        labels[vol_idx] = Label::from_geant4(vol->GetLabel());
+        labels[vol_idx] = Label::from_geant(vol->GetLabel());
     }
     return labels;
 }

--- a/src/celeritas/ext/VecgeomParams.cc
+++ b/src/celeritas/ext/VecgeomParams.cc
@@ -158,7 +158,7 @@ const Label& VecgeomParams::id_to_label(VolumeId vol) const
  */
 auto VecgeomParams::find_volume(const std::string& name) const -> VolumeId
 {
-    auto result = vol_labels_.find(name);
+    auto result = vol_labels_.find_all(name);
     if (result.empty())
         return {};
     CELER_VALIDATE(result.size() == 1,
@@ -176,7 +176,7 @@ auto VecgeomParams::find_volume(const std::string& name) const -> VolumeId
 auto VecgeomParams::find_volumes(const std::string& name) const
     -> SpanConstVolumeId
 {
-    return vol_labels_.find(name);
+    return vol_labels_.find_all(name);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/VecgeomParams.cc
+++ b/src/celeritas/ext/VecgeomParams.cc
@@ -206,10 +206,4 @@ auto VecgeomParams::find_volumes(const std::string& name) const
 }
 
 //---------------------------------------------------------------------------//
-// PRIVATE MEMBER FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- * Construct label metadata from volumes.
- */
-//---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/celeritas/ext/VecgeomParams.hh
+++ b/src/celeritas/ext/VecgeomParams.hh
@@ -8,9 +8,10 @@
 #pragma once
 
 #include <string>
-#include <unordered_map>
 
 #include "corecel/Types.hh"
+#include "corecel/cont/LabelIdMultiMap.hh"
+#include "corecel/cont/Span.hh"
 
 #include "VecgeomData.hh"
 
@@ -31,6 +32,7 @@ class VecgeomParams
         = VecgeomParamsData<Ownership::const_reference, MemSpace::host>;
     using DeviceRef
         = VecgeomParamsData<Ownership::const_reference, MemSpace::device>;
+    using SpanConstVolumeId = Span<const VolumeId>;
     //!@}
 
   public:
@@ -49,10 +51,13 @@ class VecgeomParams
     VolumeId::size_type num_volumes() const { return vol_labels_.size(); }
 
     // Get the label for a placed volume ID
-    const std::string& id_to_label(VolumeId vol_id) const;
+    const Label& id_to_label(VolumeId vol_id) const;
 
-    // Get the volume ID corresponding to a label
-    VolumeId find_volume(const std::string& label) const;
+    // Get the volume ID corresponding to a unique label name
+    VolumeId find_volume(const std::string& name) const;
+
+    // Get zero or more volume IDs corresponding to a name
+    SpanConstVolumeId find_volumes(const std::string& name) const;
 
     //! Maximum nested geometry depth
     int max_depth() const { return host_ref_.max_depth; }
@@ -69,8 +74,7 @@ class VecgeomParams
     //// DATA ////
 
     // Host metadata/access
-    std::vector<std::string>                  vol_labels_;
-    std::unordered_map<std::string, VolumeId> vol_ids_;
+    LabelIdMultiMap<VolumeId> vol_labels_;
 
     // Host/device storage and reference
     HostRef   host_ref_;

--- a/src/celeritas/ext/VecgeomParams.hh
+++ b/src/celeritas/ext/VecgeomParams.hh
@@ -11,7 +11,6 @@
 #include <unordered_map>
 
 #include "corecel/Types.hh"
-#include "orange/Types.hh"
 
 #include "VecgeomData.hh"
 

--- a/src/celeritas/ext/detail/DetectorConstruction.cc
+++ b/src/celeritas/ext/detail/DetectorConstruction.cc
@@ -20,13 +20,15 @@ namespace detail
 /*!
  * Construct with a given gdml input file.
  */
-DetectorConstruction::DetectorConstruction(G4String gdml_input)
+DetectorConstruction::DetectorConstruction(const std::string& gdml_input)
 {
     CELER_LOG(info) << "Loading geometry from " << gdml_input;
 
     // Create parser; do *not* strip `0x` extensions since those are needed to
     // deduplicate complex geometries (e.g. CMS) and are handled by the Label
-    // and LabelIdMultiMap.
+    // and LabelIdMultiMap. Note that material and element names (at least as
+    // of Geant4@11.0) are *always* stripped: only volumes and solids keep
+    // their extension.
     G4GDMLParser   gdml_parser;
     gdml_parser.SetStripFlag(false);
 

--- a/src/celeritas/ext/detail/DetectorConstruction.cc
+++ b/src/celeritas/ext/detail/DetectorConstruction.cc
@@ -20,21 +20,21 @@ namespace detail
 /*!
  * Construct with a given gdml input file.
  */
-DetectorConstruction::DetectorConstruction(G4String gdmlInput)
+DetectorConstruction::DetectorConstruction(G4String gdml_input)
 {
-    CELER_LOG(info) << "Loading geometry from " << gdmlInput;
+    CELER_LOG(info) << "Loading geometry from " << gdml_input;
+
+    // Create parser; do *not* strip `0x` extensions since those are needed to
+    // deduplicate complex geometries (e.g. CMS) and are handled by the Label
+    // and LabelIdMultiMap.
     G4GDMLParser   gdml_parser;
+    gdml_parser.SetStripFlag(false);
+
     constexpr bool validate_gdml_schema = false;
-    gdml_parser.Read(gdmlInput, validate_gdml_schema);
+    gdml_parser.Read(gdml_input, validate_gdml_schema);
     phys_vol_world_.reset(gdml_parser.GetWorldVolume());
     CELER_ENSURE(phys_vol_world_);
 }
-
-//---------------------------------------------------------------------------//
-/*!
- * Default destructor.
- */
-DetectorConstruction::~DetectorConstruction() = default;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/ext/detail/DetectorConstruction.hh
+++ b/src/celeritas/ext/detail/DetectorConstruction.hh
@@ -21,8 +21,8 @@ namespace detail
 class DetectorConstruction : public G4VUserDetectorConstruction
 {
   public:
-    explicit DetectorConstruction(G4String gdmlInput);
-    ~DetectorConstruction();
+    // Construct from a GDML filename
+    explicit DetectorConstruction(G4String gdml_input);
 
     G4VPhysicalVolume*       Construct() override;
     const G4VPhysicalVolume* get_world_volume() const;

--- a/src/celeritas/ext/detail/DetectorConstruction.hh
+++ b/src/celeritas/ext/detail/DetectorConstruction.hh
@@ -22,7 +22,7 @@ class DetectorConstruction : public G4VUserDetectorConstruction
 {
   public:
     // Construct from a GDML filename
-    explicit DetectorConstruction(G4String gdml_input);
+    explicit DetectorConstruction(const std::string& gdml_input);
 
     G4VPhysicalVolume*       Construct() override;
     const G4VPhysicalVolume* get_world_volume() const;

--- a/src/celeritas/geo/GeoMaterialParams.hh
+++ b/src/celeritas/geo/GeoMaterialParams.hh
@@ -11,12 +11,13 @@
 #include <vector>
 
 #include "corecel/Types.hh"
+#include "corecel/cont/Label.hh"
 #include "corecel/data/CollectionMirror.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/mat/MaterialParams.hh"
 
 #include "GeoMaterialData.hh"
-#include "GeoParams.hh"
+#include "GeoParamsFwd.hh"
 
 namespace celeritas
 {
@@ -50,7 +51,7 @@ class GeoMaterialParams
         std::shared_ptr<const GeoParams>      geometry;
         std::shared_ptr<const MaterialParams> materials;
         std::vector<MaterialId>               volume_to_mat;
-        std::vector<std::string>              volume_names; // Optional
+        std::vector<Label>                    volume_labels; // Optional
     };
 
   public:

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -153,8 +153,11 @@ auto Stepper<M>::operator()(VecPrimary primaries) -> result_type
 
     // Create track initializers
     resize(&inits_, init_params.host_ref(), states_.size());
-    CELER_ASSERT(init_params.host_ref().primaries.size()
-                 <= inits_.initializers.capacity());
+    CELER_VALIDATE(init_params.host_ref().primaries.size()
+                       <= inits_.initializers.capacity(),
+                   << "insufficient initializer capacity ("
+                   << inits_.initializers.capacity() << ") for primaries ("
+                   << init_params.host_ref().primaries.size() << ')');
 
     extend_from_primaries(init_params.host_ref(), &inits_);
 

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -120,8 +120,6 @@ inline CELER_FUNCTION S operator-(OpaqueId<V, S> self, OpaqueId<V, S> other)
 } // namespace celeritas
 
 //---------------------------------------------------------------------------//
-// STD::HASH SPECIALIZATION FOR HOST CODE
-//---------------------------------------------------------------------------//
 //! \cond
 namespace std
 {

--- a/src/corecel/cont/Label.cc
+++ b/src/corecel/cont/Label.cc
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/cont/Label.cc
+//---------------------------------------------------------------------------//
+#include "Label.hh"
+
+#include <ostream>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Write a label to a stream.
+ *
+ * \todo account for \c os.width .
+ */
+std::ostream& operator<<(std::ostream& os, const Label& lab)
+{
+    os << lab.name;
+
+    if (lab.ext.empty())
+    {
+        // No extension: don't add '@' or anything
+        return os;
+    }
+    os << '@' << lab.ext;
+
+    return os;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/corecel/cont/Label.cc
+++ b/src/corecel/cont/Label.cc
@@ -16,7 +16,7 @@ namespace celeritas
 /*!
  * Construct a label from a Geant4 pointer-appended name.
  */
-Label Label::from_geant4(const std::string& name)
+Label Label::from_geant(const std::string& name)
 {
     static const std::regex final_ptr_regex{"0x[0-9a-f]{8,16}$"};
 

--- a/src/corecel/cont/Label.hh
+++ b/src/corecel/cont/Label.hh
@@ -32,8 +32,14 @@ struct Label
     //! Create an empty label
     Label() = default;
 
-    //! Create from just a name
-    explicit Label(std::string n) : name{std::move(n)}, ext{} {}
+    //! Create *implicitly* from a C string (mostly for testing)
+    Label(const char* cstr) : name{cstr} {}
+
+    //! Create *implicitly* from just a string name (capture)
+    Label(std::string&& n) : name{std::move(n)} {}
+
+    //! Create *implicitly* from just a string name (copy)
+    Label(const std::string& n) : name{n} {}
 
     //! Create from a name and label
     Label(std::string n, std::string e) : name{std::move(n)}, ext{std::move(e)}

--- a/src/corecel/cont/Label.hh
+++ b/src/corecel/cont/Label.hh
@@ -46,7 +46,8 @@ struct Label
     static Label from_geant4(const std::string& name);
 
     // Construct a label from by splitting on a separator
-    static Label from_separator(const std::string& name, char sep = default_sep);
+    static Label
+    from_separator(const std::string& name, char sep = default_sep);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/cont/Label.hh
+++ b/src/corecel/cont/Label.hh
@@ -58,13 +58,13 @@ struct Label
 
 //---------------------------------------------------------------------------//
 //! Test equality
-inline constexpr bool operator==(const Label& lhs, const Label& rhs)
+inline bool operator==(const Label& lhs, const Label& rhs)
 {
     return lhs.name == rhs.name && lhs.ext == rhs.ext;
 }
 
 //! Test inequality
-inline constexpr bool operator!=(const Label& lhs, const Label& rhs)
+inline bool operator!=(const Label& lhs, const Label& rhs)
 {
     return !(lhs == rhs);
 }

--- a/src/corecel/cont/Label.hh
+++ b/src/corecel/cont/Label.hh
@@ -22,6 +22,16 @@ struct Label
     std::string name; //!< Primary readable label component
     std::string ext; //!< Uniquifying component such as a pointer address or ID
 
+    //// STATIC DATA ////
+
+    //! Default separator for output and splitting
+    static constexpr char default_sep = '@';
+
+    //// CLASS METHODS ////
+
+    //! Create an empty label
+    Label() = default;
+
     //! Create from just a name
     explicit Label(std::string n) : name{std::move(n)}, ext{} {}
 
@@ -29,6 +39,14 @@ struct Label
     Label(std::string n, std::string e) : name{std::move(n)}, ext{std::move(e)}
     {
     }
+
+    //// STATIC METHODS ////
+
+    // Construct a label from a Geant4 pointer-appended name
+    static Label from_geant4(const std::string& name);
+
+    // Construct a label from by splitting on a separator
+    static Label from_separator(const std::string& name, char sep = default_sep);
 };
 
 //---------------------------------------------------------------------------//
@@ -59,6 +77,10 @@ inline bool operator<(const Label& lhs, const Label& rhs)
 //---------------------------------------------------------------------------//
 // Write a label to a stream
 std::ostream& operator<<(std::ostream&, const Label&);
+
+//---------------------------------------------------------------------------//
+// Get the label as a string
+std::string to_string(const Label&);
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/corecel/cont/Label.hh
+++ b/src/corecel/cont/Label.hh
@@ -7,8 +7,11 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <functional>
 #include <iosfwd>
 #include <string>
+
+#include "corecel/math/HashUtils.hh"
 
 namespace celeritas
 {
@@ -59,3 +62,21 @@ std::ostream& operator<<(std::ostream&, const Label&);
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas
+
+//---------------------------------------------------------------------------//
+//! \cond
+namespace std
+{
+//! Specialization for std::hash for unordered storage.
+template<>
+struct hash<celeritas::Label>
+{
+    using argument_type = celeritas::Label;
+    using result_type   = std::size_t;
+    result_type operator()(const argument_type& label) const noexcept
+    {
+        return celeritas::hash_combine(label.name, label.ext);
+    }
+};
+} // namespace std
+//! \endcond

--- a/src/corecel/cont/Label.hh
+++ b/src/corecel/cont/Label.hh
@@ -43,7 +43,7 @@ struct Label
     //// STATIC METHODS ////
 
     // Construct a label from a Geant4 pointer-appended name
-    static Label from_geant4(const std::string& name);
+    static Label from_geant(const std::string& name);
 
     // Construct a label from by splitting on a separator
     static Label

--- a/src/corecel/cont/Label.hh
+++ b/src/corecel/cont/Label.hh
@@ -1,0 +1,61 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/cont/Label.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <iosfwd>
+#include <string>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+//! Small class for volume and material labels
+struct Label
+{
+    std::string name; //!< Primary readable label component
+    std::string ext; //!< Uniquifying component such as a pointer address or ID
+
+    //! Create from just a name
+    explicit Label(std::string n) : name{std::move(n)}, ext{} {}
+
+    //! Create from a name and label
+    Label(std::string n, std::string e) : name{std::move(n)}, ext{std::move(e)}
+    {
+    }
+};
+
+//---------------------------------------------------------------------------//
+//! Test equality
+inline constexpr bool operator==(const Label& lhs, const Label& rhs)
+{
+    return lhs.name == rhs.name && lhs.ext == rhs.ext;
+}
+
+//! Test inequality
+inline constexpr bool operator!=(const Label& lhs, const Label& rhs)
+{
+    return !(lhs == rhs);
+}
+
+//! Less-than comparison for sorting
+inline bool operator<(const Label& lhs, const Label& rhs)
+{
+    if (lhs.name < rhs.name)
+        return true;
+    else if (lhs.name > rhs.name)
+        return false;
+    if (lhs.ext < rhs.ext)
+        return true;
+    return false;
+}
+
+//---------------------------------------------------------------------------//
+// Write a label to a stream
+std::ostream& operator<<(std::ostream&, const Label&);
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/corecel/cont/Label.json.hh
+++ b/src/corecel/cont/Label.json.hh
@@ -1,0 +1,34 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/cont/Label.json.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <sstream>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Read an array from a JSON file.
+ */
+inline void from_json(const nlohmann::json& j, Label& value)
+{
+    value = Label::from_separator(j.get<std::string>());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write an array to a JSON file.
+ */
+inline void to_json(nlohmann::json& j, const Label& value)
+{
+    j = to_string(value);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/corecel/cont/Label.json.hh
+++ b/src/corecel/cont/Label.json.hh
@@ -7,8 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <nlohmann/json.hpp>
 #include <sstream>
+#include <nlohmann/json.hpp>
 
 namespace celeritas
 {

--- a/src/corecel/cont/LabelIdMultiMap.hh
+++ b/src/corecel/cont/LabelIdMultiMap.hh
@@ -1,0 +1,183 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/cont/LabelIdMultiMap.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "corecel/Assert.hh"
+
+#include "Label.hh"
+#include "Range.hh"
+#include "Span.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Map IDs to label+sublabel.
+ *
+ * Many Geant4 geometry definitions reuse a label for material or volume
+ * definitions, and we need to track the unique name across multiple codes
+ * (Geant4, VecGeom+GDML) to differentiate between materials or volumes. This
+ * class maps a "label" to a range of "sublabels", each of which corresponds to
+ * a unique ID. It also provides the reverse mapping so that an ID can retrieve
+ * the corresponding label/sublabel pair.
+ *
+ * There is no requirement that sublabels be ordered adjacent to each other:
+ * the IDs corresponding to a label may be noncontiguous.
+ *
+ * If no sublabels or labels are available, an empty span or "false" OpaqueId
+ * will be returned.
+ */
+template<class I>
+class LabelIdMultiMap
+{
+  public:
+    //!@{
+    //! Type aliases
+    using IdT          = I;
+    using SpanConstIdT = Span<const IdT>;
+    using VecLabel     = std::vector<Label>;
+    using size_type    = typename IdT::size_type;
+    //!@}
+
+  public:
+    // Construct from a vector of label+sublabel pairs
+    explicit LabelIdMultiMap(VecLabel keys);
+
+    // Access the range of IDs corresponding to a label
+    inline SpanConstIdT find(const std::string& label) const;
+
+    // Access an ID by label/sublabel pair
+    inline IdT find(const Label& label_sub) const;
+
+    // Access the label+sublabel pair for an Id
+    inline const Label& get(IdT id) const;
+
+    //! Get the number of elements
+    size_type size() const { return keys_.size(); }
+
+  private:
+    VecLabel                                   keys_;
+    std::vector<IdT>                           id_data_;
+    std::vector<size_type>                     id_offsets_;
+    std::unordered_map<std::string, size_type> ids_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with defaults.
+ */
+template<class I>
+LabelIdMultiMap<I>::LabelIdMultiMap(VecLabel keys) : keys_(std::move(keys))
+{
+    CELER_EXPECT(!keys_.empty());
+
+    // Build list of IDs corresponding to each key
+    id_data_.resize(keys_.size());
+    for (auto idx : range<size_type>(keys_.size()))
+    {
+        id_data_[idx] = IdT{idx};
+    }
+    // Reorder consecutive ID data based on string lexicographic ordering
+    std::sort(id_data_.begin(), id_data_.end(), [this](IdT a, IdT b) {
+        return this->keys_[a.unchecked_get()] < this->keys_[b.unchecked_get()];
+    });
+
+    // Reserve space for groups
+    id_offsets_.reserve(keys_.size() / 2 + 2);
+    ids_.reserve(id_offsets_.capacity());
+
+    // Search for when the label changes
+    id_offsets_.push_back(0);
+    ids_.insert({keys_[id_data_[0].unchecked_get()].name, 0});
+    for (auto idx : range<size_type>(1, id_data_.size()))
+    {
+        const Label& prev = keys_[id_data_[idx - 1].unchecked_get()];
+        const Label& cur  = keys_[id_data_[idx].unchecked_get()];
+        CELER_VALIDATE(prev != cur, << "Duplicate label: " << prev);
+        if (prev.name != cur.name)
+        {
+            // Add start index of the new name
+            size_type offset_idx = id_offsets_.size();
+            id_offsets_.push_back(idx);
+            auto insert_ok = ids_.insert({cur.name, offset_idx});
+            CELER_ASSERT(insert_ok.second);
+        }
+    }
+    id_offsets_.push_back(id_data_.size());
+
+    CELER_ENSURE(keys_.size() == id_data_.size());
+    CELER_ENSURE(id_offsets_.size() == ids_.size() + 1);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access the range of IDs corresponding to a label.
+ */
+template<class I>
+auto LabelIdMultiMap<I>::find(const std::string& name) const -> SpanConstIdT
+{
+    auto iter = ids_.find(name);
+    if (iter == ids_.end())
+        return {};
+
+    size_type offset_idx = iter->second;
+    CELER_ASSERT(offset_idx + 1 < id_offsets_.size());
+    size_type start = id_offsets_[offset_idx];
+    size_type stop  = id_offsets_[offset_idx + 1];
+    CELER_ENSURE(0 <= start && start < stop && stop <= id_data_.size());
+    return {id_data_.data() + start, stop - start};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access an ID by label/sublabel pair.
+ *
+ * This returns a \c false OpaqueId if no such label pair exists.
+ */
+template<class I>
+auto LabelIdMultiMap<I>::find(const Label& label_sub) const -> IdT
+{
+    auto items = this->find(label_sub.name);
+
+    // Just do a linear search on sublabels
+    auto iter
+        = std::find_if(items.begin(), items.end(), [this, &label_sub](IdT id) {
+              CELER_EXPECT(id < this->keys_.size());
+              return this->keys_[id.unchecked_get()].ext == label_sub.ext;
+          });
+    if (iter == items.end())
+    {
+        // No sublabel matches
+        return {};
+    }
+    CELER_ENSURE(keys_[iter->unchecked_get()] == label_sub);
+    return *iter;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access the label+sublabel pair for an Id.
+ *
+ * This raises an exception if the ID is outside of the valid range.
+ */
+template<class I>
+const Label& LabelIdMultiMap<I>::get(IdT id) const
+{
+    CELER_EXPECT(id < this->size());
+    return keys_[id.unchecked_get()];
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/corecel/cont/LabelIdMultiMap.hh
+++ b/src/corecel/cont/LabelIdMultiMap.hh
@@ -57,7 +57,7 @@ class LabelIdMultiMap
     explicit LabelIdMultiMap(VecLabel keys);
 
     // Access the range of IDs corresponding to a label
-    inline SpanConstIdT find(const std::string& label) const;
+    inline SpanConstIdT find_all(const std::string& label) const;
 
     // Access an ID by label/sublabel pair
     inline IdT find(const Label& label_sub) const;
@@ -134,7 +134,7 @@ LabelIdMultiMap<I>::LabelIdMultiMap(VecLabel keys) : keys_(std::move(keys))
  * Access the range of IDs corresponding to a label.
  */
 template<class I>
-auto LabelIdMultiMap<I>::find(const std::string& name) const -> SpanConstIdT
+auto LabelIdMultiMap<I>::find_all(const std::string& name) const -> SpanConstIdT
 {
     auto iter = ids_.find(name);
     if (iter == ids_.end())
@@ -157,7 +157,7 @@ auto LabelIdMultiMap<I>::find(const std::string& name) const -> SpanConstIdT
 template<class I>
 auto LabelIdMultiMap<I>::find(const Label& label_sub) const -> IdT
 {
-    auto items = this->find(label_sub.name);
+    auto items = this->find_all(label_sub.name);
 
     // Just do a linear search on sublabels
     auto iter

--- a/src/corecel/cont/LabelIdMultiMap.hh
+++ b/src/corecel/cont/LabelIdMultiMap.hh
@@ -50,6 +50,9 @@ class LabelIdMultiMap
     //!@}
 
   public:
+    // Empty constructor for delayed build
+    LabelIdMultiMap() = default;
+
     // Construct from a vector of label+sublabel pairs
     explicit LabelIdMultiMap(VecLabel keys);
 

--- a/src/corecel/cont/LabelIdMultiMap.hh
+++ b/src/corecel/cont/LabelIdMultiMap.hh
@@ -84,7 +84,12 @@ class LabelIdMultiMap
 template<class I>
 LabelIdMultiMap<I>::LabelIdMultiMap(VecLabel keys) : keys_(std::move(keys))
 {
-    CELER_EXPECT(!keys_.empty());
+    if (keys_.empty())
+    {
+        // Sometimes we don't have any items to map. Rely on the
+        // default-constructed values.
+        return;
+    }
 
     // Build list of IDs corresponding to each key
     id_data_.resize(keys_.size());

--- a/src/corecel/cont/LabelIdMultiMap.hh
+++ b/src/corecel/cont/LabelIdMultiMap.hh
@@ -134,7 +134,8 @@ LabelIdMultiMap<I>::LabelIdMultiMap(VecLabel keys) : keys_(std::move(keys))
  * Access the range of IDs corresponding to a label.
  */
 template<class I>
-auto LabelIdMultiMap<I>::find_all(const std::string& name) const -> SpanConstIdT
+auto LabelIdMultiMap<I>::find_all(const std::string& name) const
+    -> SpanConstIdT
 {
     auto iter = ids_.find(name);
     if (iter == ids_.end())

--- a/src/corecel/math/HashUtils.hh
+++ b/src/corecel/math/HashUtils.hh
@@ -1,0 +1,45 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/math/HashUtils.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+
+#include "detail/HashUtilsImpl.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Combine hashes of the given arguments using a fast hash algorithm.
+ *
+ * See https://florianjw.de/en/variadic_templates.html for why we constructed
+ * this as such. By making the variadic template use function argument
+ * expansion rather than recursion, we can unpack the args in a left-to-right
+ * order. The `(HASH,0)` construction is to give the unpacked expression a
+ * return type; and putting these in an `initializer_list` constructor
+ * guarantees the hashes are evaluated from left to right (unlike a typical
+ * argument expansion where the orders may be arbitrary).
+ */
+template<class... Args>
+std::size_t hash_combine(Args const&... args)
+{
+    // Construct a hasher and initialize
+    std::size_t result;
+    auto        hash_fnv = detail::make_fast_hasher(&result);
+
+    // Hash each one of the arguments sequentially by expanding into an unused
+    // initializer list.
+    (void)std::initializer_list<int>{(hash_fnv(std::hash<Args>()(args)), 0)...};
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/corecel/math/HashUtils.hh
+++ b/src/corecel/math/HashUtils.hh
@@ -11,6 +11,8 @@
 #include <functional>
 #include <initializer_list>
 
+#include "corecel/Macros.hh"
+
 #include "detail/HashUtilsImpl.hh"
 
 namespace celeritas
@@ -32,7 +34,7 @@ std::size_t hash_combine(Args const&... args)
 {
     // Construct a hasher and initialize
     std::size_t result;
-    auto        hash_fnv = detail::make_fast_hasher(&result);
+    CELER_MAYBE_UNUSED auto hash_fnv = detail::make_fast_hasher(&result);
 
     // Hash each one of the arguments sequentially by expanding into an unused
     // initializer list.

--- a/src/corecel/math/detail/HashUtilsImpl.hh
+++ b/src/corecel/math/detail/HashUtilsImpl.hh
@@ -1,0 +1,158 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/math/detail/HashUtilsImpl.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "corecel/Assert.hh"
+#include "corecel/Types.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Implementation of the FNV-1a algorithm.
+ *
+ * From http://www.isthe.com/chongo/tech/comp/fnv:
+ * <blockquote>
+   The basis of the FNV hash algorithm was taken from an idea sent as
+   reviewer comments to the IEEE POSIX P1003.2 committee by Glenn Fowler and
+   Phong Vo back in 1991. In a subsequent ballot round: Landon Curt Noll
+   improved on their algorithm. Some people tried this hash and found that it
+   worked rather well. In an EMail message to Landon, they named it the
+   ``Fowler/Noll/Vo'' or FNV hash.
+
+   FNV hashes are designed to be fast while maintaining a low collision rate.
+   The FNV speed allows one to quickly hash lots of data while maintaining a
+   reasonable collision rate. The high dispersion of the FNV hashes makes
+   them well suited for hashing nearly identical strings such as URLs,
+   hostnames, filenames, text, IP addresses, etc.
+   </blockquote>
+ *
+ * High dispersion, quick hashes for similar data is often needed for hash
+ * tables of pairs of similar values (or strings).
+ */
+template<std::size_t S>
+struct FnvHashTraits;
+
+// 32-bit specialization
+template<>
+struct FnvHashTraits<4ul>
+{
+    using value_type                          = std::uint32_t;
+    static constexpr value_type initial_basis = 0x811c9dc5u;
+    static constexpr value_type magic_prime   = 0x01000193u;
+};
+
+// 64-bit specialization
+template<>
+struct FnvHashTraits<8ul>
+{
+    using value_type                          = std::uint64_t;
+    static constexpr value_type initial_basis = 0xcbf29ce484222325ull;
+    static constexpr value_type magic_prime   = 0x00000100000001b3ull;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Use a fast algorithm to construct a well-distributed hash.
+ * \tparam T integer type to use for hashing.
+ *
+ * This utility class is meant for processing keys in hash tables with native
+ * integer size.
+ */
+template<class T>
+class FnvHasher
+{
+    static_assert(std::is_unsigned<T>::value,
+                  "Hash type must be an unsigned integer");
+
+  public:
+    //@{
+    //! Public type aliases
+    using value_type = T;
+    //@}
+
+  public:
+    // Construct with a reference to the hashed value which we initialize
+    explicit inline CELER_FUNCTION FnvHasher(value_type* hash_result);
+
+    // Hash a byte of data
+    CELER_FORCEINLINE_FUNCTION void operator()(Byte byte) const;
+
+    // Hash a size_t (useful for std::hash integration)
+    inline CELER_FUNCTION void operator()(std::size_t value) const;
+
+  private:
+    using TraitsT = FnvHashTraits<sizeof(T)>;
+
+    // Current hash, starting with a prescribed initial value
+    value_type* hash_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Initialize the result on construction.
+ */
+template<class T>
+CELER_FUNCTION FnvHasher<T>::FnvHasher(value_type* hash_result)
+    : hash_(hash_result)
+{
+    CELER_EXPECT(hash_);
+    *hash_ = TraitsT::initial_basis;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Hash a byte of data.
+ *
+ * The FNV1a algorithm is very simple.
+ */
+template<class T>
+CELER_FORCEINLINE_FUNCTION void FnvHasher<T>::operator()(Byte byte) const
+{
+    // XOR hash with the current byte
+    *hash_ ^= static_cast<unsigned char>(byte);
+    // Multiply by magic prime
+    *hash_ *= TraitsT::magic_prime;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Hash a size_t.
+ *
+ * This is useful for std::hash integration).
+ */
+template<class T>
+CELER_FUNCTION void FnvHasher<T>::operator()(std::size_t value) const
+{
+    for (std::size_t i = 0; i < sizeof(std::size_t); ++i)
+    {
+        (*this)(static_cast<Byte>(value & 0xffu));
+        value >>= 8;
+    }
+}
+
+//---------------------------------------------------------------------------//
+// HELPER FUNCTIONS
+//---------------------------------------------------------------------------//
+//! Create a hasher from an integer
+template<class T>
+CELER_FORCEINLINE_FUNCTION FnvHasher<T> make_fast_hasher(T* i)
+{
+    CELER_EXPECT(i);
+    return FnvHasher<T>{i};
+}
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -233,7 +233,7 @@ const Label& OrangeParams::id_to_label(VolumeId vol) const
  */
 VolumeId OrangeParams::find_volume(const std::string& name) const
 {
-    auto result = vol_labels_.find(name);
+    auto result = vol_labels_.find_all(name);
     if (result.empty())
         return {};
     CELER_VALIDATE(result.size() == 1,
@@ -251,7 +251,7 @@ VolumeId OrangeParams::find_volume(const std::string& name) const
 auto OrangeParams::find_volumes(const std::string& name) const
     -> SpanConstVolumeId
 {
-    return vol_labels_.find(name);
+    return vol_labels_.find_all(name);
 }
 
 //---------------------------------------------------------------------------//
@@ -270,7 +270,7 @@ const Label& OrangeParams::id_to_label(SurfaceId surf) const
  */
 SurfaceId OrangeParams::find_surface(const std::string& name) const
 {
-    auto result = surf_labels_.find(name);
+    auto result = surf_labels_.find_all(name);
     if (result.empty())
         return {};
     CELER_VALIDATE(result.size() == 1,

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -12,6 +12,9 @@
 #include <vector>
 
 #include "corecel/Types.hh"
+#include "corecel/cont/Label.hh"
+#include "corecel/cont/LabelIdMultiMap.hh"
+#include "corecel/cont/Span.hh"
 #include "corecel/data/CollectionMirror.hh"
 
 #include "BoundingBox.hh"
@@ -36,18 +39,19 @@ class OrangeParams
         = OrangeParamsData<Ownership::const_reference, MemSpace::host>;
     using DeviceRef
         = OrangeParamsData<Ownership::const_reference, MemSpace::device>;
+    using SpanConstVolumeId = Span<const VolumeId>;
     //!@}
 
     struct Input
     {
         using Surfaces = SurfaceData<Ownership::value, MemSpace::host>;
         using Volumes  = VolumeData<Ownership::value, MemSpace::host>;
-        using VecStr   = std::vector<std::string>;
+        using VecLabel = std::vector<Label>;
 
         Surfaces    surfaces;       //!< Surface definitions
         Volumes     volumes;        //!< Volume definitions
-        VecStr      surface_labels; //!< Surface names (metadata)
-        VecStr      volume_labels;  //!< Volume names (metadata)
+        VecLabel    surface_labels; //!< Surface names (metadata)
+        VecLabel    volume_labels;  //!< Volume names (metadata)
         BoundingBox bbox;           //!< Outer bounding box (metadata)
     };
 
@@ -67,10 +71,13 @@ class OrangeParams
     VolumeId::size_type num_volumes() const { return vol_labels_.size(); }
 
     // Get the label for a placed volume ID
-    const std::string& id_to_label(VolumeId vol_id) const;
+    const Label& id_to_label(VolumeId vol_id) const;
 
-    // Get the volume ID corresponding to a label
-    VolumeId find_volume(const std::string& label) const;
+    // Get the volume ID corresponding to a unique label lname
+    VolumeId find_volume(const std::string& name) const;
+
+    // Get zero or more volume IDs corresponding to a name
+    SpanConstVolumeId find_volumes(const std::string& name) const;
 
     //! Outer bounding box of geometry
     const BoundingBox& bbox() const { return bbox_; }
@@ -78,10 +85,10 @@ class OrangeParams
     //// SURFACES ////
 
     // Get the label for a placed volume ID
-    const std::string& id_to_label(SurfaceId surf_id) const;
+    const Label& id_to_label(SurfaceId surf_id) const;
 
-    // Get the surface ID corresponding to a label
-    SurfaceId find_surface(const std::string& label) const;
+    // Get the surface ID corresponding to a unique label name
+    SurfaceId find_surface(const std::string& name) const;
 
     //! Number of distinct surfaces
     size_type num_surfaces() const { return surf_labels_.size(); }
@@ -96,12 +103,10 @@ class OrangeParams
 
   private:
     // Host metadata/access
-    std::vector<std::string>                   surf_labels_;
-    std::vector<std::string>                   vol_labels_;
-    std::unordered_map<std::string, VolumeId>  vol_ids_;
-    std::unordered_map<std::string, SurfaceId> surf_ids_;
-    BoundingBox                                bbox_;
-    bool                                       supports_safety_{};
+    LabelIdMultiMap<SurfaceId> surf_labels_;
+    LabelIdMultiMap<VolumeId>  vol_labels_;
+    BoundingBox                bbox_;
+    bool                       supports_safety_{};
 
     // Host/device storage and reference
     CollectionMirror<OrangeParamsData> data_;

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "corecel/Types.hh"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -119,6 +119,7 @@ celeritas_setup_tests(SERIAL PREFIX corecel)
 # Cont
 celeritas_add_test(corecel/cont/Array.test.cc)
 celeritas_add_test(corecel/cont/Span.test.cc)
+celeritas_add_test(corecel/cont/LabelIdMultiMap.test.cc)
 celeritas_device_test(corecel/cont/Range)
 
 # Data

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -139,6 +139,7 @@ celeritas_add_test(corecel/io/Repr.test.cc)
 # Math
 celeritas_add_test(corecel/math/Algorithms.test.cc)
 celeritas_add_test(corecel/math/ArrayUtils.test.cc)
+celeritas_add_test(corecel/math/HashUtils.test.cc)
 celeritas_device_test(corecel/math/NumericLimits)
 celeritas_add_test(corecel/math/Quantity.test.cc)
 celeritas_add_test(corecel/math/SoftEqual.test.cc)

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -81,7 +81,7 @@ auto MockTestBase::build_geomaterial() -> SPConstGeoMaterial
     input.geometry      = this->geometry();
     input.materials     = this->material();
     input.volume_to_mat = {MaterialId{0}, MaterialId{2}, MaterialId{1}};
-    input.volume_names  = {"inner", "middle", "outer"};
+    input.volume_labels = {Label{"inner"}, Label{"middle"}, Label{"outer"}};
     return std::make_shared<GeoMaterialParams>(std::move(input));
 }
 

--- a/test/celeritas/SimpleTestBase.cc
+++ b/test/celeritas/SimpleTestBase.cc
@@ -44,7 +44,8 @@ auto SimpleTestBase::build_geomaterial() -> SPConstGeoMaterial
     input.geometry      = this->geometry();
     input.materials     = this->material();
     input.volume_to_mat = {MaterialId{0}, MaterialId{1}, MaterialId{}};
-    input.volume_names  = {"Detector", "World", "[EXTERIOR]"};
+    input.volume_labels
+        = {Label{"Detector"}, Label{"World"}, Label{"[EXTERIOR]"}};
     return std::make_shared<GeoMaterialParams>(std::move(input));
 }
 

--- a/test/celeritas/TestEm3Base.cc
+++ b/test/celeritas/TestEm3Base.cc
@@ -79,7 +79,7 @@ auto TestEm3Base::build_geomaterial() -> SPConstGeoMaterial
         input.volume_to_mat[volume_idx]
             = MaterialId{imported.volumes[volume_idx].material_id};
         input.volume_labels[volume_idx]
-            = Label::from_geant4(imported.volumes[volume_idx].name);
+            = Label::from_geant(imported.volumes[volume_idx].name);
     }
     return std::make_shared<GeoMaterialParams>(std::move(input));
 }

--- a/test/celeritas/TestEm3Base.cc
+++ b/test/celeritas/TestEm3Base.cc
@@ -72,13 +72,14 @@ auto TestEm3Base::build_geomaterial() -> SPConstGeoMaterial
     const auto& imported = this->imported_data();
 
     input.volume_to_mat.resize(imported.volumes.size());
-    input.volume_names.resize(imported.volumes.size());
+    input.volume_labels.resize(imported.volumes.size());
     for (auto volume_idx :
          range<VolumeId::size_type>(input.volume_to_mat.size()))
     {
         input.volume_to_mat[volume_idx]
             = MaterialId{imported.volumes[volume_idx].material_id};
-        input.volume_names[volume_idx] = imported.volumes[volume_idx].name;
+        input.volume_labels[volume_idx]
+            = Label::from_geant4(imported.volumes[volume_idx].name);
     }
     return std::make_shared<GeoMaterialParams>(std::move(input));
 }

--- a/test/celeritas/data/four-steel-slabs.gdml
+++ b/test/celeritas/data/four-steel-slabs.gdml
@@ -91,9 +91,9 @@
 
   <solids>
     <box lunit="mm" name="box0x125555b70" x="200" y="200" z="40"/>
-    <box lunit="mm" name="boxReplica0x125556c70" x="200" y="200" z="40"/>
-    <box lunit="mm" name="boxReplica20x1255570a0" x="200" y="200" z="40"/>
-    <box lunit="mm" name="boxReplica30x125557500" x="200" y="200" z="40"/>
+    <box lunit="mm" name="box0x125556c70" x="200" y="200" z="40"/>
+    <box lunit="mm" name="box0x1255570a0" x="200" y="200" z="40"/>
+    <box lunit="mm" name="box0x125557500" x="200" y="200" z="40"/>
     <box lunit="mm" name="World0x125555ea0" x="10000" y="10000" z="10000"/>
   </solids>
 
@@ -102,17 +102,17 @@
       <materialref ref="G4_STAINLESS-STEEL0x125553a10"/>
       <solidref ref="box0x125555b70"/>
     </volume>
-    <volume name="boxReplica0x125556d20">
+    <volume name="box0x125556d20">
       <materialref ref="G4_STAINLESS-STEEL0x125553a10"/>
-      <solidref ref="boxReplica0x125556c70"/>
+      <solidref ref="box0x125556c70"/>
     </volume>
-    <volume name="boxReplica0x125557160">
+    <volume name="box0x125557160">
       <materialref ref="G4_STAINLESS-STEEL0x125553a10"/>
-      <solidref ref="boxReplica20x1255570a0"/>
+      <solidref ref="box0x1255570a0"/>
     </volume>
-    <volume name="boxReplica0x1255575a0">
+    <volume name="box0x1255575a0">
       <materialref ref="G4_STAINLESS-STEEL0x125553a10"/>
-      <solidref ref="boxReplica30x125557500"/>
+      <solidref ref="box0x125557500"/>
     </volume>
     <volume name="World0x125555f10">
       <materialref ref="G4_Galactic0x125554f50"/>
@@ -121,15 +121,15 @@
         <volumeref ref="box0x125555be0"/>
       </physvol>
       <physvol name="box0x125556dc0">
-        <volumeref ref="boxReplica0x125556d20"/>
+        <volumeref ref="box0x125556d20"/>
         <position name="box0x125556dc0_pos" unit="mm" x="0" y="0" z="60"/>
       </physvol>
       <physvol name="box0x125557110">
-        <volumeref ref="boxReplica0x125557160"/>
+        <volumeref ref="box0x125557160"/>
         <position name="box0x125557110_pos" unit="mm" x="0" y="0" z="120"/>
       </physvol>
       <physvol name="box0x125557640">
-        <volumeref ref="boxReplica0x1255575a0"/>
+        <volumeref ref="box0x1255575a0"/>
         <position name="box0x125557640_pos" unit="mm" x="0" y="0" z="180"/>
       </physvol>
     </volume>

--- a/test/celeritas/data/four-steel-slabs.org.omn
+++ b/test/celeritas/data/four-steel-slabs.org.omn
@@ -12,18 +12,18 @@ interior "World"
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
-[UNIVERSE][SHAPE=box box]
+[UNIVERSE][SHAPE=box box@0]
 widths 20 20 4
 
-[UNIVERSE][SHAPE=box boxReplica]
+[UNIVERSE][SHAPE=box box@1]
 widths 20 20 4
 translate 0 0 6
 
-[UNIVERSE][SHAPE=box boxReplica2]
+[UNIVERSE][SHAPE=box box@2]
 widths 20 20 4
 translate 0 0 12
 
-[UNIVERSE][SHAPE=box boxReplica3]
+[UNIVERSE][SHAPE=box box@3]
 widths 20 20 4
 translate 0 0 18
 
@@ -34,22 +34,22 @@ widths 1000 1000 1000
 ! CELLS ("volumes")
 !##############################################################################
 
-[UNIVERSE][CELL box]
+[UNIVERSE][CELL box@0]
 comp "G4_STAINLESS-STEEL"
-shapes box
+shapes box@0
 
-[UNIVERSE][CELL boxReplica]
+[UNIVERSE][CELL box@1]
 comp "G4_STAINLESS-STEEL"
-shapes boxReplica
+shapes box@1
 
-[UNIVERSE][CELL boxReplica2]
+[UNIVERSE][CELL box@2]
 comp "G4_STAINLESS-STEEL"
-shapes boxReplica2
+shapes box@2
 
-[UNIVERSE][CELL boxReplica3]
+[UNIVERSE][CELL box@3]
 comp "G4_STAINLESS-STEEL"
-shapes boxReplica3
+shapes box@3
 
 [UNIVERSE][CELL World]
 comp G4_Galactic
-shapes World ~box ~boxReplica ~boxReplica2 ~boxReplica3
+shapes World ~box@0 ~box@1 ~box@2 ~box@3

--- a/test/celeritas/em/BetheHeitler.test.cc
+++ b/test/celeritas/em/BetheHeitler.test.cc
@@ -23,7 +23,6 @@
 using celeritas::BetheHeitlerInteractor;
 using celeritas::ElementComponentId;
 using celeritas::GammaConversionProcess;
-using celeritas::units::AmuMass;
 namespace constants = celeritas::constants;
 namespace pdg       = celeritas::pdg;
 
@@ -38,24 +37,6 @@ class BetheHeitlerInteractorTest : public celeritas_test::InteractorHostTestBase
   protected:
     void SetUp() override
     {
-        using celeritas::ParticleRecord;
-        using namespace celeritas::units;
-        constexpr auto zero   = celeritas::zero_quantity();
-        auto           stable = ParticleRecord::stable_decay_constant();
-
-        // Particles for interactor
-        Base::set_particle_params(
-            {{"electron",
-              pdg::electron(),
-              MevMass{0.5109989461},
-              ElementaryCharge{-1},
-              stable},
-             {"positron",
-              pdg::positron(),
-              MevMass{0.5109989461},
-              ElementaryCharge{1},
-              stable},
-             {"gamma", pdg::gamma(), zero, zero, stable}});
         const auto& params  = *this->particle_params();
         data_.ids.electron  = params.find(pdg::electron());
         data_.ids.positron  = params.find(pdg::positron());
@@ -66,19 +47,7 @@ class BetheHeitlerInteractorTest : public celeritas_test::InteractorHostTestBase
         // Set default particle to photon with energy of 100 MeV
         this->set_inc_particle(pdg::gamma(), MevEnergy{100.0});
         this->set_inc_direction({0, 0, 1});
-
-        // Setup MaterialView
-        MaterialParams::Input inp;
-        inp.elements  = {{29, AmuMass{63.546}, "Cu"}};
-        inp.materials = {
-            {1.0 * constants::na_avogadro,
-             293.0,
-             celeritas::MatterState::solid,
-             {{celeritas::ElementId{0}, 1.0}},
-             "Cu"},
-        };
-        this->set_material_params(inp);
-        this->set_material("Cu");
+        this->set_material("Cu-1.0");
     }
 
     void sanity_check(const Interaction& interaction) const

--- a/test/celeritas/em/EPlusGG.test.cc
+++ b/test/celeritas/em/EPlusGG.test.cc
@@ -32,47 +32,16 @@ class EPlusGGInteractorTest : public celeritas_test::InteractorHostTestBase
   protected:
     void SetUp() override
     {
-        using celeritas::MatterState;
-        using celeritas::ParticleRecord;
-        using namespace celeritas::units;
-        using namespace celeritas::constants;
-        constexpr auto zero   = celeritas::zero_quantity();
-        constexpr auto stable = ParticleRecord::stable_decay_constant();
-
-        Base::set_particle_params(
-            {{"electron",
-              pdg::electron(),
-              MevMass{0.5109989461},
-              ElementaryCharge{-1},
-              stable},
-             {"positron",
-              pdg::positron(),
-              MevMass{0.5109989461},
-              ElementaryCharge{1},
-              stable},
-             {"gamma", pdg::gamma(), zero, zero, stable}});
-
         const auto& params  = *this->particle_params();
         data_.ids.positron  = params.find(pdg::positron());
         data_.ids.gamma     = params.find(pdg::gamma());
-        data_.electron_mass = 0.5109989461;
-
-        // Set up shared material data
-        MaterialParams::Input mi;
-        mi.elements  = {{19, AmuMass{39.0983}, "K"}};
-        mi.materials = {{1e-5 * na_avogadro,
-                         293.,
-                         MatterState::solid,
-                         {{ElementId{0}, 1.0}},
-                         "K"}};
-
-        // Set default material to potassium
-        this->set_material_params(mi);
-        this->set_material("K");
+        data_.electron_mass
+            = params.get(params.find(pdg::electron())).mass().value();
 
         // Set default particle to incident 10 MeV positron
         this->set_inc_particle(pdg::positron(), MevEnergy{10});
         this->set_inc_direction({0, 0, 1});
+        this->set_material("K");
     }
 
     void sanity_check(const Interaction& interaction) const

--- a/test/celeritas/em/KleinNishina.test.cc
+++ b/test/celeritas/em/KleinNishina.test.cc
@@ -28,20 +28,6 @@ class KleinNishinaInteractorTest : public celeritas_test::InteractorHostTestBase
   protected:
     void SetUp() override
     {
-        using celeritas::ParticleRecord;
-        using namespace celeritas::units;
-        constexpr auto zero   = celeritas::zero_quantity();
-        constexpr auto stable = ParticleRecord::stable_decay_constant();
-
-        Base::set_particle_params(
-            {{"electron",
-              pdg::electron(),
-              MevMass{0.5109989461},
-              ElementaryCharge{-1},
-              stable},
-             {"gamma", pdg::gamma(), zero, zero, stable}});
-
-        // TODO: this should be part of the process's data storage/management
         const auto& params = *this->particle_params();
         data_.ids.electron = params.find(pdg::electron());
         data_.ids.gamma    = params.find(pdg::gamma());

--- a/test/celeritas/em/LivermorePE.test.cc
+++ b/test/celeritas/em/LivermorePE.test.cc
@@ -73,20 +73,10 @@ class LivermorePETest : public celeritas_test::InteractorHostTestBase
     void SetUp() override
     {
         using celeritas::MatterState;
-        using celeritas::ParticleRecord;
         using namespace celeritas::units;
         using namespace celeritas::constants;
-        constexpr auto zero   = celeritas::zero_quantity();
-        constexpr auto stable = ParticleRecord::stable_decay_constant();
 
         // Set up shared particle data
-        Base::set_particle_params(
-            {{"electron",
-              pdg::electron(),
-              MevMass{0.5109989461},
-              ElementaryCharge{-1},
-              stable},
-             {"gamma", pdg::gamma(), zero, zero, stable}});
         const auto& particles = *this->particle_params();
 
         // Set up shared material data
@@ -98,7 +88,6 @@ class LivermorePETest : public celeritas_test::InteractorHostTestBase
                          {{ElementId{0}, 1.0}},
                          "K"}};
         this->set_material_params(mi);
-        this->set_material("K");
 
         // Set cutoffs (no cuts)
         CutoffParams::Input ci;
@@ -123,6 +112,7 @@ class LivermorePETest : public celeritas_test::InteractorHostTestBase
         // Set default particle to incident 1 keV photon
         this->set_inc_particle(pdg::gamma(), MevEnergy{0.001});
         this->set_inc_direction({0, 0, 1});
+        this->set_material("K");
     }
 
     void sanity_check(const Interaction& interaction) const

--- a/test/celeritas/em/MollerBhabha.test.cc
+++ b/test/celeritas/em/MollerBhabha.test.cc
@@ -38,22 +38,7 @@ class MollerBhabhaInteractorTest : public celeritas_test::InteractorHostTestBase
   protected:
     void SetUp() override
     {
-        using celeritas::ParticleRecord;
         using namespace celeritas::units;
-        constexpr auto stable = ParticleRecord::stable_decay_constant();
-
-        // Particles needed by interactor
-        Base::set_particle_params({{"electron",
-                                    pdg::electron(),
-                                    MevMass{0.5109989461},
-                                    ElementaryCharge{-1},
-                                    stable},
-
-                                   {"positron",
-                                    pdg::positron(),
-                                    MevMass{0.5109989461},
-                                    ElementaryCharge{1},
-                                    stable}});
 
         // Setup MaterialView
         MaterialParams::Input inp;

--- a/test/celeritas/em/MuBremsstrahlung.test.cc
+++ b/test/celeritas/em/MuBremsstrahlung.test.cc
@@ -32,48 +32,16 @@ class MuBremsstrahlungInteractorTest
   protected:
     void SetUp() override
     {
-        using celeritas::ParticleRecord;
-        using namespace celeritas::units;
-        constexpr auto zero   = celeritas::zero_quantity();
-        constexpr auto stable = ParticleRecord::stable_decay_constant();
-
-        Base::set_particle_params({{"mu_minus",
-                                    pdg::mu_minus(),
-                                    MevMass{105.6583745},
-                                    ElementaryCharge{-1},
-                                    stable},
-                                   {"mu_plus",
-                                    pdg::mu_plus(),
-                                    MevMass{105.6583745},
-                                    ElementaryCharge{1},
-                                    stable},
-                                   {"gamma", pdg::gamma(), zero, zero, stable},
-                                   {"electron",
-                                    pdg::electron(),
-                                    MevMass{0.5109989461},
-                                    ElementaryCharge{-1},
-                                    stable}});
         const auto& params  = this->particle_params();
         data_.ids.gamma     = params->find(pdg::gamma());
         data_.ids.mu_minus  = params->find(pdg::mu_minus());
         data_.ids.mu_plus   = params->find(pdg::mu_plus());
         data_.electron_mass = params->get(params->find(pdg::electron())).mass();
 
-        MaterialParams::Input inp;
-        inp.elements  = {{29, AmuMass{63.546}, "Cu"}};
-        inp.materials = {
-            {1.0 * constants::na_avogadro,
-             293.0,
-             celeritas::MatterState::solid,
-             {{celeritas::ElementId{0}, 1.0}},
-             "Cu"},
-        };
-        this->set_material_params(inp);
-        this->set_material("Cu");
-
         // Set default particle to muon with energy of 1100 MeV
         this->set_inc_particle(pdg::mu_minus(), MevEnergy{1100});
         this->set_inc_direction({0, 0, 1});
+        this->set_material("Cu");
     }
 
     void sanity_check(const Interaction& interaction) const

--- a/test/celeritas/em/Rayleigh.test.cc
+++ b/test/celeritas/em/Rayleigh.test.cc
@@ -49,10 +49,6 @@ class RayleighInteractorTest : public celeritas_test::InteractorHostTestBase
         const auto& particles = *this->particle_params();
         model_ref_.ids.gamma  = particles.find(pdg::gamma());
 
-        // Set default particle to incident 1 MeV photon
-        this->set_inc_particle(pdg::gamma(), MevEnergy{1.0});
-        this->set_inc_direction({0, 0, 1});
-
         // Setup MaterialView
         MaterialParams::Input inp;
         inp.elements  = {{8, AmuMass{15.999}, "O"},
@@ -68,12 +64,16 @@ class RayleighInteractorTest : public celeritas_test::InteractorHostTestBase
              "PbWO"},
         };
         this->set_material_params(inp);
-        this->set_material("PbWO");
 
         // Construct RayleighModel and save the host data reference
         model_ = std::make_shared<RayleighModel>(
             ActionId{0}, particles, *this->material_params());
         model_ref_ = model_->host_ref();
+
+        // Set default particle to incident 1 MeV photon
+        this->set_inc_particle(pdg::gamma(), MevEnergy{1.0});
+        this->set_inc_direction({0, 0, 1});
+        this->set_material("PbWO");
     }
 
     void sanity_check(const Interaction& interaction) const

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -55,34 +55,14 @@ class SeltzerBergerTest : public celeritas_test::InteractorHostTestBase
     void SetUp() override
     {
         using celeritas::MatterState;
-        using celeritas::ParticleRecord;
         using namespace celeritas::constants;
         using namespace celeritas::units;
-        constexpr auto zero   = celeritas::zero_quantity();
-        constexpr auto stable = ParticleRecord::stable_decay_constant();
 
-        // Set up shared particle data
-        Base::set_particle_params(
-            {{"electron",
-              pdg::electron(),
-              MevMass{0.5109989461},
-              ElementaryCharge{-1},
-              stable},
-             {"positron",
-              pdg::positron(),
-              MevMass{0.5109989461},
-              ElementaryCharge{1},
-              stable},
-             {"gamma", pdg::gamma(), zero, zero, stable}});
         const auto& particles = *this->particle_params();
         data_.ids.electron    = particles.find(pdg::electron());
         data_.ids.positron    = particles.find(pdg::positron());
         data_.ids.gamma       = particles.find(pdg::gamma());
         data_.electron_mass   = particles.get(data_.ids.electron).mass();
-
-        // Set default particle to incident 1 MeV photon
-        this->set_inc_particle(pdg::electron(), MevEnergy{1.0});
-        this->set_inc_direction({0, 0, 1});
 
         // Set up shared material data
         MaterialParams::Input mat_inp;
@@ -95,7 +75,6 @@ class SeltzerBergerTest : public celeritas_test::InteractorHostTestBase
              "Cu"},
         };
         this->set_material_params(mat_inp);
-        this->set_material("Cu");
 
         // Set up Seltzer-Berger cross section data
         std::string         data_path = this->test_data_path("celeritas", "");
@@ -116,6 +95,11 @@ class SeltzerBergerTest : public celeritas_test::InteractorHostTestBase
         input.particles = this->particle_params();
         input.cutoffs.insert({pdg::gamma(), material_cutoffs});
         this->set_cutoff_params(input);
+
+        // Set default particle to incident 1 MeV photon in copper
+        this->set_inc_particle(pdg::electron(), MevEnergy{1.0});
+        this->set_inc_direction({0, 0, 1});
+        this->set_material("Cu");
     }
 
     EnergySq density_correction(MaterialId matid, Energy e) const

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -114,7 +114,7 @@ auto VecgeomTestBase::track(const Real3& pos, const Real3& dir)
 
     while (!geo.is_outside())
     {
-        result.volumes.push_back(params.id_to_label(geo.volume_id()));
+        result.volumes.push_back(params.id_to_label(geo.volume_id()).name);
         auto next = geo.find_next_step();
         result.distances.push_back(next.distance);
         if (!next.boundary)
@@ -160,10 +160,11 @@ TEST_F(FourLevelsTest, accessors)
     EXPECT_EQ(4, geom.num_volumes());
     EXPECT_EQ(4, geom.max_depth());
 
-    EXPECT_EQ("Shape2", geom.id_to_label(VolumeId{0}));
-    EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{1}));
-    EXPECT_EQ("Envelope", geom.id_to_label(VolumeId{2}));
-    EXPECT_EQ("World", geom.id_to_label(VolumeId{3}));
+    EXPECT_EQ("Shape2", geom.id_to_label(VolumeId{0}).name);
+    EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{1}).name);
+    EXPECT_EQ("Envelope", geom.id_to_label(VolumeId{2}).name);
+    EXPECT_EQ("World", geom.id_to_label(VolumeId{3}).name);
+    EXPECT_EQ(Label("World", "0xdeadbeef"), geom.id_to_label(VolumeId{3}));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/field/LinearPropagator.test.cc
+++ b/test/celeritas/field/LinearPropagator.test.cc
@@ -44,7 +44,7 @@ class LinearPropagatorTest : public celeritas_test::GlobalGeoTestBase
         {
             return "[OUTSIDE]";
         }
-        return this->geometry()->id_to_label(geo.volume_id());
+        return this->geometry()->id_to_label(geo.volume_id()).name;
     }
 
   protected:

--- a/test/celeritas/geo/GeoMaterial.test.cc
+++ b/test/celeritas/geo/GeoMaterial.test.cc
@@ -91,7 +91,7 @@ TEST_F(GeoMaterialTest, host)
     {
         MaterialId matid = geo_mat_view.material_id(geo.volume_id());
 
-        materials.push_back(matid ? mat_params.id_to_label(matid)
+        materials.push_back(matid ? mat_params.id_to_label(matid).name
                                   : "[invalid]");
 
         geo.find_next_step();

--- a/test/celeritas/geo/GeoMaterial.test.cc
+++ b/test/celeritas/geo/GeoMaterial.test.cc
@@ -43,14 +43,14 @@ class GeoMaterialTest : public celeritas_test::GlobalGeoTestBase
         input.geometry  = this->geometry();
         input.materials = this->material();
         input.volume_to_mat.resize(data_.volumes.size());
-        input.volume_names.resize(data_.volumes.size());
+        input.volume_labels.resize(data_.volumes.size());
 
         for (const auto vol_idx : range(data_.volumes.size()))
         {
             const ImportVolume& volume = data_.volumes[vol_idx];
 
             input.volume_to_mat[vol_idx] = MaterialId{volume.material_id};
-            input.volume_names[vol_idx]  = volume.name;
+            input.volume_labels[vol_idx] = Label::from_geant4(volume.name);
         }
         return std::make_shared<GeoMaterialParams>(std::move(input));
     }

--- a/test/celeritas/geo/GeoMaterial.test.cc
+++ b/test/celeritas/geo/GeoMaterial.test.cc
@@ -50,7 +50,7 @@ class GeoMaterialTest : public celeritas_test::GlobalGeoTestBase
             const ImportVolume& volume = data_.volumes[vol_idx];
 
             input.volume_to_mat[vol_idx] = MaterialId{volume.material_id};
-            input.volume_labels[vol_idx] = Label::from_geant4(volume.name);
+            input.volume_labels[vol_idx] = Label::from_geant(volume.name);
         }
         return std::make_shared<GeoMaterialParams>(std::move(input));
     }

--- a/test/celeritas/mat/ElementSelector.test.cc
+++ b/test/celeritas/mat/ElementSelector.test.cc
@@ -114,7 +114,7 @@ struct CalcFancyMicroXs
 //! You can't select an element in pure void. (No interactions anyway.)
 TEST_F(ElementSelectorTest, TEST_IF_CELERITAS_DEBUG(vacuum))
 {
-    MaterialView material(mats->host_ref(), mats->find("hard_vacuum"));
+    MaterialView material(mats->host_ref(), mats->find_material("hard_vacuum"));
     EXPECT_THROW(ElementSelector(material, mock_micro_xs, make_span(storage)),
                  celeritas::DebugError);
 }
@@ -122,7 +122,7 @@ TEST_F(ElementSelectorTest, TEST_IF_CELERITAS_DEBUG(vacuum))
 //! Single element should always select the first one.
 TEST_F(ElementSelectorTest, single)
 {
-    MaterialView    material(host_mats, mats->find("Al"));
+    MaterialView    material(host_mats, mats->find_material("Al"));
     ElementSelector select_el(material, mock_micro_xs, make_span(storage));
 
     // Construction should have precalculated cross sections
@@ -142,7 +142,7 @@ TEST_F(ElementSelectorTest, single)
 //! Equal number densities but unequal cross sections
 TEST_F(ElementSelectorTest, everything_even)
 {
-    MaterialView    material(host_mats, mats->find("everything_even"));
+    MaterialView material(host_mats, mats->find_material("everything_even"));
     ElementSelector select_el(material, mock_micro_xs, make_span(storage));
 
     // Test cross sections
@@ -182,7 +182,8 @@ TEST_F(ElementSelectorTest, everything_even)
 //! Number densities scaled to 1/xs so equiprobable
 TEST_F(ElementSelectorTest, everything_weighted)
 {
-    MaterialView    material(host_mats, mats->find("everything_weighted"));
+    MaterialView    material(host_mats,
+                          mats->find_material("everything_weighted"));
     ElementSelector select_el(material, mock_micro_xs, make_span(storage));
 
     // Test cross sections
@@ -208,7 +209,7 @@ TEST_F(ElementSelectorTest, everything_weighted)
 //! Many zero cross sections
 TEST_F(ElementSelectorTest, even_zero_xs)
 {
-    MaterialView material(host_mats, mats->find("everything_even"));
+    MaterialView material(host_mats, mats->find_material("everything_even"));
     auto         calc_xs
         = [](ElementId el) -> real_type { return (el.get() % 2 ? 1 : 0); };
     ElementSelector select_el(material, calc_xs, make_span(storage));
@@ -229,7 +230,8 @@ TEST_F(ElementSelectorTest, even_zero_xs)
 TEST_F(ElementSelectorTest, fancy_xs)
 {
     units::MevEnergy energy{123};
-    MaterialView     material(host_mats, mats->find("everything_weighted"));
+    MaterialView     material(host_mats,
+                          mats->find_material("everything_weighted"));
     ElementSelector  select_el(
         material, CalcFancyMicroXs{host_mats, energy}, make_span(storage));
 

--- a/test/corecel/cont/LabelIdMultiMap.test.cc
+++ b/test/corecel/cont/LabelIdMultiMap.test.cc
@@ -77,12 +77,6 @@ class LabelIdMultiMapTest : public celeritas_test::Test
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST_F(LabelIdMultiMapTest, exceptions)
-{
-    EXPECT_THROW(CatMultiMap({Label{"kali"}, Label{"kali"}}),
-                 celeritas::RuntimeError);
-}
-
 TEST_F(LabelIdMultiMapTest, empty)
 {
     const CatMultiMap default_cats;
@@ -98,15 +92,18 @@ TEST_F(LabelIdMultiMapTest, empty)
     }
 }
 
-TEST_F(LabelIdMultiMapTest, no_ext)
+TEST_F(LabelIdMultiMapTest, no_ext_with_duplicates)
 {
-    CatMultiMap cats{VecLabel{{"dexter", "andy", "loki"}}};
-    EXPECT_EQ(3, cats.size());
+    CatMultiMap cats{VecLabel{{"dexter", "andy", "loki", "", "", ""}}};
+    EXPECT_EQ(6, cats.size());
     EXPECT_EQ(CatId{}, cats.find("nyoka"));
     EXPECT_EQ(CatId{0}, cats.find("dexter"));
     EXPECT_EQ(CatId{1}, cats.find("andy"));
     EXPECT_EQ(CatId{2}, cats.find("loki"));
     EXPECT_EQ(CatId{2}, cats.find(Label{"loki"}));
+
+    static const CatId expected_duplicates[] = {CatId{3}, CatId{4}, CatId{5}};
+    EXPECT_VEC_EQ(expected_duplicates, cats.duplicates());
 }
 
 TEST_F(LabelIdMultiMapTest, some_labels)

--- a/test/corecel/cont/LabelIdMultiMap.test.cc
+++ b/test/corecel/cont/LabelIdMultiMap.test.cc
@@ -48,8 +48,8 @@ TEST(LabelTest, ordering)
 
 TEST(LabelTest, construction)
 {
-    EXPECT_EQ(Label("foo"), Label::from_geant4("foo"));
-    EXPECT_EQ(Label("foo", "0xdeadb01d"), Label::from_geant4("foo0xdeadb01d"));
+    EXPECT_EQ(Label("foo"), Label::from_geant("foo"));
+    EXPECT_EQ(Label("foo", "0xdeadb01d"), Label::from_geant("foo0xdeadb01d"));
 
     EXPECT_EQ(Label("bar"), Label::from_separator("bar", '@'));
     EXPECT_EQ(Label("bar"), Label::from_separator("bar@", '@'));

--- a/test/corecel/cont/LabelIdMultiMap.test.cc
+++ b/test/corecel/cont/LabelIdMultiMap.test.cc
@@ -1,0 +1,131 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/cont/LabelIdMultiMap.test.cc
+//---------------------------------------------------------------------------//
+#include "corecel/cont/LabelIdMultiMap.hh"
+
+#include <iostream>
+
+#include "corecel/OpaqueId.hh"
+#include "corecel/cont/Range.hh"
+
+#include "celeritas_test.hh"
+
+using celeritas::Label;
+using celeritas::LabelIdMultiMap;
+
+using CatId       = celeritas::OpaqueId<struct Cat>;
+using CatMultiMap = LabelIdMultiMap<CatId>;
+
+std::ostream& operator<<(std::ostream& os, const CatId& cat)
+{
+    os << "CatId{";
+    if (cat)
+        os << cat.unchecked_get();
+    os << "}";
+    return os;
+}
+
+TEST(LabelCmp, ordering)
+{
+    EXPECT_EQ(Label("a"), Label("a"));
+    EXPECT_EQ(Label("a", "1"), Label("a", "1"));
+    EXPECT_NE(Label("a"), Label("b"));
+    EXPECT_NE(Label("a", "1"), Label("a", "2"));
+    EXPECT_TRUE(Label("a") < Label("b"));
+    EXPECT_FALSE(Label("a") < Label("a"));
+    EXPECT_FALSE(Label("b") < Label("a"));
+    EXPECT_TRUE(Label("a") < Label("a", "1"));
+    EXPECT_TRUE(Label("a", "0") < Label("a", "1"));
+    EXPECT_FALSE(Label("a", "1") < Label("a", "1"));
+    EXPECT_FALSE(Label("a", "2") < Label("a", "1"));
+}
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class LabelIdMultiMapTest : public celeritas_test::Test
+{
+  protected:
+    void SetUp() override {}
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(LabelIdMultiMapTest, exceptions)
+{
+    EXPECT_THROW(CatMultiMap({Label{"kali"}, Label{"kali"}}),
+                 celeritas::RuntimeError);
+#if CELERITAS_DEBUG
+    EXPECT_THROW(CatMultiMap({}), celeritas::DebugError);
+#endif
+}
+
+TEST_F(LabelIdMultiMapTest, no_labels)
+{
+    CatMultiMap cats{{Label{"dexter"}, Label{"andy"}, Label{"loki"}}};
+    EXPECT_EQ(3, cats.size());
+    EXPECT_EQ(CatId{}, cats.find(Label{"nyoka"}));
+    EXPECT_EQ(CatId{0}, cats.find(Label{"dexter"}));
+    EXPECT_EQ(CatId{1}, cats.find(Label{"andy"}));
+    EXPECT_EQ(CatId{2}, cats.find(Label{"loki"}));
+}
+
+TEST_F(LabelIdMultiMapTest, some_labels)
+{
+    CatMultiMap cats{{{Label{"leroy"},
+                       Label{"fluffy"},
+                       {"fluffy", "jr"},
+                       {"fluffy", "sr"}}}};
+    EXPECT_EQ(4, cats.size());
+    EXPECT_EQ(CatId{1}, cats.find(Label{"fluffy"}));
+    EXPECT_EQ(CatId{2}, cats.find(Label{"fluffy", "jr"}));
+    {
+        auto               found            = cats.find("fluffy");
+        static const CatId expected_found[] = {CatId{1}, CatId{2}, CatId{3}};
+        EXPECT_VEC_EQ(expected_found, found);
+    }
+}
+
+TEST_F(LabelIdMultiMapTest, shuffled_labels)
+{
+    const std::vector<Label> labels = {
+        {"c", "2"},
+        {"b", "1"},
+        {"b", "0"},
+        {"a", "0"},
+        {"c", "0"},
+        {"c", "1"},
+    };
+
+    CatMultiMap cats{labels};
+
+    // Check ordering of IDs
+    for (auto i : celeritas::range(labels.size()))
+    {
+        EXPECT_EQ(labels[i], cats.get(CatId{i}));
+    }
+
+    // Check discontinuous ID listing
+    {
+        auto               found            = cats.find("a");
+        static const CatId expected_found[] = {CatId{3}};
+        EXPECT_VEC_EQ(expected_found, found);
+    }
+    {
+        auto               found            = cats.find("b");
+        static const CatId expected_found[] = {CatId{2}, CatId{1}};
+        EXPECT_VEC_EQ(expected_found, found);
+    }
+    {
+        auto               found            = cats.find("c");
+        static const CatId expected_found[] = {CatId{4}, CatId{5}, CatId{0}};
+        EXPECT_VEC_EQ(expected_found, found);
+    }
+}

--- a/test/corecel/cont/LabelIdMultiMap.test.cc
+++ b/test/corecel/cont/LabelIdMultiMap.test.cc
@@ -91,7 +91,7 @@ TEST_F(LabelIdMultiMapTest, empty)
     {
         EXPECT_EQ(0, cats->size());
         EXPECT_EQ(CatId{}, cats->find(Label{"merry"}));
-        EXPECT_EQ(0, cats->find("pippin").size());
+        EXPECT_EQ(0, cats->find_all("pippin").size());
 #if CELERITAS_DEBUG
         EXPECT_THROW(cats->get(CatId{0}), celeritas::DebugError);
 #endif
@@ -100,11 +100,12 @@ TEST_F(LabelIdMultiMapTest, empty)
 
 TEST_F(LabelIdMultiMapTest, no_ext)
 {
-    CatMultiMap cats{{Label{"dexter"}, Label{"andy"}, Label{"loki"}}};
+    CatMultiMap cats{VecLabel{{"dexter", "andy", "loki"}}};
     EXPECT_EQ(3, cats.size());
-    EXPECT_EQ(CatId{}, cats.find(Label{"nyoka"}));
-    EXPECT_EQ(CatId{0}, cats.find(Label{"dexter"}));
-    EXPECT_EQ(CatId{1}, cats.find(Label{"andy"}));
+    EXPECT_EQ(CatId{}, cats.find("nyoka"));
+    EXPECT_EQ(CatId{0}, cats.find("dexter"));
+    EXPECT_EQ(CatId{1}, cats.find("andy"));
+    EXPECT_EQ(CatId{2}, cats.find("loki"));
     EXPECT_EQ(CatId{2}, cats.find(Label{"loki"}));
 }
 
@@ -118,7 +119,7 @@ TEST_F(LabelIdMultiMapTest, some_labels)
     EXPECT_EQ(CatId{1}, cats.find(Label{"fluffy"}));
     EXPECT_EQ(CatId{2}, cats.find(Label{"fluffy", "jr"}));
     {
-        auto               found            = cats.find("fluffy");
+        auto               found            = cats.find_all("fluffy");
         static const CatId expected_found[] = {CatId{1}, CatId{2}, CatId{3}};
         EXPECT_VEC_EQ(expected_found, found);
     }
@@ -145,17 +146,17 @@ TEST_F(LabelIdMultiMapTest, shuffled_labels)
 
     // Check discontinuous ID listing
     {
-        auto               found            = cats.find("a");
+        auto               found            = cats.find_all("a");
         static const CatId expected_found[] = {CatId{3}};
         EXPECT_VEC_EQ(expected_found, found);
     }
     {
-        auto               found            = cats.find("b");
+        auto               found            = cats.find_all("b");
         static const CatId expected_found[] = {CatId{2}, CatId{1}};
         EXPECT_VEC_EQ(expected_found, found);
     }
     {
-        auto               found            = cats.find("c");
+        auto               found            = cats.find_all("c");
         static const CatId expected_found[] = {CatId{4}, CatId{5}, CatId{0}};
         EXPECT_VEC_EQ(expected_found, found);
     }

--- a/test/corecel/cont/LabelIdMultiMap.test.cc
+++ b/test/corecel/cont/LabelIdMultiMap.test.cc
@@ -136,7 +136,7 @@ TEST_F(LabelIdMultiMapTest, shuffled_labels)
     CatMultiMap cats{labels};
 
     // Check ordering of IDs
-    for (auto i : celeritas::range(labels.size()))
+    for (auto i : celeritas::range<CatId::size_type>(labels.size()))
     {
         EXPECT_EQ(labels[i], cats.get(CatId{i}));
     }

--- a/test/corecel/cont/LabelIdMultiMap.test.cc
+++ b/test/corecel/cont/LabelIdMultiMap.test.cc
@@ -81,20 +81,21 @@ TEST_F(LabelIdMultiMapTest, exceptions)
 {
     EXPECT_THROW(CatMultiMap({Label{"kali"}, Label{"kali"}}),
                  celeritas::RuntimeError);
-#if CELERITAS_DEBUG
-    EXPECT_THROW(CatMultiMap(VecLabel{}), celeritas::DebugError);
-#endif
 }
 
 TEST_F(LabelIdMultiMapTest, empty)
 {
-    CatMultiMap cats;
-    EXPECT_EQ(0, cats.size());
-    EXPECT_EQ(CatId{}, cats.find(Label{"merry"}));
-    EXPECT_EQ(0, cats.find("pippin").size());
+    const CatMultiMap default_cats;
+    const CatMultiMap empty_cats(VecLabel{});
+    for (const CatMultiMap* cats : {&default_cats, &empty_cats})
+    {
+        EXPECT_EQ(0, cats->size());
+        EXPECT_EQ(CatId{}, cats->find(Label{"merry"}));
+        EXPECT_EQ(0, cats->find("pippin").size());
 #if CELERITAS_DEBUG
-    EXPECT_THROW(cats.get(CatId{0}), celeritas::DebugError);
+        EXPECT_THROW(cats->get(CatId{0}), celeritas::DebugError);
 #endif
+    }
 }
 
 TEST_F(LabelIdMultiMapTest, no_ext)

--- a/test/corecel/math/HashUtils.test.cc
+++ b/test/corecel/math/HashUtils.test.cc
@@ -1,0 +1,53 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/math/HashUtils.test.cc
+//---------------------------------------------------------------------------//
+#include "corecel/math/HashUtils.hh"
+
+#include <cstdint>
+
+#include "celeritas_test.hh"
+// #include "HashUtils.test.hh"
+
+using namespace celeritas;
+using celeritas::detail::make_fast_hasher;
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST(FastHasherTest, four_byte)
+{
+    std::uint32_t result{0};
+    auto          hash = make_fast_hasher(&result);
+    EXPECT_NE(0, result);
+    hash(static_cast<Byte>(0xab));
+    hash(static_cast<Byte>(0xcd));
+    hash(static_cast<Byte>(0x19));
+    EXPECT_EQ(0x111e8cf4u, result);
+}
+
+TEST(FastHasherTest, eight_byte)
+{
+    std::uint64_t result{0};
+    auto          hash = make_fast_hasher(&result);
+    EXPECT_NE(0, result);
+    hash(static_cast<Byte>(0xab));
+    hash(static_cast<Byte>(0xcd));
+    hash(static_cast<Byte>(0x19));
+    EXPECT_EQ(0x679fea1a6fe6ebb4ull, result);
+}
+
+TEST(HashUtilsTest, hash_combine)
+{
+    const std::string foo{"foo"};
+    const std::string bar{"bar"};
+
+    EXPECT_NE(hash_combine(), 0);
+    EXPECT_NE(hash_combine(), hash_combine(0));
+    EXPECT_NE(hash_combine(0, 1), hash_combine(1, 0));
+    EXPECT_NE(hash_combine(foo, bar), hash_combine(bar, foo));
+}

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -83,7 +83,7 @@ TEST_F(OneVolumeTest, params)
     EXPECT_EQ(1, geo.num_volumes());
     EXPECT_EQ(0, geo.num_surfaces());
 
-    EXPECT_EQ("infinite", geo.id_to_label(VolumeId{0}));
+    EXPECT_EQ("infinite", geo.id_to_label(VolumeId{0}).name);
     EXPECT_EQ(VolumeId{0}, geo.find_volume("infinite"));
 }
 
@@ -129,7 +129,7 @@ TEST_F(TwoVolumeTest, params)
     EXPECT_EQ(2, geo.num_volumes());
     EXPECT_EQ(1, geo.num_surfaces());
 
-    EXPECT_EQ("sphere", geo.id_to_label(SurfaceId{0}));
+    EXPECT_EQ("sphere", geo.id_to_label(SurfaceId{0}).name);
     EXPECT_EQ(SurfaceId{0}, geo.find_surface("sphere"));
 
     const auto& bbox = geo.bbox();

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -97,7 +97,7 @@ void OrangeGeoTestBase::build_geometry(OneVolInput inp)
         vi.flags = (inp.complex_tracking ? VolumeInput::Flags::internal_surfaces
                                          : 0);
         insert(vi);
-        input.volume_labels = {"infinite"};
+        input.volume_labels = {Label("infinite")};
     }
 
     // Save fake bbox for sampling
@@ -120,7 +120,7 @@ void OrangeGeoTestBase::build_geometry(TwoVolInput inp)
         // Insert surfaces
         SurfaceInserter insert(&input.surfaces);
         insert(Sphere({0, 0, 0}, inp.radius));
-        input.surface_labels = {"sphere"};
+        input.surface_labels = {Label("sphere")};
     }
     {
         // Insert volumes
@@ -139,7 +139,7 @@ void OrangeGeoTestBase::build_geometry(TwoVolInput inp)
             vi.logic = {0, logic::lnot};
             insert(vi);
         }
-        input.volume_labels = {"outside", "inside"};
+        input.volume_labels = {Label("outside"), Label("inside")};
 
         {
             auto volumes      = make_builder(&input.volumes.volumes);
@@ -243,7 +243,7 @@ std::string OrangeGeoTestBase::id_to_label(SurfaceId surf) const
     if (!surf)
         return "[none]";
 
-    return params_->id_to_label(surf);
+    return params_->id_to_label(surf).name;
 }
 
 //---------------------------------------------------------------------------//
@@ -255,7 +255,7 @@ std::string OrangeGeoTestBase::id_to_label(VolumeId vol) const
     if (!vol)
         return "[none]";
 
-    return params_->id_to_label(vol);
+    return params_->id_to_label(vol).name;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
CMS and other complex detectors reuse the same volume and material names for multiple logical units, presumably for different cutoffs or densities or other requirements. Previously Celeritas required volumes to be unique and allowed materials to be duplicated (but didn't have a good method to retrieve duplicates). This new implementation allows a single "name" to map to a series of unique ids that each have a different extension. Each `Label` is ideally unique but is allowed to be duplicated since it's only used for metadata access. The `LabelIdMultiMap` class manages the mapping of labels/strings to and from ids.

With the new implementation we can load and set up CMS 2018. 🎉  There are still warnings about "empty" volume IDs (I assume created as temporaries by vecgeom?) but they can be ignored.

Closes #419