### PR TITLE
Add thread-local transporter and Celeritas shared params setup to Acceleritas

### DIFF
--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -18,6 +18,7 @@ list(APPEND SOURCES
   Logger.cc
   RunAction.cc
   TrackingAction.cc
+  detail/LocalTransporter.cc
 )
 
 #-----------------------------------------------------------------------------#

--- a/src/accel/EventAction.cc
+++ b/src/accel/EventAction.cc
@@ -17,10 +17,8 @@ namespace celeritas
 /*!
  * Construct with Celeritas shared data.
  */
-EventAction::EventAction(SPParams params, SPTransporter transport)
-    : params_(params), transport_(transport)
+EventAction::EventAction(SPTransporter transport) : transport_(transport)
 {
-    CELER_EXPECT(params_);
     CELER_EXPECT(transport_);
 }
 

--- a/src/accel/EventAction.cc
+++ b/src/accel/EventAction.cc
@@ -17,7 +17,12 @@ namespace celeritas
 /*!
  * Construct with Celeritas shared data.
  */
-EventAction::EventAction() {}
+EventAction::EventAction(SPParams params, SPTransporter transport)
+    : params_(params), transport_(transport)
+{
+    CELER_EXPECT(params_);
+    CELER_EXPECT(transport_);
+}
 
 //---------------------------------------------------------------------------//
 /*!
@@ -27,7 +32,8 @@ void EventAction::BeginOfEventAction(const G4Event* event)
 {
     CELER_EXPECT(event);
 
-    // TODO: Set event ID in local transporter
+    // Set event ID in local transporter
+    transport_->set_event(EventId{EventId::size_type(event->GetEventID())});
 }
 
 //---------------------------------------------------------------------------//
@@ -36,7 +42,8 @@ void EventAction::BeginOfEventAction(const G4Event* event)
  */
 void EventAction::EndOfEventAction(const G4Event*)
 {
-    // TODO: Transport any tracks left in the buffer
+    // Transport any tracks left in the buffer
+    transport_->flush();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/EventAction.hh
+++ b/src/accel/EventAction.hh
@@ -28,7 +28,7 @@ class EventAction final : public G4UserEventAction
     //!@}
 
   public:
-    EventAction(SPTransporter transport);
+    explicit EventAction(SPTransporter transport);
 
     void BeginOfEventAction(const G4Event* event) final;
     void EndOfEventAction(const G4Event* event) final;

--- a/src/accel/EventAction.hh
+++ b/src/accel/EventAction.hh
@@ -10,6 +10,7 @@
 #include <G4UserEventAction.hh>
 
 #include "SharedParams.hh"
+#include "detail/LocalTransporter.hh"
 
 namespace celeritas
 {
@@ -24,13 +25,19 @@ class EventAction final : public G4UserEventAction
   public:
     //!@{
     //! \name Type aliases
+    using SPParams      = std::shared_ptr<SharedParams>;
+    using SPTransporter = std::shared_ptr<detail::LocalTransporter>;
     //!@}
 
   public:
-    EventAction();
+    EventAction(SPParams params, SPTransporter transport);
 
     void BeginOfEventAction(const G4Event* event) final;
     void EndOfEventAction(const G4Event* event) final;
+
+  private:
+    SPParams      params_;
+    SPTransporter transport_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/accel/EventAction.hh
+++ b/src/accel/EventAction.hh
@@ -9,7 +9,6 @@
 
 #include <G4UserEventAction.hh>
 
-#include "SharedParams.hh"
 #include "detail/LocalTransporter.hh"
 
 namespace celeritas
@@ -25,18 +24,16 @@ class EventAction final : public G4UserEventAction
   public:
     //!@{
     //! \name Type aliases
-    using SPParams      = std::shared_ptr<SharedParams>;
     using SPTransporter = std::shared_ptr<detail::LocalTransporter>;
     //!@}
 
   public:
-    EventAction(SPParams params, SPTransporter transport);
+    EventAction(SPTransporter transport);
 
     void BeginOfEventAction(const G4Event* event) final;
     void EndOfEventAction(const G4Event* event) final;
 
   private:
-    SPParams      params_;
     SPTransporter transport_;
 };
 

--- a/src/accel/InitializeActions.cc
+++ b/src/accel/InitializeActions.cc
@@ -44,7 +44,7 @@ void initialize_actions_impl(const std::shared_ptr<const SetupOptions>& options,
     manager->SetUserAction(new RunAction{options, params, transport});
     // Event action saves event ID for offloading and runs queued particles at
     // end of event
-    manager->SetUserAction(new EventAction{params, transport});
+    manager->SetUserAction(new EventAction{transport});
     // Tracking action offloads tracks to device and kills them
     manager->SetUserAction(new TrackingAction{params, transport});
 }

--- a/src/accel/InitializeActions.cc
+++ b/src/accel/InitializeActions.cc
@@ -16,6 +16,7 @@
 #include "SetupOptions.hh"
 #include "SharedParams.hh"
 #include "TrackingAction.hh"
+#include "detail/LocalTransporter.hh"
 
 namespace celeritas
 {
@@ -27,8 +28,8 @@ namespace
  */
 template<class Manager>
 void initialize_actions_impl(const std::shared_ptr<const SetupOptions>& options,
-                             const std::shared_ptr<SharedParams>&,
-                             Manager* manager)
+                             const std::shared_ptr<SharedParams>& params,
+                             Manager*                             manager)
 {
     if (Device::num_devices() > 0)
     {
@@ -37,13 +38,15 @@ void initialize_actions_impl(const std::shared_ptr<const SetupOptions>& options,
         celeritas::activate_device(Device{0});
     }
 
+    auto transport = std::make_shared<detail::LocalTransporter>();
+
     // Run action sets up Celeritas
-    manager->SetUserAction(new RunAction{options});
+    manager->SetUserAction(new RunAction{options, params, transport});
     // Event action saves event ID for offloading and runs queued particles at
     // end of event
-    manager->SetUserAction(new EventAction{});
+    manager->SetUserAction(new EventAction{params, transport});
     // Tracking action offloads tracks to device and kills them
-    manager->SetUserAction(new TrackingAction{});
+    manager->SetUserAction(new TrackingAction{params, transport});
 }
 //---------------------------------------------------------------------------//
 } // namespace

--- a/src/accel/RunAction.cc
+++ b/src/accel/RunAction.cc
@@ -7,11 +7,27 @@
 //---------------------------------------------------------------------------//
 #include "RunAction.hh"
 
+#include <CLHEP/Random/Random.h>
 #include <G4AutoLock.hh>
 #include <G4Run.hh>
 #include <G4Threading.hh>
+#include <G4TransportationManager.hh>
 
 #include "corecel/Assert.hh"
+#include "corecel/io/Logger.hh"
+#include "celeritas/ext/GeantImporter.hh"
+#include "celeritas/geo/GeoMaterialParams.hh"
+#include "celeritas/geo/GeoParams.hh"
+#include "celeritas/global/ActionRegistry.hh"
+#include "celeritas/global/alongstep/AlongStepGeneralLinearAction.hh"
+#include "celeritas/io/ImportProcess.hh"
+#include "celeritas/mat/MaterialParams.hh"
+#include "celeritas/phys/CutoffParams.hh"
+#include "celeritas/phys/ParticleParams.hh"
+#include "celeritas/phys/PhysicsParams.hh"
+#include "celeritas/phys/ProcessBuilder.hh"
+#include "celeritas/random/RngParams.hh"
+#include "celeritas/track/TrackInitParams.hh"
 
 namespace
 {

--- a/src/accel/RunAction.hh
+++ b/src/accel/RunAction.hh
@@ -25,21 +25,21 @@ class RunAction final : public G4UserRunAction
   public:
     //!@{
     //! \name Type aliases
-    using SPCOptions    = std::shared_ptr<const SetupOptions>;
-    using SPParams      = std::shared_ptr<SharedParams>;
-    using SPTransporter = std::shared_ptr<detail::LocalTransporter>;
+    using SPConstOptions = std::shared_ptr<const SetupOptions>;
+    using SPParams       = std::shared_ptr<SharedParams>;
+    using SPTransporter  = std::shared_ptr<detail::LocalTransporter>;
     //!@}
 
   public:
-    RunAction(SPCOptions options, SPParams params, SPTransporter transport);
+    RunAction(SPConstOptions options, SPParams params, SPTransporter transport);
 
     void BeginOfRunAction(const G4Run* run) final;
     void EndOfRunAction(const G4Run* run) final;
 
   private:
-    SPCOptions    options_;
-    SPParams      params_;
-    SPTransporter transport_;
+    SPConstOptions options_;
+    SPParams       params_;
+    SPTransporter  transport_;
 
     void build_core_params();
 };

--- a/src/accel/RunAction.hh
+++ b/src/accel/RunAction.hh
@@ -12,6 +12,7 @@
 
 #include "SetupOptions.hh"
 #include "SharedParams.hh"
+#include "detail/LocalTransporter.hh"
 
 namespace celeritas
 {
@@ -24,17 +25,21 @@ class RunAction final : public G4UserRunAction
   public:
     //!@{
     //! \name Type aliases
-    using SPCOptions = std::shared_ptr<const SetupOptions>;
+    using SPCOptions    = std::shared_ptr<const SetupOptions>;
+    using SPParams      = std::shared_ptr<SharedParams>;
+    using SPTransporter = std::shared_ptr<detail::LocalTransporter>;
     //!@}
 
   public:
-    RunAction(SPCOptions options);
+    RunAction(SPCOptions options, SPParams params, SPTransporter transport);
 
     void BeginOfRunAction(const G4Run* run) final;
     void EndOfRunAction(const G4Run* run) final;
 
   private:
-    SPCOptions options_;
+    SPCOptions    options_;
+    SPParams      params_;
+    SPTransporter transport_;
 
     void build_core_params();
 };

--- a/src/accel/TrackingAction.cc
+++ b/src/accel/TrackingAction.cc
@@ -19,7 +19,12 @@ namespace celeritas
 /*!
  * Construct with Celeritas shared data.
  */
-TrackingAction::TrackingAction() {}
+TrackingAction::TrackingAction(SPParams params, SPTransporter transport)
+    : params_(params), transport_(transport)
+{
+    CELER_EXPECT(params_);
+    CELER_EXPECT(transport_);
+}
 
 //---------------------------------------------------------------------------//
 /*!
@@ -29,9 +34,10 @@ void TrackingAction::PreUserTrackingAction(const G4Track* track)
 {
     // Check against list of supported celeritas particles
     PDGNumber pdg{track->GetDefinition()->GetPDGEncoding()};
-    if (true)
+    if (params_->params->particle()->find(pdg))
     {
-        // TODO Send track to transporter and kill
+        // Send track to transporter and kill
+        transport_->add(*track);
         const_cast<G4Track*>(track)->SetTrackStatus(fStopAndKill);
     }
 }

--- a/src/accel/TrackingAction.cc
+++ b/src/accel/TrackingAction.cc
@@ -20,7 +20,7 @@ namespace celeritas
 /*!
  * Construct with Celeritas shared data.
  */
-TrackingAction::TrackingAction(SPParams params, SPTransporter transport)
+TrackingAction::TrackingAction(SPConstParams params, SPTransporter transport)
     : params_(params), transport_(transport)
 {
     CELER_EXPECT(params_);
@@ -33,6 +33,9 @@ TrackingAction::TrackingAction(SPParams params, SPTransporter transport)
  */
 void TrackingAction::PreUserTrackingAction(const G4Track* track)
 {
+    CELER_EXPECT(params_->params);
+    CELER_EXPECT(*transport_);
+
     // Check against list of supported celeritas particles
     PDGNumber pdg{track->GetDefinition()->GetPDGEncoding()};
     if (params_->params->particle()->find(pdg))

--- a/src/accel/TrackingAction.cc
+++ b/src/accel/TrackingAction.cc
@@ -12,6 +12,7 @@
 #include <G4TrackStatus.hh>
 
 #include "celeritas/phys/PDGNumber.hh"
+#include "celeritas/phys/ParticleParams.hh"
 
 namespace celeritas
 {

--- a/src/accel/TrackingAction.hh
+++ b/src/accel/TrackingAction.hh
@@ -23,17 +23,17 @@ class TrackingAction final : public G4UserTrackingAction
   public:
     //!@{
     //! \name Type aliases
-    using SPParams      = std::shared_ptr<SharedParams>;
+    using SPConstParams = std::shared_ptr<const SharedParams>;
     using SPTransporter = std::shared_ptr<detail::LocalTransporter>;
     //!@}
 
   public:
-    TrackingAction(SPParams params, SPTransporter transport);
+    TrackingAction(SPConstParams params, SPTransporter transport);
 
     void PreUserTrackingAction(const G4Track* track) final;
 
   private:
-    SPParams      params_;
+    SPConstParams params_;
     SPTransporter transport_;
 };
 

--- a/src/accel/TrackingAction.hh
+++ b/src/accel/TrackingAction.hh
@@ -9,6 +9,9 @@
 
 #include <G4UserTrackingAction.hh>
 
+#include "SharedParams.hh"
+#include "detail/LocalTransporter.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -18,9 +21,20 @@ namespace celeritas
 class TrackingAction final : public G4UserTrackingAction
 {
   public:
-    TrackingAction();
+    //!@{
+    //! \name Type aliases
+    using SPParams      = std::shared_ptr<SharedParams>;
+    using SPTransporter = std::shared_ptr<detail::LocalTransporter>;
+    //!@}
+
+  public:
+    TrackingAction(SPParams params, SPTransporter transport);
 
     void PreUserTrackingAction(const G4Track* track) final;
+
+  private:
+    SPParams      params_;
+    SPTransporter transport_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/accel/detail/LocalTransporter.cc
+++ b/src/accel/detail/LocalTransporter.cc
@@ -76,7 +76,7 @@ void LocalTransporter::flush()
     }
 
     // Copy buffered tracks to device and transport the first step
-    auto track_counts = (*step_)(buffer_);
+    auto track_counts = (*step_)(make_span(buffer_));
 
     size_type step_iters = 1;
 

--- a/src/accel/detail/LocalTransporter.cc
+++ b/src/accel/detail/LocalTransporter.cc
@@ -7,10 +7,10 @@
 //---------------------------------------------------------------------------//
 #include "LocalTransporter.hh"
 
+#include <G4SystemOfUnits.hh>
+
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
-
-#include "G4SystemOfUnits.hh"
 
 namespace celeritas
 {

--- a/src/accel/detail/LocalTransporter.cc
+++ b/src/accel/detail/LocalTransporter.cc
@@ -1,0 +1,110 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/detail/LocalTransporter.cc
+//---------------------------------------------------------------------------//
+#include "LocalTransporter.hh"
+
+#include "celeritas/phys/PDGNumber.hh"
+#include "celeritas/phys/ParticleParams.hh"
+
+#include "G4SystemOfUnits.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared (MT) params.
+ */
+LocalTransporter::LocalTransporter(SPCOptions opts, SPCParams params)
+    : opts_(opts), params_(params)
+{
+    CELER_EXPECT(opts_);
+    CELER_EXPECT(params_);
+
+    StepperInput inp{params_, opts_->max_num_tracks, opts_->sync};
+    if (celeritas::device())
+    {
+        step_ = std::make_shared<Stepper<MemSpace::device>>(inp);
+    }
+    else
+    {
+        step_ = std::make_shared<Stepper<MemSpace::host>>(inp);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a Geant4 track to a Celeritas primary and add to buffer.
+ */
+void LocalTransporter::add(const G4Track& g4track)
+{
+    CELER_EXPECT(event_);
+
+    Primary track;
+
+    track.particle_id = params_->particle()->find(
+        PDGNumber{g4track.GetDefinition()->GetPDGEncoding()});
+    track.energy = units::MevEnergy{g4track.GetKineticEnergy() / MeV};
+
+    G4ThreeVector pos = g4track.GetPosition();
+    track.position    = Real3{pos.x() / cm, pos.y() / cm, pos.z() / cm};
+
+    G4ThreeVector dir = g4track.GetMomentumDirection();
+    track.direction   = Real3{dir.x(), dir.y(), dir.z()};
+
+    track.time     = g4track.GetGlobalTime() / s;
+    track.track_id = TrackId{TrackId::size_type(g4track.GetTrackID())};
+    track.event_id = event_;
+
+    buffer_.push_back(track);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Transport the buffered tracks and all secondaries produced.
+ */
+void LocalTransporter::flush()
+{
+    if (buffer_.empty())
+    {
+        return;
+    }
+
+    // Copy buffered tracks to device and transport the first step
+    auto track_counts = (*step_)(buffer_);
+
+    size_type step_iters = 1;
+
+    while (track_counts)
+    {
+        CELER_VALIDATE(step_iters < opts_->max_steps,
+                       << "number of step iterations exceeded the allowed "
+                          "maximum ("
+                       << opts_->max_steps << ")");
+
+        track_counts = (*step_)();
+        step_iters += 1;
+    }
+
+    buffer_.clear();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set the event ID at the beginning of an event.
+ */
+void LocalTransporter::set_event(EventId event)
+{
+    CELER_EXPECT(event);
+    CELER_EXPECT(buffer_.empty());
+    event_ = event;
+}
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/accel/detail/LocalTransporter.cc
+++ b/src/accel/detail/LocalTransporter.cc
@@ -20,7 +20,7 @@ namespace detail
 /*!
  * Construct with shared (MT) params.
  */
-LocalTransporter::LocalTransporter(SPCOptions opts, SPCParams params)
+LocalTransporter::LocalTransporter(SPConstOptions opts, SPConstParams params)
     : opts_(opts), params_(params)
 {
     CELER_EXPECT(opts_);
@@ -88,7 +88,7 @@ void LocalTransporter::flush()
                        << opts_->max_steps << ")");
 
         track_counts = (*step_)();
-        step_iters += 1;
+        ++step_iters;
     }
 
     buffer_.clear();

--- a/src/accel/detail/LocalTransporter.hh
+++ b/src/accel/detail/LocalTransporter.hh
@@ -28,8 +28,8 @@ class LocalTransporter
   public:
     //!@{
     //! \name Type aliases
-    using SPCOptions = std::shared_ptr<const SetupOptions>;
-    using SPCParams  = std::shared_ptr<const CoreParams>;
+    using SPConstOptions = std::shared_ptr<const SetupOptions>;
+    using SPConstParams  = std::shared_ptr<const CoreParams>;
     //!@}
 
   public:
@@ -37,7 +37,7 @@ class LocalTransporter
     LocalTransporter() = default;
 
     // Construct with shared (MT) params
-    LocalTransporter(SPCOptions, SPCParams);
+    LocalTransporter(SPConstOptions, SPConstParams);
 
     // Convert a Geant4 track to a Celeritas primary and add to buffer
     void add(const G4Track&);
@@ -55,8 +55,8 @@ class LocalTransporter
     explicit operator bool() const { return opts_ && params_ && step_; }
 
   private:
-    SPCOptions                        opts_;
-    SPCParams                         params_;
+    SPConstOptions                    opts_;
+    SPConstParams                     params_;
     std::shared_ptr<StepperInterface> step_;
     std::vector<Primary>              buffer_;
     EventId                           event_;

--- a/src/accel/detail/LocalTransporter.hh
+++ b/src/accel/detail/LocalTransporter.hh
@@ -7,12 +7,13 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <G4Track.hh>
+
 #include "corecel/Types.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/Stepper.hh"
 
 #include "../SetupOptions.hh"
-#include "G4Track.hh"
 
 namespace celeritas
 {

--- a/src/accel/detail/LocalTransporter.hh
+++ b/src/accel/detail/LocalTransporter.hh
@@ -1,0 +1,66 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/detail/LocalTransporter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Types.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/Stepper.hh"
+
+#include "../SetupOptions.hh"
+#include "G4Track.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Transport a set of primaries to completion.
+ */
+class LocalTransporter
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using SPCOptions = std::shared_ptr<const SetupOptions>;
+    using SPCParams  = std::shared_ptr<const CoreParams>;
+    //!@}
+
+  public:
+    // Construct in an invalid state
+    LocalTransporter() = default;
+
+    // Construct with shared (MT) params
+    LocalTransporter(SPCOptions, SPCParams);
+
+    // Convert a Geant4 track to a Celeritas primary and add to buffer
+    void add(const G4Track&);
+
+    // Transport all buffered tracks to completion
+    void flush();
+
+    // Set the event ID
+    void set_event(EventId);
+
+    // Number of buffered tracks
+    size_type buffer_size() const { return buffer_.size(); }
+
+    // Whether the transporter is valid
+    explicit operator bool() const { return opts_ && params_ && step_; }
+
+  private:
+    SPCOptions                        opts_;
+    SPCParams                         params_;
+    std::shared_ptr<StepperInterface> step_;
+    std::vector<Primary>              buffer_;
+    EventId                           event_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas


### PR DESCRIPTION
Follow-up to #567: set up the shared Celeritas params and add a thread-local  transporter in the Acceleritas library.