### PR TITLE
Check for unlikely "zero speed" condition

### DIFF
--- a/src/celeritas/global/alongstep/AlongStep.hh
+++ b/src/celeritas/global/alongstep/AlongStep.hh
@@ -96,10 +96,16 @@ inline CELER_FUNCTION void along_step(MH&& msc,
     // Update track's lab-frame time using the beginning-of-step speed
     {
         auto particle = track.make_particle_view();
+        CELER_ASSERT(!particle.is_stopped());
         real_type speed = native_value_from(particle.speed());
-        CELER_ASSERT(speed > 0);
-        real_type delta_time = local.step_limit.step / speed;
-        sim.add_time(delta_time);
+        CELER_ASSERT(speed >= 0);
+        if (speed > 0)
+        {
+            // For very small energies (< numeric_limits<real_type>::epsilon)
+            // the calculated speed can be zero.
+            real_type delta_time = local.step_limit.step / speed;
+            sim.add_time(delta_time);
+        }
     }
 
     apply_eloss(track, &local.step_limit);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -332,7 +332,7 @@ celeritas_add_test(celeritas/global/ActionRegistry.test.cc)
 if(CELERITAS_USE_Geant4)
   set(_filter
     FILTER
-      "KnAlongStepTest.*"
+      "-Em3*"
       "Em3AlongStepTest.nofluct_nomsc"
       "Em3AlongStepTest.msc_nofluct"
       "Em3AlongStepTest.fluct_nomsc"

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -14,6 +14,7 @@
 #include "celeritas/phys/CutoffParams.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/PhysicsParams.hh"
+#include "celeritas/track/TrackInitParams.hh"
 
 #include "phys/MockProcess.hh"
 
@@ -75,6 +76,11 @@ auto MockTestBase::build_material() -> SPConstMaterial
          MatterState::solid,
          {{ElementId{0}, 0.1}, {ElementId{1}, 0.3}, {ElementId{2}, 0.6}},
          "celer composite"});
+    inp.materials.push_back({1.0,
+                             2.7,
+                             MatterState::gas,
+                             {{ElementId{0}, 1.0}},
+                             "the cold emptiness of space"});
     return std::make_shared<MaterialParams>(std::move(inp));
 }
 
@@ -84,8 +90,10 @@ auto MockTestBase::build_geomaterial() -> SPConstGeoMaterial
     GeoMaterialParams::Input input;
     input.geometry = this->geometry();
     input.materials = this->material();
-    input.volume_to_mat = {MaterialId{0}, MaterialId{2}, MaterialId{1}};
-    input.volume_labels = {Label{"inner"}, Label{"middle"}, Label{"outer"}};
+    input.volume_to_mat
+        = {MaterialId{0}, MaterialId{2}, MaterialId{1}, MaterialId{3}};
+    input.volume_labels
+        = {Label{"inner"}, Label{"middle"}, Label{"outer"}, Label{"world"}};
     return std::make_shared<GeoMaterialParams>(std::move(input));
 }
 
@@ -213,6 +221,15 @@ auto MockTestBase::build_along_step() -> SPConstAction
     CELER_ASSERT(!result->has_msc());
     action_reg.insert(result);
     return result;
