### PR TITLE
Extend Urban MSC to high energy by default

### DIFF
--- a/doc/_static/ornltm-header-celeritas.tex
+++ b/doc/_static/ornltm-header-celeritas.tex
@@ -2,18 +2,20 @@
 
 \author{Seth R.~Johnson
 \and Philippe Canal (FNAL)
+\and Julien Esseiva (LBNL)
 \and Thomas M.~Evans
 \and Soon Yung Jun (FNAL)
 \and Guilherme Lima (FNAL)
 \and Amanda Lund (ANL)
 \and Paul Romano (ANL)
 \and Stefano C.~Tognini
+\and Ben Morgan (Univeristy of Warwick)
 }
 \title{Celeritas User Manual}
-\date{Dec.~2022}
-\reportnum{ORNL/TM-2022/XXXX}
+\date{Jul.~2023}
+\reportnum{ORNL/TM-2023/XXXX}
 \reportdraft
-\division{Nuclear Energy and Fuel Cycle Division}
+\division{Computational Sciences and Engineering Division}
 
 \begin{document}
 \frontmatter

--- a/doc/api/celeritas.rst
+++ b/doc/api/celeritas.rst
@@ -178,17 +178,11 @@ Physics properties
    :undoc-members:
 
 .. doxygenenum:: ImportProcessType
-   :undoc-members:
 .. doxygenenum:: ImportProcessClass
-   :undoc-members:
 .. doxygenenum:: ImportModelClass
-   :undoc-members:
 .. doxygenenum:: ImportTableType
-   :undoc-members:
 .. doxygenenum:: ImportUnits
-   :undoc-members:
 .. doxygenenum:: ImportPhysicsVectorType
-   :undoc-members:
 
 EM data
 ~~~~~~~

--- a/doc/api/celeritas.rst
+++ b/doc/api/celeritas.rst
@@ -126,3 +126,86 @@ secondaries.
    :members: none
 .. doxygenclass:: celeritas::detail::UrbanMscScatter
    :members: none
+
+Physics data
+------------
+
+Celeritas reads physics data from Geant4 (or from a ROOT file exported from
+data previously loaded into Geant4). Different versions of Geant4 (and Geant4
+data) can be used seamlessly with any version of Celeritas, allowing
+differences to be isolated without respect to machine or model implementation.
+The following classes enumerate all the data used at runtime.
+
+.. doxygenstruct:: celeritas::ImportData
+   :undoc-members:
+
+Material and geometry properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. doxygenstruct:: celeritas::ImportElement
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportProductionCut
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportMatElemComponent
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportMaterial
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportVolume
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportTransParameters
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportLoopingThreshold
+   :undoc-members:
+
+.. doxygenenum:: ImportMaterialState
+
+Physics properties
+~~~~~~~~~~~~~~~~~~
+
+.. doxygenstruct:: celeritas::ImportParticle
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportProcess
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportModel
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportMscModel
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportModelMaterial
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportPhysicsTable
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportPhysicsVector
+   :undoc-members:
+
+.. doxygenenum:: ImportProcessType
+   :undoc-members:
+.. doxygenenum:: ImportProcessClass
+   :undoc-members:
+.. doxygenenum:: ImportModelClass
+   :undoc-members:
+.. doxygenenum:: ImportTableType
+   :undoc-members:
+.. doxygenenum:: ImportUnits
+   :undoc-members:
+.. doxygenenum:: ImportPhysicsVectorType
+   :undoc-members:
+
+EM data
+~~~~~~~
+
+.. doxygenstruct:: celeritas::ImportEmParameters
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportAtomicTransition
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportAtomicSubshell
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportAtomicRelaxation
+   :undoc-members:
+
+.. doxygenstruct:: celeritas::ImportLivermoreSubshell
+   :undoc-members:
+.. doxygenstruct:: celeritas::ImportLivermorePE
+   :undoc-members:
+
+.. doxygenstruct:: celeritas::ImportSBTable
+   :undoc-members:

--- a/doc/appendices/development.rst
+++ b/doc/appendices/development.rst
@@ -101,9 +101,9 @@ Examples:
 
 - Random number sampling: write a unit sphere sampling functor instead of
   replicating a polar-to-Cartesian transform in a thousand places.
