### PR TITLE
Unify convergence criteria in field driver

### DIFF
--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -159,8 +159,7 @@ FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
     CELER_ASSERT(output.end.step <= step);
 
     // Evaluate the relative error
-    real_type rel_error = output.err_sq
-                          / (options_.epsilon_step * output.end.step);
+    real_type rel_error = output.err_sq / options_.epsilon_step;
 
     if (rel_error > 1)
     {
@@ -319,8 +318,8 @@ FieldDriver<StepperT>::integrate_step(real_type step,
         // Compute a proposed new step
         real_type err_sq = detail::rel_err_sq(result.err_state, step, state.mom)
                            / ipow<2>(options_.epsilon_rel_max);
-        output.proposed_step = this->new_step_size(
-            step, err_sq / (options_.epsilon_step * step));
+        output.proposed_step
+            = this->new_step_size(step, err_sq / options_.epsilon_step);
     }
 
     return output;

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -197,11 +197,12 @@ FieldDriver<StepperT>::find_next_chord(real_type step,
         real_type dchord = detail::distance_chord(
             state, result.mid_state, result.end_state);
 
-        // TODO: drop dchord_tol?
         if (dchord > options_.delta_chord + options_.dchord_tol)
         {
             // Estimate a new trial chord with a relative scale
-            step *= max(std::sqrt(options_.delta_chord / dchord), half());
+            real_type scale_step = max(std::sqrt(options_.delta_chord / dchord),
+                                       options_.min_chord_shrink);
+            step *= scale_step;
         }
         else
         {
@@ -353,9 +354,11 @@ FieldDriver<StepperT>::one_good_step(real_type step, OdeState const& state) cons
         if (err_eps_sq > 1)
         {
             // Step failed; compute the size of re-trial step.
-            step *= max(options_.safety
-                            * fastpow(err_eps_sq, half() * options_.pshrink),
-                        options_.max_stepping_decrease);
+            real_type scale_step
+                = max(options_.safety
+                          * fastpow(err_eps_sq, half() * options_.pshrink),
+                      options_.max_stepping_decrease);
+            step *= scale_step;
         }
         else
         {

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -8,15 +8,20 @@
 #pragma once
 
 #include <cmath>
+#include <iostream>
 
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "corecel/cont/ArrayIO.hh"
+#include "corecel/io/ColorUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/SoftEqual.hh"
 
 #include "FieldDriverOptions.hh"
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
+using std::cout;
+using std::endl;
 
 namespace celeritas
 {
@@ -141,12 +146,18 @@ template<class StepperT>
 CELER_FUNCTION DriverResult
 FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
 {
+    cout << color_code('b') << "Step up to " << step << color_code(' ')
+         << " from " << state.pos << endl;
+
     if (step <= options_.minimum_step)
     {
+        cout << " - quick advance" << endl;
+
         // If the input is a very tiny step, do a "quick advance".
         DriverResult result;
         result.state = apply_step_(step, state).end_state;
         result.step = step;
+        cout << color_code('g') << "==> distance " << result.step << endl;
         return result;
     }
 
@@ -165,6 +176,8 @@ FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
         output.end = this->accurate_advance(output.end.step, state, next_step);
     }
 
+    cout << color_code('g') << "==> substep " << output.end.step
+         << color_code(' ') << endl;
     CELER_ENSURE(output.end.step > 0 && output.end.step <= step);
     return output.end;
 }
@@ -183,6 +196,8 @@ FieldDriver<StepperT>::find_next_chord(real_type step,
     // Output with a step control error
     ChordSearch output;
 
+    cout << " - find next chord" << endl;
+
     bool succeeded = false;
     auto remaining_steps = options_.max_nsteps;
     FieldStepperResult result;
@@ -197,18 +212,29 @@ FieldDriver<StepperT>::find_next_chord(real_type step,
         real_type dchord = detail::distance_chord(
             state, result.mid_state, result.end_state);
 
+        cout << "  + step " << step << " -> dchord " << dchord;
+
         if (dchord > options_.delta_chord + options_.dchord_tol)
         {
             // Estimate a new trial chord with a relative scale
             real_type scale_step = max(std::sqrt(options_.delta_chord / dchord),
                                        options_.min_chord_shrink);
             step *= scale_step;
+            cout << " -> scale by 1 - " << (1 - scale_step);
         }
         else
         {
+            // Close enough to the desired chord tolerance
+            cout << " -> " << color_code('g') << "converged" << color_code(' ');
             succeeded = true;
         }
+        cout << endl;
     } while (!succeeded && --remaining_steps > 0);
+    if (remaining_steps == 0)
+    {
+        cout << "  + " << color_code('y') << "failed to converge"
+             << color_code(' ') << endl;
+    }
 
     // Update step, position and momentum
     output.end.step = step;
@@ -231,6 +257,9 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
     real_type step, OdeState const& state, real_type hinitial) const
 {
     CELER_ASSERT(step > 0);
+
+    cout << " - accurate advance to " << step << " with initial step "
+         << hinitial << endl;
 
     // Set an initial proposed step and evaluate the minimum threshold
     real_type end_curve_length = step;
@@ -257,12 +286,19 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
     do
     {
         CELER_ASSERT(h > 0);
+        cout << "  + integrating substep " << h << " from "
+             << output.end.state.pos << endl;
+
         output = this->integrate_step(h, output.end.state);
 
         curve_length += output.end.step;
 
+        cout << "  + integrated substep " << h << " -> " << output.end.step
+             << ", proposed step " << output.proposed_step;
+
         if (h < h_threshold || curve_length >= end_curve_length)
         {
+            cout << " -> " << color_code('g') << "complete" << color_code(' ');
             succeeded = true;
         }
         else
@@ -270,8 +306,16 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
             h = celeritas::min(
                 celeritas::max(output.proposed_step, options_.minimum_step),
                 end_curve_length - curve_length);
+            cout << "\n    " << color_code('x') << remaining_steps
+                 << " remaining" << color_code(' ');
         }
+        cout << endl;
     } while (!succeeded && --remaining_steps > 0);
+    if (remaining_steps == 0)
+    {
+        cout << "  + " << color_code('y') << "failed to converge"
+             << color_code(' ') << endl;
+    }
 
     // Curve length may be slightly longer than step due to roundoff in
     // accumulation
@@ -304,6 +348,8 @@ FieldDriver<StepperT>::integrate_step(real_type step,
     }
     else
     {
+        cout << "   * quick advance\n";
+
         // Do an integration step for a small step (a.k.a quick advance)
         FieldStepperResult result = apply_step_(step, state);
 
@@ -335,6 +381,8 @@ FieldDriver<StepperT>::one_good_step(real_type step, OdeState const& state) cons
     -> Integration
 {
     CELER_EXPECT(step >= options_.minimum_step);
+    cout << "   * one good step\n";
+
     // Output with a proposed next step
     Integration output;
 
@@ -351,6 +399,8 @@ FieldDriver<StepperT>::one_good_step(real_type step, OdeState const& state) cons
         err_eps_sq = detail::rel_err_sq(result.err_state, step, state.mom)
                      / ipow<2>(options_.epsilon_rel_max);
 
+        cout << "    # apply step " << step
+             << " -> err/eps=" << std::sqrt(err_eps_sq);
         if (err_eps_sq > 1)
         {
             // Step failed; compute the size of re-trial step.
@@ -359,13 +409,21 @@ FieldDriver<StepperT>::one_good_step(real_type step, OdeState const& state) cons
                           * fastpow(err_eps_sq, half() * options_.pshrink),
                       options_.max_stepping_decrease);
             step *= scale_step;
+            cout << " -> scale by " << scale_step;
         }
         else
         {
             // Success or possibly nan!
+            cout << " -> " << color_code('g') << "converged" << color_code(' ');
             succeeded = true;
         }
+        cout << endl;
     } while (!succeeded && --remaining_steps > 0);
+    if (remaining_steps == 0)
+    {
+        cout << "    # " << color_code('y') << "failed to converge"
+             << color_code(' ') << endl;
+    }
 
     // Update state, step taken by this trial and the next predicted step
     output.end.state = result.end_state;

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -8,20 +8,15 @@
 #pragma once
 
 #include <cmath>
-#include <iostream>
 
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
-#include "corecel/cont/ArrayIO.hh"
-#include "corecel/io/ColorUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/SoftEqual.hh"
 
 #include "FieldDriverOptions.hh"
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
-using std::cout;
-using std::endl;
 
 namespace celeritas
 {
@@ -146,18 +141,12 @@ template<class StepperT>
 CELER_FUNCTION DriverResult
 FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
 {
-    cout << color_code('b') << "Step up to " << step << color_code(' ')
-         << " from " << state.pos << endl;
-
     if (step <= options_.minimum_step)
     {
-        cout << " - quick advance" << endl;
-
         // If the input is a very tiny step, do a "quick advance".
         DriverResult result;
         result.state = apply_step_(step, state).end_state;
         result.step = step;
-        cout << color_code('g') << "==> distance " << result.step << endl;
         return result;
     }
 
@@ -176,8 +165,6 @@ FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
         output.end = this->accurate_advance(output.end.step, state, next_step);
     }
 
-    cout << color_code('g') << "==> substep " << output.end.step
-         << color_code(' ') << endl;
     CELER_ENSURE(output.end.step > 0 && output.end.step <= step);
     return output.end;
 }
@@ -196,8 +183,6 @@ FieldDriver<StepperT>::find_next_chord(real_type step,
     // Output with a step control error
     ChordSearch output;
 
-    cout << " - find next chord" << endl;
-
     bool succeeded = false;
     auto remaining_steps = options_.max_nsteps;
     FieldStepperResult result;
@@ -212,29 +197,18 @@ FieldDriver<StepperT>::find_next_chord(real_type step,
         real_type dchord = detail::distance_chord(
             state, result.mid_state, result.end_state);
 
-        cout << "  + step " << step << " -> dchord " << dchord;
-
         if (dchord > options_.delta_chord + options_.dchord_tol)
         {
             // Estimate a new trial chord with a relative scale
             real_type scale_step = max(std::sqrt(options_.delta_chord / dchord),
                                        options_.min_chord_shrink);
             step *= scale_step;
-            cout << " -> scale by 1 - " << (1 - scale_step);
         }
         else
         {
-            // Close enough to the desired chord tolerance
-            cout << " -> " << color_code('g') << "converged" << color_code(' ');
             succeeded = true;
         }
-        cout << endl;
     } while (!succeeded && --remaining_steps > 0);
-    if (remaining_steps == 0)
-    {
-        cout << "  + " << color_code('y') << "failed to converge"
-             << color_code(' ') << endl;
-    }
 
     // Update step, position and momentum
     output.end.step = step;
@@ -257,9 +231,6 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
     real_type step, OdeState const& state, real_type hinitial) const
 {
     CELER_ASSERT(step > 0);
-
-    cout << " - accurate advance to " << step << " with initial step "
-         << hinitial << endl;
 
     // Set an initial proposed step and evaluate the minimum threshold
     real_type end_curve_length = step;
@@ -286,19 +257,12 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
     do
     {
         CELER_ASSERT(h > 0);
-        cout << "  + integrating substep " << h << " from "
-             << output.end.state.pos << endl;
-
         output = this->integrate_step(h, output.end.state);
 
         curve_length += output.end.step;
 
-        cout << "  + integrated substep " << h << " -> " << output.end.step
-             << ", proposed step " << output.proposed_step;
-
         if (h < h_threshold || curve_length >= end_curve_length)
         {
-            cout << " -> " << color_code('g') << "complete" << color_code(' ');
             succeeded = true;
         }
         else
@@ -306,16 +270,8 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
             h = celeritas::min(
                 celeritas::max(output.proposed_step, options_.minimum_step),
                 end_curve_length - curve_length);
-            cout << "\n    " << color_code('x') << remaining_steps
-                 << " remaining" << color_code(' ');
         }
-        cout << endl;
     } while (!succeeded && --remaining_steps > 0);
-    if (remaining_steps == 0)
-    {
-        cout << "  + " << color_code('y') << "failed to converge"
-             << color_code(' ') << endl;
-    }
 
     // Curve length may be slightly longer than step due to roundoff in
     // accumulation
@@ -348,8 +304,6 @@ FieldDriver<StepperT>::integrate_step(real_type step,
     }
     else
     {
-        cout << "   * quick advance\n";
-
         // Do an integration step for a small step (a.k.a quick advance)
         FieldStepperResult result = apply_step_(step, state);
 
@@ -381,8 +335,6 @@ FieldDriver<StepperT>::one_good_step(real_type step, OdeState const& state) cons
     -> Integration
 {
     CELER_EXPECT(step >= options_.minimum_step);
-    cout << "   * one good step\n";
-
     // Output with a proposed next step
     Integration output;
 
@@ -399,8 +351,6 @@ FieldDriver<StepperT>::one_good_step(real_type step, OdeState const& state) cons
         err_eps_sq = detail::rel_err_sq(result.err_state, step, state.mom)
                      / ipow<2>(options_.epsilon_rel_max);
 
-        cout << "    # apply step " << step
-             << " -> err/eps=" << std::sqrt(err_eps_sq);
         if (err_eps_sq > 1)
         {
             // Step failed; compute the size of re-trial step.
@@ -409,21 +359,13 @@ FieldDriver<StepperT>::one_good_step(real_type step, OdeState const& state) cons
                           * fastpow(err_eps_sq, half() * options_.pshrink),
                       options_.max_stepping_decrease);
             step *= scale_step;
-            cout << " -> scale by " << scale_step;
         }
         else
         {
             // Success or possibly nan!
-            cout << " -> " << color_code('g') << "converged" << color_code(' ');
             succeeded = true;
         }
-        cout << endl;
     } while (!succeeded && --remaining_steps > 0);
-    if (remaining_steps == 0)
-    {
-        cout << "    # " << color_code('y') << "failed to converge"
-             << color_code(' ') << endl;
-    }
 
     // Update state, step taken by this trial and the next predicted step
     output.end.state = result.end_state;

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -21,6 +21,7 @@ namespace celeritas
  * TODO: replace safety with step_shrink_mul (or something to indicate that
  * it's a multiplicative factor for reducing the step, not anything with
  * geometry)
+ * TODO: remove errcon
  */
 struct FieldDriverOptions
 {
@@ -39,7 +40,7 @@ struct FieldDriverOptions
     //! Targeted discretization error for "integrate step"
     real_type epsilon_rel_max = 1.0e-3;
 
-    //! Targeted discretization error for "one good step"
+    //! UNUSED: Targeted discretization error for "one good step"
     real_type errcon = 1.0e-4;
 
     //! Exponent to increase a step size
@@ -78,7 +79,6 @@ struct FieldDriverOptions
 	       && (delta_intersection > minimum_step)
 	       && (epsilon_step > 0 && epsilon_step < 1)
 	       && (epsilon_rel_max > 0)
-	       && (errcon > 0)
 	       && (pgrow < 0)
 	       && (pshrink < 0)
 	       && (safety > 0 && safety < 1)

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -33,13 +33,13 @@ struct FieldDriverOptions
     //! Accuracy of intersection of the boundary crossing
     real_type delta_intersection = 1.0e-4 * units::millimeter;
 
-    //! Relative error scale on the step length
+    //! Discretization error tolerance for each field substep
     real_type epsilon_step = 1.0e-5;
 
-    //! Maximum of the error ratio
+    //! Targeted discretization error for "integrate step"
     real_type epsilon_rel_max = 1.0e-3;
 
-    //! Truncation error tolerance
+    //! Targeted discretization error for "one good step"
     real_type errcon = 1.0e-4;
 
     //! Exponent to increase a step size
@@ -51,10 +51,10 @@ struct FieldDriverOptions
     //! Scale factor for the predicted step size
     real_type safety = 0.9;
 
-    //! Maximum scale to increase a step size
+    //! Largrest allowable relative increase a step size
     real_type max_stepping_increase = 5;
 
-    //! Maximum scale factor to decrease a step size
+    //! Smallest allowable relative decrease in step size
     real_type max_stepping_decrease = 0.1;
 
     //! Maximum number of steps (or trials)

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -16,6 +16,11 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Configuration options for the field driver.
+ *
+ * TODO: replace epsilon_rel_max with 1/epsilon_rel_max^2
+ * TODO: replace safety with step_shrink_mul (or something to indicate that
+ * it's a multiplicative factor for reducing the step, not anything with
+ * geometry)
  */
 struct FieldDriverOptions
 {

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -19,6 +19,7 @@ namespace celeritas
  *
  * TODO: replace epsilon_rel_max with 1/epsilon_rel_max^2
  * TODO: replace safety with step_shrink_mul (or something to indicate that
+ * TODO: deletee errcon
  * it's a multiplicative factor for reducing the step, not anything with
  * geometry)
  */
@@ -39,7 +40,7 @@ struct FieldDriverOptions
     //! Targeted discretization error for "integrate step"
     real_type epsilon_rel_max = 1.0e-3;
 
-    //! Targeted discretization error for "one good step"
+    //! UNUSED: Targeted discretization error for "one good step"
     real_type errcon = 1.0e-4;
 
     //! Exponent to increase a step size
@@ -75,7 +76,6 @@ struct FieldDriverOptions
 	       && (delta_intersection > minimum_step)
 	       && (epsilon_step > 0 && epsilon_step < 1)
 	       && (epsilon_rel_max > 0)
-	       && (errcon > 0)
 	       && (pgrow < 0)
 	       && (pshrink < 0)
 	       && (safety > 0 && safety < 1)

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -33,13 +33,13 @@ struct FieldDriverOptions
     //! Accuracy of intersection of the boundary crossing
     real_type delta_intersection = 1.0e-4 * units::millimeter;
 
-    //! Relative error scale on the step length
+    //! Discretization error tolerance for each field substep
     real_type epsilon_step = 1.0e-5;
 
-    //! Maximum of the error ratio
+    //! Targeted discretization error for "integrate step"
     real_type epsilon_rel_max = 1.0e-3;
 
-    //! Truncation error tolerance
+    //! Targeted discretization error for "one good step"
     real_type errcon = 1.0e-4;
 
     //! Exponent to increase a step size
@@ -51,10 +51,10 @@ struct FieldDriverOptions
     //! Scale factor for the predicted step size
     real_type safety = 0.9;
 
-    //! Maximum scale to increase a step size
+    //! Largrest allowable relative increase a step size
     real_type max_stepping_increase = 5;
 
-    //! Maximum scale factor to decrease a step size
+    //! Smallest allowable relative decrease in step size
     real_type max_stepping_decrease = 0.1;
 
     //! Maximum number of steps (or trials)
@@ -65,6 +65,9 @@ struct FieldDriverOptions
 
     //! Chord distance fudge factor
     static constexpr inline real_type dchord_tol = 1e-5 * units::millimeter;
+
+    //! Lowest allowable scaling factor when searching for a chord
+    static constexpr inline real_type min_chord_shrink = 0.5;
 
     //! Whether all data are assigned and valid
     explicit CELER_FUNCTION operator bool() const

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -67,6 +67,9 @@ struct FieldDriverOptions
     //! Chord distance fudge factor
     static constexpr inline real_type dchord_tol = 1e-5 * units::millimeter;
 
+    //! Lowest allowable scaling factor when searching for a chord
+    static constexpr inline real_type min_chord_shrink = 0.5;
+
     //! Whether all data are assigned and valid
     explicit CELER_FUNCTION operator bool() const
     {

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -7,12 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <iostream>
-
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
-#include "corecel/cont/ArrayIO.hh"
-#include "corecel/io/ColorUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "orange/Types.hh"
@@ -21,8 +17,6 @@
 
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
-using std::cout;
-using std::endl;
 
 namespace celeritas
 {
@@ -166,15 +160,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
     result.boundary = geo_.is_on_boundary();
     result.distance = 0;
 
-    cout << color_code('b') << "Propagate up to " << step << color_code(' ')
-         << " from " << geo_.pos();
-    if (result.boundary)
-    {
-        cout << " (on boundary)";
-    }
-
-    cout << " along " << geo_.dir() << endl;
-
     // Break the curved steps into substeps as determined by the driver *and*
     // by the proximity of geometry boundaries. Test for intersection with the
     // geometry boundary in each substep. This loop is guaranteed to converge
@@ -189,9 +174,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         // Advance up to (but probably less than) the remaining step length
         DriverResult substep = driver_.advance(remaining, state_);
         CELER_ASSERT(substep.step > 0 && substep.step <= remaining);
-
-        cout << "- advance(" << remaining << ", " << state_.pos << ") -> {"
-             << substep.step << ", " << substep.state.pos << "}" << endl;
 
         // Check whether the chord for this sub-step intersects a boundary
         auto chord = detail::make_chord(state_.pos, substep.state.pos);
@@ -211,12 +193,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             //   boundary test does lose some accuracy)
             geo_.set_dir(chord.dir);
         }
-        else
-        {
-            cout << "- " << color_code('y')
-                 << "Skipping direction update: chord < "
-                 << driver_.minimum_step() << color_code(' ') << endl;
-        }
         auto linear_step
             = geo_.find_next_step(chord.length + driver_.delta_intersection());
 
@@ -226,14 +202,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         // intersection).
         real_type const update_length = substep.step * linear_step.distance
                                         / chord.length;
-
-        cout << " + chord " << chord.length << " cm along " << chord.dir
-             << " => linear step " << linear_step.distance;
-        if (linear_step.boundary)
-        {
-            cout << " (HIT!)";
-        }
-        cout << ": update length " << update_length << '\n';
 
         if (!linear_step.boundary)
         {
@@ -249,8 +217,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
             --remaining_substeps;
-            cout << " + advancing to substep end point (" << remaining_substeps
-                 << " remaining)" << endl;
         }
         else if (CELER_UNLIKELY(result.boundary
                                 && linear_step.distance < this->bump_distance()))
@@ -259,7 +225,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // surface (this can happen when tracking through a volume at a
             // near tangent). Reduce substep size and try again.
             remaining = substep.step / 2;
-            cout << " + halving substep distance" << endl;
         }
         else if (update_length <= driver_.minimum_step()
                  || detail::is_intercept_close(state_.pos,
@@ -284,29 +249,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             result.boundary = (linear_step.distance <= chord.length
                                || result.distance + update_length <= step);
 
-            if (update_length <= driver_.minimum_step())
-            {
-                cout << " + update length is less than minimum step "
-                     << driver_.minimum_step() << endl;
-            }
-            if (detail::is_intercept_close(state_.pos,
-                                           chord.dir,
-                                           linear_step.distance,
-                                           substep.state.pos,
-                                           driver_.delta_intersection()))
-            {
-                Real3 intercept = geo_.pos();
-                axpy(linear_step.distance, geo_.dir(), &intercept);
-                cout << " + intercept " << intercept << " is within "
-                     << driver_.delta_intersection() << " of substep endpoint"
-                     << endl;
-                if (result.distance + update_length > step)
-                {
-                    cout << " + but it's is past the end of the step by "
-                         << result.distance + update_length - step << endl;
-                }
-            }
-
             if (!result.boundary)
             {
                 // Don't move to the boundary, but instead move to the end of
@@ -314,13 +256,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
                 // as "!linear_step.boundary" above.
                 state_.pos = substep.state.pos;
                 geo_.move_internal(substep.state.pos);
-                cout << " + moved to " << state_.pos;
-                if (linear_step.boundary && !result.boundary)
-                {
-                    cout << color_code('y') << ": ignoring intercept!"
-                         << color_code(' ');
-                }
-                cout << endl;
             }
 
             // The update length can be slightly greater than the substep due
@@ -336,9 +271,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // Decrease the allowed substep (curved path distance) by the
             // fraction along the chord, and retry the driver step.
             remaining = update_length;
-            cout << " + Setting remaining distance to a fraction "
-                 << linear_step.distance / chord.length << " of the substep"
-                 << endl;
         }
     } while (remaining >= driver_.minimum_step() && remaining_substeps > 0);
 
@@ -347,9 +279,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         // Flag track as looping if the max number of substeps was reached
         // without hitting a boundary or moving the full step length
         result.looping = true;
-        cout << "- " << color_code('r')
-             << "Did not complete step: marked as looping" << color_code(' ')
-             << endl;
     }
     else if (result.distance > 0)
     {
@@ -360,8 +289,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // because of the tolerance in the intercept checks above).
             geo_.move_to_boundary();
             state_.pos = geo_.pos();
-            cout << "- Moved to boundary " << geo_.surface_id().unchecked_get()
-                 << " at position " << state_.pos << endl;
         }
         else if (CELER_UNLIKELY(result.distance < step))
         {
@@ -370,8 +297,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // error. Reset the distance so the track's action isn't
             // erroneously set as propagation-limited.
             CELER_ASSERT(soft_equal(result.distance, step));
-            cout << "- " << color_code('y') << "Updating distance by "
-                 << step - result.distance << color_code(' ') << endl;
             result.distance = step;
         }
     }
@@ -393,13 +318,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         result.boundary = false;
         axpy(result.distance, dir, &state_.pos);
         geo_.move_internal(state_.pos);
-        cout << "- " << color_code('y') << "Failed to move: bumped to "
-             << state_.pos << endl;
     }
-
-    cout << color_code('g') << "==> distance " << result.distance
-         << color_code(' ') << " (in "
-         << this->max_substeps() - remaining_substeps << " steps)" << endl;
 
     // Due to accumulation errors from multiple substeps or chord-finding
     // within the driver, the distance may be very slightly beyond the

--- a/src/celeritas/field/MagFieldEquation.hh
+++ b/src/celeritas/field/MagFieldEquation.hh
@@ -21,15 +21,27 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Evaluate the force applied by a magnetic field.
+ * Evaluate the right hand side of the Lorentz equation.
  *
  * The templated \c FieldT must be a function-like object with the signature
  * \code
  * Real3 (*)(const Real3&)
  * \endcode
  * which returns a magnetic field vector at a given position. The field
- * strength is in Celeritas native units, so multiply by \c units::tesla if
- * necessary.
+ * strength is in Celeritas native units, not Tesla.
+ *
+ * Calling an instance of this class calculates the local derivatives of
+ * position and momentum (i.e.  direction and force) based on the given
+ * magnetic field state.
+ *
+ * \f[
+    m \frac{d^2 \vec{x}}{d t^2} = (q/c)(\vec{v} \times  \vec{B})
+    s = |v|t
+    \vec{y} = d\vec{x}/ds
+    \frac{d\vec{x}}{ds} = \vec{v}/|v|
+    \frac{d\vec{y}}{ds} = (q/pc)(\vec{y} \times \vec{B})
+   \f]
+ *
  */
 template<class FieldT>
 class MagFieldEquation
@@ -52,7 +64,7 @@ class MagFieldEquation
     // Field evaluator
     Field_t calc_field_;
 
-    // The (Lorentz) coefficent in ElementaryCharge and MevMomentum
+    // The (Lorentz) coefficent in 1/OdeState::MomentumUnits
     real_type coeffi_;
 };
 
@@ -67,7 +79,10 @@ CELER_FUNCTION MagFieldEquation(FieldT&&, units::ElementaryCharge)
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Construct with a magnetic field equation.
+ * Construct with a magnetic field equation and particle charge.
+ *
+ * The internal coefficient is based on Celeritas native units and the
+ * "natural" unit system used by the \c ParticleTrackView.
  */
 template<class FieldT>
 CELER_FUNCTION
@@ -75,24 +90,13 @@ MagFieldEquation<FieldT>::MagFieldEquation(FieldT&& field,
                                            units::ElementaryCharge charge)
     : calc_field_(::celeritas::forward<FieldT>(field))
     , coeffi_{native_value_from(charge)
-              / native_value_from(units::MevMomentum{1})}
+              / native_value_from(OdeState::MomentumUnits{1})}
 {
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Evaluate the right hand side of the Lorentz equation.
- *
- * This calculates the force based on the given magnetic field state
- * (position and momentum).
- *
- * \f[
-    m \frac{d^2 \vec{x}}{d t^2} = (q/c)(\vec{v} \times  \vec{B})
-    s = |v|t
-    \vec{y} = d\vec{x}/ds
-    \frac{d\vec{x}}{ds} = \vec{v}/|v|
-    \frac{d\vec{y}}{ds} = (q/pc)(\vec{y} \times \vec{B})
-   \f]
  */
 template<class FieldT>
 CELER_FUNCTION auto

--- a/src/celeritas/field/detail/FieldUtils.hh
+++ b/src/celeritas/field/detail/FieldUtils.hh
@@ -97,31 +97,25 @@ inline CELER_FUNCTION bool is_intercept_close(Real3 const& pos,
 
 //---------------------------------------------------------------------------//
 /*!
- * Evaluate the stepper truncation error square:
- * \f$ \Delta = max (\delta_{pos}^{2}, \epsilon \delta_{mom}^{2}) \f$
+ * Evaluate the square of the relative stepper truncation error.
+ *
+ * \f$ \max(\delta_\textrm{pos}^{2}, \epsilon \delta_\textrm{mom}^{2}) \f$
  */
-inline CELER_FUNCTION real_type truncation_error(real_type step,
-                                                 real_type eps_rel_max,
-                                                 OdeState const& beg_state,
-                                                 OdeState const& err_state)
+inline CELER_FUNCTION real_type rel_err_sq(OdeState const& err_state,
+                                           real_type step,
+                                           Real3 const& mom)
 {
     CELER_EXPECT(step > 0);
-    CELER_EXPECT(eps_rel_max > 0);
 
-    // Evaluate tolerance and squre of the position and momentum accuracy
-
-    real_type magvel2 = dot_product(beg_state.mom, beg_state.mom);
+    // Evaluate square of the position and momentum accuracy
     real_type errpos2 = dot_product(err_state.pos, err_state.pos);
     real_type errvel2 = dot_product(err_state.mom, err_state.mom);
 
-    // Scale relative to a required tolerance
-    CELER_ASSERT(errpos2 >= 0);
-    CELER_ASSERT(magvel2 > 0);
+    // Scale position error relative to step
+    errpos2 /= ipow<2>(step);
+    // Scale momentum error relative to starting momentum
+    errvel2 /= dot_product(mom, mom);
 
-    errpos2 /= ipow<2>(eps_rel_max * step);
-    errvel2 /= (magvel2 * ipow<2>(eps_rel_max));
-
-    // Return the square of the maximum truncation error
     real_type result = max(errpos2, errvel2);
     CELER_ENSURE(result >= 0);
     return result;

--- a/src/celeritas/field/detail/FieldUtils.hh
+++ b/src/celeritas/field/detail/FieldUtils.hh
@@ -100,6 +100,9 @@ inline CELER_FUNCTION bool is_intercept_close(Real3 const& pos,
  * Evaluate the square of the relative stepper truncation error.
  *
  * \f$ \max(\delta_\textrm{pos}^{2}, \epsilon \delta_\textrm{mom}^{2}) \f$
+ *
+ * The return value is the square of \c dyerr in
+ * \c G4MagIntegratorDriver::AccurateAdvance .
  */
 inline CELER_FUNCTION real_type rel_err_sq(OdeState const& err_state,
                                            real_type step,

--- a/test/celeritas/field/DiagnosticStepper.hh
+++ b/test/celeritas/field/DiagnosticStepper.hh
@@ -62,9 +62,6 @@ class DiagnosticStepper
 template<class StepperT>
 CELER_FUNCTION DiagnosticStepper(StepperT&&)->DiagnosticStepper<StepperT>;
 
-template<class StepperT>
-CELER_FUNCTION DiagnosticStepper(StepperT&)->DiagnosticStepper<StepperT&>;
-
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -223,9 +223,9 @@ TEST_F(FieldDriverTest, horrible_field)
     EXPECT_EQ(23, stepper.count());
     EXPECT_SOFT_EQ(0.2, accum);
     EXPECT_SOFT_NEAR(0,
-                     distance(Real3({0.49050256502367656,
-                                     0.14023921152905028,
-                                     0.046573401548558623}),
+                     distance(Real3({0.49051449384873164,
+                                     0.14023728367864752,
+                                     0.046574329126744189}),
                               state.pos),
                      1e-5)
         << state.pos;

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -174,8 +174,8 @@ TEST_F(FieldDriverTest, step_counts)
     static double const expected_radii[] = {0.00010663611598835,
         0.0010663663247419, 0.010668826843187, 0.11173141982667,
         3.5019461121752, 333.73450257138, 33356.579970281};
-    static unsigned int const expected_counts[] = {4u, 92u, 777u, 786u, 1u,
-        12u, 88u, 96u, 1u, 4u, 28u, 35u, 1u, 1u, 7u, 15u, 1u, 1u, 2u, 9u, 1u,
+    static unsigned int const expected_counts[] = {3u, 92u, 779u, 786u, 1u,
+        11u, 90u, 96u, 1u, 3u, 29u, 35u, 1u, 1u, 7u, 15u, 1u, 1u, 2u, 9u, 1u,
         1u, 1u, 5u, 1u, 1u, 1u, 2u};
     static double const expected_lengths[] = {0.0001, 0.01, 0.077563521220272,
         0.077562922424298, 0.0001, 0.01, 0.076209386999884, 0.076210431034511,

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -213,7 +213,7 @@ TEST_F(RevolutionFieldDriverTest, advance)
     real_type total_step_length{0};
 
     // Try the stepper by hstep for (num_revolutions * num_steps) times
-    real_type delta = driver_options.errcon;
+    real_type eps = 1.0e-4;
     for (int nr = 0; nr < test_params.revolutions; ++nr)
     {
         y_expected.pos
@@ -228,12 +228,12 @@ TEST_F(RevolutionFieldDriverTest, advance)
         }
 
         // Check the total error and the state (position, momentum)
-        EXPECT_VEC_NEAR(y_expected.pos, y.pos, delta);
+        EXPECT_VEC_NEAR(y_expected.pos, y.pos, eps);
     }
 
     // Check the total error, step/curve length
     EXPECT_SOFT_NEAR(
-        total_step_length, circumference * test_params.revolutions, delta);
+        total_step_length, circumference * test_params.revolutions, eps);
 }
 
 TEST_F(RevolutionFieldDriverTest, accurate_advance)
@@ -256,7 +256,7 @@ TEST_F(RevolutionFieldDriverTest, accurate_advance)
 
     // Try the stepper by hstep for (num_revolutions * num_steps) times
     real_type total_curved_length{0};
-    real_type delta = driver_options.errcon;
+    real_type eps = 1.0e-4;
 
     for (int nr = 0; nr < test_params.revolutions; ++nr)
     {
@@ -272,12 +272,12 @@ TEST_F(RevolutionFieldDriverTest, accurate_advance)
             y_accurate = end.state;
         }
         // Check the total error and the state (position, momentum)
-        EXPECT_VEC_NEAR(y_expected.pos, y.pos, delta);
+        EXPECT_VEC_NEAR(y_expected.pos, y.pos, eps);
     }
 
     // Check the total error, step/curve length
     EXPECT_LT(total_curved_length - circumference * test_params.revolutions,
-              delta);
+              eps);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -273,7 +273,7 @@ TEST_F(FieldDriverTest, step_counts)
     static double const expected_radii[] = {0.00010663611598835,
         0.0010663663247419, 0.010668826843187, 0.11173141982667,
         3.5019461121752, 333.73450257138, 33356.579970281};
-    static unsigned int const expected_counts[] = {4u, 93u, 776u, 786u, 1u,
+    static unsigned int const expected_counts[] = {5u, 93u, 776u, 786u, 1u,
         13u, 88u, 96u, 1u, 5u, 28u, 35u, 1u, 1u, 7u, 15u, 1u, 1u, 2u, 9u, 1u,
         1u, 1u, 5u, 1u, 1u, 1u, 2u};
     static double const expected_lengths[] = {0.0001, 0.01, 0.077563521220272,

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -186,8 +186,8 @@ TEST_F(FieldDriverTest, unpleasant_field)
         distance += result.step;
         state = result.state;
     }
-    EXPECT_EQ(33, stepper.count());
-    EXPECT_SOFT_EQ(7.2169115414296314, distance);
+    EXPECT_EQ(31, stepper.count());
+    EXPECT_SOFT_EQ(7.2232269169635632, distance);
 }
 
 // As the track moves along +z near 0, the field strength oscillates horribly,
@@ -220,12 +220,12 @@ TEST_F(FieldDriverTest, horrible_field)
         accum += result.step;
         state = result.state;
     }
-    EXPECT_EQ(23, stepper.count());
+    EXPECT_EQ(9, stepper.count());
     EXPECT_SOFT_EQ(0.2, accum);
     EXPECT_SOFT_NEAR(0,
-                     distance(Real3({0.49051449384873164,
-                                     0.14023728367864752,
-                                     0.046574329126744189}),
+                     distance(Real3({0.49120878051539413,
+                                     0.14017717257531165,
+                                     0.04668993728754612}),
                               state.pos),
                      1e-5)
         << state.pos;
@@ -273,8 +273,8 @@ TEST_F(FieldDriverTest, step_counts)
     static double const expected_radii[] = {0.00010663611598835,
         0.0010663663247419, 0.010668826843187, 0.11173141982667,
         3.5019461121752, 333.73450257138, 33356.579970281};
-    static unsigned int const expected_counts[] = {5u, 93u, 776u, 786u, 1u,
-        13u, 88u, 96u, 1u, 5u, 28u, 35u, 1u, 1u, 7u, 15u, 1u, 1u, 2u, 9u, 1u,
+    static unsigned int const expected_counts[] = {1u, 93u, 779u, 786u, 1u,
+        12u, 90u, 96u, 1u, 1u, 29u, 35u, 1u, 1u, 7u, 15u, 1u, 1u, 2u, 9u, 1u,
         1u, 1u, 5u, 1u, 1u, 1u, 2u};
     static double const expected_lengths[] = {0.0001, 0.01, 0.077563521220272,
         0.077562922424298, 0.0001, 0.01, 0.076209386999884, 0.076210431034511,

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -9,6 +9,7 @@
 #include "celeritas/field/FieldDriver.hh"
 
 #include "corecel/Types.hh"
+#include "corecel/cont/ArrayIO.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/math/Algorithms.hh"
 #include "celeritas/Constants.hh"
@@ -112,6 +113,30 @@ make_mag_field_driver(FieldT&& field,
                         ::celeritas::forward<FieldT>(field), charge)};
 }
 
+//! Z oriented field of 2**(y / scale)
+struct ExpZField
+{
+    real_type strength{1 * units::tesla};
+    real_type scale{1};
+
+    Real3 operator()(Real3 const& pos) const
+    {
+        return {0, 0, this->strength * std::exp2(pos[1] / scale)};
+    }
+};
+
+//! sin(1/z), scaled and with multiplicative constant
+struct HorribleZField
+{
+    real_type strength{1};
+    real_type scale{1};
+
+    Real3 operator()(Real3 const& pos) const
+    {
+        return {0, 0, this->strength * std::sin(this->scale / pos[2])};
+    }
+};
+
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
@@ -132,6 +157,80 @@ TEST_F(FieldDriverTest, types)
               sizeof(driver));
 }
 
+// Field strength changes quickly with z, so different chord steps require
+// different substeps
+TEST_F(FieldDriverTest, unpleasant_field)
+{
+    constexpr auto cm = units::centimeter;
+
+    FieldDriverOptions driver_options;
+    driver_options.max_nsteps = 32;
+
+    real_type field_strength = 1.0 * units::tesla;
+    MevEnergy e{1.0};
+    real_type radius = this->calc_curvature(e, field_strength);
+
+    // Vary by a factor of 1024 over the radius of curvature
+    auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
+        ExpZField{field_strength, radius / 10}, units::ElementaryCharge{-1});
+    FieldDriver<decltype(stepper)&> driver{driver_options, stepper};
+
+    OdeState state;
+    state.pos = {radius, 0, 0};
+    state.mom = this->calc_momentum(e, {0, sqrt_two / 2, sqrt_two / 2});
+
+    real_type distance{0};
+    for (auto i : range(1, 6))
+    {
+        auto result = driver.advance(i * cm, state);
+        distance += result.step;
+        state = result.state;
+    }
+    EXPECT_EQ(33, stepper.count());
+    EXPECT_SOFT_EQ(7.2169115414296314, distance);
+}
+
+// As the track moves along +z near 0, the field strength oscillates horribly,
+// so the "one good step" convergence requires more than one iteration (which
+// doesn't happen for any of the other more well-behaved fields).
+TEST_F(FieldDriverTest, horrible_field)
+{
+    constexpr auto cm = units::centimeter;
+
+    FieldDriverOptions driver_options;
+    driver_options.max_nsteps = 32;
+
+    real_type field_strength = 1.0 * units::tesla;
+    MevEnergy e{1.0};
+    real_type radius = this->calc_curvature(e, field_strength);
+
+    auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
+        HorribleZField{field_strength, radius / 10},
+        units::ElementaryCharge{-1});
+    FieldDriver<decltype(stepper)&> driver{driver_options, stepper};
+
+    OdeState state;
+    state.pos = {radius, 0, -radius / 5};
+    state.mom = this->calc_momentum(e, {0, sqrt_two / 2, sqrt_two / 2});
+
+    real_type accum{0};
+    for (int i = 1; i < 5; ++i)
+    {
+        auto result = driver.advance(0.05 * cm, state);
+        accum += result.step;
+        state = result.state;
+    }
+    EXPECT_EQ(23, stepper.count());
+    EXPECT_SOFT_EQ(0.2, accum);
+    EXPECT_SOFT_NEAR(0,
+                     distance(Real3({0.49051398594014156,
+                                     0.1402373650199745,
+                                     0.046574287893661338}),
+                              state.pos),
+                     1e-5)
+        << state.pos;
+}
+
 TEST_F(FieldDriverTest, step_counts)
 {
     FieldDriverOptions driver_options;
@@ -142,43 +241,47 @@ TEST_F(FieldDriverTest, step_counts)
         UniformField({0, 0, field_strength}), units::ElementaryCharge{-1});
     FieldDriver<decltype(stepper)&> driver{driver_options, stepper};
 
