### PR TITLE
Loosen up real_type comparison in assert

### DIFF
--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -390,7 +390,7 @@ CELER_FUNCTION void VecgeomTrackView::cross_boundary()
 CELER_FUNCTION void VecgeomTrackView::move_internal(real_type dist)
 {
     CELER_EXPECT(this->has_next_step());
-    CELER_EXPECT(dist > 0 && dist <= next_step_);
+    CELER_EXPECT(dist > 0 && dist <= next_step_ + real_type(1e-16));
     CELER_EXPECT(dist != next_step_ || !vgnext_.IsOnBoundary());
 
     // Move and update next_step_


### PR DESCRIPTION
This commit follows from the conversation in pull request #484 .  An assert was being triggered due to a difference smaller than 1e-23.  This commit loosens up that real_type comparison.  See https://github.com/celeritas-project/celeritas/pull/484#issuecomment-1218922244 for more details.