### PR TITLE
Sort track slots by step limit `ActionId`

### DIFF
--- a/app/demo-loop/LDemoIO.hh
+++ b/app/demo-loop/LDemoIO.hh
@@ -30,11 +30,12 @@ namespace celeritas
 class OutputRegistry;
 class CoreParams;
 
-NLOHMANN_JSON_SERIALIZE_ENUM(TrackOrder,
-                             {{TrackOrder::unsorted, "unsorted"},
-                              {TrackOrder::shuffled, "shuffled"},
-                              {TrackOrder::partition_status,
-                               "partition-status"}})
+NLOHMANN_JSON_SERIALIZE_ENUM(
+    TrackOrder,
+    {{TrackOrder::unsorted, "unsorted"},
+     {TrackOrder::shuffled, "shuffled"},
+     {TrackOrder::partition_status, "partition-status"},
+     {TrackOrder::sort_step_limit_action, "action-id"}})
 }
 
 namespace demo_loop

--- a/src/celeritas/Types.cc
+++ b/src/celeritas/Types.cc
@@ -34,8 +34,8 @@ char const* to_cstring(ActionOrder value)
 {
     static EnumStringMapper<ActionOrder> const to_cstring_impl{
         "start",
-        "sort_start",
         "pre",
+        "sort_start",
         "along",
         "pre_post",
         "post",

--- a/src/celeritas/Types.cc
+++ b/src/celeritas/Types.cc
@@ -34,8 +34,9 @@ char const* to_cstring(ActionOrder value)
 {
     static EnumStringMapper<ActionOrder> const to_cstring_impl{
         "start",
-        "pre",
         "sort_start",
+        "pre",
+        "sort_pre",
         "along",
         "pre_post",
         "post",

--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -105,8 +105,9 @@ enum class TrackStatus : std::int_least8_t
 enum class ActionOrder
 {
     start,  //!< Initialize tracks
-    pre,  //!< Pre-step physics and setup
     sort_start,  //!< Sort track slots for GPU optimization
+    pre,  //!< Pre-step physics and setup
+    sort_pre,  //!< Sort track slots for GPU optimization
     along,  //!< Along-step
     pre_post,  //!< Discrete selection kernel
     post,  //!< After step

--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -105,8 +105,8 @@ enum class TrackStatus : std::int_least8_t
 enum class ActionOrder
 {
     start,  //!< Initialize tracks
-    sort_start,  //!< Sort track slots for GPU optimization
     pre,  //!< Pre-step physics and setup
+    sort_start,  //!< Sort track slots for GPU optimization
     along,  //!< Along-step
     pre_post,  //!< Discrete selection kernel
     post,  //!< After step
@@ -132,6 +132,7 @@ enum class TrackOrder
     shuffled,  //!< Tracks are shuffled at the start ot the simulation
     partition_status,  //!< Tracks are partitioned by status at the start of
                        //!< each step
+    sort_step_limit_action,  //!< Sort by the step limit action id.
     size_
 };
 

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -157,24 +157,29 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
     input_.action_reg->insert(std::make_shared<InitializeTracksAction>(
         input_.action_reg->next_id()));
 
-    if (input_.init->host_ref().track_order == TrackOrder::partition_status)
-    {
-        // Construct sort tracks action for start-step
+    // TrackOrder doesn't have to be an argument right now and could be
+    // captured but we're eventually expecting different TrackOrder for
+    // different ActionOrder
+    auto insert_sort_tracks_action = [this](const ActionOrder action_order,
+                                            const TrackOrder track_order) {
         input_.action_reg->insert(std::make_shared<SortTracksAction>(
-            input_.action_reg->next_id(),
-            ActionOrder::sort_start,
-            input_.init->host_ref().track_order));
+            input_.action_reg->next_id(), action_order, track_order));
+    };
+    const TrackOrder track_order{input_.init->host_ref().track_order};
+    switch (track_order)
+    {
+        case TrackOrder::partition_status:
+            // Construct sort tracks action for start-step
+            insert_sort_tracks_action(ActionOrder::sort_start, track_order);
+            break;
+        case TrackOrder::sort_step_limit_action:
+            // Construct sort tracks action for pre-step
+            insert_sort_tracks_action(ActionOrder::sort_pre, track_order);
+            break;
+        default:
+            break;
     }
 
-    if (input_.init->host_ref().track_order
-        == TrackOrder::sort_step_limit_action)
-    {
-        // Construct sort tracks action for pre-step
-        input_.action_reg->insert(std::make_shared<SortTracksAction>(
-            input_.action_reg->next_id(),
-            ActionOrder::sort_pre,
-            input_.init->host_ref().track_order));
-    }
     // Construct extend from secondaries action
     input_.action_reg->insert(std::make_shared<ExtendFromSecondariesAction>(
         input_.action_reg->next_id()));

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -157,12 +157,24 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
     input_.action_reg->insert(std::make_shared<InitializeTracksAction>(
         input_.action_reg->next_id()));
 
-    // Construct sort tracks action
-    input_.action_reg->insert(std::make_shared<SortTracksAction>(
-        input_.action_reg->next_id(),
-        ActionOrder::sort_start,
-        input_.init->host_ref().track_order));
+    if (input_.init->host_ref().track_order == TrackOrder::partition_status)
+    {
+        // Construct sort tracks action for start-step
+        input_.action_reg->insert(std::make_shared<SortTracksAction>(
+            input_.action_reg->next_id(),
+            ActionOrder::sort_start,
+            input_.init->host_ref().track_order));
+    }
 
+    if (input_.init->host_ref().track_order
+        == TrackOrder::sort_step_limit_action)
+    {
+        // Construct sort tracks action for pre-step
+        input_.action_reg->insert(std::make_shared<SortTracksAction>(
+            input_.action_reg->next_id(),
+            ActionOrder::sort_pre,
+            input_.init->host_ref().track_order));
+    }
     // Construct extend from secondaries action
     input_.action_reg->insert(std::make_shared<ExtendFromSecondariesAction>(
         input_.action_reg->next_id()));

--- a/src/celeritas/track/SortTracksAction.cc
+++ b/src/celeritas/track/SortTracksAction.cc
@@ -35,9 +35,16 @@ std::string SortTracksAction::label() const
 void SortTracksAction::execute(ParamsHostCRef const&,
                                StateHostRef& states) const
 {
-    if (track_order_ == TrackOrder::partition_status)
+    switch (track_order_)
     {
-        detail::partition_tracks_by_status(states);
+        case TrackOrder::partition_status:
+            detail::partition_tracks_by_status(states);
+            break;
+        case TrackOrder::sort_step_limit_action:
+            detail::sort_tracks_by_action_id(states);
+            break;
+        default:
+            break;
     }
 }
 
@@ -48,9 +55,16 @@ void SortTracksAction::execute(ParamsHostCRef const&,
 void SortTracksAction::execute(ParamsDeviceCRef const&,
                                StateDeviceRef& states) const
 {
-    if (track_order_ == TrackOrder::partition_status)
+    switch (track_order_)
     {
-        detail::partition_tracks_by_status(states);
+        case TrackOrder::partition_status:
+            detail::partition_tracks_by_status(states);
+            break;
+        case TrackOrder::sort_step_limit_action:
+            detail::sort_tracks_by_action_id(states);
+            break;
+        default:
+            break;
     }
 }
 

--- a/src/celeritas/track/SortTracksAction.cc
+++ b/src/celeritas/track/SortTracksAction.cc
@@ -32,28 +32,26 @@ std::string SortTracksAction::label() const
 /*!
  * Execute the action with host data
  */
-void SortTracksAction::execute(ParamsHostCRef const&,
+void SortTracksAction::execute(ParamsHostCRef const& params,
                                StateHostRef& states) const
 {
-    switch (track_order_)
-    {
-        case TrackOrder::partition_status:
-            detail::partition_tracks_by_status(states);
-            break;
-        case TrackOrder::sort_step_limit_action:
-            detail::sort_tracks_by_action_id(states);
-            break;
-        default:
-            break;
-    }
+    execute_impl(params, states);
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Execute the action with device data
  */
-void SortTracksAction::execute(ParamsDeviceCRef const&,
+void SortTracksAction::execute(ParamsDeviceCRef const& params,
                                StateDeviceRef& states) const
+{
+    execute_impl(params, states);
+}
+
+template<MemSpace M>
+void SortTracksAction::execute_impl(
+    CoreParamsData<Ownership::const_reference, M> const&,
+    CoreStateData<Ownership::reference, M>& states) const
 {
     switch (track_order_)
     {
@@ -63,7 +61,10 @@ void SortTracksAction::execute(ParamsDeviceCRef const&,
         case TrackOrder::sort_step_limit_action:
             detail::sort_tracks_by_action_id(states);
             break;
-        default:
+        // TODO: Do not instantiate the action in the first place and check
+        // here with CELER_ASSERT_UNREACHABLE()
+        case TrackOrder::shuffled:
+        case TrackOrder::unsorted:
             break;
     }
 }

--- a/src/celeritas/track/SortTracksAction.cc
+++ b/src/celeritas/track/SortTracksAction.cc
@@ -24,6 +24,8 @@ std::string SortTracksAction::label() const
     {
         case ActionOrder::sort_start:
             return "sort-tracks-start";
+        case ActionOrder::sort_pre:
+            return "sort-tracks-pre";
         default:
             return "sort-tracks";
     }
@@ -61,11 +63,8 @@ void SortTracksAction::execute_impl(
         case TrackOrder::sort_step_limit_action:
             detail::sort_tracks_by_action_id(states);
             break;
-        // TODO: Do not instantiate the action in the first place and check
-        // here with CELER_ASSERT_UNREACHABLE()
-        case TrackOrder::shuffled:
-        case TrackOrder::unsorted:
-            break;
+        default:
+            CELER_ASSERT_UNREACHABLE();
     }
 }
 

--- a/src/celeritas/track/SortTracksAction.hh
+++ b/src/celeritas/track/SortTracksAction.hh
@@ -54,6 +54,11 @@ class SortTracksAction final : public ExplicitActionInterface
     ActionOrder order() const final { return action_order_; }
 
   private:
+    template<MemSpace M>
+    void
+    execute_impl(CoreParamsData<Ownership::const_reference, M> const& params,
+                 CoreStateData<Ownership::reference, M>& states) const;
+
     ActionId id_;
     ActionOrder action_order_;
     TrackOrder track_order_;

--- a/src/celeritas/track/detail/TrackSortUtils.cc
+++ b/src/celeritas/track/detail/TrackSortUtils.cc
@@ -38,7 +38,6 @@ void shuffle_track_slots<MemSpace::host>(Span<TrackSlotId::size_type> track_slot
     std::shuffle(track_slots.begin(), track_slots.end(), g);
 }
 
-template<>
 void partition_tracks_by_status(
     CoreStateData<Ownership::reference, MemSpace::host> const& states)
 {
@@ -53,7 +52,6 @@ void partition_tracks_by_status(
                    });
 }
 
-template<>
 void sort_tracks_by_action_id(
     CoreStateData<Ownership::reference, MemSpace::host> const& states)
 {

--- a/src/celeritas/track/detail/TrackSortUtils.cc
+++ b/src/celeritas/track/detail/TrackSortUtils.cc
@@ -57,6 +57,16 @@ template<>
 void sort_tracks_by_action_id(
     CoreStateData<Ownership::reference, MemSpace::host> const& states)
 {
+    CELER_EXPECT(states.size() > 0);
+    Span track_slots{
+        states.track_slots[AllItems<TrackSlotId::size_type, MemSpace::host>{}]};
+    std::sort(
+        track_slots.begin(),
+        track_slots.end(),
+        [&step_limit = states.sim.step_limit](auto const& a, auto const& b) {
+            return step_limit[TrackSlotId{a}].action
+                   < step_limit[TrackSlotId{b}].action;
+        });
 }
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/track/detail/TrackSortUtils.cc
+++ b/src/celeritas/track/detail/TrackSortUtils.cc
@@ -52,6 +52,12 @@ void partition_tracks_by_status(
                               == TrackStatus::alive;
                    });
 }
+
+template<>
+void sort_tracks_by_action_id(
+    CoreStateData<Ownership::reference, MemSpace::host> const& states)
+{
+}
 //---------------------------------------------------------------------------//
 }  // namespace detail
 }  // namespace celeritas

--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -88,7 +88,6 @@ struct step_limit_comparator
 
 }  // namespace
 
-template<>
 void partition_tracks_by_status(
     CoreStateData<Ownership::reference, MemSpace::device> const& states)
 {
@@ -104,7 +103,6 @@ void partition_tracks_by_status(
     CELER_DEVICE_CHECK_ERROR();
 }
 
-template<>
 void sort_tracks_by_action_id(
     CoreStateData<Ownership::reference, MemSpace::device> const& states)
 {

--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -85,6 +85,12 @@ void partition_tracks_by_status(
             states.sim.status[AllItems<TrackStatus, MemSpace::device>{}]});
     CELER_DEVICE_CHECK_ERROR();
 }
+
+template<>
+void sort_tracks_by_action_id(
+    CoreStateData<Ownership::reference, MemSpace::device> const& states)
+{
+}
 //---------------------------------------------------------------------------//
 }  // namespace detail
 }  // namespace celeritas

--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -14,6 +14,7 @@
 #include <thrust/random.h>
 #include <thrust/sequence.h>
 #include <thrust/shuffle.h>
+#include <thrust/sort.h>
 
 #include "corecel/Macros.hh"
 #include "corecel/data/Collection.hh"
@@ -68,6 +69,23 @@ struct alive_predicate
         return status_[track_slot] == TrackStatus::alive;
     }
 };
