### PR TITLE
Fix coincident boundary/step created by field propagator

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,6 +93,15 @@
       }
     },
     {
+      "name": ".reldeb",
+      "hidden": true,
+      "description": "Enable debug with basic optimizations",
+      "cacheVariables": {
+        "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "ON"},
+        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "RelWithDebInfo"}
+      }
+    },
+    {
       "name": ".spack-base",
       "description": "Setup for using spack environment",
       "hidden": true,

--- a/scripts/cmake-presets/goldfinger.json
+++ b/scripts/cmake-presets/goldfinger.json
@@ -20,6 +20,7 @@
         "CMAKE_CXX_STANDARD":   {"type": "STRING",   "value": "17"},
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL",   "value": "OFF"},
         "CMAKE_FIND_FRAMEWORK": {"type": "STRING", "value": "LAST"},
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fno-inline -fno-omit-frame-pointer",
         "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-error=deprecated -pedantic -fdiagnostics-color=always"
       }
     },
@@ -51,6 +52,15 @@
       "inherits": [".base", "default"],
       "cacheVariables": {
         "CELERITAS_USE_VecGeom": {"type": "BOOL",   "value": "ON"}
+      }
+    },
+    {
+      "name": "vecgeom-reldeb",
+      "displayName": "With vecgeom in optimized mode",
+      "inherits": [".reldeb", "vecgeom"],
+      "cacheVariables": {
+        "CELERITAS_BUILD_DEMOS": {"type": "BOOL", "value": "ON"},
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "ON"}
       }
     },
     {

--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -19,6 +19,7 @@
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
         "CMAKE_CXX_COMPILER": "/usr/bin/g++",
         "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always",
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG  -fno-inline  -fno-omit-frame-pointer",
         "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=skylake-avx512 -mtune=skylake-avx512",
         "CMAKE_CUDA_FLAGS": "-Werror all-warnings  -Wno-deprecated-gpu-targets",
         "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"},

--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -19,20 +19,11 @@
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
         "CMAKE_CXX_COMPILER": "/usr/bin/g++",
         "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always",
-        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG  -fno-inline  -fno-omit-frame-pointer",
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fno-inline -fno-omit-frame-pointer",
         "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=skylake-avx512 -mtune=skylake-avx512",
         "CMAKE_CUDA_FLAGS": "-Werror all-warnings  -Wno-deprecated-gpu-targets",
         "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"},
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}"
-      }
-    },
-    {
-      "name": ".reldeb",
-      "hidden": true,
-      "description": "Enable debug with basic optimizations",
-      "cacheVariables": {
-        "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "ON"},
-        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "RelWithDebInfo"}
       }
     },
     {

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -162,8 +162,9 @@ FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
         output.end = this->accurate_advance(output.end.step, state, next_step);
     }
 
-    CELER_ENSURE(output.end.step > 0 && output.end.step <= step
-                 || soft_equal(output.end.step, step));
+    CELER_ENSURE(
+        output.end.step > 0
+        && (output.end.step <= step || soft_equal(output.end.step, step)));
     return output.end;
 }
 
@@ -277,8 +278,8 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
 
     // Curve length may be slightly longer than step due to roundoff in
     // accumulation
-    CELER_ENSURE(curve_length > 0 && curve_length <= step
-                 || soft_equal(curve_length, step));
+    CELER_ENSURE(curve_length > 0
+                 && (curve_length <= step || soft_equal(curve_length, step)));
     output.end.step = curve_length;
     return output.end;
 }

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -82,11 +82,11 @@ class FieldDriver
 
     //// HEPER FUNCTIONS ////
 
-    // Find the next acceptable chord of with the miss-distance
+    // Find the next acceptable chord whose sagitta is less than delta_chord
     inline CELER_FUNCTION ChordSearch
     find_next_chord(real_type step, OdeState const& state) const;
 
