### PR TITLE
Support adding primaries at any step in the transport loop

### DIFF
--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -46,6 +46,7 @@ struct LDemoArgs
     size_type    max_num_tracks{};
     size_type    max_steps = TransporterInput::no_max_steps();
     size_type    initializer_capacity{};
+    size_type    max_events{};
     real_type    secondary_stack_factor{};
     bool         enable_diagnostics{};
     bool         use_device{};
@@ -74,7 +75,8 @@ struct LDemoArgs
         return !geometry_filename.empty() && !physics_filename.empty()
                && (primary_gen_options || !hepmc3_filename.empty())
                && max_num_tracks > 0 && max_steps > 0
-               && initializer_capacity > 0 && secondary_stack_factor > 0
+               && initializer_capacity > 0 && max_events > 0
+               && secondary_stack_factor > 0
                && (mag_field == no_field() || field_options);
     }
 };

--- a/app/demo-loop/Transporter.cc
+++ b/app/demo-loop/Transporter.cc
@@ -156,7 +156,7 @@ Transporter<M>::Transporter(TransporterInput inp)
  * Transport the input primaries and all secondaries produced.
  */
 template<MemSpace M>
-TransporterResult Transporter<M>::operator()(VecPrimary primaries)
+TransporterResult Transporter<M>::operator()(const VecPrimary& primaries)
 {
     Stopwatch get_transport_time;
 
@@ -180,17 +180,16 @@ TransporterResult Transporter<M>::operator()(VecPrimary primaries)
     CELER_LOG(status) << "Transporting";
 
     StepperInput input;
-    input.params             = input_.params;
-    input.num_track_slots    = input_.num_track_slots;
-    input.num_initializers   = input_.num_initializers;
-    input.sync               = input_.sync;
+    input.params          = input_.params;
+    input.num_track_slots = input_.num_track_slots;
+    input.sync            = input_.sync;
     Stepper<M> step(std::move(input));
 
     Stopwatch get_step_time;
     size_type remaining_steps = input_.max_steps;
 
     // Copy primaries to device and transport the first step
-    auto track_counts = step(std::move(primaries));
+    auto track_counts = step(primaries);
     append_track_counts(track_counts);
     result.time.steps.push_back(get_step_time());
 

--- a/app/demo-loop/Transporter.hh
+++ b/app/demo-loop/Transporter.hh
@@ -57,8 +57,7 @@ struct TransporterInput
 
     // Stepper input
     std::shared_ptr<const CoreParams> params;
-    size_type num_track_slots{};  //!< AKA max_num_tracks
-    size_type num_initializers{}; //!< AKA initializer_capacity
+    size_type num_track_slots{}; //!< AKA max_num_tracks
     bool      sync{false};
 
     // Loop control
@@ -71,8 +70,7 @@ struct TransporterInput
     //! True if all params are assigned
     explicit operator bool() const
     {
-        return params && num_track_slots > 0 && num_initializers > 0
-               && max_steps > 0;
+        return params && num_track_slots > 0 && max_steps > 0;
     }
 };
 
@@ -151,7 +149,7 @@ class TransporterBase
     virtual ~TransporterBase() = 0;
 
     // Transport the input primaries and all secondaries produced
-    virtual TransporterResult operator()(VecPrimary primaries) = 0;
+    virtual TransporterResult operator()(const VecPrimary& primaries) = 0;
 
     //! Access input parameters (TODO hacky)
     const CoreParams& params() const { return *input_.params; }
@@ -173,7 +171,7 @@ class Transporter final : public TransporterBase
     explicit Transporter(TransporterInput inp);
 
     // Transport the input primaries and all secondaries produced
-    TransporterResult operator()(VecPrimary primaries) final;
+    TransporterResult operator()(const VecPrimary& primaries) final;
 
   private:
     std::shared_ptr<DiagnosticStore> diagnostics_;

--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -117,7 +117,7 @@ void run(std::istream* is, OutputManager* output)
             event = read_event();
         }
     }
