### PR TITLE
Add new capabilities to run CMS with sensitive detectors

### DIFF
--- a/app/demo-geant-integration/DetectorConstruction.cc
+++ b/app/demo-geant-integration/DetectorConstruction.cc
@@ -57,7 +57,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
     CELER_LOG_LOCAL(status) << "Loading detector geometry";
 
     G4GDMLParser gdml_parser;
-    gdml_parser.SetStripFlag(false);
+    gdml_parser.SetStripFlag(GlobalSetup::Instance()->StripGDMLPointers());
 
     std::string const& filename = GlobalSetup::Instance()->GetGeometryFile();
     if (filename.empty())

--- a/app/demo-geant-integration/DetectorConstruction.cc
+++ b/app/demo-geant-integration/DetectorConstruction.cc
@@ -98,11 +98,9 @@ void DetectorConstruction::ConstructSDandField()
     {
         // Find the end of the current range of keys
         auto stop = iter;
-        int num_keys = 0;
         do
         {
             ++stop;
-            ++num_keys;
         } while (stop != detectors_.end() && iter->first == stop->first);
 
         // Create one detector for all the volumes

--- a/app/demo-geant-integration/DetectorConstruction.hh
+++ b/app/demo-geant-integration/DetectorConstruction.hh
@@ -7,10 +7,9 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
-#include <utility>
-#include <vector>
 #include <G4VUserDetectorConstruction.hh>
 
 class G4LogicalVolume;
@@ -32,7 +31,7 @@ class DetectorConstruction final : public G4VUserDetectorConstruction
 
   private:
     std::unique_ptr<G4VPhysicalVolume> world_;
-    std::vector<std::pair<G4LogicalVolume*, std::string>> detectors_;
+    std::multimap<std::string, G4LogicalVolume*> detectors_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/demo-geant-integration/GlobalSetup.cc
+++ b/app/demo-geant-integration/GlobalSetup.cc
@@ -59,6 +59,13 @@ GlobalSetup::GlobalSetup()
         cmd.SetDefaultValue("false");
     }
     {
+        auto& cmd = messenger_->DeclareProperty("stripGDMLPointers",
+                                                strip_gdml_pointers_);
+        cmd.SetGuidance(
+            "Remove pointer suffix from input logical volume names");
+        cmd.SetDefaultValue("false");
+    }
+    {
         auto& cmd = messenger_->DeclareProperty("outputFile",
                                                 options_->output_file);
         cmd.SetGuidance("Set the JSON output file name");

--- a/app/demo-geant-integration/GlobalSetup.hh
+++ b/app/demo-geant-integration/GlobalSetup.hh
@@ -41,6 +41,7 @@ class GlobalSetup
     std::string const& GetEventFile() const { return event_file_; }
     int GetRootBufferSize() const { return root_buffer_size_; }
     bool GetWriteSDHits() const { return write_sd_hits_; }
+    bool StripGDMLPointers() const { return strip_gdml_pointers_; }
     //!@}
 
     //! Get a mutable reference to the setup options for DetectorConstruction
@@ -72,6 +73,7 @@ class GlobalSetup
     std::string event_file_;
     int root_buffer_size_{128000};
     bool write_sd_hits_{false};
+    bool strip_gdml_pointers_{false};
     G4ThreeVector field_;
 
     std::unique_ptr<G4GenericMessenger> messenger_;

--- a/app/demo-geant-integration/HitRootIO.cc
+++ b/app/demo-geant-integration/HitRootIO.cc
@@ -42,6 +42,11 @@ HitRootIO::HitRootIO()
         std::regex("\\.json$"),
         ".root");
 
