### PR TITLE
Use the integral approach for all processes with particles that can lose energy over the step

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -268,12 +268,19 @@ TransporterInput load_input(const LDemoArgs& args)
         input.options.secondary_stack_factor = args.secondary_stack_factor;
         input.action_manager                 = params.action_mgr.get();
 
-        BremsstrahlungProcess::BremsstrahlungOptions brem_options;
-        brem_options.combined_model = args.brem_combined;
-        brem_options.enable_lpm     = args.brem_lpm;
+        BremsstrahlungProcess::Options brem_options;
+        brem_options.combined_model  = args.brem_combined;
+        brem_options.enable_lpm      = args.brem_lpm;
+        brem_options.use_integral_xs = true;
 
-        GammaConversionProcess::GammaConversionOptions conv_options;
+        GammaConversionProcess::Options conv_options;
         conv_options.enable_lpm = args.conv_lpm;
+
+        EPlusAnnihilationProcess::Options epgg_options;
+        epgg_options.use_integral_xs = true;
+
+        EIonizationProcess::Options ioni_options;
+        ioni_options.use_integral_xs = true;
 
         auto process_data = std::make_shared<ImportedProcesses>(
             std::move(imported_data.processes));
@@ -288,10 +295,10 @@ TransporterInput load_input(const LDemoArgs& args)
         }
         input.processes.push_back(std::make_shared<GammaConversionProcess>(
             params.particle, process_data, conv_options));
-        input.processes.push_back(
-            std::make_shared<EPlusAnnihilationProcess>(params.particle));
+        input.processes.push_back(std::make_shared<EPlusAnnihilationProcess>(
+            params.particle, epgg_options));
         input.processes.push_back(std::make_shared<EIonizationProcess>(
-            params.particle, process_data));
+            params.particle, process_data, ioni_options));
         input.processes.push_back(std::make_shared<BremsstrahlungProcess>(
             params.particle, params.material, process_data, brem_options));
         if (args.enable_msc)

--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -268,19 +268,12 @@ TransporterInput load_input(const LDemoArgs& args)
         input.options.secondary_stack_factor = args.secondary_stack_factor;
         input.action_manager                 = params.action_mgr.get();
 
-        BremsstrahlungProcess::Options brem_options;
-        brem_options.combined_model  = args.brem_combined;
-        brem_options.enable_lpm      = args.brem_lpm;
-        brem_options.use_integral_xs = true;
+        BremsstrahlungProcess::BremsstrahlungOptions brem_options;
+        brem_options.combined_model = args.brem_combined;
+        brem_options.enable_lpm     = args.brem_lpm;
 
-        GammaConversionProcess::Options conv_options;
+        GammaConversionProcess::GammaConversionOptions conv_options;
         conv_options.enable_lpm = args.conv_lpm;
-
-        EPlusAnnihilationProcess::Options epgg_options;
-        epgg_options.use_integral_xs = true;
-
-        EIonizationProcess::Options ioni_options;
-        ioni_options.use_integral_xs = true;
 
         auto process_data = std::make_shared<ImportedProcesses>(
             std::move(imported_data.processes));
@@ -295,10 +288,10 @@ TransporterInput load_input(const LDemoArgs& args)
         }
         input.processes.push_back(std::make_shared<GammaConversionProcess>(
             params.particle, process_data, conv_options));
-        input.processes.push_back(std::make_shared<EPlusAnnihilationProcess>(
-            params.particle, epgg_options));
+        input.processes.push_back(
+            std::make_shared<EPlusAnnihilationProcess>(params.particle));
         input.processes.push_back(std::make_shared<EIonizationProcess>(
-            params.particle, process_data, ioni_options));
+            params.particle, process_data));
         input.processes.push_back(std::make_shared<BremsstrahlungProcess>(
             params.particle, params.material, process_data, brem_options));
         if (args.enable_msc)

--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -269,11 +269,18 @@ TransporterInput load_input(const LDemoArgs& args)
         input.action_manager                 = params.action_mgr.get();
 
         BremsstrahlungProcess::Options brem_options;
-        brem_options.combined_model = args.brem_combined;
-        brem_options.enable_lpm     = args.brem_lpm;
+        brem_options.combined_model  = args.brem_combined;
+        brem_options.enable_lpm      = args.brem_lpm;
+        brem_options.use_integral_xs = true;
 
         GammaConversionProcess::Options conv_options;
         conv_options.enable_lpm = args.conv_lpm;
+
+        EPlusAnnihilationProcess::Options epgg_options;
+        epgg_options.use_integral_xs = true;
+
+        EIonizationProcess::Options ioni_options;
+        ioni_options.use_integral_xs = true;
 
         auto process_data = std::make_shared<ImportedProcesses>(
             std::move(imported_data.processes));
@@ -288,10 +295,10 @@ TransporterInput load_input(const LDemoArgs& args)
         }
         input.processes.push_back(std::make_shared<GammaConversionProcess>(
             params.particle, process_data, conv_options));
-        input.processes.push_back(
-            std::make_shared<EPlusAnnihilationProcess>(params.particle));
+        input.processes.push_back(std::make_shared<EPlusAnnihilationProcess>(
+            params.particle, epgg_options));
         input.processes.push_back(std::make_shared<EIonizationProcess>(
-            params.particle, process_data));
+            params.particle, process_data, ioni_options));
         input.processes.push_back(std::make_shared<BremsstrahlungProcess>(
             params.particle, params.material, process_data, brem_options));
         if (args.enable_msc)

