### PR TITLE
Add option to use RZ magnetic field and along step action in the celer-g4 application

### DIFF
--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -9,22 +9,32 @@
 
 #include <map>
 #include <G4Exception.hh>
+#include <G4FieldManager.hh>
 #include <G4GDMLAuxStructType.hh>
 #include <G4GDMLParser.hh>
 #include <G4LogicalVolume.hh>
+#include <G4MagneticField.hh>
 #include <G4SDManager.hh>
+#include <G4TransportationManager.hh>
+#include <G4UniformMagField.hh>
 #include <G4VPhysicalVolume.hh>
 
 #include "corecel/io/Logger.hh"
+#include "celeritas/field/RZMapFieldInput.hh"
+#include "celeritas/field/RZMapFieldParams.hh"
+#include "accel/AlongStepFactory.hh"
 #include "accel/SetupOptions.hh"
 
 #include "GlobalSetup.hh"
+#include "MagneticField.hh"
 #include "SensitiveDetector.hh"
 
 namespace celeritas
 {
 namespace app
 {
+G4ThreadLocal G4MagneticField* DetectorConstruction::mag_field_ = nullptr;
+
 //---------------------------------------------------------------------------//
 /*!
  * Set up Celeritas SD options during construction.
@@ -97,6 +107,43 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
         sd.enabled = false;
     }
 
+    // Setup options for the magnetic field
+    auto field_type = GlobalSetup::Instance()->GetFieldType();
+    if (field_type == "rzmap")
+    {
+        auto map_filename = GlobalSetup::Instance()->GetFieldFile();
+        if (map_filename.empty())
+        {
+            G4Exception("DetectorConstruction::Construct()",
+                        "",
+                        FatalException,
+                        "No field file was specified with /celerg4/fieldFile");
+        }
+        CELER_LOG_LOCAL(info) << "Using RZMapField with " << map_filename;
+        use_field_map_ = true;
+
+        // Create celeritas::RZMapFieldParams from input
+        RZMapFieldInput rz_map;
+        std::ifstream(map_filename) >> rz_map;
+        field_params_ = std::make_shared<RZMapFieldParams>(rz_map);
+
+        celeritas::app::GlobalSetup::Instance()->GetAlongStepOptions()
+            = celeritas::RZMapFieldAlongStepFactory([=] { return rz_map; });
+    }
+    else
+    {
+        G4ThreeVector field{0, 0, 0};
+        if (field_type == "uniform")
+        {
+            field = GlobalSetup::Instance()->GetMagFieldZTesla();
+        }
+        CELER_LOG_LOCAL(info)
+            << "Using a unifrom field (0, 0, " << field[2] << ") in Tesla";
+
+        celeritas::app::GlobalSetup::Instance()->GetAlongStepOptions()
+            = UniformAlongStepFactory([&] { return field; });
+    }
+
     // Claim ownership of world volume and pass it to the caller
     return gdml_parser.GetWorldVolume();
 }
@@ -139,6 +186,22 @@ void DetectorConstruction::ConstructSDandField()
         // Hand SD to the manager
         sd_manager->AddNewDetector(detector.release());
     }
+
+    // Construct the magnetic field
+    G4FieldManager* field_manager
+        = G4TransportationManager::GetTransportationManager()->GetFieldManager();
+
+    if (use_field_map_)
+    {
+        mag_field_ = new MagneticField(field_params_);
+    }
+    else
+    {
+        G4ThreeVector field = GlobalSetup::Instance()->GetMagFieldZTesla();
+        mag_field_ = new G4UniformMagField(field);
+    }
+    field_manager->SetDetectorField(mag_field_);
+    field_manager->CreateChordFinder(mag_field_);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -140,7 +140,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
         mag_field_ = std::make_shared<G4UniformMagField>(field);
 
         celeritas::app::GlobalSetup::Instance()->GetAlongStepOptions()
-            = UniformAlongStepFactory([&] { return field; });
+            = UniformAlongStepFactory([=] { return field; });
     }
 
     // Claim ownership of world volume and pass it to the caller

--- a/app/celer-g4/DetectorConstruction.hh
+++ b/app/celer-g4/DetectorConstruction.hh
@@ -39,9 +39,8 @@ class DetectorConstruction final : public G4VUserDetectorConstruction
     std::multimap<std::string, G4LogicalVolume*> detectors_;
 
     // Mangetic field
-    bool use_field_map_{false};
     std::shared_ptr<RZMapFieldParams> field_params_;
-    static G4ThreadLocal G4MagneticField* mag_field_;
+    std::shared_ptr<G4MagneticField> mag_field_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/DetectorConstruction.hh
+++ b/app/celer-g4/DetectorConstruction.hh
@@ -17,7 +17,7 @@ class G4MagneticField;
 
 namespace celeritas
 {
-struct RZMapFieldParams;
+class RZMapFieldParams;
 
 namespace app
 {

--- a/app/celer-g4/DetectorConstruction.hh
+++ b/app/celer-g4/DetectorConstruction.hh
@@ -13,9 +13,12 @@
 #include <G4VUserDetectorConstruction.hh>
 
 class G4LogicalVolume;
+class G4MagneticField;
 
 namespace celeritas
 {
+struct RZMapFieldParams;
+
 namespace app
 {
 //---------------------------------------------------------------------------//
@@ -34,6 +37,11 @@ class DetectorConstruction final : public G4VUserDetectorConstruction
   private:
     std::unique_ptr<G4VPhysicalVolume> world_;
     std::multimap<std::string, G4LogicalVolume*> detectors_;
+
+    // Mangetic field
+    bool use_field_map_{false};
+    std::shared_ptr<RZMapFieldParams> field_params_;
+    static G4ThreadLocal G4MagneticField* mag_field_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #include "GlobalSetup.hh"
 
-#include <fstream>
 #include <utility>
 #include <G4GenericMessenger.hh>
 

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -7,11 +7,14 @@
 //---------------------------------------------------------------------------//
 #include "GlobalSetup.hh"
 
+#include <fstream>
 #include <utility>
 #include <G4GenericMessenger.hh>
 
 #include "corecel/Assert.hh"
+#include "corecel/io/Logger.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/field/RZMapFieldInput.hh"
 #include "accel/AlongStepFactory.hh"
 #include "accel/SetupOptionsMessenger.hh"
 
@@ -40,7 +43,7 @@ GlobalSetup* GlobalSetup::Instance()
 GlobalSetup::GlobalSetup()
 {
     options_ = std::make_shared<SetupOptions>();
-    field_ = G4ThreeVector(0, 0, 0);
+
     messenger_ = std::make_unique<G4GenericMessenger>(
         this, "/celerg4/", "Demo geant integration setup");
 
@@ -87,6 +90,17 @@ GlobalSetup::GlobalSetup()
         cmd.SetGuidance("Number of bins for the Geant4 step diagnostic");
         cmd.SetDefaultValue(std::to_string(step_diagnostic_bins_));
     }
+
+    // Setup options for the magnetic field
+    {
+        auto& cmd = messenger_->DeclareProperty("fieldType", field_type_);
+        cmd.SetGuidance("Select the field type [rzmap|uniform]");
+        cmd.SetDefaultValue(field_type_);
+    }
+    {
+        auto& cmd = messenger_->DeclareProperty("fieldFile", field_file_);
+        cmd.SetGuidance("Filename of the rz-map loaded by RZMapFieldInput");
+    }
     {
         messenger_->DeclareMethod("magFieldZ",
                                   &GlobalSetup::SetMagFieldZTesla,
@@ -95,10 +109,6 @@ GlobalSetup::GlobalSetup()
     {
         // TODO: expose other options here
     }
-
-    // At setup time, get the field strength (native G4units)
-    options_->make_along_step
-        = UniformAlongStepFactory([this] { return field_; });
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -41,7 +41,7 @@ class GlobalSetup
     std::string const& GetPhysicsList() const { return physics_list_; }
     bool StepDiagnostic() const { return step_diagnostic_; }
     int GetStepDiagnosticBins() const { return step_diagnostic_bins_; }
-    std::string GetFieldType() const { return field_type_; }
+    std::string const& GetFieldType() const { return field_type_; }
     std::string const& GetFieldFile() const { return field_file_; }
     G4ThreeVector GetMagFieldZTesla() const { return field_; }
     //!@}

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -49,10 +49,10 @@ class GlobalSetup
     //! Get a mutable reference to the setup options for DetectorConstruction
     SDSetupOptions& GetSDSetupOptions() { return options_->sd; }
 
-    //! Get a mutable reference to the along step options
-    SetupOptions::AlongStepFactory& GetAlongStepOptions()
+    //! Set an along step factory to the setup options
+    void SetAlongStepFactory(SetupOptions::AlongStepFactory factory)
     {
-        return options_->make_along_step;
+        options_->make_along_step = std::move(factory);
     }
 
     //! Get an immutable reference to the setup options
@@ -85,7 +85,7 @@ class GlobalSetup
     std::string physics_list_{"FTFP_BERT"};
     bool step_diagnostic_{false};
     int step_diagnostic_bins_{1000};
-    std::string field_type_{"none"};
+    std::string field_type_{"uniform"};
     std::string field_file_;
     G4ThreeVector field_{0, 0, 0};
 

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -41,10 +41,19 @@ class GlobalSetup
     std::string const& GetPhysicsList() const { return physics_list_; }
     bool StepDiagnostic() const { return step_diagnostic_; }
     int GetStepDiagnosticBins() const { return step_diagnostic_bins_; }
+    std::string GetFieldType() const { return field_type_; }
+    std::string const& GetFieldFile() const { return field_file_; }
+    G4ThreeVector GetMagFieldZTesla() const { return field_; }
     //!@}
 
     //! Get a mutable reference to the setup options for DetectorConstruction
     SDSetupOptions& GetSDSetupOptions() { return options_->sd; }
+
+    //! Get a mutable reference to the along step options
+    SetupOptions::AlongStepFactory& GetAlongStepOptions()
+    {
+        return options_->make_along_step;
+    }
 
     //! Get an immutable reference to the setup options
     std::shared_ptr<SetupOptions const> GetSetupOptions() const
@@ -76,7 +85,9 @@ class GlobalSetup
     std::string physics_list_{"FTFP_BERT"};
     bool step_diagnostic_{false};
     int step_diagnostic_bins_{1000};
-    G4ThreeVector field_;
+    std::string field_type_{"none"};
+    std::string field_file_;
+    G4ThreeVector field_{0, 0, 0};
 
     std::unique_ptr<G4GenericMessenger> messenger_;
 };

--- a/app/celer-g4/MagneticField.hh
+++ b/app/celer-g4/MagneticField.hh
@@ -71,7 +71,6 @@ void MagneticField::GetFieldValue(double const pos[3], double* field) const
         // Return values of the field vector in CLHEP::tesla for Geant4
         field[i] = result[i] * this->scale();
     }
-    printf("B[2]= %g\n", field[2]);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/MagneticField.hh
+++ b/app/celer-g4/MagneticField.hh
@@ -1,0 +1,79 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file MagneticField.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include <G4MagneticField.hh>
+#include <globals.hh>
+
+#include "corecel/Macros.hh"
+#include "celeritas/field/RZMapField.hh"
+#include "celeritas/field/RZMapFieldParams.hh"
+
+namespace celeritas
+{
+namespace app
+{
+//---------------------------------------------------------------------------//
+/*!
+ * A user magnetic field equivalent to celeritas::RZMapField.
+ */
+class MagneticField : public G4MagneticField
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using SPConstFieldParams = std::shared_ptr<RZMapFieldParams const>;
+    //!@}
+
+  public:
+    // Construct with RZMapFieldParams
+    inline explicit MagneticField(SPConstFieldParams field_params);
+
+    // Calculate values of the magnetic field vector
+    inline void GetFieldValue(double const point[3], double* field) const;
+
+    //// COMMON PROPERTIES ////
+    static constexpr double scale() { return CLHEP::tesla / units::tesla; }
+
+  private:
+    SPConstFieldParams params_;
+    RZMapField calc_field_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with the Celeritas shared RZMapFieldParams.
+ */
+MagneticField::MagneticField(SPConstFieldParams params)
+    : params_(std::move(params))
+    , calc_field_(RZMapField{params_->ref<MemSpace::native>()})
+{
+    CELER_EXPECT(params_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Evaluate values of the magnetic field vector at the given position
+ * using the volume-based celetias::RZMapField.
+ */
+void MagneticField::GetFieldValue(double const pos[3], double* field) const
+{
+    // Calculate the magnetic field value in the native Celeritas unit system
+    Real3 result = this->calc_field_(Real3{pos[0], pos[1], pos[2]});
+    for (auto i = 0; i < 3; ++i)
+    {
+        // Return values of the field vector in CLHEP::tesla for Geant4
+        field[i] = result[i] * this->scale();
+    }
+    printf("B[2]= %g\n", field[2]);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace app
+}  // namespace celeritas

--- a/src/accel/RZMapMagneticField.hh
+++ b/src/accel/RZMapMagneticField.hh
@@ -3,13 +3,13 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file RZMapMagneticField.hh
+//! \file accel/RZMapMagneticField.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include <memory>
+#include <CLHEP/Units/SystemOfUnits.h>
 #include <G4MagneticField.hh>
-#include <globals.hh>
 
 #include "corecel/Macros.hh"
 #include "corecel/math/ArrayOperators.hh"
@@ -38,8 +38,14 @@ class RZMapMagneticField : public G4MagneticField
     inline void GetFieldValue(double const point[3], double* field) const;
 
     //// COMMON PROPERTIES ////
-    static constexpr double scale() { return CLHEP::tesla / units::tesla; }
-    static constexpr real_type to_celer_cm() { return 1 / CLHEP::cm; }
+    static constexpr double from_celer_tesla()
+    {
+        return CLHEP::tesla / celeritas::units::tesla;
+    }
+    static constexpr real_type to_celer_cm()
+    {
+        return celeritas::units::centimeter / CLHEP::cm;
+    }
 
   private:
     SPConstFieldParams params_;
@@ -70,7 +76,7 @@ void RZMapMagneticField::GetFieldValue(double const pos[3], double* field) const
     for (auto i = 0; i < 3; ++i)
     {
         // Return values of the field vector in CLHEP::tesla for Geant4
-        field[i] = result[i] * this->scale();
+        field[i] = result[i] * this->from_celer_tesla();
     }
 }
 

--- a/src/celeritas/field/RZMapField.hh
+++ b/src/celeritas/field/RZMapField.hh
@@ -36,8 +36,7 @@ class RZMapField
 
   public:
     // Construct with the shared map data
-    CELER_FUNCTION
-    explicit RZMapField(FieldParamsRef const& shared);
+    inline CELER_FUNCTION explicit RZMapField(FieldParamsRef const& shared);
 
     // Evaluate the magnetic field value for the given position
     CELER_FUNCTION


### PR DESCRIPTION
The MR includes

1. a user defined Geant4 magnetic field constructed with a common rz-map used in celeritas.
2. setup options for different magnetic field types and along step actions. 

An extension to use different Geant4 field drivers or steppers and additional monitoring APIs may be 
added later, if necessary.  The current feature should be good enough to evaluate performance
of celer-g4 with CMS run3 and HL-LHC detector configurations and volume-based magnetic field maps,
serving as a standalone CMS detector simulation outside CMSSW. 
      