-    // Advance for a given step and  evaluate the next predicted step.
+    // Advance for a given step and evaluate the next predicted step.
     inline CELER_FUNCTION Integration
     integrate_step(real_type step, OdeState const& state) const;
 
@@ -128,7 +128,7 @@ FieldDriver<StepperT>::FieldDriver(FieldDriverOptions const& options,
  *
  * For a given trial step, advance by a sub-step within a required tolerance
  * and update the current state (position and momentum).  For an efficient
- * adaptive integration, the proposed chord of which the miss-distance (the
+ * adaptive integration, the proposed chord of which the sagitta (the
  * closest distance from the curved trajectory to the chord) is smaller than
  * a reference distance (dist_chord) will be accepted if its stepping error is
  * within a reference accuracy. Otherwise, the more accurate step integration
@@ -170,7 +170,7 @@ FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Find the next acceptable chord of which the miss-distance is smaller than
+ * Find the next acceptable chord of which the sagitta is smaller than
  * a given reference (delta_chord) and evaluate the associated error.
  */
 template<class StepperT>

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -22,7 +22,7 @@ struct FieldDriverOptions
     //! The minimum length of the field step
     real_type minimum_step = 1.0e-5 * units::millimeter;
 
-    //! The closest miss distance
+    //! The maximum sagitta of each substep ("miss distance")
     real_type delta_chord = 0.25 * units::millimeter;
 
     //! Accuracy of intersection of the boundary crossing

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -214,7 +214,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // on a reentrant boundary crossing below.
             state_ = substep.state;
             result.boundary = false;
-            result.distance += substep.step;
+            result.distance += celeritas::min(substep.step, remaining);
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
             --remaining_substeps;

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -243,8 +243,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // The update length can be slightly greater than the substep due
             // to the extra delta_intersection boost when searching. The
             // substep itself can be more than the requested step.
-            result.distance += celeritas::min(
-                celeritas::min(update_length, substep.step), remaining);
+            result.distance += celeritas::min(update_length, substep.step);
             CELER_ASSERT(result.distance <= step);
             state_.mom = substep.state.mom;
             remaining = 0;
@@ -286,8 +285,13 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         geo_.move_internal(state_.pos);
     }
 
+    // Due to accumulation errors from multiple substeps or chord-finding
+    // within the driver, the distance may be very slightly beyond the
+    // requested step.
     CELER_ENSURE(result.boundary == geo_.is_on_boundary());
-    CELER_ENSURE(result.distance > 0 && result.distance <= step);
+    CELER_ENSURE(
+        result.distance > 0
+        && (result.distance <= step || soft_equal(result.distance, step)));
     return result;
 }
 

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <iostream>
+
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/ArrayIO.hh"
@@ -19,6 +21,8 @@
 
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
+using std::cout;
+using std::endl;
 
 namespace celeritas
 {
@@ -142,6 +146,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     result.boundary = geo_.is_on_boundary();
     result.distance = 0;
 
+    cout << color_code('b') << "Propagate up to " << step << color_code(' ')
+         << endl;
+
     // Break the curved steps into substeps as determined by the driver *and*
     // by the proximity of geometry boundaries. Test for intersection with the
     // geometry boundary in each substep. This loop is guaranteed to converge
@@ -156,6 +163,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // Advance up to (but probably less than) the remaining step length
         // Due to roundoff this may be slightly more than remaining.
         DriverResult substep = driver_.advance(remaining, state_);
+
+        cout << "- advance(" << remaining << ", " << state_.pos << ") -> {"
+             << substep.step << ", " << substep.state.pos << "}" << endl;
 
         // Check whether the chord for this sub-step intersects a boundary
         auto chord = detail::make_chord(state_.pos, substep.state.pos);
@@ -185,6 +195,15 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         real_type const update_length = substep.step * linear_step.distance
                                         / chord.length;
 
+        cout << " + chord length " << chord.length << " => linear step "
+             << linear_step.distance;
+        if (linear_step.boundary)
+        {
+            cout << " (hit surface " << geo_.next_surface_id().unchecked_get()
+                 << ')';
+        }
+        cout << ": update length " << update_length << '\n';
+
         if (!linear_step.boundary)
         {
             // No boundary intersection along the chord: accept substep
@@ -199,6 +218,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
             --remaining_substeps;
+            cout << " + advancing to substep end point (" << remaining_substeps
+                 << " remaining)" << endl;
         }
         else if (CELER_UNLIKELY(result.boundary
                                 && linear_step.distance < this->bump_distance()))
@@ -207,6 +228,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // surface (this can happen when tracking through a volume at a
             // near tangent). Reduce substep size and try again.
             remaining = substep.step / 2;
+            cout << " + halving substep distance" << endl;
         }
         else if (update_length <= driver_.minimum_step()
                  || detail::is_intercept_close(state_.pos,
@@ -225,6 +247,22 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // conservatively reduce the *reported* traveled distance to avoid
             // coincident boundary crossings.
 
+            if (update_length <= driver_.minimum_step())
+            {
+                cout << " + next trial step exceeds driver minimum "
+                     << driver_.minimum_step();
+            }
+            else
+            {
+                cout << " + intercept is sufficiently close (miss distance = "
+                     << std::sqrt(
+                            detail::calc_miss_distance_sq(state_.pos,
+                                                          chord.dir,
+                                                          linear_step.distance,
+                                                          substep.state.pos))
+                     << ") to substep point: ";
+            }
+
             // Only cross the boundary if the intersect point is less
             // than or exactly on the boundary, or if the crossing
             // doesn't put us past the end of the step
@@ -235,7 +273,13 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
                 // Don't move to the boundary, but instead move to the end of
                 // the substep.
                 geo_.move_internal(substep.state.pos);
+                cout << "moved to " << substep.state.pos;
             }
+            else
+            {
+                cout << "moved to boundary";
+            }
+            cout << endl;
 
             // The update length can be slightly greater than the substep due
             // to the extra delta_intersection boost when searching.
@@ -250,6 +294,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // Decrease the allowed substep (curved path distance) by the
             // fraction along the chord, and retry the driver step.
             remaining = update_length;
+            cout << " + Setting remaining distance to a fraction "
+                 << linear_step.distance / chord.length << " of the substep"
+                 << endl;
         }
     } while (remaining >= driver_.minimum_step() && remaining_substeps > 0);
 
