### PR TITLE
Fix Seltzer-Berger max xs for positrons

### DIFF
--- a/src/celeritas/em/distribution/SBEnergyDistribution.hh
+++ b/src/celeritas/em/distribution/SBEnergyDistribution.hh
@@ -27,12 +27,6 @@ struct SBElectronXsCorrector
 
     //! No cross section scaling for any exiting energy
     CELER_FUNCTION real_type operator()(units::MevEnergy) const { return 1; }
-
-    // Calculate maximum differential cross section for the incident energy
-    CELER_FUNCTION Xs max_xs(SBEnergyDistHelper const& helper) const
-    {
-        return helper.max_xs();
-    }
 };
 
 //---------------------------------------------------------------------------//
@@ -141,7 +135,7 @@ CELER_FUNCTION
 SBEnergyDistribution<X>::SBEnergyDistribution(SBEnergyDistHelper const& helper,
                                               X scale_xs)
     : helper_(helper)
-    , inv_max_xs_(1 / scale_xs.max_xs(helper).value())
+    , inv_max_xs_(1 / helper.max_xs().value())
     , scale_xs_(::celeritas::move(scale_xs))
 {
 }

--- a/src/celeritas/em/interactor/detail/SBPositronXsCorrector.hh
+++ b/src/celeritas/em/interactor/detail/SBPositronXsCorrector.hh
@@ -13,7 +13,6 @@
 #include "corecel/math/NumericLimits.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/Quantities.hh"
-#include "celeritas/em/distribution/SBEnergyDistHelper.hh"
 #include "celeritas/mat/ElementView.hh"
 
 namespace celeritas
@@ -70,9 +69,6 @@ class SBPositronXsCorrector
     // Calculate cross section scaling factor for the given exiting energy
     inline CELER_FUNCTION real_type operator()(Energy energy) const;
 
-    // Get the maximum differential cross section for the incident energy
-    inline CELER_FUNCTION Xs max_xs(SBEnergyDistHelper const& helper) const;
-
   private:
     //// DATA ////
 
@@ -124,19 +120,6 @@ CELER_FUNCTION real_type SBPositronXsCorrector::operator()(Energy energy) const
     real_type result = std::exp(alpha_z_ * celeritas::min(delta, real_type{0}));
     CELER_ENSURE(result <= 1);
     return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the maximum differential cross section for the given incident energy.
