### PR TITLE
Allow tracks taking small steps to propagate in field

### DIFF
--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -139,8 +139,6 @@ template<class StepperT>
 CELER_FUNCTION DriverResult
 FieldDriver<StepperT>::advance(real_type step, const OdeState& state) const
 {
-    CELER_EXPECT(step >= this->minimum_step());
-
     // Output with a step control error
     ChordSearch output = this->find_next_chord(step, state);
 

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -176,7 +176,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // would be less than the driver's minimum step. Hop to the
             // boundary without committing the substep.
             result.boundary = true;
-            result.distance += linear_step.distance;
+            result.distance += min(linear_step.distance, remaining);
             remaining = 0;
         }
         else if (detail::is_intercept_close(state_.pos,

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -136,7 +136,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     // geometry boundary in each substep. This loop is guaranteed to converge
     // since the trial step always decreases *or* the actual position advances.
     real_type remaining = step;
-    while (remaining >= driver_.minimum_step())
+    do
     {
         CELER_ASSERT(soft_zero(distance(state_.pos, geo_.pos())));
 
@@ -206,7 +206,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // fraction along the chord, and retry the driver step.
             remaining = substep.step * linear_step.distance / chord.length;
         }
-    }
+    } while (remaining >= driver_.minimum_step());
 
     if (result.boundary)
     {


### PR DESCRIPTION
Previously, the `FieldPropagator` would not propagate tracks if the step length was smaller than the driver’s minimum step. This led to problems when a track starting on a boundary tried to take a very small step, but the geo state didn't actually change. Based on discussion with @sethrj, this changes the while loop in the `FieldPropagator` to a do...while loop to allow tracks taking small steps to advance.