### PR TITLE
Fix HIP/Crusher build

### DIFF
--- a/app/demo-loop/Transporter.cc
+++ b/app/demo-loop/Transporter.cc
@@ -187,7 +187,7 @@ TransporterResult Transporter<M>::operator()(VecPrimary primaries)
     size_type remaining_steps = input_.max_steps;
 
     // Copy primaries to device and transport the first step
-    auto      track_counts    = step(std::move(primaries));
+    auto track_counts = step(std::move(primaries));
     append_track_counts(track_counts);
     result.time.steps.push_back(get_step_time());
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -289,12 +289,7 @@ if(CELERITAS_USE_HIP)
   # This is a hacky workaround for not having the equivalent of CUDAToolkit: it
   # works on Crusher as of ROCm 5.1.0
   set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "Path to ROCm headers")
-  target_include_directories(celeritas
-    SYSTEM PUBLIC
-      "${ROCM_PATH}/hiprand/include"
-      "${ROCM_PATH}/rocrand/include"
-      "${ROCM_PATH}/hip/include"
-  )
+  target_include_directories(celeritas SYSTEM PUBLIC "${ROCM_PATH}/include")
 endif()
 
 celeritas_install(TARGETS celeritas

--- a/src/celeritas/ext/detail/DetectorConstruction.cc
+++ b/src/celeritas/ext/detail/DetectorConstruction.cc
@@ -29,7 +29,7 @@ DetectorConstruction::DetectorConstruction(const std::string& gdml_input)
     // and LabelIdMultiMap. Note that material and element names (at least as
     // of Geant4@11.0) are *always* stripped: only volumes and solids keep
     // their extension.
-    G4GDMLParser   gdml_parser;
+    G4GDMLParser gdml_parser;
     gdml_parser.SetStripFlag(false);
 
     constexpr bool validate_gdml_schema = false;

--- a/src/celeritas/field/RungeKuttaStepper.hh
+++ b/src/celeritas/field/RungeKuttaStepper.hh
@@ -90,7 +90,7 @@ RungeKuttaStepper<E>::operator()(real_type step, const OdeState& beg_state) cons
     constexpr real_type fourth_order_correction = 1 / real_type(15);
 
     result_type result;
-    OdeState beg_slope = calc_rhs_(beg_state);
+    OdeState    beg_slope = calc_rhs_(beg_state);
 
     // Do two half steps
     result.mid_state = this->do_step(half_step, beg_state, beg_slope);

--- a/src/celeritas/global/ActionManagerOutput.cc
+++ b/src/celeritas/global/ActionManagerOutput.cc
@@ -38,7 +38,7 @@ ActionManagerOutput::ActionManagerOutput(SPConstActionManager actions)
 void ActionManagerOutput::output(JsonPimpl* j) const
 {
 #if CELERITAS_USE_JSON
-    auto obj = nlohmann::json::array();
+    auto obj        = nlohmann::json::array();
     bool has_timing = actions_->sync();
     for (auto id : range(ActionId{actions_->num_actions()}))
     {

--- a/src/celeritas/global/CoreTrackData.hh
+++ b/src/celeritas/global/CoreTrackData.hh
@@ -62,14 +62,14 @@ struct CoreParamsData
     CoreParamsData& operator=(const CoreParamsData<W2, M2>& other)
     {
         CELER_EXPECT(other);
-        geometry   = other.geometry;
-        geo_mats   = other.geo_mats;
-        materials  = other.materials;
-        particles  = other.particles;
-        cutoffs    = other.cutoffs;
-        physics    = other.physics;
-        rng        = other.rng;
-        scalars    = other.scalars;
+        geometry  = other.geometry;
+        geo_mats  = other.geo_mats;
+        materials = other.materials;
+        particles = other.particles;
+        cutoffs   = other.cutoffs;
+        physics   = other.physics;
+        rng       = other.rng;
+        scalars   = other.scalars;
         return *this;
     }
 };
@@ -107,12 +107,12 @@ struct CoreStateData
     CoreStateData& operator=(CoreStateData<W2, M2>& other)
     {
         CELER_EXPECT(other);
-        geometry    = other.geometry;
-        materials   = other.materials;
-        particles   = other.particles;
-        physics     = other.physics;
-        rng         = other.rng;
-        sim         = other.sim;
+        geometry  = other.geometry;
+        materials = other.materials;
+        particles = other.particles;
+        physics   = other.physics;
+        rng       = other.rng;
+        sim       = other.sim;
         return *this;
     }
 };

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -214,13 +214,13 @@ void PhysicsParams::build_options(const Options& opts, HostValue* data) const
                    << "invalid linear_loss_limit=" << opts.linear_loss_limit
                    << " (should be within 0 <= limit <= 1)");
     CELER_VALIDATE(opts.secondary_stack_factor > 0,
-                   << "invalid secondary_stack_factor=" << opts.secondary_stack_factor
-                   << " (should be positive)");
-    data->scalars.scaling_min_range  = opts.min_range;
-    data->scalars.scaling_fraction   = opts.max_step_over_range;
-    data->scalars.energy_fraction    = opts.min_eprime_over_e;
-    data->scalars.linear_loss_limit  = opts.linear_loss_limit;
-    data->scalars.enable_fluctuation = opts.enable_fluctuation;
+                   << "invalid secondary_stack_factor="
+                   << opts.secondary_stack_factor << " (should be positive)");
+    data->scalars.scaling_min_range      = opts.min_range;
+    data->scalars.scaling_fraction       = opts.max_step_over_range;
+    data->scalars.energy_fraction        = opts.min_eprime_over_e;
+    data->scalars.linear_loss_limit      = opts.linear_loss_limit;
+    data->scalars.enable_fluctuation     = opts.enable_fluctuation;
     data->scalars.secondary_stack_factor = opts.secondary_stack_factor;
 }
 

