### PR TITLE
Fix unusual errors in field propagation

### DIFF
--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -22,7 +22,7 @@ struct FieldDriverOptions
     //! The minimum length of the field step
     real_type minimum_step = 1.0e-5 * units::millimeter;
 
-    //! The closest miss distrance
+    //! The closest miss distance
     real_type delta_chord = 0.25 * units::millimeter;
 
     //! Accuracy of intersection of the boundary crossing
@@ -67,7 +67,7 @@ struct FieldDriverOptions
         // clang-format off
       return  (minimum_step > 0)
 	       && (delta_chord > 0)
-	       && (delta_intersection > 0)
+	       && (delta_intersection > minimum_step)
 	       && (epsilon_step > 0 && epsilon_step < 1)
 	       && (epsilon_rel_max > 0)
 	       && (errcon > 0)

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -185,10 +185,17 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         {
             // The straight-line intersection point is a distance less than
             // `delta_intersection` from the substep's end position.
-            // Commit the proposed state's momentum but use the
-            // post-boundary-crossing track position for consistency
+            // Commit the proposed state's momentum, use the
+            // post-boundary-crossing track position for consistency, and
+            // conservatively reduce the *reported* traveled distance to avoid
+            // coincident boundary crossings.
             result.boundary = true;
-            result.distance += substep.step;
+            real_type miss_distance = detail::calc_miss_distance(
+                state_.pos, chord.dir, linear_step.distance, substep.state.pos);
+            // The distance to boundary will be less than the chord distance,
+            // and the chord distance is less than
+            CELER_ASSERT(miss_distance < substep.step);
+            result.distance += substep.step - miss_distance;
             state_.mom = substep.state.mom;
             remaining  = 0;
         }

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -192,9 +192,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.boundary = true;
             real_type miss_distance = detail::calc_miss_distance(
                 state_.pos, chord.dir, linear_step.distance, substep.state.pos);
-            // The distance to boundary will be less than the chord distance,
-            // and the chord distance is less than
-            CELER_ASSERT(miss_distance < substep.step);
+            CELER_ASSERT(miss_distance >= 0 && miss_distance < substep.step);
             result.distance += substep.step - miss_distance;
             state_.mom = substep.state.mom;
             remaining  = 0;

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -9,6 +9,7 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "corecel/math/Algorithms.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "orange/Types.hh"
 #include "celeritas/geo/GeoTrackView.hh"
@@ -141,7 +142,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
 
         // Advance up to (but probably less than) the remaining step length
         DriverResult substep = driver_.advance(remaining, state_);
-        CELER_ASSERT(substep.step <= remaining);
+        CELER_ASSERT(substep.step <= remaining
+                     || soft_equal(substep.step, remaining));
 
         // TODO: use safety distance to reduce number of calls to
         // find_next_step
@@ -160,7 +162,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // distance so we can continue toward the next boundary or end of
             // caller-requested step.
             state_ = substep.state;
-            result.distance += substep.step;
+            result.distance += celeritas::min(substep.step, remaining);
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
         }

--- a/src/celeritas/field/detail/FieldUtils.hh
+++ b/src/celeritas/field/detail/FieldUtils.hh
@@ -17,10 +17,6 @@
 #include "celeritas/Types.hh"
 
 #include "../Types.hh"
-using std::cout;
-using std::endl;
-#include "corecel/cont/ArrayIO.hh"
-#include "corecel/io/Repr.hh"
 
 namespace celeritas
 {

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -621,7 +621,7 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
         auto result = propagate(first_step);
 
         EXPECT_TRUE(result.boundary);
-        EXPECT_SOFT_EQ(result.distance, first_step);
+        EXPECT_SOFT_NEAR(result.distance, first_step, 1e-10);
         // Y position suffers from roundoff
         EXPECT_VEC_SOFT_EQ((Real3{-5.0, -9.26396730438483e-07, 0}), geo.pos());
     }
@@ -638,7 +638,8 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
         auto result = propagate(first_step);
 
         EXPECT_TRUE(result.boundary);
-        EXPECT_SOFT_EQ(result.distance, first_step);
+        EXPECT_LT(result.distance, first_step);
+        EXPECT_SOFT_EQ(0.44613335936932041, result.distance);
         EXPECT_VEC_SOFT_EQ((Real3{-5, -0.0438785349441534, 0}), geo.pos());
     }
 }

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -574,6 +574,75 @@ TEST_F(TwoBoxTest, electron_corner_hit)
     }
 }
 