-- Cell IDs: Opaque IDs add type safety so that you can't accidentally convert a
-  cell identifier into a double or switch a cell and material ID. It also makes
-  code more readable of course.
+- Volume IDs: Opaque IDs add type safety so that you can't accidentally convert
+  a volume identifier into a double or switch a volume and material ID. It also
+  makes code more readable of course.
 
 Encapsulation is also useful for code reuse. Always avoid copy-pasting code, as
 it means potentially duplicating bugs, duplicating the amount of work needed

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,12 +17,15 @@ all_authors = [
  'Seth R Johnson',
  # Remaining core team in alphabetical order
  'Philippe Canal',
+ 'Julien Esseiva',
  'Tom Evans',
  'Soon Yung Jun',
  'Guilherme Lima',
  'Amanda Lund',
  'Paul Romano',
  'Stefano C Tognini',
+ # Notable contributors to code and documenation
+ 'Ben Morgan'
 ]
 author = " and ".join(all_authors)
 copyright = '{:%Y}, UT–Battelle/ORNL and Celeritas team'.format(

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -74,53 +74,51 @@ Physics
 =======
 
 Celeritas implements physics processes and models for transporting electron, positron,
-and gamma particles as shown in the accompanying table. Implementation details of these models 
+and gamma particles as shown in the accompanying table. Implementation details of these models
 and their corresponding Geant4 classes are documented in :ref:`celeritas_physics`.
 
 .. only:: html
 
    .. table:: Electromagnetic physics processes and models available in Celeritas.
 
-      +----------------+---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      | **Particle**   | **Processes**       | **Models**                | **Celeritas Implementation**                       | **Applicability**        |
-      +----------------+---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |:math:`e^-`     | Ionisation          | Møller                    | :cpp:class:`celeritas::MollerBhabhaInteractor`     |       0--100 TeV         |
-      |                +---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |                | Bremsstrahlung      | Seltzer--Berger           | :cpp:class:`celeritas::SeltzerBergerInteractor`    |       0--1 GeV           |
-      |                |                     +---------------------------+----------------------------------------------------+--------------------------+
-      |                |                     | Relativistic              | :cpp:class:`celeritas::RelativisticBremInteractor` |   1 GeV -- 100 TeV       |
-      |                +---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |                | Coulomb scattering  | Urban                     | :cpp:class:`celeritas::UrbanMscScatter` [1]_       |   10 eV -- 100 MeV       |
-      +----------------+---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |:math:`e^+`     | Ionisation          | Bhabha                    | :cpp:class:`celeritas::MollerBhabhaInteractor`     |       0--100 TeV         |
-      |                +---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |                | Bremsstrahlung      | Seltzer-Berger            | :cpp:class:`celeritas::SeltzerBergerInteractor`    |       0--1 GeV           |
-      |                |                     +---------------------------+----------------------------------------------------+--------------------------+
-      |                |                     | Relativistic              | :cpp:class:`celeritas::RelativisticBremInteractor` |   1 GeV -- 100 TeV       |
-      |                +---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |                | Coulomb scattering  | Urban                     | :cpp:class:`celeritas::UrbanMscScatter` [1]_       |   10 eV -- 100 MeV       |
-      |                +---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |                | Annihilation        |:math:`e^+-e^- \to 2\gamma`| :cpp:class:`celeritas::EPlusGGInteractor`          |       0--100 TeV         |
-      +----------------+---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |:math:`\gamma`  | Photoelectric       | Livermore                 | :cpp:class:`celeritas::LivermorePEInteractor`      |       0--100 TeV         |
-      |                +---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |                | Compton scattering  | Klein--Nishina            | :cpp:class:`celeritas::KleinNishinaInteractor`     |       0--100 TeV         |
-      |                +---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |                | Pair production     | Bethe--Heitler            | :cpp:class:`celeritas::BetheHeitlerInteractor`     |       0--100 TeV         |
-      |                +---------------------+---------------------------+----------------------------------------------------+--------------------------+
-      |                | Rayleigh scattering | Livermore                 | :cpp:class:`celeritas::RayleighInteractor`         |       0--100 TeV         |
-      +----------------+---------------------+---------------------------+----------------------------------------------------+--------------------------+
-
-  .. [1] Multiple Scattering using the Urban Model is only applied up to 100MeV in Celeritas, with no model used above this energy.  
+      +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      | **Particle**   | **Processes**       |  **Models**                 | **Celeritas Implementation**                       | **Applicability**        |
+      +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      | :math:`e^-`    | Ionisation          |  Møller                     | :cpp:class:`celeritas::MollerBhabhaInteractor`     |       0--100 TeV         |
+      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      |                | Bremsstrahlung      |  Seltzer--Berger            | :cpp:class:`celeritas::SeltzerBergerInteractor`    |       0--1 GeV           |
+      |                |                     +-----------------------------+----------------------------------------------------+--------------------------+
+      |                |                     |  Relativistic               | :cpp:class:`celeritas::RelativisticBremInteractor` |   1 GeV -- 100 TeV       |
+      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      |                | Coulomb scattering  |  Urban                      | :cpp:class:`celeritas::UrbanMscScatter`            |   10 eV -- 100 TeV       |
+      +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      | :math:`e^+`    | Ionisation          |  Bhabha                     | :cpp:class:`celeritas::MollerBhabhaInteractor`     |       0--100 TeV         |
+      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      |                | Bremsstrahlung      |  Seltzer-Berger             | :cpp:class:`celeritas::SeltzerBergerInteractor`    |       0--1 GeV           |
+      |                |                     +-----------------------------+----------------------------------------------------+--------------------------+
+      |                |                     |  Relativistic               | :cpp:class:`celeritas::RelativisticBremInteractor` |   1 GeV -- 100 TeV       |
+      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      |                | Coulomb scattering  |  Urban                      | :cpp:class:`celeritas::UrbanMscScatter`            |   10 eV -- 100 TeV       |
+      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      |                | Annihilation        | :math:`e^+,e^- \to 2\gamma` | :cpp:class:`celeritas::EPlusGGInteractor`          |       0--100 TeV         |
+      +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      | :math:`\gamma` | Photoelectric       |  Livermore                  | :cpp:class:`celeritas::LivermorePEInteractor`      |       0--100 TeV         |
+      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      |                | Compton scattering  |  Klein--Nishina             | :cpp:class:`celeritas::KleinNishinaInteractor`     |       0--100 TeV         |
+      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      |                | Pair production     |  Bethe--Heitler             | :cpp:class:`celeritas::BetheHeitlerInteractor`     |       0--100 TeV         |
+      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      |                | Rayleigh scattering |  Livermore                  | :cpp:class:`celeritas::RayleighInteractor`         |       0--100 TeV         |
+      +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
 
 .. only:: latex
 
    .. raw:: latex
-      
+
       \begin{table}[h]
         \caption{Electromagnetic physics processes and models available in Celeritas.}
         \begin{threeparttable}
-        \begin{tabular} {|l | l | l | l | r |}
+        \begin{tabular}{| l | l | l | l | r | }
           \hline
           \textbf{Particle}         & \textbf{Processes}              & \textbf{Models}      & \textbf{Celeritas Implementation}                          & \textbf{Applicability} \\
           \hline
@@ -130,7 +128,7 @@ and their corresponding Geant4 classes are documented in :ref:`celeritas_physics
                                                                       \cline{3-5}
                                     &                                 & Relativistic         & \texttt{\scriptsize celeritas::RelativisticBremInteractor} & 1 GeV -- 100 TeV \\
                                     \cline{2-5}
-                                    & Coulomb scattering              & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter} \tnote{1}  & 10 eV -- 100 MeV \\
+                                    & Coulomb scattering              & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter}            & 10 eV -- 100 TeV \\
           \hline
           \multirow{5}{*}{$e^+$}    & Ionisation                      & Bhabha               & \texttt{\scriptsize celeritas::MollerBhabhaInteractor}     & 0--100 TeV \\
                                     \cline{2-5}
@@ -138,9 +136,9 @@ and their corresponding Geant4 classes are documented in :ref:`celeritas_physics
                                                                       \cline{3-5}
                                     &                                 & Relativistic         & \texttt{\scriptsize celeritas::RelativisticBremInteractor} & 1 GeV -- 100 TeV \\
                                     \cline{2-5}
-                                    & Coulomb scattering              & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter} \tnote{1}  & 10 eV -- 100 MeV \\
+                                    & Coulomb scattering              & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter}            & 10 eV -- 100 TeV \\
                                     \cline{2-5}
