### PR TITLE
Add an option to apply cuts to all secondaries

### DIFF
--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -424,7 +424,8 @@ void print_em_params(ImportEmParameters const& em_params)
          << PEP_STREAM_PARAM(lowest_electron_energy) << PEP_STREAM_BOOL(auger)
          << PEP_STREAM_PARAM(msc_range_factor)
          << PEP_STREAM_PARAM(msc_safety_factor)
-         << PEP_STREAM_PARAM(msc_lambda_limit) << endl;
+         << PEP_STREAM_PARAM(msc_lambda_limit) << PEP_STREAM_BOOL(apply_cuts)
+         << endl;
 #undef PEP_STREAM_PARAM
 #undef PEP_STREAM_BOOL
 }

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -605,6 +605,7 @@ ImportEmParameters import_em_parameters()
     import.msc_range_factor = g4.MscRangeFactor();
     import.msc_safety_factor = g4.MscSafetyFactor();
     import.msc_lambda_limit = g4.MscLambdaLimit() / cm;
+    import.apply_cuts = g4.ApplyCuts();
 
     CELER_ENSURE(import);
     return import;

--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -70,6 +70,7 @@ enum class RelaxationSelection
  * - \c msc_range_factor: e-/e+ range factor for MSC models
  * - \c msc_safety_factor: safety factor for MSC models
  * - \c msc_lambda_limit: lambda limit for MSC models [cm]
+ * - \c apply_cuts: kill secondaries below the production cut
  * - \c verbose: print detailed Geant4 output
  */
 struct GeantPhysicsOptions
@@ -93,6 +94,7 @@ struct GeantPhysicsOptions
     real_type msc_range_factor{0.04};
     real_type msc_safety_factor{0.6};
     real_type msc_lambda_limit{0.1};  // 1 mm
+    bool apply_cuts{false};
 
     bool verbose{false};
 };
@@ -115,7 +117,7 @@ operator==(GeantPhysicsOptions const& a, GeantPhysicsOptions const& b)
            && a.msc_range_factor == b.msc_range_factor
            && a.msc_safety_factor == b.msc_safety_factor
            && a.msc_lambda_limit == b.msc_lambda_limit
-           && a.verbose == b.verbose;
+           && a.apply_cuts == b.apply_cuts && a.verbose == b.verbose;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
+++ b/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
@@ -86,6 +86,7 @@ void from_json(nlohmann::json const& j, GeantPhysicsOptions& options)
     GPO_LOAD_OPTION(msc_range_factor);
     GPO_LOAD_OPTION(msc_safety_factor);
     GPO_LOAD_OPTION(msc_lambda_limit);
+    GPO_LOAD_OPTION(apply_cuts);
     GPO_LOAD_OPTION(verbose);
 #undef GPO_LOAD_OPTION
 }
@@ -115,6 +116,7 @@ void to_json(nlohmann::json& j, GeantPhysicsOptions const& options)
     GPO_SAVE_OPTION(msc_range_factor);
     GPO_SAVE_OPTION(msc_safety_factor);
     GPO_SAVE_OPTION(msc_lambda_limit);
+    GPO_SAVE_OPTION(apply_cuts);
     GPO_SAVE_OPTION(verbose);
 #undef GPO_SAVE_OPTION
 }

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -79,6 +79,7 @@ GeantPhysicsList::GeantPhysicsList(Options const& options) : options_(options)
         CELER_LOG(debug) << "Extended low-energy MSC limit to 100 TeV";
         em_parameters.SetMscEnergyLimit(100 * CLHEP::TeV);
     }
+    em_parameters.SetApplyCuts(options.apply_cuts);
 
     int verb = options_.verbose ? 1 : 0;
     this->SetVerboseLevel(verb);

--- a/src/celeritas/io/ImportParameters.hh
+++ b/src/celeritas/io/ImportParameters.hh
@@ -41,6 +41,8 @@ struct ImportEmParameters
     double msc_safety_factor{0.6};
     //! MSC lambda limit [cm]
     double msc_lambda_limit{0.1};
+    //! Kill secondaries below production cut
+    bool apply_cuts{false};
 
     //! Whether parameters are assigned and valid
     explicit operator bool() const

