### PR TITLE
Implement CSG tree simplification algorithms

### DIFF
--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -19,6 +19,7 @@ list(APPEND SOURCES
   OrangeTypes.cc
   construct/CsgTree.cc
   construct/CsgTypes.cc
+  construct/CsgTreeUtils.cc
   construct/SurfaceInputBuilder.cc
   construct/detail/NodeSimplifier.cc
   detail/BIHBuilder.cc

--- a/src/orange/construct/CsgTreeUtils.cc
+++ b/src/orange/construct/CsgTreeUtils.cc
@@ -1,0 +1,142 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/construct/CsgTreeUtils.cc
+//---------------------------------------------------------------------------//
+#include "CsgTreeUtils.hh"
+
+#include <utility>
+#include <variant>
+
+#include "corecel/cont/Range.hh"
+
+#include "detail/NodeReplacementInserter.hh"
+#include "detail/PostfixLogicBuilder.hh"
+
+using namespace celeritas::csg;
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Replace the given node ID with the replacement node.
+ *
+ * This recurses through daughters of "Joined" to simplify their originating
+ * surfaces if possible.
+ * - "negated": non-constant daughter node is replaced with ~b
+ * - "replaced": non-constant daughter node is replaced with `b`
+ * - "joined": for (false, or): all daughters are "false"
+ *             for (true, and): all daughters are "true"
+ * - surface: "true"
+ * - constant: check for contradiction
+ *
+ * \return Node ID of the lowest node that required simplification.
+ */
+NodeId replace_down(CsgTree* tree, NodeId n, Node repl)
+{
+    CELER_EXPECT(is_boolean_node(repl));
+
+    NodeReplacementInserter::VecNode stack{{n, std::move(repl)}};
+
+    NodeId lowest_node{n};
+
+    while (!stack.empty())
+    {
+        n = std::move(stack.back().first);
+        repl = std::move(stack.back().second);
+        stack.pop_back();
+        lowest_node = std::min(n, lowest_node);
+
+        Node prev = tree->exchange(n, std::move(repl));
+        std::visit(NodeReplacementInserter{&stack, repl}, prev);
+    }
+    return lowest_node;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Simplify all nodes in the tree starting with this one.
+ *
+ * \return Lowest ID of any simplified node
+ */
+NodeId simplify_up(CsgTree* tree, NodeId start)
+{
+    CELER_EXPECT(tree);
+    CELER_EXPECT(start < tree->size());
+
+    // Sweep bottom to top to simplify the tree
+    NodeId result;
+    for (auto node_id : range(start, NodeId{tree->size()}))
+    {
+        bool simplified = tree->simplify(node_id);
+        if (simplified && !result)
+        {
+            result = node_id;
+        }
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Iteratively simplify all nodes in the tree.
+ *
+ * The input 'start' node should be the minimum node from a \c replace_down
+ * operation. In the worst case, it should take as many sweeps as the depth of
+ * the tree.
+ */
+void simplify(CsgTree* tree, NodeId start)
+{
+    CELER_EXPECT(tree);
+    CELER_EXPECT(start > tree->false_node_id() && start < tree->size());
+
+    while (start)
+    {
+        auto next_start = simplify_up(tree, start);
+        CELER_ASSERT(!next_start || next_start > start);
+        start = next_start;
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a node to postfix notation.
+ */
+std::vector<LocalSurfaceId::size_type>
+build_postfix(CsgTree const& tree, csg::NodeId n)
+{
+    CELER_EXPECT(n < tree.size());
+    std::vector<LocalSurfaceId::size_type> result;
+    csg::PostfixLogicBuilder build_logic{tree, &result};
+
+    build_logic(n);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct the sorted set of all surfaces that are part of the tree.
+ *
+ * This list removes surfaces that have been eliminated by logical replacement.
+ * Thanks to the CSG tree's deduplication, each surface should appear in the
+ * tree at most once.
+ */
+std::vector<LocalSurfaceId> calc_surfaces(CsgTree const& tree)
+{
+    std::vector<LocalSurfaceId> result;
+    for (auto node_id : range(NodeId{tree.size()}))
+    {
+        if (Surface const* s = std::get_if<Surface>(&tree[node_id]))
+        {
+            result.push_back(s->id);
+        }
+    }
+    std::sort(result.begin(), result.end());
+    CELER_ENSURE(std::unique(result.begin(), result.end()) == result.end());
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/construct/CsgTreeUtils.hh
+++ b/src/orange/construct/CsgTreeUtils.hh
@@ -1,0 +1,39 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/construct/CsgTreeUtils.hh
+//! \brief Free functions to apply to a CSG tree
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+
+#include "orange/OrangeTypes.hh"
+
+#include "CsgTypes.hh"
+
+namespace celeritas
+{
+class CsgTree;
+//---------------------------------------------------------------------------//
+
+// Replace a node in the tree with a boolean constant
+csg::NodeId replace_down(CsgTree* tree, csg::NodeId n, csg::Node repl_node);
+
+// Simplify the tree by sweeping
+csg::NodeId simplify_up(CsgTree* tree, csg::NodeId start);
+
+// Simplify the tree iteratively
+void simplify(CsgTree* tree, csg::NodeId start);
+
+// Convert a node to postfix notation
+std::vector<LocalSurfaceId::size_type>
+build_postfix(CsgTree const& tree, csg::NodeId n);
+
+// Get the set of unsimplified surfaces in a tree
+std::vector<LocalSurfaceId> calc_surfaces(CsgTree const& tree);
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/construct/detail/NodeReplacementInserter.hh
+++ b/src/orange/construct/detail/NodeReplacementInserter.hh
@@ -33,20 +33,20 @@ class NodeReplacementInserter
     //!@}
 
   public:
-    // Construct with references to the stack and the replacement value
+    // Construct with pointers to the stack and replacement
     inline NodeReplacementInserter(VecNode* stack, Node const& repl);
-
-    // If replacing a queued node with a boolean, ours should match
-    inline void operator()(True const&);
-    inline void operator()(False const&);
-
-    // Surfaces cannot be simplified further
-    void operator()(Surface const&) {}
 
     // Simplify node types that reference other nodes
     inline void operator()(Aliased const& n);
     inline void operator()(Negated const& n);
     inline void operator()(Joined const& n);
+
+    // Check that replacement matches our stored boolean
+    inline void operator()(True const&);
+    inline void operator()(False const&);
+
+    // Surfaces cannot be simplified further
+    void operator()(Surface const&) {}
 
   private:
     VecNode* stack_;
@@ -59,7 +59,7 @@ class NodeReplacementInserter
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Construct with references to the stack and the replacement value.
+ * Construct with pointer to the stack and the replacement value.
  *
  * For now the replacement must be a boolean.
  */
@@ -85,7 +85,7 @@ NodeReplacementInserter::NodeReplacementInserter(VecNode* stack,
 
 //---------------------------------------------------------------------------//
 /*!
- * If replacing a queued node with a boolean, ours should match.
+ * Check that the replacement node matches this queued node.
  */
 void NodeReplacementInserter::operator()(True const&)
 {
@@ -94,7 +94,7 @@ void NodeReplacementInserter::operator()(True const&)
 
 //---------------------------------------------------------------------------//
 /*!
- * If replacing a queued node with a boolean, ours should match.
+ * Check that the replacement node matches this queued node.
  */
 void NodeReplacementInserter::operator()(False const&)
 {
@@ -103,6 +103,8 @@ void NodeReplacementInserter::operator()(False const&)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Push the target of an aliased node onto the stack.
+ *
  * Aliasing a node implies the alias has the same value.
  */
 void NodeReplacementInserter::operator()(Aliased const& n)
@@ -112,6 +114,8 @@ void NodeReplacementInserter::operator()(Aliased const& n)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Push a negated node onto the stack.
+ *
  * Negating a node implies its daughter has the opposite value.
  */
 void NodeReplacementInserter::operator()(Negated const& n)

--- a/src/orange/construct/detail/NodeReplacementInserter.hh
+++ b/src/orange/construct/detail/NodeReplacementInserter.hh
@@ -1,0 +1,142 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/construct/detail/NodeReplacementInserter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <variant>
+#include <vector>
+
+#include "../CsgTree.hh"
+#include "../CsgTypes.hh"
+
+namespace celeritas
+{
+namespace csg
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Add a node ID and its "replaced" value.
+ *
+ * This implementation detail of the "replace down" algorithm adds daughters
+ * to a queue of nodes to visit, along with their replacement values.
+ */
+class NodeReplacementInserter
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using VecNode = std::vector<std::pair<NodeId, Node>>;
+    //!@}
+
+  public:
+    // Construct with references to the stack and the replacement value
+    inline NodeReplacementInserter(VecNode* stack, Node const& repl);
+
+    // If replacing a queued node with a boolean, ours should match
+    inline void operator()(True const&);
+    inline void operator()(False const&);
+
+    // Surfaces cannot be simplified further
+    void operator()(Surface const&) {}
+
+    // Simplify node types that reference other nodes
+    inline void operator()(Aliased const& n);
+    inline void operator()(Negated const& n);
+    inline void operator()(Joined const& n);
+
+  private:
+    VecNode* stack_;
+    Node const& repl_;
+    Node negated_;
+    OperatorToken join_token_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with references to the stack and the replacement value.
+ *
+ * For now the replacement must be a boolean.
+ */
+NodeReplacementInserter::NodeReplacementInserter(VecNode* stack,
+                                                 Node const& repl)
+    : stack_{stack}, repl_{repl}
+{
+    CELER_EXPECT(stack_);
+    CELER_EXPECT(is_boolean_node(repl_));
+
+    // Save "negated" node and "join" implication for daughters
+    if (std::holds_alternative<True>(repl_))
+    {
+        negated_ = Node{False{}};
+        join_token_ = op_and;  // all{...} = true
+    }
+    else
+    {
+        negated_ = Node{True{}};
+        join_token_ = op_or;  // any{...} = false
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * If replacing a queued node with a boolean, ours should match.
+ */
+void NodeReplacementInserter::operator()(True const&)
+{
+    CELER_ASSERT(std::holds_alternative<True>(repl_));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * If replacing a queued node with a boolean, ours should match.
+ */
+void NodeReplacementInserter::operator()(False const&)
+{
+    CELER_ASSERT(std::holds_alternative<False>(repl_));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Aliasing a node implies the alias has the same value.
+ */
+void NodeReplacementInserter::operator()(Aliased const& n)
+{
+    stack_->emplace_back(n.node, repl_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Negating a node implies its daughter has the opposite value.
+ */
+void NodeReplacementInserter::operator()(Negated const& n)
+{
+    stack_->emplace_back(n.node, negated_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Some 'join' operations imply requirements for the daughters.
+ *
+ * If this node is "true" and it uses an "and" operation, all daughters must be
+ * true. Likewise, "false" with "or" implies all daughters are false.
+ */
+void NodeReplacementInserter::operator()(Joined const& n)
+{
+    if (n.op == join_token_)
+    {
+        for (NodeId d : n.nodes)
+        {
+            stack_->emplace_back(d, repl_);
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace csg
+}  // namespace celeritas

--- a/src/orange/construct/detail/PostfixLogicBuilder.hh
+++ b/src/orange/construct/detail/PostfixLogicBuilder.hh
@@ -1,0 +1,149 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/construct/detail/PostfixLogicBuilder.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/cont/VariantUtils.hh"
+#include "orange/OrangeTypes.hh"
+
+#include "../CsgTree.hh"
+
+namespace celeritas
+{
+namespace csg
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Recursively construct a logic vector from a node with postfix operation.
+ */
+class PostfixLogicBuilder
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using VecLogic = std::vector<logic_int>;
+    //!@}
+
+    static_assert(std::is_same_v<LocalSurfaceId::size_type, logic_int>,
+                  "unsupported: add enum logic conversion for different-sized "
+                  "face and surface ints");
+
+  public:
+    // Construct with reference to vector to append to
+    explicit inline PostfixLogicBuilder(CsgTree const& tree, VecLogic* logic);
+
+    //! Build from a node ID
+    inline void operator()(NodeId const& n);
+
+    // Visit an actual surface
+    inline void operator()(True const&);
+    inline void operator()(False const&);
+    inline void operator()(Surface const&);
+    inline void operator()(Aliased const&);
+    inline void operator()(Negated const&);
+    inline void operator()(Joined const&);
+
+  private:
+    ContainerVisitor<CsgTree const&, NodeId> visit_node_;
+    VecLogic* logic_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with reference to the logic expression.
+ */
+PostfixLogicBuilder::PostfixLogicBuilder(CsgTree const& tree, VecLogic* logic)
+    : visit_node_{tree}, logic_{logic}
+{
+    CELER_EXPECT(logic_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build from a node ID.
+ */
+void PostfixLogicBuilder::operator()(NodeId const& n)
+{
+    return this->visit_node_(*this, n);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Append the "true" token.
+ */
+void PostfixLogicBuilder::operator()(True const&)
+{
+    logic_->push_back(logic::ltrue);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Explicit "False" should never be possible for a CSG cell.
+ *
+ * The 'false' standin is always aliased to "not true" in the CSG tree.
+ */
+void PostfixLogicBuilder::operator()(False const&)
+{
+    CELER_ASSERT_UNREACHABLE();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Push a surface ID.
+ */
+void PostfixLogicBuilder::operator()(Surface const& s)
+{
+    CELER_EXPECT(s.id < logic::lbegin);
+    return logic_->push_back(s.id.unchecked_get());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Push an aliased node.
+ *
+ * TODO: aliased node shouldn't be reachable if we're fully simplified.
+ */
+void PostfixLogicBuilder::operator()(Aliased const& n)
+{
+    // CELER_ASSERT_UNREACHABLE();
+    return (*this)(n.node);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * If replacing a queued node with a boolean, ours should match.
+ */
+void PostfixLogicBuilder::operator()(Negated const& n)
+{
+    (*this)(n.node);
+    logic_->push_back(logic::lnot);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * If replacing a queued node with a boolean, ours should match.
+ */
+void PostfixLogicBuilder::operator()(Joined const& n)
+{
+    CELER_EXPECT(n.nodes.size() > 1);
+
+    // Visit first node, then add conjunction for subsequent nodes
+    auto iter = n.nodes.begin();
+    (*this)(*iter++);
+
+    while (iter != n.nodes.end())
+    {
+        (*this)(*iter++);
+        logic_->push_back(n.op);
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace csg
+}  // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -204,6 +204,7 @@ celeritas_add_test(orange/BoundingBox.test.cc)
 celeritas_add_test(orange/BoundingBoxUtils.test.cc)
 celeritas_add_test(orange/CsgTree.test.cc
   LINK_LIBRARIES ${nlohmann_json_LIBRARIES})
+celeritas_add_test(orange/CsgTreeUtils.test.cc)
 celeritas_add_test(orange/MatrixUtils.test.cc)
 celeritas_add_test(orange/Orange.test.cc)
 

--- a/test/orange/CsgTreeUtils.test.cc
+++ b/test/orange/CsgTreeUtils.test.cc
@@ -1,0 +1,227 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/CsgTreeUtils.test.cc
+//---------------------------------------------------------------------------//
+#include "orange/construct/CsgTreeUtils.hh"
+
+#include "orange/construct/CsgTree.hh"
+
+#include "celeritas_test.hh"
+
+using namespace celeritas::csg;
+using N = celeritas::csg::NodeId;
+using S = celeritas::LocalSurfaceId;
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+class CsgTreeUtilsTest : public ::celeritas::test::Test
+{
+  protected:
+    template<class T>
+    N insert(T&& n)
+    {
+        return tree_.insert(std::forward<T>(n));
+    }
+
+    std::string to_string() const
+    {
+        std::ostringstream os;
+        os << tree_;
+        return os.str();
+    }
+
+  protected:
+    CsgTree tree_;
+
+    static constexpr auto true_id = CsgTree::true_node_id();
+    static constexpr auto false_id = CsgTree::false_node_id();
+};
+
+constexpr NodeId CsgTreeUtilsTest::true_id;
+constexpr NodeId CsgTreeUtilsTest::false_id;
+
+TEST_F(CsgTreeUtilsTest, postfix_simplify)
+{
+    auto mz = this->insert(S{0});
+    auto pz = this->insert(S{1});
+    auto below_pz = this->insert(Negated{pz});
+    auto r_inner = this->insert(S{2});
+    auto inside_inner = this->insert(Negated{r_inner});
+    auto inner_cyl = this->insert(Joined{op_and, {mz, below_pz, inside_inner}});
+    auto r_outer = this->insert(S{3});
+    auto inside_outer = this->insert(Negated{r_outer});
+    auto outer_cyl = this->insert(Joined{op_and, {mz, below_pz, inside_outer}});
+    auto not_inner = this->insert(Negated{inner_cyl});
+    auto shell = this->insert(Joined{op_and, {not_inner, outer_cyl}});
+    auto bdy_outer = this->insert(S{4});
+    auto bdy = this->insert(Joined{op_and, {bdy_outer, mz, below_pz}});
+    auto zslab = this->insert(Joined{op_and, {mz, below_pz}});
+
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: "
+        "surface 2, 6: not{5}, 7: all{2,4,6}, 8: surface 3, 9: not{8}, 10: "
+        "all{2,4,9}, 11: not{7}, 12: all{10,11}, 13: surface 4, 14: "
+        "all{2,4,13}, 15: all{2,4}, }",
+        this->to_string());
+
+    // Test postfix
+    {
+        static size_type expected_lgc[] = {0};
+        auto lgc = build_postfix(tree_, mz);
+        EXPECT_VEC_EQ(expected_lgc, lgc);
+    }
+    {
+        static size_type expected_lgc[] = {1, logic::lnot};
+        auto lgc = build_postfix(tree_, below_pz);
+        EXPECT_VEC_EQ(expected_lgc, lgc);
+    }
+    {
+        auto lgc = build_postfix(tree_, zslab);
+        static size_type const expected_lgc[]
+            = {0u, 1u, logic::lnot, logic::land};
+        EXPECT_VEC_EQ(expected_lgc, lgc);
+    }
+    {
+        auto lgc = build_postfix(tree_, inner_cyl);
+        static size_type const expected_lgc[]
+            = {0u, 1u, logic::lnot, logic::land, 2u, logic::lnot, logic::land};
+        EXPECT_VEC_EQ(expected_lgc, lgc);
+    }
+    {
+        auto lgc = build_postfix(tree_, shell);
+        static size_type const expected_lgc[] = {0u,
+                                                 1u,
+                                                 logic::lnot,
+                                                 logic::land,
+                                                 3u,
+                                                 logic::lnot,
+                                                 logic::land,
+                                                 0u,
+                                                 1u,
+                                                 logic::lnot,
+                                                 logic::land,
+                                                 2u,
+                                                 logic::lnot,
+                                                 logic::land,
+                                                 logic::lnot,
+                                                 logic::land};
+        EXPECT_VEC_EQ(expected_lgc, lgc);
+    }
+    {
+        auto lgc = build_postfix(tree_, bdy);
+        static size_type const expected_lgc[]
+            = {0u, 1u, logic::lnot, logic::land, 4u, logic::land};
+        EXPECT_VEC_EQ(expected_lgc, lgc);
+    }
+
+    // Imply inside boundary
+    auto min_node = replace_down(&tree_, bdy, True{});
+    EXPECT_EQ(mz, min_node);
+
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: ->{0}, 3: ->{1}, 4: ->{0}, 5: surface 2, 6: "
+        "not{5}, 7: all{2,4,6}, 8: surface 3, 9: not{8}, 10: all{2,4,9}, 11: "
+        "not{7}, 12: all{10,11}, 13: ->{0}, 14: ->{0}, 15: all{2,4}, }",
+        this->to_string());
+
+    // Simplify once: first simplification is the inner cylinder
+    min_node = simplify_up(&tree_, min_node);
+    EXPECT_EQ(NodeId{7}, min_node);
+
+    // Simplify again: the shell is simplified this time
+    min_node = simplify_up(&tree_, min_node);
+    EXPECT_EQ(NodeId{11}, min_node);
+
+    // Simplify one final time: nothing further is simplified
+    min_node = simplify_up(&tree_, min_node);
+    EXPECT_EQ(NodeId{}, min_node);
+
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: ->{0}, 3: ->{1}, 4: ->{0}, 5: surface 2, 6: "
+        "not{5}, 7: ->{6}, 8: surface 3, 9: not{8}, 10: ->{9}, 11: ->{5}, 12: "
+        "all{5,9}, 13: ->{0}, 14: ->{0}, 15: ->{0}, }",
+        this->to_string());
+}
+
+TEST_F(CsgTreeUtilsTest, replace_union)
+{
+    auto a = this->insert(S{0});
+    auto b = this->insert(S{1});
+    auto inside_a = this->insert(Negated{a});
+    auto inside_b = this->insert(Negated{b});
+    auto inside_a_or_b = this->insert(Joined{op_or, {inside_a, inside_b}});
+
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{2}, 5: "
+        "not{3}, 6: any{4,5}, }",
+        this->to_string());
+
+    // Imply inside neither
+    auto min_node = replace_down(&tree_, inside_a_or_b, False{});
+    EXPECT_EQ(a, min_node);
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: ->{0}, 3: ->{0}, 4: ->{1}, 5: ->{1}, 6: "
+        "->{1}, }",
+        this->to_string());
+
+    min_node = simplify_up(&tree_, min_node);
+    EXPECT_EQ(NodeId{}, min_node);
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: ->{0}, 3: ->{0}, 4: ->{1}, 5: ->{1}, 6: "
+        "->{1}, }",
+        this->to_string());
+}
+
+TEST_F(CsgTreeUtilsTest, replace_union_2)
+{
+    auto a = this->insert(S{0});
+    auto b = this->insert(S{1});
+    auto inside_a = this->insert(Negated{a});
+    this->insert(Negated{b});
+    auto outside_a_or_b = this->insert(Joined{op_or, {a, b}});
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{2}, 5: "
+        "not{3}, 6: any{2,3}, }",
+        this->to_string());
+
+    // Imply !(a | b) -> a & b
+    auto min_node = replace_down(&tree_, outside_a_or_b, False{});
+    EXPECT_EQ(a, min_node);
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: ->{1}, 3: ->{1}, 4: not{2}, 5: not{3}, 6: "
+        "->{1}, }",
+        this->to_string());
+
+    min_node = simplify_up(&tree_, min_node);
+    EXPECT_EQ(inside_a, min_node);
+
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: ->{1}, 3: ->{1}, 4: ->{0}, 5: ->{0}, 6: "
+        "->{1}, }",
+        this->to_string());
+
+    // No simplification
+    min_node = simplify_up(&tree_, min_node);
+    EXPECT_EQ(NodeId{}, min_node);
+}
+
+TEST_F(CsgTreeUtilsTest, calc_surfaces)
+{
+    this->insert(S{3});
+    auto s1 = this->insert(S{1});
+    this->insert(Negated{s1});
+    this->insert(S{1});
+
+    EXPECT_EQ((std::vector<S>{S{1}, S{3}}), calc_surfaces(tree_));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
This adds logic for replacing nodes in a CSG tree with a constant value, then propagating the implications of that down and up the tree. This is a substantial improvement of the simplification logic in SCALE, which still leaves unnecessary constants in the tree and cannot combine multiple nodes.