### PR TITLE
Refactor StepLimit to SoA

### DIFF
--- a/src/celeritas/em/msc/UrbanMsc.hh
+++ b/src/celeritas/em/msc/UrbanMsc.hh
@@ -44,17 +44,16 @@ class UrbanMsc
     is_applicable(CoreTrackView const&, real_type step) const;
 
     // Update the physical and geometric step lengths
-    inline CELER_FUNCTION void limit_step(CoreTrackView const&, StepLimit*);
+    inline CELER_FUNCTION void limit_step(CoreTrackView const&);
 
     // Apply MSC
-    inline CELER_FUNCTION void apply_step(CoreTrackView const&, StepLimit*);
+    inline CELER_FUNCTION void apply_step(CoreTrackView const&);
 
   private:
     ParamsRef const msc_params_;
 
     // Whether the step was limited by geometry
-    static inline CELER_FUNCTION bool
-    is_geo_limited(CoreTrackView const&, StepLimit const&);
+    static inline CELER_FUNCTION bool is_geo_limited(CoreTrackView const&);
 };
 
 //---------------------------------------------------------------------------//
@@ -95,21 +94,21 @@ UrbanMsc::is_applicable(CoreTrackView const& track, real_type step) const
 /*!
  * Update the physical and geometric step lengths.
  */
-CELER_FUNCTION void
-UrbanMsc::limit_step(CoreTrackView const& track, StepLimit* step_limit)
+CELER_FUNCTION void UrbanMsc::limit_step(CoreTrackView const& track)
 {
     auto phys = track.make_physics_view();
     auto par = track.make_particle_view();
+    auto sim = track.make_sim_view();
     detail::UrbanMscHelper msc_helper(msc_params_, par, phys);
 
     bool displaced = false;
 
     // Sample multiple scattering step length
     real_type const true_path = [&] {
-        if (step_limit->step <= msc_params_.params.limit_min_fix())
+        if (sim.step_length() <= msc_params_.params.limit_min_fix())
         {
             // Very short step: don't displace or limit
-            return step_limit->step;
+            return sim.step_length();
         }
 
         auto geo = track.make_geo_view();
@@ -127,7 +126,7 @@ UrbanMsc::limit_step(CoreTrackView const& track, StepLimit* step_limit)
             {
                 // The nearest boundary is further than the maximum expected
                 // travel distance of the particle: don't displace or limit
-                return step_limit->step;
+                return sim.step_length();
             }
         }
 
@@ -139,13 +138,13 @@ UrbanMsc::limit_step(CoreTrackView const& track, StepLimit* step_limit)
                                              phys.material_id(),
                                              geo.is_on_boundary(),
                                              safety,
-                                             step_limit->step);
+                                             sim.step_length());
         auto rng = track.make_rng_engine();
         return calc_limit(rng);
     }();
-    CELER_ASSERT(true_path <= step_limit->step);
+    CELER_ASSERT(true_path <= sim.step_length());
 
-    bool limited = (true_path < step_limit->step);
+    bool limited = (true_path < sim.step_length());
 
     // Always apply the step transformation, even if the physical step wasn't
     // necessarily limited. This transformation will be reversed in
@@ -179,11 +178,11 @@ UrbanMsc::limit_step(CoreTrackView const& track, StepLimit* step_limit)
         return result;
     }());
 
-    step_limit->step = gp.step;
+    sim.step_length() = gp.step;
     if (limited)
     {
         // Physical step was further limited by MSC
-        step_limit->action = phys.scalars().msc_action();
+        sim.force_step_limit(phys.scalars().msc_action());
     }
 }
 
@@ -191,22 +190,22 @@ UrbanMsc::limit_step(CoreTrackView const& track, StepLimit* step_limit)
 /*!
  * Apply MSC.
  */
