### PR TITLE
Make UrbanMscScatter input geometry immutable

### DIFF
--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -98,7 +98,7 @@ class VecgeomTrackView
     inline CELER_FUNCTION Propagation find_next_step(real_type max_step);
 
     // Find the safety at the current position
-    inline CELER_FUNCTION real_type find_safety();
+    inline CELER_FUNCTION real_type find_safety() const;
 
     // Move to the boundary in preparation for crossing it
     inline CELER_FUNCTION void move_to_boundary();
@@ -334,7 +334,7 @@ CELER_FUNCTION Propagation VecgeomTrackView::find_next_step(real_type max_step)
 /*!
  * Find the safety at the current position.
  */
-CELER_FUNCTION real_type VecgeomTrackView::find_safety()
+CELER_FUNCTION real_type VecgeomTrackView::find_safety() const
 {
     real_type safety = detail::BVHNavigator::ComputeSafety(
         detail::to_vector(this->pos()), vgstate_);

--- a/src/celeritas/global/alongstep/detail/UrbanMsc.hh
+++ b/src/celeritas/global/alongstep/detail/UrbanMsc.hh
@@ -144,7 +144,7 @@ CELER_FUNCTION void UrbanMsc::apply_step(CoreTrackView const& track,
 
     UrbanMscScatter msc_scatter(msc_params_,
                                 par,
-                                &geo,
+                                geo,
                                 phys,
                                 mat.make_material_view(),
                                 msc_step_result,

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -76,7 +76,7 @@ class OrangeTrackView
     inline CELER_FUNCTION Propagation find_next_step(real_type max_step);
 
     // Find the distance to the nearest boundary in any direction
-    inline CELER_FUNCTION real_type find_safety();
+    inline CELER_FUNCTION real_type find_safety() const;
 
     // Move to the boundary in preparation for crossing it
     inline CELER_FUNCTION void move_to_boundary();
@@ -290,7 +290,7 @@ CELER_FUNCTION Propagation OrangeTrackView::find_next_step(real_type max_step)
 /*!
  * Find the distance to the nearest boundary in any direction.
  */
-CELER_FUNCTION real_type OrangeTrackView::find_safety()
+CELER_FUNCTION real_type OrangeTrackView::find_safety() const
 {
     if (states_.surf[thread_])
     {

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -308,7 +308,7 @@ TEST_F(UrbanMscTest, msc_scattering)
 
         UrbanMscScatter scatter(model->host_ref(),
                                 *part_view_,
-                                &geo_view,
+                                geo_view,
                                 phys,
                                 material_view,
                                 step_result,


### PR DESCRIPTION
This MR include minor changes for the UrbanMscScatter input geometry parameter:
- Make the input geometry immutable reference.
- Remove the member data geometry_ and add safety_ instead.
- Change relevant codes accordingly.

I was going to include this as a part of moving dedx_range from PhysicsTrackView to PhysicsStepView, but request this MR separately as the proposed change is postponed.  