### PR TITLE
Don't slow particles to zero when hitting boundary

### DIFF
--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -26,6 +26,15 @@
       }
     },
     {
+      "name": ".reldeb",
+      "hidden": true,
+      "description": "Enable debug with basic optimizations",
+      "cacheVariables": {
+        "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "ON"},
+        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "RelWithDebInfo"}
+      }
+    },
+    {
       "name": "acceleritas",
       "displayName": "Everything in release mode",
       "inherits": [".ndebug", ".base"],
@@ -70,41 +79,41 @@
       }
     },
     {
-      "name": "ndebug",
+      "name": "reldeb",
       "displayName": "Everything but vecgeom in release mode",
-      "inherits": [".ndebug", ".base"]
+      "inherits": [".reldeb", ".base"]
     },
     {
-      "name": "ndebug-vecgeom",
+      "name": "reldeb-vecgeom",
       "displayName": "Everything in release mode",
-      "inherits": [".ndebug", "vecgeom"],
+      "inherits": [".reldeb", "vecgeom"],
       "cacheVariables": {
         "CELERITAS_LAUNCH_BOUNDS":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_RNG": "XORWOW"
       }
     },
     {
-      "name": "ndebug-serial",
+      "name": "reldeb-serial",
       "displayName": "Release, OpenMP is disabled",
-      "inherits": [".ndebug", ".base"],
+      "inherits": [".reldeb", ".base"],
       "cacheVariables": {
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_OpenMP": {"type": "BOOL", "value": "OFF"}
       }
     },
     {
-      "name": "ndebug-nocuda",
+      "name": "reldeb-nocuda",
       "displayName": "Forcibly disable CUDA mode",
-      "inherits": [".ndebug", ".base"],
+      "inherits": [".reldeb", ".base"],
       "cacheVariables": {
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_CUDA": {"type": "BOOL", "value": "OFF"}
       }
     },
     {
-      "name": "ndebug-vecgeom-serial",
+      "name": "reldeb-vecgeom-serial",
       "displayName": "Everything but openmp in release mode",
-      "inherits": [".ndebug", "vecgeom"],
+      "inherits": [".reldeb", "vecgeom"],
       "cacheVariables": {
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_OpenMP": {"type": "BOOL", "value": "OFF"}
@@ -120,8 +129,8 @@
     },
     {"name": "serial", "configurePreset": "serial", "inherits": "base"},
     {"name": "vecgeom", "configurePreset": "vecgeom", "inherits": "base"},
-    {"name": "ndebug-vecgeom", "configurePreset": "ndebug-vecgeom", "inherits": "base"},
-    {"name": "ndebug", "configurePreset": "ndebug", "inherits": "base"}
+    {"name": "reldeb-vecgeom", "configurePreset": "reldeb-vecgeom", "inherits": "base"},
+    {"name": "reldeb", "configurePreset": "reldeb", "inherits": "base"}
   ],
   "testPresets": [
     {
@@ -131,8 +140,8 @@
       "execution": {"noTestsAction": "error", "stopOnFailure": false, "jobs": 32}
     },
     {"name": "serial", "configurePreset": "serial", "inherits": "base"},
-    {"name": "ndebug-vecgeom", "configurePreset": "ndebug-vecgeom", "inherits": "base"},
+    {"name": "reldeb-vecgeom", "configurePreset": "reldeb-vecgeom", "inherits": "base"},
     {"name": "vecgeom", "configurePreset": "vecgeom", "inherits": "base"},
-    {"name": "ndebug", "configurePreset": "ndebug", "inherits": "base"}
+    {"name": "reldeb", "configurePreset": "reldeb", "inherits": "base"}
   ]
 }

--- a/src/celeritas/global/alongstep/detail/EnergyLossApplier.hh
+++ b/src/celeritas/global/alongstep/detail/EnergyLossApplier.hh
@@ -53,12 +53,14 @@ CELER_FUNCTION void EnergyLossApplier::operator()(CoreTrackView const& track,
 
     auto   particle = track.make_particle_view();
     Energy eloss;
-    if (particle.energy() < phys.scalars().eloss_calc_limit)
+    if (particle.energy() < phys.scalars().eloss_calc_limit
+        && step_limit->action != track.boundary_action())
     {
-        // Immediately stop low-energy particles
+        // Immediately stop low-energy tracks (as long as they're not crossing
+        // a boundary)
         // TODO: this should happen before creating tracks from secondaries
         // *OR* after slowing down tracks: duplicated in
-        // EnergyLossApplier.hh
+        // EnergyLossFluctApplier.hh
         eloss = particle.energy();
     }
     else

--- a/src/celeritas/global/alongstep/detail/EnergyLossFluctApplier.hh
+++ b/src/celeritas/global/alongstep/detail/EnergyLossFluctApplier.hh
@@ -77,9 +77,11 @@ EnergyLossFluctApplier::operator()(CoreTrackView const& track,
     Energy eloss;
 
     auto particle = track.make_particle_view();
-    if (particle.energy() < phys.scalars().eloss_calc_limit)
+    if (particle.energy() < phys.scalars().eloss_calc_limit
+        && step_limit->action != track.boundary_action())
     {
-        // Immediately stop low-energy particles
+        // Immediately stop low-energy tracks (as long as they're not crossing
+        // a boundary)
         // TODO: this should happen before creating tracks from secondaries
         // *OR* after slowing down tracks: duplicated in
         // EnergyLossApplier.hh


### PR DESCRIPTION
The hard kinetic energy cutoff (user defined, defaults to 1 keV) reduces the steps due to low energy particles. If it's applied to particles that are undergoing a geometry-limited step, it will kill them, which can cause positrons to emit gammas exactly on a boundary. This is a nonphysical bias: the particles should continue into the next volume.

Closes #523. 