### PR TITLE
Hotfix: warning in ipow template instantiation

### DIFF
--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -414,6 +414,7 @@ CELER_CONSTEXPR_FUNCTION T ipow(T v) noexcept
 {
     if constexpr (N == 0)
     {
+        (void)sizeof(v);  // Suppress warning in older compilers
         return 1;
     }
     else if constexpr (N % 2 == 0)


### PR DESCRIPTION
#930 introduces a warning (which can be converted to an error) in `ipow` when running GCC 8.5 due to an unfortunate bug in how it does `if constexpr`.

```
In file included from src/corecel/math/ArrayUtils.hh:17,
                 from src/orange/surf/ConeAligned.hh:13,
                 from src/orange/surf/ConeAligned.cc:8:
src/corecel/math/Algorithms.hh: In instantiation of 'constexpr T celeritas::ipow(T) [with unsigned int N = 0; T = double]':
src/corecel/math/Algorithms.hh:425:37:   required from 'constexpr T celeritas::ipow(T) [with unsigned int N = 1; T = double]'
src/corecel/math/Algorithms.hh:421:27:   required from 'constexpr T celeritas::ipow(T) [with unsigned int N = 2; T = double]'
src/orange/surf/detail/QuadraticSolver.hh:162:34:   required from here
src/corecel/math/Algorithms.hh:413:35: error: parameter 'v' set but not used [-Werror=unused-but-set-parameter]
 CELER_CONSTEXPR_FUNCTION T ipow(T v) noexcept
```