### PR TITLE
Divide initializer capacity by number of streams in celer-sim

### DIFF
--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -56,7 +56,7 @@ struct RunnerInput
     unsigned int seed{};
     size_type num_track_slots{};  //!< Divided among streams
     size_type max_steps{unspecified};
-    size_type initializer_capacity{};
+    size_type initializer_capacity{};  //!< Divided among streams
     size_type max_events{};
     real_type secondary_stack_factor{};
     bool use_device{};


### PR DESCRIPTION
Previously in the celer-sim app we were only dividing the number of track slots.