-CELER_FUNCTION void
-UrbanMsc::apply_step(CoreTrackView const& track, StepLimit* step_limit)
+CELER_FUNCTION void UrbanMsc::apply_step(CoreTrackView const& track)
 {
     auto par = track.make_particle_view();
     auto geo = track.make_geo_view();
     auto phys = track.make_physics_view();
+    auto sim = track.make_sim_view();
 
     // Replace step with actual geometry distance traveled
     detail::UrbanMscHelper msc_helper(msc_params_, par, phys);
     auto msc_step = track.make_physics_step_view().msc_step();
-    if (this->is_geo_limited(track, *step_limit))
+    if (this->is_geo_limited(track))
     {
         // Convert geometrical distance to equivalent physical distance, which
         // will be greater than (or in edge cases equal to) that distance and
         // less than the original physical step limit.
-        msc_step.geom_path = step_limit->step;
+        msc_step.geom_path = sim.step_length();
         detail::MscStepFromGeo geo_to_true(msc_params_.params,
                                            msc_step,
                                            phys.dedx_range(),
@@ -220,7 +219,7 @@ UrbanMsc::apply_step(CoreTrackView const& track, StepLimit* step_limit)
 
     // Update full path length traveled along the step based on MSC to
     // correctly calculate energy loss, step time, etc.
-    step_limit->step = msc_step.true_path;
+    sim.step_length() = msc_step.true_path;
 
     auto msc_result = [&] {
         real_type safety = 0;
@@ -277,11 +276,11 @@ UrbanMsc::apply_step(CoreTrackView const& track, StepLimit* step_limit)
  * it should be "boundary action") but in rare circumstances the propagation
  * has to pause before the end of the step is reached.
  */
-CELER_FUNCTION bool
-UrbanMsc::is_geo_limited(CoreTrackView const& track, StepLimit const& limit)
+CELER_FUNCTION bool UrbanMsc::is_geo_limited(CoreTrackView const& track)
 {
-    return (limit.action == track.boundary_action()
-            || limit.action == track.propagation_limit_action());
+    auto sim = track.make_sim_view();
+    return (sim.post_step_action() == track.boundary_action()
+            || sim.post_step_action() == track.propagation_limit_action());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/msc/UrbanMsc.hh
+++ b/src/celeritas/em/msc/UrbanMsc.hh
@@ -178,11 +178,11 @@ CELER_FUNCTION void UrbanMsc::limit_step(CoreTrackView const& track)
         return result;
     }());
 
-    sim.step_length() = gp.step;
+    sim.step_length(gp.step);
     if (limited)
     {
         // Physical step was further limited by MSC
-        sim.force_step_limit(phys.scalars().msc_action());
+        sim.post_step_action(phys.scalars().msc_action());
     }
 }
 
@@ -219,7 +219,7 @@ CELER_FUNCTION void UrbanMsc::apply_step(CoreTrackView const& track)
 
     // Update full path length traveled along the step based on MSC to
     // correctly calculate energy loss, step time, etc.
-    sim.step_length() = msc_step.true_path;
+    sim.step_length(msc_step.true_path);
 
     auto msc_result = [&] {
         real_type safety = 0;

--- a/src/celeritas/geo/detail/BoundaryExecutor.hh
+++ b/src/celeritas/geo/detail/BoundaryExecutor.hh
@@ -39,7 +39,7 @@ BoundaryExecutor::operator()(celeritas::CoreTrackView const& track)
 {
     CELER_EXPECT([track] {
         auto sim = track.make_sim_view();
-        return sim.step_limit().action == track.boundary_action()
+        return sim.post_step_action() == track.boundary_action()
                && sim.status() == TrackStatus::alive;
     }());
 

--- a/src/celeritas/global/alongstep/detail/AlongStepNeutralImpl.hh
+++ b/src/celeritas/global/alongstep/detail/AlongStepNeutralImpl.hh
@@ -36,10 +36,10 @@ struct NoMsc
     }
 
     //! No updates needed to the physical and geometric step lengths
-    CELER_FUNCTION void limit_step(CoreTrackView const&, StepLimit*) const {}
+    CELER_FUNCTION void limit_step(CoreTrackView const&) const {}
 
     //! MSC is never applied
-    CELER_FUNCTION void apply_step(CoreTrackView const&, StepLimit*) const {}
+    CELER_FUNCTION void apply_step(CoreTrackView const&) const {}
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/detail/ElossApplier.hh
+++ b/src/celeritas/global/alongstep/detail/ElossApplier.hh
@@ -79,12 +79,12 @@ CELER_FUNCTION void ElossApplier<EH>::operator()(CoreTrackView const& track)
         {
             // Immediately kill stopped particles with no at rest processes
             sim.status(TrackStatus::killed);
-            sim.force_step_limit(phys.scalars().range_action());
+            sim.post_step_action(phys.scalars().range_action());
         }
         else
         {
             // Particle slowed down to zero: force a discrete interaction
-            sim.force_step_limit(phys.scalars().discrete_action());
+            sim.post_step_action(phys.scalars().discrete_action());
         }
     }
 }

--- a/src/celeritas/global/alongstep/detail/ElossApplier.hh
+++ b/src/celeritas/global/alongstep/detail/ElossApplier.hh
@@ -47,11 +47,12 @@ CELER_FUNCTION void ElossApplier<EH>::operator()(CoreTrackView const& track)
     }
 
     auto sim = track.make_sim_view();
-    StepLimit const& step_limit = sim.step_limit();
+    auto step = sim.step_length();
+    auto post_step_action = sim.post_step_action();
 
     // Calculate energy loss, possibly applying tracking cuts
-    bool apply_cut = (step_limit.action != track.boundary_action());
-    auto deposited = eloss.calc_eloss(track, step_limit.step, apply_cut);
+    bool apply_cut = (post_step_action != track.boundary_action());
+    auto deposited = eloss.calc_eloss(track, step, apply_cut);
     CELER_ASSERT(deposited <= particle.energy());
     CELER_ASSERT(apply_cut || deposited != particle.energy());
 
@@ -72,18 +73,18 @@ CELER_FUNCTION void ElossApplier<EH>::operator()(CoreTrackView const& track)
     if (particle.is_stopped())
     {
         // Particle lost all energy over the step
-        CELER_ASSERT(step_limit.action != track.boundary_action());
+        CELER_ASSERT(post_step_action != track.boundary_action());
         auto const phys = track.make_physics_view();
         if (!phys.has_at_rest())
         {
             // Immediately kill stopped particles with no at rest processes
             sim.status(TrackStatus::killed);
-            sim.step_limit().action = phys.scalars().range_action();
+            sim.force_step_limit(phys.scalars().range_action());
         }
         else
         {
             // Particle slowed down to zero: force a discrete interaction
-            sim.step_limit().action = phys.scalars().discrete_action();
+            sim.force_step_limit(phys.scalars().discrete_action());
         }
     }
 }

