### PR TITLE
Unify units in EM interactors/data

### DIFF
--- a/src/celeritas/em/AtomicRelaxationParams.cc
+++ b/src/celeritas/em/AtomicRelaxationParams.cc
@@ -176,7 +176,8 @@ void AtomicRelaxationParams::append_element(const ImportAtomicRelaxation& inp,
             transitions[j].auger_shell
                 = des_to_id[import_transitions[j].auger_shell];
             transitions[j].probability = import_transitions[j].probability;
-            transitions[j].energy      = import_transitions[j].energy;
+            transitions[j].energy
+                = units::MevEnergy{import_transitions[j].energy};
         }
         shells[i].transitions
             = make_builder(&data->transitions)

--- a/src/celeritas/em/FluctuationParams.cc
+++ b/src/celeritas/em/FluctuationParams.cc
@@ -38,7 +38,7 @@ FluctuationParams::FluctuationParams(const ParticleParams& particles,
     CELER_VALIDATE(data.electron_id,
                    << "missing electron particle (required for energy loss "
                       "fluctuations)");
-    data.electron_mass = particles.get(data.electron_id).mass().value();
+    data.electron_mass = particles.get(data.electron_id).mass();
 
     // Loop over materials
     auto urban = make_builder(&data.urban);
@@ -54,7 +54,7 @@ FluctuationParams::FluctuationParams(const ParticleParams& particles,
         params.oscillator_strength[0] = 1 - params.oscillator_strength[1];
         params.binding_energy[1]      = 1e-5 * ipow<2>(avg_z);
         params.binding_energy[0]
-            = std::pow(mat.mean_excitation_energy().value()
+            = std::pow(value_as<units::MevEnergy>(mat.mean_excitation_energy())
                            / std::pow(params.binding_energy[1],
                                       params.oscillator_strength[1]),
                        1 / params.oscillator_strength[0]);

--- a/src/celeritas/em/data/AtomicRelaxationData.hh
+++ b/src/celeritas/em/data/AtomicRelaxationData.hh
@@ -23,12 +23,10 @@ namespace celeritas
  */
 struct AtomicRelaxTransition
 {
-    using Energy = units::MevEnergy;
-
     SubshellId initial_shell; //!< Index of the originating shell
     SubshellId auger_shell;   //!< Index of the Auger electron shell
     real_type  probability;
-    real_type  energy;
+    units::MevEnergy energy;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/data/AtomicRelaxationData.hh
+++ b/src/celeritas/em/data/AtomicRelaxationData.hh
@@ -23,6 +23,8 @@ namespace celeritas
  */
 struct AtomicRelaxTransition
 {
+    using Energy = units::MevEnergy;
+
     SubshellId initial_shell; //!< Index of the originating shell
     SubshellId auger_shell;   //!< Index of the Auger electron shell
     real_type  probability;

--- a/src/celeritas/em/data/BetheHeitlerData.hh
+++ b/src/celeritas/em/data/BetheHeitlerData.hh
@@ -58,7 +58,7 @@ struct BetheHeitlerData
     //! Check whether the data is assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return ids && electron_mass > 0;
+        return ids && electron_mass > zero_quantity();
     }
 };
 

--- a/src/celeritas/em/data/BetheHeitlerData.hh
+++ b/src/celeritas/em/data/BetheHeitlerData.hh
@@ -9,6 +9,7 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
 
 namespace celeritas
@@ -44,7 +45,7 @@ struct BetheHeitlerData
     //! Model/particle IDs
     BetheHeitlerIds ids;
     //! Electron mass [MevMass]
-    real_type electron_mass{0};
+    units::MevMass electron_mass;
     //! LPM flag
     bool enable_lpm{false};
 

--- a/src/celeritas/em/data/EPlusGGData.hh
+++ b/src/celeritas/em/data/EPlusGGData.hh
@@ -32,13 +32,14 @@ struct EPlusGGData
         ParticleId gamma;
     } ids;
 
-    //! electron mass [MevMass]
-    real_type electron_mass;
+    //! Electron mass
+    units::MevMass electron_mass;
 
     //! Check whether the data is assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return ids.action && ids.positron && ids.gamma && electron_mass > 0;
+        return ids.action && ids.positron && ids.gamma
+               && electron_mass > zero_quantity();
     }
 };
 

--- a/src/celeritas/em/data/FluctuationData.hh
+++ b/src/celeritas/em/data/FluctuationData.hh
@@ -11,6 +11,7 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/data/Collection.hh"
+#include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
 
 namespace celeritas
