### PR TITLE
Add G4ExtrudedSolid conversion

### DIFF
--- a/src/celeritas/ext/g4vg/SolidConverter.cc
+++ b/src/celeritas/ext/g4vg/SolidConverter.cc
@@ -19,6 +19,7 @@
 #include <G4Ellipsoid.hh>
 #include <G4EllipticalCone.hh>
 #include <G4EllipticalTube.hh>
+#include <G4ExtrudedSolid.hh>
 #include <G4GDMLWriteStructure.hh>
 #include <G4GenericPolycone.hh>
 #include <G4GenericTrap.hh>
@@ -142,6 +143,7 @@ auto SolidConverter::convert_impl(arg_type solid_base) -> result_type
         VGSC_TYPE_FUNC(Ellipsoid        , ellipsoid),
         VGSC_TYPE_FUNC(EllipticalCone   , ellipticalcone),
         VGSC_TYPE_FUNC(EllipticalTube   , ellipticaltube),
+        VGSC_TYPE_FUNC(ExtrudedSolid    , extrudedsolid),
         VGSC_TYPE_FUNC(GenericPolycone  , genericpolycone),
         VGSC_TYPE_FUNC(GenericTrap      , generictrap),
         VGSC_TYPE_FUNC(Hype             , hype),
@@ -266,6 +268,44 @@ auto SolidConverter::ellipticaltube(arg_type solid_base) -> result_type
         this->convert_scale_(solid.GetDx()),
         this->convert_scale_(solid.GetDy()),
         this->convert_scale_(solid.GetDz()));
