### PR TITLE
Improve static/shared CUDA library choice when linking VecGeom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,18 +211,6 @@ if(CELERITAS_USE_VecGeom)
   if(NOT VecGeom_GDML_FOUND)
     message(SEND_ERROR "VecGeom GDML capability is required for Celeritas")
   endif()
-  if(CELERITAS_USE_CUDA AND VecGeom_VERSION VERSION_GREATER_EQUAL 1.2
-      AND BUILD_SHARED_LIBS
-      AND NOT CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "Shared")
-    message(SEND_ERROR "VecGeom 1.2+ is incompatible with a Celeritas shared "
-      "library build (BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}) unless; "
-      "CMAKE_CUDA_RUNTIME_LIBRARY is set to Shared as well. Forcing the "
-      "CUDA runtime libraries to change for the next configure."
-    )
-    set(CMAKE_CUDA_RUNTIME_LIBRARY "Shared" CACHE STRING
-      "Forcibly enabled due to VecGeom CUDA requirements" FORCE
-    )
-  endif()
 endif()
 
 if(CELERITAS_BUILD_TESTS AND NOT GTest_FOUND)

--- a/cmake/CeleritasLibrary.cmake
+++ b/cmake/CeleritasLibrary.cmake
@@ -562,6 +562,12 @@ function(celeritas_target_link_libraries target)
           CUDA_RESOLVE_DEVICE_SYMBOLS OFF
         )
         get_target_property(_final_target_type ${target} TYPE)
+
+        get_target_property(_final_runtime ${_finallibs} CUDA_RUNTIME_LIBRARY)
+        if ("${_final_runtime}" STREQUAL "Shared")
+          set_target_properties(${target} PROPERTIES CUDA_RUNTIME_LIBRARY "Shared")
+        endif()
+
         if(${_final_target_type} STREQUAL "STATIC_LIBRARY")
           # for static libraries we need to list the libraries a second time (to resolve symbol from the final library)
           get_target_property(_current_link_libraries ${target} LINK_LIBRARIES)

--- a/cmake/CeleritasLibrary.cmake
+++ b/cmake/CeleritasLibrary.cmake
@@ -595,6 +595,10 @@ function(celeritas_target_link_libraries target)
           # but we get
           #   You have used file(GET_RUNTIME_DEPENDENCIES) in project mode.  This is
           #     probably not what you intended to do.
+          # On the other hand, if the library is using (relocatable) CUDA code and
+          # the shared run-time library and we don't have the scafolding libraries
+          # (shared/static/final) then this won't work well. i.e. if we were to detect this
+          # case we probably need to 'error out'.
           #get_property(_lib_loc TARGET ${_lib} PROPERTY LOCATION)
           #if(NOT _lib_loc)
           #  message(WARNING "Setting to None for ${_lib}")

--- a/cmake/CeleritasLibrary.cmake
+++ b/cmake/CeleritasLibrary.cmake
@@ -519,17 +519,12 @@ function(celeritas_check_cuda_runtime OUTVAR library)
     # the shared run-time library and we don't have the scafolding libraries
     # (shared/static/final) then this won't work well. i.e. if we were to detect this
     # case we probably need to 'error out'.
-    #get_property(_lib_loc TARGET ${_lib} PROPERTY LOCATION)
-    #if(NOT _lib_loc)
-    #  message(WARNING "Setting to None for ${_lib}")
-    #  set_target_properties(${_lib} PROPERTIES CUDA_RUNTIME_LIBRARY "None")
-    #endi()/else()
     get_target_property(_cuda_library_type ${library} CELERITAS_CUDA_LIBRARY_TYPE)
     get_target_property(_cuda_find_library ${library} CELERITAS_CUDA_FINAL_LIBRARY)
     if ("${_cuda_library_type}" STREQUAL "Shared")
       set_target_properties(${library} PROPERTIES CUDA_RUNTIME_LIBRARY "Shared")
       set(_runtime "Shared")
-    elseif(NOT _cuda_find_library) # ${_cuda_find_library}" STREQUAL "_cuda_find_library-NOTFOUND")
+    elseif(NOT _cuda_find_library)
       set_target_properties(${library} PROPERTIES CUDA_RUNTIME_LIBRARY "None")
       set(_runtime "None")
     else()
@@ -692,8 +687,6 @@ function(celeritas_target_link_libraries target)
           endif()
         endif()
       endif()
-      #message(STATUS "We  should have failed for ${target} ${_target_type}")
-
     endif()
   endif()
 


### PR DESCRIPTION
* Revert Force disabling of shared libs for newer vecgeom 
* Replace explicit link against CUDA::cudart with adding the proper path to the include directory.
* Inherit the CUDA_RUNTIME_LIBRARY setting from the library being used.