--- a/src/celeritas/global/alongstep/detail/FluctELoss.hh
+++ b/src/celeritas/global/alongstep/detail/FluctELoss.hh
@@ -167,7 +167,7 @@ CELER_FUNCTION auto FluctELoss::calc_eloss(CoreTrackView const& track,
 
     CELER_ASSERT(eloss <= particle.energy());
     CELER_ENSURE(eloss != particle.energy() || apply_cut
-                 || track.make_sim_view().step_limit().action
+                 || track.make_sim_view().post_step_action()
                         == phys.scalars().range_action());
     return eloss;
 }

--- a/src/celeritas/global/alongstep/detail/MeanELoss.hh
+++ b/src/celeritas/global/alongstep/detail/MeanELoss.hh
@@ -84,7 +84,7 @@ CELER_FUNCTION auto MeanELoss::calc_eloss(CoreTrackView const& track,
 
     CELER_ENSURE(eloss <= particle.energy());
     CELER_ENSURE(eloss != particle.energy()
-                 || track.make_sim_view().step_limit().action
+                 || track.make_sim_view().post_step_action()
                         == phys.scalars().range_action());
     return eloss;
 }

--- a/src/celeritas/global/alongstep/detail/MscApplier.hh
+++ b/src/celeritas/global/alongstep/detail/MscApplier.hh
@@ -43,8 +43,7 @@ CELER_FUNCTION MscApplier(MH&&)->MscApplier<MH>;
 template<class MH>
 CELER_FUNCTION void MscApplier<MH>::operator()(CoreTrackView const& track)
 {
-    auto sim = track.make_sim_view();
-    if (sim.status() == TrackStatus::killed)
+    if (track.make_sim_view().status() == TrackStatus::killed)
     {
         // Active track killed during propagation: don't apply MSC
         return;
@@ -54,7 +53,7 @@ CELER_FUNCTION void MscApplier<MH>::operator()(CoreTrackView const& track)
     {
         // Scatter the track and transform the "geometrical" step back to
         // "physical" step
-        msc.apply_step(track, &sim.step_limit());
+        msc.apply_step(track);
     }
 }
 

--- a/src/celeritas/global/alongstep/detail/MscStepLimitApplier.hh
+++ b/src/celeritas/global/alongstep/detail/MscStepLimitApplier.hh
@@ -44,12 +44,11 @@ template<class MH>
 CELER_FUNCTION void
 MscStepLimitApplier<MH>::operator()(CoreTrackView const& track)
 {
-    auto sim = track.make_sim_view();
-    if (msc.is_applicable(track, sim.step_limit().step))
+    if (msc.is_applicable(track, track.make_sim_view().step_length()))
     {
         // Apply MSC step limiters and transform "physical" step (with MSC) to
         // "geometrical" step (smooth curve)
-        msc.limit_step(track, &sim.step_limit());
+        msc.limit_step(track);
 
         auto step_view = track.make_physics_step_view();
         CELER_ASSERT(step_view.msc_step().geom_path > 0);

--- a/src/celeritas/global/alongstep/detail/PropagationApplier.hh
+++ b/src/celeritas/global/alongstep/detail/PropagationApplier.hh
@@ -156,7 +156,8 @@ PropagationApplierBaseImpl<MP>::operator()(CoreTrackView const& track)
     {
         // Stopped at a geometry boundary: this is the new step action.
         CELER_ASSERT(p.distance <= sim.step_length());
-        sim.force_step_limit({p.distance, track.boundary_action()});
+        sim.step_length(p.distance);
+        sim.post_step_action(track.boundary_action());
     }
     else if (p.distance < sim.step_length())
     {
@@ -164,7 +165,8 @@ PropagationApplierBaseImpl<MP>::operator()(CoreTrackView const& track)
         // all in the field propagator, and will get bumped a small
         // distance. This primarily occurs with reentrant tracks on a
         // boundary with VecGeom.
-        sim.force_step_limit({p.distance, track.propagation_limit_action()});
+        sim.step_length(p.distance);
+        sim.post_step_action(track.boundary_action());
     }
 }
 

--- a/src/celeritas/global/alongstep/detail/PropagationApplier.hh
+++ b/src/celeritas/global/alongstep/detail/PropagationApplier.hh
@@ -90,14 +90,13 @@ CELER_FUNCTION void
 PropagationApplierBaseImpl<MP>::operator()(CoreTrackView const& track)
 {
     auto sim = track.make_sim_view();
-    StepLimit& step_limit = sim.step_limit();
-    if (step_limit.step == 0)
+    if (sim.step_length() == 0)
     {
         // Track is stopped: no movement or energy loss will happen
         // (could be a stopped positron waiting for annihilation, or a
         // particle waiting to decay?)
         CELER_ASSERT(track.make_particle_view().is_stopped());
-        CELER_ASSERT(step_limit.action
+        CELER_ASSERT(sim.post_step_action()
                      == track.make_physics_view().scalars().discrete_action());
         CELER_ASSERT(track.make_physics_view().has_at_rest());
         return;
@@ -107,7 +106,7 @@ PropagationApplierBaseImpl<MP>::operator()(CoreTrackView const& track)
     Propagation p;
     {
         auto propagate = make_propagator(track);
-        p = propagate(step_limit.step);
+        p = propagate(sim.step_length());
         tracks_can_loop = propagate.tracks_can_loop();
     }
 
@@ -120,21 +119,21 @@ PropagationApplierBaseImpl<MP>::operator()(CoreTrackView const& track)
         // The track is looping, i.e. progressing little over many
         // integration steps in the field propagator (likely a low energy
         // particle in a low density material/strong magnetic field).
-        step_limit.step = p.distance;
+        sim.step_length() = p.distance;
 
         // Kill the track if it's stable and below the threshold energy or
         // above the threshold number of steps allowed while looping.
         auto particle = track.make_particle_view();
-        step_limit.action = [&track, &particle, &sim] {
+        sim.force_step_limit([&track, &particle, &sim] {
             if (particle.is_stable()
                 && sim.is_looping(particle.particle_id(), particle.energy()))
             {
                 return track.abandon_looping_action();
             }
             return track.propagation_limit_action();
-        }();
+        }());
 
-        if (step_limit.action == track.abandon_looping_action())
+        if (sim.post_step_action() == track.abandon_looping_action())
         {
             // TODO: move this branch into a separate post-step kernel.
             // If the track is looping (or if it's a stuck track that was
@@ -156,18 +155,18 @@ PropagationApplierBaseImpl<MP>::operator()(CoreTrackView const& track)
     else if (p.boundary)
     {
         // Stopped at a geometry boundary: this is the new step action.
-        CELER_ASSERT(p.distance <= step_limit.step);
-        step_limit.step = p.distance;
-        step_limit.action = track.boundary_action();
+        CELER_ASSERT(p.distance <= sim.step_length());
+        sim.step_length() = p.distance;
+        sim.force_step_limit(track.boundary_action());
     }
-    else if (p.distance < step_limit.step)
+    else if (p.distance < sim.step_length())
     {
         // Some tracks may get stuck on a boundary and fail to move at
         // all in the field propagator, and will get bumped a small
         // distance. This primarily occurs with reentrant tracks on a
         // boundary with VecGeom.
-        step_limit.step = p.distance;
-        step_limit.action = track.propagation_limit_action();
+        sim.step_length() = p.distance;
+        sim.force_step_limit(track.propagation_limit_action());
     }
 }
 

--- a/src/celeritas/global/alongstep/detail/PropagationApplier.hh
+++ b/src/celeritas/global/alongstep/detail/PropagationApplier.hh
@@ -166,7 +166,7 @@ PropagationApplierBaseImpl<MP>::operator()(CoreTrackView const& track)
         // distance. This primarily occurs with reentrant tracks on a
         // boundary with VecGeom.
         sim.step_length(p.distance);
-        sim.post_step_action(track.boundary_action());
+        sim.post_step_action(track.propagation_limit_action());
     }
 }
 

--- a/src/celeritas/global/alongstep/detail/TimeUpdater.hh
+++ b/src/celeritas/global/alongstep/detail/TimeUpdater.hh
@@ -35,7 +35,7 @@ CELER_FUNCTION void TimeUpdater::operator()(CoreTrackView const& track)
         // For very small energies (< numeric_limits<real_type>::epsilon)
         // the calculated speed can be zero.
         auto sim = track.make_sim_view();
-        real_type delta_time = sim.step_limit().step / speed;
+        real_type delta_time = sim.step_length() / speed;
         sim.add_time(delta_time);
     }
 }

--- a/src/celeritas/global/alongstep/detail/TrackUpdater.hh
+++ b/src/celeritas/global/alongstep/detail/TrackUpdater.hh
@@ -34,19 +34,18 @@ CELER_FUNCTION void TrackUpdater::operator()(CoreTrackView const& track)
     auto sim = track.make_sim_view();
     if (sim.status() != TrackStatus::killed)
     {
-        StepLimit const& step_limit = sim.step_limit();
-        CELER_ASSERT(step_limit.step > 0
+        CELER_ASSERT(sim.step_length() > 0
                      || track.make_particle_view().is_stopped());
-        CELER_ASSERT(step_limit.action);
+        CELER_ASSERT(sim.post_step_action());
         auto phys = track.make_physics_view();
-        if (step_limit.action != phys.scalars().discrete_action())
+        if (sim.post_step_action() != phys.scalars().discrete_action())
         {
             // Reduce remaining mean free paths to travel. The 'discrete
             // action' case is launched separately and resets the
             // interaction MFP itself.
             auto step = track.make_physics_step_view();
             real_type mfp = phys.interaction_mfp()
-                            - step_limit.step * step.macro_xs();
+                            - sim.step_length() * step.macro_xs();
             CELER_ASSERT(mfp > 0);
             phys.interaction_mfp(mfp);
         }

--- a/src/celeritas/global/detail/TrackExecutorImpl.hh
+++ b/src/celeritas/global/detail/TrackExecutorImpl.hh
@@ -40,7 +40,7 @@ struct IsStepActionEqual
 
     CELER_FUNCTION bool operator()(SimTrackView const& sim) const
     {
-        return sim.step_limit().action == this->action;
+        return sim.post_step_action() == this->action;
     }
 };
 

--- a/src/celeritas/phys/detail/DiscreteSelectExecutor.hh
+++ b/src/celeritas/phys/detail/DiscreteSelectExecutor.hh
@@ -38,7 +38,7 @@ CELER_FUNCTION void
 DiscreteSelectExecutor::operator()(celeritas::CoreTrackView const& track)
 {
     CELER_EXPECT(track.make_sim_view().status() == TrackStatus::alive);
-    CELER_EXPECT(track.make_sim_view().step_limit().action
+    CELER_EXPECT(track.make_sim_view().post_step_action()
                  == track.make_physics_view().scalars().discrete_action());
     // Reset the MFP counter, to be resampled if the track survives the
     // interaction

--- a/src/celeritas/phys/detail/DiscreteSelectExecutor.hh
+++ b/src/celeritas/phys/detail/DiscreteSelectExecutor.hh
@@ -56,7 +56,7 @@ DiscreteSelectExecutor::operator()(celeritas::CoreTrackView const& track)
         CELER_ASSERT(action);
         // Save it as the next kernel
         auto sim = track.make_sim_view();
-        sim.force_step_limit(action);
+        sim.post_step_action(action);
     }
 
     CELER_ENSURE(!phys.has_interaction_mfp());

--- a/src/celeritas/phys/detail/PreStepExecutor.hh
+++ b/src/celeritas/phys/detail/PreStepExecutor.hh
@@ -86,7 +86,7 @@ PreStepExecutor::operator()(celeritas::CoreTrackView const& track)
 
     // Initialize along-step action based on particle charge:
     // This should eventually be dependent on region, energy, etc.
-    sim.along_step_action() = [&particle, &scalars = track.core_scalars()] {
+    sim.along_step_action([&particle, &scalars = track.core_scalars()] {
         if (particle.charge() == zero_quantity())
         {
             return scalars.along_step_neutral_action;
@@ -95,7 +95,7 @@ PreStepExecutor::operator()(celeritas::CoreTrackView const& track)
         {
             return scalars.along_step_user_action;
         }
-    }();
+    }());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/SimData.hh
+++ b/src/celeritas/track/SimData.hh
@@ -130,7 +130,7 @@ struct SimStateData
                             //!< [s]
 
     Items<TrackStatus> status;
-    Items<real_type> steps;
+    Items<real_type> step_length;
     Items<ActionId> post_step_action;
     Items<ActionId> along_step_action;
 
@@ -141,7 +141,7 @@ struct SimStateData
     {
         return !track_ids.empty() && !parent_ids.empty() && !event_ids.empty()
                && !num_steps.empty() && !num_looping_steps.empty()
-               && !time.empty() && !status.empty() && !steps.empty()
+               && !time.empty() && !status.empty() && !step_length.empty()
                && !post_step_action.empty() && !along_step_action.empty();
     }
 
@@ -163,7 +163,7 @@ struct SimStateData
         num_looping_steps = other.num_looping_steps;
         time = other.time;
         status = other.status;
-        steps = other.steps;
+        step_length = other.step_length;
         post_step_action = other.post_step_action;
         along_step_action = other.along_step_action;
         return *this;
@@ -195,7 +195,7 @@ void resize(SimStateData<Ownership::value, M>* data, size_type size)
     resize(&data->status, size);
     fill(TrackStatus::inactive, &data->status);
 
-    resize(&data->steps, size);
+    resize(&data->step_length, size);
     resize(&data->post_step_action, size);
     resize(&data->along_step_action, size);
 

--- a/src/celeritas/track/SimData.hh
+++ b/src/celeritas/track/SimData.hh
@@ -98,7 +98,6 @@ struct SimTrackInitializer
     real_type time{0};  //!< Time elapsed in lab frame since start of event [s]
 
     TrackStatus status{TrackStatus::inactive};
-    StepLimit step_limit;
 
     //! True if assigned and valid
     explicit CELER_FUNCTION operator bool() const
@@ -131,8 +130,8 @@ struct SimStateData
                             //!< [s]
 
     Items<TrackStatus> status;
-    // TODO: separate into post-step action, distance
-    Items<StepLimit> step_limit;
+    Items<real_type> steps;
+    Items<ActionId> post_step_action;
     Items<ActionId> along_step_action;
 
     //// METHODS ////
@@ -142,8 +141,8 @@ struct SimStateData
     {
         return !track_ids.empty() && !parent_ids.empty() && !event_ids.empty()
                && !num_steps.empty() && !num_looping_steps.empty()
-               && !time.empty() && !status.empty() && !step_limit.empty()
-               && !along_step_action.empty();
+               && !time.empty() && !status.empty() && !steps.empty()
+               && !post_step_action.empty() && !along_step_action.empty();
     }
 
     //! State size
@@ -164,7 +163,8 @@ struct SimStateData
         num_looping_steps = other.num_looping_steps;
         time = other.time;
         status = other.status;
-        step_limit = other.step_limit;
+        steps = other.steps;
+        post_step_action = other.post_step_action;
         along_step_action = other.along_step_action;
         return *this;
     }
@@ -195,7 +195,8 @@ void resize(SimStateData<Ownership::value, M>* data, size_type size)
     resize(&data->status, size);
     fill(TrackStatus::inactive, &data->status);
 
-    resize(&data->step_limit, size);
+    resize(&data->steps, size);
+    resize(&data->post_step_action, size);
     resize(&data->along_step_action, size);
 
     CELER_ENSURE(*data);

--- a/src/celeritas/track/SimTrackView.hh
+++ b/src/celeritas/track/SimTrackView.hh
@@ -63,9 +63,6 @@ class SimTrackView
     // Reset step limiter to the given limit
     inline CELER_FUNCTION void reset_step_limit(StepLimit const& sl);
 
-    // Limit the step and override if the step is equal
-    inline CELER_FUNCTION void force_step_limit(StepLimit const& sl);
-
     // Limit the step by this distance and action
     inline CELER_FUNCTION bool step_limit(StepLimit const& sl);
 
@@ -150,7 +147,7 @@ CELER_FUNCTION SimTrackView& SimTrackView::operator=(Initializer_t const& other)
     states_.num_looping_steps[track_slot_] = 0;
     states_.time[track_slot_] = other.time;
     states_.status[track_slot_] = other.status;
-    states_.steps[track_slot_] = {};
+    states_.step_length[track_slot_] = {};
     states_.post_step_action[track_slot_] = {};
     states_.along_step_action[track_slot_] = {};
     return *this;
@@ -220,7 +217,7 @@ CELER_FUNCTION void SimTrackView::reset_step_limit(StepLimit const& sl)
     CELER_EXPECT(sl.step >= 0);
     CELER_EXPECT(static_cast<bool>(sl.action)
                  != (sl.step == numeric_limits<real_type>::infinity()));
-    states_.steps[track_slot_] = sl.step;
+    states_.step_length[track_slot_] = sl.step;
     states_.post_step_action[track_slot_] = sl.action;
 }
 
@@ -253,21 +250,6 @@ CELER_FUNCTION void SimTrackView::post_step_action(ActionId action)
 
 //---------------------------------------------------------------------------//
 /*!
- * Forcibly limit the step by this distance and action.
- *
- * If the step limits are the same, the new action overrides. The new step must
- * not be greater than the current step.
- */
-CELER_FUNCTION void SimTrackView::force_step_limit(StepLimit const& sl)
-{
-    CELER_ASSERT(sl.step >= 0 && sl.step <= states_.steps[track_slot_]);
-
-    states_.steps[track_slot_] = sl.step;
-    states_.post_step_action[track_slot_] = sl.action;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Limit the step by this distance and action.
  *
  * If the step limits are the same, the original action is retained.
@@ -278,10 +260,10 @@ CELER_FUNCTION bool SimTrackView::step_limit(StepLimit const& sl)
 {
     CELER_ASSERT(sl.step >= 0);
 
-    bool is_limiting = (sl.step < states_.steps[track_slot_]);
+    bool is_limiting = (sl.step < states_.step_length[track_slot_]);
     if (is_limiting)
     {
-        states_.steps[track_slot_] = sl.step;
+        states_.step_length[track_slot_] = sl.step;
         states_.post_step_action[track_slot_] = sl.action;
     }
     return is_limiting;
@@ -395,7 +377,7 @@ CELER_FUNCTION TrackStatus SimTrackView::status() const
  */
 CELER_FUNCTION real_type SimTrackView::step_length() const
 {
-    return states_.steps[track_slot_];
+    return states_.step_length[track_slot_];
 }
 
 //---------------------------------------------------------------------------//
@@ -405,7 +387,7 @@ CELER_FUNCTION real_type SimTrackView::step_length() const
 CELER_FUNCTION void SimTrackView::step_length(real_type length)
 {
     CELER_EXPECT(length > 0);
-    states_.steps[track_slot_] = length;
+    states_.step_length[track_slot_] = length;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/SimTrackView.hh
+++ b/src/celeritas/track/SimTrackView.hh
@@ -63,9 +63,6 @@ class SimTrackView
     // Reset step limiter to the given limit
     inline CELER_FUNCTION void reset_step_limit(StepLimit const& sl);
 
-    // Force the limiting action to take
-    inline CELER_FUNCTION void force_step_limit(ActionId action);
-
     // Limit the step and override if the step is equal
     inline CELER_FUNCTION void force_step_limit(StepLimit const& sl);
 
@@ -98,11 +95,14 @@ class SimTrackView
     // Limiting step
     CELER_FORCEINLINE_FUNCTION real_type step_length() const;
 
-    // Mutable access to limiting step
-    CELER_FORCEINLINE_FUNCTION real_type& step_length();
+    // Update limiting step
+    CELER_FORCEINLINE_FUNCTION void step_length(real_type length);
 
     // Access post-step action to take
     inline CELER_FUNCTION ActionId post_step_action() const;
+
+    // Force the limiting action to take
+    inline CELER_FUNCTION void post_step_action(ActionId action);
 
     // Access along-step action to take
     inline CELER_FUNCTION ActionId along_step_action() const;
@@ -245,7 +245,7 @@ CELER_FUNCTION void SimTrackView::reset_step_limit()
  * that dispatch to another kernel action before the end of the step without
  * changing the step itself.
  */
-CELER_FUNCTION void SimTrackView::force_step_limit(ActionId action)
+CELER_FUNCTION void SimTrackView::post_step_action(ActionId action)
 {
     CELER_ASSERT(action);
     states_.post_step_action[track_slot_] = action;
@@ -404,9 +404,9 @@ CELER_FUNCTION real_type SimTrackView::step_length() const
 /*!
  * Get mutable access to the current limiting step.
  */
-CELER_FUNCTION real_type& SimTrackView::step_length()
+CELER_FUNCTION void SimTrackView::step_length(real_type length)
 {
-    return states_.steps[track_slot_];
+    states_.steps[track_slot_] = length;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/SimTrackView.hh
+++ b/src/celeritas/track/SimTrackView.hh
@@ -400,10 +400,11 @@ CELER_FUNCTION real_type SimTrackView::step_length() const
 
 //---------------------------------------------------------------------------//
 /*!
- * Get mutable access to the current limiting step.
+ * Update the current limiting step.
  */
 CELER_FUNCTION void SimTrackView::step_length(real_type length)
 {
+    CELER_EXPECT(length > 0);
     states_.steps[track_slot_] = length;
 }
 

--- a/src/celeritas/track/SimTrackView.hh
+++ b/src/celeritas/track/SimTrackView.hh
@@ -107,8 +107,8 @@ class SimTrackView
     // Access along-step action to take
     inline CELER_FUNCTION ActionId along_step_action() const;
 
-    // Mutable access to along-step action to take (TODO: hack
-    inline CELER_FUNCTION ActionId& along_step_action();
+    // Update along-step action to take
+    inline CELER_FUNCTION void along_step_action(ActionId action);
 
     //// PARAMETER DATA ////
 
@@ -234,7 +234,7 @@ CELER_FUNCTION void SimTrackView::reset_step_limit()
     limit.step = numeric_limits<real_type>::infinity();
     limit.action = {};
     this->reset_step_limit(limit);
-    this->along_step_action() = {};
+    this->along_step_action({});
 }
 
 //---------------------------------------------------------------------------//
@@ -307,13 +307,11 @@ CELER_FUNCTION ActionId SimTrackView::along_step_action() const
 
 //---------------------------------------------------------------------------//
 /*!
- * Mutable access to along-step action to take.
- *
- * (TODO: hack)
+ * Update along-step action to take.
  */
-CELER_FUNCTION ActionId& SimTrackView::along_step_action()
+CELER_FUNCTION void SimTrackView::along_step_action(ActionId action)
 {
-    return states_.along_step_action[track_slot_];
+    states_.along_step_action[track_slot_] = action;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/detail/TrackSortUtils.cc
+++ b/src/celeritas/track/detail/TrackSortUtils.cc
@@ -114,12 +114,12 @@ void sort_tracks(HostRef<CoreStateData> const& states, TrackOrder order)
         case TrackOrder::sort_along_step_action:
             return sort_impl(
                 states.track_slots,
-                along_action_comparator{states.sim.along_step_action.data()},
+                action_comparator{states.sim.along_step_action.data()},
                 states.stream_id);
         case TrackOrder::sort_step_limit_action:
             return sort_impl(
                 states.track_slots,
-                step_limit_comparator{states.sim.step_limit.data()},
+                action_comparator{states.sim.post_step_action.data()},
                 states.stream_id);
         default:
             CELER_ASSERT_UNREACHABLE();
@@ -144,14 +144,14 @@ void count_tracks_per_action(
             return count_tracks_per_action_impl(
                 offsets,
                 states.size(),
-                AlongStepActionAccessor{states.sim.along_step_action.data(),
-                                        states.track_slots.data()});
+                ActionAccessor{states.sim.along_step_action.data(),
+                               states.track_slots.data()});
         case TrackOrder::sort_step_limit_action:
             return count_tracks_per_action_impl(
                 offsets,
                 states.size(),
-                StepLimitActionAccessor{states.sim.step_limit.data(),
-                                        states.track_slots.data()});
+                ActionAccessor{states.sim.post_step_action.data(),
+                               states.track_slots.data()});
         default:
             return;
     }

--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -108,14 +108,14 @@ __global__ void tracks_per_action_kernel(DeviceRef<CoreStateData> const states,
             return tracks_per_action_impl(
                 offsets,
                 size,
-                AlongStepActionAccessor{states.sim.along_step_action.data(),
-                                        states.track_slots.data()});
+                ActionAccessor{states.sim.along_step_action.data(),
+                               states.track_slots.data()});
         case TrackOrder::sort_step_limit_action:
             return tracks_per_action_impl(
                 offsets,
                 size,
-                StepLimitActionAccessor{states.sim.step_limit.data(),
-                                        states.track_slots.data()});
+                ActionAccessor{states.sim.post_step_action.data(),
+                               states.track_slots.data()});
         default:
             CELER_ASSERT_UNREACHABLE();
     }
@@ -173,12 +173,12 @@ void sort_tracks(DeviceRef<CoreStateData> const& states, TrackOrder order)
         case TrackOrder::sort_along_step_action:
             return sort_impl(
                 states.track_slots,
-                along_action_comparator{states.sim.along_step_action.data()},
+                action_comparator{states.sim.along_step_action.data()},
                 states.stream_id);
         case TrackOrder::sort_step_limit_action:
             return sort_impl(
                 states.track_slots,
-                step_limit_comparator{states.sim.step_limit.data()},
+                action_comparator{states.sim.post_step_action.data()},
                 states.stream_id);
         default:
             CELER_ASSERT_UNREACHABLE();

--- a/src/celeritas/track/detail/TrackSortUtils.hh
+++ b/src/celeritas/track/detail/TrackSortUtils.hh
@@ -87,17 +87,7 @@ struct alive_predicate
     }
 };
 
-struct step_limit_comparator
-{
-    ObserverPtr<StepLimit const> step_limit_;
-
-    CELER_FUNCTION bool operator()(unsigned int a, unsigned int b) const
-    {
-        return step_limit_.get()[a].action < step_limit_.get()[b].action;
-    }
-};
-
-struct along_action_comparator
+struct action_comparator
 {
     ObserverPtr<ActionId const> action_;
 
@@ -107,25 +97,14 @@ struct along_action_comparator
     }
 };
 