@@ -260,6 +307,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // because of the tolerance in the intercept checks above).
         geo_.move_to_boundary();
         state_.pos = geo_.pos();
+        cout << "- Moved to boundary " << geo_.surface_id().unchecked_get()
+             << " at position " << state_.pos << endl;
     }
     CELER_ASSERT(remaining == 0 || remaining_substeps == 0);
 
@@ -281,6 +330,10 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         axpy(result.distance, dir, &state_.pos);
         geo_.move_internal(state_.pos);
     }
+
+    cout << color_code('g') << "==> distance " << result.distance
+         << color_code(' ') << " (in "
+         << this->max_substeps() - remaining_substeps << " steps)" << endl;
 
     CELER_ENSURE(result.boundary == geo_.is_on_boundary());
     CELER_ENSURE(result.distance > 0 && result.distance <= step);

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -7,8 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <iostream>
-
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/ArrayIO.hh"
@@ -21,8 +19,6 @@
 
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
-using std::cout;
-using std::endl;
 
 namespace celeritas
 {
@@ -146,9 +142,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
     result.boundary = geo_.is_on_boundary();
     result.distance = 0;
 
-    cout << color_code('b') << "Propagate up to " << step << color_code(' ')
-         << endl;
-
     // Break the curved steps into substeps as determined by the driver *and*
     // by the proximity of geometry boundaries. Test for intersection with the
     // geometry boundary in each substep. This loop is guaranteed to converge
@@ -163,9 +156,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // Advance up to (but probably less than) the remaining step length
         // Due to roundoff this may be slightly more than remaining.
         DriverResult substep = driver_.advance(remaining, state_);
-
-        cout << "- advance(" << remaining << ", " << state_.pos << ") -> {"
-             << substep.step << ", " << substep.state.pos << "}" << endl;
 
         // Check whether the chord for this sub-step intersects a boundary
         auto chord = detail::make_chord(state_.pos, substep.state.pos);
@@ -195,15 +185,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         real_type const update_length = substep.step * linear_step.distance
                                         / chord.length;
 
-        cout << " + chord length " << chord.length << " => linear step "
-             << linear_step.distance;
-        if (linear_step.boundary)
-        {
-            cout << " (hit surface " << geo_.next_surface_id().unchecked_get()
-                 << ')';
-        }
-        cout << ": update length " << update_length << '\n';
-
         if (!linear_step.boundary)
         {
             // No boundary intersection along the chord: accept substep
@@ -218,8 +199,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
             --remaining_substeps;
-            cout << " + advancing to substep end point (" << remaining_substeps
-                 << " remaining)" << endl;
         }
         else if (CELER_UNLIKELY(result.boundary
                                 && linear_step.distance < this->bump_distance()))
@@ -228,7 +207,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // surface (this can happen when tracking through a volume at a
             // near tangent). Reduce substep size and try again.
             remaining = substep.step / 2;
-            cout << " + halving substep distance" << endl;
         }
         else if (update_length <= driver_.minimum_step()
                  || detail::is_intercept_close(state_.pos,
@@ -247,22 +225,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // conservatively reduce the *reported* traveled distance to avoid
             // coincident boundary crossings.
 
-            if (update_length <= driver_.minimum_step())
-            {
-                cout << " + next trial step exceeds driver minimum "
-                     << driver_.minimum_step();
-            }
-            else
-            {
-                cout << " + intercept is sufficiently close (miss distance = "
-                     << std::sqrt(
-                            detail::calc_miss_distance_sq(state_.pos,
-                                                          chord.dir,
-                                                          linear_step.distance,
-                                                          substep.state.pos))
-                     << ") to substep point: ";
-            }
-
             // Only cross the boundary if the intersect point is less
             // than or exactly on the boundary, or if the crossing
             // doesn't put us past the end of the step
@@ -276,13 +238,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
                 // as "!linear_step.boundary" above.
                 state_.pos = substep.state.pos;
                 geo_.move_internal(substep.state.pos);
-                cout << "moved to " << substep.state.pos;
             }
-            else
-            {
-                cout << "moved to boundary";
-            }
-            cout << endl;
 
             // The update length can be slightly greater than the substep due
             // to the extra delta_intersection boost when searching. The
@@ -299,9 +255,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // Decrease the allowed substep (curved path distance) by the
             // fraction along the chord, and retry the driver step.
             remaining = update_length;
-            cout << " + Setting remaining distance to a fraction "
-                 << linear_step.distance / chord.length << " of the substep"
-                 << endl;
         }
     } while (remaining >= driver_.minimum_step() && remaining_substeps > 0);
 
