### PR TITLE
Define arithmetic operators for Array

### DIFF
--- a/src/celeritas/em/interactor/EPlusGGInteractor.hh
+++ b/src/celeritas/em/interactor/EPlusGGInteractor.hh
@@ -10,6 +10,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/data/StackAllocator.hh"
+#include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/EPlusGGData.hh"
@@ -119,10 +120,7 @@ CELER_FUNCTION Interaction EPlusGGInteractor::operator()(Engine& rng)
 
         IsotropicDistribution<real_type> gamma_dir;
         secondaries[0].direction = gamma_dir(rng);
-        for (int i = 0; i < 3; ++i)
-        {
-            secondaries[1].direction[i] = -secondaries[0].direction[i];
-        }
+        secondaries[1].direction = -secondaries[0].direction;
     }
     else
     {

--- a/src/celeritas/em/msc/UrbanMsc.hh
+++ b/src/celeritas/em/msc/UrbanMsc.hh
@@ -10,6 +10,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "corecel/math/ArrayOperators.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/em/data/UrbanMscData.hh"
 #include "celeritas/global/CoreTrackView.hh"
@@ -264,12 +265,7 @@ UrbanMsc::apply_step(CoreTrackView const& track, StepLimit* step_limit)
     {
         // Displacment during a boundary crossing is *not* OK
         CELER_ASSERT(!geo.is_on_boundary());
-        Real3 new_pos;
-        for (int i = 0; i < 3; ++i)
-        {
-            new_pos[i] = geo.pos()[i] + msc_result.displacement[i];
-        }
-        geo.move_internal(new_pos);
+        geo.move_internal(geo.pos() + msc_result.displacement);
     }
 }
 

--- a/src/celeritas/em/msc/detail/UrbanMscScatter.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscScatter.hh
@@ -11,6 +11,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/Quantities.hh"
@@ -342,10 +343,7 @@ CELER_FUNCTION auto UrbanMscScatter::operator()(Engine& rng) -> MscInteraction
         {
             // Displacement distance is large enough to worry about
             result.displacement = this->sample_displacement_dir(rng, phi);
-            for (int i = 0; i < 3; ++i)
-            {
-                result.displacement[i] *= length;
-            }
+            result.displacement *= length;
             result.action = MscInteraction::Action::displaced;
         }
     }

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -10,6 +10,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/NumericLimits.hh"
 #include "orange/Types.hh"
 #include "celeritas/geo/GeoTrackView.hh"
@@ -111,8 +112,7 @@ CELER_FUNCTION FieldPropagator<DriverT, GTV>::FieldPropagator(
     using MomentumUnits = OdeState::MomentumUnits;
 
     state_.pos = geo_.pos();
-    state_.mom
-        = detail::ax(value_as<MomentumUnits>(particle.momentum()), geo_.dir());
+    state_.mom = value_as<MomentumUnits>(particle.momentum()) * geo_.dir();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/MagFieldEquation.hh
+++ b/src/celeritas/field/MagFieldEquation.hh
@@ -11,6 +11,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/math/ArrayOperators.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/Quantities.hh"
 
@@ -108,12 +109,12 @@ MagFieldEquation<FieldT>::operator()(OdeState const& y) const -> OdeState
     // Evaluate the rate of change in particle's position per unit length: this
     // is just the direction
     OdeState result;
-    result.pos = detail::ax(momentum_inv, y.mom);
+    result.pos = momentum_inv * y.mom;
 
     // Calculate the magnetic field value at the current position
     // to calculate the force on the particle
-    result.mom = detail::ax(coeffi_ * momentum_inv,
-                            cross_product(y.mom, calc_field_(y.pos)));
+    result.mom = (coeffi_ * momentum_inv)
+                 * cross_product(y.mom, calc_field_(y.pos));
 
     return result;
 }

--- a/src/celeritas/field/ZHelixStepper.hh
+++ b/src/celeritas/field/ZHelixStepper.hh
@@ -121,11 +121,8 @@ ZHelixStepper<E>::operator()(real_type step, OdeState const& beg_state) const
     result.end_state = this->move(step, radius, helicity, beg_state, rhs);
 
     // Solution are exact, but assign a tolerance for numerical treatments
-    for (int i = 0; i < 3; ++i)
-    {
-        result.err_state.pos[i] = ZHelixStepper::tolerance();
-        result.err_state.mom[i] = ZHelixStepper::tolerance();
-    }
+    result.err_state.pos.fill(ZHelixStepper::tolerance());
+    result.err_state.mom.fill(ZHelixStepper::tolerance());
 
     return result;
 }

--- a/src/celeritas/field/detail/FieldUtils.hh
+++ b/src/celeritas/field/detail/FieldUtils.hh
@@ -13,6 +13,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Types.hh"
 
