### PR TITLE
Support Geant4 11.1+

### DIFF
--- a/app/demo-geant-integration/demo-geant-integration.cc
+++ b/app/demo-geant-integration/demo-geant-integration.cc
@@ -69,7 +69,15 @@ void run(std::string const& macro_filename)
     run_manager->SetUserInitialization(new FTFP_BERT{/* verbosity = */ 0});
     run_manager->SetUserInitialization(new demo_geant::ActionInitialization());
 
-    demo_geant::GlobalSetup::Instance()->SetIgnoreProcesses({"CoulombScat"});
+    std::vector<std::string> ignore_processes = {"CoulombScat"};
+    if (G4VERSION_NUMBER >= 1110)
+    {
+        CELER_LOG(warning) << "Default Rayleigh scattering 'MinKinEnergyPrim' "
+                              "is not compatible between Celeritas and "
+                              "Geant4@11.1: disabling Rayleigh scattering";
+        ignore_processes.push_back("Rayl");
+    }
+    demo_geant::GlobalSetup::Instance()->SetIgnoreProcesses(ignore_processes);
 
     G4UImanager* ui = G4UImanager::GetUIpointer();
     CELER_ASSERT(ui);

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -30,6 +30,7 @@
 #include <G4ParticleTable.hh>
 #include <G4ProcessManager.hh>
 #include <G4ProcessType.hh>
+#include <G4PropagatorInField.hh>
 #include <G4ProcessVector.hh>
 #include <G4ProductionCuts.hh>
 #include <G4ProductionCutsTable.hh>

--- a/src/celeritas/ext/detail/GeantLoggerAdapter.cc
+++ b/src/celeritas/ext/detail/GeantLoggerAdapter.cc
@@ -9,7 +9,12 @@
 
 #include <cctype>
 #include <memory>
-#include <G4strstreambuf.hh>
+#include <G4Version.hh>
+#if CELER_G4SSBUF
+#    include <G4strstreambuf.hh>
+#else
+#    include <G4ios.hh>
+#endif
 
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringUtils.hh"
@@ -23,12 +28,19 @@ namespace detail
  * Redirect geant4's stdout/cerr on construction.
  */
 GeantLoggerAdapter::GeantLoggerAdapter()
+#if CELER_G4SSBUF
     : saved_cout_(G4coutbuf.GetDestination())
     , saved_cerr_(G4cerrbuf.GetDestination())
 {
     G4coutbuf.SetDestination(this);
     G4cerrbuf.SetDestination(this);
 }
