### PR TITLE
Reuse chord length between successive field advances

### DIFF
--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -36,6 +36,26 @@ namespace celeritas
  * a targeted relative error `epsilon_rel_max` based on the position and
  * momentum update.
  *
+ * This iteratively reduces the given step length until the sagitta is no more
+ * than \c delta_chord . The sagitta is calculated as the projection of the
+ * mid-step point onto the line between the start and end-step points.
+ *
+ * Each iteration reduces the step length by a factor of no more than \c
+ * min_chord_shrink , but is based on an approximate "exact" correction factor
+ * if the chord length is very small and the curve is circular.
+ * The sagitta \em h is related to the chord length \em s and radius of
+ * curvature \em r with the trig expression: \f[
+   r - h = r \cos \frac{s}{2r}
+  \f]
+ * For small chord lengths or a large radius, we expand
+ * \f$ \cos \theta \sim 1 \frac{\theta^2}{2} \f$, giving a radius of curvature
+ * \f[ r = \frac{s^2}{8h} \; . \f]
+ * Given a trial step (chord length) \em s and resulting sagitta of \em h,
+ * the exact step needed to give a chord length of \f$ \epsilon = {} \f$ \c
+ * delta_chord is \f[
+   s' = s \sqrt{\frac{\epsilon}{h}} \,.
+ * \f]
+ *
  * \note This class is based on G4ChordFinder and G4MagIntegratorDriver.
  */
 template<class StepperT>
@@ -192,26 +212,6 @@ FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
 //---------------------------------------------------------------------------//
 /*!
  * Find the maximum step length that satisfies a maximum "miss distance".
- *
- * This iteratively reduces the given step length until the sagitta is no more
- * than \c delta_chord . The sagitta is calculated as the projection of the
- * mid-step point onto the line between the start and end-step points.
- *
- * Each iteration reduces the step length by a factor of no more than \c
- * min_chord_shrink , but is based on an approximate "exact" correction factor
- * if the chord length is very small and the curve is circular.
- * The sagitta \em h is related to the chord length \em s and radius of
- * curvature \em r with the trig expression: \f[
-   r - h = r \cos \frac{s}{2r}
-  \f]
- * For small chord lengths or a large radius, we expand
- * \f$ \cos \theta \sim 1 \frac{\theta^2}{2} \f$, giving a radius of curvature
- * \f[ r = \frac{s^2}{8h} \; . \f]
- * Given a trial step (chord length) \em s and resulting sagitta of \em h,
- * the exact step needed to give a chord length of \f$ \epsilon = {} \f$ \c
- * delta_chord is \f[
-   s' = s \sqrt{\frac{\epsilon}{h}} \,.
- * \f]
  */
 template<class StepperT>
 CELER_FUNCTION auto

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -8,15 +8,20 @@
 #pragma once
 
 #include <cmath>
+#include <iostream>
 
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "corecel/cont/ArrayIO.hh"
+#include "corecel/io/ColorUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/SoftEqual.hh"
 
 #include "FieldDriverOptions.hh"
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
+using std::cout;
+using std::endl;
 
 namespace celeritas
 {
@@ -151,12 +156,18 @@ template<class StepperT>
 CELER_FUNCTION DriverResult
 FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
 {
+    cout << color_code('b') << "Step up to " << step << color_code(' ')
+         << " from " << state.pos << endl;
+
     if (step <= options_.minimum_step)
     {
+        cout << " - quick advance" << endl;
+
         // If the input is a very tiny step, do a "quick advance".
         DriverResult result;
         result.state = apply_step_(step, state).end_state;
         result.step = step;
+        cout << color_code('g') << "==> distance " << result.step << endl;
         return result;
     }
 
@@ -172,6 +183,8 @@ FieldDriver<StepperT>::advance(real_type step, OdeState const& state) const
         output.end = this->accurate_advance(output.end.step, state, next_step);
     }
 
+    cout << color_code('g') << "==> substep " << output.end.step
+         << color_code(' ') << endl;
     CELER_ENSURE(output.end.step > 0 && output.end.step <= step);
     return output.end;
 }
