### PR TITLE
Gather and set more Step/Track attributes when calling sensitive detectors

### DIFF
--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -72,7 +72,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
         G4Exception("DetectorConstruction::Construct()",
                     "",
                     FatalException,
-                    "No GDML file was specified with setGeometryFile");
+                    "No GDML file was specified with /celerg4/geometryFile");
     }
     constexpr bool validate_gdml_schema = false;
     gdml_parser.Read(filename, validate_gdml_schema);

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -45,6 +45,8 @@ struct SDSetupOptions
     bool energy_deposition{true};
     //! Set TouchableHandle for PreStepPoint
     bool locate_touchable{false};
+    //! Create a track with the dynamic particle type and post-step data
+    bool track{false};
     //! Options for saving and converting beginning-of-step data
     StepPoint pre;
     //! Options for saving and converting end-of-step data

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -34,6 +34,7 @@ struct SDSetupOptions
     {
         bool global_time{false};
         bool position{false};
+        bool direction{false};  //!< AKA momentum direction
         bool kinetic_energy{false};
     };
 

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -30,7 +30,8 @@ class ExplicitActionInterface;
  *
  * Various attributes on the step, track, and pre/post step points may be
  * available depending on the selected options.
- * - Disabling \c track will leave \c G4Step::GetTrack as null
+ * - Disabling \c track will leave \c G4Step::GetTrack and \c
+ *   G4Step::GetSecondary as null
  * - Enabling \c locate_touchable will also set \c Material and \c
  *   MaterialCutsCouple
  * - Enabling \c track will set particle the \c Charge attribute on the

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -27,6 +27,19 @@ class ExplicitActionInterface;
  *
  * These affect only the \c HitManager construction that is responsible for
  * reconstructing CPU hits and sending directly to the Geant4 detectors.
