### PR TITLE
Account for zero-processes only in pre-step action

### DIFF
--- a/src/celeritas/global/alongstep/detail/TrackUpdater.hh
+++ b/src/celeritas/global/alongstep/detail/TrackUpdater.hh
@@ -39,8 +39,7 @@ CELER_FUNCTION void TrackUpdater::operator()(CoreTrackView const& track)
                      || track.make_particle_view().is_stopped());
         CELER_ASSERT(step_limit.action);
         auto phys = track.make_physics_view();
-        if (step_limit.action != phys.scalars().discrete_action()
-            && phys.num_particle_processes() != 0)
+        if (step_limit.action != phys.scalars().discrete_action())
         {
             // Reduce remaining mean free paths to travel. The 'discrete
             // action' case is launched separately and resets the

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -77,12 +77,14 @@ calc_physics_step_limit(MaterialTrackView const& material,
 
     // Determine limits from discrete interactions
     StepLimit limit;
-    limit.step = 0;
     limit.action = physics.scalars().discrete_action();
-    if (!particle.is_stopped())
+    if (particle.is_stopped())
+    {
+        limit.step = 0;
+    }
+    else
     {
         limit.step = physics.interaction_mfp() / total_macro_xs;
-
         if (auto ppid = physics.eloss_ppid())
         {
             auto grid_id = physics.value_grid(VGT::range, ppid);
@@ -106,6 +108,11 @@ calc_physics_step_limit(MaterialTrackView const& material,
                 limit.step = fixed_limit;
                 limit.action = physics.scalars().fixed_step_action;
             }
+        }
+        else if (physics.num_particle_processes() == 0)
+        {
+            // Clear post-step action so that unknown particles don't interact
+            limit.action = {};
         }
     }
 

--- a/src/celeritas/phys/detail/PreStepExecutor.hh
+++ b/src/celeritas/phys/detail/PreStepExecutor.hh
@@ -71,18 +71,6 @@ PreStepExecutor::operator()(celeritas::CoreTrackView const& track)
     }
 
     auto phys = track.make_physics_view();
-    if (phys.num_particle_processes() == 0)
-    {
-        // Replicate G4Transportation
-        // Set MFP to infinity and set action as geo-boundary
-        sim.reset_step_limit(
-            {numeric_limits<real_type>::max(), track.boundary_action()});
-        phys.interaction_mfp(numeric_limits<real_type>::max());
-        sim.along_step_action()
-            = track.core_scalars().along_step_neutral_action;
-        return;
-    }
-
     if (!phys.has_interaction_mfp())
     {
         // Sample mean free path

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -121,7 +121,7 @@ auto MockTestBase::build_particle() -> SPConstParticle
                    ElementaryCharge{-1},
                    stable});
     inp.push_back(
-        {"celerino", PDGNumber{18}, MevMass{0}, ElementaryCharge{0}, stable});
+        {"celerino", PDGNumber{81}, MevMass{0}, ElementaryCharge{0}, stable});
     return std::make_shared<ParticleParams>(std::move(inp));
 }
 

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -120,6 +120,8 @@ auto MockTestBase::build_particle() -> SPConstParticle
                    MevMass{0.5109989461},
                    ElementaryCharge{-1},
                    stable});
+    inp.push_back(
+        {"celerino", PDGNumber{18}, MevMass{0}, ElementaryCharge{0}, stable});
     return std::make_shared<ParticleParams>(std::move(inp));
 }
 

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -129,7 +129,7 @@ TEST_F(PhysicsParamsTest, output)
     if (CELERITAS_USE_JSON)
     {
         EXPECT_EQ(
-            R"json({"models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"max_step_over_range":0.2,"min_eprime_over_e":0.8,"min_range":0.1},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":4,"process_ids":8,"reals":231,"value_grid_ids":89,"value_grids":89,"value_tables":35}})json",
+            R"json({"models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"max_step_over_range":0.2,"min_eprime_over_e":0.8,"min_range":0.1},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"reals":231,"value_grid_ids":89,"value_grids":89,"value_tables":35}})json",
             to_string(out))
             << "\n/*** REPLACE ***/\nR\"json(" << to_string(out)
             << ")json\"\n/******/";

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -202,6 +202,16 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
         EXPECT_EQ(range_action, step.action);
         EXPECT_SOFT_EQ(5.2704627669473019e-12, step.step);
     }
+    {
+        // Celerino should have infinite step with no action
+        PhysicsTrackView phys = this->init_track(
+            &material, MaterialId{0}, &particle, "celerino", MevEnergy{1});
+        phys.interaction_mfp(1.234);
+        StepLimit step
+            = calc_physics_step_limit(material, particle, phys, pstep);
+        EXPECT_EQ(ActionId{}, step.action);
+        EXPECT_SOFT_EQ(std::numeric_limits<real_type>::infinity(), step.step);
+    }
 }
 
 TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)


### PR DESCRIPTION
This removes the need for extra along-step logic for null processes, moving the necessary changes to PreStepUtils where it's more testable.