### PR TITLE
Refactor hit manager SD mapping

### DIFF
--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -22,6 +22,7 @@ list(APPEND SOURCES
   SimpleOffload.cc
   detail/HitManager.cc
   detail/HitProcessor.cc
+  detail/SensDetInserter.cc
 )
 
 celeritas_polysource(ExceptionConverter)

--- a/src/accel/detail/HitManager.hh
+++ b/src/accel/detail/HitManager.hh
@@ -23,6 +23,7 @@ struct SDSetupOptions;
 namespace detail
 {
 class HitProcessor;
+//---------------------------------------------------------------------------//
 
 //---------------------------------------------------------------------------//
 /*!
@@ -53,7 +54,7 @@ class HitManager final : public StepInterface
     //!@}
 
   public:
-    // Construct with VecGeom for mapping volume IDs
+    // Construct with Celeritas objects for mapping
     HitManager(GeoParams const& geo,
                SDSetupOptions const& setup,
                StreamId::size_type num_streams);
@@ -88,11 +89,17 @@ class HitManager final : public StepInterface
     using VecLV = std::vector<G4LogicalVolume const*>;
 
     bool nonzero_energy_deposition_{};
-    bool locate_touchable_{};
-    StepSelection selection_;
-    SPConstVecLV geant_vols_;
     VecVolId vecgeom_vols_;
+
+    // Hit processor setup
+    SPConstVecLV geant_vols_;
+    StepSelection selection_;
+    bool locate_touchable_{};
+
     std::vector<std::unique_ptr<HitProcessor>> processors_;
+
+    // Construct vecgeom/geant volumes
+    void setup_volumes(GeoParams const& geo, SDSetupOptions const& setup);
 
     // Ensure thread-local hit processor exists and return it
     HitProcessor& get_local_hit_processor(StreamId);

--- a/src/accel/detail/SensDetInserter.cc
+++ b/src/accel/detail/SensDetInserter.cc
@@ -1,0 +1,103 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/detail/SensDetInserter.cc
+//---------------------------------------------------------------------------//
+#include "SensDetInserter.hh"
+
+#include <G4VSensitiveDetector.hh>
+
+#include "celeritas_cmake_strings.h"
+#include "corecel/io/Logger.hh"
+#include "celeritas/ext/GeantGeoUtils.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Save a sensitive detector.
+ */
+void SensDetInserter::operator()(G4LogicalVolume const* lv,
+                                 G4VSensitiveDetector const* sd)
+{
+    CELER_EXPECT(lv);
+    CELER_EXPECT(sd);
+
+    if (VolumeId id = insert_impl(lv))
+    {
+        CELER_LOG(debug) << "Mapped sensitive detector \"" << sd->GetName()
+                         << "\" on logical volume " << PrintableLV{lv}
+                         << " to " << celeritas_core_geo << " volume \""
+                         << geo_.id_to_label(id)
+                         << "\" (ID=" << id.unchecked_get() << ')';
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Save a sensitive detector.
+ */
+void SensDetInserter::operator()(G4LogicalVolume const* lv)
+{
+    CELER_EXPECT(lv);
+
+    if (VolumeId id = insert_impl(lv))
+    {
+        CELER_LOG(debug) << "Mapped unspecified detector on logical volume "
+                         << PrintableLV{lv} << " to " << celeritas_core_geo
+                         << " volume \"" << geo_.id_to_label(id)
+                         << "\" (ID=" << id.unchecked_get() << ')';
+    }
+}
+
+//---------------------------------------------------------------------------//
+VolumeId SensDetInserter::insert_impl(G4LogicalVolume const* lv)
+{
+    if (skip_volumes_.count(lv))
+    {
+        CELER_LOG(debug)
+            << "Skipping automatic SD callback for logical volume \""
+            << lv->GetName() << "\" due to user option";
+        return {};
+    }
+
+    auto id = lv ? g4_to_celer_(*lv) : VolumeId{};
+    if (!id)
+    {
+        CELER_LOG(error) << "Failed to find " << celeritas_core_geo
+                         << " volume corresponding to Geant4 volume "
+                         << PrintableLV{lv};
+        missing_->push_back(lv);
+        return {};
+    }
+
+    // Add Geant4 volume and corresponding volume ID to list
+    auto [iter, inserted] = found_->insert({id, lv});
+
+    if (CELER_UNLIKELY(!inserted))  // && iter->second != lv))
+    {
+        if (iter->second != lv)
+        {
+            CELER_LOG(warning)
+                << "Celeritas volume \"" << geo_.id_to_label(id)
+                << "\" is mapped to two different volumes with "
+                   "sensitive detectors: "
+                << PrintableLV{lv} << " and " << PrintableLV{iter->second};
+        }
+        else
+        {
+            CELER_LOG(debug)
+                << "Ignored duplicate logical volume " << PrintableLV{lv};
+        }
+    }
+
+    return inserted ? id : VolumeId{};
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/accel/detail/SensDetInserter.hh
+++ b/src/accel/detail/SensDetInserter.hh
@@ -1,0 +1,86 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/detail/SensDetInserter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <map>
+#include <unordered_set>
+#include <vector>
+
+#include "corecel/Assert.hh"
+#include "orange/GeoParamsInterface.hh"
+#include "celeritas/ext/GeantVolumeMapper.hh"
+
+class G4LogicalVolume;
+class G4VSensitiveDetector;
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Map logical volumes to native geometry and log potential issues.
+ *
+ * This is an implementation detail of \c HitManager .
+ */
+class SensDetInserter
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using SetLV = std::unordered_set<G4LogicalVolume const*>;
+    using VecLV = std::vector<G4LogicalVolume const*>;
+    using MapIdLv = std::map<VolumeId, G4LogicalVolume const*>;
+    //!@}
+
+  public:
+    // Construct with defaults
+    inline SensDetInserter(GeoParamsInterface const& geo,
+                           SetLV const& skip_volumes,
+                           MapIdLv* found,
+                           VecLV* missing);
+
+    // Save a sensitive detector
+    void operator()(G4LogicalVolume const* lv, G4VSensitiveDetector const* sd);
+
+    // Forcibly add the given volume
+    void operator()(G4LogicalVolume const* lv);
+
+  private:
+    GeoParamsInterface const& geo_;
+    GeantVolumeMapper g4_to_celer_;
+    SetLV const& skip_volumes_;
+    MapIdLv* found_;
+    VecLV* missing_;
+
+    VolumeId insert_impl(G4LogicalVolume const* lv);
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with references to the inserted data.
+ */
+SensDetInserter::SensDetInserter(GeoParamsInterface const& geo,
+                                 SetLV const& skip_volumes,
+                                 MapIdLv* found,
+                                 VecLV* missing)
+    : geo_(geo)
+    , g4_to_celer_{geo}
+    , skip_volumes_{skip_volumes}
+    , found_{found}
+    , missing_{missing}
+{
+    CELER_EXPECT(found_);
+    CELER_EXPECT(missing_);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/ext/GeantGeoParams.cc
+++ b/src/celeritas/ext/GeantGeoParams.cc
@@ -176,7 +176,14 @@ VolumeId GeantGeoParams::find_volume(G4LogicalVolume const* volume) const
     CELER_EXPECT(volume);
     auto inst_id = volume->GetInstanceID();
     CELER_ENSURE(inst_id >= 0);
-    return VolumeId{static_cast<VolumeId::size_type>(inst_id)};
+    VolumeId result{static_cast<VolumeId::size_type>(inst_id)};
+    if (!(result < this->num_volumes()))
+    {
+        // Volume is out of range: possibly an LV defined after this geometry
+        // class was created
+        result = {};
+    }
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/Repr.hh
+++ b/src/corecel/io/Repr.hh
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -212,6 +213,34 @@ struct ReprTraits<unsigned long long>
 };
 
 template<>
+struct ReprTraits<std::string_view>
+{
+    static void print_type(std::ostream& os, char const* name = nullptr)
+    {
+        detail::print_simple_type(os, "std::string_view", name);
+    }
+
+    static void init(std::ostream&) {}
+    static void print_value(std::ostream& os, std::string_view value)
+    {
+        std::streamsize width = os.width();
+
+        os.width(width - value.size() - 2);
+
+        os << '"';
+        for (char c : value)
+        {
+            if (c == '\"')
+            {
+                os << '\\';
+            }
+            detail::repr_char(os, c);
+        }
+        os << '"';
+    }
+};
+
+template<>
 struct ReprTraits<std::string>
 {
     static void print_type(std::ostream& os, char const* name = nullptr)
@@ -222,16 +251,7 @@ struct ReprTraits<std::string>
     static void init(std::ostream&) {}
     static void print_value(std::ostream& os, std::string const& value)
     {
-        std::streamsize width = os.width();
-
-        os.width(width - value.size() - 2);
-
-        os << '"';
-        for (char c : value)
-        {
-            detail::repr_char(os, c);
-        }
-        os << '"';
+        ReprTraits<std::string_view>::print_value(os, value);
     }
 };
 
@@ -249,7 +269,7 @@ struct ReprTraits<char*>
     {
         if (value)
         {
-            ReprTraits<std::string>::print_value(os, value);
+            ReprTraits<std::string_view>::print_value(os, value);
         }
         else
         {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -565,10 +565,10 @@ if(CELERITAS_USE_Geant4)
     accel/SDTestBase.cc
   )
   celeritas_target_link_libraries(testcel_accel
-    PUBLIC testcel_harness testcel_celeritas Celeritas::accel
+    PUBLIC testcel_celeritas testcel_core testcel_harness Celeritas::accel
   )
   celeritas_setup_tests(SERIAL PREFIX accel
-    LINK_LIBRARIES Celeritas::accel Celeritas::celeritas testcel_accel
+    LINK_LIBRARIES testcel_accel Celeritas::accel Celeritas::celeritas
   )
 
   celeritas_add_test(accel/ExceptionConverter.test.cc)

--- a/test/accel/detail/HitManager.test.cc
+++ b/test/accel/detail/HitManager.test.cc
@@ -130,7 +130,7 @@ TEST_F(SimpleCmsTest, add_duplicate)
     static char const* const expected_vnames[]
         = {"em_calorimeter", "had_calorimeter"};
     EXPECT_VEC_EQ(expected_vnames, vnames);
-    if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
+    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM)
     {
         static char const* const expected_log_messages[] = {
             "Mapped sensitive detector \"em_calorimeter\" on logical volume "
@@ -183,7 +183,7 @@ TEST_F(SimpleCmsTest, detached_detector)
     sd_setup_.force_volumes = {SimpleCmsTest::detached_lv};
     EXPECT_THROW(this->make_hit_manager(), celeritas::RuntimeError);
 
-    if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
+    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM)
     {
         static char const* const expected_log_messages[]
             = {"Failed to find VecGeom volume corresponding to Geant4 volume "

--- a/test/accel/detail/HitManager.test.cc
+++ b/test/accel/detail/HitManager.test.cc
@@ -9,8 +9,14 @@
 
 #include <G4LogicalVolume.hh>
 #include <G4LogicalVolumeStore.hh>
+#include <G4NistManager.hh>
+#include <G4Orb.hh>
 
+#include "celeritas_config.h"
+#include "corecel/ScopedLogStorer.hh"
+#include "corecel/io/Logger.hh"
 #include "celeritas/SimpleCmsTestBase.hh"
+#include "celeritas/ext/GeantGeoUtils.hh"
 #include "celeritas/geo/GeoParams.hh"
 #include "accel/SDTestBase.hh"
 #include "accel/SetupOptions.hh"
@@ -34,6 +40,20 @@ class SimpleCmsTest : public ::celeritas::test::SDTestBase,
         sd_setup_.ignore_zero_deposition = false;
     }
 
+    SPConstGeoI build_fresh_geometry(std::string_view basename) override
+    {
+        auto result = SDTestBase::build_fresh_geometry(basename);
+        scoped_log_.clear();
+
+        // Create unused volume when building geometry
+        G4Material* mat
+            = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+        SimpleCmsTest::detached_lv = new G4LogicalVolume(
+            new G4Orb("unused_solid", 10.0), mat, "unused_lv");
+
+        return result;
+    }
+
     SetStr detector_volumes() const final
     {
         // *Don't* add SD for si_tracker
@@ -53,29 +73,18 @@ class SimpleCmsTest : public ::celeritas::test::SDTestBase,
         return result;
     }
 
-    std::unordered_set<G4LogicalVolume const*>
-    find_lvs(std::unordered_set<std::string> const& inp)
-    {
-        EXPECT_TRUE(this->geometry());
-
-        std::unordered_set<G4LogicalVolume const*> result;
-        for (G4LogicalVolume* lv : *G4LogicalVolumeStore::GetInstance())
-        {
-            if (inp.find(lv->GetName()) != inp.end())
-            {
-                result.insert(lv);
-            }
-        }
-        return result;
-    }
-
     HitManager make_hit_manager()
     {
         return HitManager(*this->geometry(), sd_setup_, 1);
     }
 
+  protected:
     SDSetupOptions sd_setup_;
+    ::celeritas::test::ScopedLogStorer scoped_log_{&celeritas::world_logger()};
+    static G4LogicalVolume* detached_lv;
 };
+
+G4LogicalVolume* SimpleCmsTest::detached_lv{nullptr};
 
 TEST_F(SimpleCmsTest, no_change)
 {
@@ -86,11 +95,15 @@ TEST_F(SimpleCmsTest, no_change)
     static char const* const expected_vnames[]
         = {"em_calorimeter", "had_calorimeter"};
     EXPECT_VEC_EQ(expected_vnames, vnames);
+    if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
+    {
+        EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
+    }
 }
 
 TEST_F(SimpleCmsTest, delete_one)
 {
-    sd_setup_.skip_volumes = this->find_lvs({"had_calorimeter"});
+    sd_setup_.skip_volumes = find_geant_volumes({"had_calorimeter"});
     HitManager man = this->make_hit_manager();
 
     EXPECT_EQ(1, man.geant_vols()->size());
@@ -98,11 +111,45 @@ TEST_F(SimpleCmsTest, delete_one)
 
     static char const* const expected_vnames[] = {"em_calorimeter"};
     EXPECT_VEC_EQ(expected_vnames, vnames);
+    if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
+    {
+        EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
+    }
+}
+
+TEST_F(SimpleCmsTest, add_duplicate)
+{
+    sd_setup_.force_volumes = find_geant_volumes({"em_calorimeter"});
+    celeritas::world_logger().level(LogLevel::debug);
+    HitManager man = this->make_hit_manager();
+    celeritas::world_logger().level(Logger::default_level());
+
+    EXPECT_EQ(2, man.geant_vols()->size());
+    auto vnames = this->volume_names(man.celer_vols());
+
+    static char const* const expected_vnames[]
+        = {"em_calorimeter", "had_calorimeter"};
+    EXPECT_VEC_EQ(expected_vnames, vnames);
+    if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
+    {
+        static char const* const expected_log_messages[] = {
+            "Mapped sensitive detector \"em_calorimeter\" on logical volume "
+            "\"em_calorimeter\"@0x0 (ID=2) to VecGeom volume "
+            "\"em_calorimeter@0x0\" (ID=2)",
+            "Mapped sensitive detector \"had_calorimeter\" on logical volume "
+            "\"had_calorimeter\"@0x0 (ID=3) to VecGeom volume "
+            "\"had_calorimeter@0x0\" (ID=3)",
+            "Ignored duplicate logical volume \"em_calorimeter\"@0x0 (ID=2)"};
+        EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
+        static char const* const expected_log_levels[]
+            = {"debug", "debug", "debug"};
+        EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
+    }
 }
 
 TEST_F(SimpleCmsTest, add_one)
 {
-    sd_setup_.force_volumes = this->find_lvs({"si_tracker"});
+    sd_setup_.force_volumes = find_geant_volumes({"si_tracker"});
     HitManager man = this->make_hit_manager();
 
     EXPECT_EQ(3, man.geant_vols()->size());
@@ -111,21 +158,39 @@ TEST_F(SimpleCmsTest, add_one)
     static char const* const expected_vnames[]
         = {"si_tracker", "em_calorimeter", "had_calorimeter"};
     EXPECT_VEC_EQ(expected_vnames, vnames);
+    if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
+    {
+        EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
+    }
 }
 
-TEST_F(SimpleCmsTest, errors)
+TEST_F(SimpleCmsTest, no_detector)
 {
+    // No detectors
+    sd_setup_.skip_volumes
+        = find_geant_volumes({"em_calorimeter", "had_calorimeter"});
+    EXPECT_THROW(this->make_hit_manager(), celeritas::RuntimeError);
+    if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
     {
-        // No detectors
-        sd_setup_.skip_volumes
-            = this->find_lvs({"em_calorimeter", "had_calorimeter"});
-        EXPECT_THROW(this->make_hit_manager(), celeritas::RuntimeError);
+        EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
     }
+}
+
+TEST_F(SimpleCmsTest, detached_detector)
+{
+    // Detector for LV that isn't in the world tree
+    sd_setup_.skip_volumes = {};
+    sd_setup_.force_volumes = {SimpleCmsTest::detached_lv};
+    EXPECT_THROW(this->make_hit_manager(), celeritas::RuntimeError);
+
+    if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
     {
-        // Nonexistent forced detector (nullptr in this case)
-        sd_setup_.skip_volumes = {};
-        sd_setup_.force_volumes = {nullptr};
-        EXPECT_THROW(this->make_hit_manager(), celeritas::RuntimeError);
+        static char const* const expected_log_messages[]
+            = {"Failed to find VecGeom volume corresponding to Geant4 volume "
+               "\"unused_lv\"@0x0 (ID=7)"};
+        EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
+        static char const* const expected_log_levels[] = {"error"};
+        EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
     }
 }
 

--- a/test/corecel/ScopedLogStorer.cc
+++ b/test/corecel/ScopedLogStorer.cc
@@ -77,14 +77,27 @@ void ScopedLogStorer::print_expected() const
          << repr(this->messages_)
          << ";\n"
             "EXPECT_VEC_EQ(expected_log_messages, "
-            "store_log_.messages());\n"
+            "scoped_log_.messages());\n"
             "static char const* const expected_log_levels[] = "
          << repr(this->levels_)
          << ";\n"
             "EXPECT_VEC_EQ(expected_log_levels, "
-            "store_log_.levels());\n"
+            "scoped_log_.levels());\n"
             "/*** END CODE ***/"
          << endl;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Print expected results.
+ */
+std::ostream& operator<<(std::ostream& os, ScopedLogStorer const& logs)
+{
+    os << "messages: " << repr(logs.messages())
+       << "\n"
+          "levels: "
+       << repr(logs.levels());
+    return os;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
As a precursor to extensions to the HitManager callbacks, I've refactored the hit manager constructor with a helper class. While testing I made a few minor fixes/improvements to other helper classes, and added tests for logged messages.