@@ -57,15 +58,9 @@ inline CELER_FUNCTION Array<T, 3> ax(T a, Array<T, 3> const& x)
 inline CELER_FUNCTION Chord make_chord(Real3 const& src, Real3 const& dst)
 {
     Chord result;
-    for (int i = 0; i < 3; ++i)
-    {
-        result.dir[i] = dst[i] - src[i];
-    }
+    result.dir = dst - src;
     result.length = norm(result.dir);
-    for (int i = 0; i < 3; ++i)
-    {
-        result.dir[i] /= result.length;
-    }
+    result.dir /= result.length;
     return result;
 }
 

--- a/src/corecel/cont/Array.hh
+++ b/src/corecel/cont/Array.hh
@@ -22,6 +22,12 @@ namespace celeritas
  * N=0 for example. Additionally it uses the native celeritas \c size_type,
  * even though this has *no* effect on generated code for values of N inside
  * the range of \c size_type.
+ *
+ * \note For supplementary functionality, include:
+ * - \c corecel/math/ArrayUtils.hh for real-number vector/matrix applications
+ * - \c corecel/math/ArrayOperators.hh for mathematical operators
+ * - \c ArrayIO.hh for streaming and string conversion
+ * - \c ArrayIO.json.hh for JSON input and output
  */
 template<class T, ::celeritas::size_type N>
 struct Array

