### PR TITLE
Add testem15 for orange and fix safety flag

### DIFF
--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -213,7 +213,14 @@ OrangeParams::OrangeParams(Input input)
         max_faces = std::max<size_type>(max_faces, def.faces.size());
         max_intersections
             = std::max<size_type>(max_intersections, def.max_intersections);
-        simple_safety &= (def.flags & VolumeRecord::simple_safety);
+
+        // Safe if an implicit cell *or* has simple surface types and no
+        // internal surfaces
+        simple_safety
+            = simple_safety
+              && ((def.flags & VolumeRecord::implicit_cell)
+                  || ((def.flags & VolumeRecord::simple_safety)
+                      && !(def.flags & VolumeRecord::internal_surfaces)));
     }
     host_data.scalars.max_faces         = max_faces;
     host_data.scalars.max_intersections = max_intersections;

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -72,6 +72,12 @@ class FiveVolumesTest : public OrangeTest
     void SetUp() override { this->build_geometry("five-volumes.org.json"); }
 };
 
+#define Geant4Testem15Test TEST_IF_CELERITAS_JSON(Geant4Testem15Test)
+class Geant4Testem15Test : public OrangeTest
+{
+    void SetUp() override { this->build_geometry("geant4-testem15.org.json"); }
+};
+
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
@@ -82,6 +88,7 @@ TEST_F(OneVolumeTest, params)
 
     EXPECT_EQ(1, geo.num_volumes());
     EXPECT_EQ(0, geo.num_surfaces());
+    EXPECT_TRUE(geo.supports_safety());
 
     EXPECT_EQ("infinite", geo.id_to_label(VolumeId{0}));
     EXPECT_EQ(VolumeId{0}, geo.find_volume("infinite"));
@@ -128,6 +135,7 @@ TEST_F(TwoVolumeTest, params)
 
     EXPECT_EQ(2, geo.num_volumes());
     EXPECT_EQ(1, geo.num_surfaces());
+    EXPECT_TRUE(geo.supports_safety());
 
     EXPECT_EQ("sphere", geo.id_to_label(SurfaceId{0}));
     EXPECT_EQ(SurfaceId{0}, geo.find_surface("sphere"));
@@ -310,4 +318,55 @@ TEST_F(TwoVolumeTest, intersect_limited)
     next = geo.find_next_step(12345.0);
     EXPECT_SOFT_EQ(12345.0, next.distance);
     EXPECT_FALSE(next.boundary);
+}
+
+TEST_F(FiveVolumesTest, params)
+{
+    const OrangeParams& geo = this->params();
+
+    EXPECT_EQ(6, geo.num_volumes());
+    EXPECT_EQ(12, geo.num_surfaces());
+    EXPECT_FALSE(geo.supports_safety());
+}
+
+TEST_F(Geant4Testem15Test, params)
+{
+    const OrangeParams& geo = this->params();
+
+    EXPECT_EQ(3, geo.num_volumes());
+    EXPECT_EQ(12, geo.num_surfaces());
+    // The 'world' volume includes a negated box
+    EXPECT_FALSE(geo.supports_safety());
+}
+
+TEST_F(Geant4Testem15Test, safety)
+{
+    OrangeTrackView geo = this->make_track_view();
+
+    geo = Initializer_t{{0, 0, 0}, {1, 0, 0}};
+    EXPECT_VEC_SOFT_EQ(Real3({0, 0, 0}), geo.pos());
+    EXPECT_VEC_SOFT_EQ(Real3({1, 0, 0}), geo.dir());
+    EXPECT_EQ(VolumeId{1}, geo.volume_id());
+    EXPECT_EQ(SurfaceId{}, geo.surface_id());
+    EXPECT_FALSE(geo.is_outside());
+
+    // Safety at middle should be to the box boundary
+    EXPECT_SOFT_EQ(5000.0, geo.find_safety());
+
+    // Check safety near face
+    auto next = geo.find_next_step(4995.0);
+    EXPECT_SOFT_EQ(4995.0, next.distance);
+    EXPECT_FALSE(next.boundary);
+    geo.move_internal(4995.0);
+    EXPECT_SOFT_EQ(5.0, geo.find_safety());
+
+    // Check safety near edge
+    geo.set_dir({0, 1, 0});
+    next = geo.find_next_step();
+    geo.move_internal(4990.0);
+    EXPECT_SOFT_EQ(5.0, geo.find_safety());
+    geo.set_dir({-1, 0, 0});
+    next = geo.find_next_step();
+    geo.move_internal(6.0);
+    EXPECT_SOFT_EQ(10.0, geo.find_safety());
 }

