### PR TITLE
Add granular along-step tests

### DIFF
--- a/src/celeritas/io/EventReader.hh
+++ b/src/celeritas/io/EventReader.hh
@@ -23,14 +23,15 @@ struct Primary;
 //---------------------------------------------------------------------------//
 /*!
  * Read an event record file using the HepMC3 event record library and create
- * primary particles. Supported forrmats are Asciiv3, IO_GenEvent, HEPEVT, and
- * LHEF.
+ * primary particles.
+ *
+ * Supported forrmats are Asciiv3, IO_GenEvent, HEPEVT, and LHEF.
  */
 class EventReader
 {
   public:
     //!@{
-    //! Type aliases
+    //! \name Type aliases
     using SPConstParticles = std::shared_ptr<const ParticleParams>;
     using result_type      = std::vector<Primary>;
     //!@}

--- a/src/celeritas/phys/Primary.hh
+++ b/src/celeritas/phys/Primary.hh
@@ -16,7 +16,9 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Starting "source" particle. One or more of these are emitted by an Event.
+ * Starting "source" particle.
+ *
+ * One or more of these are emitted by an Event.
  */
 struct Primary
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -213,6 +213,7 @@ add_library(CeleritasTest
   celeritas/MockTestBase.cc
   celeritas/SimpleTestBase.cc
   celeritas/TestEm3Base.cc
+  celeritas/global/AlongStepTestBase.cc
   celeritas/global/StepperTestBase.cc
 )
 celeritas_target_link_libraries(CeleritasTest
@@ -291,6 +292,7 @@ celeritas_add_test(celeritas/geo/GeoMaterial.test.cc
 # Global
 set(CELERITASTEST_PREFIX celeritas/global)
 celeritas_add_test(celeritas/global/ActionManager.test.cc)
+celeritas_add_test(celeritas/global/AlongStep.test.cc)
 celeritas_add_test(celeritas/global/Stepper.test.cc
   GPU ${_needs_geant4})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -292,7 +292,8 @@ celeritas_add_test(celeritas/geo/GeoMaterial.test.cc
 # Global
 set(CELERITASTEST_PREFIX celeritas/global)
 celeritas_add_test(celeritas/global/ActionManager.test.cc)
-celeritas_add_test(celeritas/global/AlongStep.test.cc)
+celeritas_add_test(celeritas/global/AlongStep.test.cc
+  ${_optional_geant4_env})
 celeritas_add_test(celeritas/global/Stepper.test.cc
   GPU ${_needs_geant4})
 

--- a/test/celeritas/TestEm3Base.cc
+++ b/test/celeritas/TestEm3Base.cc
@@ -30,6 +30,8 @@
 #include "celeritas/phys/PhysicsParams.hh"
 #include "celeritas/random/RngParams.hh"
 
+#include "celeritas_cmake_strings.h"
+
 using namespace celeritas;
 
 namespace celeritas_test
@@ -54,7 +56,41 @@ ImportData load_import_data(std::string filename)
 }
 
 //---------------------------------------------------------------------------//
+//! Test for equality of two C strings
+bool cstring_equal(const char* lhs, const char* rhs)
+{
+    return std::strcmp(lhs, rhs) == 0;
+}
+
+//---------------------------------------------------------------------------//
 } // namespace
+
+//---------------------------------------------------------------------------//
+//! Whether Geant4 dependencies match those on the CI build
+bool TestEm3Base::is_ci_build()
+{
+    return cstring_equal(celeritas_rng, "XORWOW")
+           && cstring_equal(celeritas_clhep_version, "2.4.4.0")
+           && cstring_equal(celeritas_geant4_version, "10.7.2");
+}
+
+//---------------------------------------------------------------------------//
+//! Whether Geant4 dependencies match those on Wildstyle
+bool TestEm3Base::is_wildstyle_build()
+{
+    return cstring_equal(celeritas_rng, "XORWOW")
+           && cstring_equal(celeritas_clhep_version, "2.4.5.1")
+           && cstring_equal(celeritas_geant4_version, "10.7.3");
+}
+
+//---------------------------------------------------------------------------//
+//! Whether Geant4 dependencies match those on the CI build
+bool TestEm3Base::is_srj_build()
+{
+    return cstring_equal(celeritas_rng, "XORWOW")
+           && cstring_equal(celeritas_clhep_version, "2.4.5.1")
+           && cstring_equal(celeritas_geant4_version, "11.0.0");
+}
 
 //---------------------------------------------------------------------------//
 // PROTECTED MEMBER FUNCTIONS
@@ -164,6 +200,15 @@ auto TestEm3Base::imported_data() const -> const ImportData&
     static ImportData imported = load_import_data(this->test_data_path(
         "celeritas", gdml_filename(this->geometry_basename()).c_str()));
     return imported;
+}
+
+//---------------------------------------------------------------------------//
+std::ostream& operator<<(std::ostream& os, const PrintableBuildConf&)
+{
+    os << "RNG=\"" << celeritas_rng << "\", CLHEP=\""
+       << celeritas_clhep_version << "\", Geant4=\""
+       << celeritas_geant4_version << '"';
+    return os;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/TestEm3Base.hh
+++ b/test/celeritas/TestEm3Base.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <iosfwd>
+
 #include "celeritas/Types.hh"
 
 #include "GlobalGeoTestBase.hh"
@@ -24,6 +26,9 @@ namespace celeritas_test
  * Test harness for replicating the AdePT TestEm3 input.
  *
  * This class requires Geant4 to import the data.
+ *
+ * \todo Refactor to allow more generic geant4 problem setup, move similar code
+ * with LDemo and Acceleritas into main library.
  */
 class TestEm3Base : virtual public GlobalGeoTestBase
 {
@@ -33,6 +38,14 @@ class TestEm3Base : virtual public GlobalGeoTestBase
     using real_type      = celeritas::real_type;
     using ImportData     = celeritas::ImportData;
     using PhysicsOptions = celeritas::PhysicsParamsOptions;
+    //!@}
+
+  public:
+    //!@{
+    //! Whether the Geant4 configuration match a certain machine
+    static bool is_ci_build();
+    static bool is_wildstyle_build();
+    static bool is_srj_build();
     //!@}
 
   protected:
@@ -53,6 +66,13 @@ class TestEm3Base : virtual public GlobalGeoTestBase
     // Access lazily loaded static geant4 data
     const celeritas::ImportData& imported_data() const;
 };
+
+//---------------------------------------------------------------------------//
+//! Print the current configuration
+struct PrintableBuildConf
+{
+};
+std::ostream& operator<<(std::ostream& os, const PrintableBuildConf&);
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas_test

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -1,0 +1,43 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/AlongStep.test.cc
+//---------------------------------------------------------------------------//
+#include "celeritas/global/alongstep/AlongStep.hh"
+
+#include "celeritas/phys/PDGNumber.hh"
+#include "celeritas/phys/ParticleParams.hh"
+
+#include "../SimpleTestBase.hh"
+#include "AlongStepTestBase.hh"
+#include "celeritas_cmake_strings.h"
+#include "celeritas_test.hh"
+
+using namespace celeritas;
+using namespace celeritas_test;
+
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
+
+class KnAlongStepTest : public celeritas_test::SimpleTestBase,
+                        public celeritas_test::AlongStepTestBase
+{
+  protected:
+    void SetUp() override {}
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(KnAlongStepTest, all)
+{
+    Input inp;
+    inp.particle_id = this->particle()->find(pdg::gamma());
+    inp.energy      = MevEnergy{1};
+    auto result     = this->run(inp);
+    result.print_expected();
+}

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -93,7 +93,7 @@ TEST_F(Em3AlongStepTest, nofluct_nomsc)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.00018784530172589, result.eloss, 5e-4);
+        EXPECT_SOFT_NEAR(0.00018784530172589, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.0001, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(3.3395898137996e-15, result.time);
@@ -115,11 +115,11 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 0.25};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.4749606626165, result.eloss, 5e-4);
+        EXPECT_SOFT_NEAR(0.4749606626165, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.25, result.displacement);
-        EXPECT_SOFT_EQ(0.86092633070668, result.angle, 5e-4);
-        EXPECT_SOFT_EQ(8.4653845033461e-12, result.time, 1e-5);
-        EXPECT_SOFT_EQ(0.25348575649519, result.step, 1e-5);
+        EXPECT_SOFT_NEAR(0.86092633070668, result.angle, 5e-4);
+        EXPECT_SOFT_NEAR(8.4653845033461e-12, result.time, 1e-5);
+        EXPECT_SOFT_NEAR(0.25348575649519, result.step, 1e-5);
     }
     {
         SCOPED_TRACE("low energy electron far from boundary");
@@ -127,9 +127,9 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.energy      = MevEnergy{1};
         inp.position    = {0.0 - 0.25};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.29099416915603, result.eloss, 5e-4);
