### PR TITLE
Fix minor warning with VecGeom and test failures when JSON is unavailable

### DIFF
--- a/src/celeritas/ext/detail/VecgeomNavCollection.hh
+++ b/src/celeritas/ext/detail/VecgeomNavCollection.hh
@@ -85,6 +85,7 @@ struct VecgeomNavCollection<Ownership::reference, MemSpace::host>
     // Obtain reference from host memory
     VecgeomNavCollection&
     operator=(VecgeomNavCollection<Ownership::value, MemSpace::host>& other);
+    // Default assignment
     VecgeomNavCollection& operator=(VecgeomNavCollection const&) = default;
 
     // Get the navigation state for a given track slot
@@ -147,6 +148,10 @@ struct VecgeomNavCollection<Ownership::reference, MemSpace::device>
     using NavState = vecgeom::NavigationState;
 
     vecgeom::NavStatePoolView pool_view = {nullptr, 0, 0};
+
+    // Default construct and copy construct
+    VecgeomNavCollection() = default;
+    VecgeomNavCollection(VecgeomNavCollection const& other) = default;
 
     // Assign from device value
     VecgeomNavCollection&

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -9,6 +9,7 @@
 
 #include <fstream>
 #include <initializer_list>
+#include <numeric>
 #include <utility>
 #include <vector>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -371,13 +371,13 @@ else()
   set(_filter)
 endif()
 celeritas_add_test(celeritas/global/AlongStep.test.cc
-  NT 1 ${_optional_geant4_env} ${_filter}
+  NT 1 ${_optional_geant4_env} ${_needs_geo} ${_filter}
 )
 celeritas_add_test(celeritas/global/KernelContextException.test.cc NT 1
-  LINK_LIBRARIES ${_optional_json_link}
+  LINK_LIBRARIES ${_optional_json_link} ${_needs_geo}
 )
 celeritas_add_test(celeritas/global/Stepper.test.cc
-  GPU NT 4 ${_needs_geant4}
+  GPU NT 4 ${_needs_geant4} ${_needs_geo}
   FILTER
     # NOTE: these can be run in the same invocation once Geant4 reload works
     "TestEm3NoMsc.*"
@@ -454,14 +454,14 @@ endif()
 # Track
 set(CELERITASTEST_PREFIX celeritas/track)
 celeritas_add_test(celeritas/track/Sim.test.cc ${_needs_geant4})
-celeritas_add_test(celeritas/track/TrackSort.test.cc GPU ${_needs_geant4})
+celeritas_add_test(celeritas/track/TrackSort.test.cc GPU ${_needs_geant4} ${_needs_geo})
 celeritas_add_device_test(celeritas/track/TrackInit ${_needs_device})
 
 #-------------------------------------#
 # User
 set(CELERITASTEST_PREFIX celeritas/user)
 celeritas_add_test(celeritas/user/DetectorSteps.test.cc GPU)
-celeritas_add_test(celeritas/user/StepCollector.test.cc ${_optional_geant4_env})
+celeritas_add_test(celeritas/user/StepCollector.test.cc ${_optional_geant4_env} ${_needs_geo})
 
 #-----------------------------------------------------------------------------#
 # ACCELERITAS TESTS

--- a/test/celeritas/geo/Geometry.test.cc
+++ b/test/celeritas/geo/Geometry.test.cc
@@ -208,7 +208,7 @@ TEST_F(SimpleCmsTest, output)
 
     if (!CELERITAS_USE_JSON)
     {
-        EXPECT_THROW(to_string(out), celeritas::DebugError);
+        EXPECT_EQ(R"json("output unavailable")json", to_string(out));
     }
     else if (CELERITAS_USE_VECGEOM)
     {

--- a/test/corecel/io/OutputRegistry.test.cc
+++ b/test/corecel/io/OutputRegistry.test.cc
@@ -40,8 +40,7 @@ class TestInterface final : public OutputInterface
 #if CELERITAS_USE_JSON
         json->obj = value_;
 #else
-        (void)sizeof(json);
-        (void)sizeof(value_);
+        (void)sizeof(json, value_);
 #endif
     }
 
@@ -71,7 +70,7 @@ class MockKernelContextException : public RichContextException
         json->obj["event"] = event_;
         json->obj["track"] = track_;
 #else
-        (void)sizeof(json);
+        (void)sizeof(json, thread_, event_, track_);
 #endif
     }
 
@@ -152,7 +151,7 @@ TEST_F(OutputRegistryTest, minimal)
     }
 }
 
-TEST_F(OutputRegistryTest, build_output)
+TEST_F(OutputRegistryTest, TEST_IF_CELERITAS_JSON(build_output))
 {
     OutputRegistry reg;
     reg.insert(std::make_shared<celeritas::BuildOutput>());

--- a/test/corecel/sys/Environment.test.cc
+++ b/test/corecel/sys/Environment.test.cc
@@ -51,7 +51,7 @@ TEST(EnvironmentTest, global)
     EXPECT_EQ("1", getenv("ENVTEST_ONE"));
 }
 
-TEST(EnvironmentTest, json)
+TEST(EnvironmentTest, TEST_IF_CELERITAS_JSON(json))
 {
 #if CELERITAS_USE_JSON
     // Pre-set one environment variable
@@ -72,8 +72,6 @@ TEST(EnvironmentTest, json)
             = R"json([{"ENVTEST_CUSTOM":"custom","ENVTEST_ONE":"111111","ENVTEST_ZERO":"0"}])json";
         EXPECT_EQ(std::string(expected), std::string(out.dump()));
     }
-#else
-    GTEST_SKIP() << "JSON is disabled";
 #endif
 }
 

--- a/test/orange/univ/VolumeView.test.cc
+++ b/test/orange/univ/VolumeView.test.cc
@@ -69,13 +69,8 @@ TEST_F(VolumeViewTest, one_volume)
     }
 }
 
-TEST_F(VolumeViewTest, five_volumes)
+TEST_F(VolumeViewTest, TEST_IF_CELERITAS_JSON(five_volumes))
 {
-    if (!CELERITAS_USE_JSON)
-    {
-        GTEST_SKIP() << "JSON is not enabled";
-    }
-
     this->build_geometry("five-volumes.org.json");
 
     std::vector<size_type> num_faces;


### PR DESCRIPTION
- Fixes warning about deprecated copy constructor in VecGeom
- Disables and fixes some unit tests when JSON is unavailable