### PR TITLE
Add basic field driver option support to RZ map field

### DIFF
--- a/src/celeritas/field/FieldDriverOptionsIO.json.cc
+++ b/src/celeritas/field/FieldDriverOptionsIO.json.cc
@@ -20,7 +20,12 @@ namespace celeritas
  */
 void from_json(nlohmann::json const& j, FieldDriverOptions& opts)
 {
-#define FDO_INPUT(FIELD) j.at(#FIELD).get_to(opts.FIELD)
+#define FDO_INPUT(NAME)                    \
+    do                                     \
+    {                                      \
+        if (j.contains(#NAME))             \
+            j.at(#NAME).get_to(opts.NAME); \
+    } while (0)
 
     FDO_INPUT(minimum_step);
     FDO_INPUT(delta_chord);

--- a/src/celeritas/field/RZMapFieldInput.hh
+++ b/src/celeritas/field/RZMapFieldInput.hh
@@ -14,6 +14,8 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 
+#include "FieldDriverOptions.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -36,6 +38,8 @@ struct RZMapFieldInput
     double max_r{};  //!< Last r coordinate [cm]
     std::vector<double> field_z;  //!< Flattened Z field component [tesla]
     std::vector<double> field_r;  //!< Flattened R field component [tesla]
+
+    FieldDriverOptions driver_options;
 
     //! Whether all data are assigned and valid
     explicit CELER_FUNCTION operator bool() const

--- a/src/celeritas/field/RZMapFieldInputIO.json.cc
+++ b/src/celeritas/field/RZMapFieldInputIO.json.cc
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "FieldDriverOptionsIO.json.hh"
 #include "RZMapFieldInput.hh"
 
 namespace celeritas
@@ -31,6 +32,10 @@ void from_json(nlohmann::json const& j, RZMapFieldInput& inp)
     RZFI_LOAD(max_r);
     RZFI_LOAD(field_z);
     RZFI_LOAD(field_r);
+    if (j.contains("driver_options"))
+    {
+        RZFI_LOAD(driver_options);
+    }
 #undef RZFI_LOAD
 }
 
@@ -50,6 +55,7 @@ void to_json(nlohmann::json& j, RZMapFieldInput const& inp)
         RZFI_KEY_VALUE(max_r),
         RZFI_KEY_VALUE(field_z),
         RZFI_KEY_VALUE(field_r),
+        RZFI_KEY_VALUE(driver_options),
     };
 #undef RZFI_KEY_VALUE
 }

--- a/src/celeritas/field/RZMapFieldParams.cc
+++ b/src/celeritas/field/RZMapFieldParams.cc
@@ -70,6 +70,8 @@ RZMapFieldParams::RZMapFieldParams(RZMapFieldInput const& inp)
             el.value_r = inp.field_r[i] * units::tesla;
             fieldmap.push_back(el);
         }
+
+        host.options = inp.driver_options;
         return host;
     }();
 


### PR DESCRIPTION
This simply adds a `FieldDriverOption` to the RZ field map input, allowing you to change the field driver options by modifying the input JSON RZ map file. It's not ideal but it's an easy first step. To make tweaking the driver options easier, the individual values are now optional.