### PR TITLE
Implement generic transforms in multi-universe ORANGE

### DIFF
--- a/src/corecel/cont/Range.hh
+++ b/src/corecel/cont/Range.hh
@@ -120,8 +120,8 @@ class Range
 
     //// STRIDED ACCESS ////
 
-    //! Return a stepped range using a different integer type
-    template<class U, std::enable_if_t<std::is_signed<U>::value, U> = 0>
+    //! Return a stepped range using a *signed* integer type
+    template<class U, std::enable_if_t<std::is_signed<U>::value, bool> = true>
     CELER_CONSTEXPR_FUNCTION detail::StepRange<step_type<U>> step(U step)
     {
         if (step < 0)
@@ -133,8 +133,8 @@ class Range
     }
 
     //! \cond
-    //! Return a stepped range using a different integer type
-    template<class U, std::enable_if_t<std::is_unsigned<U>::value, U> = 0>
+    //! Return a stepped range using an *unsigned* integer type
+    template<class U, std::enable_if_t<std::is_unsigned<U>::value, bool> = true>
     CELER_CONSTEXPR_FUNCTION detail::StepRange<step_type<U>> step(U step)
     {
         return {*begin_, *end_, step};

--- a/src/corecel/data/CollectionBuilder.hh
+++ b/src/corecel/data/CollectionBuilder.hh
@@ -41,7 +41,7 @@ namespace celeritas
  * assertions enabled on host memory, it will assign garbage values to aid in
  * reproducible debugging.)
  */
-template<class T, MemSpace M, class I>
+template<class T, MemSpace M = MemSpace::host, class I = ItemId<T>>
 class CollectionBuilder
 {
   public:
@@ -56,13 +56,16 @@ class CollectionBuilder
 
   public:
     //! Construct from a collection
-    explicit CollectionBuilder(CollectionT* collection) : col_(*collection) {}
+    explicit CollectionBuilder(CollectionT* collection) : col_(*collection)
+    {
+        CELER_EXPECT(collection);
+    }
 
     // Increase size to this capacity
-    inline void resize(size_type count);
+    inline void resize(std::size_t count);
 
     // Reserve space
-    inline void reserve(size_type count);
+    inline void reserve(std::size_t count);
 
     // Extend with a series of elements, returning the range inserted
     template<class InputIterator>
@@ -78,6 +81,9 @@ class CollectionBuilder
     //! Number of elements in the collection
     size_type size() const { return col_.size(); }
 
+    //! Get the size as an ID type
+    ItemIdT size_id() const { return ItemIdT{size()}; }
+
   private:
     CollectionT& col_;
 
@@ -85,12 +91,20 @@ class CollectionBuilder
     StorageT& storage() { return col_.storage(); }
     StorageT const& storage() const { return col_.storage(); }
 
-    //! Maximum elements in a Collection, in underlying storage size
-    static constexpr size_type max_size()
+    //! Maximum elements in a Collection
+    static constexpr std::size_t max_size()
     {
         return std::numeric_limits<size_type>::max();
     }
 };
+
+//---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+
+template<class T, MemSpace M, class I>
+CollectionBuilder(Collection<T, Ownership::value, M, I>*)
+    -> CollectionBuilder<T, M, I>;
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
@@ -99,7 +113,7 @@ class CollectionBuilder
  * Reserve space for the given number of elements.
  */
 template<class T, MemSpace M, class I>
-void CollectionBuilder<T, M, I>::reserve(size_type count)
+void CollectionBuilder<T, M, I>::reserve(std::size_t count)
 {
     CELER_EXPECT(count <= max_size());
     static_assert(M == MemSpace::host,
@@ -120,9 +134,9 @@ auto CollectionBuilder<T, M, I>::insert_back(InputIterator first,
                  <= this->max_size());
     static_assert(M == MemSpace::host,
                   "Insertion currently works only for host memory");
-    auto start = ItemIdT{this->size()};
+    auto start = this->size_id();
     this->storage().insert(this->storage().end(), first, last);
-    return {start, ItemIdT{this->size()}};
+    return {start, this->size_id()};
 }
 
 //---------------------------------------------------------------------------//
@@ -146,9 +160,9 @@ auto CollectionBuilder<T, M, I>::push_back(T const& el) -> ItemIdT
     CELER_EXPECT(this->storage().size() + 1 <= this->max_size());
     static_assert(M == MemSpace::host,
                   "Insertion currently works only for host memory");
-    size_type idx = this->size();
+    auto result = this->size_id();
     this->storage().push_back(el);
-    return ItemIdT{idx};
+    return result;
 }
 
 template<class T, MemSpace M, class I>
@@ -157,9 +171,9 @@ auto CollectionBuilder<T, M, I>::push_back(T&& el) -> ItemIdT
     CELER_EXPECT(this->storage().size() + 1 <= this->max_size());
     static_assert(M == MemSpace::host,
                   "Insertion currently works only for host memory");
-    size_type idx = this->size();
+    auto result = this->size_id();
     this->storage().push_back(std::move(el));
-    return ItemIdT{idx};
+    return result;
 }
 
 //---------------------------------------------------------------------------//
@@ -167,10 +181,11 @@ auto CollectionBuilder<T, M, I>::push_back(T&& el) -> ItemIdT
  * Increase the size to the given number of elements.
  */
 template<class T, MemSpace M, class I>