- *
- * The positron cross section is always maximum at the first reduced photon
- * energy grid point.
- */
-CELER_FUNCTION auto
-SBPositronXsCorrector::max_xs(SBEnergyDistHelper const& helper) const -> Xs
-{
-    return helper.xs_zero();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -75,10 +75,8 @@ SeltzerBergerModel::SeltzerBergerModel(ActionId id,
     for (auto el_id : range(ElementId{materials.num_elements()}))
     {
         auto element = materials.get(el_id);
-        this->append_table(element,
-                           load_sb_table(element.atomic_number()),
-                           &host_data.differential_xs,
-                           host_data.electron_mass);
+        this->append_table(load_sb_table(element.atomic_number()),
+                           &host_data.differential_xs);
     }
     CELER_ASSERT(host_data.differential_xs.elements.size()
                  == materials.num_elements());
@@ -159,10 +157,8 @@ ActionId SeltzerBergerModel::action_id() const
  * and y = scaled exiting energy (E_gamma / E_inc)
  * and values are the cross sections.
  */
-void SeltzerBergerModel::append_table(ElementView const& element,
-                                      ImportSBTable const& imported,
-                                      HostXsTables* tables,
-                                      Mass electron_mass) const
+void SeltzerBergerModel::append_table(ImportSBTable const& imported,
+                                      HostXsTables* tables) const
 {
     auto reals = make_builder(&tables->reals);
 
@@ -199,32 +195,6 @@ void SeltzerBergerModel::append_table(ElementView const& element,
         CELER_ASSERT(max_el < num_y);
         // Save it!
         argmax[i] = max_el;
-
-        if constexpr (CELERITAS_DEBUG)
-        {
-            using Energy = units::MevEnergy;
-
-            // Check that the maximum scaled positron cross section is always
-            // at the first reduced photon energy grid point
-            real_type inc_energy = std::exp(imported.x[i]);
-            SBPositronXsCorrector scale_xs(electron_mass,
-                                           element,
-                                           Energy{imported.y[0] * inc_energy},
-                                           Energy{inc_energy});
-
-            // When the reduced photon energy is 1 the scaling factor is 0
-            size_type num_scaled = num_y - 1;
-            CELER_ASSERT(imported.y[num_scaled] == 1);
-
-            std::vector<real_type> scaled_xs(iter, iter + num_scaled);
-            for (size_type j : range(num_scaled))
-            {
-                scaled_xs[j] *= scale_xs(Energy{imported.y[j] * inc_energy});
-            }
-            CELER_ASSERT(std::max_element(scaled_xs.begin(), scaled_xs.end())
-                             - scaled_xs.begin()
-                         == 0);
-        }
     }
     table.argmax
         = make_builder(&tables->sizes).insert_back(argmax.begin(), argmax.end());

--- a/src/celeritas/em/model/SeltzerBergerModel.hh
+++ b/src/celeritas/em/model/SeltzerBergerModel.hh
@@ -14,7 +14,6 @@
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/SeltzerBergerData.hh"
 #include "celeritas/io/ImportSBTable.hh"
-#include "celeritas/mat/ElementView.hh"
 #include "celeritas/phys/AtomicNumber.hh"
 #include "celeritas/phys/ImportedModelAdapter.hh"
 #include "celeritas/phys/ImportedProcessAdapter.hh"
@@ -103,10 +102,7 @@ class SeltzerBergerModel final : public Model
     ImportedModelAdapter imported_;
 
     using HostXsTables = HostVal<SeltzerBergerTableData>;
-    void append_table(ElementView const& element,
-                      ImportSBTable const& table,
-                      HostXsTables* tables,
-                      Mass electron_mass) const;
+    void append_table(ImportSBTable const& table, HostXsTables* tables) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -207,9 +207,14 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
     };
 
     // Note: the first point has a very low cross section compared to
-    // ionization so won't be encountered in practice. The differential cross
-    // section distribution is much flatter there, so there should be lower
-    // rejection. The second point is where the maximum of the differential SB
+    // ionization so won't be encountered in practice. The electron
+    // differential cross section distribution is much flatter there, so there
+    // should be lower rejection. However, the scaled positron DCS drops
+    // quickly from its maximum (equal to the electron DCS) to near zero at
+    // this point, so the rejection rate will be very high for incident
+    // positrons (see
+    // https://github.com/celeritas-project/celeritas/pull/922#discussion_r1315295079).
+    // The second point is where the maximum of the electron differential SB
     // data switches between a high-exit-energy peak and a low-exit-energy
     // peak, which should result in a higher rejection rate. The remaining
     // points are arbitrary.

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -188,7 +188,6 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
 
     int const num_samples = 8192;
     std::vector<double> max_xs;
-    std::vector<double> xs_zero;
     std::vector<double> avg_exit_frac;
     std::vector<double> avg_engine_samples;
 
@@ -223,12 +222,12 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
             this->density_correction(MaterialId{0}, Energy{inc_energy}),
             gamma_cutoff);
         max_xs.push_back(edist_helper.max_xs().value());
-        xs_zero.push_back(edist_helper.xs_zero().value());
 
         // Sample with the electron XS correction
         {
             SBEnergyDistribution<SBElectronXsCorrector> sample_energy(
                 edist_helper, {});
+
             // Loop over many particles
             sample_many(inc_energy, sample_energy);
         }
@@ -280,39 +279,23 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
             // Loop over many particles
             sample_many(inc_energy, sample_energy);
         }
