### PR TITLE
Restore "small step updates momentum" condition (part of #875) in field propagator

### DIFF
--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -85,6 +85,9 @@ class FieldPropagator
     // Distance to bump or to consider a "zero" movement
     inline CELER_FUNCTION real_type bump_distance() const;
 
+    // Smallest allowable inner loop distance to take
+    inline CELER_FUNCTION real_type minimum_substep() const;
+
   private:
     //// DATA ////
 
@@ -184,7 +187,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
         // Do a detailed check boundary check from the start position toward
         // the substep end point. Travel to the end of the chord, plus a little
         // extra.
-        if (chord.length >= this->bump_distance())
+        if (chord.length >= this->minimum_substep())
         {
             // Only update the direction if the chord length is nontrivial.
             // This is usually the case but might be skipped in two cases:
@@ -229,7 +232,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // near tangent). Reduce substep size and try again.
             remaining = substep.step / 2;
         }
-        else if (update_length <= this->bump_distance()
+        else if (update_length <= this->minimum_substep()
                  || detail::is_intercept_close(state_.pos,
                                                chord.dir,
                                                linear_step.distance,
@@ -275,7 +278,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             // fraction along the chord, and retry the driver step.
             remaining = update_length;
         }
-    } while (remaining > 0 && remaining_substeps > 0);
+    } while (remaining > this->minimum_substep() && remaining_substeps > 0);
 
     if (remaining_substeps == 0 && result.distance < step)
     {
@@ -347,6 +350,16 @@ template<class DriverT, class GTV>
 CELER_FUNCTION real_type FieldPropagator<DriverT, GTV>::delta_intersection() const
 {
     return driver_.delta_intersection();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Distance to bump or to consider a "zero" movement.
+ */
+template<class DriverT, class GTV>
+CELER_FUNCTION real_type FieldPropagator<DriverT, GTV>::minimum_substep() const
+{
+    return driver_.minimum_step();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -222,22 +222,23 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             --remaining_substeps;
         }
         else if (CELER_UNLIKELY(result.boundary
-                                && linear_step.distance < this->bump_distance()
-                                && this->bump_distance() < remaining))
+                                && linear_step.distance < this->bump_distance()))
         {
-            // This substep *started* on a surface and the step length is very
-            // small despite a large expected step: likely heading back into
-            // the old volume when starting on a surface (this can happen when
-            // tracking through a volume at a near tangent). Reduce substep
-            // size and try again.
+            // Likely heading back into the old volume when starting on a
+            // surface (this can happen when tracking through a volume at a
+            // near tangent). Reduce substep size and try again.
             remaining = substep.step / 2;
         }
-        else if (detail::is_intercept_close(state_.pos,
-                                            chord.dir,
-                                            linear_step.distance,
-                                            substep.state.pos,
-                                            this->delta_intersection()))
+        else if (update_length <= this->bump_distance()
+                 || detail::is_intercept_close(state_.pos,
+                                               chord.dir,
+                                               linear_step.distance,
+                                               substep.state.pos,
+                                               this->delta_intersection()))
         {
+            // We're close enough to the boundary that the next trial step
+            // would be less than the driver's minimum step.
+            // *OR*
             // The straight-line intersection point is a distance less than
             // `delta_intersection` from the substep's end position.
             // Commit the proposed state's momentum, use the

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1310,10 +1310,10 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         else
         {
             // Repeated substep bisection failed; particle is bumped
-            EXPECT_SOFT_NEAR(1e-8, result.distance, 1e-8);
+            EXPECT_SOFT_NEAR(1e-6, result.distance, 1e-8);
             // Minor floating point differences could make this 98 or so
             EXPECT_SOFT_NEAR(real_type(95), real_type(stepper.count()), 0.05);
-            EXPECT_TRUE(result.boundary);
+            EXPECT_FALSE(result.boundary);  // FIXME: should have reentered
             EXPECT_FALSE(result.looping);
 
             if (scoped_log_.empty()) {}
@@ -1327,7 +1327,8 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
             {
                 static char const* const expected_log_messages[]
                     = {"Moved internally from boundary but safety didn't "
-                       "increase: volume 6 at {123.254,-20.8187,-40.8262}"};
+                       "increase: volume 6 from {123.254,-20.8187,-40.8262} "
+                       "to {123.254,-20.8187,-40.8262} (distance: 1e-06)"};
                 EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
                 static char const* const expected_log_levels[] = {"warning"};
                 EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1283,17 +1283,13 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
         Propagation result;
         // This absurdly long step is because in the "failed" case the
         // track thinks it's in the world volume (nearly vacuum)
-        try
+        result = propagate(2.12621374950874703e+21);
+
+        if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_GEANT4
+            && result.boundary != geo.is_on_boundary())
         {
-            result = propagate(2.12621374950874703e+21);
-        }
-        catch (RuntimeError const& e)
-        {
-            // Failure during Geant4 propagation
-            result.boundary = true;
-            result.looping = true;
-            result.distance = 0;
-            CELER_LOG_LOCAL(error) << e.what();
+            // FIXME: see #882
+            GTEST_SKIP() << "The current fix fails with the Geant4 navigator";
         }
 
         EXPECT_EQ(result.boundary, geo.is_on_boundary());
@@ -1310,29 +1306,6 @@ TEST_F(SimpleCmsTest, vecgeom_failure)
             EXPECT_EQ("em_calorimeter", this->volume_name(geo));
             EXPECT_EQ(573, stepper.count());
             EXPECT_TRUE(result.looping);
-        }
-        else if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_GEANT4
-                 && result.boundary && result.looping)
-        {
-            // FIXME: this happens because of incorrect momentum update when
-            // stuck on a boundary
-            static char const* const expected_log_levels[] = {"error", "error"};
-            EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels())
-                << scoped_log_;
-
-            std::vector<std::string> errors;
-            std::regex const re_err{"Geant4 error: (\\w+) failed:"};
-            std::smatch match;
-            for (auto const& msg : scoped_log_.messages())
-            {
-                if (std::regex_search(msg, match, re_err))
-                {
-                    errors.push_back(match[1]);
-                }
-            }
-            static char const* const expected_errors[]
-                = {"GeomNav1002", "GeomNav0003"};
-            EXPECT_VEC_EQ(expected_errors, errors);
         }
         else
         {
@@ -1438,16 +1411,16 @@ TEST_F(CmseTest, coarse)
         // FIXME: this happens because of incorrect momentum update
         expected_num_boundary = {134, 37, 60, 40};
         expected_num_step = {10001, 179, 3236, 1303};
-        expected_num_intercept = {30419, 1670, 16170, 9956};
-        expected_num_integration = {80659, 2725, 41914, 26114};
+        expected_num_intercept = {30419, 615, 16170, 9956};
+        expected_num_integration = {80659, 1670, 41914, 26114};
     }
     else if (!scoped_log_.empty())
     {
         // Bumped (platform-dependent!): counts change a bit
         expected_num_boundary = {134, 101, 60, 40};
         expected_num_step = {10001, 6462, 3236, 1303};
-        expected_num_intercept = {30419, 20606, 16170, 9956};
-        expected_num_integration = {80659, 59337, 41914, 26114};
+        expected_num_intercept = {30419, 19551, 16170, 9956};
+        expected_num_integration = {80659, 58282, 41914, 26114};
         static char const* const expected_log_messages[]
             = {"Moved internally from boundary but safety didn't increase: "
                "volume 18 from {10.3161,-6.56495,796.923} to "


### PR DESCRIPTION
This reverts commit 30f7e12e2952294ec58baeb22fe6cacaef8aa86b, part of #875:

> This was erroneously using the momentum update from a 0.2-length step for a 1e-14 length step.  The updated logic now performs a "quick advance" and uses the resulting momentum, so the particle now resumes the correct (though undesirable) loop inside the vacuum tube.

After that commit, several (average of ~3) tracks get stuck looping in cms2018+field and a couple of tracks in `testem3-flat+field+msc` with ORANGE failed to converge (or failed in debug mode). I'm reverting this to see if it restores the field behavior from v0.3, and we can explore a fix to this in a follow-on PR.