### PR TITLE
Add utility for constructing SD "force_volumes" option

### DIFF
--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND SOURCES
   AlongStepFactory.cc
   Logger.cc
   LocalTransporter.cc
+  SetupOptions.cc
   SetupOptionsMessenger.cc
   SharedParams.cc
   SimpleOffload.cc

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -1,0 +1,25 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/SetupOptions.cc
+//---------------------------------------------------------------------------//
+#include "SetupOptions.hh"
+
+#include "celeritas/ext/GeantGeoUtils.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Find volumes by name for SDSetupOptions.
+ */
+std::unordered_set<G4LogicalVolume const*>
+FindVolumes(std::unordered_set<std::string> names)
+{
+    return find_geant_volumes(std::move(names));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -9,6 +9,8 @@
 
 #include "celeritas/ext/GeantGeoUtils.hh"
 
+#include "ExceptionConverter.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -18,7 +20,11 @@ namespace celeritas
 std::unordered_set<G4LogicalVolume const*>
 FindVolumes(std::unordered_set<std::string> names)
 {
-    return find_geant_volumes(std::move(names));
+    ExceptionConverter call_g4exception{"celer0006"};
+    std::unordered_set<G4LogicalVolume const*> result;
+    CELER_TRY_HANDLE(result = find_geant_volumes(std::move(names)),
+                     call_g4exception);
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <unordered_set>
 #include <vector>

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -145,4 +145,12 @@ struct SetupOptions
 };
 
 //---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+
+// Find volumes by name for SDSetupOptions
+std::unordered_set<G4LogicalVolume const*>
+    FindVolumes(std::unordered_set<std::string>);
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -102,6 +102,7 @@ class SharedParams
 
     static void initialize_device(SetupOptions const& options);
     void initialize_core(SetupOptions const& options);
+    void try_output() const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantGeoUtils.cc
+++ b/src/celeritas/ext/GeantGeoUtils.cc
@@ -201,7 +201,7 @@ Span<G4LogicalVolume*> geant_logical_volumes()
 /*!
  * Find Geant4 logical volumes corresponding to a list of names.
  *
- * If logical volumes with duplicate names are present, they will show up twice
+ * If logical volumes with duplicate names are present, they will all show up
  * in the output and a warning will be emitted. If one is missing, a
  * \c RuntimeError will be raised.
  *
@@ -210,20 +210,17 @@ Span<G4LogicalVolume*> geant_logical_volumes()
    auto vols = find_geant_volumes(make_span(labels));
  * \endcode
  */
-std::vector<G4LogicalVolume*>
-find_geant_volumes(Span<std::string_view const> inp)
+std::unordered_set<G4LogicalVolume const*>
+find_geant_volumes(std::unordered_set<std::string> names)
 {
-    // Copy names to a local set
-    std::unordered_set<std::string> names(inp.begin(), inp.end());
-
     // Find all names that match the set
-    std::vector<G4LogicalVolume*> result;
-    result.reserve(inp.size());
+    std::unordered_set<G4LogicalVolume const*> result;
+    result.reserve(names.size());
     for (auto* lv : geant_logical_volumes())
     {
         if (lv && names.count(lv->GetName()))
         {
-            result.push_back(lv);
+            result.insert(lv);
         }
     }
 

--- a/src/celeritas/ext/GeantGeoUtils.cc
+++ b/src/celeritas/ext/GeantGeoUtils.cc
@@ -9,6 +9,8 @@
 
 #include <iostream>
 #include <string>
+#include <string_view>
+#include <unordered_set>
 #include <G4GDMLParser.hh>
 #include <G4LogicalVolume.hh>
 #include <G4LogicalVolumeStore.hh>
@@ -20,6 +22,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/ScopedStreamRedirect.hh"
 #include "corecel/io/ScopedTimeLog.hh"
@@ -192,6 +195,61 @@ Span<G4LogicalVolume*> geant_logical_volumes()
         ++start;
     }
     return {start, stop};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Find Geant4 logical volumes corresponding to a list of names.
+ *
+ * If logical volumes with duplicate names are present, they will show up twice
+ * in the output and a warning will be emitted. If one is missing, a
+ * \c RuntimeError will be raised.
+ *
+ * \code
+   static std::string_view const labels[] = {"Vol1", "Vol2"};
+   auto vols = find_geant_volumes(make_span(labels));
+ * \endcode
+ */
+std::vector<G4LogicalVolume*>
+find_geant_volumes(Span<std::string_view const> inp)
+{
+    // Copy names to a local set
+    std::unordered_set<std::string> names(inp.begin(), inp.end());
+
+    // Find all names that match the set
+    std::vector<G4LogicalVolume*> result;
+    result.reserve(inp.size());
+    for (auto* lv : geant_logical_volumes())
+    {
+        if (lv && names.count(lv->GetName()))
+        {
+            result.push_back(lv);
+        }
+    }
+
+    // Remove found names and warn about duplicates
+    for (auto* lv : result)
+    {
+        auto iter = names.find(lv->GetName());
+        if (iter != names.end())
+        {
+            names.erase(iter);
+        }
+        else
+        {
+            CELER_LOG(warning)
+                << "Multiple Geant4 volumes are mapped to name '"
+                << lv->GetName();
+        }
+    }
+
+    // Make sure all requested names are found
+    CELER_VALIDATE(names.empty(),
+                   << "failed to find Geant4 volumes corresponding to the "
+                      "following names: "
+                   << join(names.begin(), names.end(), ", "));
+
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantGeoUtils.hh
+++ b/src/celeritas/ext/GeantGeoUtils.hh
@@ -9,8 +9,7 @@
 
 #include <iosfwd>
 #include <string>
-#include <string_view>
-#include <vector>
+#include <unordered_set>
 
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
@@ -60,7 +59,8 @@ void reset_geant_geometry();
 Span<G4LogicalVolume*> geant_logical_volumes();
 
 // Find Geant4 logical volumes corresponding to a list of names
-std::vector<G4LogicalVolume*> find_geant_volumes(Span<std::string_view const>);
+std::unordered_set<G4LogicalVolume const*>
+    find_geant_volumes(std::unordered_set<std::string>);
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/src/celeritas/ext/GeantGeoUtils.hh
+++ b/src/celeritas/ext/GeantGeoUtils.hh
@@ -9,6 +9,8 @@
 
 #include <iosfwd>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
@@ -56,6 +58,9 @@ void reset_geant_geometry();
 //---------------------------------------------------------------------------//
 // Get a view to the Geant4 LV store
 Span<G4LogicalVolume*> geant_logical_volumes();
+
+// Find Geant4 logical volumes corresponding to a list of names
+std::vector<G4LogicalVolume*> find_geant_volumes(Span<std::string_view const>);
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -326,6 +326,9 @@ if(CELERITAS_USE_Geant4)
   celeritas_add_test(celeritas/ext/GeantGeo.test.cc
     LINK_LIBRARIES ${Geant4_LIBRARIES}
   )
+  celeritas_add_test(celeritas/ext/GeantGeoUtils.test.cc
+    LINK_LIBRARIES ${Geant4_LIBRARIES}
+  )
 endif()
 
 celeritas_add_test(celeritas/ext/EventReader.test.cc ${_needs_hepmc})

--- a/test/celeritas/ext/GeantGeoUtils.test.cc
+++ b/test/celeritas/ext/GeantGeoUtils.test.cc
@@ -1,0 +1,86 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/GeantGeoUtils.test.cc
+//---------------------------------------------------------------------------//
+#include "celeritas/ext/GeantGeoUtils.hh"
+
+#include <G4LogicalVolume.hh>
+
+#include "celeritas/ext/GeantGeoParams.hh"
+
+#include "../GenericGeoTestBase.hh"
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+namespace
+{
+// Get volume names for a bunch of G4LV*
+template<class InputIterator>
+decltype(auto) get_vol_names(InputIterator iter, InputIterator stop)
+{
+    std::vector<std::string> result;
+    for (; iter != stop; ++iter)
+    {
+        CELER_ASSERT(*iter);
+        result.push_back((*iter)->GetName());
+    }
+    return result;
+}
+}  // namespace
+//---------------------------------------------------------------------------//
+
+class GeantGeoUtilsTest : public GenericGeantGeoTestBase
+{
+  public:
+    SPConstGeo build_geometry() final
+    {
+        return this->build_geometry_from_basename();
+    }
+
+    void SetUp() override
+    {
+        // Build geometry during setup
+        ASSERT_TRUE(this->geometry());
+    }
+};
+
+class SolidsTest : public GeantGeoUtilsTest
+{
+    std::string geometry_basename() const override { return "solids"; }
+};
+
+using FindGeantVolumesTest = SolidsTest;
+
+TEST_F(FindGeantVolumesTest, standard)
+{
+    static std::string_view const labels[] = {"box500", "trd3", "trd1"};
+    auto vols = find_geant_volumes(make_span(labels));
+    auto vol_names = get_vol_names(vols.begin(), vols.end());
+    static char const* const expected_vol_names[] = {"box500", "trd1", "trd3"};
+    EXPECT_VEC_EQ(expected_vol_names, vol_names);
+}
+
+TEST_F(FindGeantVolumesTest, missing)
+{
+    static std::string_view const labels[] = {"box500", "trd3", "turd3"};
+    EXPECT_THROW(find_geant_volumes(make_span(labels)), RuntimeError);
+}
+
+TEST_F(FindGeantVolumesTest, duplicate)
+{
+    static std::string_view const labels[] = {"trd3_refl"};
+    auto vols = find_geant_volumes(make_span(labels));
+    auto vol_names = get_vol_names(vols.begin(), vols.end());
+    static char const* const expected_vol_names[] = {"trd3_refl", "trd3_refl"};
+    EXPECT_VEC_EQ(expected_vol_names, vol_names);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/ext/GeantGeoUtils.test.cc
+++ b/test/celeritas/ext/GeantGeoUtils.test.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "celeritas/ext/GeantGeoUtils.hh"
 
+#include <algorithm>
 #include <G4LogicalVolume.hh>
 
 #include "celeritas/ext/GeantGeoParams.hh"
@@ -30,6 +31,7 @@ decltype(auto) get_vol_names(InputIterator iter, InputIterator stop)
         CELER_ASSERT(*iter);
         result.push_back((*iter)->GetName());
     }
+    std::sort(result.begin(), result.end());
     return result;
 }
 }  // namespace
