### PR TITLE
Update documentation and precalculate Wenzel nuclear form factor constants

### DIFF
--- a/src/celeritas/em/data/WentzelData.hh
+++ b/src/celeritas/em/data/WentzelData.hh
@@ -82,9 +82,14 @@ struct WentzelData
 {
     template<class T>
     using ElementItems = celeritas::Collection<T, W, M, ElementId>;
+    template<class T>
+    using IsotopeItems = celeritas::Collection<T, W, M, IsotopeId>;
 
     // Ids
     WentzelIds ids;
+
+    //! Constant prefactor for the squared momentum transfer [(MeV/c)^-2]
+    IsotopeItems<real_type> nuclear_form_prefactor;
 
     // Per element form factors
     ElementItems<WentzelElementData> elem_data;
@@ -98,7 +103,7 @@ struct WentzelData
     // Check if the data is initialized
     explicit CELER_FUNCTION operator bool() const
     {
-        return ids && !elem_data.empty();
+        return ids && !nuclear_form_prefactor.empty() && !elem_data.empty();
     }
 
     // Copy initialize from an existing WentzelData
@@ -107,6 +112,7 @@ struct WentzelData
     {
         CELER_EXPECT(other);
         ids = other.ids;
+        nuclear_form_prefactor = other.nuclear_form_prefactor;
         elem_data = other.elem_data;
         form_factor_type = other.form_factor_type;
         screening_factor = other.screening_factor;
@@ -120,4 +126,3 @@ using WentzelRef = NativeCRef<WentzelData>;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas
- 

--- a/src/celeritas/em/distribution/WentzelDistribution.hh
+++ b/src/celeritas/em/distribution/WentzelDistribution.hh
@@ -84,9 +84,6 @@ class WentzelDistribution
     // Calculates the form factor from the scattered polar angle
     inline CELER_FUNCTION real_type calculate_form_factor(real_type cos_t) const;
 
-    // Helper function for calculating the flat form factor
-    inline CELER_FUNCTION real_type flat_form_factor(real_type x) const;
-
     // Calculate the nuclear form momentum scale
     inline CELER_FUNCTION real_type nuclear_form_momentum_scale() const;
 
@@ -100,6 +97,9 @@ class WentzelDistribution
     template<class Engine>
     inline CELER_FUNCTION real_type sample_cos_t(real_type cos_t_max,
                                                  Engine& rng) const;
+
+    // Helper function for calculating the flat form factor
+    inline static CELER_FUNCTION real_type flat_form_factor(real_type x);
 
     // Momentum coefficient used in the flat nuclear form factor model
     static CELER_CONSTEXPR_FUNCTION real_type flat_coeff();
@@ -187,13 +187,14 @@ WentzelDistribution::calculate_form_factor(real_type cos_t) const
             real_type x0 = real_type{0.6} * x1
                            * fastpow(value_as<Mass>(target_.nuclear_mass()),
                                      real_type{1} / 3);
-            return flat_form_factor(x0) * flat_form_factor(x1);
+            return this->flat_form_factor(x0) * this->flat_form_factor(x1);
         }
         case NuclearFormFactorType::exponential:
             return 1 / ipow<2>(1 + this->nuclear_form_prefactor() * mt_sq);
         case NuclearFormFactorType::gaussian:
             return std::exp(-2 * this->nuclear_form_prefactor() * mt_sq);
     }
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//
@@ -202,7 +203,7 @@ WentzelDistribution::calculate_form_factor(real_type cos_t) const
  *
  * See [LR15] eqn 2.265.
  */
-CELER_FUNCTION real_type WentzelDistribution::flat_form_factor(real_type x) const
+CELER_FUNCTION real_type WentzelDistribution::flat_form_factor(real_type x)
 {
     return 3 * (std::sin(x) - x * std::cos(x)) / ipow<3>(x);
 }