-    std::vector<real_type> energy;
     std::vector<real_type> radii;
     std::vector<unsigned int> counts;
     std::vector<real_type> lengths;
 
     // Test the number of field equation evaluations that have to be done to
-    // travel a step length of 10 cm, for electrons from 0.1 eV to 10 TeV.
-    for (int loge : range(-7, 7).step(1))
+    // travel a step length of 1e-4 cm and 10 cm, for electrons from 0.1 eV to
+    // 10 TeV.
+    for (int loge : range(-7, 7).step(2))
     {
-        MevEnergy e{std::pow(10, loge)};
+        MevEnergy e{std::pow(10.0, loge)};
         real_type radius = this->calc_curvature(e, field_strength);
+        radii.push_back(radius);
 
         OdeState state;
         state.pos = {radius, 0, 0};
         state.mom = this->calc_momentum(e, {0, sqrt_two / 2, sqrt_two / 2});
 
-        stepper.reset_count();
-        auto end = driver.advance(10 * units::centimeter, state);
+        for (int log_len : range(-4, 3).step(2))
+        {
+            real_type step_len = std::pow(10.0, log_len);
+            stepper.reset_count();
+            auto end = driver.advance(step_len * units::centimeter, state);
 
-        energy.push_back(e.value());
-        radii.push_back(radius);
-        counts.push_back(stepper.count());
-        lengths.push_back(end.step);
+            counts.push_back(stepper.count());
+            lengths.push_back(end.step);
+        }
     }
 
     // clang-format off
     static double const expected_radii[] = {0.00010663611598835,
-        0.00033721315583664, 0.0010663663247419, 0.0033722948818996,
-        0.010668826843187, 0.033885874824232, 0.11173141982667,
-        0.47431804394274, 3.5019461121752, 33.526427131057, 333.73450257138,
-        3335.8113985278, 33356.579970281, 333564.26564901};
-    static unsigned int const expected_counts[] = {782u, 247u, 92u, 45u, 31u,
-        13u, 10u, 8u, 6u, 4u, 2u, 1u, 1u, 1u};
-    static double const expected_lengths[] = {0.077562380895466,
-        0.077251971561029, 0.076209747456898, 0.072434474486632,
-        0.063064404446822, 0.085308004478855, 0.15625, 0.36823861947329,
-        0.99606722344324, 3.0796706094122, 9.7157674620814, 10, 10, 10};
+        0.0010663663247419, 0.010668826843187, 0.11173141982667,
+        3.5019461121752, 333.73450257138, 33356.579970281};
+    static unsigned int const expected_counts[] = {4u, 93u, 776u, 786u, 1u,
+        13u, 88u, 96u, 1u, 5u, 28u, 35u, 1u, 1u, 7u, 15u, 1u, 1u, 2u, 9u, 1u,
+        1u, 1u, 5u, 1u, 1u, 1u, 2u};
+    static double const expected_lengths[] = {0.0001, 0.01, 0.077563521220272,
+        0.077562922424298, 0.0001, 0.01, 0.076209386999884, 0.076210431034511,
+        0.0001, 0.01, 0.063064075311856, 0.063064905456757, 0.0001, 0.01,
+        0.17398853544975, 0.1788332443937, 0.0001, 0.01, 0.99607291767799,
+        0.99606836440819, 0.0001, 0.01, 1, 9.7158185571513, 0.0001, 0.01, 1,
+        97.132215683182};
     // clang-format on
 
     EXPECT_VEC_SOFT_EQ(expected_radii, radii);