@@ -59,8 +61,7 @@ using FindGeantVolumesTest = SolidsTest;
 
 TEST_F(FindGeantVolumesTest, standard)
 {
-    static std::string_view const labels[] = {"box500", "trd3", "trd1"};
-    auto vols = find_geant_volumes(make_span(labels));
+    auto vols = find_geant_volumes({"box500", "trd3", "trd1"});
     auto vol_names = get_vol_names(vols.begin(), vols.end());
     static char const* const expected_vol_names[] = {"box500", "trd1", "trd3"};
     EXPECT_VEC_EQ(expected_vol_names, vol_names);
@@ -68,14 +69,12 @@ TEST_F(FindGeantVolumesTest, standard)
 
 TEST_F(FindGeantVolumesTest, missing)
 {
-    static std::string_view const labels[] = {"box500", "trd3", "turd3"};
-    EXPECT_THROW(find_geant_volumes(make_span(labels)), RuntimeError);
+    EXPECT_THROW(find_geant_volumes({"box500", "trd3", "turd3"}), RuntimeError);
 }
 
 TEST_F(FindGeantVolumesTest, duplicate)
 {
-    static std::string_view const labels[] = {"trd3_refl"};
-    auto vols = find_geant_volumes(make_span(labels));
+    auto vols = find_geant_volumes({"trd3_refl"});
     auto vol_names = get_vol_names(vols.begin(), vols.end());
     static char const* const expected_vol_names[] = {"trd3_refl", "trd3_refl"};
     EXPECT_VEC_EQ(expected_vol_names, vol_names);


### PR DESCRIPTION
With this enhancement, you can add SDs by name in the setup for `accel`:
```c++
options.sd.force_volumes = FindVolumes({"foo", "bar"});
```

We [discovered](https://github.com/celeritas-project/celeritas/issues/822#issuecomment-1604388937) that the HGCal seems to create several intermediate G4LVs that have attached detectors but are *not* part of the world tree hierarchy. Such volumes are listed in an error message because the equivalent VecGeom volumes aren't created.