--- a/src/celeritas/phys/CutoffData.hh
+++ b/src/celeritas/phys/CutoffData.hh
@@ -25,9 +25,12 @@ struct ParticleCutoff
 
 //---------------------------------------------------------------------------//
 /*!
- * IDs of particles that can be killed when \c apply_cuts is enabled.
+ * IDs of particles that can be killed post-interaction.
+ *
+ * The ID will be valid if the \c apply_post_interaction option is enabled and
+ * the particle is present in the problem.
  */
-struct ApplyCutsIds
+struct CutoffIds
 {
     ParticleId gamma;
     ParticleId electron;
@@ -39,9 +42,9 @@ struct ApplyCutsIds
  * Persistent shared cutoff data.
  *
  * Secondary production cuts are stored for every material and for only the
- * particle types to which production cuts apply. Currently production cuts are
- * only needed for electrons and photons (protons are unused and positrons
- * cannot have a cutoff).
+ * particle types to which production cuts apply. Positron production cuts are
+ * only used when the post-interaction cutoff is enabled. Proton production
+ * cuts are currently unused.
  *
  * \sa CutoffView
  * \sa CutoffParams
@@ -63,8 +66,9 @@ struct CutoffParamsData
     ParticleId::size_type num_particles;  //!< Particles with production cuts
     MaterialId::size_type num_materials;  //!< All materials in the problem
 
-    bool apply_cuts{false};  //!< Kill secondaries below production cut
-    ApplyCutsIds ids;  //!< Secondaries that can be killed below production cut
+    bool apply_post_interaction{false};  //!< Apply cutoff post-interaction
+    CutoffIds ids;  //!< Secondaries that can be killed post-interaction if
+                    //!< their energy is below the production cut
 
     //// MEMBER FUNCTIONS ////
 
@@ -85,7 +89,7 @@ struct CutoffParamsData
         this->id_to_index = other.id_to_index;
         this->num_particles = other.num_particles;
         this->num_materials = other.num_materials;
-        this->apply_cuts = other.apply_cuts;
+        this->apply_post_interaction = other.apply_post_interaction;
         this->ids = other.ids;
 
         return *this;

--- a/src/celeritas/phys/CutoffData.hh
+++ b/src/celeritas/phys/CutoffData.hh
@@ -25,6 +25,17 @@ struct ParticleCutoff
 
 //---------------------------------------------------------------------------//
 /*!
+ * IDs of particles that can be killed when \c apply_cuts is enabled.
+ */
+struct ApplyCutsIds
+{
+    ParticleId gamma;
+    ParticleId electron;
+    ParticleId positron;
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Persistent shared cutoff data.
  *
  * Secondary production cuts are stored for every material and for only the
@@ -52,6 +63,9 @@ struct CutoffParamsData
     ParticleId::size_type num_particles;  //!< Particles with production cuts
     MaterialId::size_type num_materials;  //!< All materials in the problem
 
+    bool apply_cuts{false};  //!< Kill secondaries below production cut
+    ApplyCutsIds ids;  //!< Secondaries that can be killed below production cut
+
     //// MEMBER FUNCTIONS ////
 
     //! True if assigned
@@ -71,6 +85,8 @@ struct CutoffParamsData
         this->id_to_index = other.id_to_index;
         this->num_particles = other.num_particles;
         this->num_materials = other.num_materials;
+        this->apply_cuts = other.apply_cuts;
+        this->ids = other.ids;
 
         return *this;
     }

--- a/src/celeritas/phys/CutoffParams.cc
+++ b/src/celeritas/phys/CutoffParams.cc
@@ -59,6 +59,7 @@ CutoffParams::from_import(ImportData const& data,
         }
         input.cutoffs.insert({pdg, mat_cutoffs});
     }
+    input.apply_cuts = data.em_params.apply_cuts;
 
     return std::make_shared<CutoffParams>(input);
 }
@@ -74,6 +75,10 @@ CutoffParams::CutoffParams(Input const& input)
 
     HostValue host_data;
     host_data.num_materials = input.materials->size();
