### PR TITLE
Fix SWIG and mac builds

### DIFF
--- a/interface/celeritas.i
+++ b/interface/celeritas.i
@@ -90,10 +90,14 @@ namespace celeritas
 %rename(process_type_to_string) to_cstring(ImportProcessType);
 %rename(process_class_to_string) to_cstring(ImportProcessClass);
 %rename(model_to_string) to_cstring(ImportModelClass);
+%rename(process_class_to_geant_name) to_geant_name(ImportProcessClass);
+%rename(model_to_geant_name) to_geant_name(ImportModelClass);
 
 %rename(xs_lo) ImportTableType::lambda;
 %rename(xs_hi) ImportTableType::lambda_prim;
 }
+
+%include "celeritas/io/ImportParameters.hh"
 
 %include "celeritas/io/ImportPhysicsVector.hh"
 %template(VecImportPhysicsVector) std::vector<celeritas::ImportPhysicsVector>;

--- a/src/celeritas/track/detail/TrackSortUtils.cc
+++ b/src/celeritas/track/detail/TrackSortUtils.cc
@@ -31,7 +31,8 @@ void fill_track_slots<MemSpace::host>(Span<TrackSlotId::size_type> track_slots)
 template<>
 void shuffle_track_slots<MemSpace::host>(Span<TrackSlotId::size_type> track_slots)
 {
-    std::mt19937 g{track_slots.size()};
+    unsigned int seed = track_slots.size();
+    std::mt19937 g{seed};
     std::shuffle(track_slots.begin(), track_slots.end(), g);
 }
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -212,7 +212,7 @@ class FourSteelSlabsEmStandard : public GeantImporterTest
         {
             nlohmann::json out = opts;
             static char const expected[]
-                = R"json({"brems":"all","coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_general":false,"integral_approach":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
+                = R"json({"brems":"all","coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_general":false,"integral_approach":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban_extended","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
             EXPECT_EQ(std::string(expected), std::string(out.dump()))
                 << "\n/*** REPLACE ***/\nR\"json(" << std::string(out.dump())
                 << ")json\"\n/******/";

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -212,7 +212,7 @@ class FourSteelSlabsEmStandard : public GeantImporterTest
         {
             nlohmann::json out = opts;
             static char const expected[]
-                = R"json({"brems":"all","coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_general":false,"integral_approach":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban_extended","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
+                = R"json({"brems":"all","coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_general":false,"integral_approach":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
             EXPECT_EQ(std::string(expected), std::string(out.dump()))
                 << "\n/*** REPLACE ***/\nR\"json(" << std::string(out.dump())
                 << ")json\"\n/******/";


### PR DESCRIPTION
A few recent commits have broken capabilities that aren't tested by the CI: on macOS, size_type and unsigned int aren't the same, and SWIG isn't tested because of the warnings it emits.