### PR TITLE
Extend user-facing app/environment options

### DIFF
--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -597,7 +597,7 @@ int main(int argc, char* argv[])
     if (argc != 2)
     {
         // If number of arguments is incorrect, print help
-        std::cerr << "Usage: " << argv[0] << " {output}.root" << std::endl;
+        std::cerr << "usage: " << argv[0] << " {output}.root" << std::endl;
         return 2;
     }
 

--- a/app/celer-export-geant.cc
+++ b/app/celer-export-geant.cc
@@ -40,9 +40,12 @@ namespace
 //---------------------------------------------------------------------------//
 void print_usage(char const* exec_name)
 {
-    std::cerr << "Usage: " << exec_name
-              << " {input}.gdml [{options}.json, -, ''] {output}.root"
-              << std::endl;
+    // clang-format off
+    std::cerr
+        << "usage: " << exec_name << " {input}.gdml "
+                                     "[{options}.json, -, ''] {output}.root\n"
+           "       " << exec_name << " --dump-default\n";
+    // clang-format on
 }
 
 //---------------------------------------------------------------------------//
@@ -115,18 +118,19 @@ int main(int argc, char* argv[])
     if (args.size() == 1 && (args.front() == "--help" || args.front() == "-h"))
     {
         print_usage(argv[0]);
-        return 0;
+        return EXIT_SUCCESS;
     }
