### PR TITLE
Add a simple SensitiveHit for demo-geant4-integration

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -346,6 +346,7 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_Geant4)
     demo-geant-integration/PrimaryGeneratorAction.cc
     demo-geant-integration/RunAction.cc
     demo-geant-integration/SensitiveDetector.cc
+    demo-geant-integration/SensitiveHit.cc
     demo-geant-integration/TrackingAction.cc
   )
   celeritas_target_link_libraries(demo-geant-integration Celeritas::accel)

--- a/app/demo-geant-integration/SensitiveDetector.cc
+++ b/app/demo-geant-integration/SensitiveDetector.cc
@@ -57,8 +57,10 @@ bool SensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
     }
 
     // Create a hit for this step
-    auto         touchable = step->GetPreStepPoint()->GetTouchable();
-    unsigned int id        = touchable->GetVolume()->GetCopyNo();
+    auto* touchable = step->GetPreStepPoint()->GetTouchable();
+    CELER_ASSERT(touchable);
+
+    unsigned int id = touchable->GetVolume()->GetCopyNo();
     HitData      data{id,
                  edep,
                  step->GetPreStepPoint()->GetGlobalTime(),

--- a/app/demo-geant-integration/SensitiveDetector.cc
+++ b/app/demo-geant-integration/SensitiveDetector.cc
@@ -22,7 +22,7 @@ namespace demo_geant
 SensitiveDetector::SensitiveDetector(std::string name)
     : G4VSensitiveDetector(name), hcid_(-1)
 {
-    collectionName.insert(name + "_HC");
+    this->collectionName.insert(name + "_HC");
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-geant-integration/SensitiveDetector.cc
+++ b/app/demo-geant-integration/SensitiveDetector.cc
@@ -19,7 +19,7 @@ namespace demo_geant
 {
 //---------------------------------------------------------------------------//
 SensitiveDetector::SensitiveDetector(G4String name)
-    : G4VSensitiveDetector(std::move(name)), hcid_(-1)
+    : G4VSensitiveDetector(name), hcid_(-1)
 {
     G4String nameHC = name + "_HC";
     collectionName.insert(nameHC);

--- a/app/demo-geant-integration/SensitiveDetector.hh
+++ b/app/demo-geant-integration/SensitiveDetector.hh
@@ -13,7 +13,6 @@
 #include "SensitiveHit.hh"
 
 class G4Step;
-class G4String;
 class G4HCofThisEvent;
 
 namespace demo_geant
@@ -24,21 +23,20 @@ namespace demo_geant
  */
 class SensitiveDetector final : public G4VSensitiveDetector
 {
-  public:
     //!@{
     //! \name Type aliases
     using SensitiveHitsCollection = G4THitsCollection<SensitiveHit>;
     //!@}
 
   public:
-    explicit SensitiveDetector(G4String name);
+    explicit SensitiveDetector(std::string name);
 
   protected:
-    void   Initialize(G4HCofThisEvent*) final;
-    G4bool ProcessHits(G4Step*, G4TouchableHistory*) final;
+    void Initialize(G4HCofThisEvent*) final;
+    bool ProcessHits(G4Step*, G4TouchableHistory*) final;
 
   private:
-    G4int                                    hcid_;
+    int                                      hcid_;
     std::unique_ptr<SensitiveHitsCollection> collection_;
 };
 

--- a/app/demo-geant-integration/SensitiveDetector.hh
+++ b/app/demo-geant-integration/SensitiveDetector.hh
@@ -7,8 +7,14 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <string>
+#include <G4THitsCollection.hh>
 #include <G4VSensitiveDetector.hh>
+
+#include "SensitiveHit.hh"
+
+class G4Step;
+class G4String;
+class G4HCofThisEvent;
 
 namespace demo_geant
 {
@@ -19,11 +25,22 @@ namespace demo_geant
 class SensitiveDetector final : public G4VSensitiveDetector
 {
   public:
-    explicit SensitiveDetector(std::string name);
+    //!@{
+    //! \name Type aliases
+    using SensitiveHitsCollection = G4THitsCollection<SensitiveHit>;
+
+    //!@}
+
+  public:
+    explicit SensitiveDetector(G4String name);
 
   protected:
     void   Initialize(G4HCofThisEvent*) final;
     G4bool ProcessHits(G4Step*, G4TouchableHistory*) final;
+
+  private:
+    G4int                                    hcid_;
+    std::unique_ptr<SensitiveHitsCollection> collection_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/demo-geant-integration/SensitiveDetector.hh
+++ b/app/demo-geant-integration/SensitiveDetector.hh
@@ -28,7 +28,6 @@ class SensitiveDetector final : public G4VSensitiveDetector
     //!@{
     //! \name Type aliases
     using SensitiveHitsCollection = G4THitsCollection<SensitiveHit>;
-
     //!@}
 
   public:

--- a/app/demo-geant-integration/SensitiveHit.cc
+++ b/app/demo-geant-integration/SensitiveHit.cc
@@ -1,0 +1,19 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file demo-geant-integration/SensitiveHit.cc
+//---------------------------------------------------------------------------//
+#include "SensitiveHit.hh"
+
+namespace demo_geant
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Constructor.
+ */
+SensitiveHit::SensitiveHit(const HitData& data) : G4VHit(), data_{data} {}
+
+//---------------------------------------------------------------------------//
+} // namespace demo_geant

--- a/app/demo-geant-integration/SensitiveHit.cc
+++ b/app/demo-geant-integration/SensitiveHit.cc
@@ -9,11 +9,11 @@
 
 namespace demo_geant
 {
+G4ThreadLocal SensitiveHit::PHitAllocator SensitiveHit::allocator_ = nullptr;
 //---------------------------------------------------------------------------//
 /*!
  * Constructor.
  */
 SensitiveHit::SensitiveHit(const HitData& data) : G4VHit(), data_{data} {}
-
 //---------------------------------------------------------------------------//
 } // namespace demo_geant

--- a/app/demo-geant-integration/SensitiveHit.hh
+++ b/app/demo-geant-integration/SensitiveHit.hh
@@ -1,0 +1,47 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file demo-geant-integration/SensitiveHit.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <G4ThreeVector.hh>
+#include <G4VHit.hh>
+
+namespace demo_geant
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Example sensitive hit data.
+ */
+struct HitData
+{
+    unsigned int  id{0};        //!< detector id
+    G4double      edep{0};      //!< energy deposition
+    G4double      time{0};      //!< time (global coordinate)
+    G4ThreeVector pos{0, 0, 0}; //!< position (global coordinate)
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Example sensitive hit class.
+ */
+class SensitiveHit final : public G4VHit
+{
+  public:
+    explicit SensitiveHit(const HitData& data);
+
+    // Accessors
+    inline HitData data() const { return data_; }
+
+    // Add energy deposition
+    inline void add_edep(G4double edep) { data_.edep += edep; }
+
+  private:
+    HitData data_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace demo_geant

--- a/app/demo-geant-integration/SensitiveHit.hh
+++ b/app/demo-geant-integration/SensitiveHit.hh
@@ -40,8 +40,9 @@ class SensitiveHit final : public G4VHit
     //! Accessor the hit data
     const HitData& data() const { return data_; }
 
-    // Overload of operator new
+    // Overload of operator new and delete
     inline void* operator new(size_t);
+    inline void  operator delete(void*);
 
   private:
     HitData                            data_;
@@ -61,6 +62,15 @@ inline void* SensitiveHit::operator new(size_t)
         allocator_ = new G4Allocator<SensitiveHit>;
     }
     return (void*)allocator_->MallocSingle();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Overload the operator new with G4Allocator.
+ */
+inline void SensitiveHit::operator delete(void* hit)
+{
+    allocator_->FreeSingle((SensitiveHit*)hit);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Add a simple/example sensitive hit class for sensitive detectors:

- Assuming that the hit data structure is same for all sensitive detectors, which needs to be modified for different hit data structures for different sensitive detectors
- Merging hits is not implemented yet as the GPU transporter is not actually turned on