### PR TITLE
Add detector mapping and filtering to hit collector

### DIFF
--- a/doc/appendices/development.rst
+++ b/doc/appendices/development.rst
@@ -184,7 +184,8 @@ Certain decorations (separators, Doxygen comment structure,
 etc.) are standard throughout the code. Use the :file:`celeritas-gen.py` script
 (in the :file:`scripts/dev` directory) to generate skeletons for new files, and
 use existing source code as a guide to how to structure the decorations.
-
+Doxygen comments should be provided next to the *definition* of functions (both
+member and free) and classes.
 
 Symbol names
 ------------

--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -62,6 +62,9 @@ using ParticleModelId = OpaqueId<ModelId>;
 //! Opaque index of electron subshell
 using SubshellId = OpaqueId<struct Subshell>;
 
+//! Opaque index for mapping volume-specific "sensitive detector" objects
+using DetectorId = OpaqueId<struct Detector>;
+
 //---------------------------------------------------------------------------//
 // ENUMERATIONS
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/StepCollector.hh
+++ b/src/celeritas/user/StepCollector.hh
@@ -9,6 +9,8 @@
 
 #include <memory>
 
+#include "celeritas/geo/GeoParamsFwd.hh"
+
 #include "StepData.hh"
 #include "StepInterface.hh"
 
@@ -31,6 +33,11 @@ struct StepStorage;
  * This defines the interface to set up and manage a generic class for
  * interfacing with the GPU track states at the beginning and/or end of every
  * step.
+ *
+ * \todo The step collector serves two purposes: supporting "sensitive
+ * detectors" (mapping volume IDs to detector IDs and ignoring unmapped
+ * volumes) and supporting unfiltered output for "MC truth" . Right now only
+ * one or the other can be used, not both.
  */
 class StepCollector
 {
@@ -38,12 +45,15 @@ class StepCollector
     //!@{
     //! \name Type aliases
     using SPStepInterface = std::shared_ptr<StepInterface>;
+    using SPConstGeo      = std::shared_ptr<const GeoParams>;
     using VecInterface    = std::vector<SPStepInterface>;
     //!@}
 
   public:
     // Construct with options and register pre/post-step actions
-    StepCollector(VecInterface callbacks, ActionRegistry* action_registry);
+    StepCollector(VecInterface    callbacks,
+                  SPConstGeo      geo,
+                  ActionRegistry* action_registry);
 
     // Default destructor and move
     ~StepCollector();

--- a/src/celeritas/user/StepData.hh
+++ b/src/celeritas/user/StepData.hh
@@ -19,6 +19,9 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+// TYPES
+//---------------------------------------------------------------------------//
+//! Differentiate between data at the beginning and end of a step.
 enum class StepPoint
 {
     pre,
@@ -113,12 +116,22 @@ struct StepParamsData
 {
     //// DATA ////
 
+    //! Options for gathering data at each step
     StepSelection selection;
+
+    //! Optional mapping for volume -> sensitive detector
+    Collection<DetectorId, W, M, VolumeId> detector;
+
+    //! Filter out steps that have not deposited energy (for sensitive det)
+    bool nonzero_energy_deposition{false};
 
     //// METHODS ////
 
     //! Whether the data is assigned
-    explicit CELER_FUNCTION operator bool() const { return true; }
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return static_cast<bool>(selection);
+    }
 
     //! Assign from another set of data
     template<Ownership W2, MemSpace M2>
@@ -126,6 +139,8 @@ struct StepParamsData
     {
         CELER_EXPECT(other);
         selection = other.selection;
+        detector  = other.detector;
+        nonzero_energy_deposition = other.nonzero_energy_deposition;
         return *this;
     }
 };
@@ -187,6 +202,10 @@ struct StepPointStateData
  * - If the flag is disabled (no step interfaces require the data), then the
  *   corresponding member data will be empty.
  * - The track ID will be set to "false" if the track is inactive.
+ * - If sensitive detector are specified, the \c detector field is set based
+ *   on the pre-step geometric volume. Data members will have \b unspecified
+ *   values if the detector ID is "false" (i.e. no information is being
+ *   collected). The detector ID for inactive threads is always "false".
  */
 template<Ownership W, MemSpace M>
 struct StepStateData
@@ -203,8 +222,11 @@ struct StepStateData
     // Pre- and post-step data
     EnumArray<StepPoint, StepPointData> points;
 
-    // Track ID is always set
+    //! Track ID is always assigned (but will be false for inactive tracks)
     StateItems<TrackId> track;
+
+    //! Detector ID is non-empty if params.detector is nonempty
+    StateItems<DetectorId> detector;
 
     // Sim
     StateItems<EventId>   event;
@@ -225,7 +247,7 @@ struct StepStateData
             return (t.size() == this->size()) || t.empty();
         };
 
