### PR TITLE
Add math operators to Quantity

### DIFF
--- a/src/celeritas/global/alongstep/detail/FluctELoss.hh
+++ b/src/celeritas/global/alongstep/detail/FluctELoss.hh
@@ -158,8 +158,7 @@ CELER_FUNCTION auto FluctELoss::calc_eloss(CoreTrackView const& track,
     }
 
     if (apply_cut
-        && value_as<Energy>(particle.energy()) - value_as<Energy>(eloss)
-               <= value_as<Energy>(phys.scalars().eloss_calc_limit))
+        && (particle.energy() - eloss <= phys.scalars().eloss_calc_limit))
     {
         // Deposit all energy when we end below the tracking cut
         return particle.energy();

--- a/src/celeritas/global/alongstep/detail/MeanELoss.hh
+++ b/src/celeritas/global/alongstep/detail/MeanELoss.hh
@@ -76,8 +76,7 @@ CELER_FUNCTION auto MeanELoss::calc_eloss(CoreTrackView const& track,
     Energy eloss = calc_mean_energy_loss(particle, phys, step);
 
     if (apply_cut
-        && value_as<Energy>(particle.energy()) - value_as<Energy>(eloss)
-               <= value_as<Energy>(phys.scalars().eloss_calc_limit))
+        && (particle.energy() - eloss <= phys.scalars().eloss_calc_limit))
     {
         // Deposit all energy when we end below the tracking cut
         return particle.energy();

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -237,8 +237,7 @@ struct PhysicsParamsScalars
     {
         return max_particle_processes > 0 && model_to_action >= 4
                && num_models > 0 && min_range > 0 && max_step_over_range > 0
-               && min_eprime_over_e > 0
-               && value_as<Energy>(eloss_calc_limit) > 0
+               && min_eprime_over_e > 0 && eloss_calc_limit > zero_quantity()
                && linear_loss_limit > 0 && secondary_stack_factor > 0
                && ((fixed_step_limiter > 0)
                    == static_cast<bool>(fixed_step_action));

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -178,16 +178,16 @@ calc_mean_energy_loss(ParticleTrackView const& particle,
                   "Incompatible energy types");
 
     auto ppid = physics.eloss_ppid();
-    const real_type pre_step_energy = value_as<Energy>(particle.energy());
+    Energy const pre_step_energy = particle.energy();
 
     // Calculate the sum of energy loss rate over all processes.
-    real_type eloss;
+    Energy eloss;
     {
         auto grid_id = physics.value_grid(VGT::energy_loss, ppid);
         CELER_ASSERT(grid_id);
         auto calc_eloss_rate
             = physics.make_calculator<EnergyLossCalculator>(grid_id);
-        eloss = step * calc_eloss_rate(Energy{pre_step_energy});
+        eloss = Energy{step * calc_eloss_rate(pre_step_energy)};
     }
 
     if (eloss >= pre_step_energy * physics.scalars().linear_loss_limit)
@@ -206,7 +206,7 @@ calc_mean_energy_loss(ParticleTrackView const& particle,
             // TODO: eloss should be pre_step_energy at this point only if the
             // range was the step limiter (step == range), and if the
             // range-to-step conversion was 1.
-            return Energy{pre_step_energy};
+            return pre_step_energy;
         }
         CELER_ASSERT(range > step);
 
@@ -217,10 +217,10 @@ calc_mean_energy_loss(ParticleTrackView const& particle,
         // without going through the condition above.
         auto calc_energy
             = physics.make_calculator<InverseRangeCalculator>(grid_id);
-        eloss = pre_step_energy - value_as<Energy>(calc_energy(range - step));
+        eloss = pre_step_energy - calc_energy(range - step);
     }
 
-    return Energy{eloss};
+    return eloss;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -111,9 +111,9 @@ class Quantity
 //---------------------------------------------------------------------------//
 //! \cond
 #define CELER_DEFINE_QUANTITY_CMP(TOKEN)                             \
-    template<class U, class T>                                       \
+    template<class U, class T, class T2>                                       \
     CELER_CONSTEXPR_FUNCTION bool operator TOKEN(Quantity<U, T> lhs, \
-                                                 Quantity<U, T> rhs) \
+                                                 Quantity<U, T2> rhs) \
     {                                                                \
         return lhs.value() TOKEN rhs.value();                        \
     }                                                                \

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -140,7 +140,7 @@ class Quantity
     }
 
 //!@{
-//! Comparisons for Quantity
+//! Comparison for Quantity
 CELER_DEFINE_QUANTITY_CMP(==)
 CELER_DEFINE_QUANTITY_CMP(!=)
 CELER_DEFINE_QUANTITY_CMP(<)
@@ -151,19 +151,49 @@ CELER_DEFINE_QUANTITY_CMP(>=)
 
 #undef CELER_DEFINE_QUANTITY_CMP
 
-#define CELER_DEFINE_QUANTITY_MATH(TOKEN)                                     \
-    template<class U, class T, class T2>                                      \
-    CELER_CONSTEXPR_FUNCTION auto operator TOKEN(Quantity<U, T> lhs,          \
-                                                 Quantity<U, T2> rhs)         \
-        ->decltype(auto)                                                      \
-    {                                                                         \
-        return Quantity<U, std::common_type_t<T, T2>>{lhs.value()             \
-                                                          TOKEN rhs.value()}; \
-    }
-CELER_DEFINE_QUANTITY_MATH(+)
-CELER_DEFINE_QUANTITY_MATH(-)
+//!@{
+//! Math operator for Quantity
+template<class U, class T, class T2>
+CELER_CONSTEXPR_FUNCTION auto
+operator+(Quantity<U, T> lhs, Quantity<U, T2> rhs) -> decltype(auto)
+{
+    return Quantity<U, std::common_type_t<T, T2>>{lhs.value() + rhs.value()};
+}
 
-#undef CELER_DEFINE_QUANTITY_MATH
+template<class U, class T, class T2>
+CELER_CONSTEXPR_FUNCTION auto
+operator-(Quantity<U, T> lhs, Quantity<U, T2> rhs) -> decltype(auto)
+{
+    return Quantity<U, std::common_type_t<T, T2>>{lhs.value() - rhs.value()};
+}
+
+template<class U, class T>
+CELER_CONSTEXPR_FUNCTION auto operator-(Quantity<U, T> q) -> Quantity<U, T>
+{
+    return Quantity<U, T>{-q.value()};
+}
+
+template<class U, class T, class T2>
+CELER_CONSTEXPR_FUNCTION auto operator*(Quantity<U, T> lhs, T2 rhs)
+    -> decltype(auto)
+{
+    return Quantity<U, std::common_type_t<T, T2>>{lhs.value() * rhs};
+}
+
+template<class U, class T, class T2>
+CELER_CONSTEXPR_FUNCTION auto operator*(T rhs, Quantity<U, T> lhs)
+    -> decltype(auto)
+{
+    return Quantity<U, std::common_type_t<T, T2>>{rhs * lhs.value()};
+}
+
+template<class U, class T, class T2>
+CELER_CONSTEXPR_FUNCTION auto operator/(Quantity<U, T> lhs, T2 rhs)
+    -> decltype(auto)
+{
+    return Quantity<U, std::common_type_t<T, T2>>{lhs.value() / rhs};
+}
+//!@!}
 
 //! \endcond
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -110,33 +110,33 @@ class Quantity
 
 //---------------------------------------------------------------------------//
 //! \cond
-#define CELER_DEFINE_QUANTITY_CMP(TOKEN)                             \
-    template<class U, class T, class T2>                                       \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(Quantity<U, T> lhs, \
+#define CELER_DEFINE_QUANTITY_CMP(TOKEN)                              \
+    template<class U, class T, class T2>                              \
+    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(Quantity<U, T> lhs,  \
                                                  Quantity<U, T2> rhs) \
-    {                                                                \
-        return lhs.value() TOKEN rhs.value();                        \
-    }                                                                \
-    template<class U, class T>                                       \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                    \
-        Quantity<U, T> lhs, detail::UnitlessQuantity<T> rhs)         \
-    {                                                                \
-        return lhs.value() TOKEN rhs.value_;                         \
-    }                                                                \
-    template<class U, class T>                                       \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                    \
-        detail::UnitlessQuantity<T> lhs, Quantity<U, T> rhs)         \
-    {                                                                \
-        return lhs.value_ TOKEN rhs.value();                         \
-    }                                                                \
-    namespace detail                                                 \
-    {                                                                \
-    template<class T>                                                \
-    CELER_CONSTEXPR_FUNCTION bool                                    \
-    operator TOKEN(UnitlessQuantity<T> lhs, UnitlessQuantity<T> rhs) \
-    {                                                                \
-        return lhs.value_ TOKEN rhs.value_;                          \
-    }                                                                \
+    {                                                                 \
+        return lhs.value() TOKEN rhs.value();                         \
+    }                                                                 \
+    template<class U, class T>                                        \
+    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                     \
+        Quantity<U, T> lhs, detail::UnitlessQuantity<T> rhs)          \
+    {                                                                 \
+        return lhs.value() TOKEN rhs.value_;                          \
+    }                                                                 \
+    template<class U, class T>                                        \
+    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                     \
+        detail::UnitlessQuantity<T> lhs, Quantity<U, T> rhs)          \
+    {                                                                 \
+        return lhs.value_ TOKEN rhs.value();                          \
+    }                                                                 \
+    namespace detail                                                  \
+    {                                                                 \
+    template<class T>                                                 \
+    CELER_CONSTEXPR_FUNCTION bool                                     \
+    operator TOKEN(UnitlessQuantity<T> lhs, UnitlessQuantity<T> rhs)  \
+    {                                                                 \
+        return lhs.value_ TOKEN rhs.value_;                           \
+    }                                                                 \
     }
 
 //!@{

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -151,6 +151,20 @@ CELER_DEFINE_QUANTITY_CMP(>=)
 
 #undef CELER_DEFINE_QUANTITY_CMP
 
