### PR TITLE
Use radix sort for ordering tracks

### DIFF
--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -70,7 +70,7 @@ reorder_actions_kernel(ObserverPtr<TrackSlotId::size_type const> track_slots,
         tid < size)
     {
         out_actions.get()[tid.get()]
-            = actions.get()[track_slots.get()[tid.get()]].get();
+            = actions.get()[track_slots.get()[tid.get()]].unchecked_get();
     }
 }
 


### PR DESCRIPTION
Update the current implementation of sorting tracks to use radix sort. The goal of the first iteration is to adapt the collections to use Thrust's radix sort implementation which only works on arithmetic types. We need to launch an extra kernel that will follow the thread to track slot indirection and fill an array that can be used as a key to sort the track_slots indirection. This will still be useful if we decide to implement our own radix sort or use cub instead of thrust.  