### PR TITLE
Differentiate between local and global Volume and Surface Ids within ORANGE

### DIFF
--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -136,6 +136,9 @@ using ItemRange = Range<OpaqueId<T, Size>>;
 template<class T1, class T2>
 class ItemMap
 {
+    static_assert(detail::IsOpaqueId<T1>::value, "T1 isn't opaque ID");
+    static_assert(detail::IsOpaqueId<T2>::value, "T2 isn't opaque ID");
+
   public:
     //!@{
     //! \name Type aliases
@@ -149,11 +152,7 @@ class ItemMap
     ItemMap() = default;
 
     //! Contruct from an exising Range<T2>
-   explicit CELER_FUNCTION ItemMap(Range<T2> range) : range_(range)
-    {
-        static_assert(detail::IsOpaqueId<T1>::value, "T1 isn't opaque ID");
-        static_assert(detail::IsOpaqueId<T2>::value, "T2 isn't opaque ID");
-    }
+    explicit CELER_FUNCTION ItemMap(Range<T2> range) : range_(range) {}
 
     //// ACCESS ////
 

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -130,26 +130,38 @@ using ItemRange = Range<OpaqueId<T, Size>>;
 //---------------------------------------------------------------------------//
 /*! Access data in a Range<T2> with an index of type T1
  *
- * Here, T1 and T2 are expected to be OpaqueIds.
+ * Here, T1 and T2 are expected to be OpaqueId types
  */
 template<class T1, class T2>
 class ItemMap
 {
+  public:
+    //!@{
+    //! \name Type aliases
+    using key_type = T1;
+    using mapped_type = T2;
+    //!@}
+
   public:
     //// CONSTRUCTION ////
 
     ItemMap() = default;
 
     //! Contruct from an exising Range<T2>
-    ItemMap(Range<T2> range) : range_(range){};
+    ItemMap(Range<T2> range) : range_(range)
+    {
+        static_assert(detail::IsOpaqueId<T1>::value, "T1 isn't opaque ID");
+        static_assert(detail::IsOpaqueId<T2>::value, "T2 isn't opaque ID");
+    }
 
     //// ACCESS ////
 
     //! Access Range via OpaqueId of type T1
     CELER_FORCEINLINE_FUNCTION T2 operator[](T1 id) const
     {
+        CELER_EXPECT(id < this->size());
         return range_[id.unchecked_get()];
-    };
+    }
 
     //! Wheter the underlying Range<T2> is empty
     CELER_FORCEINLINE_FUNCTION bool empty() const { return range_.empty(); }

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -128,9 +128,10 @@ template<class T, class Size = size_type>
 using ItemRange = Range<OpaqueId<T, Size>>;
 
 //---------------------------------------------------------------------------//
-/*! Access data in a Range<T2> with an index of type T1
+/*!
+ * Access data in a Range<T2> with an index of type T1.
  *
- * Here, T1 and T2 are expected to be OpaqueId types
+ * Here, T1 and T2 are expected to be OpaqueId types.
  */
 template<class T1, class T2>
 class ItemMap
@@ -148,7 +149,7 @@ class ItemMap
     ItemMap() = default;
 
     //! Contruct from an exising Range<T2>
-    ItemMap(Range<T2> range) : range_(range)
+   explicit CELER_FUNCTION ItemMap(Range<T2> range) : range_(range)
     {
         static_assert(detail::IsOpaqueId<T1>::value, "T1 isn't opaque ID");
         static_assert(detail::IsOpaqueId<T2>::value, "T2 isn't opaque ID");

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -127,6 +127,41 @@ using ItemId = OpaqueId<T, size_type>;
 template<class T, class Size = size_type>
 using ItemRange = Range<OpaqueId<T, Size>>;
 
+//---------------------------------------------------------------------------//
+/*! Access data in a Range<T2> with an index of type T1
+ *
+ * Here, T1 and T2 are expected to be OpaqueIds.
+ */
+template<class T1, class T2>
+class ItemMap
+{
+  public:
+    //// CONSTRUCTION ////
+
+    ItemMap() = default;
+
+    //! Contruct from an exising Range<T2>
+    ItemMap(Range<T2> range) : range_(range){};
+
+    //// ACCESS ////
+
+    //! Access Range via OpaqueId of type T1
+    CELER_FORCEINLINE_FUNCTION T2 operator[](T1 id) const
+    {
+        return range_[id.unchecked_get()];
+    };
+
+    //! Wheter the underlying Range<T2> is empty
+    CELER_FORCEINLINE_FUNCTION bool empty() const { return range_.empty(); }
+
+    //! Size of the underlying Range<T2>
+    CELER_FORCEINLINE_FUNCTION size_type size() const { return range_.size(); }
+
+  private:
+    //// DATA ////
+    Range<T2> range_;
+};
+
 // Forward-declare collection builder, needed for GCC7
 template<class T2, MemSpace M2, class Id2>
 class CollectionBuilder;

--- a/src/corecel/data/detail/CollectionImpl.hh
+++ b/src/corecel/data/detail/CollectionImpl.hh
@@ -197,5 +197,18 @@ struct CollectionAssigner<Ownership::value, MemSpace::device>
 };
 
 //---------------------------------------------------------------------------//
+//! Template matching to determine if T is an OpaqueId
+template<class T>
+struct IsOpaqueId
+{
+    static constexpr bool value = false;
+};
+template<class V, class S>
+struct IsOpaqueId<OpaqueId<V, S>>
+{
+    static constexpr bool value = true;
+};
+
+//---------------------------------------------------------------------------//
 }  // namespace detail
 }  // namespace celeritas

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -212,12 +212,12 @@ struct OrangeParamsData
 
     // Low-level storage
     Items<LocalSurfaceId> local_surface_ids;
+    Items<LocalVolumeId> local_volume_ids;
     Items<RealId> real_ids;
     Items<logic_int> logic_ints;
     Items<real_type> reals;
     Items<SurfaceType> surface_types;
     Items<Connectivity> connectivities;
