### PR TITLE
Use independent params and state arguments for actions

### DIFF
--- a/app/demo-loop/Transporter.cc
+++ b/app/demo-loop/Transporter.cc
@@ -69,15 +69,16 @@ class DiagnosticActionAdapter final : public ExplicitActionInterface
     }
 
     //! Execute the action with host data
-    void execute(CoreHostRef const& core) const final
+    void execute(ParamsHostCRef const& params, StateHostRef& states) const final
     {
-        this->execute_impl(core.params, core.states, diagnostics_->host);
+        this->execute_impl(params, states, diagnostics_->host);
     }
 
     //! Execute the action with device data
-    void execute(CoreDeviceRef const& core) const final
+    void
+    execute(ParamsDeviceCRef const& params, StateDeviceRef& states) const final
     {
-        this->execute_impl(core.params, core.states, diagnostics_->device);
+        this->execute_impl(params, states, diagnostics_->device);
     }
 
     //!@{

--- a/app/demo-loop/diagnostic/EnergyDiagnostic.cc
+++ b/app/demo-loop/diagnostic/EnergyDiagnostic.cc
@@ -16,8 +16,8 @@ namespace demo_loop
 //---------------------------------------------------------------------------//
 // KERNEL INTERFACE
 //---------------------------------------------------------------------------//
