### PR TITLE
Define SimpleOffload for dead-simple Geant4 integration

### DIFF
--- a/doc/api/accel.rst
+++ b/doc/api/accel.rst
@@ -8,34 +8,54 @@ Acceleritas
 ===========
 
 The ``accel`` directory contains components exclusive to coupling Celeritas
-with Geant4 for user-oriented integration. See the
-:file:`app/demo-geant-integration` for a complete example of how to use
-Celeritas to offload EM tracks to GPU and dispatch hits back to Geant4
-sensitive detectors.
+with Geant4 for user-oriented integration. See :ref:`example_geant_full` for a
+detailed example of how to use Celeritas to offload EM tracks to GPU and
+dispatch hits back to Geant4 sensitive detectors. The simpler interface for
+multithreaded or serial applications is demonstrated in
+:ref:`example_geant_minimal`.
 
-Utilities
-------------
+High-level interface
+--------------------
 
-.. doxygenfunction:: celeritas::MakeMTLogger
+The SimpleOffload class is an extremely easy-to-use interface for
+offloading tracks to Celeritas in a multithreaded or serial application. The
+class names correspond to user actions and ActionInitialization. It requires a
+few app-owned pieces such as SharedParams and LocalTransporter to be owned by
+the calling application; the options described below must also be set up and
+provided.
 
-.. doxygenclass:: celeritas::ExceptionConverter
+.. doxygenclass:: celeritas::SimpleOffload
 
-Setup
------
+Celeritas setup
+---------------
+
+The setup options help translate the Geant4 physics and problem setup to
+Celeritas. They are also necessary to set up the GPU offloading
+characteristics. Future versions of Celeritas will automate more of these
+settings.
 
 .. doxygenstruct:: celeritas::SetupOptions
 
 .. doxygenstruct:: celeritas::SDSetupOptions
 
-.. doxygenclass:: celeritas::AlongStepFactoryInterface
-
 .. doxygenclass:: celeritas::UniformAlongStepFactory
 
-Transport interface
--------------------
+Detailed interface
+------------------
 
-These classes are usually integrated into UserActions.
+These classes are usually integrated into UserActions. The ``SimpleOffload``
+interface above hides the complexity of these classes, or for more complex
+applications you can choose to use these classes directly instead of it.
 
 .. doxygenclass:: celeritas::SharedParams
 
 .. doxygenclass:: celeritas::LocalTransporter
+
+Interface utilities
+-------------------
+
+.. doxygenfunction:: celeritas::MakeMTLogger
+
+.. doxygenclass:: celeritas::ExceptionConverter
+
+.. doxygenclass:: celeritas::AlongStepFactoryInterface

--- a/doc/examples/geant4-minimal.rst
+++ b/doc/examples/geant4-minimal.rst
@@ -2,11 +2,17 @@
 .. See the doc/COPYRIGHT file for details.
 .. SPDX-License-Identifier: CC-BY-4.0
 
+.. _example_geant_minimal:
 
 Minimal Geant4 integration
 ==========================
 
-This small example demonstrates how to offload tracks to Celeritas.
+This small example demonstrates how to offload tracks to Celeritas in a serial
+or multithreaded environment. The :ref:`accel` library is the only part of
+Celeritas that needs to be understood for it to work. The key components are
+global SetupOptions and SharedParams, coupled to thread-local SimpleOffload and
+LocalTransporter. The SimpleOffload provides all the methods needed to
+integrate into Geant4 application's UserActions.
 
 .. _example_cmake:
 

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND SOURCES
   Logger.cc
   LocalTransporter.cc
   SharedParams.cc
+  SimpleOffload.cc
   detail/HitManager.cc
   detail/HitProcessor.cc
 )

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -12,6 +12,7 @@
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <G4ParticleDefinition.hh>
 #include <G4ThreeVector.hh>
