### PR TITLE
Fix volume mapping and navigation issues found with HGCal prototype

### DIFF
--- a/app/demo-geant-integration/EventAction.cc
+++ b/app/demo-geant-integration/EventAction.cc
@@ -30,6 +30,8 @@ EventAction::EventAction(SPTransporter transport) : transport_(transport) {}
  */
 void EventAction::BeginOfEventAction(G4Event const* event)
 {
+    CELER_LOG_LOCAL(debug) << "Starting event " << event->GetEventID();
+
     // Set event ID in local transporter
     celeritas::ExceptionConverter call_g4exception{"celer0002"};
     CELER_TRY_HANDLE(transport_->SetEventId(event->GetEventID()),
@@ -53,6 +55,8 @@ void EventAction::EndOfEventAction(G4Event const* event)
         // Write sensitive hits
         HitRootIO::Instance()->WriteHits(event);
     }
+
+    CELER_LOG_LOCAL(debug) << "Finished event " << event->GetEventID();
 }
 
 //---------------------------------------------------------------------------//

--- a/scripts/cmake-presets/goldfinger.json
+++ b/scripts/cmake-presets/goldfinger.json
@@ -12,6 +12,8 @@
         "CELERITAS_USE_HIP":     {"type": "BOOL",   "value": "OFF"},
         "CELERITAS_USE_JSON":     {"type": "BOOL",   "value": "ON"},
         "CELERITAS_USE_Geant4":   {"type": "BOOL",   "value": "ON"},
+        "CELERITAS_USE_MPI":     {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_SWIG":    {"type": "BOOL",   "value": "OFF"},
         "CMAKE_BUILD_TYPE":      {"type": "STRING", "value": "Debug"},
         "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL",   "value": "ON"},
         "CMAKE_OSX_DEPLOYMENT_TARGET": {"type": "STRING", "value": "13"},
@@ -39,7 +41,6 @@
       "inherits": [".base", "default"],
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-        "CELERITAS_USE_MPI":     {"type": "BOOL",   "value": "OFF"},
         "CELERITAS_USE_SWIG":    {"type": "BOOL",   "value": "ON"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL",   "value": "OFF"}
       }
@@ -47,11 +48,18 @@
     {
       "name": "vecgeom",
       "displayName": "With vecgeom",
-      "inherits": ["base"],
-      "binaryDir": "${sourceDir}/build-${presetName}",
+      "inherits": [".base", "default"],
       "cacheVariables": {
-        "CELERITAS_USE_SWIG":    {"type": "BOOL",   "value": "OFF"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL",   "value": "ON"}
+      }
+    },
+    {
+      "name": "vecgeom-ndebug",
+      "displayName": "With vecgeom in optimized mode",
+      "inherits": [".ndebug", "vecgeom"],
+      "cacheVariables": {
+        "CELERITAS_BUILD_DEMOS": {"type": "BOOL", "value": "ON"},
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
       }
     }
   ],

--- a/src/accel/HepMC3PrimaryGenerator.cc
+++ b/src/accel/HepMC3PrimaryGenerator.cc
@@ -97,8 +97,9 @@ void HepMC3PrimaryGenerator::GeneratePrimaryVertex(G4Event* g4_event)
     }
 
     CELER_LOG_LOCAL(info) << "Read " << gen_event.particles().size()
-                          << " primaries from event "
-                          << gen_event.event_number();
+                          << " primaries from HepMC event ID "
+                          << gen_event.event_number()
+                          << " for Geant4 event " << g4_event->GetEventID();
 
     gen_event.set_units(HepMC3::Units::MEV, HepMC3::Units::MM);  // Geant4
                                                                  // units

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "LocalTransporter.hh"
 
+#include <csignal>
 #include <type_traits>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <G4ParticleDefinition.hh>
@@ -15,6 +16,7 @@
 #include "corecel/cont/Span.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/ScopedSignalHandler.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"  // IWYU pragma: keep
@@ -140,6 +142,9 @@ void LocalTransporter::Flush()
         << "Transporting " << buffer_.size() << " tracks from event "
         << event_id_.unchecked_get() + 1 << " with Celeritas";
 
