### PR TITLE
Accelerate ORANGE track initialization with Bounding Interval Hierarchy

### DIFF
--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -21,9 +21,9 @@ namespace celeritas
 /*!
  * Determine if a point is contained in a bounding box.
  */
-template<class T>
+template<class T, class U>
 inline CELER_FUNCTION bool
-is_inside(BoundingBox<T> const& bbox, Array<T, 3> point)
+is_inside(BoundingBox<T> const& bbox, Array<U, 3> point)
 {
     CELER_EXPECT(bbox);
 

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -256,17 +256,9 @@ struct BIHTreeData
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        if (!inner_nodes.empty())
-        {
-            return !bboxes.empty() && !local_volume_ids.empty()
-                   && !leaf_nodes.empty();
-        }
-        else
-        {
-            // Degenerate single leaf node case
-            return !bboxes.empty() && !local_volume_ids.empty()
-                   && leaf_nodes.size() == 1;
-        }
+        // Note that inner_nodes may be empty for single-node trees
+        return !bboxes.empty() && !local_volume_ids.empty()
+               && !leaf_nodes.empty();
     }
 
     //! Assign from another set of data

--- a/src/orange/detail/BIHBuilder.cc
+++ b/src/orange/detail/BIHBuilder.cc
@@ -101,7 +101,7 @@ BIHTree BIHBuilder::operator()(VecBBox bboxes)
     {
         // Degenerate case where all bounding boxes are infinite. Create a
         // single empty leaf node, so that the existance of leaf nodes does not
-        // need to be checked at runtime
+        // need to be checked at runtime.
 
         VecLeafNodes leaf_nodes{1};
         tree.leaf_nodes

--- a/src/orange/detail/BIHBuilder.hh
+++ b/src/orange/detail/BIHBuilder.hh
@@ -44,7 +44,7 @@ class BIHBuilder
     //!@{
     //! \name Type aliases
     using VecBBox = std::vector<FastBBox>;
-    using Storage = BIHTreeData<Ownership::value, MemSpace::native>;
+    using Storage = BIHTreeData<Ownership::value, MemSpace::host>;
     //!@}
 
   public:

--- a/src/orange/detail/BIHBuilder.hh
+++ b/src/orange/detail/BIHBuilder.hh
@@ -12,7 +12,7 @@
 
 #include "corecel/cont/Range.hh"
 #include "orange/BoundingBox.hh"
-#include "orange/detail/BIHData.hh"
+#include "orange/OrangeData.hh"
 #include "orange/detail/BIHPartitioner.hh"
 
 namespace celeritas
@@ -39,6 +39,7 @@ class BIHBuilder
     //!@{
     //! \name Type aliases
     using VecBBox = std::vector<FastBBox>;
+    using Storage = BIHTreeData<Ownership::value, MemSpace::native>;
     //!@}
 
   public:
@@ -46,7 +47,7 @@ class BIHBuilder
     BIHBuilder() = default;
 
     // Construct from a Storage object
-    explicit BIHBuilder(BIHStorage storage);
+    explicit BIHBuilder(Storage* storage);
 
     // Create BIH Nodes
     BIHTree operator()(VecBBox bboxes);
@@ -68,7 +69,7 @@ class BIHBuilder
 
     VecBBox bboxes_;
     VecReal3 centers_;
-    BIHStorage storage_;
+    Storage* storage_;
 
     //// HELPER FUNCTIONS ////
 

--- a/src/orange/detail/BIHBuilder.hh
+++ b/src/orange/detail/BIHBuilder.hh
@@ -27,7 +27,12 @@ namespace detail
  * paper [1]. Partitioning is done on the basis of bounding box centers using
  * the "longest dimension" heuristic. All leaf nodes contain either a single
  * volume id, or multiple volume ids if the volumes have bounding boxes that
- * share the same center.
+ * share the same center. A tree may consist of a single leaf node if the
+ * tree contains only 1 volume, or multiple non-partitionable volumes. In the
+ * event that all bounding boxes are infinite, the tree will consist of a
+ * single empty leaf node with all volumes in the stored inf_vols. This final
+ * case is useful in the event that an ORANGE geometry is created via a method
+ * where volume bounding boxes are not availible.
  *
  * [1] C. Wachter, Carsten and A. Keller, "Instant Ray Tracing: The Bounding
  * Interval Hierarchy" Eurographics Symposium on Rendering, 2006,

--- a/src/orange/detail/BIHData.hh
+++ b/src/orange/detail/BIHData.hh
@@ -73,32 +73,6 @@ struct BIHLeafNode
 
 //---------------------------------------------------------------------------//
 /*!
- * References to host storage while constructing a Bounding Interval Hierarchy
- * tree.
- */
-struct BIHStorage
-{
-    template<class T>
-    using Storage = Collection<T, Ownership::value, MemSpace::host>;
-    using BBoxStorage = Storage<FastBBox>;
-    using LVIStorage = Storage<LocalVolumeId>;
-    using InnerNodeStorage = Storage<BIHInnerNode>;
-    using LeafNodeStorage = Storage<BIHLeafNode>;
-
-    BBoxStorage* bboxes = nullptr;
-    LVIStorage* local_volume_ids = nullptr;
-    InnerNodeStorage* inner_nodes = nullptr;
-    LeafNodeStorage* leaf_nodes = nullptr;
-
-    explicit CELER_FUNCTION operator bool() const
-    {
-        return bboxes != nullptr && local_volume_ids != nullptr
-               && inner_nodes != nullptr && leaf_nodes != nullptr;
-    }
-};
-
-//---------------------------------------------------------------------------//
-/*!
  * Bounding Interval Hierarchy tree.
  */
 struct BIHTree
@@ -115,6 +89,11 @@ struct BIHTree
     // VolumeIds for which bboxes have infinite extents, and are therefore
     // note included in the tree
     ItemRange<LocalVolumeId> inf_volids;
+
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return bboxes.size() > 0 && leaf_nodes.size() > 0;
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/BIHData.hh
+++ b/src/orange/detail/BIHData.hh
@@ -92,7 +92,16 @@ struct BIHTree
 
     explicit CELER_FUNCTION operator bool() const
     {
-        return bboxes.size() > 0 && leaf_nodes.size() > 0;
+        if (!inner_nodes.empty())
+        {
+            return !bboxes.empty() && !leaf_nodes.empty();
+        }
+        else
+        {
+            // Degenerate single leaf node case. This occurs a tree owns a
+            // single volume or muliple non-partitionable volumes.
+            return !bboxes.empty() && leaf_nodes.size() == 1;
+        }
     }
 };
 