+    host_data.apply_cuts = input.apply_cuts;
+    host_data.ids.electron = input.particles->find(pdg::electron());
+    host_data.ids.positron = input.particles->find(pdg::positron());
+    host_data.ids.gamma = input.particles->find(pdg::gamma());
 
     std::vector<ParticleCutoff> cutoffs;
 

--- a/src/celeritas/phys/CutoffParams.cc
+++ b/src/celeritas/phys/CutoffParams.cc
@@ -127,13 +127,14 @@ CutoffParams::CutoffParams(Input const& input)
 /*!
  * PDG numbers of particles with prodution cuts.
  *
- * Only electrons and photons have secondary production cuts -- protons are not
- * currently used, and positrons cannot have production cuts.
+ * Positron production cuts are only used when the \c apply_cuts option is
+ * enabled to explicitly kill secondary positrons with energies below the
+ * production threshold. Protons production cuts are not currently used.
  */
 std::vector<PDGNumber> const& CutoffParams::pdg_numbers()
 {
-    static const std::vector<PDGNumber> pdg_numbers{pdg::electron(),
-                                                    pdg::gamma()};
+    static const std::vector<PDGNumber> pdg_numbers{
+        pdg::electron(), pdg::gamma(), pdg::positron()};
     return pdg_numbers;
 }
 

--- a/src/celeritas/phys/CutoffParams.cc
+++ b/src/celeritas/phys/CutoffParams.cc
@@ -59,7 +59,7 @@ CutoffParams::from_import(ImportData const& data,
         }
         input.cutoffs.insert({pdg, mat_cutoffs});
     }
-    input.apply_cuts = data.em_params.apply_cuts;
+    input.apply_post_interaction = data.em_params.apply_cuts;
 
     return std::make_shared<CutoffParams>(input);
 }
@@ -75,10 +75,13 @@ CutoffParams::CutoffParams(Input const& input)
 
     HostValue host_data;
     host_data.num_materials = input.materials->size();
-    host_data.apply_cuts = input.apply_cuts;
-    host_data.ids.electron = input.particles->find(pdg::electron());
-    host_data.ids.positron = input.particles->find(pdg::positron());
-    host_data.ids.gamma = input.particles->find(pdg::gamma());
+    host_data.apply_post_interaction = input.apply_post_interaction;
+    if (input.apply_post_interaction)
+    {
+        host_data.ids.electron = input.particles->find(pdg::electron());
+        host_data.ids.positron = input.particles->find(pdg::positron());
+        host_data.ids.gamma = input.particles->find(pdg::gamma());
+    }
 
     std::vector<ParticleCutoff> cutoffs;
 
