### PR TITLE
Pass host-only classes to actions

### DIFF
--- a/cmake/CeleritasGen/gen-action.py
+++ b/cmake/CeleritasGen/gen-action.py
@@ -28,7 +28,6 @@ HH_TEMPLATE = CLIKE_TOP + """\
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "celeritas/global/ActionInterface.hh"
-#include "celeritas/global/CoreTrackData.hh"
 
 namespace celeritas
 {{
@@ -42,17 +41,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(CoreParams const&, StateHostRef&) const final;
+  void execute(CoreParams const&, CoreStateHost&) const final;
 
   // Launch kernel with device data
-  void execute(CoreParams const&, StateDeviceRef&) const final;
+  void execute(CoreParams const&, CoreStateDevice&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final {{ return ActionOrder::{actionorder}; }}
 }};
 
 #if !CELER_USE_DEVICE
-inline void {clsname}::execute(CoreParams const&, StateDeviceRef&) const
+inline void {clsname}::execute(CoreParams const&, CoreStateDevice&) const
 {{
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }}
@@ -73,6 +72,7 @@ CC_TEMPLATE = CLIKE_TOP + """\
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "../detail/{clsname}Impl.hh" // IWYU pragma: associated
@@ -81,19 +81,17 @@ namespace celeritas
 {{
 namespace generated
 {{
-void {clsname}::execute(CoreParams const& params, StateHostRef& state) const
+void {clsname}::execute(CoreParams const& params, CoreStateHost& state) const
 {{
-    CELER_EXPECT(state);
-
     MultiExceptionHandler capture_exception;
-    TrackLauncher launch{{params.ref<MemSpace::native>(), state, detail::{func}_track}};
+    TrackLauncher launch{{params.ref<MemSpace::native>(), state.ref(), detail::{func}_track}};
     #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {{
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{{i}}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{{i}}, this->label()));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{{i}}, this->label()));
     }}
     log_and_rethrow(std::move(capture_exception));
 }}
@@ -129,14 +127,13 @@ __global__ void{launch_bounds}{func}_kernel(
 }}
 }}  // namespace
 
-void {clsname}::execute(CoreParams const& params, StateDeviceRef& state) const
+void {clsname}::execute(CoreParams const& params, CoreStateDevice& state) const
 {{
-    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL({func},
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
 }}
 
 }}  // namespace generated

