### PR TITLE
Warn about crashing ORANGE+optimization+debug mode

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -86,6 +86,22 @@ pipeline {
             }
           }
         }
+        stage('full-novg-reldeb') {
+          agent {
+            docker {
+              image 'celeritas/ci-jammy-cuda11:2022-12-06'
+              label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
+            }
+          }
+          steps {
+            sh 'entrypoint-shell ./scripts/ci/run-ci.sh ubuntu-cuda full-novg-reldeb'
+          }
+          post {
+            always {
+              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
+            }
+          }
+        }
         stage('vecgeom-demos') {
           agent {
             docker {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,17 @@ if(CELERITAS_BUILD_DOCS)
   endif()
 endif()
 
+if(CELERITAS_USE_CUDA AND NOT CELERITAS_USE_VecGeom
+    AND CELERITAS_DEBUG AND DEFINED CMAKE_BUILD_TYPE)
+  string(TOLOWER "${CMAKE_BUILD_TYPE}" _bt)
+  if(_bt STREQUAL "relwithdebinfo")
+    message(WARNING "The current configuration (CUDA + ORANGE + DEBUG + "
+      "RelWithDebInfo) is known to fail on GPU in some cases. See "
+      "https://github.com/celeritas-project/celeritas/issues/639 for more "
+      "details.")
+  endif()
+endif()
+
 #----------------------------------------------------------------------------#
 # LIBRARY
 #----------------------------------------------------------------------------#

--- a/scripts/cmake-presets/ci-ubuntu-cuda.json
+++ b/scripts/cmake-presets/ci-ubuntu-cuda.json
@@ -60,6 +60,11 @@
       "inherits": [".ndebug", "full-novg"]
     },
     {
+      "name": "full-novg-reldeb",
+      "description": "Build everything but VecGeom with RelDebInfo + assertions",
+      "inherits": [".reldeb", "full-novg"]
+    },
+    {
       "name": "vecgeom-tests",
       "description": "Build tests in debug with vecgeom",
       "inherits": [".vecgeom", "base"],
@@ -88,6 +93,7 @@
     },
     {"name": "full-novg"       , "configurePreset": "full-novg"       , "inherits": "base"},
     {"name": "full-novg-ndebug", "configurePreset": "full-novg-ndebug", "inherits": "base", "targets": ["all", "install"]},
+    {"name": "full-novg-reldeb", "configurePreset": "full-novg-reldeb", "inherits": "base", "targets": ["all", "install"]},
     {"name": "vecgeom-tests"   , "configurePreset": "vecgeom-tests"   , "inherits": "base", "jobs": 8},
     {"name": "vecgeom-demos"   , "configurePreset": "vecgeom-demos"   , "inherits": "base", "jobs": 8, "targets": ["app/all", "install"]}
   ],
@@ -109,6 +115,7 @@
     },
     {"name": "full-novg"       , "configurePreset": "full-novg"       , "inherits": "base"},
     {"name": "full-novg-ndebug", "configurePreset": "full-novg-ndebug", "inherits": "base"},
+    {"name": "full-novg-reldeb", "configurePreset": "full-novg-reldeb", "inherits": "base"},
     {"name": "vecgeom-tests"   , "configurePreset": "vecgeom-tests"   , "inherits": "base"},
     {"name": "vecgeom-demos"   , "configurePreset": "vecgeom-demos"   , "inherits": "base",
       "filter": {


### PR DESCRIPTION
Since we haven't fixed #639 yet, at least print a configure-time warning if the known-bad configuration is used.