@@ -209,6 +222,8 @@ FieldDriver<StepperT>::find_next_chord(real_type step,
     // Output with a step control error
     ChordSearch output;
 
+    cout << " - find next chord" << endl;
+
     bool succeeded = false;
     auto remaining_steps = options_.max_nsteps;
     FieldStepperResult result;
@@ -223,18 +238,31 @@ FieldDriver<StepperT>::find_next_chord(real_type step,
         real_type dchord = detail::distance_chord(
             state, result.mid_state, result.end_state);
 
+        cout << "  + step " << step << " to " << result.end_state.pos
+             << " by way of " << result.mid_state.pos
+             << " -> dchord=" << dchord;
+
         if (dchord > options_.delta_chord + options_.dchord_tol)
         {
             // Estimate a new trial chord with a relative scale
             real_type scale_step = max(std::sqrt(options_.delta_chord / dchord),
                                        options_.min_chord_shrink);
             step *= scale_step;
+            cout << " -> scale by 1 - " << (1 - scale_step);
         }
         else
         {
+            // Close enough to the desired chord tolerance
+            cout << " -> " << color_code('g') << "converged" << color_code(' ');
             succeeded = true;
         }
+        cout << endl;
     } while (!succeeded && --remaining_steps > 0);
+    if (remaining_steps == 0)
+    {
+        cout << "  + " << color_code('y') << "failed to converge"
+             << color_code(' ') << endl;
+    }
 
     // Update step, position and momentum
     output.end.step = step;
@@ -258,6 +286,9 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
     real_type step, OdeState const& state, real_type hinitial) const
 {
     CELER_ASSERT(step > 0);
+
+    cout << " - accurate advance to " << step << " with initial step "
+         << hinitial << endl;
 
     // Set an initial proposed step and evaluate the minimum threshold
     real_type end_curve_length = step;
@@ -284,12 +315,19 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
     do
     {
         CELER_ASSERT(h > 0);
+        cout << "  + integrating substep " << h << " from "
+             << output.end.state.pos << endl;
+
         output = this->integrate_step(h, output.end.state);
 
         curve_length += output.end.step;
 
+        cout << "  + integrated substep " << h << " -> " << output.end.step
+             << ", proposed step " << output.proposed_step;
+
         if (h < h_threshold || curve_length >= end_curve_length)
         {
+            cout << " -> " << color_code('g') << "complete" << color_code(' ');
             succeeded = true;
         }
         else
@@ -297,8 +335,16 @@ CELER_FUNCTION DriverResult FieldDriver<StepperT>::accurate_advance(
             h = celeritas::min(
                 celeritas::max(output.proposed_step, options_.minimum_step),
                 end_curve_length - curve_length);
+            cout << "\n    " << color_code('x') << remaining_steps
+                 << " remaining" << color_code(' ');
         }
+        cout << endl;
     } while (!succeeded && --remaining_steps > 0);
+    if (remaining_steps == 0)
+    {
+        cout << "  + " << color_code('y') << "failed to converge"
+             << color_code(' ') << endl;
+    }
 
     // Curve length may be slightly longer than step due to roundoff in
     // accumulation
@@ -331,6 +377,8 @@ FieldDriver<StepperT>::integrate_step(real_type step,
     }
     else
     {
+        cout << "   * quick advance\n";
+
         // Do an integration step for a small step (a.k.a quick advance)
         FieldStepperResult result = apply_step_(step, state);
 
@@ -357,6 +405,9 @@ CELER_FUNCTION auto
 FieldDriver<StepperT>::one_good_step(real_type step, OdeState const& state) const
     -> Integration
 {
+    CELER_EXPECT(step >= options_.minimum_step);
+    cout << "   * one good step\n";
+
     // Output with a proposed next step
     Integration output;
 
@@ -373,18 +424,30 @@ FieldDriver<StepperT>::one_good_step(real_type step, OdeState const& state) cons
         err_sq = detail::rel_err_sq(result.err_state, step, state.mom)
                  / ipow<2>(options_.epsilon_rel_max);
 
+        cout << "    # apply step " << step
+             << " -> err/eps=" << std::sqrt(err_sq);
+
         if (err_sq > 1)
         {
             // Truncation error too large, reduce stepsize with a low bound
-            step *= max(this->new_step_scale(err_sq),
-                        options_.max_stepping_decrease);
+            real_type scale_step = max(this->new_step_scale(err_sq),
+                                       options_.max_stepping_decrease);
+            step *= scale_step;
+            cout << " -> scale by " << scale_step;
         }
         else
         {
             // Success or possibly nan!
+            cout << " -> " << color_code('g') << "converged" << color_code(' ');
             succeeded = true;
         }
+        cout << endl;
     } while (!succeeded && --remaining_steps > 0);
+    if (remaining_steps == 0)
+    {
+        cout << "    # " << color_code('y') << "failed to converge"
+             << color_code(' ') << endl;
+    }
 
     // Update state, step taken by this trial and the next predicted step
     output.end.state = result.end_state;

--- a/src/celeritas/field/FieldDriver.hh
+++ b/src/celeritas/field/FieldDriver.hh
@@ -236,7 +236,7 @@ FieldDriver<StepperT>::find_next_chord(real_type step,
         // Check whether the distance to the chord is smaller than the
         // reference
         real_type dchord = detail::distance_chord(
-            state, result.mid_state, result.end_state);
+            state.pos, result.mid_state.pos, result.end_state.pos);
 
         cout << "  + step " << step << " to " << result.end_state.pos
              << " by way of " << result.mid_state.pos

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -19,9 +19,8 @@ namespace celeritas
  *
  * TODO: replace epsilon_rel_max with 1/epsilon_rel_max^2
  * TODO: replace safety with step_shrink_mul (or something to indicate that
- * TODO: deletee errcon
- * it's a multiplicative factor for reducing the step, not anything with
- * geometry)
+ *       it's a multiplicative factor for reducing the step, not anything with
+ *       geometry)
  * TODO: remove errcon
  */
 struct FieldDriverOptions
@@ -53,7 +52,7 @@ struct FieldDriverOptions
     //! Scale factor for the predicted step size
     real_type safety = 0.9;
 
-    //! Largrest allowable relative increase a step size
+    //! Largest allowable relative increase a step size
     real_type max_stepping_increase = 5;
 
     //! Smallest allowable relative decrease in step size

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -7,8 +7,12 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <iostream>
+
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "corecel/cont/ArrayIO.hh"
+#include "corecel/io/ColorUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/NumericLimits.hh"
@@ -18,6 +22,8 @@
 
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
+using std::cout;
+using std::endl;
 
 namespace celeritas
 {
@@ -163,6 +169,15 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
     result.boundary = geo_.is_on_boundary();
     result.distance = 0;
 
+    cout << color_code('b') << "Propagate up to " << step << color_code(' ')
+         << " from " << geo_.pos();
+    if (result.boundary)
+    {
+        cout << " (on boundary)";
+    }
+
+    cout << " along " << geo_.dir() << endl;
+
     // Break the curved steps into substeps as determined by the driver *and*
     // by the proximity of geometry boundaries. Test for intersection with the
     // geometry boundary in each substep. This loop is guaranteed to converge
@@ -177,6 +192,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         // Advance up to (but probably less than) the remaining step length
         DriverResult substep = driver_.advance(remaining, state_);
         CELER_ASSERT(substep.step > 0 && substep.step <= remaining);
+
+        cout << "- advance(" << remaining << ", " << state_.pos << ") -> {"
+             << substep.step << ", " << substep.state.pos << "}" << endl;
 
         // Check whether the chord for this sub-step intersects a boundary
         auto chord = detail::make_chord(state_.pos, substep.state.pos);
@@ -196,6 +214,12 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             //   boundary test does lose some accuracy)
             geo_.set_dir(chord.dir);
         }
+        else
+        {
+            cout << " + " << color_code('y')
+                 << "Skipping direction update: chord < "
+                 << this->bump_distance() << color_code(' ') << endl;
+        }
         auto linear_step
             = geo_.find_next_step(chord.length + this->delta_intersection());
 
@@ -205,6 +229,14 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         // intersection).
         real_type const update_length = substep.step * linear_step.distance
                                         / chord.length;
+
+        cout << " + chord " << chord.length << " cm along " << chord.dir
+             << " => linear step " << linear_step.distance;
+        if (linear_step.boundary)
+        {
+            cout << " (HIT!)";
+        }
+        cout << ": update length " << update_length << '\n';
 
         if (!linear_step.boundary)
         {
@@ -220,6 +252,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
             --remaining_substeps;
+            cout << " + advancing to substep end point (" << remaining_substeps
+                 << " remaining)" << endl;
         }
         else if (CELER_UNLIKELY(result.boundary
                                 && linear_step.distance < this->bump_distance()))
@@ -228,6 +262,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // surface (this can happen when tracking through a volume at a
             // near tangent). Reduce substep size and try again.
             remaining = substep.step / 2;
+            cout << " + halving substep distance" << endl;
         }
         else if (update_length <= this->bump_distance()
                  || detail::is_intercept_close(state_.pos,
@@ -252,6 +287,28 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             result.boundary = (linear_step.distance <= chord.length
                                || result.distance + update_length <= step);
 
+            if (update_length <= this->bump_distance())
+            {
+                cout << " + update length is less than bump distance" << endl;
+            }
+            if (detail::is_intercept_close(state_.pos,
+                                           chord.dir,
+                                           linear_step.distance,
+                                           substep.state.pos,
+                                           this->delta_intersection()))
+            {
+                Real3 intercept = geo_.pos();
+                axpy(linear_step.distance, geo_.dir(), &intercept);
+                cout << " + intercept " << intercept << " is within "
+                     << this->delta_intersection() << " of substep endpoint"
+                     << endl;
+                if (result.distance + update_length > step)
+                {
+                    cout << " + but it's is past the end of the step by "
+                         << result.distance + update_length - step << endl;
+                }
+            }
+
             if (!result.boundary)
             {
                 // Don't move to the boundary, but instead move to the end of
@@ -259,6 +316,13 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
                 // as "!linear_step.boundary" above.
                 state_.pos = substep.state.pos;
                 geo_.move_internal(substep.state.pos);
+                cout << " + moved to " << state_.pos;
+                if (linear_step.boundary && !result.boundary)
+                {
+                    cout << color_code('y') << ": ignoring intercept!"
+                         << color_code(' ');
+                }
+                cout << endl;
             }
 
             // The update length can be slightly greater than the substep due
@@ -274,6 +338,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // Decrease the allowed substep (curved path distance) by the
             // fraction along the chord, and retry the driver step.
             remaining = update_length;
+            cout << " + Setting remaining distance to a fraction "
+                 << linear_step.distance / chord.length << " of the substep"
+                 << endl;
         }
     } while (remaining > 0 && remaining_substeps > 0);
 
