### PR TITLE
Fix field propagation for stuck and long-track particles

### DIFF
--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -410,6 +410,8 @@ CELER_FUNCTION void VecgeomTrackView::cross_boundary()
     }
 
     vgstate_ = vgnext_;
+
+    CELER_ENSURE(this->is_on_boundary());
 }
 
 //---------------------------------------------------------------------------//
@@ -429,20 +431,24 @@ CELER_FUNCTION void VecgeomTrackView::move_internal(real_type dist)
     axpy(dist, dir_, &pos_);
     next_step_ -= dist;
     vgstate_.SetBoundaryState(false);
+
+    CELER_ENSURE(!this->is_on_boundary());
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Move within the current volume to a nearby point.
  *
- * \todo Currently it's up to the caller to make sure that the position is
- * "nearby". We should actually test this with a safety distance.
+ * \warning It's up to the caller to make sure that the position is
+ * "nearby" and within the same volume.
  */
 CELER_FUNCTION void VecgeomTrackView::move_internal(const Real3& pos)
 {
     pos_       = pos;
     next_step_ = 0;
     vgstate_.SetBoundaryState(false);
+
+    CELER_ENSURE(!this->is_on_boundary());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -49,8 +49,6 @@ class FieldDriver
         return options_.minimum_step;
     }
 
