### PR TITLE
Disable Geant4+ROOT system signal hooks

### DIFF
--- a/src/celeritas/ext/GeantSetup.cc
+++ b/src/celeritas/ext/GeantSetup.cc
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <utility>
+#include <G4Backtrace.hh>
 #include <G4ParticleTable.hh>
 #include <G4RunManager.hh>
 #include <G4VPhysicalVolume.hh>
@@ -84,6 +85,9 @@ GeantSetup::GeantSetup(std::string const& gdml_filename, Options options)
                        << "Geant4 cannot be 'run' more than once per "
                           "execution");
         ++geant_launch_count;
+
+        // Disable geant4 signal interception
+        G4Backtrace::DefaultSignals() = {};
 
 #if CELERITAS_G4_V10
         // Note: custom deleter means `make_unique` won't work

--- a/src/celeritas/ext/ScopedRootErrorHandler.cc
+++ b/src/celeritas/ext/ScopedRootErrorHandler.cc
@@ -71,11 +71,10 @@ ScopedRootErrorHandler::ScopedRootErrorHandler()
     : previous_(SetErrorHandler(RootErrorHandler))
 {
     // Disable ROOT interception of system signals the first time we run
-    static bool const disabled_root_backtrace = [] {
+    [[maybe_unused]] static bool const disabled_root_backtrace = [] {
         gSystem->ResetSignals();
         return true;
     }();
-    (void)sizeof(disabled_root_backtrace);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/ScopedRootErrorHandler.cc
+++ b/src/celeritas/ext/ScopedRootErrorHandler.cc
@@ -8,6 +8,7 @@
 #include "ScopedRootErrorHandler.hh"
 
 #include <TError.h>
+#include <TSystem.h>
 
 #include "corecel/Assert.hh"
 #include "corecel/io/ColorUtils.hh"
@@ -69,6 +70,12 @@ void RootErrorHandler(Int_t rootlevel,
 ScopedRootErrorHandler::ScopedRootErrorHandler()
     : previous_(SetErrorHandler(RootErrorHandler))
 {
+    // Disable ROOT interception of system signals the first time we run
+    static bool const disabled_root_backtrace = [] {
+        gSystem->ResetSignals();
+        return true;
+    }();
+    (void)sizeof(disabled_root_backtrace);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -445,7 +445,8 @@ if(CELERITAS_USE_Geant4)
   )
 
   celeritas_add_test(accel/ExceptionConverter.test.cc)
-  celeritas_add_test(accel/detail/HitProcessor.test.cc)
+  celeritas_add_test(accel/detail/HitProcessor.test.cc
+    ENVIRONMENT "${_geant4_test_env}")
 endif()
 
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
When loading ROOT, or when activating the Geant4 run managers, the two codes register signal callback functions for lots of "unexpected" system interrupts like SIGILL (illegal instruction), SIGKILL (which shouldn't even be interceptable), and SIGSEGV. This strikes me as being both unexpected (the scope of the interrupt override exceeds that of the run manager or ROOT actions) and dangerous (hitting an illegal instruction or segmentation violation puts the code in an unusable state). It might also be interfering with debugging... I was getting unexpected `SIGILL` just from constructing a `std::logic_error`, and then Geant4 and ROOT tried to intercept them.

Unless we're running through an external user's Geant4 app, disable these signal handlers.

There is also a fix for a test introduced in #637 that requires Geant4 data variables.