### PR TITLE
Accelerate ORANGE boundary crossing with BIH

### DIFF
--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -186,7 +186,7 @@ calc_intersection(BoundingBox<T> const& a, BoundingBox<T> const& b)
  * Infinite values are unchanged.
  */
 template<class T, class U>
-inline constexpr BoundingBox<T> calc_bumped(BoundingBox<U> const& bbox)
+inline BoundingBox<T> calc_bumped(BoundingBox<U> const& bbox)
 {
     CELER_EXPECT(bbox);
 

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -178,4 +178,31 @@ calc_intersection(BoundingBox<T> const& a, BoundingBox<T> const& b)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Convert bbox with U type values to a bumped bbox with T type values.
+ *
+ * Each U lower value is bumped to the greatest T value less than the U value.
+ * Each U upper value is bumped to the lowest T value greater than the U value.
+ * Infinite values are unchanged.
+ */
+template<class T, class U>
+inline constexpr BoundingBox<T> calc_bumped(BoundingBox<U> const& bbox)
+{
+    CELER_EXPECT(bbox);
+
+    Array<T, 3> lower;
+    Array<T, 3> upper;
+
+    for (auto ax : range(to_int(Axis::size_)))
+    {
+        lower[ax] = std::nextafter(static_cast<T>(bbox.lower()[ax]),
+                                   -numeric_limits<T>::infinity());
+        upper[ax] = std::nextafter(static_cast<T>(bbox.upper()[ax]),
+                                   numeric_limits<T>::infinity());
+    }
+
+    return BoundingBox<T>::from_unchecked(lower, upper);
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -21,6 +21,7 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/Ref.hh"
 #include "corecel/math/Algorithms.hh"
+#include "orange/BoundingBoxUtils.hh"
 #include "orange/construct/OrangeInput.hh"
 #include "orange/surf/SurfaceAction.hh"
 #include "orange/surf/Surfaces.hh"
@@ -131,26 +132,6 @@ struct NumIntersectionGetter
 };
 
 //---------------------------------------------------------------------------//
-//! Create a FastBBox from a BBox
-celeritas::FastBBox make_fast_bbox(celeritas::BBox bbox)
-{
-    if (!bbox)
-    {
-        return FastBBox();
-    }
-
-    using Real3 = celeritas::Array<celeritas::fast_real_type, 3>;
-    Real3 lower, upper;
-    for (auto axis : range(celeritas::Axis::size_))
-    {
-        auto ax = celeritas::to_int(axis);
-        lower[ax] = bbox.lower()[ax];
-        upper[ax] = bbox.upper()[ax];
-    }
-    return {lower, upper};
-}
-
-//---------------------------------------------------------------------------//
 }  // namespace
 
 //---------------------------------------------------------------------------//