-struct StepLimitActionAccessor
+struct ActionAccessor
 {
-    ObserverPtr<StepLimit const> step_limit_;
+    ObserverPtr<ActionId const> action_;
     ObserverPtr<TrackSlotId::size_type const> track_slots_;
 
     CELER_FUNCTION ActionId operator()(ThreadId tid) const
     {
-        return step_limit_.get()[track_slots_.get()[tid.get()]].action;
-    }
-};
-
-struct AlongStepActionAccessor
-{
-    ObserverPtr<ActionId const> along_step_;
-    ObserverPtr<TrackSlotId::size_type const> track_slots_;
-
-    CELER_FUNCTION ActionId operator()(ThreadId tid) const
-    {
-        return along_step_.get()[track_slots_.get()[tid.get()]];
+        return action_.get()[track_slots_.get()[tid.get()]];
     }
 };
 

--- a/src/celeritas/user/detail/ActionDiagnosticExecutor.hh
+++ b/src/celeritas/user/detail/ActionDiagnosticExecutor.hh
@@ -40,7 +40,7 @@ ActionDiagnosticExecutor::operator()(CoreTrackView const& track)
 
     using BinId = ItemId<size_type>;
 
-    auto action = track.make_sim_view().step_limit().action;
+    auto action = track.make_sim_view().post_step_action();
     CELER_ASSERT(action);
     auto particle = track.make_particle_view().particle_id();
     CELER_ASSERT(particle);