+}
+
+//---------------------------------------------------------------------------//
+//! Convert an extruded solid
+auto SolidConverter::extrudedsolid(arg_type solid_base) -> result_type
+{
+    auto const& solid = dynamic_cast<G4ExtrudedSolid const&>(solid_base);
+
+    // Convert vertices
+    std::vector<double> x(solid.GetNofVertices());
+    std::vector<double> y(x.size());
+    for (auto i : range(x.size()))
+    {
+        std::tie(x[i], y[i]) = this->convert_scale_(solid.GetVertex(i));
+    }
+
+    // Convert Z sections
+    std::vector<double> z(solid.GetNofZSections());
+    if (z.size() != 2)
+    {
+        CELER_LOG(error) << "Extruded solid named '" << solid_base.GetName()
+                         << "' has " << z.size()
+                         << " Z sections, but VecGeom requires exactly 2";
+        CELER_ASSERT(z.size() >= 2);
+    }
+    for (auto i : range(z.size()))
+    {
+        G4ExtrudedSolid::ZSection const& zsec = solid.GetZSection(i);
+        CELER_VALIDATE(zsec.fScale == 1.0,
+                       << "unsupported scale factor '" << zsec.fScale << '\'');
+        CELER_VALIDATE(zsec.fOffset.x() == 0.0 && zsec.fOffset.y() == 0.0,
+                       << "unsupported z section translation ("
+                       << zsec.fOffset.x() << "," << zsec.fOffset.y() << ")");
+        z[i] = this->convert_scale_(zsec.fZ);
+    }
+
+    return GeoManager::MakeInstance<UnplacedSExtruVolume>(
+        x.size(), x.data(), y.data(), z.front(), z.back());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/g4vg/SolidConverter.hh
+++ b/src/celeritas/ext/g4vg/SolidConverter.hh
@@ -80,6 +80,7 @@ class SolidConverter
     result_type ellipsoid(arg_type);
     result_type ellipticalcone(arg_type);
     result_type ellipticaltube(arg_type);
+    result_type extrudedsolid(arg_type);
     result_type genericpolycone(arg_type);
     result_type generictrap(arg_type);
     result_type hype(arg_type);

--- a/test/celeritas/data/solids.gdml
+++ b/test/celeritas/data/solids.gdml
@@ -61,6 +61,7 @@ acceptance of all terms of the Geant4 Software license.
   <position name="posTessel1"    x="-5000" y=" 1250" z="0" unit="mm" />
   <position name="posDirect"     x="-5000" y="    0" z="0" unit="mm" />
   <position name="posReflect"    x="-5000" y="-1250" z="0" unit="mm" />
+  <position name="posXtru1"      x="-5250" y="    0" z="0" unit="mm" />
 
   <position name="v0" unit="mm"  x=" 400" y=" 400" z="-500" />
   <position name="v1" unit="mm"  x="-400" y=" 400" z="-500" />
@@ -190,7 +191,16 @@ acceptance of all terms of the Geant4 Software license.
   <elcone    name="testellcone"   lunit="mm" dx="0.10" dy="0.15" zmax="500" zcut="200"/>
 
   <tet name="testtet" vertex1="v4" vertex2="v3" vertex3="v1" vertex4="v2"/>
-  <!--trd name="testtet" lunit="mm" x1="400" y1="400" x2="1" y2="1" z="500"/-->
+
+  <xtru lunit="mm" name="testxtru">
+    <twoDimVertex x="-85" y="-80"/>
+    <twoDimVertex x="-65" y="60"/>
+    <twoDimVertex x="0" y="95"/>
+    <twoDimVertex x="90" y="50"/>
+    <twoDimVertex x="80" y="-55"/>
+    <section scalingFactor="1" xOffset="0" yOffset="0" zOrder="0" zPosition="-100"/>
+    <section scalingFactor="1" xOffset="0" yOffset="0" zOrder="1" zPosition="100"/>
+  </xtru>
  </solids>
 
  <structure>
@@ -321,6 +331,11 @@ acceptance of all terms of the Geant4 Software license.
   <volume name="arb8a">
    <materialref ref="Water"/>
    <solidref ref="arb82"/>
+  </volume>
+
+  <volume name="xtru1">
+   <materialref ref="Water"/>
+   <solidref ref="testxtru"/>
   </volume>
 
   <volume name="World">
@@ -476,6 +491,12 @@ acceptance of all terms of the Geant4 Software license.
    <physvol>
      <volumeref ref="genPocone1"/>
      <positionref ref="posGenPocone1"/>
+     <rotationref ref="norot"/>
+   </physvol>
+
+   <physvol>
+     <volumeref ref="xtru1"/>
+     <positionref ref="posXtru1"/>
      <rotationref ref="norot"/>
    </physvol>
 

--- a/test/celeritas/ext/GeantGeo.test.cc
+++ b/test/celeritas/ext/GeantGeo.test.cc
@@ -328,11 +328,11 @@ TEST_F(SolidsTest, accessors)
     // offset. This value will be zero if running the solids test as
     // standalone.
     int const offset = 4;
-    ASSERT_EQ(25 + offset, geom.num_volumes());
+    ASSERT_EQ(26 + offset, geom.num_volumes());
     EXPECT_EQ("box500", geom.id_to_label(VolumeId{0 + offset}).name);
     EXPECT_EQ("cone1", geom.id_to_label(VolumeId{1 + offset}).name);
-    EXPECT_EQ("World", geom.id_to_label(VolumeId{23 + offset}).name);
-    EXPECT_EQ("trd3_refl", geom.id_to_label(VolumeId{24 + offset}).name);
+    EXPECT_EQ("World", geom.id_to_label(VolumeId{24 + offset}).name);
+    EXPECT_EQ("trd3_refl", geom.id_to_label(VolumeId{25 + offset}).name);
 }
 
 //---------------------------------------------------------------------------//
