### PR TITLE
Fix Geant4/GDML volume names to get TileCal working

### DIFF
--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -117,13 +117,14 @@ void print_materials(std::vector<ImportMaterial>& materials,
 
         cout << "| " << setw(11) << material_id << " | " << setw(31)
              << material.name << " | " << setw(31)
-             << to_string(
-                    join(material.elements.begin(),
-                         material.elements.end(),
-                         ", ",
-                         [&](auto const& mat_el_comp) {
-                             return elements.at(mat_el_comp.element_id).name;
-                         }))
+             << to_string(join(
+                    material.elements.begin(),
+                    material.elements.end(),
+                    ", ",
+                    [&](auto const& mat_el_comp) {
+                        CELER_ASSERT(mat_el_comp.element_id < elements.size());
+                        return elements[mat_el_comp.element_id].name;
+                    }))
              << " |\n";
     }
     cout << endl;
@@ -380,14 +381,19 @@ void print_volumes(std::vector<ImportVolume> const& volumes,
     for (unsigned int volume_id : range(volumes.size()))
     {
         auto const& volume = volumes[volume_id];
-        auto const& material = materials.at(volume.material_id);
+        if (!volume)
+        {
+            continue;
+        }
+        CELER_ASSERT(static_cast<std::size_t>(volume.material_id)
+                     < materials.size());
 
         // clang-format off
         cout << "| "
              << setw(9) << std::left << volume_id << " | "
              << setw(36) << volume.name << " | "
              << setw(11) << volume.material_id << " | "
-             << setw(27) << material.name << " |\n";
+             << setw(27) << materials[volume.material_id].name << " |\n";
         // clang-format on
     }
     cout << endl;

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -256,7 +256,10 @@ void SharedParams::initialize_core(SetupOptions const& options)
                       "defined in the celeritas::SetupOptions");
 
     celeritas::GeantImporter load_geant_data(GeantImporter::get_world_volume());
-    auto imported = std::make_shared<ImportData>(load_geant_data());
+    // Convert ImportVolume names to GDML versions if we're exporting
+    GeantImportDataSelection import_opts;
+    import_opts.unique_volumes = options.geometry_file.empty();
+    auto imported = std::make_shared<ImportData>(load_geant_data(import_opts));
     CELER_ASSERT(imported && *imported);
 
     if (CELERITAS_USE_ROOT && options.output_file.size() > 5)

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -24,6 +24,7 @@
 #include "corecel/sys/Device.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/ext/GeantImporter.hh"
+#include "celeritas/ext/RootExporter.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"
 #include "celeritas/geo/GeoParams.hh"
 #include "celeritas/global/ActionRegistry.hh"
@@ -257,6 +258,15 @@ void SharedParams::initialize_core(SetupOptions const& options)
     celeritas::GeantImporter load_geant_data(GeantImporter::get_world_volume());
     auto imported = std::make_shared<ImportData>(load_geant_data());
     CELER_ASSERT(imported && *imported);
+
+    if (CELERITAS_USE_ROOT && options.output_file.size() > 5)
+    {
+        std::string root_out{options.output_file.begin(),
+                             options.output_file.end() - 5};
+        root_out += ".root";
+        RootExporter export_root(root_out.c_str());
+        export_root(*imported);
+    }
 
     CoreParams::Input params;
 

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -16,6 +16,7 @@
 #include <G4StepPoint.hh>
 #include <G4ThreeVector.hh>
 #include <G4TouchableHistory.hh>
+#include <G4Track.hh>
 #include <G4TransportationManager.hh>
 #include <G4VPhysicalVolume.hh>
 #include <G4VSensitiveDetector.hh>
@@ -165,6 +166,8 @@ HitProcessor::HitProcessor(VecLV detector_volumes,
         touch_handle_ = new G4TouchableHistory;
         step_->GetPreStepPoint()->SetTouchableHandle(touch_handle_);
     }
+    track_ = std::make_unique<G4Track>();
+    step_->SetTrack(track_.get());
 }
 
 //---------------------------------------------------------------------------//
