### PR TITLE
Activate fine-grid MSC test and make GeantImporter less verbose

### DIFF
--- a/app/celer-export-geant.cc
+++ b/app/celer-export-geant.cc
@@ -93,6 +93,8 @@ int main(int argc, char* argv[])
     if (option_filename.empty())
     {
         CELER_LOG(info) << "Using default Celeritas Geant4 options";
+        // ... but add verbosity
+        options.verbose = true;
     }
 #if CELERITAS_USE_JSON
     else if (option_filename == "-")

--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -60,6 +60,7 @@ enum class RelaxationSelection
  * - \c min_energy: lowest energy of any EM physics process
  * - \c max_energy: highest energy of any EM physics process
  * - \c linear_loss_limit: see \c PhysicsParamsOptions::linear_loss_limit
+ * - \c verbose: print detailed Geant4 output
  */
 struct GeantPhysicsOptions
 {
@@ -77,6 +78,8 @@ struct GeantPhysicsOptions
     units::MevEnergy min_energy{0.1 * 1e-3};  // 0.1 keV
     units::MevEnergy max_energy{100 * 1e6};  // 100 TeV
     real_type linear_loss_limit{0.01};
+
+    bool verbose{false};
 };
 
 //! Equality operator, mainly for test harness
@@ -91,7 +94,8 @@ operator==(GeantPhysicsOptions const& a, GeantPhysicsOptions const& b)
            && a.msc == b.msc && a.relaxation == b.relaxation
            && a.em_bins_per_decade == b.em_bins_per_decade
            && a.min_energy == b.min_energy && a.max_energy == b.max_energy
-           && a.linear_loss_limit == b.linear_loss_limit;
+           && a.linear_loss_limit == b.linear_loss_limit
+           && a.verbose == b.verbose;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
+++ b/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
@@ -135,6 +135,7 @@ void from_json(nlohmann::json const& j, GeantPhysicsOptions& options)
     GPO_LOAD_OPTION(min_energy);
     GPO_LOAD_OPTION(max_energy);
     GPO_LOAD_OPTION(linear_loss_limit);
+    GPO_LOAD_OPTION(verbose);
 #undef GPO_LOAD_OPTION
 }
 
@@ -158,6 +159,7 @@ void to_json(nlohmann::json& j, GeantPhysicsOptions const& options)
     GPO_SAVE_OPTION(min_energy);
     GPO_SAVE_OPTION(max_energy);
     GPO_SAVE_OPTION(linear_loss_limit);
+    GPO_SAVE_OPTION(verbose);
 #undef GPO_SAVE_OPTION
 }
 

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -65,6 +65,10 @@ GeantPhysicsList::GeantPhysicsList(Options const& options) : options_(options)
     em_parameters.SetAuger(options.relaxation == RelaxationSelection::all);
     em_parameters.SetIntegral(options.integral_approach);
     em_parameters.SetLinearLossLimit(options.linear_loss_limit);
+
+    int verb = options_.verbose ? 1 : 0;
+    this->SetVerboseLevel(verb);
+    em_parameters.SetVerbose(verb);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -335,6 +335,7 @@ if(CELERITAS_USE_Geant4)
       "KnAlongStepTest.*"
       "Em3AlongStepTest.nofluct_nomsc"
       "Em3AlongStepTest.msc_nofluct"
+      "Em3AlongStepTest.msc_nofluct_finegrid"
       "Em3AlongStepTest.fluct_nomsc"
   )
 else()

--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -149,19 +149,24 @@ auto GeantTestBase::build_geant_options() const -> GeantPhysicsOptions
 // Lazily set up and load geant4
 auto GeantTestBase::imported_data() const -> ImportData const&
 {
+    GeantPhysicsOptions opts = this->build_geant_options();
     ImportHelper& i = GeantTestBase::import_helper();
     if (!i.import)
     {
         i.geometry_basename = this->geometry_basename();
-        i.options = this->build_geant_options();
+        i.options = opts;
         std::string gdml_inp = this->test_data_path(
             "celeritas", (i.geometry_basename + ".gdml").c_str());
         i.import = std::make_unique<GeantImporter>(
             GeantSetup{gdml_inp.c_str(), i.options});
         i.imported = (*i.import)();
+        i.options.verbose = false;
     }
     else
     {
+        // Verbosity change is allowable
+        opts.verbose = false;
+
         static char const explanation[]
             = " (Geant4 cannot be set up twice in one execution: see issue "
               "#462)";
@@ -170,7 +175,7 @@ auto GeantTestBase::imported_data() const -> ImportData const&
                        << this->geometry_basename() << "' when another '"
                        << i.geometry_basename << "' was already set up"
                        << explanation);
-        CELER_VALIDATE(this->build_geant_options() == i.options,
+        CELER_VALIDATE(opts == i.options,
                        << "cannot change physics options after "
                        << explanation);
     }

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -228,11 +228,12 @@ class FourSteelSlabsEmStandard : public GeantImporterTest
     {
         GeantSetup::Options opts;
         opts.relaxation = RelaxationSelection::all;
+        opts.verbose = true;
 #if CELERITAS_USE_JSON
         {
             nlohmann::json out = opts;
             static char const expected[]
-                = R"json({"brems":"all","coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"integral_approach":true,"linear_loss_limit":0.01,"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban","rayleigh_scattering":true,"relaxation":"all"})json";
+                = R"json({"brems":"all","coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"integral_approach":true,"linear_loss_limit":0.01,"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban","rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
             EXPECT_EQ(std::string(expected), std::string(out.dump()));
         }
 #endif


### PR DESCRIPTION
This fixes https://github.com/celeritas-project/celeritas/pull/642#discussion_r1104505415 and turns off the Geant4 physics list diagnostic output (which is shown at the 'diagnostic' level by default).