### PR TITLE
Minor fixes for older Geant4/VecGeom releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,19 @@ $ cmake ..
 $ make && ctest
 ```
 
+Celeritas guarantees full compatibility and correctness only on the
+combinations of compilers and dependencies tested under continuous integration.
+Currently supported compilers are GCC 11.2 + NVCC 11.8, and HIP-Clang 15.0, but
+since we compile with extra warning flags and avoid non-portable code, most
+other compilers *should* work.
+Currently Geant4 11.0 and VecGeom 1.2 are the only versions that are guaranteed
+to work, but older versions might be OK.
+The full set of configurations is viewable on [the CI web site][jenkins].
+Compatibility fixes that do not cause newer versions to fail are welcome.
+
 [spack]: https://github.com/spack/spack
 [infra]: doc/infrastructure.rst
+[jenkins]: https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/Celeritas/activity?branch=master
 
 # Installation for applications
 

--- a/scripts/spack.yaml
+++ b/scripts/spack.yaml
@@ -2,10 +2,10 @@ spack:
   specs: 
     - cmake
     - doxygen
-    - geant4@11 cxxstd=17
+    - "geant4@11 cxxstd=17"
     - git
     - git-lfs
-    - googletest
+    - "googletest@1.10:"
     - hepmc3
     - ninja
     - nlohmann-json
@@ -17,7 +17,7 @@ spack:
     - py-sphinxcontrib-bibtex
     - root cxxstd=17
     - swig
-    - vecgeom +gdml cxxstd=17
+    - "vecgeom@1.2: +gdml cxxstd=17"
   view: true
   concretizer:
     unify: true

--- a/src/corecel/cont/Label.cc
+++ b/src/corecel/cont/Label.cc
@@ -18,7 +18,7 @@ namespace celeritas
  */
 Label Label::from_geant(const std::string& name)
 {
-    static const std::regex final_ptr_regex{"0x[0-9a-f]{8,16}$"};
+    static const std::regex final_ptr_regex{"0x[0-9a-f]{4,16}$"};
 
     // Remove possible Geant uniquifying pointer-address suffix
     // (Geant4 does this automatically, but VGDML does not)

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -509,6 +509,11 @@ class SolidsGeantTest : public GeantBuilderTestBase
 
 TEST_F(SolidsGeantTest, accessors)
 {
+    if (starts_with(celeritas_vecgeom_version, "1.1"))
+    {
+        GTEST_SKIP() << "This geometry crashes when loading in VecGeom 1.1.17";
+    }
+
     const auto& geom = *this->geometry();
     // TODO: This is known to be incorrect because of missing VecGeom shapes.
     EXPECT_EQ(25, geom.num_volumes());


### PR DESCRIPTION
I think this should address two recent issues @amandalund saw with Geant4 10.7 (exported GDML pointer suffixes) and VecGeom 1.1.17 (crash on VGDML read with unsupported shapes). I also documented that we're only testing Geant4 11.0 and VecGeom 1.2 but that other versions may work (and we want to support them if it doesn't break things).