@@ -21,6 +22,7 @@ namespace celeritas
  */
 struct UrbanFluctuationParameters
 {
+    using Energy = units::MevEnergy;
     using Real2 = Array<real_type, 2>;
 
     Real2 binding_energy;      //!< Binding energies E_1 and E_2 [MeV]
@@ -37,11 +39,12 @@ struct FluctuationData
 {
     template<class T>
     using MaterialItems = Collection<T, W, M, MaterialId>;
+    using Mass          = units::MevMass;
 
     //// MEMBER DATA ////
 
     ParticleId electron_id;   //!< ID of an electron
-    real_type  electron_mass; //!< Electron mass [MevMass]
+    Mass       electron_mass; //!< Electron mass
     MaterialItems<UrbanFluctuationParameters> urban; //!< Model parameters
 
     //// MEMBER FUNCTIONS ////
@@ -49,7 +52,7 @@ struct FluctuationData
     //! Check whether the data is assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return electron_id && electron_mass > 0;
+        return electron_id && electron_mass > zero_quantity();
     }
 
     //! Assign from another set of data

--- a/src/celeritas/em/data/LivermorePEData.hh
+++ b/src/celeritas/em/data/LivermorePEData.hh
@@ -149,12 +149,14 @@ struct LivermorePEIds
 template<Ownership W, MemSpace M>
 struct LivermorePEData
 {
+    using Mass = units::MevMass;
+
     //// MEMBER DATA ////
 
     //! IDs in a separate struct for readability/easier copying
     LivermorePEIds ids;
 
-    //! 1 / electron mass [1 / MevMass]
+    //! 1 / electron mass [1 / Mass]
     real_type inv_electron_mass;
 
     //! Livermore EPICS2014 photoelectric data

--- a/src/celeritas/em/data/MollerBhabhaData.hh
+++ b/src/celeritas/em/data/MollerBhabhaData.hh
@@ -36,27 +36,30 @@ struct MollerBhabhaIds
  */
 struct MollerBhabhaData
 {
+    using Energy = units::MevEnergy;
+    using Mass   = units::MevMass;
+
     //! Model and particle IDs
     MollerBhabhaIds ids;
 
     //! Electron mass * c^2 [MeV]
-    real_type electron_mass_c_sq;
+    real_type electron_mass;
 
     //! Model's mininum energy limit [MeV]
-    static CELER_CONSTEXPR_FUNCTION real_type min_valid_energy()
+    static CELER_CONSTEXPR_FUNCTION Energy min_valid_energy()
     {
-        return 1e-3;
+        return units::MevEnergy{1e-3};
     }
     //! Model's maximum energy limit [MeV]
-    static CELER_CONSTEXPR_FUNCTION real_type max_valid_energy()
+    static CELER_CONSTEXPR_FUNCTION Energy max_valid_energy()
     {
-        return 100e6;
+        return units::MevEnergy{100e6};
     }
 
     //! Whether the data are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return ids && electron_mass_c_sq > 0;
+        return ids && electron_mass_c_sq > zero_quantity();
     }
 };
 

--- a/src/celeritas/em/data/MollerBhabhaData.hh
+++ b/src/celeritas/em/data/MollerBhabhaData.hh
@@ -9,6 +9,7 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
 
 namespace celeritas
@@ -36,22 +37,19 @@ struct MollerBhabhaIds
  */
 struct MollerBhabhaData
 {
-    using Energy = units::MevEnergy;
-    using Mass   = units::MevMass;
-
     //! Model and particle IDs
     MollerBhabhaIds ids;
 
     //! Electron mass * c^2 [MeV]
-    real_type electron_mass;
+    units::MevMass electron_mass;
 
     //! Model's mininum energy limit [MeV]
-    static CELER_CONSTEXPR_FUNCTION Energy min_valid_energy()
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy min_valid_energy()
     {
         return units::MevEnergy{1e-3};
     }
     //! Model's maximum energy limit [MeV]
-    static CELER_CONSTEXPR_FUNCTION Energy max_valid_energy()
+    static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_valid_energy()
     {
         return units::MevEnergy{100e6};
     }
@@ -59,7 +57,7 @@ struct MollerBhabhaData
     //! Whether the data are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return ids && electron_mass_c_sq > zero_quantity();
+        return ids && electron_mass > zero_quantity();
     }
 };
 

--- a/src/celeritas/em/detail/Utils.cc
+++ b/src/celeritas/em/detail/Utils.cc
@@ -23,12 +23,12 @@ namespace detail
 MaxSecondariesCalculator::MaxSecondariesCalculator(
     const Values&                         data,
     const ItemRange<AtomicRelaxSubshell>& shells,
-    MevEnergy                             electron_cut,
-    MevEnergy                             gamma_cut)
+    Energy                                electron_cut,
+    Energy                                gamma_cut)
     : data_(data)
     , shells_(data.shells[shells])
-    , electron_cut_(electron_cut.value())
-    , gamma_cut_(gamma_cut.value())
+    , electron_cut_(electron_cut)
+    , gamma_cut_(gamma_cut)
 {
 }
 

--- a/src/celeritas/em/detail/Utils.hh
+++ b/src/celeritas/em/detail/Utils.hh
@@ -29,7 +29,7 @@ class MaxSecondariesCalculator
   public:
     //!@{
     //! Type aliases
-    using MevEnergy = units::MevEnergy;
+    using Energy    = units::MevEnergy;
     using Values    = HostCRef<AtomicRelaxParamsData>;
     //!@}
 
@@ -37,8 +37,8 @@ class MaxSecondariesCalculator
     // Construct with EADL transition data and production thresholds
     MaxSecondariesCalculator(const Values&                         data,
                              const ItemRange<AtomicRelaxSubshell>& shells,
-                             MevEnergy electron_cut,
-                             MevEnergy gamma_cut);
+                             Energy electron_cut,
+                             Energy gamma_cut);
 
     // Calculate the maximum possible number of secondaries produced
     size_type operator()();
@@ -46,8 +46,8 @@ class MaxSecondariesCalculator
   private:
     const Values&                             data_;
     Span<const AtomicRelaxSubshell>           shells_;