+ *
+ * Various attributes on the step, track, and pre/post step points may be
+ * available depending on the selected options.
+ * - Disabling \c track will leave \c G4Step::GetTrack as null
+ * - Enabling \c locate_touchable will also set \c Material and \c
+ *   MaterialCutsCouple
+ * - Enabling \c track will set particle the \c Charge attribute on the
+ *   pre-step
+ * - Requested post-step data including \c GlobalTime, \c Position, \c
+ *   KineticEnergy, and \c MomentumDirection will be copied to the \c Track
+ *   when the combination of options is enabled
+ * - Track and Parent IDs will \em never be a valid value since Celeritas track
+ *   counters are independent from Geant4 track counters.
  */
 struct SDSetupOptions
 {

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -30,8 +30,7 @@ class ExplicitActionInterface;
  *
  * Various attributes on the step, track, and pre/post step points may be
  * available depending on the selected options.
- * - Disabling \c track will leave \c G4Step::GetTrack and \c
- *   G4Step::GetSecondary as null
+ * - Disabling \c track will leave \c G4Step::GetTrack as \c nullptr
  * - Enabling \c locate_touchable will also set \c Material and \c
  *   MaterialCutsCouple
  * - Enabling \c track will set particle the \c Charge attribute on the

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -385,7 +385,7 @@ void SharedParams::initialize_core(SetupOptions const& options)
     if (options.sd)
     {
         hit_manager_ = std::make_shared<detail::HitManager>(
-            *params.geometry, options.sd, params.max_streams);
+            *params.geometry, *params.particle, options.sd, params.max_streams);
         step_collector_ = std::make_shared<StepCollector>(
             StepCollector::VecInterface{hit_manager_},
             params.geometry,

--- a/src/accel/detail/HitManager.cc
+++ b/src/accel/detail/HitManager.cc
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <utility>
 #include <G4LogicalVolumeStore.hh>
+#include <G4ParticleTable.hh>
 #include <G4RunManager.hh>
 #include <G4Threading.hh>
 
@@ -21,6 +22,7 @@
 #include "celeritas/Types.hh"
 #include "celeritas/ext/GeantSetup.hh"
 #include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
+#include "celeritas/phys/ParticleParams.hh"  // IWYU pragma: keep
 #include "accel/SetupOptions.hh"
 
 #include "HitProcessor.hh"
@@ -49,6 +51,7 @@ void update_selection(StepPointSelection* selection,
  * Map detector IDs on construction.
  */
 HitManager::HitManager(GeoParams const& geo,
+                       ParticleParams const& par,
                        SDSetupOptions const& setup,
                        StreamId::size_type num_streams)
     : nonzero_energy_deposition_(setup.ignore_zero_deposition)
@@ -58,6 +61,7 @@ HitManager::HitManager(GeoParams const& geo,
     CELER_EXPECT(num_streams > 0);
 
     // Convert setup options to step data
+    selection_.particle = setup.track;
     selection_.energy_deposition = setup.energy_deposition;
     update_selection(&selection_.points[StepPoint::pre], setup.pre);
     update_selection(&selection_.points[StepPoint::post], setup.post);
@@ -74,6 +78,12 @@ HitManager::HitManager(GeoParams const& geo,
     // Map detector volumes
     this->setup_volumes(geo, setup);
 
+    if (setup.track)
+    {
+        this->setup_particles(par);
+    }
+
+    CELER_ENSURE(setup.track == !this->particles_.empty());
     CELER_ENSURE(geant_vols_ && geant_vols_->size() == vecgeom_vols_.size());
 }
 
@@ -191,6 +201,42 @@ void HitManager::setup_volumes(GeoParams const& geo,
         vecgeom_vols_.push_back(id);
     }
     geant_vols_ = std::make_shared<VecLV>(std::move(geant_vols));
+}
+
+//---------------------------------------------------------------------------//
+void HitManager::setup_particles(ParticleParams const& par)
+{
+    CELER_EXPECT(selection_.particle);
+
+    auto& g4particles = *G4ParticleTable::GetParticleTable();
+
+    particles_.resize(par.size());
+    std::vector<ParticleId> missing;
+    for (auto pid : range(ParticleId{par.size()}))
+    {
+        int pdg = par.id_to_pdg(pid).get();
+        if (G4ParticleDefinition* particle = g4particles.FindParticle(pdg))
+        {
+            particles_[pid.get()] = particle;
+        }
+        else
+        {
+            missing.push_back(pid);
+        }
+    }
+
+    CELER_VALIDATE(missing.empty(),
+                   << "failed to map Celeritas particles to Geant4: missing "
+                   << join_stream(missing.begin(),
+                                  missing.end(),
+                                  ", ",
+                                  [&par](std::ostream& os, ParticleId pid) {
+                                      os << '"' << par.id_to_label(pid)
+                                         << "\" (ID=" << pid.unchecked_get()
+                                         << ", PDG="
+                                         << par.id_to_pdg(pid).unchecked_get()
+                                         << ")";
+                                  }));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/detail/HitManager.cc
+++ b/src/accel/detail/HitManager.cc
@@ -253,7 +253,7 @@ HitProcessor& HitManager::get_local_hit_processor(StreamId sid)
             << "Allocating hit processor (stream " << sid.get() << ")";
         // Allocate the hit processor locally
         processors_[sid.unchecked_get()] = std::make_unique<HitProcessor>(
-            geant_vols_, selection_, locate_touchable_);
+            geant_vols_, particles_, selection_, locate_touchable_);
     }
     return *processors_[sid.unchecked_get()];
 }

--- a/src/accel/detail/HitManager.cc
+++ b/src/accel/detail/HitManager.cc
@@ -40,6 +40,7 @@ void update_selection(StepPointSelection* selection,
 {
     selection->time = options.global_time;
     selection->pos = options.position;
+    selection->dir = options.direction;
     selection->energy = options.kinetic_energy;
 }
 

--- a/src/accel/detail/HitManager.hh
+++ b/src/accel/detail/HitManager.hh
@@ -15,10 +15,12 @@
 #include "celeritas/user/StepInterface.hh"
 
 class G4LogicalVolume;
+class G4ParticleDefinition;
 
 namespace celeritas
 {
 struct SDSetupOptions;
+class ParticleParams;
 
 namespace detail
 {
@@ -51,11 +53,13 @@ class HitManager final : public StepInterface
     using SPConstVecLV
         = std::shared_ptr<const std::vector<G4LogicalVolume const*>>;
     using VecVolId = std::vector<VolumeId>;
+    using VecParticle = std::vector<G4ParticleDefinition const*>;
     //!@}
 
   public:
     // Construct with Celeritas objects for mapping
     HitManager(GeoParams const& geo,
+               ParticleParams const& par,
                SDSetupOptions const& setup,
                StreamId::size_type num_streams);
 
@@ -85,6 +89,9 @@ class HitManager final : public StepInterface
     //! Access the Celeritas volume IDs corresponding to the detectors
     VecVolId const& celer_vols() const { return vecgeom_vols_; }
 
+    //! Access mapped particles if recreating G4Tracks later
+    VecParticle const& geant_particles() const { return particles_; }
+
   private:
     using VecLV = std::vector<G4LogicalVolume const*>;
 
@@ -93,6 +100,7 @@ class HitManager final : public StepInterface
 
     // Hit processor setup
     SPConstVecLV geant_vols_;
+    VecParticle particles_;
     StepSelection selection_;
     bool locate_touchable_{};
 
@@ -100,6 +108,8 @@ class HitManager final : public StepInterface
 
     // Construct vecgeom/geant volumes
     void setup_volumes(GeoParams const& geo, SDSetupOptions const& setup);
+    // Construct celeritas/geant particles
+    void setup_particles(ParticleParams const& par);
 
     // Ensure thread-local hit processor exists and return it
     HitProcessor& get_local_hit_processor(StreamId);

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -64,11 +64,15 @@ namespace detail
  * Construct local navigator and step data.
  */
 HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
+                           VecParticle const& particles,
                            StepSelection const& selection,
                            bool locate_touchable)
     : detector_volumes_(std::move(detector_volumes))
 {
     CELER_EXPECT(detector_volumes_ && !detector_volumes_->empty());
+    CELER_VALIDATE(!locate_touchable || selection.points[StepPoint::pre].pos,
+                   << "cannot set 'locate_touchable' because the pre-step "
+                      "position is not being collected");
     CELER_VALIDATE(!locate_touchable || selection.points[StepPoint::pre].pos,
                    << "cannot set 'locate_touchable' because the pre-step "
                       "position is not being collected");
@@ -105,8 +109,10 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
         = G4TransportationManager::GetTransportationManager()
               ->GetNavigatorForTracking()
               ->GetWorldVolume();
-    if (locate_touchable && selection.points[StepPoint::pre].pos)
+    if (locate_touchable)
     {
+        CELER_ASSERT(selection.points[StepPoint::pre].pos
+                     && selection.points[StepPoint::pre].dir);
         navi_ = std::make_unique<G4Navigator>();
         navi_->SetWorldVolume(world_volume);
 
@@ -114,8 +120,16 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
         touch_handle_ = new G4TouchableHistory;
         step_->GetPreStepPoint()->SetTouchableHandle(touch_handle_);
     }
-    track_ = std::make_unique<G4Track>();
-    step_->SetTrack(track_.get());
+
+    // Create track
+    for (G4ParticleDefinition const* pd : particles)
+    {
+        CELER_ASSERT(pd);
+        tracks_.emplace_back(new G4Track(
+            new G4DynamicParticle(pd, G4ThreeVector()), 0.0, G4ThreeVector()));
+        tracks_.back()->SetTrackID(-1);
+        tracks_.back()->SetParentID(-1);
+    }
 
     // Convert logical volumes (global) to sensitive detectors (thread local)
     CELER_LOG_LOCAL(debug) << "Setting up " << detector_volumes_->size()
@@ -177,6 +191,7 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
     CELER_EXPECT(!out.detector.empty());
     CELER_ASSERT(!navi_ || !out.points[StepPoint::pre].pos.empty());
     CELER_ASSERT(!navi_ || !out.points[StepPoint::pre].dir.empty());
+    CELER_ASSERT(tracks_.empty() || !out.particle.empty());
 
     CELER_LOG_LOCAL(debug) << "Processing " << out.size() << " hits";
 
@@ -192,11 +207,6 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
     } while (0)
 
         HP_SET(step_->SetTotalEnergyDeposit, out.energy_deposition, CLHEP::MeV);
-        // TODO: how to handle track attributes?
-        // track_->SetTrackID(...);
-
-        // TODO: assert that event ID is consistent with active
-        // LocalTransporter event?
 
         EnumArray<StepPoint, G4StepPoint*> points
             = {step_->GetPreStepPoint(), step_->GetPostStepPoint()};
@@ -211,20 +221,17 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
             HP_SET(points[sp]->SetKineticEnergy,
                    out.points[sp].energy,
                    CLHEP::MeV);
-            // TODO: do we set secondary properties like the velocity,
-            // material, mass, charge,  ... ?
-
-            // TODO: how to handle these attributes?
-            // step_->SetTrack(primary_track);
-            // dynamic particle, ParticleDefinition
-            // pre->SetLocalTime
-            // pre->SetProperTime
-            // pre->SetTouchableHandle
         }
 #undef HP_SET
 
+        if (!tracks_.empty())
+        {
+            this->update_track(out.particle[i]);
+        }
+
         if (navi_)
         {
+            // Set the navigation
             CELER_ASSERT(out.detector[i] < detectors_.size());
             bool success = this->update_touchable(
                 out.points[StepPoint::pre].pos[i],
@@ -241,6 +248,20 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
         CELER_ASSERT(out.detector[i] < detectors_.size());
         detectors_[out.detector[i].unchecked_get()]->Hit(step_.get());
     }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Recreate the track from the particle ID and saved post-step data.
+ */
+void HitProcessor::update_track(ParticleId id) const
+{
+    CELER_EXPECT(id < tracks_.size());
+    G4Track& track = *tracks_[id.unchecked_get()];
+    step_->SetTrack(&track);
+
+    G4StepPoint* post_step = step_->GetPostStepPoint();
+    track.SetKineticEnergy(post_step->GetKineticEnergy());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -77,8 +77,9 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
                    << "cannot set 'locate_touchable' because the pre-step "
                       "position is not being collected");
 
-    // Create pre- and post-step
+    // Create step and step-owned structures
     step_ = std::make_unique<G4Step>();
+    step_->NewSecondaryVector();
 
 #if G4VERSION_NUMBER >= 1103
 #    define HP_CLEAR_STEP_POINT(CMD) step_->CMD(nullptr)
@@ -121,7 +122,7 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
         step_->GetPreStepPoint()->SetTouchableHandle(touch_handle_);
     }
 
-    // Create track
+    // Create track if user requested particle types
     for (G4ParticleDefinition const* pd : particles)
     {
         CELER_ASSERT(pd);
@@ -132,10 +133,6 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
     }
 
     // Create secondary vector if using track data
-    if (!tracks_.empty())
-    {
-        step_->NewSecondaryVector();
-    }
 
     // Convert logical volumes (global) to sensitive detectors (thread local)
     CELER_LOG_LOCAL(debug) << "Setting up " << detector_volumes_->size()

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -241,6 +241,10 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
                 // Inconsistent touchable: skip this energy deposition
                 continue;
             }
+
+            // Copy attributes from logical volume
+            points[sp]->SetMaterial(lv->GetMaterial());
+            points[sp]->SetMaterialCutsCouple(lv->GetMaterialCutsCouple());
         }
 
         if (!tracks_.empty())
