### PR TITLE
Fix a few edge cases in field propagation

### DIFF
--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -275,7 +275,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
 
     // Flag track as looping if the max number of substeps was reached without
     // hitting a boundary or moving the full step length
-    if (remaining_substeps == 0)
+    if (remaining_substeps == 0 && result.distance < step)
     {
         result.looping = true;
     }

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -260,7 +260,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // to the extra delta_intersection boost when searching. The
             // substep itself can be more than the requested step.
             result.distance += celeritas::min(update_length, substep.step);
-            CELER_ASSERT(result.distance <= step);
             state_.mom = substep.state.mom;
             remaining = 0;
         }

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -272,20 +272,31 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         }
     } while (remaining >= driver_.minimum_step() && remaining_substeps > 0);
 
-    // Flag track as looping if the max number of substeps was reached without
-    // hitting a boundary or moving the full step length
     if (remaining_substeps == 0 && result.distance < step)
     {
+        // Flag track as looping if the max number of substeps was reached
+        // without hitting a boundary or moving the full step length
         result.looping = true;
     }
-
-    if (result.boundary && result.distance > 0)
+    else if (result.distance > 0)
     {
-        // We moved to a new boundary. Update the position to reflect the
-        // geometry's state (and possibly "bump" the ODE state's position
-        // because of the tolerance in the intercept checks above).
-        geo_.move_to_boundary();
-        state_.pos = geo_.pos();
+        if (result.boundary)
+        {
+            // We moved to a new boundary. Update the position to reflect the
+            // geometry's state (and possibly "bump" the ODE state's position
+            // because of the tolerance in the intercept checks above).
+            geo_.move_to_boundary();
+            state_.pos = geo_.pos();
+        }
+        else if (CELER_UNLIKELY(result.distance < step))
+        {
+            // Even though the track traveled the full step length, the
+            // distance might be slightly less than the step due to roundoff
+            // error. Reset the distance so the track's action isn't
+            // erroneously set as propagation-limited.
+            CELER_ASSERT(soft_equal(result.distance, step));
+            result.distance = step;
+        }
     }
 
     // Even though the along-substep movement was through chord lengths,


### PR DESCRIPTION
### Don't flag a track as looping in the `FieldPropagator` if it moves the full step length in exactly `max_substeps` iterations ([add20c1](https://github.com/celeritas-project/celeritas/commit/add20c1778c45c2f47da6d468e5b49b420065f87))  
In rare cases a track might move the full step length in exactly `max_substep` iterations: if this happens we shouldn't mark the track as looping. This showed up as an assertion failure in cms2018 because the track traveled the full step length but had a propagation-limit action:
```json
{"exception":{"condition":"mfp > 0","context":{"dir":[-0.6708090450876616,0.6791981437773759,0.2978340251179283],"energy":[0.3844323920705494,"MeV"],"event":6,"label":"along-step-uniform-msc","num_steps":4,"parent":149561,"particle":1,"pos":[-67.16439207220591,162.36017199988802,280.4362872022029],"thread":487,"track":187151,"track_slot":487,"type":"KernelContextException","volume":3085},"file":"/home/alund/celeritas_project/celeritas/src/celeritas/global/alongstep/AlongStep.hh","line":194,"type":"DebugError","which":"internal assertion failed"}} 
```
<details><summary>JSON input</summary><pre>

```json
{
"brem_combined": false,
"enable_diagnostics": false,
"geant_options": {
"coulomb_scattering": false,
"eloss_fluctuation": false,
"em_bins_per_decade": 56,
"lpm": true,
"msc": "none",
"physics": "em_basic",
"rayleigh_scattering": true
},
"geometry_filename": "/home/alund/celeritas_project/regression/input/cms2018.gdml",
"hepmc3_filename": "/home/alund/celeritas_project/regression/input/simple-cms-13TeV.hepmc3",
"initializer_capacity": 1048576,
"mag_field": [
0.0,
0.0,
1.0
],
"max_events": 7,
"max_num_tracks": 4096,
"max_steps": 2097152,
"physics_filename": "/home/alund/celeritas_project/regression/input/cms2018.gdml",
"secondary_stack_factor": 3.0,
"seed": 20220904,
"sync": true,
"use_device": false
}
```