-    const real_type                           electron_cut_;
-    const real_type                           gamma_cut_;
+    const Energy                              electron_cut_;
+    const Energy                              gamma_cut_;
     std::unordered_map<SubshellId, size_type> visited_;
 
     // HELPER FUNCTIONS

--- a/src/celeritas/em/distribution/EnergyLossUrbanDistribution.hh
+++ b/src/celeritas/em/distribution/EnergyLossUrbanDistribution.hh
@@ -163,7 +163,7 @@ CELER_FUNCTION EnergyLossUrbanDistribution::EnergyLossUrbanDistribution(
     // Calculate the excitation macroscopic cross sections and apply the width
     // correction
     const auto& mat = cur_mat.make_material_view();
-    if (max_energy_ > mat.mean_excitation_energy().value())
+    if (max_energy_ > value_as<Energy>(mat.mean_excitation_energy()))
     {
         // Common term in the numerator and denominator of PRM Eq. 7.10
         // two_mebsgs = 2 * m_e c^2 * beta^2 * gamma^2

--- a/src/celeritas/em/distribution/TsaiUrbanDistribution.hh
+++ b/src/celeritas/em/distribution/TsaiUrbanDistribution.hh
@@ -38,14 +38,14 @@ class TsaiUrbanDistribution
   public:
     //!@{
     //! Type aliases
-    using MevEnergy   = units::MevEnergy;
-    using MevMass     = units::MevMass;
+    using Energy      = units::MevEnergy;
+    using Mass        = units::MevMass;
     using result_type = real_type;
     //!@}
 
   public:
     // Construct with defaults
-    inline CELER_FUNCTION TsaiUrbanDistribution(MevEnergy energy, MevMass mass);
+    inline CELER_FUNCTION TsaiUrbanDistribution(Energy energy, Mass mass);
 
     // Sample using the given random number generator
     template<class Engine>
@@ -63,9 +63,8 @@ class TsaiUrbanDistribution
  * Construct from input data.
  */
 CELER_FUNCTION
-TsaiUrbanDistribution::TsaiUrbanDistribution(MevEnergy energy, MevMass mass)
+TsaiUrbanDistribution::TsaiUrbanDistribution(Energy energy, Mass mass)
 {
-    // MevMass{}.value() [MeV]
     umax_ = 2 * (1 + energy.value() / mass.value());
 }
 

--- a/src/celeritas/em/distribution/UrbanMscHelper.hh
+++ b/src/celeritas/em/distribution/UrbanMscHelper.hh
@@ -58,7 +58,7 @@ class UrbanMscHelper
     //// DATA ////
 
     // Incident particle energy
-    const Energy inc_energy_;
+    const real_type inc_energy_;
     // PhysicsTrackView
     const PhysicsTrackView& physics_;
     // Range scaling factor
@@ -82,7 +82,7 @@ CELER_FUNCTION
 UrbanMscHelper::UrbanMscHelper(const UrbanMscRef&       shared,
                                const ParticleTrackView& particle,
                                const PhysicsTrackView&  physics)
-    : inc_energy_(particle.energy())
+    : inc_energy_(value_as<Energy>(particle.energy()))
     , physics_(physics)
     , dtrl_(shared.params.dtrl())
 {
@@ -131,9 +131,9 @@ CELER_FUNCTION auto UrbanMscHelper::calc_end_energy(real_type step) const
     {
         // Short step can be approximated with linear extrapolation.
         real_type dedx = physics_.make_calculator<EnergyLossCalculator>(
-            eloss_gid_)(inc_energy_);
+            eloss_gid_)(Energy{inc_energy_});
 
-        return Energy{inc_energy_.value() - step * dedx};
+        return Energy{inc_energy_ - step * dedx};
     }
     else
     {

--- a/src/celeritas/em/distribution/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/distribution/UrbanMscStepLimit.hh
@@ -334,7 +334,7 @@ CELER_FUNCTION real_type UrbanMscStepLimit::calc_limit_min() const
     {
         // Energy is below a pre-defined limit
         xm *= (real_type(0.5)
-               + real_type(0.5) * inc_energy_ / this->tlow().value());
+               + real_type(0.5) * inc_energy_ / value_as<Energy>(this->tlow()));
     }
 
     return max<real_type>(xm, shared_.params.limit_min_fix());

--- a/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
+++ b/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
@@ -43,6 +43,14 @@ namespace celeritas
 class MollerBhabhaInteractor
 {
   public:
+    //!@{
+    //! \name Type aliases
+    using Mass     = units::MevMass;
+    using Energy   = units::MevEnergy;
+    using Momentum = units::MevMomentum;
+    //!@}
+
+  public:
     //! Construct with shared and state data
     inline CELER_FUNCTION
     MollerBhabhaInteractor(const MollerBhabhaData&    shared,
@@ -88,16 +96,17 @@ CELER_FUNCTION MollerBhabhaInteractor::MollerBhabhaInteractor(
     const Real3&               inc_direction,
     StackAllocator<Secondary>& allocate)
     : shared_(shared)
-    , inc_energy_(particle.energy().value())
-    , inc_momentum_(particle.momentum().value())
+    , inc_energy_{value_as<Energy>(particle.energy())}
+    , inc_momentum_{value_as<Momentum>(particle.momentum())}
     , inc_direction_(inc_direction)
-    , electron_cutoff_(cutoffs.energy(shared_.ids.electron).value())
+    , electron_cutoff_(value_as<Energy>(cutoffs.energy(shared_.ids.electron)))
     , allocate_(allocate)
     , inc_particle_is_electron_(particle.particle_id() == shared_.ids.electron)
 {
     CELER_EXPECT(particle.particle_id() == shared_.ids.electron
                  || particle.particle_id() == shared_.ids.positron);
-    CELER_EXPECT(electron_cutoff_ >= shared_.min_valid_energy());
+    CELER_EXPECT(electron_cutoff_
+                 >= value_as<Energy>(shared_.min_valid_energy()));
 }
 
 //---------------------------------------------------------------------------//
@@ -115,8 +124,7 @@ CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
         // The secondary should not be emitted. This interaction cannot
         // happen and the incident particle must undergo an energy loss
         // process.
-        return Interaction::from_unchanged(units::MevEnergy{inc_energy_},
-                                           inc_direction_);
+        return Interaction::from_unchanged(Energy{inc_energy_}, inc_direction_);
     }
 
     // Allocate memory for the produced electron
@@ -133,13 +141,17 @@ CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
     if (inc_particle_is_electron_)
     {
         MollerEnergyDistribution sample_moller(
-            shared_.electron_mass_c_sq, electron_cutoff_, inc_energy_);
+            value_as<Mass>(shared_.electron_mass),
+            electron_cutoff_,
+            inc_energy_);
         epsilon = sample_moller(rng);
     }
     else
     {
         BhabhaEnergyDistribution sample_bhabha(
-            shared_.electron_mass_c_sq, electron_cutoff_, inc_energy_);
+            value_as<Mass>(shared_.electron_mass),
+            electron_cutoff_,
+            inc_energy_);
         epsilon = sample_bhabha(rng);
     }
 
@@ -149,13 +161,16 @@ CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
 
     // Same equation as in ParticleTrackView::momentum_sq()
     const real_type secondary_momentum = std::sqrt(
-        secondary_energy * (secondary_energy + 2 * shared_.electron_mass_c_sq));
+        secondary_energy
+        * (secondary_energy + 2 * value_as<Mass>(shared_.electron_mass)));
 
