### PR TITLE
Allow downstream packages to find a newer version of Celeritas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,7 @@ configure_file(
 # TODO for version 1.0.0: change COMPATIBILITY to MajorVersion
 write_basic_package_version_file(
   "${CELERITAS_CMAKE_CONFIG_DIRECTORY}/CeleritasConfigVersion.cmake"
-  COMPATIBILITY SameMinorVersion
+  COMPATIBILITY AnyNewerVersion
 )
 
 # Install generated config files

--- a/cmake/CeleritasConfig.cmake.in
+++ b/cmake/CeleritasConfig.cmake.in
@@ -16,6 +16,26 @@ if(CMAKE_VERSION VERSION_LESS 3.18)
 endif()
 
 #-----------------------------------------------------------------------------#
+# Version compatibility
+#
+# To avoid unnecessary strictness (with non-obvious error messages) we do not
+# use the `SameMajorVersion`/`SameMinorVersion` argument to
+# \c write_basic_package_version_file . Instead we check for any requested
+# package version here and warn deliberately if it doesn't match.
+#-----------------------------------------------------------------------------#
+# TODO for version 1.0.0: update logic to major version
+if(((@PROJECT_NAME@_FIND_VERSION_MAJOR EQUAL 0
+     AND @PROJECT_NAME@_FIND_VERSION_MINOR LESS @PROJECT_NAME@_VERSION_MINOR)
+    OR @PROJECT_NAME@_FIND_VERSION_MAJOR GREATER 0)
+   AND NOT @PROJECT_NAME@_FIND_VERSION_MAX VERSION_GREATER_EQUAL @PROJECT_NAME@_VERSION)
+   message(AUTHOR_WARNING "@PROJECT_NAME@ version ${@PROJECT_NAME@_VERSION} "
+     "may not be compatible with requested version "
+     "${@PROJECT_NAME@_FIND_VERSION}: please update your find_package "
+     "version range"
+   )
+endif()
+
+#-----------------------------------------------------------------------------#
 # Variables
 #-----------------------------------------------------------------------------#
 
@@ -112,7 +132,7 @@ endif()
 #-----------------------------------------------------------------------------#
 
 foreach(_dep CUDA ROOT Geant4 VecGeom MPI OpenMP)
-  set(Celeritas_${_dep}_FOUND ${CELERITAS_USE_${_dep}})
+  set(@PROJECT_NAME@_${_dep}_FOUND ${CELERITAS_USE_${_dep}})
 endforeach()
 
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
This fixes the CI failure and makes our project compatibility scheme more realistic: not all "major" versions will be incompatible with older requested versions; it just depends on the feature set. Now you'll just get a warning if you request celeritas v0.3 and only v0.4 is available.