### PR TITLE
Restrict where CUDA CI builds can run

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -26,7 +26,7 @@ pipeline {
            agent {
              docker {
                image 'celeritas/ci-jammy-cuda11:2022-12-06'
-               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
+               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
              }
            }
            steps {
@@ -42,7 +42,7 @@ pipeline {
            agent {
              docker {
                image 'celeritas/ci-jammy-cuda11:2022-12-06'
-               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
+               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
              }
            }
            steps {
@@ -58,7 +58,7 @@ pipeline {
            agent {
              docker {
                image 'celeritas/ci-jammy-cuda11:2022-12-06'
-               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
+               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
              }
            }
            steps {
@@ -74,7 +74,7 @@ pipeline {
            agent {
              docker {
                image 'celeritas/ci-jammy-cuda11:2022-12-06'
-               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker'
+               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
              }
            }
            steps {


### PR DESCRIPTION
Specify `large_images` label which is used on nodes that can actually handle the Celeritas base image. The Celeritas builds were routinely causing some of the CI machines to run out of disk space.