### PR TITLE
Add option to generate primaries without an event file in celer-g4

### DIFF
--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -12,7 +12,8 @@
 
 #include "EventAction.hh"
 #include "GlobalSetup.hh"
-#include "PrimaryGeneratorAction.hh"
+#include "HepMC3PrimaryGeneratorAction.hh"
+#include "PGPrimaryGeneratorAction.hh"
 #include "RunAction.hh"
 #include "TrackingAction.hh"
 
@@ -68,7 +69,14 @@ void ActionInitialization::Build() const
     CELER_LOG_LOCAL(status) << "Constructing user actions on worker threads";
 
     // Primary generator emits source particles
-    this->SetUserAction(new PrimaryGeneratorAction());
+    if (!GlobalSetup::Instance()->GetEventFile().empty())
+    {
+        this->SetUserAction(new HepMC3PrimaryGeneratorAction());
+    }
+    else
+    {
+        this->SetUserAction(new PGPrimaryGeneratorAction());
+    }
 
     // Create thread-local transporter to share between actions
     auto transport = std::make_shared<LocalTransporter>();

--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -12,7 +12,8 @@ if(CELERITAS_USE_Geant4)
     EventAction.cc
     GeantDiagnostics.cc
     GlobalSetup.cc
-    PrimaryGeneratorAction.cc
+    HepMC3PrimaryGeneratorAction.cc
+    PGPrimaryGeneratorAction.cc
     RunAction.cc
     RunInput.cc
     SensitiveDetector.cc

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -38,6 +38,10 @@ class GlobalSetup
     //! \name Demo setup options
     std::string const& GetGeometryFile() const { return input_.geometry_file; }
     std::string const& GetEventFile() const { return input_.event_file; }
+    PrimaryGeneratorOptions const& GetPrimaryGeneratorOptions() const
+    {
+        return input_.primary_options;
+    }
     int GetRootBufferSize() const { return input_.root_buffer_size; }
     bool GetWriteSDHits() const { return input_.write_sd_hits; }
     bool StripGDMLPointers() const { return input_.strip_gdml_pointers; }

--- a/app/celer-g4/HepMC3PrimaryGeneratorAction.cc
+++ b/app/celer-g4/HepMC3PrimaryGeneratorAction.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celer-g4/PrimaryGeneratorAction.cc
+//! \file celer-g4/HepMC3PrimaryGeneratorAction.cc
 //---------------------------------------------------------------------------//
-#include "PrimaryGeneratorAction.hh"
+#include "HepMC3PrimaryGeneratorAction.hh"
 
 #include <G4Event.hh>
 
@@ -43,7 +43,7 @@ HepMC3PrimaryGenerator& shared_reader()
  *
  * This will load the HepMC3 file if not already active.
  */
-int PrimaryGeneratorAction::NumEvents()
+int HepMC3PrimaryGeneratorAction::NumEvents()
 {
     return shared_reader().NumEvents();
 }
@@ -52,7 +52,7 @@ int PrimaryGeneratorAction::NumEvents()
 /*!
  * Generate primaries from HepMC3 input file.
  */
