### PR TITLE
Add Geant4 Exception converter

### DIFF
--- a/app/demo-geant-integration/ActionInitialization.cc
+++ b/app/demo-geant-integration/ActionInitialization.cc
@@ -9,7 +9,9 @@
 
 #include <G4RunManager.hh>
 
+#include "corecel/Macros.hh"
 #include "corecel/io/Logger.hh"
+#include "accel/ExceptionConverter.hh"
 
 #include "EventAction.hh"
 #include "GlobalSetup.hh"

--- a/app/demo-geant-integration/ActionInitialization.cc
+++ b/app/demo-geant-integration/ActionInitialization.cc
@@ -9,9 +9,7 @@
 
 #include <G4RunManager.hh>
 
-#include "corecel/Macros.hh"
 #include "corecel/io/Logger.hh"
-#include "accel/ExceptionConverter.hh"
 
 #include "EventAction.hh"
 #include "GlobalSetup.hh"

--- a/app/demo-geant-integration/DetectorConstruction.cc
+++ b/app/demo-geant-integration/DetectorConstruction.cc
@@ -15,7 +15,9 @@
 #include <G4SDManager.hh>
 #include <G4VPhysicalVolume.hh>
 
+#include "corecel/Macros.hh"
 #include "corecel/io/Logger.hh"
+#include "accel/ExceptionConverter.hh"
 
 #include "GlobalSetup.hh"
 #include "SensitiveDetector.hh"

--- a/app/demo-geant-integration/EventAction.cc
+++ b/app/demo-geant-integration/EventAction.cc
@@ -9,6 +9,9 @@
 
 #include <G4Event.hh>
 
