### PR TITLE
Require semicolon for statement-like CELER_X_COPY_MOVE macros

### DIFF
--- a/src/accel/AlongStepFactory.hh
+++ b/src/accel/AlongStepFactory.hh
@@ -90,7 +90,7 @@ class AlongStepFactoryInterface
 
   protected:
     AlongStepFactoryInterface() = default;
-    CELER_DEFAULT_COPY_MOVE(AlongStepFactoryInterface)
+    CELER_DEFAULT_COPY_MOVE(AlongStepFactoryInterface);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/ScopedGeantExceptionHandler.hh
+++ b/src/celeritas/ext/ScopedGeantExceptionHandler.hh
@@ -34,7 +34,7 @@ class ScopedGeantExceptionHandler
     ~ScopedGeantExceptionHandler();
     //!@{
     //! Prevent copying and moving for RAII class
-    CELER_DELETE_COPY_MOVE(ScopedGeantExceptionHandler)
+    CELER_DELETE_COPY_MOVE(ScopedGeantExceptionHandler);
     //!@}
 
   private:

--- a/src/celeritas/ext/ScopedGeantLogger.hh
+++ b/src/celeritas/ext/ScopedGeantLogger.hh
@@ -34,7 +34,7 @@ class ScopedGeantLogger
     ~ScopedGeantLogger();
     //!@{
     //! Prevent copying and moving for RAII class
-    CELER_DELETE_COPY_MOVE(ScopedGeantLogger)
+    CELER_DELETE_COPY_MOVE(ScopedGeantLogger);
     //!@}
 
   private:

--- a/src/celeritas/ext/ScopedRootErrorHandler.hh
+++ b/src/celeritas/ext/ScopedRootErrorHandler.hh
@@ -33,7 +33,7 @@ class ScopedRootErrorHandler
     ~ScopedRootErrorHandler();
     //!@{
     //! Prevent copying and moving for RAII class
-    CELER_DELETE_COPY_MOVE(ScopedRootErrorHandler)
+    CELER_DELETE_COPY_MOVE(ScopedRootErrorHandler);
     //!@}
 
   private:

--- a/src/celeritas/global/ActionInterface.hh
+++ b/src/celeritas/global/ActionInterface.hh
@@ -70,7 +70,7 @@ class ActionInterface
     //!@{
     //! Allow construction and assignment only through daughter classes
     ActionInterface() = default;
-    CELER_DEFAULT_COPY_MOVE(ActionInterface)
+    CELER_DEFAULT_COPY_MOVE(ActionInterface);
     //!@}
 };
 

--- a/src/celeritas/io/EventReader.hh
+++ b/src/celeritas/io/EventReader.hh
@@ -49,7 +49,7 @@ class EventReader
     EventReader(std::string const& filename, SPConstParticles params);
 
     //! Prevent copying and moving
-    CELER_DELETE_COPY_MOVE(EventReader)
+    CELER_DELETE_COPY_MOVE(EventReader);
 
     // Read a single event from the event record
     result_type operator()();

--- a/src/celeritas/io/EventWriter.hh
+++ b/src/celeritas/io/EventWriter.hh
@@ -59,7 +59,7 @@ class EventWriter
                 Format fmt);
 
     //! Prevent copying and moving due to file ownership
-    CELER_DELETE_COPY_MOVE(EventWriter)
+    CELER_DELETE_COPY_MOVE(EventWriter);
 
     // Write all the primaries from a single event
     void operator()(argument_type primaries);

--- a/src/celeritas/phys/Process.hh
+++ b/src/celeritas/phys/Process.hh
@@ -73,7 +73,7 @@ class Process
     //!@{
     //! Allow construction and assignment only through daughter classes
     Process() = default;
-    CELER_DEFAULT_COPY_MOVE(Process)
+    CELER_DEFAULT_COPY_MOVE(Process);
     //!@}
 };
 

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -220,8 +220,8 @@
 /*!
  * \def CELER_DEFAULT_COPY_MOVE
  *
- * Explicitly declares defaulted copy and move constructors ans assignment
- * operators.
+ * Explicitly declare defaulted copy and move constructors and assignment
+ * operators. Use this if the destructor is declared explicitly.
  */
 #define CELER_DEFAULT_COPY_MOVE(CLS)      \
     CLS(CLS const&) = default;            \