--- a/src/celeritas/em/process/BremsstrahlungProcess.cc
+++ b/src/celeritas/em/process/BremsstrahlungProcess.cc
@@ -25,7 +25,7 @@ namespace celeritas
 BremsstrahlungProcess::BremsstrahlungProcess(SPConstParticles particles,
                                              SPConstMaterials materials,
                                              SPConstImported  process_data,
-                                             BremsstrahlungOptions options)
+                                             Options          options)
     : particles_(std::move(particles))
     , materials_(std::move(materials))
     , imported_(process_data,
@@ -79,6 +79,15 @@ auto BremsstrahlungProcess::step_limits(Applicability applic) const
     -> StepLimitBuilders
 {
     return imported_.step_limits(std::move(applic));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether to use the integral method to sample discrete interaction length.
+ */
+bool BremsstrahlungProcess::use_integral_xs() const
+{
+    return options_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/BremsstrahlungProcess.cc
+++ b/src/celeritas/em/process/BremsstrahlungProcess.cc
@@ -83,15 +83,6 @@ auto BremsstrahlungProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool BremsstrahlungProcess::use_integral_xs() const
-{
-    return options_.use_integral_xs;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Name of the process.
  */
 std::string BremsstrahlungProcess::label() const

--- a/src/celeritas/em/process/BremsstrahlungProcess.cc
+++ b/src/celeritas/em/process/BremsstrahlungProcess.cc
@@ -83,11 +83,11 @@ auto BremsstrahlungProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Type of process.
+ * Whether to use the integral method to sample discrete interaction length.
  */
-ProcessType BremsstrahlungProcess::type() const
+bool BremsstrahlungProcess::use_integral_xs() const
 {
-    return ProcessType::electromagnetic_dedx;
+    return options_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/BremsstrahlungProcess.cc
+++ b/src/celeritas/em/process/BremsstrahlungProcess.cc
@@ -25,7 +25,7 @@ namespace celeritas
 BremsstrahlungProcess::BremsstrahlungProcess(SPConstParticles particles,
                                              SPConstMaterials materials,
                                              SPConstImported  process_data,
-                                             Options          options)
+                                             BremsstrahlungOptions options)
     : particles_(std::move(particles))
     , materials_(std::move(materials))
     , imported_(process_data,
@@ -79,15 +79,6 @@ auto BremsstrahlungProcess::step_limits(Applicability applic) const
     -> StepLimitBuilders
 {
     return imported_.step_limits(std::move(applic));
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool BremsstrahlungProcess::use_integral_xs() const
-{
-    return options_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/BremsstrahlungProcess.hh
+++ b/src/celeritas/em/process/BremsstrahlungProcess.hh
@@ -19,11 +19,6 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Bremsstrahlung process for electrons and positrons.
- *
- * Input options are:
- * - \c combined_model: Use a unified model that applies over the entire energy
- *   range of the process
- * - \c enable_lpm: Account for LPM effect at very high energies
  */
 class BremsstrahlungProcess : public Process
 {
@@ -35,20 +30,24 @@ class BremsstrahlungProcess : public Process
     using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
     //!@}
 
-    struct BremsstrahlungOptions : Options
+    // Options for the Bremsstrahlung process
+    // TODO: update options based on ImportData
+    struct Options
     {
-        bool combined_model{true};
-        bool enable_lpm{true};
-
-        BremsstrahlungOptions() : Options(true) {}
+        bool combined_model{true};  //!> Use a unified relativistic/SB
+                                    //! interactor
+        bool enable_lpm{true};      //!> Account for LPM effect at very high
+                                    //! energies
+        bool use_integral_xs{true}; //!> Use integral method for sampling
+                                    //! discrete interaction length
     };
 
   public:
     // Construct from Bremsstrahlung data
-    BremsstrahlungProcess(SPConstParticles      particles,
-                          SPConstMaterials      materials,
-                          SPConstImported       process_data,
-                          BremsstrahlungOptions options);
+    BremsstrahlungProcess(SPConstParticles particles,
+                          SPConstMaterials materials,
+                          SPConstImported  process_data,
+                          Options          options);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -56,8 +55,8 @@ class BremsstrahlungProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Get the options for the process
-    const BremsstrahlungOptions& options() const final { return options_; }
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;
@@ -66,7 +65,7 @@ class BremsstrahlungProcess : public Process
     SPConstParticles       particles_;
     SPConstMaterials       materials_;
     ImportedProcessAdapter imported_;
-    BremsstrahlungOptions  options_;
+    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/BremsstrahlungProcess.hh
+++ b/src/celeritas/em/process/BremsstrahlungProcess.hh
@@ -34,10 +34,12 @@ class BremsstrahlungProcess : public Process
     // TODO: update options based on ImportData
     struct Options
     {
-        bool combined_model{true}; //!> Use a unified relativistic/SB
-                                   //! interactor
-        bool enable_lpm{true};     //!> Account for LPM effect at very high
-                                   //! energies
+        bool combined_model{true};  //!> Use a unified relativistic/SB
+                                    //! interactor
+        bool enable_lpm{true};      //!> Account for LPM effect at very high
+                                    //! energies
+        bool use_integral_xs{true}; //!> Use integral method for sampling
+                                    //! discrete interaction length
     };
 
   public:
@@ -53,8 +55,8 @@ class BremsstrahlungProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Type of process
-    ProcessType type() const final;
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/BremsstrahlungProcess.hh
+++ b/src/celeritas/em/process/BremsstrahlungProcess.hh
@@ -19,6 +19,11 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Bremsstrahlung process for electrons and positrons.
+ *
+ * Input options are:
+ * - \c combined_model: Use a unified model that applies over the entire energy
+ *   range of the process
+ * - \c enable_lpm: Account for LPM effect at very high energies
  */
 class BremsstrahlungProcess : public Process
 {
@@ -30,24 +35,20 @@ class BremsstrahlungProcess : public Process
     using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
     //!@}
 
-    // Options for the Bremsstrahlung process
-    // TODO: update options based on ImportData
-    struct Options
+    struct BremsstrahlungOptions : Options
     {
-        bool combined_model{true};  //!> Use a unified relativistic/SB
-                                    //! interactor
-        bool enable_lpm{true};      //!> Account for LPM effect at very high
-                                    //! energies
-        bool use_integral_xs{true}; //!> Use integral method for sampling
-                                    //! discrete interaction length
+        bool combined_model{true};
+        bool enable_lpm{true};
+
+        BremsstrahlungOptions() : Options(true) {}
     };
 
   public:
     // Construct from Bremsstrahlung data
-    BremsstrahlungProcess(SPConstParticles particles,
-                          SPConstMaterials materials,
-                          SPConstImported  process_data,
-                          Options          options);
+    BremsstrahlungProcess(SPConstParticles      particles,
+                          SPConstMaterials      materials,
+                          SPConstImported       process_data,
+                          BremsstrahlungOptions options);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -55,8 +56,8 @@ class BremsstrahlungProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    //! Get the options for the process
+    const BremsstrahlungOptions& options() const final { return options_; }
 
     // Name of the process
     std::string label() const final;
@@ -65,7 +66,7 @@ class BremsstrahlungProcess : public Process
     SPConstParticles       particles_;
     SPConstMaterials       materials_;
     ImportedProcessAdapter imported_;
-    Options                options_;
+    BremsstrahlungOptions  options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/BremsstrahlungProcess.hh
+++ b/src/celeritas/em/process/BremsstrahlungProcess.hh
@@ -56,7 +56,7 @@ class BremsstrahlungProcess : public Process
     StepLimitBuilders step_limits(Applicability range) const final;
 
     //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    bool use_integral_xs() const final { return options_.use_integral_xs; }
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/ComptonProcess.cc
+++ b/src/celeritas/em/process/ComptonProcess.cc
@@ -47,6 +47,15 @@ auto ComptonProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
+ * Whether to use the integral method to sample discrete interaction length.
+ */
+bool ComptonProcess::use_integral_xs() const
+{
+    return false;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Name of the process.
  */
 std::string ComptonProcess::label() const

--- a/src/celeritas/em/process/ComptonProcess.cc
+++ b/src/celeritas/em/process/ComptonProcess.cc
@@ -47,15 +47,6 @@ auto ComptonProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool ComptonProcess::use_integral_xs() const
-{
-    return false;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Name of the process.
  */
 std::string ComptonProcess::label() const

--- a/src/celeritas/em/process/ComptonProcess.cc
+++ b/src/celeritas/em/process/ComptonProcess.cc
@@ -47,11 +47,11 @@ auto ComptonProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Type of process.
+ * Whether to use the integral method to sample discrete interaction length.
  */
-ProcessType ComptonProcess::type() const
+bool ComptonProcess::use_integral_xs() const
 {
-    return ProcessType::electromagnetic_discrete;
+    return false;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/ComptonProcess.hh
+++ b/src/celeritas/em/process/ComptonProcess.hh
@@ -38,8 +38,8 @@ class ComptonProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applic) const final;
 
-    //! Type of process
-    ProcessType type() const final;
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/ComptonProcess.hh
+++ b/src/celeritas/em/process/ComptonProcess.hh
@@ -39,7 +39,7 @@ class ComptonProcess : public Process
     StepLimitBuilders step_limits(Applicability applic) const final;
 
     //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    bool use_integral_xs() const final { return false; }
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/ComptonProcess.hh
+++ b/src/celeritas/em/process/ComptonProcess.hh
@@ -38,8 +38,8 @@ class ComptonProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applic) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    //! Get the options for the process
+    const Options& options() const final { return options_; }
 
     // Name of the process
     std::string label() const final;
@@ -47,6 +47,7 @@ class ComptonProcess : public Process
   private:
     SPConstParticles       particles_;
     ImportedProcessAdapter imported_;
+    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/ComptonProcess.hh
+++ b/src/celeritas/em/process/ComptonProcess.hh
@@ -38,8 +38,8 @@ class ComptonProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applic) const final;
 
-    //! Get the options for the process
-    const Options& options() const final { return options_; }
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;
@@ -47,7 +47,6 @@ class ComptonProcess : public Process
   private:
     SPConstParticles       particles_;
     ImportedProcessAdapter imported_;
-    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EIonizationProcess.cc
+++ b/src/celeritas/em/process/EIonizationProcess.cc
@@ -19,12 +19,14 @@ namespace celeritas
  * Construct process from host data.
  */
 EIonizationProcess::EIonizationProcess(SPConstParticles particles,
-                                       SPConstImported  process_data)
+                                       SPConstImported  process_data,
+                                       Options          options)
     : particles_(std::move(particles))
     , imported_(process_data,
                 particles_,
                 ImportProcessClass::e_ioni,
                 {pdg::electron(), pdg::positron()})
+    , options_(options)
 {
     CELER_EXPECT(particles_);
 }
@@ -46,6 +48,15 @@ auto EIonizationProcess::step_limits(Applicability applicability) const
     -> StepLimitBuilders
 {
     return imported_.step_limits(std::move(applicability));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether to use the integral method to sample discrete interaction length.
+ */
+bool EIonizationProcess::use_integral_xs() const
+{
+    return options_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EIonizationProcess.cc
+++ b/src/celeritas/em/process/EIonizationProcess.cc
@@ -52,15 +52,6 @@ auto EIonizationProcess::step_limits(Applicability applicability) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool EIonizationProcess::use_integral_xs() const
-{
-    return options_.use_integral_xs;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Name of the process.
  */
 std::string EIonizationProcess::label() const

--- a/src/celeritas/em/process/EIonizationProcess.cc
+++ b/src/celeritas/em/process/EIonizationProcess.cc
@@ -19,12 +19,14 @@ namespace celeritas
  * Construct process from host data.
  */
 EIonizationProcess::EIonizationProcess(SPConstParticles particles,
-                                       SPConstImported  process_data)
+                                       SPConstImported  process_data,
+                                       Options          options)
     : particles_(std::move(particles))
     , imported_(process_data,
                 particles_,
                 ImportProcessClass::e_ioni,
                 {pdg::electron(), pdg::positron()})
+    , options_(options)
 {
     CELER_EXPECT(particles_);
 }
@@ -50,11 +52,11 @@ auto EIonizationProcess::step_limits(Applicability applicability) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Type of process.
+ * Whether to use the integral method to sample discrete interaction length.
  */
-ProcessType EIonizationProcess::type() const
+bool EIonizationProcess::use_integral_xs() const
 {
-    return ProcessType::electromagnetic_dedx;
+    return options_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EIonizationProcess.cc
+++ b/src/celeritas/em/process/EIonizationProcess.cc
@@ -19,14 +19,12 @@ namespace celeritas
  * Construct process from host data.
  */
 EIonizationProcess::EIonizationProcess(SPConstParticles particles,
-                                       SPConstImported  process_data,
-                                       Options          options)
+                                       SPConstImported  process_data)
     : particles_(std::move(particles))
     , imported_(process_data,
                 particles_,
                 ImportProcessClass::e_ioni,
                 {pdg::electron(), pdg::positron()})
-    , options_(options)
 {
     CELER_EXPECT(particles_);
 }
@@ -48,15 +46,6 @@ auto EIonizationProcess::step_limits(Applicability applicability) const
     -> StepLimitBuilders
 {
     return imported_.step_limits(std::move(applicability));
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool EIonizationProcess::use_integral_xs() const
-{
-    return options_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EIonizationProcess.hh
+++ b/src/celeritas/em/process/EIonizationProcess.hh
@@ -28,10 +28,19 @@ class EIonizationProcess : public Process
     using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
     //!@}
 
+    // Options for electron ionization
+    // TODO: update options based on ImportData
+    struct Options
+    {
+        bool use_integral_xs{true}; //!> Use integral method for sampling
+                                    //! discrete interaction length
+    };
+
   public:
     // Construct with imported data
     EIonizationProcess(SPConstParticles particles,
-                       SPConstImported  process_data);
+                       SPConstImported  process_data,
+                       Options          options);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -39,8 +48,8 @@ class EIonizationProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applicability) const final;
 
-    //! Type of process
-    ProcessType type() const final;
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;
@@ -48,6 +57,7 @@ class EIonizationProcess : public Process
   private:
     SPConstParticles       particles_;
     ImportedProcessAdapter imported_;
+    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EIonizationProcess.hh
+++ b/src/celeritas/em/process/EIonizationProcess.hh
@@ -28,8 +28,7 @@ class EIonizationProcess : public Process
     using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
     //!@}
 
-    // Options for electron ionization
-    // TODO: update options based on ImportData
+    // Options for electron and positron ionization
     struct Options
     {
         bool use_integral_xs{true}; //!> Use integral method for sampling
@@ -49,7 +48,7 @@ class EIonizationProcess : public Process
     StepLimitBuilders step_limits(Applicability applicability) const final;
 
     //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    bool use_integral_xs() const final { return options_.use_integral_xs; }
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/EIonizationProcess.hh
+++ b/src/celeritas/em/process/EIonizationProcess.hh
@@ -28,15 +28,19 @@ class EIonizationProcess : public Process
     using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
     //!@}
 
-    struct EIonizationOptions : Options
+    // Options for electron ionization
+    // TODO: update options based on ImportData
+    struct Options
     {
-        EIonizationOptions() : Options(true) {}
+        bool use_integral_xs{true}; //!> Use integral method for sampling
+                                    //! discrete interaction length
     };
 
   public:
     // Construct with imported data
     EIonizationProcess(SPConstParticles particles,
-                       SPConstImported  process_data);
+                       SPConstImported  process_data,
+                       Options          options);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -44,8 +48,8 @@ class EIonizationProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applicability) const final;
 
-    //! Get the options for the process
-    const Options& options() const final { return options_; }
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;
@@ -53,7 +57,7 @@ class EIonizationProcess : public Process
   private:
     SPConstParticles       particles_;
     ImportedProcessAdapter imported_;
-    EIonizationOptions     options_;
+    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EIonizationProcess.hh
+++ b/src/celeritas/em/process/EIonizationProcess.hh
@@ -28,19 +28,15 @@ class EIonizationProcess : public Process
     using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
     //!@}
 
-    // Options for electron ionization
-    // TODO: update options based on ImportData
-    struct Options
+    struct EIonizationOptions : Options
     {
-        bool use_integral_xs{true}; //!> Use integral method for sampling
-                                    //! discrete interaction length
+        EIonizationOptions() : Options(true) {}
     };
 
   public:
     // Construct with imported data
     EIonizationProcess(SPConstParticles particles,
-                       SPConstImported  process_data,
-                       Options          options);
+                       SPConstImported  process_data);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -48,8 +44,8 @@ class EIonizationProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applicability) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    //! Get the options for the process
+    const Options& options() const final { return options_; }
 
     // Name of the process
     std::string label() const final;
@@ -57,7 +53,7 @@ class EIonizationProcess : public Process
   private:
     SPConstParticles       particles_;
     ImportedProcessAdapter imported_;
-    Options                options_;
+    EIonizationOptions     options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.cc
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.cc
@@ -19,9 +19,11 @@ namespace celeritas
 /*!
  * Construct from host data.
  */
-EPlusAnnihilationProcess::EPlusAnnihilationProcess(SPConstParticles particles)
+EPlusAnnihilationProcess::EPlusAnnihilationProcess(SPConstParticles particles,
+                                                   Options          options)
     : particles_(std::move(particles))
     , positron_id_(particles_->find(pdg::positron()))
+    , options_(options)
 {
     CELER_EXPECT(particles_);
     CELER_ENSURE(positron_id_);
@@ -50,6 +52,15 @@ auto EPlusAnnihilationProcess::step_limits(Applicability range) const
     builders[ValueGridType::macro_xs] = std::make_unique<ValueGridOTFBuilder>();
 
     return builders;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether to use the integral method to sample discrete interaction length.
+ */
+bool EPlusAnnihilationProcess::use_integral_xs() const
+{
+    return options_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.cc
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.cc
@@ -56,15 +56,6 @@ auto EPlusAnnihilationProcess::step_limits(Applicability range) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool EPlusAnnihilationProcess::use_integral_xs() const
-{
-    return options_.use_integral_xs;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Name of the process.
  */
 std::string EPlusAnnihilationProcess::label() const

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.cc
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.cc
@@ -19,11 +19,9 @@ namespace celeritas
 /*!
  * Construct from host data.
  */
-EPlusAnnihilationProcess::EPlusAnnihilationProcess(SPConstParticles particles,
-                                                   Options          options)
+EPlusAnnihilationProcess::EPlusAnnihilationProcess(SPConstParticles particles)
     : particles_(std::move(particles))
     , positron_id_(particles_->find(pdg::positron()))
-    , options_(options)
 {
     CELER_EXPECT(particles_);
     CELER_ENSURE(positron_id_);
@@ -52,15 +50,6 @@ auto EPlusAnnihilationProcess::step_limits(Applicability range) const
     builders[ValueGridType::macro_xs] = std::make_unique<ValueGridOTFBuilder>();
 
     return builders;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool EPlusAnnihilationProcess::use_integral_xs() const
-{
-    return options_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.cc
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.cc
@@ -19,9 +19,11 @@ namespace celeritas
 /*!
  * Construct from host data.
  */
-EPlusAnnihilationProcess::EPlusAnnihilationProcess(SPConstParticles particles)
+EPlusAnnihilationProcess::EPlusAnnihilationProcess(SPConstParticles particles,
+                                                   Options          options)
     : particles_(std::move(particles))
     , positron_id_(particles_->find(pdg::positron()))
+    , options_(options)
 {
     CELER_EXPECT(particles_);
     CELER_ENSURE(positron_id_);
@@ -54,11 +56,11 @@ auto EPlusAnnihilationProcess::step_limits(Applicability range) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Type of process.
+ * Whether to use the integral method to sample discrete interaction length.
  */
-ProcessType EPlusAnnihilationProcess::type() const
+bool EPlusAnnihilationProcess::use_integral_xs() const
 {
-    return ProcessType::electromagnetic_discrete;
+    return options_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.hh
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.hh
@@ -26,18 +26,14 @@ class EPlusAnnihilationProcess final : public Process
     using SPConstParticles = std::shared_ptr<const ParticleParams>;
     //!@}
 
-    // Options for electron-positron annihilation
-    // TODO: update options based on ImportData
-    struct Options
+    struct EPlusAnnihilationOptions : Options
     {
-        bool use_integral_xs{true}; //!> Use integral method for sampling
-                                    //! discrete interaction length
+        EPlusAnnihilationOptions() : Options(true) {}
     };
 
   public:
     // Construct from particle data
-    explicit EPlusAnnihilationProcess(SPConstParticles particles,
-                                      Options          options);
+    explicit EPlusAnnihilationProcess(SPConstParticles particles);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -45,16 +41,16 @@ class EPlusAnnihilationProcess final : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    //! Get the options for the process
+    const Options& options() const final { return options_; }
 
     // Name of the process
     std::string label() const final;
 
   private:
-    SPConstParticles particles_;
-    ParticleId       positron_id_;
-    Options          options_;
+    SPConstParticles         particles_;
+    ParticleId               positron_id_;
+    EPlusAnnihilationOptions options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.hh
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.hh
@@ -26,14 +26,18 @@ class EPlusAnnihilationProcess final : public Process
     using SPConstParticles = std::shared_ptr<const ParticleParams>;
     //!@}
 
-    struct EPlusAnnihilationOptions : Options
+    // Options for electron-positron annihilation
+    // TODO: update options based on ImportData
+    struct Options
     {
-        EPlusAnnihilationOptions() : Options(true) {}
+        bool use_integral_xs{true}; //!> Use integral method for sampling
+                                    //! discrete interaction length
     };
 
   public:
     // Construct from particle data
-    explicit EPlusAnnihilationProcess(SPConstParticles particles);
+    explicit EPlusAnnihilationProcess(SPConstParticles particles,
+                                      Options          options);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -41,16 +45,16 @@ class EPlusAnnihilationProcess final : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Get the options for the process
-    const Options& options() const final { return options_; }
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;
 
   private:
-    SPConstParticles         particles_;
-    ParticleId               positron_id_;
-    EPlusAnnihilationOptions options_;
+    SPConstParticles particles_;
+    ParticleId       positron_id_;
+    Options          options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.hh
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.hh
@@ -26,9 +26,18 @@ class EPlusAnnihilationProcess final : public Process
     using SPConstParticles = std::shared_ptr<const ParticleParams>;
     //!@}
 
+    // Options for electron-positron annihilation
+    // TODO: update options based on ImportData
+    struct Options
+    {
+        bool use_integral_xs{true}; //!> Use integral method for sampling
+                                    //! discrete interaction length
+    };
+
   public:
     // Construct from particle data
-    explicit EPlusAnnihilationProcess(SPConstParticles particles);
+    explicit EPlusAnnihilationProcess(SPConstParticles particles,
+                                      Options          options);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -36,8 +45,8 @@ class EPlusAnnihilationProcess final : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Type of process
-    ProcessType type() const final;
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;
@@ -45,6 +54,7 @@ class EPlusAnnihilationProcess final : public Process
   private:
     SPConstParticles particles_;
     ParticleId       positron_id_;
+    Options          options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.hh
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.hh
@@ -27,7 +27,6 @@ class EPlusAnnihilationProcess final : public Process
     //!@}
 
     // Options for electron-positron annihilation
-    // TODO: update options based on ImportData
     struct Options
     {
         bool use_integral_xs{true}; //!> Use integral method for sampling
@@ -46,7 +45,7 @@ class EPlusAnnihilationProcess final : public Process
     StepLimitBuilders step_limits(Applicability range) const final;
 
     //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    bool use_integral_xs() const final { return options_.use_integral_xs; }
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/GammaConversionProcess.cc
+++ b/src/celeritas/em/process/GammaConversionProcess.cc
@@ -56,11 +56,11 @@ auto GammaConversionProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Type of process.
+ * Whether to use the integral method to sample discrete interaction length.
  */
-ProcessType GammaConversionProcess::type() const
+bool GammaConversionProcess::use_integral_xs() const
 {
-    return ProcessType::electromagnetic_discrete;
+    return false;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/GammaConversionProcess.cc
+++ b/src/celeritas/em/process/GammaConversionProcess.cc
@@ -56,15 +56,6 @@ auto GammaConversionProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool GammaConversionProcess::use_integral_xs() const
-{
-    return false;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Name of the process.
  */
 std::string GammaConversionProcess::label() const

--- a/src/celeritas/em/process/GammaConversionProcess.cc
+++ b/src/celeritas/em/process/GammaConversionProcess.cc
@@ -22,7 +22,7 @@ namespace celeritas
  */
 GammaConversionProcess::GammaConversionProcess(SPConstParticles particles,
                                                SPConstImported  process_data,
-                                               GammaConversionOptions options)
+                                               Options          options)
     : particles_(std::move(particles))
     , imported_(process_data,
                 particles_,
@@ -52,6 +52,15 @@ auto GammaConversionProcess::step_limits(Applicability applic) const
     -> StepLimitBuilders
 {
     return imported_.step_limits(std::move(applic));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether to use the integral method to sample discrete interaction length.
+ */
+bool GammaConversionProcess::use_integral_xs() const
+{
+    return false;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/GammaConversionProcess.cc
+++ b/src/celeritas/em/process/GammaConversionProcess.cc
@@ -22,7 +22,7 @@ namespace celeritas
  */
 GammaConversionProcess::GammaConversionProcess(SPConstParticles particles,
                                                SPConstImported  process_data,
-                                               Options          options)
+                                               GammaConversionOptions options)
     : particles_(std::move(particles))
     , imported_(process_data,
                 particles_,
@@ -52,15 +52,6 @@ auto GammaConversionProcess::step_limits(Applicability applic) const
     -> StepLimitBuilders
 {
     return imported_.step_limits(std::move(applic));
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool GammaConversionProcess::use_integral_xs() const
-{
-    return false;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/GammaConversionProcess.hh
+++ b/src/celeritas/em/process/GammaConversionProcess.hh
@@ -18,6 +18,9 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Conversion of gammas to electrons and positrons.
+ *
+ * Input options are:
+ * - \c enable_lpm: Account for LPM effect at very high energies
  */
 class GammaConversionProcess : public Process
 {
@@ -28,17 +31,18 @@ class GammaConversionProcess : public Process
     using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
     //!@}
 
-    // Options for pair production
-    struct Options
+    struct GammaConversionOptions : Options
     {
-        bool enable_lpm{true}; //!< Account for LPM effect at high energies
+        bool enable_lpm{true};
+
+        GammaConversionOptions() : Options(true) {}
     };
 
   public:
     // Construct from particle data
-    GammaConversionProcess(SPConstParticles particles,
-                           SPConstImported  process_data,
-                           Options          options);
+    GammaConversionProcess(SPConstParticles       particles,
+                           SPConstImported        process_data,
+                           GammaConversionOptions options);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -46,8 +50,8 @@ class GammaConversionProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applic) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    //! Get the options for the process
+    const GammaConversionOptions& options() const final { return options_; }
 
     // Name of the process
     std::string label() const final;
@@ -55,7 +59,7 @@ class GammaConversionProcess : public Process
   private:
     SPConstParticles       particles_;
     ImportedProcessAdapter imported_;
-    Options                options_;
+    GammaConversionOptions options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/GammaConversionProcess.hh
+++ b/src/celeritas/em/process/GammaConversionProcess.hh
@@ -46,8 +46,8 @@ class GammaConversionProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applic) const final;
 
-    //! Type of process
-    ProcessType type() const final;
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/GammaConversionProcess.hh
+++ b/src/celeritas/em/process/GammaConversionProcess.hh
@@ -47,7 +47,7 @@ class GammaConversionProcess : public Process
     StepLimitBuilders step_limits(Applicability applic) const final;
 
     //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    bool use_integral_xs() const final { return false; }
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/GammaConversionProcess.hh
+++ b/src/celeritas/em/process/GammaConversionProcess.hh
@@ -18,9 +18,6 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Conversion of gammas to electrons and positrons.
- *
- * Input options are:
- * - \c enable_lpm: Account for LPM effect at very high energies
  */
 class GammaConversionProcess : public Process
 {
@@ -31,18 +28,17 @@ class GammaConversionProcess : public Process
     using SPConstImported  = std::shared_ptr<const ImportedProcesses>;
     //!@}
 
-    struct GammaConversionOptions : Options
+    // Options for pair production
+    struct Options
     {
-        bool enable_lpm{true};
-
-        GammaConversionOptions() : Options(true) {}
+        bool enable_lpm{true}; //!< Account for LPM effect at high energies
     };
 
   public:
     // Construct from particle data
-    GammaConversionProcess(SPConstParticles       particles,
-                           SPConstImported        process_data,
-                           GammaConversionOptions options);
+    GammaConversionProcess(SPConstParticles particles,
+                           SPConstImported  process_data,
+                           Options          options);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -50,8 +46,8 @@ class GammaConversionProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applic) const final;
 
-    //! Get the options for the process
-    const GammaConversionOptions& options() const final { return options_; }
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;
@@ -59,7 +55,7 @@ class GammaConversionProcess : public Process
   private:
     SPConstParticles       particles_;
     ImportedProcessAdapter imported_;
-    GammaConversionOptions options_;
+    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/MultipleScatteringProcess.cc
+++ b/src/celeritas/em/process/MultipleScatteringProcess.cc
@@ -52,11 +52,11 @@ auto MultipleScatteringProcess::step_limits(Applicability applicability) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Type of process.
+ * Whether to use the integral method to sample discrete interaction length.
  */
-ProcessType MultipleScatteringProcess::type() const
+bool MultipleScatteringProcess::use_integral_xs() const
 {
-    return ProcessType::electromagnetic_msc;
+    return false;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/MultipleScatteringProcess.cc
+++ b/src/celeritas/em/process/MultipleScatteringProcess.cc
@@ -52,15 +52,6 @@ auto MultipleScatteringProcess::step_limits(Applicability applicability) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool MultipleScatteringProcess::use_integral_xs() const
-{
-    return false;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Name of the process.
  */
 std::string MultipleScatteringProcess::label() const

--- a/src/celeritas/em/process/MultipleScatteringProcess.cc
+++ b/src/celeritas/em/process/MultipleScatteringProcess.cc
@@ -52,6 +52,15 @@ auto MultipleScatteringProcess::step_limits(Applicability applicability) const
 
 //---------------------------------------------------------------------------//
 /*!
+ * Whether to use the integral method to sample discrete interaction length.
+ */
+bool MultipleScatteringProcess::use_integral_xs() const
+{
+    return false;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Name of the process.
  */
 std::string MultipleScatteringProcess::label() const

--- a/src/celeritas/em/process/MultipleScatteringProcess.hh
+++ b/src/celeritas/em/process/MultipleScatteringProcess.hh
@@ -41,7 +41,7 @@ class MultipleScatteringProcess : public Process
     StepLimitBuilders step_limits(Applicability applicability) const final;
 
     //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    bool use_integral_xs() const final { return false; }
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/MultipleScatteringProcess.hh
+++ b/src/celeritas/em/process/MultipleScatteringProcess.hh
@@ -40,8 +40,8 @@ class MultipleScatteringProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applicability) const final;
 
-    //! Type of process
-    ProcessType type() const final;
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/MultipleScatteringProcess.hh
+++ b/src/celeritas/em/process/MultipleScatteringProcess.hh
@@ -40,8 +40,8 @@ class MultipleScatteringProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applicability) const final;
 
-    //! Get the options for the process
-    const Options& options() const final { return options_; }
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;
@@ -50,7 +50,6 @@ class MultipleScatteringProcess : public Process
     SPConstParticles       particles_;
     SPConstMaterials       materials_;
     ImportedProcessAdapter imported_;
-    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/MultipleScatteringProcess.hh
+++ b/src/celeritas/em/process/MultipleScatteringProcess.hh
@@ -40,8 +40,8 @@ class MultipleScatteringProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applicability) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    //! Get the options for the process
+    const Options& options() const final { return options_; }
 
     // Name of the process
     std::string label() const final;
@@ -50,6 +50,7 @@ class MultipleScatteringProcess : public Process
     SPConstParticles       particles_;
     SPConstMaterials       materials_;
     ImportedProcessAdapter imported_;
+    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/PhotoelectricProcess.cc
+++ b/src/celeritas/em/process/PhotoelectricProcess.cc
@@ -59,6 +59,15 @@ auto PhotoelectricProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
+ * Whether to use the integral method to sample discrete interaction length.
+ */
+bool PhotoelectricProcess::use_integral_xs() const
+{
+    return false;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Name of the process.
  */
 std::string PhotoelectricProcess::label() const

--- a/src/celeritas/em/process/PhotoelectricProcess.cc
+++ b/src/celeritas/em/process/PhotoelectricProcess.cc
@@ -59,15 +59,6 @@ auto PhotoelectricProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool PhotoelectricProcess::use_integral_xs() const
-{
-    return false;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Name of the process.
  */
 std::string PhotoelectricProcess::label() const

--- a/src/celeritas/em/process/PhotoelectricProcess.cc
+++ b/src/celeritas/em/process/PhotoelectricProcess.cc
@@ -59,11 +59,11 @@ auto PhotoelectricProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Type of process.
+ * Whether to use the integral method to sample discrete interaction length.
  */
-ProcessType PhotoelectricProcess::type() const
+bool PhotoelectricProcess::use_integral_xs() const
 {
-    return ProcessType::electromagnetic_discrete;
+    return false;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/PhotoelectricProcess.hh
+++ b/src/celeritas/em/process/PhotoelectricProcess.hh
@@ -42,8 +42,8 @@ class PhotoelectricProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    //! Get the options for the process
+    const Options& options() const final { return options_; }
 
     // Name of the process
     std::string label() const final;
@@ -52,6 +52,7 @@ class PhotoelectricProcess : public Process
     SPConstParticles       particles_;
     SPConstMaterials       materials_;
     ImportedProcessAdapter imported_;
+    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/PhotoelectricProcess.hh
+++ b/src/celeritas/em/process/PhotoelectricProcess.hh
@@ -42,8 +42,8 @@ class PhotoelectricProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Type of process
-    ProcessType type() const final;
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/PhotoelectricProcess.hh
+++ b/src/celeritas/em/process/PhotoelectricProcess.hh
@@ -43,7 +43,7 @@ class PhotoelectricProcess : public Process
     StepLimitBuilders step_limits(Applicability range) const final;
 
     //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    bool use_integral_xs() const final { return false; }
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/PhotoelectricProcess.hh
+++ b/src/celeritas/em/process/PhotoelectricProcess.hh
@@ -42,8 +42,8 @@ class PhotoelectricProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Get the options for the process
-    const Options& options() const final { return options_; }
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;
@@ -52,7 +52,6 @@ class PhotoelectricProcess : public Process
     SPConstParticles       particles_;
     SPConstMaterials       materials_;
     ImportedProcessAdapter imported_;
-    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/RayleighProcess.cc
+++ b/src/celeritas/em/process/RayleighProcess.cc
@@ -51,11 +51,11 @@ auto RayleighProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Type of process.
+ * Whether to use the integral method to sample discrete interaction length.
  */
-ProcessType RayleighProcess::type() const
+bool RayleighProcess::use_integral_xs() const
 {
-    return ProcessType::electromagnetic_discrete;
+    return false;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/RayleighProcess.cc
+++ b/src/celeritas/em/process/RayleighProcess.cc
@@ -51,6 +51,15 @@ auto RayleighProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
+ * Whether to use the integral method to sample discrete interaction length.
+ */
+bool RayleighProcess::use_integral_xs() const
+{
+    return false;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Name of the process.
  */
 std::string RayleighProcess::label() const

--- a/src/celeritas/em/process/RayleighProcess.cc
+++ b/src/celeritas/em/process/RayleighProcess.cc
@@ -51,15 +51,6 @@ auto RayleighProcess::step_limits(Applicability applic) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to use the integral method to sample discrete interaction length.
- */
-bool RayleighProcess::use_integral_xs() const
-{
-    return false;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Name of the process.
  */
 std::string RayleighProcess::label() const

--- a/src/celeritas/em/process/RayleighProcess.hh
+++ b/src/celeritas/em/process/RayleighProcess.hh
@@ -42,8 +42,8 @@ class RayleighProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Type of process
-    ProcessType type() const final;
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/em/process/RayleighProcess.hh
+++ b/src/celeritas/em/process/RayleighProcess.hh
@@ -42,8 +42,8 @@ class RayleighProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Get the options for the process
-    const Options& options() const final { return options_; }
+    //! Whether to use the integral method to sample interaction length
+    bool use_integral_xs() const final;
 
     // Name of the process
     std::string label() const final;
@@ -52,7 +52,6 @@ class RayleighProcess : public Process
     SPConstParticles       particles_;
     SPConstMaterials       materials_;
     ImportedProcessAdapter imported_;
-    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/RayleighProcess.hh
+++ b/src/celeritas/em/process/RayleighProcess.hh
@@ -42,8 +42,8 @@ class RayleighProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    //! Get the options for the process
+    const Options& options() const final { return options_; }
 
     // Name of the process
     std::string label() const final;
@@ -52,6 +52,7 @@ class RayleighProcess : public Process
     SPConstParticles       particles_;
     SPConstMaterials       materials_;
     ImportedProcessAdapter imported_;
+    Options                options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/RayleighProcess.hh
+++ b/src/celeritas/em/process/RayleighProcess.hh
@@ -43,7 +43,7 @@ class RayleighProcess : public Process
     StepLimitBuilders step_limits(Applicability range) const final;
 
     //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    bool use_integral_xs() const final { return false; }
 
     // Name of the process
     std::string label() const final;

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -96,13 +96,13 @@ struct ModelGroup
 
 //---------------------------------------------------------------------------//
 /*!
- * Energy loss process that uses MC integration to sample interaction length.
+ * Particle-process that uses MC integration to sample interaction length.
  *
  * This is needed for the integral approach for correctly sampling the discrete
  * interaction length after a particle loses energy along a step. An \c
  * IntegralXsProcess is stored for each particle-process. This will be "false"
- * (i.e. no energy_max assigned) if the process is not continuous-discrete or
- * if \c use_integral_xs is false.
+ * (i.e. no energy_max assigned) if the particle associated with the process
+ * does not have energy loss processes or if \c use_integral_xs is false.
  */
 struct IntegralXsProcess
 {

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -452,7 +452,7 @@ void PhysicsParams::build_xs(const MaterialParams& mats, HostValue* data) const
 
             // Energy of maximum cross section for each material
             std::vector<real_type> energy_max_xs;
-            bool                   use_integral_xs = proc.use_integral_xs();
+            bool use_integral_xs = proc.options().use_integral_xs;
             if (use_integral_xs)
             {
                 energy_max_xs.resize(mats.size());

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -452,7 +452,7 @@ void PhysicsParams::build_xs(const MaterialParams& mats, HostValue* data) const
 
             // Energy of maximum cross section for each material
             std::vector<real_type> energy_max_xs;
-            bool use_integral_xs = proc.options().use_integral_xs;
+            bool                   use_integral_xs = proc.use_integral_xs();
             if (use_integral_xs)
             {
                 energy_max_xs.resize(mats.size());

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -123,7 +123,7 @@ PhysicsParams::PhysicsParams(Input inp)
     this->build_options(inp.options, &host_data);
     this->build_fluct(inp.options, *inp.materials, *inp.particles, &host_data);
     this->build_ids(*inp.particles, &host_data);
-    this->build_xs(*inp.materials, &host_data);
+    this->build_xs(inp.options, *inp.materials, &host_data);
     this->build_model_xs(*inp.materials, &host_data);
 
     // Add step limiter if being used (TODO: remove this hack from physics)
@@ -391,7 +391,9 @@ void PhysicsParams::build_ids(const ParticleParams& particles,
 /*!
  * Construct cross section data.
  */
-void PhysicsParams::build_xs(const MaterialParams& mats, HostValue* data) const
+void PhysicsParams::build_xs(const Options&        opts,
+                             const MaterialParams& mats,
+                             HostValue*            data) const
 {
     CELER_EXPECT(*data);
 
@@ -452,7 +454,8 @@ void PhysicsParams::build_xs(const MaterialParams& mats, HostValue* data) const
 
             // Energy of maximum cross section for each material
             std::vector<real_type> energy_max_xs;
-            bool                   use_integral_xs = proc.use_integral_xs();
+            bool                   use_integral_xs = !opts.disable_integral_xs
+                                   && proc.use_integral_xs();
             if (use_integral_xs)
             {
                 energy_max_xs.resize(mats.size());

--- a/src/celeritas/phys/PhysicsParams.hh
+++ b/src/celeritas/phys/PhysicsParams.hh
@@ -46,6 +46,12 @@ class ParticleParams;
  *   energy loss.
  * - \c secondary_stack_factor: the number of secondary slots per track slot
  *   allocated.
+ * - \c disable_integral_xs: for particles with energy loss processes, the
+ *   particle energy changes over the step, so the assumption that the cross
+ *   section is constant is no longer valid. By default, many charged particle
+ *   processes use MC integration to sample the discrete interaction length
+ *   with the correct probability. Disable this integral approach for all
+ *   processes.
  * - \c enable_fluctuation: enable simulation of energy loss fluctuations.
  */
 struct PhysicsParamsOptions
@@ -56,6 +62,7 @@ struct PhysicsParamsOptions
     real_type fixed_step_limiter     = 0;
     real_type linear_loss_limit      = 0.01;
     real_type secondary_stack_factor = 3;
+    bool      disable_integral_xs    = false;
     bool      enable_fluctuation     = true;
 };
 
@@ -179,7 +186,9 @@ class PhysicsParams
     VecModel build_models(ActionManager*) const;
     void     build_options(const Options& opts, HostValue* data) const;
     void     build_ids(const ParticleParams& particles, HostValue* data) const;
-    void     build_xs(const MaterialParams& mats, HostValue* data) const;
+    void     build_xs(const Options&        opts,
+                      const MaterialParams& mats,
+                      HostValue*            data) const;
     void     build_model_xs(const MaterialParams& mats, HostValue* data) const;
     void     build_fluct(const Options&        opts,
                          const MaterialParams& mats,

--- a/src/celeritas/phys/PhysicsParams.hh
+++ b/src/celeritas/phys/PhysicsParams.hh
@@ -46,10 +46,6 @@ class ParticleParams;
  *   energy loss.
  * - \c secondary_stack_factor: the number of secondary slots per track slot
  *   allocated.
- * - \c use_integral_xs: for energy loss processes, the particle energy changes
- *   over the step, so the assumption that the cross section is constant is no
- *   longer valid. Use MC integration to sample the discrete interaction length
- *   with the correct probability.
  * - \c enable_fluctuation: enable simulation of energy loss fluctuations.
  */
 struct PhysicsParamsOptions
@@ -60,7 +56,6 @@ struct PhysicsParamsOptions
     real_type fixed_step_limiter     = 0;
     real_type linear_loss_limit      = 0.01;
     real_type secondary_stack_factor = 3;
-    bool      use_integral_xs        = true;
     bool      enable_fluctuation     = true;
 };
 
@@ -184,9 +179,7 @@ class PhysicsParams
     VecModel build_models(ActionManager*) const;
     void     build_options(const Options& opts, HostValue* data) const;
     void     build_ids(const ParticleParams& particles, HostValue* data) const;
-    void     build_xs(const Options&        opts,
-                      const MaterialParams& mats,
-                      HostValue*            data) const;
+    void     build_xs(const MaterialParams& mats, HostValue* data) const;
     void     build_model_xs(const MaterialParams& mats, HostValue* data) const;
     void     build_fluct(const Options&        opts,
                          const MaterialParams& mats,

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -92,8 +92,7 @@ calc_physics_step_limit(const MaterialTrackView& material,
             process_xs = physics.calc_xs(
                 ppid, material.make_material_view(), particle.energy());
         }
-        // Accumulate process cross section into the total cross section and
-        // save it for later
+        // Accumulate into the total cross section and save it for later
         total_macro_xs += process_xs;
         pstep.per_process_xs(ppid) = process_xs;
     }

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -92,7 +92,8 @@ calc_physics_step_limit(const MaterialTrackView& material,
             process_xs = physics.calc_xs(
                 ppid, material.make_material_view(), particle.energy());
         }
-        // Accumulate into the total cross section and save it for later
+        // Accumulate process cross section into the total cross section and
+        // save it for later
         total_macro_xs += process_xs;
         pstep.per_process_xs(ppid) = process_xs;
     }

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -79,23 +79,21 @@ calc_physics_step_limit(const MaterialTrackView& material,
     for (auto ppid : range(ParticleProcessId{physics.num_particle_processes()}))
     {
         real_type process_xs = 0;
-        if (auto model_id = physics.hardwired_model(ppid, particle.energy()))
+        if (const auto& process = physics.integral_xs_process(ppid))
         {
-            // Calculate macroscopic cross section on the fly for special
-            // hardwired processes.
-            auto material_view = material.make_material_view();
-            process_xs         = physics.calc_xs_otf(
-                model_id, material_view, particle.energy());
-            total_macro_xs += process_xs;
+            // If the integral approach is used and this particle has an energy
+            // loss process, estimate the maximum cross section over the step
+            process_xs = physics.calc_max_xs(
+                process, ppid, material.make_material_view(), particle.energy());
         }
-        else if (auto grid_id = physics.value_grid(VGT::macro_xs, ppid))
+        else
         {
-            // Calculate macroscopic cross section for this process, then
-            // accumulate it into the total cross section and save the cross
-            // section for later.
-            process_xs = physics.calc_xs(ppid, grid_id, particle.energy());
-            total_macro_xs += process_xs;
+            // Calculate the macroscopic cross section for this process
+            process_xs = physics.calc_xs(
+                ppid, material.make_material_view(), particle.energy());
         }
+        // Accumulate into the total cross section and save it for later
+        total_macro_xs += process_xs;
         pstep.per_process_xs(ppid) = process_xs;
     }
     pstep.macro_xs(total_macro_xs);
@@ -316,19 +314,12 @@ select_discrete_interaction(const MaterialView&      material,
         ParticleProcessId{physics.num_particle_processes()},
         pstep.macro_xs())(rng);
 
-    // Determine if the discrete interaction occurs for energy loss
-    // processes
-    if (physics.use_integral_xs(ppid))
+    // Determine if the discrete interaction occurs for particles with energy
+    // loss processes
+    if (physics.integral_xs_process(ppid))
     {
-        // This is an energy loss process that was sampled for a
-        // discrete interaction, so it will have macro xs tables
-        auto grid_id = physics.value_grid(ValueGridType::macro_xs, ppid);
-        CELER_ASSERT(grid_id);
-
-        // Recalculate the cross section at the post-step energy \f$
-        // E_1 \f$
-        auto      calc_xs = physics.make_calculator<XsCalculator>(grid_id);
-        real_type xs      = calc_xs(particle.energy());
+        // Recalculate the cross section at the post-step energy \f$ E_1 \f$
+        real_type xs = physics.calc_xs(ppid, material, particle.energy());
 
         // The discrete interaction occurs with probability \f$ \sigma(E_1) /
         // \sigma_{\max} \f$. Note that it's possible for \f$ \sigma(E_1) \f$

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -97,7 +97,7 @@ class PhysicsTrackView
                                             const MaterialView& material,
                                             Energy              energy) const;
 
-    // Estimate maximum macroscopic cross section for the process over the step
+    // Estimate maximum macroscopic cross section over the steps
     inline CELER_FUNCTION real_type calc_max_xs(const IntegralXsProcess& process,
                                                 ParticleProcessId        ppid,
                                                 const MaterialView& material,
@@ -348,6 +348,7 @@ CELER_FUNCTION real_type PhysicsTrackView::calc_xs(ParticleProcessId   ppid,
                                                    Energy energy) const
 {
     real_type result = 0;
+
     if (auto model_id = this->hardwired_model(ppid, energy))
     {
         // Calculate macroscopic cross section on the fly for special
@@ -371,6 +372,7 @@ CELER_FUNCTION real_type PhysicsTrackView::calc_xs(ParticleProcessId   ppid,
         auto calc_xs = this->make_calculator<XsCalculator>(grid_id);
         result       = calc_xs(energy);
     }
+
     CELER_ENSURE(result >= 0);
     return result;
 }

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -97,7 +97,7 @@ class PhysicsTrackView
                                             const MaterialView& material,
                                             Energy              energy) const;
 
-    // Estimate maximum macroscopic cross section over the steps
+    // Estimate maximum macroscopic cross section for the process over the step
     inline CELER_FUNCTION real_type calc_max_xs(const IntegralXsProcess& process,
                                                 ParticleProcessId        ppid,
                                                 const MaterialView& material,
@@ -348,7 +348,6 @@ CELER_FUNCTION real_type PhysicsTrackView::calc_xs(ParticleProcessId   ppid,
                                                    Energy energy) const
 {
     real_type result = 0;
-
     if (auto model_id = this->hardwired_model(ppid, energy))
     {
         // Calculate macroscopic cross section on the fly for special
@@ -372,7 +371,6 @@ CELER_FUNCTION real_type PhysicsTrackView::calc_xs(ParticleProcessId   ppid,
         auto calc_xs = this->make_calculator<XsCalculator>(grid_id);
         result       = calc_xs(energy);
     }
-
     CELER_ENSURE(result >= 0);
     return result;
 }

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -97,7 +97,7 @@ class PhysicsTrackView
                                             const MaterialView& material,
                                             Energy              energy) const;
 
-    // Estimate maximum macroscopic cross section over the steps
+    // Estimate maximum macroscopic cross section for the process over the step
     inline CELER_FUNCTION real_type calc_max_xs(const IntegralXsProcess& process,
                                                 ParticleProcessId        ppid,
                                                 const MaterialView& material,

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -88,16 +88,20 @@ class PhysicsTrackView
     inline CELER_FUNCTION ValueGridId value_grid(ValueGridType table,
                                                  ParticleProcessId) const;
 
-    // Whether to use integral approach to sample the discrete interaction
-    inline CELER_FUNCTION bool use_integral_xs(ParticleProcessId ppid) const;
-
-    // Energy corresponding to the maximum cross section for the material
-    inline CELER_FUNCTION real_type energy_max_xs(ParticleProcessId ppid) const;
+    // Get data for processes that use the integral approach
+    inline CELER_FUNCTION const IntegralXsProcess&
+    integral_xs_process(ParticleProcessId ppid) const;
 
     // Calculate macroscopic cross section for the process
-    inline CELER_FUNCTION real_type calc_xs(ParticleProcessId ppid,
-                                            ValueGridId       grid_id,
-                                            Energy            energy) const;
+    inline CELER_FUNCTION real_type calc_xs(ParticleProcessId   ppid,
+                                            const MaterialView& material,
+                                            Energy              energy) const;
+
+    // Estimate maximum macroscopic cross section over the steps
+    inline CELER_FUNCTION real_type calc_max_xs(const IntegralXsProcess& process,
+                                                ParticleProcessId        ppid,
+                                                const MaterialView& material,
+                                                Energy energy) const;
 
     // Models that apply to the given process ID
     inline CELER_FUNCTION
@@ -137,11 +141,6 @@ class PhysicsTrackView
     // Urban multiple scattering data
     inline CELER_FUNCTION const UrbanMscRef& urban_data() const;
 
-    // Calculate macroscopic cross section on the fly for the given model
-    inline CELER_FUNCTION real_type calc_xs_otf(ModelId             model,
-                                                const MaterialView& material,
-                                                Energy energy) const;
-
     // Number of particle types
     inline CELER_FUNCTION size_type num_particles() const;
 
@@ -150,12 +149,6 @@ class PhysicsTrackView
     inline CELER_FUNCTION T make_calculator(ValueGridId) const;
 
     //// HACKS ////
-
-    // Process ID for photoelectric effect
-    inline CELER_FUNCTION ProcessId photoelectric_process_id() const;
-
-    // Process ID for positron annihilation
-    inline CELER_FUNCTION ProcessId eplusgg_process_id() const;
 
     // Get hardwired model, null if not present
     inline CELER_FUNCTION ModelId hardwired_model(ParticleProcessId ppid,
@@ -314,12 +307,12 @@ CELER_FUNCTION auto PhysicsTrackView::value_grid(ValueGridType     table_type,
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to use integral approach to sample the discrete interaction.
+ * Get data for processes that use the integral approach.
  *
- * For energy loss processes, the particle will have a different energy at the
- * pre- and post-step points. This means the assumption that the cross section
- * is constant along the step is no longer valid. Instead, Monte Carlo
- * integration can be used to sample the interaction for the discrete
+ * Particles that have energy loss processes will have a different energy at
+ * the pre- and post-step points. This means the assumption that the cross
+ * section is constant along the step is no longer valid. Instead, Monte Carlo
+ * integration can be used to sample the interaction length for the discrete
  * process with the correct probability from the exact distribution,
  * \f[
      p = 1 - \exp \left( -\int_{E_0}^{E_1} n \sigma(E) \dif s \right),
@@ -338,73 +331,86 @@ CELER_FUNCTION auto PhysicsTrackView::value_grid(ValueGridType     table_type,
  *
  * See section 7.4 of the Geant4 Physics Reference (release 10.6) for details.
  */
-CELER_FUNCTION bool
-PhysicsTrackView::use_integral_xs(ParticleProcessId ppid) const
+CELER_FUNCTION auto
+PhysicsTrackView::integral_xs_process(ParticleProcessId ppid) const
+    -> const IntegralXsProcess&
 {
     CELER_EXPECT(ppid < this->num_particle_processes());
-    return this->energy_max_xs(ppid) > 0;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Energy corresponding to the maximum cross section for the material.
- *
- * If the \c IntegralXsProcess is "true", the integral approach is used and
- * that process has both energy loss and macro xs tables. If \c
- * energy_max_xs[material] is nonzero, both of those tables are present for
- * this material.
- */
-CELER_FUNCTION real_type
-PhysicsTrackView::energy_max_xs(ParticleProcessId ppid) const
-{
-    CELER_EXPECT(ppid < this->num_particle_processes());
-
-    real_type                result = 0;
-    const IntegralXsProcess& process
-        = params_.integral_xs[this->process_group().integral_xs[ppid.get()]];
-    if (process)
-    {
-        CELER_ASSERT(material_ < process.energy_max_xs.size());
-        result = params_.reals[process.energy_max_xs[material_.get()]];
-    }
-    return result;
+    return params_.integral_xs[this->process_group().integral_xs[ppid.get()]];
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Calculate macroscopic cross section for the process.
- *
- * If this is an energy loss process, this returns the estimate of the maximum
- * cross section over the step. If the energy of the global maximum of the
- * cross section (calculated at initialization) is in the interval \f$ [\xi
- * E_0, E_0) \f$, where \f$ E_0 \f$ is the pre-step energy and \f$ \xi \f$ is
- * \c energy_fraction (defined by default as \f$ \xi = 1 - \alpha \f$, where
- * \f$ \alpha \f$ is \c scaling_fraction),
- * \f$ \sigma_{\max} \f$ is set to the global maximum.
- * Otherwise, \f$ \sigma_{\max} = \max( \sigma(E_0), \sigma(\xi E_0) ) \f$. If
- * the cross section is not monotonic in the interval \f$ [\xi E_0, E_0) \f$
- * and the interval does not contain the global maximum, the post-step cross
- * section \f$ \sigma(E_1) \f$ may be larger than \f$ \sigma_{\max} \f$.
  */
-CELER_FUNCTION real_type PhysicsTrackView::calc_xs(ParticleProcessId ppid,
-                                                   ValueGridId       grid_id,
+CELER_FUNCTION real_type PhysicsTrackView::calc_xs(ParticleProcessId   ppid,
+                                                   const MaterialView& material,
                                                    Energy energy) const
 {
-    auto calc_xs = this->make_calculator<XsCalculator>(grid_id);
+    real_type result = 0;
 
-    // Check if the integral approach is used (true if \c energy_max_xs > 0).
-    // If so, an estimate of the maximum cross section over the step is used as
-    // the macro xs for this process
-    real_type energy_max_xs = this->energy_max_xs(ppid);
-    if (energy_max_xs > 0)
+    if (auto model_id = this->hardwired_model(ppid, energy))
     {
-        real_type energy_xi = energy.value() * params_.scalars.energy_fraction;
-        if (energy_max_xs >= energy_xi && energy_max_xs < energy.value())
-            return calc_xs(Energy{energy_max_xs});
-        return max(calc_xs(energy), calc_xs(Energy{energy_xi}));
+        // Calculate macroscopic cross section on the fly for special
+        // hardwired processes.
+        if (model_id == params_.hardwired.livermore_pe)
+        {
+            auto calc_xs = LivermorePEMacroXsCalculator(
+                params_.hardwired.livermore_pe_data, material);
+            result = calc_xs(energy);
+        }
+        else if (model_id == params_.hardwired.eplusgg)
+        {
+            auto calc_xs = EPlusGGMacroXsCalculator(
+                params_.hardwired.eplusgg_data, material);
+            result = calc_xs(energy);
+        }
+    }
+    else if (auto grid_id = this->value_grid(ValueGridType::macro_xs, ppid))
+    {
+        // Calculate cross section from the tabulated data
+        auto calc_xs = this->make_calculator<XsCalculator>(grid_id);
+        result       = calc_xs(energy);
     }
 
-    return calc_xs(energy);
+    CELER_ENSURE(result >= 0);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Estimate maximum macroscopic cross section for the process over the step.
+ *
+ * If this is a particle with an energy loss process, this returns the
+ * estimate of the maximum cross section over the step. If the energy of the
+ * global maximum of the cross section (calculated at initialization) is in the
+ * interval \f$ [\xi E_0, E_0) \f$, where \f$ E_0 \f$ is the pre-step energy
+ * and \f$ \xi \f$ is \c energy_fraction (defined by default as \f$ \xi = 1 -
+ * \alpha \f$, where \f$ \alpha \f$ is \c scaling_fraction), \f$ \sigma_{\max}
+ * \f$ is set to the global maximum.  Otherwise, \f$ \sigma_{\max} = \max(
+ * \sigma(E_0), \sigma(\xi E_0) ) \f$. If the cross section is not monotonic in
+ * the interval \f$ [\xi E_0, E_0) \f$ and the interval does not contain the
+ * global maximum, the post-step cross section \f$ \sigma(E_1) \f$ may be
+ * larger than \f$ \sigma_{\max} \f$.
+ */
+CELER_FUNCTION real_type
+PhysicsTrackView::calc_max_xs(const IntegralXsProcess& process,
+                              ParticleProcessId        ppid,
+                              const MaterialView&      material,
+                              Energy                   energy) const
+{
+    CELER_EXPECT(process);
+    CELER_EXPECT(material_ < process.energy_max_xs.size());
+
+    real_type energy_max_xs
+        = params_.reals[process.energy_max_xs[material_.get()]];
+    real_type energy_xi = energy.value() * params_.scalars.energy_fraction;
+    if (energy_max_xs >= energy_xi && energy_max_xs < energy.value())
+    {
+        return this->calc_xs(ppid, material, Energy{energy_max_xs});
+    }
+    return max(this->calc_xs(ppid, material, energy),
+               this->calc_xs(ppid, material, Energy{energy_xi}));
 }
 
 //---------------------------------------------------------------------------//
@@ -417,9 +423,9 @@ CELER_FUNCTION ModelId PhysicsTrackView::hardwired_model(ParticleProcessId ppid,
                                                          Energy energy) const
 {
     ProcessId process = this->process(ppid);
-    if ((process == this->photoelectric_process_id()
+    if ((process == params_.hardwired.photoelectric
          && energy < params_.hardwired.photoelectric_table_thresh)
-        || (process == this->eplusgg_process_id()))
+        || (process == params_.hardwired.positron_annihilation))
     {
         auto find_model = this->make_model_finder(ppid);
         return this->model_id(find_model(energy));
@@ -609,31 +615,6 @@ CELER_FUNCTION auto PhysicsTrackView::urban_data() const -> const UrbanMscRef&
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate macroscopic cross section on the fly.
- */
-CELER_FUNCTION real_type PhysicsTrackView::calc_xs_otf(
-    ModelId model, const MaterialView& material, Energy energy) const
-{
-    real_type result = 0;
-    if (model == params_.hardwired.livermore_pe)
-    {
-        auto calc_xs = LivermorePEMacroXsCalculator(
-            params_.hardwired.livermore_pe_data, material);
-        result = calc_xs(energy);
-    }
-    else if (model == params_.hardwired.eplusgg)
-    {
-        auto calc_xs = EPlusGGMacroXsCalculator(params_.hardwired.eplusgg_data,
-                                                material);
-        result       = calc_xs(energy);
-    }
-
-    CELER_ENSURE(result >= 0);
-    return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Number of particle types.
  */
 CELER_FUNCTION size_type PhysicsTrackView::num_particles() const
@@ -653,24 +634,6 @@ CELER_FUNCTION T PhysicsTrackView::make_calculator(ValueGridId id) const
 {
     CELER_EXPECT(id < params_.value_grids.size());
     return T{params_.value_grids[id], params_.reals};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Process ID for photoelectric effect.
- */
-CELER_FUNCTION ProcessId PhysicsTrackView::photoelectric_process_id() const
-{
-    return params_.hardwired.photoelectric;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Process ID for positron annihilation.
- */
-CELER_FUNCTION ProcessId PhysicsTrackView::eplusgg_process_id() const
-{
-    return params_.hardwired.positron_annihilation;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/Process.hh
+++ b/src/celeritas/phys/Process.hh
@@ -41,12 +41,6 @@ class ValueGridBuilder;
  * - macro_xs:    Cross section [1/cm]
  * - energy_loss: dE/dx [MeV/cm]
  * - range:       Range limit [cm]
- *
- * Base input options are:
- * - \c use_integral_xs: For particles with energy loss processes, the energy
- *   changes over the step, so the assumption that the cross section is
- *   constant is no longer valid. Use MC integration to sample the discrete
- *   interaction length with the correct probability.
  */
 class Process
 {
@@ -61,15 +55,6 @@ class Process
     using Applicability      = ::celeritas::Applicability;
     //!@}
 
-    // TODO: update options based on ImportData
-    struct Options
-    {
-        bool use_integral_xs;
-
-        Options(bool integral_xs) : use_integral_xs{integral_xs} {}
-        Options() : Options(false) {}
-    };
-
   public:
     // Virtual destructor for polymorphic deletion
     virtual ~Process();
@@ -80,8 +65,8 @@ class Process
     //! Get the interaction cross sections for the given energy range
     virtual StepLimitBuilders step_limits(Applicability range) const = 0;
 
-    //! Get the options for the process
-    virtual const Options& options() const = 0;
+    //! Whether to use the integral method to sample interaction length
+    virtual bool use_integral_xs() const = 0;
 
     //! Name of the process
     virtual std::string label() const = 0;

--- a/src/celeritas/phys/Process.hh
+++ b/src/celeritas/phys/Process.hh
@@ -41,6 +41,12 @@ class ValueGridBuilder;
  * - macro_xs:    Cross section [1/cm]
  * - energy_loss: dE/dx [MeV/cm]
  * - range:       Range limit [cm]
+ *
+ * Base input options are:
+ * - \c use_integral_xs: For particles with energy loss processes, the energy
+ *   changes over the step, so the assumption that the cross section is
+ *   constant is no longer valid. Use MC integration to sample the discrete
+ *   interaction length with the correct probability.
  */
 class Process
 {
@@ -55,6 +61,15 @@ class Process
     using Applicability      = ::celeritas::Applicability;
     //!@}
 
+    // TODO: update options based on ImportData
+    struct Options
+    {
+        bool use_integral_xs;
+
+        Options(bool integral_xs) : use_integral_xs{integral_xs} {}
+        Options() : Options(false) {}
+    };
+
   public:
     // Virtual destructor for polymorphic deletion
     virtual ~Process();
@@ -65,8 +80,8 @@ class Process
     //! Get the interaction cross sections for the given energy range
     virtual StepLimitBuilders step_limits(Applicability range) const = 0;
 
-    //! Whether to use the integral method to sample interaction length
-    virtual bool use_integral_xs() const = 0;
+    //! Get the options for the process
+    virtual const Options& options() const = 0;
 
     //! Name of the process
     virtual std::string label() const = 0;

--- a/src/celeritas/phys/Process.hh
+++ b/src/celeritas/phys/Process.hh
@@ -24,17 +24,6 @@ class ValueGridBuilder;
 
 //---------------------------------------------------------------------------//
 /*!
- * Type of physics process.
- */
-enum class ProcessType
-{
-    electromagnetic_discrete, //!< Discrete EM process
-    electromagnetic_dedx,     //!< Continuous-discrete EM process
-    electromagnetic_msc       //!< Multiple scattering
-};
-
-//---------------------------------------------------------------------------//
-/*!
  * An interface/factory method for creating models.
  *
  * Currently processes pull their data from Geant4 which combines multiple
@@ -63,7 +52,6 @@ class Process
     using VecModel           = std::vector<SPConstModel>;
     using StepLimitBuilders  = ValueGridArray<UPConstGridBuilder>;
     using ActionIdIter       = RangeIter<ActionId>;
-    using ProcessType        = ::celeritas::ProcessType;
     using Applicability      = ::celeritas::Applicability;
     //!@}
 
@@ -77,8 +65,8 @@ class Process
     //! Get the interaction cross sections for the given energy range
     virtual StepLimitBuilders step_limits(Applicability range) const = 0;
 
-    //! Type of process
-    virtual ProcessType type() const = 0;
+    //! Whether to use the integral method to sample interaction length
+    virtual bool use_integral_xs() const = 0;
 
     //! Name of the process
     virtual std::string label() const = 0;

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -139,57 +139,59 @@ auto MockTestBase::build_physics() -> SPConstPhysics
     inp.materials = this->material();
     inp.interact  = this->make_model_callback();
     {
-        inp.label       = "scattering";
-        inp.applic      = {make_applicability("gamma", 1e-6, 100),
+        inp.label           = "scattering";
+        inp.use_integral_xs = false;
+        inp.applic          = {make_applicability("gamma", 1e-6, 100),
                       make_applicability("celeriton", 1, 100)};
-        inp.xs          = {Barn{1.0}, Barn{1.0}};
-        inp.energy_loss = {};
+        inp.xs              = {Barn{1.0}, Barn{1.0}};
+        inp.energy_loss     = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
-        inp.label       = "absorption";
-        inp.applic      = {make_applicability("gamma", 1e-6, 100)};
-        inp.xs          = {Barn{2.0}, Barn{2.0}};
-        inp.energy_loss = {};
+        inp.label           = "absorption";
+        inp.use_integral_xs = false;
+        inp.applic          = {make_applicability("gamma", 1e-6, 100)};
+        inp.xs              = {Barn{2.0}, Barn{2.0}};
+        inp.energy_loss     = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
         // Three different models for the single process
-        inp.label                   = "purrs";
-        inp.options.use_integral_xs = true;
-        inp.applic      = {make_applicability("celeriton", 1e-3, 1),
+        inp.label           = "purrs";
+        inp.use_integral_xs = true;
+        inp.applic          = {make_applicability("celeriton", 1e-3, 1),
                       make_applicability("celeriton", 1, 10),
                       make_applicability("celeriton", 10, 100)};
-        inp.xs          = {Barn{3.0}, Barn{3.0}};
-        inp.energy_loss = 0.6 * 1e-20; // 0.6 MeV/cm in celerogen
+        inp.xs              = {Barn{3.0}, Barn{3.0}};
+        inp.energy_loss     = 0.6 * 1e-20; // 0.6 MeV/cm in celerogen
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
         // Two models for anti-celeriton
-        inp.label                   = "hisses";
-        inp.options.use_integral_xs = true;
-        inp.applic      = {make_applicability("anti-celeriton", 1e-3, 1),
+        inp.label           = "hisses";
+        inp.use_integral_xs = true;
+        inp.applic          = {make_applicability("anti-celeriton", 1e-3, 1),
                       make_applicability("anti-celeriton", 1, 100)};
-        inp.xs          = {Barn{4.0}, Barn{4.0}};
-        inp.energy_loss = 0.7 * 1e-20;
+        inp.xs              = {Barn{4.0}, Barn{4.0}};
+        inp.energy_loss     = 0.7 * 1e-20;
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
-        inp.label                   = "meows";
-        inp.options.use_integral_xs = true;
-        inp.applic      = {make_applicability("celeriton", 1e-3, 10),
+        inp.label           = "meows";
+        inp.use_integral_xs = true;
+        inp.applic          = {make_applicability("celeriton", 1e-3, 10),
                       make_applicability("anti-celeriton", 1e-3, 10)};
-        inp.xs          = {Barn{5.0}, Barn{5.0}};
-        inp.energy_loss = {};
+        inp.xs              = {Barn{5.0}, Barn{5.0}};
+        inp.energy_loss     = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
         // Energy-dependent cross section
-        inp.label                   = "barks";
-        inp.options.use_integral_xs = true;
-        inp.applic      = {make_applicability("electron", 1e-5, 10)};
-        inp.xs          = {Barn{0}, Barn{6.0}, Barn{12.0}, Barn{6.0}};
-        inp.energy_loss = 0.5 * 1e-20;
+        inp.label           = "barks";
+        inp.use_integral_xs = true;
+        inp.applic          = {make_applicability("electron", 1e-5, 10)};
+        inp.xs              = {Barn{0}, Barn{6.0}, Barn{12.0}, Barn{6.0}};
+        inp.energy_loss     = 0.5 * 1e-20;
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     return std::make_shared<PhysicsParams>(std::move(physics_inp));

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -139,59 +139,57 @@ auto MockTestBase::build_physics() -> SPConstPhysics
     inp.materials = this->material();
     inp.interact  = this->make_model_callback();
     {
-        inp.label           = "scattering";
-        inp.use_integral_xs = false;
-        inp.applic          = {make_applicability("gamma", 1e-6, 100),
+        inp.label       = "scattering";
+        inp.applic      = {make_applicability("gamma", 1e-6, 100),
                       make_applicability("celeriton", 1, 100)};
-        inp.xs              = {Barn{1.0}, Barn{1.0}};
-        inp.energy_loss     = {};
+        inp.xs          = {Barn{1.0}, Barn{1.0}};
+        inp.energy_loss = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
-        inp.label           = "absorption";
-        inp.use_integral_xs = false;
-        inp.applic          = {make_applicability("gamma", 1e-6, 100)};
-        inp.xs              = {Barn{2.0}, Barn{2.0}};
-        inp.energy_loss     = {};
+        inp.label       = "absorption";
+        inp.applic      = {make_applicability("gamma", 1e-6, 100)};
+        inp.xs          = {Barn{2.0}, Barn{2.0}};
+        inp.energy_loss = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
         // Three different models for the single process
-        inp.label           = "purrs";
-        inp.use_integral_xs = true;
-        inp.applic          = {make_applicability("celeriton", 1e-3, 1),
+        inp.label                   = "purrs";
+        inp.options.use_integral_xs = true;
+        inp.applic      = {make_applicability("celeriton", 1e-3, 1),
                       make_applicability("celeriton", 1, 10),
                       make_applicability("celeriton", 10, 100)};
-        inp.xs              = {Barn{3.0}, Barn{3.0}};
-        inp.energy_loss     = 0.6 * 1e-20; // 0.6 MeV/cm in celerogen
+        inp.xs          = {Barn{3.0}, Barn{3.0}};
+        inp.energy_loss = 0.6 * 1e-20; // 0.6 MeV/cm in celerogen
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
         // Two models for anti-celeriton
-        inp.label           = "hisses";
-        inp.use_integral_xs = true;
-        inp.applic          = {make_applicability("anti-celeriton", 1e-3, 1),
+        inp.label                   = "hisses";
+        inp.options.use_integral_xs = true;
+        inp.applic      = {make_applicability("anti-celeriton", 1e-3, 1),
                       make_applicability("anti-celeriton", 1, 100)};
-        inp.xs              = {Barn{4.0}, Barn{4.0}};
-        inp.energy_loss     = 0.7 * 1e-20;
+        inp.xs          = {Barn{4.0}, Barn{4.0}};
+        inp.energy_loss = 0.7 * 1e-20;
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
-        inp.label           = "meows";
-        inp.use_integral_xs = true;
-        inp.applic          = {make_applicability("celeriton", 1e-3, 10),
+        inp.label                   = "meows";
+        inp.options.use_integral_xs = true;
+        inp.applic      = {make_applicability("celeriton", 1e-3, 10),
                       make_applicability("anti-celeriton", 1e-3, 10)};
-        inp.xs              = {Barn{5.0}, Barn{5.0}};
-        inp.energy_loss     = {};
+        inp.xs          = {Barn{5.0}, Barn{5.0}};
+        inp.energy_loss = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
         // Energy-dependent cross section
-        inp.label           = "barks";
-        inp.use_integral_xs = true;
-        inp.applic          = {make_applicability("electron", 1e-5, 10)};
-        inp.xs              = {Barn{0}, Barn{6.0}, Barn{12.0}, Barn{6.0}};
-        inp.energy_loss     = 0.5 * 1e-20;
+        inp.label                   = "barks";
+        inp.options.use_integral_xs = true;
+        inp.applic      = {make_applicability("electron", 1e-5, 10)};
+        inp.xs          = {Barn{0}, Barn{6.0}, Barn{12.0}, Barn{6.0}};
+        inp.energy_loss = 0.5 * 1e-20;
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     return std::make_shared<PhysicsParams>(std::move(physics_inp));

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -139,59 +139,59 @@ auto MockTestBase::build_physics() -> SPConstPhysics
     inp.materials = this->material();
     inp.interact  = this->make_model_callback();
     {
-        inp.label       = "scattering";
-        inp.type        = ProcessType::electromagnetic_discrete;
-        inp.applic      = {make_applicability("gamma", 1e-6, 100),
+        inp.label           = "scattering";
+        inp.use_integral_xs = false;
+        inp.applic          = {make_applicability("gamma", 1e-6, 100),
                       make_applicability("celeriton", 1, 100)};
-        inp.xs          = {Barn{1.0}, Barn{1.0}};
-        inp.energy_loss = {};
+        inp.xs              = {Barn{1.0}, Barn{1.0}};
+        inp.energy_loss     = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
-        inp.label       = "absorption";
-        inp.type        = ProcessType::electromagnetic_discrete;
-        inp.applic      = {make_applicability("gamma", 1e-6, 100)};
-        inp.xs          = {Barn{2.0}, Barn{2.0}};
-        inp.energy_loss = {};
+        inp.label           = "absorption";
+        inp.use_integral_xs = false;
+        inp.applic          = {make_applicability("gamma", 1e-6, 100)};
+        inp.xs              = {Barn{2.0}, Barn{2.0}};
+        inp.energy_loss     = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
         // Three different models for the single process
-        inp.label       = "purrs";
-        inp.type        = ProcessType::electromagnetic_dedx;
-        inp.applic      = {make_applicability("celeriton", 1e-3, 1),
+        inp.label           = "purrs";
+        inp.use_integral_xs = true;
+        inp.applic          = {make_applicability("celeriton", 1e-3, 1),
                       make_applicability("celeriton", 1, 10),
                       make_applicability("celeriton", 10, 100)};
-        inp.xs          = {Barn{3.0}, Barn{3.0}};
-        inp.energy_loss = 0.6 * 1e-20; // 0.6 MeV/cm in celerogen
+        inp.xs              = {Barn{3.0}, Barn{3.0}};
+        inp.energy_loss     = 0.6 * 1e-20; // 0.6 MeV/cm in celerogen
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
         // Two models for anti-celeriton
-        inp.label       = "hisses";
-        inp.type        = ProcessType::electromagnetic_dedx;
-        inp.applic      = {make_applicability("anti-celeriton", 1e-3, 1),
+        inp.label           = "hisses";
+        inp.use_integral_xs = true;
+        inp.applic          = {make_applicability("anti-celeriton", 1e-3, 1),
                       make_applicability("anti-celeriton", 1, 100)};
-        inp.xs          = {Barn{4.0}, Barn{4.0}};
-        inp.energy_loss = 0.7 * 1e-20;
+        inp.xs              = {Barn{4.0}, Barn{4.0}};
+        inp.energy_loss     = 0.7 * 1e-20;
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
-        inp.label       = "meows";
-        inp.type        = ProcessType::electromagnetic_dedx;
-        inp.applic      = {make_applicability("celeriton", 1e-3, 10),
+        inp.label           = "meows";
+        inp.use_integral_xs = true;
+        inp.applic          = {make_applicability("celeriton", 1e-3, 10),
                       make_applicability("anti-celeriton", 1e-3, 10)};
-        inp.xs          = {Barn{5.0}, Barn{5.0}};
-        inp.energy_loss = {};
+        inp.xs              = {Barn{5.0}, Barn{5.0}};
+        inp.energy_loss     = {};
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     {
         // Energy-dependent cross section
-        inp.label       = "barks";
-        inp.type        = ProcessType::electromagnetic_dedx;
-        inp.applic      = {make_applicability("electron", 1e-5, 10)};
-        inp.xs          = {Barn{0}, Barn{6.0}, Barn{12.0}, Barn{6.0}};
-        inp.energy_loss = 0.5 * 1e-20;
+        inp.label           = "barks";
+        inp.use_integral_xs = true;
+        inp.applic          = {make_applicability("electron", 1e-5, 10)};
+        inp.xs              = {Barn{0}, Barn{6.0}, Barn{12.0}, Barn{6.0}};
+        inp.energy_loss     = 0.5 * 1e-20;
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));
     }
     return std::make_shared<PhysicsParams>(std::move(physics_inp));

--- a/test/celeritas/TestEm3Base.cc
+++ b/test/celeritas/TestEm3Base.cc
@@ -106,19 +106,12 @@ auto TestEm3Base::build_physics() -> SPConstPhysics
     input.options        = this->build_physics_options();
     input.action_manager = this->action_mgr().get();
 
-    BremsstrahlungProcess::Options brem_options;
-    brem_options.combined_model  = true;
-    brem_options.enable_lpm      = true;
-    brem_options.use_integral_xs = true;
+    BremsstrahlungProcess::BremsstrahlungOptions brem_options;
+    brem_options.combined_model = true;
+    brem_options.enable_lpm     = true;
 
-    GammaConversionProcess::Options conv_options;
+    GammaConversionProcess::GammaConversionOptions conv_options;
     conv_options.enable_lpm = true;
-
-    EPlusAnnihilationProcess::Options epgg_options;
-    epgg_options.use_integral_xs = true;
-
-    EIonizationProcess::Options ioni_options;
-    ioni_options.use_integral_xs = true;
 
     auto process_data
         = std::make_shared<ImportedProcesses>(this->imported_data().processes);
@@ -128,10 +121,10 @@ auto TestEm3Base::build_physics() -> SPConstPhysics
         input.particles, input.materials, process_data));
     input.processes.push_back(std::make_shared<GammaConversionProcess>(
         input.particles, process_data, conv_options));
-    input.processes.push_back(std::make_shared<EPlusAnnihilationProcess>(
-        input.particles, epgg_options));
-    input.processes.push_back(std::make_shared<EIonizationProcess>(
-        input.particles, process_data, ioni_options));
+    input.processes.push_back(
+        std::make_shared<EPlusAnnihilationProcess>(input.particles));
+    input.processes.push_back(
+        std::make_shared<EIonizationProcess>(input.particles, process_data));
     input.processes.push_back(std::make_shared<BremsstrahlungProcess>(
         input.particles, input.materials, process_data, brem_options));
     if (this->enable_msc())

--- a/test/celeritas/TestEm3Base.cc
+++ b/test/celeritas/TestEm3Base.cc
@@ -107,11 +107,18 @@ auto TestEm3Base::build_physics() -> SPConstPhysics
     input.action_manager = this->action_mgr().get();
 
     BremsstrahlungProcess::Options brem_options;
-    brem_options.combined_model = true;
-    brem_options.enable_lpm     = true;
+    brem_options.combined_model  = true;
+    brem_options.enable_lpm      = true;
+    brem_options.use_integral_xs = true;
 
     GammaConversionProcess::Options conv_options;
     conv_options.enable_lpm = true;
+
+    EPlusAnnihilationProcess::Options epgg_options;
+    epgg_options.use_integral_xs = true;
+
+    EIonizationProcess::Options ioni_options;
+    ioni_options.use_integral_xs = true;
 
     auto process_data
         = std::make_shared<ImportedProcesses>(this->imported_data().processes);
@@ -121,10 +128,10 @@ auto TestEm3Base::build_physics() -> SPConstPhysics
         input.particles, input.materials, process_data));
     input.processes.push_back(std::make_shared<GammaConversionProcess>(
         input.particles, process_data, conv_options));
-    input.processes.push_back(
-        std::make_shared<EPlusAnnihilationProcess>(input.particles));
-    input.processes.push_back(
-        std::make_shared<EIonizationProcess>(input.particles, process_data));
+    input.processes.push_back(std::make_shared<EPlusAnnihilationProcess>(
+        input.particles, epgg_options));
+    input.processes.push_back(std::make_shared<EIonizationProcess>(
+        input.particles, process_data, ioni_options));
     input.processes.push_back(std::make_shared<BremsstrahlungProcess>(
         input.particles, input.materials, process_data, brem_options));
     if (this->enable_msc())

--- a/test/celeritas/TestEm3Base.cc
+++ b/test/celeritas/TestEm3Base.cc
@@ -106,12 +106,19 @@ auto TestEm3Base::build_physics() -> SPConstPhysics
     input.options        = this->build_physics_options();
     input.action_manager = this->action_mgr().get();
 
-    BremsstrahlungProcess::BremsstrahlungOptions brem_options;
-    brem_options.combined_model = true;
-    brem_options.enable_lpm     = true;
+    BremsstrahlungProcess::Options brem_options;
+    brem_options.combined_model  = true;
+    brem_options.enable_lpm      = true;
+    brem_options.use_integral_xs = true;
 
-    GammaConversionProcess::GammaConversionOptions conv_options;
+    GammaConversionProcess::Options conv_options;
     conv_options.enable_lpm = true;
+
+    EPlusAnnihilationProcess::Options epgg_options;
+    epgg_options.use_integral_xs = true;
+
+    EIonizationProcess::Options ioni_options;
+    ioni_options.use_integral_xs = true;
 
     auto process_data
         = std::make_shared<ImportedProcesses>(this->imported_data().processes);
@@ -121,10 +128,10 @@ auto TestEm3Base::build_physics() -> SPConstPhysics
         input.particles, input.materials, process_data));
     input.processes.push_back(std::make_shared<GammaConversionProcess>(
         input.particles, process_data, conv_options));
-    input.processes.push_back(
-        std::make_shared<EPlusAnnihilationProcess>(input.particles));
-    input.processes.push_back(
-        std::make_shared<EIonizationProcess>(input.particles, process_data));
+    input.processes.push_back(std::make_shared<EPlusAnnihilationProcess>(
+        input.particles, epgg_options));
+    input.processes.push_back(std::make_shared<EIonizationProcess>(
+        input.particles, process_data, ioni_options));
     input.processes.push_back(std::make_shared<BremsstrahlungProcess>(
         input.particles, input.materials, process_data, brem_options));
     if (this->enable_msc())

--- a/test/celeritas/em/ImportedProcesses.test.cc
+++ b/test/celeritas/em/ImportedProcesses.test.cc
@@ -65,9 +65,6 @@ TEST_F(ImportedProcessesTest, compton)
     // Create Compton process
     auto process = std::make_shared<ComptonProcess>(particles_, processes_);
 
-    // Test options
-    EXPECT_FALSE(process->options().use_integral_xs);
-
     // Test model
     auto models = process->build_models(ActionIdIter{});
     ASSERT_EQ(1, models.size());
@@ -91,10 +88,10 @@ TEST_F(ImportedProcessesTest, compton)
 TEST_F(ImportedProcessesTest, e_ionization)
 {
     // Create electron ionization process
-    auto process = std::make_shared<EIonizationProcess>(particles_, processes_);
-
-    // Test options
-    EXPECT_TRUE(process->options().use_integral_xs);
+    EIonizationProcess::Options options;
+    options.use_integral_xs = true;
+    auto process            = std::make_shared<EIonizationProcess>(
+        particles_, processes_, options);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -121,10 +118,10 @@ TEST_F(ImportedProcessesTest, e_ionization)
 TEST_F(ImportedProcessesTest, eplus_annihilation)
 {
     // Create positron annihilation process
-    auto process = std::make_shared<EPlusAnnihilationProcess>(particles_);
-
-    // Test options
-    EXPECT_TRUE(process->options().use_integral_xs);
+    EPlusAnnihilationProcess::Options options;
+    options.use_integral_xs = true;
+    auto process
+        = std::make_shared<EPlusAnnihilationProcess>(particles_, options);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -150,16 +147,12 @@ TEST_F(ImportedProcessesTest, eplus_annihilation)
 
 TEST_F(ImportedProcessesTest, gamma_conversion)
 {
-    GammaConversionProcess::GammaConversionOptions options;
+    GammaConversionProcess::Options options;
     options.enable_lpm = true;
 
     // Create gamma conversion process
     auto process = std::make_shared<GammaConversionProcess>(
         particles_, processes_, options);
-
-    // Test options
-    EXPECT_TRUE(process->options().enable_lpm);
-    EXPECT_TRUE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -186,9 +179,6 @@ TEST_F(ImportedProcessesTest, msc)
     // Create Multiple scattering process
     auto process = std::make_shared<MultipleScatteringProcess>(
         particles_, materials_, processes_);
-
-    // Test options
-    EXPECT_FALSE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -222,9 +212,6 @@ TEST_F(ImportedProcessesTest, photoelectric)
         GTEST_SKIP() << "Failed to create process: " << e.what();
     }
 
-    // Test options
-    EXPECT_FALSE(process->options().use_integral_xs);
-
     // Test model
     auto models = process->build_models(ActionIdIter{});
     ASSERT_EQ(1, models.size());
@@ -249,8 +236,9 @@ TEST_F(ImportedProcessesTest, bremsstrahlung_multiple_models)
 {
     // Create bremsstrahlung process (requires Geant4 environment variables)
     // with multiple models (SeltzerBergerModel and RelativisticBremModel)
-    BremsstrahlungProcess::BremsstrahlungOptions options;
-    options.combined_model = false;
+    BremsstrahlungProcess::Options options;
+    options.combined_model  = false;
+    options.use_integral_xs = true;
     std::shared_ptr<BremsstrahlungProcess> process;
     try
     {
@@ -261,11 +249,6 @@ TEST_F(ImportedProcessesTest, bremsstrahlung_multiple_models)
     {
         GTEST_SKIP() << "Failed to create process: " << e.what();
     }
-
-    // Test options
-    EXPECT_FALSE(process->options().combined_model);
-    EXPECT_TRUE(process->options().enable_lpm);
-    EXPECT_TRUE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -294,8 +277,9 @@ TEST_F(ImportedProcessesTest, bremsstrahlung_multiple_models)
 TEST_F(ImportedProcessesTest, bremsstrahlung_combined_model)
 {
     // Create the combined bremsstrahlung process
-    BremsstrahlungProcess::BremsstrahlungOptions options;
-    options.combined_model = true;
+    BremsstrahlungProcess::Options options;
+    options.combined_model  = true;
+    options.use_integral_xs = true;
     std::shared_ptr<BremsstrahlungProcess> process;
     try
     {
@@ -306,11 +290,6 @@ TEST_F(ImportedProcessesTest, bremsstrahlung_combined_model)
     {
         GTEST_SKIP() << "Failed to create process: " << e.what();
     }
-
-    // Test options
-    EXPECT_TRUE(process->options().combined_model);
-    EXPECT_TRUE(process->options().enable_lpm);
-    EXPECT_TRUE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -341,9 +320,6 @@ TEST_F(ImportedProcessesTest, rayleigh)
     // Create Rayleigh scattering process
     auto process = std::make_shared<RayleighProcess>(
         particles_, materials_, processes_);
-
-    // Test options
-    EXPECT_FALSE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});

--- a/test/celeritas/em/ImportedProcesses.test.cc
+++ b/test/celeritas/em/ImportedProcesses.test.cc
@@ -65,6 +65,9 @@ TEST_F(ImportedProcessesTest, compton)
     // Create Compton process
     auto process = std::make_shared<ComptonProcess>(particles_, processes_);
 
+    // Test options
+    EXPECT_FALSE(process->options().use_integral_xs);
+
     // Test model
     auto models = process->build_models(ActionIdIter{});
     ASSERT_EQ(1, models.size());
@@ -88,10 +91,10 @@ TEST_F(ImportedProcessesTest, compton)
 TEST_F(ImportedProcessesTest, e_ionization)
 {
     // Create electron ionization process
-    EIonizationProcess::Options options;
-    options.use_integral_xs = true;
-    auto process            = std::make_shared<EIonizationProcess>(
-        particles_, processes_, options);
+    auto process = std::make_shared<EIonizationProcess>(particles_, processes_);
+
+    // Test options
+    EXPECT_TRUE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -118,10 +121,10 @@ TEST_F(ImportedProcessesTest, e_ionization)
 TEST_F(ImportedProcessesTest, eplus_annihilation)
 {
     // Create positron annihilation process
-    EPlusAnnihilationProcess::Options options;
-    options.use_integral_xs = true;
-    auto process
-        = std::make_shared<EPlusAnnihilationProcess>(particles_, options);
+    auto process = std::make_shared<EPlusAnnihilationProcess>(particles_);
+
+    // Test options
+    EXPECT_TRUE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -147,12 +150,16 @@ TEST_F(ImportedProcessesTest, eplus_annihilation)
 
 TEST_F(ImportedProcessesTest, gamma_conversion)
 {
-    GammaConversionProcess::Options options;
+    GammaConversionProcess::GammaConversionOptions options;
     options.enable_lpm = true;
 
     // Create gamma conversion process
     auto process = std::make_shared<GammaConversionProcess>(
         particles_, processes_, options);
+
+    // Test options
+    EXPECT_TRUE(process->options().enable_lpm);
+    EXPECT_TRUE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -179,6 +186,9 @@ TEST_F(ImportedProcessesTest, msc)
     // Create Multiple scattering process
     auto process = std::make_shared<MultipleScatteringProcess>(
         particles_, materials_, processes_);
+
+    // Test options
+    EXPECT_FALSE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -212,6 +222,9 @@ TEST_F(ImportedProcessesTest, photoelectric)
         GTEST_SKIP() << "Failed to create process: " << e.what();
     }
 
+    // Test options
+    EXPECT_FALSE(process->options().use_integral_xs);
+
     // Test model
     auto models = process->build_models(ActionIdIter{});
     ASSERT_EQ(1, models.size());
@@ -236,9 +249,8 @@ TEST_F(ImportedProcessesTest, bremsstrahlung_multiple_models)
 {
     // Create bremsstrahlung process (requires Geant4 environment variables)
     // with multiple models (SeltzerBergerModel and RelativisticBremModel)
-    BremsstrahlungProcess::Options options;
-    options.combined_model  = false;
-    options.use_integral_xs = true;
+    BremsstrahlungProcess::BremsstrahlungOptions options;
+    options.combined_model = false;
     std::shared_ptr<BremsstrahlungProcess> process;
     try
     {
@@ -249,6 +261,11 @@ TEST_F(ImportedProcessesTest, bremsstrahlung_multiple_models)
     {
         GTEST_SKIP() << "Failed to create process: " << e.what();
     }
+
+    // Test options
+    EXPECT_FALSE(process->options().combined_model);
+    EXPECT_TRUE(process->options().enable_lpm);
+    EXPECT_TRUE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -277,9 +294,8 @@ TEST_F(ImportedProcessesTest, bremsstrahlung_multiple_models)
 TEST_F(ImportedProcessesTest, bremsstrahlung_combined_model)
 {
     // Create the combined bremsstrahlung process
-    BremsstrahlungProcess::Options options;
-    options.combined_model  = true;
-    options.use_integral_xs = true;
+    BremsstrahlungProcess::BremsstrahlungOptions options;
+    options.combined_model = true;
     std::shared_ptr<BremsstrahlungProcess> process;
     try
     {
@@ -290,6 +306,11 @@ TEST_F(ImportedProcessesTest, bremsstrahlung_combined_model)
     {
         GTEST_SKIP() << "Failed to create process: " << e.what();
     }
+
+    // Test options
+    EXPECT_TRUE(process->options().combined_model);
+    EXPECT_TRUE(process->options().enable_lpm);
+    EXPECT_TRUE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -320,6 +341,9 @@ TEST_F(ImportedProcessesTest, rayleigh)
     // Create Rayleigh scattering process
     auto process = std::make_shared<RayleighProcess>(
         particles_, materials_, processes_);
+
+    // Test options
+    EXPECT_FALSE(process->options().use_integral_xs);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});

--- a/test/celeritas/em/ImportedProcesses.test.cc
+++ b/test/celeritas/em/ImportedProcesses.test.cc
@@ -88,7 +88,10 @@ TEST_F(ImportedProcessesTest, compton)
 TEST_F(ImportedProcessesTest, e_ionization)
 {
     // Create electron ionization process
-    auto process = std::make_shared<EIonizationProcess>(particles_, processes_);
+    EIonizationProcess::Options options;
+    options.use_integral_xs = true;
+    auto process            = std::make_shared<EIonizationProcess>(
+        particles_, processes_, options);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -115,7 +118,10 @@ TEST_F(ImportedProcessesTest, e_ionization)
 TEST_F(ImportedProcessesTest, eplus_annihilation)
 {
     // Create positron annihilation process
-    auto process = std::make_shared<EPlusAnnihilationProcess>(particles_);
+    EPlusAnnihilationProcess::Options options;
+    options.use_integral_xs = true;
+    auto process
+        = std::make_shared<EPlusAnnihilationProcess>(particles_, options);
 
     // Test model
     auto models = process->build_models(ActionIdIter{});
@@ -231,7 +237,8 @@ TEST_F(ImportedProcessesTest, bremsstrahlung_multiple_models)
     // Create bremsstrahlung process (requires Geant4 environment variables)
     // with multiple models (SeltzerBergerModel and RelativisticBremModel)
     BremsstrahlungProcess::Options options;
-    options.combined_model = false;
+    options.combined_model  = false;
+    options.use_integral_xs = true;
     std::shared_ptr<BremsstrahlungProcess> process;
     try
     {
@@ -271,7 +278,8 @@ TEST_F(ImportedProcessesTest, bremsstrahlung_combined_model)
 {
     // Create the combined bremsstrahlung process
     BremsstrahlungProcess::Options options;
-    options.combined_model = true;
+    options.combined_model  = true;
+    options.use_integral_xs = true;
     std::shared_ptr<BremsstrahlungProcess> process;
     try
     {

--- a/test/celeritas/em/ImportedProcesses.test.cc
+++ b/test/celeritas/em/ImportedProcesses.test.cc
@@ -87,10 +87,11 @@ TEST_F(ImportedProcessesTest, compton)
 
 TEST_F(ImportedProcessesTest, e_ionization)
 {
-    // Create electron ionization process
     EIonizationProcess::Options options;
     options.use_integral_xs = true;
-    auto process            = std::make_shared<EIonizationProcess>(
+
+    // Create electron ionization process
+    auto process = std::make_shared<EIonizationProcess>(
         particles_, processes_, options);
 
     // Test model
@@ -117,9 +118,10 @@ TEST_F(ImportedProcessesTest, e_ionization)
 
 TEST_F(ImportedProcessesTest, eplus_annihilation)
 {
-    // Create positron annihilation process
     EPlusAnnihilationProcess::Options options;
     options.use_integral_xs = true;
+
+    // Create positron annihilation process
     auto process
         = std::make_shared<EPlusAnnihilationProcess>(particles_, options);
 

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -109,8 +109,10 @@ class UrbanMscTest : public celeritas_test::GlobalGeoTestBase
         input.materials = this->material();
 
         // Add EIonizationProcess and MultipleScatteringProcess
+        EIonizationProcess::Options ioni_options;
+        ioni_options.use_integral_xs = true;
         input.processes.push_back(std::make_shared<EIonizationProcess>(
-            this->particle(), processes_data_));
+            this->particle(), processes_data_, ioni_options));
         input.processes.push_back(std::make_shared<MultipleScatteringProcess>(
             this->particle(), this->material(), processes_data_));
 

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -109,10 +109,8 @@ class UrbanMscTest : public celeritas_test::GlobalGeoTestBase
         input.materials = this->material();
 
         // Add EIonizationProcess and MultipleScatteringProcess
-        EIonizationProcess::Options ioni_options;
-        ioni_options.use_integral_xs = true;
         input.processes.push_back(std::make_shared<EIonizationProcess>(
-            this->particle(), processes_data_, ioni_options));
+            this->particle(), processes_data_));
         input.processes.push_back(std::make_shared<MultipleScatteringProcess>(
             this->particle(), this->material(), processes_data_));
 

--- a/test/celeritas/phys/MockProcess.cc
+++ b/test/celeritas/phys/MockProcess.cc
@@ -92,12 +92,6 @@ auto MockProcess::step_limits(Applicability range) const -> StepLimitBuilders
 }
 
 //---------------------------------------------------------------------------//
-bool MockProcess::use_integral_xs() const
-{
-    return data_.use_integral_xs;
-}
-
-//---------------------------------------------------------------------------//
 std::string MockProcess::label() const
 {
     return data_.label;

--- a/test/celeritas/phys/MockProcess.cc
+++ b/test/celeritas/phys/MockProcess.cc
@@ -92,9 +92,9 @@ auto MockProcess::step_limits(Applicability range) const -> StepLimitBuilders
 }
 
 //---------------------------------------------------------------------------//
-ProcessType MockProcess::type() const
+bool MockProcess::use_integral_xs() const
 {
-    return data_.type;
+    return data_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/phys/MockProcess.cc
+++ b/test/celeritas/phys/MockProcess.cc
@@ -92,6 +92,12 @@ auto MockProcess::step_limits(Applicability range) const -> StepLimitBuilders
 }
 
 //---------------------------------------------------------------------------//
+bool MockProcess::use_integral_xs() const
+{
+    return data_.use_integral_xs;
+}
+
+//---------------------------------------------------------------------------//
 std::string MockProcess::label() const
 {
     return data_.label;

--- a/test/celeritas/phys/MockProcess.hh
+++ b/test/celeritas/phys/MockProcess.hh
@@ -41,7 +41,6 @@ class MockProcess : public celeritas::Process
     using real_type        = celeritas::real_type;
     using BarnMicroXs      = celeritas::Quantity<celeritas::units::Barn>;
     using Applicability    = celeritas::Applicability;
-    using ProcessType      = celeritas::ProcessType;
     using VecApplicability = std::vector<Applicability>;
     using VecMicroXs       = std::vector<BarnMicroXs>;
     using SPConstMaterials = std::shared_ptr<const celeritas::MaterialParams>;
@@ -51,8 +50,8 @@ class MockProcess : public celeritas::Process
     struct Input
     {
         SPConstMaterials materials;
-        ProcessType      type;
         std::string      label;
+        bool             use_integral_xs;
         VecApplicability applic;        //!< Applicablity per model
         ModelCallback    interact;      //!< MockModel::interact callback
         VecMicroXs       xs;            //!< Constant per atom [bn]
@@ -64,7 +63,7 @@ class MockProcess : public celeritas::Process
 
     VecModel          build_models(ActionIdIter start_id) const final;
     StepLimitBuilders step_limits(Applicability range) const final;
-    ProcessType       type() const final;
+    bool              use_integral_xs() const final;
     std::string       label() const final;
 
   private:

--- a/test/celeritas/phys/MockProcess.hh
+++ b/test/celeritas/phys/MockProcess.hh
@@ -51,7 +51,7 @@ class MockProcess : public celeritas::Process
     {
         SPConstMaterials materials;
         std::string      label;
-        Options          options;
+        bool             use_integral_xs;
         VecApplicability applic;        //!< Applicablity per model
         ModelCallback    interact;      //!< MockModel::interact callback
         VecMicroXs       xs;            //!< Constant per atom [bn]
@@ -63,7 +63,7 @@ class MockProcess : public celeritas::Process
 
     VecModel          build_models(ActionIdIter start_id) const final;
     StepLimitBuilders step_limits(Applicability range) const final;
-    const Options&    options() const final { return data_.options; }
+    bool              use_integral_xs() const final;
     std::string       label() const final;
 
   private:

--- a/test/celeritas/phys/MockProcess.hh
+++ b/test/celeritas/phys/MockProcess.hh
@@ -51,7 +51,7 @@ class MockProcess : public celeritas::Process
     {
         SPConstMaterials materials;
         std::string      label;
-        bool             use_integral_xs;
+        Options          options;
         VecApplicability applic;        //!< Applicablity per model
         ModelCallback    interact;      //!< MockModel::interact callback
         VecMicroXs       xs;            //!< Constant per atom [bn]
@@ -63,7 +63,7 @@ class MockProcess : public celeritas::Process
 
     VecModel          build_models(ActionIdIter start_id) const final;
     StepLimitBuilders step_limits(Applicability range) const final;
-    bool              use_integral_xs() const final;
+    const Options&    options() const final { return data_.options; }
     std::string       label() const final;
 
   private:

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -754,8 +754,11 @@ auto EPlusAnnihilationTest::build_physics() -> SPConstPhysics
     physics_inp.options.enable_fluctuation = false;
     physics_inp.action_manager             = this->action_mgr().get();
 
-    physics_inp.processes.push_back(
-        std::make_shared<EPlusAnnihilationProcess>(physics_inp.particles));
+    EPlusAnnihilationProcess::Options epgg_options;
+    epgg_options.use_integral_xs = true;
+
+    physics_inp.processes.push_back(std::make_shared<EPlusAnnihilationProcess>(
+        physics_inp.particles, epgg_options));
     return std::make_shared<PhysicsParams>(std::move(physics_inp));
 }
 

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -754,11 +754,8 @@ auto EPlusAnnihilationTest::build_physics() -> SPConstPhysics
     physics_inp.options.enable_fluctuation = false;
     physics_inp.action_manager             = this->action_mgr().get();
 
-    EPlusAnnihilationProcess::Options epgg_options;
-    epgg_options.use_integral_xs = true;
-
-    physics_inp.processes.push_back(std::make_shared<EPlusAnnihilationProcess>(
-        physics_inp.particles, epgg_options));
+    physics_inp.processes.push_back(
+        std::make_shared<EPlusAnnihilationProcess>(physics_inp.particles));
     return std::make_shared<PhysicsParams>(std::move(physics_inp));
 }
 

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -323,12 +323,12 @@ TEST_F(PhysicsStepUtilsTest, select_discrete_interaction)
                                                      "electron",
                                                      MevEnergy{inc_energy[i]});
             ParticleProcessId ppid{0};
-            EXPECT_TRUE(phys.use_integral_xs(ppid));
-            auto grid_id = phys.value_grid(ValueGridType::macro_xs, ppid);
-            CELER_ASSERT(grid_id);
+            const auto& integral_process = phys.integral_xs_process(ppid);
+            EXPECT_TRUE(integral_process);
 
             // Get the estimate of the maximum cross section over the step
-            real_type xs_max = phys.calc_xs(ppid, grid_id, particle.energy());
+            real_type xs_max = phys.calc_max_xs(
+                integral_process, ppid, mat_view, particle.energy());
             pstep.per_process_xs(ppid) = xs_max;
 
             // Set the post-step energy


### PR DESCRIPTION
@sethrj discovered that we are not using the integral approach for all processes where the energy of the applicable particle can change over the step, but instead only for continuous-discrete processes. This fix makes sure we also use integral rejection for electron-positron annihilation. I've tagged on a couple other minor fixes:

- Check if an element had been previously sampled in the Livermore PE launcher (accidentally omitted from the last PR)
- Correct the overflow bin in the step diagnostic