### PR TITLE
Create ORANGE RectArrayRecord objects

### DIFF
--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND SOURCES
   OrangeParams.cc
   OrangeTypes.cc
   construct/SurfaceInputBuilder.cc
+  detail/RectArrayInserter.cc
   detail/UnitInserter.cc
   surf/SurfaceIO.cc
 )

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -147,7 +147,7 @@ struct SimpleUnitRecord
 
 //---------------------------------------------------------------------------//
 /*!
- * Data for a single rectilinear array universe
+ * Data for a single rectilinear array universe.
  */
 struct RectArrayRecord
 {
@@ -156,14 +156,13 @@ struct RectArrayRecord
     // Daughter data [index by LocalVolumeId]
     ItemMap<LocalVolumeId, DaughterId> daughters;
 
-    bool simple_safety{};
-
     explicit CELER_FUNCTION operator bool() const
     {
         return daughters.size() > 0
                && daughters.size()
-                      == (grid[Axis::x].size() - 1) * (grid[Axis::y].size() - 1)
-                             * (grid[Axis::z].size() - 1);
+                      == (grid[to_int(Axis::x)].size() - 1)
+                             * (grid[to_int(Axis::y)].size() - 1)
+                             * (grid[to_int(Axis::z)].size() - 1);
     }
 };
 

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -156,13 +156,12 @@ struct RectArrayRecord
     // Daughter data [index by LocalVolumeId]
     ItemMap<LocalVolumeId, DaughterId> daughters;
 
