### PR TITLE
Fix build errors from Geant4@10

### DIFF
--- a/src/accel/SetupOptionsMessenger.cc
+++ b/src/accel/SetupOptionsMessenger.cc
@@ -56,13 +56,13 @@ struct UICommandTraits<T, std::enable_if_t<std::is_integral_v<T>>>
     static long from_string(G4String const& v)
     {
         // Conversion to long int introduced in Geant4 10.7.0
-#if G4VERSION_NUMBER < 1070
+#if G4VERSION_NUMBER >= 1070
+        return G4UIcommand::ConvertToLongInt(v.c_str());
+#else
         G4long vl;
         std::istringstream is(v);
         is >> vl;
         return vl;
-#else
-        return G4UIcommand::ConvertToLongInt(v.c_str());
 #endif
     }
 };

--- a/src/accel/SetupOptionsMessenger.cc
+++ b/src/accel/SetupOptionsMessenger.cc
@@ -10,6 +10,7 @@
 #include <type_traits>
 #include <G4UIcmdWithABool.hh>
 #include <G4UIcmdWithAnInteger.hh>
+#include <G4Version.hh>
 
 #include "corecel/Assert.hh"
 #include "corecel/sys/Device.hh"
@@ -54,7 +55,15 @@ struct UICommandTraits<T, std::enable_if_t<std::is_integral_v<T>>>
     static std::string to_string(T v) { return std::to_string(v); }
     static long from_string(G4String const& v)
     {
+        // Conversion to long int introduced in Geant4 10.7.0
+#if G4VERSION_NUMBER < 1070
+        G4long vl;
+        std::istringstream is(v);
+        is >> vl;
+        return vl;
+#else
         return G4UIcommand::ConvertToLongInt(v.c_str());
+#endif
     }
 };
 

--- a/src/celeritas/ext/g4vg/SolidConverter.cc
+++ b/src/celeritas/ext/g4vg/SolidConverter.cc
@@ -386,7 +386,10 @@ auto SolidConverter::orb(arg_type solid_base) -> result_type
 auto SolidConverter::para(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Para const&>(solid_base);
-#if G4VERSION_NUMBER < 1100
+#if G4VERSION_NUMBER >= 1100
+    double const theta = solid.GetTheta();
+    double const phi = solid.GetPhi();
+#else
     // Theta/Phi are not directly accessible before 11.0 but are encoded in the
     // symmetry axis vector in the normalized x, y components. Geant4
     // internally constructs the unnormalized vector with z = 1, so can be
@@ -401,9 +404,6 @@ auto SolidConverter::para(arg_type solid_base) -> result_type
         = std::atan(std::sqrt(tan_theta_cos_phi * tan_theta_cos_phi
                               + tan_theta_sin_phi * tan_theta_sin_phi));
     double const phi = std::atan2(tan_theta_sin_phi, tan_theta_cos_phi);
-#else
-    double const theta = solid.GetTheta();
-    double const phi = solid.GetPhi();
 #endif
     return GeoManager::MakeInstance<UnplacedParallelepiped>(
         this->convert_scale_(solid.GetXHalfLength()),
@@ -581,7 +581,12 @@ auto SolidConverter::torus(arg_type solid_base) -> result_type
 auto SolidConverter::trap(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Trap const&>(solid_base);
-#if G4VERSION_NUMBER < 1100
+#if G4VERSION_NUMBER >= 1100
+    double const theta = solid.GetTheta();
+    double const phi = solid.GetPhi();
+    double const alpha_1 = solid.GetAlpha1();
+    double const alpha_2 = solid.GetAlpha2();
+#else
     // Theta/Phi are not directly accessible before 11.0 but are encoded in the
     // symmetry axis vector x, y components. Here they are multiplied by
     // cos(theta), which is the z component, and so we can reconstruct them.
@@ -597,11 +602,6 @@ auto SolidConverter::trap(arg_type solid_base) -> result_type
                               + tan_theta_sin_phi * tan_theta_sin_phi));
     double const alpha_1 = std::atan(solid.GetTanAlpha1());
     double const alpha_2 = std::atan(solid.GetTanAlpha2());
-#else
-    double const theta = solid.GetTheta();
-    double const phi = solid.GetPhi();
-    double const alpha_1 = solid.GetAlpha1();
-    double const alpha_2 = solid.GetAlpha2();
 #endif
 
     return GeoManager::MakeInstance<UnplacedTrapezoid>(


### PR DESCRIPTION
As reported in #828, the latest `develop` has a few compilation errors against Geant4 10.6 due to missing accessors. These are worked around here through use of the `G4VERSION_NUMBER` macro and direct/intermediate implementations:

- Missing `G4UIcommand::ConvertToLongInt()` is fixed by directly using `std::istringstream` as in the Geant4 implementation available from 10.7.
- Missing `GetTheta()`, `GetPhi()` accessors in `G4Trap` and `G4Para` calculate these parameters as in Geant4 11.0, using `GetSymAxis()` to obtain the needed inputs.
- Missing `GetAlpha...()` accessors in `G4Trap` simply use the `GetTanAlpha...()` accessors and `std::atan`.

The use of the direct Geant4 accessors is retained if the version supports them. Both implementations have been tested against Geant4 11, and produce the same results. Compilation against 10.6 works, but a few tests still fail:

```
The following tests FAILED:
	 81 - celeritas/ext/GeantImporter:FourSteelSlabs* (Failed)
	 83 - celeritas/ext/GeantImporter:OneSteelSphere.* (Failed)
	 98 - celeritas/global/AlongStep:Em3AlongStepTest.nofluct_nomsc (Failed)
	100 - celeritas/global/AlongStep:Em3AlongStepTest.msc_nofluct_finegrid (Failed)
	111 - celeritas/global/Stepper:TestEm3MscNofluct.* (Failed)
	151 - celeritas/user/Diagnostic:TestEm3* (Failed)
```

These need more investigation but on first look appear due to small (but above tolerance) differences in imported data, which is perhaps not surprising. I didn't look at trying to address these here until the compilation error fixes are reviewed and merged. 