-    if (args.size() == 1 && args.front() == "--options")
+    if (args.size() == 1 && args.front() == "--dump-default")
     {
 #if CELERITAS_USE_JSON
         GeantPhysicsOptions options;
         constexpr int indent = 1;
         std::cout << nlohmann::json{options}.dump(indent) << std::endl;
+        return EXIT_SUCCESS;
 #else
         CELER_LOG(error) << "JSON is unavailable: can't output geant options";
+        return EXIT_FAILURE;
 #endif
-        return 0;
     }
     if (args.size() != 3)
     {

--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -76,30 +76,30 @@ endif()
 
 if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    set(DEMO_MAX_NUM_TRACKS 524288)
-    set(DEMO_INIT_CAPACITY 4194304)
+    set(CELERG4_MAX_NUM_TRACKS 524288)
+    set(CELERG4_INIT_CAPACITY 4194304)
   else()
     # Use smaller number of tracks when running on CPU
-    set(DEMO_MAX_NUM_TRACKS 2048)
-    set(DEMO_INIT_CAPACITY 65536)
+    set(CELERG4_MAX_NUM_TRACKS 2048)
+    set(CELERG4_INIT_CAPACITY 65536)
   endif()
 else()
   # Use smaller number of tracks when running on CPU
-  set(DEMO_MAX_NUM_TRACKS 1024)
-  set(DEMO_INIT_CAPACITY 32768)
+  set(CELERG4_MAX_NUM_TRACKS 1024)
+  set(CELERG4_INIT_CAPACITY 32768)
 endif()
 
 if(NOT CELERITAS_DEBUG)
-  set(DEMO_EVENTS
+  set(CELERG4_EVENTS
     "${CELER_APP_DATA_DIR}/ttbarsplit-12evt-1108prim.hepmc3")
 else()
   # Use fewer events for debug
-  set(DEMO_EVENTS
+  set(CELERG4_EVENTS
     "${CELER_APP_DATA_DIR}/ttbarbits-12evt-118prim.hepmc3")
 endif()
 if(CELERITAS_USE_ROOT)
-  set(DEMO_ROOT_OPTIONS "/setup/rootBufferSize 128000
-/setup/writeSDHits true")
+  set(CELERG4_ROOT_OPTIONS "/celerg4/rootBufferSize 128000
+/celerg4/writeSDHits true")
 endif()
 configure_file(
   "simple-cms-test.mac.in"

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -13,6 +13,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/sys/Device.hh"
 #include "accel/AlongStepFactory.hh"
+#include "accel/SetupOptionsMessenger.hh"
 
 namespace celeritas
 {
@@ -21,10 +22,14 @@ namespace app
 //---------------------------------------------------------------------------//
 /*!
  * Return non-owning pointer to a singleton.
+ *
+ * Creating the instance also creates a "messenger" that allows control over
+ * the Celeritas user inputs.
  */
 GlobalSetup* GlobalSetup::Instance()
 {
     static GlobalSetup setup;
+    static SetupOptionsMessenger mess{setup.options_.get()};
     return &setup;
 }
 
@@ -37,7 +42,7 @@ GlobalSetup::GlobalSetup()
     options_ = std::make_shared<SetupOptions>();
     field_ = G4ThreeVector(0, 0, 0);
     messenger_ = std::make_unique<G4GenericMessenger>(
-        this, "/setup/", "Demo geant integration setup");
+        this, "/celerg4/", "Demo geant integration setup");
 
     {
         auto& cmd = messenger_->DeclareProperty("geometryFile", geometry_file_);
@@ -64,57 +69,6 @@ GlobalSetup::GlobalSetup()
         cmd.SetGuidance(
             "Remove pointer suffix from input logical volume names");
         cmd.SetDefaultValue("true");
-    }
-    {
-        auto& cmd
-            = messenger_->DeclareProperty("outputFile", options_->output_file);
-        cmd.SetGuidance("Set the JSON output file name");
-    }
-    {
-        auto& cmd = messenger_->DeclareProperty("maxNumTracks",
-                                                options_->max_num_tracks);
-        cmd.SetGuidance("Set the maximum number of track slots");
-        options_->max_num_tracks = Device::num_devices() > 0 ? 524288 : 64;
-        cmd.SetDefaultValue(std::to_string(options_->max_num_tracks));
-    }
-    {
-        auto& cmd = messenger_->DeclareProperty("maxNumEvents",
-                                                options_->max_num_events);
-        cmd.SetGuidance("Set the maximum number of events in the run");
-        options_->max_num_events = 1024;
-        cmd.SetDefaultValue(std::to_string(options_->max_num_events));
-    }
-    {
-        auto& cmd = messenger_->DeclareProperty(
-            "secondaryStackFactor", options_->secondary_stack_factor);
-        cmd.SetGuidance("Set the number of secondary slots per track slot");
-        options_->secondary_stack_factor = 3;
-        cmd.SetDefaultValue(std::to_string(options_->secondary_stack_factor));
-    }
-    {
-        auto& cmd = messenger_->DeclareProperty(
-            "initializerCapacity", options_->initializer_capacity);
-        cmd.SetGuidance("Set the maximum number of queued tracks");
-        options_->initializer_capacity = 1048576;
-        cmd.SetDefaultValue(std::to_string(options_->initializer_capacity));
-    }
-    {
-        auto& cmd = messenger_->DeclareProperty("cudaStackSize",
-                                                options_->cuda_stack_size);
-        cmd.SetGuidance("Set the per-thread dynamic CUDA stack size (bytes)");
-        options_->cuda_stack_size = 0;
-    }
-    {
-        auto& cmd = messenger_->DeclareProperty("cudaHeapSize",
-                                                options_->cuda_heap_size);
-        cmd.SetGuidance("Set the shared dynamic CUDA heap size (bytes)");
-        options_->cuda_heap_size = 0;
-    }
-    {
-        auto& cmd = messenger_->DeclareProperty("defaultStream",
-                                                options_->default_stream);
-        cmd.SetGuidance("Launch all kernels on the default stream");
-        options_->default_stream = false;
     }
     {
         messenger_->DeclareMethod("magFieldZ",

--- a/app/celer-g4/simple-cms-test.mac.in
+++ b/app/celer-g4/simple-cms-test.mac.in
@@ -3,11 +3,12 @@
 /run/verbose 0
 /event/verbose 0
 
-/setup/geometryFile @PROJECT_SOURCE_DIR@/app/data/simple-cms.gdml
-/setup/eventFile @DEMO_EVENTS@
-/setup/outputFile simple-cms.out.json
-/setup/maxNumTracks @DEMO_MAX_NUM_TRACKS@
-/setup/maxNumEvents 1024
-@DEMO_ROOT_OPTIONS@
-/setup/secondaryStackFactor 3
-/setup/initializerCapacity @DEMO_INIT_CAPACITY@
+/celer/outputFile simple-cms.out.json
+/celer/maxNumTracks @CELERG4_MAX_NUM_TRACKS@
+/celer/maxNumEvents 1024
+/celer/maxInitializers @CELERG4_INIT_CAPACITY@
+/celer/secondaryStackFactor 3
+
+/celerg4/geometryFile @PROJECT_SOURCE_DIR@/app/data/simple-cms.gdml
+/celerg4/eventFile @CELERG4_EVENTS@
+@CELERG4_ROOT_OPTIONS@

--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -167,18 +167,16 @@ void Runner::build_core_params(RunnerInput const& inp,
     ImportData const imported = [&inp] {
         if (ends_with(inp.physics_filename, ".root"))
         {
-            // Load imported from ROOT file
-            return RootImporter(inp.physics_filename.c_str())();
+            // Load from ROOT file
+            return RootImporter(inp.physics_filename)();
         }
-        else if (ends_with(inp.physics_filename, ".gdml"))
+        std::string filename = inp.physics_filename;
+        if (filename.empty())
         {
-            // Load imported directly from Geant4
-            return GeantImporter(
-                GeantSetup(inp.physics_filename, inp.geant_options))();
+            filename = inp.geometry_filename;
         }
-        CELER_VALIDATE(false,
-                       << "invalid physics filename '" << inp.physics_filename
-                       << "' (expected gdml or root)");
+        // Load imported data directly from Geant4
+        return GeantImporter(GeantSetup(filename, inp.geant_options))();
     }();
 
     // Create action manager

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -84,7 +84,7 @@ struct RunnerInput
     //! Whether the run arguments are valid
     explicit operator bool() const
     {
-        return !geometry_filename.empty() && !physics_filename.empty()
+        return !geometry_filename.empty()
                && (primary_gen_options || !hepmc3_filename.empty())
                && num_track_slots > 0 && max_steps > 0
                && initializer_capacity > 0 && max_events > 0

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -63,7 +63,7 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_OPTION(environ);
 
     LDIO_LOAD_REQUIRED(geometry_filename);
-    LDIO_LOAD_REQUIRED(physics_filename);
+    LDIO_LOAD_OPTION(physics_filename);
     LDIO_LOAD_OPTION(hepmc3_filename);
 
     LDIO_LOAD_OPTION(primary_gen_options);
@@ -174,7 +174,7 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE_OPTION(brem_combined);
 
     LDIO_SAVE_OPTION(track_order);
-    if (ends_with(v.physics_filename, ".gdml"))
+    if (v.physics_filename.empty() || !ends_with(v.physics_filename, ".root"))
     {
         LDIO_SAVE_REQUIRED(geant_options);
     }

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -48,6 +48,8 @@
 #    include "RunnerInputIO.json.hh"
 #endif
 
+using namespace std::literals::string_view_literals;
+
 namespace celeritas
 {
 namespace app
@@ -148,7 +150,8 @@ void print_usage(char const* exec_name)
     std::cerr << "usage: " << exec_name << " {input}.json\n"
                  "       " << exec_name << " [--help|-h]\n"
                  "       " << exec_name << " --version\n"
-                 "       " << exec_name << " --config\n";
+                 "       " << exec_name << " --config\n"
+                 "       " << exec_name << " --dump-default\n";
     // clang-format on
 }
 
@@ -165,6 +168,7 @@ int main(int argc, char* argv[])
 {
     using celeritas::MpiCommunicator;
     using celeritas::ScopedMpiInit;
+    using celeritas::to_string;
     using std::cerr;
     using std::cout;
     using std::endl;
@@ -191,27 +195,35 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
     std::string_view filename{argv[1]};
-    if (filename == "--help" || filename == "-h")
+    if (filename == "--help"sv || filename == "-h"sv)
     {
         celeritas::app::print_usage(argv[0]);
         return EXIT_SUCCESS;
     }
-    if (filename == "--version" || filename == "-v")
+    if (filename == "--version"sv || filename == "-v"sv)
     {
         std::cout << celeritas_version << std::endl;
         return EXIT_SUCCESS;
     }
     if (!CELERITAS_USE_JSON)
     {
-        // Check for JSON *before* checking the config option
+        // Check for JSON *before* checking the options below
         std::cerr << argv[0]
                   << ": JSON is not enabled in this build of Celeritas"
                   << std::endl;
         return EXIT_FAILURE;
     }
-    if (filename == "--config")
+    if (filename == "--config"sv)
     {
         std::cout << to_string(celeritas::BuildOutput{}) << std::endl;
+        return EXIT_SUCCESS;
+    }
+    if (filename == "--dump-default"sv)
+    {
+#if CELERITAS_USE_JSON
+        std::cout << nlohmann::json{celeritas::app::RunnerInput{}}.dump(1)
+                  << std::endl;
+#endif
         return EXIT_SUCCESS;
     }
 

--- a/doc/api/accel.rst
+++ b/doc/api/accel.rst
@@ -26,6 +26,12 @@ provided.
 
 .. doxygenclass:: celeritas::SimpleOffload
 
+The SetupOptionsMessenger can be instantiated with a reference to a global
+SetupOptions instance in order to provide a Geant4 "UI" macro interface to an
+app's celeritas options.
+
+.. doxygenclass:: celeritas::SetupOptionsMessenger
+
 Celeritas setup
 ---------------
 

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND SOURCES
   AlongStepFactory.cc
   Logger.cc
   LocalTransporter.cc
+  SetupOptionsMessenger.cc
   SharedParams.cc
   SimpleOffload.cc
   detail/HitManager.cc

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -98,8 +98,6 @@ struct SetupOptions
     size_type initializer_capacity{};
     //! At least the average number of secondaries per track slot
     real_type secondary_stack_factor{3.0};
-    //! Sync the GPU at every kernel for error checking
-    bool sync{false};
     //!@}
 
     //! Set the number of streams (defaults to run manager # threads)
@@ -125,6 +123,8 @@ struct SetupOptions
     //! \name CUDA options
     size_type cuda_stack_size{};
     size_type cuda_heap_size{};
+    //! Sync the GPU at every kernel for timing
+    bool sync{false};
     //! Launch all kernels on the default stream
     bool default_stream{false};
     //!@}

--- a/src/accel/SetupOptionsMessenger.cc
+++ b/src/accel/SetupOptionsMessenger.cc
@@ -98,9 +98,11 @@ class CelerParamCommand final : public CelerCommand
         , dest_(dest)
     {
         // NOTE: Geant4 takes ownership of the parameter
-        param_ = new G4UIparameter(CmdTraits::type_info);
+        auto param = std::make_unique<G4UIparameter>(CmdTraits::type_info);
         // Set default value based on the current pointed-to value
-        param_->SetDefaultValue(CmdTraits::to_string(*dest).c_str());
+        param->SetDefaultValue(CmdTraits::to_string(*dest).c_str());
+        // Save to this command
+        this->SetParameter(param.release());
 
         // We're for setup only
         this->AvailableForStates(G4State_PreInit, G4State_Init);
@@ -109,12 +111,12 @@ class CelerParamCommand final : public CelerCommand
     void apply(G4String const& value_str) const final
     {
         auto converted = CmdTraits::from_string(value_str);
+
         // TODO: validation for non-matching types, i.e. int to unsigned
         *this->dest_ = static_cast<T>(converted);
     }
 
   private:
-    G4UIparameter* param_{nullptr};
     T* dest_;
 };
 

--- a/src/accel/SetupOptionsMessenger.cc
+++ b/src/accel/SetupOptionsMessenger.cc
@@ -188,8 +188,8 @@ SetupOptionsMessenger::SetupOptionsMessenger(SetupOptions* options)
                 "Set the CUDA per-thread heap size for VecGeom");
         add_cmd(
             &options->sync, "sync", "Sync the GPU at every kernel for timing");
-        add_cmd(&options->sync,
-                "default_stream",
+        add_cmd(&options->default_stream,
+                "defaultStream",
                 "Launch all kernels on the default stream");
     }
 }

--- a/src/accel/SetupOptionsMessenger.cc
+++ b/src/accel/SetupOptionsMessenger.cc
@@ -1,0 +1,210 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/SetupOptionsMessenger.cc
+//---------------------------------------------------------------------------//
+#include "SetupOptionsMessenger.hh"
+
+#include <type_traits>
+#include <G4UIcmdWithABool.hh>
+#include <G4UIcmdWithAnInteger.hh>
+
+#include "corecel/Assert.hh"
+#include "corecel/sys/Device.hh"
+
+#include "SetupOptions.hh"
+
+namespace celeritas
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+//! Helper traits for dealing with Geant4 UI commands
+template<class T, class = void>
+struct UICommandTraits;
+
+template<>
+struct UICommandTraits<std::string>
+{
+    static inline constexpr char type_info = 's';
+    static std::string const& to_string(G4String const& v) { return v; }
+    static std::string from_string(G4String const& v) { return v; }
+};
+
+template<>
+struct UICommandTraits<bool>
+{
+    static inline constexpr char type_info = 'b';
+    static G4String to_string(bool v)
+    {
+        return G4UIcommand::ConvertToString(v);
+    }
+    static bool from_string(G4String const& v)
+    {
+        return G4UIcommand::ConvertToBool(v.c_str());
+    }
+};
+
+template<class T>
+struct UICommandTraits<T, std::enable_if_t<std::is_integral_v<T>>>
+{
+    static inline constexpr char type_info = 'i';
+    static std::string to_string(T v) { return std::to_string(v); }
+    static long from_string(G4String const& v)
+    {
+        return G4UIcommand::ConvertToLongInt(v.c_str());
+    }
+};
+
+template<>
+struct UICommandTraits<double>
+{
+    static inline constexpr char type_info = 'd';
+    static G4String to_string(double v)
+    {
+        return G4UIcommand::ConvertToString(v);
+    }
+    static double from_string(G4String const& v)
+    {
+        return G4UIcommand::ConvertToDouble(v.c_str());
+    }
+};
+
+//---------------------------------------------------------------------------//
+//! Object-oriented command to invoke a user macro
+class CelerCommand : public G4UIcommand
+{
+  public:
+    using G4UIcommand::G4UIcommand;
+
+    virtual void apply(G4String const& newValue) const = 0;
+};
+
+template<class T>
+class CelerParamCommand final : public CelerCommand
+{
+  private:
+    using CmdTraits = UICommandTraits<T>;
+
+  public:
+    CelerParamCommand(G4UIdirectory const& parent,
+                      char const* cmd_path,
+                      G4UImessenger* mess,
+                      T* dest)
+        : CelerCommand(
+            (parent.GetCommandPath() + std::string(cmd_path)).c_str(), mess)
+        , dest_(dest)
+    {
+        // NOTE: Geant4 takes ownership of the parameter
+        param_ = new G4UIparameter(CmdTraits::type_info);
+        // Set default value based on the current pointed-to value
+        param_->SetDefaultValue(CmdTraits::to_string(*dest).c_str());
+
+        // We're for setup only
+        this->AvailableForStates(G4State_PreInit, G4State_Init);
+    }
+
+    void apply(G4String const& value_str) const final
+    {
+        auto converted = CmdTraits::from_string(value_str);
+        // TODO: validation for non-matching types, i.e. int to unsigned
+        *this->dest_ = static_cast<T>(converted);
+    }
+
+  private:
+    G4UIparameter* param_{nullptr};
+    T* dest_;
+};
+
+template<class T>
+CelerParamCommand(G4UIdirectory const&, char const*, G4UImessenger*, T*)
+    -> CelerParamCommand<T>;
+
+//---------------------------------------------------------------------------//
+//! Helper class for constructing a "directory"
+class CelerDirectory final : public G4UIdirectory
+{
+  public:
+    CelerDirectory(char const* path, char const* desc) : G4UIdirectory(path)
+    {
+        this->SetGuidance(desc);
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace
+
+SetupOptionsMessenger::SetupOptionsMessenger(SetupOptions* options)
+{
+    CELER_EXPECT(options);
+
+    auto add_cmd = [this](auto* ptr, char const* relpath, char const* desc) {
+        CELER_ASSERT(!directories_.empty());
+        this->commands_.emplace_back(
+            new CelerParamCommand{*directories_.back(), relpath, this, ptr});
+        this->commands_.back()->SetGuidance(desc);
+    };
+
+    directories_.emplace_back(
+        new CelerDirectory("/celer/", "Celeritas setup options"));
+    add_cmd(&options->geometry_file,
+            "geometryFile",
+            "Override detector geometry with a custom GDML");
+    add_cmd(&options->output_file,
+            "outputFile",
+            "Filename for JSON diagnostic output");
+    add_cmd(&options->physics_output_file,
+            "physicsOutputFile",
+            "Filename for ROOT dump of physics data");
+    add_cmd(&options->max_num_tracks,
+            "maxNumTracks",
+            "Number of track \"slots\" to be transported simultaneously");
+    add_cmd(&options->max_num_events,
+            "maxNumEvents",
+            "Maximum number of events in use");
+    add_cmd(&options->max_steps,
+            "maxNumSteps",
+            "Limit on number of step iterations before aborting");
+    add_cmd(&options->initializer_capacity,
+            "maxInitializers",
+            "Maximum number of track initializers (primaries+secondaries)");
+    add_cmd(&options->secondary_stack_factor,
+            "secondaryStackFactor",
+            "At least the average number of secondaries per track slot");
+
+    if (Device::num_devices() > 0)
+    {
+        directories_.emplace_back(new CelerDirectory(
+            "/celer/cuda/", "Celeritas CUDA setup options"));
+        add_cmd(&options->cuda_stack_size,
+                "stackSize",
+                "Set the CUDA per-thread stack size for VecGeom");
+        add_cmd(&options->cuda_heap_size,
+                "heapSize",
+                "Set the CUDA per-thread heap size for VecGeom");
+        add_cmd(
+            &options->sync, "sync", "Sync the GPU at every kernel for timing");
+        add_cmd(&options->sync,
+                "default_stream",
+                "Launch all kernels on the default stream");
+    }
+}
+
+//---------------------------------------------------------------------------//
+//! Default destructor
+SetupOptionsMessenger::~SetupOptionsMessenger() = default;
+
+//---------------------------------------------------------------------------//
+//! Dispatch a command
+void SetupOptionsMessenger::SetNewValue(G4UIcommand* cmd, G4String val)
+{
+    auto* celer_cmd = dynamic_cast<CelerCommand*>(cmd);
+    CELER_EXPECT(celer_cmd);
+
+    celer_cmd->apply(val);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/accel/SetupOptionsMessenger.hh
+++ b/src/accel/SetupOptionsMessenger.hh
@@ -1,0 +1,44 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/SetupOptionsMessenger.hh
+//---------------------------------------------------------------------------//
+#pragma once
+#include <memory>
+#include <vector>
+#include <G4UIcommand.hh>
+#include <G4UIdirectory.hh>
+#include <G4UImessenger.hh>
+
+namespace celeritas
+{
+struct SetupOptions;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Expose setup options through the Geant4 "macro" UI interface.
+ *
+ * \warning The given SetupOptions should be global *or* otherwise must exceed
+ * the scope of this UI messenger.
+ */
+class SetupOptionsMessenger : public G4UImessenger
+{
+  public:
+    // Construct with a reference to a setup options instance
+    explicit SetupOptionsMessenger(SetupOptions* options);
+
+    // Default destructor
+    ~SetupOptionsMessenger();
+
+  protected:
+    void SetNewValue(G4UIcommand* command, G4String newValue) override;
+
+  private:
+    std::vector<std::unique_ptr<G4UIdirectory>> directories_;
+    std::vector<std::unique_ptr<G4UIcommand>> commands_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/ext/GeantGeoUtils.hh
+++ b/src/celeritas/ext/GeantGeoUtils.hh
@@ -76,7 +76,7 @@ inline void reset_geant_geometry()
     CELER_NOT_CONFIGURED("Geant4");
 }
 
-inline void Span<G4LogicalVolume*> geant_logical_volumes()
+inline Span<G4LogicalVolume*> geant_logical_volumes()
 {
     CELER_NOT_CONFIGURED("Geant4");
 }

--- a/src/celeritas/ext/GeantGeoUtils.hh
+++ b/src/celeritas/ext/GeantGeoUtils.hh
@@ -66,7 +66,17 @@ inline G4VPhysicalVolume* load_geant_geometry(std::string const&)
     CELER_NOT_CONFIGURED("Geant4");
 }
 
+inline G4VPhysicalVolume* load_geant_geometry_native(std::string const&)
+{
+    CELER_NOT_CONFIGURED("Geant4");
+}
+
 inline void reset_geant_geometry()
+{
+    CELER_NOT_CONFIGURED("Geant4");
+}
+
+inline void Span<G4LogicalVolume*> geant_logical_volumes()
 {
     CELER_NOT_CONFIGURED("Geant4");
 }

--- a/src/celeritas/ext/RootImporter.hh
+++ b/src/celeritas/ext/RootImporter.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <string>
+
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
 #include "celeritas/io/ImportData.hh"
@@ -45,6 +47,12 @@ class RootImporter
   public:
     // Construct with ROOT file name
     explicit RootImporter(char const* filename);
+
+    //! Construct with ROOT file name
+    explicit RootImporter(std::string const& filename)
+        : RootImporter(filename.c_str())
+    {
+    }
 
     // Load data from the ROOT files
     ImportData operator()();

--- a/src/celeritas/user/RootStepWriterIO.json.cc
+++ b/src/celeritas/user/RootStepWriterIO.json.cc
@@ -38,8 +38,13 @@ void from_json(nlohmann::json const& j, SimpleRootFilterInput& options)
  */
 void to_json(nlohmann::json& j, SimpleRootFilterInput const& options)
 {
-#define SRFI_SAVE_OPTION(NAME) j[#NAME] = options.NAME
-    SRFI_SAVE_OPTION(track_id);
+    j["track_id"] = options.track_id;
+#define SRFI_SAVE_OPTION(NAME)                   \
+    do                                           \
+    {                                            \
+        if (options.NAME != options.unspecified) \
+            j[#NAME] = options.NAME;             \
+    } while (0)
     SRFI_SAVE_OPTION(event_id);
     SRFI_SAVE_OPTION(parent_id);
     SRFI_SAVE_OPTION(action_id);

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND SOURCES
   io/ScopedStreamRedirect.cc
   io/ScopedTimeAndRedirect.cc
   io/StringUtils.cc
+  io/detail/EnumStringMapperImpl.cc
   io/detail/LoggerMessage.cc
   io/detail/ReprImpl.cc
   sys/Device.cc

--- a/src/corecel/io/ColorUtils.cc
+++ b/src/corecel/io/ColorUtils.cc
@@ -46,7 +46,7 @@ bool use_color()
         }
         if (!isatty(fileno(stream)))
         {
-            // This stream is a user-facing terminal
+            // This stream is not a user-facing terminal
             return false;
         }
         if (const char* term_str = std::getenv("TERM"))

--- a/src/corecel/io/EnumStringMapper.hh
+++ b/src/corecel/io/EnumStringMapper.hh
@@ -10,6 +10,8 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/Array.hh"
 
+#include "detail/EnumStringMapperImpl.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -37,7 +39,7 @@ class EnumStringMapper
     //! Construct with one string per valid enum value
     template<class... Ts>
     explicit CELER_CONSTEXPR_FUNCTION EnumStringMapper(Ts... strings)
-        : strings_{strings...}
+        : strings_{strings..., detail::g_invalid_string}
     {
         // Protect against leaving off a string
         static_assert(sizeof...(strings) == static_cast<size_type>(T::size_),
@@ -50,7 +52,7 @@ class EnumStringMapper
   private:
     using size_type = std::underlying_type_t<T>;
 
-    Array<char const*, static_cast<size_type>(T::size_)> const strings_;
+    Array<char const*, static_cast<size_type>(T::size_) + 1> const strings_;
 };
 
 //---------------------------------------------------------------------------//
@@ -62,7 +64,7 @@ class EnumStringMapper
 template<class T>
 char const* EnumStringMapper<T>::operator()(T value) const
 {
-    CELER_EXPECT(value < T::size_);
+    CELER_EXPECT(value <= T::size_);
     return strings_[static_cast<size_type>(value)];
 }
 

--- a/src/corecel/io/detail/EnumStringMapperImpl.cc
+++ b/src/corecel/io/detail/EnumStringMapperImpl.cc
@@ -1,0 +1,20 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/io/detail/EnumStringMapperImpl.cc
+//---------------------------------------------------------------------------//
+#include "EnumStringMapperImpl.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+//! Externally defined "invalid" string
+char const g_invalid_string[] = "<invalid>";
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/corecel/io/detail/EnumStringMapperImpl.hh
+++ b/src/corecel/io/detail/EnumStringMapperImpl.hh
@@ -1,0 +1,20 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/io/detail/EnumStringMapperImpl.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+//! Externally defined "invalid" string
+extern char const g_invalid_string[];
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/test/corecel/io/EnumStringMapper.test.cc
+++ b/test/corecel/io/EnumStringMapper.test.cc
@@ -39,10 +39,8 @@ TEST(EnumStringMapperTest, all)
     EXPECT_STREQ("argonne", to_string(CeleritasLabs::argonne));
     EXPECT_STREQ("fermilab", to_string(CeleritasLabs::fermilab));
     EXPECT_STREQ("ornl", to_string(CeleritasLabs::ornl));
-    if (CELERITAS_DEBUG)
-    {
-        EXPECT_THROW(to_string(CeleritasLabs::size_), DebugError);
-    }
+    EXPECT_TRUE(std::string{to_string(CeleritasLabs::size_)}.find("invalid")
+                != std::string::npos);
 }
 
 // The following instances should fail to compile.


### PR DESCRIPTION
Key changes:
- Add a reusable Geant4 "UI" component for interfacing with `SetupOptions`, and renames the "directories" from `/setup` to `/celer` (common celeritas options) and `/celerg4` (app-specific)
- Use `CELER_COLOR` instead of `GTEST_COLOR` by default
- Add `--dump-default` argument to celer-sim app to print the default JSON database