### PR TITLE
Release v0.3.2

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -181,7 +181,7 @@ set(DOXYGEN_XML_PROGRAMLISTING NO)
 
 # Annotations break breathe parsing
 foreach(_var
-  CELER_FUNCTION CELER_FORCEINLINE_FUNCTION CELER_CONSTEXPR_FUNCTION
+  CELER_FUNCTION CELER_FORCEINLINE CELER_FORCEINLINE_FUNCTION CELER_CONSTEXPR_FUNCTION
   [[maybe_unused]] CFIF_)
   list(APPEND DOXYGEN_PREDEFINED "${_var}=")
 endforeach()
@@ -194,6 +194,7 @@ file(GLOB _DOXYGEN_SOURCE
   "${PROJECT_SOURCE_DIR}/src/celeritas/em/*.hh"
   "${PROJECT_SOURCE_DIR}/src/celeritas/em/*.cc"
   "${PROJECT_SOURCE_DIR}/src/celeritas/em/interactor/*.hh"
+  "${PROJECT_SOURCE_DIR}/src/celeritas/em/interactor/detail/*.hh"
   "${PROJECT_SOURCE_DIR}/src/celeritas/em/model/*.hh"
   "${PROJECT_SOURCE_DIR}/src/celeritas/em/model/*.cc"
   "${PROJECT_SOURCE_DIR}/src/celeritas/em/distribution/*.hh"

--- a/doc/api/celeritas.rst
+++ b/doc/api/celeritas.rst
@@ -183,6 +183,11 @@ as properties of any secondary particles produced.
 .. doxygenclass:: celeritas::detail::UrbanMscScatter
    :members: none
 
+.. doxygenclass:: celeritas::SBEnergyDistribution
+   :members: none
+.. doxygenclass:: celeritas::detail::SBPositronXsCorrector
+   :members: none
+
 .. _api_importdata:
 
 Physics data

--- a/doc/appendices/release-history/v0.3.rst
+++ b/doc/appendices/release-history/v0.3.rst
@@ -8,11 +8,12 @@
 Version 0.3.2
 =============
 
-*Released 2023/09/06*
+*Released 2023/09/07*
 
 Version 0.3.2 is a bug fix release of Celeritas that addresses all
 identified discrepancies between Geant4 and Celeritas EM physics processes.
-
+It also should provide better performance when running Celeritas
+through Geant4 with many threads sharing the same GPU.
 
 Bug fixes
 ---------
@@ -21,8 +22,9 @@ Bug fixes
 * Fix unit conversion errors when reading from event file *(@amandalund, #916)*
 * Fix Seltzer-Berger max xs for positrons *(@amandalund, #922)*
 * Fix Geant4 step limiter when ionization is disabled *(@amandalund, #920)*
+* Fix resetting of CUDA streams when running through accel *(@sethrj, #927)*
 
-Reviewers: @sethrj *(4)*, @mrguilima *(1)*, @stognini *(1)*
+Reviewers: @sethrj *(4)*, @mrguilima *(1)*, @stognini *(1)*, @amandalund *(1)*
 
 Documentation improvements
 --------------------------

--- a/doc/appendices/release-history/v0.3.rst
+++ b/doc/appendices/release-history/v0.3.rst
@@ -3,6 +3,38 @@
 .. SPDX-License-Identifier: CC-BY-4.0
 
 
+.. _release_v0.3.2:
+
+Version 0.3.2
+=============
+
+*Released 2023/09/06*
+
+Version 0.3.2 is a bug fix release of Celeritas that addresses all
+identified discrepancies between Geant4 and Celeritas EM physics processes.
+
+
+Bug fixes
+---------
+
+* Fix sampling of secondary gamma energies in EPlusGGInteractor *(@whokion, #888)*
+* Fix unit conversion errors when reading from event file *(@amandalund, #916)*
+* Fix Seltzer-Berger max xs for positrons *(@amandalund, #922)*
+* Fix Geant4 step limiter when ionization is disabled *(@amandalund, #920)*
+
+Reviewers: @sethrj *(4)*, @mrguilima *(1)*, @stognini *(1)*
+
+Documentation improvements
+--------------------------
+
+* Release v0.3.1 *(@sethrj, #876)*
+* Fix density correction calculation in Seltzer-Berger test *(@amandalund, #921)*
+
+Reviewers: @amandalund *(1)*, @sethrj *(1)*
+
+**Full Changelog**: https://github.com/celeritas-project/celeritas/compare/v0.3.1...v0.3.2
+
+
 .. _release_v0.3.1:
 
 Version 0.3.1

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,6 +9,7 @@ import os
 import json
 import sys
 from pathlib import Path
+from sphinx import __version__ as sphinx_version
 
 # -- Project information -----------------------------------------------------
 
@@ -137,6 +138,19 @@ if html_theme == 'alabaster':
         'show_relbars': True,
         'show_powered_by': False,
     }
+
+mathjax3_config = {
+    "tex": {
+        "macros": {
+            "dif": r"\;\mathrm{d}",
+        },
+    },
+    "loader": {"load": ["ui/lazy", "output/svg"]},
+}
+
+if int(sphinx_version.partition('.')[0]) < 4:
+    # See https://mathjax.github.io/MathJax-demos-web/convert-configuration/convert-configuration.html
+    mathjax_config = {"TeX": { "Macros": mathjax3_config["tex"]["macros"]}}
 
 # -- Options for LaTeX output ------------------------------------------------
 

--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -18,7 +18,7 @@
         "CELERITAS_USE_SWIG":    {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
         "CMAKE_CXX_COMPILER": "/usr/bin/g++",
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations -Wno-attributes -fdiagnostics-color=always",
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fno-inline -fno-omit-frame-pointer",
         "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=skylake-avx512 -mtune=skylake-avx512",
         "CMAKE_CUDA_FLAGS": "-Werror all-warnings  -Wno-deprecated-gpu-targets",

--- a/scripts/env/crusher.sh
+++ b/scripts/env/crusher.sh
@@ -28,7 +28,11 @@ export SPACK_ROOT=/ccs/proj/csc404/spack-crusher
 export PATH=${_celer_base}/spack/view/bin:$PATH
 export CMAKE_PREFIX_PATH=${_celer_base}/spack/view:${CMAKE_PREFIX_PATH}
 export MODULEPATH=${SPACK_ROOT}/share/spack/lmod/cray-sles15-x86_64/Core:${MODULEPATH}
+
+# Set up Geant4 data 
 module load geant4-data
+test -n "${G4ENSDFSTATEDATA}"
+test -e "${G4ENSDFSTATEDATA}"
 
 # Make llvm available
 test -n "${ROCM_PATH}"

--- a/src/celeritas/em/interactor/detail/BremFinalStateHelper.hh
+++ b/src/celeritas/em/interactor/detail/BremFinalStateHelper.hh
@@ -19,7 +19,6 @@ namespace detail
 //---------------------------------------------------------------------------//
 /*!
  * Sample the angular distribution of photon from e+/e- Bremsstrahlung.
- *
  */
 class BremFinalStateHelper
 {

--- a/src/celeritas/em/interactor/detail/SBPositronXsCorrector.hh
+++ b/src/celeritas/em/interactor/detail/SBPositronXsCorrector.hh
@@ -17,6 +17,8 @@
 
 namespace celeritas
 {
+namespace detail
+{
 //---------------------------------------------------------------------------//
 /*!
  * Scale SB differential cross sections for positrons.
@@ -155,4 +157,5 @@ SBPositronXsCorrector::calc_invbeta(real_type gamma_energy) const
 }
 
 //---------------------------------------------------------------------------//
+}  // namespace detail
 }  // namespace celeritas

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -224,7 +224,7 @@ template<class T, std::size_t N>
 CELER_CONSTEXPR_FUNCTION Array<std::remove_cv_t<T>, N>
 make_array(Span<T, N> const& s)
 {
-    Array<std::remove_cv_t<T>, N> result;
+    Array<std::remove_cv_t<T>, N> result{};
     for (std::size_t i = 0; i < N; ++i)
     {
         result[i] = s[i];

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -145,8 +145,8 @@ template<class T>
 inline constexpr BoundingBox<T>
 calc_union(BoundingBox<T> const& a, BoundingBox<T> const& b)
 {
-    Array<T, 3> lower;
-    Array<T, 3> upper;
+    Array<T, 3> lower{};
+    Array<T, 3> upper{};
 
     for (auto ax : range(to_int(Axis::size_)))
     {
@@ -167,8 +167,8 @@ template<class T>
 inline constexpr BoundingBox<T>
 calc_intersection(BoundingBox<T> const& a, BoundingBox<T> const& b)
 {
-    Array<T, 3> lower;
-    Array<T, 3> upper;
+    Array<T, 3> lower{};
+    Array<T, 3> upper{};
 
     for (auto ax : range(to_int(Axis::size_)))
     {

--- a/src/orange/detail/BIHUtils.hh
+++ b/src/orange/detail/BIHUtils.hh
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "orange/BoundingBoxUtils.hh"
+#include "orange/OrangeTypes.hh"
 
 namespace celeritas
 {
@@ -20,15 +21,11 @@ namespace celeritas
 inline FastBBox calc_union(std::vector<FastBBox> const& bboxes,
                            std::vector<LocalVolumeId> const& indices)
 {
-    CELER_EXPECT(!bboxes.empty());
-    CELER_EXPECT(!indices.empty());
-
-    auto id = indices.begin();
-    auto result = bboxes[id->unchecked_get()];
-    ++id;
-    for (; id != indices.end(); ++id)
+    FastBBox result;
+    for (auto const& id : indices)
     {
-        result = calc_union(result, bboxes[id->unchecked_get()]);
+        CELER_ASSERT(id < bboxes.size());
+        result = calc_union(result, bboxes[id.unchecked_get()]);
     }
 
     return result;

--- a/src/orange/surf/LocalSurfaceVisitor.hh
+++ b/src/orange/surf/LocalSurfaceVisitor.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/surface/LocalSurfaceVisitor.hh
+//! \file orange/surf/LocalSurfaceVisitor.hh
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/orange/surf/SurfaceSimplifier.cc
+++ b/src/orange/surf/SurfaceSimplifier.cc
@@ -77,8 +77,9 @@ auto SurfaceSimplifier::operator()(PlaneAligned<T> const& p) const
     // No simplification performed
     return {};
 }
-
+//! \cond
 ORANGE_INSTANTIATE_OP(PlaneAligned, PlaneAligned);
+//! \endcond
 
 //---------------------------------------------------------------------------//
 /*!
@@ -104,7 +105,9 @@ auto SurfaceSimplifier::operator()(CylAligned<T> const& c) const
     return {};
 }
 
+//! \cond
 ORANGE_INSTANTIATE_OP(CylCentered, CylAligned);
+//! \endcond
 
 //---------------------------------------------------------------------------//
 /*!

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -23,6 +23,8 @@
 
 #include "celeritas_test.hh"
 
+using celeritas::detail::SBPositronXsCorrector;
+
 namespace celeritas
 {
 namespace test


### PR DESCRIPTION
Update documentation and add release notes for v0.3.2, which backports the recent physics fixes that @whokion and @amandalund have implemented using @mrguilima and @stognini 's work. Go team!! 🎉 

| Problem                      | Geometry |      Speedup |
| ---------------------------- | -------- | ------------ |
| cms2018 [Z]                  | vecgeom  |  9.4× (±0.1) |
| cms2018+field+msc [ZFM]      | vecgeom  |  6.6× (±0.1) |
| simple-cms+field [BF]        | orange   | 24.3× (±1.9) |
| simple-cms+field+msc [BFM]   | orange   | 28.5× (±1.8) |
|                              | vecgeom  | 28.7× (±1.1) |
| simple-cms+msc [BM]          | orange   | 27.4× (±2.6) |
| testem15 [A]                 | orange   | 21.1× (±0.2) |
| testem15+field [AF]          | orange   | 26.5× (±2.7) |
| testem15+field+msc [AFM]     | orange   | 32.2× (±3.2) |
|                              | vecgeom  | 31.7× (±2.9) |
| testem3-flat [C]             | orange   | 25.3× (±1.5) |
|                              | vecgeom  | 26.5× (±0.6) |
| testem3-flat+field [CF]      | orange   | 22.8× (±0.9) |
| testem3-flat+field+msc [CFM] | orange   | 27.8× (±1.0) |
|                              | vecgeom  | 15.6× (±0.3) |
| testem3-flat+msc [CM]        | orange   | 34.3× (±0.8) |

![speedup](https://github.com/celeritas-project/celeritas/assets/741229/758fca6d-1a2b-445f-b081-e85c13387709)
