### PR TITLE
Output descriptive state on CPU when an offloaded track dies

### DIFF
--- a/app/demo-geant-integration/ActionInitialization.cc
+++ b/app/demo-geant-integration/ActionInitialization.cc
@@ -76,7 +76,7 @@ void ActionInitialization::Build() const
                       init_celeritas_});
     // Event action saves event ID for offloading and runs queued particles at
     // end of event
-    this->SetUserAction(new EventAction{transport});
+    this->SetUserAction(new EventAction{params_, transport});
     // Tracking action offloads tracks to device and kills them
     this->SetUserAction(new TrackingAction{params_, transport});
 }

--- a/app/demo-geant-integration/EventAction.cc
+++ b/app/demo-geant-integration/EventAction.cc
@@ -22,7 +22,12 @@ namespace demo_geant
 /*!
  * Construct with thread-local Celeritas data.
  */
-EventAction::EventAction(SPTransporter transport) : transport_(transport) {}
+EventAction::EventAction(SPConstParams params, SPTransporter transport)
+    : params_(params), transport_(transport)
+{
+    CELER_EXPECT(params_);
+    CELER_EXPECT(transport_);
+}
 
 //---------------------------------------------------------------------------//
 /*!
@@ -47,7 +52,7 @@ void EventAction::EndOfEventAction(G4Event const* event)
     CELER_EXPECT(event);
 
     // Transport any tracks left in the buffer
-    celeritas::ExceptionConverter call_g4exception{"celer0004"};
+    celeritas::ExceptionConverter call_g4exception{"celer0004", params_.get()};
     CELER_TRY_HANDLE(transport_->Flush(), call_g4exception);
 
     if (GlobalSetup::Instance()->GetWriteSDHits())

--- a/app/demo-geant-integration/EventAction.hh
+++ b/app/demo-geant-integration/EventAction.hh
@@ -11,6 +11,7 @@
 #include <G4UserEventAction.hh>
 
 #include "accel/LocalTransporter.hh"
+#include "accel/SharedParams.hh"
 
 namespace demo_geant
 {
@@ -26,16 +27,18 @@ class EventAction final : public G4UserEventAction
   public:
     //!@{
     //! \name Type aliases
+    using SPConstParams = std::shared_ptr<const celeritas::SharedParams>;
     using SPTransporter = std::shared_ptr<celeritas::LocalTransporter>;
     //!@}
 
   public:
-    explicit EventAction(SPTransporter transport);
+    EventAction(SPConstParams params, SPTransporter transport);
 
     void BeginOfEventAction(G4Event const* event) final;
     void EndOfEventAction(G4Event const* event) final;
 
   private:
+    SPConstParams params_;
     SPTransporter transport_;
 };
 

--- a/app/demo-geant-integration/TrackingAction.cc
+++ b/app/demo-geant-integration/TrackingAction.cc
@@ -60,7 +60,8 @@ void TrackingAction::PreUserTrackingAction(G4Track const* track)
         != std::end(allowed_particles))
     {
         // Celeritas is transporting this track
-        celeritas::ExceptionConverter call_g4exception{"celer0003"};
+        celeritas::ExceptionConverter call_g4exception{"celer0003",
+                                                       params_.get()};
         CELER_TRY_HANDLE(transport_->Push(*track), call_g4exception);
         const_cast<G4Track*>(track)->SetTrackStatus(fStopAndKill);
     }

--- a/src/accel/ExceptionConverter.hh
+++ b/src/accel/ExceptionConverter.hh
@@ -11,6 +11,7 @@
 
 namespace celeritas
 {
+class SharedParams;
 //---------------------------------------------------------------------------//
 /*!
  * Translate Celeritas C++ exceptions into Geant4 G4Exception calls.
@@ -32,7 +33,10 @@ namespace celeritas
 class ExceptionConverter
 {
   public:
-    // Construct with "error code"
+    // Construct with "error code" and optional pointer to shared params
+    inline ExceptionConverter(char const* err_code, SharedParams const* params);
+
+    // Construct with just an "error code"
     inline explicit ExceptionConverter(char const* err_code);
 
     // Capture the current exception and convert it to a G4Exception call
@@ -40,6 +44,7 @@ class ExceptionConverter
 
   private:
     char const* err_code_;
+    SharedParams const* params_{nullptr};
 
     void convert_device_exceptions(std::exception_ptr p) const;
 };
@@ -48,10 +53,24 @@ class ExceptionConverter
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
+ * Construct with an error code and shared parameters.
+ *
+ * The error code is reported to the Geant4 exception manager. The shared
+ * parameters are used to translate internal particle data if an exception
+ * occurs.
+ */
+ExceptionConverter::ExceptionConverter(char const* err_code,
+                                       SharedParams const* params)
+    : err_code_{err_code}, params_(params)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct with an error code for dispatching to Geant4.
  */
 ExceptionConverter::ExceptionConverter(char const* err_code)