--- a/src/corecel/math/ArrayOperators.hh
+++ b/src/corecel/math/ArrayOperators.hh
@@ -1,0 +1,107 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+/*!
+ * \file corecel/math/ArrayOperators.hh
+ * \brief Mathematical operators for the Array type.
+ *
+ * For performance reasons, avoid chaining these operators together: unroll
+ * arithmetic when possible. Note that all types must be consistent (unless
+ * promotion is automatically applied to scalar arguments), so you cannot
+ * multiply an array of doubles with an array of ints without explicitly
+ * converting first.
+ */
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/cont/Array.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+#define CELER_DEFINE_ARRAY_ASSIGN(TOKEN)                                    \
+    template<class T, size_type N>                                          \
+    inline CELER_FUNCTION Array<T, N>& operator TOKEN(Array<T, N>& x,       \
+                                                      Array<T, N> const& y) \
+    {                                                                       \
+        for (size_type i = 0; i != N; ++i)                                  \
+        {                                                                   \
+            x[i] TOKEN y[i];                                                \
+        }                                                                   \
+        return x;                                                           \
+    }                                                                       \
+                                                                            \
+    template<class T, size_type N>                                          \
+    inline CELER_FUNCTION Array<T, N>& operator TOKEN(Array<T, N>& x,       \
+                                                      T const& y)           \
+    {                                                                       \
+        for (size_type i = 0; i != N; ++i)                                  \
+        {                                                                   \
+            x[i] TOKEN y;                                                   \
+        }                                                                   \
+        return x;                                                           \
+    }
+
+#define CELER_DEFINE_ARRAY_ARITHM(TOKEN)                                   \
+    template<class T, size_type N>                                         \
+    inline CELER_FUNCTION Array<T, N> operator TOKEN(Array<T, N> const& x, \
+                                                     Array<T, N> const& y) \
+    {                                                                      \
+        Array<T, N> result{x};                                             \
+        return (result TOKEN## = y);                                       \
+    }                                                                      \
+                                                                           \
+    template<class T, size_type N>                                         \
+    inline CELER_FUNCTION Array<T, N> operator TOKEN(Array<T, N> const& x, \
+                                                     T const& y)           \
+    {                                                                      \
+        Array<T, N> result{x};                                             \
+        return (result TOKEN## = y);                                       \
+    }
+
+//---------------------------------------------------------------------------//
+//!@{
+//! Assignment arithmetic
+CELER_DEFINE_ARRAY_ASSIGN(+=)
+CELER_DEFINE_ARRAY_ASSIGN(-=)
+CELER_DEFINE_ARRAY_ASSIGN(*=)
+CELER_DEFINE_ARRAY_ASSIGN(/=)
+//!@}
+
+//---------------------------------------------------------------------------//
+//!@{
+//! Arithmetic
+CELER_DEFINE_ARRAY_ARITHM(+)
+CELER_DEFINE_ARRAY_ARITHM(-)
+CELER_DEFINE_ARRAY_ARITHM(*)
+CELER_DEFINE_ARRAY_ARITHM(/)
+//!@}
+
+//! Left-multiply by scalar
+template<class T, size_type N>
+inline CELER_FUNCTION Array<T, N> operator*(T const& y, Array<T, N> const& x)
+{
+    return x * y;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Unary negation.
+ */
+template<class T, size_type N>
+inline CELER_FUNCTION Array<T, N> operator-(Array<T, N> const& x)
+{
+    Array<T, N> result;
+    for (size_type i = 0; i != N; ++i)
+    {
+        result[i] = -x[i];
+    }
+    return result;
+}
+
+#undef CELER_DEFINE_ARRAY_ASSIGN
+#undef CELER_DEFINE_ARRAY_ARITHM
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/math/ArrayUtils.hh
+++ b/src/corecel/math/ArrayUtils.hh
@@ -107,11 +107,11 @@ CELER_FUNCTION T dot_product(Array<T, N> const& x, Array<T, N> const& y)
  */
 template<class T>
 CELER_FUNCTION Array<T, 3>
-cross_product(Array<T, 3> const& A, Array<T, 3> const& B)
+cross_product(Array<T, 3> const& x, Array<T, 3> const& y)
 {
-    return {A[1] * B[2] - A[2] * B[1],
-            A[2] * B[0] - A[0] * B[2],
-            A[0] * B[1] - A[1] * B[0]};
+    return {x[1] * y[2] - x[2] * y[1],
+            x[2] * y[0] - x[0] * y[2],
+            x[0] * y[1] - x[1] * y[0]};
 }
 
 //---------------------------------------------------------------------------//

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -176,6 +176,7 @@ celeritas_add_test(corecel/io/StringUtils.test.cc)
 # Math
 set(CELERITASTEST_PREFIX corecel/math)
 celeritas_add_test(corecel/math/Algorithms.test.cc)
+celeritas_add_test(corecel/math/ArrayOperators.test.cc)
 celeritas_add_test(corecel/math/ArrayUtils.test.cc)
 celeritas_add_test(corecel/math/HashUtils.test.cc)
 celeritas_add_device_test(corecel/math/NumericLimits)

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -12,6 +12,7 @@
 #include "corecel/cont/ArrayIO.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/math/ArrayOperators.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/field/DormandPrinceStepper.hh"
@@ -65,7 +66,7 @@ class FieldDriverTest : public Test
     Real3 calc_momentum(MevEnergy energy, Real3 const& dir)
     {
         CELER_EXPECT(is_soft_unit_vector(dir));
-        return detail::ax(this->calc_momentum(energy).value(), dir);
+        return this->calc_momentum(energy).value() * dir;
     }
 
     // Calculate momentum assuming an electron

--- a/test/corecel/math/ArrayOperators.test.cc
+++ b/test/corecel/math/ArrayOperators.test.cc
@@ -1,0 +1,85 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/math/ArrayOperators.test.cc
+//---------------------------------------------------------------------------//
+#include "corecel/math/ArrayOperators.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+TEST(ArrayOperatorsTest, add)
+{
+    using Int2 = Array<int, 2>;
+    Int2 arr{1, 2};
+    {
+        auto const& result = (arr += Int2{2, 3});
+        EXPECT_EQ(&result, &arr);
+    }
+    EXPECT_EQ((Int2{3, 5}), arr);
+
+    {
+        auto const& result = (arr += 4);
+        EXPECT_EQ(&result, &arr);
+    }
+    EXPECT_EQ((Int2{7, 9}), arr);
+
+    EXPECT_EQ((Int2{3, 4}), (Int2{1, 2} + Int2{2, 2}));
+    EXPECT_EQ((Int2{3, 4}), (Int2{1, 2} + 2));
+}
+
+TEST(ArrayOperatorsTest, sub)
+{
+    using Int2 = Array<int, 2>;
+    Int2 arr{1, 2};
+    arr -= Int2{2, 3};
+    EXPECT_EQ((Int2{-1, -1}), arr);
+
+    arr -= 4;
+    EXPECT_EQ((Int2{-5, -5}), arr);
+
+    EXPECT_EQ((Int2{3, 4}), (Int2{5, 6} - Int2{2, 2}));
+    EXPECT_EQ((Int2{3, 4}), (Int2{5, 6} - 2));
+}
+
+TEST(ArrayOperatorsTest, mul)
+{
+    using Int2 = Array<int, 2>;
+    Int2 arr{1, 2};
+    arr *= Int2{2, 3};
+    EXPECT_EQ((Int2{2, 6}), arr);
+
+    arr *= 4;
+    EXPECT_EQ((Int2{8, 24}), arr);
+
+    EXPECT_EQ((Int2{10, 12}), (Int2{5, 6} * Int2{2, 2}));
+    EXPECT_EQ((Int2{10, 12}), (Int2{5, 6} * 2));
+
+    // Multiplication only: left-multiply by scalar
+    EXPECT_EQ((Int2{10, 12}), (2 * Int2{5, 6}));
+}
+
+TEST(ArrayOperatorsTest, div)
+{
+    using Int2 = Array<int, 2>;
+    Int2 arr{4, 6};
+    arr /= Int2{2, 3};
+    EXPECT_EQ((Int2{2, 2}), arr);
+
+    arr /= 2;
+    EXPECT_EQ((Int2{1, 1}), arr);
+
+    EXPECT_EQ((Int2{3, 4}), (Int2{6, 8} / Int2{2, 2}));
+    EXPECT_EQ((Int2{3, 4}), (Int2{6, 8} / 2));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
Hearkening back to some of our earliest discussion about implementing the field driver, I think it's time we can now carefully introduce arithmetic operators for `Array` objects. The original motivation to avoid inline operators is performance, that compilers aren't smart enough to avoid multiple temporary copies when chaining operations. This concern is still valid, but by putting the operators into a separate include and keeping an eye on that during code review, it'll be easier to catch efficiency mistakes before they happen. I've added the operators and simplified a few pieces of code that should be unaffected by the use of operators.