### PR TITLE
Fix hit mapping when using GDML geometry with pointers

### DIFF
--- a/src/accel/detail/HitManager.cc
+++ b/src/accel/detail/HitManager.cc
@@ -80,8 +80,14 @@ HitManager::HitManager(GeoParams const& geo, SDSetupOptions const& setup)
         }
 
         // Convert volume name to GPU geometry ID
-        auto label
-            = Label::from_geant(temp_writer.GenerateName(lv->GetName(), lv));
+        auto label = Label::from_geant(lv->GetName());
+        if (label.ext.empty())
+        {
+            // Label doesn't have a pointer address attached: we probably need
+            // to regenerate to match the exported GDML file
+            label = Label::from_geant(temp_writer.GenerateName(label.name, lv));
+        }
+
         auto id = geo.find_volume(label);
         if (!id)
         {

--- a/src/celeritas/phys/ImportedModelAdapter.cc
+++ b/src/celeritas/phys/ImportedModelAdapter.cc
@@ -84,7 +84,9 @@ auto ImportedModelAdapter::micro_xs(Applicability applic) const
 
     // Get the micro xs grids for the given model, particle, and material
     auto xs = import_process.micro_xs.find(model_class_);
-    CELER_ASSERT(xs != import_process.micro_xs.end());
+    CELER_VALIDATE(xs != import_process.micro_xs.end(),
+                   << "missing microscopic cross sections for "
+                   << to_cstring(model_class_));
     CELER_ASSERT(applic.material < xs->second.size());
     auto const& elem_phys_vectors = xs->second[applic.material.get()];
 


### PR DESCRIPTION
When we elect *not* to strip pointers from a GDML file, and we want touchable locations in the SD callbacks, the HitMapper construction fails because the pointers are effectively added twice (so the first pointer is parsed as being part of the "name" of the label whereas the second pointer becomes the extension).

Also adds an always-on assertion for checking imported models to avoid a segfault if the model failed to import.