@@ -232,8 +232,8 @@
 /*!
  * \def CELER_DELETE_COPY_MOVE
  *
- * Explicitly declares deleted copy and move constructors ans assignment
- * operators.
+ * Explicitly declare *deleted* copy and move constructors and assignment
+ * operators. Use this for scoped RAII classes.
  */
 #define CELER_DELETE_COPY_MOVE(CLS)      \
     CLS(CLS const&) = delete;            \

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -227,7 +227,7 @@
     CLS(CLS const&) = default;            \
     CLS& operator=(CLS const&) = default; \
     CLS(CLS&&) = default;                 \
-    CLS& operator=(CLS&&) = default;
+    CLS& operator=(CLS&&) = default
 
 /*!
  * \def CELER_DELETE_COPY_MOVE
@@ -239,4 +239,4 @@
     CLS(CLS const&) = delete;            \
     CLS& operator=(CLS const&) = delete; \
     CLS(CLS&&) = delete;                 \
-    CLS& operator=(CLS&&) = delete;
+    CLS& operator=(CLS&&) = delete

--- a/src/corecel/io/ScopedStreamFormat.hh
+++ b/src/corecel/io/ScopedStreamFormat.hh
@@ -36,7 +36,7 @@ class ScopedStreamFormat
 
     //!@{
     //! Prevent copying and moving for RAII class
-    CELER_DELETE_COPY_MOVE(ScopedStreamFormat)
+    CELER_DELETE_COPY_MOVE(ScopedStreamFormat);
     //!@}
 
   private:

--- a/src/corecel/io/ScopedStreamRedirect.hh
+++ b/src/corecel/io/ScopedStreamRedirect.hh
@@ -46,7 +46,7 @@ class ScopedStreamRedirect
 
     //!@{
     //! Prevent copying and moving for RAII class
-    CELER_DELETE_COPY_MOVE(ScopedStreamRedirect)
+    CELER_DELETE_COPY_MOVE(ScopedStreamRedirect);
     //!@}
 
     // Get redirected output, with trailing whitespaces removed

--- a/src/corecel/io/ScopedTimeAndRedirect.hh
+++ b/src/corecel/io/ScopedTimeAndRedirect.hh
@@ -39,7 +39,7 @@ class ScopedTimeAndRedirect
 
     //!@{
     //! Prevent copying and moving for RAII class
-    CELER_DELETE_COPY_MOVE(ScopedTimeAndRedirect)
+    CELER_DELETE_COPY_MOVE(ScopedTimeAndRedirect);
     //!@}
 
   private:

--- a/src/corecel/io/ScopedTimeLog.hh
+++ b/src/corecel/io/ScopedTimeLog.hh
@@ -50,7 +50,7 @@ class ScopedTimeLog
 
     //!@{
     //! Prevent copying and moving for RAII class
-    CELER_DELETE_COPY_MOVE(ScopedTimeLog)
+    CELER_DELETE_COPY_MOVE(ScopedTimeLog);
     //!@}
 
   private:

--- a/src/corecel/sys/ScopedMpiInit.hh
+++ b/src/corecel/sys/ScopedMpiInit.hh
@@ -41,7 +41,7 @@ class ScopedMpiInit
 
     //!@{
     //! Prevent copying and moving for RAII class
-    CELER_DELETE_COPY_MOVE(ScopedMpiInit)
+    CELER_DELETE_COPY_MOVE(ScopedMpiInit);
     //!@}
 
   private:

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -65,7 +65,7 @@ class ScopedProfiling
 
     //!@{
     //! Prevent copying and moving for RAII class
-    CELER_DELETE_COPY_MOVE(ScopedProfiling)
+    CELER_DELETE_COPY_MOVE(ScopedProfiling);
     //!@}
 };
 


### PR DESCRIPTION
All the other celeritas macros that act as statements require a semicolon after them, so do the same with the statements that act like substitutes for `CLS& operator=(CLS&&) = delete`.

Follow-on to #834 .