### PR TITLE
Automatically calculate ORANGE universe depth

### DIFF
--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -30,7 +30,7 @@ namespace celeritas
  */
 struct OrangeParamsScalars
 {
-    size_type max_level{};
+    size_type max_num_levels{};
     size_type max_faces{};
     size_type max_intersections{};
     size_type max_logic_depth{};
@@ -42,7 +42,7 @@ struct OrangeParamsScalars
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return max_level > 0 && max_faces > 0 && max_intersections > 0
+        return max_num_levels > 0 && max_faces > 0 && max_intersections > 0
                && bump_rel > 0 && bump_abs > 0;
     }
 };
@@ -390,21 +390,21 @@ struct OrangeStateData
     StateItems<LevelId> level;
     StateItems<LevelId> surface_level;
 
-    // Dimensions {num_tracks, max_level}
+    // Dimensions {num_tracks, max_num_levels}
     Items<Real3> pos;
     Items<Real3> dir;
     Items<LocalVolumeId> vol;
     Items<UniverseId> universe;
 
-    // Surface crossing, dimensions {num_tracks, max_level}
+    // Surface crossing, dimensions {num_tracks, max_num_levels}
     Items<LocalSurfaceId> surf;
     Items<Sense> sense;
     Items<BoundaryResult> boundary;
 
     // TODO: this is problem-dependent data and should eventually be removed
-    // max_level defines the stride into the preceding pseudo-2D Collections
-    // (pos, dir, ..., etc.)
-    size_type max_level{0};
+    // max_num_levels defines the stride into the preceding pseudo-2D
+    // Collections (pos, dir, ..., etc.)
+    size_type max_num_levels{0};
 
     // Scratch space
     Items<Sense> temp_sense;  // [track][max_faces]
@@ -427,7 +427,7 @@ struct OrangeStateData
             && surf.size() == pos.size()
             && sense.size() == pos.size()
             && boundary.size() == pos.size()
-            && max_level > 0
+            && max_num_levels > 0
             && !temp_sense.empty()
             && !temp_face.empty()
             && temp_distance.size() == temp_face.size()
@@ -452,7 +452,7 @@ struct OrangeStateData
         surf = other.surf;
         sense = other.sense;
         boundary = other.boundary;
-        max_level = other.max_level;
+        max_num_levels = other.max_num_levels;
 
         temp_sense = other.temp_sense;
         temp_face = other.temp_face;
@@ -479,8 +479,8 @@ inline void resize(OrangeStateData<Ownership::value, M>* data,
     resize(&data->level, num_tracks);
     resize(&data->surface_level, num_tracks);
 
-    data->max_level = params.scalars.max_level;
-    auto const size = data->max_level * num_tracks;
+    data->max_num_levels = params.scalars.max_num_levels;
+    auto const size = data->max_num_levels * num_tracks;
 
     resize(&data->pos, size);
     resize(&data->dir, size);

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -30,7 +30,7 @@ namespace celeritas
  */
 struct OrangeParamsScalars
 {
-    size_type max_num_levels{};
+    size_type max_depth{};
     size_type max_faces{};
     size_type max_intersections{};
     size_type max_logic_depth{};
@@ -42,7 +42,7 @@ struct OrangeParamsScalars
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return max_num_levels > 0 && max_faces > 0 && max_intersections > 0
+        return max_depth > 0 && max_faces > 0 && max_intersections > 0
                && bump_rel > 0 && bump_abs > 0;
     }
 };
@@ -390,21 +390,21 @@ struct OrangeStateData
     StateItems<LevelId> level;
     StateItems<LevelId> surface_level;
 
-    // Dimensions {num_tracks, max_num_levels}
+    // Dimensions {num_tracks, max_depth}
     Items<Real3> pos;
     Items<Real3> dir;
     Items<LocalVolumeId> vol;
     Items<UniverseId> universe;
 
-    // Surface crossing, dimensions {num_tracks, max_num_levels}
+    // Surface crossing, dimensions {num_tracks, max_depth}
     Items<LocalSurfaceId> surf;
     Items<Sense> sense;
     Items<BoundaryResult> boundary;
 
     // TODO: this is problem-dependent data and should eventually be removed
-    // max_num_levels defines the stride into the preceding pseudo-2D
+    // max_depth defines the stride into the preceding pseudo-2D
     // Collections (pos, dir, ..., etc.)
