### PR TITLE
NVHPC: silence warnings

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -238,7 +238,8 @@ if(CELERITAS_BUILD_DEMOS)
   celeritas_target_link_libraries(demo-loop ${_demo_loop_libs})
 
   if(NOT CELERITAS_USE_OpenMP AND
-      (CMAKE_CXX_COMPILER STREQUAL "GNU" OR CMAKE_CXX_COMPILER MATCHES "Clang"))
+      (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+          OR CMAKE_CXX_COMPILER_ID MATCHES "Clang$"))
     celeritas_target_compile_options(demo-loop
       PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>
     )

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -237,9 +237,11 @@ if(CELERITAS_BUILD_DEMOS)
   add_executable(demo-loop ${_demo_loop_src})
   celeritas_target_link_libraries(demo-loop ${_demo_loop_libs})
 
-  if(NOT CELERITAS_USE_OpenMP)
+  if(NOT CELERITAS_USE_OpenMP AND
+      (CMAKE_CXX_COMPILER STREQUAL "GNU" OR CMAKE_CXX_COMPILER MATCHES "Clang"))
     celeritas_target_compile_options(demo-loop
-      PRIVATE -Wno-unknown-pragmas)
+      PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>
+    )
   endif()
 
   if(CELERITAS_BUILD_TESTS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -286,12 +286,11 @@ endif()
 
 if(CELERITAS_USE_OpenMP)
   celeritas_target_link_libraries(celeritas PRIVATE OpenMP::OpenMP_CXX)
-else()
-  if(CMAKE_CXX_COMPILER STREQUAL "GNU" OR CMAKE_CXX_COMPILER MATCHES "Clang")
-    celeritas_target_compile_options(celeritas
-      PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>
-    )
-  endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+  celeritas_target_compile_options(celeritas
+    PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>
+  )
 endif()
 
 celeritas_target_link_libraries(celeritas

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -287,7 +287,11 @@ endif()
 if(CELERITAS_USE_OpenMP)
   celeritas_target_link_libraries(celeritas PRIVATE OpenMP::OpenMP_CXX)
 else()
-  celeritas_target_compile_options(celeritas PRIVATE -Wno-unknown-pragmas)
+  if(CMAKE_CXX_COMPILER STREQUAL "GNU" OR CMAKE_CXX_COMPILER MATCHES "Clang")
+    celeritas_target_compile_options(celeritas
+      PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>
+    )
+  endif()
 endif()
 
 celeritas_target_link_libraries(celeritas

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -142,7 +142,7 @@
         do                                     \
         {                                      \
             assert(false);                     \
-            celeritas::unreachable();          \
+            ::celeritas::unreachable();        \
         } while (0)
 #endif
 

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -129,7 +129,7 @@
         {                                                                  \
             ::celeritas::device_debug_error(                               \
                 "Unreachable code point encountered", __FILE__, __LINE__); \
-            CELER_UNREACHABLE;                                             \
+            ::celeritas::unreachable();                                    \
         } while (0)
 #elif CELERITAS_USE_CUDA && !defined(NDEBUG)
 // CUDA assert macro is enabled
@@ -142,7 +142,7 @@
         do                                     \
         {                                      \
             assert(false);                     \
-            CELER_UNREACHABLE;                 \
+            celeritas::unreachable();          \
         } while (0)
 #endif
 
@@ -191,7 +191,7 @@
 #    define CELER_EXPECT(COND) CELER_NOASSERT_(COND)
 #    define CELER_ASSERT(COND) CELER_NOASSERT_(COND)
 #    define CELER_ENSURE(COND) CELER_NOASSERT_(COND)
-#    define CELER_ASSERT_UNREACHABLE() CELER_UNREACHABLE
+#    define CELER_ASSERT_UNREACHABLE() ::celeritas::unreachable()
 #endif
 
 #if !CELER_DEVICE_COMPILE
@@ -398,6 +398,12 @@ enum class DebugErrorType
                                       const char* condition,
                                       const char* file,
                                       int         line);
+
+//! Invoke undefined behavior
+[[noreturn]] inline CELER_FUNCTION void unreachable()
+{
+    CELER_UNREACHABLE;
+}
 
 //---------------------------------------------------------------------------//
 // TYPES

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -116,6 +116,7 @@
  * (to provide a more detailed error message in case the point *is* reached).
  */
 #if (!defined(__CUDA_ARCH__) && (defined(__clang__) || defined(__GNUC__))) \
+    || defined(__NVCOMPILER)                                               \
     || (defined(__CUDA_ARCH__) && CUDART_VERSION >= 11030)                 \
     || defined(__HIP_DEVICE_COMPILE__)
 #    define CELER_UNREACHABLE __builtin_unreachable()

--- a/src/corecel/cont/LabelIdMultiMap.hh
+++ b/src/corecel/cont/LabelIdMultiMap.hh
@@ -161,7 +161,7 @@ auto LabelIdMultiMap<I>::find_all(const std::string& name) const
     CELER_ASSERT(offset_idx + 1 < id_offsets_.size());
     size_type start = id_offsets_[offset_idx];
     size_type stop  = id_offsets_[offset_idx + 1];
-    CELER_ENSURE(0 <= start && start < stop && stop <= id_data_.size());
+    CELER_ENSURE(start < stop && stop <= id_data_.size());
     return {id_data_.data() + start, stop - start};
 }
 

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -140,8 +140,8 @@ class Span
     CELER_FUNCTION Span<T, detail::subspan_extent(Extent, Offset, Count)>
                    subspan() const
     {
-        CELER_EXPECT(Count == dynamic_extent || (Offset == 0 && Count == 0)
-                     || Offset + Count <= this->size());
+        CELER_EXPECT((Count == dynamic_extent) || (Offset == 0 && Count == 0)
+                     || (Offset + Count <= this->size()));
         return {s_.data + Offset,
                 detail::subspan_size(this->size(), Offset, Count)};
     }

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -140,7 +140,7 @@ class Span
     CELER_FUNCTION Span<T, detail::subspan_extent(Extent, Offset, Count)>
                    subspan() const
     {
-        CELER_EXPECT(Count == dynamic_extent || Offset == 0 && Count == 0
+        CELER_EXPECT(Count == dynamic_extent || (Offset == 0 && Count == 0)
                      || Offset + Count <= this->size());
         return {s_.data + Offset,
                 detail::subspan_size(this->size(), Offset, Count)};

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -126,7 +126,7 @@ class Span
     template<std::size_t Count>
     CELER_FUNCTION Span<T, Count> first() const
     {
-        CELER_EXPECT(Count <= this->size());
+        CELER_EXPECT(Count == 0 || Count <= this->size());
         return {s_.data, Count};
     }
     CELER_FUNCTION
@@ -140,7 +140,8 @@ class Span
     CELER_FUNCTION Span<T, detail::subspan_extent(Extent, Offset, Count)>
                    subspan() const
     {
-        CELER_EXPECT(Offset + Count <= this->size());
+        CELER_EXPECT(Count == dynamic_extent || Offset == 0 && Count == 0
+                     || Offset + Count <= this->size());
         return {s_.data + Offset,
                 detail::subspan_size(this->size(), Offset, Count)};
     }
@@ -156,7 +157,7 @@ class Span
     template<std::size_t Count>
     CELER_FUNCTION Span<T, Count> last() const
     {
-        CELER_EXPECT(Count <= this->size());
+        CELER_EXPECT(Count == 0 || Count <= this->size());
         return {this->data() + this->size() - Count, Count};
     }
     CELER_FUNCTION

--- a/src/orange/surf/detail/SurfaceAction.hh
+++ b/src/orange/surf/detail/SurfaceAction.hh
@@ -74,10 +74,21 @@ struct StaticSurfaceAction
 // PRIVATE MACRO DEFINITIONS
 //---------------------------------------------------------------------------//
 
+//! Call a function for the given type, using the type as the argument.
 #define ORANGE_SURF_DISPATCH_CASE_IMPL(FUNC, TYPE) \
     case SurfaceType::TYPE:                        \
         FUNC(typename SurfaceTypeTraits<SurfaceType::TYPE>::type)
 
+/*!
+ * Expand a macro to a switch statement over all possible surface types.
+ *
+ * The \c FUNC argument should be a macro that:
+ * - takes a single argument which is a surface class identifier (e.g.
+ *   \c GeneralQuadric)
+ * - calls \c return or \c break
+ *
+ * The \c ST argument must be a value of type \c SurfaceType.
+ */
 #define ORANGE_SURF_DISPATCH_IMPL(FUNC, ST)                 \
     do                                                      \
     {                                                       \

--- a/src/orange/surf/detail/SurfaceAction.hh
+++ b/src/orange/surf/detail/SurfaceAction.hh
@@ -76,7 +76,7 @@ struct StaticSurfaceAction
 
 #define ORANGE_SURF_DISPATCH_CASE_IMPL(FUNC, TYPE) \
     case SurfaceType::TYPE:                        \
-        FUNC(typename SurfaceTypeTraits<SurfaceType::TYPE>::type) break
+        FUNC(typename SurfaceTypeTraits<SurfaceType::TYPE>::type)
 
 #define ORANGE_SURF_DISPATCH_IMPL(FUNC, ST)                 \
     do                                                      \

--- a/test/celeritas/grid/PolyEvaluator.test.cc
+++ b/test/celeritas/grid/PolyEvaluator.test.cc
@@ -25,12 +25,14 @@ TEST(PolyEvaluatorTest, make_eval)
     EXPECT_TRUE(
         (std::is_same<decltype(eval_poly), PolyEvaluator<double, 3>>()));
     EXPECT_EQ(4 * sizeof(double), sizeof(eval_poly));
+    EXPECT_DOUBLE_EQ(63.0, eval_poly(2.0));
 
     // Second-order int poly: 3 x^2 + 1
     auto eval_int_poly = make_poly_evaluator(1, 0, 3);
     EXPECT_TRUE(
         (std::is_same<decltype(eval_int_poly), PolyEvaluator<int, 2>>()));
     EXPECT_EQ(3 * sizeof(int), sizeof(eval_int_poly));
+    EXPECT_EQ(13, eval_int_poly(2));
 }
 
 TEST(PolyEvaluatorTest, degenerate)

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -404,7 +404,7 @@ TEST_F(PhysicsTrackViewHostTest, value_grids)
                 for (ValueGridType vgt : range(ValueGridType::size_))
                 {
                     auto id = phys.value_grid(vgt, pp_id);
-                    grid_ids.push_back(id ? id.get() : -1);
+                    grid_ids.push_back(id ? static_cast<int>(id.get()) : -1);
                 }
             }
         }

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -298,7 +298,7 @@ TEST_F(PhysicsStepUtilsTest, select_discrete_interaction)
         // random number generator and by the energy of particle.
         // The number of tries is picked so that each process is selected at
         // least once.
-        std::vector<ActionId::size_type> models(13, -1);
+        std::vector<ActionId::size_type> models(13, ActionId::size_type{-1});
         for (auto i : range(models.size()))
         {
             auto action_id = select_discrete_interaction(

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -298,7 +298,7 @@ TEST_F(PhysicsStepUtilsTest, select_discrete_interaction)
         // random number generator and by the energy of particle.
         // The number of tries is picked so that each process is selected at
         // least once.
-        std::vector<ActionId::size_type> models(13, ActionId::size_type{-1});
+        std::vector<ActionId::size_type> models(13, ActionId::size_type(-1));
         for (auto i : range(models.size()))
         {
             auto action_id = select_discrete_interaction(

--- a/test/celeritas/random/curand/CurandPerformance.test.cu
+++ b/test/celeritas/random/curand/CurandPerformance.test.cu
@@ -83,7 +83,7 @@ TestOutput curand_test(TestParams params)
 
     curand_setup_kernel<<<params.nblocks, params.nthreads>>>(devStates,
                                                              time(NULL));
-    CELER_CUDA_CALL(cudaThreadSynchronize());
+    CELER_CUDA_CALL(cudaDeviceSynchronize());
 
     // Output data for kernel
     thrust::device_vector<double> sum(params.nthreads * params.nblocks, 0.0);

--- a/test/corecel/OpaqueId.test.cc
+++ b/test/corecel/OpaqueId.test.cc
@@ -32,6 +32,7 @@ class OpaqueIdTest : public celeritas_test::Test
 TEST(OpaqueIdTest, operations)
 {
     using Id_t = OpaqueId<TestInstantiator, std::size_t>;
+    constexpr auto sizemax = static_cast<std::size_t>(-1);
 
     Id_t unassigned;
     EXPECT_FALSE(unassigned);
@@ -41,8 +42,8 @@ TEST(OpaqueIdTest, operations)
 #if CELERITAS_DEBUG
     EXPECT_THROW(unassigned.get(), celeritas::DebugError);
 #endif
-    EXPECT_EQ(static_cast<size_t>(-1), Id_t{}.unchecked_get());
-    EXPECT_EQ(std::hash<std::size_t>()(-1), std::hash<Id_t>()(unassigned));
+    EXPECT_EQ(sizemax, Id_t{}.unchecked_get());
+    EXPECT_EQ(std::hash<std::size_t>()(sizemax), std::hash<Id_t>()(unassigned));
 
     Id_t assigned{123};
     EXPECT_TRUE(assigned);

--- a/test/corecel/sys/TypeDemangler.test.cc
+++ b/test/corecel/sys/TypeDemangler.test.cc
@@ -92,8 +92,8 @@ TEST(TypeDemanglerTest, dynamic)
     using namespace tdtest;
 
     TypeDemangler<JapaneseIsland> demangle;
-    const Honshu                  honshu;
-    const Hokkaido                hokkaido;
+    const Honshu                  honshu{};
+    const Hokkaido                hokkaido{};
     const JapaneseIsland&         hon_ptr = honshu;
     const JapaneseIsland&         hok_ptr = hokkaido;
 


### PR DESCRIPTION
Nvhpc was complaining about `break` being unreachable, and first (just in case the compiler macros were unexpected) I added a backport of [std::unreachable](https://en.cppreference.com/w/cpp/utility/unreachable).