@@ -209,7 +312,7 @@ TEST_F(RevolutionFieldDriverTest, advance)
     real_type total_step_length{0};
 
     // Try the stepper by hstep for (num_revolutions * num_steps) times
-    real_type delta = driver_options.errcon;
+    real_type eps = 1.0e-4;
     for (int nr = 0; nr < test_params.revolutions; ++nr)
     {
         y_expected.pos
@@ -224,12 +327,12 @@ TEST_F(RevolutionFieldDriverTest, advance)
         }
 
         // Check the total error and the state (position, momentum)
-        EXPECT_VEC_NEAR(y_expected.pos, y.pos, delta);
+        EXPECT_VEC_NEAR(y_expected.pos, y.pos, eps);
     }
 
     // Check the total error, step/curve length
     EXPECT_SOFT_NEAR(
-        total_step_length, circumference * test_params.revolutions, delta);
+        total_step_length, circumference * test_params.revolutions, eps);
 }
 
 TEST_F(RevolutionFieldDriverTest, accurate_advance)
@@ -252,7 +355,7 @@ TEST_F(RevolutionFieldDriverTest, accurate_advance)
 
     // Try the stepper by hstep for (num_revolutions * num_steps) times
     real_type total_curved_length{0};
-    real_type delta = driver_options.errcon;
+    real_type eps = 1.0e-4;
 
     for (int nr = 0; nr < test_params.revolutions; ++nr)
     {
@@ -268,12 +371,12 @@ TEST_F(RevolutionFieldDriverTest, accurate_advance)
             y_accurate = end.state;
         }
         // Check the total error and the state (position, momentum)
