### PR TITLE
Fix Collection usage from inside .cu files

### DIFF
--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -179,9 +179,9 @@
             }                                                             \
         } while (0)
 #else
-#    define CELER_VALIDATE(COND, MSG) \
-        static_assert(false,          \
-                      "CELER_VALIDATE cannot be called from device code")
+#    define CELER_VALIDATE(COND, MSG)                                         \
+        CELER_DEBUG_FAIL_("CELER_VALIDATE cannot be called from device code", \
+                          unreachable);
 #endif
 
 #define CELER_NOT_CONFIGURED(WHAT) CELER_DEBUG_FAIL_(WHAT, unconfigured)
@@ -506,7 +506,8 @@ inline __host__ void device_debug_error(DebugErrorType which,
     throw DebugError({which, condition, __FILE__, __LINE__});
 }
 
-//! Device-only call for HIP (must always be declared; only used if NDEBUG)
+//! Device-only call for HIP (must always be declared; only used if
+//! NDEBUG)
 inline __attribute__((noinline)) __device__ void device_debug_error(
     DebugErrorType, char const* condition, char const* file, unsigned int line)
 {

--- a/src/corecel/data/detail/CollectionImpl.hh
+++ b/src/corecel/data/detail/CollectionImpl.hh
@@ -79,7 +79,7 @@ struct CollectionStorage<T, Ownership::value, MemSpace::host>
 {
     static_assert(!std::is_same<T, bool>::value,
                   "bool is not compatible between vector and anything else");
-#ifdef CELER_DEVICE_SOURCE
+#ifdef CELER_DEVICE_COMPILE
     // Use "not implemented" but __host__ __device__ decorated functions when
     // compiling in CUDA
     using type = DisabledStorage<T>;
@@ -93,7 +93,7 @@ struct CollectionStorage<T, Ownership::value, MemSpace::host>
 template<class T>
 struct CollectionStorage<T, Ownership::value, MemSpace::device>
 {
-#ifdef CELER_DEVICE_SOURCE
+#ifdef CELER_DEVICE_COMPILE
     // Use "not implemented" but __host__ __device__ decorated functions when
     // compiling in CUDA
     using type = DisabledStorage<T>;

--- a/src/corecel/data/detail/CollectionImpl.hh
+++ b/src/corecel/data/detail/CollectionImpl.hh
@@ -79,7 +79,13 @@ struct CollectionStorage<T, Ownership::value, MemSpace::host>
 {
     static_assert(!std::is_same<T, bool>::value,
                   "bool is not compatible between vector and anything else");
+#ifdef CELER_DEVICE_SOURCE
+    // Use "not implemented" but __host__ __device__ decorated functions when
+    // compiling in CUDA
+    using type = DisabledStorage<T>;
+#else
     using type = std::vector<T>;
+#endif
     type data;
 };
 
@@ -87,13 +93,14 @@ struct CollectionStorage<T, Ownership::value, MemSpace::host>
 template<class T>
 struct CollectionStorage<T, Ownership::value, MemSpace::device>
 {
-#ifndef CELER_DEVICE_COMPILE
-    using type = DeviceVector<T>;
-    type data;
-#else
+#ifdef CELER_DEVICE_SOURCE
+    // Use "not implemented" but __host__ __device__ decorated functions when
+    // compiling in CUDA
     using type = DisabledStorage<T>;
-    type data;
+#else
+    using type = DeviceVector<T>;
 #endif
+    type data;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/detail/CollectionImpl.hh
+++ b/src/corecel/data/detail/CollectionImpl.hh
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "corecel/Assert.hh"
+#include "corecel/OpaqueId.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/Span.hh"
 
@@ -182,15 +183,18 @@ struct CollectionAssigner<Ownership::value, MemSpace::host>
 template<>
 struct CollectionAssigner<Ownership::value, MemSpace::device>
 {
+    template<class T>
+    using StorageValDev
+        = CollectionStorage<T, Ownership::value, MemSpace::device>;
+
     template<class T, Ownership W2, MemSpace M2>
-    CollectionStorage<T, Ownership::value, MemSpace::device>
-    operator()(CollectionStorage<T, W2, M2> const& source)
+    StorageValDev<T> operator()(CollectionStorage<T, W2, M2> const& source)
     {
         static_assert(M2 == MemSpace::host,
                       "Can only assign by value from host to device");
 
-        CollectionStorage<T, Ownership::value, MemSpace::device> result{
-            DeviceVector<T>(source.data.size())};
+        StorageValDev<T> result{
+            typename StorageValDev<T>::type(source.data.size())};
         result.data.copy_to_device({source.data.data(), source.data.size()});
         return result;
     }

--- a/src/corecel/data/detail/DisabledStorage.hh
+++ b/src/corecel/data/detail/DisabledStorage.hh
@@ -35,6 +35,8 @@ class DisabledStorage
     using const_reference = T const&;
     using iterator = pointer;
     using const_iterator = const_pointer;
+    using SpanT = Span<T>;
+    using SpanConstT = Span<T const>;
     //!@}
   public:
     //!@{
@@ -56,6 +58,15 @@ class DisabledStorage
         CELER_ASSERT_UNREACHABLE();
         return nullptr;
     }
+    CELER_FORCEINLINE_FUNCTION void copy_to_device(SpanConstT)
+    {
+        CELER_ASSERT_UNREACHABLE();
+    }
+    CELER_FORCEINLINE_FUNCTION void copy_to_host(SpanT) const
+    {
+        CELER_ASSERT_UNREACHABLE();
+    }
+
     //!@}
 };
 

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -353,9 +353,12 @@ TEST_F(CollectionTest, TEST_IF_CELER_DEVICE(device))
     // Check that we can copy back to the device
     MockStateData<Ownership::value, MemSpace::host> host_states;
     resize(&host_states, 16);
+    device_states = copy_to_device_test(host_states);
+    EXPECT_EQ(16, device_states.size());
+    resize(&host_states, 8);
     auto host_state_ref = make_ref(host_states);
     device_states = copy_to_device_test(host_state_ref);
-    EXPECT_EQ(16, device_states.size());
+    EXPECT_EQ(8, device_states.size());
     MockStateData<Ownership::reference, MemSpace::device> device_state_ref;
     device_state_ref = copy_to_device_test(device_states);
 }

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -353,14 +353,22 @@ TEST_F(CollectionTest, TEST_IF_CELER_DEVICE(device))
     // Check that we can copy back to the device
     MockStateData<Ownership::value, MemSpace::host> host_states;
     resize(&host_states, 16);
-    device_states = copy_to_device_test(host_states);
+    ASSERT_NO_THROW(device_states = copy_to_device_test(host_states));
     EXPECT_EQ(16, device_states.size());
+
     resize(&host_states, 8);
     auto host_state_ref = make_ref(host_states);
-    device_states = copy_to_device_test(host_state_ref);
+    ASSERT_NO_THROW(device_states = copy_to_device_test(host_state_ref));
     EXPECT_EQ(8, device_states.size());
+
+    resize(&host_states, 4);
+    auto host_state_cref = make_ref(host_states);
+    ASSERT_NO_THROW(device_states = copy_to_device_test(host_state_cref));
+    EXPECT_EQ(4, device_states.size());
+
     MockStateData<Ownership::reference, MemSpace::device> device_state_ref;
-    device_state_ref = copy_to_device_test(device_states);
+    device_state_ref = reference_device_test(device_states);
+    EXPECT_EQ(4, device_state_ref.size());
 }
 //---------------------------------------------------------------------------//
 }  // namespace test

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -356,6 +356,8 @@ TEST_F(CollectionTest, TEST_IF_CELER_DEVICE(device))
     auto host_state_ref = make_ref(host_states);
     device_states = copy_to_device_test(host_state_ref);
     EXPECT_EQ(16, device_states.size());
