### PR TITLE
Fix duplicate CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -97,6 +97,7 @@
       "hidden": true,
       "description": "Enable debug with basic optimizations",
       "cacheVariables": {
+        "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
         "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "ON"},
         "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "RelWithDebInfo"}
       }

--- a/scripts/cmake-presets/perlmutter.json
+++ b/scripts/cmake-presets/perlmutter.json
@@ -33,15 +33,6 @@
       }
     },
     {
-      "name": ".reldeb",
-      "hidden": true,
-      "cacheVariables": {
-        "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
-        "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "ON"},
-        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "RelWithDebInfo"}
-      }
-    },
-    {
       "name": "base",
       "displayName": "Perlmutter default options (GCC, debug)",
       "inherits": [".base"],

--- a/scripts/cmake-presets/summit.json
+++ b/scripts/cmake-presets/summit.json
@@ -34,15 +34,6 @@
       }
     },
     {
-      "name": ".reldeb",
-      "hidden": true,
-      "cacheVariables": {
-        "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
-        "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "ON"},
-        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "RelWithDebInfo"}
-      }
-    },
-    {
       "name": "base",
       "displayName": "Summit default options (GCC, debug)",
       "inherits": [".base"],


### PR DESCRIPTION
I unintentionally broke the CMake presets on summit when I added `.reldeb` to the top level `CMakePresets.json` in #654.