### PR TITLE
Better workaround for VecGeom 1.2 crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,13 +212,16 @@ if(CELERITAS_USE_VecGeom)
     message(SEND_ERROR "VecGeom GDML capability is required for Celeritas")
   endif()
   if(CELERITAS_USE_CUDA AND VecGeom_VERSION VERSION_GREATER_EQUAL 1.2
-      AND BUILD_SHARED_LIBS)
-    #message(SEND_ERROR "VecGeom 1.2+ is incompatible with a Celeritas shared "
-    #  "library build (BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}); "
-    #  "overriding for next configure"
-    #)
-    #set(BUILD_SHARED_LIBS OFF CACHE BOOL
-    #  "Disabled due to VecGeom CUDA requirements" FORCE)
+      AND BUILD_SHARED_LIBS
+      AND NOT CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "Shared")
+    message(SEND_ERROR "VecGeom 1.2+ is incompatible with a Celeritas shared "
+      "library build (BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}) unless; "
+      "CMAKE_CUDA_RUNTIME_LIBRARY is set to Shared as well. Forcing the "
+      "CUDA runtime libraries to change for the next configure."
+    )
+    set(CMAKE_CUDA_RUNTIME_LIBRARY "Shared" CACHE STRING
+      "Forcibly enabled due to VecGeom CUDA requirements" FORCE
+    )
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,15 @@ if(CELERITAS_USE_VecGeom)
   if(NOT VecGeom_GDML_FOUND)
     message(SEND_ERROR "VecGeom GDML capability is required for Celeritas")
   endif()
+  if(CELERITAS_USE_CUDA AND VecGeom_VERSION VERSION_GREATER_EQUAL 1.2
+      AND BUILD_SHARED_LIBS)
+    #message(SEND_ERROR "VecGeom 1.2+ is incompatible with a Celeritas shared "
+    #  "library build (BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}); "
+    #  "overriding for next configure"
+    #)
+    #set(BUILD_SHARED_LIBS OFF CACHE BOOL
+    #  "Disabled due to VecGeom CUDA requirements" FORCE)
+  endif()
 endif()
 
 if(CELERITAS_BUILD_TESTS AND NOT GTest_FOUND)
@@ -275,6 +284,10 @@ elseif(CELERITAS_USE_HIP)
     SYSTEM INTERFACE "${ROCM_PATH}/include"
   )
 endif()
+
+install(TARGETS celeritas_device_toolkit
+  EXPORT celeritas-targets
+)
 
 # Add the main libraries
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,15 +211,6 @@ if(CELERITAS_USE_VecGeom)
   if(NOT VecGeom_GDML_FOUND)
     message(SEND_ERROR "VecGeom GDML capability is required for Celeritas")
   endif()
-  if(CELERITAS_USE_CUDA AND VecGeom_VERSION VERSION_GREATER_EQUAL 1.2
-      AND BUILD_SHARED_LIBS)
-    message(SEND_ERROR "VecGeom 1.2+ is incompatible with a Celeritas shared "
-      "library build (BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}); "
-      "overriding for next configure"
-    )
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL
-      "Disabled due to VecGeom CUDA requirements" FORCE)
-  endif()
 endif()
 
 if(CELERITAS_BUILD_TESTS AND NOT GTest_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,33 @@ endif()
 # LIBRARY
 #----------------------------------------------------------------------------#
 
+# Define an interface library for propagating include paths for GPU compilers.
+# This allow API calls, so long as the compiler or linker implicitly bring in
+# the correct CUDA/ROCM libraries. Those libraries are *not* explicitly linked
+# because mistakenly linking against both cudart and cudart_static (one of which
+# might come from upstream libraries such as vecgeom) can cause nasty link- and
+# run-time errors.
+add_library(celeritas_device_toolkit INTERFACE)
+add_library(Celeritas::DeviceToolkit ALIAS celeritas_device_toolkit)
+
+if(CELERITAS_USE_CUDA)
+  target_include_directories(celeritas_device_toolkit
+    SYSTEM INTERFACE $<$<COMPILE_LANGUAGE:C,CXX>:${CUDAToolkit_INCLUDE_DIRS}>
+  )
+elseif(CELERITAS_USE_HIP)
+  if(CMAKE_HIP_COMPILER_ROCM_ROOT)
+    # Undocumented CMake variable
+    set(ROCM_PATH "${CMAKE_HIP_COMPILER_ROCM_ROOT}")
+  else()
+    # This hack works on Crusher as of ROCm 5.1.0
+    set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "Path to ROCm headers")
+  endif()
+  target_include_directories(celeritas_device_toolkit
+    SYSTEM INTERFACE "${ROCM_PATH}/include"
+  )
+endif()
+
+# Add the main libraries
 add_subdirectory(src)
 
 #----------------------------------------------------------------------------#

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -221,6 +221,7 @@ if(CELERITAS_BUILD_DEMOS)
     Celeritas::Core
     nlohmann_json::nlohmann_json
     Celeritas::IO