@@ -344,7 +344,7 @@ TEST_F(SolidsTest, output)
     if (CELERITAS_USE_JSON)
     {
         EXPECT_EQ(
-            R"json({"bbox":[[-600.0,-300.0,-75.0],[600.0,300.0,75.0]],"supports_safety":true,"volumes":{"label":["","","","","box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","","trd3_refl","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","World","trd3_refl"]}})json",
+            R"json({"bbox":[[-600.0,-300.0,-75.0],[600.0,300.0,75.0]],"supports_safety":true,"volumes":{"label":["","","","","box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","","trd3_refl","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","trd3_refl"]}})json",
             to_string(out))
             << "\n/*** REPLACE ***/\nR\"json(" << to_string(out)
             << ")json\"\n/******/";
@@ -359,24 +359,11 @@ TEST_F(SolidsTest, trace)
         SCOPED_TRACE("Center -x");
         auto result = this->track({375, 0, 0}, {-1, 0, 0});
 
-        static char const* const expected_volumes[] = {"ellipsoid1",
-                                                       "World",
-                                                       "polycone1",
-                                                       "World",
-                                                       "polycone1",
-                                                       "World",
-                                                       "sphere1",
-                                                       "World",
-                                                       "box500",
-                                                       "World",
-                                                       "cone1",
-                                                       "World",
-                                                       "trd1",
-                                                       "World",
-                                                       "parabol1",
-                                                       "World",
-                                                       "trd2",
-                                                       "World"};
+        static char const* const expected_volumes[]
+            = {"ellipsoid1", "World",   "polycone1", "World",  "polycone1",
+               "World",      "sphere1", "World",     "box500", "World",
+               "cone1",      "World",   "trd1",      "World",  "parabol1",
+               "World",      "trd2",    "World",     "xtru1",  "World"};
         EXPECT_VEC_EQ(expected_volumes, result.volumes);
         static real_type const expected_distances[] = {20,
                                                        95,
@@ -395,7 +382,9 @@ TEST_F(SolidsTest, trace)
                                                        42.426642572798,
                                                        88.786678713601,
                                                        30,
-                                                       85};
+                                                       1.4761904761905,
+                                                       15.880952380952,
+                                                       67.642857142857};
         EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
         static real_type const expected_hw_safety[] = {0,
                                                        45.496748548005,
@@ -408,13 +397,15 @@ TEST_F(SolidsTest, trace)
                                                        25,
                                                        36.240004604773,
                                                        25,
-                                                       41.2043887972073,
+                                                       41.204388797207,
                                                        14.92555785315,
                                                        35.6066606432,
                                                        14.09753916278,
                                                        35.6066606432,
                                                        14.92555785315,
-                                                       42.289080583925};
+                                                       0.73443221182165,
+                                                       6.5489918373272,
+                                                       33.481506089183};
         EXPECT_VEC_SOFT_EQ(expected_hw_safety, result.halfway_safeties);
     }
     {
@@ -558,7 +549,7 @@ TEST_F(SolidsTest, trace)
 TEST_F(SolidsTest, reflected_vol)
 {
     auto geo = this->make_geo_track_view({-500, -125, 0}, {0, 1, 0});
-    EXPECT_EQ(VolumeId{28}, geo.volume_id());
+    EXPECT_EQ(VolumeId{29}, geo.volume_id());
     auto const& label = this->geometry()->id_to_label(geo.volume_id());
     EXPECT_EQ("trd3_refl", label.name);
     EXPECT_FALSE(ends_with(label.ext, "_refl"));

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -1239,7 +1239,8 @@ TEST_F(Solids, volumes_only)
            "trap1",    "trd1",     "trd2",      "",           "trd3_refl",
            "tube100",  "boolean1", "polycone1", "genPocone1", "ellipsoid1",
            "tetrah1",  "orb1",     "polyhedr1", "hype1",      "elltube1",
-           "ellcone1", "arb8b",    "arb8a",     "World",      "trd3_refl"};
+           "ellcone1", "arb8b",    "arb8a",     "xtru1",      "World",
+           "trd3_refl"};
     EXPECT_VEC_EQ(expected_names, names);
 }
 
@@ -1269,8 +1270,8 @@ TEST_F(Solids, volumes_unique)
            "polycone10x0", "genPocone10x0", "ellipsoid10x0",
            "tetrah10x0",   "orb10x0",       "polyhedr10x0",
            "hype10x0",     "elltube10x0",   "ellcone10x0",