@@ -282,6 +349,9 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         // Flag track as looping if the max number of substeps was reached
         // without hitting a boundary or moving the full step length
         result.looping = true;
+        cout << "- " << color_code('r')
+             << "Did not complete step: marked as looping" << color_code(' ')
+             << endl;
     }
     else if (result.distance > 0)
     {
@@ -292,6 +362,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // because of the tolerance in the intercept checks above).
             geo_.move_to_boundary();
             state_.pos = geo_.pos();
+            cout << "- Moved to boundary " << geo_.surface_id().unchecked_get()
+                 << " at position " << state_.pos << endl;
         }
         else if (CELER_UNLIKELY(result.distance < step))
         {
@@ -300,6 +372,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // error. Reset the distance so the track's action isn't
             // erroneously set as propagation-limited.
             CELER_ASSERT(soft_equal(result.distance, step));
+            cout << "- " << color_code('y') << "Updating distance by "
+                 << step - result.distance << color_code(' ') << endl;
             result.distance = step;
         }
     }
@@ -321,7 +395,13 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         result.boundary = false;
         axpy(result.distance, dir, &state_.pos);
         geo_.move_internal(state_.pos);
+        cout << "- " << color_code('y') << "Failed to move: bumped to "
+             << state_.pos << endl;
     }
+
+    cout << color_code('g') << "==> distance " << result.distance
+         << color_code(' ') << " (in "
+         << this->max_substeps() - remaining_substeps << " steps)" << endl;
 
     // Due to accumulation errors from multiple substeps or chord-finding
     // within the driver, the distance may be very slightly beyond the

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -7,12 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <iostream>
-
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
-#include "corecel/cont/ArrayIO.hh"
-#include "corecel/io/ColorUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/NumericLimits.hh"
@@ -22,8 +18,6 @@
 
 #include "Types.hh"
 #include "detail/FieldUtils.hh"
