### PR TITLE
Rename `CELER_TRY_ELSE` to `CELER_TRY_HANDLE`

### DIFF
--- a/app/demo-geant-integration/EventAction.cc
+++ b/app/demo-geant-integration/EventAction.cc
@@ -28,8 +28,8 @@ void EventAction::BeginOfEventAction(const G4Event* event)
 {
     // Set event ID in local transporter
     celeritas::ExceptionConverter call_g4exception{"celer0002"};
-    CELER_TRY_ELSE(transport_->SetEventId(event->GetEventID()),
-                   call_g4exception);
+    CELER_TRY_HANDLE(transport_->SetEventId(event->GetEventID()),
+                     call_g4exception);
 }
 
 //---------------------------------------------------------------------------//
@@ -40,7 +40,7 @@ void EventAction::EndOfEventAction(const G4Event*)
 {
     // Transport any tracks left in the buffer
     celeritas::ExceptionConverter call_g4exception{"celer0004"};
-    CELER_TRY_ELSE(transport_->Flush(), call_g4exception);
+    CELER_TRY_HANDLE(transport_->Flush(), call_g4exception);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-geant-integration/PrimaryGeneratorAction.cc
+++ b/app/demo-geant-integration/PrimaryGeneratorAction.cc
@@ -53,8 +53,8 @@ int PrimaryGeneratorAction::NumEvents()
 void PrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
 {
     celeritas::ExceptionConverter call_g4exception{"celer0000"};
-    CELER_TRY_ELSE(shared_reader().GeneratePrimaryVertex(event),
-                   call_g4exception);
+    CELER_TRY_HANDLE(shared_reader().GeneratePrimaryVertex(event),
+                     call_g4exception);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/demo-geant-integration/RunAction.cc
+++ b/app/demo-geant-integration/RunAction.cc
@@ -60,20 +60,20 @@ void RunAction::BeginOfRunAction(const G4Run* run)
         GlobalSetup::Instance()->SetAlongStep(NoFieldAlongStepFactory{});
 
         // Initialize shared data and setup GPU on all threads
-        CELER_TRY_ELSE(params_->Initialize(*options_), call_g4exception);
+        CELER_TRY_HANDLE(params_->Initialize(*options_), call_g4exception);
         CELER_ASSERT(*params_);
     }
     else
     {
-        CELER_TRY_ELSE(celeritas::SharedParams::InitializeWorker(*options_),
-                       call_g4exception);
+        CELER_TRY_HANDLE(celeritas::SharedParams::InitializeWorker(*options_),
+                         call_g4exception);
     }
 
     if (transport_)
     {
         // Allocate data in shared thread-local transporter
-        CELER_TRY_ELSE(transport_->Initialize(*options_, *params_),
-                       call_g4exception);
+        CELER_TRY_HANDLE(transport_->Initialize(*options_, *params_),
+                         call_g4exception);
         CELER_ENSURE(*transport_);
     }
 }
@@ -92,13 +92,13 @@ void RunAction::EndOfRunAction(const G4Run*)
         // Deallocate Celeritas state data (ensures that objects are deleted on
         // the thread in which they're created, necessary by some geant4
         // thread-local allocators)
-        CELER_TRY_ELSE(transport_->Finalize(), call_g4exception);
+        CELER_TRY_HANDLE(transport_->Finalize(), call_g4exception);
     }
 
     if (init_celeritas_)
     {
         // Clear shared data and write
-        CELER_TRY_ELSE(params_->Finalize(), call_g4exception);
+        CELER_TRY_HANDLE(params_->Finalize(), call_g4exception);
     }
 }
 

--- a/app/demo-geant-integration/TrackingAction.cc
+++ b/app/demo-geant-integration/TrackingAction.cc
@@ -54,7 +54,7 @@ void TrackingAction::PreUserTrackingAction(const G4Track* track)
     {
         // Celeritas is transporting this track
         celeritas::ExceptionConverter call_g4exception{"celer0003"};
-        CELER_TRY_ELSE(transport_->Push(*track), call_g4exception);
+        CELER_TRY_HANDLE(transport_->Push(*track), call_g4exception);
         const_cast<G4Track*>(track)->SetTrackStatus(fStopAndKill);
     }
 }

--- a/app/demo-geant-integration/demo-geant-integration.cc
+++ b/app/demo-geant-integration/demo-geant-integration.cc
@@ -85,8 +85,9 @@ void run(const std::string& macro_filename)
 
     // Load the input file
     int num_events{0};
-    CELER_TRY_ELSE(num_events = demo_geant::PrimaryGeneratorAction::NumEvents(),
-                   celeritas::ExceptionConverter{"demo-geant000"});
+    CELER_TRY_HANDLE(
+        num_events = demo_geant::PrimaryGeneratorAction::NumEvents(),
+        celeritas::ExceptionConverter{"demo-geant000"});
 
     run_manager->BeamOn(num_events);
 }

