### PR TITLE
Fix unintentional MSC enable and some displacement logic

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -231,6 +231,29 @@ TransporterInput load_input(const LDemoArgs& args)
                        << "' (expected gdml or root)");
     }
 
+    // TODO: delete when #485 is merged
+    auto is_msc = [](const ImportProcess& p) {
+        return p.process_class == ImportProcessClass::msc;
+    };
+    if (!args.enable_msc)
+    {
+        // Delete MSC data
+        auto iter = std::remove_if(imported_data.processes.begin(),
+                                   imported_data.processes.end(),
+                                   is_msc);
+        imported_data.processes.erase(iter, imported_data.processes.end());
+    }
+    else
+    {
+        // Make sure MSC data is there
+        CELER_VALIDATE(std::find_if(imported_data.processes.begin(),
+                                    imported_data.processes.end(),
+                                    is_msc)
+                           != imported_data.processes.end(),
+                       << "multiple scattering data is not available but "
+                          "input requested 'enable_msc=true'");
+    }
+
     // Create action manager
     {
         ActionManager::Options opts;
@@ -303,8 +326,8 @@ TransporterInput load_input(const LDemoArgs& args)
     // Load physics: create individual processes with make_shared
     {
         PhysicsParams::Input input;
-        input.particles = params.particle;
-        input.materials = params.material;
+        input.particles                      = params.particle;
+        input.materials                      = params.material;
         input.options.fixed_step_limiter     = args.step_limiter;
         input.options.secondary_stack_factor = args.secondary_stack_factor;
         input.action_manager                 = params.action_mgr.get();
@@ -331,12 +354,15 @@ TransporterInput load_input(const LDemoArgs& args)
     if (args.mag_field == LDemoArgs::no_field())
     {
         // Create along-step action
-        params.along_step = AlongStepGeneralLinearAction::from_params(
+        auto along_step = AlongStepGeneralLinearAction::from_params(
             *params.material,
             *params.particle,
             *params.physics,
             args.eloss_fluctuation,
             params.action_mgr.get());
+        CELER_ASSERT(args.enable_msc == along_step->has_msc());
+        CELER_ASSERT(args.eloss_fluctuation == along_step->has_fluct());
+        params.along_step = std::move(along_step);
     }
     else
     {
@@ -347,8 +373,11 @@ TransporterInput load_input(const LDemoArgs& args)
         field_params.field   = args.mag_field;
         field_params.options = args.field_options;
 
-        params.along_step = AlongStepUniformMscAction::from_params(
+        auto along_step = AlongStepUniformMscAction::from_params(
             *params.physics, field_params, params.action_mgr.get());
+        CELER_ASSERT(args.enable_msc == along_step->has_msc());
+        CELER_ASSERT(args.mag_field == along_step->field());
+        params.along_step = std::move(along_step);
     }
 
     // Construct RNG params

--- a/src/celeritas/em/distribution/UrbanMscScatter.hh
+++ b/src/celeritas/em/distribution/UrbanMscScatter.hh
@@ -567,9 +567,19 @@ UrbanMscScatter::calc_displacement_length(real_type rmax2)
 {
     CELER_EXPECT(rmax2 >= 0);
 
-    real_type rho = real_type(0.73) * std::sqrt(rmax2);
-    // Do not sample near the boundary
-    if (rho > params_.geom_limit)
+    // 0.73 is (roughly) the expected value of a distribution of the mean
+    // radius given rmax "based on single scattering results"
+    // https://github.com/Geant4/geant4/blame/28a70706e0edf519b16e864ebf1d2f02a00ba596/source/processes/electromagnetic/standard/src/G4UrbanMscModel.cc#L1142
+    constexpr real_type mean_radius_frac{0.73};
+
+    real_type rho = mean_radius_frac * std::sqrt(rmax2);
+
+    if (rho <= params_.geom_limit)
+    {
+        // Displacement is too small to bother with
+        rho = 0;
+    }
+    else
     {
         real_type safety = (1 - params_.safety_tol) * geometry_.find_safety();
         if (rho <= safety)

--- a/src/celeritas/em/distribution/UrbanMscScatter.hh
+++ b/src/celeritas/em/distribution/UrbanMscScatter.hh
@@ -582,18 +582,15 @@ UrbanMscScatter::calc_displacement_length(real_type rmax2)
     else
     {
         real_type safety = (1 - params_.safety_tol) * geometry_.find_safety();
-        if (rho <= safety)
+        if (safety <= params_.geom_limit)
         {
-            // No scaling needed
-        }
-        else if (safety > params_.geom_limit)
-        {
-            rho *= safety / rho;
+            // We're near a volume boundary so do not displace at all
+            rho = 0;
         }
         else
         {
-            // Otherwise (near a volume boundary), do not change position
-            rho = 0;
+            // Do not displace further than safety
+            rho = min(rho, safety);
         }
     }
 

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.hh
@@ -75,12 +75,11 @@ class AlongStepUniformMscAction final : public ExplicitActionInterface
     bool has_msc() const { return static_cast<bool>(msc_); }
 
     //! Field strength
-    const Real3& field() const { return field_; }
+    const Real3& field() const { return field_params_.field; }
 
   private:
     ActionId           id_;
     SPConstMsc         msc_;
-    Real3              field_;
     UniformFieldParams field_params_;
 
     // TODO: kind of hacky way to support msc being optional


### PR DESCRIPTION
In #483 I started importing *all* the data from geant, including MSC data if it's on the file. When exporting ROOT data or just loading Celeritas data, it *is* always on the file: so MSC has accidentally been "always on" since that was merged.

The second error is fixing missing logic (and improving readability of similar logic)  in the MSC scatterer. When the geometry step was very small we did not set a "do not displace" flag. This allowed MSC to move the particle while it is on the boundary, leading to failures in the `is_on_boundary()` assertions incoming in #494.