-        EXPECT_VEC_NEAR(y_expected.pos, y.pos, delta);
+        EXPECT_VEC_NEAR(y_expected.pos, y.pos, eps);
     }
 
     // Check the total error, step/curve length
     EXPECT_LT(total_curved_length - circumference * test_params.revolutions,
-              delta);
+              eps);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -223,11 +223,11 @@ TEST_F(FieldDriverTest, horrible_field)
     EXPECT_EQ(19, stepper.count());
     EXPECT_SOFT_EQ(0.2, accum);
     EXPECT_SOFT_NEAR(0,
-                     distance(Real3({0.48839126874570266,
-                                     0.14055631310339731,
-                                     0.046552225487429072}),
+                     distance(Real3({0.48839333214883401,
+                                     0.14055602543975546,
+                                     0.046552192651615608}),
                               state.pos),
-                     1e-10)
+                     1e-5)
         << state.pos;
 }
 

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -170,16 +170,12 @@ TEST_F(FieldDriverTest, step_counts)
         }
     }
 
-    PRINT_EXPECTED(radii);
-    PRINT_EXPECTED(counts);
-    PRINT_EXPECTED(lengths);
-
     // clang-format off
     static double const expected_radii[] = {0.00010663611598835,
         0.0010663663247419, 0.010668826843187, 0.11173141982667,
         3.5019461121752, 333.73450257138, 33356.579970281};
