### PR TITLE
Rewrite soft equality for simplicity

### DIFF
--- a/app/demo-interactor/XsGridParams.cc
+++ b/app/demo-interactor/XsGridParams.cc
@@ -31,20 +31,20 @@ namespace app
 namespace
 {
 bool is_same_log_grid(UniformGridData const& grid,
-                      std::vector<real_type> const& energy)
+                      std::vector<real_type> const& energy,
+                      real_type tol)
 {
-    SoftEqual<> soft_eq(1e-8);
     UniformGrid log_energy(grid);
     if (log_energy.size() != energy.size())
     {
         return false;
     }
-    for (auto i : range(energy.size()))
-    {
-        if (!soft_eq(std::log(energy[i]), log_energy[i]))
-            return false;
-    }
-    return true;
+
+    auto r = range(energy.size());
+    SoftEqual const soft_eq{tol};
+    return std::all_of(r.begin(), r.end(), [&](auto i) {
+        return soft_eq(std::log(energy[i]), log_energy[i]);
+    });
 }
 }  // namespace
 
@@ -69,7 +69,7 @@ XsGridParams::XsGridParams(Input const& input)
         = UniformGridData::from_bounds(std::log(input.energy.front()),
                                        std::log(input.energy.back()),
                                        input.energy.size());
-    CELER_ASSERT(is_same_log_grid(host_xs.log_energy, input.energy));
+    CELER_ASSERT(is_same_log_grid(host_xs.log_energy, input.energy, 1e-6));
     host_xs.prime_index = std::find(input.energy.begin(),
                                     input.energy.end(),
                                     input.prime_energy)

