### PR TITLE
Support Geant4@10.5

### DIFF
--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -13,7 +13,6 @@
 #include <string>
 #include <vector>
 #include <CLHEP/Random/Random.h>
-#include <G4GlobalConfig.hh>
 #include <G4RunManager.hh>
 #include <G4UIExecutive.hh>
 #include <G4UImanager.hh>
@@ -23,6 +22,9 @@
 #    include <G4RunManagerFactory.hh>
 #else
 #    include <G4MTRunManager.hh>
+#endif
+#if G4VERSION_NUMBER >= 1060
+#    include <G4GlobalConfig.hh>
 #endif
 
 #include <FTFP_BERT.hh>

--- a/cmake/FindGeant4.cmake
+++ b/cmake/FindGeant4.cmake
@@ -27,15 +27,23 @@ if(Geant4_FOUND AND Geant4_VERSION VERSION_GREATER_EQUAL 11 AND CELERITAS_USE_CU
 endif()
 
 if(Geant4_VERSION VERSION_LESS 10.6)
-  # Version 10.5 and older do *not* use `target_include_directories`:
-  # make a fake target and add it to the geant library list
+  # Version 10.5 and older have some problems.
+
+  # Move definitions from CXX flags to geant4 definitions
+  string(REGEX MATCHALL "-D[a-zA-Z0-9_]+" _defs "${Geant4_CXX_FLAGS}")
+  list(APPEND Geant4_DEFINITIONS ${_defs})
+  unset(defs)
+
+  # Make a fake target with includes and definitions
   set(_tgt Geant4_headers)
   if(NOT TARGET "${_tgt}")
     add_library(${_tgt} INTERFACE)
     add_library(celeritas::${_tgt} ALIAS ${_tgt})
     target_include_directories(${_tgt} INTERFACE ${Geant4_INCLUDE_DIRS})
+    target_compile_definitions(${_tgt} INTERFACE ${Geant4_DEFINITIONS})
     install(TARGETS ${_tgt} EXPORT celeritas-targets)
   endif()
+  # Add the fake target to the list of geant4 libraries
   list(APPEND Geant4_LIBRARIES ${_tgt})
   unset(_tgt)
 endif()

--- a/cmake/FindVecGeom.cmake
+++ b/cmake/FindVecGeom.cmake
@@ -16,9 +16,9 @@ find_package(VecGeom QUIET CONFIG)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(VecGeom CONFIG_MODE)
 
-if(VecGeom_FOUND)
+if(VecGeom_FOUND AND TARGET VecGeom::vecgeomcuda)
   get_target_property(_vecgeom_lib_type VecGeom::vecgeom TYPE)
-  if ("x${_vecgeom_lib_type}" STREQUAL "xSTATIC_LIBRARY")
+  if (_vecgeom_lib_type STREQUAL "STATIC_LIBRARY")
      set(_vecgeom_cuda_runtime "Static")
   else()
      set(_vecgeom_cuda_runtime "Shared")
@@ -28,34 +28,32 @@ if(VecGeom_FOUND)
     CELERITAS_CUDA_MIDDLE_LIBRARY VecGeom::vecgeomcuda
     CELERITAS_CUDA_FINAL_LIBRARY VecGeom::vecgeomcuda
   )
