### PR TITLE
Add option to disable Celeritas offloading in celer-g4

### DIFF
--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -28,8 +28,6 @@ ActionInitialization::ActionInitialization() : init_celeritas_{true}
 {
     // Create params to be shared across worker threads
     params_ = std::make_shared<SharedParams>();
-    // Make global setup commands available to UI
-    GlobalSetup::Instance();
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/EventAction.hh
+++ b/app/celer-g4/EventAction.hh
@@ -42,6 +42,7 @@ class EventAction final : public G4UserEventAction
   private:
     SPConstParams params_;
     SPTransporter transport_;
+    bool disable_offloading_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -71,6 +71,11 @@ GlobalSetup::GlobalSetup()
         cmd.SetDefaultValue("true");
     }
     {
+        auto& cmd = messenger_->DeclareProperty("physicsList", physics_list_);
+        cmd.SetGuidance("Select the physics list");
+        cmd.SetDefaultValue(physics_list_);
+    }
+    {
         messenger_->DeclareMethod("magFieldZ",
                                   &GlobalSetup::SetMagFieldZTesla,
                                   "Set Z-axis magnetic field strength (T)");

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -38,6 +38,7 @@ class GlobalSetup
     int GetRootBufferSize() const { return root_buffer_size_; }
     bool GetWriteSDHits() const { return write_sd_hits_; }
     bool StripGDMLPointers() const { return strip_gdml_pointers_; }
+    std::string const& GetPhysicsList() const { return physics_list_; }
     //!@}
 
     //! Get a mutable reference to the setup options for DetectorConstruction
@@ -70,6 +71,7 @@ class GlobalSetup
     int root_buffer_size_{128000};
     bool write_sd_hits_{false};
     bool strip_gdml_pointers_{true};
+    std::string physics_list_{"FTFP_BERT"};
     G4ThreeVector field_;
 
     std::unique_ptr<G4GenericMessenger> messenger_;

--- a/app/celer-g4/RunAction.hh
+++ b/app/celer-g4/RunAction.hh
@@ -53,6 +53,7 @@ class RunAction final : public G4UserRunAction
     SPParams params_;
     SPTransporter transport_;
     bool init_celeritas_;
+    bool disable_offloading_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -19,6 +19,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
+#include "corecel/sys/Environment.hh"
 #include "accel/ExceptionConverter.hh"
 
 namespace celeritas
@@ -30,7 +31,9 @@ namespace app
  * Construct with Celeritas shared and thread-local data.
  */
 TrackingAction::TrackingAction(SPConstParams params, SPTransporter transport)
-    : params_(params), transport_(transport)
+    : params_(params)
+    , transport_(transport)
+    , disable_offloading_(!celeritas::getenv("CELER_DISABLE").empty())
 {
     CELER_EXPECT(params_);
     CELER_EXPECT(transport_);
@@ -46,6 +49,9 @@ TrackingAction::TrackingAction(SPConstParams params, SPTransporter transport)
  */
 void TrackingAction::PreUserTrackingAction(G4Track const* track)
 {
+    if (disable_offloading_)
+        return;
+
     CELER_EXPECT(track);
     CELER_EXPECT(*params_);
     CELER_EXPECT(*transport_);

--- a/app/celer-g4/TrackingAction.hh
+++ b/app/celer-g4/TrackingAction.hh
@@ -42,6 +42,7 @@ class TrackingAction final : public G4UserTrackingAction
   private:
     SPConstParams params_;
     SPTransporter transport_;
+    bool disable_offloading_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -6,6 +6,7 @@
 //! \file celer-g4/celer-g4.cc
 //---------------------------------------------------------------------------//
 
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
@@ -31,7 +32,9 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Environment.hh"
 #include "corecel/sys/TypeDemangler.hh"
+#include "celeritas/ext/GeantPhysicsOptions.hh"
 #include "celeritas/ext/ScopedRootErrorHandler.hh"
+#include "celeritas/ext/detail/GeantPhysicsList.hh"
 #include "accel/ExceptionConverter.hh"
 #include "accel/Logger.hh"
 
@@ -75,20 +78,8 @@ void run(int argc, char** argv)
     CELER_LOG(info) << "Run manager type: "
                     << TypeDemangler<G4RunManager>{}(*run_manager);
 
-    // Construct geometry, SD factory, physics, actions
-    run_manager->SetUserInitialization(new DetectorConstruction{});
-    run_manager->SetUserInitialization(new FTFP_BERT{/* verbosity = */ 0});
-    run_manager->SetUserInitialization(new ActionInitialization());
-
-    std::vector<std::string> ignore_processes = {"CoulombScat"};
-    if (G4VERSION_NUMBER >= 1110)
-    {
-        CELER_LOG(warning) << "Default Rayleigh scattering 'MinKinEnergyPrim' "
-                              "is not compatible between Celeritas and "
-                              "Geant4@11.1: disabling Rayleigh scattering";
-        ignore_processes.push_back("Rayl");
-    }
-    GlobalSetup::Instance()->SetIgnoreProcesses(ignore_processes);
+    // Make global setup commands available to UI
+    GlobalSetup::Instance();
 
     G4UImanager* ui = G4UImanager::GetUIpointer();
     CELER_ASSERT(ui);
@@ -104,6 +95,39 @@ void run(int argc, char** argv)
                       << "'";
     ui->ApplyCommand(std::string("/control/execute ")
                      + std::string(macro_filename));
+
+    std::vector<std::string> ignore_processes = {"CoulombScat"};
+    if (G4VERSION_NUMBER >= 1110)
+    {
+        CELER_LOG(warning) << "Default Rayleigh scattering 'MinKinEnergyPrim' "
+                              "is not compatible between Celeritas and "
+                              "Geant4@11.1: disabling Rayleigh scattering";
+        ignore_processes.push_back("Rayl");
+    }
+    GlobalSetup::Instance()->SetIgnoreProcesses(ignore_processes);
+
+    // Construct geometry, SD factory, physics, actions
+    run_manager->SetUserInitialization(new DetectorConstruction{});
+    if (GlobalSetup::Instance()->GetPhysicsList() == "FTFP_BERT")
+    {
+        run_manager->SetUserInitialization(new FTFP_BERT{/* verbosity = */ 0});
+    }
+    else if (GlobalSetup::Instance()->GetPhysicsList() == "GeantPhysicsList")
+    {
+        GeantPhysicsOptions opts;
+        if (std::find(ignore_processes.begin(), ignore_processes.end(), "Rayl")
+            != ignore_processes.end())
+        {
+            opts.rayleigh_scattering = false;
+        }
+        run_manager->SetUserInitialization(new detail::GeantPhysicsList{opts});
+    }
+    else
+    {
+        CELER_LOG(error) << "Unknown physics list '"
+                         << GlobalSetup::Instance()->GetPhysicsList() << "'";
+    }
+    run_manager->SetUserInitialization(new ActionInitialization());
 
     // Initialize run and process events
     CELER_LOG(status) << "Initializing run manager";

--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -29,6 +29,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/sys/Environment.hh"
 #include "corecel/sys/TypeDemangler.hh"
 #include "celeritas/ext/ScopedRootErrorHandler.hh"
 #include "accel/ExceptionConverter.hh"
@@ -113,6 +114,13 @@ void run(int argc, char** argv)
     CELER_TRY_HANDLE(num_events = PrimaryGeneratorAction::NumEvents(),
                      ExceptionConverter{"demo-geant000"});
 
+    if (!celeritas::getenv("CELER_DISABLE").empty())
+    {
+        CELER_LOG(info)
+            << "Disabling Celeritas offloading since the 'CELER_DISABLE' "
+               "environment variable is present and non-empty";
+    }
+
     CELER_LOG(status) << "Transporting " << num_events << " events";
     run_manager->BeamOn(num_events);
 }
@@ -135,6 +143,7 @@ int main(int argc, char* argv[])
                   << "Environment variables:\n"
                   << "  G4FORCE_RUN_MANAGER_TYPE: MT or Serial\n"
                   << "  G4FORCENUMBEROFTHREADS: set CPU worker thread count\n"
+                  << "  CELER_DISABLE: nonempty disables offloading\n"
                   << "  CELER_DISABLE_DEVICE: nonempty disables CUDA\n"
                   << "  CELER_LOG: global logging level\n"
                   << "  CELER_LOG_LOCAL: thread-local logging level\n"


### PR DESCRIPTION
For #850.

I also added an option to use the Celeritas physics list instead of the default `FTFP_BERT`.