-    : err_code_{err_code}
+    : ExceptionConverter(err_code, nullptr)
 {
 }
 

--- a/src/accel/SimpleOffload.cc
+++ b/src/accel/SimpleOffload.cc
@@ -117,7 +117,7 @@ void SimpleOffload::PreUserTrackingAction(G4Track* track)
         != params_->OffloadParticles().end())
     {
         // Celeritas is transporting this track
-        ExceptionConverter call_g4exception{"celer0003"};
+        ExceptionConverter call_g4exception{"celer0003", params_};
         CELER_TRY_HANDLE(local_->Push(*track), call_g4exception);
         track->SetTrackStatus(fStopAndKill);
     }
@@ -132,7 +132,7 @@ void SimpleOffload::EndOfEventAction(G4Event const*)
     if (!*this)
         return;
 
-    ExceptionConverter call_g4exception{"celer0004"};
+    ExceptionConverter call_g4exception{"celer0004", params_};
     CELER_TRY_HANDLE(local_->Flush(), call_g4exception);
 }
 

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "KernelContextException.hh"
 
+#include "corecel/OpaqueIdIO.hh"
 #include "corecel/cont/ArrayIO.hh"
 #include "corecel/io/JsonPimpl.hh"
 #if CELERITAS_USE_JSON
@@ -33,19 +34,6 @@ void insert_if_valid(char const* key,
     }
 }
 #endif
-template<class V, class S>
-std::ostream& operator<<(std::ostream& os, OpaqueId<V, S> const& v)
-{
-    if (v)
-    {
-        os << v.unchecked_get();
-    }
-    else
-    {
-        os << '?';
-    }
-    return os;
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace

--- a/src/corecel/OpaqueIdIO.hh
+++ b/src/corecel/OpaqueIdIO.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/OpaqueIdIO.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <ostream>
+
+#include "OpaqueId.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Output an opaque ID's value or a placeholder if unavailable.
+ */
+template<class V, class S>
+std::ostream& operator<<(std::ostream& os, OpaqueId<V, S> const& v)
+{
+    if (v)
+    {
+        os << v.unchecked_get();
+    }
+    else
+    {
+        os << "<invalid>";
+    }
+    return os;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/math/QuantityIO.hh
+++ b/src/corecel/math/QuantityIO.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ostream>
+
 #include "Quantity.hh"
 
 namespace celeritas

--- a/src/corecel/math/QuantityIO.hh
+++ b/src/corecel/math/QuantityIO.hh
@@ -1,0 +1,29 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/math/QuantityIO.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <ostream>
+#include "Quantity.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Output an quantity with its label.
+ */
+template<class UnitT, class ValueT>
+std::ostream& operator<<(std::ostream& os, Quantity<UnitT, ValueT> const& q)
+{
+    static_assert(sizeof(UnitT::label()) > 0,
+                  "Unit does not have a 'label' definition");
+    os << q.value() << " [" << UnitT::label() << ']';
+    return os;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas


### PR DESCRIPTION
In combination with #751 :
```
G4WT1 > ExceptionConverter.cc:153: [2/2] critical: The following error is from: kernel context: track slot 787 in 'geo-boundary', track 501 of event 0
- Particle type: gamma (PDG=22,  ID=0)
- Energy: 0.689991 [MeV]
- Position: {119.121,48.1344,-192.09} (cm)
- Direction: {0.943236,0.244289,0.225008}
- Volume: eregalgo_EBAR@0x6000028a8a00 (ID=1618)
- Surface ID: <invalid>
- Step counter: 71
G4WT1 >
-------- EEEE ------- G4Exception-START -------- EEEE -------
*** G4Exception : celer0004
      issued by : celeritas/ext/detail/GenericPlacedVolume.hh:90
feature is not yet implemented: GenericPlacedVolume
*** Fatal Exception *** core dump ***
G4WT1 > G4Track (0x11c8ca930) - track ID = 0, parent ID = 0
```