### PR TITLE
Fix unique Geant4/GDML volume names

### DIFF
--- a/src/celeritas/ext/detail/GeantVolumeVisitor.cc
+++ b/src/celeritas/ext/detail/GeantVolumeVisitor.cc
@@ -7,10 +7,10 @@
 //---------------------------------------------------------------------------//
 #include "GeantVolumeVisitor.hh"
 
-#include <regex>
 #include <G4GDMLWriteStructure.hh>
 #include <G4LogicalVolume.hh>
 #include <G4MaterialCutsCouple.hh>
+#include <G4ReflectionFactory.hh>
 #include <G4VSolid.hh>
 
 #include "corecel/Assert.hh"
@@ -30,7 +30,7 @@ namespace detail
  * duplicated.
  * Function called by \c store_volumes(...) .
  */
-void GeantVolumeVisitor::visit(G4LogicalVolume const& logical_volume)
+void GeantVolumeVisitor::visit(G4LogicalVolume& logical_volume)
 {
     auto&& [iter, inserted] = volids_volumes_.emplace(
         logical_volume.GetInstanceID(), ImportVolume{});
@@ -56,22 +56,7 @@ void GeantVolumeVisitor::visit(G4LogicalVolume const& logical_volume)
     }
     else if (unique_volumes_)
     {
-        // See if the name already has a uniquifying address (e.g., we loaded
-        // it through our GdmlLoader with `SetStripFlag(false)`)
-        // static std::regex const final_ptr_regex{"0x[0-9a-f]{4,16}$"};
-        static std::regex const final_ptr_regex{"0x[0-9a-f]{4,16}$"};
-        std::smatch ptr_match;
-        if (!std::regex_search(volume.name, ptr_match, final_ptr_regex))
-        {
-            // No unique extension: run the LV through the GDML export name
-            // generator so that the volume is uniquely identifiable in
-            // VecGeom.
-            // Reuse the same instance to reduce overhead: note that the method
-            // isn't const correct.
-            static G4GDMLWriteStructure temp_writer;
-            volume.name
-                = temp_writer.GenerateName(volume.name, &logical_volume);
-        }
+        volume.name = this->generate_name(logical_volume);
     }
 
     // Recursive: repeat for every daughter volume, if there are any
@@ -81,6 +66,35 @@ void GeantVolumeVisitor::visit(G4LogicalVolume const& logical_volume)
     }
 
     CELER_ENSURE(volume);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Generate the GDML name for a Geant4 logical volume.
+ */
+std::string GeantVolumeVisitor::generate_name(G4LogicalVolume& logical_volume)
+{
+    std::string name = logical_volume.GetName();
+
+    // Run the LV through the GDML export name generator so that the volume is
+    // uniquely identifiable in VecGeom. Reuse the same instance to reduce
+    // overhead: note that the method isn't const correct.
+    static G4GDMLWriteStructure temp_writer;
+    auto const* refl_factory = G4ReflectionFactory::Instance();
+    if (auto const* lv = refl_factory->GetConstituentLV(&logical_volume))
+    {
+        // If this is a reflected volume, generate the name based on the
+        // constituent volume and re-add the reflection extension after the
+        // final pointer so the name will match the GDML name.
+        name = lv->GetName();
+        name = temp_writer.GenerateName(name, lv)
+               + refl_factory->GetVolumesNameExtension();
+    }
+    else
+    {
+        name = temp_writer.GenerateName(name, &logical_volume);
+    }
+    return name;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantVolumeVisitor.hh
+++ b/src/celeritas/ext/detail/GeantVolumeVisitor.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <vector>
 
 class G4LogicalVolume;
@@ -29,7 +30,10 @@ class GeantVolumeVisitor
     explicit inline GeantVolumeVisitor(bool unique_volumes);
 
     // Recurse into the given logical volume
-    void visit(G4LogicalVolume const& logical_volume);
+    void visit(G4LogicalVolume& logical_volume);
+
+    // Generate the GDML name for a Geant4 logical volume
+    std::string generate_name(G4LogicalVolume& logical_volume);
 
     // Transform the map of volumes into a contiguous vector with empty spaces
     std::vector<ImportVolume> build_volume_vector() const;

--- a/src/corecel/cont/Label.cc
+++ b/src/corecel/cont/Label.cc
@@ -18,7 +18,7 @@ namespace celeritas
  */
 Label Label::from_geant(std::string const& name)
 {
-    static const std::regex final_ptr_regex{"0x[0-9a-f]{4,16}$"};
+    static const std::regex final_ptr_regex{"(.*)(0x[0-9a-f]{4,16}.+)"};
 
     // Remove possible Geant uniquifying pointer-address suffix
     // (Geant4 does this automatically, but VGDML does not)
@@ -27,7 +27,7 @@ Label Label::from_geant(std::string const& name)
     if (std::regex_search(name, ptr_match, final_ptr_regex))
     {
         // Copy pointer as 'extension' and delete from name
-        split_point = name.begin() + ptr_match.position(0);
+        split_point = name.begin() + ptr_match.position(2);
     }
 
     Label result;


### PR DESCRIPTION
Volumes with a pointer suffix in the name in the original GDML did not have another pointer appended when generating the "unique" name, but *did* have a pointer appended in the exported GDML. This changes how unique names are generated so that a pointer suffix is always added.

This also fixes the generated name for reflected volumes (when a reflected volume is written to GDML the name of its constituent volume is used and the reflection extension is stripped from the name; when it is read, the extension is added again).