### PR TITLE
Fix the true path length limit of UrbanMsc

### DIFF
--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -36,7 +36,8 @@ struct UrbanMscParameters
     real_type safety_fact{0.6}; //!< safety factor
     real_type safety_tol{0.01}; //!< safety tolerance
     real_type geom_limit{5e-8 * units::millimeter}; //!< minimum step
-    Energy    energy_limit{1e-5};                   //!< 10 eV
+    Energy    low_energy_limit{1e-5};               //!< 10 eV
+    Energy    high_energy_limit{1e+2};              //!< 100 MeV
 
     //! A scale factor for the range
     static CELER_CONSTEXPR_FUNCTION real_type dtrl() { return 5e-2; }
@@ -79,6 +80,7 @@ struct UrbanMscMaterialData
     using Real4 = Array<real_type, 4>;
 
     real_type zeff{};        //!< effective atomic_number
+    real_type scaled_zeff{}; //!< 0.70 * sqrt(zeff)
     real_type z23{};         //!< zeff^(2/3)
     real_type coeffth1{};    //!< correction in theta_0 formula
     real_type coeffth2{};    //!< correction in theta_0 formula

--- a/src/celeritas/em/model/UrbanMscModel.cc
+++ b/src/celeritas/em/model/UrbanMscModel.cc
@@ -150,7 +150,8 @@ auto UrbanMscModel::calc_material_data(const MaterialView& material_view)
 
     MaterialData data;
 
-    data.zeff = zeff;
+    data.zeff        = zeff;
+    data.scaled_zeff = real_type(0.70) * std::sqrt(zeff);
 
     // Correction in the (modified Highland-Lynch-Dahl) theta_0 formula
     const double z16 = fastpow(zeff, 1.0 / 6.0);

--- a/src/celeritas/global/alongstep/detail/UrbanMsc.hh
+++ b/src/celeritas/global/alongstep/detail/UrbanMsc.hh
@@ -81,7 +81,8 @@ UrbanMsc::is_applicable(CoreTrackView const& track, real_type step) const
         return false;
 
     auto particle = track.make_particle_view();
-    return particle.energy() > msc_params_.params.energy_limit;
+    return particle.energy() > msc_params_.params.low_energy_limit
+           && particle.energy() < msc_params_.params.high_energy_limit;
 }
 
 //---------------------------------------------------------------------------//