--- a/src/celeritas/phys/PhysicsParams.hh
+++ b/src/celeritas/phys/PhysicsParams.hh
@@ -90,10 +90,10 @@ class PhysicsParams
   public:
     //!@{
     //! Type aliases
-    using SPConstParticles   = std::shared_ptr<const ParticleParams>;
-    using SPConstMaterials   = std::shared_ptr<const MaterialParams>;
-    using SPConstProcess     = std::shared_ptr<const Process>;
-    using SPConstRelaxation  = std::shared_ptr<const AtomicRelaxationParams>;
+    using SPConstParticles  = std::shared_ptr<const ParticleParams>;
+    using SPConstMaterials  = std::shared_ptr<const MaterialParams>;
+    using SPConstProcess    = std::shared_ptr<const Process>;
+    using SPConstRelaxation = std::shared_ptr<const AtomicRelaxationParams>;
 
     using VecProcess         = std::vector<SPConstProcess>;
     using SpanConstProcessId = Span<const ProcessId>;
@@ -173,8 +173,8 @@ class PhysicsParams
     SPAction fixed_step_action_;
 
     // Host metadata/access
-    VecProcess processes_;
-    VecModel   models_;
+    VecProcess        processes_;
+    VecModel          models_;
     SPConstRelaxation relaxation_;
 
     // Host/device storage and reference