-    const real_type total_energy = inc_energy_ + shared_.electron_mass_c_sq;
+    const real_type total_energy = inc_energy_
+                                   + value_as<Mass>(shared_.electron_mass);
 
     // Calculate theta from energy-momentum conservation
     real_type secondary_cos_theta
-        = secondary_energy * (total_energy + shared_.electron_mass_c_sq)
+        = secondary_energy
+          * (total_energy + value_as<Mass>(shared_.electron_mass))
           / (secondary_momentum * inc_momentum_);
 
     secondary_cos_theta = celeritas::min<real_type>(secondary_cos_theta, 1);
@@ -182,13 +197,13 @@ CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
     // Construct interaction for change to primary (incident) particle
     const real_type inc_exiting_energy = inc_energy_ - secondary_energy;
     Interaction     result;
-    result.energy      = units::MevEnergy{inc_exiting_energy};
+    result.energy      = Energy{inc_exiting_energy};
     result.secondaries = {electron_secondary, 1};
     result.direction   = inc_exiting_direction;
 
     // Assign values to the secondary particle
     electron_secondary[0].particle_id = shared_.ids.electron;
-    electron_secondary[0].energy      = units::MevEnergy{secondary_energy};
+    electron_secondary[0].energy      = Energy{secondary_energy};
     electron_secondary[0].direction   = secondary_direction;
 
     return result;