+    Celeritas::DeviceToolkit
   )
   if(CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
     list(APPEND _demo_loop_libs VecGeom::vecgeom)
@@ -232,12 +233,6 @@ if(CELERITAS_BUILD_DEMOS)
   # Add the executable
   add_executable(demo-loop ${_demo_loop_src})
   celeritas_target_link_libraries(demo-loop ${_demo_loop_libs})
-  if(CELERITAS_USE_CUDA)
-    # Transporter calls deviceSync
-    celeritas_target_include_directories(demo-loop
-      PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CUDAToolkit_INCLUDE_DIRS}>
-    )
-  endif()
 
   if(NOT CELERITAS_USE_OpenMP AND
       (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -222,10 +222,6 @@ if(CELERITAS_BUILD_DEMOS)
     nlohmann_json::nlohmann_json
     Celeritas::IO
   )
-  if(CELERITAS_USE_CUDA)
-    # Transporter calls deviceSync
-    list(APPEND _demo_loop_libs CUDA::cudart)
-  endif()
   if(CELERITAS_USE_CUDA AND CELERITAS_USE_VecGeom)
     list(APPEND _demo_loop_libs VecGeom::vecgeom)
   endif()
@@ -236,6 +232,12 @@ if(CELERITAS_BUILD_DEMOS)
   # Add the executable
   add_executable(demo-loop ${_demo_loop_src})
   celeritas_target_link_libraries(demo-loop ${_demo_loop_libs})
+  if(CELERITAS_USE_CUDA)
+    # Transporter calls deviceSync
+    celeritas_target_include_directories(demo-loop
+      PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CUDAToolkit_INCLUDE_DIRS}>
+    )
+  endif()
 
   if(NOT CELERITAS_USE_OpenMP AND
       (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"

--- a/app/geo-check/gcheck-four-levels.json
+++ b/app/geo-check/gcheck-four-levels.json
@@ -2,6 +2,5 @@
     "input": "../../test/celeritas/data/four-levels.gdml",
     "max_steps": 500,
     "track_origin": [0, 0, 0],
-    "track_direction": [1, 1, 1],
-    "cuda_stack_size": 65536
+    "track_direction": [1, 1, 1]
 }

--- a/app/geo-check/gcheck-simplecms.json
+++ b/app/geo-check/gcheck-simplecms.json
@@ -2,6 +2,5 @@
     "input": "../../app/data/simple-cms.gdml",
     "max_steps": 5000,
     "track_origin": [0, 0, 0],
-    "track_direction": [1, 1, 1],
-    "cuda_stack_size": 65536
+    "track_direction": [1, 1, 1]
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ configure_file("celeritas_cmake_strings.h.in" "celeritas_cmake_strings.h" @ONLY)
 #----------------------------------------------------------------------------#
 
 set(SOURCES)
+set(DEVICE_SOURCES)
 set(PRIVATE_DEPS)
 set(PUBLIC_DEPS)
 
@@ -201,7 +202,6 @@ list(APPEND SOURCES
   celeritas/track/TrackInitParams.cc
 )
 
-set(DEVICE_SOURCES)
 celeritas_polysource(celeritas/global/alongstep/AlongStepGeneralLinearAction)
 celeritas_polysource(celeritas/global/alongstep/AlongStepNeutralAction)
 celeritas_polysource(celeritas/global/alongstep/AlongStepUniformMscAction)
@@ -240,8 +240,18 @@ if(CELERITAS_USE_JSON)
   list(APPEND PUBLIC_DEPS nlohmann_json::nlohmann_json)
 endif()
 
+if(CELERITAS_RNG STREQUAL "CURAND")
+  list(APPEND PUBLIC_DEPS Celeritas::DeviceToolkit)
+else()
+  list(APPEND PRIVATE_DEPS Celeritas::DeviceToolkit)
+endif()
+
 if(CELERITAS_USE_MPI)
   list(APPEND PUBLIC_DEPS MPI::MPI_CXX)
+endif()
+
+if(CELERITAS_USE_OpenMP)
+  list(APPEND PRIVATE_DEPS OpenMP::OpenMP_CXX)
 endif()
 
 if(CELERITAS_USE_VecGeom)
@@ -254,6 +264,15 @@ if(CELERITAS_USE_VecGeom)
   # to resolve the symbol generate by the `nvcc -dlink` of
   # one of the executable.
   list(APPEND PUBLIC_DEPS VecGeom::vecgeom)
+endif()
+
+if(CELERITAS_USE_HIP)
+  # Compile with HIP instead of CUDA (since we don't change our source
+  # extensions)
+  set_source_files_properties(
+    ${DEVICE_SOURCES}
+    PROPERTIES LANGUAGE HIP
+  )
 endif()
 
 celeritas_add_library(celeritas ${SOURCES} ${DEVICE_SOURCES})
@@ -271,10 +290,9 @@ if(CELERITAS_USE_ROOT AND NOT BUILD_SHARED_LIBS)
   )
 endif()
 
