### PR TITLE
Add memory diagnostic

### DIFF
--- a/app/demo-loop/LDemoIO.cc
+++ b/app/demo-loop/LDemoIO.cc
@@ -15,6 +15,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/Units.hh"
 #include "celeritas/em/UrbanMscParams.hh"
 #include "celeritas/ext/GeantImporter.hh"
@@ -220,6 +221,7 @@ void from_json(nlohmann::json const& j, LDemoArgs& v)
 CoreParams::Input load_core_params(LDemoArgs const& args)
 {
     CELER_LOG(status) << "Loading input and initializing problem data";
+    ScopedMem record_mem("demo_loop.load_core_params");
     CoreParams::Input params;
     ImportData const imported = [&args] {
         if (ends_with(args.physics_filename, ".root"))

--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -59,6 +59,15 @@
       "inherits": [".reldeb", ".base"]
     },
     {
+      "name": "ndebug-vecgeom",
+      "displayName": "Everything in release mode",
+      "inherits": [".ndebug", "vecgeom"],
+      "cacheVariables": {
+        "CELERITAS_LAUNCH_BOUNDS":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_RNG": "XORWOW"
+      }
+    },
+    {
       "name": "reldeb-vecgeom",
       "displayName": "Everything in release mode",
       "inherits": [".reldeb", "vecgeom"],

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -26,6 +26,7 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/Environment.hh"
 #include "corecel/sys/KernelRegistry.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/ext/GeantImporter.hh"
 #include "celeritas/ext/GeantSetup.hh"
@@ -153,6 +154,7 @@ SharedParams::SharedParams(SetupOptions const& options)
     CELER_EXPECT(!*this);
 
     CELER_LOG_LOCAL(status) << "Initializing Celeritas shared data";
+    ScopedMem record_mem("SharedParams.construct");
     ScopedTimeLog scoped_time;
 
     // Initialize device and other "global" data

--- a/src/celeritas/em/AtomicRelaxationParams.cc
+++ b/src/celeritas/em/AtomicRelaxationParams.cc
@@ -21,6 +21,7 @@
 #include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/SoftEqual.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/mat/ElementView.hh"
 #include "celeritas/mat/MaterialParams.hh"  // IWYU pragma: keep
@@ -49,6 +50,8 @@ AtomicRelaxationParams::AtomicRelaxationParams(Input const& inp)
     CELER_EXPECT(inp.cutoffs);
     CELER_EXPECT(inp.materials);
     CELER_EXPECT(inp.particles);
+
+    ScopedMem record_mem("AtomicRelaxationParams.construct");
 
     HostData host_data;
 

--- a/src/celeritas/em/UrbanMscParams.cc
+++ b/src/celeritas/em/UrbanMscParams.cc
@@ -19,6 +19,7 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/UrbanMscData.hh"
 #include "celeritas/grid/PolyEvaluator.hh"
@@ -74,6 +75,8 @@ UrbanMscParams::UrbanMscParams(ParticleParams const& particles,
                                Options options)
 {
     using units::MevEnergy;
+
+    ScopedMem record_mem("UrbanMscParams.construct");
 
     HostVal<UrbanMscData> host_data;
 

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -18,6 +18,7 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/ScopedTimeLog.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/em/data/ElectronBremsData.hh"
 #include "celeritas/em/generated/SeltzerBergerInteract.hh"
 #include "celeritas/em/interactor/detail/PhysicsConstants.hh"
@@ -48,6 +49,8 @@ SeltzerBergerModel::SeltzerBergerModel(ActionId id,
 {
     CELER_EXPECT(id);
     CELER_EXPECT(load_sb_table);
+
+    ScopedMem record_mem("SeltzerBergerModel.construct");
 
     HostVal<SeltzerBergerData> host_data;
 

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -51,6 +51,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/ScopedTimeLog.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "corecel/sys/TypeDemangler.hh"
 #include "celeritas/ext/GeantSetup.hh"
 #include "celeritas/io/AtomicRelaxationReader.hh"
@@ -658,6 +659,7 @@ GeantImporter::GeantImporter(GeantSetup&& setup) : setup_(std::move(setup))
  */
 ImportData GeantImporter::operator()(DataSelection const& selected)
 {
+    ScopedMem record_mem("GeantImporter.load");
     ImportData imported;
 
     {

--- a/src/celeritas/ext/GeantSetup.cc
+++ b/src/celeritas/ext/GeantSetup.cc
@@ -28,6 +28,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/io/ScopedTimeAndRedirect.hh"
 #include "corecel/io/ScopedTimeLog.hh"
+#include "corecel/sys/ScopedMem.hh"
 
 #include "LoadGdml.hh"
 #include "detail/GeantExceptionHandler.hh"
@@ -93,6 +94,7 @@ int get_num_threads(G4RunManager const& runman)
 GeantSetup::GeantSetup(std::string const& gdml_filename, Options options)
 {
     CELER_LOG(status) << "Initializing Geant4 run manager";
+    ScopedMem record_setup_mem("GeantSetup.construct");
 
     {
         // Run manager writes output that cannot be redirected...
@@ -149,6 +151,7 @@ GeantSetup::GeantSetup(std::string const& gdml_filename, Options options)
 
     {
         CELER_LOG(status) << "Initializing Geant4 physics tables";
+        ScopedMem record_mem("GeantSetup.initialize");
         ScopedTimeLog scoped_time;
 
         run_manager_->Initialize();

--- a/src/celeritas/ext/LoadGdml.cc
+++ b/src/celeritas/ext/LoadGdml.cc
@@ -12,6 +12,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/sys/ScopedMem.hh"
 
 namespace celeritas
 {
@@ -36,6 +37,7 @@ void detail::PVDeleter::operator()(G4VPhysicalVolume* vol) const
 UPG4PhysicalVolume load_gdml(std::string const& filename)
 {
     CELER_LOG(info) << "Loading Geant4 geometry from GDML at " << filename;
+    ScopedMem record_mem("load_gdml");
 
     // Create parser; do *not* strip `0x` extensions since those are needed to
     // deduplicate complex geometries (e.g. CMS) and are handled by the Label

--- a/src/celeritas/ext/RootExporter.cc
+++ b/src/celeritas/ext/RootExporter.cc
@@ -16,6 +16,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/ScopedTimeLog.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/io/ImportData.hh"
 
 namespace celeritas
@@ -27,6 +28,7 @@ namespace celeritas
 RootExporter::RootExporter(char const* filename)
 {
     CELER_LOG(info) << "Creating ROOT file at " << filename;
+    ScopedMem record_mem("RootImporter.open");
     ScopedTimeLog scoped_time;
     root_output_.reset(TFile::Open(filename, "recreate"));
     CELER_VALIDATE(root_output_ && !root_output_->IsZombie(),
@@ -39,6 +41,7 @@ RootExporter::RootExporter(char const* filename)
  */
 void RootExporter::operator()(ImportData const& import_data)
 {
+    ScopedMem record_mem("RootImporter.write");
     TTree tree_data(tree_name(), tree_name());
     TBranch* branch = tree_data.Branch(branch_name(),
                                        const_cast<ImportData*>(&import_data));

--- a/src/celeritas/ext/RootExporter.cc
+++ b/src/celeritas/ext/RootExporter.cc
@@ -28,7 +28,7 @@ namespace celeritas
 RootExporter::RootExporter(char const* filename)
 {
     CELER_LOG(info) << "Creating ROOT file at " << filename;
-    ScopedMem record_mem("RootImporter.open");
+    ScopedMem record_mem("RootExporter.open");
     ScopedTimeLog scoped_time;
     root_output_.reset(TFile::Open(filename, "recreate"));
     CELER_VALIDATE(root_output_ && !root_output_->IsZombie(),
@@ -41,7 +41,7 @@ RootExporter::RootExporter(char const* filename)
  */
 void RootExporter::operator()(ImportData const& import_data)
 {
-    ScopedMem record_mem("RootImporter.write");
+    ScopedMem record_mem("RootExporter.write");
     TTree tree_data(tree_name(), tree_name());
     TBranch* branch = tree_data.Branch(branch_name(),
                                        const_cast<ImportData*>(&import_data));

--- a/src/celeritas/ext/RootImporter.cc
+++ b/src/celeritas/ext/RootImporter.cc
@@ -15,6 +15,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/ScopedTimeLog.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/io/ImportData.hh"
 
 // This "public API" function is defined in CeleritasRootInterface.cxx to
@@ -35,6 +36,7 @@ RootImporter::RootImporter(char const* filename)
     TriggerDictionaryInitialization_libceleritas();
 
     CELER_LOG(info) << "Opening ROOT file at " << filename;
+    ScopedMem record_mem("RootImporter.open");
     ScopedTimeLog scoped_time;
     root_input_.reset(TFile::Open(filename, "read"));
     CELER_VALIDATE(root_input_ && !root_input_->IsZombie(),
@@ -49,6 +51,7 @@ RootImporter::RootImporter(char const* filename)
 ImportData RootImporter::operator()()
 {
     CELER_LOG(debug) << "Reading data from ROOT";
+    ScopedMem record_mem("RootImporter.read");
     ScopedTimeLog scoped_time;
 
     std::unique_ptr<TTree> tree_data(root_input_->Get<TTree>(tree_name()));

--- a/src/celeritas/geo/GeoMaterialParams.cc
+++ b/src/celeritas/geo/GeoMaterialParams.cc
@@ -19,6 +19,7 @@
 #include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/detail/Joined.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "orange/Types.hh"
 #include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
 #include "celeritas/io/ImportData.hh"
@@ -90,6 +91,8 @@ GeoMaterialParams::GeoMaterialParams(Input input)
                                  return !m
                                         || m < input.materials->num_materials();
                              }));
+
+    ScopedMem record_mem("GeoMaterialParams.construct");
 
     if (!input.volume_labels.empty())
     {

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -19,6 +19,8 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/Environment.hh"
 #include "corecel/sys/KernelRegistry.hh"
+#include "corecel/sys/MemRegistry.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/GeoParamsOutput.hh"
@@ -45,6 +47,7 @@
 #    include "corecel/sys/DeviceIO.json.hh"
 #    include "corecel/sys/EnvironmentIO.json.hh"
 #    include "corecel/sys/KernelRegistryIO.json.hh"
+#    include "corecel/sys/MemRegistryIO.json.hh"
 #endif
 
 namespace celeritas
@@ -122,6 +125,8 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
 
     CELER_EXPECT(input_);
 
+    ScopedMem record_mem("CoreParams.construct");
+
     CoreScalars scalars;
 
     // Construct geometry action
@@ -171,6 +176,8 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
             OutputInterface::Category::system,
             "kernels",
             celeritas::kernel_registry()));
+    input_.output_reg->insert(OutputInterfaceAdapter<MemRegistry>::from_const_ref(
+        OutputInterface::Category::system, "memory", celeritas::mem_registry()));
     input_.output_reg->insert(OutputInterfaceAdapter<Environment>::from_const_ref(
         OutputInterface::Category::system, "environ", celeritas::environment()));
 #endif

--- a/src/celeritas/mat/MaterialParams.cc
+++ b/src/celeritas/mat/MaterialParams.cc
@@ -18,6 +18,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "corecel/math/SoftEqual.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/io/ImportData.hh"
@@ -109,6 +110,8 @@ MaterialParams::from_import(ImportData const& data)
 MaterialParams::MaterialParams(Input const& inp)
 {
     CELER_EXPECT(!inp.materials.empty());
+
+    ScopedMem record_mem("MaterialParams.construct");
 
     // Build elements and materials on host.
     HostValue host_data;

--- a/src/celeritas/phys/CutoffParams.cc
+++ b/src/celeritas/phys/CutoffParams.cc
@@ -13,6 +13,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionBuilder.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/io/ImportData.hh"
 #include "celeritas/io/ImportMaterial.hh"
@@ -72,6 +73,8 @@ CutoffParams::CutoffParams(Input const& input)
 {
     CELER_EXPECT(input.materials);
     CELER_EXPECT(input.particles);
+
+    ScopedMem record_mem("CutoffParams.construct");
 
     HostValue host_data;
     host_data.num_materials = input.materials->size();

--- a/src/celeritas/phys/ParticleParams.cc
+++ b/src/celeritas/phys/ParticleParams.cc
@@ -14,6 +14,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionBuilder.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/io/ImportData.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleData.hh"  // IWYU pragma: associated
@@ -75,6 +76,8 @@ ParticleParams::from_import(ImportData const& data)
  */
 ParticleParams::ParticleParams(Input const& input)
 {
+    ScopedMem record_mem("ParticleParams.construct");
+
     md_.reserve(input.size());
 
     // Build elements and materials on host.

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -22,6 +22,7 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/Ref.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/em/AtomicRelaxationParams.hh"  // IWYU pragma: keep
 #include "celeritas/em/data/AtomicRelaxationData.hh"
@@ -78,6 +79,8 @@ PhysicsParams::PhysicsParams(Input inp)
     CELER_EXPECT(inp.particles);
     CELER_EXPECT(inp.materials);
     CELER_EXPECT(inp.action_registry);
+
+    ScopedMem record_mem("PhysicsParams.construct");
 
     // Create actions (order matters due to accessors in PhysicsParamsScalars)
     {

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -60,6 +60,7 @@ if(CELERITAS_USE_JSON)
     AssertIO.json.cc
     sys/DeviceIO.json.cc
     sys/KernelRegistryIO.json.cc
+    sys/MemRegistryIO.json.cc
   )
   list(APPEND PRIVATE_DEPS nlohmann_json::nlohmann_json)
 endif()

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -32,6 +32,8 @@ list(APPEND SOURCES
   sys/Device.cc
   sys/Environment.cc
   sys/KernelRegistry.cc
+  sys/MemRegistry.cc
+  sys/ScopedMem.cc
   sys/MpiCommunicator.cc
   sys/MultiExceptionHandler.cc
   sys/ScopedMpiInit.cc

--- a/src/corecel/cont/InitializedValue.hh
+++ b/src/corecel/cont/InitializedValue.hh
@@ -116,9 +116,14 @@ class InitializedValue
     //!@{
     //! \name Conversion
 
-    //! Implicit reference to stored type
+    //! Implicit reference to stored value
     operator T const&() const noexcept { return value_; }
     operator T&() noexcept { return value_; }
+
+    //! Explicit reference to stored value
+    T const& value() const& { return value_; }
+    T& value() & { return value_; }
+    T&& value() && { return value_; }
 
     //!@}
 

--- a/src/corecel/sys/KernelAttributes.hh
+++ b/src/corecel/sys/KernelAttributes.hh
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <type_traits>
 
+#include "celeritas_config.h"
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 
@@ -42,6 +43,11 @@ struct KernelAttributes
     // Derivative but useful occupancy information
     unsigned int max_warps_per_eu{0};  //!< Occupancy (execution unit)
     double occupancy{0};  //!< Fractional occupancy (CU)
+
+    // Resource limits at first call
+    std::size_t stack_size{0};  //!< CUDA Dynamic per-thread stack limit [b]
+    std::size_t heap_size{0};  //!< Dynamic malloc heap size [b]
+    std::size_t print_buffer_size{0};  //!< FIFO buffer size for printf [b]
 };
 
 //---------------------------------------------------------------------------//
@@ -85,6 +91,19 @@ KernelAttributes make_kernel_attributes(F* func, unsigned int threads_per_block)
     result.occupancy
         = static_cast<double>(num_blocks * result.threads_per_block)
           / static_cast<double>(d.max_threads_per_cu());
+
+    // Get size limits
+    if constexpr (CELERITAS_USE_CUDA)
+    {
+        // Stack size limit is CUDA-only
+        CELER_CUDA_CALL(
+            cudaDeviceGetLimit(&result.stack_size, cudaLimitStackSize));
+    }
+    CELER_DEVICE_CALL_PREFIX(DeviceGetLimit(
+        &result.heap_size, CELER_DEVICE_PREFIX(LimitMallocHeapSize)));
+    CELER_DEVICE_CALL_PREFIX(DeviceGetLimit(
+        &result.print_buffer_size, CELER_DEVICE_PREFIX(PrintfFifoSize)));
+
 #else
     (void)sizeof(func);
     CELER_ASSERT_UNREACHABLE();

--- a/src/corecel/sys/KernelAttributes.hh
+++ b/src/corecel/sys/KernelAttributes.hh
@@ -98,11 +98,12 @@ KernelAttributes make_kernel_attributes(F* func, unsigned int threads_per_block)
         // Stack size limit is CUDA-only
         CELER_CUDA_CALL(
             cudaDeviceGetLimit(&result.stack_size, cudaLimitStackSize));
+        // HIP throws 'limit is not supported on this architecture'
+        CELER_CUDA_CALL(cudaDeviceGetLimit(&result.print_buffer_size,
+                                           cudaLimitPrintfFifoSize));
     }
     CELER_DEVICE_CALL_PREFIX(DeviceGetLimit(
         &result.heap_size, CELER_DEVICE_PREFIX(LimitMallocHeapSize)));
-    CELER_DEVICE_CALL_PREFIX(DeviceGetLimit(
-        &result.print_buffer_size, CELER_DEVICE_PREFIX(LimitPrintfFifoSize)));
 
 #else
     (void)sizeof(func);

--- a/src/corecel/sys/KernelAttributes.hh
+++ b/src/corecel/sys/KernelAttributes.hh
@@ -102,7 +102,7 @@ KernelAttributes make_kernel_attributes(F* func, unsigned int threads_per_block)
     CELER_DEVICE_CALL_PREFIX(DeviceGetLimit(
         &result.heap_size, CELER_DEVICE_PREFIX(LimitMallocHeapSize)));
     CELER_DEVICE_CALL_PREFIX(DeviceGetLimit(
-        &result.print_buffer_size, CELER_DEVICE_PREFIX(PrintfFifoSize)));
+        &result.print_buffer_size, CELER_DEVICE_PREFIX(LimitPrintfFifoSize)));
 
 #else
     (void)sizeof(func);

--- a/src/corecel/sys/KernelRegistry.hh
+++ b/src/corecel/sys/KernelRegistry.hh
@@ -77,9 +77,11 @@ class KernelRegistry
 
     //// ACCESSORS ////
 
+    // TODO: rename to size
     // Number of kernel diagnostics available
     KernelId::size_type num_kernels() const;
 
+    // TODO: rename to get
     // Access kernel data for a single kernel
     KernelMetadata const& kernel(KernelId id) const;
 

--- a/src/corecel/sys/KernelRegistryIO.json.cc
+++ b/src/corecel/sys/KernelRegistryIO.json.cc
@@ -55,6 +55,7 @@ void to_json(nlohmann::json& j, KernelRegistry const& kr)
     {
         auto const& md = kr.kernel(kernel_id);
         j.push_back(md.attributes);
+        j.back()["name"] = md.name;
         if (write_profiling)
         {
             j.back()["num_launches"]

--- a/src/corecel/sys/KernelRegistryIO.json.cc
+++ b/src/corecel/sys/KernelRegistryIO.json.cc
@@ -20,6 +20,30 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Write one kernel's metadata to JSON.
+ */
+void to_json(nlohmann::json& j, KernelAttributes const& attrs)
+{
+    j = {
+        {"threads_per_block", attrs.threads_per_block},
+        {"num_regs", attrs.num_regs},
+        {"const_mem", attrs.const_mem},
+        {"local_mem", attrs.local_mem},
+        {"max_threads_per_block", attrs.max_threads_per_block},
+        {"max_blocks_per_cu", attrs.max_blocks_per_cu},
+        {"max_warps_per_eu", attrs.max_warps_per_eu},
+        {"occupancy", attrs.occupancy},
+        {"heap_size", attrs.heap_size},
+        {"print_buffer_size", attrs.print_buffer_size},
+    };
+    if constexpr (CELERITAS_USE_CUDA)
+    {
+        j["stack_size"] = attrs.stack_size;
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Write kernel metadata out to JSON.
  */
 void to_json(nlohmann::json& j, KernelRegistry const& kr)
@@ -30,23 +54,7 @@ void to_json(nlohmann::json& j, KernelRegistry const& kr)
     for (auto kernel_id : range(KernelId{kr.num_kernels()}))
     {
         auto const& md = kr.kernel(kernel_id);
-        j.emplace_back(nlohmann::json::object({
-            {"name", md.name},
-            {"threads_per_block", md.attributes.threads_per_block},
-            {"num_regs", md.attributes.num_regs},
-            {"const_mem", md.attributes.const_mem},
-            {"local_mem", md.attributes.local_mem},
-            {"max_threads_per_block", md.attributes.max_threads_per_block},
-            {"max_blocks_per_cu", md.attributes.max_blocks_per_cu},
-            {"max_warps_per_eu", md.attributes.max_warps_per_eu},
-            {"occupancy", md.attributes.occupancy},
-            {"heap_size", md.attributes.heap_size},
-            {"print_buffer_size", md.attributes.print_buffer_size},
-        }));
-        if constexpr (CELERITAS_USE_CUDA)
-        {
-            j.back()["stack_size"] = md.attributes.stack_size;
-        }
+        j.push_back(md.attributes);
         if (write_profiling)
         {
             j.back()["num_launches"]

--- a/src/corecel/sys/KernelRegistryIO.json.cc
+++ b/src/corecel/sys/KernelRegistryIO.json.cc
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <string>
 
+#include "celeritas_config.h"
 #include "corecel/cont/Range.hh"
 #include "corecel/sys/KernelAttributes.hh"
 
@@ -39,7 +40,13 @@ void to_json(nlohmann::json& j, KernelRegistry const& kr)
             {"max_blocks_per_cu", md.attributes.max_blocks_per_cu},
             {"max_warps_per_eu", md.attributes.max_warps_per_eu},
             {"occupancy", md.attributes.occupancy},
+            {"heap_size", md.attributes.heap_size},
+            {"print_buffer_size", md.attributes.print_buffer_size},
         }));
+        if constexpr (CELERITAS_USE_CUDA)
+        {
+            j.back()["stack_size"] = md.attributes.stack_size;
+        }
         if (write_profiling)
         {
             j.back()["num_launches"]

--- a/src/corecel/sys/MemRegistry.cc
+++ b/src/corecel/sys/MemRegistry.cc
@@ -16,7 +16,7 @@ namespace celeritas
 MemUsageId MemRegistry::push()
 {
     // Add a new entry
-    MemUsageId result_id{entries_.size()};
+    MemUsageId result_id(entries_.size());
     entries_.resize(entries_.size() + 1);
 
     // Record the parent index and update the stack

--- a/src/corecel/sys/MemRegistry.cc
+++ b/src/corecel/sys/MemRegistry.cc
@@ -1,0 +1,51 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/MemRegistry.cc
+//---------------------------------------------------------------------------//
+#include "MemRegistry.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Create a new entry and push it onto the stack.
+ */
+MemUsageId MemRegistry::push()
+{
+    // Add a new entry
+    MemUsageId result_id{entries_.size()};
+    entries_.resize(entries_.size() + 1);
+
+    // Record the parent index and update the stack
+    if (!stack_.empty())
+    {
+        entries_.back().parent_index = stack_.back();
+    }
+    stack_.push_back(result_id);
+
+    return result_id;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Pop the last entry.
+ */
+void MemRegistry::pop()
+{
+    CELER_EXPECT(!stack_.empty());
+    stack_.pop_back();
+}
+
+//---------------------------------------------------------------------------//
+// Globally shared registry of memory usage
+MemRegistry& mem_registry()
+{
+    static MemRegistry mr;
+    return mr;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/sys/MemRegistry.hh
+++ b/src/corecel/sys/MemRegistry.hh
@@ -21,7 +21,7 @@ namespace celeritas
 struct Kibi
 {
     static CELER_CONSTEXPR_FUNCTION int value() { return 1024; }
-    static char const* label() { return "Ki"; }
+    static char const* label() { return "kibi"; }
 };
 
 //! 1024 bytes

--- a/src/corecel/sys/MemRegistry.hh
+++ b/src/corecel/sys/MemRegistry.hh
@@ -1,0 +1,119 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/MemRegistry.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "corecel/OpaqueId.hh"
+#include "corecel/Types.hh"
+#include "corecel/math/Quantity.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+//! SI prefix for multiples of 1024
+struct Kibi
+{
+    static CELER_CONSTEXPR_FUNCTION int value() { return 1024; }
+    static char const* label() { return "Ki"; }
+};
+
+//! 1024 bytes
+using KibiBytes = Quantity<Kibi, int>;
+//! Ordered identifiers for memory allocation segments
+using MemUsageId = OpaqueId<struct MemUsageEntry>;
+
+//! Statistics about a block of memory usage
+struct MemUsageEntry
+{
+    //! Name of this entry
+    std::string label;
+    //! Index of the umbrella entry
+    MemUsageId parent_index{};
+    //! Difference in CPU memory usage from beginning to end
+    KibiBytes cpu_delta{};
+    //! Reported CPU "high water mark" at the end the block
+    KibiBytes cpu_hwm{};
+    //! Difference in GPU memory usage from beginning to end
+    KibiBytes gpu_delta{};
+    //! Reported GPU "high water mark" at the end the block
+    KibiBytes gpu_hwm{};
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Track memory usage across the application.
+ *
+ * This class is not thread-safe and should generally be used during setup. The
+ * memory usage entries are a tree. Pushing and popping should be done with \c
+ * ScopedMem .
+ */
+class MemRegistry
+{
+  public:
+    // Construct with no entries
+    MemRegistry() = default;
+
+    //// ACCESSORS ////
+
+    //! Number of entries
+    MemUsageId::size_type size() const { return entries_.size(); }
+
+    // Get the entry for an ID
+    inline MemUsageEntry& get(MemUsageId id);
+
+    // Get the entry for an ID
+    inline MemUsageEntry const& get(MemUsageId id) const;
+
+    //! Number of memory entries deep
+    size_type depth() const { return stack_.size(); }
+
+    //// MUTATORS ////
+
+    // Create a new entry and push it onto the stack, returning the new ID
+    MemUsageId push();
+
+    // Pop the last entry
+    void pop();
+
+  private:
+    std::vector<MemUsageEntry> entries_;
+    std::vector<MemUsageId> stack_;
+};
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+// Globally shared registry of memory usage
+MemRegistry& mem_registry();
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Get the entry for an ID.
+ */
+MemUsageEntry const& MemRegistry::get(MemUsageId id) const
+{
+    CELER_EXPECT(id < this->size());
+    return entries_[id.unchecked_get()];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the entry for an ID.
+ */
+MemUsageEntry& MemRegistry::get(MemUsageId id)
+{
+    CELER_EXPECT(id < this->size());
+    return entries_[id.unchecked_get()];
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/sys/MemRegistry.hh
+++ b/src/corecel/sys/MemRegistry.hh
@@ -39,11 +39,11 @@ struct MemUsageEntry
     //! Difference in CPU memory usage from beginning to end
     KibiBytes cpu_delta{};
     //! Reported CPU "high water mark" at the end the block
-    KibiBytes cpu_hwm{};
+    KibiBytes cpu_hwm{-1};
     //! Difference in GPU memory usage from beginning to end
     KibiBytes gpu_delta{};
     //! Reported GPU "high water mark" at the end the block
-    KibiBytes gpu_hwm{};
+    KibiBytes gpu_usage{-1};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/MemRegistryIO.json.cc
+++ b/src/corecel/sys/MemRegistryIO.json.cc
@@ -8,6 +8,7 @@
 #include "MemRegistryIO.json.hh"
 
 #include "corecel/cont/Range.hh"
+#include "corecel/math/QuantityIO.json.hh"
 
 namespace celeritas
 {
@@ -27,15 +28,21 @@ void to_json(nlohmann::json& j, MemUsageEntry const& entry)
     {
         j["parent_index"] = entry.parent_index.unchecked_get();
     }
-    if (entry.cpu_hwm.value() >= 0)
+    if (entry.cpu_delta.value() > 0)
     {
-        j["cpu_delta"] = entry.cpu_delta.value();
-        j["cpu_hwm"] = entry.cpu_hwm.value();
+        j["cpu_delta"] = entry.cpu_delta;
     }
-    if (entry.gpu_usage.value() >= 0)
+    if (entry.cpu_hwm.value() > 0)
     {
-        j["gpu_delta"] = entry.gpu_delta.value();
-        j["gpu_usage"] = entry.gpu_usage.value();
+        j["cpu_hwm"] = entry.cpu_hwm;
+    }
+    if (entry.gpu_delta.value() > 0)
+    {
+        j["gpu_delta"] = entry.gpu_delta;
+    }
+    if (entry.gpu_usage.value() > 0)
+    {
+        j["gpu_usage"] = entry.gpu_usage;
     }
 }
 

--- a/src/corecel/sys/MemRegistryIO.json.cc
+++ b/src/corecel/sys/MemRegistryIO.json.cc
@@ -14,22 +14,28 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Write one kernel's metadata to JSON.
+ *
+ * If the registry is dumped before a "scoped memory" saves the memory results,
+ * no entries will be written. Parent indices are only written for child nodes.
  */
 void to_json(nlohmann::json& j, MemUsageEntry const& entry)
 {
     j = {
         {"label", entry.label},
-        {"parent_index",
-         entry.parent_index
-             ? static_cast<int>(entry.parent_index.unchecked_get())
-             : -1},
-        {"cpu_delta", entry.cpu_delta.value()},
-        {"cpu_hwm", entry.cpu_hwm.value()},
     };
-    if (entry.gpu_hwm.value() != 0)
+    if (entry.parent_index)
+    {
+        j["parent_index"] = entry.parent_index.unchecked_get();
+    }
+    if (entry.cpu_hwm.value() >= 0)
+    {
+        j["cpu_delta"] = entry.cpu_delta.value();
+        j["cpu_hwm"] = entry.cpu_hwm.value();
+    }
+    if (entry.gpu_usage.value() >= 0)
     {
         j["gpu_delta"] = entry.gpu_delta.value();
-        j["gpu_hwm"] = entry.gpu_hwm.value();
+        j["gpu_usage"] = entry.gpu_usage.value();
     }
 }
 

--- a/src/corecel/sys/MemRegistryIO.json.cc
+++ b/src/corecel/sys/MemRegistryIO.json.cc
@@ -1,0 +1,50 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/MemRegistryIO.json.cc
+//---------------------------------------------------------------------------//
+#include "MemRegistryIO.json.hh"
+
+#include "corecel/cont/Range.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Write one kernel's metadata to JSON.
+ */
+void to_json(nlohmann::json& j, MemUsageEntry const& entry)
+{
+    j = {
+        {"label", entry.label},
+        {"parent_index",
+         entry.parent_index
+             ? static_cast<int>(entry.parent_index.unchecked_get())
+             : -1},
+        {"cpu_delta", entry.cpu_delta.value()},
+        {"cpu_hwm", entry.cpu_hwm.value()},
+    };
+    if (entry.gpu_hwm.value() != 0)
+    {
+        j["gpu_delta"] = entry.gpu_delta.value();
+        j["gpu_hwm"] = entry.gpu_hwm.value();
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write kernel metadata out to JSON.
+ */
+void to_json(nlohmann::json& j, MemRegistry const& mr)
+{
+    j = nlohmann::json::array();
+    for (auto mem_id : range(MemUsageId{mr.size()}))
+    {
+        j.push_back(mr.get(mem_id));
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/sys/MemRegistryIO.json.cc
+++ b/src/corecel/sys/MemRegistryIO.json.cc
@@ -21,29 +21,30 @@ namespace celeritas
  */
 void to_json(nlohmann::json& j, MemUsageEntry const& entry)
 {
-    j = {
-        {"label", entry.label},
-    };
+    using MemQuantity = KibiBytes;
+    j = nlohmann::json::object();
+#define MRIO_MEM_OUT(MEMBER)                                  \
+    do                                                        \
+    {                                                         \
+        if (entry.MEMBER.value() > 0)                         \
+        {                                                     \
+            j[#MEMBER] = value_as<MemQuantity>(entry.MEMBER); \
+        }                                                     \
+    } while (false)
+    MRIO_MEM_OUT(cpu_delta);
+    MRIO_MEM_OUT(cpu_hwm);
+    MRIO_MEM_OUT(gpu_delta);
+    MRIO_MEM_OUT(gpu_usage);
+#undef MRIO_MEM_OUT
+    if (!j.empty())
+    {
+        j["_units"] = MemQuantity::unit_type::label();
+    }
     if (entry.parent_index)
     {
         j["parent_index"] = entry.parent_index.unchecked_get();
     }
-    if (entry.cpu_delta.value() > 0)
-    {
-        j["cpu_delta"] = entry.cpu_delta;
-    }
-    if (entry.cpu_hwm.value() > 0)
-    {
-        j["cpu_hwm"] = entry.cpu_hwm;
-    }
-    if (entry.gpu_delta.value() > 0)
-    {
-        j["gpu_delta"] = entry.gpu_delta;
-    }
-    if (entry.gpu_usage.value() > 0)
-    {
-        j["gpu_usage"] = entry.gpu_usage;
-    }
+    j["label"] = entry.label;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/MemRegistryIO.json.hh
+++ b/src/corecel/sys/MemRegistryIO.json.hh
@@ -1,24 +1,24 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2021-2023 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/sys/KernelRegistryIO.json.hh
+//! \file corecel/sys/MemRegistryIO.json.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include <nlohmann/json.hpp>
 
-#include "KernelRegistry.hh"
+#include "MemRegistry.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 
-// Write one kernel's attributes to json
-void to_json(nlohmann::json& j, KernelAttributes const& md);
-// Write all kernels to JSON
-void to_json(nlohmann::json& j, KernelRegistry const& diagnostics);
+// Write one memory diagnostic block to json
+void to_json(nlohmann::json& j, MemUsageEntry const& md);
+// Write device diagnostics to JSON
+void to_json(nlohmann::json& j, MemRegistry const& diagnostics);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/sys/ScopedMem.cc
+++ b/src/corecel/sys/ScopedMem.cc
@@ -1,0 +1,108 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/ScopedMem.cc
+//---------------------------------------------------------------------------//
+#include "ScopedMem.hh"
+
+#if defined(__APPLE__)
+#    include <cstring>
+#    include <mach/mach.h>
+#elif defined(__linux__)
+#    include <sys/resource.h>
+#elif defined(_WIN32)
+#    include <psapi.h>
+#    include <windows.h>
+#endif
+
+#include "corecel/Assert.hh"
+
+namespace celeritas
+{
+namespace
+{
+struct MemResult
+{
+    std::size_t hwm{0};
+    std::size_t resident{0};  // unused, not available on linux
+};
+//---------------------------------------------------------------------------//
+MemResult get_usage_bytes()
+{
+    MemResult result;
+#if defined(__APPLE__)
+    struct mach_task_basic_info tinfo;
+    mach_msg_type_number_t tcount = MACH_TASK_BASIC_INFO_COUNT;
+    tinfo.resident_size = 0;
+    tinfo.resident_size_max = 0;
+
+    if (task_info(mach_task_self(),
+                  MACH_TASK_BASIC_INFO,
+                  reinterpret_cast<task_info_t>(&tinfo),
+                  &tcount)
+        == KERN_SUCCESS)
+    {
+        result.hwm = tinfo.resident_size_max;
+        result.resident = tinfo.resident_size;
+    }
+#elif defined(__linux__)
+    struct rusage usage;
+    usage.ru_maxrss = 0;
+    if (!getrusage(RUSAGE_SELF, &usage))
+    {
+        result.hwm = tinfo.resident_size_max;
+    }
+#elif defined(_WIN32)
+    PROCESS_MEMORY_COUNTERS info;
+    GetProcessMemoryInfo(GetCurrentProcess(), &info, sizeof(info));
+    result.hwm = info.PeakWorkingSetSize;
+    result.resident = info.WorkingSetSize;
+#endif
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with name and a pointer to the mem registry.
+ */
+ScopedMem::ScopedMem(std::string_view label, MemRegistry* registry)
+    : registry_(registry)
+{
+    CELER_EXPECT(registry_.value());
+    CELER_EXPECT(!label.empty());
+
+    id_ = registry_.value()->push();
+    CELER_ASSERT(id_);
+
+    MemUsageEntry& entry = registry_.value()->get(id_);
+    entry.label = label;
+
+    cpu_start_hwm_ = get_usage_bytes().hwm;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Register data on destruction.
+ */
+ScopedMem::~ScopedMem()
+{
+    if (registry_.value() != nullptr)
+    {
+        MemUsageEntry& entry = registry_.value()->get(id_);
+
+        // Save HWM and delta
+        std::ptrdiff_t stop_hwm = get_usage_bytes().hwm;
+        entry.cpu_hwm = native_value_to<KibiBytes>(stop_hwm);
+        entry.cpu_delta = native_value_to<KibiBytes>(stop_hwm - cpu_start_hwm_);
+
+        registry_.value()->pop();
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/sys/ScopedMem.cc
+++ b/src/corecel/sys/ScopedMem.cc
@@ -68,13 +68,13 @@ MemResult get_cpu_mem()
     return result;
 }
 
-std::size_t get_gpu_mem()
+std::ptrdiff_t get_gpu_mem()
 {
     std::size_t free{0};
     std::size_t total{0};
     CELER_DEVICE_CALL_PREFIX(MemGetInfo(&free, &total));
     CELER_ASSERT(total > free);
-    return total - free;
+    return std::ptrdiff_t(total) - std::ptrdiff_t(free);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedMem.cc
+++ b/src/corecel/sys/ScopedMem.cc
@@ -49,6 +49,7 @@ MemResult get_cpu_mem()
                   &tcount)
         == KERN_SUCCESS)
     {
+        // Units are B
         result.hwm = tinfo.resident_size_max;
         result.resident = tinfo.resident_size;
     }
@@ -57,9 +58,11 @@ MemResult get_cpu_mem()
     usage.ru_maxrss = 0;
     if (!getrusage(RUSAGE_SELF, &usage))
     {
-        result.hwm = usage.ru_maxrss;
+        // Units are kiB!
+        result.hwm = usage.ru_maxrss * 1024u;
     }
 #elif defined(_WIN32)
+    // Units are B
     PROCESS_MEMORY_COUNTERS info;
     GetProcessMemoryInfo(GetCurrentProcess(), &info, sizeof(info));
     result.hwm = info.PeakWorkingSetSize;

--- a/src/corecel/sys/ScopedMem.cc
+++ b/src/corecel/sys/ScopedMem.cc
@@ -57,7 +57,7 @@ MemResult get_cpu_mem()
     usage.ru_maxrss = 0;
     if (!getrusage(RUSAGE_SELF, &usage))
     {
-        result.hwm = tinfo.resident_size_max;
+        result.hwm = usage.ru_maxrss;
     }
 #elif defined(_WIN32)
     PROCESS_MEMORY_COUNTERS info;

--- a/src/corecel/sys/ScopedMem.hh
+++ b/src/corecel/sys/ScopedMem.hh
@@ -62,7 +62,8 @@ class ScopedMem
   private:
     InitializedValue<MemRegistry*> registry_;
     MemUsageId id_;
-    std::ptrdiff_t cpu_start_hwm_;
+    std::ptrdiff_t cpu_start_hwm_{0};
+    std::ptrdiff_t gpu_start_used_{0};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedMem.hh
+++ b/src/corecel/sys/ScopedMem.hh
@@ -1,0 +1,69 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/ScopedMem.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cstddef>
+#include <string_view>
+
+#include "corecel/cont/InitializedValue.hh"
+
+#include "MemRegistry.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Record the change in memory usage between construction and destruction.
+ *
+ * \code
+    {
+      ScopedMem record_mem("create objects");
+      this->create_stuff();
+    }
+   \endcode
+ * In a multithreaded environment a "null" scoped memory can be used:
+ * \code
+ * {
+     auto record_mem = (stream_id == StreamId{0} ? ScopedMem{"label"}
+                                                 : ScopedMem{});
+     this->do_stuff();
+ * }
+ * \endcode
+ */
+class ScopedMem
+{
+  public:
+    // Default constructor for "null-op" recording
+    // Construct with name and registries
+    ScopedMem(std::string_view label, MemRegistry* registry);
+
+    //! Construct with name and default registry
+    explicit ScopedMem(std::string_view label)
+        : ScopedMem{label, &celeritas::mem_registry()}
+    {
+    }
+
+    // Register data on destruction
+    ~ScopedMem();
+
+    //!@{
+    //! Default move assign and construct; no copying
+    ScopedMem(ScopedMem&&) = default;
+    ScopedMem(ScopedMem const&) = delete;
+    ScopedMem& operator=(ScopedMem&&) = default;
+    ScopedMem& operator=(ScopedMem const&) = delete;
+    //!@}
+
+  private:
+    InitializedValue<MemRegistry*> registry_;
+    MemUsageId id_;
+    std::ptrdiff_t cpu_start_hwm_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas


### PR DESCRIPTION
This uses system tools to calculate the memory "high watermark" before and after blocks, recording the change in peak across the block (i.e. what's the most new memory allocated) and the high-water marks. The GPU memory may not be as accurate, since it's the reported "free" amount subtracted from the reported "total".  Each block records its "parent" block (if applicable) so it will be possible to make a flame graph of memory usage.

<details><summary>simple-cms-cpu.out.json</summary><pre>
  "memory": [
   {
    "_units": "kibi",
    "cpu_delta": 547920,
    "cpu_hwm": 732772,
    "label": "demo_loop.run"
   },
   {
    "_units": "kibi",
    "cpu_delta": 222236,
    "cpu_hwm": 407088,
    "gpu_delta": 2048,
    "gpu_usage": 319488,
    "label": "demo_loop.load_core_params",
    "parent_index": 0
   },
   {
    "_units": "kibi",
    "cpu_delta": 205968,
    "cpu_hwm": 390820,
    "gpu_usage": 317440,
    "label": "RootImporter.open",
    "parent_index": 1
   },
   {
    "_units": "kibi",
    "cpu_delta": 13880,
    "cpu_hwm": 404700,
    "gpu_usage": 317440,
    "label": "RootImporter.read",
    "parent_index": 1
   },
   {
    "_units": "kibi",
    "cpu_hwm": 404700,
    "gpu_usage": 319488,
    "label": "MaterialParams.construct",
    "parent_index": 1
   },
   {
    "_units": "kibi",
    "cpu_hwm": 404700,
    "gpu_usage": 319488,
    "label": "GeoMaterialParams.construct",
    "parent_index": 1
   },
   {
    "_units": "kibi",
    "cpu_hwm": 404700,
    "gpu_usage": 319488,
    "label": "ParticleParams.construct",
    "parent_index": 1
   },
   {
    "_units": "kibi",
    "cpu_hwm": 404700,
    "gpu_usage": 319488,
    "label": "CutoffParams.construct",
    "parent_index": 1
   },
   {
    "_units": "kibi",
    "cpu_delta": 444,
    "cpu_hwm": 407088,
    "gpu_usage": 319488,
    "label": "PhysicsParams.construct",
    "parent_index": 1
   },
   {
    "_units": "kibi",
    "cpu_hwm": 406644,
    "gpu_usage": 319488,
    "label": "SeltzerBergerModel.construct",
    "parent_index": 8
   },
   {
    "_units": "kibi",
    "cpu_hwm": 407088,
    "gpu_usage": 319488,
    "label": "CoreParams.construct",
    "parent_index": 0
   }
  ]
</pre></details>

In the "simple GPU demo loop" above, initializing ROOT takes over half of the total CPU usage. The CPU reporting statistics are more granular on macOS:
<details><summary>macOS CPU demo lookp</summary><pre>
"memory": [
 {
  "_units": "kibi",
  "cpu_delta": 258208,
  "cpu_hwm": 289904,
  "label": "demo_loop.run"
 },
 {
  "_units": "kibi",
  "cpu_delta": 253872,
  "cpu_hwm": 286176,
  "label": "demo_loop.load_core_params",
  "parent_index": 0
 },
 {
  "_units": "kibi",
  "cpu_delta": 234624,
  "cpu_hwm": 266944,
  "label": "RootImporter.open",
  "parent_index": 1
 },
 {
  "_units": "kibi",
  "cpu_delta": 15744,
  "cpu_hwm": 282704,
  "label": "RootImporter.read",
  "parent_index": 1
 },
 {
  "_units": "kibi",
  "cpu_delta": 240,
  "cpu_hwm": 284400,
  "label": "MaterialParams.construct",
  "parent_index": 1
 },
 {
  "_units": "kibi",
  "cpu_hwm": 284400,
  "label": "GeoMaterialParams.construct",
  "parent_index": 1
 },
 {
  "_units": "kibi",
  "cpu_delta": 48,
  "cpu_hwm": 284512,
  "label": "ParticleParams.construct",
  "parent_index": 1
 },
 {
  "_units": "kibi",
  "cpu_delta": 32,
  "cpu_hwm": 284624,
  "label": "CutoffParams.construct",
  "parent_index": 1
 },
 {
  "_units": "kibi",
  "cpu_delta": 864,
  "cpu_hwm": 285984,
  "label": "PhysicsParams.construct",
  "parent_index": 1
 },
 {
  "_units": "kibi",
  "cpu_delta": 112,
  "cpu_hwm": 285360,
  "label": "SeltzerBergerModel.construct",
  "parent_index": 8
 },
 {
  "_units": "kibi",
  "cpu_delta": 144,
  "cpu_hwm": 286336,
  "label": "CoreParams.construct",
  "parent_index": 0
 }
]
</pre></details>