### PR TITLE
Support user-defined along-step kernels in accel+demo

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -344,6 +344,7 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_Geant4)
     demo-geant-integration/EventAction.cc
     demo-geant-integration/GlobalSetup.cc
     demo-geant-integration/MasterRunAction.cc
+    demo-geant-integration/NoFieldAlongStepFactory.cc
     demo-geant-integration/PrimaryGeneratorAction.cc
     demo-geant-integration/RunAction.cc
     demo-geant-integration/SensitiveDetector.cc

--- a/app/demo-geant-integration/GlobalSetup.cc
+++ b/app/demo-geant-integration/GlobalSetup.cc
@@ -9,6 +9,7 @@
 
 #include <G4GenericMessenger.hh>
 
+#include "corecel/Assert.hh"
 #include "corecel/sys/Device.hh"
 
 namespace demo_geant
@@ -29,7 +30,7 @@ GlobalSetup* GlobalSetup::Instance()
  */
 GlobalSetup::GlobalSetup()
 {
-    options_   = std::make_shared<celeritas::SetupOptions>();
+    options_   = std::make_shared<SetupOptions>();
     messenger_ = std::make_unique<G4GenericMessenger>(
         this, "/setup/", "Demo geant integration setup");
 
@@ -87,6 +88,20 @@ GlobalSetup::GlobalSetup()
     {
         // TODO: expose other options here
     }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set the along-step factory.
+ *
+ * The "asf" can be an instance of a class inheriting from \c
+ * celeritas::AlongStepFactoryInterface , a functor, or just a function.
+ */
+void GlobalSetup::SetAlongStep(SetupOptions::AlongStepFactory asf)
+{
+    CELER_EXPECT(asf);
+
+    options_->make_along_step = std::move(asf);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-geant-integration/GlobalSetup.hh
+++ b/app/demo-geant-integration/GlobalSetup.hh
@@ -23,6 +23,12 @@ namespace demo_geant
 class GlobalSetup
 {
   public:
+    //!@{
+    //! \name Type aliases
+    using SetupOptions = celeritas::SetupOptions;
+    //!@}
+
+  public:
     // Return non-owning pointer to a singleton
     static GlobalSetup* Instance();
 
@@ -32,10 +38,13 @@ class GlobalSetup
     //!@}
 
     //! Get an immutable reference to the setup options
-    std::shared_ptr<const celeritas::SetupOptions> GetSetupOptions() const
+    std::shared_ptr<const SetupOptions> GetSetupOptions() const
     {
         return options_;
     }
+
+    // Set the along-step factory function/instance
+    void SetAlongStep(SetupOptions::AlongStepFactory asf);
 
   private:
     // Private constructor since we're a singleton
@@ -43,8 +52,8 @@ class GlobalSetup
     ~GlobalSetup();
 
     // Data
-    std::shared_ptr<celeritas::SetupOptions> options_;
-    std::string                              geometry_file_;
+    std::shared_ptr<SetupOptions> options_;
+    std::string                   geometry_file_;
 
     std::unique_ptr<G4GenericMessenger> messenger_;
 };

--- a/app/demo-geant-integration/MasterRunAction.cc
+++ b/app/demo-geant-integration/MasterRunAction.cc
@@ -16,6 +16,7 @@
 #include "accel/ExceptionConverter.hh"
 
 #include "GlobalSetup.hh"
+#include "NoFieldAlongStepFactory.hh"
 
 namespace demo_geant
 {
@@ -44,6 +45,9 @@ void MasterRunAction::BeginOfRunAction(const G4Run* run)
         const_cast<celeritas::SetupOptions&>(*options_).geometry_file
             = GlobalSetup::Instance()->GetGeometryFile();
     }
+
+    // Create the along-step action
+    GlobalSetup::Instance()->SetAlongStep(NoFieldAlongStepFactory{});
 
     celeritas::ExceptionConverter call_g4exception{"celer0001"};
     CELER_TRY_ELSE(

--- a/app/demo-geant-integration/NoFieldAlongStepFactory.cc
+++ b/app/demo-geant-integration/NoFieldAlongStepFactory.cc
@@ -1,0 +1,32 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file demo-geant-integration/NoFieldAlongStepFactory.cc
+//---------------------------------------------------------------------------//
+#include "NoFieldAlongStepFactory.hh"
+
+#include "celeritas/io/ImportData.hh"
+#include "celeritas/global/alongstep/AlongStepGeneralLinearAction.hh"
+
+namespace demo_geant
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Emit the along-step action.
+ */
+auto NoFieldAlongStepFactory::operator()(argument_type input) const
+    -> result_type
+{
+    // Create along-step action
+    return celeritas::AlongStepGeneralLinearAction::from_params(
+        input.action_id,
+        *input.material,
+        *input.particle,
+        *input.physics,
+        input.imported->em_params.energy_loss_fluct);
+}
+
+//---------------------------------------------------------------------------//
+} // namespace demo_geant

--- a/app/demo-geant-integration/NoFieldAlongStepFactory.hh
+++ b/app/demo-geant-integration/NoFieldAlongStepFactory.hh
@@ -1,0 +1,27 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file demo-geant-integration/NoFieldAlongStepFactory.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "accel/AlongStepFactory.hh"
+
+namespace demo_geant
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct an along-step action with MSC but no field.
+ */
+class NoFieldAlongStepFactory final
+    : public celeritas::AlongStepFactoryInterface
+{
+  public:
+    // Emit the along-step action
+    result_type operator()(argument_type input) const final;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/accel/AlongStepFactory.hh
+++ b/src/accel/AlongStepFactory.hh
@@ -1,0 +1,88 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/AlongStepFactory.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include "celeritas/geo/GeoParamsFwd.hh"
+#include "celeritas/global/ActionInterface.hh"
+
+namespace celeritas
+{
+struct ImportData;
+class CutoffParams;
+class FluctuationParams;
+class GeoMaterialParams;
+class MaterialParams;
+class ParticleParams;
+class PhysicsParams;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Input argument to the AlongStepFactory interface.
+ *
+ * When passed to a factory instance, all member data will be set (so the
+ * instance will be 'true').
+ *
+ * Most of these classes have been forward-declared because they simply need to
+ * be passed along to another class's constructor.
+ */
+struct AlongStepFactoryInput
+{
+    ActionId action_id;
+
+    std::shared_ptr<const GeoParams>         geometry;
+    std::shared_ptr<const MaterialParams>    material;
+    std::shared_ptr<const GeoMaterialParams> geomaterial;
+    std::shared_ptr<const ParticleParams>    particle;
+    std::shared_ptr<const CutoffParams>      cutoff;
+    std::shared_ptr<const PhysicsParams>     physics;
+    std::shared_ptr<const ImportData>        imported;
+
+    //! True if all data is assigned
+    explicit operator bool() const
+    {
+        return action_id && geometry && material && geomaterial && particle
+               && cutoff && physics && imported;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Helper class for emitting an AlongStep action.
+ *
+ * Currently Celeritas accepts a single along-step action (i.e., the same
+ * stepper is used for both neutral and charged particles, across all energies
+ * and regions of the problem). The along-step action is a single GPU
+ * kernel that combines the field stepper selection, the magnetic field,
+ * slowing-down calculation, multiple scattering, and energy loss fluctuations.
+ *
+ * The factory will be called from the thread that initializes \c SharedParams.
+ * Instead of a daughter class, you can provide any function-like object that
+ * has the same interface.
+ *
+ * Celeritas provides a few "default" configurations of along-step actions in
+ * `celeritas/global/alongstep`.
+ */
+class AlongStepFactoryInterface
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using argument_type = const AlongStepFactoryInput&;
+    using result_type = std::shared_ptr<const ExplicitActionInterface>;
+    //!@}
+
+  public:
+    virtual ~AlongStepFactoryInterface() = default;
+
+    // Emit an along-step action
+    virtual result_type operator()(argument_type input) const = 0;
+};
+
+//---------------------------------------------------------------------------//
+} // namespace celeritas

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -7,18 +7,31 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <functional>
 #include <string>
 
 namespace celeritas
 {
+struct AlongStepFactoryInput;
+class ExplicitActionInterface;
 //---------------------------------------------------------------------------//
 /*!
  * Control options for initializing Celeritas.
+ *
+ * The interface for the "along-step factory" (input parameters and output) is
+ * described in AlongStepFactory.hh .
  */
 struct SetupOptions
 {
+    //!@{
+    //! \name Type aliases
     using size_type = unsigned int;
     using real_type = double;
+
+    using SPConstAction = std::shared_ptr<const ExplicitActionInterface>;
+    using AlongStepFactory
+        = std::function<SPConstAction(const AlongStepFactoryInput&)>;
+    //!@}
 
     //! Don't limit the number of steps
     static constexpr size_type no_max_steps()
@@ -27,7 +40,6 @@ struct SetupOptions
     }
 
     // TODO: names of sensitive detectors
-    // TODO: along-step construction option/callback
 
     //!@{
     //! \name I/O
@@ -51,6 +63,11 @@ struct SetupOptions
     real_type   secondary_stack_factor{};
     //! Sync the GPU at every kernel for error checking
     bool sync{false};
+    //!@}
+
+    //!@{
+    //! \name Stepping actions
+    AlongStepFactory make_along_step;
     //!@}
 
     //!@{


### PR DESCRIPTION
This defines a factory interface for Acceleritas users to create an along-step action. We'll still probably want to enhance the demo by including a parameterized CMS field.