### PR TITLE
Add PolyEvaluator deduction guides

### DIFF
--- a/src/celeritas/grid/PolyEvaluator.hh
+++ b/src/celeritas/grid/PolyEvaluator.hh
@@ -92,6 +92,12 @@ class PolyEvaluator
 };
 
 //---------------------------------------------------------------------------//
+// Deduction Guides
+//---------------------------------------------------------------------------//
+template<typename T, unsigned int N>
+PolyEvaluator(Array<T, N> const& array) -> PolyEvaluator<T, N - 1>;
+
+//---------------------------------------------------------------------------//
 /*!
  * Create a polynomial evaluator from the given arguments.
  */

--- a/src/celeritas/grid/PolyEvaluator.hh
+++ b/src/celeritas/grid/PolyEvaluator.hh
@@ -95,7 +95,11 @@ class PolyEvaluator
 // Deduction Guides
 //---------------------------------------------------------------------------//
 template<typename T, unsigned int N>
-PolyEvaluator(Array<T, N> const& array) -> PolyEvaluator<T, N - 1>;
+PolyEvaluator(Array<T, N> const&) -> PolyEvaluator<T, N - 1>;
+
+template<typename... Ts>
+PolyEvaluator(Ts...)
+    -> PolyEvaluator<typename std::common_type_t<Ts...>, sizeof...(Ts) - 1>;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/grid/PolyEvaluator.hh
+++ b/src/celeritas/grid/PolyEvaluator.hh
@@ -94,8 +94,8 @@ class PolyEvaluator
 //---------------------------------------------------------------------------//
 // Deduction Guides
 //---------------------------------------------------------------------------//
-template<typename T, unsigned int N>
-PolyEvaluator(Array<T, N> const&) -> PolyEvaluator<T, N - 1>;
+template<typename ArrayT>
+PolyEvaluator(ArrayT const&) -> PolyEvaluator<typename ArrayT::value_type, ArrayT::size() - 1>;
 
 template<typename... Ts>
 PolyEvaluator(Ts...)

--- a/src/celeritas/grid/PolyEvaluator.hh
+++ b/src/celeritas/grid/PolyEvaluator.hh
@@ -32,7 +32,7 @@ namespace celeritas
  * \endcode
  * with
  * \code
-    corr = make_poly_evaluator(1.41125, -1.86427e-2, 1.84035e-4)(zeff);
+    corr = PolyEvaluator{1.41125, -1.86427e-2, 1.84035e-4}(zeff);
    \endcode
  * or, to use an explicit type without having to cast each coefficient:
  * \code
@@ -100,17 +100,6 @@ PolyEvaluator(Array<T, N> const&) -> PolyEvaluator<T, N - 1>;
 template<typename... Ts>
 PolyEvaluator(Ts...)
     -> PolyEvaluator<typename std::common_type_t<Ts...>, sizeof...(Ts) - 1>;
