### PR TITLE
Fix NaN/assertion when taking extremely small steps in a field

### DIFF
--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -164,7 +164,14 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // extra.
         if (chord.length >= driver_.minimum_step())
         {
-            // Only update the direction if the chord length is nontrivial
+            // Only update the direction if the chord length is nontrivial.
+            // This is usually the case but might be skipped in two cases:
+            // - if the initial step is very small compared to the
+            //   magnitude of the position (which can result in a zero length
+            //   for the chord and NaNs for the direction)
+            // - in a high-curvature track where the remaining distance is just
+            //   barely above the remaining minimum step (in which case our
+            //   boundary test does lose some accuracy)
             geo_.set_dir(chord.dir);
         }
         auto linear_step

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -162,7 +162,11 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // Do a detailed check boundary check from the start position toward
         // the substep end point. Travel to the end of the chord, plus a little
         // extra.
-        geo_.set_dir(chord.dir);
+        if (chord.length >= driver_.minimum_step())
+        {
+            // Only update the direction if the chord length is nontrivial
+            geo_.set_dir(chord.dir);
+        }
         auto linear_step
             = geo_.find_next_step(chord.length + driver_.delta_intersection());
         if (!linear_step.boundary)

--- a/src/celeritas/field/detail/FieldUtils.hh
+++ b/src/celeritas/field/detail/FieldUtils.hh
@@ -62,10 +62,9 @@ inline CELER_FUNCTION Chord make_chord(Real3 const& src, Real3 const& dst)
         result.dir[i] = dst[i] - src[i];
     }
     result.length = norm(result.dir);
-    const real_type norm = 1 / result.length;
     for (int i = 0; i < 3; ++i)
     {
-        result.dir[i] *= norm;
+        result.dir[i] /= result.length;
     }
     return result;
 }

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -472,16 +472,17 @@ TEST_F(TwoBoxTest, electron_super_small_step)
         this->particle()->find(pdg::electron()), MevEnergy{2});
     UniformZField field(1 * units::tesla);
     FieldDriverOptions driver_options;
-    constexpr real_type delta = 1e-14;
-
+    for (real_type delta : {1e-14, 1e-8, 1e-2, 0.1})
     {
         auto geo = this->init_geo({90, 90, 90}, {1, 0, 0});
-
-        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+        auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
+            field, particle.charge());
+        auto propagate
+            = make_field_propagator(stepper, driver_options, particle, &geo);
         auto result = propagate(delta);
 
         EXPECT_DOUBLE_EQ(delta, result.distance);
+        EXPECT_EQ(1, stepper.count());
     }
 }
 

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -466,6 +466,25 @@ TEST_F(TwoBoxTest, gamma_exit)
     }
 }
 
+TEST_F(TwoBoxTest, electron_super_small_step)
+{
+    auto particle = this->init_particle(
+        this->particle()->find(pdg::electron()), MevEnergy{2});
+    UniformZField field(1 * units::tesla);
+    FieldDriverOptions driver_options;
+    constexpr real_type delta = 1e-14;
+
+    {
+        auto geo = this->init_geo({90, 90, 90}, {1, 0, 0});
+
+        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
+            field, driver_options, particle, &geo);
+        auto result = propagate(delta);
+
+        EXPECT_DOUBLE_EQ(delta, result.distance);
+    }
+}
+
 // Electron takes small steps up to and from a boundary
 TEST_F(TwoBoxTest, electron_small_step)
 {

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -524,7 +524,7 @@ TEST_F(TwoBoxTest, electron_small_step)
         auto result = propagate(2 * delta);
 
         // Distance is the linear step
-        EXPECT_DOUBLE_EQ(1.0000000028043181e-07, result.distance);
+        EXPECT_SOFT_EQ(1.0000000028043181e-07, result.distance);
         EXPECT_TRUE(result.boundary);
         EXPECT_TRUE(geo.is_on_boundary());
         EXPECT_VEC_SOFT_EQ(Real3({5, 0, 0}), geo.pos());
@@ -976,17 +976,17 @@ TEST_F(TwoBoxTest, electron_tangent_cross_smallradius)
 
     static int const expected_boundary[] = {1, 1, 1, 1, 1, 0, 1, 0, 1, 0};
     EXPECT_VEC_EQ(expected_boundary, boundary);
-    static double const expected_distances[] = {0.0078539816339744,
-                                                0.0028233449997633,
-                                                0.0044879895051283,
-                                                0.0028259703523794,
+    static double const expected_distances[] = {0.00785398163,
+                                                0.00282334500,
+                                                0.00448798951,
+                                                0.00282597035,
                                                 1e-05,
                                                 1e-05,
                                                 1e-08,
                                                 1e-08,
-                                                9.9937975537864e-12,
+                                                9.99379755e-12,
                                                 1e-11};
-    EXPECT_VEC_SOFT_EQ(expected_distances, distances);
+    EXPECT_VEC_NEAR(expected_distances, distances, 1e-5);
     static int const expected_substeps[] = {4, 63, 3, 14, 1, 1, 1, 1, 1, 1};
 
     EXPECT_VEC_EQ(expected_substeps, substeps);
@@ -1161,7 +1161,7 @@ TEST_F(SimpleCmsTest, electron_stuck)
             = make_field_propagator(stepper, driver_options, particle, &geo);
         auto result = propagate(1000);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
-        EXPECT_EQ(92, stepper.count());
+        EXPECT_EQ(CELERITAS_USE_VECGEOM ? 93 : 92, stepper.count());
         ASSERT_TRUE(geo.is_on_boundary());
         if (!CELERITAS_USE_VECGEOM)
         {


### PR DESCRIPTION
See #618 for a description of the problem. If the chord is super small, the starting direction (which is kept in sync with the field state momentum) will be very close to the expected chord direction. This holds even when the chord length is zero. Therefore *only* update the trial direction for nontrivial (i.e. greater than the driver's "minimum step") distances.

Fixes #618