### PR TITLE
Fix field propagator at boundary crossings

### DIFF
--- a/src/celeritas/ext/VecgeomParams.hh
+++ b/src/celeritas/ext/VecgeomParams.hh
@@ -60,6 +60,17 @@ class VecgeomParams
     //! Maximum nested geometry depth
     int max_depth() const { return host_ref_.max_depth; }
 
+    //// SURFACES (NOT APPLICABLE FOR VECGEOM) ////
+
+    // Get the label for a placed volume ID
+    inline const Label& id_to_label(SurfaceId) const;
+
+    // Get the surface ID corresponding to a unique label name
+    inline SurfaceId find_surface(const std::string& name) const;
+
+    //! Number of distinct surfaces
+    size_type num_surfaces() const { return 0; }
+
     //// DATA ACCESS ////
 
     //! Access geometry data on host
@@ -85,6 +96,24 @@ class VecgeomParams
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * No surface IDs are defined in vecgeom.
+ */
+const Label& VecgeomParams::id_to_label(SurfaceId) const
+{
+    CELER_NOT_IMPLEMENTED("surfaces in VecGeom");
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * No surface IDs are defined in vecgeom.
+ */
+SurfaceId VecgeomParams::find_surface(const std::string&) const
+{
+    return {};
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Access geometry data on host.

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -7,12 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <iostream>
-
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
-#include "corecel/cont/ArrayIO.hh"
-#include "corecel/io/ColorUtils.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "orange/Types.hh"
 #include "celeritas/geo/GeoTrackView.hh"
@@ -20,8 +16,6 @@
 
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
-using std::cout;
-using std::endl;
 
 namespace celeritas
 {
@@ -136,8 +130,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     result_type result;
     result.distance = 0;
 
-    cout << "Propagate up to " << step << endl;
-
     // Break the curved steps into substeps as determined by the driver *and*
     // by the proximity of geometry boundaries. Test for intersection with the
     // geometry boundary in each substep. This loop is guaranteed to converge
@@ -151,9 +143,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         DriverResult substep = driver_.advance(remaining, state_);
         CELER_ASSERT(substep.step <= remaining);
 
-        cout << "- advance(" << remaining << ", " << state_.pos << ") -> {"
-             << substep.step << ", " << substep.state.pos << "}" << endl;
-
         // TODO: use safety distance to reduce number of calls to
         // find_next_step
 
@@ -164,9 +153,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // the substep end point.
         geo_.set_dir(chord.dir);
         auto linear_step = geo_.find_next_step(chord.length);
-        cout << " + chord length " << chord.length << " => linear step "
-             << linear_step.distance
-             << (linear_step.boundary ? " (boundary!)" : "") << endl;
         if (!linear_step.boundary)
         {
             // No boundary intersection along the chord: accept substep
@@ -177,7 +163,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.distance += substep.step;
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
-            cout << " + advancing to substep end point" << endl;
         }
         else if (substep.step * linear_step.distance
                  <= driver_.minimum_step() * chord.length)
@@ -189,8 +174,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.boundary = true;
             result.distance += linear_step.distance;
             remaining = 0;
-            cout << " + next trial step exceeds driver minimum "
-                 << driver_.minimum_step() << endl;
         }
         else if (detail::is_intercept_close(state_.pos,
                                             chord.dir,
@@ -206,9 +189,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.distance += substep.step;
             state_.mom = substep.state.mom;
             remaining  = 0;
-
-            cout << " + intercept is sufficiently close to substep point "
-                 << driver_.minimum_step() << endl;
         }
         else
         {
@@ -216,10 +196,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // Decrease the allowed substep (curved path distance) by the
             // fraction along the chord, and retry the driver step.
             remaining = substep.step * linear_step.distance / chord.length;
-
-            cout << " + Setting remaining distance to a fraction "
-                 << linear_step.distance / chord.length << " of the substep"
-                 << endl;
         }
     }
 
@@ -227,7 +203,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     {
         geo_.move_to_boundary();
         state_.pos = geo_.pos();
-        cout << "- Moved to boundary at position " << state_.pos << endl;
     }
     else if (remaining > 0)
     {
@@ -235,8 +210,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // value for "step". Return that we've moved this tiny amount (for e.g.
         // dE/dx purposes) but don't physically propagate the track.
         result.distance += remaining;
-        cout << "- Moved distance " << remaining
-             << " without physically changing position" << endl;
     }
 
     // Even though the along-substep movement was through chord lengths,
@@ -245,9 +218,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     Real3 dir = state_.mom;
     normalize_direction(&dir);
     geo_.set_dir(dir);
-
-    cout << color_code('g') << "==> distance " << result.distance
-         << color_code(' ') << endl;
 
     CELER_ENSURE(result.distance >= 0 && result.distance <= step);
     return result;

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -88,7 +88,7 @@ class OrangeParams
     SurfaceId find_surface(const std::string& name) const;
 
     //! Number of distinct surfaces
-    size_type num_surfaces() const { return surf_labels_.size(); }
+    SurfaceId::size_type num_surfaces() const { return surf_labels_.size(); }
 
     //// DATA ACCESS ////
 

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -9,6 +9,7 @@
 
 #include "corecel/cont/ArrayIO.hh"
 #include "corecel/data/CollectionStateStore.hh"
+#include "corecel/math/Algorithms.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/GlobalGeoTestBase.hh"
@@ -441,14 +442,17 @@ TEST_F(TwoBoxTest, electron_tangent_cross)
             field, driver_options, particle, &geo);
         auto result = propagate(circ);
 
-        EXPECT_SOFT_NEAR(circ / 4, result.distance, .025);
+        // Trigonometry to find actual intersection point and length along arc
+        real_type theta = std::asin(1 - dy);
+        real_type x     = std::sqrt(2 * dy - ipow<2>(dy));
+
+        EXPECT_SOFT_NEAR(theta, result.distance, .025);
         EXPECT_TRUE(result.boundary);
-        EXPECT_LT(distance(Real3({1, 5, 0}), geo.pos()), 1e-5)
+        EXPECT_LT(distance(Real3({x, 5, 0}), geo.pos()), 1e-5)
             << "Actually stopped at " << geo.pos();
-        EXPECT_LT(distance(Real3({-1, 0, 0}), geo.dir()), 1e-5)
+        EXPECT_LT(distance(Real3({dy - 1, x, 0}), geo.dir()), 1e-5)
             << "Ending direction at " << geo.dir();
     }
