### PR TITLE
Fix inconsistencies in Geant4-to-VecGeom boolean conversion

### DIFF
--- a/cmake/CeleritasUtils.cmake
+++ b/cmake/CeleritasUtils.cmake
@@ -373,7 +373,7 @@ function(celeritas_define_options var doc)
     endif()
   endif()
   set(_last_var _LAST_${var})
-  if(NOT ${var} STREQUAL ${_last_var}) # compare *values* of variable names
+  if(NOT "${_val}" STREQUAL "${${_last_var}}")
     message(STATUS "Set ${var}=${_val}")
     set(${_last_var} "${_val}" CACHE INTERNAL "")
   endif()

--- a/scripts/dev/celeritas-gen.py
+++ b/scripts/dev/celeritas-gen.py
@@ -22,7 +22,7 @@ CXX_TOP = '''\
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \\file {dirname}/{basename}
+//! \\file {dirname}{basename}
 //---------------------------------------------------------------------------//
 '''
 
@@ -77,14 +77,12 @@ CODE_FILE = '''\
 '''
 
 TEST_HARNESS_FILE = '''\
-#include "{dirname}/{name}.{hext}"
+#include "{dirname}{name}.{hext}"
 
 #include "celeritas_test.hh"
 // #include "{name}.test.hh"
 
 {namespace_begin}
-namespace test
-{{
 //---------------------------------------------------------------------------//
 
 class {name}Test : public ::celeritas::test::Test
@@ -106,7 +104,6 @@ TEST_F({name}Test, host)
 // }}
 
 //---------------------------------------------------------------------------//
-}}  // namespace test
 {namespace_end}
 '''
 
@@ -119,8 +116,6 @@ TEST_HEADER_FILE = '''
 #include "corecel/Types.hh"
 
 {namespace_begin}
-namespace test
-{{
 //---------------------------------------------------------------------------//
 // DATA
 //---------------------------------------------------------------------------//
@@ -239,7 +234,6 @@ inline void {lowabbr}_test(
 #endif
 
 //---------------------------------------------------------------------------//
-}}  // namespace test
 {namespace_end}
 '''
 
@@ -252,8 +246,6 @@ TEST_CODE_FILE = '''\
 #include "corecel/sys/Device.hh"
 
 {namespace_begin}
-namespace test
-{{
 namespace
 {{
 //---------------------------------------------------------------------------//
@@ -291,7 +283,6 @@ void {lowabbr}_test(
 }}
 
 //---------------------------------------------------------------------------//
-}}  // namespace test
 {namespace_end}
 '''
 
@@ -500,25 +491,29 @@ HEXT = {
 }
 
 
-def removed_toplevel(filestr):
-    """Strip the leading directory from filestr.
-    """
-    return filestr.partition(os.path.sep)[-1]
-
 def generate(repodir, filename, namespace):
     if os.path.exists(filename):
         print("Skipping existing file " + filename)
         return
 
     dirname = os.path.relpath(filename, start=repodir)
-    dirname = removed_toplevel(dirname)
-    dirname = os.path.dirname(dirname)
-    basename = os.path.basename(filename)
-    (name, _, longext) = basename.partition('.')
+    all_dirs = dirname.split(os.sep)
 
     if namespace is None:
-        namespace = 'celeritas' + ('::detail' if dirname.endswith('/detail')
-                                   else '')
+        namespace = 'celeritas'
+        if all_dirs[0] == 'app':
+            namespace += '::app'
+        elif all_dirs[0] == 'test':
+            namespace += '::test'
+        if all_dirs[-1] == 'detail':
+            namespace += '::detail'
+
+    dirname = os.sep.join(all_dirs[1:-1])
+    if dirname:
+        dirname += os.sep
+
+    basename = os.path.basename(filename)
+    (name, _, longext) = basename.partition('.')
 
     lang = None
     template = None