-  if(CELERITAS_USE_CUDA)
-    set_target_properties(VecGeom::vecgeomcuda PROPERTIES
-      CELERITAS_CUDA_LIBRARY_TYPE Shared
-      #CUDA_RUNTIME_LIBRARY ${_vecgeom_cuda_runtime}
+  set_target_properties(VecGeom::vecgeomcuda PROPERTIES
+    CELERITAS_CUDA_LIBRARY_TYPE Shared
+    #CUDA_RUNTIME_LIBRARY ${_vecgeom_cuda_runtime}
+  )
+  set_target_properties(VecGeom::vecgeomcuda_static PROPERTIES
+    CELERITAS_CUDA_LIBRARY_TYPE Static
+  )
+  # Suppress warnings from virtual function calls in RDC
+  foreach(_lib VecGeom::vecgeomcuda VecGeom::vecgeomcuda_static)
+    target_compile_options(${_lib}
+      INTERFACE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL: -Xnvlink --suppress-stack-size-warning>"
     )
-    set_target_properties(VecGeom::vecgeomcuda_static PROPERTIES
-      CELERITAS_CUDA_LIBRARY_TYPE Static
+    target_link_options(${_lib}
+      INTERFACE "$<DEVICE_LINK:SHELL: -Xnvlink --suppress-stack-size-warning>"
     )
-    # Suppress warnings from virtual function calls in RDC
-    foreach(_lib VecGeom::vecgeomcuda VecGeom::vecgeomcuda_static)
-      target_compile_options(${_lib}
-        INTERFACE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL: -Xnvlink --suppress-stack-size-warning>"
-      )
-      target_link_options(${_lib}
-        INTERFACE "$<DEVICE_LINK:SHELL: -Xnvlink --suppress-stack-size-warning>"
-      )
-    endforeach()
+  endforeach()
 
-    # Inform celeritas_add_library code
-    foreach(_lib VecGeom::vecgeom VecGeom::vecgeomcuda
-        VecGeom::vecgeomcuda_static)
-      set_target_properties(${_lib} PROPERTIES
-        CELERITAS_CUDA_STATIC_LIBRARY VecGeom::vecgeomcuda_static
-        CELERITAS_CUDA_MIDDLE_LIBRARY VecGeom::vecgeomcuda
-        CELERITAS_CUDA_FINAL_LIBRARY VecGeom::vecgeomcuda
-      )
-    endforeach()
-  endif()
+  # Inform celeritas_add_library code
+  foreach(_lib VecGeom::vecgeom VecGeom::vecgeomcuda
+      VecGeom::vecgeomcuda_static)
+    set_target_properties(${_lib} PROPERTIES
+      CELERITAS_CUDA_STATIC_LIBRARY VecGeom::vecgeomcuda_static
+      CELERITAS_CUDA_MIDDLE_LIBRARY VecGeom::vecgeomcuda
+      CELERITAS_CUDA_FINAL_LIBRARY VecGeom::vecgeomcuda
+    )
+  endforeach()
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/src/accel/GeantStepDiagnostic.cc
+++ b/src/accel/GeantStepDiagnostic.cc
@@ -8,6 +8,7 @@
 #include "GeantStepDiagnostic.hh"
 
 #include <algorithm>
+#include <set>
 #include <G4Track.hh>
 
 #include "corecel/Assert.hh"

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -48,6 +48,7 @@
 #include <G4VPhysicalVolume.hh>
 #include <G4VProcess.hh>
 #include <G4VRangeToEnergyConverter.hh>
+#include <G4Version.hh>
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
@@ -504,6 +505,7 @@ auto import_processes(GeantImporter::DataSelection::Flags process_flags,
         if (auto const* gg_process
             = dynamic_cast<G4GammaGeneralProcess const*>(&process))
         {
+#if G4VERSION_NUMBER >= 1060
             // Extract the real EM processes embedded inside "gamma general"
             // using an awkward string-based lookup which is the only one
             // available to us :(
@@ -516,6 +518,10 @@ auto import_processes(GeantImporter::DataSelection::Flags process_flags,
                     processes.push_back(import_process(particle, *subprocess));
                 }
             }
+#else
+            (void)sizeof(gg_process);
+            CELER_NOT_IMPLEMENTED("GammaGeneralProcess for Geant4 < 10.6");
+#endif
         }
         else if (auto const* em_process
                  = dynamic_cast<G4VEmProcess const*>(&process))
@@ -664,8 +670,10 @@ ImportEmParameters import_em_parameters()
     import.lowest_electron_energy = g4.LowestElectronEnergy() / MeV;
     import.auger = g4.Auger();
     import.msc_range_factor = g4.MscRangeFactor();
+#if G4VERSION_NUMBER >= 1060
     import.msc_safety_factor = g4.MscSafetyFactor();
     import.msc_lambda_limit = g4.MscLambdaLimit() / cm;
+#endif
     import.apply_cuts = g4.ApplyCuts();
     import.screening_factor = g4.ScreeningFactor();
 

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -70,8 +70,12 @@ GeantPhysicsList::GeantPhysicsList(Options const& options) : options_(options)
     em_parameters.SetIntegral(options.integral_approach);
     em_parameters.SetLinearLossLimit(options.linear_loss_limit);
     em_parameters.SetMscRangeFactor(options.msc_range_factor);
+#if G4VERSION_NUMBER >= 1060
+    // Customizable MSC safety factor/lambda limit were added in
+    // emutils-V10-05-18
     em_parameters.SetMscSafetyFactor(options.msc_safety_factor);
     em_parameters.SetMscLambdaLimit(options.msc_lambda_limit * CLHEP::cm);
+#endif
     em_parameters.SetLowestElectronEnergy(
         value_as<units::MevEnergy>(options.lowest_electron_energy)
         * CLHEP::MeV);

--- a/src/celeritas/ext/g4vg/SolidConverter.cc
+++ b/src/celeritas/ext/g4vg/SolidConverter.cc
@@ -585,20 +585,19 @@ auto SolidConverter::tessellatedsolid(arg_type solid_base) -> result_type
 auto SolidConverter::tet(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Tet const&>(solid_base);
-    G4ThreeVector anchor;
-    Array<G4ThreeVector, 3> points;
+    Array<G4ThreeVector, 4> points;
 #if G4VERSION_NUMBER >= 1060
-    solid.GetVertices(anchor, points[0], points[1], points[2]);
+    solid.GetVertices(points[0], points[1], points[2], points[3]);
 #else
     auto g4points = solid.GetVertices();
-    CELER_ASSERT(g4points.size() == 3);
+    CELER_ASSERT(g4points.size() == 4);
     std::copy(g4points.begin(), g4points.end(), points.begin());
 #endif
     return GeoManager::MakeInstance<UnplacedTet>(
-        this->convert_scale_(anchor),
         this->convert_scale_(points[0]),
         this->convert_scale_(points[1]),
-        this->convert_scale_(points[2]));
+        this->convert_scale_(points[2]),
+        this->convert_scale_(points[3]));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -282,6 +282,14 @@ class OneSteelSphere : public GeantImporterTest
 class OneSteelSphereGG : public OneSteelSphere
 {
   protected:
+    void SetUp()
+    {
+        if (geant4_version < Version{10, 6, 0})
+        {
+            GTEST_SKIP() << "Celeritas does not support gamma general for old "
+                            "Geant4 versions";
+        }
+    }
     GeantPhysicsOptions build_geant_options() const override
     {
         auto opts = OneSteelSphere::build_geant_options();

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -282,7 +282,7 @@ class OneSteelSphere : public GeantImporterTest
 class OneSteelSphereGG : public OneSteelSphere
 {
   protected:
-    void SetUp()
+    void SetUp() override
     {
         if (geant4_version < Version{10, 6, 0})
         {


### PR DESCRIPTION
As requested by the LZ team, this adds support for Geant4 10.5. A few capabilities and accessors were added in 10.6, and the CMake infrastructure was improved a bit.

Some tests fail because the Geant4 physics (and geometry) has changed:
```
	 77 - celeritas/ext/Vecgeom:SolidsGeantTest.* (Failed)
	 78 - celeritas/ext/GeantGeo (Failed)
	 80 - celeritas/ext/GeantImporter:FourSteelSlabs* (Failed)
	 82 - celeritas/ext/GeantImporter:OneSteelSphere.* (Failed)
	 97 - celeritas/global/AlongStep:Em3AlongStepTest.nofluct_nomsc (Failed)
	 99 - celeritas/global/AlongStep:Em3AlongStepTest.msc_nofluct_finegrid (Failed)
	109 - celeritas/global/Stepper:TestEm3Msc.* (Failed)
```
but the differences are pretty minor (e.g. missing log message).