### PR TITLE
Add upper_bound functions to corecel/math

### DIFF
--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -160,6 +160,31 @@ CELER_FORCEINLINE_FUNCTION ForwardIt lower_bound(ForwardIt first,
 
 //---------------------------------------------------------------------------//
 /*!
+ * Find the first element which is greater than <value>
+ */
+template<class ForwardIt, class T, class Compare>
+CELER_FORCEINLINE_FUNCTION ForwardIt
+upper_bound(ForwardIt first, ForwardIt last, const T& value, Compare comp)
+{
+    using CompareRef = std::add_lvalue_reference_t<Compare>;
+    return ::celeritas::detail::upper_bound_impl<CompareRef>(
+        first, last, value, comp);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Find the first element which is greater than <value>
+ */
+template<class ForwardIt, class T>
+CELER_FORCEINLINE_FUNCTION ForwardIt upper_bound(ForwardIt first,
+                                                 ForwardIt last,
+                                                 const T&  value)
+{
+    return ::celeritas::upper_bound(first, last, value, Less<>{});
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Partition elements in the given range, "true" before "false".
  *
  * This is done by swapping elements until the range is partitioned.

--- a/src/corecel/math/detail/AlgorithmsImpl.hh
+++ b/src/corecel/math/detail/AlgorithmsImpl.hh
@@ -29,7 +29,7 @@ using difference_type_t =
     typename std::iterator_traits<RandomAccessIt>::difference_type;
 
 //---------------------------------------------------------------------------//
-// LOWER_BOUND
+// LOWER and UPPER BOUNDS
 //---------------------------------------------------------------------------//
 //!@{
 /*!
@@ -79,6 +79,36 @@ CELER_FUNCTION ForwardIterator lower_bound_impl(ForwardIterator first,
         }
         else
             len = half_len;
+    }
+    return first;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Implementation of upper-bound assuming iterator arithmetic.
+ */
+template<class Compare, class ForwardIterator, class T>
+CELER_FUNCTION ForwardIterator upper_bound_impl(ForwardIterator first,
+                                                ForwardIterator last,
+                                                const T&        value_,
+                                                Compare         comp)
+{
+    using difference_type = difference_type_t<ForwardIterator>;
+
+    difference_type len = last - first;
+    while (len != 0)
+    {
+        difference_type half_len = ::celeritas::detail::half_positive(len);
+        ForwardIterator m        = first + half_len;
+        if (comp(value_, *m))
+        {
+            len = half_len;
+        }
+        else
+        {
+            first = ++m;
+            len -= half_len + 1;
+        }
     }
     return first;
 }

--- a/src/orange/detail/UnitIndexer.hh
+++ b/src/orange/detail/UnitIndexer.hh
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "corecel/data/Collection.hh"
+#include "corecel/math/Algorithms.hh"
 #include "orange/OrangeData.hh"
 #include "orange/OrangeTypes.hh"
 
@@ -91,9 +92,6 @@ class UnitIndexer
                                                       size_type id);
     static inline CELER_FUNCTION size_type local_size(DataRef    offsets,
                                                       UniverseId uni);
-    static inline CELER_FUNCTION SpanIter  upper_bound(SpanIter  begin,
-                                                       SpanIter  end,
-                                                       size_type id);
 };
 
 //---------------------------------------------------------------------------//
@@ -203,26 +201,6 @@ CELER_FUNCTION size_type UnitIndexer::local_size(DataRef    offsets,
            - offsets[SizeId{uni.unchecked_get()}];
 }
 
-//---------------------------------------------------------------------------//
-/*!
- * Host/device implementaiton of std::upper_bound
- */
-CELER_FUNCTION UnitIndexer::SpanIter
-               UnitIndexer::upper_bound(UnitIndexer::SpanIter begin,
-                         UnitIndexer::SpanIter end,
-                         size_type             id)
-{
-    CELER_EXPECT(begin <= end);
-
-    SpanIter iter = begin;
-
-    while (id >= *iter)
-    {
-        iter++;
-    }
-
-    return iter;
-}
 //---------------------------------------------------------------------------//
 } // namespace detail
 } // namespace celeritas

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -118,6 +118,28 @@ TEST(AlgorithmsTest, lower_bound)
     }
 }
 
+TEST(AlgorithmsTest, upper_bound)
+{
+    // Test empty vector
+    std::vector<int> v;
+    EXPECT_EQ(0, celeritas::upper_bound(v.begin(), v.end(), 10) - v.begin());
+
+    // Test a selection of sorted values, and values surroundig them
+    v = {-3, 1, 4, 9, 10, 11, 15, 15};
+
+    for (int val : v)
+    {
+        for (int delta : {-1, 0, 1})
+        {
+            auto expected = std::upper_bound(v.begin(), v.end(), val + delta);
+            auto actual
+                = celeritas::upper_bound(v.begin(), v.end(), val + delta);
+            EXPECT_EQ(expected - v.begin(), actual - v.begin())
+                << "Lower bound failed for value " << val + delta;
+        }
+    }
+}
+
 TEST(AlgorithmsTest, partition)
 {
     std::vector<int> values{-1, 2, 3, 4, 2, 6, 9, 4};

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -124,7 +124,7 @@ TEST(AlgorithmsTest, upper_bound)
     std::vector<int> v;
     EXPECT_EQ(0, celeritas::upper_bound(v.begin(), v.end(), 10) - v.begin());
 
-    // Test a selection of sorted values, and values surroundig them
+    // Test a selection of sorted values, and values surrounding them
     v = {-3, 1, 4, 9, 10, 11, 15, 15};
 
     for (int val : v)
@@ -135,7 +135,7 @@ TEST(AlgorithmsTest, upper_bound)
             auto actual
                 = celeritas::upper_bound(v.begin(), v.end(), val + delta);
             EXPECT_EQ(expected - v.begin(), actual - v.begin())
-                << "Lower bound failed for value " << val + delta;
+                << "Upper bound failed for value " << val + delta;
         }
     }
 }


### PR DESCRIPTION
This MR adds `upper_bound` functions to `corecel/math/Algorithms.hh`. The corresponding `lower_bound` functions were already present. The `orance/detail/UnitIndexer` is modified to use this implementation.