--- a/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
+++ b/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
@@ -32,7 +32,8 @@ namespace celeritas
 /*!
  * Perform Moller (e-e-) and Bhabha (e+e-) scattering.
  *
- * This is a model for both Moller and Bhabha scattering processes.
+ * This interaction, part of the ionization process, is when an incident
+ * electron or positron ejects an electron from the surrounding matter.
  *
  * \note This performs the same sampling routine as in Geant4's
  * G4MollerBhabhaModel class, as documented in section 10.1.4 of the Geant4
@@ -156,6 +157,7 @@ CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
     CELER_ASSERT(secondary_energy >= electron_cutoff_);
 
     // Same equation as in ParticleTrackView::momentum_sq()
+    // TODO: use local data ParticleTrackView
     const real_type secondary_momentum = std::sqrt(
         secondary_energy
         * (secondary_energy + 2 * value_as<Mass>(shared_.electron_mass)));

--- a/src/celeritas/em/interactor/detail/SBPositronXsCorrector.hh
+++ b/src/celeritas/em/interactor/detail/SBPositronXsCorrector.hh
@@ -139,17 +139,12 @@ CELER_FUNCTION real_type SBPositronXsCorrector::operator()(Energy energy) const
    = 1/\sqrt{1 - \left( \frac{mc^2}{K + mc^2} \right)^2}
    = 1 / \beta(K)
  * \f]
- *
- * \todo I originally wanted all these sort of calculations to be in
- * ParticleTrackView, but that class requires a full set of state, params, etc.
- * Maybe we need to refactor it so that this calculation doesn't get duplicated
- * everywhere inside the physics -- maybe a "LocalParticle" that has the same
- * functions.
  */
 CELER_FUNCTION real_type
 SBPositronXsCorrector::calc_invbeta(real_type gamma_energy) const
 {
     CELER_EXPECT(gamma_energy > 0 && gamma_energy < inc_energy_);
+    // TODO: use local data ParticleTrackView
     // Positron has all the energy except what it gave to the gamma
     real_type energy = inc_energy_ - gamma_energy;
     return (energy + positron_mass_)

--- a/src/celeritas/phys/ParticleTrackView.hh
+++ b/src/celeritas/phys/ParticleTrackView.hh
@@ -364,7 +364,7 @@ CELER_FUNCTION real_type ParticleTrackView::lorentz_factor() const
 CELER_FUNCTION units::MevMomentumSq ParticleTrackView::momentum_sq() const
 {
     const real_type energy = this->energy().value();
-    real_type result = energy * energy + 2 * this->mass().value() * energy;
+    real_type result = ipow<2>(energy) + 2 * this->mass().value() * energy;
     CELER_ENSURE(result >= 0);
     return units::MevMomentumSq{result};
 }

--- a/src/corecel/math/ArrayUtils.hh
+++ b/src/corecel/math/ArrayUtils.hh
@@ -264,6 +264,26 @@ rotate(Array<T, 3> const& dir, Array<T, 3> const& rot)
 /*!
  * Test for being approximately a unit vector.
  *
+ * Consider a unit vector \em v with a small perturbation along a unit vector
+ * \em e: \f[
+   \vec v + \epsilon \vec e
+  \f]
+ * The magnitude squared is
+ * \f[
+  m^2 = (v + \epsilon e) \cdot (v + \epsilon e)
+   = |v|^2 + 2 \epsilon v \cdot e +  \epsilon^2 e \cdot e
+   = 1 + 2 \epsilon v \cdot e + \epsilon^2
+ \f]
+ *
+ * Since \f[ v \cdot e  <= |v||e| = 1 \f] by the triangle inequality,
+ * then the magnitude squared of a perturbed unit vector is bounded
+ * \f[
+  m^2 = 1 \pm (2 \epsilon + \epsilon^2)
+  \f]
+ *
+ * Instead of calculating the square of the tolerance we loosely bound with
+ * another epsilon.
+ *
  * Example:
  * \code
     CELER_EXPECT(is_soft_unit_vector(v));
@@ -272,9 +292,9 @@ rotate(Array<T, 3> const& dir, Array<T, 3> const& rot)
 template<class T, size_type N>
 CELER_FUNCTION bool is_soft_unit_vector(Array<T, N> const& v)
 {
-    // (1 + eps, 0, 0) is not quite allowed for 2*eps precision; increase
-    SoftEqual<T> cmp{10 * detail::SoftEqualTraits<T>::rel_prec()};
-    return cmp(T(1), dot_product(v, v));
+    constexpr SoftEqual<T> default_soft_eq;
+    SoftEqual cmp{3 * default_soft_eq.rel(), 3 * default_soft_eq.abs()};
+    return cmp(T{1}, dot_product(v, v));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/SoftEqual.hh
+++ b/src/corecel/math/SoftEqual.hh
@@ -46,13 +46,13 @@ class SoftEqual
 
   public:
     // Construct with default relative/absolute precision
-    inline CELER_FUNCTION SoftEqual();
+    CELER_CONSTEXPR_FUNCTION SoftEqual();
 
     // Construct with default absolute precision
-    inline explicit CELER_FUNCTION SoftEqual(value_type rel);
+    explicit CELER_FUNCTION SoftEqual(value_type rel);
 
     // Construct with both relative and absolute precision
-    inline CELER_FUNCTION SoftEqual(value_type rel, value_type abs);
+    CELER_FUNCTION SoftEqual(value_type rel, value_type abs);
 
     //// COMPARISON ////
 
@@ -62,10 +62,10 @@ class SoftEqual
     //// ACCESSORS ////
 
     //! Relative allowable error
-    CELER_FUNCTION value_type rel() const { return rel_; }
+    CELER_CONSTEXPR_FUNCTION value_type rel() const { return rel_; }
 
     //! Absolute tolerance
-    CELER_FUNCTION value_type abs() const { return abs_; }
+    CELER_CONSTEXPR_FUNCTION value_type abs() const { return abs_; }
 
   private:
     value_type rel_;
@@ -77,6 +77,8 @@ class SoftEqual
 //---------------------------------------------------------------------------//
 /*!
  * Compare for equality before checking with the given functor.
+ *
+ * This CRTP class allows \c SoftEqual to work for infinities.
  */
 template<class F>
 class EqualOr : public F
@@ -112,10 +114,10 @@ class SoftZero
 
   public:
     // Construct with default relative/absolute precision
-    inline CELER_FUNCTION SoftZero();
+    CELER_CONSTEXPR_FUNCTION SoftZero();
 
     // Construct with absolute precision
-    inline explicit CELER_FUNCTION SoftZero(value_type abs);
+    explicit CELER_FUNCTION SoftZero(value_type abs);
 
     //// COMPARISON ////
 
@@ -125,7 +127,7 @@ class SoftZero
     //// ACCESSORS ////
 
     //! Absolute tolerance
-    CELER_FUNCTION value_type abs() const { return abs_; }
+    CELER_CONSTEXPR_FUNCTION value_type abs() const { return abs_; }
 
   private:
     value_type abs_;
@@ -150,8 +152,8 @@ CELER_FUNCTION EqualOr(F&&)->EqualOr<F>;
  * Construct with default relative/absolute precision.
  */
 template<class RealType>
-CELER_FUNCTION SoftEqual<RealType>::SoftEqual()
-    : SoftEqual(SETraits::rel_prec(), SETraits::abs_thresh())
+CELER_CONSTEXPR_FUNCTION SoftEqual<RealType>::SoftEqual()
+    : rel_{SETraits::rel_prec()}, abs_{SETraits::abs_thresh()}
 {
 }
 
@@ -177,7 +179,7 @@ CELER_FUNCTION SoftEqual<RealType>::SoftEqual(value_type rel)
  */
 template<class RealType>
 CELER_FUNCTION SoftEqual<RealType>::SoftEqual(value_type rel, value_type abs)
-    : rel_(rel), abs_(abs)
+    : rel_{rel}, abs_{abs}
 {
     CELER_EXPECT(rel > 0);
     CELER_EXPECT(abs > 0);
@@ -203,8 +205,8 @@ SoftEqual<RealType>::operator()(value_type a, value_type b) const
  * Construct with default relative/absolute precision.
  */
 template<class RealType>
-CELER_FUNCTION SoftZero<RealType>::SoftZero()
-    : SoftZero(SETraits::abs_thresh())
+CELER_CONSTEXPR_FUNCTION SoftZero<RealType>::SoftZero()
+    : abs_(SETraits::abs_thresh())
 {
 }
 

--- a/src/corecel/math/SoftEqual.hh
+++ b/src/corecel/math/SoftEqual.hh
@@ -76,6 +76,28 @@ class SoftEqual
 
 //---------------------------------------------------------------------------//
 /*!
+ * Compare for equality before checking with the given functor.
+ */
+template<class F>
+class EqualOr : public F
+{
+  public:
+    //! Forward arguments to parent class
+    template<class... C>
+    CELER_FUNCTION EqualOr(C&&... args) : F{std::forward<C>(args)...}
+    {
+    }
+
+    //! Forward arguments to comparison operator after comparing
+    template<class T, class U>
+    bool CELER_FUNCTION operator()(T a, U b) const
+    {
+        return a == b || static_cast<F const&>(*this)(a, b);
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Functor for floating point equality.
  */
 template<class RealType = ::celeritas::real_type>
@@ -110,6 +132,16 @@ class SoftZero
 
     using SETraits = detail::SoftEqualTraits<value_type>;
 };
+
+//---------------------------------------------------------------------------//
+// TEMPLATE DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class T>
+CELER_FUNCTION SoftEqual(T)->SoftEqual<T>;
+template<class T>
+CELER_FUNCTION SoftEqual(T, T)->SoftEqual<T>;
+template<class F>
+CELER_FUNCTION EqualOr(F&&)->EqualOr<F>;
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/test/TestMacros.test.cc
+++ b/test/TestMacros.test.cc
@@ -143,8 +143,8 @@ TEST(IsVecSoftEquiv, floats)
 
     // Compare vector vs array
     EXPECT_VEC_SOFT_EQ(actual, expected_array);
-    EXPECT_VEC_NEAR(actual, expected_array, 1.e-3);
-    EXPECT_VEC_CLOSE(actual, expected_array, 1.e-3, 1e-5);
+    EXPECT_VEC_NEAR(actual, expected_array, 1.e-3f);
+    EXPECT_VEC_CLOSE(actual, expected_array, 1.e-3f, 1e-5f);
 
     // Compare floating point tolerance is not 1e-12
     float actual_array[] = {1.000001f, 3.000001f, 5.000001f};
@@ -154,7 +154,7 @@ TEST(IsVecSoftEquiv, floats)
 
     // The floating point type should convert from double to float
     EXPECT_TRUE(IsVecSoftEquiv(
-        "expected_array", "actual", "1e-6", expected_array, actual_array, 1e-6));
+        "expected_array", "actual", "1e-6", expected_array, actual_array, 1e-6f));
 
     actual_array[0] = 1.0001f;
     EXPECT_FALSE(IsVecSoftEquiv(
@@ -182,7 +182,7 @@ TEST(IsVecSoftEquiv, mixed)
                                "1.e-12",
                                expected_flt,
                                expected_dbl,
-                               1.e-12));
+                               1.e-12f));
 
     VecFlt actual_flt = {0.126f, 1.123f, 5.f};
 
