### PR TITLE
Document how to link loadable shared libraries with Celeritas

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -39,6 +39,30 @@ of ``target_link_libraries`` with a customized version::
   include(CeleritasLibrary)
   celeritas_target_link_libraries(mycode PUBLIC Celeritas::celeritas)
 
+As ``celeritas_target_link_libraries`` decays to ``target_link_libraries`` if
+CUDA and VecGeom are not used, you can use it safely to link nearly all targets consuming
+Celeritas, or Celeritas consumers, in your project to track the appropriate sequence
+of linking for the final application whether CPU-only or CUDA enabled::
+
+  add_library(myconsumer SHARED ...)
+  celeritas_target_link_libraries(myconsumer PUBLIC Celeritas::celeritas)
+
+  add_executable(myapplication ...)
+  celeritas_target_link_libraries(myapplication PRIVATE myconsumer)
+
+The one exception to this is when your project builds a shared library that will
+be loaded into an application at runtime (e.g. via ``dlopen``). To correctly link
+targets of this type, you should use ``target_link_libraries`` and link to both
+the primary Celeritas target and its device code counterpart::
+
+  add_library(myplugin MODULE ...)
+  target_link_libraries(myplugin PRIVATE Celeritas::celeritas $<TARGET_NAME_IF_EXISTS:Celeritas::celeritas_final>)
+
+Celeritas device code counterpart target names are always the name of the primary
+target appended with ``_final``. They are only present if Celeritas was built with CUDA
+support so it is recommended to use the CMake generator expression above to support
+CUDA or CPU-only builds transparently.
+
 The :ref:`example_minimal` example demonstrates how to use Celeritas as a
 library with a short standalone CMake project.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -32,35 +32,35 @@ and if VecGeom or CUDA are disabled a single line to link::
 
    target_link_libraries(mycode PUBLIC Celeritas::celeritas)
 
-Because of complexities involving CUDA Relocatable Device Code, linking when
-using both CUDA and VecGeom requires an additional include and the replacement
-of ``target_link_libraries`` with a customized version::
+Because of complexities involving CUDA Relocatable Device Code, consuming Celeritas
+with CUDA and VecGeom support requires an additional include and the use of wrappers 
+around CMake's target commands::
 
   include(CeleritasLibrary)
+  celeritas_add_executable(mycode ...)
   celeritas_target_link_libraries(mycode PUBLIC Celeritas::celeritas)
 
-As ``celeritas_target_link_libraries`` decays to ``target_link_libraries`` if
-CUDA and VecGeom are not used, you can use it safely to link nearly all targets consuming
-Celeritas in your project to track the appropriate sequence of linking for the 
-final application whether CPU-only or CUDA enabled::
+As the ``celeritas_...`` functions decay to the wrapped CMake commands if CUDA and VecGeom
+you can use them to safely build and link nearly all targets consuming
+Celeritas in your project. This provides tracking of the appropriate sequence of linking for the 
+final application whether it uses CUDA code or not, and whether Celeritas is CPU-only or CUDA enabled::
 
-  add_library(myconsumer SHARED ...)
+  celeritas_add_library(myconsumer SHARED ...)
   celeritas_target_link_libraries(myconsumer PUBLIC Celeritas::celeritas)
 
-  add_executable(myapplication ...)
+  celeritas_add_executable(myapplication ...)
   celeritas_target_link_libraries(myapplication PRIVATE myconsumer)
 
 If your project builds shared libraries that are intended to be loaded at application
 runtime (e.g. via ``dlopen``), you should prefer use the the CMake ``MODULE`` target type::
 
-  add_library(myplugin MODULE ...)
+  celeritas_add_library(myplugin MODULE ...)
   celeritas_target_link_libraries(myplugin PRIVATE Celeritas::celeritas)
 
 This is recommended as ``celeritas_target_link_libraries`` understands these as a final
 target for which all device symbols require resolving. If you are forced to use the ``SHARED`` 
