### PR TITLE
Add thread-safe assertion to RootStepWriter

### DIFF
--- a/src/celeritas/user/RootStepWriter.cc
+++ b/src/celeritas/user/RootStepWriter.cc
@@ -139,7 +139,7 @@ void RootStepWriter::process_steps(HostStepState state)
     } while (0)
 
     CELER_EXPECT(state.steps);
-    if (state.stream_id.get() != 0)
+    if (state.stream_id != StreamId{0})
     {
         CELER_NOT_IMPLEMENTED("Thread-safe ROOT output");
     }

--- a/src/celeritas/user/RootStepWriter.cc
+++ b/src/celeritas/user/RootStepWriter.cc
@@ -139,6 +139,10 @@ void RootStepWriter::process_steps(HostStepState state)
     } while (0)
 
     CELER_EXPECT(state.steps);
+    if (state.stream_id.get() != 0)
+    {
+        CELER_NOT_IMPLEMENTED("Thread-safe ROOT output");
+    }
     tstep_ = TStepData();
 
     // Loop over track slots and fill TTree


### PR DESCRIPTION
`RootStepWriter` is not thread-safe yet. This ensures that it is only used during single-thread executions.