--- a/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
+++ b/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
@@ -200,7 +200,6 @@ CELER_FUNCTION real_type MuBremsstrahlungInteractor::differential_cross_section(
     const real_type delta = real_type(0.5) * inc_mass_sq * rel_energy_transfer
                             / (inc_total_energy - gamma_energy);
 
-
     // TODO: precalculate these data per element
     real_type       d_n_prime, b, b1;
     const real_type d_n = real_type(1.54)

--- a/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
+++ b/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
@@ -200,6 +200,8 @@ CELER_FUNCTION real_type MuBremsstrahlungInteractor::differential_cross_section(
     const real_type delta = real_type(0.5) * inc_mass_sq * rel_energy_transfer
                             / (inc_total_energy - gamma_energy);
 
+
+    // TODO: precalculate these data per element
     real_type       d_n_prime, b, b1;
     const real_type d_n = real_type(1.54)
                           * std::pow(atomic_mass, real_type(0.27));

--- a/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
+++ b/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
@@ -42,8 +42,9 @@ class MuBremsstrahlungInteractor
 {
     //!@{
     //! \name Type aliases
-    using Energy = units::MevEnergy;
-    using Mass   = units::MevMass;
+    using Energy   = units::MevEnergy;
+    using Mass     = units::MevMass;
+    using Momentum = units::MevMomentum;
     //!@}
 
   public:
@@ -146,7 +147,8 @@ CELER_FUNCTION Interaction MuBremsstrahlungInteractor::operator()(Engine& rng)
     Real3 inc_direction;
     for (int i : range(3))
     {
-        inc_direction[i] = particle_.momentum().value() * inc_direction_[i]
+        inc_direction[i] = value_as<Momentum>(particle_.momentum())
+                               * inc_direction_[i]
                            - epsilon * gamma_dir[i];
     }
     normalize_direction(&inc_direction);
@@ -199,7 +201,8 @@ CELER_FUNCTION real_type MuBremsstrahlungInteractor::differential_cross_section(
     }
 
     const int       atomic_number    = element_.atomic_number();
-    const real_type atomic_mass      = element_.atomic_mass().value();
+    const real_type atomic_mass
+        = value_as<units::AmuMass>(element_.atomic_mass());
     const real_type sqrt_e           = std::sqrt(constants::euler);
     const real_type inc_total_energy = value_as<Mass>(particle_.mass())
                                        + value_as<Energy>(particle_.energy());

--- a/src/celeritas/em/interactor/RayleighInteractor.hh
+++ b/src/celeritas/em/interactor/RayleighInteractor.hh
@@ -187,7 +187,8 @@ auto RayleighInteractor::evaluate_weight_and_prob() const -> SampleInput
         input.weight[i] = (x[i] > this->fit_slice())
                               ? 1 - fastpow(1 + x[i], -n[i])
                               : n[i] * x[i]
-                                    * (1 - (n[i] - 1) / 2 * x[i]
+                                    * (1
+                                       - (n[i] - 1) / 2 * x[i]
                                              * (1 - (n[i] - 2) / 3 * x[i]));
 
         prob[i] = input.weight[i] * a[i] / (b[i] * n[i]);

--- a/src/celeritas/em/interactor/RayleighInteractor.hh
+++ b/src/celeritas/em/interactor/RayleighInteractor.hh
@@ -174,8 +174,9 @@ auto RayleighInteractor::evaluate_weight_and_prob() const -> SampleInput
     const Real3& n = shared_.params[element_id_].n;
 
     SampleInput input;
-    input.factor = ipow<2>(units::centimeter * native_value_from(inc_energy_)
-                           / (constants::c_light * constants::h_planck));
+    input.factor = ipow<2>(units::centimeter
+                           / (constants::c_light * constants::h_planck)
+                           * native_value_from(inc_energy_));
 
     Real3 x = b;
     axpy(input.factor, b, &x);

--- a/src/celeritas/em/interactor/RayleighInteractor.hh
+++ b/src/celeritas/em/interactor/RayleighInteractor.hh
@@ -149,7 +149,7 @@ CELER_FUNCTION Interaction RayleighInteractor::operator()(Engine& rng)
         }
         else
         {
-            x = std::pow(1 - y, -ninv) - 1;
+            x = fastpow(1 - y, -ninv) - 1;
         }
 
         cost = 1 - 2 * x / (b * input.factor);
@@ -184,12 +184,11 @@ auto RayleighInteractor::evaluate_weight_and_prob() const -> SampleInput
     Real3 prob;
     for (auto i : range(3))
     {
-        input.weight[i] = (x[i] > fit_slice())
-                              ? 1 - std::pow(1 + x[i], -n[i])
+        input.weight[i] = (x[i] > this->fit_slice())
+                              ? 1 - fastpow(1 + x[i], -n[i])
                               : n[i] * x[i]
-                                    * (1
-                                       - real_type(0.5) * (n[i] - 1) * (x[i])
-                                             * (1 - (n[i] - 2) * (x[i]) / 3));
+                                    * (1 - (n[i] - 1) / 2 * x[i]
+                                             * (1 - (n[i] - 2) / 3 * x[i]));
 
         prob[i] = input.weight[i] * a[i] / (b[i] * n[i]);
     }

--- a/src/celeritas/em/interactor/SeltzerBergerInteractor.hh
+++ b/src/celeritas/em/interactor/SeltzerBergerInteractor.hh
@@ -48,7 +48,7 @@ class SeltzerBergerInteractor
 {
   public:
     //!@{
-    //! Type aliases
+    //! \name Type aliases
     using Energy   = units::MevEnergy;
     using Momentum = units::MevMomentum;
     //!@}

--- a/src/celeritas/em/model/BetheHeitlerModel.cc
+++ b/src/celeritas/em/model/BetheHeitlerModel.cc
@@ -38,8 +38,7 @@ BetheHeitlerModel::BetheHeitlerModel(ActionId              id,
                    << "missing electron, positron and/or gamma particles "
                       "(required for "
                    << this->description() << ")");
-    interface_.electron_mass
-        = particles.get(interface_.ids.electron).mass().value();
+    interface_.electron_mass = particles.get(interface_.ids.electron).mass();
     CELER_ENSURE(interface_);
 }
 

--- a/src/celeritas/em/model/EPlusGGModel.cc
+++ b/src/celeritas/em/model/EPlusGGModel.cc
@@ -32,8 +32,7 @@ EPlusGGModel::EPlusGGModel(ActionId id, const ParticleParams& particles)
     CELER_VALIDATE(interface_.ids.positron && interface_.ids.gamma,
                    << "missing positron and/or gamma particles (required for "
                    << this->description() << ")");
-    interface_.electron_mass
-        = particles.get(interface_.ids.positron).mass().value();
+    interface_.electron_mass = particles.get(interface_.ids.positron).mass();
     CELER_ENSURE(interface_);
 }
 

--- a/src/celeritas/em/model/KleinNishinaModel.cc
+++ b/src/celeritas/em/model/KleinNishinaModel.cc
@@ -30,7 +30,9 @@ KleinNishinaModel::KleinNishinaModel(ActionId              id,
                       "(required for "
                    << this->description() << ")");
     interface_.inv_electron_mass
-        = 1 / particles.get(interface_.ids.electron).mass().value();
+        = 1
+          / value_as<KleinNishinaData::Mass>(
+              particles.get(interface_.ids.electron).mass());
     CELER_ENSURE(interface_);
 }
 

--- a/src/celeritas/em/model/LivermorePEModel.cc
+++ b/src/celeritas/em/model/LivermorePEModel.cc
@@ -53,7 +53,9 @@ LivermorePEModel::LivermorePEModel(ActionId              id,
 
     // Save particle properties
     host_data.inv_electron_mass
-        = 1 / particles.get(host_data.ids.electron).mass().value();
+        = 1
+          / value_as<LivermorePERef::Mass>(
+              particles.get(host_data.ids.electron).mass());
 
     // Load Livermore cross section data
     CELER_LOG(status) << "Reading and building Livermore PE model data";

--- a/src/celeritas/em/model/MollerBhabhaModel.cc
+++ b/src/celeritas/em/model/MollerBhabhaModel.cc
@@ -35,8 +35,7 @@ MollerBhabhaModel::MollerBhabhaModel(ActionId              id,
                       "(required for "
                    << this->description() << ")");
 
-    interface_.electron_mass_c_sq
-        = particles.get(interface_.ids.electron).mass().value(); // [MeV]
+    interface_.electron_mass = particles.get(interface_.ids.electron).mass();
 
     CELER_ENSURE(interface_);
 }

--- a/src/celeritas/em/model/UrbanMscModel.cc
+++ b/src/celeritas/em/model/UrbanMscModel.cc
@@ -153,7 +153,7 @@ auto UrbanMscModel::calc_material_data(const MaterialView& material_view)
     data.zeff = zeff;
 
     // Correction in the (modified Highland-Lynch-Dahl) theta_0 formula
-    const double z16 = std::pow(zeff, 1.0 / 6.0);
+    const double z16 = fastpow(zeff, 1.0 / 6.0);
     double       fz  = PolyQuad(0.990395, -0.168386, 0.093286)(z16);
     data.coeffth1    = fz * (1 - 8.7780e-2 / zeff);
     data.coeffth2    = fz * (4.0780e-2 + 1.7315e-4 * zeff);

--- a/src/celeritas/em/xs/EPlusGGMacroXsCalculator.hh
+++ b/src/celeritas/em/xs/EPlusGGMacroXsCalculator.hh
@@ -30,7 +30,7 @@ class EPlusGGMacroXsCalculator
   public:
     //!@{
     //! Type aliases
-    using MevEnergy = units::MevEnergy;
+    using Energy    = units::MevEnergy;
     using XsUnits   = units::NativeUnit;
     //!@}
 
@@ -41,12 +41,12 @@ class EPlusGGMacroXsCalculator
                              const MaterialView& material);
 
     // Compute cross section on the fly at the given energy
