### PR TITLE
Update CI VecGeom to 1.2.2

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -57,7 +57,7 @@ pipeline {
         stage('full-novg') {
           agent {
             docker {
-              image 'celeritas/ci-jammy-cuda11:2022-12-06'
+              image 'celeritas/ci-jammy-cuda11:2023-03-13'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
             }
           }
@@ -73,7 +73,7 @@ pipeline {
         stage('full-novg-ndebug') {
           agent {
             docker {
-              image 'celeritas/ci-jammy-cuda11:2022-12-06'
+              image 'celeritas/ci-jammy-cuda11:2023-03-13'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
             }
           }
@@ -89,7 +89,7 @@ pipeline {
         stage('vecgeom-demos') {
           agent {
             docker {
-              image 'celeritas/ci-jammy-cuda11:2022-12-06'
+              image 'celeritas/ci-jammy-cuda11:2023-03-13'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
             }
           }
@@ -105,7 +105,7 @@ pipeline {
         stage('vecgeom-tests') {
           agent {
             docker {
-              image 'celeritas/ci-jammy-cuda11:2022-12-06'
+              image 'celeritas/ci-jammy-cuda11:2023-03-13'
               label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
             }
           }

--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -27,23 +27,6 @@
       }
     },
     {
-      "name": "acceleritas",
-      "displayName": "Everything in release mode",
-      "inherits": [".ndebug", ".base"],
-      "environment": {
-        "PATH": "$env{SPACK_ROOT}/var/spack/environments/celeritas/.spack-env/view/bin:/usr/local/cuda-11.5/bin:$penv{PATH}",
-        "CMAKE_PREFIX_PATH": "$env{SPACK_ROOT}/var/spack/environments/celeritas/.spack-env/view"
-      },
-      "cacheVariables": {
-        "CELERITAS_BUILD_DEMOS":{"type": "BOOL",   "value": "OFF"},
-        "CELERITAS_BUILD_TESTS":{"type": "BOOL",   "value": "OFF"},
-        "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "ON"},
-        "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "ON"}
-      }
-    },
-    {
       "name": "base",
       "displayName": "Wildstyle default options (GCC, debug, no omp)",
       "inherits": [".base"],

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -50,7 +50,7 @@ case $CONFIG in
     # ***IMPORTANT***: update cuda external version in dev/jammy-cuda11!
     DOCKERFILE_DISTRO=ubuntu
     BASE_TAG=nvidia/cuda:11.8.0-devel-ubuntu22.04
-    VECGEOM=v1.2.1
+    VECGEOM=v1.2.2
     ;;
   centos7-rocm5)
     # ***IMPORTANT***: update hip external version in dev/centos7-rocm5!
@@ -67,12 +67,12 @@ esac
 ${DOCKER} pull ${BASE_TAG}
 ${DOCKER} tag ${BASE_TAG} base-${CONFIG}
 
-${DOCKER} build -t dev-${CONFIG} \
-  --build-arg CONFIG=${CONFIG} \
-  --build-arg SPACK_VERSION=${SPACK_VERSION} \
-  --build-arg DOCKERFILE_DISTRO=${DOCKERFILE_DISTRO} \
-  ${BUILDARGS} \
-  dev
+#${DOCKER} build -t dev-${CONFIG} \
+#  --build-arg CONFIG=${CONFIG} \
+#  --build-arg SPACK_VERSION=${SPACK_VERSION} \
+#  --build-arg DOCKERFILE_DISTRO=${DOCKERFILE_DISTRO} \
+#  ${BUILDARGS} \
+#  dev
 
 ${DOCKER} build -t ci-${CONFIG} \
   --build-arg CONFIG=${CONFIG} \

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -67,12 +67,12 @@ esac
 ${DOCKER} pull ${BASE_TAG}
 ${DOCKER} tag ${BASE_TAG} base-${CONFIG}
 
-#${DOCKER} build -t dev-${CONFIG} \
-#  --build-arg CONFIG=${CONFIG} \
-#  --build-arg SPACK_VERSION=${SPACK_VERSION} \
-#  --build-arg DOCKERFILE_DISTRO=${DOCKERFILE_DISTRO} \
-#  ${BUILDARGS} \
-#  dev
+${DOCKER} build -t dev-${CONFIG} \
+  --build-arg CONFIG=${CONFIG} \
+  --build-arg SPACK_VERSION=${SPACK_VERSION} \
+  --build-arg DOCKERFILE_DISTRO=${DOCKERFILE_DISTRO} \
+  ${BUILDARGS} \
+  dev
 
 ${DOCKER} build -t ci-${CONFIG} \
   --build-arg CONFIG=${CONFIG} \

--- a/scripts/docker/ci/Dockerfile
+++ b/scripts/docker/ci/Dockerfile
@@ -39,7 +39,7 @@ COPY --from=builder /etc/profile.d/celeritas_spack_env.sh /etc/profile.d/celerit
 
 # Add core files
 # TODO: gcc isn't used for centos build
-RUN if [ "$DOCKERFILE_DISTRO" == "ubuntu" ] ; then \
+RUN if [ "$DOCKERFILE_DISTRO" = "ubuntu" ] ; then \
   apt-get -yqq update \
   && apt-get -yqq install --no-install-recommends \
     build-essential \
@@ -50,7 +50,7 @@ RUN if [ "$DOCKERFILE_DISTRO" == "ubuntu" ] ; then \
     ssh \
     vim \
   && rm -rf /var/lib/apt/lists/* ; \
-elif [ "$DOCKERFILE_DISTRO" == "centos" ] ; then \
+elif [ "$DOCKERFILE_DISTRO" = "centos" ] ; then \
   yum update -y \
   && yum install -y epel-release \
   && yum update -y \
@@ -93,7 +93,7 @@ RUN if [ -n "${VECGEOM}" ] ; then \
 fi
 
 # Set up entrypoint and group
-RUN if [ "$DOCKERFILE_DISTRO" == "ubuntu" ] ; then CELER_ID=999 ; else CELER_ID=990 ; fi ; \
+RUN if [ "$DOCKERFILE_DISTRO" = "ubuntu" ] ; then CELER_ID=999 ; else CELER_ID=990 ; fi ; \
  groupadd -g $CELER_ID celeritas \
  && useradd -r -u $CELER_ID -g celeritas -d /home/celeritas -m celeritas \
  && ln -s /opt/docker/entrypoint.bash /usr/local/bin/entrypoint-shell \

--- a/scripts/docker/dev/Dockerfile
+++ b/scripts/docker/dev/Dockerfile
@@ -19,7 +19,7 @@ ENV DEBIAN_FRONTEND=noninteractive    \
 
 # Combined ubuntu/centos run command
 ARG DOCKERFILE_DISTRO
-RUN if [ "$DOCKERFILE_DISTRO" == "ubuntu" ] ; then \
+RUN if [ "$DOCKERFILE_DISTRO" = "ubuntu" ] ; then \
   apt-get -yqq update \
   && apt-get -yqq install --no-install-recommends \
     build-essential \
@@ -45,7 +45,7 @@ RUN if [ "$DOCKERFILE_DISTRO" == "ubuntu" ] ; then \
   && locale-gen en_US.UTF-8 \
   && pip3 install boto3 \
   && rm -rf /var/lib/apt/lists/* ; \
-elif [ "$DOCKERFILE_DISTRO" == "centos" ] ; then \
+elif [ "$DOCKERFILE_DISTRO" = "centos" ] ; then \
   yum update -y \
   && yum install -y epel-release \
   && yum update -y \
@@ -82,7 +82,7 @@ RUN mkdir -p $SPACK_ROOT \
 
 # TODO: delete when next spack version comes out
 # see https://github.com/spack/spack/pull/33128
-RUN if [ "$DOCKERFILE_DISTRO" == "centos" ] ; then \
+RUN if [ "$DOCKERFILE_DISTRO" = "centos" ] ; then \
   curl -s -L https://patch-diff.githubusercontent.com/raw/spack/spack/pull/33128.patch?full_index=1 \
   | patch -p1 -d $SPACK_ROOT ; \
   fi

--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -74,18 +74,14 @@ bool GeantTestBase::is_ci_build()
 //! Whether Geant4 dependencies match those on Wildstyle
 bool GeantTestBase::is_wildstyle_build()
 {
-    return cstring_equal(celeritas_rng, "XORWOW")
-           && cstring_equal(celeritas_clhep_version, "2.4.6.0")
-           && cstring_equal(celeritas_geant4_version, "11.0.3");
+    return GeantTestBase::is_ci_build();
 }
 
 //---------------------------------------------------------------------------//
 //! Whether Geant4 dependencies match those on Summit
 bool GeantTestBase::is_summit_build()
 {
-    return cstring_equal(celeritas_rng, "XORWOW")
-           && cstring_equal(celeritas_clhep_version, "2.4.5.1")
-           && cstring_equal(celeritas_geant4_version, "11.0.0");
+    return GeantTestBase::is_ci_build();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -443,10 +443,10 @@ TEST_F(SolidsTest, accessors)
     // TODO: there are 27 actual solids, but there are a few "unused" volumes
     // created during construction, and different versions of VecGeom are
     // missing different solids (and thus are missing volumes!)
-    EXPECT_EQ(25, geom.num_volumes());
+    EXPECT_EQ(26, geom.num_volumes());
     EXPECT_EQ(2, geom.max_depth());
 
-    EXPECT_EQ("World", geom.id_to_label(VolumeId{24}).name);
+    EXPECT_EQ("World", geom.id_to_label(VolumeId{25}).name);
     EXPECT_EQ("vol0", geom.id_to_label(VolumeId{4}).name);
     EXPECT_EQ("vol1", geom.id_to_label(VolumeId{5}).name);
     EXPECT_EQ("vol11", geom.id_to_label(VolumeId{9}).name);
@@ -520,11 +520,11 @@ TEST_F(SolidsGeantTest, accessors)
     // TODO: there are 27 actual solids, but there are a few "unused" volumes
     // created during construction, and different versions of VecGeom are
     // missing different solids (and thus are missing volumes!)
-    // 25 is the "expected" number from VecGeom 1.2.1 (used by CI)
-    EXPECT_EQ(25, geom.num_volumes());
+    // 26 is the "expected" number from VecGeom 1.2.2 (used by CI)
+    EXPECT_EQ(26, geom.num_volumes());
     EXPECT_EQ(2, geom.max_depth());
 
-    EXPECT_EQ("World", geom.id_to_label(VolumeId{24}).name);
+    EXPECT_EQ("World", geom.id_to_label(VolumeId{25}).name);
     EXPECT_EQ("vol0", geom.id_to_label(VolumeId{4}).name);
     EXPECT_EQ("vol1", geom.id_to_label(VolumeId{5}).name);
     EXPECT_EQ("vol11", geom.id_to_label(VolumeId{9}).name);


### PR DESCRIPTION
This updates the CI version of VecGeom to 1.2.2. Required for #557.