### PR TITLE
Fix additional failures resulting from direction change on a boundary after crossing

### DIFF
--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -160,7 +160,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // movement inside the current volume and reset the remaining
             // distance so we can continue toward the next boundary or end of
             // caller-requested step.
-            state_ = substep.state;
+            result.boundary = false;
+            state_          = substep.state;
             result.distance += celeritas::min(substep.step, remaining);
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
@@ -171,7 +172,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // Likely heading back into the old volume when starting on a
             // surface (this can happen when tracking through a volume at a
             // near tangent). Reduce substep size and try again.
-            remaining = substep.step / 2;
+            result.boundary = true;
+            remaining       = substep.step / 2;
         }
         else if (substep.step * linear_step.distance
                  <= driver_.minimum_step() * chord.length)
@@ -233,7 +235,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     normalize_direction(&dir);
     geo_.set_dir(dir);
 
-    CELER_ENSURE(result.distance >= 0 && result.distance <= step);
+    CELER_ENSURE(result.boundary == geo_.is_on_boundary());
+    CELER_ENSURE(result.distance > 0 && result.distance <= step);
     return result;
 }
 

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -415,6 +415,7 @@ CELER_FUNCTION void OrangeTrackView::cross_boundary()
     {
         // Direction changed while on boundary leading to no change in
         // volume/surface. This is logically equivalent to a reflection.
+        states_.boundary[thread_] = BoundaryResult::exiting;
         return;
     }
 

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -293,16 +293,22 @@ TEST_F(TwoVolumeTest, reentrant_boundary_setdir)
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
     }
     {
-        // Scatter on boundary so we're heading back into volume 0
+        // Scatter on boundary so we're heading back into volume 1
         geo.set_dir({-1, 0, 0});
         EXPECT_EQ(VolumeId{1}, geo.volume_id());
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
     }
     {
-        // Cross into new volume
+        // Cross back into volume
         geo.cross_boundary();
         EXPECT_EQ(VolumeId{1}, geo.volume_id());
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
+    }
+    {
+        // Find next distance
+        Propagation next = geo.find_next_step();
+        EXPECT_TRUE(next.boundary);
+        EXPECT_SOFT_EQ(2.98, next.distance);
     }
 }
 
@@ -327,7 +333,7 @@ TEST_F(TwoVolumeTest, nonreentrant_boundary_setdir)
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
     }
     {
-        // Scatter on boundary so we're still leaving volume 0
+        // Scatter on boundary so we're still leaving volume 1
         geo.set_dir({1, 0, 0});
         EXPECT_EQ(VolumeId{1}, geo.volume_id());
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
@@ -364,7 +370,7 @@ TEST_F(TwoVolumeTest, doubly_reentrant_boundary_setdir)
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
     }
     {
-        // Scatter on boundary so we're heading back into volume 0
+        // Scatter on boundary so we're heading back into volume 1
         geo.set_dir({-1, 0, 0});
         EXPECT_EQ(VolumeId{1}, geo.volume_id());
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
@@ -411,7 +417,7 @@ TEST_F(TwoVolumeTest, reentrant_boundary_setdir_post)
         EXPECT_EQ(SurfaceId{0}, geo.surface_id());
     }
     {
-        // Propose direction on boundary so we're heading back into volume 0
+        // Propose direction on boundary so we're heading back into volume 1
         EXPECT_TRUE(geo.is_on_boundary());
         geo.set_dir({-1, 0, 0});
 
@@ -423,6 +429,7 @@ TEST_F(TwoVolumeTest, reentrant_boundary_setdir_post)
         // Propose a new direction but still headed back inside
         EXPECT_TRUE(geo.is_on_boundary());
         geo.set_dir({-sqrt_two / 2, sqrt_two / 2, 0});
+        next = geo.find_next_step();
         EXPECT_TRUE(next.boundary);
         EXPECT_SOFT_EQ(0, next.distance);
 


### PR DESCRIPTION
After #515 we were still seeing an assertion failure (`OrangeTrackView.hh:433: celeritas: internal assertion failed: init.volume`) with simple-cms+field using ORANGE, and the transport loop with VecGeom was taking ~15x more step iterations than ORANGE. This proposes a couple more fixes:
- Reset the boundary state after a reentrant boundary crossing so the next `find_next_step()` will be correct
- Make sure the boundary result from the `FieldPropagator` is accurate

Currently simple-cms+field with VecGeom will crash (`FieldPropagator.hh:239: celeritas: internal assertion failed: result.distance > 0 && result.distance <= step`) with `result.distance == 0`. This is because most of the time when a track changes direction on a boundary immediately after crossing, the field propagator just keeps halving the remaining distance until it's smaller than the driver minimum step and exits the loop with the track still at the initial position on the boundary. But at least the number of step iterations now looks reasonable...