### PR TITLE
Fix failure when changing direction on boundary immediately after crossing

### DIFF
--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -86,8 +86,11 @@ class VecgeomTrackView
     CELER_FORCEINLINE_FUNCTION VolumeId volume_id() const;
     CELER_FORCEINLINE_FUNCTION int      volume_physid() const;
 
+    //!@{
     //! VecGeom states are never "on" a surface
     CELER_FUNCTION SurfaceId surface_id() const { return {}; }
+    CELER_FUNCTION SurfaceId next_surface_id() const { return {}; }
+    //!@}
 
     // Whether the track is outside the valid geometry region
     CELER_FORCEINLINE_FUNCTION bool is_outside() const;

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -183,9 +183,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         fout << substep.state.pos[0] << ',' << substep.state.pos[1] << ','
              << substep.state.pos[2] << ',' << substep.step << ",proposed\n";
 
-        // TODO: use safety distance to reduce number of calls to
-        // find_next_step
-
         // Check whether the chord for this sub-step intersects a boundary
         auto chord = detail::make_chord(state_.pos, substep.state.pos);
 
@@ -222,6 +219,16 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             geo_.move_internal(state_.pos);
             cout << " + advancing to substep end point" << endl;
             fout << "no_hit";
+        }
+        else if (CELER_UNLIKELY(linear_step.distance < driver_.minimum_step()
+                                && geo_.is_on_boundary()))
+        {
+            // Likely heading back into the old volume when starting on a
+            // surface (this can happen when tracking through a volume at a
+            // near tangent). Reduce substep size and try again.
+            remaining = substep.step / 2;
+            cout << " + halving substep distance" << endl;
+            fout << "reentrant";
         }
         else if (substep.step * linear_step.distance
                  <= driver_.minimum_step() * chord.length)

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -7,6 +7,9 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <fstream>
+#include <iomanip>
+
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/math/Algorithms.hh"
@@ -20,6 +23,24 @@
 
 namespace celeritas
 {
+namespace detail
+{
+std::ofstream make_fstream()
+{
+    std::ofstream fout("debug-field-propagator.csv");
+    fout << 'x' << ',' << 'y' << ',' << 'z' << ',' << "step" << ','
+         << "action\n";
+    return fout;
+}
+
+std::ostream& debug_fstream()
+{
+    static std::ofstream out = make_fstream();
+    out << std::setprecision(15);
+    return out;
+}
+} // namespace detail
+
 //---------------------------------------------------------------------------//
 /*!
  * Propagate a charged particle in a field.
@@ -131,6 +152,10 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     result_type result;
     result.distance = 0;
 
+    std::ostream& fout = detail::debug_fstream();
+    fout << geo_.pos()[0] << ',' << geo_.pos()[1] << ',' << geo_.pos()[2]
+         << ',' << step << ",start\n";
+
     // Break the curved steps into substeps as determined by the driver *and*
     // by the proximity of geometry boundaries. Test for intersection with the
     // geometry boundary in each substep. This loop is guaranteed to converge
@@ -145,6 +170,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         CELER_ASSERT(substep.step <= remaining
                      || soft_equal(substep.step, remaining));
 
+        fout << substep.state.pos[0] << ',' << substep.state.pos[1] << ','
+             << substep.state.pos[2] << ',' << substep.step << ",proposed\n";
+
         // Check whether the chord for this sub-step intersects a boundary
         auto chord = detail::make_chord(state_.pos, substep.state.pos);
 
@@ -154,6 +182,12 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         geo_.set_dir(chord.dir);
         auto linear_step
             = geo_.find_next_step(chord.length + driver_.delta_intersection());
+
+        Real3 temp = geo_.pos();
+        axpy(linear_step.distance, chord.dir, &temp);
+        fout << temp[0] << ',' << temp[1] << ',' << temp[2] << ','
+             << linear_step.distance << ',';
+
         if (!linear_step.boundary)
         {
             // No boundary intersection along the chord: accept substep
@@ -164,6 +198,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.distance += celeritas::min(substep.step, remaining);
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
+            fout << "no_hit";
         }
         else if (CELER_UNLIKELY(linear_step.distance < driver_.minimum_step()
                                 && geo_.is_on_boundary()))
@@ -172,6 +207,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // surface (this can happen when tracking through a volume at a
             // near tangent). Reduce substep size and try again.
             remaining = substep.step / 2;
+            fout << "reentrant";
         }
         else if (substep.step * linear_step.distance
                  <= driver_.minimum_step() * chord.length)
@@ -183,6 +219,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.boundary = true;
             result.distance += min(linear_step.distance, remaining);
             remaining = 0;
+            fout << "nearly_boundary";
         }
         else if (detail::is_intercept_close(state_.pos,
                                             chord.dir,
@@ -203,6 +240,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.distance += substep.step - miss_distance;
             state_.mom = substep.state.mom;
             remaining  = 0;
+            fout << "barely_boundary";
         }
         else
         {
@@ -210,7 +248,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // Decrease the allowed substep (curved path distance) by the
             // fraction along the chord, and retry the driver step.
             remaining = substep.step * linear_step.distance / chord.length;
+            fout << "too_far";
         }
+        fout << '\n';
     } while (remaining >= driver_.minimum_step());
 
     if (result.boundary)

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -7,8 +7,12 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <iostream>
+
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "corecel/cont/ArrayIO.hh"
+#include "corecel/io/ColorUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "orange/Types.hh"
@@ -17,6 +21,8 @@
 
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
+using std::cout;
+using std::endl;
 
 namespace celeritas
 {
@@ -131,6 +137,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     result_type result;
     result.distance = 0;
 
+    cout << color_code('b') << "Propagate up to " << step << color_code(' ')
+         << endl;
+
     // Break the curved steps into substeps as determined by the driver *and*
     // by the proximity of geometry boundaries. Test for intersection with the
     // geometry boundary in each substep. This loop is guaranteed to converge
@@ -145,6 +154,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         CELER_ASSERT(substep.step <= remaining
                      || soft_equal(substep.step, remaining));
 
+        cout << "- advance(" << remaining << ", " << state_.pos << ") -> {"
+             << substep.step << ", " << substep.state.pos << "}" << endl;
+
         // TODO: use safety distance to reduce number of calls to
         // find_next_step
 
@@ -157,6 +169,16 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         geo_.set_dir(chord.dir);
         auto linear_step
             = geo_.find_next_step(chord.length + driver_.delta_intersection());
+
+        cout << " + chord length " << chord.length << " => linear step "
+             << linear_step.distance;
+        if (linear_step.boundary)
+        {
+            cout << " (hit surface " << geo_.surface_id().unchecked_get()
+                 << ')';
+        }
+        cout << '\n';
+
         if (!linear_step.boundary)
         {
             // No boundary intersection along the chord: accept substep
@@ -167,6 +189,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.distance += celeritas::min(substep.step, remaining);
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
+            cout << " + advancing to substep end point" << endl;
         }
         else if (substep.step * linear_step.distance
                  <= driver_.minimum_step() * chord.length)
@@ -178,6 +201,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.boundary = true;
             result.distance += min(linear_step.distance, remaining);
             remaining = 0;
+            cout << " + next trial step exceeds driver minimum "
+                 << driver_.minimum_step() << endl;
         }
         else if (detail::is_intercept_close(state_.pos,
                                             chord.dir,
@@ -198,6 +223,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.distance += substep.step - miss_distance;
             state_.mom = substep.state.mom;
             remaining  = 0;
+
+            cout << " + intercept is sufficiently close (miss distance = "
+                 << miss_distance << ") to substep point" << endl;
         }
         else
         {
@@ -205,6 +233,10 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // Decrease the allowed substep (curved path distance) by the
             // fraction along the chord, and retry the driver step.
             remaining = substep.step * linear_step.distance / chord.length;
+
+            cout << " + Setting remaining distance to a fraction "
+                 << linear_step.distance / chord.length << " of the substep"
+                 << endl;
         }
     } while (remaining >= driver_.minimum_step());
 
@@ -212,6 +244,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     {
         geo_.move_to_boundary();
         state_.pos = geo_.pos();
+        cout << "- Moved to boundary " << geo_.surface_id().unchecked_get()
+            << " at position " << state_.pos << endl;
     }
     else if (remaining > 0)
     {
@@ -219,6 +253,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // value for "step". Return that we've moved this tiny amount (for e.g.
         // dE/dx purposes) but don't physically propagate the track.
         result.distance += remaining;
+        cout << "- Moved distance " << remaining
+             << " without physically changing position" << endl;
     }
 
     // Even though the along-substep movement was through chord lengths,
@@ -227,6 +263,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     Real3 dir = state_.mom;
     normalize_direction(&dir);
     geo_.set_dir(dir);
+
+    cout << color_code('g') << "==> distance " << result.distance
+         << color_code(' ') << endl;
 
     CELER_ENSURE(result.distance >= 0 && result.distance <= step);
     return result;

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -226,6 +226,7 @@ OrangeTrackView& OrangeTrackView::operator=(const DetailedInitializer& init)
     states_.vol[thread_]   = states_.vol[init.other.thread_];
     states_.surf[thread_]  = states_.surf[init.other.thread_];
     states_.sense[thread_] = states_.sense[init.other.thread_];
+    states_.boundary[thread_] = states_.boundary[init.other.thread_];
 
     // Clear step and surface info
     this->clear_next_step();

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -84,6 +84,11 @@ class OrangeTrackView
     {
         return states_.surf[thread_];
     }
+    //! After 'find_next_step', the next straight-line surface
+    CELER_FUNCTION SurfaceId next_surface_id() const
+    {
+        return next_surface_.id();
+    }
     // Whether the track is outside the valid geometry region
     CELER_FORCEINLINE_FUNCTION bool is_outside() const;
     // Whether the track is exactly on a surface

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -150,6 +150,11 @@ class LayersTest : public FieldPropagatorTestBase
     const char* geometry_basename() const override { return "field-test"; }
 };
 
+class SimpleCmsTest : public FieldPropagatorTestBase
+{
+    const char* geometry_basename() const override { return "simple-cms"; }
+};
+
 //---------------------------------------------------------------------------//
 // HELPER CLASSES
 //---------------------------------------------------------------------------//
@@ -1004,6 +1009,34 @@ TEST_F(LayersTest, revolutions_through_cms_field)
         }
     }
     EXPECT_SOFT_NEAR(2 * pi * radius * num_revs, total_length, 1e-5);
+}
+
+//---------------------------------------------------------------------------//
+
+TEST_F(SimpleCmsTest, electron_stuck)
+{
+    auto particle = this->init_particle(this->particle()->find(pdg::electron()),
+                                        MevEnergy{4.25402379798713e-01});
+    UniformZField      field(1000);
+    FieldDriverOptions driver_options;
+    constexpr int      max_iter = 1000;
+
+    auto geo = this->init_geo(
+        {-2.43293925496543e+01, -1.75522265870979e+01, 2.80918346435833e+02},
+        {7.01343313647855e-01, -6.43327996599957e-01, 3.06996164784077e-01});
+
+    for (int i = 0; i < max_iter; ++i)
+    {
+        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
+            field, driver_options, particle, &geo);
+        auto result = propagate(1000);
+        EXPECT_TRUE(geo.is_on_boundary());
+
+        if (result.boundary)
+        {
+            geo.cross_boundary();
+        }
+    }
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
The last remaining major failure mode in the regression suite is in simple CMS with fields, where ORANGE crashes (failure to find the new volume after a boundary crossing) and VecGeom hangs. @amandalund set up a minimal test case which is where an electron is traveling *mostly* inside the vacuum tube but *barely* scraping the inner cylinder every cycle. She tracked down the error to the fact that at the end of one step, the track is heading out of the inner vacuum into the tracker, but the first substep attempt in the next field propagator step changes the direction so it's reentrant: and `find_next_boundary` fails to check for that case.

We hit a similar problem in #501, but in that case the direction changed *before* calling `cross_boundary`.

Here's the plot of the three steps leading to the boundary crossing failure:
![spirograph](https://user-images.githubusercontent.com/741229/191876743-065973be-a5e6-445e-8c93-91a77711d97f.png)

The final loop starts in the `tracker` volume but incorrectly heads inward (and doesn't see the reentrant cylinder boundary).
![last-loop](https://user-images.githubusercontent.com/741229/191876777-21668d4f-274d-45aa-a266-bccf60cc2446.png)

Zooming in on the crossing point for the last loop (with the last couple of points from the previous step included) shows the rejected substep end points (`+`) coming from the last accepted step far above the top of the graph, and their corresponding intercept points (`x`).
![boundary-convergence](https://user-images.githubusercontent.com/741229/191876863-859e9363-272c-4f81-b066-b2ae6a20f33a.png)

Because the proposed end points are so close to the intercept points, the propagation loop converges rather slowly.

## Solution

If we're on the boundary and the "next step" returns a tiny distance, halve the substep. Now the last loop correctly searches for the boundary from the outside of the cylinder:

![last-loop](https://user-images.githubusercontent.com/741229/192053160-691f6a49-fa4e-4e69-b655-76d235b3bff6.png)