@@ -96,14 +97,12 @@ CELER_FUNCTION void UrbanMsc::calc_step(CoreTrackView const& track,
     auto particle = track.make_particle_view();
     auto geo      = track.make_geo_view();
     auto phys     = track.make_physics_view();
-    auto sim      = track.make_sim_view();
 
     // Sample multiple scattering step length
     UrbanMscStepLimit msc_step_limit(msc_params_,
                                      particle,
                                      phys,
                                      track.make_material_view().material_id(),
-                                     sim.num_steps() == 0,
                                      geo.find_safety(),
                                      local->step_limit.step);
 

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -308,7 +308,6 @@ TEST_F(UrbanMscTest, msc_scattering)
                                        *part_view_,
                                        phys,
                                        material_view.material_id(),
-                                       sim_track_view.num_steps() == 0,
                                        geo_view.find_safety(),
                                        step[i]);
 

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -280,37 +280,10 @@ TEST_F(TestEm3MscTest, host)
 
     if (this->is_ci_build() || this->is_wildstyle_build())
     {
-        if (CELERITAS_USE_VECGEOM)
-        {
-            EXPECT_EQ(49, result.num_step_iters());
-            EXPECT_SOFT_EQ(44.875, result.calc_avg_steps_per_primary());
-            EXPECT_EQ(7, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({4, 6}), result.calc_queue_hwm());
-        }
-        else
-        {
-            EXPECT_EQ(48, result.num_step_iters());
-            EXPECT_SOFT_EQ(47.125, result.calc_avg_steps_per_primary());
-            EXPECT_EQ(12, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({8, 6}), result.calc_queue_hwm());
-        }
-    }
-    else if (this->is_summit_build())
-    {
-        if (CELERITAS_USE_VECGEOM)
-        {
-            EXPECT_EQ(53, result.num_step_iters());
-            EXPECT_SOFT_NEAR(44.75, result.calc_avg_steps_per_primary(), 0.02);
-            EXPECT_EQ(7, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({4, 6}), result.calc_queue_hwm());
-        }
-        else
-        {
-            EXPECT_EQ(51, result.num_step_iters());
-            EXPECT_SOFT_NEAR(51.75, result.calc_avg_steps_per_primary(), 0.02);
-            EXPECT_EQ(12, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({8, 6}), result.calc_queue_hwm());
-        }
+        EXPECT_EQ(30, result.num_step_iters());
+        EXPECT_SOFT_EQ(30.625, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(10, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({8, 6}), result.calc_queue_hwm());
     }
     else
     {
@@ -327,11 +300,6 @@ TEST_F(TestEm3MscTest, host)
 
 TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
 {
-    if (CELERITAS_USE_VECGEOM && this->is_ci_build())
-    {
-        GTEST_SKIP() << "TODO: TestEm3 + vecgeom crashes on CI";
-    }
-
     size_type num_primaries   = 8;
     size_type inits_per_track = 512;
     size_type num_tracks      = 1024;
@@ -340,39 +308,12 @@ TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
 
-    if (this->is_ci_build() || this->is_wildstyle_build())
+    if (this->is_ci_build())
     {
-        if (CELERITAS_USE_VECGEOM)
-        {
-            EXPECT_EQ(106, result.num_step_iters());
-            EXPECT_SOFT_EQ(76.875, result.calc_avg_steps_per_primary());
-            EXPECT_EQ(11, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({6, 6}), result.calc_queue_hwm());
-        }
-        else
-        {
-            EXPECT_EQ(61, result.num_step_iters());
-            EXPECT_SOFT_EQ(55.625, result.calc_avg_steps_per_primary());
-            EXPECT_EQ(9, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({7, 8}), result.calc_queue_hwm());
-        }
-    }
-    else if (this->is_summit_build())
-    {
-        if (CELERITAS_USE_VECGEOM)
-        {
-            EXPECT_EQ(90, result.num_step_iters());
-            EXPECT_SOFT_EQ(78.375, result.calc_avg_steps_per_primary());
-            EXPECT_EQ(11, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({6, 6}), result.calc_queue_hwm());
-        }
-        else
-        {
-            EXPECT_EQ(61, result.num_step_iters());
-            EXPECT_SOFT_EQ(54.375, result.calc_avg_steps_per_primary());
-            EXPECT_EQ(9, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({7, 8}), result.calc_queue_hwm());
-        }
+        EXPECT_EQ(63, result.num_step_iters());
+        EXPECT_SOFT_EQ(62.375, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(8, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({6, 7}), result.calc_queue_hwm());
     }
     else
     {
@@ -402,39 +343,12 @@ TEST_F(TestEm3MscNofluctTest, host)
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(55, result.calc_avg_steps_per_primary(), 0.50);
 
-    if (this->is_ci_build() || this->is_wildstyle_build())
+    if (this->is_ci_build())
     {
-        if (CELERITAS_USE_VECGEOM)
-        {
-            EXPECT_EQ(104, result.num_step_iters());
-            EXPECT_SOFT_EQ(55.25, result.calc_avg_steps_per_primary());
-            EXPECT_EQ(8, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({5, 5}), result.calc_queue_hwm());
-        }
-        else
-        {
-            EXPECT_EQ(69, result.num_step_iters());
-            EXPECT_SOFT_EQ(57.5, result.calc_avg_steps_per_primary());
-            EXPECT_EQ(8, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({4, 5}), result.calc_queue_hwm());
-        }
-    }
-    else if (this->is_summit_build())
-    {
-        if (CELERITAS_USE_VECGEOM)
-        {
-            EXPECT_EQ(84, result.num_step_iters());
-            EXPECT_SOFT_NEAR(53.625, result.calc_avg_steps_per_primary(), 0.04);
-            EXPECT_EQ(8, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({5, 5}), result.calc_queue_hwm());
-        }
-        else
-        {
-            EXPECT_EQ(73, result.num_step_iters());
-            EXPECT_SOFT_NEAR(60.375, result.calc_avg_steps_per_primary(), 0.04);
-            EXPECT_EQ(8, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({4, 5}), result.calc_queue_hwm());
-        }
+        EXPECT_EQ(71, result.num_step_iters());
+        EXPECT_SOFT_EQ(57.125, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(8, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({4, 5}), result.calc_queue_hwm());
     }
     else
     {
@@ -464,22 +378,12 @@ TEST_F(TestEm3MscNofluctTest, TEST_IF_CELER_DEVICE(device))
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
 
-    if (this->is_ci_build() || this->is_wildstyle_build())
+    if (this->is_ci_build())
     {
-        if (CELERITAS_USE_VECGEOM)
-        {
-            EXPECT_EQ(57, result.num_step_iters());
-            EXPECT_SOFT_EQ(53.25, result.calc_avg_steps_per_primary());
-            EXPECT_EQ(10, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({11, 5}), result.calc_queue_hwm());
-        }
-        else
-        {
-            EXPECT_EQ(42, result.num_step_iters());
-            EXPECT_SOFT_EQ(52.625, result.calc_avg_steps_per_primary());
-            EXPECT_EQ(11, result.calc_emptying_step());
-            EXPECT_EQ(RunResult::StepCount({9, 4}), result.calc_queue_hwm());
-        }
+        EXPECT_EQ(38, result.num_step_iters());
+        EXPECT_SOFT_EQ(44.75, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(11, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({10, 5}), result.calc_queue_hwm());
     }
     else
     {
@@ -509,21 +413,8 @@ TEST_F(TestEm15FieldTest, host)
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(35, result.calc_avg_steps_per_primary(), 0.50);
 
-    if (this->is_ci_build())
-    {
-        EXPECT_EQ(14, result.num_step_iters());
-        EXPECT_SOFT_EQ(35, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(6, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({4, 7}), result.calc_queue_hwm());
-    }
-    else if (this->is_summit_build())
-    {
-        EXPECT_EQ(14, result.num_step_iters());
-        EXPECT_SOFT_EQ(35, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(6, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({4, 7}), result.calc_queue_hwm());
-    }
-    else if (this->is_wildstyle_build())
+    if (this->is_ci_build() || this->is_summit_build()
+        || this->is_wildstyle_build())
     {
         EXPECT_EQ(14, result.num_step_iters());
         EXPECT_SOFT_EQ(35, result.calc_avg_steps_per_primary());
@@ -553,21 +444,8 @@ TEST_F(TestEm15FieldTest, TEST_IF_CELER_DEVICE(device))
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
 
-    if (this->is_ci_build())
-    {
-        EXPECT_EQ(14, result.num_step_iters());
-        EXPECT_SOFT_EQ(29.75, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(5, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({2, 11}), result.calc_queue_hwm());
-    }
-    else if (this->is_wildstyle_build())
-    {
-        EXPECT_EQ(14, result.num_step_iters());
-        EXPECT_SOFT_EQ(29.75, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(5, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({2, 11}), result.calc_queue_hwm());
-    }
-    else if (this->is_summit_build())
+    if (this->is_ci_build() || this->is_summit_build()
+        || this->is_wildstyle_build())
     {
         EXPECT_EQ(14, result.num_step_iters());
         EXPECT_SOFT_EQ(29.75, result.calc_avg_steps_per_primary());

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -310,8 +310,16 @@ TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
 
     if (this->is_ci_build())
     {
-        EXPECT_EQ(63, result.num_step_iters());
-        EXPECT_SOFT_EQ(62.375, result.calc_avg_steps_per_primary());
+        if (CELERITAS_USE_VECGEOM)
+        {
+            EXPECT_EQ(64, result.num_step_iters());
+            EXPECT_SOFT_EQ(62.5, result.calc_avg_steps_per_primary());
+        }
+        else
+        {
+            EXPECT_EQ(63, result.num_step_iters());
+            EXPECT_SOFT_EQ(62.375, result.calc_avg_steps_per_primary());
+        }
         EXPECT_EQ(8, result.calc_emptying_step());
         EXPECT_EQ(RunResult::StepCount({6, 7}), result.calc_queue_hwm());
     }

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -276,7 +276,7 @@ TEST_F(TestEm3MscTest, host)
     Stepper<MemSpace::host> step(
         this->make_stepper_input(num_tracks, inits_per_track));
     auto result = this->run(step, num_primaries);
-    EXPECT_SOFT_NEAR(55, result.calc_avg_steps_per_primary(), 0.25);
+    EXPECT_SOFT_NEAR(30.5, result.calc_avg_steps_per_primary(), 0.25);
 
     if (this->is_ci_build() || this->is_wildstyle_build())
     {


### PR DESCRIPTION
The PR includes a bug fix for the minimum of the true path length limit which is now calculated every msc step and associated changes in along step and tests.   See comparisons between Geant4 and Celeritas for positrons after the bug fix with the testem3 benchmark with 100 events of a 10 GeV electron:
![msc-fix](https://user-images.githubusercontent.com/26611211/194690189-33c22bc6-0056-45e0-b238-dfba4810b49a.png)