+// Endpoint of a step is very close to the boundary.
+TEST_F(TwoBoxTest, electron_step_endpoint)
+{
+    auto particle = this->init_particle(
+        this->particle()->find(pdg::electron()), MevEnergy{10});
+    UniformZField      field(unit_radius_field_strength);
+    FieldDriverOptions driver_options;
+    driver_options.delta_intersection = 0.1;
+
+    // First step length and position from starting at {0,0,0} along {0,1,0}
+    static constexpr real_type first_step = 0.44815869703174;
+    static constexpr Real3     first_pos
+        = {-0.098753281951459, 0.43330671122068, 0};
+
+    {
+        SCOPED_TRACE("First step ends barely closer than boundary");
+        // Note: this ends up being the !linear_step.boundary case
+
+        real_type dx = 0.1 * driver_options.delta_intersection;
+        Real3     start_pos{-5 + dx, 0, 0};
+        axpy(real_type(-1), first_pos, &start_pos);
+
+        auto geo       = this->init_geo(start_pos, {0, 1, 0});
+        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
+            field, driver_options, particle, &geo);
+        auto result = propagate(first_step);
+
+        EXPECT_FALSE(result.boundary);
+        EXPECT_SOFT_EQ(result.distance, first_step);
+        EXPECT_VEC_SOFT_EQ((Real3{-4.99000022992164, 8.24444331692931e-08, 0}),
+                           geo.pos());
+    }
+    {
+        SCOPED_TRACE("First step ends on boundary");
+        // Note: hard to tell without debug code, but this does end up with a
+        // single substep
+
+        real_type dx = 0;
+        Real3     start_pos{-5 - dx, 0, 0};
+        axpy(real_type(-1), first_pos, &start_pos);
+
+        auto geo       = this->init_geo(start_pos, {0, 1, 0});
+        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
+            field, driver_options, particle, &geo);
+        auto result = propagate(first_step);
+
+        EXPECT_TRUE(result.boundary);
+        EXPECT_SOFT_EQ(result.distance, first_step);
+        // Y position suffers from roundoff
+        EXPECT_VEC_SOFT_EQ((Real3{-5.0, -9.26396730438483e-07, 0}), geo.pos());
+    }
+    {
+        SCOPED_TRACE("First step is a slightly further than boundary");
+
+        real_type dx = 0.1 * driver_options.delta_intersection;
+        Real3     start_pos{-5 - dx, 0, 0};
+        axpy(real_type(-1), first_pos, &start_pos);
+
+        auto geo       = this->init_geo(start_pos, {0, 1, 0});
+        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
+            field, driver_options, particle, &geo);
+        auto result = propagate(first_step);
+
+        EXPECT_TRUE(result.boundary);
+        EXPECT_SOFT_EQ(result.distance, first_step);
+        EXPECT_VEC_SOFT_EQ((Real3{-5, -0.0438785349441534, 0}), geo.pos());
+    }
+}
+
 // Heuristic test: plotting points with finer propagation distance show a track
 // with decreasing radius
 TEST_F(TwoBoxTest, nonuniform_field)


### PR DESCRIPTION
## Avoid coincident boundary and field step

With magnetic field enabled, occasionally an assertion in the along-step implementation would fail with an assertion that the physics step is greater than the boundary step. This ended up being because of the "substep end point is close enough to the boundary" condition in the field propagator: we counted the whole distance as being moved even though the substep end point may have been just a bit beyond the boundary point. My proposed solution reduces the "distance  traveled" based on the mismatch of the intercept and end-substep boundary points. The new field propagator unit tests show this in action.

![propagator](https://user-images.githubusercontent.com/741229/186129877-0f8eeec1-19df-4292-ade1-d011599051db.png)
 
In the above diagram, the endpoint _B_ is accepted because it's within the delta-intersection of the boundary crossing point. The geometry position at the end of the propagation is set to _C_, but the momentum of the end-step position _B_ is still used. The total "propagation distance" is now decreased (to effectively point _D_), so that we don't end up accidentally with the same physics and geometry step lengths.

<details><summary>LLDB backtrace</summary>
<pre>
frame #2: 0x00007ffff625b642 libceleritas.so`void celeritas::along_step<celeritas::detail::UrbanMsc, celeritas::detail::along_step_uniform_msc(celeritas::UrbanMscData<(celeritas::Ownership)2, (celeritas::MemSpace)0> const&, celeritas::UniformFieldParams const&, celeritas::NoData, celeritas::CoreTrackView const&)::'lambda'(celeritas::ParticleTrackView const&, celeritas::VecgeomTrackView*), celeritas::detail::EnergyLossApplier>(msc=0x00007ffffffef208, make_propagator=0x00007ffffffef200, apply_eloss=0x00007ffffffef1ff, track=0x00007ffffffef260)2, (celeritas::MemSpace)0> const&, celeritas::UniformFieldParams const&, celeritas::NoData, celeritas::CoreTrackView const&)::'lambda'(celeritas::ParticleTrackView const&, celeritas::VecgeomTrackView*)&&, celeritas::detail::EnergyLossApplier&&, celeritas::CoreTrackView const&) at AlongStep.hh:83:13
   80  	        {
   81  	            // Stopped at a geometry boundary: this is the new step action.
   82  	            CELER_ASSERT(p.distance <= local.geo_step);
-> 83  	            CELER_ASSERT(p.distance < local.step_limit.step);
   84  	            local.geo_step          = p.distance;
   85  	            local.step_limit.action = track.boundary_action();
   86  	        }
</pre></details>

## Driver soft equal

The driver step can be very slightly more than remaining due to floating point accumulation.

<details><summary>LLDB backtrace</summary>
frame #2: 0x00007ffff625c627 libceleritas.so`celeritas::FieldPropagator<celeritas::FieldDriver<celeritas::DormandPrinceStepper<celeritas::MagFieldEquation<celeritas::UniformField> > > >::operator(this=0x00007ffffffeedf0, step=0.21835597575582824)(double) at FieldPropagator.hh:144:9
   141
   142 	        // Advance up to (but probably less than) the remaining step length
   143 	        DriverResult substep = driver_.advance(remaining, state_);
-> 144 	        CELER_ASSERT(substep.step <= remaining);
   145
   146 	        // TODO: use safety distance to reduce number of calls to
   147 	        // find_next_step
(lldb) print substep
(celeritas::DriverResult) $0 = {
  state = {
    pos = {
      data_ = ([0] = 7.3460321920331423, [1] = 2.974603058389766, [2] = -0.20596576298384228)
    }
    mom = {
      data_ = ([0] = 1.2796285441916315, [1] = 0.23358718821967159, [2] = 0.33215589367561205)
    }
  }
  step = 0.21835597575582827
}
(lldb) print remaining
(celeritas::real_type) $1 = 0.21835597575582824
```
</pre></details>