### PR TITLE
Only use ROOT in celer-g4 when Celeritas uses Geant4

### DIFF
--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -18,46 +18,46 @@ if(CELERITAS_USE_Geant4)
     TrackingAction.cc
   )
   set(LIBRARIES Celeritas::accel)
-
-  if(CELERITAS_USE_ROOT)
-    function(celeritas_local_root_generate_dictionary name)
-      # No need for the rootmap file for an executable.
-      set(CMAKE_ROOTTEST_NOROOTMAP TRUE)
-      include_directories(
-        # root_generate_dictionary cannot handle the '$<INSTALL_INTERFACE:include>'
-        # part of the Celeritas::corecel target's include, so we cannot use it in
-        # the 'DEPENDENCIES' property.
-        "${CELERITAS_HEADER_CONFIG_DIRECTORY}"
-        "${PROJECT_SOURCE_DIR}/src"
-        # The include directory are attached to the Geant4 target through
-        # INTERFACE_INCLUDE_DIRECTORIES which is not looked at by
-        # root_generate_dictionary.
-        ${Geant4_INCLUDE_DIRS}
-        ${CLHEP_INCLUDE_DIRS}
-      )
-      root_generate_dictionary(${name}
-        ${CMAKE_CURRENT_SOURCE_DIR}/HitRootIO.hh
-        ${CMAKE_CURRENT_SOURCE_DIR}/SensitiveHit.hh
-        NOINSTALL
-        MODULE celer-g4
-        # TODO Uncomment this line and remove the include_directories when
-        # the minimal required ROOT version is v6.28/02 or later.
-        # DEPENDENCIES ${Geant4_LIBRARIES} Celeritas::accel Celeritas::corecel
-        LINKDEF "${CMAKE_CURRENT_SOURCE_DIR}/HitClassesLinkDef.h"
-      )
-    endfunction(celeritas_local_root_generate_dictionary)
-    celeritas_local_root_generate_dictionary(HitClassesRootInterfaces)
-    list(APPEND SOURCES
-      "${CMAKE_CURRENT_BINARY_DIR}/HitClassesRootInterfaces.cxx"
-      HitRootIO.cc
-    )
-    list(APPEND LIBRARIES ROOT::Tree)
-  endif()
 else()
   set(SOURCES
     celer-g4.nogeant.cc
   )
   set(LIBRARIES)
+endif()
+
+if(CELERITAS_USE_ROOT AND CELERITAS_USE_Geant4)
+  function(celeritas_local_root_generate_dictionary name)
+    # No need for the rootmap file for an executable.
+    set(CMAKE_ROOTTEST_NOROOTMAP TRUE)
+    include_directories(
+      # root_generate_dictionary cannot handle the '$<INSTALL_INTERFACE:include>'
+      # part of the Celeritas::corecel target's include, so we cannot use it in
+      # the 'DEPENDENCIES' property.
+      "${CELERITAS_HEADER_CONFIG_DIRECTORY}"
+      "${PROJECT_SOURCE_DIR}/src"
+      # The include directory are attached to the Geant4 target through
+      # INTERFACE_INCLUDE_DIRECTORIES which is not looked at by
+      # root_generate_dictionary.
+      ${Geant4_INCLUDE_DIRS}
+      ${CLHEP_INCLUDE_DIRS}
+    )
+    root_generate_dictionary(${name}
+      ${CMAKE_CURRENT_SOURCE_DIR}/HitRootIO.hh
+      ${CMAKE_CURRENT_SOURCE_DIR}/SensitiveHit.hh
+      NOINSTALL
+      MODULE celer-g4
+      # TODO Uncomment this line and remove the include_directories when
+      # the minimal required ROOT version is v6.28/02 or later.
+      # DEPENDENCIES ${Geant4_LIBRARIES} Celeritas::accel Celeritas::corecel
+      LINKDEF "${CMAKE_CURRENT_SOURCE_DIR}/HitClassesLinkDef.h"
+    )
+  endfunction(celeritas_local_root_generate_dictionary)
+  celeritas_local_root_generate_dictionary(HitClassesRootInterfaces)
+  list(APPEND SOURCES
+    "${CMAKE_CURRENT_BINARY_DIR}/HitClassesRootInterfaces.cxx"
+    HitRootIO.cc
+  )
+  list(APPEND LIBRARIES ROOT::Tree)
 endif()
 
 celeritas_add_executable(celer-g4 ${SOURCES})

--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -18,46 +18,46 @@ if(CELERITAS_USE_Geant4)
     TrackingAction.cc
   )
   set(LIBRARIES Celeritas::accel)
