### PR TITLE
Fix app/demo-geo-check test failure when using MPI

### DIFF
--- a/app/demo-geo-check/CMakeLists.txt
+++ b/app/demo-geo-check/CMakeLists.txt
@@ -57,8 +57,9 @@ if(CELERITAS_CORE_GEO STREQUAL "ORANGE")
   list(APPEND _props DISABLED true)
 endif()
 set_tests_properties("app/demo-geo-check" PROPERTIES
-  ${_props}
+  ENVIRONMENT "CELER_DISABLE_PARALLEL=1"
   LABELS "${_labels}"
+  ${_props}
 )
 
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
The `app/demo-geo-check` test needs `CELER_DISABLE_PARALLEL=1` to run. To avoid having the test returning a `Subprocess aborted` signal, this environment variable is now set as a test property in its CMakeLists.txt.