--- a/cmake/CeleritasGen/gen-action.py
+++ b/cmake/CeleritasGen/gen-action.py
@@ -108,6 +108,8 @@ CU_TEMPLATE = CLIKE_TOP + """\
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "../detail/{clsname}Impl.hh"
 

--- a/scripts/dev/celeritas-gen.py
+++ b/scripts/dev/celeritas-gen.py
@@ -192,7 +192,6 @@ inline void resize({capabbr}TestStateData<Ownership::value, M>* state,
                    const HostCRef<{capabbr}TestParamsData>&     params,
                    {corecel_ns}size_type                             size)
 {{
-    CELER_EXPECT(state);
     CELER_EXPECT(params);
     CELER_EXPECT(size > 0);
     // FIXME

--- a/scripts/dev/celeritas-gen.py
+++ b/scripts/dev/celeritas-gen.py
@@ -285,7 +285,7 @@ void {lowabbr}_test(
     CELER_LAUNCH_KERNEL({lowabbr}_test,
                         {corecel_ns}device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
 
     CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cc
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/BetheHeitlerLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -28,14 +29,13 @@ namespace generated
 void bethe_heitler_interact(
     celeritas::BetheHeitlerHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::HostRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::host>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state, model_data,
+        params.ref<MemSpace::native>(), state.ref(), model_data,
         celeritas::bethe_heitler_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -43,7 +43,7 @@ void bethe_heitler_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "bethe_heitler"));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, "bethe_heitler"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cc
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cc
@@ -27,16 +27,16 @@ namespace celeritas
 namespace generated
 {
 void bethe_heitler_interact(
-    celeritas::BetheHeitlerHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::host>& state)
+    celeritas::CoreState<MemSpace::host>& state,
+    celeritas::BetheHeitlerHostRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(), model_data,
-        celeritas::bethe_heitler_interact_track);
+        params.ref<MemSpace::native>(), state.ref(),
+        celeritas::bethe_heitler_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cc
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/BetheHeitlerLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -26,15 +27,15 @@ namespace generated
 {
 void bethe_heitler_interact(
     celeritas::BetheHeitlerHostRef const& model_data,
-    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::HostRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
+        params.ref<MemSpace::native>(), state, model_data,
         celeritas::bethe_heitler_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -42,7 +43,7 @@ void bethe_heitler_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, "bethe_heitler"));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "bethe_heitler"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cu
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cu
@@ -14,6 +14,7 @@
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/em/launcher/BetheHeitlerLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -51,15 +52,14 @@ bethe_heitler_interact_kernel(
 void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::DeviceRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::device>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(bethe_heitler_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state);
+                        model_data, params.ref<MemSpace::native>(), state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cu
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cu
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/em/launcher/BetheHeitlerLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -49,16 +50,16 @@ bethe_heitler_interact_kernel(
 
 void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const& model_data,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(bethe_heitler_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params, state);
+                        model_data, params.ref<MemSpace::native>(), state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cu
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cu
@@ -34,32 +34,31 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 bethe_heitler_interact_kernel(
-    celeritas::BetheHeitlerDeviceRef const model_data,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state)
+    celeritas::DeviceRef<celeritas::CoreStateData> const state,
+    celeritas::BetheHeitlerDeviceRef const model_data)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
-        celeritas::bethe_heitler_interact_track);
+        params, state, celeritas::bethe_heitler_interact_track, model_data);
     launch(tid);
 }
 }  // namespace
 
 void bethe_heitler_interact(
-    celeritas::BetheHeitlerDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::device>& state)
+    celeritas::CoreState<MemSpace::device>& state,
+    celeritas::BetheHeitlerDeviceRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(bethe_heitler_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state.ref());
+                        params.ref<MemSpace::native>(), state.ref(), model_data);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/BetheHeitlerInteract.hh
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.hh
@@ -25,20 +25,20 @@ namespace celeritas
 namespace generated
 {
 void bethe_heitler_interact(
-    celeritas::BetheHeitlerHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::host>&);
+    celeritas::CoreState<MemSpace::host>&,
+    celeritas::BetheHeitlerHostRef const&);
 
 void bethe_heitler_interact(
-    celeritas::BetheHeitlerDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&);
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::BetheHeitlerDeviceRef const&);
 
 #if !CELER_USE_DEVICE
 inline void bethe_heitler_interact(
-    celeritas::BetheHeitlerDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&)
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::BetheHeitlerDeviceRef const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/BetheHeitlerInteract.hh
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.hh
@@ -14,24 +14,26 @@
 #include "celeritas/em/data/BetheHeitlerData.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
+namespace celeritas { class CoreParams; }
+
 namespace celeritas
 {
 namespace generated
 {
 void bethe_heitler_interact(
     celeritas::BetheHeitlerHostRef const&,
-    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::HostRef<celeritas::CoreStateData>&);
 
 void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/em/generated/BetheHeitlerInteract.hh
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.hh
@@ -12,9 +12,13 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/BetheHeitlerData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackDataFwd.hh"
 
-namespace celeritas { class CoreParams; }
+namespace celeritas
+{
+class CoreParams;
+template<MemSpace M>
+class CoreState;
+}
 
 namespace celeritas
 {
@@ -23,18 +27,18 @@ namespace generated
 void bethe_heitler_interact(
     celeritas::BetheHeitlerHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::HostRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::host>&);
 
 void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void bethe_heitler_interact(
     celeritas::BetheHeitlerDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&)
+    celeritas::CoreState<MemSpace::device>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/CombinedBremInteract.cc
+++ b/src/celeritas/em/generated/CombinedBremInteract.cc
@@ -27,16 +27,16 @@ namespace celeritas
 namespace generated
 {
 void combined_brem_interact(
-    celeritas::CombinedBremHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::host>& state)
+    celeritas::CoreState<MemSpace::host>& state,
+    celeritas::CombinedBremHostRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(), model_data,
-        celeritas::combined_brem_interact_track);
+        params.ref<MemSpace::native>(), state.ref(),
+        celeritas::combined_brem_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/em/generated/CombinedBremInteract.cc
+++ b/src/celeritas/em/generated/CombinedBremInteract.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/CombinedBremLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -28,14 +29,13 @@ namespace generated
 void combined_brem_interact(
     celeritas::CombinedBremHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::HostRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::host>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state, model_data,
+        params.ref<MemSpace::native>(), state.ref(), model_data,
         celeritas::combined_brem_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -43,7 +43,7 @@ void combined_brem_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "combined_brem"));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, "combined_brem"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/CombinedBremInteract.cu
+++ b/src/celeritas/em/generated/CombinedBremInteract.cu
@@ -34,32 +34,31 @@ __launch_bounds__(1024, 5)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 combined_brem_interact_kernel(
-    celeritas::CombinedBremDeviceRef const model_data,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state)
+    celeritas::DeviceRef<celeritas::CoreStateData> const state,
+    celeritas::CombinedBremDeviceRef const model_data)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
-        celeritas::combined_brem_interact_track);
+        params, state, celeritas::combined_brem_interact_track, model_data);
     launch(tid);
 }
 }  // namespace
 
 void combined_brem_interact(
-    celeritas::CombinedBremDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::device>& state)
+    celeritas::CoreState<MemSpace::device>& state,
+    celeritas::CombinedBremDeviceRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(combined_brem_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state.ref());
+                        params.ref<MemSpace::native>(), state.ref(), model_data);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/CombinedBremInteract.cu
+++ b/src/celeritas/em/generated/CombinedBremInteract.cu
@@ -14,6 +14,7 @@
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/em/launcher/CombinedBremLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -51,15 +52,14 @@ combined_brem_interact_kernel(
 void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::DeviceRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::device>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(combined_brem_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state);
+                        model_data, params.ref<MemSpace::native>(), state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/CombinedBremInteract.cu
+++ b/src/celeritas/em/generated/CombinedBremInteract.cu
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/em/launcher/CombinedBremLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -49,16 +50,16 @@ combined_brem_interact_kernel(
 
 void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const& model_data,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(combined_brem_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params, state);
+                        model_data, params.ref<MemSpace::native>(), state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/CombinedBremInteract.hh
+++ b/src/celeritas/em/generated/CombinedBremInteract.hh
@@ -25,20 +25,20 @@ namespace celeritas
 namespace generated
 {
 void combined_brem_interact(
-    celeritas::CombinedBremHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::host>&);
+    celeritas::CoreState<MemSpace::host>&,
+    celeritas::CombinedBremHostRef const&);
 
 void combined_brem_interact(
-    celeritas::CombinedBremDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&);
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::CombinedBremDeviceRef const&);
 
 #if !CELER_USE_DEVICE
 inline void combined_brem_interact(
-    celeritas::CombinedBremDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&)
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::CombinedBremDeviceRef const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/CombinedBremInteract.hh
+++ b/src/celeritas/em/generated/CombinedBremInteract.hh
@@ -12,9 +12,13 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/CombinedBremData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackDataFwd.hh"
 
-namespace celeritas { class CoreParams; }
+namespace celeritas
+{
+class CoreParams;
+template<MemSpace M>
+class CoreState;
+}
 
 namespace celeritas
 {
@@ -23,18 +27,18 @@ namespace generated
 void combined_brem_interact(
     celeritas::CombinedBremHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::HostRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::host>&);
 
 void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&)
+    celeritas::CoreState<MemSpace::device>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/CombinedBremInteract.hh
+++ b/src/celeritas/em/generated/CombinedBremInteract.hh
@@ -14,24 +14,26 @@
 #include "celeritas/em/data/CombinedBremData.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
+namespace celeritas { class CoreParams; }
+
 namespace celeritas
 {
 namespace generated
 {
 void combined_brem_interact(
     celeritas::CombinedBremHostRef const&,
-    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::HostRef<celeritas::CoreStateData>&);
 
 void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void combined_brem_interact(
     celeritas::CombinedBremDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/em/generated/EPlusGGInteract.cc
+++ b/src/celeritas/em/generated/EPlusGGInteract.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/EPlusGGLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -26,15 +27,15 @@ namespace generated
 {
 void eplusgg_interact(
     celeritas::EPlusGGHostRef const& model_data,
-    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::HostRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
+        params.ref<MemSpace::native>(), state, model_data,
         celeritas::eplusgg_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -42,7 +43,7 @@ void eplusgg_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, "eplusgg"));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "eplusgg"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/EPlusGGInteract.cc
+++ b/src/celeritas/em/generated/EPlusGGInteract.cc
@@ -27,16 +27,16 @@ namespace celeritas
 namespace generated
 {
 void eplusgg_interact(
-    celeritas::EPlusGGHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::host>& state)
+    celeritas::CoreState<MemSpace::host>& state,
+    celeritas::EPlusGGHostRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(), model_data,
-        celeritas::eplusgg_interact_track);
+        params.ref<MemSpace::native>(), state.ref(),
+        celeritas::eplusgg_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/em/generated/EPlusGGInteract.cc
+++ b/src/celeritas/em/generated/EPlusGGInteract.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/EPlusGGLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -28,14 +29,13 @@ namespace generated
 void eplusgg_interact(
     celeritas::EPlusGGHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::HostRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::host>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state, model_data,
+        params.ref<MemSpace::native>(), state.ref(), model_data,
         celeritas::eplusgg_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -43,7 +43,7 @@ void eplusgg_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "eplusgg"));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, "eplusgg"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/EPlusGGInteract.cu
+++ b/src/celeritas/em/generated/EPlusGGInteract.cu
@@ -34,32 +34,31 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 eplusgg_interact_kernel(
-    celeritas::EPlusGGDeviceRef const model_data,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state)
+    celeritas::DeviceRef<celeritas::CoreStateData> const state,
+    celeritas::EPlusGGDeviceRef const model_data)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
-        celeritas::eplusgg_interact_track);
+        params, state, celeritas::eplusgg_interact_track, model_data);
     launch(tid);
 }
 }  // namespace
 
 void eplusgg_interact(
-    celeritas::EPlusGGDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::device>& state)
+    celeritas::CoreState<MemSpace::device>& state,
+    celeritas::EPlusGGDeviceRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(eplusgg_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state.ref());
+                        params.ref<MemSpace::native>(), state.ref(), model_data);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/EPlusGGInteract.cu
+++ b/src/celeritas/em/generated/EPlusGGInteract.cu
@@ -14,6 +14,7 @@
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/em/launcher/EPlusGGLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -51,15 +52,14 @@ eplusgg_interact_kernel(
 void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::DeviceRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::device>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(eplusgg_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state);
+                        model_data, params.ref<MemSpace::native>(), state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/EPlusGGInteract.cu
+++ b/src/celeritas/em/generated/EPlusGGInteract.cu
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/em/launcher/EPlusGGLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -49,16 +50,16 @@ eplusgg_interact_kernel(
 
 void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const& model_data,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(eplusgg_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params, state);
+                        model_data, params.ref<MemSpace::native>(), state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/EPlusGGInteract.hh
+++ b/src/celeritas/em/generated/EPlusGGInteract.hh
@@ -12,9 +12,13 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/EPlusGGData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackDataFwd.hh"
 
-namespace celeritas { class CoreParams; }
+namespace celeritas
+{
+class CoreParams;
+template<MemSpace M>
+class CoreState;
+}
 
 namespace celeritas
 {
@@ -23,18 +27,18 @@ namespace generated
 void eplusgg_interact(
     celeritas::EPlusGGHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::HostRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::host>&);
 
 void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&)
+    celeritas::CoreState<MemSpace::device>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/EPlusGGInteract.hh
+++ b/src/celeritas/em/generated/EPlusGGInteract.hh
@@ -14,24 +14,26 @@
 #include "celeritas/em/data/EPlusGGData.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
+namespace celeritas { class CoreParams; }
+
 namespace celeritas
 {
 namespace generated
 {
 void eplusgg_interact(
     celeritas::EPlusGGHostRef const&,
-    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::HostRef<celeritas::CoreStateData>&);
 
 void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void eplusgg_interact(
     celeritas::EPlusGGDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/em/generated/EPlusGGInteract.hh
+++ b/src/celeritas/em/generated/EPlusGGInteract.hh
@@ -25,20 +25,20 @@ namespace celeritas
 namespace generated
 {
 void eplusgg_interact(
-    celeritas::EPlusGGHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::host>&);
+    celeritas::CoreState<MemSpace::host>&,
+    celeritas::EPlusGGHostRef const&);
 
 void eplusgg_interact(
-    celeritas::EPlusGGDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&);
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::EPlusGGDeviceRef const&);
 
 #if !CELER_USE_DEVICE
 inline void eplusgg_interact(
-    celeritas::EPlusGGDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&)
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::EPlusGGDeviceRef const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/KleinNishinaInteract.cc
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cc
@@ -27,16 +27,16 @@ namespace celeritas
 namespace generated
 {
 void klein_nishina_interact(
-    celeritas::KleinNishinaHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::host>& state)
+    celeritas::CoreState<MemSpace::host>& state,
+    celeritas::KleinNishinaHostRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(), model_data,
-        celeritas::klein_nishina_interact_track);
+        params.ref<MemSpace::native>(), state.ref(),
+        celeritas::klein_nishina_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/em/generated/KleinNishinaInteract.cc
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/KleinNishinaLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -28,14 +29,13 @@ namespace generated
 void klein_nishina_interact(
     celeritas::KleinNishinaHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::HostRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::host>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state, model_data,
+        params.ref<MemSpace::native>(), state.ref(), model_data,
         celeritas::klein_nishina_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -43,7 +43,7 @@ void klein_nishina_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "klein_nishina"));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, "klein_nishina"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/KleinNishinaInteract.cc
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/KleinNishinaLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -26,15 +27,15 @@ namespace generated
 {
 void klein_nishina_interact(
     celeritas::KleinNishinaHostRef const& model_data,
-    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::HostRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
+        params.ref<MemSpace::native>(), state, model_data,
         celeritas::klein_nishina_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -42,7 +43,7 @@ void klein_nishina_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, "klein_nishina"));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "klein_nishina"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/KleinNishinaInteract.cu
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cu
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/em/launcher/KleinNishinaLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -49,16 +50,16 @@ klein_nishina_interact_kernel(
 
 void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const& model_data,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(klein_nishina_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params, state);
+                        model_data, params.ref<MemSpace::native>(), state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/KleinNishinaInteract.cu
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cu
@@ -14,6 +14,7 @@
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/em/launcher/KleinNishinaLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -51,15 +52,14 @@ klein_nishina_interact_kernel(
 void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::DeviceRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::device>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(klein_nishina_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state);
+                        model_data, params.ref<MemSpace::native>(), state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/KleinNishinaInteract.cu
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cu
@@ -34,32 +34,31 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 klein_nishina_interact_kernel(
-    celeritas::KleinNishinaDeviceRef const model_data,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state)
+    celeritas::DeviceRef<celeritas::CoreStateData> const state,
+    celeritas::KleinNishinaDeviceRef const model_data)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
-        celeritas::klein_nishina_interact_track);
+        params, state, celeritas::klein_nishina_interact_track, model_data);
     launch(tid);
 }
 }  // namespace
 
 void klein_nishina_interact(
-    celeritas::KleinNishinaDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::device>& state)
+    celeritas::CoreState<MemSpace::device>& state,
+    celeritas::KleinNishinaDeviceRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(klein_nishina_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state.ref());
+                        params.ref<MemSpace::native>(), state.ref(), model_data);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/KleinNishinaInteract.hh
+++ b/src/celeritas/em/generated/KleinNishinaInteract.hh
@@ -14,24 +14,26 @@
 #include "celeritas/em/data/KleinNishinaData.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
+namespace celeritas { class CoreParams; }
+
 namespace celeritas
 {
 namespace generated
 {
 void klein_nishina_interact(
     celeritas::KleinNishinaHostRef const&,
-    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::HostRef<celeritas::CoreStateData>&);
 
 void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/em/generated/KleinNishinaInteract.hh
+++ b/src/celeritas/em/generated/KleinNishinaInteract.hh
@@ -25,20 +25,20 @@ namespace celeritas
 namespace generated
 {
 void klein_nishina_interact(
-    celeritas::KleinNishinaHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::host>&);
+    celeritas::CoreState<MemSpace::host>&,
+    celeritas::KleinNishinaHostRef const&);
 
 void klein_nishina_interact(
-    celeritas::KleinNishinaDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&);
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::KleinNishinaDeviceRef const&);
 
 #if !CELER_USE_DEVICE
 inline void klein_nishina_interact(
-    celeritas::KleinNishinaDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&)
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::KleinNishinaDeviceRef const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/KleinNishinaInteract.hh
+++ b/src/celeritas/em/generated/KleinNishinaInteract.hh
@@ -12,9 +12,13 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/KleinNishinaData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackDataFwd.hh"
 
-namespace celeritas { class CoreParams; }
+namespace celeritas
+{
+class CoreParams;
+template<MemSpace M>
+class CoreState;
+}
 
 namespace celeritas
 {
@@ -23,18 +27,18 @@ namespace generated
 void klein_nishina_interact(
     celeritas::KleinNishinaHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::HostRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::host>&);
 
 void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void klein_nishina_interact(
     celeritas::KleinNishinaDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&)
+    celeritas::CoreState<MemSpace::device>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/LivermorePEInteract.cc
+++ b/src/celeritas/em/generated/LivermorePEInteract.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/LivermorePELauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -26,15 +27,15 @@ namespace generated
 {
 void livermore_pe_interact(
     celeritas::LivermorePEHostRef const& model_data,
-    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::HostRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
+        params.ref<MemSpace::native>(), state, model_data,
         celeritas::livermore_pe_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -42,7 +43,7 @@ void livermore_pe_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, "livermore_pe"));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "livermore_pe"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/LivermorePEInteract.cc
+++ b/src/celeritas/em/generated/LivermorePEInteract.cc
@@ -27,16 +27,16 @@ namespace celeritas
 namespace generated
 {
 void livermore_pe_interact(
-    celeritas::LivermorePEHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::host>& state)
+    celeritas::CoreState<MemSpace::host>& state,
+    celeritas::LivermorePEHostRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(), model_data,
-        celeritas::livermore_pe_interact_track);
+        params.ref<MemSpace::native>(), state.ref(),
+        celeritas::livermore_pe_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/em/generated/LivermorePEInteract.cc
+++ b/src/celeritas/em/generated/LivermorePEInteract.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/LivermorePELauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -28,14 +29,13 @@ namespace generated
 void livermore_pe_interact(
     celeritas::LivermorePEHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::HostRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::host>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state, model_data,
+        params.ref<MemSpace::native>(), state.ref(), model_data,
         celeritas::livermore_pe_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -43,7 +43,7 @@ void livermore_pe_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "livermore_pe"));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, "livermore_pe"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/LivermorePEInteract.cu
+++ b/src/celeritas/em/generated/LivermorePEInteract.cu
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/em/launcher/LivermorePELauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -49,16 +50,16 @@ livermore_pe_interact_kernel(
 
 void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const& model_data,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(livermore_pe_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params, state);
+                        model_data, params.ref<MemSpace::native>(), state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/LivermorePEInteract.cu
+++ b/src/celeritas/em/generated/LivermorePEInteract.cu
@@ -34,32 +34,31 @@ __launch_bounds__(1024, 7)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 livermore_pe_interact_kernel(
-    celeritas::LivermorePEDeviceRef const model_data,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state)
+    celeritas::DeviceRef<celeritas::CoreStateData> const state,
+    celeritas::LivermorePEDeviceRef const model_data)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
-        celeritas::livermore_pe_interact_track);
+        params, state, celeritas::livermore_pe_interact_track, model_data);
     launch(tid);
 }
 }  // namespace
 
 void livermore_pe_interact(
-    celeritas::LivermorePEDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::device>& state)
+    celeritas::CoreState<MemSpace::device>& state,
+    celeritas::LivermorePEDeviceRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(livermore_pe_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state.ref());
+                        params.ref<MemSpace::native>(), state.ref(), model_data);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/LivermorePEInteract.cu
+++ b/src/celeritas/em/generated/LivermorePEInteract.cu
@@ -14,6 +14,7 @@
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/em/launcher/LivermorePELauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -51,15 +52,14 @@ livermore_pe_interact_kernel(
 void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::DeviceRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::device>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(livermore_pe_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state);
+                        model_data, params.ref<MemSpace::native>(), state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/LivermorePEInteract.hh
+++ b/src/celeritas/em/generated/LivermorePEInteract.hh
@@ -12,9 +12,13 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/LivermorePEData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackDataFwd.hh"
 
-namespace celeritas { class CoreParams; }
+namespace celeritas
+{
+class CoreParams;
+template<MemSpace M>
+class CoreState;
+}
 
 namespace celeritas
 {
@@ -23,18 +27,18 @@ namespace generated
 void livermore_pe_interact(
     celeritas::LivermorePEHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::HostRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::host>&);
 
 void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&)
+    celeritas::CoreState<MemSpace::device>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/LivermorePEInteract.hh
+++ b/src/celeritas/em/generated/LivermorePEInteract.hh
@@ -25,20 +25,20 @@ namespace celeritas
 namespace generated
 {
 void livermore_pe_interact(
-    celeritas::LivermorePEHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::host>&);
+    celeritas::CoreState<MemSpace::host>&,
+    celeritas::LivermorePEHostRef const&);
 
 void livermore_pe_interact(
-    celeritas::LivermorePEDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&);
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::LivermorePEDeviceRef const&);
 
 #if !CELER_USE_DEVICE
 inline void livermore_pe_interact(
-    celeritas::LivermorePEDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&)
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::LivermorePEDeviceRef const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/LivermorePEInteract.hh
+++ b/src/celeritas/em/generated/LivermorePEInteract.hh
@@ -14,24 +14,26 @@
 #include "celeritas/em/data/LivermorePEData.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
+namespace celeritas { class CoreParams; }
+
 namespace celeritas
 {
 namespace generated
 {
 void livermore_pe_interact(
     celeritas::LivermorePEHostRef const&,
-    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::HostRef<celeritas::CoreStateData>&);
 
 void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void livermore_pe_interact(
     celeritas::LivermorePEDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cc
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/MollerBhabhaLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -28,14 +29,13 @@ namespace generated
 void moller_bhabha_interact(
     celeritas::MollerBhabhaHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::HostRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::host>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state, model_data,
+        params.ref<MemSpace::native>(), state.ref(), model_data,
         celeritas::moller_bhabha_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -43,7 +43,7 @@ void moller_bhabha_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "moller_bhabha"));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, "moller_bhabha"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cc
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/MollerBhabhaLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -26,15 +27,15 @@ namespace generated
 {
 void moller_bhabha_interact(
     celeritas::MollerBhabhaHostRef const& model_data,
-    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::HostRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
+        params.ref<MemSpace::native>(), state, model_data,
         celeritas::moller_bhabha_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -42,7 +43,7 @@ void moller_bhabha_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, "moller_bhabha"));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "moller_bhabha"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cc
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cc
@@ -27,16 +27,16 @@ namespace celeritas
 namespace generated
 {
 void moller_bhabha_interact(
-    celeritas::MollerBhabhaHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::host>& state)
+    celeritas::CoreState<MemSpace::host>& state,
+    celeritas::MollerBhabhaHostRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(), model_data,
-        celeritas::moller_bhabha_interact_track);
+        params.ref<MemSpace::native>(), state.ref(),
+        celeritas::moller_bhabha_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cu
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cu
@@ -34,32 +34,31 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 moller_bhabha_interact_kernel(
-    celeritas::MollerBhabhaDeviceRef const model_data,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state)
+    celeritas::DeviceRef<celeritas::CoreStateData> const state,
+    celeritas::MollerBhabhaDeviceRef const model_data)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
-        celeritas::moller_bhabha_interact_track);
+        params, state, celeritas::moller_bhabha_interact_track, model_data);
     launch(tid);
 }
 }  // namespace
 
 void moller_bhabha_interact(
-    celeritas::MollerBhabhaDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::device>& state)
+    celeritas::CoreState<MemSpace::device>& state,
+    celeritas::MollerBhabhaDeviceRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(moller_bhabha_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state.ref());
+                        params.ref<MemSpace::native>(), state.ref(), model_data);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cu
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cu
@@ -14,6 +14,7 @@
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/em/launcher/MollerBhabhaLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -51,15 +52,14 @@ moller_bhabha_interact_kernel(
 void moller_bhabha_interact(
     celeritas::MollerBhabhaDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::DeviceRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::device>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(moller_bhabha_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state);
+                        model_data, params.ref<MemSpace::native>(), state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cu
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cu
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/em/launcher/MollerBhabhaLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -49,16 +50,16 @@ moller_bhabha_interact_kernel(
 
 void moller_bhabha_interact(
     celeritas::MollerBhabhaDeviceRef const& model_data,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(moller_bhabha_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params, state);
+                        model_data, params.ref<MemSpace::native>(), state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/MollerBhabhaInteract.hh
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.hh
@@ -14,24 +14,26 @@
 #include "celeritas/em/data/MollerBhabhaData.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
+namespace celeritas { class CoreParams; }
+
 namespace celeritas
 {
 namespace generated
 {
 void moller_bhabha_interact(
     celeritas::MollerBhabhaHostRef const&,
-    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::HostRef<celeritas::CoreStateData>&);
 
 void moller_bhabha_interact(
     celeritas::MollerBhabhaDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void moller_bhabha_interact(
     celeritas::MollerBhabhaDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/em/generated/MollerBhabhaInteract.hh
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.hh
@@ -25,20 +25,20 @@ namespace celeritas
 namespace generated
 {
 void moller_bhabha_interact(
-    celeritas::MollerBhabhaHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::host>&);
+    celeritas::CoreState<MemSpace::host>&,
+    celeritas::MollerBhabhaHostRef const&);
 
 void moller_bhabha_interact(
-    celeritas::MollerBhabhaDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&);
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::MollerBhabhaDeviceRef const&);
 
 #if !CELER_USE_DEVICE
 inline void moller_bhabha_interact(
-    celeritas::MollerBhabhaDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&)
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::MollerBhabhaDeviceRef const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/MollerBhabhaInteract.hh
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.hh
@@ -12,9 +12,13 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/MollerBhabhaData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackDataFwd.hh"
 
-namespace celeritas { class CoreParams; }
+namespace celeritas
+{
+class CoreParams;
+template<MemSpace M>
+class CoreState;
+}
 
 namespace celeritas
 {
@@ -23,18 +27,18 @@ namespace generated
 void moller_bhabha_interact(
     celeritas::MollerBhabhaHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::HostRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::host>&);
 
 void moller_bhabha_interact(
     celeritas::MollerBhabhaDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void moller_bhabha_interact(
     celeritas::MollerBhabhaDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&)
+    celeritas::CoreState<MemSpace::device>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/MuBremsstrahlungLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -26,15 +27,15 @@ namespace generated
 {
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungHostRef const& model_data,
-    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::HostRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
+        params.ref<MemSpace::native>(), state, model_data,
         celeritas::mu_bremsstrahlung_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -42,7 +43,7 @@ void mu_bremsstrahlung_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, "mu_bremsstrahlung"));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "mu_bremsstrahlung"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
@@ -27,16 +27,16 @@ namespace celeritas
 namespace generated
 {
 void mu_bremsstrahlung_interact(
-    celeritas::MuBremsstrahlungHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::host>& state)
+    celeritas::CoreState<MemSpace::host>& state,
+    celeritas::MuBremsstrahlungHostRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(), model_data,
-        celeritas::mu_bremsstrahlung_interact_track);
+        params.ref<MemSpace::native>(), state.ref(),
+        celeritas::mu_bremsstrahlung_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/MuBremsstrahlungLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -28,14 +29,13 @@ namespace generated
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::HostRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::host>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state, model_data,
+        params.ref<MemSpace::native>(), state.ref(), model_data,
         celeritas::mu_bremsstrahlung_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -43,7 +43,7 @@ void mu_bremsstrahlung_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "mu_bremsstrahlung"));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, "mu_bremsstrahlung"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cu
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cu
@@ -25,32 +25,31 @@ namespace generated
 namespace
 {
 __global__ void mu_bremsstrahlung_interact_kernel(
-    celeritas::MuBremsstrahlungDeviceRef const model_data,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state)
+    celeritas::DeviceRef<celeritas::CoreStateData> const state,
+    celeritas::MuBremsstrahlungDeviceRef const model_data)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
-        celeritas::mu_bremsstrahlung_interact_track);
+        params, state, celeritas::mu_bremsstrahlung_interact_track, model_data);
     launch(tid);
 }
 }  // namespace
 
 void mu_bremsstrahlung_interact(
-    celeritas::MuBremsstrahlungDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::device>& state)
+    celeritas::CoreState<MemSpace::device>& state,
+    celeritas::MuBremsstrahlungDeviceRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(mu_bremsstrahlung_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state.ref());
+                        params.ref<MemSpace::native>(), state.ref(), model_data);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cu
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cu
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/em/launcher/MuBremsstrahlungLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -40,16 +41,16 @@ __global__ void mu_bremsstrahlung_interact_kernel(
 
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const& model_data,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(mu_bremsstrahlung_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params, state);
+                        model_data, params.ref<MemSpace::native>(), state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cu
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cu
@@ -14,6 +14,7 @@
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/em/launcher/MuBremsstrahlungLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -42,15 +43,14 @@ __global__ void mu_bremsstrahlung_interact_kernel(
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::DeviceRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::device>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(mu_bremsstrahlung_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state);
+                        model_data, params.ref<MemSpace::native>(), state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.hh
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.hh
@@ -25,20 +25,20 @@ namespace celeritas
 namespace generated
 {
 void mu_bremsstrahlung_interact(
-    celeritas::MuBremsstrahlungHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::host>&);
+    celeritas::CoreState<MemSpace::host>&,
+    celeritas::MuBremsstrahlungHostRef const&);
 
 void mu_bremsstrahlung_interact(
-    celeritas::MuBremsstrahlungDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&);
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::MuBremsstrahlungDeviceRef const&);
 
 #if !CELER_USE_DEVICE
 inline void mu_bremsstrahlung_interact(
-    celeritas::MuBremsstrahlungDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&)
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::MuBremsstrahlungDeviceRef const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.hh
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.hh
@@ -12,9 +12,13 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/MuBremsstrahlungData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackDataFwd.hh"
 
-namespace celeritas { class CoreParams; }
+namespace celeritas
+{
+class CoreParams;
+template<MemSpace M>
+class CoreState;
+}
 
 namespace celeritas
 {
@@ -23,18 +27,18 @@ namespace generated
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::HostRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::host>&);
 
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&)
+    celeritas::CoreState<MemSpace::device>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.hh
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.hh
@@ -14,24 +14,26 @@
 #include "celeritas/em/data/MuBremsstrahlungData.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
+namespace celeritas { class CoreParams; }
+
 namespace celeritas
 {
 namespace generated
 {
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungHostRef const&,
-    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::HostRef<celeritas::CoreStateData>&);
 
 void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void mu_bremsstrahlung_interact(
     celeritas::MuBremsstrahlungDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/em/generated/RayleighInteract.cc
+++ b/src/celeritas/em/generated/RayleighInteract.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/RayleighLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -28,14 +29,13 @@ namespace generated
 void rayleigh_interact(
     celeritas::RayleighHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::HostRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::host>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state, model_data,
+        params.ref<MemSpace::native>(), state.ref(), model_data,
         celeritas::rayleigh_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -43,7 +43,7 @@ void rayleigh_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "rayleigh"));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, "rayleigh"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/RayleighInteract.cc
+++ b/src/celeritas/em/generated/RayleighInteract.cc
@@ -27,16 +27,16 @@ namespace celeritas
 namespace generated
 {
 void rayleigh_interact(
-    celeritas::RayleighHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::host>& state)
+    celeritas::CoreState<MemSpace::host>& state,
+    celeritas::RayleighHostRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(), model_data,
-        celeritas::rayleigh_interact_track);
+        params.ref<MemSpace::native>(), state.ref(),
+        celeritas::rayleigh_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/em/generated/RayleighInteract.cc
+++ b/src/celeritas/em/generated/RayleighInteract.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/RayleighLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -26,15 +27,15 @@ namespace generated
 {
 void rayleigh_interact(
     celeritas::RayleighHostRef const& model_data,
-    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::HostRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
+        params.ref<MemSpace::native>(), state, model_data,
         celeritas::rayleigh_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -42,7 +43,7 @@ void rayleigh_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, "rayleigh"));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "rayleigh"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/RayleighInteract.cu
+++ b/src/celeritas/em/generated/RayleighInteract.cu
@@ -14,6 +14,7 @@
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/em/launcher/RayleighLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -51,15 +52,14 @@ rayleigh_interact_kernel(
 void rayleigh_interact(
     celeritas::RayleighDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::DeviceRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::device>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(rayleigh_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state);
+                        model_data, params.ref<MemSpace::native>(), state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/RayleighInteract.cu
+++ b/src/celeritas/em/generated/RayleighInteract.cu
@@ -34,32 +34,31 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 rayleigh_interact_kernel(
-    celeritas::RayleighDeviceRef const model_data,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state)
+    celeritas::DeviceRef<celeritas::CoreStateData> const state,
+    celeritas::RayleighDeviceRef const model_data)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
-        celeritas::rayleigh_interact_track);
+        params, state, celeritas::rayleigh_interact_track, model_data);
     launch(tid);
 }
 }  // namespace
 
 void rayleigh_interact(
-    celeritas::RayleighDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::device>& state)
+    celeritas::CoreState<MemSpace::device>& state,
+    celeritas::RayleighDeviceRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(rayleigh_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state.ref());
+                        params.ref<MemSpace::native>(), state.ref(), model_data);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/RayleighInteract.cu
+++ b/src/celeritas/em/generated/RayleighInteract.cu
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/em/launcher/RayleighLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -49,16 +50,16 @@ rayleigh_interact_kernel(
 
 void rayleigh_interact(
     celeritas::RayleighDeviceRef const& model_data,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(rayleigh_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params, state);
+                        model_data, params.ref<MemSpace::native>(), state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/RayleighInteract.hh
+++ b/src/celeritas/em/generated/RayleighInteract.hh
@@ -14,24 +14,26 @@
 #include "celeritas/em/data/RayleighData.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
+namespace celeritas { class CoreParams; }
+
 namespace celeritas
 {
 namespace generated
 {
 void rayleigh_interact(
     celeritas::RayleighHostRef const&,
-    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::HostRef<celeritas::CoreStateData>&);
 
 void rayleigh_interact(
     celeritas::RayleighDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void rayleigh_interact(
     celeritas::RayleighDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/em/generated/RayleighInteract.hh
+++ b/src/celeritas/em/generated/RayleighInteract.hh
@@ -12,9 +12,13 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/RayleighData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackDataFwd.hh"
 
-namespace celeritas { class CoreParams; }
+namespace celeritas
+{
+class CoreParams;
+template<MemSpace M>
+class CoreState;
+}
 
 namespace celeritas
 {
@@ -23,18 +27,18 @@ namespace generated
 void rayleigh_interact(
     celeritas::RayleighHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::HostRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::host>&);
 
 void rayleigh_interact(
     celeritas::RayleighDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void rayleigh_interact(
     celeritas::RayleighDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&)
+    celeritas::CoreState<MemSpace::device>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/RayleighInteract.hh
+++ b/src/celeritas/em/generated/RayleighInteract.hh
@@ -25,20 +25,20 @@ namespace celeritas
 namespace generated
 {
 void rayleigh_interact(
-    celeritas::RayleighHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::host>&);
+    celeritas::CoreState<MemSpace::host>&,
+    celeritas::RayleighHostRef const&);
 
 void rayleigh_interact(
-    celeritas::RayleighDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&);
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::RayleighDeviceRef const&);
 
 #if !CELER_USE_DEVICE
 inline void rayleigh_interact(
-    celeritas::RayleighDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&)
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::RayleighDeviceRef const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/RelativisticBremInteract.cc
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cc
@@ -27,16 +27,16 @@ namespace celeritas
 namespace generated
 {
 void relativistic_brem_interact(
-    celeritas::RelativisticBremHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::host>& state)
+    celeritas::CoreState<MemSpace::host>& state,
+    celeritas::RelativisticBremHostRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(), model_data,
-        celeritas::relativistic_brem_interact_track);
+        params.ref<MemSpace::native>(), state.ref(),
+        celeritas::relativistic_brem_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/em/generated/RelativisticBremInteract.cc
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/RelativisticBremLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -26,15 +27,15 @@ namespace generated
 {
 void relativistic_brem_interact(
     celeritas::RelativisticBremHostRef const& model_data,
-    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::HostRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
+        params.ref<MemSpace::native>(), state, model_data,
         celeritas::relativistic_brem_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -42,7 +43,7 @@ void relativistic_brem_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, "relativistic_brem"));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "relativistic_brem"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/RelativisticBremInteract.cu
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cu
@@ -25,32 +25,31 @@ namespace generated
 namespace
 {
 __global__ void relativistic_brem_interact_kernel(
-    celeritas::RelativisticBremDeviceRef const model_data,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state)
+    celeritas::DeviceRef<celeritas::CoreStateData> const state,
+    celeritas::RelativisticBremDeviceRef const model_data)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
-        celeritas::relativistic_brem_interact_track);
+        params, state, celeritas::relativistic_brem_interact_track, model_data);
     launch(tid);
 }
 }  // namespace
 
 void relativistic_brem_interact(
-    celeritas::RelativisticBremDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::device>& state)
+    celeritas::CoreState<MemSpace::device>& state,
+    celeritas::RelativisticBremDeviceRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(relativistic_brem_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state.ref());
+                        params.ref<MemSpace::native>(), state.ref(), model_data);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/RelativisticBremInteract.cu
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cu
@@ -14,6 +14,7 @@
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/em/launcher/RelativisticBremLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -42,15 +43,14 @@ __global__ void relativistic_brem_interact_kernel(
 void relativistic_brem_interact(
     celeritas::RelativisticBremDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::DeviceRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::device>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(relativistic_brem_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state);
+                        model_data, params.ref<MemSpace::native>(), state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/RelativisticBremInteract.cu
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cu
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/em/launcher/RelativisticBremLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -40,16 +41,16 @@ __global__ void relativistic_brem_interact_kernel(
 
 void relativistic_brem_interact(
     celeritas::RelativisticBremDeviceRef const& model_data,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(relativistic_brem_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params, state);
+                        model_data, params.ref<MemSpace::native>(), state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/RelativisticBremInteract.hh
+++ b/src/celeritas/em/generated/RelativisticBremInteract.hh
@@ -12,9 +12,13 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/RelativisticBremData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackDataFwd.hh"
 
-namespace celeritas { class CoreParams; }
+namespace celeritas
+{
+class CoreParams;
+template<MemSpace M>
+class CoreState;
+}
 
 namespace celeritas
 {
@@ -23,18 +27,18 @@ namespace generated
 void relativistic_brem_interact(
     celeritas::RelativisticBremHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::HostRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::host>&);
 
 void relativistic_brem_interact(
     celeritas::RelativisticBremDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void relativistic_brem_interact(
     celeritas::RelativisticBremDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&)
+    celeritas::CoreState<MemSpace::device>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/RelativisticBremInteract.hh
+++ b/src/celeritas/em/generated/RelativisticBremInteract.hh
@@ -14,24 +14,26 @@
 #include "celeritas/em/data/RelativisticBremData.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
+namespace celeritas { class CoreParams; }
+
 namespace celeritas
 {
 namespace generated
 {
 void relativistic_brem_interact(
     celeritas::RelativisticBremHostRef const&,
-    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::HostRef<celeritas::CoreStateData>&);
 
 void relativistic_brem_interact(
     celeritas::RelativisticBremDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void relativistic_brem_interact(
     celeritas::RelativisticBremDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/em/generated/RelativisticBremInteract.hh
+++ b/src/celeritas/em/generated/RelativisticBremInteract.hh
@@ -25,20 +25,20 @@ namespace celeritas
 namespace generated
 {
 void relativistic_brem_interact(
-    celeritas::RelativisticBremHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::host>&);
+    celeritas::CoreState<MemSpace::host>&,
+    celeritas::RelativisticBremHostRef const&);
 
 void relativistic_brem_interact(
-    celeritas::RelativisticBremDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&);
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::RelativisticBremDeviceRef const&);
 
 #if !CELER_USE_DEVICE
 inline void relativistic_brem_interact(
-    celeritas::RelativisticBremDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&)
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::RelativisticBremDeviceRef const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cc
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/SeltzerBergerLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -26,15 +27,15 @@ namespace generated
 {
 void seltzer_berger_interact(
     celeritas::SeltzerBergerHostRef const& model_data,
-    celeritas::HostCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::HostRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
+        params.ref<MemSpace::native>(), state, model_data,
         celeritas::seltzer_berger_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -42,7 +43,7 @@ void seltzer_berger_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, "seltzer_berger"));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "seltzer_berger"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cc
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cc
@@ -27,16 +27,16 @@ namespace celeritas
 namespace generated
 {
 void seltzer_berger_interact(
-    celeritas::SeltzerBergerHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::host>& state)
+    celeritas::CoreState<MemSpace::host>& state,
+    celeritas::SeltzerBergerHostRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(), model_data,
-        celeritas::seltzer_berger_interact_track);
+        params.ref<MemSpace::native>(), state.ref(),
+        celeritas::seltzer_berger_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cc
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/em/launcher/SeltzerBergerLauncher.hh" // IWYU pragma: associated
 #include "celeritas/phys/InteractionLauncher.hh"
@@ -28,14 +29,13 @@ namespace generated
 void seltzer_berger_interact(
     celeritas::SeltzerBergerHostRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::HostRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::host>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state, model_data,
+        params.ref<MemSpace::native>(), state.ref(), model_data,
         celeritas::seltzer_berger_interact_track);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)
@@ -43,7 +43,7 @@ void seltzer_berger_interact(
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, "seltzer_berger"));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, "seltzer_berger"));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cu
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cu
@@ -14,6 +14,7 @@
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/em/launcher/SeltzerBergerLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -42,15 +43,14 @@ __global__ void seltzer_berger_interact_kernel(
 void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::DeviceRef<celeritas::CoreStateData>& state)
+    celeritas::CoreState<MemSpace::device>& state)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(seltzer_berger_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state);
+                        model_data, params.ref<MemSpace::native>(), state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cu
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cu
@@ -25,32 +25,31 @@ namespace generated
 namespace
 {
 __global__ void seltzer_berger_interact_kernel(
-    celeritas::SeltzerBergerDeviceRef const model_data,
     celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state)
+    celeritas::DeviceRef<celeritas::CoreStateData> const state,
+    celeritas::SeltzerBergerDeviceRef const model_data)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
     if (!(tid < state.size()))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
-        params, state, model_data,
-        celeritas::seltzer_berger_interact_track);
+        params, state, celeritas::seltzer_berger_interact_track, model_data);
     launch(tid);
 }
 }  // namespace
 
 void seltzer_berger_interact(
-    celeritas::SeltzerBergerDeviceRef const& model_data,
     celeritas::CoreParams const& params,
-    celeritas::CoreState<MemSpace::device>& state)
+    celeritas::CoreState<MemSpace::device>& state,
+    celeritas::SeltzerBergerDeviceRef const& model_data)
 {
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(seltzer_berger_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params.ref<MemSpace::native>(), state.ref());
+                        params.ref<MemSpace::native>(), state.ref(), model_data);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cu
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cu
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/em/launcher/SeltzerBergerLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
@@ -40,16 +41,16 @@ __global__ void seltzer_berger_interact_kernel(
 
 void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const& model_data,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const& params,
+    celeritas::CoreParams const& params,
     celeritas::DeviceRef<celeritas::CoreStateData>& state)
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_EXPECT(model_data);
 
     CELER_LAUNCH_KERNEL(seltzer_berger_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        model_data, params, state);
+                        model_data, params.ref<MemSpace::native>(), state);
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/SeltzerBergerInteract.hh
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.hh
@@ -25,20 +25,20 @@ namespace celeritas
 namespace generated
 {
 void seltzer_berger_interact(
-    celeritas::SeltzerBergerHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::host>&);
+    celeritas::CoreState<MemSpace::host>&,
+    celeritas::SeltzerBergerHostRef const&);
 
 void seltzer_berger_interact(
-    celeritas::SeltzerBergerDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&);
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::SeltzerBergerDeviceRef const&);
 
 #if !CELER_USE_DEVICE
 inline void seltzer_berger_interact(
-    celeritas::SeltzerBergerDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::CoreState<MemSpace::device>&)
+    celeritas::CoreState<MemSpace::device>&,
+    celeritas::SeltzerBergerDeviceRef const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/SeltzerBergerInteract.hh
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.hh
@@ -12,9 +12,13 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/em/data/SeltzerBergerData.hh" // IWYU pragma: associated
-#include "celeritas/global/CoreTrackDataFwd.hh"
 
-namespace celeritas { class CoreParams; }
+namespace celeritas
+{
+class CoreParams;
+template<MemSpace M>
+class CoreState;
+}
 
 namespace celeritas
 {
@@ -23,18 +27,18 @@ namespace generated
 void seltzer_berger_interact(
     celeritas::SeltzerBergerHostRef const&,
     celeritas::CoreParams const&,
-    celeritas::HostRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::host>&);
 
 void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&);
+    celeritas::CoreState<MemSpace::device>&);
 
 #if !CELER_USE_DEVICE
 inline void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const&,
     celeritas::CoreParams const&,
-    celeritas::DeviceRef<celeritas::CoreStateData>&)
+    celeritas::CoreState<MemSpace::device>&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/em/generated/SeltzerBergerInteract.hh
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.hh
@@ -14,24 +14,26 @@
 #include "celeritas/em/data/SeltzerBergerData.hh" // IWYU pragma: associated
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
+namespace celeritas { class CoreParams; }
+
 namespace celeritas
 {
 namespace generated
 {
 void seltzer_berger_interact(
     celeritas::SeltzerBergerHostRef const&,
-    celeritas::HostCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::HostRef<celeritas::CoreStateData>&);
 
 void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&);
 
 #if !CELER_USE_DEVICE
 inline void seltzer_berger_interact(
     celeritas::SeltzerBergerDeviceRef const&,
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const&,
+    celeritas::CoreParams const&,
     celeritas::DeviceRef<celeritas::CoreStateData>&)
 {
     CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/em/model/BetheHeitlerModel.cc
+++ b/src/celeritas/em/model/BetheHeitlerModel.cc
@@ -73,17 +73,17 @@ auto BetheHeitlerModel::micro_xs(Applicability applic) const -> MicroXsBuilders
 //---------------------------------------------------------------------------//
 //!@{
 void BetheHeitlerModel::execute(CoreParams const& params,
-                                StateHostRef& states) const
+                                CoreStateHost& state) const
 {
-    generated::bethe_heitler_interact(this->host_ref(), params, states);
+    generated::bethe_heitler_interact(this->host_ref(), params, state);
 }
 /*!
  * Apply the interaction kernel.
  */
 void BetheHeitlerModel::execute(CoreParams const& params,
-                                StateDeviceRef& states) const
+                                CoreStateDevice& state) const
 {
-    generated::bethe_heitler_interact(this->device_ref(), params, states);
+    generated::bethe_heitler_interact(this->device_ref(), params, state);
 }
 
 //!@}

--- a/src/celeritas/em/model/BetheHeitlerModel.cc
+++ b/src/celeritas/em/model/BetheHeitlerModel.cc
@@ -75,7 +75,7 @@ auto BetheHeitlerModel::micro_xs(Applicability applic) const -> MicroXsBuilders
 void BetheHeitlerModel::execute(CoreParams const& params,
                                 CoreStateHost& state) const
 {
-    generated::bethe_heitler_interact(this->host_ref(), params, state);
+    generated::bethe_heitler_interact(params, state, this->host_ref());
 }
 /*!
  * Apply the interaction kernel.
@@ -83,7 +83,7 @@ void BetheHeitlerModel::execute(CoreParams const& params,
 void BetheHeitlerModel::execute(CoreParams const& params,
                                 CoreStateDevice& state) const
 {
-    generated::bethe_heitler_interact(this->device_ref(), params, state);
+    generated::bethe_heitler_interact(params, state, this->device_ref());
 }
 
 //!@}

--- a/src/celeritas/em/model/BetheHeitlerModel.cc
+++ b/src/celeritas/em/model/BetheHeitlerModel.cc
@@ -11,6 +11,7 @@
 
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/generated/BetheHeitlerInteract.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/io/ImportProcess.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleView.hh"
@@ -71,20 +72,20 @@ auto BetheHeitlerModel::micro_xs(Applicability applic) const -> MicroXsBuilders
 
 //---------------------------------------------------------------------------//
 //!@{
+void BetheHeitlerModel::execute(CoreParams const& params,
+                                StateHostRef& states) const
+{
+    generated::bethe_heitler_interact(this->host_ref(), params, states);
+}
 /*!
  * Apply the interaction kernel.
  */
-void BetheHeitlerModel::execute(ParamsDeviceCRef const& params,
+void BetheHeitlerModel::execute(CoreParams const& params,
                                 StateDeviceRef& states) const
 {
-    generated::bethe_heitler_interact(data_, params, states);
+    generated::bethe_heitler_interact(this->device_ref(), params, states);
 }
 
-void BetheHeitlerModel::execute(ParamsHostCRef const& params,
-                                StateHostRef& states) const
-{
-    generated::bethe_heitler_interact(data_, params, states);
-}
 //!@}
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/em/model/BetheHeitlerModel.hh
+++ b/src/celeritas/em/model/BetheHeitlerModel.hh
@@ -43,10 +43,10 @@ class BetheHeitlerModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Apply the interaction kernel on device
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;
@@ -59,6 +59,12 @@ class BetheHeitlerModel final : public Model
     {
         return "Bethe-Heitler gamma conversion";
     }
+
+    //!@{
+    //! Access model data
+    BetheHeitlerData const& host_ref() const { return data_; }
+    BetheHeitlerData const& device_ref() const { return data_; }
+    //!@}
 
   private:
     BetheHeitlerData data_;

--- a/src/celeritas/em/model/BetheHeitlerModel.hh
+++ b/src/celeritas/em/model/BetheHeitlerModel.hh
@@ -43,10 +43,10 @@ class BetheHeitlerModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/CombinedBremModel.cc
+++ b/src/celeritas/em/model/CombinedBremModel.cc
@@ -90,15 +90,15 @@ auto CombinedBremModel::micro_xs(Applicability) const -> MicroXsBuilders
  * Apply the interaction kernel.
  */
 void CombinedBremModel::execute(CoreParams const& params,
-                                StateHostRef& states) const
+                                CoreStateHost& state) const
 {
-    generated::combined_brem_interact(this->host_ref(), params, states);
+    generated::combined_brem_interact(this->host_ref(), params, state);
 }
 
 void CombinedBremModel::execute(CoreParams const& params,
-                                StateDeviceRef& states) const
+                                CoreStateDevice& state) const
 {
-    generated::combined_brem_interact(this->device_ref(), params, states);
+    generated::combined_brem_interact(this->device_ref(), params, state);
 }
 
 //!@}

--- a/src/celeritas/em/model/CombinedBremModel.cc
+++ b/src/celeritas/em/model/CombinedBremModel.cc
@@ -92,13 +92,13 @@ auto CombinedBremModel::micro_xs(Applicability) const -> MicroXsBuilders
 void CombinedBremModel::execute(CoreParams const& params,
                                 CoreStateHost& state) const
 {
-    generated::combined_brem_interact(this->host_ref(), params, state);
+    generated::combined_brem_interact(params, state, this->host_ref());
 }
 
 void CombinedBremModel::execute(CoreParams const& params,
                                 CoreStateDevice& state) const
 {
-    generated::combined_brem_interact(this->device_ref(), params, state);
+    generated::combined_brem_interact(params, state, this->device_ref());
 }
 
 //!@}

--- a/src/celeritas/em/model/CombinedBremModel.cc
+++ b/src/celeritas/em/model/CombinedBremModel.cc
@@ -17,6 +17,7 @@
 #include "celeritas/em/data/RelativisticBremData.hh"
 #include "celeritas/em/data/SeltzerBergerData.hh"
 #include "celeritas/em/generated/CombinedBremInteract.hh"
+#include "celeritas/global/CoreParams.hh"
 
 #include "../interactor/detail/PhysicsConstants.hh"
 #include "RelativisticBremModel.hh"
@@ -88,16 +89,16 @@ auto CombinedBremModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void CombinedBremModel::execute(ParamsDeviceCRef const& params,
-                                StateDeviceRef& states) const
-{
-    generated::combined_brem_interact(this->device_ref(), params, states);
-}
-
-void CombinedBremModel::execute(ParamsHostCRef const& params,
+void CombinedBremModel::execute(CoreParams const& params,
                                 StateHostRef& states) const
 {
     generated::combined_brem_interact(this->host_ref(), params, states);
+}
+
+void CombinedBremModel::execute(CoreParams const& params,
+                                StateDeviceRef& states) const
+{
+    generated::combined_brem_interact(this->device_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/CombinedBremModel.hh
+++ b/src/celeritas/em/model/CombinedBremModel.hh
@@ -59,10 +59,10 @@ class CombinedBremModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel to host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/CombinedBremModel.hh
+++ b/src/celeritas/em/model/CombinedBremModel.hh
@@ -59,10 +59,10 @@ class CombinedBremModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel to host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/EPlusGGModel.cc
+++ b/src/celeritas/em/model/EPlusGGModel.cc
@@ -65,13 +65,13 @@ auto EPlusGGModel::micro_xs(Applicability) const -> MicroXsBuilders
  */
 void EPlusGGModel::execute(CoreParams const& params, CoreStateHost& state) const
 {
-    generated::eplusgg_interact(this->host_ref(), params, state);
+    generated::eplusgg_interact(params, state, this->host_ref());
 }
 
 void EPlusGGModel::execute(CoreParams const& params,
                            CoreStateDevice& state) const
 {
-    generated::eplusgg_interact(this->device_ref(), params, state);
+    generated::eplusgg_interact(params, state, this->device_ref());
 }
 
 //!@}

--- a/src/celeritas/em/model/EPlusGGModel.cc
+++ b/src/celeritas/em/model/EPlusGGModel.cc
@@ -10,6 +10,7 @@
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/EPlusGGData.hh"
 #include "celeritas/em/generated/EPlusGGInteract.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleView.hh"
 
@@ -62,16 +63,15 @@ auto EPlusGGModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void EPlusGGModel::execute(ParamsDeviceCRef const& params,
-                           StateDeviceRef& states) const
+void EPlusGGModel::execute(CoreParams const& params, StateHostRef& states) const
 {
-    generated::eplusgg_interact(data_, params, states);
+    generated::eplusgg_interact(this->host_ref(), params, states);
 }
 
-void EPlusGGModel::execute(ParamsHostCRef const& params,
-                           StateHostRef& states) const
+void EPlusGGModel::execute(CoreParams const& params,
+                           StateDeviceRef& states) const
 {
-    generated::eplusgg_interact(data_, params, states);
+    generated::eplusgg_interact(this->device_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/EPlusGGModel.cc
+++ b/src/celeritas/em/model/EPlusGGModel.cc
@@ -63,15 +63,15 @@ auto EPlusGGModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void EPlusGGModel::execute(CoreParams const& params, StateHostRef& states) const
+void EPlusGGModel::execute(CoreParams const& params, CoreStateHost& state) const
 {
-    generated::eplusgg_interact(this->host_ref(), params, states);
+    generated::eplusgg_interact(this->host_ref(), params, state);
 }
 
 void EPlusGGModel::execute(CoreParams const& params,
-                           StateDeviceRef& states) const
+                           CoreStateDevice& state) const
 {
-    generated::eplusgg_interact(this->device_ref(), params, states);
+    generated::eplusgg_interact(this->device_ref(), params, state);
 }
 
 //!@}

--- a/src/celeritas/em/model/EPlusGGModel.hh
+++ b/src/celeritas/em/model/EPlusGGModel.hh
@@ -30,10 +30,10 @@ class EPlusGGModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Apply the interaction kernel on device
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;
@@ -47,8 +47,11 @@ class EPlusGGModel final : public Model
         return "Positron annihilation yielding two gammas";
     }
 
-    // Access data on device
-    EPlusGGData device_ref() const { return data_; }
+    //!@{
+    //! Access model data
+    EPlusGGData const& host_ref() const { return data_; }
+    EPlusGGData const& device_ref() const { return data_; }
+    //!@}
 
   private:
     EPlusGGData data_;

--- a/src/celeritas/em/model/EPlusGGModel.hh
+++ b/src/celeritas/em/model/EPlusGGModel.hh
@@ -30,10 +30,10 @@ class EPlusGGModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/KleinNishinaModel.cc
+++ b/src/celeritas/em/model/KleinNishinaModel.cc
@@ -67,15 +67,15 @@ auto KleinNishinaModel::micro_xs(Applicability) const -> MicroXsBuilders
  * Apply the interaction kernel.
  */
 void KleinNishinaModel::execute(CoreParams const& params,
-                                StateHostRef& states) const
+                                CoreStateHost& state) const
 {
-    generated::klein_nishina_interact(this->host_ref(), params, states);
+    generated::klein_nishina_interact(this->host_ref(), params, state);
 }
 
 void KleinNishinaModel::execute(CoreParams const& params,
-                                StateDeviceRef& states) const
+                                CoreStateDevice& state) const
 {
-    generated::klein_nishina_interact(this->device_ref(), params, states);
+    generated::klein_nishina_interact(this->device_ref(), params, state);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/KleinNishinaModel.cc
+++ b/src/celeritas/em/model/KleinNishinaModel.cc
@@ -69,13 +69,13 @@ auto KleinNishinaModel::micro_xs(Applicability) const -> MicroXsBuilders
 void KleinNishinaModel::execute(CoreParams const& params,
                                 CoreStateHost& state) const
 {
-    generated::klein_nishina_interact(this->host_ref(), params, state);
+    generated::klein_nishina_interact(params, state, this->host_ref());
 }
 
 void KleinNishinaModel::execute(CoreParams const& params,
                                 CoreStateDevice& state) const
 {
-    generated::klein_nishina_interact(this->device_ref(), params, state);
+    generated::klein_nishina_interact(params, state, this->device_ref());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/KleinNishinaModel.cc
+++ b/src/celeritas/em/model/KleinNishinaModel.cc
@@ -9,6 +9,7 @@
 
 #include "corecel/math/Quantity.hh"
 #include "celeritas/em/generated/KleinNishinaInteract.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleView.hh"
 
@@ -65,16 +66,16 @@ auto KleinNishinaModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void KleinNishinaModel::execute(ParamsDeviceCRef const& params,
-                                StateDeviceRef& states) const
-{
-    generated::klein_nishina_interact(data_, params, states);
-}
-
-void KleinNishinaModel::execute(ParamsHostCRef const& params,
+void KleinNishinaModel::execute(CoreParams const& params,
                                 StateHostRef& states) const
 {
-    generated::klein_nishina_interact(data_, params, states);
+    generated::klein_nishina_interact(this->host_ref(), params, states);
+}
+
+void KleinNishinaModel::execute(CoreParams const& params,
+                                StateDeviceRef& states) const
+{
+    generated::klein_nishina_interact(this->device_ref(), params, states);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/KleinNishinaModel.hh
+++ b/src/celeritas/em/model/KleinNishinaModel.hh
@@ -30,10 +30,10 @@ class KleinNishinaModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     //! Apply the interaction kernel to host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;
@@ -46,6 +46,12 @@ class KleinNishinaModel final : public Model
     {
         return "Klein-Nishina Compton scattering";
     }
+
+    //!@{
+    //! Access model data
+    KleinNishinaData const& host_ref() const { return data_; }
+    KleinNishinaData const& device_ref() const { return data_; }
+    //!@}
 
   private:
     KleinNishinaData data_;

--- a/src/celeritas/em/model/KleinNishinaModel.hh
+++ b/src/celeritas/em/model/KleinNishinaModel.hh
@@ -30,10 +30,10 @@ class KleinNishinaModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     //! Apply the interaction kernel to host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/LivermorePEModel.cc
+++ b/src/celeritas/em/model/LivermorePEModel.cc
@@ -106,13 +106,13 @@ auto LivermorePEModel::micro_xs(Applicability) const -> MicroXsBuilders
 void LivermorePEModel::execute(CoreParams const& params,
                                CoreStateHost& state) const
 {
-    generated::livermore_pe_interact(this->host_ref(), params, state);
+    generated::livermore_pe_interact(params, state, this->host_ref());
 }
 
 void LivermorePEModel::execute(CoreParams const& params,
                                CoreStateDevice& state) const
 {
-    generated::livermore_pe_interact(this->device_ref(), params, state);
+    generated::livermore_pe_interact(params, state, this->device_ref());
 }
 
 //!@}

--- a/src/celeritas/em/model/LivermorePEModel.cc
+++ b/src/celeritas/em/model/LivermorePEModel.cc
@@ -19,6 +19,7 @@
 #include "corecel/io/ScopedTimeLog.hh"
 #include "celeritas/em/data/LivermorePEData.hh"
 #include "celeritas/em/generated/LivermorePEInteract.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/grid/XsGridData.hh"
 #include "celeritas/io/ImportLivermorePE.hh"
 #include "celeritas/io/ImportPhysicsVector.hh"
@@ -102,16 +103,16 @@ auto LivermorePEModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void LivermorePEModel::execute(ParamsDeviceCRef const& params,
-                               StateDeviceRef& states) const
-{
-    generated::livermore_pe_interact(this->device_ref(), params, states);
-}
-
-void LivermorePEModel::execute(ParamsHostCRef const& params,
+void LivermorePEModel::execute(CoreParams const& params,
                                StateHostRef& states) const
 {
     generated::livermore_pe_interact(this->host_ref(), params, states);
+}
+
+void LivermorePEModel::execute(CoreParams const& params,
+                               StateDeviceRef& states) const
+{
+    generated::livermore_pe_interact(this->device_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/LivermorePEModel.cc
+++ b/src/celeritas/em/model/LivermorePEModel.cc
@@ -104,15 +104,15 @@ auto LivermorePEModel::micro_xs(Applicability) const -> MicroXsBuilders
  * Apply the interaction kernel.
  */
 void LivermorePEModel::execute(CoreParams const& params,
-                               StateHostRef& states) const
+                               CoreStateHost& state) const
 {
-    generated::livermore_pe_interact(this->host_ref(), params, states);
+    generated::livermore_pe_interact(this->host_ref(), params, state);
 }
 
 void LivermorePEModel::execute(CoreParams const& params,
-                               StateDeviceRef& states) const
+                               CoreStateDevice& state) const
 {
-    generated::livermore_pe_interact(this->device_ref(), params, states);
+    generated::livermore_pe_interact(this->device_ref(), params, state);
 }
 
 //!@}

--- a/src/celeritas/em/model/LivermorePEModel.hh
+++ b/src/celeritas/em/model/LivermorePEModel.hh
@@ -49,10 +49,10 @@ class LivermorePEModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/LivermorePEModel.hh
+++ b/src/celeritas/em/model/LivermorePEModel.hh
@@ -49,10 +49,10 @@ class LivermorePEModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Apply the interaction kernel on device
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/MollerBhabhaModel.cc
+++ b/src/celeritas/em/model/MollerBhabhaModel.cc
@@ -79,15 +79,15 @@ auto MollerBhabhaModel::micro_xs(Applicability) const -> MicroXsBuilders
  * Apply the interaction kernel.
  */
 void MollerBhabhaModel::execute(CoreParams const& params,
-                                StateHostRef& states) const
+                                CoreStateHost& state) const
 {
-    generated::moller_bhabha_interact(this->host_ref(), params, states);
+    generated::moller_bhabha_interact(this->host_ref(), params, state);
 }
 
 void MollerBhabhaModel::execute(CoreParams const& params,
-                                StateDeviceRef& states) const
+                                CoreStateDevice& state) const
 {
-    generated::moller_bhabha_interact(this->device_ref(), params, states);
+    generated::moller_bhabha_interact(this->device_ref(), params, state);
 }
 
 //!@}

--- a/src/celeritas/em/model/MollerBhabhaModel.cc
+++ b/src/celeritas/em/model/MollerBhabhaModel.cc
@@ -10,6 +10,7 @@
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/MollerBhabhaData.hh"
 #include "celeritas/em/generated/MollerBhabhaInteract.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/ParticleView.hh"
@@ -77,16 +78,16 @@ auto MollerBhabhaModel::micro_xs(Applicability) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void MollerBhabhaModel::execute(ParamsDeviceCRef const& params,
-                                StateDeviceRef& states) const
-{
-    generated::moller_bhabha_interact(data_, params, states);
-}
-
-void MollerBhabhaModel::execute(ParamsHostCRef const& params,
+void MollerBhabhaModel::execute(CoreParams const& params,
                                 StateHostRef& states) const
 {
-    generated::moller_bhabha_interact(data_, params, states);
+    generated::moller_bhabha_interact(this->host_ref(), params, states);
+}
+
+void MollerBhabhaModel::execute(CoreParams const& params,
+                                StateDeviceRef& states) const
+{
+    generated::moller_bhabha_interact(this->device_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/MollerBhabhaModel.cc
+++ b/src/celeritas/em/model/MollerBhabhaModel.cc
@@ -81,13 +81,13 @@ auto MollerBhabhaModel::micro_xs(Applicability) const -> MicroXsBuilders
 void MollerBhabhaModel::execute(CoreParams const& params,
                                 CoreStateHost& state) const
 {
-    generated::moller_bhabha_interact(this->host_ref(), params, state);
+    generated::moller_bhabha_interact(params, state, this->host_ref());
 }
 
 void MollerBhabhaModel::execute(CoreParams const& params,
                                 CoreStateDevice& state) const
 {
-    generated::moller_bhabha_interact(this->device_ref(), params, state);
+    generated::moller_bhabha_interact(params, state, this->device_ref());
 }
 
 //!@}

--- a/src/celeritas/em/model/MollerBhabhaModel.hh
+++ b/src/celeritas/em/model/MollerBhabhaModel.hh
@@ -31,10 +31,10 @@ class MollerBhabhaModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/MollerBhabhaModel.hh
+++ b/src/celeritas/em/model/MollerBhabhaModel.hh
@@ -31,10 +31,10 @@ class MollerBhabhaModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Apply the interaction kernel on device
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;
@@ -47,6 +47,12 @@ class MollerBhabhaModel final : public Model
     {
         return "Moller+Bhabha scattering";
     }
+
+    //!@{
+    //! Access model data
+    MollerBhabhaData const& host_ref() const { return data_; }
+    MollerBhabhaData const& device_ref() const { return data_; }
+    //!@}
 
   private:
     MollerBhabhaData data_;

--- a/src/celeritas/em/model/MuBremsstrahlungModel.cc
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.cc
@@ -82,13 +82,13 @@ auto MuBremsstrahlungModel::micro_xs(Applicability applic) const
 void MuBremsstrahlungModel::execute(CoreParams const& params,
                                     CoreStateHost& state) const
 {
-    generated::mu_bremsstrahlung_interact(this->host_ref(), params, state);
+    generated::mu_bremsstrahlung_interact(params, state, this->host_ref());
 }
 
 void MuBremsstrahlungModel::execute(CoreParams const& params,
                                     CoreStateDevice& state) const
 {
-    generated::mu_bremsstrahlung_interact(this->device_ref(), params, state);
+    generated::mu_bremsstrahlung_interact(params, state, this->device_ref());
 }
 
 //!@}

--- a/src/celeritas/em/model/MuBremsstrahlungModel.cc
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.cc
@@ -80,15 +80,15 @@ auto MuBremsstrahlungModel::micro_xs(Applicability applic) const
  * Apply the interaction kernel.
  */
 void MuBremsstrahlungModel::execute(CoreParams const& params,
-                                    StateHostRef& states) const
+                                    CoreStateHost& state) const
 {
-    generated::mu_bremsstrahlung_interact(this->host_ref(), params, states);
+    generated::mu_bremsstrahlung_interact(this->host_ref(), params, state);
 }
 
 void MuBremsstrahlungModel::execute(CoreParams const& params,
-                                    StateDeviceRef& states) const
+                                    CoreStateDevice& state) const
 {
-    generated::mu_bremsstrahlung_interact(this->device_ref(), params, states);
+    generated::mu_bremsstrahlung_interact(this->device_ref(), params, state);
 }
 
 //!@}

--- a/src/celeritas/em/model/MuBremsstrahlungModel.cc
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.cc
@@ -11,6 +11,7 @@
 
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/generated/MuBremsstrahlungInteract.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/io/ImportProcess.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleView.hh"
@@ -78,16 +79,16 @@ auto MuBremsstrahlungModel::micro_xs(Applicability applic) const
 /*!
  * Apply the interaction kernel.
  */
-void MuBremsstrahlungModel::execute(ParamsDeviceCRef const& params,
-                                    StateDeviceRef& states) const
-{
-    generated::mu_bremsstrahlung_interact(data_, params, states);
-}
-
-void MuBremsstrahlungModel::execute(ParamsHostCRef const& params,
+void MuBremsstrahlungModel::execute(CoreParams const& params,
                                     StateHostRef& states) const
 {
-    generated::mu_bremsstrahlung_interact(data_, params, states);
+    generated::mu_bremsstrahlung_interact(this->host_ref(), params, states);
+}
+
+void MuBremsstrahlungModel::execute(CoreParams const& params,
+                                    StateDeviceRef& states) const
+{
+    generated::mu_bremsstrahlung_interact(this->device_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/MuBremsstrahlungModel.hh
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.hh
@@ -42,10 +42,10 @@ class MuBremsstrahlungModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Apply the interaction kernel on device
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;
@@ -55,6 +55,12 @@ class MuBremsstrahlungModel final : public Model
 
     //! Name of the model, for user interaction
     std::string description() const final { return "Muon bremsstrahlung"; }
+
+    //!@{
+    //! Access model data
+    MuBremsstrahlungData const& host_ref() const { return data_; }
+    MuBremsstrahlungData const& device_ref() const { return data_; }
+    //!@}
 
   private:
     MuBremsstrahlungData data_;

--- a/src/celeritas/em/model/MuBremsstrahlungModel.hh
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.hh
@@ -42,10 +42,10 @@ class MuBremsstrahlungModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on host
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/RayleighModel.cc
+++ b/src/celeritas/em/model/RayleighModel.cc
@@ -14,6 +14,7 @@
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/RayleighData.hh"
 #include "celeritas/em/generated/RayleighInteract.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/io/ImportProcess.hh"
 #include "celeritas/mat/ElementView.hh"
 #include "celeritas/phys/PDGNumber.hh"
@@ -81,16 +82,15 @@ auto RayleighModel::micro_xs(Applicability applic) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void RayleighModel::execute(ParamsDeviceCRef const& params,
+void RayleighModel::execute(CoreParams const& params, StateHostRef& states) const
+{
+    generated::rayleigh_interact(this->host_ref(), params, states);
+}
+
+void RayleighModel::execute(CoreParams const& params,
                             StateDeviceRef& states) const
 {
     generated::rayleigh_interact(this->device_ref(), params, states);
-}
-
-void RayleighModel::execute(ParamsHostCRef const& params,
-                            StateHostRef& states) const
-{
-    generated::rayleigh_interact(this->host_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/RayleighModel.cc
+++ b/src/celeritas/em/model/RayleighModel.cc
@@ -82,15 +82,15 @@ auto RayleighModel::micro_xs(Applicability applic) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void RayleighModel::execute(CoreParams const& params, StateHostRef& states) const
+void RayleighModel::execute(CoreParams const& params, CoreStateHost& state) const
 {
-    generated::rayleigh_interact(this->host_ref(), params, states);
+    generated::rayleigh_interact(this->host_ref(), params, state);
 }
 
 void RayleighModel::execute(CoreParams const& params,
-                            StateDeviceRef& states) const
+                            CoreStateDevice& state) const
 {
-    generated::rayleigh_interact(this->device_ref(), params, states);
+    generated::rayleigh_interact(this->device_ref(), params, state);
 }
 
 //!@}

--- a/src/celeritas/em/model/RayleighModel.cc
+++ b/src/celeritas/em/model/RayleighModel.cc
@@ -84,13 +84,13 @@ auto RayleighModel::micro_xs(Applicability applic) const -> MicroXsBuilders
  */
 void RayleighModel::execute(CoreParams const& params, CoreStateHost& state) const
 {
-    generated::rayleigh_interact(this->host_ref(), params, state);
+    generated::rayleigh_interact(params, state, this->host_ref());
 }
 
 void RayleighModel::execute(CoreParams const& params,
                             CoreStateDevice& state) const
 {
-    generated::rayleigh_interact(this->device_ref(), params, state);
+    generated::rayleigh_interact(params, state, this->device_ref());
 }
 
 //!@}

--- a/src/celeritas/em/model/RayleighModel.hh
+++ b/src/celeritas/em/model/RayleighModel.hh
@@ -49,10 +49,10 @@ class RayleighModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel to host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/RayleighModel.hh
+++ b/src/celeritas/em/model/RayleighModel.hh
@@ -49,10 +49,10 @@ class RayleighModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel to host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -102,15 +102,15 @@ auto RelativisticBremModel::micro_xs(Applicability applic) const
  * Apply the interaction kernel.
  */
 void RelativisticBremModel::execute(CoreParams const& params,
-                                    StateHostRef& states) const
+                                    CoreStateHost& state) const
 {
-    generated::relativistic_brem_interact(this->host_ref(), params, states);
+    generated::relativistic_brem_interact(this->host_ref(), params, state);
 }
 
 void RelativisticBremModel::execute(CoreParams const& params,
-                                    StateDeviceRef& states) const
+                                    CoreStateDevice& state) const
 {
-    generated::relativistic_brem_interact(this->device_ref(), params, states);
+    generated::relativistic_brem_interact(this->device_ref(), params, state);
 }
 
 //!@}

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -104,13 +104,13 @@ auto RelativisticBremModel::micro_xs(Applicability applic) const
 void RelativisticBremModel::execute(CoreParams const& params,
                                     CoreStateHost& state) const
 {
-    generated::relativistic_brem_interact(this->host_ref(), params, state);
+    generated::relativistic_brem_interact(params, state, this->host_ref());
 }
 
 void RelativisticBremModel::execute(CoreParams const& params,
                                     CoreStateDevice& state) const
 {
-    generated::relativistic_brem_interact(this->device_ref(), params, state);
+    generated::relativistic_brem_interact(params, state, this->device_ref());
 }
 
 //!@}

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -17,6 +17,7 @@
 #include "celeritas/em/data/ElectronBremsData.hh"
 #include "celeritas/em/data/RelativisticBremData.hh"
 #include "celeritas/em/generated/RelativisticBremInteract.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/io/ImportProcess.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
@@ -100,16 +101,16 @@ auto RelativisticBremModel::micro_xs(Applicability applic) const
 /*!
  * Apply the interaction kernel.
  */
-void RelativisticBremModel::execute(ParamsDeviceCRef const& params,
-                                    StateDeviceRef& states) const
-{
-    generated::relativistic_brem_interact(this->device_ref(), params, states);
-}
-
-void RelativisticBremModel::execute(ParamsHostCRef const& params,
+void RelativisticBremModel::execute(CoreParams const& params,
                                     StateHostRef& states) const
 {
     generated::relativistic_brem_interact(this->host_ref(), params, states);
+}
+
+void RelativisticBremModel::execute(CoreParams const& params,
+                                    StateDeviceRef& states) const
+{
+    generated::relativistic_brem_interact(this->device_ref(), params, states);
 }
 
 //!@}

--- a/src/celeritas/em/model/RelativisticBremModel.hh
+++ b/src/celeritas/em/model/RelativisticBremModel.hh
@@ -52,10 +52,10 @@ class RelativisticBremModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel to host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/RelativisticBremModel.hh
+++ b/src/celeritas/em/model/RelativisticBremModel.hh
@@ -52,10 +52,10 @@ class RelativisticBremModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel to host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Apply the interaction kernel to device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -128,13 +128,13 @@ auto SeltzerBergerModel::micro_xs(Applicability applic) const -> MicroXsBuilders
 void SeltzerBergerModel::execute(CoreParams const& params,
                                  CoreStateHost& state) const
 {
-    generated::seltzer_berger_interact(this->host_ref(), params, state);
+    generated::seltzer_berger_interact(params, state, this->host_ref());
 }
 
 void SeltzerBergerModel::execute(CoreParams const& params,
                                  CoreStateDevice& state) const
 {
-    generated::seltzer_berger_interact(this->device_ref(), params, state);
+    generated::seltzer_berger_interact(params, state, this->device_ref());
 }
 
 //!@}

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -24,6 +24,7 @@
 #include "celeritas/em/generated/SeltzerBergerInteract.hh"
 #include "celeritas/em/interactor/detail/PhysicsConstants.hh"
 #include "celeritas/em/interactor/detail/SBPositronXsCorrector.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/io/ImportProcess.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/phys/PDGNumber.hh"
@@ -124,17 +125,18 @@ auto SeltzerBergerModel::micro_xs(Applicability applic) const -> MicroXsBuilders
 /*!
  * Apply the interaction kernel.
  */
-void SeltzerBergerModel::execute(ParamsDeviceCRef const& params,
+void SeltzerBergerModel::execute(CoreParams const& params,
+                                 StateHostRef& states) const
+{
+    generated::seltzer_berger_interact(this->host_ref(), params, states);
+}
+
+void SeltzerBergerModel::execute(CoreParams const& params,
                                  StateDeviceRef& states) const
 {
     generated::seltzer_berger_interact(this->device_ref(), params, states);
 }
 
-void SeltzerBergerModel::execute(ParamsHostCRef const& params,
-                                 StateHostRef& states) const
-{
-    generated::seltzer_berger_interact(this->host_ref(), params, states);
-}
 //!@}
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -126,15 +126,15 @@ auto SeltzerBergerModel::micro_xs(Applicability applic) const -> MicroXsBuilders
  * Apply the interaction kernel.
  */
 void SeltzerBergerModel::execute(CoreParams const& params,
-                                 StateHostRef& states) const
+                                 CoreStateHost& state) const
 {
-    generated::seltzer_berger_interact(this->host_ref(), params, states);
+    generated::seltzer_berger_interact(this->host_ref(), params, state);
 }
 
 void SeltzerBergerModel::execute(CoreParams const& params,
-                                 StateDeviceRef& states) const
+                                 CoreStateDevice& state) const
 {
-    generated::seltzer_berger_interact(this->device_ref(), params, states);
+    generated::seltzer_berger_interact(this->device_ref(), params, state);
 }
 
 //!@}

--- a/src/celeritas/em/model/SeltzerBergerModel.hh
+++ b/src/celeritas/em/model/SeltzerBergerModel.hh
@@ -73,10 +73,10 @@ class SeltzerBergerModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on device
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Apply the interaction kernel
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/em/model/SeltzerBergerModel.hh
+++ b/src/celeritas/em/model/SeltzerBergerModel.hh
@@ -73,10 +73,10 @@ class SeltzerBergerModel final : public Model
     MicroXsBuilders micro_xs(Applicability) const final;
 
     // Apply the interaction kernel on device
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Apply the interaction kernel
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     // ID of the model
     ActionId action_id() const final;

--- a/src/celeritas/geo/generated/BoundaryAction.cc
+++ b/src/celeritas/geo/generated/BoundaryAction.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "../detail/BoundaryActionImpl.hh" // IWYU pragma: associated
@@ -23,19 +24,17 @@ namespace celeritas
 {
 namespace generated
 {
-void BoundaryAction::execute(CoreParams const& params, StateHostRef& state) const
+void BoundaryAction::execute(CoreParams const& params, CoreStateHost& state) const
 {
-    CELER_EXPECT(state);
-
     MultiExceptionHandler capture_exception;
-    TrackLauncher launch{params.ref<MemSpace::native>(), state, detail::boundary_track};
+    TrackLauncher launch{params.ref<MemSpace::native>(), state.ref(), detail::boundary_track};
     #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, this->label()));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/geo/generated/BoundaryAction.cc
+++ b/src/celeritas/geo/generated/BoundaryAction.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "../detail/BoundaryActionImpl.hh" // IWYU pragma: associated
@@ -22,19 +23,19 @@ namespace celeritas
 {
 namespace generated
 {
-void BoundaryAction::execute(ParamsHostCRef const& params, StateHostRef& state) const
+void BoundaryAction::execute(CoreParams const& params, StateHostRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
 
     MultiExceptionHandler capture_exception;
-    TrackLauncher launch{params, state, detail::boundary_track};
+    TrackLauncher launch{params.ref<MemSpace::native>(), state, detail::boundary_track};
     #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, this->label()));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/geo/generated/BoundaryAction.cu
+++ b/src/celeritas/geo/generated/BoundaryAction.cu
@@ -32,13 +32,13 @@ __global__ void boundary_kernel(
 }
 }  // namespace
 
-void BoundaryAction::execute(ParamsDeviceCRef const& params, StateDeviceRef& state) const
+void BoundaryAction::execute(CoreParams const& params, StateDeviceRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(boundary,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
 }
 

--- a/src/celeritas/geo/generated/BoundaryAction.cu
+++ b/src/celeritas/geo/generated/BoundaryAction.cu
@@ -13,6 +13,8 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "../detail/BoundaryActionImpl.hh"
 

--- a/src/celeritas/geo/generated/BoundaryAction.cu
+++ b/src/celeritas/geo/generated/BoundaryAction.cu
@@ -32,14 +32,13 @@ __global__ void boundary_kernel(
 }
 }  // namespace
 
-void BoundaryAction::execute(CoreParams const& params, StateDeviceRef& state) const
+void BoundaryAction::execute(CoreParams const& params, CoreStateDevice& state) const
 {
-    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(boundary,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/geo/generated/BoundaryAction.hh
+++ b/src/celeritas/geo/generated/BoundaryAction.hh
@@ -25,17 +25,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(ParamsHostCRef const&, StateHostRef&) const final;
+  void execute(CoreParams const&, StateHostRef&) const final;
 
   // Launch kernel with device data
-  void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+  void execute(CoreParams const&, StateDeviceRef&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final { return ActionOrder::post; }
 };
 
 #if !CELER_USE_DEVICE
-inline void BoundaryAction::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
+inline void BoundaryAction::execute(CoreParams const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/geo/generated/BoundaryAction.hh
+++ b/src/celeritas/geo/generated/BoundaryAction.hh
@@ -11,7 +11,6 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "celeritas/global/ActionInterface.hh"
-#include "celeritas/global/CoreTrackData.hh"
 
 namespace celeritas
 {
@@ -25,17 +24,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(CoreParams const&, StateHostRef&) const final;
+  void execute(CoreParams const&, CoreStateHost&) const final;
 
   // Launch kernel with device data
-  void execute(CoreParams const&, StateDeviceRef&) const final;
+  void execute(CoreParams const&, CoreStateDevice&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final { return ActionOrder::post; }
 };
 
 #if !CELER_USE_DEVICE
-inline void BoundaryAction::execute(CoreParams const&, StateDeviceRef&) const
+inline void BoundaryAction::execute(CoreParams const&, CoreStateDevice&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/ActionInterface.hh
+++ b/src/celeritas/global/ActionInterface.hh
@@ -14,7 +14,10 @@
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
 class CoreParams;
+template<MemSpace M>
+class CoreState;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -70,16 +73,16 @@ class ExplicitActionInterface : public virtual ActionInterface
   public:
     //@{
     //! \name Type aliases
-    using StateDeviceRef = DeviceRef<CoreStateData>;
-    using StateHostRef = HostRef<CoreStateData>;
+    using CoreStateHost = CoreState<MemSpace::host>;
+    using CoreStateDevice = CoreState<MemSpace::device>;
     //@}
 
   public:
     //! Execute the action with host data
-    virtual void execute(CoreParams const&, StateHostRef&) const = 0;
+    virtual void execute(CoreParams const&, CoreStateHost&) const = 0;
 
     //! Execute the action with device data
-    virtual void execute(CoreParams const&, StateDeviceRef&) const = 0;
+    virtual void execute(CoreParams const&, CoreStateDevice&) const = 0;
 
     //! Dependency ordering of the action
     virtual ActionOrder order() const = 0;
@@ -102,8 +105,8 @@ class ExplicitActionInterface : public virtual ActionInterface
       // Construct with ID and label
       using ConcreteAction::ConcreteAction;
 
-      void execute(CoreParams const&, StateHostRef&) const final;
-      void execute(CoreParams const&, StateDeviceRef&) const final;
+      void execute(CoreParams const&, CoreStateHost&) const final;
+      void execute(CoreParams const&, CoreStateDevice&) const final;
 
       ActionOrder order() const final { return ActionOrder::post; }
   };

--- a/src/celeritas/global/ActionInterface.hh
+++ b/src/celeritas/global/ActionInterface.hh
@@ -14,6 +14,8 @@
 
 namespace celeritas
 {
+class CoreParams;
+
 //---------------------------------------------------------------------------//
 /*!
  * Pure abstract interface for an end-of-step action.
@@ -68,18 +70,16 @@ class ExplicitActionInterface : public virtual ActionInterface
   public:
     //@{
     //! \name Type aliases
-    using ParamsDeviceCRef = DeviceCRef<CoreParamsData>;
-    using ParamsHostCRef = HostCRef<CoreParamsData>;
     using StateDeviceRef = DeviceRef<CoreStateData>;
     using StateHostRef = HostRef<CoreStateData>;
     //@}
 
   public:
     //! Execute the action with host data
-    virtual void execute(ParamsHostCRef const&, StateHostRef&) const = 0;
+    virtual void execute(CoreParams const&, StateHostRef&) const = 0;
 
     //! Execute the action with device data
-    virtual void execute(ParamsDeviceCRef const&, StateDeviceRef&) const = 0;
+    virtual void execute(CoreParams const&, StateDeviceRef&) const = 0;
 
     //! Dependency ordering of the action
     virtual ActionOrder order() const = 0;
@@ -102,8 +102,8 @@ class ExplicitActionInterface : public virtual ActionInterface
       // Construct with ID and label
       using ConcreteAction::ConcreteAction;
 
-      void execute(ParamsHostCRef const&, StateHostRef&) const final;
-      void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+      void execute(CoreParams const&, StateHostRef&) const final;
+      void execute(CoreParams const&, StateDeviceRef&) const final;
 
       ActionOrder order() const final { return ActionOrder::post; }
   };

--- a/src/celeritas/global/CoreTrackData.cc
+++ b/src/celeritas/global/CoreTrackData.cc
@@ -21,7 +21,6 @@ void resize(CoreStateData<Ownership::value, M>* state,
             StreamId stream_id,
             size_type size)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(params);
     CELER_EXPECT(stream_id);
     CELER_EXPECT(size > 0);

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -59,7 +59,7 @@ Stepper<M>::~Stepper() = default;
 template<MemSpace M>
 auto Stepper<M>::operator()() -> result_type
 {
-    actions_->execute(*params_, state_.ref());
+    actions_->execute(*params_, state_);
 
     // Get the number of track initializers and active tracks
     auto const& init = this->state_ref().init;
@@ -97,7 +97,7 @@ auto Stepper<M>::operator()(SpanConstPrimary primaries) -> result_type
                    << " exceeds max_events=" << params_->init()->max_events());
 
     // Create track initializers
-    extend_from_primaries(*params_, state_.ref(), primaries);
+    extend_from_primaries(*params_, state_, primaries);
 
     return (*this)();
 }

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -59,7 +59,7 @@ Stepper<M>::~Stepper() = default;
 template<MemSpace M>
 auto Stepper<M>::operator()() -> result_type
 {
-    actions_->execute(params_->ref<M>(), state_.ref());
+    actions_->execute(*params_, state_.ref());
 
     // Get the number of track initializers and active tracks
     auto const& init = this->state_ref().init;
@@ -97,7 +97,7 @@ auto Stepper<M>::operator()(SpanConstPrimary primaries) -> result_type
                    << " exceeds max_events=" << params_->init()->max_events());
 
     // Create track initializers
-    extend_from_primaries(params_->ref<M>(), state_.ref(), primaries);
+    extend_from_primaries(*params_, state_.ref(), primaries);
 
     return (*this)();
 }

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
@@ -18,6 +18,7 @@
 #include "celeritas/em/FluctuationParams.hh"
 #include "celeritas/em/UrbanMscParams.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/CoreTrackData.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
@@ -72,13 +73,11 @@ AlongStepGeneralLinearAction::~AlongStepGeneralLinearAction() = default;
  * Launch the along-step action on host.
  */
 void AlongStepGeneralLinearAction::execute(CoreParams const& params,
-                                           StateHostRef& state) const
+                                           CoreStateHost& state) const
 {
-    CELER_EXPECT(state);
-
     MultiExceptionHandler capture_exception;
     auto launch = make_active_track_launcher(params.ref<MemSpace::native>(),
-                                             state,
+                                             state.ref(),
                                              detail::along_step_general_linear,
                                              host_data_.msc,
                                              host_data_.fluct);
@@ -90,7 +89,7 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
             launch(ThreadId{i}),
             capture_exception,
             KernelContextException(params.ref<MemSpace::host>(),
-                                   state,
+                                   state.ref(),
                                    ThreadId{i},
                                    this->label()));
     }

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
@@ -105,14 +105,13 @@ along_step_update_track_kernel(DeviceCRef<CoreParamsData> const params,
  * Launch the along-step action on device.
  */
 void AlongStepGeneralLinearAction::execute(CoreParams const& params,
-                                           StateDeviceRef& state) const
+                                           CoreStateDevice& state) const
 {
-    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(along_step_apply_msc_step_limit,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_apply_linear_propagation,
                         celeritas::device().default_block_size(),
@@ -123,7 +122,7 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_update_time,
                         celeritas::device().default_block_size(),
@@ -134,7 +133,7 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         device_data_.fluct);
     CELER_LAUNCH_KERNEL(along_step_update_track,
                         celeritas::device().default_block_size(),

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
@@ -16,6 +16,7 @@
 #include "celeritas/em/data/FluctuationData.hh"
 #include "celeritas/em/data/UrbanMscData.hh"
 #include "celeritas/em/msc/UrbanMsc.hh"  // IWYU pragma: associated
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
 #include "detail/AlongStepImpl.hh"
@@ -103,42 +104,42 @@ along_step_update_track_kernel(DeviceCRef<CoreParamsData> const params,
 /*!
  * Launch the along-step action on device.
  */
-void AlongStepGeneralLinearAction::execute(ParamsDeviceCRef const& params,
+void AlongStepGeneralLinearAction::execute(CoreParams const& params,
                                            StateDeviceRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(along_step_apply_msc_step_limit,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_apply_linear_propagation,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
     CELER_LAUNCH_KERNEL(along_step_apply_msc,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_update_time,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
     CELER_LAUNCH_KERNEL(along_step_apply_fluct_eloss,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         device_data_.fluct);
     CELER_LAUNCH_KERNEL(along_step_update_track,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
 }
 

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
@@ -17,6 +17,7 @@
 #include "celeritas/em/data/UrbanMscData.hh"
 #include "celeritas/em/msc/UrbanMsc.hh"  // IWYU pragma: associated
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
 #include "detail/AlongStepImpl.hh"
@@ -117,7 +118,7 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
     CELER_LAUNCH_KERNEL(along_step_apply_msc,
                         celeritas::device().default_block_size(),
                         state.size(),
@@ -128,7 +129,7 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
     CELER_LAUNCH_KERNEL(along_step_apply_fluct_eloss,
                         celeritas::device().default_block_size(),
                         state.size(),
@@ -139,7 +140,7 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.hh
@@ -59,10 +59,10 @@ class AlongStepGeneralLinearAction final : public ExplicitActionInterface
     ~AlongStepGeneralLinearAction();
 
     // Launch kernel with host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Launch kernel with device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }
@@ -113,8 +113,8 @@ class AlongStepGeneralLinearAction final : public ExplicitActionInterface
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void AlongStepGeneralLinearAction::execute(ParamsDeviceCRef const&,
-                                                  StateDeviceRef&) const
+inline void
+AlongStepGeneralLinearAction::execute(CoreParams const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.hh
@@ -59,10 +59,10 @@ class AlongStepGeneralLinearAction final : public ExplicitActionInterface
     ~AlongStepGeneralLinearAction();
 
     // Launch kernel with host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Launch kernel with device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }
@@ -113,8 +113,8 @@ class AlongStepGeneralLinearAction final : public ExplicitActionInterface
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void
-AlongStepGeneralLinearAction::execute(CoreParams const&, StateDeviceRef&) const
+inline void AlongStepGeneralLinearAction::execute(CoreParams const&,
+                                                  CoreStateDevice&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
@@ -12,6 +12,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "celeritas/Types.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreTrackData.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
@@ -33,29 +34,31 @@ AlongStepNeutralAction::AlongStepNeutralAction(ActionId id) : id_(id)
 /*!
  * Launch the along-step action on host.
  */
-void AlongStepNeutralAction::execute(ParamsHostCRef const& params,
+void AlongStepNeutralAction::execute(CoreParams const& params,
                                      StateHostRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
 
     MultiExceptionHandler capture_exception;
     auto launch = make_active_track_launcher(
-        params, state, detail::along_step_neutral);
+        params.ref<MemSpace::native>(), state, detail::along_step_neutral);
 #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, this->label()));
+            KernelContextException(params.ref<MemSpace::host>(),
+                                   state,
+                                   ThreadId{i},
+                                   this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }
 
 //---------------------------------------------------------------------------//
 #if !CELER_USE_DEVICE
-void AlongStepNeutralAction::execute(ParamsDeviceCRef const&,
-                                     StateDeviceRef&) const
+void AlongStepNeutralAction::execute(CoreParams const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
@@ -12,6 +12,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
 #include "detail/AlongStepNeutral.hh"
@@ -36,14 +37,14 @@ along_step_neutral_kernel(DeviceCRef<CoreParamsData> const params,
 /*!
  * Launch the along-step action on device.
  */
-void AlongStepNeutralAction::execute(ParamsDeviceCRef const& params,
+void AlongStepNeutralAction::execute(CoreParams const& params,
                                      StateDeviceRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(along_step_neutral,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
 }
 

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
@@ -13,6 +13,7 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
 #include "detail/AlongStepNeutral.hh"
@@ -44,7 +45,7 @@ void AlongStepNeutralAction::execute(CoreParams const& params,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
@@ -38,9 +38,8 @@ along_step_neutral_kernel(DeviceCRef<CoreParamsData> const params,
  * Launch the along-step action on device.
  */
 void AlongStepNeutralAction::execute(CoreParams const& params,
-                                     StateDeviceRef& state) const
+                                     CoreStateDevice& state) const
 {
-    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(along_step_neutral,
                         celeritas::device().default_block_size(),
                         state.size(),

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.hh
@@ -29,10 +29,10 @@ class AlongStepNeutralAction final : public ExplicitActionInterface
     explicit AlongStepNeutralAction(ActionId id);
 
     // Launch kernel with host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Launch kernel with device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.hh
@@ -29,10 +29,10 @@ class AlongStepNeutralAction final : public ExplicitActionInterface
     explicit AlongStepNeutralAction(ActionId id);
 
     // Launch kernel with host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Launch kernel with device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
@@ -18,12 +18,12 @@
 #include "celeritas/em/FluctuationParams.hh"
 #include "celeritas/em/UrbanMscParams.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreTrackData.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
 #include "detail/AlongStepRZMapFieldMsc.hh"
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -67,13 +67,13 @@ AlongStepRZMapFieldMscAction::AlongStepRZMapFieldMscAction(
 /*!
  * Launch the along-step action on host.
  */
-void AlongStepRZMapFieldMscAction::execute(ParamsHostCRef const& params,
+void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
                                            StateHostRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     MultiExceptionHandler capture_exception;
 
-    auto launch = make_active_track_launcher(params,
+    auto launch = make_active_track_launcher(params.ref<MemSpace::native>(),
                                              state,
                                              detail::along_step_mapfield_msc,
                                              msc_->host_ref(),
@@ -86,7 +86,10 @@ void AlongStepRZMapFieldMscAction::execute(ParamsHostCRef const& params,
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, this->label()));
+            KernelContextException(params.ref<MemSpace::host>(),
+                                   state,
+                                   ThreadId{i},
+                                   this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
@@ -19,6 +19,7 @@
 #include "celeritas/em/UrbanMscParams.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/CoreTrackData.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
@@ -68,13 +69,12 @@ AlongStepRZMapFieldMscAction::AlongStepRZMapFieldMscAction(
  * Launch the along-step action on host.
  */
 void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
-                                           StateHostRef& state) const
+                                           CoreStateHost& state) const
 {
-    CELER_EXPECT(state);
     MultiExceptionHandler capture_exception;
 
     auto launch = make_active_track_launcher(params.ref<MemSpace::native>(),
-                                             state,
+                                             state.ref(),
                                              detail::along_step_mapfield_msc,
                                              msc_->host_ref(),
                                              field_->host_ref(),
@@ -87,7 +87,7 @@ void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
             launch(ThreadId{i}),
             capture_exception,
             KernelContextException(params.ref<MemSpace::host>(),
-                                   state,
+                                   state.ref(),
                                    ThreadId{i},
                                    this->label()));
     }

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cu
@@ -115,26 +115,25 @@ along_step_update_track_kernel(DeviceCRef<CoreParamsData> const params,
  * Launch the along-step action on device.
  */
 void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
-                                           StateDeviceRef& state) const
+                                           CoreStateDevice& state) const
 {
-    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(along_step_apply_msc_step_limit,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         msc_->device_ref());
     CELER_LAUNCH_KERNEL(along_step_apply_rzmap_propagation,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         field_->device_ref());
     CELER_LAUNCH_KERNEL(along_step_apply_msc,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         msc_->device_ref());
     CELER_LAUNCH_KERNEL(along_step_update_time,
                         celeritas::device().default_block_size(),
@@ -145,7 +144,7 @@ void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         fluct_->device_ref());
     CELER_LAUNCH_KERNEL(along_step_update_track,
                         celeritas::device().default_block_size(),

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cu
@@ -22,6 +22,8 @@
 #include "celeritas/field/RZMapField.hh"
 #include "celeritas/field/RZMapFieldData.hh"
 #include "celeritas/field/RZMapFieldParams.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
 #include "detail/AlongStepImpl.hh"
@@ -139,7 +141,7 @@ void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
     CELER_LAUNCH_KERNEL(along_step_apply_fluct_eloss,
                         celeritas::device().default_block_size(),
                         state.size(),
@@ -150,7 +152,7 @@ void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cu
@@ -114,43 +114,43 @@ along_step_update_track_kernel(DeviceCRef<CoreParamsData> const params,
 /*!
  * Launch the along-step action on device.
  */
-void AlongStepRZMapFieldMscAction::execute(ParamsDeviceCRef const& params,
+void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
                                            StateDeviceRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(along_step_apply_msc_step_limit,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         msc_->device_ref());
     CELER_LAUNCH_KERNEL(along_step_apply_rzmap_propagation,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         field_->device_ref());
     CELER_LAUNCH_KERNEL(along_step_apply_msc,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         msc_->device_ref());
     CELER_LAUNCH_KERNEL(along_step_update_time,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
     CELER_LAUNCH_KERNEL(along_step_apply_fluct_eloss,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         fluct_->device_ref());
     CELER_LAUNCH_KERNEL(along_step_update_track,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
 }
 

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.hh
@@ -56,10 +56,10 @@ class AlongStepRZMapFieldMscAction final : public ExplicitActionInterface
                                  SPConstMsc msc);
 
     // Launch kernel with host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Launch kernel with device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }
@@ -96,8 +96,8 @@ class AlongStepRZMapFieldMscAction final : public ExplicitActionInterface
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void AlongStepRZMapFieldMscAction::execute(ParamsDeviceCRef const&,
-                                                  StateDeviceRef&) const
+inline void
+AlongStepRZMapFieldMscAction::execute(CoreParams const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.hh
@@ -56,10 +56,10 @@ class AlongStepRZMapFieldMscAction final : public ExplicitActionInterface
                                  SPConstMsc msc);
 
     // Launch kernel with host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Launch kernel with device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }
@@ -96,8 +96,8 @@ class AlongStepRZMapFieldMscAction final : public ExplicitActionInterface
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void
-AlongStepRZMapFieldMscAction::execute(CoreParams const&, StateDeviceRef&) const
+inline void AlongStepRZMapFieldMscAction::execute(CoreParams const&,
+                                                  CoreStateDevice&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
@@ -15,12 +15,12 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "celeritas/em/UrbanMscParams.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreTrackData.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
 #include "detail/AlongStepUniformMsc.hh"
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -46,13 +46,13 @@ AlongStepUniformMscAction::~AlongStepUniformMscAction() = default;
 /*!
  * Launch the along-step action on host.
  */
-void AlongStepUniformMscAction::execute(ParamsHostCRef const& params,
+void AlongStepUniformMscAction::execute(CoreParams const& params,
                                         StateHostRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
 
     MultiExceptionHandler capture_exception;
-    auto launch = make_active_track_launcher(params,
+    auto launch = make_active_track_launcher(params.ref<MemSpace::native>(),
                                              state,
                                              detail::along_step_uniform_msc,
                                              host_data_.msc,
@@ -64,7 +64,10 @@ void AlongStepUniformMscAction::execute(ParamsHostCRef const& params,
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, this->label()));
+            KernelContextException(params.ref<MemSpace::host>(),
+                                   state,
+                                   ThreadId{i},
+                                   this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
@@ -16,6 +16,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "celeritas/em/UrbanMscParams.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/CoreTrackData.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
@@ -47,13 +48,11 @@ AlongStepUniformMscAction::~AlongStepUniformMscAction() = default;
  * Launch the along-step action on host.
  */
 void AlongStepUniformMscAction::execute(CoreParams const& params,
-                                        StateHostRef& state) const
+                                        CoreStateHost& state) const
 {
-    CELER_EXPECT(state);
-
     MultiExceptionHandler capture_exception;
     auto launch = make_active_track_launcher(params.ref<MemSpace::native>(),
-                                             state,
+                                             state.ref(),
                                              detail::along_step_uniform_msc,
                                              host_data_.msc,
                                              field_params_);
@@ -65,7 +64,7 @@ void AlongStepUniformMscAction::execute(CoreParams const& params,
             launch(ThreadId{i}),
             capture_exception,
             KernelContextException(params.ref<MemSpace::host>(),
-                                   state,
+                                   state.ref(),
                                    ThreadId{i},
                                    this->label()));
     }

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
@@ -18,6 +18,8 @@
 #include "celeritas/field/FieldDriverOptions.hh"
 #include "celeritas/field/MakeMagFieldPropagator.hh"
 #include "celeritas/field/UniformField.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
 #include "detail/AlongStepImpl.hh"
@@ -133,17 +135,17 @@ void AlongStepUniformMscAction::execute(CoreParams const& params,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
     CELER_LAUNCH_KERNEL(along_step_apply_mean_eloss,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
     CELER_LAUNCH_KERNEL(along_step_update_track,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
@@ -109,26 +109,25 @@ along_step_update_track_kernel(DeviceCRef<CoreParamsData> const params,
  * Launch the along-step action on device.
  */
 void AlongStepUniformMscAction::execute(CoreParams const& params,
-                                        StateDeviceRef& state) const
+                                        CoreStateDevice& state) const
 {
-    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(along_step_apply_msc_step_limit,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_apply_uniform_propagation,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         field_params_);
     CELER_LAUNCH_KERNEL(along_step_apply_msc,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_update_time,
                         celeritas::device().default_block_size(),

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
@@ -108,42 +108,42 @@ along_step_update_track_kernel(DeviceCRef<CoreParamsData> const params,
 /*!
  * Launch the along-step action on device.
  */
-void AlongStepUniformMscAction::execute(ParamsDeviceCRef const& params,
+void AlongStepUniformMscAction::execute(CoreParams const& params,
                                         StateDeviceRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(along_step_apply_msc_step_limit,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_apply_uniform_propagation,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         field_params_);
     CELER_LAUNCH_KERNEL(along_step_apply_msc,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_update_time,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
     CELER_LAUNCH_KERNEL(along_step_apply_mean_eloss,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
     CELER_LAUNCH_KERNEL(along_step_update_track,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
 }
 

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.hh
@@ -45,10 +45,10 @@ class AlongStepUniformMscAction final : public ExplicitActionInterface
     ~AlongStepUniformMscAction();
 
     // Launch kernel with host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Launch kernel with device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }
@@ -97,8 +97,8 @@ class AlongStepUniformMscAction final : public ExplicitActionInterface
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void AlongStepUniformMscAction::execute(ParamsDeviceCRef const&,
-                                               StateDeviceRef&) const
+inline void
+AlongStepUniformMscAction::execute(CoreParams const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.hh
@@ -45,10 +45,10 @@ class AlongStepUniformMscAction final : public ExplicitActionInterface
     ~AlongStepUniformMscAction();
 
     // Launch kernel with host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Launch kernel with device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }
@@ -98,7 +98,7 @@ class AlongStepUniformMscAction final : public ExplicitActionInterface
 
 #if !CELER_USE_DEVICE
 inline void
-AlongStepUniformMscAction::execute(CoreParams const&, StateDeviceRef&) const
+AlongStepUniformMscAction::execute(CoreParams const&, CoreStateDevice&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -80,9 +80,8 @@ ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
  * The given action ID \em must be an explicit action.
  */
 template<MemSpace M>
-void ActionSequence::execute(
-    CoreParamsData<Ownership::const_reference, M> const& params,
-    CoreStateData<Ownership::reference, M>& state)
+void ActionSequence::execute(CoreParams const& params,
+                             CoreStateData<Ownership::reference, M>& state)
 {
     if (M == MemSpace::host || options_.sync)
     {
@@ -112,12 +111,12 @@ void ActionSequence::execute(
 // Explicit template instantiation
 //---------------------------------------------------------------------------//
 
-template void ActionSequence::execute(
-    CoreParamsData<Ownership::const_reference, MemSpace::host> const&,
-    CoreStateData<Ownership::reference, MemSpace::host>&);
-template void ActionSequence::execute(
-    CoreParamsData<Ownership::const_reference, MemSpace::device> const&,
-    CoreStateData<Ownership::reference, MemSpace::device>&);
+template void
+ActionSequence::execute(CoreParams const&,
+                        CoreStateData<Ownership::reference, MemSpace::host>&);
+template void
+ActionSequence::execute(CoreParams const&,
+                        CoreStateData<Ownership::reference, MemSpace::device>&);
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -18,7 +18,6 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/sys/Stopwatch.hh"
 #include "celeritas/global/ActionInterface.hh"
-#include "celeritas/global/CoreTrackData.hh"
 
 #include "../ActionRegistry.hh"
 
@@ -80,8 +79,7 @@ ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
  * The given action ID \em must be an explicit action.
  */
 template<MemSpace M>
-void ActionSequence::execute(CoreParams const& params,
-                             CoreStateData<Ownership::reference, M>& state)
+void ActionSequence::execute(CoreParams const& params, CoreState<M>& state)
 {
     if (M == MemSpace::host || options_.sync)
     {
@@ -112,11 +110,9 @@ void ActionSequence::execute(CoreParams const& params,
 //---------------------------------------------------------------------------//
 
 template void
-ActionSequence::execute(CoreParams const&,
-                        CoreStateData<Ownership::reference, MemSpace::host>&);
+ActionSequence::execute(CoreParams const&, CoreState<MemSpace::host>&);
 template void
-ActionSequence::execute(CoreParams const&,
-                        CoreStateData<Ownership::reference, MemSpace::device>&);
+ActionSequence::execute(CoreParams const&, CoreState<MemSpace::device>&);
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/global/detail/ActionSequence.hh
+++ b/src/celeritas/global/detail/ActionSequence.hh
@@ -19,6 +19,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 class ActionRegistry;
+class CoreParams;
 
 namespace detail
 {
@@ -53,7 +54,7 @@ class ActionSequence
 
     // Launch all actions with the given memory space.
     template<MemSpace M>
-    void execute(CoreParamsData<Ownership::const_reference, M> const& params,
+    void execute(CoreParams const& params,
                  CoreStateData<Ownership::reference, M>& state);
 
     //// ACCESSORS ////

--- a/src/celeritas/global/detail/ActionSequence.hh
+++ b/src/celeritas/global/detail/ActionSequence.hh
@@ -54,8 +54,7 @@ class ActionSequence
 
     // Launch all actions with the given memory space.
     template<MemSpace M>
-    void execute(CoreParams const& params,
-                 CoreStateData<Ownership::reference, M>& state);
+    void execute(CoreParams const& params, CoreState<M>& state);
 
     //// ACCESSORS ////
 

--- a/src/celeritas/phys/InteractionLauncher.hh
+++ b/src/celeritas/phys/InteractionLauncher.hh
@@ -40,11 +40,11 @@ template<class D, class F>
 CELER_FUNCTION detail::InteractionLauncherImpl<D, F>
 make_interaction_launcher(NativeCRef<CoreParamsData> const& params,
                           NativeRef<CoreStateData> const& states,
-                          D const& model_data,
-                          F&& call_with_track)
+                          F&& call_with_track,
+                          D const& model_data)
 {
     return {
-        params, states, model_data, ::celeritas::forward<F>(call_with_track)};
+        params, states, ::celeritas::forward<F>(call_with_track), model_data};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/detail/InteractionLauncherImpl.hh
+++ b/src/celeritas/phys/detail/InteractionLauncherImpl.hh
@@ -30,8 +30,8 @@ struct InteractionLauncherImpl
 
     NativeCRef<CoreParamsData> const& params;
     NativeRef<CoreStateData> const& states;
-    D const& model_data;
     F call_with_track;
+    D const& model_data;
 
     //// METHODS ////
 

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cc
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "../detail/DiscreteSelectActionImpl.hh" // IWYU pragma: associated
@@ -23,19 +24,17 @@ namespace celeritas
 {
 namespace generated
 {
-void DiscreteSelectAction::execute(CoreParams const& params, StateHostRef& state) const
+void DiscreteSelectAction::execute(CoreParams const& params, CoreStateHost& state) const
 {
-    CELER_EXPECT(state);
-
     MultiExceptionHandler capture_exception;
-    TrackLauncher launch{params.ref<MemSpace::native>(), state, detail::discrete_select_track};
+    TrackLauncher launch{params.ref<MemSpace::native>(), state.ref(), detail::discrete_select_track};
     #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, this->label()));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cu
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cu
@@ -32,14 +32,13 @@ __global__ void discrete_select_kernel(
 }
 }  // namespace
 
-void DiscreteSelectAction::execute(CoreParams const& params, StateDeviceRef& state) const
+void DiscreteSelectAction::execute(CoreParams const& params, CoreStateDevice& state) const
 {
-    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(discrete_select,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cu
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cu
@@ -32,13 +32,13 @@ __global__ void discrete_select_kernel(
 }
 }  // namespace
 
-void DiscreteSelectAction::execute(ParamsDeviceCRef const& params, StateDeviceRef& state) const
+void DiscreteSelectAction::execute(CoreParams const& params, StateDeviceRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(discrete_select,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
 }
 

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cu
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cu
@@ -13,6 +13,8 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "../detail/DiscreteSelectActionImpl.hh"
 

--- a/src/celeritas/phys/generated/DiscreteSelectAction.hh
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.hh
@@ -11,7 +11,6 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "celeritas/global/ActionInterface.hh"
-#include "celeritas/global/CoreTrackData.hh"
 
 namespace celeritas
 {
@@ -25,17 +24,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(CoreParams const&, StateHostRef&) const final;
+  void execute(CoreParams const&, CoreStateHost&) const final;
 
   // Launch kernel with device data
-  void execute(CoreParams const&, StateDeviceRef&) const final;
+  void execute(CoreParams const&, CoreStateDevice&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final { return ActionOrder::pre_post; }
 };
 
 #if !CELER_USE_DEVICE
-inline void DiscreteSelectAction::execute(CoreParams const&, StateDeviceRef&) const
+inline void DiscreteSelectAction::execute(CoreParams const&, CoreStateDevice&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/phys/generated/DiscreteSelectAction.hh
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.hh
@@ -25,17 +25,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(ParamsHostCRef const&, StateHostRef&) const final;
+  void execute(CoreParams const&, StateHostRef&) const final;
 
   // Launch kernel with device data
-  void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+  void execute(CoreParams const&, StateDeviceRef&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final { return ActionOrder::pre_post; }
 };
 
 #if !CELER_USE_DEVICE
-inline void DiscreteSelectAction::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
+inline void DiscreteSelectAction::execute(CoreParams const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/phys/generated/PreStepAction.cc
+++ b/src/celeritas/phys/generated/PreStepAction.cc
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "../detail/PreStepActionImpl.hh" // IWYU pragma: associated
@@ -22,19 +23,19 @@ namespace celeritas
 {
 namespace generated
 {
-void PreStepAction::execute(ParamsHostCRef const& params, StateHostRef& state) const
+void PreStepAction::execute(CoreParams const& params, StateHostRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
 
     MultiExceptionHandler capture_exception;
-    TrackLauncher launch{params, state, detail::pre_step_track};
+    TrackLauncher launch{params.ref<MemSpace::native>(), state, detail::pre_step_track};
     #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params, state, ThreadId{i}, this->label()));
+            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/phys/generated/PreStepAction.cc
+++ b/src/celeritas/phys/generated/PreStepAction.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "../detail/PreStepActionImpl.hh" // IWYU pragma: associated
@@ -23,19 +24,17 @@ namespace celeritas
 {
 namespace generated
 {
-void PreStepAction::execute(CoreParams const& params, StateHostRef& state) const
+void PreStepAction::execute(CoreParams const& params, CoreStateHost& state) const
 {
-    CELER_EXPECT(state);
-
     MultiExceptionHandler capture_exception;
-    TrackLauncher launch{params.ref<MemSpace::native>(), state, detail::pre_step_track};
+    TrackLauncher launch{params.ref<MemSpace::native>(), state.ref(), detail::pre_step_track};
     #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             launch(ThreadId{i}),
             capture_exception,
-            KernelContextException(params.ref<MemSpace::host>(), state, ThreadId{i}, this->label()));
+            KernelContextException(params.ref<MemSpace::host>(), state.ref(), ThreadId{i}, this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/phys/generated/PreStepAction.cu
+++ b/src/celeritas/phys/generated/PreStepAction.cu
@@ -13,6 +13,8 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "../detail/PreStepActionImpl.hh"
 

--- a/src/celeritas/phys/generated/PreStepAction.cu
+++ b/src/celeritas/phys/generated/PreStepAction.cu
@@ -41,14 +41,13 @@ pre_step_kernel(
 }
 }  // namespace
 
-void PreStepAction::execute(CoreParams const& params, StateDeviceRef& state) const
+void PreStepAction::execute(CoreParams const& params, CoreStateDevice& state) const
 {
-    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(pre_step,
                         celeritas::device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state);
+                        state.ref());
 }
 
 }  // namespace generated

--- a/src/celeritas/phys/generated/PreStepAction.cu
+++ b/src/celeritas/phys/generated/PreStepAction.cu
@@ -41,13 +41,13 @@ pre_step_kernel(
 }
 }  // namespace
 
-void PreStepAction::execute(ParamsDeviceCRef const& params, StateDeviceRef& state) const
+void PreStepAction::execute(CoreParams const& params, StateDeviceRef& state) const
 {
-    CELER_EXPECT(params && state);
+    CELER_EXPECT(state);
     CELER_LAUNCH_KERNEL(pre_step,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state);
 }
 

--- a/src/celeritas/phys/generated/PreStepAction.hh
+++ b/src/celeritas/phys/generated/PreStepAction.hh
@@ -25,17 +25,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(ParamsHostCRef const&, StateHostRef&) const final;
+  void execute(CoreParams const&, StateHostRef&) const final;
 
   // Launch kernel with device data
-  void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+  void execute(CoreParams const&, StateDeviceRef&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final { return ActionOrder::pre; }
 };
 
 #if !CELER_USE_DEVICE
-inline void PreStepAction::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
+inline void PreStepAction::execute(CoreParams const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/phys/generated/PreStepAction.hh
+++ b/src/celeritas/phys/generated/PreStepAction.hh
@@ -11,7 +11,6 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "celeritas/global/ActionInterface.hh"
-#include "celeritas/global/CoreTrackData.hh"
 
 namespace celeritas
 {
@@ -25,17 +24,17 @@ public:
   using ConcreteAction::ConcreteAction;
 
   // Launch kernel with host data
-  void execute(CoreParams const&, StateHostRef&) const final;
+  void execute(CoreParams const&, CoreStateHost&) const final;
 
   // Launch kernel with device data
-  void execute(CoreParams const&, StateDeviceRef&) const final;
+  void execute(CoreParams const&, CoreStateDevice&) const final;
 
   //! Dependency ordering of the action
   ActionOrder order() const final { return ActionOrder::pre; }
 };
 
 #if !CELER_USE_DEVICE
-inline void PreStepAction::execute(CoreParams const&, StateDeviceRef&) const
+inline void PreStepAction::execute(CoreParams const&, CoreStateDevice&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/track/ExtendFromSecondariesAction.cc
+++ b/src/celeritas/track/ExtendFromSecondariesAction.cc
@@ -18,9 +18,9 @@ namespace celeritas
  * Execute the action with host data
  */
 void ExtendFromSecondariesAction::execute(CoreParams const& params,
-                                          StateHostRef& states) const
+                                          CoreStateHost& state) const
 {
-    extend_from_secondaries(params, states);
+    extend_from_secondaries(params, state);
 }
 
 //---------------------------------------------------------------------------//
@@ -28,9 +28,9 @@ void ExtendFromSecondariesAction::execute(CoreParams const& params,
  * Execute the action with device data
  */
 void ExtendFromSecondariesAction::execute(CoreParams const& params,
-                                          StateDeviceRef& states) const
+                                          CoreStateDevice& state) const
 {
-    extend_from_secondaries(params, states);
+    extend_from_secondaries(params, state);
 }
 
 }  // namespace celeritas

--- a/src/celeritas/track/ExtendFromSecondariesAction.cc
+++ b/src/celeritas/track/ExtendFromSecondariesAction.cc
@@ -17,7 +17,7 @@ namespace celeritas
 /*!
  * Execute the action with host data
  */
-void ExtendFromSecondariesAction::execute(ParamsHostCRef const& params,
+void ExtendFromSecondariesAction::execute(CoreParams const& params,
                                           StateHostRef& states) const
 {
     extend_from_secondaries(params, states);
@@ -27,7 +27,7 @@ void ExtendFromSecondariesAction::execute(ParamsHostCRef const& params,
 /*!
  * Execute the action with device data
  */
-void ExtendFromSecondariesAction::execute(ParamsDeviceCRef const& params,
+void ExtendFromSecondariesAction::execute(CoreParams const& params,
                                           StateDeviceRef& states) const
 {
     extend_from_secondaries(params, states);

--- a/src/celeritas/track/ExtendFromSecondariesAction.hh
+++ b/src/celeritas/track/ExtendFromSecondariesAction.hh
@@ -27,12 +27,10 @@ class ExtendFromSecondariesAction final : public ExplicitActionInterface
     ~ExtendFromSecondariesAction() = default;
 
     // Execute the action with host data
-    void
-    execute(ParamsHostCRef const& params, StateHostRef& states) const final;
+    void execute(CoreParams const& params, StateHostRef& states) const final;
 
     // Execute the action with device data
-    void execute(ParamsDeviceCRef const& params,
-                 StateDeviceRef& states) const final;
+    void execute(CoreParams const& params, StateDeviceRef& states) const final;
 
     //! ID of the action
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/track/ExtendFromSecondariesAction.hh
+++ b/src/celeritas/track/ExtendFromSecondariesAction.hh
@@ -27,10 +27,10 @@ class ExtendFromSecondariesAction final : public ExplicitActionInterface
     ~ExtendFromSecondariesAction() = default;
 
     // Execute the action with host data
-    void execute(CoreParams const& params, StateHostRef& states) const final;
+    void execute(CoreParams const& params, CoreStateHost& state) const final;
 
     // Execute the action with device data
-    void execute(CoreParams const& params, StateDeviceRef& states) const final;
+    void execute(CoreParams const& params, CoreStateDevice& state) const final;
 
     //! ID of the action
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/track/InitializeTracksAction.cc
+++ b/src/celeritas/track/InitializeTracksAction.cc
@@ -17,7 +17,7 @@ namespace celeritas
 /*!
  * Execute the action with host data
  */
-void InitializeTracksAction::execute(ParamsHostCRef const& params,
+void InitializeTracksAction::execute(CoreParams const& params,
                                      StateHostRef& states) const
 {
     initialize_tracks(params, states);
@@ -27,7 +27,7 @@ void InitializeTracksAction::execute(ParamsHostCRef const& params,
 /*!
  * Execute the action with device data
  */
-void InitializeTracksAction::execute(ParamsDeviceCRef const& params,
+void InitializeTracksAction::execute(CoreParams const& params,
                                      StateDeviceRef& states) const
 {
     initialize_tracks(params, states);

--- a/src/celeritas/track/InitializeTracksAction.cc
+++ b/src/celeritas/track/InitializeTracksAction.cc
@@ -18,9 +18,9 @@ namespace celeritas
  * Execute the action with host data
  */
 void InitializeTracksAction::execute(CoreParams const& params,
-                                     StateHostRef& states) const
+                                     CoreStateHost& state) const
 {
-    initialize_tracks(params, states);
+    initialize_tracks(params, state);
 }
 
 //---------------------------------------------------------------------------//
@@ -28,9 +28,9 @@ void InitializeTracksAction::execute(CoreParams const& params,
  * Execute the action with device data
  */
 void InitializeTracksAction::execute(CoreParams const& params,
-                                     StateDeviceRef& states) const
+                                     CoreStateDevice& state) const
 {
-    initialize_tracks(params, states);
+    initialize_tracks(params, state);
 }
 
 }  // namespace celeritas

--- a/src/celeritas/track/InitializeTracksAction.hh
+++ b/src/celeritas/track/InitializeTracksAction.hh
@@ -29,10 +29,10 @@ class InitializeTracksAction final : public ExplicitActionInterface
     ~InitializeTracksAction() = default;
 
     //! Execute the action with host data
-    void execute(CoreParams const& params, StateHostRef& states) const final;
+    void execute(CoreParams const& params, CoreStateHost& state) const final;
 
     //! Execute the action with device data
-    void execute(CoreParams const& params, StateDeviceRef& states) const final;
+    void execute(CoreParams const& params, CoreStateDevice& state) const final;
 
     //! ID of the action
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/track/InitializeTracksAction.hh
+++ b/src/celeritas/track/InitializeTracksAction.hh
@@ -29,12 +29,10 @@ class InitializeTracksAction final : public ExplicitActionInterface
     ~InitializeTracksAction() = default;
 
     //! Execute the action with host data
-    void
-    execute(ParamsHostCRef const& params, StateHostRef& states) const final;
+    void execute(CoreParams const& params, StateHostRef& states) const final;
 
     //! Execute the action with device data
-    void execute(ParamsDeviceCRef const& params,
-                 StateDeviceRef& states) const final;
+    void execute(CoreParams const& params, StateDeviceRef& states) const final;
 
     //! ID of the action
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/track/SortTracksAction.cc
+++ b/src/celeritas/track/SortTracksAction.cc
@@ -10,6 +10,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "celeritas/Types.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/track/detail/TrackSortUtils.hh"
 
 namespace celeritas
@@ -35,9 +36,9 @@ std::string SortTracksAction::label() const
  * Execute the action with host data
  */
 void SortTracksAction::execute(CoreParams const& params,
-                               StateHostRef& states) const
+                               CoreStateHost& state) const
 {
-    return this->execute_impl(params, states);
+    return this->execute_impl(params, state);
 }
 
 //---------------------------------------------------------------------------//
@@ -45,23 +46,22 @@ void SortTracksAction::execute(CoreParams const& params,
  * Execute the action with device data
  */
 void SortTracksAction::execute(CoreParams const& params,
-                               StateDeviceRef& states) const
+                               CoreStateDevice& state) const
 {
-    return this->execute_impl(params, states);
+    return this->execute_impl(params, state);
 }
 
 //---------------------------------------------------------------------------//
 template<MemSpace M>
-void SortTracksAction::execute_impl(
-    CoreParams const&, CoreStateData<Ownership::reference, M>& states) const
+void SortTracksAction::execute_impl(CoreParams const&, CoreState<M>& state) const
 {
     switch (track_order_)
     {
         case TrackOrder::partition_status:
-            detail::partition_tracks_by_status(states);
+            detail::partition_tracks_by_status(state.ref());
             break;
         case TrackOrder::sort_step_limit_action:
-            detail::sort_tracks_by_action_id(states);
+            detail::sort_tracks_by_action_id(state.ref());
             break;
         default:
             CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/track/SortTracksAction.cc
+++ b/src/celeritas/track/SortTracksAction.cc
@@ -34,26 +34,26 @@ std::string SortTracksAction::label() const
 /*!
  * Execute the action with host data
  */
-void SortTracksAction::execute(ParamsHostCRef const& params,
+void SortTracksAction::execute(CoreParams const& params,
                                StateHostRef& states) const
 {
-    execute_impl(params, states);
+    return this->execute_impl(params, states);
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Execute the action with device data
  */
-void SortTracksAction::execute(ParamsDeviceCRef const& params,
+void SortTracksAction::execute(CoreParams const& params,
                                StateDeviceRef& states) const
 {
-    execute_impl(params, states);
+    return this->execute_impl(params, states);
 }
 
+//---------------------------------------------------------------------------//
 template<MemSpace M>
 void SortTracksAction::execute_impl(
-    CoreParamsData<Ownership::const_reference, M> const&,
-    CoreStateData<Ownership::reference, M>& states) const
+    CoreParams const&, CoreStateData<Ownership::reference, M>& states) const
 {
     switch (track_order_)
     {
@@ -68,4 +68,5 @@ void SortTracksAction::execute_impl(
     }
 }
 
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/track/SortTracksAction.hh
+++ b/src/celeritas/track/SortTracksAction.hh
@@ -34,10 +34,10 @@ class SortTracksAction final : public ExplicitActionInterface
     ~SortTracksAction() = default;
 
     //! Execute the action with host data
-    void execute(CoreParams const& params, StateHostRef& states) const final;
+    void execute(CoreParams const& params, CoreStateHost& state) const final;
 
     //! Execute the action with device data
-    void execute(CoreParams const& params, StateDeviceRef& states) const final;
+    void execute(CoreParams const& params, CoreStateDevice& state) const final;
 
     //! ID of the action
     ActionId action_id() const final { return id_; }
@@ -46,15 +46,14 @@ class SortTracksAction final : public ExplicitActionInterface
     std::string label() const final;
 
     //! Description of the action for user interaction
-    std::string description() const final { return "sort tracks states"; }
+    std::string description() const final { return "sort tracks state.ref()"; }
 
     //! Dependency ordering of the action
     ActionOrder order() const final { return action_order_; }
 
   private:
     template<MemSpace M>
-    void execute_impl(CoreParams const& params,
-                      CoreStateData<Ownership::reference, M>& states) const;
+    void execute_impl(CoreParams const& params, CoreState<M>& state) const;
 
     ActionId id_;
     ActionOrder action_order_;

--- a/src/celeritas/track/SortTracksAction.hh
+++ b/src/celeritas/track/SortTracksAction.hh
@@ -34,12 +34,10 @@ class SortTracksAction final : public ExplicitActionInterface
     ~SortTracksAction() = default;
 
     //! Execute the action with host data
-    void
-    execute(ParamsHostCRef const& params, StateHostRef& states) const final;
+    void execute(CoreParams const& params, StateHostRef& states) const final;
 
     //! Execute the action with device data
-    void execute(ParamsDeviceCRef const& params,
-                 StateDeviceRef& states) const final;
+    void execute(CoreParams const& params, StateDeviceRef& states) const final;
 
     //! ID of the action
     ActionId action_id() const final { return id_; }
@@ -55,9 +53,8 @@ class SortTracksAction final : public ExplicitActionInterface
 
   private:
     template<MemSpace M>
-    void
-    execute_impl(CoreParamsData<Ownership::const_reference, M> const& params,
-                 CoreStateData<Ownership::reference, M>& states) const;
+    void execute_impl(CoreParams const& params,
+                      CoreStateData<Ownership::reference, M>& states) const;
 
     ActionId id_;
     ActionOrder action_order_;

--- a/src/celeritas/track/TrackInitUtils.hh
+++ b/src/celeritas/track/TrackInitUtils.hh
@@ -15,6 +15,7 @@
 #include "corecel/data/Ref.hh"
 #include "corecel/math/Algorithms.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/CoreTrackData.hh"
 
 #include "TrackInitData.hh"
@@ -33,15 +34,13 @@ namespace celeritas
  * Create track initializers from a vector of host primary particles.
  */
 template<MemSpace M>
-inline void
-extend_from_primaries(CoreParams const& core_params,
-                      CoreStateData<Ownership::reference, M>& core_states,
-                      Span<Primary const> host_primaries)
+inline void extend_from_primaries(CoreParams const& core_params,
+                                  CoreState<M>& core_state,
+                                  Span<Primary const> host_primaries)
 {
-    CELER_EXPECT(core_states);
     CELER_EXPECT(!host_primaries.empty());
 
-    auto& data = core_states.init.initializers;
+    auto& data = core_state.ref().init.initializers;
     CELER_ASSERT(host_primaries.size() + data.size() <= data.capacity());
 
     // Resizing the initializers is a non-const operation, but the only one.
@@ -54,8 +53,9 @@ extend_from_primaries(CoreParams const& core_params,
     copy_to_temp(MemSpace::host, host_primaries);
 
     // Create track initializers from primaries
-    generated::process_primaries(
-        core_params.ref<M>(), core_states, primaries[AllItems<Primary, M>{}]);
+    generated::process_primaries(core_params.ref<M>(),
+                                 core_state.ref(),
+                                 primaries[AllItems<Primary, M>{}]);
 }
 
 //---------------------------------------------------------------------------//
@@ -69,12 +69,9 @@ extend_from_primaries(CoreParams const& core_params,
  */
 template<MemSpace M>
 inline void
-initialize_tracks(CoreParams const& core_params,
-                  CoreStateData<Ownership::reference, M>& core_states)
+initialize_tracks(CoreParams const& core_params, CoreState<M>& core_state)
 {
-    CELER_EXPECT(core_states);
-
-    auto& data = core_states.init;
+    auto& data = core_state.ref().init;
 
     // The number of new tracks to initialize is the smaller of the number of
     // empty slots in the track vector and the number of track initializers
@@ -86,14 +83,14 @@ initialize_tracks(CoreParams const& core_params,
         auto num_vacancies
             = min(data.vacancies.size(), data.initializers.size());
         generated::init_tracks(
-            core_params.ref<M>(), core_states, num_vacancies);
+            core_params.ref<M>(), core_state.ref(), num_vacancies);
         // Resizing initializers/vacancies is a non-const operation
         data.initializers.resize(data.initializers.size() - num_tracks);
         data.vacancies.resize(data.vacancies.size() - num_tracks);
     }
 
     // Store number of active tracks (a non-const operation)
-    data.num_active = core_states.size() - data.vacancies.size();
+    data.num_active = core_state.size() - data.vacancies.size();
 }
 
 //---------------------------------------------------------------------------//
@@ -155,19 +152,16 @@ initialize_tracks(CoreParams const& core_params,
  */
 template<MemSpace M>
 inline void
-extend_from_secondaries(CoreParams const& core_params,
-                        CoreStateData<Ownership::reference, M>& core_states)
+extend_from_secondaries(CoreParams const& core_params, CoreState<M>& core_state)
 {
-    CELER_EXPECT(core_states);
-
-    TrackInitStateData<Ownership::reference, M>& data = core_states.init;
+    TrackInitStateData<Ownership::reference, M>& data = core_state.ref().init;
 
     // Resize the vector of vacancies to be equal to the number of tracks
-    data.vacancies.resize(core_states.size());
+    data.vacancies.resize(core_state.size());
 
     // Launch a kernel to identify which track slots are still alive and count
     // the number of surviving secondaries per track
-    generated::locate_alive(core_params.ref<M>(), core_states);
+    generated::locate_alive(core_params.ref<M>(), core_state.ref());
 
     // Remove all elements in the vacancy vector that were flagged as active
     // tracks, leaving the (sorted) indices of the empty slots
@@ -194,7 +188,7 @@ extend_from_secondaries(CoreParams const& core_params,
 
     // Launch a kernel to create track initializers from secondaries
     data.initializers.resize(data.initializers.size() + data.num_secondaries);
-    generated::process_secondaries(core_params.ref<M>(), core_states);
+    generated::process_secondaries(core_params.ref<M>(), core_state.ref());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/ActionDiagnostic.cc
+++ b/src/celeritas/user/ActionDiagnostic.cc
@@ -15,6 +15,7 @@
 #include "celeritas/global/ActionRegistry.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "celeritas/phys/ParticleParams.hh"
++ #include "celeritas/global/CoreParams.hh"
 
 #include "detail/ActionDiagnosticImpl.hh"
 
@@ -24,7 +25,7 @@
 #    include "corecel/io/LabelIO.json.hh"
 #endif
 
-namespace celeritas
+    namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
@@ -57,8 +58,8 @@ ActionDiagnostic::~ActionDiagnostic() = default;
 /*!
  * Execute action with host data.
  */
-void ActionDiagnostic::execute(ParamsHostCRef const& params,
-                               StateHostRef& state) const
+void ActionDiagnostic::execute(CoreParams const& params, StateHostRef& state)
+    const
 {
     CELER_EXPECT(params);
     CELER_EXPECT(state);
@@ -69,7 +70,7 @@ void ActionDiagnostic::execute(ParamsHostCRef const& params,
     }
     MultiExceptionHandler capture_exception;
     auto launch = make_active_track_launcher(
-        params,
+        params.ref<MemSpace::native>(),
         state,
         detail::tally_action,
         store_.params<MemSpace::host>(),

--- a/src/celeritas/user/ActionDiagnostic.cc
+++ b/src/celeritas/user/ActionDiagnostic.cc
@@ -13,9 +13,10 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/ActionRegistry.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "celeritas/phys/ParticleParams.hh"
-+ #include "celeritas/global/CoreParams.hh"
 
 #include "detail/ActionDiagnosticImpl.hh"
 
@@ -58,12 +59,9 @@ ActionDiagnostic::~ActionDiagnostic() = default;
 /*!
  * Execute action with host data.
  */
-void ActionDiagnostic::execute(CoreParams const& params, StateHostRef& state)
-    const
+void ActionDiagnostic::execute(CoreParams const& params,
+                               CoreStateHost& state) const
 {
-    CELER_EXPECT(params);
-    CELER_EXPECT(state);
-
     if (!store_)
     {
         this->build_stream_store();
@@ -71,7 +69,7 @@ void ActionDiagnostic::execute(CoreParams const& params, StateHostRef& state)
     MultiExceptionHandler capture_exception;
     auto launch = make_active_track_launcher(
         params.ref<MemSpace::native>(),
-        state,
+        state.ref(),
         detail::tally_action,
         store_.params<MemSpace::host>(),
         store_.state<MemSpace::host>(state.stream_id, this->state_size()));

--- a/src/celeritas/user/ActionDiagnostic.cc
+++ b/src/celeritas/user/ActionDiagnostic.cc
@@ -72,7 +72,7 @@ void ActionDiagnostic::execute(CoreParams const& params,
         state.ref(),
         detail::tally_action,
         store_.params<MemSpace::host>(),
-        store_.state<MemSpace::host>(state.stream_id, this->state_size()));
+        store_.state<MemSpace::host>(state.stream_id(), this->state_size()));
 #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/user/ActionDiagnostic.cu
+++ b/src/celeritas/user/ActionDiagnostic.cu
@@ -12,10 +12,11 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "celeritas/global/TrackLauncher.hh"
++ #include "celeritas/global/CoreParams.hh"
 
 #include "detail/ActionDiagnosticImpl.hh"
 
-namespace celeritas
+    namespace celeritas
 {
 namespace
 {
@@ -38,8 +39,8 @@ tally_action_kernel(DeviceCRef<CoreParamsData> const params,
 /*!
  * Execute action with device data.
  */
-void ActionDiagnostic::execute(ParamsDeviceCRef const& params,
-                               StateDeviceRef& state) const
+void ActionDiagnostic::execute(CoreParams const& params, StateDeviceRef& state)
+    const
 {
     CELER_EXPECT(params);
     CELER_EXPECT(state);
@@ -52,7 +53,7 @@ void ActionDiagnostic::execute(ParamsDeviceCRef const& params,
         tally_action,
         celeritas::device().default_block_size(),
         state.size(),
-        params,
+        params.ref<MemSpace::native>(),
         state,
         store_.params<MemSpace::device>(),
         store_.state<MemSpace::device>(state.stream_id, this->state_size()));

--- a/src/celeritas/user/ActionDiagnostic.cu
+++ b/src/celeritas/user/ActionDiagnostic.cu
@@ -54,7 +54,7 @@ void ActionDiagnostic::execute(CoreParams const& params,
         params.ref<MemSpace::native>(),
         state.ref(),
         store_.params<MemSpace::device>(),
-        store_.state<MemSpace::device>(state.stream_id, this->state_size()));
+        store_.state<MemSpace::device>(state.stream_id(), this->state_size()));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/ActionDiagnostic.cu
+++ b/src/celeritas/user/ActionDiagnostic.cu
@@ -11,12 +11,13 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
-+ #include "celeritas/global/CoreParams.hh"
 
 #include "detail/ActionDiagnosticImpl.hh"
 
-    namespace celeritas
+namespace celeritas
 {
 namespace
 {
@@ -39,12 +40,9 @@ tally_action_kernel(DeviceCRef<CoreParamsData> const params,
 /*!
  * Execute action with device data.
  */
-void ActionDiagnostic::execute(CoreParams const& params, StateDeviceRef& state)
-    const
+void ActionDiagnostic::execute(CoreParams const& params,
+                               CoreStateDevice& state) const
 {
-    CELER_EXPECT(params);
-    CELER_EXPECT(state);
-
     if (!store_)
     {
         this->build_stream_store();
@@ -54,7 +52,7 @@ void ActionDiagnostic::execute(CoreParams const& params, StateDeviceRef& state)
         celeritas::device().default_block_size(),
         state.size(),
         params.ref<MemSpace::native>(),
-        state,
+        state.ref(),
         store_.params<MemSpace::device>(),
         store_.state<MemSpace::device>(state.stream_id, this->state_size()));
 }

--- a/src/celeritas/user/ActionDiagnostic.hh
+++ b/src/celeritas/user/ActionDiagnostic.hh
@@ -53,9 +53,9 @@ class ActionDiagnostic final : public ExplicitActionInterface,
     //!@{
     //! \name ExplicitAction interface
     // Execute action with host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
     // Execute action with device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
     //! ID of the action
     ActionId action_id() const final { return id_; }
     //! Short name for the action
@@ -106,8 +106,7 @@ class ActionDiagnostic final : public ExplicitActionInterface,
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void
-ActionDiagnostic::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
+inline void ActionDiagnostic::execute(CoreParams const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/user/ActionDiagnostic.hh
+++ b/src/celeritas/user/ActionDiagnostic.hh
@@ -53,9 +53,9 @@ class ActionDiagnostic final : public ExplicitActionInterface,
     //!@{
     //! \name ExplicitAction interface
     // Execute action with host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
     // Execute action with device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
     //! ID of the action
     ActionId action_id() const final { return id_; }
     //! Short name for the action
@@ -106,7 +106,7 @@ class ActionDiagnostic final : public ExplicitActionInterface,
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void ActionDiagnostic::execute(CoreParams const&, StateDeviceRef&) const
+inline void ActionDiagnostic::execute(CoreParams const&, CoreStateDevice&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/user/DetectorSteps.cc
+++ b/src/celeritas/user/DetectorSteps.cc
@@ -80,7 +80,6 @@ void copy_steps<MemSpace::host>(
     StepStateData<Ownership::reference, MemSpace::host> const& state)
 {
     CELER_EXPECT(output);
-    CELER_EXPECT(state);
 
     // Get the number of threads that are active and in a detector
     size_type size = count_num_valid(state.detector);

--- a/src/celeritas/user/DetectorSteps.cu
+++ b/src/celeritas/user/DetectorSteps.cu
@@ -112,7 +112,6 @@ void copy_steps<MemSpace::device>(
     StepStateData<Ownership::reference, MemSpace::device> const& state)
 {
     CELER_EXPECT(output);
-    CELER_EXPECT(state);
 
     // Copy the original detector IDs
     thrust::device_vector<DetectorId> orig_ids;

--- a/src/celeritas/user/StepDiagnostic.cc
+++ b/src/celeritas/user/StepDiagnostic.cc
@@ -68,7 +68,7 @@ void StepDiagnostic::execute(CoreParams const& params,
         state.ref(),
         detail::tally_steps,
         store_.params<MemSpace::host>(),
-        store_.state<MemSpace::host>(state.stream_id, this->state_size()));
+        store_.state<MemSpace::host>(state.stream_id(), this->state_size()));
 #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/user/StepDiagnostic.cc
+++ b/src/celeritas/user/StepDiagnostic.cc
@@ -14,6 +14,7 @@
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "celeritas/phys/ParticleParams.hh"
++ #include "celeritas/global/CoreParams.hh"
 
 #include "detail/StepDiagnosticImpl.hh"
 
@@ -23,7 +24,7 @@
 #    include "corecel/io/LabelIO.json.hh"
 #endif
 
-namespace celeritas
+    namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
@@ -57,15 +58,15 @@ StepDiagnostic::~StepDiagnostic() = default;
 /*!
  * Execute action with host data.
  */
-void StepDiagnostic::execute(ParamsHostCRef const& params,
-                             StateHostRef& state) const
+void StepDiagnostic::execute(CoreParams const& params, StateHostRef& state)
+    const
 {
     CELER_EXPECT(params);
     CELER_EXPECT(state);
 
     MultiExceptionHandler capture_exception;
     auto launch = make_active_track_launcher(
-        params,
+        params.ref<MemSpace::native>(),
         state,
         detail::tally_steps,
         store_.params<MemSpace::host>(),

--- a/src/celeritas/user/StepDiagnostic.cc
+++ b/src/celeritas/user/StepDiagnostic.cc
@@ -12,9 +12,10 @@
 #include "corecel/io/JsonPimpl.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "celeritas/phys/ParticleParams.hh"
-+ #include "celeritas/global/CoreParams.hh"
 
 #include "detail/StepDiagnosticImpl.hh"
 
@@ -58,16 +59,13 @@ StepDiagnostic::~StepDiagnostic() = default;
 /*!
  * Execute action with host data.
  */
-void StepDiagnostic::execute(CoreParams const& params, StateHostRef& state)
-    const
+void StepDiagnostic::execute(CoreParams const& params,
+                             CoreStateHost& state) const
 {
-    CELER_EXPECT(params);
-    CELER_EXPECT(state);
-
     MultiExceptionHandler capture_exception;
     auto launch = make_active_track_launcher(
         params.ref<MemSpace::native>(),
-        state,
+        state.ref(),
         detail::tally_steps,
         store_.params<MemSpace::host>(),
         store_.state<MemSpace::host>(state.stream_id, this->state_size()));

--- a/src/celeritas/user/StepDiagnostic.cu
+++ b/src/celeritas/user/StepDiagnostic.cu
@@ -12,10 +12,11 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "celeritas/global/TrackLauncher.hh"
++ #include "celeritas/global/CoreParams.hh"
 
 #include "detail/StepDiagnosticImpl.hh"
 
-namespace celeritas
+    namespace celeritas
 {
 namespace
 {
@@ -38,8 +39,8 @@ tally_steps_kernel(DeviceCRef<CoreParamsData> const params,
 /*!
  * Execute action with device data.
  */
-void StepDiagnostic::execute(ParamsDeviceCRef const& params,
-                             StateDeviceRef& state) const
+void StepDiagnostic::execute(CoreParams const& params, StateDeviceRef& state)
+    const
 {
     CELER_EXPECT(params);
     CELER_EXPECT(state);
@@ -48,7 +49,7 @@ void StepDiagnostic::execute(ParamsDeviceCRef const& params,
         tally_steps,
         celeritas::device().default_block_size(),
         state.size(),
-        params,
+        params.ref<MemSpace::device>(),
         state,
         store_.params<MemSpace::device>(),
         store_.state<MemSpace::device>(state.stream_id, this->state_size()));

--- a/src/celeritas/user/StepDiagnostic.cu
+++ b/src/celeritas/user/StepDiagnostic.cu
@@ -11,12 +11,13 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
+#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
-+ #include "celeritas/global/CoreParams.hh"
 
 #include "detail/StepDiagnosticImpl.hh"
 
-    namespace celeritas
+namespace celeritas
 {
 namespace
 {
@@ -39,18 +40,15 @@ tally_steps_kernel(DeviceCRef<CoreParamsData> const params,
 /*!
  * Execute action with device data.
  */
-void StepDiagnostic::execute(CoreParams const& params, StateDeviceRef& state)
-    const
+void StepDiagnostic::execute(CoreParams const& params,
+                             CoreStateDevice& state) const
 {
-    CELER_EXPECT(params);
-    CELER_EXPECT(state);
-
     CELER_LAUNCH_KERNEL(
         tally_steps,
         celeritas::device().default_block_size(),
         state.size(),
         params.ref<MemSpace::device>(),
-        state,
+        state.ref(),
         store_.params<MemSpace::device>(),
         store_.state<MemSpace::device>(state.stream_id, this->state_size()));
 }

--- a/src/celeritas/user/StepDiagnostic.cu
+++ b/src/celeritas/user/StepDiagnostic.cu
@@ -50,7 +50,7 @@ void StepDiagnostic::execute(CoreParams const& params,
         params.ref<MemSpace::device>(),
         state.ref(),
         store_.params<MemSpace::device>(),
-        store_.state<MemSpace::device>(state.stream_id, this->state_size()));
+        store_.state<MemSpace::device>(state.stream_id(), this->state_size()));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/StepDiagnostic.cu
+++ b/src/celeritas/user/StepDiagnostic.cu
@@ -47,7 +47,7 @@ void StepDiagnostic::execute(CoreParams const& params,
         tally_steps,
         celeritas::device().default_block_size(),
         state.size(),
-        params.ref<MemSpace::device>(),
+        params.ref<MemSpace::native>(),
         state.ref(),
         store_.params<MemSpace::device>(),
         store_.state<MemSpace::device>(state.stream_id(), this->state_size()));

--- a/src/celeritas/user/StepDiagnostic.hh
+++ b/src/celeritas/user/StepDiagnostic.hh
@@ -48,9 +48,9 @@ class StepDiagnostic final : public ExplicitActionInterface,
     //!@{
     //! \name ExplicitAction interface
     // Execute action with host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
     // Execute action with device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
     //! ID of the action
     ActionId action_id() const final { return id_; }
     //! Short name for the action
@@ -91,7 +91,7 @@ class StepDiagnostic final : public ExplicitActionInterface,
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void StepDiagnostic::execute(CoreParams const&, StateDeviceRef&) const
+inline void StepDiagnostic::execute(CoreParams const&, CoreStateDevice&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/user/StepDiagnostic.hh
+++ b/src/celeritas/user/StepDiagnostic.hh
@@ -48,9 +48,9 @@ class StepDiagnostic final : public ExplicitActionInterface,
     //!@{
     //! \name ExplicitAction interface
     // Execute action with host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
     // Execute action with device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
     //! ID of the action
     ActionId action_id() const final { return id_; }
     //! Short name for the action
@@ -91,8 +91,7 @@ class StepDiagnostic final : public ExplicitActionInterface,
 //---------------------------------------------------------------------------//
 
 #if !CELER_USE_DEVICE
-inline void
-StepDiagnostic::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
+inline void StepDiagnostic::execute(CoreParams const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/src/celeritas/user/detail/StepGatherAction.hh
+++ b/src/celeritas/user/detail/StepGatherAction.hh
@@ -52,10 +52,10 @@ class StepGatherAction final : public ExplicitActionInterface
     StepGatherAction(ActionId id, SPStepStorage storage, VecInterface callbacks);
 
     // Launch kernel with host data
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
 
     // Launch kernel with device data
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/user/detail/StepGatherAction.hh
+++ b/src/celeritas/user/detail/StepGatherAction.hh
@@ -52,10 +52,10 @@ class StepGatherAction final : public ExplicitActionInterface
     StepGatherAction(ActionId id, SPStepStorage storage, VecInterface callbacks);
 
     // Launch kernel with host data
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
 
     // Launch kernel with device data
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     //! ID of the model
     ActionId action_id() const final { return id_; }

--- a/test/celeritas/geo/HeuristicGeoData.hh
+++ b/test/celeritas/geo/HeuristicGeoData.hh
@@ -122,7 +122,6 @@ inline void resize(HeuristicGeoStateData<Ownership::value, M>* state,
                    HostCRef<HeuristicGeoParamsData> const& params,
                    size_type size)
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(params);
     CELER_EXPECT(size > 0);
     resize(&state->geometry, params.geometry, size);

--- a/test/celeritas/global/ActionRegistry.test.cc
+++ b/test/celeritas/global/ActionRegistry.test.cc
@@ -28,11 +28,11 @@ class MyExplicitAction final : public ExplicitActionInterface
     std::string label() const final { return "explicit"; }
     std::string description() const final { return "explicit action test"; }
 
-    void execute(ParamsHostCRef const&, StateHostRef&) const final
+    void execute(CoreParams const&, StateHostRef&) const final
     {
         ++host_count_;
     }
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final
+    void execute(CoreParams const&, StateDeviceRef&) const final
     {
         ++device_count_;
     }

--- a/test/celeritas/global/ActionRegistry.test.cc
+++ b/test/celeritas/global/ActionRegistry.test.cc
@@ -28,11 +28,11 @@ class MyExplicitAction final : public ExplicitActionInterface
     std::string label() const final { return "explicit"; }
     std::string description() const final { return "explicit action test"; }
 
-    void execute(CoreParams const&, StateHostRef&) const final
+    void execute(CoreParams const&, CoreStateHost&) const final
     {
         ++host_count_;
     }
-    void execute(CoreParams const&, StateDeviceRef&) const final
+    void execute(CoreParams const&, CoreStateDevice&) const final
     {
         ++device_count_;
     }

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -38,7 +38,7 @@ auto AlongStepTestBase::run(Input const& inp, size_type num_tracks) -> RunResult
         this->core()->host_ref(), StreamId{0}, num_tracks};
     auto& core_params = this->core()->host_ref();
     auto& core_states = states.ref();
-    CELER_ASSERT(core_params && core_states);
+    CELER_ASSERT(core_states);
 
     {
         // Create primary from input (separate event IDs)
@@ -57,8 +57,8 @@ auto AlongStepTestBase::run(Input const& inp, size_type num_tracks) -> RunResult
         }
 
         // Primary -> track initializer -> track
-        extend_from_primaries(core_params, core_states, make_span(primaries));
-        initialize_tracks(core_params, core_states);
+        extend_from_primaries(*this->core(), core_states, make_span(primaries));
+        initialize_tracks(*this->core(), core_states);
     }
 
     // Set remaining MFP and cached MSC range properties
@@ -81,12 +81,12 @@ auto AlongStepTestBase::run(Input const& inp, size_type num_tracks) -> RunResult
         auto const& prestep_action
             = dynamic_cast<ExplicitActionInterface const&>(
                 *am.action(prestep_action_id));
-        CELER_TRY_HANDLE(prestep_action.execute(core_params, core_states),
+        CELER_TRY_HANDLE(prestep_action.execute(*this->core(), core_states),
                          LogContextException{this->output_reg().get()});
 
         // Call along-step action
         auto const& along_step = *this->along_step();
-        CELER_TRY_HANDLE(along_step.execute(core_params, core_states),
+        CELER_TRY_HANDLE(along_step.execute(*this->core(), core_states),
                          LogContextException{this->output_reg().get()});
     }
 

--- a/test/celeritas/global/DummyAction.hh
+++ b/test/celeritas/global/DummyAction.hh
@@ -20,11 +20,11 @@ class DummyAction final : public ExplicitActionInterface, public ConcreteAction
     // Construct with ID and label
     using ConcreteAction::ConcreteAction;
 
-    void execute(ParamsHostCRef const&, StateHostRef&) const final
+    void execute(CoreParams const&, StateHostRef&) const final
     {
         ++num_execute_host_;
     }
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final
+    void execute(CoreParams const&, StateDeviceRef&) const final
     {
         ++num_execute_device_;
     }

--- a/test/celeritas/global/DummyAction.hh
+++ b/test/celeritas/global/DummyAction.hh
@@ -20,11 +20,11 @@ class DummyAction final : public ExplicitActionInterface, public ConcreteAction
     // Construct with ID and label
     using ConcreteAction::ConcreteAction;
 
-    void execute(CoreParams const&, StateHostRef&) const final
+    void execute(CoreParams const&, CoreStateHost&) const final
     {
         ++num_execute_host_;
     }
-    void execute(CoreParams const&, StateDeviceRef&) const final
+    void execute(CoreParams const&, CoreStateDevice&) const final
     {
         ++num_execute_device_;
     }

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -89,6 +89,11 @@ auto StepperTestBase::run(StepperInterface& step,
     EXPECT_EQ(num_primaries, counts.active);
     EXPECT_EQ(num_primaries, counts.alive);
 
+    if (this->HasFailure())
+    {
+        return {};
+    }
+
     RunResult result;
     result.active = {counts.active};
     result.queued = {counts.queued};

--- a/test/celeritas/phys/MockModel.cc
+++ b/test/celeritas/phys/MockModel.cc
@@ -55,12 +55,12 @@ auto MockModel::micro_xs(Applicability range) const -> MicroXsBuilders
     return builders;
 }
 
-void MockModel::execute(CoreParams const&, StateHostRef&) const
+void MockModel::execute(CoreParams const&, CoreStateHost&) const
 {
     // Shouldn't be called?
 }
 
-void MockModel::execute(CoreParams const&, StateDeviceRef&) const
+void MockModel::execute(CoreParams const&, CoreStateDevice&) const
 {
     // Inform calling test code that we've been launched
     data_.cb(this->action_id());

--- a/test/celeritas/phys/MockModel.cc
+++ b/test/celeritas/phys/MockModel.cc
@@ -55,12 +55,12 @@ auto MockModel::micro_xs(Applicability range) const -> MicroXsBuilders
     return builders;
 }
 
-void MockModel::execute(ParamsHostCRef const&, StateHostRef&) const
+void MockModel::execute(CoreParams const&, StateHostRef&) const
 {
     // Shouldn't be called?
 }
 
-void MockModel::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
+void MockModel::execute(CoreParams const&, StateDeviceRef&) const
 {
     // Inform calling test code that we've been launched
     data_.cb(this->action_id());

--- a/test/celeritas/phys/MockModel.hh
+++ b/test/celeritas/phys/MockModel.hh
@@ -48,8 +48,8 @@ class MockModel final : public Model
     explicit MockModel(Input data);
     SetApplicability applicability() const final;
     MicroXsBuilders micro_xs(Applicability range) const final;
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
     ActionId action_id() const final { return data_.id; }
     std::string label() const final;
     std::string description() const final;

--- a/test/celeritas/phys/MockModel.hh
+++ b/test/celeritas/phys/MockModel.hh
@@ -48,8 +48,8 @@ class MockModel final : public Model
     explicit MockModel(Input data);
     SetApplicability applicability() const final;
     MicroXsBuilders micro_xs(Applicability range) const final;
-    void execute(CoreParams const&, StateHostRef&) const final;
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
     ActionId action_id() const final { return data_.id; }
     std::string label() const final;
     std::string description() const final;

--- a/test/celeritas/track/MockInteractAction.cc
+++ b/test/celeritas/track/MockInteractAction.cc
@@ -15,6 +15,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
@@ -50,14 +51,13 @@ MockInteractAction::MockInteractAction(
 
 //---------------------------------------------------------------------------//
 void MockInteractAction::execute(CoreParams const& params,
-                                 StateHostRef& state) const
+                                 CoreStateHost& state) const
 {
-    CELER_EXPECT(state);
     CELER_EXPECT(state.size() == data_.host_ref().size());
 
     MultiExceptionHandler capture_exception;
     auto launch = make_active_track_launcher(params.ref<MemSpace::native>(),
-                                             state,
+                                             state.ref(),
                                              apply_mock_interact,
                                              data_.host_ref());
 #ifdef _OPENMP
@@ -69,7 +69,7 @@ void MockInteractAction::execute(CoreParams const& params,
             launch(ThreadId{i}),
             capture_exception,
             KernelContextException(params.ref<MemSpace::host>(),
-                                   state,
+                                   state.ref(),
                                    ThreadId{i},
                                    this->label()));
     }

--- a/test/celeritas/track/MockInteractAction.cu
+++ b/test/celeritas/track/MockInteractAction.cu
@@ -11,6 +11,7 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
 #include "MockInteractImpl.hh"
@@ -39,16 +40,15 @@ __global__ void mock_interact_kernel(DeviceCRef<CoreParamsData> const params,
 //---------------------------------------------------------------------------//
 
 void MockInteractAction::execute(CoreParams const& params,
-                                 StateDeviceRef& state) const
+                                 CoreStateDevice& state) const
 {
-    CELER_EXPECT(params && state);
     CELER_EXPECT(state.size() == data_.device_ref().size());
 
     CELER_LAUNCH_KERNEL(mock_interact,
                         device().default_block_size(),
                         state.size(),
                         params.ref<MemSpace::native>(),
-                        state,
+                        state.ref(),
                         data_.device_ref());
 }
 

--- a/test/celeritas/track/MockInteractAction.cu
+++ b/test/celeritas/track/MockInteractAction.cu
@@ -10,6 +10,7 @@
 #include "corecel/device_runtime_api.h"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
+#include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/TrackLauncher.hh"
 
 #include "MockInteractImpl.hh"
@@ -37,7 +38,7 @@ __global__ void mock_interact_kernel(DeviceCRef<CoreParamsData> const params,
 
 //---------------------------------------------------------------------------//
 
-void MockInteractAction::execute(ParamsDeviceCRef const& params,
+void MockInteractAction::execute(CoreParams const& params,
                                  StateDeviceRef& state) const
 {
     CELER_EXPECT(params && state);
@@ -46,7 +47,7 @@ void MockInteractAction::execute(ParamsDeviceCRef const& params,
     CELER_LAUNCH_KERNEL(mock_interact,
                         device().default_block_size(),
                         state.size(),
-                        params,
+                        params.ref<MemSpace::native>(),
                         state,
                         data_.device_ref());
 }

--- a/test/celeritas/track/MockInteractAction.hh
+++ b/test/celeritas/track/MockInteractAction.hh
@@ -32,9 +32,9 @@ class MockInteractAction final : public ExplicitActionInterface
                        std::vector<bool> const& alive);
 
     // Run on host
-    void execute(ParamsHostCRef const&, StateHostRef&) const final;
+    void execute(CoreParams const&, StateHostRef&) const final;
     // Run on device
-    void execute(ParamsDeviceCRef const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, StateDeviceRef&) const final;
 
     ActionId action_id() const final { return id_; }
     std::string label() const final { return "mock-interact"; }
@@ -53,7 +53,7 @@ class MockInteractAction final : public ExplicitActionInterface
 
 #if !CELER_USE_DEVICE
 inline void
-MockInteractAction::execute(ParamsDeviceCRef const&, StateDeviceRef&) const
+MockInteractAction::execute(CoreParams const&, StateDeviceRef&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/test/celeritas/track/MockInteractAction.hh
+++ b/test/celeritas/track/MockInteractAction.hh
@@ -32,9 +32,9 @@ class MockInteractAction final : public ExplicitActionInterface
                        std::vector<bool> const& alive);
 
     // Run on host
-    void execute(CoreParams const&, StateHostRef&) const final;
+    void execute(CoreParams const&, CoreStateHost&) const final;
     // Run on device
-    void execute(CoreParams const&, StateDeviceRef&) const final;
+    void execute(CoreParams const&, CoreStateDevice&) const final;
 
     ActionId action_id() const final { return id_; }
     std::string label() const final { return "mock-interact"; }
@@ -53,7 +53,7 @@ class MockInteractAction final : public ExplicitActionInterface
 
 #if !CELER_USE_DEVICE
 inline void
-MockInteractAction::execute(CoreParams const&, StateDeviceRef&) const
+MockInteractAction::execute(CoreParams const&, CoreStateDevice&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -41,7 +41,7 @@ struct RunResult
     std::vector<size_type> vacancies;
 
     template<MemSpace M>
-    static RunResult from_state(CoreStateData<Ownership::reference, M>&);
+    static RunResult from_state(CoreState<M>&);
 
     // Print code for the expected attributes
     void print_expected() const;
@@ -50,15 +50,13 @@ struct RunResult
 //---------------------------------------------------------------------------//
 
 template<MemSpace M>
-RunResult RunResult::from_state(CoreStateData<Ownership::reference, M>& states)
+RunResult RunResult::from_state(CoreState<M>& state)
 {
-    CELER_EXPECT(states);
-
     RunResult result;
 
     // Copy track initializer data to host
     HostVal<TrackInitStateData> data;
-    data = states.init;
+    data = state.ref().init;
 
     // Store the IDs of the vacant track slots
     for (TrackSlotId const& v : data.vacancies.data())
@@ -72,9 +70,9 @@ RunResult RunResult::from_state(CoreStateData<Ownership::reference, M>& states)
         result.init_ids.push_back(init.sim.track_id.get());
     }
 
-    // Copy sim states to host
+    // Copy sim state to host
     HostVal<SimStateData> sim;
-    sim = states.sim;
+    sim = state.ref().sim;
 
     // Store the track IDs and parent IDs
     for (auto tid : range(TrackSlotId{sim.size()}))
@@ -128,18 +126,19 @@ class TypedTrackInitTest : public TrackInitTest
     //! Create mutable state data
     void build_states(size_type num_tracks)
     {
-        CELER_EXPECT(num_tracks > 0);
-        state_store_ = CollectionStateStore<CoreStateData, M>(
-            this->core()->host_ref(), StreamId{0}, num_tracks);
+        // Allocate state data
+        state_ = std::make_unique<CoreState<M>>(
+            *this->core(), StreamId{0}, num_tracks);
     }
 
-    CoreStateData<Ownership::reference, M>& core_state()
+    CoreState<M>& state()
     {
-        return state_store_.ref();
+        CELER_ENSURE(state_);
+        return *state_;
     }
 
   private:
-    CollectionStateStore<CoreStateData, M> state_store_;
+    std::unique_ptr<CoreState<M>> state_;
 };
 
 using HostType = std::integral_constant<MemSpace, MemSpace::host>;
@@ -172,11 +171,10 @@ TYPED_TEST(TypedTrackInitTest, run)
     const size_type num_tracks = 10;
 
     this->build_states(num_tracks);
-    auto& core_state = this->core_state();
 
     // Check that all of the track slots were marked as empty
     {
-        auto result = RunResult::from_state(core_state);
+        auto result = RunResult::from_state(this->state());
         static unsigned int const expected_vacancies[]
             = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         EXPECT_VEC_EQ(expected_vacancies, result.vacancies);
@@ -184,22 +182,22 @@ TYPED_TEST(TypedTrackInitTest, run)
 
     // Create track initializers on device from primary particles
     auto primaries = this->make_primaries(num_primaries);
-    extend_from_primaries(*this->core(), core_state, make_span(primaries));
+    extend_from_primaries(*this->core(), this->state(), make_span(primaries));
 
     // Check the track IDs of the track initializers created from primaries
     {
-        auto result = RunResult::from_state(core_state);
+        auto result = RunResult::from_state(this->state());
         static unsigned int const expected_track_ids[]
             = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
         EXPECT_VEC_EQ(expected_track_ids, result.init_ids);
     }
 
     // Initialize the primary tracks on device
-    initialize_tracks(*this->core(), core_state);
+    initialize_tracks(*this->core(), this->state());
 
     // Check the track IDs and parent IDs of the initialized tracks
     {
-        auto result = RunResult::from_state(core_state);
+        auto result = RunResult::from_state(this->state());
         static unsigned int const expected_track_ids[]
             = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
         EXPECT_VEC_EQ(expected_track_ids, result.track_ids);
@@ -220,14 +218,14 @@ TYPED_TEST(TypedTrackInitTest, run)
     }();
 
     // Launch kernel to process interactions
-    interact.execute(*this->core(), core_state);
+    interact.execute(*this->core(), this->state());
 
     // Launch a kernel to create track initializers from secondaries
-    extend_from_secondaries(*this->core(), core_state);
+    extend_from_secondaries(*this->core(), this->state());
 
     // Check the vacancies
     {
-        auto result = RunResult::from_state(core_state);
+        auto result = RunResult::from_state(this->state());
         static unsigned int const expected_vacancies[] = {2, 6};
         EXPECT_VEC_EQ(expected_vacancies, result.vacancies);
     }
@@ -238,7 +236,7 @@ TYPED_TEST(TypedTrackInitTest, run)
     // used for the track initializers, just check that there is the correct
     // number and they are in the correct range.
     {
-        auto result = RunResult::from_state(core_state);
+        auto result = RunResult::from_state(this->state());
         EXPECT_TRUE(std::all_of(std::begin(result.init_ids),
                                 std::end(result.init_ids),
                                 [](unsigned int id) { return id <= 18; }));
@@ -250,11 +248,11 @@ TYPED_TEST(TypedTrackInitTest, run)
     }
 
     // Initialize secondaries on device
-    initialize_tracks(*this->core(), core_state);
+    initialize_tracks(*this->core(), this->state());
 
     // Check the track IDs and parent IDs of the initialized tracks
     {
-        auto result = RunResult::from_state(core_state);
+        auto result = RunResult::from_state(this->state());
         EXPECT_TRUE(std::all_of(std::begin(result.track_ids),
                                 std::end(result.track_ids),
                                 [](unsigned int id) { return id <= 18; }));
@@ -281,7 +279,6 @@ TYPED_TEST(TypedTrackInitTest, primaries)
     const size_type num_tracks = 16;
 
     this->build_states(num_tracks);
-    auto& core_state = this->core_state();
 
     // Kill half the tracks in each interaction and don't produce secondaries
     auto interact = [] {
@@ -298,18 +295,20 @@ TYPED_TEST(TypedTrackInitTest, primaries)
     {
         // Create track initializers on device from primary particles
         auto primaries = this->make_primaries(num_primaries);
-        extend_from_primaries(*this->core(), core_state, make_span(primaries));
+        extend_from_primaries(
+            *this->core(), this->state(), make_span(primaries));
 
         // Initialize tracks on device
-        initialize_tracks(*this->core(), core_state);
+        initialize_tracks(*this->core(), this->state());
 
         // Launch kernel that will kill half the tracks
-        interact.execute(*this->core(), core_state);
+        interact.execute(*this->core(), this->state());
 
         // Find vacancies and create track initializers from secondaries
-        extend_from_secondaries(*this->core(), core_state);
-        EXPECT_EQ(i * num_tracks / 2, core_state.init.initializers.size());
-        EXPECT_EQ(num_tracks / 2, core_state.init.vacancies.size());
+        extend_from_secondaries(*this->core(), this->state());
+        auto& init = this->state().ref().init;
+        EXPECT_EQ(i * num_tracks / 2, init.initializers.size());
+        EXPECT_EQ(num_tracks / 2, init.vacancies.size());
     }
 
     // Check the results
@@ -322,7 +321,7 @@ TYPED_TEST(TypedTrackInitTest, primaries)
     static unsigned int const expected_init_ids[]
         = {0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u, 0u, 1u, 2u, 3u,
            4u, 5u, 6u, 7u, 0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u};
-    auto result = RunResult::from_state(core_state);
+    auto result = RunResult::from_state(this->state());
     EXPECT_VEC_EQ(expected_track_ids, result.track_ids);
     EXPECT_VEC_EQ(expected_parent_ids, result.parent_ids);
     EXPECT_VEC_EQ(expected_vacancies, result.vacancies);
@@ -334,7 +333,6 @@ TYPED_TEST(TypedTrackInitTest, secondaries)
     const size_type num_groups = 32;
     const size_type num_tracks = 8 * num_groups;
     this->build_states(num_tracks);
-    auto& core_state = this->core_state();
 
     auto interact = [] {
         size_type const nsec_inp[] = {1, 1, 2, 0, 0, 0, 0, 0};
@@ -354,29 +352,31 @@ TYPED_TEST(TypedTrackInitTest, secondaries)
     // Create track initializers on device from primary particles
     const size_type num_primaries = num_tracks;
     auto primaries = this->make_primaries(num_primaries);
-    extend_from_primaries(*this->core(), core_state, make_span(primaries));
-    EXPECT_EQ(num_primaries, core_state.init.initializers.size());
+    extend_from_primaries(*this->core(), this->state(), make_span(primaries));
+    EXPECT_EQ(num_primaries, this->state().ref().init.initializers.size());
 
     const size_type num_iter = 16;
     for ([[maybe_unused]] size_type i : range(num_iter))
     {
         SCOPED_TRACE(i);
+        auto& init = this->state().ref().init;
+
         // All queued initializers are converted to tracks
-        initialize_tracks(*this->core(), core_state);
-        ASSERT_EQ(0, core_state.init.initializers.size());
-        EXPECT_EQ(0, core_state.init.vacancies.size());
+        initialize_tracks(*this->core(), this->state());
+        ASSERT_EQ(0, init.initializers.size());
+        EXPECT_EQ(0, init.vacancies.size());
 
         // Launch kernel to process interactions
-        interact.execute(*this->core(), core_state);
+        interact.execute(*this->core(), this->state());
 
         // Launch a kernel to create track initializers from secondaries
-        extend_from_secondaries(*this->core(), core_state);
-        EXPECT_EQ(num_groups * 2, core_state.init.initializers.size());
-        EXPECT_EQ(num_groups * 2, core_state.init.vacancies.size());
+        extend_from_secondaries(*this->core(), this->state());
+        EXPECT_EQ(num_groups * 2, init.initializers.size());
+        EXPECT_EQ(num_groups * 2, init.vacancies.size());
 
         // Number of secondaries *excludes* in-place secondaries: this is
         // really the number of initializers to be consumed
-        EXPECT_EQ(num_groups * (1 + 0 + 1), core_state.init.num_secondaries);
+        EXPECT_EQ(num_groups * (1 + 0 + 1), init.num_secondaries);
         if (this->HasFailure())
         {
             FAIL() << "Aborting loop";
@@ -394,7 +394,6 @@ TYPED_TEST(TypedTrackInitTest, secondaries_action)
         = {true, false, false, true, true, false, false, true};
 
     this->build_states(num_tracks);
-    auto& core_state = this->core_state();
 
     // Create actions
     std::vector<std::shared_ptr<ExplicitActionInterface>> actions = {
@@ -405,13 +404,13 @@ TYPED_TEST(TypedTrackInitTest, secondaries_action)
 
     // Create track initializers on device from primary particles
     auto primaries = this->make_primaries(num_primaries);
-    extend_from_primaries(*this->core(), core_state, make_span(primaries));
-    EXPECT_EQ(num_primaries, core_state.init.initializers.size());
+    extend_from_primaries(*this->core(), this->state(), make_span(primaries));
+    EXPECT_EQ(num_primaries, this->state().ref().init.initializers.size());
 
-    auto apply_actions = [&actions, this, &core_state] {
+    auto apply_actions = [&actions, this] {
         for (const auto& ea_interface : actions)
         {
-            ea_interface->execute(*this->core(), core_state);
+            ea_interface->execute(*this->core(), this->state());
         }
     };
 
@@ -420,7 +419,7 @@ TYPED_TEST(TypedTrackInitTest, secondaries_action)
     {
         CELER_TRY_HANDLE(apply_actions(),
                          LogContextException{this->output_reg().get()});
-        auto result = RunResult::from_state(core_state);
+        auto result = RunResult::from_state(this->state());
 
         // Slots 5 and 6 are always vacant because these tracks are killed with
         // no secondaries


### PR DESCRIPTION
This is the next step toward passing a single device pointer to all the device data in order to reducing the `__constant__` memory usage  from the very large args (see #639).

This class introduces a thin wrapper `CoreStateData` (which will be extended in the future to include other data needed on the host, like the track initializers) and refactors `execute` and several other kernels to use it.