-    CELER_FUNCTION size_type max_nsteps() const { return options_.max_nsteps; }
-
     // TODO: this should be field propagator data
     CELER_FUNCTION real_type delta_intersection() const
     {
@@ -172,7 +170,7 @@ FieldDriver<StepperT>::find_next_chord(real_type       step,
     ChordSearch output;
 
     bool               succeeded       = false;
-    size_type          remaining_steps = options_.max_nsteps;
+    auto               remaining_steps = options_.max_nsteps;
     FieldStepperResult result;
 
     do
@@ -180,7 +178,7 @@ FieldDriver<StepperT>::find_next_chord(real_type       step,
         // Try with the proposed step
         result = apply_step_(step, state);
 
-        // Check whether the distance to the chord is small than the reference
+        // Check whether the distance to the chord is smaller than the reference
         real_type dchord = detail::distance_chord(
             state, result.mid_state, result.end_state);
 
@@ -192,8 +190,6 @@ FieldDriver<StepperT>::find_next_chord(real_type       step,
         else
         {
             succeeded    = true;
-            output.error = detail::truncation_error(
-                step, options_.epsilon_rel_max, state, result.err_state);
         }
     } while (!succeeded && --remaining_steps > 0);
 
@@ -203,6 +199,8 @@ FieldDriver<StepperT>::find_next_chord(real_type       step,
     // Update step, position and momentum
     output.end.step  = step;
     output.end.state = result.end_state;
+    output.error = detail::truncation_error(
+        step, options_.epsilon_rel_max, state, result.err_state);
 
     return output;
 }
@@ -241,7 +239,7 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
     // Perform integration
     bool      succeeded       = false;
     real_type curve_length    = 0;
-    size_type remaining_steps = options_.max_nsteps;
+    auto remaining_steps = options_.max_nsteps;
 
     do
     {

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -19,14 +19,22 @@ namespace celeritas
  */
 struct FieldDriverOptions
 {
+    //!@{
+    //! \name Propagator options
+
+    //! Accuracy of intersection of the boundary crossing
+    real_type delta_intersection = 1.0e-4 * units::millimeter;
+
+    //!@}
+
+    //!@{
+    //! \name Driver options
+
     //! The minimum length of the field step
     real_type minimum_step = 1.0e-5 * units::millimeter;
 
     //! The closest miss distance
     real_type delta_chord = 0.25 * units::millimeter;
-
-    //! Accuracy of intersection of the boundary crossing
-    real_type delta_intersection = 1.0e-4 * units::millimeter;
 
     //! Relative error scale on the step length
     real_type epsilon_step = 1.0e-5;
@@ -60,6 +68,8 @@ struct FieldDriverOptions
 
     //! Chord distance fudge factor
     static constexpr real_type dchord_tol = 1e-5 * units::millimeter;
+
+    //!@}
 
     //! Whether all data are assigned and valid
     explicit CELER_FUNCTION operator bool() const

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -53,7 +53,7 @@ struct FieldDriverOptions
     real_type max_stepping_decrease = 0.1;
 
     //! Maximum number of steps (or trials)
-    size_type max_nsteps = 100;
+    short int max_nsteps = 100;
 
     //! Initial step tolerance
     static constexpr real_type initial_step_tol = 1e-6;

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -19,22 +19,14 @@ namespace celeritas
  */
 struct FieldDriverOptions
 {
-    //!@{
-    //! \name Propagator options
-
-    //! Accuracy of intersection of the boundary crossing
-    real_type delta_intersection = 1.0e-4 * units::millimeter;
-
-    //!@}
-
-    //!@{
-    //! \name Driver options
-
     //! The minimum length of the field step
     real_type minimum_step = 1.0e-5 * units::millimeter;
 
     //! The closest miss distance
     real_type delta_chord = 0.25 * units::millimeter;
+
+    //! Accuracy of intersection of the boundary crossing
+    real_type delta_intersection = 1.0e-4 * units::millimeter;
 
     //! Relative error scale on the step length
     real_type epsilon_step = 1.0e-5;
@@ -68,8 +60,6 @@ struct FieldDriverOptions
 
     //! Chord distance fudge factor
     static constexpr real_type dchord_tol = 1e-5 * units::millimeter;
-
-    //!@}
 
     //! Whether all data are assigned and valid
     explicit CELER_FUNCTION operator bool() const

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -28,7 +28,7 @@ namespace celeritas
  * particle along a curved trajectory up to an interaction length proposed by
  * a chosen physics process for the step, possibly integrating sub-steps by
  * an adaptive step control with a required accuracy of tracking in a
- * field and updates the final state (position, momentum) along with
+ * field. It updates the final state (position, momentum, boundary) along with
  * the step actually taken.  If the final position is outside the current
  * volume, it returns a geometry limited step and the state at the
  * intersection between the curve trajectory and the first volume boundary
@@ -103,9 +103,10 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()() -> result_type
 /*!
  * Propagate a charged particle in a field.
  *
- * It utilises a field driver based on an adaptive step
- * control to track a charged particle until it travels along a curved
- * trajectory for a given step length within a required accuracy or intersects
+ * It utilises a field driver (based on an adaptive step control to limit the
+ * length traveled based on the magnetic field behavior and geometric
+ * tolerances) to track a charged particle along a curved trajectory for a
+ * given step length within a required accuracy or intersects
  * with a new volume (geometry limited step).
  *
  * The position of the internal OdeState `state_` should be consistent with the

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -215,10 +215,11 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         {
             // i.e.: substep * (linear_step / chord_length) <= min_step
             // We're close enough to the boundary that the next trial step
-            // would be less than the driver's minimum step. Hop to the
-            // boundary without committing the substep.
+            // would be less than the driver's minimum step. Accept the
+            // momentum update, but use the position from the new boundary.
             result.boundary = true;
             result.distance += min(linear_step.distance, remaining);
+            state_.mom = substep.state.mom;
             remaining = 0;
             cout << " + next trial step exceeds driver minimum "
                  << driver_.minimum_step() << endl;

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -60,7 +60,7 @@ class FieldPropagator
     inline CELER_FUNCTION result_type operator()(real_type dist);
 
     //! Limit on substeps
-    static CELER_CONSTEXPR_FUNCTION int max_substeps() { return 128; }
+    static CELER_CONSTEXPR_FUNCTION short int max_substeps() { return 128; }
 
     // Distance to bump or to consider a "zero" movement
     inline CELER_FUNCTION real_type bump_distance() const;
@@ -144,7 +144,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     // geometry boundary in each substep. This loop is guaranteed to converge
     // since the trial step always decreases *or* the actual position advances.
     real_type remaining = step;
-    int       remaining_substeps = this->max_substeps();
+    auto       remaining_substeps = this->max_substeps();
     do
     {
         CELER_ASSERT(soft_zero(distance(state_.pos, geo_.pos())));

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -7,8 +7,12 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <iostream>
+
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "corecel/cont/ArrayIO.hh"
+#include "corecel/io/ColorUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "orange/Types.hh"
@@ -17,6 +21,8 @@
 
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
+using std::cout;
+using std::endl;
 
 namespace celeritas
 {
@@ -135,6 +141,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     result_type result;
     result.distance = 0;
 
+    cout << color_code('b') << "Propagate up to " << step << color_code(' ')
+         << endl;
+
     // Break the curved steps into substeps as determined by the driver *and*
     // by the proximity of geometry boundaries. Test for intersection with the
     // geometry boundary in each substep. This loop is guaranteed to converge
@@ -150,6 +159,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         CELER_ASSERT(substep.step <= remaining
                      || soft_equal(substep.step, remaining));
 
+        cout << "- advance(" << remaining << ", " << state_.pos << ") -> {"
+             << substep.step << ", " << substep.state.pos << "}" << endl;
+
         // Check whether the chord for this sub-step intersects a boundary
         auto chord = detail::make_chord(state_.pos, substep.state.pos);
 
@@ -159,6 +171,16 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         geo_.set_dir(chord.dir);
         auto linear_step
             = geo_.find_next_step(chord.length + driver_.delta_intersection());
+
+        cout << " + chord length " << chord.length << " => linear step "
+             << linear_step.distance;
+        if (linear_step.boundary)
+        {
+            cout << " (hit surface " << geo_.surface_id().unchecked_get()
+                 << ')';
+        }
+        cout << '\n';
+
         if (!linear_step.boundary)
         {
             // No boundary intersection along the chord: accept substep
@@ -173,6 +195,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
             --remaining_substeps;
+            cout << " + advancing to substep end point (" << remaining_substeps
+                 << " remaining)" << endl;
         }
         else if (CELER_UNLIKELY(linear_step.distance < driver_.minimum_step()
                                 && geo_.is_on_boundary()))
@@ -184,6 +208,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // converge.
             result.boundary = true;
             remaining       = substep.step / 2;
+            cout << " + halving substep distance" << endl;
         }
         else if (substep.step * linear_step.distance
                  <= driver_.minimum_step() * chord.length)
@@ -195,6 +220,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.boundary = true;
             result.distance += min(linear_step.distance, remaining);
             remaining = 0;
+            cout << " + next trial step exceeds driver minimum "
+                 << driver_.minimum_step() << endl;
         }
         else if (detail::is_intercept_close(state_.pos,
                                             chord.dir,
@@ -215,6 +242,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.distance += substep.step - miss_distance;
             state_.mom = substep.state.mom;
             remaining  = 0;
+
+            cout << " + intercept is sufficiently close (miss distance = "
+                 << miss_distance << ") to substep point" << endl;
         }
         else
         {
@@ -222,6 +252,10 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // Decrease the allowed substep (curved path distance) by the
             // fraction along the chord, and retry the driver step.
             remaining = substep.step * linear_step.distance / chord.length;
+
+            cout << " + Setting remaining distance to a fraction "
+                 << linear_step.distance / chord.length << " of the substep"
+                 << endl;
         }
     } while (remaining >= driver_.minimum_step() && remaining_substeps > 0);
 
@@ -229,6 +263,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     {
         geo_.move_to_boundary();
         state_.pos = geo_.pos();
+        cout << "- Moved to boundary " << geo_.surface_id().unchecked_get()
+             << " at position " << state_.pos << endl;
     }
     else if (remaining > 0 && remaining_substeps > 0)
     {
@@ -236,6 +272,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // value for "step". Return that we've moved this tiny amount (for e.g.
         // dE/dx purposes) but don't physically propagate the track.
         result.distance += remaining;
+        cout << "- Moved distance " << remaining
+             << " without physically changing position" << endl;
     }
 
     // Even though the along-substep movement was through chord lengths,
@@ -244,6 +282,10 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     Real3 dir = state_.mom;
     normalize_direction(&dir);
     geo_.set_dir(dir);
+
+    cout << color_code('g') << "==> distance " << result.distance
+         << color_code(' ') << " (in "
+         << this->max_substeps() - remaining_substeps << " steps)" << endl;
 
     CELER_ENSURE(result.boundary == geo_.is_on_boundary());
     CELER_ENSURE(result.distance > 0 && result.distance <= step);

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -7,12 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <iostream>
-
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
-#include "corecel/cont/ArrayIO.hh"
-#include "corecel/io/ColorUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "orange/Types.hh"
@@ -21,8 +17,6 @@
 
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
-using std::cout;
-using std::endl;
 
 namespace celeritas
 {
@@ -141,9 +135,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     result_type result;
     result.distance = 0;
 
-    cout << color_code('b') << "Propagate up to " << step << color_code(' ')
-         << endl;
-
     // Break the curved steps into substeps as determined by the driver *and*
     // by the proximity of geometry boundaries. Test for intersection with the
     // geometry boundary in each substep. This loop is guaranteed to converge
@@ -159,9 +150,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         CELER_ASSERT(substep.step <= remaining
                      || soft_equal(substep.step, remaining));
 
-        cout << "- advance(" << remaining << ", " << state_.pos << ") -> {"
-             << substep.step << ", " << substep.state.pos << "}" << endl;
-
         // Check whether the chord for this sub-step intersects a boundary
         auto chord = detail::make_chord(state_.pos, substep.state.pos);
 
@@ -171,16 +159,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         geo_.set_dir(chord.dir);
         auto linear_step
             = geo_.find_next_step(chord.length + driver_.delta_intersection());
-
-        cout << " + chord length " << chord.length << " => linear step "
-             << linear_step.distance;
-        if (linear_step.boundary)
-        {
-            cout << " (hit surface " << geo_.surface_id().unchecked_get()
-                 << ')';
-        }
-        cout << '\n';
-
         if (!linear_step.boundary)
         {
             // No boundary intersection along the chord: accept substep
@@ -195,8 +173,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
             --remaining_substeps;
-            cout << " + advancing to substep end point (" << remaining_substeps
-                 << " remaining)" << endl;
         }
         else if (CELER_UNLIKELY(linear_step.distance < driver_.minimum_step()
                                 && geo_.is_on_boundary()))
@@ -208,7 +184,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // converge.
             result.boundary = true;
             remaining       = substep.step / 2;
-            cout << " + halving substep distance" << endl;
         }
         else if (substep.step * linear_step.distance
                  <= driver_.minimum_step() * chord.length)
@@ -220,9 +195,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.boundary = true;
             result.distance += min(linear_step.distance, remaining);
             state_.mom = substep.state.mom;
-            remaining = 0;
-            cout << " + next trial step exceeds driver minimum "
-                 << driver_.minimum_step() << endl;
+            remaining  = 0;
         }
         else if (detail::is_intercept_close(state_.pos,
                                             chord.dir,
@@ -243,9 +216,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             result.distance += substep.step - miss_distance;
             state_.mom = substep.state.mom;
             remaining  = 0;
-
-            cout << " + intercept is sufficiently close (miss distance = "
-                 << miss_distance << ") to substep point" << endl;
         }
         else
         {
@@ -253,10 +223,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // Decrease the allowed substep (curved path distance) by the
             // fraction along the chord, and retry the driver step.
             remaining = substep.step * linear_step.distance / chord.length;
-
-            cout << " + Setting remaining distance to a fraction "
-                 << linear_step.distance / chord.length << " of the substep"
-                 << endl;
         }
     } while (remaining >= driver_.minimum_step() && remaining_substeps > 0);
 
@@ -264,8 +230,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     {
         geo_.move_to_boundary();
         state_.pos = geo_.pos();
-        cout << "- Moved to boundary " << geo_.surface_id().unchecked_get()
-             << " at position " << state_.pos << endl;
     }
     else if (remaining > 0 && remaining_substeps > 0)
     {
@@ -273,8 +237,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // value for "step". Return that we've moved this tiny amount (for e.g.
         // dE/dx purposes) but don't physically propagate the track.
         result.distance += remaining;
-        cout << "- Moved distance " << remaining
-             << " without physically changing position" << endl;
     }
 
     // Even though the along-substep movement was through chord lengths,
@@ -283,10 +245,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     Real3 dir = state_.mom;
     normalize_direction(&dir);
     geo_.set_dir(dir);
-
-    cout << color_code('g') << "==> distance " << result.distance
-         << color_code(' ') << " (in "
-         << this->max_substeps() - remaining_substeps << " steps)" << endl;
 
     CELER_ENSURE(result.boundary == geo_.is_on_boundary());
     CELER_ENSURE(result.distance > 0 && result.distance <= step);

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -265,6 +265,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // into the current volume and bump the particle.
         axpy(this->bump_distance(), dir, &state_.pos);
         geo_.move_internal(state_.pos);
+        result.distance = this->bump_distance();
+        result.boundary = false;
     }
 
     CELER_ENSURE(result.boundary == geo_.is_on_boundary());

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -68,6 +68,9 @@ class FieldPropagator
     //! Limit on substeps
     static CELER_CONSTEXPR_FUNCTION int max_substeps() { return 128; }
 
+    //! Bisect instead of reducing substep below this fraction to boundary
+    static CELER_CONSTEXPR_FUNCTION real_type bisect_tol() { return 0.5; }
+
   private:
     //// DATA ////
 
@@ -201,11 +204,14 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         else if (CELER_UNLIKELY(linear_step.distance < driver_.minimum_step()
                                 && geo_.is_on_boundary()))
         {
-            // Likely heading back into the old volume when starting on a
-            // surface (this can happen when tracking through a volume at a
-            // near tangent). Reduce substep size and try again. Assume a
-            // boundary crossing if repeated bisection of the substep fails to
-            // converge.
+            // Distance to boundary is very small (zero for ORANGE, some
+            // epsilon for VecGeom) and we're currently on a boundary.
+            // This means we're likely heading back into the old volume when
+            // starting on a surface (this can happen when tracking through a
+            // volume at a near tangent).
+            // Reduce substep size and try again.
+            // Assume a boundary crossing if repeated bisection of the substep
+            // fails to converge.
             result.boundary = true;
             remaining       = substep.step / 2;
             cout << " + halving substep distance" << endl;
@@ -246,6 +252,17 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
 
             cout << " + intercept is sufficiently close (miss distance = "
                  << miss_distance << ") to substep point" << endl;
+        }
+        else if (linear_step.distance > (1 - this->bisect_tol()) * chord.length)
+        {
+            // i.e. 1 - linear_step.distance / chord.length < bisect_tol
+            // The intercept point is "close" to the end of the the substep.
+            // Instead of reducing the trial substep value by a small fraction,
+            // advance halfway to the end
+            remaining = substep.step * 0.5;
+
+            cout << " + Endpoint is pretty close; halve step size to converge"
+                 << endl;
         }
         else
         {

--- a/src/celeritas/global/CoreTrackData.hh
+++ b/src/celeritas/global/CoreTrackData.hh
@@ -25,11 +25,12 @@ namespace celeritas
 struct CoreScalars
 {
     ActionId boundary_action;
+    ActionId propagation_limit_action;
 
     //! True if assigned and valid
     explicit CELER_FUNCTION operator bool() const
     {
-        return bool(boundary_action);
+        return boundary_action && propagation_limit_action;
     }
 };
 

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -73,6 +73,9 @@ class CoreTrackView
     // Action ID for encountering a geometry boundary
     inline CELER_FUNCTION ActionId boundary_action() const;
 
+    // Action ID for some other propagation limit (e.g. field stepping)
+    inline CELER_FUNCTION ActionId propagation_limit_action() const;
+
   private:
     const StateRef&  states_;
     const ParamsRef& params_;
@@ -193,6 +196,15 @@ CELER_FUNCTION auto CoreTrackView::make_rng_engine() const -> RngEngine
 CELER_FUNCTION ActionId CoreTrackView::boundary_action() const
 {
     return params_.scalars.boundary_action;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the action ID for having to pause the step during propagation.
+ */
+CELER_FUNCTION ActionId CoreTrackView::propagation_limit_action() const
+{
+    return params_.scalars.propagation_limit_action;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -201,6 +201,11 @@ CELER_FUNCTION ActionId CoreTrackView::boundary_action() const
 //---------------------------------------------------------------------------//
 /*!
  * Get the action ID for having to pause the step during propagation.
+ *
+ * This could be from an internal limiter (number of substeps during field
+ * propagation) or from having to "bump" the track position for some reason
+ * (geometry issue). The volume *must not* change as a result of the
+ * propagation, and this should be an extremely rare case.
  */
 CELER_FUNCTION ActionId CoreTrackView::propagation_limit_action() const
 {

--- a/src/celeritas/global/alongstep/AlongStep.hh
+++ b/src/celeritas/global/alongstep/AlongStep.hh
@@ -84,6 +84,13 @@ inline CELER_FUNCTION void along_step(MH&&                 msc,
             local.geo_step          = p.distance;
             local.step_limit.action = track.boundary_action();
         }
+        else if (p.distance < local.geo_step)
+        {
+            // Some other internal non-boundary geometry limit has been reached
+            // (e.g. too many substeps)
+            local.geo_step          = p.distance;
+            local.step_limit.action = track.propagation_limit_action();
+        }
     }
 
     if (use_msc)

--- a/src/celeritas/global/alongstep/detail/UrbanMsc.hh
+++ b/src/celeritas/global/alongstep/detail/UrbanMsc.hh
@@ -51,7 +51,7 @@ class UrbanMsc
   private:
     const ParamsRef& msc_params_;
 
-    // Whether a
+    // Whether the step was limited by geometry
     static inline CELER_FUNCTION bool
     is_geo_limited(CoreTrackView const&, const StepLimit&);
 };

--- a/src/celeritas/global/alongstep/detail/UrbanMsc.hh
+++ b/src/celeritas/global/alongstep/detail/UrbanMsc.hh
@@ -50,6 +50,10 @@ class UrbanMsc
 
   private:
     const ParamsRef& msc_params_;
+
+    // Whether a
+    static inline CELER_FUNCTION bool
+    is_geo_limited(CoreTrackView const&, const StepLimit&);
 };
 
 //---------------------------------------------------------------------------//
@@ -148,7 +152,7 @@ CELER_FUNCTION void UrbanMsc::apply_step(CoreTrackView const& track,
                                 phys,
                                 mat.make_material_view(),
                                 msc_step_result,
-                                /* geo_limited = */ geo.is_on_boundary());
+                                is_geo_limited(track, local->step_limit));
 
     auto rng        = track.make_rng_engine();
     auto msc_result = msc_scatter(rng);
@@ -176,6 +180,21 @@ CELER_FUNCTION void UrbanMsc::apply_step(CoreTrackView const& track,
         }
         geo.move_internal(new_pos);
     }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether the step was limited by geometry.
+ *
+ * Usually the track is limited only if it's on the boundary (in which case
+ * it should be "boundary action") but in rare circumstances the propagation
+ * has to pause before the end of the step is reached.
+ */
+CELER_FUNCTION bool
+UrbanMsc::is_geo_limited(CoreTrackView const& track, const StepLimit& limit)
+{
+    return (limit.action == track.boundary_action()
+            || limit.action == track.propagation_limit_action());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/io/EventReader.nohepmc.cc
+++ b/src/celeritas/io/EventReader.nohepmc.cc
@@ -22,6 +22,7 @@ EventReader::~EventReader() = default;
 
 auto EventReader::operator()() -> result_type
 {
+    (void)sizeof(event_count_);
     CELER_ASSERT_UNREACHABLE();
 }
 

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -22,6 +22,7 @@
 #include "celeritas/em/model/EPlusGGModel.hh"
 #include "celeritas/em/model/LivermorePEModel.hh"
 #include "celeritas/em/process/MultipleScatteringProcess.hh"
+#include "celeritas/global/ActionInterface.hh"
 #include "celeritas/global/ActionManager.hh"
 #include "celeritas/grid/ValueGridBuilder.hh"
 #include "celeritas/grid/ValueGridInserter.hh"

--- a/src/corecel/io/StringUtils.cc
+++ b/src/corecel/io/StringUtils.cc
@@ -14,6 +14,19 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Whether the string starts with another string.
+ */
+bool starts_with(const std::string& main_string, const std::string& prefix)
+{
+    if (main_string.size() < prefix.size())
+        return false;
+
+    return std::equal(
+        main_string.begin(), main_string.begin() + prefix.size(), prefix.begin());
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Whether the string ends with another string.
  */
 bool ends_with(const std::string& main_string, const std::string& suffix)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,6 +138,7 @@ celeritas_add_test(corecel/io/Logger.test.cc)
 celeritas_add_test(corecel/io/OutputManager.test.cc)
 celeritas_add_test(corecel/io/Repr.test.cc)
 celeritas_add_test(corecel/io/StringEnumMap.test.cc)
+celeritas_add_test(corecel/io/StringUtils.test.cc)
 
 # Math
 celeritas_add_test(corecel/math/Algorithms.test.cc)

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -351,7 +351,7 @@ TEST_F(TwoBoxTest, gamma_interior)
         EXPECT_TRUE(result.boundary);
         EXPECT_VEC_SOFT_EQ(Real3({0, 0, 5}), geo.pos());
         EXPECT_VEC_SOFT_EQ(Real3({0, 0, 1}), geo.dir());
-        EXPECT_EQ(4, stepper.count());
+        EXPECT_EQ(2, stepper.count());
     }
     // Cross boundary
     {
@@ -462,6 +462,7 @@ TEST_F(TwoBoxTest, gamma_exit)
         EXPECT_SOFT_EQ(0.251, result.distance);
         EXPECT_TRUE(result.boundary);
         EXPECT_LT(distance(Real3({2, 5, 0}), geo.pos()), 1e-5);
+        EXPECT_EQ(2, stepper.count());
         EXPECT_EQ("inner", this->volume_name(geo));
         ASSERT_TRUE(result.boundary);
         geo.cross_boundary();
@@ -1064,8 +1065,8 @@ TEST_F(LayersTest, revolutions_through_layers)
         }
     }
 
-    EXPECT_SOFT_NEAR(-0.13150565, geo.pos()[0], 1e-3);
-    EXPECT_SOFT_NEAR(-0.03453068, geo.dir()[1], 1e-3);
+    EXPECT_SOFT_NEAR(-0.13150565, geo.pos()[0], 1e-6);
+    EXPECT_SOFT_NEAR(-0.03453068, geo.dir()[1], 1e-6);
     EXPECT_SOFT_NEAR(221.48171708, total_length, 1e-6);
     EXPECT_EQ(148, icross);
 }
@@ -1148,7 +1149,7 @@ TEST_F(SimpleCmsTest, electron_stuck)
             = make_field_propagator(stepper, driver_options, particle, &geo);
         auto result = propagate(1000);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
-        EXPECT_EQ(211, stepper.count());
+        EXPECT_EQ(92, stepper.count());
         ASSERT_TRUE(geo.is_on_boundary());
         if (!CELERITAS_USE_VECGEOM)
         {

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1214,13 +1214,12 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         auto propagate
             = make_field_propagator(stepper, driver_options, particle, &geo);
         auto result = propagate(2.12621374950874703e+21);
+        EXPECT_SOFT_EQ(14.946488966946923, result.distance);
+        EXPECT_FALSE(result.boundary);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
         EXPECT_EQ("em_calorimeter", this->volume_name(geo));
-        EXPECT_SOFT_EQ(125.04595517211715, calc_radius());
-        EXPECT_EQ(503784, stepper.count());
-        ASSERT_TRUE(geo.is_on_boundary());
-        geo.cross_boundary();
-        EXPECT_EQ("world", this->volume_name(geo));
+        EXPECT_SOFT_NEAR(125, calc_radius(), 1e-4);
+        EXPECT_EQ(9984, stepper.count());
     }
 }
 

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1220,12 +1220,11 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
                      -5.43172303859124073e-01});
         geo.cross_boundary();
         successful_reentry = (this->volume_name(geo) == "em_calorimeter");