--- a/cmake/CeleritasGen/gen-action.py
+++ b/cmake/CeleritasGen/gen-action.py
@@ -86,7 +86,7 @@ void {clsname}::execute(CoreHostRef const& data) const
     #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {{
-        CELER_TRY_ELSE(launch(ThreadId{{i}}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{{i}}), capture_exception);
     }}
     log_and_rethrow(std::move(capture_exception));
 }}

--- a/cmake/CeleritasGen/gen-interactor.py
+++ b/cmake/CeleritasGen/gen-interactor.py
@@ -91,7 +91,7 @@ void {func}_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {{
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{{i}}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{{i}}), capture_exception);
     }}
     log_and_rethrow(std::move(capture_exception));
 }}

--- a/cmake/CeleritasGen/gen-trackinit.py
+++ b/cmake/CeleritasGen/gen-trackinit.py
@@ -69,7 +69,7 @@ namespace generated
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < {num_threads}; ++i)
     {{
-        CELER_TRY_ELSE(launch(ThreadId{{i}}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{{i}}), capture_exception);
     }}
     log_and_rethrow(std::move(capture_exception));
 }}

--- a/src/accel/ExceptionConverter.hh
+++ b/src/accel/ExceptionConverter.hh
@@ -27,7 +27,7 @@ namespace celeritas
 
        celeritas::ExceptionConverter call_g4exception{"celer0003"};
 
