### PR TITLE
WIP: Add simple test to compute photon energy deposition

### DIFF
--- a/scripts/spack.yaml
+++ b/scripts/spack.yaml
@@ -17,7 +17,7 @@ spack:
     - py-sphinxcontrib-bibtex
     - "root@6.24: cxxstd=17"
     - "swig@4.1:"
-    - "vecgeom@1.2: +gdml cxxstd=17"
+    - "vecgeom@1.2.2: +gdml cxxstd=17"
   view: true
   concretizer:
     unify: true

--- a/test/celeritas/user/CaloTestBase.cc
+++ b/test/celeritas/user/CaloTestBase.cc
@@ -59,6 +59,52 @@ void CaloTestBase::RunResult::print_expected() const
 }
 
 //---------------------------------------------------------------------------//
+//! Initalize results
+void CaloTestBase::initalize()
+{
+    // Initialize RunResult vectors
+    size_t num_detectors = this->calo_->num_detectors();
+    result.edep=std::vector<double>(num_detectors,0.);
+    result.edep_err=std::vector<double>(num_detectors,0.);
+}
+
+//---------------------------------------------------------------------------//
+//! Gather results during a batch
+void CaloTestBase::gather_batch_results()
+{
+  // Retrieve energies deposited this batch for each detector
+  auto edep = calo_->calc_total_energy_deposition();
+
+  // Update results for each detector
+  size_t num_detectors = this->calo_->num_detectors();
+  for(size_t i_det=0; i_det<num_detectors; ++i_det){
+    auto edep_det=edep[i_det];
+    result.edep.at(i_det)+=edep_det;
+    result.edep_err.at(i_det)+=(edep_det*edep_det);
+  }
+  calo_->clear();
+}
+
+//---------------------------------------------------------------------------//
+//! Finalize results
+void CaloTestBase::finalize()
+{
+  if ( num_batches_ <= 1 ) return;
+
+  // Compute the mean and relative_err over batches for each detector
+  double norm= 1.0/double(num_batches_);
+  size_t num_detectors = this->calo_->num_detectors();
+  for(size_t i_det=0; i_det<num_detectors; ++i_det){
+    auto mu=result.edep.at(i_det)*norm;
+    auto var=result.edep_err.at(i_det)*norm- mu*mu;
+      CELER_ASSERT(var>0);
+      auto err=sqrt(var) / mu;
+      result.edep.at(i_det) = mu;
+      result.edep_err.at(i_det) = err;
+  }
+}
+
+//---------------------------------------------------------------------------//
 /*!
  * Run a number of tracks.
  */
