### PR TITLE
Fix assertion when field driver step has zero error

### DIFF
--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -149,6 +149,7 @@ FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
 
     // Output with a step control error
     ChordSearch output = this->find_next_chord(step, state);
+    CELER_ASSERT(output.end.step <= step);
 
     // Evaluate the relative error
     real_type rel_error = output.error
@@ -162,9 +163,7 @@ FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
         output.end = this->accurate_advance(output.end.step, state, next_step);
     }
 
-    CELER_ENSURE(
-        output.end.step > 0
-        && (output.end.step <= step || soft_equal(output.end.step, step)));
+    CELER_ENSURE(output.end.step > 0 && output.end.step <= step);
     return output.end;
 }
 
@@ -275,7 +274,7 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
     // accumulation
     CELER_ENSURE(curve_length > 0
                  && (curve_length <= step || soft_equal(curve_length, step)));
-    output.end.step = curve_length;
+    output.end.step = min(curve_length, step);
     return output.end;
 }
 

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -254,6 +254,7 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
 
     do
     {
+        CELER_ASSERT(h > 0);
         output = this->integrate_step(h, output.end.state);
 
         curve_length += output.end.step;
@@ -290,6 +291,8 @@ FieldDriver<StepperT>::integrate_step(real_type step,
                                       OdeState const& state) const
     -> Integration
 {
+    CELER_EXPECT(step > 0);
+
     // Output with a next proposed step
     Integration output;
 
@@ -310,7 +313,6 @@ FieldDriver<StepperT>::integrate_step(real_type step,
         output.end.step = step;
 
         // Compute a proposed new step
-        CELER_ASSERT(output.end.step > 0);
         output.proposed_step = this->new_step_size(
             step, dyerr / (options_.epsilon_step * step));
     }
@@ -378,7 +380,7 @@ template<class StepperT>
 CELER_FUNCTION real_type
 FieldDriver<StepperT>::new_step_size(real_type step, real_type rel_error) const
 {
-    CELER_ASSERT(rel_error > 0);
+    CELER_ASSERT(rel_error >= 0);
     real_type scale_factor = fastpow(
         rel_error, rel_error > 1 ? options_.pshrink : options_.pgrow);
     return options_.safety * step * scale_factor;

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -170,8 +170,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
         CELER_ASSERT(result.boundary == geo_.is_on_boundary());
 
         // Advance up to (but probably less than) the remaining step length
-        // Due to roundoff this may be slightly more than remaining.
         DriverResult substep = driver_.advance(remaining, state_);
+        CELER_ASSERT(substep.step > 0 && substep.step <= remaining);
 
         // Check whether the chord for this sub-step intersects a boundary
         auto chord = detail::make_chord(state_.pos, substep.state.pos);
@@ -211,7 +211,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
             // on a reentrant boundary crossing below.
             state_ = substep.state;
             result.boundary = false;
-            result.distance += celeritas::min(substep.step, remaining);
+            result.distance += substep.step;
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
             --remaining_substeps;

--- a/src/celeritas/field/detail/FieldUtils.hh
+++ b/src/celeritas/field/detail/FieldUtils.hh
@@ -122,7 +122,9 @@ inline CELER_FUNCTION real_type truncation_error(real_type step,
     errvel2 /= (magvel2 * ipow<2>(eps_rel_max));
 
     // Return the square of the maximum truncation error
-    return max(errpos2, errvel2);
+    real_type result = max(errpos2, errvel2);
+    CELER_ENSURE(result >= 0);
+    return result;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
In an unusual case, the end of the curve length after the second iteration of the loop in `FieldDriver::accurate_advance` was almost exactly total step, leading to a call to `integrate_step` with a substep length of machine epsilon that resulted in a truncation error of zero.

I've also adjusted the logic so that the `FieldDriver` ensures the returned "step" is less than or equal to the input step, rather than accounting for that extra fuzziness in the bowels of the propagator.