-using std::cout;
-using std::endl;
 
 namespace celeritas
 {
@@ -169,15 +163,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
     result.boundary = geo_.is_on_boundary();
     result.distance = 0;
 
-    cout << color_code('b') << "Propagate up to " << step << color_code(' ')
-         << " from " << geo_.pos();
-    if (result.boundary)
-    {
-        cout << " (on boundary)";
-    }
-
-    cout << " along " << geo_.dir() << endl;
-
     // Break the curved steps into substeps as determined by the driver *and*
     // by the proximity of geometry boundaries. Test for intersection with the
     // geometry boundary in each substep. This loop is guaranteed to converge
@@ -192,9 +177,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         // Advance up to (but probably less than) the remaining step length
         DriverResult substep = driver_.advance(remaining, state_);
         CELER_ASSERT(substep.step > 0 && substep.step <= remaining);
-
-        cout << "- advance(" << remaining << ", " << state_.pos << ") -> {"
-             << substep.step << ", " << substep.state.pos << "}" << endl;
 
         // Check whether the chord for this sub-step intersects a boundary
         auto chord = detail::make_chord(state_.pos, substep.state.pos);
@@ -214,12 +196,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             //   boundary test does lose some accuracy)
             geo_.set_dir(chord.dir);
         }
-        else
-        {
-            cout << " + " << color_code('y')
-                 << "Skipping direction update: chord < "
-                 << this->bump_distance() << color_code(' ') << endl;
-        }
         auto linear_step
             = geo_.find_next_step(chord.length + this->delta_intersection());
 
@@ -229,14 +205,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         // intersection).
         real_type const update_length = substep.step * linear_step.distance
                                         / chord.length;
-
-        cout << " + chord " << chord.length << " cm along " << chord.dir
-             << " => linear step " << linear_step.distance;
-        if (linear_step.boundary)
-        {
-            cout << " (HIT!)";
-        }
-        cout << ": update length " << update_length << '\n';
 
         if (!linear_step.boundary)
         {
@@ -252,8 +220,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             remaining = step - result.distance;
             geo_.move_internal(state_.pos);
             --remaining_substeps;
-            cout << " + advancing to substep end point (" << remaining_substeps
-                 << " remaining)" << endl;
         }
         else if (CELER_UNLIKELY(result.boundary
                                 && linear_step.distance < this->bump_distance()))
@@ -263,7 +229,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // a surface (this can happen when tracking through a volume at a
             // near tangent). Reduce substep size and try again.
             remaining = substep.step / 2;
-            cout << " + halving substep distance" << endl;
         }
         else if (detail::is_intercept_close(state_.pos,
                                             chord.dir,
@@ -284,24 +249,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             result.boundary = (linear_step.distance <= chord.length
                                || result.distance + update_length <= step);
 
-            if (detail::is_intercept_close(state_.pos,
-                                           chord.dir,
-                                           linear_step.distance,
-                                           substep.state.pos,
-                                           this->delta_intersection()))
-            {
-                Real3 intercept = geo_.pos();
-                axpy(linear_step.distance, geo_.dir(), &intercept);
-                cout << " + intercept " << intercept << " is within "
-                     << this->delta_intersection() << " of substep endpoint"
-                     << endl;
-                if (result.distance + update_length > step)
-                {
-                    cout << " + but it's is past the end of the step by "
-                         << result.distance + update_length - step << endl;
-                }
-            }
-
             if (!result.boundary)
             {
                 // Don't move to the boundary, but instead move to the end of
@@ -309,13 +256,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
                 // as "!linear_step.boundary" above.
                 state_.pos = substep.state.pos;
                 geo_.move_internal(substep.state.pos);
-                cout << " + moved to " << state_.pos;
-                if (linear_step.boundary && !result.boundary)
-                {
-                    cout << color_code('y') << ": ignoring intercept!"
-                         << color_code(' ');
-                }
-                cout << endl;
             }
 
             // The update length can be slightly greater than the substep due
@@ -331,9 +271,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // Decrease the allowed substep (curved path distance) by the
             // fraction along the chord, and retry the driver step.
             remaining = update_length;
-            cout << " + Setting remaining distance to a fraction "
-                 << linear_step.distance / chord.length << " of the substep"
-                 << endl;
         }
     } while (remaining > 0 && remaining_substeps > 0);
 
@@ -342,9 +279,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         // Flag track as looping if the max number of substeps was reached
         // without hitting a boundary or moving the full step length
         result.looping = true;
-        cout << "- " << color_code('r')
-             << "Did not complete step: marked as looping" << color_code(' ')
-             << endl;
     }
     else if (result.distance > 0)
     {
@@ -355,8 +289,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // because of the tolerance in the intercept checks above).
             geo_.move_to_boundary();
             state_.pos = geo_.pos();
-            cout << "- Moved to boundary " << geo_.surface_id().unchecked_get()
-                 << " at position " << state_.pos << endl;
         }
         else if (CELER_UNLIKELY(result.distance < step))
         {
@@ -365,8 +297,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // error. Reset the distance so the track's action isn't
             // erroneously set as propagation-limited.
             CELER_ASSERT(soft_equal(result.distance, step));
-            cout << "- " << color_code('y') << "Updating distance by "
-                 << step - result.distance << color_code(' ') << endl;
             result.distance = step;
         }
     }
@@ -388,13 +318,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         result.boundary = false;
         axpy(result.distance, dir, &state_.pos);
         geo_.move_internal(state_.pos);
-        cout << "- " << color_code('y') << "Failed to move: bumped to "
-             << state_.pos << endl;
     }