@@ -312,8 +265,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         // because of the tolerance in the intercept checks above).
         geo_.move_to_boundary();
         state_.pos = geo_.pos();
-        cout << "- Moved to boundary " << geo_.surface_id().unchecked_get()
-             << " at position " << state_.pos << endl;
     }
 
     // Even though the along-substep movement was through chord lengths,
@@ -334,10 +285,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         axpy(result.distance, dir, &state_.pos);
         geo_.move_internal(state_.pos);
     }
-
-    cout << color_code('g') << "==> distance " << result.distance
-         << color_code(' ') << " (in "
-         << this->max_substeps() - remaining_substeps << " steps)" << endl;
 
     CELER_ENSURE(result.boundary == geo_.is_on_boundary());
     CELER_ENSURE(result.distance > 0 && result.distance <= step);

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -226,9 +226,10 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // conservatively reduce the *reported* traveled distance to avoid
             // coincident boundary crossings.
             result.boundary = true;
-            real_type miss_distance = detail::calc_miss_distance(
-                state_.pos, chord.dir, linear_step.distance, substep.state.pos);
-            CELER_ASSERT(miss_distance >= 0 && miss_distance < substep.step);
+            real_type miss_distance = std::sqrt(detail::calc_miss_distance_sq(
+                state_.pos, chord.dir, linear_step.distance, substep.state.pos));
+            CELER_ASSERT(miss_distance >= 0
+                         && miss_distance <= driver_.delta_intersection());
             result.distance += substep.step - miss_distance;
             state_.mom = substep.state.mom;
             remaining = 0;

