### PR TITLE
Fix minor issues with exceptions

### DIFF
--- a/src/celeritas/phys/ImportedProcessAdapter.cc
+++ b/src/celeritas/phys/ImportedProcessAdapter.cc
@@ -27,28 +27,6 @@
 
 namespace celeritas
 {
-namespace
-{
-//---------------------------------------------------------------------------//
-//! Rough helper class to hopefully help a little with debugging errors
-class IPAContextException : public RichContextException
-{
-  public:
-    IPAContextException(ParticleId id, ImportProcessClass ipc, MaterialId mid);
-
-    //! This class type
-    char const* type() const final { return "ImportProcessAdapterContext"; }
-
-    // Save context to a JSON object
-    void output(JsonPimpl*) const final {}
-
-    //! Get an explanatory message
-    char const* what() const noexcept final { return what_.c_str(); }
-
-  private:
-    std::string what_;
-};
-
 //---------------------------------------------------------------------------//
 IPAContextException::IPAContextException(ParticleId id,
                                          ImportProcessClass ipc,
@@ -59,9 +37,6 @@ IPAContextException::IPAContextException(ParticleId id,
        << to_cstring(ipc) << ", material ID=" << mid.unchecked_get();
     what_ = os.str();
 }
-
-//---------------------------------------------------------------------------//
-}  // namespace
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/phys/ImportedProcessAdapter.hh
+++ b/src/celeritas/phys/ImportedProcessAdapter.hh
@@ -29,6 +29,25 @@ namespace celeritas
 {
 class ParticleParams;
 struct ImportData;
+//---------------------------------------------------------------------------//
+//! Small helper class to hopefully help a little with debugging errors
+class IPAContextException : public RichContextException
+{
+  public:
+    IPAContextException(ParticleId id, ImportProcessClass ipc, MaterialId mid);
+
+    //! This class type
+    char const* type() const final { return "ImportProcessAdapterContext"; }
+
+    // Save context to a JSON object
+    void output(JsonPimpl*) const final {}
+
+    //! Get an explanatory message
+    char const* what() const noexcept final { return what_.c_str(); }
+
+  private:
+    std::string what_;
+};
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -491,7 +491,7 @@ class RichContextException : public std::exception
 #if defined(__CUDA_ARCH__) && defined(NDEBUG)
 //! Host+device definition for CUDA when \c assert is unavailable
 inline __attribute__((noinline)) __host__ __device__ void device_debug_error(
-    DebugErrorType, char const* condition, char const* file, unsigned int line)
+    DebugErrorType, char const* condition, char const* file, int line)
 {
     printf("%s:%u:\nceleritas: internal assertion failed: %s\n",
            file,
@@ -504,7 +504,7 @@ inline __attribute__((noinline)) __host__ __device__ void device_debug_error(
 inline __host__ void device_debug_error(DebugErrorType which,
                                         char const* condition,
                                         char const* file,
-                                        unsigned int line)
+                                        int line)
 {
     throw DebugError({which, condition, file, line});
 }
@@ -512,7 +512,7 @@ inline __host__ void device_debug_error(DebugErrorType which,
 //! Device-only call for HIP (must always be declared; only used if
 //! NDEBUG)
 inline __attribute__((noinline)) __device__ void device_debug_error(
-    DebugErrorType, char const* condition, char const* file, unsigned int line)
+    DebugErrorType, char const* condition, char const* file, int line)
 {
     printf("%s:%u:\nceleritas: internal assertion failed: %s\n",
            file,

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -194,7 +194,10 @@
  * RuntimeError if it fails. If CUDA is disabled, throw an unconfigured
  * assertion.
  *
- * If it fails, we call \c cudaGetLastError to clear the error code.
+ * If it fails, we call \c cudaGetLastError to clear the error code. Note that
+ * this will \em not clear the code in a few fatal error cases (kernel
+ assertion
+ * failure, invalid memory access) and all subsequent CUDA calls will fail.
  *
  * \code
    CELER_CUDA_CALL(cudaMalloc(&ptr_gpu, 100 * sizeof(float)));

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -503,7 +503,7 @@ inline __host__ void device_debug_error(DebugErrorType which,
                                         char const* file,
                                         unsigned int line)
 {
-    throw DebugError({which, condition, __FILE__, __LINE__});
+    throw DebugError({which, condition, file, line});
 }
 
 //! Device-only call for HIP (must always be declared; only used if

--- a/src/corecel/sys/ScopedMem.cc
+++ b/src/corecel/sys/ScopedMem.cc
@@ -16,6 +16,7 @@
 #    include <psapi.h>
 #    include <windows.h>
 #endif
+#include <iostream>
 
 #include "corecel/device_runtime_api.h"
 #include "corecel/Assert.hh"
@@ -125,10 +126,19 @@ ScopedMem::~ScopedMem()
 
         if (celeritas::device())
         {
-            std::ptrdiff_t stop_usage = get_gpu_mem();
-            entry.gpu_usage = native_value_to<KibiBytes>(stop_usage);
-            entry.gpu_delta
-                = native_value_to<KibiBytes>(stop_usage - gpu_start_used_);
+            try
+            {
+                std::ptrdiff_t stop_usage = get_gpu_mem();
+                entry.gpu_usage = native_value_to<KibiBytes>(stop_usage);
+                entry.gpu_delta
+                    = native_value_to<KibiBytes>(stop_usage - gpu_start_used_);
+            }
+            catch (std::exception const& e)
+            {
+                std::cerr << "An error occurred while calculating GPU memory "
+                             "usage for '"
+                          << entry.label << ": " << e.what() << std::endl;
+            }
         }
 
         registry_.value()->pop();

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/sys/ScopedProfiling.nvtx.cc
+//! \file corecel/sys/ScopedProfiling.cuda.cc
 //---------------------------------------------------------------------------//
 
 #include "ScopedProfiling.hh"


### PR DESCRIPTION
The main change is to fix an error @amandalund reported:
```
status: Transporting
terminate called after throwing an instance of 'celeritas::RuntimeError'
  what():  /home/alund/celeritas_project/celeritas/src/corecel/sys/ScopedMem.cc:80:
celeritas: CUDA error: an illegal memory access was encountered
Aborted
```
which is because CUDA illegal accesses and assertions aren't cleared with `cudaGetLastError`, and the `ScopedMem` destructor has a CUDA call that isn't wrapped with a `catch`.