-
-    cout << color_code('g') << "==> distance " << result.distance
-         << color_code(' ') << " (in "
-         << this->max_substeps() - remaining_substeps << " steps)" << endl;
 
     // Due to accumulation errors from multiple substeps or chord-finding
     // within the driver, the distance may be very slightly beyond the

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -258,22 +258,19 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         else if (CELER_UNLIKELY(result.boundary
                                 && linear_step.distance < this->bump_distance()))
         {
-            // Likely heading back into the old volume when starting on a
-            // surface (this can happen when tracking through a volume at a
+            // This substep *started* on a surface and the step length is very
+            // small: likely heading back into the old volume when starting on
+            // a surface (this can happen when tracking through a volume at a
             // near tangent). Reduce substep size and try again.
             remaining = substep.step / 2;
             cout << " + halving substep distance" << endl;
         }
-        else if (update_length <= this->bump_distance()
-                 || detail::is_intercept_close(state_.pos,
-                                               chord.dir,
-                                               linear_step.distance,
-                                               substep.state.pos,
-                                               this->delta_intersection()))
+        else if (detail::is_intercept_close(state_.pos,
+                                            chord.dir,
+                                            linear_step.distance,
+                                            substep.state.pos,
+                                            this->delta_intersection()))
         {
-            // We're close enough to the boundary that the next trial step
-            // would be less than the driver's minimum step.
-            // *OR*
             // The straight-line intersection point is a distance less than
             // `delta_intersection` from the substep's end position.
             // Commit the proposed state's momentum, use the
@@ -287,10 +284,6 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             result.boundary = (linear_step.distance <= chord.length
                                || result.distance + update_length <= step);
 
-            if (update_length <= this->bump_distance())
-            {
-                cout << " + update length is less than bump distance" << endl;
-            }
             if (detail::is_intercept_close(state_.pos,
                                            chord.dir,
                                            linear_step.distance,

--- a/src/celeritas/field/detail/FieldUtils.hh
+++ b/src/celeritas/field/detail/FieldUtils.hh
@@ -127,17 +127,17 @@ inline CELER_FUNCTION real_type rel_err_sq(OdeState const& err_state,
  *   d = |\vec{AM}| \sin(\theta) = \frac{\vec{AM} \times \vec{AB}}{|\vec{AB}|}
  * \f]
  */
-inline CELER_FUNCTION real_type distance_chord(OdeState const& beg_state,
-                                               OdeState const& mid_state,
-                                               OdeState const& end_state)
+inline CELER_FUNCTION real_type distance_chord(Real3 const& beg_pos,
+                                               Real3 const& mid_pos,
+                                               Real3 const& end_pos)
 {
     Real3 beg_mid;
     Real3 beg_end;
 
     for (int i = 0; i < 3; ++i)
     {
-        beg_mid[i] = mid_state.pos[i] - beg_state.pos[i];
-        beg_end[i] = end_state.pos[i] - beg_state.pos[i];
+        beg_mid[i] = mid_pos[i] - beg_pos[i];
+        beg_end[i] = end_pos[i] - beg_pos[i];
     }
 
     Real3 cross = cross_product(beg_end, beg_mid);

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -155,9 +155,8 @@ TEST_F(FieldDriverTest, types)
             FieldDriver<DormandPrinceStepper<MagFieldEquation<UniformZField>>>,
             decltype(driver)>::value));
     // Size: field vector, q / c, reference to options
-    EXPECT_EQ(
-        sizeof(real_type) + sizeof(real_type) + sizeof(FieldDriverOptions*),
-        sizeof(driver));
+    EXPECT_EQ(3 * sizeof(real_type) + sizeof(FieldDriverOptions*),
+              sizeof(driver));
 }
 
 // Field strength changes quickly with z, so different chord steps require
@@ -189,8 +188,8 @@ TEST_F(FieldDriverTest, unpleasant_field)
         distance += result.step;
         state = result.state;
     }
-    EXPECT_EQ(31, stepper.count());
-    EXPECT_SOFT_EQ(7.2232269169635632, distance);
+    EXPECT_EQ(20, stepper.count());
+    EXPECT_SOFT_EQ(2.0197620480043263, distance);
 }
 
 // As the track moves along +z near 0, the field strength oscillates horribly,
@@ -266,12 +265,12 @@ TEST_F(FieldDriverTest, pathological_chord)
         lengths.push_back(end.step);
     }
 
-    static unsigned int const expected_counts[] = {1u, 6u, 1u, 1u, 1u};
+    static unsigned int const expected_counts[] = {1u, 6u, 4u, 4u, 4u};
     static double const expected_lengths[] = {0.029802281646312,
                                               0.30937398137671,
-                                              5.9604563292623,
-                                              11.920912658525,
-                                              23.841825317049};
+                                              0.30936881116327,
+                                              0.30936881114832,
+                                              0.30936881114832};
     EXPECT_VEC_EQ(expected_counts, counts);
     EXPECT_VEC_SOFT_EQ(expected_lengths, lengths);
 }
@@ -284,7 +283,6 @@ TEST_F(FieldDriverTest, step_counts)
     real_type field_strength = 1.0 * units::tesla;
     auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
         UniformZField{field_strength}, units::ElementaryCharge{-1});
-    FieldDriver driver{driver_options, stepper};
 
     std::vector<real_type> radii;
     std::vector<unsigned int> counts;
@@ -303,6 +301,7 @@ TEST_F(FieldDriverTest, step_counts)
         state.pos = {radius, 0, 0};
         state.mom = this->calc_momentum(e, {0, sqrt_two / 2, sqrt_two / 2});
 
