### PR TITLE
Fix incorrect Urban MSC path length correction due to discontinuity in positron cross section

### DIFF
--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -66,6 +66,12 @@ struct UrbanMscParameters
     {
         return units::MevEnergy{1e-6};
     }
+
+    //! Use a small step approximation for the path length correction
+    static CELER_CONSTEXPR_FUNCTION real_type small_step_transformation()
+    {
+        return -1;
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -66,12 +66,6 @@ struct UrbanMscParameters
     {
         return units::MevEnergy{1e-6};
     }
-
-    //! Use a small step approximation for the path length correction
-    static CELER_CONSTEXPR_FUNCTION real_type small_step_transformation()
-    {
-        return -1;
-    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/msc/UrbanMscScatter.hh
+++ b/src/celeritas/em/msc/UrbanMscScatter.hh
@@ -641,7 +641,7 @@ real_type UrbanMscScatter::calc_true_path(real_type true_path,
     // NOTE: add && !insideskin if the UseDistanceToBoundary algorithm is used
     if (geom_path > lambda_ * params_.tau_small)
     {
-        if (alpha < 0)
+        if (alpha == params_.small_step_transformation())
         {
             // For cases that the true path is very small compared to either
             // the mean free path or the range

--- a/src/celeritas/em/msc/UrbanMscScatter.hh
+++ b/src/celeritas/em/msc/UrbanMscScatter.hh
@@ -641,7 +641,7 @@ real_type UrbanMscScatter::calc_true_path(real_type true_path,
     // NOTE: add && !insideskin if the UseDistanceToBoundary algorithm is used
     if (geom_path > lambda_ * params_.tau_small)
     {
-        if (alpha == params_.small_step_transformation())
+        if (alpha == MscStep::small_step_alpha())
         {
             // For cases that the true path is very small compared to either
             // the mean free path or the range

--- a/src/celeritas/em/msc/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/msc/UrbanMscStepLimit.hh
@@ -254,6 +254,16 @@ CELER_FUNCTION auto UrbanMscStepLimit::operator()(Engine& rng) -> MscStep
  * \f$ \lambda_{10} (\lambda_{11}) \f$ denotes the value of \f$\lambda_{1}\f$
  * at the start (end) of the step, respectively.
  *
+ * Since the MSC cross section decreases as the energy increases, \f$
+ * \lambda_{10} \f$ will be larger than \f$ \lambda_{11} \f$ and \f$ \alpha \f$
+ * will be positive. However, in the Geant4 Urban MSC model, different methods
+ * are used to calculate the cross section above and below 10 MeV. In the
+ * higher energy region the cross sections are identical for electrons and
+ * positrons, resulting in a discontinuity in the positron cross section at 10
+ * MeV. This means on fine energy grids it's possible for the cross section to
+ * be *increasing* with energy just above the 10 MeV threshold and therefore
+ * for \f$ \alpha \f$ is negative.
+ *
  * \note This performs the same method as in ComputeGeomPathLength of
  * G4UrbanMscModel of the Geant4 10.7 release.
  */
@@ -264,7 +274,7 @@ auto UrbanMscStepLimit::calc_geom_path(real_type true_path) const
     // Do the true path -> geom path transformation
     GeomPathAlpha result;
     result.geom_path = true_path;
-    result.alpha = -1;
+    result.alpha = params_.small_step_transformation();
 
     if (true_path < shared_.params.min_step())
     {

--- a/src/celeritas/em/msc/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/msc/UrbanMscStepLimit.hh
@@ -274,7 +274,7 @@ auto UrbanMscStepLimit::calc_geom_path(real_type true_path) const
     // Do the true path -> geom path transformation
     GeomPathAlpha result;
     result.geom_path = true_path;
-    result.alpha = params_.small_step_transformation();
+    result.alpha = MscStep::small_step_alpha();
 
     if (true_path < shared_.params.min_step())
     {

--- a/src/celeritas/phys/Interaction.hh
+++ b/src/celeritas/phys/Interaction.hh
@@ -67,17 +67,22 @@ struct Interaction
  * Step lengths and properties needed to apply multiple scattering.
  *
  * \todo Document and/or refactor into a class that hides details:
- * - alpha < 0 ? "true path is very small" (true path scaling changes)
- * - is_displaced == false ? limit_min is unchanged and alpha < 0
+ * - alpha == small_step_alpha() ? "true path is very small" (true path scaling
+ *   changes)
+ * - is_displaced == false ? limit_min is unchanged and alpha ==
+ *   small_step_alpha()
  * - true_step >= geom_path
  */
 struct MscStep
 {
+    //! Use a small step approximation for the path length correction
+    static CELER_CONSTEXPR_FUNCTION real_type small_step_alpha() { return -1; }
+
     bool is_displaced{true};  //!< Flag for the lateral displacement
     real_type phys_step{};  //!< Step length from physics processes
     real_type true_path{};  //!< True path length due to the msc
     real_type geom_path{};  //!< Geometrical path length
-    real_type alpha{-1};  //!< An effecive mfp rate by distance
+    real_type alpha = small_step_alpha();  //!< Effective mfp rate by distance
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -199,7 +199,8 @@ TEST_F(Em3AlongStepTest, msc_nofluct_finegrid)
             = {0.995881993983801, -0.0107323420361051, 0.0900215023939723};
         inp.phys_mfp = 0.469519866261640;
         auto result = this->run(inp, num_tracks);
-        EXPECT_SOFT_NEAR(0.0499189990540797, result.step, 1e-8);
+        // Distance to interaction = 0.0499189990540797
+        EXPECT_SOFT_NEAR(0.049721747266950993, result.step, 1e-8);
         EXPECT_EQ("geo-boundary", result.action);
     }
 }

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -34,11 +34,13 @@ class Em3AlongStepTest : public TestEm3Base, public AlongStepTestBase
     GeantPhysicsOptions build_geant_options() const override
     {
         auto opts = TestEm3Base::build_geant_options();
+        opts.em_bins_per_decade = bpd_;
         opts.eloss_fluctuation = fluct_;
         opts.msc = msc_ ? MscModelSelection::urban : MscModelSelection::none;
         return opts;
     }
 
+    size_type bpd_{14};
     bool msc_{false};
     bool fluct_{true};
 };
@@ -171,6 +173,33 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         EXPECT_SOFT_NEAR(0.9999807140391257, result.angle, 1e-3);
         EXPECT_SOFT_EQ(3.3396076266578e-15, result.time);
         EXPECT_SOFT_NEAR(0.00010000053338476, result.step, 1e-8);
+        EXPECT_EQ("geo-boundary", result.action);
+    }
+}
+
+TEST_F(Em3AlongStepTest, msc_nofluct_finegrid)
+{
+    msc_ = true;
+    fluct_ = false;
+    bpd_ = 56;
+
+    size_type num_tracks = 1024;
+    Input inp;
+    {
+        // Even though the MSC cross section decreases with increasing energy,
+        // on a finer energy grid the discontinuity in the positron cross
+        // section means the cross section could have a *positive* slope just
+        // above 10 MeV.
+        SCOPED_TRACE("positron wth MSC cross section near discontinuity");
+        inp.particle_id = this->particle()->find(pdg::positron());
+        inp.energy = MevEnergy{10.6026777729432};
+        inp.position
+            = {-3.81588975039638, 0.0396989319776775, -0.0362911231520308};
+        inp.direction
+            = {0.995881993983801, -0.0107323420361051, 0.0900215023939723};
+        inp.phys_mfp = 0.469519866261640;
+        auto result = this->run(inp, num_tracks);
+        EXPECT_SOFT_NEAR(0.0499189990540797, result.step, 1e-8);
         EXPECT_EQ("geo-boundary", result.action);
     }
 }


### PR DESCRIPTION
Because of a discontinuity in the Urban MSC positron cross section at 10 MeV, when a positron has energy slightly larger than 10 MeV it's possible for the final transport mean free path to be _larger_ than the initial mfp and therefore for the `alpha` calculated in `UrbanMscStepLimit::calc_geom_path()` to be negative. Since `UrbanMscScatter::calc_true_path()` checked for `alpha < 0` (instead of `alpha == -1`, indicating a small true path length) when determining which geom path --> true path conversion to use, the true path for these positrons was calculated using the wrong transformation.

See full discussion in #615
Some overlap with #641 ;)
Closes #615 