-
-//---------------------------------------------------------------------------//
-/*!
- * Create a polynomial evaluator from the given arguments.
- */
-template<typename... Ts>
-constexpr auto make_poly_evaluator(Ts... args)
-{
-    using value_type = std::common_type_t<Ts...>;
-    return PolyEvaluator<value_type, sizeof...(Ts) - 1>{args...};
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/cont/Array.hh
+++ b/src/corecel/cont/Array.hh
@@ -75,7 +75,7 @@ struct Array
     //!@{
     //! \name Capacity
     CELER_CONSTEXPR_FUNCTION bool empty() const { return N == 0; }
-    CELER_CONSTEXPR_FUNCTION size_type size() const { return N; }
+    static CELER_CONSTEXPR_FUNCTION size_type size() { return N; }
     //!@}
 
     //!@{

--- a/test/celeritas/grid/PolyEvaluator.test.cc
+++ b/test/celeritas/grid/PolyEvaluator.test.cc
@@ -20,14 +20,14 @@ namespace test
 TEST(PolyEvaluatorTest, make_eval)
 {
     // Third-order double poly
-    auto eval_poly = make_poly_evaluator(1.0, 3, 4.0f, 5);
+    auto eval_poly = PolyEvaluator{1.0, 3, 4.0f, 5};
     EXPECT_TRUE(
         (std::is_same<decltype(eval_poly), PolyEvaluator<double, 3>>()));
     EXPECT_EQ(4 * sizeof(double), sizeof(eval_poly));
     EXPECT_DOUBLE_EQ(63.0, eval_poly(2.0));
 
     // Second-order int poly: 3 x^2 + 1
-    auto eval_int_poly = make_poly_evaluator(1, 0, 3);
+    auto eval_int_poly = PolyEvaluator{1, 0, 3};
     EXPECT_TRUE(
         (std::is_same<decltype(eval_int_poly), PolyEvaluator<int, 2>>()));
     EXPECT_EQ(3 * sizeof(int), sizeof(eval_int_poly));
@@ -35,7 +35,8 @@ TEST(PolyEvaluatorTest, make_eval)
 
     // First-order poly from an array
     constexpr Array<int, 2> linear_data{10, 1};
-    constexpr PolyEvaluator<int, 1> eval_linear{linear_data};
+    constexpr auto eval_linear = PolyEvaluator(linear_data);
+    EXPECT_TRUE((std::is_same<decltype(eval_linear),  PolyEvaluator<int, 1> const >)));
     EXPECT_EQ(9, eval_linear(-1));
     EXPECT_EQ(10, eval_linear(0));
     EXPECT_EQ(12, eval_linear(2));
@@ -63,16 +64,6 @@ TEST(PolyEvaluatorTest, eval_int)
     for (int x : {-1, 0, 2, 8})
     {
         EXPECT_EQ(3 + 2 * x + x * x - x * x * x, eval(x));
-    }
-}
-
-TEST(PolyEvaluatorTest, deduction)
-{
-    Array<int, 5> coeffs = {1, -3, 2, 7, 5};
-    auto eval = PolyEvaluator{coeffs};
-    for (int x : {0, 1})
-    {
-        EXPECT_EQ(1 + x * 11, eval(x));
     }
 }
 

--- a/test/celeritas/grid/PolyEvaluator.test.cc
+++ b/test/celeritas/grid/PolyEvaluator.test.cc
@@ -66,6 +66,16 @@ TEST(PolyEvaluatorTest, eval_int)
     }
 }
 
+TEST(PolyEvaluatorTest, deduction)
+{
+    Array<int, 5> coeffs = {1, -3, 2, 7, 5};
+    auto eval = PolyEvaluator{coeffs};
+    for (int x : {0, 1})
+    {
+        EXPECT_EQ(1 + x * 11, eval(x));
+    }
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/celeritas/grid/PolyEvaluator.test.cc
+++ b/test/celeritas/grid/PolyEvaluator.test.cc
@@ -36,7 +36,8 @@ TEST(PolyEvaluatorTest, make_eval)
     // First-order poly from an array
     constexpr Array<int, 2> linear_data{10, 1};
     constexpr auto eval_linear = PolyEvaluator(linear_data);
-    EXPECT_TRUE((std::is_same<decltype(eval_linear),  PolyEvaluator<int, 1> const >)));
+    EXPECT_TRUE(
+        (std::is_same<decltype(eval_linear), PolyEvaluator<int, 1> const>()));
     EXPECT_EQ(9, eval_linear(-1));
     EXPECT_EQ(10, eval_linear(0));
     EXPECT_EQ(12, eval_linear(2));


### PR DESCRIPTION
Added deduction guides to `PolyEvaluator` to automatically determine the polynomial degree at compile time from the number of coefficients provided in the constructor. Works for both the array and argument pack constructors.

Array example:
```c++
Array<int, 3> coeffs = {1, 0, 3};
// old method
using PolyQuad = PolyEvaluator<int, 2>;
int result = PolyQuad(coeffs)(-5);
// new method
int result = PolyEvaluator(coeffs)(-5);
```

Parameter pack example:
```c++
// old method
using PolyQuad = PolyEvaluator<int, 2>;
int result = PolyQuad{1, 0, 3}(-5);
// old method with make_poly_eval
int result = make_poly_eval(1, 0, 3)(-5);
// new method
int result = PolyEvaluator{1, 0, 3}(-5);
```

The old methods still work. Type deduction for the argument pack is `std::common_type(Ts...)` which is the same as was used in `make_poly_eval`.