+#include <G4Track.hh>
 
 #include "corecel/cont/Span.hh"
 #include "corecel/io/Logger.hh"

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -84,24 +84,12 @@ void LocalTransporter::SetEventId(int id)
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether Celeritas supports offloading of this track.
- */
-bool LocalTransporter::IsApplicable(G4Track const& g4track) const
-{
-    CELER_EXPECT(*this);
-    PDGNumber pdg{g4track.GetDefinition()->GetPDGEncoding()};
-    return static_cast<bool>(particles_->find(pdg));
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Convert a Geant4 track to a Celeritas primary and add to buffer.
  */
 void LocalTransporter::Push(G4Track const& g4track)
 {
     CELER_EXPECT(*this);
     CELER_EXPECT(event_id_);
-    CELER_EXPECT(this->IsApplicable(g4track));
 
     using detail::convert_from_geant;
 
@@ -111,6 +99,11 @@ void LocalTransporter::Push(G4Track const& g4track)
         PDGNumber{g4track.GetDefinition()->GetPDGEncoding()});
     track.energy = units::MevEnergy{
         convert_from_geant(g4track.GetKineticEnergy(), CLHEP::MeV)};
+
+    CELER_VALIDATE(track.particle_id,
+                   << "cannot offload '"
+                   << g4track.GetDefinition()->GetParticleName()
+                   << "' particles");
 
     track.position = convert_from_geant(g4track.GetPosition(), CLHEP::cm);
     track.direction = convert_from_geant(g4track.GetMomentumDirection(), 1);

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -39,7 +39,10 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
     , max_steps_(options.max_steps)
     , hit_manager_{params.hit_manager()}
 {
-    CELER_EXPECT(params);
+    CELER_VALIDATE(params,
+                   << "Celeritas SharedParams was not initialized before "
+                      "constructing LocalTransporter (perhaps the master "
+                      "thread did not call BeginOfRunAction?");
     particles_ = params.Params()->particle();
 
     // Thread ID is -1 when running serially

--- a/src/accel/LocalTransporter.hh
+++ b/src/accel/LocalTransporter.hh
@@ -9,7 +9,6 @@
 
 #include <memory>
 #include <vector>
-#include <G4Track.hh>
 
 #include "corecel/Types.hh"
 #include "corecel/cont/InitializedValue.hh"
@@ -18,6 +17,8 @@
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/Stepper.hh"
 #include "celeritas/phys/Primary.hh"
+
+class G4Track;
 
 namespace celeritas
 {
@@ -55,9 +56,6 @@ class LocalTransporter
 
     // Set the event ID
     void SetEventId(int);
-
-    // Whether Celeritas supports offloading of this track
-    bool IsApplicable(G4Track const&) const;
 
     // Offload this track
     void Push(G4Track const&);

--- a/src/accel/Logger.cc
+++ b/src/accel/Logger.cc
@@ -8,7 +8,6 @@
 #include "Logger.hh"
 
 #include <algorithm>
-#include <atomic>
 #include <functional>
 #include <mutex>
 #include <string>

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -92,7 +92,7 @@ struct SetupOptions
     //! Maximum number of track initializers (primaries+secondaries)
     size_type initializer_capacity{};
     //! At least the average number of secondaries per track slot
-    real_type secondary_stack_factor{};
+    real_type secondary_stack_factor{3.0};
     //! Sync the GPU at every kernel for error checking
     bool sync{false};
     //!@}

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -13,10 +13,10 @@
 #include <utility>
 #include <vector>
 #include <CLHEP/Random/Random.h>
-#include <G4RunManager.hh>
-#include <G4Threading.hh>
 #include <G4ParticleDefinition.hh>
 #include <G4ParticleTable.hh>
+#include <G4RunManager.hh>
+#include <G4Threading.hh>
 
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -129,7 +129,8 @@ build_g4_particles(std::shared_ptr<ParticleParams const> const& particles,
         if (phys->processes(par_id).empty())
         {
             CELER_LOG(warning)
-                << "Not offloading particle '" << particles->label(par_id)
+                << "Not offloading particle '"
+                << particles->id_to_label(par_id)
                 << "' because it has no physics processes defined";
             continue;
         }

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -131,7 +131,7 @@ auto SharedParams::Params() const -> SPConstParams
  *
  * This can only be called after \c Initialize.
  */
-auto SharedParams::OffloadParticles() const -> VecG4ParticleDef
+auto SharedParams::OffloadParticles() const -> VecG4ParticleDef const&
 {
     CELER_EXPECT(*this);
     return particles_;

--- a/src/accel/SimpleOffload.cc
+++ b/src/accel/SimpleOffload.cc
@@ -38,25 +38,24 @@ SimpleOffload::SimpleOffload(SetupOptions const* setup,
                  == (G4Threading::IsWorkerThread()
                      || !G4Threading::IsMultithreadedApplication()));
 
-    if (!celeritas::getenv("CELER_DISABLE").empty())
-    {
-        CELER_LOG(info)
-            << "Disabling Celeritas offloading since the 'CELER_DISABLE' "
-               "environment variable is present and non-empty";
-        *this = {};
-        CELER_ENSURE(!*this);
-    }
-    else if (G4Threading::IsMasterThread())
+    if (G4Threading::IsMasterThread())
     {
         if (auto* run_man = G4RunManager::GetRunManager())
         {
             // Initialize multithread logger if run manager exists
             celeritas::self_logger() = celeritas::MakeMTLogger(*run_man);
-
-            CELER_LOG(debug)
-                << "Run manager type: "
-                << celeritas::TypeDemangler<G4RunManager>{}(*run_man);
         }
+    }
+    if (!celeritas::getenv("CELER_DISABLE").empty())
+    {
+        using LL = celeritas::LogLevel;
+        celeritas::self_logger()(CELER_CODE_PROVENANCE,
+                                 G4Threading::IsMasterThread() ? LL::info
+                                                               : LL::debug)
+            << "Disabling Celeritas offloading since the 'CELER_DISABLE' "
+               "environment variable is present and non-empty";
+        *this = {};
+        CELER_ENSURE(!*this);
     }
 }
 

--- a/src/accel/SimpleOffload.cc
+++ b/src/accel/SimpleOffload.cc
@@ -1,0 +1,164 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/SimpleOffload.cc
+//---------------------------------------------------------------------------//
+#include "SimpleOffload.hh"
+
+#include <G4RunManager.hh>
+
+#include "corecel/io/Logger.hh"
+#include "corecel/sys/Environment.hh"
+#include "corecel/sys/TypeDemangler.hh"
+
+#include "ExceptionConverter.hh"
+#include "LocalTransporter.hh"
+#include "Logger.hh"
+#include "SharedParams.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a reference to shared params and local data.
+ *
+ * On construction, this will check for the \c CELER_DISABLE variable and
+ * disable offloading if set. Otherwise it will initialize the multithread
+ * logging if the run manager is initialized.
+ */
+SimpleOffload::SimpleOffload(SetupOptions const* setup,
+                             SharedParams* params,
+                             LocalTransporter* local)
+    : setup_(setup), params_(params), local_(local)
+{
+    CELER_EXPECT(setup_ && params_);
+    CELER_EXPECT((local_ != nullptr)
+                 == (G4Threading::IsWorkerThread()
+                     || !G4Threading::IsMultithreadedApplication()));
+
+    if (!celeritas::getenv("CELER_DISABLE").empty())
+    {
+        CELER_LOG(info)
+            << "Disabling Celeritas offloading since the 'CELER_DISABLE' "
+               "environment variable is present and non-empty";
+        *this = {};
+        CELER_ENSURE(!*this);
+    }
+    else if (G4Threading::IsMasterThread())
+    {
+        if (auto* run_man = G4RunManager::GetRunManager())
+        {
+            // Initialize multithread logger if run manager exists
+            celeritas::self_logger() = celeritas::MakeMTLogger(*run_man);
+
+            CELER_LOG(debug)
+                << "Run manager type: "
+                << celeritas::TypeDemangler<G4RunManager>{}(*run_man);
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Initialize celeritas data from setup options.
+ */
+void SimpleOffload::BeginOfRunAction(G4Run const*)
+{
+    if (!*this)
+        return;
+
+    ExceptionConverter call_g4exception{"celer0001"};
+
+    if (G4Threading::IsMasterThread())
+    {
+        CELER_TRY_HANDLE(params_->Initialize(*setup_), call_g4exception);
+    }
+    else
+    {
+        CELER_TRY_HANDLE(celeritas::SharedParams::InitializeWorker(*setup_),
+                         call_g4exception);
+    }
+
+    if (local_)
+    {
+        CELER_LOG_LOCAL(status) << "Constructing local state";
+        CELER_TRY_HANDLE(local_->Initialize(*setup_, *params_),
+                         call_g4exception);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Send Celeritas the event ID.
+ */
+void SimpleOffload::BeginOfEventAction(G4Event const* event)
+{
+    if (!*this)
+        return;
+
+    // Set event ID in local transporter
+    ExceptionConverter call_g4exception{"celer0002"};
+    CELER_TRY_HANDLE(local_->SetEventId(event->GetEventID()), call_g4exception);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Send tracks to Celeritas if applicable and "StopAndKill" if so.
+ */
+void SimpleOffload::PreUserTrackingAction(G4Track* track)
+{
+    if (!*this)
+        return;
+
+    if (std::find(params_->OffloadParticles().begin(),
+                  params_->OffloadParticles().end(),
+                  track->GetDefinition())
+        != params_->OffloadParticles().end())
+    {
+        // Celeritas is transporting this track
+        ExceptionConverter call_g4exception{"celer0003"};
+        CELER_TRY_HANDLE(local_->Push(*track), call_g4exception);
+        track->SetTrackStatus(fStopAndKill);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Flush offloaded tracks from Celeritas.
+ */
+void SimpleOffload::EndOfEventAction(G4Event const*)
+{
+    if (!*this)
+        return;
+
+    ExceptionConverter call_g4exception{"celer0004"};
+    CELER_TRY_HANDLE(local_->Flush(), call_g4exception);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Finalize Celeritas.
+ */
+void SimpleOffload::EndOfRunAction(G4Run const*)
+{
+    if (!*this)
+        return;
+
+    CELER_LOG_LOCAL(status) << "Finalizing Celeritas";
+    ExceptionConverter call_g4exception{"celer0005"};
+
+    if (local_)
+    {
+        CELER_TRY_HANDLE(local_->Finalize(), call_g4exception);
+    }
+
+    if (G4Threading::IsMasterThread())
+    {
+        CELER_TRY_HANDLE(params_->Finalize(), call_g4exception);
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/accel/SimpleOffload.hh
+++ b/src/accel/SimpleOffload.hh
@@ -51,7 +51,7 @@ class SimpleOffload
         *this = {setup, params, local};
     }
 
-    //! Lazy initialization of this class (master thread)
+    //! Lazy initialization of this class on the master thread
     void BuildForMaster(SetupOptions const* setup, SharedParams* params)
     {
         *this = {setup, params, nullptr};

--- a/src/accel/SimpleOffload.hh
+++ b/src/accel/SimpleOffload.hh
@@ -1,0 +1,85 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/SimpleOffload.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+class G4Run;
+class G4Event;
+class G4Track;
+
+namespace celeritas
+{
+class SharedParams;
+struct SetupOptions;
+class LocalTransporter;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Compressed interface for running Celeritas in a multithread Geant4 app.
+ *
+ * This class *must* be a thread-local instance with references to data that
+ * exceed the lifetime of the class: e.g. SharedParams can be a global
+ * variable, and LocalTransporter can be a global variable with \c thread_local
+ * storage duration.
+ *
+ * The \c CELER_DISABLE environment variable, if set and non-empty, will
+ * disable offloading so that Celeritas will not be built nor kill tracks.
+ *
+ * The method names correspond to methods in Geant4 User Actions and *must* be
+ * called from all threads, both worker and master.
+ */
+class SimpleOffload
+{
+  public:
+    //! Construct with celeritas disabled
+    SimpleOffload() = default;
+
+    // Construct from a reference to shared params and local data
+    SimpleOffload(SetupOptions const* setup,
+                  SharedParams* params,
+                  LocalTransporter* local);
+
+    //! Lazy initialization of this class on a worker thread
+    void Build(SetupOptions const* setup,
+               SharedParams* params,
+               LocalTransporter* local)
+    {
+        *this = {setup, params, local};
+    }
+
+    //! Lazy initialization of this class (master thread)
+    void BuildForMaster(SetupOptions const* setup, SharedParams* params)
+    {
+        *this = {setup, params, nullptr};
+    }
+
+    // Initialize celeritas data from setup options
+    void BeginOfRunAction(G4Run const* run);
+
+    // Send Celeritas the event ID
+    void BeginOfEventAction(G4Event const* event);
+
+    // Send tracks to Celeritas if applicable and "StopAndKill" if so
+    void PreUserTrackingAction(G4Track* track);
+
+    // Flush offloaded tracks from Celeritas
+    void EndOfEventAction(G4Event const* event);
+
+    // Finalize
+    void EndOfRunAction(G4Run const* run);
+
+    //! Whether offloading is enabled
+    explicit operator bool() const { return setup_ != nullptr; }
+
+  private:
+    SetupOptions const* setup_{nullptr};
+    SharedParams* params_{nullptr};
+    LocalTransporter* local_{nullptr};
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/io/Logger.hh
+++ b/src/corecel/io/Logger.hh
@@ -18,6 +18,13 @@
 //---------------------------------------------------------------------------//
 // MACROS
 //---------------------------------------------------------------------------//
+//! Inject the source code provenance (current file and line)
+#define CELER_CODE_PROVENANCE \
+    ::celeritas::Provenance   \
+    {                         \
+        __FILE__, __LINE__    \
+    }
+
 /*!
  * \def CELER_LOG
  *
@@ -34,8 +41,8 @@
  CELER_LOG(critical) << "Caught a fatal exception: " << e.what();
  * \endcode
  */
-#define CELER_LOG(LEVEL)                              \
-    ::celeritas::world_logger()({__FILE__, __LINE__}, \
+#define CELER_LOG(LEVEL)                               \
+    ::celeritas::world_logger()(CELER_CODE_PROVENANCE, \
                                 ::celeritas::LogLevel::LEVEL)
 
 //---------------------------------------------------------------------------//
@@ -45,8 +52,8 @@
  * Like \c CELER_LOG but for code paths that may only happen on a single
  * process. Use sparingly.
  */
-#define CELER_LOG_LOCAL(LEVEL)                       \
-    ::celeritas::self_logger()({__FILE__, __LINE__}, \
+#define CELER_LOG_LOCAL(LEVEL)                        \
+    ::celeritas::self_logger()(CELER_CODE_PROVENANCE, \
                                ::celeritas::LogLevel::LEVEL)
 
 namespace celeritas


### PR DESCRIPTION
This replaces the multithreading boilerplate repeated across the HGCal, ATLAS TileCal, and example/geant-minimal apps as an optional super-high-level interface to Celeritas from Geant4. It's probably not useful for CMS but will enable trivially easy integration for generic user applications.