--- a/src/celeritas/ext/g4vg/SolidConverter.cc
+++ b/src/celeritas/ext/g4vg/SolidConverter.cc
@@ -90,6 +90,12 @@
 #include "Scaler.hh"
 #include "Transformer.hh"
 
+using namespace vecgeom;
+
+namespace celeritas
+{
+namespace g4vg
+{
 namespace
 {
 //---------------------------------------------------------------------------//
@@ -111,15 +117,21 @@ namespace
     double const phi = std::atan2(tan_theta_sin_phi, tan_theta_cos_phi);
     return {theta, phi};
 }
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create a boolean volume in vecgeom.
+ */
+template<vecgeom::BooleanOperation Op>
+VUnplacedVolume*
+make_unplaced_boolean(VPlacedVolume const* left, VPlacedVolume const* right)
+{
+    return GeoManager::MakeInstance<UnplacedBooleanVolume<Op>>(Op, left, right);
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace
 
-using namespace vecgeom;
-
-namespace celeritas
-{
-namespace g4vg
-{
 //---------------------------------------------------------------------------//
 /*!
  * Convert a geant4 solid to a VecGeom "unplaced volume".
@@ -392,8 +404,7 @@ auto SolidConverter::intersectionsolid(arg_type solid_base) -> result_type
 {
     PlacedBoolVolumes pv = this->convert_bool_impl(
         static_cast<G4BooleanSolid const&>(solid_base));
-    return GeoManager::MakeInstance<UnplacedBooleanVolume<kIntersection>>(
-        kIntersection, pv[0], pv[1]);
+    return make_unplaced_boolean<kIntersection>(pv[0], pv[1]);
 }
 
 //---------------------------------------------------------------------------//
@@ -523,8 +534,7 @@ auto SolidConverter::subtractionsolid(arg_type solid_base) -> result_type
 {
     PlacedBoolVolumes pv = this->convert_bool_impl(
         static_cast<G4BooleanSolid const&>(solid_base));
-    return GeoManager::MakeInstance<UnplacedBooleanVolume<kSubtraction>>(
-        kSubtraction, pv[0], pv[1]);
+    return make_unplaced_boolean<kSubtraction>(pv[0], pv[1]);
 }
 
 //---------------------------------------------------------------------------//
@@ -653,8 +663,7 @@ auto SolidConverter::unionsolid(arg_type solid_base) -> result_type
 {
     PlacedBoolVolumes pv = this->convert_bool_impl(
         static_cast<G4BooleanSolid const&>(solid_base));
-    return GeoManager::MakeInstance<UnplacedBooleanVolume<kUnion>>(
-        kUnion, pv[0], pv[1]);
+    return make_unplaced_boolean<kUnion>(pv[0], pv[1]);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/g4vg/SolidConverter.cc
+++ b/src/celeritas/ext/g4vg/SolidConverter.cc
@@ -393,7 +393,7 @@ auto SolidConverter::intersectionsolid(arg_type solid_base) -> result_type
     PlacedBoolVolumes pv = this->convert_bool_impl(
         static_cast<G4BooleanSolid const&>(solid_base));
     return GeoManager::MakeInstance<UnplacedBooleanVolume<kIntersection>>(
-        kSubtraction, pv[0], pv[1]);
+        kIntersection, pv[0], pv[1]);
 }
 
 //---------------------------------------------------------------------------//
@@ -654,7 +654,7 @@ auto SolidConverter::unionsolid(arg_type solid_base) -> result_type
     PlacedBoolVolumes pv = this->convert_bool_impl(
         static_cast<G4BooleanSolid const&>(solid_base));
     return GeoManager::MakeInstance<UnplacedBooleanVolume<kUnion>>(
-        kSubtraction, pv[0], pv[1]);
+        kUnion, pv[0], pv[1]);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
There are two probably small issues with the boolean conversion in `g4vg`. The first is that the boolean operator needs to be repeated twice but I didn't due to a copy paste error. The second is an difference visible only when printing the vecgeom geometry: the naming used by the transformed bool daughter was inconsistent with the GDML file/VGDML reader.