### PR TITLE
Fix multi-level ORANGE direction change

### DIFF
--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -666,6 +666,8 @@ CELER_FUNCTION void OrangeTrackView::cross_boundary()
  * the boundary, but changing direction so that it goes from pointing outward
  * to inward (or vice versa) will mean that \c cross_boundary will be a
  * null-op.
+ *
+ * TODO: This needs to be updated to handle reflections through levels
  */
 CELER_FUNCTION void OrangeTrackView::set_dir(Real3 const& newdir)
 {
@@ -694,7 +696,11 @@ CELER_FUNCTION void OrangeTrackView::set_dir(Real3 const& newdir)
     }
 
     // Complete direction setting
-    lsa.dir() = newdir;
+    for (auto levelid : range(this->level() + 1))
+    {
+        auto lsa = this->make_lsa(levelid);
+        lsa.dir() = newdir;
+    }
 
     this->clear_next_step();
 }

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -139,7 +139,7 @@ struct OrangeInput
 
     // TODO: Calculate automatically in Shift by traversing the parent/daughter
     // tree
-    size_type max_level = 3;
+    size_type max_level = 4;
 
     // TODO: array of universe types and universe ID -> offset
     // or maybe std::variant when we require C++17

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -7,10 +7,12 @@
 //---------------------------------------------------------------------------//
 #include "orange/OrangeParams.hh"
 #include "orange/OrangeTrackView.hh"
+#include "orange/Types.hh"
 #include "orange/construct/OrangeInput.hh"
 #include "celeritas/Constants.hh"
 
 #include "OrangeGeoTestBase.hh"
+#include "TestMacros.hh"
 #include "celeritas_test.hh"
 
 using celeritas::constants::sqrt_two;
@@ -601,6 +603,22 @@ TEST_F(UniversesTest, move_internal_multiple_universes)
     geo.move_internal(0.1);
     next = geo.find_next_step();
     EXPECT_SOFT_EQ(0.9, next.distance);
+}
+
+// Set direction in a daughter universe and then make sure the direction is
+// correctly returned at the top level
+TEST_F(UniversesTest, change_dir_daughter_universe)
+{
+    auto geo = this->make_track_view();
+
+    // Initialize inside daughter universe a
+    geo = Initializer_t{{1.5, -2.0, 1.0}, {1.0, 0.0, 0.0}};
+
+    // Change the direction
+    geo.set_dir({0.0, 1.0, 0.0});
+
+    // Get the direction
+    EXPECT_VEC_EQ(Real3({0.0, 1.0, 0.0}), geo.dir());
 }
 
 // Cross into daughter universe for the case where the hole cell does not share


### PR DESCRIPTION
This fixes an issue in `orange` in which the direction is not updated at all levels *above* the current track position.  It also hardcodes the maximum level from 3->4 to support common reactor geometry types.  This is a temporary fix until we can dynamically determine the maximum level during setup.