-    inline CELER_FUNCTION real_type operator()(MevEnergy energy) const;
+    inline CELER_FUNCTION real_type operator()(Energy energy) const;
 
     //! Minimum energy for Heitler formula validity
-    static CELER_CONSTEXPR_FUNCTION MevEnergy min_energy()
+    static CELER_CONSTEXPR_FUNCTION Energy min_energy()
     {
-        return MevEnergy{1e-6};
+        return units::MevEnergy{1e-6};
     }
 
   private:
@@ -63,7 +63,7 @@ class EPlusGGMacroXsCalculator
 CELER_FUNCTION
 EPlusGGMacroXsCalculator::EPlusGGMacroXsCalculator(const EPlusGGData&  shared,
                                                    const MaterialView& material)
-    : electron_mass_(shared.electron_mass)
+    : electron_mass_(value_as<units::MevMass>(shared.electron_mass))
     , electron_density_(material.electron_density())
 {
 }
@@ -76,15 +76,14 @@ EPlusGGMacroXsCalculator::EPlusGGMacroXsCalculator(const EPlusGGData&  shared,
  * Release 10.6) is used to compute the macroscopic cross section for positron
  * annihilation on the fly at the given energy.
  */
-CELER_FUNCTION real_type
-EPlusGGMacroXsCalculator::operator()(MevEnergy energy) const
+CELER_FUNCTION real_type EPlusGGMacroXsCalculator::operator()(Energy energy) const
 {
     using constants::pi;
     using constants::r_electron;
     using PolyQuad = PolyEvaluator<real_type, 2>;
 
     const real_type gamma
-        = celeritas::max(energy.value(), this->min_energy().value())
+        = celeritas::max(energy.value(), value_as<Energy>(this->min_energy()))
           / electron_mass_;
     const real_type sqrt_gg2 = std::sqrt(gamma * (gamma + 2));
 

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -344,7 +344,7 @@ FieldDriver<StepperT>::one_good_step(real_type step, const OdeState& state) cons
         {
             // Step failed; compute the size of re-trial step.
             real_type htemp = options_.safety * step
-                              * std::pow(errmax2, half() * options_.pshrink);
+                              * fastpow(errmax2, half() * options_.pshrink);
 
             // Truncation error too large, reduce stepsize with a low bound
             step = max(htemp, options_.max_stepping_decrease * step);
@@ -360,7 +360,7 @@ FieldDriver<StepperT>::one_good_step(real_type step, const OdeState& state) cons
     output.proposed_step
         = (errmax2 > ipow<2>(options_.errcon))
               ? options_.safety * step
-                    * std::pow(errmax2, half() * options_.pgrow)
+                    * fastpow(errmax2, half() * options_.pgrow)
               : options_.max_stepping_increase * step;
 
     return output;
@@ -375,7 +375,7 @@ CELER_FUNCTION real_type
 FieldDriver<StepperT>::new_step_size(real_type step, real_type rel_error) const
 {
     CELER_ASSERT(rel_error > 0);
-    real_type scale_factor = std::pow(
+    real_type scale_factor = fastpow(
         rel_error, rel_error > 1 ? options_.pshrink : options_.pgrow);
     return options_.safety * step * scale_factor;
 }

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -357,11 +357,10 @@ FieldDriver<StepperT>::one_good_step(real_type step, const OdeState& state) cons
     // Update state, step taken by this trial and the next predicted step
     output.end.state = result.end_state;
     output.end.step  = step;
-    output.proposed_step
-        = (errmax2 > ipow<2>(options_.errcon))
-              ? options_.safety * step
-                    * fastpow(errmax2, half() * options_.pgrow)
-              : options_.max_stepping_increase * step;
+    output.proposed_step = (errmax2 > ipow<2>(options_.errcon))
+                               ? options_.safety * step
+                                     * fastpow(errmax2, half() * options_.pgrow)
+                               : options_.max_stepping_increase * step;
 
     return output;
 }

--- a/src/celeritas/field/Types.hh
+++ b/src/celeritas/field/Types.hh
@@ -35,8 +35,8 @@ struct OdeState
  */
 struct StepperResult
 {
-    OdeState end_state; //!< OdeState at the end
     OdeState mid_state; //!< OdeState at the middle
+    OdeState end_state; //!< OdeState at the end
     OdeState err_state; //!< Delta between one full step and two half steps
 };
 

--- a/src/celeritas/io/ImportAtomicRelaxation.hh
+++ b/src/celeritas/io/ImportAtomicRelaxation.hh
@@ -20,7 +20,7 @@ struct ImportAtomicTransition
     int    initial_shell; //!< Originating shell designator
     int    auger_shell;   //!< Auger shell designator
     double probability;   //!< Transition probability
-    double energy;        //!< Transition energy
+    double energy;        //!< Transition energy [MeV]
 };
 
 struct ImportAtomicSubshell

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -590,11 +590,14 @@ CELER_FUNCTION real_type PhysicsTrackView::range_to_step(real_type range) const
 {
     CELER_ASSERT(range >= 0);
     const real_type rho = params_.scalars.scaling_min_range;
-    if (range < rho * real_type(1.0000001))
+    if (range < rho)
         return range;
 
     const real_type alpha = params_.scalars.scaling_fraction;
     real_type step = alpha * range + rho * (1 - alpha) * (2 - rho / range);
+    step           = celeritas::min<real_type>(range, step);
+    // TODO: drop this temporary tweak when numerical instability (off by 1ulp)
+    // of the range scaling calculation.
     CELER_ENSURE(step > 0 && step <= range);
     return step;
 }

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -590,14 +590,11 @@ CELER_FUNCTION real_type PhysicsTrackView::range_to_step(real_type range) const
 {
     CELER_ASSERT(range >= 0);
     const real_type rho = params_.scalars.scaling_min_range;
-    if (range < rho)
+    if (range < rho * real_type(1.0000001))
         return range;
 
     const real_type alpha = params_.scalars.scaling_fraction;
     real_type step = alpha * range + rho * (1 - alpha) * (2 - rho / range);
-    step           = celeritas::min<real_type>(range, step);
-    // TODO: drop this temporary tweak when numerical instability (off by 1ulp)
-    // of the range scaling calculation.
     CELER_ENSURE(step > 0 && step <= range);
     return step;
 }

--- a/src/celeritas/random/distribution/GammaDistribution.hh
+++ b/src/celeritas/random/distribution/GammaDistribution.hh
@@ -117,7 +117,7 @@ CELER_FUNCTION auto GammaDistribution<RealType>::operator()(Generator& rng)
 
     result_type result = d_ * v * beta_;
     if (alpha_ != alpha_p_)
-        result *= std::pow(generate_canonical(rng), 1 / alpha_);
+        result *= fastpow(generate_canonical(rng), 1 / alpha_);
     return result;
 }
 

