### PR TITLE
Add enum string mapper

### DIFF
--- a/src/celeritas/Types.cc
+++ b/src/celeritas/Types.cc
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #include "Types.hh"
 
+#include "corecel/io/EnumStringMapper.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -15,9 +17,7 @@ namespace celeritas
  */
 char const* to_cstring(ActionOrder value)
 {
-    CELER_EXPECT(value != ActionOrder::size_);
-
-    static char const* const strings[] = {
+    static EnumStringMapper<ActionOrder> const to_cstring_impl{
         "start",
         "pre",
         "along",
@@ -26,12 +26,7 @@ char const* to_cstring(ActionOrder value)
         "post_post",
         "end",
     };
-    static_assert(
-        static_cast<unsigned int>(ActionOrder::size_) * sizeof(char const*)
-            == sizeof(strings),
-        "Enum strings are incorrect");
-
-    return strings[static_cast<unsigned int>(value)];
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
+++ b/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
@@ -11,7 +11,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
-#include "corecel/io/StringEnumMap.hh"
+#include "corecel/io/StringEnumMapper.hh"
 #include "corecel/math/QuantityIO.json.hh"
 #include "celeritas/ext/GeantPhysicsOptions.hh"
 
@@ -93,8 +93,8 @@ char const* to_cstring(RelaxationSelection value)
 void from_json(nlohmann::json const& j, MscModelSelection& value)
 {
     static auto const from_string
-        = StringEnumMap<MscModelSelection>::from_cstring_func(to_cstring,
-                                                              "msc model");
+        = StringEnumMapper<MscModelSelection>::from_cstring_func(to_cstring,
+                                                                 "msc model");
     value = from_string(j.get<std::string>());
 }
 
@@ -106,8 +106,8 @@ void to_json(nlohmann::json& j, MscModelSelection const& value)
 void from_json(nlohmann::json const& j, BremsModelSelection& value)
 {
     static auto const from_string
-        = StringEnumMap<BremsModelSelection>::from_cstring_func(to_cstring,
-                                                                "brems model");
+        = StringEnumMapper<BremsModelSelection>::from_cstring_func(
+            to_cstring, "brems model");
     value = from_string(j.get<std::string>());
 }
 
@@ -119,7 +119,7 @@ void to_json(nlohmann::json& j, BremsModelSelection const& value)
 void from_json(nlohmann::json const& j, RelaxationSelection& value)
 {
     static auto const from_string
-        = StringEnumMap<RelaxationSelection>::from_cstring_func(
+        = StringEnumMapper<RelaxationSelection>::from_cstring_func(
             to_cstring, "atomic relaxation");
     value = from_string(j.get<std::string>());
 }

--- a/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
+++ b/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
@@ -11,6 +11,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/io/EnumStringMapper.hh"
 #include "corecel/io/StringEnumMapper.hh"
 #include "corecel/math/QuantityIO.json.hh"
 #include "celeritas/ext/GeantPhysicsOptions.hh"
@@ -27,19 +28,12 @@ namespace
  */
 char const* to_cstring(BremsModelSelection value)
 {
-    CELER_EXPECT(value != BremsModelSelection::size_);
-
-    static char const* const strings[] = {
+    static EnumStringMapper<BremsModelSelection> const to_cstring_impl{
         "seltzer_berger",
         "relativistic",
         "all",
     };
-    static_assert(
-        static_cast<int>(BremsModelSelection::size_) * sizeof(char const*)
-            == sizeof(strings),
-        "Enum strings are incorrect");
-
-    return strings[static_cast<int>(value)];
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//
@@ -48,19 +42,12 @@ char const* to_cstring(BremsModelSelection value)
  */
 char const* to_cstring(MscModelSelection value)
 {
-    CELER_EXPECT(value != MscModelSelection::size_);
-
-    static char const* const strings[] = {
+    static EnumStringMapper<MscModelSelection> const to_cstring_impl{
         "none",
         "urban",
         "wentzel_vi",
     };
-    static_assert(
-        static_cast<int>(MscModelSelection::size_) * sizeof(char const*)
-            == sizeof(strings),
-        "Enum strings are incorrect");
-
-    return strings[static_cast<int>(value)];
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//
@@ -69,19 +56,12 @@ char const* to_cstring(MscModelSelection value)
  */
 char const* to_cstring(RelaxationSelection value)
 {
-    CELER_EXPECT(value != RelaxationSelection::size_);
-
-    static char const* const strings[] = {
+    static EnumStringMapper<RelaxationSelection> const to_cstring_impl{
         "none",
         "radiative",
         "all",
     };
-    static_assert(
-        static_cast<int>(RelaxationSelection::size_) * sizeof(char const*)
-            == sizeof(strings),
-        "Enum strings are incorrect");
-
-    return strings[static_cast<int>(value)];
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/io/ImportPhysicsTable.cc
+++ b/src/celeritas/io/ImportPhysicsTable.cc
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "ImportPhysicsTable.hh"
 
-#include "corecel/Assert.hh"
+#include "corecel/io/EnumStringMapper.hh"
 
 namespace celeritas
 {
@@ -17,7 +17,7 @@ namespace celeritas
  */
 char const* to_cstring(ImportTableType value)
 {
-    static char const* const strings[] = {
+    static EnumStringMapper<ImportTableType> const to_cstring_impl{
         "dedx",
         "dedx_process",
         "dedx_subsec",
@@ -32,9 +32,7 @@ char const* to_cstring(ImportTableType value)
         "sublambda",
         "lambda_prim",
     };
-    CELER_EXPECT(static_cast<unsigned int>(value) * sizeof(char const*)
-                 < sizeof(strings));
-    return strings[static_cast<unsigned int>(value)];
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//
@@ -43,7 +41,7 @@ char const* to_cstring(ImportTableType value)
  */
 char const* to_cstring(ImportUnits value)
 {
-    static char const* const strings[] = {
+    static EnumStringMapper<ImportUnits> const to_cstring_impl{
         "unitless",
         "MeV",
         "MeV/cm",
@@ -51,9 +49,7 @@ char const* to_cstring(ImportUnits value)
         "1/cm",
         "1/cm-MeV",
     };
-    CELER_EXPECT(static_cast<unsigned int>(value) * sizeof(char const*)
-                 < sizeof(strings));
-    return strings[static_cast<unsigned int>(value)];
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/io/ImportProcess.cc
+++ b/src/celeritas/io/ImportProcess.cc
@@ -13,6 +13,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/EnumArray.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/io/EnumStringMapper.hh"
 #include "corecel/io/StringEnumMapper.hh"
 
 namespace celeritas
@@ -52,26 +53,22 @@ ModelArray<bool> make_microxs_flag_array()
  */
 char const* to_cstring(ImportProcessType value)
 {
-    CELER_EXPECT(value < ImportProcessType::size_);
-    static char const* const strings[] = {"",
-                                          "transportation",
-                                          "electromagnetic",
-                                          "optical",
-                                          "hadronic",
-                                          "photolepton_hadron",
-                                          "decay",
-                                          "general",
-                                          "parameterisation",
-                                          "user_defined",
-                                          "parallel",
-                                          "phonon",
-                                          "ucn"};
-    static_assert(static_cast<unsigned int>(ImportProcessType::size_)
-                          * sizeof(char const*)
-                      == sizeof(strings),
-                  "Enum strings are incorrect");
-
-    return strings[static_cast<unsigned int>(value)];
+    static EnumStringMapper<ImportProcessType> const to_cstring_impl{
+        "",
+        "transportation",
+        "electromagnetic",
+        "optical",
+        "hadronic",
+        "photolepton_hadron",
+        "decay",
+        "general",
+        "parameterisation",
+        "user_defined",
+        "parallel",
+        "phonon",
+        "ucn",
+    };
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//
@@ -82,30 +79,26 @@ char const* to_cstring(ImportProcessType value)
  */
 char const* to_cstring(ImportProcessClass value)
 {
-    CELER_EXPECT(value < ImportProcessClass::size_);
-    static char const* const strings[] = {"",
-                                          "ion_ioni",
-                                          "msc",
-                                          "h_ioni",
-                                          "h_brems",
-                                          "h_pair_prod",
-                                          "coulomb_scat",
-                                          "e_ioni",
-                                          "e_brems",
-                                          "photoelectric",
-                                          "compton",
-                                          "conversion",
-                                          "rayleigh",
-                                          "annihilation",
-                                          "mu_ioni",
-                                          "mu_brems",
-                                          "mu_pair_prod"};
-    static_assert(static_cast<unsigned int>(ImportProcessClass::size_)
-                          * sizeof(char const*)
-                      == sizeof(strings),
-                  "Enum strings are incorrect");
-
-    return strings[static_cast<unsigned int>(value)];
+    static EnumStringMapper<ImportProcessClass> const to_cstring_impl{
+        "",
+        "ion_ioni",
+        "msc",
+        "h_ioni",
+        "h_brems",
+        "h_pair_prod",
+        "coulomb_scat",
+        "e_ioni",
+        "e_brems",
+        "photoelectric",
+        "compton",
+        "conversion",
+        "rayleigh",
+        "annihilation",
+        "mu_ioni",
+        "mu_brems",
+        "mu_pair_prod",
+    };
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//
@@ -116,35 +109,31 @@ char const* to_cstring(ImportProcessClass value)
  */
 char const* to_cstring(ImportModelClass value)
 {
-    CELER_EXPECT(value < ImportModelClass::size_);
-    static char const* const strings[] = {"",
-                                          "bragg_ion",
-                                          "bethe_bloch",
-                                          "urban_msc",
-                                          "icru_73_qo",
-                                          "wentzel_VI_uni",
-                                          "h_brems",
-                                          "h_pair_prod",
-                                          "e_coulomb_scattering",
-                                          "bragg",
-                                          "moller_bhabha",
-                                          "e_brems_sb",
-                                          "e_brems_lpm",
-                                          "e_plus_to_gg",
-                                          "livermore_photoelectric",
-                                          "klein_nishina",
-                                          "bethe_heitler",
-                                          "bethe_heitler_lpm",
-                                          "livermore_rayleigh",
-                                          "mu_bethe_bloch",
-                                          "mu_brems",
-                                          "mu_pair_prod"};
-    static_assert(static_cast<unsigned int>(ImportModelClass::size_)
-                          * sizeof(char const*)
-                      == sizeof(strings),
-                  "Enum strings are incorrect");
-
-    return strings[static_cast<unsigned int>(value)];
+    static EnumStringMapper<ImportModelClass> const to_cstring_impl{
+        "",
+        "bragg_ion",
+        "bethe_bloch",
+        "urban_msc",
+        "icru_73_qo",
+        "wentzel_VI_uni",
+        "h_brems",
+        "h_pair_prod",
+        "e_coulomb_scattering",
+        "bragg",
+        "moller_bhabha",
+        "e_brems_sb",
+        "e_brems_lpm",
+        "e_plus_to_gg",
+        "livermore_photoelectric",
+        "klein_nishina",
+        "bethe_heitler",
+        "bethe_heitler_lpm",
+        "livermore_rayleigh",
+        "mu_bethe_bloch",
+        "mu_brems",
+        "mu_pair_prod",
+    };
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//
@@ -153,9 +142,7 @@ char const* to_cstring(ImportModelClass value)
  */
 char const* to_geant_name(ImportProcessClass value)
 {
-    CELER_EXPECT(value != ImportProcessClass::size_);
-
-    static char const* const strings[] = {
+    static EnumStringMapper<ImportProcessClass> const to_name_impl{
         "",  // unknown,
         "ionIoni",  // ion_ioni,
         "msc",  // msc,
@@ -174,12 +161,7 @@ char const* to_geant_name(ImportProcessClass value)
         "muBrems",  // mu_brems,
         "muPairProd",  // mu_pair_prod,
     };
-    static_assert(static_cast<unsigned int>(ImportProcessClass::size_)
-                          * sizeof(char const*)
-                      == sizeof(strings),
-                  "Enum strings are incorrect");
-
-    return strings[static_cast<unsigned int>(value)];
+    return to_name_impl(value);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/io/ImportProcess.cc
+++ b/src/celeritas/io/ImportProcess.cc
@@ -13,7 +13,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/EnumArray.hh"
 #include "corecel/cont/Range.hh"
-#include "corecel/io/StringEnumMap.hh"
+#include "corecel/io/StringEnumMapper.hh"
 
 namespace celeritas
 {
@@ -192,7 +192,7 @@ char const* to_geant_name(ImportProcessClass value)
 ImportProcessClass geant_name_to_import_process_class(std::string const& s)
 {
     static auto const from_string
-        = StringEnumMap<ImportProcessClass>::from_cstring_func(
+        = StringEnumMapper<ImportProcessClass>::from_cstring_func(
             to_geant_name, "process class");
 
     return from_string(s);

--- a/src/celeritas/phys/PrimaryGeneratorOptions.hh
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.hh
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/io/StringEnumMap.hh"
+#include "corecel/io/StringEnumMapper.hh"
 
 #include "PDGNumber.hh"
 

--- a/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
@@ -14,7 +14,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/ArrayIO.json.hh"
 #include "corecel/cont/Range.hh"
-#include "corecel/io/StringEnumMap.hh"
+#include "corecel/io/StringEnumMapper.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
 
@@ -54,7 +54,7 @@ char const* to_cstring(DistributionSelection value)
 void from_json(nlohmann::json const& j, DistributionSelection& value)
 {
     static auto from_string
-        = StringEnumMap<DistributionSelection>::from_cstring_func(
+        = StringEnumMapper<DistributionSelection>::from_cstring_func(
             to_cstring, "distribution type");
     value = from_string(j.get<std::string>());
 }

--- a/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
@@ -14,6 +14,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/ArrayIO.json.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/io/EnumStringMapper.hh"
 #include "corecel/io/StringEnumMapper.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
@@ -30,19 +31,12 @@ namespace
  */
 char const* to_cstring(DistributionSelection value)
 {
-    CELER_EXPECT(value != DistributionSelection::size_);
-
-    static char const* const strings[] = {
+    static EnumStringMapper<DistributionSelection> const to_cstring_impl{
         "delta",
         "isotropic",
         "box",
     };
-    static_assert(
-        static_cast<int>(DistributionSelection::size_) * sizeof(char const*)
-            == sizeof(strings),
-        "Enum strings are incorrect");
-
-    return strings[static_cast<int>(value)];
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/EnumStringMapper.hh
+++ b/src/corecel/io/EnumStringMapper.hh
@@ -1,0 +1,61 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/io/EnumStringMapper.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Assert.hh"
+#include "corecel/cont/Array.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Map enums to strings for user output.
+ *
+ * This should generally be a static const class.
+ */
+template<class T>
+class EnumStringMapper
+{
+    static_assert(std::is_enum<T>::value, "not an enum type");
+    static_assert(static_cast<int>(T::size_) >= 0, "invalid enum type");
+
+  public:
+    //! Construct with one string per valid enum value
+    template<class... Ts>
+    explicit CELER_CONSTEXPR_FUNCTION EnumStringMapper(Ts... strings)
+        : strings_{strings...}
+    {
+        // Protect against leaving off a string
+        static_assert(sizeof...(strings) == static_cast<size_type>(T::size_),
+                      "All strings (except size_) must be explicitly given");
+    }
+
+    // Convert from a string
+    inline char const* operator()(T value) const;
+
+  private:
+    using size_type = std::underlying_type_t<T>;
+
+    Array<char const*, static_cast<size_type>(T::size_)> const strings_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Convert an enum to the corresponding string.
+ */
+template<class T>
+char const* EnumStringMapper<T>::operator()(T value) const
+{
+    CELER_EXPECT(value < T::size_);
+    return strings_[static_cast<size_type>(value)];
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/io/OutputInterface.cc
+++ b/src/corecel/io/OutputInterface.cc
@@ -9,6 +9,7 @@
 
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
+#include "corecel/io/EnumStringMapper.hh"
 
 #include "JsonPimpl.hh"
 #if CELERITAS_USE_JSON
@@ -25,20 +26,13 @@ namespace celeritas
  */
 char const* to_cstring(Category value)
 {
-    CELER_EXPECT(value != Category::size_);
-
-    static char const* const strings[] = {
+    static EnumStringMapper<Category> const to_cstring_impl{
         "input",
         "result",
         "system",
         "internal",
     };
-    static_assert(
-        static_cast<unsigned int>(Category::size_) * sizeof(char const*)
-            == sizeof(strings),
-        "Enum strings are incorrect");
-
-    return strings[static_cast<unsigned int>(value)];
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/StringEnumMapper.hh
+++ b/src/corecel/io/StringEnumMapper.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/io/StringEnumMap.hh
+//! \file corecel/io/StringEnumMapper.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -30,14 +30,14 @@ namespace celeritas
 void from_json(const nlohmann::json& j, GeantSetupOptions& opts)
 {
     static auto gspl_from_string
-        = StringEnumMap<PhysicsList>::from_cstring_func(
+        = StringEnumMapper<PhysicsList>::from_cstring_func(
             to_cstring, "physics list");
     opts.physics = gspl_from_string(j.at("physics").get<std::string>());
 }
    \endcode
  */
 template<class T>
-class StringEnumMap
+class StringEnumMapper
 {
     static_assert(std::is_enum<T>::value, "not an enum type");
     static_assert(static_cast<int>(T::size_) >= 0, "invalid enum type");
@@ -50,13 +50,13 @@ class StringEnumMap
 
   public:
     // Construct from a "to_cstring" function pointer
-    static inline StringEnumMap<T>
+    static inline StringEnumMapper<T>
     from_cstring_func(EnumCStringFuncPtr, char const* desc = nullptr);
 
     // Construct with a function that takes an enum and returns a stringlike
     template<class U>
-    explicit inline StringEnumMap(U&& enum_to_string,
-                                  char const* desc = nullptr);
+    explicit inline StringEnumMapper(U&& enum_to_string,
+                                     char const* desc = nullptr);
 
     // Convert from a string
     inline T operator()(std::string const& s) const;
@@ -73,11 +73,11 @@ class StringEnumMap
  * Construct using a \c to_cstring function.
  */
 template<class T>
-StringEnumMap<T>
-StringEnumMap<T>::from_cstring_func(EnumCStringFuncPtr fp, char const* desc)
+StringEnumMapper<T>
+StringEnumMapper<T>::from_cstring_func(EnumCStringFuncPtr fp, char const* desc)
 {
     CELER_EXPECT(fp);
-    return StringEnumMap<T>{fp, desc};
+    return StringEnumMapper<T>{fp, desc};
 }
 
 //---------------------------------------------------------------------------//
@@ -88,7 +88,7 @@ StringEnumMap<T>::from_cstring_func(EnumCStringFuncPtr fp, char const* desc)
  */
 template<class T>
 template<class U>
-StringEnumMap<T>::StringEnumMap(U&& enum_to_string, char const* desc)
+StringEnumMapper<T>::StringEnumMapper(U&& enum_to_string, char const* desc)
     : description_(desc)
 {
     map_.reserve(static_cast<std::size_t>(T::size_));
@@ -104,7 +104,7 @@ StringEnumMap<T>::StringEnumMap(U&& enum_to_string, char const* desc)
  * Convert a string to the corresponding enum.
  */
 template<class T>
-T StringEnumMap<T>::operator()(std::string const& s) const
+T StringEnumMapper<T>::operator()(std::string const& s) const
 {
     auto result = map_.find(s);
     CELER_VALIDATE(result != map_.end(),

--- a/src/orange/OrangeTypes.cc
+++ b/src/orange/OrangeTypes.cc
@@ -8,6 +8,7 @@
 #include "OrangeTypes.hh"
 
 #include "corecel/Assert.hh"
+#include "corecel/io/EnumStringMapper.hh"
 
 namespace celeritas
 {
@@ -17,9 +18,8 @@ namespace celeritas
  */
 char const* to_cstring(SurfaceType value)
 {
-    CELER_EXPECT(value != SurfaceType::size_);
-
-    static char const* const strings[] = {
+    static EnumStringMapper<SurfaceType> const to_cstring_impl
+    {
         "px",
         "py",
         "pz",
@@ -42,12 +42,7 @@ char const* to_cstring(SurfaceType value)
 #endif
         "gq",
     };
-    static_assert(
-        static_cast<unsigned int>(SurfaceType::size_) * sizeof(char const*)
-            == sizeof(strings),
-        "Enum strings are incorrect");
-
-    return strings[static_cast<unsigned int>(value)];
+    return to_cstring_impl(value);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -20,7 +20,7 @@
 #include "corecel/cont/Label.hh"
 #include "corecel/cont/LabelIO.json.hh"
 #include "corecel/cont/Range.hh"
-#include "corecel/io/StringEnumMap.hh"
+#include "corecel/io/StringEnumMapper.hh"
 #include "orange/BoundingBox.hh"
 #include "orange/OrangeTypes.hh"
 #include "orange/construct/OrangeInput.hh"
@@ -36,8 +36,8 @@ namespace
 SurfaceType to_surface_type(std::string const& s)
 {
     static auto const from_string
-        = StringEnumMap<SurfaceType>::from_cstring_func(to_cstring,
-                                                        "surface type");
+        = StringEnumMapper<SurfaceType>::from_cstring_func(to_cstring,
+                                                           "surface type");
     return from_string(s);
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,6 +137,7 @@ celeritas_add_device_test(corecel/data/StackAllocator)
 
 # IO
 set(CELERITASTEST_PREFIX corecel/io)
+celeritas_add_test(corecel/io/EnumStringMapper.test.cc)
 celeritas_add_test(corecel/io/Join.test.cc)
 celeritas_add_test(corecel/io/Logger.test.cc)
 celeritas_add_test(corecel/io/OutputManager.test.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -142,7 +142,7 @@ celeritas_add_test(corecel/io/Logger.test.cc)
 celeritas_add_test(corecel/io/OutputManager.test.cc
   LINK_LIBRARIES ${_optional_json_link})
 celeritas_add_test(corecel/io/Repr.test.cc)
-celeritas_add_test(corecel/io/StringEnumMap.test.cc)
+celeritas_add_test(corecel/io/StringEnumMapper.test.cc)
 celeritas_add_test(corecel/io/StringUtils.test.cc)
 
 # Math

--- a/test/corecel/cont/Range.test.cc
+++ b/test/corecel/cont/Range.test.cc
@@ -214,10 +214,6 @@ TEST(RangeTest, enum_step)
     EXPECT_TRUE((std::is_same<std::underlying_type<pokemon::Pokemon>::type,
                               unsigned int>::value));
 
-    /*!
-     * The following should fail to compile because enums cannot be added to
-     * ints.
-     */
     std::vector<int> vals;
     for (auto p : range(pokemon::size_).step(3u))
     {
@@ -253,7 +249,8 @@ TEST(RangeTest, enum_classes)
     EXPECT_VEC_EQ((VecInt{0, 2}), vals);
 
     /*!
-     * The following should fail because the enum doesn't have a size_ member.
+     * The following should fail to compile because the enum doesn't have a
+     * size_ member.
      *
      * \verbatim
      * ../src/base/detail/RangeImpl.hh:61:24: error: no member named 'size_' in

--- a/test/corecel/io/EnumStringMapper.test.cc
+++ b/test/corecel/io/EnumStringMapper.test.cc
@@ -45,6 +45,8 @@ TEST(EnumStringMapperTest, all)
     }
 }
 
+// The following instances should fail to compile.
+#if 0
 TEST(EnumStringMapperTest, compiler_error)
 {
     static EnumStringMapper<CeleritasLabs> const too_short{"argonne", "ornl"};
@@ -52,6 +54,7 @@ TEST(EnumStringMapperTest, compiler_error)
         "argonne", "ornl", "foo", "bar"};
     static EnumStringMapper<InvalidEnum> const no_size{"foo", "bar"};
 }
+#endif
 
 //---------------------------------------------------------------------------//
 }  // namespace test

--- a/test/corecel/io/EnumStringMapper.test.cc
+++ b/test/corecel/io/EnumStringMapper.test.cc
@@ -1,0 +1,58 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/io/EnumStringMapper.test.cc
+//---------------------------------------------------------------------------//
+#include "corecel/io/EnumStringMapper.hh"
+
+#include "celeritas_test.hh"
+// #include "EnumStringMapper.test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+enum class CeleritasLabs
+{
+    argonne,
+    fermilab,
+    ornl,
+    size_
+};
+
+enum class InvalidEnum
+{
+    foo,
+    bar
+};
+
+//---------------------------------------------------------------------------//
+
+TEST(EnumStringMapperTest, all)
+{
+    static EnumStringMapper<CeleritasLabs> const to_string{
+        "argonne", "fermilab", "ornl"};
+
+    EXPECT_STREQ("argonne", to_string(CeleritasLabs::argonne));
+    EXPECT_STREQ("fermilab", to_string(CeleritasLabs::fermilab));
+    EXPECT_STREQ("ornl", to_string(CeleritasLabs::ornl));
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(to_string(CeleritasLabs::size_), DebugError);
+    }
+}
+
+TEST(EnumStringMapperTest, compiler_error)
+{
+    static EnumStringMapper<CeleritasLabs> const too_short{"argonne", "ornl"};
+    static EnumStringMapper<CeleritasLabs> const too_long{
+        "argonne", "ornl", "foo", "bar"};
+    static EnumStringMapper<InvalidEnum> const no_size{"foo", "bar"};
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/corecel/io/StringEnumMapper.test.cc
+++ b/test/corecel/io/StringEnumMapper.test.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/io/StringEnumMap.test.cc
+//! \file corecel/io/StringEnumMapper.test.cc
 //---------------------------------------------------------------------------//
-#include "corecel/io/StringEnumMap.hh"
+#include "corecel/io/StringEnumMapper.hh"
 
 #include <algorithm>
 #include <cctype>
@@ -43,9 +43,9 @@ char const* to_cstring(SomeOtherEnum);
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST(StringEnumMapTest, from_cstring)
+TEST(StringEnumMapperTest, from_cstring)
 {
-    auto from_string = StringEnumMap<CeleritasLabs>::from_cstring_func(
+    auto from_string = StringEnumMapper<CeleritasLabs>::from_cstring_func(
         to_cstring, "lab name");
 
     EXPECT_EQ(CeleritasLabs::argonne, from_string("argonne"));
@@ -54,7 +54,7 @@ TEST(StringEnumMapTest, from_cstring)
     EXPECT_THROW(from_string("inl"), RuntimeError);
 }
 
-TEST(StringEnumMapTest, from_generic)
+TEST(StringEnumMapperTest, from_generic)
 {
     auto capstring = [](CeleritasLabs lab) -> std::string {
         std::string temp = to_cstring(lab);
@@ -65,7 +65,7 @@ TEST(StringEnumMapTest, from_generic)
         return temp;
     };
 
-    StringEnumMap<CeleritasLabs> from_string(capstring);
+    StringEnumMapper<CeleritasLabs> from_string(capstring);
 
     EXPECT_EQ(CeleritasLabs::argonne, from_string("ARGONNE"));
     EXPECT_EQ(CeleritasLabs::fermilab, from_string("FERMILAB"));


### PR DESCRIPTION
This defines a small helper class to improve the safety of enum->string mapping and reduce the amount of code we have to use to do it.