### PR TITLE
Support multithreaded CPU using single GPU in demo loop

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -309,10 +309,11 @@ if(CELERITAS_BUILD_DEMOS)
       "CELER_DISABLE_PARALLEL=1"
     )
     if(CELERITAS_USE_OpenMP)
+      # TODO: update when OpenMP nested parallelism is enabled
       if(CELERITAS_USE_ROOT)
-        list(APPEND _env "OMP_NUM_THREADS=1,4")
+        list(APPEND _env "OMP_NUM_THREADS=1")
       else()
-        list(APPEND _env "OMP_NUM_THREADS=2,2")
+        list(APPEND _env "OMP_NUM_THREADS=4")
       endif()
     endif()
     if(NOT CELERITAS_CORE_GEO STREQUAL "VecGeom")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -245,14 +245,6 @@ if(CELERITAS_BUILD_DEMOS)
   add_executable(demo-loop ${_demo_loop_src})
   celeritas_target_link_libraries(demo-loop ${_demo_loop_libs})
 
-  if(NOT CELERITAS_USE_OpenMP AND
-      (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-          OR CMAKE_CXX_COMPILER_ID MATCHES "Clang$"))
-    celeritas_target_compile_options(demo-loop
-      PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>
-    )
-  endif()
-
   if(CELERITAS_BUILD_TESTS)
     set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/demo-loop/simple-driver.py")
     set(_gdml_inp "${CMAKE_CURRENT_SOURCE_DIR}/data/simple-cms.gdml")
@@ -311,6 +303,7 @@ if(CELERITAS_BUILD_DEMOS)
     if(CELERITAS_USE_OpenMP)
       # TODO: update when OpenMP nested parallelism is enabled
       if(CELERITAS_USE_ROOT)
+        # TODO: ROOT writer is not currently thread safe
         list(APPEND _env "OMP_NUM_THREADS=1")
       else()
         list(APPEND _env "OMP_NUM_THREADS=4")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -221,6 +221,7 @@ if(CELERITAS_BUILD_DEMOS)
     demo-loop/demo-loop.cc
     demo-loop/RunnerInputIO.json.cc
     demo-loop/Runner.cc
+    demo-loop/RunnerOutput.cc
     demo-loop/Transporter.cc
   )
 
@@ -306,8 +307,14 @@ if(CELERITAS_BUILD_DEMOS)
       "CELER_LOG=debug"
       "CELER_DISABLE_DEVICE=1"
       "CELER_DISABLE_PARALLEL=1"
-      ${_omp_env}
     )
+    if(CELERITAS_USE_OpenMP)
+      if(CELERITAS_USE_ROOT)
+        list(APPEND _env "OMP_NUM_THREADS=1,4")
+      else()
+        list(APPEND _env "OMP_NUM_THREADS=2,2")
+      endif()
+    endif()
     if(NOT CELERITAS_CORE_GEO STREQUAL "VecGeom")
       list(APPEND _env "CELER_DISABLE_VECGEOM=1")
     endif()

--- a/app/demo-loop/Runner.cc
+++ b/app/demo-loop/Runner.cc
@@ -520,6 +520,8 @@ int Runner::get_num_streams(RunnerInput const& inp)
                        << "nonpositive num_streams=" << num_threads);
         return num_threads;
     }
+#else
+    (void)sizeof(inp);
 #endif
     return 1;
 }

--- a/app/demo-loop/Runner.hh
+++ b/app/demo-loop/Runner.hh
@@ -68,19 +68,15 @@ class Runner
     using SPOutputRegistry = std::shared_ptr<celeritas::OutputRegistry>;
     //!@}
 
-    //! ID of the stream and event to be run
-    struct RunStreamEvent
-    {
-        StreamId stream{};
-        EventId event{};
-    };
-
   public:
     // Construct on all threads from a JSON input and shared output manager
     Runner(RunnerInput const& inp, SPOutputRegistry output);
 
     // Run on a single stream/thread, returning the transport result
-    RunnerResult operator()(RunStreamEvent);
+    RunnerResult operator()(StreamId, EventId);
+
+    // Run all events simultaneously on a single stream
+    RunnerResult operator()();
 
     // Number of streams supported
     StreamId::size_type num_streams() const;
@@ -92,7 +88,8 @@ class Runner
     //// TYPES ////
 
     using UPTransporterBase = std::unique_ptr<TransporterBase>;