@@ -190,7 +190,7 @@ TEST(IsVecSoftEquiv, mixed)
         "expected_flt", "actual_flt", expected_flt, actual_flt));
 
     EXPECT_TRUE(IsVecSoftEquiv(
-        "expected_flt", "actual_flt", ".1", expected_flt, actual_flt, 0.1));
+        "expected_flt", "actual_flt", ".1", expected_flt, actual_flt, 0.1f));
 }
 
 // NOTE: these should fail to compile and produce relatively understandable

--- a/test/TestMacros.test.cc
+++ b/test/TestMacros.test.cc
@@ -115,8 +115,10 @@ TEST(IsVecSoftEquiv, successes_double)
     // test comparison against zero
     expected.push_back(0.);
     actual.push_back(0.009);
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         IsVecSoftEquiv("expected", "actual", "0.01", expected, actual, 0.01));
+    EXPECT_TRUE(IsVecSoftEquiv(
+        "expected", "actual", "0.01", "0.01", expected, actual, 0.01, 0.01));
 
     EXPECT_TRUE(IsVecSoftEquiv(
         "expected_array", "actual", "0.01", expected_array, actual, 0.01));

--- a/test/celeritas/Constants.test.cc
+++ b/test/celeritas/Constants.test.cc
@@ -86,7 +86,8 @@ TEST(ConstantsTest, derivative)
 {
     // Compared against definition of Dalton, table 8 of SI 2019
     EXPECT_SOFT_NEAR(1.66053906660e-27 * units::kilogram, atomic_mass, 1e-11);
-    EXPECT_SOFT_NEAR(1.602176634e-19, e_electron * units::volt, 1e-9);
+    EXPECT_SOFT_NEAR(
+        1.602176634e-19 * units::joule, e_electron * units::volt, 1e-9);
 
     // CODATA 2018 listings
     EXPECT_SOFT_NEAR(1.49241808560e-10 * units::joule,

--- a/test/celeritas/Constants.test.cc
+++ b/test/celeritas/Constants.test.cc
@@ -43,19 +43,15 @@ TEST(ConstantsTest, exact_equivalence)
 
 TEST(ConstantsTest, formulas)
 {
-    EXPECT_SOFT_NEAR(e_electron * e_electron
-                         / (2 * alpha_fine_structure * h_planck * c_light),
-                     eps_electric,
-                     1e-11);
-    EXPECT_SOFT_NEAR(
-        1 / (eps_electric * c_light * c_light), mu_magnetic, 1e-11);
-    EXPECT_SOFT_NEAR(
+    EXPECT_SOFT_EQ(e_electron * e_electron
+                       / (2 * alpha_fine_structure * h_planck * c_light),
+                   eps_electric);
+    EXPECT_SOFT_EQ(1 / (eps_electric * c_light * c_light), mu_magnetic);
+    EXPECT_SOFT_EQ(
         hbar_planck / (alpha_fine_structure * electron_mass * c_light),
-        a0_bohr,
-        1e-11);
-    EXPECT_SOFT_NEAR(alpha_fine_structure * alpha_fine_structure * a0_bohr,
-                     r_electron,
-                     1e-11);
+        a0_bohr);
+    EXPECT_SOFT_EQ(alpha_fine_structure * alpha_fine_structure * a0_bohr,
+                   r_electron);
 }
 
 TEST(ConstantsTest, clhep)
@@ -85,17 +81,14 @@ TEST(ConstantsTest, clhep)
 TEST(ConstantsTest, derivative)
 {
     // Compared against definition of Dalton, table 8 of SI 2019
-    EXPECT_SOFT_NEAR(1.66053906660e-27 * units::kilogram, atomic_mass, 1e-11);
-    EXPECT_SOFT_NEAR(
-        1.602176634e-19 * units::joule, e_electron * units::volt, 1e-9);
+    EXPECT_SOFT_EQ(1.66053906660e-27 * units::kilogram, atomic_mass);
+    EXPECT_SOFT_EQ(1.602176634e-19 * units::joule, e_electron * units::volt);
 
     // CODATA 2018 listings
-    EXPECT_SOFT_NEAR(1.49241808560e-10 * units::joule,
-                     atomic_mass * c_light * c_light,
-                     1e-11);
-    EXPECT_SOFT_NEAR(931.49410242e6 * e_electron * units::volt,
-                     atomic_mass * c_light * c_light,
-                     1e-11);
+    EXPECT_SOFT_EQ(1.49241808560e-10 * units::joule,
+                   atomic_mass * c_light * c_light);
+    EXPECT_SOFT_EQ(931.49410242e6 * e_electron * units::volt,
+                   atomic_mass * c_light * c_light);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/Constants.test.cc
+++ b/test/celeritas/Constants.test.cc
@@ -86,7 +86,7 @@ TEST(ConstantsTest, derivative)
 {
     // Compared against definition of Dalton, table 8 of SI 2019
     EXPECT_SOFT_NEAR(1.66053906660e-27 * units::kilogram, atomic_mass, 1e-11);
-    EXPECT_SOFT_NEAR(1.602176634e-19, e_electron * units::volt, 1e-11);
+    EXPECT_SOFT_NEAR(1.602176634e-19, e_electron * units::volt, 1e-9);
 
     // CODATA 2018 listings
     EXPECT_SOFT_NEAR(1.49241808560e-10 * units::joule,

--- a/test/celeritas/em/MollerBhabha.test.cc
+++ b/test/celeritas/em/MollerBhabha.test.cc
@@ -321,6 +321,8 @@ TEST_F(MollerBhabhaInteractorTest, stress_test)
     // NOTE: As E_K -> 2e-3, engine_samples -> infinity
     for (auto particle : {pdg::electron(), pdg::positron()})
     {
+        ParticleParams const& pp = *this->particle_params();
+        SCOPED_TRACE(pp.id_to_label(pp.find(particle)));
         for (double inc_e : {5e-3, 1.0, 10.0, 100.0, 1000.0})
         {
             RandomEngine& rng_engine = this->rng();
@@ -349,6 +351,11 @@ TEST_F(MollerBhabhaInteractorTest, stress_test)
                 {
                     Interaction result = mb_interact(rng_engine);
                     this->sanity_check(result);
+                    if (this->HasFailure())
+                    {
+                        // Only do one comparison in case of failure
+                        break;
+                    }
                 }
 
                 EXPECT_EQ(num_samples,

--- a/test/celeritas/em/RelativisticBrem.test.cc
+++ b/test/celeritas/em/RelativisticBrem.test.cc
@@ -324,7 +324,6 @@ TEST_F(RelativisticBremTest, stress_with_lpm)
     for (int i : range(num_samples))
     {
         Interaction result = interact(rng_engine);
-        SCOPED_TRACE(result);
 
         average_energy += result.secondaries[0].energy.value();
         average_angle[0] += result.secondaries[0].direction[0];

--- a/test/celeritas/field/FieldDriver.test.cc
+++ b/test/celeritas/field/FieldDriver.test.cc
@@ -369,7 +369,7 @@ TEST_F(RevolutionFieldDriverTest, advance)
         }
 
         // Check the total error and the state (position, momentum)
-        EXPECT_VEC_NEAR(y_expected.pos, y.pos, eps);
+        EXPECT_VEC_CLOSE(y_expected.pos, y.pos, eps, eps);
     }
 
     // Check the total error, step/curve length

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -278,7 +278,7 @@ TEST_F(TwoBoxesTest, positron_interior)
     // Test a quarter turn
     Propagation result = propagate(0.5 * pi * radius);
     EXPECT_SOFT_EQ(0.5 * pi * radius, result.distance);
-    EXPECT_SOFT_NEAR(0, distance(Real3({0, -radius, 0}), geo.pos()), 1e-5);
+    EXPECT_NEAR(0, distance(Real3({0, -radius, 0}), geo.pos()), 1e-5);
     EXPECT_SOFT_EQ(1.0, dot_product(Real3({-1, 0, 0}), geo.dir()));
 }
 
@@ -541,8 +541,8 @@ TEST_F(TwoBoxesTest, electron_small_step)
         EXPECT_DOUBLE_EQ(delta, result.distance);
         EXPECT_FALSE(result.boundary);
         EXPECT_FALSE(geo.is_on_boundary());
-        EXPECT_VEC_SOFT_EQ(Real3({5 + delta, 0, 0}), geo.pos());
-        EXPECT_VEC_SOFT_EQ(Real3({1, 3 * delta, 0}), geo.dir());
+        EXPECT_LT(distance(Real3({5 + delta, 0, 0}), geo.pos()), 1e-12);
+        EXPECT_LT(distance(Real3({1, 3 * delta, 0}), geo.dir()), 1e-12);
     }
 }
 

--- a/test/celeritas/field/Steppers.test.cc
+++ b/test/celeritas/field/Steppers.test.cc
@@ -100,10 +100,10 @@ class SteppersTest : public Test
                     total_err2
                         += detail::rel_err_sq(result.err_state, hstep, y.mom);
                 }
-                real_type rel_err = std::sqrt(total_err2) / 0.001;
+                real_type tol = std::sqrt(total_err2) / 0.001;
                 // Check the state after each revolution and the total error
-                EXPECT_VEC_NEAR(expected_y.pos, y.pos, rel_err);
-                EXPECT_VEC_NEAR(expected_y.mom, y.mom, rel_err);
+                EXPECT_VEC_CLOSE(expected_y.pos, y.pos, tol, tol);
+                EXPECT_VEC_CLOSE(expected_y.mom, y.mom, tol, tol);
                 EXPECT_LT(total_err2, param.epsilon);
             }
         }

--- a/test/celeritas/random/RngTally.hh
+++ b/test/celeritas/random/RngTally.hh
@@ -51,10 +51,10 @@ struct RngTally
         {
             m /= num_samples;
         }
-        EXPECT_SOFT_NEAR(0, moments[0], tol);
-        EXPECT_SOFT_NEAR(0, moments[1], tol);
-        EXPECT_SOFT_NEAR(0, moments[2], tol);
-        EXPECT_SOFT_NEAR(0, moments[3], tol);
+        EXPECT_NEAR(0, moments[0], tol);
+        EXPECT_NEAR(0, moments[1], tol);
+        EXPECT_NEAR(0, moments[2], tol);
+        EXPECT_NEAR(0, moments[3], tol);
     }
 };
 