-                                    & Annihilation                    & $e^+-e^-\to 2\gamma$ & \texttt{\scriptsize celeritas::EPlusGGInteractor}          & 0--100 TeV \\
+                                    & Annihilation                    & $e^+,e^-\to 2\gamma$ & \texttt{\scriptsize celeritas::EPlusGGInteractor}          & 0--100 TeV \\
           \hline
           \multirow{4}{*}{$\gamma$} & Photoelectric                   & Livermore            & \texttt{\scriptsize celeritas::LivermorePEInteractor}      & 0--100 TeV \\
                                     \cline{2-5}
@@ -151,12 +149,18 @@ and their corresponding Geant4 classes are documented in :ref:`celeritas_physics
                                     & Rayleigh scattering             & Livermore            & \texttt{\scriptsize celeritas::RayleighInteractor}         & 0--100 TeV \\
           \hline
         \end{tabular}
-        \begin{tablenotes}
-          \item[1] \footnotesize Multiple Scattering using the Urban Model is only applied up to 100MeV in Celeritas, with no model used above this energy. 
-        \end{tablenotes}
         \end{threeparttable}
       \end{table}
 
+
+The implemented physics models are meant to match the defaults constructed in
+``G4EmStandardPhysics``.  Known differences are:
+
+* Particles other than electrons, positrons, and gammas are not currently
+  supported.
+* As with the AdePT project, Celeritas currently extends the range of Urban MSC
+  to higher energies rather than implementing the Wentzel-VI and discrete
+  Coulomb scattering.
 
 Geometry
 ========

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -90,7 +90,7 @@ and their corresponding Geant4 classes are documented in :ref:`celeritas_physics
       |                |                     +-----------------------------+----------------------------------------------------+--------------------------+
       |                |                     |  Relativistic               | :cpp:class:`celeritas::RelativisticBremInteractor` |   1 GeV -- 100 TeV       |
       |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      |                | Coulomb scattering  |  Urban                      | :cpp:class:`celeritas::UrbanMscScatter`            |   10 eV -- 100 TeV       |
