### PR TITLE
Optimize ORANGE surface intersection testing

### DIFF
--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -114,7 +114,7 @@ class SimpleUnitTracker
 
     template<class F>
     inline CELER_FUNCTION Intersection intersect_impl(LocalState const&,
-                                                      F) const;
+                                                      F&&) const;
 
     inline CELER_FUNCTION Intersection simple_intersect(LocalState const&,
                                                         VolumeView const&,
@@ -387,7 +387,7 @@ SimpleUnitTracker::find_volume_where(Real3 const& pos, F&& predicate) const
  */
 template<class F>
 CELER_FUNCTION auto
-SimpleUnitTracker::intersect_impl(LocalState const& state, F is_valid) const
+SimpleUnitTracker::intersect_impl(LocalState const& state, F&& is_valid) const
     -> Intersection
 {
     CELER_EXPECT(state.volume && !state.temp_sense.empty());
@@ -399,10 +399,10 @@ SimpleUnitTracker::intersect_impl(LocalState const& state, F is_valid) const
     // Find all valid (nearby or finite, depending on F) surface intersection
     // distances inside this volume. Fill the `isect` array if the tracking
     // algorithm requires sorting.
-    detail::CalcIntersections<F const&> calc_intersections{
+    detail::CalcIntersections calc_intersections{
+        celeritas::forward<F>(is_valid),
         state.pos,
         state.dir,
-        is_valid,
         state.surface ? vol.find_face(state.surface.id()) : FaceId{},
         vol.simple_intersection(),
         state.temp_next};

--- a/src/orange/univ/detail/SurfaceFunctors.hh
+++ b/src/orange/univ/detail/SurfaceFunctors.hh
@@ -139,6 +139,15 @@ class CalcIntersections
     {
         auto on_surface = (on_face_idx_ == face_idx_) ? SurfaceState::on
                                                       : SurfaceState::off;
+        if constexpr (typename S::Intersections{}.size() == 1)
+        {
+            if (on_surface == SurfaceState::on)
+            {
+                // On surface so cannot reintersect
+                ++face_idx_;
+                return;
+            }
+        }
 
         // Calculate distance to surface along this direction
         auto all_dist = surf.calc_intersections(pos_, dir_, on_surface);

--- a/src/orange/univ/detail/SurfaceFunctors.hh
+++ b/src/orange/univ/detail/SurfaceFunctors.hh
@@ -107,23 +107,25 @@ struct CalcSafetyDistance
 /*!
  * Fill an array with valid distances-to-intersection.
  *
+ * \tparam F Predicate for returning whether the distance is allowable
+ *
  * This assumes that each call is to the next face index, starting with face
  * zero.
  */
-template<class IsValid>
+template<class F>
 class CalcIntersections
 {
   public:
     //! Construct from the particle point, direction, face ID, and temp storage
-    CELER_FUNCTION CalcIntersections(Real3 const& pos,
+    CELER_FUNCTION CalcIntersections(F is_valid_isect,
+                                     Real3 const& pos,
                                      Real3 const& dir,
-                                     IsValid is_valid_isect,
                                      FaceId on_face,
                                      bool is_simple,
                                      TempNextFace const& next_face)
-        : pos_(pos)
+        : is_valid_isect_(celeritas::forward<F>(is_valid_isect))
+        , pos_(pos)
         , dir_(dir)
-        , is_valid_isect_(is_valid_isect)
         , on_face_idx_(on_face.unchecked_get())
         , fill_isect_(!is_simple)
         , face_(next_face.face)
@@ -178,9 +180,9 @@ class CalcIntersections
   private:
     //// DATA ////
 
+    F is_valid_isect_;
     Real3 const& pos_;
     Real3 const& dir_;
-    const IsValid is_valid_isect_;
     const size_type on_face_idx_;
     bool const fill_isect_;
     FaceId* const face_;
@@ -189,6 +191,9 @@ class CalcIntersections
     size_type face_idx_{0};
     size_type isect_idx_{0};
 };
+
+template<class F, class... Args>
+CELER_FUNCTION CalcIntersections(F&&, Args&&... args)->CalcIntersections<F>;
 
 //---------------------------------------------------------------------------//
 }  // namespace detail


### PR DESCRIPTION
This is a tiny optimization for planes that I realized while discussing @tmdelellis 's EMPIRE problem. I have also modified one of the surface functors to use correct template forwarding and added template deduction.