### PR TITLE
Ignore Geant4 muons and muon processes by default in accel

### DIFF
--- a/app/demo-geant-integration/demo-geant-integration.cc
+++ b/app/demo-geant-integration/demo-geant-integration.cc
@@ -69,8 +69,7 @@ void run(std::string const& macro_filename)
     run_manager->SetUserInitialization(new FTFP_BERT{/* verbosity = */ 0});
     run_manager->SetUserInitialization(new demo_geant::ActionInitialization());
 
-    demo_geant::GlobalSetup::Instance()->SetIgnoreProcesses(
-        {"CoulombScat", "muIoni", "muBrems", "muPairProd"});
+    demo_geant::GlobalSetup::Instance()->SetIgnoreProcesses({"CoulombScat"});
 
     G4UImanager* ui = G4UImanager::GetUIpointer();
     CELER_ASSERT(ui);

--- a/example/accel/accel.cc
+++ b/example/accel/accel.cc
@@ -245,8 +245,7 @@ int main()
     setup_options.max_num_events = 1024;
     setup_options.initializer_capacity = 1024 * 128;
     setup_options.secondary_stack_factor = 3.0;
-    setup_options.ignore_processes
-        = {"CoulombScat", "muIoni", "muBrems", "muPairProd"};
+    setup_options.ignore_processes = {"CoulombScat"};
 
     run_manager->Initialize();
     run_manager->BeamOn(1);

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -258,6 +258,8 @@ void SharedParams::initialize_core(SetupOptions const& options)
     celeritas::GeantImporter load_geant_data(GeantImporter::get_world_volume());
     // Convert ImportVolume names to GDML versions if we're exporting
     GeantImportDataSelection import_opts;
+    import_opts.particles = GeantImportDataSelection::em_basic;
+    import_opts.processes = import_opts.particles;
     import_opts.unique_volumes = options.geometry_file.empty();
     auto imported = std::make_shared<ImportData>(load_geant_data(import_opts));
     CELER_ASSERT(imported && *imported);

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -70,12 +70,18 @@ namespace
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS
 //---------------------------------------------------------------------------//
-decltype(auto) em_particles()
+decltype(auto) em_basic_particles()
 {
     static const std::unordered_set<PDGNumber> particles = {pdg::electron(),
                                                             pdg::positron(),
-                                                            pdg::gamma(),
-                                                            pdg::mu_minus(),
+                                                            pdg::gamma()};
+    return particles;
+}
+
+//---------------------------------------------------------------------------//
+decltype(auto) em_ex_particles()
+{
+    static const std::unordered_set<PDGNumber> particles = {pdg::mu_minus(),
                                                             pdg::mu_plus()};
     return particles;
 }
@@ -94,9 +100,13 @@ struct ParticleFilter
         {
             return (which & DataSelection::dummy);
         }
-        else if (em_particles().count(pdgnum))
+        else if (em_basic_particles().count(pdgnum))
         {
-            return (which & DataSelection::em);
+            return (which & DataSelection::em_basic);
+        }
+        else if (em_ex_particles().count(pdgnum))
+        {
+            return (which & DataSelection::em_ex);
         }
         else
         {
@@ -396,6 +406,7 @@ auto store_processes(GeantImporter::DataSelection::Flags process_flags,
                      std::vector<ImportMaterial> const& materials)
     -> std::pair<std::vector<ImportProcess>, std::vector<ImportMscModel>>
 {
+    ParticleFilter include_particle{process_flags};
     ProcessFilter include_process{process_flags};
 
     std::vector<ImportProcess> processes;
@@ -409,6 +420,13 @@ auto store_processes(GeantImporter::DataSelection::Flags process_flags,
         G4ParticleDefinition const* g4_particle_def
             = G4ParticleTable::GetParticleTable()->FindParticle(p.pdg);
         CELER_ASSERT(g4_particle_def);
+
+        if (!include_particle(PDGNumber{g4_particle_def->GetPDGEncoding()}))
+        {
+            CELER_LOG(debug) << "Filtered all processes from particle '"
+                             << g4_particle_def->GetParticleName() << "'";
+            continue;
+        }
 
         G4ProcessVector const& process_list
             = *g4_particle_def->GetProcessManager()->GetProcessList();

--- a/src/celeritas/ext/GeantImporter.hh
+++ b/src/celeritas/ext/GeantImporter.hh
@@ -28,8 +28,10 @@ struct GeantImportDataSelection
     enum : unsigned int
     {
         dummy = 0x1,  //!< Dummy particles+processes
-        em = 0x2,  //!< EM particles and fundamental proceses
-        hadron = 0x4,  //!< Hadronic particles and processes
+        em_basic = 0x2,  //!< Electron, positron, gamma
+        em_ex = 0x4,  //!< Extended/exotic EM particles
+        em = em_basic | em_ex, //!< Any EM
+        hadron = 0x8,  //!< Hadronic particles and processes
     };
 
     Flags particles = em;

--- a/src/celeritas/ext/GeantImporter.hh
+++ b/src/celeritas/ext/GeantImporter.hh
@@ -29,8 +29,8 @@ struct GeantImportDataSelection
     {
         dummy = 0x1,  //!< Dummy particles+processes
         em_basic = 0x2,  //!< Electron, positron, gamma
-        em_ex = 0x4,  //!< Extended/exotic EM particles
-        em = em_basic | em_ex, //!< Any EM
+        em_ex = 0x4,  //!< Extended EM particles
+        em = em_basic | em_ex,  //!< Any EM
         hadron = 0x8,  //!< Hadronic particles and processes
     };
 


### PR DESCRIPTION
When putting in the Geant4 importer I added some very coarse granularity (em vs hadron) for importing particles and processes. Because we don't distinguish between EM particles we support (e/gamma) and those we don't (muon) we end up having to manually ignore mubrems, muioni, etc. This PR makes the `accel` code ignore `muioni` and such by default (and correspondingly write out less data).