+
+struct step_limit_comparator
+{
+    using SpanT = Span<StepLimit>;
+    SpanT step_limit_;
+
+    CELER_FUNCTION explicit step_limit_comparator(SpanT step_limit)
+        : step_limit_{step_limit}
+    {
+    }
+    CELER_FUNCTION bool operator()(TrackSlotId::size_type const& a,
+                                   TrackSlotId::size_type const& b) const
+    {
+        return step_limit_[a].action < step_limit_[b].action;
+    }
+};
+
 }  // namespace
 
 template<>
@@ -90,6 +108,16 @@ template<>
 void sort_tracks_by_action_id(
     CoreStateData<Ownership::reference, MemSpace::device> const& states)
 {
+    CELER_EXPECT(states.size() > 0);
+    Span track_slots{
+        states.track_slots[AllItems<TrackSlotId::size_type, MemSpace::device>{}]};
+    thrust::sort(
+        thrust::device,
+        thrust::device_pointer_cast(track_slots.begin()),
+        thrust::device_pointer_cast(track_slots.end()),
+        step_limit_comparator{
+            states.sim.step_limit[AllItems<StepLimit, MemSpace::device>{}]});
+    CELER_DEVICE_CHECK_ERROR();
 }
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/track/detail/TrackSortUtils.hh
+++ b/src/celeritas/track/detail/TrackSortUtils.hh
@@ -50,24 +50,18 @@ void shuffle_track_slots<MemSpace::device>(
 
 //---------------------------------------------------------------------------//
 // Sort tracks
-template<MemSpace M>
-void partition_tracks_by_status(
-    CoreStateData<Ownership::reference, M> const& states);
-template<>
+
 void partition_tracks_by_status(
     CoreStateData<Ownership::reference, MemSpace::host> const& states);
-template<>
+
 void partition_tracks_by_status(
     CoreStateData<Ownership::reference, MemSpace::device> const& states);
 
 //---------------------------------------------------------------------------//
-template<MemSpace M>
-void sort_tracks_by_action_id(
-    CoreStateData<Ownership::reference, M> const& states);
-template<>
+
 void sort_tracks_by_action_id(
     CoreStateData<Ownership::reference, MemSpace::host> const& states);
-template<>
+
 void sort_tracks_by_action_id(
     CoreStateData<Ownership::reference, MemSpace::device> const& states);
 
@@ -87,14 +81,12 @@ inline void shuffle_track_slots<MemSpace::device>(Span<TrackSlotId::size_type>)
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }
 