-        EXPECT_SOFT_EQ(0.13232372765681, result.displacement, 5e-4);
-        EXPECT_SOFT_EQ(0.5577360891992, result.angle, 5e-4);
+        EXPECT_SOFT_NEAR(0.29099416915603, result.eloss, 5e-4);
+        EXPECT_SOFT_NEAR(0.13232372765681, result.displacement, 5e-4);
+        EXPECT_SOFT_NEAR(0.5577360891992, result.angle, 5e-4);
         EXPECT_SOFT_EQ(5.4180974597247e-12, result.time);
         EXPECT_SOFT_EQ(0.15285994752696, result.step);
     }
@@ -139,11 +139,11 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.00018784630366397, result.eloss, 5e-4);
+        EXPECT_SOFT_NEAR(0.00018784630366397, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.0001, result.displacement);
-        EXPECT_SOFT_EQ(0.86607133776412, result.angle, 5e-4);
-        EXPECT_SOFT_EQ(3.3396076266577e-15, result.time, 1e-5);
-        EXPECT_SOFT_EQ(0.00010000053338461, result.step, 1e-5);
+        EXPECT_SOFT_NEAR(0.86607133776412, result.angle, 5e-4);
+        EXPECT_SOFT_NEAR(3.3396076266577e-15, result.time, 1e-5);
+        EXPECT_SOFT_NEAR(0.00010000053338461, result.step, 1e-5);
     }
 }
 
@@ -161,7 +161,7 @@ TEST_F(Em3AlongStepTest, fluct_nomsc)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 0.25};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.46402579396636, result.eloss, 5e-4);
+        EXPECT_SOFT_NEAR(0.46402579396636, result.eloss, 5e-3);
         EXPECT_SOFT_EQ(0.25, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(8.348974534499e-12, result.time);
@@ -173,7 +173,8 @@ TEST_F(Em3AlongStepTest, fluct_nomsc)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.00025317374297664, result.eloss);
+        // Geant4 v11 and v10 disagree strongly on this result!
+        // EXPECT_SOFT_NEAR(0.00025317374297664, result.eloss, 1e-3);
         EXPECT_SOFT_EQ(0.0001, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(3.3395898137996e-15, result.time);

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -81,7 +81,7 @@ TEST_F(Em3AlongStepTest, nofluct_nomsc)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 0.25};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.46842934015656, result.eloss);
+        EXPECT_SOFT_NEAR(0.46842934015656, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.25, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(8.348974534499e-12, result.time);
@@ -93,7 +93,7 @@ TEST_F(Em3AlongStepTest, nofluct_nomsc)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.00018784530172589, result.eloss);
+        EXPECT_SOFT_EQ(0.00018784530172589, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.0001, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(3.3395898137996e-15, result.time);
@@ -115,11 +115,11 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 0.25};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.4749606626165, result.eloss);
+        EXPECT_SOFT_EQ(0.4749606626165, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.25, result.displacement);
-        EXPECT_SOFT_EQ(0.86092633070668, result.angle);
-        EXPECT_SOFT_EQ(8.4653845033461e-12, result.time);
-        EXPECT_SOFT_EQ(0.25348575649519, result.step);
+        EXPECT_SOFT_EQ(0.86092633070668, result.angle, 5e-4);
+        EXPECT_SOFT_EQ(8.4653845033461e-12, result.time, 1e-5);
+        EXPECT_SOFT_EQ(0.25348575649519, result.step, 1e-5);
     }
     {
         SCOPED_TRACE("low energy electron far from boundary");
@@ -127,9 +127,9 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.energy      = MevEnergy{1};
         inp.position    = {0.0 - 0.25};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.29099416915603, result.eloss);
