### PR TITLE
Convert Thrust exceptions to Geant4

### DIFF
--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -5,7 +5,7 @@
 #-----------------------------------------------------------------------------#
 
 set(SOURCES)
-set(PRIVATE_DEPS Celeritas::DeviceToolkit)
+set(PRIVATE_DEPS)
 set(PUBLIC_DEPS Celeritas::celeritas Celeritas::corecel ${Geant4_LIBRARIES})
 
 #-----------------------------------------------------------------------------#
@@ -13,11 +13,12 @@ set(PUBLIC_DEPS Celeritas::celeritas Celeritas::corecel ${Geant4_LIBRARIES})
 #-----------------------------------------------------------------------------#
 
 list(APPEND SOURCES
-  ExceptionConverter.cc
   Logger.cc
   LocalTransporter.cc
   SharedParams.cc
 )
+
+celeritas_polysource(ExceptionConverter)
 
 #-----------------------------------------------------------------------------#
 # Create library

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -5,7 +5,7 @@
 #-----------------------------------------------------------------------------#
 
 set(SOURCES)
-set(PRIVATE_DEPS)
+set(PRIVATE_DEPS Celeritas::DeviceToolkit)
 set(PUBLIC_DEPS Celeritas::celeritas Celeritas::corecel ${Geant4_LIBRARIES})
 
 #-----------------------------------------------------------------------------#

--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -12,7 +12,12 @@
 
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
 #include "corecel/sys/Environment.hh"
+
+#if CELER_USE_DEVICE
+#    include <thrust/system/system_error.h>
+#endif
 
 namespace celeritas
 {
@@ -99,6 +104,12 @@ void ExceptionConverter::operator()(std::exception_ptr eptr)
         G4Exception(
             where.str().c_str(), err_code_, FatalException, what.str().c_str());
     }
+#if CELER_USE_DEVICE
+    catch (const thrust::system_error& e)
+    {
+        G4Exception("Thrust GPU library", err_code_, FatalException, e.what());
+    }
+#endif
     // (Any other errors will be rethrown and abort the program.)
 }
 

--- a/src/accel/ExceptionConverter.cu
+++ b/src/accel/ExceptionConverter.cu
@@ -1,0 +1,36 @@
+//---------------------------------*-CUDA-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/ExceptionConverter.cu
+//---------------------------------------------------------------------------//
+#include "ExceptionConverter.hh"
+
+#include <G4Exception.hh>
+#include <thrust/system/system_error.h>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Catch exceptions that require CUDA headers.
+ *
+ * This should be called as a fallback after Celeritas exceptions are caught.
+ * It can't be part of the main "catch" clause when building with HIP because
+ * of how the HIP-thrust fork is implemented.
+ */
+void ExceptionConverter::convert_device_exceptions(std::exception_ptr eptr) const
+{
+    try
+    {
+        std::rethrow_exception(eptr);
+    }
+    catch (const thrust::system_error& e)
+    {
+        G4Exception("Thrust GPU library", err_code_, FatalException, e.what());
+    }
+}
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/accel/ExceptionConverter.hh
+++ b/src/accel/ExceptionConverter.hh
@@ -38,10 +38,12 @@ class ExceptionConverter
     inline explicit ExceptionConverter(const char* err_code);
 
     // Capture the current exception and convert it to a G4Exception call
-    void operator()(std::exception_ptr p);
+    void operator()(std::exception_ptr p) const;
 
   private:
     const char* err_code_;
+
+    void convert_device_exceptions(std::exception_ptr p) const;
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
In the demo app I encountered `thrust::system_error` exceptions when running 128 threads, each with an absurd initializer storage requirement: thrust ran out of memory and crashed the program ungracefully. This PR catches thrust  exceptions, which requires a little extra work because including HIP thrust doesn't work unless using the HIP compilers: otherwise it assumes you are building CUDA thrust and have CUDA headers.

🎅🎄🎁