### PR TITLE
Improve logger construction and add test helper class

### DIFF
--- a/src/accel/Logger.cc
+++ b/src/accel/Logger.cc
@@ -121,9 +121,10 @@ void MtLogger::operator()(Provenance prov, LogLevel lev, std::string msg)
  */
 Logger MakeMTLogger(G4RunManager const& runman)
 {
-    return Logger(MpiCommunicator{},
-                  MtLogger{get_num_threads(runman)},
-                  "CELER_LOG_LOCAL");
+    Logger log(MpiCommunicator{}, MtLogger{get_num_threads(runman)});
+
+    log.level(log_level_from_env("CELER_LOG_LOCAL"));
+    return log;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/Logger.cc
+++ b/src/corecel/io/Logger.cc
@@ -105,6 +105,15 @@ void set_log_level_from_env(Logger* log, std::string const& level_env)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Construct with default communicator and handler.
+ */
+Logger::Logger(LogHandler handle)
+    : Logger(MpiCommunicator::comm_default(), std::move(handle))
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct with communicator (only rank zero is active) and handler.
  */
 Logger::Logger(MpiCommunicator const& comm, LogHandler handle)
@@ -151,10 +160,7 @@ LogLevel log_level_from_env(std::string const& level_env)
  */
 Logger make_default_world_logger()
 {
-    auto comm = ScopedMpiInit::status() != ScopedMpiInit::Status::disabled
-                    ? MpiCommunicator::comm_world()
-                    : MpiCommunicator{};
-    Logger log{comm, &default_global_handler};
+    Logger log{&default_global_handler};
     set_log_level_from_env(&log, "CELER_LOG");
     return log;
 }
@@ -165,9 +171,7 @@ Logger make_default_world_logger()
  */
 Logger make_default_self_logger()
 {
-    auto comm = ScopedMpiInit::status() != ScopedMpiInit::Status::disabled
-                    ? MpiCommunicator::comm_world()
-                    : MpiCommunicator{};
+    auto comm = MpiCommunicator::comm_default();
     auto handler = ScopedMpiInit::status() != ScopedMpiInit::Status::disabled
                        ? LocalHandler{comm}
                        : LogHandler{&default_global_handler};

--- a/src/corecel/io/Logger.cc
+++ b/src/corecel/io/Logger.cc
@@ -84,49 +84,65 @@ class LocalHandler
 };
 
 //---------------------------------------------------------------------------//
+/*!
+ * Set the log level from an environment variable, warn on failure.
+ */
+void set_log_level_from_env(Logger* log, std::string const& level_env)
+{
+    CELER_EXPECT(log);
+    try
+    {
+        log->level(log_level_from_env(level_env));
+    }
+    catch (RuntimeError const& e)
+    {
+        (*log)(CELER_CODE_PROVENANCE, LogLevel::warning) << e.details().what;
+    }
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct with communicator (only rank zero is active) and handler.
  */
-Logger::Logger(MpiCommunicator const& comm,
-               LogHandler handle,
-               char const* level_env)
+Logger::Logger(MpiCommunicator const& comm, LogHandler handle)
 {
     if (comm.rank() == 0)
     {
         // Accept handler, otherwise it is a "null" function pointer.
         handle_ = std::move(handle);
     }
-    if (level_env)
-    {
-        // Search for the provided environment variable to set the default
-        // logging level using the `to_cstring` function in LoggerTypes.
-        std::string const& env_value = celeritas::getenv(level_env);
-        if (!env_value.empty())
-        {
-            auto levels = range(LogLevel::size_);
-            auto iter = std::find_if(
-                levels.begin(), levels.end(), [&env_value](LogLevel lev) {
-                    return env_value == to_cstring(lev);
-                });
-            if (iter != levels.end())
-            {
-                min_level_ = *iter;
-            }
-            else if (comm.rank() == 0)
-            {
-                std::clog << "Log level environment variable '" << level_env
-                          << "' has an invalid value '" << env_value
-                          << "': ignoring" << std::endl;
-            }
-        }
-    }
 }
 
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Get the log level from an environment variable.
+ */
+LogLevel log_level_from_env(std::string const& level_env)
+{
+    // Search for the provided environment variable to set the default
+    // logging level using the `to_cstring` function in LoggerTypes.
+    std::string const& env_value = celeritas::getenv(level_env);
+    if (env_value.empty())
+    {
+        return Logger::default_level();
+    }
+
+    auto levels = range(LogLevel::size_);
+    auto iter = std::find_if(
+        levels.begin(), levels.end(), [&env_value](LogLevel lev) {
+            return env_value == to_cstring(lev);
+        });
+    CELER_VALIDATE(iter != levels.end(),
+                   << "invalid log level '" << env_value
+                   << "' in environment variable '" << level_env << "'");
+    return *iter;
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Create a default logger using the world communicator.
@@ -138,7 +154,9 @@ Logger make_default_world_logger()
     auto comm = ScopedMpiInit::status() != ScopedMpiInit::Status::disabled
                     ? MpiCommunicator::comm_world()
                     : MpiCommunicator{};
-    return {comm, &default_global_handler, "CELER_LOG"};
+    Logger log{comm, &default_global_handler};
+    set_log_level_from_env(&log, "CELER_LOG");
+    return log;
 }
 
 //---------------------------------------------------------------------------//
@@ -153,7 +171,9 @@ Logger make_default_self_logger()
     auto handler = ScopedMpiInit::status() != ScopedMpiInit::Status::disabled
                        ? LocalHandler{comm}
                        : LogHandler{&default_global_handler};
-    return {comm, std::move(handler), "CELER_LOG_LOCAL"};
+    Logger log{comm, std::move(handler)};
+    set_log_level_from_env(&log, "CELER_LOG_LOCAL");
+    return log;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/Logger.hh
+++ b/src/corecel/io/Logger.hh
@@ -85,6 +85,9 @@ class Logger
     //! Get the default log level
     static constexpr LogLevel default_level() { return LogLevel::status; }
 
+    // Construct with default communicator
+    explicit Logger(LogHandler handle);
+
     // Construct with communicator (only rank zero is active) and handler
     Logger(MpiCommunicator const& comm, LogHandler handle);
 

--- a/src/corecel/io/Logger.hh
+++ b/src/corecel/io/Logger.hh
@@ -82,10 +82,11 @@ class Logger
     //!@}
 
   public:
+    //! Get the default log level
+    static constexpr LogLevel default_level() { return LogLevel::status; }
+
     // Construct with communicator (only rank zero is active) and handler
-    Logger(MpiCommunicator const& comm,
-           LogHandler handle,
-           char const* level_env = nullptr);
+    Logger(MpiCommunicator const& comm, LogHandler handle);
 
     // Create a logger that flushes its contents when it destructs
     inline Message operator()(Provenance prov, LogLevel lev);
@@ -98,7 +99,7 @@ class Logger
 
   private:
     LogHandler handle_;
-    LogLevel min_level_ = LogLevel::status;
+    LogLevel min_level_{default_level()};
 };
 
 //---------------------------------------------------------------------------//
@@ -118,6 +119,9 @@ auto Logger::operator()(Provenance prov, LogLevel lev) -> Message
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//
+// Get the log level from an environment variable
+LogLevel log_level_from_env(std::string const&);
+
 // Create loggers with reasonable default behaviors.
 Logger make_default_world_logger();
 Logger make_default_self_logger();

--- a/src/corecel/io/detail/LoggerMessage.hh
+++ b/src/corecel/io/detail/LoggerMessage.hh
@@ -19,7 +19,7 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Helper class for writing log messages.
+ * Stream-like helper class for writing log messages.
  *
  * This class should only be created by a Logger instance. When it destructs,
  * the handler is called to print the information.

--- a/src/corecel/sys/MpiCommunicator.cc
+++ b/src/corecel/sys/MpiCommunicator.cc
@@ -15,6 +15,18 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Construct a communicator with MPI_COMM_WORLD or null if disabled.
+ */
+MpiCommunicator MpiCommunicator::comm_default()
+{
+    if (ScopedMpiInit::status() == ScopedMpiInit::Status::disabled)
+        return {};
+
+    return comm_world();
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct with a native MPI communicator.
  *
  * This will fail with a \c NotConfigured error if MPI is disabled.

--- a/src/corecel/sys/MpiCommunicator.hh
+++ b/src/corecel/sys/MpiCommunicator.hh
@@ -21,6 +21,8 @@ namespace celeritas
  * A "null" communicator (the default) does not use MPI calls and can be
  * constructed without calling \c MPI_Init or having MPI compiled. It will act
  * like \c MPI_Comm_Self but will not actually use MPI calls.
+ *
+ * TODO: drop \c comm_ prefix from static helpers
  */
 class MpiCommunicator
 {
@@ -36,6 +38,9 @@ class MpiCommunicator
 
     // Construct a communicator with MPI_COMM_WORLD
     inline static MpiCommunicator comm_world();
+
+    // Construct a communicator with MPI_COMM_WORLD or null if disabled
+    static MpiCommunicator comm_default();
 
     //// CONSTRUCTORS ////
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,7 +123,16 @@ celeritas_add_test(TestMacros.test.cc)
 # CORECEL TESTS
 #-----------------------------------------------------------------------------#
 
-celeritas_setup_tests(SERIAL PREFIX corecel)
+celeritas_add_library(testcel_core
+  corecel/ScopedLogStorer.cc
+)
+celeritas_target_link_libraries(testcel_core
+  PRIVATE Celeritas::testcel_harness Celeritas::corecel
+)
+
+celeritas_setup_tests(SERIAL PREFIX corecel
+  LINK_LIBRARIES testcel_core Celeritas::corecel
+)
 
 celeritas_add_test(corecel/OpaqueId.test.cc)
 
@@ -287,7 +296,7 @@ celeritas_target_link_libraries(testcel_celeritas
 )
 
 celeritas_setup_tests(SERIAL PREFIX celeritas
-  LINK_LIBRARIES testcel_celeritas Celeritas::celeritas
+  LINK_LIBRARIES testcel_celeritas testcel_core Celeritas::celeritas
 )
 
 #-----------------------------------------------------------------------------#

--- a/test/accel/SimpleSensitiveDetector.cc
+++ b/test/accel/SimpleSensitiveDetector.cc
@@ -51,7 +51,6 @@ void SimpleHitsResult::print_expected() const
          << repr(this->post_time)
          << ";\n"
             "EXPECT_VEC_SOFT_EQ(expected_post_time, result.post_time);\n"
-
             "/*** END CODE ***/\n";
 }
 

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -53,7 +53,10 @@ namespace test
 class GeantVolumeMapperTestBase : public ::celeritas::test::Test
 {
   protected:
-    GeantVolumeMapperTestBase() : store_log_(&celeritas::world_logger()) {}
+    GeantVolumeMapperTestBase()
+        : store_log_(&celeritas::world_logger(), LogLevel::warning)
+    {
+    }
 
     // Clean up geometry at destruction
     void TearDown() override
@@ -263,6 +266,7 @@ TEST_F(NestedTest, unique)
     }
     else
     {
+        store_log_.print_expected();
         EXPECT_EQ(0, store_log_.messages().size());
     }
 }

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -32,6 +32,7 @@
 #    include "celeritas/ext/VecgeomParams.hh"
 #endif
 
+#include "corecel/ScopedLogStorer.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/MpiCommunicator.hh"
 #include "orange/OrangeParams.hh"
@@ -52,32 +53,7 @@ namespace test
 class GeantVolumeMapperTestBase : public ::celeritas::test::Test
 {
   protected:
-    void SetUp() override
-    {
-        using namespace std::placeholders;
-        celeritas::world_logger() = Logger(
-            MpiCommunicator{},
-            std::bind(
-                &GeantVolumeMapperTestBase::log_message, this, _1, _2, _3));
-    }
-
-    void log_message(Provenance, LogLevel lev, std::string msg)
-    {
-        if (lev > LogLevel::info)
-        {
-            static const std::regex delete_ansi("\033\\[[0-9;]*m");
-            static const std::regex subs_ptr("0x[0-9a-f]+");
-            msg = std::regex_replace(msg, delete_ansi, "");
-            msg = std::regex_replace(msg, subs_ptr, "0x1234abcd");
-            messages_.push_back(std::move(msg));
-        }
-    }
-
-    static void TearDownTestCase()
-    {
-        // Restore logger
-        celeritas::world_logger() = celeritas::make_default_world_logger();
-    }
+    GeantVolumeMapperTestBase() : store_log_(&celeritas::world_logger()) {}
 
     // Clean up geometry at destruction
     void TearDown() override
@@ -117,7 +93,8 @@ class GeantVolumeMapperTestBase : public ::celeritas::test::Test
 
     // Celeritas data
     std::shared_ptr<GeoParams> geo_params_;
-    std::vector<std::string> messages_;
+
+    ScopedLogStorer store_log_;
 };
 
 //---------------------------------------------------------------------------//
@@ -268,29 +245,25 @@ TEST_F(NestedTest, unique)
     {
         static char const* const expected_messages[]
             = {"Failed to exactly match ORANGE volume from Geant4 volume "
-               "'world'@0x1234abcd; found 'world@global' by omitting the "
-               "extension",
+               "'world'@0x0; found 'world@global' by omitting the extension",
                "Failed to exactly match ORANGE volume from Geant4 volume "
-               "'outer'@0x1234abcd; found 'outer@global' by omitting the "
-               "extension",
+               "'outer'@0x0; found 'outer@global' by omitting the extension",
                "Failed to exactly match ORANGE volume from Geant4 volume "
-               "'middle'@0x1234abcd; found 'middle@global' by omitting the "
-               "extension",
+               "'middle'@0x0; found 'middle@global' by omitting the extension",
                "Failed to exactly match ORANGE volume from Geant4 volume "
-               "'inner'@0x1234abcd; found 'inner@global' by omitting the "
-               "extension"};
-        EXPECT_VEC_EQ(expected_messages, messages_);
+               "'inner'@0x0; found 'inner@global' by omitting the extension"};
+        EXPECT_VEC_EQ(expected_messages, store_log_.messages());
     }
     else if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_GEANT4)
     {
         static char const* const expected_messages[] = {
             "Geant4 geometry was initialized with inconsistent world volume: "
-            "given 'world_pv'@' 0x1234abcd; navigation world is unset"};
-        EXPECT_VEC_EQ(expected_messages, messages_);
+            "given 'world_pv'@' 0x0; navigation world is unset"};
+        EXPECT_VEC_EQ(expected_messages, store_log_.messages());
     }
     else
     {
-        EXPECT_EQ(0, messages_.size());
+        EXPECT_EQ(0, store_log_.messages().size());
     }
 }
 
