### PR TITLE
Only capture kernel context if corresponding track is alive

### DIFF
--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -64,7 +64,7 @@ KernelContextException::KernelContextException(CoreHostRef const& data,
         if (!thread)
         {
             // Make sure the thread is valid before trying to construct
-            // detailed debug informatino
+            // detailed debug information
             throw std::exception();
         }
         CoreTrackView core(data.params, data.states, thread);
@@ -128,25 +128,26 @@ void KernelContextException::output(JsonPimpl* json) const
  */
 void KernelContextException::initialize(CoreTrackView const& core)
 {
+    auto const&& sim = core.make_sim_view();
+    if (sim.status() == TrackStatus::alive)
     {
-        auto const&& sim = core.make_sim_view();
         event_ = sim.event_id();
         track_ = sim.track_id();
         parent_ = sim.parent_id();
         num_steps_ = sim.num_steps();
-    }
-    {
-        auto const&& par = core.make_particle_view();
-        particle_ = par.particle_id();
-        energy_ = par.energy();
-    }
-    {
-        auto const&& geo = core.make_geo_view();
-        pos_ = geo.pos();
-        dir_ = geo.dir();
-        volume_ = geo.volume_id();
-        surface_ = geo.surface_id();
-        next_surface_ = geo.next_surface_id();
+        {
+            auto const&& par = core.make_particle_view();
+            particle_ = par.particle_id();
+            energy_ = par.energy();
+        }
+        {
+            auto const&& geo = core.make_geo_view();
+            pos_ = geo.pos();
+            dir_ = geo.dir();
+            volume_ = geo.volume_id();
+            surface_ = geo.surface_id();
+            next_surface_ = geo.next_surface_id();
+        }
     }
     {
         // Construct std::exception message

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -155,12 +155,9 @@ TEST_F(KernelContextExceptionTest, uninitialized_track)
     step(make_span(primaries));
 
     this->check_kce = [](KernelContextException const& e) {
-        if (!CELERITAS_USE_VECGEOM)
-        {
-            // Don't test this with vecgeom which has more assertions when
-            // acquiring data
-            EXPECT_STREQ("kernel context: thread 1 in 'test-kernel'", e.what());
-        }
+        // Don't test this with vecgeom which has more assertions when
+        // acquiring data
+        EXPECT_STREQ("kernel context: thread 1 in 'test-kernel'", e.what());
         EXPECT_EQ(ThreadId{1}, e.thread());
         EXPECT_EQ(EventId{}, e.event());
         EXPECT_EQ(TrackId{}, e.track());


### PR DESCRIPTION
Closes #640 . Should fix CI in #607 .