### PR TITLE
Allow invalid volume IDs in ROOT MC truth output

### DIFF
--- a/src/celeritas/io/RootStepWriter.cc
+++ b/src/celeritas/io/RootStepWriter.cc
@@ -113,7 +113,7 @@ void RootStepWriter::execute(StateHostRef const& steps)
 
         for (auto const sp : range(StepPoint::size_))
         {
-            RSW_STORE(points[sp].volume_id, .get());
+            RSW_STORE(points[sp].volume_id, .unchecked_get());
             RSW_STORE(points[sp].energy, .value());
             RSW_STORE(points[sp].time, /* no getter */);
             RSW_STORE(points[sp].dir, /* no getter */);


### PR DESCRIPTION
Running some problems with ROOT MC truth output enabled results in a failure:
```
/home/alund/celeritas_project/celeritas/app/demo-loop/demo-loop.cc:254: critical: While running input at testem3.inp.json: /home/alund/celeritas_project/celeritas/src/corecel/OpaqueId.hh:60:
celeritas: precondition failed: *this
```
because the post-step volume ID will be invalid if the track is outside. This simply allows invalid volume IDs to be stored in the steps TTree.