-        if (!CELERITAS_USE_VECGEOM
-            || !starts_with(celeritas_vecgeom_version, "1.1."))
+        if (!CELERITAS_USE_VECGEOM)
         {
-            // Both ORANGE and newer VecGeom versions should successfully
-            // reenter. Some older versions on some systems will sometimes move
-            // into the world volume.
+            // ORANGE should successfully reenter. However, under certain
+            // system configurations, VecGeom will end up in the world volume,
+            // so we don't test in all cases.
             EXPECT_EQ("em_calorimeter", this->volume_name(geo));
         }
     }

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -351,7 +351,7 @@ TEST_F(TwoBoxTest, gamma_interior)
         EXPECT_TRUE(result.boundary);
         EXPECT_VEC_SOFT_EQ(Real3({0, 0, 5}), geo.pos());
         EXPECT_VEC_SOFT_EQ(Real3({0, 0, 1}), geo.dir());
-        EXPECT_EQ(2, stepper.count());
+        EXPECT_EQ(4, stepper.count());
     }
     // Cross boundary
     {
@@ -462,7 +462,6 @@ TEST_F(TwoBoxTest, gamma_exit)
         EXPECT_SOFT_EQ(0.251, result.distance);
         EXPECT_TRUE(result.boundary);
         EXPECT_LT(distance(Real3({2, 5, 0}), geo.pos()), 1e-5);
-        EXPECT_EQ(2, stepper.count());
         EXPECT_EQ("inner", this->volume_name(geo));
         ASSERT_TRUE(result.boundary);
         geo.cross_boundary();
@@ -1065,8 +1064,8 @@ TEST_F(LayersTest, revolutions_through_layers)
         }
     }
 