-    result = (*transport_ptr)(std::move(primaries));
+    result = (*transport_ptr)(primaries);
 
     result.time.setup = setup_time;
 

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -72,6 +72,7 @@ inp = {
     'max_num_tracks': num_tracks,
     'max_steps': max_steps,
     'initializer_capacity': 100 * max([num_tracks, num_primaries]),
+    'max_events': 1000,
     'secondary_stack_factor': 3,
     'enable_diagnostics': True,
     'sync': True,

--- a/cmake/CeleritasGen/gen-trackinit.py
+++ b/cmake/CeleritasGen/gen-trackinit.py
@@ -28,9 +28,9 @@ HH_TEMPLATE = """\
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
+#include "celeritas/global/CoreTrackData.hh"
 #include "celeritas/track/detail/{clsname}Launcher.hh" // IWYU pragma: associated
 {extra_includes}
-#include "celeritas/track/TrackInitData.hh"
 
 namespace celeritas
 {{
@@ -189,32 +189,29 @@ DEFS = {
     "InitTracks": KernelDefinition(
         Function("init_tracks", ParamList([
             Param("Core{Memspace}Ref", "core_data"),
-            Param("TrackInitState{Memspace}Ref", "init_data"),
             Param("size_type", "num_vacancies"),
         ])),
         "num_vacancies",
-        ["celeritas/global/CoreTrackData.hh"]),
+        []),
     "LocateAlive": KernelDefinition(
         Function("locate_alive", ParamList([
             Param("Core{Memspace}Ref", "core_data"),
-            Param("TrackInitState{Memspace}Ref", "init_data"),
         ])),
         "core_data.states.size()",
-        ["celeritas/global/CoreTrackData.hh"]),
+        []),
     "ProcessPrimaries": KernelDefinition(
         Function("process_primaries", ParamList([
+            Param("Core{Memspace}Ref", "core_data"),
             Param("Span<const Primary>", "primaries"),
-            Param("TrackInitState{Memspace}Ref", "init_data"),
         ])),
         "primaries.size()",
         ["corecel/cont/Span.hh", "celeritas/phys/Primary.hh"]),
     "ProcessSecondaries": KernelDefinition(
         Function("process_secondaries", ParamList([
             Param("Core{Memspace}Ref", "core_data"),
-            Param("TrackInitState{Memspace}Ref", "init_data"),
         ])),
         "core_data.states.size()",
-        ["celeritas/global/CoreTrackData.hh"]),
+        []),
 }
 
 def transformed_param_types(params, apply, **kwargs):

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -13,11 +13,12 @@
 #include "celeritas/geo/GeoMaterialParams.hh" // IWYU pragma: keep
 #include "celeritas/geo/GeoParams.hh"         // IWYU pragma: keep
 #include "celeritas/geo/generated/BoundaryAction.hh"
-#include "celeritas/mat/MaterialParams.hh"  // IWYU pragma: keep
-#include "celeritas/phys/CutoffParams.hh"   // IWYU pragma: keep
-#include "celeritas/phys/ParticleParams.hh" // IWYU pragma: keep
-#include "celeritas/phys/PhysicsParams.hh"  // IWYU pragma: keep
-#include "celeritas/random/RngParams.hh"    // IWYU pragma: keep
+#include "celeritas/mat/MaterialParams.hh"    // IWYU pragma: keep
+#include "celeritas/phys/CutoffParams.hh"     // IWYU pragma: keep
+#include "celeritas/phys/ParticleParams.hh"   // IWYU pragma: keep
+#include "celeritas/phys/PhysicsParams.hh"    // IWYU pragma: keep
+#include "celeritas/random/RngParams.hh"      // IWYU pragma: keep
+#include "celeritas/track/TrackInitParams.hh" // IWYU pragma: keep
 
 #include "ActionInterface.hh"
 #include "ActionRegistry.hh" // IWYU pragma: keep
@@ -46,6 +47,7 @@ build_params_refs(const CoreParams::Input& p, CoreScalars scalars)
     ref.cutoffs   = get_ref<M>(*p.cutoff);
     ref.physics   = get_ref<M>(*p.physics);
     ref.rng       = get_ref<M>(*p.rng);
+    ref.init      = get_ref<M>(*p.init);
 
     CELER_ENSURE(ref);
     return ref;
@@ -77,6 +79,7 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
     CP_VALIDATE_INPUT(cutoff);
     CP_VALIDATE_INPUT(physics);
     CP_VALIDATE_INPUT(rng);
+    CP_VALIDATE_INPUT(init);
     CP_VALIDATE_INPUT(action_reg);
 #undef CP_VALIDATE_INPUT
 

--- a/src/celeritas/global/CoreParams.hh
+++ b/src/celeritas/global/CoreParams.hh
@@ -44,6 +44,7 @@ class CoreParams
     using SPConstCutoff      = std::shared_ptr<const CutoffParams>;
     using SPConstPhysics     = std::shared_ptr<const PhysicsParams>;
     using SPConstRng         = std::shared_ptr<const RngParams>;
+    using SPConstTrackInit   = std::shared_ptr<const TrackInitParams>;
     using SPActionRegistry   = std::shared_ptr<ActionRegistry>;
     using SPConstAction      = std::shared_ptr<const ExplicitActionInterface>;
 
@@ -60,6 +61,7 @@ class CoreParams
         SPConstCutoff      cutoff;
         SPConstPhysics     physics;
         SPConstRng         rng;
+        SPConstTrackInit   init;
 
         SPActionRegistry action_reg;
 
@@ -67,7 +69,7 @@ class CoreParams
         explicit operator bool() const
         {
             return geometry && material && geomaterial && particle && cutoff
-                   && physics && rng && action_reg;
+                   && physics && rng && init && action_reg;
         }
     };
 
@@ -83,10 +85,11 @@ class CoreParams
     {
         return input_.geomaterial;
     }
-    const SPConstParticle& particle() const { return input_.particle; }
-    const SPConstCutoff&   cutoff() const { return input_.cutoff; }
+    const SPConstParticle&  particle() const { return input_.particle; }
+    const SPConstCutoff&    cutoff() const { return input_.cutoff; }
     const SPConstPhysics&   physics() const { return input_.physics; }
-    const SPConstRng&      rng() const { return input_.rng; }
+    const SPConstRng&       rng() const { return input_.rng; }
+    const SPConstTrackInit& init() const { return input_.init; }
     const SPActionRegistry& action_reg() const { return input_.action_reg; }
     //!@}
 

--- a/src/celeritas/global/CoreTrackData.hh
+++ b/src/celeritas/global/CoreTrackData.hh
@@ -15,6 +15,7 @@
 #include "celeritas/phys/PhysicsData.hh"
 #include "celeritas/random/RngData.hh"
 #include "celeritas/track/SimData.hh"
+#include "celeritas/track/TrackInitData.hh"
 
 namespace celeritas
 {
@@ -48,6 +49,7 @@ struct CoreParamsData
     CutoffParamsData<W, M>      cutoffs;
     PhysicsParamsData<W, M>     physics;
     RngParamsData<W, M>         rng;
+    TrackInitParamsData<W, M>   init;
 
     CoreScalars scalars;
 
@@ -55,7 +57,7 @@ struct CoreParamsData
     explicit CELER_FUNCTION operator bool() const
     {
         return geometry && geo_mats && materials && particles && cutoffs
-               && physics && scalars;
+               && physics && init && scalars;
     }
 
     //! Assign from another set of data
@@ -70,6 +72,7 @@ struct CoreParamsData
         cutoffs   = other.cutoffs;
         physics   = other.physics;
         rng       = other.rng;
+        init      = other.init;
         scalars   = other.scalars;
         return *this;
     }
@@ -87,12 +90,13 @@ struct CoreStateData
     template<class T>
     using Items = StateCollection<T, W, M>;
 
-    GeoStateData<W, M>      geometry;
-    MaterialStateData<W, M> materials;
-    ParticleStateData<W, M> particles;
-    PhysicsStateData<W, M>  physics;
-    RngStateData<W, M>      rng;
-    SimStateData<W, M>      sim;
+    GeoStateData<W, M>       geometry;
+    MaterialStateData<W, M>  materials;
+    ParticleStateData<W, M>  particles;
+    PhysicsStateData<W, M>   physics;
+    RngStateData<W, M>       rng;
+    SimStateData<W, M>       sim;
+    TrackInitStateData<W, M> init;
 
     //! Number of state elements
     CELER_FUNCTION size_type size() const { return particles.size(); }
@@ -100,7 +104,8 @@ struct CoreStateData
     //! Whether the data are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return geometry && materials && particles && physics && rng && sim;
+        return geometry && materials && particles && physics && rng && sim
+               && init;
     }
 
     //! Assign from another set of data
@@ -114,6 +119,7 @@ struct CoreStateData
         physics   = other.physics;
         rng       = other.rng;
         sim       = other.sim;
+        init      = other.init;
         return *this;
     }
 };
@@ -162,6 +168,7 @@ inline void resize(CoreStateData<Ownership::value, M>* state,
     resize(&state->physics, params.physics, size);
     resize(&state->rng, params.rng, size);
     resize(&state->sim, size);
+    resize(&state->init, params.init, size);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/Stepper.hh
+++ b/src/celeritas/global/Stepper.hh
@@ -35,20 +35,15 @@ class ActionSequence;
  *
  * - \c params : Problem definition
  * - \c num_track_slots : Maximum number of threads to run in parallel on GPU
- * - \c num_initializers : Maximum number of secondaries + primaries allowable
  */
 struct StepperInput
 {
     std::shared_ptr<const CoreParams> params;
     size_type                         num_track_slots{};
-    size_type                         num_initializers{};
     bool                              sync{false};
 
     //! True if defined
-    explicit operator bool() const
-    {
-        return params && num_track_slots > 0 && num_initializers > 0;
-    }
+    explicit operator bool() const { return params && num_track_slots > 0; }
 };
 
 //---------------------------------------------------------------------------//
@@ -83,7 +78,7 @@ class StepperInterface
     virtual StepperResult operator()() = 0;
 
     // Transport existing states and these new primaries
-    virtual StepperResult operator()(VecPrimary primaries) = 0;
+    virtual StepperResult operator()(const VecPrimary& primaries) = 0;
 
     //! Whether the stepper is assigned/valid
     virtual explicit operator bool() const = 0;
@@ -143,7 +138,7 @@ class Stepper final : public StepperInterface
     StepperResult operator()() final;
 
     // Transport existing states and these new primaries
-    StepperResult operator()(VecPrimary primaries) final;
+    StepperResult operator()(const VecPrimary& primaries) final;
 
     //! Whether the stepper is assigned/valid
     explicit operator bool() const final { return static_cast<bool>(states_); }
@@ -153,13 +148,11 @@ class Stepper final : public StepperInterface
 
   private:
     // Params and call sequence
-    std::shared_ptr<const CoreParams> params_;
+    std::shared_ptr<const CoreParams>       params_;
     std::shared_ptr<detail::ActionSequence> actions_;
 
     // State data
-    size_type                               num_initializers_;
-    CollectionStateStore<CoreStateData, M>  states_;
-    TrackInitStateData<Ownership::value, M> inits_;
+    CollectionStateStore<CoreStateData, M> states_;
 
     // Combined param/state for action calls
     CoreRef<M> core_ref_;

--- a/src/celeritas/track/TrackInitData.hh
+++ b/src/celeritas/track/TrackInitData.hh
@@ -23,63 +23,32 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Static track initializer data.
- *
- * There is no persistent data needed on device. Primaries are copied to device
- * only when they are needed to initialize new tracks and are not stored on
- * device. \c capacity is only used at construction to allocate memory
- * for track initializers and parent track IDs.
+ * Persistent data for track initialization.
  */
 template<Ownership W, MemSpace M>
-struct TrackInitParamsData;
-
-template<Ownership W>
-struct TrackInitParamsData<W, MemSpace::device>
+struct TrackInitParamsData
 {
-    /* no data on device */
-
-    //// METHODS ////
-
-    //! Assign from another set of data
-    template<Ownership W2, MemSpace M2>
-    TrackInitParamsData& operator=(const TrackInitParamsData<W2, M2>&)
-    {
-        return *this;
-    }
-};
-
-template<Ownership W>
-struct TrackInitParamsData<W, MemSpace::host>
-{
-    //// TYPES ////
-
-    template<class T>
-    using Items = Collection<T, W, MemSpace::host>;
-
-    //// DATA ////
-
-    Items<Primary> primaries;   //!< Primary particles
-    size_type      capacity{0}; //!< Initializer/parent storage per track
+    size_type capacity{0};   //!< Track initializer storage size
+    size_type max_events{0}; //!< Maximum number of events that can be run
 
     //// METHODS ////
 
     //! Whether the data are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return !primaries.empty() && capacity > 0;
+        return capacity > 0 && max_events > 0;
     }
 
     //! Assign from another set of data
     template<Ownership W2, MemSpace M2>
     TrackInitParamsData& operator=(const TrackInitParamsData<W2, M2>& other)
     {
-        primaries = other.primaries;
-        capacity  = other.capacity;
+        CELER_EXPECT(other);
+        capacity   = other.capacity;
+        max_events = other.max_events;
         return *this;
     }
 };
-
-using TrackInitParamsHostRef = HostCRef<TrackInitParamsData>;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -165,7 +134,7 @@ struct ResizableData
  * Not all of this is technically "state" data, though it is all mutable and in
  * most cases accessed by \c ThreadId. Specifically, \c initializers and \c
  * vacancies are resizable, and \c track_counters has size
- * \c num_events.
+ * \c max_events.
  * - \c initializers stores the data for primaries and secondaries waiting to
  *   be turned into new tracks and can be any size up to \c capacity.
  * - \c parents is the \c ThreadId of the parent tracks of the initializers.
@@ -195,8 +164,7 @@ struct TrackInitStateData
     StateItems<size_type>            secondary_counts;
     EventItems<TrackId::size_type>   track_counters;
 
-    size_type num_primaries{};   //!< Number of uninitialized primaries
-    size_type num_secondaries{}; //!< Number of secondaries produced in step
+    size_type num_secondaries{}; //!< Number of secondaries produced in a step
 
     //// METHODS ////
 
@@ -217,7 +185,6 @@ struct TrackInitStateData
         vacancies        = other.vacancies;
         secondary_counts = other.secondary_counts;
         track_counters   = other.track_counters;
-        num_primaries    = other.num_primaries;
         num_secondaries  = other.num_secondaries;
         return *this;
     }
@@ -247,10 +214,10 @@ void resize(TrackInitStateData<Ownership::value, M>* data,
     CELER_EXPECT(M == MemSpace::host || celeritas::device());
 
     // Allocate device data
-    auto capacity = params.capacity;
-    resize(&data->initializers.storage, capacity);
+    resize(&data->initializers.storage, params.capacity);
     resize(&data->parents, size);
     resize(&data->secondary_counts, size);
+    resize(&data->track_counters, params.max_events);
 
     // Start with an empty vector of track initializers
     data->initializers.resize(0);
@@ -265,23 +232,10 @@ void resize(TrackInitStateData<Ownership::value, M>* data,
     data->vacancies.storage = vacancies;
     data->vacancies.resize(size);
 
-    // Initialize the track counter for each event as the number of primary
-    // particles in that event
-    std::vector<size_type> counters;
-    for (const auto& p : params.primaries[AllItems<Primary, MemSpace::host>{}])
-    {
-        const auto event_id = p.event_id.get();
-        if (!(event_id < counters.size()))
-        {
-            counters.resize(event_id + 1);
-        }
-        ++counters[event_id];
-    }
-    Collection<TrackId::size_type, Ownership::value, MemSpace::host, EventId>
-        track_counters;
-    make_builder(&track_counters).insert_back(counters.begin(), counters.end());
-    data->track_counters = track_counters;
-    data->num_primaries  = params.primaries.size();
+    // Initialize the track counter for each event to zero
+    fill(size_type(0), &data->track_counters);
+
+    CELER_ENSURE(*data);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/TrackInitData.hh
+++ b/src/celeritas/track/TrackInitData.hh
@@ -24,6 +24,10 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Persistent data for track initialization.
+ *
+ * TODO: change \c max_events to be the maximum number of events in flight at
+ * once rather than the maximum number of events that can be run over the
+ * entire simulation
  */
 template<Ownership W, MemSpace M>
 struct TrackInitParamsData

--- a/src/celeritas/track/TrackInitParams.cc
+++ b/src/celeritas/track/TrackInitParams.cc
@@ -7,26 +7,22 @@
 //---------------------------------------------------------------------------//
 #include "TrackInitParams.hh"
 
-#include "corecel/data/CollectionBuilder.hh"
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with primaries and storage factor.
+ * Construct with capacity and number of events.
  */
 TrackInitParams::TrackInitParams(const Input& inp)
 {
-    CELER_EXPECT(!inp.primaries.empty());
     CELER_EXPECT(inp.capacity > 0);
+    CELER_EXPECT(inp.max_events > 0);
 
-    make_builder(&host_value_.primaries)
-        .insert_back(inp.primaries.begin(), inp.primaries.end());
-    host_value_.capacity = inp.capacity;
-    host_ref_            = host_value_;
-
-    CELER_ENSURE(host_value_);
-    CELER_ENSURE(host_ref_);
+    HostVal<TrackInitParamsData> host_data;
+    host_data.capacity   = inp.capacity;
+    host_data.max_events = inp.max_events;
+    CELER_ASSERT(host_data);
+    data_ = CollectionMirror<TrackInitParamsData>{std::move(host_data)};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/TrackInitParams.hh
+++ b/src/celeritas/track/TrackInitParams.hh
@@ -7,10 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <vector>
-
 #include "corecel/Types.hh"
-#include "celeritas/phys/Primary.hh"
+#include "corecel/data/CollectionMirror.hh"
 
 #include "TrackInitData.hh"
 
@@ -19,13 +17,6 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Manage persistent track initializer data.
- *
- * Primary particles are stored on the host and only copied to device when they
- * are needed to initialize new tracks.
- *
- * \todo This class will probably go away. The interface as-is requires a copy
- * when none is needed, and the capacity of the secondaries doesn't need to be
- * set every time new primaries are added to the state.
  */
 class TrackInitParams
 {
@@ -39,26 +30,23 @@ class TrackInitParams
     //! Track initializer construction arguments
     struct Input
     {
-        std::vector<Primary> primaries;
-        size_type            capacity; //!< Max number of initializers
+        size_type capacity;   //!< Max number of initializers
+        size_type max_events; //!< Max number of events that can be run
     };
 
   public:
-    // Construct with primaries and storage factor
+    // Construct with capacity and number of events
     explicit TrackInitParams(const Input&);
 
     //! Access primaries for contructing track initializer states
-    const HostRef& host_ref() const { return host_ref_; }
+    const HostRef& host_ref() const { return data_.host(); }
 
     //! Access data on device
-    const DeviceRef& device_ref() const { return device_ref_; }
+    const DeviceRef& device_ref() const { return data_.device(); }
 
   private:
-    using HostValue = HostVal<TrackInitParamsData>;
-
-    HostValue host_value_;
-    HostRef   host_ref_;
-    DeviceRef device_ref_;
+    // Host/device storage and reference
+    CollectionMirror<TrackInitParamsData> data_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
@@ -54,8 +54,11 @@ CELER_FUNCTION void ProcessPrimariesLauncher<M>::operator()(ThreadId tid) const
 {
     const Primary& primary = primaries_[tid.get()];
 
+    CELER_ASSERT(primaries_.size() <= data_.initializers.size() + tid.get());
+    TrackInitializer& ti = data_.initializers[ThreadId(
+        data_.initializers.size() - primaries_.size() + tid.get())];
+
     // Construct a track initializer from a primary particle
-    TrackInitializer ti;
     ti.sim.track_id         = primary.track_id;
     ti.sim.parent_id        = TrackId{};
     ti.sim.event_id         = primary.event_id;
@@ -66,12 +69,6 @@ CELER_FUNCTION void ProcessPrimariesLauncher<M>::operator()(ThreadId tid) const
     ti.geo.dir              = primary.direction;
     ti.particle.particle_id = primary.particle_id;
     ti.particle.energy      = primary.energy;
-
-    // Store the track initializer at the appropriate index
-    CELER_ASSERT(primaries_.size() <= data_.initializers.size() + tid.get());
-    data_.initializers[ThreadId(data_.initializers.size() - primaries_.size()
-                                + tid.get())]
-        = ti;
 
     // Update per-event counter of number of tracks created
     CELER_ASSERT(ti.sim.event_id < data_.track_counters.size());

--- a/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
@@ -8,8 +8,8 @@
 #pragma once
 
 #include "corecel/cont/Span.hh"
-
-#include "../TrackInitData.hh"
+#include "corecel/math/Atomics.hh"
+#include "celeritas/global/CoreTrackData.hh"
 
 namespace celeritas
 {
@@ -30,9 +30,9 @@ class ProcessPrimariesLauncher
 
   public:
     // Construct with shared and state data
-    CELER_FUNCTION ProcessPrimariesLauncher(Span<const Primary>      primaries,
-                                            const TrackInitStateRef& data)
-        : primaries_(primaries), data_(data)
+    CELER_FUNCTION ProcessPrimariesLauncher(const CoreRef<M>&   core_data,
+                                            Span<const Primary> primaries)
+        : data_(core_data.states.init), primaries_(primaries)
     {
         CELER_EXPECT(data_);
     }
@@ -41,8 +41,8 @@ class ProcessPrimariesLauncher
     inline CELER_FUNCTION void operator()(ThreadId tid) const;
 
   private:
-    Span<const Primary>      primaries_;
     const TrackInitStateRef& data_;
+    Span<const Primary>      primaries_;
 };
 
 //---------------------------------------------------------------------------//
@@ -52,21 +52,30 @@ class ProcessPrimariesLauncher
 template<MemSpace M>
 CELER_FUNCTION void ProcessPrimariesLauncher<M>::operator()(ThreadId tid) const
 {
-    TrackInitializer& init    = data_.initializers[ThreadId(
-        data_.initializers.size() - primaries_.size() + tid.get())];
-    const Primary&    primary = primaries_[tid.get()];
+    const Primary& primary = primaries_[tid.get()];
 
     // Construct a track initializer from a primary particle
-    init.sim.track_id         = primary.track_id;
-    init.sim.parent_id        = TrackId{};
-    init.sim.event_id         = primary.event_id;
-    init.sim.num_steps        = 0;
-    init.sim.time             = primary.time;
-    init.sim.status           = TrackStatus::alive;
-    init.geo.pos              = primary.position;
-    init.geo.dir              = primary.direction;
-    init.particle.particle_id = primary.particle_id;
-    init.particle.energy      = primary.energy;
+    TrackInitializer ti;
+    ti.sim.track_id         = primary.track_id;
+    ti.sim.parent_id        = TrackId{};
+    ti.sim.event_id         = primary.event_id;
+    ti.sim.num_steps        = 0;
+    ti.sim.time             = primary.time;
+    ti.sim.status           = TrackStatus::alive;
+    ti.geo.pos              = primary.position;
+    ti.geo.dir              = primary.direction;
+    ti.particle.particle_id = primary.particle_id;
+    ti.particle.energy      = primary.energy;
+
+    // Store the track initializer at the appropriate index
+    CELER_ASSERT(primaries_.size() <= data_.initializers.size() + tid.get());
+    data_.initializers[ThreadId(data_.initializers.size() - primaries_.size()
+                                + tid.get())]
+        = ti;
+
+    // Update per-event counter of number of tracks created
+    CELER_ASSERT(ti.sim.event_id < data_.track_counters.size());
+    atomic_add(&data_.track_counters[ti.sim.event_id], size_type{1});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/detail/TrackInitAlgorithms.cc
+++ b/src/celeritas/track/detail/TrackInitAlgorithms.cc
@@ -25,7 +25,7 @@ size_type remove_if_alive<MemSpace::host>(Span<size_type> vacancies)
 {
     auto end = std::remove_if(vacancies.data(),
                               vacancies.data() + vacancies.size(),
-                              IsEqual{flag_id()});
+                              IsEqual{occupied()});
 
     // New size of the vacancy vector
     size_type result = end - vacancies.data();

--- a/src/celeritas/track/detail/TrackInitAlgorithms.cu
+++ b/src/celeritas/track/detail/TrackInitAlgorithms.cu
@@ -31,7 +31,7 @@ size_type remove_if_alive<MemSpace::device>(Span<size_type> vacancies)
     thrust::device_ptr<size_type> end = thrust::remove_if(
         thrust::device_pointer_cast(vacancies.data()),
         thrust::device_pointer_cast(vacancies.data() + vacancies.size()),
-        IsEqual{flag_id()});
+        IsEqual{occupied()});
 
     CELER_DEVICE_CHECK_ERROR();
 

--- a/src/celeritas/track/detail/Utils.hh
+++ b/src/celeritas/track/detail/Utils.hh
@@ -27,7 +27,7 @@ struct IsEqual
 
 //---------------------------------------------------------------------------//
 //! Invalid index flag
-CELER_CONSTEXPR_FUNCTION size_type flag_id()
+CELER_CONSTEXPR_FUNCTION size_type occupied()
 {
     return numeric_limits<size_type>::max();
 }

--- a/src/celeritas/track/generated/InitTracks.cc
+++ b/src/celeritas/track/generated/InitTracks.cc
@@ -16,10 +16,9 @@ namespace generated
 {
 void init_tracks(
     const CoreHostRef& core_data,
-    const TrackInitStateHostRef& init_data,
     const size_type num_vacancies)
 {
-    detail::InitTracksLauncher<MemSpace::host> launch(core_data, init_data, num_vacancies);
+    detail::InitTracksLauncher<MemSpace::host> launch(core_data, num_vacancies);
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < num_vacancies; ++i)
     {

--- a/src/celeritas/track/generated/InitTracks.cu
+++ b/src/celeritas/track/generated/InitTracks.cu
@@ -29,28 +29,26 @@ __launch_bounds__(1024, 8)
 #endif // CELERITAS_LAUNCH_BOUNDS
 init_tracks_kernel(
     const CoreDeviceRef core_data,
-    const TrackInitStateDeviceRef init_data,
     const size_type num_vacancies)
 {
     auto tid = KernelParamCalculator::thread_id();
     if (!(tid < num_vacancies))
         return;
 
-    detail::InitTracksLauncher<MemSpace::device> launch(core_data, init_data, num_vacancies);
+    detail::InitTracksLauncher<MemSpace::device> launch(core_data, num_vacancies);
     launch(tid);
 }
 } // namespace
 
 void init_tracks(
     const CoreDeviceRef& core_data,
-    const TrackInitStateDeviceRef& init_data,
     const size_type num_vacancies)
 {
     CELER_LAUNCH_KERNEL(
         init_tracks,
         celeritas::device().default_block_size(),
         num_vacancies,
-        core_data, init_data, num_vacancies);
+        core_data, num_vacancies);
 }
 
 } // namespace generated

--- a/src/celeritas/track/generated/InitTracks.hh
+++ b/src/celeritas/track/generated/InitTracks.hh
@@ -2,9 +2,9 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
-#include "celeritas/track/detail/InitTracksLauncher.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackData.hh"
-#include "celeritas/track/TrackInitData.hh"
+#include "celeritas/track/detail/InitTracksLauncher.hh" // IWYU pragma: associated
+
 
 namespace celeritas
 {
@@ -13,16 +13,14 @@ namespace generated
 
 void init_tracks(
     const CoreHostRef& core_data,
-    const TrackInitStateHostRef& init_data,
     const size_type num_vacancies);
 
 void init_tracks(
     const CoreDeviceRef& core_data,
-    const TrackInitStateDeviceRef& init_data,
     const size_type num_vacancies);
 
 #if !CELER_USE_DEVICE
-inline void init_tracks(const CoreDeviceRef&, const TrackInitStateDeviceRef&, const size_type)
+inline void init_tracks(const CoreDeviceRef&, const size_type)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/src/celeritas/track/generated/LocateAlive.cc
+++ b/src/celeritas/track/generated/LocateAlive.cc
@@ -15,10 +15,9 @@ namespace celeritas
 namespace generated
 {
 void locate_alive(
-    const CoreHostRef& core_data,
-    const TrackInitStateHostRef& init_data)
+    const CoreHostRef& core_data)
 {
-    detail::LocateAliveLauncher<MemSpace::host> launch(core_data, init_data);
+    detail::LocateAliveLauncher<MemSpace::host> launch(core_data);
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < core_data.states.size(); ++i)
     {

--- a/src/celeritas/track/generated/LocateAlive.cu
+++ b/src/celeritas/track/generated/LocateAlive.cu
@@ -28,27 +28,25 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 locate_alive_kernel(
-    const CoreDeviceRef core_data,
-    const TrackInitStateDeviceRef init_data)
+    const CoreDeviceRef core_data)
 {
     auto tid = KernelParamCalculator::thread_id();
     if (!(tid < core_data.states.size()))
         return;
 
-    detail::LocateAliveLauncher<MemSpace::device> launch(core_data, init_data);
+    detail::LocateAliveLauncher<MemSpace::device> launch(core_data);
     launch(tid);
 }
 } // namespace
 
 void locate_alive(
-    const CoreDeviceRef& core_data,
-    const TrackInitStateDeviceRef& init_data)
+    const CoreDeviceRef& core_data)
 {
     CELER_LAUNCH_KERNEL(
         locate_alive,
         celeritas::device().default_block_size(),
         core_data.states.size(),
-        core_data, init_data);
+        core_data);
 }
 
 } // namespace generated

--- a/src/celeritas/track/generated/LocateAlive.hh
+++ b/src/celeritas/track/generated/LocateAlive.hh
@@ -2,9 +2,9 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
-#include "celeritas/track/detail/LocateAliveLauncher.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackData.hh"
-#include "celeritas/track/TrackInitData.hh"
+#include "celeritas/track/detail/LocateAliveLauncher.hh" // IWYU pragma: associated
+
 
 namespace celeritas
 {
@@ -12,15 +12,13 @@ namespace generated
 {
 
 void locate_alive(
-    const CoreHostRef& core_data,
-    const TrackInitStateHostRef& init_data);
+    const CoreHostRef& core_data);
 
 void locate_alive(
-    const CoreDeviceRef& core_data,
-    const TrackInitStateDeviceRef& init_data);
+    const CoreDeviceRef& core_data);
 
 #if !CELER_USE_DEVICE
-inline void locate_alive(const CoreDeviceRef&, const TrackInitStateDeviceRef&)
+inline void locate_alive(const CoreDeviceRef&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/src/celeritas/track/generated/ProcessPrimaries.cc
+++ b/src/celeritas/track/generated/ProcessPrimaries.cc
@@ -15,10 +15,10 @@ namespace celeritas
 namespace generated
 {
 void process_primaries(
-    const Span<const Primary> primaries,
-    const TrackInitStateHostRef& init_data)
+    const CoreHostRef& core_data,
+    const Span<const Primary> primaries)
 {
-    detail::ProcessPrimariesLauncher<MemSpace::host> launch(primaries, init_data);
+    detail::ProcessPrimariesLauncher<MemSpace::host> launch(core_data, primaries);
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < primaries.size(); ++i)
     {

--- a/src/celeritas/track/generated/ProcessPrimaries.cu
+++ b/src/celeritas/track/generated/ProcessPrimaries.cu
@@ -28,27 +28,27 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 process_primaries_kernel(
-    const Span<const Primary> primaries,
-    const TrackInitStateDeviceRef init_data)
+    const CoreDeviceRef core_data,
+    const Span<const Primary> primaries)
 {
     auto tid = KernelParamCalculator::thread_id();
     if (!(tid < primaries.size()))
         return;
 
-    detail::ProcessPrimariesLauncher<MemSpace::device> launch(primaries, init_data);
+    detail::ProcessPrimariesLauncher<MemSpace::device> launch(core_data, primaries);
     launch(tid);
 }
 } // namespace
 
 void process_primaries(
-    const Span<const Primary> primaries,
-    const TrackInitStateDeviceRef& init_data)
+    const CoreDeviceRef& core_data,
+    const Span<const Primary> primaries)
 {
     CELER_LAUNCH_KERNEL(
         process_primaries,
         celeritas::device().default_block_size(),
         primaries.size(),
-        primaries, init_data);
+        core_data, primaries);
 }
 
 } // namespace generated

--- a/src/celeritas/track/generated/ProcessPrimaries.hh
+++ b/src/celeritas/track/generated/ProcessPrimaries.hh
@@ -2,10 +2,10 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
+#include "celeritas/global/CoreTrackData.hh"
 #include "celeritas/track/detail/ProcessPrimariesLauncher.hh" // IWYU pragma: associated
 #include "corecel/cont/Span.hh"
 #include "celeritas/phys/Primary.hh"
-#include "celeritas/track/TrackInitData.hh"
 
 namespace celeritas
 {
@@ -13,15 +13,15 @@ namespace generated
 {
 
 void process_primaries(
-    const Span<const Primary> primaries,
-    const TrackInitStateHostRef& init_data);
+    const CoreHostRef& core_data,
+    const Span<const Primary> primaries);
 
 void process_primaries(
-    const Span<const Primary> primaries,
-    const TrackInitStateDeviceRef& init_data);
+    const CoreDeviceRef& core_data,
+    const Span<const Primary> primaries);
 
 #if !CELER_USE_DEVICE
-inline void process_primaries(const Span<const Primary>, const TrackInitStateDeviceRef&)
+inline void process_primaries(const CoreDeviceRef&, const Span<const Primary>)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/src/celeritas/track/generated/ProcessSecondaries.cc
+++ b/src/celeritas/track/generated/ProcessSecondaries.cc
@@ -15,10 +15,9 @@ namespace celeritas
 namespace generated
 {
 void process_secondaries(
-    const CoreHostRef& core_data,
-    const TrackInitStateHostRef& init_data)
+    const CoreHostRef& core_data)
 {
-    detail::ProcessSecondariesLauncher<MemSpace::host> launch(core_data, init_data);
+    detail::ProcessSecondariesLauncher<MemSpace::host> launch(core_data);
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < core_data.states.size(); ++i)
     {

--- a/src/celeritas/track/generated/ProcessSecondaries.cu
+++ b/src/celeritas/track/generated/ProcessSecondaries.cu
@@ -28,27 +28,25 @@ __launch_bounds__(1024, 2)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 process_secondaries_kernel(
-    const CoreDeviceRef core_data,
-    const TrackInitStateDeviceRef init_data)
+    const CoreDeviceRef core_data)
 {
     auto tid = KernelParamCalculator::thread_id();
     if (!(tid < core_data.states.size()))
         return;
 
-    detail::ProcessSecondariesLauncher<MemSpace::device> launch(core_data, init_data);
+    detail::ProcessSecondariesLauncher<MemSpace::device> launch(core_data);
     launch(tid);
 }
 } // namespace
 
 void process_secondaries(
-    const CoreDeviceRef& core_data,
-    const TrackInitStateDeviceRef& init_data)
+    const CoreDeviceRef& core_data)
 {
     CELER_LAUNCH_KERNEL(
         process_secondaries,
         celeritas::device().default_block_size(),
         core_data.states.size(),
-        core_data, init_data);
+        core_data);
 }
 
 } // namespace generated

--- a/src/celeritas/track/generated/ProcessSecondaries.hh
+++ b/src/celeritas/track/generated/ProcessSecondaries.hh
@@ -2,9 +2,9 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
-#include "celeritas/track/detail/ProcessSecondariesLauncher.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackData.hh"
-#include "celeritas/track/TrackInitData.hh"
+#include "celeritas/track/detail/ProcessSecondariesLauncher.hh" // IWYU pragma: associated
+
 
 namespace celeritas
 {
@@ -12,15 +12,13 @@ namespace generated
 {
 
 void process_secondaries(
-    const CoreHostRef& core_data,
-    const TrackInitStateHostRef& init_data);
+    const CoreHostRef& core_data);
 
 void process_secondaries(
-    const CoreDeviceRef& core_data,
-    const TrackInitStateDeviceRef& init_data);
+    const CoreDeviceRef& core_data);
 
 #if !CELER_USE_DEVICE
-inline void process_secondaries(const CoreDeviceRef&, const TrackInitStateDeviceRef&)
+inline void process_secondaries(const CoreDeviceRef&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -32,6 +32,7 @@
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/PhysicsParams.hh"
 #include "celeritas/random/RngParams.hh"
+#include "celeritas/track/TrackInitParams.hh"
 
 namespace celeritas
 {
@@ -170,6 +171,15 @@ auto GeantTestBase::build_physics() -> SPConstPhysics
             input.particles, input.materials, process_data));
     }
     return std::make_shared<PhysicsParams>(std::move(input));
+}
+
+//---------------------------------------------------------------------------//
+auto GeantTestBase::build_init() -> SPConstTrackInit
+{
+    TrackInitParams::Input input;
+    input.capacity   = 4096;
+    input.max_events = 4096;
+    return std::make_shared<TrackInitParams>(input);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/GeantTestBase.hh
+++ b/test/celeritas/GeantTestBase.hh
@@ -54,6 +54,7 @@ class GeantTestBase : virtual public GlobalGeoTestBase
     SPConstParticle    build_particle() override;
     SPConstCutoff      build_cutoff() override;
     SPConstPhysics     build_physics() override;
+    SPConstTrackInit   build_init() override;
     SPConstAction      build_along_step() override;
 
     virtual PhysicsOptions build_physics_options() const;

--- a/test/celeritas/GlobalTestBase.cc
+++ b/test/celeritas/GlobalTestBase.cc
@@ -60,6 +60,7 @@ auto GlobalTestBase::build_core() -> SPConstCore
     inp.cutoff      = this->cutoff();
     inp.physics     = this->physics();
     inp.rng         = this->rng();
+    inp.init        = this->init();
     inp.action_reg  = this->action_reg();
     CELER_ASSERT(inp);
 

--- a/test/celeritas/GlobalTestBase.hh
+++ b/test/celeritas/GlobalTestBase.hh
@@ -60,6 +60,7 @@ class GlobalTestBase : public Test
     using SPConstPhysics     = SP<const PhysicsParams>;
     using SPConstAction      = SP<const ExplicitActionInterface>;
     using SPConstRng         = SP<const RngParams>;
+    using SPConstTrackInit   = SP<const TrackInitParams>;
     using SPConstCore        = SP<const CoreParams>;
 
     using SPActionRegistry = SP<ActionRegistry>;
@@ -84,6 +85,7 @@ class GlobalTestBase : public Test
     inline SPConstPhysics const&     physics();
     inline SPConstAction const&      along_step();
     inline SPConstRng const&         rng();
+    inline SPConstTrackInit const&   init();
     inline SPActionRegistry const&   action_reg();
     inline SPConstCore const&        core();
 
@@ -95,6 +97,7 @@ class GlobalTestBase : public Test
     inline SPConstPhysics const&     physics() const;
     inline SPConstAction const&      along_step() const;
     inline SPConstRng const&         rng() const;
+    inline SPConstTrackInit const&   init() const;
     inline SPActionRegistry const&   action_reg() const;
     inline SPConstCore const&        core() const;
     //!@}
@@ -115,12 +118,13 @@ class GlobalTestBase : public Test
     virtual SPConstParticle    build_particle()    = 0;
     virtual SPConstCutoff      build_cutoff()      = 0;
     virtual SPConstPhysics     build_physics()     = 0;
+    virtual SPConstTrackInit   build_init()        = 0;
     virtual SPConstAction      build_along_step()  = 0;
 
   private:
-    SPConstRng      build_rng() const;
+    SPConstRng       build_rng() const;
     SPActionRegistry build_action_reg() const;
-    SPConstCore     build_core();
+    SPConstCore      build_core();
 
     void register_geometry_output() {}
     void register_material_output() {}
@@ -130,6 +134,7 @@ class GlobalTestBase : public Test
     void register_physics_output();
     void register_along_step_output() {}
     void register_rng_output() {}
+    void register_init_output() {}
     void register_action_reg_output();
     void register_core_output() {}
 
@@ -143,6 +148,7 @@ class GlobalTestBase : public Test
     SPActionRegistry   action_reg_;
     SPConstAction      along_step_;
     SPConstRng         rng_;
+    SPConstTrackInit   init_;
     SPConstCore        core_;
     SPOutputManager    output_;
 };
@@ -176,6 +182,7 @@ DEF_GTB_ACCESSORS(SPConstCutoff, cutoff)
 DEF_GTB_ACCESSORS(SPConstPhysics, physics)
 DEF_GTB_ACCESSORS(SPConstAction, along_step)
 DEF_GTB_ACCESSORS(SPConstRng, rng)
+DEF_GTB_ACCESSORS(SPConstTrackInit, init)
 DEF_GTB_ACCESSORS(SPActionRegistry, action_reg)
 DEF_GTB_ACCESSORS(SPConstCore, core)
 

--- a/test/celeritas/MockTestBase.hh
+++ b/test/celeritas/MockTestBase.hh
@@ -74,6 +74,7 @@ class MockTestBase : virtual public GlobalGeoTestBase
     SPConstCutoff      build_cutoff() override;
     SPConstPhysics     build_physics() override;
     SPConstAction      build_along_step() override;
+    SPConstTrackInit   build_init() override { CELER_ASSERT_UNREACHABLE(); }
 
     virtual PhysicsOptions build_physics_options() const;
 

--- a/test/celeritas/SimpleTestBase.cc
+++ b/test/celeritas/SimpleTestBase.cc
@@ -19,6 +19,7 @@
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/PhysicsParams.hh"
+#include "celeritas/track/TrackInitParams.hh"
 
 namespace celeritas
 {
@@ -141,6 +142,15 @@ auto SimpleTestBase::build_physics() -> SPConstPhysics
     input.action_registry = this->action_reg().get();
 
     return std::make_shared<PhysicsParams>(std::move(input));
+}
+
+//---------------------------------------------------------------------------//
+auto SimpleTestBase::build_init() -> SPConstTrackInit
+{
+    TrackInitParams::Input input;
+    input.capacity   = 4096;
+    input.max_events = 4096;
+    return std::make_shared<TrackInitParams>(input);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/SimpleTestBase.hh
+++ b/test/celeritas/SimpleTestBase.hh
@@ -31,6 +31,7 @@ class SimpleTestBase : virtual public GlobalGeoTestBase
     SPConstParticle    build_particle() override;
     SPConstCutoff      build_cutoff() override;
     SPConstPhysics     build_physics() override;
+    SPConstTrackInit   build_init() override;
     SPConstAction      build_along_step() override;
 };
 

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -123,6 +123,7 @@ class UrbanMscTest : public GlobalGeoTestBase
 
         return std::make_shared<PhysicsParams>(std::move(input));
     }
+    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstAction build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
 
     SPConstGeoMaterial build_geomaterial() override

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -82,6 +82,7 @@ class VecgeomTestBase : virtual public GlobalTestBase
     SPConstParticle    build_particle() final { CELER_ASSERT_UNREACHABLE(); }
     SPConstCutoff      build_cutoff() final { CELER_ASSERT_UNREACHABLE(); }
     SPConstPhysics     build_physics() final { CELER_ASSERT_UNREACHABLE(); }
+    SPConstTrackInit   build_init() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstAction      build_along_step() final { CELER_ASSERT_UNREACHABLE(); }
     SPConstMaterial    build_material() final { CELER_ASSERT_UNREACHABLE(); }
     SPConstGeoMaterial build_geomaterial() final

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -58,9 +58,10 @@ class FieldPropagatorTestBase : public GlobalGeoTestBase
     {
         CELER_ASSERT_UNREACHABLE();
     }
-    SPConstCutoff  build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstPhysics build_physics() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstAction  build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstCutoff    build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstPhysics   build_physics() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstAction build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
 
     SPConstParticle build_particle() override
     {

--- a/test/celeritas/field/LinearPropagator.test.cc
+++ b/test/celeritas/field/LinearPropagator.test.cc
@@ -59,9 +59,10 @@ class LinearPropagatorTestBase : public GlobalGeoTestBase
     }
 
   protected:
-    SPConstParticle build_particle() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstCutoff   build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstPhysics  build_physics() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstParticle  build_particle() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstCutoff    build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstPhysics   build_physics() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstAction   build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstMaterial build_material() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstGeoMaterial build_geomaterial() override

--- a/test/celeritas/field/LinearPropagator.test.cc
+++ b/test/celeritas/field/LinearPropagator.test.cc
@@ -14,6 +14,7 @@
 #include "celeritas/GlobalGeoTestBase.hh"
 #include "celeritas/geo/GeoData.hh"
 #include "celeritas/geo/GeoParams.hh"
+#include "celeritas/geo/OnlyGeoTestBase.hh"
 
 #include "celeritas_test.hh"
 
@@ -25,7 +26,8 @@ namespace test
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class LinearPropagatorTestBase : public GlobalGeoTestBase
+class LinearPropagatorTestBase : public GlobalGeoTestBase,
+                                 public OnlyGeoTestBase
 {
   public:
     using GeoStateStore = CollectionStateStore<GeoStateData, MemSpace::host>;
@@ -56,18 +58,6 @@ class LinearPropagatorTestBase : public GlobalGeoTestBase
             return "[OUTSIDE]";
         }
         return this->geometry()->id_to_label(geo.volume_id()).name;
-    }
-
-  protected:
-    SPConstParticle  build_particle() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstCutoff    build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstPhysics   build_physics() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstAction   build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstMaterial build_material() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstGeoMaterial build_geomaterial() override
-    {
-        CELER_ASSERT_UNREACHABLE();
     }
 
   protected:

--- a/test/celeritas/geo/GeoMaterial.test.cc
+++ b/test/celeritas/geo/GeoMaterial.test.cc
@@ -29,10 +29,11 @@ class GeoMaterialTest : public GlobalGeoTestBase
 {
     const char* geometry_basename() const override { return "simple-cms"; }
 
-    SPConstParticle build_particle() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstCutoff   build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstPhysics  build_physics() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstAction   build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstParticle  build_particle() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstCutoff    build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstPhysics   build_physics() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstAction build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
 
     SPConstMaterial build_material() override
     {

--- a/test/celeritas/geo/HeuristicGeoTestBase.hh
+++ b/test/celeritas/geo/HeuristicGeoTestBase.hh
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/data/Collection.hh"
+#include "celeritas/geo/OnlyGeoTestBase.hh"
 
 #include "../GlobalGeoTestBase.hh"
 #include "HeuristicGeoData.hh"
@@ -29,7 +30,7 @@ namespace test
 /*!
  * Manage a "heuristic" stepper-like test that accumulates path length.
  */
-class HeuristicGeoTestBase : public GlobalGeoTestBase
+class HeuristicGeoTestBase : public GlobalGeoTestBase, public OnlyGeoTestBase
 {
   public:
     //!@{
@@ -41,21 +42,6 @@ class HeuristicGeoTestBase : public GlobalGeoTestBase
         = Collection<real_type, Ownership::reference, M, VolumeId>;
     using SpanConstReal = Span<const real_type>;
     using SpanConstStr  = Span<const std::string>;
-    //!@}
-
-  public:
-    //!@{
-    //! Most param construction will not be used.
-    SPConstParticle  build_particle() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstCutoff    build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstPhysics   build_physics() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstAction   build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstMaterial build_material() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstGeoMaterial build_geomaterial() override
-    {
-        CELER_ASSERT_UNREACHABLE();
-    }
     //!@}
 
     //// INTERFACE ////

--- a/test/celeritas/geo/HeuristicGeoTestBase.hh
+++ b/test/celeritas/geo/HeuristicGeoTestBase.hh
@@ -46,9 +46,10 @@ class HeuristicGeoTestBase : public GlobalGeoTestBase
   public:
     //!@{
     //! Most param construction will not be used.
-    SPConstParticle build_particle() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstCutoff   build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstPhysics  build_physics() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstParticle  build_particle() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstCutoff    build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstPhysics   build_physics() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstAction   build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstMaterial build_material() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstGeoMaterial build_geomaterial() override

--- a/test/celeritas/geo/OnlyGeoTestBase.hh
+++ b/test/celeritas/geo/OnlyGeoTestBase.hh
@@ -1,0 +1,38 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/geo/OnlyGeoTestBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Assert.hh"
+
+#include "../GlobalTestBase.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Mixin class providing "unreachable" implementations for param construction.
+ */
+class OnlyGeoTestBase : virtual public GlobalTestBase
+{
+  public:
+    SPConstParticle  build_particle() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstCutoff    build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstPhysics   build_physics() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstAction   build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstMaterial build_material() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstGeoMaterial build_geomaterial() override
+    {
+        CELER_ASSERT_UNREACHABLE();
+    }
+};
+//---------------------------------------------------------------------------//
+} // namespace test
+} // namespace celeritas

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -48,21 +48,16 @@ auto AlongStepTestBase::run(const Input& inp, size_type num_tracks) -> RunResult
         p.direction   = inp.direction;
         p.time        = inp.time;
 
-        TrackInitParams::Input inp;
-        inp.primaries.assign(num_tracks, p);
-        inp.capacity = num_tracks;
+        std::vector<Primary> primaries(num_tracks, p);
         for (auto i : range(num_tracks))
         {
-            inp.primaries[i].event_id = EventId{i};
-            inp.primaries[i].track_id = TrackId{i};
+            primaries[i].event_id = EventId{i};
+            primaries[i].track_id = TrackId{i};
         }
 
         // Primary -> track initializer -> track
-        TrackInitParams init_params{std::move(inp)};
-        TrackInitStateData<Ownership::value, MemSpace::host> init_states;
-        resize(&init_states, init_params.host_ref(), num_tracks);
-        extend_from_primaries(init_params.host_ref(), &init_states);
-        initialize_tracks(core_ref, &init_states);
+        extend_from_primaries(core_ref, primaries);
+        initialize_tracks(core_ref);
     }
 
     // Set remaining MFP

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -196,12 +196,11 @@ TEST_F(TestEm3Test, setup)
 
 TEST_F(TestEm3Test, host)
 {
-    size_type num_sets      = 1;
     size_type num_primaries = 1;
     size_type num_tracks    = 256;
 
     Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
-    auto                    result = this->run(step, num_primaries, num_sets);
+    auto                    result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(63490, result.calc_avg_steps_per_primary(), 0.10);
 
     if (this->is_ci_build() || this->is_wildstyle_build())
@@ -237,38 +236,34 @@ TEST_F(TestEm3Test, host)
 
 TEST_F(TestEm3Test, host_multi)
 {
-    // Run and inject multiple sets of primaries during the transport loop
+    // Run and inject multiple sets of primaries during transport
 
-    size_type num_sets      = 4;
-    size_type num_primaries = 2;
-    size_type num_tracks    = 2048;
+    size_type num_primaries = 8;
+    size_type num_tracks    = 128;
 
     Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
-    auto                    result = this->run(step, num_primaries, num_sets);
-    EXPECT_SOFT_NEAR(61883.75, result.calc_avg_steps_per_primary(), 0.10);
 
-    if (this->is_ci_build() || this->is_wildstyle_build())
-    {
-        EXPECT_EQ(740, result.num_step_iters());
-        EXPECT_SOFT_EQ(61883.75, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(641, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({637, 294}), result.calc_queue_hwm());
-    }
-    else
-    {
-        cout << "No output saved for combination of "
-             << test::PrintableBuildConf{} << std::endl;
-        result.print_expected();
+    // Initialize some primaries and take a step
+    auto primaries = this->make_primaries(num_primaries);
+    auto counts    = step(primaries);
+    EXPECT_EQ(num_primaries, counts.active);
+    EXPECT_EQ(num_primaries, counts.alive);
 
-        if (this->strict_testing())
-        {
-            FAIL() << "Updated stepper results are required for CI tests";
-        }
-    }
+    // Transport existing tracks
+    counts = step();
+    EXPECT_EQ(num_primaries, counts.active);
+    EXPECT_EQ(num_primaries, counts.alive);
 
-    // Check that callback was called
-    EXPECT_EQ(result.active.size(), this->dummy_action().num_execute_host());
-    EXPECT_EQ(0, this->dummy_action().num_execute_device());
+    // Add some more primaries
+    primaries = this->make_primaries(num_primaries);
+    counts    = step(primaries);
+    EXPECT_EQ(24, counts.active);
+    EXPECT_EQ(24, counts.alive);
+
+    // Transport existing tracks
+    counts = step();
+    EXPECT_EQ(44, counts.active);
+    EXPECT_EQ(44, counts.alive);
 }
 
 TEST_F(TestEm3Test, TEST_IF_CELER_DEVICE(device))
@@ -278,13 +273,12 @@ TEST_F(TestEm3Test, TEST_IF_CELER_DEVICE(device))
         GTEST_SKIP() << "TODO: TestEm3 + vecgeom crashes on CI";
     }
 
-    size_type num_sets      = 1;
     size_type num_primaries = 8;
     // Num tracks is low enough to hit capacity
     size_type num_tracks = num_primaries * 800;
 
     Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
-    auto result = this->run(step, num_primaries, num_sets);
+    auto                      result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(62756.625, result.calc_avg_steps_per_primary(), 0.10);
 
     if (this->is_ci_build() || this->is_wildstyle_build())
@@ -293,42 +287,6 @@ TEST_F(TestEm3Test, TEST_IF_CELER_DEVICE(device))
         EXPECT_SOFT_EQ(62756.625, result.calc_avg_steps_per_primary());
         EXPECT_EQ(82, result.calc_emptying_step());
         EXPECT_EQ(RunResult::StepCount({75, 1450}), result.calc_queue_hwm());
-    }
-    else
-    {
-        cout << "No output saved for combination of "
-             << test::PrintableBuildConf{} << std::endl;
-        result.print_expected();
-
-        if (this->strict_testing())
-        {
-            FAIL() << "Updated stepper results are required for CI tests";
-        }
-    }
-
-    // Check that callback was called
-    EXPECT_EQ(result.active.size(), this->dummy_action().num_execute_device());
-    EXPECT_EQ(0, this->dummy_action().num_execute_host());
-}
-
-TEST_F(TestEm3Test, TEST_IF_CELER_DEVICE(device_multi))
-{
-    // Run and inject multiple sets of primaries during the transport loop
-
-    size_type num_sets      = 4;
-    size_type num_primaries = 2;
-    size_type num_tracks    = 2048;
-
-    Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
-    auto result = this->run(step, num_primaries, num_sets);
-    EXPECT_SOFT_NEAR(61883.75, result.calc_avg_steps_per_primary(), 0.10);
-
-    if (this->is_ci_build() || this->is_wildstyle_build())
-    {
-        EXPECT_EQ(740, result.num_step_iters());
-        EXPECT_SOFT_EQ(61883.75, result.calc_avg_steps_per_primary());
-        EXPECT_EQ(641, result.calc_emptying_step());
-        EXPECT_EQ(RunResult::StepCount({637, 294}), result.calc_queue_hwm());
     }
     else
     {
@@ -384,12 +342,11 @@ TEST_F(TestEm3MscTest, setup)
 
 TEST_F(TestEm3MscTest, host)
 {
-    size_type num_sets      = 1;
     size_type num_primaries = 8;
     size_type num_tracks    = 2048;
 
     Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
-    auto                    result = this->run(step, num_primaries, num_sets);
+    auto                    result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(45.125, result.calc_avg_steps_per_primary(), 0.10);
 
     if (this->is_ci_build() || this->is_wildstyle_build())
@@ -414,12 +371,11 @@ TEST_F(TestEm3MscTest, host)
 
 TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
 {
-    size_type num_sets      = 1;
     size_type num_primaries = 8;
     size_type num_tracks    = 1024;
 
     Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
-    auto result = this->run(step, num_primaries, num_sets);
+    auto                      result = this->run(step, num_primaries);
 
     if (this->is_ci_build() || this->is_wildstyle_build())
     {
@@ -455,12 +411,11 @@ TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
 
 TEST_F(TestEm3MscNofluctTest, host)
 {
-    size_type num_sets      = 1;
     size_type num_primaries = 8;
     size_type num_tracks    = 2048;
 
     Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
-    auto                    result = this->run(step, num_primaries, num_sets);
+    auto                    result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(58, result.calc_avg_steps_per_primary(), 0.10);
 
     if (this->is_ci_build() || this->is_wildstyle_build())
@@ -497,12 +452,11 @@ TEST_F(TestEm3MscNofluctTest, TEST_IF_CELER_DEVICE(device))
         GTEST_SKIP() << "TODO: TestEm3 + vecgeom crashes on CI";
     }
 
-    size_type num_sets      = 1;
     size_type num_primaries = 8;
     size_type num_tracks    = 1024;
 
     Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
-    auto result = this->run(step, num_primaries, num_sets);
+    auto                      result = this->run(step, num_primaries);
 
     if (this->is_ci_build() || this->is_wildstyle_build())
     {
@@ -562,12 +516,11 @@ TEST_F(TestEm15FieldTest, setup)
 
 TEST_F(TestEm15FieldTest, host)
 {
-    size_type num_sets      = 1;
     size_type num_primaries = 4;
     size_type num_tracks    = 1024;
 
     Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
-    auto                    result = this->run(step, num_primaries, num_sets);
+    auto                    result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(35, result.calc_avg_steps_per_primary(), 0.10);
 
     if (this->is_ci_build() || this->is_summit_build()
@@ -593,12 +546,11 @@ TEST_F(TestEm15FieldTest, host)
 
 TEST_F(TestEm15FieldTest, TEST_IF_CELER_DEVICE(device))
 {
-    size_type num_sets      = 1;
     size_type num_primaries = 8;
     size_type num_tracks    = 1024;
 
     Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
-    auto result = this->run(step, num_primaries, num_sets);
+    auto                      result = this->run(step, num_primaries);
 
     if (this->is_ci_build() || this->is_summit_build()
         || this->is_wildstyle_build())

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -196,12 +196,10 @@ TEST_F(TestEm3Test, setup)
 
 TEST_F(TestEm3Test, host)
 {
-    size_type num_primaries   = 1;
-    size_type inits_per_track = 32 * 8;
-    size_type num_tracks      = num_primaries * inits_per_track;
+    size_type num_primaries = 1;
+    size_type num_tracks    = 256;
 
-    Stepper<MemSpace::host> step(
-        this->make_stepper_input(num_tracks, inits_per_track));
+    Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(63490, result.calc_avg_steps_per_primary(), 0.10);
 
@@ -243,13 +241,11 @@ TEST_F(TestEm3Test, TEST_IF_CELER_DEVICE(device))
         GTEST_SKIP() << "TODO: TestEm3 + vecgeom crashes on CI";
     }
 
-    size_type num_primaries   = 8;
-    size_type inits_per_track = 1024;
+    size_type num_primaries = 8;
     // Num tracks is low enough to hit capacity
     size_type num_tracks = num_primaries * 800;
 
-    Stepper<MemSpace::device> step(
-        this->make_stepper_input(num_tracks, inits_per_track));
+    Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(62756.625, result.calc_avg_steps_per_primary(), 0.10);
 
@@ -314,12 +310,10 @@ TEST_F(TestEm3MscTest, setup)
 
 TEST_F(TestEm3MscTest, host)
 {
-    size_type num_primaries   = 8;
-    size_type inits_per_track = 32 * 8;
-    size_type num_tracks      = num_primaries * inits_per_track;
+    size_type num_primaries = 8;
+    size_type num_tracks    = 2048;
 
-    Stepper<MemSpace::host> step(
-        this->make_stepper_input(num_tracks, inits_per_track));
+    Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(45.125, result.calc_avg_steps_per_primary(), 0.10);
 
@@ -345,12 +339,10 @@ TEST_F(TestEm3MscTest, host)
 
 TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
 {
-    size_type num_primaries   = 8;
-    size_type inits_per_track = 512;
-    size_type num_tracks      = 1024;
+    size_type num_primaries = 8;
+    size_type num_tracks    = 1024;
 
-    Stepper<MemSpace::device> step(
-        this->make_stepper_input(num_tracks, inits_per_track));
+    Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
 
     if (this->is_ci_build() || this->is_wildstyle_build())
@@ -387,12 +379,10 @@ TEST_F(TestEm3MscTest, TEST_IF_CELER_DEVICE(device))
 
 TEST_F(TestEm3MscNofluctTest, host)
 {
-    size_type num_primaries   = 8;
-    size_type inits_per_track = 32 * 8;
-    size_type num_tracks      = num_primaries * inits_per_track;
+    size_type num_primaries = 8;
+    size_type num_tracks    = 2048;
 
-    Stepper<MemSpace::host> step(
-        this->make_stepper_input(num_tracks, inits_per_track));
+    Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(58, result.calc_avg_steps_per_primary(), 0.10);
 
@@ -430,12 +420,10 @@ TEST_F(TestEm3MscNofluctTest, TEST_IF_CELER_DEVICE(device))
         GTEST_SKIP() << "TODO: TestEm3 + vecgeom crashes on CI";
     }
 
-    size_type num_primaries   = 8;
-    size_type inits_per_track = 512;
-    size_type num_tracks      = 1024;
+    size_type num_primaries = 8;
+    size_type num_tracks    = 1024;
 
-    Stepper<MemSpace::device> step(
-        this->make_stepper_input(num_tracks, inits_per_track));
+    Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
 
     if (this->is_ci_build() || this->is_wildstyle_build())
@@ -496,12 +484,10 @@ TEST_F(TestEm15FieldTest, setup)
 
 TEST_F(TestEm15FieldTest, host)
 {
-    size_type num_primaries   = 4;
-    size_type inits_per_track = 32 * 8;
-    size_type num_tracks      = num_primaries * inits_per_track;
+    size_type num_primaries = 4;
+    size_type num_tracks    = 1024;
 
-    Stepper<MemSpace::host> step(
-        this->make_stepper_input(num_tracks, inits_per_track));
+    Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
     EXPECT_SOFT_NEAR(35, result.calc_avg_steps_per_primary(), 0.10);
 
@@ -528,12 +514,10 @@ TEST_F(TestEm15FieldTest, host)
 
 TEST_F(TestEm15FieldTest, TEST_IF_CELER_DEVICE(device))
 {
-    size_type num_primaries   = 8;
-    size_type inits_per_track = 512;
-    size_type num_tracks      = 1024;
+    size_type num_primaries = 8;
+    size_type num_tracks    = 1024;
 
-    Stepper<MemSpace::device> step(
-        this->make_stepper_input(num_tracks, inits_per_track));
+    Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
 
     if (this->is_ci_build() || this->is_summit_build()

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -38,16 +38,13 @@ StepperTestBase::StepperTestBase()
 
 //---------------------------------------------------------------------------//
 //! Generate a stepper construction class
-StepperInput
-StepperTestBase::make_stepper_input(size_type tracks, size_type init_scaling)
+StepperInput StepperTestBase::make_stepper_input(size_type tracks)
 {
     CELER_EXPECT(tracks > 0);
-    CELER_EXPECT(init_scaling > 1);
 
     StepperInput result;
-    result.params           = this->core();
-    result.num_track_slots  = tracks;
-    result.num_initializers = init_scaling * tracks;
+    result.params          = this->core();
+    result.num_track_slots = tracks;
 
     return result;
 }
@@ -67,7 +64,7 @@ auto StepperTestBase::check_setup() -> SetupCheckResult
     }
 
     // Create temporary host stepper to get action ordering
-    Stepper<MemSpace::host> temp_stepper(this->make_stepper_input(1, 2));
+    Stepper<MemSpace::host> temp_stepper(this->make_stepper_input(1));
     const auto&             action_seq = temp_stepper.actions();
     for (const auto& sp_action : action_seq.actions())
     {
@@ -84,7 +81,8 @@ auto StepperTestBase::run(StepperInterface& step,
     CELER_EXPECT(step);
 
     // Perform first step
-    auto counts = step(this->make_primaries(num_primaries));
+    auto primaries = this->make_primaries(num_primaries);
+    auto counts    = step(primaries);
     EXPECT_EQ(num_primaries, counts.active);
     EXPECT_EQ(num_primaries, counts.alive);
 

--- a/test/celeritas/global/StepperTestBase.hh
+++ b/test/celeritas/global/StepperTestBase.hh
@@ -58,6 +58,8 @@ class StepperTestBase : virtual public GlobalTestBase
     {
         using StepCount = std::pair<size_type, size_type>;
 
+        size_type              num_primaries{};
+        size_type              num_sets{};
         std::vector<size_type> active;
         std::vector<size_type> queued;
 
@@ -76,7 +78,8 @@ class StepperTestBase : virtual public GlobalTestBase
         //! True if run was performed and data is consistent
         explicit operator bool() const
         {
-            return !active.empty() && queued.size() == active.size();
+            return !active.empty() && queued.size() == active.size()
+                   && num_primaries > 0 && num_sets > 0;
         }
     };
 
@@ -96,8 +99,10 @@ class StepperTestBase : virtual public GlobalTestBase
     // Get the physics output
     SetupCheckResult check_setup();
 
-    // Run a bunch of primaries to completion
-    RunResult run(StepperInterface& step, size_type num_primaries) const;
+    // Run multiple sets of primaries to completion
+    RunResult run(StepperInterface& step,
+                  size_type         num_primaries,
+                  size_type         num_sets) const;
 
     //! Access the dummy action
     const DummyAction& dummy_action() const { return *dummy_action_; }

--- a/test/celeritas/global/StepperTestBase.hh
+++ b/test/celeritas/global/StepperTestBase.hh
@@ -58,8 +58,6 @@ class StepperTestBase : virtual public GlobalTestBase
     {
         using StepCount = std::pair<size_type, size_type>;
 
-        size_type              num_primaries{};
-        size_type              num_sets{};
         std::vector<size_type> active;
         std::vector<size_type> queued;
 
@@ -78,8 +76,7 @@ class StepperTestBase : virtual public GlobalTestBase
         //! True if run was performed and data is consistent
         explicit operator bool() const
         {
-            return !active.empty() && queued.size() == active.size()
-                   && num_primaries > 0 && num_sets > 0;
+            return !active.empty() && queued.size() == active.size();
         }
     };
 
@@ -99,10 +96,8 @@ class StepperTestBase : virtual public GlobalTestBase
     // Get the physics output
     SetupCheckResult check_setup();
 
-    // Run multiple sets of primaries to completion
-    RunResult run(StepperInterface& step,
-                  size_type         num_primaries,
-                  size_type         num_sets) const;
+    // Run a bunch of primaries to completion
+    RunResult run(StepperInterface& step, size_type num_primaries) const;
 
     //! Access the dummy action
     const DummyAction& dummy_action() const { return *dummy_action_; }

--- a/test/celeritas/global/StepperTestBase.hh
+++ b/test/celeritas/global/StepperTestBase.hh
@@ -85,7 +85,7 @@ class StepperTestBase : virtual public GlobalTestBase
     StepperTestBase();
 
     // Construct the setup values for Stepper
-    StepperInput make_stepper_input(size_type tracks, size_type init_scaling);
+    StepperInput make_stepper_input(size_type tracks);
 
     //! Create a vector of primaries inside the 'run' function
     virtual std::vector<Primary> make_primaries(size_type count) const = 0;

--- a/test/celeritas/phys/Physics.test.hh
+++ b/test/celeritas/phys/Physics.test.hh
@@ -56,7 +56,7 @@ inline CELER_FUNCTION real_type calc_step(PhysicsTrackView& phys,
                                           PhysicsStepView&  pstep,
                                           units::MevEnergy  energy)
 {
-    // Calc total macro_xs over processsess
+    // Calc total macro_xs over processes
     real_type total_xs = 0;
     for (auto ppid : range(ParticleProcessId{phys.num_particle_processes()}))
     {

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -243,8 +243,10 @@ TEST_F(TrackInitTest, run)
 
 TEST_F(TrackInitTest, primaries)
 {
-    const size_type num_primaries = 1024;
-    const size_type num_tracks    = 512;
+    const size_type num_sets            = 8;
+    const size_type num_primaries       = 1024;
+    const size_type num_tracks          = 512;
+    const size_type primaries_per_track = num_primaries / num_tracks;
 
     build_states(num_tracks);
 
@@ -253,14 +255,14 @@ TEST_F(TrackInitTest, primaries)
     std::vector<char>      alive(num_tracks, 0);
     ITTestInput            input(alloc, alive);
 
-    for (int i = 0; i < 8; ++i)
+    for (size_type i = 0; i < num_sets; ++i)
     {
         // Create track initializers on device from primary particles
         auto primaries = generate_primaries(num_primaries);
         extend_from_primaries(core_data, primaries);
         EXPECT_EQ(core_data.states.init.initializers.size(), num_primaries);
 
-        for (int j = 0; j < 2; ++j)
+        for (size_type j = 0; j < primaries_per_track; ++j)
         {
             // Initialize tracks on device
             initialize_tracks(core_data);

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -86,28 +86,24 @@ class TrackInitTest : public SimpleTestBase
     void build_states(size_type num_tracks)
     {
         CELER_EXPECT(core_data.params);
-        CELER_EXPECT(track_inits);
 
         // Allocate state data
         resize(&device_states, this->core()->host_ref(), num_tracks);
         core_data.states = device_states;
 
-        resize(&track_init_states, track_inits->host_ref(), num_tracks);
-        CELER_ENSURE(core_data.states && track_init_states);
+        CELER_ENSURE(core_data.states);
     }
 
     //! Copy results to host
-    ITTestOutput get_result(CoreStateDeviceRef&   states,
-                            TrackInitDeviceValue& track_init_states)
+    ITTestOutput get_result(CoreStateDeviceRef& states)
     {
         CELER_EXPECT(states);
-        CELER_EXPECT(track_init_states);
 
         ITTestOutput result;
 
         // Copy track initializer data to host
         HostVal<TrackInitStateData> data;
-        data = track_init_states;
+        data = states.init;
 
         // Store the IDs of the vacant track slots
         const auto vacancies = data.vacancies.data();
@@ -133,12 +129,8 @@ class TrackInitTest : public SimpleTestBase
         return result;
     }
 
-    std::shared_ptr<TrackInitParams> track_inits;
-
-    CollectionMirror<PhysicsParamsData>               physics;
     CoreStateData<Ownership::value, MemSpace::device> device_states;
     CoreDeviceRef                                     core_data;
-    TrackInitDeviceValue                              track_init_states;
 };
 
 //---------------------------------------------------------------------------//
@@ -147,42 +139,37 @@ class TrackInitTest : public SimpleTestBase
 
 TEST_F(TrackInitTest, run)
 {
-    const size_type num_primaries  = 12;
-    const size_type num_tracks     = 10;
-    const size_type storage_factor = 10;
-    size_type       capacity       = num_tracks * storage_factor;
-
-    // Construct persistent track initializer data
-    track_inits = std::make_shared<TrackInitParams>(
-        TrackInitParams::Input{generate_primaries(num_primaries), capacity});
+    const size_type num_primaries = 12;
+    const size_type num_tracks    = 10;
 
     build_states(num_tracks);
 
     // Check that all of the track slots were marked as empty
     {
-        auto result = get_result(core_data.states, track_init_states);
+        auto                      result = get_result(core_data.states);
         static const unsigned int expected_vacancies[]
             = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         EXPECT_VEC_EQ(expected_vacancies, result.vacancies);
     }
 
     // Create track initializers on device from primary particles
-    extend_from_primaries(track_inits->host_ref(), &track_init_states);
+    auto primaries = generate_primaries(num_primaries);
+    extend_from_primaries(core_data, primaries);
 
     // Check the track IDs of the track initializers created from primaries
     {
-        auto result = get_result(core_data.states, track_init_states);
+        auto                      result = get_result(core_data.states);
         static const unsigned int expected_track_ids[]
             = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
         EXPECT_VEC_EQ(expected_track_ids, result.init_ids);
     }
 
     // Initialize the primary tracks on device
-    initialize_tracks(core_data, &track_init_states);
+    initialize_tracks(core_data);
 
     // Check the track IDs and parent IDs of the initialized tracks
     {
-        auto result = get_result(core_data.states, track_init_states);
+        auto                      result = get_result(core_data.states);
         static const unsigned int expected_track_ids[]
             = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
         EXPECT_VEC_EQ(expected_track_ids, result.track_ids);
@@ -203,11 +190,11 @@ TEST_F(TrackInitTest, run)
     interact(core_data.states, input.device_ref());
 
     // Launch a kernel to create track initializers from secondaries
-    extend_from_secondaries(core_data, &track_init_states);
+    extend_from_secondaries(core_data);
 
     // Check the vacancies
     {
-        auto result = get_result(core_data.states, track_init_states);
+        auto                      result = get_result(core_data.states);
         static const unsigned int expected_vacancies[] = {2, 6};
         EXPECT_VEC_EQ(expected_vacancies, result.vacancies);
     }
@@ -218,7 +205,7 @@ TEST_F(TrackInitTest, run)
     // used for the track initializers, just check that there is the correct
     // number and they are in the correct range.
     {
-        auto result = get_result(core_data.states, track_init_states);
+        auto result = get_result(core_data.states);
         EXPECT_TRUE(std::all_of(std::begin(result.init_ids),
                                 std::end(result.init_ids),
                                 [](unsigned int id) { return id <= 18; }));
@@ -230,11 +217,11 @@ TEST_F(TrackInitTest, run)
     }
 
     // Initialize secondaries on device
-    initialize_tracks(core_data, &track_init_states);
+    initialize_tracks(core_data);
 
     // Check the track IDs and parent IDs of the initialized tracks
     {
-        auto result = get_result(core_data.states, track_init_states);
+        auto result = get_result(core_data.states);
         EXPECT_TRUE(std::all_of(std::begin(result.track_ids),
                                 std::end(result.track_ids),
                                 [](unsigned int id) { return id <= 18; }));
@@ -256,14 +243,8 @@ TEST_F(TrackInitTest, run)
 
 TEST_F(TrackInitTest, primaries)
 {
-    const size_type num_primaries  = 8192;
-    const size_type num_tracks     = 512;
-    const size_type storage_factor = 2;
-    size_type       capacity       = num_tracks * storage_factor;
-
-    // Construct persistent track initializer data
-    track_inits = std::make_shared<TrackInitParams>(
-        TrackInitParams::Input{generate_primaries(num_primaries), capacity});
+    const size_type num_primaries = 1024;
+    const size_type num_tracks    = 512;
 
     build_states(num_tracks);
 
@@ -272,36 +253,32 @@ TEST_F(TrackInitTest, primaries)
     std::vector<char>      alive(num_tracks, 0);
     ITTestInput            input(alloc, alive);
 
-    for (auto i = num_primaries; i > 0; i -= capacity)
+    for (int i = 0; i < 8; ++i)
     {
-        EXPECT_EQ(track_init_states.num_primaries, i);
-
         // Create track initializers on device from primary particles
-        extend_from_primaries(track_inits->host_ref(), &track_init_states);
+        auto primaries = generate_primaries(num_primaries);
+        extend_from_primaries(core_data, primaries);
+        EXPECT_EQ(core_data.states.init.initializers.size(), num_primaries);
 
-        for (auto j = capacity; j > 0; j -= num_tracks)
+        for (int j = 0; j < 2; ++j)
         {
-            EXPECT_EQ(track_init_states.initializers.size(), j);
-
             // Initialize tracks on device
-            initialize_tracks(core_data, &track_init_states);
+            initialize_tracks(core_data);
 
-            // Launch kernel that will kill all trackss
+            // Launch kernel that will kill all tracks
             interact(core_data.states, input.device_ref());
 
-            // Launch a kernel to create track initializers from secondaries
-            extend_from_secondaries(core_data, &track_init_states);
+            // Find vacancies and create track initializers from secondaries
+            extend_from_secondaries(core_data);
         }
+        EXPECT_EQ(core_data.states.init.initializers.size(), 0);
     }
 
     // Check the final track IDs
-    auto result = get_result(core_data.states, track_init_states);
+    auto                   result = get_result(core_data.states);
     std::vector<size_type> expected_track_ids(num_tracks);
     std::iota(expected_track_ids.begin(), expected_track_ids.end(), 0);
     EXPECT_VEC_EQ(expected_track_ids, result.track_ids);
-
-    EXPECT_EQ(track_init_states.num_primaries, 0);
-    EXPECT_EQ(track_init_states.initializers.size(), 0);
 }
 
 #define TrackInitSecondaryTest TEST_IF_CELER_DEVICE(TrackInitSecondaryTest)
@@ -314,14 +291,8 @@ class TrackInitSecondaryTest : public TrackInitTest
 
 TEST_F(TrackInitSecondaryTest, secondaries)
 {
-    const size_type num_primaries  = 512;
-    const size_type num_tracks     = 512;
-    const size_type storage_factor = 8;
-    size_type       capacity       = num_tracks * storage_factor;
-
-    // Construct persistent track initializer data
-    track_inits = std::make_shared<TrackInitParams>(
-        TrackInitParams::Input{generate_primaries(num_primaries), capacity});
+    const size_type num_primaries = 512;
+    const size_type num_tracks    = 512;
 
     build_states(num_tracks);
 
@@ -338,25 +309,25 @@ TEST_F(TrackInitSecondaryTest, secondaries)
     ITTestInput input(alloc, alive);
 
     // Create track initializers on device from primary particles
-    extend_from_primaries(track_inits->host_ref(), &track_init_states);
-    EXPECT_EQ(0, track_init_states.num_primaries);
-    EXPECT_EQ(num_primaries, track_init_states.initializers.size());
+    auto primaries = generate_primaries(num_primaries);
+    extend_from_primaries(core_data, primaries);
+    EXPECT_EQ(num_primaries, core_data.states.init.initializers.size());
 
     const size_type num_iter = 16;
     for (CELER_MAYBE_UNUSED size_type i : range(num_iter))
     {
         // All queued initializers are converted to tracks
-        initialize_tracks(core_data, &track_init_states);
-        ASSERT_EQ(0, track_init_states.initializers.size());
+        initialize_tracks(core_data);
+        ASSERT_EQ(0, core_data.states.init.initializers.size());
 
         // Launch kernel to process interactions
         interact(core_data.states, input.device_ref());
 
         // Launch a kernel to create track initializers from secondaries
-        extend_from_secondaries(core_data, &track_init_states);
-        ASSERT_EQ(128, track_init_states.initializers.size())
+        extend_from_secondaries(core_data);
+        ASSERT_EQ(128, core_data.states.init.initializers.size())
             << "iteration " << i;
-        ASSERT_EQ(128, track_init_states.vacancies.size());
+        ASSERT_EQ(128, core_data.states.init.vacancies.size());
     }
 }
 


### PR DESCRIPTION
Closes #476.

- Modify track initialization code to allow new primaries to be added at any step
- Store track initialization params/states with the other core data