### PR TITLE
Add field template deduction and parameterized test

### DIFF
--- a/app/demo-geo-check/GCheckKernel.cc
+++ b/app/demo-geo-check/GCheckKernel.cc
@@ -37,7 +37,7 @@ GCheckOutput run_cpu(SPConstGeo const& params,
     GeoTrackView geo(params->host_ref(), state.ref(), TrackSlotId(0));
     geo = GeoTrackInitializer{init->pos, init->dir};
 
-    LinearPropagator propagate(&geo);  // one propagator per track
+    LinearPropagator propagate(geo);  // one propagator per track
 
     printf("Initial track: pos=(%f, %f, %f), dir=(%f, %f, %f), outside=%i\n",
            geo.pos()[0],

--- a/app/demo-geo-check/GCheckKernel.cu
+++ b/app/demo-geo-check/GCheckKernel.cu
@@ -42,7 +42,7 @@ __global__ void gcheck_kernel(const GeoParamsCRefDevice params,
         return;
 
     GeoTrackView geo(params, state, TrackSlotId{tid.unchecked_get()});
-    LinearPropagator propagate(&geo);
+    LinearPropagator propagate(geo);
 
     // Start track at the leftmost point in the requested direction
     geo = init[tid.unchecked_get()];

--- a/src/celeritas/field/DormandPrinceStepper.hh
+++ b/src/celeritas/field/DormandPrinceStepper.hh
@@ -84,6 +84,15 @@ class DormandPrinceStepper
 };
 
 //---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class EquationT>
+CELER_FUNCTION DormandPrinceStepper(EquationT&&)->DormandPrinceStepper<EquationT>;
+
+template<class EquationT>
+CELER_FUNCTION DormandPrinceStepper(EquationT&)->DormandPrinceStepper<EquationT&>;
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/field/DormandPrinceStepper.hh
+++ b/src/celeritas/field/DormandPrinceStepper.hh
@@ -89,9 +89,6 @@ class DormandPrinceStepper
 template<class EquationT>
 CELER_FUNCTION DormandPrinceStepper(EquationT&&)->DormandPrinceStepper<EquationT>;
 
-template<class EquationT>
-CELER_FUNCTION DormandPrinceStepper(EquationT&)->DormandPrinceStepper<EquationT&>;
-
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -104,6 +104,17 @@ class FieldDriver
 };
 
 //---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class StepperT>
+CELER_FUNCTION FieldDriver(FieldDriverOptions const&, StepperT&&)
+    ->FieldDriver<StepperT>;
+
+template<class StepperT>
+CELER_FUNCTION FieldDriver(FieldDriverOptions const&, StepperT&)
+    ->FieldDriver<StepperT&>;
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -110,10 +110,6 @@ template<class StepperT>
 CELER_FUNCTION FieldDriver(FieldDriverOptions const&, StepperT&&)
     ->FieldDriver<StepperT>;
 
-template<class StepperT>
-CELER_FUNCTION FieldDriver(FieldDriverOptions const&, StepperT&)
-    ->FieldDriver<StepperT&>;
-
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -95,10 +95,6 @@ class FieldPropagator
 // DEDUCTION GUIDES
 //---------------------------------------------------------------------------//
 template<class DriverT, class GTV>
-CELER_FUNCTION FieldPropagator(DriverT&&, ParticleTrackView const&, GTV&)
-    ->FieldPropagator<DriverT, GTV&>;
-
-template<class DriverT, class GTV>
 CELER_FUNCTION FieldPropagator(DriverT&&, ParticleTrackView const&, GTV&&)
     ->FieldPropagator<DriverT, GTV>;
 

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -50,7 +50,7 @@ struct FieldPropagatorOptions
  *
  * \note This follows similar methods as in Geant4's G4PropagatorInField class.
  */
-template<class DriverT>
+template<class DriverT, class GTV>
 class FieldPropagator
 {
   public:
@@ -63,7 +63,7 @@ class FieldPropagator
     // Construct with shared parameters and the field driver
     inline CELER_FUNCTION FieldPropagator(DriverT&& driver,
                                           ParticleTrackView const& particle,
-                                          GeoTrackView* geo);
+                                          GTV&& geo);
 
     // Move track to next volume boundary.
     inline CELER_FUNCTION result_type operator()();
@@ -87,9 +87,20 @@ class FieldPropagator
     //// DATA ////
 
     DriverT driver_;
-    GeoTrackView& geo_;
+    GTV geo_;
     OdeState state_;
 };
+
+//---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class DriverT, class GTV>
+CELER_FUNCTION FieldPropagator(DriverT&&, ParticleTrackView const&, GTV&)
+    ->FieldPropagator<DriverT, GTV&>;
+
+template<class DriverT, class GTV>
+CELER_FUNCTION FieldPropagator(DriverT&&, ParticleTrackView const&, GTV&&)
+    ->FieldPropagator<DriverT, GTV>;
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
@@ -97,15 +108,12 @@ class FieldPropagator
 /*!
  * Construct with shared field parameters and the field driver.
  */