@@ -67,50 +113,8 @@ auto CaloTestBase::run(size_type num_tracks,
                        size_type num_steps,
                        size_type num_batches) -> RunResult
 {
-    // Can't have fewer than 1 track per batch
-    CELER_ASSERT(num_batches<=num_tracks);
-
-    // Don't want to deal with remainders
-    CELER_ASSERT(num_tracks%num_batches==0);
-
-    // Compute tracks per batch
-    size_type num_tracks_per_batch=num_tracks/num_batches;
-
-    // Initialize RunResult
-    RunResult result;
-    size_t num_detectors = this->calo_->num_detectors();
-    result.edep=std::vector<double>(num_detectors,0.);
-    result.edep_err=std::vector<double>(num_detectors,0.);
-
-    // Loop over batches
-    for(size_type i_batch=0; i_batch<num_batches; ++i_batch){
-
-      this->run_impl<M>(num_tracks_per_batch, num_steps);
-
-      // Retrieve energies deposited this batch for each detector
-      auto edep = calo_->calc_total_energy_deposition();
-
-      // Update results for each detector
-      for(size_t i_det=0; i_det<num_detectors; ++i_det){
-        auto edep_det=edep[i_det];
-        result.edep.at(i_det)+=edep_det;
-        result.edep_err.at(i_det)+=(edep_det*edep_det);
-      }
-
-      calo_->clear();
-    }
-
-    // Finally, compute the mean and relative_err
-    double norm=num_batches > 1 ?  1.0/double(num_batches) : 1.0;
-    for(size_t i_det=0; i_det<num_detectors; ++i_det){
-      auto mu=result.edep.at(i_det)*norm;
-      auto var=result.edep_err.at(i_det)*norm - mu*mu;
-      auto err=sqrt(var) / mu;
-      result.edep.at(i_det) = mu;
-      result.edep_err.at(i_det) = err;
-    }
-
-    return result;
+   this->run_impl<M>(num_tracks, num_steps, num_batches);
+   return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/CaloTestBase.cc
+++ b/test/celeritas/user/CaloTestBase.cc
@@ -64,44 +64,47 @@ void CaloTestBase::initalize()
 {
     // Initialize RunResult vectors
     size_t num_detectors = this->calo_->num_detectors();
-    result.edep=std::vector<double>(num_detectors,0.);
-    result.edep_err=std::vector<double>(num_detectors,0.);
+    result.edep = std::vector<double>(num_detectors, 0.);
+    result.edep_err = std::vector<double>(num_detectors, 0.);
 }
 
 //---------------------------------------------------------------------------//
 //! Gather results during a batch
 void CaloTestBase::gather_batch_results()
 {
-  // Retrieve energies deposited this batch for each detector
-  auto edep = calo_->calc_total_energy_deposition();
+    // Retrieve energies deposited this batch for each detector
+    auto edep = calo_->calc_total_energy_deposition();
 
-  // Update results for each detector
-  size_t num_detectors = this->calo_->num_detectors();
-  for(size_t i_det=0; i_det<num_detectors; ++i_det){
-    auto edep_det=edep[i_det];
-    result.edep.at(i_det)+=edep_det;
-    result.edep_err.at(i_det)+=(edep_det*edep_det);
-  }
-  calo_->clear();
+    // Update results for each detector
+    size_t num_detectors = this->calo_->num_detectors();
+    for (size_t i_det = 0; i_det < num_detectors; ++i_det)
+    {
+        auto edep_det = edep[i_det];
+        result.edep.at(i_det) += edep_det;
+        result.edep_err.at(i_det) += (edep_det * edep_det);
+    }
+    calo_->clear();
 }
 
 //---------------------------------------------------------------------------//
 //! Finalize results
 void CaloTestBase::finalize()
 {
-  if ( num_batches_ <= 1 ) return;
+    if (num_batches_ <= 1)
+        return;
 
-  // Compute the mean and relative_err over batches for each detector
-  double norm= 1.0/double(num_batches_);
-  size_t num_detectors = this->calo_->num_detectors();
-  for(size_t i_det=0; i_det<num_detectors; ++i_det){
-    auto mu=result.edep.at(i_det)*norm;
-    auto var=result.edep_err.at(i_det)*norm- mu*mu;
-      CELER_ASSERT(var>0);
-      auto err=sqrt(var) / mu;
-      result.edep.at(i_det) = mu;
-      result.edep_err.at(i_det) = err;
-  }
+    // Compute the mean and relative_err over batches for each detector
+    double norm = 1.0 / double(num_batches_);
+    size_t num_detectors = this->calo_->num_detectors();
+    for (size_t i_det = 0; i_det < num_detectors; ++i_det)
+    {
+        auto mu = result.edep.at(i_det) * norm;
+        auto var = result.edep_err.at(i_det) * norm - mu * mu;
+        CELER_ASSERT(var > 0);
+        auto err = sqrt(var) / mu;
+        result.edep.at(i_det) = mu;
+        result.edep_err.at(i_det) = err;
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -113,8 +116,8 @@ auto CaloTestBase::run(size_type num_tracks,
                        size_type num_steps,
                        size_type num_batches) -> RunResult
 {
-   this->run_impl<M>(num_tracks, num_steps, num_batches);
-   return result;
+    this->run_impl<M>(num_tracks, num_steps, num_batches);
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/CaloTestBase.hh
+++ b/test/celeritas/user/CaloTestBase.hh
@@ -35,6 +35,7 @@ class CaloTestBase : virtual public StepCollectorTestBase
     struct RunResult
     {
         std::vector<double> edep;
+        std::vector<double> edep_err;
 
         void print_expected() const;
     };
@@ -48,7 +49,7 @@ class CaloTestBase : virtual public StepCollectorTestBase
     virtual VecString get_detector_names() const = 0;
 
     template<MemSpace M>
-    RunResult run(size_type num_tracks, size_type num_steps);
+    RunResult run(size_type num_tracks, size_type num_steps, size_type num_batches=1);
 
     // Get JSON output from the simple calo interface
     std::string output() const;

--- a/test/celeritas/user/CaloTestBase.hh
+++ b/test/celeritas/user/CaloTestBase.hh
@@ -55,9 +55,17 @@ class CaloTestBase : virtual public StepCollectorTestBase
     std::string output() const;
 
   protected:
+
+    virtual void gather_batch_results();
+    virtual void initalize();
+    virtual void finalize();
+
     std::shared_ptr<SimpleCalo> calo_;
     std::shared_ptr<StepCollector> collector_;
     std::shared_ptr<OutputRegistry> output_;
+
+  private:
+    RunResult result;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/CaloTestBase.hh
+++ b/test/celeritas/user/CaloTestBase.hh
@@ -49,13 +49,13 @@ class CaloTestBase : virtual public StepCollectorTestBase
     virtual VecString get_detector_names() const = 0;
 
     template<MemSpace M>
-    RunResult run(size_type num_tracks, size_type num_steps, size_type num_batches=1);
+    RunResult
+    run(size_type num_tracks, size_type num_steps, size_type num_batches = 1);
 
     // Get JSON output from the simple calo interface
     std::string output() const;
 
   protected:
-
     virtual void gather_batch_results();
     virtual void initalize();
     virtual void finalize();

--- a/test/celeritas/user/DiagnosticTestBase.cc
+++ b/test/celeritas/user/DiagnosticTestBase.cc
@@ -93,9 +93,13 @@ auto DiagnosticTestBase::run(size_type num_tracks, size_type num_steps)
     -> RunResult
 {
     this->run_impl<M>(num_tracks, num_steps);
+    return result;
+}
 
-    RunResult result;
-
+//---------------------------------------------------------------------------//
+//! Initalize results
+void DiagnosticTestBase::gather_batch_results()
+{
     // Save action diagnostic results
     for (auto const& [label, count] : action_diagnostic_->calc_actions_map())
     {
@@ -108,8 +112,6 @@ auto DiagnosticTestBase::run(size_type num_tracks, size_type num_steps)
     {
         result.steps.insert(result.steps.end(), vec.begin(), vec.end());
     }
-
-    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/DiagnosticTestBase.hh
+++ b/test/celeritas/user/DiagnosticTestBase.hh
@@ -61,8 +61,13 @@ class DiagnosticTestBase : virtual public StepCollectorTestBase
     void print_expected() const;
 
   protected:
+    virtual void gather_batch_results();
+
     std::shared_ptr<ActionDiagnostic> action_diagnostic_;
     std::shared_ptr<StepDiagnostic> step_diagnostic_;
+
+  private:
+    RunResult result;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/MctruthTestBase.cc
+++ b/test/celeritas/user/MctruthTestBase.cc
@@ -81,10 +81,13 @@ auto MctruthTestBase::run(size_type num_tracks, size_type num_steps)
     -> RunResult
 {
     this->run_impl<MemSpace::host>(num_tracks, num_steps);
+    return result;
+}
 
+void MctruthTestBase::gather_batch_results()
+{
     example_mctruth_->sort();
 
-    RunResult result;
     for (ExampleMctruth::Step const& s : example_mctruth_->steps())
     {
         result.event.push_back(s.event);
@@ -94,7 +97,6 @@ auto MctruthTestBase::run(size_type num_tracks, size_type num_steps)
         result.pos.insert(result.pos.end(), std::begin(s.pos), std::end(s.pos));
         result.dir.insert(result.dir.end(), std::begin(s.dir), std::end(s.dir));
     }
-    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/MctruthTestBase.hh
+++ b/test/celeritas/user/MctruthTestBase.hh
@@ -51,8 +51,13 @@ class MctruthTestBase : virtual public StepCollectorTestBase
     RunResult run(size_type num_tracks, size_type num_steps);
 
   protected:
+    virtual void gather_batch_results();
+
     std::shared_ptr<ExampleMctruth> example_mctruth_;
     std::shared_ptr<StepCollector> collector_;
+
+  private:
+    RunResult result;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -114,34 +114,30 @@ class TestEm3CollectorTestBase : public TestEm3Base,
     }
 };
 
+class TestPhotonCollectorTestBase : public TestEm3CollectorTestBase
+{
+    VecPrimary make_primaries(size_type count) override
+    {
+        // Get photo id
+        auto photon = this->particle()->find(pdg::gamma());
+        CELER_ASSERT(photon);
 
-class TestPhotonCollectorTestBase : public  TestEm3CollectorTestBase {
+        Primary p;
+        p.energy = MevEnergy{10.0};
+        p.position = {-22, 0, 0};
+        p.direction = {1, 0, 0};
+        p.time = 0;
+        p.particle_id = photon;
+        std::vector<Primary> result(count, p);
 
-  VecPrimary make_primaries(size_type count) override
-  {
-
-    // Get photo id
-    auto photon = this->particle()->find(pdg::gamma());
-    CELER_ASSERT(photon);
-
-    Primary p;
-    p.energy = MevEnergy{10.0};
-    p.position = {-22, 0, 0};
-    p.direction = {1, 0, 0};
-    p.time = 0;
-    p.particle_id=photon;
-    std::vector<Primary> result(count, p);
-
-    for (auto i : range(count))
-      {
-        result[i].event_id = EventId{0};
-        result[i].track_id = TrackId{i};
-      }
-    return result;
-  }
-
+        for (auto i : range(count))
+        {
+            result[i].event_id = EventId{0};
+            result[i].track_id = TrackId{i};
+        }
+        return result;
+    }
 };
-
 
 #define TestEm3MctruthTest TEST_IF_CELERITAS_GEANT(TestEm3MctruthTest)
 class TestEm3MctruthTest : public TestEm3CollectorTestBase,
@@ -158,9 +154,9 @@ class TestEm3CaloTest : public TestEm3CollectorTestBase, public CaloTestBase
     }
 };
 
-
 #define TestPhotonCaloTest TEST_IF_CELERITAS_GEANT(TestPhotonCaloTest)
-class TestPhotonCaloTest : public TestPhotonCollectorTestBase, public CaloTestBase
+class TestPhotonCaloTest : public TestPhotonCollectorTestBase,
+                           public CaloTestBase
 {
     VecString get_detector_names() const final
     {
@@ -354,24 +350,28 @@ TEST_F(TestEm3CaloTest, TEST_IF_CELER_DEVICE(step_device))
 
 TEST_F(TestPhotonCaloTest, sixteen_batches)
 {
-  auto result = this->run<MemSpace::host>(16, 32, 16);
+    auto result = this->run<MemSpace::host>(16, 32, 16);
 
-  static double const expected_edep[] = {9.0653751813736, 17.177626720468, 12.691359768897};
-  static double const expected_edep_err[] = {0.64823529758419, 0.42812745087497, 0.63485083267392};
+    static double const expected_edep[]
+        = {9.0653751813736, 17.177626720468, 12.691359768897};
+    static double const expected_edep_err[]
+        = {0.64823529758419, 0.42812745087497, 0.63485083267392};
 
-  EXPECT_VEC_NEAR(expected_edep, result.edep, 0.5);
-  EXPECT_VEC_NEAR(expected_edep_err, result.edep_err, 0.5);
+    EXPECT_VEC_NEAR(expected_edep, result.edep, 0.5);
+    EXPECT_VEC_NEAR(expected_edep_err, result.edep_err, 0.5);
 }
 
 TEST_F(TestPhotonCaloTest, TEST_IF_CELER_DEVICE(step_device))
 {
-  auto result = this->run<MemSpace::device>(16,32, 16);
+    auto result = this->run<MemSpace::device>(16, 32, 16);
 
-  static double const expected_edep[] = {9.0653751813736, 17.177626720468, 12.691359768897};
-  static double const expected_edep_err[] = {0.64823529758419, 0.42812745087497, 0.63485083267392};
+    static double const expected_edep[]
+        = {9.0653751813736, 17.177626720468, 12.691359768897};
+    static double const expected_edep_err[]
+        = {0.64823529758419, 0.42812745087497, 0.63485083267392};
 
-  EXPECT_VEC_NEAR(expected_edep, result.edep, 0.5);
-  EXPECT_VEC_NEAR(expected_edep_err, result.edep_err, 0.5);
+    EXPECT_VEC_NEAR(expected_edep, result.edep, 0.5);
+    EXPECT_VEC_NEAR(expected_edep_err, result.edep_err, 0.5);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -352,25 +352,26 @@ TEST_F(TestEm3CaloTest, TEST_IF_CELER_DEVICE(step_device))
     EXPECT_VEC_NEAR(expected_edep, result.edep, 0.5);
 }
 
-TEST_F(TestPhotonCaloTest, sixteen_batches_short)
+TEST_F(TestPhotonCaloTest, sixteen_batches)
 {
   auto result = this->run<MemSpace::host>(16, 32, 16);
-  PRINT_EXPECTED(result.edep);
-  PRINT_EXPECTED(result.edep_err);
-}
 
-TEST_F(TestPhotonCaloTest, sixteen_batches_long)
-{
-  auto result = this->run<MemSpace::host>(256, 512, 16);
-  PRINT_EXPECTED(result.edep);
-  PRINT_EXPECTED(result.edep_err);
+  static double const expected_edep[] = {9.0653751813736, 17.177626720468, 12.691359768897};
+  static double const expected_edep_err[] = {0.64823529758419, 0.42812745087497, 0.63485083267392};
+
+  EXPECT_VEC_NEAR(expected_edep, result.edep, 0.5);
+  EXPECT_VEC_NEAR(expected_edep_err, result.edep_err, 0.5);
 }
 
 TEST_F(TestPhotonCaloTest, TEST_IF_CELER_DEVICE(step_device))
 {
-  auto result = this->run<MemSpace::device>(256, 512, 16);
-  PRINT_EXPECTED(result.edep);
-  PRINT_EXPECTED(result.edep_err);
+  auto result = this->run<MemSpace::device>(16,32, 16);
+
+  static double const expected_edep[] = {9.0653751813736, 17.177626720468, 12.691359768897};
+  static double const expected_edep_err[] = {0.64823529758419, 0.42812745087497, 0.63485083267392};
+
+  EXPECT_VEC_NEAR(expected_edep, result.edep, 0.5);
+  EXPECT_VEC_NEAR(expected_edep_err, result.edep_err, 0.5);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -354,21 +354,21 @@ TEST_F(TestEm3CaloTest, TEST_IF_CELER_DEVICE(step_device))
 
 TEST_F(TestPhotonCaloTest, sixteen_batches_short)
 {
-  auto result = this->run<MemSpace::host>(256, 32, 16);
+  auto result = this->run<MemSpace::host>(16, 32, 16);
   PRINT_EXPECTED(result.edep);
   PRINT_EXPECTED(result.edep_err);
 }
 
 TEST_F(TestPhotonCaloTest, sixteen_batches_long)
 {
-  auto result = this->run<MemSpace::host>(4096, 512, 16);
+  auto result = this->run<MemSpace::host>(256, 512, 16);
   PRINT_EXPECTED(result.edep);
   PRINT_EXPECTED(result.edep_err);
 }
 
 TEST_F(TestPhotonCaloTest, TEST_IF_CELER_DEVICE(step_device))
 {
-  auto result = this->run<MemSpace::device>(4096, 512, 16);
+  auto result = this->run<MemSpace::device>(256, 512, 16);
   PRINT_EXPECTED(result.edep);
   PRINT_EXPECTED(result.edep_err);
 }

--- a/test/celeritas/user/StepCollectorTestBase.cc
+++ b/test/celeritas/user/StepCollectorTestBase.cc
@@ -24,10 +24,10 @@ void StepCollectorTestBase::run_impl(size_type num_tracks_per_batch,
                                      size_type num_batches)
 {
     // Save number of batches internally for normalization
-    num_batches_=num_batches;
+    num_batches_ = num_batches;
 
     // Compute total tracks
-    size_type num_tracks = num_tracks_per_batch*num_batches;
+    size_type num_tracks = num_tracks_per_batch * num_batches;
 
     // Initialize stepper
     StepperInput step_inp;
@@ -41,30 +41,33 @@ void StepCollectorTestBase::run_impl(size_type num_tracks_per_batch,
     this->initalize();
 
     // Loop over batches
-    for(size_type i_batch=0; i_batch<num_batches; ++i_batch){
-      // Initialize primaries for this batch
-      auto primaries = this->make_primaries(num_tracks_per_batch);
+    for (size_type i_batch = 0; i_batch < num_batches; ++i_batch)
+    {
+        // Initialize primaries for this batch
+        auto primaries = this->make_primaries(num_tracks_per_batch);
 
-      // Take num_steps steps
-      StepperResult count;
-      CELER_TRY_HANDLE(count = step(make_span(primaries)), log_context);
-      while (count && --num_steps > 0)
+        // Take num_steps steps
+        StepperResult count;
+        CELER_TRY_HANDLE(count = step(make_span(primaries)), log_context);
+        while (count && --num_steps > 0)
         {
-          CELER_TRY_HANDLE(count = step(), log_context);
+            CELER_TRY_HANDLE(count = step(), log_context);
         }
 
-      // Gathering of results
-      this->gather_batch_results();
+        // Gathering of results
+        this->gather_batch_results();
     }
 
     // Post-processing (e.g. normalization) of results
     this->finalize();
 }
 
-template void
-    StepCollectorTestBase::run_impl<MemSpace::host>(size_type, size_type, size_type);
-template void
-    StepCollectorTestBase::run_impl<MemSpace::device>(size_type, size_type, size_type);
+template void StepCollectorTestBase::run_impl<MemSpace::host>(size_type,
+                                                              size_type,
+                                                              size_type);
+template void StepCollectorTestBase::run_impl<MemSpace::device>(size_type,
+                                                                size_type,
+                                                                size_type);
 
 //---------------------------------------------------------------------------//
 }  // namespace test

--- a/test/celeritas/user/StepCollectorTestBase.hh
+++ b/test/celeritas/user/StepCollectorTestBase.hh
@@ -33,7 +33,9 @@ class StepCollectorTestBase : virtual public GlobalTestBase
 
   protected:
     template<MemSpace M>
-    void run_impl(size_type num_tracks_per_batch, size_type num_steps, size_type num_batches=1);
+    void run_impl(size_type num_tracks_per_batch,
+                  size_type num_steps,
+                  size_type num_batches = 1);
 
     virtual void gather_batch_results(){};
     virtual void initalize(){};

--- a/test/celeritas/user/StepCollectorTestBase.hh
+++ b/test/celeritas/user/StepCollectorTestBase.hh
@@ -33,7 +33,13 @@ class StepCollectorTestBase : virtual public GlobalTestBase
 
   protected:
     template<MemSpace M>
-    void run_impl(size_type num_tracks, size_type num_steps);
+    void run_impl(size_type num_tracks_per_batch, size_type num_steps, size_type num_batches=1);
+
+    virtual void gather_batch_results(){};
+    virtual void initalize(){};
+    virtual void finalize(){};
+
+    size_t num_batches_;
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Still WIP - one test is failing depending on which system I run it on.

## Purpose
Ultimately the goal is to enable photon energy deposition tallies in Celeritas. The addition of this test is a step towards that goal.

## New features
- This PR adds `TestPhotonCaloTest` (inherits from `CaloTest`) to StepCollector.test.cc.
- StepCollectorTestBase::run_impl now takes an additional optional argument `num_batches`, to perform a loop over several batches of tracks.
 - It was necessary to add some virtual methods to `StepCollectorTestBase` which are called in `run_impl`. This is because the Stepper initialisation should only occur once, and thus the loop over batches needs to be performed inside `run_impl`. However, accumulation of results needs to occur between batches, so this is now handled by `generate_batch_results`, with intialization and finalization of results occuring in `initialize` and `finalize` respectively.

## Other changes
- A consequence of the aforementioned changes to `StepCollectorTestBase` was the need to add additional state attributes and refactor the run methods within the other tests that inherit from this class (e.g. RunResults is now a member variable). 