--- a/test/corecel/math/ArrayUtils.test.cc
+++ b/test/corecel/math/ArrayUtils.test.cc
@@ -84,8 +84,15 @@ TEST(ArrayUtilsTest, is_soft_unit_vector)
     Real3 dir{1, 2, 3};
     normalize_direction(&dir);
     EXPECT_TRUE(is_soft_unit_vector(dir));
-    dir[0] += 1e-12;
+    constexpr real_type eps = SoftEqual{}.rel();
+    dir[0] += eps;
     EXPECT_TRUE(is_soft_unit_vector(dir));
+    dir[1] += eps;
+    EXPECT_TRUE(is_soft_unit_vector(dir));
+    dir[2] -= eps;
+    EXPECT_TRUE(is_soft_unit_vector(dir));
+    dir[0] += 10 * eps;
+    EXPECT_FALSE(is_soft_unit_vector(dir));
 }
 
 TEST(ArrayUtilsTest, rotate)

--- a/test/corecel/math/SoftEqual.test.cc
+++ b/test/corecel/math/SoftEqual.test.cc
@@ -107,6 +107,29 @@ TYPED_TEST(FloatingTest, soft_equal)
     EXPECT_FALSE(comp(inf, inf));
 }
 
+TYPED_TEST(FloatingTest, equal_or_soft_equal)
+{
+    using value_type = typename TestFixture::value_type;
+    using Limits_t = typename TestFixture::Limits_t;
+    const value_type nan = Limits_t::quiet_NaN();
+    const value_type inf = Limits_t::infinity();
+
+    EqualOr<SoftEqual<value_type>> comp;
+
+    EXPECT_TRUE(comp(1, 1));
+    EXPECT_TRUE(comp(0, 0));
+    EXPECT_FALSE(comp(-1, 1));
+    EXPECT_FALSE(comp(1, -1));
+    EXPECT_FALSE(comp(inf, -inf));
+    EXPECT_FALSE(comp(-inf, inf));
+
+    EXPECT_TRUE(comp(inf, inf));
+    EXPECT_TRUE(comp(1e6, 1e6 * (1 + comp.rel() / 2)));
+    EXPECT_FALSE(comp(1e6, 1e6 * (1 + comp.rel() * 2)));
+
+    EXPECT_FALSE(comp(1, nan));
+}
+
 TYPED_TEST(FloatingTest, soft_zero)
 {
     using value_type = typename TestFixture::value_type;

--- a/test/corecel/math/SoftEqual.test.cc
+++ b/test/corecel/math/SoftEqual.test.cc
@@ -21,16 +21,20 @@ namespace test
 
 TEST(SoftEqual, default_precisions)
 {
-    using Comp_t = SoftEqual<>;
+    using Comp = SoftEqual<>;
 
-    EXPECT_DOUBLE_EQ(1e-12, Comp_t().rel());
-    EXPECT_DOUBLE_EQ(1e-14, Comp_t().abs());
+    // Check that defaults can be accessed as constexpr
+    constexpr auto rel = Comp().rel();
+    constexpr auto abs = Comp().abs();
 
-    EXPECT_DOUBLE_EQ(1e-6, Comp_t(1e-6).rel());
-    EXPECT_DOUBLE_EQ(1e-8, Comp_t(1e-6).abs());
+    EXPECT_DOUBLE_EQ(1e-12, rel);
+    EXPECT_DOUBLE_EQ(1e-14, abs);
 
-    EXPECT_DOUBLE_EQ(1e-4, Comp_t(1e-4, 1e-9).rel());
-    EXPECT_DOUBLE_EQ(1e-9, Comp_t(1e-4, 1e-9).abs());
+    EXPECT_DOUBLE_EQ(1e-6, Comp(1e-6).rel());
+    EXPECT_DOUBLE_EQ(1e-8, Comp(1e-6).abs());
+
+    EXPECT_DOUBLE_EQ(1e-4, Comp(1e-4, 1e-9).rel());
+    EXPECT_DOUBLE_EQ(1e-9, Comp(1e-4, 1e-9).abs());
 }
 
 //---------------------------------------------------------------------------//
@@ -55,9 +59,9 @@ TYPED_TEST(FloatingTest, soft_equal)
 {
     using value_type = typename TestFixture::value_type;
     using Limits_t = typename TestFixture::Limits_t;
-    using Comp_t = SoftEqual<value_type>;
+    using Comp = SoftEqual<value_type>;
 
-    Comp_t comp;
+    Comp comp;
 
     // Test basic equality
     EXPECT_TRUE(comp(1, 1));
@@ -134,9 +138,9 @@ TYPED_TEST(FloatingTest, soft_zero)
 {
     using value_type = typename TestFixture::value_type;
     using Limits_t = typename TestFixture::Limits_t;
-    using Comp_t = SoftZero<value_type>;
+    using Comp = SoftZero<value_type>;
 
-    Comp_t comp;
+    Comp comp;
 
     // Test basic equality
     EXPECT_TRUE(comp(0));

--- a/test/corecel/math/SoftEqual.test.cc
+++ b/test/corecel/math/SoftEqual.test.cc
@@ -68,10 +68,15 @@ TYPED_TEST(FloatingTest, soft_equal)
     // Test with tolerance
     EXPECT_TRUE(comp(1, 1 + comp.rel() / 2));
     EXPECT_FALSE(comp(1, 1 + comp.rel() * 2));
+    // Large scale
+    EXPECT_TRUE(comp(1e6, 1e6 * (1 + comp.rel() / 2)));
+    EXPECT_FALSE(comp(1e6, 1e6 * (1 + comp.rel() * 2)));
+    // Smaller scale
+    EXPECT_TRUE(comp(1e-6, 1e-6 * (1 + comp.rel() / 2)));
+    EXPECT_FALSE(comp(1e-6, 1e-7));
 
-    // TODO: absolute tolerace is wacky
-    EXPECT_TRUE(comp(0, comp.rel() / 2));
-    EXPECT_TRUE(comp(comp.abs() / 2, comp.rel() / 2));
+    EXPECT_FALSE(comp(0, comp.rel() / 2));
+    EXPECT_FALSE(comp(comp.abs() / 2, comp.rel() / 2));
     EXPECT_FALSE(comp(0, comp.rel()));
     EXPECT_FALSE(comp(comp.abs(), comp.rel() / 2));
     EXPECT_FALSE(comp(comp.abs(), comp.rel()));
@@ -93,10 +98,13 @@ TYPED_TEST(FloatingTest, soft_equal)
     const value_type maxval = Limits_t::max();
     EXPECT_FALSE(comp(0, inf));
     EXPECT_FALSE(comp(inf, 0));
-    EXPECT_TRUE(comp(inf, inf));
     EXPECT_FALSE(comp(inf, -inf));
     EXPECT_FALSE(comp(-inf, inf));
     EXPECT_FALSE(comp(inf, maxval));
+
+    // NOTE: values that are legitimately infinite require additional testing
+    // outside of soft equal because they're an edge case.
+    EXPECT_FALSE(comp(inf, inf));
 }
 
 TYPED_TEST(FloatingTest, soft_zero)
@@ -138,7 +146,7 @@ TYPED_TEST(FloatingTest, soft_mod)
     EXPECT_TRUE(soft_mod(value_type(1.0), value_type(0.25)));
     EXPECT_FALSE(soft_mod(value_type(1.0), value_type(0.8)));
 
-    auto tol = SoftEqual<value_type>().rel() / 2;
+    auto tol = SoftEqual<value_type>().abs() / 2;
     EXPECT_TRUE(soft_mod(value_type(1), value_type(0.25)));
     EXPECT_TRUE(soft_mod(value_type(3.6) + tol, value_type(1.2)));
     EXPECT_TRUE(soft_mod(value_type(3.6) - tol, value_type(1.2)));

--- a/test/orange/surf/SurfaceSimplifier.test.cc
+++ b/test/orange/surf/SurfaceSimplifier.test.cc
@@ -243,7 +243,7 @@ TEST_F(SurfaceSimplifierTest, simple_quadric)
         SCOPED_TRACE("scaled near-cylinder");
         // CylY{{1,2,3}, 2.5} -> SQ{{1,0,1}, {-2,0,-6}, 3.75}
         this->check_simplifies_to(
-            SimpleQuadric{{1, 1e-8, 1}, {-2, 0, -6}, 3.75},
+            SimpleQuadric{{1, 1e-9, 1}, {-2, 0, -6}, 3.75},
             CylY{{1, 2, 3}, 2.5});
     }
 

--- a/test/testdetail/TestMacrosImpl.hh
+++ b/test/testdetail/TestMacrosImpl.hh
@@ -552,7 +552,7 @@ template<class ContainerE, class ContainerA, class T>
 
     // Construct with given tolerance
     return IsVecSoftEquivImpl(
-        expected, expected_expr, actual, actual_expr, BinaryOp(rel, abs));
+        expected, expected_expr, actual, actual_expr, BinaryOp{rel, abs});
 }
 
 //---------------------------------------------------------------------------//