+        FieldDriver driver{driver_options, stepper};
         for (int log_len : range(-4, 3).step(2))
         {
             real_type step_len = std::pow(10.0, log_len);
@@ -318,14 +317,14 @@ TEST_F(FieldDriverTest, step_counts)
     static double const expected_radii[] = {0.00010663611598835,
         0.0010663663247419, 0.010668826843187, 0.11173141982667,
         3.5019461121752, 333.73450257138, 33356.579970281};
-    static unsigned int const expected_counts[] = {1u, 93u, 779u, 786u, 1u,
-        12u, 90u, 96u, 1u, 1u, 29u, 35u, 1u, 1u, 7u, 15u, 1u, 1u, 2u, 9u, 1u,
+    static unsigned int const expected_counts[] = {1u, 93u, 779u, 777u, 1u,
+        12u, 90u, 87u, 1u, 1u, 29u, 25u, 1u, 1u, 7u, 5u, 1u, 1u, 2u, 3u, 1u,
         1u, 1u, 5u, 1u, 1u, 1u, 2u};
     static double const expected_lengths[] = {0.0001, 0.01, 0.077563521220272,
-        0.077562922424298, 0.0001, 0.01, 0.076209386999884, 0.076210431034511,
-        0.0001, 0.01, 0.063064075311856, 0.063064905456757, 0.0001, 0.01,
-        0.17398853544975, 0.1788332443937, 0.0001, 0.01, 0.99607291767799,
-        0.99606836440819, 0.0001, 0.01, 1, 9.7158185571513, 0.0001, 0.01, 1,
+        0.077562363386602, 0.0001, 0.01, 0.076209386999884, 0.076209671160348,
+        0.0001, 0.01, 0.063064075311856, 0.063065174124004, 0.0001, 0.01,
+        0.17398853544975, 0.17398853544975, 0.0001, 0.01, 0.99607291767799,
+        0.99607023941998, 0.0001, 0.01, 1, 9.7158185571513, 0.0001, 0.01, 1,
         97.132215683182};
     // clang-format on
 

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -20,7 +20,8 @@
 #include "celeritas/field/MagFieldEquation.hh"
 #include "celeritas/field/MakeMagFieldPropagator.hh"
 #include "celeritas/field/Types.hh"
-#include "celeritas/field/UniformField.hh"
+#include "celeritas/field/UniformZField.hh"
+#include "celeritas/field/ZHelixStepper.hh"
 #include "celeritas/field/detail/FieldUtils.hh"
 
 #include "DiagnosticStepper.hh"
@@ -146,16 +147,17 @@ TEST_F(FieldDriverTest, types)
 {
     FieldDriverOptions driver_options;
     auto driver = make_mag_field_driver<DormandPrinceStepper>(
-        UniformField({0, 0, 1}), driver_options, electron_charge());
+        UniformZField(1), driver_options, electron_charge());
 
     // Make sure object is holding things by value
     EXPECT_TRUE(
         (std::is_same<
-            FieldDriver<DormandPrinceStepper<MagFieldEquation<UniformField>>>,
+            FieldDriver<DormandPrinceStepper<MagFieldEquation<UniformZField>>>,
             decltype(driver)>::value));
     // Size: field vector, q / c, reference to options
-    EXPECT_EQ(sizeof(Real3) + sizeof(real_type) + sizeof(FieldDriverOptions*),
-              sizeof(driver));
+    EXPECT_EQ(
+        sizeof(real_type) + sizeof(real_type) + sizeof(FieldDriverOptions*),
+        sizeof(driver));
 }
 
 // Field strength changes quickly with z, so different chord steps require
@@ -174,7 +176,7 @@ TEST_F(FieldDriverTest, unpleasant_field)
     // Vary by a factor of 1024 over the radius of curvature
     auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
         ExpZField{field_strength, radius / 10}, units::ElementaryCharge{-1});
-    FieldDriver<decltype(stepper)&> driver{driver_options, stepper};
+    FieldDriver driver{driver_options, stepper};
 
     OdeState state;
     state.pos = {radius, 0, 0};
@@ -208,7 +210,7 @@ TEST_F(FieldDriverTest, horrible_field)
     auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
         HorribleZField{field_strength, radius / 10},
         units::ElementaryCharge{-1});
-    FieldDriver<decltype(stepper)&> driver{driver_options, stepper};
+    FieldDriver driver{driver_options, stepper};
 
     OdeState state;
     state.pos = {radius, 0, -radius / 5};
@@ -232,6 +234,48 @@ TEST_F(FieldDriverTest, horrible_field)
         << state.pos;
 }
 
+/*!
+ * Demonstrate the misbehavior of the chord finder for tightly circling
+ * particles.
+ */
+TEST_F(FieldDriverTest, pathological_chord)
+{
+    FieldDriverOptions driver_options;
+    driver_options.max_nsteps = std::numeric_limits<short int>::max();
+
+    real_type field_strength = 1.0 * units::tesla;
+    MevEnergy e{1.0};
+    real_type radius = this->calc_curvature(e, field_strength);
+
+    OdeState state;
+    state.pos = {radius, 0, 0};
+    state.mom = this->calc_momentum(e, {0, std::sqrt(1 - ipow<2>(0.2)), 0.2});
+
+    DiagnosticStepper stepper{ZHelixStepper{MagFieldEquation{
+        UniformZField{field_strength}, units::ElementaryCharge{-1}}}};
+    FieldDriver driver{driver_options, stepper};
+
+    std::vector<unsigned int> counts;
+    std::vector<real_type> lengths;
+
+    for (auto rev : {0.01, 1.0, 2.0, 4.0, 8.0})
+    {
+        stepper.reset_count();
+        auto end = driver.advance(rev * 2 * constants::pi * radius, state);
+        counts.push_back(stepper.count());
+        lengths.push_back(end.step);
+    }
+
+    static unsigned int const expected_counts[] = {1u, 6u, 1u, 1u, 1u};
+    static double const expected_lengths[] = {0.029802281646312,
+                                              0.30937398137671,
+                                              5.9604563292623,
+                                              11.920912658525,
+                                              23.841825317049};
+    EXPECT_VEC_EQ(expected_counts, counts);
+    EXPECT_VEC_SOFT_EQ(expected_lengths, lengths);
+}
+
 TEST_F(FieldDriverTest, step_counts)
 {
     FieldDriverOptions driver_options;
@@ -239,8 +283,8 @@ TEST_F(FieldDriverTest, step_counts)
 
     real_type field_strength = 1.0 * units::tesla;
     auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
-        UniformField({0, 0, field_strength}), units::ElementaryCharge{-1});
-    FieldDriver<decltype(stepper)&> driver{driver_options, stepper};
+        UniformZField{field_strength}, units::ElementaryCharge{-1});
+    FieldDriver driver{driver_options, stepper};
 
     std::vector<real_type> radii;
     std::vector<unsigned int> counts;
