### PR TITLE
Fix build on Summit

### DIFF
--- a/src/celeritas/global/CoreParams.hh
+++ b/src/celeritas/global/CoreParams.hh
@@ -136,8 +136,6 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
 };
 
 //---------------------------------------------------------------------------//
-// INLINE DEFINITIONS
-//---------------------------------------------------------------------------//
 /*!
  * Access a native pointer to a NativeCRef.
  *
@@ -151,7 +149,12 @@ auto CoreParams::ptr() const -> ConstPtr<M>
     {
         return make_observer(&host_ref_);
     }
-    else if constexpr (M == MemSpace::device)
+#ifndef __NVCC__
+        // CUDA 11.4 complains about 'else if constexpr' ("missing return
+        // statement") and GCC 11.2 complains about leaving off the 'else'
+        // ("inconsistent deduction for auto return type")
+        else
+#endif
     {
         CELER_ENSURE(!device_ref_vec_.empty());
         return make_observer(device_ref_vec_);

--- a/src/celeritas/global/CoreState.cc
+++ b/src/celeritas/global/CoreState.cc
@@ -40,10 +40,16 @@ CoreState<M>::CoreState(CoreParams const& params,
     {
         device_ref_vec_ = DeviceVector<Ref>(1);
         device_ref_vec_.copy_to_device({&this->ref(), 1});
+        ptr_ = make_observer(device_ref_vec_);
+    }
+    else if constexpr (M == MemSpace::host)
+    {
+        ptr_ = make_observer(&this->ref());
     }
 
     CELER_LOG_LOCAL(status) << "Celeritas core state initialization complete";
     CELER_ENSURE(states_);
+    CELER_ENSURE(ptr_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -55,6 +55,10 @@ class CoreStateInterface
 //---------------------------------------------------------------------------//
 /*!
  * Store all state data for a single thread.
+ *
+ * When the state lives on the device, we maintain a separate copy of the
+ * device "ref" in device memory: otherwise we'd have to copy the entire state
+ * in launch arguments and access it through constant memory.
  */
 template<MemSpace M>
 class CoreState final : public CoreStateInterface
@@ -85,8 +89,8 @@ class CoreState final : public CoreStateInterface
     //! Get a reference to the mutable state data
     Ref const& ref() const { return states_.ref(); }
 
-    // Get a native-memspace pointer to the mutable state data
-    inline Ptr ptr();
+    //! Get a native-memspace pointer to the mutable state data
+    Ptr ptr() { return ptr_; }
 
     //! Track initialization counters
     CoreStateCounters& counters() { return counters_; }
@@ -118,30 +122,12 @@ class CoreState final : public CoreStateInterface
     // Copy of state ref in device memory, if M == MemSpace::device
     DeviceVector<Ref> device_ref_vec_;
 
+    // Native pointer to ref or
+    Ptr ptr_;
+
     // Counters for track initialization and activity
     CoreStateCounters counters_;
 };
-
-//---------------------------------------------------------------------------//
-/*!
- * Access a native pointer to a NativeCRef.
- *
- * This way, CUDA kernels only need to copy a pointer in the kernel arguments,
- * rather than the entire (rather large) DeviceRef object.
- */
-template<MemSpace M>
-auto CoreState<M>::ptr() -> Ptr
-{
-    if constexpr (M == MemSpace::host)
-    {
-        return make_observer(&this->ref());
-    }
-    else if constexpr (M == MemSpace::device)
-    {
-        CELER_ENSURE(!device_ref_vec_.empty());
-        return make_observer(device_ref_vec_);
-    }
-}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/corecel/data/ParamsDataInterface.hh
+++ b/src/corecel/data/ParamsDataInterface.hh
@@ -9,6 +9,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Types.hh"
+#include "Ref.hh"
 
 namespace celeritas
 {
@@ -51,22 +52,8 @@ template<template<Ownership, MemSpace> class P>
 template<MemSpace M>
 P<Ownership::const_reference, M> const& ParamsDataInterface<P>::ref() const
 {
-    if constexpr (M == MemSpace::host)
-    {
-        auto const& result = this->host_ref();
-        CELER_ENSURE(result);
-        return result;
-    }
-    else if constexpr (M == MemSpace::device)
-    {
-        auto const& result = this->device_ref();
-        CELER_ENSURE(result);
-        return result;
-    }
-    // "error #128-D: loop is not reachable"
-#ifndef __NVCC__
-    CELER_ASSERT_UNREACHABLE();
-#endif
+    // Note: CUDA 11.4.2 + GCC 11.2.0 doesn't support 'if constexpr'
+    return get_ref<M>(*this);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/StreamStore.hh
+++ b/src/corecel/data/StreamStore.hh
@@ -120,10 +120,13 @@ class StreamStore
             // Extra parens needed to return reference instead of copy
             return (self.host_states_);
         }
-        else if constexpr (M == MemSpace::device)
-        {
-            return (self.device_states_);
-        }
+#ifndef __NVCC__
+        // CUDA 11.4 complains about 'else if constexpr' ("missing return
+        // statement") and GCC 11.2 complains about leaving off the 'else'
+        // ("inconsistent deduction for auto return type")
+        else
+#endif
+        return (self.device_states_);
     }
 
     template<MemSpace M, class Self>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -271,7 +271,7 @@ celeritas_add_object_library(testcel_celeritas_core
   celeritas/user/MctruthTestBase.cc
   celeritas/user/StepCollectorTestBase.cc
 )
-target_link_libraries(testcel_celeritas_core
+celeritas_target_link_libraries(testcel_celeritas_core
   PRIVATE Celeritas::testcel_harness Celeritas::celeritas ${_optional_json_libs}
 )
 
@@ -540,7 +540,7 @@ celeritas_add_test(celeritas/user/StepCollector.test.cc
 
 if(CELERITAS_USE_Geant4)
   celeritas_setup_tests(SERIAL PREFIX accel
-    LINK_LIBRARIES Celeritas::accel testcel_celeritas
+    LINK_LIBRARIES Celeritas::accel Celeritas::celeritas testcel_celeritas
   )
 
   celeritas_add_test(accel/ExceptionConverter.test.cc)


### PR DESCRIPTION
Summit fails to build Celeritas because of some bugs in its `if constexpr` handling (they change from warnings to errors because of our strict flags; so maybe we should loosen those on the LCFs?). See [CUDA: "missing return statement at end of non-void function" in constexpr if function](https://stackoverflow.com/questions/64523302/cuda-missing-return-statement-at-end-of-non-void-function-in-constexpr-if-fun).

A second issue is when building with VecGeom, a missing explicit link to `celeritas` resulted in a bunch of
```
lib64/libceleritas.a(TrackInitAlgorithms.cu.o): In function `__sti____cudaRegisterAll()':
tmpxft_00117171_00000000-6_TrackInitAlgorithms.cudafe1.cpp:(.text.startup+0x34): undefined reference to `__cudaRegisterLinkedBinary_54_tmpxft_00117171_00000000_7_TrackInitAlgorithms_cpp1_ii_50dc7a1b'
```
errors.