--- a/test/testdetail/TestMacrosImpl.hh
+++ b/test/testdetail/TestMacrosImpl.hh
@@ -501,13 +501,13 @@ template<class ContainerE, class ContainerA>
  * This signature uses the default tolerance for the appropriate floating point
  * operations.
  */
-template<class ContainerE, class ContainerA>
+template<class ContainerE, class ContainerA, class T>
 ::testing::AssertionResult IsVecSoftEquiv(char const* expected_expr,
                                           char const* actual_expr,
                                           char const*,
                                           ContainerE const& expected,
                                           ContainerA const& actual,
-                                          double rel)
+                                          T rel)
 {
     using Traits_t = TCT<ContainerE, ContainerA>;
     using value_type_E = typename Traits_t::first_type;
@@ -521,7 +521,7 @@ template<class ContainerE, class ContainerA>
 
     // Construct with given tolerance
     return IsVecSoftEquivImpl(
-        expected, expected_expr, actual, actual_expr, BinaryOp(rel));
+        expected, expected_expr, actual, actual_expr, BinaryOp{rel});
 }
 
 //-------------------------------------------------------------------------//
@@ -530,15 +530,15 @@ template<class ContainerE, class ContainerA>
  *
  * Used by \c EXPECT_VEC_CLOSE.
  */
