### PR TITLE
Access params/state through global rather than constant memory

### DIFF
--- a/cmake/CeleritasGen/gen-action.py
+++ b/cmake/CeleritasGen/gen-action.py
@@ -84,7 +84,7 @@ namespace generated
 void {clsname}::execute(CoreParams const& params, CoreStateHost& state) const
 {{
     MultiExceptionHandler capture_exception;
-    TrackLauncher launch{{params.ref<MemSpace::native>(), state.ref(), detail::{func}_track}};
+    TrackLauncher launch{{*params.ptr<MemSpace::native>(), *state.ptr(), detail::{func}_track}};
     #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {{
@@ -120,11 +120,11 @@ namespace generated
 namespace
 {{
 __global__ void{launch_bounds}{func}_kernel(
-    DeviceCRef<CoreParamsData> const params,
-    DeviceRef<CoreStateData> const state
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state
 )
 {{
-    TrackLauncher launch{{params, state, detail::{func}_track}};
+    TrackLauncher launch{{*params, *state, detail::{func}_track}};
     launch(KernelParamCalculator::thread_id());
 }}
 }}  // namespace
@@ -134,8 +134,8 @@ void {clsname}::execute(CoreParams const& params, CoreStateDevice& state) const
     CELER_LAUNCH_KERNEL({func},
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
 }}
 
 }}  // namespace generated

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cc
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cc
@@ -35,7 +35,7 @@ void bethe_heitler_interact(
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(),
+        params.ptr<MemSpace::native>(), state.ptr(),
         celeritas::bethe_heitler_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/em/generated/BetheHeitlerInteract.cu
+++ b/src/celeritas/em/generated/BetheHeitlerInteract.cu
@@ -18,6 +18,8 @@
 #include "celeritas/em/launcher/BetheHeitlerLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
+using celeritas::MemSpace;
+
 namespace celeritas
 {
 namespace generated
@@ -34,12 +36,13 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 bethe_heitler_interact_kernel(
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state,
-    celeritas::BetheHeitlerDeviceRef const model_data)
+    celeritas::CRefPtr<celeritas::CoreParamsData, MemSpace::device> const params,
+    celeritas::RefPtr<celeritas::CoreStateData, MemSpace::device> const state,
+    celeritas::BetheHeitlerDeviceRef const model_data,
+    celeritas::size_type size)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < state.size()))
+    if (!(tid < size))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
@@ -58,7 +61,10 @@ void bethe_heitler_interact(
     CELER_LAUNCH_KERNEL(bethe_heitler_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(), state.ref(), model_data);
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
+                        model_data,
+                        state.size());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/CombinedBremInteract.cc
+++ b/src/celeritas/em/generated/CombinedBremInteract.cc
@@ -35,7 +35,7 @@ void combined_brem_interact(
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(),
+        params.ptr<MemSpace::native>(), state.ptr(),
         celeritas::combined_brem_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/em/generated/EPlusGGInteract.cc
+++ b/src/celeritas/em/generated/EPlusGGInteract.cc
@@ -35,7 +35,7 @@ void eplusgg_interact(
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(),
+        params.ptr<MemSpace::native>(), state.ptr(),
         celeritas::eplusgg_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/em/generated/EPlusGGInteract.cu
+++ b/src/celeritas/em/generated/EPlusGGInteract.cu
@@ -18,6 +18,8 @@
 #include "celeritas/em/launcher/EPlusGGLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
+using celeritas::MemSpace;
+
 namespace celeritas
 {
 namespace generated
@@ -34,12 +36,13 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 eplusgg_interact_kernel(
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state,
-    celeritas::EPlusGGDeviceRef const model_data)
+    celeritas::CRefPtr<celeritas::CoreParamsData, MemSpace::device> const params,
+    celeritas::RefPtr<celeritas::CoreStateData, MemSpace::device> const state,
+    celeritas::EPlusGGDeviceRef const model_data,
+    celeritas::size_type size)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < state.size()))
+    if (!(tid < size))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
@@ -58,7 +61,10 @@ void eplusgg_interact(
     CELER_LAUNCH_KERNEL(eplusgg_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(), state.ref(), model_data);
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
+                        model_data,
+                        state.size());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/KleinNishinaInteract.cc
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cc
@@ -35,7 +35,7 @@ void klein_nishina_interact(
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(),
+        params.ptr<MemSpace::native>(), state.ptr(),
         celeritas::klein_nishina_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/em/generated/KleinNishinaInteract.cu
+++ b/src/celeritas/em/generated/KleinNishinaInteract.cu
@@ -18,6 +18,8 @@
 #include "celeritas/em/launcher/KleinNishinaLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
+using celeritas::MemSpace;
+
 namespace celeritas
 {
 namespace generated
@@ -34,12 +36,13 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 klein_nishina_interact_kernel(
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state,
-    celeritas::KleinNishinaDeviceRef const model_data)
+    celeritas::CRefPtr<celeritas::CoreParamsData, MemSpace::device> const params,
+    celeritas::RefPtr<celeritas::CoreStateData, MemSpace::device> const state,
+    celeritas::KleinNishinaDeviceRef const model_data,
+    celeritas::size_type size)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < state.size()))
+    if (!(tid < size))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
@@ -58,7 +61,10 @@ void klein_nishina_interact(
     CELER_LAUNCH_KERNEL(klein_nishina_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(), state.ref(), model_data);
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
+                        model_data,
+                        state.size());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/LivermorePEInteract.cc
+++ b/src/celeritas/em/generated/LivermorePEInteract.cc
@@ -35,7 +35,7 @@ void livermore_pe_interact(
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(),
+        params.ptr<MemSpace::native>(), state.ptr(),
         celeritas::livermore_pe_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/em/generated/LivermorePEInteract.cu
+++ b/src/celeritas/em/generated/LivermorePEInteract.cu
@@ -18,6 +18,8 @@
 #include "celeritas/em/launcher/LivermorePELauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
+using celeritas::MemSpace;
+
 namespace celeritas
 {
 namespace generated
@@ -34,12 +36,13 @@ __launch_bounds__(1024, 7)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 livermore_pe_interact_kernel(
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state,
-    celeritas::LivermorePEDeviceRef const model_data)
+    celeritas::CRefPtr<celeritas::CoreParamsData, MemSpace::device> const params,
+    celeritas::RefPtr<celeritas::CoreStateData, MemSpace::device> const state,
+    celeritas::LivermorePEDeviceRef const model_data,
+    celeritas::size_type size)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < state.size()))
+    if (!(tid < size))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
@@ -58,7 +61,10 @@ void livermore_pe_interact(
     CELER_LAUNCH_KERNEL(livermore_pe_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(), state.ref(), model_data);
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
+                        model_data,
+                        state.size());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/MollerBhabhaInteract.cc
+++ b/src/celeritas/em/generated/MollerBhabhaInteract.cc
@@ -35,7 +35,7 @@ void moller_bhabha_interact(
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(),
+        params.ptr<MemSpace::native>(), state.ptr(),
         celeritas::moller_bhabha_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
+++ b/src/celeritas/em/generated/MuBremsstrahlungInteract.cc
@@ -35,7 +35,7 @@ void mu_bremsstrahlung_interact(
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(),
+        params.ptr<MemSpace::native>(), state.ptr(),
         celeritas::mu_bremsstrahlung_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/em/generated/RayleighInteract.cc
+++ b/src/celeritas/em/generated/RayleighInteract.cc
@@ -35,7 +35,7 @@ void rayleigh_interact(
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(),
+        params.ptr<MemSpace::native>(), state.ptr(),
         celeritas::rayleigh_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/em/generated/RayleighInteract.cu
+++ b/src/celeritas/em/generated/RayleighInteract.cu
@@ -18,6 +18,8 @@
 #include "celeritas/em/launcher/RayleighLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
+using celeritas::MemSpace;
+
 namespace celeritas
 {
 namespace generated
@@ -34,12 +36,13 @@ __launch_bounds__(1024, 8)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 rayleigh_interact_kernel(
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state,
-    celeritas::RayleighDeviceRef const model_data)
+    celeritas::CRefPtr<celeritas::CoreParamsData, MemSpace::device> const params,
+    celeritas::RefPtr<celeritas::CoreStateData, MemSpace::device> const state,
+    celeritas::RayleighDeviceRef const model_data,
+    celeritas::size_type size)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < state.size()))
+    if (!(tid < size))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
@@ -58,7 +61,10 @@ void rayleigh_interact(
     CELER_LAUNCH_KERNEL(rayleigh_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(), state.ref(), model_data);
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
+                        model_data,
+                        state.size());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/RelativisticBremInteract.cc
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cc
@@ -35,7 +35,7 @@ void relativistic_brem_interact(
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(),
+        params.ptr<MemSpace::native>(), state.ptr(),
         celeritas::relativistic_brem_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/em/generated/RelativisticBremInteract.cu
+++ b/src/celeritas/em/generated/RelativisticBremInteract.cu
@@ -18,6 +18,8 @@
 #include "celeritas/em/launcher/RelativisticBremLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
+using celeritas::MemSpace;
+
 namespace celeritas
 {
 namespace generated
@@ -25,12 +27,13 @@ namespace generated
 namespace
 {
 __global__ void relativistic_brem_interact_kernel(
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state,
-    celeritas::RelativisticBremDeviceRef const model_data)
+    celeritas::CRefPtr<celeritas::CoreParamsData, MemSpace::device> const params,
+    celeritas::RefPtr<celeritas::CoreStateData, MemSpace::device> const state,
+    celeritas::RelativisticBremDeviceRef const model_data,
+    celeritas::size_type size)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < state.size()))
+    if (!(tid < size))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
@@ -49,7 +52,10 @@ void relativistic_brem_interact(
     CELER_LAUNCH_KERNEL(relativistic_brem_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(), state.ref(), model_data);
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
+                        model_data,
+                        state.size());
 }
 
 }  // namespace generated

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cc
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cc
@@ -35,7 +35,7 @@ void seltzer_berger_interact(
 
     celeritas::MultiExceptionHandler capture_exception;
     auto launch = celeritas::make_interaction_launcher(
-        params.ref<MemSpace::native>(), state.ref(),
+        params.ptr<MemSpace::native>(), state.ptr(),
         celeritas::seltzer_berger_interact_track, model_data);
     #pragma omp parallel for
     for (celeritas::size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/em/generated/SeltzerBergerInteract.cu
+++ b/src/celeritas/em/generated/SeltzerBergerInteract.cu
@@ -18,6 +18,8 @@
 #include "celeritas/em/launcher/SeltzerBergerLauncher.hh"
 #include "celeritas/phys/InteractionLauncher.hh"
 
+using celeritas::MemSpace;
+
 namespace celeritas
 {
 namespace generated
@@ -25,12 +27,13 @@ namespace generated
 namespace
 {
 __global__ void seltzer_berger_interact_kernel(
-    celeritas::DeviceCRef<celeritas::CoreParamsData> const params,
-    celeritas::DeviceRef<celeritas::CoreStateData> const state,
-    celeritas::SeltzerBergerDeviceRef const model_data)
+    celeritas::CRefPtr<celeritas::CoreParamsData, MemSpace::device> const params,
+    celeritas::RefPtr<celeritas::CoreStateData, MemSpace::device> const state,
+    celeritas::SeltzerBergerDeviceRef const model_data,
+    celeritas::size_type size)
 {
     auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < state.size()))
+    if (!(tid < size))
         return;
 
     auto launch = celeritas::make_interaction_launcher(
@@ -49,7 +52,10 @@ void seltzer_berger_interact(
     CELER_LAUNCH_KERNEL(seltzer_berger_interact,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(), state.ref(), model_data);
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
+                        model_data,
+                        state.size());
 }
 
 }  // namespace generated

--- a/src/celeritas/geo/generated/BoundaryAction.cc
+++ b/src/celeritas/geo/generated/BoundaryAction.cc
@@ -27,7 +27,7 @@ namespace generated
 void BoundaryAction::execute(CoreParams const& params, CoreStateHost& state) const
 {
     MultiExceptionHandler capture_exception;
-    TrackLauncher launch{params.ref<MemSpace::native>(), state.ref(), detail::boundary_track};
+    TrackLauncher launch{*params.ptr<MemSpace::native>(), *state.ptr(), detail::boundary_track};
     #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/geo/generated/BoundaryAction.cu
+++ b/src/celeritas/geo/generated/BoundaryAction.cu
@@ -25,11 +25,11 @@ namespace generated
 namespace
 {
 __global__ void boundary_kernel(
-    DeviceCRef<CoreParamsData> const params,
-    DeviceRef<CoreStateData> const state
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state
 )
 {
-    TrackLauncher launch{params, state, detail::boundary_track};
+    TrackLauncher launch{*params, *state, detail::boundary_track};
     launch(KernelParamCalculator::thread_id());
 }
 }  // namespace
@@ -39,8 +39,8 @@ void BoundaryAction::execute(CoreParams const& params, CoreStateDevice& state) c
     CELER_LAUNCH_KERNEL(boundary,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
 }
 
 }  // namespace generated

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -189,6 +189,9 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
     if (celeritas::device())
     {
         device_ref_ = build_params_refs<MemSpace::device>(input_, scalars);
+        // Copy device ref to device global memory
+        device_ref_vec_ = DeviceVector<DeviceRef>(1);
+        device_ref_vec_.copy_to_device({&device_ref_, 1});
     }
 
 #if CELERITAS_USE_JSON

--- a/src/celeritas/global/CoreState.cc
+++ b/src/celeritas/global/CoreState.cc
@@ -28,6 +28,13 @@ CoreState<M>::CoreState(CoreParams const& params,
 
     states_ = CollectionStateStore<CoreStateData, M>(
         params.host_ref(), stream_id, num_track_slots);
+
+    if constexpr (M == MemSpace::device)
+    {
+        device_ref_vec_ = DeviceVector<Ref>(1);
+        device_ref_vec_.copy_to_device({&this->ref(), 1});
+    }
+
     CELER_ENSURE(states_);
 }
 

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -64,9 +64,9 @@ auto Stepper<M>::operator()() -> result_type
     // Get the number of track initializers and active tracks
     auto const& init = this->state_ref().init;
     result_type result;
-    result.active = init.num_active;
-    result.alive = state_.size() - init.vacancies.size();
-    result.queued = init.initializers.size();
+    result.active = init.scalars.num_active;
+    result.alive = init.scalars.num_alive;
+    result.queued = init.scalars.num_initializers;
 
     return result;
 }