@@ -194,8 +197,8 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
     } while (0)
 
         HP_SET(step_->SetTotalEnergyDeposit, out.energy_deposition, CLHEP::MeV);
-        // TODO: how to handle these attributes?
-        // step_->SetTrack(primary_track);
+        // TODO: how to handle track attributes?
+        // track_->SetTrackID(...);
 
         // TODO: assert that event ID is consistent with active
         // LocalTransporter event?

--- a/src/accel/detail/HitProcessor.hh
+++ b/src/accel/detail/HitProcessor.hh
@@ -17,6 +17,7 @@
 class G4LogicalVolume;
 class G4Step;
 class G4Navigator;
+class G4Track;
 class G4VSensitiveDetector;
 
 namespace celeritas
@@ -75,6 +76,8 @@ class HitProcessor
     VecLV detector_volumes_;
     //! Temporary step
     std::unique_ptr<G4Step> step_;
+    //! Temporary track, required by some frameworks
+    std::unique_ptr<G4Track> track_;
     //! Navigator for finding points
     std::unique_ptr<G4Navigator> navi_;
     //! Geant4 reference-counted pointer to a G4VTouchable

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -103,10 +103,11 @@ if(CELERITAS_USE_Geant4)
     ext/detail/GeantExceptionHandler.cc
     ext/detail/GeantGeoExporter.cc
     ext/detail/GeantLoggerAdapter.cc
-    ext/detail/GeantPhysicsList.cc
-    ext/detail/GeantModelImporter.cc
-    ext/detail/GeantProcessImporter.cc
     ext/detail/GeantMicroXsCalculator.cc