--- a/test/orange/OrangeGeoTestBase.hh
+++ b/test/orange/OrangeGeoTestBase.hh
@@ -52,7 +52,7 @@ class OrangeGeoTestBase : public celeritas_test::Test
     //! On-the-fly construction inputs
     struct OneVolInput
     {
-        bool complex_tracking = true;
+        bool complex_tracking = false;
     };
 
     struct TwoVolInput

--- a/test/orange/data/geant4-testem15.org.json
+++ b/test/orange/data/geant4-testem15.org.json
@@ -1,0 +1,198 @@
+{
+"_format": "SCALE ORANGE",
+"_version": 0,
+"materials": {
+"cell_to_mat": [
+-1,
+0,
+1
+],
+"names": [
+"G4_STAINLESS-STEEL",
+"G4_Galactic"
+]
+},
+"universes": [
+{
+"_type": "simple unit",
+"bbox": [
+[
+-60000.0,
+-60000.0,
+-60000.0
+],
+[
+60000.0,
+60000.0,
+60000.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"box",
+"World"
+],
+"cells": [
+{
+"faces": [
+0,
+1,
+2,
+3,
+4,
+5
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ & ~",
+"num_intersections": 6,
+"zorder": 2
+},
+{
+"faces": [
+6,
+7,
+8,
+9,
+10,
+11
+],
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ &",
+"num_intersections": 6,
+"zorder": 2
+},
+{
+"faces": [
+0,
+1,
+2,
+3,
+4,
+5,
+6,
+7,
+8,
+9,
+10,
+11
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ & 6 7 ~ & 8 & 9 ~ & 10 & 11 ~ & ~ &",
+"num_intersections": 12,
+"zorder": 2
+}
+],
+"md": {
+"name": "global",
+"provenance": "geant4-testem15.org.omn:13"
+},
+"surface_names": [
+"World.mx",
+"World.px",
+"World.my",
+"World.py",
+"World.mz",
+"World.pz",
+"box.mx",
+"box.px",
+"box.my",
+"box.py",
+"box.mz",
+"box.pz"
+],
+"surfaces": {
+"connectivity": [
+[
+0,
+2
+],
+[
+0,
+2
+],
+[
+0,
+2
+],
+[
+0,
+2
+],
+[
+0,
+2
+],
+[
+0,
+2
+],
+[
+1,
+2
+],
+[
+1,
+2
+],
+[
+1,
+2
+],
+[
+1,
+2
+],
+[
+1,
+2
+],
+[
+1,
+2
+]
+],
+"data": [
+-60000.0,
+60000.0,
+-60000.0,
+60000.0,
+-60000.0,
+60000.0,
+-5000.0,
+5000.0,
+-5000.0,
+5000.0,
+-5000.0,
+5000.0
+],
+"sizes": [
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1
+],
+"types": [
+"px",
+"px",
+"py",
+"py",
+"pz",
+"pz",
+"px",
+"px",
+"py",
+"py",
+"pz",
+"pz"
+]
+}
+}
+]
+}

--- a/test/orange/data/geant4-testem15.org.omn
+++ b/test/orange/data/geant4-testem15.org.omn
@@ -1,0 +1,30 @@
+! Copyright 2022 UT-Battelle, LLC and other Celeritas Developers.
+! See the top-level COPYRIGHT file for details.
+! SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+[GEOMETRY]
+global "global"
+comp : matid
+    "G4_STAINLESS-STEEL" 0
+    "G4_Galactic" 1
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+
+[UNIVERSE=general global]
+interior "World"
+
+[UNIVERSE][SHAPE=box box]
+widths 10000 10000 10000  ! note: units are in cm
+
+[UNIVERSE][SHAPE=box World]
+widths 120000 120000 120000
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+
+[UNIVERSE][CELL box]
+comp "G4_STAINLESS-STEEL"
+shapes box
+
+[UNIVERSE][CELL World]
+comp G4_Galactic
+shapes World ~box


### PR DESCRIPTION
The "simple safety" flag is just used for printing a diagnostic message in the demo loop, but this adds the testem15 geometry (near-"infinite" medium) and adds a few more tests of the safety distance.