@@ -263,9 +267,15 @@ void HitProcessor::update_track(ParticleId id) const
     G4Track& track = *tracks_[id.unchecked_get()];
     step_->SetTrack(&track);
 
-    // Copy data from track to post-step
+    if (G4StepPoint* pre_step = step_->GetPreStepPoint())
+    {
+        // Copy data from track to pre-step
+        G4ParticleDefinition const& pd = *track.GetParticleDefinition();
+        pre_step->SetCharge(pd.GetPDGCharge());
+    }
     if (G4StepPoint* post_step = step_->GetPostStepPoint())
     {
+        // Copy data from post-step to track
         track.SetGlobalTime(post_step->GetGlobalTime());
         track.SetPosition(post_step->GetPosition());
         track.SetKineticEnergy(post_step->GetKineticEnergy());

--- a/src/accel/detail/HitProcessor.hh
+++ b/src/accel/detail/HitProcessor.hh
@@ -19,6 +19,7 @@
 class G4LogicalVolume;
 class G4Step;
 class G4Navigator;
+class G4ParticleDefinition;
 class G4Track;
 class G4VSensitiveDetector;
 
@@ -54,11 +55,13 @@ class HitProcessor
     using StepStateDeviceRef = DeviceRef<StepStateData>;
     using SPConstVecLV
         = std::shared_ptr<const std::vector<G4LogicalVolume const*>>;
+    using VecParticle = std::vector<G4ParticleDefinition const*>;
     //!@}
 
   public:
     // Construct from volumes that have SDs and step selection
     HitProcessor(SPConstVecLV detector_volumes,
+                 VecParticle const& particles,
                  StepSelection const& selection,
                  bool locate_touchable);
 
@@ -84,13 +87,17 @@ class HitProcessor
 
     //! Temporary step
     std::unique_ptr<G4Step> step_;
-    //! Temporary track, required by some frameworks
-    std::unique_ptr<G4Track> track_;
+    //! Tracks for each particle type
+    std::vector<std::unique_ptr<G4Track>> tracks_;
     //! Navigator for finding points
     std::unique_ptr<G4Navigator> navi_;
     //! Geant4 reference-counted pointer to a G4VTouchable
     G4TouchableHandle touch_handle_;
 
+    //! Post-step selection for copying to track
+    StepPointSelection post_step_selection_;
+
+    void update_track(ParticleId id) const;
     bool update_touchable(Real3 const& pos,
                           Real3 const& dir,
                           G4LogicalVolume const* lv) const;

--- a/src/accel/detail/HitProcessor.hh
+++ b/src/accel/detail/HitProcessor.hh
@@ -77,6 +77,12 @@ class HitProcessor
     // Generate and call hits from a detector output (for testing)
     void operator()(DetectorStepOutput const& out) const;
 
+    // Access detector volume corresponding to an ID
+    inline G4LogicalVolume const* detector_volume(DetectorId) const;
+
+    // Access thread-local SD corresponding to an ID
+    inline G4VSensitiveDetector* detector(DetectorId) const;
+
   private:
     //! Detector volumes for navigation updating
     SPConstVecLV detector_volumes_;
@@ -100,8 +106,31 @@ class HitProcessor
     void update_track(ParticleId id) const;
     bool update_touchable(Real3 const& pos,
                           Real3 const& dir,
-                          G4LogicalVolume const* lv) const;
+                          G4LogicalVolume const* lv,
+                          G4VTouchable* touchable) const;
 };
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Access detector volume corresponding to an ID.
+ */
+G4LogicalVolume const* HitProcessor::detector_volume(DetectorId did) const
+{
+    CELER_EXPECT(did < detector_volumes_->size());
+    return (*detector_volumes_)[did.unchecked_get()];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access thread-local sensitive detector corresponding to an ID.
+ */
+G4VSensitiveDetector* HitProcessor::detector(DetectorId did) const
+{
+    CELER_EXPECT(did < detectors_.size());
+    return detectors_[did.unchecked_get()];
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/user/StepData.hh
+++ b/src/celeritas/user/StepData.hh
@@ -64,6 +64,8 @@ struct StepPointSelection
  * Which track properties to gather at every step.
  *
  * These should correspond to the data items in StepStateDataImpl.
+ *
+ * TODO: particle -> particle_id for consistency
  */
 struct StepSelection
 {

--- a/test/accel/SimpleSensitiveDetector.cc
+++ b/test/accel/SimpleSensitiveDetector.cc
@@ -10,8 +10,10 @@
 #include <iostream>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <G4LogicalVolume.hh>
+#include <G4ParticleDefinition.hh>
 #include <G4Step.hh>
 #include <G4TouchableHistory.hh>
+#include <G4Track.hh>
 
 #include "corecel/Assert.hh"
 #include "corecel/io/Repr.hh"
@@ -32,6 +34,11 @@ void SimpleHitsResult::print_expected() const
             "EXPECT_VEC_SOFT_EQ(expected_energy_deposition, "
             "result.energy_deposition);\n"
 
+            "static char const* const expected_particle[] = "
+         << repr(this->particle)
+         << ";\n"
+            "EXPECT_VEC_EQ(expected_particle, result.particle);\n"
+
             "static double const expected_pre_energy[] = "
          << repr(this->pre_energy)
          << ";\n"
@@ -42,7 +49,7 @@ void SimpleHitsResult::print_expected() const
          << ";\n"
             "EXPECT_VEC_SOFT_EQ(expected_pre_pos, result.pre_pos);\n"
 
-            "static char const * const expected_pre_physvol[] = "
+            "static char const* const expected_pre_physvol[] = "
          << repr(this->pre_physvol)
          << ";\n"
             "EXPECT_VEC_EQ(expected_pre_physvol, result.pre_physvol);\n"
@@ -70,6 +77,11 @@ bool SimpleSensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
 
     hits_.energy_deposition.push_back(step->GetTotalEnergyDeposit()
                                       / CLHEP::MeV);
+    if (auto* track = step->GetTrack())
+    {
+        hits_.particle.push_back(track->GetDefinition()->GetParticleName());
+    }
+
     hits_.pre_energy.push_back(pre_step->GetKineticEnergy() / CLHEP::MeV);
 
     for (int i : range(3))

--- a/test/accel/SimpleSensitiveDetector.hh
+++ b/test/accel/SimpleSensitiveDetector.hh
@@ -19,6 +19,7 @@ namespace test
 struct SimpleHitsResult
 {
     std::vector<double> energy_deposition;  // [MeV]
+    std::vector<std::string> particle;
     std::vector<double> pre_energy;  // [MeV]
     std::vector<double> pre_pos;  // [cm]
     std::vector<std::string> pre_physvol;


### PR DESCRIPTION
**CHAINED ON #835 **

This introduces a few new options for calling back from GPU to Geant4 sensitive detector classes. With the `track` option, a particle-type-dependent track will be used for the step, and post-step data will be copied to the track temporarily. A new `direction` attribute allows the setting of `MomentumDirection` for pre/post/track.

See #822 .