+    //! Cursory check for validity
     explicit CELER_FUNCTION operator bool() const
     {
-        return daughters.size() > 0
-               && daughters.size()
-                      == (grid[to_int(Axis::x)].size() - 1)
-                             * (grid[to_int(Axis::y)].size() - 1)
-                             * (grid[to_int(Axis::z)].size() - 1);
+        return !daughters.empty() && !grid[to_int(Axis::x)].empty()
+               && !grid[to_int(Axis::y)].empty()
+               && !grid[to_int(Axis::z)].empty();
     }
 };
 

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -147,6 +147,28 @@ struct SimpleUnitRecord
 
 //---------------------------------------------------------------------------//
 /*!
+ * Data for a single rectilinear array universe
+ */
+struct RectArrayRecord
+{
+    Array<ItemRange<real_type>, 3> grid;
+
+    // Daughter data [index by LocalVolumeId]
+    ItemMap<LocalVolumeId, DaughterId> daughters;
+
+    bool simple_safety{};
+
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return daughters.size() > 0
+               && daughters.size()
+                      == (grid[Axis::x].size() - 1) * (grid[Axis::y].size() - 1)
+                             * (grid[Axis::z].size() - 1);
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Surface and volume offsets to convert between local and global indices.
  *
  * Each collection should be of length num_universes + 1. The first entry is
@@ -183,10 +205,10 @@ struct UnitIndexerData
  * Most data will be accessed through the invidual units, which reference data
  * in the "storage" below. The type and index for a universe ID will determine
  * the class type and data of the Tracker to instantiate. If *only* simple
- * units are present, then the \c simple_unit data structure will just be equal
- * to a range (with the total number of universes present). Use `universe_type`
- * to switch on the type of universe; then `universe_index` to index into
- * `simple_unit` or `rect_array` or ...
+ * units are present, then the \c simple_units data structure will just be
+ * equal to a range (with the total number of universes present). Use
+ * `universe_types` to switch on the type of universe; then `universe_indices`
+ * to index into `simple_units` or `rect_arrays` or ...
  */
 template<Ownership W, MemSpace M>
 struct OrangeParamsData
@@ -203,9 +225,10 @@ struct OrangeParamsData
     OrangeParamsScalars scalars;
 
     // High-level universe definitions
-    UnivItems<UniverseType> universe_type;
-    UnivItems<size_type> universe_index;
-    Items<SimpleUnitRecord> simple_unit;
+    UnivItems<UniverseType> universe_types;
+    UnivItems<size_type> universe_indices;
+    Items<SimpleUnitRecord> simple_units;
+    Items<RectArrayRecord> rect_arrays;
 
     // Low-level storage
     Items<LocalSurfaceId> local_surface_ids;
@@ -227,8 +250,8 @@ struct OrangeParamsData
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return scalars && !universe_type.empty()
-               && universe_index.size() == universe_type.size()
+        return scalars && !universe_types.empty()
+               && universe_indices.size() == universe_types.size()
                && ((!local_volume_ids.empty() && !logic_ints.empty()
                     && !reals.empty())
                    || surface_types.empty())
@@ -241,9 +264,10 @@ struct OrangeParamsData
     {
         scalars = other.scalars;
 
-        universe_type = other.universe_type;
-        universe_index = other.universe_index;
-        simple_unit = other.simple_unit;
+        universe_types = other.universe_types;
+        universe_indices = other.universe_indices;
+        simple_units = other.simple_units;
+        rect_arrays = other.rect_arrays;
 
         local_surface_ids = other.local_surface_ids;
         local_volume_ids = other.local_volume_ids;

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -205,14 +205,10 @@ OrangeParams::OrangeParams(OrangeInput input)
 
     supports_safety_ = host_data.simple_units[SimpleUnitId{0}].simple_safety;
 
-    auto GetBoundingBox
-        = Overload<std::function<BoundingBox(UnitInput const&)>,
-                   std::function<BoundingBox(RectArrayInput const&)>>{
-            [](UnitInput const& u) { return u.bbox; },
-            [](RectArrayInput const& u) { return u.bbox; },
-        };
+    CELER_VALIDATE(std::holds_alternative<UnitInput>(input.universes.front()),
+                   << "global universe is not a SimpleUnit");
+    bbox_ = std::get<UnitInput>(input.universes.front()).bbox;
 
-    bbox_ = std::visit(GetBoundingBox, input.universes.front());
     // Update scalars *after* loading all units
     host_data.scalars.max_level = input.max_level;
     CELER_VALIDATE(host_data.scalars.max_logic_depth

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -127,7 +127,7 @@ OrangeParams::OrangeParams(OrangeInput input)
     // Insert simple units
     this->insert_simple_units(host_data, input);
 
-    // Insert rect array Units
+    // Insert rect arrays
     detail::RectArrayInserter insert_rect_array(&host_data);
     for (RectArrayInput const& r : input.rect_arrays)
     {

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -147,17 +147,13 @@ OrangeParams::OrangeParams(OrangeInput input)
     ui_surf.push_back(0);
     ui_vol.push_back(0);
 
-    auto GetNumSurfaces
-        = Overload<std::function<size_type(UnitInput const&)>,
-                   std::function<size_type(RectArrayInput const&)>>{
-            [](UnitInput const& u) { return u.surfaces.size(); },
-            [](RectArrayInput const&) { return size_type{0}; }};
+    auto get_num_surfaces
+        = Overload{[](UnitInput const& u) { return u.surfaces.size(); },
+                   [](RectArrayInput const&) { return size_type{0}; }};
 
-    auto GetNumVolumes
-        = Overload<std::function<size_type(UnitInput const&)>,
-                   std::function<size_type(RectArrayInput const&)>>{
-            [](UnitInput const& u) { return u.volumes.size(); },
-            [](RectArrayInput const&) { return size_type{0}; }};
+    auto get_num_volumes
+        = Overload{[](UnitInput const& u) { return u.volumes.size(); },
+                   [](RectArrayInput const&) { return size_type{0}; }};
 
     for (auto const& u : input.universes)
     {
@@ -168,8 +164,8 @@ OrangeParams::OrangeParams(OrangeInput input)
         auto volume_offset
             = host_data.unit_indexer_data.volumes[AllVals{}].back();
 
-        auto surfs = std::visit(GetNumSurfaces, u);
-        auto vols = std::visit(GetNumVolumes, u);
+        auto surfs = std::visit(get_num_surfaces, u);
+        auto vols = std::visit(get_num_volumes, u);
 
         ui_surf.push_back(surface_offset + surfs);
         ui_vol.push_back(volume_offset + vols);
@@ -178,7 +174,7 @@ OrangeParams::OrangeParams(OrangeInput input)
     detail::UnitInserter insert_unit(&host_data);
     detail::RectArrayInserter insert_rect_array(&host_data);
 
-    auto InsertUniverse = Overload{
+    auto insert_universe = Overload{
         [&insert_unit](UnitInput const& u) {
             CELER_VALIDATE(u,
                            << "simple unit '" << u.label
@@ -197,7 +193,7 @@ OrangeParams::OrangeParams(OrangeInput input)
 
     for (auto const& u : input.universes)
     {
-        std::visit(InsertUniverse, u);
+        std::visit(insert_universe, u);
     }
 
     // Get surface/volume labels
@@ -335,9 +331,9 @@ void OrangeParams::process_metadata(OrangeInput const& input)
                     for (auto k : range(r.grid[to_int(Axis::z)].size() - 1))
                     {
                         Label vl;
-                        vl.name = std::string("(" + std::to_string(i) + ", "
-                                              + std::to_string(j) + ", "
-                                              + std::to_string(k) + ")");
+                        vl.name = std::string("{" + std::to_string(i) + ","
+                                              + std::to_string(j) + ","
+                                              + std::to_string(k) + "}");
                         vl.ext = r.label.name;
                         volume_labels.push_back(std::move(vl));
                     }
@@ -363,8 +359,8 @@ void OrangeParams::process_metadata(OrangeInput const& input)
                 for (auto i : range(r.grid[to_int(ax)].size() - 1))
                 {
                     Label sl;
-                    sl.name = std::string("(" + std::string(1, to_char(ax))
-                                          + ", " + std::to_string(i) + ")");
+                    sl.name = std::string("{" + std::string(1, to_char(ax))
+                                          + "," + std::to_string(i) + "}");
                     sl.ext = r.label.name;
                     surface_labels.push_back(std::move(sl));
                 }

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -147,17 +147,13 @@ OrangeParams::OrangeParams(OrangeInput input)
     ui_surf.push_back(0);
     ui_vol.push_back(0);
 
-    auto get_num_surfaces
-        = Overload<std::function<size_type(UnitInput const&)>,
-                   std::function<size_type(RectArrayInput const&)>>{
-            [](UnitInput const& u) { return u.surfaces.size(); },
-            [](RectArrayInput const&) { return size_type{0}; }};
+    auto get_num_surfaces = Overload{
+        [](UnitInput const& u) -> size_type { return u.surfaces.size(); },
+        [](RectArrayInput const&) -> size_type { return 0; }};
 
-    auto get_num_volumes
-        = Overload<std::function<size_type(UnitInput const&)>,
-                   std::function<size_type(RectArrayInput const&)>>{
-            [](UnitInput const& u) { return u.volumes.size(); },
-            [](RectArrayInput const&) { return size_type{0}; }};
+    auto get_num_volumes = Overload{
+        [](UnitInput const& u) -> size_type { return u.volumes.size(); },
+        [](RectArrayInput const&) -> size_type { return 0; }};
 
     for (auto const& u : input.universes)
     {

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -148,12 +148,16 @@ OrangeParams::OrangeParams(OrangeInput input)
     ui_vol.push_back(0);
 
     auto get_num_surfaces
-        = Overload{[](UnitInput const& u) { return u.surfaces.size(); },
-                   [](RectArrayInput const&) { return size_type{0}; }};
+        = Overload<std::function<size_type(UnitInput const&)>,
+                   std::function<size_type(RectArrayInput const&)>>{
+            [](UnitInput const& u) { return u.surfaces.size(); },
+            [](RectArrayInput const&) { return size_type{0}; }};
 
     auto get_num_volumes
-        = Overload{[](UnitInput const& u) { return u.volumes.size(); },
-                   [](RectArrayInput const&) { return size_type{0}; }};
+        = Overload<std::function<size_type(UnitInput const&)>,
+                   std::function<size_type(RectArrayInput const&)>>{
+            [](UnitInput const& u) { return u.volumes.size(); },
+            [](RectArrayInput const&) { return size_type{0}; }};
 
     for (auto const& u : input.universes)
     {

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -112,13 +112,8 @@ class OrangeParams
   private:
     //// HELPER METHODS ////
 
-    // Insert all simple units
-    void insert_simple_units(HostVal<OrangeParamsData>& host_data,
-                             OrangeInput const& input);
-
     // Get surface and volume labels for all universes.
-    void process_metadata(HostVal<OrangeParamsData>& host_data,
-                          OrangeInput const& input);
+    void process_metadata(OrangeInput const& input);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -20,6 +20,8 @@
 #include "BoundingBox.hh"
 #include "OrangeData.hh"
 #include "OrangeTypes.hh"
+#include "detail/RectArrayInserter.hh"
+#include "detail/UnitIndexer.hh"
 
 class G4VPhysicalVolume;
 
@@ -108,6 +110,11 @@ class OrangeParams
 
     // Host/device storage and reference
     CollectionMirror<OrangeParamsData> data_;
+
+  private:
+    // Host metadata/access
+    void insert_simple_units(HostVal<OrangeParamsData>& host_data,
+                             OrangeInput const& input);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -20,8 +20,6 @@
 #include "BoundingBox.hh"
 #include "OrangeData.hh"
 #include "OrangeTypes.hh"
-#include "detail/RectArrayInserter.hh"
-#include "detail/UnitIndexer.hh"
 
 class G4VPhysicalVolume;
 
@@ -112,9 +110,15 @@ class OrangeParams
     CollectionMirror<OrangeParamsData> data_;
 
   private:
-    // Host metadata/access
+    //// HELPER METHODS ////
+
+    // Insert all simple units
     void insert_simple_units(HostVal<OrangeParamsData>& host_data,
                              OrangeInput const& input);
+
+    // Get surface and volume labels for all universes.
+    void process_metadata(HostVal<OrangeParamsData>& host_data,
+                          OrangeInput const& input);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -858,8 +858,8 @@ CELER_FUNCTION real_type OrangeTrackView::find_safety()
  */
 CELER_FUNCTION SimpleUnitTracker OrangeTrackView::make_tracker(UniverseId id) const
 {
-    CELER_EXPECT(id < params_.universe_type.size());
-    CELER_EXPECT(id.unchecked_get() == params_.universe_index[id]);
+    CELER_EXPECT(id < params_.universe_types.size());
+    CELER_EXPECT(id.unchecked_get() == params_.universe_indices[id]);
 
     using TraitsT = UniverseTypeTraits<UniverseType::simple>;
     using IdT = OpaqueId<typename TraitsT::record_type>;

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -48,6 +48,9 @@ using LocalVolumeId = OpaqueId<struct LocalVolume>;
 //! Opaque index for "simple unit" data
 using SimpleUnitId = OpaqueId<struct SimpleUnitRecord>;
 
+//! Opaque index for rectilinear array data
+using RectArrayId = OpaqueId<struct RectArrayRecord>;
+
 //! Translation of a single embedded universe
 using Translation = Real3;
 
@@ -122,8 +125,8 @@ enum class SurfaceType : unsigned char
 enum class UniverseType : unsigned char
 {
     simple,
-#if 0
     rect_array,
+#if 0
     hex_array,
     dode_array,
     ...

--- a/src/orange/Types.hh
+++ b/src/orange/Types.hh
@@ -33,12 +33,12 @@ using VolumeId = OpaqueId<struct Volume>;
 /*!
  * Enumeration for cartesian axes.
  */
-enum class Axis
+enum Axis : size_type
 {
-    x,  //!< X axis/I index coordinate
-    y,  //!< Y axis/J index coordinate
-    z,  //!< Z axis/K index coordinate
-    size_  //!< Sentinel value for looping over axes
+    x = 0,  //!< X axis/I index coordinate
+    y = 1,  //!< Y axis/J index coordinate
+    z = 2,  //!< Z axis/K index coordinate
+    size_ = 3  //!< Sentinel value for looping over axes
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/Types.hh
+++ b/src/orange/Types.hh
@@ -33,12 +33,12 @@ using VolumeId = OpaqueId<struct Volume>;
 /*!
  * Enumeration for cartesian axes.
  */
-enum Axis : size_type
+enum class Axis
 {
-    x = 0,  //!< X axis/I index coordinate
-    y = 1,  //!< Y axis/J index coordinate
-    z = 2,  //!< Z axis/K index coordinate
-    size_ = 3  //!< Sentinel value for looping over axes
+    x,  //!< X axis/I index coordinate
+    y,  //!< Y axis/J index coordinate
+    z,  //!< Z axis/K index coordinate
+    size_  //!< Sentinel value for looping over axes
 };
 
 //---------------------------------------------------------------------------//
@@ -70,6 +70,19 @@ struct Propagation
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS (HOST)
 //---------------------------------------------------------------------------//
+//! Convert Axis enum value to int
+CELER_CONSTEXPR_FUNCTION int to_int(Axis a)
+{
+    return static_cast<int>(a);
+}
+
+//! Convert int to Axis enum value
+inline CELER_FUNCTION Axis to_axis(int a)
+{
+    CELER_EXPECT(a >= 0 && a < 3);
+    return static_cast<Axis>(a);
+}
+
 //! Get the lowercase name of the axis.
 inline constexpr char to_char(Axis ax)
 {

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -115,8 +115,6 @@ struct RectArrayInput
     // Daughter loading
     std::vector<DaughterInput> daughters;
 
-    BoundingBox bbox;  //!< Outer bounding box
-
     // Unit metadata
     Label label;
 

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <unordered_map>  // IWYU pragma: export
+#include <variant>
 #include <vector>
 
 #include "corecel/cont/Label.hh"
@@ -129,8 +130,7 @@ struct RectArrayInput
  */
 struct OrangeInput
 {
-    std::vector<UnitInput> units;
-    std::vector<RectArrayInput> rect_arrays;
+    std::vector<std::variant<UnitInput, RectArrayInput>> universes;
 
     std::vector<UniverseType> universe_types;
     std::vector<size_type> universe_indices;
@@ -143,7 +143,10 @@ struct OrangeInput
     // or maybe std::variant when we require C++17
 
     //! Whether the unit definition is valid
-    explicit operator bool() const { return !units.empty() && max_level > 0; }
+    explicit operator bool() const
+    {
+        return !universes.empty() && max_level > 0;
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -74,16 +74,21 @@ struct VolumeInput
 
 //---------------------------------------------------------------------------//
 /*!
+ * Input definition a daughter universe embedded in a parent cell
+ */
+struct DaughterInput
+{
+    UniverseId universe_id;
+    Translation translation;
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Input definition for a unit.
  */
 struct UnitInput
 {
-    struct Daughter
-    {
-        UniverseId universe_id;
-        Translation translation;
-    };
-    using MapVolumeDaughter = std::unordered_map<LocalVolumeId, Daughter>;
+    using MapVolumeDaughter = std::unordered_map<LocalVolumeId, DaughterInput>;
 
     SurfaceInput surfaces;
     std::vector<VolumeInput> volumes;
@@ -99,11 +104,36 @@ struct UnitInput
 
 //---------------------------------------------------------------------------//
 /*!
+ * Input definition for a rectangular array universe.
+ */
+struct RectArrayInput
+{
+    // Grid boundaries in x, y, and z
+    Array<std::vector<double>, 3> grid;
+
+    // Daughter loading
+    std::vector<DaughterInput> daughters;
+
+    BoundingBox bbox;  //!< Outer bounding box
+
+    // Unit metadata
+    Label label;
+
+    //! Whether the universe definition is valid
+    explicit operator bool() const { return !daughters.empty(); }
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Construction definition for a full ORANGE geometry.
  */
 struct OrangeInput
 {
     std::vector<UnitInput> units;
+    std::vector<RectArrayInput> rect_arrays;
+
+    std::vector<UniverseType> universe_types;
+    std::vector<size_type> universe_indices;
 
     // TODO: Calculate automatically in Shift by traversing the parent/daughter
     // tree

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <algorithm>
 #include <unordered_map>  // IWYU pragma: export
 #include <variant>
 #include <vector>
@@ -112,14 +113,20 @@ struct RectArrayInput
     // Grid boundaries in x, y, and z
     Array<std::vector<double>, 3> grid;
 
-    // Daughter loading
+    // Daughters in each cell [x][y][z]
     std::vector<DaughterInput> daughters;
 
     // Unit metadata
     Label label;
 
     //! Whether the universe definition is valid
-    explicit operator bool() const { return !daughters.empty(); }
+    explicit operator bool() const
+    {
+        return !daughters.empty()
+               && std::all_of(grid.begin(), grid.end(), [](auto& v) {
+                      return v.size() >= 2;
+                  });
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -266,21 +266,25 @@ void from_json(nlohmann::json const& j, OrangeInput& value)
 {
     auto const& universes = j.at("universes");
 
-    value.units.reserve(universes.size());
+    value.universes.reserve(universes.size());
+
+    size_type simple_unit_index = 0;
+    size_type rect_array_index = 0;
+
     for (auto const& uni : universes)
     {
         auto uni_type = uni.at("_type").get<std::string>();
         if (uni_type == "simple unit")
         {
             value.universe_types.push_back(UniverseType::simple);
-            value.universe_indices.push_back(value.units.size());
-            value.units.push_back(uni.get<UnitInput>());
+            value.universe_indices.push_back(simple_unit_index++);
+            value.universes.push_back(uni.get<UnitInput>());
         }
         else if (uni_type == "rectangular array")
         {
             value.universe_types.push_back(UniverseType::rect_array);
-            value.universe_indices.push_back(value.rect_arrays.size());
-            value.rect_arrays.push_back(uni.get<RectArrayInput>());
+            value.universe_indices.push_back(rect_array_index++);
+            value.universes.push_back(uni.get<RectArrayInput>());
         }
         else if (uni_type == "hexagonal array")
         {

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -228,9 +228,6 @@ void from_json(nlohmann::json const& j, RectArrayInput& value)
 {
     j.at("md").at("name").get_to(value.label);
 
-    auto const& bbox = j.at("bbox");
-    value.bbox = {bbox.at(0).get<Real3>(), bbox.at(1).get<Real3>()};
-
     for (auto ax : range(Axis::size_))
     {
         value.grid[to_int(ax)]

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -231,13 +231,12 @@ void from_json(nlohmann::json const& j, RectArrayInput& value)
     auto const& bbox = j.at("bbox");
     value.bbox = {bbox.at(0).get<Real3>(), bbox.at(1).get<Real3>()};
 
-    std::vector<std::string> dim_strings({"x", "y", "z"});
-
-    for (auto i : range(3))
+    for (auto ax : range(Axis::size_))
     {
-        value.grid[i] = j.at(dim_strings[i]).get<std::vector<real_type>>();
-        CELER_VALIDATE(value.grid[i].size() >= 2,
-                       << "axis " << dim_strings[i]
+        value.grid[to_int(ax)]
+            = j.at(std::string(1, to_char(ax))).get<std::vector<real_type>>();
+        CELER_VALIDATE(value.grid[to_int(ax)].size() >= 2,
+                       << "axis " << to_char(ax)
                        << " does must have at least two grid points");
     }
 

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -278,7 +278,7 @@ void from_json(nlohmann::json const& j, OrangeInput& value)
         }
         else if (uni_type == "rectangular array")
         {
-            value.universe_types.push_back(UniverseType::simple);
+            value.universe_types.push_back(UniverseType::rect_array);
             value.universe_indices.push_back(value.rect_arrays.size());
             value.rect_arrays.push_back(uni.get<RectArrayInput>());
         }

--- a/src/orange/detail/RectArrayInserter.cc
+++ b/src/orange/detail/RectArrayInserter.cc
@@ -38,20 +38,21 @@ RectArrayId RectArrayInserter::operator()(RectArrayInput const& inp)
 {
     RectArrayRecord rect_array;
 
+    auto reals_builder = make_builder(&orange_data_->reals);
     for (auto i : range(3))
     {
-        rect_array.grid[i]
-            = make_builder(&orange_data_->reals)
-                  .insert_back(inp.grid[i].begin(), inp.grid[i].end());
+        rect_array.grid[i] = reals_builder.insert_back(inp.grid[i].begin(),
+                                                       inp.grid[i].end());
     }
 
     std::vector<Daughter> daughters;
+    auto translations_builder = make_builder(&orange_data_->translations);
     for (auto const& daughter_input : inp.daughters)
     {
         Daughter d;
         d.universe_id = daughter_input.universe_id;
-        d.translation_id = make_builder(&orange_data_->translations)
-                               .push_back(daughter_input.translation);
+        d.translation_id
+            = translations_builder.push_back(daughter_input.translation);
         daughters.push_back(d);
     }
 

--- a/src/orange/detail/RectArrayInserter.cc
+++ b/src/orange/detail/RectArrayInserter.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "RectArrayInserter.hh"
 
+#include <algorithm>
 #include <vector>
 
 #include "corecel/Assert.hh"
@@ -36,14 +37,33 @@ RectArrayInserter::RectArrayInserter(Data* orange_data)
  */
 RectArrayId RectArrayInserter::operator()(RectArrayInput const& inp)
 {
-    RectArrayRecord rect_array;
+    RectArrayRecord record;
 
     auto reals_builder = make_builder(&orange_data_->reals);
-    for (auto i : range(3))
+    size_type num_volumes = 1;
+    for (auto ax : range(Axis::size_))
     {
-        rect_array.grid[i] = reals_builder.insert_back(inp.grid[i].begin(),
-                                                       inp.grid[i].end());
+        std::vector<double> const& grid = inp.grid[to_int(ax)];
+        CELER_VALIDATE(grid.size() >= 2,
+                       << "grid for " << to_char(ax) << " axis in '"
+                       << inp.label << "' is too small (size " << grid.size()
+                       << ")");
+        CELER_VALIDATE(std::is_sorted(grid.begin(), grid.end()),
+                       << "grid for " << to_char(ax) << " axis in '"
+                       << inp.label << "' is not monotonically increasing");
+
+        num_volumes *= grid.size() - 1;
+
+        // Construct grid
+        record.grid[to_int(ax)]
+            = reals_builder.insert_back(grid.begin(), grid.end());
     }
+
+    CELER_VALIDATE(inp.daughters.size() == num_volumes,
+                   << "number of input daughters (" << inp.daughters.size()
+                   << ") in '" << inp.label
+                   << "' does not match number of volumes (" << num_volumes
+                   << ")");
 
     std::vector<Daughter> daughters;
     auto translations_builder = make_builder(&orange_data_->translations);
@@ -56,13 +76,13 @@ RectArrayId RectArrayInserter::operator()(RectArrayInput const& inp)
         daughters.push_back(d);
     }
 
-    rect_array.daughters = ItemMap<LocalVolumeId, DaughterId>(
+    record.daughters = ItemMap<LocalVolumeId, DaughterId>(
         make_builder(&orange_data_->daughters)
             .insert_back(daughters.begin(), daughters.end()));
 
-    CELER_ASSERT(rect_array);
+    CELER_ASSERT(record);
     return RectArrayId(
-        make_builder(&orange_data_->rect_arrays).push_back(rect_array).get());
+        make_builder(&orange_data_->rect_arrays).push_back(record).get());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/RectArrayInserter.cc
+++ b/src/orange/detail/RectArrayInserter.cc
@@ -1,0 +1,69 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/detail/RectArrayInserter.cc
+//---------------------------------------------------------------------------//
+#include "RectArrayInserter.hh"
+
+#include <vector>
+
+#include "corecel/Assert.hh"
+#include "corecel/cont/Range.hh"
+#include "corecel/data/Collection.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "orange/construct/OrangeInput.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from full parameter data.
+ */
+RectArrayInserter::RectArrayInserter(Data* orange_data)
+    : orange_data_(orange_data)
+{
+    CELER_EXPECT(orange_data);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create a simple unit and return its ID.
+ */
+RectArrayId RectArrayInserter::operator()(RectArrayInput const& inp)
+{
+    RectArrayRecord rect_array;
+
+    for (auto i : range(3))
+    {
+        rect_array.grid[i]
+            = make_builder(&orange_data_->reals)
+                  .insert_back(inp.grid[i].begin(), inp.grid[i].end());
+    }
+
+    std::vector<Daughter> daughters;
+    for (auto const& daughter_input : inp.daughters)
+    {
+        Daughter d;
+        d.universe_id = daughter_input.universe_id;
+        d.translation_id = make_builder(&orange_data_->translations)
+                               .push_back(daughter_input.translation);
+        daughters.push_back(d);
+    }
+
+    rect_array.daughters = ItemMap<LocalVolumeId, DaughterId>(
+        make_builder(&orange_data_->daughters)
+            .insert_back(daughters.begin(), daughters.end()));
+
+    CELER_ASSERT(rect_array);
+    return RectArrayId(
+        make_builder(&orange_data_->rect_arrays).push_back(rect_array).get());
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/orange/detail/RectArrayInserter.hh
+++ b/src/orange/detail/RectArrayInserter.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/UnitInserter.hh
+//! \file orange/detail/RectArrayInserter.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -20,11 +20,9 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Convert a unit input to params data.
- *
- * Linearize the data in a UnitInput and add it to the host.
+ * Convert a RectArrayInput a RectArrayRecord.
  */
-class UnitInserter
+class RectArrayInserter
 {
   public:
     //!@{
@@ -34,24 +32,13 @@ class UnitInserter
 
   public:
     // Construct from full parameter data
-    UnitInserter(Data* orange_data);
+    RectArrayInserter(Data* orange_data);
 
-    // Create a simple unit and store in in OrangeParamsData
-    void operator()(UnitInput const& inp);
+    // Create a simple unit and return its ID
+    RectArrayId operator()(RectArrayInput const& inp);
 
   private:
     Data* orange_data_{nullptr};
-
-    // TODO: additional caches for hashed data?
-
-    //// HELPER METHODS ////
-
-    SurfacesRecord insert_surfaces(SurfaceInput const& s);
-    VolumeRecord
-    insert_volume(SurfacesRecord const& unit, VolumeInput const& v);
-
-    void process_daughter(VolumeRecord* vol_record,
-                          DaughterInput const& daughter_input);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/RectArrayInserter.hh
+++ b/src/orange/detail/RectArrayInserter.hh
@@ -7,8 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <vector>
-
 #include "corecel/Types.hh"
 #include "orange/OrangeData.hh"
 #include "orange/OrangeTypes.hh"

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -149,7 +149,7 @@ UnitInserter::UnitInserter(Data* orange_data) : orange_data_(orange_data)
 /*!
  * Create a simple unit and return its ID.
  */
-void UnitInserter::operator()(UnitInput const& inp)
+SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
 {
     SimpleUnitRecord unit;
 
@@ -214,7 +214,7 @@ void UnitInserter::operator()(UnitInput const& inp)
         });
 
     CELER_ASSERT(unit);
-    make_builder(&orange_data_->simple_units).push_back(unit);
+    return make_builder(&orange_data_->simple_units).push_back(unit);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -149,7 +149,7 @@ UnitInserter::UnitInserter(Data* orange_data) : orange_data_(orange_data)
 /*!
  * Create a simple unit and return its ID.
  */
-SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
+void UnitInserter::operator()(UnitInput const& inp)
 {
     SimpleUnitRecord unit;
 
@@ -214,8 +214,7 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
         });
 
     CELER_ASSERT(unit);
-    auto simple_units = make_builder(&orange_data_->simple_unit);
-    return simple_units.push_back(unit);
+    make_builder(&orange_data_->simple_units).push_back(unit);
 }
 
 //---------------------------------------------------------------------------//
@@ -354,7 +353,7 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
  * Process a single daughter universe.
  */
 void UnitInserter::process_daughter(VolumeRecord* vol_record,
-                                    UnitInput::Daughter const& daughter_input)
+                                    DaughterInput const& daughter_input)
 {
     Daughter daughter;
     daughter.universe_id = daughter_input.universe_id;

--- a/src/orange/detail/UnitInserter.hh
+++ b/src/orange/detail/UnitInserter.hh
@@ -37,7 +37,7 @@ class UnitInserter
     UnitInserter(Data* orange_data);
 
     // Create a simple unit and store in in OrangeParamsData
-    void operator()(UnitInput const& inp);
+    SimpleUnitId operator()(UnitInput const& inp);
 
   private:
     Data* orange_data_{nullptr};

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -138,7 +138,7 @@ class SimpleUnitTracker
  */
 CELER_FUNCTION
 SimpleUnitTracker::SimpleUnitTracker(ParamsRef const& params, SimpleUnitId suid)
-    : params_(params), unit_record_(params.simple_unit[suid])
+    : params_(params), unit_record_(params.simple_units[suid])
 {
     CELER_EXPECT(params_);
 }

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -211,7 +211,7 @@ void NestedTest::build_orange()
 
     OrangeInput input;
     input.max_level = 1;
-    input.units.push_back(std::move(ui));
+    input.universes.push_back(std::move(ui));
     auto geo = std::make_shared<OrangeParams>(std::move(input));
 #if !CELERITAS_USE_VECGEOM
     geo_params_ = std::move(geo);

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -212,6 +212,8 @@ void NestedTest::build_orange()
     OrangeInput input;
     input.max_level = 1;
     input.universes.push_back(std::move(ui));
+    input.universe_types.push_back(celeritas::UniverseType::simple);
+    input.universe_indices.push_back(0);
     auto geo = std::make_shared<OrangeParams>(std::move(input));
 #if !CELERITAS_USE_VECGEOM
     geo_params_ = std::move(geo);

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -847,11 +847,6 @@ TEST_F(UniversesTest, cross_between_daughters)
     EXPECT_EQ("bob.mz", this->params().id_to_label(geo.surface_id()).name);
 }
 
-TEST_F(RectArrayTest, initialization)
-{
-    FAIL() << "not implemented";
-}
-
 TEST_F(Geant4Testem15Test, safety)
 {
     OrangeTrackView geo = this->make_track_view();

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -849,7 +849,7 @@ TEST_F(UniversesTest, cross_between_daughters)
 
 TEST_F(RectArrayTest, initialization)
 {
-    OrangeTrackView geo = this->make_track_view();
+    FAIL() << "not implemented";
 }
 
 TEST_F(Geant4Testem15Test, safety)

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -75,6 +75,12 @@ class UniversesTest : public OrangeTest
     void SetUp() override { this->build_geometry("universes.org.json"); }
 };
 
+#define RectArrayTest TEST_IF_CELERITAS_JSON(RectArrayTest)
+class RectArrayTest : public OrangeTest
+{
+    void SetUp() override { this->build_geometry("rect_array.org.json"); }
+};
+
 #define Geant4Testem15Test TEST_IF_CELERITAS_JSON(Geant4Testem15Test)
 class Geant4Testem15Test : public OrangeTest
 {
@@ -839,6 +845,11 @@ TEST_F(UniversesTest, cross_between_daughters)
     geo.move_to_boundary();
     EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("bob.mz", this->params().id_to_label(geo.surface_id()).name);
+}
+
+TEST_F(RectArrayTest, initialization)
+{
+    OrangeTrackView geo = this->make_track_view();
 }
 
 TEST_F(Geant4Testem15Test, safety)

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -46,6 +46,8 @@ OrangeInput to_input(UnitInput u)
 {
     OrangeInput result;
     result.units.push_back(std::move(u));
+    result.universe_types.push_back(celeritas::UniverseType::simple);
+    result.universe_indices.push_back(0);
     return result;
 }
 
@@ -215,10 +217,11 @@ void OrangeGeoTestBase::describe(std::ostream& os) const
 
     // TODO: update when multiple units are in play
     auto const& host_ref = this->host_params();
-    CELER_ASSERT(host_ref.simple_unit.size() == 1);
+    CELER_ASSERT(host_ref.simple_units.size() == 1);
 
     os << "# Surfaces\n";
-    Surfaces surfaces(host_ref, host_ref.simple_unit[SimpleUnitId{0}].surfaces);
+    Surfaces surfaces(host_ref,
+                      host_ref.simple_units[SimpleUnitId{0}].surfaces);
     auto surf_to_stream = make_surface_action(surfaces, ToStream{os});
 
     // Loop over all surfaces and apply

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -45,7 +45,7 @@ struct ToStream
 OrangeInput to_input(UnitInput u)
 {
     OrangeInput result;
-    result.units.push_back(std::move(u));
+    result.universes.push_back(std::move(u));
     result.universe_types.push_back(celeritas::UniverseType::simple);
     result.universe_indices.push_back(0);
     return result;

--- a/test/orange/data/rect_array.org.json
+++ b/test/orange/data/rect_array.org.json
@@ -1,0 +1,575 @@
+{
+"_format": "SCALE ORANGE",
+"_version": 0,
+"materials": {
+"cell_to_mat": [
+-1,
+-1,
+0,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+1,
+-1,
+1,
+-1,
+1
+],
+"names": [
+"0",
+"1"
+]
+},
+"universes": [
+{
+"_type": "simple unit",
+"bbox": [
+[
+-12.0,
+-4.0,
+-5.0
+],
+[
+12.0,
+10.0,
+5.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"arrfill",
+"interior"
+],
+"cells": [
+{
+"faces": [
+0,
+1,
+2,
+3,
+4,
+5
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ & ~",
+"num_intersections": 6,
+"zorder": 2
+},
+{
+"faces": [
+4,
+5,
+6,
+7,
+8,
+9
+],
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ &",
+"num_intersections": 6,
+"zorder": 2
+},
+{
+"faces": [
+0,
+1,
+2,
+3,
+4,
+5,
+6,
+7,
+8,
+9
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ & 4 5 ~ & 6 & 7 ~ & 8 & 9 ~ & ~ &",
+"num_intersections": 10,
+"zorder": 2
+}
+],
+"daughters": [
+1
+],
+"md": {
+"name": "global",
+"provenance": "rect_array.org.omn:98"
+},
+"parent_cells": [
+1
+],
+"surface_names": [
+"outer.mx",
+"outer.px",
+"outer.my",
+"outer.py",
+"arrfill.mz",
+"arrfill.pz",
+"arrfill.mx",
+"arrfill.px",
+"arrfill.my",
+"arrfill.py"
+],
+"surfaces": {
+"data": [
+-12.0,
+12.0,
+-4.0,
+10.0,
+-5.0,
+5.0,
+-6.0,
+6.0,
+-3.0,
+9.0
+],
+"sizes": [
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1
+],
+"types": [
+"px",
+"px",
+"py",
+"py",
+"pz",
+"pz",
+"px",
+"px",
+"py",
+"py"
+]
+},
+"translations": [
+0.0,
+0.0,
+0.0
+]
+},
+{
+"_type": "simple unit",
+"bbox": [
+[
+-6.0,
+-3.0,
+-5.0
+],
+[
+6.0,
+9.0,
+5.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"arr+"
+],
+"cells": [
+{
+"faces": [],
+"flags": 2,
+"logic": "* ~",
+"num_intersections": 0,
+"zorder": 65534
+},
+{
+"faces": [],
+"logic": "*",
+"num_intersections": 0,
+"zorder": 2
+}
+],
+"daughters": [
+2
+],
+"md": {
+"name": "arr",
+"provenance": "rect_array.org.omn:79"
+},
+"parent_cells": [
+1
+],
+"surface_names": [],
+"surfaces": {
+"data": [],
+"sizes": [],
+"types": []
+},
+"translations": [
+-6.0,
+-3.0,
+-5.0
+]
+},
+{
+"_type": "rectangular array",
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+12.0,
+12.0,
+10.0
+]
+],
+"cell_names": [
+"{0,0,0}",
+"{1,0,0}",
+"{2,0,0}",
+"{0,1,0}",
+"{1,1,0}",
+"{2,1,0}",
+"{0,2,0}",
+"{1,2,0}",
+"{2,2,0}",
+"{0,3,0}",
+"{1,3,0}",
+"{2,3,0}",
+"{0,0,1}",
+"{1,0,1}",
+"{2,0,1}",
+"{0,1,1}",
+"{1,1,1}",
+"{2,1,1}",
+"{0,2,1}",
+"{1,2,1}",
+"{2,2,1}",
+"{0,3,1}",
+"{1,3,1}",
+"{2,3,1}"
+],
+"daughters": [
+3,
+4,
+5,
+3,
+4,
+5,
+4,
+3,
+5,
+4,
+3,
+5,
+4,
+3,
+5,
+3,
+4,
+5,
+4,
+3,
+5,
+3,
+4,
+5
+],
+"md": {
+"description": "Embedded unplaced array",
+"name": "arr+",
+"provenance": "rect_array.org.omn:79"
+},
+"parent_cells": [
+0,
+1,
+2,
+3,
+4,
+5,
+6,
+7,
+8,
+9,
+10,
+11,
+12,
+13,
+14,
+15,
+16,
+17,
+18,
+19,
+20,
+21,
+22,
+23
+],
+"surface_names": [
+"-x",
+"+x",
+"-y",
+"+y",
+"-z",
+"+z"
+],
+"translations": [
+1.5,
+1.5,
+2.5,
+4.5,
+1.5,
+0.0,
+6.0,
+0.0,
+0.0,
+1.5,
+4.5,
+2.5,
+4.5,
+4.5,
+0.0,
+6.0,
+3.0,
+0.0,
+1.5,
+7.5,
+0.0,
+4.5,
+7.5,
+2.5,
+6.0,
+6.0,
+0.0,
+1.5,
+10.5,
+0.0,
+4.5,
+10.5,
+2.5,
+6.0,
+9.0,
+0.0,
+1.5,
+1.5,
+5.0,
+4.5,
+1.5,
+7.5,
+6.0,
+0.0,
+5.0,
+1.5,
+4.5,
+7.5,
+4.5,
+4.5,
+5.0,
+6.0,
+3.0,
+5.0,
+1.5,
+7.5,
+5.0,
+4.5,
+7.5,
+7.5,
+6.0,
+6.0,
+5.0,
+1.5,
+10.5,
+7.5,
+4.5,
+10.5,
+5.0,
+6.0,
+9.0,
+5.0
+],
+"x": [
+0.0,
+3.0,
+6.0,
+12.0
+],
+"y": [
+0.0,
+3.0,
+6.0,
+9.0,
+12.0
+],
+"z": [
+0.0,
+5.0,
+10.0
+]
+},
+{
+"_type": "simple unit",
+"bbox": [
+[
+-1.5,
+-1.5,
+-2.5
+],
+[
+1.5,
+1.5,
+2.5
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"Tfill"
+],
+"cells": [
+{
+"faces": [],
+"flags": 2,
+"logic": "* ~",
+"num_intersections": 0,
+"zorder": 65534
+},
+{
+"faces": [],
+"logic": "*",
+"num_intersections": 0,
+"zorder": 2
+}
+],
+"daughters": [],
+"md": {
+"name": "T",
+"provenance": "rect_array.org.omn:12"
+},
+"parent_cells": [],
+"surface_names": [],
+"surfaces": {
+"data": [],
+"sizes": [],
+"types": []
+},
+"translations": []
+},
+{
+"_type": "simple unit",
+"bbox": [
+[
+-1.5,
+-1.5,
+0.0
+],
+[
+1.5,
+1.5,
+5.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"Hfill"
+],
+"cells": [
+{
+"faces": [],
+"flags": 2,
+"logic": "* ~",
+"num_intersections": 0,
+"zorder": 65534
+},
+{
+"faces": [],
+"logic": "*",
+"num_intersections": 0,
+"zorder": 2
+}
+],
+"daughters": [],
+"md": {
+"name": "H",
+"provenance": "rect_array.org.omn:33"
+},
+"parent_cells": [],
+"surface_names": [],
+"surfaces": {
+"data": [],
+"sizes": [],
+"types": []
+},
+"translations": []
+},
+{
+"_type": "simple unit",
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+6.0,
+3.0,
+5.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"Cfill"
+],
+"cells": [
+{
+"faces": [],
+"flags": 2,
+"logic": "* ~",
+"num_intersections": 0,
+"zorder": 65534
+},
+{
+"faces": [],
+"logic": "*",
+"num_intersections": 0,
+"zorder": 2
+}
+],
+"daughters": [],
+"md": {
+"name": "C",
+"provenance": "rect_array.org.omn:54"
+},
+"parent_cells": [],
+"surface_names": [],
+"surfaces": {
+"data": [],
+"sizes": [],
+"types": []
+},
+"translations": []
+}
+]
+}

--- a/test/orange/data/rect_array.org.omn
+++ b/test/orange/data/rect_array.org.omn
@@ -1,14 +1,10 @@
-!##############################################################################
-! File  : Geometria/orange/test/data/array.org.omn
-!
-! Note that this is now different from the GG geometry: the array has two
-! elements along Z.
-!##############################################################################
-
+! Copyright 2021-2023 UT-Battelle, LLC, and other Celeritas developers.
+! See the top-level COPYRIGHT file for details.
+! SPDX-License-Identifier: (Apache-2.0 OR MIT)
 [GEOMETRY]
 global "global"
 
-!##############################################################################
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 [UNIVERSE=general T]
 interior "outer"
 
@@ -29,7 +25,7 @@ comp 1
 !shapes -outer +triangle
 shapes -outer
 
-!##############################################################################
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 [UNIVERSE=general H]
 interior "outer"
 
@@ -50,7 +46,7 @@ comp 1
 !shapes -outer +hexagon
 shapes -outer
 
-!##############################################################################
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 [UNIVERSE=general C]
 interior "outer"
 
@@ -73,8 +69,7 @@ comp 1
 !shapes -outer +cylinder
 shapes -outer
 
-!##############################################################################
-
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 ! (3 + 3 + 6) x (3 + 3) x (10)
 [UNIVERSE=array arr]
 nx 3
@@ -93,8 +88,7 @@ fill  T H C
       T H C
 origin -6 -3 -5
 
-!##############################################################################
-
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 [UNIVERSE=general global]
 interior "outer"
 
@@ -110,8 +104,4 @@ fill arr
 
 [UNIVERSE][CELL interior]
 comp 0
-shapes +arrfill -outer ! +arrfill2 
-
-!##############################################################################
-! end of Geometria/orange/test/data/array.org.omn
-!##############################################################################
+shapes +arrfill -outer ! +arrfill2

--- a/test/orange/data/rect_array.org.omn
+++ b/test/orange/data/rect_array.org.omn
@@ -1,0 +1,117 @@
+!##############################################################################
+! File  : Geometria/orange/test/data/array.org.omn
+!
+! Note that this is now different from the GG geometry: the array has two
+! elements along Z.
+!##############################################################################
+
+[GEOMETRY]
+global "global"
+
+!##############################################################################
+[UNIVERSE=general T]
+interior "outer"
+
+[UNIVERSE][SHAPE=cuboid outer]
+faces -1.5 1.5 -1.5 1.5 -2.5 2.5
+
+![UNIVERSE][SHAPE=prism triangle]
+!num_sides 3
+!apothem 0.6
+!extents -5 5
+!
+![UNIVERSE][CELL tri]
+!comp 2
+!shapes -triangle
+
+[UNIVERSE][CELL Tfill]
+comp 1
+!shapes -outer +triangle
+shapes -outer
+
+!##############################################################################
+[UNIVERSE=general H]
+interior "outer"
+
+[UNIVERSE][SHAPE=cuboid outer]
+faces -1.5 1.5 -1.5 1.5 0 5
+
+![UNIVERSE][SHAPE=prism hexagon]
+!num_sides 6
+!apothem 1.0
+!extents -5 5
+!
+![UNIVERSE][CELL hex]
+!comp 3
+!shapes -hexagon
+
+[UNIVERSE][CELL Hfill]
+comp 1
+!shapes -outer +hexagon
+shapes -outer
+
+!##############################################################################
+[UNIVERSE=general C]
+interior "outer"
+
+[UNIVERSE][SHAPE=cuboid outer]
+! Note that the X dimension is different, and the Y origin is translated
+faces 0 6 0 3 0 5
+
+![UNIVERSE][SHAPE=cyl cylinder]
+!radius 1.2
+!extents -5 5
+!origin 3 1.5 0
+!axis z
+!
+![UNIVERSE][CELL cyl]
+!comp 4
+!shapes -cylinder
+
+[UNIVERSE][CELL Cfill]
+comp 1
+!shapes -outer +cylinder
+shapes -outer
+
+!##############################################################################
+
+! (3 + 3 + 6) x (3 + 3) x (10)
+[UNIVERSE=array arr]
+nx 3
+ny 4
+nz 2
+! Each level is laid out on screen like it is in xy
+! "top" level on screen is highest Z level
+fill  T H C
+      H T C
+      T H C
+      H T C
+! Lower axial level
+      H T C
+      H T C
+      T H C
+      T H C
+origin -6 -3 -5
+
+!##############################################################################
+
+[UNIVERSE=general global]
+interior "outer"
+
+[UNIVERSE][SHAPE=cuboid outer]
+faces -12 12 -4 10 -5 5
+
+[UNIVERSE][HOLE arrfill]
+fill arr
+
+! [UNIVERSE][HOLE arrfill2]
+! fill arr
+! translate 5 6 0
+
+[UNIVERSE][CELL interior]
+comp 0
+shapes +arrfill -outer ! +arrfill2 
+
+!##############################################################################
+! end of Geometria/orange/test/data/array.org.omn
+!##############################################################################

--- a/test/orange/surf/SurfaceAction.test.cc
+++ b/test/orange/surf/SurfaceAction.test.cc
@@ -159,7 +159,8 @@ TEST_F(SurfaceActionTest, string)
 {
     // Create functor
     auto const& host_ref = this->host_params();
-    Surfaces surfaces(host_ref, host_ref.simple_unit[SimpleUnitId{0}].surfaces);
+    Surfaces surfaces(host_ref,
+                      host_ref.simple_units[SimpleUnitId{0}].surfaces);
     auto surf_to_string = make_surface_action(surfaces, ToString{});
 
     // Loop over all surfaces and apply

--- a/test/orange/surf/SurfaceAction.test.hh
+++ b/test/orange/surf/SurfaceAction.test.hh
@@ -118,9 +118,9 @@ struct CalcSenseDistanceLauncher
 
     CELER_FUNCTION void operator()(TrackSlotId tid) const
     {
-        CELER_EXPECT(this->params.simple_unit.size() == 1);
+        CELER_EXPECT(this->params.simple_units.size() == 1);
         Surfaces surfaces(this->params,
-                          this->params.simple_unit[SimpleUnitId{0}].surfaces);
+                          this->params.simple_units[SimpleUnitId{0}].surfaces);
 
         auto calc_sense_dist = make_surface_action(
             surfaces,

--- a/test/orange/univ/VolumeView.test.cc
+++ b/test/orange/univ/VolumeView.test.cc
@@ -28,7 +28,7 @@ class VolumeViewTest : public OrangeGeoTestBase
     {
         CELER_EXPECT(v);
         auto const& host_ref = this->host_params();
-        return VolumeView{host_ref, host_ref.simple_unit[SimpleUnitId{0}], v};
+        return VolumeView{host_ref, host_ref.simple_units[SimpleUnitId{0}], v};
     }
 
     void test_face_accessors(VolumeView const& volumes)

--- a/test/orange/univ/detail/SenseCalculator.test.cc
+++ b/test/orange/univ/detail/SenseCalculator.test.cc
@@ -54,14 +54,14 @@ class SenseCalculatorTest : public ::celeritas::test::OrangeGeoTestBase
     {
         CELER_EXPECT(v);
         auto const& host_ref = this->host_params();
-        return VolumeView{host_ref, host_ref.simple_unit[SimpleUnitId{0}], v};
+        return VolumeView{host_ref, host_ref.simple_units[SimpleUnitId{0}], v};
     }
 
     Surfaces make_surfaces() const
     {
         auto const& host_ref = this->host_params();
         return Surfaces(host_ref,
-                        host_ref.simple_unit[SimpleUnitId{0}].surfaces);
+                        host_ref.simple_units[SimpleUnitId{0}].surfaces);
     }
 
     //! Access the shared CPU storage space for senses

--- a/test/orange/univ/detail/SurfaceFunctors.test.cc
+++ b/test/orange/univ/detail/SurfaceFunctors.test.cc
@@ -58,7 +58,7 @@ class SurfaceFunctorsTest : public ::celeritas::test::OrangeGeoTestBase
         auto const& host_ref = this->host_params();
 
         surfaces_ = std::make_unique<Surfaces>(
-            host_ref, host_ref.simple_unit[SimpleUnitId{0}].surfaces);
+            host_ref, host_ref.simple_units[SimpleUnitId{0}].surfaces);
     }
 
     template<class T>


### PR DESCRIPTION
This PR is the first step towards supporting rectilinear array universes within ORANGE. `RectArrayInput` objects are constructed from JSON and `RectArrayInserter` is used to convert these objects to `RectArrayRecord` objects. In addition, basic grid functionality is moved from `celeritas/grid` to `corecel/grid`.