### PR TITLE
Update crusher environment to use AMD LLVM compilers

### DIFF
--- a/scripts/cmake-presets/crusher.json
+++ b/scripts/cmake-presets/crusher.json
@@ -24,8 +24,9 @@
         "CMAKE_HIP_FLAGS": "-munsafe-fp-atomics -Wno-#warnings",
         "CMAKE_EXE_LINKER_FLAGS": "-Wno-unused-command-line-argument",
         "CMAKE_HIP_FLAGS_DEBUG": "-g -ggdb -O",
-        "CMAKE_CXX_COMPILER": "CC",
         "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=znver3 -mtune=znver3",
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
         "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"}
       }
     },

--- a/scripts/env/crusher.sh
+++ b/scripts/env/crusher.sh
@@ -1,15 +1,35 @@
 #!/bin/sh -e
 
-module load DefApps/default PrgEnv-gnu craype-accel-amd-gfx90a rocm
-module load nlohmann-json cmake ninja googletest
-module try_load root clhep xerces-c expat geant4 hepmc3
-module load cray-python/3.9.13.1
+_celer_base=$PROJWORK/csc404/celeritas-crusher
+
+# From %clang@14.0.0-rocm5.1.0 in OLCF's spack compilers:
+module load PrgEnv-amd/8.3.3 amd/5.1.0 craype-x86-trento libfabric \
+  cray-pmi/6.1.2 cray-python/3.9.13.1
+export RFE_811452_DISABLE=1
+export LD_LIBRARY_PATH=/opt/cray/pe/pmi/6.1.2/lib:$LD_LIBRARY_PATH:/opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.0.0/lib64
+export LIBRARY_PATH=/opt/rocm-5.1.0/lib:/opt/rocm-5.1.0/lib64:$LIBRARY_PATH
+
+# Avoid linking multiple different libsci (one with openmp, one without)
 module unload cray-libsci
 
-# NOTE: these might only be necessary when we add MPI support
-# export PE_MPICH_GTL_DIR_amd_gfx90a="-L${CRAY_MPICH_ROOTDIR}/gtl/lib"
-# export PE_MPICH_GTL_LIBS_amd_gfx90a="-lmpi_gtl_hsa"
-# export MPICH_GPU_SUPPORT_ENABLED=1
-# export MPICH_SMP_SINGLE_COPY_MODE=CMA
-#export HIPFLAGS="-I$MPICH_DIR/include"
-#export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64 -lhsa-runtime64"
+# Set up compilers
+test -n "${CRAYPE_DIR}"
+export CXX=${CRAYPE_DIR}/bin/CC
+export CC=${CRAYPE_DIR}/bin/cc
+
+# Do NOT load the accelerator target, because it adds
+# -fopenmp-targets=amdgcn-amd-amdhsa 
+# -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a
+# which implicitly defines __CUDA_ARCH__
+# module load craype-accel-amd-gfx90a
+
+# Set up celeritas
+export SPACK_ROOT=/ccs/proj/csc404/spack-crusher
+export PATH=${_celer_base}/spack/view/bin:$PATH
+export CMAKE_PREFIX_PATH=${_celer_base}/spack/view:${CMAKE_PREFIX_PATH}
+export MODULEPATH=${SPACK_ROOT}/share/spack/lmod/cray-sles15-x86_64/Core:${MODULEPATH}
+module load geant4-data
+
+# Make llvm available
+test -n "${ROCM_PATH}"
+export PATH=$PATH:${ROCM_PATH}/llvm/bin


### PR DESCRIPTION
For the latest benchmark runs I've redone the crusher toolchain to use LLVM for the C++ compilers in *addition* to for the HIP compiler.