-if(CELERITAS_USE_OpenMP)
-  celeritas_target_link_libraries(celeritas PRIVATE OpenMP::OpenMP_CXX)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-    OR CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+if(NOT CELERITAS_USE_OpenMP
+    AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+         OR CMAKE_CXX_COMPILER_ID MATCHES "Clang$"))
   celeritas_target_compile_options(celeritas
     PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>
   )
@@ -291,36 +309,6 @@ celeritas_target_include_directories(celeritas
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-
-if(CELERITAS_USE_CUDA)
-  # Add the CUDA include directories to allow API calls. Rely on the CUDA
-  # linker to bring in the correct libraries, because mistakenly linking
-  # against both cudart and cudart_static (one of which might come from upstream
-  # libraries such as vecgeom) can cause nasty link- and run-time errors.
-  set(_cuda_access PRIVATE)
-  if(CELERITAS_RNG STREQUAL "CURAND")
-    set(_cuda_access PUBLIC)
-  endif()
-  celeritas_target_include_directories(celeritas
-    ${_cuda_access} $<$<COMPILE_LANGUAGE:CXX>:${CUDAToolkit_INCLUDE_DIRS}>
-  )
-elseif(CELERITAS_USE_HIP)
-  if(CMAKE_HIP_COMPILER_ROCM_ROOT)
-    # Undocumented CMake variable
-    set(ROCM_PATH "${CMAKE_HIP_COMPILER_ROCM_ROOT}")
-  else()
-    # This hack works on Crusher as of ROCm 5.1.0
-    set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "Path to ROCm headers")
-  endif()
-  target_include_directories(celeritas SYSTEM PUBLIC "${ROCM_PATH}/include")
-
-  # Compile with HIP instead of CUDA (since we don't change our source
-  # extensions)
-  set_source_files_properties(
-    ${DEVICE_SOURCES}
-    PROPERTIES LANGUAGE HIP
-  )
-endif()
 
 celeritas_install(TARGETS celeritas
   EXPORT celeritas-targets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -217,19 +217,6 @@ if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
   )
 endif()
 
