### PR TITLE
Remove next-distance caching from geometry and add limited-distance safety search

### DIFF
--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -130,11 +130,6 @@ void log_state(Logger::Message& msg,
         msg << "\n- Surface ID: " << kce.surface();
     }
 
-    if (core_params && kce.surface())
-    {
-        msg << "\n- Next surface: " << kce.next_surface();
-    }
-
     msg << "\n- Step counter: " << kce.num_steps();
 }
 

--- a/src/celeritas/em/msc/UrbanMsc.hh
+++ b/src/celeritas/em/msc/UrbanMsc.hh
@@ -111,6 +111,7 @@ UrbanMsc::limit_step(CoreTrackView const& track, StepLimit* step_limit)
     // Sample multiple scattering step length
     auto msc_step = [&] {
         auto par = track.make_particle_view();
+        real_type const safety = (geo.is_on_boundary() ? 0 : geo.find_safety());
         detail::UrbanMscHelper msc_helper(msc_params_, par, phys);
         detail::UrbanMscStepLimit calc_limit(msc_params_,
                                              msc_helper,
@@ -118,7 +119,7 @@ UrbanMsc::limit_step(CoreTrackView const& track, StepLimit* step_limit)
                                              &phys,
                                              phys.material_id(),
                                              geo.is_on_boundary(),
-                                             geo.find_safety(),
+                                             safety,
                                              step_limit->step);
 
         auto rng = track.make_rng_engine();

--- a/src/celeritas/em/msc/detail/UrbanMscScatter.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscScatter.hh
@@ -162,6 +162,7 @@ UrbanMscScatter::UrbanMscScatter(UrbanMscRef const& shared,
     CELER_EXPECT(true_path_ >= geom_path_);
     CELER_EXPECT(limit_min_ >= UrbanMscParameters::limit_min_fix()
                  || !is_displaced_);
+    CELER_EXPECT(!is_displaced_ || !geometry->is_on_boundary());
 
     skip_sampling_ = [this, &helper, &physics] {
         if (true_path_ == physics.dedx_range())

--- a/src/celeritas/em/msc/detail/UrbanMscStepLimit.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscStepLimit.hh
@@ -145,6 +145,7 @@ UrbanMscStepLimit::UrbanMscStepLimit(UrbanMscRef const& shared,
     {
         MscRange new_range;
         // Initialize MSC range cache on the first step in a volume
+        // TODO for hadrons/muons: this value is hard-coded for electrons
         new_range.range_fact = shared.params.range_fact;
         // XXX the 1 MFP limitation is applied to the *geo* step, not the true
         // step, so this isn't quite right (See UrbanMsc.hh)

--- a/src/celeritas/ext/VecgeomData.hh
+++ b/src/celeritas/ext/VecgeomData.hh
@@ -78,7 +78,6 @@ struct VecgeomStateData
     // Collections
     Items<Real3> pos;
     Items<Real3> dir;
-    Items<real_type> next_step;
 
     // Wrapper for NavStatePool, vector, or void*
     detail::VecgeomNavCollection<W, M> vgstate;
@@ -89,8 +88,8 @@ struct VecgeomStateData
     //! True if sizes are consistent and states are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return this->size() > 0 && dir.size() == this->size()
-               && next_step.size() == this->size() && vgstate && vgnext;
+        return this->size() > 0 && dir.size() == this->size() && vgstate
+               && vgnext;
     }
 
     //! State size
@@ -106,7 +105,6 @@ struct VecgeomStateData
         CELER_EXPECT(other);
         pos = other.pos;
         dir = other.dir;
-        next_step = other.next_step;
         vgstate = other.vgstate;
         vgnext = other.vgnext;
         return *this;
@@ -128,7 +126,6 @@ void resize(VecgeomStateData<Ownership::value, M>* data,
 
     resize(&data->pos, size);
     resize(&data->dir, size);
-    resize(&data->next_step, size);
     data->vgstate.resize(params.max_depth, size);
     data->vgnext.resize(params.max_depth, size);
 

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -383,7 +383,7 @@ CELER_FUNCTION void VecgeomTrackView::move_to_boundary()
     // Move next step
     axpy(next_step_, dir_, &pos_);
     next_step_ = 0;
-    vgstate_.SetBoundaryState(true);  // XXX
+    vgstate_.SetBoundaryState(true);
 
     CELER_ENSURE(this->is_on_boundary());
 }

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -106,8 +106,11 @@ class VecgeomTrackView
     // Find the distance to the next boundary, up to and including a step
     inline CELER_FUNCTION Propagation find_next_step(real_type max_step);
 
-    // Find the safety at the current position
+    // Find the safety at the current position (infinite max)
     inline CELER_FUNCTION real_type find_safety();
+
+    // Find the safety at the current position up to a maximum step distance
+    inline CELER_FUNCTION real_type find_safety(real_type max_step);
 
     // Move to the boundary in preparation for crossing it
     inline CELER_FUNCTION void move_to_boundary();
@@ -347,9 +350,23 @@ CELER_FUNCTION Propagation VecgeomTrackView::find_next_step(real_type max_step)
  */
 CELER_FUNCTION real_type VecgeomTrackView::find_safety()
 {
+    return this->find_safety(vecgeom::kInfLength);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Find the safety at the current position up to a maximum distance.
+ *
+ * The safety within a step is only needed up to the end of the physics step
+ * length.
+ */
+CELER_FUNCTION real_type VecgeomTrackView::find_safety(real_type max_radius)
+{
     CELER_EXPECT(!this->is_outside());
+    CELER_EXPECT(!this->is_on_boundary());
+    CELER_EXPECT(max_radius > 0);
     real_type safety = detail::BVHNavigator::ComputeSafety(
-        detail::to_vector(this->pos()), vgstate_);
+        detail::to_vector(this->pos()), vgstate_, max_radius);
 
     // Since the reported "safety" is negative if we've moved slightly beyond
     // the boundary of a solid without crossing it, we must clamp to zero.

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -51,8 +51,8 @@ class VecgeomTrackView
     //! Helper struct for initializing from an existing geometry state
     struct DetailedInitializer
     {
-        VecgeomTrackView& other;  //!< Existing geometry
-        Real3 dir;  //!< New direction
+        VecgeomTrackView const& other;  //!< Existing geometry
+        Real3 const& dir;  //!< New direction
     };
 
   public:

--- a/src/celeritas/ext/detail/BVHNavigator.hh
+++ b/src/celeritas/ext/detail/BVHNavigator.hh
@@ -211,7 +211,8 @@ class BVHNavigator
     // Computes the isotropic safety from the globalpoint.
     CELER_FUNCTION static double
     ComputeSafety(Vector3D const& globalpoint,
-                  vecgeom::NavigationState const& state)
+                  vecgeom::NavigationState const& state,
+                  Precision safety)
     {
         VPlacedVolumePtr_t pvol = state.Top();
         vecgeom::Transformation3D m;
@@ -219,7 +220,7 @@ class BVHNavigator
         Vector3D localpoint = m.Transform(globalpoint);
 
         // need to calc DistanceToOut first
-        Precision safety = pvol->SafetyToOut(localpoint);
+        safety = min(safety, pvol->SafetyToOut(localpoint));
 
         if (safety > 0 && pvol->GetDaughters().size() > 0)
         {

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -100,7 +100,6 @@ void KernelContextException::output(JsonPimpl* json) const
         j["dir"] = dir_;
         KCE_INSERT_IF_VALID(volume);
         KCE_INSERT_IF_VALID(surface);
-        KCE_INSERT_IF_VALID(next_surface);
     }
     if (!label_.empty())
     {
@@ -138,7 +137,6 @@ void KernelContextException::initialize(CoreTrackView const& core)
             dir_ = geo.dir();
             volume_ = geo.volume_id();
             surface_ = geo.surface_id();
-            next_surface_ = geo.next_surface_id();
         }
     }
     {

--- a/src/celeritas/global/KernelContextException.hh
+++ b/src/celeritas/global/KernelContextException.hh
@@ -84,8 +84,6 @@ class KernelContextException : public RichContextException
     VolumeId volume() const { return volume_; }
     //! Surface
     SurfaceId surface() const { return surface_; }
-    //! Next surface
-    SurfaceId next_surface() const { return next_surface_; }
     //!@}
 
     //! Label of the kernel that died
@@ -104,7 +102,6 @@ class KernelContextException : public RichContextException
     Real3 dir_;
     VolumeId volume_;
     SurfaceId surface_;
-    SurfaceId next_surface_;
 
     std::string label_;
     std::string what_;

--- a/src/celeritas/track/detail/InitTracksLauncher.hh
+++ b/src/celeritas/track/detail/InitTracksLauncher.hh
@@ -115,8 +115,9 @@ CELER_FUNCTION void InitTracksLauncher::operator()(ThreadId tid) const
             // performance
             TrackSlotId parent_id = data.parents[TrackSlotId{
                 index_before(data.parents.size(), tid)}];
-            GeoTrackView parent(params->geometry, state->geometry, parent_id);
-            geo = GeoTrackView::DetailedInitializer{parent, init.geo.dir};
+            GeoTrackView const parent_geo(
+                params->geometry, state->geometry, parent_id);
+            geo = GeoTrackView::DetailedInitializer{parent_geo, init.geo.dir};
         }
         else
         {

--- a/src/celeritas/track/detail/ProcessSecondariesLauncher.hh
+++ b/src/celeritas/track/detail/ProcessSecondariesLauncher.hh
@@ -95,10 +95,10 @@ ProcessSecondariesLauncher::operator()(TrackSlotId tid) const
 
     // Save the parent ID since it will be overwritten if a secondary is
     // initialized in this slot
-    const TrackId parent_id{sim.track_id()};
+    TrackId const parent_id{sim.track_id()};
 
-    PhysicsStepView phys(params->physics, state->physics, tid);
-    for (auto const& secondary : phys.secondaries())
+    PhysicsStepView const phys_step(params->physics, state->physics, tid);
+    for (auto const& secondary : phys_step.secondaries())
     {
         if (secondary)
         {

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -306,10 +306,6 @@ struct OrangeStateData
     StateItems<LevelId> level;
     StateItems<LevelId> surface_level;
 
-    StateItems<real_type> next_step;
-    StateItems<detail::OnSurface> next_surface;
-    StateItems<LevelId> next_surface_level;
-
     // Dimensions {num_tracks, max_level}
     Items<Real3> pos;
     Items<Real3> dir;
@@ -340,9 +336,6 @@ struct OrangeStateData
         // clang-format off
         return !level.empty()
             && surface_level.size() == level.size()
-            && next_step.size() == level.size()
-            && next_surface.size() == level.size()
-            && next_surface_level.size() == level.size()
             && !pos.empty()
             && dir.size() == pos.size()
             && vol.size() == pos.size()
@@ -368,9 +361,6 @@ struct OrangeStateData
         CELER_EXPECT(other);
         level = other.level;
         surface_level = other.surface_level;
-        next_step = other.next_step;
-        next_surface = other.next_surface;
-        next_surface_level = other.next_surface_level;
         pos = other.pos;
         dir = other.dir;
         vol = other.vol;
@@ -404,10 +394,6 @@ inline void resize(OrangeStateData<Ownership::value, M>* data,
 
     resize(&data->level, num_tracks);
     resize(&data->surface_level, num_tracks);
-
-    resize(&data->next_step, num_tracks);
-    resize(&data->next_surface, num_tracks);
-    resize(&data->next_surface_level, num_tracks);
 
     data->max_level = params.scalars.max_level;
     auto const size = data->max_level * num_tracks;

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -64,7 +64,7 @@ class OrangeTrackView
     };
 
   public:
-    // Construct from params and state params
+    // Construct from params and state
     inline CELER_FUNCTION OrangeTrackView(ParamsRef const& params,
                                           StateRef const& states,
                                           TrackSlotId tid);
@@ -489,6 +489,7 @@ CELER_FUNCTION void OrangeTrackView::move_to_boundary()
     lsa.sense() = this->next_surface().unchecked_sense();
 
     this->clear_next_step();
+    CELER_ENSURE(this->is_on_boundary());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -103,6 +103,9 @@ class OrangeTrackView
     // Find the distance to the nearest boundary in any direction
     inline CELER_FUNCTION real_type find_safety();
 
+    // Find the distance to the nearest nearby boundary in any direction
+    inline CELER_FUNCTION real_type find_safety(real_type max_step);
+
     // Move to the boundary in preparation for crossing it
     inline CELER_FUNCTION void move_to_boundary();
 
@@ -833,17 +836,24 @@ OrangeTrackView::find_next_step_impl(detail::Intersection isect)
  */
 CELER_FUNCTION real_type OrangeTrackView::find_safety()
 {
+    CELER_EXPECT(!this->is_on_boundary());
     auto lsa = this->make_lsa();
-
-    if (lsa.surf())
-    {
-        // Zero distance to boundary on a surface
-        return real_type{0};
-    }
 
     CELER_ASSERT(lsa.universe() == UniverseId{0});
     auto tracker = this->make_tracker(lsa.universe());
     return tracker.safety(lsa.pos(), lsa.vol());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Find the distance to the nearest nearby boundary.
+ *
+ * Since we currently support only "simple" safety distances, we can't
+ * eliminate anything by checking only nearby surfaces.
+ */
+CELER_FUNCTION real_type OrangeTrackView::find_safety(real_type)
+{
+    return this->find_safety();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -59,8 +59,8 @@ class OrangeTrackView
     //! Helper struct for initializing from an existing geometry state
     struct DetailedInitializer
     {
-        OrangeTrackView& other;  //!< Existing geometry
-        Real3 dir;  //!< New direction
+        OrangeTrackView const& other;  //!< Existing geometry
+        Real3 const& dir;  //!< New direction
     };
 
   public:
@@ -289,15 +289,22 @@ OrangeTrackView& OrangeTrackView::operator=(DetailedInitializer const& init)
 
     for (auto i : range(states_.level[init.other.track_slot_] + 1))
     {
-        // Copy all data accessed via LSA
+        // Copy all data accessed via LSA except for direction
         auto lsa = this->make_lsa(LevelId{i});
-        lsa = init.other.make_lsa(LevelId{i});
+        if (this != &init.other)
+        {
+            lsa = init.other.make_lsa(LevelId{i});
+        }
+        // TODO: apply rotation when we use Transform instead of Translate
         lsa.dir() = init.dir;
     }
 
-    // Copy init track's position but update the direction
-    this->level() = states_.level[init.other.track_slot_];
-    this->surface_level() = states_.surface_level[init.other.track_slot_];
+    if (this != &init.other)
+    {
+        // Copy init track's position but update the direction
+        this->level() = states_.level[init.other.track_slot_];
+        this->surface_level() = states_.surface_level[init.other.track_slot_];
+    }
 
     // Clear step and surface info
     this->clear_next_step();

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -313,6 +313,7 @@ TEST_F(FourLevelsTest, safety)
 {
     auto geo = this->make_geo_track_view();
     std::vector<real_type> safeties;
+    std::vector<real_type> lim_safeties;
 
     for (auto i : range(11))
     {
@@ -323,6 +324,7 @@ TEST_F(FourLevelsTest, safety)
         {
             geo.find_next_step();
             safeties.push_back(geo.find_safety());
+            lim_safeties.push_back(geo.find_safety(1.5));
         }
     }
 
@@ -338,6 +340,10 @@ TEST_F(FourLevelsTest, safety)
                                                1.1,
                                                3.1};
     EXPECT_VEC_SOFT_EQ(expected_safeties, safeties);
+
+    static double const expected_lim_safeties[]
+        = {1.5, 0.9, 0.1, 1.5, 1.5, 1.5, 1.3626933041054, 1.5, 0.1, 1.1, 1.5};
+    EXPECT_VEC_SOFT_EQ(expected_lim_safeties, lim_safeties);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -105,48 +105,49 @@ TEST_F(FourLevelsTest, accessors)
 
 TEST_F(FourLevelsTest, detailed_track)
 {
-    auto geo = this->make_geo_track_view();
-    geo = GeoTrackInitializer{{-10, -10, -10}, {1, 0, 0}};
-    ASSERT_FALSE(geo.is_outside());
-    EXPECT_EQ(VolumeId{0}, geo.volume_id());
-    EXPECT_FALSE(geo.is_on_boundary());
+    {
+        SCOPED_TRACE("rightward along corner");
+        auto geo = this->make_geo_track_view({-10, -10, -10}, {1, 0, 0});
+        ASSERT_FALSE(geo.is_outside());
+        EXPECT_EQ(VolumeId{0}, geo.volume_id());
+        EXPECT_FALSE(geo.is_on_boundary());
 
-    // Check for surfaces up to a distance of 4 units away
-    auto next = geo.find_next_step(4.0);
-    EXPECT_SOFT_EQ(4.0, next.distance);
-    EXPECT_FALSE(next.boundary);
-    next = geo.find_next_step(4.0);
-    EXPECT_SOFT_EQ(4.0, next.distance);
-    EXPECT_FALSE(next.boundary);
-    geo.move_internal(3.5);
-    EXPECT_FALSE(geo.is_on_boundary());
+        // Check for surfaces up to a distance of 4 units away
+        auto next = geo.find_next_step(4.0);
+        EXPECT_SOFT_EQ(4.0, next.distance);
+        EXPECT_FALSE(next.boundary);
+        next = geo.find_next_step(4.0);
+        EXPECT_SOFT_EQ(4.0, next.distance);
+        EXPECT_FALSE(next.boundary);
+        geo.move_internal(3.5);
+        EXPECT_FALSE(geo.is_on_boundary());
 
-    // Find one a bit further, then cross it
-    next = geo.find_next_step(4.0);
-    EXPECT_SOFT_EQ(1.5, next.distance);
-    EXPECT_TRUE(next.boundary);
-    geo.move_to_boundary();
-    EXPECT_EQ(VolumeId{0}, geo.volume_id());
-    geo.cross_boundary();
-    EXPECT_EQ(VolumeId{1}, geo.volume_id());
-    EXPECT_TRUE(geo.is_on_boundary());
+        // Find one a bit further, then cross it
+        next = geo.find_next_step(4.0);
+        EXPECT_SOFT_EQ(1.5, next.distance);
+        EXPECT_TRUE(next.boundary);
+        geo.move_to_boundary();
+        EXPECT_EQ(VolumeId{0}, geo.volume_id());
+        geo.cross_boundary();
+        EXPECT_EQ(VolumeId{1}, geo.volume_id());
+        EXPECT_TRUE(geo.is_on_boundary());
 
-    // Find the next boundary and make sure that nearer distances aren't
-    // accepted
-    next = geo.find_next_step();
-    EXPECT_SOFT_EQ(1.0, next.distance);
-    EXPECT_TRUE(next.boundary);
-    EXPECT_TRUE(geo.is_on_boundary());
-    next = geo.find_next_step(0.5);
-    EXPECT_SOFT_EQ(0.5, next.distance);
-    EXPECT_FALSE(next.boundary);
-
+        // Find the next boundary and make sure that nearer distances aren't
+        // accepted
+        next = geo.find_next_step();
+        EXPECT_SOFT_EQ(1.0, next.distance);
+        EXPECT_TRUE(next.boundary);
+        EXPECT_TRUE(geo.is_on_boundary());
+        next = geo.find_next_step(0.5);
+        EXPECT_SOFT_EQ(0.5, next.distance);
+        EXPECT_FALSE(next.boundary);
+    }
     {
         SCOPED_TRACE("outside in");
-        geo = GeoTrackInitializer{{-25, 6.5, 6.5}, {1, 0, 0}};
+        auto geo = this->make_geo_track_view({-25, 6.5, 6.5}, {1, 0, 0});
         EXPECT_TRUE(geo.is_outside());
 
-        next = geo.find_next_step();
+        auto next = geo.find_next_step();
         EXPECT_SOFT_EQ(1.0, next.distance);
         EXPECT_TRUE(next.boundary);
 
@@ -158,11 +159,11 @@ TEST_F(FourLevelsTest, detailed_track)
     }
     {
         SCOPED_TRACE("inside out");
-        geo = GeoTrackInitializer{{-23.5, 6.5, 6.5}, {-1, 0, 0}};
+        auto geo = this->make_geo_track_view({-23.5, 6.5, 6.5}, {-1, 0, 0});
         EXPECT_FALSE(geo.is_outside());
         EXPECT_EQ(VolumeId{3}, geo.volume_id());
 
-        next = geo.find_next_step(2);
+        auto next = geo.find_next_step(2);
         EXPECT_SOFT_EQ(0.5, next.distance);
         EXPECT_TRUE(next.boundary);
 
@@ -464,7 +465,7 @@ TEST_F(SolidsTest, trace)
         static real_type const expected_distances[] = {20,
                                                        95,
                                                        20,
-                                                       115,
+                                                       125,
                                                        40,
                                                        60,
                                                        50,
@@ -481,13 +482,13 @@ TEST_F(SolidsTest, trace)
         static real_type const expected_hw_safety[] = {0,
                                                        45.496748548005,
                                                        0,
-                                                       41.247975226723,
+                                                       44.8347556812201,
                                                        13.934134186943,
                                                        30,
                                                        25,
                                                        36.240004604773,
                                                        25,
-                                                       41.204388797207,
+                                                       41.2043887972073,
                                                        14.92555785315,
                                                        42.910442345001,
                                                        18.741024106017,
@@ -570,6 +571,8 @@ TEST_F(SolidsTest, trace)
                                                        "World",
                                                        "genPocone1",
                                                        "World",
+                                                       "genPocone1",
+                                                       "World",
                                                        "elltube1",
                                                        "World"};
         EXPECT_VEC_EQ(expected_volumes, result.volumes);
@@ -578,13 +581,15 @@ TEST_F(SolidsTest, trace)
                                                        80,
                                                        68.125,
                                                        33.75,
-                                                       57.5193323464911,
-                                                       50.6056676535089,
+                                                       57.519332346491,
+                                                       50.605667653509,
                                                        85,
                                                        80,
                                                        40,
                                                        45,
-                                                       105,
+                                                       127.5,
+                                                       3.7499999999998,
+                                                       60,
                                                        40,
                                                        205};
         EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
@@ -599,7 +604,9 @@ TEST_F(SolidsTest, trace)
                                                        40,
                                                        19.156525704423,
                                                        0,
-                                                       7.1836971391586,
+                                                       0,
+                                                       0,
+                                                       28.734788556635,
                                                        20,
                                                        75};
         EXPECT_VEC_SOFT_EQ(expected_hw_safety, result.halfway_safeties);
@@ -804,7 +811,7 @@ TEST_F(SolidsGeantTest, trace)
         static real_type const expected_distances[] = {20,
                                                        95,
                                                        20,
-                                                       115,
+                                                       125,
                                                        40,
                                                        60,
                                                        50,
@@ -874,6 +881,8 @@ TEST_F(SolidsGeantTest, trace)
                                                        "World",
                                                        "genPocone1",
                                                        "World",
+                                                       "genPocone1",
+                                                       "World",
                                                        "elltube1",
                                                        "World"};
         EXPECT_VEC_EQ(expected_volumes, result.volumes);
@@ -882,13 +891,15 @@ TEST_F(SolidsGeantTest, trace)
                                                        80,
                                                        68.125,
                                                        33.75,
-                                                       57.5193323464911,
-                                                       50.6056676535089,
+                                                       57.519332346491,
+                                                       50.605667653509,
                                                        85,
                                                        80,
                                                        40,
                                                        45,
-                                                       105,
+                                                       127.5,
+                                                       3.7499999999998,
+                                                       60,
                                                        40,
                                                        205};
         EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);

--- a/test/celeritas/geo/HeuristicGeoLauncher.hh
+++ b/test/celeritas/geo/HeuristicGeoLauncher.hh
@@ -81,6 +81,7 @@ CELER_FUNCTION void HeuristicGeoLauncher::operator()(TrackSlotId tid) const
 
     // Calculate latest safety and truncate estimated step length (MSC-like)
     // half the time
+    if (!geo.is_on_boundary())
     {
         real_type safety = geo.find_safety();
         constexpr real_type safety_tol = 0.01;

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -144,7 +144,6 @@ TEST_F(KernelContextExceptionTest, typical)
             EXPECT_EQ(VolumeId{2}, e.volume());
             EXPECT_EQ(SurfaceId{11}, e.surface());
         }
-        EXPECT_EQ(SurfaceId{}, e.next_surface());
         if (CELERITAS_USE_JSON && !CELERITAS_USE_VECGEOM)
         {
             std::stringstream ss;

--- a/test/celeritas/user/Diagnostic.test.cc
+++ b/test/celeritas/user/Diagnostic.test.cc
@@ -83,10 +83,10 @@ TEST_F(TestEm3DiagnosticTest, host)
         && std::find(result.nonzero_action_keys.begin(),
                      result.nonzero_action_keys.end(),
                      "geo-propagation-limit e+")
-               != result.nonzero_action_keys)
+               != result.nonzero_action_keys.end())
     {
-        SKIP_TEST() << "VecGeom seems to have an edge case where tracks get "
-                       "stuck on some builds but not others";
+        GTEST_SKIP() << "VecGeom seems to have an edge case where tracks get "
+                        "stuck on some builds but not others";
     }
 
     // Check action diagnostic results

--- a/test/celeritas/user/Diagnostic.test.cc
+++ b/test/celeritas/user/Diagnostic.test.cc
@@ -79,6 +79,16 @@ TEST_F(TestEm3DiagnosticTest, host)
 {
     auto result = this->run<MemSpace::host>(256, 32);
 
+    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM
+        && std::find(result.nonzero_action_keys.begin(),
+                     result.nonzero_action_keys.end(),
+                     "geo-propagation-limit e+")
+               != result.nonzero_action_keys)
+    {
+        SKIP_TEST() << "VecGeom seems to have an edge case where tracks get "
+                       "stuck on some builds but not others";
+    }
+
     // Check action diagnostic results
     static char const* const expected_nonzero_action_keys[]
         = {"annihil-2-gamma e+",
@@ -122,7 +132,6 @@ TEST_F(TestEm3DiagnosticTest, host)
         EXPECT_VEC_EQ(expected_nonzero_action_counts,
                       result.nonzero_action_counts);
 
-        // ORANGE results are slightly different
         static size_type const expected_steps[]
             = {0u, 316u, 209u, 91u, 33u, 35u, 21u, 20u, 7u,  11u, 10u,
                1u, 2u,   3u,   3u,  1u,  1u,  1u,  0u,  0u,  1u,  1u,

--- a/test/celeritas/user/Diagnostic.test.cc
+++ b/test/celeritas/user/Diagnostic.test.cc
@@ -80,119 +80,57 @@ TEST_F(TestEm3DiagnosticTest, host)
     auto result = this->run<MemSpace::host>(256, 32);
 
     // Check action diagnostic results
-    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM)
-    {
-        static char const* const expected_nonzero_action_keys[]
-            = {"annihil-2-gamma e+",
-               "brems-combined e+",
-               "brems-combined e-",
-               "conv-bethe-heitler gamma",
-               "eloss-range e+",
-               "eloss-range e-",
-               "geo-boundary e+",
-               "geo-boundary e-",
-               "geo-boundary gamma",
-               "geo-propagation-limit e+",
-               "geo-propagation-limit e-",
-               "ioni-moller-bhabha e+",
-               "ioni-moller-bhabha e-",
-               "msc-range e+",
-               "msc-range e-",
-               "photoel-livermore gamma",
-               "physics-integral-rejected e+",
-               "physics-integral-rejected e-",
-               "scat-klein-nishina gamma"};
-        EXPECT_VEC_EQ(expected_nonzero_action_keys, result.nonzero_action_keys);
+    static char const* const expected_nonzero_action_keys[]
+        = {"annihil-2-gamma e+",
+           "brems-combined e+",
+           "brems-combined e-",
+           "conv-bethe-heitler gamma",
+           "eloss-range e+",
+           "eloss-range e-",
+           "geo-boundary e+",
+           "geo-boundary e-",
+           "geo-boundary gamma",
+           "ioni-moller-bhabha e+",
+           "ioni-moller-bhabha e-",
+           "msc-range e+",
+           "msc-range e-",
+           "photoel-livermore gamma",
+           "physics-integral-rejected e+",
+           "physics-integral-rejected e-",
+           "scat-klein-nishina gamma"};
+    EXPECT_VEC_EQ(expected_nonzero_action_keys, result.nonzero_action_keys);
 
-        if (this->is_ci_build())
-        {
-            static size_type const expected_nonzero_action_counts[] = {127u,
-                                                                       386u,
-                                                                       467u,
-                                                                       19u,
-                                                                       55u,
-                                                                       1019u,
-                                                                       284u,
-                                                                       289u,
-                                                                       1769u,
-                                                                       10u,
-                                                                       15u,
-                                                                       14u,
-                                                                       20u,
-                                                                       1168u,
-                                                                       1580u,
-                                                                       575u,
-                                                                       90u,
-                                                                       22u,
-                                                                       283u};
-            EXPECT_VEC_EQ(expected_nonzero_action_counts,
-                          result.nonzero_action_counts);
-
-            static size_type const expected_steps[]
-                = {0u, 327u, 196u, 81u, 41u, 29u, 26u, 17u, 13u, 6u, 7u,
-                   1u, 3u,   4u,   2u,  1u,  0u,  2u,  1u,  0u,  1u, 1u,
-                   0u, 737u, 43u,  17u, 9u,  11u, 7u,  5u,  9u,  5u, 4u,
-                   9u, 11u,  9u,   10u, 14u, 4u,  5u,  2u,  2u,  4u, 22u,
-                   0u, 0u,   5u,   2u,  1u,  4u,  5u,  8u,  4u,  7u, 7u,
-                   7u, 7u,   13u,  8u,  7u,  3u,  2u,  5u,  6u,  1u, 27u};
-            EXPECT_VEC_EQ(expected_steps, result.steps);
-        }
-    }
-    else
+    if (this->is_ci_build())
     {
+        static size_type const expected_nonzero_action_counts[] = {124u,
+                                                                   391u,
+                                                                   476u,
+                                                                   19u,
+                                                                   59u,
+                                                                   1010u,
+                                                                   274u,
+                                                                   281u,
+                                                                   1813u,
+                                                                   15u,
+                                                                   19u,
+                                                                   1186u,
+                                                                   1549u,
+                                                                   567u,
+                                                                   87u,
+                                                                   24u,
+                                                                   298u};
+        EXPECT_VEC_EQ(expected_nonzero_action_counts,
+                      result.nonzero_action_counts);
+
         // ORANGE results are slightly different
-        static char const* const expected_nonzero_action_keys[]
-            = {"annihil-2-gamma e+",
-               "brems-combined e+",
-               "brems-combined e-",
-               "conv-bethe-heitler gamma",
-               "eloss-range e+",
-               "eloss-range e-",
-               "geo-boundary e+",
-               "geo-boundary e-",
-               "geo-boundary gamma",
-               "ioni-moller-bhabha e+",
-               "ioni-moller-bhabha e-",
-               "msc-range e+",
-               "msc-range e-",
-               "photoel-livermore gamma",
-               "physics-integral-rejected e+",
-               "physics-integral-rejected e-",
-               "scat-klein-nishina gamma"};
-        EXPECT_VEC_EQ(expected_nonzero_action_keys, result.nonzero_action_keys);
-
-        if (this->is_ci_build())
-        {
-            static size_type const expected_nonzero_action_counts[] = {124u,
-                                                                       391u,
-                                                                       476u,
-                                                                       19u,
-                                                                       59u,
-                                                                       1010u,
-                                                                       274u,
-                                                                       281u,
-                                                                       1813u,
-                                                                       15u,
-                                                                       19u,
-                                                                       1186u,
-                                                                       1549u,
-                                                                       567u,
-                                                                       87u,
-                                                                       24u,
-                                                                       298u};
-            EXPECT_VEC_EQ(expected_nonzero_action_counts,
-                          result.nonzero_action_counts);
-
-            // ORANGE results are slightly different
-            static size_type const expected_steps[]
-                = {0u, 316u, 209u, 91u, 33u, 35u, 21u, 20u, 7u,  11u, 10u,
-                   1u, 2u,   3u,   3u,  1u,  1u,  1u,  0u,  0u,  1u,  1u,
-                   0u, 742u, 39u,  11u, 7u,  10u, 6u,  10u, 11u, 5u,  3u,
-                   7u, 11u,  11u,  10u, 14u, 4u,  4u,  3u,  3u,  3u,  23u,
-                   0u, 2u,   2u,   1u,  1u,  6u,  5u,  7u,  4u,  6u,  8u,
-                   7u, 7u,   13u,  8u,  7u,  3u,  2u,  5u,  6u,  2u,  24u};
-            EXPECT_VEC_EQ(expected_steps, result.steps);
-        }
+        static size_type const expected_steps[]
+            = {0u, 316u, 209u, 91u, 33u, 35u, 21u, 20u, 7u,  11u, 10u,
+               1u, 2u,   3u,   3u,  1u,  1u,  1u,  0u,  0u,  1u,  1u,
+               0u, 742u, 39u,  11u, 7u,  10u, 6u,  10u, 11u, 5u,  3u,
+               7u, 11u,  11u,  10u, 14u, 4u,  4u,  3u,  3u,  3u,  23u,
+               0u, 2u,   2u,   1u,  1u,  6u,  5u,  7u,  4u,  6u,  8u,
+               7u, 7u,   13u,  8u,  7u,  3u,  2u,  5u,  6u,  2u,  24u};
+        EXPECT_VEC_EQ(expected_steps, result.steps);
     }
 }
 

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -610,18 +610,14 @@ TEST_F(UniversesTest, cross_into_daughter_non_coincident)
 
     auto next = geo.find_next_step();
     EXPECT_SOFT_EQ(1, next.distance);
-    EXPECT_EQ("inner_a.my",
-              this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("johnny", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({2, -4, 1}), geo.pos());
 
     // Cross universe boundary
     geo.cross_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("c", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({2, -4, 1}), geo.pos());
@@ -629,11 +625,8 @@ TEST_F(UniversesTest, cross_into_daughter_non_coincident)
     // Make sure we can take another step after crossing
     next = geo.find_next_step();
     EXPECT_SOFT_EQ(1, next.distance);
-    EXPECT_EQ("alpha.my",
-              this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("alpha.my", this->params().id_to_label(geo.surface_id()).name);
 }
 
@@ -646,17 +639,13 @@ TEST_F(UniversesTest, cross_into_parent_non_coincident)
 
     auto next = geo.find_next_step();
     EXPECT_SOFT_EQ(0.5, next.distance);
-    EXPECT_EQ("inner_a.my",
-              this->params().id_to_label(geo.next_surface_id()).name);
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("c", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({2, -4, 1}), geo.pos());
 
     // Cross universe boundary
     geo.cross_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("johnny", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({2, -4, 1}), geo.pos());
@@ -664,11 +653,8 @@ TEST_F(UniversesTest, cross_into_parent_non_coincident)
     // Make sure we can take another step after crossing
     next = geo.find_next_step();
     EXPECT_SOFT_EQ(2, next.distance);
-    EXPECT_EQ("john.my",
-              this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("john.my", this->params().id_to_label(geo.surface_id()).name);
 }
 
@@ -681,17 +667,14 @@ TEST_F(UniversesTest, cross_into_daughter_coincident)
 
     auto next = geo.find_next_step();
     EXPECT_SOFT_EQ(1, next.distance);
-    EXPECT_EQ("bob.my", this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("bob.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("bobby", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({2, 0, 1}), geo.pos());
 
     // Cross universe boundary
     geo.cross_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("bob.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("c", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({2, 0, 1}), geo.pos());
@@ -699,11 +682,8 @@ TEST_F(UniversesTest, cross_into_daughter_coincident)
     // Make sure we can take another step after crossing
     next = geo.find_next_step();
     EXPECT_SOFT_EQ(1, next.distance);
-    EXPECT_EQ("alpha.py",
-              this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("alpha.py", this->params().id_to_label(geo.surface_id()).name);
 }
 
@@ -716,17 +696,14 @@ TEST_F(UniversesTest, cross_into_parent_coincident)
 
     auto next = geo.find_next_step();
     EXPECT_SOFT_EQ(0.5, next.distance);
-    EXPECT_EQ("bob.my", this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("bob.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("c", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({2, 0, 1}), geo.pos());
 
     // Cross universe boundary
     geo.cross_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("bob.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("bobby", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({2, 0, 1}), geo.pos());
@@ -734,10 +711,8 @@ TEST_F(UniversesTest, cross_into_parent_coincident)
     // Make sure we can take another step after crossing
     next = geo.find_next_step();
     EXPECT_SOFT_EQ(2, next.distance);
-    EXPECT_EQ("bob.py", this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("bob.py", this->params().id_to_label(geo.surface_id()).name);
 }
 
@@ -749,18 +724,14 @@ TEST_F(UniversesTest, cross_into_daughter_doubly_coincident)
 
     auto next = geo.find_next_step();
     EXPECT_SOFT_EQ(0.5, next.distance);
-    EXPECT_EQ("inner_a.my",
-              this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("johnny", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({0.25, -4, 1}), geo.pos());
 
     // Cross universe boundary
     geo.cross_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("patty", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({0.25, -4, 1}), geo.pos());
@@ -768,11 +739,8 @@ TEST_F(UniversesTest, cross_into_daughter_doubly_coincident)
     // Make sure we can take another step after crossing
     next = geo.find_next_step();
     EXPECT_SOFT_EQ(0.5, next.distance);
-    EXPECT_EQ("inner_c.py",
-              this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_c.py", this->params().id_to_label(geo.surface_id()).name);
 }
 
@@ -784,18 +752,14 @@ TEST_F(UniversesTest, cross_into_parent_doubly_coincident)
 
     auto next = geo.find_next_step();
     EXPECT_SOFT_EQ(0.25, next.distance);
-    EXPECT_EQ("inner_a.my",
-              this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("patty", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({0.25, -4, 1}), geo.pos());
 
     // Cross universe boundary
     geo.cross_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_a.my", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("johnny", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({0.25, -4, 1}), geo.pos());
@@ -803,11 +767,8 @@ TEST_F(UniversesTest, cross_into_parent_doubly_coincident)
     // Make sure we can take another step after crossing
     next = geo.find_next_step();
     EXPECT_SOFT_EQ(2, next.distance);
-    EXPECT_EQ("john.my",
-              this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("john.my", this->params().id_to_label(geo.surface_id()).name);
 }
 
@@ -821,18 +782,14 @@ TEST_F(UniversesTest, cross_between_daughters)
 
     auto next = geo.find_next_step();
     EXPECT_SOFT_EQ(0.2, next.distance);
-    EXPECT_EQ("inner_a.pz",
-              this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_a.pz", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("a", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({2, -2, 0.5}), geo.pos());
 
     // Cross universe boundary
     geo.cross_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("inner_a.pz", this->params().id_to_label(geo.surface_id()).name);
     EXPECT_EQ("a", this->params().id_to_label(geo.volume_id()).name);
     EXPECT_VEC_SOFT_EQ(Real3({2, -2, 0.5}), geo.pos());
@@ -840,10 +797,8 @@ TEST_F(UniversesTest, cross_between_daughters)
     // Make sure we can take another step after crossing
     next = geo.find_next_step();
     EXPECT_SOFT_EQ(1, next.distance);
-    EXPECT_EQ("bob.mz", this->params().id_to_label(geo.next_surface_id()).name);
 
     geo.move_to_boundary();
-    EXPECT_EQ(-1, geo.next_surface_id().unchecked_get());
     EXPECT_EQ("bob.mz", this->params().id_to_label(geo.surface_id()).name);
 }
 

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -199,7 +199,10 @@ TEST_F(TwoVolumeTest, simple_track)
     EXPECT_EQ(SurfaceId{0}, geo.surface_id());
     EXPECT_FALSE(geo.is_outside());
     EXPECT_TRUE(geo.is_on_boundary());
-    EXPECT_DOUBLE_EQ(0.0, geo.find_safety());
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(geo.find_safety(), celeritas::DebugError);
+    }
 
     // Logically flip the surface into the new volume
     geo.cross_boundary();
@@ -207,7 +210,6 @@ TEST_F(TwoVolumeTest, simple_track)
     EXPECT_EQ(SurfaceId{0}, geo.surface_id());
     EXPECT_TRUE(geo.is_outside());
     EXPECT_TRUE(geo.is_on_boundary());
-    EXPECT_DOUBLE_EQ(0.0, geo.find_safety());
 
     // Move internally to an arbitrary position
     geo.find_next_step();


### PR DESCRIPTION
- Don't cache the next-distance, since in practice our current implementation never really uses it, and the existing implementation seems to be causing vecgeom to get lost occasionally (?)
- Add a maximum search distance for the safety, which can be used in the upcoming tracker improvements
- Prohibit "find_safety" when known to be on the boundary