### PR TITLE
Characterize and remove field driver convergence assertions

### DIFF
--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -194,9 +194,6 @@ FieldDriver<StepperT>::find_next_chord(real_type step,
         }
     } while (!succeeded && --remaining_steps > 0);
 
-    // TODO: loop check and handle rare cases if happen
-    CELER_ASSERT(succeeded);
-
     // Update step, position and momentum
     output.end.step = step;
     output.end.state = result.end_state;
@@ -259,9 +256,6 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
                 end_curve_length - curve_length);
         }
     } while (!succeeded && --remaining_steps > 0);
-
-    // TODO: loop check and handle rare cases if happen
-    CELER_ASSERT(succeeded);
 
     output.end.step = curve_length;
     return output.end;
@@ -347,9 +341,6 @@ FieldDriver<StepperT>::one_good_step(real_type step, OdeState const& state) cons
             succeeded = true;
         }
     } while (!succeeded && --remaining_steps > 0);
-
-    // TODO: loop check and handle rare cases if happen
-    CELER_ASSERT(succeeded);
 
     // Update state, step taken by this trial and the next predicted step
     output.end.state = result.end_state;

--- a/src/corecel/io/Repr.hh
+++ b/src/corecel/io/Repr.hh
@@ -240,7 +240,7 @@ struct ReprTraits<char*>
 {
     static void print_type(std::ostream& os, char const* name = nullptr)
     {
-        detail::print_simple_type(os, "const char*", name);
+        detail::print_simple_type(os, "char const*", name);
     }
 
     static void init(std::ostream&) {}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,7 +108,7 @@ endif()
 # GOOGLETEST EXTENSION TESTS
 #-----------------------------------------------------------------------------#
 
-celeritas_setup_tests(SERIAL PREFIX detail)
+celeritas_setup_tests(SERIAL PREFIX testdetail)
 
 celeritas_add_test(TestMacros.test.cc)
 

--- a/test/TestMacros.test.cc
+++ b/test/TestMacros.test.cc
@@ -50,10 +50,10 @@ TEST(PrintExpected, example)
     }
     out_result.push_back('\n');
     EXPECT_EQ(R"(
-static const int expected_values[] = {1, 2, 3};
-static const double expected_more[] = {0.5, 0.001, inf, nan};
-static const const char* expected_cstrings[] = {"one", "three", "five"};
-static const std::string expected_strings[] = {"a", "", "special\nchars\t"};
+static int const expected_values[] = {1, 2, 3};
+static double const expected_more[] = {0.5, 0.001, inf, nan};
+static char const* const expected_cstrings[] = {"one", "three", "five"};
+static std::string const expected_strings[] = {"a", "", "special\nchars\t"};
 )",
               out_result);
 }

--- a/test/celeritas/field/DiagnosticStepper.hh
+++ b/test/celeritas/field/DiagnosticStepper.hh
@@ -57,5 +57,5 @@ class DiagnosticStepper
 };
 
 //---------------------------------------------------------------------------//
-}  // namespace celeritas
+}  // namespace test
 }  // namespace celeritas