@@ -127,9 +130,9 @@ CutoffParams::CutoffParams(Input const& input)
 /*!
  * PDG numbers of particles with prodution cuts.
  *
- * Positron production cuts are only used when the \c apply_cuts option is
- * enabled to explicitly kill secondary positrons with energies below the
- * production threshold. Protons production cuts are not currently used.
+ * Positron production cuts are only used when the \c apply_post_interaction
+ * option is enabled to explicitly kill secondary positrons with energies below
+ * the production threshold. Proton production cuts are not currently used.
  */
 std::vector<PDGNumber> const& CutoffParams::pdg_numbers()
 {

--- a/src/celeritas/phys/CutoffParams.hh
+++ b/src/celeritas/phys/CutoffParams.hh
@@ -45,6 +45,14 @@ struct ImportData;
  *
  * The \c Input structure provides a failsafe mechanism to construct the
  * host/device data.
+ *
+ * Some processes (e.g. photoelectric effect, decay) can produce secondaries
+ * below the production threshold, while others (e.g. bremsstrahlung,
+ * ionization) use the production cut as their instrinsic limit. By default all
+ * of these secondaries are transported, even if their energy is below the
+ * threshold. If the \c apply_cuts option is enabled, any secondary photon,
+ * electron, or positron with energy below the cutoff will be killed (the flag
+ * will be ignored for other particle types).
  */
 class CutoffParams
 {
@@ -65,6 +73,7 @@ class CutoffParams
         SPConstParticles particles;
         SPConstMaterials materials;
         std::map<PDGNumber, MaterialCutoffs> cutoffs;
+        bool apply_cuts{false};
     };
 
   public:

--- a/src/celeritas/phys/CutoffParams.hh
+++ b/src/celeritas/phys/CutoffParams.hh
@@ -50,9 +50,9 @@ struct ImportData;
  * below the production threshold, while others (e.g. bremsstrahlung,
  * ionization) use the production cut as their instrinsic limit. By default all
  * of these secondaries are transported, even if their energy is below the
- * threshold. If the \c apply_cuts option is enabled, any secondary photon,
- * electron, or positron with energy below the cutoff will be killed (the flag
- * will be ignored for other particle types).
+ * threshold. If the \c apply_post_interaction option is enabled, any secondary
+ * photon, electron, or positron with energy below the cutoff will be killed
+ * (the flag will be ignored for other particle types).
  */
 class CutoffParams
 {
@@ -73,7 +73,7 @@ class CutoffParams
         SPConstParticles particles;
         SPConstMaterials materials;
         std::map<PDGNumber, MaterialCutoffs> cutoffs;
-        bool apply_cuts{false};
+        bool apply_post_interaction{false};
     };
 
   public:

--- a/src/celeritas/phys/CutoffView.hh
+++ b/src/celeritas/phys/CutoffView.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "CutoffData.hh"
+#include "celeritas/phys/Secondary.hh"
 
 namespace celeritas
 {
@@ -45,6 +46,12 @@ class CutoffView
 
     // Return range cutoff value
     inline CELER_FUNCTION real_type range(ParticleId particle) const;
+
+    // Whether to kill secondaries below the production cut
+    inline CELER_FUNCTION bool apply_cuts() const;
+
+    // Whether the secondary should be killed if \c apply_cuts is enabled
+    inline CELER_FUNCTION bool apply_cut(Secondary const&) const;
 
   private:
     CutoffData const& params_;
@@ -86,6 +93,27 @@ CELER_FUNCTION auto CutoffView::energy(ParticleId particle) const -> Energy
 CELER_FUNCTION real_type CutoffView::range(ParticleId particle) const
 {
     return this->get(particle).range;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether to kill secondaries below the production cut.
+ */
+CELER_FUNCTION bool CutoffView::apply_cuts() const
+{
+    return params_.apply_cuts;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether the secondary should be killed if \c apply_cuts is enabled.
+ */
+CELER_FUNCTION bool CutoffView::apply_cut(Secondary const& secondary) const
+{
+    return (secondary.particle_id == params_.ids.gamma
+            || secondary.particle_id == params_.ids.electron
+            || secondary.particle_id == params_.ids.positron)
+           && secondary.energy < this->energy(secondary.particle_id);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/CutoffView.hh
+++ b/src/celeritas/phys/CutoffView.hh
@@ -47,11 +47,11 @@ class CutoffView
     // Return range cutoff value
     inline CELER_FUNCTION real_type range(ParticleId particle) const;
 
-    // Whether to kill secondaries below the production cut
-    inline CELER_FUNCTION bool apply_cuts() const;
+    // Whether to kill secondaries below the production cut post-interaction
+    inline CELER_FUNCTION bool apply_post_interaction() const;
 
-    // Whether the secondary should be killed if \c apply_cuts is enabled
-    inline CELER_FUNCTION bool apply_cut(Secondary const&) const;
+    // Whether the post-interaction cutoff should be applied to the secondary
+    inline CELER_FUNCTION bool apply(Secondary const&) const;
 
   private:
     CutoffData const& params_;
@@ -97,18 +97,22 @@ CELER_FUNCTION real_type CutoffView::range(ParticleId particle) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to kill secondaries below the production cut.
+ * Whether to kill secondaries below the production cut post-interaction.
  */
-CELER_FUNCTION bool CutoffView::apply_cuts() const
+CELER_FUNCTION bool CutoffView::apply_post_interaction() const
 {
-    return params_.apply_cuts;
+    return params_.apply_post_interaction;
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether the secondary should be killed if \c apply_cuts is enabled.
+ * Whether the post-interaction cutoff should be applied to the secondary.
+ *
+ * This will be true if the \c apply_post_interaction option is enabled and the
+ * seccondary is an electron, positron, or gamma with energy below the
+ * production cut.
  */
-CELER_FUNCTION bool CutoffView::apply_cut(Secondary const& secondary) const
+CELER_FUNCTION bool CutoffView::apply(Secondary const& secondary) const
 {
     return (secondary.particle_id == params_.ids.gamma
             || secondary.particle_id == params_.ids.electron

--- a/src/celeritas/phys/detail/InteractionLauncherImpl.hh
+++ b/src/celeritas/phys/detail/InteractionLauncherImpl.hh
@@ -85,16 +85,16 @@ InteractionLauncherImpl<D, F>::operator()(ThreadId thread) const
 
         real_type deposition = result.energy_deposition.value();
         auto cutoff = track.make_cutoff_view();
-        if (cutoff.apply_cuts())
+        if (cutoff.apply_post_interaction())
         {
             // Kill secondaries with energies below the production cut
             for (auto& secondary : result.secondaries)
             {
-                if (cutoff.apply_cut(secondary))
+                if (cutoff.apply(secondary))
                 {
                     // Secondary is an electron, positron or gamma with energy
                     // below the production cut -- deposit the energy locally
-                    // and kill it
+                    // and clear the secondary
                     deposition += secondary.energy.value();
                     ParticleView particle{this->core_data.params.particles,
                                           secondary.particle_id};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -398,7 +398,7 @@ celeritas_add_device_test(celeritas/mat/Material)
 #-------------------------------------#
 # Phys
 set(CELERITASTEST_PREFIX celeritas/phys)
-celeritas_add_test(celeritas/phys/CutoffParams.test.cc)
+celeritas_add_test(celeritas/phys/CutoffParams.test.cc ${_needs_root})
 celeritas_add_device_test(celeritas/phys/Particle)
 celeritas_add_device_test(celeritas/phys/Physics)
 celeritas_add_test(celeritas/phys/PhysicsStepUtils.test.cc)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -398,7 +398,7 @@ celeritas_add_device_test(celeritas/mat/Material)
 #-------------------------------------#
 # Phys
 set(CELERITASTEST_PREFIX celeritas/phys)
-celeritas_add_test(celeritas/phys/CutoffParams.test.cc ${_needs_root})
+celeritas_add_test(celeritas/phys/CutoffParams.test.cc)
 celeritas_add_device_test(celeritas/phys/Particle)
 celeritas_add_device_test(celeritas/phys/Physics)
 celeritas_add_test(celeritas/phys/PhysicsStepUtils.test.cc)

--- a/test/celeritas/data/four-steel-slabs.geant.json
+++ b/test/celeritas/data/four-steel-slabs.geant.json
@@ -9,6 +9,7 @@
 "msc_range_factor": 0.04,
 "msc_safety_factor": 0.6,
 "msc_lambda_limit": 0.1,
+"apply_cuts": false,
 "lpm": true,
 "max_energy": [
  1000000.0,

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -227,7 +227,7 @@ class FourSteelSlabsEmStandard : public GeantImporterTest
         {
             nlohmann::json out = opts;
             static char const expected[]
-                = R"json({"brems":"all","coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_general":false,"integral_approach":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban_extended","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
+                = R"json({"apply_cuts":false,"brems":"all","coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_general":false,"integral_approach":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban_extended","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
             EXPECT_EQ(std::string(expected), std::string(out.dump()))
                 << "\n/*** REPLACE ***/\nR\"json(" << std::string(out.dump())
                 << ")json\"\n/******/";

--- a/test/celeritas/phys/CutoffParams.test.cc
+++ b/test/celeritas/phys/CutoffParams.test.cc
@@ -106,16 +106,16 @@ TEST_F(CutoffParamsTest, empty_cutoffs)
         for (auto const mid : range(MaterialId{materials->size()}))
         {
             CutoffView cutoffs(cutoff.host_ref(), mid);
-            if (pid == particles->find(pdg::proton()))
+            if (pid != particles->find(pdg::proton()))
+            {
+                energies.push_back(cutoffs.energy(pid).value());
+                ranges.push_back(cutoffs.range(pid));
+            }
+            else if (CELERITAS_DEBUG)
             {
                 // Protons aren't currently used
                 EXPECT_THROW(cutoffs.energy(pid), DebugError);
                 EXPECT_THROW(cutoffs.range(pid), DebugError);
-            }
-            else
-            {
-                energies.push_back(cutoffs.energy(pid).value());
-                ranges.push_back(cutoffs.range(pid));
             }
         }
     }
@@ -145,16 +145,16 @@ TEST_F(CutoffParamsTest, electron_cutoffs)
         for (auto const mid : range(MaterialId{materials->size()}))
         {
             CutoffView cutoffs(cutoff.host_ref(), mid);
-            if (pid == particles->find(pdg::proton()))
+            if (pid != particles->find(pdg::proton()))
+            {
+                energies.push_back(cutoffs.energy(pid).value());
+                ranges.push_back(cutoffs.range(pid));
+            }
+            else if (CELERITAS_DEBUG)
             {
                 // Protons aren't currently used
                 EXPECT_THROW(cutoffs.energy(pid), DebugError);
                 EXPECT_THROW(cutoffs.range(pid), DebugError);
-            }
-            else
-            {
-                energies.push_back(cutoffs.energy(pid).value());
-                ranges.push_back(cutoffs.range(pid));
             }
         }
     }

--- a/test/celeritas/phys/CutoffParams.test.cc
+++ b/test/celeritas/phys/CutoffParams.test.cc
@@ -9,10 +9,8 @@
 
 #include "corecel/cont/Range.hh"
 #include "celeritas/Quantities.hh"
+#include "celeritas/RootTestBase.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/ext/RootImporter.hh"
-#include "celeritas/ext/ScopedRootErrorHandler.hh"
-#include "celeritas/io/ImportData.hh"
 #include "celeritas/mat/ElementView.hh"
 #include "celeritas/mat/MaterialData.hh"
 #include "celeritas/mat/MaterialParams.hh"
@@ -20,6 +18,7 @@
 #include "celeritas/phys/CutoffView.hh"
 #include "celeritas/phys/ParticleData.hh"
 #include "celeritas/phys/ParticleParams.hh"
+#include "celeritas/phys/Secondary.hh"
 
 #include "celeritas_test.hh"
 
@@ -32,6 +31,8 @@ namespace test
 class CutoffParamsTest : public Test
 {
   protected:
+    using Energy = units::MevEnergy;
+
     void SetUp() override
     {
         using namespace units;
@@ -60,7 +61,7 @@ class CutoffParamsTest : public Test
              {{ElementId{0}, 1.0}},
              "H2"},
         };
-        material_params = std::make_shared<MaterialParams>(std::move(m_input));
+        materials = std::make_shared<MaterialParams>(std::move(m_input));
 
         // Set up ParticleParams
         ParticleParams::Input p_input;
@@ -73,36 +74,54 @@ class CutoffParamsTest : public Test
                            ElementaryCharge{-1},
                            stable});
         p_input.push_back({"gamma", pdg::gamma(), zero, zero, stable});
-        particle_params = std::make_shared<ParticleParams>(std::move(p_input));
+        p_input.push_back({"positron",
+                           pdg::positron(),
+                           MevMass{0.5109989461},
+                           ElementaryCharge{1},
+                           stable});
+        p_input.push_back({"proton",
+                           pdg::proton(),
+                           MevMass{938.27208816},
+                           ElementaryCharge{1},
+                           stable});
+        particles = std::make_shared<ParticleParams>(std::move(p_input));
     }
 
-    std::shared_ptr<MaterialParams> material_params;
-    std::shared_ptr<ParticleParams> particle_params;
+    std::shared_ptr<MaterialParams> materials;
+    std::shared_ptr<ParticleParams> particles;
 };
 
 TEST_F(CutoffParamsTest, empty_cutoffs)
 {
     CutoffParams::Input input;
-    input.materials = material_params;
-    input.particles = particle_params;
+    input.materials = materials;
+    input.particles = particles;
 
     // input.cutoffs left empty
-    CutoffParams cutoff_params(input);
+    CutoffParams cutoff(input);
 
     std::vector<double> energies, ranges;
-    for (auto const pid : range(ParticleId{particle_params->size()}))
+    for (auto const pid : range(ParticleId{particles->size()}))
     {
-        for (auto const matid : range(MaterialId{material_params->size()}))
+        for (auto const mid : range(MaterialId{materials->size()}))
         {
-            CutoffView cutoff_view(cutoff_params.host_ref(), matid);
-            energies.push_back(cutoff_view.energy(pid).value());
-            ranges.push_back(cutoff_view.range(pid));
+            CutoffView cutoffs(cutoff.host_ref(), mid);
+            if (pid == particles->find(pdg::proton()))
+            {
+                // Protons aren't currently used
+                EXPECT_THROW(cutoffs.energy(pid), DebugError);
+                EXPECT_THROW(cutoffs.range(pid), DebugError);
+            }
+            else
+            {
+                energies.push_back(cutoffs.energy(pid).value());
+                ranges.push_back(cutoffs.range(pid));
+            }
         }
     }
 
-    double const expected_energies[] = {0, 0, 0, 0, 0, 0};
-    double const expected_ranges[] = {0, 0, 0, 0, 0, 0};
-
+    double const expected_energies[] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+    double const expected_ranges[] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
     EXPECT_VEC_SOFT_EQ(expected_energies, energies);
     EXPECT_VEC_SOFT_EQ(expected_ranges, ranges);
 }
@@ -111,75 +130,107 @@ TEST_F(CutoffParamsTest, electron_cutoffs)
 {
     CutoffParams::Input input;
     CutoffParams::MaterialCutoffs mat_cutoffs;
-    input.materials = material_params;
-    input.particles = particle_params;
-    mat_cutoffs.push_back({units::MevEnergy{0.2}, 0.1});
-    mat_cutoffs.push_back({units::MevEnergy{0.0}, 0.0});
-    mat_cutoffs.push_back({units::MevEnergy{0.4}, 0.3});
+    input.materials = materials;
+    input.particles = particles;
+    mat_cutoffs.push_back({Energy{0.2}, 0.1});
+    mat_cutoffs.push_back({Energy{0.0}, 0.0});
+    mat_cutoffs.push_back({Energy{0.4}, 0.3});
     input.cutoffs.insert({pdg::electron(), mat_cutoffs});
 
-    CutoffParams cutoff_params(input);
+    CutoffParams cutoff(input);
 
     std::vector<double> energies, ranges;
-    for (auto const pid : range(ParticleId{particle_params->size()}))
+    for (auto const pid : range(ParticleId{particles->size()}))
     {
-        for (auto const matid : range(MaterialId{material_params->size()}))
+        for (auto const mid : range(MaterialId{materials->size()}))
         {
-            CutoffView cutoff_view(cutoff_params.host_ref(), matid);
-
-            energies.push_back(cutoff_view.energy(pid).value());
-            ranges.push_back(cutoff_view.range(pid));
+            CutoffView cutoffs(cutoff.host_ref(), mid);
+            if (pid == particles->find(pdg::proton()))
+            {
+                // Protons aren't currently used
+                EXPECT_THROW(cutoffs.energy(pid), DebugError);
+                EXPECT_THROW(cutoffs.range(pid), DebugError);
+            }
+            else
+            {
+                energies.push_back(cutoffs.energy(pid).value());
+                ranges.push_back(cutoffs.range(pid));
+            }
         }
     }
 
-    double const expected_energies[] = {0.2, 0, 0.4, 0, 0, 0};
-    double const expected_ranges[] = {0.1, 0, 0.3, 0, 0, 0};
-
+    double const expected_energies[] = {0.2, 0, 0.4, 0, 0, 0, 0, 0, 0};
+    double const expected_ranges[] = {0.1, 0, 0.3, 0, 0, 0, 0, 0, 0};
     EXPECT_VEC_SOFT_EQ(expected_energies, energies);
     EXPECT_VEC_SOFT_EQ(expected_ranges, ranges);
 }
 
+TEST_F(CutoffParamsTest, apply_cuts)
+{
+    CutoffParams::Input input;
+    input.materials = materials;
+    input.particles = particles;
+    input.cutoffs.insert({pdg::electron(), {{Energy{6}, 0.6}, {}, {}}});
+    input.cutoffs.insert({pdg::gamma(), {{Energy{4}, 0.4}, {}, {}}});
+    input.cutoffs.insert({pdg::positron(), {{Energy{2}, 0.2}, {}, {}}});
+    input.apply_cuts = true;
+    CutoffParams cutoff(input);
+
+    CutoffView cutoffs(cutoff.host_ref(), MaterialId{0});
+    EXPECT_TRUE(cutoffs.apply_cuts());
+
+    Secondary secondary;
+    secondary.energy = Energy{7};
+    secondary.particle_id = particles->find(pdg::electron());
+    EXPECT_FALSE(cutoffs.apply_cut(secondary));
+    secondary.energy = Energy{5};
+    EXPECT_TRUE(cutoffs.apply_cut(secondary));
+
+    secondary.particle_id = particles->find(pdg::gamma());
+    EXPECT_FALSE(cutoffs.apply_cut(secondary));
+    secondary.energy = Energy{3};
+    EXPECT_TRUE(cutoffs.apply_cut(secondary));
+
+    secondary.particle_id = particles->find(pdg::positron());
+    EXPECT_FALSE(cutoffs.apply_cut(secondary));
+    secondary.energy = Energy{1};
+    EXPECT_TRUE(cutoffs.apply_cut(secondary));
+}
+
 //---------------------------------------------------------------------------//
 
-class CutoffParamsImportTest : public Test
+class CutoffParamsImportTest : public RootTestBase
 {
   protected:
-    void SetUp() override
-    {
-        root_filename_
-            = this->test_data_path("celeritas", "four-steel-slabs.root");
-        RootImporter import_from_root(root_filename_.c_str());
-        data_ = import_from_root();
-    }
-    std::string root_filename_;
-    ImportData data_;
+    char const* geometry_basename() const final { return "four-steel-slabs"; }
 
-    ScopedRootErrorHandler scoped_root_error_;
+    SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstAction build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
 };
 
-TEST_F(CutoffParamsImportTest, TEST_IF_CELERITAS_USE_ROOT(import_cutoffs))
+TEST_F(CutoffParamsImportTest, import_cutoffs)
 {
-    auto const particles = ParticleParams::from_import(data_);
-    auto const materials = MaterialParams::from_import(data_);
-    auto const cutoffs = CutoffParams::from_import(data_, particles, materials);
-
     std::vector<double> energies, ranges;
-
-    for (auto const pid :
-         {particles->find(pdg::electron()), particles->find(pdg::gamma())})
+    for (auto const pid : {this->particle()->find(pdg::electron()),
+                           this->particle()->find(pdg::gamma()),
+                           this->particle()->find(pdg::positron())})
     {
-        for (auto const matid : range(MaterialId{materials->size()}))
+        for (auto const mid : range(MaterialId{this->material()->size()}))
         {
-            CutoffView cutoff_view(cutoffs->host_ref(), matid);
-            energies.push_back(cutoff_view.energy(pid).value());
-            ranges.push_back(cutoff_view.range(pid));
+            CutoffView cutoffs(this->cutoff()->host_ref(), mid);
+            energies.push_back(cutoffs.energy(pid).value());
+            ranges.push_back(cutoffs.range(pid));
+            EXPECT_FALSE(cutoffs.apply_cuts());
         }
     }
 
-    static double const expected_energies[]
-        = {0.00099, 1.3082781553076, 0.00099, 0.020822442086622};
-    static double const expected_ranges[] = {0.1, 0.1, 0.1, 0.1};
-
+    static double const expected_energies[] = {0.00099,
+                                               1.3082781553076,
+                                               0.00099,
+                                               0.020822442086622,
+                                               0.00099,
+                                               1.2358930791935};
+    static double const expected_ranges[] = {0.1, 0.1, 0.1, 0.1, 0.1, 0.1};
     EXPECT_VEC_SOFT_EQ(expected_energies, energies);
     EXPECT_VEC_SOFT_EQ(expected_ranges, ranges);
 }


### PR DESCRIPTION
This adds an [option to apply production cuts](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/TrackingAndPhysics/thresholdVScut.html#apply-cut) to all secondaries. Some processes can produce secondaries below the production threshold: the default behavior is to transport all of these secondaries. If the `apply_cuts` option is enabled (off by default, but on e.g. in the CMS physics list), secondary electrons, positrons, and gammas with energies below the production cut will be killed.