+}
+
+//---------------------------------------------------------------------------//
+auto MockTestBase::build_init() -> SPConstTrackInit
+{
+    TrackInitParams::Input input;
+    input.capacity = 4096;
+    input.max_events = 4096;
+    return std::make_shared<TrackInitParams>(input);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/MockTestBase.hh
+++ b/test/celeritas/MockTestBase.hh
@@ -74,7 +74,7 @@ class MockTestBase : virtual public GlobalGeoTestBase
     SPConstCutoff build_cutoff() override;
     SPConstPhysics build_physics() override;
     SPConstAction build_along_step() override;
-    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstTrackInit build_init() override;
 
     virtual PhysicsOptions build_physics_options() const;
 

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -10,6 +10,7 @@
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
 
+#include "../MockTestBase.hh"
 #include "../SimpleTestBase.hh"
 #include "AlongStepTestBase.hh"
 #include "celeritas_test.hh"
@@ -24,7 +25,10 @@ namespace test
 
 class KnAlongStepTest : public SimpleTestBase, public AlongStepTestBase
 {
-  public:
+};
+
+class MockAlongStepTest : public MockTestBase, public AlongStepTestBase
+{
 };
 
 #define Em3AlongStepTest TEST_IF_CELERITAS_GEANT(Em3AlongStepTest)
@@ -84,6 +88,48 @@ TEST_F(KnAlongStepTest, basic)
         EXPECT_SOFT_EQ(3.3386159562990149e-14, result.time);
         EXPECT_SOFT_EQ(0.0010008918838569024, result.step);
         EXPECT_EQ("physics-discrete-select", result.action);
+    }
+}
+
+TEST_F(MockAlongStepTest, basic)
+{
+    size_type num_tracks = 10;
+    Input inp;
+    inp.particle_id = this->particle()->find("celeriton");
+    {
+        inp.energy = MevEnergy{1};
+        auto result = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(0.29312, result.eloss);
+        EXPECT_SOFT_EQ(0.48853333333333, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(1.881667426791e-11, result.time);
+        EXPECT_SOFT_EQ(0.48853333333333, result.step);
+        EXPECT_EQ("eloss-range", result.action);
+    }
+    {
+        inp.energy = MevEnergy{1e-6};
+        auto result = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(1e-06, result.eloss);
+        EXPECT_SOFT_EQ(5.2704627669473e-05, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(1.2431209185653e-12, result.time);
+        EXPECT_SOFT_EQ(5.2704627669473e-05, result.step);
+        EXPECT_EQ("physics-discrete-select", result.action);
+    }
+    {
+        inp.energy = MevEnergy{1e-12};
+        auto result = this->run(inp, num_tracks);
+        EXPECT_SOFT_EQ(1e-12, result.eloss);
+        EXPECT_SOFT_EQ(5.2704627669473e-08, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(1.2430647328325e-12, result.time);
+        EXPECT_SOFT_EQ(5.2704627669473e-08, result.step);
+        EXPECT_EQ("physics-discrete-select", result.action);
+    }
+    {
+        inp.energy = MevEnergy{1e-18};
+        auto result = this->run(inp, num_tracks);
+        result.print_expected();
     }
 }
 

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -129,7 +129,11 @@ TEST_F(MockAlongStepTest, basic)
     {
         inp.energy = MevEnergy{1e-18};
         auto result = this->run(inp, num_tracks);
-        result.print_expected();
+        EXPECT_SOFT_EQ(5.2704627669473e-11, result.displacement);
+        EXPECT_SOFT_EQ(1, result.angle);
+        EXPECT_SOFT_EQ(0, result.time);
+        EXPECT_SOFT_EQ(5.2704627669473e-11, result.step);
+        EXPECT_EQ("physics-discrete-select", result.action);
     }
 }
 

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -129,9 +129,10 @@ TEST_F(PhysicsParamsTest, output)
     if (CELERITAS_USE_JSON)
     {
         EXPECT_EQ(
-            R"json({"models":[{"label":"mock-model-1","process":0},{"label":"mock-model-2","process":0},{"label":"mock-model-3","process":1},{"label":"mock-model-4","process":2},{"label":"mock-model-5","process":2},{"label":"mock-model-6","process":2},{"label":"mock-model-7","process":3},{"label":"mock-model-8","process":3},{"label":"mock-model-9","process":4},{"label":"mock-model-10","process":4},{"label":"mock-model-11","process":5}],"options":{"eloss_calc_limit":[0.001,"MeV"],"fixed_step_limiter":0.0,"linear_loss_limit":0.01,"max_step_over_range":0.2,"min_eprime_over_e":0.8,"min_range":0.1},"processes":[{"label":"scattering"},{"label":"absorption"},{"label":"purrs"},{"label":"hisses"},{"label":"meows"},{"label":"barks"}],"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":4,"process_ids":8,"reals":196,"value_grid_ids":75,"value_grids":75,"value_tables":35}})json",
+            R"json({"models":[{"label":"mock-model-1","process":0},{"label":"mock-model-2","process":0},{"label":"mock-model-3","process":1},{"label":"mock-model-4","process":2},{"label":"mock-model-5","process":2},{"label":"mock-model-6","process":2},{"label":"mock-model-7","process":3},{"label":"mock-model-8","process":3},{"label":"mock-model-9","process":4},{"label":"mock-model-10","process":4},{"label":"mock-model-11","process":5}],"options":{"eloss_calc_limit":[0.001,"MeV"],"fixed_step_limiter":0.0,"linear_loss_limit":0.01,"max_step_over_range":0.2,"min_eprime_over_e":0.8,"min_range":0.1},"processes":[{"label":"scattering"},{"label":"absorption"},{"label":"purrs"},{"label":"hisses"},{"label":"meows"},{"label":"barks"}],"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":4,"process_ids":8,"reals":231,"value_grid_ids":89,"value_grids":89,"value_tables":35}})json",
             to_string(out))
-            << "R\"json(" << to_string(out) << ")json";
+            << "\n/*** REPLACE ***/\nR\"json(" << to_string(out)
+            << ")json\"\n/******/";
     }
 }
 
@@ -419,10 +420,11 @@ TEST_F(PhysicsTrackViewHostTest, value_grids)
     // Grid IDs should be unique if they exist. Gammas should have fewer
     // because there aren't any slowing down/range limiters.
     static int const expected_grid_ids[]
-        = {0,  -1, -1, 3,  -1, -1, 1,  -1, -1, 4,  -1, -1, 2,  -1, -1, 5,
-           -1, -1, 6,  -1, -1, 9,  10, 11, 18, -1, -1, 7,  -1, -1, 12, 13,
-           14, 19, -1, -1, 8,  -1, -1, 15, 16, 17, 20, -1, -1, 21, 22, 23,
-           30, -1, -1, 24, 25, 26, 31, -1, -1, 27, 28, 29, 32, -1, -1};
+        = {0,  -1, -1, 4,  -1, -1, 1,  -1, -1, 5,  -1, -1, 2,  -1, -1, 6,  -1,
+           -1, 3,  -1, -1, 7,  -1, -1, 8,  -1, -1, 12, 13, 14, 24, -1, -1, 9,
+           -1, -1, 15, 16, 17, 25, -1, -1, 10, -1, -1, 18, 19, 20, 26, -1, -1,
+           11, -1, -1, 21, 22, 23, 27, -1, -1, 28, 29, 30, 40, -1, -1, 31, 32,
+           33, 41, -1, -1, 34, 35, 36, 42, -1, -1, 37, 38, 39, 43, -1, -1};
     EXPECT_VEC_EQ(expected_grid_ids, grid_ids);
 }
 
@@ -445,7 +447,8 @@ TEST_F(PhysicsTrackViewHostTest, calc_xs)
         }
     }
 
-    double const expected_xs[] = {0.0001, 0.001, 0.1, 0.0001, 0.001, 0.1};
+    double const expected_xs[]
+        = {0.0001, 0.001, 0.1, 1e-24, 0.0001, 0.001, 0.1, 1e-24};
     EXPECT_VEC_SOFT_EQ(expected_xs, xs);
 }
 


### PR DESCRIPTION
For very small energies the calculated speed of a non-stopped particle can be exactly zero: see the note on `celeritas::ParticleTrackView::beta_sq()`. This only occurs when the `energy / mass` ratio is less than numeric epsilon (so ~1e-17 MeV for electrons). Rather than try to improve the precision of `beta_sq` for massive particles that are nearly at rest (not relevant to the current HEP detectors we're targeting), I've just added a conditional to *not* adjust the global time when the speed is almost zero.

Fixes #616