### PR TITLE
Calculate range properties of multiple scattering at the first step in every tracking step  

### DIFF
--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -35,7 +35,7 @@ struct UrbanMscParameters
     real_type range_fact{0.04}; //!< range_factor for e-/e+ (0.2 for muon/h)
     real_type safety_fact{0.6}; //!< safety factor
     real_type safety_tol{0.01}; //!< safety tolerance
-    real_type geom_limit{5e-8 * units::millimeter}; //!< minimum step
+    real_type geom_limit{5e-9 * units::millimeter}; //!< minimum step
     Energy    low_energy_limit{1e-5};               //!< 10 eV
     Energy    high_energy_limit{1e+2};              //!< 100 MeV
 

--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -35,9 +35,10 @@ struct UrbanMscParameters
     real_type range_fact{0.04}; //!< range_factor for e-/e+ (0.2 for muon/h)
     real_type safety_fact{0.6}; //!< safety factor
     real_type safety_tol{0.01}; //!< safety tolerance
-    real_type geom_limit{5e-9 * units::millimeter}; //!< minimum step
-    Energy    low_energy_limit{1e-5};               //!< 10 eV
-    Energy    high_energy_limit{1e+2};              //!< 100 MeV
+    real_type geom_limit{5e-8 * units::millimeter};    //!< minimum step
+    real_type safety_limit{1e-11 * units::millimeter}; //!< minimum safety
+    Energy    low_energy_limit{1e-5};                  //!< 10 eV
+    Energy    high_energy_limit{1e+2};                 //!< 100 MeV
 
     //! A scale factor for the range
     static CELER_CONSTEXPR_FUNCTION real_type dtrl() { return 5e-2; }

--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -35,10 +35,9 @@ struct UrbanMscParameters
     real_type range_fact{0.04}; //!< range_factor for e-/e+ (0.2 for muon/h)
     real_type safety_fact{0.6}; //!< safety factor
     real_type safety_tol{0.01}; //!< safety tolerance
-    real_type geom_limit{5e-8 * units::millimeter};    //!< minimum step
-    real_type safety_limit{1e-11 * units::millimeter}; //!< minimum safety
-    Energy    low_energy_limit{1e-5};                  //!< 10 eV
-    Energy    high_energy_limit{1e+2};                 //!< 100 MeV
+    real_type geom_limit{5e-8 * units::millimeter}; //!< minimum step
+    Energy    low_energy_limit{1e-5};               //!< 10 eV
+    Energy    high_energy_limit{1e+2};              //!< 100 MeV
 
     //! A scale factor for the range
     static CELER_CONSTEXPR_FUNCTION real_type dtrl() { return 5e-2; }