-    using VecEvent = std::vector<std::vector<celeritas::Primary>>;
+    using VecPrimary = std::vector<celeritas::Primary>;
+    using VecEvent = std::vector<VecPrimary>;
 
     //// DATA ////
 
@@ -114,13 +111,9 @@ class Runner
     void build_diagnostics(RunnerInput const&);
     void build_transporter_input(RunnerInput const&);
     void build_events(RunnerInput const&);
+    int get_num_streams(RunnerInput const&);
+    UPTransporterBase& build_transporter(StreamId);
 };
-
-//---------------------------------------------------------------------------//
-// FREE FUNCTIONS
-//---------------------------------------------------------------------------//
-// Get the number of streams from the OMP_NUM_THREADS environment variable
-int get_num_streams();
 
 //---------------------------------------------------------------------------//
 }  // namespace demo_loop

--- a/app/demo-loop/Runner.hh
+++ b/app/demo-loop/Runner.hh
@@ -66,7 +66,6 @@ class Runner
     using Input = RunnerInput;
     using RunnerResult = TransporterResult;
     using SPOutputRegistry = std::shared_ptr<celeritas::OutputRegistry>;
-    using UPTransporterBase = std::unique_ptr<TransporterBase>;
     //!@}
 
     //! ID of the stream and event to be run
@@ -92,6 +91,7 @@ class Runner
   private:
     //// TYPES ////
 
+    using UPTransporterBase = std::unique_ptr<TransporterBase>;
     using VecEvent = std::vector<std::vector<celeritas::Primary>>;
 
     //// DATA ////

--- a/app/demo-loop/Runner.hh
+++ b/app/demo-loop/Runner.hh
@@ -87,12 +87,19 @@ class Runner
     using SPOutputRegistry = std::shared_ptr<celeritas::OutputRegistry>;
     //!@}
 
+    //! ID of the stream and event to be run
+    struct RunStreamEvent
+    {
+        StreamId stream{};
+        EventId event{};
+    };
+
   public:
     // Construct on all threads from a JSON input and shared output manager
     Runner(RunnerInput const& inp, SPOutputRegistry output);
 
     // Run on a single stream/thread, returning the transport result
-    RunnerResult operator()(StreamId, EventId) const;
+    RunnerResult operator()(RunStreamEvent) const;
 
     // Number of streams supported
     StreamId::size_type num_streams() const;
@@ -125,6 +132,12 @@ class Runner
     void build_transporter_input(RunnerInput const&);
     void build_events(RunnerInput const&);
 };
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+// Get the number of streams from the OMP_NUM_THREADS environment variable
+int get_num_streams();
 
 //---------------------------------------------------------------------------//
 }  // namespace demo_loop

--- a/app/demo-loop/RunnerInput.hh
+++ b/app/demo-loop/RunnerInput.hh
@@ -63,6 +63,7 @@ struct RunnerInput
     real_type secondary_stack_factor{};
     bool use_device{};
     bool sync{};
+    bool merge_events{false};  //!< Run all events at once on a single stream
 
     // Magnetic field vector [* 1/Tesla] and associated field options
     Real3 mag_field{no_field()};

--- a/app/demo-loop/RunnerInputIO.json.cc
+++ b/app/demo-loop/RunnerInputIO.json.cc
@@ -80,6 +80,7 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_REQUIRED(secondary_stack_factor);
     LDIO_LOAD_REQUIRED(use_device);
     LDIO_LOAD_OPTION(sync);
+    LDIO_LOAD_OPTION(merge_events);
 
     LDIO_LOAD_OPTION(mag_field);
     LDIO_LOAD_OPTION(field_options);
@@ -150,6 +151,7 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE_REQUIRED(secondary_stack_factor);
     LDIO_SAVE_REQUIRED(use_device);
     LDIO_SAVE_OPTION(sync);
+    LDIO_SAVE_OPTION(merge_events);
 
     LDIO_SAVE_OPTION(mag_field);
     if (v.mag_field != RunnerInput::no_field())

