### PR TITLE
Extend and update SWIG wrappers

### DIFF
--- a/interface/celeritas.i
+++ b/interface/celeritas.i
@@ -8,16 +8,24 @@
 %module "celeritas"
 
 %include <cstring.i>
+%include <std_string.i>
+%include <std_vector.i>
+
+%include "detail/macros.i"
 %feature("flatnested");
 
 //---------------------------------------------------------------------------//
 // CONFIG FILE
 //---------------------------------------------------------------------------//
 %{
+#include "celeritas_version.h"
 #include "celeritas_config.h"
+#include "celeritas_cmake_strings.h"
 %}
 
+%include "celeritas_version.h"
 %include "celeritas_config.h"
+%include "celeritas_cmake_strings.h"
 
 //---------------------------------------------------------------------------//
 // ASSERTIONS
@@ -49,7 +57,6 @@
 %include "corecel/Macros.hh"
 %include "corecel/Types.hh"
 
-%include <std_vector.i>
 %template(VecReal) std::vector<celeritas::real_type>;
 
 //---------------------------------------------------------------------------//
@@ -79,17 +86,17 @@
 //---------------------------------------------------------------------------//
 
 %{
-#include "celeritas/ext/RootImporter.hh"
+#include "celeritas/io/ImportData.hh"
 %}
 
 namespace celeritas
 {
-%rename(table_type_to_string) to_cstring(ImportTableType);
-%rename(units_to_string) to_cstring(ImportUnits);
-%rename(vector_type_to_string) to_cstring(ImportPhysicsVectorType);
-%rename(process_type_to_string) to_cstring(ImportProcessType);
-%rename(process_class_to_string) to_cstring(ImportProcessClass);
-%rename(model_to_string) to_cstring(ImportModelClass);
+%celer_rename_to_cstring(table_type, ImportTableType);
+%celer_rename_to_cstring(units, ImportUnits);
+%celer_rename_to_cstring(vector_type, ImportPhysicsVectorType);
+%celer_rename_to_cstring(process_type, ImportProcessType);
+%celer_rename_to_cstring(process_class, ImportProcessClass);
+%celer_rename_to_cstring(model, ImportModelClass);
 %rename(process_class_to_geant_name) to_geant_name(ImportProcessClass);
 %rename(model_to_geant_name) to_geant_name(ImportModelClass);
 
@@ -126,9 +133,6 @@ namespace celeritas
 
 %include "celeritas/io/ImportData.hh"
 
-%rename(RootImportResult) celeritas::RootImporter::result_type;
-%include "celeritas/ext/RootImporter.hh"
-
 //---------------------------------------------------------------------------//
 
 %{
@@ -148,5 +152,31 @@ namespace celeritas
 %template(VecImportLivermoreSubshell) std::vector<celeritas::ImportLivermoreSubshell>;
 
 %include "celeritas/io/LivermorePEReader.hh"
+
+//---------------------------------------------------------------------------//
+// EXT
+//---------------------------------------------------------------------------//
+%{
+#include "celeritas/ext/RootImporter.hh"
+#include "celeritas/ext/RootExporter.hh"
+#include "celeritas/ext/GeantPhysicsOptions.hh"
+#include "celeritas/ext/GeantSetup.hh"
+#include "celeritas/ext/GeantImporter.hh"
+%}
+
+namespace celeritas
+{
+%celer_rename_to_cstring(brems_model, BremsModelSelection);
+%celer_rename_to_cstring(msc_model, MscModelSelection);
+%celer_rename_to_cstring(relaxation_selection, RelaxationSelection);
+
+%warnfilter(362) GeantSetup::operator=;
+}
+
+%include "celeritas/ext/RootImporter.hh"
+%include "celeritas/ext/RootExporter.hh"
+%include "celeritas/ext/GeantPhysicsOptions.hh"
+%include "celeritas/ext/GeantSetup.hh"
+%include "celeritas/ext/GeantImporter.hh"
 
 // vim: set ft=lex ts=2 sw=2 sts=2 :

--- a/interface/celeritas.i
+++ b/interface/celeritas.i
@@ -8,6 +8,7 @@
 %module "celeritas"
 
 %include <cstring.i>
+%include <std_map.i>
 %include <std_string.i>
 %include <std_vector.i>
 
@@ -131,6 +132,17 @@ namespace celeritas
 %include "celeritas/io/ImportVolume.hh"
 %template(VecImportVolume) std::vector<celeritas::ImportVolume>;
 
+%include "celeritas/io/ImportAtomicRelaxation.hh"
+%template(VecImportAtomicTransition) std::vector<celeritas::ImportAtomicTransition>;
+
+%include "celeritas/io/ImportSBTable.hh"
+
+%include "celeritas/io/ImportLivermorePE.hh"
+%template(VecImportLivermoreSubshell) std::vector<celeritas::ImportLivermoreSubshell>;
+
+%template(MapIAR) std::map<int, celeritas::ImportAtomicRelaxation>;
+%template(MapLivermorePE) std::map<int, celeritas::ImportLivermorePE>;
+%template(MapImportSB) std::map<int, celeritas::ImportSBTable>;
 %include "celeritas/io/ImportData.hh"
 
 //---------------------------------------------------------------------------//
@@ -139,7 +151,6 @@ namespace celeritas
 #include "celeritas/io/SeltzerBergerReader.hh"
 %}
 
-%include "celeritas/io/ImportSBTable.hh"
 %include "celeritas/io/SeltzerBergerReader.hh"
 
 //---------------------------------------------------------------------------//
@@ -147,9 +158,6 @@ namespace celeritas
 %{
 #include "celeritas/io/LivermorePEReader.hh"
 %}
-
-%include "celeritas/io/ImportLivermorePE.hh"
-%template(VecImportLivermoreSubshell) std::vector<celeritas::ImportLivermoreSubshell>;
 
 %include "celeritas/io/LivermorePEReader.hh"
 

--- a/interface/detail/macros.i
+++ b/interface/detail/macros.i
@@ -1,0 +1,12 @@
+//---------------------------------*-SWIG-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file detail/macros.i
+//---------------------------------------------------------------------------//
+
+%define %celer_rename_to_cstring(CLASS_LOWER, CLASS)
+%rename(CLASS_LOWER ## _to_string) to_cstring(CLASS);
+%enddef
+

--- a/scripts/cmake-presets/goldfinger.json
+++ b/scripts/cmake-presets/goldfinger.json
@@ -42,6 +42,7 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CELERITAS_USE_SWIG":    {"type": "BOOL",   "value": "ON"},
+        "CMAKE_SWIG_CXX_FLAGS": "-Wno-unused-parameter;-Wno-deprecated-declarations",
         "CELERITAS_USE_VecGeom": {"type": "BOOL",   "value": "OFF"}
       }
     },

--- a/src/celeritas/ext/RootUniquePtr.root.cc
+++ b/src/celeritas/ext/RootUniquePtr.root.cc
@@ -10,6 +10,8 @@
 #include <TFile.h>
 #include <TTree.h>
 
+#include "corecel/io/Logger.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -20,6 +22,9 @@ namespace celeritas
 template<class T>
 void RootWritableDeleter<T>::operator()(T* ptr)
 {
+    CELER_EXPECT(ptr);
+    CELER_LOG(debug) << "Writing " << ptr->ClassName() << " '"
+                     << ptr->GetName() << "'";
     ptr->Write();
     delete ptr;
 }
@@ -32,6 +37,9 @@ void RootWritableDeleter<T>::operator()(T* ptr)
 template<class T>
 void ExternDeleter<T>::operator()(T* ptr)
 {
+    CELER_EXPECT(ptr);
+    CELER_LOG(debug) << "Closing " << ptr->ClassName() << " '"
+                     << ptr->GetName() << "'";
     delete ptr;
 }
 


### PR DESCRIPTION
I added further SWIG support and fixes while trying to plot Geant4 cross section data for v11.0 and v11.1.