### PR TITLE
Fail fast instead of giving wrong answers for multithreading

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -418,11 +418,9 @@ if(CELERITAS_BUILD_DEMOS AND CELERITAS_USE_Geant4)
     )
     if(Geant4_multithreaded_FOUND)
       list(APPEND _env
-        "G4FORCENUMBEROFTHREADS=2"
+        "G4FORCENUMBEROFTHREADS=1"
+        "G4FORCE_RUN_MANAGER_TYPE=Serial"
       )
-    endif()
-    if(CELERITAS_USE_OpenMP)
-      list(APPEND _env "OMP_NUM_THREADS=1")
     endif()
     set_tests_properties("app/demo-geant-integration" PROPERTIES
       ENVIRONMENT "${_env}"

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -184,6 +184,7 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
     CELER_ASSERT(!navi_ || !out.points[StepPoint::pre].dir.empty());
 
     CELER_LOG_LOCAL(debug) << "Processing " << out.size() << " hits";
+    step_->ResetTotalEnergyDeposit();
 
     for (auto i : range(out.size()))
     {
@@ -192,6 +193,7 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
     {                                                \
         if (!OUT.empty())                            \
         {                                            \
+            CELER_ASSERT(i < OUT.size());            \
             SETTER(convert_to_geant(OUT[i], UNITS)); \
         }                                            \
     } while (0)

--- a/src/celeritas/user/DetectorSteps.cc
+++ b/src/celeritas/user/DetectorSteps.cc
@@ -107,6 +107,13 @@ void copy_steps<MemSpace::host>(
     DS_ASSIGN(particle);
     DS_ASSIGN(energy_deposition);
 #undef DS_ASSIGN
+    for (ThreadId tid : range(ThreadId{state.energy_deposition.size()}))
+    {
+        if (state.detector[tid])
+        {
+            CELER_ASSERT(state.energy_deposition[tid] >= zero_quantity());
+        }
+    }
 
     CELER_ENSURE(output->detector.size() == size);
     CELER_ENSURE(output->track_id.size() == size);

--- a/src/celeritas/user/detail/StepGatherAction.cc
+++ b/src/celeritas/user/detail/StepGatherAction.cc
@@ -69,6 +69,16 @@ void StepGatherAction<P>::execute(CoreHostRef const& core) const
     // creating/accessing/processing state data simultaneously
     std::lock_guard<std::mutex> scoped_lock{storage_->mumu};
 
+    auto this_thread_id = std::this_thread::get_id();
+    if (P == StepPoint::pre)
+    {
+        storage_->pre_id = this_thread_id;
+    }
+    else if (storage_->pre_id != this_thread_id)
+    {
+        CELER_NOT_IMPLEMENTED("multithreading for StepCollector");
+    }
+
     auto const& step_state = this->get_state(core);
     CELER_ASSERT(step_state.size() == core.states.size());
 

--- a/src/celeritas/user/detail/StepStorage.hh
+++ b/src/celeritas/user/detail/StepStorage.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <mutex>
+#include <thread>
 #include <type_traits>
 
 #include "corecel/data/CollectionMirror.hh"
@@ -36,6 +37,8 @@ struct StepStorage
 
     // Mutex to prevent multiple CPU threads from writing simultaneously
     mutable std::mutex mumu;
+    // For checking that pre/post aren't stepping on each other
+    mutable std::thread::id pre_id;
 
     // Parameter data
     CollectionMirror<StepParamsData> params;


### PR DESCRIPTION
Version 0.2 likely won't support multithreading as it would require enhancements to the core. This PR simply adds assertions so that we don't generate wrong answers when running the older version in multithreading mode.