--- a/src/celeritas/user/detail/StepGatherExecutor.hh
+++ b/src/celeritas/user/detail/StepGatherExecutor.hh
@@ -120,9 +120,8 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
             SGL_SET_IF_SELECTED(parent_id, sim.parent_id());
             SGL_SET_IF_SELECTED(track_step_count, sim.num_steps());
 
-            auto const& limit = sim.step_limit();
-            SGL_SET_IF_SELECTED(action_id, limit.action);
-            SGL_SET_IF_SELECTED(step_length, limit.step);
+            SGL_SET_IF_SELECTED(action_id, sim.post_step_action());
+            SGL_SET_IF_SELECTED(step_length, sim.step_length());
         }
     }
 

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -98,10 +98,10 @@ auto AlongStepTestBase::run(Input const& inp, size_type num_tracks) -> RunResult
         result.displacement += distance(geo.pos(), inp.position);
         result.angle += dot_product(geo.dir(), inp.direction);
         result.time += sim.time();
-        result.step += sim.step_limit().step;
+        result.step += sim.step_length();
         result.mfp += inp.phys_mfp - phys.interaction_mfp();
         result.alive += sim.status() == TrackStatus::alive ? 1 : 0;
-        actions[sim.step_limit().action] += 1;
+        actions[sim.post_step_action()] += 1;
     }
 
     real_type norm = 1 / real_type(num_tracks);

