### PR TITLE
Refactor and extend BoundingBox

### DIFF
--- a/src/celeritas/ext/GeantGeoParams.cc
+++ b/src/celeritas/ext/GeantGeoParams.cc
@@ -246,12 +246,12 @@ void GeantGeoParams::build_metadata()
 
         G4VisExtent const& extent = solid->GetExtent();
 
-        return BoundingBox({convert_from_geant(extent.GetXmin(), CLHEP::cm),
-                            convert_from_geant(extent.GetYmin(), CLHEP::cm),
-                            convert_from_geant(extent.GetZmin(), CLHEP::cm)},
-                           {convert_from_geant(extent.GetXmax(), CLHEP::cm),
-                            convert_from_geant(extent.GetYmax(), CLHEP::cm),
-                            convert_from_geant(extent.GetZmax(), CLHEP::cm)});
+        return BBox({convert_from_geant(extent.GetXmin(), CLHEP::cm),
+                     convert_from_geant(extent.GetYmin(), CLHEP::cm),
+                     convert_from_geant(extent.GetZmin(), CLHEP::cm)},
+                    {convert_from_geant(extent.GetXmax(), CLHEP::cm),
+                     convert_from_geant(extent.GetYmax(), CLHEP::cm),
+                     convert_from_geant(extent.GetZmax(), CLHEP::cm)});
     }();
 }
 

--- a/src/celeritas/ext/GeantGeoParams.hh
+++ b/src/celeritas/ext/GeantGeoParams.hh
@@ -55,7 +55,7 @@ class GeantGeoParams final : public GeoParamsInterface,
     bool supports_safety() const final { return true; }
 
     //! Outer bounding box of geometry
-    BoundingBox const& bbox() const final { return bbox_; }
+    BBox const& bbox() const final { return bbox_; }
 
     //// VOLUMES ////
 
@@ -105,7 +105,7 @@ class GeantGeoParams final : public GeoParamsInterface,
 
     // Host metadata/access
     LabelIdMultiMap<VolumeId> vol_labels_;
-    BoundingBox bbox_;
+    BBox bbox_;
 
     // Host/device storage and reference
     HostRef host_ref_;

--- a/src/celeritas/ext/VecgeomParams.cc
+++ b/src/celeritas/ext/VecgeomParams.cc
@@ -395,7 +395,7 @@ void VecgeomParams::build_metadata()
         Vector3D<real_type> lower, upper;
         ABBoxManager::Instance().ComputeABBox(pv, &lower, &upper);
 
-        return BoundingBox{detail::to_array(lower), detail::to_array(upper)};
+        return BBox{detail::to_array(lower), detail::to_array(upper)};
     }();
 }
 

--- a/src/celeritas/ext/VecgeomParams.hh
+++ b/src/celeritas/ext/VecgeomParams.hh
@@ -46,7 +46,7 @@ class VecgeomParams final : public GeoParamsInterface,
     bool supports_safety() const final { return true; }
 
     //! Outer bounding box of geometry
-    BoundingBox const& bbox() const final { return bbox_; }
+    BBox const& bbox() const final { return bbox_; }
 
     //! Maximum nested geometry depth
     int max_depth() const { return host_ref_.max_depth; }
@@ -93,7 +93,7 @@ class VecgeomParams final : public GeoParamsInterface,
     LabelIdMultiMap<VolumeId> vol_labels_;
     std::unordered_map<G4LogicalVolume const*, VolumeId> g4log_volid_map_;
 
-    BoundingBox bbox_;
+    BBox bbox_;
 
     // Host/device storage and reference
     HostRef host_ref_;

--- a/src/orange/BoundingBox.hh
+++ b/src/orange/BoundingBox.hh
@@ -32,7 +32,7 @@ class BoundingBox
     //!@{
     //! \name Type aliases
     using value_type = T;
