### PR TITLE
Add debugging/profiling utilities

### DIFF
--- a/app/demo-loop/demo-loop.cc
+++ b/app/demo-loop/demo-loop.cc
@@ -24,6 +24,7 @@
 #include "corecel/io/OutputRegistry.hh"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/MpiCommunicator.hh"
+#include "corecel/sys/ScopedDeviceProfiling.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "corecel/sys/ScopedMpiInit.hh"
 #include "corecel/sys/Stopwatch.hh"
@@ -83,7 +84,10 @@ void run(std::istream* is, std::shared_ptr<celeritas::OutputRegistry> output)
     double const setup_time = get_setup_time();
 
     // Run on a single thread
-    RunnerResult result = run_stream(celeritas::StreamId{0});
+    RunnerResult result = [&run_stream] {
+        celeritas::ScopedDeviceProfiling profile_this;
+        return run_stream(celeritas::StreamId{0});
+    }();
     result.time.setup = setup_time;
 
     // TODO: convert individual results into OutputInterface so we don't have

--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -55,21 +55,26 @@
     },
     {
       "name": "reldeb",
-      "displayName": "Everything but vecgeom in release mode",
+      "displayName": "Everything but vecgeom in release mode with debug symbols and assertions",
       "inherits": [".reldeb", ".base"]
     },
     {
-      "name": "ndebug-vecgeom",
-      "displayName": "Everything in release mode",
-      "inherits": [".ndebug", "vecgeom"],
+      "name": "ndebug",
+      "displayName": "Everything but vecgeom in release mode",
+      "inherits": [".ndebug", ".base"]
+    },
+    {
+      "name": "reldeb-vecgeom",
+      "displayName": "Everything in release mode with debug symbols and assertions",
+      "inherits": [".reldeb", "vecgeom"],
       "cacheVariables": {
         "CELERITAS_LAUNCH_BOUNDS":  {"type": "BOOL", "value": "OFF"}
       }
     },
     {
-      "name": "reldeb-vecgeom",
+      "name": "ndebug-vecgeom",
       "displayName": "Everything in release mode",
-      "inherits": [".reldeb", "vecgeom"],
+      "inherits": [".ndebug", "vecgeom"],
       "cacheVariables": {
         "CELERITAS_LAUNCH_BOUNDS":  {"type": "BOOL", "value": "OFF"}
       }

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -53,7 +53,11 @@ if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
   list(APPEND SOURCES
     data/detail/Filler.cu
     sys/KernelParamCalculator.device.cc
-    sys/ScopedDeviceProfiling.device.cc
+  )
+endif()
+if(CELERITAS_USE_CUDA)
+  list(APPEND SOURCES
+    sys/ScopedDeviceProfiling.cuda.cc
   )
 endif()
 

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -20,6 +20,7 @@ list(APPEND SOURCES
   io/ColorUtils.cc
   io/ExceptionOutput.cc
   io/Label.cc
+  io/LogContextException.cc
   io/Logger.cc
   io/LoggerTypes.cc
   io/OutputInterface.cc

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -53,6 +53,7 @@ if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
   list(APPEND SOURCES
     data/detail/Filler.cu
     sys/KernelParamCalculator.device.cc
+    sys/ScopedDeviceProfiling.device.cc
   )
 endif()
 

--- a/src/corecel/io/LogContextException.cc
+++ b/src/corecel/io/LogContextException.cc
@@ -1,0 +1,39 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/io/LogContextException.cc
+//---------------------------------------------------------------------------//
+#include "LogContextException.hh"
+
+#include "corecel/Assert.hh"
+
+#include "Logger.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+void log_context_exception(std::exception_ptr eptr)
+{
+    try
+    {
+        std::rethrow_exception(eptr);
+    }
+    catch (RichContextException const& e)
+    {
+        CELER_LOG_LOCAL(critical)
+            << "The following error is from: " << e.what();
+        try
+        {
+            std::rethrow_if_nested(e);
+        }
+        catch (...)
+        {
+            return log_context_exception(std::current_exception());
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/io/LogContextException.hh
+++ b/src/corecel/io/LogContextException.hh
@@ -1,0 +1,28 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/io/LogContextException.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <exception>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Log any RichContextException and rethrow the embedded pointer.
+ *
+ * This is useful for unit tests and other situations where the nearest `catch`
+ * does not use `std::rethrow_if_nested`.
+ *
+ * \code
+ CELER_TRY_HANDLE(step(), log_context_exception);
+   \endcode
+ */
+void log_context_exception(std::exception_ptr p);
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/sys/ScopedDeviceProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedDeviceProfiling.cuda.cc
@@ -3,17 +3,15 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/sys/ScopedDeviceProfiling.device.cc
+//! \file corecel/sys/ScopedDeviceProfiling.cuda.cc
 //---------------------------------------------------------------------------//
 #include "ScopedDeviceProfiling.hh"
 
 #include "celeritas_config.h"
 #include "corecel/device_runtime_api.h"
 
-#if CELERITAS_USE_CUDA
 // Profiler API isn't included with regular CUDA API headers
-#    include <cuda_profiler_api.h>
-#endif
+#include <cuda_profiler_api.h>
 
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
@@ -32,7 +30,7 @@ ScopedDeviceProfiling::ScopedDeviceProfiling()
     {
         try
         {
-            CELER_DEVICE_CALL_PREFIX(ProfilerStart());
+            CELER_CUDA_CALL(cudaProfilerStart());
         }
         catch (RuntimeError const& e)
         {
@@ -53,7 +51,7 @@ ScopedDeviceProfiling::~ScopedDeviceProfiling()
     {
         try
         {
-            CELER_DEVICE_CALL_PREFIX(ProfilerStop());
+            CELER_CUDA_CALL(cudaProfilerStop());
         }
         catch (RuntimeError const& e)
         {

--- a/src/corecel/sys/ScopedDeviceProfiling.device.cc
+++ b/src/corecel/sys/ScopedDeviceProfiling.device.cc
@@ -1,0 +1,66 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/ScopedDeviceProfiling.device.cc
+//---------------------------------------------------------------------------//
+#include "ScopedDeviceProfiling.hh"
+
+#include "celeritas_config.h"
+#include "corecel/device_runtime_api.h"
+
+#if CELERITAS_USE_CUDA
+// Profiler API isn't included with regular CUDA API headers
+#    include <cuda_profiler_api.h>
+#endif
+
+#include "corecel/Assert.hh"
+#include "corecel/io/Logger.hh"
+
+#include "Device.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Activate device profiling.
+ */
+ScopedDeviceProfiling::ScopedDeviceProfiling()
+{
+    if (celeritas::device())
+    {
+        try
+        {
+            CELER_DEVICE_CALL_PREFIX(ProfilerStart());
+        }
+        catch (RuntimeError const& e)
+        {
+            CELER_LOG(error) << "Failed to start profiling: " << e.what();
+            return;
+        }
+        activated_ = true;
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Deactivate device profiling if this function activated it.
+ */
+ScopedDeviceProfiling::~ScopedDeviceProfiling()
+{
+    if (activated_)
+    {
+        try
+        {
+            CELER_DEVICE_CALL_PREFIX(ProfilerStop());
+        }
+        catch (RuntimeError const& e)
+        {
+            CELER_LOG(error) << "Failed to stop profiling: " << e.what();
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/sys/ScopedDeviceProfiling.hh
+++ b/src/corecel/sys/ScopedDeviceProfiling.hh
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/Macros.hh"
+#include "celeritas_config.h"
 
 #include "Device.hh"
 
@@ -18,9 +18,10 @@ namespace celeritas
  * RAII class for CUDA/HIP profiling flags .
  *
  * This should be instantiated in a single-thread context. If celeritas::device
- * is enabled, it will call \c (cuda|hip)ProfilerStart at construction and
- * \c \\1ProfilerStop at destruction. If device support is disabled, this class
- * is a null-op.
+ * is enabled, it will call \c cudaProfilerStart at construction and
+ * \c cudaProfilerStop at destruction. If device support is disabled, this
+ * class is a null-op. HIP support for the profiler start/stop macros is
+ * deprecated so we do not support it at present.
  *
  * This is useful for wrapping the main stepper/transport loop for profiling to
  * allow ignoring of VecGeom instantiation kernels.
@@ -38,7 +39,7 @@ class ScopedDeviceProfiling
 };
 
 //---------------------------------------------------------------------------//
-#if !CELER_USE_DEVICE
+#if !CELERITAS_USE_CUDA
 inline ScopedDeviceProfiling::ScopedDeviceProfiling()
 {
     (void)sizeof(activated_);

--- a/src/corecel/sys/ScopedDeviceProfiling.hh
+++ b/src/corecel/sys/ScopedDeviceProfiling.hh
@@ -1,0 +1,50 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/ScopedDeviceProfiling.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Macros.hh"
+
+#include "Device.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * RAII class for CUDA/HIP profiling flags .
+ *
+ * This should be instantiated in a single-thread context. If celeritas::device
+ * is enabled, it will call \c (cuda|hip)ProfilerStart at construction and
+ * \c \\1ProfilerStop at destruction. If device support is disabled, this class
+ * is a null-op.
+ *
+ * This is useful for wrapping the main stepper/transport loop for profiling to
+ * allow ignoring of VecGeom instantiation kernels.
+ */
+class ScopedDeviceProfiling
+{
+  public:
+    // Activate profiling
+    ScopedDeviceProfiling();
+    // Deactivate profiling
+    ~ScopedDeviceProfiling();
+
+  private:
+    bool activated_{false};
+};
+
+//---------------------------------------------------------------------------//
+#if !CELER_USE_DEVICE
+inline ScopedDeviceProfiling::ScopedDeviceProfiling()
+{
+    (void)sizeof(activated_);
+}
+inline ScopedDeviceProfiling::~ScopedDeviceProfiling() {}
+#endif
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -303,12 +303,13 @@ TEST_F(UrbanMscTest, step_conversion)
             {
                 // Calculate between a nearby hypothetical geometric boundary
                 // and "no boundary" (i.e. pstep limited)
-                real_type gstep = calc_gstep(gpt);
+                real_type gstep = celeritas::min(calc_gstep(gpt), pstep);
                 SCOPED_TRACE((LabeledValue{"gstep", gstep}));
                 real_type true_step;
                 ASSERT_NO_THROW(true_step = geo_to_true(gstep));
                 EXPECT_LE(true_step, pstep);
-                EXPECT_GE(true_step, gstep);
+                EXPECT_GE(true_step, gstep)
+                    << LabeledValue{"true_step", true_step};
             }
 
             // Test exact true -> geo -> true conversion
@@ -534,7 +535,7 @@ TEST_F(UrbanMscTest, msc_scattering)
     EXPECT_VEC_SOFT_EQ(expected_tstep, tstep);
     EXPECT_VEC_SOFT_EQ(expected_gstep, gstep);
     EXPECT_VEC_SOFT_EQ(expected_alpha, alpha);
-    EXPECT_VEC_SOFT_EQ(expected_angle, angle);
+    EXPECT_VEC_NEAR(expected_angle, angle, 2e-12);
     EXPECT_VEC_SOFT_EQ(expected_displace, displace);
     EXPECT_VEC_EQ(expected_action, action);
     EXPECT_VEC_EQ(expected_avg_engine_samples, avg_engine_samples);

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -11,6 +11,7 @@
 #include "corecel/cont/Span.hh"
 #include "corecel/data/CollectionStateStore.hh"
 #include "corecel/io/Join.hh"
+#include "corecel/io/LogContextException.hh"
 #include "corecel/io/Repr.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/global/ActionRegistry.hh"
@@ -80,11 +81,13 @@ auto AlongStepTestBase::run(Input const& inp, size_type num_tracks) -> RunResult
         auto const& prestep_action
             = dynamic_cast<ExplicitActionInterface const&>(
                 *am.action(prestep_action_id));
-        prestep_action.execute(core_params, core_states);
+        CELER_TRY_HANDLE(prestep_action.execute(core_params, core_states),
+                         log_context_exception);
 
         // Call along-step action
         auto const& along_step = *this->along_step();
-        along_step.execute(core_params, core_states);
+        CELER_TRY_HANDLE(along_step.execute(core_params, core_states),
+                         log_context_exception);
     }
 
     // Process output

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include "corecel/cont/Span.hh"
+#include "corecel/io/LogContextException.hh"
 #include "corecel/io/Repr.hh"
 #include "celeritas/global/ActionRegistry.hh"
 #include "celeritas/global/Stepper.hh"
@@ -84,7 +85,9 @@ auto StepperTestBase::run(StepperInterface& step,
 
     // Perform first step
     auto primaries = this->make_primaries(num_primaries);
-    auto counts = step(make_span(primaries));
+    StepperResult counts;
+    CELER_TRY_HANDLE(counts = step(make_span(primaries)),
+                     log_context_exception);
     EXPECT_EQ(num_primaries, counts.active);
     EXPECT_EQ(num_primaries, counts.alive);
 
@@ -97,7 +100,7 @@ auto StepperTestBase::run(StepperInterface& step,
 
     while (counts)
     {
-        counts = step();
+        CELER_TRY_HANDLE(counts = step(), log_context_exception);
         result.active.push_back(counts.active);
         result.queued.push_back(counts.queued);
         accum_steps += counts.active;

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -13,6 +13,7 @@
 
 #include "corecel/cont/Span.hh"
 #include "corecel/data/CollectionMirror.hh"
+#include "corecel/io/LogContextException.hh"
 #include "celeritas/SimpleTestBase.hh"
 #include "celeritas/global/ActionInterface.hh"
 #include "celeritas/global/ActionRegistry.hh"
@@ -458,7 +459,8 @@ TEST_F(TrackInitSecondaryTest, secondaries_action)
     const size_type num_iter = 4;
     for ([[maybe_unused]] size_type i : range(num_iter))
     {
-        actions_.execute(core_params, core_state);
+        CELER_TRY_HANDLE(actions_.execute(core_params, core_state),
+                         log_context_exception);
         auto result = get_result(core_state);
 
         // Slots 5 and 6 are always vacant because these tracks are killed with


### PR DESCRIPTION
- Add a utility to start/stop CUDA/HIP profiling (to avoid the hundred thousand kernel launches when loading vecgeom+cms)
- Add a utility to make error messages inside the stepper/along-step google test understandable
- Fix some tolerances in the UrbanMsc unit test when compiling with optimization