### PR TITLE
Add simulation time

### DIFF
--- a/src/celeritas/global/detail/AlongStepActionImpl.hh
+++ b/src/celeritas/global/detail/AlongStepActionImpl.hh
@@ -179,9 +179,9 @@ inline CELER_FUNCTION void along_step_track(CoreTrackView const& track)
 
     // Update track's lab-frame time using the beginning-of-step velocity
     {
-        real_type velocity = native_value_from(particle.speed());
-        CELER_ASSERT(velocity > 0);
-        real_type delta_time = step_limit.step / velocity;
+        real_type speed = native_value_from(particle.speed());
+        CELER_ASSERT(speed > 0);
+        real_type delta_time = step_limit.step / speed;
         sim.add_time(delta_time);
     }
 

--- a/src/celeritas/global/detail/AlongStepActionImpl.hh
+++ b/src/celeritas/global/detail/AlongStepActionImpl.hh
@@ -177,7 +177,13 @@ inline CELER_FUNCTION void along_step_track(CoreTrackView const& track)
         step_limit.step = geo_step;
     }
 
-    // TODO: update track's lab-frame time here
+    // Update track's lab-frame time using the beginning-of-step velocity
+    {
+        real_type velocity = native_value_from(particle.speed());
+        CELER_ASSERT(velocity > 0);
+        real_type delta_time = step_limit.step / velocity;
+        sim.add_time(delta_time);
+    }
 
     using Energy = ParticleTrackView::Energy;
     Energy eloss = calc_energy_loss(

--- a/src/celeritas/io/EventReader.cc
+++ b/src/celeritas/io/EventReader.cc
@@ -12,6 +12,7 @@
 
 #include "corecel/io/Logger.hh"
 #include "corecel/math/ArrayUtils.hh"
+#include "celeritas/Constants.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/Primary.hh"
@@ -88,6 +89,9 @@ EventReader::result_type EventReader::operator()()
             primary.position = {pos.x() * units::centimeter,
                                 pos.y() * units::centimeter,
                                 pos.z() * units::centimeter};
+
+            // Get the lab-frame time [s]
+            primary.time = pos.t() * units::centimeter / constants::c_light;
 
             // Get the direction of the primary
             primary.direction = {gen_particle->momentum().px(),

--- a/src/celeritas/phys/Primary.hh
+++ b/src/celeritas/phys/Primary.hh
@@ -24,6 +24,7 @@ struct Primary
     units::MevEnergy energy;
     Real3            position;
     Real3            direction;
+    real_type        time;
     EventId          event_id;
     TrackId          track_id;
 };

--- a/src/celeritas/track/SimData.hh
+++ b/src/celeritas/track/SimData.hh
@@ -30,6 +30,7 @@ struct SimTrackState
     TrackId   parent_id;    //!< ID of parent that created it
     EventId   event_id;     //!< ID of originating event
     size_type num_steps{0}; //!< Total number of steps taken
+    real_type time; //!< Time elapsed in lab frame since start of event [s]
 
     TrackStatus status{TrackStatus::inactive};
     StepLimit   step_limit;

--- a/src/celeritas/track/SimData.hh
+++ b/src/celeritas/track/SimData.hh
@@ -30,7 +30,7 @@ struct SimTrackState
     TrackId   parent_id;    //!< ID of parent that created it
     EventId   event_id;     //!< ID of originating event
     size_type num_steps{0}; //!< Total number of steps taken
-    real_type time; //!< Time elapsed in lab frame since start of event [s]
+    real_type time{0}; //!< Time elapsed in lab frame since start of event [s]
 
     TrackStatus status{TrackStatus::inactive};
     StepLimit   step_limit;

--- a/src/celeritas/track/SimTrackView.hh
+++ b/src/celeritas/track/SimTrackView.hh
@@ -37,6 +37,9 @@ class SimTrackView
     // Initialize the sim state
     inline CELER_FUNCTION SimTrackView& operator=(const Initializer_t& other);
 
+    // Add the time change over the step
+    inline CELER_FUNCTION void add_time(real_type delta);
+
     // Increment the total number of steps
     CELER_FORCEINLINE_FUNCTION void increment_num_steps();
 
@@ -72,6 +75,9 @@ class SimTrackView
     // Total number of steps taken by the track
     CELER_FORCEINLINE_FUNCTION size_type num_steps() const;
 
+    // Time elapsed in the lab frame since the start of the event [s]
+    CELER_FORCEINLINE_FUNCTION real_type time() const;
+
     // Whether the track is alive or inactive or dying
     CELER_FORCEINLINE_FUNCTION TrackStatus status() const;
 
@@ -104,6 +110,16 @@ CELER_FUNCTION SimTrackView& SimTrackView::operator=(const Initializer_t& other)
 {
     states_.state[thread_] = other;
     return *this;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add the time change over the step.
+ */
+CELER_FUNCTION void SimTrackView::add_time(real_type delta)
+{
+    CELER_EXPECT(delta >= 0);
+    states_.state[thread_].time += delta;
 }
 
 //---------------------------------------------------------------------------//
@@ -236,6 +252,15 @@ CELER_FUNCTION EventId SimTrackView::event_id() const
 CELER_FUNCTION size_type SimTrackView::num_steps() const
 {
     return states_.state[thread_].num_steps;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Time elapsed in the lab frame since the start of the event [s].
+ */
+CELER_FUNCTION real_type SimTrackView::time() const
+{
+    return states_.state[thread_].time;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
@@ -61,7 +61,7 @@ CELER_FUNCTION void ProcessPrimariesLauncher<M>::operator()(ThreadId tid) const
     init.sim.parent_id        = TrackId{};
     init.sim.event_id         = primary.event_id;
     init.sim.num_steps        = 0;
-    init.sim.time             = 0;
+    init.sim.time             = primary.time;
     init.sim.status           = TrackStatus::alive;
     init.geo.pos              = primary.position;
     init.geo.dir              = primary.direction;

--- a/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
@@ -60,6 +60,8 @@ CELER_FUNCTION void ProcessPrimariesLauncher<M>::operator()(ThreadId tid) const
     init.sim.track_id         = primary.track_id;
     init.sim.parent_id        = TrackId{};
     init.sim.event_id         = primary.event_id;
+    init.sim.num_steps        = 0;
+    init.sim.time             = 0;
     init.sim.status           = TrackStatus::alive;
     init.geo.pos              = primary.position;
     init.geo.dir              = primary.direction;

--- a/src/celeritas/track/detail/ProcessSecondariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessSecondariesLauncher.hh
@@ -106,6 +106,7 @@ ProcessSecondariesLauncher<M>::operator()(ThreadId tid) const
             init.sim.parent_id        = parent_id;
             init.sim.event_id         = sim.event_id();
             init.sim.num_steps        = 0;
+            init.sim.time             = sim.time();
             init.sim.status           = TrackStatus::alive;
             init.geo.pos              = geo.pos();
             init.geo.dir              = secondary.direction;

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -261,6 +261,7 @@ TEST_F(UrbanMscTest, msc_scattering)
                                TrackId{i},
                                EventId{1},
                                i % 2,
+                               0,
                                TrackStatus::alive,
                                StepLimit{}};
         sim_state_data.push_back(state);

--- a/test/celeritas/ext/EventReader.test.cc
+++ b/test/celeritas/ext/EventReader.test.cc
@@ -113,6 +113,7 @@ TEST_P(EventReaderTest, read_all_formats)
         EXPECT_VEC_SOFT_EQ(expected_position, primary.position);
         EXPECT_VEC_SOFT_EQ(expected_direction[i], primary.direction);
         EXPECT_DOUBLE_EQ(expected_energy[i], primary.energy.value());
+        EXPECT_EQ(0, primary.time);
     }
 }
 

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -112,6 +112,7 @@ class TestEm3Test : public celeritas_test::TestEm3Base, public StepperTest
         p.track_id  = TrackId{0};
         p.position  = {-22, 0, 0};
         p.direction = {1, 0, 0};
+        p.time      = 0;
 
         std::vector<Primary> result(count, p);
         for (auto i : range(count))

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -68,12 +68,15 @@ class TrackInitTest : public celeritas_test::SimpleTestBase
         std::vector<Primary> result;
         for (unsigned int i = 0; i < num_primaries; ++i)
         {
-            result.push_back({ParticleId{0},
-                              units::MevEnergy{1. + i},
-                              {0., 0., 0.},
-                              {0., 0., 1.},
-                              EventId{0},
-                              TrackId{i}});
+            Primary p;
+            p.particle_id = ParticleId{0};
+            p.energy      = units::MevEnergy{1. + i};
+            p.position    = {0, 0, 0};
+            p.direction   = {0, 0, 1};
+            p.time        = 0;
+            p.event_id    = EventId{0};
+            p.track_id    = TrackId{i};
+            result.push_back(p);
         }
         return result;
     }


### PR DESCRIPTION
This adds the elapsed time in the lab frame since the beginning of the event to the track state (see #357).

In the Geant4 PRM the time change over a step is defined as the ratio of the true step length to the harmonic mean of the pre- and post-step particle velocity, but in the code it seems to be calculated using only the pre-step velocity, which is how it's implemented here (maybe @whokion could check if this is correct?)

I also added a fix to make sure the number of steps is initialized to zero for primaries.