### PR TITLE
Fail consistently when trying to track in unsupported volumes

### DIFF
--- a/src/celeritas/ext/detail/GeantGeoConverter.cc
+++ b/src/celeritas/ext/detail/GeantGeoConverter.cc
@@ -295,7 +295,9 @@ LogicalVolume* GeantGeoConverter::convert(G4LogicalVolume const* g4_logvol)
 
     // can be used to make a cross check for dimensions and other properties
     // make a cross check using cubic volume property
-    if (!dynamic_cast<UnplacedScaledShape const*>(vg_logvol->GetUnplacedVolume())
+    if (!dynamic_cast<GenericSolidBase const*>(vg_logvol->GetUnplacedVolume())
+        && !dynamic_cast<UnplacedScaledShape const*>(
+            vg_logvol->GetUnplacedVolume())
         && !dynamic_cast<G4BooleanSolid const*>(g4_logvol->GetSolid()))
     {
         auto vg_cap = vg_logvol->GetUnplacedVolume()->Capacity();
@@ -304,7 +306,7 @@ LogicalVolume* GeantGeoConverter::convert(G4LogicalVolume const* g4_logvol)
 
         if (CELER_UNLIKELY(!SoftEqual{0.01}(vg_cap, g4_cap)))
         {
-            CELER_LOG(warning)
+            CELER_LOG(error)
                 << "Volume " << g4_logvol->GetName() << " (VecGeom volume ID "
                 << volid.get()
                 << ") conversion may have failed: VecGeom/G4 volume ratio is "
@@ -714,21 +716,20 @@ VUnplacedVolume* GeantGeoConverter::convert(G4VSolid const* shape)
     else if (auto refl = dynamic_cast<G4ReflectedSolid const*>(shape))
     {
         G4VSolid* underlyingSolid = refl->GetConstituentMovedSolid();
-        CELER_LOG(debug)
-            << " Reflected solid found: "
-            << " volume: " << refl->GetName()
-            << " type = " << refl->GetEntityType()
-            << "   -- underlying solid: " << underlyingSolid->GetName()
-            << " type = " << underlyingSolid->GetEntityType();
+        CELER_ASSERT(underlyingSolid);
+        CELER_LOG(error) << "Encountered unsupported reflected solid '"
+                         << refl->GetName() << "' (underlying "
+                         << underlyingSolid->GetEntityType() << " solid is '"
+                         << underlyingSolid->GetName() << "')";
         unplaced_volume = new GenericSolid<G4ReflectedSolid>(refl);
     }
 
     // New volumes should be implemented here...
     if (!unplaced_volume)
     {
-        CELER_LOG(error) << "Unsupported shape for G4 solid "
-                         << shape->GetName().c_str() << ", of type "
-                         << shape->GetEntityType().c_str();
+        CELER_LOG(error) << "Encountered nsupported shape for G4 solid '"
+                         << shape->GetName() << "' of type "
+                         << shape->GetEntityType();
         unplaced_volume = new GenericSolid<G4VSolid>(shape);
         CELER_LOG(debug) << " -- capacity = "
                          << unplaced_volume->Capacity() / ipow<3>(scale);

--- a/src/celeritas/ext/detail/GeantGeoConverter.cc
+++ b/src/celeritas/ext/detail/GeantGeoConverter.cc
@@ -275,6 +275,14 @@ LogicalVolume* GeantGeoConverter::convert(G4LogicalVolume const* g4_logvol)
 
     VUnplacedVolume const* unplaced;
     unplaced = this->convert(g4_logvol->GetSolid());
+    bool const is_unknown_solid
+        = dynamic_cast<GenericSolidBase const*>(unplaced);
+    if (is_unknown_solid)
+    {
+        CELER_LOG(info) << "Unsupported solid belongs to logical volume '"
+                        << g4_logvol->GetName() << "'@"
+                        << static_cast<void const*>(g4_logvol);
+    }
 
     // add 0x suffix, unless already provided from GDML through Geant4 parser
     static G4GDMLWriteStructure gdml_mangler;
@@ -298,7 +306,7 @@ LogicalVolume* GeantGeoConverter::convert(G4LogicalVolume const* g4_logvol)
     if (!dynamic_cast<GenericSolidBase const*>(vg_logvol->GetUnplacedVolume())
         && !dynamic_cast<UnplacedScaledShape const*>(
             vg_logvol->GetUnplacedVolume())
-        && !dynamic_cast<G4BooleanSolid const*>(g4_logvol->GetSolid()))
+        && !is_unknown_solid)
     {
         auto vg_cap = vg_logvol->GetUnplacedVolume()->Capacity();
         CELER_ASSERT(vg_cap > 0);
@@ -727,7 +735,7 @@ VUnplacedVolume* GeantGeoConverter::convert(G4VSolid const* shape)
     // New volumes should be implemented here...
     if (!unplaced_volume)
     {
-        CELER_LOG(error) << "Encountered nsupported shape for G4 solid '"
+        CELER_LOG(error) << "Encountered unsupported shape for G4 solid '"
                          << shape->GetName() << "' of type "
                          << shape->GetEntityType();
         unplaced_volume = new GenericSolid<G4VSolid>(shape);

--- a/src/celeritas/ext/detail/GeantGeoConverter.cc
+++ b/src/celeritas/ext/detail/GeantGeoConverter.cc
@@ -298,11 +298,18 @@ LogicalVolume* GeantGeoConverter::convert(G4LogicalVolume const* g4_logvol)
     if (!dynamic_cast<UnplacedScaledShape const*>(vg_logvol->GetUnplacedVolume())
         && !dynamic_cast<G4BooleanSolid const*>(g4_logvol->GetSolid()))
     {
-        auto v1 = vg_logvol->GetUnplacedVolume()->Capacity() / ipow<3>(scale);
-        auto v2 = g4_logvol->GetSolid()->GetCubicVolume();
+        auto vg_cap = vg_logvol->GetUnplacedVolume()->Capacity();
+        CELER_ASSERT(vg_cap > 0);
+        auto g4_cap = g4_logvol->GetSolid()->GetCubicVolume() * ipow<3>(scale);
 
-        CELER_ASSERT(v1 > 0.);
-        CELER_ASSERT(SoftEqual{0.01}(v1, v2));
+        if (CELER_UNLIKELY(!SoftEqual{0.01}(vg_cap, g4_cap)))
+        {
+            CELER_LOG(warning)
+                << "Volume " << g4_logvol->GetName() << " (VecGeom volume ID "
+                << volid.get()
+                << ") conversion may have failed: VecGeom/G4 volume ratio is "
+                << vg_cap / g4_cap;
+        }
     }
     return vg_logvol;
 }

--- a/src/celeritas/ext/detail/GenericPlacedVolume.hh
+++ b/src/celeritas/ext/detail/GenericPlacedVolume.hh
@@ -16,6 +16,8 @@
 #include <VecGeom/volumes/LogicalVolume.h>
 #include <VecGeom/volumes/PlacedVolume.h>
 
+#include "corecel/Assert.hh"
+
 namespace celeritas
 {
 namespace detail
@@ -79,13 +81,13 @@ class GenericPlacedVolume : public vecgeom::VPlacedVolume
 
     virtual void Contains(SOA3D<Precision> const&, bool* const) const override
     {
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
-    virtual bool
 
+    virtual bool
     Contains(Vector3D<Precision> const&, Vector3D<Precision>&) const override
     {
-        assert(false);
-        return false;
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
 
     virtual bool
@@ -170,8 +172,7 @@ class GenericPlacedVolume : public vecgeom::VPlacedVolume
                         Vector3D<Precision> const&,
                         Precision const /*step_max = kInfLength*/) const override
     {
-        assert(false);
-        return 0;
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
 
     virtual void DistanceToOut(SOA3D<Precision> const&,
@@ -179,6 +180,7 @@ class GenericPlacedVolume : public vecgeom::VPlacedVolume
                                Precision const* const,
                                Precision* const) const override
     {
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
 
     virtual void DistanceToOut(SOA3D<Precision> const&,
@@ -187,6 +189,7 @@ class GenericPlacedVolume : public vecgeom::VPlacedVolume
                                Precision* const,
                                int* const) const override
     {
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
 
     virtual Precision
@@ -198,6 +201,7 @@ class GenericPlacedVolume : public vecgeom::VPlacedVolume
     virtual void
     SafetyToOut(SOA3D<Precision> const&, Precision* const) const override
     {
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
 
     // define this interface in case we don't have the Scalar interface
@@ -206,12 +210,12 @@ class GenericPlacedVolume : public vecgeom::VPlacedVolume
                      Vector3D<Real_v> const&,
                      Real_v const /*step_max = kInfLength*/) const override
     {
-        return Real_v{0.};
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
 
     virtual Real_v SafetyToOutVec(Vector3D<Real_v> const&) const override
     {
-        return Real_v{0.};
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
     //!@}
 
@@ -223,7 +227,7 @@ class GenericPlacedVolume : public vecgeom::VPlacedVolume
 
     virtual VPlacedVolume const* ConvertToUnspecialized() const override
     {
-        return nullptr;
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
 
 #ifdef VECGEOM_ROOT
@@ -278,14 +282,14 @@ class GenericPlacedVolume : public vecgeom::VPlacedVolume
               DevicePtr<CudaTransformation3D> const,
               DevicePtr<CudaVPlacedVolume> const) const
     {
-        return {};
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
 
     DevicePtr<CudaVPlacedVolume>
     CopyToGpu(DevicePtr<CudaLogicalVolume> const,
               DevicePtr<CudaTransformation3D> const) const
     {
-        return {};
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
 
     void CopyManyToGpu(std::vector<VPlacedVolume const*> const&,
@@ -293,6 +297,7 @@ class GenericPlacedVolume : public vecgeom::VPlacedVolume
                        std::vector<DevicePtr<CudaTransformation3D>> const&,
                        std::vector<DevicePtr<CudaVPlacedVolume>> const&) const
     {
+        CELER_NOT_IMPLEMENTED("GenericPlacedVolume");
     }
     //!@}
 #endif  // VECGEOM_CUDA_INTERFACE

--- a/src/celeritas/ext/detail/GenericSolid.hh
+++ b/src/celeritas/ext/detail/GenericSolid.hh
@@ -16,6 +16,8 @@
 #include <VecGeom/volumes/PlacedVolume.h>
 #include <VecGeom/volumes/UnplacedVolume.h>
 
+#include "corecel/Assert.hh"
+
 #include "GenericPlacedVolume.hh"
 
 namespace celeritas
@@ -209,12 +211,12 @@ class GenericSolid : public vecgeom::VUnplacedVolume
     }
     DevicePtr<CudaUnplacedVolume> CopyToGpu() const
     {
-        return {};
+        CELER_NOT_IMPLEMENTED("GenericSolid with CUDA");
     }
     DevicePtr<CudaUnplacedVolume>
     CopyToGpu(DevicePtr<CudaUnplacedVolume> const) const
     {
-        return {};
+        CELER_NOT_IMPLEMENTED("GenericSolid with CUDA");
     }
     //! @}
 #endif

--- a/src/celeritas/ext/detail/GenericSolid.hh
+++ b/src/celeritas/ext/detail/GenericSolid.hh
@@ -26,6 +26,14 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Base class for identifying "generic" VecGeom volumes.
+ */
+class GenericSolidBase : public vecgeom::VUnplacedVolume
+{
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * A generic VecGeom solid converted from a Geant4 geometry.
  *
  * Some complex geometry functionalities in Geant4 don't have equivalents yet
@@ -33,7 +41,7 @@ namespace detail
  * when it makes sense to use some functionality from the original G4 shape.
  */
 template<typename S>
-class GenericSolid : public vecgeom::VUnplacedVolume
+class GenericSolid : public GenericSolidBase
 {
   private:
     //!@{


### PR DESCRIPTION
This improves the error message and failure mode when encountering a reflected solid. Instead of a hard `assert` which might be compiled out, we now get a more graceful failure. See #750 .