### PR TITLE
Support for geant4 v10.6.3 and Cmake preset for Zeus

### DIFF
--- a/app/demo-geant-integration/HitRootIO.cc
+++ b/app/demo-geant-integration/HitRootIO.cc
@@ -9,10 +9,10 @@
 
 #include <cstdio>
 #include <regex>
-#include <G4Version.hh>
 #include <G4Event.hh>
 #include <G4RunManager.hh>
 #include <G4Threading.hh>
+#include <G4Version.hh>
 #include <TBranch.h>
 #include <TFile.h>
 #include <TObject.h>
@@ -113,10 +113,11 @@ void HitRootIO::WriteObject(HitRootEvent* hit_event)
 {
     if (!event_branch_)
     {
-        event_branch_ =tree_->Branch("event.",
-                          &hit_event,
-                          GlobalSetup::Instance()->GetRootBufferSize(),
-                          this->SplitLevel());
+        event_branch_
+            = tree_->Branch("event.",
+                            &hit_event,
+                            GlobalSetup::Instance()->GetRootBufferSize(),
+                            this->SplitLevel());
     }
     else
     {
@@ -181,7 +182,7 @@ void HitRootIO::Merge()
     std::unique_ptr<TList> list(new TList);
 
     CELER_LOG_LOCAL(info) << "Merging hit root files from " << nthreads
-                    << " threads into \"" << file_name_ << "\"";
+                          << " threads into \"" << file_name_ << "\"";
 
     for (int i = 0; i < nthreads; ++i)
     {

--- a/app/demo-geant-integration/HitRootIO.cc
+++ b/app/demo-geant-integration/HitRootIO.cc
@@ -9,6 +9,7 @@
 
 #include <cstdio>
 #include <regex>
+#include <G4Version.hh>
 #include <G4Event.hh>
 #include <G4RunManager.hh>
 #include <G4Threading.hh>
@@ -170,7 +171,11 @@ void HitRootIO::Close()
  */
 void HitRootIO::Merge()
 {
+#if G4VERSION_NUMBER >= 1070
     auto nthreads = G4RunManager::GetRunManager()->GetNumberOfThreads();
+#else
+    auto nthreads = 1;
+#endif
     std::vector<TFile*> files;
     std::vector<TTree*> trees;
     std::unique_ptr<TList> list(new TList);

--- a/app/demo-geant-integration/demo-geant-integration.cc
+++ b/app/demo-geant-integration/demo-geant-integration.cc
@@ -47,12 +47,12 @@ void run(std::string const& macro_filename)
 
     std::unique_ptr<G4RunManager> run_manager;
 #if !CELERITAS_G4_V10
-        run_manager.reset(G4RunManagerFactory::CreateRunManager(
-            CELERITAS_G4_MT ? G4RunManagerType::MT : G4RunManagerType::Serial));
+    run_manager.reset(G4RunManagerFactory::CreateRunManager(
+        CELERITAS_G4_MT ? G4RunManagerType::MT : G4RunManagerType::Serial));
 #elif CELERITAS_G4_MT
-        run_manager = std::make_unique<G4MTRunManager>();
+    run_manager = std::make_unique<G4MTRunManager>();
 #else
-        run_manager = std::make_unique<G4RunManager>();
+    run_manager = std::make_unique<G4RunManager>();
 #endif
     CELER_ASSERT(run_manager);
     celeritas::self_logger() = celeritas::make_mt_logger(*run_manager);

--- a/app/demo-geant-integration/demo-geant-integration.cc
+++ b/app/demo-geant-integration/demo-geant-integration.cc
@@ -46,19 +46,14 @@ void run(std::string const& macro_filename)
     CLHEP::HepRandom::setTheSeed(0xcf39c1fa9a6e29bcul);
 
     std::unique_ptr<G4RunManager> run_manager;
-    if constexpr (!CELERITAS_G4_V10)
-    {
+#if !CELERITAS_G4_V10
         run_manager.reset(G4RunManagerFactory::CreateRunManager(
             CELERITAS_G4_MT ? G4RunManagerType::MT : G4RunManagerType::Serial));
-    }
-    else if constexpr (CELERITAS_G4_MT)
-    {
+#elif CELERITAS_G4_MT
         run_manager = std::make_unique<G4MTRunManager>();
-    }
-    else
-    {
+#else
         run_manager = std::make_unique<G4RunManager>();
-    }
+#endif
     CELER_ASSERT(run_manager);
     celeritas::self_logger() = celeritas::make_mt_logger(*run_manager);
     CELER_LOG(info) << "Run manager type: "

--- a/scripts/cmake-presets/zeus.json
+++ b/scripts/cmake-presets/zeus.json
@@ -27,7 +27,7 @@
         "CMAKE_CXX_STANDARD": {"type": "STRING", "value": "17"},
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}",
-        "CMAKE_PREFIX_PATH": "/bld3/build/celeritas/json/install/share/cmake;/bld3/build/celeritas/geant4/geant4-v11.1.0-install/lib64/cmake;/bld3/build/celeritas/VecGeom/install/lib64/cmake;/cvmfs/atlas-nightlies.cern.ch/repo/sw/master_Athena_x86_64-centos7-gcc11-opt/2023-02-13T2101/AthenaExternals/23.0.17/InstallArea/x86_64-centos7-gcc11-opt/lib/cmake;/cvmfs/sft.cern.ch/lcg/views/LCG_102b_ATLAS_11/x86_64-centos7-gcc11-opt/lib64/cmake;/cvmfs/sft.cern.ch/lcg/views/LCG_102b_ATLAS_11/x86_64-centos7-gcc11-opt/cmake",
+        "CMAKE_PREFIX_PATH": "/bld3/build/celeritas/geant4/geant4-v10.6.0-install/lib64;/bld3/build/celeritas/VecGeom/install-v1.1.20/lib64/cmake;/cvmfs/atlas-nightlies.cern.ch/repo/sw/master_Athena_x86_64-centos7-gcc11-opt/2023-02-13T2101/AthenaExternals/23.0.17/InstallArea/x86_64-centos7-gcc11-opt/lib/cmake;/cvmfs/sft.cern.ch/lcg/views/LCG_102b_ATLAS_11/x86_64-centos7-gcc11-opt/lib64/cmake;/cvmfs/sft.cern.ch/lcg/views/LCG_102b_ATLAS_11/x86_64-centos7-gcc11-opt/cmake",
         "CMAKE_CXX_COMPILER": "g++",
         "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=cascadelake -mtune=cascadelake",
         "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"}

--- a/scripts/cmake-presets/zeus.json
+++ b/scripts/cmake-presets/zeus.json
@@ -1,0 +1,101 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {"major": 3, "minor": 21, "patch": 0},
+  "configurePresets": [
+    {
+      "name": ".base",
+      "hidden": true,
+      "inherits": ["full"],
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS":     {"type": "BOOL", "value": "ON"},
+        "CELERITAS_BUILD_DOCS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_CUDA":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_HIP":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_JSON":    {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_MPI":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_SWIG":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "ON"},
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wno-psabi -pedantic -pedantic-errors",
+        "CMAKE_CUDA_FLAGS": "-Xcompiler -Wno-psabi",
+        "CMAKE_CUDA_ARCHITECTURES": {"type": "STRING", "value": "80"},
+        "CMAKE_CXX_STANDARD": {"type": "STRING", "value": "17"},
+        "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}",
+        "CMAKE_PREFIX_PATH": "/bld3/build/celeritas/json/install/share/cmake;/bld3/build/celeritas/geant4/geant4-v11.1.0-install/lib64/cmake;/bld3/build/celeritas/VecGeom/install/lib64/cmake;/cvmfs/atlas-nightlies.cern.ch/repo/sw/master_Athena_x86_64-centos7-gcc11-opt/2023-02-13T2101/AthenaExternals/23.0.17/InstallArea/x86_64-centos7-gcc11-opt/lib/cmake;/cvmfs/sft.cern.ch/lcg/views/LCG_102b_ATLAS_11/x86_64-centos7-gcc11-opt/lib64/cmake;/cvmfs/sft.cern.ch/lcg/views/LCG_102b_ATLAS_11/x86_64-centos7-gcc11-opt/cmake",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=cascadelake -mtune=cascadelake",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"}
+      }
+    },
+    {
+      "name": ".reldeb",
+      "hidden": true,
+      "cacheVariables": {
+        "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "ON"},
+        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "RelWithDebInfo"}
+      }
+    },
+    {
+      "name": "base",
+      "displayName": "Zeus default options (GCC, debug)",
+      "inherits": [".base"],
+      "binaryDir": "${sourceDir}/build"
+    },
+    {
+      "name": "reldeb-novg",
+      "displayName": "Zeus release mode",
+      "inherits": [".reldeb", ".base"],
+      "cacheVariables": {
+        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
+      "name": "reldeb",
+      "displayName": "Zeus release mode",
+      "inherits": [".reldeb", ".base"]
+    },
+    {
+      "name": "ndebug-novg",
+      "displayName": "Zeus release mode",
+      "inherits": [".ndebug", ".base"],
+      "cacheVariables": {
+        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
+      "name": "ndebug",
+      "displayName": "Zeus release mode",
+      "inherits": [".ndebug", ".base"]
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base",
+      "configurePreset": "base",
+      "jobs": 8,
+      "nativeToolOptions": ["-k0"]
+    },
+    {"name": "ndebug", "configurePreset": "ndebug", "inherits": "base"},
+    {"name": "ndebug-novg", "configurePreset": "ndebug-novg", "inherits": "base"},
+    {"name": "reldeb", "configurePreset": "reldeb", "inherits": "base"},
+    {"name": "reldeb-novg", "configurePreset": "reldeb-novg", "inherits": "base"}
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "configurePreset": "base",
+      "output": {"outputOnFailure": true},
+      "execution": {"noTestsAction": "error", "stopOnFailure": false, "jobs": 8}
+    },
+    {"name": "ndebug", "configurePreset": "ndebug", "inherits": "base"},
+    {"name": "ndebug-novg", "configurePreset": "ndebug-novg", "inherits": "base"},
+    {"name": "reldeb", "configurePreset": "reldeb", "inherits": "base"},
+    {"name": "reldeb-novg", "configurePreset": "reldeb-novg", "inherits": "base"}
+  ]
+}