-    EXPECT_SOFT_NEAR(-0.13150565, geo.pos()[0], 1e-6);
-    EXPECT_SOFT_NEAR(-0.03453068, geo.dir()[1], 1e-6);
+    EXPECT_SOFT_NEAR(-0.13150565, geo.pos()[0], 1e-3);
+    EXPECT_SOFT_NEAR(-0.03453068, geo.dir()[1], 1e-3);
     EXPECT_SOFT_NEAR(221.48171708, total_length, 1e-6);
     EXPECT_EQ(148, icross);
 }
@@ -1149,7 +1148,7 @@ TEST_F(SimpleCmsTest, electron_stuck)
             = make_field_propagator(stepper, driver_options, particle, &geo);
         auto result = propagate(1000);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
-        EXPECT_EQ(92, stepper.count());
+        EXPECT_EQ(211, stepper.count());
         ASSERT_TRUE(geo.is_on_boundary());
         if (!CELERITAS_USE_VECGEOM)
         {

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -495,7 +495,7 @@ TEST_F(TwoBoxTest, electron_small_step)
         EXPECT_TRUE(result.boundary);
         EXPECT_TRUE(geo.is_on_boundary());
         EXPECT_VEC_SOFT_EQ(Real3({5, 0, 0}), geo.pos());
-        EXPECT_VEC_EQ(Real3({1, 0, 0}), geo.dir());
+        EXPECT_VEC_SOFT_EQ(Real3({1, delta, 0}), geo.dir());
     }
     {
         SCOPED_TRACE("Small step intersected by boundary");
@@ -512,7 +512,7 @@ TEST_F(TwoBoxTest, electron_small_step)
         EXPECT_TRUE(result.boundary);
         EXPECT_TRUE(geo.is_on_boundary());
         EXPECT_VEC_SOFT_EQ(Real3({5, 0, 0}), geo.pos());
-        EXPECT_VEC_EQ(Real3({1, 0, 0}), geo.dir());
+        EXPECT_VEC_SOFT_EQ(Real3({1, 2 * delta, 0}), geo.dir());
     }
     {
         SCOPED_TRACE("Cross boundary");
@@ -538,7 +538,7 @@ TEST_F(TwoBoxTest, electron_small_step)
         EXPECT_FALSE(result.boundary);
         EXPECT_FALSE(geo.is_on_boundary());
         EXPECT_VEC_SOFT_EQ(Real3({5 + delta, 0, 0}), geo.pos());
-        EXPECT_VEC_SOFT_EQ(Real3({1, delta, 0}), geo.dir());
+        EXPECT_VEC_SOFT_EQ(Real3({1, 3 * delta, 0}), geo.dir());
     }
 }
 

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -11,6 +11,7 @@
 
 #include "corecel/cont/ArrayIO.hh"
 #include "corecel/data/CollectionStateStore.hh"
