### PR TITLE
Fix Geant4 step limiter when ionization is disabled

### DIFF
--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -109,6 +109,8 @@ struct GeantPhysicsOptions
     units::MevEnergy lowest_electron_energy{0.001};  // 1 keV
     //! Kill secondaries below the production cut
     bool apply_cuts{false};
+    //! Set the default production cut for all particle types [cm]
+    real_type default_cutoff{0.1};
     //!@}
 
     //!@{

--- a/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
+++ b/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
@@ -92,6 +92,7 @@ void from_json(nlohmann::json const& j, GeantPhysicsOptions& options)
     GPO_LOAD_OPTION(linear_loss_limit);
     GPO_LOAD_OPTION(lowest_electron_energy);
     GPO_LOAD_OPTION(apply_cuts);
+    GPO_LOAD_OPTION(default_cutoff);
 
     GPO_LOAD_OPTION(msc_range_factor);
     GPO_LOAD_OPTION(msc_safety_factor);
@@ -132,6 +133,7 @@ void to_json(nlohmann::json& j, GeantPhysicsOptions const& options)
     GPO_SAVE_OPTION(linear_loss_limit);
     GPO_SAVE_OPTION(lowest_electron_energy);
     GPO_SAVE_OPTION(apply_cuts);
+    GPO_SAVE_OPTION(default_cutoff);
 
     GPO_SAVE_OPTION(msc_range_factor);
     GPO_SAVE_OPTION(msc_safety_factor);

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -24,6 +24,7 @@
 #include <G4PhotoElectricEffect.hh>
 #include <G4PhysicsListHelper.hh>
 #include <G4Positron.hh>
+#include <G4ProcessManager.hh>
 #include <G4ProcessType.hh>
 #include <G4Proton.hh>
 #include <G4RayleighScattering.hh>
@@ -270,6 +271,28 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
     {
         physics_list->RegisterProcess(
             new GeantBremsstrahlungProcess(options_.brems), p);
+
+        if (!options_.ionization)
+        {
+            // If ionization is turned off, activate the along-step "do it" for
+            // bremsstrahlung *after* the process has been registered and set
+            // the order to be the same as the default post-step order. See \c
+            // G4PhysicsListHelper and the ordering parameter table for more
+            // information on which "do its" are activated for each process and
+            // the default process ordering.
+            auto* process_manager = p->GetProcessManager();
+            CELER_ASSERT(process_manager);
+            auto* bremsstrahlung = dynamic_cast<GeantBremsstrahlungProcess*>(
+                process_manager->GetProcess("eBrem"));
+            CELER_ASSERT(bremsstrahlung);
+            auto order = process_manager->GetProcessOrdering(
+                bremsstrahlung, G4ProcessVectorDoItIndex::idxPostStep);
+            process_manager->SetProcessOrdering(
+                bremsstrahlung, G4ProcessVectorDoItIndex::idxAlongStep, order);
+
+            // Let this process be a candidate for range limiting the step
+            bremsstrahlung->SetIonisation(true);
+        }
 
         auto msg = CELER_LOG(debug);
         msg << "Loaded Bremsstrahlung with ";

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -85,6 +85,7 @@ GeantPhysicsList::GeantPhysicsList(Options const& options) : options_(options)
         em_parameters.SetMscEnergyLimit(100 * CLHEP::TeV);
     }
     em_parameters.SetApplyCuts(options.apply_cuts);
+    this->SetDefaultCutValue(options.default_cutoff * CLHEP::cm);
 
     int verb = options_.verbose ? 1 : 0;
     this->SetVerboseLevel(verb);

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -181,7 +181,7 @@ PhysicsParams::PhysicsParams(Input inp)
  */
 auto PhysicsParams::processes(ParticleId id) const -> SpanConstProcessId
 {
-    CELER_EXPECT(id < this->num_processes());
+    CELER_EXPECT(id < this->host_ref().process_groups.size());
     auto const& data = this->host_ref();
     return data.process_ids[data.process_groups[id].processes];
 }

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -230,7 +230,7 @@ class FourSteelSlabsEmStandard : public GeantImporterTest
         {
             nlohmann::json out = opts;
             static char const expected[]
-                = R"json({"annihilation":true,"apply_cuts":false,"brems":"all","compton_scattering":true,"coulomb_scattering":false,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_conversion":true,"gamma_general":false,"integral_approach":true,"ionization":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban_extended","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"photoelectric":true,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
+                = R"json({"annihilation":true,"apply_cuts":false,"brems":"all","compton_scattering":true,"coulomb_scattering":false,"default_cutoff":0.1,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_conversion":true,"gamma_general":false,"integral_approach":true,"ionization":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban_extended","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"photoelectric":true,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
             EXPECT_EQ(std::string(expected), std::string(out.dump()))
                 << "\n/*** REPLACE ***/\nR\"json(" << std::string(out.dump())
                 << ")json\"\n/******/";


### PR DESCRIPTION
I believe the difference @mrguilima is seeing between Geant4 and Celeritas in the bremsstrahlung step length is because the step is *only* being limited by the distance to interaction (and not the range) in our Geant4 apps. When a process is registered to the physics list, the [default process ordering](https://github.com/Geant4/geant4/blob/master/source/physics_lists/builders/OrderingParameterTable) is used (this specifies in what order the processes' at rest, along-step, and post-step `GPIL`/`DoIt` methods are called by the stepping manager, and whether any of them are inactive). The along-step methods for ionization are active and for bremsstrahlung are inactive by default, since the ionization dE/dx and range tables will contain the contributions from all energy loss processes. **When ionization is missing, we need to activate the along-step for brems**—that is done here in our `GeantPhysicsList`. I also added an option to set the default cutoff value (mainly for debugging).

@mrguilima could you update the geant validation app with this change and see if the brems results improve?