### PR TITLE
Sorting and indexing tracks by `TrackSlotId`

### DIFF
--- a/src/celeritas/global/CoreTrackData.hh
+++ b/src/celeritas/global/CoreTrackData.hh
@@ -90,6 +90,8 @@ struct CoreStateData
     template<class T>
     using Items = StateCollection<T, W, M>;
 
+    using TrackSlotsLookup = Collection<TrackSlotId, W, M, ThreadId>;
+
     GeoStateData<W, M> geometry;
     MaterialStateData<W, M> materials;
     ParticleStateData<W, M> particles;
@@ -97,6 +99,8 @@ struct CoreStateData
     RngStateData<W, M> rng;
     SimStateData<W, M> sim;
     TrackInitStateData<W, M> init;
+    TrackSlotsLookup track_slots;
+
 
     //! Number of state elements
     CELER_FUNCTION size_type size() const { return particles.size(); }
@@ -120,6 +124,7 @@ struct CoreStateData
         rng = other.rng;
         sim = other.sim;
         init = other.init;
+        track_slots = other.track_slots;
         return *this;
     }
 };
@@ -169,6 +174,7 @@ inline void resize(CoreStateData<Ownership::value, M>* state,
     resize(&state->rng, params.rng, size);
     resize(&state->sim, size);
     resize(&state->init, params.init, size);
+    resize(&state->track_slots, size);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "corecel/sys/ThreadId.hh"
+#include "corecel/data/Collection.hh"
 #include "celeritas/geo/GeoMaterialView.hh"
 #include "celeritas/geo/GeoTrackView.hh"
 #include "celeritas/mat/MaterialTrackView.hh"
@@ -99,6 +100,8 @@ CoreTrackView::CoreTrackView(ParamsRef const& params,
     : states_(states), params_(params), thread_(thread)
 {
     CELER_EXPECT(thread_ < states_.size());
+    //TODO: Smarter mapping of thread to track index
+    states_.track_slots[thread_] = TrackSlotId{thread_.get()};
 }
 
 //---------------------------------------------------------------------------//
@@ -203,7 +206,7 @@ CELER_FUNCTION auto CoreTrackView::make_rng_engine() const -> RngEngine
  */
 CELER_FUNCTION TrackSlotId CoreTrackView::track_slot_id() const
 {
-    return TrackSlotId{thread_.unchecked_get()};
+    return states_.track_slots[thread_];
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
As mentioned in #675, this is an initial implementation of indexing tracks by `TrackSlotId` instead of `ThreadId`. Sorting should help adjacent threads working on similar tracks (alive, same particle type, energy,...). 

I added a `Collection` in `CoreStateData` which does the thread --> track slot lookup. No sorting is done yet, only a 1-1 correspondence. 

