### PR TITLE
Add more bounding box utilities

### DIFF
--- a/src/corecel/cont/Range.hh
+++ b/src/corecel/cont/Range.hh
@@ -74,13 +74,13 @@ class Range
     //// CONSTRUCTORS ////
 
     //! Empty constructor for empty range
-    CELER_FORCEINLINE_FUNCTION Range() : begin_{}, end_{} {}
+    CELER_CONSTEXPR_FUNCTION Range() : begin_{}, end_{} {}
 
     //! Construct from stop
-    CELER_FORCEINLINE_FUNCTION Range(T end) : begin_{}, end_(end) {}
+    CELER_CONSTEXPR_FUNCTION Range(T end) : begin_{}, end_(end) {}
 
     //! Construct from start/stop
-    CELER_FORCEINLINE_FUNCTION Range(T begin, T end) : begin_(begin), end_(end)
+    CELER_CONSTEXPR_FUNCTION Range(T begin, T end) : begin_(begin), end_(end)
     {
     }
 
@@ -88,32 +88,32 @@ class Range
 
     //!@{
     //! Iterators
-    CELER_FORCEINLINE_FUNCTION const_iterator begin() const { return begin_; }
-    CELER_FORCEINLINE_FUNCTION const_iterator cbegin() const { return begin_; }
-    CELER_FORCEINLINE_FUNCTION const_iterator end() const { return end_; }
-    CELER_FORCEINLINE_FUNCTION const_iterator cend() const { return end_; }
+    CELER_CONSTEXPR_FUNCTION const_iterator begin() const { return begin_; }
+    CELER_CONSTEXPR_FUNCTION const_iterator cbegin() const { return begin_; }
+    CELER_CONSTEXPR_FUNCTION const_iterator end() const { return end_; }
+    CELER_CONSTEXPR_FUNCTION const_iterator cend() const { return end_; }
     //!@}
 
     //! Array-like access
-    CELER_FORCEINLINE_FUNCTION value_type operator[](size_type i) const
+    CELER_CONSTEXPR_FUNCTION value_type operator[](size_type i) const
     {
         return *(begin_ + i);
     }
 
     //! Number of elements
-    CELER_FORCEINLINE_FUNCTION size_type size() const
+    CELER_CONSTEXPR_FUNCTION size_type size() const
     {
         return TraitsT::to_counter(*end_) - TraitsT::to_counter(*begin_);
     }
 
     //! Whether the range has no elements
-    CELER_FORCEINLINE_FUNCTION bool empty() const { return begin_ == end_; }
+    CELER_CONSTEXPR_FUNCTION bool empty() const { return begin_ == end_; }
 
     //! First item in the range
-    CELER_FORCEINLINE_FUNCTION value_type front() const { return *begin_; }
+    CELER_CONSTEXPR_FUNCTION value_type front() const { return *begin_; }
 
     //! Last item in the range
-    CELER_FORCEINLINE_FUNCTION value_type back() const
+    CELER_CONSTEXPR_FUNCTION value_type back() const
     {
         return (*this)[this->size() - 1];
     }
@@ -122,7 +122,7 @@ class Range
 
     //! Return a stepped range using a different integer type
     template<class U, std::enable_if_t<std::is_signed<U>::value, U> = 0>