-    static unsigned int const expected_counts[] = {4u, 93u, 776u, 786u, 1u,
-        13u, 88u, 96u, 1u, 5u, 28u, 35u, 1u, 1u, 7u, 15u, 1u, 1u, 2u, 9u, 1u,
+    static unsigned int const expected_counts[] = {4u, 92u, 777u, 786u, 1u,
+        12u, 88u, 96u, 1u, 4u, 28u, 35u, 1u, 1u, 7u, 15u, 1u, 1u, 2u, 9u, 1u,
         1u, 1u, 5u, 1u, 1u, 1u, 2u};
     static double const expected_lengths[] = {0.0001, 0.01, 0.077563521220272,
         0.077562922424298, 0.0001, 0.01, 0.076209386999884, 0.076210431034511,

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -871,7 +871,7 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
          */
         auto result = propagate(0.1 * dr, 0);
         EXPECT_FALSE(result.boundary);
-        EXPECT_EQ(3, stepper.count());
+        EXPECT_EQ(1, stepper.count());
         EXPECT_SOFT_EQ(0.44815869703173999, result.distance);
         EXPECT_LE(result.distance, first_step);
         EXPECT_LT(-5.0, geo.pos()[0]);
@@ -895,11 +895,11 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
          ==> distance 0.448159 (in 0 steps)
          */
         auto result = propagate(1e-6 * dr, 0);
-        EXPECT_TRUE(result.boundary);  // WRONG? false
-        EXPECT_EQ(3, stepper.count());
-        EXPECT_SOFT_EQ(0.44815810742726675, result.distance);
+        EXPECT_FALSE(result.boundary);
+        EXPECT_EQ(1, stepper.count());
+        EXPECT_SOFT_EQ(0.44815869703173999, result.distance);
         EXPECT_LE(result.distance, first_step);
-        EXPECT_LE(-5.0, geo.pos()[0]);  // WRONG? LT
+        EXPECT_LT(-5.0, geo.pos()[0]);
         EXPECT_LT(
             distance(Real3{-4.9999998999999997, 3.0685999199146494e-15, 0},
                      geo.pos()),
@@ -921,8 +921,8 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
 
         auto result = propagate(-0.1 * dr, 0);
         EXPECT_TRUE(result.boundary);
-        EXPECT_EQ(3, stepper.count());
-        EXPECT_SOFT_EQ(0.40277610833495897, result.distance);
+        EXPECT_EQ(1, stepper.count());
+        EXPECT_SOFT_EQ(0.40277704609562048, result.distance);
         EXPECT_LE(result.distance, first_step);
         EXPECT_LT(distance(Real3{-5, -0.04387770235662955, 0}, geo.pos()), 1e-6)
             << geo.pos();
@@ -940,8 +940,8 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
          */
         auto result = propagate(-1e-6 * dr, 0);
         EXPECT_TRUE(result.boundary);
-        EXPECT_EQ(3, stepper.count());
-        EXPECT_SOFT_EQ(0.44815719979635865, result.distance);
+        EXPECT_EQ(1, stepper.count());
+        EXPECT_SOFT_EQ(0.44815824321522935, result.distance);
         EXPECT_LE(result.distance, first_step);
         EXPECT_LT(distance(Real3{-5, -4.3877702173875065e-07, 0}, geo.pos()),
                   1e-6)
@@ -1009,18 +1009,19 @@ TEST_F(TwoBoxTest, electron_tangent_cross_smallradius)
 
     static int const expected_boundary[] = {1, 1, 1, 1, 1, 0, 1, 0, 1, 0};
     EXPECT_VEC_EQ(expected_boundary, boundary);
-    static double const expected_distances[] = {0.00785398163,
-                                                0.00282334506,
-                                                0.00448798951,
-                                                0.00282597038,
+    static double const expected_distances[] = {0.0078534718906499,
+                                                0.0028235332722979,
+                                                0.0044879852658442,
+                                                0.0028259738005751,
                                                 1e-05,
                                                 1e-05,
+                                                9.9999658622419e-09,
                                                 1e-08,
-                                                1e-08,
-                                                9.99379755e-12,
+                                                9.9981633254417e-12,
                                                 1e-11};
     EXPECT_VEC_NEAR(expected_distances, distances, 1e-5);
-    static int const expected_substeps[] = {4, 63, 3, 14, 1, 1, 1, 1, 1, 1};
+
+    static int const expected_substeps[] = {1, 25, 1, 12, 1, 1, 1, 1, 1, 1};
 
     EXPECT_VEC_EQ(expected_substeps, substeps);
     static char const* expected_volumes[] = {"world",
@@ -1062,18 +1063,18 @@ TEST_F(TwoBoxTest, nonuniform_field)
 
     // clang-format off
     static double const expected_all_pos[] = {
-        -2.082588410019, 0.698321021704, 0.70710499699532,
-        -2.5772834156698, 1.1563858825744, 1.4142082224578,
-        -3.0638597711046, 0.77477404071578, 2.1213130872795,
-        -2.5584330807733, 0.58519791464035, 2.8284269544963,
-        -2.9044449938663, 0.86374380213917, 3.5355750324309,
-        -2.580544641158, 0.76589682238491, 4.2428026858314,
-        -2.7422321216414, 0.60282499262184, 4.9501039569049,
-        -2.6938835431219, 0.61388130598869, 5};
+        -2.0825709359803, 0.69832583461676, 0.70710666844698,
+        -2.5772824508968, 1.1564020888258, 1.4141930958099,
+        -3.0638510057122, 0.77473521479087, 2.1212684403177,
+        -2.5583491669886, 0.58538464818192, 2.8283305521706,
+        -2.9046903231357, 0.86312856101992, 3.5354509992431,
+        -2.5810335650695, 0.76746368848985, 4.242728100241,
+        -2.7387773891353, 0.6033529790486, 4.9501400379322,
+        -2.6908755627764, 0.61552642042372, 5};
     // clang-format on
     EXPECT_VEC_SOFT_EQ(expected_all_pos, all_pos);
 
-    static int const expected_step_counter[] = {5, 7, 12, 13, 19, 22, 26, 10};
+    static int const expected_step_counter[] = {3, 3, 6, 6, 9, 11, 15, 9};
     EXPECT_VEC_EQ(expected_step_counter, step_counter);
 }
 
@@ -1205,8 +1206,8 @@ TEST_F(SimpleCmsTest, electron_stuck)
             = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(1000);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
-        EXPECT_LE(92, stepper.count());
-        EXPECT_LE(stepper.count(), 93);
+        EXPECT_LE(79, stepper.count());
+        EXPECT_LE(stepper.count(), 80);
         ASSERT_TRUE(geo.is_on_boundary());
         if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
         {
@@ -1307,8 +1308,8 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         {
             // Repeated substep bisection failed; particle is bumped
             EXPECT_SOFT_EQ(1e-6, result.distance);
-            // Minor floating point differences among geometries
-            EXPECT_SOFT_NEAR(real_type(103), real_type(stepper.count()), 0.03);
+            // Minor floating point differences could make this 98 or so
+            EXPECT_SOFT_NEAR(real_type(99), real_type(stepper.count()), 0.03);
             EXPECT_FALSE(result.looping);
         }
     }

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -572,7 +572,7 @@ TEST_F(TwoBoxTest, electron_tangent)
         EXPECT_LT(
             distance(Real3({std::cos(0.49 * pi), 4 + std::sin(0.49 * pi), 0}),
                      geo.pos()),
-            1e-6);
+            2e-6);
     }
     {
         SCOPED_TRACE("Short step tangent to boundary");
@@ -587,7 +587,7 @@ TEST_F(TwoBoxTest, electron_tangent)
         EXPECT_LT(
             distance(Real3({std::cos(0.51 * pi), 4 + std::sin(0.51 * pi), 0}),
                      geo.pos()),
-            1e-6);
+            2e-6);
     }
 }
 