-void PrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
+void HepMC3PrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
 {
     ExceptionConverter call_g4exception{"celer0000"};
     CELER_TRY_HANDLE(shared_reader().GeneratePrimaryVertex(event),

--- a/app/celer-g4/HepMC3PrimaryGeneratorAction.hh
+++ b/app/celer-g4/HepMC3PrimaryGeneratorAction.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celer-g4/PrimaryGeneratorAction.hh
+//! \file celer-g4/HepMC3PrimaryGeneratorAction.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -17,14 +17,14 @@ namespace app
 /*!
  * Generate events by reading from a HepMC3 file.
  */
-class PrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
+class HepMC3PrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
 {
   public:
     // Get the total number of events available in the HepMC3 file
     static int NumEvents();
 
     // Construct primary action
-    PrimaryGeneratorAction() = default;
+    HepMC3PrimaryGeneratorAction() = default;
 
     // Generate events
     void GeneratePrimaries(G4Event* event) final;

--- a/app/celer-g4/PGPrimaryGeneratorAction.cc
+++ b/app/celer-g4/PGPrimaryGeneratorAction.cc
@@ -7,9 +7,12 @@
 //---------------------------------------------------------------------------//
 #include "PGPrimaryGeneratorAction.hh"
 
+#include <random>
+#include <CLHEP/Units/SystemOfUnits.h>
 #include <G4ParticleTable.hh>
 
 #include "corecel/Macros.hh"
+#include "celeritas/ext/Convert.geant.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
 
 #include "GlobalSetup.hh"

--- a/app/celer-g4/PGPrimaryGeneratorAction.cc
+++ b/app/celer-g4/PGPrimaryGeneratorAction.cc
@@ -40,6 +40,9 @@ PGPrimaryGeneratorAction::PGPrimaryGeneratorAction()
 
     num_events_ = options.num_events;
     primaries_per_event_ = options.primaries_per_event;
+    sample_energy_ = make_energy_sampler(options.energy);
+    sample_pos_ = make_position_sampler(options.position);
+    sample_dir_ = make_direction_sampler(options.direction);
 
     // Set the particle definitions
     particle_def_.reserve(options.pdg.size());
@@ -47,56 +50,6 @@ PGPrimaryGeneratorAction::PGPrimaryGeneratorAction()
     {
         particle_def_.push_back(
             G4ParticleTable::GetParticleTable()->FindParticle(pdg.get()));
-    }
-
-    using DS = DistributionSelection;
-    {
-        // Create energy distribution
-        auto const& p = options.energy.params;
-        switch (options.energy.distribution)
-        {
-            case DS::delta:
-                CELER_ASSERT(p.size() == 1);
-                sample_energy_ = DeltaDistribution<real_type>(p[0]);
-                break;
-            default:
-                CELER_ASSERT_UNREACHABLE();
-        }
-    }
-    {
-        // Create spatial distribution
-        auto const& p = options.position.params;
-        switch (options.position.distribution)
-        {
-            case DS::delta:
-                CELER_ASSERT(p.size() == 3);
-                sample_pos_ = DeltaDistribution<Real3>(Real3{p[0], p[1], p[2]});
-                break;
-            case DS::box:
-                CELER_ASSERT(p.size() == 6);
-                sample_pos_ = UniformBoxDistribution<real_type>(
-                    Real3{p[0], p[1], p[2]}, Real3{p[3], p[4], p[5]});
-                break;
-            default:
-                CELER_ASSERT_UNREACHABLE();
-        }
-    }
-    {
-        // Create angular distribution
-        auto const& p = options.direction.params;
-        switch (options.direction.distribution)
-        {
-            case DS::delta:
-                CELER_ASSERT(p.size() == 3);
-                sample_dir_ = DeltaDistribution<Real3>(Real3{p[0], p[1], p[2]});
-                break;
-            case DS::isotropic:
-                CELER_ASSERT(p.empty());
-                sample_dir_ = IsotropicDistribution<real_type>();
-                break;
-            default:
-                CELER_ASSERT_UNREACHABLE();
-        }
     }
 }
 

--- a/app/celer-g4/PGPrimaryGeneratorAction.cc
+++ b/app/celer-g4/PGPrimaryGeneratorAction.cc
@@ -11,9 +11,6 @@
 
 #include "corecel/Macros.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
-#include "celeritas/random/distribution/DeltaDistribution.hh"
-#include "celeritas/random/distribution/IsotropicDistribution.hh"
-#include "celeritas/random/distribution/UniformBoxDistribution.hh"
 
 #include "GlobalSetup.hh"
 
@@ -27,16 +24,18 @@ namespace app
  */
 PGPrimaryGeneratorAction::PGPrimaryGeneratorAction()
 {
-    if (G4Threading::IsMultithreadedApplication())
-    {
-        rng_.seed(G4Threading::G4GetThreadId());
-    }
-
     // Generate one particle at each call to \c GeneratePrimaryVertex()
     gun_.SetNumberOfParticles(1);
 
     auto options = GlobalSetup::Instance()->GetPrimaryGeneratorOptions();
     CELER_ASSERT(options);
+
+    auto seed = options.seed;
+    if (G4Threading::IsMultithreadedApplication())
+    {
+        seed += G4Threading::G4GetThreadId();
+    }
+    rng_.seed(seed);
 
     num_events_ = options.num_events;
     primaries_per_event_ = options.primaries_per_event;

--- a/app/celer-g4/PGPrimaryGeneratorAction.cc
+++ b/app/celer-g4/PGPrimaryGeneratorAction.cc
@@ -1,0 +1,143 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celer-g4/PGPrimaryGeneratorAction.cc
+//---------------------------------------------------------------------------//
+#include "PGPrimaryGeneratorAction.hh"
+
+#include <G4ParticleTable.hh>
+
+#include "corecel/Macros.hh"
+#include "celeritas/phys/PrimaryGeneratorOptions.hh"
+#include "celeritas/random/distribution/DeltaDistribution.hh"
+#include "celeritas/random/distribution/IsotropicDistribution.hh"
+#include "celeritas/random/distribution/UniformBoxDistribution.hh"
+
+#include "GlobalSetup.hh"
+
+namespace celeritas
+{
+namespace app
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct primary action.
+ */
+PGPrimaryGeneratorAction::PGPrimaryGeneratorAction()
+{
+    if (G4Threading::IsMultithreadedApplication())
+    {
+        rng_.seed(G4Threading::G4GetThreadId());
+    }
+
+    // Generate one particle at each call to \c GeneratePrimaryVertex()
+    gun_.SetNumberOfParticles(1);
+
+    auto options = GlobalSetup::Instance()->GetPrimaryGeneratorOptions();
+    CELER_ASSERT(options);
+
+    num_events_ = options.num_events;
+    primaries_per_event_ = options.primaries_per_event;
+
+    // Set the particle definitions
+    particle_def_.reserve(options.pdg.size());
+    for (auto const& pdg : options.pdg)
+    {
+        particle_def_.push_back(
+            G4ParticleTable::GetParticleTable()->FindParticle(pdg.get()));
+    }
+
+    using DS = DistributionSelection;
+    {
+        // Create energy distribution
+        auto const& p = options.energy.params;
+        switch (options.energy.distribution)
+        {
+            case DS::delta:
+                CELER_ASSERT(p.size() == 1);
+                sample_energy_ = DeltaDistribution<real_type>(p[0]);
+                break;
+            default:
+                CELER_ASSERT_UNREACHABLE();
+        }
+    }
+    {
+        // Create spatial distribution
+        auto const& p = options.position.params;
+        switch (options.position.distribution)
+        {
+            case DS::delta:
+                CELER_ASSERT(p.size() == 3);
+                sample_pos_ = DeltaDistribution<Real3>(Real3{p[0], p[1], p[2]});
+                break;
+            case DS::box:
+                CELER_ASSERT(p.size() == 6);
+                sample_pos_ = UniformBoxDistribution<real_type>(
+                    Real3{p[0], p[1], p[2]}, Real3{p[3], p[4], p[5]});
+                break;
+            default:
+                CELER_ASSERT_UNREACHABLE();
+        }
+    }
+    {
+        // Create angular distribution
+        auto const& p = options.direction.params;
+        switch (options.direction.distribution)
+        {
+            case DS::delta:
+                CELER_ASSERT(p.size() == 3);
+                sample_dir_ = DeltaDistribution<Real3>(Real3{p[0], p[1], p[2]});
+                break;
+            case DS::isotropic:
+                CELER_ASSERT(p.empty());
+                sample_dir_ = IsotropicDistribution<real_type>();
+                break;
+            default:
+                CELER_ASSERT_UNREACHABLE();
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Generate primaries from a particle gun.
+ */
+void PGPrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
+{
+    CELER_EXPECT(event);
+
+    if (event_count_ == num_events_)
+    {
+        return;
+    }
+
+    for (size_type i = 0; i < primaries_per_event_; ++i)
+    {
+        gun_.SetParticleDefinition(
+            particle_def_[primary_count_ % particle_def_.size()]);
+        gun_.SetParticlePosition(
+            convert_to_geant(sample_pos_(rng_), CLHEP::cm));
+        gun_.SetParticleMomentumDirection(
+            convert_to_geant(sample_dir_(rng_), 1));
+        gun_.SetParticleEnergy(
+            convert_to_geant(sample_energy_(rng_), CLHEP::MeV));
+        gun_.GeneratePrimaryVertex(event);
+        ++primary_count_;
+
+        if (CELERITAS_DEBUG)
+        {
+            CELER_ASSERT(G4VPrimaryGenerator::CheckVertexInsideWorld(
+                gun_.GetParticlePosition()));
+        }
+    }
+    ++event_count_;
+
+    CELER_ENSURE(event->GetNumberOfPrimaryVertex()
+                 == static_cast<int>(primaries_per_event_));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace app
+}  // namespace celeritas

--- a/app/celer-g4/PGPrimaryGeneratorAction.hh
+++ b/app/celer-g4/PGPrimaryGeneratorAction.hh
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <functional>
-#include <random>
 #include <G4Event.hh>
 #include <G4ParticleDefinition.hh>
 #include <G4ParticleGun.hh>
@@ -17,6 +16,7 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "orange/Types.hh"
+#include "celeritas/phys/PrimaryGeneratorOptions.hh"
 
 namespace celeritas
 {
@@ -37,9 +37,9 @@ class PGPrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
   public:
     //!@{
     //! \name Type aliases
-    using EnergySampler = std::function<real_type(std::mt19937&)>;
-    using PositionSampler = std::function<Real3(std::mt19937&)>;
-    using DirectionSampler = std::function<Real3(std::mt19937&)>;
+    using EnergySampler = std::function<real_type(PrimaryGeneratorEngine&)>;
+    using PositionSampler = std::function<Real3(PrimaryGeneratorEngine&)>;
+    using DirectionSampler = std::function<Real3(PrimaryGeneratorEngine&)>;
     //!@}
 
   public:
@@ -51,7 +51,7 @@ class PGPrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
 
   private:
     G4ParticleGun gun_;
-    std::mt19937 rng_;
+    PrimaryGeneratorEngine rng_;
     size_type num_events_{};
     size_type primaries_per_event_{};
     std::vector<G4ParticleDefinition*> particle_def_;

--- a/app/celer-g4/PGPrimaryGeneratorAction.hh
+++ b/app/celer-g4/PGPrimaryGeneratorAction.hh
@@ -16,6 +16,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
+#include "orange/Types.hh"
 
 namespace celeritas
 {
@@ -24,13 +25,18 @@ namespace app
 //---------------------------------------------------------------------------//
 /*!
  * Generate events from a particle gun.
+ *
+ * This generates primary particles with energy, position, and direction
+ * sampled from distributions specified by the user in \c
+ * PrimaryGeneratorOptions.
+ *
+ * \sa PrimaryGenerator
  */
 class PGPrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
 {
   public:
     //!@{
     //! \name Type aliases
-    using Real3 = Array<real_type, 3>;
     using EnergySampler = std::function<real_type(std::mt19937&)>;
     using PositionSampler = std::function<Real3(std::mt19937&)>;
     using DirectionSampler = std::function<Real3(std::mt19937&)>;

--- a/app/celer-g4/PGPrimaryGeneratorAction.hh
+++ b/app/celer-g4/PGPrimaryGeneratorAction.hh
@@ -1,0 +1,61 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celer-g4/PGPrimaryGeneratorAction.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <functional>
+#include <random>
+#include <G4Event.hh>
+#include <G4ParticleDefinition.hh>
+#include <G4ParticleGun.hh>
+#include <G4VUserPrimaryGeneratorAction.hh>
+
+#include "corecel/Types.hh"
+#include "corecel/cont/Array.hh"
+
+namespace celeritas
+{
+namespace app
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Generate events from a particle gun.
+ */
+class PGPrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Real3 = Array<real_type, 3>;
+    using EnergySampler = std::function<real_type(std::mt19937&)>;
+    using PositionSampler = std::function<Real3(std::mt19937&)>;
+    using DirectionSampler = std::function<Real3(std::mt19937&)>;
+    //!@}
+
+  public:
+    // Construct primary action
+    PGPrimaryGeneratorAction();
+
+    // Generate events
+    void GeneratePrimaries(G4Event* event) final;
+
+  private:
+    G4ParticleGun gun_;
+    std::mt19937 rng_;
+    size_type num_events_{};
+    size_type primaries_per_event_{};
+    std::vector<G4ParticleDefinition*> particle_def_;
+    EnergySampler sample_energy_;
+    PositionSampler sample_pos_;
+    DirectionSampler sample_dir_;
+    size_type primary_count_{0};
+    size_type event_count_{0};
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace app
+}  // namespace celeritas

--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -14,6 +14,7 @@
 #include "corecel/sys/Environment.hh"
 #include "celeritas/ext/GeantPhysicsOptions.hh"
 #include "celeritas/field/FieldDriverOptions.hh"
+#include "celeritas/phys/PrimaryGeneratorOptions.hh"
 
 namespace celeritas
 {
@@ -44,6 +45,9 @@ struct RunInput
     // Problem definition
     std::string geometry_file;  //!< Path to GDML file
     std::string event_file;  //!< Path to HepMC3 event record file
+
+    // Setup options for generating primaries from a distribution
+    PrimaryGeneratorOptions primary_options;
 
     // Control
     size_type num_track_slots{};
@@ -82,7 +86,8 @@ struct RunInput
     //! Whether the run arguments are valid
     explicit operator bool() const
     {
-        return !geometry_file.empty() && !event_file.empty()
+        return !geometry_file.empty()
+               && (primary_options || !event_file.empty())
                && physics_list < PhysicsListSelection::size_
                && (field == no_field() || field_options)
                && ((num_track_slots > 0 && max_events > 0 && max_steps > 0

--- a/app/celer-g4/RunInputIO.json.cc
+++ b/app/celer-g4/RunInputIO.json.cc
@@ -12,6 +12,7 @@
 #include "celeritas/Types.hh"
 #include "celeritas/ext/GeantPhysicsOptionsIO.json.hh"
 #include "celeritas/field/FieldDriverOptionsIO.json.hh"
+#include "celeritas/phys/PrimaryGeneratorOptionsIO.json.hh"
 
 namespace celeritas
 {
@@ -48,6 +49,8 @@ void from_json(nlohmann::json const& j, RunInput& v)
     RI_LOAD_REQUIRED(geometry_file);
     RI_LOAD_OPTION(event_file);
 
+    RI_LOAD_OPTION(primary_options);
+
     RI_LOAD_OPTION(num_track_slots);
     RI_LOAD_OPTION(max_events);
     RI_LOAD_OPTION(max_steps);
@@ -78,6 +81,9 @@ void from_json(nlohmann::json const& j, RunInput& v)
 #undef RI_LOAD_OPTION
 #undef RI_LOAD_REQUIRED
 
+    CELER_VALIDATE(v.event_file.empty() != !v.primary_options,
+                   << "either a HepMC3 filename or options to generate "
+                      "primaries must be provided (but not both)");
     CELER_VALIDATE(v.physics_list == PhysicsListSelection::geant_physics_list
                        || !j.contains("physics_options"),
                    << "'physics_options' can only be specified for "
@@ -106,6 +112,11 @@ void to_json(nlohmann::json& j, RunInput const& v)
 
     RI_SAVE_REQUIRED(geometry_file);
     RI_SAVE_OPTION(event_file);
+
+    if (v.event_file.empty())
+    {
+        RI_SAVE_REQUIRED(primary_options);
+    }
 
     RI_SAVE_OPTION(num_track_slots);
     RI_SAVE_OPTION(max_events);

--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -48,7 +48,8 @@
 #include "ActionInitialization.hh"
 #include "DetectorConstruction.hh"
 #include "GlobalSetup.hh"
-#include "PrimaryGeneratorAction.hh"
+#include "HepMC3PrimaryGeneratorAction.hh"
+#include "PGPrimaryGeneratorAction.hh"
 
 using namespace std::literals::string_view_literals;
 
@@ -151,10 +152,18 @@ void run(int argc, char** argv)
     CELER_LOG(status) << "Initializing run manager";
     run_manager->Initialize();
 
-    // Load the input file
     int num_events{0};
-    CELER_TRY_HANDLE(num_events = PrimaryGeneratorAction::NumEvents(),
-                     ExceptionConverter{"demo-geant000"});
+    if (!GlobalSetup::Instance()->GetEventFile().empty())
+    {
+        // Load the input file
+        CELER_TRY_HANDLE(num_events = HepMC3PrimaryGeneratorAction::NumEvents(),
+                         ExceptionConverter{"demo-geant000"});
+    }
+    else
+    {
+        num_events
+            = GlobalSetup::Instance()->GetPrimaryGeneratorOptions().num_events;
+    }
 
     if (!celeritas::getenv("CELER_DISABLE").empty())
     {

--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -157,7 +157,7 @@ void run(int argc, char** argv)
     {
         // Load the input file
         CELER_TRY_HANDLE(num_events = HepMC3PrimaryGeneratorAction::NumEvents(),
-                         ExceptionConverter{"demo-geant000"});
+                         ExceptionConverter{"celer-g4000"});
     }
     else
     {

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -61,6 +61,7 @@ list(APPEND SOURCES
   phys/PhysicsParams.cc
   phys/PhysicsParamsOutput.cc
   phys/PrimaryGenerator.cc
+  phys/PrimaryGeneratorOptions.cc
   phys/Process.cc
   phys/ProcessBuilder.cc
   random/CuHipRngData.cc

--- a/src/celeritas/phys/PrimaryGenerator.cc
+++ b/src/celeritas/phys/PrimaryGenerator.cc
@@ -30,6 +30,7 @@ PrimaryGenerator::from_options(SPConstParticles particles,
     CELER_EXPECT(opts);
 
     PrimaryGenerator::Input inp;
+    inp.seed = opts.seed;
     inp.pdg = std::move(opts.pdg);
     inp.num_events = opts.num_events;
     inp.primaries_per_event = opts.primaries_per_event;

--- a/src/celeritas/phys/PrimaryGenerator.cc
+++ b/src/celeritas/phys/PrimaryGenerator.cc
@@ -9,15 +9,36 @@
 
 #include "corecel/cont/Range.hh"
 #include "celeritas/Units.hh"
-#include "celeritas/random/distribution/DeltaDistribution.hh"
-#include "celeritas/random/distribution/IsotropicDistribution.hh"
-#include "celeritas/random/distribution/UniformBoxDistribution.hh"
 
 #include "ParticleParams.hh"
 #include "Primary.hh"
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from user input.
+ *
+ * This creates a \c PrimaryGenerator from options read from a JSON input using
+ * a few predefined energy, spatial, and angular distributions (that can be
+ * extended as needed).
+ */
+PrimaryGenerator
+PrimaryGenerator::from_options(SPConstParticles particles,
+                               PrimaryGeneratorOptions const& opts)
+{
+    CELER_EXPECT(opts);
+
+    PrimaryGenerator::Input inp;
+    inp.pdg = std::move(opts.pdg);
+    inp.num_events = opts.num_events;
+    inp.primaries_per_event = opts.primaries_per_event;
+    inp.sample_energy = make_energy_sampler(opts.energy);
+    inp.sample_pos = make_position_sampler(opts.position);
+    inp.sample_dir = make_direction_sampler(opts.direction);
+    return PrimaryGenerator(particles, inp);
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Construct with options and shared particle data.
@@ -65,81 +86,6 @@ auto PrimaryGenerator::operator()() -> result_type
     }
     ++event_count_;
     return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct from user input.
- *
- * This creates a \c PrimaryGenerator from options read from a JSON input using
- * a few predefined energy, spatial, and angular distributions (that can be
- * extended as needed).
- */
-PrimaryGenerator
-PrimaryGenerator::from_options(SPConstParticles particles,
-                               PrimaryGeneratorOptions const& opts)
-{
-    CELER_EXPECT(opts);
-
-    using DS = DistributionSelection;
-
-    PrimaryGenerator::Input inp;
-    inp.pdg = std::move(opts.pdg);
-    inp.num_events = opts.num_events;
-    inp.primaries_per_event = opts.primaries_per_event;
-
-    // Create energy distribution
-    {
-        auto const& p = opts.energy.params;
-        switch (opts.energy.distribution)
-        {
-            case DS::delta:
-                CELER_ASSERT(p.size() == 1);
-                inp.sample_energy = DeltaDistribution<real_type>(p[0]);
-                break;
-            default:
-                CELER_ASSERT_UNREACHABLE();
-        }
-    }
-    // Create spatial distribution
-    {
-        auto const& p = opts.position.params;
-        switch (opts.position.distribution)
-        {
-            case DS::delta:
-                CELER_ASSERT(p.size() == 3);
-                inp.sample_pos
-                    = DeltaDistribution<Real3>(Real3{p[0], p[1], p[2]});
-                break;
-            case DS::box:
-                CELER_ASSERT(p.size() == 6);
-                inp.sample_pos = UniformBoxDistribution<real_type>(
-                    Real3{p[0], p[1], p[2]}, Real3{p[3], p[4], p[5]});
-                break;
-            default:
-                CELER_ASSERT_UNREACHABLE();
-        }
-    }
-    // Create angular distribution
-    {
-        auto const& p = opts.direction.params;
-        switch (opts.direction.distribution)
-        {
-            case DS::delta:
-                CELER_ASSERT(p.size() == 3);
-                inp.sample_dir
-                    = DeltaDistribution<Real3>(Real3{p[0], p[1], p[2]});
-                break;
-            case DS::isotropic:
-                CELER_ASSERT(p.empty());
-                inp.sample_dir = IsotropicDistribution<real_type>();
-                break;
-            default:
-                CELER_ASSERT_UNREACHABLE();
-        }
-    }
-
-    return PrimaryGenerator(particles, inp);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PrimaryGenerator.cc
+++ b/src/celeritas/phys/PrimaryGenerator.cc
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #include "PrimaryGenerator.hh"
 
+#include <random>
+
 #include "corecel/cont/Range.hh"
 #include "celeritas/Units.hh"
 

--- a/src/celeritas/phys/PrimaryGenerator.hh
+++ b/src/celeritas/phys/PrimaryGenerator.hh
@@ -9,7 +9,6 @@
 
 #include <functional>
 #include <memory>
-#include <random>
 #include <vector>
 
 #include "celeritas/Types.hh"
@@ -39,9 +38,9 @@ class PrimaryGenerator : public EventReaderInterface
   public:
     //!@{
     //! \name Type aliases
-    using EnergySampler = std::function<real_type(std::mt19937&)>;
-    using PositionSampler = std::function<Real3(std::mt19937&)>;
-    using DirectionSampler = std::function<Real3(std::mt19937&)>;
+    using EnergySampler = std::function<real_type(PrimaryGeneratorEngine&)>;
+    using PositionSampler = std::function<Real3(PrimaryGeneratorEngine&)>;
+    using DirectionSampler = std::function<Real3(PrimaryGeneratorEngine&)>;
     using SPConstParticles = std::shared_ptr<ParticleParams const>;
     using result_type = std::vector<Primary>;
     //!@}
@@ -80,7 +79,7 @@ class PrimaryGenerator : public EventReaderInterface
     std::vector<ParticleId> particle_id_;
     size_type primary_count_{0};
     size_type event_count_{0};
-    std::mt19937 rng_;
+    PrimaryGeneratorEngine rng_;
 };
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/phys/PrimaryGeneratorOptions.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.cc
@@ -1,0 +1,84 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/phys/PrimaryGeneratorOptions.cc
+//---------------------------------------------------------------------------//
+#include "PrimaryGeneratorOptions.hh"
+
+#include "celeritas/random/distribution/DeltaDistribution.hh"
+#include "celeritas/random/distribution/IsotropicDistribution.hh"
+#include "celeritas/random/distribution/UniformBoxDistribution.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Return a distribution for sampling the energy.
+ */
+std::function<real_type(std::mt19937&)>
+make_energy_sampler(DistributionOptions options)
+{
+    CELER_EXPECT(options);
+
+    auto const& p = options.params;
+    switch (options.distribution)
+    {
+        case DistributionSelection::delta:
+            CELER_ASSERT(p.size() == 1);
+            return DeltaDistribution<real_type>(p[0]);
+        default:
+            CELER_ASSERT_UNREACHABLE();
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a distribution for sampling the position.
+ */
+std::function<Real3(std::mt19937&)>
+make_position_sampler(DistributionOptions options)
+{
+    CELER_EXPECT(options);
+
+    auto const& p = options.params;
+    switch (options.distribution)
+    {
+        case DistributionSelection::delta:
+            CELER_ASSERT(p.size() == 3);
+            return DeltaDistribution<Real3>(Real3{p[0], p[1], p[2]});
+        case DistributionSelection::box:
+            CELER_ASSERT(p.size() == 6);
+            return UniformBoxDistribution<real_type>(Real3{p[0], p[1], p[2]},
+                                                     Real3{p[3], p[4], p[5]});
+        default:
+            CELER_ASSERT_UNREACHABLE();
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a distribution for sampling the direction.
+ */
+std::function<Real3(std::mt19937&)>
+make_direction_sampler(DistributionOptions options)
+{
+    CELER_EXPECT(options);
+
+    auto const& p = options.params;
+    switch (options.distribution)
+    {
+        case DistributionSelection::delta:
+            CELER_ASSERT(p.size() == 3);
+            return DeltaDistribution<Real3>(Real3{p[0], p[1], p[2]});
+        case DistributionSelection::isotropic:
+            CELER_ASSERT(p.empty());
+            return IsotropicDistribution<real_type>();
+        default:
+            CELER_ASSERT_UNREACHABLE();
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/phys/PrimaryGeneratorOptions.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.cc
@@ -17,7 +17,7 @@ namespace celeritas
 /*!
  * Return a distribution for sampling the energy.
  */
-std::function<real_type(std::mt19937&)>
+std::function<real_type(PrimaryGeneratorEngine&)>
 make_energy_sampler(DistributionOptions options)
 {
     CELER_EXPECT(options);
@@ -37,7 +37,7 @@ make_energy_sampler(DistributionOptions options)
 /*!
  * Return a distribution for sampling the position.
  */
-std::function<Real3(std::mt19937&)>
+std::function<Real3(PrimaryGeneratorEngine&)>
 make_position_sampler(DistributionOptions options)
 {
     CELER_EXPECT(options);
@@ -61,7 +61,7 @@ make_position_sampler(DistributionOptions options)
 /*!
  * Return a distribution for sampling the direction.
  */
-std::function<Real3(std::mt19937&)>
+std::function<Real3(PrimaryGeneratorEngine&)>
 make_direction_sampler(DistributionOptions options)
 {
     CELER_EXPECT(options);

--- a/src/celeritas/phys/PrimaryGeneratorOptions.hh
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.hh
@@ -78,20 +78,22 @@ struct PrimaryGeneratorOptions
     }
 };
 
+using PrimaryGeneratorEngine = std::mt19937;
+
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//
 
 // Return a distribution for sampling the energy
-std::function<real_type(std::mt19937&)>
+std::function<real_type(PrimaryGeneratorEngine&)>
 make_energy_sampler(DistributionOptions options);
 
 // Return a distribution for sampling the position
-std::function<Real3(std::mt19937&)>
+std::function<Real3(PrimaryGeneratorEngine&)>
 make_position_sampler(DistributionOptions options);
 
 // Return a distribution for sampling the direction
-std::function<Real3(std::mt19937&)>
+std::function<Real3(PrimaryGeneratorEngine&)>
 make_direction_sampler(DistributionOptions options);
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PrimaryGeneratorOptions.hh
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.hh
@@ -7,7 +7,11 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <functional>
+#include <random>
+
 #include "corecel/io/StringEnumMapper.hh"
+#include "orange/Types.hh"
 
 #include "PDGNumber.hh"
 
@@ -71,6 +75,22 @@ struct PrimaryGeneratorOptions
                && position && direction;
     }
 };
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+
+// Return a distribution for sampling the energy
+std::function<real_type(std::mt19937&)>
+make_energy_sampler(DistributionOptions options);
+
+// Return a distribution for sampling the position
+std::function<Real3(std::mt19937&)>
+make_position_sampler(DistributionOptions options);
+
+// Return a distribution for sampling the direction
+std::function<Real3(std::mt19937&)>
+make_direction_sampler(DistributionOptions options);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/phys/PrimaryGeneratorOptions.hh
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.hh
@@ -47,6 +47,7 @@ struct DistributionOptions
 /*!
  * Primary generator options.
  *
+ * - \c seed: RNG seed
  * - \c pdg: PDG numbers of the primaries. An equal number of primaries of each
  *   type will be generated
  * - \c num_events: total number of events to generate
@@ -57,6 +58,7 @@ struct DistributionOptions
  */
 struct PrimaryGeneratorOptions
 {
+    unsigned int seed{};
     std::vector<PDGNumber> pdg;
     size_type num_events{};
     size_type primaries_per_event{};

--- a/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
@@ -76,6 +76,7 @@ void to_json(nlohmann::json& j, DistributionOptions const& opts)
  */
 void from_json(nlohmann::json const& j, PrimaryGeneratorOptions& opts)
 {
+    j.at("seed").get_to(opts.seed);
     std::vector<int> pdg;
     auto&& pdg_input = j.at("pdg");
     if (pdg_input.is_array())
@@ -142,7 +143,8 @@ void to_json(nlohmann::json& j, PrimaryGeneratorOptions const& opts)
         opts.pdg.begin(), opts.pdg.end(), pdg.begin(), [](PDGNumber p) {
             return p.unchecked_get();
         });
-    j = nlohmann::json{{"pdg", pdg},
+    j = nlohmann::json{{"seed", opts.seed},
+                       {"pdg", pdg},
                        {"num_events", opts.num_events},
                        {"primaries_per_event", opts.primaries_per_event},
                        {"energy", opts.energy},

--- a/test/celeritas/phys/PrimaryGenerator.test.cc
+++ b/test/celeritas/phys/PrimaryGenerator.test.cc
@@ -134,7 +134,7 @@ TEST_F(PrimaryGeneratorTest, options)
     {
         nlohmann::json out = opts;
         static char const expected[]
-            = R"json({"direction":{"distribution":"isotropic","params":[]},"energy":{"distribution":"delta","params":[1.0]},"num_events":1,"pdg":[22],"position":{"distribution":"box","params":[-3.0,-3.0,-3.0,3.0,3.0,3.0]},"primaries_per_event":10})json";
+            = R"json({"direction":{"distribution":"isotropic","params":[]},"energy":{"distribution":"delta","params":[1.0]},"num_events":1,"pdg":[22],"position":{"distribution":"box","params":[-3.0,-3.0,-3.0,3.0,3.0,3.0]},"primaries_per_event":10,"seed":0})json";
         EXPECT_EQ(std::string(expected), std::string(out.dump()));
     }
 #endif


### PR DESCRIPTION
This adds another `PrimaryGeneratorAction` to celer-g4 which lets us optionally generate primaries from a particle gun with parameters specified in the user input (similar to the `PrimaryGenerator` used in celer-sim).