-        EXPECT_SOFT_EQ(0.13232372765681, result.displacement);
-        EXPECT_SOFT_EQ(0.5577360891992, result.angle);
+        EXPECT_SOFT_EQ(0.29099416915603, result.eloss, 5e-4);
+        EXPECT_SOFT_EQ(0.13232372765681, result.displacement, 5e-4);
+        EXPECT_SOFT_EQ(0.5577360891992, result.angle, 5e-4);
         EXPECT_SOFT_EQ(5.4180974597247e-12, result.time);
         EXPECT_SOFT_EQ(0.15285994752696, result.step);
     }
@@ -139,11 +139,11 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.00018784630366397, result.eloss);
+        EXPECT_SOFT_EQ(0.00018784630366397, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.0001, result.displacement);
-        EXPECT_SOFT_EQ(0.86607133776412, result.angle);
-        EXPECT_SOFT_EQ(3.3396076266577e-15, result.time);
-        EXPECT_SOFT_EQ(0.00010000053338461, result.step);
+        EXPECT_SOFT_EQ(0.86607133776412, result.angle, 5e-4);
+        EXPECT_SOFT_EQ(3.3396076266577e-15, result.time, 1e-5);
+        EXPECT_SOFT_EQ(0.00010000053338461, result.step, 1e-5);
     }
 }
 
@@ -161,7 +161,7 @@ TEST_F(Em3AlongStepTest, fluct_nomsc)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 0.25};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(0.46402579396636, result.eloss);
+        EXPECT_SOFT_EQ(0.46402579396636, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.25, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(8.348974534499e-12, result.time);

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -139,7 +139,7 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_NEAR(0.00018784630366397, result.eloss, 1e-4);
+        EXPECT_SOFT_NEAR(0.00018784630366397, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.0001, result.displacement);
         EXPECT_SOFT_NEAR(0.87210603989396, result.angle, 1e-3);
         EXPECT_SOFT_EQ(3.3396076266578e-15, result.time);

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -5,14 +5,12 @@
 //---------------------------------------------------------------------------//
 //! \file celeritas/global/AlongStep.test.cc
 //---------------------------------------------------------------------------//
-#include "celeritas/global/alongstep/AlongStep.hh"
-
+#include "celeritas/TestEm3Base.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
 
 #include "../SimpleTestBase.hh"
 #include "AlongStepTestBase.hh"
-#include "celeritas_cmake_strings.h"
 #include "celeritas_test.hh"
 
 using namespace celeritas;
@@ -25,19 +23,160 @@ using namespace celeritas_test;
 class KnAlongStepTest : public celeritas_test::SimpleTestBase,
                         public celeritas_test::AlongStepTestBase
 {
-  protected:
-    void SetUp() override {}
+  public:
+};
+
+#define Em3AlongStepTest TEST_IF_CELERITAS_GEANT(Em3AlongStepTest)
+class Em3AlongStepTest : public celeritas_test::TestEm3Base,
+                         public celeritas_test::AlongStepTestBase
+{
+  public:
+    bool enable_msc() const override { return msc_; }
+    bool enable_fluctuation() const override { return fluct_; }
+
+    bool msc_{false};
+    bool fluct_{true};
 };
 
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST_F(KnAlongStepTest, all)
+TEST_F(KnAlongStepTest, basic)
 {
+    size_type num_tracks = 10;
     Input inp;
     inp.particle_id = this->particle()->find(pdg::gamma());
-    inp.energy      = MevEnergy{1};
-    auto result     = this->run(inp);
-    result.print_expected();
+    {
+        inp.energy  = MevEnergy{1};
+        auto result = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0, result.eloss);
+        EXPECT_SOFT_EQ(5, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(1.6678204759908e-10, result.time);
+        EXPECT_SOFT_EQ(5, result.step);
+    }
+    {
+        inp.energy  = MevEnergy{10};
+        auto result = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0, result.eloss);
+        EXPECT_SOFT_EQ(5, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(1.6678204759908e-10, result.time);
+        EXPECT_SOFT_EQ(5, result.step);
+    }
+}
+
+TEST_F(Em3AlongStepTest, nofluct_nomsc)
+{
+    msc_   = false;
+    fluct_ = false;
+
+    size_type num_tracks = 10;
+    Input     inp;
+    inp.direction = {1, 0, 0};
+    {
+        SCOPED_TRACE("electron far from boundary");
+        inp.particle_id = this->particle()->find(pdg::electron());
+        inp.energy      = MevEnergy{10};
+        inp.position    = {0.0 - 0.25};
+        auto result     = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0.46842934015656, result.eloss);
+        EXPECT_SOFT_EQ(0.25, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(8.348974534499e-12, result.time);
+        EXPECT_SOFT_EQ(0.25, result.step);
+    }
+    {
+        SCOPED_TRACE("electron very near (1um) boundary");
+        inp.particle_id = this->particle()->find(pdg::electron());
+        inp.energy      = MevEnergy{10};
+        inp.position    = {0.0 - 1e-4};
+        auto result     = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0.00018784530172589, result.eloss);
+        EXPECT_SOFT_EQ(0.0001, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(3.3395898137996e-15, result.time);
+        EXPECT_SOFT_EQ(0.0001, result.step);
+    }
+}
+
+TEST_F(Em3AlongStepTest, msc_nofluct)
+{
+    msc_   = true;
+    fluct_ = false;
+
+    size_type num_tracks = 10;
+    Input     inp;
+    inp.direction = {1, 0, 0};
+    {
+        SCOPED_TRACE("electron far from boundary");
+        inp.particle_id = this->particle()->find(pdg::electron());
+        inp.energy      = MevEnergy{10};
+        inp.position    = {0.0 - 0.25};
+        auto result     = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0.4749606626165, result.eloss);
+        EXPECT_SOFT_EQ(0.25, result.displacement);
+        EXPECT_SOFT_EQ(0.86092633070668, result.angle);
+        EXPECT_SOFT_EQ(8.4653845033461e-12, result.time);
+        EXPECT_SOFT_EQ(0.25348575649519, result.step);
+    }
+    {
+        SCOPED_TRACE("low energy electron far from boundary");
+        inp.particle_id = this->particle()->find(pdg::electron());
+        inp.energy      = MevEnergy{1};
+        inp.position    = {0.0 - 0.25};
+        auto result     = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0.29099416915603, result.eloss);
+        EXPECT_SOFT_EQ(0.13232372765681, result.displacement);
+        EXPECT_SOFT_EQ(0.5577360891992, result.angle);
+        EXPECT_SOFT_EQ(5.4180974597247e-12, result.time);
+        EXPECT_SOFT_EQ(0.15285994752696, result.step);
+    }
+    {
+        SCOPED_TRACE("electron very near (1um) boundary");
+        inp.particle_id = this->particle()->find(pdg::electron());
+        inp.energy      = MevEnergy{10};
+        inp.position    = {0.0 - 1e-4};
+        auto result     = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0.00018784630366397, result.eloss);
+        EXPECT_SOFT_EQ(0.0001, result.displacement);
+        EXPECT_SOFT_EQ(0.86607133776412, result.angle);
+        EXPECT_SOFT_EQ(3.3396076266577e-15, result.time);
+        EXPECT_SOFT_EQ(0.00010000053338461, result.step);
+    }
+}
+
+TEST_F(Em3AlongStepTest, fluct_nomsc)
+{
+    msc_   = false;
+    fluct_ = true;
+
+    size_type num_tracks = 10;
+    Input     inp;
+    inp.direction = {1, 0, 0};
+    {
+        SCOPED_TRACE("electron far from boundary");
+        inp.particle_id = this->particle()->find(pdg::electron());
+        inp.energy      = MevEnergy{10};
+        inp.position    = {0.0 - 0.25};
+        auto result     = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0.46402579396636, result.eloss);
+        EXPECT_SOFT_EQ(0.25, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(8.348974534499e-12, result.time);
+        EXPECT_SOFT_EQ(0.25, result.step);
+    }
+    {
+        SCOPED_TRACE("electron very near (1um) boundary");
+        inp.particle_id = this->particle()->find(pdg::electron());
+        inp.energy      = MevEnergy{10};
+        inp.position    = {0.0 - 1e-4};
+        auto result     = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0.00025317374297664, result.eloss);
+        EXPECT_SOFT_EQ(0.0001, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(3.3395898137996e-15, result.time);
+        EXPECT_SOFT_EQ(0.0001, result.step);
+    }
 }

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -55,6 +55,7 @@ TEST_F(KnAlongStepTest, basic)
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(1.6678204759908e-10, result.time);
         EXPECT_SOFT_EQ(5, result.step);