+#include "corecel/io/StringUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Constants.hh"

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1209,12 +1209,15 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         auto particle
             = this->init_particle(this->particle()->find(pdg::electron()),
                                   MevEnergy{3.25917780979408864e-02});
-        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+        auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
+            field, particle.charge());
+        auto propagate
+            = make_field_propagator(stepper, driver_options, particle, &geo);
         auto result = propagate(2.12621374950874703e+21);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
         EXPECT_EQ("em_calorimeter", this->volume_name(geo));
         EXPECT_SOFT_EQ(125.04595517211715, calc_radius());
+        EXPECT_EQ(503784, stepper.count());
         ASSERT_TRUE(geo.is_on_boundary());
         geo.cross_boundary();
         EXPECT_EQ("world", this->volume_name(geo));

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1143,10 +1143,13 @@ TEST_F(SimpleCmsTest, electron_stuck)
         EXPECT_EQ("vacuum_tube", this->volume_name(geo));
     }
     {
-        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+        auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
+            field, particle.charge());
+        auto propagate
+            = make_field_propagator(stepper, driver_options, particle, &geo);
         auto result = propagate(1000);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
+        EXPECT_EQ(92, stepper.count());
         ASSERT_TRUE(geo.is_on_boundary());
         if (!CELERITAS_USE_VECGEOM)
         {
@@ -1192,12 +1195,15 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         auto particle
             = this->init_particle(this->particle()->find(pdg::electron()),
                                   MevEnergy{3.27089632881079409e-02});
-        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+        auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
+            field, particle.charge());
+        auto propagate
+            = make_field_propagator(stepper, driver_options, particle, &geo);
         auto result = propagate(1.39170198361108938e-05);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
         EXPECT_EQ("em_calorimeter", this->volume_name(geo));
         EXPECT_SOFT_EQ(125.00000000000001, calc_radius());
