### PR TITLE
Validate `KernelParamCalculator` block size using CUDA/HIP function attributes

### DIFF
--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -89,11 +89,7 @@ class ActionLauncher
              std::enable_if_t<detail::has_max_block_size_v<A_>, bool> = true>
     explicit ActionLauncher(std::string_view name)
         : calc_launch_params_{
-            name,
-            &detail::launch_action_impl<F_>,
-            A_::max_block_size < celeritas::device().default_block_size()
-                ? A_::max_block_size
-                : celeritas::device().default_block_size()}
+            name, &detail::launch_action_impl<F_>, A_::max_block_size}
     {
     }
 

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -70,14 +70,13 @@ class ActionLauncher
 
     // Alias F to avoid hard error as SFINAE only works in the immediate
     // context
-    template<typename F_ = F,
-             std::enable_if_t<!detail::has_applier_v<F_>, bool> = true>
+    template<class F_ = F, std::enable_if_t<!detail::has_applier_v<F_>, bool> = true>
     explicit ActionLauncher(std::string_view name)
         : calc_launch_params_{name, &detail::launch_action_impl<F_>}
     {
     }
 
-    template<typename F_ = F,
+    template<class F_ = F,
              std::enable_if_t<detail::kernel_no_bound<typename F_::Applier>, bool>
              = true>
     explicit ActionLauncher(std::string_view name)
@@ -85,12 +84,16 @@ class ActionLauncher
     {
     }
 
-    template<typename F_ = F,
-             std::enable_if_t<detail::has_max_block_size_v<typename F_::Applier>, bool>
-             = true>
+    template<class F_ = F,
+             class A_ = typename F_::Applier,
+             std::enable_if_t<detail::has_max_block_size_v<A_>, bool> = true>
     explicit ActionLauncher(std::string_view name)
         : calc_launch_params_{
-            name, &detail::launch_action_impl<F_>, F_::Applier::max_block_size}
+            name,
+            &detail::launch_action_impl<F_>,
+            A_::max_block_size < celeritas::device().default_block_size()
+                ? A_::max_block_size
+                : celeritas::device().default_block_size()}
     {
     }
 


### PR DESCRIPTION
~Sorry, missed that on #853, we don't want to use the max threads per block as block size if it's higher than the default block size.~