### PR TITLE
Add minimal failing test for #620

### DIFF
--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -5,8 +5,13 @@
 //---------------------------------------------------------------------------//
 //! \file celeritas/global/AlongStep.test.cc
 //---------------------------------------------------------------------------//
+#include "celeritas/SimpleCmsTestBase.hh"
 #include "celeritas/TestEm3Base.hh"
+#include "celeritas/em/UrbanMscParams.hh"
 #include "celeritas/ext/GeantPhysicsOptions.hh"
+#include "celeritas/field/UniformFieldData.hh"
+#include "celeritas/global/ActionRegistry.hh"
+#include "celeritas/global/alongstep/AlongStepUniformMscAction.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
 
@@ -47,6 +52,41 @@ class Em3AlongStepTest : public TestEm3Base, public AlongStepTestBase
     size_type bpd_{14};
     bool msc_{false};
     bool fluct_{true};
+};
+
+#define SimpleCmsAlongStepTest TEST_IF_CELERITAS_GEANT(SimpleCmsAlongStepTest)
+class SimpleCmsAlongStepTest : public SimpleCmsTestBase,
+                               public AlongStepTestBase
+{
+  public:
+    GeantPhysicsOptions build_geant_options() const override
+    {
+        auto opts = SimpleCmsTestBase::build_geant_options();
+        opts.em_bins_per_decade = bpd_;
+        opts.eloss_fluctuation = fluct_;
+        opts.msc = msc_ ? MscModelSelection::urban : MscModelSelection::none;
+        return opts;
+    }
+
+    SPConstAction build_along_step() override
+    {
+        auto& action_reg = *this->action_reg();
+        UniformFieldParams field_params;
+        field_params.field = {0, 0, 1 * units::tesla};
+
+        auto msc = UrbanMscParams::from_import(
+            *this->particle(), *this->material(), this->imported_data());
+        CELER_ASSERT(msc);
+
+        auto result = std::make_shared<AlongStepUniformMscAction>(
+            action_reg.next_id(), field_params, msc);
+        action_reg.insert(result);
+        return result;
+    }
+
+    size_type bpd_{56};
+    bool msc_{true};
+    bool fluct_{false};
 };
 
 //---------------------------------------------------------------------------//
@@ -289,6 +329,29 @@ TEST_F(Em3AlongStepTest, fluct_nomsc)
         EXPECT_SOFT_EQ(1, result.angle);
         EXPECT_SOFT_EQ(3.3395898137995e-15, result.time);
         EXPECT_SOFT_EQ(9.9999999999993e-05, result.step);
+        EXPECT_EQ("geo-boundary", result.action);
+    }
+}
+
+TEST_F(SimpleCmsAlongStepTest, msc_field_finegrid)
+{
+    size_type num_tracks = 1024;
+    Input inp;
+    {
+        SCOPED_TRACE("range-limited electron in field near boundary");
+        inp.particle_id = this->particle()->find(pdg::electron());
+        inp.energy = MevEnergy{1.76660104663773580e-3};
+        // The track is taking its second step in the EM calorimeter, so uses
+        // the cached MSC range values from the previous step
+        inp.msc_range = {8.43525996595540601e-4, 0.04, 1.34976131122020193e-5};
+        inp.position = {
+            59.3935490766840459, -109.988210668881749, -81.7228237502843484};
+        inp.direction = {
+            -0.333769826820287552, 0.641464235110772663, -0.690739703345700562};
+        auto result = this->run(inp, num_tracks);
+        // Range = 6.41578930992857482e-06
+        EXPECT_SOFT_EQ(6.41578930992857482e-6, result.step);
+        EXPECT_SOFT_EQ(inp.energy.value(), result.eloss);
         EXPECT_EQ("geo-boundary", result.action);
     }
 }

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -61,12 +61,16 @@ auto AlongStepTestBase::run(Input const& inp, size_type num_tracks) -> RunResult
         initialize_tracks(core_ref);
     }
 
-    // Set remaining MFP
+    // Set remaining MFP and cached MSC range properties
     for (auto tid : range(ThreadId{num_tracks}))
     {
         CoreTrackView track{core_ref.params, core_ref.states, tid};
         auto phys = track.make_physics_view();
         phys.interaction_mfp(inp.phys_mfp);
+        if (inp.msc_range)
+        {
+            phys.msc_range(inp.msc_range);
+        }
     }
 
     auto const& am = *this->action_reg();

--- a/test/celeritas/global/AlongStepTestBase.hh
+++ b/test/celeritas/global/AlongStepTestBase.hh
@@ -10,6 +10,7 @@
 #include "corecel/Types.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
+#include "celeritas/phys/Interaction.hh"
 
 #include "../GlobalTestBase.hh"
 
@@ -40,6 +41,7 @@ class AlongStepTestBase : virtual public GlobalTestBase
         Real3 direction{0, 0, 1};
         real_type time{0};
         real_type phys_mfp{1};  //!< Number of MFP to collision
+        MscRange msc_range{0, 0, 0};
 
         explicit operator bool() const
         {


### PR DESCRIPTION
- A low energy (~2 keV) electron near a boundary has a physics step limited by range (range = 6.41578930992857482e-06)
- `UrbanMscStepLimit` calculates the geometrical path using the range as the true path (geom path = 6.11329043405346748e-07)
- Since the track is very near the boundary, the field propagator moves the track to the boundary but just sets the distance equal to the step (the geom path)
- Since the geom path is unchanged, the true path calculated in the g --> t transformation in `UrbanMscScatter` is equal to the range
- The track loses all energy over the step but is on a boundary