### PR TITLE
Do not include ROOT's CMake "use" file to avoid potential nlohmann_json conflicts

### DIFF
--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -140,7 +140,6 @@ if(CELERITAS_USE_ROOT)
   # Call the ROOT library generation inside a function to prevent ROOT-defined
   # directory properties from escaping
   function(celeritas_root_library objlib root_tgt)
-    include(${ROOT_USE_FILE})
     # Use directory includes because ROOT has trouble with build/install
     # interface dependencies propagated through corecel
     include_directories(

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -137,59 +137,57 @@ if(CELERITAS_USE_OpenMP)
 endif()
 
 if(CELERITAS_USE_ROOT)
-  # Call the ROOT library generation inside a function to prevent ROOT-defined
-  # directory properties from escaping
-  function(celeritas_root_library objlib root_tgt)
-    # Use directory includes because ROOT has trouble with build/install
-    # interface dependencies propagated through corecel
-    include_directories(
-      "${PROJECT_SOURCE_DIR}/src"
-      "${CELERITAS_HEADER_CONFIG_DIRECTORY}"
-    )
+  # Use directory includes because ROOT has trouble with build/install
+  # interface dependencies propagated through corecel.
+  # This is safe here as it is only adding project-local paths that are
+  # identical to those set in corecel's usage requirments.
+  include_directories(
+    "${PROJECT_SOURCE_DIR}/src"
+    "${CELERITAS_HEADER_CONFIG_DIRECTORY}"
+  )
 
-    # Set the CMAKE output directory locally to inform ROOT where we put our
-    # libs
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CELERITAS_LIBRARY_OUTPUT_DIRECTORY})
+  # Set the CMAKE output directory locally to inform ROOT where we put our
+  # libs. Safe against overriding project settings as the celeritas_add_...
+  # functions set this to the same value for our targets.
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CELERITAS_LIBRARY_OUTPUT_DIRECTORY})
 
-    # Generate the
-    root_generate_dictionary(${root_tgt}
-      "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportData.hh"
-      "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportElement.hh"
-      "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportMaterial.hh"
-      "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportParticle.hh"
-      "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportPhysicsTable.hh"
-      "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportPhysicsVector.hh"
-      "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportProcess.hh"
-      "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportVolume.hh"
-      NOINSTALL
-      MODULE celeritas
-      LINKDEF "${CMAKE_CURRENT_SOURCE_DIR}/ext/RootInterfaceLinkDef.h"
-    )
-    celeritas_add_object_library(${objlib}
-      ext/RootExporter.cc
-      ext/RootImporter.cc
-      ext/ScopedRootErrorHandler.cc
-      ext/detail/TFileUniquePtr.root.cc
-      "${CMAKE_CURRENT_BINARY_DIR}/${root_tgt}.cxx"
-    )
-    target_link_libraries(${objlib}
-      PRIVATE Celeritas::corecel ROOT::Core ROOT::Tree
-    )
+  # Generate the dictionary source file
+  root_generate_dictionary(CeleritasRootInterface
+    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportData.hh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportElement.hh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportMaterial.hh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportParticle.hh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportPhysicsTable.hh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportPhysicsVector.hh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportProcess.hh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportVolume.hh"
+    NOINSTALL
+    MODULE celeritas
+    LINKDEF "${CMAKE_CURRENT_SOURCE_DIR}/ext/RootInterfaceLinkDef.h"
+  )
+  celeritas_add_object_library(celeritas_root
+    ext/RootExporter.cc
+    ext/RootImporter.cc
+    ext/ScopedRootErrorHandler.cc
+    ext/detail/TFileUniquePtr.root.cc
+    "${CMAKE_CURRENT_BINARY_DIR}/CeleritasRootInterface.cxx"
+  )
+  target_link_libraries(celeritas_root
+    PRIVATE Celeritas::corecel ROOT::Core ROOT::Tree
+  )
 
-    # Install the rootmap/pcm files needed for users or downstream apps to use
-    # Celeritas ROOT interfaces
-    set(_lib_prefix
-      "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_SHARED_LIBRARY_PREFIX}celeritas"
-    )
-    install(FILES
-      "${_lib_prefix}.rootmap"
-      "${_lib_prefix}_rdict.pcm"
-      COMPONENT runtime
-      DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    )
-  endfunction()
+  # Install the rootmap/pcm files needed for users or downstream apps to use
+  # Celeritas ROOT interfaces
+  set(_lib_prefix
+    "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_SHARED_LIBRARY_PREFIX}celeritas"
+  )
+  install(FILES
+    "${_lib_prefix}.rootmap"
+    "${_lib_prefix}_rdict.pcm"
+    COMPONENT runtime
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  )
 
-  celeritas_root_library(celeritas_root CeleritasRootInterface)
   list(APPEND SOURCES $<TARGET_OBJECTS:celeritas_root>)
   list(APPEND PRIVATE_DEPS celeritas_root)
 endif()


### PR DESCRIPTION
ROOT's "use" file for CMake executes CMake `include_directories`, `link_directories` and `add_definitions` as well as appending to `CMAKE_CXX_FLAGS` among others. The primary issue here is the use of `include_directories`, which

- adds `-I` rather than `-isystem` paths to compile commands
- mixes these with project-local setttings (in Celeritas, the ROOT path appears _before_ anything else)
- flags appear in all subsequent compilations at the same directory scope any further subdirectories

This was observed to cause an issue at link time for Celeritas programs using `nlohmann_json`, where the found ROOT install was using a builtin `nlohmann_json` of different version to that found by CMake. The above scoped injection of the ROOT include path meant that different `nlohmann_json` headers were used at library and application compile time resulting in undefined symbol errors when linking.

Whilst that's fundamentally an issue with the install of ROOT I was building against (to be fixed!), Celeritas does not _appear_ to need the use file. ROOT's CMake config file should include `ROOTMacros.cmake` for the dictionary generation, and usage requirements should be propagated through the imported targets. I've removed inclusion of ROOT's use file from Celeritas build scripts in this PR, and builds appear o.k. both on macOS and CentOS with different ROOT installs, however, let's see if CI throws up any issues.