### PR TITLE
Define gauss as internal field strength and use tesla for input

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -347,6 +347,12 @@ TransporterInput load_input(const LDemoArgs& args)
         field_params.field   = args.mag_field;
         field_params.options = args.field_options;
 
+        // Interpret input in units of Tesla
+        for (real_type& f : field_params.field)
+        {
+            f *= units::tesla;
+        }
+
         auto along_step = AlongStepUniformMscAction::from_params(
             *params.physics, field_params, params.action_mgr.get());
         CELER_ASSERT(args.mag_field == along_step->field());

--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -51,7 +51,7 @@ struct LDemoArgs
     bool         use_device{};
     bool         sync{};
 
-    // Magnetic field vector (mT) and associated field options
+    // Magnetic field vector [* 1/Tesla] and associated field options
     Real3                         mag_field{no_field()};
     celeritas::FieldDriverOptions field_options;
 

--- a/doc/api/celeritas.rst
+++ b/doc/api/celeritas.rst
@@ -9,6 +9,22 @@ The ``celeritas`` directory focuses on the physics and transport loop
 implementation for the Celeritas codebase, using components from the
 ``corecel`` and ``orange`` dependencies.
 
+Fundamentals
+------------
+
+.. doxygennamespace:: units
+
+.. doxygennamespace:: constants
+
+.. doxygenfile:: celeritas/Units.hh
+   :sections: user-defined var innernamespace
+
+.. doxygenfile:: celeritas/Quantities.hh
+   :sections: user-defined var innernamespace
+
+.. doxygenfile:: celeritas/Constants.hh
+   :sections: user-defined var innernamespace
+
 Problem definition
 ------------------
 

--- a/doc/api/corecel.rst
+++ b/doc/api/corecel.rst
@@ -4,13 +4,13 @@
 
 .. doxygenfile:: celeritas_version.h
 
+.. _corecel:
+
 Core package
 ============
 
 The ``corecel`` directory contains functionality shared by Celeritas and ORANGE
 primarily pertaining to GPU abstractions.
-
-.. _corecel:
 
 Fundamentals
 ------------

--- a/src/celeritas/Constants.hh
+++ b/src/celeritas/Constants.hh
@@ -49,7 +49,7 @@ namespace constants
  */
 
 //!@{
-//! Mathemetical constants (truncated)
+//! \name Mathemetical constants (truncated)
 constexpr real_type pi         = 3.14159265358979323846;
 constexpr real_type euler      = 2.71828182845904523536;
 constexpr real_type sqrt_two   = 1.41421356237309504880;
@@ -57,7 +57,7 @@ constexpr real_type sqrt_three = 1.73205080756887729353;
 //!@}
 
 //!@{
-//! Physical constant with *exact* value as defined by SI
+//! \name Physical constants with *exact* value as defined by SI
 constexpr real_type c_light    = 299792458. * units::meter / units::second;
 constexpr real_type h_planck   = 6.62607015e-34 * units::joule * units::second;
 constexpr real_type e_electron = 1.602176634e-19 * units::coulomb;
@@ -67,12 +67,12 @@ constexpr real_type kcd_luminous = 683;
 //!@}
 
 //!@{
-//! Exact derivative constant
+//! \name Exact derivative constants
 constexpr real_type hbar_planck = h_planck / (2 * pi);
 //!@}
 
 //!@{
-//! Experimental physical constant from CODATA 2018
+//! \name Experimental physical constants from CODATA 2018
 constexpr real_type a0_bohr              = 5.29177210903e-11 * units::meter;
 constexpr real_type alpha_fine_structure = 7.2973525693e-3;
 constexpr real_type atomic_mass          = 1.66053906660e-24 * units::gram;

--- a/src/celeritas/Quantities.hh
+++ b/src/celeritas/Quantities.hh
@@ -96,7 +96,7 @@ using CLightSq = UnitProduct<CLight, CLight>;
 
 //---------------------------------------------------------------------------//
 //!@{
-//! Units for particle quantities
+//! \name Units for particle quantities
 using ElementaryCharge = Quantity<EElectron>;
 using MevEnergy        = Quantity<Mev>;
 using LogMevEnergy     = Quantity<LogMev>;

--- a/src/celeritas/Units.hh
+++ b/src/celeritas/Units.hh
@@ -47,7 +47,7 @@ namespace units
 constexpr real_type centimeter = 1; //!< Length
 constexpr real_type gram       = 1; //!< Mass
 constexpr real_type second     = 1; //!< Time
-constexpr real_type coulomb    = 1; //!< Charge
+constexpr real_type gauss      = 1; //!< Field strength
 constexpr real_type kelvin     = 1; //!< Temperature
 //!@}
 