+#define CELER_DEFINE_QUANTITY_MATH(TOKEN)                                     \
+    template<class U, class T, class T2>                                      \
+    CELER_CONSTEXPR_FUNCTION auto operator TOKEN(Quantity<U, T> lhs,          \
+                                                 Quantity<U, T2> rhs)         \
+        ->decltype(auto)                                                      \
+    {                                                                         \
+        return Quantity<U, std::common_type_t<T, T2>>{lhs.value()             \
+                                                          TOKEN rhs.value()}; \
+    }
+CELER_DEFINE_QUANTITY_MATH(+)
+CELER_DEFINE_QUANTITY_MATH(-)
+
+#undef CELER_DEFINE_QUANTITY_MATH
+
 //! \endcond
 //---------------------------------------------------------------------------//
 //! Value is C1::value() / C2::value()

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -248,10 +248,7 @@ CELER_CONSTEXPR_FUNCTION auto native_value_from(Quantity<UnitT, ValueT> quant)
 template<class Q>
 CELER_CONSTEXPR_FUNCTION Q native_value_to(typename Q::value_type value)
 {
-    using value_type = typename Q::value_type;
-    using unit_type = typename Q::unit_type;
-
-    return Q{value * (value_type{1} / unit_type::value())};
+    return Q{value / Q::unit_type::value()};
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -67,6 +67,16 @@ TEST(QuantityTest, usage)
     auto half_rev = native_value_to<Revolution>(constants::pi);
     EXPECT_TRUE((std::is_same<decltype(half_rev), Revolution>::value));
     EXPECT_DOUBLE_EQ(0.5, value_as<Revolution>(half_rev));
+
+    // Check integer division works correctly
+    using Dozen = Quantity<DozenUnit, int>;
+    auto two_dozen = native_value_to<Dozen>(24);
+    EXPECT_TRUE((std::is_same_v<decltype(two_dozen), Dozen>));
+    EXPECT_EQ(2, value_as<Dozen>(two_dozen));
+
+    auto twentyfour = native_value_from(two_dozen);
+    EXPECT_TRUE((std::is_same_v<decltype(twentyfour), int>));
+    EXPECT_EQ(24, twentyfour);
 }
 
 TEST(QuantityTest, zeros)