+    MockStateData<Ownership::reference, MemSpace::device> device_state_ref;
+    device_state_ref = copy_to_device_test(device_states);
 }
 //---------------------------------------------------------------------------//
 }  // namespace test

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -356,11 +356,13 @@ TEST_F(CollectionTest, TEST_IF_CELER_DEVICE(device))
     ASSERT_NO_THROW(device_states = copy_to_device_test(host_states));
     EXPECT_EQ(16, device_states.size());
 
+    host_states = {};
     resize(&host_states, 8);
     auto host_state_ref = make_ref(host_states);
     ASSERT_NO_THROW(device_states = copy_to_device_test(host_state_ref));
     EXPECT_EQ(8, device_states.size());
 
+    host_states = {};
     resize(&host_states, 4);
     auto host_state_cref = make_ref(host_states);
     ASSERT_NO_THROW(device_states = copy_to_device_test(host_state_cref));

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -349,6 +349,13 @@ TEST_F(CollectionTest, TEST_IF_CELER_DEVICE(device))
     result.resize(6);
     double const expected_result[] = {2.2, 41, 0, 3.333333333333, 41, 0};
     EXPECT_VEC_SOFT_EQ(expected_result, result);
+
+    // Check that we can copy back to the device
+    MockStateData<Ownership::value, MemSpace::host> host_states;
+    resize(&host_states, 16);
+    auto host_state_ref = make_ref(host_states);
+    device_states = copy_to_device_test(host_state_ref);
+    EXPECT_EQ(16, device_states.size());
 }
 //---------------------------------------------------------------------------//
 }  // namespace test