+      |                | Coulomb scattering  |  Urban                      | :cpp:class:`celeritas::UrbanMscScatter`            |   100 eV -- 100 TeV      |
       +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
       | :math:`e^+`    | Ionisation          |  Bhabha                     | :cpp:class:`celeritas::MollerBhabhaInteractor`     |       0--100 TeV         |
       |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
@@ -98,7 +98,7 @@ and their corresponding Geant4 classes are documented in :ref:`celeritas_physics
       |                |                     +-----------------------------+----------------------------------------------------+--------------------------+
       |                |                     |  Relativistic               | :cpp:class:`celeritas::RelativisticBremInteractor` |   1 GeV -- 100 TeV       |
       |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      |                | Coulomb scattering  |  Urban                      | :cpp:class:`celeritas::UrbanMscScatter`            |   10 eV -- 100 TeV       |
+      |                | Coulomb scattering  |  Urban                      | :cpp:class:`celeritas::UrbanMscScatter`            |   100 eV -- 100 TeV      |
       |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
       |                | Annihilation        | :math:`e^+,e^- \to 2\gamma` | :cpp:class:`celeritas::EPlusGGInteractor`          |       0--100 TeV         |
       +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
@@ -128,7 +128,7 @@ and their corresponding Geant4 classes are documented in :ref:`celeritas_physics
                                                                       \cline{3-5}
                                     &                                 & Relativistic         & \texttt{\scriptsize celeritas::RelativisticBremInteractor} & 1 GeV -- 100 TeV \\
                                     \cline{2-5}
-                                    & Coulomb scattering              & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter}            & 10 eV -- 100 TeV \\
+                                    & Coulomb scattering              & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter}            & 100 eV -- 100 TeV \\
           \hline
           \multirow{5}{*}{$e^+$}    & Ionisation                      & Bhabha               & \texttt{\scriptsize celeritas::MollerBhabhaInteractor}     & 0--100 TeV \\
                                     \cline{2-5}