+
+  if(CELERITAS_USE_ROOT)
+    function(celeritas_local_root_generate_dictionary name)
+      # No need for the rootmap file for an executable.
+      set(CMAKE_ROOTTEST_NOROOTMAP TRUE)
+      include_directories(
+        # root_generate_dictionary cannot handle the '$<INSTALL_INTERFACE:include>'
+        # part of the Celeritas::corecel target's include, so we cannot use it in
+        # the 'DEPENDENCIES' property.
+        "${CELERITAS_HEADER_CONFIG_DIRECTORY}"
+        "${PROJECT_SOURCE_DIR}/src"
+        # The include directory are attached to the Geant4 target through
+        # INTERFACE_INCLUDE_DIRECTORIES which is not looked at by
+        # root_generate_dictionary.
+        ${Geant4_INCLUDE_DIRS}
+        ${CLHEP_INCLUDE_DIRS}
+      )
+      root_generate_dictionary(${name}
+        ${CMAKE_CURRENT_SOURCE_DIR}/HitRootIO.hh
+        ${CMAKE_CURRENT_SOURCE_DIR}/SensitiveHit.hh
+        NOINSTALL
+        MODULE celer-g4
+        # TODO Uncomment this line and remove the include_directories when
+        # the minimal required ROOT version is v6.28/02 or later.
+        # DEPENDENCIES ${Geant4_LIBRARIES} Celeritas::accel Celeritas::corecel
+        LINKDEF "${CMAKE_CURRENT_SOURCE_DIR}/HitClassesLinkDef.h"
+      )
+    endfunction(celeritas_local_root_generate_dictionary)
+    celeritas_local_root_generate_dictionary(HitClassesRootInterfaces)
+    list(APPEND SOURCES
+      "${CMAKE_CURRENT_BINARY_DIR}/HitClassesRootInterfaces.cxx"
+      HitRootIO.cc
+    )
+    list(APPEND LIBRARIES ROOT::Tree)
+  endif()
 else()
   set(SOURCES
     celer-g4.nogeant.cc
   )
   set(LIBRARIES)
-endif()
-
-if(CELERITAS_USE_ROOT)
-  function(celeritas_local_root_generate_dictionary name)
-    # No need for the rootmap file for an executable.
-    set(CMAKE_ROOTTEST_NOROOTMAP TRUE)
-    include_directories(
-      # root_generate_dictionary cannot handle the '$<INSTALL_INTERFACE:include>'
-      # part of the Celeritas::corecel target's include, so we cannot use it in
-      # the 'DEPENDENCIES' property.
-      "${CELERITAS_HEADER_CONFIG_DIRECTORY}"
-      "${PROJECT_SOURCE_DIR}/src"
-      # The include directory are attached to the Geant4 target through
-      # INTERFACE_INCLUDE_DIRECTORIES which is not looked at by
-      # root_generate_dictionary.
-      ${Geant4_INCLUDE_DIRS}
-      ${CLHEP_INCLUDE_DIRS}
-    )
-    root_generate_dictionary(${name}
-      ${CMAKE_CURRENT_SOURCE_DIR}/HitRootIO.hh
-      ${CMAKE_CURRENT_SOURCE_DIR}/SensitiveHit.hh
-      NOINSTALL
-      MODULE celer-g4
-      # TODO Uncomment this line and remove the include_directories when
-      # the minimal required ROOT version is v6.28/02 or later.
-      # DEPENDENCIES ${Geant4_LIBRARIES} Celeritas::accel Celeritas::corecel
-      LINKDEF "${CMAKE_CURRENT_SOURCE_DIR}/HitClassesLinkDef.h"
-    )
-  endfunction(celeritas_local_root_generate_dictionary)
-  celeritas_local_root_generate_dictionary(HitClassesRootInterfaces)
-  list(APPEND SOURCES
-    "${CMAKE_CURRENT_BINARY_DIR}/HitClassesRootInterfaces.cxx"
-    HitRootIO.cc
-  )
-  list(APPEND LIBRARIES ROOT::Tree)
 endif()
 
 celeritas_add_executable(celer-g4 ${SOURCES})


### PR DESCRIPTION
A really minor fix for an configuration corner case - In the situation that Celeritas uses ROOT but not Geant4, dictionary generation for `celer-g4` will fail because it needs the Geant4 headers.

The changes here just move the dictionary generation inside the `CELERITAS_USE_Geant4` conditional so it only happens when both packages are used. The "no Geant4" case is trivial and doesn't need either package, so this should be safe under all combinations.