-if(CELERITAS_USE_CUDA)
-  if(CELERITAS_RNG STREQUAL "CURAND")
-    list(APPEND PUBLIC_DEPS CUDA::cudart)
-  else()
-    list(APPEND PRIVATE_DEPS CUDA::cudart)
-  endif()
-elseif(CELERITAS_USE_HIP)
-  set_source_files_properties(
-    ${DEVICE_SOURCES}
-    PROPERTIES LANGUAGE HIP
-  )
-endif()
-
 if(CELERITAS_USE_HepMC3)
   list(APPEND SOURCES
     celeritas/io/EventReader.cc
@@ -305,11 +292,34 @@ celeritas_target_include_directories(celeritas
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-if(CELERITAS_USE_HIP)
-  # This is a hacky workaround for not having the equivalent of CUDAToolkit: it
-  # works on Crusher as of ROCm 5.1.0
-  set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "Path to ROCm headers")
+if(CELERITAS_USE_CUDA)
+  # Add the CUDA include directories to allow API calls. Rely on the CUDA
+  # linker to bring in the correct libraries, because mistakenly linking
+  # against both cudart and cudart_static (one of which might come from upstream
+  # libraries such as vecgeom) can cause nasty link- and run-time errors.
+  set(_cuda_access PRIVATE)
+  if(CELERITAS_RNG STREQUAL "CURAND")
+    set(_cuda_access PUBLIC)
+  endif()
+  celeritas_target_include_directories(celeritas
+    ${_cuda_access} $<$<COMPILE_LANGUAGE:CXX>:${CUDAToolkit_INCLUDE_DIRS}>
+  )
+elseif(CELERITAS_USE_HIP)
+  if(CMAKE_HIP_COMPILER_ROCM_ROOT)
+    # Undocumented CMake variable
+    set(ROCM_PATH "${CMAKE_HIP_COMPILER_ROCM_ROOT}")
+  else()
+    # This hack works on Crusher as of ROCm 5.1.0
+    set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "Path to ROCm headers")
+  endif()
   target_include_directories(celeritas SYSTEM PUBLIC "${ROCM_PATH}/include")