-template<class DriverT>
-CELER_FUNCTION
-FieldPropagator<DriverT>::FieldPropagator(DriverT&& driver,
-                                          ParticleTrackView const& particle,
-                                          GeoTrackView* geo)
-    : driver_(::celeritas::forward<DriverT>(driver)), geo_(*geo)
+template<class DriverT, class GTV>
+CELER_FUNCTION FieldPropagator<DriverT, GTV>::FieldPropagator(
+    DriverT&& driver, ParticleTrackView const& particle, GTV&& geo)
+    : driver_(::celeritas::forward<DriverT>(driver))
+    , geo_(::celeritas::forward<GTV>(geo))
 {
-    CELER_ASSERT(geo);
-
     using MomentumUnits = OdeState::MomentumUnits;
 
     state_.pos = geo_.pos();
@@ -117,8 +125,8 @@ FieldPropagator<DriverT>::FieldPropagator(DriverT&& driver,
 /*!
  * Propagate a charged particle until it hits a boundary.
  */
-template<class DriverT>
-CELER_FUNCTION auto FieldPropagator<DriverT>::operator()() -> result_type
+template<class DriverT, class GTV>
+CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()() -> result_type
 {
     return (*this)(numeric_limits<real_type>::infinity());
 }
@@ -149,8 +157,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()() -> result_type
  *   be slightly higher (again, up to a driver-based tolerance) than the
  *   physical distance travelled.
  */
-template<class DriverT>
-CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
+template<class DriverT, class GTV>
+CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
     -> result_type
 {
     CELER_EXPECT(step > 0);
@@ -335,8 +343,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT>::operator()(real_type step)
  * Currently this is set to the field driver's minimum step, but it should
  * probably be related to the geometry instead.
  */
-template<class DriverT>
-CELER_FUNCTION real_type FieldPropagator<DriverT>::bump_distance() const
+template<class DriverT, class GTV>
+CELER_FUNCTION real_type FieldPropagator<DriverT, GTV>::bump_distance() const
 {
     return driver_.minimum_step();
 }

--- a/src/celeritas/field/LinearPropagator.hh
+++ b/src/celeritas/field/LinearPropagator.hh
@@ -50,9 +50,6 @@ class LinearPropagator
 template<class GTV>
 CELER_FUNCTION LinearPropagator(GTV&&)->LinearPropagator<GTV>;
 
-template<class GTV>
-CELER_FUNCTION LinearPropagator(GTV&)->LinearPropagator<GTV&>;
-
 //---------------------------------------------------------------------------//
 /*!
  * Move track to next volume boundary.

--- a/src/celeritas/field/LinearPropagator.hh
+++ b/src/celeritas/field/LinearPropagator.hh
@@ -8,7 +8,6 @@
 #pragma once
 
 #include "orange/Types.hh"
-#include "celeritas/geo/GeoTrackView.hh"
 
 namespace celeritas
 {
@@ -16,6 +15,7 @@ namespace celeritas
 /*!
  * Propagate (move) a particle in a straight line.
  */
+template<class GTV>
 class LinearPropagator
 {
   public:
@@ -25,8 +25,11 @@ class LinearPropagator
     //!@}
 
   public:
-    // Construct from persistent and state data
-    inline CELER_FUNCTION LinearPropagator(GeoTrackView* track);
+    //! Construct from a geo track view
+    CELER_FUNCTION LinearPropagator(GTV&& track)
+        : geo_(::celeritas::forward<GTV>(track))
+    {
+    }
 
     // Move track to next volume boundary.
     inline CELER_FUNCTION result_type operator()();
@@ -38,31 +41,30 @@ class LinearPropagator
     static CELER_CONSTEXPR_FUNCTION bool tracks_can_loop() { return false; }
 
   private:
-    GeoTrackView& track_;
+    GTV geo_;
 };
 
 //---------------------------------------------------------------------------//
-/*!
- * Construct from persistent and state data.
- */
-CELER_FUNCTION LinearPropagator::LinearPropagator(GeoTrackView* track)
-    : track_(*track)
-{
-    CELER_EXPECT(track);
-}
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class GTV>
+CELER_FUNCTION LinearPropagator(GTV&&)->LinearPropagator<GTV>;
+
+template<class GTV>
+CELER_FUNCTION LinearPropagator(GTV&)->LinearPropagator<GTV&>;
 
 //---------------------------------------------------------------------------//
 /*!
  * Move track to next volume boundary.
  */
-CELER_FUNCTION
-LinearPropagator::result_type LinearPropagator::operator()()
+template<class GTV>
+CELER_FUNCTION auto LinearPropagator<GTV>::operator()() -> result_type
 {
-    CELER_EXPECT(!track_.is_outside());
+    CELER_EXPECT(!geo_.is_outside());
 
-    result_type result = track_.find_next_step();
+    result_type result = geo_.find_next_step();
     CELER_ASSERT(result.boundary);
-    track_.move_to_boundary();
+    geo_.move_to_boundary();
 
     return result;
 }
@@ -71,21 +73,22 @@ LinearPropagator::result_type LinearPropagator::operator()()
 /*!
  * Move track by a user-provided distance up to the next boundary.
  */
-CELER_FUNCTION
-LinearPropagator::result_type LinearPropagator::operator()(real_type dist)
+template<class GTV>
+CELER_FUNCTION auto LinearPropagator<GTV>::operator()(real_type dist)
+    -> result_type
 {
     CELER_EXPECT(dist > 0);
 
-    result_type result = track_.find_next_step(dist);
+    result_type result = geo_.find_next_step(dist);
 
     if (result.boundary)
     {
-        track_.move_to_boundary();
+        geo_.move_to_boundary();
     }
     else
     {
         CELER_ASSERT(dist == result.distance);
-        track_.move_internal(dist);
+        geo_.move_internal(dist);
     }
 
     return result;

--- a/src/celeritas/field/MagFieldEquation.hh
+++ b/src/celeritas/field/MagFieldEquation.hh
@@ -63,10 +63,6 @@ template<class FieldT>
 CELER_FUNCTION MagFieldEquation(FieldT&&, units::ElementaryCharge)
     ->MagFieldEquation<FieldT>;
 
-template<class FieldT>
-CELER_FUNCTION MagFieldEquation(FieldT&, units::ElementaryCharge)
-    ->MagFieldEquation<FieldT&>;
-
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/MagFieldEquation.hh
+++ b/src/celeritas/field/MagFieldEquation.hh
@@ -57,6 +57,17 @@ class MagFieldEquation
 };
 
 //---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class FieldT>
+CELER_FUNCTION MagFieldEquation(FieldT&&, units::ElementaryCharge)
+    ->MagFieldEquation<FieldT>;
+
+template<class FieldT>
+CELER_FUNCTION MagFieldEquation(FieldT&, units::ElementaryCharge)
+    ->MagFieldEquation<FieldT&>;
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/field/MakeMagFieldPropagator.hh
+++ b/src/celeritas/field/MakeMagFieldPropagator.hh
@@ -56,19 +56,17 @@ make_mag_field_stepper(FieldT&& field, units::ElementaryCharge charge)
  * propagate(0.123);
  * \endcode
  */
-template<class StepperT>
+template<class StepperT, class GTV>
 CELER_FUNCTION decltype(auto)
 make_field_propagator(StepperT&& stepper,
                       FieldDriverOptions const& options,
                       ParticleTrackView const& particle,
-                      GeoTrackView* geometry)
+                      GTV&& geometry)
 {
-    CELER_ASSERT(geometry);
-    using Driver_t = FieldDriver<StepperT>;
-    return FieldPropagator<Driver_t>{
-        Driver_t{options, ::celeritas::forward<StepperT>(stepper)},
+    return FieldPropagator{
+        FieldDriver{options, ::celeritas::forward<StepperT>(stepper)},
         particle,
-        geometry};
+        ::celeritas::forward<GTV>(geometry)};
 }
 
 //---------------------------------------------------------------------------//
@@ -86,19 +84,19 @@ make_field_propagator(StepperT&& stepper,
  * propagate(0.123);
  * \endcode
  */
-template<template<class EquationT> class StepperT, class FieldT>
+template<template<class EquationT> class StepperT, class FieldT, class GTV>
 CELER_FUNCTION decltype(auto)
 make_mag_field_propagator(FieldT&& field,
                           FieldDriverOptions const& options,
                           ParticleTrackView const& particle,
-                          GeoTrackView* geometry)
+                          GTV geometry)
 {
     return make_field_propagator(
         make_mag_field_stepper<StepperT>(::celeritas::forward<FieldT>(field),
                                          particle.charge()),
         options,
         particle,
-        geometry);
+        ::celeritas::forward<GTV>(geometry));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/MakeMagFieldPropagator.hh
+++ b/src/celeritas/field/MakeMagFieldPropagator.hh
@@ -89,7 +89,7 @@ CELER_FUNCTION decltype(auto)
 make_mag_field_propagator(FieldT&& field,
                           FieldDriverOptions const& options,
                           ParticleTrackView const& particle,
-                          GTV geometry)
+                          GTV&& geometry)
 {
     return make_field_propagator(
         make_mag_field_stepper<StepperT>(::celeritas::forward<FieldT>(field),

--- a/src/celeritas/field/RungeKuttaStepper.hh
+++ b/src/celeritas/field/RungeKuttaStepper.hh
@@ -56,6 +56,15 @@ class RungeKuttaStepper
 };
 
 //---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class EquationT>
+CELER_FUNCTION RungeKuttaStepper(EquationT&&)->RungeKuttaStepper<EquationT>;
+
+template<class EquationT>
+CELER_FUNCTION RungeKuttaStepper(EquationT&)->RungeKuttaStepper<EquationT&>;
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/field/RungeKuttaStepper.hh
+++ b/src/celeritas/field/RungeKuttaStepper.hh
@@ -61,9 +61,6 @@ class RungeKuttaStepper
 template<class EquationT>
 CELER_FUNCTION RungeKuttaStepper(EquationT&&)->RungeKuttaStepper<EquationT>;
 
-template<class EquationT>
-CELER_FUNCTION RungeKuttaStepper(EquationT&)->RungeKuttaStepper<EquationT&>;
-
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/ZHelixStepper.hh
+++ b/src/celeritas/field/ZHelixStepper.hh
@@ -81,9 +81,6 @@ class ZHelixStepper
 template<class EquationT>
 CELER_FUNCTION ZHelixStepper(EquationT&&)->ZHelixStepper<EquationT>;
 
-template<class EquationT>
-CELER_FUNCTION ZHelixStepper(EquationT&)->ZHelixStepper<EquationT&>;
-
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/ZHelixStepper.hh
+++ b/src/celeritas/field/ZHelixStepper.hh
@@ -76,6 +76,15 @@ class ZHelixStepper
 };
 
 //---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class EquationT>
+CELER_FUNCTION ZHelixStepper(EquationT&&)->ZHelixStepper<EquationT>;
+
+template<class EquationT>
+CELER_FUNCTION ZHelixStepper(EquationT&)->ZHelixStepper<EquationT&>;
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
@@ -24,7 +24,7 @@
 
 #include "detail/ElossApplier.hh"
 #include "detail/FluctELoss.hh"  // IWYU pragma: associated
-#include "detail/LinearTrackPropagator.hh"
+#include "detail/LinearPropagatorFactory.hh"
 #include "detail/MeanELoss.hh"  // IWYU pragma: associated
 #include "detail/MscApplier.hh"
 #include "detail/MscStepLimitApplier.hh"
@@ -96,7 +96,7 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
         launch_impl(
             MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}});
     }