+        EXPECT_EQ("geo-boundary", result.action);
     }
     {
         inp.energy  = MevEnergy{10};
@@ -64,6 +65,18 @@ TEST_F(KnAlongStepTest, basic)
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(1.6678204759908e-10, result.time);
         EXPECT_SOFT_EQ(5, result.step);
+        EXPECT_EQ("geo-boundary", result.action);
+    }
+    {
+        inp.energy   = MevEnergy{10};
+        inp.phys_mfp = 1e-4;
+        auto result  = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0, result.eloss);
+        EXPECT_SOFT_EQ(0.1, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(3.3356409519815e-12, result.time);
+        EXPECT_SOFT_EQ(0.1, result.step);
+        EXPECT_EQ("physics-discrete-select", result.action);
     }
 }
 
@@ -76,28 +89,32 @@ TEST_F(Em3AlongStepTest, nofluct_nomsc)
     Input     inp;
     inp.direction = {1, 0, 0};
     {
-        SCOPED_TRACE("electron far from boundary");
+        SCOPED_TRACE("low energy electron far from boundary");
         inp.particle_id = this->particle()->find(pdg::electron());
-        inp.energy      = MevEnergy{10};
+        inp.energy      = MevEnergy{1};
         inp.position    = {0.0 - 0.25};
+        inp.direction   = {0, 1, 0};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_NEAR(0.46842934015656, result.eloss, 5e-4);
-        EXPECT_SOFT_EQ(0.25, result.displacement);
+        EXPECT_SOFT_NEAR(0.44074534601915, result.eloss, 5e-4);
+        EXPECT_SOFT_EQ(0.22820529792233, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
-        EXPECT_SOFT_EQ(8.348974534499e-12, result.time);
-        EXPECT_SOFT_EQ(0.25, result.step);
+        EXPECT_SOFT_EQ(8.0887018802006e-12, result.time);
+        EXPECT_SOFT_EQ(0.22820529792233, result.step);
+        EXPECT_EQ("eloss-range", result.action);
     }
     {
         SCOPED_TRACE("electron very near (1um) boundary");
         inp.particle_id = this->particle()->find(pdg::electron());
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
+        inp.direction   = {1, 0, 0};
         auto result     = this->run(inp, num_tracks);
         EXPECT_SOFT_NEAR(0.00018784530172589, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.0001, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(3.3395898137996e-15, result.time);
         EXPECT_SOFT_EQ(0.0001, result.step);
+        EXPECT_EQ("geo-boundary", result.action);
     }
 }
 
@@ -108,42 +125,48 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
 
     size_type num_tracks = 1024;
     Input     inp;
-    inp.direction = {1, 0, 0};
     {
         SCOPED_TRACE("electron far from boundary");
         inp.particle_id = this->particle()->find(pdg::electron());
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 0.25};
+        inp.direction   = {0, 1, 0};
+        inp.phys_mfp    = 100;
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_NEAR(0.47496066261651, result.eloss, 5e-4);
-        EXPECT_SOFT_EQ(0.25, result.displacement);
-        EXPECT_SOFT_NEAR(0.86687445437576, result.angle, 1e-3);
-        EXPECT_SOFT_NEAR(8.4653845033461e-12, result.time, 1e-5);
-        EXPECT_SOFT_NEAR(0.25348575649519, result.step, 1e-5);
+        EXPECT_SOFT_NEAR(2.2870403276278, result.eloss, 5e-4);
+        EXPECT_SOFT_NEAR(1.1622519442871, result.displacement, 5e-4);
+        EXPECT_SOFT_NEAR(0.82595842677474, result.angle, 1e-3);
+        EXPECT_SOFT_NEAR(4.083585865972e-11, result.time, 1e-5);
+        EXPECT_SOFT_NEAR(1.222780668781, result.step, 1e-5);
+        EXPECT_EQ("eloss-range", result.action);
     }
     {
         SCOPED_TRACE("low energy electron far from boundary");
         inp.particle_id = this->particle()->find(pdg::electron());
         inp.energy      = MevEnergy{1};
         inp.position    = {0.0 - 0.25};
+        inp.direction   = {1, 0, 0};
         auto result     = this->run(inp, num_tracks);
         EXPECT_SOFT_NEAR(0.28579817262705, result.eloss, 5e-4);
         EXPECT_SOFT_NEAR(0.13028709259427, result.displacement, 5e-4);
         EXPECT_SOFT_NEAR(0.42060290539404, result.angle, 1e-3);
         EXPECT_SOFT_EQ(5.3240431819014e-12, result.time);
         EXPECT_SOFT_EQ(0.1502064087009, result.step);
+        EXPECT_EQ("msc-urban", result.action);
     }
     {
         SCOPED_TRACE("electron very near (1um) boundary");
         inp.particle_id = this->particle()->find(pdg::electron());
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
+        inp.direction   = {1, 0, 0};
         auto result     = this->run(inp, num_tracks);
         EXPECT_SOFT_NEAR(0.00018784630366397, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.0001, result.displacement);
-        EXPECT_SOFT_NEAR(0.87210603989396, result.angle, 1e-3);
+        EXPECT_SOFT_NEAR(0.85890566074896, result.angle, 1e-3);
         EXPECT_SOFT_EQ(3.3396076266578e-15, result.time);
-        EXPECT_SOFT_NEAR(0.00010000053338461, result.step, 1e-8);
+        EXPECT_SOFT_NEAR(0.00010000053338476, result.step, 1e-8);
+        EXPECT_EQ("geo-boundary", result.action);
     }
 }
 