-target type for plugin libraries (e.g. via your project), then to correctly link these
-for runtime loading you must explicitly link to both the primary Celeritas target and 
-its device code counterpart::
+target type for plugin libraries (e.g. via your project), then these should be declared with
+the bare CMake commands with linking to both the primary Celeritas target and its device code counterpart::
 
   add_library(mybadplugin SHARED ...)
   target_link_libraries(mybadplugin PRIVATE Celeritas::celeritas $<TARGET_NAME_IF_EXISTS:Celeritas::celeritas_final>)

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -41,8 +41,8 @@ of ``target_link_libraries`` with a customized version::
 
 As ``celeritas_target_link_libraries`` decays to ``target_link_libraries`` if
 CUDA and VecGeom are not used, you can use it safely to link nearly all targets consuming
-Celeritas, or Celeritas consumers, in your project to track the appropriate sequence
-of linking for the final application whether CPU-only or CUDA enabled::
+Celeritas in your project to track the appropriate sequence of linking for the 
+final application whether CPU-only or CUDA enabled::
 
   add_library(myconsumer SHARED ...)
   celeritas_target_link_libraries(myconsumer PUBLIC Celeritas::celeritas)
@@ -50,13 +50,18 @@ of linking for the final application whether CPU-only or CUDA enabled::
   add_executable(myapplication ...)
   celeritas_target_link_libraries(myapplication PRIVATE myconsumer)
 
-The one exception to this is when your project builds a shared library that will
-be loaded into an application at runtime (e.g. via ``dlopen``). To correctly link
-targets of this type, you should use ``target_link_libraries`` and link to both
-the primary Celeritas target and its device code counterpart::
+The two exceptions to this are when your project builds a CMake ``SHARED`` library that:
 
-  add_library(myplugin MODULE ...)
-  target_link_libraries(myplugin PRIVATE Celeritas::celeritas $<TARGET_NAME_IF_EXISTS:Celeritas::celeritas_final>)
+* will be loaded into an application at runtime (e.g. via ``dlopen``).
+* is intended to be linked to by downstream projects that do not use Celeritas
+
+In the first case the CMake target type should be changed to ``MODULE`` for which
+CMake and ``celeritas_target_link_libraries`` correctly handle device linking. For
+the second case, or if you cannot use ``MODULE``, you must use ``target_link_libraries`` 
+and link to both the primary Celeritas target and its device code counterpart::
+
+  add_library(mylibrary SHARED ...)
+  target_link_libraries(mylibrary PRIVATE Celeritas::celeritas $<TARGET_NAME_IF_EXISTS:Celeritas::celeritas_final>)
 
 Celeritas device code counterpart target names are always the name of the primary
 target appended with ``_final``. They are only present if Celeritas was built with CUDA

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -59,11 +59,14 @@ runtime (e.g. via ``dlopen``), you should prefer use the the CMake ``MODULE`` ta
 
 This is recommended as ``celeritas_target_link_libraries`` understands these as a final
 target for which all device symbols require resolving. If you are forced to use the ``SHARED`` 
-target type for plugin libraries (e.g. via your project), then these should be declared with
-the bare CMake commands with linking to both the primary Celeritas target and its device code counterpart::
+target type for plugin libraries (e.g. via your project's own wrapper functions), then these should 
+be declared with the CMake or project-specific commands with linking to both the primary Celeritas
+target and its device code counterpart::
 
   add_library(mybadplugin SHARED ...)
+  # ... or myproject_add_library(mybadplugin ...)
   target_link_libraries(mybadplugin PRIVATE Celeritas::celeritas $<TARGET_NAME_IF_EXISTS:Celeritas::celeritas_final>)
+  # ... or otherwise declare the plugin as requiring linking to the two targets
 
 Celeritas device code counterpart target names are always the name of the primary
 target appended with ``_final``. They are only present if Celeritas was built with CUDA


### PR DESCRIPTION
Integration of Celeritas in ATLAS's FullSimLight required it to be used in and linked from a shared library loaded by the FullSimLight application at runtime (a "plugin"). `celeritas_target_link_libraries` on the plugin library did not result in the needed "_final" device code library being linked to it, leading to undefined symbols at load time. Traced to `celeritas_target_link_libraries` not considering a shared library as an endpoint required full device link resolution.

As requested in offline discussion, this adds some brief documentation on this use case, and the workaround. I'm not sure if it's too verbose, or equally not enough detail 😆, but easy to address this in review.