-        return !track.empty() && right_sized(event)
+        return !track.empty() && right_sized(detector) && right_sized(event)
                && right_sized(track_step_count) && right_sized(action)
                && right_sized(step_length) && right_sized(particle)
                && right_sized(energy_deposition);
@@ -246,6 +268,7 @@ struct StepStateData
         }
 
         track                   = other.track;
+        detector                = other.detector;
         event                   = other.event;
         track_step_count        = other.track_step_count;
         action                  = other.action;
@@ -313,6 +336,10 @@ inline void resize(StepStateData<Ownership::value, M>* state,
     } while (0)
 
     resize(&state->track, size);
+    if (!params.detector.empty())
+    {
+        resize(&state->detector, size);
+    }
 
     SD_RESIZE_IF_SELECTED(event);
     SD_RESIZE_IF_SELECTED(track_step_count);

--- a/src/celeritas/user/StepInterface.hh
+++ b/src/celeritas/user/StepInterface.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <map>
+
 #include "corecel/Types.hh"
 
 #include "StepData.hh"
@@ -16,6 +18,16 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Callback class to gather and process data from many tracks at a single step.
+ *
+ * The filtering mechanism allows different step interfaces to gather data from
+ * different detector volumes. Filtered step interfaces cannot be combined with
+ * unfiltered in a single hit collector. (FIXME: maybe we need a slightly
+ * different class hierarchy for the two cases?) If detectors are in use, and
+ * all \c StepInterface instances in use by a \c StepCollector select the
+ * "nonzero_energy_deposition" flag, then the \c StepStateData::detector entry
+ * for a thread with no energy deposition will be cleared even if it is in a
+ * sensitive detector. Otherwise entries with zero energy deposition will
+ * remain.
  */
 class StepInterface
 {
@@ -24,9 +36,22 @@ class StepInterface
     //! \name Type aliases
     using StateHostRef   = HostRef<StepStateData>;
     using StateDeviceRef = DeviceRef<StepStateData>;
+    using MapVolumeDetector = std::map<VolumeId, DetectorId>;
     //@}
 
+    //! Filtering to apply to the gathered data for this step.
+    struct Filters
+    {
+        //! Only select data from these volume IDs and map to detectors
+        MapVolumeDetector detectors;
+        //! Only select data with nonzero energy deposition (if detectors)
+        bool nonzero_energy_deposition{false};
+    };
+
   public:
+    //! Selection of data required for this interface
+    virtual Filters filters() const = 0;
+
     //! Selection of data required for this interface
     virtual StepSelection selection() const = 0;
 

--- a/src/corecel/data/CollectionBuilder.hh
+++ b/src/corecel/data/CollectionBuilder.hh
@@ -38,9 +38,8 @@ namespace celeritas
  * The CollectionBuilder can also be used to resize device-value collections
  * without having to allocate a host version and copy to device. (This is
  * useful for state allocations.) When resizing values with debugging
- assertions
- * enabled on host memory, it will assign garbage values to aid in reproducible
- * debugging.)
+ * assertions enabled on host memory, it will assign garbage values to aid in
+ * reproducible debugging.)
  */
 template<class T, MemSpace M, class I>
 class CollectionBuilder

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -234,8 +234,10 @@ celeritas_add_library(testcel_celeritas
   celeritas/SimpleTestBase.cc
   celeritas/global/AlongStepTestBase.cc
   celeritas/global/StepperTestBase.cc
+  celeritas/user/ExampleCalorimeters.cc
   celeritas/user/ExampleMctruth.cc
-  celeritas/user/StepCollectorTestBase.cc
+  celeritas/user/CaloTestBase.cc
+  celeritas/user/MctruthTestBase.cc
 )
 celeritas_target_link_libraries(testcel_celeritas
   PRIVATE Celeritas::celeritas Celeritas::testcel_harness ${_optional_json_link}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -234,7 +234,7 @@ celeritas_add_library(testcel_celeritas
   celeritas/SimpleTestBase.cc
   celeritas/global/AlongStepTestBase.cc
   celeritas/global/StepperTestBase.cc
-  celeritas/user/ExampleStepCallback.cc
+  celeritas/user/ExampleMctruth.cc
   celeritas/user/StepCollectorTestBase.cc
 )
 celeritas_target_link_libraries(testcel_celeritas

--- a/test/celeritas/user/CaloTestBase.cc
+++ b/test/celeritas/user/CaloTestBase.cc
@@ -1,0 +1,83 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/user/CaloTestBase.cc
+//---------------------------------------------------------------------------//
+#include "CaloTestBase.hh"
+
+#include <iostream>
+
+#include "celeritas/global/Stepper.hh"
+#include "celeritas/user/StepCollector.hh"
+
+#include "ExampleCalorimeters.hh"
+
+using std::cout;
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+CaloTestBase::~CaloTestBase() = default;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct example callback and step collector at setup time.
+ */
+void CaloTestBase::SetUp()
+{
+    example_calos_ = std::make_shared<ExampleCalorimeters>(
+        *this->geometry(), this->get_detector_names());
+
+    StepCollector::VecInterface interfaces = {example_calos_};
+
+    collector_ = std::make_shared<StepCollector>(
+        std::move(interfaces), this->geometry(), this->action_reg().get());
+}
+
+//---------------------------------------------------------------------------//
+//! Print the expected result
+void CaloTestBase::RunResult::print_expected() const
+{
+    cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
+            "static const double expected_edep[] = "
+         << repr(this->edep)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_edep, result.edep);\n"
+            "/*** END CODE ***/\n";
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Run a number of tracks.
+ */
+auto CaloTestBase::run(size_type num_tracks, size_type num_steps) -> RunResult
+{
+    StepperInput step_inp;
+    step_inp.params          = this->core();
+    step_inp.num_track_slots = num_tracks;
+
+    Stepper<MemSpace::host> step(step_inp);
+
+    // Initial step
+    auto count = step(this->make_primaries(num_tracks));
+
+    while (count && --num_steps > 0)
+    {
+        count = step();
+    }
+
+    RunResult result;
+    auto      edep = example_calos_->deposition();
+    result.edep.assign(edep.begin(), edep.end());
+    example_calos_->clear();
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace test
+} // namespace celeritas

--- a/test/celeritas/user/CaloTestBase.hh
+++ b/test/celeritas/user/CaloTestBase.hh
@@ -1,0 +1,58 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/user/CaloTestBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "corecel/io/Repr.hh"
+#include "celeritas/phys/Primary.hh"
+
+#include "StepCollectorTestBase.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+class StepCollector;
+
+namespace test
+{
+//---------------------------------------------------------------------------//
+class ExampleCalorimeters;
+
+class CaloTestBase : virtual public StepCollectorTestBase
+{
+  public:
+    using VecPrimary = std::vector<Primary>;
+    using VecString  = std::vector<std::string>;
+
+    struct RunResult
+    {
+        std::vector<double> edep;
+
+        void print_expected() const;
+    };
+
+  public:
+    // Default destructor
+    ~CaloTestBase();
+
+    void SetUp() override;
+
+    virtual VecString get_detector_names() const = 0;
+
+    RunResult run(size_type num_tracks, size_type num_steps);
+
+  protected:
+    std::shared_ptr<ExampleCalorimeters> example_calos_;
+    std::shared_ptr<StepCollector>       collector_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace test
+} // namespace celeritas

--- a/test/celeritas/user/ExampleCalorimeters.cc
+++ b/test/celeritas/user/ExampleCalorimeters.cc
@@ -1,0 +1,109 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/user/ExampleCalorimeters.cc
+//---------------------------------------------------------------------------//
+#include "ExampleCalorimeters.hh"
+
+#include "celeritas/geo/GeoParams.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Convert calorimeter volume names to volume IDs.
+ */
+ExampleCalorimeters::ExampleCalorimeters(const GeoParams&                geo,
+                                         const std::vector<std::string>& volumes)
+{
+    CELER_EXPECT(!volumes.empty());
+
+    for (const auto& name : volumes)
+    {
+        auto vid = geo.find_volume(name);
+        CELER_VALIDATE(vid, << "volume '" << name << "' does not exist");
+        detectors_.push_back(vid);
+    }
+
+    this->clear();
+    CELER_ENSURE(detectors_.size() == deposition_.size());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Map volume names to detector IDs and exclude tracks with no deposition.
+ */
+auto ExampleCalorimeters::filters() const -> Filters
+{
+    Filters result;
+
+    for (auto didx : range(detectors_.size()))
+    {
+        result.detectors[detectors_[didx]] = DetectorId{didx};
+    }
+
+    result.nonzero_energy_deposition = true;
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Gather event IDs and local energy deposition.
+ */
+StepSelection ExampleCalorimeters::selection() const
+{
+    StepSelection result;
+    result.event             = true;
+    result.energy_deposition = true;
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Process detector tallies.
+ */
+void ExampleCalorimeters::execute(StateHostRef const& data)
+{
+    for (auto tid : range(ThreadId{data.size()}))
+    {
+        DetectorId det = data.detector[tid];
+        if (!det)
+        {
+            // Skip thread slot that's inactive or not in a calorimeter
+            continue;
+        }
+
+        if (!event_)
+        {
+            event_ = data.event[tid];
+        }
+        // Only tally results from one event at a time
+        CELER_ASSERT(event_ == data.event[tid]);
+
+        CELER_ASSERT(det < deposition_.size());
+        real_type edep
+            = value_as<units::MevEnergy>(data.energy_deposition[tid]);
+        CELER_ASSERT(edep > 0);
+        deposition_[det.unchecked_get()] += edep;
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Reset for a new event.
+ */
+void ExampleCalorimeters::clear()
+{
+    event_ = {};
+    deposition_.assign(detectors_.size(), 0);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace test
+} // namespace celeritas

--- a/test/celeritas/user/ExampleCalorimeters.cc
+++ b/test/celeritas/user/ExampleCalorimeters.cc
@@ -41,7 +41,7 @@ auto ExampleCalorimeters::filters() const -> Filters
 {
     Filters result;
 
-    for (auto didx : range(detectors_.size()))
+    for (auto didx : range<DetectorId::size_type>(detectors_.size()))
     {
         result.detectors[detectors_[didx]] = DetectorId{didx};
     }

--- a/test/celeritas/user/ExampleCalorimeters.hh
+++ b/test/celeritas/user/ExampleCalorimeters.hh
@@ -3,12 +3,14 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/user/ExampleMctruth.hh
+//! \file celeritas/user/ExampleCalorimeters.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/cont/Span.hh"
-#include "celeritas/Types.hh"
+#include <string>
+#include <vector>
+
+#include "celeritas/geo/GeoParamsFwd.hh"
 #include "celeritas/user/StepInterface.hh"
 
 namespace celeritas
@@ -17,28 +19,22 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 /*!
- * Store all step data in an AOS.
+ * Construct a "detector" that accumulates energy deposition at every step.
  *
- * Construct a StepCollector with this callback interface to tally data during
- * execution. At the end of the run, for testing, call \c sort to reorder the
- * data by event/track/step, and then access the data with \c steps .
+ * This is not the most efficient way to integrate data over multiple steps
+ * (especially on device) but it is the most user-friendly way to do it.
+ *
+ * The current implementation only works with a single event at a time.
  */
-class ExampleMctruth final : public StepInterface
+class ExampleCalorimeters final : public StepInterface
 {
   public:
-    struct Step
-    {
-        int    event;
-        int    track;
-        int    step;
-        int    volume; // Beginning of step
-        double pos[3]; // Beginning of step
-        double dir[3]; // Beginning of step
-    };
+    // Construct from detectors to monitor
+    ExampleCalorimeters(const GeoParams&                geo,
+                        const std::vector<std::string>& volumes);
 
-  public:
-    //! Selection of data required for this interface
-    Filters filters() const final { return {}; }
+    // Filter data being gathered
+    Filters filters() const final;
 
     // Return flags corresponding to the "Step" above
     StepSelection selection() const final;
@@ -52,17 +48,16 @@ class ExampleMctruth final : public StepInterface
         CELER_NOT_IMPLEMENTED("device example");
     }
 
-    // Sort tallied tracks by {event, track, step}
-    void sort();
+    //! Access summed energy deposition [MeV] for all volumes
+    Span<const real_type> deposition() const { return make_span(deposition_); }
 
-    //! Access all steps
-    Span<const Step> steps() const { return make_span(steps_); }
-
-    //! Reset after output or whatever
-    void clear() { steps_.clear(); }
+    // Reset for a new event
+    void clear();
 
   private:
-    std::vector<Step> steps_;
+    std::vector<VolumeId>  detectors_;
+    std::vector<real_type> deposition_;
+    EventId                event_;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/ExampleMctruth.cc
+++ b/test/celeritas/user/ExampleMctruth.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/user/ExampleStepCallback.cc
+//! \file celeritas/user/ExampleMctruth.cc
 //---------------------------------------------------------------------------//
-#include "ExampleStepCallback.hh"
+#include "ExampleMctruth.hh"
 
 #include <algorithm>
 #include <tuple>
@@ -28,7 +28,7 @@ void copy_array(double dst[3], const Real3& src)
 } // namespace
 
 //---------------------------------------------------------------------------//
-StepSelection ExampleStepCallback::selection() const
+StepSelection ExampleMctruth::selection() const
 {
     StepSelection result;
     result.event            = true;
@@ -43,7 +43,7 @@ StepSelection ExampleStepCallback::selection() const
 }
 
 //---------------------------------------------------------------------------//
-void ExampleStepCallback::execute(StateHostRef const& data)
+void ExampleMctruth::execute(StateHostRef const& data)
 {
     for (auto tid : range(ThreadId{data.size()}))
     {
@@ -69,7 +69,7 @@ void ExampleStepCallback::execute(StateHostRef const& data)
 }
 
 //---------------------------------------------------------------------------//
-void ExampleStepCallback::sort()
+void ExampleMctruth::sort()
 {
     std::sort(
         steps_.begin(), steps_.end(), [](const Step& lhs, const Step& rhs) {

--- a/test/celeritas/user/ExampleMctruth.hh
+++ b/test/celeritas/user/ExampleMctruth.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/user/ExampleStepCallback.hh
+//! \file celeritas/user/ExampleMctruth.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -23,7 +23,7 @@ namespace test
  * execution. At the end of the run, for testing, call \c sort to reorder the
  * data by event/track/step, and then access the data with \c steps .
  */
-class ExampleStepCallback final : public StepInterface
+class ExampleMctruth final : public StepInterface
 {
   public:
     struct Step
@@ -37,6 +37,9 @@ class ExampleStepCallback final : public StepInterface
     };
 
   public:
+    //! Selection of data required for this interface
+    Mappings mappings() const final { return {}; }
+
     // Return flags corresponding to the "Step" above
     StepSelection selection() const final;
 
@@ -49,7 +52,7 @@ class ExampleStepCallback final : public StepInterface
         CELER_NOT_IMPLEMENTED("device example");
     }
 
-    //! Sort tallied tracks by {event, track, step}
+    // Sort tallied tracks by {event, track, step}
     void sort();
 
     //! Access all steps

--- a/test/celeritas/user/MctruthTestBase.cc
+++ b/test/celeritas/user/MctruthTestBase.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/user/StepCollectorTestBase.cc
+//! \file celeritas/user/MctruthTestBase.cc
 //---------------------------------------------------------------------------//
-#include "StepCollectorTestBase.hh"
+#include "MctruthTestBase.hh"
 
 #include <iostream>
 
@@ -21,25 +21,25 @@ namespace celeritas
 namespace test
 {
 //---------------------------------------------------------------------------//
-StepCollectorTestBase::~StepCollectorTestBase() = default;
+MctruthTestBase::~MctruthTestBase() = default;
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct example callback and step collector at setup time.
  */
-void StepCollectorTestBase::SetUp()
+void MctruthTestBase::SetUp()
 {
     example_mctruth_ = std::make_shared<ExampleMctruth>();
 
     StepCollector::VecInterface interfaces = {example_mctruth_};
 
-    collector_ = std::make_shared<StepCollector>(std::move(interfaces),
-                                                 this->action_reg().get());
+    collector_ = std::make_shared<StepCollector>(
+        std::move(interfaces), this->geometry(), this->action_reg().get());
 }
 
 //---------------------------------------------------------------------------//
 //! Print the expected result
-void StepCollectorTestBase::RunResult::print_expected() const
+void MctruthTestBase::RunResult::print_expected() const
 {
     cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
             "static const int expected_event[] = "
@@ -73,12 +73,12 @@ void StepCollectorTestBase::RunResult::print_expected() const
 /*!
  * Run a number of tracks.
  */
-auto StepCollectorTestBase::run(size_type num_tracks, size_type num_steps)
+auto MctruthTestBase::run(size_type num_tracks, size_type num_steps)
     -> RunResult
 {
     StepperInput step_inp;
-    step_inp.params           = this->core();
-    step_inp.num_track_slots  = num_tracks;
+    step_inp.params          = this->core();
+    step_inp.num_track_slots = num_tracks;
 
     Stepper<MemSpace::host> step(step_inp);
 

--- a/test/celeritas/user/MctruthTestBase.hh
+++ b/test/celeritas/user/MctruthTestBase.hh
@@ -1,0 +1,60 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/user/MctruthTestBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "corecel/io/Repr.hh"
+#include "celeritas/phys/Primary.hh"
+
+#include "StepCollectorTestBase.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+class StepCollector;
+
+namespace test
+{
+//---------------------------------------------------------------------------//
+class ExampleMctruth;
+
+class MctruthTestBase : virtual public StepCollectorTestBase
+{
+  public:
+    using VecPrimary = std::vector<Primary>;
+
+    struct RunResult
+    {
+        std::vector<int>    event;
+        std::vector<int>    track;
+        std::vector<int>    step;
+        std::vector<int>    volume;
+        std::vector<double> pos;
+        std::vector<double> dir;
+
+        void print_expected() const;
+    };
+
+  public:
+    // Default destructor
+    ~MctruthTestBase();
+
+    void SetUp() override;
+
+    RunResult run(size_type num_tracks, size_type num_steps);
+
+  protected:
+    std::shared_ptr<ExampleMctruth> example_mctruth_;
+    std::shared_ptr<StepCollector>  collector_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace test
+} // namespace celeritas

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -218,11 +218,11 @@ TEST_F(TestEm3MctruthTest, four_step)
 TEST_F(TestEm3CaloTest, four_step)
 {
     auto result = this->run(256, 32);
-    result.print_expected();
+    // result.print_expected();
 
     static const double expected_edep[]
-        = {1556.8107126148, 107.49535416277, 28.96731890737};
-    EXPECT_VEC_SOFT_EQ(expected_edep, result.edep);
+        = {1535.4185205798, 109.69434829612, 20.443067191226};
+    EXPECT_VEC_NEAR(expected_edep, result.edep, 0.5);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -108,10 +108,12 @@ class TestEm3CollectorTest : public TestEm3Base,
     }
 };
 
+#define TestEm3MctruthTest TEST_IF_CELERITAS_GEANT(TestEm3MctruthTest)
 class TestEm3MctruthTest : public TestEm3CollectorTest, public MctruthTestBase
 {
 };
 
+#define TestEm3CaloTest TEST_IF_CELERITAS_GEANT(TestEm3CaloTest)
 class TestEm3CaloTest : public TestEm3CollectorTest, public CaloTestBase
 {
     VecString get_detector_names() const final

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -8,6 +8,7 @@
 #include "celeritas/user/StepCollector.hh"
 
 #include "celeritas/global/ActionRegistry.hh"
+#include "celeritas/global/Stepper.hh"
 #include "celeritas/global/alongstep/AlongStepUniformMscAction.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
@@ -17,6 +18,8 @@
 #include "../TestEm15Base.hh"
 #include "../TestEm3Base.hh"
 #include "CaloTestBase.hh"
+#include "ExampleCalorimeters.hh"
+#include "ExampleMctruth.hh"
 #include "MctruthTestBase.hh"
 #include "celeritas_test.hh"
 
@@ -30,9 +33,10 @@ namespace test
 // TEST FIXTURES
 //---------------------------------------------------------------------------//
 
-class KnStepCollectorTest : public SimpleTestBase,
-                            virtual public StepCollectorTestBase
+class KnStepCollectorTestBase : public SimpleTestBase,
+                                virtual public StepCollectorTestBase
 {
+  protected:
     VecPrimary make_primaries(size_type count) override
     {
         Primary p;
@@ -53,20 +57,19 @@ class KnStepCollectorTest : public SimpleTestBase,
     }
 };
 
-class KnMctruthTest : public KnStepCollectorTest, public MctruthTestBase
+class KnMctruthTest : public KnStepCollectorTestBase, public MctruthTestBase
 {
 };
 
-class KnCaloTest : public KnStepCollectorTest, public CaloTestBase
+class KnCaloTest : public KnStepCollectorTestBase, public CaloTestBase
 {
     VecString get_detector_names() const final { return {"inner"}; }
 };
 
 //---------------------------------------------------------------------------//
 
-#define TestEm3CollectorTest TEST_IF_CELERITAS_GEANT(TestEm3CollectorTest)
-class TestEm3CollectorTest : public TestEm3Base,
-                             virtual public StepCollectorTestBase
+class TestEm3CollectorTestBase : public TestEm3Base,
+                                 virtual public StepCollectorTestBase
 {
     //! Use MSC
     bool enable_msc() const override { return true; }
@@ -109,18 +112,58 @@ class TestEm3CollectorTest : public TestEm3Base,
 };
 
 #define TestEm3MctruthTest TEST_IF_CELERITAS_GEANT(TestEm3MctruthTest)
-class TestEm3MctruthTest : public TestEm3CollectorTest, public MctruthTestBase
+class TestEm3MctruthTest : public TestEm3CollectorTestBase,
+                           public MctruthTestBase
 {
 };
 
 #define TestEm3CaloTest TEST_IF_CELERITAS_GEANT(TestEm3CaloTest)
-class TestEm3CaloTest : public TestEm3CollectorTest, public CaloTestBase
+class TestEm3CaloTest : public TestEm3CollectorTestBase, public CaloTestBase
 {
     VecString get_detector_names() const final
     {
         return {"gap_lv_0", "gap_lv_1", "gap_lv_2"};
     }
 };
+
+//---------------------------------------------------------------------------//
+// ERROR CHECKING
+//---------------------------------------------------------------------------//
+
+TEST_F(KnStepCollectorTestBase, mixing_types)
+{
+    auto calos = std::make_shared<ExampleCalorimeters>(
+        *this->geometry(), std::vector<std::string>{"inner"});
+    auto mctruth = std::make_shared<ExampleMctruth>();
+
+    StepCollector::VecInterface interfaces = {calos, mctruth};
+
+    EXPECT_THROW((StepCollector{std::move(interfaces),
+                                this->geometry(),
+                                this->action_reg().get()}),
+                 celeritas::RuntimeError);
+}
+
+TEST_F(KnStepCollectorTestBase, multiple_interfaces)
+{
+    // Add mctruth twice so each step is doubly written
+    auto                        mctruth = std::make_shared<ExampleMctruth>();
+    StepCollector::VecInterface interfaces = {mctruth, mctruth};
+    auto                        collector  = std::make_shared<StepCollector>(
+        std::move(interfaces), this->geometry(), this->action_reg().get());
+
+    // Do one step with two tracks
+    {
+        StepperInput step_inp;
+        step_inp.params          = this->core();
+        step_inp.num_track_slots = 2;
+
+        Stepper<MemSpace::host> step(step_inp);
+        step(this->make_primaries(2));
+    }
+
+    EXPECT_EQ(4, mctruth->steps().size());
+}
 
 //---------------------------------------------------------------------------//
 // KLEIN-NISHINA
@@ -217,10 +260,9 @@ TEST_F(TestEm3MctruthTest, four_step)
     }
 }
 
-TEST_F(TestEm3CaloTest, four_step)
+TEST_F(TestEm3CaloTest, thirtytwo_step)
 {
     auto result = this->run(256, 32);
-    // result.print_expected();
 
     static const double expected_edep[]
         = {1535.4185205798, 109.69434829612, 20.443067191226};

--- a/test/celeritas/user/StepCollectorTestBase.cc
+++ b/test/celeritas/user/StepCollectorTestBase.cc
@@ -12,7 +12,7 @@
 #include "celeritas/global/Stepper.hh"
 #include "celeritas/user/StepCollector.hh"
 
-#include "ExampleStepCallback.hh"
+#include "ExampleMctruth.hh"
 
 using std::cout;
 
@@ -29,9 +29,9 @@ StepCollectorTestBase::~StepCollectorTestBase() = default;
  */
 void StepCollectorTestBase::SetUp()
 {
-    example_steps_ = std::make_shared<ExampleStepCallback>();
+    example_mctruth_ = std::make_shared<ExampleMctruth>();
 
-    StepCollector::VecInterface interfaces = {example_steps_};
+    StepCollector::VecInterface interfaces = {example_mctruth_};
 
     collector_ = std::make_shared<StepCollector>(std::move(interfaces),
                                                  this->action_reg().get());
@@ -90,10 +90,10 @@ auto StepCollectorTestBase::run(size_type num_tracks, size_type num_steps)
         count = step();
     }
 
-    example_steps_->sort();
+    example_mctruth_->sort();
 
     RunResult result;
-    for (const ExampleStepCallback::Step& s : example_steps_->steps())
+    for (const ExampleMctruth::Step& s : example_mctruth_->steps())
     {
         result.event.push_back(s.event);
         result.track.push_back(s.track);

--- a/test/celeritas/user/StepCollectorTestBase.hh
+++ b/test/celeritas/user/StepCollectorTestBase.hh
@@ -7,54 +7,20 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <memory>
-#include <vector>
-
-#include "corecel/io/Repr.hh"
-#include "celeritas/phys/Primary.hh"
-
 #include "../GlobalTestBase.hh"
 
 namespace celeritas
 {
-//---------------------------------------------------------------------------//
-class StepCollector;
-
 namespace test
 {
 //---------------------------------------------------------------------------//
-class ExampleMctruth;
-
 class StepCollectorTestBase : virtual public GlobalTestBase
 {
   public:
     using VecPrimary = std::vector<Primary>;
-
-    struct RunResult
-    {
-        std::vector<int>    event;
-        std::vector<int>    track;
-        std::vector<int>    step;
-        std::vector<int>    volume;
-        std::vector<double> pos;
-        std::vector<double> dir;
-
-        void print_expected() const;
-    };
-
-  public:
-    // Default destructor
-    ~StepCollectorTestBase();
-
-    void SetUp() override;
+    using VecString  = std::vector<std::string>;
 
     virtual VecPrimary make_primaries(size_type count) = 0;
-
-    RunResult run(size_type num_tracks, size_type num_steps);
-
-  protected:
-    std::shared_ptr<ExampleMctruth> example_mctruth_;
-    std::shared_ptr<StepCollector>  collector_;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/StepCollectorTestBase.hh
+++ b/test/celeritas/user/StepCollectorTestBase.hh
@@ -23,7 +23,7 @@ class StepCollector;
 namespace test
 {
 //---------------------------------------------------------------------------//
-class ExampleStepCallback;
+class ExampleMctruth;
 
 class StepCollectorTestBase : virtual public GlobalTestBase
 {
@@ -53,8 +53,8 @@ class StepCollectorTestBase : virtual public GlobalTestBase
     RunResult run(size_type num_tracks, size_type num_steps);
 
   protected:
-    std::shared_ptr<ExampleStepCallback> example_steps_;
-    std::shared_ptr<StepCollector>       collector_;
+    std::shared_ptr<ExampleMctruth> example_mctruth_;
+    std::shared_ptr<StepCollector>  collector_;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/StepCollectorTestBase.hh
+++ b/test/celeritas/user/StepCollectorTestBase.hh
@@ -17,9 +17,13 @@ namespace test
 class StepCollectorTestBase : virtual public GlobalTestBase
 {
   public:
+    //!@{
+    //! \name Type aliases
     using VecPrimary = std::vector<Primary>;
     using VecString  = std::vector<std::string>;
+    //!@}
 
+  public:
     virtual VecPrimary make_primaries(size_type count) = 0;
 };
 


### PR DESCRIPTION
This is the next step toward implementing #29 . It allows users to provide a volume name -> detector ID mapping that can be used to filter and map collected hit data.

Right now it's a little awkward because this makes the StepCollector have two different collection modes: one for mctruth-type collection, and another with detector filtering, and two StepInterface with the different modes can't be combined. I wonder if I should make two different Interface subclasses, one with filtering/mapping (detectors) and one without (mctruth), and add a "name" flag so they can instantiate different actions with the different data.