### PR TITLE
Create CUDA streams when integrating with Geant4

### DIFF
--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -111,6 +111,12 @@ GlobalSetup::GlobalSetup()
         options_->cuda_heap_size = 0;
     }
     {
+        auto& cmd = messenger_->DeclareProperty("defaultStream",
+                                                options_->default_stream);
+        cmd.SetGuidance("Launch all kernels on the default stream");
+        options_->default_stream = false;
+    }
+    {
         messenger_->DeclareMethod("magFieldZ",
                                   &GlobalSetup::SetMagFieldZTesla,
                                   "Set Z-axis magnetic field strength (T)");

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -125,6 +125,8 @@ struct SetupOptions
     //! \name CUDA options
     size_type cuda_stack_size{};
     size_type cuda_heap_size{};
+    //! Launch all kernels on the default stream
+    bool default_stream{false};
     //!@}
 
     //!@{

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -370,6 +370,13 @@ void SharedParams::initialize_core(SetupOptions const& options)
         }();
     }
 
+    // Allocate device streams, or use the default stream if there is only one.
+    if (celeritas::device() && !options.default_stream
+        && params.max_streams > 1)
+    {
+        celeritas::device().create_streams(params.max_streams);
+    }
+
     // Construct along-step action
     params.action_reg->insert([&params, &options, &imported] {
         AlongStepFactoryInput asfi;


### PR DESCRIPTION
Previously we were only actually creating the streams in the celer-sim app.