### PR TITLE
Fix imported micro xs when lower energy grid bound is higher than upper bound

### DIFF
--- a/src/celeritas/ext/detail/GeantModelImporter.cc
+++ b/src/celeritas/ext/detail/GeantModelImporter.cc
@@ -146,10 +146,12 @@ ImportModel GeantModelImporter::operator()(G4VEmModel const& model) const
               / CLHEP::MeV;
         double max_energy = model.HighEnergyLimit() / CLHEP::MeV;
         CELER_ASSERT(0 <= min_energy);
-        CELER_ASSERT(min_energy < max_energy);
 
+        // It's possible for the lower energy bound to be higher than the upper
+        // energy bound if the production cut values are very high. Don't build
+        // the xs grid if this is the case.
         auto& model_mat = result.materials[mat_idx];
-        if (needs_micro_xs(result.model_class))
+        if (needs_micro_xs(result.model_class) && min_energy < max_energy)
         {
             // Calculate microscopic cross section grid with a reduced number
             // of bins compared to to regular cross sections

--- a/src/celeritas/ext/detail/GeantModelImporter.cc
+++ b/src/celeritas/ext/detail/GeantModelImporter.cc
@@ -147,11 +147,22 @@ ImportModel GeantModelImporter::operator()(G4VEmModel const& model) const
         double max_energy = model.HighEnergyLimit() / CLHEP::MeV;
         CELER_ASSERT(0 <= min_energy);
 
-        // It's possible for the lower energy bound to be higher than the upper
-        // energy bound if the production cut values are very high. Don't build
-        // the xs grid if this is the case.
         auto& model_mat = result.materials[mat_idx];
-        if (needs_micro_xs(result.model_class) && min_energy < max_energy)
+        bool export_micros = needs_micro_xs(result.model_class);
+        if (CELER_UNLIKELY(!(min_energy < max_energy)))
+        {
+            // It's possible for the lower energy bound to be higher than the
+            // upper energy bound if the production cuts are very high.  Don't
+            // build the microscopic cross section grid if this is the case.
+            CELER_LOG(debug)
+                << "Skipping microscopic cross section grid for model '"
+                << model.GetName() << "' in material '" << g4mat.GetName()
+                << ": lower energy bound " << min_energy
+                << " [MeV] is not less than upper energy bound " << max_energy
+                << " [MeV]";
+            export_micros = false;
+        }
+        if (export_micros)
         {
             // Calculate microscopic cross section grid with a reduced number
             // of bins compared to to regular cross sections

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -289,6 +289,7 @@ celeritas_add_test(celeritas/ext/GeantImporter.test.cc
   FILTER
     "FourSteelSlabs*"
     "TestEm3*"
+    "OneSteelSphere*"
   )
 celeritas_add_test(celeritas/ext/RootImporter.test.cc ${_needs_root})
 
@@ -358,6 +359,7 @@ celeritas_add_test(celeritas/global/Stepper.test.cc
     "TestEm3Msc.*"
     "TestEm3MscNofluct.*"
     "TestEm15MscField.*"
+    "OneSteelSphere.*"
 )
 
 #-------------------------------------#

--- a/test/celeritas/OneSteelSphereBase.hh
+++ b/test/celeritas/OneSteelSphereBase.hh
@@ -1,0 +1,31 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/OneSteelSphereBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "GeantTestBase.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Test harness for steel sphere with 50 meter production cuts.
+ */
+class OneSteelSphereBase : public GeantTestBase
+{
+  protected:
+    char const* geometry_basename() const override
+    {
+        return "one-steel-sphere";
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/data/one-steel-sphere.gdml
+++ b/test/celeritas/data/one-steel-sphere.gdml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+  <define/>
+
+  <materials>
+    <isotope N="1" Z="1" name="H1">
+      <atom unit="g/mole" value="1.00782503081372"/>
+    </isotope>
+    <isotope N="2" Z="1" name="H2">
+      <atom unit="g/mole" value="2.01410199966617"/>
+    </isotope>
+    <element name="H">
+      <fraction n="0.999885" ref="H1"/>
+      <fraction n="0.000115" ref="H2"/>
+    </element>
+    <material name="vacuum" state="gas">
+      <T unit="K" value="2.73"/>
+      <P unit="pascal" value="3e-18"/>
+      <MEE unit="eV" value="21.8"/>
+      <D unit="g/cm3" value="1e-25"/>
+      <fraction n="1" ref="H"/>
+    </material>
+    <isotope N="54" Z="26" name="Fe54">
+      <atom unit="g/mole" value="53.9396"/>
+    </isotope>
+    <isotope N="56" Z="26" name="Fe56">
+      <atom unit="g/mole" value="55.9349"/>
+    </isotope>
+    <isotope N="57" Z="26" name="Fe57">
+      <atom unit="g/mole" value="56.9354"/>
+    </isotope>
+    <isotope N="58" Z="26" name="Fe58">
+      <atom unit="g/mole" value="57.9333"/>
+    </isotope>
+    <element name="Fe">
+      <fraction n="0.05845" ref="Fe54"/>
+      <fraction n="0.91754" ref="Fe56"/>
+      <fraction n="0.02119" ref="Fe57"/>
+      <fraction n="0.00282" ref="Fe58"/>
+    </element>
+    <isotope N="50" Z="24" name="Cr50">
+      <atom unit="g/mole" value="49.946"/>
+    </isotope>
+    <isotope N="52" Z="24" name="Cr52">
+      <atom unit="g/mole" value="51.9405"/>
+    </isotope>
+    <isotope N="53" Z="24" name="Cr53">
+      <atom unit="g/mole" value="52.9407"/>
+    </isotope>
+    <isotope N="54" Z="24" name="Cr54">
+      <atom unit="g/mole" value="53.9389"/>
+    </isotope>
+    <element name="Cr">
+      <fraction n="0.04345" ref="Cr50"/>
+      <fraction n="0.83789" ref="Cr52"/>
+      <fraction n="0.09501" ref="Cr53"/>
+      <fraction n="0.02365" ref="Cr54"/>
+    </element>
+    <isotope N="58" Z="28" name="Ni58">
+      <atom unit="g/mole" value="57.9353"/>
+    </isotope>
+    <isotope N="60" Z="28" name="Ni60">
+      <atom unit="g/mole" value="59.9308"/>
+    </isotope>
+    <isotope N="61" Z="28" name="Ni61">
+      <atom unit="g/mole" value="60.9311"/>
+    </isotope>
+    <isotope N="62" Z="28" name="Ni62">
+      <atom unit="g/mole" value="61.9283"/>
+    </isotope>
+    <isotope N="64" Z="28" name="Ni64">
+      <atom unit="g/mole" value="63.928"/>
+    </isotope>
+    <element name="Ni">
+      <fraction n="0.680769" ref="Ni58"/>
+      <fraction n="0.262231" ref="Ni60"/>
+      <fraction n="0.011399" ref="Ni61"/>
+      <fraction n="0.036345" ref="Ni62"/>
+      <fraction n="0.009256" ref="Ni64"/>
+    </element>
+    <material name="stainless_steel" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="282.97693634122"/>
+      <D unit="g/cm3" value="8"/>
+      <fraction n="0.746212874621521" ref="Fe"/>
+      <fraction n="0.169001044311525" ref="Cr"/>
+      <fraction n="0.0847860810669534" ref="Ni"/>
+    </material>
+  </materials>
+
+  <solids>
+    <sphere lunit="cm" name="sphere" rmax="100.0" deltaphi="360" deltatheta="180" aunit="deg"/>
+    <sphere lunit="cm" name="world_sphere" rmin="0.0" rmax="1000.0" deltaphi="360" deltatheta="180" aunit="deg"/>
+  </solids>
+
+  <structure>
+    <volume name="sphere">
+      <solidref ref="sphere"/>
+      <materialref ref="stainless_steel"/>
+    </volume>
+    <volume name="world">
+      <solidref ref="world_sphere"/>
+      <materialref ref="vacuum"/>
+      <physvol>
+        <volumeref ref="sphere"/>
+      </physvol>
+    </volume>
+  </structure>
+
+  <userinfo>
+    <auxiliary auxtype="Region" auxvalue="sphere">
+      <auxiliary auxtype="volume" auxvalue="sphere"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="50000"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="50000"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="50000"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="50000"/>
+    </auxiliary>
+  </userinfo>
+
+  <setup name="Default" version="1.0">
+    <world ref="world"/>
+  </setup>
+
+</gdml>

--- a/test/celeritas/data/one-steel-sphere.org.json
+++ b/test/celeritas/data/one-steel-sphere.org.json
@@ -1,0 +1,70 @@
+{
+"_format": "SCALE ORANGE",
+"_version": 0,
+"materials": {
+"cell_to_mat": [
+-1,
+1,
+0
+],
+"names": [
+"vacuum",
+"stainless_steel"
+]
+},
+"universes": [
+{
+"_type": "simple unit",
+"bbox": [
+[
+-1000.000000000001,
+-1000.000000000001,
+-1000.000000000001
+],
+[
+1000.000000000001,
+1000.000000000001,
+1000.000000000001
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"sphere",
+"world"
+],
+"cells": [
+{
+"faces": [ 0 ],
+"logic": "0",
+"num_intersections": 2,
+"zorder": 2
+},
+{
+"faces": [ 1 ],
+"logic": "0 ~",
+"num_intersections": 2,
+"zorder": 2
+},
+{
+"faces": [ 0, 1 ],
+"logic": "0 ~ 1 &",
+"num_intersections": 4,
+"zorder": 2
+}
+],
+"md": {
+"name": "global",
+"provenance": "one-steel-sphere.org.omn:14"
+},
+"surface_names": [
+"world_sphere.s",
+"sphere.s"
+],
+"surfaces": {
+"data": [ 1000000.0, 10000.0 ],
+"sizes": [ 1, 1 ],
+"types": [ "sc", "sc" ]
+}
+}
+]
+}

--- a/test/celeritas/data/one-steel-sphere.org.omn
+++ b/test/celeritas/data/one-steel-sphere.org.omn
@@ -1,0 +1,37 @@
+!##############################################################################
+! File  : one-steel-sphere.org.omn
+!
+! One steel sphere.
+! Regenerate the JSON file with `orange2celeritas` from SCALE
+!##############################################################################
+
+[GEOMETRY]
+global "global"
+comp       : matid
+    "vacuum" 0
+    "stainless_steel" 1
+
+[UNIVERSE=general global]
+interior "world"
+
+!##############################################################################
+! SHAPES ("solids")
+!##############################################################################
+
+[UNIVERSE][SHAPE=sphere sphere]
+radius 100
+
+[UNIVERSE][SHAPE=sphere world_sphere]
+radius 1000
+
+!##############################################################################
+! CELLS ("volumes")
+!##############################################################################
+
+[UNIVERSE][CELL sphere]
+comp "stainless_steel"
+shapes sphere
+
+[UNIVERSE][CELL world]
+comp "vacuum"
+shapes world_sphere ~sphere

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -23,6 +23,7 @@
 #include "celeritas/phys/Primary.hh"
 #include "celeritas/random/distribution/IsotropicDistribution.hh"
 
+#include "../OneSteelSphereBase.hh"
 #include "../SimpleTestBase.hh"
 #include "../TestEm15Base.hh"
 #include "../TestEm3Base.hh"
@@ -164,6 +165,42 @@ class TestEm15MscField : public TestEm15Base, public StepperTestBase
         for (auto i : range(count))
         {
             result[i].event_id = EventId{i};
+            result[i].direction = sample_dir(rng);
+            result[i].particle_id = particles[i % particles.size()];
+        }
+        return result;
+    }
+
+    size_type max_average_steps() const override { return 500; }
+};
+
+//---------------------------------------------------------------------------//
+#define OneSteelSphere TEST_IF_CELERITAS_GEANT(OneSteelSphere)
+class OneSteelSphere : public OneSteelSphereBase, public StepperTestBase
+{
+    //! Make isotropic 10MeV electron/positron/gamma mix
+    std::vector<Primary> make_primaries(size_type count) const override
+    {
+        Primary p;
+        p.energy = MevEnergy{10};
+        p.position = {0, 0, 0};
+        p.time = 0;
+        p.event_id = EventId{0};
+
+        Array<ParticleId, 3> const particles = {
+            this->particle()->find(pdg::gamma()),
+            this->particle()->find(pdg::electron()),
+            this->particle()->find(pdg::positron()),
+        };
+        CELER_ASSERT(particles[0] && particles[1] && particles[2]);
+
+        std::vector<Primary> result(count, p);
+        IsotropicDistribution<> sample_dir;
+        std::mt19937 rng;
+
+        for (auto i : range(count))
+        {
+            result[i].track_id = TrackId{i};
             result[i].direction = sample_dir(rng);
             result[i].particle_id = particles[i % particles.size()];
         }
@@ -557,6 +594,71 @@ TEST_F(TestEm15MscField, TEST_IF_CELER_DEVICE(device))
         EXPECT_SOFT_EQ(34, result.calc_avg_steps_per_primary());
         EXPECT_EQ(5, result.calc_emptying_step());
         EXPECT_EQ(RunResult::StepCount({1, 10}), result.calc_queue_hwm());
+    }
+    else
+    {
+        cout << "No output saved for combination of "
+             << test::PrintableBuildConf{} << std::endl;
+        result.print_expected();
+
+        if (this->strict_testing())
+        {
+            FAIL() << "Updated stepper results are required for CI tests";
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+// ONESTEELSPHERE
+//---------------------------------------------------------------------------//
+
+TEST_F(OneSteelSphere, setup)
+{
+    auto result = this->check_setup();
+
+    static char const* const expected_processes[] = {
+        "Compton scattering",
+        "Photoelectric effect",
+        "Photon annihiliation",
+        "Positron annihiliation",
+        "Electron/positron ionization",
+        "Bremsstrahlung",
+    };
+    EXPECT_VEC_EQ(expected_processes, result.processes);
+    static char const* const expected_actions[] = {
+        "initialize-tracks",
+        "pre-step",
+        "along-step-general-linear",
+        "physics-discrete-select",
+        "scat-klein-nishina",
+        "photoel-livermore",
+        "conv-bethe-heitler",
+        "annihil-2-gamma",
+        "ioni-moller-bhabha",
+        "brems-sb",
+        "brems-rel",
+        "geo-boundary",
+        "dummy-action",
+        "extend-from-secondaries",
+    };
+    EXPECT_VEC_EQ(expected_actions, result.actions);
+}
+
+TEST_F(OneSteelSphere, host)
+{
+    size_type num_primaries = 128;
+    size_type num_tracks = 1024;
+
+    Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
+    auto result = this->run(step, num_primaries);
+    EXPECT_SOFT_NEAR(15.8671875, result.calc_avg_steps_per_primary(), 0.10);
+
+    if (this->is_ci_build())
+    {
+        EXPECT_EQ(16, result.num_step_iters());
+        EXPECT_SOFT_EQ(15.8671875, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(7, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({5, 114}), result.calc_queue_hwm());
     }
     else
     {


### PR DESCRIPTION
It’s possible for the lower energy bound of the microscopic cross section grid to be higher than the upper bound if the production cut values are very high. Simply skip building the grid if this is the case instead of requiring `min_energy < max_energy`.