-    Items<LocalVolumeId> local_volume_ids;
     Items<VolumeRecord> volume_records;
 
     Items<Translation> translations;

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -53,7 +53,7 @@ struct OrangeParamsScalars
  */
 struct VolumeRecord
 {
-    ItemRange<SurfaceId> faces;
+    ItemRange<LocalSurfaceId> faces;
     ItemRange<logic_int> logic;
 
     logic_int max_intersections{0};
@@ -127,7 +127,7 @@ struct SimpleUnitRecord
 
     // Surface data
     SurfacesRecord surfaces;
-    ItemRange<Connectivity> connectivity;  // Index by SurfaceId
+    ItemRange<Connectivity> connectivity;  // Index by LocalSurfaceId
 
     // Volume data [index by LocalVolumeId]
     ItemMap<LocalVolumeId, VolumeRecordId> volumes;
@@ -211,13 +211,13 @@ struct OrangeParamsData
     Items<SimpleUnitRecord> simple_unit;
 
     // Low-level storage
-    Items<SurfaceId> surface_ids;
-    Items<LocalVolumeId> connectivity_volume_ids;
+    Items<LocalSurfaceId> local_surface_ids;
     Items<RealId> real_ids;
     Items<logic_int> logic_ints;
     Items<real_type> reals;
     Items<SurfaceType> surface_types;
     Items<Connectivity> connectivities;
+    Items<LocalVolumeId> local_volume_ids;
     Items<VolumeRecord> volume_records;
 
     Items<Translation> translations;
@@ -231,7 +231,7 @@ struct OrangeParamsData
     {
         return scalars && !universe_type.empty()
                && universe_index.size() == universe_type.size()
-               && ((!connectivity_volume_ids.empty() && !logic_ints.empty()
+               && ((!local_volume_ids.empty() && !logic_ints.empty()
                     && !reals.empty())
                    || surface_types.empty())
                && !volume_records.empty() && unit_indexer_data;
@@ -247,8 +247,8 @@ struct OrangeParamsData
         universe_index = other.universe_index;
         simple_unit = other.simple_unit;
 
-        surface_ids = other.surface_ids;
-        connectivity_volume_ids = other.connectivity_volume_ids;
+        local_surface_ids = other.local_surface_ids;
+        local_volume_ids = other.local_volume_ids;
         real_ids = other.real_ids;
         logic_ints = other.logic_ints;
         reals = other.reals;
@@ -292,7 +292,7 @@ struct OrangeStateData
     Items<UniverseId> universe;
 
     // Surface crossing, dimensions {num_tracks, max_level}
-    Items<SurfaceId> surf;
+    Items<LocalSurfaceId> surf;
     Items<Sense> sense;
     Items<BoundaryResult> boundary;
 

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -114,7 +114,7 @@ struct SurfacesRecord
  */
 struct Connectivity
 {
-    ItemRange<VolumeId> neighbors;
+    ItemRange<LocalVolumeId> neighbors;
 };
 
 //---------------------------------------------------------------------------//
@@ -123,21 +123,21 @@ struct Connectivity
  */
 struct SimpleUnitRecord
 {
-    using VolumeRecordRange = Range<VolumeId>;
+    using VolumeRecordId = OpaqueId<VolumeRecord>;
 
     // Surface data
     SurfacesRecord surfaces;
     ItemRange<Connectivity> connectivity;  // Index by SurfaceId
 
-    // Volume data [index by VolumeId]
-    VolumeRecordRange volumes;
+    // Volume data [index by LocalVolumeId]
+    ItemMap<LocalVolumeId, VolumeRecordId> volumes;
 
     // Translation data [index by TranslationId]
     ItemRange<Translation> translations;
 
     // TODO: transforms
     // TODO: acceleration structure (bvh/kdtree/grid)
-    VolumeId background{};  //!< Default if not in any other volume
+    LocalVolumeId background{};  //!< Default if not in any other volume
     bool simple_safety{};
 
     //! True if defined
@@ -198,8 +198,6 @@ struct OrangeParamsData
     using Items = Collection<T, W, M>;
     template<class T>
     using UnivItems = Collection<T, W, M, UniverseId>;
-    template<class T>
-    using VolumeItems = Collection<T, W, M, VolumeId>;
     using RealId = OpaqueId<real_type>;
 
     //// DATA ////
@@ -214,13 +212,14 @@ struct OrangeParamsData
 
     // Low-level storage
     Items<SurfaceId> surface_ids;
-    Items<VolumeId> volume_ids;
+    Items<LocalVolumeId> connectivity_volume_ids;
     Items<RealId> real_ids;
     Items<logic_int> logic_ints;
     Items<real_type> reals;
     Items<SurfaceType> surface_types;
     Items<Connectivity> connectivities;
-    VolumeItems<VolumeRecord> volume_records;
+    Items<VolumeRecord> volume_records;
+
     Items<Translation> translations;
 
     UnitIndexerData<W, M> unit_indexer_data;
@@ -232,7 +231,8 @@ struct OrangeParamsData
     {
         return scalars && !universe_type.empty()
                && universe_index.size() == universe_type.size()
-               && ((!volume_ids.empty() && !logic_ints.empty() && !reals.empty())
+               && ((!connectivity_volume_ids.empty() && !logic_ints.empty()
+                    && !reals.empty())
                    || surface_types.empty())
                && !volume_records.empty() && unit_indexer_data;
     }
@@ -248,7 +248,7 @@ struct OrangeParamsData
         simple_unit = other.simple_unit;
 
         surface_ids = other.surface_ids;
-        volume_ids = other.volume_ids;
+        connectivity_volume_ids = other.connectivity_volume_ids;
         real_ids = other.real_ids;
         logic_ints = other.logic_ints;
         reals = other.reals;
@@ -288,7 +288,7 @@ struct OrangeStateData
     // Dimensions {num_tracks, max_level}
     Items<Real3> pos;
     Items<Real3> dir;
-    Items<VolumeId> vol;
+    Items<LocalVolumeId> vol;
     Items<UniverseId> universe;
 
     // Surface crossing, dimensions {num_tracks, max_level}

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -220,7 +220,7 @@ OrangeTrackView::operator=(Initializer_t const& init)
         lsa.pos() = init.pos;
         lsa.dir() = init.dir;
         lsa.universe() = uid;
-        lsa.surf() = SurfaceId{};
+        lsa.surf() = LocalSurfaceId{};
         lsa.sense() = Sense{};
         lsa.boundary() = BoundaryResult::exiting;
 
@@ -461,7 +461,7 @@ CELER_FUNCTION void OrangeTrackView::move_internal(real_type dist)
     axpy(dist, lsa.dir(), &lsa.pos());
 
     next_step_ -= dist;
-    lsa.surf() = SurfaceId{};
+    lsa.surf() = LocalSurfaceId{};
 }
 
 //---------------------------------------------------------------------------//
@@ -475,7 +475,7 @@ CELER_FUNCTION void OrangeTrackView::move_internal(Real3 const& pos)
 {
     auto lsa = this->make_lsa();
     lsa.pos() = pos;
-    lsa.surf() = SurfaceId{};
+    lsa.surf() = LocalSurfaceId{};
     this->clear_next_step();
 }
 
@@ -557,7 +557,9 @@ CELER_FUNCTION void OrangeTrackView::set_dir(Real3 const& newdir)
         // dotted with the surface normal changes (i.e. heading from inside to
         // outside or vice versa).
         auto tracker = this->make_tracker(UniverseId{0});
-        const Real3 normal = tracker.normal(this->pos(), this->surface_id());
+        detail::UnitIndexer ui(params_.unit_indexer_data);
+        const Real3 normal = tracker.normal(
+            this->pos(), ui.local_surface(this->surface_id()).surface);
 
         if ((dot_product(normal, newdir) >= 0)
             != (dot_product(normal, this->dir()) >= 0))

--- a/src/orange/Types.hh
+++ b/src/orange/Types.hh
@@ -21,6 +21,9 @@ namespace celeritas
 //! Identifier for a geometry volume
 using VolumeId = OpaqueId<struct Volume>;
 
+//! Lacal identifier for a geometry volume in a single universe
+using LocalVolumeId = OpaqueId<struct LocalVolume>;
+
 //! Identifier for a surface (for surface-based geometries)
 using SurfaceId = OpaqueId<struct Surface>;
 

--- a/src/orange/Types.hh
+++ b/src/orange/Types.hh
@@ -21,11 +21,14 @@ namespace celeritas
 //! Identifier for a geometry volume
 using VolumeId = OpaqueId<struct Volume>;
 
-//! Lacal identifier for a geometry volume in a single universe
+//! Lacal identifier for a geometry volume in a universe
 using LocalVolumeId = OpaqueId<struct LocalVolume>;
 
 //! Identifier for a surface (for surface-based geometries)
 using SurfaceId = OpaqueId<struct Surface>;
+
+//! Local Identifier for a surface within within a universe
+using LocalSurfaceId = OpaqueId<struct LocalSurface>;
 
 //! Fixed-size array for 3D space
 using Real3 = Array<real_type, 3>;

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -54,7 +54,7 @@ struct VolumeInput
     Label label{};
 
     //! Sorted list of surface IDs in this volume
-    std::vector<SurfaceId> faces{};
+    std::vector<LocalSurfaceId> faces{};
     //! RPN region definition for this volume, using local surface index
     std::vector<logic_int> logic{};
     //! Axis-aligned bounding box (TODO: currently unused)

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -83,7 +83,7 @@ struct UnitInput
         UniverseId universe_id;
         Translation translation;
     };
-    using MapVolumeDaughter = std::unordered_map<VolumeId, Daughter>;
+    using MapVolumeDaughter = std::unordered_map<LocalVolumeId, Daughter>;
 
     SurfaceInput surfaces;
     std::vector<VolumeInput> volumes;

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -122,12 +122,12 @@ void from_json(nlohmann::json const& j, SurfaceInput& value)
 void from_json(nlohmann::json const& j, VolumeInput& value)
 {
     // Convert faces to OpaqueId
-    std::vector<SurfaceId::size_type> temp_faces;
+    std::vector<LocalSurfaceId::size_type> temp_faces;
     j.at("faces").get_to(temp_faces);
     value.faces.reserve(temp_faces.size());
     for (auto surfid : temp_faces)
     {
-        CELER_ASSERT(surfid != SurfaceId{}.unchecked_get());
+        CELER_ASSERT(surfid != LocalSurfaceId{}.unchecked_get());
         value.faces.emplace_back(surfid);
     }
 

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -188,7 +188,7 @@ void from_json(nlohmann::json const& j, UnitInput& value)
         UnitInput::MapVolumeDaughter daughter_map;
         for (auto i : range(parent_cells.size()))
         {
-            daughter_map[VolumeId{parent_cells[i]}]
+            daughter_map[LocalVolumeId{parent_cells[i]}]
                 = {UniverseId{daughters[i]}, {0, 0, 0}};
         }
 

--- a/src/orange/construct/SurfaceInputBuilder.cc
+++ b/src/orange/construct/SurfaceInputBuilder.cc
@@ -47,12 +47,12 @@ SurfaceInputBuilder::SurfaceInputBuilder(SurfaceInput* input) : input_(input)
 /*!
  * Insert a generic surface.
  */
-SurfaceId SurfaceInputBuilder::operator()(GenericSurfaceRef generic_surf,
-                                          Label const& label)
+LocalSurfaceId SurfaceInputBuilder::operator()(GenericSurfaceRef generic_surf,
+                                               Label const& label)
 {
     CELER_EXPECT(generic_surf);
 
-    SurfaceId::size_type new_id = input_->size();
+    LocalSurfaceId::size_type new_id = input_->size();
     input_->types.push_back(generic_surf.type);
     input_->data.insert(
         input_->data.end(), generic_surf.data.begin(), generic_surf.data.end());
@@ -61,7 +61,7 @@ SurfaceId SurfaceInputBuilder::operator()(GenericSurfaceRef generic_surf,
 
     CELER_ENSURE(input_->types.size() == input_->sizes.size());
     CELER_ENSURE(input_->types.size() == input_->labels.size());
-    return SurfaceId{new_id};
+    return LocalSurfaceId{new_id};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/construct/SurfaceInputBuilder.hh
+++ b/src/orange/construct/SurfaceInputBuilder.hh
@@ -48,10 +48,11 @@ class SurfaceInputBuilder
 
     // Add a new surface
     template<class T>
-    inline SurfaceId operator()(T const& surface, Label const& label);
+    inline LocalSurfaceId operator()(T const& surface, Label const& label);
 
     // Append a generic surface view to the vector
-    SurfaceId operator()(GenericSurfaceRef generic_surf, Label const& label);
+    LocalSurfaceId
+    operator()(GenericSurfaceRef generic_surf, Label const& label);
 
   private:
     SurfaceInput* input_;
@@ -73,7 +74,8 @@ SurfaceInputBuilder::GenericSurfaceRef::operator bool() const
  * Add a surface (type-deleted) with the given coefficients
  */
 template<class T>
-SurfaceId SurfaceInputBuilder::operator()(T const& surface, Label const& label)
+LocalSurfaceId
+SurfaceInputBuilder::operator()(T const& surface, Label const& label)
 {
     static_assert(sizeof(typename T::Intersections) > 0,
                   "Template parameter must be a surface class");

--- a/src/orange/detail/LevelStateAccessor.hh
+++ b/src/orange/detail/LevelStateAccessor.hh
@@ -37,9 +37,9 @@ class LevelStateAccessor
 
     //// ACCESSORS ////
 
-    CELER_FUNCTION VolumeId& vol()
+    CELER_FUNCTION LocalVolumeId& vol()
     {
-        return states_->vol[OpaqueId<VolumeId>{index_}];
+        return states_->vol[OpaqueId<LocalVolumeId>{index_}];
     }
 
     CELER_FUNCTION Real3& pos()
@@ -74,9 +74,9 @@ class LevelStateAccessor
 
     //// CONST ACCESSORS ////
 
-    CELER_FUNCTION VolumeId const& vol() const
+    CELER_FUNCTION LocalVolumeId const& vol() const
     {
-        return states_->vol[OpaqueId<VolumeId>{index_}];
+        return states_->vol[OpaqueId<LocalVolumeId>{index_}];
     }
 
     CELER_FUNCTION Real3 const& pos() const

--- a/src/orange/detail/LevelStateAccessor.hh
+++ b/src/orange/detail/LevelStateAccessor.hh
@@ -57,9 +57,9 @@ class LevelStateAccessor
         return states_->universe[OpaqueId<UniverseId>{index_}];
     }
 
-    CELER_FUNCTION SurfaceId& surf()
+    CELER_FUNCTION LocalSurfaceId& surf()
     {
-        return states_->surf[OpaqueId<SurfaceId>{index_}];
+        return states_->surf[OpaqueId<LocalSurfaceId>{index_}];
     }
 
     CELER_FUNCTION Sense& sense()
@@ -94,9 +94,9 @@ class LevelStateAccessor
         return states_->universe[OpaqueId<UniverseId>{index_}];
     }
 
-    CELER_FUNCTION SurfaceId const& surf() const
+    CELER_FUNCTION LocalSurfaceId const& surf() const
     {
-        return states_->surf[OpaqueId<SurfaceId>{index_}];
+        return states_->surf[OpaqueId<LocalSurfaceId>{index_}];
     }
 
     CELER_FUNCTION Sense const& sense() const

--- a/src/orange/detail/UnitIndexer.hh
+++ b/src/orange/detail/UnitIndexer.hh
@@ -41,7 +41,7 @@ class UnitIndexer
     struct LocalVolume
     {
         UniverseId universe;
-        VolumeId volume;
+        LocalVolumeId volume;
     };
     //!@}
 
@@ -53,7 +53,7 @@ class UnitIndexer
     inline CELER_FUNCTION SurfaceId global_surface(UniverseId uni,
                                                    SurfaceId surface) const;
     inline CELER_FUNCTION VolumeId global_volume(UniverseId uni,
-                                                 VolumeId volume) const;
+                                                 LocalVolumeId volume) const;
 
     // Global-to-local
     inline CELER_FUNCTION LocalSurface local_surface(SurfaceId id) const;
@@ -125,7 +125,7 @@ CELER_FUNCTION SurfaceId UnitIndexer::global_surface(UniverseId uni,
  * Transform local to global volume ID.
  */
 CELER_FUNCTION VolumeId UnitIndexer::global_volume(UniverseId uni,
-                                                   VolumeId volume) const
+                                                   LocalVolumeId volume) const
 {
     CELER_EXPECT(uni < this->num_universes());
     CELER_EXPECT(volume < this->local_size(data_.volumes, uni));
@@ -161,7 +161,7 @@ UnitIndexer::local_volume(VolumeId id) const
     auto iter = this->find_local(data_.volumes, id.unchecked_get());
 
     UniverseId uni(iter - data_.volumes[AllVals{}].begin());
-    VolumeId volume(id - *iter);
+    LocalVolumeId volume((id - *iter).unchecked_get());
     CELER_ENSURE(uni.get() < this->num_universes());
     return {uni, volume};
 }

--- a/src/orange/detail/UnitIndexer.hh
+++ b/src/orange/detail/UnitIndexer.hh
@@ -35,7 +35,7 @@ class UnitIndexer
     struct LocalSurface
     {
         UniverseId universe;
-        SurfaceId surface;
+        LocalSurfaceId surface;
     };
 
     struct LocalVolume
@@ -51,7 +51,7 @@ class UnitIndexer
 
     // Local-to-global
     inline CELER_FUNCTION SurfaceId global_surface(UniverseId uni,
-                                                   SurfaceId surface) const;
+                                                   LocalSurfaceId surface) const;
     inline CELER_FUNCTION VolumeId global_volume(UniverseId uni,
                                                  LocalVolumeId volume) const;
 
@@ -111,7 +111,7 @@ CELER_FUNCTION UnitIndexer::UnitIndexer(UnitIndexerDataRef const& data)
  * Transform local to global surface ID.
  */
 CELER_FUNCTION SurfaceId UnitIndexer::global_surface(UniverseId uni,
-                                                     SurfaceId surf) const
+                                                     LocalSurfaceId surf) const
 {
     CELER_EXPECT(uni < this->num_universes());
     CELER_EXPECT(surf < this->local_size(data_.surfaces, uni));
@@ -145,7 +145,7 @@ UnitIndexer::local_surface(SurfaceId id) const
     auto iter = this->find_local(data_.surfaces, id.unchecked_get());
 
     UniverseId uni(iter - data_.surfaces[AllVals{}].begin());
-    SurfaceId surface(id - *iter);
+    LocalSurfaceId surface((id - *iter).unchecked_get());
     CELER_ENSURE(uni < this->num_universes());
     return {uni, surface};
 }

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -176,7 +176,7 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
         // Add connectivity for explicitly connected volumes
         if (!(vol_records[i].flags & VolumeRecord::implicit_vol))
         {
-            for (SurfaceId f : inp.volumes[i].faces)
+            for (LocalSurfaceId f : inp.volumes[i].faces)
             {
                 CELER_ASSERT(f < connectivity.size());
                 connectivity[f.unchecked_get()].insert(LocalVolumeId(i));
@@ -198,7 +198,7 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
     {
         std::vector<Connectivity> conn(connectivity.size());
         CELER_ASSERT(conn.size() == unit.surfaces.types.size());
-        auto vol_ids = make_builder(&orange_data_->connectivity_volume_ids);
+        auto vol_ids = make_builder(&orange_data_->local_volume_ids);
         for (auto i : range(connectivity.size()))
         {
             Connectivity c;
@@ -308,7 +308,7 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
     auto get_num_intersections
         = make_surface_action(surfaces, NumIntersectionGetter{});
 
-    for (SurfaceId sid : v.faces)
+    for (LocalSurfaceId sid : v.faces)
     {
         CELER_ASSERT(sid < surfaces.num_surfaces());
         simple_safety = simple_safety && get_simple_safety(sid);
@@ -329,12 +329,11 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
         input_logic = make_span(nowhere_logic);
     }
 
-    auto faces = make_builder(&orange_data_->surface_ids);
-    auto logic = make_builder(&orange_data_->logic_ints);
-
     VolumeRecord output;
-    output.faces = faces.insert_back(v.faces.begin(), v.faces.end());
-    output.logic = logic.insert_back(input_logic.begin(), input_logic.end());
+    output.faces = make_builder(&orange_data_->local_surface_ids)
+                       .insert_back(v.faces.begin(), v.faces.end());
+    output.logic = make_builder(&orange_data_->logic_ints)
+                       .insert_back(input_logic.begin(), input_logic.end());
     output.max_intersections = max_intersections;
     output.flags = v.flags;
     if (simple_safety)

--- a/src/orange/surf/Surfaces.hh
+++ b/src/orange/surf/Surfaces.hh
@@ -31,14 +31,14 @@ class Surfaces
     Surfaces(ParamsRef const& params, SurfacesRecord const& surf_record);
 
     // Number of surfaces
-    inline CELER_FUNCTION SurfaceId::size_type num_surfaces() const;
+    inline CELER_FUNCTION LocalSurfaceId::size_type num_surfaces() const;
 
     // Get the type of an indexed surface
-    inline CELER_FUNCTION SurfaceType surface_type(SurfaceId) const;
+    inline CELER_FUNCTION SurfaceType surface_type(LocalSurfaceId) const;
 
     // Convert a stored surface to a class
     template<class T>
-    inline CELER_FUNCTION T make_surface(SurfaceId) const;
+    inline CELER_FUNCTION T make_surface(LocalSurfaceId) const;
 
   private:
     ParamsRef const& params_;
@@ -61,7 +61,7 @@ Surfaces::Surfaces(ParamsRef const& params, SurfacesRecord const& surf_record)
 /*!
  * Number of surfaces.
  */
-CELER_FUNCTION SurfaceId::size_type Surfaces::num_surfaces() const
+CELER_FUNCTION LocalSurfaceId::size_type Surfaces::num_surfaces() const
 {
     return surf_record_.size();
 }
@@ -70,7 +70,7 @@ CELER_FUNCTION SurfaceId::size_type Surfaces::num_surfaces() const
 /*!
  * Get the type of an indexed surface.
  */
-CELER_FUNCTION SurfaceType Surfaces::surface_type(SurfaceId sid) const
+CELER_FUNCTION SurfaceType Surfaces::surface_type(LocalSurfaceId sid) const
 {
     CELER_EXPECT(sid < this->num_surfaces());
     OpaqueId<SurfaceType> offset = *surf_record_.types.begin();
@@ -84,7 +84,7 @@ CELER_FUNCTION SurfaceType Surfaces::surface_type(SurfaceId sid) const
  * Convert a stored surface to a class.
  */
 template<class T>
-CELER_FUNCTION T Surfaces::make_surface(SurfaceId sid) const
+CELER_FUNCTION T Surfaces::make_surface(LocalSurfaceId sid) const
 {
     static_assert(T::Storage::extent > 0,
                   "Template parameter must be a surface class");

--- a/src/orange/surf/detail/SurfaceAction.hh
+++ b/src/orange/surf/detail/SurfaceAction.hh
@@ -42,7 +42,7 @@ class SurfaceAction
     inline CELER_FUNCTION SurfaceAction(Surfaces const& surfaces, F&& action);
 
     // Apply to the surface specified by a surface ID
-    inline CELER_FUNCTION decltype(auto) operator()(SurfaceId id);
+    inline CELER_FUNCTION decltype(auto) operator()(LocalSurfaceId id);
 
     //! Access the resulting action
     CELER_FUNCTION F const& action() const { return action_; }
@@ -134,7 +134,7 @@ SurfaceAction<F>::SurfaceAction(Surfaces const& surfaces, F&& action)
  * Apply to the surface specified by the given surface ID.
  */
 template<class F>
-CELER_FUNCTION auto SurfaceAction<F>::operator()(SurfaceId id)
+CELER_FUNCTION auto SurfaceAction<F>::operator()(LocalSurfaceId id)
     -> decltype(auto)
 {
     CELER_EXPECT(id < surfaces_.num_surfaces());

--- a/src/orange/univ/VolumeView.hh
+++ b/src/orange/univ/VolumeView.hh
@@ -51,13 +51,13 @@ class VolumeView
     CELER_FORCEINLINE_FUNCTION FaceId::size_type num_faces() const;
 
     // Get surface ID for a single face
-    inline CELER_FUNCTION SurfaceId get_surface(FaceId id) const;
+    inline CELER_FUNCTION LocalSurfaceId get_surface(FaceId id) const;
 
     // Get the face ID of a surface if present
-    inline CELER_FUNCTION FaceId find_face(SurfaceId id) const;
+    inline CELER_FUNCTION FaceId find_face(LocalSurfaceId id) const;
 
     // Get all surface IDs for the volume
-    CELER_FORCEINLINE_FUNCTION Span<SurfaceId const> faces() const;
+    CELER_FORCEINLINE_FUNCTION Span<LocalSurfaceId const> faces() const;
 
     // Get logic definition
     CELER_FORCEINLINE_FUNCTION Span<logic_int const> logic() const;
@@ -114,12 +114,12 @@ CELER_FUNCTION FaceId::size_type VolumeView::num_faces() const
  *
  * This is an O(1) operation.
  */
-CELER_FUNCTION SurfaceId VolumeView::get_surface(FaceId id) const
+CELER_FUNCTION LocalSurfaceId VolumeView::get_surface(FaceId id) const
 {
     CELER_EXPECT(id < this->num_faces());
     auto offset = def_.faces.begin()->unchecked_get();
     offset += id.unchecked_get();
-    return params_.surface_ids[ItemId<SurfaceId>(offset)];
+    return params_.local_surface_ids[ItemId<LocalSurfaceId>(offset)];
 }
 
 //---------------------------------------------------------------------------//
@@ -134,7 +134,7 @@ CELER_FUNCTION SurfaceId VolumeView::get_surface(FaceId id) const
  *
  * This is an O(log(num_faces)) operation.
  */
-CELER_FUNCTION FaceId VolumeView::find_face(SurfaceId surface) const
+CELER_FUNCTION FaceId VolumeView::find_face(LocalSurfaceId surface) const
 {
     CELER_EXPECT(surface);
     auto surface_list = this->faces();
@@ -154,9 +154,9 @@ CELER_FUNCTION FaceId VolumeView::find_face(SurfaceId surface) const
 /*!
  * Get all the surface IDs corresponding to the faces of this volume.
  */
-CELER_FUNCTION Span<SurfaceId const> VolumeView::faces() const
+CELER_FUNCTION Span<LocalSurfaceId const> VolumeView::faces() const
 {
-    return params_.surface_ids[def_.faces];
+    return params_.local_surface_ids[def_.faces];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/univ/VolumeView.hh
+++ b/src/orange/univ/VolumeView.hh
@@ -43,7 +43,7 @@ class VolumeView
     // Construct with reference to persistent data
     inline CELER_FUNCTION VolumeView(ParamsRef const& params,
                                      SimpleUnitRecord const& unit_record,
-                                     VolumeId id);
+                                     LocalVolumeId id);
 
     //// ACCESSORS ////
 
@@ -84,7 +84,7 @@ class VolumeView
     static inline CELER_FUNCTION VolumeRecord const&
     volume_record(ParamsRef const&,
                   SimpleUnitRecord const& unit_record,
-                  VolumeId id);
+                  LocalVolumeId id);
 };
 
 //---------------------------------------------------------------------------//
@@ -94,7 +94,7 @@ class VolumeView
 CELER_FUNCTION
 VolumeView::VolumeView(ParamsRef const& params,
                        SimpleUnitRecord const& unit_record,
-                       VolumeId id)
+                       LocalVolumeId id)
     : params_(params), def_(VolumeView::volume_record(params, unit_record, id))
 {
 }
@@ -223,13 +223,10 @@ CELER_FUNCTION bool VolumeView::simple_intersection() const
 inline CELER_FUNCTION VolumeRecord const&
 VolumeView::volume_record(ParamsRef const& params,
                           SimpleUnitRecord const& unit,
-                          VolumeId local_vol_id)
+                          LocalVolumeId local_vol_id)
 {
     CELER_EXPECT(local_vol_id < unit.volumes.size());
-
-    VolumeId global_vol_id = unit.volumes[local_vol_id.unchecked_get()];
-
-    return params.volume_records[global_vol_id];
+    return params.volume_records[unit.volumes[local_vol_id]];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/univ/detail/Types.hh
+++ b/src/orange/univ/detail/Types.hh
@@ -94,6 +94,7 @@ operator!=(OnTface<ValueT> const& lhs, OnTface<ValueT> const& rhs) noexcept
 }
 
 using OnSurface = OnTface<struct Surface>;
+using OnLocalSurface = OnTface<struct LocalSurface>;
 using OnFace = OnTface<struct Face>;
 
 //---------------------------------------------------------------------------//
@@ -105,7 +106,7 @@ using OnFace = OnTface<struct Face>;
  */
 struct Intersection
 {
-    OnSurface surface;
+    OnLocalSurface surface;
     real_type distance = no_intersection();
 
     //! Whether a next surface has been found
@@ -132,7 +133,7 @@ struct Intersection
 struct Initialization
 {
     LocalVolumeId volume;
-    OnSurface surface;
+    OnLocalSurface surface;
 
     //! Whether initialization succeeded
     explicit CELER_FUNCTION operator bool() const
@@ -183,7 +184,7 @@ struct LocalState
     Real3 pos;
     Real3 dir;
     LocalVolumeId volume;
-    OnSurface surface;
+    OnLocalSurface surface;
     Span<Sense> temp_sense;
     TempNextFace temp_next;
 };

--- a/src/orange/univ/detail/Types.hh
+++ b/src/orange/univ/detail/Types.hh
@@ -131,7 +131,7 @@ struct Intersection
  */
 struct Initialization
 {
-    VolumeId volume;
+    LocalVolumeId volume;
     OnSurface surface;
 
     //! Whether initialization succeeded
@@ -182,7 +182,7 @@ struct LocalState
 {
     Real3 pos;
     Real3 dir;
-    VolumeId volume;
+    LocalVolumeId volume;
     OnSurface surface;
     Span<Sense> temp_sense;
     TempNextFace temp_next;

--- a/src/orange/univ/detail/Utils.hh
+++ b/src/orange/univ/detail/Utils.hh
@@ -88,20 +88,22 @@ class BumpCalculator
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Convert an OnSurface (may be null) to an OnFace using a volume view.
+ * Convert an OnLocalSurface (may be null) to an OnFace using a volume view.
  */
-inline CELER_FUNCTION OnFace find_face(VolumeView const& vol, OnSurface surf)
+inline CELER_FUNCTION OnFace find_face(VolumeView const& vol,
+                                       OnLocalSurface surf)
 {
     return {surf ? vol.find_face(surf.id()) : FaceId{}, surf.unchecked_sense()};
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Convert an OnFace (may be null) to an OnSurface using a volume view.
+ * Convert an OnFace (may be null) to an OnLocalSurface using a volume view.
  */
-inline CELER_FUNCTION OnSurface get_surface(VolumeView const& vol, OnFace face)
+inline CELER_FUNCTION OnLocalSurface get_surface(VolumeView const& vol,
+                                                 OnFace face)
 {
-    return {face ? vol.get_surface(face.id()) : SurfaceId{},
+    return {face ? vol.get_surface(face.id()) : LocalSurfaceId{},
             face.unchecked_sense()};
 }
 

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -59,6 +59,50 @@ TEST(ItemRange, accessors)
     EXPECT_EQ(ItemIdT{12}, ps[2]);
 }
 
+TEST(ItemMap, basic)
+{
+    using T1 = OpaqueId<double>;
+    using T2 = OpaqueId<int>;
+    using ItemMap = ItemMap<T1, T2>;
+
+    Collection<double, Ownership::value, MemSpace::host, T2> host_val;
+    std::vector<T2::value_type> data_a = {5, 6, 7, 8};
+    std::vector<T2::value_type> data_b = {9, 10, 11};
+
+    // Add both vectors to the Collection, creating a Range for each
+    auto range_a
+        = make_builder(&host_val).insert_back(data_a.begin(), data_a.end());
+    auto range_b
+        = make_builder(&host_val).insert_back(data_b.begin(), data_b.end());
+
+    ItemMap im_a;
+    ItemMap im_b;
+
+    EXPECT_EQ(0, im_a.size());
+    EXPECT_TRUE(im_a.empty());
+
+    // Create an ItemMap for each Range
+    im_a = ItemMap(range_a);
+    im_b = ItemMap(range_b);
+
+    EXPECT_EQ(4, im_a.size());
+    EXPECT_EQ(3, im_b.size());
+
+    EXPECT_FALSE(im_a.empty());
+    EXPECT_FALSE(im_b.empty());
+
+    // Verify we can access the T2 data with index type T1
+    for (size_type i : range(data_a.size()))
+    {
+        EXPECT_EQ(range_a[i], im_a[T1{i}]);
+    }
+
+    for (size_type i : range(data_b.size()))
+    {
+        EXPECT_EQ(range_b[i], im_b[T1{i}]);
+    }
+}
+
 TEST(CollectionBuilder, size_limits)
 {
     using IdType = OpaqueId<struct Tiny, std::uint8_t>;

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -140,7 +140,7 @@ void OrangeGeoTestBase::build_geometry(TwoVolInput inp)
     {
         // Insert volumes
         VolumeInput vi;
-        vi.faces = {SurfaceId{0}};
+        vi.faces = {LocalSurfaceId{0}};
 
         // Outside
         vi.logic = {0};
@@ -206,9 +206,10 @@ void OrangeGeoTestBase::describe(std::ostream& os) const
     auto surf_to_stream = make_surface_action(surfaces, ToStream{os});
 
     // Loop over all surfaces and apply
-    for (auto id : range(SurfaceId{surfaces.num_surfaces()}))
+    for (auto id : range(LocalSurfaceId{surfaces.num_surfaces()}))
     {
-        os << " - " << params_->id_to_label(id) << "(" << id.get() << "): ";
+        os << " - " << this->id_to_label(UniverseId{0}, id) << "(" << id.get()
+           << "): ";
         surf_to_stream(id);
         os << '\n';
     }
@@ -252,12 +253,14 @@ VolumeId OrangeGeoTestBase::find_volume(char const* label) const
 /*!
  * Surface name (or sentinel if no surface).
  */
-std::string OrangeGeoTestBase::id_to_label(SurfaceId surf) const
+std::string
+OrangeGeoTestBase::id_to_label(UniverseId uid, LocalSurfaceId surfid) const
 {
-    if (!surf)
+    if (!surfid)
         return "[none]";
 
-    return params_->id_to_label(surf).name;
+    detail::UnitIndexer ui(this->params().host_ref().unit_indexer_data);
+    return params_->id_to_label(ui.global_surface(uid, surfid)).name;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -264,12 +264,14 @@ std::string OrangeGeoTestBase::id_to_label(SurfaceId surf) const
 /*!
  * Volume name (or sentinel if no volume).
  */
-std::string OrangeGeoTestBase::id_to_label(VolumeId vol) const
+std::string
+OrangeGeoTestBase::id_to_label(UniverseId uid, LocalVolumeId volid) const
 {
-    if (!vol)
+    if (!volid)
         return "[none]";
 
-    return params_->id_to_label(vol).name;
+    detail::UnitIndexer ui(this->params().host_ref().unit_indexer_data);
+    return params_->id_to_label(ui.global_volume(uid, volid)).name;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -265,6 +265,15 @@ OrangeGeoTestBase::id_to_label(UniverseId uid, LocalSurfaceId surfid) const
 
 //---------------------------------------------------------------------------//
 /*!
+ * Surface name (or sentinel if no surface) within UniverseId{0}.
+ */
+std::string OrangeGeoTestBase::id_to_label(LocalSurfaceId surfid) const
+{
+    return this->id_to_label(UniverseId{0}, surfid);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Volume name (or sentinel if no volume).
  */
 std::string
@@ -275,6 +284,15 @@ OrangeGeoTestBase::id_to_label(UniverseId uid, LocalVolumeId volid) const
 
     detail::UnitIndexer ui(this->params().host_ref().unit_indexer_data);
     return params_->id_to_label(ui.global_volume(uid, volid)).name;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Volume name (or sentinel if no volume) within UniverseId{0}.
+ */
+std::string OrangeGeoTestBase::id_to_label(LocalVolumeId volid) const
+{
+    return this->id_to_label(UniverseId{0}, volid);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeGeoTestBase.hh
+++ b/test/orange/OrangeGeoTestBase.hh
@@ -97,11 +97,17 @@ class OrangeGeoTestBase : public Test
     // Find the surface from its label (NULL pointer allowed)
     SurfaceId find_surface(char const* label) const;
 
-    // Surface name (or sentinel if no surface);
+    // Surface name (or sentinel if no surface)
     std::string id_to_label(UniverseId uid, LocalSurfaceId surfid) const;
 
-    // Cell name (or sentinel if no surface);
+    // Surface name (or sentinel if no surface) within UniverseId{0}
+    std::string id_to_label(LocalSurfaceId surfid) const;
+
+    // Cell name (or sentinel if no surface)
     std::string id_to_label(UniverseId uid, LocalVolumeId volid) const;
+
+    // Cell name (or sentinel if no surface) within UniverseId{0}
+    std::string id_to_label(LocalVolumeId volid) const;
 
     // Print geometry description
     void describe(std::ostream& os) const;

--- a/test/orange/OrangeGeoTestBase.hh
+++ b/test/orange/OrangeGeoTestBase.hh
@@ -101,7 +101,7 @@ class OrangeGeoTestBase : public Test
     std::string id_to_label(SurfaceId) const;
 
     // Cell name (or sentinel if no surface);
-    std::string id_to_label(VolumeId) const;
+    std::string id_to_label(UniverseId uid, LocalVolumeId volid) const;
 
     // Print geometry description
     void describe(std::ostream& os) const;

--- a/test/orange/OrangeGeoTestBase.hh
+++ b/test/orange/OrangeGeoTestBase.hh
@@ -98,7 +98,7 @@ class OrangeGeoTestBase : public Test
     SurfaceId find_surface(char const* label) const;
 
     // Surface name (or sentinel if no surface);
-    std::string id_to_label(SurfaceId) const;
+    std::string id_to_label(UniverseId uid, LocalSurfaceId surfid) const;
 
     // Cell name (or sentinel if no surface);
     std::string id_to_label(UniverseId uid, LocalVolumeId volid) const;

--- a/test/orange/detail/UnitIndexer.test.cc
+++ b/test/orange/detail/UnitIndexer.test.cc
@@ -61,8 +61,10 @@ TEST_F(UnitIndexerTest, single)
     EXPECT_EQ(SurfaceId(3),
               indexer.global_surface(UniverseId{0}, SurfaceId{3}));
 
-    EXPECT_EQ(VolumeId(0), indexer.global_volume(UniverseId{0}, VolumeId{0}));
-    EXPECT_EQ(VolumeId(9), indexer.global_volume(UniverseId{0}, VolumeId{9}));
+    EXPECT_EQ(VolumeId(0),
+              indexer.global_volume(UniverseId{0}, LocalVolumeId{0}));
+    EXPECT_EQ(VolumeId(9),
+              indexer.global_volume(UniverseId{0}, LocalVolumeId{9}));
 
     auto local_s = indexer.local_surface(SurfaceId{0});
     EXPECT_EQ(UniverseId(0), local_s.universe);
@@ -73,10 +75,10 @@ TEST_F(UnitIndexerTest, single)
 
     auto local_v = indexer.local_volume(VolumeId{0});
     EXPECT_EQ(UniverseId(0), local_v.universe);
-    EXPECT_EQ(VolumeId(0), local_v.volume);
+    EXPECT_EQ(LocalVolumeId(0), local_v.volume);
     local_v = indexer.local_volume(VolumeId{3});
     EXPECT_EQ(UniverseId(0), local_v.universe);
-    EXPECT_EQ(VolumeId(3), local_v.volume);
+    EXPECT_EQ(LocalVolumeId(3), local_v.volume);
 }
 
 TEST_F(UnitIndexerTest, TEST_IF_CELERITAS_DEBUG(errors))
@@ -88,9 +90,10 @@ TEST_F(UnitIndexerTest, TEST_IF_CELERITAS_DEBUG(errors))
                  DebugError);
     EXPECT_THROW(indexer.global_surface(UniverseId{1}, SurfaceId{0}),
                  DebugError);
-    EXPECT_THROW(indexer.global_volume(UniverseId{0}, VolumeId{10}),
+    EXPECT_THROW(indexer.global_volume(UniverseId{0}, LocalVolumeId{10}),
                  DebugError);
-    EXPECT_THROW(indexer.global_volume(UniverseId{1}, VolumeId{0}), DebugError);
+    EXPECT_THROW(indexer.global_volume(UniverseId{1}, LocalVolumeId{0}),
+                 DebugError);
 
     EXPECT_THROW(indexer.local_surface(SurfaceId(4)), DebugError);
     EXPECT_THROW(indexer.local_volume(VolumeId(10)), DebugError);

--- a/test/orange/detail/UnitIndexer.test.cc
+++ b/test/orange/detail/UnitIndexer.test.cc
@@ -57,9 +57,9 @@ TEST_F(UnitIndexerTest, single)
     EXPECT_EQ(10, indexer.num_volumes());
 
     EXPECT_EQ(SurfaceId(0),
-              indexer.global_surface(UniverseId{0}, SurfaceId{0}));
+              indexer.global_surface(UniverseId{0}, LocalSurfaceId{0}));
     EXPECT_EQ(SurfaceId(3),
-              indexer.global_surface(UniverseId{0}, SurfaceId{3}));
+              indexer.global_surface(UniverseId{0}, LocalSurfaceId{3}));
 
     EXPECT_EQ(VolumeId(0),
               indexer.global_volume(UniverseId{0}, LocalVolumeId{0}));
@@ -68,10 +68,10 @@ TEST_F(UnitIndexerTest, single)
 
     auto local_s = indexer.local_surface(SurfaceId{0});
     EXPECT_EQ(UniverseId(0), local_s.universe);
-    EXPECT_EQ(SurfaceId(0), local_s.surface);
+    EXPECT_EQ(LocalSurfaceId(0), local_s.surface);
     local_s = indexer.local_surface(SurfaceId{3});
     EXPECT_EQ(UniverseId(0), local_s.universe);
-    EXPECT_EQ(SurfaceId(3), local_s.surface);
+    EXPECT_EQ(LocalSurfaceId(3), local_s.surface);
 
     auto local_v = indexer.local_volume(VolumeId{0});
     EXPECT_EQ(UniverseId(0), local_v.universe);
@@ -86,9 +86,9 @@ TEST_F(UnitIndexerTest, TEST_IF_CELERITAS_DEBUG(errors))
     this->set_data({0, 4}, {0, 10});
     UnitIndexer indexer(this->host_ref());
 
-    EXPECT_THROW(indexer.global_surface(UniverseId{0}, SurfaceId{4}),
+    EXPECT_THROW(indexer.global_surface(UniverseId{0}, LocalSurfaceId{4}),
                  DebugError);
-    EXPECT_THROW(indexer.global_surface(UniverseId{1}, SurfaceId{0}),
+    EXPECT_THROW(indexer.global_surface(UniverseId{1}, LocalSurfaceId{0}),
                  DebugError);
     EXPECT_THROW(indexer.global_volume(UniverseId{0}, LocalVolumeId{10}),
                  DebugError);

--- a/test/orange/surf/SurfaceAction.test.cc
+++ b/test/orange/surf/SurfaceAction.test.cc
@@ -73,7 +73,7 @@ class SurfaceActionTest : public OrangeGeoTestBase
                 {
                     v.logic.push_back(logic::lor);
                 }
-                v.faces.push_back(SurfaceId{i});
+                v.faces.push_back(LocalSurfaceId{i});
             }
             v.logic.insert(v.logic.end(), {logic::ltrue, logic::lor});
             unit.volumes = {std::move(v)};
@@ -163,7 +163,7 @@ TEST_F(SurfaceActionTest, string)
 
     // Loop over all surfaces and apply
     std::vector<std::string> strings;
-    for (auto id : range(SurfaceId{surfaces.num_surfaces()}))
+    for (auto id : range(LocalSurfaceId{surfaces.num_surfaces()}))
     {
         strings.push_back(surf_to_string(id));
     }

--- a/test/orange/surf/SurfaceAction.test.hh
+++ b/test/orange/surf/SurfaceAction.test.hh
@@ -129,7 +129,7 @@ struct CalcSenseDistanceLauncher
                               &this->states.sense[tid],
                               &this->states.distance[tid]});
 
-        SurfaceId sid{tid.get() % surfaces.num_surfaces()};
+        LocalSurfaceId sid{tid.get() % surfaces.num_surfaces()};
         calc_sense_dist(sid);
     }
 };

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -434,7 +434,7 @@ TEST_F(TwoVolumeTest, initialize)
         SCOPED_TRACE("In the inner sphere");
         auto init
             = tracker.initialize(this->make_state({0.5, 0, 0}, {0, 0, 1}));
-        EXPECT_EQ("inside", this->id_to_label(UniverseId{0}, init.volume));
+        EXPECT_EQ("inside", this->id_to_label(init.volume));
         EXPECT_FALSE(init.surface);
     }
     {
@@ -448,7 +448,7 @@ TEST_F(TwoVolumeTest, initialize)
         SCOPED_TRACE("Outside the sphere");
         auto init
             = tracker.initialize(this->make_state({3.0, 0, 0}, {0, 0, 1}));
-        EXPECT_EQ("outside", this->id_to_label(UniverseId{0}, init.volume));
+        EXPECT_EQ("outside", this->id_to_label(init.volume));
         EXPECT_FALSE(init.surface);
     }
 }
@@ -461,18 +461,16 @@ TEST_F(TwoVolumeTest, cross_boundary)
         SCOPED_TRACE("Crossing the boundary from the inside");
         auto init = tracker.cross_boundary(this->make_state_crossing(
             {1.5, 0, 0}, {0, 0, 1}, "inside", "sphere", '-'));
-        EXPECT_EQ("outside", this->id_to_label(UniverseId{0}, init.volume));
-        EXPECT_EQ("sphere",
-                  this->id_to_label(UniverseId{0}, init.surface.id()));
+        EXPECT_EQ("outside", this->id_to_label(init.volume));
+        EXPECT_EQ("sphere", this->id_to_label(init.surface.id()));
         EXPECT_EQ(Sense::outside, init.surface.sense());
     }
     {
         SCOPED_TRACE("Crossing the boundary from the outside");
         auto init = tracker.cross_boundary(this->make_state_crossing(
             {1.5, 0, 0}, {0, 0, 1}, "outside", "sphere", '+'));
-        EXPECT_EQ("inside", this->id_to_label(UniverseId{0}, init.volume));
-        EXPECT_EQ("sphere",
-                  this->id_to_label(UniverseId{0}, init.surface.id()));
+        EXPECT_EQ("inside", this->id_to_label(init.volume));
+        EXPECT_EQ("sphere", this->id_to_label(init.surface.id()));
         EXPECT_EQ(Sense::inside, init.surface.sense());
     }
 }
@@ -663,18 +661,18 @@ TEST_F(FieldLayersTest, initialize)
         SCOPED_TRACE("Exterior");
         auto init
             = tracker.initialize(this->make_state({0, 50, 0}, {0, -1, 0}));
-        EXPECT_EQ("[EXTERIOR]", this->id_to_label(UniverseId{0}, init.volume));
+        EXPECT_EQ("[EXTERIOR]", this->id_to_label(init.volume));
         EXPECT_FALSE(init.surface);
     }
     {
         auto init = tracker.initialize(this->make_state({0, -3, 0}, {0, 0, 1}));
-        EXPECT_EQ("world", this->id_to_label(UniverseId{0}, init.volume));
+        EXPECT_EQ("world", this->id_to_label(init.volume));
         EXPECT_FALSE(init.surface);
     }
     {
         auto init
             = tracker.initialize(this->make_state({0, -2.4, 0}, {0, 0, 1}));
-        EXPECT_EQ("layer1", this->id_to_label(UniverseId{0}, init.volume));
+        EXPECT_EQ("layer1", this->id_to_label(init.volume));
         EXPECT_FALSE(init.surface);
     }
 }
@@ -692,18 +690,16 @@ TEST_F(FieldLayersTest, cross_boundary)
             // From background to volume
             auto init = tracker.cross_boundary(this->make_state_crossing(
                 {0, -1.5 + eps, 0}, {0, -1, 0}, "world", "layerbox1.py", '+'));
-            EXPECT_EQ("layer1", this->id_to_label(UniverseId{0}, init.volume));
-            EXPECT_EQ("layerbox1.py",
-                      this->id_to_label(UniverseId{0}, init.surface.id()));
+            EXPECT_EQ("layer1", this->id_to_label(init.volume));
+            EXPECT_EQ("layerbox1.py", this->id_to_label(init.surface.id()));
             EXPECT_EQ(Sense::inside, init.surface.unchecked_sense());
         }
         {
             // From volume to background
             auto init = tracker.cross_boundary(this->make_state_crossing(
                 {0, -2.5 - eps, 0}, {0, -1, 0}, "layer1", "layerbox1.my", '+'));
-            EXPECT_EQ("world", this->id_to_label(UniverseId{0}, init.volume));
-            EXPECT_EQ("layerbox1.my",
-                      this->id_to_label(UniverseId{0}, init.surface.id()));
+            EXPECT_EQ("world", this->id_to_label(init.volume));
+            EXPECT_EQ("layerbox1.my", this->id_to_label(init.surface.id()));
             EXPECT_EQ(Sense::inside, init.surface.unchecked_sense());
         }
     }
@@ -718,8 +714,7 @@ TEST_F(FieldLayersTest, intersect)
         auto state = this->make_state({0, -1, 0}, {0, 1, 0}, "world");
         auto isect = tracker.intersect(state);
         EXPECT_TRUE(isect);
-        EXPECT_EQ("layerbox2.my",
-                  this->id_to_label(UniverseId{0}, isect.surface.id()));
+        EXPECT_EQ("layerbox2.my", this->id_to_label(isect.surface.id()));
         EXPECT_EQ(Sense::inside, isect.surface.unchecked_sense());
         EXPECT_SOFT_EQ(0.5, isect.distance);
     }
@@ -728,8 +723,7 @@ TEST_F(FieldLayersTest, intersect)
         auto state = this->make_state({9.6, 4, 9.7}, {-1, -1, -1}, "world");
         auto isect = tracker.intersect(state);
         EXPECT_TRUE(isect);
-        EXPECT_EQ("layerbox3.py",
-                  this->id_to_label(UniverseId{0}, isect.surface.id()));
+        EXPECT_EQ("layerbox3.py", this->id_to_label(isect.surface.id()));
         EXPECT_EQ(Sense::outside, isect.surface.unchecked_sense());
         EXPECT_SOFT_EQ(1.5 * sqrt_three, isect.distance);
     }
@@ -779,28 +773,28 @@ TEST_F(FiveVolumesTest, initialize)
         SCOPED_TRACE("Exterior");
         auto init = tracker.initialize(
             this->make_state({1000, 1000, -1000}, {1, 0, 0}));
-        EXPECT_EQ("[EXTERIOR]", this->id_to_label(UniverseId{0}, init.volume));
+        EXPECT_EQ("[EXTERIOR]", this->id_to_label(init.volume));
         EXPECT_FALSE(init.surface);
     }
     {
         SCOPED_TRACE("Single sphere 'e'");
         auto init
             = tracker.initialize(this->make_state({-.25, -.25, 0}, {0, 0, 1}));
-        EXPECT_EQ("e", this->id_to_label(UniverseId{0}, init.volume));
+        EXPECT_EQ("e", this->id_to_label(init.volume));
         EXPECT_FALSE(init.surface);
     }
     {
         SCOPED_TRACE("Trimmed square 'a'");
         auto init
             = tracker.initialize(this->make_state({-.7, .7, 0}, {0, 0, 1}));
-        EXPECT_EQ("a", this->id_to_label(UniverseId{0}, init.volume));
+        EXPECT_EQ("a", this->id_to_label(init.volume));
         EXPECT_FALSE(init.surface);
     }
     {
         SCOPED_TRACE("Complicated fill volume 'd'");
         auto init
             = tracker.initialize(this->make_state({.75, 0.2, 0}, {0, 0, 1}));
-        EXPECT_EQ("d", this->id_to_label(UniverseId{0}, init.volume));
+        EXPECT_EQ("d", this->id_to_label(init.volume));
         EXPECT_FALSE(init.surface);
     }
     {
@@ -820,9 +814,8 @@ TEST_F(FiveVolumesTest, cross_boundary)
         SCOPED_TRACE("Crossing the boundary from the inside of 'e'");
         auto init = tracker.cross_boundary(this->make_state_crossing(
             {-0.5, -0.25, 0}, {-1, 0, 0}, "e", "epsilon.s", '-'));
-        EXPECT_EQ("c", this->id_to_label(UniverseId{0}, init.volume));
-        EXPECT_EQ("epsilon.s",
-                  this->id_to_label(UniverseId{0}, init.surface.id()));
+        EXPECT_EQ("c", this->id_to_label(init.volume));
+        EXPECT_EQ("epsilon.s", this->id_to_label(init.surface.id()));
         EXPECT_EQ(Sense::outside, init.surface.sense());
     }
     {
@@ -832,9 +825,8 @@ TEST_F(FiveVolumesTest, cross_boundary)
         real_type eps = 1e-10;
         auto init = tracker.cross_boundary(this->make_state_crossing(
             {eps, -0.25, 0}, {1, 0, 0}, "e", "epsilon.s", '-'));
-        EXPECT_EQ("c", this->id_to_label(UniverseId{0}, init.volume));
-        EXPECT_EQ("epsilon.s",
-                  this->id_to_label(UniverseId{0}, init.surface.id()));
+        EXPECT_EQ("c", this->id_to_label(init.volume));
+        EXPECT_EQ("epsilon.s", this->id_to_label(init.surface.id()));
         EXPECT_EQ(Sense::outside, init.surface.sense());
     }
     {
@@ -845,9 +837,8 @@ TEST_F(FiveVolumesTest, cross_boundary)
                                       "c",
                                       "gamma.s",
                                       '-'));