+        EXPECT_EQ(2, stepper.count());
         geo.set_dir({-1.31178657592616127e-01,
                      -8.29310561920304168e-01,
                      -5.43172303859124073e-01});

--- a/test/corecel/io/StringUtils.test.cc
+++ b/test/corecel/io/StringUtils.test.cc
@@ -3,22 +3,34 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/io/StringUtils.hh
-//! \brief Helper functions for string processing
+//! \file corecel/io/StringUtils.test.cc
 //---------------------------------------------------------------------------//
-#pragma once
+#include "corecel/io/StringUtils.hh"
 
-#include <string>
+#include "celeritas_test.hh"
 
 namespace celeritas
 {
+namespace test
+{
 //---------------------------------------------------------------------------//
-// Whether the string starts with another string.
-bool starts_with(const std::string& main_string, const std::string& prefix);
+TEST(StringUtils, starts_with)
+{
+    EXPECT_TRUE(starts_with("prefix", "pre"));
+    EXPECT_FALSE(starts_with("abcd", "b"));
+    EXPECT_FALSE(starts_with("a", "abcd"));
+    EXPECT_TRUE(starts_with("", ""));
+}
 
 //---------------------------------------------------------------------------//
-// Whether the string ends with another string.
-bool ends_with(const std::string& main_string, const std::string& suffix);
+TEST(StringUtils, ends_with)
+{
+    EXPECT_TRUE(ends_with("prefix", "fix"));
+    EXPECT_FALSE(ends_with("abcd", "c"));
+    EXPECT_FALSE(ends_with("d", "abcd"));
+    EXPECT_TRUE(ends_with("", ""));
+}
 
 //---------------------------------------------------------------------------//
+} // namespace test
 } // namespace celeritas