@@ -712,7 +712,7 @@ TEST_F(TwoBoxTest, electron_tangent_cross)
 
         EXPECT_SOFT_EQ(circ, result.distance);
         EXPECT_FALSE(result.boundary);
-        EXPECT_LT(distance(Real3({1, 4 + dy, 0}), geo.pos()), 1e-5);
+        EXPECT_LT(distance(Real3({1, 4 + dy, 0}), geo.pos()), 2e-5);
         EXPECT_LT(distance(Real3({0, 1, 0}), geo.dir()), 1e-5);
     }
 }
@@ -812,6 +812,7 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
     auto particle = this->make_particle_view(pdg::electron(), MevEnergy{10});
     UniformZField field(unit_radius_field_strength);
     FieldDriverOptions driver_options;
+    const real_type dr = 0.1;
     driver_options.delta_intersection = 0.1;
 
     // First step length and position from starting at {0,0,0} along {0,1,0}
@@ -819,93 +820,132 @@ TEST_F(TwoBoxTest, electron_step_endpoint)
     static constexpr Real3 first_pos
         = {-0.098753281951459, 0.43330671122068, 0};
 
-    {
-        SCOPED_TRACE("First step ends barely closer than boundary");
-        /*
-         * Note: this ends up being the !linear_step.boundary case:
-          Propagate up to 0.448159
-          - advance(0.348159, {-4.89125,-0.433307,0})
-                -> {0.348159, {-4.95124,-0.0921392,0}}
-           + chord length 0.346403 => linear step 0.446403
-           + advancing to substep end point
-        */
-
-        real_type dx = 0.1 * driver_options.delta_intersection;
-        Real3 start_pos{-5 + dx, 0, 0};
+    auto geo = this->make_geo_track_view();
+    auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
+        field, particle.charge());
+    auto propagate = [&](real_type start_delta, real_type move_delta) {
+        Real3 start_pos{-5 + start_delta, 0, 0};
         axpy(real_type(-1), first_pos, &start_pos);
 
-        auto geo = this->make_geo_track_view(start_pos, {0, 1, 0});
-        auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
-            field, particle.charge());
+        geo = GeoTrackInitializer{start_pos, {0, 1, 0}};
+        stepper.reset_count();
         auto propagate
             = make_field_propagator(stepper, driver_options, particle, geo);
