### PR TITLE
Hotfix: fix missing include from #849

### DIFF
--- a/src/orange/detail/BIHUtils.hh
+++ b/src/orange/detail/BIHUtils.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <vector>
+
 #include "orange/BoundingBoxUtils.hh"
 
 namespace celeritas


### PR DESCRIPTION
This fixes a missing header error in `BIHUtils.hh` caused by a forward declaration on macOS (Xcode 14.2, command line tools 2395) that results in:

```shell
celeritas/src/orange/detail/BIHUtils.hh:21:25: error: implicit instantiation of undefined template 'std::vector<celeritas::BoundingBox<float>>'
    CELER_EXPECT(!bboxes.empty());
                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/iosfwd:259:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
```