-       CELER_TRY_ELSE(transport_->Flush(), call_g4exception);
+       CELER_TRY_HANDLE(transport_->Flush(), call_g4exception);
    }
  * \endcode
  */

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cc
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cc
@@ -36,7 +36,7 @@ void bethe_heitler_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/CombinedBremInteract.cc
+++ b/src/celeritas/em/generated/CombinedBremInteract.cc
@@ -36,7 +36,7 @@ void combined_brem_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/EPlusGGInteract.cc
+++ b/src/celeritas/em/generated/EPlusGGInteract.cc
@@ -36,7 +36,7 @@ void eplusgg_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/KleinNishinaInteract.cc
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cc
@@ -36,7 +36,7 @@ void klein_nishina_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/LivermorePEInteract.cc
+++ b/src/celeritas/em/generated/LivermorePEInteract.cc
@@ -36,7 +36,7 @@ void livermore_pe_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cc
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cc
@@ -36,7 +36,7 @@ void moller_bhabha_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
@@ -36,7 +36,7 @@ void mu_bremsstrahlung_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/RayleighInteract.cc
+++ b/src/celeritas/em/generated/RayleighInteract.cc
@@ -36,7 +36,7 @@ void rayleigh_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/RelativisticBremInteract.cc
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cc
@@ -36,7 +36,7 @@ void relativistic_brem_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cc
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cc
@@ -36,7 +36,7 @@ void seltzer_berger_interact(
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(celeritas::ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(celeritas::ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/geo/generated/BoundaryAction.cc
+++ b/src/celeritas/geo/generated/BoundaryAction.cc
@@ -28,7 +28,7 @@ void BoundaryAction::execute(CoreHostRef const& data) const
     #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
@@ -94,7 +94,7 @@ void AlongStepGeneralLinearAction::execute(CoreHostRef const& data) const
 #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
@@ -42,7 +42,7 @@ void AlongStepNeutralAction::execute(CoreHostRef const& data) const
 #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
@@ -85,7 +85,7 @@ void AlongStepUniformMscAction::execute(CoreHostRef const& data) const
 #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cc
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cc
@@ -28,7 +28,7 @@ void DiscreteSelectAction::execute(CoreHostRef const& data) const
     #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/phys/generated/PreStepAction.cc
+++ b/src/celeritas/phys/generated/PreStepAction.cc
@@ -28,7 +28,7 @@ void PreStepAction::execute(CoreHostRef const& data) const
     #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/track/generated/InitTracks.cc
+++ b/src/celeritas/track/generated/InitTracks.cc
@@ -24,7 +24,7 @@ void init_tracks(
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < num_vacancies; ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/track/generated/LocateAlive.cc
+++ b/src/celeritas/track/generated/LocateAlive.cc
@@ -23,7 +23,7 @@ void locate_alive(
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/track/generated/ProcessPrimaries.cc
+++ b/src/celeritas/track/generated/ProcessPrimaries.cc
@@ -24,7 +24,7 @@ void process_primaries(
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < primaries.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/track/generated/ProcessSecondaries.cc
+++ b/src/celeritas/track/generated/ProcessSecondaries.cc
@@ -23,7 +23,7 @@ void process_secondaries(
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < core_data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/user/detail/StepGatherAction.cc
+++ b/src/celeritas/user/detail/StepGatherAction.cc
@@ -71,7 +71,7 @@ void StepGatherAction<P>::execute(CoreHostRef const& core) const
 #pragma omp parallel for
     for (size_type i = 0; i < core.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
 

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -175,16 +175,16 @@
 #endif
 
 /*!
- * \def CELER_TRY_ELSE
+ * \def CELER_TRY_HANDLE
  *
- * Execute the statement, catching *all* thrown errors by calling the given
- * function-like operator with a \c std::exception_ptr object.
+ * "Try" to execute the statement, and "handle" *all* thrown errors by calling
+ * the given function-like error handler with a \c std::exception_ptr object.
  *
  * \note A file that uses this macro must include the <exception> header (but
  * since the \c HANDLE_EXCEPTION needs to take an exception pointer, it's
  * got to be included anyway).
  */
-#define CELER_TRY_ELSE(STATEMENT, HANDLE_EXCEPTION)     \
+#define CELER_TRY_HANDLE(STATEMENT, HANDLE_EXCEPTION)   \
     do                                                  \
     {                                                   \
         try                                             \

--- a/src/corecel/sys/MultiExceptionHandler.hh
+++ b/src/corecel/sys/MultiExceptionHandler.hh
@@ -27,7 +27,7 @@ namespace celeritas
     #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {
-        CELER_TRY_ELSE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
     }
     log_and_rethrow(std::move(capture_exception));
  * \endcode

--- a/test/accel/ExceptionConverter.test.cc
+++ b/test/accel/ExceptionConverter.test.cc
@@ -80,7 +80,7 @@ class ExceptionConverterTest : public ::celeritas::test::Test
 TEST_F(ExceptionConverterTest, debug)
 {
     ExceptionConverter call_g4e{"test001"};
-    CELER_TRY_ELSE(
+    CELER_TRY_HANDLE(
         throw ::celeritas::DebugError({::celeritas::DebugErrorType::internal,
                                        "there are five lights",
                                        "me.cc",
@@ -97,8 +97,8 @@ TEST_F(ExceptionConverterTest, debug)
 TEST_F(ExceptionConverterTest, runtime)
 {
     ExceptionConverter call_g4e{"test002"};
-    CELER_TRY_ELSE(CELER_VALIDATE(2 + 2 == 5, << "math actually works"),
-                   call_g4e);
+    CELER_TRY_HANDLE(CELER_VALIDATE(2 + 2 == 5, << "math actually works"),
+                     call_g4e);
 
     EXPECT_EQ(0, handler().origin.find("accel/ExceptionConverter.test.cc"))
         << "actual path: '" << handler().origin << '\'';

--- a/test/corecel/sys/MultiExceptionHandler.test.cc
+++ b/test/corecel/sys/MultiExceptionHandler.test.cc
@@ -53,7 +53,7 @@ TEST_F(MultiExceptionHandlerTest, single)
 {
     MultiExceptionHandler capture_exception;
     EXPECT_TRUE(capture_exception.empty());
-    CELER_TRY_ELSE(
+    CELER_TRY_HANDLE(
         throw RuntimeError::from_validate("first exception", "", "here", 1),
         capture_exception);
     EXPECT_FALSE(capture_exception.empty());
@@ -64,14 +64,14 @@ TEST_F(MultiExceptionHandlerTest, single)
 TEST_F(MultiExceptionHandlerTest, multi)
 {
     MultiExceptionHandler capture_exception;
-    CELER_TRY_ELSE(
+    CELER_TRY_HANDLE(
         throw RuntimeError::from_validate("first exception", "", "here", 1),
         capture_exception);
     for (auto i : range(3))
     {
         DebugErrorDetails deets{
             DebugErrorType::internal, "false", "test.cc", i};
-        CELER_TRY_ELSE(throw DebugError(deets), capture_exception);
+        CELER_TRY_HANDLE(throw DebugError(deets), capture_exception);
     }
     EXPECT_THROW(log_and_rethrow(std::move(capture_exception)), RuntimeError);
 
@@ -89,7 +89,7 @@ TEST_F(MultiExceptionHandlerTest, multi)
 TEST_F(MultiExceptionHandlerTest, DISABLED_uncaught)
 {
     MultiExceptionHandler catchme;
-    CELER_TRY_ELSE(CELER_VALIDATE(false, << "derp"), catchme);
+    CELER_TRY_HANDLE(CELER_VALIDATE(false, << "derp"), catchme);
     // Program will terminate when catchme leaves scope
 }
 


### PR DESCRIPTION
Simple find-replace to make the macro name more sensible. It "tries" the first argument, and "handles" all exceptions using the second argument (an error handling function). `TRY_ELSE` is wrong because (in python) `else` is the branch that is used if *no* exception is raised.