### PR TITLE
Optionally generate primaries without a HepMC3 input file in the demo loop

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -34,6 +34,7 @@
 #include "celeritas/phys/ImportedProcessAdapter.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/PhysicsParams.hh"
+#include "celeritas/phys/PrimaryGeneratorOptionsIO.json.hh"
 #include "celeritas/random/RngParams.hh"
 
 using namespace celeritas;
@@ -95,7 +96,6 @@ void to_json(nlohmann::json& j, const LDemoArgs& v)
 {
     j = nlohmann::json{{"geometry_filename", v.geometry_filename},
                        {"physics_filename", v.physics_filename},
-                       {"hepmc3_filename", v.hepmc3_filename},
                        {"seed", v.seed},
                        {"max_num_tracks", v.max_num_tracks},
                        {"max_steps", v.max_steps},
@@ -122,13 +122,28 @@ void to_json(nlohmann::json& j, const LDemoArgs& v)
     {
         j["geant_options"] = v.geant_options;
     }
+    if (v.primary_gen_options)
+    {
+        j["primary_gen_options"] = v.primary_gen_options;
+    }
+    if (!v.hepmc3_filename.empty())
+    {
+        j["hepmc3_filename"] = v.hepmc3_filename;
+    }
 }
 
 void from_json(const nlohmann::json& j, LDemoArgs& v)
 {
     j.at("geometry_filename").get_to(v.geometry_filename);
     j.at("physics_filename").get_to(v.physics_filename);
-    j.at("hepmc3_filename").get_to(v.hepmc3_filename);
+    if (j.contains("hepmc3_filename"))
+    {
+        j.at("hepmc3_filename").get_to(v.hepmc3_filename);
+    }
+    if (j.contains("primary_gen_options"))
+    {
+        j.at("primary_gen_options").get_to(v.primary_gen_options);
+    }
 
     j.at("seed").get_to(v.seed);
     j.at("max_num_tracks").get_to(v.max_num_tracks);

--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -144,6 +144,9 @@ void from_json(const nlohmann::json& j, LDemoArgs& v)
     {
         j.at("primary_gen_options").get_to(v.primary_gen_options);
     }
+    CELER_VALIDATE(v.hepmc3_filename.empty() != !v.primary_gen_options,
+                   << "either a HepMC3 filename or options to generate "
+                      "primaries must be provided (but not both)");
 
     j.at("seed").get_to(v.seed);
     j.at("max_num_tracks").get_to(v.max_num_tracks);

--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "celeritas/ext/GeantSetup.hh"
+#include "celeritas/phys/PrimaryGenerator.hh"
 
 #include "Transporter.hh"
 
@@ -31,7 +32,10 @@ struct LDemoArgs
     // Problem definition
     std::string geometry_filename; //!< Path to GDML file
     std::string physics_filename;  //!< Path to ROOT exported Geant4 data
-    std::string hepmc3_filename;   //!< Path to Hepmc3 event data
+    std::string hepmc3_filename;   //!< Path to HepMC3 event data
+
+    // Optional setup options for generating primaries programmatically
+    celeritas::PrimaryGeneratorOptions primary_gen_options;
 
     // Control
     unsigned int seed{};
@@ -65,9 +69,9 @@ struct LDemoArgs
     explicit operator bool() const
     {
         return !geometry_filename.empty() && !physics_filename.empty()
-               && !hepmc3_filename.empty() && max_num_tracks > 0
-               && max_steps > 0 && initializer_capacity > 0
-               && secondary_stack_factor > 0;
+               && (primary_gen_options || !hepmc3_filename.empty())
+               && max_num_tracks > 0 && max_steps > 0
+               && initializer_capacity > 0 && secondary_stack_factor > 0;
     }
 };
 

--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -33,6 +33,7 @@
 #include "celeritas/io/EventReader.hh"
 #include "celeritas/phys/PhysicsParamsOutput.hh"
 #include "celeritas/phys/Primary.hh"
+#include "celeritas/phys/PrimaryGenerator.hh"
 
 #include "LDemoIO.hh"
 #include "Transporter.hh"
@@ -90,6 +91,13 @@ void run(std::istream* is, OutputManager* output)
 
     // Run all the primaries
     TransporterResult result;
+    if (run_args.primary_gen_options)
+    {
+        PrimaryGenerator generate_primaries(transport_ptr->params().particle(),
+                                            run_args.primary_gen_options);
+        result = (*transport_ptr)(generate_primaries());
+    }
+    else
     {
         EventReader read_all_events(run_args.hepmc3_filename.c_str(),
                                     transport_ptr->params().particle());

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -192,6 +192,7 @@ list(APPEND SOURCES
   celeritas/phys/ParticleParams.cc
   celeritas/phys/PhysicsParams.cc
   celeritas/phys/PhysicsParamsOutput.cc
+  celeritas/phys/PrimaryGenerator.cc
   celeritas/phys/Process.cc
   celeritas/random/CuHipRngData.cc
   celeritas/random/XorwowRngData.cc
@@ -242,6 +243,7 @@ if(CELERITAS_USE_JSON)
   list(APPEND SOURCES
     corecel/sys/DeviceIO.json.cc
     corecel/sys/KernelDiagnosticsIO.json.cc
+    celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
     orange/construct/SurfaceInputIO.json.cc
     orange/construct/VolumeInputIO.json.cc
   )

--- a/src/celeritas/phys/PrimaryGenerator.cc
+++ b/src/celeritas/phys/PrimaryGenerator.cc
@@ -21,8 +21,14 @@ namespace celeritas
  */
 PrimaryGenerator::PrimaryGenerator(SPConstParticles        particles,
                                    PrimaryGeneratorOptions options)
-    : particles_(std::move(particles)), options_(options)
+    : num_events_(options.num_events)
+    , primaries_per_event_(options.primaries_per_event)
 {
+    primary_.particle_id = particles->find(PDGNumber{options.pdg});
+    primary_.energy      = units::MevEnergy{options.energy};
+    primary_.position    = options.position;
+    primary_.direction   = options.direction;
+    primary_.time        = 0;
 }
 
 //---------------------------------------------------------------------------//
@@ -31,22 +37,15 @@ PrimaryGenerator::PrimaryGenerator(SPConstParticles        particles,
  */
 auto PrimaryGenerator::operator()() -> VecPrimary
 {
-    Primary p;
-    p.particle_id = particles_->find(PDGNumber{options_.pdg});
-    p.energy      = units::MevEnergy{options_.energy};
-    p.position    = options_.position;
-    p.direction   = options_.direction;
-    p.time        = 0;
-
     VecPrimary result;
-    result.reserve(options_.num_events * options_.primaries_per_event);
-    for (auto i : range(options_.num_events))
+    result.reserve(num_events_ * primaries_per_event_);
+    for (auto i : range(num_events_))
     {
-        for (auto j : range(options_.primaries_per_event))
+        for (auto j : range(primaries_per_event_))
         {
-            p.event_id = EventId{i};
-            p.track_id = TrackId{j};
-            result.push_back(p);
+            primary_.event_id = EventId{i};
+            primary_.track_id = TrackId{j};
+            result.push_back(primary_);
         }
     }
     return result;

--- a/src/celeritas/phys/PrimaryGenerator.cc
+++ b/src/celeritas/phys/PrimaryGenerator.cc
@@ -1,0 +1,56 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020-2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/phys/PrimaryGenerator.cc
+//---------------------------------------------------------------------------//
+#include "PrimaryGenerator.hh"
+
+#include "corecel/cont/Range.hh"
+#include "celeritas/Types.hh"
+#include "celeritas/Units.hh"
+
+#include "PDGNumber.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with options and shared particle data.
+ */
+PrimaryGenerator::PrimaryGenerator(SPConstParticles        particles,
+                                   PrimaryGeneratorOptions options)
+    : particles_(std::move(particles)), options_(options)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Generate primary particles.
+ */
+auto PrimaryGenerator::operator()() -> VecPrimary
+{
+    Primary p;
+    p.particle_id = particles_->find(PDGNumber{options_.pdg});
+    p.energy      = units::MevEnergy{options_.energy};
+    p.position    = options_.position;
+    p.direction   = options_.direction;
+    p.time        = 0;
+
+    VecPrimary result;
+    result.reserve(options_.num_events * options_.primaries_per_event);
+    for (auto i : range(options_.num_events))
+    {
+        for (auto j : range(options_.primaries_per_event))
+        {
+            p.event_id = EventId{i};
+            p.track_id = TrackId{j};
+            result.push_back(p);
+        }
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/celeritas/phys/PrimaryGenerator.hh
+++ b/src/celeritas/phys/PrimaryGenerator.hh
@@ -58,8 +58,9 @@ class PrimaryGenerator
     VecPrimary operator()();
 
   private:
-    SPConstParticles        particles_;
-    PrimaryGeneratorOptions options_;
+    size_type num_events_;
+    size_type primaries_per_event_;
+    Primary   primary_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PrimaryGenerator.hh
+++ b/src/celeritas/phys/PrimaryGenerator.hh
@@ -1,0 +1,66 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2020-2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/phys/PrimaryGenerator.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+
+#include "ParticleParams.hh"
+#include "Primary.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Primary generator construction arguments.
+ */
+struct PrimaryGeneratorOptions
+{
+    int       pdg;      //!< Primary PDG number
+    real_type energy;   //!< [MeV]
+    Real3     position; //!< [cm]
+    Real3     direction;
+    size_type num_events;
+    size_type primaries_per_event;
+
+    //! Whether the options are valid
+    explicit operator bool() const
+    {
+        return pdg != 0 && energy >= 0 && num_events > 0
+               && primaries_per_event > 0;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Generate a vector of primaries.
+ *
+ * This simple helper class can be used to generate primary particles of a
+ * single particle type with a fixed energy, position, and direction.
+ */
+class PrimaryGenerator
+{
+  public:
+    //!@{
+    using SPConstParticles = std::shared_ptr<const ParticleParams>;
+    using VecPrimary       = std::vector<Primary>;
+    //!@}
+
+  public:
+    // Construct with options and shared particle data
+    PrimaryGenerator(SPConstParticles, PrimaryGeneratorOptions);
+
+    // Generate primary particles
+    VecPrimary operator()();
+
+  private:
+    SPConstParticles        particles_;
+    PrimaryGeneratorOptions options_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
@@ -1,0 +1,43 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
+//---------------------------------------------------------------------------//
+#include "PrimaryGeneratorOptionsIO.json.hh"
+
+#include "corecel/cont/Array.json.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Read options from JSON.
+ */
+void from_json(const nlohmann::json& j, PrimaryGeneratorOptions& opts)
+{
+    j.at("pdg").get_to(opts.pdg);
+    j.at("energy").get_to(opts.energy);
+    j.at("position").get_to(opts.position);
+    j.at("direction").get_to(opts.direction);
+    j.at("num_events").get_to(opts.num_events);
+    j.at("primaries_per_event").get_to(opts.primaries_per_event);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write options to JSON.
+ */
+void to_json(nlohmann::json& j, const PrimaryGeneratorOptions& opts)
+{
+    j = nlohmann::json{{"pdg", opts.pdg},
+                       {"energy", opts.energy},
+                       {"position", opts.position},
+                       {"direction", opts.direction},
+                       {"num_events", opts.num_events},
+                       {"primaries_per_event", opts.primaries_per_event}};
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.hh
+++ b/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.hh
@@ -1,0 +1,25 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/phys/PrimaryGeneratorOptionsIO.json.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "PrimaryGenerator.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+
+// Read options from JSON
+void from_json(const nlohmann::json& j, PrimaryGeneratorOptions& opts);
+
+// Write options to JSON
+void to_json(nlohmann::json& j, const PrimaryGeneratorOptions& opts);
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas


### PR DESCRIPTION
This adds an optional demo loop input argument to generate primaries based on a specified quantity, particle type, energy, position, and direction rather than reading the events from a HepMC3 input file. For example, adding the following to the input JSON would generate the same primaries as in testem3.100k.hepmc3:

```json
"primary_gen_options": {"pdg": 11, "energy": 10000, "position": [-22, 0, 0], "direction": [1, 0, 0], "num_events": 100000, "primaries_per_event": 1}
```

This should make it easier to run with a range of inputs, e.g. for #460, without needing to create a new HepMC3 input file each time.