-           "arb8b0x0",     "arb8a0x0",      "World0x0",
-           "trd30x0_refl"};
+           "arb8b0x0",     "arb8a0x0",      "xtru10x0",
+           "World0x0",     "trd30x0_refl"};
     EXPECT_VEC_EQ(expected_names, names);
 }
 

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -504,9 +504,10 @@ TEST_F(SolidsTest, names)
     // clang-format off
     static char const* const expected_labels[] = {"b500", "b100", "union1",
         "b100", "box500", "cone1", "para1", "sphere1", "parabol1", "trap1",
-        "trd1", "trd2", "trd3", "trd3_refl", "tube100", "boolean1", "polycone1",
-        "genPocone1", "ellipsoid1", "tetrah1", "orb1", "polyhedr1", "hype1",
-        "elltube1", "ellcone1", "arb8b", "arb8a", "World", "", "trd3_refl"};
+        "trd1", "trd2", "trd3", "trd3_refl", "tube100", "boolean1",
+        "polycone1", "genPocone1", "ellipsoid1", "tetrah1", "orb1",
+        "polyhedr1", "hype1", "elltube1", "ellcone1", "arb8b", "arb8a",
+        "xtru1", "World", "", "trd3_refl"};
     // clang-format on
     EXPECT_VEC_EQ(expected_labels, labels);
 }
@@ -522,7 +523,7 @@ TEST_F(SolidsTest, output)
         auto out_str = simplify_pointers(to_string(out));
 
         EXPECT_EQ(
-            R"json({"bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"supports_safety":true,"volumes":{"label":["b500","b100","union1","b100","box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","trd3","trd3_refl","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","World","","trd3_refl"]}})json",
+            R"json({"bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"supports_safety":true,"volumes":{"label":["b500","b100","union1","b100","box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","trd3","trd3_refl","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","","trd3_refl"]}})json",
             out_str)
             << "\n/*** REPLACE ***/\nR\"json(" << out_str
             << ")json\"\n/******/";
@@ -552,6 +553,8 @@ TEST_F(SolidsTest, trace)
                                                        "parabol1",
                                                        "World",
                                                        "trd2",
+                                                       "World",
+                                                       "xtru1",
                                                        "World"};
         EXPECT_VEC_EQ(expected_volumes, result.volumes);
         static real_type const expected_distances[] = {20,
@@ -567,26 +570,30 @@ TEST_F(SolidsTest, trace)
                                                        30,
                                                        88.786678713601,
                                                        42.426642572799,
-                                                       88.7866787136,
+                                                       88.786678713601,
                                                        30,
-                                                       85};
+                                                       1.4761904761905,
+                                                       15.880952380952,
+                                                       67.642857142857};
         EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
         static real_type const expected_hw_safety[] = {0,
                                                        45.496748548005,
                                                        0,
-                                                       44.8347556812201,
+                                                       44.83475568122,
                                                        13.934134186943,
                                                        30,
                                                        25,
                                                        36.240004604773,
                                                        25,
-                                                       41.2043887972073,
+                                                       41.204388797207,
                                                        14.92555785315,
                                                        42.910442345001,
                                                        18.741024106017,
                                                        42.910442345001,
                                                        14.92555785315,
-                                                       42.289080583925};
+                                                       0.7344322118216,
+                                                       6.5489918373272,
+                                                       33.481506089183};
         EXPECT_VEC_SOFT_EQ(expected_hw_safety, result.halfway_safeties);
     }
     {
@@ -940,8 +947,8 @@ TEST_F(SolidsGeantTest, names)
         "trd2@0x0", "trd3@0x0", "trd3_refl@0x0", "tube100@0x0", "", "", "", "",
         "boolean1@0x0", "polycone1@0x0", "genPocone1@0x0", "ellipsoid1@0x0",
         "tetrah1@0x0", "orb1@0x0", "polyhedr1@0x0", "hype1@0x0",
-        "elltube1@0x0", "ellcone1@0x0", "arb8b@0x0", "arb8a@0x0", "World@0x0",
-        "", "trd3@0x0_refl"};
+        "elltube1@0x0", "ellcone1@0x0", "arb8b@0x0", "arb8a@0x0", "xtru1@0x0",
+        "World@0x0", "", "trd3@0x0_refl"};;
     // clang-format on
     EXPECT_VEC_EQ(expected_labels, labels);
 }
