### PR TITLE
Implement surface promotion in ORANGE

### DIFF
--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -21,6 +21,11 @@ list(APPEND SOURCES
   detail/BIHPartitioner.cc
   detail/RectArrayInserter.cc
   detail/UnitInserter.cc
+  surf/CylAligned.cc
+  surf/GeneralQuadric.cc
+  surf/Plane.cc
+  surf/SimpleQuadric.cc
+  surf/Sphere.cc
   surf/SurfaceIO.cc
   transform/Transformation.cc
 )

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND SOURCES
   detail/BIHPartitioner.cc
   detail/RectArrayInserter.cc
   detail/UnitInserter.cc
+  surf/ConeAligned.cc
   surf/CylAligned.cc
   surf/GeneralQuadric.cc
   surf/Plane.cc

--- a/src/orange/surf/ConeAligned.cc
+++ b/src/orange/surf/ConeAligned.cc
@@ -11,7 +11,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with a new origin using the radius of another cone.
+ * Construct with a new origin using the opening angle of another cone.
  */
 template<Axis T>
 ConeAligned<T>::ConeAligned(Real3 const& origin, ConeAligned const& other)

--- a/src/orange/surf/ConeAligned.cc
+++ b/src/orange/surf/ConeAligned.cc
@@ -11,12 +11,17 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with a new origin using the opening angle of another cone.
+ * Construct with square of tangent for simplification.
  */
 template<Axis T>
