### PR TITLE
Change Transport/Stepper interfaces to take span of `Primary` instead of vector

### DIFF
--- a/app/demo-loop/Transporter.cc
+++ b/app/demo-loop/Transporter.cc
@@ -156,7 +156,7 @@ Transporter<M>::Transporter(TransporterInput inp)
  * Transport the input primaries and all secondaries produced.
  */
 template<MemSpace M>
-TransporterResult Transporter<M>::operator()(const VecPrimary& primaries)
+TransporterResult Transporter<M>::operator()(SpanConstPrimary primaries)
 {
     Stopwatch get_transport_time;
 

--- a/app/demo-loop/Transporter.hh
+++ b/app/demo-loop/Transporter.hh
@@ -15,6 +15,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/cont/Span.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/global/CoreParams.hh"
@@ -140,16 +141,16 @@ class TransporterBase
   public:
     //!@{
     //! Type aliases
-    using VecPrimary = std::vector<celeritas::Primary>;
-    using CoreParams = celeritas::CoreParams;
-    using ActionId   = celeritas::ActionId;
+    using SpanConstPrimary = celeritas::Span<const celeritas::Primary>;
+    using CoreParams       = celeritas::CoreParams;
+    using ActionId         = celeritas::ActionId;
     //!@}
 
   public:
     virtual ~TransporterBase() = 0;
 
     // Transport the input primaries and all secondaries produced
-    virtual TransporterResult operator()(const VecPrimary& primaries) = 0;
+    virtual TransporterResult operator()(SpanConstPrimary primaries) = 0;
 
     //! Access input parameters (TODO hacky)
     const CoreParams& params() const { return *input_.params; }
@@ -171,7 +172,7 @@ class Transporter final : public TransporterBase
     explicit Transporter(TransporterInput inp);
 
     // Transport the input primaries and all secondaries produced
-    TransporterResult operator()(const VecPrimary& primaries) final;
+    TransporterResult operator()(SpanConstPrimary primaries) final;
 
   private:
     std::shared_ptr<DiagnosticStore> diagnostics_;

--- a/app/demo-loop/Transporter.hh
+++ b/app/demo-loop/Transporter.hh
@@ -58,7 +58,7 @@ struct TransporterInput
     // Stepper input
     std::shared_ptr<const CoreParams> params;
     size_type num_track_slots{}; //!< AKA max_num_tracks
-    bool      sync{false};
+    bool sync{false}; //!< Whether to synchronize device between actions
 
     // Loop control
     size_type max_steps{};
@@ -82,9 +82,9 @@ struct TransporterTiming
     using VecReal    = std::vector<real_type>;
     using MapStrReal = std::unordered_map<std::string, real_type>;
 
-    VecReal   steps;   //!< Real time per step
-    real_type total{}; //!< Total simulation time
-    real_type setup{}; //!< One-time initialization cost
+    VecReal    steps;     //!< Real time per step
+    real_type  total{};   //!< Total simulation time
+    real_type  setup{};   //!< One-time initialization cost
     MapStrReal actions{}; //!< Accumulated action timing
 };
 

--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -154,7 +154,7 @@ void run(std::istream* is, OutputManager* output)
     }
 
     // Transport
-    result = (*transport_ptr)(primaries);
+    result = (*transport_ptr)(make_span(primaries));
 
     result.time.setup = setup_time;
 

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -87,7 +87,7 @@ auto Stepper<M>::operator()() -> result_type
  * Initialize new primaries and transport them for a single step.
  */
 template<MemSpace M>
