### PR TITLE
Add Geant4 environment to celeritas/ext/VecGeom

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -278,6 +278,7 @@ set(CELERITASTEST_PREFIX celeritas/ext)
 
 if(CELERITAS_USE_VecGeom)
   celeritas_add_device_test(celeritas/ext/Vecgeom
+    ${_optional_geant4_env}
     LINK_LIBRARIES VecGeom::vecgeom)
 endif()
 


### PR DESCRIPTION
Very minor fix to one test which was failing when the `G4ENSDFSTATEDATA` variable wasn't set directly in the environment. Following other tests, fixed by adding the optional Geant4 env to the offending test. Credit should go to Chris Brady at Warwick for identifying this!