### PR TITLE
Add minor fixes for UrbanMsc

### DIFF
--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -59,10 +59,10 @@ struct UrbanMscParameters
         return 100 * limit_min_fix();
     }
 
-    //! Below this endpoint energy, don't sample scattering
+    //! Below this endpoint energy, don't sample scattering: 1 eV
     static CELER_CONSTEXPR_FUNCTION Energy min_sampling_energy()
     {
-        return units::MevEnergy{1e-9};
+        return units::MevEnergy{1e-6};
     }
 };
 

--- a/src/celeritas/em/distribution/UrbanMscScatter.hh
+++ b/src/celeritas/em/distribution/UrbanMscScatter.hh
@@ -201,8 +201,10 @@ CELER_FUNCTION auto UrbanMscScatter::operator()(Engine& rng) -> MscInteraction
     if (skip_sampling_)
     {
         // Do not sample scattering at the last or at a small step
-        return {
-            true_path_, {0, 0, 0}, {0, 0, 0}, MscInteraction::Action::unchanged};
+        return {true_path_,
+                inc_direction_,
+                {0, 0, 0},
+                MscInteraction::Action::unchanged};
     }
 
     // Sample polar angle and update tau_


### PR DESCRIPTION
This MR includes minor fixes for the UrbanMsc sampling:
- Fix the lowest kinetic energy to sample the multiple scattering (from 1e-3 eV to 1 eV)
- Return the original direction when the msc sampling is skipped (instead of {0,0,0})