+
+  # Compile with HIP instead of CUDA (since we don't change our source
+  # extensions)
+  set_source_files_properties(
+    ${DEVICE_SOURCES}
+    PROPERTIES LANGUAGE HIP
+  )
 endif()
 
 celeritas_install(TARGETS celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -363,7 +363,7 @@ celeritas_add_test(celeritas/random/distribution/UniformRealDistribution.test.cc
 if(CELERITAS_USE_CUDA)
   celeritas_add_test(celeritas/random/curand/CurandPerformance.test.cc GPU
     SOURCES celeritas/random/curand/CurandPerformance.test.cu
-    LINK_LIBRARIES CUDA::cudart
+    LINK_LIBRARIES Celeritas::DeviceToolkit
     ${_disable_if_debug}
   )
 endif()

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -276,7 +276,7 @@ TEST_F(TestEm3MscTest, host)
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(55, result.calc_avg_steps_per_primary(), 0.25);
 
-    if (this->is_ci_build())
+    if (this->is_ci_build() || this->is_wildstyle_build())
     {
         if (CELERITAS_USE_VECGEOM)
         {
@@ -292,13 +292,6 @@ TEST_F(TestEm3MscTest, host)
             EXPECT_EQ(12, result.calc_emptying_step());
             EXPECT_EQ(RunResult::StepCount({8, 6}), result.calc_queue_hwm());
         }
-    }
-    else if (this->is_wildstyle_build())
-    {
-        EXPECT_EQ(48, result.num_step_iters());
-        EXPECT_SOFT_EQ(47.125, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(12, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({8, 6}), result.calc_queue_hwm());
     }
     else if (this->is_srj_build())
     {
@@ -335,19 +328,22 @@ TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
 
-    if (this->is_ci_build())
+    if (this->is_ci_build() || this->is_wildstyle_build())
     {
-        EXPECT_EQ(61, result.num_step_iters());
-        EXPECT_SOFT_EQ(55.625, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(9, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({7, 8}), result.calc_queue_hwm());
-    }
-    else if (this->is_wildstyle_build())
-    {
-        EXPECT_EQ(61, result.num_step_iters());
-        EXPECT_SOFT_EQ(55.625, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(9, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({7, 8}), result.calc_queue_hwm());
+        if (CELERITAS_USE_VECGEOM)
+        {
+            EXPECT_EQ(106, result.num_step_iters());
+            EXPECT_SOFT_EQ(76.875, result.calc_avg_steps_per_primary());
+            EXPECT_EQ(11, result.calc_emptying_step());
+            EXPECT_EQ(RunResult::StepCount({6, 6}), result.calc_queue_hwm());
+        }
+        else
+        {
+            EXPECT_EQ(61, result.num_step_iters());
+            EXPECT_SOFT_EQ(55.625, result.calc_avg_steps_per_primary());
+            EXPECT_EQ(9, result.calc_emptying_step());
+            EXPECT_EQ(RunResult::StepCount({7, 8}), result.calc_queue_hwm());
+        }
     }
     else
     {
@@ -377,7 +373,7 @@ TEST_F(TestEm3MscNofluctTest, host)
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(55, result.calc_avg_steps_per_primary(), 0.50);
 
-    if (this->is_ci_build())
+    if (this->is_ci_build() || this->is_wildstyle_build())
     {
         if (CELERITAS_USE_VECGEOM)
         {
@@ -400,13 +396,6 @@ TEST_F(TestEm3MscNofluctTest, host)
         EXPECT_SOFT_EQ(53.625, result.calc_avg_steps_per_primary());
         EXPECT_EQ(10, result.calc_emptying_step());
         EXPECT_EQ(RunResult::StepCount({7, 5}), result.calc_queue_hwm());
-    }
-    else if (this->is_wildstyle_build())
-    {
-        EXPECT_EQ(69, result.num_step_iters());
-        EXPECT_SOFT_EQ(57.5, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(8, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({4, 5}), result.calc_queue_hwm());
     }
     else
     {
@@ -436,19 +425,22 @@ TEST_F(TestEm3MscNofluctTest, TEST_IF_CELER_DEVICE(device))
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
 
-    if (this->is_ci_build())
+    if (this->is_ci_build() || this->is_wildstyle_build())
     {
-        EXPECT_EQ(42, result.num_step_iters());
-        EXPECT_SOFT_EQ(52.625, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(11, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({9, 4}), result.calc_queue_hwm());
+        if (CELERITAS_USE_VECGEOM)
+        {
+            EXPECT_EQ(57, result.num_step_iters());
+            EXPECT_SOFT_EQ(53.25, result.calc_avg_steps_per_primary());
+            EXPECT_EQ(10, result.calc_emptying_step());
+            EXPECT_EQ(RunResult::StepCount({11, 5}), result.calc_queue_hwm());
+        }
+        else
+        {
+            EXPECT_EQ(42, result.num_step_iters());
+            EXPECT_SOFT_EQ(52.625, result.calc_avg_steps_per_primary());
+            EXPECT_EQ(11, result.calc_emptying_step());
+            EXPECT_EQ(RunResult::StepCount({9, 4}), result.calc_queue_hwm());
     }
-    else if (this->is_wildstyle_build())
-    {
-        EXPECT_EQ(42, result.num_step_iters());
-        EXPECT_SOFT_EQ(52.625, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(11, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({9, 4}), result.calc_queue_hwm());
     }
     else
     {


### PR DESCRIPTION
Thanks to @drbenmorgan and @mrguilima for helping constrain the passing/failing configurations, and @pcanal for finding out once and for all that it's the mix of linking `libcudart` and `libcudart_shared` that causes our linking errors.

## UNFORTUNATELY

At this draft state, linking against vecgeom 1.1.18 OR 1.2.0 (shared, cmake 3.23.1, CUDA 11.5) ends up with the main libraries linking against `libcudart`, but the final link steps (e.g., `CMakeFiles/demo-loop.dir/cmake_device_link.o` and `app/demo-loop`) use `libcudart_static`, and the code still crashes when running 1.2.0 presumably due to the indeterminate link order. *However*, when building CUDA without vecgeom, everything just links against `libcudart_static`.

## FORTUNATELY

When I set `CMAKE_CUDA_RUNTIME_LIBRARY=Shared` in the vecgeom builds now, though, nothing seems to link against `libcudart_static` (just `libcudart`), and the tests pass. But even with mixed libraries and static builds, the tests pass too.

So I'm just going to require either static celeritas or Shared cuda linking.

I'm also pulling in the fixed-for-vecgeom stepper test from #494 so let's get this merged before that one.