### PR TITLE
Rename OutputManager to OutputRegistry and add to CoreParams

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -217,10 +217,9 @@ void from_json(nlohmann::json const& j, LDemoArgs& v)
 //!@}
 
 //---------------------------------------------------------------------------//
-TransporterInput load_input(LDemoArgs const& args)
+CoreParams::Input load_core_params(LDemoArgs const& args)
 {
     CELER_LOG(status) << "Loading input and initializing problem data";
-    TransporterInput result;
     CoreParams::Input params;
     ImportData const imported = [&args] {
         if (ends_with(args.physics_filename, ".root"))
@@ -360,39 +359,43 @@ TransporterInput load_input(LDemoArgs const& args)
         return std::make_shared<TrackInitParams>(std::move(input));
     }();
 
-    // Create params
-    CELER_ASSERT(params);
-    result.params = std::make_shared<CoreParams>(std::move(params));
-
-    // Save constants
-    CELER_VALIDATE(args.max_num_tracks > 0,
-                   << "nonpositive max_num_tracks=" << args.max_num_tracks);
-    CELER_VALIDATE(args.max_steps > 0,
-                   << "nonpositive max_steps=" << args.max_steps);
-    result.num_track_slots = args.max_num_tracks;
-    result.max_steps = args.max_steps;
-    result.enable_diagnostics = args.enable_diagnostics;
-    result.sync = args.sync;
-
-    // Save diagnosics
-    result.energy_diag = args.energy_diag;
-
-    CELER_ENSURE(result);
-    return result;
+    return params;
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct parameters, input, and transporter from the given run arguments.
  */
-std::unique_ptr<TransporterBase> build_transporter(LDemoArgs const& run_args)
+std::unique_ptr<TransporterBase>
+build_transporter(LDemoArgs const& args,
+                  std::shared_ptr<OutputRegistry> const& outreg)
 {
+    CELER_EXPECT(outreg);
     using celeritas::MemSpace;
 
-    TransporterInput input = load_input(run_args);
+    // Save constants from args
+    TransporterInput input;
+    CELER_VALIDATE(args.max_num_tracks > 0,
+                   << "nonpositive max_num_tracks=" << args.max_num_tracks);
+    CELER_VALIDATE(args.max_steps > 0,
+                   << "nonpositive max_steps=" << args.max_steps);
+    input.num_track_slots = args.max_num_tracks;
+    input.max_steps = args.max_steps;
+    input.enable_diagnostics = args.enable_diagnostics;
+    input.sync = args.sync;
+    input.energy_diag = args.energy_diag;
+
+    // Create core params
+    input.params = [&args, &outreg] {
+        auto params = load_core_params(args);
+        params.output_reg = outreg;
+        CELER_ASSERT(params);
+        return std::make_shared<CoreParams>(std::move(params));
+    }();
+
     std::unique_ptr<TransporterBase> result;
 
-    if (run_args.use_device)
+    if (args.use_device)
     {
         CELER_VALIDATE(celeritas::device(),
                        << "CUDA device is unavailable but GPU run was "

--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -27,6 +27,7 @@
 
 namespace celeritas
 {
+class OutputRegistry;
 class CoreParams;
 
 NLOHMANN_JSON_SERIALIZE_ENUM(TrackOrder,
@@ -129,11 +130,10 @@ struct LDemoArgs
     }
 };
 
-// Load params from input arguments
-TransporterInput load_input(LDemoArgs const& args);
-
 // Build transporter from input arguments
-std::unique_ptr<TransporterBase> build_transporter(LDemoArgs const& run_args);
+std::unique_ptr<TransporterBase>
+build_transporter(LDemoArgs const& args,
+                  std::shared_ptr<celeritas::OutputRegistry> const& outreg);
 
 void to_json(nlohmann::json& j, LDemoArgs const& value);
 void from_json(nlohmann::json const& j, LDemoArgs& value);

--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -25,7 +25,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/io/OutputInterface.hh"
 #include "corecel/io/OutputInterfaceAdapter.hh"
-#include "corecel/io/OutputManager.hh"
+#include "corecel/io/outputRegistry.hh"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/DeviceIO.json.hh"
 #include "corecel/sys/Environment.hh"
@@ -167,7 +167,7 @@ init_root_mctruth_output(LDemoArgs const& run_args,
 /*!
  * Run, launch, and output.
  */
-void run(std::istream* is, OutputManager* output)
+void run(std::istream* is, outputRegistry* output)
 {
     // Read input options
     auto inp = nlohmann::json::parse(*is);
@@ -306,7 +306,7 @@ int main(int argc, char* argv[])
     }
 
     // Set up output
-    OutputManager output;
+    outputRegistry output;
     output.insert(OutputInterfaceAdapter<Device>::from_const_ref(
         OutputInterface::Category::system, "device", celeritas::device()));
     output.insert(OutputInterfaceAdapter<KernelRegistry>::from_const_ref(

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -23,7 +23,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/io/OutputInterface.hh"
 #include "corecel/io/OutputInterfaceAdapter.hh"
-#include "corecel/io/OutputManager.hh"
+#include "corecel/io/OutputRegistry.hh"
 #include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/Types.hh"
@@ -207,7 +207,7 @@ void SharedParams::Finalize()
 #if CELERITAS_USE_JSON
         CELER_LOG(info) << "Writing Celeritas output to \"" << output_filename_
                         << '"';
-        OutputManager output;
+        OutputRegistry output;
 
         // System diagnostics
         output.insert(OutputInterfaceAdapter<Device>::from_const_ref(

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -294,8 +294,9 @@ void SharedParams::initialize_core(SetupOptions const& options)
 
     CoreParams::Input params;
 
-    // Create action manager
+    // Create registries
     params.action_reg = std::make_shared<ActionRegistry>();
+    params.output_reg = std::make_shared<OutputRegistry>();
 
     // Load geometry
     params.geometry = [&options] {

--- a/src/celeritas/global/ActionRegistry.hh
+++ b/src/celeritas/global/ActionRegistry.hh
@@ -62,6 +62,9 @@ class ActionRegistry
     //! Get the number of defined actions
     ActionId::size_type num_actions() const { return actions_.size(); }
 
+    //! Whether no actions have been registered
+    bool empty() const { return actions_.empty(); }
+
     // Access an action
     inline SPConstAction const& action(ActionId id) const;
 

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -11,17 +11,14 @@
 #include <type_traits>
 #include <utility>
 
+#include "celeritas_config.h"
 #include "corecel/Assert.hh"
 #include "corecel/data/Ref.hh"
 #include "corecel/io/BuildOutput.hh"
-#include "corecel/io/OutputInterfaceAdapter.hh"
 #include "corecel/io/OutputRegistry.hh"  // IWYU pragma: keep
 #include "corecel/sys/Device.hh"
-#include "corecel/sys/DeviceIO.json.hh"
 #include "corecel/sys/Environment.hh"
-#include "corecel/sys/EnvironmentIO.json.hh"
 #include "corecel/sys/KernelRegistry.hh"
-#include "corecel/sys/KernelRegistryIO.json.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/generated/BoundaryAction.hh"
@@ -40,6 +37,13 @@
 
 #include "ActionInterface.hh"
 #include "ActionRegistry.hh"  // IWYU pragma: keep
+
+#if CELERITAS_USE_JSON
+#    include "corecel/io/OutputInterfaceAdapter.hh"
+#    include "corecel/sys/DeviceIO.json.hh"
+#    include "corecel/sys/EnvironmentIO.json.hh"
+#    include "corecel/sys/KernelRegistryIO.json.hh"
+#endif
 
 namespace celeritas
 {
@@ -156,6 +160,7 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
         device_ref_ = build_params_refs<MemSpace::device>(input_, scalars);
     }
 
+#if CELERITAS_USE_JSON
     // Save system diagnostic information
     input_.output_reg->insert(OutputInterfaceAdapter<Device>::from_const_ref(
         OutputInterface::Category::system, "device", celeritas::device()));
@@ -167,6 +172,7 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
     input_.output_reg->insert(OutputInterfaceAdapter<Environment>::from_const_ref(
         OutputInterface::Category::system, "environ", celeritas::environment()));
     input_.output_reg->insert(std::make_shared<BuildOutput>());
+#endif
 
     // Save core diagnostic information
     input_.output_reg->insert(

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -13,14 +13,25 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/data/Ref.hh"
+#include "corecel/io/BuildOutput.hh"
+#include "corecel/io/OutputInterfaceAdapter.hh"
+#include "corecel/io/OutputRegistry.hh"  // IWYU pragma: keep
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/DeviceIO.json.hh"
+#include "corecel/sys/Environment.hh"
+#include "corecel/sys/EnvironmentIO.json.hh"
+#include "corecel/sys/KernelRegistry.hh"
+#include "corecel/sys/KernelRegistryIO.json.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/generated/BoundaryAction.hh"
+#include "celeritas/global/ActionRegistryOutput.hh"
 #include "celeritas/mat/MaterialParams.hh"  // IWYU pragma: keep
 #include "celeritas/phys/CutoffParams.hh"  // IWYU pragma: keep
 #include "celeritas/phys/ParticleParams.hh"  // IWYU pragma: keep
+#include "celeritas/phys/ParticleParamsOutput.hh"
 #include "celeritas/phys/PhysicsParams.hh"  // IWYU pragma: keep
+#include "celeritas/phys/PhysicsParamsOutput.hh"
 #include "celeritas/random/RngParams.hh"  // IWYU pragma: keep
 #include "celeritas/track/ExtendFromSecondariesAction.hh"
 #include "celeritas/track/InitializeTracksAction.hh"
@@ -99,6 +110,7 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
     CP_VALIDATE_INPUT(sim);
     CP_VALIDATE_INPUT(init);
     CP_VALIDATE_INPUT(action_reg);
+    CP_VALIDATE_INPUT(output_reg);
     CP_VALIDATE_INPUT(max_streams);
 #undef CP_VALIDATE_INPUT
 
@@ -143,6 +155,27 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
     {
         device_ref_ = build_params_refs<MemSpace::device>(input_, scalars);
     }
+
+    // Save system diagnostic information
+    input_.output_reg->insert(OutputInterfaceAdapter<Device>::from_const_ref(
+        OutputInterface::Category::system, "device", celeritas::device()));
+    input_.output_reg->insert(
+        OutputInterfaceAdapter<KernelRegistry>::from_const_ref(
+            OutputInterface::Category::system,
+            "kernels",
+            celeritas::kernel_registry()));
+    input_.output_reg->insert(OutputInterfaceAdapter<Environment>::from_const_ref(
+        OutputInterface::Category::system, "environ", celeritas::environment()));
+    input_.output_reg->insert(std::make_shared<BuildOutput>());
+
+    // Save core diagnostic information
+    input_.output_reg->insert(
+        std::make_shared<ParticleParamsOutput>(input_.particle));
+    input_.output_reg->insert(
+        std::make_shared<PhysicsParamsOutput>(input_.physics));
+    input_.output_reg->insert(
+        std::make_shared<ActionRegistryOutput>(input_.action_reg));
+
     CELER_ENSURE(host_ref_);
     CELER_ENSURE(host_ref_.scalars.max_streams == this->max_streams());
 }

--- a/src/celeritas/global/CoreParams.hh
+++ b/src/celeritas/global/CoreParams.hh
@@ -25,6 +25,7 @@ class CutoffParams;
 class FluctuationParams;
 class GeoMaterialParams;
 class MaterialParams;
+class OutputRegistry;
 class ParticleParams;
 class PhysicsParams;
 class SimParams;
@@ -49,6 +50,7 @@ class CoreParams
     using SPConstSim = std::shared_ptr<SimParams const>;
     using SPConstTrackInit = std::shared_ptr<TrackInitParams const>;
     using SPActionRegistry = std::shared_ptr<ActionRegistry>;
+    using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
 
     using HostRef = HostCRef<CoreParamsData>;
     using DeviceRef = DeviceCRef<CoreParamsData>;
@@ -67,6 +69,7 @@ class CoreParams
         SPConstTrackInit init;
 
         SPActionRegistry action_reg;
+        SPOutputRegistry output_reg;
 
         //! Maximum number of simultaneous threads/tasks per process
         StreamId::size_type max_streams{1};
@@ -75,7 +78,7 @@ class CoreParams
         explicit operator bool() const
         {
             return geometry && material && geomaterial && particle && cutoff
-                   && physics && rng && sim && init && action_reg
+                   && physics && rng && sim && init && action_reg && output_reg
                    && max_streams;
         }
     };
@@ -99,6 +102,7 @@ class CoreParams
     SPConstSim const& sim() const { return input_.sim; }
     SPConstTrackInit const& init() const { return input_.init; }
     SPActionRegistry const& action_reg() const { return input_.action_reg; }
+    SPOutputRegistry const& output_reg() const { return input_.output_reg; }
     //!@}
 
     // Access properties on the host

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -23,7 +23,7 @@ list(APPEND SOURCES
   io/Logger.cc
   io/LoggerTypes.cc
   io/OutputInterface.cc
-  io/OutputManager.cc
+  io/OutputRegistry.cc
   io/ScopedStreamRedirect.cc
   io/ScopedTimeAndRedirect.cc
   io/StringUtils.cc

--- a/src/corecel/cont/Label.hh
+++ b/src/corecel/cont/Label.hh
@@ -35,8 +35,7 @@ namespace celeritas
 struct Label
 {
     std::string name;  //!< Primary readable label component
-    std::string ext;  //!< Uniquifying component such as a pointer address or
-                      //!< ID
+    std::string ext;  //!< Uniquifying component: pointer address or ID
 
     //// STATIC DATA ////
 

--- a/src/corecel/cont/LabelIO.json.hh
+++ b/src/corecel/cont/LabelIO.json.hh
@@ -14,7 +14,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Read an array from a JSON file.
+ * Read a label from a JSON file.
  */
 inline void from_json(nlohmann::json const& j, Label& value)
 {
@@ -23,7 +23,7 @@ inline void from_json(nlohmann::json const& j, Label& value)
 
 //---------------------------------------------------------------------------//
 /*!
- * Write an array to a JSON file.
+ * Write a label to a JSON file.
  */
 inline void to_json(nlohmann::json& j, Label const& value)
 {

--- a/src/corecel/io/OutputInterface.hh
+++ b/src/corecel/io/OutputInterface.hh
@@ -19,7 +19,7 @@ struct JsonPimpl;
 /*!
  * Pure abstract interface for writing metadata output to JSON.
  *
- * At the end of the program/run, the OutputManager will call the "output"
+ * At the end of the program/run, the OutputRegistry will call the "output"
  * method on all interfaces.
  *
  * \todo Perhaps another output method for saving a schema?

--- a/src/corecel/io/OutputRegistry.cc
+++ b/src/corecel/io/OutputRegistry.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/io/OutputManager.cc
+//! \file corecel/io/OutputRegistry.cc
 //---------------------------------------------------------------------------//
-#include "OutputManager.hh"
+#include "OutputRegistry.hh"
 
 #include <string>
 #include <type_traits>
@@ -29,7 +29,7 @@ namespace celeritas
 /*!
  * Add an interface for writing.
  */
-void OutputManager::insert(SPConstInterface interface)
+void OutputRegistry::insert(SPConstInterface interface)
 {
     CELER_EXPECT(interface);
     CELER_EXPECT(interface->category() != Category::size_);
@@ -49,7 +49,7 @@ void OutputManager::insert(SPConstInterface interface)
 /*!
  * Output all classes to a JSON object.
  */
-void OutputManager::output(JsonPimpl* j) const
+void OutputRegistry::output(JsonPimpl* j) const
 {
 #if CELERITAS_USE_JSON
     nlohmann::json result;
@@ -96,7 +96,7 @@ void OutputManager::output(JsonPimpl* j) const
 /*!
  * Output all classes to a JSON object that's written to the given stream.
  */
-void OutputManager::output(std::ostream* os) const
+void OutputRegistry::output(std::ostream* os) const
 {
 #if CELERITAS_USE_JSON
     JsonPimpl json_wrap;

--- a/src/corecel/io/OutputRegistry.cc
+++ b/src/corecel/io/OutputRegistry.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "OutputRegistry.hh"
 
+#include <algorithm>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -108,6 +109,17 @@ void OutputRegistry::output(std::ostream* os) const
                         "in the current build configuration";
     *os << "\"output unavailable\"";
 #endif
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether no output has been registered.
+ */
+bool OutputRegistry::empty() const
+{
+    return std::all_of(interfaces_.begin(),
+                       interfaces_.end(),
+                       [](auto const& m) { return m.empty(); });
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/OutputRegistry.hh
+++ b/src/corecel/io/OutputRegistry.hh
@@ -47,6 +47,9 @@ class OutputRegistry
     // Dump all outputs as JSON to the given stream
     void output(std::ostream* os) const;
 
+    // Whether no output has been registered
+    bool empty() const;
+
   private:
     using Category = OutputInterface::Category;
 

--- a/src/corecel/io/OutputRegistry.hh
+++ b/src/corecel/io/OutputRegistry.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/io/OutputManager.hh
+//! \file corecel/io/OutputRegistry.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -29,7 +29,7 @@ namespace celeritas
    {"category": {"label": "data"}}
  * \endverbatim
  */
-class OutputManager
+class OutputRegistry
 {
   public:
     //!@{
@@ -53,8 +53,6 @@ class OutputManager
     // Interfaces by category
     EnumArray<Category, std::map<std::string, SPConstInterface>> interfaces_;
 };
-
-// TODO: potentially add a global instance here?
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/sys/EnvironmentIO.json.hh
+++ b/src/corecel/sys/EnvironmentIO.json.hh
@@ -17,7 +17,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Read an array from a JSON file.
+ * Read environment variables from a JSON file.
  */
 inline void from_json(nlohmann::json const& j, Environment& value)
 {
@@ -30,9 +30,9 @@ inline void from_json(nlohmann::json const& j, Environment& value)
 
 //---------------------------------------------------------------------------//
 /*!
- * Write an array to a JSON file.
+ * Write environment variables to a JSON file.
  */
-void to_json(nlohmann::json& j, Environment const& value)
+inline void to_json(nlohmann::json& j, Environment const& value)
 {
     j = nlohmann::json::object();
     for (auto const& kvref : value.ordered_environment())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,7 +141,7 @@ set(CELERITASTEST_PREFIX corecel/io)
 celeritas_add_test(corecel/io/EnumStringMapper.test.cc)
 celeritas_add_test(corecel/io/Join.test.cc)
 celeritas_add_test(corecel/io/Logger.test.cc)
-celeritas_add_test(corecel/io/OutputManager.test.cc
+celeritas_add_test(corecel/io/OutputRegistry.test.cc
   LINK_LIBRARIES ${_optional_json_link})
 celeritas_add_test(corecel/io/Repr.test.cc)
 celeritas_add_test(corecel/io/StringEnumMapper.test.cc)

--- a/test/celeritas/GlobalTestBase.cc
+++ b/test/celeritas/GlobalTestBase.cc
@@ -12,7 +12,7 @@
 #include "celeritas_config.h"
 #include "corecel/io/JsonPimpl.hh"
 #include "corecel/io/Logger.hh"
-#include "corecel/io/OutputManager.hh"
+#include "corecel/io/OutputRegistry.hh"
 #include "celeritas/geo/GeoParams.hh"
 #include "celeritas/global/ActionRegistry.hh"
 #include "celeritas/global/ActionRegistryOutput.hh"
@@ -30,7 +30,7 @@ namespace test
 //---------------------------------------------------------------------------//
 GlobalTestBase::GlobalTestBase()
 {
-    output_ = std::make_shared<OutputManager>();
+    output_ = std::make_shared<OutputRegistry>();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/GlobalTestBase.cc
+++ b/test/celeritas/GlobalTestBase.cc
@@ -35,10 +35,9 @@ GlobalTestBase::GlobalTestBase()
 }
 
 //---------------------------------------------------------------------------//
-// Default destructor
 GlobalTestBase::~GlobalTestBase()
 {
-    if (this->HasFailure())
+    if (this->HasFailure() && !this->output_reg()->empty())
     {
         std::cerr << "Writing diagnostic output to screen because test failed:\n";
         this->write_output(std::cout);
@@ -101,7 +100,7 @@ void GlobalTestBase::write_output(std::ostream& os) const
 {
 #if CELERITAS_USE_JSON
     JsonPimpl json_wrap;
-    output_reg_->output(&json_wrap);
+    this->output_reg()->output(&json_wrap);
 
     // Print with pretty indentation
     os << json_wrap.obj.dump(1) << '\n';

--- a/test/celeritas/GlobalTestBase.cc
+++ b/test/celeritas/GlobalTestBase.cc
@@ -63,6 +63,7 @@ auto GlobalTestBase::build_core() -> SPConstCore
     inp.sim = this->sim();
     inp.init = this->init();
     inp.action_reg = this->action_reg();
+    inp.output_reg = this->output_reg();
     CELER_ASSERT(inp);
 
     // Build along-step action to add to the stepping loop

--- a/test/celeritas/GlobalTestBase.hh
+++ b/test/celeritas/GlobalTestBase.hh
@@ -33,7 +33,7 @@ class SimParams;
 class TrackInitParams;
 
 class CoreParams;
-class OutputManager;
+class OutputRegistry;
 
 namespace test
 {
@@ -66,7 +66,7 @@ class GlobalTestBase : public Test
     using SPConstCore = SP<CoreParams const>;
 
     using SPActionRegistry = SP<ActionRegistry>;
-    using SPOutputManager = SP<OutputManager>;
+    using SPOutputRegistry = SP<OutputRegistry>;
     //!@}
 
   public:
@@ -109,7 +109,7 @@ class GlobalTestBase : public Test
     //// OUTPUT ////
 
     //! Access output manager
-    SPOutputManager const& output_mgr() const { return output_; }
+    SPOutputRegistry const& output_mgr() const { return output_; }
     //! Write output to a debug text file
     void write_output();
     //! Write output to a stream
@@ -157,7 +157,7 @@ class GlobalTestBase : public Test
     SPConstSim sim_;
     SPConstTrackInit init_;
     SPConstCore core_;
-    SPOutputManager output_;
+    SPOutputRegistry output_;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/GlobalTestBase.hh
+++ b/test/celeritas/GlobalTestBase.hh
@@ -72,7 +72,7 @@ class GlobalTestBase : public Test
   public:
     // Create output manager on construction
     GlobalTestBase();
-    // Default destructor
+    // Print output on failure if available
     virtual ~GlobalTestBase();
 
     //// ACCESSORS ////
@@ -109,7 +109,7 @@ class GlobalTestBase : public Test
     //// OUTPUT ////
 
     //! Access output manager
-    SPOutputRegistry const& output_mgr() const { return output_; }
+    SPOutputRegistry const& output_reg() const { return output_reg_; }
     //! Write output to a debug text file
     void write_output();
     //! Write output to a stream
@@ -131,19 +131,6 @@ class GlobalTestBase : public Test
     SPActionRegistry build_action_reg() const;
     SPConstCore build_core();
 
-    void register_geometry_output() {}
-    void register_material_output() {}
-    void register_geomaterial_output() {}
-    void register_particle_output() {}
-    void register_cutoff_output() {}
-    void register_physics_output();
-    void register_along_step_output() {}
-    void register_rng_output() {}
-    void register_sim_output() {}
-    void register_init_output() {}
-    void register_action_reg_output();
-    void register_core_output() {}
-
   private:
     SPConstGeo geometry_;
     SPConstMaterial material_;
@@ -157,7 +144,7 @@ class GlobalTestBase : public Test
     SPConstSim sim_;
     SPConstTrackInit init_;
     SPConstCore core_;
-    SPOutputRegistry output_;
+    SPOutputRegistry output_reg_;
 };
 
 //---------------------------------------------------------------------------//
@@ -171,7 +158,6 @@ class GlobalTestBase : public Test
         {                                         \
             this->NAME##_ = this->build_##NAME(); \
             CELER_ASSERT(this->NAME##_);          \
-            this->register_##NAME##_output();     \
         }                                         \
         return this->NAME##_;                     \
     }                                             \

--- a/test/celeritas/global/ActionRegistry.test.cc
+++ b/test/celeritas/global/ActionRegistry.test.cc
@@ -69,6 +69,7 @@ class ActionRegistryTest : public Test
     {
         EXPECT_EQ(ActionId{0}, mgr.next_id());
         EXPECT_EQ(0, mgr.num_actions());
+        EXPECT_TRUE(mgr.empty());
 
         // Add actions
         auto impl1 = std::make_shared<MyImplicitAction>(mgr.next_id(), "impl1");
@@ -93,6 +94,7 @@ class ActionRegistryTest : public Test
 
 TEST_F(ActionRegistryTest, accessors)
 {
+    EXPECT_FALSE(mgr.empty());
     EXPECT_EQ(3, mgr.num_actions());
 
     // Find IDs

--- a/test/corecel/io/OutputRegistry.test.cc
+++ b/test/corecel/io/OutputRegistry.test.cc
@@ -110,6 +110,7 @@ class OutputRegistryTest : public Test
 TEST_F(OutputRegistryTest, empty)
 {
     OutputRegistry reg;
+    EXPECT_TRUE(reg.empty());
 
     std::string result = this->to_string(reg);
     if (CELERITAS_USE_JSON)
@@ -131,7 +132,9 @@ TEST_F(OutputRegistryTest, minimal)
 
     OutputRegistry reg;
     reg.insert(first);
+    EXPECT_FALSE(reg.empty());
     reg.insert(second);
+    EXPECT_FALSE(reg.empty());
     reg.insert(third);
 
     EXPECT_THROW(reg.insert(first), RuntimeError);

--- a/test/testdetail/TestMainImpl.cc
+++ b/test/testdetail/TestMainImpl.cc
@@ -16,7 +16,6 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/Environment.hh"
-#include "corecel/sys/KernelRegistry.hh"
 #include "corecel/sys/MpiCommunicator.hh"
 #include "corecel/sys/MpiOperations.hh"
 #include "corecel/sys/ScopedMpiInit.hh"
@@ -99,16 +98,6 @@ int test_main(int argc, char** argv)
         }
 
         // Write diagnostics and overall test result
-        if (device())
-        {
-            auto const& kr = celeritas::kernel_registry();
-            auto msg = CELER_LOG(debug);
-            msg << "Kernel diagnostics: ";
-            for (auto kernel_id : range(KernelId{kr.num_kernels()}))
-            {
-                msg << kr.kernel(kernel_id) << '\n';
-            }
-        }
         CELER_LOG(debug) << "Celeritas environment variables: "
                          << environment();
 


### PR DESCRIPTION
See #553. This makes it more clear that the output should be shared across threads. It also moves more code to the main library from the demo-loop, and removes the code from `accel` as well.