### PR TITLE
Improve stream redirection behavior and logger destination

### DIFF
--- a/src/corecel/io/ScopedStreamRedirect.hh
+++ b/src/corecel/io/ScopedStreamRedirect.hh
@@ -25,10 +25,17 @@ namespace celeritas
     LoadVecGeom();
     CELER_LOG(diagnostic) << "Vecgeom said: " << silenced.str();
    \endcode
+ *
+ * The environment variable \c CELER_DISABLE_REDIRECT will prevent stream
+ * redirection, which might be needed if the code segfaults/aborts before this
+ * class's destructor is reached.
  */
 class ScopedStreamRedirect
 {
   public:
+    // Whether stream redirection is enabled
+    static bool allow_redirect();
+
     // Construct with pointer to a stream e.g. cout
     explicit ScopedStreamRedirect(std::ostream* os);
 
@@ -48,7 +55,7 @@ class ScopedStreamRedirect
     std::ostream* input_stream_;
 
     // Stores the redirected streams output buffer
-    std::streambuf* input_buffer_;
+    std::streambuf* input_buffer_{nullptr};
 
     // Holds an output buffer to share with the redirected stream
     std::stringstream temp_stream_;

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -290,7 +290,7 @@ void activate_device(Device&& device)
     CELER_LOG_LOCAL(debug) << "Initializing '" << device.name() << "', ID "
                            << device.device_id() << " of "
                            << Device::num_devices();
-    ScopedTimeLog scoped_time;
+    ScopedTimeLog scoped_time(&self_logger(), 1.0);
     Device& d = global_device();
     {
         // Lock *after* getting the pointer to the global_device, because

--- a/src/corecel/sys/ScopedSignalHandler.hh
+++ b/src/corecel/sys/ScopedSignalHandler.hh
@@ -25,7 +25,8 @@ namespace celeritas
  *
  * When the class exits scope, the signal for the active type will be cleared.
  *
- * Signal handling can be disabled by setting CELER_DISABLE_SIGNALS to a
+ * Signal handling can be disabled by setting the environment variable \c
+ * CELER_DISABLE_SIGNALS to a
  * non-empty value, but hopefully this will not be necessary because signal
  * handling should be used sparingly.
  *


### PR DESCRIPTION
Moved from #812 . These are small changes to:
- Give users a `CELER_DISABLE_REDIRECT` environment option to bypass stream redirection (which is needed for command-like applications where the JSON output is sent to screen, but bad for debugging when the code crashes before the buffer is printed)
- Print the device initialization time to the "local" screen, which is where the status message (debug, really) is now printed