-    return;
     {
         SCOPED_TRACE("Barely misses boundary");
 

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -421,7 +421,7 @@ TEST_F(TwoBoxTest, electron_cross)
 }
 
 // Electron barely crosses boundary
-TEST_F(TwoBoxTest, DISABLED_electron_tangent_cross)
+TEST_F(TwoBoxTest, electron_tangent_cross)
 {
     auto particle = this->init_particle(
         this->particle()->find(pdg::electron()), MevEnergy{10});
@@ -448,6 +448,7 @@ TEST_F(TwoBoxTest, DISABLED_electron_tangent_cross)
         EXPECT_LT(distance(Real3({-1, 0, 0}), geo.dir()), 1e-5)
             << "Ending direction at " << geo.dir();
     }
+    return;
     {
         SCOPED_TRACE("Barely misses boundary");
 

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -326,6 +326,7 @@ TEST_F(TwoBoxTest, electron_tangent)
             field, driver_options, particle, &geo);
         auto result = propagate(0.49 * pi);
 
+        EXPECT_FALSE(result.boundary);
         EXPECT_SOFT_EQ(0.49 * pi, result.distance);
         EXPECT_LT(
             distance(Real3({std::cos(0.49 * pi), 4 + std::sin(0.49 * pi), 0}),
@@ -340,6 +341,7 @@ TEST_F(TwoBoxTest, electron_tangent)
             field, driver_options, particle, &geo);
         auto result = propagate(0.02 * pi);
 
+        EXPECT_FALSE(result.boundary);
         EXPECT_SOFT_EQ(0.02 * pi, result.distance);
         EXPECT_LT(
             distance(Real3({std::cos(0.51 * pi), 4 + std::sin(0.51 * pi), 0}),
@@ -452,6 +454,10 @@ TEST_F(TwoBoxTest, electron_tangent_cross)
             << "Actually stopped at " << geo.pos();
         EXPECT_LT(distance(Real3({dy - 1, x, 0}), geo.dir()), 1e-5)
             << "Ending direction at " << geo.dir();
+
+        geo.cross_boundary();
+        EXPECT_EQ("world", this->geometry()->id_to_label(geo.volume_id()));
+        EXPECT_FALSE(geo.is_outside());
     }
     {
         SCOPED_TRACE("Barely misses boundary");


### PR DESCRIPTION
Based on the discussion we had today, it's possible to miss a tangent boundary if the intersection point is less than the chord tolerance. I've updated the test so that one track goes beyond the boundary by less than the chord tolerance (it barely ignores the surface) and the second by greater than the tolerance (it definitely hits it but at a grazing angle). Both tests now pass.

-----------

This is a work-in-progress commit where I'm narrowing down a potential failure in solving the intersection point with a single surface along a curved path with the field propagator. There are two slight variations on the same test in which the track barely leaves the current volume, traveling left at the point {0,5,0} along a curve of unit radius. The first variation starts the particle at $y=4 + 1.1 \Delta_\textrm{chord}$, which should definitely intersect the surface; and the second starts at $y=4 + 0.9 \Delta_\textrm{chord}$ which probably should not (and in practice does not). In this test the field driver has a delta chord tolerance of 0.025 cm.

# Initial behavior

The output values are at each step in the main propagation loop:
```
        cout << "- advance(" << remaining << ", " << state_.pos << ") -> {"
             << substep.step << ", " << substep.state.pos << "}" << endl;
```

## Intersects boundary (fail)

```
- advance(6.28319, {1,4.0275,0}) -> {0.448159, {0.901247,4.46081,0}}
 + chord length 0.444418 => linear step 0.444418
 + advancing to substep end point
- advance(5.83503, {0.901247,4.46081,0}) -> {0.448157, {0.624492,4.80853,0}}
 + chord length 0.444416 => linear step 0.444416
 + advancing to substep end point
- advance(5.38687, {0.624492,4.80853,0}) -> {0.448155, {0.224399,5.002,0}}
 + chord length 0.444414 => linear step 0.439825 (boundary!)
 + Setting remaining distance to a fraction 0.989673 of the substep
- advance(0.443527, {0.624492,4.80853,0}) -> {0.443527, {0.228906,5.00095,0}}
 + chord length 0.439901 => linear step 0.437732 (boundary!)
 + Setting remaining distance to a fraction 0.995069 of the substep
- advance(0.44134, {0.624492,4.80853,0}) -> {0.44134, {0.231035,5.00045,0}}
 + chord length 0.437767 => linear step 0.43675 (boundary!)
 + Setting remaining distance to a fraction 0.997677 of the substep
- advance(0.440315, {0.624492,4.80853,0}) -> {0.440315, {0.232032,5.00021,0}}
 + chord length 0.436767 => linear step 0.436292 (boundary!)
 + Setting remaining distance to a fraction 0.998912 of the substep
- advance(0.439836, {0.624492,4.80853,0}) -> {0.439836, {0.232498,5.0001,0}}
 + chord length 0.436299 => linear step 0.436078 (boundary!)
 + Setting remaining distance to a fraction 0.999492 of the substep
- advance(0.439613, {0.624492,4.80853,0}) -> {0.439613, {0.232715,5.00005,0}}
 + chord length 0.436081 => linear step 0.435978 (boundary!)
 + Setting remaining distance to a fraction 0.999763 of the substep
- advance(0.439509, {0.624492,4.80853,0}) -> {0.439509, {0.232816,5.00002,0}}
 + chord length 0.43598 => linear step 0.435932 (boundary!)
 + Setting remaining distance to a fraction 0.99989 of the substep
- advance(0.43946, {0.624492,4.80853,0}) -> {0.43946, {0.232863,5.00001,0}}
 + chord length 0.435933 => linear step 0.43591 (boundary!)
 + Setting remaining distance to a fraction 0.999949 of the substep
- advance(0.439438, {0.624492,4.80853,0}) -> {0.439438, {0.232885,5,0}}
 + chord length 0.435911 => linear step 0.4359 (boundary!)
 + Setting remaining distance to a fraction 0.999976 of the substep
- advance(0.439427, {0.624492,4.80853,0}) -> {0.439427, {0.232896,5,0}}
 + chord length 0.4359 => linear step 0.435896 (boundary!)
 + intercept is sufficiently close to substep point 1e-06
- Moved to boundary at position {0.2329,5,0}
```
failure messages:
```
/Users/seth/.local/src/celeritas/test/celeritas/field/FieldPropagator.test.cc:444: Failure
Value of: result.distance
  Actual: 1.3357430026561443
Expected: circ / 4
Which is: 1.5707963267948966
(Relative error -0.14963959370745578 exceeds tolerance 0.025000000000000001)
Google Test trace:
/Users/seth/.local/src/celeritas/test/celeritas/field/FieldPropagator.test.cc:435: Barely hits boundary
/Users/seth/.local/src/celeritas/test/celeritas/field/FieldPropagator.test.cc:446: Failure
Expected: (distance(Real3({1, 5, 0}), geo.pos())) < (1e-5), actual: 0.7671 vs 1e-05
Actually stopped at {0.2328998819190623,5,0}
Google Test trace:
/Users/seth/.local/src/celeritas/test/celeritas/field/FieldPropagator.test.cc:435: Barely hits boundary
/Users/seth/.local/src/celeritas/test/celeritas/field/FieldPropagator.test.cc:448: Failure
Expected: (distance(Real3({-1, 0, 0}), geo.dir())) < (1e-5), actual: 0.234513 vs 1e-05
Ending direction at {-0.97250177989559339,0.23289544456666161,0}
Google Test trace:
/Users/seth/.local/src/celeritas/test/celeritas/field/FieldPropagator.test.cc:435: Barely hits boundary
```

## Misses boundary

```
Propagate up to 6.28319
- advance(6.28319, {1,4.0225,0}) -> {0.448159, {0.901247,4.45581,0}}
 + chord length 0.444418 => linear step 0.444418
 + advancing to substep end point
- advance(5.83503, {0.901247,4.45581,0}) -> {0.448157, {0.624492,4.80353,0}}
 + chord length 0.444416 => linear step 0.444416
 + advancing to substep end point
- advance(5.38687, {0.624492,4.80353,0}) -> {0.448155, {0.224399,4.997,0}}
 + chord length 0.444414 => linear step 0.444414
 + advancing to substep end point
- advance(4.93871, {0.224399,4.997,0}) -> {0.448154, {-0.220013,4.998,0}}
 + chord length 0.444413 => linear step 0.444413
 + advancing to substep end point
(etc...)
```