### PR TITLE
Refactor stepper test and add "action result" for MSC interaction

### DIFF
--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -44,11 +44,12 @@
     },
     {
       "name": "base",
-      "displayName": "Wildstyle default options (GCC, debug)",
+      "displayName": "Wildstyle default options (GCC, debug, no omp)",
       "inherits": [".base"],
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install"
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install",
+        "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "OFF"}
       }
     },
     {

--- a/scripts/docker/ci/run-ci.sh
+++ b/scripts/docker/ci/run-ci.sh
@@ -18,6 +18,9 @@ cmake --preset=${CMAKE_PRESET}
 # Build
 cmake --build --preset=${CMAKE_PRESET}
 
+# Require regression-like tests to be enabled and pass
+export CELER_TEST_STRICT=1
+
 cd build
 # Test
 ctest -T Test ${_ctest_args}

--- a/src/celeritas/em/distribution/UrbanMscScatter.hh
+++ b/src/celeritas/em/distribution/UrbanMscScatter.hh
@@ -189,10 +189,8 @@ CELER_FUNCTION auto UrbanMscScatter::operator()(Engine& rng) -> MscInteraction
     if (skip_sampling_)
     {
         // Do not sample scattering at the last or at a small step
-        return {true_path_,
-                inc_direction_,
-                {0, 0, 0},
-                MscInteraction::Action::unchanged};
+        return {
+            true_path_, {0, 0, 0}, {0, 0, 0}, MscInteraction::Action::unchanged};
     }
 
     // Sample polar angle and update tau_
@@ -206,6 +204,10 @@ CELER_FUNCTION auto UrbanMscScatter::operator()(Engine& rng) -> MscInteraction
 
     MscInteraction result;
     result.action = MscInteraction::Action::scattered;
+    {
+        // This should only be needed to silence compiler warning
+        result.displacement = {0, 0, 0};
+    }
 
     // Calculate displacement
     if (input_.is_displaced && tau_ >= params_.tau_small)

--- a/src/celeritas/global/Stepper.hh
+++ b/src/celeritas/global/Stepper.hh
@@ -55,6 +55,33 @@ struct StepperResult
 };
 
 //---------------------------------------------------------------------------//
+//! Interface class for stepper classes.
+class StepperInterface
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Input       = StepperInput;
+    using VecPrimary  = std::vector<Primary>;
+    using result_type = StepperResult;
+    //!@}
+
+  public:
+    // Transport existing states
+    virtual StepperResult operator()() = 0;
+
+    // Transport existing states and these new primaries
+    virtual StepperResult operator()(VecPrimary primaries) = 0;
+
+    //! Whether the stepper is assigned/valid
+    virtual explicit operator bool() const = 0;
+
+  protected:
+    // Protected destructor prevents deletion of pointer-to-interface
+    ~StepperInterface() = default;
+};
+
+//---------------------------------------------------------------------------//
 /*!
  * Manage a state vector and execute a single step on all of them.
  *
@@ -71,11 +98,11 @@ struct StepperResult
    \endcode
  */
 template<MemSpace M>