-        auto result = propagate(first_step - driver_options.delta_intersection);
+        return propagate(first_step - move_delta);
+    };
 
+    {
+        SCOPED_TRACE("First step misses boundary");
+        /*
+         * Note: this ends up being the !linear_step.boundary case:
+         Propagate up to 0.348159 from {-4.89125,-0.433307,0} along {0,1,0}
+         - advance(0.348159, {-4.89125,-0.433307,0})
+           -> {0.348159, {-4.95124,-0.0921392,0}}
+          + chord 0.346403 cm along {-0.173201,0.984886,0}
+            => linear step 0.446403: update length 0.448666
+          + advancing to substep end point (99 remaining)
+         ==> distance 0.348159 (in 1 steps)
+         */
+
+        auto result = propagate(0.1 * dr, dr);
         EXPECT_FALSE(result.boundary);
         EXPECT_EQ(1, stepper.count());
-        EXPECT_SOFT_EQ(first_step - driver_options.delta_intersection,
-                       result.distance);
+        EXPECT_SOFT_EQ(first_step - dr, result.distance);
         EXPECT_LT(distance(Real3{-4.9512441890768795, -0.092139178167222446, 0},
                            geo.pos()),
                   1e-8)
             << geo.pos();
     }
     {
-        SCOPED_TRACE("First step ends barely closer than boundary");
+        SCOPED_TRACE("First step ends barely before boundary");
         /*
-         Propagate up to 0.448159
+         Propagate up to 0.448159 from {-4.89125,-0.433307,0} along {0,1,0}
          - advance(0.448159, {-4.89125,-0.433307,0})
-           -> {0.448159, {-4.99,8.24444e-08,0}}
-          + chord length 0.444418 => linear step 0.489419 (hit surface 6):
-           update length 0.493539
-          + next trial step exceeds driver minimum 1e-06 *OR* intercept is
-           sufficiently close (miss distance = 0.0450017) to substep point
-         - Moved remaining distance 0 without physically changing position
+           -> {0.448159, {-4.99,3.0686e-15,0}}
+          + chord 0.444418 cm along {-0.222208,0.974999,0}
+            => linear step 0.48942 (HIT!): update length 0.49354
+          + intercept {-5,0.0438777,0} is within 0.1 of substep endpoint
+          + but it's is past the end of the step by 0.0453817
+          + moved to {-4.99,3.0686e-15,0}: ignoring intercept!
          ==> distance 0.448159 (in 0 steps)
          */
-
-        real_type dx = 0.1 * driver_options.delta_intersection;
-        Real3 start_pos{-5 + dx, 0, 0};
-        axpy(real_type(-1), first_pos, &start_pos);
-
-        auto geo = this->make_geo_track_view(start_pos, {0, 1, 0});
-        auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
-            field, particle.charge());
-        auto propagate
-            = make_field_propagator(stepper, driver_options, particle, geo);
-        auto result = propagate(first_step);
-
+        auto result = propagate(0.1 * dr, 0);
         EXPECT_FALSE(result.boundary);
         EXPECT_EQ(3, stepper.count());
         EXPECT_SOFT_EQ(0.44815869703173999, result.distance);
         EXPECT_LE(result.distance, first_step);
+        EXPECT_LT(-5.0, geo.pos()[0]);
         EXPECT_LT(
             distance(Real3{-4.9900002299216384, 8.2444433238682002e-08, 0},
                      geo.pos()),
-            1e-8)
+            1e-6)
             << geo.pos();
     }
     {
-        SCOPED_TRACE("First step ends on boundary");
+        SCOPED_TRACE("First step ends BARELY before boundary");
+        /*
+         Propagate up to 0.448159 from {-4.90125,-0.433307,0} along {0,1,0}
+         - advance(0.448159, {-4.90125,-0.433307,0})
+           -> {0.448159, {-5,3.0686e-15,0}}
+          + chord 0.444418 cm along {-0.222208,0.974999,0}
+            => linear step 0.444418 (HIT!): update length 0.448159
+          + intercept {-5,4.38777e-07,0} is within 0.1 of substep endpoint
+          + but it's is past the end of the step by 4.53817e-07
+          + moved to {-5,3.0686e-15,0}: ignoring intercept!
+         ==> distance 0.448159 (in 0 steps)
+         */
+        auto result = propagate(1e-6 * dr, 0);
+        EXPECT_TRUE(result.boundary);  // WRONG? false
+        EXPECT_EQ(3, stepper.count());
+        EXPECT_SOFT_EQ(0.44815810742726675, result.distance);
+        EXPECT_LE(result.distance, first_step);
+        EXPECT_LE(-5.0, geo.pos()[0]);  // WRONG? LT
+        EXPECT_LT(
+            distance(Real3{-4.9999998999999997, 3.0685999199146494e-15, 0},
+                     geo.pos()),
+            1e-6)
+            << geo.pos();
+    }
+    {
+        SCOPED_TRACE("First step ends barely past boundary");
+        /*
+         Propagate up to 0.448159 from {-4.91125,-0.433307,0} along {0,1,0}
+         - advance(0.448159, {-4.91125,-0.433307,0})
+           -> {0.448159, {-5.01,3.0686e-15,0}}
+          + chord 0.444418 cm along {-0.222208,0.974999,0}
+            => linear step 0.399415 (HIT!): update length 0.402777
+          + intercept {-5,-0.0438777,0} is within 0.1 of substep endpoint
+         - Moved to boundary 6 at position {-5,-0.0438777,0}
+         ==> distance 0.402777 (in 0 steps)
+        */
 
-        real_type dx = 0;
-        Real3 start_pos{-5 - dx, 0, 0};
-        axpy(real_type(-1), first_pos, &start_pos);
-
-        auto geo = this->make_geo_track_view(start_pos, {0, 1, 0});
-        auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
-            field, particle.charge());
-        auto propagate
-            = make_field_propagator(stepper, driver_options, particle, geo);
-        auto result = propagate(first_step);
-
+        auto result = propagate(-0.1 * dr, 0);
         EXPECT_TRUE(result.boundary);
         EXPECT_EQ(3, stepper.count());
-        EXPECT_SOFT_NEAR(result.distance, first_step, 1e-5);
-        EXPECT_LT(result.distance, first_step);
-        // Y position suffers from roundoff
-        EXPECT_LT(distance(Real3{-5.0, -9.26396730438483e-07, 0}, geo.pos()),
-                  1e-8);
+        EXPECT_SOFT_EQ(0.40277610833495897, result.distance);
+        EXPECT_LE(result.distance, first_step);
+        EXPECT_LT(distance(Real3{-5, -0.04387770235662955, 0}, geo.pos()), 1e-6)
+            << geo.pos();
+    }
+    {
+        SCOPED_TRACE("First step ends BARELY past boundary");
+        /*
+         Propagate up to 0.448159 from {-4.90125,-0.433307,0} along {0,1,0}
+         - advance(0.448159, {-4.90125,-0.433307,0})
+           -> {0.448159, {-5,3.0686e-15,0}}
+          + chord 0.444418 cm along {-0.222208,0.974999,0}
+            => linear step 0.444417 (HIT!): update length 0.448158
+          + intercept {-5,-4.38777e-07,0} is within 0.1 of substep endpoint
+         - Moved to boundary 6 at position {-5,-4.38777e-07,0}
+         */
+        auto result = propagate(-1e-6 * dr, 0);
+        EXPECT_TRUE(result.boundary);
+        EXPECT_EQ(3, stepper.count());
+        EXPECT_SOFT_EQ(0.44815719979635865, result.distance);
+        EXPECT_LE(result.distance, first_step);
+        EXPECT_LT(distance(Real3{-5, -4.3877702173875065e-07, 0}, geo.pos()),
+                  1e-6)
+            << geo.pos();
     }
 }
 