-void bin_energy(CoreParamsHostRef const& params,
-                CoreStateHostRef const& states,
+void bin_energy(HostCRef<CoreParamsData> const& params,
+                HostRef<CoreStateData> const& states,
                 PointersHost& pointers)
 {
     EnergyDiagnosticLauncher<MemSpace::host> launch(params, states, pointers);

--- a/app/demo-loop/diagnostic/EnergyDiagnostic.cu
+++ b/app/demo-loop/diagnostic/EnergyDiagnostic.cu
@@ -21,8 +21,8 @@ namespace demo_loop
 /*!
  * Get energy deposition from state data and accumulate in appropriate bin
  */
-__global__ void bin_energy_kernel(CoreParamsDeviceRef const params,
-                                  CoreStateDeviceRef const states,
+__global__ void bin_energy_kernel(DeviceCRef<CoreParamsData> const params,
+                                  DeviceRef<CoreStateData> const states,
                                   PointersDevice pointers)
 {
     auto tid = KernelParamCalculator::thread_id();
@@ -36,8 +36,8 @@ __global__ void bin_energy_kernel(CoreParamsDeviceRef const params,
 //---------------------------------------------------------------------------//
 // KERNEL INTERFACE
 //---------------------------------------------------------------------------//
-void bin_energy(CoreParamsDeviceRef const& params,
-                CoreStateDeviceRef const& states,
+void bin_energy(DeviceCRef<CoreParamsData> const& params,
+                DeviceRef<CoreStateData> const& states,
                 PointersDevice& pointers)
 {
     CELER_LAUNCH_KERNEL(bin_energy,

--- a/app/demo-loop/diagnostic/EnergyDiagnostic.hh
+++ b/app/demo-loop/diagnostic/EnergyDiagnostic.hh
@@ -127,11 +127,11 @@ class EnergyDiagnosticLauncher
 using PointersDevice = EnergyBinPointers<MemSpace::device>;
 using PointersHost = EnergyBinPointers<MemSpace::host>;
 
-void bin_energy(celeritas::CoreParamsDeviceRef const& params,
-                celeritas::CoreStateDeviceRef const& states,
+void bin_energy(celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+                celeritas::DeviceRef<celeritas::CoreStateData> const& states,
                 PointersDevice& pointers);
-void bin_energy(celeritas::CoreParamsHostRef const& params,
-                celeritas::CoreStateHostRef const& states,
+void bin_energy(celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+                celeritas::HostRef<celeritas::CoreStateData> const& states,
                 PointersHost& pointers);
 
 //---------------------------------------------------------------------------//
@@ -277,8 +277,8 @@ EnergyDiagnosticLauncher<M>::operator()(TrackSlotId tid) const
 }
 
 #if !CELER_USE_DEVICE
-inline void bin_energy(celeritas::CoreParamsDeviceRef const&,
-                       celeritas::CoreStateDeviceRef const&,
+inline void bin_energy(celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+                       celeritas::DeviceRef<celeritas::CoreStateData> const&,
                        PointersDevice&)
 {
     CELER_NOT_CONFIGURED("CUDA/HIP");

--- a/app/demo-loop/diagnostic/ParticleProcessDiagnostic.cc
+++ b/app/demo-loop/diagnostic/ParticleProcessDiagnostic.cc
@@ -16,8 +16,8 @@ namespace demo_loop
  * Tally the particle/process combinations that occur at each step.
  */
 void count_particle_process(
-    CoreParamsHostRef const& params,
-    CoreStateHostRef const& states,
+    HostCRef<CoreParamsData> const& params,
+    HostRef<CoreStateData> const& states,
     ParticleProcessLauncher<MemSpace::host>::ItemsRef counts)
 {
     ParticleProcessLauncher<MemSpace::host> launch(params, states, counts);

--- a/app/demo-loop/diagnostic/ParticleProcessDiagnostic.cu
+++ b/app/demo-loop/diagnostic/ParticleProcessDiagnostic.cu
@@ -20,8 +20,8 @@ namespace demo_loop
  * Tally the particle/process combinations that occur at each step.
  */
 __global__ void count_particle_process_kernel(
-    CoreParamsDeviceRef const params,
-    CoreStateDeviceRef const states,
+    DeviceCRef<CoreParamsData> const params,
+    DeviceRef<CoreStateData> const states,
     ParticleProcessLauncher<MemSpace::device>::ItemsRef counts)
 {
     auto tid = KernelParamCalculator::thread_id();
@@ -39,8 +39,8 @@ __global__ void count_particle_process_kernel(
  * Launch kernel to tally the particle/process combinations.
  */
 void count_particle_process(
-    CoreParamsDeviceRef const& params,
-    CoreStateDeviceRef const& states,
+    DeviceCRef<CoreParamsData> const& params,
+    DeviceRef<CoreStateData> const& states,
     ParticleProcessLauncher<MemSpace::device>::ItemsRef counts)
 {
     CELER_LAUNCH_KERNEL(count_particle_process,

--- a/app/demo-loop/diagnostic/ParticleProcessDiagnostic.hh
+++ b/app/demo-loop/diagnostic/ParticleProcessDiagnostic.hh
@@ -114,19 +114,19 @@ class ParticleProcessLauncher
 };
 
 void count_particle_process(
-    celeritas::CoreParamsHostRef const& params,
-    celeritas::CoreStateHostRef const& states,
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& states,
     ParticleProcessLauncher<MemSpace::host>::ItemsRef counts);
 
 void count_particle_process(
-    celeritas::CoreParamsDeviceRef const& params,
-    celeritas::CoreStateDeviceRef const& states,
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::DeviceRef<celeritas::CoreStateData> const& states,
     ParticleProcessLauncher<MemSpace::device>::ItemsRef counts);
 
 #if !CELER_USE_DEVICE
 inline void
-count_particle_process(celeritas::CoreParamsDeviceRef const&,
-                       celeritas::CoreStateDeviceRef const&,
+count_particle_process(celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+                       celeritas::DeviceRef<celeritas::CoreStateData> const&,
                        ParticleProcessLauncher<MemSpace::device>::ItemsRef)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/app/demo-loop/diagnostic/StepDiagnostic.cc
+++ b/app/demo-loop/diagnostic/StepDiagnostic.cc
@@ -15,8 +15,8 @@ namespace demo_loop
 /*!
  * Count the steps per track for each particle type.
  */
-void count_steps(CoreParamsHostRef const& params,
-                 CoreStateHostRef const& states,
+void count_steps(HostCRef<CoreParamsData> const& params,
+                 HostRef<CoreStateData> const& states,
                  StepDiagnosticDataRef<MemSpace::host> data)
 {
     StepLauncher<MemSpace::host> launch(params, states, data);

--- a/app/demo-loop/diagnostic/StepDiagnostic.cu
+++ b/app/demo-loop/diagnostic/StepDiagnostic.cu
@@ -19,7 +19,7 @@ namespace demo_loop
 /*!
  * Count the steps per track for each particle type.
  */
-__global__ void count_steps_kernel(DeviceRef<CoreParamsData> const params,
+__global__ void count_steps_kernel(DeviceCRef<CoreParamsData> const params,
                                    DeviceRef<CoreStateData> const states,
                                    StepDiagnosticDataRef<MemSpace::device> data)
 {
@@ -37,7 +37,7 @@ __global__ void count_steps_kernel(DeviceRef<CoreParamsData> const params,
 /*!
  * Launch kernel to tally the steps per track.
  */
-void count_steps(DeviceRef<CoreParamsData> const& params,
+void count_steps(DeviceCRef<CoreParamsData> const& params,
                  DeviceRef<CoreStateData> const& states,
                  StepDiagnosticDataRef<MemSpace::device> data)
 {

--- a/app/demo-loop/diagnostic/StepDiagnostic.cu
+++ b/app/demo-loop/diagnostic/StepDiagnostic.cu
@@ -19,8 +19,8 @@ namespace demo_loop
 /*!
  * Count the steps per track for each particle type.
  */
-__global__ void count_steps_kernel(CoreParamsDeviceRef const params,
-                                   CoreStateDeviceRef const states,
+__global__ void count_steps_kernel(DeviceRef<CoreParamsData> const params,
+                                   DeviceRef<CoreStateData> const states,
                                    StepDiagnosticDataRef<MemSpace::device> data)
 {
     auto tid = KernelParamCalculator::thread_id();
@@ -37,8 +37,8 @@ __global__ void count_steps_kernel(CoreParamsDeviceRef const params,
 /*!
  * Launch kernel to tally the steps per track.
  */
-void count_steps(CoreParamsDeviceRef const& params,
-                 CoreStateDeviceRef const& states,
+void count_steps(DeviceRef<CoreParamsData> const& params,
+                 DeviceRef<CoreStateData> const& states,
                  StepDiagnosticDataRef<MemSpace::device> data)
 {
     CELER_LAUNCH_KERNEL(count_steps,

--- a/app/demo-loop/diagnostic/StepDiagnostic.hh
+++ b/app/demo-loop/diagnostic/StepDiagnostic.hh
@@ -149,17 +149,17 @@ class StepLauncher
     StepDiagnosticDataRef<M> data_;
 };
 
-void count_steps(celeritas::CoreParamsHostRef const& params,
-                 celeritas::CoreStateHostRef const& states,
+void count_steps(celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+                 celeritas::HostRef<celeritas::CoreStateData> const& states,
                  StepDiagnosticDataRef<MemSpace::host> data);
 
-void count_steps(celeritas::CoreParamsDeviceRef const& params,
-                 celeritas::CoreStateDeviceRef const& states,
+void count_steps(celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+                 celeritas::DeviceRef<celeritas::CoreStateData> const& states,
                  StepDiagnosticDataRef<MemSpace::device> data);
 
 #if !CELER_USE_DEVICE
-inline void count_steps(celeritas::CoreParamsDeviceRef const&,
-                        celeritas::CoreStateDeviceRef const&,
+inline void count_steps(celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+                        celeritas::DeviceRef<celeritas::CoreStateData> const&,
                         StepDiagnosticDataRef<MemSpace::device>)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/cmake/CeleritasGen/gen-action.py
+++ b/cmake/CeleritasGen/gen-action.py
@@ -42,17 +42,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(CoreHostRef const&) const final;
+  void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
   // Launch kernel with device data
-  void execute(CoreDeviceRef const&) const final;
+  void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final {{ return ActionOrder::{actionorder}; }}
 }};
 
 #if !CELER_USE_DEVICE
-inline void {clsname}::execute(CoreDeviceRef const&) const
+inline void {clsname}::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
 {{
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }}
@@ -80,22 +80,19 @@ namespace celeritas
 {{
 namespace generated
 {{
-void {clsname}::execute(CoreHostRef const& data) const
+void {clsname}::execute(ParamsHostCRef const& params, StateHostRef& state) const
 {{
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
 
     MultiExceptionHandler capture_exception;
-    auto launch = make_track_launcher(
-        data.params,
-        const_cast<HostRef<CoreStateData>&>(data.states),
-        detail::{func}_track);
+    auto launch = make_track_launcher(params, state, detail::{func}_track);
     #pragma omp parallel for
-    for (size_type i = 0; i < data.states.size(); ++i)
+    for (size_type i = 0; i < state.size(); ++i)
     {{
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{{i}}),
             capture_exception,
-            KernelContextException(data.params, data.states, ThreadId{{i}}, this->label()));
+            KernelContextException(params, state, ThreadId{{i}}, this->label()));
     }}
     log_and_rethrow(std::move(capture_exception));
 }}
@@ -127,7 +124,7 @@ __global__ void{launch_bounds}{func}_kernel(
 )
 {{
     auto tid = KernelParamCalculator::thread_id();
-    if (!(tid < data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = make_track_launcher(params, state, detail::{func}_track);
@@ -135,14 +132,14 @@ __global__ void{launch_bounds}{func}_kernel(
 }}
 }}  // namespace
 
-void {clsname}::execute(CoreDeviceRef const& data) const
+void {clsname}::execute(ParamsDeviceCRef const& params, StateDeviceRef& state) const
 {{
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
     CELER_LAUNCH_KERNEL({func},
                         celeritas::device().default_block_size(),
-                        data.states.size(),
-                        data.params,
-                        data.states);
+                        state.size(),
+                        params,
+                        state);
 }}
 
 }}  // namespace generated

--- a/cmake/CeleritasGen/gen-action.py
+++ b/cmake/CeleritasGen/gen-action.py
@@ -95,7 +95,7 @@ void {clsname}::execute(CoreHostRef const& data) const
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{{i}}),
             capture_exception,
-            KernelContextException(data, ThreadId{{i}}, this->label()));
+            KernelContextException(data.params, data.states, ThreadId{{i}}, this->label()));
     }}
     log_and_rethrow(std::move(capture_exception));
 }}

--- a/cmake/CeleritasGen/gen-interactor.py
+++ b/cmake/CeleritasGen/gen-interactor.py
@@ -42,18 +42,18 @@ namespace generated
 void {func}_interact(
     {namespace}::{class}HostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void {func}_interact(
     {namespace}::{class}DeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void {func}_interact(
     {namespace}::{class}DeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {{
     CELER_ASSERT_UNREACHABLE();
 }}
@@ -85,7 +85,7 @@ namespace generated
 void {func}_interact(
     {namespace}::{class}HostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {{
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/cmake/CeleritasGen/gen-interactor.py
+++ b/cmake/CeleritasGen/gen-interactor.py
@@ -97,7 +97,7 @@ void {func}_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{{i}}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{{i}}, "{func}"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{{i}}, "{func}"));
     }}
     log_and_rethrow(std::move(capture_exception));
 }}

--- a/cmake/CeleritasGen/gen-trackinit.py
+++ b/cmake/CeleritasGen/gen-trackinit.py
@@ -74,7 +74,7 @@ namespace generated
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{{i}}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{{i}}, "{funcname}"));
+            KernelContextException(core_params, core_states, ThreadId{{i}}, "{funcname}"));
     }}
     log_and_rethrow(std::move(capture_exception));
 }}
@@ -196,29 +196,33 @@ LANG = {
 DEFS = {
     "InitTracks": KernelDefinition(
         Function("init_tracks", ParamList([
-            Param("Core{Memspace}Ref", "core_data"),
+            Param("{Memspace}CRef<CoreParamsData>", "core_params"),
+            Param("{Memspace}Ref<CoreStateData>", "core_states"),
             Param("size_type", "num_vacancies"),
         ])),
         "num_vacancies",
         []),
     "LocateAlive": KernelDefinition(
         Function("locate_alive", ParamList([
-            Param("Core{Memspace}Ref", "core_data"),
+            Param("{Memspace}CRef<CoreParamsData>", "core_params"),
+            Param("{Memspace}Ref<CoreStateData>", "core_states"),
         ])),
-        "core_data.states.size()",
+        "core_states.size()",
         []),
     "ProcessPrimaries": KernelDefinition(
         Function("process_primaries", ParamList([
-            Param("Core{Memspace}Ref", "core_data"),
+            Param("{Memspace}CRef<CoreParamsData>", "core_params"),
+            Param("{Memspace}Ref<CoreStateData>", "core_states"),
             Param("Span<const Primary>", "primaries"),
         ])),
         "primaries.size()",
         ["corecel/cont/Span.hh", "celeritas/phys/Primary.hh"]),
     "ProcessSecondaries": KernelDefinition(
         Function("process_secondaries", ParamList([
-            Param("Core{Memspace}Ref", "core_data"),
+            Param("{Memspace}CRef<CoreParamsData>", "core_params"),
+            Param("{Memspace}Ref<CoreStateData>", "core_states"),
         ])),
-        "core_data.states.size()",
+        "core_states.size()",
         []),
 }
 

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cc
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cc
@@ -27,7 +27,7 @@ namespace generated
 void bethe_heitler_interact(
     celeritas::BetheHeitlerHostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cc
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cc
@@ -42,7 +42,7 @@ void bethe_heitler_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "bethe_heitler"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "bethe_heitler"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cc
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cc
@@ -26,23 +26,23 @@ namespace generated
 {
 void bethe_heitler_interact(
     celeritas::BetheHeitlerHostRef const& model_data,
-    celeritas::CoreRef<MemSpace::host> const& core_data)
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::bethe_heitler_interact_track);
     #pragma omp parallel for
-    for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
+    for (celeritas::size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "bethe_heitler"));
+            KernelContextException(params, state, ThreadId{i}, "bethe_heitler"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cu
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cu
@@ -16,8 +16,6 @@
 #include "celeritas/em/launcher/BetheHeitlerLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
-using celeritas::MemSpace;
-
 namespace celeritas
 {
 namespace generated
@@ -35,15 +33,15 @@ __launch_bounds__(1024, 8)
 #endif // CELERITAS_LAUNCH_BOUNDS
 bethe_heitler_interact_kernel(
     celeritas::BetheHeitlerDeviceRef const model_data,
-    celeritas::CoreRef<MemSpace::device> const core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
+    celeritas::DeviceRef<celeritas::CoreStateData> const state)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < core_data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::bethe_heitler_interact_track);
     launch(tid);
 }
@@ -51,15 +49,16 @@ bethe_heitler_interact_kernel(
 
 void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const& model_data,
-    celeritas::CoreRef<MemSpace::device> const& core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(bethe_heitler_interact,
                         celeritas::device().default_block_size(),
-                        core_data.states.size(),
-                        model_data, core_data);
+                        state.size(),
+                        model_data, params, state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/BetheHeitlerInteract.hh
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.hh
@@ -12,7 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/BetheHeitlerData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 namespace celeritas
 {
@@ -20,16 +20,19 @@ namespace generated
 {
 void bethe_heitler_interact(
     celeritas::BetheHeitlerHostRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::host> const&);
+    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::HostRef<celeritas::CoreStateData> const&);
 
 void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&);
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&);
 
 #if !CELER_USE_DEVICE
 inline void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/BetheHeitlerInteract.hh
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.hh
@@ -21,18 +21,18 @@ namespace generated
 void bethe_heitler_interact(
     celeritas::BetheHeitlerHostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/CombinedBremInteract.cc
+++ b/src/celeritas/em/generated/CombinedBremInteract.cc
@@ -26,23 +26,23 @@ namespace generated
 {
 void combined_brem_interact(
     celeritas::CombinedBremHostRef const& model_data,
-    celeritas::CoreRef<MemSpace::host> const& core_data)
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::combined_brem_interact_track);
     #pragma omp parallel for
-    for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
+    for (celeritas::size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "combined_brem"));
+            KernelContextException(params, state, ThreadId{i}, "combined_brem"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/CombinedBremInteract.cc
+++ b/src/celeritas/em/generated/CombinedBremInteract.cc
@@ -27,7 +27,7 @@ namespace generated
 void combined_brem_interact(
     celeritas::CombinedBremHostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/src/celeritas/em/generated/CombinedBremInteract.cc
+++ b/src/celeritas/em/generated/CombinedBremInteract.cc
@@ -42,7 +42,7 @@ void combined_brem_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "combined_brem"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "combined_brem"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/CombinedBremInteract.cu
+++ b/src/celeritas/em/generated/CombinedBremInteract.cu
@@ -16,8 +16,6 @@
 #include "celeritas/em/launcher/CombinedBremLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
-using celeritas::MemSpace;
-
 namespace celeritas
 {
 namespace generated
@@ -35,15 +33,15 @@ __launch_bounds__(1024, 5)
 #endif // CELERITAS_LAUNCH_BOUNDS
 combined_brem_interact_kernel(
     celeritas::CombinedBremDeviceRef const model_data,
-    celeritas::CoreRef<MemSpace::device> const core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
+    celeritas::DeviceRef<celeritas::CoreStateData> const state)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < core_data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::combined_brem_interact_track);
     launch(tid);
 }
@@ -51,15 +49,16 @@ combined_brem_interact_kernel(
 
 void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const& model_data,
-    celeritas::CoreRef<MemSpace::device> const& core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(combined_brem_interact,
                         celeritas::device().default_block_size(),
-                        core_data.states.size(),
-                        model_data, core_data);
+                        state.size(),
+                        model_data, params, state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/CombinedBremInteract.hh
+++ b/src/celeritas/em/generated/CombinedBremInteract.hh
@@ -12,7 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/CombinedBremData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 namespace celeritas
 {
@@ -20,16 +20,19 @@ namespace generated
 {
 void combined_brem_interact(
     celeritas::CombinedBremHostRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::host> const&);
+    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::HostRef<celeritas::CoreStateData> const&);
 
 void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&);
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&);
 
 #if !CELER_USE_DEVICE
 inline void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/CombinedBremInteract.hh
+++ b/src/celeritas/em/generated/CombinedBremInteract.hh
@@ -21,18 +21,18 @@ namespace generated
 void combined_brem_interact(
     celeritas::CombinedBremHostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/EPlusGGInteract.cc
+++ b/src/celeritas/em/generated/EPlusGGInteract.cc
@@ -26,23 +26,23 @@ namespace generated
 {
 void eplusgg_interact(
     celeritas::EPlusGGHostRef const& model_data,
-    celeritas::CoreRef<MemSpace::host> const& core_data)
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::eplusgg_interact_track);
     #pragma omp parallel for
-    for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
+    for (celeritas::size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "eplusgg"));
+            KernelContextException(params, state, ThreadId{i}, "eplusgg"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/EPlusGGInteract.cc
+++ b/src/celeritas/em/generated/EPlusGGInteract.cc
@@ -42,7 +42,7 @@ void eplusgg_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "eplusgg"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "eplusgg"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/EPlusGGInteract.cc
+++ b/src/celeritas/em/generated/EPlusGGInteract.cc
@@ -27,7 +27,7 @@ namespace generated
 void eplusgg_interact(
     celeritas::EPlusGGHostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/src/celeritas/em/generated/EPlusGGInteract.cu
+++ b/src/celeritas/em/generated/EPlusGGInteract.cu
@@ -16,8 +16,6 @@
 #include "celeritas/em/launcher/EPlusGGLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
-using celeritas::MemSpace;
-
 namespace celeritas
 {
 namespace generated
@@ -35,15 +33,15 @@ __launch_bounds__(1024, 8)
 #endif // CELERITAS_LAUNCH_BOUNDS
 eplusgg_interact_kernel(
     celeritas::EPlusGGDeviceRef const model_data,
-    celeritas::CoreRef<MemSpace::device> const core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
+    celeritas::DeviceRef<celeritas::CoreStateData> const state)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < core_data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::eplusgg_interact_track);
     launch(tid);
 }
@@ -51,15 +49,16 @@ eplusgg_interact_kernel(
 
 void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const& model_data,
-    celeritas::CoreRef<MemSpace::device> const& core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(eplusgg_interact,
                         celeritas::device().default_block_size(),
-                        core_data.states.size(),
-                        model_data, core_data);
+                        state.size(),
+                        model_data, params, state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/EPlusGGInteract.hh
+++ b/src/celeritas/em/generated/EPlusGGInteract.hh
@@ -21,18 +21,18 @@ namespace generated
 void eplusgg_interact(
     celeritas::EPlusGGHostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/EPlusGGInteract.hh
+++ b/src/celeritas/em/generated/EPlusGGInteract.hh
@@ -12,7 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/EPlusGGData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 namespace celeritas
 {
@@ -20,16 +20,19 @@ namespace generated
 {
 void eplusgg_interact(
     celeritas::EPlusGGHostRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::host> const&);
+    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::HostRef<celeritas::CoreStateData> const&);
 
 void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&);
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&);
 
 #if !CELER_USE_DEVICE
 inline void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/KleinNishinaInteract.cc
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cc
@@ -27,7 +27,7 @@ namespace generated
 void klein_nishina_interact(
     celeritas::KleinNishinaHostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/src/celeritas/em/generated/KleinNishinaInteract.cc
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cc
@@ -26,23 +26,23 @@ namespace generated
 {
 void klein_nishina_interact(
     celeritas::KleinNishinaHostRef const& model_data,
-    celeritas::CoreRef<MemSpace::host> const& core_data)
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::klein_nishina_interact_track);
     #pragma omp parallel for
-    for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
+    for (celeritas::size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "klein_nishina"));
+            KernelContextException(params, state, ThreadId{i}, "klein_nishina"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/KleinNishinaInteract.cc
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cc
@@ -42,7 +42,7 @@ void klein_nishina_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "klein_nishina"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "klein_nishina"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/KleinNishinaInteract.cu
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cu
@@ -16,8 +16,6 @@
 #include "celeritas/em/launcher/KleinNishinaLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
-using celeritas::MemSpace;
-
 namespace celeritas
 {
 namespace generated
@@ -35,15 +33,15 @@ __launch_bounds__(1024, 8)
 #endif // CELERITAS_LAUNCH_BOUNDS
 klein_nishina_interact_kernel(
     celeritas::KleinNishinaDeviceRef const model_data,
-    celeritas::CoreRef<MemSpace::device> const core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
+    celeritas::DeviceRef<celeritas::CoreStateData> const state)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < core_data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::klein_nishina_interact_track);
     launch(tid);
 }
@@ -51,15 +49,16 @@ klein_nishina_interact_kernel(
 
 void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const& model_data,
-    celeritas::CoreRef<MemSpace::device> const& core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(klein_nishina_interact,
                         celeritas::device().default_block_size(),
-                        core_data.states.size(),
-                        model_data, core_data);
+                        state.size(),
+                        model_data, params, state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/KleinNishinaInteract.hh
+++ b/src/celeritas/em/generated/KleinNishinaInteract.hh
@@ -21,18 +21,18 @@ namespace generated
 void klein_nishina_interact(
     celeritas::KleinNishinaHostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/KleinNishinaInteract.hh
+++ b/src/celeritas/em/generated/KleinNishinaInteract.hh
@@ -12,7 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/KleinNishinaData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 namespace celeritas
 {
@@ -20,16 +20,19 @@ namespace generated
 {
 void klein_nishina_interact(
     celeritas::KleinNishinaHostRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::host> const&);
+    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::HostRef<celeritas::CoreStateData> const&);
 
 void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&);
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&);
 
 #if !CELER_USE_DEVICE
 inline void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/LivermorePEInteract.cc
+++ b/src/celeritas/em/generated/LivermorePEInteract.cc
@@ -26,23 +26,23 @@ namespace generated
 {
 void livermore_pe_interact(
     celeritas::LivermorePEHostRef const& model_data,
-    celeritas::CoreRef<MemSpace::host> const& core_data)
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::livermore_pe_interact_track);
     #pragma omp parallel for
-    for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
+    for (celeritas::size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "livermore_pe"));
+            KernelContextException(params, state, ThreadId{i}, "livermore_pe"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/LivermorePEInteract.cc
+++ b/src/celeritas/em/generated/LivermorePEInteract.cc
@@ -27,7 +27,7 @@ namespace generated
 void livermore_pe_interact(
     celeritas::LivermorePEHostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/src/celeritas/em/generated/LivermorePEInteract.cc
+++ b/src/celeritas/em/generated/LivermorePEInteract.cc
@@ -42,7 +42,7 @@ void livermore_pe_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "livermore_pe"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "livermore_pe"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/LivermorePEInteract.cu
+++ b/src/celeritas/em/generated/LivermorePEInteract.cu
@@ -16,8 +16,6 @@
 #include "celeritas/em/launcher/LivermorePELauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
-using celeritas::MemSpace;
-
 namespace celeritas
 {
 namespace generated
@@ -35,15 +33,15 @@ __launch_bounds__(1024, 7)
 #endif // CELERITAS_LAUNCH_BOUNDS
 livermore_pe_interact_kernel(
     celeritas::LivermorePEDeviceRef const model_data,
-    celeritas::CoreRef<MemSpace::device> const core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
+    celeritas::DeviceRef<celeritas::CoreStateData> const state)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < core_data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::livermore_pe_interact_track);
     launch(tid);
 }
@@ -51,15 +49,16 @@ livermore_pe_interact_kernel(
 
 void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const& model_data,
-    celeritas::CoreRef<MemSpace::device> const& core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(livermore_pe_interact,
                         celeritas::device().default_block_size(),
-                        core_data.states.size(),
-                        model_data, core_data);
+                        state.size(),
+                        model_data, params, state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/LivermorePEInteract.hh
+++ b/src/celeritas/em/generated/LivermorePEInteract.hh
@@ -12,7 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/LivermorePEData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 namespace celeritas
 {
@@ -20,16 +20,19 @@ namespace generated
 {
 void livermore_pe_interact(
     celeritas::LivermorePEHostRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::host> const&);
+    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::HostRef<celeritas::CoreStateData> const&);
 
 void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&);
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&);
 
 #if !CELER_USE_DEVICE
 inline void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/LivermorePEInteract.hh
+++ b/src/celeritas/em/generated/LivermorePEInteract.hh
@@ -21,18 +21,18 @@ namespace generated
 void livermore_pe_interact(
     celeritas::LivermorePEHostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cc
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cc
@@ -27,7 +27,7 @@ namespace generated
 void moller_bhabha_interact(
     celeritas::MollerBhabhaHostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cc
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cc
@@ -42,7 +42,7 @@ void moller_bhabha_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "moller_bhabha"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "moller_bhabha"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cc
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cc
@@ -26,23 +26,23 @@ namespace generated
 {
 void moller_bhabha_interact(
     celeritas::MollerBhabhaHostRef const& model_data,
-    celeritas::CoreRef<MemSpace::host> const& core_data)
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::moller_bhabha_interact_track);
     #pragma omp parallel for
-    for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
+    for (celeritas::size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "moller_bhabha"));
+            KernelContextException(params, state, ThreadId{i}, "moller_bhabha"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/MollerBhabhaInteract.hh
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.hh
@@ -21,18 +21,18 @@ namespace generated
 void moller_bhabha_interact(
     celeritas::MollerBhabhaHostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void moller_bhabha_interact(
     celeritas::MollerBhabhaDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void moller_bhabha_interact(
     celeritas::MollerBhabhaDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/MollerBhabhaInteract.hh
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.hh
@@ -12,7 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/MollerBhabhaData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 namespace celeritas
 {
@@ -20,16 +20,19 @@ namespace generated
 {
 void moller_bhabha_interact(
     celeritas::MollerBhabhaHostRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::host> const&);
+    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::HostRef<celeritas::CoreStateData> const&);
 
 void moller_bhabha_interact(
     celeritas::MollerBhabhaDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&);
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&);
 
 #if !CELER_USE_DEVICE
 inline void moller_bhabha_interact(
     celeritas::MollerBhabhaDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
@@ -27,7 +27,7 @@ namespace generated
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungHostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
@@ -42,7 +42,7 @@ void mu_bremsstrahlung_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "mu_bremsstrahlung"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "mu_bremsstrahlung"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
@@ -26,23 +26,23 @@ namespace generated
 {
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungHostRef const& model_data,
-    celeritas::CoreRef<MemSpace::host> const& core_data)
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::mu_bremsstrahlung_interact_track);
     #pragma omp parallel for
-    for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
+    for (celeritas::size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "mu_bremsstrahlung"));
+            KernelContextException(params, state, ThreadId{i}, "mu_bremsstrahlung"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cu
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cu
@@ -16,8 +16,6 @@
 #include "celeritas/em/launcher/MuBremsstrahlungLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
-using celeritas::MemSpace;
-
 namespace celeritas
 {
 namespace generated
@@ -26,15 +24,15 @@ namespace
 {
 __global__ void mu_bremsstrahlung_interact_kernel(
     celeritas::MuBremsstrahlungDeviceRef const model_data,
-    celeritas::CoreRef<MemSpace::device> const core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
+    celeritas::DeviceRef<celeritas::CoreStateData> const state)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < core_data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::mu_bremsstrahlung_interact_track);
     launch(tid);
 }
@@ -42,15 +40,16 @@ __global__ void mu_bremsstrahlung_interact_kernel(
 
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const& model_data,
-    celeritas::CoreRef<MemSpace::device> const& core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(mu_bremsstrahlung_interact,
                         celeritas::device().default_block_size(),
-                        core_data.states.size(),
-                        model_data, core_data);
+                        state.size(),
+                        model_data, params, state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.hh
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.hh
@@ -21,18 +21,18 @@ namespace generated
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungHostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.hh
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.hh
@@ -12,7 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/MuBremsstrahlungData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 namespace celeritas
 {
@@ -20,16 +20,19 @@ namespace generated
 {
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungHostRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::host> const&);
+    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::HostRef<celeritas::CoreStateData> const&);
 
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&);
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&);
 
 #if !CELER_USE_DEVICE
 inline void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/RayleighInteract.cc
+++ b/src/celeritas/em/generated/RayleighInteract.cc
@@ -27,7 +27,7 @@ namespace generated
 void rayleigh_interact(
     celeritas::RayleighHostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/src/celeritas/em/generated/RayleighInteract.cc
+++ b/src/celeritas/em/generated/RayleighInteract.cc
@@ -42,7 +42,7 @@ void rayleigh_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "rayleigh"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "rayleigh"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/RayleighInteract.cc
+++ b/src/celeritas/em/generated/RayleighInteract.cc
@@ -26,23 +26,23 @@ namespace generated
 {
 void rayleigh_interact(
     celeritas::RayleighHostRef const& model_data,
-    celeritas::CoreRef<MemSpace::host> const& core_data)
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::rayleigh_interact_track);
     #pragma omp parallel for
-    for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
+    for (celeritas::size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "rayleigh"));
+            KernelContextException(params, state, ThreadId{i}, "rayleigh"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/RayleighInteract.cu
+++ b/src/celeritas/em/generated/RayleighInteract.cu
@@ -16,8 +16,6 @@
 #include "celeritas/em/launcher/RayleighLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
-using celeritas::MemSpace;
-
 namespace celeritas
 {
 namespace generated
@@ -35,15 +33,15 @@ __launch_bounds__(1024, 8)
 #endif // CELERITAS_LAUNCH_BOUNDS
 rayleigh_interact_kernel(
     celeritas::RayleighDeviceRef const model_data,
-    celeritas::CoreRef<MemSpace::device> const core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
+    celeritas::DeviceRef<celeritas::CoreStateData> const state)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < core_data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::rayleigh_interact_track);
     launch(tid);
 }
@@ -51,15 +49,16 @@ rayleigh_interact_kernel(
 
 void rayleigh_interact(
     celeritas::RayleighDeviceRef const& model_data,
-    celeritas::CoreRef<MemSpace::device> const& core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(rayleigh_interact,
                         celeritas::device().default_block_size(),
-                        core_data.states.size(),
-                        model_data, core_data);
+                        state.size(),
+                        model_data, params, state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/RayleighInteract.hh
+++ b/src/celeritas/em/generated/RayleighInteract.hh
@@ -12,7 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/RayleighData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 namespace celeritas
 {
@@ -20,16 +20,19 @@ namespace generated
 {
 void rayleigh_interact(
     celeritas::RayleighHostRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::host> const&);
+    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::HostRef<celeritas::CoreStateData> const&);
 
 void rayleigh_interact(
     celeritas::RayleighDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&);
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&);
 
 #if !CELER_USE_DEVICE
 inline void rayleigh_interact(
     celeritas::RayleighDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/RayleighInteract.hh
+++ b/src/celeritas/em/generated/RayleighInteract.hh
@@ -21,18 +21,18 @@ namespace generated
 void rayleigh_interact(
     celeritas::RayleighHostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void rayleigh_interact(
     celeritas::RayleighDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void rayleigh_interact(
     celeritas::RayleighDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/RelativisticBremInteract.cc
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cc
@@ -26,23 +26,23 @@ namespace generated
 {
 void relativistic_brem_interact(
     celeritas::RelativisticBremHostRef const& model_data,
-    celeritas::CoreRef<MemSpace::host> const& core_data)
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::relativistic_brem_interact_track);
     #pragma omp parallel for
-    for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
+    for (celeritas::size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "relativistic_brem"));
+            KernelContextException(params, state, ThreadId{i}, "relativistic_brem"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/RelativisticBremInteract.cc
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cc
@@ -27,7 +27,7 @@ namespace generated
 void relativistic_brem_interact(
     celeritas::RelativisticBremHostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/src/celeritas/em/generated/RelativisticBremInteract.cc
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cc
@@ -42,7 +42,7 @@ void relativistic_brem_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "relativistic_brem"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "relativistic_brem"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/RelativisticBremInteract.hh
+++ b/src/celeritas/em/generated/RelativisticBremInteract.hh
@@ -12,7 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/RelativisticBremData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 namespace celeritas
 {
@@ -20,16 +20,19 @@ namespace generated
 {
 void relativistic_brem_interact(
     celeritas::RelativisticBremHostRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::host> const&);
+    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::HostRef<celeritas::CoreStateData> const&);
 
 void relativistic_brem_interact(
     celeritas::RelativisticBremDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&);
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&);
 
 #if !CELER_USE_DEVICE
 inline void relativistic_brem_interact(
     celeritas::RelativisticBremDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/RelativisticBremInteract.hh
+++ b/src/celeritas/em/generated/RelativisticBremInteract.hh
@@ -21,18 +21,18 @@ namespace generated
 void relativistic_brem_interact(
     celeritas::RelativisticBremHostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void relativistic_brem_interact(
     celeritas::RelativisticBremDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void relativistic_brem_interact(
     celeritas::RelativisticBremDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cc
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cc
@@ -42,7 +42,7 @@ void seltzer_berger_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "seltzer_berger"));
+            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "seltzer_berger"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cc
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cc
@@ -27,7 +27,7 @@ namespace generated
 void seltzer_berger_interact(
     celeritas::SeltzerBergerHostRef const& model_data,
     celeritas::HostCRef<celeritas::CoreParamsData> const& params,
-    celeritas::HostRef<celeritas::CoreStateData> const& state)
+    celeritas::HostRef<celeritas::CoreStateData>& state)
 {
     CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cc
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cc
@@ -26,23 +26,23 @@ namespace generated
 {
 void seltzer_berger_interact(
     celeritas::SeltzerBergerHostRef const& model_data,
-    celeritas::CoreRef<MemSpace::host> const& core_data)
+    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::HostRef<celeritas::CoreStateData> const& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::seltzer_berger_interact_track);
     #pragma omp parallel for
-    for (celeritas::size_type i = 0; i < core_data.states.size(); ++i)
+    for (celeritas::size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data.params, core_data.states, ThreadId{i}, "seltzer_berger"));
+            KernelContextException(params, state, ThreadId{i}, "seltzer_berger"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cu
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cu
@@ -16,8 +16,6 @@
 #include "celeritas/em/launcher/SeltzerBergerLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
-using celeritas::MemSpace;
-
 namespace celeritas
 {
 namespace generated
@@ -26,15 +24,15 @@ namespace
 {
 __global__ void seltzer_berger_interact_kernel(
     celeritas::SeltzerBergerDeviceRef const model_data,
-    celeritas::CoreRef<MemSpace::device> const core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
+    celeritas::DeviceRef<celeritas::CoreStateData> const state)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < core_data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        core_data,
-        model_data,
+        params, state, model_data,
         celeritas::seltzer_berger_interact_track);
     launch(tid);
 }
@@ -42,15 +40,16 @@ __global__ void seltzer_berger_interact_kernel(
 
 void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const& model_data,
-    celeritas::CoreRef<MemSpace::device> const& core_data)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(core_data);
+    CELER_EXPECT(params && state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(seltzer_berger_interact,
                         celeritas::device().default_block_size(),
-                        core_data.states.size(),
-                        model_data, core_data);
+                        state.size(),
+                        model_data, params, state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/SeltzerBergerInteract.hh
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.hh
@@ -21,18 +21,18 @@ namespace generated
 void seltzer_berger_interact(
     celeritas::SeltzerBergerHostRef const&,
     celeritas::HostCRef<celeritas::CoreParamsData> const&,
-    celeritas::HostRef<celeritas::CoreStateData> const&);
+    celeritas::HostRef<celeritas::CoreStateData>&);
 
 void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&);
+    celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const&,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
-    celeritas::DeviceRef<celeritas::CoreStateData> const&)
+    celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/SeltzerBergerInteract.hh
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.hh
@@ -12,7 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/SeltzerBergerData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 namespace celeritas
 {
@@ -20,16 +20,19 @@ namespace generated
 {
 void seltzer_berger_interact(
     celeritas::SeltzerBergerHostRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::host> const&);
+    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::HostRef<celeritas::CoreStateData> const&);
 
 void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&);
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&);
 
 #if !CELER_USE_DEVICE
 inline void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const&,
-    celeritas::CoreRef<celeritas::MemSpace::device> const&)
+    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::DeviceRef<celeritas::CoreStateData> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/model/BetheHeitlerModel.cc
+++ b/src/celeritas/em/model/BetheHeitlerModel.cc
@@ -32,18 +32,18 @@ BetheHeitlerModel::BetheHeitlerModel(ActionId id,
                 {pdg::gamma()})
 {
     CELER_EXPECT(id);
-    interface_.ids.action = id;
-    interface_.ids.electron = particles.find(pdg::electron());
-    interface_.ids.positron = particles.find(pdg::positron());
-    interface_.ids.gamma = particles.find(pdg::gamma());
-    interface_.enable_lpm = enable_lpm;
+    data_.ids.action = id;
+    data_.ids.electron = particles.find(pdg::electron());
+    data_.ids.positron = particles.find(pdg::positron());
+    data_.ids.gamma = particles.find(pdg::gamma());
+    data_.enable_lpm = enable_lpm;
 
-    CELER_VALIDATE(interface_.ids,
+    CELER_VALIDATE(data_.ids,
                    << "missing electron, positron and/or gamma particles "
                       "(required for "
                    << this->description() << ")");
-    interface_.electron_mass = particles.get(interface_.ids.electron).mass();
-    CELER_ENSURE(interface_);
+    data_.electron_mass = particles.get(data_.ids.electron).mass();
+    CELER_ENSURE(data_);
 }
 
 //---------------------------------------------------------------------------//
@@ -53,7 +53,7 @@ BetheHeitlerModel::BetheHeitlerModel(ActionId id,
 auto BetheHeitlerModel::applicability() const -> SetApplicability
 {
     Applicability photon_applic;
-    photon_applic.particle = interface_.ids.gamma;
+    photon_applic.particle = data_.ids.gamma;
     photon_applic.lower = zero_quantity();
     photon_applic.upper = units::MevEnergy{1e8};
 
@@ -74,14 +74,16 @@ auto BetheHeitlerModel::micro_xs(Applicability applic) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void BetheHeitlerModel::execute(CoreDeviceRef const& data) const
+void BetheHeitlerModel::execute(ParamsDeviceCRef const& params,
+                                StateDeviceRef& states) const
 {
-    generated::bethe_heitler_interact(interface_, data);
+    generated::bethe_heitler_interact(data_, params, states);
 }
 
-void BetheHeitlerModel::execute(CoreHostRef const& data) const
+void BetheHeitlerModel::execute(ParamsHostCRef const& params,
+                                StateHostRef& states) const
 {
-    generated::bethe_heitler_interact(interface_, data);
+    generated::bethe_heitler_interact(data_, params, states);
 }
 //!@}
 //---------------------------------------------------------------------------//
@@ -90,7 +92,7 @@ void BetheHeitlerModel::execute(CoreHostRef const& data) const
  */
 ActionId BetheHeitlerModel::action_id() const
 {
-    return interface_.ids.action;
+    return data_.ids.action;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/BetheHeitlerModel.hh
+++ b/src/celeritas/em/model/BetheHeitlerModel.hh
@@ -43,10 +43,10 @@ class BetheHeitlerModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;
@@ -61,7 +61,7 @@ class BetheHeitlerModel final : public Model
     }
 
   private:
-    BetheHeitlerData interface_;
+    BetheHeitlerData data_;
     ImportedModelAdapter imported_;
 };
 

--- a/src/celeritas/em/model/CombinedBremModel.cc
+++ b/src/celeritas/em/model/CombinedBremModel.cc
@@ -88,14 +88,16 @@ auto CombinedBremModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void CombinedBremModel::execute(CoreDeviceRef const& data) const
+void CombinedBremModel::execute(ParamsDeviceCRef const& params,
+                                StateDeviceRef& states) const
 {
-    generated::combined_brem_interact(this->device_ref(), data);
+    generated::combined_brem_interact(this->device_ref(), params, states);
 }
 
-void CombinedBremModel::execute(CoreHostRef const& data) const
+void CombinedBremModel::execute(ParamsHostCRef const& params,
+                                StateHostRef& states) const
 {
-    generated::combined_brem_interact(this->host_ref(), data);
+    generated::combined_brem_interact(this->host_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/CombinedBremModel.hh
+++ b/src/celeritas/em/model/CombinedBremModel.hh
@@ -59,10 +59,10 @@ class CombinedBremModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel to host data
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/EPlusGGModel.cc
+++ b/src/celeritas/em/model/EPlusGGModel.cc
@@ -22,15 +22,15 @@ namespace celeritas
 EPlusGGModel::EPlusGGModel(ActionId id, ParticleParams const& particles)
 {
     CELER_EXPECT(id);
-    interface_.ids.action = id;
-    interface_.ids.positron = particles.find(pdg::positron());
-    interface_.ids.gamma = particles.find(pdg::gamma());
+    data_.ids.action = id;
+    data_.ids.positron = particles.find(pdg::positron());
+    data_.ids.gamma = particles.find(pdg::gamma());
 
-    CELER_VALIDATE(interface_.ids.positron && interface_.ids.gamma,
+    CELER_VALIDATE(data_.ids.positron && data_.ids.gamma,
                    << "missing positron and/or gamma particles (required for "
                    << this->description() << ")");
-    interface_.electron_mass = particles.get(interface_.ids.positron).mass();
-    CELER_ENSURE(interface_);
+    data_.electron_mass = particles.get(data_.ids.positron).mass();
+    CELER_ENSURE(data_);
 }
 
 //---------------------------------------------------------------------------//
@@ -40,7 +40,7 @@ EPlusGGModel::EPlusGGModel(ActionId id, ParticleParams const& particles)
 auto EPlusGGModel::applicability() const -> SetApplicability
 {
     Applicability applic;
-    applic.particle = interface_.ids.positron;
+    applic.particle = data_.ids.positron;
     applic.lower = neg_max_quantity();  // Valid at rest
     applic.upper = units::MevEnergy{1e8};  // 100 TeV
 
@@ -62,14 +62,16 @@ auto EPlusGGModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void EPlusGGModel::execute(CoreDeviceRef const& data) const
+void EPlusGGModel::execute(ParamsDeviceCRef const& params,
+                           StateDeviceRef& states) const
 {
-    generated::eplusgg_interact(interface_, data);
+    generated::eplusgg_interact(data_, params, states);
 }
 
-void EPlusGGModel::execute(CoreHostRef const& data) const
+void EPlusGGModel::execute(ParamsHostCRef const& params,
+                           StateHostRef& states) const
 {
-    generated::eplusgg_interact(interface_, data);
+    generated::eplusgg_interact(data_, params, states);
 }
 
 //!@}
@@ -79,7 +81,7 @@ void EPlusGGModel::execute(CoreHostRef const& data) const
  */
 ActionId EPlusGGModel::action_id() const
 {
-    return interface_.ids.action;
+    return data_.ids.action;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/EPlusGGModel.hh
+++ b/src/celeritas/em/model/EPlusGGModel.hh
@@ -30,10 +30,10 @@ class EPlusGGModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;
@@ -48,10 +48,10 @@ class EPlusGGModel final : public Model
     }
 
     // Access data on device
-    EPlusGGData device_ref() const { return interface_; }
+    EPlusGGData device_ref() const { return data_; }
 
   private:
-    EPlusGGData interface_;
+    EPlusGGData data_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/KleinNishinaModel.cc
+++ b/src/celeritas/em/model/KleinNishinaModel.cc
@@ -22,19 +22,18 @@ KleinNishinaModel::KleinNishinaModel(ActionId id,
                                      ParticleParams const& particles)
 {
     CELER_EXPECT(id);
-    interface_.ids.action = id;
-    interface_.ids.electron = particles.find(pdg::electron());
-    interface_.ids.gamma = particles.find(pdg::gamma());
+    data_.ids.action = id;
+    data_.ids.electron = particles.find(pdg::electron());
+    data_.ids.gamma = particles.find(pdg::gamma());
 
-    CELER_VALIDATE(interface_.ids.electron && interface_.ids.gamma,
+    CELER_VALIDATE(data_.ids.electron && data_.ids.gamma,
                    << "missing electron, positron and/or gamma particles "
                       "(required for "
                    << this->description() << ")");
-    interface_.inv_electron_mass
-        = 1
-          / value_as<KleinNishinaData::Mass>(
-              particles.get(interface_.ids.electron).mass());
-    CELER_ENSURE(interface_);
+    data_.inv_electron_mass = 1
+                              / value_as<KleinNishinaData::Mass>(
+                                  particles.get(data_.ids.electron).mass());
+    CELER_ENSURE(data_);
 }
 
 //---------------------------------------------------------------------------//
@@ -44,7 +43,7 @@ KleinNishinaModel::KleinNishinaModel(ActionId id,
 auto KleinNishinaModel::applicability() const -> SetApplicability
 {
     Applicability photon_applic;
-    photon_applic.particle = interface_.ids.gamma;
+    photon_applic.particle = data_.ids.gamma;
     photon_applic.lower = zero_quantity();
     photon_applic.upper = max_quantity();
 
@@ -66,14 +65,16 @@ auto KleinNishinaModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void KleinNishinaModel::execute(CoreDeviceRef const& data) const
+void KleinNishinaModel::execute(ParamsDeviceCRef const& params,
+                                StateDeviceRef& states) const
 {
-    generated::klein_nishina_interact(interface_, data);
+    generated::klein_nishina_interact(data_, params, states);
 }
 
-void KleinNishinaModel::execute(CoreHostRef const& data) const
+void KleinNishinaModel::execute(ParamsHostCRef const& params,
+                                StateHostRef& states) const
 {
-    generated::klein_nishina_interact(interface_, data);
+    generated::klein_nishina_interact(data_, params, states);
 }
 
 //---------------------------------------------------------------------------//
@@ -82,7 +83,7 @@ void KleinNishinaModel::execute(CoreHostRef const& data) const
  */
 ActionId KleinNishinaModel::action_id() const
 {
-    return interface_.ids.action;
+    return data_.ids.action;
 }
 
 //!@}

--- a/src/celeritas/em/model/KleinNishinaModel.hh
+++ b/src/celeritas/em/model/KleinNishinaModel.hh
@@ -30,10 +30,10 @@ class KleinNishinaModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     //! Apply the interaction kernel to host data
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;
@@ -48,7 +48,7 @@ class KleinNishinaModel final : public Model
     }
 
   private:
-    KleinNishinaData interface_;
+    KleinNishinaData data_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/LivermorePEModel.cc
+++ b/src/celeritas/em/model/LivermorePEModel.cc
@@ -102,14 +102,16 @@ auto LivermorePEModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void LivermorePEModel::execute(CoreDeviceRef const& data) const
+void LivermorePEModel::execute(ParamsDeviceCRef const& params,
+                               StateDeviceRef& states) const
 {
-    generated::livermore_pe_interact(this->device_ref(), data);
+    generated::livermore_pe_interact(this->device_ref(), params, states);
 }
 
-void LivermorePEModel::execute(CoreHostRef const& data) const
+void LivermorePEModel::execute(ParamsHostCRef const& params,
+                               StateHostRef& states) const
 {
-    generated::livermore_pe_interact(this->host_ref(), data);
+    generated::livermore_pe_interact(this->host_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/LivermorePEModel.hh
+++ b/src/celeritas/em/model/LivermorePEModel.hh
@@ -49,10 +49,10 @@ class LivermorePEModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/MollerBhabhaModel.cc
+++ b/src/celeritas/em/model/MollerBhabhaModel.cc
@@ -24,18 +24,18 @@ MollerBhabhaModel::MollerBhabhaModel(ActionId id,
                                      ParticleParams const& particles)
 {
     CELER_EXPECT(id);
-    interface_.ids.action = id;
-    interface_.ids.electron = particles.find(pdg::electron());
-    interface_.ids.positron = particles.find(pdg::positron());
+    data_.ids.action = id;
+    data_.ids.electron = particles.find(pdg::electron());
+    data_.ids.positron = particles.find(pdg::positron());
 
-    CELER_VALIDATE(interface_.ids.electron && interface_.ids.positron,
+    CELER_VALIDATE(data_.ids.electron && data_.ids.positron,
                    << "missing electron and/or positron particles "
                       "(required for "
                    << this->description() << ")");
 
-    interface_.electron_mass = particles.get(interface_.ids.electron).mass();
+    data_.electron_mass = particles.get(data_.ids.electron).mass();
 
-    CELER_ENSURE(interface_);
+    CELER_ENSURE(data_);
 }
 
 //---------------------------------------------------------------------------//
@@ -50,11 +50,11 @@ auto MollerBhabhaModel::applicability() const -> SetApplicability
 
     Applicability electron_applic, positron_applic;
 
-    electron_applic.particle = interface_.ids.electron;
+    electron_applic.particle = data_.ids.electron;
     electron_applic.lower = zero_quantity();
-    electron_applic.upper = units::MevEnergy{interface_.max_valid_energy()};
+    electron_applic.upper = units::MevEnergy{data_.max_valid_energy()};
 
-    positron_applic.particle = interface_.ids.positron;
+    positron_applic.particle = data_.ids.positron;
     positron_applic.lower = zero_quantity();
     positron_applic.upper = electron_applic.upper;
 
@@ -77,14 +77,16 @@ auto MollerBhabhaModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void MollerBhabhaModel::execute(CoreDeviceRef const& data) const
+void MollerBhabhaModel::execute(ParamsDeviceCRef const& params,
+                                StateDeviceRef& states) const
 {
-    generated::moller_bhabha_interact(interface_, data);
+    generated::moller_bhabha_interact(data_, params, states);
 }
 
-void MollerBhabhaModel::execute(CoreHostRef const& data) const
+void MollerBhabhaModel::execute(ParamsHostCRef const& params,
+                                StateHostRef& states) const
 {
-    generated::moller_bhabha_interact(interface_, data);
+    generated::moller_bhabha_interact(data_, params, states);
 }
 
 //!@}
@@ -94,7 +96,7 @@ void MollerBhabhaModel::execute(CoreHostRef const& data) const
  */
 ActionId MollerBhabhaModel::action_id() const
 {
-    return interface_.ids.action;
+    return data_.ids.action;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/MollerBhabhaModel.hh
+++ b/src/celeritas/em/model/MollerBhabhaModel.hh
@@ -31,10 +31,10 @@ class MollerBhabhaModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;
@@ -49,7 +49,7 @@ class MollerBhabhaModel final : public Model
     }
 
   private:
-    MollerBhabhaData interface_;
+    MollerBhabhaData data_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/MuBremsstrahlungModel.cc
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.cc
@@ -31,19 +31,17 @@ MuBremsstrahlungModel::MuBremsstrahlungModel(ActionId id,
                 {pdg::mu_minus(), pdg::mu_plus()})
 {
     CELER_EXPECT(id);
-    interface_.ids.action = id;
-    interface_.ids.gamma = particles.find(pdg::gamma());
-    interface_.ids.mu_minus = particles.find(pdg::mu_minus());
-    interface_.ids.mu_plus = particles.find(pdg::mu_plus());
+    data_.ids.action = id;
+    data_.ids.gamma = particles.find(pdg::gamma());
+    data_.ids.mu_minus = particles.find(pdg::mu_minus());
+    data_.ids.mu_plus = particles.find(pdg::mu_plus());
 
-    CELER_VALIDATE(interface_.ids.gamma && interface_.ids.mu_minus
-                       && interface_.ids.mu_plus,
+    CELER_VALIDATE(data_.ids.gamma && data_.ids.mu_minus && data_.ids.mu_plus,
                    << "missing muon and/or gamma particles (required for "
                    << this->description() << ")");
 
-    interface_.electron_mass
-        = particles.get(particles.find(pdg::electron())).mass();
-    CELER_ENSURE(interface_);
+    data_.electron_mass = particles.get(particles.find(pdg::electron())).mass();
+    CELER_ENSURE(data_);
 }
 
 //---------------------------------------------------------------------------//
@@ -54,11 +52,11 @@ auto MuBremsstrahlungModel::applicability() const -> SetApplicability
 {
     Applicability mu_minus_applic, mu_plus_applic;
 
-    mu_minus_applic.particle = interface_.ids.mu_minus;
+    mu_minus_applic.particle = data_.ids.mu_minus;
     mu_minus_applic.lower = zero_quantity();
-    mu_minus_applic.upper = interface_.max_incident_energy();
+    mu_minus_applic.upper = data_.max_incident_energy();
 
-    mu_plus_applic.particle = interface_.ids.mu_plus;
+    mu_plus_applic.particle = data_.ids.mu_plus;
     mu_plus_applic.lower = mu_minus_applic.lower;
     mu_plus_applic.upper = mu_minus_applic.upper;
 
@@ -80,14 +78,16 @@ auto MuBremsstrahlungModel::micro_xs(Applicability applic) const
 /*!
  * Apply the interaction kernel.
  */
-void MuBremsstrahlungModel::execute(CoreDeviceRef const& data) const
+void MuBremsstrahlungModel::execute(ParamsDeviceCRef const& params,
+                                    StateDeviceRef& states) const
 {
-    generated::mu_bremsstrahlung_interact(interface_, data);
+    generated::mu_bremsstrahlung_interact(data_, params, states);
 }
 
-void MuBremsstrahlungModel::execute(CoreHostRef const& data) const
+void MuBremsstrahlungModel::execute(ParamsHostCRef const& params,
+                                    StateHostRef& states) const
 {
-    generated::mu_bremsstrahlung_interact(interface_, data);
+    generated::mu_bremsstrahlung_interact(data_, params, states);
 }
 
 //!@}
@@ -97,7 +97,7 @@ void MuBremsstrahlungModel::execute(CoreHostRef const& data) const
  */
 ActionId MuBremsstrahlungModel::action_id() const
 {
-    return interface_.ids.action;
+    return data_.ids.action;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/MuBremsstrahlungModel.hh
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.hh
@@ -42,10 +42,10 @@ class MuBremsstrahlungModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;
@@ -57,7 +57,7 @@ class MuBremsstrahlungModel final : public Model
     std::string description() const final { return "Muon bremsstrahlung"; }
 
   private:
-    MuBremsstrahlungData interface_;
+    MuBremsstrahlungData data_;
     ImportedModelAdapter imported_;
 };
 

--- a/src/celeritas/em/model/RayleighModel.cc
+++ b/src/celeritas/em/model/RayleighModel.cc
@@ -81,14 +81,16 @@ auto RayleighModel::micro_xs(Applicability applic) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void RayleighModel::execute(CoreDeviceRef const& data) const
+void RayleighModel::execute(ParamsDeviceCRef const& params,
+                            StateDeviceRef& states) const
 {
-    generated::rayleigh_interact(this->device_ref(), data);
+    generated::rayleigh_interact(this->device_ref(), params, states);
 }
 
-void RayleighModel::execute(CoreHostRef const& data) const
+void RayleighModel::execute(ParamsHostCRef const& params,
+                            StateHostRef& states) const
 {
-    generated::rayleigh_interact(this->host_ref(), data);
+    generated::rayleigh_interact(this->host_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/RayleighModel.hh
+++ b/src/celeritas/em/model/RayleighModel.hh
@@ -49,10 +49,10 @@ class RayleighModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel to host data
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -100,14 +100,16 @@ auto RelativisticBremModel::micro_xs(Applicability applic) const
 /*!
  * Apply the interaction kernel.
  */
-void RelativisticBremModel::execute(CoreDeviceRef const& data) const
+void RelativisticBremModel::execute(ParamsDeviceCRef const& params,
+                                    StateDeviceRef& states) const
 {
-    generated::relativistic_brem_interact(this->device_ref(), data);
+    generated::relativistic_brem_interact(this->device_ref(), params, states);
 }
 
-void RelativisticBremModel::execute(CoreHostRef const& data) const
+void RelativisticBremModel::execute(ParamsHostCRef const& params,
+                                    StateHostRef& states) const
 {
-    generated::relativistic_brem_interact(this->host_ref(), data);
+    generated::relativistic_brem_interact(this->host_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/RelativisticBremModel.hh
+++ b/src/celeritas/em/model/RelativisticBremModel.hh
@@ -52,10 +52,10 @@ class RelativisticBremModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel to host data
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -124,14 +124,16 @@ auto SeltzerBergerModel::micro_xs(Applicability applic) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void SeltzerBergerModel::execute(CoreDeviceRef const& data) const
+void SeltzerBergerModel::execute(ParamsDeviceCRef const& params,
+                                 StateDeviceRef& states) const
 {
-    generated::seltzer_berger_interact(this->device_ref(), data);
+    generated::seltzer_berger_interact(this->device_ref(), params, states);
 }
 
-void SeltzerBergerModel::execute(CoreHostRef const& data) const
+void SeltzerBergerModel::execute(ParamsHostCRef const& params,
+                                 StateHostRef& states) const
 {
-    generated::seltzer_berger_interact(this->host_ref(), data);
+    generated::seltzer_berger_interact(this->host_ref(), params, states);
 }
 //!@}
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/SeltzerBergerModel.hh
+++ b/src/celeritas/em/model/SeltzerBergerModel.hh
@@ -73,10 +73,10 @@ class SeltzerBergerModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Apply the interaction kernel
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/ext/VecgeomData.hh
+++ b/src/celeritas/ext/VecgeomData.hh
@@ -100,9 +100,9 @@ struct VecgeomStateData
     template<Ownership W2, MemSpace M2>
     VecgeomStateData& operator=(VecgeomStateData<W2, M2>& other)
     {
-        static_assert(M2 == M && W2 == Ownership::value
-                          && W == Ownership::reference,
-                      "Only supported assignment is from value to reference");
+        static_assert(M2 == M && W == Ownership::reference,
+                      "Only supported assignment is from the same memspace to "
+                      "a reference");
         CELER_EXPECT(other);
         pos = other.pos;
         dir = other.dir;

--- a/src/celeritas/ext/detail/VecgeomNavCollection.cc
+++ b/src/celeritas/ext/detail/VecgeomNavCollection.cc
@@ -43,10 +43,12 @@ void VecgeomNavCollection<Ownership::value, MemSpace::host>::resize(
 /*!
  * Get a reference to host value data.
  */
-void VecgeomNavCollection<Ownership::reference, MemSpace::host>::operator=(
+auto VecgeomNavCollection<Ownership::reference, MemSpace::host>::operator=(
     VecgeomNavCollection<Ownership::value, MemSpace::host>& other)
+    -> VecgeomNavCollection&
 {
     nav_state = make_span(other.nav_state);
+    return *this;
 }
 
 //---------------------------------------------------------------------------//
@@ -95,12 +97,14 @@ void VecgeomNavCollection<Ownership::value, MemSpace::device>::resize(
 /*!
  * Copy the GPU pointer from the host-managed pool.
  */
-void VecgeomNavCollection<Ownership::reference, MemSpace::device>::operator=(
+auto VecgeomNavCollection<Ownership::reference, MemSpace::device>::operator=(
     VecgeomNavCollection<Ownership::value, MemSpace::device>& other)
+    -> VecgeomNavCollection&
 {
     CELER_ASSERT(other);
     pool_view = vecgeom::NavStatePoolView{
         (char*)other.ptr, other.max_depth, (int)other.size};
+    return *this;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/VecgeomNavCollection.hh
+++ b/src/celeritas/ext/detail/VecgeomNavCollection.hh
@@ -83,8 +83,10 @@ struct VecgeomNavCollection<Ownership::reference, MemSpace::host>
     Span<UPNavState> nav_state;
 
     // Obtain reference from host memory
-    void
+    VecgeomNavCollection&
     operator=(VecgeomNavCollection<Ownership::value, MemSpace::host>& other);
+    VecgeomNavCollection& operator=(VecgeomNavCollection const&) = default;
+
     // Get the navigation state for a given track slot
     NavState& at(int, TrackSlotId tid) const;
     //! True if the collection is assigned/valiid
@@ -147,8 +149,12 @@ struct VecgeomNavCollection<Ownership::reference, MemSpace::device>
     vecgeom::NavStatePoolView pool_view = {nullptr, 0, 0};
 
     // Assign from device value
-    void
+    VecgeomNavCollection&
     operator=(VecgeomNavCollection<Ownership::value, MemSpace::device>& other);
+    // Assign from device reference
+    VecgeomNavCollection& operator=(VecgeomNavCollection const& other)
+        = default;
+
     // Get the navigation state for the given track slot
     inline CELER_FUNCTION NavState& at(int max_depth, TrackSlotId tid) const;
 

--- a/src/celeritas/geo/generated/BoundaryAction.cc
+++ b/src/celeritas/geo/generated/BoundaryAction.cc
@@ -27,7 +27,10 @@ void BoundaryAction::execute(CoreHostRef const& data) const
     CELER_EXPECT(data);
 
     MultiExceptionHandler capture_exception;
-    auto launch = make_track_launcher(data, detail::boundary_track);
+    auto launch = make_track_launcher(
+        data.params,
+        const_cast<HostRef<CoreStateData>&>(data.states),
+        detail::boundary_track);
     #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {

--- a/src/celeritas/geo/generated/BoundaryAction.cc
+++ b/src/celeritas/geo/generated/BoundaryAction.cc
@@ -37,7 +37,7 @@ void BoundaryAction::execute(CoreHostRef const& data) const
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(data, ThreadId{i}, this->label()));
+            KernelContextException(data.params, data.states, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/geo/generated/BoundaryAction.cc
+++ b/src/celeritas/geo/generated/BoundaryAction.cc
@@ -22,22 +22,19 @@ namespace celeritas
 {
 namespace generated
 {
-void BoundaryAction::execute(CoreHostRef const& data) const
+void BoundaryAction::execute(ParamsHostCRef const& params, StateHostRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
 
     MultiExceptionHandler capture_exception;
-    auto launch = make_track_launcher(
-        data.params,
-        const_cast<HostRef<CoreStateData>&>(data.states),
-        detail::boundary_track);
+    auto launch = make_track_launcher(params, state, detail::boundary_track);
     #pragma omp parallel for
-    for (size_type i = 0; i < data.states.size(); ++i)
+    for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(data.params, data.states, ThreadId{i}, this->label()));
+            KernelContextException(params, state, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/geo/generated/BoundaryAction.cu
+++ b/src/celeritas/geo/generated/BoundaryAction.cu
@@ -28,7 +28,7 @@ __global__ void boundary_kernel(
 )
 {
     auto tid = KernelParamCalculator::thread_id();
-    if (!(tid < data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = make_track_launcher(params, state, detail::boundary_track);
@@ -36,14 +36,14 @@ __global__ void boundary_kernel(
 }
 }  // namespace
 
-void BoundaryAction::execute(CoreDeviceRef const& data) const
+void BoundaryAction::execute(ParamsDeviceCRef const& params, StateDeviceRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
     CELER_LAUNCH_KERNEL(boundary,
                         celeritas::device().default_block_size(),
-                        data.states.size(),
-                        data.params,
-                        data.states);
+                        state.size(),
+                        params,
+                        state);
 }
 
 }  // namespace generated

--- a/src/celeritas/geo/generated/BoundaryAction.cu
+++ b/src/celeritas/geo/generated/BoundaryAction.cu
@@ -22,14 +22,16 @@ namespace generated
 {
 namespace
 {
-__global__ void boundary_kernel(CoreDeviceRef const data
+__global__ void boundary_kernel(
+    DeviceCRef<CoreParamsData> const params,
+    DeviceRef<CoreStateData> const state
 )
 {
     auto tid = KernelParamCalculator::thread_id();
     if (!(tid < data.states.size()))
         return;
 
-    auto launch = make_track_launcher(data, detail::boundary_track);
+    auto launch = make_track_launcher(params, state, detail::boundary_track);
     launch(tid);
 }
 }  // namespace
@@ -40,7 +42,8 @@ void BoundaryAction::execute(CoreDeviceRef const& data) const
     CELER_LAUNCH_KERNEL(boundary,
                         celeritas::device().default_block_size(),
                         data.states.size(),
-                        data);
+                        data.params,
+                        data.states);
 }
 
 }  // namespace generated

--- a/src/celeritas/geo/generated/BoundaryAction.hh
+++ b/src/celeritas/geo/generated/BoundaryAction.hh
@@ -25,17 +25,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(CoreHostRef const&) const final;
+  void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
   // Launch kernel with device data
-  void execute(CoreDeviceRef const&) const final;
+  void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final { return ActionOrder::post; }
 };
 
 #if !CELER_USE_DEVICE
-inline void BoundaryAction::execute(CoreDeviceRef const&) const
+inline void BoundaryAction::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/ActionInterface.hh
+++ b/src/celeritas/global/ActionInterface.hh
@@ -68,16 +68,18 @@ class ExplicitActionInterface : public virtual ActionInterface
   public:
     //@{
     //! \name Type aliases
-    using CoreHostRef = CoreRef<MemSpace::host>;
-    using CoreDeviceRef = CoreRef<MemSpace::device>;
+    using ParamsDeviceCRef = DeviceCRef<CoreParamsData>;
+    using ParamsHostCRef = HostCRef<CoreParamsData>;
+    using StateDeviceRef = DeviceRef<CoreStateData>;
+    using StateHostRef = HostRef<CoreStateData>;
     //@}
 
   public:
     //! Execute the action with host data
-    virtual void execute(CoreHostRef const&) const = 0;
+    virtual void execute(ParamsHostCRef const&, StateHostRef&) const = 0;
 
     //! Execute the action with device data
-    virtual void execute(CoreDeviceRef const&) const = 0;
+    virtual void execute(ParamsDeviceCRef const&, StateDeviceRef&) const = 0;
 
     //! Dependency ordering of the action
     virtual ActionOrder order() const = 0;
@@ -100,8 +102,8 @@ class ExplicitActionInterface : public virtual ActionInterface
       // Construct with ID and label
       using ConcreteAction::ConcreteAction;
 
-      void execute(CoreHostRef const&) const final;
-      void execute(CoreDeviceRef const&) const final;
+      void execute(ParamsHostCRef const&, StateHostRef&) const final;
+      void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
       ActionOrder order() const final { return ActionOrder::post; }
   };

--- a/src/celeritas/global/CoreTrackData.hh
+++ b/src/celeritas/global/CoreTrackData.hh
@@ -139,12 +139,6 @@ struct CoreStateData
     }
 };
 
-// TODO: DEPRECATED TYPE ALIASES
-using CoreParamsDeviceRef = DeviceCRef<CoreParamsData>;
-using CoreParamsHostRef = HostCRef<CoreParamsData>;
-using CoreStateDeviceRef = DeviceRef<CoreStateData>;
-using CoreStateHostRef = HostRef<CoreStateData>;
-
 //---------------------------------------------------------------------------//
 /*!
  * Reference to core parameters and states.
@@ -162,8 +156,8 @@ struct CoreRef
 };
 
 // TODO: DEPRECATED TYPE ALIASES
-using CoreHostRef = CoreRef<MemSpace::host>;
-using CoreDeviceRef = CoreRef<MemSpace::device>;
+[[deprecated]] typedef CoreRef<MemSpace::host> CoreHostRef;
+[[deprecated]] typedef CoreRef<MemSpace::device> CoreDeviceRef;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -57,6 +57,19 @@ std::ostream& operator<<(std::ostream& os, OpaqueId<V, S> const& v)
 KernelContextException::KernelContextException(CoreHostRef const& data,
                                                ThreadId thread,
                                                std::string&& label)
+    : KernelContextException(data.params, data.states, thread, std::move(label))
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with track data and kernel label.
+ */
+KernelContextException::KernelContextException(
+    HostCRef<CoreParamsData> const& params,
+    HostRef<CoreStateData> const& states,
+    ThreadId thread,
+    std::string&& label)
     : thread_(thread), label_(std::move(label))
 {
     try
@@ -67,7 +80,7 @@ KernelContextException::KernelContextException(CoreHostRef const& data,
             // detailed debug information
             throw std::exception();
         }
-        CoreTrackView core(data.params, data.states, thread);
+        CoreTrackView core(params, states, thread);
         this->initialize(core);
     }
     catch (...)

--- a/src/celeritas/global/KernelContextException.hh
+++ b/src/celeritas/global/KernelContextException.hh
@@ -29,7 +29,8 @@ class CoreTrackView;
     CELER_TRY_HANDLE_CONTEXT(
         launch(ThreadId{i}),
         capture_exception,
-        KernelContextException(data, ThreadId{i}, this->label())
+        KernelContextException(data.params, data.states, ThreadId{i},
+ this->label())
     );
  * \endcode
  */

--- a/src/celeritas/global/KernelContextException.hh
+++ b/src/celeritas/global/KernelContextException.hh
@@ -44,9 +44,15 @@ class KernelContextException : public RichContextException
 
   public:
     // Construct with track data and kernel label
-    KernelContextException(CoreHostRef const& data,
+    KernelContextException(HostCRef<CoreParamsData> const& params,
+                           HostRef<CoreStateData> const& states,
                            ThreadId tid,
                            std::string&& label);
+
+    //! Construct with combined track data
+    [[deprecated]] KernelContextException(CoreHostRef const& data,
+                                          ThreadId tid,
+                                          std::string&& label);
 
     // This class type
     char const* type() const final;

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -69,7 +69,7 @@ auto Stepper<M>::operator()() -> result_type
 {
     CELER_EXPECT(*this);
 
-    actions_->execute(core_ref_);
+    actions_->execute(core_ref_.params, core_ref_.states);
 
     // Get the number of track initializers and active tracks
     result_type result;
@@ -108,7 +108,7 @@ auto Stepper<M>::operator()(SpanConstPrimary primaries) -> result_type
                    << " exceeds max_events=" << params_->init()->max_events());
 
     // Create track initializers
-    extend_from_primaries(core_ref_, primaries);
+    extend_from_primaries(core_ref_.params, core_ref_.states, primaries);
 
     return (*this)();
 }

--- a/src/celeritas/global/TrackLauncher.hh
+++ b/src/celeritas/global/TrackLauncher.hh
@@ -54,7 +54,7 @@ make_track_launcher(CoreRef<MemSpace::native> const& data, F&& call_with_track)
 template<class F>
 CELER_FUNCTION detail::TrackLauncher<F>
 make_track_launcher(NativeCRef<CoreParamsData> const& params,
-                    NativeRef<CoreStateData>& state,
+                    NativeRef<CoreStateData> const& state,
                     F&& call_with_track)
 {
     return {params, state, ::celeritas::forward<F>(call_with_track)};

--- a/src/celeritas/global/TrackLauncher.hh
+++ b/src/celeritas/global/TrackLauncher.hh
@@ -43,10 +43,21 @@ inline CELER_FUNCTION void foo_track(celeritas::CoreTrackView const& track)
    \endcode
  */
 template<class F>
-CELER_FUNCTION detail::TrackLauncher<F>
+[[deprecated]] CELER_FUNCTION detail::TrackLauncher<F>
 make_track_launcher(CoreRef<MemSpace::native> const& data, F&& call_with_track)
 {
-    return {data, ::celeritas::forward<F>(call_with_track)};
+    return {data.params,
+            const_cast<NativeRef<CoreStateData>&>(data.states),
+            ::celeritas::forward<F>(call_with_track)};
+}
+
+template<class F>
+CELER_FUNCTION detail::TrackLauncher<F>
+make_track_launcher(NativeCRef<CoreParamsData> const& params,
+                    NativeRef<CoreStateData>& state,
+                    F&& call_with_track)
+{
+    return {params, state, ::celeritas::forward<F>(call_with_track)};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
@@ -70,25 +70,26 @@ AlongStepGeneralLinearAction::~AlongStepGeneralLinearAction() = default;
 /*!
  * Launch the along-step action on host.
  */
-void AlongStepGeneralLinearAction::execute(CoreHostRef const& data) const
+void AlongStepGeneralLinearAction::execute(ParamsHostCRef const& params,
+                                           StateHostRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
 
     MultiExceptionHandler capture_exception;
-    auto launch = make_along_step_launcher(data,
+    auto launch = make_along_step_launcher(params,
+                                           state,
                                            host_data_.msc,
                                            NoData{},
                                            host_data_.fluct,
                                            detail::along_step_general_linear);
 
 #pragma omp parallel for
-    for (size_type i = 0; i < data.states.size(); ++i)
+    for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(
-                data.params, data.states, ThreadId{i}, this->label()));
+            KernelContextException(params, state, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
@@ -87,7 +87,8 @@ void AlongStepGeneralLinearAction::execute(CoreHostRef const& data) const
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(data, ThreadId{i}, this->label()));
+            KernelContextException(
+                data.params, data.states, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
@@ -44,7 +44,8 @@ along_step_general_linear_kernel(CoreRef<MemSpace::device> const track_data,
 /*!
  * Launch the along-step action on device.
  */
-void AlongStepGeneralLinearAction::execute(CoreDeviceRef const& data) const
+void AlongStepGeneralLinearAction::execute(ParamsDeviceCRef const& params,
+                                           StateDeviceRef& states) const
 {
     CELER_EXPECT(data);
     CELER_LAUNCH_KERNEL(along_step_general_linear,

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
@@ -22,16 +22,18 @@ namespace
 {
 //---------------------------------------------------------------------------//
 __global__ void
-along_step_general_linear_kernel(CoreRef<MemSpace::device> const track_data,
-                                 DeviceCRef<UrbanMscData> const msc_data,
+along_step_general_linear_kernel(DeviceCRef<CoreParamsData> const params,
+                                 DeviceRef<CoreStateData> const state,
+                                 DeviceCRef<UrbanMscData> const msc_params,
                                  DeviceCRef<FluctuationData> const fluct)
 {
     auto tid = KernelParamCalculator::thread_id();
-    if (!(tid < track_data.states.size()))
+    if (!(tid < state.size()))
         return;
 
-    auto launch = make_along_step_launcher(track_data,
-                                           msc_data,
+    auto launch = make_along_step_launcher(params,
+                                           state,
+                                           msc_params,
                                            NoData{},
                                            fluct,
                                            detail::along_step_general_linear);
@@ -45,13 +47,14 @@ along_step_general_linear_kernel(CoreRef<MemSpace::device> const track_data,
  * Launch the along-step action on device.
  */
 void AlongStepGeneralLinearAction::execute(ParamsDeviceCRef const& params,
-                                           StateDeviceRef& states) const
+                                           StateDeviceRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
     CELER_LAUNCH_KERNEL(along_step_general_linear,
                         celeritas::device().default_block_size(),
-                        data.states.size(),
-                        data,
+                        state.size(),
+                        params,
+                        state,
                         device_data_.msc,
                         device_data_.fluct);
 }

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.hh
@@ -59,10 +59,10 @@ class AlongStepGeneralLinearAction final : public ExplicitActionInterface
     ~AlongStepGeneralLinearAction();
 
     // Launch kernel with host data
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Launch kernel with device data
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }
@@ -113,7 +113,8 @@ class AlongStepGeneralLinearAction final : public ExplicitActionInterface
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void AlongStepGeneralLinearAction::execute(CoreDeviceRef const&) const
+inline void AlongStepGeneralLinearAction::execute(ParamsDeviceCRef const&,
+                                                  StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/alongstep/AlongStepLauncher.hh
+++ b/src/celeritas/global/alongstep/AlongStepLauncher.hh
@@ -24,13 +24,15 @@ namespace celeritas
  */
 template<class M, class P, class E, class F>
 CELER_FUNCTION detail::AlongStepLauncherImpl<M, P, E, F>
-make_along_step_launcher(CoreRef<MemSpace::native> const& core_data,
+make_along_step_launcher(NativeCRef<CoreParamsData> const& core_params,
+                         NativeRef<CoreStateData> const& core_state,
                          M&& msc_data,
                          P&& propagator_data,
                          E&& eloss_data,
                          F&& call_with_track)
 {
-    return {core_data,
+    return {core_params,
+            core_state,
             ::celeritas::forward<M>(msc_data),
             ::celeritas::forward<P>(propagator_data),
             ::celeritas::forward<E>(eloss_data),

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
@@ -33,28 +33,29 @@ AlongStepNeutralAction::AlongStepNeutralAction(ActionId id) : id_(id)
 /*!
  * Launch the along-step action on host.
  */
-void AlongStepNeutralAction::execute(CoreHostRef const& data) const
+void AlongStepNeutralAction::execute(ParamsHostCRef const& params,
+                                     StateHostRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
 
     MultiExceptionHandler capture_exception;
     auto launch = make_along_step_launcher(
-        data, NoData{}, NoData{}, NoData{}, detail::along_step_neutral);
+        params, state, NoData{}, NoData{}, NoData{}, detail::along_step_neutral);
 #pragma omp parallel for
-    for (size_type i = 0; i < data.states.size(); ++i)
+    for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(
-                data.params, data.states, ThreadId{i}, this->label()));
+            KernelContextException(params, state, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }
 
 //---------------------------------------------------------------------------//
 #if !CELER_USE_DEVICE
-void AlongStepNeutralAction::execute(CoreDeviceRef const&) const
+void AlongStepNeutralAction::execute(ParamsDeviceCRef const&,
+                                     StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
@@ -46,7 +46,8 @@ void AlongStepNeutralAction::execute(CoreHostRef const& data) const
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(data, ThreadId{i}, this->label()));
+            KernelContextException(
+                data.params, data.states, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
@@ -38,7 +38,8 @@ __global__ void along_step_neutral_kernel(CoreDeviceRef const data)
 /*!
  * Launch the along-step action on device.
  */
-void AlongStepNeutralAction::execute(CoreDeviceRef const& data) const
+void AlongStepNeutralAction::execute(ParamsDeviceCRef const& params,
+                                     StateDeviceRef& states) const
 {
     CELER_EXPECT(data);
     CELER_LAUNCH_KERNEL(along_step_neutral,

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
@@ -21,14 +21,16 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
-__global__ void along_step_neutral_kernel(CoreDeviceRef const data)
+__global__ void
+along_step_neutral_kernel(DeviceCRef<CoreParamsData> const params,
+                          DeviceRef<CoreStateData> const state)
 {
     auto tid = KernelParamCalculator::thread_id();
-    if (!(tid < data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = make_along_step_launcher(
-        data, NoData{}, NoData{}, NoData{}, detail::along_step_neutral);
+        params, state, NoData{}, NoData{}, NoData{}, detail::along_step_neutral);
     launch(tid);
 }
 //---------------------------------------------------------------------------//
@@ -39,13 +41,14 @@ __global__ void along_step_neutral_kernel(CoreDeviceRef const data)
  * Launch the along-step action on device.
  */
 void AlongStepNeutralAction::execute(ParamsDeviceCRef const& params,
-                                     StateDeviceRef& states) const
+                                     StateDeviceRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
     CELER_LAUNCH_KERNEL(along_step_neutral,
                         celeritas::device().default_block_size(),
-                        data.states.size(),
-                        data);
+                        state.size(),
+                        params,
+                        state);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.hh
@@ -29,10 +29,10 @@ class AlongStepNeutralAction final : public ExplicitActionInterface
     explicit AlongStepNeutralAction(ActionId id);
 
     // Launch kernel with host data
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Launch kernel with device data
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
@@ -64,7 +64,8 @@ void AlongStepUniformMscAction::execute(CoreHostRef const& data) const
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(data, ThreadId{i}, this->label()));
+            KernelContextException(
+                data.params, data.states, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
@@ -47,25 +47,26 @@ AlongStepUniformMscAction::~AlongStepUniformMscAction() = default;
 /*!
  * Launch the along-step action on host.
  */
-void AlongStepUniformMscAction::execute(CoreHostRef const& data) const
+void AlongStepUniformMscAction::execute(ParamsHostCRef const& params,
+                                        StateHostRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
 
     MultiExceptionHandler capture_exception;
-    auto launch = make_along_step_launcher(data,
+    auto launch = make_along_step_launcher(params,
+                                           state,
                                            host_data_.msc,
                                            field_params_,
                                            NoData{},
                                            detail::along_step_uniform_msc);
 
 #pragma omp parallel for
-    for (size_type i = 0; i < data.states.size(); ++i)
+    for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(
-                data.params, data.states, ThreadId{i}, this->label()));
+            KernelContextException(params, state, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
@@ -44,7 +44,8 @@ along_step_uniform_msc_kernel(CoreRef<MemSpace::device> const track_data,
 /*!
  * Launch the along-step action on device.
  */
-void AlongStepUniformMscAction::execute(CoreDeviceRef const& data) const
+void AlongStepUniformMscAction::execute(ParamsDeviceCRef const& params,
+                                        StateDeviceRef& states) const
 {
     CELER_EXPECT(data);
     CELER_LAUNCH_KERNEL(along_step_uniform_msc,

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
@@ -22,15 +22,17 @@ namespace
 {
 //---------------------------------------------------------------------------//
 __global__ void
-along_step_uniform_msc_kernel(CoreRef<MemSpace::device> const track_data,
+along_step_uniform_msc_kernel(DeviceCRef<CoreParamsData> const params,
+                              DeviceRef<CoreStateData> const state,
                               DeviceCRef<UrbanMscData> const msc_data,
                               UniformFieldParams const field_params)
 {
     auto tid = KernelParamCalculator::thread_id();
-    if (!(tid < track_data.states.size()))
+    if (!(tid < state.size()))
         return;
 
-    auto launch = make_along_step_launcher(track_data,
+    auto launch = make_along_step_launcher(params,
+                                           state,
                                            msc_data,
                                            field_params,
                                            NoData{},
@@ -45,13 +47,14 @@ along_step_uniform_msc_kernel(CoreRef<MemSpace::device> const track_data,
  * Launch the along-step action on device.
  */
 void AlongStepUniformMscAction::execute(ParamsDeviceCRef const& params,
-                                        StateDeviceRef& states) const
+                                        StateDeviceRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
     CELER_LAUNCH_KERNEL(along_step_uniform_msc,
                         celeritas::device().default_block_size(),
-                        data.states.size(),
-                        data,
+                        state.size(),
+                        params,
+                        state,
                         device_data_.msc,
                         field_params_);
 }

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.hh
@@ -45,10 +45,10 @@ class AlongStepUniformMscAction final : public ExplicitActionInterface
     ~AlongStepUniformMscAction();
 
     // Launch kernel with host data
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Launch kernel with device data
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }
@@ -97,7 +97,8 @@ class AlongStepUniformMscAction final : public ExplicitActionInterface
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void AlongStepUniformMscAction::execute(CoreDeviceRef const&) const
+inline void AlongStepUniformMscAction::execute(ParamsDeviceCRef const&,
+                                               StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/alongstep/detail/AlongStepLauncherImpl.hh
+++ b/src/celeritas/global/alongstep/detail/AlongStepLauncherImpl.hh
@@ -33,14 +33,10 @@ namespace detail
 template<class M, class P, class E, class F>
 struct AlongStepLauncherImpl
 {
-    //!@{
-    //! \name Type aliases
-    using CoreRefNative = CoreRef<MemSpace::native>;
-    //!@}
-
     //// DATA ////
 
-    CoreRefNative const& core_data;
+    NativeCRef<CoreParamsData> const& core_params;
+    NativeRef<CoreStateData> const& core_state;
     M msc_data;
     P propagator_data;
     E eloss_data;
@@ -61,9 +57,9 @@ template<class M, class P, class E, class F>
 CELER_FUNCTION void
 AlongStepLauncherImpl<M, P, E, F>::operator()(ThreadId thread) const
 {
-    CELER_ASSERT(thread < this->core_data.states.size());
+    CELER_ASSERT(thread < this->core_state.size());
     const celeritas::CoreTrackView track(
-        this->core_data.params, this->core_data.states, thread);
+        this->core_params, this->core_state, thread);
 
     {
         auto sim = track.make_sim_view();

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -18,6 +18,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/sys/Stopwatch.hh"
 #include "celeritas/global/ActionInterface.hh"
+#include "celeritas/global/CoreTrackData.hh"
 
 #include "../ActionRegistry.hh"
 
@@ -79,7 +80,9 @@ ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
  * The given action ID \em must be an explicit action.
  */
 template<MemSpace M>
-void ActionSequence::execute(CoreRef<M> const& data)
+void ActionSequence::execute(
+    CoreParamsData<Ownership::const_reference, M> const& params,
+    CoreStateData<Ownership::reference, M>& state)
 {
     if (M == MemSpace::host || options_.sync)
     {
@@ -87,7 +90,7 @@ void ActionSequence::execute(CoreRef<M> const& data)
         for (auto i : range(actions_.size()))
         {
             Stopwatch get_time;
-            actions_[i]->execute(data);
+            actions_[i]->execute(params, state);
             if (M == MemSpace::device)
             {
                 CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
@@ -100,7 +103,7 @@ void ActionSequence::execute(CoreRef<M> const& data)
         // Just loop over the actions
         for (SPConstExplicit const& sp_action : actions_)
         {
-            sp_action->execute(data);
+            sp_action->execute(params, state);
         }
     }
 }
@@ -109,8 +112,12 @@ void ActionSequence::execute(CoreRef<M> const& data)
 // Explicit template instantiation
 //---------------------------------------------------------------------------//
 
-template void ActionSequence::execute(CoreRef<MemSpace::host> const&);
-template void ActionSequence::execute(CoreRef<MemSpace::device> const&);
+template void ActionSequence::execute(
+    CoreParamsData<Ownership::const_reference, MemSpace::host> const&,
+    CoreStateData<Ownership::reference, MemSpace::host>&);
+template void ActionSequence::execute(
+    CoreParamsData<Ownership::const_reference, MemSpace::device> const&,
+    CoreStateData<Ownership::reference, MemSpace::device>&);
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/global/detail/ActionSequence.hh
+++ b/src/celeritas/global/detail/ActionSequence.hh
@@ -53,7 +53,8 @@ class ActionSequence
 
     // Launch all actions with the given memory space.
     template<MemSpace M>
-    void execute(CoreRef<M> const& data);
+    void execute(CoreParamsData<Ownership::const_reference, M> const& params,
+                 CoreStateData<Ownership::reference, M>& state);
 
     //// ACCESSORS ////
 

--- a/src/celeritas/global/detail/TrackLauncherImpl.hh
+++ b/src/celeritas/global/detail/TrackLauncherImpl.hh
@@ -28,16 +28,15 @@ struct TrackLauncher
     //// DATA ////
 
     NativeCRef<CoreParamsData> const& params;
-    NativeRef<CoreStateData>& states;
+    NativeRef<CoreStateData> const& state;
     F call_with_track;
 
     //// METHODS ////
 
     CELER_FUNCTION void operator()(ThreadId thread) const
     {
-        CELER_ASSERT(thread < this->states.size());
-        const celeritas::CoreTrackView track(
-            this->params, this->states, thread);
+        CELER_ASSERT(thread < this->state.size());
+        const celeritas::CoreTrackView track(this->params, this->state, thread);
         this->call_with_track(track);
     }
 };

--- a/src/celeritas/global/detail/TrackLauncherImpl.hh
+++ b/src/celeritas/global/detail/TrackLauncherImpl.hh
@@ -25,20 +25,19 @@ namespace detail
 template<class F>
 struct TrackLauncher
 {
-    using CoreRefNative = celeritas::CoreRef<MemSpace::native>;
-
     //// DATA ////
 
-    CoreRefNative const& data;
+    NativeCRef<CoreParamsData> const& params;
+    NativeRef<CoreStateData>& states;
     F call_with_track;
 
     //// METHODS ////
 
     CELER_FUNCTION void operator()(ThreadId thread) const
     {
-        CELER_ASSERT(thread < this->data.states.size());
+        CELER_ASSERT(thread < this->states.size());
         const celeritas::CoreTrackView track(
-            this->data.params, this->data.states, thread);
+            this->params, this->states, thread);
         this->call_with_track(track);
     }
 };

--- a/src/celeritas/phys/InteractionLauncher.hh
+++ b/src/celeritas/phys/InteractionLauncher.hh
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "corecel/math/Algorithms.hh"
-#include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/CoreTrackDataFwd.hh"
 
 #include "detail/InteractionLauncherImpl.hh"
 
@@ -38,11 +38,13 @@ inline CELER_FUNCTION Interaction foo_interact(
  */
 template<class D, class F>
 CELER_FUNCTION detail::InteractionLauncherImpl<D, F>
-make_interaction_launcher(CoreRef<MemSpace::native> const& core_data,
+make_interaction_launcher(NativeCRef<CoreParamsData> const& params,
+                          NativeRef<CoreStateData> const& states,
                           D const& model_data,
                           F&& call_with_track)
 {
-    return {core_data, model_data, ::celeritas::forward<F>(call_with_track)};
+    return {
+        params, states, model_data, ::celeritas::forward<F>(call_with_track)};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/detail/InteractionLauncherImpl.hh
+++ b/src/celeritas/phys/detail/InteractionLauncherImpl.hh
@@ -26,14 +26,10 @@ namespace detail
 template<class D, class F>
 struct InteractionLauncherImpl
 {
-    //!@{
-    //! \name Type aliases
-    using CoreRefNative = CoreRef<MemSpace::native>;
-    //!@}
-
     //// DATA ////
 
-    CoreRefNative const& core_data;
+    NativeCRef<CoreParamsData> const& params;
+    NativeRef<CoreStateData> const& states;
     D const& model_data;
     F call_with_track;
 
@@ -52,9 +48,8 @@ template<class D, class F>
 CELER_FUNCTION void
 InteractionLauncherImpl<D, F>::operator()(ThreadId thread) const
 {
-    CELER_ASSERT(thread < this->core_data.states.size());
-    const celeritas::CoreTrackView track(
-        this->core_data.params, this->core_data.states, thread);
+    CELER_ASSERT(thread < this->states.size());
+    const celeritas::CoreTrackView track(this->params, this->states, thread);
 
     auto sim = track.make_sim_view();
     if (sim.step_limit().action != model_data.ids.action)
@@ -96,7 +91,7 @@ InteractionLauncherImpl<D, F>::operator()(ThreadId thread) const
                     // below the production cut -- deposit the energy locally
                     // and clear the secondary
                     deposition += secondary.energy.value();
-                    ParticleView particle{this->core_data.params.particles,
+                    ParticleView particle{this->params.particles,
                                           secondary.particle_id};
                     if (particle.is_antiparticle())
                     {

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cc
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cc
@@ -37,7 +37,7 @@ void DiscreteSelectAction::execute(CoreHostRef const& data) const
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(data, ThreadId{i}, this->label()));
+            KernelContextException(data.params, data.states, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cc
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cc
@@ -22,22 +22,19 @@ namespace celeritas
 {
 namespace generated
 {
-void DiscreteSelectAction::execute(CoreHostRef const& data) const
+void DiscreteSelectAction::execute(ParamsHostCRef const& params, StateHostRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
 
     MultiExceptionHandler capture_exception;
-    auto launch = make_track_launcher(
-        data.params,
-        const_cast<HostRef<CoreStateData>&>(data.states),
-        detail::discrete_select_track);
+    auto launch = make_track_launcher(params, state, detail::discrete_select_track);
     #pragma omp parallel for
-    for (size_type i = 0; i < data.states.size(); ++i)
+    for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(data.params, data.states, ThreadId{i}, this->label()));
+            KernelContextException(params, state, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cc
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cc
@@ -27,7 +27,10 @@ void DiscreteSelectAction::execute(CoreHostRef const& data) const
     CELER_EXPECT(data);
 
     MultiExceptionHandler capture_exception;
-    auto launch = make_track_launcher(data, detail::discrete_select_track);
+    auto launch = make_track_launcher(
+        data.params,
+        const_cast<HostRef<CoreStateData>&>(data.states),
+        detail::discrete_select_track);
     #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cu
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cu
@@ -28,7 +28,7 @@ __global__ void discrete_select_kernel(
 )
 {
     auto tid = KernelParamCalculator::thread_id();
-    if (!(tid < data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = make_track_launcher(params, state, detail::discrete_select_track);
@@ -36,14 +36,14 @@ __global__ void discrete_select_kernel(
 }
 }  // namespace
 
-void DiscreteSelectAction::execute(CoreDeviceRef const& data) const
+void DiscreteSelectAction::execute(ParamsDeviceCRef const& params, StateDeviceRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
     CELER_LAUNCH_KERNEL(discrete_select,
                         celeritas::device().default_block_size(),
-                        data.states.size(),
-                        data.params,
-                        data.states);
+                        state.size(),
+                        params,
+                        state);
 }
 
 }  // namespace generated

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cu
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cu
@@ -22,14 +22,16 @@ namespace generated
 {
 namespace
 {
-__global__ void discrete_select_kernel(CoreDeviceRef const data
+__global__ void discrete_select_kernel(
+    DeviceCRef<CoreParamsData> const params,
+    DeviceRef<CoreStateData> const state
 )
 {
     auto tid = KernelParamCalculator::thread_id();
     if (!(tid < data.states.size()))
         return;
 
-    auto launch = make_track_launcher(data, detail::discrete_select_track);
+    auto launch = make_track_launcher(params, state, detail::discrete_select_track);
     launch(tid);
 }
 }  // namespace
@@ -40,7 +42,8 @@ void DiscreteSelectAction::execute(CoreDeviceRef const& data) const
     CELER_LAUNCH_KERNEL(discrete_select,
                         celeritas::device().default_block_size(),
                         data.states.size(),
-                        data);
+                        data.params,
+                        data.states);
 }
 
 }  // namespace generated

--- a/src/celeritas/phys/generated/DiscreteSelectAction.hh
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.hh
@@ -25,17 +25,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(CoreHostRef const&) const final;
+  void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
   // Launch kernel with device data
-  void execute(CoreDeviceRef const&) const final;
+  void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final { return ActionOrder::pre_post; }
 };
 
 #if !CELER_USE_DEVICE
-inline void DiscreteSelectAction::execute(CoreDeviceRef const&) const
+inline void DiscreteSelectAction::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/phys/generated/PreStepAction.cc
+++ b/src/celeritas/phys/generated/PreStepAction.cc
@@ -27,7 +27,10 @@ void PreStepAction::execute(CoreHostRef const& data) const
     CELER_EXPECT(data);
 
     MultiExceptionHandler capture_exception;
-    auto launch = make_track_launcher(data, detail::pre_step_track);
+    auto launch = make_track_launcher(
+        data.params,
+        const_cast<HostRef<CoreStateData>&>(data.states),
+        detail::pre_step_track);
     #pragma omp parallel for
     for (size_type i = 0; i < data.states.size(); ++i)
     {

--- a/src/celeritas/phys/generated/PreStepAction.cc
+++ b/src/celeritas/phys/generated/PreStepAction.cc
@@ -37,7 +37,7 @@ void PreStepAction::execute(CoreHostRef const& data) const
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(data, ThreadId{i}, this->label()));
+            KernelContextException(data.params, data.states, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/phys/generated/PreStepAction.cu
+++ b/src/celeritas/phys/generated/PreStepAction.cu
@@ -31,14 +31,16 @@ __launch_bounds__(1024, 4)
 __launch_bounds__(1024, 7)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
-pre_step_kernel(CoreDeviceRef const data
+pre_step_kernel(
+    DeviceCRef<CoreParamsData> const params,
+    DeviceRef<CoreStateData> const state
 )
 {
     auto tid = KernelParamCalculator::thread_id();
     if (!(tid < data.states.size()))
         return;
 
-    auto launch = make_track_launcher(data, detail::pre_step_track);
+    auto launch = make_track_launcher(params, state, detail::pre_step_track);
     launch(tid);
 }
 }  // namespace
@@ -49,7 +51,8 @@ void PreStepAction::execute(CoreDeviceRef const& data) const
     CELER_LAUNCH_KERNEL(pre_step,
                         celeritas::device().default_block_size(),
                         data.states.size(),
-                        data);
+                        data.params,
+                        data.states);
 }
 
 }  // namespace generated

--- a/src/celeritas/phys/generated/PreStepAction.cu
+++ b/src/celeritas/phys/generated/PreStepAction.cu
@@ -37,7 +37,7 @@ pre_step_kernel(
 )
 {
     auto tid = KernelParamCalculator::thread_id();
-    if (!(tid < data.states.size()))
+    if (!(tid < state.size()))
         return;
 
     auto launch = make_track_launcher(params, state, detail::pre_step_track);
@@ -45,14 +45,14 @@ pre_step_kernel(
 }
 }  // namespace
 
-void PreStepAction::execute(CoreDeviceRef const& data) const
+void PreStepAction::execute(ParamsDeviceCRef const& params, StateDeviceRef& state) const
 {
-    CELER_EXPECT(data);
+    CELER_EXPECT(params && state);
     CELER_LAUNCH_KERNEL(pre_step,
                         celeritas::device().default_block_size(),
-                        data.states.size(),
-                        data.params,
-                        data.states);
+                        state.size(),
+                        params,
+                        state);
 }
 
 }  // namespace generated

--- a/src/celeritas/phys/generated/PreStepAction.hh
+++ b/src/celeritas/phys/generated/PreStepAction.hh
@@ -25,17 +25,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(CoreHostRef const&) const final;
+  void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
   // Launch kernel with device data
-  void execute(CoreDeviceRef const&) const final;
+  void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final { return ActionOrder::pre; }
 };
 
 #if !CELER_USE_DEVICE
-inline void PreStepAction::execute(CoreDeviceRef const&) const
+inline void PreStepAction::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/track/ExtendFromSecondariesAction.cc
+++ b/src/celeritas/track/ExtendFromSecondariesAction.cc
@@ -17,23 +17,20 @@ namespace celeritas
 /*!
  * Execute the action with host data
  */
-void ExtendFromSecondariesAction::execute(CoreHostRef const& core) const
+void ExtendFromSecondariesAction::execute(ParamsHostCRef const& params,
+                                          StateHostRef& states) const
 {
-    extend_from_secondaries(core);
+    extend_from_secondaries(params, states);
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Execute the action with device data
  */
-void ExtendFromSecondariesAction::execute(
-    [[maybe_unused]] CoreDeviceRef const& core) const
+void ExtendFromSecondariesAction::execute(ParamsDeviceCRef const& params,
+                                          StateDeviceRef& states) const
 {
-#if !CELER_USE_DEVICE
-    CELER_NOT_CONFIGURED("CUDA OR HIP");
-#else
-    extend_from_secondaries(core);
-#endif
+    extend_from_secondaries(params, states);
 }
 
 }  // namespace celeritas

--- a/src/celeritas/track/ExtendFromSecondariesAction.hh
+++ b/src/celeritas/track/ExtendFromSecondariesAction.hh
@@ -26,11 +26,13 @@ class ExtendFromSecondariesAction final : public ExplicitActionInterface
     //! Default destructor
     ~ExtendFromSecondariesAction() = default;
 
-    //! Execute the action with host data
-    void execute(CoreHostRef const& core) const final;
+    // Execute the action with host data
+    void
+    execute(ParamsHostCRef const& params, StateHostRef& states) const final;
 
-    //! Execute the action with device data
-    void execute(CoreDeviceRef const& core) const final;
+    // Execute the action with device data
+    void execute(ParamsDeviceCRef const& params,
+                 StateDeviceRef& states) const final;
 
     //! ID of the action
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/track/InitializeTracksAction.cc
+++ b/src/celeritas/track/InitializeTracksAction.cc
@@ -17,23 +17,20 @@ namespace celeritas
 /*!
  * Execute the action with host data
  */
-void InitializeTracksAction::execute(CoreHostRef const& core) const
+void InitializeTracksAction::execute(ParamsHostCRef const& params,
+                                     StateHostRef& states) const
 {
-    initialize_tracks(core);
+    initialize_tracks(params, states);
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Execute the action with device data
  */
-void InitializeTracksAction::execute(
-    [[maybe_unused]] CoreDeviceRef const& core) const
+void InitializeTracksAction::execute(ParamsDeviceCRef const& params,
+                                     StateDeviceRef& states) const
 {
-#if !CELER_USE_DEVICE
-    CELER_NOT_CONFIGURED("CUDA OR HIP");
-#else
-    initialize_tracks(core);
-#endif
+    initialize_tracks(params, states);
 }
 
 }  // namespace celeritas

--- a/src/celeritas/track/InitializeTracksAction.hh
+++ b/src/celeritas/track/InitializeTracksAction.hh
@@ -29,10 +29,12 @@ class InitializeTracksAction final : public ExplicitActionInterface
     ~InitializeTracksAction() = default;
 
     //! Execute the action with host data
-    void execute(CoreHostRef const& core) const final;
+    void
+    execute(ParamsHostCRef const& params, StateHostRef& states) const final;
 
     //! Execute the action with device data
-    void execute(CoreDeviceRef const& core) const final;
+    void execute(ParamsDeviceCRef const& params,
+                 StateDeviceRef& states) const final;
 
     //! ID of the action
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/track/TrackInitUtils.hh
+++ b/src/celeritas/track/TrackInitUtils.hh
@@ -53,7 +53,8 @@ inline void extend_from_primaries(CoreRef<M> const& core_data,
     copy(M, primaries[AllItems<Primary, M>{}]);
 
     // Create track initializers from primaries
-    generated::process_primaries(core_data, primaries[AllItems<Primary, M>{}]);
+    generated::process_primaries(
+        core_data.params, core_data.states, primaries[AllItems<Primary, M>{}]);
 }
 
 //---------------------------------------------------------------------------//
@@ -82,7 +83,8 @@ inline void initialize_tracks(CoreRef<M> const& core_data)
         // Launch a kernel to initialize tracks on device
         auto num_vacancies
             = min(data.vacancies.size(), data.initializers.size());
-        generated::init_tracks(core_data, num_vacancies);
+        generated::init_tracks(
+            core_data.params, core_data.states, num_vacancies);
         // Resizing initializers/vacancies is a non-const operation
         const_cast<TrackInitStates&>(data).initializers.resize(
             data.initializers.size() - num_tracks);
@@ -166,7 +168,7 @@ inline void extend_from_secondaries(CoreRef<M> const& core_data)
 
     // Launch a kernel to identify which track slots are still alive and count
     // the number of surviving secondaries per track
-    generated::locate_alive(core_data);
+    generated::locate_alive(core_data.params, core_data.states);
 
     // Remove all elements in the vacancy vector that were flagged as active
     // tracks, leaving the (sorted) indices of the empty slots
@@ -196,7 +198,7 @@ inline void extend_from_secondaries(CoreRef<M> const& core_data)
     // Launch a kernel to create track initializers from secondaries
     const_cast<TrackInitStates&>(data).initializers.resize(
         data.initializers.size() + data.num_secondaries);
-    generated::process_secondaries(core_data);
+    generated::process_secondaries(core_data.params, core_data.states);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/detail/InitTracksLauncher.hh
+++ b/src/celeritas/track/detail/InitTracksLauncher.hh
@@ -51,9 +51,10 @@ class InitTracksLauncher
 
   public:
     // Construct with shared and state data
-    CELER_FUNCTION InitTracksLauncher(CoreRef<M> const& core_data,
+    CELER_FUNCTION InitTracksLauncher(ParamsRef const& params,
+                                      StateRef const& states,
                                       size_type /* num_vacancies */)
-        : params_(core_data.params), states_(core_data.states)
+        : params_(params), states_(states)
     {
         CELER_EXPECT(params_);
         CELER_EXPECT(states_);

--- a/src/celeritas/track/detail/LocateAliveLauncher.hh
+++ b/src/celeritas/track/detail/LocateAliveLauncher.hh
@@ -43,8 +43,9 @@ class LocateAliveLauncher
 
   public:
     // Construct with shared and state data
-    CELER_FUNCTION LocateAliveLauncher(CoreRef<M> const& core_data)
-        : params_(core_data.params), states_(core_data.states)
+    CELER_FUNCTION
+    LocateAliveLauncher(ParamsRef const& params, StateRef const& states)
+        : params_(params), states_(states)
     {
         CELER_EXPECT(params_);
         CELER_EXPECT(states_);

--- a/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
@@ -33,14 +33,17 @@ class ProcessPrimariesLauncher
   public:
     //!@{
     //! \name Type aliases
+    using ParamsRef = CoreParamsData<Ownership::const_reference, M>;
+    using StateRef = CoreStateData<Ownership::reference, M>;
     using TrackInitStateRef = TrackInitStateData<Ownership::reference, M>;
     //!@}
 
   public:
     // Construct with shared and state data
-    CELER_FUNCTION ProcessPrimariesLauncher(CoreRef<M> const& core_data,
+    CELER_FUNCTION ProcessPrimariesLauncher(ParamsRef const&,
+                                            StateRef const& states,
                                             Span<Primary const> primaries)
-        : data_(core_data.states.init), primaries_(primaries)
+        : data_(states.init), primaries_(primaries)
     {
         CELER_EXPECT(data_);
     }

--- a/src/celeritas/track/detail/ProcessSecondariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessSecondariesLauncher.hh
@@ -47,8 +47,8 @@ class ProcessSecondariesLauncher
   public:
     // Construct with shared and state data
     CELER_FUNCTION
-    ProcessSecondariesLauncher(CoreRef<M> const& core_data)
-        : params_(core_data.params), states_(core_data.states)
+    ProcessSecondariesLauncher(ParamsRef const& params, StateRef const& states)
+        : params_(params), states_(states)
     {
         CELER_EXPECT(params_);
         CELER_EXPECT(states_);

--- a/src/celeritas/track/generated/InitTracks.cc
+++ b/src/celeritas/track/generated/InitTracks.cc
@@ -19,18 +19,19 @@ namespace celeritas
 namespace generated
 {
 void init_tracks(
-    CoreHostRef const& core_data,
+    HostCRef<CoreParamsData> const& core_params,
+    HostRef<CoreStateData> const& core_states,
     size_type const num_vacancies)
 {
     MultiExceptionHandler capture_exception;
-    detail::InitTracksLauncher<MemSpace::host> launch(core_data, num_vacancies);
+    detail::InitTracksLauncher<MemSpace::host> launch(core_params, core_states, num_vacancies);
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < num_vacancies; ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "init_tracks"));
+            KernelContextException(core_params, core_states, ThreadId{i}, "init_tracks"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/track/generated/InitTracks.cu
+++ b/src/celeritas/track/generated/InitTracks.cu
@@ -28,27 +28,29 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 init_tracks_kernel(
-    CoreDeviceRef const core_data,
+    DeviceCRef<CoreParamsData> const core_params,
+    DeviceRef<CoreStateData> const core_states,
     size_type const num_vacancies)
 {
     auto tid = KernelParamCalculator::thread_id();
     if (!(tid < num_vacancies))
         return;
 
-    detail::InitTracksLauncher<MemSpace::device> launch(core_data, num_vacancies);
+    detail::InitTracksLauncher<MemSpace::device> launch(core_params, core_states, num_vacancies);
     launch(tid);
 }
 }  // namespace
 
 void init_tracks(
-    CoreDeviceRef const& core_data,
+    DeviceCRef<CoreParamsData> const& core_params,
+    DeviceRef<CoreStateData> const& core_states,
     size_type const num_vacancies)
 {
     CELER_LAUNCH_KERNEL(
         init_tracks,
         celeritas::device().default_block_size(),
         num_vacancies,
-        core_data, num_vacancies);
+        core_params, core_states, num_vacancies);
 }
 
 }  // namespace generated

--- a/src/celeritas/track/generated/InitTracks.hh
+++ b/src/celeritas/track/generated/InitTracks.hh
@@ -11,15 +11,17 @@ namespace generated
 {
 
 void init_tracks(
-    CoreHostRef const& core_data,
+    HostCRef<CoreParamsData> const& core_params,
+    HostRef<CoreStateData> const& core_states,
     size_type const num_vacancies);
 
 void init_tracks(
-    CoreDeviceRef const& core_data,
+    DeviceCRef<CoreParamsData> const& core_params,
+    DeviceRef<CoreStateData> const& core_states,
     size_type const num_vacancies);
 
 #if !CELER_USE_DEVICE
-inline void init_tracks(CoreDeviceRef const&, size_type const)
+inline void init_tracks(DeviceCRef<CoreParamsData> const&, DeviceRef<CoreStateData> const&, size_type const)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/src/celeritas/track/generated/LocateAlive.cc
+++ b/src/celeritas/track/generated/LocateAlive.cc
@@ -19,17 +19,18 @@ namespace celeritas
 namespace generated
 {
 void locate_alive(
-    CoreHostRef const& core_data)
+    HostCRef<CoreParamsData> const& core_params,
+    HostRef<CoreStateData> const& core_states)
 {
     MultiExceptionHandler capture_exception;
-    detail::LocateAliveLauncher<MemSpace::host> launch(core_data);
+    detail::LocateAliveLauncher<MemSpace::host> launch(core_params, core_states);
     #pragma omp parallel for
-    for (ThreadId::size_type i = 0; i < core_data.states.size(); ++i)
+    for (ThreadId::size_type i = 0; i < core_states.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "locate_alive"));
+            KernelContextException(core_params, core_states, ThreadId{i}, "locate_alive"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/track/generated/LocateAlive.cu
+++ b/src/celeritas/track/generated/LocateAlive.cu
@@ -28,25 +28,27 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 locate_alive_kernel(
-    CoreDeviceRef const core_data)
+    DeviceCRef<CoreParamsData> const core_params,
+    DeviceRef<CoreStateData> const core_states)
 {
     auto tid = KernelParamCalculator::thread_id();
-    if (!(tid < core_data.states.size()))
+    if (!(tid < core_states.size()))
         return;
 
-    detail::LocateAliveLauncher<MemSpace::device> launch(core_data);
+    detail::LocateAliveLauncher<MemSpace::device> launch(core_params, core_states);
     launch(tid);
 }
 }  // namespace
 
 void locate_alive(
-    CoreDeviceRef const& core_data)
+    DeviceCRef<CoreParamsData> const& core_params,
+    DeviceRef<CoreStateData> const& core_states)
 {
     CELER_LAUNCH_KERNEL(
         locate_alive,
         celeritas::device().default_block_size(),
-        core_data.states.size(),
-        core_data);
+        core_states.size(),
+        core_params, core_states);
 }
 
 }  // namespace generated

--- a/src/celeritas/track/generated/LocateAlive.hh
+++ b/src/celeritas/track/generated/LocateAlive.hh
@@ -11,13 +11,15 @@ namespace generated
 {
 
 void locate_alive(
-    CoreHostRef const& core_data);
+    HostCRef<CoreParamsData> const& core_params,
+    HostRef<CoreStateData> const& core_states);
 
 void locate_alive(
-    CoreDeviceRef const& core_data);
+    DeviceCRef<CoreParamsData> const& core_params,
+    DeviceRef<CoreStateData> const& core_states);
 
 #if !CELER_USE_DEVICE
-inline void locate_alive(CoreDeviceRef const&)
+inline void locate_alive(DeviceCRef<CoreParamsData> const&, DeviceRef<CoreStateData> const&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/src/celeritas/track/generated/ProcessPrimaries.cc
+++ b/src/celeritas/track/generated/ProcessPrimaries.cc
@@ -19,18 +19,19 @@ namespace celeritas
 namespace generated
 {
 void process_primaries(
-    CoreHostRef const& core_data,
+    HostCRef<CoreParamsData> const& core_params,
+    HostRef<CoreStateData> const& core_states,
     Span<const Primary> const primaries)
 {
     MultiExceptionHandler capture_exception;
-    detail::ProcessPrimariesLauncher<MemSpace::host> launch(core_data, primaries);
+    detail::ProcessPrimariesLauncher<MemSpace::host> launch(core_params, core_states, primaries);
     #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < primaries.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "process_primaries"));
+            KernelContextException(core_params, core_states, ThreadId{i}, "process_primaries"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/track/generated/ProcessPrimaries.cu
+++ b/src/celeritas/track/generated/ProcessPrimaries.cu
@@ -28,27 +28,29 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 process_primaries_kernel(
-    CoreDeviceRef const core_data,
+    DeviceCRef<CoreParamsData> const core_params,
+    DeviceRef<CoreStateData> const core_states,
     Span<const Primary> const primaries)
 {
     auto tid = KernelParamCalculator::thread_id();
     if (!(tid < primaries.size()))
         return;
 
-    detail::ProcessPrimariesLauncher<MemSpace::device> launch(core_data, primaries);
+    detail::ProcessPrimariesLauncher<MemSpace::device> launch(core_params, core_states, primaries);
     launch(tid);
 }
 }  // namespace
 
 void process_primaries(
-    CoreDeviceRef const& core_data,
+    DeviceCRef<CoreParamsData> const& core_params,
+    DeviceRef<CoreStateData> const& core_states,
     Span<const Primary> const primaries)
 {
     CELER_LAUNCH_KERNEL(
         process_primaries,
         celeritas::device().default_block_size(),
         primaries.size(),
-        core_data, primaries);
+        core_params, core_states, primaries);
 }
 
 }  // namespace generated

--- a/src/celeritas/track/generated/ProcessPrimaries.hh
+++ b/src/celeritas/track/generated/ProcessPrimaries.hh
@@ -12,15 +12,17 @@ namespace generated
 {
 
 void process_primaries(
-    CoreHostRef const& core_data,
+    HostCRef<CoreParamsData> const& core_params,
+    HostRef<CoreStateData> const& core_states,
     Span<const Primary> const primaries);
 
 void process_primaries(
-    CoreDeviceRef const& core_data,
+    DeviceCRef<CoreParamsData> const& core_params,
+    DeviceRef<CoreStateData> const& core_states,
     Span<const Primary> const primaries);
 
 #if !CELER_USE_DEVICE
-inline void process_primaries(CoreDeviceRef const&, Span<const Primary> const)
+inline void process_primaries(DeviceCRef<CoreParamsData> const&, DeviceRef<CoreStateData> const&, Span<const Primary> const)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/src/celeritas/track/generated/ProcessSecondaries.cc
+++ b/src/celeritas/track/generated/ProcessSecondaries.cc
@@ -19,17 +19,18 @@ namespace celeritas
 namespace generated
 {
 void process_secondaries(
-    CoreHostRef const& core_data)
+    HostCRef<CoreParamsData> const& core_params,
+    HostRef<CoreStateData> const& core_states)
 {
     MultiExceptionHandler capture_exception;
-    detail::ProcessSecondariesLauncher<MemSpace::host> launch(core_data);
+    detail::ProcessSecondariesLauncher<MemSpace::host> launch(core_params, core_states);
     #pragma omp parallel for
-    for (ThreadId::size_type i = 0; i < core_data.states.size(); ++i)
+    for (ThreadId::size_type i = 0; i < core_states.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(core_data, ThreadId{i}, "process_secondaries"));
+            KernelContextException(core_params, core_states, ThreadId{i}, "process_secondaries"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/track/generated/ProcessSecondaries.cu
+++ b/src/celeritas/track/generated/ProcessSecondaries.cu
@@ -28,25 +28,27 @@ __launch_bounds__(1024, 2)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 process_secondaries_kernel(
-    CoreDeviceRef const core_data)
+    DeviceCRef<CoreParamsData> const core_params,
+    DeviceRef<CoreStateData> const core_states)
 {
     auto tid = KernelParamCalculator::thread_id();
-    if (!(tid < core_data.states.size()))
+    if (!(tid < core_states.size()))
         return;
 
-    detail::ProcessSecondariesLauncher<MemSpace::device> launch(core_data);
+    detail::ProcessSecondariesLauncher<MemSpace::device> launch(core_params, core_states);
     launch(tid);
 }
 }  // namespace
 
 void process_secondaries(
-    CoreDeviceRef const& core_data)
+    DeviceCRef<CoreParamsData> const& core_params,
+    DeviceRef<CoreStateData> const& core_states)
 {
     CELER_LAUNCH_KERNEL(
         process_secondaries,
         celeritas::device().default_block_size(),
-        core_data.states.size(),
-        core_data);
+        core_states.size(),
+        core_params, core_states);
 }
 
 }  // namespace generated

--- a/src/celeritas/track/generated/ProcessSecondaries.hh
+++ b/src/celeritas/track/generated/ProcessSecondaries.hh
@@ -11,13 +11,15 @@ namespace generated
 {
 
 void process_secondaries(
-    CoreHostRef const& core_data);
+    HostCRef<CoreParamsData> const& core_params,
+    HostRef<CoreStateData> const& core_states);
 
 void process_secondaries(
-    CoreDeviceRef const& core_data);
+    DeviceCRef<CoreParamsData> const& core_params,
+    DeviceRef<CoreStateData> const& core_states);
 
 #if !CELER_USE_DEVICE
-inline void process_secondaries(CoreDeviceRef const&)
+inline void process_secondaries(DeviceCRef<CoreParamsData> const&, DeviceRef<CoreStateData> const&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/src/celeritas/user/detail/StepGatherAction.cu
+++ b/src/celeritas/user/detail/StepGatherAction.cu
@@ -19,15 +19,18 @@ namespace
 {
 //---------------------------------------------------------------------------//
 template<StepPoint P>
-__global__ void step_gather_kernel(CoreDeviceRef const core,
-                                   DeviceCRef<StepParamsData> const step_params,
-                                   DeviceRef<StepStateData> const step_state)
+__global__ void
+step_gather_kernel(DeviceCRef<CoreParamsData> const core_params,
+                   DeviceRef<CoreStateData> const core_state,
+                   DeviceCRef<StepParamsData> const step_params,
+                   DeviceRef<StepStateData> const step_state)
 {
     auto tid = KernelParamCalculator::thread_id();
     if (!(tid < step_state.size()))
         return;
 
-    StepGatherLauncher<P> launch{core, step_params, step_state};
+    StepGatherLauncher<P> launch{
+        core_params, core_state, step_params, step_state};
     launch(tid);
 }
 //---------------------------------------------------------------------------//
@@ -38,24 +41,26 @@ __global__ void step_gather_kernel(CoreDeviceRef const core,
  * Launch the action on device.
  */
 template<StepPoint P>
-void step_gather_device(CoreRef<MemSpace::device> const& core,
+void step_gather_device(DeviceCRef<CoreParamsData> const& core_params,
+                        DeviceRef<CoreStateData>& core_state,
                         DeviceCRef<StepParamsData> const& step_params,
-                        DeviceRef<StepStateData> const& step_state)
+                        DeviceRef<StepStateData>& step_state)
 {
-    CELER_EXPECT(core);
-    CELER_EXPECT(step_state.size() == core.states.size());
+    CELER_EXPECT(core_params && core_state);
+    CELER_EXPECT(step_state.size() == core_state.size());
 
     static const KernelParamCalculator calc_launch_params_(
         P == StepPoint::pre ? "step_gather_pre" : "step_gather_post",
         step_gather_kernel<P>);
-    auto grid = calc_launch_params_(core.states.size());
+    auto grid = calc_launch_params_(core_state.size());
 
     CELER_LAUNCH_KERNEL_IMPL(step_gather_kernel<P>,
                              grid.blocks_per_grid,
                              grid.threads_per_block,
                              0,
                              0,
-                             core,
+                             core_params,
+                             core_state,
                              step_params,
                              step_state);
     CELER_DEVICE_CHECK_ERROR();
@@ -64,13 +69,15 @@ void step_gather_device(CoreRef<MemSpace::device> const& core,
 //---------------------------------------------------------------------------//
 
 template void
-step_gather_device<StepPoint::pre>(CoreRef<MemSpace::device> const&,
+step_gather_device<StepPoint::pre>(DeviceCRef<CoreParamsData> const&,
+                                   DeviceRef<CoreStateData>&,
                                    DeviceCRef<StepParamsData> const&,
-                                   DeviceRef<StepStateData> const&);
+                                   DeviceRef<StepStateData>&);
 template void
-step_gather_device<StepPoint::post>(CoreRef<MemSpace::device> const&,
+step_gather_device<StepPoint::post>(DeviceCRef<CoreParamsData> const&,
+                                    DeviceRef<CoreStateData>&,
                                     DeviceCRef<StepParamsData> const&,
-                                    DeviceRef<StepStateData> const&);
+                                    DeviceRef<StepStateData>&);
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/user/detail/StepGatherAction.hh
+++ b/src/celeritas/user/detail/StepGatherAction.hh
@@ -52,10 +52,10 @@ class StepGatherAction final : public ExplicitActionInterface
     StepGatherAction(ActionId id, SPStepStorage storage, VecInterface callbacks);
 
     // Launch kernel with host data
-    void execute(CoreHostRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
 
     // Launch kernel with device data
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }
@@ -89,8 +89,9 @@ class StepGatherAction final : public ExplicitActionInterface
     //// HELPER FUNCTIONS ////
 
     template<MemSpace M>
-    inline StepStateData<Ownership::reference, M> const&
-    get_state(CoreRef<M> const& core_data) const;
+    inline StepStateData<Ownership::reference, M>&
+    get_state(CoreParamsData<Ownership::const_reference, M> const&,
+              CoreStateData<Ownership::reference, M>&) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -98,8 +99,10 @@ class StepGatherAction final : public ExplicitActionInterface
 //---------------------------------------------------------------------------//
 // Get a reference to the stream-local step state data, allocating if needed.
 template<MemSpace M>
-StepStateData<Ownership::reference, M> const&
-get_stream_state(CoreRef<M> const& core, StepStorage* storage);
+StepStateData<Ownership::reference, M>&
+get_stream_state(CoreParamsData<Ownership::const_reference, M> const& params,
+                 CoreStateData<Ownership::reference, M>& states,
+                 StepStorage* storage);
 
 //---------------------------------------------------------------------------//
 // PRIVATE HELPER FUNCTIONS
@@ -109,10 +112,11 @@ get_stream_state(CoreRef<M> const& core, StepStorage* storage);
  */
 template<StepPoint P>
 template<MemSpace M>
-StepStateData<Ownership::reference, M> const&
-StepGatherAction<P>::get_state(CoreRef<M> const& core) const
+StepStateData<Ownership::reference, M>& StepGatherAction<P>::get_state(
+    CoreParamsData<Ownership::const_reference, M> const& params,
+    CoreStateData<Ownership::reference, M>& states) const
 {
-    return get_stream_state(core, storage_.get());
+    return get_stream_state(params, states, storage_.get());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/detail/StepGatherLauncher.hh
+++ b/src/celeritas/user/detail/StepGatherLauncher.hh
@@ -23,18 +23,12 @@ namespace detail
 template<StepPoint P>
 struct StepGatherLauncher
 {
-    //!@{
-    //! \name Type aliases
-    using CoreRefNative = CoreRef<MemSpace::native>;
-    using StepParamsRefNative = NativeCRef<StepParamsData>;
-    using StepStateRefNative = NativeRef<StepStateData>;
-    //!@}
-
     //// DATA ////
 
-    CoreRefNative const& core_data;
-    StepParamsRefNative const& step_params;
-    StepStateRefNative const& step_state;
+    NativeCRef<CoreParamsData> const& core_params;
+    NativeRef<CoreStateData> const& core_state;
+    NativeCRef<StepParamsData> const& step_params;
+    NativeRef<StepStateData> const& step_state;
 
     //// METHODS ////
 
@@ -50,10 +44,10 @@ struct StepGatherLauncher
 template<StepPoint P>
 CELER_FUNCTION void StepGatherLauncher<P>::operator()(ThreadId thread) const
 {
-    CELER_ASSERT(thread < this->core_data.states.size());
+    CELER_ASSERT(thread < this->core_state.size());
 
     celeritas::CoreTrackView const track(
-        this->core_data.params, this->core_data.states, thread);
+        this->core_params, this->core_state, thread);
 
 #define SGL_SET_IF_SELECTED(ATTR, VALUE)                          \
     do                                                            \

--- a/src/corecel/data/CollectionStateStore.hh
+++ b/src/corecel/data/CollectionStateStore.hh
@@ -91,6 +91,9 @@ class CollectionStateStore
     size_type size() const { return val_.size(); }
 
     // Get a reference to the mutable state data
+    inline Ref& ref();
+
+    // Get a reference to the mutable state data
     inline Ref const& ref() const;
 
   private:
@@ -202,6 +205,17 @@ auto CollectionStateStore<S, M>::operator=(S<W2, M2> const& other)
     // Save reference
     ref_ = val_;
     return *this;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get a reference to the mutable state data.
+ */
+template<template<Ownership, MemSpace> class S, MemSpace M>
+auto CollectionStateStore<S, M>::ref() -> Ref&
+{
+    CELER_EXPECT(*this);
+    return ref_;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/global/ActionRegistry.test.cc
+++ b/test/celeritas/global/ActionRegistry.test.cc
@@ -35,8 +35,14 @@ class MyExplicitAction final : public ExplicitActionInterface
     std::string label() const final { return "explicit"; }
     std::string description() const final { return "explicit action test"; }
 
-    void execute(CoreHostRef const&) const final { ++host_count_; }
-    void execute(CoreDeviceRef const&) const final { ++device_count_; }
+    void execute(ParamsHostCRef const&, StateHostRef&) const final
+    {
+        ++host_count_;
+    }
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final
+    {
+        ++device_count_;
+    }
 
     int host_count() const { return host_count_; }
     int device_count() const { return device_count_; }

--- a/test/celeritas/global/DummyAction.hh
+++ b/test/celeritas/global/DummyAction.hh
@@ -20,8 +20,14 @@ class DummyAction final : public ExplicitActionInterface, public ConcreteAction
     // Construct with ID and label
     using ConcreteAction::ConcreteAction;
 
-    void execute(CoreHostRef const&) const final { ++num_execute_host_; }
-    void execute(CoreDeviceRef const&) const final { ++num_execute_device_; }
+    void execute(ParamsHostCRef const&, StateHostRef&) const final
+    {
+        ++num_execute_host_;
+    }
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final
+    {
+        ++num_execute_device_;
+    }
 
     int num_execute_host() const { return num_execute_host_; }
     int num_execute_device() const { return num_execute_device_; }

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -159,7 +159,8 @@ TEST_F(KernelContextExceptionTest, typical)
     CELER_TRY_HANDLE_CONTEXT(
         throw DebugError({DebugErrorType::internal, "false", "test.cc", 0}),
         this->check_exception,
-        KernelContextException(step.core_data(),
+        KernelContextException(step.core_data().params,
+                               step.core_data().states,
                                find_thread(step.core_data(), TrackSlotId{15}),
                                "test-kernel"));
     EXPECT_TRUE(this->caught_debug);
@@ -194,7 +195,8 @@ TEST_F(KernelContextExceptionTest, uninitialized_track)
     CELER_TRY_HANDLE_CONTEXT(
         throw DebugError({DebugErrorType::internal, "false", "test.cc", 0}),
         this->check_exception,
-        KernelContextException(step.core_data(),
+        KernelContextException(step.core_data().params,
+                               step.core_data().states,
                                find_thread(step.core_data(), TrackSlotId{1}),
                                "test-kernel"));
     EXPECT_TRUE(this->caught_debug);
@@ -221,7 +223,10 @@ TEST_F(KernelContextExceptionTest, bad_thread)
     CELER_TRY_HANDLE_CONTEXT(
         throw DebugError({DebugErrorType::internal, "false", "test.cc", 0}),
         this->check_exception,
-        KernelContextException(step.core_data(), ThreadId{}, "dumb-kernel"));
+        KernelContextException(step.core_data().params,
+                               step.core_data().states,
+                               ThreadId{},
+                               "dumb-kernel"));
     EXPECT_TRUE(this->caught_debug);
     EXPECT_TRUE(this->caught_kce);
 }

--- a/test/celeritas/phys/MockModel.cc
+++ b/test/celeritas/phys/MockModel.cc
@@ -55,12 +55,12 @@ auto MockModel::micro_xs(Applicability range) const -> MicroXsBuilders
     return builders;
 }
 
-void MockModel::execute(CoreHostRef const&) const
+void MockModel::execute(ParamsHostCRef const&, StateHostRef&) const
 {
     // Shouldn't be called?
 }
 
-void MockModel::execute(CoreDeviceRef const&) const
+void MockModel::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
 {
     // Inform calling test code that we've been launched
     data_.cb(this->action_id());

--- a/test/celeritas/phys/MockModel.hh
+++ b/test/celeritas/phys/MockModel.hh
@@ -48,8 +48,8 @@ class MockModel final : public Model
     explicit MockModel(Input data);
     SetApplicability applicability() const final;
     MicroXsBuilders micro_xs(Applicability range) const final;
-    void execute(CoreHostRef const&) const final;
-    void execute(CoreDeviceRef const&) const final;
+    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
     ActionId action_id() const final { return data_.id; }
     std::string label() const final;
     std::string description() const final;

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -88,7 +88,7 @@ class InteractAction final : public ExplicitActionInterface
 };
 
 //! Copy results to host
-ITTestOutput get_result(CoreStateDeviceRef& states)
+ITTestOutput get_result(DeviceRef<CoreStateData>& states)
 {
     CELER_EXPECT(states);
 
@@ -172,7 +172,7 @@ class TrackInitTest : public SimpleTestBase
     }
 
     //! Copy results to host
-    ITTestOutput get_result(CoreStateDeviceRef& states)
+    ITTestOutput get_result(DeviceRef<CoreStateData>& states)
     {
         CELER_EXPECT(states);
 

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -209,7 +209,7 @@ class TrackInitTest : public SimpleTestBase
     }
 
     CoreStateData<Ownership::value, MemSpace::device> device_states;
-    CoreDeviceRef core_data;
+    CoreRef<MemSpace::device> core_data;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/track/TrackInit.test.cu
+++ b/test/celeritas/track/TrackInit.test.cu
@@ -23,7 +23,8 @@ namespace test
 // KERNELS
 //---------------------------------------------------------------------------//
 
-__global__ void interact_kernel(CoreDeviceRef data, ITTestInputData const input)
+__global__ void
+interact_kernel(CoreRef<MemSpace::device> data, ITTestInputData const input)
 {
     auto slot_id
         = TrackSlotId{KernelParamCalculator::thread_id().unchecked_get()};
@@ -60,7 +61,7 @@ __global__ void interact_kernel(CoreDeviceRef data, ITTestInputData const input)
 // TESTING INTERFACE
 //---------------------------------------------------------------------------//
 
-void interact(CoreDeviceRef data, ITTestInputData input)
+void interact(CoreRef<MemSpace::device> data, ITTestInputData input)
 {
     CELER_EXPECT(data.states.size() > 0);
     CELER_EXPECT(data.states.size() == input.alloc_size.size());

--- a/test/celeritas/track/TrackInit.test.hh
+++ b/test/celeritas/track/TrackInit.test.hh
@@ -24,7 +24,6 @@ namespace test
 //---------------------------------------------------------------------------//
 // TESTING INTERFACE
 //---------------------------------------------------------------------------//
-//! Interactor
 struct Interactor
 {
     CELER_FUNCTION Interactor(StackAllocator<Secondary>& allocate_secondaries,
@@ -108,10 +107,14 @@ using SecondaryAllocatorData
 
 //---------------------------------------------------------------------------//
 //! Launch a kernel to produce secondaries and apply cutoffs
-void interact(CoreRef<MemSpace::device> data, ITTestInputData input);
+void interact(DeviceCRef<CoreParamsData> const& params,
+              DeviceRef<CoreStateData> const& state,
+              ITTestInputData const& input);
 
 #if !CELER_USE_DEVICE
-inline void interact(CoreRef<MemSpace::device>, ITTestInputData)
+inline void interact(DeviceCRef<CoreParamsData> const&,
+                     DeviceRef<CoreStateData> const&,
+                     ITTestInputData const&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/test/celeritas/track/TrackInit.test.hh
+++ b/test/celeritas/track/TrackInit.test.hh
@@ -108,10 +108,10 @@ using SecondaryAllocatorData
 
 //---------------------------------------------------------------------------//
 //! Launch a kernel to produce secondaries and apply cutoffs
-void interact(CoreDeviceRef data, ITTestInputData input);
+void interact(CoreRef<MemSpace::device> data, ITTestInputData input);
 
 #if !CELER_USE_DEVICE
-inline void interact(CoreDeviceRef, ITTestInputData)
+inline void interact(CoreRef<MemSpace::device>, ITTestInputData)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }


### PR DESCRIPTION
This corrects a lazy and flawed design decision to pass the params and states together in actions (and all over the place).
- Fixes `const_cast` workarounds needed for #664 
- Good thing to do before making `StreamStateData` (#553)
- Also good to try before trying to put the core data pointers on device for #715

It's 100% refactoring; there should be no substantive changes.

Note: this may interfere with #717 and https://github.com/stognini/celeritas/tree/null-process .

