### PR TITLE
Add `screening_factor` to `ImportEmParameters`

### DIFF
--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -474,7 +474,7 @@ void print_em_params(ImportEmParameters const& em_params)
          << PEP_STREAM_PARAM(msc_range_factor)
          << PEP_STREAM_PARAM(msc_safety_factor)
          << PEP_STREAM_PARAM(msc_lambda_limit) << PEP_STREAM_BOOL(apply_cuts)
-         << endl;
+         << PEP_STREAM_PARAM(screening_factor) << endl;
 #undef PEP_STREAM_PARAM
 #undef PEP_STREAM_BOOL
 }

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -667,6 +667,7 @@ ImportEmParameters import_em_parameters()
     import.msc_safety_factor = g4.MscSafetyFactor();
     import.msc_lambda_limit = g4.MscLambdaLimit() / cm;
     import.apply_cuts = g4.ApplyCuts();
+    import.screening_factor = g4.ScreeningFactor();
 
     CELER_ENSURE(import);
     return import;

--- a/src/celeritas/io/ImportParameters.hh
+++ b/src/celeritas/io/ImportParameters.hh
@@ -43,8 +43,7 @@ struct ImportEmParameters
     double msc_lambda_limit{0.1};
     //! Kill secondaries below production cut
     bool apply_cuts{false};
-    //! Parameter used by the Coulomb scattering process for calculating
-    //! nuclear form factors (screening effect)
+    //! Nuclear screening factor for single/multiple Coulomb scattering
     double screening_factor{1};
 
     //! Whether parameters are assigned and valid

--- a/src/celeritas/io/ImportParameters.hh
+++ b/src/celeritas/io/ImportParameters.hh
@@ -43,13 +43,16 @@ struct ImportEmParameters
     double msc_lambda_limit{0.1};
     //! Kill secondaries below production cut
     bool apply_cuts{false};
+    //! TODO
+    double screening_factor{1};
 
     //! Whether parameters are assigned and valid
     explicit operator bool() const
     {
         return linear_loss_limit > 0 && lowest_electron_energy > 0
                && msc_range_factor > 0 && msc_range_factor < 1
-               && msc_safety_factor >= 0.1 && msc_lambda_limit > 0;
+               && msc_safety_factor >= 0.1 && msc_lambda_limit > 0
+               && screening_factor > 0;
     }
 };
 

--- a/src/celeritas/io/ImportParameters.hh
+++ b/src/celeritas/io/ImportParameters.hh
@@ -43,7 +43,8 @@ struct ImportEmParameters
     double msc_lambda_limit{0.1};
     //! Kill secondaries below production cut
     bool apply_cuts{false};
-    //! TODO
+    //! Parameter used by the Coulomb scattering process for calculating
+    //! nuclear form factors (screening effect)
     double screening_factor{1};
 
     //! Whether parameters are assigned and valid


### PR DESCRIPTION
This PR adds the `G4EmParameters::ScreeningFactor` parameter to `ImportData` as it is a requirement for the Coulomb scattering process.