@@ -154,29 +177,33 @@ TEST_F(Em3AlongStepTest, fluct_nomsc)
 
     size_type num_tracks = 4096;
     Input     inp;
-    inp.direction = {1, 0, 0};
     {
-        SCOPED_TRACE("electron far from boundary");
+        SCOPED_TRACE("electron parallel to boundary");
         inp.particle_id = this->particle()->find(pdg::electron());
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 0.25};
+        inp.direction   = {0, 1, 0};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_NEAR(0.4682011732253, result.eloss, 2e-3);
-        EXPECT_SOFT_EQ(0.25, result.displacement);
+
+        EXPECT_SOFT_EQ(2.0631083076865, result.eloss);
+        EXPECT_SOFT_EQ(1.1026770872455, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
-        EXPECT_SOFT_EQ(8.3489745344989e-12, result.time);
-        EXPECT_SOFT_EQ(0.25, result.step);
+        EXPECT_SOFT_EQ(3.6824891684752e-11, result.time);
+        EXPECT_SOFT_EQ(1.1026770872455, result.step);
+        EXPECT_EQ("physics-discrete-select", result.action);
     }
     {
         SCOPED_TRACE("electron very near (1um) boundary");
         inp.particle_id = this->particle()->find(pdg::electron());
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
+        inp.direction   = {1, 0, 0};
         auto result     = this->run(inp, num_tracks);
         EXPECT_SOFT_NEAR(0.00019264335626186, result.eloss, 0.1);
         EXPECT_SOFT_EQ(9.9999999999993e-05, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(3.3395898137995e-15, result.time);
         EXPECT_SOFT_EQ(9.9999999999993e-05, result.step);
+        EXPECT_EQ("geo-boundary", result.action);
     }
 }

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -45,7 +45,7 @@ class Em3AlongStepTest : public celeritas_test::TestEm3Base,
 TEST_F(KnAlongStepTest, basic)
 {
     size_type num_tracks = 10;
-    Input inp;
+    Input     inp;
     inp.particle_id = this->particle()->find(pdg::gamma());
     {
         inp.energy  = MevEnergy{1};
@@ -72,7 +72,7 @@ TEST_F(Em3AlongStepTest, nofluct_nomsc)
     msc_   = false;
     fluct_ = false;
 
-    size_type num_tracks = 10;
+    size_type num_tracks = 128;
     Input     inp;
     inp.direction = {1, 0, 0};
     {
@@ -106,7 +106,7 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
     msc_   = true;
     fluct_ = false;
 
-    size_type num_tracks = 10;
+    size_type num_tracks = 1024;
     Input     inp;
     inp.direction = {1, 0, 0};
     {
@@ -115,9 +115,9 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 0.25};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_NEAR(0.4749606626165, result.eloss, 5e-4);
+        EXPECT_SOFT_NEAR(0.47496066261651, result.eloss, 5e-4);
         EXPECT_SOFT_EQ(0.25, result.displacement);
-        EXPECT_SOFT_NEAR(0.86092633070668, result.angle, 5e-4);
+        EXPECT_SOFT_NEAR(0.86687445437576, result.angle, 1e-3);
         EXPECT_SOFT_NEAR(8.4653845033461e-12, result.time, 1e-5);
         EXPECT_SOFT_NEAR(0.25348575649519, result.step, 1e-5);
     }
@@ -127,11 +127,11 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.energy      = MevEnergy{1};
         inp.position    = {0.0 - 0.25};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_NEAR(0.29099416915603, result.eloss, 5e-4);
-        EXPECT_SOFT_NEAR(0.13232372765681, result.displacement, 5e-4);
-        EXPECT_SOFT_NEAR(0.5577360891992, result.angle, 5e-4);
-        EXPECT_SOFT_EQ(5.4180974597247e-12, result.time);
-        EXPECT_SOFT_EQ(0.15285994752696, result.step);
+        EXPECT_SOFT_NEAR(0.28579817262705, result.eloss, 5e-4);
+        EXPECT_SOFT_NEAR(0.13028709259427, result.displacement, 5e-4);
+        EXPECT_SOFT_NEAR(0.42060290539404, result.angle, 1e-3);
+        EXPECT_SOFT_EQ(5.3240431819014e-12, result.time);
+        EXPECT_SOFT_EQ(0.1502064087009, result.step);
     }
     {
         SCOPED_TRACE("electron very near (1um) boundary");
@@ -139,11 +139,11 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_NEAR(0.00018784630366397, result.eloss, 5e-4);
+        EXPECT_SOFT_NEAR(0.00018784630366397, result.eloss, 1e-4);
         EXPECT_SOFT_EQ(0.0001, result.displacement);
-        EXPECT_SOFT_NEAR(0.86607133776412, result.angle, 5e-4);
-        EXPECT_SOFT_NEAR(3.3396076266577e-15, result.time, 1e-5);
-        EXPECT_SOFT_NEAR(0.00010000053338461, result.step, 1e-5);
+        EXPECT_SOFT_NEAR(0.87210603989396, result.angle, 1e-3);
+        EXPECT_SOFT_EQ(3.3396076266578e-15, result.time);
+        EXPECT_SOFT_NEAR(0.00010000053338461, result.step, 1e-8);
     }
 }
 
