### PR TITLE
Add safety cache and evaluate outside of MSC kernels

### DIFF
--- a/src/celeritas/ext/GeantGeoParams.cc
+++ b/src/celeritas/ext/GeantGeoParams.cc
@@ -210,6 +210,7 @@ void GeantGeoParams::build_tracking()
     CELER_ASSERT(geo_man);
     if (!geo_man->IsGeometryClosed())
     {
+        CELER_LOG(debug) << "Initializing tracking information";
         geo_man->CloseGeometry(
             /* optimize = */ true, /* verbose = */ false, host_ref_.world);
         closed_geometry_ = true;

--- a/src/celeritas/ext/VecgeomParams.cc
+++ b/src/celeritas/ext/VecgeomParams.cc
@@ -45,7 +45,7 @@ namespace celeritas
  */
 VecgeomParams::VecgeomParams(std::string const& filename)
 {
-    CELER_LOG(status) << "Loading VecGeom geometry from GDML at " << filename;
+    CELER_LOG(info) << "Loading VecGeom geometry from GDML at " << filename;
     if (!ends_with(filename, ".gdml"))
     {
         CELER_LOG(warning) << "Expected '.gdml' extension for GDML input";
@@ -189,7 +189,7 @@ auto VecgeomParams::find_volumes(std::string const& name) const
 void VecgeomParams::build_tracking()
 {
     CELER_EXPECT(vecgeom::GeoManager::Instance().GetWorld());
-    CELER_LOG(status) << "Initializing tracking information";
+    CELER_LOG(debug) << "Initializing tracking information";
     ScopedMem record_mem("VecgeomParams.build_tracking");
     {
         ScopedTimeAndRedirect time_and_output_("vecgeom::ABBoxManager");

--- a/src/celeritas/geo/SafetyCacheData.hh
+++ b/src/celeritas/geo/SafetyCacheData.hh
@@ -1,0 +1,79 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/geo/SafetyCacheData.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/data/Collection.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "corecel/sys/ThreadId.hh"
+#include "celeritas/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+//! Initializer sets a flag
+struct SafetyCacheInitializer
+{
+    bool use_safety{true};
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Store and access the safety cache.
+ */
+template<Ownership W, MemSpace M>
+struct SafetyCacheStateData
+{
+    //// TYPES ////
+
+    template<class T>
+    using Items = celeritas::StateCollection<T, W, M>;
+
+    //// DATA ////
+
+    Items<real_type> radius;
+    Items<Real3> origin;
+
+    //// METHODS ////
+
+    //! Check whether the interface is assigned
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return !radius.empty() && origin.size() == radius.size();
+    }
+
+    //! State size
+    CELER_FUNCTION ThreadId::size_type size() const { return radius.size(); }
+
+    //! Assign from another set of data
+    template<Ownership W2, MemSpace M2>
+    SafetyCacheStateData& operator=(SafetyCacheStateData<W2, M2>& other)
+    {
+        CELER_EXPECT(other);
+        radius = other.radius;
+        origin = other.origin;
+        return *this;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Resize safety cache states.
+ */
+template<MemSpace M>
+void resize(SafetyCacheStateData<Ownership::value, M>* data, size_type size)
+{
+    CELER_EXPECT(size > 0);
+    resize(&data->radius, size);
+    resize(&data->origin, size);
+    CELER_ENSURE(*data);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/geo/SafetyCacheTrackView.hh
+++ b/src/celeritas/geo/SafetyCacheTrackView.hh
@@ -80,10 +80,11 @@ class SafetyCacheTrackView : public detail::SafetyCacheTrackViewBase
     //! Whether the given point is inside the safety sphere
     using Base::is_inside;
 
-    //! Calculate the cached safety distance at the current position
+    //! Calculate the cached safety distance at the current position (must be
+    //! inside)
     CELER_FIF real_type safety() const
     {
-        return Base::calc_safety(geo_.pos());
+        return Base::calc_safety_inside(geo_.pos());
     }
 
     // Calculate or return the safety up to the given distance
@@ -160,7 +161,7 @@ class SafetyCacheTrackView<GTV const&> : public detail::SafetyCacheTrackViewBase
     //! Calculate the cached safety distance at the current position
     CELER_FIF real_type safety() const
     {
-        return Base::calc_safety(geo_.pos());
+        return Base::calc_safety_inside(geo_.pos());
     }
 
     //!@{

--- a/src/celeritas/geo/SafetyCacheTrackView.hh
+++ b/src/celeritas/geo/SafetyCacheTrackView.hh
@@ -1,0 +1,269 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/geo/SafetyCacheTrackView.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "GeoTrackView.hh"
+#include "detail/SafetyCacheTrackViewBase.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+//! \cond
+// Local convenience declaration
+#define CELER_FIF CELER_FORCEINLINE_FUNCTION
+//! \endcond
+
+//---------------------------------------------------------------------------//
+/*!
+ * Wrap geometry functions that use the safety distance.
+ *
+ * This class stores a persistent safety sphere (origin plus radius) that is
+ * updated as needed by the geometry. The view does *not* support direct
+ * movement along a straight line but supports moving to arbitrary distances
+ * within the safety sphere.
+ *
+ * Internally the radius has a negative value if safety calculations are not
+ * needed for the current track, zero if the safety is on the boundary or has
+ * not been updated, and positive for the typical case where the track is not
+ * on a boundary.
+ *
+ * There are two specializations for this class:
+ * - mutable (or owning) track view can update the safety and geometry
+ * - const reference track view is used for *only* checking the safety
+ */
+template<class GTV>
+class SafetyCacheTrackView : public detail::SafetyCacheTrackViewBase
+{
+    using Base = detail::SafetyCacheTrackViewBase;
+
+  public:
+    //!@{
+    //! \name Type aliases
+    using StateRef = NativeRef<SafetyCacheStateData>;
+    using GeoTrackViewT = GTV;
+    using Initializer_t = SafetyCacheInitializer;
+    using DetailedInitializer = Base::DetailedInitializer;
+    //!@}
+
+  public:
+    //! Construct with state data and geometry
+    CELER_FUNCTION SafetyCacheTrackView(GeoTrackViewT geo,
+                                        StateRef const& state,
+                                        TrackSlotId tid)
+        : Base{state, tid}, geo_{geo}
+    {
+    }
+
+    //! Initialize with a flag for safety calculation
+    CELER_FUNCTION SafetyCacheTrackView& operator=(Initializer_t const& init)
+    {
+        Base::operator=(init);
+        return *this;
+    }
+
+    //! Initialize from another safety cache
+    CELER_FUNCTION SafetyCacheTrackView&
+    operator=(DetailedInitializer const& init)
+    {
+        Base::operator=(init);
+        return *this;
+    }
+
+    //! Whether the safety is being calculated for this track type
+    using Base::use_safety;
+
+    //! Whether the given point is inside the safety sphere
+    using Base::is_inside;
+
+    //! Calculate the cached safety distance at the current position
+    CELER_FIF real_type safety() const
+    {
+        return Base::calc_safety(geo_.pos());
+    }
+
+    // Calculate or return the safety up to the given distance
+    inline CELER_FUNCTION real_type find_safety(real_type max_safety);
+
+    // Find the distance to the next boundary
+    inline CELER_FUNCTION Propagation find_next_step(real_type max_distance);
+
+    // Move within the safety distance to a specific point
+    inline CELER_FUNCTION void move_internal(Real3 const& pos);
+
+    // Move to the boundary in preparation for crossing it
+    inline CELER_FUNCTION void move_to_boundary();
+
+    //!@{
+    //! Forward state from underlying GeoTrackView
+    CELER_FIF Real3 const& pos() const { return geo_.pos(); }
+    CELER_FIF Real3 const& dir() const { return geo_.dir(); }
+    CELER_FIF bool is_outside() const { return geo_.is_outside(); }
+    CELER_FIF bool is_on_boundary() const { return geo_.is_on_boundary(); }
+    CELER_FIF void set_dir(Real3 const& d) { return geo_.set_dir(d); }
+    //!@}
+
+  private:
+    GeoTrackViewT geo_;
+};
+
+//---------------------------------------------------------------------------//
+//! Read-only specialization for accessing safety
+template<class GTV>
+class SafetyCacheTrackView<GTV const&> : public detail::SafetyCacheTrackViewBase
+{
+    using Base = detail::SafetyCacheTrackViewBase;
+
+  public:
+    //!@{
+    //! \name Type aliases
+    using StateRef = NativeRef<SafetyCacheStateData>;
+    using GeoTrackViewT = GTV const&;
+    using Initializer_t = SafetyCacheInitializer;
+    using DetailedInitializer = Base::DetailedInitializer;
+    //!@}
+
+  public:
+    //! Construct with state data and geometry
+    CELER_FUNCTION SafetyCacheTrackView(GeoTrackViewT geo,
+                                        StateRef const& state,
+                                        TrackSlotId tid)
+        : Base{state, tid}, geo_{geo}
+    {
+    }
+
+    //! Initialize with a flag for safety calculation
+    CELER_FUNCTION SafetyCacheTrackView& operator=(Initializer_t const& init)
+    {
+        Base::operator=(init);
+        return *this;
+    }
+
+    //! Initialize from another safety cache
+    CELER_FUNCTION SafetyCacheTrackView&
+    operator=(DetailedInitializer const& init)
+    {
+        Base::operator=(init);
+        return *this;
+    }
+
+    //! Whether the safety is being calculated for this track type
+    using Base::use_safety;
+
+    //! Whether the given point is inside the safety sphere
+    using Base::is_inside;
+
+    //! Calculate the cached safety distance at the current position
+    CELER_FIF real_type safety() const
+    {
+        return Base::calc_safety(geo_.pos());
+    }
+
+    //!@{
+    //! Forward state from underlying GeoTrackView
+    CELER_FIF Real3 const& pos() const { return geo_.pos(); }
+    CELER_FIF Real3 const& dir() const { return geo_.dir(); }
+    CELER_FIF bool is_outside() const { return geo_.is_outside(); }
+    CELER_FIF bool is_on_boundary() const { return geo_.is_on_boundary(); }
+    //!@}
+
+  private:
+    GeoTrackViewT geo_;
+};
+
+#undef CELER_FIF
+
+//---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+
+template<class GTV>
+CELER_FUNCTION SafetyCacheTrackView(GTV&&,
+                                    NativeRef<SafetyCacheStateData> const&,
+                                    TrackSlotId tid)
+    ->SafetyCacheTrackView<GTV>;
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Update the safety from the geometry if current is less than this value.
+ */
+template<class GTV>
+inline CELER_FUNCTION real_type
+SafetyCacheTrackView<GTV>::find_safety(real_type max_safety)
+{
+    CELER_EXPECT(max_safety > 0);
+    CELER_EXPECT(this->use_safety());
+
+    real_type result = this->calc_safety(geo_.pos());
+    if (result >= max_safety)
+    {
+        return result;
+    }
+
+    // Calculate new safety
+    result = geo_.find_safety(max_safety);
+    CELER_EXPECT(result >= 0);
+
+    // Save it and the position
+    this->reset(geo_.pos(), result);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Update the safety from the geometry if current is less than this value.
+ */
+template<class GTV>
+inline CELER_FUNCTION Propagation
+SafetyCacheTrackView<GTV>::find_next_step(real_type distance)
+{
+    CELER_EXPECT(distance > 0);
+    CELER_EXPECT(this->use_safety());
+    if (distance < this->safety())
+    {
+        return Propagation::from_miss(distance);
+    }
+    return geo_.find_next_step(distance);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Move within the volume to a nearby position.
+ *
+ * The other position *must* be within the safety distance.
+ */
+template<class GTV>
+inline CELER_FUNCTION void
+SafetyCacheTrackView<GTV>::move_internal(Real3 const& pos)
+{
+    CELER_EXPECT(this->use_safety());
+    CELER_EXPECT(this->is_inside(pos));
+
+    geo_.move_internal(pos);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Move to the next boundary.
+ *
+ * The other position *must* be within the safety distance.
+ */
+template<class GTV>
+inline CELER_FUNCTION void SafetyCacheTrackView<GTV>::move_to_boundary()
+{
+    CELER_EXPECT(this->use_safety());
+
+    // Move to boundary
+    geo_.move_to_boundary();
+    // Reset the safety to zero
+    this->reset();
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/geo/detail/SafetyCacheTrackViewBase.hh
+++ b/src/celeritas/geo/detail/SafetyCacheTrackViewBase.hh
@@ -1,0 +1,176 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/geo/detail/SafetyCacheTrackViewBase.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cmath>
+
+#include "corecel/Macros.hh"
+#include "corecel/math/ArrayUtils.hh"
+
+#include "../SafetyCacheData.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Provide common functionality for SafetyCacheTrackView.
+ */
+class SafetyCacheTrackViewBase
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Initializer_t = SafetyCacheInitializer;
+    using StateRef = NativeRef<SafetyCacheStateData>;
+    //!@}
+
+    //! Helper struct for initializing from an existing geometry state
+    struct DetailedInitializer
+    {
+        SafetyCacheTrackViewBase const& other;  //!< Existing safety cache
+        bool use_safety{true};
+    };
+
+  public:
+    //! Construct with state reference
+    CELER_FUNCTION
+    SafetyCacheTrackViewBase(StateRef const& state, TrackSlotId tid)
+        : state_{state}, tid_{tid}
+    {
+    }
+
+    //! Initialize with a flag for safety calculation
+    CELER_FUNCTION SafetyCacheTrackViewBase&
+    operator=(Initializer_t const& init)
+    {
+        this->reset(init.use_safety);
+        return *this;
+    }
+
+    // Initialize from another safety cache
+    inline CELER_FUNCTION SafetyCacheTrackViewBase&
+    operator=(DetailedInitializer const&);
+
+    //! Whether the safety is being calculated for this track type
+    CELER_FORCEINLINE_FUNCTION bool use_safety() const
+    {
+        return state_.radius[tid_] >= 0;
+    }
+
+    //! Whether the given position is inside the safety sphere
+    inline CELER_FUNCTION bool is_inside(Real3 const& pos) const;
+
+  protected:
+    //! Clear the safety and flag if not available
+    CELER_FORCEINLINE_FUNCTION void reset(bool use_safety = true)
+    {
+        state_.radius[tid_] = (use_safety ? 0 : -1);
+    }
+
+    //! Update the safety
+    CELER_FORCEINLINE_FUNCTION void reset(Real3 const& origin, real_type radius)
+    {
+        CELER_EXPECT(this->use_safety());
+        return this->reset_impl(origin, radius);
+    }
+
+    //! Get the cached safety sphere's radius
+    CELER_FORCEINLINE_FUNCTION real_type radius() const
+    {
+        CELER_EXPECT(this->use_safety());
+        return state_.radius[tid_];
+    }
+
+    //! Get the cache safety sphere's origin
+    CELER_FORCEINLINE_FUNCTION Real3 const& origin() const
+    {
+        return state_.origin[tid_];
+    }
+
+    // Calculate the distance to the edge of the current safety sphere
+    inline CELER_FUNCTION real_type calc_safety(Real3 const& pos) const;
+
+  private:
+    StateRef const& state_;
+    TrackSlotId tid_;
+
+    //! Update the safety (always allowed when constructing)
+    CELER_FORCEINLINE_FUNCTION void
+    reset_impl(Real3 const& origin, real_type radius)
+    {
+        CELER_EXPECT(radius >= 0);
+        state_.radius[tid_] = radius;
+        state_.origin[tid_] = origin;
+    }
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Copy safety from another view.
+ */
+CELER_FUNCTION auto
+SafetyCacheTrackViewBase::operator=(DetailedInitializer const& init)
+    -> SafetyCacheTrackViewBase&
+{
+    if (!init.use_safety || !init.other.use_safety())
+    {
+        // We don't need the safety or one isn't available
+        this->reset(init.use_safety);
+    }
+    else if (this != &init.other)
+    {
+        // Copy a valid safety from a different safety cache view
+        this->reset_impl(init.other.origin(), init.other.radius());
+    }
+    return *this;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the distance from the point to the edge of the safety sphere.
+ *
+ * This is just the distance from the given point to the edge of the safety
+ * sphere.
+ *
+ * \note The input position must be within the safety sphere.
+ */
+CELER_FUNCTION bool SafetyCacheTrackViewBase::is_inside(Real3 const& pos) const
+{
+    CELER_EXPECT(this->use_safety());
+    real_type to_origin_sq = celeritas::distance_sq(this->origin(), pos);
+    return to_origin_sq <= ipow<2>(this->radius());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the distance from the point to the edge of the safety sphere.
+ *
+ * This is just the distance from the given point to the edge of the safety
+ * sphere.
+ *
+ * \note The input position must be within the safety sphere.
+ */
+CELER_FUNCTION real_type
+SafetyCacheTrackViewBase::calc_safety(Real3 const& pos) const
+{
+    CELER_EXPECT(this->use_safety());
+    if (this->radius() == 0)
+        return 0;
+
+    real_type to_origin = celeritas::distance(this->origin(), pos);
+    CELER_EXPECT(to_origin <= this->radius());
+    return this->radius() - to_origin;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/geo/detail/SafetyCacheTrackViewBase.hh
+++ b/src/celeritas/geo/detail/SafetyCacheTrackViewBase.hh
@@ -97,6 +97,10 @@ class SafetyCacheTrackViewBase
     // Calculate the distance to the edge of the current safety sphere
     inline CELER_FUNCTION real_type calc_safety(Real3 const& pos) const;
 
+    // Calculate the distance to the edge of the current safety sphere when
+    // inside
+    inline CELER_FUNCTION real_type calc_safety_inside(Real3 const& pos) const;
+
   private:
     StateRef const& state_;
     TrackSlotId tid_;
@@ -155,9 +159,9 @@ CELER_FUNCTION bool SafetyCacheTrackViewBase::is_inside(Real3 const& pos) const
  * Calculate the distance from the point to the edge of the safety sphere.
  *
  * This is just the distance from the given point to the edge of the safety
- * sphere.
- *
- * \note The input position must be within the safety sphere.
+ * sphere. If the current point is *outside* the sphere (because e.g. the
+ * position was updated *without* using the safety cache) then the result will
+ * be negative.
  */
 CELER_FUNCTION real_type
 SafetyCacheTrackViewBase::calc_safety(Real3 const& pos) const
@@ -167,10 +171,15 @@ SafetyCacheTrackViewBase::calc_safety(Real3 const& pos) const
         return 0;
 
     real_type to_origin = celeritas::distance(this->origin(), pos);
-    CELER_EXPECT(to_origin <= this->radius());
     return this->radius() - to_origin;
 }
-
+CELER_FUNCTION real_type
+SafetyCacheTrackViewBase::calc_safety_inside(Real3 const& pos) const
+{
+    real_type sft = this->calc_safety(pos);
+    CELER_ENSURE(sft >= 0);
+    return sft;
+}
 //---------------------------------------------------------------------------//
 }  // namespace detail
 }  // namespace celeritas

--- a/src/celeritas/global/CoreTrackData.cc
+++ b/src/celeritas/global/CoreTrackData.cc
@@ -33,6 +33,7 @@ void resize(CoreStateData<Ownership::value, M>* state,
     // Geant4 state is stream-local
     resize(&state->geometry, params.geometry, stream_id, size);
 #endif
+    resize(&state->safety_cache, size);
     resize(&state->materials, params.materials, size);
     resize(&state->particles, params.particles, size);
     resize(&state->physics, params.physics, size);

--- a/src/celeritas/global/CoreTrackData.hh
+++ b/src/celeritas/global/CoreTrackData.hh
@@ -12,6 +12,7 @@
 #include "celeritas/Types.hh"
 #include "celeritas/geo/GeoData.hh"
 #include "celeritas/geo/GeoMaterialData.hh"
+#include "celeritas/geo/SafetyCacheData.hh"
 #include "celeritas/mat/MaterialData.hh"
 #include "celeritas/phys/CutoffData.hh"
 #include "celeritas/phys/ParticleData.hh"
@@ -110,6 +111,7 @@ struct CoreStateData
     using ThreadItems = Collection<T, W, M, ThreadId>;
 
     GeoStateData<W, M> geometry;
+    SafetyCacheStateData<W, M> safety_cache;
     MaterialStateData<W, M> materials;
     ParticleStateData<W, M> particles;
     PhysicsStateData<W, M> physics;
@@ -127,8 +129,8 @@ struct CoreStateData
     //! Whether the data are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return geometry && materials && particles && physics && rng && sim
-               && init && stream_id;
+        return geometry && safety_cache && materials && particles && physics
+               && rng && sim && init && stream_id;
     }
 
     //! Assign from another set of data
@@ -137,6 +139,7 @@ struct CoreStateData
     {
         CELER_EXPECT(other);
         geometry = other.geometry;
+        safety_cache = other.safety_cache;
         materials = other.materials;
         particles = other.particles;
         physics = other.physics;

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -10,6 +10,7 @@
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/geo/GeoMaterialView.hh"
 #include "celeritas/geo/GeoTrackView.hh"
+#include "celeritas/geo/SafetyCacheTrackView.hh"
 #include "celeritas/mat/MaterialTrackView.hh"
 #include "celeritas/phys/CutoffView.hh"
 #include "celeritas/phys/ParticleTrackView.hh"
@@ -46,6 +47,15 @@ class CoreTrackView
 
     // Return a geometry view
     inline CELER_FUNCTION GeoTrackView make_geo_view() const;
+
+    // Return a safety cache view that owns a geometry track view
+    inline CELER_FUNCTION SafetyCacheTrackView<GeoTrackView>
+    make_safety_cache_view() const;
+
+    // Return a safety cache view from an existing geometry track view
+    template<class GTV>
+    inline CELER_FUNCTION SafetyCacheTrackView<GTV>
+    make_safety_cache_view(GTV&& geo_view) const;
 
     // Return a geometry-material view
     inline CELER_FUNCTION GeoMaterialView make_geo_material_view() const;
@@ -127,6 +137,29 @@ CELER_FUNCTION auto CoreTrackView::make_geo_view() const -> GeoTrackView
 {
     return GeoTrackView{
         params_.geometry, states_.geometry, this->track_slot_id()};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a safety cache view from an existing geometry view.
+ */
+CELER_FUNCTION auto CoreTrackView::make_safety_cache_view() const
+    -> SafetyCacheTrackView<GeoTrackView>
+{
+    return this->make_safety_cache_view(this->make_geo_view());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a safety cache view from an existing geometry view.
+ */
+template<class GTV>
+CELER_FUNCTION auto CoreTrackView::make_safety_cache_view(GTV&& geo_view) const
+    -> SafetyCacheTrackView<GTV>
+{
+    return SafetyCacheTrackView{::celeritas::forward<GTV>(geo_view),
+                                states_.safety_cache,
+                                this->track_slot_id()};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStep.hh
+++ b/src/celeritas/global/alongstep/AlongStep.hh
@@ -13,6 +13,8 @@
 #include "detail/ElossApplier.hh"  // IWYU pragma: associated
 #include "detail/MscApplier.hh"  // IWYU pragma: associated
 #include "detail/MscStepLimitApplier.hh"  // IWYU pragma: associated
+#include "detail/PostStepSafetyCalculator.hh"  // IWYU pragma: associated
+#include "detail/PreStepSafetyCalculator.hh"  // IWYU pragma: associated
 #include "detail/PropagationApplier.hh"  // IWYU pragma: associated
 #include "detail/TimeUpdater.hh"  // IWYU pragma: associated
 #include "detail/TrackUpdater.hh"  // IWYU pragma: associated
@@ -51,7 +53,9 @@ CELER_FUNCTION void
 AlongStep<MH, MP, EH>::operator()(CoreTrackView const& track)
 {
     detail::MscStepLimitApplier{msc}(track);
+    detail::PreStepSafetyCalculator{msc}(track);
     detail::PropagationApplier{make_propagator}(track);
+    detail::PostStepSafetyCalculator{msc}(track);
     detail::MscApplier{msc}(track);
     detail::TimeUpdater{}(track);
     detail::ElossApplier{eloss}(track);

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cc
@@ -15,8 +15,9 @@
 #include "celeritas/global/TrackExecutor.hh"
 
 #include "AlongStep.hh"  // IWYU pragma: associated
-#include "detail/AlongStepNeutralImpl.hh"  // IWYU pragma: associated
 #include "detail/LinearPropagatorFactory.hh"  // IWYU pragma: associated
+#include "detail/NoELoss.hh"  // IWYU pragma: associated
+#include "detail/NoMsc.hh"  // IWYU pragma: associated
 
 namespace celeritas
 {

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
@@ -12,8 +12,10 @@
 #include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackExecutor.hh"
 
-#include "detail/AlongStepNeutralImpl.hh"
+#include "AlongStep.hh"
 #include "detail/LinearPropagatorFactory.hh"
+#include "detail/NoELoss.hh"
+#include "detail/NoMsc.hh"
 
 namespace celeritas
 {

--- a/src/celeritas/global/alongstep/detail/NoELoss.hh
+++ b/src/celeritas/global/alongstep/detail/NoELoss.hh
@@ -1,18 +1,14 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/global/alongstep/detail/AlongStepNeutralImpl.hh
+//! \file celeritas/global/alongstep/detail/NoELoss.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
-#include "corecel/Types.hh"
 #include "corecel/math/Quantity.hh"
-
-#include "../AlongStep.hh"
 
 namespace celeritas
 {
@@ -21,27 +17,6 @@ class CoreTrackView;
 
 namespace detail
 {
-//---------------------------------------------------------------------------//
-/*!
- * Helper class for along-step kernel when no MSC is in use.
- */
-struct NoMsc
-{
-    //! MSC never applies to the current track
-    CELER_FUNCTION bool
-    is_applicable(CoreTrackView const&, real_type step) const
-    {
-        CELER_ASSERT(step > 0);
-        return false;
-    }
-
-    //! No updates needed to the physical and geometric step lengths
-    CELER_FUNCTION void limit_step(CoreTrackView const&, StepLimit*) const {}
-
-    //! MSC is never applied
-    CELER_FUNCTION void apply_step(CoreTrackView const&, StepLimit*) const {}
-};
-
 //---------------------------------------------------------------------------//
 /*!
  * Class that returns zero energy loss.

--- a/src/celeritas/global/alongstep/detail/NoMsc.hh
+++ b/src/celeritas/global/alongstep/detail/NoMsc.hh
@@ -32,11 +32,23 @@ struct NoMsc
         return false;
     }
 
+    //! Get the maximum required safety radius before step limiting
+    CELER_FUNCTION real_type safety_pre(CoreTrackView const&) const
+    {
+        return 0;
+    }
+
     //! No updates needed to the physical and geometric step lengths
     CELER_FUNCTION void limit_step(CoreTrackView const&, StepLimit*) const {}
 
     //! MSC is never applied
     CELER_FUNCTION void apply_step(CoreTrackView const&, StepLimit*) const {}
+
+    //! Get the maximum required safety radius after step limiting
+    CELER_FUNCTION real_type safety_post(CoreTrackView const&) const
+    {
+        return 0;
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/detail/NoMsc.hh
+++ b/src/celeritas/global/alongstep/detail/NoMsc.hh
@@ -1,0 +1,44 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/alongstep/detail/NoMsc.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+class CoreTrackView;
+struct StepLimit;
+
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Helper class for along-step kernel when no MSC is in use.
+ */
+struct NoMsc
+{
+    //! MSC never applies to the current track
+    CELER_FUNCTION bool
+    is_applicable(CoreTrackView const&, real_type step) const
+    {
+        CELER_ASSERT(step > 0);
+        return false;
+    }
+
+    //! No updates needed to the physical and geometric step lengths
+    CELER_FUNCTION void limit_step(CoreTrackView const&, StepLimit*) const {}
+
+    //! MSC is never applied
+    CELER_FUNCTION void apply_step(CoreTrackView const&, StepLimit*) const {}
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/global/alongstep/detail/PostStepSafetyCalculator.hh
+++ b/src/celeritas/global/alongstep/detail/PostStepSafetyCalculator.hh
@@ -1,0 +1,62 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/alongstep/detail/PostStepSafetyCalculator.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "celeritas/global/CoreTrackView.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate safety distance at the end of a step.
+ *
+ * TODO: this is currently *only* for MSC.
+ */
+template<class MH>
+struct PostStepSafetyCalculator
+{
+    inline CELER_FUNCTION void operator()(CoreTrackView const& track);
+
+    MH msc;
+};
+
+//---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class MH>
+CELER_FUNCTION PostStepSafetyCalculator(MH&&)->PostStepSafetyCalculator<MH>;
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+
+template<class MH>
+CELER_FUNCTION void
+PostStepSafetyCalculator<MH>::operator()(CoreTrackView const& track)
+{
+    CELER_EXPECT(track.make_sim_view().status() == TrackStatus::alive);
+
+    auto cache = track.make_safety_cache_view();
+    if (cache.is_on_boundary())
+    {
+        // No safety update
+        return;
+    }
+
+    real_type min_safety = msc.safety_post(track);
+    if (min_safety > 0)
+    {
+        cache.find_safety(min_safety);
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/global/alongstep/detail/PreStepSafetyCalculator.hh
+++ b/src/celeritas/global/alongstep/detail/PreStepSafetyCalculator.hh
@@ -1,0 +1,70 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/alongstep/detail/PreStepSafetyCalculator.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "celeritas/global/CoreTrackView.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate safety distance at the beginning of a step.
+ *
+ * TODO: this is currently *only* for MSC. We will want to extend this to
+ * accommodate the physics step so that we don't have to do any geometry
+ * interaction when far from boundaries.
+ */
+template<class MH>
+struct PreStepSafetyCalculator
+{
+    inline CELER_FUNCTION void operator()(CoreTrackView const& track);
+
+    MH msc;
+};
+
+//---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class MH>
+CELER_FUNCTION PreStepSafetyCalculator(MH&&)->PreStepSafetyCalculator<MH>;
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+
+template<class MH>
+CELER_FUNCTION void
+PreStepSafetyCalculator<MH>::operator()(CoreTrackView const& track)
+{
+    CELER_ASSERT(track.make_sim_view().status() == TrackStatus::alive);
+
+    auto geo = track.make_safety_cache_view();
+    if (geo.is_on_boundary())
+    {
+        // Safety is zero
+        return;
+    }
+
+    if (!msc.is_applicable(track, track.make_sim_view().step_limit().step))
+    {
+        return;
+    }
+
+    real_type min_safety = msc.safety_pre(track);
+    if (min_safety > 0)
+    {
+        // Calculate and cache safety
+        geo.find_safety(min_safety);
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/phys/ParticleTrackView.hh
+++ b/src/celeritas/phys/ParticleTrackView.hh
@@ -89,6 +89,9 @@ class ParticleTrackView
     // Whether the particle is stable
     CELER_FORCEINLINE_FUNCTION bool is_stable() const;
 
+    // Whether it uses safety distance due to fields or MSC
+    CELER_FORCEINLINE_FUNCTION bool use_safety() const;
+
     //// DERIVED PROPERTIES (indirection plus calculation) ////
 
     // Square of fraction of lightspeed [unitless]
@@ -251,6 +254,17 @@ CELER_FUNCTION bool ParticleTrackView::is_antiparticle() const
 CELER_FUNCTION bool ParticleTrackView::is_stable() const
 {
     return this->decay_constant() == ParticleRecord::stable_decay_constant();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether particle needs to calculate safety distances.
+ *
+ * Currently this is hardcoded to whether the particle uses a nonzero charge.
+ */
+CELER_FUNCTION bool ParticleTrackView::use_safety() const
+{
+    return this->charge() != zero_quantity();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/ArrayUtils.hh
+++ b/src/corecel/math/ArrayUtils.hh
@@ -43,6 +43,12 @@ template<class T, size_type N>
 [[nodiscard]] inline CELER_FUNCTION T norm(Array<T, N> const& vec);
 
 //---------------------------------------------------------------------------//
+// Calculate the square of the distance between two points
+template<class T, size_type N>
+[[nodiscard]] inline CELER_FUNCTION T distance_sq(Array<T, N> const& x,
+                                                  Array<T, N> const& y);
+
+//---------------------------------------------------------------------------//
 // Calculate the Euclidian (2) distance between two points
 template<class T, size_type N>
 [[nodiscard]] inline CELER_FUNCTION T distance(Array<T, N> const& x,
@@ -129,14 +135,24 @@ CELER_FUNCTION T norm(Array<T, N> const& v)
  * Calculate the Euclidian (2) distance between two points.
  */
 template<class T, size_type N>
-CELER_FUNCTION T distance(Array<T, N> const& x, Array<T, N> const& y)
+CELER_FUNCTION T distance_sq(Array<T, N> const& x, Array<T, N> const& y)
 {
     T dist_sq = 0;
     for (size_type i = 0; i != N; ++i)
     {
         dist_sq += ipow<2>(y[i] - x[i]);
     }
-    return std::sqrt(dist_sq);
+    return dist_sq;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the Euclidian (2) distance between two points.
+ */
+template<class T, size_type N>
+CELER_FUNCTION T distance(Array<T, N> const& x, Array<T, N> const& y)
+{
+    return std::sqrt(distance_sq(x, y));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/Types.hh
+++ b/src/orange/Types.hh
@@ -69,6 +69,11 @@ struct GeoTrackInitializer
  */
 struct Propagation
 {
+    static CELER_CONSTEXPR_FUNCTION Propagation from_miss(real_type distance)
+    {
+        return {distance, false, false};
+    }
+
     real_type distance{0};  //!< Distance traveled
     bool boundary{false};  //!< True if hit a boundary before given distance
     bool looping{false};  //!< True if track is looping in the field propagator

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -378,7 +378,7 @@ celeritas_add_test(celeritas/field/FieldDriver.test.cc)
 celeritas_add_test(celeritas/field/FieldPropagator.test.cc
   ${_needs_geo} LINK_LIBRARIES ${_core_geo_lib})
 celeritas_add_test(celeritas/field/LinearPropagator.test.cc
-  ${_needs_geo} LINK_LIBRARIES ${_geo_libs})
+  LINK_LIBRARIES ${_geo_libs})
 celeritas_add_test(celeritas/field/MagFieldEquation.test.cc)
 
 #-------------------------------------#
@@ -400,6 +400,9 @@ else()
 endif()
 celeritas_add_test(celeritas/geo/GeoMaterial.test.cc
   ${_needs_geant_or_root} ${_needs_geo} ${_optional_geant4_env})
+
+celeritas_add_test(celeritas/geo/SafetyCache.test.cc
+  LINK_LIBRARIES ${_geo_libs})
 
 #-------------------------------------#
 # Global

--- a/test/celeritas/GenericGeoTestBase.hh
+++ b/test/celeritas/GenericGeoTestBase.hh
@@ -115,6 +115,9 @@ class GenericGeoTestBase : virtual public Test, private LazyGeoManager
     using GeoTrackView = typename TraitsT::TrackView;
     using TrackingResult = GenericGeoTrackingResult;
     using GeantVolResult = GenericGeoGeantImportVolumeResult;
+
+    template<MemSpace M>
+    using GeoStateStore = typename TraitsT::template StateStore<M>;
     //!@}
 
   public:
@@ -160,8 +163,7 @@ class GenericGeoTestBase : virtual public Test, private LazyGeoManager
     }
 
   private:
-    using HostStateStore =
-        typename TraitsT::template StateStore<MemSpace::host>;
+    using HostStateStore = GeoStateStore<MemSpace::host>;
 
     SPConstGeo geo_;
     HostStateStore host_state_;

--- a/test/celeritas/geo/SafetyCache.test.cc
+++ b/test/celeritas/geo/SafetyCache.test.cc
@@ -1,0 +1,251 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/geo/SafetyCache.test.cc
+//---------------------------------------------------------------------------//
+#include "celeritas/geo/SafetyCacheData.hh"
+#include "celeritas/geo/SafetyCacheTrackView.hh"
+
+#include "../AllGeoTypedTestBase.hh"
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+template<class HP>
+class SafetyCacheTest : public AllGeoTypedTestBase<HP>
+{
+  protected:
+    using SPConstGeo = typename GenericGeoTestBase<HP>::SPConstGeo;
+    using GeoTrackView = typename GenericGeoTestBase<HP>::GeoTrackView;
+
+    template<MemSpace M>
+    using SafetyStateStore = CollectionStateStore<SafetyCacheStateData, M>;
+
+    std::string geometry_basename() const final { return "simple-cms"; }
+
+    //! Get a single-thread host track view for safety manipulation
+    template<class GTV>
+    decltype(auto) make_safety_track_view(GTV&& geo)
+    {
+        if (!host_state_)
+        {
+            host_state_ = HostStateStore{1};
+        }
+        return SafetyCacheTrackView{
+            std::forward<GTV>(geo), host_state_.ref(), TrackSlotId{0}};
+    }
+
+    //! Get and initialize
+    template<class GTV>
+    decltype(auto) make_safety_track_view(GTV&& geo, bool use_safety)
+    {
+        auto result = this->make_safety_track_view(std::forward<GTV>(geo));
+        result = SafetyCacheInitializer{use_safety};
+        return result;
+    }
+
+  private:
+    using HostStateStore = SafetyStateStore<MemSpace::host>;
+
+    HostStateStore host_state_;
+};
+
+TYPED_TEST_SUITE(SafetyCacheTest, AllGeoTestingTypes, AllGeoTestingTypeNames);
+
+//---------------------------------------------------------------------------//
+// HOST TESTS
+//----------------------------------------------------------------------------//
+
+TYPED_TEST(SafetyCacheTest, nav_replacement)
+{
+    // Initialize at {1,0,0} along +y
+    auto geo = this->make_geo_track_view({1, 0, 0}, {0, 1, 0});
+    EXPECT_EQ("vacuum_tube", this->volume_name(geo));
+
+    // Build and initialize safety
+    auto sft = this->make_safety_track_view(geo, true);
+
+    EXPECT_TRUE(sft.use_safety());
+
+    // Check uninitialized safety
+    EXPECT_DOUBLE_EQ(0, sft.safety());
+
+    if (CELERITAS_DEBUG)
+    {
+        // Movement outside safety should be prohibited
+        EXPECT_THROW(sft.move_internal(Real3{2, 3, 4}), DebugError);
+        EXPECT_THROW(sft.move_to_boundary(), DebugError);
+    }
+
+    // Get safety up to a given distance (no nearby boundaries)
+    // (returned safety may be more)
+    sft.find_safety(20);
+    EXPECT_LE(20, sft.safety());
+    real_type const bonus_safety = sft.safety() - 20;
+
+    // Move to another position within safety sphere
+    Real3 pos{0.5, 19.0, 0.1};
+    sft.move_internal(pos);
+    EXPECT_VEC_SOFT_EQ(pos, sft.pos());
+    EXPECT_VEC_SOFT_EQ(pos, geo.pos());
+
+    EXPECT_SOFT_EQ(0.99315912625141323 + bonus_safety, sft.safety());
+
+    // Recalculate safety with a long distance
+    sft.find_safety(30);
+    EXPECT_DOUBLE_EQ(10.993422191251788, sft.safety());
+
+    // Find a boundary
+    sft.set_dir({0, -1, 0});
+    auto next = sft.find_next_step(5.0);
+    EXPECT_FALSE(next.boundary);
+    EXPECT_DOUBLE_EQ(5.0, next.distance);
+    sft.move_internal({0, 15, 0});
+    EXPECT_DOUBLE_EQ(6.9610531605205974, sft.safety());
+
+    // Find and move to a boundary
+    sft.set_dir({0, 1, 0});
+    next = sft.find_next_step(25);
+    EXPECT_TRUE(next.boundary);
+    EXPECT_DOUBLE_EQ(15.0, next.distance);
+
+    sft.move_to_boundary();
+    EXPECT_DOUBLE_EQ(0, sft.safety());
+
+    geo.cross_boundary();
+    EXPECT_EQ("si_tracker", this->volume_name(geo));
+}
+
+TYPED_TEST(SafetyCacheTest, no_safety)
+{
+    auto geo = this->make_geo_track_view({29, 0, 0}, {0, 1, 0});
+    auto sft = this->make_safety_track_view(geo, false);
+    EXPECT_FALSE(sft.use_safety());
+
+    if (CELERITAS_DEBUG)
+    {
+        // No safety-related operations should be permitted
+        EXPECT_THROW(sft.safety(), DebugError);
+        EXPECT_THROW(sft.find_safety(123), DebugError);
+        EXPECT_THROW(sft.move_internal(Real3{2, 3, 4}), DebugError);
+        EXPECT_THROW(sft.move_to_boundary(), DebugError);
+    }
+}
+
+TYPED_TEST(SafetyCacheTest, persistence_and_const)
+{
+    {
+        // Initialize at {29,0,0} along +y
+        auto geo = this->make_geo_track_view({29, 0, 0}, {0, 1, 0});
+        EXPECT_EQ("vacuum_tube", this->volume_name(geo));
+        this->make_safety_track_view(geo, true);
+    }
+    {
+        // Create safety view with rvalue geo track view
+        auto sft = this->make_safety_track_view(this->make_geo_track_view());
+        real_type safety = sft.find_safety(10);
+        EXPECT_SOFT_EQ(safety, sft.safety());
+        EXPECT_SOFT_EQ(1.0, sft.safety());
+    }
+    {
+        // Create with const ref: *cannot* update safety but can access
+        auto const geo = this->make_geo_track_view();
+        auto sft = this->make_safety_track_view(geo);
+        EXPECT_SOFT_EQ(1.0, sft.safety());
+    }
+}
+
+TYPED_TEST(SafetyCacheTest, construction)
+{
+    using HostGeoStateStore =
+        typename TestFixture::template GeoStateStore<MemSpace::host>;
+    using HostSafetyStateStore =
+        typename TestFixture::template SafetyStateStore<MemSpace::host>;
+    using GeoTrackView = typename TestFixture::GeoTrackView;
+
+    HostGeoStateStore primary_geo_data{this->geometry()->host_ref(), 1};
+    HostSafetyStateStore primary_safety_data{1};
+
+    GeoTrackView primary_geo{
+        this->geometry()->host_ref(), primary_geo_data.ref(), TrackSlotId{0}};
+    SafetyCacheTrackView primary_sft{
+        primary_geo, primary_safety_data.ref(), TrackSlotId{0}};
+
+    GeoTrackView secondary_geo = this->make_geo_track_view();
+    SafetyCacheTrackView secondary_sft
+        = this->make_safety_track_view(secondary_geo);
+
+    double x = 10;
+    for (auto primary_use_safety : {0, 1, 2})
+    {
+        SCOPED_TRACE(primary_use_safety == 0   ? "no parent safety"
+                     : primary_use_safety == 1 ? "parent uncalculated safety"
+                                               : "parent calculated safety");
+        // Initialize primary and safety
+        primary_geo = GeoTrackInitializer{{x, 0, 0}, {1, 0, 0}};
+        primary_sft = SafetyCacheInitializer{primary_use_safety > 0};
+        if (primary_use_safety == 2)
+        {
+            // Parent precalculates safety distance
+            primary_sft.find_safety(25);
+        }
+        for (auto secondary_use_safety : {false, true})
+        {
+            SCOPED_TRACE(secondary_use_safety ? "secondary uses safety"
+                                              : "no safety used for "
+                                                "secondary");
+            for (auto detailed : {false, true})
+            {
+                SCOPED_TRACE(detailed ? "initialization from other track slot"
+                                      : "normal secondary initialization");
+                if (detailed)
+                {
+                    using GeoDetailedInit =
+                        typename GeoTrackView::DetailedInitializer;
+                    using SafetyDetailedInit =
+                        typename decltype(primary_sft)::DetailedInitializer;
+                    secondary_geo = GeoDetailedInit{primary_geo, {0, 1, 0}};
+                    secondary_sft = SafetyDetailedInit{primary_sft,
+                                                       secondary_use_safety};
+                    if (primary_use_safety == 2 && secondary_sft.use_safety())
+                    {
+                        EXPECT_SOFT_EQ(30 - x, secondary_sft.safety());
+                    }
+                }
+                else
+                {
+                    secondary_geo = {{x, 0, 0}, {0, 1, 0}};
+                    secondary_sft
+                        = SafetyCacheInitializer{secondary_use_safety};
+                }
+
+                EXPECT_EQ(secondary_use_safety, secondary_sft.use_safety());
+                if (secondary_sft.use_safety())
+                {
+                    secondary_sft.find_safety(15);
+                    EXPECT_SOFT_EQ(30 - x, secondary_sft.safety());
+                }
+
+                x += 1.0;
+                if (primary_use_safety == 2)
+                {
+                    primary_sft.move_internal({x, 0, 0});
+                }
+                else
+                {
+                    primary_geo.move_internal({x, 0, 0});
+                }
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/phys/Particle.test.cc
+++ b/test/celeritas/phys/Particle.test.cc
@@ -182,6 +182,7 @@ TEST_F(ParticleTestHost, electron)
     EXPECT_DOUBLE_EQ(0.0, particle.decay_constant());
     EXPECT_FALSE(particle.is_antiparticle());
     EXPECT_TRUE(particle.is_stable());
+    EXPECT_TRUE(particle.use_safety());
     EXPECT_SOFT_EQ(0.74453076757415848, particle.beta_sq());
     EXPECT_SOFT_EQ(0.86286196322132447, particle.speed().value());
     EXPECT_SOFT_EQ(25867950886.882648, native_value_from(particle.speed()));
@@ -222,6 +223,7 @@ TEST_F(ParticleTestHost, gamma)
     EXPECT_DOUBLE_EQ(10, particle.energy().value());
     EXPECT_FALSE(particle.is_antiparticle());
     EXPECT_TRUE(particle.is_stable());
+    EXPECT_FALSE(particle.use_safety());
     EXPECT_DOUBLE_EQ(1.0, particle.beta_sq());
     EXPECT_DOUBLE_EQ(1.0, particle.speed().value());
     EXPECT_DOUBLE_EQ(10, particle.momentum().value());

--- a/test/corecel/math/ArrayUtils.test.cc
+++ b/test/corecel/math/ArrayUtils.test.cc
@@ -62,6 +62,13 @@ TEST(ArrayUtilsTest, norm)
                    norm(Array<double, 3>{2, 3, 4}));
 }
 
+TEST(ArrayUtilsTest, distance_sq)
+{
+    EXPECT_SOFT_EQ(
+        4.0 + 9.0 + 16.0,
+        distance_sq(Array<double, 3>{3, 4, 5}, Array<double, 3>{1, 1, 1}));
+}
+
 TEST(ArrayUtilsTest, distance)
 {
     EXPECT_SOFT_EQ(


### PR DESCRIPTION
As part of #762 I've added a new "safety cache" class that acts essentially as a wrapper for GeoTrackView. It stores the origin and radius of the safety distance in a persistent class and can either call the geometry to update it *or* just update the internal state without calling `geo.find_safety`. This latter mode allows for much smaller geometry-interactive kernels because they don't call expensive functions.

I added new "pre" and "post" step safety calculations to allow the safety to be separated from the MSC limiter and post-step scatter. This ends up drastically increasing the occupancy of the MSC kernels but has negligible effect on the overall time for CMS2018 problem. It looks like more steps are taken in the CMS test, which is strange because there should be no effect (and the unit tests seem to pass). This change may make it easier to profile the geometry, since there's effectively one kernel that *only* calls a single geometry function.

I originally wanted to make two versions of the safety cache view, one that's "const" which guarantees not to call any expensive geometry functions (useful for guaranteeing that we don't call VecGeom from within certain kernels) so there's extra complication from a `const` specialization of the SafetyTrackView and a base class. I don't think I use that specialization anywhere but the launcher so I should kill it and simplify.

Also, sadly, merging #844 does not speed up the field propagator.