### PR TITLE
Enable resizing of CUDA malloc heap to fix VecGeom failures

### DIFF
--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -58,6 +58,11 @@ void run(std::istream* is, OutputManager* output)
     // Read input options
     auto inp = nlohmann::json::parse(*is);
 
+    if (inp.contains("cuda_heap_size"))
+    {
+        int heapSize = inp.at("cuda_heap_size").get<int>();
+        set_cuda_heap_size(heapSize);
+    }
     if (inp.contains("cuda_stack_size"))
     {
         celeritas::set_cuda_stack_size(inp.at("cuda_stack_size").get<int>());

--- a/app/demo-rasterizer/demo-rasterizer.cc
+++ b/app/demo-rasterizer/demo-rasterizer.cc
@@ -43,16 +43,21 @@ void run(std::istream& is)
     auto inp    = nlohmann::json::parse(is);
     auto timers = nlohmann::json::object();
 
+    if (inp.contains("cuda_heap_size"))
+    {
+        int heapSize = inp.at("cuda_heap_size").get<int>();
+        set_cuda_heap_size(heapSize);
+    }
+    if (inp.contains("cuda_stack_size"))
+    {
+        set_cuda_stack_size(inp.at("cuda_stack_size").get<int>());
+    }
+
     // Load geometry
     Stopwatch get_time;
     auto      geo_params = std::make_shared<GeoParams>(
         inp.at("input").get<std::string>().c_str());
     timers["load"] = get_time();
-
-    if (inp.contains("cuda_stack_size"))
-    {
-        set_cuda_stack_size(inp.at("cuda_stack_size").get<int>());
-    }
 
     // Construct image
     ImageStore image(inp.at("image").get<ImageRunArgs>());

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -287,4 +287,19 @@ void set_cuda_stack_size(int limit)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Increase CUDA heap size to enable complex geometries with VecGeom.
+ *
+ * For the cms-hllhc.gdml detector geometry, the 8MB default heap size is too
+ * small, and a new size as high as 33554432 (=32MB) has run successfully.
+ * This should be increased as necessary, but avoid setting it too high.
+ */
+void set_cuda_heap_size(int limit)
+{
+    CELER_EXPECT(limit > 0);
+    CELER_EXPECT(celeritas::device());
+    CELER_CUDA_CALL(cudaDeviceSetLimit(cudaLimitMallocHeapSize, limit));
+}
+
+//---------------------------------------------------------------------------//
 } // namespace celeritas

--- a/src/corecel/sys/Device.hh
+++ b/src/corecel/sys/Device.hh
@@ -129,6 +129,9 @@ std::ostream& operator<<(std::ostream&, const Device&);
 // Increase CUDA stack size
 void set_cuda_stack_size(int limit);
 
+// Increase CUDA HEAP size
+void set_cuda_heap_size(int limit);
+
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Default size of CUDA heap is 8MB = 2^23 = 8388608, which is not enough to load cms-hllhc.gdml onto the GPU.  
A new heap size of 12MB = 12582912 works, as tested in demo-rasterizer.