@@ -152,7 +152,7 @@ TEST_F(Em3AlongStepTest, fluct_nomsc)
     msc_   = false;
     fluct_ = true;
 
-    size_type num_tracks = 10;
+    size_type num_tracks = 4096;
     Input     inp;
     inp.direction = {1, 0, 0};
     {
@@ -161,10 +161,10 @@ TEST_F(Em3AlongStepTest, fluct_nomsc)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 0.25};
         auto result     = this->run(inp, num_tracks);
-        EXPECT_SOFT_NEAR(0.46402579396636, result.eloss, 5e-3);
+        EXPECT_SOFT_NEAR(0.4682011732253, result.eloss, 2e-3);
         EXPECT_SOFT_EQ(0.25, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
-        EXPECT_SOFT_EQ(8.348974534499e-12, result.time);
+        EXPECT_SOFT_EQ(8.3489745344989e-12, result.time);
         EXPECT_SOFT_EQ(0.25, result.step);
     }
     {
@@ -173,11 +173,10 @@ TEST_F(Em3AlongStepTest, fluct_nomsc)
         inp.energy      = MevEnergy{10};
         inp.position    = {0.0 - 1e-4};
         auto result     = this->run(inp, num_tracks);
-        // Geant4 v11 and v10 disagree strongly on this result!
-        // EXPECT_SOFT_NEAR(0.00025317374297664, result.eloss, 1e-3);
-        EXPECT_SOFT_EQ(0.0001, result.displacement);
+        EXPECT_SOFT_NEAR(0.00019264335626186, result.eloss, 0.1);
+        EXPECT_SOFT_EQ(9.9999999999993e-05, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
-        EXPECT_SOFT_EQ(3.3395898137996e-15, result.time);
-        EXPECT_SOFT_EQ(0.0001, result.step);
+        EXPECT_SOFT_EQ(3.3395898137995e-15, result.time);
+        EXPECT_SOFT_EQ(9.9999999999993e-05, result.step);
     }
 }

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -96,10 +96,10 @@ TEST_F(Em3AlongStepTest, nofluct_nomsc)
         inp.direction   = {0, 1, 0};
         auto result     = this->run(inp, num_tracks);
         EXPECT_SOFT_NEAR(0.44074534601915, result.eloss, 5e-4);
-        EXPECT_SOFT_EQ(0.22820529792233, result.displacement);
+        EXPECT_SOFT_NEAR(0.22820529792233, result.displacement, 5e-4);
         EXPECT_SOFT_EQ(1, result.angle);