--- a/test/celeritas/field/DiagnosticStepper.hh
+++ b/test/celeritas/field/DiagnosticStepper.hh
@@ -14,6 +14,8 @@
 
 namespace celeritas
 {
+namespace test
+{
 //---------------------------------------------------------------------------//
 /*!
  * Count the number of invocations to the field stepper.
@@ -55,4 +57,5 @@ class DiagnosticStepper
 };
 
 //---------------------------------------------------------------------------//
+}  // namespace celeritas
 }  // namespace celeritas

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -19,10 +19,20 @@
 #include "celeritas/field/MakeMagFieldPropagator.hh"
 #include "celeritas/field/Types.hh"
 #include "celeritas/field/UniformField.hh"
+#include "celeritas/field/detail/FieldUtils.hh"
 
 #include "DiagnosticStepper.hh"
 #include "FieldTestParams.hh"
 #include "celeritas_test.hh"
+
+using celeritas::units::MevEnergy;
+using celeritas::units::MevMass;
+using celeritas::units::MevMomentum;
+using celeritas::units::ElementaryCharge;
+using celeritas::constants::sqrt_two;
+
+template<class E>
+using DiagnosticDPStepper = celeritas::test::DiagnosticStepper<celeritas::DormandPrinceStepper<E>>;
 
 namespace celeritas
 {
@@ -34,19 +44,45 @@ namespace test
 
 class FieldDriverTest : public Test
 {
+  public:
+    static constexpr MevMass electron_mass() { return MevMass{0.5109989461}; }
+    static constexpr ElementaryCharge electron_charge() { return ElementaryCharge{-1}; }
+
+    // Calculate momentum assuming an electron
+    MevMomentum calc_momentum(MevEnergy energy) const
+    {
+        real_type m = electron_mass().value();
+        real_type e = energy.value();
+        return MevMomentum{std::sqrt(e * e + 2 * m * e)};
+    }
+
+    // Get the momentum in units of MevMomentum
+    Real3 calc_momentum(MevEnergy energy, Real3 const& dir)
+    {
+        CELER_EXPECT(is_soft_unit_vector(dir));
+        return detail::ax(this->calc_momentum(energy).value(), dir);
+    }
+
+    // Calculate momentum assuming an electron
+    real_type calc_curvature(MevEnergy energy, real_type field_strength) const
+    {
+        CELER_EXPECT(field_strength > 0);
+        return native_value_from(calc_momentum(energy))
+               / (std::fabs(native_value_from(electron_charge()))
+                  * field_strength);
+    }
+};
+
+class RevolutionFieldDriverTest : public FieldDriverTest
+{
   protected:
     void SetUp() override
     {
         // Input parameters of an electron in a uniform magnetic field
-        test_params.nstates = 1;
         test_params.nsteps = 100;
         test_params.revolutions = 10;
-        test_params.field_value = 1.0 * units::tesla;
         test_params.radius = 3.8085386036 * units::centimeter;
         test_params.delta_z = 6.7003310629 * units::centimeter;
-        test_params.energy = 10.9181415106;  // MeV
-        test_params.momentum_y = 10.9610028286;  // MeV/c
-        test_params.momentum_z = 3.1969591583;  // MeV/c
         test_params.epsilon = 1.0e-5;
     }
 
@@ -78,10 +114,11 @@ make_mag_field_driver(FieldT&& field,
 
 TEST_F(FieldDriverTest, types)
 {
+    FieldDriverOptions driver_options;
     auto driver = make_mag_field_driver<DormandPrinceStepper>(
-        UniformField({0, 0, test_params.field_value}),
+        UniformField({0, 0, 1}),
         driver_options,
-        units::ElementaryCharge{-1});
+        electron_charge());
 
     // Make sure object is holding things by value
     EXPECT_TRUE(
@@ -93,12 +130,68 @@ TEST_F(FieldDriverTest, types)
               sizeof(driver));
 }
 
-TEST_F(FieldDriverTest, revolutions)
+TEST_F(FieldDriverTest, step_counts)
+{
+    FieldDriverOptions driver_options;
+    driver_options.max_nsteps = std::numeric_limits<short int>::max();
+
+    real_type field_strength = 1.0 * units::tesla;
+    auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
+        UniformField({0, 0, field_strength}), units::ElementaryCharge{-1});
+    FieldDriver<decltype(stepper)&> driver{driver_options, stepper};
+
+    std::vector<real_type> energy;
+    std::vector<real_type> radii;
+    std::vector<unsigned int> counts;
+    std::vector<real_type> lengths;
+
+    // Test the number of field equation evaluations that have to be done to
+    // travel a step length of 10 cm, for electrons from 0.1 eV to 10 TeV.
+    for (int loge : range(-7, 7).step(1))
+    {
+        MevEnergy e{std::pow(10, loge)};
+        real_type radius = this->calc_curvature(e, field_strength);
+
+        OdeState state;
+        state.pos = {radius, 0, 0};
+        state.mom = this->calc_momentum(e, {0, sqrt_two/2, sqrt_two/2});
+
+        stepper.reset_count();
+        auto end = driver.advance(10 * units::centimeter, state);
+
+        energy.push_back(e.value());
+        radii.push_back(radius);
+        counts.push_back(stepper.count());
+        lengths.push_back(end.step);
+    }
+
+    // clang-format off
+    static double const expected_radii[] = {0.00010663611598835,
+        0.00033721315583664, 0.0010663663247419, 0.0033722948818996,
+        0.010668826843187, 0.033885874824232, 0.11173141982667,
+        0.47431804394274, 3.5019461121752, 33.526427131057, 333.73450257138,
+        3335.8113985278, 33356.579970281, 333564.26564901};
+    static unsigned int const expected_counts[] = {782u, 247u, 92u, 45u, 31u,
+        13u, 10u, 8u, 6u, 4u, 2u, 1u, 1u, 1u};
+    static double const expected_lengths[] = {0.077562380895466,
+        0.077251971561029, 0.076209747456898, 0.072434474486632,
+        0.063064404446822, 0.085308004478855, 0.15625, 0.36823861947329,
+        0.99606722344324, 3.0796706094122, 9.7157674620814, 10, 10, 10};
+    // clang-format on
+
+    EXPECT_VEC_SOFT_EQ(expected_radii, radii);
+    EXPECT_VEC_EQ(expected_counts, counts);
+    EXPECT_VEC_SOFT_EQ(expected_lengths, lengths);
+}
+
+//---------------------------------------------------------------------------//
+
+TEST_F(RevolutionFieldDriverTest, advance)
 {
     auto driver = make_mag_field_driver<DormandPrinceStepper>(
-        UniformField({0, 0, test_params.field_value}),
+        UniformField({0, 0, 1.0 * units::tesla}),
         driver_options,
-        units::ElementaryCharge{-1});
+        electron_charge());
 
     // Test parameters and the sub-step size
     real_type circumference = 2 * constants::pi * test_params.radius;
@@ -107,7 +200,7 @@ TEST_F(FieldDriverTest, revolutions)
     // Initial state and the epected state after revolutions
     OdeState y;
     y.pos = {test_params.radius, 0, 0};
-    y.mom = {0, test_params.momentum_y, test_params.momentum_z};
+    y.mom = this->calc_momentum(MevEnergy{10.9181415106}, {0, 0.96, 0.28});
 
     OdeState y_expected = y;
 
@@ -137,12 +230,12 @@ TEST_F(FieldDriverTest, revolutions)
         total_step_length, circumference * test_params.revolutions, delta);
 }
 
-TEST_F(FieldDriverTest, accurate_advance)
+TEST_F(RevolutionFieldDriverTest, accurate_advance)
 {
     auto driver = make_mag_field_driver<DormandPrinceStepper>(
-        UniformField({0, 0, test_params.field_value}),
+        UniformField({0, 0, 1.0 * units::tesla}),
         driver_options,
-        units::ElementaryCharge{-1});
+        electron_charge());
 
     // Test parameters and the sub-step size
     real_type circumference = 2 * constants::pi * test_params.radius;
@@ -151,7 +244,7 @@ TEST_F(FieldDriverTest, accurate_advance)
     // Initial state and the epected state after revolutions
     OdeState y;
     y.pos = {test_params.radius, 0, 0};
-    y.mom = {0, test_params.momentum_y, test_params.momentum_z};
+    y.mom = this->calc_momentum(MevEnergy{10.9181415106}, {0, 0.96, 0.28});
 
     OdeState y_expected = y;
 

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -25,14 +25,15 @@
 #include "FieldTestParams.hh"
 #include "celeritas_test.hh"
 
+using celeritas::constants::sqrt_two;
+using celeritas::units::ElementaryCharge;
 using celeritas::units::MevEnergy;
 using celeritas::units::MevMass;
 using celeritas::units::MevMomentum;
-using celeritas::units::ElementaryCharge;
-using celeritas::constants::sqrt_two;
 
 template<class E>
-using DiagnosticDPStepper = celeritas::test::DiagnosticStepper<celeritas::DormandPrinceStepper<E>>;
+using DiagnosticDPStepper
+    = celeritas::test::DiagnosticStepper<celeritas::DormandPrinceStepper<E>>;
 
 namespace celeritas
 {
@@ -46,7 +47,10 @@ class FieldDriverTest : public Test
 {
   public:
     static constexpr MevMass electron_mass() { return MevMass{0.5109989461}; }
-    static constexpr ElementaryCharge electron_charge() { return ElementaryCharge{-1}; }
+    static constexpr ElementaryCharge electron_charge()
+    {
+        return ElementaryCharge{-1};
+    }
 
     // Calculate momentum assuming an electron
     MevMomentum calc_momentum(MevEnergy energy) const
@@ -116,9 +120,7 @@ TEST_F(FieldDriverTest, types)
 {
     FieldDriverOptions driver_options;
     auto driver = make_mag_field_driver<DormandPrinceStepper>(
-        UniformField({0, 0, 1}),
-        driver_options,
-        electron_charge());
+        UniformField({0, 0, 1}), driver_options, electron_charge());
 
     // Make sure object is holding things by value
     EXPECT_TRUE(
@@ -154,7 +156,7 @@ TEST_F(FieldDriverTest, step_counts)
 
         OdeState state;
         state.pos = {radius, 0, 0};
-        state.mom = this->calc_momentum(e, {0, sqrt_two/2, sqrt_two/2});
+        state.mom = this->calc_momentum(e, {0, sqrt_two / 2, sqrt_two / 2});
 
         stepper.reset_count();
         auto end = driver.advance(10 * units::centimeter, state);

--- a/test/testdetail/TestMacrosImpl.hh
+++ b/test/testdetail/TestMacrosImpl.hh
@@ -413,8 +413,8 @@ void print_expected(Container const& data, std::string label)
     using RT = ReprTraits<Container>;
     using VRT = ReprTraits<typename RT::value_type>;
 
-    std::cout << "static const ";
-    label.insert(0, "expected_");
+    std::cout << "static ";
+    label.insert(0, "const expected_");
     VRT::print_type(std::cout, label.c_str());
     std::cout << "[] = ";
 


### PR DESCRIPTION
This demonstrates that #619 will be fixed by properly killing particles less than ~1 keV. The number of equation evaluations required to meet the FieldDriver 'accurate' tolerance increases rapidly with decreasing energy below 1 keV for electrons. At 1 MeV, ~10 steps are required to converge on a ~0.4cm step from a 10cm physics length. At 1 eV, ~250 are required for a 0.08cm step. So if we have low energy tracks in a low density material we're really screwed.