-class Stepper
+class Stepper : public StepperInterface
 {
   public:
     //!@{
-    //! Type aliases
+    //! \name Type aliases
     using Input       = StepperInput;
     using VecPrimary  = std::vector<Primary>;
     using result_type = StepperResult;
@@ -98,13 +125,13 @@ class Stepper
     ~Stepper();
 
     // Transport existing states
-    StepperResult operator()();
+    StepperResult operator()() final;
 
     // Transport existing states and these new primaries
-    StepperResult operator()(VecPrimary primaries);
+    StepperResult operator()(VecPrimary primaries) final;
 
     //! Whether the stepper is assigned/valid
-    explicit operator bool() const { return static_cast<bool>(states_); }
+    explicit operator bool() const final { return static_cast<bool>(states_); }
 
   private:
     // Params and call sequence

--- a/src/celeritas/global/detail/AlongStepActionImpl.hh
+++ b/src/celeritas/global/detail/AlongStepActionImpl.hh
@@ -163,13 +163,19 @@ inline CELER_FUNCTION void along_step_track(CoreTrackView const& track)
         step_limit.step = msc_result.step_length;
 
         // Update direction and position
-        geo.set_dir(msc_result.direction);
-        Real3 new_pos;
-        for (int i : range(3))
+        if (msc_result.action != MscInteraction::Action::unchanged)
         {
-            new_pos[i] = geo.pos()[i] + msc_result.displacement[i];
+            geo.set_dir(msc_result.direction);
         }
-        geo.move_internal(new_pos);
+        if (msc_result.action == MscInteraction::Action::displaced)
+        {
+            Real3 new_pos;
+            for (int i : range(3))
+            {
+                new_pos[i] = geo.pos()[i] + msc_result.displacement[i];
+            }
+            geo.move_internal(new_pos);
+        }
     }
     else
     {

--- a/src/celeritas/phys/Interaction.hh
+++ b/src/celeritas/phys/Interaction.hh
@@ -50,7 +50,7 @@ struct Interaction
     // Return an interaction representing an absorbed process
     static inline CELER_FUNCTION Interaction from_absorption();
 
-    // Return an interaction with no change in the particle's state
+    // Return an interaction with no change in the track state
     static inline CELER_FUNCTION Interaction
     from_unchanged(units::MevEnergy energy, const Real3& direction);
 
@@ -90,9 +90,18 @@ struct MscStep
  */
 struct MscInteraction
 {
-    real_type step_length;  //!< True step length
-    Real3     direction;    //!< Post-step direction
-    Real3     displacement; //!< Lateral displacement
+    //! Interaction result category
+    enum class Action
+    {
+        displaced, //!< Direction and position changed
+        scattered, //!< Only direction changed
+        unchanged  //!< No state change
+    };
+
+    real_type step_length;               //!< True step length
+    Real3     direction;                 //!< Post-step direction
+    Real3     displacement;              //!< Lateral displacement
+    Action    action{Action::unchanged}; //!< Flags for interaction result
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/KernelDiagnostics.cc
+++ b/src/corecel/sys/KernelDiagnostics.cc
@@ -26,9 +26,19 @@ namespace celeritas
  */
 void KernelDiagnostics::log_launch(value_type& diag, unsigned int num_threads)
 {
+    static unsigned int remaining_log_msg = 32;
+    if (remaining_log_msg == 0)
+        return;
+
     CELER_LOG(debug) << "Launching '" << diag.name << "' on "
                      << diag.threads_per_block << " blocks with "
                      << num_threads << " threads";
+
+    if (--remaining_log_msg == 0)
+    {
+        CELER_LOG(debug) << "(Launch log limit reached: suppressing further "
+                            "output)";
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/KernelDiagnostics.hh
+++ b/src/corecel/sys/KernelDiagnostics.hh
@@ -128,9 +128,10 @@ void KernelDiagnostics::launch(key_type key, unsigned int num_threads)
     value_type& diag = values_[key.get()];
     ++diag.num_launches;
     diag.max_num_threads = std::max(num_threads, diag.max_num_threads);
-#if CELERITAS_DEBUG
-    this->log_launch(diag, num_threads);
-#endif
+    if (CELERITAS_DEBUG)
+    {
+        this->log_launch(diag, num_threads);
+    }
 }
 
 #ifdef CELER_DEVICE_SOURCE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -212,6 +212,7 @@ add_library(CeleritasTest
   celeritas/MockTestBase.cc
   celeritas/SimpleTestBase.cc
   celeritas/TestEm3Base.cc
+  celeritas/global/StepperTestBase.cc
 )
 celeritas_target_link_libraries(CeleritasTest
   PRIVATE celeritas celeritas_io CelerTest)

--- a/test/Test.cc
+++ b/test/Test.cc
@@ -115,7 +115,7 @@ std::string Test::make_unique_filename(const char* ext)
 /*!
  * True if strict testing is required.
  *
- * This is set during CI tests to that "loose" tests (which might depend on the
+ * This is set during CI tests so that "loose" tests (which might depend on the
  * environment) are enabled inside the CI.
  */
 bool Test::strict_testing()

--- a/test/Test.cc
+++ b/test/Test.cc
@@ -12,6 +12,7 @@
 #include <fstream>
 
 #include "corecel/Assert.hh"
+#include "corecel/sys/Environment.hh"
 
 #include "detail/TestConfig.hh"
 
@@ -36,7 +37,7 @@ std::string Test::test_data_path(const char* subdir, const char* filename)
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Generate test-unique filename.
+ * Generate test-unique filename.
  */
 std::string Test::make_unique_filename(const char* ext)
 {
@@ -108,6 +109,23 @@ std::string Test::make_unique_filename(const char* ext)
     os << ext;
 
     return os.str();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * True if strict testing is required.
+ *
+ * This is set during CI tests to that "loose" tests (which might depend on the
+ * environment) are enabled inside the CI.
+ */
+bool Test::strict_testing()
+{
+    const std::string& envstr = celeritas::getenv("CELER_TEST_STRICT");
+    if (envstr == "0")
+    {
+        return false;
+    }
+    return !envstr.empty();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/Test.hh
+++ b/test/Test.hh
@@ -30,6 +30,9 @@ class Test : public ::testing::Test
     // Get the path to a test file in `{source}/test/{subdir}/data/{filename}`
     static std::string test_data_path(const char* subdir, const char* filename);
 
+    // True if CELER_TEST_STRICT is set (under CI)
+    static bool strict_testing();
+
     // Define "inf" value for subclass testing
     static constexpr double inf = HUGE_VAL;
 

--- a/test/celeritas/TestEm3Base.cc
+++ b/test/celeritas/TestEm3Base.cc
@@ -107,9 +107,11 @@ auto TestEm3Base::build_physics() -> SPConstPhysics
     input.options        = this->build_physics_options();
     input.action_manager = this->action_mgr().get();
 
-    // For now, always use energy fluctuations
-    input.fluctuation = std::make_shared<FluctuationParams>(input.particles,
-                                                            input.materials);
+    if (this->enable_fluctuation())
+    {
+        input.fluctuation = std::make_shared<FluctuationParams>(
+            input.particles, input.materials);
+    }
 
     BremsstrahlungProcess::Options brem_options;
     brem_options.combined_model  = true;

--- a/test/celeritas/TestEm3Base.hh
+++ b/test/celeritas/TestEm3Base.hh
@@ -29,7 +29,7 @@ class TestEm3Base : virtual public GlobalGeoTestBase
 {
   public:
     //!@{
-    //! Type aliases
+    //! \name Type aliases
     using real_type      = celeritas::real_type;
     using ImportData     = celeritas::ImportData;
     using PhysicsOptions = celeritas::PhysicsParamsOptions;
@@ -38,6 +38,7 @@ class TestEm3Base : virtual public GlobalGeoTestBase
   protected:
     const char* geometry_basename() const override { return "testem3-flat"; }
 
+    virtual bool      enable_fluctuation() const { return true; }
     virtual bool      enable_msc() const { return false; }
     virtual real_type secondary_stack_factor() const { return 3.0; }
 

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -39,6 +39,7 @@ using namespace celeritas;
 
 using VGT       = ValueGridType;
 using MevEnergy = units::MevEnergy;
+using Action    = celeritas::MscInteraction::Action;
 
 using celeritas::MemSpace;
 using celeritas::Ownership;
@@ -272,6 +273,7 @@ TEST_F(UrbanMscTest, msc_scattering)
     RandomEngine&       rng_engine = this->rng();
     std::vector<double> fstep;
     std::vector<double> angle;
+    std::vector<char>   action;
     Real3               direction{0, 0, 1};
 
     for (auto i : celeritas::range(nsamples))
@@ -302,6 +304,9 @@ TEST_F(UrbanMscTest, msc_scattering)
 
         fstep.push_back(sample_result.step_length);
         angle.push_back(sample_result.direction[0]);
+        action.push_back(sample_result.action == Action::displaced   ? 'd'
+                         : sample_result.action == Action::scattered ? 's'
+                                                                     : 'u');
     }
 
     static const double expected_fstep[] = {0.0027916899999997,
@@ -322,4 +327,7 @@ TEST_F(UrbanMscTest, msc_scattering)
                                             0.793645871128744,
                                             -0.98020130119347};
     EXPECT_VEC_NEAR(expected_angle, angle, 1e-10);
+    static const char expected_action[]
+        = {'d', 'd', 'd', 's', 'd', 'd', 's', 's'};
+    EXPECT_VEC_EQ(expected_action, action);
 }

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -273,6 +273,7 @@ TEST_F(UrbanMscTest, msc_scattering)
     RandomEngine&       rng_engine = this->rng();
     std::vector<double> fstep;
     std::vector<double> angle;
+    std::vector<double> displace;
     std::vector<char>   action;
     Real3               direction{0, 0, 1};
 
@@ -303,7 +304,12 @@ TEST_F(UrbanMscTest, msc_scattering)
         sample_result = scatter(rng_engine);
 
         fstep.push_back(sample_result.step_length);
-        angle.push_back(sample_result.direction[0]);
+        angle.push_back(sample_result.action != Action::unchanged
+                            ? sample_result.direction[0]
+                            : 0);
+        displace.push_back(sample_result.action == Action::displaced
+                               ? sample_result.displacement[0]
+                               : 0);
         action.push_back(sample_result.action == Action::displaced   ? 'd'
                          : sample_result.action == Action::scattered ? 's'
                                                                      : 'u');
@@ -327,6 +333,15 @@ TEST_F(UrbanMscTest, msc_scattering)
                                             0.793645871128744,
                                             -0.98020130119347};
     EXPECT_VEC_NEAR(expected_angle, angle, 1e-10);
+    static const double expected_displace[] = {8.1986203515048e-06,
+                                               9.7530617641316e-05,
+                                               -7.1670542039709e-05,
+                                               0,
+                                               1.1960188979908e-05,
+                                               -2.8858960846053e-05,
+                                               0,
+                                               0};
+    EXPECT_VEC_NEAR(expected_displace, displace, 1e-10);
     static const char expected_action[]
         = {'d', 'd', 'd', 's', 'd', 'd', 's', 's'};
     EXPECT_VEC_EQ(expected_action, action);

--- a/test/celeritas/global/DummyAction.hh
+++ b/test/celeritas/global/DummyAction.hh
@@ -1,0 +1,34 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/DummyAction.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "celeritas/global/ActionInterface.hh"
+
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+class DummyAction final : public celeritas::ExplicitActionInterface,
+                          public celeritas::ConcreteAction
+{
+  public:
+    // Construct with ID and label
+    using ConcreteAction::ConcreteAction;
+
+    void execute(CoreHostRef const&) const final { ++num_execute_host_; }
+    void execute(CoreDeviceRef const&) const final { ++num_execute_device_; }
+
+    int num_execute_host() const { return num_execute_host_; }
+    int num_execute_device() const { return num_execute_device_; }
+
+  private:
+    mutable int num_execute_host_{0};
+    mutable int num_execute_device_{0};
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -213,7 +213,7 @@ TEST_F(TestEm3MscTest, host)
 
     if (this->is_ci_build())
     {
-        if (CELER_USE_VECGEOM)
+        if (CELERITAS_USE_VECGEOM)
         {
             EXPECT_EQ(128, result.num_step_iters());
             EXPECT_SOFT_EQ(338.75, result.calc_avg_steps_per_primary());
@@ -261,7 +261,7 @@ TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
 
     if (this->is_ci_build())
     {
-        if (CELER_USE_VECGEOM)
+        if (CELERITAS_USE_VECGEOM)
         {
             EXPECT_EQ(171, result.num_step_iters());
             EXPECT_SOFT_EQ(370.375, result.calc_avg_steps_per_primary());
@@ -311,7 +311,7 @@ TEST_F(TestEm3MscNofluctTest, host)
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(360, result.calc_avg_steps_per_primary(), 0.50);
 
-    if (this->is_ci_build() && CELER_USE_VECGEOM)
+    if (this->is_ci_build() && CELERITAS_USE_VECGEOM)
     {
         EXPECT_EQ(153, result.num_step_iters());
         EXPECT_SOFT_EQ(412.625, result.calc_avg_steps_per_primary());
@@ -348,7 +348,7 @@ TEST_F(TestEm3MscNofluctTest, TEST_IF_CELER_DEVICE(device))
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
 
-    if (this->is_ci_build() && CELER_USE_VECGEOM)
+    if (this->is_ci_build() && CELERITAS_USE_VECGEOM)
     {
         EXPECT_EQ(145, result.num_step_iters());
         EXPECT_SOFT_EQ(552, result.calc_avg_steps_per_primary());

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -113,8 +113,10 @@ TEST_F(TestEm3Test, host)
 
     if (this->is_ci_build())
     {
-        result.print_expected();
-        FAIL() << "Add CI data here";
+        EXPECT_EQ(343, result.num_step_iters());
+        EXPECT_SOFT_EQ(63490, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(255, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({108, 1416}), result.calc_queue_hwm());
     }
     else if (this->is_wildstyle_build())
     {
@@ -159,7 +161,14 @@ TEST_F(TestEm3Test, TEST_IF_CELER_DEVICE(device))
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(58000, result.calc_avg_steps_per_primary(), 0.10);
 
-    if (this->is_wildstyle_build())
+    if (this->is_ci_build())
+    {
+        EXPECT_EQ(218, result.num_step_iters());
+        EXPECT_SOFT_EQ(62756.625, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(82, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({75, 1450}), result.calc_queue_hwm());
+    }
+    else if (this->is_wildstyle_build())
     {
         EXPECT_EQ(218, result.num_step_iters());
         EXPECT_SOFT_EQ(62756.625, result.calc_avg_steps_per_primary());

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -65,7 +65,9 @@ class TestEm3Test : public celeritas_test::TestEm3Base,
 };
 
 //---------------------------------------------------------------------------//
-#define TestEm3MscTest TEST_IF_CELERITAS_GEANT(TestEm3MscTest)
+// TODO: these tests sporadically fail
+// #define TestEm3MscTest TEST_IF_CELERITAS_GEANT(TestEm3MscTest)
+#define TestEm3MscTest DISABLED_TestEm3MscTest
 class TestEm3MscTest : public TestEm3Test
 {
   public:
@@ -80,7 +82,9 @@ class TestEm3MscTest : public TestEm3Test
 };
 
 //---------------------------------------------------------------------------//
-#define TestEm3MscNofluctTest TEST_IF_CELERITAS_GEANT(TestEm3MscNofluctTest)
+// TODO: these tests sporadically fail
+// #define TestEm3MscNofluctTest TEST_IF_CELERITAS_GEANT(TestEm3MscNofluctTest)
+#define TestEm3MscNofluctTest DISABLED_TestEm3MscNofluctTest
 class TestEm3MscNofluctTest : public TestEm3Test
 {
   public:
@@ -207,7 +211,24 @@ TEST_F(TestEm3MscTest, host)
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(375, result.calc_avg_steps_per_primary(), 0.10);
 
-    if (this->is_wildstyle_build())
+    if (this->is_ci_build())
+    {
+        if (CELER_USE_VECGEOM)
+        {
+            EXPECT_EQ(128, result.num_step_iters());
+            EXPECT_SOFT_EQ(338.75, result.calc_avg_steps_per_primary());
+            EXPECT_EQ(32, result.calc_emptying_step());
+            EXPECT_EQ(RunResult::StepCount({4, 6}), result.calc_queue_hwm());
+        }
+        else
+        {
+            EXPECT_EQ(134, result.num_step_iters());
+            EXPECT_SOFT_EQ(381.25, result.calc_avg_steps_per_primary());
+            EXPECT_EQ(24, result.calc_emptying_step());
+            EXPECT_EQ(RunResult::StepCount({9, 7}), result.calc_queue_hwm());
+        }
+    }
+    else if (this->is_wildstyle_build())
     {
         EXPECT_EQ(134, result.num_step_iters());
         EXPECT_SOFT_EQ(381.25, result.calc_avg_steps_per_primary());
@@ -238,7 +259,24 @@ TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(375, result.calc_avg_steps_per_primary(), 0.10);
 
-    if (this->is_wildstyle_build())
+    if (this->is_ci_build())
+    {
+        if (CELER_USE_VECGEOM)
+        {
+            EXPECT_EQ(171, result.num_step_iters());
+            EXPECT_SOFT_EQ(370.375, result.calc_avg_steps_per_primary());
+            EXPECT_EQ(30, result.calc_emptying_step());
+            EXPECT_EQ(RunResult::StepCount({7, 8}), result.calc_queue_hwm());
+        }
+        else
+        {
+            EXPECT_EQ(161, result.num_step_iters());
+            EXPECT_SOFT_EQ(374.625, result.calc_avg_steps_per_primary());
+            EXPECT_EQ(19, result.calc_emptying_step());
+            EXPECT_EQ(RunResult::StepCount({7, 9}), result.calc_queue_hwm());
+        }
+    }
+    else if (this->is_wildstyle_build())
     {
         EXPECT_EQ(161, result.num_step_iters());
         EXPECT_SOFT_EQ(374.625, result.calc_avg_steps_per_primary());
@@ -271,9 +309,16 @@ TEST_F(TestEm3MscNofluctTest, host)
     Stepper<MemSpace::host> step(
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
-    EXPECT_SOFT_NEAR(300, result.calc_avg_steps_per_primary(), 0.10);
+    EXPECT_SOFT_NEAR(360, result.calc_avg_steps_per_primary(), 0.50);
 
-    if (this->is_srj_build())
+    if (this->is_ci_build() && CELER_USE_VECGEOM)
+    {
+        EXPECT_EQ(153, result.num_step_iters());
+        EXPECT_SOFT_EQ(412.625, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(60, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({5, 5}), result.calc_queue_hwm());
+    }
+    else if (this->is_srj_build())
     {
         EXPECT_EQ(131, result.num_step_iters());
         EXPECT_SOFT_EQ(299.625, result.calc_avg_steps_per_primary());
@@ -303,7 +348,14 @@ TEST_F(TestEm3MscNofluctTest, TEST_IF_CELER_DEVICE(device))
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
 
-    if (this->is_wildstyle_build())
+    if (this->is_ci_build() && CELER_USE_VECGEOM)
+    {
+        EXPECT_EQ(145, result.num_step_iters());
+        EXPECT_SOFT_EQ(552, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(52, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({7, 5}), result.calc_queue_hwm());
+    }
+    else if (this->is_wildstyle_build())
     {
         EXPECT_EQ(134, result.num_step_iters());
         EXPECT_SOFT_EQ(521.75, result.calc_avg_steps_per_primary());

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -227,7 +227,7 @@ TEST_F(TestEm3MscTest, host)
     }
 }
 
-TEST_F(TestEm3MscTest, device)
+TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
 {
     size_type num_primaries   = 8;
     size_type inits_per_track = 512;
@@ -245,6 +245,7 @@ TEST_F(TestEm3MscTest, device)
         EXPECT_EQ(19, result.calc_emptying_step());
         EXPECT_EQ(RunResult::StepCount({7, 9}), result.calc_queue_hwm());
     }
+    else
     {
         cout << "No output saved for combination of "
              << celeritas_test::PrintableBuildConf{} << std::endl;
@@ -270,7 +271,16 @@ TEST_F(TestEm3MscNofluctTest, host)
     Stepper<MemSpace::host> step(
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
+    EXPECT_SOFT_NEAR(300, result.calc_avg_steps_per_primary(), 0.10);
 
+    if (this->is_srj_build())
+    {
+        EXPECT_EQ(131, result.num_step_iters());
+        EXPECT_SOFT_EQ(299.625, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(35, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({1, 4}), result.calc_queue_hwm());
+    }
+    else
     {
         cout << "No output saved for combination of "
              << celeritas_test::PrintableBuildConf{} << std::endl;
@@ -283,7 +293,7 @@ TEST_F(TestEm3MscNofluctTest, host)
     }
 }
 
-TEST_F(TestEm3MscNofluctTest, device)
+TEST_F(TestEm3MscNofluctTest, TEST_IF_CELER_DEVICE(device))
 {
     size_type num_primaries   = 8;
     size_type inits_per_track = 512;
@@ -293,6 +303,14 @@ TEST_F(TestEm3MscNofluctTest, device)
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
 
+    if (this->is_wildstyle_build())
+    {
+        EXPECT_EQ(134, result.num_step_iters());
+        EXPECT_SOFT_EQ(521.75, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(52, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({16, 6}), result.calc_queue_hwm());
+    }
+    else
     {
         cout << "No output saved for combination of "
              << celeritas_test::PrintableBuildConf{} << std::endl;

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -7,12 +7,8 @@
 //---------------------------------------------------------------------------//
 #include "celeritas/global/Stepper.hh"
 
-#include <cstring>
-#include <memory>
-
 #include "corecel/Types.hh"
 #include "corecel/cont/Range.hh"
-#include "celeritas/GlobalGeoTestBase.hh"
 #include "celeritas/SimpleTestBase.hh"
 #include "celeritas/TestEm3Base.hh"
 #include "celeritas/global/ActionInterface.hh"
@@ -20,95 +16,40 @@
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/Primary.hh"
 
-#include "celeritas_cmake_strings.h"
+#include "DummyAction.hh"
+#include "StepperTestBase.hh"
 #include "celeritas_test.hh"
 
 using namespace celeritas;
-
-namespace
-{
-bool string_equal(const char* lhs, const char* rhs)
-{
-    return std::strcmp(lhs, rhs) == 0;
-}
-} // namespace
+using celeritas::units::MevEnergy;
 
 //---------------------------------------------------------------------------//
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class DummyAction final : public ExplicitActionInterface, public ConcreteAction
-{
-  public:
-    // Construct with ID and label
-    using ConcreteAction::ConcreteAction;
-
-    void execute(CoreHostRef const&) const final { ++num_execute_host_; }
-    void execute(CoreDeviceRef const&) const final { ++num_execute_device_; }
-
-    int num_execute_host() const { return num_execute_host_; }
-    int num_execute_device() const { return num_execute_device_; }
-
-  private:
-    mutable int num_execute_host_{0};
-    mutable int num_execute_device_{0};
-};
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct helper action and set up stepper/primary inputs.
- *
- * This class must be virtual so that it can be used as a mixin to other class
- * definitions.
- */
-class StepperTest : virtual public celeritas_test::GlobalTestBase
-{
-  protected:
-    void SetUp() override
-    {
-        auto& action_mgr = *this->action_mgr();
-
-        static const char desc[] = "count the number of executions";
-
-        dummy_action_ = std::make_shared<DummyAction>(
-            action_mgr.next_id(), "dummy-action", desc);
-        action_mgr.insert(dummy_action_);
-    }
-
-    StepperInput make_stepper_input(size_type tracks, size_type init_scaling)
-    {
-        CELER_EXPECT(tracks > 0);
-        CELER_EXPECT(init_scaling > 1);
-
-        StepperInput result;
-        result.params           = this->core();
-        result.num_track_slots  = tracks;
-        result.num_initializers = init_scaling * tracks;
-
-        CELER_ASSERT(dummy_action_);
-        result.post_step_callback = dummy_action_->action_id();
-        CELER_ENSURE(result.post_step_callback);
-        return result;
-    }
-
-    virtual std::vector<Primary> make_primaries(size_type count) const = 0;
-
-    std::shared_ptr<DummyAction> dummy_action_;
-};
-
-#if !CELERITAS_USE_GEANT4
-#    define TestEm3Test DISABLED_TestEm3Test
-#endif
-class TestEm3Test : public celeritas_test::TestEm3Base, public StepperTest
+#define TestEm3Test TEST_IF_CELERITAS_GEANT(TestEm3Test)
+class TestEm3Test : public celeritas_test::TestEm3Base,
+                    public celeritas_test::StepperTestBase
 {
   public:
     //! Make 10GeV electrons along +x
-    std::vector<Primary> make_primaries(size_type count) const final
+    std::vector<Primary> make_primaries(size_type count) const override
+    {
+        return this->make_primaries_with_energy(count, MevEnergy{10000});
+    }
+
+    size_type max_average_steps() const override
+    {
+        return 100000; // 8 primaries -> ~500k steps, be conservative
+    }
+
+    std::vector<Primary>
+    make_primaries_with_energy(size_type count, MevEnergy energy) const
     {
         Primary p;
         p.particle_id = this->particle()->find("e-");
         CELER_ASSERT(p.particle_id);
-        p.energy    = units::MevEnergy{10000};
+        p.energy    = energy;
         p.track_id  = TrackId{0};
         p.position  = {-22, 0, 0};
         p.direction = {1, 0, 0};
@@ -124,216 +65,220 @@ class TestEm3Test : public celeritas_test::TestEm3Base, public StepperTest
 };
 
 //---------------------------------------------------------------------------//
+// XXX: disabled due to MSC errors
+// #define TestEm3MscTest TEST_IF_CELERITAS_GEANT(TestEm3MscTest)
+#define TestEm3MscTest DISABLED_TestEm3MscTest
+class TestEm3MscTest : public TestEm3Test
+{
+  public:
+    //! Use MSC
+    bool enable_msc() const override { return true; }
+
+    //! Make 10MeV electrons along +x
+    std::vector<Primary> make_primaries(size_type count) const override
+    {
+        return this->make_primaries_with_energy(count, MevEnergy{10});
+    }
+};
+
+//---------------------------------------------------------------------------//
+// XXX: disabled due to MSC errors
+//#define TestEm3MscNofluctTest TEST_IF_CELERITAS_GEANT(TestEm3MscNofluctTest)
+#define TestEm3MscNofluctTest DISABLED_TestEm3MscNofluctTest
+class TestEm3MscNofluctTest : public TestEm3Test
+{
+  public:
+    //! Use MSC
+    bool enable_msc() const override { return true; }
+    //! Disable energy loss fluctuation
+    bool enable_fluctuation() const override { return false; }
+
+    //! Make 10MeV electrons along +x
+    std::vector<Primary> make_primaries(size_type count) const override
+    {
+        return this->make_primaries_with_energy(count, MevEnergy{10});
+    }
+};
+
+//---------------------------------------------------------------------------//
 // TESTEM3
 //---------------------------------------------------------------------------//
 
 TEST_F(TestEm3Test, host)
 {
-    size_type               num_primaries   = 1;
-    size_type               inits_per_track = 32 * 8;
-    size_type               num_tracks      = num_primaries * inits_per_track;
+    size_type num_primaries   = 1;
+    size_type inits_per_track = 32 * 8;
+    size_type num_tracks      = num_primaries * inits_per_track;
+
     Stepper<MemSpace::host> step(
         this->make_stepper_input(num_tracks, inits_per_track));
+    auto result = this->run(step, num_primaries);
+    EXPECT_SOFT_NEAR(58000, result.calc_avg_steps_per_primary(), 0.10);
 
-    auto counts = step(this->make_primaries(num_primaries));
-    EXPECT_EQ(1, counts.active);
-    EXPECT_EQ(0, counts.queued);
-    EXPECT_EQ(1, counts.alive);
-
-    std::vector<size_type> active = {counts.active};
-    std::vector<size_type> queued = {counts.queued};
-    while (counts)
+    if (this->is_ci_build())
     {
-        counts = step();
-        active.push_back(counts.active);
-        queued.push_back(counts.queued);
-        ASSERT_LT(active.size(), 1000) << "max iterations exceeded";
+        result.print_expected();
+        FAIL() << "Add CI data here";
     }
-
-    if (string_equal(celeritas_rng, "XORWOW")
-        && string_equal(celeritas_clhep_version, "2.4.5.1")
-        && string_equal(celeritas_geant4_version, "10.7.3"))
+    else if (this->is_wildstyle_build())
     {
-        static const unsigned int expected_active[] = {
-            1u,   1u,   2u,   3u,   5u,   7u,   8u,   12u,  16u,  21u,  26u,
-            29u,  32u,  35u,  41u,  47u,  55u,  64u,  85u,  102u, 111u, 117u,
-            130u, 130u, 140u, 153u, 167u, 185u, 206u, 226u, 239u, 255u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u,
-            256u, 256u, 256u, 256u, 256u, 256u, 256u, 256u, 249u, 241u, 228u,
-            209u, 208u, 203u, 193u, 190u, 173u, 164u, 158u, 149u, 148u, 151u,
-            156u, 155u, 155u, 147u, 135u, 139u, 140u, 129u, 117u, 114u, 113u,
-            104u, 98u,  102u, 99u,  88u,  91u,  88u,  83u,  80u,  79u,  75u,
-            73u,  76u,  75u,  72u,  66u,  67u,  63u,  63u,  63u,  58u,  56u,
-            49u,  39u,  35u,  34u,  31u,  34u,  35u,  32u,  34u,  35u,  33u,
-            27u,  29u,  31u,  28u,  30u,  29u,  28u,  21u,  19u,  16u,  15u,
-            13u,  13u,  13u,  12u,  9u,   9u,   9u,   9u,   9u,   10u,  12u,
-            12u,  13u,  11u,  11u,  12u,  11u,  9u,   10u,  9u,   8u,   7u,
-            6u,   3u,   3u,   3u,   3u,   2u,   2u,   1u,   1u};
-        EXPECT_VEC_EQ(expected_active, active);
-
-        static const unsigned int expected_queued[]
-            = {0u,    1u,    1u,    2u,    2u,    1u,    4u,    4u,    6u,
-               7u,    5u,    8u,    5u,    7u,    10u,   9u,    15u,   24u,
-               22u,   18u,   21u,   24u,   16u,   19u,   26u,   30u,   30u,
-               36u,   34u,   39u,   46u,   52u,   84u,   97u,   124u,  153u,
-               196u,  240u,  276u,  312u,  350u,  388u,  426u,  445u,  483u,
-               517u,  553u,  583u,  592u,  615u,  625u,  647u,  672u,  691u,
-               715u,  745u,  770u,  803u,  829u,  860u,  885u,  916u,  947u,
-               970u,  990u,  1024u, 1056u, 1088u, 1106u, 1132u, 1145u, 1161u,
-               1185u, 1199u, 1214u, 1241u, 1263u, 1278u, 1276u, 1278u, 1278u,
-               1280u, 1274u, 1254u, 1247u, 1247u, 1252u, 1249u, 1234u, 1212u,
-               1204u, 1175u, 1174u, 1159u, 1151u, 1138u, 1127u, 1108u, 1094u,
-               1079u, 1053u, 1036u, 1030u, 1017u, 1002u, 989u,  972u,  949u,
-               928u,  917u,  916u,  908u,  884u,  867u,  846u,  825u,  821u,
-               820u,  815u,  805u,  790u,  780u,  763u,  754u,  739u,  730u,
-               733u,  721u,  715u,  711u,  697u,  677u,  664u,  652u,  645u,
-               643u,  635u,  624u,  617u,  596u,  581u,  565u,  552u,  547u,
-               549u,  547u,  551u,  547u,  543u,  541u,  538u,  547u,  536u,
-               538u,  535u,  542u,  546u,  539u,  533u,  530u,  510u,  496u,
-               480u,  463u,  458u,  449u,  447u,  441u,  446u,  450u,  457u,
-               457u,  453u,  443u,  433u,  432u,  409u,  403u,  397u,  395u,
-               394u,  386u,  379u,  378u,  384u,  390u,  390u,  387u,  375u,
-               376u,  369u,  367u,  362u,  356u,  354u,  341u,  318u,  317u,
-               319u,  310u,  295u,  287u,  291u,  289u,  283u,  279u,  284u,
-               271u,  262u,  240u,  217u,  196u,  199u,  191u,  183u,  183u,
-               177u,  176u,  165u,  141u,  129u,  139u,  138u,  131u,  126u,
-               128u,  127u,  116u,  110u,  103u,  100u,  90u,   76u,   68u,
-               75u,   60u,   52u,   41u,   28u,   33u,   31u,   22u,   24u,
-               25u,   25u,   25u,   19u,   19u,   16u,   15u,   18u,   22u,
-               20u,   16u,   25u,   17u,   14u,   16u,   19u,   15u,   17u,
-               15u,   15u,   12u,   8u,    13u,   10u,   8u,    16u,   14u,
-               8u,    9u,    7u,    8u,    10u,   9u,    11u,   9u,    6u,
-               11u,   10u,   9u,    9u,    10u,   9u,    3u,    4u,    3u,
-               5u,    1u,    4u,    4u,    2u,    5u,    5u,    2u,    2u,
-               3u,    6u,    4u,    6u,    4u,    6u,    3u,    3u,    1u,
-               1u,    1u,    1u,    1u,    1u,    0u,    1u,    0u,    1u,
-               1u,    1u,    2u,    1u,    3u,    2u,    1u,    2u,    1u,
-               0u,    2u,    1u,    1u,    0u,    0u,    0u,    0u,    0u,
-               0u,    0u,    0u,    0u,    0u,    0u};
-        EXPECT_VEC_EQ(expected_queued, queued);
+        EXPECT_EQ(343, result.num_step_iters());
+        EXPECT_SOFT_EQ(63490, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(255, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({108, 1416}), result.calc_queue_hwm());
+    }
+    else if (this->is_srj_build())
+    {
+        EXPECT_EQ(321, result.num_step_iters());
+        EXPECT_SOFT_EQ(54526, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(207, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({90, 1268}), result.calc_queue_hwm());
     }
     else
     {
-        cout << "No output saved for combination of RNG=\"" << celeritas_rng
-             << "\", CLHEP=\"" << celeritas_clhep_version << "\", Geant4=\""
-             << celeritas_geant4_version << "\"\n";
-        PRINT_EXPECTED(active);
-        PRINT_EXPECTED(queued);
+        cout << "No output saved for combination of "
+             << celeritas_test::PrintableBuildConf{} << std::endl;
+        result.print_expected();
+
+        if (this->strict_testing())
+        {
+            FAIL() << "Updated stepper results are required for CI tests";
+        }
     }
 
     // Check that callback was called
-    EXPECT_EQ(active.size(), dummy_action_->num_execute_host());
-    EXPECT_EQ(0, dummy_action_->num_execute_device());
+    EXPECT_EQ(result.active.size(), this->dummy_action().num_execute_host());
+    EXPECT_EQ(0, this->dummy_action().num_execute_device());
 }
 
 TEST_F(TestEm3Test, TEST_IF_CELER_DEVICE(device))
 {
     size_type num_primaries   = 8;
     size_type inits_per_track = 1024;
-    size_type num_tracks = num_primaries * 800; // low enough to max out the
-                                                // active tracks
+    // Num tracks is low enough to hit capacity
+    size_type num_tracks = num_primaries * 800;
 
     Stepper<MemSpace::device> step(
         this->make_stepper_input(num_tracks, inits_per_track));
+    auto result = this->run(step, num_primaries);
+    EXPECT_SOFT_NEAR(58000, result.calc_avg_steps_per_primary(), 0.10);
 
-    auto counts = step(this->make_primaries(num_primaries));
-    EXPECT_EQ(num_primaries, counts.active);
-    EXPECT_EQ(num_primaries, counts.alive);
-    if (std::string(celeritas_rng) == std::string("XORWOW"))
+    if (this->is_wildstyle_build())
     {
-        EXPECT_EQ(0, counts.queued);
-    }
-
-    std::vector<size_type> active = {counts.active};
-    std::vector<size_type> queued = {counts.queued};
-    while (counts)
-    {
-        counts = step();
-        active.push_back(counts.active);
-        queued.push_back(counts.queued);
-        ASSERT_LT(active.size(), 300) << "max iterations exceeded";
-    }
-
-    if (string_equal(celeritas_rng, "XORWOW")
-        && string_equal(celeritas_clhep_version, "2.4.5.1")
-        && string_equal(celeritas_geant4_version, "10.7.3"))
-    {
-        static const unsigned int expected_active[]
-            = {8u,    8u,    16u,   27u,   35u,   49u,   64u,   74u,   87u,
-               99u,   114u,  129u,  164u,  200u,  235u,  285u,  335u,  378u,
-               425u,  491u,  544u,  621u,  700u,  799u,  889u,  995u,  1123u,
-               1236u, 1359u, 1509u, 1666u, 1832u, 1970u, 2144u, 2333u, 2488u,
-               2641u, 2798u, 2980u, 3187u, 3331u, 3485u, 3673u, 3851u, 4022u,
-               4201u, 4397u, 4591u, 4848u, 5075u, 5223u, 5449u, 5714u, 5962u,
-               6141u, 6297u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u,
-               6400u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u,
-               6400u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u,
-               6400u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u, 6400u,
-               6400u, 6400u, 6400u, 6400u, 6042u, 5819u, 5648u, 5434u, 5225u,
-               5049u, 4891u, 4694u, 4566u, 4488u, 4336u, 4246u, 4070u, 3925u,
-               3796u, 3640u, 3453u, 3292u, 3128u, 3030u, 2931u, 2822u, 2758u,
-               2667u, 2485u, 2418u, 2374u, 2312u, 2188u, 2053u, 1947u, 1848u,
-               1685u, 1631u, 1554u, 1484u, 1398u, 1317u, 1246u, 1146u, 1072u,
-               999u,  932u,  897u,  804u,  745u,  681u,  615u,  574u,  523u,
-               471u,  416u,  372u,  330u,  299u,  297u,  281u,  258u,  226u,
-               202u,  183u,  157u,  134u,  119u,  106u,  98u,   92u,   81u,
-               76u,   67u,   66u,   62u,   55u,   46u,   41u,   37u,   30u,
-               29u,   24u,   18u,   17u,   15u,   17u,   16u,   14u,   14u,
-               9u,    6u,    6u,    6u,    5u,    4u,    3u,    3u,    2u,
-               2u,    2u,    2u,    2u,    2u,    1u};
-        EXPECT_VEC_EQ(expected_active, active);
-        static const unsigned int expected_queued[]
-            = {0u,    8u,    11u,   8u,    14u,   15u,   12u,   16u,   17u,
-               21u,   22u,   42u,   44u,   48u,   58u,   67u,   75u,   76u,
-               93u,   95u,   122u,  125u,  157u,  168u,  186u,  223u,  218u,
-               241u,  275u,  289u,  313u,  331u,  354u,  414u,  395u,  437u,
-               438u,  478u,  540u,  523u,  561u,  605u,  614u,  623u,  627u,
-               679u,  726u,  782u,  778u,  806u,  858u,  907u,  941u,  923u,
-               961u,  936u,  994u,  1126u, 1289u, 1495u, 1695u, 1886u, 2047u,
-               2199u, 2349u, 2529u, 2644u, 2754u, 2888u, 3045u, 3143u, 3217u,
-               3336u, 3391u, 3452u, 3407u, 3432u, 3400u, 3366u, 3364u, 3342u,
-               3294u, 3201u, 3033u, 2870u, 2674u, 2531u, 2335u, 2129u, 1935u,
-               1712u, 1437u, 1089u, 749u,  769u,  726u,  676u,  666u,  666u,
-               623u,  581u,  572u,  591u,  545u,  549u,  493u,  483u,  476u,
-               441u,  427u,  394u,  368u,  388u,  381u,  333u,  366u,  336u,
-               258u,  319u,  282u,  282u,  272u,  246u,  235u,  218u,  171u,
-               192u,  175u,  185u,  173u,  155u,  144u,  136u,  120u,  119u,
-               98u,   115u,  90u,   86u,   74u,   58u,   67u,   61u,   60u,
-               43u,   38u,   33u,   26u,   35u,   32u,   37u,   20u,   18u,
-               21u,   15u,   18u,   15u,   12u,   10u,   15u,   6u,    10u,
-               5u,    7u,    9u,    4u,    4u,    5u,    6u,    4u,    6u,
-               1u,    1u,    3u,    1u,    4u,    2u,    2u,    3u,    0u,
-               0u,    1u,    1u,    0u,    1u,    0u,    0u,    0u,    0u,
-               0u,    0u,    1u,    0u,    0u,    0u};
-        EXPECT_VEC_EQ(expected_queued, queued);
+        EXPECT_EQ(218, result.num_step_iters());
+        EXPECT_SOFT_EQ(62756.625, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(82, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({75, 1450}), result.calc_queue_hwm());
     }
     else
     {
-        cout << "No output saved for combination of RNG=\"" << celeritas_rng
-             << "\", CLHEP=\"" << celeritas_clhep_version << "\", Geant4=\""
-             << celeritas_geant4_version << "\"\n";
-        PRINT_EXPECTED(active);
-        PRINT_EXPECTED(queued);
+        cout << "No output saved for combination of "
+             << celeritas_test::PrintableBuildConf{} << std::endl;
+        result.print_expected();
+
+        if (this->strict_testing())
+        {
+            FAIL() << "Updated stepper results are required for CI tests";
+        }
     }
 
     // Check that callback was called
-    EXPECT_EQ(active.size(), dummy_action_->num_execute_device());
-    EXPECT_EQ(0, dummy_action_->num_execute_host());
+    EXPECT_EQ(result.active.size(), this->dummy_action().num_execute_device());
+    EXPECT_EQ(0, this->dummy_action().num_execute_host());
+}
+
+//---------------------------------------------------------------------------//
+// TESTEM3_MSC
+//---------------------------------------------------------------------------//
+
+TEST_F(TestEm3MscTest, host)
+{
+    size_type num_primaries   = 8;
+    size_type inits_per_track = 32 * 8;
+    size_type num_tracks      = num_primaries * inits_per_track;
+
+    Stepper<MemSpace::host> step(
+        this->make_stepper_input(num_tracks, inits_per_track));
+    auto result = this->run(step, num_primaries);
+
+    {
+        cout << "No output saved for combination of "
+             << celeritas_test::PrintableBuildConf{} << std::endl;
+        result.print_expected();
+
+        if (this->strict_testing())
+        {
+            FAIL() << "Updated stepper results are required for CI tests";
+        }
+    }
+}
+
+TEST_F(TestEm3MscTest, device)
+{
+    size_type num_primaries   = 8;
+    size_type inits_per_track = 512;
+    size_type num_tracks      = 1024;
+
+    Stepper<MemSpace::device> step(
+        this->make_stepper_input(num_tracks, inits_per_track));
+    auto result = this->run(step, num_primaries);
+
+    {
+        cout << "No output saved for combination of "
+             << celeritas_test::PrintableBuildConf{} << std::endl;
+        result.print_expected();
+
+        if (this->strict_testing())
+        {
+            FAIL() << "Updated stepper results are required for CI tests";
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+// TESTEM3_MSC_NOFLUCT
+//---------------------------------------------------------------------------//
+
+TEST_F(TestEm3MscNofluctTest, host)
+{
+    size_type num_primaries   = 8;
+    size_type inits_per_track = 32 * 8;
+    size_type num_tracks      = num_primaries * inits_per_track;
+
+    Stepper<MemSpace::host> step(
+        this->make_stepper_input(num_tracks, inits_per_track));
+    auto result = this->run(step, num_primaries);
+
+    {
+        cout << "No output saved for combination of "
+             << celeritas_test::PrintableBuildConf{} << std::endl;
+        result.print_expected();
+
+        if (this->strict_testing())
+        {
+            FAIL() << "Updated stepper results are required for CI tests";
+        }
+    }
+}
+
+TEST_F(TestEm3MscNofluctTest, device)
+{
+    size_type num_primaries   = 8;
+    size_type inits_per_track = 512;
+    size_type num_tracks      = 1024;
+
+    Stepper<MemSpace::device> step(
+        this->make_stepper_input(num_tracks, inits_per_track));
+    auto result = this->run(step, num_primaries);
+
+    {
+        cout << "No output saved for combination of "
+             << celeritas_test::PrintableBuildConf{} << std::endl;
+        result.print_expected();
+
+        if (this->strict_testing())
+        {
+            FAIL() << "Updated stepper results are required for CI tests";
+        }
+    }
 }

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -65,9 +65,7 @@ class TestEm3Test : public celeritas_test::TestEm3Base,
 };
 
 //---------------------------------------------------------------------------//
-// XXX: disabled due to MSC errors
-// #define TestEm3MscTest TEST_IF_CELERITAS_GEANT(TestEm3MscTest)
-#define TestEm3MscTest DISABLED_TestEm3MscTest
+#define TestEm3MscTest TEST_IF_CELERITAS_GEANT(TestEm3MscTest)
 class TestEm3MscTest : public TestEm3Test
 {
   public:
@@ -82,9 +80,7 @@ class TestEm3MscTest : public TestEm3Test
 };
 
 //---------------------------------------------------------------------------//
-// XXX: disabled due to MSC errors
-//#define TestEm3MscNofluctTest TEST_IF_CELERITAS_GEANT(TestEm3MscNofluctTest)
-#define TestEm3MscNofluctTest DISABLED_TestEm3MscNofluctTest
+#define TestEm3MscNofluctTest TEST_IF_CELERITAS_GEANT(TestEm3MscNofluctTest)
 class TestEm3MscNofluctTest : public TestEm3Test
 {
   public:
@@ -200,7 +196,16 @@ TEST_F(TestEm3MscTest, host)
     Stepper<MemSpace::host> step(
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
+    EXPECT_SOFT_NEAR(375, result.calc_avg_steps_per_primary(), 0.10);
 
+    if (this->is_wildstyle_build())
+    {
+        EXPECT_EQ(134, result.num_step_iters());
+        EXPECT_SOFT_EQ(381.25, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(24, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({9, 7}), result.calc_queue_hwm());
+    }
+    else
     {
         cout << "No output saved for combination of "
              << celeritas_test::PrintableBuildConf{} << std::endl;
@@ -222,7 +227,15 @@ TEST_F(TestEm3MscTest, device)
     Stepper<MemSpace::device> step(
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
+    EXPECT_SOFT_NEAR(375, result.calc_avg_steps_per_primary(), 0.10);
 
+    if (this->is_wildstyle_build())
+    {
+        EXPECT_EQ(161, result.num_step_iters());
+        EXPECT_SOFT_EQ(374.625, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(19, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({7, 9}), result.calc_queue_hwm());
+    }
     {
         cout << "No output saved for combination of "
              << celeritas_test::PrintableBuildConf{} << std::endl;

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -1,0 +1,208 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/StepperTestBase.cc
+//---------------------------------------------------------------------------//
+#include "StepperTestBase.hh"
+
+#include <algorithm>
+#include <cstring>
+#include <numeric>
+#include <gtest/gtest.h>
+
+#include "corecel/io/Repr.hh"
+#include "celeritas/global/ActionManager.hh"
+#include "celeritas/global/Stepper.hh"
+
+#include "celeritas_cmake_strings.h"
+
+using namespace celeritas;
+using std::cout;
+
+namespace celeritas_test
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+//! Test for equality of two C strings
+bool cstring_equal(const char* lhs, const char* rhs)
+{
+    return std::strcmp(lhs, rhs) == 0;
+}
+//---------------------------------------------------------------------------//
+} // namespace
+
+//---------------------------------------------------------------------------//
+//! Whether Geant4 dependencies match those on the CI build
+bool StepperTestBase::is_ci_build()
+{
+    return cstring_equal(celeritas_rng, "XORWOW")
+           && cstring_equal(celeritas_clhep_version, "2.4.4.0")
+           && cstring_equal(celeritas_geant4_version, "10.7.2");
+}
+
+//---------------------------------------------------------------------------//
+//! Whether Geant4 dependencies match those on Wildstyle
+bool StepperTestBase::is_wildstyle_build()
+{
+    return cstring_equal(celeritas_rng, "XORWOW")
+           && cstring_equal(celeritas_clhep_version, "2.4.5.1")
+           && cstring_equal(celeritas_geant4_version, "10.7.3");
+}
+
+//---------------------------------------------------------------------------//
+//! Whether Geant4 dependencies match those on the CI build
+bool StepperTestBase::is_srj_build()
+{
+    return cstring_equal(celeritas_rng, "XORWOW")
+           && cstring_equal(celeritas_clhep_version, "2.4.5.1")
+           && cstring_equal(celeritas_geant4_version, "11.0.0");
+}
+
+//---------------------------------------------------------------------------//
+//! Construct dummy action at creation
+StepperTestBase::StepperTestBase()
+{
+    auto& action_mgr = *this->action_mgr();
+
+    static const char desc[] = "count the number of executions";
+    dummy_action_            = std::make_shared<DummyAction>(
+        action_mgr.next_id(), "dummy-action", desc);
+    action_mgr.insert(dummy_action_);
+}
+
+//---------------------------------------------------------------------------//
+//! Generate a stepper construction class
+StepperInput
+StepperTestBase::make_stepper_input(size_type tracks, size_type init_scaling)
+{
+    CELER_EXPECT(tracks > 0);
+    CELER_EXPECT(init_scaling > 1);
+
+    StepperInput result;
+    result.params           = this->core();
+    result.num_track_slots  = tracks;
+    result.num_initializers = init_scaling * tracks;
+
+    CELER_ASSERT(dummy_action_);
+    result.post_step_callback = dummy_action_->action_id();
+    CELER_ENSURE(result.post_step_callback);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+auto StepperTestBase::run(StepperInterface& step,
+                          size_type         num_primaries) const -> RunResult
+{
+    CELER_EXPECT(step);
+
+    // Perform first step
+    auto counts = step(this->make_primaries(num_primaries));
+    EXPECT_EQ(num_primaries, counts.active);
+    EXPECT_EQ(num_primaries, counts.alive);
+
+    RunResult result;
+    result.active = {counts.active};
+    result.queued = {counts.queued};
+
+    const size_type max_steps   = this->max_average_steps() * num_primaries;
+    size_type       accum_steps = counts.active;
+
+    while (counts)
+    {
+        counts = step();
+        result.active.push_back(counts.active);
+        result.queued.push_back(counts.queued);
+        accum_steps += counts.active;
+        EXPECT_LT(accum_steps, max_steps) << "max steps exceeded";
+        if (accum_steps >= max_steps)
+        {
+            break;
+        }
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+// RUN RESULT
+//---------------------------------------------------------------------------//
+//! Cumulative number of steps over all tracks / number of primaries
+double StepperTestBase::RunResult::calc_avg_steps_per_primary() const
+{
+    CELER_EXPECT(*this);
+    size_type num_primaries = this->active.front();
+    auto      accum_steps   = std::accumulate(
+        this->active.begin(), this->active.end(), size_type{0});
+    return static_cast<double>(accum_steps)
+           / static_cast<double>(num_primaries);
+}
+
+//---------------------------------------------------------------------------//
+//! Index of last non-full step after capacity/maximum is reached
+size_type StepperTestBase::RunResult::calc_emptying_step() const
+{
+    CELER_EXPECT(*this);
+    auto iter = this->active.begin();
+    // Iterator where previous value is high water mark and current is less
+    auto result = iter;
+    // Value of the previous step
+    size_type prev = *iter++;
+    // Unfortunately we don't know the capacity (and it might not even be
+    // reached?) so find the highest value
+    size_type max_cap = 0;
+    while (iter != this->active.end())
+    {
+        max_cap = celeritas::max(prev, max_cap);
+        if (prev == max_cap && *iter < max_cap)
+        {
+            result = iter;
+        }
+        prev = *iter++;
+    }
+    return result - this->active.begin();
+}
+
+//---------------------------------------------------------------------------//
+//! Index of the high water mark of the initializer queue
+auto StepperTestBase::RunResult::calc_queue_hwm() const -> StepCount
+{
+    CELER_EXPECT(*this);
+    auto iter = std::max_element(this->queued.begin(), this->queued.end());
+    return {iter - this->queued.begin(), *iter};
+}
+
+//---------------------------------------------------------------------------//
+//! Print the expected result
+void StepperTestBase::RunResult::print_expected() const
+{
+    CELER_EXPECT(*this);
+    auto step_value = this->calc_queue_hwm();
+    cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
+            "EXPECT_EQ("
+         << this->num_step_iters()
+         << ", result.num_step_iters());\n"
+            "EXPECT_SOFT_EQ("
+         << repr(this->calc_avg_steps_per_primary())
+         << ", result.calc_avg_steps_per_primary());\n"
+            "EXPECT_EQ("
+         << this->calc_emptying_step()
+         << ", result.calc_emptying_step());\n"
+            "EXPECT_EQ(RunResult::StepCount({"
+         << step_value.first << ", " << step_value.second
+         << "}), result.calc_queue_hwm());\n"
+            "/*** END CODE ***/\n";
+}
+
+//---------------------------------------------------------------------------//
+std::ostream& operator<<(std::ostream& os, const PrintableBuildConf&)
+{
+    os << "RNG=\"" << celeritas_rng << "\", CLHEP=\""
+       << celeritas_clhep_version << "\", Geant4=\""
+       << celeritas_geant4_version << '"';
+    return os;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -140,7 +140,15 @@ double StepperTestBase::RunResult::calc_avg_steps_per_primary() const
 }
 
 //---------------------------------------------------------------------------//
-//! Index of last non-full step after capacity/maximum is reached
+/*!
+ * Index of step after the final non-full capacity/maximum is reached.
+ *
+ * For example: \verbatim
+    1, 2, 4, 8, 7, 8, 4, 3, 2, 1, 0
+                      ^
+   \endverbatim
+ * returns 6.
+ */
 size_type StepperTestBase::RunResult::calc_emptying_step() const
 {
     CELER_EXPECT(*this);

--- a/test/celeritas/global/StepperTestBase.hh
+++ b/test/celeritas/global/StepperTestBase.hh
@@ -1,0 +1,121 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/StepperTestBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <iosfwd>
+#include <memory>
+#include <vector>
+
+#include "corecel/Types.hh"
+#include "celeritas/GlobalTestBase.hh"
+
+#include "DummyAction.hh"
+
+namespace celeritas
+{
+struct StepperInput;
+struct Primary;
+class StepperInterface;
+} // namespace celeritas
+
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct helper action and set up stepper/primary inputs.
+ *
+ * This class must be virtual so that it can be used as a mixin to other class
+ * definitions.
+ *
+ * Example:
+ * \code
+    class TestEm3Test : public celeritas_test::TestEm3Base,
+                        public celeritas_test::StepperTestBase
+    {
+      public:
+        //! Make 10GeV electrons along +x
+        std::vector<Primary> make_primaries(size_type count) const override;
+    };
+ * \endcode
+ */
+class StepperTestBase : virtual public celeritas_test::GlobalTestBase
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using size_type = celeritas::size_type;
+    //!@}
+
+    struct RunResult
+    {
+        using StepCount = std::pair<size_type, size_type>;
+
+        std::vector<size_type> active;
+        std::vector<size_type> queued;
+
+        //! Total number of step iterations
+        size_type num_step_iters() const { return active.size(); }
+        // Cumulative number of steps over all tracks / number of primaries
+        double calc_avg_steps_per_primary() const;
+        // Index of first non-full step after capacity is reached
+        size_type calc_emptying_step() const;
+        // Step index and value of the high water mark of the initializer queue
+        StepCount calc_queue_hwm() const;
+
+        // Print code for the expected attributes
+        void print_expected() const;
+
+        //! True if run was performed and data is consistent
+        explicit operator bool() const
+        {
+            return !active.empty() && queued.size() == active.size();
+        }
+    };
+
+  public:
+    //!@{
+    //! Whether the Geant4 configuration match a certain machine
+    static bool is_ci_build();
+    static bool is_wildstyle_build();
+    static bool is_srj_build();
+    //!@}
+
+    // Add dummy action at construction
+    StepperTestBase();
+
+    // Construct the setup values for Stepper
+    celeritas::StepperInput
+    make_stepper_input(size_type tracks, size_type init_scaling);
+
+    //! Create a vector of primaries inside the 'run' function
+    virtual std::vector<celeritas::Primary>
+    make_primaries(size_type count) const = 0;
+
+    //! Maximum number of steps on average before aborting
+    virtual size_type max_average_steps() const = 0;
+
+    // Run a bunch of primaries to completion
+    RunResult
+    run(celeritas::StepperInterface& step, size_type num_primaries) const;
+
+    //! Access the dummy action
+    const DummyAction& dummy_action() const { return *dummy_action_; }
+
+  protected:
+    std::shared_ptr<DummyAction> dummy_action_;
+};
+
+//---------------------------------------------------------------------------//
+//! Print the current configuration
+struct PrintableBuildConf
+{
+};
+std::ostream& operator<<(std::ostream& os, const PrintableBuildConf&);
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/detail/Macros.hh
+++ b/test/detail/Macros.hh
@@ -70,7 +70,7 @@
 #    define TEST_IF_CELER_DEVICE(name) DISABLED_##name
 #endif
 
-//! Construct a test name that is disabled when JSON is disabled
+//! Construct a test name that is disabled when Geant4 is disabled
 #if CELERITAS_USE_GEANT4
 #    define TEST_IF_CELERITAS_GEANT(name) name
 #else

--- a/test/detail/Macros.hh
+++ b/test/detail/Macros.hh
@@ -70,11 +70,11 @@
 #    define TEST_IF_CELER_DEVICE(name) DISABLED_##name
 #endif
 
-//! Construct a test name that is disabled when ROOT is disabled
-#if CELERITAS_USE_ROOT
-#    define TEST_IF_CELERITAS_USE_ROOT(name) name
+//! Construct a test name that is disabled when JSON is disabled
+#if CELERITAS_USE_GEANT4
+#    define TEST_IF_CELERITAS_GEANT(name) name
 #else
-#    define TEST_IF_CELERITAS_USE_ROOT(name) DISABLED_##name
+#    define TEST_IF_CELERITAS_GEANT(name) DISABLED_##name
 #endif
 
 //! Construct a test name that is disabled when JSON is disabled
@@ -82,6 +82,13 @@
 #    define TEST_IF_CELERITAS_JSON(name) name
 #else
 #    define TEST_IF_CELERITAS_JSON(name) DISABLED_##name
+#endif
+
+//! Construct a test name that is disabled when ROOT is disabled
+#if CELERITAS_USE_ROOT
+#    define TEST_IF_CELERITAS_USE_ROOT(name) name
+#else
+#    define TEST_IF_CELERITAS_USE_ROOT(name) DISABLED_##name
 #endif
 
 namespace celeritas_test

--- a/test/detail/TestMain.cc
+++ b/test/detail/TestMain.cc
@@ -99,17 +99,17 @@ int test_main(int argc, char** argv)
         }
 
         // Write diagnostics and overall test result
-        cout << color_code('x');
         if (celeritas::device())
         {
-            cout << "Kernel diagnostics: " << celeritas::kernel_diagnostics()
-                 << endl;
+            CELER_LOG(debug)
+                << "Kernel diagnostics: " << celeritas::kernel_diagnostics();
         }
-        cout << "Celeritas environment variables: " << celeritas::environment()
-             << endl;
+        CELER_LOG(debug) << "Celeritas environment variables: "
+                         << celeritas::environment();
 
-        cout << (argc > 0 ? argv[0] : "UNKNOWN") << ": tests "
-             << (failed ? "FAILED" : "PASSED") << color_code(' ') << endl;
+        cout << color_code('x') << (argc > 0 ? argv[0] : "UNKNOWN")
+             << ": tests " << (failed ? "FAILED" : "PASSED") << color_code(' ')
+             << endl;
     }
 
     // Return 1 if any failure, 0 if all success


### PR DESCRIPTION
This now checks statistical/behavioral properties of the stepper loop, and adds a strict check that the results haven't changed when running on CI. I've also added two tests with MSC, which sometimes fail depending on the build configuration... it's failing when crossing a boundary:
```
{
  pos = {
    data_ = ([0] = -19.77, [1] = -0.42402311530894171, [2] = -0.08797186786456046)
  }
  dir = {
    data_ = ([0] = 0.55080690811242594, [1] = -0.02079914375594025, [2] = -0.83437350484938677)
  }
  volume = (value_ = 3)
  surface = {
    id_ = (value_ = 12)
    sense_ = outside
  }
}
```