@@ -136,7 +136,7 @@ and their corresponding Geant4 classes are documented in :ref:`celeritas_physics
                                                                       \cline{3-5}
                                     &                                 & Relativistic         & \texttt{\scriptsize celeritas::RelativisticBremInteractor} & 1 GeV -- 100 TeV \\
                                     \cline{2-5}
-                                    & Coulomb scattering              & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter}            & 10 eV -- 100 TeV \\
+                                    & Coulomb scattering              & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter}            & 100 eV -- 100 TeV \\
                                     \cline{2-5}
                                     & Annihilation                    & $e^+,e^-\to 2\gamma$ & \texttt{\scriptsize celeritas::EPlusGGInteractor}          & 0--100 TeV \\
           \hline
@@ -161,6 +161,9 @@ The implemented physics models are meant to match the defaults constructed in
 * As with the AdePT project, Celeritas currently extends the range of Urban MSC
   to higher energies rather than implementing the Wentzel-VI and discrete
   Coulomb scattering.
+* Celeritas imports tracking cutoffs and other parameters from
+  ``G4EmParameters``, but some custom model cutoffs are not accessible to
+  Celeritas.
 
 Geometry
 ========

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -48,6 +48,7 @@ list(APPEND SOURCES
   em/process/GammaConversionProcess.cc
   em/process/PhotoelectricProcess.cc
   em/process/RayleighProcess.cc
+  ext/GeantPhysicsOptions.cc
   geo/GeoMaterialParams.cc
   global/ActionInterface.cc
   global/ActionRegistry.cc

--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -37,8 +37,8 @@ struct UrbanMscParameters
     real_type safety_fact{0.6};  //!< safety factor
     real_type safety_tol{0.01};  //!< safety tolerance
     real_type geom_limit{5e-8 * units::millimeter};  //!< minimum step
-    Energy low_energy_limit{1e-5};  //!< 10 eV
-    Energy high_energy_limit{1e+2};  //!< 100 MeV
+    Energy low_energy_limit{0};
+    Energy high_energy_limit{0};
 
     //! A scale factor for the range
     static CELER_CONSTEXPR_FUNCTION real_type dtrl() { return 5e-2; }

--- a/src/celeritas/ext/GeantPhysicsOptions.cc
+++ b/src/celeritas/ext/GeantPhysicsOptions.cc
@@ -1,0 +1,59 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/GeantPhysicsOptions.cc
+//---------------------------------------------------------------------------//
+#include "GeantPhysicsOptions.hh"
+
+#include "corecel/io/EnumStringMapper.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Get a string corresponding to the Bremsstrahlung model selection.
+ */
+char const* to_cstring(BremsModelSelection value)
+{
+    static EnumStringMapper<BremsModelSelection> const to_cstring_impl{
+        "seltzer_berger",
+        "relativistic",
+        "all",
+    };
+    return to_cstring_impl(value);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get a string corresponding to the multiple scattering model selection.
+ */
+char const* to_cstring(MscModelSelection value)
+{
+    static EnumStringMapper<MscModelSelection> const to_cstring_impl{
+        "none",
+        "urban",
+        "urban_extended",
+        "wentzel_vi",
+        "urban_wentzel",
+    };
+    return to_cstring_impl(value);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get a string corresponding to the atomic relaxation option.
+ */
+char const* to_cstring(RelaxationSelection value)
+{
+    static EnumStringMapper<RelaxationSelection> const to_cstring_impl{
+        "none",
+        "radiative",
+        "all",
+    };
+    return to_cstring_impl(value);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/ext/GeantPhysicsOptions.cc
+++ b/src/celeritas/ext/GeantPhysicsOptions.cc
@@ -37,6 +37,7 @@ char const* to_cstring(MscModelSelection value)
         "urban_extended",
         "wentzel_vi",
         "urban_wentzel",
+        "goudsmit_saunderson",
     };
     return to_cstring_impl(value);
 }

--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -30,6 +30,7 @@ enum class MscModelSelection
     urban_extended,  //!< Use 100 TeV as upper bound instead of 100 MeV
     wentzel_vi,
     urban_wentzel,  //!< Urban for low-E, Wentzel_VI for high-E
+    goudsmit_saunderson,
     size_
 };
 

--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -22,13 +22,14 @@ enum class BremsModelSelection
 };
 
 //---------------------------------------------------------------------------//
-//! MSC selection (TODO: make bitset)
+//! MSC selection (TODO: make bitset?)
 enum class MscModelSelection
 {
     none,
     urban,
+    urban_extended,  //!< Use 100 TeV as upper bound instead of 100 MeV
     wentzel_vi,
-    all,
+    urban_wentzel,  //!< Urban for low-E, Wentzel_VI for high-E
     size_
 };
 
@@ -45,6 +46,9 @@ enum class RelaxationSelection
 //---------------------------------------------------------------------------//
 /*!
  * Construction options for geant physics.
+ *
+ * These options attempt to default to our closest match to
+ * \c G4StandardEmPhysics.
  *
  * Note that not all Geant physics choices are implemented in Celeritas.
  *
@@ -77,7 +81,7 @@ struct GeantPhysicsOptions
     bool gamma_general{false};
 
     BremsModelSelection brems{BremsModelSelection::all};
-    MscModelSelection msc{MscModelSelection::urban};
+    MscModelSelection msc{MscModelSelection::urban_extended};
     RelaxationSelection relaxation{RelaxationSelection::none};
 
     int em_bins_per_decade{7};
@@ -112,6 +116,14 @@ operator==(GeantPhysicsOptions const& a, GeantPhysicsOptions const& b)
            && a.msc_lambda_limit == b.msc_lambda_limit
            && a.verbose == b.verbose;
 }
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+
+char const* to_cstring(BremsModelSelection value);
+char const* to_cstring(MscModelSelection value);
+char const* to_cstring(RelaxationSelection value);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
+++ b/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
@@ -9,67 +9,13 @@
 
 #include <string>
 
-#include "corecel/Assert.hh"
-#include "corecel/cont/Range.hh"
-#include "corecel/io/EnumStringMapper.hh"
 #include "corecel/io/StringEnumMapper.hh"
 #include "corecel/math/QuantityIO.json.hh"
-#include "celeritas/ext/GeantPhysicsOptions.hh"
+
+#include "GeantPhysicsOptions.hh"
 
 namespace celeritas
 {
-namespace
-{
-//---------------------------------------------------------------------------//
-// HELPER FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- * Get a string corresponding to the Bremsstrahlung model selection.
- */
-char const* to_cstring(BremsModelSelection value)
-{
-    static EnumStringMapper<BremsModelSelection> const to_cstring_impl{
-        "seltzer_berger",
-        "relativistic",
-        "all",
-    };
-    return to_cstring_impl(value);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get a string corresponding to the multiple scattering model selection.
- */
-char const* to_cstring(MscModelSelection value)
-{
-    static EnumStringMapper<MscModelSelection> const to_cstring_impl{
-        "none",
-        "urban",
-        "wentzel_vi",
-        "all",
-    };
-    return to_cstring_impl(value);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get a string corresponding to the atomic relaxation option.
- */
-char const* to_cstring(RelaxationSelection value)
-{
-    static EnumStringMapper<RelaxationSelection> const to_cstring_impl{
-        "none",
-        "radiative",
-        "all",
-    };
-    return to_cstring_impl(value);
-}
-
-//---------------------------------------------------------------------------//
-}  // namespace
-
-//---------------------------------------------------------------------------//
-// JSON serializers
 //---------------------------------------------------------------------------//
 void from_json(nlohmann::json const& j, MscModelSelection& value)
 {

--- a/src/celeritas/ext/detail/GeantExceptionHandler.cc
+++ b/src/celeritas/ext/detail/GeantExceptionHandler.cc
@@ -42,7 +42,7 @@ G4bool GeantExceptionHandler::Notify(char const* origin_of_exception,
             throw err;
         case JustWarning:
             // Display a message
-            CELER_LOG(warning) << err.what();
+            CELER_LOG(error) << err.what();
             break;
         default:
             CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -308,7 +308,7 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
         auto process = std::make_unique<G4eMultipleScattering>();
 
         if (options_.msc == MscModelSelection::urban
-            || options_.msc == MscModelSelection::urban
+            || options_.msc == MscModelSelection::urban_extended
             || options_.msc == MscModelSelection::urban_wentzel)
         {
             auto model = std::make_unique<G4UrbanMscModel>();

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -291,8 +291,8 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
 
         CELER_LOG(debug) << "Loaded Coulomb scattering with "
                             "G4eCoulombScatteringModel";
-        if (options_.msc == MscModelSelection::wentzel_vi
-            || options_.msc == MscModelSelection::urban_wentzel)
+        if (options_.msc == MscModelSelection::urban
+            || options_.msc == MscModelSelection::urban_extended)
         {
             CELER_LOG(warning)
                 << "Coulomb scattering may be inconsistent with msc="

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -289,16 +289,6 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
         model->SetActivationLowEnergyLimit(msc_energy_limit);
         process->SetEmModel(model.release());
         physics_list->RegisterProcess(process.release(), p);
-
-        CELER_LOG(debug) << "Loaded Coulomb scattering with "
-                            "G4eCoulombScatteringModel";
-        if (options_.msc == MscModelSelection::urban
-            || options_.msc == MscModelSelection::urban_extended)
-        {
-            CELER_LOG(warning)
-                << "Coulomb scattering may be inconsistent with msc="
-                << to_cstring(options_.msc);
-        }
     }
 
     if (options_.msc != MscModelSelection::none)

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -16,6 +16,7 @@
 #include <G4Gamma.hh>
 #include <G4GammaConversion.hh>
 #include <G4GammaGeneralProcess.hh>
+#include <G4GoudsmitSaundersonMscModel.hh>
 #include <G4LivermorePhotoElectricModel.hh>
 #include <G4LossTableManager.hh>
 #include <G4MollerBhabhaModel.hh>
@@ -328,6 +329,15 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
 
             CELER_LOG(debug) << "Loaded high-energy multiple scattering with "
                                 "G4WentzelVIModel";
+        }
+
+        if (options_.msc == MscModelSelection::goudsmit_saunderson)
+        {
+            auto model = std::make_unique<G4GoudsmitSaundersonMscModel>();
+            process->SetEmModel(model.release());
+
+            CELER_LOG(debug) << "Loaded multiple scattering with "
+                                "G4GoudsmitSaundersonMscModel";
         }
 
         physics_list->RegisterProcess(process.release(), p);

--- a/src/celeritas/io/ImportData.hh
+++ b/src/celeritas/io/ImportData.hh
@@ -25,7 +25,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Import all the needed data from external sources (currently Geant4).
+ * Store imported physics data from external sources.
  *
  * All the data imported to Celeritas is stored in this single entity. This
  * struct can be used in memory or recorded in a ROOT TBranch as a single TTree
@@ -44,14 +44,6 @@ namespace celeritas
  * Celeritas' unit standard. Refer to \c base/Units.hh for further information.
  *
  * The "processes" field may be empty for testing applications.
- *
- * \sa celeritas::units
- * \sa ImportParticle
- * \sa ImportElement
- * \sa ImportMaterial
- * \sa ImportProcess
- * \sa ImportVolume
- * \sa RootImporter
  */
 struct ImportData
 {

--- a/src/celeritas/io/ImportElement.hh
+++ b/src/celeritas/io/ImportElement.hh
@@ -14,8 +14,6 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Store element data.
- *
- * \sa ImportData
  */
 struct ImportElement
 {

--- a/src/celeritas/io/ImportMaterial.hh
+++ b/src/celeritas/io/ImportMaterial.hh
@@ -18,8 +18,6 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Enum for storing G4State enumerators.
- *
- * See G4Material.hh.
  */
 enum class ImportMaterialState
 {
@@ -55,8 +53,6 @@ struct ImportMatElemComponent
 //---------------------------------------------------------------------------//
 /*!
  * Store material data.
- *
- * \sa ImportData
  */
 struct ImportMaterial
 {

--- a/src/celeritas/io/ImportModel.cc
+++ b/src/celeritas/io/ImportModel.cc
@@ -44,6 +44,7 @@ char const* to_cstring(ImportModelClass value)
         "mu_brems",
         "mu_pair_prod",
         "fluo_photoelectric",
+        "goudsmit_saunderson",
     };
     return to_cstring_impl(value);
 }
@@ -78,6 +79,7 @@ char const* to_geant_name(ImportModelClass value)
         "MuBrem",
         "muPairProd",
         "PhotoElectric",
+        "GoudsmitSaunderson",
     };
     return to_name_impl(value);
 }

--- a/src/celeritas/io/ImportModel.hh
+++ b/src/celeritas/io/ImportModel.hh
@@ -49,6 +49,7 @@ enum class ImportModelClass
     mu_brems,
     mu_pair_prod,
     fluo_photoelectric,
+    goudsmit_saunderson,
     size_
 };
 

--- a/src/celeritas/io/ImportParticle.hh
+++ b/src/celeritas/io/ImportParticle.hh
@@ -14,8 +14,6 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Store particle data.
- *
- * \sa ImportData
  */
 struct ImportParticle
 {

--- a/src/celeritas/io/ImportProcess.hh
+++ b/src/celeritas/io/ImportProcess.hh
@@ -80,8 +80,6 @@ enum class ImportProcessClass
 /*!
  * Store physics process data.
  *
- * \sa ImportData
- *
  * \note
  * \c ImportPhysicsTable is process and type (lambda, dedx, and so
  * on) dependent, with each table type including physics vectors for all

--- a/src/celeritas/io/ImportVolume.hh
+++ b/src/celeritas/io/ImportVolume.hh
@@ -13,9 +13,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Store volume data.
- *
- * \sa ImportData
+ * Store logical volume properties.
  */
 struct ImportVolume
 {

--- a/src/celeritas/track/detail/TrackSortUtils.hh
+++ b/src/celeritas/track/detail/TrackSortUtils.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/track/TrackSortUtils.hh
+//! \file celeritas/track/detail/TrackSortUtils.hh
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -212,6 +212,8 @@ TEST_F(UrbanMscTest, coeff_data)
 {
     auto const& params = msc_params_->host_ref();
 
+    EXPECT_SOFT_EQ(1e-4, value_as<MevEnergy>(params.params.low_energy_limit));
+    EXPECT_SOFT_EQ(1e2, value_as<MevEnergy>(params.params.high_energy_limit));
     {
         // Check steel material data
         auto mid = this->material()->find_material("G4_STAINLESS-STEEL");

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -72,7 +72,6 @@ class GeantImporterTest : public GeantTestBase
         void print_expected() const;
     };
 
-
     ImportSummary summarize(ImportData const& data) const;
     ImportXsSummary summarize(VecModelMaterial const& xs) const;
 
@@ -89,15 +88,31 @@ class GeantImporterTest : public GeantTestBase
         auto const& processes = this->imported_data().processes;
         auto result = std::find_if(processes.begin(),
                                    processes.end(),
-                                   [&pdg, &ipc](ImportProcess const& proc) {
+                                   [pdg, ipc](ImportProcess const& proc) {
                                        return PDGNumber{proc.particle_pdg}
                                                   == pdg
                                               && proc.process_class == ipc;
                                    });
-        CELER_ENSURE(result != processes.end());
+        CELER_VALIDATE(result != processes.end(),
+                       << "missing process " << to_cstring(ipc)
+                       << " for particle PDG=" << pdg.get());
         return *result;
     }
 
+    ImportMscModel const&
+    find_msc_model(PDGNumber pdg, ImportModelClass imc) const
+    {
+        CELER_EXPECT(this->imported_data());
+        auto const& models = this->imported_data().msc_models;
+        auto result = std::find_if(
+            models.begin(), models.end(), [pdg, imc](ImportMscModel const& m) {
+                return PDGNumber{m.particle_pdg} == pdg && m.model_class == imc;
+            });
+        CELER_VALIDATE(result != models.end(),
+                       << "missing model " << to_cstring(imc)
+                       << " for particle PDG=" << pdg.get());
+        return *result;
+    }
     real_type comparison_tolerance() const
     {
         // Some values change substantially between geant versions
@@ -212,7 +227,7 @@ class FourSteelSlabsEmStandard : public GeantImporterTest
         {
             nlohmann::json out = opts;
             static char const expected[]
-                = R"json({"brems":"all","coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_general":false,"integral_approach":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
+                = R"json({"brems":"all","coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_general":false,"integral_approach":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban_extended","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
             EXPECT_EQ(std::string(expected), std::string(out.dump()))
                 << "\n/*** REPLACE ***/\nR\"json(" << std::string(out.dump())
                 << ")json\"\n/******/";
@@ -247,6 +262,7 @@ class OneSteelSphere : public GeantImporterTest
     GeantPhysicsOptions build_geant_options() const override
     {
         GeantPhysicsOptions opts;
+        opts.msc = MscModelSelection::urban;
         opts.relaxation = RelaxationSelection::none;
         opts.verbose = false;
         return opts;
@@ -261,6 +277,7 @@ class OneSteelSphereGG : public OneSteelSphere
     {
         auto opts = OneSteelSphere::build_geant_options();
         opts.gamma_general = true;
+        opts.msc = MscModelSelection::urban_extended;
         return opts;
     }
 };
@@ -1103,6 +1120,19 @@ TEST_F(OneSteelSphere, physics)
         EXPECT_SOFT_EQ(9549.651635687942, steel.x.front());
         EXPECT_SOFT_EQ(1e8, steel.x.back());
     }
+    // Check MSC bounds
+    {
+        // Check the ionization electron macro xs
+        ImportMscModel const& msc = this->find_msc_model(
+            celeritas::pdg::electron(), ImportModelClass::urban_msc);
+        EXPECT_TRUE(msc);
+        for (ImportPhysicsVector const& pv : msc.xs_table.physics_vectors)
+        {
+            ASSERT_FALSE(pv.x.empty());
+            EXPECT_SOFT_EQ(1e-4, pv.x.front());
+            EXPECT_SOFT_EQ(1e2, pv.x.back());
+        }
+    }
 }
 
 TEST_F(OneSteelSphereGG, physics)
@@ -1130,6 +1160,20 @@ TEST_F(OneSteelSphereGG, physics)
                                             "bethe_heitler_lpm",
                                             "livermore_rayleigh"};
     EXPECT_VEC_EQ(expected_models, summary.models);
+
+    // Check MSC bounds
+    {
+        // Check the ionization electron macro xs
+        ImportMscModel const& msc = this->find_msc_model(
+            celeritas::pdg::electron(), ImportModelClass::urban_msc);
+        EXPECT_TRUE(msc);
+        for (ImportPhysicsVector const& pv : msc.xs_table.physics_vectors)
+        {
+            ASSERT_FALSE(pv.x.empty());
+            EXPECT_SOFT_EQ(1e-4, pv.x.front());
+            EXPECT_SOFT_EQ(1e8, pv.x.back());
+        }
+    }
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This gives Celeritas the same default behavior as AdePT/G4HepEM: instead of using coulomb+wenzel-VI we extend the low-energy MSC model. One small thing to note is that our existing "lower MSC limit" was set to 1e-5 even though cross sections only went to 1e-4.