### PR TITLE
Improve support for building as a "vendored" dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,11 +154,11 @@ elseif(CELERITAS_USE_HIP)
   enable_language(HIP)
 endif()
 
-if(CELERITAS_USE_Doxygen)
+if(CELERITAS_USE_Doxygen AND NOT Doxygen_FOUND)
   find_package(Doxygen REQUIRED)
 endif()
 
-if(CELERITAS_USE_Geant4)
+if(CELERITAS_USE_Geant4 AND NOT Geant4_FOUND)
   # Geant4 calls `include_directories` for CLHEP :( which is not what we want!
   # Save and restore include directories around the call -- even though as a
   # standalone project Celeritas will never have directory-level includes
@@ -167,11 +167,11 @@ if(CELERITAS_USE_Geant4)
   set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES "${_include_dirs}")
 endif()
 
-if(CELERITAS_USE_HepMC3)
+if(CELERITAS_USE_HepMC3 AND NOT HepMC3_FOUND)
   find_package(HepMC3 REQUIRED)
 endif()
 
-if(CELERITAS_USE_JSON)
+if(CELERITAS_USE_JSON AND NOT nlohmann_json_FOUND)
   find_package(nlohmann_json 3.7.0 REQUIRED)
 endif()
 
@@ -198,7 +198,7 @@ if(CELERITAS_USE_ROOT)
   find_package(ROOT REQUIRED)
 endif()
 
-if(CELERITAS_USE_SWIG)
+if(CELERITAS_USE_SWIG AND NOT SWIG_FOUND)
   find_package(SWIG 4.0 REQUIRED)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ if(CELERITAS_USE_VecGeom)
   endif()
 endif()
 
-if(CELERITAS_BUILD_TESTS)
+if(CELERITAS_BUILD_TESTS AND NOT GTest_FOUND)
   # TODO: download and build GTest as a subproject if not available
   find_package(GTest)
   if(NOT GTest_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -261,6 +261,9 @@ celeritas_strip_alias(_TARGET celeritas)
 add_library(Celeritas::Core ALIAS ${_TARGET})
 add_library(Celeritas::celeritas ALIAS ${_TARGET})
 
+# Require at least C++14
+set_property(TARGET ${_TARGET} PROPERTY CXX_STANDARD 14)
+
 if(CELERITAS_USE_ROOT AND NOT BUILD_SHARED_LIBS)
   # Must build with -fPIC to link with ROOT
   set_target_properties(celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND CELER_SOURCES
 
 add_library(CelerTest ${CELER_SOURCES})
 add_library(Celeritas::Test ALIAS CelerTest)
+set_property(TARGET CelerTest PROPERTY CXX_STANDARD 14)
 celeritas_target_link_libraries(CelerTest PRIVATE celeritas PUBLIC GTest::GTest)
 
 target_include_directories(CelerTest


### PR DESCRIPTION
This is for testing with SCALE building Celeritas inline as an `add_subdirectory`.
- Allows codes upstream to provide several external libraries without re-searching for them
- Prevents accidental C++11 building when an upstream code sets `CMAKE_CXX_STANDARD`.