+#include "corecel/Macros.hh"
+#include "accel/ExceptionConverter.hh"
+
 namespace demo_geant
 {
 //---------------------------------------------------------------------------//
@@ -24,7 +27,9 @@ EventAction::EventAction(SPTransporter transport) : transport_(transport) {}
 void EventAction::BeginOfEventAction(const G4Event* event)
 {
     // Set event ID in local transporter
-    transport_->SetEventId(event->GetEventID());
+    celeritas::ExceptionConverter call_g4exception{"celer0002"};
+    CELER_TRY_ELSE(transport_->SetEventId(event->GetEventID()),
+                   call_g4exception);
 }
 
 //---------------------------------------------------------------------------//
@@ -34,7 +39,8 @@ void EventAction::BeginOfEventAction(const G4Event* event)
 void EventAction::EndOfEventAction(const G4Event*)
 {
     // Transport any tracks left in the buffer
-    transport_->Flush();
+    celeritas::ExceptionConverter call_g4exception{"celer0004"};
+    CELER_TRY_ELSE(transport_->Flush(), call_g4exception);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-geant-integration/RunAction.cc
+++ b/app/demo-geant-integration/RunAction.cc
@@ -7,6 +7,9 @@
 //---------------------------------------------------------------------------//
 #include "RunAction.hh"
 
+#include "corecel/Macros.hh"
+#include "accel/ExceptionConverter.hh"
+
 namespace demo_geant
 {
 //---------------------------------------------------------------------------//
@@ -31,13 +34,18 @@ void RunAction::BeginOfRunAction(const G4Run* run)
 {
     CELER_EXPECT(run);
 
-    // Initialize shared data
-    params_->Initialize(*options_);
-    CELER_ASSERT(*params_);
+    celeritas::ExceptionConverter call_g4exception{"celer0001"};
+    CELER_TRY_ELSE(
+        {
+            // Initialize shared data
+            params_->Initialize(*options_);
+            CELER_ASSERT(*params_);
 
-    // Construct thread-local transporter
-    *transport_ = celeritas::LocalTransporter(*options_, *params_);
-    CELER_ENSURE(*transport_);
+            // Construct thread-local transporter
+            *transport_ = celeritas::LocalTransporter(*options_, *params_);
+            CELER_ENSURE(*transport_);
+        },
+        call_g4exception);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-geant-integration/TrackingAction.cc
+++ b/app/demo-geant-integration/TrackingAction.cc
@@ -15,6 +15,8 @@
 #include <G4TrackStatus.hh>
 
 #include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+#include "accel/ExceptionConverter.hh"
 
 namespace demo_geant
 {
@@ -51,7 +53,8 @@ void TrackingAction::PreUserTrackingAction(const G4Track* track)
         != std::end(allowed_particles))
     {
         // Celeritas is transporting this track
-        transport_->Push(*track);
+        celeritas::ExceptionConverter call_g4exception{"celer0003"};
+        CELER_TRY_ELSE(transport_->Push(*track), call_g4exception);
         const_cast<G4Track*>(track)->SetTrackStatus(fStopAndKill);
     }
 }

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -13,6 +13,7 @@ set(PUBLIC_DEPS Celeritas::celeritas Celeritas::corecel ${Geant4_LIBRARIES})
 #-----------------------------------------------------------------------------#
 
 list(APPEND SOURCES
+  ExceptionConverter.cc
   Logger.cc
   LocalTransporter.cc
   SharedParams.cc

--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -13,16 +13,28 @@
 
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
+#include "corecel/sys/Environment.hh"
 
 namespace celeritas
 {
 namespace
 {
 //---------------------------------------------------------------------------//
+bool determine_strip()
+{
+    if (CELERITAS_DEBUG)
+    {
+        return true;
+    }
+    return !celeritas::getenv("CELER_STRIP_SOURCEDIR").empty();
+}
+
+//---------------------------------------------------------------------------//
 //! Try removing up to and including the filename from the reported path.
 std::string strip_source_dir(const std::string& filename)
 {
-    if (CELERITAS_DEBUG)
+    static const bool do_strip = determine_strip();
+    if (!do_strip)
     {
         // Don't strip in debug mode
         return filename;

--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #include "ExceptionConverter.hh"
 
-#include <cstring>
 #include <sstream>
 #include <G4Exception.hh>
 
@@ -22,11 +21,11 @@ namespace
 //---------------------------------------------------------------------------//
 bool determine_strip()
 {
-    if (CELERITAS_DEBUG)
+    if (!celeritas::getenv("CELER_STRIP_SOURCEDIR").empty())
     {
         return true;
     }
-    return !celeritas::getenv("CELER_STRIP_SOURCEDIR").empty();
+    return static_cast<bool>(CELERITAS_DEBUG);
 }
 
 //---------------------------------------------------------------------------//
@@ -40,24 +39,24 @@ std::string strip_source_dir(const std::string& filename)
         return filename;
     }
 
-    auto pos = std::string::npos;
-    for (const char* path : {"src/", "app/", "test/"})
+    std::string::size_type max_pos = 0;
+    for (const std::string path : {"src/", "app/", "test/"})
     {
-        pos = filename.rfind(path);
+        auto pos = filename.rfind(path);
 
         if (pos != std::string::npos)
         {
-            pos += std::strlen(path) - 1;
-            break;
+            pos += path.size() - 1;
+            max_pos = std::max(max_pos, pos);
         }
     }
-    if (pos == std::string::npos)
+    if (max_pos == 0)
     {
         // No telling where the filename is from...
         return filename;
     }
 
-    return filename.substr(pos + 1);
+    return filename.substr(max_pos + 1);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <G4Exception.hh>
 
+#include "celeritas_config.h"
 #include "corecel/Assert.hh"
 
 namespace celeritas
@@ -21,6 +22,12 @@ namespace
 //! Try removing up to and including the filename from the reported path.
 std::string strip_source_dir(const std::string& filename)
 {
+    if (CELERITAS_DEBUG)
+    {
+        // Don't strip in debug mode
+        return filename;
+    }
+
     auto pos = std::string::npos;
     for (const char* path : {"src/", "app/", "test/"})
     {

--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -1,0 +1,58 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/ExceptionConverter.cc
+//---------------------------------------------------------------------------//
+#include "ExceptionConverter.hh"
+
+#include <sstream>
+#include <G4Exception.hh>
+
+#include "corecel/Assert.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Capture the current exception and convert it to a G4Exception call.
+ */
+void ExceptionConverter::operator()(std::exception_ptr eptr)
+{
+    try
+    {
+        std::rethrow_exception(eptr);
+    }
+    catch (const RuntimeError& e)
+    {
+        // Translate a runtime error into a G4Exception call
+        std::ostringstream where;
+        if (e.details().file)
+        {
+            where << e.details().file;
+        }
+        if (e.details().line != 0)
+        {
+            where << ':' << e.details().line;
+        }
+        G4Exception(where.str().c_str(),
+                    err_code_,
+                    FatalException,
+                    e.details().what.c_str());
+    }
+    catch (const DebugError& e)
+    {
+        // Translate a *debug* error
+        std::ostringstream where;
+        where << e.details().file << ':' << e.details().line;
+        std::ostringstream what;
+        what << to_cstring(e.details().which) << ": " << e.details().condition;
+        G4Exception(
+            where.str().c_str(), err_code_, FatalException, what.str().c_str());
+    }
+    // (Any other errors will be rethrown and abort the program.)
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/accel/ExceptionConverter.hh
+++ b/src/accel/ExceptionConverter.hh
@@ -1,0 +1,59 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/ExceptionConverter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <exception>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Translate Celeritas C++ exceptions into Geant4 G4Exception calls.
+ *
+ * This should generally be used when wrapping calls to Celeritas in a user
+ * application.
+ *
+ * For example, the user event action to transport particles on device could be
+ * used as:
+ * \code
+   void EventAction::EndOfEventAction(const G4Event*)
+   {
+       // Transport any tracks left in the buffer
+
+       celeritas::ExceptionConverter call_g4exception{"celer0003"};
+
+       CELER_TRY_ELSE(transport_->Flush(), call_g4exception);
+   }
+ * \endcode
+ */
+class ExceptionConverter
+{
+  public:
+    // Construct with "error code"
+    inline explicit ExceptionConverter(const char* err_code);
+
+    // Capture the current exception and convert it to a G4Exception call
+    void operator()(std::exception_ptr p);
+
+  private:
+    const char* err_code_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with an error code for dispatching to Geant4.
+ */
+ExceptionConverter::ExceptionConverter(const char* err_code)
+    : err_code_{err_code}
+{
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -205,8 +205,7 @@
 #    define CELER_VALIDATE(COND, MSG)                                         \
         throw ::celeritas::DebugError({::celeritas::DebugErrorType::internal, \
                                        "CELER_VALIDATE cannot be called "     \
-                                       "from "                                \
-                                       "device code",                         \
+                                       "from device code",                    \
                                        __FILE__,                              \
                                        __LINE__});
 #    define CELER_NOT_CONFIGURED(WHAT) CELER_ASSERT(0)

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -181,14 +181,18 @@
  * function-like operator with a \c std::exception_ptr object.
  *
  * \note A file that uses this macro must include the <exception> header (but
- * since the \c HANDLE_EXCEPTION needs to take an exception pointer anyway).
+ * since the \c HANDLE_EXCEPTION needs to take an exception pointer, it's
+ * got to be included anyway).
  */
-#define CELER_TRY_ELSE(STATEMENT, HANDLE_EXCEPTION) \
-    try                                             \
-    {                                               \
-        STATEMENT;                                  \
-    }                                               \
-    catch (...)                                     \
-    {                                               \
-        HANDLE_EXCEPTION(std::current_exception()); \
-    }
+#define CELER_TRY_ELSE(STATEMENT, HANDLE_EXCEPTION)     \
+    do                                                  \
+    {                                                   \
+        try                                             \
+        {                                               \
+            STATEMENT;                                  \
+        }                                               \
+        catch (...)                                     \
+        {                                               \
+            HANDLE_EXCEPTION(std::current_exception()); \
+        }                                               \
+    } while (0)

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -173,3 +173,22 @@
 #else
 #    define CELER_DEVICE_PREFIX(TOK) DEVICE_UNAVAILABLE
 #endif
+
+/*!
+ * \def CELER_TRY_ELSE
+ *
+ * Execute the statement, catching *all* thrown errors by calling the given
+ * function-like operator with a \c std::exception_ptr object.
+ *
+ * \note A file that uses this macro must include the <exception> header (but
+ * since the \c HANDLE_EXCEPTION needs to take an exception pointer anyway).
+ */
+#define CELER_TRY_ELSE(STATEMENT, HANDLE_EXCEPTION) \
+    try                                             \
+    {                                               \
+        STATEMENT;                                  \
+    }                                               \
+    catch (...)                                     \
+    {                                               \
+        HANDLE_EXCEPTION(std::current_exception()); \
+    }

--- a/src/corecel/sys/MultiExceptionHandler.hh
+++ b/src/corecel/sys/MultiExceptionHandler.hh
@@ -12,22 +12,6 @@
 
 #include "corecel/Macros.hh"
 
-/*!
- * \def CELER_TRY_ELSE
- *
- * Execute the statement, catching *all* thrown errors by calling the given
- * function-like operator with a \c std::exception_ptr object.
- */
-#define CELER_TRY_ELSE(STATEMENT, HANDLE_EXCEPTION) \
-    try                                             \
-    {                                               \
-        STATEMENT;                                  \
-    }                                               \
-    catch (...)                                     \
-    {                                               \
-        HANDLE_EXCEPTION(std::current_exception()); \
-    }
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,7 +105,7 @@ else()
 endif()
 
 #-----------------------------------------------------------------------------#
-# TESTING ADDITION TESTS
+# GOOGLETEST EXTENSION TESTS
 #-----------------------------------------------------------------------------#
 
 celeritas_setup_tests(SERIAL PREFIX detail)
@@ -411,6 +411,18 @@ celeritas_add_device_test(celeritas/track/TrackInit ${_needs_cuda})
 set(CELERITASTEST_PREFIX celeritas/user)
 celeritas_add_test(celeritas/user/DetectorSteps.test.cc GPU)
 celeritas_add_test(celeritas/user/StepCollector.test.cc ${_optional_geant4_env})
+
+#-----------------------------------------------------------------------------#
+# ACCELERITAS TESTS
+#-----------------------------------------------------------------------------#
+
+if(CELERITAS_USE_Geant4)
+  celeritas_setup_tests(SERIAL PREFIX accel
+    LINK_LIBRARIES Celeritas::accel
+  )
+
+  celeritas_add_test(accel/ExceptionConverter.test.cc)
+endif()
 
 #-----------------------------------------------------------------------------#
 # DATA UPDATE

--- a/test/accel/ExceptionConverter.test.cc
+++ b/test/accel/ExceptionConverter.test.cc
@@ -1,0 +1,111 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/ExceptionConverter.test.cc
+//---------------------------------------------------------------------------//
+#include "accel/ExceptionConverter.hh"
+
+#include <G4VExceptionHandler.hh>
+
+#include "corecel/Macros.hh"
+#include "corecel/sys/Environment.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+class ExceptionHandler final : public G4VExceptionHandler
+{
+  public:
+    //! Accept error codes from geant4
+    G4bool Notify(const char*         originOfException,
+                  const char*         exceptionCode,
+                  G4ExceptionSeverity severity,
+                  const char*         description) final
+    {
+        if (originOfException)
+            origin = originOfException;
+        if (exceptionCode)
+            code = exceptionCode;
+        if (description)
+            desc = description;
+        level = severity;
+
+        return /* abort_the_program = */ false;
+    }
+
+    void clear()
+    {
+        origin = {};
+        code   = {};
+        level  = G4ExceptionSeverity::JustWarning;
+        desc   = {};
+    }
+
+    std::string         origin;
+    std::string         code;
+    G4ExceptionSeverity level;
+    std::string         desc;
+};
+
+class ExceptionConverterTest : public ::celeritas::test::Test
+{
+  protected:
+    static ExceptionHandler& handler()
+    {
+        // Instantiating the error handler's base class changes the global
+        // state
+        static ExceptionHandler eh;
+        return eh;
+    }
+
+    static void SetUpTestCase()
+    {
+        // Instantiate error handler
+        handler();
+
+        // Set environment variable to strip the source directory name from
+        // assertions
+        celeritas::environment().insert({"CELER_STRIP_SOURCEDIR", "1"});
+    }
+
+    void SetUp() override { handler().clear(); }
+};
+
+TEST_F(ExceptionConverterTest, debug)
+{
+    ExceptionConverter call_g4e{"test001"};
+    CELER_TRY_ELSE(
+        throw ::celeritas::DebugError({::celeritas::DebugErrorType::internal,
+                                       "there are five lights",
+                                       "me.cc",
+                                       123}),
+        call_g4e);
+
+    EXPECT_EQ("me.cc:123", handler().origin);
+    EXPECT_EQ("test001", handler().code);
+    EXPECT_EQ(G4ExceptionSeverity::FatalException, handler().level);
+    EXPECT_EQ("internal assertion failed: there are five lights",
+              handler().desc);
+}
+
+TEST_F(ExceptionConverterTest, runtime)
+{
+    ExceptionConverter call_g4e{"test002"};
+    CELER_TRY_ELSE(CELER_VALIDATE(2 + 2 == 5, << "math actually works"),
+                   call_g4e);
+
+    EXPECT_EQ(0, handler().origin.find("accel/ExceptionConverter.test.cc"))
+        << "actual path: '" << handler().origin << '\'';
+    EXPECT_EQ("test002", handler().code);
+    EXPECT_EQ("math actually works", handler().desc);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace test
+} // namespace celeritas


### PR DESCRIPTION
This is an attempt at a utility to convert Celeritas internal exceptions (runtime errors and debug failures) into Geant4-friendly `G4Exception` calls. Here's a debug failure on a single thread during tracking:
```
LocalTransporter.cc:128: info: Transporting 1 tracks with Celeritas

-------- EEEE ------- G4Exception-START -------- EEEE -------
*** G4Exception : celer0004
      issued by : /Users/seth/.local/src/celeritas/app/demo-geant-integration/SensitiveDetector.cc:52
precondition failed: collection_
*** Fatal Exception *** core dump ***
G4Track (0x11d81abd0) - track ID = 1, parent ID = 0
 Particle type : e- - creator process : not available
 Kinetic energy : 500 MeV - Momentum direction : (2.36658e-314,0,0)
 Step length : 0 fm  - total energy deposit : 0 eV
 Pre-step point : (0,0,0) - Physical volume : vacuum_tube_pv (vacuum)
 - defined by : not available
 Post-step point : (0,0,0) - Physical volume : vacuum_tube_pv (vacuum)
 - defined by : not available
 *** Note: Step information might not be properly updated.

-------- EEEE -------- G4Exception-END --------- EEEE -------


*** G4Exception: Aborting execution ***
```