@@ -80,6 +90,19 @@ TEST(QuantityTest, zeros)
     // Construct from a "zero" sentinel type
     zero_turn = zero_quantity();
     EXPECT_EQ(0, value_as<Revolution>(zero_turn));
+}
+
+TEST(QuantityTest, mixed_precision)
+{
+    using RevInt = Quantity<TwoPi, int>;
+    auto fourpi = native_value_from(RevInt{2});
+    EXPECT_TRUE((std::is_same_v<decltype(fourpi), double>));
+    EXPECT_SOFT_EQ(4 * constants::pi, fourpi);
+
+    using DozenDbl = Quantity<DozenUnit, double>;
+    auto two_dozen = native_value_to<DozenDbl>(24);
+    EXPECT_TRUE((std::is_same_v<decltype(two_dozen), DozenDbl>));
+    EXPECT_SOFT_EQ(2, two_dozen.value());
 }
 
 TEST(QuantityTest, comparators)
@@ -106,7 +129,7 @@ TEST(QuantityTest, comparators)
     EXPECT_FALSE(Revolution{5} == Revolution{4});
 }
 
-TEST(QuantityTest, infinities)
+TEST(QuantityTest, unitless)
 {
     EXPECT_TRUE(neg_max_quantity() < Revolution{-1e300});
     EXPECT_TRUE(neg_max_quantity() < zero_quantity());

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -127,6 +127,8 @@ TEST(QuantityTest, comparators)
     EXPECT_TRUE(Revolution{5} > Revolution{4});
     EXPECT_TRUE(Revolution{5} >= Revolution{4});
     EXPECT_FALSE(Revolution{5} == Revolution{4});
+
+    EXPECT_TRUE((Quantity<DozenUnit, int>{5} == Quantity<DozenUnit, long>{5}));
 }
 
 TEST(QuantityTest, unitless)

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -157,11 +157,34 @@ TEST(QuantityTest, math)
         EXPECT_FLOAT_EQ(-1.0, subbed.value());
     }
 