+    // Abort cleanly for interrupt and user-defined signals
+    ScopedSignalHandler interrupted{SIGINT, SIGUSR2};
+
     // Copy buffered tracks to device and transport the first step
     auto track_counts = (*step_)(make_span(buffer_));
     buffer_.clear();
@@ -155,6 +160,8 @@ void LocalTransporter::Flush()
 
         track_counts = (*step_)();
         ++step_iters;
+
+        CELER_VALIDATE(!interrupted(), << "caught interrupt signal");
     }
 }
 

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -140,7 +140,7 @@ void LocalTransporter::Flush()
 
     CELER_LOG_LOCAL(info)
         << "Transporting " << buffer_.size() << " tracks from event "
-        << event_id_.unchecked_get() + 1 << " with Celeritas";
+        << event_id_.unchecked_get() << " with Celeritas";
 
     // Abort cleanly for interrupt and user-defined signals
     ScopedSignalHandler interrupted{SIGINT, SIGUSR2};

--- a/src/accel/detail/HitManager.cc
+++ b/src/accel/detail/HitManager.cc
@@ -56,6 +56,7 @@ HitManager::HitManager(GeoParams const& geo, SDSetupOptions const& setup)
     if (setup.locate_touchable)
     {
         selection_.points[StepPoint::pre].pos = true;
+        selection_.points[StepPoint::pre].dir = true;
     }
 
     // Logical volumes to pass to hit processor

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -206,10 +206,12 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
 
         if (navi_)
         {
+            CELER_ASSERT(!out.points[StepPoint::pre].dir.empty());
             G4VTouchable* touchable = touch_handle_();
             // Locate pre-step point
             navi_->LocateGlobalPointAndUpdateTouchable(
                 points[StepPoint::pre]->GetPosition(),
+                convert_to_geant(out.points[StepPoint::pre].dir[i], 1),
                 touchable,
                 /* relative_search = */ false);
 

--- a/src/accel/detail/HitProcessor.hh
+++ b/src/accel/detail/HitProcessor.hh
@@ -79,6 +79,10 @@ class HitProcessor
     std::unique_ptr<G4Navigator> navi_;
     //! Geant4 reference-counted pointer to a G4VTouchable
     G4TouchableHandle touch_handle_;
+
+    bool update_touchable(Real3 const& pos,
+                          Real3 const& dir,
+                          G4LogicalVolume* lv) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -180,22 +180,31 @@ PDGNumber to_pdg(G4ProductionCutsIndex const& index)
  * duplicated.
  * Function called by \c store_volumes(...) .
  */
-void loop_volumes(std::map<unsigned int, ImportVolume>& volids_volumes,
+void loop_volumes(std::map<int, ImportVolume>& volids_volumes,
                   G4LogicalVolume const& logical_volume)
 {
-    auto iter_inserted = volids_volumes.emplace(logical_volume.GetInstanceID(),
-                                                ImportVolume{});
-    if (!iter_inserted.second)
+    auto&& [iter, inserted] = volids_volumes.emplace(
+        logical_volume.GetInstanceID(), ImportVolume{});
+    if (!inserted)
     {
         // Logical volume is already in the map
         return;
     }
 
+    CELER_ASSERT(iter->first >= 0);
+
     // Fill volume properties
-    ImportVolume& volume = iter_inserted.first->second;
+    ImportVolume& volume = iter->second;
     volume.material_id = logical_volume.GetMaterialCutsCouple()->GetIndex();
     volume.name = logical_volume.GetName();
     volume.solid_name = logical_volume.GetSolid()->GetName();
+
+    if (volume.name.empty())
+    {
+        CELER_LOG(warning)
+            << "No logical volume name specified for instance ID "
+            << iter->first << " (material " << volume.material_id << ")";
+    }
 
     // Recursive: repeat for every daughter volume, if there are any
     for (auto const i : range(logical_volume.GetNoDaughters()))
@@ -203,6 +212,8 @@ void loop_volumes(std::map<unsigned int, ImportVolume>& volids_volumes,
         loop_volumes(volids_volumes,
                      *logical_volume.GetDaughter(i)->GetLogicalVolume());
     }
+
+    CELER_ENSURE(volume);
 }
 
 //---------------------------------------------------------------------------//
@@ -493,17 +504,20 @@ auto store_processes(GeantImporter::DataSelection::Flags process_flags,
 std::vector<ImportVolume> store_volumes(G4VPhysicalVolume const* world_volume)
 {
     std::vector<ImportVolume> volumes;
-    std::map<unsigned int, ImportVolume> volids_volumes;
+    std::map<int, ImportVolume> volids_volumes;
 
     // Recursive loop over all logical volumes to populate map<volid, volume>
     loop_volumes(volids_volumes, *world_volume->GetLogicalVolume());
 
     // Populate vector<ImportVolume>
-    volumes.reserve(volids_volumes.size());
-    for (auto const& key : volids_volumes)
+    volumes.resize(volids_volumes.size());
+    for (auto&& [volid, volume] : volids_volumes)
     {
-        CELER_ASSERT(key.first == volumes.size());
-        volumes.push_back(key.second);
+        if (static_cast<std::size_t>(volid) >= volumes.size())
+        {
+            volumes.resize(volid + 1);
+        }
+        volumes[volid] = std::move(volume);
     }
 
     CELER_LOG(debug) << "Loaded " << volumes.size() << " volumes";

--- a/src/celeritas/geo/GeoMaterialParams.cc
+++ b/src/celeritas/geo/GeoMaterialParams.cc
@@ -44,8 +44,11 @@ GeoMaterialParams::from_import(ImportData const& data,
     for (auto volume_idx :
          range<VolumeId::size_type>(input.volume_to_mat.size()))
     {
+        if (!data.volumes[volume_idx])
+            continue;
+
         input.volume_to_mat[volume_idx]
-            = MaterialId{data.volumes[volume_idx].material_id};
+            = MaterialId(data.volumes[volume_idx].material_id);
     }
 
     // Assume that since Geant4 is using internal geometry and
@@ -55,6 +58,10 @@ GeoMaterialParams::from_import(ImportData const& data,
     input.volume_labels.resize(data.volumes.size());
     for (auto volume_idx : range(data.volumes.size()))
     {
+        if (!data.volumes[volume_idx])
+            continue;
+
+        CELER_EXPECT(!data.volumes[volume_idx].name.empty());
         input.volume_labels[volume_idx]
             = Label::from_geant(data.volumes[volume_idx].name);
     }
@@ -92,6 +99,12 @@ GeoMaterialParams::GeoMaterialParams(Input input)
         std::set<Label> duplicates;
         for (auto idx : range(input.volume_to_mat.size()))
         {
+            if (!input.volume_to_mat[idx])
+            {
+                // Skip volumes without matids
+                continue;
+            }
+
             auto [prev, inserted]
                 = lab_to_id.insert({std::move(input.volume_labels[idx]),
                                     input.volume_to_mat[idx]});

--- a/src/celeritas/io/ImportVolume.hh
+++ b/src/celeritas/io/ImportVolume.hh
@@ -19,9 +19,12 @@ namespace celeritas
  */
 struct ImportVolume
 {
-    unsigned int material_id;
+    int material_id{-1};
     std::string name;
     std::string solid_name;
+
+    //! Whether this represents a physical volume or is just a placeholder
+    explicit operator bool() const { return material_id >= 0; }
 };
 
 //---------------------------------------------------------------------------//

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -440,10 +440,11 @@ celeritas_add_test(celeritas/user/StepCollector.test.cc ${_optional_geant4_env})
 
 if(CELERITAS_USE_Geant4)
   celeritas_setup_tests(SERIAL PREFIX accel
-    LINK_LIBRARIES Celeritas::accel
+    LINK_LIBRARIES Celeritas::accel testcel_celeritas
   )
 
   celeritas_add_test(accel/ExceptionConverter.test.cc)
+  celeritas_add_test(accel/detail/HitProcessor.test.cc)
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/test/accel/detail/HitProcessor.test.cc
+++ b/test/accel/detail/HitProcessor.test.cc
@@ -1,0 +1,423 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/detail/HitProcessor.test.cc
+//---------------------------------------------------------------------------//
+#include "accel/detail/HitProcessor.hh"
+
+#include <cmath>
+#include <map>
+#include <string>
+#include <vector>
+#include <CLHEP/Units/SystemOfUnits.h>
+#include <G4LogicalVolume.hh>
+#include <G4LogicalVolumeStore.hh>
+#include <G4SDManager.hh>
+#include <G4VSensitiveDetector.hh>
+
+#include "celeritas/SimpleCmsTestBase.hh"
+#include "celeritas/io/ImportData.hh"
+#include "celeritas/user/DetectorSteps.hh"
+#include "celeritas/user/StepData.hh"
+
+#include "celeritas_test.hh"
+
+using namespace celeritas::units;
+
+namespace celeritas
+{
+namespace detail
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+struct HitsResult
+{
+    std::vector<double> energy_deposition;  // [MeV]
+    std::vector<double> pre_energy;  // [MeV]
+    std::vector<double> pre_pos;  // [cm]
+    std::vector<std::string> pre_physvol;
+    std::vector<double> post_time;  // [ns]
+
+    void print_expected() const;
+};
+
+void HitsResult::print_expected() const
+{
+    cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
+            "static double const expected_energy_deposition[] = "
+         << repr(this->energy_deposition)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_energy_deposition, "
+            "result.energy_deposition);\n"
+
+            "static double const expected_pre_energy[] = "
+         << repr(this->pre_energy)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_pre_energy, result.pre_energy);\n"
+
+            "static double const expected_pre_pos[] = "
+         << repr(this->pre_pos)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_pre_pos, result.pre_pos);\n"
+
+            "static char const * const expected_pre_physvol[] = "
+         << repr(this->pre_physvol)
+         << ";\n"
+            "EXPECT_VEC_EQ(expected_pre_physvol, result.pre_physvol);\n"
+
+            "static double const expected_post_time[] = "
+         << repr(this->post_time)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_post_time, result.post_time);\n"
+
+            "/*** END CODE ***/\n";
+}
+
+//---------------------------------------------------------------------------//
+class SensitiveDetector final : public G4VSensitiveDetector
+{
+  public:
+    explicit SensitiveDetector(std::string const& name)
+        : G4VSensitiveDetector(name)
+    {
+    }
+
+    //! Access hit data
+    HitsResult const& hits() const { return hits_; }
+
+    //! Reset hits between tests
+    void clear() { hits_ = {}; }
+
+  protected:
+    void Initialize(G4HCofThisEvent*) final { this->clear(); }
+    bool ProcessHits(G4Step*, G4TouchableHistory*) final;
+
+    HitsResult hits_;
+};
+
+//---------------------------------------------------------------------------//
+bool SensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
+{
+    CELER_EXPECT(step);
+
+    auto* pre_step = step->GetPreStepPoint();
+    CELER_ASSERT(pre_step);
+
+    hits_.energy_deposition.push_back(step->GetTotalEnergyDeposit()
+                                      / CLHEP::MeV);
+    hits_.pre_energy.push_back(pre_step->GetKineticEnergy() / CLHEP::MeV);
+
+    for (int i : range(3))
+    {
+        hits_.pre_pos.push_back(pre_step->GetPosition()[i] / CLHEP::cm);
+    }
+
+    if (auto* touchable = pre_step->GetTouchable())
+    {
+        auto* vol = touchable->GetVolume();
+        hits_.pre_physvol.push_back(vol ? vol->GetName() : "<nullptr>");
+    }
+    hits_.post_time.push_back(step->GetPostStepPoint()->GetGlobalTime()
+                              / CLHEP::ns);
+    return true;
+}
+
+//---------------------------------------------------------------------------//
+
+class HitProcessorTest : public ::celeritas::test::SimpleCmsTestBase
+{
+  protected:
+    using MapStrSD = std::map<std::string, SensitiveDetector*>;
+    using VecLV = std::vector<G4LogicalVolume*>;
+
+    void SetUp() override
+    {
+        // Make sure Geant4 is loaded and detctors are set up
+        ASSERT_TRUE(this->imported_data());
+        this->setup_detectors();
+
+        // Reset detectors between simulations
+        for (auto&& kv : detectors())
+        {
+            CELER_ASSERT(kv.second);
+            kv.second->clear();
+        }
+
+        // Create default step selection (see HitManager)
+        selection_.energy_deposition = true;
+        selection_.points[StepPoint::pre].energy = true;
+        selection_.points[StepPoint::pre].pos = true;
+        selection_.points[StepPoint::post].time = true;
+    }
+
+    static MapStrSD& detectors();
+    static VecLV& detector_volumes();
+    static void setup_detectors();
+
+    static HitsResult const& get_hits(std::string const& name)
+    {
+        auto iter = detectors().find(name);
+        CELER_ASSERT(iter != detectors().end());
+        CELER_ASSERT(iter->second);
+        return iter->second->hits();
+    }
+
+    DetectorStepOutput make_dso() const;
+
+  protected:
+    StepSelection selection_;
+};
+
+//---------------------------------------------------------------------------//
+auto HitProcessorTest::detectors() -> MapStrSD&
+{
+    // Non-owning pointers
+    static MapStrSD det{
+        {"em_calorimeter", nullptr},
+        {"had_calorimeter", nullptr},
+        {"si_tracker", nullptr},
+    };
+
+    return det;
+}
+
+//---------------------------------------------------------------------------//
+auto HitProcessorTest::detector_volumes() -> VecLV&
+{
+    static VecLV dv;
+    return dv;
+}
+
+//---------------------------------------------------------------------------//
+void HitProcessorTest::setup_detectors()
+{
+    auto& dv = HitProcessorTest::detector_volumes();
+    if (!dv.empty())
+    {
+        // We've already set them up
+        return;
+    }
+
+    // Find and set up sensitive detectors
+    G4SDManager* sd_manager = G4SDManager::GetSDMpointer();
+    G4LogicalVolumeStore* lv_store = G4LogicalVolumeStore::GetInstance();
+    CELER_ASSERT(lv_store);
+
+    auto& det = HitProcessorTest::detectors();
+    for (G4LogicalVolume* lv : *lv_store)
+    {
+        CELER_ASSERT(lv);
+        auto iter = det.find(lv->GetName());
+        if (iter == det.end())
+            continue;
+        CELER_ASSERT(iter->second == nullptr);
+
+        // Found a volume we want for a detector
+        dv.push_back(lv);
+
+        // Create SD, attach to volume, and save a reference to it
+        auto sd = std::make_unique<SensitiveDetector>(iter->first);
+        lv->SetSensitiveDetector(sd.get());
+        iter->second = sd.get();
+        sd_manager->AddNewDetector(sd.release());
+    }
+
+    for (auto&& [name, sdptr] : det)
+    {
+        EXPECT_TRUE(sdptr != nullptr) << "for detector " << name;
+    }
+
+    // Sort detector volumes by name since these will correspond to the
+    // DetectorId
+    std::sort(
+        dv.begin(), dv.end(), [](G4LogicalVolume* lhs, G4LogicalVolume* rhs) {
+            return lhs->GetName() < rhs->GetName();
+        });
+}
+
+//---------------------------------------------------------------------------//
+DetectorStepOutput HitProcessorTest::make_dso() const
+{
+    DetectorStepOutput dso;
+    dso.detector = {
+        DetectorId{2},  // si_tracker
+        DetectorId{0},  // em_calorimeter
+        DetectorId{1},  // had_calorimeter
+    };
+    dso.track_id = {
+        TrackId{0},
+        TrackId{2},
+        TrackId{4},
+    };
+    if (selection_.energy_deposition)
+    {
+        dso.energy_deposition = {
+            MevEnergy{0.1},
+            MevEnergy{0.2},
+            MevEnergy{0.3},
+        };
+    }
+    if (selection_.points[StepPoint::post].time)
+    {
+        dso.points[StepPoint::post].time = {
+            1e-9 * second,
+            2e-10 * second,
+            3e-8 * second,
+        };
+    }
+    if (selection_.points[StepPoint::pre].pos)
+    {
+        // note: points must correspond to detector volumes!
+        dso.points[StepPoint::pre].pos = {
+            {100, 0, 0},
+            {0, 150, 10},
+            {0, 200, -20},
+        };
+    }
+    if (selection_.points[StepPoint::pre].dir)
+    {
+        dso.points[StepPoint::pre].dir = {
+            {1, 0, 0},
+            {0, 1, 0},
+            {0, 0, -1},
+        };
+    }
+    return dso;
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(HitProcessorTest, no_touchable)
+{
+    HitProcessor process_hits{detector_volumes(), selection_, false};
+    auto dso_hits = this->make_dso();
+    process_hits(dso_hits);
+    dso_hits.energy_deposition = {
+        MevEnergy{0.4},
+        MevEnergy{0.5},
+        MevEnergy{0.6},
+    };
+    process_hits(dso_hits);
+
+    {
+        auto& result = this->get_hits("si_tracker");
+        static double const expected_energy_deposition[] = {0.1, 0.4};
+        EXPECT_VEC_SOFT_EQ(expected_energy_deposition,
+                           result.energy_deposition);
+        static double const expected_pre_energy[] = {0, 0};
+        EXPECT_VEC_SOFT_EQ(expected_pre_energy, result.pre_energy);
+        static double const expected_pre_pos[] = {100, 0, 0, 100, 0, 0};
+        EXPECT_VEC_SOFT_EQ(expected_pre_pos, result.pre_pos);
+        static double const expected_post_time[] = {1, 1};
+        EXPECT_VEC_SOFT_EQ(expected_post_time, result.post_time);
+    }
+    {
+        auto& result = this->get_hits("em_calorimeter");
+        static double const expected_energy_deposition[] = {0.2, 0.5};
+        EXPECT_VEC_SOFT_EQ(expected_energy_deposition,
+                           result.energy_deposition);
+        static double const expected_pre_energy[] = {0, 0};
+        EXPECT_VEC_SOFT_EQ(expected_pre_energy, result.pre_energy);
+        static double const expected_pre_pos[] = {0, 150, 10, 0, 150, 10};
+        EXPECT_VEC_SOFT_EQ(expected_pre_pos, result.pre_pos);
+        static double const expected_post_time[] = {0.2, 0.2};
+        EXPECT_VEC_SOFT_EQ(expected_post_time, result.post_time);
+    }
+    {
+        auto& result = this->get_hits("had_calorimeter");
+        static double const expected_energy_deposition[] = {0.3, 0.6};
+        EXPECT_VEC_SOFT_EQ(expected_energy_deposition,
+                           result.energy_deposition);
+        static double const expected_pre_energy[] = {0, 0};
+        EXPECT_VEC_SOFT_EQ(expected_pre_energy, result.pre_energy);
+        static double const expected_pre_pos[] = {0, 200, -20, 0, 200, -20};
+        EXPECT_VEC_SOFT_EQ(expected_pre_pos, result.pre_pos);
+        static double const expected_post_time[] = {30, 30};
+        EXPECT_VEC_SOFT_EQ(expected_post_time, result.post_time);
+    }
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(HitProcessorTest, touchable_midvol)
+{
+    selection_.points[StepPoint::pre].dir = true;
+    HitProcessor process_hits{detector_volumes(), selection_, true};
+    auto dso_hits = this->make_dso();
+    process_hits(dso_hits);
+    process_hits(dso_hits);
+
+    {
+        auto& result = this->get_hits("si_tracker");
+        static char const* const expected_pre_physvol[]
+            = {"si_tracker_pv", "si_tracker_pv"};
+        EXPECT_VEC_EQ(expected_pre_physvol, result.pre_physvol);
+    }
+    {
+        auto& result = this->get_hits("em_calorimeter");
+        static char const* const expected_pre_physvol[]
+            = {"em_calorimeter_pv", "em_calorimeter_pv"};
+        EXPECT_VEC_EQ(expected_pre_physvol, result.pre_physvol);
+    }
+    {
+        auto& result = this->get_hits("had_calorimeter");
+        static char const* const expected_pre_physvol[]
+            = {"had_calorimeter_pv", "had_calorimeter_pv"};
+        EXPECT_VEC_EQ(expected_pre_physvol, result.pre_physvol);
+    }
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(HitProcessorTest, touchable_edgecase)
+{
+    selection_.points[StepPoint::pre].dir = true;
+    HitProcessor process_hits{detector_volumes(), selection_, true};
+    auto dso_hits = this->make_dso();
+    auto& pos = dso_hits.points[StepPoint::pre].pos;
+    auto& dir = dso_hits.points[StepPoint::pre].dir;
+    pos = {
+        {30, 0, 0},
+        {0, 125, 10},
+        {0, 175, -20},
+    };
+    process_hits(dso_hits);
+
+    pos = {
+        {-120.20472398905, 34.290294993135, -58.348475076307},
+        {-58.042349740868, -165.09417202481, -315.41125902053},
+        {0, 275, -20},
+    };
+    EXPECT_SOFT_EQ(125.0, std::hypot(pos[0][0], pos[0][1]));
+    EXPECT_SOFT_EQ(175.0, std::hypot(pos[1][0], pos[1][1]));
+    dir = {
+        {0.39117837162751, -0.78376148752334, -0.48238720157779},
+        {0.031769215780742, 0.6378450322959, -0.76950921482729},
+        {0, -1, 0},
+    };
+    process_hits(dso_hits);
+
+    {
+        auto& result = this->get_hits("si_tracker");
+        static char const* const expected_pre_physvol[]
+            = {"si_tracker_pv", "si_tracker_pv"};
+        EXPECT_VEC_EQ(expected_pre_physvol, result.pre_physvol);
+    }
+    {
+        auto& result = this->get_hits("em_calorimeter");
+        static char const* const expected_pre_physvol[]
+            = {"em_calorimeter_pv", "em_calorimeter_pv"};
+        EXPECT_VEC_EQ(expected_pre_physvol, result.pre_physvol);
+    }
+    {
+        auto& result = this->get_hits("had_calorimeter");
+        static char const* const expected_pre_physvol[]
+            = {"had_calorimeter_pv", "had_calorimeter_pv"};
+        EXPECT_VEC_EQ(expected_pre_physvol, result.pre_physvol);
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace detail
+}  // namespace celeritas

--- a/test/celeritas/SimpleCmsTestBase.hh
+++ b/test/celeritas/SimpleCmsTestBase.hh
@@ -1,0 +1,41 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/SimpleCmsTestBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "GeantTestBase.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Test harness for "simple CMS".
+ *
+ * This geometry is a set of nested cylinders with length 1400 cm.
+ *
+ * | Radius [cm] | Material | Volume name |
+ * | ----------: | -------- | ----------- |
+ * |          0  |          |             |
+ * |         30  | galactic | vacuum_tube |
+ * |        125  | si       | si_tracker |
+ * |        175  | pb       | em_calorimeter |
+ * |        275  | c        | had_calorimeter |
+ * |        375  | ti       | sc_solenoid |
+ * |        700  | fe       | fe_muon_chambers |
+ * |             | galactic | world |
+ */
+class SimpleCmsTestBase : public GeantTestBase
+{
+  protected:
+    char const* geometry_basename() const override { return "simple-cms"; }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
Trying to run https://github.com/sethrj/hgcal-prototype, I identified a few issues:
- We assumed logical volumes in the Geant4 geometry had contiguous `InstanceID`s. This is not the case; so I had to modify the `GeantImporter` and `GeoMaterialParams` to fix.
- To stop long-running tracks without killing the entire simulation I added signal handling to the Celeritas transporter in the `accel` framework.
- *Many* hits in the Celeritas SD callback were mapping to incorrect volumes. I added code to try bumping particles across boundaries based on the particle's direction. It's possible we will never be able to get rid of this due to minor differences in volume locations between VecGeom and Geant4 geometry representations.

With this fix in place, we now get helpful error messages describing what happened:
```
/Users/seth/.local/src/celeritas/src/accel/detail/HitProcessor.cc:292: warning: Bumping navigation state by 0.45191227190116 [mm] because the pre-step point at {-42.941131996129, 40.164883430406, 8976.6} [mm] along {-0.37122466310106, 0.64923123028887, 0.66384565911295} is expected to be in logical volume 'SiCell' (ID 1) but navigation gives {{pv='Si_wafer', lv=0='Si_wafer'}}
/Users/seth/.local/src/celeritas/src/accel/detail/HitProcessor.cc:321: error: expected step point at {-42.941131996129, 40.164883430406, 8976.6} [mm] along {-0.37122466310106, 0.64923123028887, 0.66384565911295} to be in logical volume 'SiCell' (ID 1) but navigation gives {{pv='PCB', lv=4='PCB'}}: omitting energy deposition of 0.159813 [MeV]
```