### PR TITLE
Remove MSC data from core physics class

### DIFF
--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -57,8 +57,8 @@ list(APPEND SOURCES
   global/Stepper.cc
   global/detail/ActionSequence.cc
   grid/ValueGridBuilder.cc
+  grid/ValueGridData.cc
   grid/ValueGridInserter.cc
-  grid/ValueGridInterface.cc
   io/AtomicRelaxationReader.cc
   io/ImportPhysicsTable.cc
   io/ImportPhysicsVector.cc

--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -79,7 +79,6 @@ struct UrbanMscMaterialData
 {
     using Real4 = Array<real_type, 4>;
 
-    real_type zeff{};  //!< effective atomic_number
     real_type scaled_zeff{};  //!< 0.70 * sqrt(zeff)
     real_type z23{};  //!< zeff^(2/3)
     real_type coeffth1{};  //!< correction in theta_0 formula

--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -12,6 +12,7 @@
 #include "corecel/data/Collection.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
+#include "celeritas/grid/XsGridData.hh"
 
 namespace celeritas
 {
@@ -79,8 +80,6 @@ struct UrbanMscMaterialData
 {
     using Real4 = Array<real_type, 4>;
 
-    real_type scaled_zeff{};  //!< 0.70 * sqrt(zeff)
-    real_type z23{};  //!< zeff^(2/3)
     real_type coeffth1{};  //!< correction in theta_0 formula
     real_type coeffth2{};  //!< correction in theta_0 formula
     Real4 d{0, 0, 0, 0};  //!< coefficients of tail parameters
@@ -92,7 +91,7 @@ struct UrbanMscMaterialData
 
 //---------------------------------------------------------------------------//
 /*!
- * Physics IDs for MSC
+ * Physics IDs for MSC.
  */
 struct UrbanMscIds
 {
@@ -109,13 +108,47 @@ struct UrbanMscIds
 
 //---------------------------------------------------------------------------//
 /*!
- * Device data for step limitation algorithms and angular scattering.
+ * Particle- and material-dependent data for MSC.
+ *
+ * The scaled Zeff parameters are:
+ *
+ *   Particle | a    | b
+ *   -------- | ---- | ----
+ *   electron | 0.87 | 2/3
+ *   positron | 0.7  | 1/2
+ */
+struct UrbanMscParMatData
+{
+    XsGridData xs;  //!< For calculating MFP
+    real_type scaled_zeff{};  //!< a * Z^b
+
+    //! Whether the data is assigned
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return xs && scaled_zeff > 0;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Device data for Urban MSC.
+ *
+ * This model applies only to electrons and positrons, so the ParticleItems are
+ * hard-coded as a length-2 array.
  */
 template<Ownership W, MemSpace M>
 struct UrbanMscData
 {
+    //// TYPES ////
+
+    template<class T>
+    using Items = Collection<T, W, M>;
     template<class T>
     using MaterialItems = celeritas::Collection<T, W, M, MaterialId>;
+    template<class T>
+    using ParticleItems = celeritas::Array<T, 2>;
+
+    //// DATA ////
 
     //! Type-free IDs
     UrbanMscIds ids;
@@ -124,12 +157,20 @@ struct UrbanMscData
     //! User-assignable options
     UrbanMscParameters params;
     //! Material-dependent data
-    MaterialItems<UrbanMscMaterialData> msc_data;
+    MaterialItems<UrbanMscMaterialData> material_data;
+    //! Particle and material-dependent data
+    Items<UrbanMscParMatData> par_mat_data;  // [mat]{electron, positron}
+
+    // Backend storage
+    Items<real_type> reals;
+
+    //// METHODS ////
 
     //! Check whether the data is assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return ids && electron_mass > zero_quantity() && !msc_data.empty();
+        return ids && electron_mass > zero_quantity() && !material_data.empty()
+               && !par_mat_data.empty() && !reals.empty();
     }
 
     //! Assign from another set of data
@@ -140,13 +181,22 @@ struct UrbanMscData
         ids = other.ids;
         electron_mass = other.electron_mass;
         params = other.params;
-        msc_data = other.msc_data;
+        material_data = other.material_data;
+        par_mat_data = other.par_mat_data;
+        reals = other.reals;
         return *this;
     }
-};
 
-using UrbanMscDeviceRef = DeviceCRef<UrbanMscData>;
-using UrbanMscHostRef = HostCRef<UrbanMscData>;
-using UrbanMscRef = NativeCRef<UrbanMscData>;
+    //! Get the data location for a material + particle
+    CELER_FUNCTION ItemId<UrbanMscParMatData>
+    at(MaterialId mat, ParticleId par) const
+    {
+        CELER_EXPECT(mat && par);
+        size_type result = mat.unchecked_get() * 2;
+        result += (par == this->ids.electron ? 0 : 1);
+        CELER_ENSURE(result < this->par_mat_data.size());
+        return ItemId<UrbanMscParMatData>{result};
+    }
+};
 
 }  // namespace celeritas

--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -95,7 +95,9 @@ struct UrbanMscMaterialData
  */
 struct UrbanMscIds
 {
+    // TODO: remove when this is no longer a model
     ActionId action;
+    // TODO: change to a bitset based on particle ID when we add muons, hadrons
     ParticleId electron;
     ParticleId positron;
 
@@ -133,8 +135,9 @@ struct UrbanMscParMatData
 /*!
  * Device data for Urban MSC.
  *
- * This model applies only to electrons and positrons, so the ParticleItems are
- * hard-coded as a length-2 array.
+ * Since the model currently applies only to electrons and positrons, the
+ * particles are hardcoded to be length 2. TODO: extend to other charged
+ * particles when further physics is implemented.
  */
 template<Ownership W, MemSpace M>
 struct UrbanMscData
@@ -145,8 +148,6 @@ struct UrbanMscData
     using Items = Collection<T, W, M>;
     template<class T>
     using MaterialItems = celeritas::Collection<T, W, M, MaterialId>;
-    template<class T>
-    using ParticleItems = celeritas::Array<T, 2>;
 
     //// DATA ////
 

--- a/src/celeritas/em/distribution/UrbanMscScatter.hh
+++ b/src/celeritas/em/distribution/UrbanMscScatter.hh
@@ -474,7 +474,7 @@ real_type UrbanMscScatter::compute_theta0(real_type true_path) const
         y *= this->calc_positron_correction(tau);
     }
 
-    // Note: multiply abs(charge) if the charge number is not unity
+    // TODO for hadrons: multiply abs(charge)
     real_type theta0 = value_as<Energy>(c_highland()) * std::sqrt(y)
                        * invbetacp;
 

--- a/src/celeritas/em/distribution/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/distribution/UrbanMscStepLimit.hh
@@ -44,6 +44,7 @@ class UrbanMscStepLimit
     using Mass = units::MevMass;
     using MscParameters = UrbanMscParameters;
     using MaterialData = UrbanMscMaterialData;
+    using UrbanMscRef = NativeCRef<UrbanMscData>;
     //!@}
 
   public:
@@ -69,8 +70,6 @@ class UrbanMscStepLimit
     PhysicsTrackView& physics_;
     // Incident particle energy [Energy]
     const real_type inc_energy_;
-    // Incident particle flag for positron
-    bool const is_positron_;
     // Incident particle safety
     const real_type safety_;
     // Urban MSC setable parameters
@@ -128,10 +127,9 @@ UrbanMscStepLimit::UrbanMscStepLimit(UrbanMscRef const& shared,
     : shared_(shared)
     , physics_(*physics)
     , inc_energy_(value_as<Energy>(particle.energy()))
-    , is_positron_(particle.particle_id() == shared.ids.positron)
     , safety_(safety)
     , params_(shared.params)
-    , msc_(shared_.msc_data[matid])
+    , msc_(shared_.material_data[matid])
     , helper_(shared, particle, physics_)
     , msc_range_(physics_.msc_range())
     , on_boundary_(on_boundary)
@@ -144,7 +142,7 @@ UrbanMscStepLimit::UrbanMscStepLimit(UrbanMscRef const& shared,
     CELER_EXPECT(phys_step > 0);
 
     // Mean free path for MSC at current energy
-    lambda_ = helper_.msc_mfp(Energy{inc_energy_});
+    lambda_ = helper_.calc_msc_mfp(Energy{inc_energy_});
 
     // The slowing down range should already have been applied as a step limit
     CELER_ENSURE(range_ >= phys_step_);
@@ -303,7 +301,7 @@ auto UrbanMscStepLimit::calc_geom_path(real_type true_path) const
         real_type rfinal
             = max<real_type>(range_ - true_path, real_type(0.01) * range_);
         Energy loss = helper_.calc_eloss(rfinal);
-        real_type lambda1 = helper_.msc_mfp(loss);
+        real_type lambda1 = helper_.calc_msc_mfp(loss);
 
         result.alpha = (lambda_ - lambda1) / (lambda_ * true_path);
         real_type w = 1 + 1 / (result.alpha * lambda_);
@@ -327,9 +325,8 @@ CELER_FUNCTION real_type UrbanMscStepLimit::calc_limit_min() const
     real_type xm = lambda_
                    / PolyQuad(2, msc_.stepmin_a, msc_.stepmin_b)(inc_energy_);
 
-    // Scale based on particle type and effective atomic number:
-    // 0.7 * z^{1/2} for positrons, otherwise 0.87 * z^{2/3}
-    xm *= is_positron_ ? msc_.scaled_zeff : real_type(0.87) * msc_.z23;
+    // Scale based on particle type and effective atomic number
+    xm *= helper_.scaled_zeff();
 
     if (inc_energy_ < value_as<Energy>(this->tlow()))
     {

--- a/src/celeritas/em/model/UrbanMscModel.cc
+++ b/src/celeritas/em/model/UrbanMscModel.cc
@@ -139,23 +139,9 @@ auto UrbanMscModel::calc_material_data(MaterialView const& material_view)
         return {};
     }
 
-    // Use double-precision for host-side setup since all the precomputed
-    // factors are written as doubles
-    double zeff{0};
-    double norm{0};
-    for (auto el_id : range(ElementComponentId{material_view.num_elements()}))
-    {
-        double weight = material_view.get_element_density(el_id);
-        AtomicNumber z = material_view.make_element_view(el_id).atomic_number();
-        zeff += z.unchecked_get() * weight;
-        norm += weight;
-    }
-    zeff /= norm;
-    CELER_ASSERT(zeff > 0);
-
     MaterialData data;
 
-    data.zeff = zeff;
+    double zeff = material_view.zeff();
     data.scaled_zeff = 0.70 * std::sqrt(zeff);
 
     // Correction in the (modified Highland-Lynch-Dahl) theta_0 formula
@@ -178,8 +164,7 @@ auto UrbanMscModel::calc_material_data(MaterialView const& material_view)
     data.stepmin_b = 1e3 * 6.152 / (1 + 0.111 * zeff);
 
     // Parameters for the maximum distance that particles can travel
-    data.d_over_r = 9.6280e-1 - 8.4848e-2 * std::sqrt(data.zeff)
-                    + 4.3769e-3 * zeff;
+    data.d_over_r = 9.6280e-1 - 8.4848e-2 * std::sqrt(zeff) + 4.3769e-3 * zeff;
     data.d_over_r_mh = 1.15 - 9.76e-4 * zeff;
 
     return data;

--- a/src/celeritas/em/model/UrbanMscModel.cc
+++ b/src/celeritas/em/model/UrbanMscModel.cc
@@ -8,18 +8,25 @@
 #include "UrbanMscModel.hh"
 
 #include <cmath>
+#include <memory>
 #include <utility>
+#include <vector>
 
 #include "corecel/cont/Range.hh"
+#include "corecel/cont/Span.hh"
+#include "corecel/data/Collection.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/math/Algorithms.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/UrbanMscData.hh"
 #include "celeritas/grid/PolyEvaluator.hh"
-#include "celeritas/mat/ElementView.hh"
+#include "celeritas/grid/ValueGridBuilder.hh"
+#include "celeritas/grid/ValueGridInserter.hh"
+#include "celeritas/grid/XsGridData.hh"
+#include "celeritas/io/ImportProcess.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/mat/MaterialView.hh"
-#include "celeritas/phys/AtomicNumber.hh"
+#include "celeritas/phys/ImportedProcessAdapter.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/ParticleView.hh"
@@ -32,26 +39,88 @@ namespace celeritas
  */
 UrbanMscModel::UrbanMscModel(ActionId id,
                              ParticleParams const& particles,
-                             MaterialParams const& materials)
+                             MaterialParams const& materials,
+                             ImportedProcessAdapter const& pdata)
 {
     CELER_EXPECT(id);
-    HostValue host_ref;
+    HostValue host_data;
 
-    host_ref.ids.action = id;
-    host_ref.ids.electron = particles.find(pdg::electron());
-    host_ref.ids.positron = particles.find(pdg::positron());
-    CELER_VALIDATE(host_ref.ids.electron && host_ref.ids.positron,
+    host_data.ids.action = id;
+    host_data.ids.electron = particles.find(pdg::electron());
+    host_data.ids.positron = particles.find(pdg::positron());
+    CELER_VALIDATE(host_data.ids.electron && host_data.ids.positron,
                    << "missing e-/e+ (required for " << this->description()
                    << ")");
 
     // Save electron mass
-    host_ref.electron_mass = particles.get(host_ref.ids.electron).mass();
+    host_data.electron_mass = particles.get(host_data.ids.electron).mass();
 
-    // Build UrbanMsc material data
-    this->build_data(&host_ref, materials);
+    {
+        // Particle-dependent data
+        Array<ParticleId, 2> const par_ids{
+            {host_data.ids.electron, host_data.ids.positron}};
+        Array<ImportPhysicsTable const*, 2> const xs_tables{{
+            &pdata.get_lambda(par_ids[0]),
+            &pdata.get_lambda(par_ids[1]),
+        }};
+        CELER_ASSERT(xs_tables[0]->x_units == ImportUnits::mev);
+        CELER_ASSERT(xs_tables[0]->y_units == ImportUnits::cm_inv);
+        CELER_ASSERT(xs_tables[1]->x_units == ImportUnits::mev);
+        CELER_ASSERT(xs_tables[1]->y_units == ImportUnits::cm_inv);
+
+        // Coefficients for scaled Z
+        static Array<double, 2> const a_coeff{{0.87, 0.70}};
+        static Array<double, 2> const b_coeff{{2.0 / 3, 1.0 / 2}};
+
+        // Builders
+        auto mdata = make_builder(&host_data.material_data);
+        auto pmdata = make_builder(&host_data.par_mat_data);
+        mdata.reserve(materials.num_materials());
+        pmdata.reserve(2 * materials.num_materials());
+
+        // TODO: simplify when refactoring ValueGridInserter, etc
+        ValueGridInserter::XsGridCollection xgc;
+        ValueGridInserter vgi{&host_data.reals, &xgc};
+
+        for (auto mat_id : range(MaterialId{materials.num_materials()}))
+        {
+            auto&& mat = materials.get(mat_id);
+
+            // Build material-dependent data
+            mdata.push_back(UrbanMscModel::calc_material_data(mat));
+
+            // Build particle-dependent data
+            const real_type zeff = mat.zeff();
+            for (size_type p : range(par_ids.size()))
+            {
+                UrbanMscParMatData this_pm;
+
+                // Calculate scaled zeff
+                this_pm.scaled_zeff = a_coeff[p] * fastpow(zeff, b_coeff[p]);
+
+                // Get the cross section data for this particle and material
+                ImportPhysicsVector const& pvec
+                    = xs_tables[p]->physics_vectors[mat_id.unchecked_get()];
+                CELER_ASSERT(pvec.vector_type == ImportPhysicsVectorType::log);
+
+                // To reuse existing code (TODO: simplify when refactoring)
+                // use the value grid builder to construct the grid entry in a
+                // temporary container and then copy it into the pm data.
+                auto vgb = ValueGridLogBuilder::from_geant(make_span(pvec.x),
+                                                           make_span(pvec.y));
+                auto grid_id = vgb->build(vgi);
+                CELER_ASSERT(grid_id.get() == pmdata.size());
+                this_pm.xs = xgc[grid_id];
+                pmdata.push_back(this_pm);
+                CELER_ASSERT(host_data.at(mat_id, par_ids[p]).get() + 1
+                             == host_data.par_mat_data.size());
+            }
+        }
+        CELER_ASSERT(host_data);
+    }
 
     // Move to mirrored data, copying to device
-    mirror_ = CollectionMirror<UrbanMscData>{std::move(host_ref)};
+    mirror_ = CollectionMirror<UrbanMscData>{std::move(host_data)};
 
     CELER_ENSURE(this->mirror_);
 }
@@ -89,9 +158,9 @@ auto UrbanMscModel::micro_xs(Applicability) const -> MicroXsBuilders
  * No discrete interaction: it's integrated into along_step.
  */
 void UrbanMscModel::execute(CoreDeviceRef const&) const {}
-
 void UrbanMscModel::execute(CoreHostRef const&) const {}
 //!@}
+
 //---------------------------------------------------------------------------//
 /*!
  * Get the model ID for this model.
@@ -103,46 +172,19 @@ ActionId UrbanMscModel::action_id() const
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct UrbanMsc material data for all the materials in the problem.
- */
-void UrbanMscModel::build_data(HostValue* data, MaterialParams const& materials)
-{
-    // Number of materials
-    unsigned int num_materials = materials.num_materials();
-
-    // Build msc data for available materials
-    auto msc_data = make_builder(&data->msc_data);
-    msc_data.reserve(num_materials);
-
-    for (auto mat_id : range(MaterialId{num_materials}))
-    {
-        msc_data.push_back(
-            UrbanMscModel::calc_material_data(materials.get(mat_id)));
-    }
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Build UrbanMsc data per material.
  *
  * Tabulated data based on G4UrbanMscModel::InitialiseModelCache() and
  * documented in section 8.1.5 of the Geant4 10.7 Physics Reference Manual.
  */
-auto UrbanMscModel::calc_material_data(MaterialView const& material_view)
-    -> MaterialData
+UrbanMscMaterialData
+UrbanMscModel::calc_material_data(MaterialView const& material_view)
 {
     using PolyQuad = PolyEvaluator<double, 2>;
-
-    if (CELER_UNLIKELY(material_view.num_elements() == 0))
-    {
-        // Pure vacuum, perhaps for testing?
-        return {};
-    }
 
     MaterialData data;
 
     double zeff = material_view.zeff();
-    data.scaled_zeff = 0.70 * std::sqrt(zeff);
 
     // Correction in the (modified Highland-Lynch-Dahl) theta_0 formula
     double const z16 = fastpow(zeff, 1.0 / 6.0);
@@ -156,8 +198,6 @@ auto UrbanMscModel::calc_material_data(MaterialView const& material_view)
     data.d[1] = PolyQuad(4.7526e-1, 1.7694, -3.3885e-1)(z13);
     data.d[2] = PolyQuad(2.3683e-1, -1.8111, 3.2774e-1)(z13);
     data.d[3] = PolyQuad(1.7888e-2, 1.9659e-2, -2.6664e-3)(z13);
-
-    data.z23 = ipow<2>(z13);
 
     // Parameters for the step minimum calculation
     data.stepmin_a = 1e3 * 27.725 / (1 + 0.203 * zeff);

--- a/src/celeritas/em/model/UrbanMscModel.cc
+++ b/src/celeritas/em/model/UrbanMscModel.cc
@@ -16,6 +16,7 @@
 #include "corecel/cont/Span.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/data/CollectionBuilder.hh"
+#include "corecel/io/Logger.hh"
 #include "corecel/math/Algorithms.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/UrbanMscData.hh"
@@ -51,12 +52,15 @@ UrbanMscModel::UrbanMscModel(ActionId id,
     CELER_VALIDATE(host_data.ids.electron && host_data.ids.positron,
                    << "missing e-/e+ (required for " << this->description()
                    << ")");
+
     // TODO: change IDs to a vector for all particles. This model should apply
     // to muons and charged hadrons as well
-    CELER_VALIDATE(!particles.find(pdg::mu_minus())
-                       && !particles.find(pdg::mu_plus())
-                       && !particles.find(pdg::proton()),
-                   << "support for other particles is not implemented");
+    if (particles.find(pdg::mu_minus()) || particles.find(pdg::mu_plus())
+        || particles.find(pdg::proton()))
+    {
+        CELER_LOG(warning) << "Multiple scattering is not implemented for for "
+                              "particles other than electron and positron";
+    }
 
     // Save electron mass
     host_data.electron_mass = particles.get(host_data.ids.electron).mass();

--- a/src/celeritas/em/model/UrbanMscModel.cc
+++ b/src/celeritas/em/model/UrbanMscModel.cc
@@ -51,6 +51,12 @@ UrbanMscModel::UrbanMscModel(ActionId id,
     CELER_VALIDATE(host_data.ids.electron && host_data.ids.positron,
                    << "missing e-/e+ (required for " << this->description()
                    << ")");
+    // TODO: change IDs to a vector for all particles. This model should apply
+    // to muons and charged hadrons as well
+    CELER_VALIDATE(!particles.find(pdg::mu_minus())
+                       && !particles.find(pdg::mu_plus())
+                       && !particles.find(pdg::proton()),
+                   << "support for other particles is not implemented");
 
     // Save electron mass
     host_data.electron_mass = particles.get(host_data.ids.electron).mass();

--- a/src/celeritas/em/model/UrbanMscModel.hh
+++ b/src/celeritas/em/model/UrbanMscModel.hh
@@ -16,6 +16,7 @@ namespace celeritas
 class ParticleParams;
 class MaterialParams;
 class MaterialView;
+class ImportedProcessAdapter;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -34,7 +35,8 @@ class UrbanMscModel final : public Model
     // Construct from model ID and other necessary data
     UrbanMscModel(ActionId id,
                   ParticleParams const& particles,
-                  MaterialParams const& materials);
+                  MaterialParams const& materials,
+                  ImportedProcessAdapter const& pdata);
 
     // Particle types and energy ranges that this model applies to
     SetApplicability applicability() const final;
@@ -79,8 +81,7 @@ class UrbanMscModel final : public Model
 
     //// HELPER FUNCTIONS ////
 
-    void build_data(HostValue* host_data, MaterialParams const& materials);
-    MaterialData calc_material_data(MaterialView const& material_view);
+    static MaterialData calc_material_data(MaterialView const& material_view);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/MultipleScatteringProcess.cc
+++ b/src/celeritas/em/process/MultipleScatteringProcess.cc
@@ -43,7 +43,7 @@ auto MultipleScatteringProcess::build_models(ActionIdIter start_id) const
     -> VecModel
 {
     return {std::make_shared<UrbanMscModel>(
-        *start_id++, *particles_, *materials_)};
+        *start_id++, *particles_, *materials_, imported_)};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/detail/UrbanMsc.hh
+++ b/src/celeritas/global/alongstep/detail/UrbanMsc.hh
@@ -80,11 +80,11 @@ UrbanMsc::is_applicable(CoreTrackView const& track, real_type step) const
     if (step <= msc_params_.params.geom_limit)
         return false;
 
-    auto phys = track.make_physics_view();
-    if (!phys.msc_ppid())
+    auto particle = track.make_particle_view();
+    if (particle.particle_id() != msc_params_.ids.electron
+        && particle.particle_id() != msc_params_.ids.positron)
         return false;
 
-    auto particle = track.make_particle_view();
     return particle.energy() > msc_params_.params.low_energy_limit
            && particle.energy() < msc_params_.params.high_energy_limit;
 }

--- a/src/celeritas/grid/ValueGridData.cc
+++ b/src/celeritas/grid/ValueGridData.cc
@@ -3,19 +3,18 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/grid/ValueGridInterface.cc
+//! \file celeritas/grid/ValueGridData.cc
 //---------------------------------------------------------------------------//
-#include "corecel/Assert.hh"
-
 #include "ValueGridData.hh"
+
+#include "corecel/Assert.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 char const* to_cstring(ValueGridType value)
 {
-    static char const* const strings[]
-        = {"macro_xs", "energy_loss", "range", "msc_mfp"};
+    static char const* const strings[] = {"macro_xs", "energy_loss", "range"};
     CELER_EXPECT(static_cast<unsigned int>(value) * sizeof(char const*)
                  < sizeof(strings));
     return strings[static_cast<unsigned int>(value)];

--- a/src/celeritas/grid/ValueGridData.hh
+++ b/src/celeritas/grid/ValueGridData.hh
@@ -19,7 +19,6 @@ enum class ValueGridType
     macro_xs,  //!< Interaction cross sections
     energy_loss,  //!< Energy loss per unit length
     range,  //!< Particle range
-    msc_mfp,  //!< Multiple scattering mean free path
     size_  //!< Sentinel value
 };
 

--- a/src/celeritas/io/ImportProcess.hh
+++ b/src/celeritas/io/ImportProcess.hh
@@ -141,6 +141,7 @@ struct ImportProcess
     ImportProcessType process_type;
     ImportProcessClass process_class;
     std::vector<ImportModelClass> models;
+    // TODO: map from ImportTableType
     std::vector<ImportPhysicsTable> tables;
     std::map<ImportModelClass, ModelMicroXS> micro_xs;
 

--- a/src/celeritas/mat/MaterialData.hh
+++ b/src/celeritas/mat/MaterialData.hh
@@ -74,6 +74,7 @@ struct MaterialRecord
 
     // COMPUTED PROPERTIES
 
+    real_type zeff;  //!< Weighted atomic number
     real_type density;  //!< Density [g/cm^3]
     real_type electron_density;  //!< Electron number density [1/cm^3]
     real_type rad_length;  //!< Radiation length [cm]

--- a/src/celeritas/mat/MaterialParams.cc
+++ b/src/celeritas/mat/MaterialParams.cc
@@ -329,10 +329,10 @@ void MaterialParams::append_material_def(MaterialInput const& inp,
      *
      * NOTE: Electron density calculation may need to be updated for solids.
      */
-    real_type avg_amu_mass = 0;
-    real_type avg_z = 0;
-    real_type rad_coeff = 0;
-    real_type log_mean_exc_energy = 0;
+    double avg_amu_mass = 0;
+    double avg_z = 0;
+    double rad_coeff = 0;
+    double log_mean_exc_energy = 0;
     for (MatElementComponent const& comp :
          host_data->elcomponents[result.elements])
     {
@@ -348,6 +348,7 @@ void MaterialParams::append_material_def(MaterialInput const& inp,
                * std::log(value_as<units::MevEnergy>(
                    detail::get_mean_excitation_energy(el.atomic_number)));
     }
+    result.zeff = avg_z;
     result.density = result.number_density * avg_amu_mass
                      * constants::atomic_mass;
     result.electron_density = result.number_density * avg_z;

--- a/src/celeritas/mat/MaterialView.hh
+++ b/src/celeritas/mat/MaterialView.hh
@@ -79,6 +79,9 @@ class MaterialView
 
     //// DERIVATIVE DATA ////
 
+    // Weighted atomic number
+    inline CELER_FUNCTION real_type zeff() const;
+
     // Material density [g/cm^3]
     inline CELER_FUNCTION real_type density() const;
 
@@ -201,6 +204,17 @@ MaterialView::get_element_density(ElementComponentId id) const
 CELER_FUNCTION Span<MatElementComponent const> MaterialView::elements() const
 {
     return params_.elcomponents[this->material_def().elements];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Weighted atomic number.
+ *
+ * This is Z weighted by the atomic fraction of each element in the material.
+ */
+CELER_FUNCTION real_type MaterialView::zeff() const
+{
+    return this->material_def().zeff;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/ImportedProcessAdapter.cc
+++ b/src/celeritas/phys/ImportedProcessAdapter.cc
@@ -206,7 +206,11 @@ auto ImportedProcessAdapter::step_limits(Applicability range) const
     StepLimitBuilders builders;
 
     // Construct cross section tables
-    if (ids.lambda && ids.lambda_prim)
+    if (import_process.process_class == ImportProcessClass::msc)
+    {
+        // No cross sections
+    }
+    else if (ids.lambda && ids.lambda_prim)
     {
         // Both unscaled and scaled values are present
         auto const& lo = get_vector(ids.lambda);
@@ -230,12 +234,8 @@ auto ImportedProcessAdapter::step_limits(Applicability range) const
         auto const& vec = get_vector(ids.lambda);
         CELER_ASSERT(vec.vector_type == ImportPhysicsVectorType::log);
 
-        ValueGridType vgt
-            = (import_process.process_class == ImportProcessClass::msc)
-                  ? ValueGridType::msc_mfp
-                  : ValueGridType::macro_xs;
-        builders[vgt] = ValueGridLogBuilder::from_geant(make_span(vec.x),
-                                                        make_span(vec.y));
+        builders[ValueGridType::macro_xs] = ValueGridLogBuilder::from_geant(
+            make_span(vec.x), make_span(vec.y));
     }
 
     // Construct slowing-down data

--- a/src/celeritas/phys/ImportedProcessAdapter.hh
+++ b/src/celeritas/phys/ImportedProcessAdapter.hh
@@ -97,6 +97,9 @@ class ImportedProcessAdapter
     // Construct step limits from the given particle/material type
     StepLimitBuilders step_limits(Applicability range) const;
 
+    // Get the lambda table for the given particle ID
+    inline ImportPhysicsTable const& get_lambda(ParticleId id) const;
+
     // Access the imported processes
     SPConstImported const& processes() const { return imported_; }
 
@@ -136,6 +139,22 @@ ImportProcess const& ImportedProcesses::get(ImportProcessId id) const
 auto ImportedProcesses::size() const -> ImportProcessId::size_type
 {
     return processes_.size();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get cross sections for the given particle ID.
+ *
+ * This is currently used for loading MSC data for calculating mean free paths.
+ */
+ImportPhysicsTable const&
+ImportedProcessAdapter::get_lambda(ParticleId id) const
+{
+    auto iter = ids_.find(id);
+    CELER_EXPECT(iter != ids_.end());
+    ImportTableId tab = iter->second.lambda;
+    CELER_ENSURE(tab);
+    return imported_->get(iter->second.process).tables[tab.unchecked_get()];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -133,7 +133,6 @@ struct ProcessGroup
     ItemRange<IntegralXsProcess> integral_xs;  //!< [ppid]
     ItemRange<ModelGroup> models;  //!< Model applicability [ppid]
     ParticleProcessId eloss_ppid{};  //!< Process with de/dx and range tables
-    ParticleProcessId msc_ppid{};  //!< Process of msc (TODO: delete me)
     bool has_at_rest{};  //!< Whether the particle type has an at-rest process
 
     //! True if assigned and valid

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -474,7 +474,10 @@ void PhysicsParams::build_xs(Options const& opts,
                 CELER_VALIDATE(
                     std::any_of(builders.begin(),
                                 builders.end(),
-                                [](UPGridBuilder const& p) { return bool(p); }),
+                                [](UPGridBuilder const& p) { return bool(p); })
+                        // TODO: super hack since MSC doesn't have any sampled
+                        // or along-step interaction: fix while refactoring
+                        || proc.label() == "Multiple scattering",
                     << "process '" << proc.label()
                     << "' has neither interaction nor energy loss (it must "
                        "have at least one)");
@@ -540,12 +543,6 @@ void PhysicsParams::build_xs(Options const& opts,
                     CELER_ASSERT(!process_groups.eloss_ppid
                                  || pp_idx == process_groups.eloss_ppid.get());
                     process_groups.eloss_ppid = ParticleProcessId{pp_idx};
-                }
-
-                // Index of the electromagnetic msc process
-                if (dynamic_cast<MultipleScatteringProcess const*>(&proc))
-                {
-                    process_groups.msc_ppid = ParticleProcessId{pp_idx};
                 }
             }
 

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -80,6 +80,9 @@ class PhysicsTrackView
     // Range properties for multiple scattering
     CELER_FORCEINLINE_FUNCTION MscRange const& msc_range() const;
 
+    // Current material identifier
+    CELER_FORCEINLINE_FUNCTION MaterialId material_id() const;
+
     //// PROCESSES (depend on particle type and possibly material) ////
 
     // Number of processes that apply to this track
@@ -155,9 +158,6 @@ class PhysicsTrackView
 
     // Particle-process ID of the process with the de/dx and range tables
     inline CELER_FUNCTION ParticleProcessId eloss_ppid() const;
-
-    // Particle-process ID of the process with the msc cross section table
-    inline CELER_FUNCTION ParticleProcessId msc_ppid() const;
 
   private:
     PhysicsParamsRef const& params_;
@@ -252,6 +252,15 @@ CELER_FUNCTION void PhysicsTrackView::dedx_range(real_type range)
 CELER_FUNCTION void PhysicsTrackView::msc_range(MscRange const& msc_range)
 {
     this->state().msc_range = msc_range;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Current material identifier.
+ */
+CELER_FUNCTION MaterialId PhysicsTrackView::material_id() const
+{
+    return material_;
 }
 
 //---------------------------------------------------------------------------//
@@ -483,15 +492,6 @@ CELER_FUNCTION ModelId PhysicsTrackView::hardwired_model(ParticleProcessId ppid,
 CELER_FUNCTION ParticleProcessId PhysicsTrackView::eloss_ppid() const
 {
     return this->process_group().eloss_ppid;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Particle-process ID of the multiple scattering process
- */
-CELER_FUNCTION ParticleProcessId PhysicsTrackView::msc_ppid() const
-{
-    return this->process_group().msc_ppid;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -226,7 +226,6 @@ TEST_F(UrbanMscTest, msc_scattering)
     UrbanMscMaterialData const& msc_
         = model->host_ref().msc_data[material_view.material_id()];
 
-    EXPECT_DOUBLE_EQ(msc_.zeff, 25.8);
     EXPECT_DOUBLE_EQ(msc_.z23, 8.7313179636909233);
     EXPECT_DOUBLE_EQ(msc_.coeffth1, 0.97326969977637379);
     EXPECT_DOUBLE_EQ(msc_.coeffth2, 0.044188139325421663);

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -204,8 +204,6 @@ class UrbanMscTest : public GlobalGeoTestBase
     // Views
     std::shared_ptr<ParticleTrackView> part_view_;
     RandomEngine rng_;
-
-    std::shared_ptr<UrbanMscModel> model_;
 };
 
 //---------------------------------------------------------------------------//
@@ -220,13 +218,18 @@ TEST_F(UrbanMscTest, msc_scattering)
 
     // Create the model
     std::shared_ptr<UrbanMscModel> model = std::make_shared<UrbanMscModel>(
-        ActionId{0}, *this->particle(), *this->material());
+        ActionId{0},
+        *this->particle(),
+        *this->material(),
+        ImportedProcessAdapter{processes_data_,
+                               this->particle(),
+                               ImportProcessClass::msc,
+                               {pdg::electron(), pdg::positron()}});
 
     // Check MscMaterialDara for the current material (G4_STAINLESS-STEEL)
     UrbanMscMaterialData const& msc_
-        = model->host_ref().msc_data[material_view.material_id()];
+        = model->host_ref().material_data[material_view.material_id()];
 
-    EXPECT_DOUBLE_EQ(msc_.z23, 8.7313179636909233);
     EXPECT_DOUBLE_EQ(msc_.coeffth1, 0.97326969977637379);
     EXPECT_DOUBLE_EQ(msc_.coeffth2, 0.044188139325421663);
     EXPECT_DOUBLE_EQ(msc_.d[0], 1.6889578380303167);

--- a/test/celeritas/mat/Material.test.cc
+++ b/test/celeritas/mat/Material.test.cc
@@ -183,6 +183,7 @@ TEST_F(MaterialTest, material_view)
         EXPECT_SOFT_EQ(2.948915064677e+22, mat.number_density());
         EXPECT_SOFT_EQ(293.0, mat.temperature());
         EXPECT_EQ(MatterState::solid, mat.matter_state());
+        EXPECT_SOFT_EQ(32.0, mat.zeff());
         EXPECT_SOFT_EQ(3.6700020622594716, mat.density());
         EXPECT_SOFT_EQ(9.4365282069663997e+23, mat.electron_density());
         EXPECT_SOFT_EQ(3.5393292693170424, mat.radiation_length());
@@ -205,6 +206,7 @@ TEST_F(MaterialTest, material_view)
         EXPECT_SOFT_EQ(0, mat.number_density());
         EXPECT_SOFT_EQ(0, mat.temperature());
         EXPECT_EQ(MatterState::unspecified, mat.matter_state());
+        EXPECT_SOFT_EQ(0, mat.zeff());
         EXPECT_SOFT_EQ(0, mat.density());
         EXPECT_SOFT_EQ(0, mat.electron_density());
         EXPECT_SOFT_EQ(std::numeric_limits<real_type>::infinity(),
@@ -223,6 +225,7 @@ TEST_F(MaterialTest, material_view)
         EXPECT_SOFT_EQ(1.0739484359044669e+20, mat.number_density());
         EXPECT_SOFT_EQ(100, mat.temperature());
         EXPECT_EQ(MatterState::gas, mat.matter_state());
+        EXPECT_SOFT_EQ(1.0, mat.zeff());
         EXPECT_SOFT_EQ(0.00017976, mat.density());
         EXPECT_SOFT_EQ(1.0739484359044669e+20, mat.electron_density());
         EXPECT_SOFT_EQ(350729.99844063615, mat.radiation_length());
@@ -240,6 +243,7 @@ TEST_F(MaterialTest, material_view)
         EXPECT_SOFT_EQ(1.072e+20, mat.number_density());
         EXPECT_SOFT_EQ(110, mat.temperature());
         EXPECT_EQ(MatterState::gas, mat.matter_state());
+        EXPECT_SOFT_EQ(1.0, mat.zeff());
         EXPECT_SOFT_EQ(0.00017943386624303615, mat.density());
         EXPECT_SOFT_EQ(1.072e+20, mat.electron_density());
         EXPECT_SOFT_EQ(351367.47504673258, mat.radiation_length());

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -127,7 +127,7 @@ TEST_F(PhysicsParamsTest, output)
     if (CELERITAS_USE_JSON)
     {
         EXPECT_EQ(
-            R"json({"models":[{"label":"mock-model-4","process":0},{"label":"mock-model-5","process":0},{"label":"mock-model-6","process":1},{"label":"mock-model-7","process":2},{"label":"mock-model-8","process":2},{"label":"mock-model-9","process":2},{"label":"mock-model-10","process":3},{"label":"mock-model-11","process":3},{"label":"mock-model-12","process":4},{"label":"mock-model-13","process":4},{"label":"mock-model-14","process":5}],"options":{"eloss_calc_limit":[0.001,"MeV"],"fixed_step_limiter":0.0,"linear_loss_limit":0.01,"max_step_over_range":0.2,"min_eprime_over_e":0.8,"min_range":0.1},"processes":[{"label":"scattering"},{"label":"absorption"},{"label":"purrs"},{"label":"hisses"},{"label":"meows"},{"label":"barks"}],"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":4,"process_ids":8,"reals":196,"value_grid_ids":75,"value_grids":75,"value_tables":43}})json",
+            R"json({"models":[{"label":"mock-model-4","process":0},{"label":"mock-model-5","process":0},{"label":"mock-model-6","process":1},{"label":"mock-model-7","process":2},{"label":"mock-model-8","process":2},{"label":"mock-model-9","process":2},{"label":"mock-model-10","process":3},{"label":"mock-model-11","process":3},{"label":"mock-model-12","process":4},{"label":"mock-model-13","process":4},{"label":"mock-model-14","process":5}],"options":{"eloss_calc_limit":[0.001,"MeV"],"fixed_step_limiter":0.0,"linear_loss_limit":0.01,"max_step_over_range":0.2,"min_eprime_over_e":0.8,"min_range":0.1},"processes":[{"label":"scattering"},{"label":"absorption"},{"label":"purrs"},{"label":"hisses"},{"label":"meows"},{"label":"barks"}],"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":4,"process_ids":8,"reals":196,"value_grid_ids":75,"value_grids":75,"value_tables":35}})json",
             to_string(out));
     }
 }
@@ -416,11 +416,10 @@ TEST_F(PhysicsTrackViewHostTest, value_grids)
     // Grid IDs should be unique if they exist. Gammas should have fewer
     // because there aren't any slowing down/range limiters.
     static int const expected_grid_ids[]
-        = {0,  -1, -1, -1, 3,  -1, -1, -1, 1,  -1, -1, -1, 4,  -1, -1, -1, 2,
-           -1, -1, -1, 5,  -1, -1, -1, 6,  -1, -1, -1, 9,  10, 11, -1, 18, -1,
-           -1, -1, 7,  -1, -1, -1, 12, 13, 14, -1, 19, -1, -1, -1, 8,  -1, -1,
-           -1, 15, 16, 17, -1, 20, -1, -1, -1, 21, 22, 23, -1, 30, -1, -1, -1,
-           24, 25, 26, -1, 31, -1, -1, -1, 27, 28, 29, -1, 32, -1, -1, -1};
+        = {0,  -1, -1, 3,  -1, -1, 1,  -1, -1, 4,  -1, -1, 2,  -1, -1, 5,
+           -1, -1, 6,  -1, -1, 9,  10, 11, 18, -1, -1, 7,  -1, -1, 12, 13,
+           14, 19, -1, -1, 8,  -1, -1, 15, 16, 17, 20, -1, -1, 21, 22, 23,
+           30, -1, -1, 24, 25, 26, 31, -1, -1, 27, 28, 29, 32, -1, -1};
     EXPECT_VEC_EQ(expected_grid_ids, grid_ids);
 }
 

--- a/test/celeritas/phys/ProcessBuilder.test.cc
+++ b/test/celeritas/phys/ProcessBuilder.test.cc
@@ -278,7 +278,7 @@ TEST_F(ProcessBuilderTest, msc)
         {
             applic.material = mat_id;
             auto builders = process->step_limits(applic);
-            EXPECT_TRUE(builders[VGT::msc_mfp]);
+            EXPECT_FALSE(builders[VGT::macro_xs]);
         }
 
         // Test micro xs


### PR DESCRIPTION
This is a follow-on from work done in #457 with the goal of physics class (builders, etc.) for #253 . It removes the MSC process from physics processing and puts particle- and material-dependent MSC data in the UrbanMsc class itself.

Since now the only purpose of passing the MscProcess into the physics is to construct the model that gets looked up by the `AlongStepUniformMscAction`, we'll want a follow-on PR to remove the MSC "process" and Urban "model" entirely since these aren't treated the same way as all the other discrete and along-step processes in the code. At that point we can add the high-energy MSC model and consider how to simplify and combine the different along-step actions.