+    if (file_name_.empty())
+    {
+        file_name_ = "demo-geant-integration.root";
+    }
+
     if (G4Threading::IsWorkerThread())
     {
         file_name_ += std::to_string(G4Threading::G4GetThreadId());
@@ -50,6 +55,9 @@ HitRootIO::HitRootIO()
     if (G4Threading::IsWorkerThread()
         || !G4Threading::IsMultithreadedApplication())
     {
+        CELER_LOG_LOCAL(info)
+            << "Creating ROOT event output file at '" << file_name_ << "'";
+
         file_.reset(TFile::Open(file_name_.c_str(), "recreate"));
         CELER_VALIDATE(file_->IsOpen(), << "failed to open " << file_name_);
         tree_.reset(new TTree(

--- a/app/demo-geant-integration/RunAction.cc
+++ b/app/demo-geant-integration/RunAction.cc
@@ -54,10 +54,10 @@ void RunAction::BeginOfRunAction(G4Run const* run)
     {
         // This worker (or master thread) is responsible for initializing
         // celeritas
-        if (!CELERITAS_USE_VECGEOM
-            || GlobalSetup::Instance()->StripGDMLPointers())
+        if (!CELERITAS_USE_VECGEOM)
         {
-            // For testing purposes, pass the GDML input filename to Celeritas
+            // To allow ORANGE to work for testing purposes, pass the GDML
+            // input filename to Celeritas
             const_cast<celeritas::SetupOptions&>(*options_).geometry_file
                 = GlobalSetup::Instance()->GetGeometryFile();
         }

--- a/app/demo-geant-integration/RunAction.cc
+++ b/app/demo-geant-integration/RunAction.cc
@@ -54,7 +54,8 @@ void RunAction::BeginOfRunAction(G4Run const* run)
     {
         // This worker (or master thread) is responsible for initializing
         // celeritas
-        if (!CELERITAS_USE_VECGEOM)
+        if (!CELERITAS_USE_VECGEOM
+            || GlobalSetup::Instance()->StripGDMLPointers())
         {
             // For testing purposes, pass the GDML input filename to Celeritas
             const_cast<celeritas::SetupOptions&>(*options_).geometry_file

--- a/app/demo-geant-integration/demo-geant-integration.cc
+++ b/app/demo-geant-integration/demo-geant-integration.cc
@@ -78,6 +78,7 @@ void run(std::string const& macro_filename)
     ui->ApplyCommand("/control/execute " + macro_filename);
 
     // Initialize run and process events
+    CELER_LOG(status) << "Initializing run manager";
     run_manager->Initialize();
 
     // Load the input file
@@ -86,6 +87,7 @@ void run(std::string const& macro_filename)
         num_events = demo_geant::PrimaryGeneratorAction::NumEvents(),
         celeritas::ExceptionConverter{"demo-geant000"});
 
+    CELER_LOG(status) << "Transporting " << num_events << " events";
     run_manager->BeamOn(num_events);
 }
 

--- a/scripts/cmake-presets/goldfinger.json
+++ b/scripts/cmake-presets/goldfinger.json
@@ -9,9 +9,10 @@
       "binaryDir": "${sourceDir}/build-${presetName}",
       "cacheVariables": {
         "CELERITAS_USE_CUDA":    {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_HepMC3":  {"type": "BOOL",   "value": "ON"},
         "CELERITAS_USE_HIP":     {"type": "BOOL",   "value": "OFF"},
-        "CELERITAS_USE_JSON":     {"type": "BOOL",   "value": "ON"},
-        "CELERITAS_USE_Geant4":   {"type": "BOOL",   "value": "ON"},
+        "CELERITAS_USE_JSON":    {"type": "BOOL",   "value": "ON"},
+        "CELERITAS_USE_Geant4":  {"type": "BOOL",   "value": "ON"},
         "CELERITAS_USE_MPI":     {"type": "BOOL",   "value": "OFF"},
         "CELERITAS_USE_SWIG":    {"type": "BOOL",   "value": "OFF"},
         "CMAKE_BUILD_TYPE":      {"type": "STRING", "value": "Debug"},

--- a/scripts/cmake-presets/goldfinger.json
+++ b/scripts/cmake-presets/goldfinger.json
@@ -61,7 +61,8 @@
       "inherits": [".reldeb", "vecgeom"],
       "cacheVariables": {
         "CELERITAS_BUILD_DEMOS": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "ON"}
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_ROOT": {"type": "BOOL",   "value": "ON"}
       }
     },
     {
@@ -70,7 +71,8 @@
       "inherits": [".ndebug", "vecgeom"],
       "cacheVariables": {
         "CELERITAS_BUILD_DEMOS": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_ROOT": {"type": "BOOL",   "value": "ON"}
       }
     }
   ],

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -66,6 +66,7 @@ struct SetupOptions
     using SPConstAction = std::shared_ptr<ExplicitActionInterface const>;
     using AlongStepFactory
         = std::function<SPConstAction(AlongStepFactoryInput const&)>;
+    using IntAccessor = std::function<int()>;
     using VecString = std::vector<std::string>;
     //!@}
 
@@ -98,6 +99,9 @@ struct SetupOptions
     //! Sync the GPU at every kernel for error checking
     bool sync{false};
     //!@}
+
+    //! Set the number of streams (defaults to run manager # threads)
+    IntAccessor get_num_streams;
 
     //!@{
     //! \name Stepping actions

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -82,6 +82,8 @@ struct SetupOptions
     std::string geometry_file;
     //! Filename for JSON diagnostic output
     std::string output_file;
+    //! Filename for ROOT dump of physics data
+    std::string physics_output_file;
     //!@}
 
     //!@{

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -271,12 +271,9 @@ void SharedParams::initialize_core(SetupOptions const& options)
     }();
     CELER_ASSERT(imported && *imported);
 
-    if (CELERITAS_USE_ROOT && options.output_file.size() > 5)
+    if (!options.physics_output_file.empty())
     {
-        std::string root_out{options.output_file.begin(),
-                             options.output_file.end() - 5};
-        root_out += ".root";
-        RootExporter export_root(root_out.c_str());
+        RootExporter export_root(options.physics_output_file.c_str());
         export_root(*imported);
     }
 

--- a/src/accel/detail/HitManager.cc
+++ b/src/accel/detail/HitManager.cc
@@ -8,7 +8,6 @@
 #include "HitManager.hh"
 
 #include <utility>
-#include <G4LogicalVolume.hh>
 #include <G4LogicalVolumeStore.hh>
 #include <G4RunManager.hh>
 #include <G4Threading.hh>
@@ -18,13 +17,11 @@
 #include "corecel/cont/EnumArray.hh"
 #include "corecel/cont/Label.hh"
 #include "corecel/cont/Range.hh"
-#include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/ext/GeantSetup.hh"
-#include "celeritas/ext/detail/GeantVolumeVisitor.hh"
+#include "celeritas/ext/GeantVolumeMapper.hh"
 #include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
-#include "celeritas/io/ImportVolume.hh"
 #include "accel/SetupOptions.hh"
 
 #include "HitProcessor.hh"
@@ -43,6 +40,7 @@ void update_selection(StepPointSelection* selection,
     selection->pos = options.position;
     selection->energy = options.kinetic_energy;
 }
+
 //---------------------------------------------------------------------------//
 }  // namespace
 
@@ -69,10 +67,8 @@ HitManager::HitManager(GeoParams const& geo, SDSetupOptions const& setup)
     // Logical volumes to pass to hit processor
     std::vector<G4LogicalVolume*> geant_vols;
 
-    // Helper class to extract GDML names+labels from Geant4 volume
-    GeantVolumeVisitor visitor(true);
-
-    // Loop over all logical volumes
+    // Loop over all logical volumes and map detectors to Volume IDS
+    GeantVolumeMapper g4_to_celer{geo};
     G4LogicalVolumeStore* lv_store = G4LogicalVolumeStore::GetInstance();
     CELER_ASSERT(lv_store);
     for (G4LogicalVolume* lv : *lv_store)
@@ -86,50 +82,7 @@ HitManager::HitManager(GeoParams const& geo, SDSetupOptions const& setup)
             continue;
         }
 
-        // Convert volume name to GPU geometry ID
-        auto label = Label::from_geant(lv->GetName());
-        if (label.ext.empty())
-        {
-            // Label doesn't have a pointer address attached: we probably need
-            // to regenerate to match the exported GDML file
-            label = Label::from_geant(visitor.generate_name(*lv));
-        }
-
-        auto id = geo.find_volume(label);
-        if (!id)
-        {
-            // Fallback to skipping the extension
-            auto all_ids = geo.find_volumes(label.name);
-            if (all_ids.size() == 1)
-            {
-                id = all_ids.front();
-                CELER_LOG(warning)
-                    << "Failed to find " << celeritas_geometry
-                    << " volume corresponding to Geant4 volume '"
-                    << lv->GetName() << "'; found '" << geo.id_to_label(id)
-                    << "' by omitting the extension";
-            }
-            else
-            {
-                // Try regenerating the name even if we *did* have a pointer
-                // address attached (in case the original volume name already
-                // had a pointer suffix and we added another)
-                label = Label::from_geant(visitor.generate_name(*lv));
-                id = geo.find_volume(label.name);
-                if (!id)
-                {
-                    CELER_LOG(warning)
-                        << "Multiple volumes '"
-                        << join(all_ids.begin(),
-                                all_ids.end(),
-                                "', '",
-                                [&geo](VolumeId v) {
-                                    return geo.id_to_label(v);
-                                })
-                        << "' match the Geant4 volume with extension omitted";
-                }
-            }
-        }
+        auto id = g4_to_celer(*lv);
         CELER_VALIDATE(id,
                        << "failed to find a unique " << celeritas_geometry
                        << " volume corresponding to Geant4 volume '"

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -106,10 +106,12 @@ if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
 endif()
 
 if(CELERITAS_USE_Geant4)
+  set(_cg4_libs Celeritas::corecel XercesC::XercesC ${Geant4_LIBRARIES})
   celeritas_add_object_library(celeritas_geant4
     ext/LoadGdml.cc
     ext/GeantImporter.cc
     ext/GeantSetup.cc
+    ext/GeantVolumeMapper.cc
     ext/detail/GeantBremsstrahlungProcess.cc
     ext/detail/GeantExceptionHandler.cc
     ext/detail/GeantGeoExporter.cc
@@ -120,9 +122,12 @@ if(CELERITAS_USE_Geant4)
     ext/detail/GeantProcessImporter.cc
     ext/detail/GeantVolumeVisitor.cc
   )
-  target_link_libraries(celeritas_geant4
-    PRIVATE Celeritas::corecel XercesC::XercesC ${Geant4_LIBRARIES}
-  )
+  if(CELERITAS_USE_VecGeom)
+    list(APPEND _cg4_libs VecGeom::vecgeom)
+  else()
+    list(APPEND _cg4_libs Celeritas::orange)
+  endif()
+  target_link_libraries(celeritas_geant4 PRIVATE ${_cg4_libs})
   list(APPEND SOURCES $<TARGET_OBJECTS:celeritas_geant4>)
   list(APPEND PRIVATE_DEPS celeritas_geant4)
 endif()

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -731,7 +731,9 @@ GeantImporter::import_volumes(bool unique_volumes) const
     visitor.visit(*world_->GetLogicalVolume());
 
     auto volumes = visitor.build_volume_vector();
-    CELER_LOG(debug) << "Loaded " << volumes.size() << " volumes";
+    CELER_LOG(debug) << "Loaded " << volumes.size() << " volumes with "
+                     << (unique_volumes ? "uniquified" : "original")
+                     << " names";
     return volumes;
 }
 

--- a/src/celeritas/ext/GeantVolumeMapper.cc
+++ b/src/celeritas/ext/GeantVolumeMapper.cc
@@ -1,0 +1,82 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/GeantVolumeMapper.cc
+//---------------------------------------------------------------------------//
+#include "GeantVolumeMapper.hh"
+
+#include <G4LogicalVolume.hh>
+
+#include "celeritas_cmake_strings.h"
+#include "corecel/io/Join.hh"
+#include "corecel/io/Logger.hh"
+#include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
+
+#include "detail/GeantVolumeVisitor.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Find the celeritas (VecGeom/ORANGE) volume ID for a Geant4 volume.
+ *
+ * This will warn if the name's extension had to be changed to match the
+ * volume; and it will return an empty ID if no match was found.
+ */
+VolumeId GeantVolumeMapper::operator()(G4LogicalVolume const& lv) const
+{
+    // Convert volume name to GPU geometry ID
+    auto label = Label::from_geant(lv.GetName());
+    if (label.ext.empty())
+    {
+        // Label doesn't have a pointer address attached: we probably need
+        // to regenerate to match the exported GDML file
+        label
+            = Label::from_geant(detail::GeantVolumeVisitor::generate_name(lv));
+    }
+
+    if (auto id = geo.find_volume(label))
+    {
+        // Exact match
+        return id;
+    }
+
+    // Fall back to skipping the extension: look for all possible matches
+    auto all_ids = geo.find_volumes(label.name);
+    if (all_ids.size() == 1)
+    {
+        CELER_LOG(warning) << "Failed to exactly match " << celeritas_geometry
+                           << " volume from Geant4 volume '" << lv.GetName()
+                           << "'; found '" << geo.id_to_label(all_ids.front())
+                           << "' by omitting the extension";
+        return all_ids.front();
+    }
+
+    // Try regenerating the name even if we *did* have a pointer
+    // address attached (in case an original GDML volume name already
+    // had a pointer suffix and LoadGdml added another)
+    label = Label::from_geant(detail::GeantVolumeVisitor::generate_name(lv));
+    all_ids = geo.find_volumes(label.name);
+    if (all_ids.size() > 1)
+    {
+        CELER_LOG(warning)
+            << "Multiple volumes '"
+            << join(all_ids.begin(),
+                    all_ids.end(),
+                    "', '",
+                    [this](VolumeId v) { return geo.id_to_label(v); })
+            << "' match the Geant4 volume with extension omitted: returning "
+               "the last one";
+        return all_ids.back();
+    }
+    else if (all_ids.empty())
+    {
+        return {};
+    }
+    return all_ids.front();
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/ext/GeantVolumeMapper.hh
+++ b/src/celeritas/ext/GeantVolumeMapper.hh
@@ -29,7 +29,7 @@ struct GeantVolumeMapper
 };
 
 #if !CELERITAS_USE_GEANT4
-inline VolumeId operator()(G4LogicalVolume const&) const
+inline VolumeId GeantVolumeMapper::operator()(G4LogicalVolume const&) const
 {
     CELER_NOT_CONFIGURED("Geant4");
 }

--- a/src/celeritas/ext/GeantVolumeMapper.hh
+++ b/src/celeritas/ext/GeantVolumeMapper.hh
@@ -1,0 +1,39 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/GeantVolumeMapper.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "celeritas_config.h"
+#include "celeritas/Types.hh"
+#include "celeritas/geo/GeoParamsFwd.hh"
+
+// Geant4 forward declaration
+class G4LogicalVolume;  // IWYU pragma: keep
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Map a Geant4 logical volume to a Celeritas volume ID.
+ */
+struct GeantVolumeMapper
+{
+    GeoParams const& geo;
+
+    // Convert a volume; null if not found; warn if inexact match
+    VolumeId operator()(G4LogicalVolume const&) const;
+};
+
+#if !CELERITAS_USE_GEANT4
+inline VolumeId operator()(G4LogicalVolume const&) const
+{
+    CELER_NOT_CONFIGURED("Geant4");
+}
+#endif
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/ext/detail/GeantGeoExporter.cc
+++ b/src/celeritas/ext/detail/GeantGeoExporter.cc
@@ -55,9 +55,9 @@ void GeantGeoExporter::operator()(std::string const& filename) const
     ScopedTimeAndRedirect time_and_output_("G4GDMLParser");
 
     G4GDMLParser parser;
-    parser.SetEnergyCutsExport(true);
-    parser.SetSDExport(true);
-    parser.SetOverlapCheck(true);
+    parser.SetEnergyCutsExport(false);
+    parser.SetSDExport(false);
+    parser.SetOverlapCheck(false);
 #if G4VERSION_NUMBER >= 1070
     parser.SetOutputFileOverwrite(true);
 #endif

--- a/src/celeritas/ext/detail/GeantGeoExporter.cc
+++ b/src/celeritas/ext/detail/GeantGeoExporter.cc
@@ -7,7 +7,10 @@
 //---------------------------------------------------------------------------//
 #include "GeantGeoExporter.hh"
 
+#include <algorithm>
 #include <G4GDMLParser.hh>
+#include <G4LogicalVolume.hh>
+#include <G4LogicalVolumeStore.hh>
 #include <G4Threading.hh>
 #include <G4VPhysicalVolume.hh>
 #include <G4Version.hh>
@@ -61,8 +64,19 @@ void GeantGeoExporter::operator()(std::string const& filename) const
 #if G4VERSION_NUMBER >= 1070
     parser.SetOutputFileOverwrite(true);
 #endif
-    constexpr bool append_pointers = true;
-    parser.Write(filename, world_, append_pointers);
+
+    G4LogicalVolumeStore* lv_store = G4LogicalVolumeStore::GetInstance();
+    CELER_ASSERT(lv_store);
+    bool all_uniquified = std::all_of(
+        lv_store->begin(), lv_store->end(), [](G4LogicalVolume* lv) {
+            std::string const& name = lv->GetName();
+            return name.find("0x") != std::string::npos;
+        });
+
+    parser.Write(filename, world_, /* append_pointers = */ !all_uniquified);
+    CELER_LOG(debug) << "Wrote temporary GDML to " << filename
+                     << (all_uniquified ? "without " : "with")
+                     << "additional pointer suffix";
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantVolumeVisitor.hh
+++ b/src/celeritas/ext/detail/GeantVolumeVisitor.hh
@@ -11,12 +11,12 @@
 #include <string>
 #include <vector>
 
+#include "celeritas/io/ImportVolume.hh"
+
 class G4LogicalVolume;
 
 namespace celeritas
 {
-struct ImportVolume;
-
 namespace detail
 {
 //---------------------------------------------------------------------------//
@@ -26,14 +26,14 @@ namespace detail
 class GeantVolumeVisitor
 {
   public:
+    // Generate the GDML name for a Geant4 logical volume
+    static std::string generate_name(G4LogicalVolume const& logical_volume);
+
     // Construct with the unique volume flag
     explicit inline GeantVolumeVisitor(bool unique_volumes);
 
     // Recurse into the given logical volume
     void visit(G4LogicalVolume const& logical_volume);
-
-    // Generate the GDML name for a Geant4 logical volume
-    std::string generate_name(G4LogicalVolume const& logical_volume);
 
     // Transform the map of volumes into a contiguous vector with empty spaces
     std::vector<ImportVolume> build_volume_vector() const;

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -110,7 +110,7 @@ OrangeParams::OrangeParams(G4VPhysicalVolume const*)
  */
 OrangeParams::OrangeParams(OrangeInput input)
 {
-    CELER_VALIDATE(!input.units.empty(), << "input geometry has no universes");
+    CELER_VALIDATE(input, << "input geometry is incomplete");
 
     HostVal<OrangeParamsData> host_data;
 

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -20,7 +20,6 @@
 #include "BoundingBox.hh"
 #include "OrangeData.hh"
 #include "OrangeTypes.hh"
-#include "detail/UnitIndexer.hh"
 
 class G4VPhysicalVolume;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -294,6 +294,8 @@ celeritas_add_test(celeritas/ext/GeantImporter.test.cc
     "OneSteelSphere.*"
     "OneSteelSphereGG.*"
   )
+celeritas_add_test(celeritas/ext/GeantVolumeMapper.test.cc ${_needs_geant4}
+  LINK_LIBRARIES ${Geant4_LIBRARIES} Celeritas::orange)
 celeritas_add_test(celeritas/ext/RootImporter.test.cc ${_needs_root})
 
 #-------------------------------------#

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -1,0 +1,368 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/GeantVolumeMapper.test.cc
+//---------------------------------------------------------------------------//
+#include "celeritas/ext/GeantVolumeMapper.hh"
+
+#include <regex>
+#include <string>
+#include <vector>
+
+#include "celeritas_config.h"
+#include "celeritas/geo/GeoParams.hh"
+
+#include "celeritas_test.hh"
+
+#if CELERITAS_USE_GEANT4
+#    include <G4LogicalVolume.hh>
+#    include <G4LogicalVolumeStore.hh>
+#    include <G4Material.hh>
+#    include <G4NistManager.hh>
+#    include <G4Orb.hh>
+#    include <G4PVPlacement.hh>
+#    include <G4PhysicalVolumeStore.hh>
+#    include <G4SolidStore.hh>
+#    include <G4SubtractionSolid.hh>
+#    include <G4ThreeVector.hh>
+#    include <G4VPhysicalVolume.hh>
+#    include <G4VSolid.hh>
+#endif
+
+#include "corecel/io/Logger.hh"
+#include "corecel/sys/MpiCommunicator.hh"
+#include "orange/OrangeParams.hh"
+#include "orange/construct/OrangeInput.hh"
+#include "orange/construct/SurfaceInputBuilder.hh"
+#include "orange/surf/Sphere.hh"
+
+class G4VSolid;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+class GeantVolumeMapperTestBase : public ::celeritas::test::Test
+{
+  protected:
+    void SetUp() override
+    {
+        using namespace std::placeholders;
+        celeritas::world_logger() = Logger(
+            MpiCommunicator{},
+            std::bind(
+                &GeantVolumeMapperTestBase::log_message, this, _1, _2, _3));
+    }
+
+    void log_message(Provenance, LogLevel lev, std::string msg)
+    {
+        if (lev > LogLevel::info)
+        {
+            static const std::regex delete_ansi("\033\\[[0-9;]*m");
+            messages_.push_back(std::regex_replace(msg, delete_ansi, ""));
+        }
+    }
+
+    static void TearDownTestCase()
+    {
+        // Restore logger
+        celeritas::world_logger() = celeritas::make_default_world_logger();
+    }
+
+    // Clean up geometry at destruction
+    void TearDown() override
+    {
+#if CELERITAS_USE_GEANT4
+        G4PhysicalVolumeStore::Clean();
+        G4LogicalVolumeStore::Clean();
+        G4SolidStore::Clean();
+#endif
+        geo_params_.reset();
+    }
+
+    // Construct geometry
+    void build()
+    {
+        if (CELERITAS_USE_GEANT4)
+        {
+            this->build_g4();
+        }
+        CELER_ASSERT(!logical_.empty());
+
+        if (CELERITAS_USE_VECGEOM)
+        {
+            this->build_vecgeom();
+        }
+        else
+        {
+            this->build_orange();
+        }
+        CELER_ENSURE(geo_params_);
+    }
+
+  private:
+    virtual void build_g4() = 0;
+    virtual void build_vecgeom() = 0;
+    virtual void build_orange() = 0;
+
+  protected:
+    // Non-owning pointers
+    std::vector<G4VSolid*> solids_;
+    std::vector<G4LogicalVolume*> logical_;
+    std::vector<G4VPhysicalVolume*> physical_;
+
+    // Celeritas data
+    std::shared_ptr<GeoParams> geo_params_;
+    std::vector<std::string> messages_;
+};
+
+//---------------------------------------------------------------------------//
+// NESTED TEST
+//---------------------------------------------------------------------------//
+class NestedTest : public GeantVolumeMapperTestBase
+{
+  private:
+    void build_g4() final;
+    void build_vecgeom() final;
+    void build_orange() final;
+
+  protected:
+    std::vector<std::string> names_;
+};
+
+void NestedTest::build_g4()
+{
+    CELER_EXPECT(!names_.empty());
+#if CELERITAS_USE_GEANT4
+    G4Material* mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+
+    G4LogicalVolume* parent_lv = nullptr;
+    double radius{static_cast<double>(names_.size()) + 1};
+    for (std::string const& name : names_)
+    {
+        // Create solid shape
+        solids_.push_back(new G4Orb(name + "_solid", radius));
+
+        // Create logical volume
+        logical_.push_back(new G4LogicalVolume(solids_.back(), mat, name));
+
+        // Create physical volume
+        physical_.push_back(new G4PVPlacement(G4Transform3D{},
+                                              logical_.back(),
+                                              name + "_pv",
+                                              parent_lv,
+                                              /* pMany = */ false,
+                                              /* pCopyNo = */ 0));
+        radius -= 1.0;
+        parent_lv = logical_.back();
+    }
+
+    CELER_ASSERT(mat);
+#else
+    CELER_NOT_CONFIGURED("Geant4");
+#endif
+}
+
+void NestedTest::build_vecgeom()
+{
+    CELER_EXPECT(!physical_.empty());
+    geo_params_ = std::make_shared<GeoParams>(physical_.front());
+}
+
+void NestedTest::build_orange()
+{
+    // Create ORANGE input manually
+    UnitInput ui;
+    ui.label = "global";
+
+    double radius{static_cast<double>(names_.size()) + 1};
+    ui.bbox = {{-radius, -radius, -radius}, {radius, radius, radius}};
+
+    SurfaceInputBuilder insert_surface(&ui.surfaces);
+    LocalSurfaceId daughter;
+    for (std::string const& name : names_)
+    {
+        // Insert surfaces
+        auto parent = insert_surface(Sphere({0, 0, 0}, radius), Label("name"));
+        radius -= 1.0;
+
+        // Insert volume
+        VolumeInput vi;
+        vi.label = name;
+        if (daughter)
+        {
+            vi.logic = {1, logic::lnot, 0, logic::land};
+            vi.faces = {daughter, parent};
+        }
+        else
+        {
+            vi.logic = {0, logic::lnot};
+            vi.faces = {parent};
+        }
+        ui.volumes.push_back(std::move(vi));
+        daughter = parent;
+    }
+
+    OrangeInput input;
+    input.max_level = 1;
+    input.units.push_back(std::move(ui));
+    auto geo = std::make_shared<OrangeParams>(std::move(input));
+#if !CELERITAS_USE_VECGEOM
+    geo_params_ = std::move(geo);
+#else
+    (void)sizeof(geo);
+#endif
+    CELER_ENSURE(geo_params_);
+}
+
+//---------------------------------------------------------------------------//
+// NESTED TEST
+//---------------------------------------------------------------------------//
+class IntersectionTest : public GeantVolumeMapperTestBase
+{
+  private:
+    void build_g4() final;
+    void build_vecgeom() final;
+    void build_orange() final;
+
+  protected:
+    bool suffix_{false};
+};
+
+#if !CELERITAS_USE_VECGEOM
+#    define SKIP_IF_ORANGE(NAME) DISABLED_##NAME
+#else
+#    define SKIP_IF_ORANGE(NAME) NAME
+#endif
+
+//---------------------------------------------------------------------------//
+// Geant4 constructed directly by user
+TEST_F(NestedTest, unique)
+{
+    names_ = {"world", "outer", "middle", "inner"};
+    this->build();
+    CELER_ASSERT(logical_.size() == names_.size());
+
+    GeantVolumeMapper find_vol{*geo_params_};
+    for (auto i : range(names_.size()))
+    {
+        VolumeId vol_id = find_vol(*logical_[i]);
+        ASSERT_NE(VolumeId{}, vol_id);
+        EXPECT_EQ(names_[i], geo_params_->id_to_label(vol_id).name);
+    }
+
+    if (CELERITAS_USE_VECGEOM)
+    {
+        EXPECT_EQ(0, messages_.size());
+    }
+    else
+    {
+        static std::string const expected_messages[]
+            = {"Failed to exactly match ORANGE volume from Geant4 volume "
+               "'world'; found 'world@global' by omitting the extension",
+               "Failed to exactly match ORANGE volume from Geant4 volume "
+               "'outer'; found 'outer@global' by omitting the extension",
+               "Failed to exactly match ORANGE volume from Geant4 volume "
+               "'middle'; found 'middle@global' by omitting the extension",
+               "Failed to exactly match ORANGE volume from Geant4 volume "
+               "'inner'; found 'inner@global' by omitting the extension"};
+        EXPECT_VEC_EQ(expected_messages, messages_);
+    }
+}
+
+// Geant4 constructed directly by user
+TEST_F(NestedTest, SKIP_IF_ORANGE(duplicated))
+{
+    names_ = {"world", "dup", "dup", "bob"};
+    this->build();
+    CELER_ASSERT(logical_.size() == names_.size());
+
+    GeantVolumeMapper find_vol{*geo_params_};
+    for (auto i : range(names_.size()))
+    {
+        VolumeId vol_id = find_vol(*logical_[i]);
+        ASSERT_NE(VolumeId{}, vol_id);
+        EXPECT_EQ(names_[i], geo_params_->id_to_label(vol_id).name);
+    }
+
+    // IDs for the unique LVs should be different
+    EXPECT_NE(find_vol(*logical_[1]), find_vol(*logical_[2]));
+
+    EXPECT_EQ(0, messages_.size());
+}
+
+// Geant4 constructed from celeritas::LoadGdml (no stripping)
+TEST_F(NestedTest, SKIP_IF_ORANGE(suffixed))
+{
+    names_ = {"world0xabc123", "outer0x123", "inner0xabc"};
+    this->build();
+    CELER_ASSERT(logical_.size() == names_.size());
+
+    GeantVolumeMapper find_vol{*geo_params_};
+    for (auto i : range(names_.size()))
+    {
+        VolumeId vol_id = find_vol(*logical_[i]);
+        ASSERT_NE(VolumeId{}, vol_id);
+        EXPECT_EQ(Label::from_geant(names_[i]),
+                  geo_params_->id_to_label(vol_id));
+    }
+}
+
+// Loaded GDML through demo app without stripping, then not stripped again
+TEST_F(NestedTest, SKIP_IF_ORANGE(duplicated_suffixed))
+{
+    names_ = {"world0x1", "dup0x2", "dup0x3", "bob0x4"};
+    this->build();
+    CELER_ASSERT(logical_.size() == names_.size());
+
+    GeantVolumeMapper find_vol{*geo_params_};
+    for (auto i : range(names_.size()))
+    {
+        VolumeId vol_id = find_vol(*logical_[i]);
+        ASSERT_NE(VolumeId{}, vol_id);
+        EXPECT_EQ(Label::from_geant(names_[i]),
+                  geo_params_->id_to_label(vol_id));
+    }
+}
+
+TEST_F(NestedTest, SKIP_IF_ORANGE(double_prefixed))
+{
+    names_ = {"world0x10xa", "outer0x20xb", "inner0x30xc"};
+    this->build();
+    CELER_ASSERT(logical_.size() == names_.size());
+
+    GeantVolumeMapper find_vol{*geo_params_};
+    for (auto i : range(names_.size()))
+    {
+        VolumeId vol_id = find_vol(*logical_[i]);
+        ASSERT_NE(VolumeId{}, vol_id);
+        EXPECT_EQ(Label::from_geant(names_[i]),
+                  geo_params_->id_to_label(vol_id));
+    }
+}
+
+TEST_F(NestedTest, SKIP_IF_ORANGE(duplicated_double_prefixed))
+{
+    names_ = {"world0x10xa", "dup0x20xb", "dup0x30xc", "bob0x40xd"};
+    this->build();
+    CELER_ASSERT(logical_.size() == names_.size());
+
+    GeantVolumeMapper find_vol{*geo_params_};
+    for (auto i : range(names_.size()))
+    {
+        VolumeId vol_id = find_vol(*logical_[i]);
+        ASSERT_NE(VolumeId{}, vol_id);
+        EXPECT_EQ(Label::from_geant(names_[i]),
+                  geo_params_->id_to_label(vol_id));
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -31,11 +31,11 @@ class OrangeTest : public OrangeGeoTestBase
     {
         if (!host_state_)
         {
-            host_state_ = HostStateStore(this->params().host_ref(), 1);
+            host_state_ = HostStateStore(this->host_params(), 1);
         }
 
         return OrangeTrackView(
-            this->params().host_ref(), host_state_.ref(), TrackSlotId{0});
+            this->host_params(), host_state_.ref(), TrackSlotId{0});
     }
 
   private:

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -18,6 +18,7 @@
 #include "orange/Types.hh"
 #include "orange/construct/OrangeInput.hh"
 #include "orange/construct/SurfaceInputBuilder.hh"
+#include "orange/detail/UnitIndexer.hh"
 #include "orange/surf/Sphere.hh"
 #include "orange/surf/SurfaceAction.hh"
 #include "orange/surf/SurfaceIO.hh"
@@ -77,6 +78,10 @@ std::vector<Sense> OrangeGeoTestBase::string_to_senses(std::string const& s)
     });
     return result;
 }
+
+//---------------------------------------------------------------------------//
+//! Default constructor
+OrangeGeoTestBase::OrangeGeoTestBase() = default;
 
 //---------------------------------------------------------------------------//
 //! Default destructor
@@ -182,9 +187,19 @@ auto OrangeGeoTestBase::host_state() -> HostStateRef const&
     CELER_EXPECT(params_);
     if (!host_state_)
     {
-        host_state_ = HostStateStore(this->params().host_ref(), 1);
+        host_state_ = HostStateStore(this->host_params(), 1);
     }
     return host_state_.ref();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access the params data on the host.
+ */
+auto OrangeGeoTestBase::host_params() const -> HostParamsRef const&
+{
+    CELER_EXPECT(params_);
+    return params_->host_ref();
 }
 
 //---------------------------------------------------------------------------//
@@ -199,7 +214,7 @@ void OrangeGeoTestBase::describe(std::ostream& os) const
     CELER_EXPECT(params_);
 
     // TODO: update when multiple units are in play
-    auto const& host_ref = this->params().host_ref();
+    auto const& host_ref = this->host_params();
     CELER_ASSERT(host_ref.simple_unit.size() == 1);
 
     os << "# Surfaces\n";
@@ -214,6 +229,16 @@ void OrangeGeoTestBase::describe(std::ostream& os) const
         surf_to_stream(id);
         os << '\n';
     }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return the number of volumes.
+ */
+VolumeId::size_type OrangeGeoTestBase::num_volumes() const
+{
+    CELER_EXPECT(params_);
+    return params_->num_volumes();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -14,6 +14,7 @@
 #include "celeritas_config.h"
 #include "corecel/data/Ref.hh"
 #include "corecel/io/Join.hh"
+#include "orange/OrangeParams.hh"
 #include "orange/Types.hh"
 #include "orange/construct/OrangeInput.hh"
 #include "orange/construct/SurfaceInputBuilder.hh"

--- a/test/orange/OrangeGeoTestBase.hh
+++ b/test/orange/OrangeGeoTestBase.hh
@@ -35,7 +35,8 @@ class OrangeGeoTestBase : public Test
   public:
     //!@{
     //! \name Type aliases
-    using HostStateRef = OrangeStateData<Ownership::reference, MemSpace::host>;
+    using HostStateRef = HostRef<OrangeStateData>;
+    using HostParamsRef = HostCRef<OrangeParamsData>;
     using Params = OrangeParams;
     //!@}
 
@@ -60,9 +61,9 @@ class OrangeGeoTestBase : public Test
     static std::vector<Sense> string_to_senses(std::string const& s);
 
     // Default constructor
-    OrangeGeoTestBase() = default;
+    OrangeGeoTestBase();
 
-    // Destructor
+    // Default destructor
     ~OrangeGeoTestBase();
 
     // Load `test/orange/data/{filename}` JSON input
@@ -86,6 +87,9 @@ class OrangeGeoTestBase : public Test
 
     // Lazily create and get a single-serving host state
     HostStateRef const& host_state();
+
+    // Access the host data
+    HostParamsRef const& host_params() const;
 
     //// QUERYING ////
 
@@ -111,11 +115,7 @@ class OrangeGeoTestBase : public Test
     void describe(std::ostream& os) const;
 
     //! Number of volumes
-    VolumeId::size_type num_volumes() const
-    {
-        CELER_EXPECT(params_);
-        return params_->num_volumes();
-    }
+    VolumeId::size_type num_volumes() const;
 
   private:
     //// TYPES ////

--- a/test/orange/OrangeGeoTestBase.hh
+++ b/test/orange/OrangeGeoTestBase.hh
@@ -12,20 +12,18 @@
 #include <unordered_map>
 #include <vector>
 
-// Source dependencies
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/data/CollectionStateStore.hh"
 #include "orange/OrangeData.hh"
-#include "orange/OrangeParams.hh"
 #include "celeritas/Types.hh"
 
-// Test dependencies
 #include "Test.hh"
 
 namespace celeritas
 {
 struct UnitInput;
+class OrangeParams;
 namespace test
 {
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/SurfaceAction.test.cc
+++ b/test/orange/surf/SurfaceAction.test.cc
@@ -18,6 +18,7 @@
 #include "corecel/data/CollectionMirror.hh"
 #include "orange/OrangeData.hh"
 #include "orange/OrangeGeoTestBase.hh"
+#include "orange/OrangeParams.hh"
 #include "orange/construct/OrangeInput.hh"
 #include "orange/construct/SurfaceInputBuilder.hh"
 #include "orange/surf/SurfaceIO.hh"
@@ -157,7 +158,7 @@ struct GetTypeSize
 TEST_F(SurfaceActionTest, string)
 {
     // Create functor
-    auto const& host_ref = this->params().host_ref();
+    auto const& host_ref = this->host_params();
     Surfaces surfaces(host_ref, host_ref.simple_unit[SimpleUnitId{0}].surfaces);
     auto surf_to_string = make_surface_action(surfaces, ToString{});
 
@@ -184,7 +185,7 @@ TEST_F(SurfaceActionTest, string)
 
 TEST_F(SurfaceActionTest, host_distances)
 {
-    auto const& host_ref = this->params().host_ref();
+    auto const& host_ref = this->host_params();
 
     // Create states and sample uniform box, isotropic direction
     HostVal<OrangeMiniStateData> states;
@@ -226,7 +227,7 @@ TEST_F(SurfaceActionTest, TEST_IF_CELER_DEVICE(device_distances))
     {
         // Initialize on host
         HostVal<OrangeMiniStateData> host_states;
-        resize(&host_states, this->params().host_ref(), 1024);
+        resize(&host_states, this->host_params(), 1024);
         this->fill_uniform_box(host_states.pos[AllItems<Real3>{}]);
         this->fill_isotropic(host_states.dir[AllItems<Real3>{}]);
 

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -18,6 +18,8 @@
 #include "corecel/math/ArrayUtils.hh"
 #include "corecel/sys/Stopwatch.hh"
 #include "orange/OrangeGeoTestBase.hh"
+#include "orange/OrangeParams.hh"
+#include "orange/detail/UnitIndexer.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/random/distribution/IsotropicDistribution.hh"
 #include "celeritas/random/distribution/UniformBoxDistribution.hh"
@@ -159,7 +161,7 @@ LocalState
 SimpleUnitTrackerTest::make_state(Real3 pos, Real3 dir, char const* vol)
 {
     LocalState state = this->make_state(pos, dir);
-    detail::UnitIndexer ui(this->params().host_ref().unit_indexer_data);
+    detail::UnitIndexer ui(this->host_params().unit_indexer_data);
     state.volume = ui.local_volume(this->find_volume(vol)).volume;
     return state;
 }
@@ -188,7 +190,7 @@ LocalState SimpleUnitTrackerTest::make_state(
     }
 
     LocalState state = this->make_state(pos, dir);
-    detail::UnitIndexer ui(this->params().host_ref().unit_indexer_data);
+    detail::UnitIndexer ui(this->host_params().unit_indexer_data);
     state.volume = ui.local_volume(this->find_volume(vol)).volume;
     // *Intentionally* flip the sense because we're looking for the
     // post-crossing volume. This is normally done by the multi-level
@@ -225,7 +227,7 @@ auto SimpleUnitTrackerTest::run_heuristic_init_host(size_type num_tracks) const
     HostStateStore states(this->setup_heuristic_states(num_tracks));
 
     // Set up for host run
-    InitializingLauncher<> calc_init{this->params().host_ref(), states.ref()};
+    InitializingLauncher<> calc_init{this->host_params(), states.ref()};
 
     // Loop over all track slots
     Stopwatch get_time;
@@ -266,7 +268,7 @@ auto SimpleUnitTrackerTest::setup_heuristic_states(size_type num_tracks) const
 {
     CELER_EXPECT(num_tracks > 0);
     StateHostValue result;
-    resize(&result, this->params().host_ref(), num_tracks);
+    resize(&result, this->host_params(), num_tracks);
     auto result_ref = make_ref(result);
 
     std::mt19937 rng;
@@ -355,7 +357,7 @@ void SimpleUnitTrackerTest::HeuristicInitResult::print_expected() const
 
 TEST_F(DetailTest, bumpcalculator)
 {
-    detail::BumpCalculator calc_bump(this->params().host_ref().scalars);
+    detail::BumpCalculator calc_bump(this->host_params().scalars);
     EXPECT_SOFT_EQ(1e-8, calc_bump(Real3{0, 0, 0}));
     EXPECT_SOFT_EQ(1e-8, calc_bump(Real3{1e-14, 0, 0}));
     EXPECT_SOFT_EQ(1e-2, calc_bump(Real3{0, 0, 1e6}));
@@ -364,7 +366,7 @@ TEST_F(DetailTest, bumpcalculator)
 
 TEST_F(OneVolumeTest, initialize)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     {
         // Anywhere is valid
@@ -377,7 +379,7 @@ TEST_F(OneVolumeTest, initialize)
 
 TEST_F(OneVolumeTest, intersect)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     {
         auto state = this->make_state({1, 2, 3}, {0, 0, 1}, "infinite");
@@ -393,8 +395,8 @@ TEST_F(OneVolumeTest, intersect)
 
 TEST_F(OneVolumeTest, safety)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
-    detail::UnitIndexer ui(this->params().host_ref().unit_indexer_data);
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
+    detail::UnitIndexer ui(this->host_params().unit_indexer_data);
 
     EXPECT_SOFT_EQ(
         inf,
@@ -428,7 +430,7 @@ TEST_F(OneVolumeTest, heuristic_init)
 
 TEST_F(TwoVolumeTest, initialize)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     {
         SCOPED_TRACE("In the inner sphere");
@@ -455,7 +457,7 @@ TEST_F(TwoVolumeTest, initialize)
 
 TEST_F(TwoVolumeTest, cross_boundary)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     {
         SCOPED_TRACE("Crossing the boundary from the inside");
@@ -477,7 +479,7 @@ TEST_F(TwoVolumeTest, cross_boundary)
 
 TEST_F(TwoVolumeTest, intersect)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     {
         SCOPED_TRACE("Inside");
@@ -584,8 +586,8 @@ TEST_F(TwoVolumeTest, intersect)
 
 TEST_F(TwoVolumeTest, safety)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
-    detail::UnitIndexer ui(this->params().host_ref().unit_indexer_data);
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
+    detail::UnitIndexer ui(this->host_params().unit_indexer_data);
     LocalVolumeId outside
         = ui.local_volume(this->find_volume("outside")).volume;
     LocalVolumeId inside = ui.local_volume(this->find_volume("inside")).volume;
@@ -606,7 +608,7 @@ TEST_F(TwoVolumeTest, safety)
 
 TEST_F(TwoVolumeTest, normal)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     if (CELERITAS_DEBUG)
     {
@@ -655,7 +657,7 @@ TEST_F(TwoVolumeTest, heuristic_init)
 
 TEST_F(FieldLayersTest, initialize)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     {
         SCOPED_TRACE("Exterior");
@@ -679,7 +681,7 @@ TEST_F(FieldLayersTest, initialize)
 
 TEST_F(FieldLayersTest, cross_boundary)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     // Test crossing into and out of the "background" with varying levels
     // of numerical imprecision
@@ -707,7 +709,7 @@ TEST_F(FieldLayersTest, cross_boundary)
 
 TEST_F(FieldLayersTest, intersect)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     {
         SCOPED_TRACE("straightforward");
@@ -768,7 +770,7 @@ TEST_F(FiveVolumesTest, properties)
 
 TEST_F(FiveVolumesTest, initialize)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
     {
         SCOPED_TRACE("Exterior");
         auto init = tracker.initialize(
@@ -808,7 +810,7 @@ TEST_F(FiveVolumesTest, initialize)
 
 TEST_F(FiveVolumesTest, cross_boundary)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     {
         SCOPED_TRACE("Crossing the boundary from the inside of 'e'");
@@ -881,7 +883,7 @@ TEST_F(FiveVolumesTest, cross_boundary)
 
 TEST_F(FiveVolumesTest, intersect)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
 
     {
         SCOPED_TRACE("internal surface for a");
@@ -919,8 +921,8 @@ TEST_F(FiveVolumesTest, intersect)
 
 TEST_F(FiveVolumesTest, safety)
 {
-    SimpleUnitTracker tracker(this->params().host_ref(), SimpleUnitId{0});
-    detail::UnitIndexer ui(this->params().host_ref().unit_indexer_data);
+    SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
+    detail::UnitIndexer ui(this->host_params().unit_indexer_data);
     LocalVolumeId a = ui.local_volume(this->find_volume("a")).volume;
     LocalVolumeId d = ui.local_volume(this->find_volume("d")).volume;
 

--- a/test/orange/univ/VolumeView.test.cc
+++ b/test/orange/univ/VolumeView.test.cc
@@ -27,7 +27,7 @@ class VolumeViewTest : public OrangeGeoTestBase
     VolumeView make_view(LocalVolumeId v) const
     {
         CELER_EXPECT(v);
-        auto const& host_ref = this->params().host_ref();
+        auto const& host_ref = this->host_params();
         return VolumeView{host_ref, host_ref.simple_unit[SimpleUnitId{0}], v};
     }
 
@@ -53,7 +53,7 @@ TEST_F(VolumeViewTest, one_volume)
 {
     // Build a volume that's infinite
     this->build_geometry(OneVolInput{});
-    ASSERT_EQ(1, this->params().num_volumes());
+    ASSERT_EQ(1, this->num_volumes());
 
     VolumeView vol = this->make_view(LocalVolumeId{0});
     EXPECT_EQ(0, vol.num_faces());
@@ -81,7 +81,7 @@ TEST_F(VolumeViewTest, five_volumes)
     std::vector<size_type> num_faces;
     std::vector<logic_int> flags;
 
-    for (auto vol_id : range(LocalVolumeId{this->params().num_volumes()}))
+    for (auto vol_id : range(LocalVolumeId{this->num_volumes()}))
     {
         VolumeView vol = this->make_view(vol_id);
         num_faces.push_back(vol.num_faces());

--- a/test/orange/univ/detail/SenseCalculator.test.cc
+++ b/test/orange/univ/detail/SenseCalculator.test.cc
@@ -53,13 +53,13 @@ class SenseCalculatorTest : public ::celeritas::test::OrangeGeoTestBase
     VolumeView make_volume_view(LocalVolumeId v) const
     {
         CELER_EXPECT(v);
-        auto const& host_ref = this->params().host_ref();
+        auto const& host_ref = this->host_params();
         return VolumeView{host_ref, host_ref.simple_unit[SimpleUnitId{0}], v};
     }
 
     Surfaces make_surfaces() const
     {
-        auto const& host_ref = this->params().host_ref();
+        auto const& host_ref = this->host_params();
         return Surfaces(host_ref,
                         host_ref.simple_unit[SimpleUnitId{0}].surfaces);
     }

--- a/test/orange/univ/detail/SurfaceFunctors.test.cc
+++ b/test/orange/univ/detail/SurfaceFunctors.test.cc
@@ -55,7 +55,7 @@ class SurfaceFunctorsTest : public ::celeritas::test::OrangeGeoTestBase
         // Construct a single dummy volume
         this->build_geometry(std::move(unit));
 
-        auto const& host_ref = this->params().host_ref();
+        auto const& host_ref = this->host_params();
 
         surfaces_ = std::make_unique<Surfaces>(
             host_ref, host_ref.simple_unit[SimpleUnitId{0}].surfaces);


### PR DESCRIPTION
- If multiple logical volumes share the same SD name, create a single SD to share among them
- Add the ability to set the number of streams manually
- Add an option to strip GDML pointers from the input file for the demo-geant app
- Fix a crash when creating the hit manager when multiple volumes have the same name
- Be smarter about appending uniquifying pointers when exporting to VecGeom

@whokion @amandalund With the new `/setup/stripGDMLPointers true` option, I can now successfully run CMS run 3 through the standalone app: see https://github.com/celeritas-project/benchmarks/blob/main/full-cms-test/demo-geant-cpu.mac .

There are still a bunch of warning messages such as:
```
VecgeomParams.cc:290: warning: Geometry contains duplicate volume names: "CTPPS_210_Left_Station_RP_210_Left_Station_Hor_Vacuum@0x60000051c160" (1603), "CTPPS_210_Left_Station_RP_210_Left_Station_Hor_Vacuum@0x60000051c160" (1601), "CTPPS_210_Left_Station_RP_210_Left_Station_Hor_Vacuum@0x60000051c160" (1517),
...
GeoMaterialParams.cc:154: warning: Some geometry volumes do not have known material IDs: pixfwdInnerDiskZplus_PixelForwardInnerDiskOuterRing_seg_1@0x11fe571c0, pixfwdInnerDiskZplus_PixelForwardInnerDiskOuterRing_seg_2@0x11fe572f0,
...
```
but these names are only inside of "union" solids, and I think they're just an artifact of how VecGeom builds temporary volumes that seem not to show up in the actual geometry. 