-template<class ContainerE, class ContainerA>
+template<class ContainerE, class ContainerA, class T>
 ::testing::AssertionResult IsVecSoftEquiv(char const* expected_expr,
                                           char const* actual_expr,
                                           char const*,
                                           char const*,
                                           ContainerE const& expected,
                                           ContainerA const& actual,
-                                          double rel,
-                                          double abs)
+                                          T rel,
+                                          T abs)
 {
     using Traits_t = TCT<ContainerE, ContainerA>;
     using value_type_E = typename Traits_t::first_type;

--- a/test/testdetail/TestMacrosImpl.hh
+++ b/test/testdetail/TestMacrosImpl.hh
@@ -91,8 +91,7 @@ IsSoftEquivImpl(typename BinaryOp::value_type expected,
            << "\nExpected: " << expected_expr << "\nWhich is: " << expected
            << '\n';
 
-    SoftZero<value_type> is_soft_zero(comp.abs());
-    if (is_soft_zero(expected))
+    if (SoftZero<value_type>{comp.abs()}(expected))
     {
         // Avoid divide by zero errors
         result << "(Absolute error " << actual - expected
@@ -121,7 +120,7 @@ template<class Value_E, class Value_A>
 
     // Construct with automatic or specified tolerances
     using ValueT = typename SoftPrecisionType<Value_E, Value_A>::type;
-    using BinaryOp = SoftEqual<ValueT>;
+    using BinaryOp = EqualOr<SoftEqual<ValueT>>;
 
     return IsSoftEquivImpl(
         expected, expected_expr, actual, actual_expr, BinaryOp());
@@ -144,7 +143,7 @@ template<class Value_E, class Value_A>
 
     // Construct with automatic or specified tolerances
     using ValueT = typename SoftPrecisionType<Value_E, Value_A>::type;
-    using BinaryOp = SoftEqual<ValueT>;
+    using BinaryOp = EqualOr<SoftEqual<ValueT>>;
 
     return IsSoftEquivImpl(
         expected, expected_expr, actual, actual_expr, BinaryOp(rel));
@@ -488,7 +487,7 @@ template<class ContainerE, class ContainerA>
                   "Invalid types for soft equivalence");
 
     using ValueT = typename SoftPrecisionType<value_type_E, value_type_A>::type;
-    using BinaryOp = SoftEqual<ValueT>;
+    using BinaryOp = EqualOr<SoftEqual<ValueT>>;
 
     // Construct with automatic or specified tolerances
     return IsVecSoftEquivImpl(
@@ -518,7 +517,7 @@ template<class ContainerE, class ContainerA>
                   "Invalid types for soft equivalence");
 
     using ValueT = typename SoftPrecisionType<value_type_E, value_type_A>::type;
-    using BinaryOp = SoftEqual<ValueT>;
+    using BinaryOp = EqualOr<SoftEqual<ValueT>>;
 
     // Construct with given tolerance
     return IsVecSoftEquivImpl(
@@ -549,7 +548,7 @@ template<class ContainerE, class ContainerA>
                   "Invalid types for soft equivalence");
 
     using ValueT = typename SoftPrecisionType<value_type_E, value_type_A>::type;
-    using BinaryOp = SoftEqual<ValueT>;
+    using BinaryOp = EqualOr<SoftEqual<ValueT>>;
 
     // Construct with given tolerance
     return IsVecSoftEquivImpl(


### PR DESCRIPTION
This rewrites the `SoftEqual` functor to be about 15× shorter. Because ARM and CUDA have intrinsics for fabs and fmax, this ends up being 8 nonbranching instructions on ARM versus ~30 instructions with branches. The only change in behavior is that infinities no longer compare "soft equal", but since `inf - inf = nan` I think this is reasonable behavior. A new functor `EqualOr` can be composed with `SoftEqual` to regain the original behavior for unit testing (where comparing infinities does make sense). The new soft equal expression is:
$$|a - b| < \max(\epsilon_r \max(|a|, |b|), \epsilon_a)$$

@tmdelellis If you're interested in seeing how much ARM vs x86 differ and for the old vs new implementation, see [godbolt compiler explorer](https://godbolt.org/z/d654anP4P).

| Implementation | LOC | ARM 64 (Clang 16) ASM-LOC | x86-64 (Clang 16) ASM-LOC  | NVCC PTX LOC |
| ---- | --- | --- | - | - |
| Old | 25 |  32 | 42 | 72 |
| New | 5 | 10 | 28 | 27 |