### PR TITLE
Connect ROOT event writer to accel and reader to celer-sim

### DIFF
--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -109,8 +109,10 @@ else()
 endif()
 if(CELERITAS_USE_ROOT)
   set(CELERG4_WRITE_SD_HITS "true")
+  set(CELERG4_OFFLOAD_FILE "simple-cms.offloaded.root")
 else()
   set(CELERG4_WRITE_SD_HITS "false")
+  set(CELERG4_OFFLOAD_FILE "simple-cms.offloaded.hepmc3")
 endif()
 configure_file(
   "simple-cms-test.inp.json.in"

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -153,7 +153,7 @@ void GlobalSetup::ReadInput(std::string const& filename)
     ui->ApplyCommand("/celer/cuda/defaultStream"
                      + to_string(input_.default_stream));
     ui->ApplyCommand("/celer/outputFile " + input_.output_file);
-    ui->ApplyCommand("/celer/offloadFile " + input_.offload_file);
+    ui->ApplyCommand("/celer/offloadOutputFile " + input_.offload_output_file);
 
     // Execute macro for Geant4 commands (e.g. to set verbosity)
     if (!input_.macro_file.empty())

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -134,9 +134,18 @@ void GlobalSetup::ReadInput(std::string const& filename)
     nlohmann::json::parse(infile).get_to(input_);
     CELER_ASSERT(input_);
 
+    // Input options
+    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
+    {
+        // To allow ORANGE to work for testing purposes, pass the GDML
+        // input filename to Celeritas
+        options_->geometry_file = input_.geometry_file;
+    }
+
+    // Output options
     options_->output_file = input_.output_file;
+    options_->physics_output_file = input_.physics_output_file;
     options_->offload_output_file = input_.offload_output_file;
-    // XXX where are geometry and physics file set?
 
     // Apply Celeritas \c SetupOptions commands
     options_->max_num_tracks = input_.num_track_slots;

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -134,30 +134,26 @@ void GlobalSetup::ReadInput(std::string const& filename)
     nlohmann::json::parse(infile).get_to(input_);
     CELER_ASSERT(input_);
 
+    options_->output_file = input_.output_file;
+    options_->offload_output_file = input_.offload_output_file;
+    // XXX where are geometry and physics file set?
+
     // Apply Celeritas \c SetupOptions commands
-    G4UImanager* ui = G4UImanager::GetUIpointer();
-    CELER_ASSERT(ui);
-    ui->ApplyCommand("/celer/maxNumTracks "
-                     + to_string(input_.num_track_slots));
-    ui->ApplyCommand("/celer/maxNumEvents " + to_string(input_.max_events));
-    ui->ApplyCommand("/celer/maxNumSteps " + to_string(input_.max_steps));
-    ui->ApplyCommand("/celer/maxInitializers "
-                     + to_string(input_.initializer_capacity));
-    ui->ApplyCommand("/celer/secondaryStackFactor "
-                     + to_string(input_.secondary_stack_factor));
-    ui->ApplyCommand("/celer/cuda/stackSize "
-                     + to_string(input_.cuda_stack_size));
-    ui->ApplyCommand("/celer/cuda/heapSize "
-                     + to_string(input_.cuda_heap_size));
-    ui->ApplyCommand("/celer/cuda/sync" + to_string(input_.sync));
-    ui->ApplyCommand("/celer/cuda/defaultStream"
-                     + to_string(input_.default_stream));
-    ui->ApplyCommand("/celer/outputFile " + input_.output_file);
-    ui->ApplyCommand("/celer/offloadOutputFile " + input_.offload_output_file);
+    options_->max_num_tracks = input_.num_track_slots;
+    options_->max_num_events = input_.max_events;
+    options_->max_steps = input_.max_steps;
+    options_->initializer_capacity = input_.initializer_capacity;
+    options_->secondary_stack_factor = input_.secondary_stack_factor;
+    options_->cuda_stack_size = input_.cuda_stack_size;
+    options_->cuda_heap_size = input_.cuda_heap_size;
+    options_->sync = input_.sync;
+    options_->default_stream = input_.default_stream;
 
     // Execute macro for Geant4 commands (e.g. to set verbosity)
     if (!input_.macro_file.empty())
     {
+        G4UImanager* ui = G4UImanager::GetUIpointer();
+        CELER_ASSERT(ui);
         ui->ApplyCommand("/control/execute " + input_.macro_file);
     }
 #else

--- a/app/celer-g4/RunAction.cc
+++ b/app/celer-g4/RunAction.cc
@@ -66,16 +66,7 @@ void RunAction::BeginOfRunAction(G4Run const* run)
         if (init_celeritas_)
         {
             // This worker (or master thread) is responsible for initializing
-            // celeritas
-            if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
-            {
-                // To allow ORANGE to work for testing purposes, pass the GDML
-                // input filename to Celeritas
-                const_cast<SetupOptions&>(*options_).geometry_file
-                    = GlobalSetup::Instance()->GetGeometryFile();
-            }
-
-            // Initialize shared data and setup GPU on all threads
+            // celeritas: initialize shared data and setup GPU on all threads
             CELER_TRY_HANDLE(params_->Initialize(*options_), call_g4exception);
             CELER_ASSERT(*params_);
         }

--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -31,6 +31,8 @@ enum class PhysicsListSelection
 //---------------------------------------------------------------------------//
 /*!
  * Input for a single run.
+ *
+ * \todo Unify names with celer-sim and SetupOptions.
  */
 struct RunInput
 {
@@ -65,10 +67,10 @@ struct RunInput
     FieldDriverOptions field_options;
 
     // IO
-    std::string output_file;  //!< Write JSON diagnostics here
-    std::string offload_output_file;  //!< Write offloaded tracks to
-                                      //!< HepMC3/ROOT
-    std::string macro_file;  //!< Read Geant4 commands
+    std::string output_file;  //!< Save JSON diagnostics
+    std::string physics_output_file;  //!< Save physics data
+    std::string offload_output_file;  //!< Save offloaded tracks to HepMC3/ROOT
+    std::string macro_file;  //!< Load additional Geant4 commands
     int root_buffer_size{128000};
     bool write_sd_hits{false};
     bool strip_gdml_pointers{true};

--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -65,9 +65,10 @@ struct RunInput
     FieldDriverOptions field_options;
 
     // IO
-    std::string output_file;  //!< Path to the JSON diagnostic output file
-    std::string offload_file;  //!< Path to the HepMC3 file of offloaded tracks
-    std::string macro_file;  //!< Path to macro file for Geant4 commands
+    std::string output_file;  //!< Write JSON diagnostics here
+    std::string offload_output_file;  //!< Write offloaded tracks to
+                                      //!< HepMC3/ROOT
+    std::string macro_file;  //!< Read Geant4 commands
     int root_buffer_size{128000};
     bool write_sd_hits{false};
     bool strip_gdml_pointers{true};

--- a/app/celer-g4/RunInputIO.json.cc
+++ b/app/celer-g4/RunInputIO.json.cc
@@ -65,6 +65,7 @@ void from_json(nlohmann::json const& j, RunInput& v)
     RI_LOAD_OPTION(field_options);
 
     RI_LOAD_OPTION(output_file);
+    RI_LOAD_OPTION(physics_output_file);
     RI_LOAD_OPTION(offload_output_file);
     RI_LOAD_OPTION(macro_file);
     RI_LOAD_OPTION(root_buffer_size);
@@ -127,6 +128,8 @@ void to_json(nlohmann::json& j, RunInput const& v)
     RI_SAVE_OPTION(field);
     RI_SAVE_OPTION(field_options);
 
+    RI_SAVE_OPTION(output_file);
+    RI_SAVE_OPTION(physics_output_file);
     RI_SAVE_OPTION(offload_output_file);
     RI_SAVE_OPTION(macro_file);
     RI_SAVE_OPTION(root_buffer_size);

--- a/app/celer-g4/RunInputIO.json.cc
+++ b/app/celer-g4/RunInputIO.json.cc
@@ -65,7 +65,7 @@ void from_json(nlohmann::json const& j, RunInput& v)
     RI_LOAD_OPTION(field_options);
 
     RI_LOAD_OPTION(output_file);
-    RI_LOAD_OPTION(offload_file);
+    RI_LOAD_OPTION(offload_output_file);
     RI_LOAD_OPTION(macro_file);
     RI_LOAD_OPTION(root_buffer_size);
     RI_LOAD_OPTION(write_sd_hits);
@@ -127,7 +127,7 @@ void to_json(nlohmann::json& j, RunInput const& v)
     RI_SAVE_OPTION(field);
     RI_SAVE_OPTION(field_options);
 
-    RI_SAVE_OPTION(offload_file);
+    RI_SAVE_OPTION(offload_output_file);
     RI_SAVE_OPTION(macro_file);
     RI_SAVE_OPTION(root_buffer_size);
     RI_SAVE_OPTION(write_sd_hits);

--- a/app/celer-g4/simple-cms-test.inp.json.in
+++ b/app/celer-g4/simple-cms-test.inp.json.in
@@ -2,7 +2,7 @@
  "geometry_file": "@PROJECT_SOURCE_DIR@/app/data/simple-cms.gdml",
  "event_file": "@CELERG4_EVENTS@",
  "output_file": "simple-cms.out.json",
- "offload_output_file": "simple-cms.offloaded.hepmc3",
+ "offload_output_file": "@CELERG4_OFFLOAD_FILE@",
  "num_track_slots": @CELERG4_MAX_NUM_TRACKS@,
  "max_events": 1024,
  "initializer_capacity": @CELERG4_INIT_CAPACITY@,

--- a/app/celer-g4/simple-cms-test.inp.json.in
+++ b/app/celer-g4/simple-cms-test.inp.json.in
@@ -2,7 +2,7 @@
  "geometry_file": "@PROJECT_SOURCE_DIR@/app/data/simple-cms.gdml",
  "event_file": "@CELERG4_EVENTS@",
  "output_file": "simple-cms.out.json",
- "offload_file": "simple-cms.offloaded.hepmc3",
+ "offload_output_file": "simple-cms.offloaded.hepmc3",
  "num_track_slots": @CELERG4_MAX_NUM_TRACKS@,
  "max_events": 1024,
  "initializer_capacity": @CELERG4_INIT_CAPACITY@,

--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -332,7 +332,7 @@ void Runner::build_transporter_input(RunnerInput const& inp)
 
 //---------------------------------------------------------------------------//
 /*!
- * Read events from a HepMC3 file or build using a primary generator.
+ * Read events from a file or build using a primary generator.
  */
 void Runner::build_events(RunnerInput const& inp)
 {

--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -40,6 +40,7 @@
 #include "celeritas/global/alongstep/AlongStepUniformMscAction.hh"
 #include "celeritas/io/EventReader.hh"
 #include "celeritas/io/ImportData.hh"
+#include "celeritas/io/RootEventReader.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/phys/CutoffParams.hh"
 #include "celeritas/phys/ParticleParams.hh"
@@ -184,8 +185,7 @@ void Runner::build_core_params(RunnerInput const& inp,
     params.output_reg = std::move(outreg);
 
     // Load geometry
-    params.geometry
-        = std::make_shared<GeoParams>(inp.geometry_filename.c_str());
+    params.geometry = std::make_shared<GeoParams>(inp.geometry_filename);
     if (!params.geometry->supports_safety())
     {
         CELER_LOG(warning) << "Geometry contains surfaces that are "
@@ -344,15 +344,20 @@ void Runner::build_events(RunnerInput const& inp)
         events_.resize(1);
     }
 
-    auto append = [&](VecPrimary& event) {
-        if (inp.merge_events)
+    auto read_events = [&](auto&& generate) {
+        auto event = generate();
+        while (!event.empty())
         {
-            events_.front().insert(
-                events_.front().end(), event.begin(), event.end());
-        }
-        else
-        {
-            events_.push_back(event);
+            if (inp.merge_events)
+            {
+                events_.front().insert(
+                    events_.front().end(), event.begin(), event.end());
+            }
+            else
+            {
+                events_.push_back(event);
+            }
+            event = generate();
         }
     };
 
@@ -361,23 +366,17 @@ void Runner::build_events(RunnerInput const& inp)
         std::mt19937 rng;
         auto generate_event = PrimaryGenerator<std::mt19937>::from_options(
             core_params_->particle(), inp.primary_gen_options);
-        auto event = generate_event(rng);
-        while (!event.empty())
-        {
-            append(event);
-            event = generate_event(rng);
-        }
+        read_events([&generate_event, &rng] { return generate_event(rng); });
+    }
+    else if (ends_with(inp.event_filename, ".root"))
+    {
+        read_events(
+            RootEventReader(inp.event_filename, core_params_->particle()));
     }
     else
     {
-        EventReader read_event(inp.hepmc3_filename.c_str(),
-                               core_params_->particle());
-        auto event = read_event();
-        while (!event.empty())
-        {
-            append(event);
-            event = read_event();
-        }
+        // Assume filename is one of the HepMC3-supported extensions
+        read_events(EventReader(inp.event_filename, core_params_->particle()));
     }
 }
 

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -39,7 +39,7 @@ struct RunnerInput
     // Problem definition
     std::string geometry_filename;  //!< Path to GDML file
     std::string physics_filename;  //!< Path to ROOT exported Geant4 data
-    std::string hepmc3_filename;  //!< Path to HepMC3 event data
+    std::string event_filename;  //!< Path to input event data
 
     // Optional setup options for generating primaries programmatically
     PrimaryGeneratorOptions primary_gen_options;
@@ -85,7 +85,7 @@ struct RunnerInput
     explicit operator bool() const
     {
         return !geometry_filename.empty()
-               && (primary_gen_options || !hepmc3_filename.empty())
+               && (primary_gen_options || !event_filename.empty())
                && num_track_slots > 0 && max_steps > 0
                && initializer_capacity > 0 && max_events > 0
                && secondary_stack_factor > 0

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -47,6 +47,8 @@ namespace app
 //---------------------------------------------------------------------------//
 /*!
  * Read options from JSON.
+ *
+ * TODO: for version 1.0, remove deprecated options.
  */
 void from_json(nlohmann::json const& j, RunnerInput& v)
 {
@@ -56,15 +58,27 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
         if (j.contains(#NAME))          \
             j.at(#NAME).get_to(v.NAME); \
     } while (0)
+#define LDIO_LOAD_DEPRECATED(OLD, NEW)                                        \
+    do                                                                        \
+    {                                                                         \
+        if (j.contains(#OLD))                                                 \
+        {                                                                     \
+            CELER_LOG(warning) << "Deprecated option '" << #OLD << "': use '" \
+                               << #NEW << "' instead";                        \
+            j.at(#OLD).get_to(v.NEW);                                         \
+        }                                                                     \
+    } while (0)
 #define LDIO_LOAD_REQUIRED(NAME) j.at(#NAME).get_to(v.NAME)
 
     LDIO_LOAD_OPTION(cuda_heap_size);
     LDIO_LOAD_OPTION(cuda_stack_size);
     LDIO_LOAD_OPTION(environ);
 
+    LDIO_LOAD_DEPRECATED(hepmc3_filename, event_filename);
+
     LDIO_LOAD_REQUIRED(geometry_filename);
     LDIO_LOAD_OPTION(physics_filename);
-    LDIO_LOAD_OPTION(hepmc3_filename);
+    LDIO_LOAD_OPTION(event_filename);
 
     LDIO_LOAD_OPTION(primary_gen_options);
 
@@ -75,11 +89,7 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_OPTION(step_diagnostic);
     LDIO_LOAD_OPTION(step_diagnostic_maxsteps);
 
-    if (j.contains("max_num_tracks"))
-    {
-        CELER_LOG(warning) << "Deprecated option 'max_num_tracks'";
-        j.at("max_num_tracks").get_to(v.num_track_slots);
-    }
+    LDIO_LOAD_DEPRECATED(max_num_tracks, num_track_slots);
 
     LDIO_LOAD_OPTION(seed);
     LDIO_LOAD_OPTION(num_track_slots);
@@ -103,8 +113,8 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
 #undef LDIO_LOAD_OPTION
 #undef LDIO_LOAD_REQUIRED
 
-    CELER_VALIDATE(v.hepmc3_filename.empty() != !v.primary_gen_options,
-                   << "either a HepMC3 filename or options to generate "
+    CELER_VALIDATE(v.event_filename.empty() != !v.primary_gen_options,
+                   << "either a event filename or options to generate "
                       "primaries must be provided (but not both)");
     CELER_VALIDATE(!v.mctruth_filter || !v.mctruth_filename.empty(),
                    << "'mctruth_filter' cannot be specified without providing "
@@ -137,8 +147,8 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
 
     LDIO_SAVE_REQUIRED(geometry_filename);
     LDIO_SAVE_REQUIRED(physics_filename);
-    LDIO_SAVE_OPTION(hepmc3_filename);
-    if (v.hepmc3_filename.empty())
+    LDIO_SAVE_OPTION(event_filename);
+    if (v.event_filename.empty())
     {
         LDIO_SAVE_REQUIRED(primary_gen_options);
     }

--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -13,7 +13,7 @@ from os import environ, path
 from sys import exit, argv, stderr
 
 try:
-    (geometry_filename, hepmc3_filename, rootout_filename) = argv[1:]
+    (geometry_filename, event_filename, rootout_filename) = argv[1:]
 except ValueError:
     print("usage: {} inp.gdml inp.hepmc3 mctruth.root (use '' for no ROOT output)".format(argv[0]))
     exit(1)
@@ -78,7 +78,7 @@ inp = {
     'use_device': use_device,
     'geometry_filename': geometry_filename,
     'physics_filename': physics_filename,
-    'hepmc3_filename': hepmc3_filename,
+    'event_filename': event_filename,
     'mctruth_filename': rootout_filename,
     'seed': 12345,
     'num_track_slots': num_tracks,

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -20,6 +20,8 @@
 #include "corecel/sys/ScopedSignalHandler.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/ext/Convert.geant.hh"
+#include "celeritas/io/EventWriter.hh"
+#include "celeritas/io/RootEventWriter.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"  // IWYU pragma: keep
 

--- a/src/accel/LocalTransporter.hh
+++ b/src/accel/LocalTransporter.hh
@@ -26,7 +26,6 @@ namespace detail
 {
 class HitManager;
 class OffloadWriter;
-class RootEventWriter;
 }  // namespace detail
 
 struct SetupOptions;
@@ -77,7 +76,6 @@ class LocalTransporter
   private:
     using SPHitManger = std::shared_ptr<detail::HitManager>;
     using SPOffloadWriter = std::shared_ptr<detail::OffloadWriter>;
-    using SPRootOffloadWriter = std::shared_ptr<detail::RootEventWriter>;
 
     struct HMFinalizer
     {

--- a/src/celeritas/ext/RootFileManager.cc
+++ b/src/celeritas/ext/RootFileManager.cc
@@ -37,6 +37,15 @@ RootFileManager::RootFileManager(char const* filename)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get the filename of the associated ROOT file.
+ */
+char const* RootFileManager::filename() const
+{
+    return tfile_->GetName();
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Create tree by providing its name and title.
  *
  * It is still possible to simply create a `TTree("name", "title")` in any

--- a/src/celeritas/ext/RootFileManager.hh
+++ b/src/celeritas/ext/RootFileManager.hh
@@ -32,6 +32,9 @@ class RootFileManager
     // Construct with filename
     explicit RootFileManager(char const* filename);
 
+    // Get the ROOT filename
+    char const* filename() const;
+
     // Create tree by passing a name and title
     UPRootTreeWritable make_tree(char const* name, char const* title);
 
@@ -45,16 +48,6 @@ class RootFileManager
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_ROOT
 inline RootFileManager::RootFileManager(char const*)
-{
-    CELER_NOT_CONFIGURED("ROOT");
-}
-
-inline UPRootTreeWritable RootFileManager::make_tree(char const*, char const*)
-{
-    CELER_NOT_CONFIGURED("ROOT");
-}
-
-inline void RootFileManager::write()
 {
     CELER_NOT_CONFIGURED("ROOT");
 }

--- a/src/celeritas/io/EventIOInterface.hh
+++ b/src/celeritas/io/EventIOInterface.hh
@@ -1,0 +1,72 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/io/EventIOInterface.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+
+#include "corecel/Macros.hh"
+
+namespace celeritas
+{
+struct Primary;
+//---------------------------------------------------------------------------//
+/*!
+ * Abstract base class for writing all primaries from an event.
+ */
+class EventWriterInterface
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using VecPrimary = std::vector<Primary>;
+    using argument_type = VecPrimary const&;
+    //!@}
+
+  public:
+    virtual ~EventWriterInterface() = default;
+
+    //! Write all primaries from a single event
+    virtual void operator()(argument_type primaries) = 0;
+
+  protected:
+    //!@{
+    //! Allow construction and assignment only through daughter classes
+    EventWriterInterface() = default;
+    CELER_DEFAULT_COPY_MOVE(EventWriterInterface);
+    //!@}
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Abstract base class for reading all primaries from an event.
+ */
+class EventReaderInterface
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using VecPrimary = std::vector<Primary>;
+    using result_type = VecPrimary;
+    //!@}
+
+  public:
+    virtual ~EventReaderInterface() = default;
+
+    //! Read all primaries from a single event
+    virtual result_type operator()() = 0;
+
+  protected:
+    //!@{
+    //! Allow construction and assignment only through daughter classes
+    EventReaderInterface() = default;
+    CELER_DEFAULT_COPY_MOVE(EventReaderInterface);
+    //!@}
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/io/EventReader.hh
+++ b/src/celeritas/io/EventReader.hh
@@ -16,6 +16,8 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 
+#include "EventIOInterface.hh"
+
 namespace HepMC3
 {
 class Reader;
@@ -35,7 +37,7 @@ struct Primary;
  * until all events have been read. Supported formats are Asciiv3, IO_GenEvent,
  * HEPEVT, and LHEF.
  */
-class EventReader
+class EventReader : public EventReaderInterface
 {
   public:
     //!@{
@@ -52,7 +54,7 @@ class EventReader
     CELER_DELETE_COPY_MOVE(EventReader);
 
     // Read a single event from the event record
-    result_type operator()();
+    result_type operator()() final;
 
   private:
     // Shared standard model particle data

--- a/src/celeritas/io/EventWriter.cc
+++ b/src/celeritas/io/EventWriter.cc
@@ -99,7 +99,7 @@ EventWriter::EventWriter(std::string const& filename,
 /*!
  * Write all primaries from a single event.
  */
-void EventWriter::operator()(argument_type primaries)
+void EventWriter::operator()(VecPrimary const& primaries)
 {
     CELER_EXPECT(!primaries.empty());
 

--- a/src/celeritas/io/EventWriter.hh
+++ b/src/celeritas/io/EventWriter.hh
@@ -9,12 +9,13 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "celeritas/Types.hh"
+
+#include "EventIOInterface.hh"
 
 namespace HepMC3
 {
@@ -25,19 +26,17 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 class ParticleParams;
-struct Primary;
 
 //---------------------------------------------------------------------------//
 /*!
  * Write events using HepMC3.
  */
-class EventWriter
+class EventWriter : public EventWriterInterface
 {
   public:
     //!@{
     //! \name Type aliases
     using SPConstParticles = std::shared_ptr<ParticleParams const>;
-    using argument_type = std::vector<Primary> const&;
     //!@}
 
     //! Output format
@@ -62,7 +61,7 @@ class EventWriter
     CELER_DELETE_COPY_MOVE(EventWriter);
 
     // Write all the primaries from a single event
-    void operator()(argument_type primaries);
+    void operator()(VecPrimary const& primaries) final;
 
   private:
     // Shared standard model particle data

--- a/src/celeritas/io/RootEventReader.hh
+++ b/src/celeritas/io/RootEventReader.hh
@@ -13,6 +13,8 @@
 #include "celeritas/ext/RootUniquePtr.hh"
 #include "celeritas/phys/Primary.hh"
 
+#include "EventIOInterface.hh"
+
 namespace celeritas
 {
 class ParticleParams;
@@ -31,7 +33,7 @@ class ParticleParams;
     }
  * \endcode
  */
-class RootEventReader
+class RootEventReader : public EventReaderInterface
 {
   public:
     //!@{
@@ -47,7 +49,7 @@ class RootEventReader
     CELER_DELETE_COPY_MOVE(RootEventReader);
 
     // Read a single event from the ROOT file
-    result_type operator()();
+    result_type operator()() final;
 
   private:
     //// DATA ////

--- a/src/celeritas/io/RootEventWriter.cc
+++ b/src/celeritas/io/RootEventWriter.cc
@@ -62,7 +62,7 @@ RootEventWriter::RootEventWriter(SPRootFileManager root_file_manager,
 /*!
  * Export primaries to ROOT.
  */
-void RootEventWriter::operator()(Primaries const& primaries)
+void RootEventWriter::operator()(VecPrimary const& primaries)
 {
     CELER_EXPECT(!primaries.empty());
     ScopedRootErrorHandler scoped_root_error;

--- a/src/celeritas/io/RootEventWriter.cc
+++ b/src/celeritas/io/RootEventWriter.cc
@@ -41,10 +41,13 @@ std::array<double, 3> real3_to_array(Real3 const& src)
  */
 RootEventWriter::RootEventWriter(SPRootFileManager root_file_manager,
                                  SPConstParticles params)
-    : tfile_mgr_(root_file_manager)
+    : tfile_mgr_(std::move(root_file_manager))
     , params_(std::move(params))
     , event_id_(static_cast<size_type>(-1))
 {
+    CELER_EXPECT(tfile_mgr_);
+    CELER_EXPECT(params_);
+
     ScopedRootErrorHandler scoped_root_error;
 
     CELER_LOG(info) << "Creating event tree '" << this->tree_name() << "' at "

--- a/src/celeritas/io/RootEventWriter.cc
+++ b/src/celeritas/io/RootEventWriter.cc
@@ -47,6 +47,9 @@ RootEventWriter::RootEventWriter(SPRootFileManager root_file_manager,
 {
     ScopedRootErrorHandler scoped_root_error;
 
+    CELER_LOG(info) << "Creating event tree '" << this->tree_name() << "' at "
+                    << tfile_mgr_->filename();
+
     ttree_ = tfile_mgr_->make_tree(this->tree_name(), this->tree_name());
     ttree_->Branch("event_id", &primary_.event_id);
     ttree_->Branch("particle", &primary_.particle);

--- a/src/celeritas/io/RootEventWriter.hh
+++ b/src/celeritas/io/RootEventWriter.hh
@@ -13,6 +13,8 @@
 #include "celeritas/ext/RootFileManager.hh"
 #include "celeritas/phys/Primary.hh"
 
+#include "EventIOInterface.hh"
+
 namespace celeritas
 {
 class ParticleParams;
@@ -23,12 +25,11 @@ class ParticleParams;
  *
  * One TTree entry represents one primary.
  */
-class RootEventWriter
+class RootEventWriter : public EventWriterInterface
 {
   public:
     //!@{
     //! \name Type aliases
-    using Primaries = std::vector<Primary>;
     using SPConstParticles = std::shared_ptr<ParticleParams const>;
     using SPRootFileManager = std::shared_ptr<RootFileManager>;
     //!@}
@@ -41,7 +42,7 @@ class RootEventWriter
     CELER_DELETE_COPY_MOVE(RootEventWriter);
 
     // Export primaries to ROOT
-    void operator()(Primaries const& primaries);
+    void operator()(VecPrimary const& primaries);
 
   private:
     //// DATA ////
@@ -82,7 +83,7 @@ inline RootEventWriter::RootEventWriter(SPRootFileManager, SPConstParticles)
     CELER_NOT_CONFIGURED("ROOT");
 }
 
-inline void RootEventWriter::operator()(Primaries const&)
+inline void RootEventWriter::operator()(VecPrimary const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/phys/PrimaryGenerator.hh
+++ b/src/celeritas/phys/PrimaryGenerator.hh
@@ -34,6 +34,9 @@ namespace celeritas
  * distributions. If more than one PDG number is specified, an equal number of
  * each particle type will be produced. Each \c operator() call will return a
  * single event until \c num_events events have been generated.
+ *
+ * \todo Hardcode engine to mt19937 and inherit from EventReaderInterface (or
+ * even change that name).
  */
 template<class Engine>
 class PrimaryGenerator

--- a/test/celeritas/io/EventIO.test.cc
+++ b/test/celeritas/io/EventIO.test.cc
@@ -63,7 +63,7 @@ TEST_P(EventIOTest, variety_rwr)
     EventReader read_event(out_filename, this->particles());
 
     // Read events from the event record
-    auto result = this->read_all(std::ref(read_event));
+    auto result = this->read_all(read_event);
     if (ext == "hepevt")
     {
         GTEST_SKIP() << "HEPEVT format sorts primaries by PDG";
@@ -115,7 +115,7 @@ TEST_P(EventIOTest, no_vertex_rwr)
 
     // Read it in and check
     EventReader read_event(out_filename, this->particles());
-    auto result = this->read_all(std::ref(read_event));
+    auto result = this->read_all(read_event);
 
     // clang-format off
     static int const expected_pdg[] = {22, 22, 22, 22, 22, 22, 22, 22, 22, 22,
@@ -164,20 +164,20 @@ TEST_P(EventIOTest, write_read)
     // Write events
     {
         EventWriter write_event(filename, this->particles());
-        this->write_test_event(std::ref(write_event));
+        this->write_test_event(write_event);
     }
 
     EventReader read_event(filename, this->particles());
     if (ext == "hepevt")
     {
         // Read events but don't check
-        auto result = this->read_all(std::ref(read_event));
+        auto result = this->read_all(read_event);
 
         GTEST_SKIP() << "HEPEVT results are nondeterministic";
     }
     else
     {
-        this->read_check_test_event(std::ref(read_event));
+        this->read_check_test_event(read_event);
     }
 }
 

--- a/test/celeritas/io/EventIOTestBase.cc
+++ b/test/celeritas/io/EventIOTestBase.cc
@@ -93,7 +93,7 @@ void EventIOTestBase::SetUp()
 /*!
  * Read all primaries from a file.
  */
-auto EventIOTestBase::read_all(ReadFunc read_event) const -> ReadAllResult
+auto EventIOTestBase::read_all(Reader& read_event) const -> ReadAllResult
 {
     ReadAllResult result;
     VecPrimary primaries;
@@ -120,7 +120,7 @@ auto EventIOTestBase::read_all(ReadFunc read_event) const -> ReadAllResult
 /*!
  * Write several events.
  */
-void EventIOTestBase::write_test_event(WriteFunc write_event) const
+void EventIOTestBase::write_test_event(Writer& write_event) const
 {
     std::vector<Primary> primaries = [&particles = *this->particles_] {
         auto proton_id = particles.find(pdg::proton());
@@ -178,9 +178,9 @@ void EventIOTestBase::write_test_event(WriteFunc write_event) const
 /*!
  * Read and check the test primaries from a file.
  */
-void EventIOTestBase::read_check_test_event(ReadFunc read_event) const
+void EventIOTestBase::read_check_test_event(Reader& read_event) const
 {
-    auto result = this->read_all(std::move(read_event));
+    auto result = this->read_all(read_event);
 
     // clang-format off
     static int const expected_pdg[] = {22, 2212, 22, 2212, 22, 2212, 22, 2212,

--- a/test/celeritas/io/EventIOTestBase.hh
+++ b/test/celeritas/io/EventIOTestBase.hh
@@ -9,6 +9,7 @@
 
 #include <functional>
 
+#include "celeritas/io/EventIOInterface.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/Primary.hh"
 
@@ -32,8 +33,8 @@ class EventIOTestBase : public Test
     //!@{
     //! \name Type aliases
     using VecPrimary = std::vector<Primary>;
-    using ReadFunc = std::function<VecPrimary()>;
-    using WriteFunc = std::function<void(VecPrimary const&)>;
+    using Reader = EventReaderInterface;
+    using Writer = EventWriterInterface;
     using SPConstParticles = std::shared_ptr<ParticleParams const>;
     //!@}
 
@@ -55,12 +56,12 @@ class EventIOTestBase : public Test
     void SetUp() override;
 
     // Read all primaries from a file
-    ReadAllResult read_all(ReadFunc read_event) const;
+    ReadAllResult read_all(Reader& read_event) const;
 
     // Write test primaries to a file
-    void write_test_event(WriteFunc write_event) const;
+    void write_test_event(Writer& write_event) const;
     // Read and check the test primaries to a file
-    void read_check_test_event(ReadFunc read_event) const;
+    void read_check_test_event(Reader& read_event) const;
 
     // Access particles
     SPConstParticles const& particles() const { return particles_; }

--- a/test/celeritas/io/RootEventIO.test.cc
+++ b/test/celeritas/io/RootEventIO.test.cc
@@ -32,8 +32,8 @@ TEST_F(EventIOTest, write_read)
         this->write_test_event(std::ref(write_event));
     }
 
-    RootEventReader read_event(filename, this->particles());
-    this->read_check_test_event(std::ref(read_event));
+    RootEventReader reader(filename, this->particles());
+    this->read_check_test_event(reader);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/io/RootEventIO.test.cc
+++ b/test/celeritas/io/RootEventIO.test.cc
@@ -17,13 +17,13 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 
-class EventIOTest : public EventIOTestBase
+class RootEventIOTest : public EventIOTestBase
 {
 };
 
-TEST_F(EventIOTest, write_read)
+TEST_F(RootEventIOTest, write_read)
 {
-    std::string filename = this->make_unique_filename(std::string{".root"});
+    std::string filename = this->make_unique_filename(".root");
 
     // Write events
     {


### PR DESCRIPTION
- Add the ability to offload to ROOT from accel
- Fix the offload keyword and a Geant4 integer overflow problem in celer-g4
- Add the ability to generate events from a .root file in celer-sim