### PR DESCRIPTION
VecGeom < 1.2 fails on this long step; on newer versions (and in ORANGE) it passes but takes ~78 equation evaluations per substep, which seems excessive for a uniform magnetic field. Credit to @amandalund for finding and adding a minimal test for the failure.

## Minor fix: nearly-boundary momentum

When the substep "nearly" hits the boundary, we were "accepting" the step by moving to the boundary, but I was unintentionally ignoring the momentum update from the substep. This situation is pretty uncommon and the momentum change usually small, so our tests didn't seem to catch anything from the change. (Perhaps with more boundary crossings we would eventually accumulate enough error?)

## Major change: add maximum substep counter

I've hardcoded a 128-substep-per-step limit into the field propagator. This also requires adding a new "implicit" action for whenever the geometry stops the track before the end of the expected geometry step limit is reached. This might be needed for other cases when tracking fails and we have to "bump" the particle, even in the absence of a field.

## Major change: bump particles when they can't move off the boundary

In #515 I added code to progressively halve the substep trial distance if the returned boundary distance is zero (i.e. if the trial direction is reentrant) so that we can make a small step in a nearly-tangent volume. Under some circumstances, though, VecGeom always returns `1e-8` no matter how small the trial step is, so it would get stuck on the boundary. Now, with the substep limit (and the fact that the trial distance eventually gets below the substepper tolerance) when we exit the substepping loop, we test for the distance being zero. If and only if it's stuck on a boundary is the distance zero. In that case, we bump the particle's position within the volume (moving it forward by a small amount, currently set to the driver minimum step).

## No change: bisecting distance when trial endpoint is barely past the geometry boundary

Some steps take many substep iterations to converge because the intercept along the substep chord is 99% of the chord length, so the trial distance is only reduced by .01. From my tests, attempting to "bisect" the intercept point by doing a half-step in such cases resulted in *no* change in the total number of equation evaluations, except that it increased the number of substeps for neutral particles (which is silly). It might be worth revisiting when we allow neutral particles to take a separate along-step kernel.