+#else
+{
+    // See Geant4 change global-V11-01-01
+    G4iosSetDestination(this);
+}
+#endif
 
 //---------------------------------------------------------------------------//
 /*!
@@ -36,6 +48,7 @@ GeantLoggerAdapter::GeantLoggerAdapter()
  */
 GeantLoggerAdapter::~GeantLoggerAdapter()
 {
+#if CELER_G4SSBUF
     if (G4coutbuf.GetDestination() == this)
     {
         G4coutbuf.SetDestination(saved_cout_);
@@ -44,6 +57,9 @@ GeantLoggerAdapter::~GeantLoggerAdapter()
     {
         G4cerrbuf.SetDestination(saved_cerr_);
     }
+#else
+    G4iosSetDestination(nullptr);
+#endif
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantLoggerAdapter.hh
+++ b/src/celeritas/ext/detail/GeantLoggerAdapter.hh
@@ -11,7 +11,7 @@
 #include <G4Types.hh>
 #include <G4Version.hh>
 #include <G4coutDestination.hh>
-#if G4VERSION_NUMBER >= 1111
+#if G4VERSION_NUMBER > 1111
 // No ability to include G4strstreambuf
 #    define CELER_G4SSBUF 0
 #else

--- a/src/celeritas/ext/detail/GeantLoggerAdapter.hh
+++ b/src/celeritas/ext/detail/GeantLoggerAdapter.hh
@@ -11,7 +11,7 @@
 #include <G4Types.hh>
 #include <G4Version.hh>
 #include <G4coutDestination.hh>
-#if G4VERSION_NUMBER > 1111
+#if G4VERSION_NUMBER >= 1111
 // No ability to include G4strstreambuf
 #    define CELER_G4SSBUF 0
 #else

--- a/src/celeritas/ext/detail/GeantLoggerAdapter.hh
+++ b/src/celeritas/ext/detail/GeantLoggerAdapter.hh
@@ -9,7 +9,14 @@
 
 #include <G4String.hh>
 #include <G4Types.hh>
+#include <G4Version.hh>
 #include <G4coutDestination.hh>
+#if G4VERSION_NUMBER > 1111
+// No ability to include G4strstreambuf
+#    define CELER_G4SSBUF 0
+#else
+#    define CELER_G4SSBUF 1
+#endif
 
 #include "corecel/io/LoggerTypes.hh"
 
@@ -35,8 +42,10 @@ class GeantLoggerAdapter : public G4coutDestination
   private:
     //// DATA ////
 
+#if CELER_G4SSBUF
     G4coutDestination* saved_cout_;
     G4coutDestination* saved_cerr_;
+#endif
 
     //// IMPLEMENTATION ////
     G4int log_impl(G4String const& str, LogLevel level);

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -28,6 +28,7 @@
 #include <G4Proton.hh>
 #include <G4RayleighScattering.hh>
 #include <G4UrbanMscModel.hh>
+#include <G4Version.hh>
 #include <G4WentzelVIModel.hh>
 #include <G4eCoulombScatteringModel.hh>
 #include <G4eIonisation.hh>
@@ -188,7 +189,14 @@ void GeantPhysicsList::add_gamma_processes()
     if (options_.rayleigh_scattering)
     {
         // Rayleigh: G4LivermoreRayleighModel
-        add_process(new G4RayleighScattering());
+        auto rayl = std::make_unique<G4RayleighScattering>();
+        if (G4VERSION_NUMBER >= 1110)
+        {
+            // Revert MinKinEnergy to its Geant 11.0 value so that the lower
+            // and energy grids have the same log spacing
+            rayl->SetMinKinEnergyPrim(100 * CLHEP::keV);
+        }
+        add_process(rayl.release());
         CELER_LOG(debug) << "Loaded Rayleigh scattering with "
                             "G4LivermoreRayleighModel";
     }

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -192,7 +192,7 @@ void GeantPhysicsList::add_gamma_processes()
         auto rayl = std::make_unique<G4RayleighScattering>();
         if (G4VERSION_NUMBER >= 1110)
         {
-            // Revert MinKinEnergy to its Geant 11.0 value so that the lower
+            // Revert MinKinEnergyPrim (150 keV) to its Geant 11.0 value so that the lower
             // and energy grids have the same log spacing
             rayl->SetMinKinEnergyPrim(100 * CLHEP::keV);
         }

--- a/src/celeritas/grid/ValueGridBuilder.cc
+++ b/src/celeritas/grid/ValueGridBuilder.cc
@@ -51,11 +51,6 @@ bool has_log_spacing(SpanConstReal vec)
     return true;
 }
 
-bool has_same_log_spacing(SpanConstReal first, SpanConstReal second)
-{
-    return soft_equal(calc_log_delta(first), calc_log_delta(second));
-}
-
 bool is_nonnegative(SpanConstReal vec)
 {
     return std::all_of(
@@ -109,12 +104,19 @@ ValueGridXsBuilder::from_geant(SpanConstReal lambda_energy,
     CELER_EXPECT(is_contiguous_increasing(lambda_energy, lambda_prim_energy));
     CELER_EXPECT(has_log_spacing(lambda_energy)
                  && has_log_spacing(lambda_prim_energy));
-    CELER_EXPECT(has_same_log_spacing(lambda_energy, lambda_prim_energy));
     CELER_EXPECT(lambda.size() == lambda_energy.size());
     CELER_EXPECT(lambda_prim.size() == lambda_prim_energy.size());
     CELER_EXPECT(soft_equal(lambda.back(),
                             lambda_prim.front() / lambda_prim_energy.front()));
     CELER_EXPECT(is_nonnegative(lambda) && is_nonnegative(lambda_prim));
+
+    real_type const log_delta_lo = calc_log_delta(lambda_energy);
+    real_type const log_delta_hi = calc_log_delta(lambda_prim_energy);
+    CELER_VALIDATE(
+        soft_equal(log_delta_lo, log_delta_hi),
+        << "Lower and upper energy grids have inconsistent spacing: "
+           "log delta E for lower grid is "
+        << log_delta_lo << " log(MeV) per bin but upper is " << log_delta_hi);
 
     // Concatenate the two XS vectors: insert the scaled (lambda_prim) value at
     // the coincident point.

--- a/src/celeritas/grid/ValueGridBuilder.cc
+++ b/src/celeritas/grid/ValueGridBuilder.cc
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "corecel/Types.hh"
+#include "corecel/io/Logger.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/grid/UniformGrid.hh"
 #include "corecel/grid/UniformGridData.hh"
@@ -49,11 +50,6 @@ bool has_log_spacing(SpanConstReal vec)
             return false;
     }
     return true;
-}
-
-bool has_same_log_spacing(SpanConstReal first, SpanConstReal second)
-{
-    return soft_equal(calc_log_delta(first), calc_log_delta(second));
 }
 
 bool is_nonnegative(SpanConstReal vec)
@@ -109,7 +105,6 @@ ValueGridXsBuilder::from_geant(SpanConstReal lambda_energy,
     CELER_EXPECT(is_contiguous_increasing(lambda_energy, lambda_prim_energy));
     CELER_EXPECT(has_log_spacing(lambda_energy)
                  && has_log_spacing(lambda_prim_energy));
-    CELER_EXPECT(has_same_log_spacing(lambda_energy, lambda_prim_energy));
     CELER_EXPECT(lambda.size() == lambda_energy.size());
     CELER_EXPECT(lambda_prim.size() == lambda_prim_energy.size());
     CELER_EXPECT(soft_equal(lambda.back(),
@@ -123,8 +118,30 @@ ValueGridXsBuilder::from_geant(SpanConstReal lambda_energy,
     dst = std::copy(lambda_prim.begin(), lambda_prim.end(), dst);
     CELER_ASSERT(dst == xs.end());
 
+
+    real_type const emin = [&] {
+        real_type const log_delta_lo = calc_log_delta(lambda_energy);
+        real_type const log_delta_hi = calc_log_delta(lambda_prim_energy);
+
+        if (soft_equal(log_delta_lo, log_delta_hi))
+        {
+            // Always the case for Geant4 < 11.1
+            return lambda_energy.front();
+        }
+        real_type const adjusted
+            = lambda_energy.back()
+              / std::pow(log_delta_hi, lambda_energy.size() - 1);
+        CELER_LOG(warning)
+            << "Adjusting cross section energy lower limit from "
+            << lambda_energy.front() << " to " << adjusted
+            << " [MeV] due to unexpected grid spacing";
+
+        // Reset lower energy point based on high energy spacing
+        return adjusted;
+    }();
+
     // Construct the grid
-    return std::make_unique<ValueGridXsBuilder>(lambda_energy.front(),
+    return std::make_unique<ValueGridXsBuilder>(emin,
                                                 lambda_prim_energy.front(),
                                                 lambda_prim_energy.back(),
                                                 VecReal(std::move(xs)));

--- a/src/celeritas/phys/ImportedProcessAdapter.hh
+++ b/src/celeritas/phys/ImportedProcessAdapter.hh
@@ -95,7 +95,7 @@ class ImportedProcessAdapter
                            std::initializer_list<PDGNumber> pdg_numbers);
 
     // Construct step limits from the given particle/material type
-    StepLimitBuilders step_limits(Applicability applic) const;
+    StepLimitBuilders step_limits(Applicability const& applic) const;
 
     // Get the lambda table for the given particle ID
     inline ImportPhysicsTable const& get_lambda(ParticleId id) const;
@@ -117,7 +117,11 @@ class ImportedProcessAdapter
     };
 
     SPConstImported imported_;
+    ImportProcessClass process_class_;
     std::map<ParticleId, ParticleProcessIds> ids_;
+
+    // Construct step limits from the given particle/material type
+    StepLimitBuilders step_limits_impl(Applicability const& applic) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -488,7 +488,7 @@ TEST_F(SimpleCmsRZFieldAlongStepTest, msc_rzfield)
 
         auto result = this->run(inp, num_tracks);
         EXPECT_SOFT_EQ(4.1632771293464517, result.displacement);
-        EXPECT_SOFT_EQ(-0.59445466152831616, result.angle);
+        EXPECT_SOFT_NEAR(-0.59445466152831616, result.angle, 2e-12);
     }
 }
 


### PR DESCRIPTION
This fixes #588 by providing a couple of workarounds for the inconsistent grid error, which is caused by the Rayleigh scattering cross sections:
- When loading through our configurable physics list, we restore the cutoff to its original (Geant4 11.0) 100 keV value from the Geant4 11.1 default
- The geant4 demo app defaults to ignoring Rayleigh scattering (after emitting a warning)
- A descriptive always-on error check will tell users what process causes any failures to import the cross sections.

I've also added fixes for two other small issues that showed up while building the development 'master' of Geant4@11:
- IWYU failure (class is forward declared rather than included)
- A change to the Geant4 logger interface improves how we can set/restore the logger (perhaps @drbenmorgan could verify that I'm doing this correctly? see 722ee3b3b7bf9df5b8d63bce34e156b41b68f7b7)