-    launch_impl(PropagationApplier{LinearTrackPropagator{}});
+    launch_impl(PropagationApplier{LinearPropagatorFactory{}});
     if (msc_)
     {
         launch_impl(MscApplier{UrbanMsc{msc_->ref<MemSpace::native>()}});

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
@@ -16,7 +16,7 @@
 
 #include "AlongStep.hh"  // IWYU pragma: associated
 #include "detail/AlongStepNeutralImpl.hh"  // IWYU pragma: associated
-#include "detail/LinearTrackPropagator.hh"  // IWYU pragma: associated
+#include "detail/LinearPropagatorFactory.hh"  // IWYU pragma: associated
 
 namespace celeritas
 {
@@ -41,7 +41,7 @@ void AlongStepNeutralAction::execute(CoreParams const& params,
         state.ptr(),
         this->action_id(),
         AlongStep{detail::NoMsc{},
-                  detail::LinearTrackPropagator{},
+                  detail::LinearPropagatorFactory{},
                   detail::NoELoss{}});
     return launch_action(*this, params, state, execute);
 }

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
@@ -13,7 +13,7 @@
 #include "celeritas/global/TrackExecutor.hh"
 
 #include "detail/AlongStepNeutralImpl.hh"
-#include "detail/LinearTrackPropagator.hh"
+#include "detail/LinearPropagatorFactory.hh"
 
 namespace celeritas
 {
@@ -29,7 +29,7 @@ void AlongStepNeutralAction::execute(CoreParams const& params,
         state.ptr(),
         this->action_id(),
         AlongStep{detail::NoMsc{},
-                  detail::LinearTrackPropagator{},
+                  detail::LinearPropagatorFactory{},
                   detail::NoELoss{}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
     launch_kernel(state, execute);

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
@@ -24,7 +24,7 @@
 
 #include "AlongStep.hh"
 #include "detail/FluctELoss.hh"
-#include "detail/RZMapFieldTrackPropagator.hh"
+#include "detail/RZMapFieldPropagatorFactory.hh"
 
 namespace celeritas
 {
@@ -79,10 +79,10 @@ void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
         params.ptr<MemSpace::native>(),
         state.ptr(),
         this->action_id(),
-        AlongStep{
-            UrbanMsc{msc_->ref<MemSpace::native>()},
-            detail::RZMapFieldTrackPropagator{field_->ref<MemSpace::native>()},
-            detail::FluctELoss{fluct_->ref<MemSpace::native>()}});
+        AlongStep{UrbanMsc{msc_->ref<MemSpace::native>()},
+                  detail::RZMapFieldPropagatorFactory{
+                      field_->ref<MemSpace::native>()},
+                  detail::FluctELoss{fluct_->ref<MemSpace::native>()}});
     return launch_action(*this, params, state, execute);
 }
 

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cu
@@ -17,7 +17,7 @@
 
 #include "detail/AlongStepKernels.hh"
 #include "detail/PropagationApplier.hh"
-#include "detail/RZMapFieldTrackPropagator.hh"
+#include "detail/RZMapFieldPropagatorFactory.hh"
 
 namespace celeritas
 {
@@ -35,7 +35,7 @@ void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
             params.ptr<MemSpace::native>(),
             state.ptr(),
             this->action_id(),
-            detail::PropagationApplier{detail::RZMapFieldTrackPropagator{
+            detail::PropagationApplier{detail::RZMapFieldPropagatorFactory{
                 field_->ref<MemSpace::native>()}});
         static ActionLauncher<decltype(execute_thread)> const launch_kernel(
             *this, "propagate-rzmap");

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
@@ -22,7 +22,7 @@
 
 #include "AlongStep.hh"
 #include "detail/MeanELoss.hh"
-#include "detail/UniformFieldTrackPropagator.hh"
+#include "detail/UniformFieldPropagatorFactory.hh"
 
 namespace celeritas
 {
@@ -67,7 +67,8 @@ void AlongStepUniformMscAction::execute(CoreParams const& params,
         launch_impl(
             MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}});
     }
-    launch_impl(PropagationApplier{UniformFieldTrackPropagator{field_params_}});
+    launch_impl(
+        PropagationApplier{UniformFieldPropagatorFactory{field_params_}});
     if (msc_)
     {
         launch_impl(MscApplier{UrbanMsc{msc_->ref<MemSpace::native>()}});

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
@@ -19,7 +19,7 @@
 
 #include "detail/AlongStepKernels.hh"
 #include "detail/PropagationApplier.hh"
-#include "detail/UniformFieldTrackPropagator.hh"
+#include "detail/UniformFieldPropagatorFactory.hh"
 
 namespace celeritas
 {
@@ -41,7 +41,7 @@ void AlongStepUniformMscAction::execute(CoreParams const& params,
             state.ptr(),
             this->action_id(),
             detail::PropagationApplier{
-                detail::UniformFieldTrackPropagator{field_params_}});
+                detail::UniformFieldPropagatorFactory{field_params_}});
         static ActionLauncher<decltype(execute_thread)> const launch_kernel(
             *this, "propagate");
         launch_kernel(state, execute_thread);

--- a/src/celeritas/global/alongstep/detail/AlongStepKernels.cu
+++ b/src/celeritas/global/alongstep/detail/AlongStepKernels.cu
@@ -17,7 +17,7 @@
 
 #include "ElossApplier.hh"
 #include "FluctELoss.hh"
-#include "LinearTrackPropagator.hh"
+#include "LinearPropagatorFactory.hh"
 #include "MeanELoss.hh"
 #include "MscApplier.hh"
 #include "MscStepLimitApplier.hh"
@@ -56,7 +56,7 @@ void launch_propagate(ExplicitActionInterface const& action,
         params.ptr<MemSpace::native>(),
         state.ptr(),
         action.action_id(),
-        detail::PropagationApplier{detail::LinearTrackPropagator{}});
+        detail::PropagationApplier{detail::LinearPropagatorFactory{}});
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(
         action, "propagate-linear");
     launch_kernel(state, execute_thread);

--- a/src/celeritas/global/alongstep/detail/LinearPropagatorFactory.hh
+++ b/src/celeritas/global/alongstep/detail/LinearPropagatorFactory.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/global/alongstep/detail/LinearTrackPropagator.hh
+//! \file celeritas/global/alongstep/detail/LinearPropagatorFactory.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -20,12 +20,11 @@ namespace detail
 /*!
  * Create a propagator for neutral particles or no fields.
  */
-struct LinearTrackPropagator
+struct LinearPropagatorFactory
 {
-    CELER_FUNCTION Propagation operator()(CoreTrackView const& track,
-                                          real_type max_step) const
+    CELER_FUNCTION decltype(auto) operator()(CoreTrackView const& track) const
     {
-        return LinearPropagator{track.make_geo_view()}(max_step);
+        return LinearPropagator{track.make_geo_view()};
     }
 
     static CELER_CONSTEXPR_FUNCTION bool tracks_can_loop() { return false; }

--- a/src/celeritas/global/alongstep/detail/LinearTrackPropagator.hh
+++ b/src/celeritas/global/alongstep/detail/LinearTrackPropagator.hh
@@ -25,14 +25,10 @@ struct LinearTrackPropagator
     CELER_FUNCTION Propagation operator()(CoreTrackView const& track,
                                           real_type max_step) const
     {
-        auto geo = track.make_geo_view();
-        return LinearPropagator{&geo}(max_step);
+        return LinearPropagator{track.make_geo_view()}(max_step);
     }
 
-    static CELER_CONSTEXPR_FUNCTION bool tracks_can_loop()
-    {
-        return LinearPropagator::tracks_can_loop();
-    }
+    static CELER_CONSTEXPR_FUNCTION bool tracks_can_loop() { return false; }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/detail/RZMapFieldPropagatorFactory.hh
+++ b/src/celeritas/global/alongstep/detail/RZMapFieldPropagatorFactory.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/global/alongstep/detail/RZMapFieldTrackPropagator.hh
+//! \file celeritas/global/alongstep/detail/RZMapFieldPropagatorFactory.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -20,17 +20,15 @@ namespace detail
 /*!
  * Propagate a track in an RZ map magnetic field.
  */
-struct RZMapFieldTrackPropagator
+struct RZMapFieldPropagatorFactory
 {
-    CELER_FUNCTION Propagation operator()(CoreTrackView const& track,
-                                          real_type max_step) const
+    CELER_FUNCTION decltype(auto) operator()(CoreTrackView const& track) const
     {
-        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
+        return make_mag_field_propagator<DormandPrinceStepper>(
             RZMapField{field},
             field.options,
             track.make_particle_view(),
             track.make_geo_view());
-        return propagate(max_step);
     }
 
     static CELER_CONSTEXPR_FUNCTION bool tracks_can_loop() { return true; }

--- a/src/celeritas/global/alongstep/detail/RZMapFieldTrackPropagator.hh
+++ b/src/celeritas/global/alongstep/detail/RZMapFieldTrackPropagator.hh
@@ -25,10 +25,11 @@ struct RZMapFieldTrackPropagator
     CELER_FUNCTION Propagation operator()(CoreTrackView const& track,
                                           real_type max_step) const
     {
-        auto geo = track.make_geo_view();
-        auto particle = track.make_particle_view();
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            RZMapField{field}, field.options, particle, &geo);
+            RZMapField{field},
+            field.options,
+            track.make_particle_view(),
+            track.make_geo_view());
         return propagate(max_step);
     }
 

--- a/src/celeritas/global/alongstep/detail/UniformFieldPropagatorFactory.hh
+++ b/src/celeritas/global/alongstep/detail/UniformFieldPropagatorFactory.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/global/alongstep/detail/UniformFieldTrackPropagator.hh
+//! \file celeritas/global/alongstep/detail/UniformFieldPropagatorFactory.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -20,17 +20,15 @@ namespace detail
 /*!
  * Propagate a track in a uniform magnetic field.
  */
-struct UniformFieldTrackPropagator
+struct UniformFieldPropagatorFactory
 {
-    CELER_FUNCTION Propagation operator()(CoreTrackView const& track,
-                                          real_type max_step) const
+    CELER_FUNCTION decltype(auto) operator()(CoreTrackView const& track) const
     {
-        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
+        return make_mag_field_propagator<DormandPrinceStepper>(
             UniformField(field.field),
             field.options,
             track.make_particle_view(),
             track.make_geo_view());
-        return propagate(max_step);
     }
 
     static CELER_CONSTEXPR_FUNCTION bool tracks_can_loop() { return true; }

--- a/src/celeritas/global/alongstep/detail/UniformFieldTrackPropagator.hh
+++ b/src/celeritas/global/alongstep/detail/UniformFieldTrackPropagator.hh
@@ -25,10 +25,11 @@ struct UniformFieldTrackPropagator
     CELER_FUNCTION Propagation operator()(CoreTrackView const& track,
                                           real_type max_step) const
     {
-        auto geo = track.make_geo_view();
-        auto particle = track.make_particle_view();
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            UniformField(field.field), field.options, particle, &geo);
+            UniformField(field.field),
+            field.options,
+            track.make_particle_view(),
+            track.make_geo_view());
         return propagate(max_step);
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -352,7 +352,7 @@ celeritas_add_test(celeritas/field/FieldDriver.test.cc)
 celeritas_add_test(celeritas/field/FieldPropagator.test.cc
   ${_needs_geo} LINK_LIBRARIES ${_core_geo_lib})
 celeritas_add_test(celeritas/field/LinearPropagator.test.cc
-  ${_needs_geo} LINK_LIBRARIES  ${_core_geo_lib})
+  ${_needs_geo} LINK_LIBRARIES ${_geo_libs})
 celeritas_add_test(celeritas/field/MagFieldEquation.test.cc)
 
 #-------------------------------------#

--- a/test/celeritas/AllGeoTypedTestBase.hh
+++ b/test/celeritas/AllGeoTypedTestBase.hh
@@ -1,0 +1,108 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/AllGeoTypedTestBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+#include <gtest/gtest.h>
+
+#include "celeritas_config.h"
+#include "orange/OrangeData.hh"
+#include "orange/OrangeParams.hh"
+#include "orange/OrangeTrackView.hh"
+
+#include "GenericGeoTestBase.hh"
+#if CELERITAS_USE_VECGEOM
+#    include "celeritas/ext/VecgeomData.hh"
+#    include "celeritas/ext/VecgeomParams.hh"
+#    include "celeritas/ext/VecgeomTrackView.hh"
+#endif
+#if CELERITAS_USE_GEANT4
+#    include "celeritas/ext/GeantGeoData.hh"
+#    include "celeritas/ext/GeantGeoParams.hh"
+#    include "celeritas/ext/GeantGeoTrackView.hh"
+#endif
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Type-parameterized geometry test harness.
+ *
+ * \tparam HP Geometry host Params class
+ *
+ * To use this class to test all available geometry types, add
+ * \code
+ *   ${_needs_geo} LINK_LIBRARIES ${_geo_libs}
+ * \endcode
+ *
+ * to the \c celeritas_add_test argument in CMakeLists.txt, and instantiate all
+ * the types with:
+ *
+ \code
+  template<class HP>
+  class MyFooTest : public AllGeoTypedTestBase<HP>
+  {
+    std::string geometry_basename() const final { return "simple-cms"; }
+  };
+
+  TYPED_TEST_SUITE(MyFooTest, AllGeoTestingTypes, AllGeoTestingTypeNames);
+
+  TYPED_TEST(MyFooTest, bar)
+  {
+      using GeoTrackView = typename TestFixture::GeoTrackView;
+      auto geo = this->geometry();
+      auto track = this->make_track_view({1, 2, 3}, {0, 0, 1});
+  }
+ \endcode
+ */
+template<class HP>
+class AllGeoTypedTestBase : public GenericGeoTestBase<HP>
+{
+  public:
+    using SPConstGeo = typename GenericGeoTestBase<HP>::SPConstGeo;
+
+    SPConstGeo build_geometry() override
+    {
+        return this->build_geometry_from_basename();
+    }
+};
+
+//---------------------------------------------------------------------------//
+// TYPE ALIASES
+//---------------------------------------------------------------------------//
+
+using GenericVecgeomTestBase = GenericGeoTestBase<VecgeomParams>;
+using GenericOrangeTestBase = GenericGeoTestBase<OrangeParams>;
+using GenericGeantGeoTestBase = GenericGeoTestBase<GeantGeoParams>;
+
+using GenericCoreGeoTestBase = GenericGeoTestBase<GeoParams>;
+
+using AllGeoTestingTypes = ::testing::Types<
+#if CELERITAS_USE_VECGEOM
+    VecgeomParams,
+#endif
+#if CELERITAS_USE_GEANT4
+    GeantGeoParams,
+#endif
+    OrangeParams>;
+
+//! Helper class for returning type names
+struct AllGeoTestingTypeNames
+{
+    template<class U>
+    static std::string GetName(int)
+    {
+        return testdetail::GenericGeoTraits<U>::name;
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/GenericGeoTestBase.cc
+++ b/test/celeritas/GenericGeoTestBase.cc
@@ -33,6 +33,7 @@
 #endif
 
 using std::cout;
+using namespace std::literals;
 using GeantVolResult = celeritas::test::GenericGeoGeantImportVolumeResult;
 
 namespace celeritas
@@ -153,8 +154,21 @@ GeantVolResult::from_pointers([[maybe_unused]] GeoParamsInterface const& geom,
 }
 
 //---------------------------------------------------------------------------//
-template<class HP, template<Ownership, MemSpace> class S, class TV>
-auto GenericGeoTestBase<HP, S, TV>::geometry() -> SPConstGeo const&
+//
+template<class HP>
+auto GenericGeoTestBase<HP>::build_from_basename(std::string_view basename)
+    -> SPConstGeo
+{
+    // Construct filename:
+    // ${SOURCE}/test/celeritas/data/${basename}${fileext}
+    auto filename = std::string{basename} + std::string{TraitsT::ext};
+    std::string test_file = test_data_path("celeritas", filename);
+    return std::make_shared<HP>(test_file);
+}
+
+//---------------------------------------------------------------------------//
+template<class HP>
+auto GenericGeoTestBase<HP>::geometry() -> SPConstGeo const&
 {
     if (!geo_)
     {
@@ -172,17 +186,16 @@ auto GenericGeoTestBase<HP, S, TV>::geometry() -> SPConstGeo const&
 }
 
 //---------------------------------------------------------------------------//
-template<class HP, template<Ownership, MemSpace> class S, class TV>
-auto GenericGeoTestBase<HP, S, TV>::geometry() const -> SPConstGeo const&
+template<class HP>
+auto GenericGeoTestBase<HP>::geometry() const -> SPConstGeo const&
 {
     CELER_ENSURE(geo_);
     return geo_;
 }
 
 //---------------------------------------------------------------------------//
-template<class HP, template<Ownership, MemSpace> class S, class TV>
-std::string
-GenericGeoTestBase<HP, S, TV>::volume_name(GeoTrackView const& geo) const
+template<class HP>
+std::string GenericGeoTestBase<HP>::volume_name(GeoTrackView const& geo) const
 {
     if (geo.is_outside())
     {
@@ -192,9 +205,8 @@ GenericGeoTestBase<HP, S, TV>::volume_name(GeoTrackView const& geo) const
 }
 
 //---------------------------------------------------------------------------//
-template<class HP, template<Ownership, MemSpace> class S, class TV>
-std::string
-GenericGeoTestBase<HP, S, TV>::surface_name(GeoTrackView const& geo) const
+template<class HP>
+std::string GenericGeoTestBase<HP>::surface_name(GeoTrackView const& geo) const
 {
     if (!geo.is_on_boundary())
     {
@@ -213,8 +225,8 @@ GenericGeoTestBase<HP, S, TV>::surface_name(GeoTrackView const& geo) const
 }
 
 //---------------------------------------------------------------------------//
-template<class HP, template<Ownership, MemSpace> class S, class TV>
-auto GenericGeoTestBase<HP, S, TV>::make_geo_track_view() -> GeoTrackView
+template<class HP>
+auto GenericGeoTestBase<HP>::make_geo_track_view() -> GeoTrackView
 {
     if (!host_state_)
     {
@@ -226,9 +238,8 @@ auto GenericGeoTestBase<HP, S, TV>::make_geo_track_view() -> GeoTrackView
 
 //---------------------------------------------------------------------------//
 // Get and initialize a single-thread host track view
-template<class HP, template<Ownership, MemSpace> class S, class TV>
-auto GenericGeoTestBase<HP, S, TV>::make_geo_track_view(Real3 const& pos,
-                                                        Real3 dir)
+template<class HP>
+auto GenericGeoTestBase<HP>::make_geo_track_view(Real3 const& pos, Real3 dir)
     -> GeoTrackView
 {
     normalize_direction(&dir);
@@ -240,10 +251,9 @@ auto GenericGeoTestBase<HP, S, TV>::make_geo_track_view(Real3 const& pos,
 
 //---------------------------------------------------------------------------//
 // Get and initialize a single-thread host track view
-template<class HP, template<Ownership, MemSpace> class S, class TV>
-auto GenericGeoTestBase<HP, S, TV>::calc_bump_pos(GeoTrackView const& geo,
-                                                  real_type delta) const
-    -> Real3
+template<class HP>
+auto GenericGeoTestBase<HP>::calc_bump_pos(GeoTrackView const& geo,
+                                           real_type delta) const -> Real3
 {
     CELER_EXPECT(delta > 0);
     auto pos = geo.pos();
@@ -252,8 +262,8 @@ auto GenericGeoTestBase<HP, S, TV>::calc_bump_pos(GeoTrackView const& geo,
 }
 
 //---------------------------------------------------------------------------//
-template<class HP, template<Ownership, MemSpace> class S, class TV>
-auto GenericGeoTestBase<HP, S, TV>::track(Real3 const& pos, Real3 const& dir)
+template<class HP>
+auto GenericGeoTestBase<HP>::track(Real3 const& pos, Real3 const& dir)
     -> TrackingResult
 {
     TrackingResult result;
@@ -302,15 +312,12 @@ auto GenericGeoTestBase<HP, S, TV>::track(Real3 const& pos, Real3 const& dir)
 //---------------------------------------------------------------------------//
 // EXPLICIT TEMPLATE INSTANTIATIONS
 //---------------------------------------------------------------------------//
-template class GenericGeoTestBase<OrangeParams, OrangeStateData, OrangeTrackView>;
+template class GenericGeoTestBase<OrangeParams>;
 #if CELERITAS_USE_VECGEOM
-template class GenericGeoTestBase<VecgeomParams, VecgeomStateData, VecgeomTrackView>;
+template class GenericGeoTestBase<VecgeomParams>;
 #endif
-
 #if CELERITAS_USE_GEANT4
-template class GenericGeoTestBase<GeantGeoParams,
-                                  GeantGeoStateData,
-                                  GeantGeoTrackView>;
+template class GenericGeoTestBase<GeantGeoParams>;
 #endif
 //---------------------------------------------------------------------------//
 }  // namespace test

--- a/test/celeritas/GenericGeoTestBase.hh
+++ b/test/celeritas/GenericGeoTestBase.hh
@@ -50,32 +50,71 @@ struct GenericGeoGeantImportVolumeResult
     void print_expected() const;
 };
 
+namespace
+{
+//---------------------------------------------------------------------------//
+template<class HP>
+struct GenericGeoTraits;
+
+template<>
+struct GenericGeoTraits<VecgeomParams>
+{
+    template<MemSpace M>
+    using StateStore = CollectionStateStore<VecgeomStateData, M>;
+    using TrackView = VecgeomTrackView;
+    static inline char const* ext = ".gdml";
+};
+
+template<>
+struct GenericGeoTraits<OrangeParams>
+{
+    template<MemSpace M>
+    using StateStore = CollectionStateStore<OrangeStateData, M>;
+
+    using TrackView = OrangeTrackView;
+    static inline char const* ext = ".org.json";
+};
+
+template<>
+struct GenericGeoTraits<GeantGeoParams>
+{
+    template<MemSpace M>
+    using StateStore = CollectionStateStore<GeantGeoStateData, M>;
+    using TrackView = GeantGeoTrackView;
+    static inline char const* ext = ".gdml";
+};
+//---------------------------------------------------------------------------//
+}  // namespace
+
 //---------------------------------------------------------------------------//
 /*!
  * Templated base class for loading geometry.
  *
  * \tparam HP Geometry host Params class
- * \tparam S State data class
- * \tparam TV Track view clsas
  *
  * \note This class is instantiated in GenericGeoTestBase.cc for each available
  * geometry type.
  */
-template<class HP, template<Ownership, MemSpace> class S, class TV>
+template<class HP>
 class GenericGeoTestBase : virtual public Test, private LazyGeoManager
 {
     static_assert(std::is_base_of_v<GeoParamsInterface, HP>);
+
+    using TraitsT = GenericGeoTraits<HP>;
 
   public:
     //!@{
     //! \name Type aliases
     using SPConstGeo = std::shared_ptr<HP const>;
-    using GeoTrackView = TV;
+    using GeoTrackView = typename TraitsT::TrackView;
     using TrackingResult = GenericGeoTrackingResult;
     using GeantVolResult = GenericGeoGeantImportVolumeResult;
     //!@}
 
   public:
+    //! Construct from celeritas data (use for implementing build_geometry)
+    static SPConstGeo build_from_basename(std::string_view basename);
+
     //! Build the geometry
     virtual SPConstGeo build_geometry() = 0;
 
@@ -112,7 +151,8 @@ class GenericGeoTestBase : virtual public Test, private LazyGeoManager
     }
 
   private:
-    using HostStateStore = CollectionStateStore<S, MemSpace::host>;
+    using HostStateStore =
+        typename TraitsT::template StateStore<MemSpace::host>;
 
     SPConstGeo geo_;
     HostStateStore host_state_;
@@ -127,19 +167,11 @@ class GenericGeoTestBase : virtual public Test, private LazyGeoManager
 // TYPE ALIASES
 //---------------------------------------------------------------------------//
 
-using GenericVecgeomTestBase
-    = GenericGeoTestBase<VecgeomParams, VecgeomStateData, VecgeomTrackView>;
-using GenericOrangeTestBase
-    = GenericGeoTestBase<OrangeParams, OrangeStateData, OrangeTrackView>;
-using GenericGeantGeoTestBase
-    = GenericGeoTestBase<GeantGeoParams, GeantGeoStateData, GeantGeoTrackView>;
-#if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM
-using GenericCoreGeoTestBase = GenericVecgeomTestBase;
-#elif CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
-using GenericCoreGeoTestBase = GenericOrangeTestBase;
-#elif CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_GEANT4
-using GenericCoreGeoTestBase = GenericGeantGeoTestBase;
-#endif
+using GenericVecgeomTestBase = GenericGeoTestBase<VecgeomParams>;
+using GenericOrangeTestBase = GenericGeoTestBase<OrangeParams>;
+using GenericGeantGeoTestBase = GenericGeoTestBase<GeantGeoParams>;
+
+using GenericCoreGeoTestBase = GenericGeoTestBase<GeoParams>;
 
 //---------------------------------------------------------------------------//
 }  // namespace test

--- a/test/celeritas/GenericGeoTestBase.hh
+++ b/test/celeritas/GenericGeoTestBase.hh
@@ -50,7 +50,7 @@ struct GenericGeoGeantImportVolumeResult
     void print_expected() const;
 };
 
-namespace
+namespace testdetail
 {
 //---------------------------------------------------------------------------//
 template<class HP>
@@ -63,6 +63,7 @@ struct GenericGeoTraits<VecgeomParams>
     using StateStore = CollectionStateStore<VecgeomStateData, M>;
     using TrackView = VecgeomTrackView;
     static inline char const* ext = ".gdml";
+    static inline char const* name = "VecGeom";
 };
 
 template<>
@@ -73,6 +74,7 @@ struct GenericGeoTraits<OrangeParams>
 
     using TrackView = OrangeTrackView;
     static inline char const* ext = ".org.json";
+    static inline char const* name = "ORANGE";
 };
 
 template<>
@@ -82,7 +84,9 @@ struct GenericGeoTraits<GeantGeoParams>
     using StateStore = CollectionStateStore<GeantGeoStateData, M>;
     using TrackView = GeantGeoTrackView;
     static inline char const* ext = ".gdml";
+    static inline char const* name = "Geant4";
 };
+
 //---------------------------------------------------------------------------//
 }  // namespace
 
@@ -92,6 +96,8 @@ struct GenericGeoTraits<GeantGeoParams>
  *
  * \tparam HP Geometry host Params class
  *
+ * \sa AllGeoTypedTestBase
+ *
  * \note This class is instantiated in GenericGeoTestBase.cc for each available
  * geometry type.
  */
@@ -100,7 +106,7 @@ class GenericGeoTestBase : virtual public Test, private LazyGeoManager
 {
     static_assert(std::is_base_of_v<GeoParamsInterface, HP>);
 
-    using TraitsT = GenericGeoTraits<HP>;
+    using TraitsT = testdetail::GenericGeoTraits<HP>;
 
   public:
     //!@{
@@ -112,11 +118,14 @@ class GenericGeoTestBase : virtual public Test, private LazyGeoManager
     //!@}
 
   public:
-    //! Construct from celeritas data (use for implementing build_geometry)
-    static SPConstGeo build_from_basename(std::string_view basename);
+    //! Get the basename or unique geometry key (defaults to suite name)
+    virtual std::string geometry_basename() const;
 
     //! Build the geometry
     virtual SPConstGeo build_geometry() = 0;
+
+    //! Construct from celeritas test data and "basename" value
+    SPConstGeo build_geometry_from_basename();
 
     // Access geometry
     SPConstGeo const& geometry();

--- a/test/celeritas/ext/GeantGeo.test.cc
+++ b/test/celeritas/ext/GeantGeo.test.cc
@@ -24,26 +24,20 @@ namespace test
 class GeantGeoTest : public GenericGeantGeoTestBase
 {
   public:
-    virtual std::string_view geometry_basename() const = 0;
-
     SPConstGeo build_geometry() final
     {
-        return std::make_shared<GeantGeoParams>(this->test_data_path(
-            "celeritas", std::string{this->geometry_basename()} + ".gdml"));
+        return this->build_geometry_from_basename();
     }
 };
 
 class FourLevelsTest : public GeantGeoTest
 {
-    std::string_view geometry_basename() const override
-    {
-        return "four-levels"sv;
-    }
+    std::string geometry_basename() const override { return "four-levels"; }
 };
 
 class SolidsTest : public GeantGeoTest
 {
-    std::string_view geometry_basename() const override { return "solids"sv; }
+    std::string geometry_basename() const override { return "solids"; }
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/field/DiagnosticStepper.hh
+++ b/test/celeritas/field/DiagnosticStepper.hh
@@ -57,5 +57,14 @@ class DiagnosticStepper
 };
 
 //---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class StepperT>
+CELER_FUNCTION DiagnosticStepper(StepperT&&)->DiagnosticStepper<StepperT>;
+
+template<class StepperT>
+CELER_FUNCTION DiagnosticStepper(StepperT&)->DiagnosticStepper<StepperT&>;
+
+//---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -85,12 +85,9 @@ class FieldPropagatorTestBase : public GenericCoreGeoTestBase
                   * field_strength);
     }
 
-    // Overload with the base filename of the geometry
-    virtual std::string_view geometry_basename() const = 0;
-
     SPConstGeo build_geometry() final
     {
-        return this->build_from_basename(this->geometry_basename());
+        return this->build_geometry_from_basename();
     }
 
   private:
@@ -131,26 +128,17 @@ void FieldPropagatorTestBase::SetUp()
 
 class TwoBoxTest : public FieldPropagatorTestBase
 {
-    std::string_view geometry_basename() const override
-    {
-        return "two-boxes"sv;
-    }
+    std::string geometry_basename() const override { return "two-boxes"; }
 };
 
 class LayersTest : public FieldPropagatorTestBase
 {
-    std::string_view geometry_basename() const override
-    {
-        return "field-layers"sv;
-    }
+    std::string geometry_basename() const override { return "field-layers"; }
 };
 
 class SimpleCmsTest : public FieldPropagatorTestBase
 {
-    std::string_view geometry_basename() const override
-    {
-        return "simple-cms"sv;
-    }
+    std::string geometry_basename() const override { return "simple-cms"; }
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -221,7 +221,7 @@ TEST_F(TwoBoxTest, electron_interior)
         field, particle.charge());
     FieldDriverOptions driver_options;
     auto propagate
-        = make_field_propagator(stepper, driver_options, particle, &geo);
+        = make_field_propagator(stepper, driver_options, particle, geo);
 
     // Test a short step
     Propagation result = propagate(1e-2);
@@ -300,7 +300,7 @@ TEST_F(TwoBoxTest, positron_interior)
     // Build propagator
     FieldDriverOptions driver_options;
     auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-        field, driver_options, particle, &geo);
+        field, driver_options, particle, geo);
 
     // Test a quarter turn
     Propagation result = propagate(0.5 * pi * radius);
@@ -324,7 +324,7 @@ TEST_F(TwoBoxTest, gamma_interior)
     {
         auto geo = this->make_geo_track_view({0, 0, 0}, {0, 0, 1});
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
 
         auto result = propagate(3.0);
         EXPECT_SOFT_EQ(3.0, result.distance);
@@ -337,7 +337,7 @@ TEST_F(TwoBoxTest, gamma_interior)
     {
         auto geo = this->make_geo_track_view();
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
 
         stepper.reset_count();
         auto result = propagate(3.0);
@@ -358,7 +358,7 @@ TEST_F(TwoBoxTest, gamma_interior)
     {
         auto geo = this->make_geo_track_view();
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
 
         stepper.reset_count();
         auto result = propagate(5.0);
@@ -385,7 +385,7 @@ TEST_F(TwoBoxTest, gamma_pathological)
     {
         auto geo = this->make_geo_track_view({0, 0, -2}, {0, 0, 1});
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
 
         auto result = propagate(3.0);
         EXPECT_SOFT_EQ(3.0, result.distance);
@@ -409,7 +409,7 @@ TEST_F(TwoBoxTest, gamma_exit)
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(0.25);
 
         EXPECT_SOFT_EQ(0.25, result.distance);
@@ -429,7 +429,7 @@ TEST_F(TwoBoxTest, gamma_exit)
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(0.251 + 1e-7);
 
         EXPECT_SOFT_EQ(0.251, result.distance);
@@ -448,7 +448,7 @@ TEST_F(TwoBoxTest, gamma_exit)
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(d);
 
         EXPECT_SOFT_EQ(0.251, result.distance);
@@ -473,7 +473,7 @@ TEST_F(TwoBoxTest, electron_super_small_step)
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(delta);
 
         EXPECT_DOUBLE_EQ(delta, result.distance);
@@ -497,7 +497,7 @@ TEST_F(TwoBoxTest, electron_small_step)
         EXPECT_FALSE(geo.is_on_boundary());
 
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(delta);
 
         // Search distance doesn't hit boundary
@@ -513,7 +513,7 @@ TEST_F(TwoBoxTest, electron_small_step)
         EXPECT_FALSE(geo.is_on_boundary());
 
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(delta);
 
         // The boundary search goes an extra driver_.delta_intersection()
@@ -531,7 +531,7 @@ TEST_F(TwoBoxTest, electron_small_step)
         EXPECT_FALSE(geo.is_on_boundary());
 
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(2 * delta);
 
         EXPECT_LE(result.distance, 2 * delta);
@@ -561,7 +561,7 @@ TEST_F(TwoBoxTest, electron_small_step)
         // Starting on the boundary, take a step smaller than driver's minimum
         // (could be, e.g., a very small distance to interaction)
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(delta);
 
         EXPECT_DOUBLE_EQ(delta, result.distance);
@@ -584,7 +584,7 @@ TEST_F(TwoBoxTest, electron_tangent)
 
         auto geo = this->make_geo_track_view({1, 4, 0}, {0, 1, 0});
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(0.49 * pi);
 
         EXPECT_FALSE(result.boundary);
@@ -599,7 +599,7 @@ TEST_F(TwoBoxTest, electron_tangent)
 
         auto geo = this->make_geo_track_view();
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(0.02 * pi);
 
         EXPECT_FALSE(result.boundary);
@@ -629,7 +629,7 @@ TEST_F(TwoBoxTest, electron_cross)
 
         auto geo = this->make_geo_track_view();
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(pi);
 
         EXPECT_SOFT_NEAR(1. / 12., result.distance / circ, 1e-5);
@@ -651,7 +651,7 @@ TEST_F(TwoBoxTest, electron_cross)
 
         auto geo = this->make_geo_track_view();
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(circ);
 
         EXPECT_SOFT_NEAR(1. / 3., result.distance / circ, 1e-5);
@@ -672,7 +672,7 @@ TEST_F(TwoBoxTest, electron_cross)
 
         auto geo = this->make_geo_track_view();
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(7. / 12. * circ);
 
         EXPECT_SOFT_NEAR(7. / 12., result.distance / circ, 1e-5);
@@ -699,7 +699,7 @@ TEST_F(TwoBoxTest, electron_tangent_cross)
 
         auto geo = this->make_geo_track_view({1, 4 + dy, 0}, {0, 1, 0});
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(circ);
 
         // Trigonometry to find actual intersection point and length along arc
@@ -727,7 +727,7 @@ TEST_F(TwoBoxTest, electron_tangent_cross)
 
         auto geo = this->make_geo_track_view({1, 4 + dy, 0}, {0, 1, 0});
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(circ);
 
         EXPECT_SOFT_EQ(circ, result.distance);
@@ -753,7 +753,7 @@ TEST_F(TwoBoxTest, electron_corner_hit)
 
         auto geo = this->make_geo_track_view({-4, 4 + dy, 0}, {0, 1, 0});
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(circ);
 
         // Trigonometry to find actual intersection point and length along arc
@@ -781,7 +781,7 @@ TEST_F(TwoBoxTest, electron_corner_hit)
 
         auto geo = this->make_geo_track_view({-4, 4 + dy, 0}, {0, 1, 0});
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(circ);
 
         // Trigonometry to find actual intersection point and length along arc
@@ -809,7 +809,7 @@ TEST_F(TwoBoxTest, electron_corner_hit)
 
         auto geo = this->make_geo_track_view({-4, 4 + dy, 0}, {0, 1, 0});
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(circ);
 
         EXPECT_SOFT_NEAR(circ * .25, result.distance, 1e-5);
@@ -858,7 +858,7 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(first_step - driver_options.delta_intersection);
 
         EXPECT_FALSE(result.boundary);
@@ -892,7 +892,7 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(first_step);
 
         EXPECT_FALSE(result.boundary);
@@ -916,7 +916,7 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(first_step);
 
         EXPECT_TRUE(result.boundary);
@@ -969,7 +969,7 @@ TEST_F(TwoBoxTest, electron_tangent_cross_smallradius)
             field, particle.charge());
         FieldDriverOptions driver_options;
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         for (int i : range(2))
         {
             SCOPED_TRACE(i);
@@ -1039,7 +1039,7 @@ TEST_F(TwoBoxTest, nonuniform_field)
     {
         auto geo = this->make_geo_track_view();
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         propagate(1.0);
         EXPECT_VEC_SOFT_EQ(pos, geo.pos());
     }
@@ -1058,7 +1058,7 @@ TEST_F(LayersTest, revolutions_through_layers)
     // Build propagator
     FieldDriverOptions driver_options;
     auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-        field, driver_options, particle, &geo);
+        field, driver_options, particle, geo);
 
     // clang-format off
     static const real_type expected_y[]
@@ -1112,7 +1112,7 @@ TEST_F(LayersTest, revolutions_through_cms_field)
 
     // Build propagator
     auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-        field, driver_options, particle, &geo);
+        field, driver_options, particle, geo);
 
     int const num_revs = 10;
     int const num_steps = 100;
@@ -1148,12 +1148,12 @@ TEST_F(SimpleCmsTest, electron_stuck)
         {7.01343313647855e-01, -6.43327996599957e-01, 3.06996164784077e-01});
 
     auto calc_radius
-        = [&geo]() { return std::hypot(geo.pos()[0], geo.pos()[1]); };
+        = [geo]() { return std::hypot(geo.pos()[0], geo.pos()[1]); };
     EXPECT_SOFT_EQ(30.000000000000011, calc_radius());
 
     {
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(1000);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
         EXPECT_EQ("si_tracker", this->volume_name(geo));
@@ -1170,7 +1170,7 @@ TEST_F(SimpleCmsTest, electron_stuck)
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(1000);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
         EXPECT_LE(92, stepper.count());
@@ -1186,7 +1186,7 @@ TEST_F(SimpleCmsTest, electron_stuck)
     }
     {
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, &geo);
+            field, driver_options, particle, geo);
         auto result = propagate(1000);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
         ASSERT_TRUE(geo.is_on_boundary());
