### PR TITLE
Fix UrbanMsc safety edge case

### DIFF
--- a/src/celeritas/em/msc/UrbanMsc.hh
+++ b/src/celeritas/em/msc/UrbanMsc.hh
@@ -237,6 +237,12 @@ UrbanMsc::apply_step(CoreTrackView const& track, StepLimit* step_limit)
             displ = max(displ * (1 + 2 * msc_params_.params.safety_tol),
                         msc_params_.params.geom_limit);
             safety = geo.find_safety(displ);
+            if (CELER_UNLIKELY(safety <= 0))
+            {
+                // Effectively on a boundary without being "logically" on:
+                // possible after tricky VecGeom boundary crossings.
+                msc_step.is_displaced = false;
+            }
         }
 
         auto mat = track.make_material_view().make_material_view();

--- a/src/celeritas/em/msc/UrbanMsc.hh
+++ b/src/celeritas/em/msc/UrbanMsc.hh
@@ -237,10 +237,11 @@ UrbanMsc::apply_step(CoreTrackView const& track, StepLimit* step_limit)
             displ = max(displ * (1 + 2 * msc_params_.params.safety_tol),
                         msc_params_.params.geom_limit);
             safety = geo.find_safety(displ);
-            if (CELER_UNLIKELY(safety <= 0))
+            if (CELER_UNLIKELY(safety == 0))
             {
-                // Effectively on a boundary without being "logically" on:
-                // possible after tricky VecGeom boundary crossings.
+                // The track is effectively on a boundary without being
+                // "logically" on, which is possible after tricky VecGeom
+                // boundary crossings.
                 msc_step.is_displaced = false;
             }
         }


### PR DESCRIPTION
This popped up from #784: previously we assumed that "not on a boundary" meant "safety is positive", but that's not always true on or slightly after tricky vecgeom boundary crossings.
Running with CMS (after fixing some of the failures) results in:
```
G4WT1 > ExceptionConverter.cc:152: [2/2] critical: The following error is from: kernel context: track slot 740 in 'along-step-general-linear', track 638 of event 2
- Particle type: e- (PDG=11,  ID=1)
- Energy: 0.766535 [MeV]
- Position: {57.2049,-8.28024,77.3424} (cm)
- Direction: {0.127977,0.394858,-0.909785}
- Volume: tob_TOBCFTube4@0x600003350820 (ID=1053)
- Step counter: 25
G4WT1 >
-------- EEEE ------- G4Exception-START -------- EEEE -------
*** G4Exception : celer0004
      issued by : celeritas/em/msc/detail/UrbanMscScatter.hh:189
precondition failed: !is_displaced_ || safety > 0
*** Fatal Exception *** core dump ***
```

Previously `safety > 0` was `!geo->is_on_boundary()`, but they aren't the same condition. Now explicitly check for a zero safety and skip displacement if needed.