### PR TITLE
Add scoped NVTX ranges for improved profiling

### DIFF
--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -108,7 +108,7 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     Stopwatch get_transport_time;
     if (run_input->merge_events)
     {
-        ScopedDeviceProfiling profile_this;
+        ScopedDeviceProfiling profile_this{"app"};
 
         // Run all events simultaneously on a single stream
         result.events.front() = run_stream();
@@ -116,7 +116,7 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     else
     {
         MultiExceptionHandler capture_exception;
-        ScopedDeviceProfiling profile_this;
+        ScopedDeviceProfiling profile_this{"app"};
 
 #ifdef _OPENMP
         // Set the maximum number of nested parallel regions

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -32,9 +32,9 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/MpiCommunicator.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
-#include "corecel/sys/ScopedDeviceProfiling.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "corecel/sys/ScopedMpiInit.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/Stopwatch.hh"
 #include "celeritas/Types.hh"
 
@@ -108,7 +108,7 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     Stopwatch get_transport_time;
     if (run_input->merge_events)
     {
-        ScopedDeviceProfiling profile_this{"app"};
+        ScopedProfiling profile_this{"app"};
 
         // Run all events simultaneously on a single stream
         result.events.front() = run_stream();
@@ -116,7 +116,7 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     else
     {
         MultiExceptionHandler capture_exception;
-        ScopedDeviceProfiling profile_this{"app"};
+        ScopedProfiling profile_this{"app"};
 
 #ifdef _OPENMP
         // Set the maximum number of nested parallel regions

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -108,9 +108,7 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     Stopwatch get_transport_time;
     if (run_input->merge_events)
     {
-        ScopedProfiling::Input input;
-        input.name = "app";
-        ScopedProfiling profile_this{input};
+        ScopedProfiling profile_this{"app"};
 
         // Run all events simultaneously on a single stream
         result.events.front() = run_stream();
@@ -118,9 +116,7 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     else
     {
         MultiExceptionHandler capture_exception;
-        ScopedProfiling::Input input;
-        input.name = "app";
-        ScopedProfiling profile_this{input};
+        ScopedProfiling profile_this{"app"};
 
 #ifdef _OPENMP
         // Set the maximum number of nested parallel regions

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -108,7 +108,7 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     Stopwatch get_transport_time;
     if (run_input->merge_events)
     {
-        ScopedProfiling profile_this{"app"};
+        ScopedProfiling profile_this{"celer-sim"};
 
         // Run all events simultaneously on a single stream
         result.events.front() = run_stream();
@@ -116,7 +116,7 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     else
     {
         MultiExceptionHandler capture_exception;
-        ScopedProfiling profile_this{"app"};
+        ScopedProfiling profile_this{"celer-sim"};
 
 #ifdef _OPENMP
         // Set the maximum number of nested parallel regions

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -108,7 +108,9 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     Stopwatch get_transport_time;
     if (run_input->merge_events)
     {
-        ScopedProfiling profile_this{"app"};
+        ScopedProfiling::Input input;
+        input.name = "app";
+        ScopedProfiling profile_this{input};
 
         // Run all events simultaneously on a single stream
         result.events.front() = run_stream();
@@ -116,7 +118,9 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     else
     {
         MultiExceptionHandler capture_exception;
-        ScopedProfiling profile_this{"app"};
+        ScopedProfiling::Input input;
+        input.name = "app";
+        ScopedProfiling profile_this{input};
 
 #ifdef _OPENMP
         // Set the maximum number of nested parallel regions

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(CELERITAS_USE_CUDA)
   # we currently depend on CUDA install including the nvtx header
   list(APPEND SOURCES
-    sys/ScopedProfiling.nvtx.cc
+    sys/ScopedProfiling.cuda.cc
   )
 endif()
 

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -58,8 +58,9 @@ if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
   )
 endif()
 if(CELERITAS_USE_CUDA)
+  # we currently depend on CUDA install including the nvtx header
   list(APPEND SOURCES
-    sys/ScopedDeviceProfiling.cuda.cc
+    sys/ScopedProfiling.nvtx.cc
   )
 endif()
 

--- a/src/corecel/sys/ScopedDeviceProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedDeviceProfiling.cuda.cc
@@ -24,10 +24,10 @@ namespace
 {
 nvtxDomainHandle_t domain_handle()
 {
-    static nvtxDomainHandle_t domain = nvtxDomainCreateA("Celeritas");
+    static nvtxDomainHandle_t domain = nvtxDomainCreateA("celeritas");
     return domain;
 }
-nvtxEventAttributes_t attributes(char const* name)
+nvtxEventAttributes_t make_attributes(std::string const& name)
 {
     nvtxEventAttributes_t attributes;
     attributes.version = NVTX_VERSION;
@@ -35,7 +35,7 @@ nvtxEventAttributes_t attributes(char const* name)
     attributes.colorType = NVTX_COLOR_ARGB;
     attributes.color = 0xff00ff00;
     attributes.messageType = NVTX_MESSAGE_TYPE_ASCII;
-    attributes.message.ascii = name;
+    attributes.message.ascii = name.c_str();
     attributes.payloadType = NVTX_PAYLOAD_TYPE_INT32;
     attributes.payload.iValue = 0;
     attributes.category = 0;
@@ -46,11 +46,11 @@ nvtxEventAttributes_t attributes(char const* name)
 /*!
  * Activate device profiling.
  */
-ScopedDeviceProfiling::ScopedDeviceProfiling(std::string_view name)
+ScopedDeviceProfiling::ScopedDeviceProfiling(std::string const& name)
 {
     if (celeritas::device())
     {
-        nvtxEventAttributes_t attributes_ = attributes(name.data());
+        nvtxEventAttributes_t attributes_ = make_attributes(name);
         nvtxDomainRangePushEx(domain_handle(), &attributes_);
     }
 }

--- a/src/corecel/sys/ScopedDeviceProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedDeviceProfiling.cuda.cc
@@ -5,7 +5,12 @@
 //---------------------------------------------------------------------------//
 //! \file corecel/sys/ScopedDeviceProfiling.cuda.cc
 //---------------------------------------------------------------------------//
+
 #include "ScopedDeviceProfiling.hh"
+
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
 
 #include "celeritas_config.h"
 #include "corecel/device_runtime_api.h"
@@ -22,11 +27,66 @@ namespace celeritas
 {
 namespace
 {
+
+//---------------------------------------------------------------------------//
+/*!
+ * Global registry for strings used by NVTX.
+ * This Implemented as a free function instead of a static in
+ * ScopedDeviceProfiling to hide the NVTX dependency from user of the
+ * interface.
+ */
+std::unordered_map<std::string, nvtxStringHandle_t>& message_registry()
+{
+    static std::unordered_map<std::string, nvtxStringHandle_t> registry;
+    return registry;
+}
+
 nvtxDomainHandle_t domain_handle()
 {
     static nvtxDomainHandle_t domain = nvtxDomainCreateA("celeritas");
     return domain;
 }
+
+//---------------------------------------------------------------------------//
+/*!
+ * Retrieve the handle for a given message, insert it if it doesn't already
+ * exists
+ */
+nvtxStringHandle_t message_handle_for(std::string const& message)
+{
+    static std::shared_mutex mutex;
+
+    {
+        std::shared_lock lock(mutex);
+        auto message_handle = message_registry().find(message);
+        if (message_handle != message_registry().end())
+        {
+            return message_handle->second;
+        }
+    }
+    // we did not find the handle, insert it
+    std::unique_lock lock(mutex);
+    auto message_handle = message_registry().find(message);
+    // recheck that nobody inserted the same message as we had to release the
+    // shared lock not strictly necessary as insert will do nothing if the key
+    // already exists
+    if (message_handle == message_registry().end())
+    {
+        auto handle
+            = nvtxDomainRegisterStringA(domain_handle(), message.c_str());
+        message_registry().insert({message, handle});
+        return handle;
+    }
+    else
+    {
+        return message_handle->second;
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create EventAttribute with a specific name
+ */
 nvtxEventAttributes_t make_attributes(std::string const& name)
 {
     nvtxEventAttributes_t attributes;
@@ -34,8 +94,8 @@ nvtxEventAttributes_t make_attributes(std::string const& name)
     attributes.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
     attributes.colorType = NVTX_COLOR_ARGB;
     attributes.color = 0xff00ff00;
-    attributes.messageType = NVTX_MESSAGE_TYPE_ASCII;
-    attributes.message.ascii = name.c_str();
+    attributes.messageType = NVTX_MESSAGE_TYPE_REGISTERED;
+    attributes.message.registered = message_handle_for(name);
     attributes.payloadType = NVTX_PAYLOAD_TYPE_INT32;
     attributes.payload.iValue = 0;
     attributes.category = 0;
@@ -48,11 +108,8 @@ nvtxEventAttributes_t make_attributes(std::string const& name)
  */
 ScopedDeviceProfiling::ScopedDeviceProfiling(std::string const& name)
 {
-    if (celeritas::device())
-    {
-        nvtxEventAttributes_t attributes_ = make_attributes(name);
-        nvtxDomainRangePushEx(domain_handle(), &attributes_);
-    }
+    nvtxEventAttributes_t attributes_ = make_attributes(name);
+    nvtxDomainRangePushEx(domain_handle(), &attributes_);
 }
 
 //---------------------------------------------------------------------------//
@@ -61,10 +118,7 @@ ScopedDeviceProfiling::ScopedDeviceProfiling(std::string const& name)
  */
 ScopedDeviceProfiling::~ScopedDeviceProfiling()
 {
-    if (celeritas::device())
-    {
-        nvtxDomainRangePop(domain_handle());
-    }
+    nvtxDomainRangePop(domain_handle());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedDeviceProfiling.hh
+++ b/src/corecel/sys/ScopedDeviceProfiling.hh
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <string_view>
+#include <string>
 
 #include "celeritas_config.h"
 
@@ -32,14 +32,14 @@ class ScopedDeviceProfiling
 {
   public:
     // Activate profiling
-    ScopedDeviceProfiling(std::string_view name);
+    explicit ScopedDeviceProfiling(std::string const& name);
     // Deactivate profiling
     ~ScopedDeviceProfiling();
 };
 
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_CUDA
-inline ScopedDeviceProfiling::ScopedDeviceProfiling(std::string_view) {}
+inline ScopedDeviceProfiling::ScopedDeviceProfiling(std::string const&) {}
 inline ScopedDeviceProfiling::~ScopedDeviceProfiling() {}
 #endif
 

--- a/src/corecel/sys/ScopedDeviceProfiling.hh
+++ b/src/corecel/sys/ScopedDeviceProfiling.hh
@@ -39,7 +39,7 @@ class ScopedDeviceProfiling
 
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_CUDA
-inline ScopedDeviceProfiling::ScopedDeviceProfiling() {}
+inline ScopedDeviceProfiling::ScopedDeviceProfiling(std::string_view) {}
 inline ScopedDeviceProfiling::~ScopedDeviceProfiling() {}
 #endif
 

--- a/src/corecel/sys/ScopedDeviceProfiling.hh
+++ b/src/corecel/sys/ScopedDeviceProfiling.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <string_view>
+
 #include "celeritas_config.h"
 
 #include "Device.hh"
@@ -30,20 +32,14 @@ class ScopedDeviceProfiling
 {
   public:
     // Activate profiling
-    ScopedDeviceProfiling();
+    ScopedDeviceProfiling(std::string_view name);
     // Deactivate profiling
     ~ScopedDeviceProfiling();
-
-  private:
-    bool activated_{false};
 };
 
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_CUDA
-inline ScopedDeviceProfiling::ScopedDeviceProfiling()
-{
-    (void)sizeof(activated_);
-}
+inline ScopedDeviceProfiling::ScopedDeviceProfiling() {}
 inline ScopedDeviceProfiling::~ScopedDeviceProfiling() {}
 #endif
 

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -13,10 +13,6 @@
 #include <unordered_map>
 #include <nvtx3/nvToolsExt.h>
 
-#include "celeritas_config.h"
-#include "corecel/Assert.hh"
-#include "corecel/io/Logger.hh"
-
 /**
  * @file
  *
@@ -34,8 +30,8 @@ namespace
 //---------------------------------------------------------------------------//
 /*!
  * Global registry for strings used by NVTX.
- * This Implemented as a free function instead of a static in
- * ScopedProfiling to hide the NVTX dependency from user of the
+ * This is implemented as a free function instead of a class static member in
+ * ScopedProfiling to hide the NVTX dependency from users of the
  * interface.
  */
 std::unordered_map<std::string, nvtxStringHandle_t>& message_registry()
@@ -46,7 +42,7 @@ std::unordered_map<std::string, nvtxStringHandle_t>& message_registry()
 
 //---------------------------------------------------------------------------//
 /*!
- * Library-wide handle to the domain name
+ * Library-wide handle to the domain name.
  */
 nvtxDomainHandle_t domain_handle()
 {
@@ -56,19 +52,7 @@ nvtxDomainHandle_t domain_handle()
 
 //---------------------------------------------------------------------------//
 /*!
- * Create ScopedProfiling input with a given name
- * TODO: replace with c++20 designated initializer
- */
-ScopedProfiling::Input make_input(std::string const& name)
-{
-    ScopedProfiling::Input input;
-    input.name = name;
-    return input;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Retrieve the handle for a given message, insert it if it doesn't already
+ * Retrieve the handle for a given message. Insert it if it doesn't already
  * exists.
  */
 nvtxStringHandle_t message_handle_for(std::string const& message)
@@ -97,7 +81,7 @@ nvtxStringHandle_t message_handle_for(std::string const& message)
 
 //---------------------------------------------------------------------------//
 /*!
- * Create EventAttribute with a specific name
+ * Create EventAttribute with a specific name.
  */
 nvtxEventAttributes_t make_attributes(ScopedProfiling::Input const& input)
 {
@@ -130,13 +114,13 @@ ScopedProfiling::ScopedProfiling(Input input)
  * Activate nvtx profiling.
  */
 ScopedProfiling::ScopedProfiling(std::string const& name)
-    : ScopedProfiling(make_input(name))
+    : ScopedProfiling{Input{name}}
 {
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Deactivate device profiling if this function activated it.
+ * End the profiling range.
  */
 ScopedProfiling::~ScopedProfiling()
 {

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -20,10 +20,10 @@
 /**
  * @file
  *
- * The nvtx implementation of \c ScopedProfiling only does anything the
+ * The nvtx implementation of \c ScopedProfiling only does something when the
  * application using Celeritas is ran through a tool that supports nvtx, e.g.
- * nsight compute with the --nvtx argument. If this is not the case, all API
- * calls to nvtx are disabled and will not do anything.
+ * nsight compute with the --nvtx argument. If this is not the case, API
+ * calls to nvtx are disabled, doing noop.
  */
 
 namespace celeritas

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -17,6 +17,15 @@
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
 
+/**
+ * @file
+ *
+ * The nvtx implementation of \c ScopedProfiling only does anything the
+ * application using Celeritas is ran through a tool that supports nvtx, e.g.
+ * nsight compute with the --nvtx argument. If this is not the case, all API
+ * calls to nvtx are disabled and will not do anything.
+ */
+
 namespace celeritas
 {
 namespace
@@ -60,7 +69,7 @@ ScopedProfiling::Input make_input(std::string const& name)
 //---------------------------------------------------------------------------//
 /*!
  * Retrieve the handle for a given message, insert it if it doesn't already
- * exists
+ * exists.
  */
 nvtxStringHandle_t message_handle_for(std::string const& message)
 {
@@ -77,7 +86,7 @@ nvtxStringHandle_t message_handle_for(std::string const& message)
     }
     // We did not find the handle; try to insert it
     std::unique_lock lock(mutex);
-    auto [iter, inserted] = message_registry().insert({message, nullptr});
+    auto [iter, inserted] = message_registry().insert({message, {}});
     if (inserted)
     {
         iter->second

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -31,6 +31,8 @@ class ScopedProfiling
     explicit ScopedProfiling(std::string const& name);
     // Deactivate profiling
     ~ScopedProfiling();
+    // RAII semantics
+    void* operator new(std::size_t count) = delete;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -24,6 +24,8 @@ struct ScopedProfilingInput
     uint32_t color{0xFF00FF00};  //!< ARGB
     int32_t payload{0};  //!< User data
     uint32_t category{0};  //!< Category, used to group ranges together
+
+    ScopedProfilingInput(std::string const& name) : name{name} {}
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -48,7 +48,7 @@ class ScopedProfiling
   public:
     using Input = ScopedProfilingInput;
     // Activate profiling
-    explicit ScopedProfiling(Input const input);
+    explicit ScopedProfiling(Input input);
     // Deactivate profiling
     ~ScopedProfiling();
     // RAII semantics
@@ -57,7 +57,7 @@ class ScopedProfiling
 
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_CUDA
-inline ScopedProfiling::ScopedProfiling(Input const) {}
+inline ScopedProfiling::ScopedProfiling(Input) {}
 inline ScopedProfiling::~ScopedProfiling() {}
 #endif
 

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -51,6 +51,8 @@ class ScopedProfiling
     //!@}
 
   public:
+    // Whether profiling is enabled
+    static bool enable_profiling();
     // Activate profiling with options
     explicit ScopedProfiling(Input input);
     // Activate profiling

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -13,6 +13,23 @@
 
 namespace celeritas
 {
+
+//---------------------------------------------------------------------------//
+/*!
+ * Input arguments for the nvtx implementation.
+ */
+struct ScopedProfilingInput
+{
+    // Name of the range
+    std::string name;
+    // ARGB
+    uint32_t color{0xFF00FF00};
+    // User data
+    int32_t payload{0};
+    // Category, used to group ranges together
+    uint32_t category{0};
+};
+
 //---------------------------------------------------------------------------//
 /*!
  * RAII class for scoped profiling.
@@ -23,12 +40,15 @@ namespace celeritas
  * This is useful for wrapping specific code fragment in a range for profiling,
  * e.g. ignoring of VecGeom instantiation kernels, profiling a specific action
  * or loop on the CPU.
+ * TODO: Template ScopedProfiling over profiling backend if we need to add a
+ * new one
  */
 class ScopedProfiling
 {
   public:
+    using Input = ScopedProfilingInput;
     // Activate profiling
-    explicit ScopedProfiling(std::string const& name);
+    explicit ScopedProfiling(Input const input);
     // Deactivate profiling
     ~ScopedProfiling();
     // RAII semantics
@@ -37,7 +57,7 @@ class ScopedProfiling
 
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_CUDA
-inline ScopedProfiling::ScopedProfiling(std::string const&) {}
+inline ScopedProfiling::ScopedProfiling(Input const) {}
 inline ScopedProfiling::~ScopedProfiling() {}
 #endif
 

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "celeritas_config.h"
@@ -21,7 +22,7 @@ namespace celeritas
 struct ScopedProfilingInput
 {
     std::string name;  //!< Name of the range
-    uint32_t color{0xFF00FF00};  //!< ARGB
+    uint32_t color{0xFF00FF00u};  //!< ARGB
     int32_t payload{0};  //!< User data
     uint32_t category{0};  //!< Category, used to group ranges together
 
@@ -58,11 +59,8 @@ class ScopedProfiling
     ~ScopedProfiling();
     // Can't outlive the scope it was created in to correctly match each push /
     // pop. Must strictly follows RAII semantics (automatic storage duration)
-    void* operator new(std::size_t) = delete;
     ScopedProfiling(ScopedProfiling const&) = delete;
     ScopedProfiling& operator=(ScopedProfiling const&) = delete;
-    ScopedProfiling(ScopedProfiling&&) = delete;
-    ScopedProfiling& operator=(ScopedProfiling&&) = delete;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/sys/ScopedDeviceProfiling.hh
+//! \file corecel/sys/ScopedProfiling.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -11,36 +11,32 @@
 
 #include "celeritas_config.h"
 
-#include "Device.hh"
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * RAII class for CUDA/HIP profiling flags .
+ * RAII class for scoped profiling.
  *
- * This should be instantiated in a single-thread context. If celeritas::device
- * is enabled, it will call \c cudaProfilerStart at construction and
- * \c cudaProfilerStop at destruction. If device support is disabled, this
- * class is a null-op. HIP support for the profiler start/stop macros is
- * deprecated so we do not support it at present.
+ * Implementations should support multithreaded context where each thread have
+ * one or more alive instance of this class.
  *
- * This is useful for wrapping the main stepper/transport loop for profiling to
- * allow ignoring of VecGeom instantiation kernels.
+ * This is useful for wrapping specific code fragment in a range for profiling,
+ * e.g. ignoring of VecGeom instantiation kernels, profiling a specific action
+ * or loop on the CPU.
  */
-class ScopedDeviceProfiling
+class ScopedProfiling
 {
   public:
     // Activate profiling
-    explicit ScopedDeviceProfiling(std::string const& name);
+    explicit ScopedProfiling(std::string const& name);
     // Deactivate profiling
-    ~ScopedDeviceProfiling();
+    ~ScopedProfiling();
 };
 
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_CUDA
-inline ScopedDeviceProfiling::ScopedDeviceProfiling(std::string const&) {}
-inline ScopedDeviceProfiling::~ScopedDeviceProfiling() {}
+inline ScopedProfiling::ScopedProfiling(std::string const&) {}
+inline ScopedProfiling::~ScopedProfiling() {}
 #endif
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -20,14 +20,10 @@ namespace celeritas
  */
 struct ScopedProfilingInput
 {
-    // Name of the range
-    std::string name;
-    // ARGB
-    uint32_t color{0xFF00FF00};
-    // User data
-    int32_t payload{0};
-    // Category, used to group ranges together
-    uint32_t category{0};
+    std::string name;  //!< Name of the range
+    uint32_t color{0xFF00FF00};  //!< ARGB
+    int32_t payload{0};  //!< User data
+    uint32_t category{0};  //!< Category, used to group ranges together
 };
 
 //---------------------------------------------------------------------------//
@@ -46,9 +42,16 @@ struct ScopedProfilingInput
 class ScopedProfiling
 {
   public:
+    //!@{
+    //! \name Type aliases
     using Input = ScopedProfilingInput;
-    // Activate profiling
+    //!@}
+
+  public:
+    // Activate profiling with options
     explicit ScopedProfiling(Input input);
+    // Activate profiling
+    explicit ScopedProfiling(std::string const& name);
     // Deactivate profiling
     ~ScopedProfiling();
     // RAII semantics
@@ -58,6 +61,7 @@ class ScopedProfiling
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_CUDA
 inline ScopedProfiling::ScopedProfiling(Input) {}
+inline ScopedProfiling::ScopedProfiling(std::string const&) {}
 inline ScopedProfiling::~ScopedProfiling() {}
 #endif
 

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -54,8 +54,13 @@ class ScopedProfiling
     explicit ScopedProfiling(std::string const& name);
     // Deactivate profiling
     ~ScopedProfiling();
-    // RAII semantics
-    void* operator new(std::size_t count) = delete;
+    // Can't outlive the scope it was created in to correctly match each push /
+    // pop. Must strictly follows RAII semantics (automatic storage duration)
+    void* operator new(std::size_t) = delete;
+    ScopedProfiling(ScopedProfiling const&) = delete;
+    ScopedProfiling& operator=(ScopedProfiling const&) = delete;
+    ScopedProfiling(ScopedProfiling&&) = delete;
+    ScopedProfiling& operator=(ScopedProfiling&&) = delete;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedProfiling.nvtx.cc
+++ b/src/corecel/sys/ScopedProfiling.nvtx.cc
@@ -3,25 +3,19 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/sys/ScopedDeviceProfiling.cuda.cc
+//! \file corecel/sys/ScopedProfiling.nvtx.cc
 //---------------------------------------------------------------------------//
 
-#include "ScopedDeviceProfiling.hh"
+#include "ScopedProfiling.hh"
 
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
-
-#include "celeritas_config.h"
-#include "corecel/device_runtime_api.h"
-
-// Profiler API isn't included with regular CUDA API headers
 #include <nvtx3/nvToolsExt.h>
 
+#include "celeritas_config.h"
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
-
-#include "Device.hh"
 
 namespace celeritas
 {
@@ -32,7 +26,7 @@ namespace
 /*!
  * Global registry for strings used by NVTX.
  * This Implemented as a free function instead of a static in
- * ScopedDeviceProfiling to hide the NVTX dependency from user of the
+ * ScopedProfiling to hide the NVTX dependency from user of the
  * interface.
  */
 std::unordered_map<std::string, nvtxStringHandle_t>& message_registry()
@@ -102,11 +96,12 @@ nvtxEventAttributes_t make_attributes(std::string const& name)
     return attributes;
 }
 }  // namespace
+
 //---------------------------------------------------------------------------//
 /*!
- * Activate device profiling.
+ * Activate nvtx profiling.
  */
-ScopedDeviceProfiling::ScopedDeviceProfiling(std::string const& name)
+ScopedProfiling::ScopedProfiling(std::string const& name)
 {
     nvtxEventAttributes_t attributes_ = make_attributes(name);
     nvtxDomainRangePushEx(domain_handle(), &attributes_);
@@ -116,7 +111,7 @@ ScopedDeviceProfiling::ScopedDeviceProfiling(std::string const& name)
 /*!
  * Deactivate device profiling if this function activated it.
  */
-ScopedDeviceProfiling::~ScopedDeviceProfiling()
+ScopedProfiling::~ScopedProfiling()
 {
     nvtxDomainRangePop(domain_handle());
 }

--- a/src/corecel/sys/ScopedProfiling.nvtx.cc
+++ b/src/corecel/sys/ScopedProfiling.nvtx.cc
@@ -81,18 +81,18 @@ nvtxStringHandle_t message_handle_for(std::string const& message)
 /*!
  * Create EventAttribute with a specific name
  */
-nvtxEventAttributes_t make_attributes(std::string const& name)
+nvtxEventAttributes_t make_attributes(ScopedProfiling::Input const& input)
 {
     nvtxEventAttributes_t attributes;
     attributes.version = NVTX_VERSION;
     attributes.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
     attributes.colorType = NVTX_COLOR_ARGB;
-    attributes.color = 0xff00ff00;
+    attributes.color = input.color;
     attributes.messageType = NVTX_MESSAGE_TYPE_REGISTERED;
-    attributes.message.registered = message_handle_for(name);
+    attributes.message.registered = message_handle_for(input.name);
     attributes.payloadType = NVTX_PAYLOAD_TYPE_INT32;
-    attributes.payload.iValue = 0;
-    attributes.category = 0;
+    attributes.payload.iValue = input.payload;
+    attributes.category = input.category;
     return attributes;
 }
 }  // namespace
@@ -101,9 +101,9 @@ nvtxEventAttributes_t make_attributes(std::string const& name)
 /*!
  * Activate nvtx profiling.
  */
-ScopedProfiling::ScopedProfiling(std::string const& name)
+ScopedProfiling::ScopedProfiling(Input const input)
 {
-    nvtxEventAttributes_t attributes_ = make_attributes(name);
+    nvtxEventAttributes_t attributes_ = make_attributes(input);
     nvtxDomainRangePushEx(domain_handle(), &attributes_);
 }
 


### PR DESCRIPTION
Use the NVTX library instead of cuda profiler. For now this implements the bare minimum functionalities to be useful. We'd probably want to use [registered strings](https://nvidia.github.io/NVTX/doxygen/group___s_t_r_i_n_g___r_e_g_i_s_t_r_a_t_i_o_n.html) and possibly allow to specify a payload / category?