@@ -80,8 +80,9 @@ auto Stepper<M>::operator()(SpanConstPrimary primaries) -> result_type
 {
     CELER_EXPECT(!primaries.empty());
 
-    size_type num_initializers = this->state_ref().init.initializers.size();
-    size_type init_capacity = state_.ref().init.initializers.capacity();
+    size_type num_initializers
+        = this->state_ref().init.scalars.num_initializers;
+    size_type init_capacity = this->state_ref().init.initializers.size();
     CELER_VALIDATE(primaries.size() + num_initializers <= init_capacity,
                    << "insufficient initializer capacity (" << init_capacity
                    << ") with size (" << num_initializers

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
@@ -76,8 +76,8 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
                                            CoreStateHost& state) const
 {
     MultiExceptionHandler capture_exception;
-    auto launch = make_active_track_launcher(params.ref<MemSpace::native>(),
-                                             state.ref(),
+    auto launch = make_active_track_launcher(*params.ptr<MemSpace::native>(),
+                                             *state.ptr(),
                                              detail::along_step_general_linear,
                                              host_data_.msc,
                                              host_data_.fluct);

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cu
@@ -29,14 +29,14 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
-__global__ void
-along_step_apply_msc_step_limit_kernel(DeviceCRef<CoreParamsData> const params,
-                                       DeviceRef<CoreStateData> const state,
-                                       DeviceCRef<UrbanMscData> const msc_data)
+__global__ void along_step_apply_msc_step_limit_kernel(
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state,
+    DeviceCRef<UrbanMscData> const msc_data)
 {
     auto launch
-        = make_active_track_launcher(params,
-                                     state,
+        = make_active_track_launcher(*params,
+                                     *state,
                                      detail::apply_msc_step_limit<UrbanMsc>,
                                      UrbanMsc{msc_data});
     launch(KernelParamCalculator::thread_id());
@@ -44,57 +44,57 @@ along_step_apply_msc_step_limit_kernel(DeviceCRef<CoreParamsData> const params,
 
 //---------------------------------------------------------------------------//
 __global__ void along_step_apply_linear_propagation_kernel(
-    DeviceCRef<CoreParamsData> const params,
-    DeviceRef<CoreStateData> const state)
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state)
 {
-    auto launch = make_active_track_launcher(params,
-                                             state,
+    auto launch = make_active_track_launcher(*params,
+                                             *state,
                                              detail::ApplyPropagation{},
                                              detail::LinearPropagatorFactory{});
     launch(KernelParamCalculator::thread_id());
 }
 
 //---------------------------------------------------------------------------//
-__global__ void
-along_step_apply_msc_kernel(DeviceCRef<CoreParamsData> const params,
-                            DeviceRef<CoreStateData> const state,
-                            DeviceCRef<UrbanMscData> const msc_data)
+__global__ void along_step_apply_msc_kernel(
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state,
+    DeviceCRef<UrbanMscData> const msc_data)
 {
     auto launch = make_active_track_launcher(
-        params, state, detail::apply_msc<UrbanMsc>, UrbanMsc{msc_data});
+        *params, *state, detail::apply_msc<UrbanMsc>, UrbanMsc{msc_data});
     launch(KernelParamCalculator::thread_id());
 }
 
 //---------------------------------------------------------------------------//
-__global__ void
-along_step_update_time_kernel(DeviceCRef<CoreParamsData> const params,
-                              DeviceRef<CoreStateData> const state)
+__global__ void along_step_update_time_kernel(
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state)
 {
     auto launch
-        = make_active_track_launcher(params, state, detail::update_time);
+        = make_active_track_launcher(*params, *state, detail::update_time);
     launch(KernelParamCalculator::thread_id());
 }
 
 //---------------------------------------------------------------------------//
-__global__ void
-along_step_apply_fluct_eloss_kernel(DeviceCRef<CoreParamsData> const params,
-                                    DeviceRef<CoreStateData> const state,
-                                    NativeCRef<FluctuationData> const fluct)
+__global__ void along_step_apply_fluct_eloss_kernel(
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state,
+    NativeCRef<FluctuationData> const fluct)
 {
     using detail::FluctELoss;
 
     auto launch = make_active_track_launcher(
-        params, state, detail::apply_eloss<FluctELoss>, FluctELoss{fluct});
+        *params, *state, detail::apply_eloss<FluctELoss>, FluctELoss{fluct});
     launch(KernelParamCalculator::thread_id());
 }
 
 //---------------------------------------------------------------------------//
-__global__ void
-along_step_update_track_kernel(DeviceCRef<CoreParamsData> const params,
-                               DeviceRef<CoreStateData> const state)
+__global__ void along_step_update_track_kernel(
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state)
 {
     auto launch
-        = make_active_track_launcher(params, state, detail::update_track);
+        = make_active_track_launcher(*params, *state, detail::update_track);
     launch(KernelParamCalculator::thread_id());
 }
 
@@ -111,36 +111,36 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
     CELER_LAUNCH_KERNEL(along_step_apply_msc_step_limit,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref(),
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_apply_linear_propagation,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
     CELER_LAUNCH_KERNEL(along_step_apply_msc,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref(),
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_update_time,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
     CELER_LAUNCH_KERNEL(along_step_apply_fluct_eloss,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref(),
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
                         device_data_.fluct);
     CELER_LAUNCH_KERNEL(along_step_update_track,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
@@ -39,8 +39,8 @@ void AlongStepNeutralAction::execute(CoreParams const& params,
                                      CoreStateHost& state) const
 {
     MultiExceptionHandler capture_exception;
-    auto launch = make_active_track_launcher(params.ref<MemSpace::native>(),
-                                             state.ref(),
+    auto launch = make_active_track_launcher(*params.ptr<MemSpace::native>(),
+                                             *state.ptr(),
                                              detail::along_step_neutral);
 #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
@@ -24,11 +24,11 @@ namespace
 {
 //---------------------------------------------------------------------------//
 __global__ void
-along_step_neutral_kernel(DeviceCRef<CoreParamsData> const params,
-                          DeviceRef<CoreStateData> const state)
+along_step_neutral_kernel(CRefPtr<CoreParamsData, MemSpace::device> const params,
+                          RefPtr<CoreStateData, MemSpace::device> const state)
 {
     auto launch = make_active_track_launcher(
-        params, state, detail::along_step_neutral);
+        *params, *state, detail::along_step_neutral);
     launch(KernelParamCalculator::thread_id());
 }
 //---------------------------------------------------------------------------//
@@ -44,8 +44,8 @@ void AlongStepNeutralAction::execute(CoreParams const& params,
     CELER_LAUNCH_KERNEL(along_step_neutral,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
@@ -73,8 +73,8 @@ void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
 {
     MultiExceptionHandler capture_exception;
 
-    auto launch = make_active_track_launcher(params.ref<MemSpace::native>(),
-                                             state.ref(),
+    auto launch = make_active_track_launcher(*params.ptr<MemSpace::native>(),
+                                             *state.ptr(),
                                              detail::along_step_mapfield_msc,
                                              msc_->host_ref(),
                                              field_->host_ref(),

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
@@ -51,8 +51,8 @@ void AlongStepUniformMscAction::execute(CoreParams const& params,
                                         CoreStateHost& state) const
 {
     MultiExceptionHandler capture_exception;
-    auto launch = make_active_track_launcher(params.ref<MemSpace::native>(),
-                                             state.ref(),
+    auto launch = make_active_track_launcher(*params.ptr<MemSpace::native>(),
+                                             *state.ptr(),
                                              detail::along_step_uniform_msc,
                                              host_data_.msc,
                                              field_params_);

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
@@ -30,14 +30,14 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
-__global__ void
-along_step_apply_msc_step_limit_kernel(DeviceCRef<CoreParamsData> const params,
-                                       DeviceRef<CoreStateData> const state,
-                                       DeviceCRef<UrbanMscData> const msc_data)
+__global__ void along_step_apply_msc_step_limit_kernel(
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state,
+    DeviceCRef<UrbanMscData> const msc_data)
 {
     auto launch
-        = make_active_track_launcher(params,
-                                     state,
+        = make_active_track_launcher(*params,
+                                     *state,
                                      detail::apply_msc_step_limit<UrbanMsc>,
                                      UrbanMsc{msc_data});
     launch(KernelParamCalculator::thread_id());
@@ -45,13 +45,13 @@ along_step_apply_msc_step_limit_kernel(DeviceCRef<CoreParamsData> const params,
 
 //---------------------------------------------------------------------------//
 __global__ void along_step_apply_uniform_propagation_kernel(
-    DeviceCRef<CoreParamsData> const params,
-    DeviceRef<CoreStateData> const state,
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state,
     UniformFieldParams const field)
 {
     auto launch = make_active_track_launcher(
-        params,
-        state,
+        *params,
+        *state,
         detail::ApplyPropagation{},
         [&field](ParticleTrackView const& particle, GeoTrackView* geo) {
             return make_mag_field_propagator<DormandPrinceStepper>(
@@ -61,45 +61,45 @@ __global__ void along_step_apply_uniform_propagation_kernel(
 }
 
 //---------------------------------------------------------------------------//
-__global__ void
-along_step_apply_msc_kernel(DeviceCRef<CoreParamsData> const params,
-                            DeviceRef<CoreStateData> const state,
-                            DeviceCRef<UrbanMscData> const msc_data)
+__global__ void along_step_apply_msc_kernel(
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state,
+    DeviceCRef<UrbanMscData> const msc_data)
 {
     auto launch = make_active_track_launcher(
-        params, state, detail::apply_msc<UrbanMsc>, UrbanMsc{msc_data});
+        *params, *state, detail::apply_msc<UrbanMsc>, UrbanMsc{msc_data});
     launch(KernelParamCalculator::thread_id());
 }
 
 //---------------------------------------------------------------------------//
-__global__ void
-along_step_update_time_kernel(DeviceCRef<CoreParamsData> const params,
-                              DeviceRef<CoreStateData> const state)
+__global__ void along_step_update_time_kernel(
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state)
 {
     auto launch
-        = make_active_track_launcher(params, state, detail::update_time);
+        = make_active_track_launcher(*params, *state, detail::update_time);
     launch(KernelParamCalculator::thread_id());
 }
 
 //---------------------------------------------------------------------------//
-__global__ void
-along_step_apply_mean_eloss_kernel(DeviceCRef<CoreParamsData> const params,
-                                   DeviceRef<CoreStateData> const state)
+__global__ void along_step_apply_mean_eloss_kernel(
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state)
 {
     using detail::MeanELoss;
 
     auto launch = make_active_track_launcher(
-        params, state, detail::apply_eloss<MeanELoss>, MeanELoss{});
+        *params, *state, detail::apply_eloss<MeanELoss>, MeanELoss{});
     launch(KernelParamCalculator::thread_id());
 }
 
 //---------------------------------------------------------------------------//
-__global__ void
-along_step_update_track_kernel(DeviceCRef<CoreParamsData> const params,
-                               DeviceRef<CoreStateData> const state)
+__global__ void along_step_update_track_kernel(
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state)
 {
     auto launch
-        = make_active_track_launcher(params, state, detail::update_track);
+        = make_active_track_launcher(*params, *state, detail::update_track);
     launch(KernelParamCalculator::thread_id());
 }
 
@@ -116,36 +116,36 @@ void AlongStepUniformMscAction::execute(CoreParams const& params,
     CELER_LAUNCH_KERNEL(along_step_apply_msc_step_limit,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref(),
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_apply_uniform_propagation,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref(),
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
                         field_params_);
     CELER_LAUNCH_KERNEL(along_step_apply_msc,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref(),
+                        params.ptr<MemSpace::native>(),
+                        state.ptr(),
                         device_data_.msc);
     CELER_LAUNCH_KERNEL(along_step_update_time,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
     CELER_LAUNCH_KERNEL(along_step_apply_mean_eloss,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
     CELER_LAUNCH_KERNEL(along_step_update_track,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/InteractionLauncher.hh
+++ b/src/celeritas/phys/InteractionLauncher.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/Types.hh"
 #include "corecel/math/Algorithms.hh"
 #include "celeritas/global/CoreTrackDataFwd.hh"
 
@@ -37,14 +38,14 @@ inline CELER_FUNCTION Interaction foo_interact(
  * filtering the tracks. We could improve this interface later.
  */
 template<class D, class F>
-CELER_FUNCTION detail::InteractionLauncherImpl<D, F>
-make_interaction_launcher(NativeCRef<CoreParamsData> const& params,
-                          NativeRef<CoreStateData> const& states,
-                          F&& call_with_track,
-                          D const& model_data)
+CELER_FUNCTION detail::InteractionLauncherImpl<D, F> make_interaction_launcher(
+    CRefPtr<CoreParamsData, MemSpace::native> const& params,
+    RefPtr<CoreStateData, MemSpace::native> const& states,
+    F&& call_with_track,
+    D const& model_data)
 {
     return {
-        params, states, ::celeritas::forward<F>(call_with_track), model_data};
+        *params, *states, ::celeritas::forward<F>(call_with_track), model_data};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cc
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cc
@@ -27,7 +27,7 @@ namespace generated
 void DiscreteSelectAction::execute(CoreParams const& params, CoreStateHost& state) const
 {
     MultiExceptionHandler capture_exception;
-    TrackLauncher launch{params.ref<MemSpace::native>(), state.ref(), detail::discrete_select_track};
+    TrackLauncher launch{*params.ptr<MemSpace::native>(), *state.ptr(), detail::discrete_select_track};
     #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/phys/generated/DiscreteSelectAction.cu
+++ b/src/celeritas/phys/generated/DiscreteSelectAction.cu
@@ -25,11 +25,11 @@ namespace generated
 namespace
 {
 __global__ void discrete_select_kernel(
-    DeviceCRef<CoreParamsData> const params,
-    DeviceRef<CoreStateData> const state
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state
 )
 {
-    TrackLauncher launch{params, state, detail::discrete_select_track};
+    TrackLauncher launch{*params, *state, detail::discrete_select_track};
     launch(KernelParamCalculator::thread_id());
 }
 }  // namespace
@@ -39,8 +39,8 @@ void DiscreteSelectAction::execute(CoreParams const& params, CoreStateDevice& st
     CELER_LAUNCH_KERNEL(discrete_select,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
 }
 
 }  // namespace generated

--- a/src/celeritas/phys/generated/PreStepAction.cc
+++ b/src/celeritas/phys/generated/PreStepAction.cc
@@ -27,7 +27,7 @@ namespace generated
 void PreStepAction::execute(CoreParams const& params, CoreStateHost& state) const
 {
     MultiExceptionHandler capture_exception;
-    TrackLauncher launch{params.ref<MemSpace::native>(), state.ref(), detail::pre_step_track};
+    TrackLauncher launch{*params.ptr<MemSpace::native>(), *state.ptr(), detail::pre_step_track};
     #pragma omp parallel for
     for (size_type i = 0; i < state.size(); ++i)
     {

--- a/src/celeritas/phys/generated/PreStepAction.cu
+++ b/src/celeritas/phys/generated/PreStepAction.cu
@@ -34,11 +34,11 @@ __launch_bounds__(1024, 7)
 #endif
 #endif // CELERITAS_LAUNCH_BOUNDS
 pre_step_kernel(
-    DeviceCRef<CoreParamsData> const params,
-    DeviceRef<CoreStateData> const state
+    CRefPtr<CoreParamsData, MemSpace::device> const params,
+    RefPtr<CoreStateData, MemSpace::device> const state
 )
 {
-    TrackLauncher launch{params, state, detail::pre_step_track};
+    TrackLauncher launch{*params, *state, detail::pre_step_track};
     launch(KernelParamCalculator::thread_id());
 }
 }  // namespace
@@ -48,8 +48,8 @@ void PreStepAction::execute(CoreParams const& params, CoreStateDevice& state) co
     CELER_LAUNCH_KERNEL(pre_step,
                         celeritas::device().default_block_size(),
                         state.size(),
-                        params.ref<MemSpace::native>(),
-                        state.ref());
+                        params.ptr<MemSpace::native>(),
+                        state.ptr());
 }
 
 }  // namespace generated

--- a/src/celeritas/track/TrackInitUtils.hh
+++ b/src/celeritas/track/TrackInitUtils.hh
@@ -29,6 +29,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS
+// TODO: move most of these to "detail" namespace
 //---------------------------------------------------------------------------//
 /*!
  * Create track initializers from a vector of host primary particles.
@@ -40,11 +41,12 @@ inline void extend_from_primaries(CoreParams const& core_params,
 {
     CELER_EXPECT(!host_primaries.empty());
 
-    auto& data = core_state.ref().init.initializers;
-    CELER_ASSERT(host_primaries.size() + data.size() <= data.capacity());
+    auto& init = core_state.ref().init;
+    CELER_ASSERT(host_primaries.size() + init.scalars.num_initializers
+                 <= init.initializers.size());
 
     // Resizing the initializers is a non-const operation, but the only one.
-    data.resize(data.size() + host_primaries.size());
+    init.scalars.num_initializers += host_primaries.size();
 
     // Allocate memory and copy primaries
     Collection<Primary, Ownership::value, M> primaries;
@@ -71,26 +73,26 @@ template<MemSpace M>
 inline void
 initialize_tracks(CoreParams const& core_params, CoreState<M>& core_state)
 {
-    auto& data = core_state.ref().init;
+    auto& scalars = core_state.ref().init.scalars;
 
     // The number of new tracks to initialize is the smaller of the number of
     // empty slots in the track vector and the number of track initializers
     size_type num_tracks
-        = std::min(data.vacancies.size(), data.initializers.size());
+        = std::min(scalars.num_vacancies, scalars.num_initializers);
     if (num_tracks > 0)
     {
         // Launch a kernel to initialize tracks on device
         auto num_vacancies
-            = min(data.vacancies.size(), data.initializers.size());
+            = min(scalars.num_vacancies, scalars.num_initializers);
         generated::init_tracks(
             core_params.ref<M>(), core_state.ref(), num_vacancies);
         // Resizing initializers/vacancies is a non-const operation
-        data.initializers.resize(data.initializers.size() - num_tracks);
-        data.vacancies.resize(data.vacancies.size() - num_tracks);
+        scalars.num_initializers = scalars.num_initializers - num_tracks;
+        scalars.num_vacancies = scalars.num_vacancies - num_tracks;
     }
 
-    // Store number of active tracks (a non-const operation)
-    data.num_active = core_state.size() - data.vacancies.size();
+    // Store number of active tracks at the start of the loop
+    scalars.num_active = core_state.size() - scalars.num_vacancies;
 }
 
 //---------------------------------------------------------------------------//
@@ -154,10 +156,7 @@ template<MemSpace M>
 inline void
 extend_from_secondaries(CoreParams const& core_params, CoreState<M>& core_state)
 {
-    TrackInitStateData<Ownership::reference, M>& data = core_state.ref().init;
-
-    // Resize the vector of vacancies to be equal to the number of tracks
-    data.vacancies.resize(core_state.size());
+    TrackInitStateData<Ownership::reference, M>& init = core_state.ref().init;
 
     // Launch a kernel to identify which track slots are still alive and count
     // the number of surviving secondaries per track
@@ -165,29 +164,28 @@ extend_from_secondaries(CoreParams const& core_params, CoreState<M>& core_state)
 
     // Remove all elements in the vacancy vector that were flagged as active
     // tracks, leaving the (sorted) indices of the empty slots
-    size_type num_vac = detail::remove_if_alive<M>(data.vacancies.data());
-    data.vacancies.resize(num_vac);
+    init.scalars.num_vacancies = detail::remove_if_alive(init.vacancies);
 
     // The exclusive prefix sum of the number of secondaries produced by each
     // track is used to get the start index in the vector of track initializers
     // for each thread. Starting at that index, each thread creates track
     // initializers from all surviving secondaries produced in its
     // interaction.
-    data.num_secondaries = detail::exclusive_scan_counts<M>(
-        data.secondary_counts[AllItems<size_type, M>{}]);
+    init.scalars.num_secondaries
+        = detail::exclusive_scan_counts(init.secondary_counts);
 
     // TODO: if we don't have space for all the secondaries, we will need to
     // buffer the current track initializers to create room
-    CELER_VALIDATE(data.num_secondaries + data.initializers.size()
-                       <= data.initializers.capacity(),
-                   << "insufficient capacity (" << data.initializers.capacity()
+    init.scalars.num_initializers += init.scalars.num_secondaries;
+    CELER_VALIDATE(init.scalars.num_initializers <= init.initializers.size(),
+                   << "insufficient capacity (" << init.initializers.size()
                    << ") for track initializers (created "
-                   << data.num_secondaries
+                   << init.scalars.num_secondaries
                    << " new secondaries for a total capacity requirement of "
-                   << data.num_secondaries + data.initializers.size() << ")");
+                   << init.scalars.num_initializers << ")");
 
     // Launch a kernel to create track initializers from secondaries
-    data.initializers.resize(data.initializers.size() + data.num_secondaries);
+    init.scalars.num_alive = core_state.size() - init.scalars.num_vacancies;
     generated::process_secondaries(core_params.ref<M>(), core_state.ref());
 }
 

--- a/src/celeritas/track/detail/InitTracksLauncher.hh
+++ b/src/celeritas/track/detail/InitTracksLauncher.hh
@@ -81,12 +81,12 @@ CELER_FUNCTION void InitTracksLauncher<M>::operator()(ThreadId tid) const
     // parent they can copy the geometry state from.
     auto const& data = states_.init;
     ItemId<TrackInitializer> idx{
-        fill_before_index(data.scalars.num_initializers, tid)};
+        index_before(data.scalars.num_initializers, tid)};
     TrackInitializer const& init = data.initializers[idx];
 
     // Thread ID of vacant track where the new track will be initialized
     TrackSlotId vacancy = [&] {
-        TrackSlotId idx{fill_before_index(data.scalars.num_vacancies, tid)};
+        TrackSlotId idx{index_before(data.scalars.num_vacancies, tid)};
         return data.vacancies[idx];
     }();
 
@@ -111,7 +111,7 @@ CELER_FUNCTION void InitTracksLauncher<M>::operator()(ThreadId tid) const
             // Copy the geometry state from the parent for improved
             // performance
             TrackSlotId parent_id = data.parents[TrackSlotId{
-                fill_before_index(data.parents.size(), tid)}];
+                index_before(data.parents.size(), tid)}];
             GeoTrackView parent(params_.geometry, states_.geometry, parent_id);
             geo = GeoTrackView::DetailedInitializer{parent, init.geo.dir};
         }

--- a/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
@@ -69,8 +69,8 @@ CELER_FUNCTION void ProcessPrimariesLauncher<M>::operator()(ThreadId tid) const
     CELER_ASSERT(primaries_.size()
                  <= data_.scalars.num_initializers + tid.get());
 
-    ItemId<TrackInitializer> idx{fill_after_index(
-        data_.scalars.num_initializers - primaries_.size(), tid)};
+    ItemId<TrackInitializer> idx{
+        index_after(data_.scalars.num_initializers - primaries_.size(), tid)};
     TrackInitializer& ti = data_.initializers[idx];
     Primary const& primary = primaries_[tid.unchecked_get()];
 

--- a/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessPrimariesLauncher.hh
@@ -19,6 +19,8 @@
 #include "celeritas/track/SimData.hh"
 #include "celeritas/track/TrackInitData.hh"
 
+#include "Utils.hh"
+
 namespace celeritas
 {
 namespace detail
@@ -63,11 +65,14 @@ class ProcessPrimariesLauncher
 template<MemSpace M>
 CELER_FUNCTION void ProcessPrimariesLauncher<M>::operator()(ThreadId tid) const
 {
-    Primary const& primary = primaries_[tid.get()];
+    CELER_EXPECT(tid < primaries_.size());
+    CELER_ASSERT(primaries_.size()
+                 <= data_.scalars.num_initializers + tid.get());
 
-    CELER_ASSERT(primaries_.size() <= data_.initializers.size() + tid.get());
-    TrackInitializer& ti = data_.initializers[data_.initializers.size()
-                                              - primaries_.size() + tid.get()];
+    ItemId<TrackInitializer> idx{fill_after_index(
+        data_.scalars.num_initializers - primaries_.size(), tid)};
+    TrackInitializer& ti = data_.initializers[idx];
+    Primary const& primary = primaries_[tid.unchecked_get()];
 
     // Construct a track initializer from a primary particle
     ti.sim.track_id = primary.track_id;

--- a/src/celeritas/track/detail/ProcessSecondariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessSecondariesLauncher.hh
@@ -89,8 +89,9 @@ ProcessSecondariesLauncher<M>::operator()(TrackSlotId tid) const
 
     // Offset in the vector of track initializers
     auto const& data = states_.init;
-    CELER_ASSERT(data.secondary_counts[tid] <= data.num_secondaries);
-    size_type offset = data.num_secondaries - data.secondary_counts[tid];
+    CELER_ASSERT(data.secondary_counts[tid] <= data.scalars.num_secondaries);
+    size_type offset = data.scalars.num_secondaries
+                       - data.secondary_counts[tid];
 
     // A new track was initialized from a secondary in the parent's track slot
     bool initialized = false;
@@ -158,8 +159,11 @@ ProcessSecondariesLauncher<M>::operator()(TrackSlotId tid) const
             else
             {
                 // Store the track initializer
-                CELER_ASSERT(offset > 0 && offset <= data.initializers.size());
-                data.initializers[data.initializers.size() - offset] = ti;
+                CELER_ASSERT(offset > 0
+                             && offset <= data.scalars.num_initializers);
+                data.initializers[ItemId<TrackInitializer>{
+                    data.scalars.num_initializers - offset}]
+                    = ti;
 
                 // Store the thread ID of the secondary's parent if the
                 // secondary could be initialized in the next step

--- a/src/celeritas/track/detail/TrackInitAlgorithms.cc
+++ b/src/celeritas/track/detail/TrackInitAlgorithms.cc
@@ -43,9 +43,6 @@ size_type remove_if_alive(
  *
  * The input size is one greater than the number of track slots so that the
  * final element will be the total accumulated value.
- *
- * \todo We should probably replace this with inclusive_scan so that the sizes
- * can be consistent?
  */
 size_type exclusive_scan_counts(
     StateCollection<size_type, Ownership::reference, MemSpace::host> const& counts)

--- a/src/celeritas/track/detail/TrackInitAlgorithms.cc
+++ b/src/celeritas/track/detail/TrackInitAlgorithms.cc
@@ -8,6 +8,7 @@
 #include "TrackInitAlgorithms.hh"
 
 #include <algorithm>
+#include <numeric>
 
 #include "Utils.hh"
 
@@ -19,17 +20,17 @@ namespace detail
 /*!
  * Remove all elements in the vacancy vector that were flagged as active
  * tracks.
+ *
+ * \return New size of the vacancy vector
  */
-template<>
-size_type remove_if_alive<MemSpace::host>(Span<TrackSlotId> vacancies)
+size_type remove_if_alive(
+    StateCollection<TrackSlotId, Ownership::reference, MemSpace::host> const&
+        vacancies)
 {
-    auto end = std::remove_if(vacancies.data(),
-                              vacancies.data() + vacancies.size(),
-                              IsEqual{occupied()});
-
-    // New size of the vacancy vector
-    size_type result = end - vacancies.data();
-    return result;
+    auto* start = static_cast<TrackSlotId*>(vacancies.data());
+    auto* stop
+        = std::remove_if(start, start + vacancies.size(), IsEqual{occupied()});
+    return stop - start;
 }
 
 //---------------------------------------------------------------------------//
@@ -40,20 +41,34 @@ size_type remove_if_alive<MemSpace::host>(Span<TrackSlotId> vacancies)
  * array elements, i.e., \f$ y_i = \sum_{j=0}^{i-1} x_j \f$,
  * where \f$ y_0 = 0 \f$, and stores the result in the input array.
  *
- * The return value is the sum of all elements in the input array.
+ * The input size is one greater than the number of track slots so that the
+ * final element will be the total accumulated value.
+ *
+ * \todo We should probably replace this with inclusive_scan so that the sizes
+ * can be consistent?
  */
-template<>
-size_type exclusive_scan_counts<MemSpace::host>(Span<size_type> counts)
+size_type exclusive_scan_counts(
+    StateCollection<size_type, Ownership::reference, MemSpace::host> const& counts)
 {
-    // TODO: Use std::exclusive_scan when C++17 is adopted
+    CELER_EXPECT(!counts.empty());
+    auto* data = static_cast<size_type*>(counts.data());
+#ifdef __cpp_lib_parallel_algorithm
+    auto* stop
+        = std::exclusive_scan(data, data + counts.size(), data, size_type{0});
+#else
+    // Standard library shipped with GCC 8.5 does not include exclusive_scan
+    // (I guess it's *too* exclusive)
     size_type acc = 0;
-    for (auto& count_i : counts)
+    auto* const stop = data + counts.size();
+    for (; data != stop; ++data)
     {
-        size_type current = count_i;
-        count_i = acc;
+        size_type current = *data;
+        *data = acc;
         acc += current;
     }
-    return acc;
+#endif
+    // Return the final value
+    return *(stop - 1);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/detail/TrackInitAlgorithms.cu
+++ b/src/celeritas/track/detail/TrackInitAlgorithms.cu
@@ -13,6 +13,7 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/data/Copier.hh"
+#include "corecel/data/ObserverPtr.device.hh"
 
 #include "Utils.hh"
 
@@ -25,19 +26,17 @@ namespace detail
  * Remove all elements in the vacancy vector that were flagged as active
  * tracks.
  */
-template<>
-size_type remove_if_alive<MemSpace::device>(Span<TrackSlotId> vacancies)
+size_type remove_if_alive(
+    StateCollection<TrackSlotId, Ownership::reference, MemSpace::device> const&
+        vacancies)
 {
-    thrust::device_ptr<TrackSlotId> end = thrust::remove_if(
-        thrust::device_pointer_cast(vacancies.data()),
-        thrust::device_pointer_cast(vacancies.data() + vacancies.size()),
-        IsEqual{occupied()});
-
+    auto start = device_pointer_cast(vacancies.data());
+    auto end = thrust::remove_if(
+        start, start + vacancies.size(), IsEqual{occupied()});
     CELER_DEVICE_CHECK_ERROR();
 
     // New size of the vacancy vector
-    size_type result = thrust::raw_pointer_cast(end) - vacancies.data();
-    return result;
+    return end - start;
 }
 
 //---------------------------------------------------------------------------//
@@ -50,26 +49,18 @@ size_type remove_if_alive<MemSpace::device>(Span<TrackSlotId> vacancies)
  *
  * The return value is the sum of all elements in the input array.
  */
-template<>
-size_type exclusive_scan_counts<MemSpace::device>(Span<size_type> counts)
+size_type exclusive_scan_counts(
+    StateCollection<size_type, Ownership::reference, MemSpace::device> const&
+        counts)
 {
-    // Copy the last element to the host
-    size_type temp{};
-    Copier<size_type, MemSpace::host> copy_to_temp{{&temp, 1}};
-    copy_to_temp(MemSpace::device, {counts.data() + counts.size() - 1, 1});
-    size_type const last_element = temp;
-
-    thrust::exclusive_scan(
-        thrust::device_pointer_cast(counts.data()),
-        thrust::device_pointer_cast(counts.data() + counts.size()),
-        thrust::device_pointer_cast(counts.data()),
-        size_type(0));
+    // Exclusive scan:
+    auto data = device_pointer_cast(counts.data());
+    auto stop = thrust::exclusive_scan(
+        data, data + counts.size(), data, size_type(0));
     CELER_DEVICE_CHECK_ERROR();
 
-    // Copy the last element (the sum of all elements but the last) to the host
-    copy_to_temp(MemSpace::device, {counts.data() + counts.size() - 1, 1});
-
-    return temp + last_element;
+    // Copy the last element (accumulated total) back to host
+    return *(stop - 1);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/detail/TrackInitAlgorithms.hh
+++ b/src/celeritas/track/detail/TrackInitAlgorithms.hh
@@ -10,7 +10,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
-#include "corecel/cont/Span.hh"
+#include "corecel/data/Collection.hh"
 #include "corecel/sys/ThreadId.hh"
 
 namespace celeritas
@@ -19,36 +19,30 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 // Remove all elements in the vacancy vector that were flagged as alive
-template<MemSpace M>
-size_type remove_if_alive(Span<TrackSlotId> vacancies);
-
-template<>
-size_type remove_if_alive<MemSpace::host>(Span<TrackSlotId> vacancies);
-template<>
-size_type remove_if_alive<MemSpace::device>(Span<TrackSlotId> vacancies);
+size_type remove_if_alive(
+    StateCollection<TrackSlotId, Ownership::reference, MemSpace::host> const&);
+size_type remove_if_alive(
+    StateCollection<TrackSlotId, Ownership::reference, MemSpace::device> const&);
 
 //---------------------------------------------------------------------------//
 // Calculate the exclusive prefix sum of the number of surviving secondaries
-template<MemSpace M>
-size_type exclusive_scan_counts(Span<size_type> counts);
-
-template<>
-size_type exclusive_scan_counts<MemSpace::host>(Span<size_type> counts);
-template<>
-size_type exclusive_scan_counts<MemSpace::device>(Span<size_type> counts);
+size_type exclusive_scan_counts(
+    StateCollection<size_type, Ownership::reference, MemSpace::host> const&);
+size_type exclusive_scan_counts(
+    StateCollection<size_type, Ownership::reference, MemSpace::device> const&);
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 #if !CELER_USE_DEVICE
-template<>
-inline size_type remove_if_alive<MemSpace::device>(Span<TrackSlotId>)
+inline size_type remove_if_alive(
+    StateCollection<TrackSlotId, Ownership::reference, MemSpace::device> const&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }
 
-template<>
-inline size_type exclusive_scan_counts<MemSpace::device>(Span<size_type>)
+inline size_type exclusive_scan_counts(
+    StateCollection<size_type, Ownership::reference, MemSpace::device> const&)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }

--- a/src/celeritas/track/detail/Utils.hh
+++ b/src/celeritas/track/detail/Utils.hh
@@ -33,9 +33,8 @@ CELER_CONSTEXPR_FUNCTION TrackSlotId occupied()
 }
 
 //---------------------------------------------------------------------------//
-//! Get an initializer index a certain number of threads from the end
-CELER_FORCEINLINE_FUNCTION size_type fill_before_index(size_type size,
-                                                       ThreadId tid)
+//! Get an initializer index where thread 0 has the last valid element
+CELER_FORCEINLINE_FUNCTION size_type index_before(size_type size, ThreadId tid)
 {
     CELER_EXPECT(tid.get() + 1 <= size);
     return size - tid.unchecked_get() - 1;
@@ -43,8 +42,7 @@ CELER_FORCEINLINE_FUNCTION size_type fill_before_index(size_type size,
 
 //---------------------------------------------------------------------------//
 //! Get an initializer index a certain number of threads past the end
-CELER_FORCEINLINE_FUNCTION size_type fill_after_index(size_type size,
-                                                      ThreadId tid)
+CELER_FORCEINLINE_FUNCTION size_type index_after(size_type size, ThreadId tid)
 {
     CELER_EXPECT(tid);
     return size + tid.unchecked_get();

--- a/src/celeritas/track/detail/Utils.hh
+++ b/src/celeritas/track/detail/Utils.hh
@@ -10,7 +10,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/OpaqueId.hh"
 #include "corecel/Types.hh"
-#include "corecel/math/NumericLimits.hh"
+#include "corecel/data/Collection.hh"
 #include "corecel/sys/ThreadId.hh"
 
 namespace celeritas
@@ -33,11 +33,21 @@ CELER_CONSTEXPR_FUNCTION TrackSlotId occupied()
 }
 
 //---------------------------------------------------------------------------//
-//! Get a track slot ID a certain number of threads from the end
-CELER_FORCEINLINE_FUNCTION size_type from_back(size_type size, ThreadId tid)
+//! Get an initializer index a certain number of threads from the end
+CELER_FORCEINLINE_FUNCTION size_type fill_before_index(size_type size,
+                                                       ThreadId tid)
 {
     CELER_EXPECT(tid.get() + 1 <= size);
-    return size - tid.get() - 1;
+    return size - tid.unchecked_get() - 1;
+}
+
+//---------------------------------------------------------------------------//
+//! Get an initializer index a certain number of threads past the end
+CELER_FORCEINLINE_FUNCTION size_type fill_after_index(size_type size,
+                                                      ThreadId tid)
+{
+    CELER_EXPECT(tid);
+    return size + tid.unchecked_get();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/ActionDiagnostic.cc
+++ b/src/celeritas/user/ActionDiagnostic.cc
@@ -15,6 +15,7 @@
 #include "celeritas/global/ActionRegistry.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
+#include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "celeritas/phys/ParticleParams.hh"
 
@@ -26,7 +27,7 @@
 #    include "corecel/io/LabelIO.json.hh"
 #endif
 
-    namespace celeritas
+namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
@@ -68,15 +69,21 @@ void ActionDiagnostic::execute(CoreParams const& params,
     }
     MultiExceptionHandler capture_exception;
     auto launch = make_active_track_launcher(
-        params.ref<MemSpace::native>(),
-        state.ref(),
+        *params.ptr<MemSpace::native>(),
+        *state.ptr(),
         detail::tally_action,
         store_.params<MemSpace::host>(),
         store_.state<MemSpace::host>(state.stream_id(), this->state_size()));
 #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < state.size(); ++i)
     {
-        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE_CONTEXT(
+            launch(ThreadId{i}),
+            capture_exception,
+            KernelContextException(params.ref<MemSpace::host>(),
+                                   state.ref(),
+                                   ThreadId{i},
+                                   this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/user/ActionDiagnostic.cu
+++ b/src/celeritas/user/ActionDiagnostic.cu
@@ -23,13 +23,13 @@ namespace
 {
 //---------------------------------------------------------------------------//
 __global__ void
-tally_action_kernel(DeviceCRef<CoreParamsData> const params,
-                    DeviceRef<CoreStateData> const state,
+tally_action_kernel(CRefPtr<CoreParamsData, MemSpace::device> const params,
+                    RefPtr<CoreStateData, MemSpace::device> const state,
                     DeviceCRef<ParticleTallyParamsData> ad_params,
                     DeviceRef<ParticleTallyStateData> ad_state)
 {
     auto launch = make_active_track_launcher(
-        params, state, detail::tally_action, ad_params, ad_state);
+        *params, *state, detail::tally_action, ad_params, ad_state);
     launch(KernelParamCalculator::thread_id());
 }
 
@@ -51,8 +51,8 @@ void ActionDiagnostic::execute(CoreParams const& params,
         tally_action,
         celeritas::device().default_block_size(),
         state.size(),
-        params.ref<MemSpace::native>(),
-        state.ref(),
+        params.ptr<MemSpace::native>(),
+        state.ptr(),
         store_.params<MemSpace::device>(),
         store_.state<MemSpace::device>(state.stream_id(), this->state_size()));
 }

--- a/src/celeritas/user/ActionDiagnostic.hh
+++ b/src/celeritas/user/ActionDiagnostic.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <vector>
 
 #include "corecel/data/StreamStore.hh"
@@ -52,9 +53,9 @@ class ActionDiagnostic final : public ExplicitActionInterface,
 
     //!@{
     //! \name ExplicitAction interface
-    // Execute action with host data
+    // Launch kernel with host data
     void execute(CoreParams const&, CoreStateHost&) const final;
-    // Execute action with device data
+    // Launch kernel with device data
     void execute(CoreParams const&, CoreStateDevice&) const final;
     //! ID of the action
     ActionId action_id() const final { return id_; }

--- a/src/celeritas/user/SimpleCalo.hh
+++ b/src/celeritas/user/SimpleCalo.hh
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "corecel/cont/Span.hh"
+#include "corecel/data/Collection.hh"
 #include "corecel/data/StreamStore.hh"
 #include "corecel/io/OutputInterface.hh"
 #include "celeritas/Quantities.hh"

--- a/src/celeritas/user/StepDiagnostic.cc
+++ b/src/celeritas/user/StepDiagnostic.cc
@@ -14,6 +14,7 @@
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
+#include "celeritas/global/KernelContextException.hh"
 #include "celeritas/global/TrackLauncher.hh"
 #include "celeritas/phys/ParticleParams.hh"
 
@@ -25,7 +26,7 @@
 #    include "corecel/io/LabelIO.json.hh"
 #endif
 
-    namespace celeritas
+namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
@@ -64,15 +65,21 @@ void StepDiagnostic::execute(CoreParams const& params,
 {
     MultiExceptionHandler capture_exception;
     auto launch = make_active_track_launcher(
-        params.ref<MemSpace::native>(),
-        state.ref(),
+        *params.ptr<MemSpace::native>(),
+        *state.ptr(),
         detail::tally_steps,
         store_.params<MemSpace::host>(),
         store_.state<MemSpace::host>(state.stream_id(), this->state_size()));
 #pragma omp parallel for
     for (ThreadId::size_type i = 0; i < state.size(); ++i)
     {
-        CELER_TRY_HANDLE(launch(ThreadId{i}), capture_exception);
+        CELER_TRY_HANDLE_CONTEXT(
+            launch(ThreadId{i}),
+            capture_exception,
+            KernelContextException(params.ref<MemSpace::host>(),
+                                   state.ref(),
+                                   ThreadId{i},
+                                   this->label()));
     }
     log_and_rethrow(std::move(capture_exception));
 }

--- a/src/celeritas/user/StepDiagnostic.cu
+++ b/src/celeritas/user/StepDiagnostic.cu
@@ -23,13 +23,13 @@ namespace
 {
 //---------------------------------------------------------------------------//
 __global__ void
-tally_steps_kernel(DeviceCRef<CoreParamsData> const params,
-                   DeviceRef<CoreStateData> const state,
+tally_steps_kernel(CRefPtr<CoreParamsData, MemSpace::device> const params,
+                   RefPtr<CoreStateData, MemSpace::device> const state,
                    DeviceCRef<ParticleTallyParamsData> sd_params,
                    DeviceRef<ParticleTallyStateData> sd_state)
 {
     auto launch = make_active_track_launcher(
-        params, state, detail::tally_steps, sd_params, sd_state);
+        *params, *state, detail::tally_steps, sd_params, sd_state);
     launch(KernelParamCalculator::thread_id());
 }
 
@@ -47,8 +47,8 @@ void StepDiagnostic::execute(CoreParams const& params,
         tally_steps,
         celeritas::device().default_block_size(),
         state.size(),
-        params.ref<MemSpace::native>(),
-        state.ref(),
+        params.ptr<MemSpace::native>(),
+        state.ptr(),
         store_.params<MemSpace::device>(),
         store_.state<MemSpace::device>(state.stream_id(), this->state_size()));
 }

--- a/src/celeritas/user/StepDiagnostic.hh
+++ b/src/celeritas/user/StepDiagnostic.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "corecel/data/StreamStore.hh"
@@ -47,9 +48,9 @@ class StepDiagnostic final : public ExplicitActionInterface,
 
     //!@{
     //! \name ExplicitAction interface
-    // Execute action with host data
+    // Launch kernel with host data
     void execute(CoreParams const&, CoreStateHost&) const final;
-    // Execute action with device data
+    // Launch kernel with device data
     void execute(CoreParams const&, CoreStateDevice&) const final;
     //! ID of the action
     ActionId action_id() const final { return id_; }

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -86,6 +86,16 @@ using NativeCRef = P<Ownership::const_reference, MemSpace::native>;
 template<template<Ownership, MemSpace> class S>
 using NativeRef = S<Ownership::reference, MemSpace::native>;
 
+template<class T, MemSpace M>
+class ObserverPtr;
+
+//! Pointer to same-memory *const* collection group
+template<template<Ownership, MemSpace> class P, MemSpace M>
+using CRefPtr = ObserverPtr<P<Ownership::const_reference, M> const, M>;
+//! Pointer to same-memory *mutable* collection group
+template<template<Ownership, MemSpace> class S, MemSpace M>
+using RefPtr = ObserverPtr<S<Ownership::reference, M>, M>;
+
 //!@}
 #endif
 

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -13,6 +13,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/sys/ThreadId.hh"
 
+#include "ObserverPtr.hh"
 #include "detail/CollectionImpl.hh"
 
 namespace celeritas
@@ -136,8 +137,8 @@ using ItemRange = Range<OpaqueId<T, Size>>;
 template<class T1, class T2>
 class ItemMap
 {
-    static_assert(detail::IsOpaqueId<T1>::value, "T1 isn't opaque ID");
-    static_assert(detail::IsOpaqueId<T2>::value, "T2 isn't opaque ID");
+    static_assert(detail::IsOpaqueId<T1>::value, "T1 is not OpaqueID");
+    static_assert(detail::IsOpaqueId<T2>::value, "T2 is not OpaqueID");
 
   public:
     //!@{
@@ -163,7 +164,7 @@ class ItemMap
         return range_[id.unchecked_get()];
     }
 
-    //! Wheter the underlying Range<T2> is empty
+    //! Whether the underlying Range<T2> is empty
     CELER_FORCEINLINE_FUNCTION bool empty() const { return range_.empty(); }
 
     //! Size of the underlying Range<T2>
@@ -231,18 +232,20 @@ class Collection
                   "Collection element is not trivially destructible");
 #endif
 
-    using CollectionTraitsT = detail::CollectionTraits<T, W>;
+    using const_value_type =
+        typename detail::CollectionTraits<T, W>::const_type;
 
   public:
     //!@{
     //! \name Type aliases
-    using SpanT = typename CollectionTraitsT::SpanT;
-    using SpanConstT = typename CollectionTraitsT::SpanConstT;
-    using reference_type = typename CollectionTraitsT::reference_type;
-    using const_reference_type =
-        typename CollectionTraitsT::const_reference_type;
+    using value_type = typename detail::CollectionTraits<T, W>::type;
+    using SpanT = Span<value_type>;
+    using SpanConstT = Span<const_value_type>;
+    using pointer = ObserverPtr<value_type, M>;
+    using const_pointer = ObserverPtr<const_value_type, M>;
+    using reference_type = value_type&;
+    using const_reference_type = const_value_type&;
     using size_type = typename I::size_type;
-    using value_type = T;
     using ItemIdT = I;
     using ItemRangeT = Range<ItemIdT>;
     using AllItemsT = AllItems<T, M>;
@@ -303,6 +306,14 @@ class Collection
     CELER_FORCEINLINE_FUNCTION bool empty() const
     {
         return this->storage().empty();
+    }
+    CELER_FORCEINLINE_FUNCTION pointer data()
+    {
+        return pointer{this->storage().data()};
+    }
+    CELER_FORCEINLINE_FUNCTION const_pointer data() const
+    {
+        return const_pointer{this->storage().data()};
     }
     //!@}
 
@@ -424,7 +435,7 @@ CELER_FUNCTION auto Collection<T, W, M, I>::operator[](ItemRangeT ps) -> SpanT
 {
     CELER_EXPECT(*ps.begin() <= *ps.end());
     CELER_EXPECT(*ps.end() < this->size() + 1);
-    typename CollectionTraitsT::pointer data = this->storage().data();
+    auto* data = this->storage().data();
     return {data + ps.begin()->unchecked_get(),
             data + ps.end()->unchecked_get()};
 }
@@ -439,7 +450,7 @@ CELER_FUNCTION auto Collection<T, W, M, I>::operator[](ItemRangeT ps) const
 {
     CELER_EXPECT(*ps.begin() <= *ps.end());
     CELER_EXPECT(*ps.end() < this->size() + 1);
-    typename CollectionTraitsT::const_pointer data = this->storage().data();
+    auto* data = this->storage().data();
     return {data + ps.begin()->unchecked_get(),
             data + ps.end()->unchecked_get()};
 }

--- a/src/corecel/data/detail/CollectionImpl.hh
+++ b/src/corecel/data/detail/CollectionImpl.hh
@@ -7,7 +7,11 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <vector>
+#ifndef CELER_DEVICE_COMPILE
+#    include <vector>
+
+#    include "../DeviceVector.hh"
+#endif
 
 #include "corecel/Assert.hh"
 #include "corecel/OpaqueId.hh"
@@ -15,7 +19,6 @@
 #include "corecel/cont/Span.hh"
 
 #include "../Copier.hh"
-#include "../DeviceVector.hh"
 #include "DisabledStorage.hh"
 
 namespace celeritas
@@ -26,36 +29,24 @@ namespace detail
 template<class T, Ownership W>
 struct CollectionTraits
 {
-    using SpanT = Span<T>;
-    using SpanConstT = Span<T const>;
-    using pointer = T*;
-    using const_pointer = T const*;
-    using reference_type = T&;
-    using const_reference_type = T const&;
+    using type = T;
+    using const_type = T const;
 };
 
 //---------------------------------------------------------------------------//
 template<class T>
 struct CollectionTraits<T, Ownership::reference>
 {
-    using SpanT = Span<T>;
-    using SpanConstT = Span<T>;
-    using pointer = T*;
-    using const_pointer = T*;
-    using reference_type = T&;
-    using const_reference_type = T&;
+    using type = T;
+    using const_type = T;
 };
 
 //---------------------------------------------------------------------------//
 template<class T>
 struct CollectionTraits<T, Ownership::const_reference>
 {
-    using SpanT = Span<T const>;
-    using SpanConstT = Span<T const>;
-    using pointer = T const*;
-    using const_pointer = T const*;
-    using reference_type = T const&;
-    using const_reference_type = T const&;
+    using type = T const;
+    using const_type = T const;
 };
 
 //---------------------------------------------------------------------------//
@@ -63,7 +54,7 @@ struct CollectionTraits<T, Ownership::const_reference>
 template<class T, Ownership W, MemSpace M>
 struct CollectionStorage
 {
-    using type = typename CollectionTraits<T, W>::SpanT;
+    using type = Span<typename CollectionTraits<T, W>::type>;
     type data;
 };
 


### PR DESCRIPTION
For CUDA kernels, this now uses the *on-device pointers* to host and state data, rather than passing the pointers themselves. The first two refactoring commits pass `Ptr` instead of `Ref` (i.e. a single pointer rather than a copy of the whole `struct` of pointers) to the action kernels and along-step kernels. The occupancy decreases:
```diff
    "occupancy": {
-    "along_step_apply_mean_eloss": 0.625,
+    "along_step_apply_mean_eloss": 0.5,
-    "discrete_select": 0.5,
+    "discrete_select": 0.375,
-    "pre_step": 0.5,
+    "pre_step": 0.375,
    },
```
but there's no observable performance difference.

The final commit (passing pointers to the `interact` function) **changes the answers** for `cms2018+field+msc-vecgeom-gpu`. There's no obvious explanation why this would happen. I added an always-on assertion to the `trackinit` (see #730) to see if the existing code is somehow breaking, but it did not fire... so I can't say whether the old result or the new result (or neither) is correct.