### PR TITLE
Support linking to Geant4 static libraries

### DIFF
--- a/cmake/FindGeant4.cmake
+++ b/cmake/FindGeant4.cmake
@@ -16,7 +16,11 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Geant4 CONFIG_MODE)
 
 if(Geant4_FOUND AND Geant4_VERSION VERSION_GREATER_EQUAL 11 AND CELERITAS_USE_CUDA)
-  target_compile_features(Geant4::G4global INTERFACE cuda_std_17)
+  if(TARGET Geant4::G4global)
+    target_compile_features(Geant4::G4global INTERFACE cuda_std_17)
+  else()
+    target_compile_features(Geant4::G4global-static INTERFACE cuda_std_17)
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/cmake/FindGeant4.cmake
+++ b/cmake/FindGeant4.cmake
@@ -16,11 +16,11 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Geant4 CONFIG_MODE)
 
 if(Geant4_FOUND AND Geant4_VERSION VERSION_GREATER_EQUAL 11 AND CELERITAS_USE_CUDA)
-  if(TARGET Geant4::G4global)
-    target_compile_features(Geant4::G4global INTERFACE cuda_std_17)
-  else()
-    target_compile_features(Geant4::G4global-static INTERFACE cuda_std_17)
-  endif()
+  foreach(_tgt Geant4::G4global Geant4::G4global-static)
+    if(TARGET ${_tgt})
+      target_compile_features(${_tgt} INTERFACE cuda_std_17)
+    endif()
+  endforeach()
 endif()
 
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
If Geant4 is installed with only static libraries, the `FindGeant4` wrapper will fail as it directly sets properties on the unavailable `Geant4::G4global` shared target. This was identified during tests with static Geant4+VecGeom+CUDA builds which experiments may be using.

Check that the shared `Geant4::G4global` target exists before setting its properties. Fallback to the static target if the shared does not exist. This is safe against dual installs, as Geant4 will prefer shared targets in this case.

Only tested on Linux with the celeritas spack environment configured with GCC11.2/CUDA11.7, and everything except Geant4 installed. VecGeom 1.2.1 was installed using the `~shared` variant to set up the static build of that. Geant4 was then built manually against this in static or shared mode, with variants/defaults as in the spack package. Celeritas was finally built on top of these with the default settings. Possible, even likely CI will bring something up, but let's see.