-        EXPECT_EQ("a", this->id_to_label(UniverseId{0}, init.volume));
-        EXPECT_EQ("gamma.s",
-                  this->id_to_label(UniverseId{0}, init.surface.id()));
+        EXPECT_EQ("a", this->id_to_label(init.volume));
+        EXPECT_EQ("gamma.s", this->id_to_label(init.surface.id()));
         EXPECT_EQ(Sense::outside, init.surface.sense());
     }
     {
@@ -858,9 +849,8 @@ TEST_F(FiveVolumesTest, cross_boundary)
                                       "a",
                                       "gamma.s",
                                       '+'));
-        EXPECT_EQ("c", this->id_to_label(UniverseId{0}, init.volume));
-        EXPECT_EQ("gamma.s",
-                  this->id_to_label(UniverseId{0}, init.surface.id()));
+        EXPECT_EQ("c", this->id_to_label(init.volume));
+        EXPECT_EQ("gamma.s", this->id_to_label(init.surface.id()));
         EXPECT_EQ(Sense::inside, init.surface.sense());
     }
     {
@@ -870,24 +860,21 @@ TEST_F(FiveVolumesTest, cross_boundary)
         SCOPED_TRACE("Crossing at triple point");
         auto init = tracker.cross_boundary(this->make_state_crossing(
             {0, 0.75, 0}, {0, 1, 0}, "c", "gamma.s", '-'));
-        EXPECT_EQ("d", this->id_to_label(UniverseId{0}, init.volume));
-        EXPECT_EQ("gamma.s",
-                  this->id_to_label(UniverseId{0}, init.surface.id()));
+        EXPECT_EQ("d", this->id_to_label(init.volume));
+        EXPECT_EQ("gamma.s", this->id_to_label(init.surface.id()));
         EXPECT_EQ(Sense::outside, init.surface.sense());
 
         init = tracker.cross_boundary(this->make_state_crossing(
             {0, 0.75, 0}, {-1, 0, 0}, "d", "gamma.s", '+'));
-        EXPECT_EQ("c", this->id_to_label(UniverseId{0}, init.volume));
-        EXPECT_EQ("gamma.s",
-                  this->id_to_label(UniverseId{0}, init.surface.id()));
+        EXPECT_EQ("c", this->id_to_label(init.volume));
+        EXPECT_EQ("gamma.s", this->id_to_label(init.surface.id()));
         EXPECT_EQ(Sense::inside, init.surface.sense());
 
         // Near triple point, on sphere but crossing plane edge
         init = tracker.cross_boundary(this->make_state_crossing(
             {0, 0.75, 0}, {-1, 0, 0}, "d", "alpha.px", '+'));
-        EXPECT_EQ("a", this->id_to_label(UniverseId{0}, init.volume));
-        EXPECT_EQ("alpha.px",
-                  this->id_to_label(UniverseId{0}, init.surface.id()));
+        EXPECT_EQ("a", this->id_to_label(init.volume));
+        EXPECT_EQ("alpha.px", this->id_to_label(init.surface.id()));
         EXPECT_EQ(Sense::inside, init.surface.sense());
     }
 }
