### PR TITLE
Fix G4 version check for `G4Step::Reset[Pre|Post]StepPoint`

### DIFF
--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -76,10 +76,10 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
     // Create temporary objects
     step_ = std::make_unique<G4Step>();
 
-#if G4VERSION_NUMBER >= 1101
+#if G4VERSION_NUMBER >= 1103
 #    define HP_CLEAR_STEP_POINT(CMD) step_->CMD(nullptr)
 #else
-#    define HP_CLEAR_STEP_POINT(CMD) /* no "reset" before v11.0.1 */
+#    define HP_CLEAR_STEP_POINT(CMD) /* no "reset" before v11.0.3 */
 #endif
 
 #define HP_SETUP_POINT(LOWER, TITLE)                                          \


### PR DESCRIPTION
`Reset[PrePost]StepPoint` were added in [11.0.3](https://gitlab.cern.ch/geant4/geant4/-/blob/v11.0.3/source/track/include/G4Step.hh?ref_type=tags#L81), not [11.0.1](https://gitlab.cern.ch/geant4/geant4/-/blob/v11.0.1/source/track/include/G4Step.hh?ref_type=tags#L80)