### PR TITLE
Disable rootmap file for demo-geant-integration dictionary.

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -353,6 +353,8 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_Geant4)
 
   if(CELERITAS_USE_ROOT)
     function(celeritas_local_root_generate_dictionary)
+      # No need for the rootmap file for an executable.
+      set(CMAKE_ROOTTEST_NOROOTMAP TRUE)
       include_directories(
         # root_generate_dictionary can not handle the '$<INSTALL_INTERFACE:include>'
         # part of the Celeritas::corecel target's include, so we can not use it in

--- a/app/demo-geant-integration/HitClassesLinkDef.h
+++ b/app/demo-geant-integration/HitClassesLinkDef.h
@@ -7,6 +7,7 @@
 //! \brief Define the classes added to the ROOT dictionary for app/demo-geant-integration
 //---------------------------------------------------------------------------//
 #ifdef __ROOTCLING__
+// clang-format off
 #pragma link C++ class G4VHit+;
 #pragma link C++ class G4ThreeVector+;
 #pragma link C++ class demo_geant::HitData+;
@@ -15,4 +16,5 @@
 #pragma link C++ class std::vector<G4VHit*>+;
 #pragma link C++ class std::vector<demo_geant::SensitiveHit*>+;
 #pragma link C++ class std::map<std::string, std::vector<G4VHit*> >+;
+// clang-format on
 #endif

--- a/app/demo-geant-integration/HitClassesLinkDef.h
+++ b/app/demo-geant-integration/HitClassesLinkDef.h
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file app/demo-geant-integration/HitClassesLinkDef.h
-//! \brief Define the classes added to the ROOT dictionary for app/demo-geant-integration
+//! \brief Request ROOT for classes used in app/demo-geant-integration
 //---------------------------------------------------------------------------//
 #ifdef __ROOTCLING__
 // clang-format off


### PR DESCRIPTION
Also disable clang-format on content of HitClassesLinkDef.h