### PR TITLE
Add Windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,10 @@ if(BUILD_SHARED_LIBS)
   # Do not relink libs/binaries when dependent shared libs change
   celeritas_set_default(CMAKE_LINK_DEPENDS_NO_SHARED ON)
 endif()
+if(BUILD_SHARED_LIBS OR CELERITAS_USE_ROOT)
+  # Make sure modules, sub-libraries, etc. are relocatable
+  celeritas_set_default(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 
 ### Installation flags ###
 # When developing add checking for proper usage of `install(`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,13 +219,17 @@ if(CELERITAS_USE_Geant4 AND NOT Geant4_FOUND)
   find_package(Geant4 REQUIRED)
 endif()
 
-if(CELERITAS_USE_HepMC3 AND NOT HepMC3_FOUND)
-  find_package(HepMC3 REQUIRED)
+if(CELERITAS_USE_HepMC3)
+  if(NOT HepMC3_FOUND)
+    find_package(HepMC3 REQUIRED)
+  endif()
   set(HepMC3_LIBRARIES HepMC3::HepMC3)
 endif()
 
-if(CELERITAS_USE_JSON AND NOT nlohmann_json_FOUND)
-  find_package(nlohmann_json 3.7.0 REQUIRED)
+if(CELERITAS_USE_JSON)
+  if(NOT nlohmann_json_FOUND)
+    find_package(nlohmann_json 3.7.0 REQUIRED)
+  endif()
   set(nlohmann_json_LIBRARIES nlohmann_json::nlohmann_json)
 endif()
 
@@ -242,7 +246,9 @@ if(CELERITAS_USE_Python)
   if(CELERITAS_USE_SWIG)
     list(APPEND _components Development)
   endif()
-  find_package(Python 3.6 REQUIRED COMPONENTS ${_components})
+  if(NOT Python_FOUND)
+    find_package(Python 3.6 REQUIRED COMPONENTS ${_components})
+  endif()
   set(CELERITAS_PYTHONPATH "$ENV{PYTHONPATH}" CACHE STRING
     "Python path used for finding modules and generating documentation"
   )
@@ -259,7 +265,9 @@ if(CELERITAS_USE_SWIG AND NOT SWIG_FOUND)
 endif()
 
 if(CELERITAS_USE_VecGeom)
-  find_package(VecGeom 1.1.17 REQUIRED)
+  if(NOT VecGeom_FOUND)
+    find_package(VecGeom 1.1.17 REQUIRED)
+  endif()
 
   if(CELERITAS_USE_CUDA AND NOT VecGeom_CUDA_FOUND)
     celeritas_error_incompatible_option(
@@ -317,11 +325,6 @@ if(CELERITAS_BUILD_DOCS)
       OFF
     )
   endif()
-endif()
-
-if(BUILD_SHARED_LIBS OR CELERITAS_USE_ROOT)
-  # Make sure modules, sub-libraries, etc. are relocatable
-  set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 endif()
 
 #----------------------------------------------------------------------------#

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -18,6 +18,13 @@
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
 #include "celeritas/user/RootStepWriter.hh"
 
+#ifdef _WIN32
+#include <cstdlib>
+#ifdef environ
+#undef environ
+#endif
+#endif
+
 namespace celeritas
 {
 namespace app

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -19,10 +19,10 @@
 #include "celeritas/user/RootStepWriter.hh"
 
 #ifdef _WIN32
-#include <cstdlib>
-#ifdef environ
-#undef environ
-#endif
+#    include <cstdlib>
+#    ifdef environ
+#        undef environ
+#    endif
 #endif
 
 namespace celeritas

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -67,7 +67,11 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
     };
 
     // Abort cleanly for interrupt and user-defined signals
+#ifndef _WIN32
     ScopedSignalHandler interrupted{SIGINT, SIGUSR2};
+#else
+    ScopedSignalHandler interrupted{SIGINT};
+#endif
     CELER_LOG(status) << "Transporting";
 
     Stopwatch get_step_time;

--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -18,7 +18,7 @@
         "CELERITAS_USE_SWIG":    {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
         "CMAKE_CXX_COMPILER": "/usr/bin/g++",
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations -Wno-attributes -fdiagnostics-color=always",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations -fdiagnostics-color=always",
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fno-inline -fno-omit-frame-pointer",
         "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=skylake-avx512 -mtune=skylake-avx512",
         "CMAKE_CUDA_FLAGS": "-Werror all-warnings  -Wno-deprecated-gpu-targets",

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -311,6 +311,13 @@ if(NOT CELERITAS_USE_OpenMP
     PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>
   )
 endif()
+if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  # Inheriting via dominance is correct behavior
+  celeritas_target_compile_options(celeritas
+    PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:/wd4267$<SEMICOLON>/wd4250>"
+  )
+endif()
+  
 
 celeritas_target_link_libraries(celeritas
   PRIVATE ${PRIVATE_DEPS}

--- a/src/celeritas/em/interactor/RayleighInteractor.hh
+++ b/src/celeritas/em/interactor/RayleighInteractor.hh
@@ -128,8 +128,8 @@ CELER_FUNCTION Interaction RayleighInteractor::operator()(Engine& rng)
     do
     {
         // Sample index from input.prob
-        unsigned int const index = celeritas::make_selector(
-            [&input](unsigned int i) { return input.prob[i]; },
+        auto const index = celeritas::make_selector(
+            [&input](size_type i) { return input.prob[i]; },
             input.prob.size())(rng);
 
         const real_type w = input.weight[index];

--- a/src/celeritas/em/model/RayleighModel.cc
+++ b/src/celeritas/em/model/RayleighModel.cc
@@ -119,7 +119,7 @@ ActionId RayleighModel::action_id() const
 void RayleighModel::build_data(HostValue* data, MaterialParams const& materials)
 {
     // Number of elements
-    unsigned int num_elements = materials.num_elements();
+    auto num_elements = materials.num_elements();
 
     // Build data for available elements
     auto params = make_builder(&data->params);

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -143,7 +143,7 @@ void RelativisticBremModel::build_data(HostValue* data,
                                        real_type particle_mass)
 {
     // Build element data for available elements
-    unsigned int num_elements = materials.num_elements();
+    auto num_elements = materials.num_elements();
 
     auto elem_data = make_builder(&data->elem_data);
     elem_data.reserve(num_elements);

--- a/src/celeritas/em/model/WentzelModel.cc
+++ b/src/celeritas/em/model/WentzelModel.cc
@@ -138,7 +138,7 @@ void WentzelModel::build_data(HostVal<WentzelData>& host_data,
                               MaterialParams const& materials)
 {
     // Build element data
-    unsigned int const num_elements = materials.num_elements();
+    size_type const num_elements = materials.num_elements();
     auto elem_data = make_builder(&host_data.elem_data);
     elem_data.reserve(num_elements);
 

--- a/src/celeritas/ext/GeantSetup.hh
+++ b/src/celeritas/ext/GeantSetup.hh
@@ -97,6 +97,8 @@ G4VPhysicalVolume const* GeantSetup::world() const
 }
 
 #if !CELERITAS_USE_GEANT4
+inline void GeantSetup::disable_signal_handler() {}
+
 inline GeantSetup::GeantSetup(std::string const&, Options)
 {
     CELER_NOT_CONFIGURED("Geant4");

--- a/src/celeritas/field/DormandPrinceStepper.hh
+++ b/src/celeritas/field/DormandPrinceStepper.hh
@@ -139,12 +139,12 @@ DormandPrinceStepper<E>::operator()(real_type step,
     constexpr R d77 = -1 / R(40);
 
     // Coefficients for the mid point calculation by Shampine
-    constexpr R c71 = 6025192743 / R(30085553152);
-    constexpr R c73 = 51252292925 / R(65400821598);
-    constexpr R c74 = -2691868925 / R(45128329728);
-    constexpr R c75 = 187940372067 / R(1594534317056);
-    constexpr R c76 = -1776094331 / R(19743644256);
-    constexpr R c77 = 11237099 / R(235043384);
+    constexpr R c71 = R(6025192743.) / R(30085553152.);
+    constexpr R c73 = R(51252292925.) / R(65400821598.);
+    constexpr R c74 = R(-2691868925.) / R(45128329728.);
+    constexpr R c75 = R(187940372067.) / R(1594534317056.);
+    constexpr R c76 = R(-1776094331.) / R(19743644256.);
+    constexpr R c77 = R(11237099.) / R(235043384.);
 
     result_type result;
 

--- a/src/celeritas/field/RZMapFieldData.hh
+++ b/src/celeritas/field/RZMapFieldData.hh
@@ -70,7 +70,7 @@ struct RZMapFieldParamsData
                 && r >= grids.data_r.front && r <= grids.data_r.back);
     }
 
-    inline CELER_FUNCTION ElementId id(int idx_z, int idx_r) const
+    inline CELER_FUNCTION ElementId id(size_type idx_z, size_type idx_r) const
     {
         CELER_EXPECT(grids.data_r);
         return ElementId(idx_z * grids.data_r.size + idx_r);

--- a/src/celeritas/grid/VectorUtils.cc
+++ b/src/celeritas/grid/VectorUtils.cc
@@ -28,7 +28,7 @@ std::vector<double> space_impl(double start, double stop, size_type n)
     result.front() = start;
     for (auto i : range<size_type>(1, n - 1))
     {
-        result[i] = interp(i);
+        result[i] = interp(static_cast<double>(i));
     }
     // Manually set last point to avoid any differences due to roundoff
     result.back() = stop;

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -473,7 +473,9 @@ inline void resize(PhysicsStateData<Ownership::value, M>* state,
     resize(&state->per_process_xs,
            size * params.scalars.max_particle_processes);
     resize(&state->relaxation, params.hardwired.relaxation_data, size);
-    resize(&state->secondaries, static_cast<size_type>(size * params.scalars.secondary_stack_factor));
+    resize(
+        &state->secondaries,
+        static_cast<size_type>(size * params.scalars.secondary_stack_factor));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -473,7 +473,7 @@ inline void resize(PhysicsStateData<Ownership::value, M>* state,
     resize(&state->per_process_xs,
            size * params.scalars.max_particle_processes);
     resize(&state->relaxation, params.hardwired.relaxation_data, size);
-    resize(&state->secondaries, size * params.scalars.secondary_stack_factor);
+    resize(&state->secondaries, static_cast<size_type>(size * params.scalars.secondary_stack_factor));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/random/XorwowRngData.cc
+++ b/src/celeritas/random/XorwowRngData.cc
@@ -33,7 +33,7 @@ void resize(XorwowRngStateData<Ownership::value, M>* state,
 
     // Seed sequence to generate well-distributed seed numbers, including
     // stream ID to give strings different starting contributions
-    std::vector<unsigned int> host_seeds(params.seed.begin(),
+    std::vector<std::seed_seq::result_type> host_seeds(params.seed.begin(),
                                          params.seed.end());
     if (stream != StreamId{0})
     {

--- a/src/celeritas/random/XorwowRngData.cc
+++ b/src/celeritas/random/XorwowRngData.cc
@@ -34,7 +34,7 @@ void resize(XorwowRngStateData<Ownership::value, M>* state,
     // Seed sequence to generate well-distributed seed numbers, including
     // stream ID to give strings different starting contributions
     std::vector<std::seed_seq::result_type> host_seeds(params.seed.begin(),
-                                         params.seed.end());
+                                                       params.seed.end());
     if (stream != StreamId{0})
     {
         // For backward compatibility with prior RNG seed, don't modify the

--- a/src/celeritas/track/detail/TrackSortUtils.cc
+++ b/src/celeritas/track/detail/TrackSortUtils.cc
@@ -96,7 +96,7 @@ template<>
 void shuffle_track_slots<MemSpace::host>(
     Span<TrackSlotId::size_type> track_slots, StreamId)
 {
-    unsigned int seed = track_slots.size();
+    auto seed = static_cast<unsigned int>(track_slots.size());
     std::mt19937 g{seed};
     std::shuffle(track_slots.begin(), track_slots.end(), g);
 }

--- a/src/celeritas/track/detail/TrackSortUtils.hh
+++ b/src/celeritas/track/detail/TrackSortUtils.hh
@@ -83,7 +83,7 @@ struct alive_predicate
 {
     ObserverPtr<TrackStatus const> status_;
 
-    CELER_FUNCTION bool operator()(unsigned int track_slot) const
+    CELER_FUNCTION bool operator()(size_type track_slot) const
     {
         return status_.get()[track_slot] == TrackStatus::alive;
     }
@@ -93,7 +93,7 @@ struct action_comparator
 {
     ObserverPtr<ActionId const> action_;
 
-    CELER_FUNCTION bool operator()(unsigned int a, unsigned int b) const
+    CELER_FUNCTION bool operator()(size_type a, size_type b) const
     {
         return action_.get()[a] < action_.get()[b];
     }

--- a/src/celeritas/user/SimpleCalo.cc
+++ b/src/celeritas/user/SimpleCalo.cc
@@ -175,7 +175,7 @@ void SimpleCalo::output(JsonPimpl* j) const
         std::vector<int> ids;
         for (VolumeId vid : volume_ids_)
         {
-            ids.push_back(vid.get());
+            ids.push_back(static_cast<int>(vid.get()));
         }
         obj["volume_ids"] = std::move(ids);
         obj["volume_labels"] = volume_labels_;

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -88,11 +88,25 @@ endif()
 
 celeritas_add_library(corecel ${SOURCES})
 
-# Require at least C++14
+# Require at least C++17
 target_compile_features(corecel PUBLIC cxx_std_17)
 if(CELERITAS_USE_CUDA)
   target_compile_features(corecel PUBLIC cuda_std_17)
 endif()
+if(WIN32)
+  target_compile_definitions(corecel PUBLIC
+    $<$<COMPILE_LANGUAGE:CXX>:NOMINMAX NOGDI>
+  )
+
+  # By default MSVC has __cplusplus at 199711L, this flag
+  # forces it to follow the standard
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(corecel PUBLIC
+      $<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus /Zc:preprocessor>
+    )
+  endif()
+endif()
+
 
 celeritas_target_include_directories(corecel
   PUBLIC

--- a/src/corecel/cont/Range.hh
+++ b/src/corecel/cont/Range.hh
@@ -137,7 +137,7 @@ class Range
     template<class U, std::enable_if_t<std::is_unsigned<U>::value, bool> = true>
     CELER_CONSTEXPR_FUNCTION detail::StepRange<step_type<U>> step(U step)
     {
-        return {*begin_, *end_, step};
+        return {*begin_, *end_, static_cast<size_type>(step)};
     }
     //! \endcond
 

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -294,7 +294,7 @@ class Collection
     //! Direct accesors to underlying data
     CELER_FORCEINLINE_FUNCTION size_type size() const
     {
-        return this->storage().size();
+        return static_cast<size_type>(this->storage().size());
     }
     CELER_FORCEINLINE_FUNCTION bool empty() const
     {

--- a/src/corecel/io/ColorUtils.cc
+++ b/src/corecel/io/ColorUtils.cc
@@ -11,7 +11,7 @@
 #include <cstdlib>
 #include <string>
 #ifndef _WIN32
-#include <unistd.h>
+#    include <unistd.h>
 #endif
 
 #include "corecel/sys/Environment.hh"

--- a/src/corecel/io/ColorUtils.cc
+++ b/src/corecel/io/ColorUtils.cc
@@ -10,7 +10,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "corecel/sys/Environment.hh"
 
@@ -23,7 +25,7 @@ namespace celeritas
 bool use_color()
 {
     const static bool result = [] {
-        FILE* stream = stderr;
+        [[maybe_unused]] FILE* stream = stderr;
         std::string color_str = celeritas::getenv("CELER_COLOR");
         if (color_str.empty())
         {
@@ -44,11 +46,13 @@ bool use_color()
             // Color is explicitly enabled
             return true;
         }
+#ifndef _WIN32
         if (!isatty(fileno(stream)))
         {
             // This stream is not a user-facing terminal
             return false;
         }
+#endif
         if (const char* term_str = std::getenv("TERM"))
         {
             if (std::string{term_str}.find("xterm") != std::string::npos)

--- a/src/corecel/io/StringUtils.cc
+++ b/src/corecel/io/StringUtils.cc
@@ -63,7 +63,7 @@ std::string_view trim(std::string_view input)
     {
         --stop;
     }
-    return {start, static_cast<std::size_t>(stop - start)};
+    return {&(*start), static_cast<std::size_t>(stop - start)};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -406,14 +406,24 @@ CELER_FORCEINLINE_FUNCTION ForwardIt min_element(ForwardIt first,
  * Example: \code
   assert(9.0 == ipow<2>(3.0));
   assert(256 == ipow<8>(2));
+  static_assert(256 == ipow<8>(2));
  \endcode
  */
 template<unsigned int N, class T>
 CELER_CONSTEXPR_FUNCTION T ipow(T v) noexcept
 {
-    return (N == 0)       ? 1
-           : (N % 2 == 0) ? ipow<N / 2>(v) * ipow<N / 2>(v)
-                          : v * ipow<(N - 1) / 2>(v) * ipow<(N - 1) / 2>(v);
+	if constexpr (N == 0)
+	{
+		return 1;
+	}
+	else if constexpr (N % 2 == 0)
+	{
+		return ipow<N / 2>(v) * ipow<N / 2>(v);
+	}
+	else
+	{
+            return v * ipow<(N - 1) / 2>(v) * ipow<(N - 1) / 2>(v);
+	    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -412,18 +412,18 @@ CELER_FORCEINLINE_FUNCTION ForwardIt min_element(ForwardIt first,
 template<unsigned int N, class T>
 CELER_CONSTEXPR_FUNCTION T ipow(T v) noexcept
 {
-	if constexpr (N == 0)
-	{
-		return 1;
-	}
-	else if constexpr (N % 2 == 0)
-	{
-		return ipow<N / 2>(v) * ipow<N / 2>(v);
-	}
-	else
-	{
-            return v * ipow<(N - 1) / 2>(v) * ipow<(N - 1) / 2>(v);
-	    }
+    if constexpr (N == 0)
+    {
+        return 1;
+    }
+    else if constexpr (N % 2 == 0)
+    {
+        return ipow<N / 2>(v) * ipow<N / 2>(v);
+    }
+    else
+    {
+        return v * ipow<(N - 1) / 2>(v) * ipow<(N - 1) / 2>(v);
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -100,7 +100,7 @@ using AccessorResultType = typename AccessorTraits<T>::result_type;
  *
  * \note The Quantity is designed to be a simple "strong type" class, not a
  * complex mathematical class. To operate on quantities, you must use
- `value_as`
+ * `value_as`
  * (to operate within the Quantity's unit system) or `native_value_from` (to
  * operate in the Celeritas native unit system), use the resulting numeric
  * values in your mathematical expressions, then return a new Quantity class
@@ -122,13 +122,15 @@ class Quantity
     constexpr Quantity() = default;
 
     //! Construct with value in celeritas native units
-    explicit CELER_CONSTEXPR_FUNCTION Quantity(value_type value)
+    explicit CELER_CONSTEXPR_FUNCTION Quantity(value_type value) noexcept
         : value_(value)
     {
     }
 
     //! Construct implicitly from a unitless quantity
-    CELER_CONSTEXPR_FUNCTION Quantity(Unitless uq) : value_(uq.value_) {}
+    CELER_CONSTEXPR_FUNCTION Quantity(Unitless uq) noexcept : value_(uq.value_)
+    {
+    }
 
     //!@{
     //! Access the underlying numeric value, discarding units
@@ -149,33 +151,33 @@ class Quantity
 
 //---------------------------------------------------------------------------//
 //! \cond
-#define CELER_DEFINE_QUANTITY_CMP(TOKEN)                              \
-    template<class U, class T, class T2>                              \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(Quantity<U, T> lhs,  \
-                                                 Quantity<U, T2> rhs) \
-    {                                                                 \
-        return lhs.value() TOKEN rhs.value();                         \
-    }                                                                 \
-    template<class U, class T>                                        \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                     \
-        Quantity<U, T> lhs, detail::UnitlessQuantity<T> rhs)          \
-    {                                                                 \
-        return lhs.value() TOKEN rhs.value_;                          \
-    }                                                                 \
-    template<class U, class T>                                        \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                     \
-        detail::UnitlessQuantity<T> lhs, Quantity<U, T> rhs)          \
-    {                                                                 \
-        return lhs.value_ TOKEN rhs.value();                          \
-    }                                                                 \
-    namespace detail                                                  \
-    {                                                                 \
-    template<class T>                                                 \
-    CELER_CONSTEXPR_FUNCTION bool                                     \
-    operator TOKEN(UnitlessQuantity<T> lhs, UnitlessQuantity<T> rhs)  \
-    {                                                                 \
-        return lhs.value_ TOKEN rhs.value_;                           \
-    }                                                                 \
+#define CELER_DEFINE_QUANTITY_CMP(TOKEN)                                      \
+    template<class U, class T, class T2>                                      \
+    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                             \
+        Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept                     \
+    {                                                                         \
+        return lhs.value() TOKEN rhs.value();                                 \
+    }                                                                         \
+    template<class U, class T>                                                \
+    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                             \
+        Quantity<U, T> lhs, detail::UnitlessQuantity<T> rhs) noexcept         \
+    {                                                                         \
+        return lhs.value() TOKEN rhs.value_;                                  \
+    }                                                                         \
+    template<class U, class T>                                                \
+    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                             \
+        detail::UnitlessQuantity<T> lhs, Quantity<U, T> rhs) noexcept         \
+    {                                                                         \
+        return lhs.value_ TOKEN rhs.value();                                  \
+    }                                                                         \
+    namespace detail                                                          \
+    {                                                                         \
+    template<class T>                                                         \
+    CELER_CONSTEXPR_FUNCTION bool                                             \
+    operator TOKEN(UnitlessQuantity<T> lhs, UnitlessQuantity<T> rhs) noexcept \
+    {                                                                         \
+        return lhs.value_ TOKEN rhs.value_;                                   \
+    }                                                                         \
     }
 
 //!@{
@@ -194,40 +196,41 @@ CELER_DEFINE_QUANTITY_CMP(>=)
 //! Math operator for Quantity
 template<class U, class T, class T2>
 CELER_CONSTEXPR_FUNCTION auto
-operator+(Quantity<U, T> lhs, Quantity<U, T2> rhs) -> decltype(auto)
+operator+(Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept -> decltype(auto)
 {
     return Quantity<U, std::common_type_t<T, T2>>{lhs.value() + rhs.value()};
 }
 
 template<class U, class T, class T2>
 CELER_CONSTEXPR_FUNCTION auto
-operator-(Quantity<U, T> lhs, Quantity<U, T2> rhs) -> decltype(auto)
+operator-(Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept -> decltype(auto)
 {
     return Quantity<U, std::common_type_t<T, T2>>{lhs.value() - rhs.value()};
 }
 
 template<class U, class T>
-CELER_CONSTEXPR_FUNCTION auto operator-(Quantity<U, T> q) -> Quantity<U, T>
+CELER_CONSTEXPR_FUNCTION auto operator-(Quantity<U, T> q) noexcept
+    -> Quantity<U, T>
 {
     return Quantity<U, T>{-q.value()};
 }
 
 template<class U, class T, class T2>
-CELER_CONSTEXPR_FUNCTION auto operator*(Quantity<U, T> lhs, T2 rhs)
+CELER_CONSTEXPR_FUNCTION auto operator*(Quantity<U, T> lhs, T2 rhs) noexcept
     -> decltype(auto)
 {
     return Quantity<U, std::common_type_t<T, T2>>{lhs.value() * rhs};
 }
 
 template<class U, class T, class T2>
-CELER_CONSTEXPR_FUNCTION auto operator*(T rhs, Quantity<U, T> lhs)
+CELER_CONSTEXPR_FUNCTION auto operator*(T rhs, Quantity<U, T> lhs) noexcept
     -> decltype(auto)
 {
     return Quantity<U, std::common_type_t<T, T2>>{rhs * lhs.value()};
 }
 
 template<class U, class T, class T2>
-CELER_CONSTEXPR_FUNCTION auto operator/(Quantity<U, T> lhs, T2 rhs)
+CELER_CONSTEXPR_FUNCTION auto operator/(Quantity<U, T> lhs, T2 rhs) noexcept
     -> decltype(auto)
 {
     return Quantity<U, std::common_type_t<T, T2>>{lhs.value() / rhs};
@@ -241,7 +244,7 @@ template<class C1, class C2>
 struct UnitDivide
 {
     //! Get the conversion factor of the resulting unit
-    static CELER_CONSTEXPR_FUNCTION auto value() -> decltype(auto)
+    static CELER_CONSTEXPR_FUNCTION auto value() noexcept -> decltype(auto)
     {
         return C1::value() / C2::value();
     }
@@ -252,7 +255,7 @@ template<class C1, class C2>
 struct UnitProduct
 {
     //! Get the conversion factor of the resulting unit
-    static CELER_CONSTEXPR_FUNCTION auto value() -> decltype(auto)
+    static CELER_CONSTEXPR_FUNCTION auto value() noexcept -> decltype(auto)
     {
         return C1::value() * C2::value();
     }
@@ -264,7 +267,8 @@ struct UnitProduct
 /*!
  * Get a zero quantity (analogous to nullptr).
  */
-CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type> zero_quantity()
+CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type>
+zero_quantity() noexcept
 {
     return {0};
 }
@@ -273,7 +277,8 @@ CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type> zero_quantity()
 /*!
  * Get a quantitity greater than any other numeric quantity.
  */
-CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type> max_quantity()
+CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type>
+max_quantity() noexcept
 {
     return {numeric_limits<real_type>::infinity()};
 }
@@ -282,7 +287,8 @@ CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type> max_quantity()
 /*!
  * Get a quantitity less than any other numeric quantity.
  */
-CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type> neg_max_quantity()
+CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type>
+neg_max_quantity() noexcept
 {
     return {-numeric_limits<real_type>::infinity()};
 }
@@ -310,8 +316,8 @@ swap(Quantity<U, V>& a, Quantity<U, V>& b) noexcept
  * \endcode
  */
 template<class UnitT, class ValueT>
-CELER_CONSTEXPR_FUNCTION auto native_value_from(Quantity<UnitT, ValueT> quant)
-    -> decltype(auto)
+CELER_CONSTEXPR_FUNCTION auto
+native_value_from(Quantity<UnitT, ValueT> quant) noexcept -> decltype(auto)
 {
     return quant.value() * UnitT::value();
 }
@@ -329,7 +335,7 @@ CELER_CONSTEXPR_FUNCTION auto native_value_from(Quantity<UnitT, ValueT> quant)
  * \endcode
  */
 template<class Q>
-CELER_CONSTEXPR_FUNCTION Q native_value_to(typename Q::value_type value)
+CELER_CONSTEXPR_FUNCTION Q native_value_to(typename Q::value_type value) noexcept
 {
     return Q{value / Q::unit_type::value()};
 }
@@ -346,8 +352,8 @@ CELER_CONSTEXPR_FUNCTION Q native_value_to(typename Q::value_type value)
  * \endcode
  */
 template<class Q, class SrcUnitT, class ValueT>
-CELER_CONSTEXPR_FUNCTION auto value_as(Quantity<SrcUnitT, ValueT> quant)
-    -> ValueT
+CELER_CONSTEXPR_FUNCTION auto
+value_as(Quantity<SrcUnitT, ValueT> quant) noexcept -> ValueT
 {
     static_assert(std::is_same<Q, Quantity<SrcUnitT, ValueT>>::value,
                   "quantity units do not match");

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -106,7 +106,7 @@ using AccessorResultType = typename AccessorTraits<T>::result_type;
  * values in your mathematical expressions, then return a new Quantity class
  * with the resulting value and correct type.
  */
-template<class UnitT, class ValueT = real_type>
+template<class UnitT, class ValueT = decltype(UnitT::value())>
 class Quantity
 {
   public:

--- a/src/corecel/math/detail/MathImpl.hh
+++ b/src/corecel/math/detail/MathImpl.hh
@@ -55,7 +55,7 @@ inline void sincospi(T x, T* sptr, T* cptr)
     }
     else
     {
-        x *= m_pi;
+        x *= static_cast<T>(m_pi);
         cval = std::cos(x);
         sval = std::sin(x);
     }

--- a/src/corecel/sys/Environment.cc
+++ b/src/corecel/sys/Environment.cc
@@ -24,8 +24,8 @@ namespace celeritas
  */
 Environment& environment()
 {
-    static Environment environ;
-    return environ;
+    static Environment result;
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/KernelRegistry.hh
+++ b/src/corecel/sys/KernelRegistry.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 #include <iosfwd>  // IWYU pragma: keep
 #include <memory>
 #include <mutex>
@@ -25,13 +26,15 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 struct KernelProfiling
 {
+    using value_type = std::uint_least64_t;
+
     //!< Number of times launched
-    std::atomic<int> num_launches{0};
+    std::atomic<value_type> num_launches{0};
     //!< Number of threads integrated over all launches
-    std::atomic<long long> accum_threads{0};
+    std::atomic<value_type> accum_threads{0};
 
     // Increment atomic counters given the number of threads
-    inline void log_launch(int num_threads);
+    inline void log_launch(value_type num_threads);
 };
 
 //---------------------------------------------------------------------------//
@@ -107,7 +110,7 @@ std::ostream& operator<<(std::ostream& os, KernelMetadata const& md);
 /*!
  * Accumulate counters for a kernel launch.
  */
-void KernelProfiling::log_launch(int num_threads)
+void KernelProfiling::log_launch(value_type num_threads)
 {
     CELER_EXPECT(num_threads > 0);
 

--- a/src/corecel/sys/MemRegistry.hh
+++ b/src/corecel/sys/MemRegistry.hh
@@ -20,12 +20,12 @@ namespace celeritas
 //! SI prefix for multiples of 1024
 struct Kibi
 {
-    static CELER_CONSTEXPR_FUNCTION int value() { return 1024; }
+    static CELER_CONSTEXPR_FUNCTION long int value() { return 1024; }
     static char const* label() { return "kibi"; }
 };
 
 //! 1024 bytes
-using KibiBytes = Quantity<Kibi, int>;
+using KibiBytes = Quantity<Kibi, long int>;
 //! Ordered identifiers for memory allocation segments
 using MemUsageId = OpaqueId<struct MemUsageEntry>;
 

--- a/src/corecel/sys/MemRegistry.hh
+++ b/src/corecel/sys/MemRegistry.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -20,12 +21,14 @@ namespace celeritas
 //! SI prefix for multiples of 1024
 struct Kibi
 {
-    static CELER_CONSTEXPR_FUNCTION long int value() { return 1024; }
+    using value_type = std::size_t;
+
+    static CELER_CONSTEXPR_FUNCTION value_type value() { return 1024u; }
     static char const* label() { return "kibi"; }
 };
 
 //! 1024 bytes
-using KibiBytes = Quantity<Kibi, long int>;
+using KibiBytes = Quantity<Kibi>;
 //! Ordered identifiers for memory allocation segments
 using MemUsageId = OpaqueId<struct MemUsageEntry>;
 
@@ -39,20 +42,20 @@ struct MemUsageEntry
     //! Difference in CPU memory usage from beginning to end
     KibiBytes cpu_delta{};
     //! Reported CPU "high water mark" at the end the block
-    KibiBytes cpu_hwm{-1};
+    KibiBytes cpu_hwm{};
     //! Difference in GPU memory usage from beginning to end
     KibiBytes gpu_delta{};
     //! Reported GPU "high water mark" at the end the block
-    KibiBytes gpu_usage{-1};
+    KibiBytes gpu_usage{};
 };
 
 //---------------------------------------------------------------------------//
 /*!
  * Track memory usage across the application.
  *
- * This class is not thread-safe and should generally be used during setup. The
- * memory usage entries are a tree. Pushing and popping should be done with \c
- * ScopedMem .
+ * This class is \em not thread-safe and should generally be used during setup.
+ * The memory usage entries are a tree. Pushing and popping should be done with
+ * \c ScopedMem .
  */
 class MemRegistry
 {

--- a/src/corecel/sys/ScopedMem.hh
+++ b/src/corecel/sys/ScopedMem.hh
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <cstddef>
 #include <string_view>
 
 #include "corecel/cont/InitializedValue.hh"
@@ -64,8 +63,8 @@ class ScopedMem
   private:
     InitializedValue<MemRegistry*> registry_;
     MemUsageId id_;
-    std::ptrdiff_t cpu_start_hwm_{0};
-    std::ptrdiff_t gpu_start_used_{0};
+    long int cpu_start_hwm_{0};
+    long int gpu_start_used_{0};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedMem.hh
+++ b/src/corecel/sys/ScopedMem.hh
@@ -61,10 +61,12 @@ class ScopedMem
     //!@}
 
   private:
+    using value_type = KibiBytes::value_type;
+
     InitializedValue<MemRegistry*> registry_;
     MemUsageId id_;
-    long int cpu_start_hwm_{0};
-    long int gpu_start_used_{0};
+    value_type cpu_start_hwm_{0};
+    value_type gpu_start_used_{0};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/Stream.cc
+++ b/src/corecel/sys/Stream.cc
@@ -18,6 +18,8 @@
 namespace celeritas
 {
 #if CELER_USE_DEVICE
+// GCC 8 and 9 are known to print a warning for "maybe unused" variables that
+// are actually used (after preprocessor logic).
 #    define CELER_UNUSED_UNLESS_DEVICE
 #else
 #    define CELER_UNUSED_UNLESS_DEVICE [[maybe_unused]]

--- a/src/corecel/sys/Stream.cc
+++ b/src/corecel/sys/Stream.cc
@@ -17,6 +17,11 @@
 
 namespace celeritas
 {
+#if CELER_USE_DEVICE
+#    define CELER_UNUSED_UNLESS_DEVICE
+#else
+#    define CELER_UNUSED_UNLESS_DEVICE [[maybe_unused]]
+#endif
 
 //---------------------------------------------------------------------------//
 /*!
@@ -24,7 +29,7 @@ namespace celeritas
  */
 template<class Pointer>
 auto AsyncMemoryResource<Pointer>::do_allocate(
-    [[maybe_unused]] std::size_t bytes, std::size_t) -> pointer
+    CELER_UNUSED_UNLESS_DEVICE std::size_t bytes, std::size_t) -> pointer
 {
     void* ret;
     CELER_DEVICE_CALL_PREFIX(MallocAsync(&ret, bytes, stream_));
@@ -36,9 +41,8 @@ auto AsyncMemoryResource<Pointer>::do_allocate(
  * Deallocate device memory.
  */
 template<class Pointer>
-void AsyncMemoryResource<Pointer>::do_deallocate([[maybe_unused]] pointer p,
-                                                 std::size_t,
-                                                 std::size_t)
+void AsyncMemoryResource<Pointer>::do_deallocate(
+    CELER_UNUSED_UNLESS_DEVICE pointer p, std::size_t, std::size_t)
 {
     try
     {

--- a/src/corecel/sys/Version.cc
+++ b/src/corecel/sys/Version.cc
@@ -38,7 +38,7 @@ Version Version::from_string(std::string_view sv)
             // No version component given
             return size_type{0};
         }
-        int result = std::atoi(submatch.first);
+        int result = std::atoi(&(*submatch.first));
         return static_cast<size_type>(result);
     };
 

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -26,6 +26,7 @@ list(APPEND SOURCES
   surf/CylAligned.cc
   surf/GeneralQuadric.cc
   surf/Plane.cc
+  surf/PlaneAligned.cc
   surf/SimpleQuadric.cc
   surf/Sphere.cc
   surf/SurfaceIO.cc

--- a/src/orange/construct/detail/NodeSimplifier.cc
+++ b/src/orange/construct/detail/NodeSimplifier.cc
@@ -7,6 +7,11 @@
 //---------------------------------------------------------------------------//
 #include "NodeSimplifier.hh"
 
+#include <algorithm>
+#include <utility>
+
+#include "../CsgTypes.hh"
+
 namespace celeritas
 {
 namespace csg

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -306,7 +306,7 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
 
     // Mark as 'simple safety' if all the surfaces are simple
     bool simple_safety = true;
-    logic_int max_intersections = 0;
+    size_type max_intersections = 0;
 
     for (LocalSurfaceId sid : v.faces)
     {
@@ -334,7 +334,7 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
                        .insert_back(v.faces.begin(), v.faces.end());
     output.logic = make_builder(&orange_data_->logic_ints)
                        .insert_back(input_logic.begin(), input_logic.end());
-    output.max_intersections = max_intersections;
+    output.max_intersections = static_cast<logic_int>(max_intersections);
     output.flags = v.flags;
     if (simple_safety)
     {

--- a/src/orange/surf/PlaneAligned.cc
+++ b/src/orange/surf/PlaneAligned.cc
@@ -1,0 +1,19 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/surf/PlaneAligned.cc
+//---------------------------------------------------------------------------//
+#include "PlaneAligned.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+
+template class PlaneAligned<Axis::x>;
+template class PlaneAligned<Axis::y>;
+template class PlaneAligned<Axis::z>;
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/surf/detail/QuadricPlaneConverter.hh
+++ b/src/orange/surf/detail/QuadricPlaneConverter.hh
@@ -7,6 +7,9 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <algorithm>
+
+#include "corecel/Assert.hh"
 #include "corecel/math/SoftEqual.hh"
 #include "orange/surf/Plane.hh"
 #include "orange/surf/SimpleQuadric.hh"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ include(CeleritasAddTest)
 # TEST HARNESS
 #-----------------------------------------------------------------------------#
 
-set(CELERITAS_SOURCE_DIR "${PROJECT_SOURCE_DIR}")
+file(TO_CMAKE_PATH "${PROJECT_SOURCE_DIR}" CELERITAS_SOURCE_DIR)
 configure_file(celeritas_test_config.h.in celeritas_test_config.h @ONLY)
 
 celeritas_add_library(testcel_harness

--- a/test/Test.cc
+++ b/test/Test.cc
@@ -31,10 +31,13 @@ Test::test_data_path(std::string_view subdir, std::string_view filename)
     std::ostringstream os;
     os << celeritas_source_dir << "/test/" << subdir << "/data/" << filename;
 
-    std::string result = os.str();
-    CELER_VALIDATE(std::ifstream(result).good(),
-                   << "Failed to open test data file at " << result);
-    return result;
+    std::string path = os.str();
+    if (!filename.empty())
+    {
+        CELER_VALIDATE(std::ifstream(path).good(),
+                       << "Failed to open test data file at '" << path << "'");
+    }
+    return path;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/em/BetheHeitler.test.cc
+++ b/test/celeritas/em/BetheHeitler.test.cc
@@ -241,7 +241,7 @@ TEST_F(BetheHeitlerInteractorTest, distributions)
             const auto electron = out.secondaries.front();
             double eps = (electron.energy.value() + data_.electron_mass.value())
                          / inc_energy;
-            int eps_bin = eps * nbins;
+            auto eps_bin = static_cast<int>(eps * nbins);
             if (eps_bin >= 0 && eps_bin < nbins)
             {
                 ++eps_dist[eps_bin];

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -300,8 +300,9 @@ TEST_F(UrbanMscTest, step_conversion)
             msc_step.alpha = gp.alpha;
             MscStepFromGeo geo_to_true(
                 msc_params_->host_ref().params, msc_step, range, lambda);
-            LogInterp calc_gstep({0, 0.9 * params.limit_min_fix()},
-                                 {static_cast<real_type>(gstep_points), gp.step});
+            LogInterp calc_gstep(
+                {0, 0.9 * params.limit_min_fix()},
+                {static_cast<real_type>(gstep_points), gp.step});
             for (auto gpt : celeritas::range(gstep_points + 1))
             {
                 // Calculate between a nearby hypothetical geometric boundary

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -278,7 +278,7 @@ TEST_F(UrbanMscTest, step_conversion)
             msc_params_->host_ref(), helper, energy, lambda, range);
 
         LogInterp calc_pstep({0, 0.9 * params.limit_min_fix()},
-                             {pstep_points, range});
+                             {static_cast<real_type>(pstep_points), range});
         for (auto ppt : celeritas::range(pstep_points + 1))
         {
             // Calculate given a physics step between "tiny" and the maximum
@@ -301,7 +301,7 @@ TEST_F(UrbanMscTest, step_conversion)
             MscStepFromGeo geo_to_true(
                 msc_params_->host_ref().params, msc_step, range, lambda);
             LogInterp calc_gstep({0, 0.9 * params.limit_min_fix()},
-                                 {gstep_points, gp.step});
+                                 {static_cast<real_type>(gstep_points), gp.step});
             for (auto gpt : celeritas::range(gstep_points + 1))
             {
                 // Calculate between a nearby hypothetical geometric boundary
@@ -372,7 +372,7 @@ TEST_F(UrbanMscTest, msc_scattering)
                                        0.102364,
                                        0.0465336,
                                        0.00708839};
-    constexpr unsigned int nsamples = std::end(energy) - std::begin(energy);
+    constexpr auto nsamples = std::size(energy);
 
     // Calculate range instead of hardcoding to ensure step and range values
     // are bit-for-bit identical when range limits the step. The first three

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -201,13 +201,13 @@ auto GeantImporterTest::summarize(VecModelMaterial const& materials) const
 void GeantImporterTest::ImportXsSummary::print_expected() const
 {
     cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
-         << "static const real_type expected_size[] = " << repr(this->size)
+         << "static size_type const expected_size[] = " << repr(this->size)
          << ";\n"
          << "EXPECT_VEC_EQ(expected_size, result.size);\n"
-         << "static const real_type expected_e[] = " << repr(this->energy)
+         << "static real_type const expected_e[] = " << repr(this->energy)
          << ";\n"
          << "EXPECT_VEC_SOFT_EQ(expected_e, result.energy);\n"
-         << "static const real_type expected_xs[] = " << repr(this->xs)
+         << "static real_type const expected_xs[] = " << repr(this->xs)
          << ";\n"
          << "EXPECT_VEC_SOFT_EQ(expected_xs, result.xs);\n"
          << "/*** END CODE ***/\n";
@@ -686,12 +686,12 @@ TEST_F(FourSteelSlabsEmStandard, ebrems)
         EXPECT_EQ(2, model.materials.size());
 
         auto result = summarize(model.materials);
-        static const real_type expected_size[] = {7ul, 5ul};
+        static size_type const expected_size[] = {7ul, 5ul};
         EXPECT_VEC_EQ(expected_size, result.size);
-        static const real_type expected_e[]
+        static real_type const expected_e[]
             = {0.001, 1000, 0.020822442086622, 1000};
         EXPECT_VEC_SOFT_EQ(expected_e, result.energy);
-        static const real_type expected_xs[] = {19.90859573288,
+        static real_type const expected_xs[] = {19.90859573288,
                                                 77.272184544415,
                                                 16.869369978465,
                                                 66.694254412524,
@@ -706,12 +706,12 @@ TEST_F(FourSteelSlabsEmStandard, ebrems)
         EXPECT_EQ(2, model.materials.size());
 
         auto result = summarize(model.materials);
-        static const real_type expected_size[] = {6ul, 6ul};
+        static size_type const expected_size[] = {6ul, 6ul};
         EXPECT_VEC_EQ(expected_size, result.size);
-        static const real_type expected_e[]
+        static real_type const expected_e[]
             = {1000, 100000000, 1000, 100000000};
         EXPECT_VEC_SOFT_EQ(expected_e, result.energy);
-        static const real_type expected_xs[] = {77.086886023111,
+        static real_type const expected_xs[] = {77.086886023111,
                                                 14.346968386977,
                                                 66.448046061979,
                                                 12.347652116819,
@@ -737,12 +737,12 @@ TEST_F(FourSteelSlabsEmStandard, conv)
 
         auto result = summarize(model.materials);
 
-        static const real_type expected_size[] = {9ul, 9ul};
+        static size_type const expected_size[] = {9ul, 9ul};
         EXPECT_VEC_EQ(expected_size, result.size);
-        static const real_type expected_e[]
+        static real_type const expected_e[]
             = {1.02199782, 100000000, 1.02199782, 100000000};
         EXPECT_VEC_SOFT_EQ(expected_e, result.energy);
-        static const real_type expected_xs[] = {1.4603666285612,
+        static real_type const expected_xs[] = {1.4603666285612,
                                                 4.4976609946794,
                                                 1.250617083013,
                                                 3.8760336885145,
@@ -1186,7 +1186,7 @@ TEST_F(OneSteelSphere, physics)
         EXPECT_EQ(2, model.materials.size());
 
         auto result = summarize(model.materials);
-        static const real_type expected_size[] = {6u, 5u};
+        static size_type const expected_size[] = {6u, 5u};
         EXPECT_VEC_EQ(expected_size, result.size);
         static double const expected_energy[]
             = {1000, 100000000, 9549.6516356879, 100000000};

--- a/test/celeritas/grid/CalculatorTestBase.cc
+++ b/test/celeritas/grid/CalculatorTestBase.cc
@@ -33,7 +33,7 @@ void CalculatorTestBase::build(real_type emin, real_type emax, size_type count)
         {0.0, emin}, {count - 1.0, emax});
     for (auto i : range(temp_xs.size()))
     {
-        temp_xs[i] = calc_xs(i);
+        temp_xs[i] = calc_xs(static_cast<real_type>(i));
     }
 
     value_storage_ = {};

--- a/test/celeritas/random/SequenceEngine.hh
+++ b/test/celeritas/random/SequenceEngine.hh
@@ -112,7 +112,7 @@ SequenceEngine SequenceEngine::from_reals(Span<double const> values)
     using real_type = double;
 
     CELER_EXPECT(!values.empty());
-    const real_type range = SequenceEngine::max() + real_type(1);
+    real_type const range = SequenceEngine::max() + real_type(1);
 
     SequenceEngine::VecResult elements(values.size() * 2);
     auto dst = elements.begin();
@@ -128,7 +128,7 @@ SequenceEngine SequenceEngine::from_reals(Span<double const> values)
         v *= range;
 
         // Store values
-        *dst++ = std::floor(v);
+        *dst++ = static_cast<result_type>(std::floor(v));
         *dst++ = second;
     }
     CELER_ENSURE(dst == elements.end());

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -300,16 +300,16 @@ TYPED_TEST(TrackInitTest, run)
 
 TYPED_TEST(TrackInitTest, primaries)
 {
-    const size_type num_sets = 4;
-    const size_type num_primaries = 16;
-    const size_type num_tracks = 16;
+    size_type num_sets = 4;
+    size_type num_primaries = 16;
+    size_type num_tracks = 16;
 
     this->build_states(num_tracks);
 
     this->init_tracks();
 
     // Kill half the tracks in each interaction and don't produce secondaries
-    auto interact = [] {
+    auto interact = [&] {
         std::vector<size_type> alloc(num_tracks, 0);
         std::vector<bool> alive(num_tracks);
         for (size_type i = 0; i < num_tracks; ++i)
@@ -360,8 +360,8 @@ TYPED_TEST(TrackInitTest, primaries)
 TYPED_TEST(TrackInitTest, extend_from_secondaries)
 {
     // Basic setup
-    const size_type num_primaries = 8;
-    const size_type num_tracks = 8;
+    size_type num_primaries = 8;
+    size_type num_tracks = 8;
 
     std::vector<bool> const alive
         = {true, false, false, true, true, false, false, true};
@@ -417,7 +417,7 @@ TYPED_TEST(TrackInitTest, extend_from_secondaries)
         EXPECT_TRUE(std::all_of(
             std::begin(result.track_ids),
             std::end(result.track_ids),
-            [i](unsigned int id) { return id < num_tracks + (i + 1) * 4; }));
+            [&](unsigned int id) { return id < num_tracks + (i + 1) * 4; }));
 
         // Parent ids may not be deterministic, but all non-killed tracks are
         // guaranteed to be primaries at every iteration. At end of first

--- a/test/corecel/cont/Range.test.cc
+++ b/test/corecel/cont/Range.test.cc
@@ -211,7 +211,8 @@ TEST(RangeTest, different_enums)
 
 TEST(RangeTest, enum_step)
 {
-    EXPECT_TRUE((std::is_same_v<std::underlying_type_t<pokemon::Pokemon>, int>));
+    EXPECT_TRUE(
+        (std::is_same_v<std::underlying_type_t<pokemon::Pokemon>, int>));
 
     std::vector<int> vals;
     for (auto p : range(pokemon::size_).step(3u))

--- a/test/corecel/cont/Range.test.cc
+++ b/test/corecel/cont/Range.test.cc
@@ -38,7 +38,7 @@ enum class WontWorkColors
 
 namespace pokemon
 {
-enum Pokemon
+enum Pokemon : int
 {
     charmander = 0,
     bulbasaur,
@@ -211,8 +211,7 @@ TEST(RangeTest, different_enums)
 
 TEST(RangeTest, enum_step)
 {
-    EXPECT_TRUE((std::is_same<std::underlying_type<pokemon::Pokemon>::type,
-                              unsigned int>::value));
+    EXPECT_TRUE((std::is_same_v<std::underlying_type_t<pokemon::Pokemon>, int>));
 
     std::vector<int> vals;
     for (auto p : range(pokemon::size_).step(3u))

--- a/test/corecel/io/Join.test.cc
+++ b/test/corecel/io/Join.test.cc
@@ -90,7 +90,7 @@ TEST_F(JoinTest, DISABLED_ginormous)
 {
     std::ofstream out(this->make_unique_filename(".txt"));
 
-    auto r = range<std::size_t>(1e7);
+    auto r = range(1000000000ull);
     out << join(r.begin(), r.end(), "\n");
 }
 

--- a/test/corecel/math/NumericLimits.test.cc
+++ b/test/corecel/math/NumericLimits.test.cc
@@ -37,7 +37,9 @@ TYPED_TEST(RealNumericLimitsTest, host)
     EXPECT_EQ(std_limits_t::infinity(), celer_limits_t::infinity());
     EXPECT_EQ(std_limits_t::max(), celer_limits_t::max());
     EXPECT_TRUE(std::isnan(celer_limits_t::quiet_NaN()));
+#ifndef _MSC_VER
     EXPECT_EQ(std_limits_t::infinity(), TypeParam(1) / TypeParam(0));
+#endif
 }
 
 #if CELER_USE_DEVICE

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -45,12 +45,12 @@ struct DozenUnit
 
 TEST(QuantityTest, constexpr_attributes)
 {
-    EXPECT_TRUE(std::is_same_v<Revolution::value_type, double>);
+    EXPECT_TRUE((std::is_same_v<Revolution::value_type, double>));
     EXPECT_EQ(sizeof(Revolution), sizeof(double));
     EXPECT_TRUE(std::is_standard_layout<Revolution>::value);
     EXPECT_TRUE(std::is_default_constructible<Revolution>::value);
 
-    EXPECT_TRUE(std::is_same_v<DozenUnit::value_type, int>);
+    EXPECT_TRUE((std::is_same_v<Quantity<DozenUnit>::value_type, int>));
 }
 
 TEST(QuantityTest, usage)

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -31,7 +31,7 @@ struct TwoPi
 {
     static double value() { return 2 * pi; }
 };
-using Revolution = Quantity<TwoPi, double>;
+using Revolution = Quantity<TwoPi>;
 
 struct DozenUnit
 {
@@ -43,11 +43,14 @@ struct DozenUnit
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST(QuantityTest, simplicity)
+TEST(QuantityTest, constexpr_attributes)
 {
+    EXPECT_TRUE(std::is_same_v<Revolution::value_type, double>);
     EXPECT_EQ(sizeof(Revolution), sizeof(double));
     EXPECT_TRUE(std::is_standard_layout<Revolution>::value);
     EXPECT_TRUE(std::is_default_constructible<Revolution>::value);
+
+    EXPECT_TRUE(std::is_same_v<DozenUnit::value_type, int>);
 }
 
 TEST(QuantityTest, usage)
@@ -69,7 +72,7 @@ TEST(QuantityTest, usage)
     EXPECT_DOUBLE_EQ(0.5, value_as<Revolution>(half_rev));
 
     // Check integer division works correctly
-    using Dozen = Quantity<DozenUnit, int>;
+    using Dozen = Quantity<DozenUnit>;
     auto two_dozen = native_value_to<Dozen>(24);
     EXPECT_TRUE((std::is_same_v<decltype(two_dozen), Dozen>));
     EXPECT_EQ(2, value_as<Dozen>(two_dozen));
@@ -190,7 +193,7 @@ TEST(QuantityTest, math)
 
 TEST(QuantityTest, swappiness)
 {
-    using Dozen = Quantity<DozenUnit, int>;
+    using Dozen = Quantity<DozenUnit>;
     Dozen dozen{1}, gross{12};
     {
         // ADL should prefer swap implementation
@@ -212,7 +215,7 @@ TEST(QuantityTest, swappiness)
 TEST(QuantityTest, TEST_IF_CELERITAS_JSON(io))
 {
 #if CELERITAS_USE_JSON
-    using Dozen = Quantity<DozenUnit, int>;
+    using Dozen = Quantity<DozenUnit>;
 
     {
         SCOPED_TRACE("Input as scalar");

--- a/test/corecel/sys/ScopedSignalHandler.test.cc
+++ b/test/corecel/sys/ScopedSignalHandler.test.cc
@@ -40,6 +40,7 @@ TEST(ScopedSignalHandlerTest, single)
     }
 }
 
+#ifndef _WIN32
 TEST(ScopedSignalHandlerTest, multiple)
 {
     using FuncPtr = int (*)(int);
@@ -63,6 +64,7 @@ TEST(ScopedSignalHandlerTest, multiple)
         }
     }
 }
+#endif
 
 TEST(ScopedSignalHandlerTest, nested)
 {

--- a/test/testdetail/TestMacrosImpl.hh
+++ b/test/testdetail/TestMacrosImpl.hh
@@ -322,7 +322,7 @@ std::string failure_msg(char const* expected_expr,
     using std::setw;
 
     // Calculate how many digits we need to space out
-    int idig = num_digits(failures.back().index);
+    int idig = num_digits(static_cast<unsigned long>(failures.back().index));
     int vdig = 16;
 
     // Construct our own stringstream because google test ignores setw
@@ -361,7 +361,7 @@ std::string float_failure_msg(char const* expected_expr,
     using std::setw;
 
     // Calculate how many digits we need to space out the index
-    int idig = num_digits(failures.back().index);
+    int idig = num_digits(static_cast<unsigned long>(failures.back().index));
     int vdig = std::max(std::numeric_limits<T1>::digits10,
                         std::numeric_limits<T2>::digits10);
 


### PR DESCRIPTION
This adds non-CI-tested support for building and running on Windows. (Compiled with MS Visual Studio 2022, 14.37.32822.) All applications and tests build and pass in a near-minimal (only JSON and Googletest enabled) configuration.

Key compatibility issues are:
- Fix many narrowing conversions, including one that would have introduced a serious bug due to integer overflow in the Dorman–Prince stepper constant
- Use `if constexpr` rather than triad to fix compiler crash from template recursion. Before this, `ipow` relied on an optimization trick.
- Fix some missing includes
- Add conditional support for `SIGUSR2` and `isatty`
- Fix  misuse of `string_view::const_iterator` as `char const*`
- Work around some MSVC lambda capture scope issues
- Normalize project source dir path written to celeritas test config file

Celeritas is about to become a dependency of [SCALE](https://www.ornl.gov/scale) to use ORANGE for CPU and GPU geometry. SCALE must compile on Windows.