@@ -295,9 +339,7 @@ TEST_F(FieldDriverTest, step_counts)
 TEST_F(RevolutionFieldDriverTest, advance)
 {
     auto driver = make_mag_field_driver<DormandPrinceStepper>(
-        UniformField({0, 0, 1.0 * units::tesla}),
-        driver_options,
-        electron_charge());
+        UniformZField{1.0 * units::tesla}, driver_options, electron_charge());
 
     // Test parameters and the sub-step size
     real_type circumference = 2 * constants::pi * test_params.radius;
@@ -339,9 +381,7 @@ TEST_F(RevolutionFieldDriverTest, advance)
 TEST_F(RevolutionFieldDriverTest, accurate_advance)
 {
     auto driver = make_mag_field_driver<DormandPrinceStepper>(
-        UniformField({0, 0, 1.0 * units::tesla}),
-        driver_options,
-        electron_charge());
+        UniformZField{1.0 * units::tesla}, driver_options, electron_charge());
 
     // Test parameters and the sub-step size
     real_type circumference = 2 * constants::pi * test_params.radius;

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1313,7 +1313,7 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
             // Repeated substep bisection failed; particle is bumped
             EXPECT_SOFT_EQ(1e-6, result.distance);
             // Minor floating point differences could make this 98 or so
-            EXPECT_SOFT_NEAR(real_type(94), real_type(stepper.count()), 0.05);
+            EXPECT_SOFT_NEAR(real_type(1149), real_type(stepper.count()), 0.05);
             EXPECT_FALSE(result.looping);
         }
     }

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -239,7 +239,7 @@ TEST_F(TwoBoxTest, electron_interior)
         EXPECT_SOFT_EQ(0.5 * pi * radius, result.distance);
         EXPECT_LT(distance(Real3({-radius, 0, 0}), geo.pos()), 1e-6);
         EXPECT_SOFT_EQ(1.0, dot_product(Real3({0, -1, 0}), geo.dir()));
-        EXPECT_EQ(27, stepper.count());
+        EXPECT_EQ(21, stepper.count());
     }
 
     // Test a ridiculously long (half-turn) step to put us back at the start
@@ -250,7 +250,7 @@ TEST_F(TwoBoxTest, electron_interior)
         EXPECT_SOFT_EQ(pi * radius, result.distance);
         EXPECT_LT(distance(Real3({radius, 0, 0}), geo.pos()), 1e-5);
         EXPECT_SOFT_EQ(1.0, dot_product(Real3({0, 1, 0}), geo.dir()));
-        EXPECT_EQ(68, stepper.count());
+        EXPECT_EQ(40, stepper.count());
     }
 
     // Test step that's smaller than driver's minimum (should take one
@@ -261,8 +261,8 @@ TEST_F(TwoBoxTest, electron_interior)
         EXPECT_DOUBLE_EQ(1e-10, result.distance);
         EXPECT_FALSE(result.boundary);
         EXPECT_VEC_NEAR(
-            Real3({3.8085385881855, -2.3814749713353e-07, 0}), geo.pos(), 1e-7);
-        EXPECT_VEC_NEAR(Real3({6.2529888474538e-08, 1, 0}), geo.dir(), 1e-7);
+            Real3({3.8085385881855, -2.381487075086e-07, 0}), geo.pos(), 1e-7);
+        EXPECT_VEC_NEAR(Real3({6.25302065531623e-08, 1, 0}), geo.dir(), 1e-7);
         EXPECT_EQ(1, stepper.count());
     }
 }
@@ -1064,19 +1064,16 @@ TEST_F(TwoBoxTest, nonuniform_field)
     }
 
     // clang-format off
-    static double const expected_all_pos[] = {
-        -2.0825709359803, 0.69832583461676, 0.70710666844698,
-        -2.5772824508968, 1.1564020888258, 1.4141930958099,
-        -3.0638510057122, 0.77473521479087, 2.1212684403177,
-        -2.5583491669886, 0.58538464818192, 2.8283305521706,
-        -2.9046903231357, 0.86312856101992, 3.5354509992431,
-        -2.5810335650695, 0.76746368848985, 4.242728100241,
-        -2.7387773891353, 0.6033529790486, 4.9501400379322,
-        -2.6908755627764, 0.61552642042372, 5};
+    static double const expected_all_pos[] = {-2.0825709359803,
+        0.69832583461676, 0.70710666844698, -2.5772824508968, 1.1564020888258,
+        1.4141930958099, -3.0638510057122, 0.77473521479087, 2.1212684403177,
+        -2.5583489716647, 0.58538451986626, 2.828330789556, -2.904690468079,
+        0.86312828878343, 3.5354504022784, -2.5810333947926, 0.76746526072066,
+        4.2427268982429, -2.7387860743405, 0.6033460543227, 4.9501275639478,
+        -2.6908723120116, 0.6155217193027, 5};
+    static int const expected_step_counter[] = {3, 3, 6, 6, 9, 10, 13, 8};
     // clang-format on
     EXPECT_VEC_SOFT_EQ(expected_all_pos, all_pos);