-ConeAligned<T>::ConeAligned(Real3 const& origin, ConeAligned const& other)
-    : origin_{origin}, tsq_{other.tsq_}
+ConeAligned<T>
+ConeAligned<T>::from_tangent_sq(Real3 const& origin, real_type tsq)
 {
+    CELER_EXPECT(tsq > 0);
+    ConeAligned result;
+    result.origin_ = origin;
+    result.tsq_ = tsq;
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/ConeAligned.cc
+++ b/src/orange/surf/ConeAligned.cc
@@ -3,25 +3,27 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/surf/GeneralQuadric.cc
+//! \file orange/surf/ConeAligned.cc
 //---------------------------------------------------------------------------//
-#include "GeneralQuadric.hh"
-
-#include "SimpleQuadric.hh"
+#include "ConeAligned.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Promote from a simple quadric.
+ * Construct with a new origin using the radius of another cone.
  */
-GeneralQuadric::GeneralQuadric(SimpleQuadric const& other)
-    : GeneralQuadric{make_array(other.second()),
-                     Real3{0, 0, 0},
-                     make_array(other.first()),
-                     other.zeroth()}
+template<Axis T>
+ConeAligned<T>::ConeAligned(Real3 const& origin, ConeAligned const& other)
+    : origin_{origin}, tsq_{other.tsq_}
 {
 }
+
+//---------------------------------------------------------------------------//
+
+template class ConeAligned<Axis::x>;
+template class ConeAligned<Axis::y>;
+template class ConeAligned<Axis::z>;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/surf/ConeAligned.hh
+++ b/src/orange/surf/ConeAligned.hh
@@ -132,23 +132,25 @@ CELER_CONSTEXPR_FUNCTION SurfaceType ConeAligned<T>::surface_type()
 /*!
  * Construct from origin and tangent of the angle of its opening.
  *
- * Given a finite cone, the tangent is ratio of the radius at its base to the
- * its height.
+ * Given a finite cone, the tangent is the ratio of its base radius to its
+ * height.
  *
- * \pre
+ * In the cone, below, the tangent of the inner angle
+ * \f$ \tan(\theta) = r/h \f$ is the second argument.
+ * \verbatim
      r
    +-------*
    |   _--^
  h |_--
    O
-   \endpre
+   \endverbatim
  */
 template<Axis T>
 CELER_FUNCTION
 ConeAligned<T>::ConeAligned(Real3 const& origin, real_type tangent)
     : origin_{origin}, tsq_{ipow<2>(tangent)}
 {
-    CELER_EXPECT(tangent >= 0);
+    CELER_EXPECT(tangent > 0);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/ConeAligned.hh
+++ b/src/orange/surf/ConeAligned.hh
@@ -25,6 +25,9 @@ namespace celeritas
  * \f[
     (y - y_0)^2 + (z - z_0)^2 - t^2 (x - x_0)^2 = 0
    \f]
+
+ * where \em t is the tangent of the opening angle (\f$r/h\f$ for a finite cone
+ * with radius \em r and height \em h).
  */
 template<Axis T>
 class ConeAligned
@@ -126,11 +129,11 @@ CELER_CONSTEXPR_FUNCTION SurfaceType ConeAligned<T>::surface_type()
 /*!
  * Construct from origin and tangent of the angle of its opening.
  *
- * Given the triangular cross section of one octant of a finite cone (i.e. a
- * right triangle), the tangent is the slope of its hypotenuse (height / base).
+ * Given a finite cone, the tangent is ratio of the radius at its base to the
+ * its height.
  *
  * \pre
-     b
+     r
    +-------*
    |   _--^
  h |_--

--- a/src/orange/surf/ConeAligned.hh
+++ b/src/orange/surf/ConeAligned.hh
@@ -65,6 +65,9 @@ class ConeAligned
     // Construct from raw data
     explicit inline CELER_FUNCTION ConeAligned(Storage);
 
+    // Construct from cone and new origin
+    ConeAligned(Real3 const& origin, ConeAligned const& other);
+
     //// ACCESSORS ////
 
     //! Get the origin position along the normal axis

--- a/src/orange/surf/ConeAligned.hh
+++ b/src/orange/surf/ConeAligned.hh
@@ -62,14 +62,14 @@ class ConeAligned
   public:
     //// CONSTRUCTORS ////
 
+    // Construct with square of tangent for simplification
+    static ConeAligned from_tangent_sq(Real3 const& origin, real_type tsq);
+
     // Construct from origin and tangent of the angle of its opening
     inline CELER_FUNCTION ConeAligned(Real3 const& origin, real_type tangent);
 
     // Construct from raw data
     explicit inline CELER_FUNCTION ConeAligned(Storage);
-
-    // Construct from cone and new origin
-    ConeAligned(Real3 const& origin, ConeAligned const& other);
 
     //// ACCESSORS ////
 
@@ -100,6 +100,9 @@ class ConeAligned
 
     // Quadric value
     real_type tsq_;
+
+    //! Private default constructor for manual construction
+    ConeAligned() = default;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/ConeAligned.hh
+++ b/src/orange/surf/ConeAligned.hh
@@ -76,7 +76,7 @@ class ConeAligned
     //! Get the origin position along the normal axis
     CELER_FUNCTION Real3 const& origin() const { return origin_; }
 
-    //! Get the square of the tangent
+    //! Get the square of the tangent of the opening angle
     CELER_FUNCTION real_type tangent_sq() const { return tsq_; }
 
     //! Get a view to the data for type-deleted storage

--- a/src/orange/surf/CylAligned.cc
+++ b/src/orange/surf/CylAligned.cc
@@ -1,0 +1,31 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/surf/CylAligned.cc
+//---------------------------------------------------------------------------//
+#include "CylAligned.hh"
+
+#include "CylCentered.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Promote implicitly from a centered axis-aligned cylinder.
+ */
+template<Axis T>
+CylAligned<T>::CylAligned(CylCentered<T> const& other)
+    : origin_u_{0}, origin_v_{0}, radius_sq_{other.radius_sq()}
+{
+}
+
+//---------------------------------------------------------------------------//
+
+template class CylAligned<Axis::x>;
+template class CylAligned<Axis::y>;
+template class CylAligned<Axis::z>;
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/surf/CylAligned.cc
+++ b/src/orange/surf/CylAligned.cc
@@ -13,12 +13,37 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Promote implicitly from a centered axis-aligned cylinder.
+ * Promote from a centered axis-aligned cylinder.
  */
 template<Axis T>
 CylAligned<T>::CylAligned(CylCentered<T> const& other)
     : origin_u_{0}, origin_v_{0}, radius_sq_{other.radius_sq()}
 {
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with a new origin using the radius of another cylinder.
+ */
+template<Axis T>
+CylAligned<T>::CylAligned(Real3 const& origin, CylAligned const& other)
+    : origin_u_{origin[to_int(U)]}
+    , origin_v_{origin[to_int(V)]}
+    , radius_sq_{other.radius_sq_}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the origin as a 3-vector.
+ */
+template<Axis T>
+Real3 CylAligned<T>::calc_origin() const
+{
+    Real3 result{0, 0, 0};
+    result[to_int(U)] = this->origin_u();
+    result[to_int(V)] = this->origin_v();
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/CylAligned.cc
+++ b/src/orange/surf/CylAligned.cc
@@ -13,23 +13,29 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Construct from the square of the radius and the origin.
+ *
+ * This is used for surface simplification.
+ */
+template<Axis T>
+CylAligned<T> CylAligned<T>::from_radius_sq(Real3 const& origin, real_type rsq)
+{
+    CELER_EXPECT(rsq > 0);
+
+    CylAligned<T> result;
+    result.origin_u_ = origin[to_int(U)];
+    result.origin_v_ = origin[to_int(V)];
+    result.radius_sq_ = rsq;
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Promote from a centered axis-aligned cylinder.
  */
 template<Axis T>
 CylAligned<T>::CylAligned(CylCentered<T> const& other)
     : origin_u_{0}, origin_v_{0}, radius_sq_{other.radius_sq()}
-{
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct with a new origin using the radius of another cylinder.
- */
-template<Axis T>
-CylAligned<T>::CylAligned(Real3 const& origin, CylAligned const& other)
-    : origin_u_{origin[to_int(U)]}
-    , origin_v_{origin[to_int(V)]}
-    , radius_sq_{other.radius_sq_}
 {
 }
 

--- a/src/orange/surf/CylAligned.cc
+++ b/src/orange/surf/CylAligned.cc
@@ -34,7 +34,7 @@ CylAligned<T> CylAligned<T>::from_radius_sq(Real3 const& origin, real_type rsq)
  * Promote from a centered axis-aligned cylinder.
  */
 template<Axis T>
-CylAligned<T>::CylAligned(CylCentered<T> const& other)
+CylAligned<T>::CylAligned(CylCentered<T> const& other) noexcept
     : origin_u_{0}, origin_v_{0}, radius_sq_{other.radius_sq()}
 {
 }

--- a/src/orange/surf/CylAligned.hh
+++ b/src/orange/surf/CylAligned.hh
@@ -72,22 +72,28 @@ class CylAligned
     // Construct from raw data
     explicit inline CELER_FUNCTION CylAligned(Storage);
 
-    // Promote implicitly from a centered axis-aligned cylinder
-    CylAligned(CylCentered<T> const& other);
+    // Promote from a centered axis-aligned cylinder
+    explicit CylAligned(CylCentered<T> const& other);
+
+    // Construct with a new origin and the radius of another cylinder
+    CylAligned(Real3 const& origin, CylAligned const& other);
 
     //// ACCESSORS ////
 
     //! Get the origin vector along the 'u' axis
-    real_type origin_u() const { return origin_u_; }
+    CELER_FUNCTION real_type origin_u() const { return origin_u_; }
 
     //! Get the origin vector along the 'v' axis
-    real_type origin_v() const { return origin_v_; }
+    CELER_FUNCTION real_type origin_v() const { return origin_v_; }
 
     //! Get the square of the radius
-    real_type radius_sq() const { return radius_sq_; }
+    CELER_FUNCTION real_type radius_sq() const { return radius_sq_; }
 
     //! Get a view to the data for type-deleted storage
     CELER_FUNCTION Storage data() const { return {&origin_u_, 3}; }
+
+    // Helper function to get the origin as a 3-vector
+    Real3 calc_origin() const;
 
     //// CALCULATION ////
 

--- a/src/orange/surf/CylAligned.hh
+++ b/src/orange/surf/CylAligned.hh
@@ -18,6 +18,10 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+template<Axis T>
+class CylCentered;
+
+//---------------------------------------------------------------------------//
 /*!
  * Axis-aligned cylinder.
  *
@@ -67,6 +71,9 @@ class CylAligned
 
     // Construct from raw data
     explicit inline CELER_FUNCTION CylAligned(Storage);
+
+    // Promote implicitly from a centered axis-aligned cylinder
+    CylAligned(CylCentered<T> const& other);
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/CylAligned.hh
+++ b/src/orange/surf/CylAligned.hh
@@ -75,7 +75,7 @@ class CylAligned
     explicit inline CELER_FUNCTION CylAligned(Storage);
 
     // Promote from a centered axis-aligned cylinder
-    explicit CylAligned(CylCentered<T> const& other);
+    explicit CylAligned(CylCentered<T> const& other) noexcept;
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/CylAligned.hh
+++ b/src/orange/surf/CylAligned.hh
@@ -65,18 +65,17 @@ class CylAligned
   public:
     //// CONSTRUCTORS ////
 
+    // Construct with square of radius for simplification
+    static CylAligned from_radius_sq(Real3 const& origin, real_type rsq);
+
     // Construct with radius
-    explicit inline CELER_FUNCTION
-    CylAligned(Real3 const& origin, real_type radius);
+    inline CELER_FUNCTION CylAligned(Real3 const& origin, real_type radius);
 
     // Construct from raw data
     explicit inline CELER_FUNCTION CylAligned(Storage);
 
     // Promote from a centered axis-aligned cylinder
     explicit CylAligned(CylCentered<T> const& other);
-
-    // Construct with a new origin and the radius of another cylinder
-    CylAligned(Real3 const& origin, CylAligned const& other);
 
     //// ACCESSORS ////
 
@@ -114,6 +113,9 @@ class CylAligned
 
     // Square of the radius
     real_type radius_sq_;
+
+    //! Private default constructor for manual construction
+    CylAligned() = default;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/CylCentered.hh
+++ b/src/orange/surf/CylCentered.hh
@@ -68,6 +68,9 @@ class CylCentered
   public:
     //// CONSTRUCTORS ////
 
+    // Construct with square of radius for simplification
+    static inline CylCentered from_radius_sq(real_type rsq);
+
     // Construct with radius
     explicit inline CELER_FUNCTION CylCentered(real_type radius);
 
@@ -97,6 +100,9 @@ class CylCentered
   private:
     //! Square of cylinder radius
     real_type radius_sq_;
+
+    //! Private default constructor for manual construction
+    CylCentered() = default;
 };
 
 //---------------------------------------------------------------------------//
@@ -120,6 +126,22 @@ CELER_CONSTEXPR_FUNCTION SurfaceType CylCentered<T>::surface_type()
            : T == Axis::y ? SurfaceType::cyc
            : T == Axis::z ? SurfaceType::czc
                           : SurfaceType::size_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from the square of the radius.
+ *
+ * This is used for surface simplification.
+ */
+template<Axis T>
+CylCentered<T> CylCentered<T>::from_radius_sq(real_type rsq)
+{
+    CELER_EXPECT(rsq > 0);
+
+    CylCentered<T> result;
+    result.radius_sq_ = rsq;
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/GeneralQuadric.cc
+++ b/src/orange/surf/GeneralQuadric.cc
@@ -1,0 +1,27 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/surf/GeneralQuadric.cc
+//---------------------------------------------------------------------------//
+#include "GeneralQuadric.hh"
+
+#include "SimpleQuadric.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Promote implicitly from a simple quadric.
+ */
+GeneralQuadric::GeneralQuadric(SimpleQuadric const& other)
+    : GeneralQuadric{make_array(other.second()),
+                     Real3{0, 0, 0},
+                     make_array(other.first()),
+                     other.zeroth()}
+{
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/surf/GeneralQuadric.cc
+++ b/src/orange/surf/GeneralQuadric.cc
@@ -15,7 +15,7 @@ namespace celeritas
 /*!
  * Promote from a simple quadric.
  */
-GeneralQuadric::GeneralQuadric(SimpleQuadric const& other)
+GeneralQuadric::GeneralQuadric(SimpleQuadric const& other) noexcept
     : GeneralQuadric{make_array(other.second()),
                      Real3{0, 0, 0},
                      make_array(other.first()),

--- a/src/orange/surf/GeneralQuadric.hh
+++ b/src/orange/surf/GeneralQuadric.hh
@@ -31,6 +31,9 @@ class SimpleQuadric;
  * \f[
     ax^2 + by^2 + cz^2 + dxy + eyz + fzx + gx + hy + iz + j = 0
    \f]
+ *
+ * Note that some formulations of a general quadric include a factor of 2 for
+ * the g/h/i terms.
  */
 class GeneralQuadric
 {
@@ -65,8 +68,8 @@ class GeneralQuadric
     // Construct from raw data
     explicit inline CELER_FUNCTION GeneralQuadric(Storage);
 
-    // Promote implicitly from a simple quadric
-    GeneralQuadric(SimpleQuadric const& other);
+    // Promote from a simple quadric
+    explicit GeneralQuadric(SimpleQuadric const& other);
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/GeneralQuadric.hh
+++ b/src/orange/surf/GeneralQuadric.hh
@@ -116,6 +116,8 @@ class GeneralQuadric
 //---------------------------------------------------------------------------//
 /*!
  * Construct with all coefficients.
+ *
+ * TODO: normalize?
  */
 CELER_FUNCTION GeneralQuadric::GeneralQuadric(Real3 const& abc,
                                               Real3 const& def,
@@ -132,6 +134,8 @@ CELER_FUNCTION GeneralQuadric::GeneralQuadric(Real3 const& abc,
     , i_(ghi[2])
     , j_(j)
 {
+    CELER_EXPECT(a_ != 0 || b_ != 0 || c_ != 0 || d_ != 0 || e_ != 0 || f_ != 0
+                 || g_ != 0 || h_ != 0 || i_ != 0);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/GeneralQuadric.hh
+++ b/src/orange/surf/GeneralQuadric.hh
@@ -69,7 +69,7 @@ class GeneralQuadric
     explicit inline CELER_FUNCTION GeneralQuadric(Storage);
 
     // Promote from a simple quadric
-    explicit GeneralQuadric(SimpleQuadric const& other);
+    explicit GeneralQuadric(SimpleQuadric const& other) noexcept;
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/GeneralQuadric.hh
+++ b/src/orange/surf/GeneralQuadric.hh
@@ -18,6 +18,9 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+class SimpleQuadric;
+
+//---------------------------------------------------------------------------//
 /*!
  * General quadric surface.
  *
@@ -61,6 +64,9 @@ class GeneralQuadric
 
     // Construct from raw data
     explicit inline CELER_FUNCTION GeneralQuadric(Storage);
+
+    // Promote implicitly from a simple quadric
+    GeneralQuadric(SimpleQuadric const& other);
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/Plane.cc
+++ b/src/orange/surf/Plane.cc
@@ -1,0 +1,31 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/surf/Plane.cc
+//---------------------------------------------------------------------------//
+#include "Plane.hh"
+
+#include "PlaneAligned.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Promote implicitly from an axis-aligned plane.
+ */
+template<Axis T>
+Plane::Plane(PlaneAligned<T> const& other)
+    : Plane{other.calc_normal({0, 0, 0}), other.position()}
+{
+}
+
+//---------------------------------------------------------------------------//
+
+template Plane::Plane(PlaneAligned<Axis::x> const&);
+template Plane::Plane(PlaneAligned<Axis::y> const&);
+template Plane::Plane(PlaneAligned<Axis::z> const&);
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/surf/Plane.cc
+++ b/src/orange/surf/Plane.cc
@@ -16,16 +16,16 @@ namespace celeritas
  * Promote from an axis-aligned plane.
  */
 template<Axis T>
-Plane::Plane(PlaneAligned<T> const& other)
-    : Plane{other.calc_normal({0, 0, 0}), other.position()}
+Plane::Plane(PlaneAligned<T> const& other) noexcept
+    : normal_{other.calc_normal({0, 0, 0})}, d_{other.position()}
 {
 }
 
 //---------------------------------------------------------------------------//
 
-template Plane::Plane(PlaneAligned<Axis::x> const&);
-template Plane::Plane(PlaneAligned<Axis::y> const&);
-template Plane::Plane(PlaneAligned<Axis::z> const&);
+template Plane::Plane(PlaneAligned<Axis::x> const&) noexcept;
+template Plane::Plane(PlaneAligned<Axis::y> const&) noexcept;
+template Plane::Plane(PlaneAligned<Axis::z> const&) noexcept;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/surf/Plane.cc
+++ b/src/orange/surf/Plane.cc
@@ -17,7 +17,7 @@ namespace celeritas
  */
 template<Axis T>
 Plane::Plane(PlaneAligned<T> const& other) noexcept
-    : normal_{other.calc_normal({0, 0, 0})}, d_{other.position()}
+    : normal_{other.calc_normal()}, d_{other.position()}
 {
 }
 

--- a/src/orange/surf/Plane.cc
+++ b/src/orange/surf/Plane.cc
@@ -13,7 +13,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Promote implicitly from an axis-aligned plane.
+ * Promote from an axis-aligned plane.
  */
 template<Axis T>
 Plane::Plane(PlaneAligned<T> const& other)

--- a/src/orange/surf/Plane.hh
+++ b/src/orange/surf/Plane.hh
@@ -16,6 +16,10 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+template<Axis T>
+class PlaneAligned;
+
+//---------------------------------------------------------------------------//
 /*!
  * Arbitrarily oriented plane.
  *
@@ -54,6 +58,10 @@ class Plane
 
     // Construct from raw data
     explicit inline CELER_FUNCTION Plane(Storage);
+
+    // Promote implicitly from an axis-aligned plane
+    template<Axis T>
+    Plane(PlaneAligned<T> const& other);
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/Plane.hh
+++ b/src/orange/surf/Plane.hh
@@ -59,9 +59,9 @@ class Plane
     // Construct from raw data
     explicit inline CELER_FUNCTION Plane(Storage);
 
-    // Promote implicitly from an axis-aligned plane
+    // Promote from an axis-aligned plane
     template<Axis T>
-    Plane(PlaneAligned<T> const& other);
+    explicit Plane(PlaneAligned<T> const& other);
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/Plane.hh
+++ b/src/orange/surf/Plane.hh
@@ -61,7 +61,7 @@ class Plane
 
     // Promote from an axis-aligned plane
     template<Axis T>
-    explicit Plane(PlaneAligned<T> const& other);
+    explicit Plane(PlaneAligned<T> const& other) noexcept;
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/Plane.hh
+++ b/src/orange/surf/Plane.hh
@@ -51,7 +51,7 @@ class Plane
     //// CONSTRUCTORS ////
 
     // Construct with normal and point
-    explicit inline CELER_FUNCTION Plane(Real3 const& n, Real3 const& d);
+    explicit inline CELER_FUNCTION Plane(Real3 const& n, Real3 const& p);
 
     // Construct with normal and displacement
     explicit inline CELER_FUNCTION Plane(Real3 const& n, real_type d);
@@ -103,7 +103,7 @@ class Plane
  * Displacement is the dot product of the point and the normal.
  */
 CELER_FUNCTION Plane::Plane(Real3 const& n, Real3 const& p)
-    : Plane{n, dot_product(normal_, p)}
+    : Plane{n, dot_product(n, p)}
 {
 }
 

--- a/src/orange/surf/Plane.hh
+++ b/src/orange/surf/Plane.hh
@@ -83,8 +83,8 @@ class Plane
     inline CELER_FUNCTION Intersections calc_intersections(
         Real3 const& pos, Real3 const& dir, SurfaceState on_surface) const;
 
-    // Calculate outward normal at a position
-    inline CELER_FUNCTION Real3 calc_normal(Real3 const& pos) const;
+    // Calculate outward normal at a position on the surface
+    inline CELER_FUNCTION Real3 calc_normal(Real3 const&) const;
 
   private:
     // Normal to plane (a,b,c)
@@ -158,9 +158,9 @@ CELER_FUNCTION auto Plane::calc_intersections(Real3 const& pos,
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate outward normal at a position.
+ * Calculate outward normal at a position on the surface.
  */
-CELER_FUNCTION Real3 Plane::calc_normal(Real3 const&) const
+CELER_FORCEINLINE_FUNCTION Real3 Plane::calc_normal(Real3 const&) const
 {
     return normal_;
 }

--- a/src/orange/surf/PlaneAligned.hh
+++ b/src/orange/surf/PlaneAligned.hh
@@ -53,6 +53,9 @@ class PlaneAligned
     //! Get a view to the data for type-deleted storage
     CELER_FUNCTION Storage data() const { return {&position_, 1}; }
 
+    // Construct outward normal vector
+    inline CELER_FUNCTION Real3 calc_normal() const;
+
     //// CALCULATION ////
 
     // Determine the sense of the position relative to this surface
@@ -114,6 +117,19 @@ CELER_FUNCTION PlaneAligned<T>::PlaneAligned(Storage data) : position_(data[0])
 
 //---------------------------------------------------------------------------//
 /*!
+ * Calculate outward normal.
+ */
+template<Axis T>
+CELER_FUNCTION Real3 PlaneAligned<T>::calc_normal() const
+{
+    Real3 norm{0, 0, 0};
+
+    norm[to_int(T)] = 1.;
+    return norm;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Determine the sense of the position relative to this surface.
  */
 template<Axis T>
@@ -148,15 +164,12 @@ PlaneAligned<T>::calc_intersections(Real3 const& pos,
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate outward normal at a position.
+ * Calculate outward normal at a position on the surface.
  */
 template<Axis T>
 CELER_FUNCTION Real3 PlaneAligned<T>::calc_normal(Real3 const&) const
 {
-    Real3 norm{0, 0, 0};
-
-    norm[to_int(T)] = 1.;
-    return norm;
+    return this->calc_normal();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/SimpleQuadric.cc
+++ b/src/orange/surf/SimpleQuadric.cc
@@ -8,18 +8,86 @@
 #include "SimpleQuadric.hh"
 
 #include "corecel/cont/Range.hh"
+#include "corecel/math/ArrayOperators.hh"
 
 #include "ConeAligned.hh"
 #include "CylAligned.hh"
+#include "Plane.hh"
+#include "Sphere.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Promote from a plane.
+ *
+ * Note that the plane is written as \f$ ax + by + cz - d = 0 \f$
+ * whereas the simple quadric has a different sign for the constant:
+ * \f$ dx + ey + fz + g = 0 \f$ .
+ */
+SimpleQuadric::SimpleQuadric(Plane const& other) noexcept
+    : SimpleQuadric{{0, 0, 0}, other.normal(), 0 - other.displacement()}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Promote from an axis-aligned cylinder.
+ */
+template<Axis T>
+SimpleQuadric::SimpleQuadric(CylAligned<T> const& other) noexcept
+{
+    constexpr auto U = CylAligned<T>::u_axis();
+    constexpr auto V = CylAligned<T>::v_axis();
+
+    Real3 second{0, 0, 0};
+    second[to_int(U)] = 1;
+    second[to_int(V)] = 1;
+
+    Real3 first{0, 0, 0};
+    first[to_int(U)] = -2 * other.origin_u();
+    first[to_int(V)] = -2 * other.origin_v();
+
+    real_type zeroth = -other.radius_sq();
+    zeroth += ipow<2>(other.origin_u());
+    zeroth += ipow<2>(other.origin_v());
+
+    *this = SimpleQuadric{second, first, zeroth};
+}
+
+template SimpleQuadric::SimpleQuadric(CylAligned<Axis::x> const&) noexcept;
+template SimpleQuadric::SimpleQuadric(CylAligned<Axis::y> const&) noexcept;
+template SimpleQuadric::SimpleQuadric(CylAligned<Axis::z> const&) noexcept;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Promote from a sphere.
+ *
+ * \verbatim
+   x^2 + y^2 + z^2
+       - 2x_0 - 2y_0 - 2z_0
+       + x_0^2 + y_0^2 + z_0^2 - r^2 = 0
+ * \endverbatim
+ */
+SimpleQuadric::SimpleQuadric(Sphere const& other) noexcept
+{
+    Real3 const& origin = other.origin();
+
+    real_type zeroth = -other.radius_sq();
+    for (auto ax : range(to_int(Axis::size_)))
+    {
+        zeroth += ipow<2>(origin[ax]);
+    }
+
+    *this = SimpleQuadric{{1, 1, 1}, real_type{-2} * origin, zeroth};
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Promote from an axis-aligned cone.
  */
 template<Axis T>
-SimpleQuadric::SimpleQuadric(ConeAligned<T> const& other)
+SimpleQuadric::SimpleQuadric(ConeAligned<T> const& other) noexcept
 {
     constexpr auto U = ConeAligned<T>::u_axis();
     constexpr auto V = ConeAligned<T>::v_axis();
@@ -42,40 +110,9 @@ SimpleQuadric::SimpleQuadric(ConeAligned<T> const& other)
     *this = SimpleQuadric{second, first, zeroth};
 }
 
-//---------------------------------------------------------------------------//
-/*!
- * Promote from an axis-aligned cylinder.
- */
-template<Axis T>
-SimpleQuadric::SimpleQuadric(CylAligned<T> const& other)
-{
-    constexpr auto U = CylAligned<T>::u_axis();
-    constexpr auto V = CylAligned<T>::v_axis();
-
-    Real3 second{0, 0, 0};
-    second[to_int(U)] = 1;
-    second[to_int(V)] = 1;
-
-    Real3 first{0, 0, 0};
-    first[to_int(U)] = -2 * other.origin_u();
-    first[to_int(V)] = -2 * other.origin_v();
-
-    real_type zeroth = -other.radius_sq();
-    zeroth += ipow<2>(other.origin_u());
-    zeroth += ipow<2>(other.origin_v());
-
-    *this = SimpleQuadric{second, first, zeroth};
-}
-
-//---------------------------------------------------------------------------//
-
-template SimpleQuadric::SimpleQuadric(ConeAligned<Axis::x> const&);
-template SimpleQuadric::SimpleQuadric(ConeAligned<Axis::y> const&);
-template SimpleQuadric::SimpleQuadric(ConeAligned<Axis::z> const&);
-
-template SimpleQuadric::SimpleQuadric(CylAligned<Axis::x> const&);
-template SimpleQuadric::SimpleQuadric(CylAligned<Axis::y> const&);
-template SimpleQuadric::SimpleQuadric(CylAligned<Axis::z> const&);
+template SimpleQuadric::SimpleQuadric(ConeAligned<Axis::x> const&) noexcept;
+template SimpleQuadric::SimpleQuadric(ConeAligned<Axis::y> const&) noexcept;
+template SimpleQuadric::SimpleQuadric(ConeAligned<Axis::z> const&) noexcept;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/surf/SimpleQuadric.cc
+++ b/src/orange/surf/SimpleQuadric.cc
@@ -15,7 +15,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Promote implicitly from an axis-aligned cylinder.
+ * Promote from an axis-aligned cylinder.
  */
 template<Axis T>
 SimpleQuadric::SimpleQuadric(CylAligned<T> const& other)

--- a/src/orange/surf/SimpleQuadric.cc
+++ b/src/orange/surf/SimpleQuadric.cc
@@ -1,0 +1,43 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/surf/SimpleQuadric.cc
+//---------------------------------------------------------------------------//
+#include "SimpleQuadric.hh"
+
+#include "corecel/cont/Range.hh"
+
+#include "CylAligned.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Promote implicitly from an axis-aligned cylinder.
+ */
+template<Axis T>
+SimpleQuadric::SimpleQuadric(CylAligned<T> const& other)
+{
+    Real3 second{1, 1, 1};
+    Real3 first{0, 0, 0};
+    real_type zeroth = -other.radius_sq();
+
+    second[to_int(T)] = 0;
+    first[to_int(other.u_axis())] -= 2 * other.origin_u();
+    first[to_int(other.v_axis())] -= 2 * other.origin_v();
+    zeroth += ipow<2>(other.origin_u());
+    zeroth += ipow<2>(other.origin_v());
+
+    *this = SimpleQuadric{second, first, zeroth};
+}
+
+//---------------------------------------------------------------------------//
+
+template SimpleQuadric::SimpleQuadric(CylAligned<Axis::x> const&);
+template SimpleQuadric::SimpleQuadric(CylAligned<Axis::y> const&);
+template SimpleQuadric::SimpleQuadric(CylAligned<Axis::z> const&);
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/surf/SimpleQuadric.hh
+++ b/src/orange/surf/SimpleQuadric.hh
@@ -18,6 +18,10 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+template<Axis T>
+class CylAligned;
+
+//---------------------------------------------------------------------------//
 /*!
  * General quadric expression but with no off-axis terms.
  *
@@ -56,12 +60,12 @@ class SimpleQuadric
     inline CELER_FUNCTION
     SimpleQuadric(Real3 const& abc, Real3 const& def, real_type g);
 
-    // Construct from another SQ and a translation
-    inline CELER_FUNCTION
-    SimpleQuadric(SimpleQuadric const& other, Real3 const& translation);
-
     // Construct from raw data
     explicit inline CELER_FUNCTION SimpleQuadric(Storage);
+
+    // Promote implicitly from an axis-aligned cylinder
+    template<Axis T>
+    SimpleQuadric(CylAligned<T> const& other);
 
     //// ACCESSORS ////
 
@@ -118,34 +122,6 @@ SimpleQuadric::SimpleQuadric(Real3 const& abc, Real3 const& def, real_type g)
 {
     CELER_EXPECT(a_ != 0 || b_ != 0 || c_ != 0 || d_ != 0 || e_ != 0
                  || f_ != 0);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct with another quadric and a translation.
- */
-CELER_FUNCTION
-SimpleQuadric::SimpleQuadric(SimpleQuadric const& other, Real3 const& origin)
-    : SimpleQuadric{other}
-{
-    Real3 const orig_def{d_, e_, f_};
-
-    constexpr auto X = to_int(Axis::x);
-    constexpr auto Y = to_int(Axis::y);
-    constexpr auto Z = to_int(Axis::z);
-
-    // Expand out origin into the other terms
-    d_ -= 2 * a_ * origin[X];
-    e_ -= 2 * b_ * origin[Y];
-    f_ -= 2 * c_ * origin[Z];
-
-    g_ += a_ * origin[X] * origin[X];
-    g_ += b_ * origin[Y] * origin[Y];
-    g_ += c_ * origin[Z] * origin[Z];
-
-    g_ -= 2 * orig_def[X] * origin[X];
-    g_ -= 2 * orig_def[Y] * origin[Y];
-    g_ -= 2 * orig_def[Z] * origin[Z];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/SimpleQuadric.hh
+++ b/src/orange/surf/SimpleQuadric.hh
@@ -63,9 +63,9 @@ class SimpleQuadric
     // Construct from raw data
     explicit inline CELER_FUNCTION SimpleQuadric(Storage);
 
-    // Promote implicitly from an axis-aligned cylinder
+    // Promote from an axis-aligned cylinder
     template<Axis T>
-    SimpleQuadric(CylAligned<T> const& other);
+    explicit SimpleQuadric(CylAligned<T> const& other);
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/SimpleQuadric.hh
+++ b/src/orange/surf/SimpleQuadric.hh
@@ -22,6 +22,8 @@ template<Axis T>
 class ConeAligned;
 template<Axis T>
 class CylAligned;
+class Plane;
+class Sphere;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -65,13 +67,19 @@ class SimpleQuadric
     // Construct from raw data
     explicit inline CELER_FUNCTION SimpleQuadric(Storage);
 
-    // Promote from a cone
-    template<Axis T>
-    explicit SimpleQuadric(ConeAligned<T> const& other);
+    // Promote from a plane
+    explicit SimpleQuadric(Plane const& other) noexcept;
 
     // Promote from an axis-aligned cylinder
     template<Axis T>
-    explicit SimpleQuadric(CylAligned<T> const& other);
+    explicit SimpleQuadric(CylAligned<T> const& other) noexcept;
+
+    // Promote from a sphere
+    explicit SimpleQuadric(Sphere const& other) noexcept;
+
+    // Promote from a cone
+    template<Axis T>
+    explicit SimpleQuadric(ConeAligned<T> const& other) noexcept;
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/SimpleQuadric.hh
+++ b/src/orange/surf/SimpleQuadric.hh
@@ -19,6 +19,8 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 template<Axis T>
+class ConeAligned;
+template<Axis T>
 class CylAligned;
 
 //---------------------------------------------------------------------------//
@@ -62,6 +64,10 @@ class SimpleQuadric
 
     // Construct from raw data
     explicit inline CELER_FUNCTION SimpleQuadric(Storage);
+
+    // Promote from a cone
+    template<Axis T>
+    explicit SimpleQuadric(ConeAligned<T> const& other);
 
     // Promote from an axis-aligned cylinder
     template<Axis T>

--- a/src/orange/surf/SimpleQuadric.hh
+++ b/src/orange/surf/SimpleQuadric.hh
@@ -123,6 +123,8 @@ class SimpleQuadric
  * Construct with coefficients.
  *
  * The quadric is ill-defined if all non-constants are zero.
+ *
+ * TODO: normalize?
  */
 CELER_FUNCTION
 SimpleQuadric::SimpleQuadric(Real3 const& abc, Real3 const& def, real_type g)

--- a/src/orange/surf/Sphere.cc
+++ b/src/orange/surf/Sphere.cc
@@ -1,0 +1,24 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/surf/Sphere.cc
+//---------------------------------------------------------------------------//
+#include "Sphere.hh"
+
+#include "SphereCentered.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Promote implicitly from a centered sphere.
+ */
+Sphere::Sphere(SphereCentered const& other)
+    : origin_{0, 0, 0}, radius_sq_{other.radius_sq()}
+{
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/surf/Sphere.cc
+++ b/src/orange/surf/Sphere.cc
@@ -13,10 +13,19 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Promote implicitly from a centered sphere.
+ * Promote from a centered sphere.
  */
 Sphere::Sphere(SphereCentered const& other)
     : origin_{0, 0, 0}, radius_sq_{other.radius_sq()}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with a new origin and the radius of another sphere.
+ */
+Sphere::Sphere(Real3 const& origin, Sphere const& other)
+    : origin_{origin}, radius_sq_{other.radius_sq_}
 {
 }
 

--- a/src/orange/surf/Sphere.cc
+++ b/src/orange/surf/Sphere.cc
@@ -13,19 +13,25 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Promote from a centered sphere.
+ * Construct from the square of the radius.
+ *
+ * This is used for surface simplification.
  */
-Sphere::Sphere(SphereCentered const& other)
-    : origin_{0, 0, 0}, radius_sq_{other.radius_sq()}
+Sphere Sphere::from_radius_sq(Real3 const& origin, real_type rsq)
 {
+    CELER_EXPECT(rsq > 0);
+    Sphere result;
+    result.origin_ = origin;
+    result.radius_sq_ = rsq;
+    return result;
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct with a new origin and the radius of another sphere.
+ * Promote from a centered sphere.
  */
-Sphere::Sphere(Real3 const& origin, Sphere const& other)
-    : origin_{origin}, radius_sq_{other.radius_sq_}
+Sphere::Sphere(SphereCentered const& other) noexcept
+    : origin_{0, 0, 0}, radius_sq_{other.radius_sq()}
 {
 }
 

--- a/src/orange/surf/Sphere.hh
+++ b/src/orange/surf/Sphere.hh
@@ -18,6 +18,9 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+class SphereCentered;
+
+//---------------------------------------------------------------------------//
 /*!
  * Sphere centered at an arbitrary point.
  */
@@ -49,6 +52,9 @@ class Sphere
 
     // Construct from raw data
     explicit inline CELER_FUNCTION Sphere(Storage);
+
+    // Promote implicitly from a centered sphere
+    Sphere(SphereCentered const& other);
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/Sphere.hh
+++ b/src/orange/surf/Sphere.hh
@@ -23,6 +23,10 @@ class SphereCentered;
 //---------------------------------------------------------------------------//
 /*!
  * Sphere centered at an arbitrary point.
+ *
+ * \f[
+   (x - x_0)^2 + (y - y_0)^2 + (z - z_0)^2 - r^2 = 0
+ * \f]
  */
 class Sphere
 {
@@ -47,6 +51,9 @@ class Sphere
   public:
     //// CONSTRUCTORS ////
 
+    // Construct with square of radius for simplification
+    static Sphere from_radius_sq(Real3 const& origin, real_type rsq);
+
     // Construct with origin and radius
     inline CELER_FUNCTION Sphere(Real3 const& origin, real_type radius);
 
@@ -54,10 +61,7 @@ class Sphere
     explicit inline CELER_FUNCTION Sphere(Storage);
 
     // Promote from a centered sphere
-    explicit Sphere(SphereCentered const& other);
-
-    // Construct with a new origin and the radius of another sphere
-    Sphere(Real3 const& origin, Sphere const& other);
+    explicit Sphere(SphereCentered const& other) noexcept;
 
     //// ACCESSORS ////
 
@@ -87,6 +91,9 @@ class Sphere
     Real3 origin_;
     // Square of the radius
     real_type radius_sq_;
+
+    //! Private default constructor for manual construction
+    Sphere() = default;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/Sphere.hh
+++ b/src/orange/surf/Sphere.hh
@@ -53,8 +53,11 @@ class Sphere
     // Construct from raw data
     explicit inline CELER_FUNCTION Sphere(Storage);
 
-    // Promote implicitly from a centered sphere
-    Sphere(SphereCentered const& other);
+    // Promote from a centered sphere
+    explicit Sphere(SphereCentered const& other);
+
+    // Construct with a new origin and the radius of another sphere
+    Sphere(Real3 const& origin, Sphere const& other);
 
     //// ACCESSORS ////
 

--- a/src/orange/surf/SphereCentered.hh
+++ b/src/orange/surf/SphereCentered.hh
@@ -76,6 +76,9 @@ class SphereCentered
   private:
     // Square of the radius
     real_type radius_sq_;
+
+    //! Private default constructor for manual construction
+    SphereCentered() = default;
 };
 
 //---------------------------------------------------------------------------//
@@ -89,7 +92,9 @@ class SphereCentered
 SphereCentered SphereCentered::from_radius_sq(real_type rsq)
 {
     CELER_EXPECT(rsq > 0);
-    return SphereCentered(Storage{&rsq, 1});
+    SphereCentered result;
+    result.radius_sq_ = rsq;
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/SphereCentered.hh
+++ b/src/orange/surf/SphereCentered.hh
@@ -44,6 +44,9 @@ class SphereCentered
   public:
     //// CONSTRUCTORS ////
 
+    // Construct with square of radius for simplification
+    static inline SphereCentered from_radius_sq(real_type rsq);
+
     // Construct with origin and radius
     explicit inline CELER_FUNCTION SphereCentered(real_type radius);
 
@@ -77,6 +80,18 @@ class SphereCentered
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from the square of the radius.
+ *
+ * This is used for surface simplification.
+ */
+SphereCentered SphereCentered::from_radius_sq(real_type rsq)
+{
+    CELER_EXPECT(rsq > 0);
+    return SphereCentered(Storage{&rsq, 1});
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Construct with sphere radius.

--- a/test/orange/surf/ConeAligned.test.cc
+++ b/test/orange/surf/ConeAligned.test.cc
@@ -18,12 +18,20 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 
-TEST(ConeAlignedTest, sense)
+TEST(ConeAlignedTest, construction)
 {
     ConeX cone{{0, 0, 1}, 0.5};
     EXPECT_VEC_SOFT_EQ((Real3{0, 0, 1}), cone.origin());
     EXPECT_SOFT_EQ(ipow<2>(0.5), cone.tangent_sq());
 
+    auto coney = ConeY::from_tangent_sq({1, 0, 1}, cone.tangent_sq());
+    EXPECT_VEC_SOFT_EQ((Real3{1, 0, 1}), coney.origin());
+    EXPECT_SOFT_EQ(ipow<2>(0.5), coney.tangent_sq());
+}
+
+TEST(ConeAlignedTest, sense)
+{
+    ConeX cone{{0, 0, 1}, 0.5};
     EXPECT_EQ(SignedSense::inside, cone.calc_sense({2, 0, 1}));
     EXPECT_EQ(SignedSense::inside, cone.calc_sense({2, 0.99, 1}));
     EXPECT_EQ(SignedSense::outside, cone.calc_sense({2, 1.01, 1}));

--- a/test/orange/surf/CylAligned.test.cc
+++ b/test/orange/surf/CylAligned.test.cc
@@ -18,6 +18,25 @@ namespace celeritas
 namespace test
 {
 //---------------------------------------------------------------------------//
+TEST(CylTest, construction)
+{
+    CylX cyl{{1, 2, 3}, 4};
+    EXPECT_SOFT_EQ(2, cyl.origin_u());
+    EXPECT_SOFT_EQ(3, cyl.origin_v());
+    EXPECT_SOFT_EQ(ipow<2>(4), cyl.radius_sq());
+    EXPECT_VEC_EQ((Real3{0, 2, 3}), cyl.calc_origin());
+
+    auto cyly = CylY::from_radius_sq({1, 2, 3}, cyl.radius_sq());
+    EXPECT_SOFT_EQ(1, cyly.origin_u());
+    EXPECT_SOFT_EQ(3, cyly.origin_v());
+    EXPECT_SOFT_EQ(cyl.radius_sq(), cyly.radius_sq());
+
+    CylZ const ccyl{CCylZ{2.5}};
+    EXPECT_SOFT_EQ(ipow<2>(2.5), ccyl.radius_sq());
+    EXPECT_SOFT_EQ(0, ccyl.origin_u());
+    EXPECT_SOFT_EQ(0, ccyl.origin_v());
+}
+
 TEST(CylXTest, sense)
 {
     CylX cyl{{0, 0, 0}, 4.0};
@@ -402,16 +421,6 @@ TEST(CylZTest, degenerate_boundary)
             }
         }
     }
-}
-
-//---------------------------------------------------------------------------//
-
-TEST(CylZTest, promotion)
-{
-    CylZ const cyl{CCylZ{2.5}};
-    EXPECT_SOFT_EQ(ipow<2>(2.5), cyl.radius_sq());
-    EXPECT_SOFT_EQ(0, cyl.origin_u());
-    EXPECT_SOFT_EQ(0, cyl.origin_v());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/CylAligned.test.cc
+++ b/test/orange/surf/CylAligned.test.cc
@@ -7,6 +7,9 @@
 //---------------------------------------------------------------------------//
 #include "orange/surf/CylAligned.hh"
 
+#include "corecel/math/Algorithms.hh"
+#include "orange/surf/CylCentered.hh"
+
 #include "SurfaceTestUtils.hh"
 #include "celeritas_test.hh"
 
@@ -399,6 +402,16 @@ TEST(CylZTest, degenerate_boundary)
             }
         }
     }
+}
+
+//---------------------------------------------------------------------------//
+
+TEST(CylZTest, promotion)
+{
+    CylZ const cyl{CCylZ{2.5}};
+    EXPECT_SOFT_EQ(ipow<2>(2.5), cyl.radius_sq());
+    EXPECT_SOFT_EQ(0, cyl.origin_u());
+    EXPECT_SOFT_EQ(0, cyl.origin_v());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/CylCentered.test.cc
+++ b/test/orange/surf/CylCentered.test.cc
@@ -36,10 +36,14 @@ TEST(TestCCylX, construction)
     EXPECT_EQ(2, CCylX::Intersections{}.size());
 
     CCylX c(4.0);
+    EXPECT_SOFT_EQ(ipow<2>(4), c.radius_sq());
 
     const real_type expected_data[] = {ipow<2>(4)};
 
     EXPECT_VEC_SOFT_EQ(expected_data, c.data());
+
+    auto cy = CCylY::from_radius_sq(c.radius_sq());
+    EXPECT_SOFT_EQ(c.radius_sq(), cy.radius_sq());
 }
 
 TEST(TestCCylX, sense)

--- a/test/orange/surf/GeneralQuadric.test.cc
+++ b/test/orange/surf/GeneralQuadric.test.cc
@@ -21,6 +21,28 @@ namespace test
 using Intersections = GeneralQuadric::Intersections;
 
 //---------------------------------------------------------------------------//
+TEST(GeneralQuadricTest, construction)
+{
+    GeneralQuadric gq{SimpleQuadric{{ipow<2>(2.5) * ipow<2>(0.3),
+                                     ipow<2>(1.0) * ipow<2>(0.3),
+                                     ipow<2>(1.0) * ipow<2>(2.5)},
+                                    {0, 0, 0},
+                                    -1 * ipow<2>(2.5) * ipow<2>(0.3)}};
+
+    auto distances
+        = gq.calc_intersections({-2.5, 0, 0}, {1, 0, 0}, SurfaceState::off);
+    EXPECT_SOFT_EQ(1.5, distances[0]);
+    EXPECT_SOFT_EQ(1.5 + 2.0, distances[1]);
+    distances
+        = gq.calc_intersections({0, 2.5, 0}, {0, -1, 0}, SurfaceState::on);
+    EXPECT_SOFT_EQ(5.0, distances[0]);
+    EXPECT_SOFT_EQ(no_intersection(), distances[1]);
+    distances = gq.calc_intersections({0, 0, 0}, {0, 0, 1}, SurfaceState::off);
+    EXPECT_SOFT_EQ(0.3, distances[1]);
+    EXPECT_SOFT_EQ(no_intersection(), distances[0]);
+}
+
+//---------------------------------------------------------------------------//
 /*!
  * This shape is an ellipsoid:
  * - with radii {3, 2, 1},
@@ -80,27 +102,6 @@ TEST(GeneralQuadricTest, all)
     distances = gq.calc_intersections(pos, outward, SurfaceState::off);
     EXPECT_SOFT_EQ(1.0, distances[0]);
     EXPECT_SOFT_EQ(7.0, distances[1]);
-}
-
-TEST(GeneralQuadricTest, promotion)
-{
-    GeneralQuadric gq{SimpleQuadric{{ipow<2>(2.5) * ipow<2>(0.3),
-                                     ipow<2>(1.0) * ipow<2>(0.3),
-                                     ipow<2>(1.0) * ipow<2>(2.5)},
-                                    {0, 0, 0},
-                                    -1 * ipow<2>(2.5) * ipow<2>(0.3)}};
-
-    auto distances
-        = gq.calc_intersections({-2.5, 0, 0}, {1, 0, 0}, SurfaceState::off);
-    EXPECT_SOFT_EQ(1.5, distances[0]);
-    EXPECT_SOFT_EQ(1.5 + 2.0, distances[1]);
-    distances
-        = gq.calc_intersections({0, 2.5, 0}, {0, -1, 0}, SurfaceState::on);
-    EXPECT_SOFT_EQ(5.0, distances[0]);
-    EXPECT_SOFT_EQ(no_intersection(), distances[1]);
-    distances = gq.calc_intersections({0, 0, 0}, {0, 0, 1}, SurfaceState::off);
-    EXPECT_SOFT_EQ(0.3, distances[1]);
-    EXPECT_SOFT_EQ(no_intersection(), distances[0]);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/GeneralQuadric.test.cc
+++ b/test/orange/surf/GeneralQuadric.test.cc
@@ -7,6 +7,9 @@
 //---------------------------------------------------------------------------//
 #include "orange/surf/GeneralQuadric.hh"
 
+#include "corecel/math/Algorithms.hh"
+#include "orange/surf/SimpleQuadric.hh"
+
 #include "celeritas_test.hh"
 
 namespace celeritas
@@ -77,6 +80,27 @@ TEST(GeneralQuadricTest, all)
     distances = gq.calc_intersections(pos, outward, SurfaceState::off);
     EXPECT_SOFT_EQ(1.0, distances[0]);
     EXPECT_SOFT_EQ(7.0, distances[1]);
+}
+
+TEST(GeneralQuadricTest, promotion)
+{
+    GeneralQuadric gq{SimpleQuadric{{ipow<2>(2.5) * ipow<2>(0.3),
+                                     ipow<2>(1.0) * ipow<2>(0.3),
+                                     ipow<2>(1.0) * ipow<2>(2.5)},
+                                    {0, 0, 0},
+                                    -1 * ipow<2>(2.5) * ipow<2>(0.3)}};
+
+    auto distances
+        = gq.calc_intersections({-2.5, 0, 0}, {1, 0, 0}, SurfaceState::off);
+    EXPECT_SOFT_EQ(1.5, distances[0]);
+    EXPECT_SOFT_EQ(1.5 + 2.0, distances[1]);
+    distances
+        = gq.calc_intersections({0, 2.5, 0}, {0, -1, 0}, SurfaceState::on);
+    EXPECT_SOFT_EQ(5.0, distances[0]);
+    EXPECT_SOFT_EQ(no_intersection(), distances[1]);
+    distances = gq.calc_intersections({0, 0, 0}, {0, 0, 1}, SurfaceState::off);
+    EXPECT_SOFT_EQ(0.3, distances[1]);
+    EXPECT_SOFT_EQ(no_intersection(), distances[0]);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/Plane.test.cc
+++ b/test/orange/surf/Plane.test.cc
@@ -8,6 +8,7 @@
 #include "orange/surf/Plane.hh"
 
 #include "orange/Constants.hh"
+#include "orange/surf/PlaneAligned.hh"
 
 #include "celeritas_test.hh"
 
@@ -86,6 +87,16 @@ TEST_F(PlaneTest, tracking)
     x = {2.0, 2.0, 0.0};
     EXPECT_EQ(no_intersection(),
               calc_intersection(p, x, dir, SurfaceState::on));
+}
+
+TEST_F(PlaneTest, promotion)
+{
+    Plane px{PlaneX{1.25}};
+    EXPECT_VEC_SOFT_EQ((Real3{1, 0, 0}), px.normal());
+    EXPECT_SOFT_EQ(1.25, px.displacement());
+
+    Plane py{PlaneY{2.25}};
+    EXPECT_VEC_SOFT_EQ((Real3{0, 1, 0}), py.normal());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/Plane.test.cc
+++ b/test/orange/surf/Plane.test.cc
@@ -39,6 +39,21 @@ class PlaneTest : public Test
     }
 };
 
+TEST_F(PlaneTest, construction)
+{
+    // Make a rotated plane in the xy axis
+    Plane p{{1 / sqrt_two, 1 / sqrt_two, 0.0}, {2 / sqrt_two, 2 / sqrt_two, 2}};
+    EXPECT_VEC_SOFT_EQ((Real3{1 / sqrt_two, 1 / sqrt_two, 0}), p.normal());
+    EXPECT_SOFT_EQ(2, p.displacement());
+
+    Plane px{PlaneX{1.25}};
+    EXPECT_VEC_SOFT_EQ((Real3{1, 0, 0}), px.normal());
+    EXPECT_SOFT_EQ(1.25, px.displacement());
+
+    Plane py{PlaneY{2.25}};
+    EXPECT_VEC_SOFT_EQ((Real3{0, 1, 0}), py.normal());
+}
+
 TEST_F(PlaneTest, tracking)
 {
     // Make a rotated plane in the xy axis
@@ -88,24 +103,6 @@ TEST_F(PlaneTest, tracking)
     x = {2.0, 2.0, 0.0};
     EXPECT_EQ(no_intersection(),
               calc_intersection(p, x, dir, SurfaceState::on));
-}
-
-TEST_F(PlaneTest, promotion)
-{
-    Plane px{PlaneX{1.25}};
-    EXPECT_VEC_SOFT_EQ((Real3{1, 0, 0}), px.normal());
-    EXPECT_SOFT_EQ(1.25, px.displacement());
-
-    Plane py{PlaneY{2.25}};
-    EXPECT_VEC_SOFT_EQ((Real3{0, 1, 0}), py.normal());
-}
-
-TEST_F(PlaneTest, construction)
-{
-    // Make a rotated plane in the xy axis
-    Plane p{{1 / sqrt_two, 1 / sqrt_two, 0.0}, {2 / sqrt_two, 2 / sqrt_two, 2}};
-    EXPECT_VEC_SOFT_EQ((Real3{1 / sqrt_two, 1 / sqrt_two, 0}), p.normal());
-    EXPECT_SOFT_EQ(2, p.displacement());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/Plane.test.cc
+++ b/test/orange/surf/Plane.test.cc
@@ -100,6 +100,14 @@ TEST_F(PlaneTest, promotion)
     EXPECT_VEC_SOFT_EQ((Real3{0, 1, 0}), py.normal());
 }
 
+TEST_F(PlaneTest, construction)
+{
+    // Make a rotated plane in the xy axis
+    Plane p{{1 / sqrt_two, 1 / sqrt_two, 0.0}, {2 / sqrt_two, 2 / sqrt_two, 2}};
+    EXPECT_VEC_SOFT_EQ((Real3{1 / sqrt_two, 1 / sqrt_two, 0}), p.normal());
+    EXPECT_SOFT_EQ(2, p.displacement());
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/orange/surf/Plane.test.cc
+++ b/test/orange/surf/Plane.test.cc
@@ -12,12 +12,13 @@
 
 #include "celeritas_test.hh"
 
-using celeritas::constants::sqrt_two;
-
 namespace celeritas
 {
 namespace test
 {
+
+using constants::sqrt_two;
+
 //---------------------------------------------------------------------------//
 // TEST HARNESS
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/PlaneAligned.test.cc
+++ b/test/orange/surf/PlaneAligned.test.cc
@@ -51,6 +51,7 @@ TEST_F(PlaneAlignedTest, x_plane)
     PlaneX p(1.0);
 
     EXPECT_EQ((Real3{1.0, 0.0, 0.0}), p.calc_normal(Real3{1.0, 0.1, -4.2}));
+    EXPECT_EQ((Real3{1.0, 0.0, 0.0}), p.calc_normal());
 
     // Test sense
     EXPECT_EQ(SignedSense::outside, p.calc_sense(Real3{1.01, 0.1, 0.0}));

--- a/test/orange/surf/SimpleQuadric.test.cc
+++ b/test/orange/surf/SimpleQuadric.test.cc
@@ -8,6 +8,7 @@
 #include "orange/surf/SimpleQuadric.hh"
 
 #include "corecel/math/Algorithms.hh"
+#include "orange/surf/ConeAligned.hh"
 #include "orange/surf/CylAligned.hh"
 
 #include "celeritas_test.hh"
@@ -51,7 +52,17 @@ TEST(Ellipsoid, origin)
     EXPECT_VEC_SOFT_EQ((Real3{-1, 0, 0}), sq.calc_normal({-1, 0, 0}));
 }
 
-TEST(Ellipsoid, promotion)
+TEST(Ellipsoid, promotion_cone)
+{
+    SimpleQuadric sq{ConeX{{1.1, 2.2, 3.3}, 2. / 3.}};
+
+    auto distances = sq.calc_intersections(
+        {1.1 + 3, 2.2 + 2 + 1.0, 3.3}, {0.0, -1.0, 0.0}, SurfaceState::off);
+    EXPECT_SOFT_EQ(1.0, distances[0]);
+    EXPECT_SOFT_EQ(5.0, distances[1]);
+}
+
+TEST(Ellipsoid, promotion_cyl)
 {
     // Radius: 2 centered at {2, 3, 0}
     SimpleQuadric sq{CylZ{{2, 3, 0}, 2}};

--- a/test/orange/surf/SimpleQuadric.test.cc
+++ b/test/orange/surf/SimpleQuadric.test.cc
@@ -8,6 +8,7 @@
 #include "orange/surf/SimpleQuadric.hh"
 
 #include "corecel/math/Algorithms.hh"
+#include "orange/surf/CylAligned.hh"
 
 #include "celeritas_test.hh"
 
@@ -50,23 +51,18 @@ TEST(Ellipsoid, origin)
     EXPECT_VEC_SOFT_EQ((Real3{-1, 0, 0}), sq.calc_normal({-1, 0, 0}));
 }
 
-TEST(Ellipsoid, translated)
+TEST(Ellipsoid, promotion)
 {
-    // Radius: {1, 2.5, .3} centered at {2, 3, 4}
-    SimpleQuadric sq{SimpleQuadric{{0.5625, 0.09, 6.25}, {0, 0, 0}, -0.5625},
-                     {2, 3, 4}};
+    // Radius: 2 centered at {2, 3, 0}
+    SimpleQuadric sq{CylZ{{2, 3, 0}, 2}};
 
     auto distances
-        = sq.calc_intersections({-0.5, 3, 4}, {1, 0, 0}, SurfaceState::off);
-    EXPECT_SOFT_EQ(1.5, distances[0]);
-    EXPECT_SOFT_EQ(1.5 + 2.0, distances[1]);
-    distances
-        = sq.calc_intersections({2, 5.5, 4}, {0, -1, 0}, SurfaceState::on);
-    EXPECT_SOFT_EQ(5.0, distances[0]);
-    EXPECT_SOFT_EQ(no_intersection(), distances[1]);
-    distances = sq.calc_intersections({2, 3, 4}, {0, 0, 1}, SurfaceState::off);
-    EXPECT_SOFT_EQ(0.3, distances[1]);
-    EXPECT_SOFT_EQ(no_intersection(), distances[0]);
+        = sq.calc_intersections({-0.5, 3, 0}, {1, 0, 0}, SurfaceState::off);
+    EXPECT_SOFT_EQ(0.5, distances[0]);
+    EXPECT_SOFT_EQ(0.5 + 4.0, distances[1]);
+
+    EXPECT_VEC_SOFT_EQ((Real3{0, 1, 0}), sq.calc_normal({2, 5, 0}));
+    EXPECT_VEC_SOFT_EQ((Real3{-1, 0, 0}), sq.calc_normal({0, 3, 0}));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/SimpleQuadric.test.cc
+++ b/test/orange/surf/SimpleQuadric.test.cc
@@ -8,8 +8,11 @@
 #include "orange/surf/SimpleQuadric.hh"
 
 #include "corecel/math/Algorithms.hh"
+#include "orange/Constants.hh"
 #include "orange/surf/ConeAligned.hh"
 #include "orange/surf/CylAligned.hh"
+#include "orange/surf/Plane.hh"
+#include "orange/surf/Sphere.hh"
 
 #include "celeritas_test.hh"
 
@@ -19,7 +22,45 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 
-TEST(Ellipsoid, origin)
+TEST(SimpleQuadricTest, construction)
+{
+    using constants::sqrt_two;
+    // Plane
+    SimpleQuadric p{Plane{{1 / sqrt_two, 1 / sqrt_two, 0.0}, 2 * sqrt_two}};
+
+    auto distances
+        = p.calc_intersections({0, 0, 0}, {1, 0, 0}, SurfaceState::off);
+    EXPECT_SOFT_EQ(4.0, distances[0]);
+    EXPECT_SOFT_EQ(no_intersection(), distances[1]);
+
+    // Sphere
+    SimpleQuadric sph{Sphere{{1, 2, 3}, 0.5}};
+
+    distances = sph.calc_intersections({1, 2, 2}, {0, 0, 1}, SurfaceState::off);
+    EXPECT_SOFT_EQ(0.5, distances[0]);
+    EXPECT_SOFT_EQ(1.5, distances[1]);
+
+    // Cone along x axis
+    SimpleQuadric cx{ConeX{{1.1, 2.2, 3.3}, 2. / 3.}};
+
+    distances = cx.calc_intersections(
+        {1.1 + 3, 2.2 + 2 + 1.0, 3.3}, {0.0, -1.0, 0.0}, SurfaceState::off);
+    EXPECT_SOFT_EQ(1.0, distances[0]);
+    EXPECT_SOFT_EQ(5.0, distances[1]);
+
+    // Cylinder with radius 2 centered at {2, 3, 0}
+    SimpleQuadric cz{CylZ{{2, 3, 0}, 2}};
+
+    distances
+        = cz.calc_intersections({-0.5, 3, 0}, {1, 0, 0}, SurfaceState::off);
+    EXPECT_SOFT_EQ(0.5, distances[0]);
+    EXPECT_SOFT_EQ(0.5 + 4.0, distances[1]);
+
+    EXPECT_VEC_SOFT_EQ((Real3{0, 1, 0}), cz.calc_normal({2, 5, 0}));
+    EXPECT_VEC_SOFT_EQ((Real3{-1, 0, 0}), cz.calc_normal({0, 3, 0}));
+}
+
+TEST(SimpleQuadricTest, ellipsoid)
 {
     // 1 x 2.5 x .3 radii
     const Real3 second{ipow<2>(2.5) * ipow<2>(0.3),
@@ -50,30 +91,6 @@ TEST(Ellipsoid, origin)
     EXPECT_VEC_SOFT_EQ((Real3{0, 0, -1}), sq.calc_normal({0, 0, -0.3}));
     EXPECT_VEC_SOFT_EQ((Real3{0, 1, 0}), sq.calc_normal({0, 2.5, 0}));
     EXPECT_VEC_SOFT_EQ((Real3{-1, 0, 0}), sq.calc_normal({-1, 0, 0}));
-}
-
-TEST(Ellipsoid, promotion_cone)
-{
-    SimpleQuadric sq{ConeX{{1.1, 2.2, 3.3}, 2. / 3.}};
-
-    auto distances = sq.calc_intersections(
-        {1.1 + 3, 2.2 + 2 + 1.0, 3.3}, {0.0, -1.0, 0.0}, SurfaceState::off);
-    EXPECT_SOFT_EQ(1.0, distances[0]);
-    EXPECT_SOFT_EQ(5.0, distances[1]);
-}
-
-TEST(Ellipsoid, promotion_cyl)
-{
-    // Radius: 2 centered at {2, 3, 0}
-    SimpleQuadric sq{CylZ{{2, 3, 0}, 2}};
-
-    auto distances
-        = sq.calc_intersections({-0.5, 3, 0}, {1, 0, 0}, SurfaceState::off);
-    EXPECT_SOFT_EQ(0.5, distances[0]);
-    EXPECT_SOFT_EQ(0.5 + 4.0, distances[1]);
-
-    EXPECT_VEC_SOFT_EQ((Real3{0, 1, 0}), sq.calc_normal({2, 5, 0}));
-    EXPECT_VEC_SOFT_EQ((Real3{-1, 0, 0}), sq.calc_normal({0, 3, 0}));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/Sphere.test.cc
+++ b/test/orange/surf/Sphere.test.cc
@@ -24,6 +24,22 @@ using Intersections = Sphere::Intersections;
 constexpr real_type sqrt_third = 1 / constants::sqrt_three;
 
 //---------------------------------------------------------------------------//
+TEST(SphereTest, construction)
+{
+    Sphere s{{-1.1, 2.2, -3.3}, 4.4};
+    EXPECT_VEC_SOFT_EQ((Real3{-1.1, 2.2, -3.3}), s.origin());
+    EXPECT_SOFT_EQ(ipow<2>(4.4), s.radius_sq());
+
+    auto s2 = Sphere::from_radius_sq({1, 2, 3}, s.radius_sq());
+    EXPECT_VEC_SOFT_EQ((Real3{1, 2, 3}), s2.origin());
+    EXPECT_SOFT_EQ(s.radius_sq(), s2.radius_sq());
+
+    Sphere sc{SphereCentered{2.5}};
+    EXPECT_VEC_SOFT_EQ((Real3{0, 0, 0}), sc.origin());
+    EXPECT_SOFT_EQ(ipow<2>(2.5), sc.radius_sq());
+}
+
+//---------------------------------------------------------------------------//
 TEST(SphereTest, all)
 {
     EXPECT_EQ(SurfaceType::s, Sphere::surface_type());
@@ -73,14 +89,6 @@ TEST(SphereTest, all)
         Real3{-6.5, 2.2, -3.3}, Real3{1, 0, 0}, SurfaceState::off);
     EXPECT_SOFT_EQ(1.0, distances[0]);
     EXPECT_SOFT_EQ(1 + 2 * radius, distances[1]);
-}
-
-//---------------------------------------------------------------------------//
-TEST(SphereTest, promotion)
-{
-    Sphere s{SphereCentered{2.5}};
-    EXPECT_VEC_SOFT_EQ((Real3{0, 0, 0}), s.origin());
-    EXPECT_SOFT_EQ(ipow<2>(2.5), s.radius_sq());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/Sphere.test.cc
+++ b/test/orange/surf/Sphere.test.cc
@@ -7,7 +7,9 @@
 //---------------------------------------------------------------------------//
 #include "orange/surf/Sphere.hh"
 
+#include "corecel/math/Algorithms.hh"
 #include "orange/Constants.hh"
+#include "orange/surf/SphereCentered.hh"
 
 #include "celeritas_test.hh"
 
@@ -33,7 +35,7 @@ TEST(SphereTest, all)
 
     Sphere s{origin, radius};
     EXPECT_VEC_SOFT_EQ(origin, s.origin());
-    EXPECT_SOFT_EQ(radius * radius, s.radius_sq());
+    EXPECT_SOFT_EQ(ipow<2>(radius), s.radius_sq());
 
     EXPECT_EQ(SignedSense::outside, s.calc_sense({4, 5, 5}));
     EXPECT_EQ(SignedSense::inside, s.calc_sense({1, 2, -3}));
@@ -71,6 +73,14 @@ TEST(SphereTest, all)
         Real3{-6.5, 2.2, -3.3}, Real3{1, 0, 0}, SurfaceState::off);
     EXPECT_SOFT_EQ(1.0, distances[0]);
     EXPECT_SOFT_EQ(1 + 2 * radius, distances[1]);
+}
+
+//---------------------------------------------------------------------------//
+TEST(SphereTest, promotion)
+{
+    Sphere s{SphereCentered{2.5}};
+    EXPECT_VEC_SOFT_EQ((Real3{0, 0, 0}), s.origin());
+    EXPECT_SOFT_EQ(ipow<2>(2.5), s.radius_sq());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/SphereCentered.test.cc
+++ b/test/orange/surf/SphereCentered.test.cc
@@ -22,16 +22,23 @@ using Intersections = SphereCentered::Intersections;
 constexpr real_type sqrt_third = 1 / constants::sqrt_three;
 
 //---------------------------------------------------------------------------//
-TEST(SphereCenteredTest, all)
+TEST(SphereCenteredTest, construction)
 {
     EXPECT_EQ(SurfaceType::sc, SphereCentered::surface_type());
     EXPECT_EQ(1, SphereCentered::Storage::extent);
     EXPECT_EQ(2, SphereCentered::Intersections{}.size());
 
-    real_type radius = 4.4;
+    SphereCentered s{3};
+    EXPECT_SOFT_EQ(ipow<2>(3), s.radius_sq());
 
+    auto s2 = SphereCentered::from_radius_sq(s.radius_sq());
+    EXPECT_SOFT_EQ(s.radius_sq(), s2.radius_sq());
+}
+
+TEST(SphereCenteredTest, maths)
+{
+    real_type radius = 4.4;
     SphereCentered s{radius};
-    EXPECT_SOFT_EQ(radius * radius, s.radius_sq());
 
     EXPECT_EQ(SignedSense::outside, s.calc_sense({2, 3, 5}));
     EXPECT_EQ(SignedSense::inside, s.calc_sense({2, 3, 1}));


### PR DESCRIPTION
This adds the ability to convert "special case" quadrics into more general quadrics. This capability is needed for transformations and translations, as well as testing surface simplification.