-
-        // Sample with the positron XS correction
-        {
-            ParticleParams const& pp = *this->particle_params();
-
-            SBEnergyDistribution<SBPositronXsCorrector> sample_energy(
-                edist_helper,
-                {pp.get(pp.find(pdg::positron())).mass(),
-                 this->material_params()->get(ElementId{0}),
-                 gamma_cutoff,
-                 Energy{inc_energy}});
-
-            // Loop over many particles
-            sample_many(inc_energy, sample_energy);
-        }
     }
 
     // clang-format off
-    const double expected_max_xs[] = {2.866525852195, 4.72696244794,
-        12.18911946078, 13.93366489719, 13.85758694967, 13.3353235437};
-    const double expected_xs_zero[] = {1.98829818915769, 4.40320232447369,
+    static double const expected_max_xs[] = {2.866525852195, 4.72696244794,
         12.18911946078, 13.93366489719, 13.85758694967, 13.3353235437};
     static double const expected_avg_exit_frac[] = {0.94912259860422,
-        0.49765332179155, 0.082254084865518, 0.064928479979342,
-        0.077435723446377, 0.089209770419741, 0.064206311258969,
-        0.064814238042425};
+        0.90270157074556, 0.49736065674058, 0.27711716215819,
+        0.081515129333292, 0.068559142299853, 0.065803331441324,
+        0.064344514250384, 0.079512002547402, 0.077647502218254,
+        0.085615341879476, 0.086428313853775, 0.065321200129584};
     static double const expected_avg_engine_samples[] = {4.0791015625,
-        4.060546875, 5.13623046875, 4.6572265625, 4.43115234375, 4.35791015625,
-        9.3740234375, 4.65478515625};
+        137.044921875, 4.060546875, 15.74169921875, 5.103515625, 5.26953125,
+        4.67333984375, 4.6572265625, 4.4306640625, 4.4638671875, 4.35400390625,
+        4.349609375, 9.189453125};
     // clang-format on
 
     EXPECT_VEC_SOFT_EQ(expected_max_xs, max_xs);
-    EXPECT_VEC_SOFT_EQ(expected_xs_zero, xs_zero);
     EXPECT_VEC_SOFT_EQ(expected_avg_exit_frac, avg_exit_frac);
     EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
 }

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -225,10 +225,28 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
         max_xs.push_back(edist_helper.max_xs().value());
         xs_zero.push_back(edist_helper.xs_zero().value());
 
-        SBEnergyDistribution<SBElectronXsCorrector> sample_energy(edist_helper,
-                                                                  {});
-        // Loop over many particles
-        sample_many(inc_energy, sample_energy);
+        // Sample with the electron XS correction
+        {
+            SBEnergyDistribution<SBElectronXsCorrector> sample_energy(
+                edist_helper, {});
+            // Loop over many particles
+            sample_many(inc_energy, sample_energy);
+        }
+
+        // Sample with the positron XS correction
+        {
+            ParticleParams const& pp = *this->particle_params();
+
+            SBEnergyDistribution<SBPositronXsCorrector> sample_energy(
+                edist_helper,
+                {pp.get(pp.find(pdg::positron())).mass(),
+                 this->material_params()->get(ElementId{0}),
+                 gamma_cutoff,
+                 Energy{inc_energy}});
+
+            // Loop over many particles
+            sample_many(inc_energy, sample_energy);
+        }
     }
 
     {


### PR DESCRIPTION
This reverts to using the max electron Seltzer-Berger DCS for positrons instead of the first DCS value (which I had mistakenly based on a zero production cut in #401). The xs scaling factor depends on the production cut, and will approach 1 as the exiting gamma energy approaches the cutoff value -- so in the extreme case the max positron xs will be the same as for electrons.

This should resolve the failure in #892, which occurs for low energy positrons when the sampled exiting gamma energy is very close to the production cut.