### PR TITLE
Expose SDSetupOptions "enabled" flag in SetupOptionsMessenger

### DIFF
--- a/src/accel/SetupOptionsMessenger.cc
+++ b/src/accel/SetupOptionsMessenger.cc
@@ -185,6 +185,12 @@ SetupOptionsMessenger::SetupOptionsMessenger(SetupOptions* options)
             "secondaryStackFactor",
             "At least the average number of secondaries per track slot");
 
+    directories_.emplace_back(new CelerDirectory(
+        "/celer/detector/", "Celeritas sensitive detector setup options"));
+    add_cmd(&options->sd.enabled,
+            "enabled",
+            "Call back to Geant4 sensitive detectors");
+
     if (Device::num_devices() > 0)
     {
         directories_.emplace_back(new CelerDirectory(

--- a/src/accel/SetupOptionsMessenger.hh
+++ b/src/accel/SetupOptionsMessenger.hh
@@ -33,6 +33,12 @@ struct SetupOptions;
   maxInitializers      | Maximum number of track initializers
   secondaryStackFactor | At least the average number of secondaries per track
 
+ * The following option is exposed in the \c /celer/detector/ command "directory":
+ *
+  Command | Description
+  ------- | -----------------------------------------
+  enabled | Call back to Geant4 sensitive detectors
+
  * If a CUDA/HIP device is available, additional options are available under \c
  * /celer/cuda/ :
  *


### PR DESCRIPTION
In testing ATLAS integration it was found useful to switch SD callbacks off/on whilst other parts of the integration were worked on and to test functionality. Though a relatively simple switch in the wrapper around SimpleOffload/SetupOptions, it is an obvious parameter for exposure as a runtime option through SetupOptionsMessenger to help integration and possibly later performance evaluation.

Add a new "enabled" command in options messenger coupled to the SDSetupOptions enabled flag. Place command in "detector" subdirectory as a pure naming marker of its purpose. Document it in a new table entry in header file for Doxygen export.