### PR TITLE
Use trailing underscore for "sentinel" classes in OpaqueId

### DIFF
--- a/doc/appendices/development.rst
+++ b/doc/appendices/development.rst
@@ -210,16 +210,18 @@ verb. For example::
 
 There are many opportunities to use ``OpaqueId`` in GPU code to indicate
 indexing into particular vectors. To maintain consistency, we let an
-index into a vector of ``Foo`` have a corresponding ``OpaqueId``  type::
+index into a vector of ``Foo`` objects have a corresponding ``OpaqueId``
+type::
 
     using FooId = OpaqueId<Foo>;
 
 and ideally be defined either immediately after ``Foo`` or in a
 :file:`Types.hh` file.  Some ``OpaqueId`` types may have only a "symbolic"
-corresponding type, in which case
-a tag struct can be be defined inline::
+corresponding type, in which case a tag struct can be be defined inline, using
+an underscore suffix as a convention indicating the type does not correspond to
+an actual class::
 
-   using BarId = OpaqueId<struct Bar>;
+   using BarId = OpaqueId<struct Bar_>;
 
 .. note:: Public functions in user-facing Geant4 classes (those in ``accel``)
    should try to conform to Geant4-style naming conventions, especially because

--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -33,7 +33,7 @@ using ActionId = OpaqueId<class ActionInterface>;
 using ElementId = OpaqueId<struct ElementRecord>;
 
 //! Counter for the initiating event for a track
-using EventId = OpaqueId<struct Event>;
+using EventId = OpaqueId<struct Event_>;
 
 //! Opaque index to IsotopeRecord in a vector
 using IsotopeId = OpaqueId<struct IsotopeRecord>;
@@ -51,14 +51,14 @@ using ParticleId = OpaqueId<struct ParticleRecord>;
 using ProcessId = OpaqueId<class Process>;
 
 //! Unique ID (for an event) of a track among all primaries and secondaries
-using TrackId = OpaqueId<struct Track>;
+using TrackId = OpaqueId<struct Track_>;
 
 //---------------------------------------------------------------------------//
 // (detailed type aliases)
 //---------------------------------------------------------------------------//
 
 //! Opaque index for mapping volume-specific "sensitive detector" objects
-using DetectorId = OpaqueId<struct Detector>;
+using DetectorId = OpaqueId<struct Detector_>;
 
 //! Opaque index to one elemental component datum in a particular material
 using ElementComponentId = OpaqueId<struct MatElementComponent>;
@@ -73,7 +73,7 @@ using ParticleProcessId = OpaqueId<ProcessId>;
 using ParticleModelId = OpaqueId<ModelId>;
 
 //! Opaque index of electron subshell
-using SubshellId = OpaqueId<struct Subshell>;
+using SubshellId = OpaqueId<struct Subshell_>;
 
 //---------------------------------------------------------------------------//
 // ENUMERATIONS

--- a/src/celeritas/ext/VecgeomData.hh
+++ b/src/celeritas/ext/VecgeomData.hh
@@ -13,6 +13,7 @@
 #include "corecel/data/Collection.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "orange/Types.hh"
 #include "celeritas/Types.hh"
 
 #include "detail/VecgeomNavCollection.hh"