-auto Stepper<M>::operator()(const VecPrimary& primaries) -> result_type
+auto Stepper<M>::operator()(SpanConstPrimary primaries) -> result_type
 {
     CELER_EXPECT(*this);
     CELER_EXPECT(!primaries.empty());

--- a/src/celeritas/track/TrackInitUtils.hh
+++ b/src/celeritas/track/TrackInitUtils.hh
@@ -30,8 +30,8 @@ namespace celeritas
  * Create track initializers from a vector of host primary particles.
  */
 template<MemSpace M>
-inline void extend_from_primaries(CoreRef<M>&                 core_data,
-                                  const std::vector<Primary>& host_primaries)
+inline void extend_from_primaries(CoreRef<M>&          core_data,
+                                  Span<const Primary>& host_primaries)
 {
     CELER_EXPECT(core_data);
     CELER_EXPECT(!host_primaries.empty());
@@ -44,7 +44,7 @@ inline void extend_from_primaries(CoreRef<M>&                 core_data,
     // Allocate memory and copy primaries
     Collection<Primary, Ownership::value, M> primaries;
     resize(&primaries, host_primaries.size());
-    Copier<Primary, MemSpace::host> copy{make_span(host_primaries)};
+    Copier<Primary, MemSpace::host> copy{host_primaries};
     copy(M, primaries[AllItems<Primary, M>{}]);
 
     // Create track initializers from primaries

--- a/src/celeritas/track/TrackInitUtils.hh
+++ b/src/celeritas/track/TrackInitUtils.hh
@@ -30,8 +30,8 @@ namespace celeritas
  * Create track initializers from a vector of host primary particles.
  */
 template<MemSpace M>
-inline void extend_from_primaries(CoreRef<M>&          core_data,
-                                  Span<const Primary>& host_primaries)
+inline void
+extend_from_primaries(CoreRef<M>& core_data, Span<const Primary> host_primaries)
 {
     CELER_EXPECT(core_data);
     CELER_EXPECT(!host_primaries.empty());

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -8,6 +8,7 @@
 #include "AlongStepTestBase.hh"
 
 #include "corecel/cont/Range.hh"
+#include "corecel/cont/Span.hh"
 #include "corecel/data/CollectionStateStore.hh"
 #include "corecel/io/Join.hh"
 #include "corecel/io/Repr.hh"
@@ -56,7 +57,7 @@ auto AlongStepTestBase::run(const Input& inp, size_type num_tracks) -> RunResult
         }
 
         // Primary -> track initializer -> track
-        extend_from_primaries(core_ref, primaries);
+        extend_from_primaries(core_ref, make_span(primaries));
         initialize_tracks(core_ref);
     }
 

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -11,6 +11,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/cont/Span.hh"
 #include "celeritas/field/UniformFieldData.hh"
 #include "celeritas/global/ActionInterface.hh"
 #include "celeritas/global/ActionRegistry.hh"
@@ -245,7 +246,7 @@ TEST_F(TestEm3Test, host_multi)
 
     // Initialize some primaries and take a step
     auto primaries = this->make_primaries(num_primaries);
-    auto counts    = step(primaries);
+    auto counts    = step(make_span(primaries));
     EXPECT_EQ(num_primaries, counts.active);
     EXPECT_EQ(num_primaries, counts.alive);
 
@@ -256,7 +257,7 @@ TEST_F(TestEm3Test, host_multi)
 
     // Add some more primaries
     primaries = this->make_primaries(num_primaries);
-    counts    = step(primaries);
+    counts    = step(make_span(primaries));
     EXPECT_EQ(24, counts.active);
     EXPECT_EQ(24, counts.alive);
 

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -12,6 +12,7 @@
 #include <numeric>
 #include <gtest/gtest.h>
 
+#include "corecel/cont/Span.hh"
 #include "corecel/io/Repr.hh"
 #include "celeritas/global/ActionRegistry.hh"
 #include "celeritas/global/Stepper.hh"
@@ -82,7 +83,7 @@ auto StepperTestBase::run(StepperInterface& step,
 
     // Perform first step
     auto primaries = this->make_primaries(num_primaries);
-    auto counts    = step(primaries);
+    auto counts    = step(make_span(primaries));
     EXPECT_EQ(num_primaries, counts.active);
     EXPECT_EQ(num_primaries, counts.alive);
 

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -11,6 +11,7 @@
 #include <numeric>
 #include <vector>
 
+#include "corecel/cont/Span.hh"
 #include "corecel/data/CollectionMirror.hh"
 #include "celeritas/SimpleTestBase.hh"
 #include "celeritas/global/CoreParams.hh"
@@ -154,7 +155,7 @@ TEST_F(TrackInitTest, run)
 
     // Create track initializers on device from primary particles
     auto primaries = generate_primaries(num_primaries);
-    extend_from_primaries(core_data, primaries);
+    extend_from_primaries(core_data, make_span(primaries));
 
     // Check the track IDs of the track initializers created from primaries
     {
@@ -262,7 +263,7 @@ TEST_F(TrackInitTest, primaries)
     {
         // Create track initializers on device from primary particles
         auto primaries = generate_primaries(num_primaries);
-        extend_from_primaries(core_data, primaries);
+        extend_from_primaries(core_data, make_span(primaries));
 
         // Initialize tracks on device
         initialize_tracks(core_data);
@@ -323,7 +324,7 @@ TEST_F(TrackInitSecondaryTest, secondaries)
 
     // Create track initializers on device from primary particles
     auto primaries = generate_primaries(num_primaries);
-    extend_from_primaries(core_data, primaries);
+    extend_from_primaries(core_data, make_span(primaries));
     EXPECT_EQ(num_primaries, core_data.states.init.initializers.size());
 
     const size_type num_iter = 16;

--- a/test/celeritas/user/CaloTestBase.cc
+++ b/test/celeritas/user/CaloTestBase.cc
@@ -9,6 +9,7 @@
 
 #include <iostream>
 
+#include "corecel/cont/Span.hh"
 #include "celeritas/global/Stepper.hh"
 #include "celeritas/user/StepCollector.hh"
 
@@ -63,7 +64,8 @@ auto CaloTestBase::run(size_type num_tracks, size_type num_steps) -> RunResult
     Stepper<MemSpace::host> step(step_inp);
 
     // Initial step
-    auto count = step(this->make_primaries(num_tracks));
+    auto primaries = this->make_primaries(num_tracks);
+    auto count     = step(make_span(primaries));
 
     while (count && --num_steps > 0)
     {

--- a/test/celeritas/user/MctruthTestBase.cc
+++ b/test/celeritas/user/MctruthTestBase.cc
@@ -9,6 +9,7 @@
 
 #include <iostream>
 
+#include "corecel/cont/Span.hh"
 #include "celeritas/global/Stepper.hh"
 #include "celeritas/user/StepCollector.hh"
 
@@ -83,7 +84,8 @@ auto MctruthTestBase::run(size_type num_tracks, size_type num_steps)
     Stepper<MemSpace::host> step(step_inp);
 
     // Initial step
-    auto count = step(this->make_primaries(num_tracks));
+    auto primaries = this->make_primaries(num_tracks);
+    auto count     = step(make_span(primaries));
 
     while (count && --num_steps > 0)
     {

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "celeritas/user/StepCollector.hh"
 
+#include "corecel/cont/Span.hh"
 #include "celeritas/global/ActionRegistry.hh"
 #include "celeritas/global/Stepper.hh"
 #include "celeritas/global/alongstep/AlongStepUniformMscAction.hh"
@@ -159,7 +160,9 @@ TEST_F(KnStepCollectorTestBase, multiple_interfaces)
         step_inp.num_track_slots = 2;
 
         Stepper<MemSpace::host> step(step_inp);
-        step(this->make_primaries(2));
+
+        auto primaries = this->make_primaries(2);
+        step(make_span(primaries));
     }
 
     EXPECT_EQ(4, mctruth->steps().size());


### PR DESCRIPTION
As some initial work toward #553, this PR changes the `operator()` methods in `Transporter` and `Stepper` to take `Span<const Primary>` instead of `std::vector<Primary>`. This will allow a transporter/stepper to operate on a subset of a larger vector of primaries (e.g., if they are divided over multiple threads). 