--- a/app/demo-loop/RunnerOutput.cc
+++ b/app/demo-loop/RunnerOutput.cc
@@ -1,0 +1,86 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file demo-loop/RunnerOutput.cc
+//---------------------------------------------------------------------------//
+#include "RunnerOutput.hh"
+
+#include <utility>
+
+#include "celeritas_config.h"
+#include "corecel/Assert.hh"
+#include "corecel/cont/Range.hh"
+#include "corecel/io/JsonPimpl.hh"
+#include "celeritas/Types.hh"
+
+#if CELERITAS_USE_JSON
+#    include <nlohmann/json.hpp>
+
+#    include "corecel/io/LabelIO.json.hh"
+#endif
+
+namespace demo_loop
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from simulation result.
+ */
+RunnerOutput::RunnerOutput(SimulationResult result)
+    : result_(std::move(result))
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void RunnerOutput::output(JsonPimpl* j) const
+{
+#if CELERITAS_USE_JSON
+    using json = nlohmann::json;
+    using real_type = celeritas::real_type;
+    using MapStrReal = std::unordered_map<std::string, real_type>;
+
+    auto obj = json::object();
+
+    auto active = json::array();
+    auto alive = json::array();
+    auto initializers = json::array();
+    auto step_times = json::array();
+    MapStrReal action_times;
+
+    for (auto const& event : result_.events)
+    {
+        active.push_back(event.active);
+        alive.push_back(event.alive);
+        initializers.push_back(event.initializers);
+        if (!event.step_times.empty())
+        {
+            step_times.push_back(event.step_times);
+        }
+        for (auto& [key, val] : event.action_times)
+        {
+            action_times[key] += val;
+        }
+    }
+    obj["_index"] = {"event", "step"};
+    obj["active"] = std::move(active);
+    obj["alive"] = std::move(alive);
+    obj["initializers"] = std::move(initializers);
+    obj["time"] = {
+        {"steps", std::move(step_times)},
+        {"actions", std::move(action_times)},
+        {"total", result_.total_time},
+        {"setup", result_.setup_time},
+    };
+
+    j->obj = std::move(obj);
+#else
+    (void)sizeof(j);
+#endif
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace demo_loop

--- a/app/demo-loop/RunnerOutput.hh
+++ b/app/demo-loop/RunnerOutput.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file demo-loop/RunnerOutput.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+
+#include "corecel/io/OutputInterface.hh"
+
+#include "Runner.hh"
+
+namespace demo_loop
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Output demo loop results.
+ */
+class RunnerOutput final : public celeritas::OutputInterface
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using JsonPimpl = celeritas::JsonPimpl;
+    //!@}
+
+  public:
+    // Construct from simulation result
+    explicit RunnerOutput(SimulationResult result);
+
+    //! Category of data to write
+    Category category() const final { return Category::result; }
+
+    //! Name of the entry inside the category.
+    std::string label() const final { return "runner"; }
+
+    // Write output to the given JSON object
+    void output(JsonPimpl*) const final;
+
+  private:
+    SimulationResult result_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace demo_loop

--- a/app/demo-loop/Transporter.cc
+++ b/app/demo-loop/Transporter.cc
@@ -36,7 +36,8 @@ TransporterBase::~TransporterBase() = default;
  * Construct from persistent problem data.
  */
 template<MemSpace M>
-Transporter<M>::Transporter(TransporterInput inp) : max_steps_(inp.max_steps)
+Transporter<M>::Transporter(TransporterInput inp)
+    : max_steps_(inp.max_steps), time_stream_(inp.params->max_streams() == 1)
 {
     CELER_EXPECT(inp);
 
@@ -54,10 +55,9 @@ Transporter<M>::Transporter(TransporterInput inp) : max_steps_(inp.max_steps)
  * Transport the input primaries and all secondaries produced.
  */
 template<MemSpace M>
-RunnerResult Transporter<M>::operator()(SpanConstPrimary primaries)
+auto Transporter<M>::operator()(SpanConstPrimary primaries)
+    -> TransporterResult
 {
-    Stopwatch get_transport_time;
-
     // Initialize results
     TransporterResult result;
     auto append_track_counts = [&result](StepperResult const& track_counts) {
@@ -77,7 +77,10 @@ RunnerResult Transporter<M>::operator()(SpanConstPrimary primaries)
     // Copy primaries to device and transport the first step
     auto track_counts = step(primaries);
     append_track_counts(track_counts);
-    result.time.steps.push_back(get_step_time());
+    if (time_stream_)
+    {
+        result.step_times.push_back(get_step_time());
+    }
 
     while (track_counts)
     {
@@ -98,12 +101,16 @@ RunnerResult Transporter<M>::operator()(SpanConstPrimary primaries)
         get_step_time = {};
         track_counts = step();
         append_track_counts(track_counts);
-        result.time.steps.push_back(get_step_time());
+        if (time_stream_)
+        {
+            result.step_times.push_back(get_step_time());
+        }
     }
 
-    // Save kernel timing if host or synchronization is enabled
+    // Save kernel timing if running with a single stream and either on the
+    // host or on the device with synchronization enabled
     auto const& action_seq = step.actions();
-    if (M == MemSpace::host || action_seq.sync())
+    if (time_stream_ && (M == MemSpace::host || action_seq.sync()))
     {
         auto const& action_ptrs = action_seq.actions();
         auto const& times = action_seq.accum_time();
@@ -112,10 +119,9 @@ RunnerResult Transporter<M>::operator()(SpanConstPrimary primaries)
         for (auto i : range(action_ptrs.size()))
         {
             auto&& label = action_ptrs[i]->label();
-            result.time.actions[label] = times[i];
+            result.action_times[label] = times[i];
         }
     }
-    result.time.total = get_transport_time();
     return result;
 }
 

--- a/app/demo-loop/Transporter.hh
+++ b/app/demo-loop/Transporter.hh
@@ -119,7 +119,7 @@ class Transporter final : public TransporterBase
   private:
     std::shared_ptr<celeritas::Stepper<M>> stepper_;
     celeritas::size_type max_steps_;
-    bool time_stream_;
+    celeritas::size_type num_streams_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/demo-loop/Transporter.hh
+++ b/app/demo-loop/Transporter.hh
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -16,8 +18,6 @@
 #include "corecel/cont/Span.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/Types.hh"
-
-#include "Runner.hh"
 
 namespace celeritas
 {
@@ -55,6 +55,25 @@ struct TransporterInput
 
 //---------------------------------------------------------------------------//
 /*!
+ * Tallied result and timing from transporting a single event.
+ */
+struct TransporterResult
+{
+    using real_type = celeritas::real_type;
+    using size_type = celeritas::size_type;
+    using MapStrReal = std::unordered_map<std::string, real_type>;
+    using VecReal = std::vector<real_type>;
+    using VecCount = std::vector<size_type>;
+
+    VecCount initializers;  //!< Num starting track initializers
+    VecCount active;  //!< Num tracks active at beginning of step
+    VecCount alive;  //!< Num living tracks at end of step
+    MapStrReal action_times{};  //!< Accumulated action timing
+    VecReal step_times;  //!< Real time per step
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Interface class for transporting a set of primaries to completion.
  *
  * We might want to change this so that the transport result gets accumulated
@@ -74,7 +93,6 @@ class TransporterBase
     using SpanConstPrimary = celeritas::Span<const celeritas::Primary>;
     using CoreParams = celeritas::CoreParams;
     using ActionId = celeritas::ActionId;
-    using TransporterResult = RunnerResult;
     //!@}
 
   public:

--- a/app/demo-loop/Transporter.hh
+++ b/app/demo-loop/Transporter.hh
@@ -18,7 +18,6 @@
 #include "celeritas/Types.hh"
 
 #include "Runner.hh"
-#include "RunnerInput.hh"
 
 namespace celeritas
 {
@@ -30,9 +29,6 @@ class CoreParams;
 
 namespace demo_loop
 {
-//---------------------------------------------------------------------------//
-struct RunnerInput;
-
 //---------------------------------------------------------------------------//
 //! Input parameters to the transporter.
 struct TransporterInput
@@ -105,6 +101,7 @@ class Transporter final : public TransporterBase
   private:
     std::shared_ptr<celeritas::Stepper<M>> stepper_;
     celeritas::size_type max_steps_;
+    bool time_stream_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -91,6 +91,7 @@ inp = {
     'step_diagnostic_maxsteps': 200,
     'simple_calo': simple_calo,
     'sync': True,
+    'merge_events': False,
     'brem_combined': True,
     'geant_options': geant_options,
 }

--- a/app/demo-loop/simple-driver.py
+++ b/app/demo-loop/simple-driver.py
@@ -134,6 +134,6 @@ with open(outfilename, 'w') as f:
     json.dump(j, f, indent=1)
 print("Results written to", outfilename, file=stderr)
 
-time = j['result']['time'].copy()
+time = j['result']['runner']['time'].copy()
 time.pop('steps')
 print(json.dumps(time, indent=1))

--- a/src/celeritas/user/ActionDiagnostic.cc
+++ b/src/celeritas/user/ActionDiagnostic.cc
@@ -168,7 +168,7 @@ auto ActionDiagnostic::calc_actions_map() const -> MapStringCount
  */
 auto ActionDiagnostic::calc_actions() const -> VecVecCount
 {
-    CELER_EXPECT(*this);
+    CELER_EXPECT(store_);
 
     // Get the raw data accumulated over all host/device streams
     VecCount counts(this->state_size(), 0);
@@ -193,7 +193,7 @@ auto ActionDiagnostic::calc_actions() const -> VecVecCount
  */
 size_type ActionDiagnostic::state_size() const
 {
-    CELER_EXPECT(*this);
+    CELER_EXPECT(store_);
 
     auto const& params = store_.params<MemSpace::host>();
     return params.num_bins * params.num_particles;
@@ -205,7 +205,7 @@ size_type ActionDiagnostic::state_size() const
  */
 void ActionDiagnostic::clear()
 {
-    CELER_EXPECT(*this);
+    CELER_EXPECT(store_);
 
     apply_to_all_streams(
         store_, [](auto& state) { fill(size_type(0), &state.counts); });
@@ -220,12 +220,12 @@ void ActionDiagnostic::clear()
  */
 void ActionDiagnostic::begin_run_impl(CoreParams const& params)
 {
-    if (!*this)
+    if (!store_)
     {
         static std::mutex initialize_mutex;
         std::lock_guard<std::mutex> scoped_lock{initialize_mutex};
 
-        if (!*this)
+        if (!store_)
         {
             action_reg_ = params.action_reg();
             particle_ = params.particle();
@@ -234,8 +234,6 @@ void ActionDiagnostic::begin_run_impl(CoreParams const& params)
             host_params.num_bins = params.action_reg()->num_actions();
             host_params.num_particles = params.particle()->size();
             store_ = {std::move(host_params), params.max_streams()};
-
-            initialized_ = true;
         }
     }
     CELER_ENSURE(store_);

--- a/src/celeritas/user/ActionDiagnostic.hh
+++ b/src/celeritas/user/ActionDiagnostic.hh
@@ -85,9 +85,6 @@ class ActionDiagnostic final : public ExplicitActionInterface,
     void output(JsonPimpl*) const final;
     //!@}
 
-    // Whether the shared params data has been initialized
-    explicit operator bool() const { return initialized_; }
-
     // Get the nonzero diagnostic results accumulated over all streams
     MapStringCount calc_actions_map() const;
 
@@ -104,7 +101,6 @@ class ActionDiagnostic final : public ExplicitActionInterface,
     using StoreT = StreamStore<ParticleTallyParamsData, ParticleTallyStateData>;
 
     ActionId id_;
-    bool initialized_{false};
 
     WPConstActionRegistry action_reg_;
     WPConstParticle particle_;

--- a/src/celeritas/user/ActionDiagnostic.hh
+++ b/src/celeritas/user/ActionDiagnostic.hh
@@ -85,6 +85,9 @@ class ActionDiagnostic final : public ExplicitActionInterface,
     void output(JsonPimpl*) const final;
     //!@}
 
+    // Whether the shared params data has been initialized
+    explicit operator bool() const { return initialized_; }
+
     // Get the nonzero diagnostic results accumulated over all streams
     MapStringCount calc_actions_map() const;
 
@@ -101,6 +104,7 @@ class ActionDiagnostic final : public ExplicitActionInterface,
     using StoreT = StreamStore<ParticleTallyParamsData, ParticleTallyStateData>;
 
     ActionId id_;
+    bool initialized_{false};
 
     WPConstActionRegistry action_reg_;
     WPConstParticle particle_;


### PR DESCRIPTION
This adds OpenMP multithreading to a loop over events in the demo loop, with each event processed by a separate thread and running on a single GPU (see #553). For multithreaded CPU-only runs, nested parallel regions are disabled until we can understand why the performance there is so poor. The GPU performance is definitely not as good as running all events simultaneously on a single thread (about a factor of two slower for cms2018+field+msc-vecgeom-gpu), but we should get some of that back when we're able to launch kernels on different CUDA streams.