### PR TITLE
Use weak_ptr to fix ActionDiagnostic shared cycle

### DIFF
--- a/src/celeritas/user/ActionDiagnostic.cc
+++ b/src/celeritas/user/ActionDiagnostic.cc
@@ -189,7 +189,7 @@ void ActionDiagnostic::clear()
  * Build the storage for diagnostic parameters and stream-dependent states.
  *
  * This must be done lazily (after construction!) because the action diagnostic
- * may be created after other actions.
+ * will be created *before* all actions are defined in the \c ActionRegistry.
  */
 void ActionDiagnostic::build_stream_store() const
 {

--- a/src/celeritas/user/ActionDiagnostic.hh
+++ b/src/celeritas/user/ActionDiagnostic.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <vector>
 
 #include "corecel/data/StreamStore.hh"
@@ -33,7 +34,7 @@ class ActionDiagnostic final : public ExplicitActionInterface,
   public:
     //!@{
     //! \name Type aliases
-    using SPConstActionRegistry = std::shared_ptr<ActionRegistry const>;
+    using WPConstActionRegistry = std::weak_ptr<ActionRegistry const>;
     using SPConstParticle = std::shared_ptr<ParticleParams const>;
     using MapStringCount = std::map<std::string, size_type>;
     using VecCount = std::vector<size_type>;
@@ -43,7 +44,7 @@ class ActionDiagnostic final : public ExplicitActionInterface,
   public:
     //! Construct with action registry and particle data
     ActionDiagnostic(ActionId id,
-                     SPConstActionRegistry action_reg,
+                     WPConstActionRegistry action_reg,
                      SPConstParticle particle,
                      size_type num_streams);
 
@@ -90,7 +91,7 @@ class ActionDiagnostic final : public ExplicitActionInterface,
     using StoreT = StreamStore<ParticleTallyParamsData, ParticleTallyStateData>;
 
     ActionId id_;
-    SPConstActionRegistry action_reg_;
+    WPConstActionRegistry action_reg_;
     SPConstParticle particle_;
     size_type num_streams_;
     mutable StoreT store_;

--- a/src/celeritas/user/StepDiagnostic.hh
+++ b/src/celeritas/user/StepDiagnostic.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "corecel/data/StreamStore.hh"


### PR DESCRIPTION
Fixes test errors in  #744 due to shared_ptr cycle introduced in #740 .