--- a/test/celeritas/track/TrackSort.test.cc
+++ b/test/celeritas/track/TrackSort.test.cc
@@ -244,15 +244,15 @@ TEST_F(TestTrackSortActionIdEm3Stepper, host_is_sorted)
     step(make_span(primaries));
 
     auto check_is_sorted = [&step] {
-        auto& step_limit = step.state_ref().sim.step_limit;
+        auto& step_limit_action = step.state_ref().sim.post_step_action;
         auto& track_slots = step.state_ref().track_slots;
         for (celeritas::size_type i = 0; i < track_slots.size() - 1; ++i)
         {
             TrackSlotId tid_current{track_slots[ThreadId{i}]},
                 tid_next{track_slots[ThreadId{i + 1}]};
             ActionId::size_type aid_current{
-                step_limit[tid_current].action.unchecked_get()},
-                aid_next{step_limit[tid_next].action.unchecked_get()};
+                step_limit_action[tid_current].unchecked_get()},
+                aid_next{step_limit_action[tid_next].unchecked_get()};
             ASSERT_LE(aid_current, aid_next)
                 << aid_current << " is larger than " << aid_next;
         }
@@ -289,16 +289,16 @@ TEST_F(TestTrackSortActionIdEm3Stepper, TEST_IF_CELER_DEVICE(device_is_sorted))
         Collection<TrackSlotId::size_type, Ownership::value, MemSpace::host, ThreadId>
             track_slots;
         track_slots = state_ref.track_slots;
-        StateCollection<StepLimit, Ownership::value, MemSpace::host> step_limit;
-        step_limit = state_ref.sim.step_limit;
+        StateCollection<ActionId, Ownership::value, MemSpace::host> step_limit;
+        step_limit = state_ref.sim.post_step_action;
 
         for (celeritas::size_type i = 0; i < track_slots.size() - 1; ++i)
         {
             TrackSlotId tid_current{track_slots[ThreadId{i}]},
                 tid_next{track_slots[ThreadId{i + 1}]};
             ActionId::size_type aid_current{
-                step_limit[tid_current].action.unchecked_get()},
-                aid_next{step_limit[tid_next].action.unchecked_get()};
+                step_limit[tid_current].unchecked_get()},
+                aid_next{step_limit[tid_next].unchecked_get()};
             ASSERT_LE(aid_current, aid_next)
                 << aid_current << " is larger than " << aid_next;
         }


### PR DESCRIPTION
Convert the StepLimit collection in SimStateData to a SoA in preparation for using radix sort as having contiguous ActionId will help with access pattern and is even necessary with thrust/cub. 

The `StepLimit` struct is kept to group return values / functions arguments. 