--- a/src/celeritas/em/distribution/UrbanMscScatter.hh
+++ b/src/celeritas/em/distribution/UrbanMscScatter.hh
@@ -377,7 +377,8 @@ CELER_FUNCTION real_type UrbanMscScatter::sample_cos_theta(Engine&   rng,
         // Sampling of cos(theta)
         if (generate_canonical(rng) < qprob)
         {
-            if (BernoulliDistribution(prob)(rng))
+            // Note: prob is sometime a little greater than one
+            if (generate_canonical(rng) < prob)
             {
                 // Sample \f$ \cos\theta \f$ from \f$ g_1(\cos\theta) \f$
                 UniformRealDistribution<real_type> sample_inner(ea, 1);

--- a/src/celeritas/em/distribution/UrbanMscScatter.hh
+++ b/src/celeritas/em/distribution/UrbanMscScatter.hh
@@ -158,7 +158,7 @@ UrbanMscScatter::UrbanMscScatter(const UrbanMscRef&       shared,
     , helper_(shared, particle, physics)
     , is_displaced_(input.is_displaced && !geo_limited)
     , geom_path_(input.geom_path)
-    , limit_min_(input.limit_min)
+    , limit_min_(physics.msc_range().limit_min)
     , geometry_(*geometry)
 {
     CELER_EXPECT(particle.particle_id() == shared.ids.electron

--- a/src/celeritas/em/distribution/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/distribution/UrbanMscStepLimit.hh
@@ -52,7 +52,7 @@ class UrbanMscStepLimit
                                             const ParticleTrackView& particle,
                                             PhysicsTrackView*        physics,
                                             MaterialId               matid,
-                                            bool      is_first_step,
+                                            bool      on_boundary,
                                             real_type safety,
                                             real_type phys_step);
 
@@ -122,7 +122,7 @@ UrbanMscStepLimit::UrbanMscStepLimit(const UrbanMscRef&       shared,
                                      const ParticleTrackView& particle,
                                      PhysicsTrackView*        physics,
                                      MaterialId               matid,
-                                     bool                     is_first_step,
+                                     bool                     on_boundary,
                                      real_type                safety,
                                      real_type                phys_step)
     : shared_(shared)
@@ -134,7 +134,7 @@ UrbanMscStepLimit::UrbanMscStepLimit(const UrbanMscRef&       shared,
     , msc_(shared_.msc_data[matid])
     , helper_(shared, particle, physics_)
     , msc_range_(physics_.msc_range())
-    , on_boundary_(is_first_step || safety_ <= shared.params.safety_limit)
+    , on_boundary_(on_boundary)
     , phys_step_(phys_step)
     , range_(physics_.dedx_range())
 {
@@ -188,7 +188,7 @@ CELER_FUNCTION auto UrbanMscStepLimit::operator()(Engine& rng) -> MscStep
     // TODO: add options for other algorithms (see G4MscStepLimitType.hh)
 
     // Initialisation at the first step or at the boundary
-    if (on_boundary_ || !msc_range_)
+    if (!msc_range_ || on_boundary_)
     {
         msc_range_.range_fact = params_.range_fact;
         msc_range_.range_init = max<real_type>(range_, lambda_);

--- a/src/celeritas/global/alongstep/detail/UrbanMsc.hh
+++ b/src/celeritas/global/alongstep/detail/UrbanMsc.hh
@@ -101,14 +101,13 @@ CELER_FUNCTION void UrbanMsc::calc_step(CoreTrackView const& track,
     auto particle = track.make_particle_view();
     auto geo      = track.make_geo_view();
     auto phys     = track.make_physics_view();
-    auto sim      = track.make_sim_view();
 
     // Sample multiple scattering step length
     UrbanMscStepLimit msc_step_limit(msc_params_,
                                      particle,
                                      &phys,
                                      track.make_material_view().material_id(),
-                                     sim.num_steps() == 0,
+                                     geo.is_on_boundary(),
                                      geo.find_safety(),
                                      local->step_limit.step);
 

--- a/src/celeritas/global/alongstep/detail/UrbanMsc.hh
+++ b/src/celeritas/global/alongstep/detail/UrbanMsc.hh
@@ -106,7 +106,7 @@ CELER_FUNCTION void UrbanMsc::calc_step(CoreTrackView const& track,
     // Sample multiple scattering step length
     UrbanMscStepLimit msc_step_limit(msc_params_,
                                      particle,
-                                     phys,
+                                     &phys,
                                      track.make_material_view().material_id(),
                                      sim.num_steps() == 0,
                                      geo.find_safety(),
@@ -114,20 +114,17 @@ CELER_FUNCTION void UrbanMsc::calc_step(CoreTrackView const& track,
 
     auto rng             = track.make_rng_engine();
     auto msc_step_result = msc_step_limit(rng);
-    track.make_physics_step_view().msc_step(msc_step_result.msc_step);
-
-    // Store range properties for multiple scattering
-    phys.msc_range(msc_step_result.msc_range);
+    track.make_physics_step_view().msc_step(msc_step_result);
 
     // Use "straight line" path calculated for geometry step
-    local->geo_step = msc_step_result.msc_step.geom_path;
+    local->geo_step = msc_step_result.geom_path;
 
-    if (msc_step_result.msc_step.true_path < local->step_limit.step)
+    if (msc_step_result.true_path < local->step_limit.step)
     {
         // True/physical step might be further limited by MSC
         // TODO: this is already kinda sorta determined inside the
         // UrbanMscStepLimit calculation
-        local->step_limit.step   = msc_step_result.msc_step.true_path;
+        local->step_limit.step   = msc_step_result.true_path;
         local->step_limit.action = msc_params_.ids.action;
     }
 }

--- a/src/celeritas/phys/Interaction.hh
+++ b/src/celeritas/phys/Interaction.hh
@@ -76,8 +76,36 @@ struct MscStep
     real_type phys_step{};        //!< Step length from physics processes
     real_type true_path{};        //!< True path length due to the msc
     real_type geom_path{};        //!< Geometrical path length
-    real_type limit_min{};        //!< Minimum of the true path limit
     real_type alpha{-1};          //!< An effecive mfp rate by distance
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Persistent range properties for multiple scattering (msc) within a volume.
+ *
+ * These values are calculated at the first step in every msc tracking volume
+ * and reused at subsequent steps within the same volume.
+ */
+struct MscRange
+{
+    real_type range_init{}; //!< Initial msc range
+    real_type range_fact{}; //!< Scale factor for the msc range
+    real_type limit_min{};  //!< Minimum of the true path limit
+
+    CELER_FUNCTION bool is_filled() const
+    {
+        return range_init > 0 && range_fact > 0 && limit_min > 0;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Result of the step limitation of multiple scattering.
+ */
+struct MscStepLimit
+{
+    MscStep  msc_step;
+    MscRange msc_range;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/Interaction.hh
+++ b/src/celeritas/phys/Interaction.hh
@@ -92,20 +92,10 @@ struct MscRange
     real_type range_fact{}; //!< Scale factor for the msc range
     real_type limit_min{};  //!< Minimum of the true path limit
 
-    CELER_FUNCTION bool is_filled() const
+    explicit CELER_FUNCTION operator bool() const
     {
         return range_init > 0 && range_fact > 0 && limit_min > 0;
     }
-};
-
-//---------------------------------------------------------------------------//
-/*!
- * Result of the step limitation of multiple scattering.
- */
-struct MscStepLimit
-{
-    MscStep  msc_step;
-    MscRange msc_range;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -378,6 +378,7 @@ struct PhysicsTrackState
     real_type macro_xs; //!< Total cross section for discrete interactions
     real_type energy_deposition; //!< Local energy deposition in a step [MeV]
     real_type dedx_range;        //!< Local energy loss range [cm]
+    MscRange  msc_range;         //!< Range properties for multiple scattering
     Span<Secondary>    secondaries; //!< Emitted secondaries
     ElementComponentId element;     //!< Element sampled for interaction
 };

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -204,6 +204,7 @@ CELER_FUNCTION PhysicsTrackView&
 PhysicsTrackView::operator=(const Initializer_t&)
 {
     this->state().interaction_mfp = 0;
+    this->state().msc_range       = {};
     return *this;
 }
 

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -64,7 +64,7 @@ class PhysicsTrackView
     inline CELER_FUNCTION void dedx_range(real_type);
 
     // Set the range properties for multiple scattering
-    inline CELER_FUNCTION void msc_range(MscRange);
+    inline CELER_FUNCTION void msc_range(const MscRange&);
 
     //// DYNAMIC PROPERTIES (pure accessors, free) ////
 
@@ -78,7 +78,7 @@ class PhysicsTrackView
     CELER_FORCEINLINE_FUNCTION real_type dedx_range() const;
 
     // Range properties for multiple scattering
-    CELER_FORCEINLINE_FUNCTION MscRange msc_range() const;
+    CELER_FORCEINLINE_FUNCTION const MscRange& msc_range() const;
 
     //// PROCESSES (depend on particle type and possibly material) ////
 
@@ -248,7 +248,7 @@ CELER_FUNCTION void PhysicsTrackView::dedx_range(real_type range)
  *
  * These values will be calculated at the first step in every tracking volume.
  */
-CELER_FUNCTION void PhysicsTrackView::msc_range(MscRange msc_range)
+CELER_FUNCTION void PhysicsTrackView::msc_range(const MscRange& msc_range)
 {
     this->state().msc_range = msc_range;
 }
@@ -288,10 +288,9 @@ CELER_FUNCTION real_type PhysicsTrackView::dedx_range() const
 /*!
  * Persistent range properties for multiple scattering within a same volume.
  */
-CELER_FUNCTION MscRange PhysicsTrackView::msc_range() const
+CELER_FUNCTION const MscRange& PhysicsTrackView::msc_range() const
 {
-    MscRange msc_range = this->state().msc_range;
-    return msc_range;
+    return this->state().msc_range;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -63,6 +63,9 @@ class PhysicsTrackView
     // Set the energy loss range for the current material and particle energy
     inline CELER_FUNCTION void dedx_range(real_type);
 
+    // Set the range properties for multiple scattering
+    inline CELER_FUNCTION void msc_range(MscRange);
+
     //// DYNAMIC PROPERTIES (pure accessors, free) ////
 
     // Whether the remaining MFP has been calculated
@@ -73,6 +76,9 @@ class PhysicsTrackView
 
     // Energy loss range for the current material and particle energy
     CELER_FORCEINLINE_FUNCTION real_type dedx_range() const;
+
+    // Range properties for multiple scattering
+    CELER_FORCEINLINE_FUNCTION MscRange msc_range() const;
 
     //// PROCESSES (depend on particle type and possibly material) ////
 
@@ -238,6 +244,17 @@ CELER_FUNCTION void PhysicsTrackView::dedx_range(real_type range)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Set the range properties for multiple scattering.
+ *
+ * These values will be calculated at the first step in every tracking volume.
+ */
+CELER_FUNCTION void PhysicsTrackView::msc_range(MscRange msc_range)
+{
+    this->state().msc_range = msc_range;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Whether the remaining MFP has been calculated.
  */
 CELER_FUNCTION bool PhysicsTrackView::has_interaction_mfp() const
@@ -265,6 +282,16 @@ CELER_FUNCTION real_type PhysicsTrackView::dedx_range() const
     real_type range = this->state().dedx_range;
     CELER_ENSURE(range > 0);
     return range;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Persistent range properties for multiple scattering within a same volume.
+ */
+CELER_FUNCTION MscRange PhysicsTrackView::msc_range() const
+{
+    MscRange msc_range = this->state().msc_range;
+    return msc_range;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -308,7 +308,7 @@ TEST_F(UrbanMscTest, msc_scattering)
                                        *part_view_,
                                        &phys,
                                        material_view.material_id(),
-                                       sim_track_view.num_steps() == 0,
+                                       geo_view.is_on_boundary(),
                                        geo_view.find_safety(),
                                        step[i]);
 

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -236,7 +236,7 @@ TEST_F(UrbanMscTest, msc_scattering)
     EXPECT_DOUBLE_EQ(msc_.d_over_r_mh, 1.1248191999999999);
 
     // Test the step limitation algorithm and the msc sample scattering
-    MscStepLimit   step_result;
+    MscStep        step_result;
     MscInteraction sample_result;
 
     // Input
@@ -306,7 +306,7 @@ TEST_F(UrbanMscTest, msc_scattering)
 
         UrbanMscStepLimit step_limiter(model->host_ref(),
                                        *part_view_,
-                                       phys,
+                                       &phys,
                                        material_view.material_id(),
                                        sim_track_view.num_steps() == 0,
                                        geo_view.find_safety(),
@@ -319,7 +319,7 @@ TEST_F(UrbanMscTest, msc_scattering)
                                 &geo_view,
                                 phys,
                                 material_view,
-                                step_result.msc_step,
+                                step_result,
                                 /* geo_limited = */ false);
 
         sample_result = scatter(rng_engine);

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -236,7 +236,7 @@ TEST_F(UrbanMscTest, msc_scattering)
     EXPECT_DOUBLE_EQ(msc_.d_over_r_mh, 1.1248191999999999);
 
     // Test the step limitation algorithm and the msc sample scattering
-    MscStep        step_result;
+    MscStepLimit   step_result;
     MscInteraction sample_result;
 
     // Input
@@ -308,6 +308,7 @@ TEST_F(UrbanMscTest, msc_scattering)
                                        *part_view_,
                                        phys,
                                        material_view.material_id(),
+                                       sim_track_view.num_steps() == 0,
                                        geo_view.find_safety(),
                                        step[i]);
 
@@ -318,7 +319,7 @@ TEST_F(UrbanMscTest, msc_scattering)
                                 &geo_view,
                                 phys,
                                 material_view,
-                                step_result,
+                                step_result.msc_step,
                                 /* geo_limited = */ false);
 
         sample_result = scatter(rng_engine);

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -398,7 +398,7 @@ TEST_F(TestEm3MscNofluctTest, host)
         EXPECT_EQ(69, result.num_step_iters());
         if (CELERITAS_USE_VECGEOM)
         {
-            EXPECT_SOFT_EQ(60.5, result.calc_avg_steps_per_primary());
+            EXPECT_SOFT_EQ(58.125, result.calc_avg_steps_per_primary());
         }
         else
         {


### PR DESCRIPTION
This MR intends to resolve remaining issues of multiple scattering and to verify physics results of multiple scattering including the total number of steps.
* Add MscRange (persistent properties within a volume) for multiple scattering to PhysicsTrackState and associated accessors to PhysicsTrackView
* Calculate MscRange in UrbanMscStepLimit at the first step in every tracking volume and reuse them at subsequent steps within the same volume
* Other related updates

See comparisons of MSC related distributions of positrons between celeritas (demo-loop) and Geant4 (g4app) with testem3-flat.gdml and 100 events of 10 GeV electrons: 
![msc-val](https://user-images.githubusercontent.com/26611211/195932673-c054105e-156a-4b69-b045-ad708fc307d6.png)
![msc-info](https://user-images.githubusercontent.com/26611211/195933186-90e991e4-f939-4c27-bca6-b7585fd52d28.png)
