### PR TITLE
Fix ORANGE bounding box bumping to be consistent with tracking tolerances

### DIFF
--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -185,8 +185,8 @@ calc_intersection(BoundingBox<T> const& a, BoundingBox<T> const& b)
  * Bump a bounding box outward and possibly convert to another type.
  * \tparam T destination type
  *
- * The upper and lower coordinates are bumped outward using the relative and
- * absolute tolerances
+ * The upper and lower coordinates are bumped outward independently using the
+ * relative and absolute tolerances.
  */
 template<class T>
 class BoundingBoxBumper
@@ -227,11 +227,8 @@ class BoundingBoxBumper
 
         for (auto ax : range(to_int(Axis::size_)))
         {
-            T const lo = static_cast<T>(bbox.lower()[ax]);
-            T const hi = static_cast<T>(bbox.upper()[ax]);
-            T const bump = celeritas::max(abs_, rel_ * (hi - lo));
-            lower[ax] = lo - bump;
-            upper[ax] = hi + bump;
+            lower[ax] = this->bumped<-1>(static_cast<T>(bbox.lower()[ax]));
+            upper[ax] = this->bumped<+1>(static_cast<T>(bbox.upper()[ax]));
         }
 
         return result_type::from_unchecked(lower, upper);
@@ -240,6 +237,13 @@ class BoundingBoxBumper
   private:
     T rel_;
     T abs_;
+
+    //! Calculate the bump distance given a point: see detail::BumpCalculator
+    template<int S>
+    T bumped(T value) const
+    {
+        return value + S * celeritas::max(abs_, rel_ * std::fabs(value));
+    }
 };
 
 // Template deduction

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -153,8 +153,8 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
     // Bounding box bumper and converter: expand to twice the potential bump
     // distance from a boundary so that the bbox will enclose the point even
     // after a potential bump
-    BoundingBoxBumper<float> calc_bumped(2 * orange_data_->scalars.bump_rel,
-                                         2 * orange_data_->scalars.bump_abs);
+    BoundingBoxBumper<float> calc_bumped{2 * orange_data_->scalars.bump_rel,
+                                         2 * orange_data_->scalars.bump_abs};
 
     // Define volumes
     std::vector<VolumeRecord> vol_records(inp.volumes.size());

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -131,6 +131,8 @@ UnitInserter::UnitInserter(Data* orange_data)
     , insert_transform_{&orange_data_->transforms, &orange_data_->reals}
 {
     CELER_EXPECT(orange_data);
+    CELER_EXPECT(orange_data->scalars.bump_rel > 0);
+    CELER_EXPECT(orange_data->scalars.bump_abs > 0);
 
     // Initialize scalars
     orange_data_->scalars.max_faces = 1;
@@ -148,6 +150,12 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
     // Insert surfaces
     unit.surfaces = this->insert_surfaces(inp.surfaces);
 
+    // Bounding box bumper and converter: expand to twice the potential bump
+    // distance from a boundary so that the bbox will enclose the point even
+    // after a potential bump
+    BoundingBoxBumper<float> calc_bumped(2 * orange_data_->scalars.bump_rel,
+                                         2 * orange_data_->scalars.bump_abs);
+
     // Define volumes
     std::vector<VolumeRecord> vol_records(inp.volumes.size());
     std::vector<std::set<LocalVolumeId>> connectivity(inp.surfaces.size());
@@ -160,7 +168,7 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
         // Store the bbox or an infinite bbox placeholder
         if (inp.volumes[i].bbox)
         {
-            bboxes.push_back(calc_bumped<fast_real_type>(inp.volumes[i].bbox));
+            bboxes.push_back(calc_bumped(inp.volumes[i].bbox));
         }
         else
         {

--- a/test/Test.hh
+++ b/test/Test.hh
@@ -48,6 +48,7 @@ class Test : public ::testing::Test
 
     // Define "inf" value for subclass testing
     static constexpr double inf = HUGE_VAL;
+    static constexpr float inff = HUGE_VALF;
 
   private:
     int filename_counter_ = 0;

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -182,10 +182,8 @@ TEST_F(BoundingBoxUtilsTest, bumped)
         SCOPED_TRACE("default precision");
         BoundingBoxBumper<float> calc_bumped{};
         auto bumped = calc_bumped(BBox{{-inf, 0, -100}, {0, precise, inf}});
-        PRINT_EXPECTED(bumped.lower());
-        PRINT_EXPECTED(bumped.upper());
-        static float const expected_lower[] = {-inff, -1.122334e-07f, -inff};
-        static float const expected_upper[] = {inff, 0.1122336f, inff};
+        static float const expected_lower[] = {-inff, -1e-08f, -100.0001f};
+        static float const expected_upper[] = {1e-08f, 0.1122336f, inff};
         EXPECT_VEC_SOFT_EQ(expected_lower, bumped.lower());
         EXPECT_VEC_SOFT_EQ(expected_upper, bumped.upper());
 
@@ -196,23 +194,25 @@ TEST_F(BoundingBoxUtilsTest, bumped)
         SCOPED_TRACE("double precise");
         BoundingBoxBumper<double> calc_bumped{1e-10};
         auto bumped = calc_bumped(BBox{{-inf, 0, -100}, {0, precise, inf}});
-        PRINT_EXPECTED(bumped.lower());
-        PRINT_EXPECTED(bumped.upper());
-        static double const expected_lower[] = {-inf, -1e-10, -inf};
-        static double const expected_upper[] = {inf, 0.11223344566677, inf};
+        static double const expected_lower[] = {-inf, -1e-10, -100.00000001};
+        static double const expected_upper[] = {1e-10, 0.11223344566677, inf};
         EXPECT_VEC_SOFT_EQ(expected_lower, bumped.lower());
         EXPECT_VEC_SOFT_EQ(expected_upper, bumped.upper());
+
+        EXPECT_TRUE(is_inside(bumped, Array<double, 3>{-inf, 0, -100}));
+        EXPECT_TRUE(is_inside(bumped, Array<double, 3>{0, precise, inf}));
     }
     {
         SCOPED_TRACE("float loose");
         BoundingBoxBumper<float> calc_bumped{1e-3, 1e-5};
         auto bumped = calc_bumped(BBox{{-inf, 0, -100}, {0, precise, inf}});
-        PRINT_EXPECTED(bumped.lower());
-        PRINT_EXPECTED(bumped.upper());
-        static float const expected_lower[] = {-inff, -0.0001122335f, -inff};
-        static float const expected_upper[] = {inff, 0.1123457f, inff};
+        static float const expected_lower[] = {-inff, -1e-05f, -100.1f};
+        static float const expected_upper[] = {1e-05f, 0.1123457f, inff};
         EXPECT_VEC_SOFT_EQ(expected_lower, bumped.lower());
         EXPECT_VEC_SOFT_EQ(expected_upper, bumped.upper());
+
+        EXPECT_TRUE(is_inside(bumped, Array<double, 3>{-inf, 0, -100}));
+        EXPECT_TRUE(is_inside(bumped, Array<double, 3>{0, precise, inf}));
     }
 }
 


### PR DESCRIPTION
Particles in EMPIRE were getting lost while crossing the $`z=0`$ plane because they didn't register as being in the bounding box on the other side. This is because `nextafter(0f, -inff)` gives a value of `-1e-45f` whereas it's reasonable and expected for the particles themselves to be bumped on $`O(10^{-12})`$. We should be using the same bump behavior as in the BumpCalculator: each box coordinate is pushed outward by `max(abs_tol, rel_tol * fabs(value))`.

Instead of bumping outward by the width, we bump outward by the local value, since semi-infinite bounding boxes are not uncommon.