--- a/scripts/cmake-presets/zeus.json
+++ b/scripts/cmake-presets/zeus.json
@@ -34,14 +34,6 @@
       }
     },
     {
-      "name": ".reldeb",
-      "hidden": true,
-      "cacheVariables": {
-        "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "ON"},
-        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "RelWithDebInfo"}
-      }
-    },
-    {
       "name": "base",
       "displayName": "Zeus default options (GCC, debug)",
       "inherits": [".base"],

--- a/scripts/env/zeus.sh
+++ b/scripts/env/zeus.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+
+export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+# we need to clear exit on unchecked error for atlasLocalSetup...
+set +e
+source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+asetup none,gcc11,cmakesetup,siteroot=cvmfs
+lsetup "views LCG_102b_ATLAS_11 x86_64-centos7-gcc11-opt"
+set -e
+module load cuda/11.8.0
+source /bld3/build/celeritas/geant4/geant4-v11.1.0-install/bin/geant4.sh

--- a/scripts/env/zeus.sh
+++ b/scripts/env/zeus.sh
@@ -4,8 +4,10 @@ export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
 # we need to clear exit on unchecked error for atlasLocalSetup...
 set +e
 source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
-asetup none,gcc11,cmakesetup,siteroot=cvmfs
 lsetup "views LCG_102b_ATLAS_11 x86_64-centos7-gcc11-opt"
+asetup none,gcc112,cmakesetup,siteroot=cvmfs
 set -e
+
+# not in standard Atlas build env but we need it for cuda-enabled vecgeom
 module load cuda/11.8.0
 source /bld3/build/celeritas/geant4/geant4-v10.6.0-install/bin/geant4.sh

--- a/scripts/env/zeus.sh
+++ b/scripts/env/zeus.sh
@@ -8,4 +8,4 @@ asetup none,gcc11,cmakesetup,siteroot=cvmfs
 lsetup "views LCG_102b_ATLAS_11 x86_64-centos7-gcc11-opt"
 set -e
 module load cuda/11.8.0
-source /bld3/build/celeritas/geant4/geant4-v11.1.0-install/bin/geant4.sh
+source /bld3/build/celeritas/geant4/geant4-v10.6.0-install/bin/geant4.sh

--- a/src/accel/Logger.cc
+++ b/src/accel/Logger.cc
@@ -110,7 +110,11 @@ void MtLogger::operator()(Provenance prov, LogLevel lev, std::string msg)
 Logger make_mt_logger(G4RunManager const& runman)
 {
     return Logger(MpiCommunicator{},
+#if G4VERSION_NUMBER < 1070
+                  MtLogger{2},
+#else
                   MtLogger{runman.GetNumberOfThreads()},
+#endif
                   "CELER_LOG_LOCAL");
 }
 

--- a/src/accel/Logger.cc
+++ b/src/accel/Logger.cc
@@ -13,6 +13,7 @@
 #include <G4RunManager.hh>
 #include <G4Threading.hh>
 #include <G4ios.hh>
+#include <G4Version.hh>
 
 #include "corecel/Assert.hh"
 #include "corecel/io/ColorUtils.hh"

--- a/src/accel/Logger.cc
+++ b/src/accel/Logger.cc
@@ -12,8 +12,8 @@
 #include <string>
 #include <G4RunManager.hh>
 #include <G4Threading.hh>
-#include <G4ios.hh>
 #include <G4Version.hh>
+#include <G4ios.hh>
 
 #include "corecel/Assert.hh"
 #include "corecel/io/ColorUtils.hh"

--- a/src/celeritas/ext/GeantSetup.cc
+++ b/src/celeritas/ext/GeantSetup.cc
@@ -9,7 +9,12 @@
 
 #include <memory>
 #include <utility>
+#include <G4Version.hh>
+
+#if G4VERSION_NUMBER > 1070
 #include <G4Backtrace.hh>
+#endif
+
 #include <G4ParticleTable.hh>
 #include <G4RunManager.hh>
 #include <G4VPhysicalVolume.hh>
@@ -87,7 +92,9 @@ GeantSetup::GeantSetup(std::string const& gdml_filename, Options options)
         ++geant_launch_count;
 
         // Disable geant4 signal interception
+#if G4VERSION_NUMBER > 1070
         G4Backtrace::DefaultSignals() = {};
+#endif
 
 #if CELERITAS_G4_V10
         // Note: custom deleter means `make_unique` won't work

--- a/src/celeritas/ext/GeantSetup.cc
+++ b/src/celeritas/ext/GeantSetup.cc
@@ -12,7 +12,7 @@
 #include <G4Version.hh>
 
 #if G4VERSION_NUMBER > 1070
-#include <G4Backtrace.hh>
+#    include <G4Backtrace.hh>
 #endif
 
 #include <G4ParticleTable.hh>

--- a/src/celeritas/ext/detail/GeantGeoExporter.cc
+++ b/src/celeritas/ext/detail/GeantGeoExporter.cc
@@ -57,7 +57,9 @@ void GeantGeoExporter::operator()(std::string const& filename) const
     parser.SetEnergyCutsExport(true);
     parser.SetSDExport(true);
     parser.SetOverlapCheck(true);
+#if G4VERSION_NUMBER > 1070
     parser.SetOutputFileOverwrite(true);
+#endif
     constexpr bool append_pointers = true;
     parser.Write(filename, world_, append_pointers);
 }