+    {
+        auto negated = -RevDbl{1.5};
+        EXPECT_TRUE((std::is_same<decltype(negated), RevDbl>::value));
+        EXPECT_DOUBLE_EQ(-1.5, negated.value());
+    }
+
+    {
+        auto muld = RevDbl{3} * 4;
+        EXPECT_TRUE((std::is_same<decltype(muld), RevDbl>::value));
+        EXPECT_DOUBLE_EQ(12, muld.value());
+    }
+
+    {
+        auto divd = RevDbl{12} / 4;
+        EXPECT_TRUE((std::is_same<decltype(divd), RevDbl>::value));
+        EXPECT_DOUBLE_EQ(3, divd.value());
+    }
+
     // Test mixed precision
     {
         EXPECT_DOUBLE_EQ(4 * constants::pi, native_value_from(RevInt{2}));
         auto added = RevFlt{1.5} + RevInt{1};
         EXPECT_TRUE((std::is_same<decltype(added), RevFlt>::value));
+    }
+    {
+        auto muld = RevInt{3} * 1.5;
+        EXPECT_TRUE((std::is_same<decltype(muld), RevDbl>::value));
+        EXPECT_DOUBLE_EQ(4.5, muld.value());
     }
 }
 

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -139,6 +139,32 @@ TEST(QuantityTest, unitless)
     EXPECT_TRUE(max_quantity() > Revolution{1e300});
 }
 
+TEST(QuantityTest, math)
+{
+    using RevInt = Quantity<TwoPi, int>;
+    using RevFlt = Quantity<TwoPi, float>;
+    using RevDbl = Quantity<TwoPi, double>;
+
+    {
+        auto added = RevDbl{1.5} + RevDbl{2.5};
+        EXPECT_TRUE((std::is_same<decltype(added), RevDbl>::value));
+        EXPECT_DOUBLE_EQ(4, added.value());
+    }
+
+    {
+        auto subbed = RevFlt{1.5} - RevFlt{2.5};
+        EXPECT_TRUE((std::is_same<decltype(subbed), RevFlt>::value));
+        EXPECT_FLOAT_EQ(-1.0, subbed.value());
+    }
+
+    // Test mixed precision
+    {
+        EXPECT_DOUBLE_EQ(4 * constants::pi, native_value_from(RevInt{2}));
+        auto added = RevFlt{1.5} + RevInt{1};
+        EXPECT_TRUE((std::is_same<decltype(added), RevFlt>::value));
+    }
+}
+
 TEST(QuantityTest, swappiness)
 {
     using Dozen = Quantity<DozenUnit, int>;


### PR DESCRIPTION
This defines a few operators for Quantity that don't change the underlying units. It also fixes an error if the underlying quantity and unit types are integers (not used presently in the code but could be useful for a memory diagnostic like KB/MB).