</pre></details>

### Remove assertion that can fail if the distance is slightly larger than the step due to roundoff error ([81cda7e](https://github.com/celeritas-project/celeritas/commit/81cda7e5a16d654db908ea0adf30335479772659))
I think it's ok to just remove this assertion since we have a check for soft equality later and the step length if only updated in along-step if it's propagation-limited.

### Make sure the correct action is set when a track moves the full step length without hitting a boundary ([8791028](https://github.com/celeritas-project/celeritas/commit/87910284a8481fab1a3c989a66107ee39db04d3d))
Sometimes the distance can be slightly less than the step length due to floating point error, for example:
```
remaining: 5.55111512312578270e-17, step: 3.09233404301630765e-01, distance: 3.09233404301630710e-01
remaining: 2.77555756156289135e-17, step: 2.19243279594166257e-01, distance: 2.19243279594166229e-01
remaining: 2.22044604925031308e-16, step: 1.98418319692290246e+00, distance: 1.98418319692290224e+00
remaining: 1.11022302462515654e-16, step: 8.74020671716127517e-01, distance: 8.74020671716127406e-01
remaining: 2.77555756156289135e-17, step: 2.44285196785915065e-01, distance: 2.44285196785915037e-01
remaining: 1.11022302462515654e-16, step: 9.16796592221665096e-01, distance: 9.16796592221664985e-01
remaining: 2.77555756156289135e-17, step: 2.44488077762943151e-01, distance: 2.44488077762943123e-01
remaining: 5.55111512312578270e-17, step: 4.59467957691895801e-01, distance: 4.59467957691895745e-01
```
If this happens, set the distance equal to the step so the track does not incorrectly get assigned a propagation-limit action. This showed up in cms2018 with the assertion failure:
```json
{"exception":{"condition":"mfp > 0","context":{"dir":[-0.07150787935933586,0.8015819379736278,-0.5935933118760468],"energy":[5.112515390156163,"MeV"],"event":0,"label":"along-step-uniform-msc","num_steps":20,"parent":900821,"particle":1,"pos":[10.98609865041482,-78.63496251369277,-102.29220396745521],"thread":2660,"track":11912046,"track_slot":2660,"type":"KernelContextException","volume":1783},"file":"/home/alund/celeritas_project/celeritas/src/celeritas/global/alongstep/AlongStep.hh","line":194,"type":"DebugError","which":"internal assertion failed"}}
```
<details><summary>JSON input</summary><pre>

```json
{
"brem_combined": false,
"enable_diagnostics": false,
"geant_options": {
"coulomb_scattering": false,
"eloss_fluctuation": false,
"em_bins_per_decade": 56,
"lpm": true,
"msc": "none",
"physics": "em_basic",
"rayleigh_scattering": true
},
"geometry_filename": "/home/alund/celeritas_project/regression/input/cms2018.gdml",
"hepmc3_filename": "/home/alund/celeritas_project/regression/input/simple-cms-13TeV.hepmc3",
"initializer_capacity": 1048576,
"mag_field": [
0.0,
0.0,
1.0
],
"max_events": 7,
"max_num_tracks": 4096,
"max_steps": 2097152,
"physics_filename": "/home/alund/celeritas_project/regression/input/cms2018.gdml",
"secondary_stack_factor": 3.0,
"seed": 20220905,
"sync": true,
"use_device": false
}
```

</pre></details>

I could add a minimal test for [81cda7e](https://github.com/celeritas-project/celeritas/commit/81cda7e5a16d654db908ea0adf30335479772659), but the other two I only hit in cms2018, so I'm not sure how easy it would be to replicate those failures with our simple test geometries.