--- a/src/celeritas/phys/PhysicsStepView.hh
+++ b/src/celeritas/phys/PhysicsStepView.hh
@@ -121,8 +121,8 @@ class PhysicsStepView
  * Construct from shared and state data.
  */
 CELER_FUNCTION PhysicsStepView::PhysicsStepView(const PhysicsParamsRef& params,
-                                 const PhysicsStateRef&  states,
-                                 ThreadId                tid)
+                                                const PhysicsStateRef&  states,
+                                                ThreadId                tid)
     : params_(params), states_(states), thread_(tid)
 {
     CELER_EXPECT(thread_);

--- a/src/celeritas/phys/PhysicsStepView.hh
+++ b/src/celeritas/phys/PhysicsStepView.hh
@@ -120,7 +120,7 @@ class PhysicsStepView
 /*!
  * Construct from shared and state data.
  */
-PhysicsStepView::PhysicsStepView(const PhysicsParamsRef& params,
+CELER_FUNCTION PhysicsStepView::PhysicsStepView(const PhysicsParamsRef& params,
                                  const PhysicsStateRef&  states,
                                  ThreadId                tid)
     : params_(params), states_(states), thread_(tid)

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -238,7 +238,6 @@ CELER_FUNCTION void PhysicsTrackView::reset_interaction_mfp()
     this->state().interaction_mfp = 0;
 }
 
-
 //---------------------------------------------------------------------------//
 /*!
  * Whether the remaining MFP has been calculated.

--- a/src/celeritas/random/CuHipRngData.hh
+++ b/src/celeritas/random/CuHipRngData.hh
@@ -32,7 +32,7 @@
 // Override an undocumented hipRAND API definition to enable usage in host
 // code.
 #    define FQUALIFIERS __forceinline__ __host__ __device__
-#    include <hiprand_kernel.h>
+#    include <hiprand/hiprand_kernel.h>
 #    define CELER_RNG_PREFIX(TOK) hip##TOK
 #else
 // CuHipRng is invalid

--- a/src/celeritas/random/Selector.hh
+++ b/src/celeritas/random/Selector.hh
@@ -53,7 +53,7 @@ class Selector
     //! Type aliases
     using value_type = T;
 #if __cplusplus < 201703L
-    using real_type  = typename std::result_of<F(value_type)>::type;
+    using real_type = typename std::result_of<F(value_type)>::type;
 #else
     using real_type = typename std::invoke_result<F, value_type>::type;
 #endif

--- a/src/celeritas/track/detail/ProcessSecondariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessSecondariesLauncher.hh
@@ -71,8 +71,8 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
         return;
     }
 
-    GeoTrackView     geo(params_.geometry, states_.geometry, tid);
-    PhysicsStepView  phys(params_.physics, states_.physics, tid);
+    GeoTrackView    geo(params_.geometry, states_.geometry, tid);
+    PhysicsStepView phys(params_.physics, states_.physics, tid);
 
     // Offset in the vector of track initializers
     CELER_ASSERT(data_.secondary_counts[tid] <= data_.num_secondaries);

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -201,7 +201,7 @@ TEST_F(SeltzerBergerTest, sb_positron_xs_scaling)
         0.99999599590292, 0.99994914123134, 0.99844428624414, 0.0041293798201,
         0.99999995934326, 0.99999948043882, 0.99998298916928, 0.33428689072689};
     // clang-format on
-    EXPECT_VEC_SOFT_EQ(expected_scaling_frac, scaling_frac);
+    EXPECT_VEC_NEAR(expected_scaling_frac, scaling_frac, 1e-11);
 }
 
 TEST_F(SeltzerBergerTest, sb_energy_dist)

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -175,7 +175,7 @@ TEST_F(FieldDriverDeviceTest, TEST_IF_CELER_DEVICE(field_driver_device))
 {
     // Run kernel
     test_params.nstates = 32 * 256;
-    auto output = driver_test(field_params, test_params);
+    auto output         = driver_test(field_params, test_params);
 
     // Check stepper results
     real_type zstep = test_params.delta_z * test_params.revolutions;
@@ -198,7 +198,7 @@ TEST_F(FieldDriverDeviceTest, TEST_IF_CELER_DEVICE(accurate_advance_device))
 {
     // Run kernel
     test_params.nstates = 32 * 256;
-    auto output = accurate_advance_test(field_params, test_params);
+    auto output         = accurate_advance_test(field_params, test_params);
 
     // Check stepper results
     real_type zstep = test_params.delta_z;

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -123,8 +123,8 @@ TEST_F(FieldPropagatorHostTest, boundary_crossing_host)
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
             field, this->field_params, particle_track, &geo_track);
 
-        int                                 icross       = 0;
-        real_type                           total_length = 0;
+        int       icross       = 0;
+        real_type total_length = 0;
 
         for (CELER_MAYBE_UNUSED int ir : celeritas::range(test.revolutions))
         {

--- a/test/celeritas/field/FieldPropagator.test.cu
+++ b/test/celeritas/field/FieldPropagator.test.cu
@@ -65,7 +65,7 @@ __global__ void fp_test_kernel(const int                       size,
 
     // Tests with input parameters of a electron in a uniform magnetic field
     const double hstep = (2.0 * constants::pi * test.radius) / test.nsteps;
-    real_type curved_length = 0;
+    real_type    curved_length = 0;
 
     for (CELER_MAYBE_UNUSED int i : celeritas::range(test.revolutions))
     {
@@ -118,7 +118,7 @@ __global__ void bc_test_kernel(const int                       size,
 
     // Tests with input parameters of a electron in a uniform magnetic field
     const double hstep = (2.0 * constants::pi * test.radius) / test.nsteps;
-    real_type curved_length = 0;
+    real_type    curved_length = 0;
 
     constexpr int num_boundary = 16;
     int           icross       = 0;

--- a/test/celeritas/field/FieldPropagator.test.hh
+++ b/test/celeritas/field/FieldPropagator.test.hh
@@ -51,7 +51,7 @@ struct FPTestInput
     ParticleStateRef          particle_states;
 
     celeritas::FieldDriverOptions field_params;
-    FieldTestParams            test;
+    FieldTestParams               test;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/field/Steppers.test.cc
+++ b/test/celeritas/field/Steppers.test.cc
@@ -162,7 +162,7 @@ TEST_F(SteppersTest, TEST_IF_CELER_DEVICE(device_helix))
 {
     // Run the ZHelix kernel
     param.nstates = 32 * 512;
-    auto output = helix_test(param);
+    auto output   = helix_test(param);
 
     // Check stepper results
     check_result(output);
@@ -173,7 +173,7 @@ TEST_F(SteppersTest, TEST_IF_CELER_DEVICE(device_classical_rk4))
 {
     // Run the classical Runge-Kutta kernel
     param.nstates = 32 * 512;
-    auto output = rk4_test(param);
+    auto output   = rk4_test(param);
 
     // Check stepper results
     check_result(output);
@@ -184,7 +184,7 @@ TEST_F(SteppersTest, TEST_IF_CELER_DEVICE(device_dormand_prince_547))
 {
     // Run the Dormand-Prince 547(M) kernel
     param.nstates = 32 * 512;
-    auto output = dp547_test(param);
+    auto output   = dp547_test(param);
 
     // Check stepper results
     check_result(output);

--- a/test/celeritas/field/UserMapField.test.cc
+++ b/test/celeritas/field/UserMapField.test.cc
@@ -87,10 +87,10 @@ class UserMapFieldTest : public FieldPropagatorTestBase
 
   protected:
     // Test parameters and input
-    GeoStateStore                  geo_state_;
-    UserFieldTestParams            test_param_;
-    std::shared_ptr<MagFieldMap>   map_;
-    FieldMapRef                    ref_;
+    GeoStateStore                geo_state_;
+    UserFieldTestParams          test_param_;
+    std::shared_ptr<MagFieldMap> map_;
+    FieldMapRef                  ref_;
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
- Include paths to kernel/rng have changed
- Missing CELER_FUNCTION on inline definition
- SB scaling answers are different by 1e-12

```
/ccs/home/s3j/.local/src/celeritas/test/celeritas/em/SeltzerBerger.test.cc:204: Failure
Values in: scaling_frac
 Expected: expected_scaling_frac
2 of 16 elements differ
by 9.9999999999999998e-13 relative error or 1e-14 absolute error
 i            EXPECTED       scaling_frac         Difference
 7 2.1585790781929e-09 2.15857907820311e-09 4.73029576933669e-12
11     0.0041293798201 0.00412937982009147 -2.06601727778273e-12
```

I'm still seeing one failure in UrbanMsc @whokion :
```
/ccs/home/s3j/.local/src/celeritas/test/celeritas/em/UrbanMsc.test.cc:315: Failure
Values in: fstep
 Expected: expected_fstep
1 of 8 elements differ
by 9.9999999999999998e-13 relative error or 1e-14 absolute error
i      expected_fstep              fstep         Difference
3   0.035727783460526  0.0358650642994174 0.00384241129996512
```