--- a/src/celeritas/ext/detail/GeantGeoExporter.cc
+++ b/src/celeritas/ext/detail/GeantGeoExporter.cc
@@ -9,6 +9,7 @@
 
 #include <G4GDMLParser.hh>
 #include <G4Threading.hh>
+#include <G4Version.hh>
 #include <G4VPhysicalVolume.hh>
 
 #include "corecel/Assert.hh"

--- a/src/celeritas/ext/detail/GeantGeoExporter.cc
+++ b/src/celeritas/ext/detail/GeantGeoExporter.cc
@@ -9,8 +9,8 @@
 
 #include <G4GDMLParser.hh>
 #include <G4Threading.hh>
-#include <G4Version.hh>
 #include <G4VPhysicalVolume.hh>
+#include <G4Version.hh>
 
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"

--- a/src/celeritas/ext/detail/GeantMicroXsCalculator.cc
+++ b/src/celeritas/ext/detail/GeantMicroXsCalculator.cc
@@ -11,8 +11,8 @@
 #include <G4Material.hh>
 #include <G4VEmModel.hh>
 
-#include "celeritas/ext/GeantConfig.hh"
 #include "corecel/cont/Range.hh"
+#include "celeritas/ext/GeantConfig.hh"
 
 namespace celeritas
 {

--- a/src/celeritas/ext/detail/GeantMicroXsCalculator.cc
+++ b/src/celeritas/ext/detail/GeantMicroXsCalculator.cc
@@ -11,6 +11,7 @@
 #include <G4Material.hh>
 #include <G4VEmModel.hh>
 
+#include "celeritas/ext/GeantConfig.hh"
 #include "corecel/cont/Range.hh"
 
 namespace celeritas
@@ -44,8 +45,11 @@ void GeantMicroXsCalculator::operator()(VecDouble const& energy_grid,
                                         VecVecDouble* result_xs) const
 {
     CELER_EXPECT(result_xs);
-
+#if CELERITAS_G4_V10
+    std::vector<G4Element*> const& elements
+#else
     std::vector<G4Element const*> const& elements
+#endif
         = *material_.GetElementVector();
 
     // Resize microscopic cross sections for all elements


### PR DESCRIPTION
Implement changes to have Celeritas build with geant4 v10.6.3. Some changes such as the number of threads in `MtLogger` or used to merge root hits files are arbitrary for now.

Multiple tests currently fail:

```
49 - celeritas/Constants (Failed)
63 - celeritas/ext/Vecgeom (Failed)
65 - celeritas/ext/GeantImporter (Failed)
70 - celeritas/field/FieldPropagator (Failed)
76 - celeritas/global/AlongStep:-Em3* (Failed)
77 - celeritas/global/AlongStep:Em3AlongStepTest.nofluct_nomsc (Failed)
79 - celeritas/global/AlongStep:Em3AlongStepTest.msc_nofluct_finegrid (Failed)
134 - app/demo-geant-integration (Subprocess aborted)
```