### PR TITLE
Add CMakePresets and env script for perlmutter

### DIFF
--- a/scripts/cmake-presets/perlmutter.json
+++ b/scripts/cmake-presets/perlmutter.json
@@ -1,0 +1,101 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {"major": 3, "minor": 21, "patch": 0},
+  "configurePresets": [
+    {
+      "name": ".base",
+      "hidden": true,
+      "inherits": ["full"],
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS":     {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILD_DOCS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_CUDA":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_HIP":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_JSON":    {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_MPI":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_SWIG":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "ON"},
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wno-psabi -pedantic -pedantic-errors",
+        "CMAKE_CUDA_FLAGS": "-Xcompiler -Wno-psabi",
+        "CMAKE_CUDA_ARCHITECTURES": {"type": "STRING", "value": "80"},
+        "CMAKE_CXX_STANDARD": {"type": "STRING", "value": "17"},
+        "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}",
+        "CMAKE_CXX_COMPILER": "CC",
+        "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=znver3 -mtune=znver3",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"}
+      }
+    },
+    {
+      "name": ".reldeb",
+      "hidden": true,
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
+        "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "ON"},
+        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "RelWithDebInfo"}
+      }
+    },
+    {
+      "name": "base",
+      "displayName": "Perlmutter default options (GCC, debug)",
+      "inherits": [".base"],
+      "binaryDir": "${sourceDir}/build"
+    },
+    {
+      "name": "reldeb-novg",
+      "displayName": "Perlmutter release mode",
+      "inherits": [".reldeb", ".base"],
+      "cacheVariables": {
+        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
+      "name": "reldeb",
+      "displayName": "Perlmutter release mode",
+      "inherits": [".reldeb", ".base"]
+    },
+    {
+      "name": "ndebug-novg",
+      "displayName": "Perlmutter release mode",
+      "inherits": [".ndebug", ".base"],
+      "cacheVariables": {
+        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
+      "name": "ndebug",
+      "displayName": "Perlmutter release mode",
+      "inherits": [".ndebug", ".base"]
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base",
+      "configurePreset": "base",
+      "jobs": 8,
+      "nativeToolOptions": ["-k0"]
+    },
+    {"name": "ndebug", "configurePreset": "ndebug", "inherits": "base"},
+    {"name": "ndebug-novg", "configurePreset": "ndebug-novg", "inherits": "base"},
+    {"name": "reldeb", "configurePreset": "reldeb", "inherits": "base"},
+    {"name": "reldeb-novg", "configurePreset": "reldeb-novg", "inherits": "base"}
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "configurePreset": "base",
+      "output": {"outputOnFailure": true},
+      "execution": {"noTestsAction": "error", "stopOnFailure": false, "jobs": 8}
+    },
+    {"name": "ndebug", "configurePreset": "ndebug", "inherits": "base"},
+    {"name": "ndebug-novg", "configurePreset": "ndebug-novg", "inherits": "base"},
+    {"name": "reldeb", "configurePreset": "reldeb", "inherits": "base"},
+    {"name": "reldeb-novg", "configurePreset": "reldeb-novg", "inherits": "base"}
+  ]
+}

--- a/scripts/env/perlmutter.sh
+++ b/scripts/env/perlmutter.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+# The cudatoolkit on Perlmutter is provided by NVHPC, which moved some CUDA headers to a "math_libs" directory (e.g., curand_kernel.h).
+# If using Spack, this will cause a compile error in VecGeom+cuda.
+# Spack uses this CUDA install as external CUDA package and doesn't look in the math_libs directory for extra headers.
+# --> the fix for now is to unload these modules and install our own cudatoolkit using Spack.
+module unload gpu cudatoolkit
+module load PrgEnv-gnu/8.3.3
+
+# Spack module on Perlmutter currently fails to create the spack env from spack.yaml, so we use our own install
+_SPACK_INSTALL=${SCRATCH}/spack
+
+. ${_SPACK_INSTALL}/share/spack/setup-env.sh
+spack env activate celeritas

--- a/scripts/env/perlmutter.sh
+++ b/scripts/env/perlmutter.sh
@@ -7,8 +7,14 @@
 module unload gpu cudatoolkit
 module load PrgEnv-gnu/8.3.3
 
-# Spack module on Perlmutter currently fails to create the spack env from spack.yaml, so we use our own install
+# Spack module on Perlmutter currently fails to create the spack env from spack.yaml, we need Spack v0.18.0; use our own install instead.
+# Expects the spack git repo to have been cloned at _SPACK_INSTALL and the environment celeritas to exist
 _SPACK_INSTALL=${SCRATCH}/spack
+_SPACK_SOURCE_FILE=${_SPACK_INSTALL}/share/spack/setup-env.sh
+if [ ! -f "${_SPACK_SOURCE_FILE}" ]; then
+    echo "Expected to find a spack install at ${_SPACK_INSTALL}" >&2
+    exit 2
+fi
 
-. ${_SPACK_INSTALL}/share/spack/setup-env.sh
+. ${_SPACK_SOURCE_FILE}
 spack env activate celeritas


### PR DESCRIPTION
I've added support for building Celeritas on Perlmutter with a few caveats:

- We need Spack  v0.18.0 and Perlmutter only has older version available so I have to use my own Spack installation for now.
- We need to install CUDA v1.7.0 in our Spack env. The CUDA version provided on Perlmutter is from NVHPC, which moved some headers file needed by Vecgeom. Another solution would be to tell Spack to keep `CPATH` set by the cudatoolkit module by setting `dirty: true` in the Spack config file; I don't like this option as much because it makes the build less reproducible depending on which modules are loaded...