### PR TITLE
Fix duplicate volume warnings and missing material IDs

### DIFF
--- a/app/demo-geant-integration/DetectorConstruction.cc
+++ b/app/demo-geant-integration/DetectorConstruction.cc
@@ -57,7 +57,12 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
     CELER_LOG_LOCAL(status) << "Loading detector geometry";
 
     G4GDMLParser gdml_parser;
-    gdml_parser.SetStripFlag(GlobalSetup::Instance()->StripGDMLPointers());
+    gdml_parser.SetStripFlag(true);
+    if (!GlobalSetup::Instance()->StripGDMLPointers())
+    {
+        // DEPRECATED: remove in 1.0?
+        CELER_LOG(warning) << "Ignoring deprecated 'stripGDMLPointers false'";
+    }
 
     std::string const& filename = GlobalSetup::Instance()->GetGeometryFile();
     if (filename.empty())

--- a/app/demo-geant-integration/GlobalSetup.cc
+++ b/app/demo-geant-integration/GlobalSetup.cc
@@ -63,7 +63,7 @@ GlobalSetup::GlobalSetup()
                                                 strip_gdml_pointers_);
         cmd.SetGuidance(
             "Remove pointer suffix from input logical volume names");
-        cmd.SetDefaultValue("false");
+        cmd.SetDefaultValue("true");
     }
     {
         auto& cmd = messenger_->DeclareProperty("outputFile",

--- a/app/demo-geant-integration/GlobalSetup.hh
+++ b/app/demo-geant-integration/GlobalSetup.hh
@@ -73,7 +73,7 @@ class GlobalSetup
     std::string event_file_;
     int root_buffer_size_{128000};
     bool write_sd_hits_{false};
-    bool strip_gdml_pointers_{false};
+    bool strip_gdml_pointers_{true};
     G4ThreeVector field_;
 
     std::unique_ptr<G4GenericMessenger> messenger_;

--- a/src/celeritas/ext/GeantVolumeMapper.cc
+++ b/src/celeritas/ext/GeantVolumeMapper.cc
@@ -55,7 +55,8 @@ VolumeId GeantVolumeMapper::operator()(G4LogicalVolume const& lv) const
     {
         CELER_LOG(warning) << "Failed to exactly match " << celeritas_core_geo
                            << " volume from Geant4 volume '" << lv.GetName()
-                           << "'; found '" << geo.id_to_label(all_ids.front())
+                           << "'@" << static_cast<void const*>(&lv)
+                           << "; found '" << geo.id_to_label(all_ids.front())
                            << "' by omitting the extension";
         return all_ids.front();
     }

--- a/src/celeritas/ext/VecgeomParams.cc
+++ b/src/celeritas/ext/VecgeomParams.cc
@@ -287,13 +287,15 @@ void VecgeomParams::build_metadata()
                 = vg_manager.FindLogicalVolume(vol_idx);
             CELER_ASSERT(vol);
 
-            auto label = Label::from_geant(vol->GetLabel());
-            if (label.name.empty())
-            {
-                // Many VGDML imported IDs seem to be empty for CMS
-                label.name = "[unused]";
-                label.ext = std::to_string(vol_idx);
-            }
+            auto label = [vol] {
+                auto const& label = vol->GetLabel();
+                if (starts_with(label, "[TEMP]"))
+                {
+                    // Temporary logical volume not directly used in transport
+                    return Label{};
+                }
+                return Label::from_geant(vol->GetLabel());
+            }();
 
             result[vol_idx] = std::move(label);
         }

--- a/src/celeritas/ext/detail/GeantGeoConverter.cc
+++ b/src/celeritas/ext/detail/GeantGeoConverter.cc
@@ -689,8 +689,11 @@ VUnplacedVolume* GeantGeoConverter::convert(G4VSolid const* shape)
         CELER_ASSERT(rightunplaced != nullptr);
 
         // the problem is that I can only place logical volumes
-        std::string left_label{left->GetName() + "_bool_left"};
-        std::string right_label{right->GetName() + "_bool_right"};
+        auto const& solid_name = boolean->GetName();
+        std::string left_label{"[TEMP]@" + solid_name + "/left/"
+                               + left->GetName()};
+        std::string right_label{"[TEMP]@" + solid_name + "/right/"
+                                + right->GetName()};
         VPlacedVolume* const leftplaced
             = (new LogicalVolume(left_label.c_str(), leftunplaced))
                   ->Place(lefttrans);

--- a/src/celeritas/ext/detail/GeantVolumeVisitor.cc
+++ b/src/celeritas/ext/detail/GeantVolumeVisitor.cc
@@ -10,7 +10,6 @@
 #include <G4GDMLWriteStructure.hh>
 #include <G4LogicalVolume.hh>
 #include <G4MaterialCutsCouple.hh>
-#include <G4ReflectionFactory.hh>
 #include <G4VSolid.hh>
 
 #include "corecel/Assert.hh"
@@ -81,22 +80,7 @@ GeantVolumeVisitor::generate_name(G4LogicalVolume const& logical_volume)
     // uniquely identifiable in VecGeom. Reuse the same instance to reduce
     // overhead: note that the method isn't const correct.
     static G4GDMLWriteStructure temp_writer;
-    auto const* refl_factory = G4ReflectionFactory::Instance();
-    if (auto const* lv = refl_factory->GetConstituentLV(
-            const_cast<G4LogicalVolume*>(&logical_volume)))
-    {
-        // If this is a reflected volume, generate the name based on the
-        // constituent volume and re-add the reflection extension after the
-        // final pointer so the name will match the GDML name.
-        name = lv->GetName();
-        name = temp_writer.GenerateName(name, lv)
-               + refl_factory->GetVolumesNameExtension();
-    }
-    else
-    {
-        name = temp_writer.GenerateName(name, &logical_volume);
-    }
-    return name;
+    return temp_writer.GenerateName(name, &logical_volume);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantVolumeVisitor.cc
+++ b/src/celeritas/ext/detail/GeantVolumeVisitor.cc
@@ -74,13 +74,11 @@ void GeantVolumeVisitor::visit(G4LogicalVolume const& logical_volume)
 std::string
 GeantVolumeVisitor::generate_name(G4LogicalVolume const& logical_volume)
 {
-    std::string name = logical_volume.GetName();
-
     // Run the LV through the GDML export name generator so that the volume is
     // uniquely identifiable in VecGeom. Reuse the same instance to reduce
     // overhead: note that the method isn't const correct.
     static G4GDMLWriteStructure temp_writer;
-    return temp_writer.GenerateName(name, &logical_volume);
+    return temp_writer.GenerateName(logical_volume.GetName(), &logical_volume);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/cont/LabelIdMultiMap.hh
+++ b/src/corecel/cont/LabelIdMultiMap.hh
@@ -35,7 +35,7 @@ namespace celeritas
  * the IDs corresponding to a label may be noncontiguous.
  *
  * Duplicate labels are allowed but will be added to a list of duplicate IDs
- * that can be warned about downstream.
+ * that can be warned about downstream. Empty labels will be ignored.
  *
  * If no sublabels or labels are available, an empty span or "false" OpaqueId
  * will be returned.
@@ -120,7 +120,7 @@ LabelIdMultiMap<I>::LabelIdMultiMap(VecLabel keys) : keys_(std::move(keys))
     {
         Label const& prev = keys_[id_data_[idx - 1].unchecked_get()];
         Label const& cur = keys_[id_data_[idx].unchecked_get()];
-        if (prev == cur)
+        if (prev == cur && !cur.empty())
         {
             if (duplicates_.empty()
                 || keys_[duplicates_.back().unchecked_get()] != prev)

--- a/src/corecel/io/Label.hh
+++ b/src/corecel/io/Label.hh
@@ -61,6 +61,9 @@ struct Label
     {
     }
 
+    //! Whether both the label and extension are empty
+    bool empty() const { return name.empty() && ext.empty(); }
+
     //// STATIC METHODS ////
 
     // Construct a label from a Geant4 pointer-appended name

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -66,7 +66,10 @@ class GeantVolumeMapperTestBase : public ::celeritas::test::Test
         if (lev > LogLevel::info)
         {
             static const std::regex delete_ansi("\033\\[[0-9;]*m");
-            messages_.push_back(std::regex_replace(msg, delete_ansi, ""));
+            static const std::regex subs_ptr("0x[0-9a-f]+");
+            msg = std::regex_replace(msg, delete_ansi, "");
+            msg = std::regex_replace(msg, subs_ptr, "0x1234abcd");
+            messages_.push_back(std::move(msg));
         }
     }
 
@@ -260,15 +263,19 @@ TEST_F(NestedTest, unique)
 
     if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
     {
-        static std::string const expected_messages[]
+        static char const* const expected_messages[]
             = {"Failed to exactly match ORANGE volume from Geant4 volume "
-               "'world'; found 'world@global' by omitting the extension",
+               "'world'@0x1234abcd; found 'world@global' by omitting the "
+               "extension",
                "Failed to exactly match ORANGE volume from Geant4 volume "
-               "'outer'; found 'outer@global' by omitting the extension",
+               "'outer'@0x1234abcd; found 'outer@global' by omitting the "
+               "extension",
                "Failed to exactly match ORANGE volume from Geant4 volume "
-               "'middle'; found 'middle@global' by omitting the extension",
+               "'middle'@0x1234abcd; found 'middle@global' by omitting the "
+               "extension",
                "Failed to exactly match ORANGE volume from Geant4 volume "
-               "'inner'; found 'inner@global' by omitting the extension"};
+               "'inner'@0x1234abcd; found 'inner@global' by omitting the "
+               "extension"};
         EXPECT_VEC_EQ(expected_messages, messages_);
     }
     else

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -861,7 +861,7 @@ TEST_F(SolidsGeantTest, accessors)
     EXPECT_EQ("World", geom.id_to_label(VolumeId{0}).name);
     EXPECT_EQ("box500", geom.id_to_label(VolumeId{1}).name);
     EXPECT_EQ("cone1", geom.id_to_label(VolumeId{2}).name);
-    EXPECT_EQ("b500_bool_left", geom.id_to_label(VolumeId{9}).name);
+    EXPECT_EQ("", geom.id_to_label(VolumeId{9}).name);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/cont/LabelIdMultiMap.test.cc
+++ b/test/corecel/cont/LabelIdMultiMap.test.cc
@@ -56,7 +56,7 @@ TEST(LabelIdMultiMapTest, empty)
 
 TEST(LabelIdMultiMapTest, no_ext_with_duplicates)
 {
-    CatMultiMap cats{VecLabel{{"dexter", "andy", "loki", "", "", ""}}};
+    CatMultiMap cats{VecLabel{{"dexter", "andy", "loki", "bob", "bob", "bob"}}};
     EXPECT_EQ(6, cats.size());
     EXPECT_EQ(CatId{}, cats.find("nyoka"));
     EXPECT_EQ(CatId{0}, cats.find("dexter"));
@@ -66,6 +66,13 @@ TEST(LabelIdMultiMapTest, no_ext_with_duplicates)
 
     static const CatId expected_duplicates[] = {CatId{3}, CatId{4}, CatId{5}};
     EXPECT_VEC_EQ(expected_duplicates, cats.duplicates());
+}
+
+TEST(LabelIdMultiMapTest, empty_duplicates)
+{
+    CatMultiMap cats{VecLabel{{"dexter", "andy", "loki", "", ""}}};
+    EXPECT_EQ(5, cats.size());
+    EXPECT_EQ(0, cats.duplicates().size());
 }
 
 TEST(LabelIdMultiMapTest, some_labels)


### PR DESCRIPTION
I think this fixes the `other.material_id < params_.materials.size` issue reported by @whokion in #750. The material IDs for reflected volumes were not being captured because the mangled volume names were not matching (see https://github.com/celeritas-project/celeritas/pull/680#issuecomment-1541946789 ).

This also fixes a bunch of warnings about duplicate volume names any time a boolean is present in the geometry: vecgeom was generating temporary unplaced volumes which show up multiple times in the "registry" of volumes (with a unique counter) but are only used as part of the underlying implementation and never encountered during navigation.