### PR TITLE
Add StreamStore for thread-safe storage of states in a params object

### DIFF
--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -148,6 +148,7 @@ init_root_mctruth_output(LDemoArgs const& run_args,
     auto step_collector = std::make_shared<StepCollector>(
         StepCollector::VecInterface{step_writer},
         transport_ptr->params().geometry(),
+        transport_ptr->params().max_streams(),
         transport_ptr->params().action_reg().get());
 
     // Store input and CoreParams data

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -395,6 +395,7 @@ void SharedParams::initialize_core(SetupOptions const& options)
         step_collector_ = std::make_shared<StepCollector>(
             StepCollector::VecInterface{hit_manager_},
             params.geometry,
+            params.max_streams,
             params.action_reg.get());
     }
 

--- a/src/celeritas/user/StepCollector.cc
+++ b/src/celeritas/user/StepCollector.cc
@@ -41,6 +41,7 @@ enum class HasDetectors
  */
 StepCollector::StepCollector(VecInterface callbacks,
                              SPConstGeo geo,
+                             size_type num_streams,
                              ActionRegistry* action_registry)
     : storage_(std::make_shared<detail::StepStorage>())
 {
@@ -125,8 +126,7 @@ StepCollector::StepCollector(VecInterface callbacks,
             host_data.nonzero_energy_deposition = nonzero_energy_deposition;
         }
 
-        storage_->params
-            = CollectionMirror<StepParamsData>(std::move(host_data));
+        storage_->obj = {std::move(host_data), num_streams};
     }
 
     if (selection.points[StepPoint::pre] || !detector_map.empty())
