### PR TITLE
Fix clang-14/ROCM build with JSON enabled

### DIFF
--- a/src/celeritas/phys/PDGNumber.hh
+++ b/src/celeritas/phys/PDGNumber.hh
@@ -30,7 +30,7 @@ class PDGNumber
 {
   public:
     //! Construct with an invalid/unassigned value of zero
-    explicit constexpr PDGNumber() = default;
+    constexpr PDGNumber() = default;
 
     //! Construct with the PDG value
     explicit constexpr PDGNumber(int val) : value_(val) {}


### PR DESCRIPTION
The unintentional explicit constructor causes problems with nljson on clang 14 (ROCm 5.1.0). This somehow showed up because of the JSON I/O for PDG numbers introduced by #463.

```
FAILED: app/CMakeFiles/demo-loop.dir/demo-loop/demo-loop.cc.o
/opt/cray/pe/craype/2.7.15/bin/CC -DJSON_DIAGNOSTICS=0 -DJSON_USE_IMPLICIT_CONVERSIONS=1 -I/ccs/home/s3j/.local/src/celeritas/src -I/ccs/home/s3j/.local/src/celeritas/build-ndebug/src -isystem /sw/crusher/spack-envs/base/opt/cray-sles15-zen3/gcc-11.2.0/nlohmann-json-3.10.2-fwiijvdxcf6lf7dfnojyswds4podhsem/include -isystem /opt/rocm-5.1.0/include -Wall -Wextra -pedantic -fdiagnostics-color=always -O3 -DNDEBUG -march=znver3 -mtune=znver3 -fopenmp -std=c++14 -MD -MT app/CMakeFiles/demo-loop.dir/demo-loop/demo-loop.cc.o -MF app/CMakeFiles/demo-loop.dir/demo-loop/demo-loop.cc.o.d -o app/CMakeFiles/demo-loop.dir/demo-loop/demo-loop.cc.o -c /ccs/home/s3j/.local/src/celeritas/app/demo-loop/demo-loop.cc
In file included from /ccs/home/s3j/.local/src/celeritas/app/demo-loop/demo-loop.cc:15:
/sw/crusher/spack-envs/base/opt/cray-sles15-zen3/gcc-11.2.0/nlohmann-json-3.10.2-fwiijvdxcf6lf7dfnojyswds4podhsem/include/nlohmann/json.hpp: In instantiation of 'ValueType nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType>::get_impl(nlohmann::detail::priority_tag<0>) const [with ValueType = demo_loop::LDemoArgs; typename std::enable_if<(nlohmann::detail::is_default_constructible<ValueType>::value && nlohmann::detail::has_from_json<nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType>, ValueType>::value), int>::type <anonymous> = 0; ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer; BinaryType = std::vector<unsigned char>]':
/sw/crusher/spack-envs/base/opt/cray-sles15-zen3/gcc-11.2.0/nlohmann-json-3.10.2-fwiijvdxcf6lf7dfnojyswds4podhsem/include/nlohmann/json.hpp:20621:35:   required from 'constexpr decltype (declval<const basic_json_t&>().get_impl<ValueType>((nlohmann::detail::priority_tag<4>)(<brace-enclosed initializer list>()))) nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType>::get() const [with ValueTypeCV = demo_loop::LDemoArgs; ValueType = demo_loop::LDemoArgs; ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer; BinaryType = std::vector<unsigned char>; decltype (declval<const basic_json_t&>().get_impl<ValueType>((nlohmann::detail::priority_tag<4>)(<brace-enclosed initializer list>()))) = demo_loop::LDemoArgs; nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType>::basic_json_t = nlohmann::basic_json<>]'
/ccs/home/s3j/.local/src/celeritas/app/demo-loop/demo-loop.cc:70:39:   required from here
/sw/crusher/spack-envs/base/opt/cray-sles15-zen3/gcc-11.2.0/nlohmann-json-3.10.2-fwiijvdxcf6lf7dfnojyswds4podhsem/include/nlohmann/json.hpp:20477:19: error: converting to 'celeritas::PDGNumber' from initializer list would use explicit constructor 'constexpr celeritas::PDGNumber::PDGNumber()'
20477 |         ValueType ret{};
      |                   ^~~
```