@@ -55,18 +55,19 @@ constexpr real_type kelvin     = 1; //!< Temperature
 //! \name Exact unit transformations for SI units
 constexpr real_type meter    = 100 * centimeter;
 constexpr real_type kilogram = 1000 * gram;
+constexpr real_type tesla    = 10000 * gauss;
 constexpr real_type newton   = kilogram * meter / (second * second);
 constexpr real_type joule    = newton * meter;
+constexpr real_type coulomb  = kilogram / (tesla * second);
 constexpr real_type ampere   = coulomb / second;
 constexpr real_type volt     = joule / coulomb;
-constexpr real_type tesla    = kilogram / (coulomb * second);
 constexpr real_type farad    = coulomb / volt;
 //!@}
 
 //!@{
 //! \name Other common units
-constexpr real_type millimeter = 0.1 * centimeter;
-constexpr real_type barn       = 1e-24 * centimeter * centimeter;
+constexpr real_type millimeter = real_type(0.1) * centimeter;
+constexpr real_type barn       = real_type(1e-24) * centimeter * centimeter;
 //!@}
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/Units.hh
+++ b/src/celeritas/Units.hh
@@ -29,9 +29,9 @@ namespace units
  * the different code components of Celeritas.
  *
  * \note This system of units should be fully consistent so that constants can
- * be precisely defined. (E.g. you cannot define both MeV as 1 and Joule as 1.)
- * To express quantities in another system of units, e.g. MeV, use the Quantity
- * class.
+ * be precisely defined. (E.g., you cannot define both MeV as 1 and Joule
+ * as 1.) To express quantities in another system of units, e.g. MeV, use the
+ * Quantity class.
  *
  * See also:
  *  - \c Constants.hh for constants defined in this unit system
@@ -43,16 +43,16 @@ namespace units
  */
 
 //!@{
-//! Units with numerical value defined to be 1
-constexpr real_type centimeter = 1.; // Length
-constexpr real_type gram       = 1.; // Mass
-constexpr real_type second     = 1.; // Time
-constexpr real_type coulomb    = 1.; // Charge
-constexpr real_type kelvin     = 1.; // Temperature
+//! \name Units with numerical value defined to be 1
+constexpr real_type centimeter = 1; //!< Length
+constexpr real_type gram       = 1; //!< Mass
+constexpr real_type second     = 1; //!< Time
+constexpr real_type coulomb    = 1; //!< Charge
+constexpr real_type kelvin     = 1; //!< Temperature
 //!@}
 
 //!@{
-//! Exact unit transformations for SI units
+//! \name Exact unit transformations for SI units
 constexpr real_type meter    = 100 * centimeter;
 constexpr real_type kilogram = 1000 * gram;
 constexpr real_type newton   = kilogram * meter / (second * second);
@@ -64,7 +64,7 @@ constexpr real_type farad    = coulomb / volt;
 //!@}
 
 //!@{
-//! Other units
+//! \name Other common units
 constexpr real_type millimeter = 0.1 * centimeter;
 constexpr real_type barn       = 1e-24 * centimeter * centimeter;
 //!@}

--- a/test/celeritas/Constants.test.cc
+++ b/test/celeritas/Constants.test.cc
@@ -119,7 +119,7 @@ TEST(UnitsTest, equivalence)
     EXPECT_EQ(real_type(1), erg);
     EXPECT_EQ(1e7 * erg, joule);
 
-    EXPECT_DOUBLE_EQ(1e3, tesla);
+    EXPECT_DOUBLE_EQ(1e4, tesla);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1254,7 +1254,8 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         {
             // Repeated substep bisection failed; particle is bumped
             EXPECT_SOFT_EQ(1e-6, result.distance);
-            EXPECT_EQ(102, stepper.count());
+            // Minor floating point differences could make this 102 or 103
+            EXPECT_SOFT_NEAR(real_type(103), real_type(stepper.count()), 0.02);
         }
     }
 }

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -203,7 +203,8 @@ struct HorribleZField
 
 // Field value (native units) for 10 MeV electron/positron to have a radius of
 // 1 cm
-constexpr real_type unit_radius_field_strength{3501.9461121752274};
+constexpr real_type unit_radius_field_strength{3.5019461121752274
+                                               * units::tesla};
 
 //---------------------------------------------------------------------------//
 // TESTS
@@ -386,7 +387,7 @@ TEST_F(TwoBoxTest, gamma_pathological)
                                         MevEnergy{1});
 
     // Construct field (shape and magnitude shouldn't matter)
-    HorribleZField     field{1234.5, 5};
+    HorribleZField     field{1.2345 * units::tesla, 5};
     FieldDriverOptions driver_options;
     auto               stepper = make_mag_field_stepper<DiagnosticDPStepper>(
         field, particle.charge());