@@ -314,7 +287,7 @@ TEST_F(NestedTest, SKIP_UNLESS_VECGEOM(duplicated))
 
     if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_GEANT4)
     {
-        EXPECT_EQ(0, messages_.size());
+        EXPECT_EQ(0, store_log_.messages().size());
     }
 }
 

--- a/test/corecel/ScopedLogStorer.cc
+++ b/test/corecel/ScopedLogStorer.cc
@@ -1,0 +1,92 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/ScopedLogStorer.cc
+//---------------------------------------------------------------------------//
+#include "ScopedLogStorer.hh"
+
+#include <iostream>
+#include <regex>
+
+#include "corecel/io/Logger.hh"
+#include "corecel/io/Repr.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct reference to log to temporarily replace.
+ */
+ScopedLogStorer::ScopedLogStorer(Logger* orig, LogLevel min_level)
+    : logger_{orig}
+{
+    CELER_EXPECT(logger_);
+    CELER_EXPECT(min_level != LogLevel::size_);
+    // Create a new logger that calls our operator(), replace orig and store
+    saved_logger_ = std::make_unique<Logger>(
+        std::exchange(*logger_, Logger{std::ref(*this)}));
+    // Update global log level
+    logger_->level(min_level);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct reference to log to temporarily replace.
+ */
+ScopedLogStorer::ScopedLogStorer(Logger* orig)
+    : ScopedLogStorer{orig, Logger::default_level()}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Restore original logger on destruction.
+ */
+ScopedLogStorer::~ScopedLogStorer()
+{
+    if (saved_logger_)
+    {
+        *logger_ = std::move(*saved_logger_);
+    }
+}
+
+//---------------------------------------------------------------------------//
+//! Save a log message
+void ScopedLogStorer::operator()(Provenance, LogLevel lev, std::string msg)
+{
+    static const std::regex delete_ansi("\033\\[[0-9;]*m");
+    static const std::regex subs_ptr("0x[0-9a-f]+");
+    msg = std::regex_replace(msg, delete_ansi, "");
+    msg = std::regex_replace(msg, subs_ptr, "0x0");
+    messages_.push_back(std::move(msg));
+    levels_.push_back(to_cstring(lev));
+}
+
+//---------------------------------------------------------------------------//
+//! Print the expected values
+void ScopedLogStorer::print_expected() const
+{
+    using std::cout;
+    using std::endl;
+    cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
+            "static char const* const expected_log_messages[] = "
+         << repr(this->messages_)
+         << ";\n"
+            "EXPECT_VEC_EQ(expected_log_messages, "
+            "store_log_.messages());\n"
+            "static char const* const expected_log_levels[] = "
+         << repr(this->levels_)
+         << ";\n"
+            "EXPECT_VEC_EQ(expected_log_levels, "
+            "store_log_.levels());\n"
+            "/*** END CODE ***/"
+         << endl;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/corecel/ScopedLogStorer.hh
+++ b/test/corecel/ScopedLogStorer.hh
@@ -1,0 +1,72 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/ScopedLogStorer.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "corecel/io/LoggerTypes.hh"
+
+namespace celeritas
+{
+class Logger;
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Log handle for saving messages for testing.
+ *
+ * Temporarily replace the given logger with this function. This removes ANSI
+ * sequences and replaces pointer-like strings with 0x0.
+ *
+ * \code
+    ScopedLogStorer store_log_;
+    world_logger() = Logger(store_log_);
+   \endcode
+ */
+class ScopedLogStorer
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using VecString = std::vector<std::string>;
+    //!@}
+
+  public:
+    // Construct reference to log to temporarily replace
+    ScopedLogStorer(Logger* orig, LogLevel min_level);
+
+    // Construct reference with default level
+    explicit ScopedLogStorer(Logger* orig);
+
+    // Restore original logger on destruction
+    ~ScopedLogStorer();
+
+    // Save a log message
+    void operator()(Provenance, LogLevel lev, std::string msg);
+
+    // Get saved messages
+    VecString const& messages() const { return messages_; }
+
+    // Get corresponding log levels
+    VecString const& levels() const { return levels_; }
+
+    // Print expected results to stdout
+    void print_expected() const;
+
+  private:
+    Logger* logger_;
+    std::unique_ptr<Logger> saved_logger_;
+    VecString messages_;
+    VecString levels_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/testdetail/TestMainImpl.cc
+++ b/test/testdetail/TestMainImpl.cc
@@ -34,10 +34,7 @@ namespace testdetail
 int test_main(int argc, char** argv)
 {
     ScopedMpiInit scoped_mpi(&argc, &argv);
-    MpiCommunicator comm
-        = (ScopedMpiInit::status() == ScopedMpiInit::Status::disabled
-               ? MpiCommunicator{}
-               : MpiCommunicator::comm_world());
+    MpiCommunicator comm = MpiCommunicator::comm_default();
 
     try
     {


### PR DESCRIPTION
Instead of giving an environment variable to pre-set the logger level, just use a helper function for the default. For testing the logger I added a helper class to store log messages, temporarily replace one of the global loggers.