+    ext/detail/GeantModelImporter.cc
+    ext/detail/GeantPhysicsList.cc
+    ext/detail/GeantProcessImporter.cc
+    ext/detail/GeantVolumeVisitor.cc
   )
   target_link_libraries(celeritas_geant4
     PRIVATE Celeritas::corecel XercesC::XercesC ${Geant4_LIBRARIES}

--- a/src/celeritas/ext/GeantImporter.hh
+++ b/src/celeritas/ext/GeantImporter.hh
@@ -20,6 +20,26 @@ class G4VPhysicalVolume;  // IWYU pragma: keep
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+//! Only import a subset of available Geant4 data
+struct GeantImportDataSelection
+{
+    //! Bit flags for selecting particles and process types
+    using Flags = unsigned int;
+    enum : unsigned int
+    {
+        dummy = 0x1,  //!< Dummy particles+processes
+        em = 0x2,  //!< EM particles and fundamental proceses
+        hadron = 0x4,  //!< Hadronic particles and processes
+    };
+
+    Flags particles = em;
+    Flags processes = em;
+
+    // TODO expand/set reader flags automatically based on loaded processes
+    bool reader_data = true;
+};
+
+//---------------------------------------------------------------------------//
 /*!
  * Load problem data directly from Geant4.
  *
@@ -39,24 +59,10 @@ namespace celeritas
 class GeantImporter
 {
   public:
-    //! Only import a subset of available Geant4 data
-    struct DataSelection
-    {
-        //! Bit flags for selecting particles and process types
-        using Flags = unsigned int;
-        enum : unsigned int
-        {
-            dummy = 0x1,  //!< Dummy particles+processes
-            em = 0x2,  //!< EM particles and fundamental proceses
-            hadron = 0x4,  //!< Hadronic particles and processes
-        };
-
-        Flags particles = em;
-        Flags processes = em;
-
-        // TODO expand/set reader flags automatically based on loaded processes
-        bool reader_data = true;
-    };
+    //!@{
+    //! \name Type aliases
+    using DataSelection = GeantImportDataSelection;
+    //!@}
 
   public:
     // Get an externally loaded Geant4 top-level geometry element

--- a/src/celeritas/ext/GeantImporter.hh
+++ b/src/celeritas/ext/GeantImporter.hh
@@ -85,6 +85,10 @@ class GeantImporter
     GeantSetup setup_;
     // World physical volume
     G4VPhysicalVolume const* world_{nullptr};
+
+    //// HELPER FUNCTIONS ////
+
+    std::vector<ImportVolume> load_volumes() const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantImporter.hh
+++ b/src/celeritas/ext/GeantImporter.hh
@@ -35,6 +35,9 @@ struct GeantImportDataSelection
     Flags particles = em;
     Flags processes = em;
 
+    //! Change volume names to match exported GDML file
+    bool unique_volumes = false;
+
     // TODO expand/set reader flags automatically based on loaded processes
     bool reader_data = true;
 };
@@ -88,7 +91,7 @@ class GeantImporter
 
     //// HELPER FUNCTIONS ////
 
-    std::vector<ImportVolume> load_volumes() const;
+    std::vector<ImportVolume> load_volumes(bool unique_volumes) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantVolumeVisitor.cc
+++ b/src/celeritas/ext/detail/GeantVolumeVisitor.cc
@@ -1,0 +1,110 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/detail/GeantVolumeVisitor.cc
+//---------------------------------------------------------------------------//
+#include "GeantVolumeVisitor.hh"
+
+#include <regex>
+#include <G4GDMLWriteStructure.hh>
+#include <G4LogicalVolume.hh>
+#include <G4MaterialCutsCouple.hh>
+#include <G4VSolid.hh>
+
+#include "corecel/Assert.hh"
+#include "corecel/cont/Range.hh"
+#include "corecel/io/Logger.hh"
+#include "celeritas/io/ImportVolume.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Store all logical volumes by recursively looping over them.
+ *
+ * Using a map ensures that volumes are both ordered by volume id and not
+ * duplicated.
+ * Function called by \c store_volumes(...) .
+ */
+void GeantVolumeVisitor::visit(G4LogicalVolume const& logical_volume)
+{
+    auto&& [iter, inserted] = volids_volumes_.emplace(
+        logical_volume.GetInstanceID(), ImportVolume{});
+    if (!inserted)
+    {
+        // Logical volume is already in the map
+        return;
+    }
+
+    CELER_ASSERT(iter->first >= 0);
+
+    // Fill volume properties
+    ImportVolume& volume = iter->second;
+    volume.material_id = logical_volume.GetMaterialCutsCouple()->GetIndex();
+    volume.name = logical_volume.GetName();
+    volume.solid_name = logical_volume.GetSolid()->GetName();
+
+    if (volume.name.empty())
+    {
+        CELER_LOG(warning)
+            << "No logical volume name specified for instance ID "
+            << iter->first << " (material " << volume.material_id << ")";
+    }
+    else if (unique_volumes_)
+    {
+        // See if the name already has a uniquifying address (e.g., we loaded
+        // it through our GdmlLoader with `SetStripFlag(false)`)
+        // static std::regex const final_ptr_regex{"0x[0-9a-f]{4,16}$"};
+        static std::regex const final_ptr_regex{"0x[0-9a-f]{4,16}$"};
+        std::smatch ptr_match;
+        if (!std::regex_search(volume.name, ptr_match, final_ptr_regex))
+        {
+            // No unique extension: run the LV through the GDML export name
+            // generator so that the volume is uniquely identifiable in
+            // VecGeom.
+            // Reuse the same instance to reduce overhead: note that the method
+            // isn't const correct.
+            static G4GDMLWriteStructure temp_writer;
+            volume.name
+                = temp_writer.GenerateName(volume.name, &logical_volume);
+        }
+    }
+
+    // Recursive: repeat for every daughter volume, if there are any
+    for (auto const i : range(logical_volume.GetNoDaughters()))
+    {
+        this->visit(*logical_volume.GetDaughter(i)->GetLogicalVolume());
+    }
+
+    CELER_ENSURE(volume);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Transform the map of volumes into a contiguous vector with empty spaces.
+ */
+std::vector<ImportVolume> GeantVolumeVisitor::build_volume_vector() const
+{
+    std::vector<ImportVolume> volumes;
+
+    // Populate vector<ImportVolume>
+    volumes.resize(volids_volumes_.size());
+    for (auto&& [volid, volume] : volids_volumes_)
+    {
+        if (static_cast<std::size_t>(volid) >= volumes.size())
+        {
+            volumes.resize(volid + 1);
+        }
+        volumes[volid] = volume;
+    }
+
+    return volumes;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/ext/detail/GeantVolumeVisitor.hh
+++ b/src/celeritas/ext/detail/GeantVolumeVisitor.hh
@@ -1,0 +1,55 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/detail/GeantVolumeVisitor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <map>
+#include <vector>
+
+class G4LogicalVolume;
+
+namespace celeritas
+{
+struct ImportVolume;
+
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Traverse a logical volume hierarchy to record import volumes.
+ */
+class GeantVolumeVisitor
+{
+  public:
+    // Construct with the unique volume flag
+    explicit inline GeantVolumeVisitor(bool unique_volumes);
+
+    // Recurse into the given logical volume
+    void visit(G4LogicalVolume const& logical_volume);
+
+    // Transform the map of volumes into a contiguous vector with empty spaces
+    std::vector<ImportVolume> build_volume_vector() const;
+
+  private:
+    bool unique_volumes_;
+    std::map<int, ImportVolume> volids_volumes_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with a uniquifying volume flag.
+ */
+GeantVolumeVisitor::GeantVolumeVisitor(bool unique_volumes)
+    : unique_volumes_(unique_volumes)
+{
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -17,6 +17,7 @@
 #include "celeritas/random/XorwowRngData.hh"
 #include "celeritas/track/TrackInitData.hh"
 #include "celeritas/track/TrackInitUtils.hh"
+#include "celeritas/track/TrackInitParams.hh"
 
 #include "CoreParams.hh"
 #include "detail/ActionSequence.hh"
@@ -102,6 +103,15 @@ auto Stepper<M>::operator()(SpanConstPrimary primaries) -> result_type
                    << ") with size ("
                    << core_ref_.states.init.initializers.size()
                    << ") for primaries (" << primaries.size() << ")");
+    auto max_id
+        = std::max_element(primaries.begin(),
+                           primaries.end(),
+                           [](Primary const& left, Primary const& right) {
+                               return left.event_id < right.event_id;
+                           });
+    CELER_VALIDATE(max_id->event_id < params_->init()->max_events(),
+                   << "event number " << max_id->event_id.unchecked_get()
+                   << " exceeds max_events=" << params_->init()->max_events());
 
     // Create track initializers
     extend_from_primaries(core_ref_, primaries);

--- a/src/celeritas/track/TrackInitParams.hh
+++ b/src/celeritas/track/TrackInitParams.hh
@@ -38,6 +38,9 @@ class TrackInitParams
     // Construct with capacity and number of events
     explicit TrackInitParams(Input const&);
 
+    //! Event number cannot exceed this value
+    size_type max_events() const { return host_ref().max_events; }
+
     //! Access primaries for contructing track initializer states
     HostRef const& host_ref() const { return data_.host(); }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -286,7 +286,11 @@ endif()
 
 celeritas_add_test(celeritas/ext/EventReader.test.cc ${_needs_hepmc})
 celeritas_add_test(celeritas/ext/GeantImporter.test.cc
-  ${_needs_geant4} LINK_LIBRARIES ${_optional_json_link})
+  ${_needs_geant4} LINK_LIBRARIES ${_optional_json_link}
+  FILTER
+    "FourSteelSlabs*"
+    "TestEm3*"
+  )
 celeritas_add_test(celeritas/ext/RootImporter.test.cc ${_needs_root})
 
 #-------------------------------------#

--- a/test/celeritas/GeantTestBase.hh
+++ b/test/celeritas/GeantTestBase.hh
@@ -19,6 +19,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 struct GeantPhysicsOptions;
+struct GeantImportDataSelection;
 
 namespace test
 {
@@ -50,6 +51,9 @@ class GeantTestBase : public ImportedDataTestBase
 
     // Access lazily loaded static geant4 data
     ImportData const& imported_data() const final;
+
+    // Import data potentially with different selection options
+    virtual GeantImportDataSelection build_import_data_selection() const;
 
   private:
     struct ImportHelper;

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -915,11 +915,9 @@ TEST_F(FourSteelSlabsEmStandard, atomic_relaxation_data)
 TEST_F(TestEm3, volume_names)
 {
     selection_.reader_data = false;
-    auto&& import_data = this->imported_data();
+    auto const& volumes = this->imported_data().volumes;
 
-    auto const& volumes = import_data.volumes;
     std::vector<std::string> names;
-
     for (auto const& volume : volumes)
     {
         names.push_back(volume.name);
@@ -929,6 +927,19 @@ TEST_F(TestEm3, volume_names)
     static std::string const expected_names[] = {"gap_lv_0", "absorber_lv_0", "gap_lv_1", "absorber_lv_1", "gap_lv_2", "absorber_lv_2", "gap_lv_3", "absorber_lv_3", "gap_lv_4", "absorber_lv_4", "gap_lv_5", "absorber_lv_5", "gap_lv_6", "absorber_lv_6", "gap_lv_7", "absorber_lv_7", "gap_lv_8", "absorber_lv_8", "gap_lv_9", "absorber_lv_9", "gap_lv_10", "absorber_lv_10", "gap_lv_11", "absorber_lv_11", "gap_lv_12", "absorber_lv_12", "gap_lv_13", "absorber_lv_13", "gap_lv_14", "absorber_lv_14", "gap_lv_15", "absorber_lv_15", "gap_lv_16", "absorber_lv_16", "gap_lv_17", "absorber_lv_17", "gap_lv_18", "absorber_lv_18", "gap_lv_19", "absorber_lv_19", "gap_lv_20", "absorber_lv_20", "gap_lv_21", "absorber_lv_21", "gap_lv_22", "absorber_lv_22", "gap_lv_23", "absorber_lv_23", "gap_lv_24", "absorber_lv_24", "gap_lv_25", "absorber_lv_25", "gap_lv_26", "absorber_lv_26", "gap_lv_27", "absorber_lv_27", "gap_lv_28", "absorber_lv_28", "gap_lv_29", "absorber_lv_29", "gap_lv_30", "absorber_lv_30", "gap_lv_31", "absorber_lv_31", "gap_lv_32", "absorber_lv_32", "gap_lv_33", "absorber_lv_33", "gap_lv_34", "absorber_lv_34", "gap_lv_35", "absorber_lv_35", "gap_lv_36", "absorber_lv_36", "gap_lv_37", "absorber_lv_37", "gap_lv_38", "absorber_lv_38", "gap_lv_39", "absorber_lv_39", "gap_lv_40", "absorber_lv_40", "gap_lv_41", "absorber_lv_41", "gap_lv_42", "absorber_lv_42", "gap_lv_43", "absorber_lv_43", "gap_lv_44", "absorber_lv_44", "gap_lv_45", "absorber_lv_45", "gap_lv_46", "absorber_lv_46", "gap_lv_47", "absorber_lv_47", "gap_lv_48", "absorber_lv_48", "gap_lv_49", "absorber_lv_49", "world_lv"};
     // clang-format on
     EXPECT_VEC_EQ(expected_names, names);
+}
+
+//---------------------------------------------------------------------------//
+
+TEST_F(TestEm3, unique_volumes)
+{
+    selection_.reader_data = false;
+    selection_.unique_volumes = true;
+
+    auto const& volumes = this->imported_data().volumes;
+
+    EXPECT_EQ(101, volumes.size());
+    EXPECT_TRUE(starts_with(volumes.front().name, "gap_lv_00x"));
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
TileCal's GDML file has duplicate volume names (and colons in the name) which are stripped when reading (and the colons replaced by underscores when writing). This leads to duplicate `ImportVolume` names that can't be resolved to unique VecGeom volumes. I added an option to the GeantImporter to convert the in-memory logical volume names to their GDML equivalents, so that they will match the exported GDML names. This option should be used whenever the client loads the geometry themselves, *not* when Celeritas loads the GDML file.

The TileCal example also accessed the `GetTrack()` property of the step, which resulted in a null pointer dereference: this has been fixed by allocating a local track that simply has no extra data.

As a debugging feature, we also now export a ROOT file with the import data when ROOT is enabled and Celeritas output is requested.