### PR TITLE
Use ProcessBuilder for ROOT and Geant4 tests

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #include "LDemoIO.hh"
 
-#include <set>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -68,26 +67,6 @@ void from_json(nlohmann::json const& j, EnergyDiagInput& v)
 }
 //!@}
 //---------------------------------------------------------------------------//
-
-namespace
-{
-//---------------------------------------------------------------------------//
-// HELPER FUNCTIONS
-//---------------------------------------------------------------------------//
-//! Get the set of all process classes in the input
-auto get_all_process_classes(std::vector<ImportProcess> const& processes)
-    -> decltype(auto)
-{
-    std::set<ImportProcessClass> result;
-    for (auto const& p : processes)
-    {
-        result.insert(p.process_class);
-    }
-    return result;
-}
-
-//---------------------------------------------------------------------------//
-}  // namespace
 
 //---------------------------------------------------------------------------//
 //!@{
@@ -281,10 +260,8 @@ TransporterInput load_input(LDemoArgs const& args)
 
             ProcessBuilder build_process(
                 imported_data, params.particle, params.material, opts);
-            // TODO: there's got to be a cleaner way to get the set of all
-            // processes: maybe better to change how the ImportData is
-            // structured
-            for (auto p : get_all_process_classes(imported_data.processes))
+            for (auto p : ProcessBuilder::get_all_process_classes(
+                     imported_data.processes))
             {
                 input.processes.push_back(build_process(p));
                 CELER_ASSERT(input.processes.back());

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -9,7 +9,6 @@
 
 #include <fstream>
 #include <memory>
-#include <set>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -87,16 +86,9 @@ build_processes(ImportData const& imported,
     ProcessBuilder::Options opts;
     ProcessBuilder build_process(imported, particle, material, ignore, opts);
 
-    // Get the set of all user-input processes
-    std::set<ImportProcessClass> all_process_classes;
-    for (auto const& p : imported.processes)
-    {
-        all_process_classes.insert(p.process_class);
-    }
-
     // Build proceses
     std::vector<std::shared_ptr<Process const>> result;
-    for (auto p : all_process_classes)
+    for (auto p : ProcessBuilder::get_all_process_classes(imported.processes))
     {
         result.push_back(build_process(p));
         if (!result.back())

--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -78,5 +78,20 @@ struct GeantPhysicsOptions
     real_type linear_loss_limit{0.01};
 };
 
+//! Equality operator, mainly for test harness
+// TODO: when we require C++20, use `friend bool operator==(...) = default;`
+constexpr bool
+operator==(GeantPhysicsOptions const& a, GeantPhysicsOptions const& b)
+{
+    return a.coulomb_scattering == b.coulomb_scattering
+           && a.rayleigh_scattering == b.rayleigh_scattering
+           && a.eloss_fluctuation == b.eloss_fluctuation && a.lpm == b.lpm
+           && a.integral_approach == b.integral_approach && a.brems == b.brems
+           && a.msc == b.msc && a.relaxation == b.relaxation
+           && a.em_bins_per_decade == b.em_bins_per_decade
+           && a.min_energy == b.min_energy && a.max_energy == b.max_energy
+           && a.linear_loss_limit == b.linear_loss_limit;
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/phys/ProcessBuilder.cc
+++ b/src/celeritas/phys/ProcessBuilder.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "ProcessBuilder.hh"
 
+#include <set>
 #include <unordered_map>
 #include <utility>
 
@@ -29,6 +30,21 @@
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+/*!
+ * Get an ordered set of all available processes.
+ */
+auto ProcessBuilder::get_all_process_classes(
+    std::vector<ImportProcess> const& processes) -> std::set<IPC>
+{
+    std::set<ImportProcessClass> result;
+    for (auto const& p : processes)
+    {
+        result.insert(p.process_class);
+    }
+    return result;
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Construct imported process data.

--- a/src/celeritas/phys/ProcessBuilder.hh
+++ b/src/celeritas/phys/ProcessBuilder.hh
@@ -9,7 +9,9 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <unordered_map>
+#include <vector>
 
 #include "celeritas/io/ImportProcess.hh"
 #include "celeritas/phys/AtomicNumber.hh"
@@ -25,6 +27,13 @@ class ParticleParams;
 struct ImportData;
 struct ImportLivermorePE;
 struct ImportSBTable;
+
+//---------------------------------------------------------------------------//
+//! Options used for constructing built-in Celeritas processes
+struct ProcessBuilderOptions
+{
+    bool brem_combined{false};
+};
 
 //---------------------------------------------------------------------------//
 /*!
@@ -51,16 +60,12 @@ class ProcessBuilder
     //!@{
     //! \name Type aliases
     using IPC = ImportProcessClass;
+    using Options = ProcessBuilderOptions;
     using SPProcess = std::shared_ptr<Process>;
     using SPConstParticle = std::shared_ptr<ParticleParams const>;
     using SPConstMaterial = std::shared_ptr<MaterialParams const>;
     using SPConstImported = std::shared_ptr<ImportedProcesses const>;
     //!@}
-
-    struct Options
-    {
-        bool brem_combined{false};
-    };
 
     //! Input argument for user-provided process construction
     struct UserBuildInput
@@ -77,6 +82,10 @@ class ProcessBuilder
     //!@}
 
   public:
+    // Get an ordered set of all available processes
+    static std::set<IPC>
+    get_all_process_classes(std::vector<ImportProcess> const& processes);
+
     // Construct from imported and shared data and user construction
     ProcessBuilder(ImportData const& data,
                    SPConstParticle particle,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -233,6 +233,7 @@ celeritas_add_library(testcel_celeritas
   celeritas/GlobalGeoTestBase.cc
   celeritas/ImportedDataTestBase.cc
   celeritas/MockTestBase.cc
+  celeritas/RootTestBase.cc
   celeritas/SimpleTestBase.cc
   celeritas/global/AlongStepTestBase.cc
   celeritas/global/StepperTestBase.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -231,6 +231,7 @@ celeritas_add_library(testcel_celeritas
   celeritas/GeantTestBase.cc
   celeritas/GlobalTestBase.cc
   celeritas/GlobalGeoTestBase.cc
+  celeritas/ImportedDataTestBase.cc
   celeritas/MockTestBase.cc
   celeritas/SimpleTestBase.cc
   celeritas/global/AlongStepTestBase.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -326,16 +326,32 @@ celeritas_add_test(celeritas/geo/GeoMaterial.test.cc
 # Global
 set(CELERITASTEST_PREFIX celeritas/global)
 celeritas_add_test(celeritas/global/ActionRegistry.test.cc)
+
+if(CELERITAS_USE_Geant4)
+  set(_filter
+    FILTER
+      "KnAlongStepTest.*"
+      "Em3AlongStepTest.nofluct_nomsc"
+      "Em3AlongStepTest.msc_nofluct"
+      "Em3AlongStepTest.fluct_nomsc"
+  )
+else()
+  set(_filter)
+endif()
 celeritas_add_test(celeritas/global/AlongStep.test.cc
-  ${_optional_geant4_env} NT 1)
+  NT 1 ${_optional_geant4_env} ${_filter}
+)
 celeritas_add_test(celeritas/global/KernelContextException.test.cc NT 1
-  LINK_LIBRARIES ${_optional_json_link})
+  LINK_LIBRARIES ${_optional_json_link}
+)
 celeritas_add_test(celeritas/global/Stepper.test.cc
   GPU NT 4 ${_needs_geant4}
   FILTER
     # NOTE: these can be run in the same invocation once Geant4 reload works
-    "TestEm3*"
-    "TestEm15FieldTest.*"
+    "TestEm3NoMsc.*"
+    "TestEm3Msc.*"
+    "TestEm3MscNofluct.*"
+    "TestEm15Field.*"
 )
 
 #-------------------------------------#

--- a/test/celeritas/GeantTestBase.hh
+++ b/test/celeritas/GeantTestBase.hh
@@ -19,6 +19,7 @@ namespace celeritas
 {
 struct ImportData;
 struct PhysicsParamsOptions;
+struct GeantPhysicsOptions;
 }  // namespace celeritas
 
 namespace celeritas
@@ -52,8 +53,6 @@ class GeantTestBase : virtual public GlobalGeoTestBase
     //!@}
 
   protected:
-    virtual bool enable_fluctuation() const = 0;
-    virtual bool enable_msc() const = 0;
     virtual bool combined_brems() const = 0;
     virtual real_type secondary_stack_factor() const = 0;
 
@@ -66,9 +65,16 @@ class GeantTestBase : virtual public GlobalGeoTestBase
     SPConstAction build_along_step() override;
 
     virtual PhysicsOptions build_physics_options() const;
+    virtual GeantPhysicsOptions build_geant_options() const;
 
-    // Access lazily (re)loaded static geant4 data
+    // Access lazily loaded static geant4 data
     ImportData const& imported_data() const;
+
+  private:
+    struct ImportHelper;
+    class CleanupGeantEnvironment;
+
+    static ImportHelper& import_helper();
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/GeantTestBase.hh
+++ b/test/celeritas/GeantTestBase.hh
@@ -11,33 +11,23 @@
 
 #include "celeritas/Types.hh"
 
-#include "GlobalGeoTestBase.hh"
+#include "ImportedDataTestBase.hh"
 
 class G4VPhysicalVolume;
 
 namespace celeritas
 {
-struct ImportData;
-struct PhysicsParamsOptions;
+//---------------------------------------------------------------------------//
 struct GeantPhysicsOptions;
-}  // namespace celeritas
 
-namespace celeritas
-{
 namespace test
 {
 //---------------------------------------------------------------------------//
 /*!
- * Test harness for simple Geant4 testem3-like problems.
+ * Test harness for loading problem data through Geant4.
  */
-class GeantTestBase : virtual public GlobalGeoTestBase
+class GeantTestBase : public ImportedDataTestBase
 {
-  public:
-    //!@{
-    //! \name Type aliases
-    using PhysicsOptions = PhysicsParamsOptions;
-    //!@}
-
   public:
     //!@{
     //! Whether the Geant4 configuration match a certain machine
@@ -53,22 +43,13 @@ class GeantTestBase : virtual public GlobalGeoTestBase
     //!@}
 
   protected:
-    virtual bool combined_brems() const = 0;
-    virtual real_type secondary_stack_factor() const = 0;
+    virtual GeantPhysicsOptions build_geant_options() const;
 
-    SPConstMaterial build_material() override;
-    SPConstGeoMaterial build_geomaterial() override;
-    SPConstParticle build_particle() override;
-    SPConstCutoff build_cutoff() override;
-    SPConstPhysics build_physics() override;
     SPConstTrackInit build_init() override;
     SPConstAction build_along_step() override;
 
-    virtual PhysicsOptions build_physics_options() const;
-    virtual GeantPhysicsOptions build_geant_options() const;
-
     // Access lazily loaded static geant4 data
-    ImportData const& imported_data() const;
+    ImportData const& imported_data() const final;
 
   private:
     struct ImportHelper;

--- a/test/celeritas/GlobalGeoTestBase.cc
+++ b/test/celeritas/GlobalGeoTestBase.cc
@@ -20,6 +20,20 @@ namespace celeritas
 namespace test
 {
 //---------------------------------------------------------------------------//
+struct GlobalGeoTestBase::LazyGeo
+{
+    std::string basename{};
+    SPConstGeo geo{};
+};
+
+class GlobalGeoTestBase::CleanupGeoEnvironment : public ::testing::Environment
+{
+  public:
+    void SetUp() override {}
+    void TearDown() override { GlobalGeoTestBase::reset_geometry(); }
+};
+
+//---------------------------------------------------------------------------//
 auto GlobalGeoTestBase::build_geometry() -> SPConstGeo
 {
     auto& lazy = GlobalGeoTestBase::lazy_geo();

--- a/test/celeritas/GlobalGeoTestBase.hh
+++ b/test/celeritas/GlobalGeoTestBase.hh
@@ -39,19 +39,9 @@ class GlobalGeoTestBase : virtual public GlobalTestBase
   private:
     //// LAZY GEOMETRY CONSTRUCTION AND CLEANUP FOR VECGEOM ////
 
-    struct LazyGeo
-    {
-        std::string basename{};
-        SPConstGeo geo{};
-    };
-
+    struct LazyGeo;
+    class CleanupGeoEnvironment;
     static LazyGeo& lazy_geo();
-
-    class CleanupGeoEnvironment : public ::testing::Environment
-    {
-        void SetUp() override {}
-        void TearDown() override { GlobalGeoTestBase::reset_geometry(); }
-    };
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ImportedDataTestBase.cc
+++ b/test/celeritas/ImportedDataTestBase.cc
@@ -1,0 +1,117 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ImportedDataTestBase.cc
+//---------------------------------------------------------------------------//
+#include "ImportedDataTestBase.hh"
+
+#include "celeritas/geo/GeoMaterialParams.hh"
+#include "celeritas/io/ImportData.hh"
+#include "celeritas/mat/MaterialParams.hh"
+#include "celeritas/phys/CutoffParams.hh"
+#include "celeritas/phys/ParticleParams.hh"
+#include "celeritas/phys/PhysicsParams.hh"
+#include "celeritas/phys/ProcessBuilder.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+auto ImportedDataTestBase::build_process_options() const
+    -> ProcessBuilderOptions
+{
+    return {};
+}
+
+//---------------------------------------------------------------------------//
+auto ImportedDataTestBase::build_physics_options() const -> PhysicsOptions
+{
+    PhysicsOptions options;
+    options.secondary_stack_factor = 3.0;
+    return options;
+}
+
+//---------------------------------------------------------------------------//
+auto ImportedDataTestBase::build_material() -> SPConstMaterial
+{
+    return MaterialParams::from_import(this->imported_data());
+}
+
+//---------------------------------------------------------------------------//
+auto ImportedDataTestBase::build_geomaterial() -> SPConstGeoMaterial
+{
+    return GeoMaterialParams::from_import(
+        this->imported_data(), this->geometry(), this->material());
+}
+
+//---------------------------------------------------------------------------//
+auto ImportedDataTestBase::build_particle() -> SPConstParticle
+{
+    return ParticleParams::from_import(this->imported_data());
+}
+
+//---------------------------------------------------------------------------//
+auto ImportedDataTestBase::build_cutoff() -> SPConstCutoff
+{
+    return CutoffParams::from_import(
+        this->imported_data(), this->particle(), this->material());
+}
+
+//---------------------------------------------------------------------------//
+auto ImportedDataTestBase::build_physics() -> SPConstPhysics
+{
+    using IPC = celeritas::ImportProcessClass;
+
+    PhysicsParams::Input input;
+    input.materials = this->material();
+    input.particles = this->particle();
+    input.options = this->build_physics_options();
+    input.action_registry = this->action_reg().get();
+
+    // Build proceses
+    auto const& imported = this->imported_data();
+    ProcessBuilder build_process(imported,
+                                 input.particles,
+                                 input.materials,
+                                 this->build_process_options());
+
+    // Start with the ordering of processes from the original test harness
+    std::vector<IPC> ipc{
+        IPC::compton,
+        IPC::photoelectric,
+        IPC::conversion,
+        IPC::annihilation,
+        IPC::e_ioni,
+        IPC::e_brems,
+    };
+    auto all_ipc = ProcessBuilder::get_all_process_classes(imported.processes);
+
+    // Remove missing processes from `ipc` and found processes from `all_ipc`
+    ipc.erase(std::remove_if(ipc.begin(),
+                             ipc.end(),
+                             [&all_ipc](ImportProcessClass i) {
+                                 auto iter = all_ipc.find(i);
+                                 if (iter == all_ipc.end())
+                                     return true;
+                                 all_ipc.erase(iter);
+                                 return false;
+                             }),
+              ipc.end());
+    // Add processes not in the original list to the end of the vector
+    ipc.insert(ipc.end(), all_ipc.begin(), all_ipc.end());
+
+    for (auto p : ipc)
+    {
+        input.processes.push_back(build_process(p));
+        CELER_ASSERT(input.processes.back());
+    }
+
+    return std::make_shared<PhysicsParams>(std::move(input));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/ImportedDataTestBase.hh
+++ b/test/celeritas/ImportedDataTestBase.hh
@@ -1,0 +1,56 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ImportedDataTestBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "GlobalGeoTestBase.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+struct ImportData;
+struct PhysicsParamsOptions;
+struct ProcessBuilderOptions;
+
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Set up Celeritas tests using imported data.
+ *
+ * This is an implementation detail of GeantTestBase and RootTestBase.
+ */
+class ImportedDataTestBase : virtual public GlobalGeoTestBase
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using PhysicsOptions = PhysicsParamsOptions;
+    //!@}
+
+  public:
+    //! Access lazily loaded problem-dependent data
+    virtual ImportData const& imported_data() const = 0;
+
+  protected:
+    // Set up options for loading processes
+    virtual ProcessBuilderOptions build_process_options() const;
+
+    // Set up options for physics
+    virtual PhysicsOptions build_physics_options() const;
+
+    // Implemented overrides that load from import data
+    SPConstMaterial build_material() override;
+    SPConstGeoMaterial build_geomaterial() override;
+    SPConstParticle build_particle() override;
+    SPConstCutoff build_cutoff() override;
+    SPConstPhysics build_physics() override;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/RootTestBase.cc
+++ b/test/celeritas/RootTestBase.cc
@@ -1,0 +1,46 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/RootTestBase.cc
+//---------------------------------------------------------------------------//
+#include "RootTestBase.hh"
+
+#include "celeritas/ext/RootImporter.hh"
+#include "celeritas/ext/ScopedRootErrorHandler.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Lazily load ROOT data.
+ */
+auto RootTestBase::imported_data() const -> ImportData const&
+{
+    static struct
+    {
+        std::string geometry_basename;
+        ImportData imported;
+    } i;
+    std::string geo_basename = this->geometry_basename();
+    if (i.geometry_basename != geo_basename)
+    {
+        ScopedRootErrorHandler scoped_root_error;
+
+        i.geometry_basename = geo_basename;
+        std::string root_inp = this->test_data_path(
+            "celeritas", (i.geometry_basename + ".root").c_str());
+
+        RootImporter import(root_inp.c_str());
+        i.imported = import();
+    }
+    CELER_ENSURE(i.imported);
+    return i.imported;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/RootTestBase.hh
+++ b/test/celeritas/RootTestBase.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/RootTestBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "ImportedDataTestBase.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Test harness for loading problem data from a ROOT file
+ */
+class RootTestBase : public ImportedDataTestBase
+{
+  protected:
+    // Access lazily loaded static ROOT data
+    ImportData const& imported_data() const final;
+
+  private:
+    struct ImportHelper;
+    class CleanupGeantEnvironment;
+
+    static ImportHelper& import_helper();
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/TestEm15Base.hh
+++ b/test/celeritas/TestEm15Base.hh
@@ -21,8 +21,6 @@ class TestEm15Base : public GeantTestBase
 {
   protected:
     char const* geometry_basename() const override { return "testem15"; }
-    bool combined_brems() const override { return false; }
-    real_type secondary_stack_factor() const override { return 3.0; }
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/TestEm15Base.hh
+++ b/test/celeritas/TestEm15Base.hh
@@ -21,8 +21,6 @@ class TestEm15Base : public GeantTestBase
 {
   protected:
     char const* geometry_basename() const override { return "testem15"; }
-    bool enable_fluctuation() const override { return true; }
-    bool enable_msc() const override { return true; }
     bool combined_brems() const override { return false; }
     real_type secondary_stack_factor() const override { return 3.0; }
 };

--- a/test/celeritas/TestEm3Base.hh
+++ b/test/celeritas/TestEm3Base.hh
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "celeritas/ext/GeantPhysicsOptions.hh"
+#include "celeritas/phys/ProcessBuilder.hh"
 
 #include "GeantTestBase.hh"
 
@@ -25,8 +25,13 @@ class TestEm3Base : public GeantTestBase
 {
   protected:
     char const* geometry_basename() const override { return "testem3-flat"; }
-    bool combined_brems() const override { return true; }
-    real_type secondary_stack_factor() const override { return 3.0; }
+
+    ProcessBuilderOptions build_process_options() const override
+    {
+        ProcessBuilderOptions opts = GeantTestBase::build_process_options();
+        opts.brem_combined = true;
+        return opts;
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/TestEm3Base.hh
+++ b/test/celeritas/TestEm3Base.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "celeritas/ext/GeantPhysicsOptions.hh"
+
 #include "GeantTestBase.hh"
 
 namespace celeritas
@@ -17,14 +19,12 @@ namespace test
 /*!
  * Test harness for replicating the AdePT TestEm3 input.
  *
- * This class requires Geant4 to import the data.
+ * This class requires Geant4 to import the data. MSC is on by default.
  */
 class TestEm3Base : public GeantTestBase
 {
   protected:
     char const* geometry_basename() const override { return "testem3-flat"; }
-    bool enable_fluctuation() const override { return true; }
-    bool enable_msc() const override { return false; }
     bool combined_brems() const override { return true; }
     real_type secondary_stack_factor() const override { return 3.0; }
 };

--- a/test/celeritas/ext/RootImporter.test.cc
+++ b/test/celeritas/ext/RootImporter.test.cc
@@ -43,27 +43,41 @@ namespace test
 class RootImporterTest : public Test
 {
   protected:
-    void SetUp() override
-    {
-        root_filename_
-            = this->test_data_path("celeritas", "four-steel-slabs.root");
+    char const* geometry_basename() const { return "four-steel-slabs"; }
 
-        RootImporter import_from_root(root_filename_.c_str());
-        data_ = import_from_root();
-    }
-
-    std::string root_filename_;
-    ImportData data_;
-
-    ScopedRootErrorHandler scoped_root_error_;
+    ImportData const& imported_data() const;
 };
+
+//---------------------------------------------------------------------------//
+auto RootImporterTest::imported_data() const -> ImportData const&
+{
+    static struct
+    {
+        std::string geometry_basename;
+        ImportData imported;
+    } i;
+    std::string geo_basename = this->geometry_basename();
+    if (i.geometry_basename != geo_basename)
+    {
+        ScopedRootErrorHandler scoped_root_error;
+
+        i.geometry_basename = geo_basename;
+        std::string root_inp = this->test_data_path(
+            "celeritas", (i.geometry_basename + ".root").c_str());
+
+        RootImporter import(root_inp.c_str());
+        i.imported = import();
+    }
+    CELER_ENSURE(i.imported);
+    return i.imported;
+}
 
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
 TEST_F(RootImporterTest, particles)
 {
-    auto const& particles = data_.particles;
+    auto const& particles = this->imported_data().particles;
     EXPECT_EQ(3, particles.size());
 
     // Check all names/PDG codes
@@ -89,7 +103,7 @@ TEST_F(RootImporterTest, particles)
 //---------------------------------------------------------------------------//
 TEST_F(RootImporterTest, elements)
 {
-    auto const& elements = data_.elements;
+    auto const& elements = this->imported_data().elements;
     EXPECT_EQ(4, elements.size());
 
     std::vector<std::string> names;
@@ -105,7 +119,7 @@ TEST_F(RootImporterTest, elements)
 //---------------------------------------------------------------------------//
 TEST_F(RootImporterTest, materials)
 {
-    auto const& materials = data_.materials;
+    auto const& materials = this->imported_data().materials;
     EXPECT_EQ(2, materials.size());
 
     std::vector<std::string> names;
@@ -121,7 +135,7 @@ TEST_F(RootImporterTest, materials)
 //---------------------------------------------------------------------------//
 TEST_F(RootImporterTest, processes)
 {
-    auto const& processes = data_.processes;
+    auto const& processes = this->imported_data().processes;
     EXPECT_EQ(11, processes.size());
 
     auto find_process = [&processes](PDGNumber pdg, ImportProcessClass ipc) {
@@ -144,7 +158,7 @@ TEST_F(RootImporterTest, processes)
 //---------------------------------------------------------------------------//
 TEST_F(RootImporterTest, volumes)
 {
-    auto const& volumes = data_.volumes;
+    auto const& volumes = this->imported_data().volumes;
     EXPECT_EQ(5, volumes.size());
 
     std::vector<unsigned int> material_ids;

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -492,9 +492,6 @@ class GeantBuilderTestBase : virtual public GeantTestBase,
     {
         return std::make_shared<VecgeomParams>(this->get_world_volume());
     }
-
-    bool enable_fluctuation() const final { return false; }
-    bool enable_msc() const final { return false; }
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -495,8 +495,6 @@ class GeantBuilderTestBase : virtual public GeantTestBase,
 
     bool enable_fluctuation() const final { return false; }
     bool enable_msc() const final { return false; }
-    bool combined_brems() const final { return false; }
-    real_type secondary_stack_factor() const final { return 0; }
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/geo/GeoMaterial.test.cc
+++ b/test/celeritas/geo/GeoMaterial.test.cc
@@ -6,16 +6,13 @@
 //! \file celeritas/geo/GeoMaterial.test.cc
 //---------------------------------------------------------------------------//
 #include "corecel/data/CollectionStateStore.hh"
-#include "celeritas/GlobalGeoTestBase.hh"
-#include "celeritas/OnlyGeoTestBase.hh"
-#include "celeritas/ext/RootImporter.hh"
-#include "celeritas/ext/ScopedRootErrorHandler.hh"
+#include "celeritas/RootTestBase.hh"
 #include "celeritas/geo/GeoData.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"
 #include "celeritas/geo/GeoMaterialView.hh"
 #include "celeritas/geo/GeoParams.hh"
 #include "celeritas/geo/GeoTrackView.hh"
-#include "celeritas/io/ImportData.hh"
+#include "celeritas/mat/MaterialParams.hh"
 
 #include "celeritas_test.hh"
 
@@ -27,48 +24,13 @@ namespace test
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class GeoMaterialTest : public GlobalGeoTestBase, public OnlyGeoTestBase
+class GeoMaterialTest : public RootTestBase
 {
+  public:
     char const* geometry_basename() const override { return "simple-cms"; }
 
-    SPConstMaterial build_material() override
-    {
-        return MaterialParams::from_import(data_);
-    }
-
-    SPConstGeoMaterial build_geomaterial() override
-    {
-        // Create geometry/material coupling
-        GeoMaterialParams::Input input;
-        input.geometry = this->geometry();
-        input.materials = this->material();
-        input.volume_to_mat.resize(data_.volumes.size());
-        input.volume_labels.resize(data_.volumes.size());
-
-        for (auto const vol_idx : range(data_.volumes.size()))
-        {
-            ImportVolume const& volume = data_.volumes[vol_idx];
-
-            input.volume_to_mat[vol_idx] = MaterialId{volume.material_id};
-            input.volume_labels[vol_idx] = Label::from_geant(volume.name);
-        }
-        return std::make_shared<GeoMaterialParams>(std::move(input));
-    }
-
-    void SetUp() override
-    {
-        // Load ROOT file
-        // The simple-cms.root has no ImportData processes stored. Process data
-        // is not used and increases the file size by > 5x.
-        std::string root_file
-            = this->test_data_path("celeritas", "simple-cms.root");
-        data_ = RootImporter(root_file.c_str())();
-    }
-
-  private:
-    ImportData data_;
-
-    ScopedRootErrorHandler scoped_root_error;
+    SPConstTrackInit build_init() final { CELER_ASSERT_UNREACHABLE(); }
+    SPConstAction build_along_step() final { CELER_ASSERT_UNREACHABLE(); }
 };
 
 //---------------------------------------------------------------------------//
@@ -107,6 +69,7 @@ TEST_F(GeoMaterialTest, host)
         = {"vacuum", "Si", "Pb", "C", "Ti", "Fe", "vacuum"};
     EXPECT_VEC_EQ(expected_materials, materials);
 }
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -30,8 +30,13 @@ class KnAlongStepTest : public SimpleTestBase, public AlongStepTestBase
 class Em3AlongStepTest : public TestEm3Base, public AlongStepTestBase
 {
   public:
-    bool enable_msc() const override { return msc_; }
-    bool enable_fluctuation() const override { return fluct_; }
+    GeantPhysicsOptions build_geant_options() const override
+    {
+        auto opts = TestEm3Base::build_geant_options();
+        opts.eloss_fluctuation = fluct_;
+        opts.msc = msc_ ? MscModelSelection::urban : MscModelSelection::none;
+        return opts;
+    }
 
     bool msc_{false};
     bool fluct_{true};

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -6,6 +6,7 @@
 //! \file celeritas/global/AlongStep.test.cc
 //---------------------------------------------------------------------------//
 #include "celeritas/TestEm3Base.hh"
+#include "celeritas/ext/GeantPhysicsOptions.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
 

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -12,6 +12,7 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/cont/Span.hh"
+#include "celeritas/ext/GeantPhysicsOptions.hh"
 #include "celeritas/field/UniformFieldData.hh"
 #include "celeritas/global/ActionInterface.hh"
 #include "celeritas/global/ActionRegistry.hh"

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -72,9 +72,6 @@ class KnCaloTest : public KnStepCollectorTestBase, public CaloTestBase
 class TestEm3CollectorTestBase : public TestEm3Base,
                                  virtual public StepCollectorTestBase
 {
-    //! Use MSC
-    bool enable_msc() const override { return true; }
-
     SPConstAction build_along_step() override
     {
         auto& action_reg = *this->action_reg();
@@ -83,7 +80,7 @@ class TestEm3CollectorTestBase : public TestEm3Base,
         auto result = AlongStepUniformMscAction::from_params(
             action_reg.next_id(), *this->physics(), field_params);
         CELER_ASSERT(result);
-        CELER_ASSERT(result->has_msc() == this->enable_msc());
+        CELER_ASSERT(result->has_msc());
         action_reg.insert(result);
         return result;
     }


### PR DESCRIPTION
This cleans up some of the "pre-ProcessBuilder" code in the Geant4 test harness so that we now use GeantPhysicsOptions to set up the actual imported data and physics options. The process builder is also used for setting up physics loaded from ROOT files, so we can reuse that data in the UrbanMSC and GeoMaterial tests. While cleaning up the UrbanMSC test I identified and fixed some copy-paste errors and did some simplification.

To avoid changing test results, the Geant4 process construction reorders the input processes to match what used to be there: the next time we rebaseline the tests, we can remove that extra complexity.