### PR TITLE
Remove universe_types/universe_indices from OrangeInput and rename UnitIndexer

### DIFF
--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -173,13 +173,13 @@ struct RectArrayRecord
  * zero and the last item should be the total number of surfaces or volumes.
  */
 template<Ownership W, MemSpace M>
-struct UnitIndexerData
+struct UniverseIndexerData
 {
     Collection<size_type, W, M> surfaces;
     Collection<size_type, W, M> volumes;
 
     template<Ownership W2, MemSpace M2>
-    UnitIndexerData& operator=(UnitIndexerData<W2, M2> const& other)
+    UniverseIndexerData& operator=(UniverseIndexerData<W2, M2> const& other)
     {
         CELER_EXPECT(other);
 
@@ -241,7 +241,7 @@ struct OrangeParamsData
     Items<Daughter> daughters;
     Items<Translation> translations;
 
-    UnitIndexerData<W, M> unit_indexer_data;
+    UniverseIndexerData<W, M> unit_indexer_data;
 
     //// METHODS ////
 

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -241,7 +241,7 @@ struct OrangeParamsData
     Items<Daughter> daughters;
     Items<Translation> translations;
 
-    UniverseIndexerData<W, M> unit_indexer_data;
+    UniverseIndexerData<W, M> universe_indexer_data;
 
     //// METHODS ////
 
@@ -253,7 +253,7 @@ struct OrangeParamsData
                && ((!local_volume_ids.empty() && !logic_ints.empty()
                     && !reals.empty())
                    || surface_types.empty())
-               && !volume_records.empty() && unit_indexer_data;
+               && !volume_records.empty() && universe_indexer_data;
     }
 
     //! Assign from another set of data
@@ -277,7 +277,7 @@ struct OrangeParamsData
         volume_records = other.volume_records;
         daughters = other.daughters;
         translations = other.translations;
-        unit_indexer_data = other.unit_indexer_data;
+        universe_indexer_data = other.universe_indexer_data;
 
         CELER_ENSURE(static_cast<bool>(*this) == static_cast<bool>(other));
         return *this;

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -136,8 +136,8 @@ OrangeParams::OrangeParams(OrangeInput input)
 
     // Calculate offsets for UniverseIndexerData
     {
-        auto ui_surf = make_builder(&host_data.unit_indexer_data.surfaces);
-        auto ui_vol = make_builder(&host_data.unit_indexer_data.volumes);
+        auto ui_surf = make_builder(&host_data.universe_indexer_data.surfaces);
+        auto ui_vol = make_builder(&host_data.universe_indexer_data.volumes);
         ui_surf.push_back(0);
         ui_vol.push_back(0);
 
@@ -163,9 +163,9 @@ OrangeParams::OrangeParams(OrangeInput input)
             using AllVals = AllItems<size_type, MemSpace::native>;
 
             auto surface_offset
-                = host_data.unit_indexer_data.surfaces[AllVals{}].back();
+                = host_data.universe_indexer_data.surfaces[AllVals{}].back();
             auto volume_offset
-                = host_data.unit_indexer_data.volumes[AllVals{}].back();
+                = host_data.universe_indexer_data.volumes[AllVals{}].back();
 
             auto surfs = std::visit(get_num_surfaces, u);
             auto vols = std::visit(get_num_volumes, u);

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -134,7 +134,7 @@ OrangeParams::OrangeParams(OrangeInput input)
 
     HostVal<OrangeParamsData> host_data;
 
-    // Calculate offsets for UnitIndexerData
+    // Calculate offsets for UniverseIndexerData
     {
         auto ui_surf = make_builder(&host_data.unit_indexer_data.surfaces);
         auto ui_vol = make_builder(&host_data.unit_indexer_data.volumes);
@@ -143,11 +143,20 @@ OrangeParams::OrangeParams(OrangeInput input)
 
         auto get_num_surfaces = Overload{
             [](UnitInput const& u) -> size_type { return u.surfaces.size(); },
-            [](RectArrayInput const&) -> size_type { return 0; }};
+            [](RectArrayInput const& r) -> size_type {
+                return r.daughters.size();
+            }};
 
         auto get_num_volumes = Overload{
             [](UnitInput const& u) -> size_type { return u.volumes.size(); },
-            [](RectArrayInput const&) -> size_type { return 0; }};
+            [](RectArrayInput const& r) -> size_type {
+                return std::accumulate(r.grid.begin(),
+                                       r.grid.end(),
+                                       size_type(0),
+                                       [](size_type acc, const auto& vec) {
+                                           return acc + vec.size();
+                                       });
+            }};
 
         for (auto const& u : input.universes)
         {

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -134,66 +134,80 @@ OrangeParams::OrangeParams(OrangeInput input)
 
     HostVal<OrangeParamsData> host_data;
 
-    // Copy data from OrangeInput
-    make_builder(&host_data.universe_types)
-        .insert_back(input.universe_types.begin(), input.universe_types.end());
-    make_builder(&host_data.universe_indices)
-        .insert_back(input.universe_indices.begin(),
-                     input.universe_indices.end());
-
     // Calculate offsets for UnitIndexerData
-    auto ui_surf = make_builder(&host_data.unit_indexer_data.surfaces);
-    auto ui_vol = make_builder(&host_data.unit_indexer_data.volumes);
-    ui_surf.push_back(0);
-    ui_vol.push_back(0);
-
-    auto get_num_surfaces = Overload{
-        [](UnitInput const& u) -> size_type { return u.surfaces.size(); },
-        [](RectArrayInput const&) -> size_type { return 0; }};
-
-    auto get_num_volumes = Overload{
-        [](UnitInput const& u) -> size_type { return u.volumes.size(); },
-        [](RectArrayInput const&) -> size_type { return 0; }};
-
-    for (auto const& u : input.universes)
     {
-        using AllVals = AllItems<size_type, MemSpace::native>;
+        auto ui_surf = make_builder(&host_data.unit_indexer_data.surfaces);
+        auto ui_vol = make_builder(&host_data.unit_indexer_data.volumes);
+        ui_surf.push_back(0);
+        ui_vol.push_back(0);
 
-        auto surface_offset
-            = host_data.unit_indexer_data.surfaces[AllVals{}].back();
-        auto volume_offset
-            = host_data.unit_indexer_data.volumes[AllVals{}].back();
+        auto get_num_surfaces = Overload{
+            [](UnitInput const& u) -> size_type { return u.surfaces.size(); },
+            [](RectArrayInput const&) -> size_type { return 0; }};
 
-        auto surfs = std::visit(get_num_surfaces, u);
-        auto vols = std::visit(get_num_volumes, u);
+        auto get_num_volumes = Overload{
+            [](UnitInput const& u) -> size_type { return u.volumes.size(); },
+            [](RectArrayInput const&) -> size_type { return 0; }};
 
-        ui_surf.push_back(surface_offset + surfs);
-        ui_vol.push_back(volume_offset + vols);
+        for (auto const& u : input.universes)
+        {
+            using AllVals = AllItems<size_type, MemSpace::native>;
+
+            auto surface_offset
+                = host_data.unit_indexer_data.surfaces[AllVals{}].back();
+            auto volume_offset
+                = host_data.unit_indexer_data.volumes[AllVals{}].back();
+
+            auto surfs = std::visit(get_num_surfaces, u);
+            auto vols = std::visit(get_num_volumes, u);
+
+            ui_surf.push_back(surface_offset + surfs);
+            ui_vol.push_back(volume_offset + vols);
+        }
     }
 
-    detail::UnitInserter insert_unit(&host_data);
-    detail::RectArrayInserter insert_rect_array(&host_data);
-
-    auto insert_universe = Overload{
-        [&insert_unit](UnitInput const& u) {
-            CELER_VALIDATE(u,
-                           << "simple unit '" << u.label
-                           << "' is not properly constructed");
-
-            insert_unit(u);
-        },
-        [&insert_rect_array](RectArrayInput const& r) {
-            CELER_VALIDATE(r,
-                           << "rect array '" << r.label
-                           << "' is not properly constructed");
-
-            insert_rect_array(r);
-        },
-    };
-
-    for (auto const& u : input.universes)
+    // Create universe_types and universe_indices vectors
     {
-        std::visit(insert_universe, u);
+        auto u_types_builder = make_builder(&host_data.universe_types);
+        auto u_indices_builder = make_builder(&host_data.universe_indices);
+
+        std::vector<size_type> current_indices(
+            static_cast<size_t>(UniverseType::size_), 0);
+
+        for (auto const& u : input.universes)
+        {
+            auto u_type_idx = u.index();
+            u_types_builder.push_back(static_cast<UniverseType>(u_type_idx));
+            u_indices_builder.push_back(current_indices[u_type_idx]++);
+        }
+    }
+
+    // Insert all universes
+    {
+        detail::UnitInserter insert_unit(&host_data);
+        detail::RectArrayInserter insert_rect_array(&host_data);
+
+        auto insert_universe = Overload{
+            [&insert_unit](UnitInput const& u) {
+                CELER_VALIDATE(u,
+                               << "simple unit '" << u.label
+                               << "' is not properly constructed");
+
+                insert_unit(u);
+            },
+            [&insert_rect_array](RectArrayInput const& r) {
+                CELER_VALIDATE(r,
+                               << "rect array '" << r.label
+                               << "' is not properly constructed");
+
+                insert_rect_array(r);
+            },
+        };
+
+        for (auto const& u : input.universes)
+        {
+            std::visit(insert_universe, u);
+        }
     }
 
     // Get surface/volume labels

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -16,7 +16,7 @@
 #include "OrangeTypes.hh"
 #include "Translator.hh"
 #include "detail/LevelStateAccessor.hh"
-#include "detail/UnitIndexer.hh"
+#include "detail/UniverseIndexer.hh"
 #include "univ/SimpleUnitTracker.hh"
 #include "univ/UniverseTypeTraits.hh"
 #include "univ/detail/Types.hh"
@@ -332,7 +332,7 @@ CELER_FUNCTION Real3 const& OrangeTrackView::dir() const
 CELER_FUNCTION VolumeId OrangeTrackView::volume_id() const
 {
     auto lsa = this->make_lsa();
-    detail::UnitIndexer ui(params_.unit_indexer_data);
+    detail::UniverseIndexer ui(params_.unit_indexer_data);
     return ui.global_volume(lsa.universe(), lsa.vol());
 }
 
@@ -346,7 +346,7 @@ CELER_FUNCTION SurfaceId OrangeTrackView::surface_id() const
     {
         auto lsa = this->make_lsa(this->surface_level());
         CELER_ASSERT(lsa.surf());
-        detail::UnitIndexer ui(params_.unit_indexer_data);
+        detail::UniverseIndexer ui(params_.unit_indexer_data);
         return ui.global_surface(lsa.universe(), lsa.surf());
     }
     else
@@ -485,7 +485,7 @@ CELER_FUNCTION void OrangeTrackView::move_to_boundary()
     this->surface_level() = this->next_surface_level();
 
     auto lsa = this->make_lsa(this->surface_level());
-    detail::UnitIndexer ui(params_.unit_indexer_data);
+    detail::UniverseIndexer ui(params_.unit_indexer_data);
     lsa.surf() = ui.local_surface(this->next_surface_id()).surface;
     lsa.sense() = this->next_surface().unchecked_sense();
 
@@ -676,7 +676,7 @@ CELER_FUNCTION void OrangeTrackView::set_dir(Real3 const& newdir)
         // dotted with the surface normal changes (i.e. heading from inside to
         // outside or vice versa).
         auto tracker = this->make_tracker(UniverseId{0});
-        detail::UnitIndexer ui(params_.unit_indexer_data);
+        detail::UniverseIndexer ui(params_.unit_indexer_data);
         const Real3 normal = tracker.normal(
             this->pos(), ui.local_surface(this->surface_id()).surface);
 
@@ -817,7 +817,7 @@ OrangeTrackView::find_next_step_impl(detail::Intersection isect)
     // If there is a valid next surface, convert it from local to global
     if (isect)
     {
-        detail::UnitIndexer ui(params_.unit_indexer_data);
+        detail::UniverseIndexer ui(params_.unit_indexer_data);
         this->next_surface() = celeritas::detail::OnSurface(
             ui.global_surface(this->make_lsa(min_level).universe(),
                               isect.surface.id()),

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -332,7 +332,7 @@ CELER_FUNCTION Real3 const& OrangeTrackView::dir() const
 CELER_FUNCTION VolumeId OrangeTrackView::volume_id() const
 {
     auto lsa = this->make_lsa();
-    detail::UniverseIndexer ui(params_.unit_indexer_data);
+    detail::UniverseIndexer ui(params_.universe_indexer_data);
     return ui.global_volume(lsa.universe(), lsa.vol());
 }
 
@@ -346,7 +346,7 @@ CELER_FUNCTION SurfaceId OrangeTrackView::surface_id() const
     {
         auto lsa = this->make_lsa(this->surface_level());
         CELER_ASSERT(lsa.surf());
-        detail::UniverseIndexer ui(params_.unit_indexer_data);
+        detail::UniverseIndexer ui(params_.universe_indexer_data);
         return ui.global_surface(lsa.universe(), lsa.surf());
     }
     else
@@ -485,7 +485,7 @@ CELER_FUNCTION void OrangeTrackView::move_to_boundary()
     this->surface_level() = this->next_surface_level();
 
     auto lsa = this->make_lsa(this->surface_level());
-    detail::UniverseIndexer ui(params_.unit_indexer_data);
+    detail::UniverseIndexer ui(params_.universe_indexer_data);
     lsa.surf() = ui.local_surface(this->next_surface_id()).surface;
     lsa.sense() = this->next_surface().unchecked_sense();
 
@@ -676,7 +676,7 @@ CELER_FUNCTION void OrangeTrackView::set_dir(Real3 const& newdir)
         // dotted with the surface normal changes (i.e. heading from inside to
         // outside or vice versa).
         auto tracker = this->make_tracker(UniverseId{0});
-        detail::UniverseIndexer ui(params_.unit_indexer_data);
+        detail::UniverseIndexer ui(params_.universe_indexer_data);
         const Real3 normal = tracker.normal(
             this->pos(), ui.local_surface(this->surface_id()).surface);
 
@@ -817,7 +817,7 @@ OrangeTrackView::find_next_step_impl(detail::Intersection isect)
     // If there is a valid next surface, convert it from local to global
     if (isect)
     {
-        detail::UniverseIndexer ui(params_.unit_indexer_data);
+        detail::UniverseIndexer ui(params_.universe_indexer_data);
         this->next_surface() = celeritas::detail::OnSurface(
             ui.global_surface(this->make_lsa(min_level).universe(),
                               isect.surface.id()),

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -131,6 +131,7 @@ enum class UniverseType : unsigned char
     dode_array,
     ...
 #endif
+    size_  //!< Sentinel value for number of universe types
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -137,9 +137,6 @@ struct OrangeInput
 {
     std::vector<std::variant<UnitInput, RectArrayInput>> universes;
 
-    std::vector<UniverseType> universe_types;
-    std::vector<size_type> universe_indices;
-
     // TODO: Calculate automatically in Shift by traversing the parent/daughter
     // tree
     size_type max_level = 3;

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -265,22 +265,15 @@ void from_json(nlohmann::json const& j, OrangeInput& value)
 
     value.universes.reserve(universes.size());
 
-    size_type simple_unit_index = 0;
-    size_type rect_array_index = 0;
-
     for (auto const& uni : universes)
     {
         auto uni_type = uni.at("_type").get<std::string>();
         if (uni_type == "simple unit")
         {
-            value.universe_types.push_back(UniverseType::simple);
-            value.universe_indices.push_back(simple_unit_index++);
             value.universes.push_back(uni.get<UnitInput>());
         }
         else if (uni_type == "rectangular array")
         {
-            value.universe_types.push_back(UniverseType::rect_array);
-            value.universe_indices.push_back(rect_array_index++);
             value.universes.push_back(uni.get<RectArrayInput>());
         }
         else if (uni_type == "hexagonal array")

--- a/src/orange/detail/UniverseIndexer.hh
+++ b/src/orange/detail/UniverseIndexer.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/UnitIndexer.hh
+//! \file orange/detail/UniverseIndexer.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -24,13 +24,13 @@ namespace detail
  *
  * Linearize the data in a UnitInput and add it to the host.
  */
-class UnitIndexer
+class UniverseIndexer
 {
   public:
     //!@{
     //! \name Type aliases
-    using UnitIndexerDataRef
-        = UnitIndexerData<Ownership::const_reference, MemSpace::native>;
+    using UniverseIndexerDataRef
+        = UniverseIndexerData<Ownership::const_reference, MemSpace::native>;
 
     struct LocalSurface
     {
@@ -46,8 +46,9 @@ class UnitIndexer
     //!@}
 
   public:
-    // Construct from UnitIndexerData
-    explicit inline CELER_FUNCTION UnitIndexer(UnitIndexerDataRef const& data);
+    // Construct from UniverseIndexerData
+    explicit inline CELER_FUNCTION
+    UniverseIndexer(UniverseIndexerDataRef const& data);
 
     // Local-to-global
     inline CELER_FUNCTION SurfaceId global_surface(UniverseId uni,
@@ -85,7 +86,7 @@ class UnitIndexer
     using SpanIter = Span<size_type const>::const_iterator;
 
     //// DATA ////
-    UnitIndexerDataRef data_;
+    UniverseIndexerDataRef data_;
 
     //// IMPLEMENTATION METHODS ////
     static inline CELER_FUNCTION SpanIter find_local(DataRef offsets,
@@ -96,9 +97,10 @@ class UnitIndexer
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct from UnitIndexerData.
+ * Construct from UniverseIndexerData.
  */
-CELER_FUNCTION UnitIndexer::UnitIndexer(UnitIndexerDataRef const& data)
+CELER_FUNCTION
+UniverseIndexer::UniverseIndexer(UniverseIndexerDataRef const& data)
     : data_(data)
 {
     CELER_EXPECT(data_.surfaces.size() == data_.volumes.size());
@@ -110,8 +112,8 @@ CELER_FUNCTION UnitIndexer::UnitIndexer(UnitIndexerDataRef const& data)
 /*!
  * Transform local to global surface ID.
  */
-CELER_FUNCTION SurfaceId UnitIndexer::global_surface(UniverseId uni,
-                                                     LocalSurfaceId surf) const
+CELER_FUNCTION SurfaceId
+UniverseIndexer::global_surface(UniverseId uni, LocalSurfaceId surf) const
 {
     CELER_EXPECT(uni < this->num_universes());
     CELER_EXPECT(surf < this->local_size(data_.surfaces, uni));
@@ -124,8 +126,8 @@ CELER_FUNCTION SurfaceId UnitIndexer::global_surface(UniverseId uni,
 /*!
  * Transform local to global volume ID.
  */
-CELER_FUNCTION VolumeId UnitIndexer::global_volume(UniverseId uni,
-                                                   LocalVolumeId volume) const
+CELER_FUNCTION VolumeId UniverseIndexer::global_volume(UniverseId uni,
+                                                       LocalVolumeId volume) const
 {
     CELER_EXPECT(uni < this->num_universes());
     CELER_EXPECT(volume < this->local_size(data_.volumes, uni));
@@ -138,8 +140,8 @@ CELER_FUNCTION VolumeId UnitIndexer::global_volume(UniverseId uni,
 /*!
  * Transform global to local surface ID.
  */
-CELER_FUNCTION UnitIndexer::LocalSurface
-UnitIndexer::local_surface(SurfaceId id) const
+CELER_FUNCTION UniverseIndexer::LocalSurface
+UniverseIndexer::local_surface(SurfaceId id) const
 {
     CELER_EXPECT(id < this->num_surfaces());
     auto iter = this->find_local(data_.surfaces, id.unchecked_get());
@@ -154,8 +156,8 @@ UnitIndexer::local_surface(SurfaceId id) const
 /*!
  * Transform global to local volume ID.
  */
-CELER_FUNCTION UnitIndexer::LocalVolume
-UnitIndexer::local_volume(VolumeId id) const
+CELER_FUNCTION UniverseIndexer::LocalVolume
+UniverseIndexer::local_volume(VolumeId id) const
 {
     CELER_EXPECT(id < this->num_volumes());
     auto iter = this->find_local(data_.volumes, id.unchecked_get());
@@ -172,8 +174,8 @@ UnitIndexer::local_volume(VolumeId id) const
 /*!
  * Locate the given ID in the list of offsets.
  */
-CELER_FUNCTION UnitIndexer::SpanIter
-UnitIndexer::find_local(DataRef offsets, size_type id)
+CELER_FUNCTION UniverseIndexer::SpanIter
+UniverseIndexer::find_local(DataRef offsets, size_type id)
 {
     CELER_EXPECT(id < offsets[SizeId{offsets.size() - 1}]);
 
@@ -193,8 +195,8 @@ UnitIndexer::find_local(DataRef offsets, size_type id)
 /*!
  * Get the number of elements in the given universe.
  */
-CELER_FUNCTION size_type UnitIndexer::local_size(DataRef offsets,
-                                                 UniverseId uni)
+CELER_FUNCTION size_type UniverseIndexer::local_size(DataRef offsets,
+                                                     UniverseId uni)
 {
     CELER_EXPECT(uni && uni.unchecked_get() + 1 < offsets.size());
     return offsets[SizeId{uni.unchecked_get() + 1}]

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -202,7 +202,7 @@ celeritas_add_test(orange/Orange.test.cc)
 celeritas_add_test(orange/Translator.test.cc)
 
 # Base detail
-celeritas_add_test(orange/detail/UnitIndexer.test.cc)
+celeritas_add_test(orange/detail/UniverseIndexer.test.cc)
 
 #-------------------------------------#
 # Surfaces

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -212,8 +212,6 @@ void NestedTest::build_orange()
     OrangeInput input;
     input.max_level = 1;
     input.universes.push_back(std::move(ui));
-    input.universe_types.push_back(celeritas::UniverseType::simple);
-    input.universe_indices.push_back(0);
     auto geo = std::make_shared<OrangeParams>(std::move(input));
 #if !CELERITAS_USE_VECGEOM
     geo_params_ = std::move(geo);

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -46,8 +46,6 @@ OrangeInput to_input(UnitInput u)
 {
     OrangeInput result;
     result.universes.push_back(std::move(u));
-    result.universe_types.push_back(celeritas::UniverseType::simple);
-    result.universe_indices.push_back(0);
     return result;
 }
 

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -18,7 +18,7 @@
 #include "orange/Types.hh"
 #include "orange/construct/OrangeInput.hh"
 #include "orange/construct/SurfaceInputBuilder.hh"
-#include "orange/detail/UnitIndexer.hh"
+#include "orange/detail/UniverseIndexer.hh"
 #include "orange/surf/Sphere.hh"
 #include "orange/surf/SurfaceAction.hh"
 #include "orange/surf/SurfaceIO.hh"
@@ -286,7 +286,7 @@ OrangeGeoTestBase::id_to_label(UniverseId uid, LocalSurfaceId surfid) const
     if (!surfid)
         return "[none]";
 
-    detail::UnitIndexer ui(this->params().host_ref().unit_indexer_data);
+    detail::UniverseIndexer ui(this->params().host_ref().unit_indexer_data);
     return params_->id_to_label(ui.global_surface(uid, surfid)).name;
 }
 
@@ -309,7 +309,7 @@ OrangeGeoTestBase::id_to_label(UniverseId uid, LocalVolumeId volid) const
     if (!volid)
         return "[none]";
 
-    detail::UnitIndexer ui(this->params().host_ref().unit_indexer_data);
+    detail::UniverseIndexer ui(this->params().host_ref().unit_indexer_data);
     return params_->id_to_label(ui.global_volume(uid, volid)).name;
 }
 

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -286,7 +286,7 @@ OrangeGeoTestBase::id_to_label(UniverseId uid, LocalSurfaceId surfid) const
     if (!surfid)
         return "[none]";
 
-    detail::UniverseIndexer ui(this->params().host_ref().unit_indexer_data);
+    detail::UniverseIndexer ui(this->params().host_ref().universe_indexer_data);
     return params_->id_to_label(ui.global_surface(uid, surfid)).name;
 }
 
@@ -309,7 +309,7 @@ OrangeGeoTestBase::id_to_label(UniverseId uid, LocalVolumeId volid) const
     if (!volid)
         return "[none]";
 
-    detail::UniverseIndexer ui(this->params().host_ref().unit_indexer_data);
+    detail::UniverseIndexer ui(this->params().host_ref().universe_indexer_data);
     return params_->id_to_label(ui.global_volume(uid, volid)).name;
 }
 

--- a/test/orange/detail/UniverseIndexer.test.cc
+++ b/test/orange/detail/UniverseIndexer.test.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/UnitIndexer.test.cc
+//! \file orange/detail/UniverseIndexer.test.cc
 //---------------------------------------------------------------------------//
-#include "orange/detail/UnitIndexer.hh"
+#include "orange/detail/UniverseIndexer.hh"
 
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/CollectionMirror.hh"
@@ -13,24 +13,24 @@
 
 #include "celeritas_test.hh"
 
-using UnitIndexer = celeritas::detail::UnitIndexer;
+using UniverseIndexer = celeritas::detail::UniverseIndexer;
 
 namespace celeritas
 {
 namespace test
 {
-class UnitIndexerTest : public Test
+class UniverseIndexerTest : public Test
 {
   public:
     using CollectionHostRef
-        = UnitIndexerData<Ownership::const_reference, MemSpace::host>;
+        = UniverseIndexerData<Ownership::const_reference, MemSpace::host>;
     using VecSize = std::vector<size_type>;
 
     CollectionHostRef const& host_ref() const { return data_.host(); }
 
     void set_data(VecSize surfaces, VecSize volumes)
     {
-        UnitIndexerData<Ownership::value, MemSpace::host> data;
+        UniverseIndexerData<Ownership::value, MemSpace::host> data;
 
         auto cb_s = make_builder(&data.surfaces);
         cb_s.insert_back(surfaces.begin(), surfaces.end());
@@ -38,19 +38,19 @@ class UnitIndexerTest : public Test
         auto cb_v = make_builder(&data.volumes);
         cb_v.insert_back(volumes.begin(), volumes.end());
 
-        data_ = CollectionMirror<UnitIndexerData>{std::move(data)};
+        data_ = CollectionMirror<UniverseIndexerData>{std::move(data)};
     }
 
   protected:
-    CollectionMirror<UnitIndexerData> data_;
+    CollectionMirror<UniverseIndexerData> data_;
 };
 
 //---------------------------------------------------------------------------//
 
-TEST_F(UnitIndexerTest, single)
+TEST_F(UniverseIndexerTest, single)
 {
     this->set_data({0, 4}, {0, 10});
-    UnitIndexer indexer(this->host_ref());
+    UniverseIndexer indexer(this->host_ref());
 
     EXPECT_EQ(1, indexer.num_universes());
     EXPECT_EQ(4, indexer.num_surfaces());
@@ -81,10 +81,10 @@ TEST_F(UnitIndexerTest, single)
     EXPECT_EQ(LocalVolumeId(3), local_v.volume);
 }
 
-TEST_F(UnitIndexerTest, TEST_IF_CELERITAS_DEBUG(errors))
+TEST_F(UniverseIndexerTest, TEST_IF_CELERITAS_DEBUG(errors))
 {
     this->set_data({0, 4}, {0, 10});
-    UnitIndexer indexer(this->host_ref());
+    UniverseIndexer indexer(this->host_ref());
 
     EXPECT_THROW(indexer.global_surface(UniverseId{0}, LocalSurfaceId{4}),
                  DebugError);
@@ -99,7 +99,7 @@ TEST_F(UnitIndexerTest, TEST_IF_CELERITAS_DEBUG(errors))
     EXPECT_THROW(indexer.local_volume(VolumeId(10)), DebugError);
 }
 
-TEST_F(UnitIndexerTest, multi)
+TEST_F(UniverseIndexerTest, multi)
 {
     // One universe has zero surfaces
     const std::vector<size_type> surfaces_per_uni{4, 1, 0, 1};
@@ -109,7 +109,7 @@ TEST_F(UnitIndexerTest, multi)
     std::vector<size_type> volumes = {0, 1, 2, 3, 5};
 
     this->set_data(surfaces, volumes);
-    UnitIndexer indexer(this->host_ref());
+    UniverseIndexer indexer(this->host_ref());
 
     EXPECT_EQ(6, indexer.num_surfaces());
     EXPECT_EQ(5, indexer.num_volumes());

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -161,7 +161,7 @@ LocalState
 SimpleUnitTrackerTest::make_state(Real3 pos, Real3 dir, char const* vol)
 {
     LocalState state = this->make_state(pos, dir);
-    detail::UniverseIndexer ui(this->host_params().unit_indexer_data);
+    detail::UniverseIndexer ui(this->host_params().universe_indexer_data);
     state.volume = ui.local_volume(this->find_volume(vol)).volume;
     return state;
 }
@@ -190,7 +190,7 @@ LocalState SimpleUnitTrackerTest::make_state(
     }
 
     LocalState state = this->make_state(pos, dir);
-    detail::UniverseIndexer ui(this->host_params().unit_indexer_data);
+    detail::UniverseIndexer ui(this->host_params().universe_indexer_data);
     state.volume = ui.local_volume(this->find_volume(vol)).volume;
     // *Intentionally* flip the sense because we're looking for the
     // post-crossing volume. This is normally done by the multi-level
@@ -396,7 +396,7 @@ TEST_F(OneVolumeTest, intersect)
 TEST_F(OneVolumeTest, safety)
 {
     SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
-    detail::UniverseIndexer ui(this->host_params().unit_indexer_data);
+    detail::UniverseIndexer ui(this->host_params().universe_indexer_data);
 
     EXPECT_SOFT_EQ(
         inf,
@@ -587,7 +587,7 @@ TEST_F(TwoVolumeTest, intersect)
 TEST_F(TwoVolumeTest, safety)
 {
     SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
-    detail::UniverseIndexer ui(this->host_params().unit_indexer_data);
+    detail::UniverseIndexer ui(this->host_params().universe_indexer_data);
     LocalVolumeId outside
         = ui.local_volume(this->find_volume("outside")).volume;
     LocalVolumeId inside = ui.local_volume(this->find_volume("inside")).volume;
@@ -922,7 +922,7 @@ TEST_F(FiveVolumesTest, intersect)
 TEST_F(FiveVolumesTest, safety)
 {
     SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
-    detail::UniverseIndexer ui(this->host_params().unit_indexer_data);
+    detail::UniverseIndexer ui(this->host_params().universe_indexer_data);
     LocalVolumeId a = ui.local_volume(this->find_volume("a")).volume;
     LocalVolumeId d = ui.local_volume(this->find_volume("d")).volume;
 

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -19,7 +19,7 @@
 #include "corecel/sys/Stopwatch.hh"
 #include "orange/OrangeGeoTestBase.hh"
 #include "orange/OrangeParams.hh"
-#include "orange/detail/UnitIndexer.hh"
+#include "orange/detail/UniverseIndexer.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/random/distribution/IsotropicDistribution.hh"
 #include "celeritas/random/distribution/UniformBoxDistribution.hh"
@@ -161,7 +161,7 @@ LocalState
 SimpleUnitTrackerTest::make_state(Real3 pos, Real3 dir, char const* vol)
 {
     LocalState state = this->make_state(pos, dir);
-    detail::UnitIndexer ui(this->host_params().unit_indexer_data);
+    detail::UniverseIndexer ui(this->host_params().unit_indexer_data);
     state.volume = ui.local_volume(this->find_volume(vol)).volume;
     return state;
 }
@@ -190,7 +190,7 @@ LocalState SimpleUnitTrackerTest::make_state(
     }
 
     LocalState state = this->make_state(pos, dir);
-    detail::UnitIndexer ui(this->host_params().unit_indexer_data);
+    detail::UniverseIndexer ui(this->host_params().unit_indexer_data);
     state.volume = ui.local_volume(this->find_volume(vol)).volume;
     // *Intentionally* flip the sense because we're looking for the
     // post-crossing volume. This is normally done by the multi-level
@@ -396,7 +396,7 @@ TEST_F(OneVolumeTest, intersect)
 TEST_F(OneVolumeTest, safety)
 {
     SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
-    detail::UnitIndexer ui(this->host_params().unit_indexer_data);
+    detail::UniverseIndexer ui(this->host_params().unit_indexer_data);
 
     EXPECT_SOFT_EQ(
         inf,
@@ -587,7 +587,7 @@ TEST_F(TwoVolumeTest, intersect)
 TEST_F(TwoVolumeTest, safety)
 {
     SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
-    detail::UnitIndexer ui(this->host_params().unit_indexer_data);
+    detail::UniverseIndexer ui(this->host_params().unit_indexer_data);
     LocalVolumeId outside
         = ui.local_volume(this->find_volume("outside")).volume;
     LocalVolumeId inside = ui.local_volume(this->find_volume("inside")).volume;
@@ -922,7 +922,7 @@ TEST_F(FiveVolumesTest, intersect)
 TEST_F(FiveVolumesTest, safety)
 {
     SimpleUnitTracker tracker(this->host_params(), SimpleUnitId{0});
-    detail::UnitIndexer ui(this->host_params().unit_indexer_data);
+    detail::UniverseIndexer ui(this->host_params().unit_indexer_data);
     LocalVolumeId a = ui.local_volume(this->find_volume("a")).volume;
     LocalVolumeId d = ui.local_volume(this->find_volume("d")).volume;
 


### PR DESCRIPTION
This PR consists of two changes:

1) The `universe_types` and `universe_indices` vectors are now calculated within ORANGE, rather than requiring them as part of `OrangeInput`, as this information has been made redundant by the vector of universe input variants.

2) UnitIndexer has been renamed UniverseIndexer. Surface and Volume offsets from RectArray universes are now accounted for. 