@@ -1217,7 +1217,7 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
                                           -5.23221772848529443e-01});
 
     auto calc_radius
-        = [&geo]() { return std::hypot(geo.pos()[0], geo.pos()[1]); };
+        = [geo]() { return std::hypot(geo.pos()[0], geo.pos()[1]); };
 
     bool successful_reentry = false;
     {
@@ -1226,7 +1226,7 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(1.39170198361108938e-05);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
         EXPECT_EQ("em_calorimeter", this->volume_name(geo));
@@ -1256,7 +1256,7 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         auto propagate
-            = make_field_propagator(stepper, driver_options, particle, &geo);
+            = make_field_propagator(stepper, driver_options, particle, geo);
         // This absurdly long step is because in the "failed" case the track
         // thinks it's in the world volume (nearly vacuum)
         auto result = propagate(2.12621374950874703e+21);

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -90,15 +90,7 @@ class FieldPropagatorTestBase : public GenericCoreGeoTestBase
 
     SPConstGeo build_geometry() final
     {
-        // Construct filename:
-        // ${SOURCE}/test/celeritas/data/${basename}${fileext}
-        auto ext = (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
-                       ? ".gdml"sv
-                       : ".org.json"sv;
-        auto filename = std::string{this->geometry_basename()}
-                        + std::string{ext};
-        std::string test_file = this->test_data_path("celeritas", filename);
-        return std::make_shared<GeoParams>(test_file);
+        return this->build_from_basename(this->geometry_basename());
     }
 
   private:

--- a/test/celeritas/field/LinearPropagator.test.cc
+++ b/test/celeritas/field/LinearPropagator.test.cc
@@ -11,10 +11,7 @@
 #include "corecel/data/CollectionStateStore.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Device.hh"
-#include "celeritas/GenericGeoTestBase.hh"
-#include "celeritas/geo/GeoData.hh"
-#include "celeritas/geo/GeoParams.hh"
-#include "celeritas/geo/GeoTrackView.hh"
+#include "celeritas/AllGeoTypedTestBase.hh"
 
 #include "celeritas_test.hh"
 
@@ -26,31 +23,27 @@ namespace test
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class LinearPropagatorTestBase : public GenericCoreGeoTestBase
+template<class HP>
+class LinearPropagatorTest : public AllGeoTypedTestBase<HP>
 {
-    // Overload with the base filename of the geometry
-    virtual std::string_view geometry_basename() const = 0;
+  protected:
+    using SPConstGeo = typename GenericGeoTestBase<HP>::SPConstGeo;
+    using GeoTrackView = typename GenericGeoTestBase<HP>::GeoTrackView;
 
-    SPConstGeo build_geometry() final
-    {
-        return this->build_from_basename(this->geometry_basename());
-    }
+    std::string geometry_basename() const final { return "simple-cms"; }
 };
 
-class SimpleCmsTest : public LinearPropagatorTestBase
-{
-    std::string_view geometry_basename() const override
-    {
-        return "simple-cms"sv;
-    }
-};
+TYPED_TEST_SUITE(LinearPropagatorTest,
+                 AllGeoTestingTypes,
+                 AllGeoTestingTypeNames);
 
 //---------------------------------------------------------------------------//
 // HOST TESTS
 //----------------------------------------------------------------------------//
 
-TEST_F(SimpleCmsTest, rvalue_type)
+TYPED_TEST(LinearPropagatorTest, rvalue_type)
 {
+    using GeoTrackView = typename TestFixture::GeoTrackView;
     {
         LinearPropagator propagate(
             this->make_geo_track_view({0, 0, 0}, {0, 0, 1}));
@@ -63,10 +56,11 @@ TEST_F(SimpleCmsTest, rvalue_type)
     EXPECT_VEC_SOFT_EQ(Real3({0, 0, 10}), this->make_geo_track_view().pos());
 }
 
-TEST_F(SimpleCmsTest, all)
+TYPED_TEST(LinearPropagatorTest, simple_cms)
 {
+    using GeoTrackView = typename TestFixture::GeoTrackView;
     // Initialize
-    GeoTrackView geo = this->make_geo_track_view({0, 0, 0}, {0, 0, 1});
+    auto geo = this->make_geo_track_view({0, 0, 0}, {0, 0, 1});
     EXPECT_EQ("vacuum_tube", this->volume_name(geo));
 
     {

--- a/test/celeritas/field/LinearPropagator.test.cc
+++ b/test/celeritas/field/LinearPropagator.test.cc
@@ -15,6 +15,7 @@
 #include "celeritas/OnlyGeoTestBase.hh"
 #include "celeritas/geo/GeoData.hh"
 #include "celeritas/geo/GeoParams.hh"
+#include "celeritas/geo/GeoTrackView.hh"
 
 #include "celeritas_test.hh"
 
@@ -76,6 +77,19 @@ class SimpleCmsTest : public LinearPropagatorTestBase
 // HOST TESTS
 //----------------------------------------------------------------------------//
 
+TEST_F(SimpleCmsTest, rvalue_type)
+{
+    {
+        LinearPropagator propagate(this->init_geo({0, 0, 0}, {0, 0, 1}));
+        EXPECT_TRUE((
+            std::is_same_v<decltype(propagate), LinearPropagator<GeoTrackView>>));
+        Propagation result = propagate(10);
+        EXPECT_SOFT_EQ(10, result.distance);
+        EXPECT_FALSE(result.boundary);
+    }
+    EXPECT_VEC_SOFT_EQ(Real3({0, 0, 10}), this->make_geo_view().pos());
+}
+
 TEST_F(SimpleCmsTest, all)
 {
     // Initialize
@@ -83,7 +97,9 @@ TEST_F(SimpleCmsTest, all)
     EXPECT_EQ("vacuum_tube", this->volume_name(geo));
 
     {
-        LinearPropagator propagate(&geo);
+        LinearPropagator propagate(geo);
+        EXPECT_TRUE((std::is_same_v<decltype(propagate),
+                                    LinearPropagator<GeoTrackView&>>));
 
         // Move up to a small distance
         Propagation result = propagate(20);
@@ -97,7 +113,7 @@ TEST_F(SimpleCmsTest, all)
     geo.set_dir({1, 0, 0});
 
     {
-        LinearPropagator propagate(&geo);
+        LinearPropagator propagate(geo);
 
         // Move to the next layer
         Propagation result = propagate(1e20);
@@ -111,7 +127,7 @@ TEST_F(SimpleCmsTest, all)
     EXPECT_EQ("si_tracker", this->volume_name(geo));
 
     {
-        LinearPropagator propagate(&geo);
+        LinearPropagator propagate(geo);
 
         // Move two steps internally
         Propagation result = propagate(35);
@@ -128,7 +144,7 @@ TEST_F(SimpleCmsTest, all)
     EXPECT_EQ("si_tracker", this->volume_name(geo));
 
     {
-        LinearPropagator propagate(&geo);
+        LinearPropagator propagate(geo);
 
         // Move to next boundary (infinite max distance)
         Propagation result = propagate();
@@ -148,7 +164,7 @@ TEST_F(SimpleCmsTest, all)
     geo.set_dir({0, 0, -1});
 
     {
-        LinearPropagator propagate(&geo);
+        LinearPropagator propagate(geo);
 
         // Move to world volume
         Propagation result = propagate(10000);


### PR DESCRIPTION
Working toward #762, it'll be more convenient to have the propagator classes able to store GeoTrackView by value rather than reference. This also would improve the interface for the propagation component of the along-step solve, because we'd have a "make propagator factory" function which wouldn't need a reference to a GeoTrackView.

To help with the correct construction of reference/value ownership for the propagators I added C++17 CTAD to the numerous field classes. Some of the `make_foo` helper functions are still necessary because CTAD is incompatbile with templated type aliases (e.g. `DiagnosticDPStepper`).

I've also added a type-parameterized test harness that lets us test all the available geometry types within a single test harness: this is useful for development locally.