### PR TITLE
Update the CMakePreset and env script for building on Zeus

### DIFF
--- a/scripts/cmake-presets/zeus.json
+++ b/scripts/cmake-presets/zeus.json
@@ -27,8 +27,7 @@
         "CMAKE_CXX_STANDARD": {"type": "STRING", "value": "17"},
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}",
-        "CMAKE_PREFIX_PATH": "/bld3/build/celeritas/geant4/geant4-v10.6.0-install/lib64;/bld3/build/celeritas/VecGeom/install-v1.1.20/lib64/cmake;/cvmfs/atlas-nightlies.cern.ch/repo/sw/master_Athena_x86_64-centos7-gcc11-opt/2023-02-13T2101/AthenaExternals/23.0.17/InstallArea/x86_64-centos7-gcc11-opt/lib/cmake;/cvmfs/sft.cern.ch/lcg/views/LCG_102b_ATLAS_11/x86_64-centos7-gcc11-opt/lib64/cmake;/cvmfs/sft.cern.ch/lcg/views/LCG_102b_ATLAS_11/x86_64-centos7-gcc11-opt/cmake",
-        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_CXX_COMPILER": "$env{CXX}",
         "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=cascadelake -mtune=cascadelake",
         "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"}
       }
@@ -41,7 +40,7 @@
     },
     {
       "name": "reldeb-novg",
-      "displayName": "Zeus release mode",
+      "displayName": "Zeus release with debug symbols and Orange",
       "inherits": [".reldeb", ".base"],
       "cacheVariables": {
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"}
@@ -49,12 +48,12 @@
     },
     {
       "name": "reldeb",
-      "displayName": "Zeus release mode",
+      "displayName": "Zeus release with debug symbols",
       "inherits": [".reldeb", ".base"]
     },
     {
       "name": "ndebug-novg",
-      "displayName": "Zeus release mode",
+      "displayName": "Zeus release with Orange",
       "inherits": [".ndebug", ".base"],
       "cacheVariables": {
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"}
@@ -62,7 +61,7 @@
     },
     {
       "name": "ndebug",
-      "displayName": "Zeus release mode",
+      "displayName": "Zeus release",
       "inherits": [".ndebug", ".base"]
     }
   ],

--- a/scripts/env/zeus.sh
+++ b/scripts/env/zeus.sh
@@ -1,13 +1,19 @@
 #!/bin/sh -e
 
-export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
-# we need to clear exit on unchecked error for atlasLocalSetup...
-set +e
-source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
-lsetup "views LCG_102b_ATLAS_11 x86_64-centos7-gcc11-opt"
-asetup none,gcc112,cmakesetup,siteroot=cvmfs
-set -e
+function _fail {
+    echo "$1" >&2
+    exit $2
+}
 
-# not in standard Atlas build env but we need it for cuda-enabled vecgeom
+celeritas_spack_env_name=celeritas
+
+if ! declare -fF spack > /dev/null; then
+    _fail "Expects spack shell support" 1
+elif [[ ! -d "${SPACK_ROOT}/var/spack/environments/${celeritas_spack_env_name}" ]]; then
+    _fail "Expects a spack environment named ${celeritas_spack_env_name}" 2
+fi
+
+module unload gcc
+source /cvmfs/sft.cern.ch/lcg/contrib/gcc/11.3.0/x86_64-centos7-gcc11-opt/setup.sh
 module load cuda/11.8.0
-source /bld3/build/celeritas/geant4/geant4-v10.6.0-install/bin/geant4.sh
+spack env activate ${celeritas_spack_env_name}


### PR DESCRIPTION
Updated Zeus config to build against Geant4 and Vecgeom from the spack env instead of using AtlasExternals.