### PR TITLE
Export full Celeritas version string as well as defaulted CMake variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,6 +428,7 @@ macro(celeritas_export_var varname)
   list(APPEND CELERITAS_EXPORT_VARIABLES "set(${varname} \"${${varname}}\")")
 endmacro()
 celeritas_export_var(Celeritas_VERSION_STRING)
+list(APPEND CELERITAS_EXPORT_VARIABLES "\n# Configuration options")
 get_directory_property(_cachevar_keys CACHE_VARIABLES)
 foreach(_key IN LISTS _cachevar_keys)
   if(_key MATCHES "^CELERITAS_")
@@ -435,13 +436,14 @@ foreach(_key IN LISTS _cachevar_keys)
   endif()
 endforeach()
 
-# Add other cache variables, prefixed with CELERITAS_
-foreach(_key BUILD_SHARED_LIBS)
+# Export defaulted variables
+list(APPEND CELERITAS_EXPORT_VARIABLES "\n# Defaulted variables")
+foreach(_key IN LISTS CELERITAS_DEFAULT_VARIABLES)
   list(APPEND CELERITAS_EXPORT_VARIABLES "set(CELERITAS_${_key} \"${${_key}}\")")
 endforeach()
 
 # Add hints for direct dependencies and indirect geant dependencies
-list(APPEND CELERITAS_EXPORT_VARIABLES "# Hints for upstream dependencies")
+list(APPEND CELERITAS_EXPORT_VARIABLES "\n# Hints for upstream dependencies")
 foreach(_key
   MPIEXEC_EXECUTABLE CUDAToolkit_BIN_DIR
   Geant4_DIR GTest_DIR HepMC3_DIR nlohmann_json_DIR Python_DIR ROOT_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,10 +424,14 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/cmake/backport"
 
 # Export all cache variables that start with CELERITAS_
 set(CELERITAS_EXPORT_VARIABLES)
+macro(celeritas_export_var varname)
+  list(APPEND CELERITAS_EXPORT_VARIABLES "set(${varname} \"${${varname}}\")")
+endmacro()
+celeritas_export_var(Celeritas_VERSION_STRING)
 get_directory_property(_cachevar_keys CACHE_VARIABLES)
 foreach(_key IN LISTS _cachevar_keys)
   if(_key MATCHES "^CELERITAS_")
-    list(APPEND CELERITAS_EXPORT_VARIABLES "set(${_key} \"${${_key}}\")")
+    celeritas_export_var(${_key})
   endif()
 endforeach()
 

--- a/cmake/CeleritasUtils.cmake
+++ b/cmake/CeleritasUtils.cmake
@@ -136,6 +136,8 @@ include_guard(GLOBAL)
 
 include(CheckLanguage)
 
+set(CELERITAS_DEFAULT_VARIABLES)
+
 #-----------------------------------------------------------------------------#
 
 function(celeritas_optional_language lang)
@@ -199,12 +201,13 @@ endmacro()
 
 #-----------------------------------------------------------------------------#
 
-function(celeritas_set_default name value)
+macro(celeritas_set_default name value)
   if(NOT DEFINED ${name})
     message(VERBOSE "Celeritas: set default ${name}=${value}")
-    set(${name} "${value}" PARENT_SCOPE)
+    set(${name} "${value}")
   endif()
-endfunction()
+  list(APPEND CELERITAS_DEFAULT_VARIABLES ${name})
+endmacro()
 
 #-----------------------------------------------------------------------------#
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,8 +62,12 @@ endforeach()
 
 foreach(_var CLHEP_VERSION Geant4_VERSION VecGeom_VERSION)
   string(TOLOWER "${_var}" _lower)
+  if(DEFINED ${_var}_STRING)
+    set(_var "${_var}_STRING")
+  endif()
+  set(_value "${${_var}}")
   string(APPEND CELERITAS_CMAKE_STRINGS
-    "static const char celeritas_${_lower}[] = \"${${_var}}\";\n"
+    "static const char celeritas_${_lower}[] = \"${_value}\";\n"
   )
 endforeach()
 celeritas_configure_file("celeritas_cmake_strings.h.in" "celeritas_cmake_strings.h" @ONLY)


### PR DESCRIPTION
This adds provenance to the CMake configuration when using a non-release version of Celeritas. It also records all the scoped settings that Celeritas uses internally (e.g. shared library construction).