-    CELER_FUNCTION detail::StepRange<step_type<U>> step(U step)
+    CELER_CONSTEXPR_FUNCTION detail::StepRange<step_type<U>> step(U step)
     {
         if (step < 0)
         {
@@ -135,7 +135,7 @@ class Range
     //! \cond
     //! Return a stepped range using a different integer type
     template<class U, std::enable_if_t<std::is_unsigned<U>::value, U> = 0>
-    CELER_FUNCTION detail::StepRange<step_type<U>> step(U step)
+    CELER_CONSTEXPR_FUNCTION detail::StepRange<step_type<U>> step(U step)
     {
         return {*begin_, *end_, step};
     }
@@ -163,17 +163,20 @@ class Count
     using value_type = T;
     //@}
 
-    CELER_FUNCTION Count() : begin_{} {}
-    CELER_FUNCTION Count(T begin) : begin_(begin) {}
+    CELER_CONSTEXPR_FUNCTION Count() : begin_{} {}
+    CELER_CONSTEXPR_FUNCTION Count(T begin) : begin_(begin) {}
 
-    CELER_FUNCTION detail::InfStepRange<T> step(T step)
+    CELER_CONSTEXPR_FUNCTION detail::InfStepRange<T> step(T step)
     {
         return {*begin_, step};
     }
 
-    CELER_FUNCTION const_iterator begin() const { return begin_; }
-    CELER_FUNCTION const_iterator end() const { return const_iterator(); }
-    CELER_FUNCTION bool empty() const { return false; }
+    CELER_CONSTEXPR_FUNCTION const_iterator begin() const { return begin_; }
+    CELER_CONSTEXPR_FUNCTION const_iterator end() const
+    {
+        return const_iterator();
+    }
+    CELER_CONSTEXPR_FUNCTION bool empty() const { return false; }
 
   private:
     const_iterator begin_;
@@ -184,7 +187,7 @@ class Count
  * Return a range over fixed beginning and end values.
  */
 template<class T>
-CELER_FUNCTION Range<T> range(T begin, T end)
+CELER_CONSTEXPR_FUNCTION Range<T> range(T begin, T end)
 {
     return {begin, end};
 }
@@ -194,7 +197,7 @@ CELER_FUNCTION Range<T> range(T begin, T end)
  * Return a range with the default start value (0 for numeric types)
  */
 template<class T>
-CELER_FUNCTION Range<T> range(T end)
+CELER_CONSTEXPR_FUNCTION Range<T> range(T end)
 {
     return {end};
 }
@@ -204,7 +207,7 @@ CELER_FUNCTION Range<T> range(T end)
  * Count upward from zero.
  */
 template<class T>
-CELER_FUNCTION Count<T> count()
+CELER_CONSTEXPR_FUNCTION Count<T> count()
 {
     return {};
 }
@@ -214,7 +217,7 @@ CELER_FUNCTION Count<T> count()
  * Count upward from a value.
  */
 template<class T>
-CELER_FUNCTION Count<T> count(T begin)
+CELER_CONSTEXPR_FUNCTION Count<T> count(T begin)
 {
     return {begin};
 }

--- a/src/corecel/cont/detail/RangeImpl.hh
+++ b/src/corecel/cont/detail/RangeImpl.hh
@@ -39,14 +39,14 @@ struct RangeTypeTraits
     {
         return c;
     }
-    static CELER_FORCEINLINE_FUNCTION value_type increment(value_type v,
-                                                           counter_type i)
+    static CELER_CONSTEXPR_FUNCTION value_type increment(value_type v,
+                                                         counter_type i)
     {
         v += i;
         return v;
     }
-    static CELER_FORCEINLINE_FUNCTION value_type decrement(value_type v,
-                                                           counter_type i)
+    static CELER_CONSTEXPR_FUNCTION value_type decrement(value_type v,
+                                                         counter_type i)
     {
         v -= i;
         return v;
@@ -90,15 +90,15 @@ struct RangeTypeTraits<T, typename std::enable_if<std::is_enum<T>::value>::type>
     {
         return static_cast<value_type>(c);
     }
-    static CELER_FORCEINLINE_FUNCTION value_type increment(value_type v,
-                                                           counter_type i)
+    static CELER_CONSTEXPR_FUNCTION value_type increment(value_type v,
+                                                         counter_type i)
     {
         counter_type temp = to_counter(v);
         temp += i;
         return to_value(temp);
     }
-    static CELER_FORCEINLINE_FUNCTION value_type decrement(value_type v,
-                                                           counter_type i)
+    static CELER_CONSTEXPR_FUNCTION value_type decrement(value_type v,
+                                                         counter_type i)
     {
         counter_type temp = to_counter(v);
         temp -= i;
@@ -128,15 +128,15 @@ struct RangeTypeTraits<OpaqueId<I, T>, void>
     {
         return value_type{c};
     }
-    static CELER_FORCEINLINE_FUNCTION value_type increment(value_type v,
-                                                           counter_type i)
+    static CELER_CONSTEXPR_FUNCTION value_type increment(value_type v,
+                                                         counter_type i)
     {
         counter_type temp = to_counter(v);
         temp += i;
         return to_value(temp);
     }
-    static CELER_FORCEINLINE_FUNCTION value_type decrement(value_type v,
-                                                           counter_type i)
+    static CELER_CONSTEXPR_FUNCTION value_type decrement(value_type v,
+                                                         counter_type i)
     {
         counter_type temp = to_counter(v);
         temp -= i;
@@ -163,7 +163,7 @@ class range_iter
   public:
     //// CONSTRUCTOR ////
 
-    CELER_FORCEINLINE_FUNCTION range_iter(value_type value = TraitsT::zero())
+    CELER_CONSTEXPR_FUNCTION range_iter(value_type value = TraitsT::zero())
         : value_(value)
     {
         CELER_EXPECT(TraitsT::is_valid(value_));
@@ -171,61 +171,61 @@ class range_iter
 
     //// ACCESSORS ////
 
-    CELER_FORCEINLINE_FUNCTION value_type operator*() const { return value_; }
-    CELER_FORCEINLINE_FUNCTION value_type const* operator->() const
+    CELER_CONSTEXPR_FUNCTION value_type operator*() const { return value_; }
+    CELER_CONSTEXPR_FUNCTION value_type const* operator->() const
     {
         return &value_;
     }
 
-    CELER_FORCEINLINE_FUNCTION value_type operator[](counter_type inc) const
+    CELER_CONSTEXPR_FUNCTION value_type operator[](counter_type inc) const
     {
         return TraitsT::increment(value_, inc);
     }
 
     //// ARITHMETIC ////
 
-    CELER_FORCEINLINE_FUNCTION range_iter& operator++()
+    CELER_CONSTEXPR_FUNCTION range_iter& operator++()
     {
         value_ = TraitsT::increment(value_, 1);
         return *this;
     }
 
-    CELER_FORCEINLINE_FUNCTION range_iter operator++(int)
+    CELER_CONSTEXPR_FUNCTION range_iter operator++(int)
     {
         auto copy = *this;
         value_ = TraitsT::increment(value_, 1);
         return copy;
     }
 
-    CELER_FORCEINLINE_FUNCTION range_iter operator+(counter_type inc) const
+    CELER_CONSTEXPR_FUNCTION range_iter operator+(counter_type inc) const
     {
         return {TraitsT::increment(value_, inc)};
     }
 
-    CELER_FORCEINLINE_FUNCTION range_iter& operator--()
+    CELER_CONSTEXPR_FUNCTION range_iter& operator--()
     {
         value_ = TraitsT::decrement(value_, 1);
         return *this;
     }
 
-    CELER_FORCEINLINE_FUNCTION range_iter operator--(int)
+    CELER_CONSTEXPR_FUNCTION range_iter operator--(int)
     {
         auto copy = *this;
         value_ = TraitsT::decrement(value_, 1);
         return copy;
     }
 
-    CELER_FORCEINLINE_FUNCTION range_iter operator-(counter_type inc) const
+    CELER_CONSTEXPR_FUNCTION range_iter operator-(counter_type inc) const
     {
         return {TraitsT::decrement(value_, inc)};
     }
 
-    CELER_FORCEINLINE_FUNCTION bool operator==(range_iter const& other) const
+    CELER_CONSTEXPR_FUNCTION bool operator==(range_iter const& other) const
     {
         return value_ == other.value_;
     }
 
-    CELER_FORCEINLINE_FUNCTION bool operator!=(range_iter const& other) const
+    CELER_CONSTEXPR_FUNCTION bool operator!=(range_iter const& other) const
     {
         return !(*this == other);
     }
@@ -243,17 +243,17 @@ class inf_range_iter : public range_iter<T>
   public:
     using TraitsT = typename Base::TraitsT;
 
-    CELER_FORCEINLINE_FUNCTION inf_range_iter(T value = TraitsT::zero())
+    CELER_CONSTEXPR_FUNCTION inf_range_iter(T value = TraitsT::zero())
         : Base(value)
     {
     }
 
-    CELER_FORCEINLINE_FUNCTION bool operator==(inf_range_iter const&) const
+    CELER_CONSTEXPR_FUNCTION bool operator==(inf_range_iter const&) const
     {
         return false;
     }
 
-    CELER_FORCEINLINE_FUNCTION bool operator!=(inf_range_iter const&) const
+    CELER_CONSTEXPR_FUNCTION bool operator!=(inf_range_iter const&) const
     {
         return true;
     }
@@ -269,25 +269,25 @@ class step_range_iter : public range_iter<T>
     using TraitsT = typename Base::TraitsT;
     using counter_type = typename TraitsT::counter_type;
 
-    CELER_FORCEINLINE_FUNCTION step_range_iter(T value, counter_type step)
+    CELER_CONSTEXPR_FUNCTION step_range_iter(T value, counter_type step)
         : Base(value), step_(step)
     {
     }
 
-    CELER_FORCEINLINE_FUNCTION step_range_iter& operator++()
+    CELER_CONSTEXPR_FUNCTION step_range_iter& operator++()
     {
         value_ = TraitsT::increment(value_, step_);
         return *this;
     }
 
-    CELER_FORCEINLINE_FUNCTION step_range_iter operator++(int)
+    CELER_CONSTEXPR_FUNCTION step_range_iter operator++(int)
     {
         auto copy = *this;
         ++*this;
         return copy;
     }
 
-    CELER_FORCEINLINE_FUNCTION step_range_iter operator+(counter_type inc)
+    CELER_CONSTEXPR_FUNCTION step_range_iter operator+(counter_type inc)
     {
         return {TraitsT::increment(value_, inc * step_)};
     }
@@ -359,8 +359,8 @@ class StepRange
     {
     }
 
-    CELER_FORCEINLINE_FUNCTION IterT begin() const { return begin_; }
-    CELER_FORCEINLINE_FUNCTION IterT end() const { return end_; }
+    CELER_CONSTEXPR_FUNCTION IterT begin() const { return begin_; }
+    CELER_CONSTEXPR_FUNCTION IterT end() const { return end_; }
 
   private:
     IterT begin_;
@@ -384,8 +384,8 @@ class InfStepRange
     {
     }
 
-    CELER_FORCEINLINE_FUNCTION IterT begin() const { return begin_; }
-    CELER_FORCEINLINE_FUNCTION IterT end() const { return IterT(); }
+    CELER_CONSTEXPR_FUNCTION IterT begin() const { return begin_; }
+    CELER_CONSTEXPR_FUNCTION IterT end() const { return IterT(); }
 
   private:
     IterT begin_;

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -112,6 +112,36 @@ struct Less<void>
 // Replace/extend <algorithm>
 //---------------------------------------------------------------------------//
 /*!
+ * Whether the predicate is true for all items.
+ */
+template<class InputIt, class Predicate>
+bool all_of(InputIt iter, InputIt last, Predicate p)
+{
+    for (; iter != last; ++iter)
+    {
+        if (!p(*iter))
+            return false;
+    }
+    return true;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether the predicate is true for any item.
+ */
+template<class InputIt, class Predicate>
+bool any_of(InputIt iter, InputIt last, Predicate p)
+{
+    for (; iter != last; ++iter)
+    {
+        if (p(*iter))
+            return true;
+    }
+    return false;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Clamp the value between lo and hi values.
  *
  * If the value is between lo and hi, return the value. Otherwise, return lo if

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -115,7 +115,7 @@ struct Less<void>
  * Whether the predicate is true for all items.
  */
 template<class InputIt, class Predicate>
-bool all_of(InputIt iter, InputIt last, Predicate p)
+inline CELER_FUNCTION bool all_of(InputIt iter, InputIt last, Predicate p)
 {
     for (; iter != last; ++iter)
     {
@@ -130,7 +130,7 @@ bool all_of(InputIt iter, InputIt last, Predicate p)
  * Whether the predicate is true for any item.
  */
 template<class InputIt, class Predicate>
-bool any_of(InputIt iter, InputIt last, Predicate p)
+inline CELER_FUNCTION bool any_of(InputIt iter, InputIt last, Predicate p)
 {
     for (; iter != last; ++iter)
     {

--- a/src/orange/BoundingBox.hh
+++ b/src/orange/BoundingBox.hh
@@ -22,8 +22,9 @@ namespace celeritas
 /*!
  * Axis-aligned bounding box.
  *
- * The bounding box can be constructed in an unassigned state, in which lower
- * and upper cannot be called.
+ * The default bounding box is "degenerate", which encloses no space and
+ * evaluates to "false". A degenerate bounding box still has the ability to be
+ * unioned and intersected with other bounding boxes with the expected effect.
  */
 template<class T>
 class BoundingBox
@@ -39,8 +40,8 @@ class BoundingBox
     static inline CELER_FUNCTION BoundingBox from_infinite();
 
     // Construct from unchecked lower/upper bounds
-    static inline CELER_FUNCTION BoundingBox from_unchecked(Real3 const& lower,
-                                                            Real3 const& upper);
+    static CELER_CONSTEXPR_FUNCTION BoundingBox
+    from_unchecked(Real3 const& lower, Real3 const& upper);
 
     // Construct in unassigned state
     CELER_CONSTEXPR_FUNCTION BoundingBox();
@@ -96,7 +97,7 @@ CELER_FUNCTION BoundingBox<T> BoundingBox<T>::from_infinite()
  * "degenerate" implementation of the bounding box.
  */
 template<class T>
-CELER_FUNCTION BoundingBox<T>
+CELER_CONSTEXPR_FUNCTION BoundingBox<T>
 BoundingBox<T>::from_unchecked(Real3 const& lo, Real3 const& hi)
 {
     return BoundingBox<T>{std::true_type{}, lo, hi};
@@ -125,7 +126,7 @@ CELER_CONSTEXPR_FUNCTION BoundingBox<T>::BoundingBox()
 
 //---------------------------------------------------------------------------//
 /*!
- * Create a valid bounding box from two points.
+ * Create a nondegenerate bounding box from two points.
  *
  * The lower and upper points are allowed to be equal (an empty bounding box
  * at a single point) but upper must not be less than lower.

--- a/src/orange/BoundingBox.hh
+++ b/src/orange/BoundingBox.hh
@@ -36,14 +36,6 @@ class BoundingBox
     using Real3 = Array<real_type, 3>;
     //!@}
 
-    // Closed, axis-aligned halfspace.
-    struct Halfspace
-    {
-        Sense sense;
-        Axis axis;
-        T position;
-    };
-
   public:
     // Construct from infinite extents
     static inline CELER_FUNCTION BoundingBox from_infinite();
@@ -72,7 +64,8 @@ class BoundingBox
     //// MUTATORS ////
 
     // Intersect in place with a half-space
-    CELER_CONSTEXPR_FUNCTION void clip(Halfspace hs);
+    CELER_CONSTEXPR_FUNCTION void
+    clip(Sense sense, Axis axis, real_type position);
 
   private:
     Real3 lower_;
@@ -187,17 +180,16 @@ CELER_CONSTEXPR_FUNCTION BoundingBox<T>::operator bool() const
  * Intersect in place with a half-space.
  */
 template<class T>
-CELER_CONSTEXPR_FUNCTION void BoundingBox<T>::clip(Halfspace hs)
+CELER_CONSTEXPR_FUNCTION void
+BoundingBox<T>::clip(Sense sense, Axis axis, real_type position)
 {
-    if (hs.sense == Sense::inside)
+    if (sense == Sense::inside)
     {
-        upper_[to_int(hs.axis)]
-            = ::celeritas::min(upper_[to_int(hs.axis)], hs.position);
+        upper_[to_int(axis)] = ::celeritas::min(upper_[to_int(axis)], position);
     }
     else
     {
-        lower_[to_int(hs.axis)]
-            = ::celeritas::max(lower_[to_int(hs.axis)], hs.position);
+        lower_[to_int(axis)] = ::celeritas::max(lower_[to_int(axis)], position);
     }
 }
 

--- a/src/orange/BoundingBox.hh
+++ b/src/orange/BoundingBox.hh
@@ -22,9 +22,19 @@ namespace celeritas
 /*!
  * Axis-aligned bounding box.
  *
- * The default bounding box is "degenerate", which encloses no space and
- * evaluates to "false". A degenerate bounding box still has the ability to be
- * unioned and intersected with other bounding boxes with the expected effect.
+ * Bounding boxes "contain" all points inside \em and on their faces. See \c
+ * is_inside in \c BoundingBoxUtils.hh .
+ *
+ * The default bounding box is "null", which has at least one \c lower
+ * coordinate greater than its \c upper coordinate: it evaluates to \c false .
+ * A null bounding box still has the ability to be unioned and intersected with
+ * other bounding boxes with the expected effect, but geometrical operations on
+ * it (center, surface area, volume) are prohibited.
+ *
+ * A "degenerate" bounding box is one that is well-defined but has zero volume
+ * because at least one lower coorindate is equal to the corresponding upper
+ * coordinate. Any point on the surface of this bounding box is still "inside".
+ * It may have nonzero surface area but will have zero volume.
  */
 template<class T>
 class BoundingBox
@@ -58,7 +68,7 @@ class BoundingBox
     //! Upper bbox coordinate
     CELER_CONSTEXPR_FUNCTION Real3 const& upper() const { return upper_; }
 
-    // Whether the bbox is nondegenerate
+    // Whether the bbox is non-null
     CELER_CONSTEXPR_FUNCTION explicit operator bool() const;
 
     //// MUTATORS ////
@@ -101,7 +111,7 @@ CELER_FUNCTION BoundingBox<T> BoundingBox<T>::from_infinite()
  * Create a bounding box from unchecked lower/upper bounds.
  *
  * This should be used exclusively for utilities that understand the
- * "degenerate" implementation of the bounding box.
+ * "null" implementation of the bounding box.
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION BoundingBox<T>
@@ -112,7 +122,7 @@ BoundingBox<T>::from_unchecked(Real3 const& lo, Real3 const& hi)
 
 //---------------------------------------------------------------------------//
 /*!
- * Create a degenerate bounding box.
+ * Create a null bounding box.
  *
  * This should naturally satisfy
  * \code
@@ -133,7 +143,7 @@ CELER_CONSTEXPR_FUNCTION BoundingBox<T>::BoundingBox()
 
 //---------------------------------------------------------------------------//
 /*!
- * Create a nondegenerate bounding box from two points.
+ * Create a non-null bounding box from two points.
  *
  * The lower and upper points are allowed to be equal (an empty bounding box
  * at a single point) but upper must not be less than lower.
@@ -154,7 +164,7 @@ CELER_FUNCTION BoundingBox<T>::BoundingBox(Real3 const& lo, Real3 const& hi)
 
 //---------------------------------------------------------------------------//
 /*!
- * Create a possibly degenerate bounding box from two points.
+ * Create a possibly null bounding box from two points.
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION
@@ -165,7 +175,7 @@ BoundingBox<T>::BoundingBox(std::true_type, Real3 const& lo, Real3 const& hi)
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether the bbox is in a nondegenerate state.
+ * Whether the bbox is in a valid state.
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION BoundingBox<T>::operator bool() const

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <algorithm>
 #include <cmath>
 
 #include "corecel/cont/Range.hh"
@@ -29,15 +28,10 @@ is_inside(BoundingBox<T> const& bbox, Array<U, 3> point)
 {
     CELER_EXPECT(bbox);
 
-    for (auto ax : range(to_int(Axis::size_)))
-    {
-        if (point[ax] < bbox.lower()[ax] || point[ax] > bbox.upper()[ax])
-        {
-            return false;
-        }
-    }
-
-    return true;
+    constexpr auto axes = range(to_int(Axis::size_));
+    return all_of(axes.begin(), axes.end(), [&point, &bbox](int ax) {
+        return point[ax] >= bbox.lower()[ax] && point[ax] <= bbox.upper()[ax];
+    });
 }
 
 //---------------------------------------------------------------------------//
@@ -51,8 +45,8 @@ inline bool is_infinite(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
     auto isinf = [](T value) { return std::isinf(value); };
-    return std::all_of(bbox.lower().begin(), bbox.lower().end(), isinf)
-           && std::all_of(bbox.upper().begin(), bbox.upper().end(), isinf);
+    return all_of(bbox.lower().begin(), bbox.lower().end(), isinf)
+           && all_of(bbox.upper().begin(), bbox.upper().end(), isinf);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -101,19 +101,42 @@ inline T calc_surface_area(BoundingBox<T> const& bbox)
  * Calculate the smallest bounding box enclosing two bounding boxes.
  */
 template<class T>
-inline BoundingBox<T>
+inline constexpr BoundingBox<T>
 calc_union(BoundingBox<T> const& a, BoundingBox<T> const& b)
 {
     Array<T, 3> lower;
     Array<T, 3> upper;
 
-    for (auto ax : range(to_int(Axis::size_)))
+    for (size_type ax = 0; ax != 3; ++ax)
     {
         lower[ax] = celeritas::min(a.lower()[ax], b.lower()[ax]);
         upper[ax] = celeritas::max(a.upper()[ax], b.upper()[ax]);
     }
 
-    return BoundingBox<T>{lower, upper};
+    return BoundingBox<T>::from_unchecked(lower, upper);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the intersection of two bounding boxes.
+ *
+ * If there is no intersection, the result will be a degenerate bounding box
+ * (evaluating to 'false').
+ */
+template<class T>
+inline constexpr BoundingBox<T>
+calc_intersection(BoundingBox<T> const& a, BoundingBox<T> const& b)
+{
+    Array<T, 3> lower;
+    Array<T, 3> upper;
+
+    for (size_type ax = 0; ax != 3; ++ax)
+    {
+        lower[ax] = celeritas::max(a.lower()[ax], b.lower()[ax]);
+        upper[ax] = celeritas::min(a.upper()[ax], b.upper()[ax]);
+    }
+
+    return BoundingBox<T>::from_unchecked(lower, upper);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -50,7 +50,7 @@ template<class T>
 inline bool is_infinite(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
-    auto isinf = static_cast<bool (*)(T)>(std::isinf);
+    auto isinf = [](T value) { return std::isinf(value); };
     return std::all_of(bbox.lower().begin(), bbox.lower().end(), isinf)
            && std::all_of(bbox.upper().begin(), bbox.upper().end(), isinf);
 }

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -100,7 +100,7 @@ calc_union(BoundingBox<T> const& a, BoundingBox<T> const& b)
     Array<T, 3> lower;
     Array<T, 3> upper;
 
-    for (size_type ax = 0; ax != 3; ++ax)
+    for (auto ax : range(to_int(Axis::size_)))
     {
         lower[ax] = celeritas::min(a.lower()[ax], b.lower()[ax]);
         upper[ax] = celeritas::max(a.upper()[ax], b.upper()[ax]);
@@ -123,7 +123,7 @@ calc_intersection(BoundingBox<T> const& a, BoundingBox<T> const& b)
     Array<T, 3> lower;
     Array<T, 3> upper;
 
-    for (size_type ax = 0; ax != 3; ++ax)
+    for (auto ax : range(to_int(Axis::size_)))
     {
         lower[ax] = celeritas::max(a.lower()[ax], b.lower()[ax]);
         upper[ax] = celeritas::min(a.upper()[ax], b.upper()[ax]);

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -8,8 +8,10 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 
 #include "corecel/cont/Range.hh"
+#include "corecel/math/Algorithms.hh"
 #include "orange/BoundingBox.hh"
 #include "orange/OrangeTypes.hh"
 
@@ -27,9 +29,8 @@ is_inside(BoundingBox<T> const& bbox, Array<U, 3> point)
 {
     CELER_EXPECT(bbox);
 
-    for (auto axis : range(Axis::size_))
+    for (auto ax : range(to_int(Axis::size_)))
     {
-        auto ax = to_int(axis);
         if (point[ax] < bbox.lower()[ax] || point[ax] > bbox.upper()[ax])
         {
             return false;
@@ -60,14 +61,13 @@ inline bool is_infinite(BoundingBox<T> const& bbox)
  * Calculate the center of a bounding box.
  */
 template<class T>
-inline Array<T, 3> center(BoundingBox<T> const& bbox)
+inline Array<T, 3> calc_center(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
 
     Array<T, 3> center;
-    for (auto axis : range(Axis::size_))
+    for (auto ax : range(to_int(Axis::size_)))
     {
-        auto ax = to_int(axis);
         center[ax] = (bbox.lower()[ax] + bbox.upper()[ax]) / 2;
     }
 
@@ -79,15 +79,14 @@ inline Array<T, 3> center(BoundingBox<T> const& bbox)
  * Calculate the surface area of a bounding box.
  */
 template<class T>
-inline T surface_area(BoundingBox<T> const& bbox)
+inline T calc_surface_area(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
 
     Array<T, 3> lengths;
 
-    for (auto axis : range(Axis::size_))
+    for (auto ax : range(to_int(Axis::size_)))
     {
-        auto ax = to_int(axis);
         lengths[ax] = bbox.upper()[ax] - bbox.lower()[ax];
     }
 
@@ -103,18 +102,15 @@ inline T surface_area(BoundingBox<T> const& bbox)
  */
 template<class T>
 inline BoundingBox<T>
-bbox_union(BoundingBox<T> const& a, BoundingBox<T> const& b)
+calc_union(BoundingBox<T> const& a, BoundingBox<T> const& b)
 {
-    CELER_EXPECT(a && b);
-
     Array<T, 3> lower;
     Array<T, 3> upper;
 
-    for (auto axis : range(Axis::size_))
+    for (auto ax : range(to_int(Axis::size_)))
     {
-        auto ax = to_int(axis);
-        lower[ax] = std::min(a.lower()[ax], b.lower()[ax]);
-        upper[ax] = std::max(a.upper()[ax], b.upper()[ax]);
+        lower[ax] = celeritas::min(a.lower()[ax], b.lower()[ax]);
+        upper[ax] = celeritas::max(a.upper()[ax], b.upper()[ax]);
     }
 
     return BoundingBox<T>{lower, upper};

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -50,10 +50,9 @@ template<class T>
 inline bool is_infinite(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
-
-    return std::all_of(bbox.lower().begin(), bbox.lower().end(), std::isinf<T>)
-           && std::all_of(
-               bbox.upper().begin(), bbox.upper().end(), std::isinf<T>);
+    auto isinf = static_cast<bool (*)(T)>(std::isinf);
+    return std::all_of(bbox.lower().begin(), bbox.lower().end(), isinf)
+           && std::all_of(bbox.upper().begin(), bbox.upper().end(), isinf);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <limits>
+#include <algorithm>
 
 #include "corecel/cont/Range.hh"
 #include "orange/BoundingBox.hh"
@@ -50,17 +50,9 @@ inline bool is_infinite(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
 
-    constexpr auto max_real = std::numeric_limits<T>::max();
-
-    for (auto axis : range(Axis::size_))
-    {
-        auto ax = to_int(axis);
-        if (bbox.lower()[ax] > -max_real || bbox.upper()[ax] < max_real)
-        {
-            return false;
-        }
-    }
-    return true;
+    return std::all_of(bbox.lower().begin(), bbox.lower().end(), std::isinf<T>)
+           && std::all_of(
+               bbox.upper().begin(), bbox.upper().end(), std::isinf<T>);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -17,13 +17,16 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/math/NumericLimits.hh"
-#include "orange/BoundingBox.hh"
 #include "orange/Types.hh"
 
 #include "Types.hh"  // IWYU pragma: export
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+template<class T>
+class BoundingBox;
+
 //---------------------------------------------------------------------------//
 // TYPE ALIASES
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/BIHBuilder.cc
+++ b/src/orange/detail/BIHBuilder.cc
@@ -55,7 +55,7 @@ BIHTree BIHBuilder::operator()(VecBBox bboxes)
     std::transform(bboxes_.begin(),
                    bboxes_.end(),
                    centers_.begin(),
-                   &celeritas::center<fast_real_type>);
+                   &celeritas::calc_center<fast_real_type>);
 
     VecIndices indices;
     VecIndices inf_volids;

--- a/src/orange/detail/BIHPartitioner.cc
+++ b/src/orange/detail/BIHPartitioner.cc
@@ -151,8 +151,8 @@ BIHPartitioner::make_partition(VecIndices const& indices,
         }
     }
 
-    p.bboxes[Edge::left] = bbox_union(*bboxes_, p.indices[Edge::left]);
-    p.bboxes[Edge::right] = bbox_union(*bboxes_, p.indices[Edge::right]);
+    p.bboxes[Edge::left] = calc_union(*bboxes_, p.indices[Edge::left]);
+    p.bboxes[Edge::right] = calc_union(*bboxes_, p.indices[Edge::right]);
 
     return p;
 }
@@ -167,8 +167,9 @@ real_type BIHPartitioner::calc_cost(Partition const& p) const
 
     using Edge = BIHInnerNode::Edge;
 
-    return surface_area(p.bboxes[Edge::left]) * p.indices[Edge::left].size()
-           + surface_area(p.bboxes[Edge::right])
+    return calc_surface_area(p.bboxes[Edge::left])
+               * p.indices[Edge::left].size()
+           + calc_surface_area(p.bboxes[Edge::right])
                  * p.indices[Edge::right].size();
 }
 

--- a/src/orange/detail/BIHUtils.hh
+++ b/src/orange/detail/BIHUtils.hh
@@ -15,7 +15,7 @@ namespace celeritas
 /*!
  * Calculate bounding box enclosing bounding boxes for specified indices.
  */
-inline FastBBox bbox_union(std::vector<FastBBox> const& bboxes,
+inline FastBBox calc_union(std::vector<FastBBox> const& bboxes,
                            std::vector<LocalVolumeId> const& indices)
 {
     CELER_EXPECT(!bboxes.empty());
@@ -26,7 +26,7 @@ inline FastBBox bbox_union(std::vector<FastBBox> const& bboxes,
     ++id;
     for (; id != indices.end(); ++id)
     {
-        result = bbox_union(result, bboxes[id->unchecked_get()]);
+        result = calc_union(result, bboxes[id->unchecked_get()]);
     }
 
     return result;

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -80,6 +80,24 @@ TEST(UtilityTest, exchange)
 
 //---------------------------------------------------------------------------//
 
+TEST(AlgorithmsTest, all_of)
+{
+    static bool const items[] = {true, false, true, true};
+    auto is_true = [](bool b) { return b; };
+    EXPECT_TRUE(all_of(std::begin(items), std::begin(items), is_true));
+    EXPECT_FALSE(all_of(std::begin(items), std::end(items), is_true));
+    EXPECT_TRUE(all_of(std::begin(items) + 2, std::end(items), is_true));
+}
+
+TEST(AlgorithmsTest, any_of)
+{
+    static bool const items[] = {false, true, false, false};
+    auto is_true = [](bool b) { return b; };
+    EXPECT_FALSE(any_of(std::begin(items), std::begin(items), is_true));
+    EXPECT_TRUE(any_of(std::begin(items), std::end(items), is_true));
+    EXPECT_FALSE(any_of(std::begin(items) + 2, std::end(items), is_true));
+}
+
 TEST(AlgorithmsTest, clamp)
 {
     EXPECT_EQ(123, clamp(123, 100, 200));

--- a/test/orange/BoundingBox.test.cc
+++ b/test/orange/BoundingBox.test.cc
@@ -23,6 +23,9 @@ TEST_F(BoundingBoxTest, null)
     BBox null_bbox;
     EXPECT_FALSE(null_bbox);
     EXPECT_GT(null_bbox.lower()[0], null_bbox.upper()[0]);
+
+    constexpr auto dumb_bbox = BBox::from_unchecked({3, 0, 0}, {-1, 0, 0});
+    EXPECT_FALSE(dumb_bbox);
 }
 
 TEST_F(BoundingBoxTest, infinite)

--- a/test/orange/BoundingBox.test.cc
+++ b/test/orange/BoundingBox.test.cc
@@ -33,6 +33,23 @@ TEST_F(BoundingBoxTest, null)
     EXPECT_FALSE(ibb);
 }
 
+TEST_F(BoundingBoxTest, degenerate)
+{
+    // Two coincident square faces
+    BBox bbox{{-2, 1, -2}, {2, 1, 2}};
+    EXPECT_TRUE(bbox);
+    EXPECT_LT(bbox.lower()[0], bbox.upper()[0]);
+    EXPECT_EQ(bbox.lower()[1], bbox.upper()[1]);
+
+    BBox ibb = BBox::from_infinite();
+    ibb.clip(Sense::outside, Axis::z, 1);
+    ibb.clip(Sense::inside, Axis::z, 1);
+    EXPECT_TRUE(ibb);
+
+    // Triple-degenerate: only contains a single point
+    EXPECT_TRUE(BBox{{1, 1, 1}, {1, 1, 1}});
+}
+
 TEST_F(BoundingBoxTest, infinite)
 {
     BBox ibb = BBox::from_infinite();

--- a/test/orange/BoundingBox.test.cc
+++ b/test/orange/BoundingBox.test.cc
@@ -47,7 +47,7 @@ TEST_F(BoundingBoxTest, degenerate)
     EXPECT_TRUE(ibb);
 
     // Triple-degenerate: only contains a single point
-    EXPECT_TRUE(BBox{{1, 1, 1}, {1, 1, 1}});
+    EXPECT_TRUE((BBox{{1, 1, 1}, {1, 1, 1}}));
 }
 
 TEST_F(BoundingBoxTest, infinite)

--- a/test/orange/BoundingBox.test.cc
+++ b/test/orange/BoundingBox.test.cc
@@ -26,6 +26,11 @@ TEST_F(BoundingBoxTest, null)
 
     constexpr auto dumb_bbox = BBox::from_unchecked({3, 0, 0}, {-1, 0, 0});
     EXPECT_FALSE(dumb_bbox);
+
+    BBox ibb = BBox::from_infinite();
+    ibb.clip(BBox::Halfspace{Sense::outside, Axis::x, 2});
+    ibb.clip(BBox::Halfspace{Sense::inside, Axis::x, 1});
+    EXPECT_FALSE(ibb);
 }
 
 TEST_F(BoundingBoxTest, infinite)
@@ -54,6 +59,12 @@ TEST_F(BoundingBoxTest, standard)
     EXPECT_TRUE(bb);
     EXPECT_VEC_SOFT_EQ((Real3{-1, -2, 3}), bb.lower());
     EXPECT_VEC_SOFT_EQ((Real3{4, 5, 6}), bb.upper());
+
+    bb.clip(BBox::Halfspace{Sense::inside, Axis::x, 2});
+    bb.clip(BBox::Halfspace{Sense::outside, Axis::z, 4});
+    bb.clip(BBox::Halfspace{Sense::inside, Axis::y, 0});
+    EXPECT_VEC_SOFT_EQ((Real3{-1, -2, 4}), bb.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{2, 0, 6}), bb.upper());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/BoundingBox.test.cc
+++ b/test/orange/BoundingBox.test.cc
@@ -28,8 +28,8 @@ TEST_F(BoundingBoxTest, null)
     EXPECT_FALSE(dumb_bbox);
 
     BBox ibb = BBox::from_infinite();
-    ibb.clip(BBox::Halfspace{Sense::outside, Axis::x, 2});
-    ibb.clip(BBox::Halfspace{Sense::inside, Axis::x, 1});
+    ibb.clip(Sense::outside, Axis::x, 2);
+    ibb.clip(Sense::inside, Axis::x, 1);
     EXPECT_FALSE(ibb);
 }
 
@@ -60,9 +60,9 @@ TEST_F(BoundingBoxTest, standard)
     EXPECT_VEC_SOFT_EQ((Real3{-1, -2, 3}), bb.lower());
     EXPECT_VEC_SOFT_EQ((Real3{4, 5, 6}), bb.upper());
 
-    bb.clip(BBox::Halfspace{Sense::inside, Axis::x, 2});
-    bb.clip(BBox::Halfspace{Sense::outside, Axis::z, 4});
-    bb.clip(BBox::Halfspace{Sense::inside, Axis::y, 0});
+    bb.clip(Sense::inside, Axis::x, 2);
+    bb.clip(Sense::outside, Axis::z, 4);
+    bb.clip(Sense::inside, Axis::y, 0);
     EXPECT_VEC_SOFT_EQ((Real3{-1, -2, 4}), bb.lower());
     EXPECT_VEC_SOFT_EQ((Real3{2, 0, 6}), bb.upper());
 }

--- a/test/orange/BoundingBox.test.cc
+++ b/test/orange/BoundingBox.test.cc
@@ -22,16 +22,13 @@ TEST_F(BoundingBoxTest, null)
 {
     BBox null_bbox;
     EXPECT_FALSE(null_bbox);
-    if (CELERITAS_DEBUG)
-    {
-        EXPECT_THROW(null_bbox.lower(), DebugError);
-        EXPECT_THROW(null_bbox.upper(), DebugError);
-    }
+    EXPECT_GT(null_bbox.lower()[0], null_bbox.upper()[0]);
 }
 
 TEST_F(BoundingBoxTest, infinite)
 {
     BBox ibb = BBox::from_infinite();
+    EXPECT_TRUE(ibb);
     EXPECT_SOFT_EQ(-inf, ibb.lower()[0]);
     EXPECT_SOFT_EQ(-inf, ibb.lower()[1]);
     EXPECT_SOFT_EQ(-inf, ibb.lower()[2]);

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -24,17 +24,16 @@ TEST(BoundingBoxUtilsTest, is_inside)
 
 TEST(BoundingBoxUtilsTest, is_infinite)
 {
-    auto max_real = std::numeric_limits<real_type>::max();
     auto inf_real = std::numeric_limits<real_type>::infinity();
 
     BBox bbox1 = {{0, 0, 0}, {1, 1, 1}};
     EXPECT_FALSE(is_infinite(bbox1));
 
-    BBox bbox2 = {{0, 0, 0}, {max_real, inf_real, max_real}};
+    BBox bbox2 = {{0, 0, 0}, {inf_real, inf_real, inf_real}};
     EXPECT_FALSE(is_infinite(bbox2));
 
     BBox bbox3
-        = {{-max_real, -inf_real, -max_real}, {max_real, inf_real, max_real}};
+        = {{-inf_real, -inf_real, -inf_real}, {inf_real, inf_real, inf_real}};
     EXPECT_TRUE(is_infinite(bbox3));
 }
 

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -24,6 +24,15 @@ TEST_F(BoundingBoxUtilsTest, is_inside)
     EXPECT_TRUE(is_inside(bbox1, Real3{-4.9, -1.9, -99.9}));
     EXPECT_FALSE(is_inside(bbox1, Real3{-6, 0, 0}));
     EXPECT_FALSE(is_inside(bbox1, Real3{-5.1, -2.1, -101.1}));
+    EXPECT_FALSE(is_inside(BBox{}, Real3{0, 0, 0}));
+
+    BBox degenerate{{1, -2, -2}, {1, 2, 2}};
+    EXPECT_TRUE(is_inside(degenerate, Real3{1, 0, 0}));
+    EXPECT_FALSE(is_inside(degenerate, Real3{1, -3, 0}));
+    EXPECT_FALSE(is_inside(degenerate, Real3{1.000001, 0, 0}));
+
+    BBox super_degenerate{{1, 1, 1}, {1, 1, 1}};
+    EXPECT_TRUE(is_inside(degenerate, Real3{1, 1, 1}));
 }
 
 TEST_F(BoundingBoxUtilsTest, is_infinite)
@@ -39,18 +48,60 @@ TEST_F(BoundingBoxUtilsTest, is_infinite)
     BBox bbox3
         = {{-inf_real, -inf_real, -inf_real}, {inf_real, inf_real, inf_real}};
     EXPECT_TRUE(is_infinite(bbox3));
+
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(is_infinite(BBox{}), DebugError);
+    }
+}
+
+TEST_F(BoundingBoxUtilsTest, is_degenerate)
+{
+    EXPECT_FALSE(is_degenerate(BBox{{0, 0, 0}, {1, 1, 1}}));
+    EXPECT_TRUE(is_degenerate(BBox{{0, 0, 1}, {1, 1, 1}}));
+    EXPECT_TRUE(is_degenerate(BBox{{1, 0, 1}, {1, 1, 1}}));
+    EXPECT_TRUE(is_degenerate(BBox{{1, 1, 1}, {1, 1, 1}}));
+
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(is_degenerate(BBox{}), DebugError);
+    }
 }
 
 TEST_F(BoundingBoxUtilsTest, center)
 {
     BBox bbox = {{-10, -20, -30}, {1, 2, 3}};
     EXPECT_VEC_SOFT_EQ(Real3({-4.5, -9, -13.5}), calc_center(bbox));
+
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(calc_center(BBox{}), DebugError);
+    }
 }
 
 TEST_F(BoundingBoxUtilsTest, surface_area)
 {
     BBox bbox = {{-1, -2, -3}, {6, 4, 5}};
     EXPECT_SOFT_EQ(2 * (7 * 6 + 7 * 8 + 6 * 8), calc_surface_area(bbox));
+
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(calc_surface_area(BBox{}), DebugError);
+    }
+}
+
+TEST_F(BoundingBoxUtilsTest, volume)
+{
+    BBox bbox = {{-1, -2, -3}, {6, 4, 5}};
+    EXPECT_SOFT_EQ(7 * 6 * 8, calc_volume(bbox));
+
+    // Degenerate volume
+    EXPECT_SOFT_EQ(0, calc_volume(BBox{{1, 1, 1}, {1, 2, 3}}));
+
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(calc_volume(BBox{}), DebugError);
+    }
 }
 
 TEST_F(BoundingBoxUtilsTest, bbox_union)
@@ -62,13 +113,13 @@ TEST_F(BoundingBoxUtilsTest, bbox_union)
     EXPECT_VEC_SOFT_EQ(Real3({10, 2, 10}), ubox.upper());
 
     {
-        SCOPED_TRACE("degenerate");
+        SCOPED_TRACE("null");
         auto dubox = calc_union(ubox, BBox{});
         EXPECT_VEC_SOFT_EQ(ubox.lower(), dubox.lower());
         EXPECT_VEC_SOFT_EQ(ubox.upper(), dubox.upper());
     }
     {
-        SCOPED_TRACE("double degenerate");
+        SCOPED_TRACE("double null");
         auto ddbox = calc_union(BBox{}, BBox{});
         EXPECT_FALSE(ddbox);
     }
@@ -83,25 +134,39 @@ TEST_F(BoundingBoxUtilsTest, bbox_intersection)
     EXPECT_VEC_SOFT_EQ(Real3({1, 2, 3}), ibox.upper());
 
     {
-        SCOPED_TRACE("degenerate");
+        SCOPED_TRACE("nonintersecting is null");
+        auto nbox = calc_intersection(BBox{{-1, -1, -1}, {1, 1, 1}},
+                                      BBox{{1.1, 0, 0}, {2, 1, 1}});
+        EXPECT_FALSE(nbox);
+    }
+    {
+        SCOPED_TRACE("common point/line/face is degenerate");
+        auto dbox = calc_intersection(BBox{{-1, -1, -1}, {1, 1, 1}},
+                                      BBox{{-1, -1, 1}, {2, 2, 2}});
+        EXPECT_TRUE(dbox);
+        EXPECT_VEC_SOFT_EQ(Real3({-1, -1, 1}), dbox.lower());
+        EXPECT_VEC_SOFT_EQ(Real3({1, 1, 1}), dbox.upper());
+    }
+    {
+        SCOPED_TRACE("null");
         auto dibox = calc_intersection(ibox, BBox{});
         EXPECT_FALSE(dibox);
         EXPECT_VEC_SOFT_EQ(BBox{}.lower(), dibox.lower());
         EXPECT_VEC_SOFT_EQ(BBox{}.upper(), dibox.upper());
     }
     {
-        SCOPED_TRACE("double degenerate");
+        SCOPED_TRACE("double null");
         auto ddbox = calc_intersection(BBox{}, BBox{});
         EXPECT_FALSE(ddbox);
     }
     {
-        SCOPED_TRACE("partial degenerate x");
+        SCOPED_TRACE("partial null x");
         auto dibox = calc_intersection(BBox{{-2, -inf, -inf}, {2, inf, inf}},
                                        BBox{{3, -inf, -inf}, {10, inf, inf}});
         EXPECT_FALSE(dibox);
     }
     {
-        SCOPED_TRACE("partial degenerate y");
+        SCOPED_TRACE("partial null y");
         auto dibox = calc_intersection(BBox{{-inf, -2, -inf}, {inf, 2, inf}},
                                        BBox{{-inf, 3, -inf}, {inf, 10, inf}});
         EXPECT_FALSE(dibox);

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -40,13 +40,13 @@ TEST(BoundingBoxUtilsTest, is_infinite)
 TEST(BoundingBoxUtilsTest, center)
 {
     BBox bbox = {{-10, -20, -30}, {1, 2, 3}};
-    EXPECT_VEC_SOFT_EQ(Real3({-4.5, -9, -13.5}), center(bbox));
+    EXPECT_VEC_SOFT_EQ(Real3({-4.5, -9, -13.5}), calc_center(bbox));
 }
 
 TEST(BoundingBoxUtilsTest, surface_area)
 {
     BBox bbox = {{-1, -2, -3}, {6, 4, 5}};
-    EXPECT_SOFT_EQ(2 * (7 * 6 + 7 * 8 + 6 * 8), surface_area(bbox));
+    EXPECT_SOFT_EQ(2 * (7 * 6 + 7 * 8 + 6 * 8), calc_surface_area(bbox));
 }
 
 TEST(BoundingBoxUtilsTest, bbox_union)
@@ -54,7 +54,7 @@ TEST(BoundingBoxUtilsTest, bbox_union)
     BBox bbox1 = {{-10, -20, -30}, {10, 2, 3}};
     BBox bbox2 = {{-15, -9, -33}, {1, 2, 10}};
 
-    auto bbox3 = bbox_union(bbox1, bbox2);
+    auto bbox3 = calc_union(bbox1, bbox2);
 
     EXPECT_VEC_SOFT_EQ(Real3({-15, -20, -33}), bbox3.lower());
     EXPECT_VEC_SOFT_EQ(Real3({10, 2, 10}), bbox3.upper());

--- a/test/orange/detail/BIHUtils.test.cc
+++ b/test/orange/detail/BIHUtils.test.cc
@@ -19,17 +19,14 @@ namespace test
 
 TEST(BIHUtilsTest, bbox_vector_union)
 {
-    FastBBox bbox1 = {{-10, -20, -30}, {10, 2, 3}};
-    FastBBox bbox2 = {{-15, -9, -33}, {1, 2, 10}};
-    FastBBox bbox3 = {{-15, -9, -34}, {1, 2, 10}};
-
-    std::vector<FastBBox> bboxes{bbox1, bbox2, bbox3};
-
-    std::vector<LocalVolumeId> ids_subset{LocalVolumeId(0), LocalVolumeId(1)};
-    std::vector<LocalVolumeId> ids_all{
-        LocalVolumeId(0), LocalVolumeId(1), LocalVolumeId(2)};
-
     using Real3 = Array<fast_real_type, 3>;
+
+    std::vector bboxes{FastBBox{{-10, -20, -30}, {10, 2, 3}},
+                       FastBBox{{-15, -9, -33}, {1, 2, 10}},
+                       FastBBox{{-15, -9, -34}, {1, 2, 10}}};
+
+    std::vector ids_subset{LocalVolumeId(0), LocalVolumeId(1)};
+    std::vector ids_all{LocalVolumeId(0), LocalVolumeId(1), LocalVolumeId(2)};
 
     auto bbox4 = calc_union(bboxes, ids_subset);
     EXPECT_VEC_SOFT_EQ(Real3({-15, -20, -33}), bbox4.lower());

--- a/test/orange/detail/BIHUtils.test.cc
+++ b/test/orange/detail/BIHUtils.test.cc
@@ -15,6 +15,8 @@ namespace detail
 {
 namespace test
 {
+//---------------------------------------------------------------------------//
+
 TEST(BIHUtilsTest, bbox_vector_union)
 {
     FastBBox bbox1 = {{-10, -20, -30}, {10, 2, 3}};
@@ -29,14 +31,15 @@ TEST(BIHUtilsTest, bbox_vector_union)
 
     using Real3 = Array<fast_real_type, 3>;
 
-    auto bbox4 = bbox_union(bboxes, ids_subset);
+    auto bbox4 = calc_union(bboxes, ids_subset);
     EXPECT_VEC_SOFT_EQ(Real3({-15, -20, -33}), bbox4.lower());
     EXPECT_VEC_SOFT_EQ(Real3({10, 2, 10}), bbox4.upper());
 
-    auto bbox5 = bbox_union(bboxes, ids_all);
+    auto bbox5 = calc_union(bboxes, ids_all);
     EXPECT_VEC_SOFT_EQ(Real3({-15, -20, -34}), bbox5.lower());
     EXPECT_VEC_SOFT_EQ(Real3({10, 2, 10}), bbox5.upper());
 }
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace detail


### PR DESCRIPTION
This changes the bounding box so that it's in a null state when any lower coordinate is higher than the upper coordinate. This change simplifies all the logic with unions and intersections: the intersection of a default bbox and another bbox is the default null bbox; the union of a null bbox and a valid bbox is the valid bbox. A bounding box being "null" is different than being "empty": empty can mean the lower and upper extents match to make a plane (finite or infinite); or an empty bbox could be a single point. Null means no point exists in the bbox.