### PR TITLE
Give different streams unique RNG seeds

### DIFF
--- a/app/demo-interactor/KNDemoRunner.cc
+++ b/app/demo-interactor/KNDemoRunner.cc
@@ -71,7 +71,7 @@ auto KNDemoRunner::operator()(KNDemoRunArgs args) -> result_type
 
     RngParams rng_params(args.seed);
     RngStateData<Ownership::value, MemSpace::device> rng_states;
-    resize(&rng_states, rng_params.host_ref(), args.num_tracks);
+    resize(&rng_states, rng_params.host_ref(), StreamId{0}, args.num_tracks);
 
     // Secondary data
     StackAllocatorData<Secondary, Ownership::value, MemSpace::device> secondaries;

--- a/src/celeritas/global/CoreTrackData.cc
+++ b/src/celeritas/global/CoreTrackData.cc
@@ -32,7 +32,7 @@ void resize(CoreStateData<Ownership::value, M>* state,
     resize(&state->materials, params.materials, size);
     resize(&state->particles, params.particles, size);
     resize(&state->physics, params.physics, size);
-    resize(&state->rng, params.rng, size);
+    resize(&state->rng, params.rng, stream_id, size);
     resize(&state->sim, size);
     resize(&state->init, params.init, size);
     resize(&state->track_slots, size);

--- a/src/celeritas/random/CuHipRngData.cc
+++ b/src/celeritas/random/CuHipRngData.cc
@@ -24,15 +24,17 @@ namespace celeritas
 template<MemSpace M>
 void resize(CuHipRngStateData<Ownership::value, M>* state,
             HostCRef<CuHipRngParamsData> const& params,
+            StreamId stream,
             size_type size)
 {
+    CELER_EXPECT(stream);
     CELER_EXPECT(size > 0);
     CELER_EXPECT(M == MemSpace::host || celeritas::device());
 
     using RngInit = CuHipRngInitializer;
 
     // Host-side RNG for creating seeds
-    std::mt19937 host_rng(params.seed);
+    std::mt19937 host_rng(params.seed + stream.get());
     std::uniform_int_distribution<ull_int> sample_uniform_int;
 
     // Create seeds for device in host memory
@@ -54,10 +56,12 @@ void resize(CuHipRngStateData<Ownership::value, M>* state,
 // Explicit instantiations
 template void resize(HostVal<CuHipRngStateData>*,
                      HostCRef<CuHipRngParamsData> const&,
+                     StreamId,
                      size_type);
 
 template void resize(CuHipRngStateData<Ownership::value, MemSpace::device>*,
                      HostCRef<CuHipRngParamsData> const&,
+                     StreamId,
                      size_type);
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/random/CuHipRngData.hh
+++ b/src/celeritas/random/CuHipRngData.hh
@@ -147,6 +147,7 @@ struct CuHipRngStateData
 template<MemSpace M>
 void resize(CuHipRngStateData<Ownership::value, M>* state,
             HostCRef<CuHipRngParamsData> const& params,
+            StreamId stream,
             size_type size);
 
 }  // namespace celeritas

--- a/src/celeritas/random/XorwowRngData.hh
+++ b/src/celeritas/random/XorwowRngData.hh
@@ -103,6 +103,7 @@ struct XorwowRngStateData
 template<MemSpace M>
 void resize(XorwowRngStateData<Ownership::value, M>* state,
             HostCRef<XorwowRngParamsData> const& params,
+            StreamId stream,
             size_type size);
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/geo/HeuristicGeoData.hh
+++ b/test/celeritas/geo/HeuristicGeoData.hh
@@ -126,7 +126,7 @@ inline void resize(HeuristicGeoStateData<Ownership::value, M>* state,
     CELER_EXPECT(params);
     CELER_EXPECT(size > 0);
     resize(&state->geometry, params.geometry, size);
-    resize(&state->rng, params.rng, size);
+    resize(&state->rng, params.rng, StreamId{0}, size);
     resize(&state->status, size);
     fill(LifeStatus::unborn, &state->status);
 

--- a/test/celeritas/random/RngEngine.test.cc
+++ b/test/celeritas/random/RngEngine.test.cc
@@ -174,7 +174,7 @@ class DeviceRngEngineTest : public Test
 TEST_F(DeviceRngEngineTest, TEST_IF_CELER_DEVICE(device))
 {
     // Create and initialize states
-    RngDeviceStore rng_store(params->host_ref(), 1024);
+    RngDeviceStore rng_store(params->host_ref(), StreamId{0}, 1024);
 
     // Generate on device
     std::vector<unsigned int> values = re_test_native(rng_store.ref());
@@ -279,7 +279,7 @@ TYPED_TEST(DeviceRngEngineFloatTest, DISABLED_device)
     using real_type = TypeParam;
 
     // Create and initialize states
-    RngDeviceStore rng_store(this->params->host_ref(), 100);
+    RngDeviceStore rng_store(this->params->host_ref(), StreamId{0}, 100);
 
     // Generate on device
     auto values = re_test_canonical<real_type>(rng_store.ref());


### PR DESCRIPTION
Currently the RNG state only has the global "seed" to initialize, so every independent RNG state instance ends up with the same RNG sequence. With this change, the StreamId is used to modify the seed that sets the RNG states.