### PR TITLE
Hotfix: fix duplicate HepMC3 symbols by creating a wrapper function

### DIFF
--- a/src/accel/HepMC3PrimaryGenerator.cc
+++ b/src/accel/HepMC3PrimaryGenerator.cc
@@ -10,10 +10,13 @@
 #include <mutex>
 #include <G4PhysicalConstants.hh>
 #include <G4TransportationManager.hh>
-#include <HepMC3/ReaderFactory.h>
+#include <HepMC3/GenEvent.h>
+#include <HepMC3/GenParticle.h>
+#include <HepMC3/Reader.h>
 
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
+#include "celeritas/io/EventReader.hh"
 
 namespace celeritas
 {
@@ -51,21 +54,24 @@ G4VSolid* get_world_solid()
 HepMC3PrimaryGenerator::HepMC3PrimaryGenerator(std::string const& filename)
     : world_solid_{get_world_solid()}
 {
-    CELER_LOG(info) << "Loading HepMC3 input file at " << filename;
-    reader_ = HepMC3::deduce_reader(filename);
-    CELER_VALIDATE(reader_, << "failed to deduce event input file type");
+    // Fetch total number of events by opening a temporary reader
+    num_events_ = [&filename] {
+        SPReader temp_reader = open_hepmc3(filename);
+        CELER_ASSERT(temp_reader);
+        int result = 0;
+        while (!temp_reader->failed())
+        {
+            temp_reader->skip(1);
+            result++;
+        }
+        CELER_LOG(debug) << "HepMC3 file has " << result << " events";
+        return result;
+    }();
 
-    // Fetch total number of events
-    SPReader temp_reader = HepMC3::deduce_reader(filename);
-    CELER_ASSERT(temp_reader);
-    num_events_ = 0;
-    while (!temp_reader->failed())
-    {
-        temp_reader->skip(1);
-        num_events_++;
-    }
+    // Open a persistent reader
+    reader_ = open_hepmc3(filename);
 
-    CELER_LOG(debug) << "HepMC3 file has " << num_events_ << " events";
+    CELER_ENSURE(reader_);
     CELER_ENSURE(num_events_ > 0);
 }
 

--- a/src/celeritas/io/EventReader.cc
+++ b/src/celeritas/io/EventReader.cc
@@ -33,14 +33,8 @@ EventReader::EventReader(std::string const& filename, SPConstParticles params)
 {
     CELER_EXPECT(params_);
 
-    CELER_LOG(info) << "Opening event file at " << filename;
-    ScopedTimeAndRedirect temp_{"HepMC3"};
-
-    set_hepmc3_verbosity_from_env();
-
     // Determine the input file format and construct the appropriate reader
-    HepMC3::Setup::set_debug_level(1);
-    reader_ = HepMC3::deduce_reader(filename);
+    reader_ = open_hepmc3(filename);
 
     CELER_LOG(debug) << "Reader type: "
                      << TypeDemangler<HepMC3::Reader>()(*reader_);
@@ -160,6 +154,34 @@ void set_hepmc3_verbosity_from_env()
     {
         HepMC3::Setup::set_debug_level(std::stoi(var));
     }
+    else
+    {
+        HepMC3::Setup::set_debug_level(1);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Wrapper function for HepMC3::deduce_reader to avoid duplicate symbols.
+ *
+ * HepMC3 through 3.2.6 has a ReaderFactory.h that includes function
+ * *definitions* without \c inline keywords, leading to duplicate symbols.
+ * Reusing this function rather than including ReaderFactory multiple times in
+ * Celeritas is the easiest way to work around the problem.
+ *
+ * It also sets the debug level from the environment, prints a status
+ * message,and validates the file.
+ */
+std::shared_ptr<HepMC3::Reader> open_hepmc3(std::string const& filename)
+{
+    set_hepmc3_verbosity_from_env();
+
+    CELER_LOG(info) << "Opening HepMC3 input file at " << filename;
+
+    ScopedTimeAndRedirect temp_{"HepMC3"};
+    auto result = HepMC3::deduce_reader(filename);
+    CELER_VALIDATE(result, << "failed to deduce event input file type");
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/io/EventReader.hh
+++ b/src/celeritas/io/EventReader.hh
@@ -70,6 +70,10 @@ class EventReader
 void set_hepmc3_verbosity_from_env();
 
 //---------------------------------------------------------------------------//
+// Wrapper function for HepMC3::deduce_reader to avoid duplicate symbols
+std::shared_ptr<HepMC3::Reader> open_hepmc3(std::string const& filename);
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_HEPMC3

--- a/test/celeritas/io/EventIO.test.cc
+++ b/test/celeritas/io/EventIO.test.cc
@@ -22,7 +22,7 @@
 #    include <HepMC3/GenEvent.h>
 #    include <HepMC3/GenParticle.h>
 #    include <HepMC3/Print.h>
-#    include <HepMC3/ReaderAscii.h>
+#    include <HepMC3/Reader.h>
 #    include <HepMC3/Selector.h>
 #    include <HepMC3/WriterAscii.h>
 #endif
@@ -469,7 +469,7 @@ TEST_F(HepMC3Example, read)
     using namespace HepMC3;
     ASSERT_FALSE(this->test_filename_.empty());
     Setup::set_debug_level(1);
-    auto reader = std::make_shared<ReaderAscii>(this->test_filename_);
+    auto reader = open_hepmc3(this->test_filename_);
 
     GenEvent evt;
     reader->read_event(evt);


### PR DESCRIPTION
See https://gitlab.cern.ch/hepmc/HepMC3/-/merge_requests/259 . Caused by #854 plus broken CI.