--- a/test/celeritas/em/BetheHeitler.test.cc
+++ b/test/celeritas/em/BetheHeitler.test.cc
@@ -41,7 +41,7 @@ class BetheHeitlerInteractorTest : public celeritas_test::InteractorHostTestBase
         data_.ids.electron  = params.find(pdg::electron());
         data_.ids.positron  = params.find(pdg::positron());
         data_.ids.gamma     = params.find(pdg::gamma());
-        data_.electron_mass = params.get(data_.ids.electron).mass().value();
+        data_.electron_mass = params.get(data_.ids.electron).mass();
         data_.enable_lpm    = true;
 
         // Set default particle to photon with energy of 100 MeV
@@ -243,7 +243,7 @@ TEST_F(BetheHeitlerInteractorTest, distributions)
             // Bin the electron reduced energy \epsilon = (E_e + m_e c^2 /
             // E_{\gamma}
             const auto electron = out.secondaries.front();
-            double     eps = (electron.energy.value() + data_.electron_mass)
+            double eps = (electron.energy.value() + data_.electron_mass.value())
                          / inc_energy;
             int eps_bin = eps * nbins;
             if (eps_bin >= 0 && eps_bin < nbins)

--- a/test/celeritas/em/EPlusGG.test.cc
+++ b/test/celeritas/em/EPlusGG.test.cc
@@ -35,8 +35,7 @@ class EPlusGGInteractorTest : public celeritas_test::InteractorHostTestBase
         const auto& params = *this->particle_params();
         data_.ids.positron = params.find(pdg::positron());
         data_.ids.gamma    = params.find(pdg::gamma());
