### PR TITLE
Define CELER_ASSUME for simpler always-on compiler assumptions

### DIFF
--- a/src/corecel/Assert.cc
+++ b/src/corecel/Assert.cc
@@ -117,6 +117,8 @@ char const* to_cstring(DebugErrorType which)
             return "feature is not yet implemented";
         case DebugErrorType::postcondition:
             return "postcondition failed";
+        case DebugErrorType::assumption:
+            return "assumption failed";
     }
     return "";
 }

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -15,6 +15,9 @@
 
 #include "celeritas_config.h"
 
+//---------------------------------------------------------------------------//
+// MACROS
+//---------------------------------------------------------------------------//
 /*!
  * \def CELER_FUNCTION
  *
@@ -92,34 +95,15 @@
  * CELER_ASSERT_UNREACHABLE() defined in base/Assert.hh should be used instead
  * (to provide a more detailed error message in case the point *is* reached).
  */
-/*!
- * \def CELER_ASSUME
- *
- * Add an always-on compiler assumption about the input data. This should
- * be used very rarely, and perhaps in addition to a CELER_EXPECT macro that
- * makes a similar assertion. Sometimes informing the compiler of an assumption
- * (such as the maximum range of an integer variable) can reduce code bloat and
- * silence odd warnings.
- */
 #if (!defined(__CUDA_ARCH__) && (defined(__clang__) || defined(__GNUC__))) \
     || defined(__NVCOMPILER)                                               \
     || (defined(__CUDA_ARCH__) && CUDART_VERSION >= 11030)                 \
     || defined(__HIP_DEVICE_COMPILE__)
 #    define CELER_UNREACHABLE __builtin_unreachable()
-#    define CELER_ASSUME(COND)                 \
-        do                                     \
-        {                                      \
-            if (__builtin_expect(!!(COND), 0)) \
-            {                                  \
-                __builtin_unreachable();       \
-            }                                  \
-        } while (0)
 #elif defined(_MSC_VER)
 #    define CELER_UNREACHABLE __assume(false)
-#    define CELER_ASSUME(COND) __assume(COND)
 #else
 #    define CELER_UNREACHABLE