--- a/src/celeritas/field/detail/FieldUtils.hh
+++ b/src/celeritas/field/detail/FieldUtils.hh
@@ -81,10 +81,10 @@ inline CELER_FUNCTION Chord make_chord(Real3 const& src, Real3 const& dst)
      return ipow<2>(distance(pos, target));
  * \endcode
  */
-inline CELER_FUNCTION real_type calc_miss_distance(Real3 const& pos,
-                                                   Real3 const& dir,
-                                                   real_type distance,
-                                                   Real3 const& target)
+inline CELER_FUNCTION real_type calc_miss_distance_sq(Real3 const& pos,
+                                                      Real3 const& dir,
+                                                      real_type distance,
+                                                      Real3 const& target)
 {
     real_type delta_sq = 0;
     for (int i = 0; i < 3; ++i)
@@ -112,7 +112,8 @@ inline CELER_FUNCTION bool is_intercept_close(Real3 const& pos,
                                               Real3 const& target,
                                               real_type tolerance)
 {
-    return calc_miss_distance(pos, dir, distance, target) <= ipow<2>(tolerance);
+    return calc_miss_distance_sq(pos, dir, distance, target)
+           <= ipow<2>(tolerance);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/detail/FieldUtils.hh
+++ b/src/celeritas/field/detail/FieldUtils.hh
@@ -71,31 +71,6 @@ inline CELER_FUNCTION Chord make_chord(Real3 const& src, Real3 const& dst)
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate the distance between a target point and a line segment's endpoint.
- *
- * This is equivalent to:
- * \code
-     Real3 temp = pos;
-     axpy(distance, dir, &pos);
-
-     return ipow<2>(distance(pos, target));
- * \endcode
- */
-inline CELER_FUNCTION real_type calc_miss_distance_sq(Real3 const& pos,
-                                                      Real3 const& dir,
-                                                      real_type distance,
-                                                      Real3 const& target)
-{
-    real_type delta_sq = 0;
-    for (int i = 0; i < 3; ++i)
-    {
-        delta_sq += ipow<2>(pos[i] - target[i] + distance * dir[i]);
-    }
-    return delta_sq;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Whether the straight-line position is within a distance of the target.
  *
  * This is equivalent to:
@@ -112,8 +87,12 @@ inline CELER_FUNCTION bool is_intercept_close(Real3 const& pos,
                                               Real3 const& target,
                                               real_type tolerance)
 {
-    return calc_miss_distance_sq(pos, dir, distance, target)
-           <= ipow<2>(tolerance);
+    real_type delta_sq = 0;
+    for (int i = 0; i < 3; ++i)
+    {
+        delta_sq += ipow<2>(pos[i] - target[i] + distance * dir[i]);
+    }
+    return delta_sq <= ipow<2>(tolerance);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -436,7 +436,7 @@ TEST_F(TwoBoxTest, gamma_exit)
             = make_field_propagator(stepper, driver_options, particle, &geo);
         auto result = propagate(0.251 + 1e-7);
 
-        EXPECT_SOFT_EQ(0.251 + 1e-7, result.distance);
+        EXPECT_SOFT_EQ(0.251, result.distance);
         EXPECT_TRUE(result.boundary);
         EXPECT_LT(distance(Real3({2, 5, 0}), geo.pos()), 1e-5);
         EXPECT_EQ(1, stepper.count());
@@ -868,12 +868,12 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
         /*
           Propagate up to 0.448159
           - advance(0.448159, {-4.89125,-0.433307,0})
-                -> {0.448159, {-4.99,8.24444e-08,0}}
-           + chord length 0.444418 => linear step 0.489419 (boundary!)
-           + intercept is sufficiently close (miss distance = 0.00202515) to
+             -> {0.448159, {-4.99,8.24444e-08,0}}
+           + chord length 0.444418 => linear step 0.489419 (hit surface 6)
+           + intercept is sufficiently close (miss distance = 0.0450017) to
              substep point
-          - Moved to boundary at position {-5,0.0438767,0}
-        */
+          - Moved to boundary 6 at position {-5,0.0438767,0}
+         */
 
         real_type dx = 0.1 * driver_options.delta_intersection;
         Real3 start_pos{-5 + dx, 0, 0};
@@ -888,7 +888,8 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
 
         EXPECT_TRUE(result.boundary);
         EXPECT_EQ(3, stepper.count());
-        EXPECT_SOFT_EQ(result.distance, 0.44613354562833657);
+        EXPECT_SOFT_EQ(0.40315701480314531, result.distance);
+        EXPECT_LT(result.distance, first_step);
         EXPECT_LT(distance(Real3{-5, 0.043876682150692459, 0}, geo.pos()), 1e-8)
             << geo.pos();
     }
@@ -908,7 +909,8 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
 
         EXPECT_TRUE(result.boundary);
         EXPECT_EQ(3, stepper.count());
-        EXPECT_SOFT_NEAR(result.distance, first_step, 1e-10);
+        EXPECT_SOFT_NEAR(result.distance, first_step, 1e-5);
+        EXPECT_LT(result.distance, first_step);
         // Y position suffers from roundoff
         EXPECT_LT(distance(Real3{-5.0, -9.26396730438483e-07, 0}, geo.pos()),
                   1e-8);
@@ -977,9 +979,9 @@ TEST_F(TwoBoxTest, electron_tangent_cross_smallradius)
     static int const expected_boundary[] = {1, 1, 1, 1, 1, 0, 1, 0, 1, 0};
     EXPECT_VEC_EQ(expected_boundary, boundary);
     static double const expected_distances[] = {0.00785398163,
-                                                0.00282334500,
+                                                0.00281586026,
                                                 0.00448798951,
-                                                0.00282597035,
+                                                0.00282112800,
                                                 1e-05,
                                                 1e-05,
                                                 1e-08,


### PR DESCRIPTION
While debugging the coincident range + boundary problem we discovered after removing the fixup in #650, I discovered that the "miss distance" calculation (responsible for reducing the reported distance to the boundary) 
There was a missing `sqrt` because of a badly chosen function name, so that the distance being subtracted off was microscopic (1e-13 instead of 1e-7) and ignored due to roundoff.

Looking again in more detail it's clear that we were hitting many coincident boundaries + physics step because the field propagator "snaps" steps to the boundary if the intersection point is close. I have updated the field propagator so that we accept a trial boundary only if (1) the intersection point is *closer* than the substep endpoint, in which case the resulting distance is guaranteed less than the requested step, or (2) moving past the boundary point doesn't put us past the end of the requested step.

The result is that we can move to boundaries when it's safe and stop before boundaries if we're about to undergo a physics interaction.

This new code is a bit messy, and there are several new `min`s corresponding to different conditions, but each use of those is justified, and we might be able to simplify after some more discussion.