--- a/src/celeritas/em/distribution/WentzelDistribution.hh
+++ b/src/celeritas/em/distribution/WentzelDistribution.hh
@@ -278,15 +278,13 @@ CELER_FUNCTION real_type WentzelDistribution::sample_cos_t(real_type cos_t_max,
 {
     // Sample scattering angle [Fern] eqn 92, where cos(theta) = 1 - 2*mu
     // For incident electrons / positrons, theta_min = 0 always
-    real_type mu = real_type{0.5} * (1 - cos_t_max);
-    real_type xi = generate_canonical(rng);
+    real_type const mu = real_type{0.5} * (1 - cos_t_max);
+    real_type const xi = generate_canonical(rng);
+    real_type const sc = wentzel_elec_ratio.screening_coefficient();
 
-    return clamp(
-        1
-            + 2 * wentzel_elec_ratio.screening_coefficient() * mu * (1 - xi)
-                  / (wentzel_elec_ratio.screening_coefficient() - mu * xi),
-        real_type{-1},
-        real_type{1});
+    return clamp(1 + 2 * sc * mu * (1 - xi) / (sc - mu * xi),
+                 real_type{-1},
+                 real_type{1});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/distribution/WentzelDistribution.hh
+++ b/src/celeritas/em/distribution/WentzelDistribution.hh
@@ -28,7 +28,7 @@ namespace celeritas
 /*!
  * Helper class for \c WentzelInteractor .
  *
- * Samples the polar scattering angle for the Wentzel model.
+ * Samples the polar scattering angle for the Wentzel Coulomb scattering model.
  *
  * References:
  * [Fern] J.M. Fernandez-Varea, R. Mayol and F. Salvat. On the theory
@@ -51,7 +51,7 @@ class WentzelDistribution
     //!@}
 
   public:
-    //! Construct with state and date from WentzelInteractor
+    // Construct with state and date from WentzelInteractor
     inline CELER_FUNCTION
     WentzelDistribution(ParticleTrackView const& particle,
                         IsotopeView const& target,
@@ -59,7 +59,7 @@ class WentzelDistribution
                         real_type cutoff_energy,
                         WentzelRef const& data);
 
-    //! Sample the polar scattering angle
+    // Sample the polar scattering angle
     template<class Engine>
     inline CELER_FUNCTION real_type operator()(Engine& rng) const;
 
@@ -81,29 +81,28 @@ class WentzelDistribution
     // Ratio of elecron to total cross sections for the Wentzel model
     WentzelRatioCalculator const wentzel_elec_ratio;
 
-    //! Calculates the form factor from the scattered polar angle
+    // Calculates the form factor from the scattered polar angle
     inline CELER_FUNCTION real_type calculate_form_factor(real_type cos_t) const;
 
-    //! Helper function for calculating the flat form factor
+    // Helper function for calculating the flat form factor
     inline CELER_FUNCTION real_type flat_form_factor(real_type x) const;
 
-    //! Calculate the nuclear form momentum scale
+    // Calculate the nuclear form momentum scale
     inline CELER_FUNCTION real_type nuclear_form_momentum_scale() const;
 
-    //! Calculate the squared momentum transfer to the target
+    // Calculate the squared momentum transfer to the target
     inline CELER_FUNCTION real_type mom_transfer_sq(real_type cos_t) const;
 
-    //! Momentum coefficient used in the flat nuclear form factor model
-    CELER_CONSTEXPR_FUNCTION real_type flat_coeff() const;
-
-    //! Momentum prefactor used in exponential and gaussian form factors
+    // Momentum prefactor used in exponential and gaussian form factors
     inline CELER_FUNCTION real_type nuclear_form_prefactor() const;
 
-    //! Samples the scattered polar angle based on the maximum scattering
-    //! angle and screening coefficient
+    // Sample the scattered polar angle
     template<class Engine>
     inline CELER_FUNCTION real_type sample_cos_t(real_type cos_t_max,
                                                  Engine& rng) const;
+
+    // Momentum coefficient used in the flat nuclear form factor model
+    static CELER_CONSTEXPR_FUNCTION real_type flat_coeff();
 };
 
 //---------------------------------------------------------------------------//
@@ -128,7 +127,7 @@ WentzelDistribution::WentzelDistribution(ParticleTrackView const& particle,
 
 //---------------------------------------------------------------------------//
 /*!
- * Samples the polar scattered angle of the incident particle.
+ * Sample the polar scattered angle of the incident particle.
  */
 template<class Engine>
 CELER_FUNCTION real_type WentzelDistribution::operator()(Engine& rng) const
@@ -166,7 +165,7 @@ CELER_FUNCTION real_type WentzelDistribution::operator()(Engine& rng) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculates the form factor based on the form factor model.
+ * Calculate the form factor based on the form factor model.
  *
  * The models are described in [LR15] section 2.4.2.1 and parameterize the
  * charge distribution inside a nucleus. The same models are used as in
@@ -201,8 +200,9 @@ WentzelDistribution::calculate_form_factor(real_type cos_t) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Helper function for calculating the flat form factors, see [LR15] eqn
- * 2.265.
+ * Calculate the flat form factor.
+ *
+ * See [LR15] eqn 2.265.
  */
 CELER_FUNCTION real_type WentzelDistribution::flat_form_factor(real_type x) const
 {
@@ -212,10 +212,11 @@ CELER_FUNCTION real_type WentzelDistribution::flat_form_factor(real_type x) cons
 //---------------------------------------------------------------------------//
 /*!
  * Momentum coefficient used in the flat model for the nuclear form factors.
+ *
  * This is the ratio of \f$ r_1 / \hbar \f$ where \f$ r_1 \f$ is defined in
  * eqn 2.265 of [LR15].
  */
-CELER_CONSTEXPR_FUNCTION real_type WentzelDistribution::flat_coeff() const
+CELER_CONSTEXPR_FUNCTION real_type WentzelDistribution::flat_coeff()
 {
     return native_value_to<units::MevMomentum>(2 * units::femtometer
                                                / constants::hbar_planck)
@@ -224,12 +225,15 @@ CELER_CONSTEXPR_FUNCTION real_type WentzelDistribution::flat_coeff() const
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculates the constant prefactors of the squared momentum transfer used
- * in the exponential and Guassian nuclear form models, see eqns 2.262-2.264
- * of [LR15].
+ * Calculate the constant prefactors of the squared momentum transfer.
  *
- * Specifically, it calculates (r_n/hbar)^2 / 12. A special case is inherited
- * from Geant for hydrogen targets.
+ * This factor is used in the exponential and Gaussian nuclear form models: see
+ * Eqs. 2.262--2.264 of [LR15].
+ *
+ * Specifically, it calculates \f$ (r_n/\bar h)^2 / 12 \f$. A special case is
+ * inherited from Geant for hydrogen targets.
+ *
+ * TODO: precalculate this and store in atomic data.
  */
 CELER_FUNCTION real_type WentzelDistribution::nuclear_form_prefactor() const
 {
@@ -267,8 +271,9 @@ CELER_FUNCTION real_type WentzelDistribution::mom_transfer_sq(real_type cos_t) c
 
 //---------------------------------------------------------------------------//
 /*!
- * Randomly samples the scattering polar angle of the incident particle
- * based on the maximum scattering angle. The probability is given in [Fern]
+ * Sample the scattering polar angle of the incident particle.
+ *
+ * The probability is given in [Fern]
  * eqn 88 and is nomalized on the interval
  * \f$ cos\theta \in [1, \cos\theta_{max}] \f$.
  */

--- a/src/celeritas/em/model/WentzelModel.cc
+++ b/src/celeritas/em/model/WentzelModel.cc
@@ -9,6 +9,7 @@
 
 #include "celeritas_config.h"
 #include "corecel/sys/ScopedMem.hh"
+#include "celeritas/Units.hh"
 #include "celeritas/em/data/WentzelData.hh"
 #include "celeritas/em/executor/WentzelExecutor.hh"
 #include "celeritas/em/interactor/detail/PhysicsConstants.hh"
@@ -18,6 +19,7 @@
 #include "celeritas/global/TrackExecutor.hh"
 #include "celeritas/io/ImportParameters.hh"
 #include "celeritas/io/ImportProcess.hh"
+#include "celeritas/mat/ElementView.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/phys/InteractionApplier.hh"
 #include "celeritas/phys/PDGNumber.hh"
@@ -148,14 +150,23 @@ void WentzelModel::build_data(HostVal<WentzelData>& host_data,
         WentzelElementData z_data;
         z_data.mott_coeff
             = get_mott_coeff_matrix(materials.get(el_id).atomic_number());
-
         elem_data.push_back(z_data);
+    }
+
+    auto prefactors = make_builder(&host_data.nuclear_form_prefactor);
+    prefactors.reserve(materials.num_isotopes());
+    for (auto iso_id : range(IsotopeId{materials.num_isotopes()}))
+    {
+        prefactors.push_back(
+            this->calc_nuclear_form_prefactor(materials.get(iso_id)));
     }
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Interpolated Mott coefficients used by the Lijian, Quing, Zhengming
+ * Get interpolated Mott coefficients for an element.
+ *
+ * These coefficients are used by the Lijian, Quing, Zhengming
  * expression [PRM 8.48] for atomic numbers 1 <= Z <= 92.
  * This data was taken from Geant4's G4MottData.hh file.
  *
@@ -920,6 +931,38 @@ WentzelModel::get_mott_coeff_matrix(AtomicNumber z)
         << WentzelElementData::num_mott_elements << ")");
 
     return mott_coeffs[index];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the constant prefactors of the squared momentum transfer.
+ *
+ * This factor is used in the exponential and Gaussian nuclear form models: see
+ * Eqs. 2.262--2.264 of [LR15].
+ *
+ * Specifically, it calculates \f$ (r_n/\bar h)^2 / 12 \f$. A special case is
+ * inherited from Geant for hydrogen targets.
+ */
+real_type WentzelModel::calc_nuclear_form_prefactor(IsotopeView const& iso)
+{
+    if (iso.atomic_number().get() == 1)
+    {
+        // TODO: Geant4 hardcodes a different prefactor for hydrogen
+        return real_type{1.5485e-6};
+    }
+
+    // The ratio has units of (MeV/c)^-2, so it's easier to convert the
+    // inverse which has units of MomentumSq, then invert afterwards
+    constexpr real_type ratio
+        = 1
+          / native_value_to<units::MevMomentumSq>(
+                12
+                * ipow<2>(constants::hbar_planck
+                          / (real_type(1.27) * units::femtometer)))
+                .value();
+    return ratio
+           * fastpow(real_type(iso.atomic_mass_number().get()),
+                     2 * real_type(0.27));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/WentzelModel.hh
+++ b/src/celeritas/em/model/WentzelModel.hh
@@ -20,6 +20,7 @@ namespace celeritas
 {
 class MaterialParams;
 class ParticleParams;
+class IsotopeView;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -51,26 +52,26 @@ class WentzelModel final : public Model
     };
 
   public:
-    //! Construct from model ID and other necessary data
+    // Construct from model ID and other necessary data
     WentzelModel(ActionId id,
                  ParticleParams const& particles,
                  MaterialParams const& materials,
                  Options const& options,
                  SPConstImported data);
 
-    //! Particle types and energy ranges that this model applies to
+    // Particle types and energy ranges that this model applies to
     SetApplicability applicability() const final;
 
-    //! Get the microscopic cross sections for the given particle and material
+    // Get the microscopic cross sections for the given particle and material
     MicroXsBuilders micro_xs(Applicability) const final;
 
-    //! Apply the interaction kernel on host
+    // Apply the interaction kernel on host
     void execute(CoreParams const&, CoreStateHost&) const final;
 
-    //! Apply the interaction kernel on device
+    // Apply the interaction kernel on device
     void execute(CoreParams const&, CoreStateDevice&) const final;
 
-    //! ID of the model
+    // ID of the model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
@@ -92,13 +93,16 @@ class WentzelModel final : public Model
     CollectionMirror<WentzelData> data_;
     ImportedModelAdapter imported_;
 
-    //! Construct per element data (loads Mott coefficients)
+    // Construct per element data (loads Mott coefficients)
     void build_data(HostVal<WentzelData>& host_data,
                     MaterialParams const& materials);
 
-    //! Retrieve matrix of interpolated Mott coefficients
+    // Retrieve matrix of interpolated Mott coefficients
     static WentzelElementData::MottCoeffMatrix
     get_mott_coeff_matrix(AtomicNumber z);
+
+    // Calculate the nuclear form prefactor
+    static real_type calc_nuclear_form_prefactor(IsotopeView const& iso);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/WentzelModel.hh
+++ b/src/celeritas/em/model/WentzelModel.hh
@@ -23,7 +23,7 @@ class ParticleParams;
 
 //---------------------------------------------------------------------------//
 /*!
- * Set up and launch the Wentzel model interaction.
+ * Set up and launch the Wentzel Coulomb scattering model interaction.
  */
 class WentzelModel final : public Model
 {

--- a/src/celeritas/em/xs/WentzelRatioCalculator.hh
+++ b/src/celeritas/em/xs/WentzelRatioCalculator.hh
@@ -38,13 +38,13 @@ class WentzelRatioCalculator
                            WentzelRef const& data,
                            real_type cutoff_energy);
 
-    //! The ratio of electron to total cross section for Coulomb scattering
+    // The ratio of electron to total cross section for Coulomb scattering
     inline CELER_FUNCTION real_type operator()() const;
 
-    //! Moilere screening coefficient
+    // Moilere screening coefficient
     inline CELER_FUNCTION real_type screening_coefficient() const;
 
-    //! (Cosine of) the maximum scattering angle off of electrons
+    // (Cosine of) the maximum scattering angle off of electrons
     inline CELER_FUNCTION real_type cos_t_max_elec() const;
 
   private:

--- a/src/celeritas/mat/IsotopeView.hh
+++ b/src/celeritas/mat/IsotopeView.hh
@@ -37,6 +37,9 @@ class IsotopeView
     inline CELER_FUNCTION
     IsotopeView(MaterialParamsRef const& params, IsotopeId isot_id);
 
+    // ID of this isotope
+    CELER_FORCEINLINE_FUNCTION IsotopeId isotope_id() const;
+
     // Atomic number Z
     CELER_FORCEINLINE_FUNCTION AtomicNumber atomic_number() const;
 
@@ -47,7 +50,15 @@ class IsotopeView
     CELER_FORCEINLINE_FUNCTION MevMass nuclear_mass() const;
 
   private:
-    IsotopeRecord const& def_;
+    MaterialParamsRef const& params_;
+    IsotopeId isotope_;
+
+    // HELPER FUNCTIONS
+
+    CELER_FORCEINLINE_FUNCTION IsotopeRecord const& isotope_def() const
+    {
+        return params_.isotopes[isotope_];
+    }
 };
 
 //---------------------------------------------------------------------------//
@@ -58,9 +69,18 @@ class IsotopeView
  */
 CELER_FUNCTION
 IsotopeView::IsotopeView(MaterialParamsRef const& params, IsotopeId isot_id)
-    : def_(params.isotopes[isot_id])
+    : params_{params}, isotope_{isot_id}
 {
-    CELER_EXPECT(isot_id < params.isotopes.size());
+    CELER_EXPECT(isotope_ < params.isotopes.size());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Isotope ID.
+ */
+CELER_FUNCTION IsotopeId IsotopeView::isotope_id() const
+{
+    return isotope_;
 }
 
 //---------------------------------------------------------------------------//
@@ -69,7 +89,7 @@ IsotopeView::IsotopeView(MaterialParamsRef const& params, IsotopeId isot_id)
  */
 CELER_FUNCTION AtomicNumber IsotopeView::atomic_number() const
 {
-    return def_.atomic_number;
+    return isotope_def().atomic_number;
 }
 
 //---------------------------------------------------------------------------//
@@ -79,17 +99,16 @@ CELER_FUNCTION AtomicNumber IsotopeView::atomic_number() const
 CELER_FUNCTION IsotopeView::AtomicMassNumber
 IsotopeView::atomic_mass_number() const
 {
-    return def_.atomic_mass_number;
+    return isotope_def().atomic_mass_number;
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Nuclear mass, which is the sum of the nucleons' mass and their binding
- * energy.
+ * Nuclear mass, the sum of the nucleons' mass and their binding energy.
  */
 CELER_FUNCTION units::MevMass IsotopeView::nuclear_mass() const
 {
-    return def_.nuclear_mass;
+    return isotope_def().nuclear_mass;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -317,7 +317,6 @@ celeritas_add_test(celeritas/Constants.test.cc
 set(CELERITASTEST_PREFIX celeritas/em)
 celeritas_add_test(celeritas/em/BetheHeitler.test.cc)
 celeritas_add_test(celeritas/em/CombinedBrem.test.cc)
-celeritas_add_test(celeritas/em/CoulombScattering.test.cc)
 celeritas_add_test(celeritas/em/EPlusGG.test.cc)
 celeritas_add_test(celeritas/em/Fluctuation.test.cc)
 celeritas_add_test(celeritas/em/KleinNishina.test.cc)
@@ -330,6 +329,7 @@ celeritas_add_test(celeritas/em/SeltzerBerger.test.cc)
 celeritas_add_test(celeritas/em/TsaiUrbanDistribution.test.cc)
 celeritas_add_test(celeritas/em/UrbanMsc.test.cc ${_needs_root}
   ${_optional_geant4_env})
+celeritas_add_test(celeritas/em/Wentzel.test.cc)
 
 #-------------------------------------#
 # External

--- a/test/celeritas/em/Wentzel.test.cc
+++ b/test/celeritas/em/Wentzel.test.cc
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/em/CoulombScattering.test.cc
+//! \file celeritas/em/Wentzel.test.cc
 //---------------------------------------------------------------------------//
 #include "celeritas/Quantities.hh"
 #include "celeritas/Units.hh"


### PR DESCRIPTION
This fixes a few small issues I noticed while updating some doxygen documentation that we'd missed during review of #861:
- Private data didn't have `_` suffix, and since it is function-like it should be named like a function
- Move some reused values outside of expressions to improve readability
- Removed doxygen markers from *declarations*: they should only be on *definitions* (e.g. inline functions, class definitions, non-inline function definitions)
- Doxygen briefs should fit on a single line
- Interactor test should be named after the model, not the process
- Nuclear form prefactor can be precalculated (one real per isotope)
- Made a function that didn't depend on state data `static`