-    using array_type = Array<value_type, 3>;
+    using Array3 = Array<value_type, 3>;
     //!@}
 
     // Construct from infinite extents
@@ -42,23 +42,22 @@ class BoundingBox
     inline CELER_FUNCTION BoundingBox();
 
     // Construct from upper and lower points
-    inline CELER_FUNCTION
-    BoundingBox(array_type const& lower, array_type const& upper);
+    inline CELER_FUNCTION BoundingBox(Array3 const& lower, Array3 const& upper);
 
     //// ACCESSORS ////
 
     // Lower bbox coordinate
-    CELER_FORCEINLINE_FUNCTION array_type const& lower() const;
+    CELER_FORCEINLINE_FUNCTION Array3 const& lower() const;
 
     // Upper bbox coordinate
-    CELER_FORCEINLINE_FUNCTION array_type const& upper() const;
+    CELER_FORCEINLINE_FUNCTION Array3 const& upper() const;
 
     // Whether the bbox is assigned
     CELER_FORCEINLINE_FUNCTION explicit operator bool() const;
 
   private:
-    array_type lower_;
-    array_type upper_;
+    Array3 lower_;
+    Array3 upper_;
 };
 
 //---------------------------------------------------------------------------//
@@ -99,8 +98,7 @@ CELER_FUNCTION BoundingBox<T>::BoundingBox()
  * at a single point) but upper must not be less than lower.
  */
 template<class T>