@@ -20,11 +21,6 @@
 
 namespace celeritas
 {
-//---------------------------------------------------------------------------//
-
-//! Identifier for a geometry volume
-using VolumeId = OpaqueId<struct Volume>;
-
 //---------------------------------------------------------------------------//
 // PARAMS
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/Logger.hh
+++ b/src/corecel/io/Logger.hh
@@ -10,8 +10,6 @@
 #include <string>
 #include <utility>
 
-#include "corecel/io/Logger.hh"
-
 #include "LoggerTypes.hh"
 #include "detail/LoggerMessage.hh"  // IWYU pragma: export
 

--- a/src/corecel/sys/ThreadId.hh
+++ b/src/corecel/sys/ThreadId.hh
@@ -12,20 +12,14 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-// Forward declare types to avoid potential conflicts (e.g. PTL::Thread)
-class Stream;
-struct Thread;
-struct TrackSlot;
-
-//---------------------------------------------------------------------------//
 //! Unique ID for multithreading/multitasking
-using StreamId = OpaqueId<class Stream>;
+using StreamId = OpaqueId<class Stream_>;
 
 //! Index of a thread inside the current kernel
-using ThreadId = OpaqueId<struct Thread>;
+using ThreadId = OpaqueId<struct Thread_>;
 
 //! Index of a state inside the vector of all states
-using TrackSlotId = OpaqueId<struct TrackSlot>;
+using TrackSlotId = OpaqueId<struct TrackSlot_>;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -45,13 +45,13 @@ using AxisTag = std::integral_constant<Axis, T>;
 //// ID TYPES ////
 
 //! Identifier for a BIHNode objects
-using BIHNodeId = OpaqueId<struct BIHNode>;
+using BIHNodeId = OpaqueId<struct BIHNode_>;
 
 //! Identifier for a daughter universe
 using DaughterId = OpaqueId<struct Daughter>;
 
 //! Identifier for a face within a volume
-using FaceId = OpaqueId<struct Face>;
+using FaceId = OpaqueId<struct Face_>;
 
 //! Bounding box used for acceleration
 using FastBBox = BoundingBox<fast_real_type>;
@@ -60,13 +60,13 @@ using FastBBox = BoundingBox<fast_real_type>;
 using FastBBoxId = OpaqueId<FastBBox>;
 
 //! Identifier for the current "level", i.e., depth of embedded universe
-using LevelId = OpaqueId<struct Level>;
+using LevelId = OpaqueId<struct Level_>;
 
 //! Local identifier for a surface within a universe
-using LocalSurfaceId = OpaqueId<struct LocalSurface>;
+using LocalSurfaceId = OpaqueId<struct LocalSurface_>;
 
 //! Local identifier for a geometry volume within a universe
-using LocalVolumeId = OpaqueId<struct LocalVolume>;
+using LocalVolumeId = OpaqueId<struct LocalVolume_>;
 
 //! Opaque index for "simple unit" data
 using SimpleUnitId = OpaqueId<struct SimpleUnitRecord>;
@@ -78,7 +78,7 @@ using RectArrayId = OpaqueId<struct RectArrayRecord>;
 using TranslationId = OpaqueId<Real3>;
 
 //! Identifier for a relocatable set of volumes
-using UniverseId = OpaqueId<struct Universe>;
+using UniverseId = OpaqueId<struct Universe_>;
 
 //---------------------------------------------------------------------------//
 // ENUMERATIONS

--- a/src/orange/Types.hh
+++ b/src/orange/Types.hh
@@ -32,10 +32,10 @@ using SquareMatrixReal3 = SquareMatrix<real_type, 3>;
 //---------------------------------------------------------------------------//
 
 //! Identifier for a surface (for surface-based geometries)
-using SurfaceId = OpaqueId<struct Surface>;
+using SurfaceId = OpaqueId<struct Surface_>;
 
 //! Identifier for a geometry volume
-using VolumeId = OpaqueId<struct Volume>;
+using VolumeId = OpaqueId<struct Volume_>;
 
 //---------------------------------------------------------------------------//
 // ENUMERATIONS

--- a/src/orange/univ/detail/Types.hh
+++ b/src/orange/univ/detail/Types.hh
@@ -26,12 +26,9 @@ namespace detail
  * bit field to compress the ID and sense at the cost of reducing the max
  * number of surfaces/faces by a factor of two.
  */
-template<class ValueT>
+template<class IdT>
 class OnTface
 {
-  public:
-    using IdT = OpaqueId<ValueT>;
-
   public:
     //! Not on a surface
     constexpr OnTface() = default;
@@ -77,25 +74,25 @@ class OnTface
 };
 
 //! Equality of an OnFace (mostly for testing)
-template<class ValueT>
+template<class IdT>
 CELER_CONSTEXPR_FUNCTION bool
-operator==(OnTface<ValueT> const& lhs, OnTface<ValueT> const& rhs) noexcept
+operator==(OnTface<IdT> const& lhs, OnTface<IdT> const& rhs) noexcept
 {
     return lhs.id() == rhs.id()
            && (!lhs || lhs.uncheckced_sense() == rhs.unchecked_sense());
 }
 
 //! Inequality for OnFace
-template<class ValueT>
+template<class IdT>
 CELER_CONSTEXPR_FUNCTION bool
-operator!=(OnTface<ValueT> const& lhs, OnTface<ValueT> const& rhs) noexcept
+operator!=(OnTface<IdT> const& lhs, OnTface<IdT> const& rhs) noexcept
 {
     return !(lhs == rhs);
 }
 
-using OnSurface = OnTface<struct Surface>;
-using OnLocalSurface = OnTface<struct LocalSurface>;
-using OnFace = OnTface<struct Face>;
+using OnSurface = OnTface<SurfaceId>;
+using OnLocalSurface = OnTface<LocalSurfaceId>;
+using OnFace = OnTface<FaceId>;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -201,7 +201,6 @@ celeritas_setup_tests(SERIAL PREFIX orange
 # Base
 celeritas_add_test(orange/BoundingBox.test.cc)
 celeritas_add_test(orange/BoundingBoxUtils.test.cc)
-celeritas_add_test(orange/CsgTree.test.cc)
 celeritas_add_test(orange/MatrixUtils.test.cc)
 celeritas_add_test(orange/Orange.test.cc)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -201,6 +201,7 @@ celeritas_setup_tests(SERIAL PREFIX orange
 # Base
 celeritas_add_test(orange/BoundingBox.test.cc)
 celeritas_add_test(orange/BoundingBoxUtils.test.cc)
+celeritas_add_test(orange/CsgTree.test.cc)
 celeritas_add_test(orange/MatrixUtils.test.cc)
 celeritas_add_test(orange/Orange.test.cc)
 

--- a/test/celeritas/grid/GridIdFinder.test.cc
+++ b/test/celeritas/grid/GridIdFinder.test.cc
@@ -22,7 +22,7 @@ class GridIdFinderTest : public Test
 {
   protected:
     using Energy = units::MevEnergy;
-    using IdT = OpaqueId<struct Foo>;
+    using IdT = OpaqueId<struct Foo_>;
     using FinderT = GridIdFinder<Energy, IdT>;
 
     std::vector<Energy::value_type> grid;

--- a/test/celeritas/random/Selector.test.cc
+++ b/test/celeritas/random/Selector.test.cc
@@ -95,7 +95,7 @@ TEST(SelectorTest, make_selector)
 
 TEST(SelectorTest, selector_element)
 {
-    using ElementId = OpaqueId<struct Element>;
+    using ElementId = OpaqueId<struct Element_>;
     static double const macro_xs[] = {1.0, 2.0, 4.0};
     std::vector<int> evaluated;
     auto get_xs = [&evaluated](ElementId el) {

--- a/test/corecel/cont/LabelIdMultiMap.test.cc
+++ b/test/corecel/cont/LabelIdMultiMap.test.cc
@@ -23,7 +23,7 @@ namespace
 {
 //---------------------------------------------------------------------------//
 
-using CatId = OpaqueId<struct Cat>;
+using CatId = OpaqueId<struct Cat_>;
 using CatMultiMap = LabelIdMultiMap<CatId>;
 using VecLabel = CatMultiMap::VecLabel;
 

--- a/test/corecel/cont/Range.test.cc
+++ b/test/corecel/cont/Range.test.cc
@@ -311,7 +311,7 @@ TEST(RangeTest, backward_conversion)
 
 TEST(RangeTest, opaque_id)
 {
-    using MatId = OpaqueId<struct Mat>;
+    using MatId = OpaqueId<struct Mat_>;
 
     {
         Range<MatId> fr;

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -105,7 +105,7 @@ TEST(ItemMap, basic)
 
 TEST(CollectionBuilder, size_limits)
 {
-    using IdType = OpaqueId<struct Tiny, std::uint8_t>;
+    using IdType = OpaqueId<struct Tiny_, std::uint8_t>;
     Collection<double, Ownership::value, MemSpace::host, IdType> host_val;
     auto build = make_builder(&host_val);
     std::vector<double> dummy(254);


### PR DESCRIPTION
I ran into a problem on a branch that a new `namespace celeritas { namespace csg { struct Surface; }}` caused an ambiguity conflict with the implicitly defined struct in `namespace celeritas { using SurfaceId = OpaqueId<struct Surface>; }`. Since we have previously had similar problems (#276) I think it would make it clearer to mark with a trailing underscore the classes that *don't* correspond to a real class.

```
/Users/seth/.local/src/celeritas/test/orange/CsgTree.test.cc:107:20: error: reference to 'Surface' is ambiguous
    EXPECT_EQ(Node{Surface{S{1}}}, tree_[N{2}]);
                   ^
/Users/seth/.local/src/celeritas/src/orange/Types.hh:35:35: note: candidate found by name lookup is 'celeritas::Surface'
using SurfaceId = OpaqueId<struct Surface>;
                                  ^
/Users/seth/.local/src/celeritas/src/orange/construct/CsgTypes.hh:55:8: note: candidate found by name lookup is 'celeritas::csg::Surface'
struct Surface
       ^
1 error generated.
```

Also I've changed a couple places (`OnFaceT`, vecgeom `VolumeId` typedef) to reuse existing OpaqueId types rather than effectively redeclaring them.