-
-    static int const expected_step_counter[] = {3, 3, 6, 6, 9, 11, 15, 9};
     EXPECT_VEC_EQ(expected_step_counter, step_counter);
 }
 
@@ -1208,8 +1205,8 @@ TEST_F(SimpleCmsTest, electron_stuck)
             = make_field_propagator(stepper, driver_options, particle, geo);
         auto result = propagate(30);
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
-        EXPECT_LE(870, stepper.count());
-        EXPECT_LE(stepper.count(), 900);
+        EXPECT_LE(370, stepper.count());
+        EXPECT_LE(stepper.count(), 380);
         ASSERT_TRUE(geo.is_on_boundary());
         if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
         {
@@ -1306,9 +1303,9 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         if (successful_reentry)
         {
             // Extremely long propagation stopped by substep countdown
-            EXPECT_SOFT_EQ(11.676851876556075, result.distance);
+            EXPECT_SOFT_EQ(12.02714054426572, result.distance);
             EXPECT_EQ("em_calorimeter", this->volume_name(geo));
-            EXPECT_EQ(7800, stepper.count());
+            EXPECT_EQ(573, stepper.count());
             EXPECT_TRUE(result.looping);
         }
         else

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -263,10 +263,10 @@ TEST_F(MockAlongStepFieldTest, basic)
         inp.phys_mfp = 100;
         auto result = this->run(inp, num_tracks);
         EXPECT_SOFT_EQ(0.001, result.eloss);
-        EXPECT_SOFT_NEAR(0.014776612598411, result.displacement, 1e-10);
-        EXPECT_SOFT_NEAR(-0.57745338446847, result.angle, 1e-10);
-        EXPECT_SOFT_EQ(5.5782096149372e-09, result.time);
-        EXPECT_SOFT_EQ(7.4731723740905, result.step);
+        EXPECT_SOFT_NEAR(0.014775335072293276, result.displacement, 1e-10);
+        EXPECT_SOFT_NEAR(-0.57704594283791188, result.angle, 1e-10);
+        EXPECT_SOFT_EQ(5.5782056196201597e-09, result.time);
+        EXPECT_SOFT_EQ(7.4731670215320127, result.step);
         EXPECT_SOFT_EQ(0, result.mfp);
         EXPECT_SOFT_EQ(1, result.alive);
         EXPECT_EQ("physics-discrete-select", result.action);
@@ -489,7 +489,7 @@ TEST_F(SimpleCmsAlongStepTest, msc_field)
                          -0.0391118941072485030};
         // Step limited by distance to interaction = 2.49798914193346685e21
         auto result = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(27.208980085333259, result.step);
+        EXPECT_SOFT_EQ(27.208989423735016, result.step);
         EXPECT_EQ(0, result.eloss);
         EXPECT_EQ(0, result.mfp);
         EXPECT_EQ("geo-propagation-limit", result.action);
@@ -537,8 +537,8 @@ TEST_F(SimpleCmsRZFieldAlongStepTest, msc_rzfield)
                          -0.0391118941072485030};
 
         auto result = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(4.1632771293464517, result.displacement);
-        EXPECT_SOFT_NEAR(-0.59445466152831616, result.angle, 2e-12);
+        EXPECT_SOFT_EQ(4.1632772063250023, result.displacement);
+        EXPECT_SOFT_NEAR(-0.59445532857679839, result.angle, 2e-12);
     }
 }
 

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -268,7 +268,7 @@ TEST_F(TestEm3MctruthTest, four_step)
             -20, -0.62729376699778, 0, -19.969797686903, -0.66354024672438,
             -0.0032805361823643, -19.956976222507, -0.71463257305966,
             0.010438618638369};
-        EXPECT_VEC_SOFT_EQ(expected_pos, result.pos);
+        EXPECT_VEC_NEAR(expected_pos, result.pos, 1e-11);
         static const double expected_dir[] = {1, 0, 0, 0.82087264698347,
             0.57111128288133, 0, 0.86898688645512, 0.46973495237486,
             0.15559841158064, 0.99921943764862, 0.020164890030908,
@@ -281,7 +281,7 @@ TEST_F(TestEm3MctruthTest, four_step)
             -0.57111128288041, 0, 0.45731722153487, -0.78666386310603,
             0.41475405407388, 0.35982246270509, -0.81678277174296,
             0.45099190582174};
-        EXPECT_VEC_SOFT_EQ(expected_dir, result.dir);
+        EXPECT_VEC_NEAR(expected_dir, result.dir, 1e-10);
         // clang-format on
     }
     else


### PR DESCRIPTION
Inside the propagation loop, we currently have to recalculate the chord length at every `advance` call. If the steps are small compared to the radius of curvature this is no big deal. However for low-energy tracks we could conceivably do a lot of extra work recalculating the chord tolerance length. This change primarily keeps a "generous" estimate of the chord length for subsequent calls to the field driver in the same step. The data is temporary so will be discarded between subsequent steps.

Although the unit tests show a substantial improvement in the number of integrations per step, the CMS 2018 performance regression test shows zero improvement in timing (and no looping tracks are being killed early).