-        data_.electron_mass
-            = params.get(params.find(pdg::electron())).mass().value();
+        data_.electron_mass = params.get(params.find(pdg::electron())).mass();
 
         // Set default particle to incident 10 MeV positron
         this->set_inc_particle(pdg::positron(), MevEnergy{10});
@@ -57,18 +56,18 @@ class EPlusGGInteractorTest : public celeritas_test::InteractorHostTestBase
         EXPECT_TRUE(gamma1);
         EXPECT_EQ(data_.ids.gamma, gamma1.particle_id);
 
-        EXPECT_GT(
-            this->particle_track().energy().value() + 2 * data_.electron_mass,
-            gamma1.energy.value());
+        EXPECT_GT(this->particle_track().energy().value()
+                      + 2 * data_.electron_mass.value(),
+                  gamma1.energy.value());
         EXPECT_LT(0, gamma1.energy.value());
         EXPECT_SOFT_EQ(1.0, celeritas::norm(gamma1.direction));
 
         const auto& gamma2 = interaction.secondaries.back();
         EXPECT_TRUE(gamma2);
         EXPECT_EQ(data_.ids.gamma, gamma2.particle_id);
-        EXPECT_GT(
-            this->particle_track().energy().value() + 2 * data_.electron_mass,
-            gamma2.energy.value());
+        EXPECT_GT(this->particle_track().energy().value()
+                      + 2 * data_.electron_mass.value(),
+                  gamma2.energy.value());
         EXPECT_LT(0, gamma2.energy.value());
         EXPECT_SOFT_EQ(1.0, celeritas::norm(gamma2.direction));
     }
@@ -170,9 +169,9 @@ TEST_F(EPlusGGInteractorTest, at_rest)
                        celeritas::dot_product(result.secondaries[0].direction,
                                               result.secondaries[1].direction));
 
-        EXPECT_SOFT_EQ(data_.electron_mass,
+        EXPECT_SOFT_EQ(data_.electron_mass.value(),
                        result.secondaries[0].energy.value());
-        EXPECT_SOFT_EQ(data_.electron_mass,
+        EXPECT_SOFT_EQ(data_.electron_mass.value(),
                        result.secondaries[1].energy.value());
     }
 }

--- a/test/celeritas/em/LivermorePE.test.cc
+++ b/test/celeritas/em/LivermorePE.test.cc
@@ -52,6 +52,7 @@ using celeritas::PhotoelectricProcess;
 using celeritas::SubshellId;
 using celeritas::ThreadId;
 using celeritas::ValueGridInserter;
+using celeritas::units::MevEnergy;
 namespace pdg = celeritas::pdg;
 
 //---------------------------------------------------------------------------//
@@ -567,8 +568,8 @@ TEST_F(LivermorePETest, utils)
         {
             // One radiative transition per subshell, each one originating in
             // the next subshell up
-            std::vector<AtomicRelaxTransition> transitions
-                = {{SubshellId{i + 1}, SubshellId{}, 1, 1}};
+            std::vector<AtomicRelaxTransition> transitions = {
+                {SubshellId{i + 1}, SubshellId{}, real_type{1}, MevEnergy{1}}};
             shells[i].transitions
                 = make_builder(&data.transitions)
                       .insert_back(transitions.begin(), transitions.end());
@@ -602,7 +603,7 @@ TEST_F(LivermorePETest, utils)
                 transitions.push_back({SubshellId{j + 1},
                                        SubshellId{j + 1},
                                        1. / (num_shells - i),
-                                       1});
+                                       MevEnergy{1}});
             }
             shells[i].transitions
                 = make_builder(&data.transitions)

--- a/test/celeritas/em/MollerBhabha.test.cc
+++ b/test/celeritas/em/MollerBhabha.test.cc
@@ -64,8 +64,7 @@ class MollerBhabhaInteractorTest : public celeritas_test::InteractorHostTestBase
         const auto& params = *this->particle_params();
         data_.ids.electron = params.find(pdg::electron());
         data_.ids.positron = params.find(pdg::positron());
-        data_.electron_mass_c_sq
-            = params.get(data_.ids.electron).mass().value();
+        data_.electron_mass = params.get(data_.ids.electron).mass();
     }
 
     void sanity_check(const Interaction& interaction) const


### PR DESCRIPTION
- Data classes now use Quantities where possible
- Interfaces uses Quantities where possible
- Consistently use `value_as<T>` when operating on automatic types (e.g. from other function calls, like `particle.mass()`), but allow e.g. `energy.value()` if `energy` is a local variable with known type

Closes #277