-    size_type max_num_levels{0};
+    size_type max_depth{0};
 
     // Scratch space
     Items<Sense> temp_sense;  // [track][max_faces]
@@ -427,7 +427,7 @@ struct OrangeStateData
             && surf.size() == pos.size()
             && sense.size() == pos.size()
             && boundary.size() == pos.size()
-            && max_num_levels > 0
+            && max_depth > 0
             && !temp_sense.empty()
             && !temp_face.empty()
             && temp_distance.size() == temp_face.size()
@@ -452,7 +452,7 @@ struct OrangeStateData
         surf = other.surf;
         sense = other.sense;
         boundary = other.boundary;
-        max_num_levels = other.max_num_levels;
+        max_depth = other.max_depth;
 
         temp_sense = other.temp_sense;
         temp_face = other.temp_face;
@@ -479,8 +479,8 @@ inline void resize(OrangeStateData<Ownership::value, M>* data,
     resize(&data->level, num_tracks);
     resize(&data->surface_level, num_tracks);
 
-    data->max_num_levels = params.scalars.max_num_levels;
-    auto const size = data->max_num_levels * num_tracks;
+    data->max_depth = params.scalars.max_depth;
+    auto const size = data->max_depth * num_tracks;
 
     resize(&data->pos, size);
     resize(&data->dir, size);

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -30,6 +30,9 @@ namespace celeritas
  */
 struct OrangeParamsScalars
 {
+    // Maximum universe depth, i.e., depth of the universe tree DAG, equivalent
+    // to the VecGeom implementation. Has a value of 1 for a non-nested
+    // geometry.
     size_type max_depth{};
     size_type max_faces{};
     size_type max_intersections{};

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -97,13 +97,14 @@ OrangeInput input_from_json(std::string filename)
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate the maximum universe level, i.e. the deepest universe depth
+ * Calculate the maximum num of universe levels within the geometry
  *
+ * A single-universe geometry will have a max_num_levels of 1.
  * This is a recursive function, so for external callers, uid should be
  * the root universe id.
  */
-size_type
-calc_max_level(HostVal<OrangeParamsData> const& data, UniverseId const& uid)
+size_type calc_max_num_levels(HostVal<OrangeParamsData> const& data,
+                              UniverseId const& uid)
 {
     CELER_EXPECT(uid);
 
@@ -123,7 +124,7 @@ calc_max_level(HostVal<OrangeParamsData> const& data, UniverseId const& uid)
             {
                 max_sub_depth = std::max(
                     max_sub_depth,
-                    calc_max_level(
+                    calc_max_num_levels(
                         data,
                         data.daughters[vol_record.daughter_id].universe_id));
             }
@@ -137,7 +138,7 @@ calc_max_level(HostVal<OrangeParamsData> const& data, UniverseId const& uid)
         {
             max_sub_depth = std::max(
                 max_sub_depth,
-                calc_max_level(
+                calc_max_num_levels(
                     data,
                     data.daughters[rect_array_record
                                        .daughters[LocalVolumeId{vol_id}]]
@@ -288,7 +289,8 @@ OrangeParams::OrangeParams(OrangeInput input)
     bbox_ = std::get<UnitInput>(input.universes.front()).bbox;
 
     // Update scalars *after* loading all units
-    host_data.scalars.max_level = calc_max_level(host_data, UniverseId{0});
+    host_data.scalars.max_num_levels
+        = calc_max_num_levels(host_data, UniverseId{0});
     CELER_VALIDATE(host_data.scalars.max_logic_depth
                        < detail::LogicStack::max_stack_depth(),
                    << "input geometry has at least one volume with a "

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -99,12 +99,12 @@ OrangeInput input_from_json(std::string filename)
 /*!
  * Calculate the maximum num of universe levels within the geometry
  *
- * A single-universe geometry will have a max_num_levels of 1.
+ * A single-universe geometry will have a max_depth of 1.
  * This is a recursive function, so for external callers, uid should be
  * the root universe id.
  */
-size_type calc_max_num_levels(HostVal<OrangeParamsData> const& data,
-                              UniverseId const& uid)
+size_type
+calc_max_depth(HostVal<OrangeParamsData> const& data, UniverseId const& uid)
 {
     CELER_EXPECT(uid);
 
@@ -124,7 +124,7 @@ size_type calc_max_num_levels(HostVal<OrangeParamsData> const& data,
             {
                 max_sub_depth = std::max(
                     max_sub_depth,
-                    calc_max_num_levels(
+                    calc_max_depth(
                         data,
                         data.daughters[vol_record.daughter_id].universe_id));
             }
@@ -138,7 +138,7 @@ size_type calc_max_num_levels(HostVal<OrangeParamsData> const& data,
         {
             max_sub_depth = std::max(
                 max_sub_depth,
-                calc_max_num_levels(
+                calc_max_depth(
                     data,
                     data.daughters[rect_array_record
                                        .daughters[LocalVolumeId{vol_id}]]
@@ -289,8 +289,7 @@ OrangeParams::OrangeParams(OrangeInput input)
     bbox_ = std::get<UnitInput>(input.universes.front()).bbox;
 
     // Update scalars *after* loading all units
-    host_data.scalars.max_num_levels
-        = calc_max_num_levels(host_data, UniverseId{0});
+    host_data.scalars.max_depth = calc_max_depth(host_data, UniverseId{0});
     CELER_VALIDATE(host_data.scalars.max_logic_depth
                        < detail::LogicStack::max_stack_depth(),
                    << "input geometry has at least one volume with a "

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -53,6 +53,9 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     //! Outer bounding box of geometry
     BBox const& bbox() const final { return bbox_; }
 
+    //! Maximum universe depth
+    size_type max_depth() const { return this->host_ref().scalars.max_depth; }
+
     //// VOLUMES ////
 
     // Number of volumes

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -136,18 +136,8 @@ struct OrangeInput
 {
     std::vector<std::variant<UnitInput, RectArrayInput>> universes;
 
-    // TODO: Calculate automatically in Shift by traversing the parent/daughter
-    // tree
-    size_type max_level = 4;
-
-    // TODO: array of universe types and universe ID -> offset
-    // or maybe std::variant when we require C++17
-
     //! Whether the unit definition is valid
-    explicit operator bool() const
-    {
-        return !universes.empty() && max_level > 0;
-    }
+    explicit operator bool() const { return !universes.empty(); }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/LevelStateAccessor.hh
+++ b/src/orange/detail/LevelStateAccessor.hh
@@ -124,9 +124,10 @@ CELER_FUNCTION
 LevelStateAccessor::LevelStateAccessor(StateRef const* states,
                                        TrackSlotId tid,
                                        LevelId level_id)
-    : states_(states), index_(tid.get() * states_->max_level + level_id.get())
+    : states_(states)
+    , index_(tid.get() * states_->max_num_levels + level_id.get())
 {
-    CELER_EXPECT(level_id < states->max_level);
+    CELER_EXPECT(level_id < states->max_num_levels);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/LevelStateAccessor.hh
+++ b/src/orange/detail/LevelStateAccessor.hh
@@ -124,10 +124,9 @@ CELER_FUNCTION
 LevelStateAccessor::LevelStateAccessor(StateRef const* states,
                                        TrackSlotId tid,
                                        LevelId level_id)
-    : states_(states)
-    , index_(tid.get() * states_->max_num_levels + level_id.get())
+    : states_(states), index_(tid.get() * states_->max_depth + level_id.get())
 {
-    CELER_EXPECT(level_id < states->max_num_levels);
+    CELER_EXPECT(level_id < states->max_depth);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -198,7 +198,6 @@ void NestedTest::build_orange()
     }
 
     OrangeInput input;
-    input.max_level = 1;
     input.universes.push_back(std::move(ui));
     auto geo = std::make_shared<OrangeParams>(std::move(input));
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -532,7 +532,7 @@ TEST_F(UniversesTest, params)
     OrangeParams const& geo = this->params();
     EXPECT_EQ(12, geo.num_volumes());
     EXPECT_EQ(25, geo.num_surfaces());
-    EXPECT_EQ(3, geo.host_ref().scalars.max_level);
+    EXPECT_EQ(3, geo.host_ref().scalars.max_num_levels);
     EXPECT_FALSE(geo.supports_safety());
 
     EXPECT_VEC_SOFT_EQ(Real3({-2, -6, -1}), geo.bbox().lower());
@@ -828,7 +828,7 @@ TEST_F(RectArrayTest, params)
     OrangeParams const& geo = this->params();
     EXPECT_EQ(35, geo.num_volumes());
     EXPECT_EQ(22, geo.num_surfaces());
-    EXPECT_EQ(4, geo.host_ref().scalars.max_level);
+    EXPECT_EQ(4, geo.host_ref().scalars.max_num_levels);
     EXPECT_FALSE(geo.supports_safety());
 
     EXPECT_VEC_SOFT_EQ(Real3({-12, -4, -5}), geo.bbox().lower());

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -532,6 +532,7 @@ TEST_F(UniversesTest, params)
     OrangeParams const& geo = this->params();
     EXPECT_EQ(12, geo.num_volumes());
     EXPECT_EQ(25, geo.num_surfaces());
+    EXPECT_EQ(3, geo.host_ref().scalars.max_level);
     EXPECT_FALSE(geo.supports_safety());
 
     EXPECT_VEC_SOFT_EQ(Real3({-2, -6, -1}), geo.bbox().lower());
@@ -820,6 +821,18 @@ TEST_F(UniversesTest, cross_between_daughters)
 
     geo.move_to_boundary();
     EXPECT_EQ("bob.mz", this->params().id_to_label(geo.surface_id()).name);
+}
+
+TEST_F(RectArrayTest, params)
+{
+    OrangeParams const& geo = this->params();
+    EXPECT_EQ(35, geo.num_volumes());
+    EXPECT_EQ(22, geo.num_surfaces());
+    EXPECT_EQ(4, geo.host_ref().scalars.max_level);
+    EXPECT_FALSE(geo.supports_safety());
+
+    EXPECT_VEC_SOFT_EQ(Real3({-12, -4, -5}), geo.bbox().lower());
+    EXPECT_VEC_SOFT_EQ(Real3({12, 10, 5}), geo.bbox().upper());
 }
 
 TEST_F(Geant4Testem15Test, safety)

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -532,7 +532,7 @@ TEST_F(UniversesTest, params)
     OrangeParams const& geo = this->params();
     EXPECT_EQ(12, geo.num_volumes());
     EXPECT_EQ(25, geo.num_surfaces());
-    EXPECT_EQ(3, geo.host_ref().scalars.max_num_levels);
+    EXPECT_EQ(3, geo.host_ref().scalars.max_depth);
     EXPECT_FALSE(geo.supports_safety());
 
     EXPECT_VEC_SOFT_EQ(Real3({-2, -6, -1}), geo.bbox().lower());
@@ -828,7 +828,7 @@ TEST_F(RectArrayTest, params)
     OrangeParams const& geo = this->params();
     EXPECT_EQ(35, geo.num_volumes());
     EXPECT_EQ(22, geo.num_surfaces());
-    EXPECT_EQ(4, geo.host_ref().scalars.max_num_levels);
+    EXPECT_EQ(4, geo.host_ref().scalars.max_depth);
     EXPECT_FALSE(geo.supports_safety());
 
     EXPECT_VEC_SOFT_EQ(Real3({-12, -4, -5}), geo.bbox().lower());

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -532,7 +532,7 @@ TEST_F(UniversesTest, params)
     OrangeParams const& geo = this->params();
     EXPECT_EQ(12, geo.num_volumes());
     EXPECT_EQ(25, geo.num_surfaces());
-    EXPECT_EQ(3, geo.host_ref().scalars.max_depth);
+    EXPECT_EQ(3, geo.max_depth());
     EXPECT_FALSE(geo.supports_safety());
 
     EXPECT_VEC_SOFT_EQ(Real3({-2, -6, -1}), geo.bbox().lower());
@@ -828,7 +828,7 @@ TEST_F(RectArrayTest, params)
     OrangeParams const& geo = this->params();
     EXPECT_EQ(35, geo.num_volumes());
     EXPECT_EQ(22, geo.num_surfaces());
-    EXPECT_EQ(4, geo.host_ref().scalars.max_depth);
+    EXPECT_EQ(4, geo.max_depth());
     EXPECT_FALSE(geo.supports_safety());
 
     EXPECT_VEC_SOFT_EQ(Real3({-12, -4, -5}), geo.bbox().lower());


### PR DESCRIPTION
This PR recursively loops through the universes within a geometry to determine the maximum depth, where a single-universe geometry has a maximum depth of 1. In addition, the variable name `max_level` has been changed to `max_num_levels`, to avoid confusion with 0 vs 1 indexing.