@@ -957,7 +964,7 @@ TEST_F(SolidsGeantTest, output)
         auto out_str = simplify_pointers(to_string(out));
 
         EXPECT_EQ(
-            R"json({"bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"supports_safety":true,"volumes":{"label":["box500@0x0","cone1@0x0","para1@0x0","sphere1@0x0","parabol1@0x0","trap1@0x0","trd1@0x0","trd2@0x0","trd3@0x0","trd3_refl@0x0","tube100@0x0","","","","","boolean1@0x0","polycone1@0x0","genPocone1@0x0","ellipsoid1@0x0","tetrah1@0x0","orb1@0x0","polyhedr1@0x0","hype1@0x0","elltube1@0x0","ellcone1@0x0","arb8b@0x0","arb8a@0x0","World@0x0","","trd3@0x0_refl"]}})json",
+            R"json({"bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"supports_safety":true,"volumes":{"label":["box500@0x0","cone1@0x0","para1@0x0","sphere1@0x0","parabol1@0x0","trap1@0x0","trd1@0x0","trd2@0x0","trd3@0x0","trd3_refl@0x0","tube100@0x0","","","","","boolean1@0x0","polycone1@0x0","genPocone1@0x0","ellipsoid1@0x0","tetrah1@0x0","orb1@0x0","polyhedr1@0x0","hype1@0x0","elltube1@0x0","ellcone1@0x0","arb8b@0x0","arb8a@0x0","xtru1@0x0","World@0x0","","trd3@0x0_refl"]}})json",
             out_str)
             << "\n/*** REPLACE ***/\nR\"json(" << out_str
             << ")json\"\n/******/";
@@ -972,7 +979,7 @@ TEST_F(SolidsGeantTest, geant_volumes)
         auto result = this->get_import_geant_volumes();
         static int const expected_volumes[]
             = {0,  1,  2,  3,  4,  5,  6,  7,  -1, 9,  10, 15, 16,
-               17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 29};
+               17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 30};
         EXPECT_VEC_EQ(expected_volumes, result.volumes);
         EXPECT_EQ(0, result.missing_names.size()) << repr(result.missing_names);
     }
@@ -980,7 +987,7 @@ TEST_F(SolidsGeantTest, geant_volumes)
         auto result = this->get_direct_geant_volumes();
         static int const expected_volumes[]
             = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 15, 16,
-               17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, -2};
+               17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, -2};
         EXPECT_VEC_EQ(expected_volumes, result.volumes);
 
         static char const* const expected_missing[] = {"trd3_refl"};
@@ -1010,6 +1017,8 @@ TEST_F(SolidsGeantTest, trace)
                                                        "parabol1",
                                                        "World",
                                                        "trd2",
+                                                       "World",
+                                                       "xtru1",
                                                        "World"};
         EXPECT_VEC_EQ(expected_volumes, result.volumes);
         static real_type const expected_distances[] = {20,
@@ -1025,9 +1034,11 @@ TEST_F(SolidsGeantTest, trace)
                                                        30,
                                                        88.786678713601,
                                                        42.426642572799,
-                                                       88.7866787136,
+                                                       88.786678713601,
                                                        30,
-                                                       85};
+                                                       1.4761904761905,
+                                                       15.880952380952,
+                                                       67.642857142857};
         EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
     }
     {
@@ -1137,7 +1148,7 @@ TEST_F(SolidsGeantTest, trace)
 TEST_F(SolidsGeantTest, reflected_vol)
 {
     auto geo = this->make_geo_track_view({-500, -125, 0}, {0, 1, 0});
-    EXPECT_EQ(VolumeId{29}, geo.volume_id());
+    EXPECT_EQ(VolumeId{30}, geo.volume_id());
     auto const& label = this->geometry()->id_to_label(geo.volume_id());
     EXPECT_EQ("trd3", label.name);
     EXPECT_TRUE(ends_with(label.ext, "_refl"));


### PR DESCRIPTION
This adds support for G4ExtrudedSolid, needed for CMS HGCal. VecGeom's limited capabilities mean that we can only have a single z 'segment' (two z points).

The volume comparison and ray traces check out, but since `vecgeom::SExtru::Print` isn't fully implemented, I haven't done a 100% complete comparison of the generated extrusions.

With this addition, the HL-LHC model is successfully converted and copied to device.