### PR TITLE
Fix SWIG and update requirements

### DIFF
--- a/interface/celeritas.i
+++ b/interface/celeritas.i
@@ -101,6 +101,10 @@ namespace celeritas
 %include "celeritas/io/ImportPhysicsTable.hh"
 %template(VecImportPhysicsTable) std::vector<celeritas::ImportPhysicsTable>;
 
+%include "celeritas/io/ImportModel.hh"
+%template(VecImportModel) std::vector<celeritas::ImportModel>;
+%template(VecImportMscModel) std::vector<celeritas::ImportMscModel>;
+
 %include "celeritas/io/ImportProcess.hh"
 %template(VecImportProcess) std::vector<celeritas::ImportProcess>;
 

--- a/scripts/docker/dev/centos7-rocm5.yaml
+++ b/scripts/docker/dev/centos7-rocm5.yaml
@@ -3,7 +3,7 @@ spack:
   - cmake
   - hepmc3
   - hip
-  - geant4@11 cxxstd=17
+  - geant4@11.0.3 cxxstd=17
   - git
   - googletest
   - ninja

--- a/scripts/docker/dev/jammy-cuda11.yaml
+++ b/scripts/docker/dev/jammy-cuda11.yaml
@@ -3,7 +3,7 @@ spack:
   - cmake
   - cuda
   - doxygen
-  - geant4@11 cxxstd=17
+  - geant4@11.0.3 cxxstd=17
   - git
   - googletest
   - hepmc3
@@ -12,7 +12,7 @@ spack:
   - openmpi
   - python
   - root
-  - swig
+  - "swig@4.1:"
   concretizer:
     unify: true
   packages:

--- a/scripts/spack.yaml
+++ b/scripts/spack.yaml
@@ -16,7 +16,7 @@ spack:
     - py-sphinx-rtd-theme
     - py-sphinxcontrib-bibtex
     - root cxxstd=17
-    - swig
+    - "swig@4.1:"
     - "vecgeom@1.2: +gdml cxxstd=17"
   view: true
   concretizer:


### PR DESCRIPTION
This has probably been broken since #634 . I did not add SWIG wrapper instantiations for `ImportModel` or `ImportMscModel`.

This fixes those omissions as well as updating the Spack environment script to require SWIG 4.1 (which is the first version that can handle C++14-style `[[attributes]]`).