### PR TITLE
Cross universe boundaries in ORANGE

### DIFF
--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -132,9 +132,6 @@ struct SimpleUnitRecord
     // Volume data [index by LocalVolumeId]
     ItemMap<LocalVolumeId, VolumeRecordId> volumes;
 
-    // Daughter data [index by DaughterId]
-    ItemRange<Daughter> daughters;
-
     // TODO: transforms
     // TODO: acceleration structure (bvh/kdtree/grid)
     LocalVolumeId background{};  //!< Default if not in any other volume

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -15,6 +15,7 @@
 #include "corecel/sys/ThreadId.hh"
 
 #include "OrangeTypes.hh"
+#include "univ/detail/Types.hh"
 
 namespace celeritas
 {
@@ -283,7 +284,11 @@ struct OrangeStateData
 
     // Dimensions {num_tracks}
     StateItems<LevelId> level;
-    StateItems<LevelId> next_level;
+    StateItems<LevelId> surface_level;
+
+    StateItems<real_type> next_step;
+    StateItems<detail::OnSurface> next_surface;
+    StateItems<LevelId> next_surface_level;
 
     // Dimensions {num_tracks, max_level}
     Items<Real3> pos;
@@ -314,7 +319,10 @@ struct OrangeStateData
     {
         // clang-format off
         return !level.empty()
-            && next_level.size() == level.size()
+            && surface_level.size() == level.size()
+            && next_step.size() == level.size()
+            && next_surface.size() == level.size()
+            && next_surface_level.size() == level.size()
             && !pos.empty()
             && dir.size() == pos.size()
             && vol.size() == pos.size()
@@ -339,7 +347,10 @@ struct OrangeStateData
     {
         CELER_EXPECT(other);
         level = other.level;
-        next_level = other.next_level;
+        surface_level = other.surface_level;
+        next_step = other.next_step;
+        next_surface = other.next_surface;
+        next_surface_level = other.next_surface_level;
         pos = other.pos;
         dir = other.dir;
         vol = other.vol;
@@ -372,7 +383,11 @@ inline void resize(OrangeStateData<Ownership::value, M>* data,
     CELER_EXPECT(num_tracks > 0);
 
     resize(&data->level, num_tracks);
-    resize(&data->next_level, num_tracks);
+    resize(&data->surface_level, num_tracks);
+
+    resize(&data->next_step, num_tracks);
+    resize(&data->next_surface, num_tracks);
+    resize(&data->next_surface_level, num_tracks);
 
     data->max_level = params.scalars.max_level;
     auto const size = data->max_level * num_tracks;

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -59,8 +59,7 @@ struct VolumeRecord
 
     logic_int max_intersections{0};
     logic_int flags{0};
-    UniverseId daughter;
-    TranslationId daughter_translation;
+    DaughterId daughter_id;
     // TODO (KENO geometry): zorder
 
     //! Flag values (bit field)
@@ -133,8 +132,8 @@ struct SimpleUnitRecord
     // Volume data [index by LocalVolumeId]
     ItemMap<LocalVolumeId, VolumeRecordId> volumes;
 
-    // Translation data [index by TranslationId]
-    ItemRange<Translation> translations;
+    // Daughter data [index by DaughterId]
+    ItemRange<Daughter> daughters;
 
     // TODO: transforms
     // TODO: acceleration structure (bvh/kdtree/grid)
@@ -221,6 +220,7 @@ struct OrangeParamsData
     Items<Connectivity> connectivities;
     Items<VolumeRecord> volume_records;
 
+    Items<Daughter> daughters;
     Items<Translation> translations;
 
     UnitIndexerData<W, M> unit_indexer_data;
@@ -256,6 +256,7 @@ struct OrangeParamsData
         surface_types = other.surface_types;
         connectivities = other.connectivities;
         volume_records = other.volume_records;
+        daughters = other.daughters;
         translations = other.translations;
         unit_indexer_data = other.unit_indexer_data;
 

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -525,11 +525,21 @@ CELER_FUNCTION void OrangeTrackView::move_internal(real_type dist)
  */
 CELER_FUNCTION void OrangeTrackView::move_internal(Real3 const& pos)
 {
+    auto local_pos = pos;
+
     for (auto i : range(this->level() + 1))
     {
         auto lsa = this->make_lsa(LevelId{i});
-        lsa.pos() = pos;
+        lsa.pos() = local_pos;
         lsa.surf() = LocalSurfaceId{};
+
+        if (i < this->level())
+        {
+            auto tracker = this->make_tracker(lsa.universe());
+            auto const& trans = tracker.translation(lsa.vol());
+            TranslatorDown td(trans);
+            local_pos = td(pos);
+        }
     }
 
     this->surface_level() = LevelId{};

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -30,6 +30,9 @@ namespace celeritas
 //! Integer type for volume CSG tree representation
 using logic_int = unsigned short int;
 
+//! Identifier for a daughter universe
+using DaughterId = OpaqueId<struct Daughter>;
+
 //! Identifier for a face local to a particular volume (internal use only)
 using FaceId = OpaqueId<struct Face>;
 
@@ -53,16 +56,6 @@ using UniverseId = OpaqueId<struct Universe>;
 
 //! Opaque index for "simple unit" data
 using SimpleUnitId = OpaqueId<struct SimpleUnitRecord>;
-
-//! Data to specify an embeded universe withing a volume
-struct Daughter
-{
-    UniverseId universe_id;
-    TranslationId translation_id;
-};
-
-//! Opaque index for "simple unit" data
-using DaughterId = OpaqueId<struct Daughter>;
 
 //---------------------------------------------------------------------------//
 // ENUMERATIONS
@@ -209,6 +202,18 @@ enum OperatorToken : logic_int
     lend
 };
 }  // namespace logic
+
+//---------------------------------------------------------------------------//
+// STRUCTS
+//---------------------------------------------------------------------------//
+/*!
+ * Data specifying a daughter universe embedded in a volume.
+ */
+struct Daughter
+{
+    UniverseId universe_id;
+    TranslationId translation_id;
+};
 
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS (HOST/DEVICE)

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -33,6 +33,12 @@ using logic_int = unsigned short int;
 //! Identifier for a face local to a particular volume (internal use only)
 using FaceId = OpaqueId<struct Face>;
 
+//! Local Identifier for a surface within within a universe
+using LocalSurfaceId = OpaqueId<struct LocalSurface>;
+
+//! Lacal identifier for a geometry volume in a universe
+using LocalVolumeId = OpaqueId<struct LocalVolume>;
+
 //! Identifier for the current "level", i.e. depth of embedded universe
 using LevelId = OpaqueId<struct Level>;
 
@@ -47,6 +53,16 @@ using UniverseId = OpaqueId<struct Universe>;
 
 //! Opaque index for "simple unit" data
 using SimpleUnitId = OpaqueId<struct SimpleUnitRecord>;
+
+//! Data to specify an embeded universe withing a volume
+struct Daughter
+{
+    UniverseId universe_id;
+    TranslationId translation_id;
+};
+
+//! Opaque index for "simple unit" data
+using DaughterId = OpaqueId<struct Daughter>;
 
 //---------------------------------------------------------------------------//
 // ENUMERATIONS

--- a/src/orange/Types.hh
+++ b/src/orange/Types.hh
@@ -21,14 +21,8 @@ namespace celeritas
 //! Identifier for a geometry volume
 using VolumeId = OpaqueId<struct Volume>;
 
-//! Lacal identifier for a geometry volume in a universe
-using LocalVolumeId = OpaqueId<struct LocalVolume>;
-
 //! Identifier for a surface (for surface-based geometries)
 using SurfaceId = OpaqueId<struct Surface>;
-
-//! Local Identifier for a surface within within a universe
-using LocalSurfaceId = OpaqueId<struct LocalSurface>;
 
 //! Fixed-size array for 3D space
 using Real3 = Array<real_type, 3>;

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -25,6 +25,21 @@
 #include "orange/OrangeTypes.hh"
 #include "orange/construct/OrangeInput.hh"
 
+namespace
+{
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return the i-th translation from a flattened vector.
+ */
+celeritas::Translation make_translation(std::vector<double> const& translations,
+                                        celeritas::size_type i)
+{
+    return celeritas::Translation{
+        translations[3 * i], translations[3 * i + 1], translations[3 * i + 2]};
+}
+}  // namespace
+
 namespace celeritas
 {
 namespace
@@ -180,16 +195,23 @@ void from_json(nlohmann::json const& j, UnitInput& value)
     {
         auto const& parent_cells
             = j.at("parent_cells").get<std::vector<size_type>>();
+
         auto const& daughters = j.at("daughters").get<std::vector<size_type>>();
         CELER_VALIDATE(parent_cells.size() == daughters.size(),
                        << "fields 'parent_cells' and 'daughters' have "
                           "different lengths");
 
+        auto const& translations
+            = j.at("translations").get<std::vector<double>>();
+        CELER_VALIDATE(3 * parent_cells.size() == translations.size(),
+                       << "field 'translations' is not 3x length of "
+                          "'parent_cells'");
+
         UnitInput::MapVolumeDaughter daughter_map;
         for (auto i : range(parent_cells.size()))
         {
-            daughter_map[LocalVolumeId{parent_cells[i]}]
-                = {UniverseId{daughters[i]}, {0, 0, 0}};
+            daughter_map[LocalVolumeId{parent_cells[i]}] = {
+                UniverseId{daughters[i]}, make_translation(translations, i)};
         }
 
         value.daughter_map = std::move(daughter_map);

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -158,7 +158,6 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
 
     // Define volumes
     std::vector<VolumeRecord> vol_records(inp.volumes.size());
-    std::vector<Daughter> daughters;
     std::vector<std::set<LocalVolumeId>> connectivity(inp.surfaces.size());
     for (auto i : range(inp.volumes.size()))
     {
@@ -169,7 +168,6 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
         if (inp.daughter_map.find(LocalVolumeId(i)) != inp.daughter_map.end())
         {
             process_daughter(&(vol_records[i]),
-                             &daughters,
                              inp.daughter_map.at(LocalVolumeId(i)));
         }
 
@@ -188,10 +186,6 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
     unit.volumes = ItemMap<LocalVolumeId, SimpleUnitRecord::VolumeRecordId>(
         make_builder(&orange_data_->volume_records)
             .insert_back(vol_records.begin(), vol_records.end()));
-
-    // Save daughters
-    unit.daughters = make_builder(&orange_data_->daughters)
-                         .insert_back(daughters.begin(), daughters.end());
 
     // Save connectivity
     {
@@ -360,18 +354,16 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
  * Process a single daughter universe.
  */
 void UnitInserter::process_daughter(VolumeRecord* vol_record,
-                                    std::vector<Daughter>* daughters,
                                     UnitInput::Daughter const& daughter_input)
 {
-    vol_record->flags &= VolumeRecord::embedded_universe;
-    vol_record->daughter_id = DaughterId(daughters->size());
-
     Daughter daughter;
     daughter.universe_id = daughter_input.universe_id;
     daughter.translation_id = make_builder(&orange_data_->translations)
                                   .push_back(daughter_input.translation);
 
-    daughters->push_back(daughter);
+    vol_record->daughter_id
+        = make_builder(&orange_data_->daughters).push_back(daughter);
+    vol_record->flags &= VolumeRecord::embedded_universe;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/UnitInserter.hh
+++ b/src/orange/detail/UnitInserter.hh
@@ -51,7 +51,6 @@ class UnitInserter
     insert_volume(SurfacesRecord const& unit, VolumeInput const& v);
 
     void process_daughter(VolumeRecord* vol_record,
-                          std::vector<Daughter>* daughters,
                           UnitInput::Daughter const& daughter_input);
 };
 

--- a/src/orange/detail/UnitInserter.hh
+++ b/src/orange/detail/UnitInserter.hh
@@ -51,8 +51,8 @@ class UnitInserter
     insert_volume(SurfacesRecord const& unit, VolumeInput const& v);
 
     void process_daughter(VolumeRecord* vol_record,
-                          std::vector<Translation>* translations,
-                          UnitInput::Daughter const& daughter);
+                          std::vector<Daughter>* daughters,
+                          UnitInput::Daughter const& daughter_input);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -67,12 +67,8 @@ class SimpleUnitTracker
         return unit_record_;
     }
 
-    // Provide the daughter universe embedded in a given volume
-    inline CELER_FUNCTION UniverseId daughter_uid(LocalVolumeId vol) const;
-
-    // Provide the translation daughter universe embedded in a given volume
-    inline CELER_FUNCTION Translation const&
-    translation(LocalVolumeId vol) const;
+    // DaughterId of universe embedded in a given volume
+    inline CELER_FUNCTION DaughterId daughter(LocalVolumeId vol) const;
 
     //// OPERATIONS ////
 
@@ -646,36 +642,21 @@ SimpleUnitTracker::make_local_volume(LocalVolumeId vid) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Provide the daughter universe embedded in a given volume.
+ * DaughterId of universe embedded in a given volume.
  */
-CELER_FORCEINLINE_FUNCTION UniverseId
-SimpleUnitTracker::daughter_uid(LocalVolumeId vol) const
+CELER_FORCEINLINE_FUNCTION DaughterId
+SimpleUnitTracker::daughter(LocalVolumeId vol) const
 {
-    auto const& vol_rec = params_.volume_records[unit_record_.volumes[vol]];
-    UniverseId uid{};
-
-    if (vol_rec.daughter_id)
+    auto local_daughter_id
+        = params_.volume_records[unit_record_.volumes[vol]].daughter_id;
+    if (local_daughter_id)
     {
-        uid = params_
-                  .daughters[unit_record_.daughters[vol_rec.daughter_id.get()]]
-                  .universe_id;
+        return unit_record_.daughters[local_daughter_id.get()];
     }
-    return uid;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Provide the translation of the daughter universe embedded in a given volume.
- */
-CELER_FORCEINLINE_FUNCTION Translation const&
-SimpleUnitTracker::translation(LocalVolumeId vol) const
-{
-    auto const& vol_rec = params_.volume_records[unit_record_.volumes[vol]];
-    auto const& trans_id
-        = params_.daughters[unit_record_.daughters[vol_rec.daughter_id.get()]]
-              .translation_id;
-    CELER_ASSERT(trans_id);
-    return params_.translations[trans_id];
+    else
+    {
+        return DaughterId{};
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -67,6 +67,13 @@ class SimpleUnitTracker
         return unit_record_;
     }
 
+    // Provide the daughter universe embedded in a given volume
+    inline CELER_FUNCTION UniverseId daughter_uid(LocalVolumeId vol) const;
+
+    // Provide the translation daughter universe embedded in a given volume
+    inline CELER_FUNCTION Translation const&
+    translation(LocalVolumeId vol) const;
+
     //// OPERATIONS ////
 
     // Find the local volume from a position
@@ -635,6 +642,40 @@ CELER_FORCEINLINE_FUNCTION VolumeView
 SimpleUnitTracker::make_local_volume(LocalVolumeId vid) const
 {
     return VolumeView{params_, unit_record_, vid};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Provide the daughter universe embedded in a given volume.
+ */
+CELER_FORCEINLINE_FUNCTION UniverseId
+SimpleUnitTracker::daughter_uid(LocalVolumeId vol) const
+{
+    auto const& vol_rec = params_.volume_records[unit_record_.volumes[vol]];
+    UniverseId uid{};
+
+    if (vol_rec.daughter_id)
+    {
+        uid = params_
+                  .daughters[unit_record_.daughters[vol_rec.daughter_id.get()]]
+                  .universe_id;
+    }
+    return uid;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Provide the translation of the daughter universe embedded in a given volume.
+ */
+CELER_FORCEINLINE_FUNCTION Translation const&
+SimpleUnitTracker::translation(LocalVolumeId vol) const
+{
+    auto const& vol_rec = params_.volume_records[unit_record_.volumes[vol]];
+    auto const& trans_id
+        = params_.daughters[unit_record_.daughters[vol_rec.daughter_id.get()]]
+              .translation_id;
+    CELER_ASSERT(trans_id);
+    return params_.translations[trans_id];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -647,16 +647,7 @@ SimpleUnitTracker::make_local_volume(LocalVolumeId vid) const
 CELER_FORCEINLINE_FUNCTION DaughterId
 SimpleUnitTracker::daughter(LocalVolumeId vol) const
 {
-    auto local_daughter_id
-        = params_.volume_records[unit_record_.volumes[vol]].daughter_id;
-    if (local_daughter_id)
-    {
-        return unit_record_.daughters[local_daughter_id.get()];
-    }
-    else
-    {
-        return DaughterId{};
-    }
+    return params_.volume_records[unit_record_.volumes[vol]].daughter_id;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -520,8 +520,8 @@ TEST_F(FiveVolumesTest, params)
 TEST_F(UniversesTest, params)
 {
     OrangeParams const& geo = this->params();
-    EXPECT_EQ(9, geo.num_volumes());
-    EXPECT_EQ(21, geo.num_surfaces());
+    EXPECT_EQ(12, geo.num_volumes());
+    EXPECT_EQ(25, geo.num_surfaces());
     EXPECT_FALSE(geo.supports_safety());
 
     EXPECT_VEC_SOFT_EQ(Real3({-2, -6, -1}), geo.bbox().lower());
@@ -533,9 +533,12 @@ TEST_F(UniversesTest, params)
                                          "bobby",
                                          "johnny",
                                          "[EXTERIOR]",
+                                         "inner_c",
                                          "a",
                                          "b",
-                                         "c"};
+                                         "c",
+                                         "[EXTERIOR]",
+                                         "patty"};
     std::vector<std::string> actual;
     for (auto const id : range(VolumeId{geo.num_volumes()}))
     {
@@ -574,27 +577,250 @@ TEST_F(UniversesTest, initialize_with_multiple_universes)
     EXPECT_FALSE(geo.is_on_boundary());
 }
 
-TEST_F(UniversesTest, boundary_crossing_multiple_universes)
+// Cross into daughter universe for the case where the hole cell does not share
+// a boundary with another with a parent cell
+TEST_F(UniversesTest, cross_into_daughter_non_coincident)
+{
+    auto geo = this->make_track_view();
+    geo = Initializer_t{{2, -5, 1}, {0, 1, 0}};
+
+    auto next = geo.find_next_step();
+    EXPECT_SOFT_EQ(1, next.distance);
+    EXPECT_EQ("inner_a.my",
+              this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("johnny", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, -4, 1}), geo.pos());
+
+    // Cross universe boundary
+    geo.cross_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("c", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, -4, 1}), geo.pos());
+
+    // Make sure we can take another step after crossing
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(1, next.distance);
+    EXPECT_EQ("alpha.my",
+              this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("alpha.my", this->params().id_to_label(geo.surface_id()).name);
+}
+
+// Cross into parent universe for the case where the hole cell does not share a
+// boundary with another with a parent cell
+TEST_F(UniversesTest, cross_into_parent_non_coincident)
+{
+    auto geo = this->make_track_view();
+    geo = Initializer_t{{2, -3.5, 1}, {0, -1, 0}};
+
+    auto next = geo.find_next_step();
+    EXPECT_SOFT_EQ(0.5, next.distance);
+    EXPECT_EQ("inner_a.my",
+              this->params().id_to_label(geo.next_surface_id()).name);
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("c", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, -4, 1}), geo.pos());
+
+    // Cross universe boundary
+    geo.cross_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("johnny", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, -4, 1}), geo.pos());
+
+    // Make sure we can take another step after crossing
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(2, next.distance);
+    EXPECT_EQ("john.my",
+              this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("john.my", this->params().id_to_label(geo.surface_id()).name);
+}
+
+// Cross into daughter universe for the case where the hole cell shares a
+// boundary with another with a parent cell
+TEST_F(UniversesTest, cross_into_daughter_coincident)
+{
+    auto geo = this->make_track_view();
+    geo = Initializer_t{{2, 1, 1}, {0, -1, 0}};
+
+    auto next = geo.find_next_step();
+    EXPECT_SOFT_EQ(1, next.distance);
+    EXPECT_EQ("bob.my", this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("bob.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("bobby", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, 0, 1}), geo.pos());
+
+    // Cross universe boundary
+    geo.cross_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("bob.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("c", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, 0, 1}), geo.pos());
+
+    // Make sure we can take another step after crossing
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(1, next.distance);
+    EXPECT_EQ("alpha.py",
+              this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("alpha.py", this->params().id_to_label(geo.surface_id()).name);
+}
+
+// Cross into parent universe for the case where the hole cell shares a
+// boundary with another with a parent cell
+TEST_F(UniversesTest, cross_into_parent_coincident)
+{
+    auto geo = this->make_track_view();
+    geo = Initializer_t{{2, -0.5, 1}, {0, 1, 0}};
+
+    auto next = geo.find_next_step();
+    EXPECT_SOFT_EQ(0.5, next.distance);
+    EXPECT_EQ("bob.my", this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("bob.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("c", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, 0, 1}), geo.pos());
+
+    // Cross universe boundary
+    geo.cross_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("bob.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("bobby", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, 0, 1}), geo.pos());
+
+    // Make sure we can take another step after crossing
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(2, next.distance);
+    EXPECT_EQ("bob.py", this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("bob.py", this->params().id_to_label(geo.surface_id()).name);
+}
+
+// Cross into daughter universe that is two levels down
+TEST_F(UniversesTest, cross_into_daughter_doubly_coincident)
+{
+    auto geo = this->make_track_view();
+    geo = Initializer_t{{0.25, -4.5, 1}, {0, 1, 0}};
+
+    auto next = geo.find_next_step();
+    EXPECT_SOFT_EQ(0.5, next.distance);
+    EXPECT_EQ("inner_a.my",
+              this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("johnny", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({0.25, -4, 1}), geo.pos());
+
+    // Cross universe boundary
+    geo.cross_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("patty", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({0.25, -4, 1}), geo.pos());
+
+    // Make sure we can take another step after crossing
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(0.5, next.distance);
+    EXPECT_EQ("inner_c.py",
+              this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_c.py", this->params().id_to_label(geo.surface_id()).name);
+}
+
+// Cross into parent universe that is two levels down
+TEST_F(UniversesTest, cross_into_parent_doubly_coincident)
+{
+    auto geo = this->make_track_view();
+    geo = Initializer_t{{0.25, -3.75, 1}, {0, -1, 0}};
+
+    auto next = geo.find_next_step();
+    EXPECT_SOFT_EQ(0.25, next.distance);
+    EXPECT_EQ("inner_a.my",
+              this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("patty", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({0.25, -4, 1}), geo.pos());
+
+    // Cross universe boundary
+    geo.cross_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("johnny", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({0.25, -4, 1}), geo.pos());
+
+    // Make sure we can take another step after crossing
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(2, next.distance);
+    EXPECT_EQ("john.my",
+              this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("john.my", this->params().id_to_label(geo.surface_id()).name);
+}
+
+// Cross between two daughter universes that share a boundary
+TEST_F(UniversesTest, cross_between_daughters)
 {
     auto geo = this->make_track_view();
 
     // Initialize in outermost universe
-    geo = Initializer_t{{-1, -2, 1}, {1, 0, 0}};
-    EXPECT_VEC_SOFT_EQ(Real3({-1, -2, 1}), geo.pos());
-    EXPECT_VEC_SOFT_EQ(Real3({1, 0, 0}), geo.dir());
-    EXPECT_EQ("johnny", this->params().id_to_label(geo.volume_id()).name);
-    EXPECT_FALSE(geo.is_outside());
-    EXPECT_FALSE(geo.is_on_boundary());
-}
+    geo = Initializer_t{{2, -2, 0.7}, {0, 0, -1}};
 
-TEST_F(Geant4Testem15Test, params)
-{
-    OrangeParams const& geo = this->params();
+    auto next = geo.find_next_step();
+    EXPECT_SOFT_EQ(0.2, next.distance);
+    EXPECT_EQ("inner_a.pz",
+              this->params().id_to_label(geo.next_surface_id()).name);
 
-    EXPECT_EQ(3, geo.num_volumes());
-    EXPECT_EQ(12, geo.num_surfaces());
-    // The 'world' volume includes a negated box
-    EXPECT_FALSE(geo.supports_safety());
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_a.pz", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("a", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, -2, 0.5}), geo.pos());
+
+    // Cross universe boundary
+    geo.cross_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("inner_a.pz", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("a", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, -2, 0.5}), geo.pos());
+
+    // Make sure we can take another step after crossing
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(1, next.distance);
+    EXPECT_EQ("bob.mz", this->params().id_to_label(geo.next_surface_id()).name);
+
+    geo.move_to_boundary();
+    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
+    EXPECT_EQ("bob.mz", this->params().id_to_label(geo.surface_id()).name);
 }
 
 TEST_F(Geant4Testem15Test, safety)

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -577,6 +577,24 @@ TEST_F(UniversesTest, initialize_with_multiple_universes)
     EXPECT_FALSE(geo.is_on_boundary());
 }
 
+TEST_F(UniversesTest, move_internal_multiple_universes)
+{
+    auto geo = this->make_track_view();
+
+    // Initialize in daughter universe
+    geo = Initializer_t{{0.5, -2, 1}, {0, 1, 0}};
+
+    // Move internally, then check that the distance to boundary is correct
+    geo.move_internal({0.5, -1, 1});
+    auto next = geo.find_next_step();
+    EXPECT_SOFT_EQ(1, next.distance);
+
+    // Move again, using other move_internal method
+    geo.move_internal(0.1);
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(0.9, next.distance);
+}
+
 // Cross into daughter universe for the case where the hole cell does not share
 // a boundary with another with a parent cell
 TEST_F(UniversesTest, cross_into_daughter_non_coincident)

--- a/test/orange/data/universes.org.json
+++ b/test/orange/data/universes.org.json
@@ -9,8 +9,11 @@
 3,
 4,
 -1,
+-1,
 0,
 1,
+2,
+-1,
 2
 ],
 "names": [
@@ -126,7 +129,7 @@
 ],
 "md": {
 "name": "outer",
-"provenance": "universes.org.omn:48"
+"provenance": "universes.org.omn:96"
 },
 "parent_cells": [
 1,
@@ -197,7 +200,15 @@
 "pz",
 "py"
 ]
-}
+},
+"translations": [
+2.0,
+-2.0,
+-0.5,
+2.0,
+-2.0,
+0.5
+]
 },
 {
 "_type": "simple unit",
@@ -215,6 +226,7 @@
 ],
 "cell_names": [
 "[EXTERIOR]",
+"inner_c",
 "a",
 "b",
 "c"
@@ -229,66 +241,91 @@
 },
 {
 "faces": [
-0,
 1,
-2,
 3
 ],
-"logic": "0 1 ~ & 2 & 3 ~ & * &",
-"num_intersections": 4,
+"logic": "0 ~ 1 ~ & * &",
+"num_intersections": 2,
 "zorder": 2
 },
 {
 "faces": [
-1,
-2,
-3,
-6
+6,
+7,
+8,
+9
 ],
-"logic": "0 1 & 2 ~ & * & 3 ~ &",
+"logic": "* 0 & 1 ~ & 2 & 3 ~ &",
 "num_intersections": 4,
 "zorder": 2
 },
 {
 "faces": [
-0,
-1,
-2,
-3,
-6
+7,
+8,
+9,
+10
+],
+"logic": "* 0 & 1 & 2 ~ & 3 ~ &",
+"num_intersections": 4,
+"zorder": 2
+},
+{
+"faces": [
+6,
+7,
+8,
+9,
+10
 ],
 "flags": 1,
-"logic": "0 1 ~ & 2 & 3 ~ & * & ~ 1 2 & 3 ~ & * & 4 ~ & ~ &",
+"logic": "* 0 & 1 ~ & 2 & 3 ~ & ~ * 1 & 2 & 3 ~ & 4 ~ & ~ &",
 "num_intersections": 5,
 "zorder": 2
 }
 ],
-"daughters": [],
+"daughters": [
+2
+],
 "md": {
 "name": "inner",
-"provenance": "universes.org.omn:16"
+"provenance": "universes.org.omn:60"
 },
-"parent_cells": [],
+"parent_cells": [
+1
+],
 "surface_names": [
+"gamma.mx",
+"inner_c.px",
+"gamma.my",
+"inner_c.py",
+"alpha.mz",
+"alpha.pz",
 "alpha.mx",
 "alpha.px",
 "alpha.my",
 "alpha.py",
-"alpha.mz",
-"alpha.pz",
 "beta.px"
 ],
 "surfaces": {
 "data": [
--1.0,
-1.0,
--1.0,
-1.0,
+-2.0,
+-1.5,
+-2.0,
+-1.5,
 0.0,
+1.0,
+-1.0,
+1.0,
+-1.0,
 1.0,
 3.0
 ],
 "sizes": [
+1,
+1,
+1,
+1,
 1,
 1,
 1,
@@ -304,9 +341,65 @@
 "py",
 "pz",
 "pz",
+"px",
+"px",
+"py",
+"py",
 "px"
 ]
+},
+"translations": [
+-2.0,
+-2.0,
+0.0
+]
+},
+{
+"_type": "simple unit",
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+0.5,
+0.5,
+1.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"patty"
+],
+"cells": [
+{
+"faces": [],
+"flags": 2,
+"logic": "* ~",
+"num_intersections": 0,
+"zorder": 65534
+},
+{
+"faces": [],
+"logic": "*",
+"num_intersections": 0,
+"zorder": 2
 }
+],
+"daughters": [],
+"md": {
+"name": "most_inner",
+"provenance": "universes.org.omn:47"
+},
+"parent_cells": [],
+"surface_names": [],
+"surfaces": {
+"data": [],
+"sizes": [],
+"types": []
+},
+"translations": []
 }
 ]
 }

--- a/test/orange/data/universes.org.omn
+++ b/test/orange/data/universes.org.omn
@@ -1,33 +1,34 @@
-# Diagram (to scale) of slice at z = 1
-# The outer cell, johnny spans z = (-1, 2)
-# Cells c, a, b make up hole inner_b which spans z = (0.5, 1.5)
-# An identical hole, inner_a is placed the same way in x and y, with z = (-0.5, 0.5)
-# Cell bobby spans the full height of inner_a and inner_b, with z = (-0.5, 1.5)
-#
-#   4_ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __
-#     |                                                            |
-#   3_|                         johnny                             |
-#     |                                                            |
-#   2_|           ____________________________________             |
-#     |           |                                   |            |
-#   1_|           |             bobby                 |            |
-#     |           |                                   |            |
-#   0_|           |___________________________________|            |
-#     |           |                 c                 |            |
-#  -1_|           |      _______________________      |            |
-#     |           |     |           |           |     |            |
-#  -2_|           |     |    a      |     b     |     |            |
-#     |           |     |           |           |     |            |
-#  -3_            |     |___________|___________|     |            |
-#     |           |                                   |            |
-#  -4_|           |___________________________________|            |
-#     |                                                            |
-#  -5_|                                                            |
-#     |                                                            |
-#  -6_|__ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ |
-#     ^     ^     ^     ^     ^     ^     ^     ^     ^     ^     ^
-#    -2    -1     0     1     2     3     4     5     6     7     8
-#
+! Diagram (to scale) of slice at z = 1
+! The outer cell, johnny spans z = (-1, 2)
+! Cell bobby spans the full height of inner_a and inner_b, with z = (-0.5, 1.5)
+! Cells c, a, b make up hole inner_a which spans z = (0.5, 1.5)
+! Cell patty makes up hole inner_c, a hole in the bottom left corner of inner_a/inner_b
+! An identical hole, inner_b is placed the same way in x and y, with z = (-0.5, 0.5)
+!
+!   4_ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __
+!     |                                                            |
+!   3_|                         johnny                             |
+!     |                                                            |
+!   2_|           ____________________________________             |
+!     |           |                                   |            |
+!   1_|           |             bobby                 |            |
+!     |           |                                   |            |
+!   0_|           |___________________________________|            |
+!     |           |                 c                 |            |
+!  -1_|           |      _______________________      |            |
+!     |           |     |           |           |     |            |
+!  -2_|           |     |    a      |     b     |     |            |
+!     |           |     |           |           |     |            |
+!  -3_            |     |___________|___________|     |            |
+!     |           |__                                 |            |
+!  -4_| patty --> |__|________________________________|            |
+!     |                                                            |
+!  -5_|                                                            |
+!     |                                                            |
+!  -6_|__ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ |
+!     ^     ^     ^     ^     ^     ^     ^     ^     ^     ^     ^
+!    -2    -1     0     1     2     3     4     5     6     7     8
+!
 [GEOMETRY]
 global "outer"
 
@@ -40,8 +41,21 @@ comp         : matid
     "media 3"  3
     "media 4"  4
 
-!#### INNER UNIVERSE ####!
+!#### LEVEL 2 UNIVERSE ####!
 ! Since this is referenced by the outer universe, it must come first !
+
+[UNIVERSE=general most_inner]
+interior "patricia"
+
+[UNIVERSE][SHAPE=cuboid patricia]
+faces 0.0 0.5 0.0 0.5 0 1
+
+[UNIVERSE][CELL patty]
+comp "media 2"
+shapes -patricia
+! volume: 0.5 * 0.5 * 1 = 0.25
+
+!#### LEVEL 1 UNIVERSE ####!
 
 [UNIVERSE=general inner]
 interior "gamma"
@@ -73,7 +87,11 @@ comp "media 2"
 shapes +alpha +beta -gamma
 volume 16.0 ! 24 - 4 - 4
 
-!#### OUTER UNIVERSE ####!
+[UNIVERSE][HOLE inner_c]
+fill most_inner
+translate -2 -2 0
+
+!#### LEVEL 0 UNIVERSE ####!
 
 [UNIVERSE=general outer]
 interior "john"


### PR DESCRIPTION
The PR adds the ability to track across universe boundaries in ORANGE: moving from parent to daughter, daughter to parent, or directly from daughter to daughter in the case where holes share a boundary. 

This PR also contains:
- minor refactor: moving `next_step_` and `next_surface_` from `OrangeTrackView` to `OrangeStateData`
- properly apply universe translations as specified in JSON