### PR TITLE
Fix git-clang-format hook and code documentation

### DIFF
--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -481,7 +481,7 @@ int main(int argc, char* argv[])
     if (argc != 2)
     {
         // If number of arguments is incorrect, print help
-        cout << "Usage: " << argv[0] << " output.root" << endl;
+        std::cerr << "Usage: " << argv[0] << " {output}.root" << std::endl;
         return 2;
     }
 

--- a/app/celer-export-geant.cc
+++ b/app/celer-export-geant.cc
@@ -26,15 +26,14 @@
 #endif
 
 using namespace celeritas;
-using std::cout;
-using std::endl;
 
 namespace
 {
 void print_usage(const char* exec_name)
 {
-    cout << "Usage: " << exec_name
-         << " input.gdml [options.json, -, ''] output.root" << endl;
+    std::cerr << "Usage: " << exec_name
+              << " {input}.gdml [{options}.json, -, ''] {output}.root"
+              << std::endl;
 }
 } // namespace
 
@@ -68,7 +67,7 @@ int main(int argc, char* argv[])
 #if CELERITAS_USE_JSON
         GeantPhysicsOptions options;
         constexpr int       indent = 1;
-        std::cout << nlohmann::json{options}.dump(indent) << endl;
+        std::cout << nlohmann::json{options}.dump(indent) << std::endl;
 #else
         CELER_LOG(error) << "JSON is unavailable: can't output geant options";
 #endif

--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -195,7 +195,7 @@ int main(int argc, char* argv[])
     std::vector<std::string> args(argv, argv + argc);
     if (args.size() != 2 || args[1] == "--help" || args[1] == "-h")
     {
-        cerr << "usage: " << args[0] << " {input}.json" << endl;
+        std::cerr << "usage: " << args[0] << " {input}.json" << std::endl;
         return EXIT_FAILURE;
     }
 

--- a/scripts/dev/post-commit.git-clang-format
+++ b/scripts/dev/post-commit.git-clang-format
@@ -26,14 +26,20 @@ to apply formatting.\e[0m
 fi
 
 printf "\e[2;37;40mRunning git-clang-format...\e[0m" >&2
-CLANG_FORMAT_RESULT="$(git-clang-format HEAD^)"
+GCF_OUT="$(git-clang-format HEAD^ || GCF_CODE=$?)"
 
-if git diff-files --quiet ; then
+if [ ! ${GCF_CODE} ]; then
+  # Return code was zero: for newer clang-format this means no changes, but
+  # we still need to check the index if it's an older version
+  git diff-files --quiet || GCF_CODE=$?
+fi
+
+if [ ! ${GCF_CODE} ]; then
   printf "\r\e[2;32mAll code changes were properly formatted\e[0m\n" >&2
 else
   BAD_COMMIT=$(git rev-parse --short HEAD)
   printf "\r\e[0;33mCode formatting changes were required:\e[0m\n" >&2
-  printf "${CLANG_FORMAT_RESULT}\n" >&2
+  printf "${GCF_OUT}\n" >&2
   git add -u :/
   SKIP_GCF=1 git commit --amend -C HEAD >/dev/null
   GOOD_COMMIT=$(git rev-parse --short HEAD)

--- a/src/celeritas/ext/detail/GeantLoggerAdapter.cc
+++ b/src/celeritas/ext/detail/GeantLoggerAdapter.cc
@@ -18,7 +18,7 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Assign exception handler on construction.
+ * Redirect geant4's stdout/cerr on construction.
  */
 GeantLoggerAdapter::GeantLoggerAdapter()
     : saved_cout_(G4coutbuf.GetDestination())
@@ -30,7 +30,7 @@ GeantLoggerAdapter::GeantLoggerAdapter()
 
 //---------------------------------------------------------------------------//
 /*!
- * Restore exception handler on destruction.
+ * Restore iostream buffers on destruction.
  */
 GeantLoggerAdapter::~GeantLoggerAdapter()
 {

--- a/src/corecel/io/Logger.cc
+++ b/src/corecel/io/Logger.cc
@@ -20,9 +20,10 @@
 
 #include "ColorUtils.hh"
 
+namespace celeritas
+{
 namespace
 {
-using namespace celeritas;
 //---------------------------------------------------------------------------//
 // HELPER CLASSES
 //---------------------------------------------------------------------------//
@@ -85,8 +86,6 @@ class LocalHandler
 //---------------------------------------------------------------------------//
 } // namespace
 
-namespace celeritas
-{
 //---------------------------------------------------------------------------//
 /*!
  * Construct with communicator (only rank zero is active) and handler.

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -284,6 +284,10 @@ void set_cuda_stack_size(int limit)
     CELER_EXPECT(limit > 0);
     CELER_EXPECT(celeritas::device());
     CELER_CUDA_CALL(cudaDeviceSetLimit(cudaLimitStackSize, limit));
+    if (CELERITAS_USE_CUDA)
+    {
+        CELER_LOG(debug) << "Set CUDA stack size to " << limit << "B";
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -299,6 +303,10 @@ void set_cuda_heap_size(int limit)
     CELER_EXPECT(limit > 0);
     CELER_EXPECT(celeritas::device());
     CELER_CUDA_CALL(cudaDeviceSetLimit(cudaLimitMallocHeapSize, limit));
+    if (CELERITAS_USE_CUDA)
+    {
+        CELER_LOG(debug) << "Set CUDA heap size to " << limit << "B";
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/Device.hh
+++ b/src/corecel/sys/Device.hh
@@ -52,7 +52,7 @@ class Device
     //!@}
 
   public:
-    // Number of devices available on the local compute node
+    // Number of devices available on the local compute node (0 if disabled)
     static int num_devices();
 
     // Whether verbose messages and error checking are enabled


### PR DESCRIPTION
On newer clang-format versions, the post-commit hook stopped working. (See https://github.com/llvm/llvm-project/issues/53220  and https://github.com/llvm/llvm-project/issues/54758 .) This fixes it! I've also moved a few code changes out of #567 .