@@ -901,8 +888,7 @@ TEST_F(FiveVolumesTest, intersect)
         auto state = this->make_state({-0.75, 0.5, 0}, {1, 0, 0}, "a");
         auto isect = tracker.intersect(state);
         EXPECT_TRUE(isect);
-        EXPECT_EQ("gamma.s",
-                  this->id_to_label(UniverseId{0}, isect.surface.id()));
+        EXPECT_EQ("gamma.s", this->id_to_label(isect.surface.id()));
         EXPECT_EQ(Sense::outside, isect.surface.unchecked_sense());
         EXPECT_SOFT_EQ(0.19098300562505255, isect.distance);
     }
@@ -911,15 +897,13 @@ TEST_F(FiveVolumesTest, intersect)
         auto state = this->make_state({-2, 0.5, 0}, {1, 1, 0}, "d");
         auto isect = tracker.intersect(state);
         EXPECT_TRUE(isect);
-        EXPECT_EQ("outer.s",
-                  this->id_to_label(UniverseId{0}, isect.surface.id()));
+        EXPECT_EQ("outer.s", this->id_to_label(isect.surface.id()));
         EXPECT_EQ(Sense::inside, isect.surface.unchecked_sense());
         EXPECT_SOFT_EQ(101.04503395088592, isect.distance);
 
         isect = tracker.intersect(state, 105.0);
         EXPECT_TRUE(isect);