@@ -1119,7 +1120,7 @@ TEST_F(SimpleCmsTest, electron_stuck)
 {
     auto particle = this->init_particle(this->particle()->find(pdg::electron()),
                                         MevEnergy{4.25402379798713e-01});
-    UniformZField      field(1000);
+    UniformZField      field(1 * units::tesla);
     FieldDriverOptions driver_options;
 
     auto geo = this->init_geo(
@@ -1184,7 +1185,7 @@ TEST_F(SimpleCmsTest, electron_stuck)
 
 TEST_F(SimpleCmsTest, vecgeom_failure)
 {
-    UniformZField      field(1000);
+    UniformZField      field(1 * units::tesla);
     FieldDriverOptions driver_options;
 
     auto geo = this->init_geo({1.23254142755319734e+02,

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -286,9 +286,9 @@ TEST_F(TwoBoxTest, electron_interior)
         result = propagate(1e-10);
         EXPECT_DOUBLE_EQ(1e-10, result.distance);
         EXPECT_FALSE(result.boundary);
-        EXPECT_VEC_SOFT_EQ(Real3({3.8085385881855, -2.3814749713353e-07, 0}),
-                           geo.pos());
-        EXPECT_VEC_SOFT_EQ(Real3({6.2529888474538e-08, 1, 0}), geo.dir());
+        EXPECT_VEC_NEAR(
+            Real3({3.8085385881855, -2.3814749713353e-07, 0}), geo.pos(), 1e-7);
+        EXPECT_VEC_NEAR(Real3({6.2529888474538e-08, 1, 0}), geo.dir(), 1e-7);
         EXPECT_EQ(1, stepper.count());
     }
 }

--- a/test/celeritas/field/Fields.test.cc
+++ b/test/celeritas/field/Fields.test.cc
@@ -48,24 +48,42 @@ TEST(CMSParameterizedFieldTest, all)
     real_type delta_z  = 25.0;
     real_type delta_r  = 12.0;
 
-    static const Real3 expected[nsamples]
-        = {{-0.000000, -0.000000, 3811.202302},
-           {0.609459, 0.609459, 3810.356958},
-           {2.458195, 2.458195, 3807.469253},
-           {5.463861, 5.463861, 3802.600730},
-           {9.587723, 9.587723, 3795.850658},
-           {14.834625, 14.834625, 3787.348683},
-           {21.253065, 21.253065, 3777.244454},
-           {28.935544, 28.935544, 3765.695087}};
+    std::vector<real_type> actual;
 
     for (int i : range(nsamples))
     {
-        // Get the field value at a given position
-        Real3 pos{i * delta_r, i * delta_r, i * delta_z};
-        EXPECT_VEC_NEAR(expected[i] * 1e-3 * units::tesla,
-                        calc_field(pos) * units::tesla,
-                        1.0e-6);
+        Real3 field = calc_field(Real3{i * delta_r, i * delta_r, i * delta_z});
+        for (real_type f : field)
+        {
+            actual.push_back(f / units::tesla);
+        }
     }
+
+    static const real_type expected_field[] = {-0,
+                                               -0,
+                                               3.8112023023834,
+                                               0.00060945895519578,
+                                               0.00060945895519578,
+                                               3.8103569576023,
+                                               0.0024581951993005,
+                                               0.0024581951993005,
+                                               3.8074692533866,
+                                               0.0054638612329989,
+                                               0.0054638612329989,
+                                               3.8026007301972,
+                                               0.0095877228523849,
+                                               0.0095877228523849,
+                                               3.7958506580647,
+                                               0.014834624748597,
+                                               0.014834624748597,
+                                               3.7873486828586,
+                                               0.021253065345318,
+                                               0.021253065345318,
+                                               3.7772444535824,
+                                               0.028935543902684,
+                                               0.028935543902684,
+                                               3.7656950871883};
+    EXPECT_VEC_SOFT_EQ(expected_field, actual);
 }
 
 TEST(CMSMapField, all)
@@ -90,24 +108,42 @@ TEST(CMSMapField, all)
     real_type delta_z  = 25.0;
     real_type delta_r  = 12.0;
 
-    static const Real3 expected[nsamples]
-        = {{-0.000000, -0.000000, 3811.202288},
-           {-0.0475228, -0.0475228, 3806.21},
-           {-0.0950456, -0.0950456, 3801.22},
-           {-0.1425684, -0.1425684, 3796.23},
-           {9.49396, 9.49396, 3791.24},
-           {11.86745, 11.86745, 3775.99},
-           {14.241, 14.241, 3771.88},
-           {16.6149, 16.6149, 3757.2}};
+    std::vector<real_type> actual;
 
     for (int i : range(nsamples))
     {
-        // Get the field value at a given position
-        Real3 pos{i * delta_r, i * delta_r, i * delta_z};
-        EXPECT_VEC_NEAR(expected[i] * 1e-3 * units::tesla,
-                        calc_field(pos) * units::tesla,
-                        1.0e-6);
+        Real3 field = calc_field(Real3{i * delta_r, i * delta_r, i * delta_z});
+        for (real_type f : field)
+        {
+            actual.push_back(f / units::tesla);
+        }
     }
+
+    static const real_type expected_field[] = {-0,
+                                               -0,
+                                               3.811202287674,
+                                               -4.7522817039862e-05,
+                                               -4.7522817039862e-05,
+                                               3.8062113523483,
+                                               -9.5045634079725e-05,
+                                               -9.5045634079725e-05,
+                                               3.8012204170227,
+                                               -0.00014256845111959,
+                                               -0.00014256845111959,
+                                               3.7962294816971,
+                                               0.0094939613342285,
+                                               0.0094939613342285,
+                                               3.7912385463715,
+                                               0.011867451667786,
+                                               0.011867451667786,
+                                               3.775991499424,
+                                               0.014240986622126,
+                                               0.014240986622126,
+                                               3.771880030632,
+                                               0.016614892251046,
+                                               0.016614892251046,
+                                               3.757196366787};
+    EXPECT_VEC_SOFT_EQ(expected_field, actual);
 }
 //---------------------------------------------------------------------------//
 } // namespace test

