### PR TITLE
Auto-export GDML from Geant4 geometry

### DIFF
--- a/app/demo-geant-integration/DetectorConstruction.cc
+++ b/app/demo-geant-integration/DetectorConstruction.cc
@@ -41,7 +41,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
     gdml_parser.SetStripFlag(false);
 
     constexpr bool validate_gdml_schema = false;
-    const std::string& filename = GlobalSetup::Instance()->GetGdmlFile();
+    const std::string& filename = GlobalSetup::Instance()->GetGeometryFile();
     if (filename.empty())
     {
         G4Exception("DetectorConstruction::Construct()",

--- a/app/demo-geant-integration/GlobalSetup.cc
+++ b/app/demo-geant-integration/GlobalSetup.cc
@@ -34,8 +34,8 @@ GlobalSetup::GlobalSetup()
         this, "/setup/", "Demo geant integration setup");
 
     {
-        auto& cmd = messenger_->DeclareProperty("setGeometryFile",
-                                                options_->geometry_file);
+        auto& cmd
+            = messenger_->DeclareProperty("setGeometryFile", geometry_file_);
         cmd.SetGuidance("Set the geometry file name");
     }
     {

--- a/app/demo-geant-integration/GlobalSetup.hh
+++ b/app/demo-geant-integration/GlobalSetup.hh
@@ -28,7 +28,7 @@ class GlobalSetup
 
     //!@{
     //! Demo setup options
-    const std::string& GetGdmlFile() const { return options_->geometry_file; }
+    const std::string& GetGeometryFile() const { return geometry_file_; }
     //!@}
 
     //! Get an immutable reference to the setup options
@@ -44,7 +44,9 @@ class GlobalSetup
 
     // Data
     std::shared_ptr<celeritas::SetupOptions> options_;
-    std::unique_ptr<G4GenericMessenger>      messenger_;
+    std::string                              geometry_file_;
+
+    std::unique_ptr<G4GenericMessenger> messenger_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/demo-geant-integration/RunAction.cc
+++ b/app/demo-geant-integration/RunAction.cc
@@ -9,10 +9,13 @@
 
 #include <G4Threading.hh>
 
+#include "celeritas_config.h"
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/io/Logger.hh"
 #include "accel/ExceptionConverter.hh"
+
+#include "GlobalSetup.hh"
 
 namespace demo_geant
 {
@@ -37,6 +40,13 @@ RunAction::RunAction(SPConstOptions options,
 void RunAction::BeginOfRunAction(const G4Run* run)
 {
     CELER_EXPECT(run);
+
+    if (!CELERITAS_USE_VECGEOM)
+    {
+        // For testing purposes, pass the GDML input filename to Celeritas
+        const_cast<celeritas::SetupOptions&>(*options_).geometry_file
+            = GlobalSetup::Instance()->GetGeometryFile();
+    }
 
     celeritas::ExceptionConverter call_g4exception{"celer0001"};
     CELER_TRY_ELSE(
@@ -63,7 +73,7 @@ void RunAction::EndOfRunAction(const G4Run*)
     // Deallocate Celeritas state data (optional)
     transport_.reset();
 
-    // Clear shared data and write if master thread
+    // Clear shared data and write if master thread (when running without MT)
     if (G4Threading::IsMasterThread())
     {
         params_->Finalize();

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -31,9 +31,7 @@ struct SetupOptions
 
     //!@{
     //! \name I/O
-    // TODO: geometry should be exported directly from Geant4 (or written to
-    // temporary GDML and re-read)
-    //! GDML filename
+    //! GDML filename (optional: defaults to exporting existing Geant4)
     std::string geometry_file;
     //! Filename for JSON diagnostic output
     std::string output_file;

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -162,11 +162,7 @@ void SharedParams::locked_initialize(const SetupOptions& options)
     CELER_LOG_LOCAL(status) << "Initializing Celeritas";
     ScopedTimeLog scoped_time;
 
-    celeritas::GeantImporter load_geant_data(
-        G4TransportationManager::GetTransportationManager()
-            ->GetNavigatorForTracking()
-            ->GetWorldVolume());
-
+    celeritas::GeantImporter load_geant_data(GeantImporter::get_world_volume());
     auto imported = load_geant_data();
     CELER_ASSERT(imported);
 

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -8,9 +8,10 @@
 #include "SharedParams.hh"
 
 #include <CLHEP/Random/Random.h>
-#include <G4AutoLock.hh>
+#include <G4Threading.hh>
 #include <G4TransportationManager.hh>
 
+#include "celeritas_config.h"
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/OutputInterfaceAdapter.hh"
@@ -61,6 +62,11 @@ SharedParams::~SharedParams() = default;
  */
 void SharedParams::Initialize(const SetupOptions& options)
 {
+    CELER_EXPECT(*this || G4Threading::IsMasterThread());
+
+    CELER_LOG_LOCAL(status) << "Initializing Celeritas";
+    ScopedTimeLog scoped_time;
+
     if (Device::num_devices() > 0)
     {
         // Initialize CUDA (you'll need to use CUDA environment variables to
@@ -79,10 +85,9 @@ void SharedParams::Initialize(const SetupOptions& options)
         }
     }
 
-    if (!*this)
+    if (G4Threading::IsMasterThread())
     {
-        // Maybe the first thread to run: build and store core params
-        this->locked_initialize(options);
+        this->initialize_master(options);
     }
     CELER_ENSURE(*this);
 }
@@ -97,6 +102,7 @@ void SharedParams::Initialize(const SetupOptions& options)
 void SharedParams::Finalize()
 {
     CELER_EXPECT(*this);
+    CELER_EXPECT(G4Threading::IsMasterThread());
 
     if (!output_filename_.empty())
     {
@@ -147,21 +153,8 @@ void SharedParams::Finalize()
 /*!
  * Construct from setup options in a thread-safe manner.
  */
-void SharedParams::locked_initialize(const SetupOptions& options)
+void SharedParams::initialize_master(const SetupOptions& options)
 {
-    static G4Mutex mutex = G4MUTEX_INITIALIZER;
-    G4AutoLock     lock(&mutex);
-
-    if (*this)
-    {
-        // Some other thread constructed params between the thread-unsafe check
-        // and this thread-safe check
-        return;
-    }
-
-    CELER_LOG_LOCAL(status) << "Initializing Celeritas";
-    ScopedTimeLog scoped_time;
-
     celeritas::GeantImporter load_geant_data(GeantImporter::get_world_volume());
     auto imported = load_geant_data();
     CELER_ASSERT(imported);
@@ -173,10 +166,17 @@ void SharedParams::locked_initialize(const SetupOptions& options)
         params.action_reg = std::make_shared<ActionRegistry>();
     }
 
-    // Load geometry
+    // Reload geometry
+    if (!options.geometry_file.empty())
     {
-        // TODO: export GDML through Geant4 to temporary file
+        // Read directly from GDML input
         params.geometry = std::make_shared<GeoParams>(options.geometry_file);
+    }
+    else
+    {
+        // Import from Geant4
+        params.geometry
+            = std::make_shared<GeoParams>(GeantImporter::get_world_volume());
     }
 
     // Load materials

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -24,8 +24,9 @@ struct SetupOptions;
  * preferably as a shared pointer. The shared pointer should be
  * passed to a thread-local \c LocalTransporter instance. At the beginning of
  * the run, after Geant4 has initialized physics data, the \c Initialize method
- * must be called to populate the Celeritas data structures (geometry,
- * physics).
+ * must be called first on the "master" thread to populate the Celeritas data
+ * structures (geometry, physics). \c Initialize must subsequently be invoked
+ * on all worker threads.
  */
 class SharedParams
 {
@@ -64,7 +65,7 @@ class SharedParams
 
     //// HELPER FUNCTIONS ////
 
-    void locked_initialize(const SetupOptions& options);
+    void initialize_master(const SetupOptions& options);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -98,6 +98,7 @@ if(CELERITAS_USE_Geant4)
     ext/GeantSetup.cc
     ext/detail/GeantBremsstrahlungProcess.cc
     ext/detail/GeantExceptionHandler.cc
+    ext/detail/GeantGeoExporter.cc
     ext/detail/GeantLoggerAdapter.cc
     ext/detail/GeantPhysicsList.cc
     ext/detail/ImportProcessConverter.cc

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -27,6 +27,7 @@
 #include <G4RToEConvForPositron.hh>
 #include <G4RToEConvForProton.hh>
 #include <G4SystemOfUnits.hh>
+#include <G4TransportationManager.hh>
 #include <G4VProcess.hh>
 #include <G4VSolid.hh>
 
@@ -491,6 +492,24 @@ ImportEmParameters store_em_parameters()
 
 //---------------------------------------------------------------------------//
 } // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get an externally loaded Geant4 top-level geometry element.
+ *
+ * This is only defined if Geant4 has already been set up. It's meant to be
+ * used in concert with GeantImporter or other Geant-importing classes.
+ */
+const G4VPhysicalVolume* GeantImporter::get_world_volume()
+{
+    auto* man = G4TransportationManager::GetTransportationManager();
+    CELER_ASSERT(man);
+    auto* nav = man->GetNavigatorForTracking();
+    CELER_ASSERT(nav);
+    auto* world = nav->GetWorldVolume();
+    CELER_ENSURE(world);
+    return world;
+}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/ext/GeantImporter.hh
+++ b/src/celeritas/ext/GeantImporter.hh
@@ -59,6 +59,9 @@ class GeantImporter
     };
 
   public:
+    // Get an externally loaded Geant4 top-level geometry element
+    static const G4VPhysicalVolume* get_world_volume();
+
     // Construct from an existing Geant4 geometry, assuming physics is loaded
     explicit GeantImporter(const G4VPhysicalVolume* world);
 
@@ -82,6 +85,11 @@ class GeantImporter
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_GEANT4
+inline const G4VPhysicalVolume* GeantImporter::get_world_volume()
+{
+    CELER_NOT_CONFIGURED("Geant4");
+}
+
 inline GeantImporter::GeantImporter(const G4VPhysicalVolume*)
 {
     (void)sizeof(world_);

--- a/src/celeritas/ext/VecgeomParams.hh
+++ b/src/celeritas/ext/VecgeomParams.hh
@@ -16,6 +16,8 @@
 
 #include "VecgeomData.hh"
 
+class G4VPhysicalVolume;
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -37,6 +39,9 @@ class VecgeomParams
   public:
     // Construct from a GDML filename
     explicit VecgeomParams(const std::string& gdml_filename);
+
+    // Create a VecGeom model from a pre-existing Geant4 geometry
+    explicit VecgeomParams(const G4VPhysicalVolume* world);
 
     // Clean up VecGeom on destruction
     ~VecgeomParams();

--- a/src/celeritas/ext/VecgeomParams.hh
+++ b/src/celeritas/ext/VecgeomParams.hh
@@ -92,7 +92,12 @@ class VecgeomParams
 
     //// HELPER FUNCTIONS ////
 
-    void build_md();
+    // Construct VecGeom tracking data and copy to GPU
+    void build_tracking();
+    // Construct host/device Celeritas data
+    void build_data();
+    // Construct labels and other host-only metadata
+    void build_metadata();
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantGeoExporter.cc
+++ b/src/celeritas/ext/detail/GeantGeoExporter.cc
@@ -1,0 +1,67 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/detail/GeantGeoExporter.cc
+//---------------------------------------------------------------------------//
+#include "GeantGeoExporter.hh"
+
+#include "corecel/Assert.hh"
+#include "corecel/io/ScopedTimeAndRedirect.hh"
+#include <G4Threading.hh>
+#include <G4GDMLParser.hh>
+#include <G4VPhysicalVolume.hh>
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a name for a temporary GDML output filename.
+ */
+std::string GeantGeoExporter::make_tmpfile_name()
+{
+    // TODO: use std::filesystem, RNG seeded by clock, PID, something.
+    return "geant-celeritas-export.gdml";
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create with a reference to the world volume.
+ */
+GeantGeoExporter::GeantGeoExporter(const G4VPhysicalVolume* world)
+    : world_(world)
+{
+    CELER_EXPECT(world_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write out the given geometry to a file.
+ *
+ * This should be called only by the master thread. (It's a null-op in the GDML
+ * parser for other threads, but we should be explicit.)
+ */
+void GeantGeoExporter::operator()(const std::string& filename) const
+{
+    CELER_EXPECT(G4Threading::IsMasterThread());
+
+    CELER_LOG(status) << "Exporting Geant4 geometry to GDML";
+    ScopedTimeAndRedirect time_and_output_("G4GDMLParser");
+
+    G4GDMLParser parser;
+    parser.SetEnergyCutsExport(true);
+    parser.SetSDExport(true);
+    parser.SetOverlapCheck(true);
+    parser.SetOutputFileOverwrite(true);
+    constexpr bool append_pointers = true;
+    parser.Write(filename,
+                 world_,
+                 append_pointers);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/celeritas/ext/detail/GeantGeoExporter.hh
+++ b/src/celeritas/ext/detail/GeantGeoExporter.hh
@@ -1,0 +1,40 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/detail/GeantGeoExporter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+
+class G4VPhysicalVolume;
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Export a Geant4 geometry to a GDML file.
+ */
+class GeantGeoExporter
+{
+  public:
+    // Helper function to create a temporary file.
+    static std::string make_tmpfile_name();
+
+    // Construct from the world geometry pointer
+    explicit GeantGeoExporter(const G4VPhysicalVolume* world);
+
+    // Save to a file and return properties
+    void operator()(const std::string& filename) const;
+
+  private:
+    const G4VPhysicalVolume* world_;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace detail
+} // namespace celeritas

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -92,6 +92,17 @@ OrangeParams::OrangeParams(const std::string& json_filename)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Construct in-memory from a Geant4 geometry (not implemented).
+ *
+ * Perhaps someday we'll implement in-memory translation...
+ */
+OrangeParams::OrangeParams(const G4VPhysicalVolume*)
+{
+    CELER_NOT_IMPLEMENTED("Geant4->VecGeom geometry translation");
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Advanced usage: construct from explicit host data.
  *
  * Volume and surface labels must be unique for the time being.

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -21,6 +21,8 @@
 #include "OrangeTypes.hh"
 #include "detail/UnitIndexer.hh"
 
+class G4VPhysicalVolume;
+
 namespace celeritas
 {
 struct OrangeInput;
@@ -44,6 +46,9 @@ class OrangeParams
   public:
     // Construct from a JSON file (if JSON is enabled)
     explicit OrangeParams(const std::string& json_filename);
+
+    // Construct in-memory from Geant4 (not implemented)
+    explicit OrangeParams(const G4VPhysicalVolume*);
 
     // ADVANCED usage: construct from explicit host data
     explicit OrangeParams(OrangeInput input);

--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -52,7 +52,11 @@ ImportData load_import_data(std::string filename)
 {
     GeantPhysicsOptions options;
     options.em_bins_per_decade = 14;
-    GeantImporter import(GeantSetup(filename, options));
+    // XXX static for now so that Vecgeom or other clients can access geant4
+    // before the test explodes. Instead let's make this a class static
+    // variable that can be reset maybe? Probably doesn't matter in practice
+    // because geant still can't handle multiple runs per exe.
+    static GeantImporter import(GeantSetup{filename, options});
     return import();
 }
 

--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -94,6 +94,22 @@ bool GeantTestBase::is_summit_build()
 }
 
 //---------------------------------------------------------------------------//
+//! Get the Geant4 top-level geometry element (immutable)
+const G4VPhysicalVolume* GeantTestBase::get_world_volume() const
+{
+    return GeantImporter::get_world_volume();
+}
+
+//---------------------------------------------------------------------------//
+//! Get the Geant4 top-level geometry element
+const G4VPhysicalVolume* GeantTestBase::get_world_volume()
+{
+    // Load geometry
+    this->imported_data();
+    return const_cast<const GeantTestBase*>(this)->get_world_volume();
+}
+
+//---------------------------------------------------------------------------//
 // PROTECTED MEMBER FUNCTIONS
 //---------------------------------------------------------------------------//
 auto GeantTestBase::build_material() -> SPConstMaterial

--- a/test/celeritas/GeantTestBase.hh
+++ b/test/celeritas/GeantTestBase.hh
@@ -13,6 +13,8 @@
 
 #include "GlobalGeoTestBase.hh"
 
+class G4VPhysicalVolume;
+
 namespace celeritas
 {
 struct ImportData;
@@ -41,6 +43,12 @@ class GeantTestBase : virtual public GlobalGeoTestBase
     static bool is_ci_build();
     static bool is_wildstyle_build();
     static bool is_summit_build();
+    //!@}
+
+    //!@{
+    //! Get the Geant4 top-level geometry element
+    const G4VPhysicalVolume* get_world_volume();
+    const G4VPhysicalVolume* get_world_volume() const;
     //!@}
 
   protected:

--- a/test/celeritas/GlobalGeoTestBase.cc
+++ b/test/celeritas/GlobalGeoTestBase.cc
@@ -66,10 +66,8 @@ void GlobalGeoTestBase::reset_geometry()
 //---------------------------------------------------------------------------//
 auto GlobalGeoTestBase::lazy_geo() -> LazyGeo&
 {
-    // Delayed initialization
-    static LazyGeo lg;
-
-    if (!lg.geo)
+    static bool registered_cleanup = false;
+    if (!registered_cleanup)
     {
         /*! Always reset geometry at end of testing before global destructors.
          *
@@ -80,9 +78,13 @@ auto GlobalGeoTestBase::lazy_geo() -> LazyGeo&
          * initialization/destruction order is undefined across translation
          * units.
          */
+        CELER_LOG(debug) << "Registering CleanupGeoEnvironment";
         ::testing::AddGlobalTestEnvironment(new CleanupGeoEnvironment());
+        registered_cleanup = true;
     }
 
+    // Delayed initialization
+    static LazyGeo lg;
     return lg;
 }
 

--- a/test/celeritas/GlobalGeoTestBase.hh
+++ b/test/celeritas/GlobalGeoTestBase.hh
@@ -31,7 +31,7 @@ class GlobalGeoTestBase : virtual public GlobalTestBase
     virtual const char* geometry_basename() const = 0;
 
     // Construct a geometry that's persistent across tests
-    SPConstGeo build_geometry() final;
+    SPConstGeo build_geometry() override;
 
     // Clear the lazy geometry
     static void reset_geometry();

--- a/test/celeritas/OnlyGeoTestBase.hh
+++ b/test/celeritas/OnlyGeoTestBase.hh
@@ -3,13 +3,13 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/geo/OnlyGeoTestBase.hh
+//! \file celeritas/OnlyGeoTestBase.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include "corecel/Assert.hh"
 
-#include "../GlobalTestBase.hh"
+#include "GlobalTestBase.hh"
 
 namespace celeritas
 {

--- a/test/celeritas/data/solids.gdml
+++ b/test/celeritas/data/solids.gdml
@@ -1,0 +1,466 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!--
+Copied from a Geant4 example: extended/persistency/gdml/G01/solids.gdml
+
+License and Disclaimer
+
+The Geant4 software is copyright of the Copyright Holders of
+the Geant4 Collaboration. It is provided under the terms and
+conditions of the Geant4 Software License, included in the file
+LICENSE and available at http://cern.ch/geant4/license . These
+include a list of copyright holders.
+
+Neither the authors of this software system, nor their employing
+institutes, nor the agencies providing financial support for this
+work make any representation or warranty, express or implied,
+regarding this software system or assume any liability for its
+use. Please see the license in the file LICENSE and URL above
+for the full disclaimer and the limitation of liability.
+
+This code implementation is the result of the scientific and
+technical work of the GEANT4 collaboration.
+By using, copying, modifying or distributing the software (or
+any work based on the software) you agree to acknowledge its
+use in resulting scientific publications, and indicate your
+acceptance of all terms of the Geant4 Software license.
+
+-->
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+ <define>
+  <constant name="HALFPI" value="pi/2."/>
+  <constant name="PI" value="1.*pi"/>
+  <constant name="TWOPI" value="2.*pi"/>
+  <expression name="customangle">2*(HALFPI+0.2*PI)</expression>
+  <position name="center" x="0" y="0" z="0"/>
+  <rotation name="identity" x="0" y="0" z="0" />
+  <position name="shiftbyx" x="-500"/>
+  <position name="pos1" x="-250"/>
+  <position name="pos2" x="-125"/>
+  <position name="pos3" x="125"/>
+  <position name="pos4" x="250"/>
+  <position name="pos11"  x="-250" y=" 125"/>
+  <position name="pos21"  x="-125" y=" 125"/>
+  <position name="pos31"  x=" 125" y=" 125"/>
+  <position name="pos41"  x=" 250" y=" 125"/>
+  <position name="pos412"  x=" 250" y=" 225"/>
+  <position name="pos51"  x=" 550" y=" 125"/>
+  <position name="pos61"  x=" 550" y="-125"/>
+  <position name="pos71"  x=" 550" y=" 0"/>
+  <position name="pos81"  x="-550" y=" 125"/>
+  <position name="pos91"  x="-550" y="-125"/>
+  <position name="pos101" x="-550" />
+  <position name="pos201"  x=" 750" y=" 0"/>
+  <position name="pos301"  x=" 750" y=" 125"/>
+  <position name="pos401"  x=" 750" y="-125"/>
+  <position name="pos501"  x="-750" y="-125"/>
+  <position name="pos502"  x="-750" y="-225"/>
+  <position name="pos601"  x="-750" y=" 125"/>
+  <position name="pos701"  x="-750" y=" 0"/>
+  <position name="pos801"  x="950"  y=" 125"/>
+  <position name="pos901"  x="950"  y="-125"/>
+  <position name="pos1001"  x="950" y="0"/>
+  <position name="pos1002"  x="950" y="125"/>
+  <position name="pos1003"  x="950" y="-125"/>
+  <rotation name="rotatebyx" x="HALFPI"/>
+  <rotation name="rotatebyall" x="HALFPI" y="PI" z="TWOPI"/>
+  <position name="v0" unit="mm" x="10" y="10" z="0" />
+  <position name="v1" unit="mm" x="-10" y="10" z="0" />
+  <position name="v2" unit="mm" x="0" y="0" z="20" />
+  <position name="v3" unit="mm" x="-10" y="-10" z="0" />
+  <position name="v4" unit="mm" x="10" y="-10" z="0" />
+  <quantity name="ro" type="density" unit="g/cm3" value="1234.00"/>
+  <quantity name="sizeoft500" type="length" unit="mm" value="500.0"/>
+  <quantity name="wextent" type="length" value="10000.0" unit="mm"/>
+  <position name="shiftbysizeoft500" x="500.0"/>
+  <position name="unionidentitypos" x="25."/>
+ </define>
+
+ <materials>
+  <element name="Hydrogen" formula="H"  Z="1.">  <atom value="1.01"/>   </element>
+  <element name="Oxygen"   formula="O"  Z="8.">  <atom value="16.0"/>   </element>
+  <element name="Nitrogen" formula="N"  Z="7.">  <atom value="14.01"/>  </element>
+  <element name="Lead"     formula="Pb" Z="82."> <atom value="207.20"/> </element>
+  <material name="Al" Z="13.0"> <D value="2.70"/> <atom value="26.98"/> </material>
+  <material name="Water" formula="H20">
+   <D value="1.0"/>
+   <composite n="2" ref="Hydrogen"/>
+   <composite n="1" ref="Oxygen"/>
+  </material>
+  <material name="Air">
+   <D value="1.290" unit="mg/cm3"/>
+   <fraction n="0.7" ref="Nitrogen"/>
+   <fraction n="0.3" ref="Oxygen"/>
+  </material>
+ </materials>
+
+ <solids>
+  <box name="WorldBox" x="wextent" y="wextent" z="wextent"/>
+
+  <box name="b100" x="10.0" y="10.0" z="10.0"/>
+  <box name="b500" x="50.0" y="50.0" z="50.0"/>
+
+  <cone name="c1" z="111.0" rmax1="22.0" rmax2="33.0" deltaphi="TWOPI" aunit="rad"/>
+
+  <para name="pa1" x="10.0" y="10.0" z="10.0" alpha="30.0" theta="30.0" phi="30.0" aunit="deg"/>
+
+  <sphere name="s1" rmax="50.0" deltaphi="TWOPI" deltatheta="PI" aunit="rad"/>
+
+  <arb8 name="arb81" dz="50.0" v1x="-45.0" v1y="-45.0" v2x="-45.0" v2y="45.0"
+             v3x="45.0"  v3y="45.0" v4x="45.0" v4y="-45.0" v5x="-35.0" v5y="-35.0"
+	     v6x="-35.0" v6y="35.0" v7x="35.0" v7y="35.0"  v8x="35.0"  v8y="-35.0" />
+  <arb8 name="arb82" dz="50.0" v1x="-45.0" v1y="-45.0" v2x="-45.0" v2y="45.0"
+             v3x="45.0"  v3y="45.0" v4x="45.0" v4y="-45.0" v5x="-35.0" v5y="-35.0"
+	     v6x="-35.0" v6y="35.0" v7x="35.0" v7y="35.0"  v8x="35.0"  v8y="-15.0" />
+  <trap name="trap1" z="100.0" theta="60.0" phi="60.0"
+                             y1="10.0"    x1="10.0" x2="10.0"
+                             alpha1="30.0"  y2="10.0" x3="10.0"
+                             x4="10.0"    alpha2="30.0" aunit="deg"/>
+  <trd name="trd1" x1="10.0" x2="10.0" y1="10.0" y2="20.0" z="30.0"/>
+  <tube name="t1000" z="1000.0" rmax="100.0" deltaphi="TWOPI" aunit="rad"/>
+  <tube name="t400" z="200.0" rmax="50.0" deltaphi="customangle" aunit="rad"/>
+  <tube name="t100" z="100.0" rmax="10.0" deltaphi="TWOPI" aunit="rad"/>
+
+  <union name="u1">
+   <first ref="b500"/>  <second ref="b100"/>
+   <positionref ref="unionidentitypos" />
+   <rotation name="unionidentityrot"/>
+   <firstpositionref ref= "center"/>
+  </union>
+  <subtraction name="sub1">
+   <first ref="u1"/> <second ref="b100"/>
+   <position  name="subidentitypos" x="-25."  />
+   <rotation name="subidentityrot"/>
+  </subtraction>
+
+  <polycone aunit="degree" name="testpoly" deltaphi="360.0" startphi="0.0">
+    <zplane z="10.0" rmin="1.0" rmax="5.0"/>
+    <zplane z="100.0" rmin="10.0" rmax="30.0"/>
+  </polycone>
+
+  <genericPolycone aunit="degree" name="testgenpoly" deltaphi="360.0" startphi="0.0">
+    <rzpoint r="0.0" z="10.0" />
+    <rzpoint r="5.0" z="20.0" />
+    <rzpoint r="0.0" z="30.0" />
+  </genericPolycone>
+
+  <tessellated  aunit="degree" lunit="mm" name="testtessel">
+     <triangular vertex1="v0" vertex2="v1" vertex3="v2"/>
+     <triangular vertex1="v1" vertex2="v3" vertex3="v2"/>
+     <triangular vertex1="v3" vertex2="v4" vertex3="v2"/>
+     <triangular vertex1="v4" vertex2="v0" vertex3="v2"/>
+     <quadrangular vertex1="v4" vertex2="v3" vertex3="v1" vertex4="v0" />
+  </tessellated>
+
+  <torus name="testtorus" rmin="0.0" rmax="10.0" rtor="80.0" startphi="0.0" deltaphi="TWOPI"/>
+
+  <orb name="testorb" r="50.0"/>
+  <polyhedra aunit="degree" deltaphi="90." lunit="mm" name="testph" numsides="3" startphi="0." >
+     <zplane z="10.0" rmin="1.0" rmax="5.0"/>
+     <zplane z="100.0" rmin="10.0" rmax="30.0"/>
+  </polyhedra>
+  <genericPolyhedra aunit="degree" deltaphi="90." lunit="mm" name="testgenph" numsides="3" startphi="0." >
+    <rzpoint r="0.0" z="10.0" />
+    <rzpoint r="5.0" z="20.0" />
+    <rzpoint r="0.0" z="30.0" />
+  </genericPolyhedra>
+
+  <hype name="testhype" rmin="10.0" rmax="30.0" inst="10.0" outst="20.0" z="50.0"/>
+
+  <eltube name="testeltube" dx="30.0" dy="50.0" dz="40.0"/>
+  <ellipsoid name="testellipsoid" ax="10" by="15" cz="20" zcut2="4" lunit="mm"/>
+  <elcone name="testelcone" dx="1" dy="1.5" zmax="2" zcut="1.5" lunit="mm"/>
+  <paraboloid name="testparaboloid" rlo="10" rhi="15" dz="20" lunit="mm"/>
+
+  <tet name="testtet" vertex1="v4" vertex2="v3" vertex3="v1" vertex4="v2" />
+
+  <twistedbox name="ttwistedbox" PhiTwist="1" x="30" y="30" z="30" aunit="rad" lunit="mm"/>
+  <twistedtrd name="ttwistedtrd" PhiTwist="1" x1="9" x2="8" y1="6" y2="5" z="10" aunit="rad" lunit="mm"/>
+  <twistedtrap name="ttwistedtrap" PhiTwist="1" z="10" Theta="1" Phi="2" y1="15" y2="15" x1="10" x2="10" x3="10" x4="10" Alph="1" aunit="rad" lunit="mm"/>
+  <twistedtubs name="ttwistedtubs" endinnerrad="10" endouterrad="15" zlen="40" phi="90." twistedangle="1" aunit="degree" lunit="mm"/>
+ </solids>
+
+ <structure>
+  <volume name="vol0">
+   <materialref ref="Water"/>
+   <solidref ref="b100"/>
+  </volume>
+
+  <volume name="vol1">
+   <materialref ref="Water"/>
+   <solidref ref="c1"/>
+  </volume>
+
+  <volume name="vol2">
+   <materialref ref="Water"/>
+   <solidref ref="pa1"/>
+  </volume>
+
+  <volume name="vol3">
+   <materialref ref="Water"/>
+   <solidref ref="s1"/>
+  </volume>
+
+  <volume name="vol4">
+   <materialref ref="Water"/>
+   <solidref ref="trap1"/>
+  </volume>
+
+  <volume name="vol11">
+   <materialref ref="Water"/>
+   <solidref ref="trd1"/>
+  </volume>
+
+  <volume name="vol21">
+   <materialref ref="Water"/>
+   <solidref ref="t100"/>
+  </volume>
+  <volume name="vol31">
+   <materialref ref="Water"/>
+   <solidref ref="sub1"/>
+  </volume>
+
+  <volume name="vol41">
+   <materialref ref="Water"/>
+   <solidref ref="testpoly"/>
+  </volume>
+
+  <volume name="vol412">
+   <materialref ref="Water"/>
+   <solidref ref="testgenpoly"/>
+  </volume>
+
+   <volume name="vol51">
+   <materialref ref="Water"/>
+   <solidref ref="testellipsoid"/>
+  </volume>
+
+  <volume name="vol61">
+   <materialref ref="Water"/>
+   <solidref ref="testtet"/>
+  </volume>
+
+  <volume name="vol71">
+   <materialref ref="Water"/>
+   <solidref ref="ttwistedbox"/>
+  </volume>
+
+  <volume name="vol81">
+   <materialref ref="Water"/>
+   <solidref ref="ttwistedtrd"/>
+  </volume>
+
+  <volume name="vol91">
+   <materialref ref="Water"/>
+   <solidref ref="ttwistedtrap"/>
+  </volume>
+
+  <volume name="vol101">
+   <materialref ref="Water"/>
+   <solidref ref="ttwistedtubs"/>
+  </volume>
+  <volume name="vol201">
+   <materialref ref="Water"/>
+   <solidref ref="testtessel"/>
+  </volume>
+  <volume name="vol301">
+   <materialref ref="Water"/>
+   <solidref ref="testtorus"/>
+  </volume>
+  <volume name="vol401">
+   <materialref ref="Water"/>
+   <solidref ref="testorb"/>
+  </volume>
+  <volume name="vol501">
+   <materialref ref="Water"/>
+   <solidref ref="testph"/>
+  </volume>
+  <volume name="vol502">
+   <materialref ref="Water"/>
+   <solidref ref="testgenph"/>
+   </volume>
+  <volume name="vol601">
+   <materialref ref="Water"/>
+   <solidref ref="testhype"/>
+  </volume>
+  <volume name="vol701">
+   <materialref ref="Water"/>
+   <solidref ref="testeltube"/>
+  </volume>
+  <volume name="vol1001">
+   <materialref ref="Water"/>
+   <solidref ref="testelcone"/>
+  </volume>
+  <volume name="vol1002">
+   <materialref ref="Water"/>
+   <solidref ref="arb81"/>
+  </volume>
+  <volume name="vol1003">
+   <materialref ref="Water"/>
+   <solidref ref="arb82"/>
+  </volume>
+  <volume name="World">
+   <materialref ref="Air"/>
+   <solidref ref="WorldBox"/>
+
+   <physvol>
+     <volumeref ref="vol0"/>
+     <positionref ref="center"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol1"/>
+     <positionref ref="pos1"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol2"/>
+     <positionref ref="pos2"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol3"/>
+     <positionref ref="pos3"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol4"/>
+     <positionref ref="pos4"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol11"/>
+     <positionref ref="pos11"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol21"/>
+     <positionref ref="pos21"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol31"/>
+     <positionref ref="pos31"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol41"/>
+     <positionref ref="pos41"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+  <physvol>
+     <volumeref ref="vol412"/>
+     <positionref ref="pos412"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+    <physvol>
+     <volumeref ref="vol51"/>
+     <positionref ref="pos51"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol61"/>
+     <positionref ref="pos61"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol71"/>
+     <positionref ref="pos71"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol81"/>
+     <positionref ref="pos81"/>
+     <rotationref ref="identity"/>
+   </physvol>
+   <physvol>
+     <volumeref ref="vol91"/>
+     <positionref ref="pos91"/>
+     <rotationref ref="identity"/>
+   </physvol>
+   <physvol>
+     <volumeref ref="vol101"/>
+     <positionref ref="pos101"/>
+     <rotationref ref="identity"/>
+   </physvol>
+   <physvol>
+     <volumeref ref="vol201"/>
+     <positionref ref="pos201"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol301"/>
+     <positionref ref="pos301"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol401"/>
+     <positionref ref="pos401"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+    <physvol>
+     <volumeref ref="vol501"/>
+     <positionref ref="pos501"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol502"/>
+     <positionref ref="pos502"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol601"/>
+     <positionref ref="pos601"/>
+     <rotationref ref="identity"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="vol701"/>
+     <positionref ref="pos701"/>
+     <rotationref ref="identity"/>
+   </physvol>
+   <physvol>
+     <volumeref ref="vol1001"/>
+     <positionref ref="pos1001"/>
+     <rotationref ref="identity"/>
+   </physvol>
+   <physvol>
+     <volumeref ref="vol1002"/>
+     <positionref ref="pos1002"/>
+     <rotationref ref="identity"/>
+   </physvol>
+   <physvol>
+     <volumeref ref="vol1003"/>
+     <positionref ref="pos1003"/>
+     <rotationref ref="identity"/>
+   </physvol>
+  </volume>
+
+ </structure>
+
+ <setup name="Default" version="1.0">
+  <world ref="World"/>
+ </setup>
+</gdml>
+
+
+
+

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -448,7 +448,6 @@ TEST_F(SolidsTest, accessors)
 
 TEST_F(SolidsTest, DISABLED_trace)
 {
-    FAIL() << "These are all wrong...";
     {
         SCOPED_TRACE("Center +x");
         auto result = this->track({-100, 0, 0}, {1, 0, 0});
@@ -464,7 +463,7 @@ TEST_F(SolidsTest, DISABLED_trace)
         auto result = this->track({-100, -12.5, 0}, {1, 0, 0});
         result.print_expected();
     }
-
+    ADD_FAILURE() << "These are all wrong...";
 }
 
 //---------------------------------------------------------------------------//
@@ -520,7 +519,6 @@ TEST_F(SolidsGeantTest, accessors)
 
 TEST_F(SolidsGeantTest, DISABLED_trace)
 {
-    FAIL() << "These distances are wrong";
     {
         SCOPED_TRACE("Center +x");
         auto                     result = this->track({-100, 0, 0}, {1, 0, 0});
@@ -558,6 +556,7 @@ TEST_F(SolidsGeantTest, DISABLED_trace)
         static const real_type expected_distances[] = {600};
         EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
     }
+    ADD_FAILURE() << "These are all wrong...";
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -7,9 +7,11 @@
 //---------------------------------------------------------------------------//
 #include "Vecgeom.test.hh"
 
+#include "celeritas_cmake_strings.h"
 #include "corecel/cont/ArrayIO.hh"
 #include "corecel/data/CollectionStateStore.hh"
 #include "corecel/io/Repr.hh"
+#include "corecel/io/StringUtils.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/GeantTestBase.hh"
@@ -57,15 +59,13 @@ class VecgeomTestBase : virtual public GlobalTestBase
     };
 
   public:
-    //! Construct host state (and load geometry) during steup
-    void SetUp() override
-    {
-        host_state = HostStateStore(this->geometry()->host_ref(), 1);
-    }
-
     //! Create a host track view
     VecgeomTrackView make_geo_track_view()
     {
+        if (!host_state)
+        {
+            host_state = HostStateStore(this->geometry()->host_ref(), 1);
+        }
         return VecgeomTrackView(
             this->geometry()->host_ref(), host_state.ref(), ThreadId(0));
     }
@@ -433,6 +433,11 @@ class SolidsTest : public GlobalGeoTestBase,
 
 TEST_F(SolidsTest, accessors)
 {
+    if (starts_with(celeritas_vecgeom_version, "1.1"))
+    {
+        GTEST_SKIP() << "This geometry crashes when loading in VecGeom 1.1.17";
+    }
+
     const auto& geom = *this->geometry();
     // TODO: this should be 31ish?
     EXPECT_EQ(25, geom.num_volumes());

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -17,6 +17,7 @@
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/GlobalGeoTestBase.hh"
+#include "celeritas/OnlyGeoTestBase.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/field/DormandPrinceStepper.hh"
 #include "celeritas/field/FieldDriverOptions.hh"
@@ -50,19 +51,9 @@ using DiagnosticDPStepper = DiagnosticStepper<DormandPrinceStepper<E>>;
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class FieldPropagatorTestBase : public GlobalGeoTestBase
+class FieldPropagatorTestBase : public GlobalGeoTestBase, public OnlyGeoTestBase
 {
   public:
-    SPConstMaterial build_material() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstGeoMaterial build_geomaterial() override
-    {
-        CELER_ASSERT_UNREACHABLE();
-    }
-    SPConstCutoff    build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstPhysics   build_physics() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstAction build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
-
     SPConstParticle build_particle() override
     {
         using namespace units;

--- a/test/celeritas/field/LinearPropagator.test.cc
+++ b/test/celeritas/field/LinearPropagator.test.cc
@@ -12,9 +12,9 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/GlobalGeoTestBase.hh"
+#include "celeritas/OnlyGeoTestBase.hh"
 #include "celeritas/geo/GeoData.hh"
 #include "celeritas/geo/GeoParams.hh"
-#include "celeritas/geo/OnlyGeoTestBase.hh"
 
 #include "celeritas_test.hh"
 

--- a/test/celeritas/geo/GeoMaterial.test.cc
+++ b/test/celeritas/geo/GeoMaterial.test.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "corecel/data/CollectionStateStore.hh"
 #include "celeritas/GlobalGeoTestBase.hh"
+#include "celeritas/OnlyGeoTestBase.hh"
 #include "celeritas/ext/RootImporter.hh"
 #include "celeritas/ext/ScopedRootErrorHandler.hh"
 #include "celeritas/geo/GeoData.hh"
@@ -26,15 +27,9 @@ namespace test
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class GeoMaterialTest : public GlobalGeoTestBase
+class GeoMaterialTest : public GlobalGeoTestBase, public OnlyGeoTestBase
 {
     const char* geometry_basename() const override { return "simple-cms"; }
-
-    SPConstParticle  build_particle() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstCutoff    build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstPhysics   build_physics() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstAction build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
 
     SPConstMaterial build_material() override
     {

--- a/test/celeritas/geo/HeuristicGeoTestBase.hh
+++ b/test/celeritas/geo/HeuristicGeoTestBase.hh
@@ -14,9 +14,9 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/data/Collection.hh"
-#include "celeritas/geo/OnlyGeoTestBase.hh"
+#include "celeritas/GlobalGeoTestBase.hh"
+#include "celeritas/OnlyGeoTestBase.hh"
 
-#include "../GlobalGeoTestBase.hh"
 #include "HeuristicGeoData.hh"
 
 namespace celeritas


### PR DESCRIPTION
This is a stopgap measure before #557 . It adds a helper class to export the Geant4 geometry from a "world" volume as a GDML, and adapts the interface from #557 along with the unit test harness updates I made. The new test geometry `solids.gdml` (from Geant4) is chock full of errors, though, so it's not a very useful test except to show that the results will change when Guilherme's work is finished.

Because G4's GDML exporter simply exits if it's not the master thread, we have to ensure that the `SharedParams` initialization happens on the master thread, so that logic has changed.

Furthermore, to allow us to test the integration on HIP and/or with ORANGE, I've added a superficial G4 constructor and added some hacky code to propagate the GDML file into the `accel` helper functions.

---

VecGeom failures on `solids.gdml`:
```
Middleware::processNode: an unknown solid genericPolycone with name testgenpoly
Middleware::processNode: an unknown solid genericPolyhedra with name testgenph
Middleware::processNode: an unknown solid twistedbox with name ttwistedbox
Middleware::processNode: an unknown solid twistedtrd with name ttwistedtrd
Middleware::processNode: an unknown solid twistedtrap with name ttwistedtrap
Middleware::processNode: an unknown solid twistedtubs with name ttwistedtubs
processLogicVolume: Could not find solid reference testgenpoly for logical volume vol412
processLogicVolume: Could not find solid reference ttwistedbox for logical volume vol71
processLogicVolume: Could not find solid reference ttwistedtrd for logical volume vol81
processLogicVolume: Could not find solid reference ttwistedtrap for logical volume vol91
processLogicVolume: Could not find solid reference ttwistedtubs for logical volume vol101
processLogicVolume: Could not find solid reference testgenph for logical volume vol502
Middleware::processPhysicalVolume: could not find volume vol412
```

And since the "real" GDML has very weird traces that the "read through Geant4 and exported" doesn't, I think there's also additional bugs in the VGDML reading.

See [VecGeom issue 427](https://sft.its.cern.ch/jira/browse/VECGEOM-427) (CERN users only)