@@ -158,7 +158,7 @@ StepCollector& StepCollector::operator=(StepCollector&&) = default;
  */
 StepSelection const& StepCollector::selection() const
 {
-    return storage_->params.host_ref().selection;
+    return storage_->obj.params<MemSpace::host>().selection;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/StepCollector.hh
+++ b/src/celeritas/user/StepCollector.hh
@@ -54,6 +54,7 @@ class StepCollector
     // Construct with options and register pre/post-step actions
     StepCollector(VecInterface callbacks,
                   SPConstGeo geo,
+                  size_type max_streams,
                   ActionRegistry* action_registry);
 
     // Default destructor and move

--- a/src/celeritas/user/StepData.hh
+++ b/src/celeritas/user/StepData.hh
@@ -335,6 +335,7 @@ inline void resize(StepPointStateData<Ownership::value, M>* state,
 template<MemSpace M>
 inline void resize(StepStateData<Ownership::value, M>* state,
                    HostCRef<StepParamsData> const& params,
+                   StreamId,
                    size_type size)
 {
     CELER_EXPECT(state->size() == 0);

--- a/src/celeritas/user/detail/StepGatherAction.cc
+++ b/src/celeritas/user/detail/StepGatherAction.cc
@@ -26,9 +26,16 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 template<StepPoint P>
-void step_gather_device(CoreRef<MemSpace::device> const& core,
-                        DeviceCRef<StepParamsData> const& step_params,
-                        DeviceRef<StepStateData> const& step_state);
+void step_gather_device(CoreRef<MemSpace::device> const&,
+                        DeviceCRef<StepParamsData> const&,
+                        DeviceRef<StepStateData> const&)
+#if CELER_USE_DEVICE
+    ;
+#else
+{
+    CELER_NOT_CONFIGURED("CUDA OR HIP");
+}
+#endif
 
 //---------------------------------------------------------------------------//
 /*!
@@ -65,11 +72,13 @@ template<StepPoint P>
 void StepGatherAction<P>::execute(CoreHostRef const& core) const
 {
     CELER_EXPECT(core);
-    auto const& step_state = this->get_state(core);
-    CELER_ASSERT(step_state.size() == core.states.size());
+    auto& state = core.states;
+    auto const& step_state
+        = storage_->obj.state<MemSpace::host>(state.stream_id, state.size());
 
     MultiExceptionHandler capture_exception;
-    StepGatherLauncher<P> launch{core, storage_->params.host_ref(), step_state};
+    StepGatherLauncher<P> launch{
+        core, storage_->obj.params<MemSpace::host>(), step_state};
 #pragma omp parallel for
     for (size_type i = 0; i < core.states.size(); ++i)
     {
@@ -95,9 +104,11 @@ void StepGatherAction<P>::execute(CoreDeviceRef const& core) const
 {
     CELER_EXPECT(core);
 
-#if CELER_USE_DEVICE
-    auto& step_state = this->get_state(core);
-    step_gather_device<P>(core, storage_->params.device_ref(), step_state);
+    auto& state = core.states;
+    auto& step_state
+        = storage_->obj.state<MemSpace::device>(state.stream_id, state.size());
+    step_gather_device<P>(
+        core, storage_->obj.params<MemSpace::device>(), step_state);
 
     if (P == StepPoint::post)
     {
@@ -106,58 +117,6 @@ void StepGatherAction<P>::execute(CoreDeviceRef const& core) const
             sp_callback->execute(step_state);
         }
     }
-#else
-    CELER_NOT_CONFIGURED("CUDA OR HIP");
-#endif
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get a reference to the stream-local step state data, allocating if needed.
- *
- * This is thread-safe and allocates storage on demand for each stream *and*
- * device type.
- */
-template<MemSpace M>
-StepStateData<Ownership::reference, M> const&
-get_stream_state(CoreRef<M> const& core, StepStorage* storage)
-{
-    CELER_EXPECT(storage);
-
-    auto& state_vec = storage->get_states<M>();
-    if (CELER_UNLIKELY(state_vec.empty()))
-    {
-        // State storage hasn't been resized to the number of streams yet:
-        // mutex and resize if needed
-        static std::mutex resize_mutex;
-        std::lock_guard<std::mutex> scoped_lock{resize_mutex};
-        if (state_vec.empty())
-        {
-            // State is guaranteed unresized and we've got a lock
-            CELER_LOG_LOCAL(debug)
-                << "Resizing " << (M == MemSpace::host ? "host" : "device")
-                << " step state data for " << core.params.scalars.max_streams
-                << " threads";
-            state_vec.resize(core.params.scalars.max_streams);
-        }
-    }
-
-    // Get the stream-local but possibly unallocated state storage for the
-    // current stream
-    CELER_ASSERT(core.states.stream_id < state_vec.size());
-    auto& state_store = state_vec[core.states.stream_id.unchecked_get()];
-    if (CELER_UNLIKELY(!state_store))
-    {
-        // Thread-local data hasn't been allocated yet
-        CELER_LOG_LOCAL(debug)
-            << "Allocating local " << (M == MemSpace::host ? "host" : "device")
-            << " step state data";
-        state_store = CollectionStateStore<StepStateData, M>{
-            storage->params.host_ref(), core.states.size()};
-    }
-
-    CELER_ENSURE(state_store);
-    return state_store.ref();
 }
 
 //---------------------------------------------------------------------------//
@@ -166,11 +125,6 @@ get_stream_state(CoreRef<M> const& core, StepStorage* storage)
 
 template class StepGatherAction<StepPoint::pre>;
 template class StepGatherAction<StepPoint::post>;
-
-template StepStateData<Ownership::reference, MemSpace::host> const&
-get_stream_state(CoreRef<MemSpace::host> const&, StepStorage*);
-template StepStateData<Ownership::reference, MemSpace::device> const&
-get_stream_state(CoreRef<MemSpace::device> const&, StepStorage*);
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/user/detail/StepGatherAction.hh
+++ b/src/celeritas/user/detail/StepGatherAction.hh
@@ -85,35 +85,7 @@ class StepGatherAction final : public ExplicitActionInterface
     ActionId id_;
     SPStepStorage storage_;
     VecInterface callbacks_;
-
-    //// HELPER FUNCTIONS ////
-
-    template<MemSpace M>
-    inline StepStateData<Ownership::reference, M> const&
-    get_state(CoreRef<M> const& core_data) const;
 };
-
-//---------------------------------------------------------------------------//
-// FREE FUNCTIONS
-//---------------------------------------------------------------------------//
-// Get a reference to the stream-local step state data, allocating if needed.
-template<MemSpace M>
-StepStateData<Ownership::reference, M> const&
-get_stream_state(CoreRef<M> const& core, StepStorage* storage);
-
-//---------------------------------------------------------------------------//
-// PRIVATE HELPER FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- * Get a reference to the step state data, allocating if needed.
- */
-template<StepPoint P>
-template<MemSpace M>
-StepStateData<Ownership::reference, M> const&
-StepGatherAction<P>::get_state(CoreRef<M> const& core) const
-{
-    return get_stream_state(core, storage_.get());
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/user/detail/StepStorage.hh
+++ b/src/celeritas/user/detail/StepStorage.hh
@@ -7,8 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/data/CollectionMirror.hh"
-#include "corecel/data/CollectionStateStore.hh"
+#include "corecel/data/StreamStore.hh"
 
 #include "../StepData.hh"
 
@@ -17,46 +16,11 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
-/*!
- * Step storage shared across multiple actions.
- */
 struct StepStorage
 {
-    //// TYPES ////
+    using StoreT = StreamStore<StepParamsData, StepStateData>;
 
-    template<MemSpace M>
-    using StepStateCollection = CollectionStateStore<StepStateData, M>;
-    template<MemSpace M>
-    using VecSSC = std::vector<StepStateCollection<M>>;
-
-    //// DATA ////
-
-    // Parameter data
-    CollectionMirror<StepParamsData> params;
-
-    // State data
-    struct
-    {
-        VecSSC<MemSpace::host> host;
-        VecSSC<MemSpace::device> device;
-    } states;
-
-    //// METHODS ////
-
-    template<MemSpace M>
-    decltype(auto) get_states()
-    {
-        if constexpr (M == MemSpace::host)
-        {
-            // NOTE: parens are necessary to return a reference instead of a
-            // value
-            return (states.host);
-        }
-        else
-        {
-            return (states.device);
-        }
-    }
+    StoreT obj;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/CollectionMirror.hh
+++ b/src/corecel/data/CollectionMirror.hh
@@ -66,16 +66,19 @@ class CollectionMirror
     //! Whether the data is assigned
     explicit operator bool() const { return static_cast<bool>(host_); }
 
-    // Get references to host data after construction
-    inline HostRef const& host_ref() const;
-    // Get references to device data after construction
-    inline DeviceRef const& device_ref() const;
+    // Get references to data after construction
+    template<MemSpace M>
+    inline P<Ownership::const_reference, M> const& ref() const;
 
     //!@{
-    //! Deprecated alias to _ref-suffixed functions
+    //! Deprecated alias to ref
     HostRef const& host() const { return this->host_ref(); }
-    // Get references to device data after construction
     DeviceRef const& device() const { return this->device_ref(); }
+    HostRef const& host_ref() const { return this->ref<MemSpace::host>(); }
+    DeviceRef const& device_ref() const
+    {
+        return this->ref<MemSpace::device>();
+    }
     //!@}
 
   private:
@@ -104,29 +107,28 @@ CollectionMirror<P>::CollectionMirror(HostValue&& host)
         device_ref_ = device_;
     }
 }
-//---------------------------------------------------------------------------//
-/*!
- * Get references to host data after construction.
- */
-template<template<Ownership, MemSpace> class P>
-auto CollectionMirror<P>::host_ref() const -> HostRef const&
-{
-    CELER_ENSURE(host_ref_);
-    return host_ref_;
-}
 
 //---------------------------------------------------------------------------//
 /*!
- * Get references to device data after construction.
+ * Get references to data after construction.
  *
- * This will raise an exception if \c celeritas::device is null (and device
- * data wasn't set).
+ * Calling with "device" memspace will raise an exception if \c
+ * celeritas::device is null (and device data wasn't set).
  */
 template<template<Ownership, MemSpace> class P>
-auto CollectionMirror<P>::device_ref() const -> DeviceRef const&
+template<MemSpace M>
+P<Ownership::const_reference, M> const& CollectionMirror<P>::ref() const
 {
-    CELER_ENSURE(device_ref_);
-    return device_ref_;
+    if constexpr (M == MemSpace::host)
+    {
+        return host_ref_;
+    }
+    else if constexpr (M == MemSpace::device)
+    {
+        CELER_ENSURE(device_ref_);
+        return device_ref_;
+    }
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/CollectionMirror.hh
+++ b/src/corecel/data/CollectionMirror.hh
@@ -128,7 +128,10 @@ P<Ownership::const_reference, M> const& CollectionMirror<P>::ref() const
         CELER_ENSURE(device_ref_);
         return device_ref_;
     }
+    // "error #128-D: loop is not reachable"
+#ifndef __NVCC__
     CELER_ASSERT_UNREACHABLE();
+#endif
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/StreamStore.hh
+++ b/src/corecel/data/StreamStore.hh
@@ -1,0 +1,150 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/data/StreamStore.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Assert.hh"
+#include "corecel/OpaqueId.hh"
+#include "corecel/Types.hh"
+#include "corecel/sys/Device.hh"
+#include "corecel/sys/ThreadId.hh"
+
+#include "CollectionMirror.hh"
+#include "CollectionStateStore.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Helper class for storing parameters and multiple stream-dependent states.
+ *
+ * This requires a templated ParamsData and StateData. Hopefully this
+ * frankenstein of a class will be replaced by a
+ */
+template<template<Ownership, MemSpace> class P, template<Ownership, MemSpace> class S>
+class StreamStore
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using ParamsHostVal = P<Ownership::value, MemSpace::host>;
+    //!@}
+
+  public:
+    // Default for unassigned/lazy construction
+    StreamStore() = default;
+
+    // Construct with number of streams and host data
+    inline StreamStore(ParamsHostVal&& host, StreamId::size_type num_streams);
+
+    //// ACCESSORS ////
+
+    //! Whether the instance is ready for storing data
+    explicit operator bool() const { return num_streams_ > 0; }
+
+    // Get references to the params data
+    template<MemSpace M>
+    inline P<Ownership::const_reference, M> const& params() const;
+
+    // Get references to the state data for a given stream, allocating if
+    // necessary.
+    template<MemSpace M>
+    inline S<Ownership::reference, M> const&
+    state(StreamId stream_id, size_type size);
+
+  private:
+    //// TYPES ////
+    using ParamMirror = CollectionMirror<P>;
+    template<MemSpace M>
+    using StateStore = CollectionStateStore<S, M>;
+    template<MemSpace M>
+    using VecSS = std::vector<StateStore<M>>;
+
+    //// DATA ////
+
+    CollectionMirror<P> params_;
+    size_type num_streams_{0};
+    VecSS<MemSpace::host> host_states_;
+    VecSS<MemSpace::device> device_states_;
+
+    //// FUNCTIONS ////
+
+    template<MemSpace M>
+    decltype(auto) states()
+    {
+        if constexpr (M == MemSpace::host)
+        {
+            // Extra parens needed to return reference instead of copy
+            return (host_states_);
+        }
+        else if constexpr (M == MemSpace::device)
+        {
+            return (device_states_);
+        }
+    }
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with parameters and the number of streams.
+ *
+ * The constructor is *not* thread safe and should be called during params
+ * setup, not at run time.
+ */
+template<template<Ownership, MemSpace> class P, template<Ownership, MemSpace> class S>
+StreamStore<P, S>::StreamStore(ParamsHostVal&& host,
+                               StreamId::size_type num_streams)
+    : params_(std::move(host)), num_streams_(num_streams)
+{
+    CELER_EXPECT(params_);
+    CELER_EXPECT(num_streams_ > 0);
+
+    // Resize stores in advance, but don't allocate memory.
+    host_states_.resize(num_streams_);
+    device_states_.resize(num_streams_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get a reference to the params data.
+ */
+template<template<Ownership, MemSpace> class P, template<Ownership, MemSpace> class S>
+template<MemSpace M>
+P<Ownership::const_reference, M> const& StreamStore<P, S>::params() const
+{
+    CELER_EXPECT(*this);
+    return params_.template ref<M>();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get a reference to the state data, allocating if necessary.
+ */
+template<template<Ownership, MemSpace> class P, template<Ownership, MemSpace> class S>
+template<MemSpace M>
+S<Ownership::reference, M> const&
+StreamStore<P, S>::state(StreamId stream_id, size_type size)
+{
+    CELER_EXPECT(*this);
+    CELER_EXPECT(stream_id < num_streams_);
+
+    auto& state_vec = this->states<M>();
+    CELER_ASSERT(state_vec.size() == num_streams_);
+    auto& state_store = state_vec[stream_id.unchecked_get()];
+    if (CELER_UNLIKELY(!state_store))
+    {
+        state_store = {this->params<MemSpace::host>(), stream_id, size};
+    }
+
+    CELER_ENSURE(state_store.size() == size);
+    return state_store.ref();
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/data/StreamStore.hh
+++ b/src/corecel/data/StreamStore.hh
@@ -23,7 +23,8 @@ namespace celeritas
  * Helper class for storing parameters and multiple stream-dependent states.
  *
  * This requires a templated ParamsData and StateData. Hopefully this
- * frankenstein of a class will be replaced by a
+ * frankenstein of a class will be replaced by a std::any-like data container
+ * owned by each (possibly thread-local) State.
  */
 template<template<Ownership, MemSpace> class P, template<Ownership, MemSpace> class S>
 class StreamStore

--- a/test/celeritas/user/CaloTestBase.cc
+++ b/test/celeritas/user/CaloTestBase.cc
@@ -35,8 +35,10 @@ void CaloTestBase::SetUp()
 
     StepCollector::VecInterface interfaces = {example_calos_};
 
-    collector_ = std::make_shared<StepCollector>(
-        std::move(interfaces), this->geometry(), this->action_reg().get());
+    collector_ = std::make_shared<StepCollector>(std::move(interfaces),
+                                                 this->geometry(),
+                                                 /* num_streams = */ 1,
+                                                 this->action_reg().get());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/DetectorSteps.test.cc
+++ b/test/celeritas/user/DetectorSteps.test.cc
@@ -82,7 +82,7 @@ class DetectorStepsTest : public ::celeritas::test::Test
     {
         CELER_EXPECT(count > 0);
         HostStates result;
-        resize(&result, params_.host_ref(), count);
+        resize(&result, params_.host_ref(), StreamId{0}, count);
 
         // Fill with bogus data
         int i = 0;

--- a/test/celeritas/user/MctruthTestBase.cc
+++ b/test/celeritas/user/MctruthTestBase.cc
@@ -34,8 +34,10 @@ void MctruthTestBase::SetUp()
 
     StepCollector::VecInterface interfaces = {example_mctruth_};
 
-    collector_ = std::make_shared<StepCollector>(
-        std::move(interfaces), this->geometry(), this->action_reg().get());
+    collector_ = std::make_shared<StepCollector>(std::move(interfaces),
+                                                 this->geometry(),
+                                                 /* num_streams = */ 1,
+                                                 this->action_reg().get());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -142,6 +142,7 @@ TEST_F(KnStepCollectorTestBase, mixing_types)
 
     EXPECT_THROW((StepCollector{std::move(interfaces),
                                 this->geometry(),
+                                /* num_streams = */ 1,
                                 this->action_reg().get()}),
                  celeritas::RuntimeError);
 }
@@ -151,8 +152,10 @@ TEST_F(KnStepCollectorTestBase, multiple_interfaces)
     // Add mctruth twice so each step is doubly written
     auto mctruth = std::make_shared<ExampleMctruth>();
     StepCollector::VecInterface interfaces = {mctruth, mctruth};
-    auto collector = std::make_shared<StepCollector>(
-        std::move(interfaces), this->geometry(), this->action_reg().get());
+    auto collector = std::make_shared<StepCollector>(std::move(interfaces),
+                                                     this->geometry(),
+                                                     /* num_streams = */ 1,
+                                                     this->action_reg().get());
 
     // Do one step with two tracks
     {


### PR DESCRIPTION
Until a more robust solution is implemented in #392, this is a solution for managing a vector of states (one per stream ID) and allocating them on the fly.