-        EXPECT_SOFT_EQ(8.0887018802006e-12, result.time);
-        EXPECT_SOFT_EQ(0.22820529792233, result.step);
+        EXPECT_SOFT_NEAR(8.0887018802006e-12, result.time, 5e-4);
+        EXPECT_SOFT_NEAR(0.22820529792233, result.step, 5e-4);
         EXPECT_EQ("eloss-range", result.action);
     }
     {
@@ -137,7 +137,7 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         EXPECT_SOFT_NEAR(1.1622519442871, result.displacement, 5e-4);
         EXPECT_SOFT_NEAR(0.82595842677474, result.angle, 1e-3);
         EXPECT_SOFT_NEAR(4.083585865972e-11, result.time, 1e-5);
-        EXPECT_SOFT_NEAR(1.222780668781, result.step, 1e-5);
+        EXPECT_SOFT_NEAR(1.222780668781, result.step, 5e-4);
         EXPECT_EQ("eloss-range", result.action);
     }
     {
@@ -185,11 +185,11 @@ TEST_F(Em3AlongStepTest, fluct_nomsc)
         inp.direction   = {0, 1, 0};
         auto result     = this->run(inp, num_tracks);
 
-        EXPECT_SOFT_EQ(2.0631083076865, result.eloss);
-        EXPECT_SOFT_EQ(1.1026770872455, result.displacement);
+        EXPECT_SOFT_NEAR(2.0631083076865, result.eloss, 1e-2);
+        EXPECT_SOFT_NEAR(1.1026770872455, result.displacement, 1e-2);
         EXPECT_SOFT_EQ(1, result.angle);
-        EXPECT_SOFT_EQ(3.6824891684752e-11, result.time);
-        EXPECT_SOFT_EQ(1.1026770872455, result.step);
+        EXPECT_SOFT_NEAR(3.6824891684752e-11, result.time, 1e-2);
+        EXPECT_SOFT_NEAR(1.1026770872455, result.step, 1e-2);
         EXPECT_EQ("physics-discrete-select", result.action);
     }
     {

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -48,16 +48,16 @@ auto AlongStepTestBase::run(const Input& inp, size_type num_tracks) -> RunResult
         p.time        = inp.time;
         p.track_id    = TrackId{0};
 
-    // Create track initializers and add primaries
-    TrackInitParams::Input inp;
-    inp.primaries.assign(num_tracks, p);
-    inp.capacity  = num_tracks;
+        // Create track initializers and add primaries
+        TrackInitParams::Input inp;
+        inp.primaries.assign(num_tracks, p);
+        inp.capacity = num_tracks;
         for (auto i : range(num_tracks))
         {
             inp.primaries[i].event_id = EventId{i};
             inp.primaries[i].track_id = TrackId{i};
         }
-    TrackInitParams init_params{std::move(inp)};
+        TrackInitParams init_params{std::move(inp)};
 
         TrackInitStateData<Ownership::value, MemSpace::host> init_states;
         resize(&init_states, init_params.host_ref(), num_tracks);

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -1,0 +1,141 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/AlongStepTestBase.cc
+//---------------------------------------------------------------------------//
+#include "AlongStepTestBase.hh"
+
+#include "corecel/cont/Range.hh"
+#include "corecel/data/CollectionStateStore.hh"
+#include "corecel/io/Repr.hh"
+#include "corecel/math/ArrayUtils.hh"
+#include "celeritas/global/ActionManager.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackView.hh"
+#include "celeritas/phys/PhysicsStepUtils.hh"
+#include "celeritas/track/TrackInitData.hh"
+#include "celeritas/track/TrackInitParams.hh"
+#include "celeritas/track/TrackInitUtils.hh"
+
+using namespace celeritas;
+
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+auto AlongStepTestBase::run(const Input& inp, size_type num_tracks) -> RunResult
+{
+    CELER_EXPECT(inp);
+    CELER_EXPECT(num_tracks > 0);
+
+    // Create states
+    CollectionStateStore<CoreStateData, MemSpace::host> states{*this->core(),
+                                                               num_tracks};
+    CoreRef<MemSpace::host>                             core_ref;
+    core_ref.params = this->core()->host_ref();
+    core_ref.states = states.ref();
+    CELER_ASSERT(core_ref);
+
+    // Create primaries
+    {
+        Primary p;
+        p.particle_id = inp.particle_id;
+        p.energy      = inp.energy;
+        p.position    = inp.position;
+        p.direction   = inp.direction;
+        p.time        = inp.time;
+        p.track_id    = TrackId{0};
+
+    // Create track initializers and add primaries
+    TrackInitParams::Input inp;
+    inp.primaries.assign(num_tracks, p);
+    inp.capacity  = num_tracks;
+        for (auto i : range(num_tracks))
+        {
+            inp.primaries[i].event_id = EventId{i};
+            inp.primaries[i].track_id = TrackId{i};
+        }
+    TrackInitParams init_params{std::move(inp)};
+
+        TrackInitStateData<Ownership::value, MemSpace::host> init_states;
+        resize(&init_states, init_params.host_ref(), num_tracks);
+
+        celeritas::extend_from_primaries(init_params.host_ref(), &init_states);
+        celeritas::initialize_tracks(core_ref, &init_states);
+    }
+
+    // Set remaining MFP
+    for (auto tid : range(ThreadId{num_tracks}))
+    {
+        CoreTrackView track{core_ref.params, core_ref.states, tid};
+        auto          phys = track.make_physics_view();
+        phys.interaction_mfp(inp.phys_mfp);
+    }
+
+    {
+        const auto& am = *this->action_mgr();
+
+        // Call pre-step action to set range, physics step
+        auto prestep_action = am.find_action("pre-step");
+        CELER_ASSERT(prestep_action);
+        am.invoke(prestep_action, core_ref);
+
+        // Call along-step action
+        auto alongstep_action = am.find_action("along-step");
+        CELER_ASSERT(alongstep_action);
+        am.invoke(alongstep_action, core_ref);
+    }
+
+    // Process output
+    RunResult result;
+    for (auto tid : range(ThreadId{num_tracks}))
+    {
+        CoreTrackView track{core_ref.params, core_ref.states, tid};
+        auto          sim      = track.make_sim_view();
+        auto          particle = track.make_particle_view();
+        auto          geo      = track.make_geo_view();
+
+        result.eloss += value_as<MevEnergy>(inp.energy)
+                        - value_as<MevEnergy>(particle.energy());
+        result.displacement += celeritas::distance(geo.pos(), inp.position);
+        result.angle += celeritas::dot_product(geo.dir(), inp.direction);
+        result.time += sim.time();
+        result.step += sim.step_limit().step;
+    }
+
+    real_type norm = 1 / real_type(num_tracks);
+    result.eloss *= norm;
+    result.displacement *= norm;
+    result.angle *= norm;
+    result.time *= norm;
+    result.step *= norm;
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+void AlongStepTestBase::RunResult::print_expected() const
+{
+    using std::cout;
+    cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n";
+
+    cout << "EXPECT_SOFT_EQ(" << repr(this->eloss)
+         << ", result.eloss);\n"
+            "EXPECT_SOFT_EQ("
+         << repr(this->displacement)
+         << ", result.displacement);\n"
+            "EXPECT_SOFT_EQ("
+         << repr(this->angle)
+         << ", result.angle);\n"
+            "EXPECT_SOFT_EQ("
+         << repr(this->time)
+         << ", result.time);\n"
+            "EXPECT_SOFT_EQ("
+         << repr(this->step)
+         << ", result.step);\n"
+            "/*** END CODE ***/\n";
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/celeritas/global/AlongStepTestBase.hh
+++ b/test/celeritas/global/AlongStepTestBase.hh
@@ -1,0 +1,68 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/AlongStepTestBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Types.hh"
+#include "celeritas/Quantities.hh"
+#include "celeritas/Types.hh"
+
+#include "../GlobalTestBase.hh"
+
+namespace celeritas_test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Run one or more tracks with the same starting conditions for a single step.
+ *
+ * This high-level test *only* executes on the host so we can extract detailed
+ * information from the states.
+ */
+class AlongStepTestBase : virtual public celeritas_test::GlobalTestBase
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using size_type  = celeritas::size_type;
+    using real_type  = celeritas::real_type;
+    using Real3      = celeritas::Real3;
+    using ParticleId = celeritas::ParticleId;
+    using MevEnergy  = celeritas::units::MevEnergy;
+    //!@}
+
+    struct Input
+    {
+        ParticleId particle_id;
+        MevEnergy  energy{0};
+        Real3      position{0, 0, 0};
+        Real3      direction{0, 0, 1};
+        real_type  time{0};
+        real_type  phys_mfp{1}; //!< Number of MFP to collision
+
+        explicit operator bool() const
+        {
+            return particle_id && energy >= celeritas::zero_quantity()
+                   && time >= 0 && phys_mfp > 0;
+        }
+    };
+
+    struct RunResult
+    {
+        real_type eloss{};        //!< Energy loss / MeV
+        real_type displacement{}; //!< Distance from start to end points
+        real_type angle{};        //!< Dot product of in/out direction
+        real_type time{};         //!< Change in time
+        real_type step{};         //!< Physical step length
+
+        void print_expected() const;
+    };
+
+    RunResult run(const Input&, size_type num_tracks = 1);
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas_test

--- a/test/celeritas/global/AlongStepTestBase.hh
+++ b/test/celeritas/global/AlongStepTestBase.hh
@@ -52,11 +52,12 @@ class AlongStepTestBase : virtual public celeritas_test::GlobalTestBase
 
     struct RunResult
     {
-        real_type eloss{};        //!< Energy loss / MeV
-        real_type displacement{}; //!< Distance from start to end points
-        real_type angle{};        //!< Dot product of in/out direction
-        real_type time{};         //!< Change in time
-        real_type step{};         //!< Physical step length
+        real_type   eloss{};        //!< Energy loss / MeV
+        real_type   displacement{}; //!< Distance from start to end points
+        real_type   angle{};        //!< Dot product of in/out direction
+        real_type   time{};         //!< Change in time
+        real_type   step{};         //!< Physical step length
+        std::string action;         //!< Most likely action to take next
 
         void print_expected() const;
     };

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -16,51 +16,11 @@
 #include "celeritas/global/ActionManager.hh"
 #include "celeritas/global/Stepper.hh"
 
-#include "celeritas_cmake_strings.h"
-
 using namespace celeritas;
 using std::cout;
 
 namespace celeritas_test
 {
-namespace
-{
-//---------------------------------------------------------------------------//
-//! Test for equality of two C strings
-bool cstring_equal(const char* lhs, const char* rhs)
-{
-    return std::strcmp(lhs, rhs) == 0;
-}
-//---------------------------------------------------------------------------//
-} // namespace
-
-//---------------------------------------------------------------------------//
-//! Whether Geant4 dependencies match those on the CI build
-bool StepperTestBase::is_ci_build()
-{
-    return cstring_equal(celeritas_rng, "XORWOW")
-           && cstring_equal(celeritas_clhep_version, "2.4.4.0")
-           && cstring_equal(celeritas_geant4_version, "10.7.2");
-}
-
-//---------------------------------------------------------------------------//
-//! Whether Geant4 dependencies match those on Wildstyle
-bool StepperTestBase::is_wildstyle_build()
-{
-    return cstring_equal(celeritas_rng, "XORWOW")
-           && cstring_equal(celeritas_clhep_version, "2.4.5.1")
-           && cstring_equal(celeritas_geant4_version, "10.7.3");
-}
-
-//---------------------------------------------------------------------------//
-//! Whether Geant4 dependencies match those on the CI build
-bool StepperTestBase::is_srj_build()
-{
-    return cstring_equal(celeritas_rng, "XORWOW")
-           && cstring_equal(celeritas_clhep_version, "2.4.5.1")
-           && cstring_equal(celeritas_geant4_version, "11.0.0");
-}
-
 //---------------------------------------------------------------------------//
 //! Construct dummy action at creation
 StepperTestBase::StepperTestBase()
@@ -202,15 +162,5 @@ void StepperTestBase::RunResult::print_expected() const
          << "}), result.calc_queue_hwm());\n"
             "/*** END CODE ***/\n";
 }
-
-//---------------------------------------------------------------------------//
-std::ostream& operator<<(std::ostream& os, const PrintableBuildConf&)
-{
-    os << "RNG=\"" << celeritas_rng << "\", CLHEP=\""
-       << celeritas_clhep_version << "\", Geant4=\""
-       << celeritas_geant4_version << '"';
-    return os;
-}
-
 //---------------------------------------------------------------------------//
 } // namespace celeritas_test

--- a/test/celeritas/global/StepperTestBase.hh
+++ b/test/celeritas/global/StepperTestBase.hh
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <iosfwd>
 #include <memory>
 #include <vector>
 
@@ -78,13 +77,6 @@ class StepperTestBase : virtual public celeritas_test::GlobalTestBase
     };
 
   public:
-    //!@{
-    //! Whether the Geant4 configuration match a certain machine
-    static bool is_ci_build();
-    static bool is_wildstyle_build();
-    static bool is_srj_build();
-    //!@}
-
     // Add dummy action at construction
     StepperTestBase();
 
@@ -109,13 +101,6 @@ class StepperTestBase : virtual public celeritas_test::GlobalTestBase
   protected:
     std::shared_ptr<DummyAction> dummy_action_;
 };
-
-//---------------------------------------------------------------------------//
-//! Print the current configuration
-struct PrintableBuildConf
-{
-};
-std::ostream& operator<<(std::ostream& os, const PrintableBuildConf&);
 
 //---------------------------------------------------------------------------//
 } // namespace celeritas_test


### PR DESCRIPTION
This test lets us probe the behavior of running multiple clones of a single primary input with a single "along-step" call: so we can examine the physics step change, geometry position change, etc. along the track.