@@ -191,7 +172,8 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
         // Store the bbox or an infinite bbox placeholder
         if (inp.volumes[i].bbox)
         {
-            bboxes.push_back(make_fast_bbox(inp.volumes[i].bbox));
+            bboxes.push_back(
+                calc_bumped<fast_real_type, real_type>(inp.volumes[i].bbox));
         }
         else
         {

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -172,8 +172,7 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
         // Store the bbox or an infinite bbox placeholder
         if (inp.volumes[i].bbox)
         {
-            bboxes.push_back(
-                calc_bumped<fast_real_type, real_type>(inp.volumes[i].bbox));
+            bboxes.push_back(calc_bumped<fast_real_type>(inp.volumes[i].bbox));
         }
         else
         {

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -205,29 +205,46 @@ SimpleUnitTracker::cross_boundary(LocalState const& state) const
     detail::SenseCalculator calc_senses(
         this->make_local_surfaces(), state.pos, state.temp_sense);
 
-    // Loop over all connected surfaces (TODO: intersect with BVH)
-    for (LocalVolumeId volid : this->get_neighbors(state.surface.id()))
-    {
-        if (volid == state.volume)
+    VolumeView* temp_vv;
+    detail::OnFace temp_face;
+    auto is_inside = [this, &state, &calc_senses, &temp_face, &temp_vv](
+                         LocalVolumeId const& id) -> bool {
+        if (id == state.volume)
         {
             // Cannot cross surface into the same volume
-            continue;
+            return false;
         }
-        VolumeView vol = this->make_local_volume(volid);
 
-        // Calculate the local senses and face
+        VolumeView vol = this->make_local_volume(id);
         auto logic_state
             = calc_senses(vol, detail::find_face(vol, state.surface));
 
-        // Evaluate whether the senses are "inside" the volume
-        if (!detail::LogicEvaluator(vol.logic())(logic_state.senses))
-        {
-            // Not inside the volume
-            continue;
-        }
+        temp_vv = &vol;
+        temp_face = logic_state.face;
+        return detail::LogicEvaluator(vol.logic())(logic_state.senses);
+    };
 
-        // Found the volume! Convert the face to a surface ID and return
-        return {volid, get_surface(vol, logic_state.face)};
+    auto neighbors = this->get_neighbors(state.surface.id());
+
+    // If this surface has 2 neighbors or fewer (excluding the current cell),
+    // use linear search to check neighbors. Otherwise, traverse the BIH tree.
+    if (neighbors.size() < 3)
+    {
+        for (LocalVolumeId id : neighbors)
+        {
+            if (is_inside(id))
+            {
+                return {id, get_surface(*temp_vv, temp_face)};
+            }
+        }
+    }
+    else
+    {
+        LocalVolumeId id = bih_point_in_vol_(state.pos, is_inside);
+        if (id)
+        {
+            return {id, get_surface(*temp_vv, temp_face)};
+        }
     }
 
     return {unit_record_.background, state.surface};

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -1,5 +1,3 @@
-
-
 //----------------------------------*-C++-*----------------------------------//
 // Copyright 2021-2023 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
@@ -177,17 +175,17 @@ TEST_F(BoundingBoxUtilsTest, bbox_intersection)
 
 TEST_F(BoundingBoxUtilsTest, bumped)
 {
-    auto inf_real = std::numeric_limits<real_type>::infinity();
-    auto inf_fast_real = std::numeric_limits<fast_real_type>::infinity();
+    auto inf_double = std::numeric_limits<double>::infinity();
+    auto inf_float = std::numeric_limits<float>::infinity();
 
     double long_number = 0.11223344556677;
 
-    BBox unbumped = {{-inf_real, 0, -100}, {0, long_number, inf_real}};
+    BBox unbumped = {{-inf_double, 0, -100}, {0, long_number, inf_double}};
 
-    auto bumped = calc_bumped<fast_real_type, real_type>(unbumped);
+    auto bumped = calc_bumped<float>(unbumped);
 
     // Test lower corner
-    EXPECT_EQ(-inf_fast_real, bumped.lower()[0]);
+    EXPECT_EQ(-inf_float, bumped.lower()[0]);
 
     EXPECT_SOFT_EQ(0, bumped.lower()[1]);
     EXPECT_TRUE(bumped.lower()[1] < 0);
@@ -203,12 +201,12 @@ TEST_F(BoundingBoxUtilsTest, bumped)
     EXPECT_SOFT_EQ(long_number, bumped.upper()[1]);
     EXPECT_TRUE(bumped.upper()[1] > long_number);
 
-    EXPECT_EQ(inf_fast_real, bumped.upper()[2]);
+    EXPECT_EQ(inf_float, bumped.upper()[2]);
 
     // Test the bounds are inside
-    EXPECT_TRUE(is_inside(bumped, Array<real_type, 3>{-inf_real, 0, -100}));
+    EXPECT_TRUE(is_inside(bumped, Array<double, 3>{-inf_double, 0, -100}));
     EXPECT_TRUE(
-        is_inside(bumped, Array<real_type, 3>{0, long_number, inf_real}));
+        is_inside(bumped, Array<double, 3>{0, long_number, inf_double}));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -1,3 +1,5 @@
+
+
 //----------------------------------*-C++-*----------------------------------//
 // Copyright 2021-2023 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
@@ -171,6 +173,42 @@ TEST_F(BoundingBoxUtilsTest, bbox_intersection)
                                        BBox{{-inf, 3, -inf}, {inf, 10, inf}});
         EXPECT_FALSE(dibox);
     }
+}
+
+TEST_F(BoundingBoxUtilsTest, bumped)
+{
+    auto inf_real = std::numeric_limits<real_type>::infinity();
+    auto inf_fast_real = std::numeric_limits<fast_real_type>::infinity();
+
+    double long_number = 0.11223344556677;
+
+    BBox unbumped = {{-inf_real, 0, -100}, {0, long_number, inf_real}};
+
+    auto bumped = calc_bumped<fast_real_type, real_type>(unbumped);
+
+    // Test lower corner
+    EXPECT_EQ(-inf_fast_real, bumped.lower()[0]);
+
+    EXPECT_SOFT_EQ(0, bumped.lower()[1]);
+    EXPECT_TRUE(bumped.lower()[1] < 0);
+
+    EXPECT_SOFT_EQ(-100, bumped.lower()[2]);
+    EXPECT_TRUE(bumped.lower()[2] < -100);
+
+    // Test upper corner
+
+    EXPECT_SOFT_EQ(0, bumped.upper()[0]);
+    EXPECT_TRUE(bumped.upper()[0] > 0);
+
+    EXPECT_SOFT_EQ(long_number, bumped.upper()[1]);
+    EXPECT_TRUE(bumped.upper()[1] > long_number);
+
+    EXPECT_EQ(inf_fast_real, bumped.upper()[2]);
+
+    // Test the bounds are inside
+    EXPECT_TRUE(is_inside(bumped, Array<real_type, 3>{-inf_real, 0, -100}));
+    EXPECT_TRUE(
+        is_inside(bumped, Array<real_type, 3>{0, long_number, inf_real}));
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This PR modifies `SimpleUnitTracker::cross_boundary` to use the bounding interval hierarchy (BIH) when there are more than 2 neighbor cells to search (excluding the current cell). With this PR, bumped bounding boxes become strictly necessary for tracking. Likewise, a `calc_bumped` function has been added to `BoundingBoxUtils` to perform this bump prior to constructing the BIH.