--- a/test/celeritas/field/Fields.test.cc
+++ b/test/celeritas/field/Fields.test.cc
@@ -62,7 +62,9 @@ TEST(CMSParameterizedFieldTest, all)
     {
         // Get the field value at a given position
         Real3 pos{i * delta_r, i * delta_r, i * delta_z};
-        EXPECT_VEC_NEAR(expected[i], calc_field(pos), 1.0e-6);
+        EXPECT_VEC_NEAR(expected[i] * 1e-3 * units::tesla,
+                        calc_field(pos) * units::tesla,
+                        1.0e-6);
     }
 }
 
@@ -102,7 +104,9 @@ TEST(CMSMapField, all)
     {
         // Get the field value at a given position
         Real3 pos{i * delta_r, i * delta_r, i * delta_z};
-        EXPECT_VEC_NEAR(expected[i], calc_field(pos), 1.0e-6);
+        EXPECT_VEC_NEAR(expected[i] * 1e-3 * units::tesla,
+                        calc_field(pos) * units::tesla,
+                        1.0e-6);
     }
 }
 //---------------------------------------------------------------------------//

--- a/test/celeritas/field/MagFieldEquation.test.cc
+++ b/test/celeritas/field/MagFieldEquation.test.cc
@@ -51,7 +51,7 @@ TEST(MagFieldEquationTest, charged)
     {
         OdeState result = eval({{1, 2, 3}, {0, 0, 1}});
         EXPECT_VEC_SOFT_EQ(Real3({0, 0, 1}), result.pos);
-        EXPECT_VEC_SOFT_EQ(Real3({-0.02698132122, 0.00899377374, 0}),
+        EXPECT_VEC_SOFT_EQ(Real3({-0.002698132122, 0.000899377374, 0}),
                            result.mom);
     }
     {
@@ -59,9 +59,10 @@ TEST(MagFieldEquationTest, charged)
         EXPECT_VEC_SOFT_EQ(
             Real3({0.26726124191242, 0.53452248382485, 0.80178372573727}),
             result.pos);
-        EXPECT_VEC_SOFT_EQ(
-            Real3({0.012018435696159, -0.009614748556927, 0.0024036871392318}),
-            result.mom);
+        EXPECT_VEC_SOFT_EQ(Real3({0.0012018435696159,
+                                  -0.0009614748556927,
+                                  0.00024036871392318}),
+                           result.mom);
     }
     if (CELERITAS_DEBUG)
     {

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -123,7 +123,7 @@ class TestEm15FieldTest : public TestEm15Base, public StepperTestBase
     {
         CELER_EXPECT(!this->enable_fluctuation());
         UniformFieldParams field_params;
-        field_params.field = {0, 0, 1};
+        field_params.field = {0, 0, 1e-3 * units::tesla};
         auto result        = AlongStepUniformMscAction::from_params(
             *this->physics(), field_params, this->action_mgr().get());
         CELER_ENSURE(result);


### PR DESCRIPTION
Defining the Coulomb to have a magnitude of 1 in the Celeritas internal unit system was kind of arbitrary, and not very consistent with choosing cm/g instead of m/kg . Since `gauss` is the appropriate field strength unit for the [CGS-EMU system](https://en.wikipedia.org/wiki/Gauss_(unit)) we should probably use that instead. The updated unit system uses the gauss as a primary definition, and derives current/charge (A/C) from that.

Since users clearly expect tesla to be the field strength unit, change the LDemoIO input so that it is defined in units of Tesla regardless of the internal unit system.