-CELER_FUNCTION
-BoundingBox<T>::BoundingBox(array_type const& lo, array_type const& hi)
+CELER_FUNCTION BoundingBox<T>::BoundingBox(Array3 const& lo, Array3 const& hi)
     : lower_(lo), upper_(hi)
 {
     CELER_EXPECT(lower_[0] <= upper_[0] && lower_[1] <= upper_[1]
@@ -112,7 +110,7 @@ BoundingBox<T>::BoundingBox(array_type const& lo, array_type const& hi)
  * Lower bbox coordinate (must be valid).
  */
 template<class T>
-CELER_FUNCTION typename BoundingBox<T>::array_type const&
+CELER_FUNCTION typename BoundingBox<T>::Array3 const&
 BoundingBox<T>::lower() const
 {
     CELER_EXPECT(*this);
@@ -124,7 +122,7 @@ BoundingBox<T>::lower() const
  * Upper bbox coordinate (must be valid).
  */
 template<class T>
-CELER_FUNCTION typename BoundingBox<T>::array_type const&
+CELER_FUNCTION typename BoundingBox<T>::Array3 const&
 BoundingBox<T>::upper() const
 {
     CELER_EXPECT(*this);

--- a/src/orange/BoundingBox.hh
+++ b/src/orange/BoundingBox.hh
@@ -22,16 +22,19 @@ namespace celeritas
 /*!
  * Axis-aligned bounding box.
  *
- * This is currently a pretty boring class; it will be extended as needed.
- * We'll add a BoundingBoxUtils class for all the fancy operations that need
- * only the accessors we provide.
- *
  * The bounding box can be constructed in an unassigned state, in which lower
  * and upper cannot be called.
  */
+template<class T>
 class BoundingBox
 {
   public:
+    //!@{
+    //! \name Type aliases
+    using value_type = T;
+    using array_type = Array<value_type, 3>;
+    //!@}
+
     // Construct from infinite extents
     static inline CELER_FUNCTION BoundingBox from_infinite();
 
@@ -39,23 +42,31 @@ class BoundingBox
     inline CELER_FUNCTION BoundingBox();
 
     // Construct from upper and lower points
-    inline CELER_FUNCTION BoundingBox(Real3 const& lower, Real3 const& upper);
+    inline CELER_FUNCTION
+    BoundingBox(array_type const& lower, array_type const& upper);
 
     //// ACCESSORS ////
 
     // Lower bbox coordinate
-    CELER_FORCEINLINE_FUNCTION Real3 const& lower() const;
+    CELER_FORCEINLINE_FUNCTION array_type const& lower() const;
 
     // Upper bbox coordinate
-    CELER_FORCEINLINE_FUNCTION Real3 const& upper() const;
+    CELER_FORCEINLINE_FUNCTION array_type const& upper() const;
 
     // Whether the bbox is assigned
     CELER_FORCEINLINE_FUNCTION explicit operator bool() const;
 
   private:
-    Real3 lower_;
-    Real3 upper_;
+    array_type lower_;
+    array_type upper_;
 };
+
+//---------------------------------------------------------------------------//
+// TYPE ALIASES
+//---------------------------------------------------------------------------//
+
+//! Bounding box for host metadata
+using BBox = BoundingBox<real_type>;
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
@@ -63,9 +74,10 @@ class BoundingBox
 /*!
  * Create a bounding box with infinite extents.
  */
-CELER_FUNCTION BoundingBox BoundingBox::from_infinite()
+template<class T>
+CELER_FUNCTION BoundingBox<T> BoundingBox<T>::from_infinite()
 {
-    constexpr real_type inf = numeric_limits<real_type>::infinity();
+    constexpr value_type inf = numeric_limits<value_type>::infinity();
     return {{-inf, -inf, -inf}, {inf, inf, inf}};
 }
 
@@ -73,9 +85,10 @@ CELER_FUNCTION BoundingBox BoundingBox::from_infinite()
 /*!
  * Create a bounding box in an invalid state.
  */
-CELER_FUNCTION BoundingBox::BoundingBox()
+template<class T>
+CELER_FUNCTION BoundingBox<T>::BoundingBox()
 {
-    lower_[0] = numeric_limits<real_type>::quiet_NaN();
+    lower_[0] = numeric_limits<value_type>::quiet_NaN();
 }
 
 //---------------------------------------------------------------------------//
@@ -85,7 +98,9 @@ CELER_FUNCTION BoundingBox::BoundingBox()
  * The lower and upper points are allowed to be equal (an empty bounding box
  * at a single point) but upper must not be less than lower.
  */
-CELER_FUNCTION BoundingBox::BoundingBox(Real3 const& lo, Real3 const& hi)
+template<class T>
+CELER_FUNCTION
+BoundingBox<T>::BoundingBox(array_type const& lo, array_type const& hi)
     : lower_(lo), upper_(hi)
 {
     CELER_EXPECT(lower_[0] <= upper_[0] && lower_[1] <= upper_[1]
@@ -96,7 +111,9 @@ CELER_FUNCTION BoundingBox::BoundingBox(Real3 const& lo, Real3 const& hi)
 /*!
  * Lower bbox coordinate (must be valid).
  */
-CELER_FUNCTION Real3 const& BoundingBox::lower() const
+template<class T>
+CELER_FUNCTION typename BoundingBox<T>::array_type const&
+BoundingBox<T>::lower() const
 {
     CELER_EXPECT(*this);
     return lower_;
@@ -106,7 +123,9 @@ CELER_FUNCTION Real3 const& BoundingBox::lower() const
 /*!
  * Upper bbox coordinate (must be valid).
  */
-CELER_FUNCTION Real3 const& BoundingBox::upper() const
+template<class T>
+CELER_FUNCTION typename BoundingBox<T>::array_type const&
+BoundingBox<T>::upper() const
 {
     CELER_EXPECT(*this);
     return upper_;
@@ -116,7 +135,8 @@ CELER_FUNCTION Real3 const& BoundingBox::upper() const
 /*!
  * Whether the bbox is in an assigned state.
  */
-CELER_FUNCTION BoundingBox::operator bool() const
+template<class T>
+CELER_FUNCTION BoundingBox<T>::operator bool() const
 {
     return !std::isnan(lower_[0]);
 }

--- a/src/orange/BoundingBoxIO.json.hh
+++ b/src/orange/BoundingBoxIO.json.hh
@@ -17,7 +17,7 @@
 namespace
 {
 template<class T>
-inline void fix_inf(typename celeritas::BoundingBox<T>::array_type* point)
+inline void fix_inf(celeritas::Array<T, 3>* point)
 {
     constexpr auto max_real = std::numeric_limits<
         typename celeritas::BoundingBox<T>::value_type>::max();
@@ -47,9 +47,8 @@ inline void from_json(nlohmann::json const& j, BoundingBox<T>& bbox)
     CELER_VALIDATE(j.size() == 2,
                    << " bounding box must have lower and upper extents");
 
-    using array_type = typename BoundingBox<T>::array_type;
-    auto lower = j[0].get<array_type>();
-    auto upper = j[1].get<array_type>();
+    auto lower = j[0].get<Array<T, 3>>();
+    auto upper = j[1].get<Array<T, 3>>();
 
     fix_inf<T>(&lower);
     fix_inf<T>(&upper);

--- a/src/orange/BoundingBoxIO.json.hh
+++ b/src/orange/BoundingBoxIO.json.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <cmath>
 #include <limits>
 #include <nlohmann/json.hpp>
 
@@ -14,15 +15,15 @@
 
 #include "BoundingBox.hh"
 
-namespace
+namespace detail
 {
+//---------------------------------------------------------------------------//
+//! Replace "max" with "inf" since the latter can't be represented in JSON.
 template<class T>
 inline void fix_inf(celeritas::Array<T, 3>* point)
 {
-    constexpr auto max_real = std::numeric_limits<
-        typename celeritas::BoundingBox<T>::value_type>::max();
-    constexpr auto inf = std::numeric_limits<
-        typename celeritas::BoundingBox<T>::value_type>::infinity();
+    constexpr auto max_real = std::numeric_limits<T>::max();
+    constexpr auto inf = std::numeric_limits<T>::infinity();
 
     for (auto axis : range(celeritas::Axis::size_))
     {
@@ -33,6 +34,7 @@ inline void fix_inf(celeritas::Array<T, 3>* point)
         }
     }
 }
+//---------------------------------------------------------------------------//
 }  // namespace
 
 namespace celeritas
@@ -50,8 +52,8 @@ inline void from_json(nlohmann::json const& j, BoundingBox<T>& bbox)
     auto lower = j[0].get<Array<T, 3>>();
     auto upper = j[1].get<Array<T, 3>>();
 
-    fix_inf<T>(&lower);
-    fix_inf<T>(&upper);
+    fix_inf(&lower);
+    fix_inf(&upper);
 
     bbox = BoundingBox<T>{lower, upper};
 }

--- a/src/orange/BoundingBoxIO.json.hh
+++ b/src/orange/BoundingBoxIO.json.hh
@@ -7,11 +7,33 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <limits>
 #include <nlohmann/json.hpp>
 
 #include "corecel/cont/ArrayIO.json.hh"
 
 #include "BoundingBox.hh"
+
+namespace
+{
+template<class T>
+inline void fix_inf(typename celeritas::BoundingBox<T>::array_type* point)
+{
+    constexpr auto max_real = std::numeric_limits<
+        typename celeritas::BoundingBox<T>::value_type>::max();
+    constexpr auto inf = std::numeric_limits<
+        typename celeritas::BoundingBox<T>::value_type>::infinity();
+
+    for (auto axis : range(celeritas::Axis::size_))
+    {
+        auto ax = to_int(axis);
+        if (std::fabs((*point)[ax]) == max_real)
+        {
+            (*point)[ax] = std::copysign(inf, (*point)[ax]);
+        }
+    }
+}
+}  // namespace
 
 namespace celeritas
 {
@@ -19,17 +41,28 @@ namespace celeritas
 /*!
  * Read a quantity from a JSON file.
  */
-inline void from_json(nlohmann::json const& j, BoundingBox& bbox)
+template<class T>
+inline void from_json(nlohmann::json const& j, BoundingBox<T>& bbox)
 {
-    auto arrays = j.at("bbox").get<Array<Real3, 2>>();
-    bbox = {arrays[0], arrays[1]};
+    CELER_VALIDATE(j.size() == 2,
+                   << " bounding box must have lower and upper extents");
+
+    using array_type = typename BoundingBox<T>::array_type;
+    auto lower = j[0].get<array_type>();
+    auto upper = j[1].get<array_type>();
+
+    fix_inf<T>(&lower);
+    fix_inf<T>(&upper);
+
+    bbox = BoundingBox<T>{lower, upper};
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Write an array to a JSON file.
  */
-inline void to_json(nlohmann::json& j, BoundingBox const& bbox)
+template<class T>
+inline void to_json(nlohmann::json& j, BoundingBox<T> const& bbox)
 {
     j = {bbox.lower(), bbox.upper()};
 }

--- a/src/orange/BoundingBoxIO.json.hh
+++ b/src/orange/BoundingBoxIO.json.hh
@@ -15,6 +15,8 @@
 
 #include "BoundingBox.hh"
 
+namespace celeritas
+{
 namespace detail
 {
 //---------------------------------------------------------------------------//
@@ -35,10 +37,8 @@ inline void fix_inf(celeritas::Array<T, 3>* point)
     }
 }
 //---------------------------------------------------------------------------//
-}  // namespace
+}  // namespace detail
 
-namespace celeritas
-{
 //---------------------------------------------------------------------------//
 /*!
  * Read a quantity from a JSON file.
@@ -52,8 +52,8 @@ inline void from_json(nlohmann::json const& j, BoundingBox<T>& bbox)
     auto lower = j[0].get<Array<T, 3>>();
     auto upper = j[1].get<Array<T, 3>>();
 
-    fix_inf(&lower);
-    fix_inf(&upper);
+    detail::fix_inf(&lower);
+    detail::fix_inf(&upper);
 
     bbox = BoundingBox<T>{lower, upper};
 }

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -50,8 +50,7 @@ inline bool is_infinite(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
 
-    constexpr auto max_real
-        = std::numeric_limits<typename BoundingBox<T>::value_type>::max();
+    constexpr auto max_real = std::numeric_limits<T>::max();
 
     for (auto axis : range(Axis::size_))
     {
@@ -88,8 +87,7 @@ inline Array<T, 3> center(BoundingBox<T> const& bbox)
  * Calculate the surface area of a bounding box.
  */
 template<class T>
-inline typename BoundingBox<T>::value_type
-surface_area(BoundingBox<T> const& bbox)
+inline T surface_area(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
 
@@ -109,7 +107,7 @@ surface_area(BoundingBox<T> const& bbox)
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate bounding box enclosing two bounding boxes.
+ * Calculate the smallest bounding box enclosing two bounding boxes.
  */
 template<class T>
 inline BoundingBox<T>

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -23,7 +23,7 @@ namespace celeritas
  */
 template<class T>
 inline CELER_FUNCTION bool
-is_inside(BoundingBox<T> const& bbox, typename BoundingBox<T>::array_type point)
+is_inside(BoundingBox<T> const& bbox, Array<T, 3> point)
 {
     CELER_EXPECT(bbox);
 
@@ -69,11 +69,11 @@ inline bool is_infinite(BoundingBox<T> const& bbox)
  * Calculate the center of a bounding box.
  */
 template<class T>
-inline Real3 center(BoundingBox<T> const& bbox)
+inline Array<T, 3> center(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
 
-    Real3 center;
+    Array<T, 3> center;
     for (auto axis : range(Axis::size_))
     {
         auto ax = to_int(axis);
@@ -93,7 +93,7 @@ surface_area(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
 
-    Array<typename BoundingBox<T>::value_type, to_int(Axis::size_)> lengths;
+    Array<T, 3> lengths;
 
     for (auto axis : range(Axis::size_))
     {
@@ -117,7 +117,8 @@ bbox_union(BoundingBox<T> const& a, BoundingBox<T> const& b)
 {
     CELER_EXPECT(a && b);
 
-    typename BoundingBox<T>::array_type lower, upper;
+    Array<T, 3> lower;
+    Array<T, 3> upper;
 
     for (auto axis : range(Axis::size_))
     {

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -1,0 +1,133 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/BoundingBoxUtils.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <limits>
+
+#include "corecel/cont/Range.hh"
+#include "orange/BoundingBox.hh"
+#include "orange/OrangeTypes.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+// Host/device functions
+//---------------------------------------------------------------------------//
+/*!
+ * Determine if a point is contained in a bounding box.
+ */
+template<class T>
+inline CELER_FUNCTION bool
+is_inside(BoundingBox<T> const& bbox, typename BoundingBox<T>::array_type point)
+{
+    CELER_EXPECT(bbox);
+
+    for (auto axis : range(Axis::size_))
+    {
+        auto ax = to_int(axis);
+        if (point[ax] < bbox.lower()[ax] || point[ax] > bbox.upper()[ax])
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+//---------------------------------------------------------------------------//
+// Host-only functions
+//---------------------------------------------------------------------------//
+/*!
+ * Check if a bounding box spans (-inf, inf) in every direction.
+ */
+template<class T>
+inline bool is_infinite(BoundingBox<T> const& bbox)
+{
+    CELER_EXPECT(bbox);
+
+    constexpr auto max_real
+        = std::numeric_limits<typename BoundingBox<T>::value_type>::max();
+
+    for (auto axis : range(Axis::size_))
+    {
+        auto ax = to_int(axis);
+        if (bbox.lower()[ax] > -max_real || bbox.upper()[ax] < max_real)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the center of a bounding box.
+ */
+template<class T>
+inline Real3 center(BoundingBox<T> const& bbox)
+{
+    CELER_EXPECT(bbox);
+
+    Real3 center;
+    for (auto axis : range(Axis::size_))
+    {
+        auto ax = to_int(axis);
+        center[ax] = (bbox.lower()[ax] + bbox.upper()[ax]) / 2;
+    }
+
+    return center;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the surface area of a bounding box.
+ */
+template<class T>
+inline typename BoundingBox<T>::value_type
+surface_area(BoundingBox<T> const& bbox)
+{
+    CELER_EXPECT(bbox);
+
+    Array<typename BoundingBox<T>::value_type, to_int(Axis::size_)> lengths;
+
+    for (auto axis : range(Axis::size_))
+    {
+        auto ax = to_int(axis);
+        lengths[ax] = bbox.upper()[ax] - bbox.lower()[ax];
+    }
+
+    return 2
+           * (lengths[to_int(Axis::x)] * lengths[to_int(Axis::y)]
+              + lengths[to_int(Axis::x)] * lengths[to_int(Axis::z)]
+              + lengths[to_int(Axis::y)] * lengths[to_int(Axis::z)]);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate bounding box enclosing two bounding boxes.
+ */
+template<class T>
+inline BoundingBox<T>
+bbox_union(BoundingBox<T> const& a, BoundingBox<T> const& b)
+{
+    CELER_EXPECT(a && b);
+
+    typename BoundingBox<T>::array_type lower, upper;
+
+    for (auto axis : range(Axis::size_))
+    {
+        auto ax = to_int(axis);
+        lower[ax] = std::min(a.lower()[ax], b.lower()[ax]);
+        upper[ax] = std::max(a.upper()[ax], b.upper()[ax]);
+    }
+
+    return BoundingBox<T>{lower, upper};
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/GeoParamsInterface.hh
+++ b/src/orange/GeoParamsInterface.hh
@@ -34,7 +34,7 @@ class GeoParamsInterface
     virtual bool supports_safety() const = 0;
 
     //! Outer bounding box of geometry
-    virtual BoundingBox const& bbox() const = 0;
+    virtual BBox const& bbox() const = 0;
 
     //// VOLUMES ////
 

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -56,7 +56,7 @@ struct Overload : Ts...
  * "Deduction guide" for instantiating Overload objects w/o specifying types.
  */
 template<class... Ts>
-Overload(Ts...) -> Overload<Ts...>;
+Overload(Ts&&...) -> Overload<Ts...>;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -51,7 +51,7 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     bool supports_safety() const final { return supports_safety_; }
 
     //! Outer bounding box of geometry
-    BoundingBox const& bbox() const final { return bbox_; }
+    BBox const& bbox() const final { return bbox_; }
 
     //// VOLUMES ////
 
@@ -100,7 +100,7 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     // Host metadata/access
     LabelIdMultiMap<SurfaceId> surf_labels_;
     LabelIdMultiMap<VolumeId> vol_labels_;
-    BoundingBox bbox_;
+    BBox bbox_;
     bool supports_safety_{};
 
     // Host/device storage and reference

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -59,8 +59,8 @@ struct VolumeInput
     std::vector<LocalSurfaceId> faces{};
     //! RPN region definition for this volume, using local surface index
     std::vector<logic_int> logic{};
-    //! Axis-aligned bounding box (TODO: currently unused)
-    BoundingBox bbox{};
+    //! Axis-aligned bounding box
+    BBox bbox{};
 
     //! Special flags
     logic_int flags{0};
@@ -94,7 +94,7 @@ struct UnitInput
 
     SurfaceInput surfaces;
     std::vector<VolumeInput> volumes;
-    BoundingBox bbox;  //!< Outer bounding box
+    BBox bbox;  //!< Outer bounding box
     MapVolumeDaughter daughter_map;
 
     // Unit metadata

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -187,8 +187,7 @@ void from_json(nlohmann::json const& j, UnitInput& value)
         j.at("surface_names").get_to(value.surfaces.labels);
     }
     {
-        auto const& bbox = j.at("bbox");
-        value.bbox = {bbox.at(0).get<Real3>(), bbox.at(1).get<Real3>()};
+        j.at("bbox").get_to(value.bbox);
     }
 
     if (j.contains("parent_cells"))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -218,6 +218,7 @@ celeritas_setup_tests(SERIAL PREFIX orange
 #-----------------------------------------------------------------------------#
 # Base
 celeritas_add_test(orange/BoundingBox.test.cc)
+celeritas_add_test(orange/BoundingBoxUtils.test.cc)
 celeritas_add_test(orange/Orange.test.cc)
 celeritas_add_test(orange/Translator.test.cc)
 

--- a/test/orange/BoundingBox.test.cc
+++ b/test/orange/BoundingBox.test.cc
@@ -20,7 +20,7 @@ using BoundingBoxTest = Test;
 
 TEST_F(BoundingBoxTest, null)
 {
-    BoundingBox null_bbox;
+    BBox null_bbox;
     EXPECT_FALSE(null_bbox);
     if (CELERITAS_DEBUG)
     {
@@ -31,7 +31,7 @@ TEST_F(BoundingBoxTest, null)
 
 TEST_F(BoundingBoxTest, infinite)
 {
-    BoundingBox ibb = BoundingBox::from_infinite();
+    BBox ibb = BBox::from_infinite();
     EXPECT_SOFT_EQ(-inf, ibb.lower()[0]);
     EXPECT_SOFT_EQ(-inf, ibb.lower()[1]);
     EXPECT_SOFT_EQ(-inf, ibb.lower()[2]);
@@ -45,12 +45,12 @@ TEST_F(BoundingBoxTest, standard)
     if (CELERITAS_DEBUG)
     {
         const Real3 lo{-1, -2, -3};
-        EXPECT_THROW((BoundingBox{lo, {-4, 5, 6}}), DebugError);
-        EXPECT_THROW((BoundingBox{lo, {4, -5, 6}}), DebugError);
-        EXPECT_THROW((BoundingBox{lo, {4, 5, -6}}), DebugError);
+        EXPECT_THROW((BBox{lo, {-4, 5, 6}}), DebugError);
+        EXPECT_THROW((BBox{lo, {4, -5, 6}}), DebugError);
+        EXPECT_THROW((BBox{lo, {4, 5, -6}}), DebugError);
     }
 
-    BoundingBox bb{{-1, -2, 3}, {4, 5, 6}};
+    BBox bb{{-1, -2, 3}, {4, 5, 6}};
     EXPECT_TRUE(bb);
     EXPECT_VEC_SOFT_EQ((Real3{-1, -2, 3}), bb.lower());
     EXPECT_VEC_SOFT_EQ((Real3{4, 5, 6}), bb.upper());

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -1,0 +1,66 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021-2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/detail/BoundingBoxUtils.test.cc
+//---------------------------------------------------------------------------//
+#include "orange/BoundingBoxUtils.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+TEST(BoundingBoxUtilsTest, is_inside)
+{
+    BBox bbox1 = {{-5, -2, -100}, {6, 1, 1}};
+    EXPECT_TRUE(is_inside(bbox1, Real3{-4, 0, 0}));
+    EXPECT_TRUE(is_inside(bbox1, Real3{-4.9, -1.9, -99.9}));
+    EXPECT_FALSE(is_inside(bbox1, Real3{-6, 0, 0}));
+    EXPECT_FALSE(is_inside(bbox1, Real3{-5.1, -2.1, -101.1}));
+}
+
+TEST(BoundingBoxUtilsTest, is_infinite)
+{
+    auto max_real = std::numeric_limits<real_type>::max();
+    auto inf_real = std::numeric_limits<real_type>::infinity();
+
+    BBox bbox1 = {{0, 0, 0}, {1, 1, 1}};
+    EXPECT_FALSE(is_infinite(bbox1));
+
+    BBox bbox2 = {{0, 0, 0}, {max_real, inf_real, max_real}};
+    EXPECT_FALSE(is_infinite(bbox2));
+
+    BBox bbox3
+        = {{-max_real, -inf_real, -max_real}, {max_real, inf_real, max_real}};
+    EXPECT_TRUE(is_infinite(bbox3));
+}
+
+TEST(BoundingBoxUtilsTest, center)
+{
+    BBox bbox = {{-10, -20, -30}, {1, 2, 3}};
+    EXPECT_VEC_SOFT_EQ(Real3({-4.5, -9, -13.5}), center(bbox));
+}
+
+TEST(BoundingBoxUtilsTest, surface_area)
+{
+    BBox bbox = {{-1, -2, -3}, {6, 4, 5}};
+    EXPECT_SOFT_EQ(2 * (7 * 6 + 7 * 8 + 6 * 8), surface_area(bbox));
+}
+
+TEST(BoundingBoxUtilsTest, bbox_union)
+{
+    BBox bbox1 = {{-10, -20, -30}, {10, 2, 3}};
+    BBox bbox2 = {{-15, -9, -33}, {1, 2, 10}};
+
+    auto bbox3 = bbox_union(bbox1, bbox2);
+
+    EXPECT_VEC_SOFT_EQ(Real3({-15, -20, -33}), bbox3.lower());
+    EXPECT_VEC_SOFT_EQ(Real3({10, 2, 10}), bbox3.upper());
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
This PR converts the `BoundingBox` class to `BoundingBox<T>`, templated on the floating point precision of the bounds. In addition, +/- max_double values in bounding boxes read from disk are converted into +/- infinities. It also adds new utility classes.

Split from #849 