### PR TITLE
Fix step limiter when losing all energy over a step

### DIFF
--- a/src/celeritas/global/alongstep/detail/AlongStepImpl.hh
+++ b/src/celeritas/global/alongstep/detail/AlongStepImpl.hh
@@ -242,6 +242,7 @@ inline CELER_FUNCTION void apply_eloss(CoreTrackView const& track, EH&& eloss)
         {
             // Immediately kill stopped particles with no at rest processes
             sim.status(TrackStatus::killed);
+            sim.step_limit().action = phys.scalars().range_action();
         }
         else
         {

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -282,7 +282,7 @@ TEST_F(Em3AlongStepTest, nofluct_nomsc)
             EXPECT_SOFT_EQ(1, result.angle);
             EXPECT_SOFT_EQ(4.8522211972805e-14, result.time);
             EXPECT_SOFT_EQ(0.00028363764374689, result.step);
-            EXPECT_EQ("physics-discrete-select", result.action);
+            EXPECT_EQ("eloss-range", result.action);
         }
         {
             SCOPED_TRACE("near boundary");


### PR DESCRIPTION
This assigns the "range" limiter when a particle loses all energy over a step (even when it's not marked as range-limited) and has no at-rest interaction.

The "discrete" process will be incorrectly selected otherwise. This isn't a probelm currently because we also filter on track.status(), but we want the action ID to be consistent.