### PR TITLE
Cache the energy loss range as a physics state data

### DIFF
--- a/src/celeritas/em/distribution/UrbanMscHelper.hh
+++ b/src/celeritas/em/distribution/UrbanMscHelper.hh
@@ -64,8 +64,6 @@ class UrbanMscHelper
     // Range scaling factor
     const real_type dtrl_;
 
-    // Shared value of range
-    real_type range_;
     // Grid ID of range value of the energy loss
     ValueGridId range_gid_;
     // Grid ID of dedx value of the energy loss
@@ -87,7 +85,6 @@ UrbanMscHelper::UrbanMscHelper(const UrbanMscRef&       shared,
     : inc_energy_(particle.energy())
     , physics_(physics)
     , dtrl_(shared.params.dtrl())
-    , range_(physics.dedx_range())
 {
     CELER_EXPECT(particle.particle_id() == shared.ids.electron
                  || particle.particle_id() == shared.ids.positron);
@@ -129,7 +126,8 @@ CELER_FUNCTION auto UrbanMscHelper::calc_eloss(real_type step) const -> Energy
 CELER_FUNCTION auto UrbanMscHelper::calc_end_energy(real_type step) const
     -> Energy
 {
-    if (step <= range_ * dtrl_)
+    real_type range = physics_.dedx_range();
+    if (step <= range * dtrl_)
     {
         // Short step can be approximated with linear extrapolation.
         real_type dedx = physics_.make_calculator<EnergyLossCalculator>(
@@ -140,7 +138,7 @@ CELER_FUNCTION auto UrbanMscHelper::calc_end_energy(real_type step) const
     else
     {
         // Longer step is calculated exactly with inverse range
-        return this->calc_eloss(range_ - step);
+        return this->calc_eloss(range - step);
     }
 }
 

--- a/src/celeritas/em/distribution/UrbanMscHelper.hh
+++ b/src/celeritas/em/distribution/UrbanMscHelper.hh
@@ -43,9 +43,6 @@ class UrbanMscHelper
 
     //// HELPER FUNCTIONS ////
 
-    //! The slowing-down range for the starting particle energy
-    CELER_FUNCTION real_type range() const { return range_; }
-
     // The mean free path of the multiple scattering for a given energy
     inline CELER_FUNCTION real_type msc_mfp(Energy energy) const;
 
@@ -90,6 +87,7 @@ UrbanMscHelper::UrbanMscHelper(const UrbanMscRef&       shared,
     : inc_energy_(particle.energy())
     , physics_(physics)
     , dtrl_(shared.params.dtrl())
+    , range_(physics.dedx_range())
 {
     CELER_EXPECT(particle.particle_id() == shared.ids.electron
                  || particle.particle_id() == shared.ids.positron);
@@ -98,7 +96,6 @@ UrbanMscHelper::UrbanMscHelper(const UrbanMscRef&       shared,
     range_gid_ = physics.value_grid(ValueGridType::range, eloss_pid);
     eloss_gid_ = physics.value_grid(ValueGridType::energy_loss, eloss_pid);
     mfp_gid_ = physics_.value_grid(ValueGridType::msc_mfp, physics_.msc_ppid());
-    range_ = physics.make_calculator<RangeCalculator>(range_gid_)(inc_energy_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/distribution/UrbanMscScatter.hh
+++ b/src/celeritas/em/distribution/UrbanMscScatter.hh
@@ -60,6 +60,7 @@ class UrbanMscScatter
     Real3     inc_direction_;
     bool      is_positron_;
     real_type rad_length_;
+    real_type range_;
     real_type mass_;
 
     // Urban MSC parameters
@@ -149,6 +150,7 @@ UrbanMscScatter::UrbanMscScatter(const UrbanMscRef&       shared,
     , inc_direction_(geometry->dir())
     , is_positron_(particle.particle_id() == shared.ids.positron)
     , rad_length_(material.radiation_length())
+    , range_(physics.dedx_range())
     , mass_(shared.electron_mass.value())
     , params_(shared.params)
     , msc_(shared.msc_data[material.material_id()])
@@ -175,7 +177,7 @@ UrbanMscScatter::UrbanMscScatter(const UrbanMscRef&       shared,
     CELER_ASSERT(true_path_ >= geom_path_);
 
     skip_sampling_ = true;
-    if (true_path_ < helper_.range() && true_path_ > params_.geom_limit)
+    if (true_path_ < range_ && true_path_ > params_.geom_limit)
     {
         end_energy_    = helper_.calc_end_energy(true_path_);
         skip_sampling_ = (end_energy_ < params_.min_sampling_energy()
@@ -628,8 +630,7 @@ real_type UrbanMscScatter::calc_true_path(real_type true_path,
         {
             real_type w = 1 + 1 / (alpha * lambda_);
             real_type x = alpha * w * geom_path;
-            length      = (x < 1) ? (1 - fastpow(1 - x, 1 / w)) / alpha
-                                  : helper_.range();
+            length = (x < 1) ? (1 - fastpow(1 - x, 1 / w)) / alpha : range_;
         }
 
         length = clamp(length, geom_path, true_path);

--- a/src/celeritas/em/distribution/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/distribution/UrbanMscStepLimit.hh
@@ -78,9 +78,10 @@ class UrbanMscStepLimit
     UrbanMscHelper helper_;
 
     bool      on_boundary_{};
-    real_type range_{};
     real_type lambda_{};
     real_type phys_step_{};
+    // Mean slowing-down distance from current energy to zero
+    real_type range_{};
 
     //// HELPER TYPES ////
 
@@ -128,14 +129,13 @@ UrbanMscStepLimit::UrbanMscStepLimit(const UrbanMscRef&       shared,
     , helper_(shared, particle, physics)
     , on_boundary_(is_first_step || safety_ <= 0)
     , phys_step_(phys_step)
+    , range_(physics.dedx_range())
 {
     CELER_EXPECT(particle.particle_id() == shared.ids.electron
                  || particle.particle_id() == shared.ids.positron);
     CELER_EXPECT(safety_ >= 0);
     CELER_EXPECT(phys_step > 0);
 
-    // Mean slowing-down distance from current energy to zero
-    range_ = helper_.range();
     // Mean free path for MSC at current energy
     lambda_ = helper_.msc_mfp(inc_energy_);
 

--- a/src/celeritas/em/distribution/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/distribution/UrbanMscStepLimit.hh
@@ -140,10 +140,7 @@ UrbanMscStepLimit::UrbanMscStepLimit(const UrbanMscRef&       shared,
     lambda_ = helper_.msc_mfp(inc_energy_);
 
     // The slowing down range should already have been applied as a step limit
-    CELER_ENSURE(range_ >= phys_step_ || soft_equal(range_, phys_step_));
-    // TODO: The second condition is to protect rare cases that range_ differs
-    // by ~1ulp from eloss_step in calc_physics_step_limit and may be removed
-    // by caching eloss_step as the value of range.
+    CELER_ENSURE(range_ >= phys_step_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -133,7 +133,7 @@ struct ProcessGroup
     ItemRange<IntegralXsProcess>          integral_xs; //!< [ppid]
     ItemRange<ModelGroup> models;   //!< Model applicability [ppid]
     ParticleProcessId eloss_ppid{}; //!< Process with de/dx and range tables
-    ParticleProcessId     msc_ppid{};   //!< Process of msc (TODO: delete me)
+    ParticleProcessId msc_ppid{};   //!< Process of msc (TODO: delete me)
     bool has_at_rest{}; //!< Whether the particle type has an at-rest process
 
     //! True if assigned and valid
@@ -346,7 +346,7 @@ struct PhysicsParamsData
         model_ids       = other.model_ids;
         model_xs        = other.model_xs;
 
-        hardwired   = other.hardwired;
+        hardwired = other.hardwired;
 
         scalars = other.scalars;
 
@@ -366,6 +366,7 @@ struct PhysicsParamsData
  * State that is reset at every step:
  * - Current macroscopic cross section
  * - Within-step energy deposition
+ * - Within-step energy loss range
  * - Secondaries emitted from an interaction
  * - Discrete process element selection
  */
@@ -376,6 +377,7 @@ struct PhysicsTrackState
     // TEMPORARY STATE
     real_type macro_xs; //!< Total cross section for discrete interactions
     real_type energy_deposition; //!< Local energy deposition in a step [MeV]
+    real_type dedx_range;        //!< Local energy loss range [cm]
     Span<Secondary>    secondaries; //!< Emitted secondaries
     ElementComponentId element;     //!< Element sampled for interaction
 };

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -209,10 +209,7 @@ inline CELER_FUNCTION ParticleTrackView::Energy
             // range-to-step conversion was 1.
             return Energy{pre_step_energy};
         }
-        step = celeritas::min<real_type>(range, step);
-        // TODO: replace this temporary tweak with CELER_ASSERT(range > step)
-        // when numerical instability (off by 1 ulp) of the conversion from
-        // range to step is fixed.
+        CELER_ASSERT(range > step);
 
         // Calculate energy along the range curve corresponding to the actual
         // step taken: this gives the exact energy loss over the step due to

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -60,6 +60,9 @@ class PhysicsTrackView
     // Reset the remaining MFP to interaction
     inline CELER_FUNCTION void reset_interaction_mfp();
 
+    // Set the energy loss range for the current material and particle energy
+    inline CELER_FUNCTION void dedx_range(real_type);
+
     //// DYNAMIC PROPERTIES (pure accessors, free) ////
 
     // Whether the remaining MFP has been calculated
@@ -67,6 +70,9 @@ class PhysicsTrackView
 
     // Remaining MFP to interaction [1]
     CELER_FORCEINLINE_FUNCTION real_type interaction_mfp() const;
+
+    // Energy loss range for the current material and particle energy
+    CELER_FORCEINLINE_FUNCTION real_type dedx_range() const;
 
     //// PROCESSES (depend on particle type and possibly material) ////
 
@@ -220,6 +226,18 @@ CELER_FUNCTION void PhysicsTrackView::reset_interaction_mfp()
 
 //---------------------------------------------------------------------------//
 /*!
+ * Set the energy loss range for the current material and particle energy.
+ *
+ * This value will be calculated once at the beginning of each step.
+ */
+CELER_FUNCTION void PhysicsTrackView::dedx_range(real_type range)
+{
+    CELER_EXPECT(range > 0);
+    this->state().dedx_range = range;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Whether the remaining MFP has been calculated.
  */
 CELER_FUNCTION bool PhysicsTrackView::has_interaction_mfp() const
@@ -236,6 +254,17 @@ CELER_FUNCTION real_type PhysicsTrackView::interaction_mfp() const
     real_type mfp = this->state().interaction_mfp;
     CELER_ENSURE(mfp >= 0);
     return mfp;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Energy loss range.
+ */
+CELER_FUNCTION real_type PhysicsTrackView::dedx_range() const
+{
+    real_type range = this->state().dedx_range;
+    CELER_ENSURE(range > 0);
+    return range;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -594,9 +594,12 @@ CELER_FUNCTION real_type PhysicsTrackView::range_to_step(real_type range) const
         return range;
 
     const real_type alpha = params_.scalars.scaling_fraction;
-    range = alpha * range + rho * (1 - alpha) * (2 - rho / range);
-    CELER_ENSURE(range > 0);
-    return range;
+    real_type step = alpha * range + rho * (1 - alpha) * (2 - rho / range);
+    step           = celeritas::min<real_type>(range, step);
+    // TODO: drop this temporary tweak when numerical instability (off by 1ulp)
+    // of the range scaling calculation.
+    CELER_ENSURE(step > 0 && step <= range);
+    return step;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -129,15 +129,16 @@ class UrbanMscTest : public celeritas_test::GlobalGeoTestBase
 
     // Make physics track view
     PhysicsTrackView
-    make_track_view(const char* particle, MaterialId mid, MevEnergy energy)
+    make_track_view(PDGNumber pdg, MaterialId mid, MevEnergy energy)
     {
-        CELER_EXPECT(particle && mid);
+        CELER_EXPECT(mid);
 
-        auto pid = this->particle()->find(particle);
+        auto pid = this->particle()->find(pdg);
         CELER_ASSERT(pid);
         CELER_ASSERT(pid.get() < physics_state_.size());
-
         ThreadId tid((pid.get() + 1) % physics_state_.size());
+
+        this->set_inc_particle(pdg::electron(), energy);
 
         // Construct and initialize
         PhysicsTrackView phys_view(
@@ -291,10 +292,9 @@ TEST_F(UrbanMscTest, msc_scattering)
         real_type r = i * 2 - real_type(1e-4);
         geo_view    = {{r, r, r}, direction};
 
-        MevEnergy inc_energy = MevEnergy{energy[i]};
-        this->set_inc_particle(pdg::electron(), inc_energy);
-        PhysicsTrackView phys
-            = this->make_track_view("e-", MaterialId{1}, inc_energy);
+        MevEnergy        inc_energy = MevEnergy{energy[i]};
+        PhysicsTrackView phys       = this->make_track_view(
+            pdg::electron(), MaterialId{1}, inc_energy);
 
         UrbanMscStepLimit step_limiter(model->host_ref(),
                                        *part_view_,

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -187,8 +187,14 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
     ParticleTrackView particle(
         this->particle()->host_ref(), par_state.ref(), ThreadId{0});
 
-    auto calc_eloss
-        = [&](const PhysicsTrackView& phys, real_type step) -> real_type {
+    auto calc_eloss = [&](PhysicsTrackView& phys, real_type step) -> real_type {
+        // Calculate and store the energy loss range to PhysicsTrackView
+        auto      ppid       = phys.eloss_ppid();
+        auto      grid_id    = phys.value_grid(ValueGridType::range, ppid);
+        auto      calc_range = phys.make_calculator<RangeCalculator>(grid_id);
+        real_type range      = calc_range(particle.energy());
+        phys.dedx_range(range);
+
         MevEnergy result
             = celeritas::calc_mean_energy_loss(particle, phys, step);
         return result.value();


### PR DESCRIPTION
This MR includes a consistent use of the energy loss range for each step:

- Calculate the energy loss range only once per step at `calc_physics_step_limit` and use the cache value elsewhere
- Add assessor and mutator functions for dedx_range in `PhysicsTrackView`
- Add a temporary tweak for numerical instability in the conversion from range  to step which will be replaced with `CELER_ASSERT(range > step)` later.