-        EXPECT_EQ("outer.s",
-                  this->id_to_label(UniverseId{0}, isect.surface.id()));
+        EXPECT_EQ("outer.s", this->id_to_label(isect.surface.id()));
         EXPECT_EQ(Sense::inside, isect.surface.unchecked_sense());
         EXPECT_SOFT_EQ(101.04503395088592, isect.distance);
 

--- a/test/orange/univ/VolumeView.test.cc
+++ b/test/orange/univ/VolumeView.test.cc
@@ -24,7 +24,7 @@ namespace test
 class VolumeViewTest : public OrangeGeoTestBase
 {
   protected:
-    VolumeView make_view(VolumeId v) const
+    VolumeView make_view(LocalVolumeId v) const
     {
         CELER_EXPECT(v);
         auto const& host_ref = this->params().host_ref();
@@ -55,7 +55,7 @@ TEST_F(VolumeViewTest, one_volume)
     this->build_geometry(OneVolInput{});
     ASSERT_EQ(1, this->params().num_volumes());
 
-    VolumeView vol = this->make_view(VolumeId{0});
+    VolumeView vol = this->make_view(LocalVolumeId{0});
     EXPECT_EQ(0, vol.num_faces());
     this->test_face_accessors(vol);
 
@@ -81,7 +81,7 @@ TEST_F(VolumeViewTest, five_volumes)
     std::vector<size_type> num_faces;
     std::vector<logic_int> flags;
 
-    for (auto vol_id : range(VolumeId{this->params().num_volumes()}))
+    for (auto vol_id : range(LocalVolumeId{this->params().num_volumes()}))
     {
         VolumeView vol = this->make_view(vol_id);
         num_faces.push_back(vol.num_faces());
@@ -92,14 +92,14 @@ TEST_F(VolumeViewTest, five_volumes)
     EXPECT_VEC_EQ(expected_num_faces, num_faces);
 
     {
-        VolumeView vol = this->make_view(VolumeId{0});
+        VolumeView vol = this->make_view(LocalVolumeId{0});
         EXPECT_FALSE(vol.internal_surfaces());
         EXPECT_FALSE(vol.implicit_vol());
         EXPECT_TRUE(vol.simple_safety());
         EXPECT_TRUE(vol.simple_intersection());
     }
     {
-        VolumeView vol = this->make_view(VolumeId{4});
+        VolumeView vol = this->make_view(LocalVolumeId{4});
         EXPECT_TRUE(vol.internal_surfaces());
         EXPECT_FALSE(vol.implicit_vol());
         EXPECT_TRUE(vol.simple_safety());

--- a/test/orange/univ/VolumeView.test.cc
+++ b/test/orange/univ/VolumeView.test.cc
@@ -38,7 +38,7 @@ class VolumeViewTest : public OrangeGeoTestBase
 
         for (auto face_id : range(FaceId{volumes.num_faces()}))
         {
-            SurfaceId surf_id = faces[face_id.get()];
+            LocalSurfaceId surf_id = faces[face_id.get()];
             EXPECT_EQ(surf_id, volumes.get_surface(face_id));
             EXPECT_EQ(face_id, volumes.find_face(surf_id));
         }
@@ -60,12 +60,12 @@ TEST_F(VolumeViewTest, one_volume)
     this->test_face_accessors(vol);
 
     // Test that nonexistent face returns "false" id
-    EXPECT_EQ(FaceId{}, vol.find_face(SurfaceId{123}));
+    EXPECT_EQ(FaceId{}, vol.find_face(LocalSurfaceId{123}));
     if (CELERITAS_DEBUG)
     {
         // Disallow empty surfaces (burden is on the caller to check for null)
         EXPECT_THROW(vol.get_surface(FaceId{}), DebugError);
-        EXPECT_THROW(vol.find_face(SurfaceId{}), DebugError);
+        EXPECT_THROW(vol.find_face(LocalSurfaceId{}), DebugError);
     }
 }
 

--- a/test/orange/univ/detail/SenseCalculator.test.cc
+++ b/test/orange/univ/detail/SenseCalculator.test.cc
@@ -50,7 +50,7 @@ TEST(Types, OnFace)
 class SenseCalculatorTest : public ::celeritas::test::OrangeGeoTestBase
 {
   protected:
-    VolumeView make_volume_view(VolumeId v) const
+    VolumeView make_volume_view(LocalVolumeId v) const
     {
         CELER_EXPECT(v);
         auto const& host_ref = this->params().host_ref();
@@ -86,7 +86,7 @@ TEST_F(SenseCalculatorTest, one_volume)
     SenseCalculator calc_senses(
         this->make_surfaces(), Real3{123, 345, 567}, this->sense_storage());
 
-    auto result = calc_senses(this->make_volume_view(VolumeId{0}));
+    auto result = calc_senses(this->make_volume_view(LocalVolumeId{0}));
     EXPECT_EQ(0, result.senses.size());
     EXPECT_FALSE(result.face);
 }
@@ -101,8 +101,8 @@ TEST_F(SenseCalculatorTest, two_volumes)
 
     // Note that since these have the same faces, the results should be the
     // same for both.
-    VolumeView outer = this->make_volume_view(VolumeId{0});
-    VolumeView inner = this->make_volume_view(VolumeId{1});
+    VolumeView outer = this->make_volume_view(LocalVolumeId{0});
+    VolumeView inner = this->make_volume_view(LocalVolumeId{1});
 
     {
         // Point is in the inner sphere
@@ -166,9 +166,9 @@ TEST_F(SenseCalculatorTest, five_volumes)
     // this->describe(std::cout);
 
     // Volume definitions
-    VolumeView vol_b = this->make_volume_view(VolumeId{2});
-    VolumeView vol_c = this->make_volume_view(VolumeId{3});
-    VolumeView vol_e = this->make_volume_view(VolumeId{5});
+    VolumeView vol_b = this->make_volume_view(LocalVolumeId{2});
+    VolumeView vol_c = this->make_volume_view(LocalVolumeId{3});
+    VolumeView vol_e = this->make_volume_view(LocalVolumeId{5});
 
     {
         // Point is in the inner sphere

--- a/test/orange/univ/detail/SurfaceFunctors.test.cc
+++ b/test/orange/univ/detail/SurfaceFunctors.test.cc
@@ -44,7 +44,7 @@ class SurfaceFunctorsTest : public ::celeritas::test::OrangeGeoTestBase
             // Create a volume
             VolumeInput v;
             v.logic = {0, 1, logic::lor, logic::ltrue, logic::lor};
-            v.faces = {SurfaceId{0}, SurfaceId{1}};
+            v.faces = {LocalSurfaceId{0}, LocalSurfaceId{1}};
             unit.volumes = {std::move(v)};
         }
 
@@ -66,7 +66,7 @@ class SurfaceFunctorsTest : public ::celeritas::test::OrangeGeoTestBase
     {
         CELER_EXPECT(surfaces_);
         CELER_EXPECT(sid < surfaces_->num_surfaces());
-        return surfaces_->make_surface<T>(SurfaceId{sid});
+        return surfaces_->make_surface<T>(LocalSurfaceId{sid});
     }
 
     std::unique_ptr<Surfaces> surfaces_;
@@ -91,8 +91,8 @@ TEST_F(SurfaceFunctorsTest, calc_sense)
     // Test as generic surfaces
     pos = {2, 0, 0};
     auto calc_generic = make_surface_action(*surfaces_, CalcSense{pos});
-    EXPECT_EQ(SignedSense::outside, calc_generic(SurfaceId{0}));
-    EXPECT_EQ(SignedSense::inside, calc_generic(SurfaceId{1}));
+    EXPECT_EQ(SignedSense::outside, calc_generic(LocalSurfaceId{0}));
+    EXPECT_EQ(SignedSense::inside, calc_generic(LocalSurfaceId{1}));
 }
 
 //---------------------------------------------------------------------------//
@@ -112,9 +112,9 @@ TEST_F(SurfaceFunctorsTest, calc_normal)
     auto calc_normal = make_surface_action(*surfaces_, CalcNormal{pos});
 
     pos = {1.25, 1, 1};
-    EXPECT_EQ(Real3({1, 0, 0}), calc_normal(SurfaceId{0}));
+    EXPECT_EQ(Real3({1, 0, 0}), calc_normal(LocalSurfaceId{0}));
     pos = {2.25, 2.25, 0};
-    EXPECT_EQ(Real3({0, 1, 0}), calc_normal(SurfaceId{1}));
+    EXPECT_EQ(Real3({0, 1, 0}), calc_normal(LocalSurfaceId{1}));
 }
 
 //---------------------------------------------------------------------------//
@@ -128,28 +128,28 @@ TEST_F(SurfaceFunctorsTest, calc_safety_distance)
 
     real_type eps = 1e-4;
     pos = {1.25 + eps, 1, 0};
-    EXPECT_SOFT_EQ(eps, calc_distance(SurfaceId{0}));
-    EXPECT_SOFT_EQ(0.25 + eps, calc_distance(SurfaceId{1}));
+    EXPECT_SOFT_EQ(eps, calc_distance(LocalSurfaceId{0}));
+    EXPECT_SOFT_EQ(0.25 + eps, calc_distance(LocalSurfaceId{1}));
 
     pos = {1.25, 1, 0};
-    EXPECT_SOFT_EQ(0, calc_distance(SurfaceId{0}));
-    EXPECT_SOFT_EQ(0.25, calc_distance(SurfaceId{1}));
+    EXPECT_SOFT_EQ(0, calc_distance(LocalSurfaceId{0}));
+    EXPECT_SOFT_EQ(0.25, calc_distance(LocalSurfaceId{1}));
 
     pos = {1.25 - eps, 1, 0};
-    EXPECT_SOFT_EQ(eps, calc_distance(SurfaceId{0}));
-    EXPECT_SOFT_EQ(0.25 - eps, calc_distance(SurfaceId{1}));
+    EXPECT_SOFT_EQ(eps, calc_distance(LocalSurfaceId{0}));
+    EXPECT_SOFT_EQ(0.25 - eps, calc_distance(LocalSurfaceId{1}));
 
     pos = {1.0 - eps, 1, 0};
-    EXPECT_SOFT_EQ(0.25 + eps, calc_distance(SurfaceId{0}));
-    EXPECT_SOFT_EQ(eps, calc_distance(SurfaceId{1}));
+    EXPECT_SOFT_EQ(0.25 + eps, calc_distance(LocalSurfaceId{0}));
+    EXPECT_SOFT_EQ(eps, calc_distance(LocalSurfaceId{1}));
 
     pos = {3.5 + eps, 1, 0};
-    EXPECT_SOFT_EQ(2.25 + eps, calc_distance(SurfaceId{0}));
-    EXPECT_SOFT_NEAR(0.0 + eps, calc_distance(SurfaceId{1}), 1e-11);
+    EXPECT_SOFT_EQ(2.25 + eps, calc_distance(LocalSurfaceId{0}));
+    EXPECT_SOFT_NEAR(0.0 + eps, calc_distance(LocalSurfaceId{1}), 1e-11);
 
     pos = {3.5, 1, 0};
-    EXPECT_SOFT_EQ(2.25, calc_distance(SurfaceId{0}));
-    EXPECT_SOFT_EQ(0.0, calc_distance(SurfaceId{1}));
+    EXPECT_SOFT_EQ(2.25, calc_distance(LocalSurfaceId{0}));
+    EXPECT_SOFT_EQ(0.0, calc_distance(LocalSurfaceId{1}));
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
In this PR, ORANGE is modified such that separate local and global types are used for volume and surface ids. To facilitate this, an `ItemMap<T1, T2>` class is added in order to access globally-typed `Collections` with locally-typed indices. 