### PR TITLE
Fix default `combined_brems` option to work with multiple-element materials

### DIFF
--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -73,7 +73,7 @@ struct RunnerInput
     real_type step_limiter{};
 
     // Options for physics
-    bool brem_combined{true};
+    bool brem_combined{false};
 
     // Track init options
     TrackOrder track_order{TrackOrder::unsorted};


### PR DESCRIPTION
We originally had `brems_combined{true}` in celer-app, but that option is incompatible with most geometry models because we never implemented elemental sampling. Change the default to `false`, consistent with the default for `ProcessBuilderOptions`.