### PR TITLE
Infrastructure changes for geo heuristic test

### DIFF
--- a/app/demo-rasterizer/RDemoRunner.cc
+++ b/app/demo-rasterizer/RDemoRunner.cc
@@ -40,7 +40,7 @@ void RDemoRunner::operator()(ImageStore* image, int ntimes) const
     CELER_EXPECT(image);
 
     CollectionStateStore<GeoStateData, MemSpace::device> geo_state(
-        *geo_params_, image->dims()[0]);
+        geo_params_->host_ref(), image->dims()[0]);
 
     CELER_LOG(status) << "Tracing geometry";
     // do it ntimes+1 as first one tends to be a warm-up run (slightly longer)

--- a/app/geo-check/GCheckKernel.cc
+++ b/app/geo-check/GCheckKernel.cc
@@ -25,7 +25,7 @@ GCheckOutput run_cpu(const SPConstGeo&          params,
 {
     using StateStore = CollectionStateStore<GeoStateData, MemSpace::host>;
 
-    StateStore state = StateStore(*params, 1);
+    StateStore state = StateStore(params->host_ref(), 1);
 
     GeoTrackView geo(params->host_ref(), state.ref(), ThreadId(0));
     geo = GeoTrackInitializer{init->pos, init->dir};

--- a/app/geo-check/GCheckRunner.cc
+++ b/app/geo-check/GCheckRunner.cc
@@ -57,7 +57,7 @@ void GCheckRunner::operator()(const GeoTrackInitializer* gti) const
     input.max_steps = this->max_steps_;
     input.params    = this->geo_params_->device_ref();
 
-    StateStore states(*this->geo_params_, 1);
+    StateStore states(this->geo_params_->host_ref(), 1);
     input.state = states.ref();
 
     CELER_LOG(status) << "Propagating track(s) on GPU";

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -65,7 +65,7 @@ Stepper<M>::Stepper(Input input)
                    << "number of track slots has not been set");
     CELER_VALIDATE(input.num_initializers > 0,
                    << "number of initializers has not been set");
-    states_ = CollectionStateStore<CoreStateData, M>(*params_,
+    states_ = CollectionStateStore<CoreStateData, M>(params_->host_ref(),
                                                      input.num_track_slots);
 
     // Construct main actions

--- a/src/corecel/data/CollectionStateStore.hh
+++ b/src/corecel/data/CollectionStateStore.hh
@@ -46,7 +46,7 @@ class CollectionStateStore
 {
   public:
     //!@{
-    //! Type aliases
+    //! \name Type aliases
     using Value     = S<Ownership::value, M>;
     using Ref       = S<Ownership::reference, M>;
     using size_type = ThreadId::size_type;
@@ -56,8 +56,8 @@ class CollectionStateStore
     CollectionStateStore() = default;
 
     // Construct from parameters
-    template<class Params>
-    inline CollectionStateStore(const Params& p, size_type size);
+    template<template<Ownership, MemSpace> class P>
+    inline CollectionStateStore(const HostCRef<P>& p, size_type size);
 
     // Construct without parameters
     explicit inline CollectionStateStore(size_type size);
@@ -100,15 +100,15 @@ class CollectionStateStore
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct from parameters.
+ * Construct from parameter data.
  */
 template<template<Ownership, MemSpace> class S, MemSpace M>
-template<class Params>
-CollectionStateStore<S, M>::CollectionStateStore(const Params& p,
-                                                 size_type     size)
+template<template<Ownership, MemSpace> class P>
+CollectionStateStore<S, M>::CollectionStateStore(const HostCRef<P>& p,
+                                                 size_type          size)
 {
     CELER_EXPECT(size > 0);
-    resize(&val_, p.host_ref(), size);
+    resize(&val_, p, size);
 
     // Save reference
     ref_ = val_;

--- a/src/corecel/data/detail/CollectionImpl.hh
+++ b/src/corecel/data/detail/CollectionImpl.hh
@@ -75,6 +75,8 @@ struct CollectionStorage<T, Ownership::value, MemSpace::device>;
 template<class T>
 struct CollectionStorage<T, Ownership::value, MemSpace::host>
 {
+    static_assert(!std::is_same<T, bool>::value,
+                  "bool is not compatible between vector and anything else");
     using type = std::vector<T>;
     type data;
 };

--- a/src/corecel/data/detail/Filler.device.t.hh
+++ b/src/corecel/data/detail/Filler.device.t.hh
@@ -3,18 +3,34 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/data/detail/Filler.cu
+//! \file corecel/data/detail/Filler.device.t.hh
 //---------------------------------------------------------------------------//
-#include "Filler.device.t.hh"
+#pragma once
+
+#include <thrust/device_malloc.h>
+#include <thrust/device_ptr.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+
+#include "corecel/device_runtime_api.h"
+
+#include "Filler.hh"
 
 namespace celeritas
 {
 namespace detail
 {
 //---------------------------------------------------------------------------//
-template class Filler<real_type, MemSpace::device>;
-template class Filler<size_type, MemSpace::device>;
-template class Filler<int, MemSpace::device>;
+template<class T>
+void Filler<T, MemSpace::device>::operator()(Span<T> data) const
+{
+    thrust::fill_n(thrust::device,
+                   thrust::device_pointer_cast<T>(data.data()),
+                   data.size(),
+                   value);
+    CELER_DEVICE_CHECK_ERROR();
+}
+
 //---------------------------------------------------------------------------//
 } // namespace detail
 } // namespace celeritas

--- a/src/corecel/data/detail/Filler.hh
+++ b/src/corecel/data/detail/Filler.hh
@@ -50,6 +50,10 @@ void Filler<T, MemSpace::device>::operator()(Span<T>) const
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }
+#else
+extern template class Filler<real_type, MemSpace::device>;
+extern template class Filler<size_type, MemSpace::device>;
+extern template class Filler<int, MemSpace::device>;
 #endif
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/ScopedStreamFormat.hh
+++ b/src/corecel/io/ScopedStreamFormat.hh
@@ -1,0 +1,63 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/io/ScopedStreamFormat.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <ios>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Save a stream's state and restore on destruction.
+ *
+ * Example:
+ * \code
+     {
+         ScopedStreamFormat save_fmt(&std::cout);
+         std::cout << setprecision(16) << 1.0;
+     }
+ * \endcode
+ */
+class ScopedStreamFormat
+{
+  public:
+    // Construct with stream to safe
+    explicit inline ScopedStreamFormat(std::ios* s);
+
+    // Restore formats on destruction
+    inline ~ScopedStreamFormat();
+
+  private:
+    std::ios* stream_;
+    std::ios  orig_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with defaults.
+ */
+ScopedStreamFormat::ScopedStreamFormat(std::ios* s)
+    : stream_{s}, orig_{nullptr}
+{
+    CELER_EXPECT(s);
+    orig_.copyfmt(*s);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Restore formats on destruction.
+ */
+ScopedStreamFormat::~ScopedStreamFormat()
+{
+    stream_->copyfmt(orig_);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/corecel/io/detail/ReprImpl.hh
+++ b/src/corecel/io/detail/ReprImpl.hh
@@ -12,6 +12,7 @@
 #include <type_traits>
 
 #include "corecel/Assert.hh"
+#include "corecel/io/ScopedStreamFormat.hh"
 
 namespace celeritas
 {
@@ -31,34 +32,6 @@ struct Repr
 {
     const T&    obj;
     const char* name = nullptr;
-};
-
-//---------------------------------------------------------------------------//
-/*!
- * Save a stream's state and restore on destruction.
- *
- * Example:
- * \code
-     {
-         ScopedStreamFormat save_fmt(&std::cout);
-         std::cout << setprecision(16) << 1.0;
-     }
- * \endcode
- */
-class ScopedStreamFormat
-{
-  public:
-    explicit ScopedStreamFormat(std::ios* s) : stream_{s}, orig_{nullptr}
-    {
-        CELER_EXPECT(s);
-        orig_.copyfmt(*s);
-    }
-
-    ~ScopedStreamFormat() { stream_->copyfmt(orig_); }
-
-  private:
-    std::ios* stream_;
-    std::ios  orig_;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/em/Fluctuation.test.cc
+++ b/test/celeritas/em/Fluctuation.test.cc
@@ -95,8 +95,8 @@ class EnergyLossDistributionTest : public celeritas_test::Test
         cutoffs = std::make_shared<CutoffParams>(std::move(cut_inp));
 
         // Construct states for a single host thread
-        particle_state = ParticleStateStore(*particles, 1);
-        material_state = MaterialStateStore(*materials, 1);
+        particle_state = ParticleStateStore(particles->host_ref(), 1);
+        material_state = MaterialStateStore(materials->host_ref(), 1);
 
         // Construct energy loss fluctuation model parameters
         fluct = std::make_shared<FluctuationParams>(*particles, *materials);

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -84,10 +84,12 @@ class UrbanMscTest : public celeritas_test::GlobalGeoTestBase
         // Make one state per particle
         auto state_size = this->particle()->size();
 
-        params_ref_     = this->physics()->host_ref();
-        physics_state_  = PhysicsStateStore(*this->physics(), state_size);
-        particle_state_ = ParticleStateStore(*this->particle(), state_size);
-        geo_state_      = GeoStateStore(*this->geometry(), 1);
+        params_ref_ = this->physics()->host_ref();
+        physics_state_
+            = PhysicsStateStore(this->physics()->host_ref(), state_size);
+        particle_state_
+            = ParticleStateStore(this->particle()->host_ref(), state_size);
+        geo_state_ = GeoStateStore(this->geometry()->host_ref(), 1);
     }
 
     SPConstParticle build_particle() override

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -62,7 +62,7 @@ class VecgeomTestBase : virtual public celeritas_test::GlobalTestBase
     //! Construct host state (and load geometry) during steup
     void SetUp() override
     {
-        host_state = HostStateStore(*this->geometry(), 1);
+        host_state = HostStateStore(this->geometry()->host_ref(), 1);
     }
 
     //! Create a host track view
@@ -395,7 +395,7 @@ TEST_F(FourLevelsTest, TEST_IF_CELERITAS_CUDA(device))
                   {{-10, 10, -10}, {-1, 0, 0}},
                   {{-10, -10, 10}, {-1, 0, 0}},
                   {{-10, -10, -10}, {-1, 0, 0}}};
-    StateStore device_states(*this->geometry(), input.init.size());
+    StateStore device_states(this->geometry()->host_ref(), input.init.size());
     input.max_segments = 5;
     input.params       = this->geometry()->device_ref();
     input.state        = device_states.ref();

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -75,8 +75,8 @@ class FieldPropagatorTestBase : public GlobalGeoTestBase
 
     void SetUp() override
     {
-        geo_state_ = GeoStateStore(*this->geometry(), 1);
-        par_state_ = ParStateStore(*this->particle(), 1);
+        geo_state_ = GeoStateStore(this->geometry()->host_ref(), 1);
+        par_state_ = ParStateStore(this->particle()->host_ref(), 1);
     }
 
     ParticleTrackView init_particle(ParticleId id, MevEnergy energy)

--- a/test/celeritas/field/LinearPropagator.test.cc
+++ b/test/celeritas/field/LinearPropagator.test.cc
@@ -30,7 +30,10 @@ class LinearPropagatorTest : public celeritas_test::GlobalGeoTestBase
 
     const char* geometry_basename() const override { return "simple-cms"; }
 
-    void SetUp() override { state = StateStore(*this->geometry(), 1); }
+    void SetUp() override
+    {
+        state = StateStore(this->geometry()->host_ref(), 1);
+    }
 
     GeoTrackView make_geo_track_view()
     {

--- a/test/celeritas/geo/GeoMaterial.test.cc
+++ b/test/celeritas/geo/GeoMaterial.test.cc
@@ -79,7 +79,8 @@ TEST_F(GeoMaterialTest, host)
     // Geometry track view and mat view
     const auto& geo_params = *this->geometry();
     const auto& mat_params = *this->material();
-    CollectionStateStore<GeoStateData, MemSpace::host> geo_state(geo_params, 1);
+    CollectionStateStore<GeoStateData, MemSpace::host> geo_state(
+        geo_params.host_ref(), 1);
     GeoTrackView    geo(geo_params.host_ref(), geo_state.ref(), ThreadId{0});
     GeoMaterialView geo_mat_view(this->geomaterial()->host_ref());
 

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -32,8 +32,8 @@ auto AlongStepTestBase::run(const Input& inp, size_type num_tracks) -> RunResult
     CELER_EXPECT(num_tracks > 0);
 
     // Create states
-    CollectionStateStore<CoreStateData, MemSpace::host> states{*this->core(),
-                                                               num_tracks};
+    CollectionStateStore<CoreStateData, MemSpace::host> states{
+        this->core()->host_ref(), num_tracks};
     CoreRef<MemSpace::host>                             core_ref;
     core_ref.params = this->core()->host_ref();
     core_ref.states = states.ref();

--- a/test/celeritas/mat/Material.test.cc
+++ b/test/celeritas/mat/Material.test.cc
@@ -343,7 +343,7 @@ TEST_F(MaterialDeviceTest, TEST_IF_CELER_DEVICE(all))
         = {{MaterialId{0}}, {MaterialId{1}}, {MaterialId{2}}, {MaterialId{3}}};
 
     CollectionStateStore<MaterialStateData, MemSpace::device> states(
-        *params, input.init.size());
+        params->host_ref(), input.init.size());
 
     input.params = params->device_ref();
     input.states = states.ref();

--- a/test/celeritas/phys/InteractorHostTestBase.cc
+++ b/test/celeritas/phys/InteractorHostTestBase.cc
@@ -114,7 +114,8 @@ void InteractorHostTestBase::set_material_params(MaterialParams::Input inp)
     CELER_EXPECT(!inp.materials.empty());
 
     material_params_ = std::make_shared<MaterialParams>(std::move(inp));
-    ms_ = StateStore<celeritas::MaterialStateData>(*material_params_, 1);
+    ms_              = StateStore<celeritas::MaterialStateData>(
+        material_params_->host_ref(), 1);
     cutoff_params_ = {};
 }
 
@@ -144,7 +145,8 @@ void InteractorHostTestBase::set_particle_params(ParticleParams::Input inp)
 {
     CELER_EXPECT(!inp.empty());
     particle_params_ = std::make_shared<ParticleParams>(std::move(inp));
-    ps_ = StateStore<celeritas::ParticleStateData>(*particle_params_, 1);
+    ps_              = StateStore<celeritas::ParticleStateData>(
+        particle_params_->host_ref(), 1);
     cutoff_params_ = {};
 }
 
@@ -266,7 +268,7 @@ void InteractorHostTestBase::check_momentum_conservation(
     const Interaction& interaction) const
 {
     CollectionStateStore<celeritas::ParticleStateData, celeritas::MemSpace::host>
-                      temp_store(*particle_params_, 1);
+                      temp_store(particle_params_->host_ref(), 1);
     ParticleTrackView temp_track(
         particle_params_->host_ref(), temp_store.ref(), ThreadId{0});
 

--- a/test/celeritas/phys/Particle.test.cc
+++ b/test/celeritas/phys/Particle.test.cc
@@ -222,7 +222,7 @@ TEST_F(ParticleDeviceTest, TEST_IF_CELER_DEVICE(calc_props))
                   {ParticleId{2}, MevEnergy{20}}};
 
     CollectionStateStore<ParticleStateData, MemSpace::device> pstates(
-        *particle_params, input.init.size());
+        particle_params->host_ref(), input.init.size());
     input.params = particle_params->device_ref();
     input.states = pstates.ref();
 

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -154,7 +154,7 @@ class PhysicsTrackViewHostTest : public PhysicsParamsTest
 
         CELER_ASSERT(this->physics());
         params_ref = this->physics()->host_ref();
-        state      = StateStore(*this->physics(), state_size);
+        state      = StateStore(params_ref, state_size);
 
         // Clear secondary data (done in pre-step kernel)
         {
@@ -672,7 +672,7 @@ TEST_F(PHYS_DEVICE_TEST, all)
         this->inits = temp_inits;
     }
 
-    states = StateStore(*this->physics(), this->inits.size());
+    states = StateStore(this->physics()->host_ref(), this->inits.size());
     celeritas::DeviceVector<real_type> step(this->states.size());
 
     PTestInput inp;
@@ -774,7 +774,7 @@ TEST_F(EPlusAnnihilationTest, accessors)
 TEST_F(EPlusAnnihilationTest, host_track_view)
 {
     CollectionStateStore<PhysicsStateData, MemSpace::host> state{
-        *this->physics(), 1};
+        this->physics()->host_ref(), 1};
     ::celeritas::HostCRef<PhysicsParamsData> params_ref{
         this->physics()->host_ref()};
 

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -47,9 +47,9 @@ class PhysicsStepUtilsTest : public MockTestBase
         Base::SetUp();
 
         // Construct state for a single host thread
-        mat_state  = MaterialStateStore(*this->material(), 1);
-        par_state  = ParticleStateStore(*this->particle(), 1);
-        phys_state = PhysicsStateStore(*this->physics(), 1);
+        mat_state  = MaterialStateStore(this->material()->host_ref(), 1);
+        par_state  = ParticleStateStore(this->particle()->host_ref(), 1);
+        phys_state = PhysicsStateStore(this->physics()->host_ref(), 1);
     }
 
     //!@{

--- a/test/celeritas/random/RngEngine.test.cc
+++ b/test/celeritas/random/RngEngine.test.cc
@@ -177,7 +177,7 @@ class DeviceRngEngineTest : public celeritas_test::Test
 TEST_F(DeviceRngEngineTest, TEST_IF_CELER_DEVICE(device))
 {
     // Create and initialize states
-    RngDeviceStore rng_store(*params, 1024);
+    RngDeviceStore rng_store(params->host_ref(), 1024);
 
     // Generate on device
     std::vector<unsigned int> values = re_test_native(rng_store.ref());
@@ -282,7 +282,7 @@ TYPED_TEST(DeviceRngEngineFloatTest, DISABLED_device)
     using real_type      = TypeParam;
 
     // Create and initialize states
-    RngDeviceStore rng_store(*this->params, 100);
+    RngDeviceStore rng_store(this->params->host_ref(), 100);
 
     // Generate on device
     auto values = re_test_canonical<real_type>(rng_store.ref());

--- a/test/celeritas/random/XorwowRngEngine.test.cc
+++ b/test/celeritas/random/XorwowRngEngine.test.cc
@@ -196,7 +196,7 @@ class XorwowRngEngineTest : public celeritas_test::Test
 TEST_F(XorwowRngEngineTest, host)
 {
     // Construct and initialize
-    HostStore states(*params, 8);
+    HostStore states(params->host_ref(), 8);
 
     Span<XorwowState> state_ref = states.ref().state[AllItems<XorwowState>{}];
 
@@ -230,7 +230,7 @@ TEST_F(XorwowRngEngineTest, moments)
     unsigned int num_samples = 1 << 12;
     unsigned int num_seeds   = 1 << 8;
 
-    HostStore states(*params, num_seeds);
+    HostStore states(params->host_ref(), num_seeds);
     RngTally  tally;
 
     for (unsigned int i = 0; i < num_seeds; ++i)
@@ -247,7 +247,7 @@ TEST_F(XorwowRngEngineTest, moments)
 TEST_F(XorwowRngEngineTest, TEST_IF_CELER_DEVICE(device))
 {
     // Create and initialize states
-    DeviceStore rng_store(*params, 1024);
+    DeviceStore rng_store(params->host_ref(), 1024);
     // Copy to host and check
     StateCollection<XorwowState, Ownership::value, MemSpace::host> host_state;
     host_state = rng_store.ref().state;

--- a/test/celeritas/random/XorwowRngEngine.test.cc
+++ b/test/celeritas/random/XorwowRngEngine.test.cc
@@ -75,7 +75,7 @@ struct HexRepr
 template<class T>
 std::ostream& operator<<(std::ostream& os, const HexRepr<T>& h)
 {
-    celeritas::detail::ScopedStreamFormat save_fmt(&os);
+    celeritas::ScopedStreamFormat save_fmt(&os);
 
     os << std::hexfloat << h.value;
     return os;

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -34,7 +34,7 @@ class OrangeTest : public OrangeGeoTestBase
     {
         if (!host_state_)
         {
-            host_state_ = HostStateStore(this->params(), 1);
+            host_state_ = HostStateStore(this->params().host_ref(), 1);
         }
 
         return OrangeTrackView(

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -171,7 +171,7 @@ auto OrangeGeoTestBase::host_state() -> const HostStateRef&
     CELER_EXPECT(params_);
     if (!host_state_)
     {
-        host_state_ = HostStateStore(this->params(), 1);
+        host_state_ = HostStateStore(this->params().host_ref(), 1);
     }
     return host_state_.ref();
 }


### PR DESCRIPTION
Pulled out of #494:
- Pass host data rather than a host-only high level "params" class into state store for easier testing
- Start using `celeritas::test` namespace for future tests
- Allow `Filler` class to be instantiated elsewhere
- Prevent vector-of-bools in collection since it can't be copied directly
- Move ScopedStreamFormat to its own file