--- a/test/corecel/data/Collection.test.cu
+++ b/test/corecel/data/Collection.test.cu
@@ -76,6 +76,15 @@ void col_cuda_test(CTestInput input)
                         input.result);
 }
 
+//! Test that we can copy inside .cu code
+MockStateData<Ownership::value, MemSpace::device> copy_to_device_test(
+    MockStateData<Ownership::const_reference, MemSpace::host> host_inp)
+{
+    MockStateData<Ownership::value, MemSpace::device> result;
+    result = host_inp;
+    return result;
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/corecel/data/Collection.test.cu
+++ b/test/corecel/data/Collection.test.cu
@@ -76,15 +76,25 @@ void col_cuda_test(CTestInput input)
                         input.result);
 }
 
+//! Test that we can make a device reference inside .cu code
+MockStateData<Ownership::reference, MemSpace::device> reference_device_test(
+    MockStateData<Ownership::value, MemSpace::device> &device_value)
+{
+    MockStateData<Ownership::reference, MemSpace::device> result;
+    result = device_value;
+    return result;
+}
+
+#if 0
 //! Test that we can copy inside .cu code
 MockStateData<Ownership::value, MemSpace::device> copy_to_device_test(
-    MockStateData<Ownership::const_reference, MemSpace::host> host_inp)
+    MockStateData<Ownership::const_reference, MemSpace::host> &host_inp)
 {
     MockStateData<Ownership::value, MemSpace::device> result;
     result = host_inp;
     return result;
 }
-
+#endif
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/corecel/data/Collection.test.cu
+++ b/test/corecel/data/Collection.test.cu
@@ -76,6 +76,16 @@ void col_cuda_test(CTestInput input)
                         input.result);
 }
 
+//! Test that we can copy inside .cu code
+template<Ownership W, MemSpace M>
+MockStateData<Ownership::value, MemSpace::device>
+copy_to_device_test(MockStateData<W, M>& inp)
+{
+    MockStateData<Ownership::value, MemSpace::device> result;
+    result = inp;
+    return result;
+}
+
 //! Test that we can make a device reference inside .cu code
 MockStateData<Ownership::reference, MemSpace::device> reference_device_test(
     MockStateData<Ownership::value, MemSpace::device> &device_value)
@@ -85,14 +95,16 @@ MockStateData<Ownership::reference, MemSpace::device> reference_device_test(
     return result;
 }
 
-//! Test that we can copy inside .cu code
-MockStateData<Ownership::value, MemSpace::device> copy_to_device_test(
-    MockStateData<Ownership::const_reference, MemSpace::host> &host_inp)
-{
-    MockStateData<Ownership::value, MemSpace::device> result;
-    result = host_inp;
-    return result;
-}
+template MockStateData<Ownership::value, MemSpace::device>
+copy_to_device_test<Ownership::value, MemSpace::host>(
+    MockStateData<Ownership::value, MemSpace::host>&);
+template MockStateData<Ownership::value, MemSpace::device>
+copy_to_device_test<Ownership::reference, MemSpace::host>(
+    MockStateData<Ownership::reference, MemSpace::host>&);
+template MockStateData<Ownership::value, MemSpace::device>
+copy_to_device_test<Ownership::const_reference, MemSpace::host>(
+    MockStateData<Ownership::const_reference, MemSpace::host>&);
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/corecel/data/Collection.test.cu
+++ b/test/corecel/data/Collection.test.cu
@@ -85,7 +85,6 @@ MockStateData<Ownership::reference, MemSpace::device> reference_device_test(
     return result;
 }
 