-#    define CELER_ASSUME(COND) (void)sizeof(COND)
 #endif
 
 /*!
@@ -240,3 +224,5 @@
     CLS& operator=(CLS const&) = delete; \
     CLS(CLS&&) = delete;                 \
     CLS& operator=(CLS&&) = delete
+
+//---------------------------------------------------------------------------//

--- a/src/orange/surf/VariantSurface.cc
+++ b/src/orange/surf/VariantSurface.cc
@@ -27,10 +27,7 @@ struct VariantTransformDispatcher
     //! Apply a translation
     VariantSurface operator()(Translation const& left) const
     {
-        if (right.valueless_by_exception())
-        {
-            CELER_ASSERT_UNREACHABLE();
-        }
+        CELER_ASSUME(!right.valueless_by_exception());
         return std::visit(
             return_as<VariantSurface>(detail::SurfaceTranslator{left}), right);
     }
@@ -38,10 +35,7 @@ struct VariantTransformDispatcher
     //! Apply a transformation
     VariantSurface operator()(Transformation const& left) const
     {
-        if (right.valueless_by_exception())
-        {
-            CELER_ASSERT_UNREACHABLE();
-        }
+        CELER_ASSUME(!right.valueless_by_exception());
         return std::visit(
             return_as<VariantSurface>(detail::SurfaceTransformer{left}), right);
     }
@@ -57,10 +51,7 @@ struct VariantTransformDispatcher
 [[nodiscard]] VariantSurface apply_transform(VariantTransform const& transform,
                                              VariantSurface const& surface)
 {
-    if (transform.valueless_by_exception())
-    {
-        CELER_ASSERT_UNREACHABLE();
-    }
+    CELER_ASSUME(!transform.valueless_by_exception());
     return std::visit(VariantTransformDispatcher{surface}, transform);
 }
 

--- a/src/orange/transform/VariantTransform.cc
+++ b/src/orange/transform/VariantTransform.cc
@@ -27,10 +27,7 @@ struct VariantTransformDispatcher
     //! Apply a translation
     VariantTransform operator()(Translation const& left) const
     {
-        if (right.valueless_by_exception())
-        {
-            CELER_ASSERT_UNREACHABLE();
-        }
+        CELER_ASSUME(!right.valueless_by_exception());
         return std::visit(
             return_as<VariantTransform>(detail::TransformTranslator{left}),
             right);
@@ -39,10 +36,7 @@ struct VariantTransformDispatcher
     //! Apply a transformation
     VariantTransform operator()(Transformation const& left) const
     {
-        if (right.valueless_by_exception())
-        {
-            CELER_ASSERT_UNREACHABLE();
-        }
+        CELER_ASSUME(!right.valueless_by_exception());
         return std::visit(
             return_as<VariantTransform>(detail::TransformTransformer{left}),
             right);
@@ -71,10 +65,7 @@ struct VariantTransformDispatcher
 [[nodiscard]] VariantTransform
 apply_transform(VariantTransform const& left, VariantTransform const& right)
 {
-    if (left.valueless_by_exception())
-    {
-        CELER_ASSERT_UNREACHABLE();
-    }
+    CELER_ASSUME(!left.valueless_by_exception());
     return std::visit(VariantTransformDispatcher{right}, left);
 }
 


### PR DESCRIPTION
This is a combination of an assertion and a compiler optimization (which remains enabled during optimized code). It's meant as an alternative to `CELER_ASSERT_UNREACHABLE()` that can help with bounds checking and other edge cases. The use case implemented in the variant dispatchers (previously with `CELER_ASSERT_UNREACHABLE`) reduces the object code size of `VariantTransform.o` (with `-O2` and no debug assertions) by 10% by avoiding the jump to exception handling code and the code itself:
```diff
$ diff -u VariantTransform.orig.s VariantTransform.s
--- VariantTransform.orig.s	2023-08-24 20:38:55
+++ VariantTransform.s	2023-08-24 20:38:29
@@ -12,14 +12,10 @@
 	.cfi_def_cfa w29, 16
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
-	str	x1, [sp]
-	ldr	w10, [x0, #96]
-	cmn	w10, #1
-	b.eq	LBB0_2
-; %bb.1:
 	mov	x9, x0
+	ldr	w10, [x0, #96]
 	mov	x11, sp
-	str	x11, [sp, #8]
+	stp	x1, x11, [sp]
 Lloh0:
 	adrp	x11, l___const._ZNSt3__116__variant_detail12__visitation6__base11__visit_altB6v15006INS1_9__variant15__value_visitorIN9celeritas12_GLOBAL__N_126VariantTransformDispatcherEEEJRKNS0_6__implIJNS_9monostateENS6_11TranslationENS6_14TransformationEEEEEEEDcOT_DpOT0_.__fmatrix@PAGE
 Lloh1:
@@ -31,55 +27,9 @@
 	ldp	x29, x30, [sp, #16]             ; 16-byte Folded Reload
 	add	sp, sp, #32
 	ret
-LBB0_2:
-	bl	std::__1::__throw_bad_variant_access[abi:v15006]()
 	.loh AdrpAdd	Lloh0, Lloh1
 	.cfi_endproc
                                         ; -- End function
-	.private_extern	std::__1::__throw_bad_variant_access[abi:v15006]() ; -- Begin function _ZNSt3__126__throw_bad_variant_accessB6v15006Ev
-	.globl	std::__1::__throw_bad_variant_access[abi:v15006]()
-	.weak_def_can_be_hidden	std::__1::__throw_bad_variant_access[abi:v15006]()
-	.p2align	2
-std::__1::__throw_bad_variant_access[abi:v15006](): ; @_ZNSt3__126__throw_bad_variant_accessB6v15006Ev
-	.cfi_startproc
-; %bb.0:
-	stp	x29, x30, [sp, #-16]!           ; 16-byte Folded Spill
-	.cfi_def_cfa_offset 16
-	mov	x29, sp
-	.cfi_def_cfa w29, 16
-	.cfi_offset w30, -8
-	.cfi_offset w29, -16
-	mov	w0, #8
-	bl	___cxa_allocate_exception
-Lloh2:
-	adrp	x8, vtable for std::bad_variant_access@GOTPAGE
-Lloh3:
-	ldr	x8, [x8, vtable for std::bad_variant_access@GOTPAGEOFF]
-	add	x8, x8, #16
-	str	x8, [x0]
-Lloh4:
-	adrp	x1, typeinfo for std::bad_variant_access@GOTPAGE
-Lloh5:
-	ldr	x1, [x1, typeinfo for std::bad_variant_access@GOTPAGEOFF]
-Lloh6:
-	adrp	x2, std::bad_variant_access::~bad_variant_access()@GOTPAGE
-Lloh7:
-	ldr	x2, [x2, std::bad_variant_access::~bad_variant_access()@GOTPAGEOFF]
-	bl	___cxa_throw
-	.loh AdrpLdrGot	Lloh6, Lloh7
-	.loh AdrpLdrGot	Lloh4, Lloh5
-	.loh AdrpLdrGot	Lloh2, Lloh3
-	.cfi_endproc
-                                        ; -- End function
-	.globl	std::bad_variant_access::~bad_variant_access()  ; -- Begin function _ZNSt18bad_variant_accessD1Ev
-	.weak_def_can_be_hidden	std::bad_variant_access::~bad_variant_access()
-	.p2align	2
-std::bad_variant_access::~bad_variant_access():         ; @_ZNSt18bad_variant_accessD1Ev
-	.cfi_startproc
-; %bb.0:
-	b	std::exception::~exception()
-	.cfi_endproc
-                                        ; -- End function
 	.p2align	2                               ; -- Begin function _ZNSt3__116__variant_detail12__visitation6__base12__dispatcherIJLm0EEE10__dispatchB6v15006IONS1_9__variant15__value_visitorIN9celeritas12_GLOBAL__N_126VariantTransformDispatcherEEEJRKNS0_6__baseILNS0_6_TraitE0EJNS_9monostateENS8_11TranslationENS8_14TransformationEEEEEEEDcT_DpT0_
 decltype(auto) std::__1::__variant_detail::__visitation::__base::__dispatcher<0ul>::__dispatch[abi:v15006]<std::__1::__variant_detail::__visitation::__variant::__value_visitor<celeritas::(anonymous namespace)::VariantTransformDispatcher>&&, std::__1::__variant_detail::__base<(std::__1::__variant_detail::_Trait)0, std::__1::monostate, celeritas::Translation, celeritas::Transformation> const&>(std::__1::__variant_detail::__visitation::__variant::__value_visitor<celeritas::(anonymous namespace)::VariantTransformDispatcher>&&, std::__1::__variant_detail::__base<(std::__1::__variant_detail::_Trait)0, std::__1::monostate, celeritas::Translation, celeritas::Transformation> const&): ; @_ZNSt3__116__variant_detail12__visitation6__base12__dispatcherIJLm0EEE10__dispatchB6v15006IONS1_9__variant15__value_visitorIN9celeritas12_GLOBAL__N_126VariantTransformDispatcherEEEJRKNS0_6__baseILNS0_6_TraitE0EJNS_9monostateENS8_11TranslationENS8_14TransformationEEEEEEEDcT_DpT0_
 	.cfi_startproc
```