@@ -1004,25 +1044,37 @@ TEST_F(TwoBoxTest, nonuniform_field)
     ReluZField field{unit_radius_field_strength};
     FieldDriverOptions driver_options;
 
-    this->make_geo_track_view({-2.0, 0, 0}, {0, 1, 1});
+    auto geo = this->make_geo_track_view({-2.0, 0, 0}, {0, 1, 1});
+    auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
+        field, particle.charge());
+    auto propagate
+        = make_field_propagator(stepper, driver_options, particle, geo);
 
-    static const Real3 expected_all_pos[]
-        = {{-2.082588410019, 0.698321021704, 0.70710499699532},
-           {-2.5772835670309, 1.1563856325251, 1.414208222427},
-           {-3.0638597406072, 0.77477344365218, 2.1213130872532},
-           {-2.5584323246703, 0.58519068474743, 2.8284269544184},
-           {-2.904435093832, 0.86378022294055, 3.5355750279272},
-           {-2.5804988125119, 0.7657810943241, 4.242802666321},
-           {-2.7424915491399, 0.60277842755393, 4.9501038870007},
-           {-2.6941223485135, 0.6137455428308, 5}};
-    for (Real3 const& pos : expected_all_pos)
+    std::vector<real_type> all_pos;
+    std::vector<int> step_counter;
+    for ([[maybe_unused]] auto i : range(8))
     {
-        auto geo = this->make_geo_track_view();
-        auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
-            field, driver_options, particle, geo);
+        stepper.reset_count();
         propagate(1.0);
-        EXPECT_VEC_SOFT_EQ(pos, geo.pos());
+        all_pos.insert(all_pos.end(), geo.pos().begin(), geo.pos().end());
+        step_counter.push_back(stepper.count());
     }
+
+    // clang-format off
+    static double const expected_all_pos[] = {
+        -2.082588410019, 0.698321021704, 0.70710499699532,
+        -2.5772834156698, 1.1563858825744, 1.4142082224578,
+        -3.0638597711046, 0.77477404071578, 2.1213130872795,
+        -2.5584330807733, 0.58519791464035, 2.8284269544963,
+        -2.9044449938663, 0.86374380213917, 3.5355750324309,
+        -2.580544641158, 0.76589682238491, 4.2428026858314,
+        -2.7422321216414, 0.60282499262184, 4.9501039569049,
+        -2.6938835431219, 0.61388130598869, 5};
+    // clang-format on
+    EXPECT_VEC_SOFT_EQ(expected_all_pos, all_pos);
+
+    static int const expected_step_counter[] = {5, 7, 12, 13, 19, 22, 27, 10};
+    EXPECT_VEC_EQ(expected_step_counter, step_counter);
 }
 
 //---------------------------------------------------------------------------//
@@ -1255,8 +1307,8 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         {
             // Repeated substep bisection failed; particle is bumped
             EXPECT_SOFT_EQ(1e-6, result.distance);
-            // Minor floating point differences could make this 102 or 103
-            EXPECT_SOFT_NEAR(real_type(103), real_type(stepper.count()), 0.02);
+            // Minor floating point differences among geometries
+            EXPECT_SOFT_NEAR(real_type(103), real_type(stepper.count()), 0.03);
             EXPECT_FALSE(result.looping);
         }
     }

--- a/test/celeritas/field/Steppers.test.cc
+++ b/test/celeritas/field/Steppers.test.cc
@@ -97,12 +97,13 @@ class SteppersTest : public Test
                     FieldStepperResult result = stepper(hstep, y);
                     y = result.end_state;
 
-                    total_err2 += detail::truncation_error(
-                        hstep, 0.001, y, result.err_state);
+                    total_err2
+                        += detail::rel_err_sq(result.err_state, hstep, y.mom);
                 }
+                real_type rel_err = std::sqrt(total_err2) / 0.001;
                 // Check the state after each revolution and the total error
-                EXPECT_VEC_NEAR(expected_y.pos, y.pos, sqrt(total_err2));
-                EXPECT_VEC_NEAR(expected_y.mom, y.mom, sqrt(total_err2));
+                EXPECT_VEC_NEAR(expected_y.pos, y.pos, rel_err);
+                EXPECT_VEC_NEAR(expected_y.mom, y.mom, rel_err);
                 EXPECT_LT(total_err2, param.epsilon);
             }
         }

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -249,8 +249,8 @@ TEST_F(MockAlongStepFieldTest, basic)
         inp.energy = MevEnergy{0.1};
         auto result = this->run(inp, num_tracks);
         EXPECT_SOFT_EQ(0.0872, result.eloss);
-        EXPECT_SOFT_EQ(0.072315483508565, result.displacement);
-        EXPECT_SOFT_EQ(-0.78966779070793, result.angle);
+        EXPECT_SOFT_EQ(0.072421206740159547, result.displacement);
+        EXPECT_SOFT_EQ(-0.79058355279796988, result.angle);
         EXPECT_SOFT_EQ(1.1636639210937e-11, result.time);
         EXPECT_SOFT_EQ(0.14533333333333, result.step);
         EXPECT_SOFT_EQ(0.00013079999999999, result.mfp);

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -252,7 +252,7 @@ TEST_F(TestEm3MctruthTest, four_step)
         EXPECT_VEC_EQ(expected_track, result.track);
         static const int expected_step[] = {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4};
         EXPECT_VEC_EQ(expected_step, result.step);
-    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
+        if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
         {
             static const int expected_volume[] = {1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2};
             EXPECT_VEC_EQ(expected_volume, result.volume);


### PR DESCRIPTION
Please look individually at the commits to see how this came about:
- Replaced several mixed use of "error", the "square of the error", the "error divided by the desired error" etc. to try to clarify the code, and moved the epsilon normalization outside of `truncation_error`
- Fixed (I think?) an extra 1/step in the chord calculation that popped out from the simplification
- Fixed (I think?) an extra division by epsilon 

I checked that the behavior (aside from the chord computation, which was a little harder to find?) See supporting code snippets from below, from lowest to highest in the call stack/usage.

---

In a follow-on discussion we can talk about comparing to a more geant4-like propagator:
- Add an adaptive epsilon based on `G4PropagatorInField`
- Change the default field driver options to match those from Geant4

---

G4FieldManager:
- `fEpsilonMinDefault= 5.0e-5;`
- `fEpsilonMaxDefault= 1.0e-3;`
- `fDefault_Delta_One_Step_Value= 0.01 * millimeter;`
- `fDefault_Delta_Intersection_Val= 0.001 * millimeter;`

G4PropagatorInField::constructor
- `fEpsilonStep= 1.0e-5 or fDetectorFieldMgr->GetMaximumEpsilonStep()`

G4PropagatorInField::ComputeStep
- `epsilon = fCurrentFieldMgr->GetDeltaOneStep() / CurrentProposedStepLength;`
- `G4double epsilonMin= fCurrentFieldMgr->GetMinimumEpsilonStep();`
- `G4double epsilonMax= fCurrentFieldMgr->GetMaximumEpsilonStep();`
- `if( epsilon < epsilonMin )  { epsilon = epsilonMin; }`
- `if( epsilon > epsilonMax )  { epsilon = epsilonMax; }`
- `SetEpsilonStep( epsilon );`

G4PropagatorInField::RefreshIntersectionLocator
- `fIntersectionLocator->SetEpsilonStepFor(fEpsilonStep)`

G4BrentLocator::EstimateIntersectionPoint
- `ApproxIntersecPointV = GetChordFinderFor()->ApproxCurvePointS(...,  GetEpsilonStepFor())`
 
G4ChordFinder::ApproxCurvePointS
- `fIntgrDriver->AccurateAdvance(EndPoint,test_step, eps_step)`

G4MagIntegratorDriver::AccurateAdvance
- `QuickAdvance( yFldTrk, dydx, h, dchord_step, dyerr_len );`
- `dyerr = dyerr_len / h;`
- `hnext = ComputeNewStepSize( dyerr/eps, h);`
- `while h < eps * hstep`
- `OneGoodStep(y,dydx,x,h,eps,hdid,hnext)`

G4MagIntegratorDriver::QuickAdvance
- `dyerr_len = std::sqrt(dyerr_pos_sq) OR std::sqrt(dyerr_mom_rel_sq) * hstep`

G4MagIntegratorDriver::ComputeNewStepSize_WithoutReductionLimit
- `hnew = GetSafety()*hstepCurrent*std::pow(errMaxNorm,GetPshrnk() OR GetPgrow()) `

G4MagInt_Driver::OneGoodStep
- `eps_rel_max = eps`
- `errpos_sq =  sqr(yerr[0]) + sqr(yerr[1]) + sqr(yerr[2]) ;`
- `eps_pos = eps_rel_max * std::max(h, fMinimumStep); `
- `errpos_sq /= (eps_pos*eps_pos); // Scale relative to required tolerance`
- `errvel_sq = sumerr_sq / magvel_sq`
- `errvel_sq /= eps_rel_max * eps_rel_max`
- `errmax_sq = std::max( errpos_sq, errvel_sq )`
- step succeeded if `errmax_sq < 1`
- success if `errmax_sq < errcon*errcon``
- else `htemp = GetSafety() * h * std::pow( errmax_sq, 0.5*GetPshrnk() );``
- `errcon = pow(max_stepping_increase/GetSafety(),1.0/GetPgrow());`


G4ChordFinderDelegate<T>:: FindNextChord
- `GetDriver().QuickAdvance(yEnd, dydx, stepTrial, dChordStep, dyErrPos);`
- `dyErr_relative = dyErrPos / (epsStep * lastStepLength)`
- `GetDriver().ComputeNewStepSize(dyErr_relative, lastStepLength`