### PR TITLE
Fix large function warnings by disabling device debug code by default

### DIFF
--- a/cmake/CeleritasMakeRulesOverride.cmake
+++ b/cmake/CeleritasMakeRulesOverride.cmake
@@ -16,11 +16,6 @@ https://cmake.org/cmake/help/latest/variable/CMAKE_USER_MAKE_RULES_OVERRIDE.html
 
 #]=======================================================================]
 
-# Default to building device debug code
-# (note this only works for CMake 3.21+, see
-# https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6253 )
-set(CMAKE_CUDA_FLAGS_DEBUG_INIT "-O0 -g -G")
-
 # Enable lots of warnings for GCC and Clang by default
 foreach(_lang C CXX)
   set(_id "${CMAKE_${_lang}_COMPILER_ID}")

--- a/scripts/cmake-presets/ci-ubuntu-cuda.json
+++ b/scripts/cmake-presets/ci-ubuntu-cuda.json
@@ -52,8 +52,7 @@
       "description": "Build with debug, everything but VecGeom",
       "inherits": [".mpi", "base"],
       "cacheVariables": {
-        "CELERITAS_USE_SWIG": {"type": "BOOL", "value": "OFF"},
-        "CMAKE_CUDA_FLAGS": ""
+        "CELERITAS_USE_SWIG": {"type": "BOOL", "value": "OFF"}
       }
     },
     {


### PR DESCRIPTION
Using the `-G` NVCC flag increases the number of instructions in the kernel by a factor of ~15 (from ~300 to 5600 for the `gather_step_kernel`) and the ptx size by a factor of ~30. I think this is why that function was warning about being too large to track line numbers accurately.

When we need detailed debug information, from now on let's manually add `-G` to the `CMAKE_CUDA_FLAGS_DEBUG`.