-#if 0
 //! Test that we can copy inside .cu code
 MockStateData<Ownership::value, MemSpace::device> copy_to_device_test(
     MockStateData<Ownership::const_reference, MemSpace::host> &host_inp)
@@ -94,7 +93,6 @@ MockStateData<Ownership::value, MemSpace::device> copy_to_device_test(
     result = host_inp;
     return result;
 }
-#endif
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/corecel/data/Collection.test.hh
+++ b/test/corecel/data/Collection.test.hh
@@ -151,8 +151,11 @@ struct CTestInput
 void col_cuda_test(CTestInput);
 
 //! Test that we can copy inside .cu code
-MockStateData<Ownership::value, MemSpace::device> copy_to_device_test(
-    MockStateData<Ownership::const_reference, MemSpace::host>);
+MockStateData<Ownership::value, MemSpace::device>
+copy_to_device_test(MockStateData<Ownership::const_reference, MemSpace::host>&);
+//! Test that we can make a reference inside of .cu code
+MockStateData<Ownership::reference, MemSpace::device>
+reference_device_test(MockStateData<Ownership::value, MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void col_cuda_test(CTestInput)
@@ -161,6 +164,11 @@ inline void col_cuda_test(CTestInput)
 }
 inline MockStateData<Ownership::value, MemSpace::device>
 copy_to_device_test(MockStateData<Ownership::value, MemSpace::host>&)
+{
+    CELER_NOT_CONFIGURED("CUDA or HIP");
+}
+inline MockStateData<Ownership::reference, MemSpace::device>
+reference_device_test(MockStateData<Ownership::value, MemSpace::device>&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/test/corecel/data/Collection.test.hh
+++ b/test/corecel/data/Collection.test.hh
@@ -151,8 +151,9 @@ struct CTestInput
 void col_cuda_test(CTestInput);
 
 //! Test that we can copy inside .cu code
+template<Ownership W, MemSpace M>
 MockStateData<Ownership::value, MemSpace::device>
-copy_to_device_test(MockStateData<Ownership::const_reference, MemSpace::host>&);
+copy_to_device_test(MockStateData<W, M>&);
 //! Test that we can make a reference inside of .cu code
 MockStateData<Ownership::reference, MemSpace::device>
 reference_device_test(MockStateData<Ownership::value, MemSpace::device>&);
@@ -162,8 +163,9 @@ inline void col_cuda_test(CTestInput)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }
+template<Ownership W, MemSpace M>
 inline MockStateData<Ownership::value, MemSpace::device>
-copy_to_device_test(MockStateData<Ownership::value, MemSpace::host>&)
+copy_to_device_test(MockStateData<W, M>&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/test/corecel/data/Collection.test.hh
+++ b/test/corecel/data/Collection.test.hh
@@ -150,8 +150,17 @@ struct CTestInput
 //! Run on device and return results
 void col_cuda_test(CTestInput);
 
+//! Test that we can copy inside .cu code
+MockStateData<Ownership::value, MemSpace::device> copy_to_device_test(
+    MockStateData<Ownership::const_reference, MemSpace::host>);
+
 #if !CELER_USE_DEVICE
 inline void col_cuda_test(CTestInput)
+{
+    CELER_NOT_CONFIGURED("CUDA or HIP");
+}
+inline MockStateData<Ownership::value, MemSpace::device>
+copy_to_device_test(MockStateData<Ownership::value, MemSpace::host>&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }


### PR DESCRIPTION
The Collection was designed to be manipulated from `.cc` files (and shallow views simply passed to `.cu`), but Shift/SCALE builds everything from inside `.cu` files.

This PR fixes #677 and adds tests so that future changes to the assert macros and collection implementation will still work with this downstream requirement.