--- a/src/orange/detail/BIHData.hh
+++ b/src/orange/detail/BIHData.hh
@@ -67,7 +67,6 @@ struct BIHLeafNode
 
     ItemRange<LocalVolumeId> vol_ids;
 
-    //! True if either a valid inner or leaf node
     explicit CELER_FUNCTION operator bool() const { return !vol_ids.empty(); }
 };
 
@@ -98,8 +97,11 @@ struct BIHTree
         }
         else
         {
-            // Degenerate single leaf node case. This occurs a tree owns a
-            // single volume or muliple non-partitionable volumes.
+            // Degenerate single leaf node case. This occurs when a tree
+            // contains either:
+            // a) a single volume
+            // b) muliple non-partitionable volumes,
+            // b) only infinite volumes.
             return !bboxes.empty() && leaf_nodes.size() == 1;
         }
     }

--- a/src/orange/detail/BIHTraverser.hh
+++ b/src/orange/detail/BIHTraverser.hh
@@ -1,0 +1,315 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/detail/BIHTraverser.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "orange/BoundingBoxUtils.hh"
+#include "orange/OrangeData.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Traverse BIH tree using a depth-first search.
+ */
+class BIHTraverser
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Storage = NativeCRef<BIHTreeData>;
+    //!@}
+
+    // Construct from vector of bounding boxes and storage for LocalVolumeIds
+    explicit inline CELER_FUNCTION
+    BIHTraverser(BIHTree const& tree, Storage const& storage);
+
+    // Point-in-volume operation
+    template<class F>
+    inline CELER_FUNCTION LocalVolumeId operator()(Real3 const& point,
+                                                   F&& functor) const;
+
+  private:
+    //// DATA ////
+    BIHTree const& tree_;
+    Storage const& storage_;
+    size_type leaf_offset_;
+
+    //// HELPER FUNCTIONS ////
+
+    // Test if any of the leaf node volumes contain the point
+    template<class F>
+    inline CELER_FUNCTION LocalVolumeId search_leaf(
+        BIHLeafNode const& leaf_node, Real3 const& point, F&& functor) const;
+
+    // Test if any of the infinite volumes contain the point
+    template<class F>
+    inline CELER_FUNCTION LocalVolumeId search_inf_vols(Real3 const& point,
+                                                        F&& functor) const;
+    // Test if a single volume contains the point
+    template<class F>
+    inline CELER_FUNCTION bool
+    test_volume(LocalVolumeId const& id, Real3 const& point, F&& functor) const;
+
+    // Get the ID of the next node in the traversal sequence
+    inline CELER_FUNCTION BIHNodeId next_node(BIHNodeId const& current_id,
+                                              BIHNodeId const& previous_id,
+                                              Real3 const& point) const;
+    // Test if a given edge needs to be explored
+    inline CELER_FUNCTION bool test_edge(BIHInnerNode const& node,
+                                         BIHInnerNode::Edge edge,
+                                         Real3 const& point) const;
+
+    // Determine if a node is inner, i.e., not a leaf
+    inline CELER_FUNCTION bool is_inner(BIHNodeId id) const;
+
+    // Get an inner node for a given BIHNodeId
+    inline CELER_FUNCTION BIHInnerNode const&
+    get_inner_node(BIHNodeId id) const;
+
+    // Get a leaf node for a given BIHNodeId
+    inline CELER_FUNCTION BIHLeafNode const& get_leaf_node(BIHNodeId id) const;
+
+    // Test if a single bbox contains the point
+    inline CELER_FUNCTION bool
+    test_bbox(LocalVolumeId const& id, Real3 const& point) const;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from vector of bounding boxes and storage.
+ */
+CELER_FUNCTION
+BIHTraverser::BIHTraverser(BIHTree const& tree,
+                           BIHTraverser::Storage const& storage)
+    : tree_(tree), storage_(storage), leaf_offset_(tree.inner_nodes.size())
+{
+    // TODO: Enforce existing of BIHTree
+    // CELER_EXPECT(tree);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Point-in-volume operation.
+ */
+template<class F>
+CELER_FUNCTION LocalVolumeId BIHTraverser::operator()(Real3 const& point,
+                                                      F&& functor) const
+{
+    BIHNodeId previous_node;
+    BIHNodeId current_node{0};
+    LocalVolumeId id;
+
+    do
+    {
+        if (!is_inner(current_node))
+        {
+            id = search_leaf(this->get_leaf_node(current_node), point, functor);
+
+            if (id)
+            {
+                return id;
+            }
+        }
+
+        auto current_node_temp = current_node;
+        current_node = this->next_node(current_node, previous_node, point);
+        previous_node = current_node_temp;
+
+    } while (current_node);
+
+    if (!id)
+    {
+        id = this->search_inf_vols(point, functor);
+    }
+
+    return id;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Test if any of the leaf node volumes contain the point.
+ */
+template<class F>
+CELER_FUNCTION LocalVolumeId BIHTraverser::search_leaf(
+    BIHLeafNode const& leaf_node, Real3 const& point, F&& functor) const
+{
+    for (auto i : range(leaf_node.vol_ids.size()))
+    {
+        auto id = storage_.local_volume_ids[leaf_node.vol_ids[i]];
+        if (test_volume(id, point, functor))
+        {
+            return id;
+        }
+    }
+    return LocalVolumeId{};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Test if any of the infinite volumes contain the point.
+ */
+template<class F>
+CELER_FUNCTION LocalVolumeId BIHTraverser::search_inf_vols(Real3 const& point,
+                                                           F&& functor) const
+{
+    LocalVolumeId result;
+
+    for (auto i : range(tree_.inf_volids.size()))
+    {
+        auto id = storage_.local_volume_ids[tree_.inf_volids[i]];
+        if (test_volume(id, point, functor))
+        {
+            return id;
+        }
+    }
+    return LocalVolumeId{};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Test if a single volume contains the point.
+ */
+template<class F>
+CELER_FUNCTION bool BIHTraverser::test_volume(LocalVolumeId const& id,
+                                              Real3 const& point,
+                                              F&& functor) const
+{
+    return test_bbox(id, point) && functor(id, point);
+}
+
+//---------------------------------------------------------------------------//
+// HELPER FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ *  Get the ID of the next node in the traversal sequence.
+ */
+CELER_FUNCTION
+BIHNodeId BIHTraverser::next_node(BIHNodeId const& current_id,
+                                  BIHNodeId const& previous_id,
+                                  Real3 const& point) const
+{
+    using Edge = BIHInnerNode::Edge;
+
+    BIHNodeId next_id;
+
+    if (is_inner(current_id))
+    {
+        auto const& current_node = this->get_inner_node(current_id);
+        if (previous_id == current_node.parent)
+        {
+            // Visiting this inner node for the first time; go down either left
+            // or right edge
+            if (this->test_edge(current_node, Edge::left, point))
+            {
+                next_id = current_node.bounding_planes[Edge::left].child;
+            }
+            else
+            {
+                next_id = current_node.bounding_planes[Edge::right].child;
+            }
+        }
+        else if (previous_id == current_node.bounding_planes[Edge::left].child)
+        {
+            // Visiting this inner node for the second time; go down right edge
+            // or return to parent
+            if (this->test_edge(current_node, Edge::right, point))
+            {
+                next_id = current_node.bounding_planes[Edge::right].child;
+            }
+            else
+            {
+                next_id = current_node.parent;
+            }
+        }
+        else
+        {
+            // Visiting this inner node for the third time; return to parent
+            CELER_EXPECT(previous_id
+                         == current_node.bounding_planes[Edge::right].child);
+            next_id = current_node.parent;
+        }
+    }
+    else
+    {
+        // Leaf node; return to parent
+        CELER_EXPECT(previous_id == this->get_leaf_node(current_id).parent);
+        next_id = previous_id;
+    }
+
+    return next_id;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Test if a given edge needs to be explored.
+ */
+CELER_FUNCTION
+bool BIHTraverser::test_edge(BIHInnerNode const& node,
+                             BIHInnerNode::Edge edge,
+                             Real3 const& point) const
+{
+    CELER_EXPECT(edge < BIHInnerNode::Edge::size_);
+
+    auto ax = to_int(node.axis);
+    auto pos = node.bounding_planes[edge].position;
+    auto point_pos = point[ax];
+
+    return (edge == BIHInnerNode::Edge::left) ? (point_pos < pos)
+                                              : (pos < point_pos);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ *  Determine if a node is inner, i.e., not a leaf.
+ */
+CELER_FUNCTION
+bool BIHTraverser::is_inner(BIHNodeId id) const
+{
+    return id.get() < leaf_offset_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ *  Get an inner node for a given BIHNodeId.
+ */
+CELER_FUNCTION
+BIHInnerNode const& BIHTraverser::get_inner_node(BIHNodeId id) const
+{
+    CELER_EXPECT(this->is_inner(id));
+    return storage_.inner_nodes[tree_.inner_nodes[id.unchecked_get()]];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ *  Get a leaf node for a given BIHNodeId.
+ */
+CELER_FUNCTION
+BIHLeafNode const& BIHTraverser::get_leaf_node(BIHNodeId id) const
+{
+    CELER_EXPECT(!this->is_inner(id));
+    return storage_
+        .leaf_nodes[tree_.leaf_nodes[id.unchecked_get() - leaf_offset_]];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ *  Get a leaf node for a given BIHNodeId.
+ */
+CELER_FUNCTION
+bool BIHTraverser::test_bbox(LocalVolumeId const& id, Real3 const& point) const
+{
+    return is_inside(storage_.bboxes[tree_.bboxes[id]], point);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/orange/detail/BIHTraverser.hh
+++ b/src/orange/detail/BIHTraverser.hh
@@ -50,17 +50,13 @@ class BIHTraverser
 
     // Test if any of the infinite volumes contain the point
     template<class F>
-    inline CELER_FUNCTION LocalVolumeId search_inf_vols(Real3 const& point,
-                                                        F&& functor) const;
-    // Test if a single volume contains the point
-    template<class F>
-    inline CELER_FUNCTION bool
-    test_volume(LocalVolumeId const& id, Real3 const& point, F&& functor) const;
+    inline CELER_FUNCTION LocalVolumeId search_inf_vols(F&& functor) const;
 
     // Get the ID of the next node in the traversal sequence
     inline CELER_FUNCTION BIHNodeId next_node(BIHNodeId const& current_id,
                                               BIHNodeId const& previous_id,
                                               Real3 const& point) const;
+
     // Test if a given edge needs to be explored
     inline CELER_FUNCTION bool test_edge(BIHInnerNode const& node,
                                          BIHInnerNode::Edge edge,
@@ -128,7 +124,7 @@ CELER_FUNCTION LocalVolumeId BIHTraverser::operator()(Real3 const& point,
 
     if (!id)
     {
-        id = this->search_inf_vols(point, functor);
+        id = this->search_inf_vols(functor);
     }
 
     return id;
@@ -145,7 +141,7 @@ CELER_FUNCTION LocalVolumeId BIHTraverser::search_leaf(
     for (auto i : range(leaf_node.vol_ids.size()))
     {
         auto id = storage_.local_volume_ids[leaf_node.vol_ids[i]];
-        if (test_volume(id, point, functor))
+        if (test_bbox(id, point) && functor(id))
         {
             return id;
         }
@@ -158,32 +154,17 @@ CELER_FUNCTION LocalVolumeId BIHTraverser::search_leaf(
  * Test if any of the infinite volumes contain the point.
  */
 template<class F>
-CELER_FUNCTION LocalVolumeId BIHTraverser::search_inf_vols(Real3 const& point,
-                                                           F&& functor) const
+CELER_FUNCTION LocalVolumeId BIHTraverser::search_inf_vols(F&& functor) const
 {
-    LocalVolumeId result;
-
     for (auto i : range(tree_.inf_volids.size()))
     {
         auto id = storage_.local_volume_ids[tree_.inf_volids[i]];
-        if (test_volume(id, point, functor))
+        if (functor(id))
         {
             return id;
         }
     }
     return LocalVolumeId{};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Test if a single volume contains the point.
- */
-template<class F>
-CELER_FUNCTION bool BIHTraverser::test_volume(LocalVolumeId const& id,
-                                              Real3 const& point,
-                                              F&& functor) const
-{
-    return test_bbox(id, point) && functor(id, point);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -188,7 +188,7 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
         vol_records[i] = this->insert_volume(unit.surfaces, inp.volumes[i]);
         CELER_ASSERT(!vol_records.empty());
 
-        // Store the bbox, or it is not supplied, and infinite bbox placeholder
+        // Store the bbox or an infinite bbox placeholder
         if (inp.volumes[i].bbox)
         {
             bboxes.push_back(make_fast_bbox(inp.volumes[i].bbox));

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -12,6 +12,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/math/Algorithms.hh"
 #include "orange/OrangeData.hh"
+#include "orange/detail/BIHTraverser.hh"
 #include "orange/surf/Surfaces.hh"
 
 #include "detail/LogicEvaluator.hh"
@@ -99,6 +100,7 @@ class SimpleUnitTracker
     //// DATA ////
     ParamsRef const& params_;
     SimpleUnitRecord const& unit_record_;
+    detail::BIHTraverser bih_traverser_;
 
     //// METHODS ////
 
@@ -138,7 +140,9 @@ class SimpleUnitTracker
  */
 CELER_FUNCTION
 SimpleUnitTracker::SimpleUnitTracker(ParamsRef const& params, SimpleUnitId suid)
-    : params_(params), unit_record_(params.simple_units[suid])
+    : params_(params)
+    , unit_record_(params.simple_units[suid])
+    , bih_traverser_(params.simple_units[suid].bih_tree, params.bih_tree_data)
 {
     CELER_EXPECT(params_);
 }

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -100,7 +100,7 @@ class SimpleUnitTracker
     //// DATA ////
     ParamsRef const& params_;
     SimpleUnitRecord const& unit_record_;
-    detail::BIHTraverser bih_traverser_;
+    detail::BIHTraverser bih_point_in_vol_;
 
     //// METHODS ////
 
@@ -142,7 +142,8 @@ CELER_FUNCTION
 SimpleUnitTracker::SimpleUnitTracker(ParamsRef const& params, SimpleUnitId suid)
     : params_(params)
     , unit_record_(params.simple_units[suid])
-    , bih_traverser_(params.simple_units[suid].bih_tree, params.bih_tree_data)
+    , bih_point_in_vol_(params.simple_units[suid].bih_tree,
+                        params.bih_tree_data)
 {
     CELER_EXPECT(params_);
 }
@@ -165,7 +166,7 @@ SimpleUnitTracker::initialize(LocalState const& state) const -> Initialization
 
     auto const& p = params_;
     auto const& u = unit_record_;
-    auto evaluate_piv = [p, u, calc_senses](LocalVolumeId const& id) -> bool {
+    auto is_inside = [p, u, calc_senses](LocalVolumeId const& id) -> bool {
         VolumeView vol(p, u, id);
         auto logic_state = calc_senses(vol);
 
@@ -173,7 +174,7 @@ SimpleUnitTracker::initialize(LocalState const& state) const -> Initialization
                && !logic_state.face;
     };
 
-    LocalVolumeId id = bih_traverser_(state.pos, evaluate_piv);
+    LocalVolumeId id = bih_point_in_vol_(state.pos, is_inside);
 
     if (!id)
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -224,6 +224,7 @@ celeritas_add_test(orange/Translator.test.cc)
 
 # Base detail
 celeritas_add_test(orange/detail/BIHBuilder.test.cc)
+celeritas_add_test(orange/detail/BIHTraverser.test.cc)
 celeritas_add_test(orange/detail/BIHUtils.test.cc)
 celeritas_add_test(orange/detail/UniverseIndexer.test.cc)
 

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -117,7 +117,6 @@ void OrangeGeoTestBase::build_geometry(OneVolInput inp)
         vi.flags = (inp.complex_tracking ? VolumeInput::Flags::internal_surfaces
                                          : 0);
         vi.label = "infinite";
-        vi.bbox = {{-0.5, -0.5, -0.5}, {0.5, 0.5, 0.5}};
         input.volumes.push_back(std::move(vi));
     }
 

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -25,11 +25,7 @@ namespace test
 class BIHBuilderTest : public Test
 {
   public:
-    void SetUp()
-    {
-        auto inf = std::numeric_limits<fast_real_type>::infinity();
-        bboxes_.push_back({{-inf, -inf, -inf}, {inf, inf, inf}});
-    }
+    void SetUp() {}
 
   protected:
     std::vector<FastBBox> bboxes_;
@@ -77,6 +73,7 @@ TEST_F(BIHBuilderTest, basic)
 {
     using Edge = BIHInnerNode::Edge;
 
+    bboxes_.push_back(FastBBox::from_infinite());
     bboxes_.push_back({{0, 0, 0}, {1.6, 1, 100}});
     bboxes_.push_back({{1.2, 0, 0}, {2.8, 1, 100}});
     bboxes_.push_back({{2.8, 0, 0}, {5, 1, 100}});
@@ -108,8 +105,8 @@ TEST_F(BIHBuilderTest, basic)
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(2.8, node.bounding_planes[Edge::left].position);
         EXPECT_SOFT_EQ(0, node.bounding_planes[Edge::right].position);
-        EXPECT_EQ(1, node.bounding_planes[Edge::left].child.unchecked_get());
-        EXPECT_EQ(2, node.bounding_planes[Edge::right].child.unchecked_get());
+        EXPECT_EQ(BIHNodeId{1}, node.bounding_planes[Edge::left].child);
+        EXPECT_EQ(BIHNodeId{2}, node.bounding_planes[Edge::right].child);
     }
 
     // N1, I1
@@ -120,8 +117,8 @@ TEST_F(BIHBuilderTest, basic)
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(1.6, node.bounding_planes[Edge::left].position);
         EXPECT_SOFT_EQ(1.2, node.bounding_planes[Edge::right].position);
-        EXPECT_EQ(3, node.bounding_planes[Edge::left].child.unchecked_get());
-        EXPECT_EQ(4, node.bounding_planes[Edge::right].child.unchecked_get());
+        EXPECT_EQ(BIHNodeId{3}, node.bounding_planes[Edge::left].child);
+        EXPECT_EQ(BIHNodeId{4}, node.bounding_planes[Edge::right].child);
     }
 
     // N2, I2
@@ -132,8 +129,8 @@ TEST_F(BIHBuilderTest, basic)
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(5, node.bounding_planes[Edge::left].position);
         EXPECT_SOFT_EQ(2.8, node.bounding_planes[Edge::right].position);
-        EXPECT_EQ(5, node.bounding_planes[Edge::left].child.unchecked_get());
-        EXPECT_EQ(6, node.bounding_planes[Edge::right].child.unchecked_get());
+        EXPECT_EQ(BIHNodeId{5}, node.bounding_planes[Edge::left].child);
+        EXPECT_EQ(BIHNodeId{6}, node.bounding_planes[Edge::right].child);
     }
 
     // N3, L0
@@ -141,8 +138,7 @@ TEST_F(BIHBuilderTest, basic)
         auto node = storage_.leaf_nodes[leaf_nodes[0]];
         ASSERT_EQ(BIHNodeId{1}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(1,
-                  storage_.local_volume_ids[node.vol_ids[0]].unchecked_get());
+        EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
 
     // N3, L1
@@ -150,8 +146,7 @@ TEST_F(BIHBuilderTest, basic)
         auto node = storage_.leaf_nodes[leaf_nodes[1]];
         ASSERT_EQ(BIHNodeId{1}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(2,
-                  storage_.local_volume_ids[node.vol_ids[0]].unchecked_get());
+        EXPECT_EQ(LocalVolumeId{2}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
 
     // N5, L2
@@ -159,10 +154,8 @@ TEST_F(BIHBuilderTest, basic)
         auto node = storage_.leaf_nodes[leaf_nodes[2]];
         ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(2, node.vol_ids.size());
-        EXPECT_EQ(4,
-                  storage_.local_volume_ids[node.vol_ids[0]].unchecked_get());
-        EXPECT_EQ(5,
-                  storage_.local_volume_ids[node.vol_ids[1]].unchecked_get());
+        EXPECT_EQ(LocalVolumeId{4}, storage_.local_volume_ids[node.vol_ids[0]]);
+        EXPECT_EQ(LocalVolumeId{5}, storage_.local_volume_ids[node.vol_ids[1]]);
     }
 
     // N6, L3
@@ -170,8 +163,7 @@ TEST_F(BIHBuilderTest, basic)
         auto node = storage_.leaf_nodes[leaf_nodes[3]];
         ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(3,
-                  storage_.local_volume_ids[node.vol_ids[0]].unchecked_get());
+        EXPECT_EQ(LocalVolumeId{3}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
 }
 
@@ -225,6 +217,8 @@ TEST_F(BIHBuilderTest, grid)
 {
     using Edge = BIHInnerNode::Edge;
 
+    bboxes_.push_back(FastBBox::from_infinite());
+
     bboxes_.push_back({{0, 0, 0}, {1, 1, 100}});
     bboxes_.push_back({{0, 1, 0}, {1, 2, 100}});
     bboxes_.push_back({{0, 2, 0}, {1, 3, 100}});
@@ -260,8 +254,8 @@ TEST_F(BIHBuilderTest, grid)
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(2, node.bounding_planes[Edge::left].position);
         EXPECT_SOFT_EQ(2, node.bounding_planes[Edge::right].position);
-        EXPECT_EQ(1, node.bounding_planes[Edge::left].child.unchecked_get());
-        EXPECT_EQ(6, node.bounding_planes[Edge::right].child.unchecked_get());
+        EXPECT_EQ(BIHNodeId{1}, node.bounding_planes[Edge::left].child);
+        EXPECT_EQ(BIHNodeId{6}, node.bounding_planes[Edge::right].child);
     }
 
     // N1, I1
@@ -272,8 +266,8 @@ TEST_F(BIHBuilderTest, grid)
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(1, node.bounding_planes[Edge::left].position);
         EXPECT_SOFT_EQ(1, node.bounding_planes[Edge::right].position);
-        EXPECT_EQ(2, node.bounding_planes[Edge::left].child.unchecked_get());
-        EXPECT_EQ(3, node.bounding_planes[Edge::right].child.unchecked_get());
+        EXPECT_EQ(BIHNodeId{2}, node.bounding_planes[Edge::left].child);
+        EXPECT_EQ(BIHNodeId{3}, node.bounding_planes[Edge::right].child);
     }
 
     // N2, I2
@@ -284,8 +278,8 @@ TEST_F(BIHBuilderTest, grid)
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(1, node.bounding_planes[Edge::left].position);
         EXPECT_SOFT_EQ(1, node.bounding_planes[Edge::right].position);
-        EXPECT_EQ(11, node.bounding_planes[Edge::left].child.unchecked_get());
-        EXPECT_EQ(12, node.bounding_planes[Edge::right].child.unchecked_get());
+        EXPECT_EQ(BIHNodeId{11}, node.bounding_planes[Edge::left].child);
+        EXPECT_EQ(BIHNodeId{12}, node.bounding_planes[Edge::right].child);
     }
 
     // N3, I3
@@ -296,8 +290,8 @@ TEST_F(BIHBuilderTest, grid)
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(2, node.bounding_planes[Edge::left].position);
         EXPECT_SOFT_EQ(2, node.bounding_planes[Edge::right].position);
-        EXPECT_EQ(4, node.bounding_planes[Edge::left].child.unchecked_get());
-        EXPECT_EQ(5, node.bounding_planes[Edge::right].child.unchecked_get());
+        EXPECT_EQ(BIHNodeId{4}, node.bounding_planes[Edge::left].child);
+        EXPECT_EQ(BIHNodeId{5}, node.bounding_planes[Edge::right].child);
     }
 
     // N4, I4
@@ -308,8 +302,8 @@ TEST_F(BIHBuilderTest, grid)
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(1, node.bounding_planes[Edge::left].position);
         EXPECT_SOFT_EQ(1, node.bounding_planes[Edge::right].position);
-        EXPECT_EQ(13, node.bounding_planes[Edge::left].child.unchecked_get());
-        EXPECT_EQ(14, node.bounding_planes[Edge::right].child.unchecked_get());
+        EXPECT_EQ(BIHNodeId{13}, node.bounding_planes[Edge::left].child);
+        EXPECT_EQ(BIHNodeId{14}, node.bounding_planes[Edge::right].child);
     }
 
     // N5, I5
@@ -320,8 +314,8 @@ TEST_F(BIHBuilderTest, grid)
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(1, node.bounding_planes[Edge::left].position);
         EXPECT_SOFT_EQ(1, node.bounding_planes[Edge::right].position);
-        EXPECT_EQ(15, node.bounding_planes[Edge::left].child.unchecked_get());
-        EXPECT_EQ(16, node.bounding_planes[Edge::right].child.unchecked_get());
+        EXPECT_EQ(BIHNodeId{15}, node.bounding_planes[Edge::left].child);
+        EXPECT_EQ(BIHNodeId{16}, node.bounding_planes[Edge::right].child);
     }
 
     // N11, I0
@@ -329,8 +323,7 @@ TEST_F(BIHBuilderTest, grid)
         auto node = storage_.leaf_nodes[leaf_nodes[0]];
         ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(1,
-                  storage_.local_volume_ids[node.vol_ids[0]].unchecked_get());
+        EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
 
     // N12, L1
@@ -338,8 +331,7 @@ TEST_F(BIHBuilderTest, grid)
         auto node = storage_.leaf_nodes[leaf_nodes[1]];
         ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(2,
-                  storage_.local_volume_ids[node.vol_ids[0]].unchecked_get());
+        EXPECT_EQ(LocalVolumeId{2}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
 
     // N13, L2
@@ -347,8 +339,7 @@ TEST_F(BIHBuilderTest, grid)
         auto node = storage_.leaf_nodes[leaf_nodes[2]];
         ASSERT_EQ(BIHNodeId{4}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(5,
-                  storage_.local_volume_ids[node.vol_ids[0]].unchecked_get());
+        EXPECT_EQ(LocalVolumeId{5}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
 
     // N14, L3
@@ -356,8 +347,7 @@ TEST_F(BIHBuilderTest, grid)
         auto node = storage_.leaf_nodes[leaf_nodes[3]];
         ASSERT_EQ(BIHNodeId{4}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(6,
-                  storage_.local_volume_ids[node.vol_ids[0]].unchecked_get());
+        EXPECT_EQ(LocalVolumeId{6}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
 
     // N15, L4
@@ -365,8 +355,7 @@ TEST_F(BIHBuilderTest, grid)
         auto node = storage_.leaf_nodes[leaf_nodes[4]];
         ASSERT_EQ(BIHNodeId{5}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(9,
-                  storage_.local_volume_ids[node.vol_ids[0]].unchecked_get());
+        EXPECT_EQ(LocalVolumeId{9}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
 
     // N16, L5
@@ -374,9 +363,82 @@ TEST_F(BIHBuilderTest, grid)
         auto node = storage_.leaf_nodes[leaf_nodes[5]];
         ASSERT_EQ(BIHNodeId{5}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(10,
-                  storage_.local_volume_ids[node.vol_ids[0]].unchecked_get());
+        EXPECT_EQ(LocalVolumeId{10},
+                  storage_.local_volume_ids[node.vol_ids[0]]);
     }
+}
+
+//---------------------------------------------------------------------------//
+// Degenerate, single leaf cases
+//---------------------------------------------------------------------------//
+//
+TEST_F(BIHBuilderTest, single_finite_volume)
+{
+    bboxes_.push_back({{0, 0, 0}, {1, 1, 1}});
+
+    BIHBuilder bih(&storage_);
+    auto bih_tree = bih(std::move(bboxes_));
+
+    ASSERT_EQ(0, bih_tree.inf_volids.size());
+    ASSERT_EQ(0, bih_tree.inner_nodes.size());
+    ASSERT_EQ(1, bih_tree.leaf_nodes.size());
+
+    auto node = storage_.leaf_nodes[bih_tree.leaf_nodes[0]];
+    ASSERT_EQ(BIHNodeId{}, node.parent);
+    EXPECT_EQ(1, node.vol_ids.size());
+    EXPECT_EQ(LocalVolumeId{0}, storage_.local_volume_ids[node.vol_ids[0]]);
+}
+
+TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
+{
+    bboxes_.push_back({{0, 0, 0}, {1, 1, 1}});
+    bboxes_.push_back({{0, 0, 0}, {1, 1, 1}});
+
+    BIHBuilder bih(&storage_);
+    auto bih_tree = bih(std::move(bboxes_));
+
+    ASSERT_EQ(0, bih_tree.inf_volids.size());
+    ASSERT_EQ(0, bih_tree.inner_nodes.size());
+    ASSERT_EQ(1, bih_tree.leaf_nodes.size());
+
+    auto node = storage_.leaf_nodes[bih_tree.leaf_nodes[0]];
+    ASSERT_EQ(BIHNodeId{}, node.parent);
+    EXPECT_EQ(2, node.vol_ids.size());
+    EXPECT_EQ(LocalVolumeId{0}, storage_.local_volume_ids[node.vol_ids[0]]);
+    EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[1]]);
+}
+
+TEST_F(BIHBuilderTest, single_infinite_volume)
+{
+    bboxes_.push_back(FastBBox::from_infinite());
+
+    BIHBuilder bih(&storage_);
+    auto bih_tree = bih(std::move(bboxes_));
+
+    ASSERT_EQ(0, bih_tree.inner_nodes.size());
+    ASSERT_EQ(1, bih_tree.leaf_nodes.size());
+    ASSERT_EQ(1, bih_tree.inf_volids.size());
+
+    EXPECT_EQ(LocalVolumeId{0},
+              storage_.local_volume_ids[bih_tree.inf_volids[0]]);
+}
+
+TEST_F(BIHBuilderTest, multiple_infinite_volumes)
+{
+    bboxes_.push_back(FastBBox::from_infinite());
+    bboxes_.push_back(FastBBox::from_infinite());
+
+    BIHBuilder bih(&storage_);
+    auto bih_tree = bih(std::move(bboxes_));
+
+    ASSERT_EQ(0, bih_tree.inner_nodes.size());
+    ASSERT_EQ(1, bih_tree.leaf_nodes.size());
+    ASSERT_EQ(2, bih_tree.inf_volids.size());
+
+    EXPECT_EQ(LocalVolumeId{0},
+              storage_.local_volume_ids[bih_tree.inf_volids[0]]);
+    EXPECT_EQ(LocalVolumeId{1},
+              storage_.local_volume_ids[bih_tree.inf_volids[1]]);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/detail/BIHTraverser.test.cc
+++ b/test/orange/detail/BIHTraverser.test.cc
@@ -39,13 +39,11 @@ class BIHTraversalTest : public Test
     BIHTreeData<Ownership::value, MemSpace::host> storage_;
     BIHTreeData<Ownership::const_reference, MemSpace::host> ref_storage_;
 
-    static constexpr auto valid_volid_
-        = [](LocalVolumeId vol_id, [[maybe_unused]] Real3 point) -> bool {
+    static constexpr auto valid_volid_ = [](LocalVolumeId vol_id) -> bool {
         return static_cast<bool>(vol_id);
     };
 
-    static constexpr auto odd_volid_
-        = [](LocalVolumeId vol_id, [[maybe_unused]] Real3 point) -> bool {
+    static constexpr auto odd_volid_ = [](LocalVolumeId vol_id) -> bool {
         return vol_id.unchecked_get() % 2 != 0;
     };
 };

--- a/test/orange/detail/BIHTraverser.test.cc
+++ b/test/orange/detail/BIHTraverser.test.cc
@@ -1,0 +1,146 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021-2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/detail/BIHTraverser.test.cc
+//---------------------------------------------------------------------------//
+#include "orange/detail/BIHTraverser.hh"
+
+#include "corecel/data/CollectionBuilder.hh"
+#include "corecel/data/CollectionMirror.hh"
+#include "orange/detail/BIHBuilder.hh"
+#include "orange/detail/BIHData.hh"
+#include "celeritas/Types.hh"
+
+#include "celeritas_test.hh"
+
+using BIHBuilder = celeritas::detail::BIHBuilder;
+using BIHInnerNode = celeritas::detail::BIHInnerNode;
+using BIHLeafNode = celeritas::detail::BIHLeafNode;
+using BIHTraverser = celeritas::detail::BIHTraverser;
+
+namespace celeritas
+{
+namespace test
+{
+class BIHTraversalTest : public Test
+{
+  public:
+    void SetUp()
+    {
+        auto inf = std::numeric_limits<fast_real_type>::infinity();
+        bboxes_.push_back({{-inf, -inf, -inf}, {inf, inf, inf}});
+    }
+
+  protected:
+    std::vector<FastBBox> bboxes_;
+
+    BIHTreeData<Ownership::value, MemSpace::host> storage_;
+    BIHTreeData<Ownership::const_reference, MemSpace::host> ref_storage_;
+
+    static constexpr auto valid_volid_
+        = [](LocalVolumeId vol_id, [[maybe_unused]] Real3 point) -> bool {
+        return static_cast<bool>(vol_id);
+    };
+
+    static constexpr auto odd_volid_
+        = [](LocalVolumeId vol_id, [[maybe_unused]] Real3 point) -> bool {
+        return vol_id.unchecked_get() % 2 != 0;
+    };
+};
+
+//---------------------------------------------------------------------------//
+/* Simple test with partial and fully overlapping bounding boxes.
+ *
+ *         0    V1    1.6
+ *         |--------------|
+ *
+ *                    1.2   V2    2.8
+ *                    |---------------|
+ *    y=1 ____________________________________________________
+ *        |           |   |           |                      |
+ *        |           |   |           |         V3           |
+ *    y=0 |___________|___|___________|______________________|
+ *        |                                                  |
+ *        |             V4, V5 (total overlap)               |
+ *   y=-1 |__________________________________________________|
+ *
+ *        x=0                                                x=5
+ */
+TEST_F(BIHTraversalTest, basic)
+{
+    bboxes_.push_back({{0, 0, 0}, {1.6, 1, 100}});
+    bboxes_.push_back({{1.2, 0, 0}, {2.8, 1, 100}});
+    bboxes_.push_back({{2.8, 0, 0}, {5, 1, 100}});
+    bboxes_.push_back({{0, -1, 0}, {5, 0, 100}});
+    bboxes_.push_back({{0, -1, 0}, {5, 0, 100}});
+
+    BIHBuilder bih(&storage_);
+    auto bih_tree = bih(std::move(bboxes_));
+
+    ref_storage_ = storage_;
+    BIHTraverser traverser(bih_tree, ref_storage_);
+
+    EXPECT_EQ(LocalVolumeId{0}, traverser({0.8, 0.5, 110}, valid_volid_));
+    EXPECT_EQ(LocalVolumeId{1}, traverser({0.8, 0.5, 30}, valid_volid_));
+    EXPECT_EQ(LocalVolumeId{2}, traverser({2.0, 0.6, 40}, valid_volid_));
+    EXPECT_EQ(LocalVolumeId{3}, traverser({2.9, 0.7, 50}, valid_volid_));
+    EXPECT_EQ(LocalVolumeId{4}, traverser({2.9, -0.7, 50}, valid_volid_));
+    EXPECT_EQ(LocalVolumeId{5}, traverser({2.9, -0.7, 50}, odd_volid_));
+}
+
+//---------------------------------------------------------------------------//
+/* Test a 3x4 grid of non-overlapping cuboids.
+ *
+ *                4 _______________
+ *                  | V4 | V8 | V12|
+ *                3 |____|____|____|
+ *                  | V3 | V7 | V11|
+ *            y   2 |____|____|____|
+ *                  | V2 | V6 | V10|
+ *                1 |____|____|____|
+ *                  | V1 | V5 | V9 |
+ *                0 |____|____|____|
+ *                  0    1    2    3
+ *                          x
+ */
+TEST_F(BIHTraversalTest, grid)
+{
+    bboxes_.push_back({{0, 0, 0}, {1, 1, 100}});
+    bboxes_.push_back({{0, 1, 0}, {1, 2, 100}});
+    bboxes_.push_back({{0, 2, 0}, {1, 3, 100}});
+    bboxes_.push_back({{0, 3, 0}, {1, 4, 100}});
+
+    bboxes_.push_back({{1, 0, 0}, {2, 1, 100}});
+    bboxes_.push_back({{1, 1, 0}, {2, 2, 100}});
+    bboxes_.push_back({{1, 2, 0}, {2, 3, 100}});
+    bboxes_.push_back({{1, 3, 0}, {2, 4, 100}});
+
+    bboxes_.push_back({{2, 0, 0}, {3, 1, 100}});
+    bboxes_.push_back({{2, 1, 0}, {3, 2, 100}});
+    bboxes_.push_back({{2, 2, 0}, {3, 3, 100}});
+    bboxes_.push_back({{2, 3, 0}, {3, 4, 100}});
+
+    BIHBuilder bih(&storage_);
+    auto bih_tree = bih(std::move(bboxes_));
+
+    ref_storage_ = storage_;
+    BIHTraverser traverser(bih_tree, ref_storage_);
+
+    EXPECT_EQ(LocalVolumeId{0}, traverser({0.8, 0.5, 110}, valid_volid_));
+
+    size_type index{1};
+    for (auto i : range(3))
+    {
+        for (auto j : range(4))
+        {
+            EXPECT_EQ(LocalVolumeId{index++},
+                      traverser({0.5 + i, 0.5 + j, 30}, valid_volid_));
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/orange/detail/BIHTraverser.test.cc
+++ b/test/orange/detail/BIHTraverser.test.cc
@@ -35,11 +35,12 @@ class BIHTraverserTest : public Test
     BIHTreeData<Ownership::value, MemSpace::host> storage_;
     BIHTreeData<Ownership::const_reference, MemSpace::host> ref_storage_;
 
-    static constexpr auto valid_volid_ = [](LocalVolumeId vol_id) -> bool {
+    static constexpr bool valid_volid_(LocalVolumeId vol_id)
+    {
         return static_cast<bool>(vol_id);
     };
-
-    static constexpr auto odd_volid_ = [](LocalVolumeId vol_id) -> bool {
+    static constexpr bool odd_volid_(LocalVolumeId vol_id)
+    {
         return vol_id.unchecked_get() % 2 != 0;
     };
 };
@@ -103,20 +104,15 @@ TEST_F(BIHTraverserTest, basic)
 TEST_F(BIHTraverserTest, grid)
 {
     bboxes_.push_back(FastBBox::from_infinite());
-    bboxes_.push_back({{0, 0, 0}, {1, 1, 100}});
-    bboxes_.push_back({{0, 1, 0}, {1, 2, 100}});
-    bboxes_.push_back({{0, 2, 0}, {1, 3, 100}});
-    bboxes_.push_back({{0, 3, 0}, {1, 4, 100}});
-
-    bboxes_.push_back({{1, 0, 0}, {2, 1, 100}});
-    bboxes_.push_back({{1, 1, 0}, {2, 2, 100}});
-    bboxes_.push_back({{1, 2, 0}, {2, 3, 100}});
-    bboxes_.push_back({{1, 3, 0}, {2, 4, 100}});
-
-    bboxes_.push_back({{2, 0, 0}, {3, 1, 100}});
-    bboxes_.push_back({{2, 1, 0}, {3, 2, 100}});
-    bboxes_.push_back({{2, 2, 0}, {3, 3, 100}});
-    bboxes_.push_back({{2, 3, 0}, {3, 4, 100}});
+    for (auto i : range(3))
+    {
+        for (auto j : range(4))
+        {
+            auto x = static_cast<fast_real_type>(i);
+            auto y = static_cast<fast_real_type>(j);
+            bboxes_.push_back({{x, y, 0}, {x + 1, y + 1, 100}});
+        }
+    }
 
     BIHBuilder bih(&storage_);
     auto bih_tree = bih(std::move(bboxes_));


### PR DESCRIPTION
In this PR, a `BIHTraversal` class is implemented, allowing for point-in-volume calls using the tree structure. For each call, a depth-first-search is carried-out. The termination criteria for the search is based on testing the point against volume bounding boxes as well as a user-supplied functor. The tree is built on device and used in `SimpleUnitTracker`.

In addition:
1)  `BIHTreeData` to store the low-level data for all BIH trees, instead of relying on `OrangeParamsData`.
2) When volumes do not have bounding boxes, infinite bounding boxes are created as placeholders. A valid BIHTree object is created, allowing all 33 units tests that rely on geometries without bounding boxes to pass.