-void CollectionBuilder<T, M, I>::resize(size_type size)
+void CollectionBuilder<T, M, I>::resize(std::size_t count)
 {
     CELER_EXPECT(this->storage().empty());
-    this->storage() = StorageT(size);
+    CELER_EXPECT(count <= max_size());
+    this->storage() = StorageT(count);
     if constexpr (CELERITAS_DEBUG && M == MemSpace::host)
     {
         // Fill with invalid values to help with debugging on host
@@ -199,8 +214,7 @@ make_builder(Collection<T, Ownership::value, M, I>* collection)
  * This is useful for analogy to the resize method defined for states.
  */
 template<class T, MemSpace M, class I>
-void resize(Collection<T, Ownership::value, M, I>* collection,
-            typename I::size_type size)
+void resize(Collection<T, Ownership::value, M, I>* collection, std::size_t size)
 {
     CELER_EXPECT(collection);
     CollectionBuilder<T, M, I>(collection).resize(size);

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -157,6 +157,23 @@ struct RaggedRightIndexerData
 
 //---------------------------------------------------------------------------//
 /*!
+ * Type-deleted transform.
+ */
+struct TransformRecord
+{
+    using RealId = OpaqueId<real_type>;
+    TransformType type{TransformType::size_};
+    RealId data_offset;
+
+    //! True if values are set
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return type != TransformType::size_ && data_offset;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Scalar data for a single "unit" of volumes defined by surfaces.
  */
 struct SimpleUnitRecord
@@ -173,7 +190,6 @@ struct SimpleUnitRecord
     // Bounding Interval Hierachy tree parameters
     detail::BIHTree bih_tree;
 
-    // TODO: transforms
     LocalVolumeId background{};  //!< Default if not in any other volume
     bool simple_safety{};
 
@@ -312,6 +328,7 @@ struct OrangeParamsData
     UnivItems<size_type> universe_indices;
     Items<SimpleUnitRecord> simple_units;
     Items<RectArrayRecord> rect_arrays;
+    Items<TransformRecord> transforms;
 
     // BIH tree storage
     BIHTreeData<W, M> bih_tree_data;
@@ -326,7 +343,6 @@ struct OrangeParamsData
     Items<Connectivity> connectivities;
     Items<VolumeRecord> volume_records;
     Items<Daughter> daughters;
-    Items<Real3> translations;
 
     UniverseIndexerData<W, M> universe_indexer_data;
 
@@ -354,6 +370,7 @@ struct OrangeParamsData
         universe_indices = other.universe_indices;
         simple_units = other.simple_units;
         rect_arrays = other.rect_arrays;
+        transforms = other.transforms;
 
         bih_tree_data = other.bih_tree_data;
 
@@ -366,7 +383,6 @@ struct OrangeParamsData
         connectivities = other.connectivities;
         volume_records = other.volume_records;
         daughters = other.daughters;
-        translations = other.translations;
         universe_indexer_data = other.universe_indexer_data;
 
         CELER_ENSURE(static_cast<bool>(*this) == static_cast<bool>(other));

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -184,17 +184,27 @@ class OrangeTrackView
     inline CELER_FUNCTION detail::LocalState
     make_local_state(LevelId level) const;
 
+    // Whether the next distance-to-boundary has been found
+    CELER_FORCEINLINE_FUNCTION bool has_next_step() const;
+
+    // Invalidate the next distance-to-boundary
+    CELER_FORCEINLINE_FUNCTION void clear_next_step();
+
     // Make a LevelStateAccessor for the current thread and level
     CELER_FORCEINLINE_FUNCTION LevelStateAccessor make_lsa() const;
 
     // Make a LevelStateAccessor for the current thread and a given level
     CELER_FORCEINLINE_FUNCTION LevelStateAccessor make_lsa(LevelId level) const;
 
-    // Whether the next distance-to-boundary has been found
-    CELER_FORCEINLINE_FUNCTION bool has_next_step() const;
+    // Get the daughter ID for the volume in the universe (or null)
+    CELER_FORCEINLINE_FUNCTION DaughterId
+    get_daughter(LevelStateAccessor const& lsa);
 
-    // Invalidate the next distance-to-boundary
-    CELER_FORCEINLINE_FUNCTION void clear_next_step();
+    // Get the transform ID for the given daughter.
+    CELER_FORCEINLINE_FUNCTION TransformId get_transform(DaughterId daughter_id);
+
+    // Get the transform ID to move from this level to the one below.
+    CELER_FUNCTION TransformId get_transform(LevelId lev);
 };
 
 //---------------------------------------------------------------------------//
@@ -237,11 +247,17 @@ OrangeTrackView::operator=(Initializer_t const& init)
     local.surface = {};
     local.temp_sense = this->make_temp_sense();
 
+    // Helpers for applying mother-to-daughter transformations
+    TransformVisitor apply_transform{params_};
+    auto transform_down_local = [&local](auto&& t) {
+        local.pos = t.transform_down(local.pos);
+        local.dir = t.rotate_down(local.dir);
+    };
+
     // Recurse into daughter universes starting with the outermost universe
     UniverseId uid = top_universe_id();
     DaughterId daughter_id;
     size_type level = 0;
-
     do
     {
         auto tracker = this->make_tracker(uid);
@@ -264,9 +280,7 @@ OrangeTrackView::operator=(Initializer_t const& init)
         {
             auto const& daughter = params_.daughters[daughter_id];
             // Apply "transform down" based on stored transform
-            local.pos = TransformVisitor{params_}(
-                [&local](auto&& t) { return t.transform_down(local.pos); },
-                daughter.transform_id);
+            apply_transform(transform_down_local, daughter.transform_id);
             // Update universe and increase level depth
             uid = daughter.universe_id;
             ++level;
@@ -293,24 +307,34 @@ OrangeTrackView& OrangeTrackView::operator=(DetailedInitializer const& init)
 {
     CELER_EXPECT(is_soft_unit_vector(init.dir));
 
-    for (auto i : range(states_.level[init.other.track_slot_] + 1))
-    {
-        // Copy all data accessed via LSA except for direction
-        auto lsa = this->make_lsa(LevelId{i});
-        if (this != &init.other)
-        {
-            lsa = init.other.make_lsa(LevelId{i});
-        }
-        // TODO: apply rotation when we use Transform instead of Translate
-        lsa.dir() = init.dir;
-    }
-
     if (this != &init.other)
     {
         // Copy init track's position but update the direction
         this->level() = states_.level[init.other.track_slot_];
         this->surface_level() = states_.surface_level[init.other.track_slot_];
+
+        for (auto lev : range(LevelId{this->level()}))
+        {
+            // Copy all data accessed via LSA
+            auto lsa = this->make_lsa(lev);
+            lsa = init.other.make_lsa(lev);
+        }
     }
+
+    // Transform direction from global to local
+    Real3 localdir = init.dir;
+    auto apply_transform = TransformVisitor{params_};
+    auto rotate_down
+        = [&localdir](auto&& t) { localdir = t.rotate_down(localdir); };
+    for (auto lev : range(LevelId{this->level()}))
+    {
+        auto lsa = this->make_lsa(lev);
+        lsa.dir() = localdir;
+        apply_transform(rotate_down,
+                        this->get_transform(this->get_daughter(lsa)));
+    }
+    // Save final level
+    this->make_lsa().dir() = localdir;
 
     CELER_ENSURE(!this->has_next_step());
     return *this;
@@ -527,29 +551,29 @@ CELER_FUNCTION void OrangeTrackView::move_internal(real_type dist)
  * Move within the current volume to a nearby point.
  *
  * \todo Currently it's up to the caller to make sure that the position is
- * "nearby". We should actually test this with a safety distance.
+ * "nearby". We should actually test this with an "is inside" call.
  */
 CELER_FUNCTION void OrangeTrackView::move_internal(Real3 const& pos)
 {
+    // Transform all nonlocal levels
     auto local_pos = pos;
-
-    for (auto i : range(this->level() + 1))
+    auto apply_transform = TransformVisitor{params_};
+    auto translate_down
+        = [&local_pos](auto&& t) { local_pos = t.transform_down(local_pos); };
+    for (auto lev : range(LevelId{this->level()}))
     {
-        auto lsa = this->make_lsa(LevelId{i});
+        auto lsa = this->make_lsa(lev);
         lsa.pos() = local_pos;
         lsa.surf() = LocalSurfaceId{};
 
-        if (i < this->level())
-        {
-            auto tracker = this->make_tracker(lsa.universe());
-            auto daughter_id = tracker.daughter(lsa.vol());
-            CELER_ASSERT(daughter_id);
-            // Apply "transform down" based on stored transform
-            local_pos = TransformVisitor{params_}(
-                [pos](auto&& t) { return t.transform_down(pos); },
-                params_.daughters[daughter_id].transform_id);
-        }
+        // Apply "transform down" based on stored transform
+        apply_transform(translate_down,
+                        this->get_transform(this->get_daughter(lsa)));
     }
+    // Save final level and remove any surface state
+    auto lsa = this->make_lsa();
+    lsa.pos() = local_pos;
+    lsa.surf() = LocalSurfaceId{};
 
     this->surface_level() = LevelId{};
     this->clear_next_step();
@@ -589,10 +613,16 @@ CELER_FUNCTION void OrangeTrackView::cross_boundary()
     detail::LocalState local;
     local.pos = lsa.pos();
     local.dir = lsa.dir();
-
     local.volume = lsa.vol();
     local.surface = {lsa.surf(), flip_sense(lsa.sense())};
     local.temp_sense = this->make_temp_sense();
+
+    // Helpers for updating local transforms
+    TransformVisitor apply_transform{params_};
+    auto transform_down_local = [&local](auto&& t) {
+        local.pos = t.transform_down(local.pos);
+        local.dir = t.rotate_down(local.dir);
+    };
 
     // Update the post-crossing volume
     auto tracker = this->make_tracker(lsa.universe());
@@ -629,11 +659,10 @@ CELER_FUNCTION void OrangeTrackView::cross_boundary()
         universe_id = daughter.universe_id;
 
         // Create local state on the daughter level
-        local.pos = TransformVisitor{params_}(
-            [&local](auto&& t) { return t.transform_down(local.pos); },
-            daughter.transform_id);
+        apply_transform(transform_down_local, daughter.transform_id);
         local.volume = {};
         local.surface = {};
+        // XXX I think the next line is redundant
         local.temp_sense = this->make_temp_sense();
 
         // Initialize in daughter and get IDs of volume and potential daughter
@@ -672,34 +701,50 @@ CELER_FUNCTION void OrangeTrackView::set_dir(Real3 const& newdir)
 {
     CELER_EXPECT(is_soft_unit_vector(newdir));
 
-    auto lsa = this->make_lsa();
-
     if (this->is_on_boundary())
     {
         // Changing direction on a boundary is dangerous, as it could mean we
-        // don't leave the volume after all. Evaluate whether the direction
-        // dotted with the surface normal changes (i.e. heading from inside to
-        // outside or vice versa).
+        // don't leave the volume after all.
         auto tracker = this->make_tracker(UniverseId{0});
         detail::UniverseIndexer ui(params_.universe_indexer_data);
-        Real3 const normal = tracker.normal(
+        Real3 normal = tracker.normal(
             this->pos(), ui.local_surface(this->surface_id()).surface);
 
+        // Normal is in *local* coordinates but newdir is in *global*: rotate
+        // up to check
+        auto apply_transform = TransformVisitor{params_};
+        auto rotate_up = [&normal](auto&& t) { normal = t.rotate_up(normal); };
+        for (auto level : range<int>(this->level().unchecked_get()).step(-1))
+        {
+            apply_transform(rotate_up, this->get_transform(LevelId(level)));
+        }
+
+        // Evaluate whether the direction dotted with the surface normal
+        // changes (i.e. heading from inside to outside or vice versa).
         if ((dot_product(normal, newdir) >= 0)
             != (dot_product(normal, this->dir()) >= 0))
         {
+            auto lsa = this->make_lsa();
             // The boundary crossing direction has changed! Reverse our plans
             // to change the logical state and move to a new volume.
             lsa.boundary() = flip_boundary(lsa.boundary());
         }
     }
 
-    // XXX: apply rotate_down over all levels
-    for (auto levelid : range(this->level() + 1))
+    // Complete direction setting by transforming direction all the way down
+    Real3 localdir = newdir;
+    auto apply_transform = TransformVisitor{params_};
+    auto rotate_down
+        = [&localdir](auto&& t) { localdir = t.rotate_down(localdir); };
+    for (auto lev : range(this->level()))
     {
-        auto lsa = this->make_lsa(levelid);
-        lsa.dir() = newdir;
+        auto lsa = this->make_lsa(lev);
+        lsa.dir() = localdir;
+        apply_transform(rotate_down,
+                        this->get_transform(this->get_daughter(lsa)));
     }
+    // Save final level
+    this->make_lsa().dir() = localdir;
 
     this->clear_next_step();
 }
@@ -972,6 +1017,39 @@ CELER_FUNCTION LevelStateAccessor OrangeTrackView::make_lsa() const
 CELER_FUNCTION LevelStateAccessor OrangeTrackView::make_lsa(LevelId level) const
 {
     return LevelStateAccessor(&states_, track_slot_, level);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the daughter ID for the given volume in the given universe.
+ *
+ * \return DaughterId or {} if the current volume is a leaf.
+ */
+CELER_FUNCTION DaughterId
+OrangeTrackView::get_daughter(LevelStateAccessor const& lsa)
+{
+    return this->make_tracker(lsa.universe()).daughter(lsa.vol());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the transform ID for the given daughter.
+ */
+CELER_FUNCTION TransformId OrangeTrackView::get_transform(DaughterId daughter_id)
+{
+    CELER_EXPECT(daughter_id);
+    return params_.daughters[daughter_id].transform_id;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the transform ID for the given daughter.
+ */
+CELER_FUNCTION TransformId OrangeTrackView::get_transform(LevelId lev)
+{
+    CELER_EXPECT(lev < this->level());
+    LevelStateAccessor lsa(&states_, track_slot_, lev);
+    return this->get_transform(this->get_daughter(lsa));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -185,26 +185,25 @@ class OrangeTrackView
     make_local_state(LevelId level) const;
 
     // Whether the next distance-to-boundary has been found
-    CELER_FORCEINLINE_FUNCTION bool has_next_step() const;
+    inline CELER_FUNCTION bool has_next_step() const;
 
     // Invalidate the next distance-to-boundary
-    CELER_FORCEINLINE_FUNCTION void clear_next_step();
+    inline CELER_FUNCTION void clear_next_step();
 
     // Make a LevelStateAccessor for the current thread and level
-    CELER_FORCEINLINE_FUNCTION LevelStateAccessor make_lsa() const;
+    inline CELER_FUNCTION LevelStateAccessor make_lsa() const;
 
     // Make a LevelStateAccessor for the current thread and a given level
-    CELER_FORCEINLINE_FUNCTION LevelStateAccessor make_lsa(LevelId level) const;
+    inline CELER_FUNCTION LevelStateAccessor make_lsa(LevelId level) const;
 
     // Get the daughter ID for the volume in the universe (or null)
-    CELER_FORCEINLINE_FUNCTION DaughterId
-    get_daughter(LevelStateAccessor const& lsa);
+    inline CELER_FUNCTION DaughterId get_daughter(LevelStateAccessor const& lsa);
 
     // Get the transform ID for the given daughter.
-    CELER_FORCEINLINE_FUNCTION TransformId get_transform(DaughterId daughter_id);
+    inline CELER_FUNCTION TransformId get_transform(DaughterId daughter_id);
 
     // Get the transform ID to move from this level to the one below.
-    CELER_FUNCTION TransformId get_transform(LevelId lev);
+    inline CELER_FUNCTION TransformId get_transform(LevelId lev);
 };
 
 //---------------------------------------------------------------------------//
@@ -984,7 +983,7 @@ OrangeTrackView::make_local_state(LevelId level) const
 /*!
  * Whether any next step has been calculated.
  */
-CELER_FUNCTION bool OrangeTrackView::has_next_step() const
+CELER_FORCEINLINE_FUNCTION bool OrangeTrackView::has_next_step() const
 {
     return next_step_ != 0;
 }
@@ -996,7 +995,7 @@ CELER_FUNCTION bool OrangeTrackView::has_next_step() const
  * The next surface ID should only ever be used when next_step is zero, so it
  * is OK to wrap it with the CELERITAS_DEBUG conditional.
  */
-CELER_FUNCTION void OrangeTrackView::clear_next_step()
+CELER_FORCEINLINE_FUNCTION void OrangeTrackView::clear_next_step()
 {
     next_step_ = 0;
 }
@@ -1005,7 +1004,7 @@ CELER_FUNCTION void OrangeTrackView::clear_next_step()
 /*!
  * Make a LevelStateAccessor for the current thread and level.
  */
-CELER_FUNCTION LevelStateAccessor OrangeTrackView::make_lsa() const
+CELER_FORCEINLINE_FUNCTION LevelStateAccessor OrangeTrackView::make_lsa() const
 {
     return this->make_lsa(this->level());
 }
@@ -1014,7 +1013,8 @@ CELER_FUNCTION LevelStateAccessor OrangeTrackView::make_lsa() const
 /*!
  * Make a LevelStateAccessor for the current thread and a given level.
  */
-CELER_FUNCTION LevelStateAccessor OrangeTrackView::make_lsa(LevelId level) const
+CELER_FORCEINLINE_FUNCTION LevelStateAccessor
+OrangeTrackView::make_lsa(LevelId level) const
 {
     return LevelStateAccessor(&states_, track_slot_, level);
 }
@@ -1025,7 +1025,7 @@ CELER_FUNCTION LevelStateAccessor OrangeTrackView::make_lsa(LevelId level) const
  *
  * \return DaughterId or {} if the current volume is a leaf.
  */
-CELER_FUNCTION DaughterId
+CELER_FORCEINLINE_FUNCTION DaughterId
 OrangeTrackView::get_daughter(LevelStateAccessor const& lsa)
 {
     return this->make_tracker(lsa.universe()).daughter(lsa.vol());
@@ -1035,7 +1035,8 @@ OrangeTrackView::get_daughter(LevelStateAccessor const& lsa)
 /*!
  * Get the transform ID for the given daughter.
  */
-CELER_FUNCTION TransformId OrangeTrackView::get_transform(DaughterId daughter_id)
+CELER_FORCEINLINE_FUNCTION TransformId
+OrangeTrackView::get_transform(DaughterId daughter_id)
 {
     CELER_EXPECT(daughter_id);
     return params_.daughters[daughter_id].transform_id;

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -312,7 +312,7 @@ OrangeTrackView& OrangeTrackView::operator=(DetailedInitializer const& init)
         this->level() = states_.level[init.other.track_slot_];
         this->surface_level() = states_.surface_level[init.other.track_slot_];
 
-        for (auto lev : range(LevelId{this->level()}))
+        for (auto lev : range(LevelId{this->level() + 1}))
         {
             // Copy all data accessed via LSA
             auto lsa = this->make_lsa(lev);

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -246,7 +246,7 @@ OrangeTrackView::operator=(Initializer_t const& init)
     local.surface = {};
     local.temp_sense = this->make_temp_sense();
 
-    // Helpers for applying mother-to-daughter transformations
+    // Helpers for applying parent-to-daughter transformations
     TransformVisitor apply_transform{params_};
     auto transform_down_local = [&local](auto&& t) {
         local.pos = t.transform_down(local.pos);

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -137,6 +137,7 @@ enum class SurfaceType : unsigned char
  */
 enum class TransformType : unsigned char
 {
+    no_transformation,  //!< Identity transform
     translation,  //!< Translation only
     transformation,  //!< Translation plus rotation
     size_

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -75,7 +75,7 @@ using SimpleUnitId = OpaqueId<struct SimpleUnitRecord>;
 using RectArrayId = OpaqueId<struct RectArrayRecord>;
 
 //! Identifier for a translation of a single embedded universe
-using TranslationId = OpaqueId<Real3>;
+using TransformId = OpaqueId<struct TransformRecord>;
 
 //! Identifier for a relocatable set of volumes
 using UniverseId = OpaqueId<struct Universe>;
@@ -244,7 +244,7 @@ enum OperatorToken : logic_int
 struct Daughter
 {
     UniverseId universe_id;
-    TranslationId translation_id;
+    TransformId transform_id;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/RectArrayInserter.cc
+++ b/src/orange/detail/RectArrayInserter.cc
@@ -27,6 +27,7 @@ namespace detail
  */
 RectArrayInserter::RectArrayInserter(Data* orange_data)
     : orange_data_(orange_data)
+    , insert_transform_{&orange_data_->transforms, &orange_data_->reals}
 {
     CELER_EXPECT(orange_data);
 }
@@ -72,13 +73,11 @@ RectArrayId RectArrayInserter::operator()(RectArrayInput const& inp)
                    << ")");
 
     std::vector<Daughter> daughters;
-    auto translations_builder = make_builder(&orange_data_->translations);
     for (auto const& daughter_input : inp.daughters)
     {
         Daughter d;
         d.universe_id = daughter_input.universe_id;
-        d.translation_id
-            = translations_builder.push_back(daughter_input.translation);
+        d.transform_id = insert_transform_(daughter_input.translation);
         daughters.push_back(d);
     }
 

--- a/src/orange/detail/RectArrayInserter.hh
+++ b/src/orange/detail/RectArrayInserter.hh
@@ -12,6 +12,8 @@
 #include "orange/OrangeTypes.hh"
 #include "orange/construct/OrangeInput.hh"
 
+#include "TransformInserter.hh"
+
 namespace celeritas
 {
 namespace detail
@@ -37,6 +39,7 @@ class RectArrayInserter
 
   private:
     Data* orange_data_{nullptr};
+    TransformInserter insert_transform_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/TransformInserter.hh
+++ b/src/orange/detail/TransformInserter.hh
@@ -1,0 +1,124 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/detail/TransformInserter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Macros.hh"
+#include "corecel/data/Collection.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "orange/OrangeData.hh"
+#include "orange/transform/VariantTransform.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a compressed transform from a variant.
+ *
+ * TODO: deduplicate transforms via hashes? Define special compressed transform
+ * for 90-degree rotations?
+ */
+class TransformInserter
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    template<class T>
+    using Items = Collection<T, Ownership::value, MemSpace::host>;
+    //!@}
+
+  public:
+    // Construct with defaults
+    inline TransformInserter(Items<TransformRecord>* transforms,
+                             Items<real_type>* reals);
+
+    // DEPRECATED: Return a transform ID from a Real3 translation
+    inline TransformId operator()(Real3 const&);
+
+    // Return a transform ID from a transform variant
+    inline TransformId operator()(VariantTransform const& tr);
+
+    // Construct a transform using known type
+    template<class T>
+    inline TransformId operator()(T const& tr);
+
+  private:
+    TransformId null_transform_;
+    CollectionBuilder<TransformRecord> transforms_;
+    CollectionBuilder<real_type> reals_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with references to params data.
+ */
+TransformInserter::TransformInserter(Items<TransformRecord>* transforms,
+                                     Items<real_type>* reals)
+    : transforms_{transforms}, reals_{reals}
+{
+    CELER_EXPECT(transforms && reals);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a translation
+ *
+ * \deprecated Change the ORANGE input when convenient.
+ */
+TransformId TransformInserter::operator()(Real3 const& tr)
+{
+    if (CELER_UNLIKELY(tr == (Real3{0, 0, 0})))
+    {
+        return (*this)(NoTransformation{});
+    }
+    return (*this)(Translation{tr});
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a transform variant.
+ */
+TransformId TransformInserter::operator()(VariantTransform const& tr)
+{
+    CELER_ASSUME(!tr.valueless_by_exception());
+    return std::visit(*this, tr);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a type.
+ */
+template<class T>
+TransformId TransformInserter::operator()(T const& tr)
+{
+    if constexpr (std::is_same_v<T, NoTransformation>)
+    {
+        // Reuse the same null transform ID everywhere
+        if (null_transform_)
+        {
+            return null_transform_;
+        }
+        // Save the transform ID for later
+        null_transform_ = transforms_.size_id();
+    }
+
+    TransformRecord record;
+    record.type = tr.transform_type();
+    auto data = tr.data();
+    record.data_offset = *reals_.insert_back(data.begin(), data.end()).begin();
+
+    CELER_ASSERT(record);
+    return transforms_.push_back(record);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/orange/detail/TransformInserter.hh
+++ b/src/orange/detail/TransformInserter.hh
@@ -34,7 +34,7 @@ class TransformInserter
     //!@}
 
   public:
-    // Construct with defaults
+    // Construct with pointers to target data
     inline TransformInserter(Items<TransformRecord>* transforms,
                              Items<real_type>* reals);
 
@@ -58,7 +58,7 @@ class TransformInserter
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Construct with references to params data.
+ * Construct with pointers to target data.
  */
 TransformInserter::TransformInserter(Items<TransformRecord>* transforms,
                                      Items<real_type>* reals)
@@ -69,7 +69,7 @@ TransformInserter::TransformInserter(Items<TransformRecord>* transforms,
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct from a translation
+ * Construct from a translation.
  *
  * \deprecated Change the ORANGE input when convenient.
  */
@@ -94,7 +94,7 @@ TransformId TransformInserter::operator()(VariantTransform const& tr)
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct from a type.
+ * Construct from a transform with a known type.
  */
 template<class T>
 TransformId TransformInserter::operator()(T const& tr)

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -125,7 +125,9 @@ struct NumIntersectionGetter
 /*!
  * Construct from full parameter data.
  */
-UnitInserter::UnitInserter(Data* orange_data) : orange_data_(orange_data)
+UnitInserter::UnitInserter(Data* orange_data)
+    : orange_data_(orange_data)
+    , insert_transform_{&orange_data_->transforms, &orange_data_->reals}
 {
     CELER_EXPECT(orange_data);
 
@@ -364,8 +366,7 @@ void UnitInserter::process_daughter(VolumeRecord* vol_record,
 {
     Daughter daughter;
     daughter.universe_id = daughter_input.universe_id;
-    daughter.translation_id = make_builder(&orange_data_->translations)
-                                  .push_back(daughter_input.translation);
+    daughter.transform_id = insert_transform_(daughter_input.translation);
 
     vol_record->daughter_id
         = make_builder(&orange_data_->daughters).push_back(daughter);

--- a/src/orange/detail/UnitInserter.hh
+++ b/src/orange/detail/UnitInserter.hh
@@ -15,6 +15,7 @@
 #include "orange/construct/OrangeInput.hh"
 
 #include "BIHBuilder.hh"
+#include "TransformInserter.hh"
 
 namespace celeritas
 {
@@ -43,9 +44,8 @@ class UnitInserter
 
   private:
     Data* orange_data_{nullptr};
-    detail::BIHBuilder bih_builder_;
-
-    // TODO: additional caches for hashed data?
+    BIHBuilder bih_builder_;
+    TransformInserter insert_transform_;
 
     //// HELPER METHODS ////
 

--- a/src/orange/surf/Surfaces.hh
+++ b/src/orange/surf/Surfaces.hh
@@ -20,10 +20,10 @@ namespace celeritas
 class Surfaces
 {
   public:
-    //@{
-    //! Type aliases
+    //!@{
+    //! \name Type aliases
     using ParamsRef = NativeCRef<OrangeParamsData>;
-    //@}
+    //!@}
 
   public:
     // Construct with reference to persistent data

--- a/src/orange/surf/VariantSurface.cc
+++ b/src/orange/surf/VariantSurface.cc
@@ -22,7 +22,7 @@ struct VariantTransformDispatcher
     VariantSurface const& right;
 
     //! Apply an identity transform (no change)
-    VariantSurface operator()(std::monostate) const { return right; }
+    VariantSurface operator()(NoTransformation const&) const { return right; }
 
     //! Apply a translation
     VariantSurface operator()(Translation const& left) const

--- a/src/orange/transform/NoTransformation.hh
+++ b/src/orange/transform/NoTransformation.hh
@@ -37,7 +37,7 @@ class NoTransformation
 
   public:
     //! Construct with an identity NoTransformation
-    explicit CELER_FUNCTION NoTransformation() = default;
+    NoTransformation() = default;
 
     //! Construct inline from storage
     explicit CELER_FUNCTION NoTransformation(StorageSpan) {}

--- a/src/orange/transform/NoTransformation.hh
+++ b/src/orange/transform/NoTransformation.hh
@@ -1,0 +1,72 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/transform/NoTransformation.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Macros.hh"
+#include "corecel/cont/Span.hh"
+
+#include "../OrangeTypes.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Apply an identity transformation.
+ *
+ * This trivial class has the Transformation interface but has no storage
+ * requirements and simply passes through all its data.
+ */
+class NoTransformation
+{
+  public:
+    //@{
+    //! \name Type aliases
+    using StorageSpan = Span<const real_type, 0>;
+    //@}
+
+    //! Transform type identifier
+    static CELER_CONSTEXPR_FUNCTION TransformType transform_type()
+    {
+        return TransformType::no_transformation;
+    }
+
+  public:
+    //! Construct with an identity NoTransformation
+    explicit CELER_FUNCTION NoTransformation() = default;
+
+    //! Construct inline from storage
+    explicit CELER_FUNCTION NoTransformation(StorageSpan) {}
+
+    //// ACCESSORS ////
+
+    //! Get a view to the data for type-deleted storage
+    CELER_FUNCTION StorageSpan data() const { return {}; }
+
+    //// CALCULATION ////
+
+    //! Transform from daughter to parent (identity)
+    CELER_FUNCTION Real3 const& transform_up(Real3 const& d) const
+    {
+        return d;
+    }
+
+    //! Transform from parent to daughter (identity)
+    CELER_FUNCTION Real3 const& transform_down(Real3 const& d) const
+    {
+        return d;
+    }
+
+    //! Rotate from daughter to parent (identity)
+    CELER_FUNCTION Real3 const& rotate_up(Real3 const& d) const { return d; }
+
+    //! Rotate from parent to daughter (identity)
+    CELER_FUNCTION Real3 const& rotate_down(Real3 const& d) const { return d; }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/transform/TransformTypeTraits.hh
+++ b/src/orange/transform/TransformTypeTraits.hh
@@ -1,0 +1,43 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/transform/TransformTypeTraits.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "orange/OrangeTypes.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+
+class NoTransformation;
+class Transformation;
+class Translation;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Map transform enumeration to surface type.
+ */
+template<TransformType S>
+struct TransformTypeTraits;
+
+#define ORANGE_TRANSFORM_TRAITS(ENUM_VALUE, CLS)          \
+    template<>                                            \
+    struct TransformTypeTraits<TransformType::ENUM_VALUE> \
+    {                                                     \
+        using type = CLS;                                 \
+    }
+
+// clang-format off
+ORANGE_TRANSFORM_TRAITS(no_transformation, NoTransformation);
+ORANGE_TRANSFORM_TRAITS(translation, Translation);
+ORANGE_TRANSFORM_TRAITS(transformation, Transformation);
+// clang-format on
+
+#undef ORANGE_TRANSFORM_TRAITS
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/transform/TransformTypeTraits.hh
+++ b/src/orange/transform/TransformTypeTraits.hh
@@ -19,7 +19,7 @@ class Translation;
 
 //---------------------------------------------------------------------------//
 /*!
- * Map transform enumeration to surface type.
+ * Map transform enumeration to transform class.
  */
 template<TransformType S>
 struct TransformTypeTraits;
@@ -31,13 +31,38 @@ struct TransformTypeTraits;
         using type = CLS;                                 \
     }
 
-// clang-format off
 ORANGE_TRANSFORM_TRAITS(no_transformation, NoTransformation);
 ORANGE_TRANSFORM_TRAITS(translation, Translation);
 ORANGE_TRANSFORM_TRAITS(transformation, Transformation);
-// clang-format on
 
 #undef ORANGE_TRANSFORM_TRAITS
+
+//---------------------------------------------------------------------------//
+/*!
+ * Expand a macro to a switch statement over all possible transform types.
+ *
+ * The \c func argument should be a functor that takes a single argument which
+ * is a TransformTypeTraits instance.
+ */
+template<class F>
+CELER_CONSTEXPR_FUNCTION decltype(auto)
+visit_transform_type(F&& func, TransformType st)
+{
+#define ORANGE_TT_VISIT_CASE(TYPE)          \
+    case TransformType::TYPE:               \
+        return celeritas::forward<F>(func)( \
+            TransformTypeTraits<TransformType::TYPE>{})
+
+    switch (st)
+    {
+        ORANGE_TT_VISIT_CASE(no_transformation);
+        ORANGE_TT_VISIT_CASE(translation);
+        ORANGE_TT_VISIT_CASE(transformation);
+        default:
+            CELER_ASSERT_UNREACHABLE();
+    }
+#undef ORANGE_TT_VISIT_CASE
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/transform/TransformVisitor.hh
+++ b/src/orange/transform/TransformVisitor.hh
@@ -21,13 +21,13 @@ namespace celeritas
 /*!
  * Apply a functor to a type-deleted transform.
  *
- * An instance of this class is like \c std::visit but accepting a TransformId
- * rather than a \c std::variant .
+ * An instance of this class is like \c std::visit but accepting a \c
+ * TransformId rather than a \c std::variant .
  *
  * Example: \code
  TransformVisitor visit_transform{params_};
  auto new_pos = visit_transform(
-    [&pos](auto&& T) { return t.transform_up(pos); },
+    [&pos](auto&& t) { return t.transform_up(pos); },
     daughter.transform_id);
  \endcode
  */

--- a/src/orange/transform/TransformVisitor.hh
+++ b/src/orange/transform/TransformVisitor.hh
@@ -54,7 +54,8 @@ class TransformVisitor
 
     // Apply the function to the transform specified by the given ID
     template<class F>
-    decltype(auto) operator()(F&& typed_visitor, TransformId t);
+    inline CELER_FUNCTION decltype(auto)
+    operator()(F&& typed_visitor, TransformId t);
 
   private:
     TransformRecords const& transforms_;

--- a/src/orange/transform/TransformVisitor.hh
+++ b/src/orange/transform/TransformVisitor.hh
@@ -1,0 +1,133 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/transform/TransformVisitor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/math/Algorithms.hh"
+#include "orange/OrangeData.hh"
+
+#include "NoTransformation.hh"
+#include "TransformTypeTraits.hh"
+#include "Transformation.hh"
+#include "Translation.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Apply a functor to a type-deleted transform.
+ *
+ * An instance of this class is like \c std::visit but accepting a TransformId
+ * rather than a \c std::variant .
+ *
+ * Example: \code
+ TransformVisitor visit_transform{params_};
+ auto new_pos = visit_transform(
+    [&pos](auto&& T) { return t.transform_up(pos); },
+    daughter.transform_id);
+ \endcode
+ */
+class TransformVisitor
+{
+    template<class T>
+    using Items = Collection<T, Ownership::const_reference, MemSpace::native>;
+
+  public:
+    //!@{
+    //! \name Type aliases
+    using ParamsRef = NativeCRef<OrangeParamsData>;
+    using TransformRecords = Items<TransformRecord>;
+    using Reals = Items<real_type>;
+    //!@}
+
+  public:
+    // Construct manually from required data
+    inline CELER_FUNCTION
+    TransformVisitor(TransformRecords const& transforms, Reals const& reals);
+
+    // Construct from ORANGE params
+    explicit inline CELER_FUNCTION TransformVisitor(ParamsRef const& params);
+
+    // Apply the function to the transform specified by the given ID
+    template<class F>
+    decltype(auto) operator()(F&& typed_visitor, TransformId t);
+
+  private:
+    TransformRecords const& transforms_;
+    Reals const& reals_;
+
+    // Construct a transform from a data offset
+    template<class T>
+    inline CELER_FUNCTION T make_transform(OpaqueId<real_type> data_offset) const;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct manually from required data.
+ */
+CELER_FUNCTION
+TransformVisitor::TransformVisitor(TransformRecords const& transforms,
+                                   Reals const& reals)
+    : transforms_{transforms}, reals_{reals}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from ORANGE data.
+ */
+CELER_FUNCTION TransformVisitor::TransformVisitor(ParamsRef const& params)
+    : TransformVisitor{params.transforms, params.reals}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Apply the function to the transform specified by the given ID.
+ */
+template<class F>
+CELER_FUNCTION decltype(auto)
+TransformVisitor::operator()(F&& func, TransformId id)
+{
+    CELER_EXPECT(id < transforms_.size());
+
+    // Load transform record (type + data)
+    TransformRecord const tr = transforms_[id];
+    CELER_ASSERT(tr);
+
+    // Apply type-deleted functor based on type
+    return visit_transform_type(
+        [&](auto tt_traits) {
+            // Call the user-provided action using the reconstructed transform
+            using TF = typename decltype(tt_traits)::type;
+            return func(this->make_transform<TF>(tr.data_offset));
+        },
+        tr.type);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Apply the function to the transform specified by the given ID.
+ */
+template<class T>
+CELER_FUNCTION T
+TransformVisitor::make_transform(OpaqueId<real_type> data_offset) const
+{
+    CELER_EXPECT(data_offset <= reals_.size());
+    constexpr size_type size{T::StorageSpan::extent};
+    CELER_ASSERT(data_offset + size <= reals_.size());
+
+    real_type const* data = reals_[AllItems<real_type>{}].data();
+    return T{Span<real_type const, size>{
+        data + data_offset.unchecked_get(),
+        data + data_offset.unchecked_get() + size}};
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/transform/VariantTransform.cc
+++ b/src/orange/transform/VariantTransform.cc
@@ -23,7 +23,10 @@ struct VariantTransformDispatcher
     VariantTransform const& right;
 
     //! Apply an identity transform (no change)
-    VariantTransform operator()(std::monostate) const { return right; }
+    VariantTransform operator()(NoTransformation const&) const
+    {
+        return right;
+    }
 
     //! Apply a translation
     VariantTransform operator()(Translation const& left) const
@@ -49,7 +52,8 @@ struct VariantTransformDispatcher
  * Apply an identity transform to a bounding box.
  */
 template<class T>
-BoundingBox<T> calc_transform(std::monostate, BoundingBox<T> const& bbox)
+BoundingBox<T>
+calc_transform(NoTransformation const&, BoundingBox<T> const& bbox)
 {
     return bbox;
 }

--- a/src/orange/transform/VariantTransform.hh
+++ b/src/orange/transform/VariantTransform.hh
@@ -9,6 +9,10 @@
 
 #include <variant>
 
+#include "corecel/cont/VariantUtils.hh"
+
+#include "NoTransformation.hh"
+#include "TransformTypeTraits.hh"
 #include "Transformation.hh"
 #include "Translation.hh"
 
@@ -18,9 +22,8 @@ template<class T>
 class BoundingBox;
 
 //---------------------------------------------------------------------------//
-//! std::variant for all transforms, with optional identity transform
-using VariantTransform
-    = std::variant<std::monostate, Translation, Transformation>;
+//! std::variant for all transforms.
+using VariantTransform = EnumVariant<TransformType, TransformTypeTraits>;
 
 //---------------------------------------------------------------------------//
 // Apply the left "daughter-to-parent" transform to the right.

--- a/src/orange/transform/detail/TransformTransformer.hh
+++ b/src/orange/transform/detail/TransformTransformer.hh
@@ -7,11 +7,10 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <variant>
-
 #include "orange/MatrixUtils.hh"
 #include "orange/Types.hh"
 
+#include "../NoTransformation.hh"
 #include "../Transformation.hh"
 #include "../Translation.hh"
 
@@ -59,7 +58,10 @@ class TransformTransformer
     explicit TransformTransformer(Transformation const& tr) : tr_{tr} {}
 
     //! Transform an identity
-    Transformation operator()(std::monostate) const { return tr_; }
+    Transformation const& operator()(NoTransformation const&) const
+    {
+        return tr_;
+    }
 
     //!@{
     //! Transform a transformation

--- a/src/orange/transform/detail/TransformTranslator.hh
+++ b/src/orange/transform/detail/TransformTranslator.hh
@@ -7,12 +7,11 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <variant>
-
 #include "corecel/math/ArrayOperators.hh"
 #include "orange/MatrixUtils.hh"
 #include "orange/Types.hh"
 
+#include "../NoTransformation.hh"
 #include "../Transformation.hh"
 #include "../Translation.hh"
 
@@ -66,7 +65,10 @@ class TransformTranslator
     //// TRANSFORMATIONS ////
 
     //! Transform an identity
-    Translation operator()(std::monostate) const { return tr_; }
+    Translation const& operator()(NoTransformation const&) const
+    {
+        return tr_;
+    }
 
     inline Transformation operator()(Mat3 const&) const;
 

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -103,11 +103,27 @@ TEST(ItemMap, basic)
     }
 }
 
+TEST(CollectionBuilder, accessors)
+{
+    Collection<int, Ownership::value, MemSpace::host> data;
+    using IdType = OpaqueId<int>;
+    CollectionBuilder builder{&data};
+    EXPECT_EQ(0, builder.size());
+    EXPECT_EQ(IdType{0}, builder.size_id());
+}
+
 TEST(CollectionBuilder, size_limits)
 {
     using IdType = OpaqueId<struct Tiny, std::uint8_t>;
     Collection<double, Ownership::value, MemSpace::host, IdType> host_val;
-    auto build = make_builder(&host_val);
+    auto build = CollectionBuilder(&host_val);
+
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(build.reserve(257), DebugError);
+        EXPECT_THROW(build.resize(1000), DebugError);
+    }
+
     std::vector<double> dummy(254);
     auto irange = build.insert_back(dummy.begin(), dummy.end());
     EXPECT_EQ(0, irange.begin()->unchecked_get());
@@ -120,17 +136,21 @@ TEST(CollectionBuilder, size_limits)
     // with a push_back and not a range insertion.
     build.push_back(123);
 
-#if CELERITAS_DEBUG
-    // Inserting 256 elements when 255 is the max int *must* raise an error
-    // when debug assertions are enabled.
-    EXPECT_THROW(build.push_back(1234.5), DebugError);
-#else
-    // With bounds checking disabled, a one-off check when getting a reference
-    // should catch the size failure.
-    build.push_back(12345.6);
-    Collection<double, Ownership::const_reference, MemSpace::host, IdType> host_ref;
-    EXPECT_THROW(host_ref = host_val, RuntimeError);
-#endif
+    if (CELERITAS_DEBUG)
+    {
+        // Inserting 256 elements when 255 is the max int *must* raise an error
+        // when debug assertions are enabled.
+        EXPECT_THROW(build.push_back(1234.5), DebugError);
+    }
+    else
+    {
+        // With bounds checking disabled, a one-off check when getting a
+        // reference should catch the size failure.
+        build.push_back(12345.6);
+        Collection<double, Ownership::const_reference, MemSpace::host, IdType>
+            host_ref;
+        EXPECT_THROW(host_ref = host_val, RuntimeError);
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/transform/VariantTransform.test.cc
+++ b/test/orange/transform/VariantTransform.test.cc
@@ -82,7 +82,7 @@ TEST_F(VariantTransformTest, variant_types)
     Transformation tf{make_rotation(Axis::z, Turn{0.25}), Real3{0, 0, 2}};
 
     VariantTransform const identity;
-    EXPECT_TRUE(holds_alternative<std::monostate>(
+    EXPECT_TRUE(holds_alternative<NoTransformation>(
         apply_transform(identity, identity)));
     EXPECT_TRUE(holds_alternative<Translation>(apply_transform(identity, tl)));
     EXPECT_TRUE(


### PR DESCRIPTION
This adds under-the-hood support for transforms in Celeritas. I have:
- added a GPU-friendly "no transform" special case to replace the `std::monostate` in the existing `TransformVariant`
- implemented a `TransformVisitor` that will apply a functor based on a given transform ID
- added some helper functions to CollectionBuilder
- replaced TranslationId with TransformId
- added a `TransformInserter` that converts `std::variant` to a `TransformRecord` and adds it to orange params (currently the only signature used is to transform a `Real3` to `Translation` to keep the orange input interface the same to ease compatibility issues with SCALE)
- replaced all the explicit transforms in OrangeTrackView with a call to the visitor

@elliottbiondo : In the final commit I went the extra mile and implemented what I think should be full parent-to-daughter transformations (including rotating the direction up and down as needed). I can back that out and add it to a follow-up PR that adds full support for transformations in the SCALE front end, but I don't want to do that until the current queue of ORANGE SCALE MRs is empty.