-template<>
 inline void partition_tracks_by_status(
     CoreStateData<Ownership::reference, MemSpace::device> const&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }
 
-template<>
 inline void sort_tracks_by_action_id(
     CoreStateData<Ownership::reference, MemSpace::device> const&)
 {

--- a/src/celeritas/track/detail/TrackSortUtils.hh
+++ b/src/celeritas/track/detail/TrackSortUtils.hh
@@ -61,6 +61,17 @@ void partition_tracks_by_status(
     CoreStateData<Ownership::reference, MemSpace::device> const& states);
 
 //---------------------------------------------------------------------------//
+template<MemSpace M>
+void sort_tracks_by_action_id(
+    CoreStateData<Ownership::reference, M> const& states);
+template<>
+void sort_tracks_by_action_id(
+    CoreStateData<Ownership::reference, MemSpace::host> const& states);
+template<>
+void sort_tracks_by_action_id(
+    CoreStateData<Ownership::reference, MemSpace::device> const& states);
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 #if !CELER_USE_DEVICE
@@ -78,6 +89,13 @@ inline void shuffle_track_slots<MemSpace::device>(Span<TrackSlotId::size_type>)
 
 template<>
 inline void partition_tracks_by_status(
+    CoreStateData<Ownership::reference, MemSpace::device> const&)
+{
+    CELER_NOT_CONFIGURED("CUDA or HIP");
+}
+
+template<>
+inline void sort_tracks_by_action_id(
     CoreStateData<Ownership::reference, MemSpace::device> const&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -175,8 +175,8 @@ TEST_F(TestEm3NoMsc, setup)
     EXPECT_VEC_EQ(expected_processes, result.processes);
     static char const* const expected_actions[] = {
         "initialize-tracks",
-        "sort-tracks-start",
         "pre-step",
+        "sort-tracks-start",
         "along-step-general-linear",
         "physics-discrete-select",
         "scat-klein-nishina",
@@ -310,8 +310,8 @@ TEST_F(TestEm3Msc, setup)
     EXPECT_VEC_EQ(expected_processes, result.processes);
     static char const* const expected_actions[] = {
         "initialize-tracks",
-        "sort-tracks-start",
         "pre-step",
+        "sort-tracks-start",
         "along-step-general-linear",
         "physics-discrete-select",
         "scat-klein-nishina",
@@ -477,8 +477,8 @@ TEST_F(TestEm15MscField, setup)
     EXPECT_VEC_EQ(expected_processes, result.processes);
     static char const* const expected_actions[] = {
         "initialize-tracks",
-        "sort-tracks-start",
         "pre-step",
+        "sort-tracks-start",
         "along-step-uniform-msc",
         "physics-discrete-select",
         "scat-klein-nishina",
@@ -581,8 +581,8 @@ TEST_F(OneSteelSphere, setup)
     EXPECT_VEC_EQ(expected_processes, result.processes);
     static char const* const expected_actions[] = {
         "initialize-tracks",
-        "sort-tracks-start",
         "pre-step",
+        "sort-tracks-start",
         "along-step-general-linear",
         "physics-discrete-select",
         "scat-klein-nishina",

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -176,7 +176,6 @@ TEST_F(TestEm3NoMsc, setup)
     static char const* const expected_actions[] = {
         "initialize-tracks",
         "pre-step",
-        "sort-tracks-start",
         "along-step-general-linear",
         "physics-discrete-select",
         "scat-klein-nishina",
@@ -311,7 +310,6 @@ TEST_F(TestEm3Msc, setup)
     static char const* const expected_actions[] = {
         "initialize-tracks",
         "pre-step",
-        "sort-tracks-start",
         "along-step-general-linear",
         "physics-discrete-select",
         "scat-klein-nishina",
@@ -478,7 +476,6 @@ TEST_F(TestEm15MscField, setup)
     static char const* const expected_actions[] = {
         "initialize-tracks",
         "pre-step",
-        "sort-tracks-start",
         "along-step-uniform-msc",
         "physics-discrete-select",
         "scat-klein-nishina",
@@ -582,7 +579,6 @@ TEST_F(OneSteelSphere, setup)
     static char const* const expected_actions[] = {
         "initialize-tracks",
         "pre-step",
-        "sort-tracks-start",
         "along-step-general-linear",
         "physics-discrete-select",
         "scat-klein-nishina",

--- a/test/celeritas/track/TrackSort.test.cc
+++ b/test/celeritas/track/TrackSort.test.cc
@@ -23,6 +23,9 @@ namespace celeritas
 {
 namespace test
 {
+//---------------------------------------------------------------------------//
+// TEST HARNESS
+//---------------------------------------------------------------------------//
 
 using celeritas::units::MevEnergy;
 
@@ -41,6 +44,25 @@ class TestTrackPartitionEm3Stepper : public TestEm3NoMsc
     }
 };
 
+#define TestTrackSortActionIdEm3Stepper \
+    TEST_IF_CELERITAS_GEANT(TestTrackSortActionIdEm3Stepper)
+class TestTrackSortActionIdEm3Stepper : public TestEm3NoMsc
+{
+  protected:
+    auto build_init() -> SPConstTrackInit override
+    {
+        TrackInitParams::Input input;
+        input.capacity = 4096;
+        input.max_events = 4096;
+        input.track_order = TrackOrder::sort_step_limit_action;
+        return std::make_shared<TrackInitParams>(input);
+    }
+};
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
 TEST_F(TestTrackPartitionEm3Stepper, host_is_partitioned)
 {
     size_type num_primaries = 8;
@@ -51,7 +73,7 @@ TEST_F(TestTrackPartitionEm3Stepper, host_is_partitioned)
     // Initialize some primaries and take a step
     auto primaries = this->make_primaries(num_primaries);
     step(make_span(primaries));
-    auto check_is_partitioned = [&step]() {
+    auto check_is_partitioned = [&step] {
         auto span = step.core_data()
                         .states.track_slots[AllItems<TrackSlotId::size_type>{}];
         return std::is_partitioned(
@@ -93,7 +115,7 @@ TEST_F(TestTrackPartitionEm3Stepper,
     // Initialize some primaries and take a step
     auto primaries = this->make_primaries(num_primaries);
     step(make_span(primaries));
-    auto check_is_partitioned = [&step]() {
+    auto check_is_partitioned = [&step] {
         // copy to host
         auto core_ref = step.core_data();
         Collection<TrackSlotId::size_type, Ownership::value, MemSpace::host, ThreadId>
@@ -125,6 +147,97 @@ TEST_F(TestTrackPartitionEm3Stepper,
         detail::partition_tracks_by_status(step.core_data().states);
         EXPECT_TRUE(check_is_partitioned()) << "Track slots are not "
                                                "partitioned by status";
+        step();
+    }
+}
+
+TEST_F(TestTrackSortActionIdEm3Stepper, host_is_sorted)
+{
+    size_type num_primaries = 8;
+    size_type num_tracks = 128;
+
+    Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
+
+    // Initialize some primaries and take a step
+    auto primaries = this->make_primaries(num_primaries);
+    step(make_span(primaries));
+    auto check_is_sorted = [&step] {
+        auto& step_limit = step.core_data().states.sim.step_limit;
+        for (celeritas::size_type i = 0;
+             i < step.core_data().states.track_slots.size() - 1;
+             ++i)
+        {
+            TrackSlotId tid_current{
+                step.core_data().states.track_slots[ThreadId{i}]},
+                tid_next{step.core_data().states.track_slots[ThreadId{i + 1}]};
+            ActionId::size_type aid_current{
+                step_limit[tid_current].action.unchecked_get()},
+                aid_next{step_limit[tid_next].action.unchecked_get()};
+            EXPECT_TRUE(aid_current <= aid_next)
+                << aid_current << " is larger than " << aid_next;
+        }
+    };
+    // A step can change the step-limit action, so we need to redo the sorting
+    // after taking a step.
+    for (auto i = 0; i < 10; ++i)
+    {
+        detail::sort_tracks_by_action_id(step.core_data().states);
+        check_is_sorted();
+        step();
+    }
+    step(make_span(primaries));
+    for (auto i = 0; i < 10; ++i)
+    {
+        detail::sort_tracks_by_action_id(step.core_data().states);
+        check_is_sorted();
+        step();
+    }
+}
+
+TEST_F(TestTrackSortActionIdEm3Stepper, TEST_IF_CELER_DEVICE(device_is_sorted))
+{
+    size_type num_primaries = 8;
+    // Num tracks is low enough to hit capacity
+    size_type num_tracks = num_primaries * 800;
+
+    Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
+
+    // Initialize some primaries and take a step
+    auto primaries = this->make_primaries(num_primaries);
+    step(make_span(primaries));
+    auto check_is_sorted = [&step] {
+        // copy to host
+        auto core_ref = step.core_data();
+        Collection<TrackSlotId::size_type, Ownership::value, MemSpace::host, ThreadId>
+            track_slots;
+        track_slots = core_ref.states.track_slots;
+        StateCollection<StepLimit, Ownership::value, MemSpace::host> step_limit;
+        step_limit = core_ref.states.sim.step_limit;
+
+        for (celeritas::size_type i = 0; i < track_slots.size() - 1; ++i)
+        {
+            TrackSlotId tid_current{track_slots[ThreadId{i}]},
+                tid_next{track_slots[ThreadId{i + 1}]};
+            ActionId::size_type aid_current{
+                step_limit[tid_current].action.unchecked_get()},
+                aid_next{step_limit[tid_next].action.unchecked_get()};
+            EXPECT_TRUE(aid_current <= aid_next)
+                << aid_current << " is larger than " << aid_next;
+        }
+    };
+    // A step can change the step-limit action, so we need to redo the sorting
+    // after taking a step.
+    for (auto i = 0; i < 10; ++i)
+    {
+        detail::sort_tracks_by_action_id(step.core_data().states);
+        check_is_sorted();
+        step();
+    }
+    step(make_span(primaries));
+    for (auto i = 0; i < 10; ++i)
+    {
+        detail::sort_tracks_by_action_id(step.core_data().states);
+        check_is_sorted();
         step();
     }
 }

--- a/test/celeritas/track/TrackSort.test.cc
+++ b/test/celeritas/track/TrackSort.test.cc
@@ -171,7 +171,7 @@ TEST_F(TestTrackSortActionIdEm3Stepper, host_is_sorted)
             ActionId::size_type aid_current{
                 step_limit[tid_current].action.unchecked_get()},
                 aid_next{step_limit[tid_next].action.unchecked_get()};
-            EXPECT_TRUE(aid_current <= aid_next)
+            EXPECT_LE(aid_current, aid_next)
                 << aid_current << " is larger than " << aid_next;
         }
     };
@@ -219,7 +219,7 @@ TEST_F(TestTrackSortActionIdEm3Stepper, TEST_IF_CELER_DEVICE(device_is_sorted))
             ActionId::size_type aid_current{
                 step_limit[tid_current].action.unchecked_get()},
                 aid_next{step_limit[tid_next].action.unchecked_get()};
-            EXPECT_TRUE(aid_current <= aid_next)
+            EXPECT_LE(aid_current, aid_next)
                 << aid_current << " is larger than " << aid_next;
         }
     };

--- a/test/celeritas/track/TrackSort.test.cc
+++ b/test/celeritas/track/TrackSort.test.cc
@@ -163,13 +163,11 @@ TEST_F(TestTrackSortActionIdEm3Stepper, host_is_sorted)
     step(make_span(primaries));
     auto check_is_sorted = [&step] {
         auto& step_limit = step.core_data().states.sim.step_limit;
-        for (celeritas::size_type i = 0;
-             i < step.core_data().states.track_slots.size() - 1;
-             ++i)
+        auto& track_slots = step.core_data().states.track_slots;
+        for (celeritas::size_type i = 0; i < track_slots.size() - 1; ++i)
         {
-            TrackSlotId tid_current{
-                step.core_data().states.track_slots[ThreadId{i}]},
-                tid_next{step.core_data().states.track_slots[ThreadId{i + 1}]};
+            TrackSlotId tid_current{track_slots[ThreadId{i}]},
+                tid_next{track_slots[ThreadId{i + 1}]};
             ActionId::size_type aid_current{
                 step_limit[tid_current].action.unchecked_get()},
                 aid_next{step_limit[tid_next].action.unchecked_get()};


### PR DESCRIPTION
Track slots are sorted by `ActionId` before the along-step.  Contiguous threads will process tracks undergoing similar interactions, which should help with warp divergence. 