### PR TITLE
Define unified tolerances class for ORANGE

### DIFF
--- a/src/orange/BoundingBox.hh
+++ b/src/orange/BoundingBox.hh
@@ -36,7 +36,7 @@ namespace celeritas
  * coordinate. Any point on the surface of this bounding box is still "inside".
  * It may have nonzero surface area but will have zero volume.
  */
-template<class T>
+template<class T = ::celeritas::real_type>
 class BoundingBox
 {
   public:
@@ -91,7 +91,7 @@ class BoundingBox
 //---------------------------------------------------------------------------//
 
 //! Bounding box for host metadata
-using BBox = BoundingBox<::celeritas::real_type>;
+using BBox = BoundingBox<>;
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -197,7 +197,7 @@ class BoundingBoxBumper
   public:
     //!@{
     //! \name Type aliases
-    using TolU = Tolerances<U>;
+    using TolU = Tolerance<U>;
     using result_type = BoundingBox<T>;
     using argument_type = BoundingBox<U>;
     //!@}

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -197,27 +197,19 @@ class BoundingBoxBumper
   public:
     //!@{
     //! \name Type aliases
+    using TolU = Tolerances<U>;
     using result_type = BoundingBox<T>;
     using argument_type = BoundingBox<U>;
     //!@}
 
   public:
     //! Construct with default "soft equal" tolerances
-    BoundingBoxBumper()
-        : rel_{SoftEqual<U>{}.rel()}, abs_{SoftEqual<U>{}.abs()}
-    {
-    }
+    BoundingBoxBumper() : tol_{TolU::from_softequal()} {}
 
-    //! Construct with a single bump tolerance used for both relative and abs
-    explicit BoundingBoxBumper(U tol) : rel_{tol}, abs_{tol}
+    //! Construct with ORANGE tolerances
+    explicit BoundingBoxBumper(TolU const& tol) : tol_{tol}
     {
-        CELER_EXPECT(rel_ > 0 && abs_ > 0);
-    }
-
-    //! Construct with relative and absolute bump tolerances
-    BoundingBoxBumper(U rel, U abs) : rel_{rel}, abs_{abs}
-    {
-        CELER_EXPECT(rel_ > 0 && abs_ > 0);
+        CELER_EXPECT(tol_);
     }
 
     //! Return the expanded and converted bounding box
@@ -238,14 +230,14 @@ class BoundingBoxBumper
     }
 
   private:
-    U rel_;
-    U abs_;
+    TolU tol_;
 
     //! Calculate the bump distance given a point: see detail::BumpCalculator
     template<int S>
     T bumped(U value) const
     {
-        U bumped = value + S * celeritas::max(abs_, rel_ * std::fabs(value));
+        U bumped = value
+                   + S * celeritas::max(tol_.abs, tol_.rel * std::fabs(value));
         return std::nextafter(static_cast<T>(bumped),
                               S * numeric_limits<T>::infinity());
     }

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -39,7 +39,7 @@ struct OrangeParamsScalars
     size_type max_logic_depth{};
 
     // Soft comparison and dynamic "bumping" values
-    Tolerances<> tol;
+    Tolerance<> tol;
 
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -38,15 +38,13 @@ struct OrangeParamsScalars
     size_type max_intersections{};
     size_type max_logic_depth{};
 
-    // Multiplicative and additive values for bumping particles
-    real_type bump_rel{1e-8};
-    real_type bump_abs{1e-8};
+    // Soft comparison and dynamic "bumping" values
+    Tolerances<> tol;
 
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return max_depth > 0 && max_faces > 0 && max_intersections > 0
-               && bump_rel > 0 && bump_abs > 0;
+        return max_depth > 0 && max_faces > 0 && max_intersections > 0 && tol;
     }
 };
 

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -195,7 +195,14 @@ OrangeParams::OrangeParams(OrangeInput input)
     CELER_VALIDATE(!input.universes.empty(),
                    << "input geometry has no universes");
 
+    if (!input.tol)
+    {
+        input.tol = Tolerances<>::from_default();
+    }
+
+    // Create host data for construction, setting tolerances first
     HostVal<OrangeParamsData> host_data;
+    host_data.scalars.tol = input.tol;
 
     // Calculate offsets for UniverseIndexerData
     {

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -197,7 +197,7 @@ OrangeParams::OrangeParams(OrangeInput input)
 
     if (!input.tol)
     {
-        input.tol = Tolerances<>::from_default();
+        input.tol = Tolerance<>::from_default();
     }
 
     // Create host data for construction, setting tolerances first

--- a/src/orange/OrangeTypes.cc
+++ b/src/orange/OrangeTypes.cc
@@ -37,7 +37,7 @@ Tolerance<T> Tolerance<T>::from_default(real_type length)
         }
     }();
     static_assert(real_type{1} - ipow<2>(sqrt_emach) != real_type{1},
-                  "default tolerance is insufficient");
+                  "default tolerance is too low");
 
     return Tolerance<T>::from_relative(sqrt_emach, length);
 }
@@ -69,6 +69,10 @@ Tolerance<T> Tolerance<T>::from_relative(real_type rel, real_type length)
     Tolerance<T> result;
     result.rel = rel;
     result.abs = rel * length;
+
+    // Check that the tolerances aren't so low that they're denormalized
+    CELER_ENSURE(result.rel >= std::numeric_limits<T>::min());
+    CELER_ENSURE(result.abs >= std::numeric_limits<T>::min());
     CELER_ENSURE(result);
     return result;
 }

--- a/src/orange/OrangeTypes.cc
+++ b/src/orange/OrangeTypes.cc
@@ -23,7 +23,8 @@ namespace celeritas
  * Technically we're rounding the machine epsilon to a nearby power of 10. We
  * could use numeric_limits<real_type>::epsilon instead.
  */
-Tolerances Tolerances::from_default(real_type length)
+template<class T>
+Tolerances<T> Tolerances<T>::from_default(real_type length)
 {
     constexpr real_type sqrt_emach = [] {
         if constexpr (std::is_same_v<real_type, double>)
@@ -32,30 +33,32 @@ Tolerances Tolerances::from_default(real_type length)
         }
         else if constexpr (std::is_same_v<real_type, float>)
         {
-            return 1.e-4f;
+            return 5.e-3f;
         }
     }();
     static_assert(real_type{1} - ipow<2>(sqrt_emach) != real_type{1},
                   "default tolerance is insufficient");
 
-    return Tolerances::from_relative(sqrt_emach, length);
+    return Tolerances<T>::from_relative(sqrt_emach, length);
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct from the default "soft equivalence" tolerance.
  */
-Tolerances Tolerances::from_softequal()
+template<class T>
+Tolerances<T> Tolerances<T>::from_softequal()
 {
     constexpr SoftEqual<> default_seq{};
-    return Tolerances::from_relative(default_seq.rel(), default_seq.abs());
+    return Tolerances<T>::from_relative(default_seq.rel(), default_seq.abs());
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct from a relative tolerance and a length scale.
  */
-Tolerances Tolerances::from_relative(real_type rel, real_type length)
+template<class T>
+Tolerances<T> Tolerances<T>::from_relative(real_type rel, real_type length)
 {
     CELER_VALIDATE(rel > 0 && rel < 1,
                    << "tolerance " << rel
@@ -63,7 +66,7 @@ Tolerances Tolerances::from_relative(real_type rel, real_type length)
     CELER_VALIDATE(length > 0,
                    << "length scale " << length
                    << " is invalid [must be positive]");
-    Tolerances result;
+    Tolerances<T> result;
     result.rel = rel;
     result.abs = rel * length;
     CELER_ENSURE(result);
@@ -99,6 +102,13 @@ char const* to_cstring(SurfaceType value)
     };
     return to_cstring_impl(value);
 }
+
+//---------------------------------------------------------------------------//
+// EXPLICIT INSTANTIATION
+//---------------------------------------------------------------------------//
+
+template struct Tolerances<float>;
+template struct Tolerances<double>;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/OrangeTypes.cc
+++ b/src/orange/OrangeTypes.cc
@@ -24,7 +24,7 @@ namespace celeritas
  * could use numeric_limits<real_type>::epsilon instead.
  */
 template<class T>
-Tolerances<T> Tolerances<T>::from_default(real_type length)
+Tolerance<T> Tolerance<T>::from_default(real_type length)
 {
     constexpr real_type sqrt_emach = [] {
         if constexpr (std::is_same_v<real_type, double>)
@@ -39,7 +39,7 @@ Tolerances<T> Tolerances<T>::from_default(real_type length)
     static_assert(real_type{1} - ipow<2>(sqrt_emach) != real_type{1},
                   "default tolerance is insufficient");
 
-    return Tolerances<T>::from_relative(sqrt_emach, length);
+    return Tolerance<T>::from_relative(sqrt_emach, length);
 }
 
 //---------------------------------------------------------------------------//
@@ -47,10 +47,10 @@ Tolerances<T> Tolerances<T>::from_default(real_type length)
  * Construct from the default "soft equivalence" tolerance.
  */
 template<class T>
-Tolerances<T> Tolerances<T>::from_softequal()
+Tolerance<T> Tolerance<T>::from_softequal()
 {
     constexpr SoftEqual<> default_seq{};
-    return Tolerances<T>::from_relative(default_seq.rel(), default_seq.abs());
+    return Tolerance<T>::from_relative(default_seq.rel(), default_seq.abs());
 }
 
 //---------------------------------------------------------------------------//
@@ -58,7 +58,7 @@ Tolerances<T> Tolerances<T>::from_softequal()
  * Construct from a relative tolerance and a length scale.
  */
 template<class T>
-Tolerances<T> Tolerances<T>::from_relative(real_type rel, real_type length)
+Tolerance<T> Tolerance<T>::from_relative(real_type rel, real_type length)
 {
     CELER_VALIDATE(rel > 0 && rel < 1,
                    << "tolerance " << rel
@@ -66,7 +66,7 @@ Tolerances<T> Tolerances<T>::from_relative(real_type rel, real_type length)
     CELER_VALIDATE(length > 0,
                    << "length scale " << length
                    << " is invalid [must be positive]");
-    Tolerances<T> result;
+    Tolerance<T> result;
     result.rel = rel;
     result.abs = rel * length;
     CELER_ENSURE(result);
@@ -107,8 +107,8 @@ char const* to_cstring(SurfaceType value)
 // EXPLICIT INSTANTIATION
 //---------------------------------------------------------------------------//
 
-template struct Tolerances<float>;
-template struct Tolerances<double>;
+template struct Tolerance<float>;
+template struct Tolerance<double>;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -249,7 +249,7 @@ struct Daughter
 
 //---------------------------------------------------------------------------//
 /*!
- * Tolerances for construction and runtime bumping.
+ * Tolerance for construction and runtime bumping.
  *
  * The relative error is used for comparisons of magnitudes of values, and the
  * absolute error provides a lower bound for the comparison tolerance. In most
@@ -270,11 +270,11 @@ struct Daughter
  * be ~1e6 m.
  *
  * \note For historical reasons, the absolute tolerance used by \c SoftEqual
- * defaults to 1/100 of the relative tolerance, whereas with \c Tolerances the
+ * defaults to 1/100 of the relative tolerance, whereas with \c Tolerance the
  * equivalent behavior is setting a length scale of 0.01.
  */
 template<class T = ::celeritas::real_type>
-struct Tolerances
+struct Tolerance
 {
     using real_type = T;
 
@@ -291,17 +291,17 @@ struct Tolerances
     }
 
     // Construct from the default relative tolerance (sqrt(precision))
-    static Tolerances from_default(real_type length = 1);
+    static Tolerance from_default(real_type length = 1);
 
     // Construct from the default "soft equivalence" relative tolerance
-    static Tolerances from_softequal();
+    static Tolerance from_softequal();
 
     // Construct from a relative tolerance and a length scale
-    static Tolerances from_relative(real_type rel, real_type length = 1);
+    static Tolerance from_relative(real_type rel, real_type length = 1);
 };
 
-extern template struct Tolerances<float>;
-extern template struct Tolerances<double>;
+extern template struct Tolerance<float>;
+extern template struct Tolerance<double>;
 
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS (HOST/DEVICE)

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -258,7 +258,10 @@ struct Daughter
  * of some spatial coordinate. In other cases (\c SurfaceSimplifier, \c
  * SoftSurfaceEqual) the similarity between surfaces is determined by solving
  * for a change in surface coefficients that results in no more than a change
- * in \f$ \epsilon \f$ of a particle intercept.
+ * in \f$ \epsilon \f$ of a particle intercept. A final special case (the \c
+ * sqrt_quadratic static variable) is used to approximate the degenerate
+ * condition \f$ a\sim 0\f$ for a particle traveling nearly parallel to a
+ * quadric surface: see \c CylAligned for a discussion.
  *
  * The absolute error should typically be constructed from the relative error
  * (since computers use floating point precision) and a characteristic length
@@ -274,6 +277,9 @@ struct Tolerances
 {
     real_type rel{};  //!< Relative error for differences
     real_type abs{};  //!< Absolute error [native length]
+
+    //! Tolerance for x^2 coefficient in quadratic solvers
+    static constexpr real_type sqrt_quadratic() { return 1e-5; }
 
     //! True if tolerances are valid
     CELER_CONSTEXPR_FUNCTION operator bool() const

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -281,8 +281,8 @@ struct Tolerance
     real_type rel{};  //!< Relative error for differences
     real_type abs{};  //!< Absolute error [native length]
 
-    //! Tolerance for x^2 coefficient in quadratic solvers
-    static constexpr real_type sqrt_quadratic() { return 1e-5; }
+    //! Intercept tolerance for parallel-to-quadric cases
+    static CELER_CONSTEXPR_FUNCTION real_type sqrt_quadratic() { return 1e-5; }
 
     //! True if tolerances are valid
     CELER_CONSTEXPR_FUNCTION operator bool() const

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -273,8 +273,11 @@ struct Daughter
  * defaults to 1/100 of the relative tolerance, whereas with \c Tolerances the
  * equivalent behavior is setting a length scale of 0.01.
  */
+template<class T = ::celeritas::real_type>
 struct Tolerances
 {
+    using real_type = T;
+
     real_type rel{};  //!< Relative error for differences
     real_type abs{};  //!< Absolute error [native length]
 
@@ -284,7 +287,7 @@ struct Tolerances
     //! True if tolerances are valid
     CELER_CONSTEXPR_FUNCTION operator bool() const
     {
-        return rel > 0 && abs > 0;
+        return rel > 0 && rel < 1 && abs > 0;
     }
 
     // Construct from the default relative tolerance (sqrt(precision))
@@ -296,6 +299,9 @@ struct Tolerances
     // Construct from a relative tolerance and a length scale
     static Tolerances from_relative(real_type rel, real_type length = 1);
 };
+
+extern template struct Tolerances<float>;
+extern template struct Tolerances<double>;
 
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS (HOST/DEVICE)

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -248,6 +248,50 @@ struct Daughter
 };
 
 //---------------------------------------------------------------------------//
+/*!
+ * Tolerances for construction and runtime bumping.
+ *
+ * The relative error is used for comparisons of magnitudes of values, and the
+ * absolute error provides a lower bound for the comparison tolerance. In most
+ * cases (see \c SoftEqual, \c BoundingBoxBumper , \c detail::BumpCalculator)
+ * the tolerance used is a maximum of the absolute error and the 1- or 2-norm
+ * of some spatial coordinate. In other cases (\c SurfaceSimplifier, \c
+ * SoftSurfaceEqual) the similarity between surfaces is determined by solving
+ * for a change in surface coefficients that results in no more than a change
+ * in \f$ \epsilon \f$ of a particle intercept.
+ *
+ * The absolute error should typically be constructed from the relative error
+ * (since computers use floating point precision) and a characteristic length
+ * scale for the problem being used. For detector/reactor problems the length
+ * might be ~1 cm, for microbiology it might be ~1 um, and for astronomy might
+ * be ~1e6 m.
+ *
+ * \note For historical reasons, the absolute tolerance used by \c SoftEqual
+ * defaults to 1/100 of the relative tolerance, whereas with \c Tolerances the
+ * equivalent behavior is setting a length scale of 0.01.
+ */
+struct Tolerances
+{
+    real_type rel{};  //!< Relative error for differences
+    real_type abs{};  //!< Absolute error [native length]
+
+    //! True if tolerances are valid
+    CELER_CONSTEXPR_FUNCTION operator bool() const
+    {
+        return rel > 0 && abs > 0;
+    }
+
+    // Construct from the default relative tolerance (sqrt(precision))
+    static Tolerances from_default(real_type length = 1);
+
+    // Construct from the default "soft equivalence" relative tolerance
+    static Tolerances from_softequal();
+
+    // Construct from a relative tolerance and a length scale
+    static Tolerances from_relative(real_type rel, real_type length = 1);
+};
+
+//---------------------------------------------------------------------------//
 // HELPER FUNCTIONS (HOST/DEVICE)
 //---------------------------------------------------------------------------//
 /*!

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -136,6 +136,9 @@ struct OrangeInput
 {
     std::vector<std::variant<UnitInput, RectArrayInput>> universes;
 
+    //! Relative and absolute error for construction and transport
+    Tolerances<> tol;
+
     //! Whether the unit definition is valid
     explicit operator bool() const { return !universes.empty(); }
 };

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -137,7 +137,7 @@ struct OrangeInput
     std::vector<std::variant<UnitInput, RectArrayInput>> universes;
 
     //! Relative and absolute error for construction and transport
-    Tolerances<> tol;
+    Tolerance<> tol;
 
     //! Whether the unit definition is valid
     explicit operator bool() const { return !universes.empty(); }

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -255,7 +255,7 @@ void from_json(nlohmann::json const& j, RectArrayInput& value)
 /*!
  * Read tolerances.
  */
-void from_json(nlohmann::json const& j, Tolerances<>& value)
+void from_json(nlohmann::json const& j, Tolerance<>& value)
 {
     j.at("rel").get_to(value.rel);
     CELER_VALIDATE(value.rel > 0 && value.rel < 1,

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -253,6 +253,23 @@ void from_json(nlohmann::json const& j, RectArrayInput& value)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Read tolerances.
+ */
+void from_json(nlohmann::json const& j, Tolerances<>& value)
+{
+    j.at("rel").get_to(value.rel);
+    CELER_VALIDATE(value.rel > 0 && value.rel < 1,
+                   << "tolerance " << value.rel
+                   << " is out of range [must be in (0,1)]");
+
+    j.at("abs").get_to(value.abs);
+    CELER_VALIDATE(value.abs > 0,
+                   << "tolerance " << value.abs
+                   << " is out of range [must be greater than zero]");
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Read a partially preprocessed geometry definition from an ORANGE JSON file.
  */
 void from_json(nlohmann::json const& j, OrangeInput& value)
@@ -263,7 +280,7 @@ void from_json(nlohmann::json const& j, OrangeInput& value)
 
     for (auto const& uni : universes)
     {
-        auto uni_type = uni.at("_type").get<std::string>();
+        auto const& uni_type = uni.at("_type").get<std::string>();
         if (uni_type == "simple unit")
         {
             value.universes.push_back(uni.get<UnitInput>());
@@ -281,6 +298,11 @@ void from_json(nlohmann::json const& j, OrangeInput& value)
             CELER_VALIDATE(
                 false, << "unsupported universe type '" << uni_type << "'");
         }
+    }
+
+    if (j.count("tol"))
+    {
+        j.at("tol").get_to(value.tol);
     }
 }
 

--- a/src/orange/construct/OrangeInputIO.json.hh
+++ b/src/orange/construct/OrangeInputIO.json.hh
@@ -19,7 +19,7 @@ namespace celeritas
 void from_json(nlohmann::json const& j, SurfaceInput& value);
 void from_json(nlohmann::json const& j, VolumeInput& value);
 void from_json(nlohmann::json const& j, UnitInput& value);
-void from_json(nlohmann::json const& j, Tolerances<>& value);
+void from_json(nlohmann::json const& j, Tolerance<>& value);
 void from_json(nlohmann::json const& j, OrangeInput& value);
 
 //---------------------------------------------------------------------------//

--- a/src/orange/construct/OrangeInputIO.json.hh
+++ b/src/orange/construct/OrangeInputIO.json.hh
@@ -9,6 +9,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "../OrangeData.hh"
 #include "OrangeInput.hh"
 
 namespace celeritas
@@ -18,6 +19,7 @@ namespace celeritas
 void from_json(nlohmann::json const& j, SurfaceInput& value);
 void from_json(nlohmann::json const& j, VolumeInput& value);
 void from_json(nlohmann::json const& j, UnitInput& value);
+void from_json(nlohmann::json const& j, Tolerances<>& value);
 void from_json(nlohmann::json const& j, OrangeInput& value);
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -154,7 +154,7 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
     // the point even after a potential bump
     BoundingBoxBumper<fast_real_type> calc_bumped{
         [&tol = orange_data_->scalars.tol] {
-            Tolerances<real_type> bbox_tol;
+            Tolerance<real_type> bbox_tol;
             bbox_tol.rel = 2 * tol.rel;
             bbox_tol.abs = 2 * tol.abs;
             CELER_ENSURE(bbox_tol);

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -131,8 +131,7 @@ UnitInserter::UnitInserter(Data* orange_data)
     , insert_transform_{&orange_data_->transforms, &orange_data_->reals}
 {
     CELER_EXPECT(orange_data);
-    CELER_EXPECT(orange_data->scalars.bump_rel > 0);
-    CELER_EXPECT(orange_data->scalars.bump_abs > 0);
+    CELER_EXPECT(orange_data->scalars.tol);
 
     // Initialize scalars
     orange_data_->scalars.max_faces = 1;
@@ -150,11 +149,17 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
     // Insert surfaces
     unit.surfaces = this->insert_surfaces(inp.surfaces);
 
-    // Bounding box bumper and converter: expand to twice the potential bump
-    // distance from a boundary so that the bbox will enclose the point even
-    // after a potential bump
-    BoundingBoxBumper<float> calc_bumped{2 * orange_data_->scalars.bump_rel,
-                                         2 * orange_data_->scalars.bump_abs};
+    // Bounding box bumper and converter: conservatively expand to twice the
+    // potential bump distance from a boundary so that the bbox will enclose
+    // the point even after a potential bump
+    BoundingBoxBumper<fast_real_type> calc_bumped{
+        [&tol = orange_data_->scalars.tol] {
+            Tolerances<real_type> bbox_tol;
+            bbox_tol.rel = 2 * tol.rel;
+            bbox_tol.abs = 2 * tol.abs;
+            CELER_ENSURE(bbox_tol);
+            return bbox_tol;
+        }()};
 
     // Define volumes
     std::vector<VolumeRecord> vol_records(inp.volumes.size());

--- a/src/orange/surf/CylAligned.hh
+++ b/src/orange/surf/CylAligned.hh
@@ -31,6 +31,38 @@ class CylCentered;
  * \f[
     (y - y_0)^2 + (z - z_0)^2 - R^2 = 0
    \f]
+ *
+ * The axis-aligned cylinder is used to calculate a tolerance for the
+ * second-order coefficient on the quadratic equation, where a small value is
+ * approximately zero.
+ *
+ * Basing the intersection tolerance on a particle traveling nearly parallel to
+ * the cylinder, the angle \f$\theta \f$
+ * between the particle's direction and the center axis of the cylinder needed
+ * to give an intersection distance of \f$ 1/\delta \f$ when a distance of 1
+ * from the cylinder (or equivalently, an intersection of 1 when a distance
+ * \f$ \delta \f$ away) is
+ * \f[
+   \sin \theta = \frac{1}{1/\delta} \;.
+   \f]
+ * Letting \f$ \mu = \cos \theta = \Omega \cdot t \f$ we have \f[
+   \mu^2 + \delta^2 = 1 \;.
+   \f]
+ * The quadratic intersection for an axis-aligned cylinder where the particle
+ * is at \f$ R + \delta \f$ is
+ * \f[
+   0 = ax^2 + bx + c
+     = (1 - \mu^2)x^2 + 2 \sqrt{1 - \mu^2} (R + 1) x + (R + 1)^2 - R^2
+  \f]
+ * so the quadric coefficient when a particle is effectively parallel to a
+ * cylinder is:
+  \f[
+  a = (1 - \mu^2) = \delta^2 \;.
+  \f]
+ *
+ * Because \em a is calculated by subtraction, this puts a hard limit on the
+ * accuracy of the intersection distance: the default value of a=1e-10
+ * corresponds to a tolerance of 1e-5, not the default tolerance 1e-8.
  */
 template<Axis T>
 class CylAligned
@@ -192,7 +224,7 @@ CylAligned<T>::calc_intersections(Real3 const& pos,
     // 1 - \omega \dot e
     const real_type a = 1 - ipow<2>(dir[to_int(T)]);
 
-    if (a < detail::QuadraticSolver::min_a())
+    if (a < ipow<2>(Tolerances::sqrt_quadratic()))
     {
         // No intersection if we're traveling along the cylinder axis
         return {no_intersection(), no_intersection()};

--- a/src/orange/surf/CylAligned.hh
+++ b/src/orange/surf/CylAligned.hh
@@ -224,7 +224,7 @@ CylAligned<T>::calc_intersections(Real3 const& pos,
     // 1 - \omega \dot e
     const real_type a = 1 - ipow<2>(dir[to_int(T)]);
 
-    if (a < ipow<2>(Tolerances<>::sqrt_quadratic()))
+    if (a < ipow<2>(Tolerance<>::sqrt_quadratic()))
     {
         // No intersection if we're traveling along the cylinder axis
         return {no_intersection(), no_intersection()};

--- a/src/orange/surf/CylAligned.hh
+++ b/src/orange/surf/CylAligned.hh
@@ -224,7 +224,7 @@ CylAligned<T>::calc_intersections(Real3 const& pos,
     // 1 - \omega \dot e
     const real_type a = 1 - ipow<2>(dir[to_int(T)]);
 
-    if (a < ipow<2>(Tolerances::sqrt_quadratic()))
+    if (a < ipow<2>(Tolerances<>::sqrt_quadratic()))
     {
         // No intersection if we're traveling along the cylinder axis
         return {no_intersection(), no_intersection()};

--- a/src/orange/surf/CylCentered.hh
+++ b/src/orange/surf/CylCentered.hh
@@ -192,7 +192,7 @@ CylCentered<T>::calc_intersections(Real3 const& pos,
     // 1 - (\omega \dot t)^2 where t is axis of cylinder
     const real_type a = 1 - ipow<2>(dir[to_int(T)]);
 
-    if (a < ipow<2>(Tolerances<>::sqrt_quadratic()))
+    if (a < ipow<2>(Tolerance<>::sqrt_quadratic()))
     {
         // No intersection if we're traveling along the cylinder axis
         return {no_intersection(), no_intersection()};

--- a/src/orange/surf/CylCentered.hh
+++ b/src/orange/surf/CylCentered.hh
@@ -192,7 +192,7 @@ CylCentered<T>::calc_intersections(Real3 const& pos,
     // 1 - (\omega \dot t)^2 where t is axis of cylinder
     const real_type a = 1 - ipow<2>(dir[to_int(T)]);
 
-    if (a < ipow<2>(Tolerances::sqrt_quadratic()))
+    if (a < ipow<2>(Tolerances<>::sqrt_quadratic()))
     {
         // No intersection if we're traveling along the cylinder axis
         return {no_intersection(), no_intersection()};

--- a/src/orange/surf/CylCentered.hh
+++ b/src/orange/surf/CylCentered.hh
@@ -189,10 +189,10 @@ CylCentered<T>::calc_intersections(Real3 const& pos,
                                    SurfaceState on_surface) const
     -> Intersections
 {
-    // 1 - \omega \dot e
+    // 1 - (\omega \dot t)^2 where t is axis of cylinder
     const real_type a = 1 - ipow<2>(dir[to_int(T)]);
 
-    if (a < detail::QuadraticSolver::min_a())
+    if (a < ipow<2>(Tolerances::sqrt_quadratic()))
     {
         // No intersection if we're traveling along the cylinder axis
         return {no_intersection(), no_intersection()};

--- a/src/orange/surf/detail/QuadraticSolver.hh
+++ b/src/orange/surf/detail/QuadraticSolver.hh
@@ -13,6 +13,7 @@
 #include "corecel/cont/Array.hh"
 #include "corecel/math/Algorithms.hh"
 #include "orange/OrangeTypes.hh"
+
 namespace celeritas
 {
 namespace detail
@@ -21,16 +22,16 @@ namespace detail
 /*!
  * Find positive, real, nonzero roots for quadratic functions.
  *
- * These are for quadratic functions \f[
+ * The quadratic equation \f[
    a x^2 + b^2 + c = 0
  * \f]
- * where a is nonzero (and not close to zero).
+ * has two solutions mathematically, but we only want solutions where x is real
+ * and positive.  Furthermore the equation is subject to catastrophic roundoff
+ * due to floating point precision (see \c Tolerances::sqrt_quadratic and the
+ * derivation in \c CylAligned ).
  *
- * This is used for all quadrics with potentially two roots (anything but
- * planes).
- *
- * Each item in the Intersections result will be a positive valid intersection
- * or the sentinel result \c no_intersection() .
+ * \return An Intersections array where each item is a positive valid
+ * intersection or the sentinel result \c no_intersection() .
  */
 class QuadraticSolver
 {
@@ -39,9 +40,6 @@ class QuadraticSolver
     //! \name Type aliases
     using Intersections = Array<real_type, 2>;
     //!@}
-
-    //! Fuzziness for "along surface"
-    static CELER_CONSTEXPR_FUNCTION real_type min_a() { return 1e-10; }
 
     // Solve when possibly along a surface (zeroish a)
     static inline CELER_FUNCTION Intersections solve_general(
@@ -65,6 +63,12 @@ class QuadraticSolver
     //// DATA ////
     real_type a_inv_;
     real_type hba_;  // (b/2)/a
+
+    //! Fuzziness for "along surface" intercept
+    static CELER_CONSTEXPR_FUNCTION real_type min_a()
+    {
+        return ipow<2>(Tolerances::sqrt_quadratic());
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/detail/QuadraticSolver.hh
+++ b/src/orange/surf/detail/QuadraticSolver.hh
@@ -27,7 +27,7 @@ namespace detail
  * \f]
  * has two solutions mathematically, but we only want solutions where x is real
  * and positive.  Furthermore the equation is subject to catastrophic roundoff
- * due to floating point precision (see \c Tolerances::sqrt_quadratic and the
+ * due to floating point precision (see \c Tolerance::sqrt_quadratic and the
  * derivation in \c CylAligned ).
  *
  * \return An Intersections array where each item is a positive valid
@@ -67,7 +67,7 @@ class QuadraticSolver
     //! Fuzziness for "along surface" intercept
     static CELER_CONSTEXPR_FUNCTION real_type min_a()
     {
-        return ipow<2>(Tolerances<>::sqrt_quadratic());
+        return ipow<2>(Tolerance<>::sqrt_quadratic());
     }
 };
 

--- a/src/orange/surf/detail/QuadraticSolver.hh
+++ b/src/orange/surf/detail/QuadraticSolver.hh
@@ -67,7 +67,7 @@ class QuadraticSolver
     //! Fuzziness for "along surface" intercept
     static CELER_CONSTEXPR_FUNCTION real_type min_a()
     {
-        return ipow<2>(Tolerances::sqrt_quadratic());
+        return ipow<2>(Tolerances<>::sqrt_quadratic());
     }
 };
 

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -595,7 +595,7 @@ SimpleUnitTracker::background_intersect(LocalState const& state,
 {
     // Calculate bump distance
     const real_type bump_dist
-        = detail::BumpCalculator{params_.scalars}(state.pos);
+        = detail::BumpCalculator{params_.scalars.tol}(state.pos);
 
     // Loop over distances and surface indices to cross by iterating over
     // temp_next.isect[:num_isect].

--- a/src/orange/univ/detail/Utils.hh
+++ b/src/orange/univ/detail/Utils.hh
@@ -63,7 +63,7 @@ class IsNotFurtherThan
 class BumpCalculator
 {
   public:
-    explicit CELER_FORCEINLINE_FUNCTION BumpCalculator(Tolerances<> const& tol)
+    explicit CELER_FORCEINLINE_FUNCTION BumpCalculator(Tolerance<> const& tol)
         : tol_(tol)
     {
     }
@@ -80,7 +80,7 @@ class BumpCalculator
     }
 
   private:
-    Tolerances<> tol_;
+    Tolerance<> tol_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/univ/detail/Utils.hh
+++ b/src/orange/univ/detail/Utils.hh
@@ -63,25 +63,24 @@ class IsNotFurtherThan
 class BumpCalculator
 {
   public:
-    explicit CELER_FORCEINLINE_FUNCTION
-    BumpCalculator(OrangeParamsScalars const& scalars)
-        : scalars_(scalars)
+    explicit CELER_FORCEINLINE_FUNCTION BumpCalculator(Tolerances<> const& tol)
+        : tol_(tol)
     {
     }
 
-    inline CELER_FUNCTION real_type operator()(Real3 const& pos) const
+    CELER_FUNCTION real_type operator()(Real3 const& pos) const
     {
-        real_type result = scalars_.bump_abs;
+        real_type result = tol_.abs;
         for (real_type p : pos)
         {
-            result = celeritas::max(result, scalars_.bump_rel * std::fabs(p));
+            result = celeritas::max(result, tol_.rel * std::fabs(p));
         }
         CELER_ENSURE(result > 0);
         return result;
     }
 
   private:
-    OrangeParamsScalars const& scalars_;
+    Tolerances<> tol_;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -192,7 +192,8 @@ TEST_F(BoundingBoxUtilsTest, bumped)
     }
     {
         SCOPED_TRACE("double precise");
-        BoundingBoxBumper<double> calc_bumped{1e-10};
+        BoundingBoxBumper<double> calc_bumped{
+            Tolerances<double>::from_relative(1e-10)};
         auto bumped = calc_bumped(ref);
         static double const expected_lower[] = {-inf, -1e-10, -100.00000001};
         static double const expected_upper[] = {1e-10, 0.11223344566677, inf};
@@ -204,7 +205,8 @@ TEST_F(BoundingBoxUtilsTest, bumped)
     }
     {
         SCOPED_TRACE("float loose");
-        BoundingBoxBumper<float, double> calc_bumped{1e-3, 1e-5};
+        BoundingBoxBumper<float, double> calc_bumped{
+            Tolerances<double>::from_relative(1e-3, /* length = */ 0.01)};
         auto bumped = calc_bumped(ref);
         static float const expected_lower[] = {-inff, -1e-05f, -100.1f};
         static float const expected_upper[] = {1e-05f, 0.1123457f, inff};
@@ -217,7 +219,8 @@ TEST_F(BoundingBoxUtilsTest, bumped)
     {
         SCOPED_TRACE("float orange");
         BBox const ref{{-2, -6, -1}, {8, 4, 2}};
-        BoundingBoxBumper<float, double> calc_bumped{2e-8, 2e-8};
+        BoundingBoxBumper<float, double> calc_bumped{
+            Tolerances<double>::from_relative(2e-8)};
         auto bumped = calc_bumped(ref);
         static float const expected_lower[] = {-2.f, -6.f, -1.f};
         static float const expected_upper[] = {8.000001f, 4.f, 2.f};

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -193,7 +193,7 @@ TEST_F(BoundingBoxUtilsTest, bumped)
     {
         SCOPED_TRACE("double precise");
         BoundingBoxBumper<double> calc_bumped{
-            Tolerances<double>::from_relative(1e-10)};
+            Tolerance<double>::from_relative(1e-10)};
         auto bumped = calc_bumped(ref);
         static double const expected_lower[] = {-inf, -1e-10, -100.00000001};
         static double const expected_upper[] = {1e-10, 0.11223344566677, inf};
@@ -206,7 +206,7 @@ TEST_F(BoundingBoxUtilsTest, bumped)
     {
         SCOPED_TRACE("float loose");
         BoundingBoxBumper<float, double> calc_bumped{
-            Tolerances<double>::from_relative(1e-3, /* length = */ 0.01)};
+            Tolerance<double>::from_relative(1e-3, /* length = */ 0.01)};
         auto bumped = calc_bumped(ref);
         static float const expected_lower[] = {-inff, -1e-05f, -100.1f};
         static float const expected_upper[] = {1e-05f, 0.1123457f, inff};
@@ -220,7 +220,7 @@ TEST_F(BoundingBoxUtilsTest, bumped)
         SCOPED_TRACE("float orange");
         BBox const ref{{-2, -6, -1}, {8, 4, 2}};
         BoundingBoxBumper<float, double> calc_bumped{
-            Tolerances<double>::from_relative(2e-8)};
+            Tolerance<double>::from_relative(2e-8)};
         auto bumped = calc_bumped(ref);
         static float const expected_lower[] = {-2.f, -6.f, -1.f};
         static float const expected_upper[] = {8.000001f, 4.f, 2.f};

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -30,7 +30,7 @@ namespace test
 
 TEST(OrangeTypes, tolerances)
 {
-    using TolT = Tolerances<>;
+    using TolT = Tolerance<>;
     EXPECT_FALSE(TolT{});
 
     EXPECT_SOFT_EQ(1e-10, ipow<2>(TolT::sqrt_quadratic()));

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -8,6 +8,7 @@
 #include <limits>
 #include <type_traits>
 
+#include "corecel/math/Algorithms.hh"
 #include "orange/OrangeParams.hh"
 #include "orange/OrangeTrackView.hh"
 #include "orange/OrangeTypes.hh"
@@ -30,6 +31,8 @@ namespace test
 TEST(OrangeTypes, tolerances)
 {
     EXPECT_FALSE(Tolerances{});
+
+    EXPECT_SOFT_EQ(1e-10, ipow<2>(Tolerances::sqrt_quadratic()));
 
     {
         SCOPED_TRACE("Default tolerance");

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -30,13 +30,14 @@ namespace test
 
 TEST(OrangeTypes, tolerances)
 {
-    EXPECT_FALSE(Tolerances{});
+    using TolT = Tolerances<>;
+    EXPECT_FALSE(TolT{});
 
-    EXPECT_SOFT_EQ(1e-10, ipow<2>(Tolerances::sqrt_quadratic()));
+    EXPECT_SOFT_EQ(1e-10, ipow<2>(TolT::sqrt_quadratic()));
 
     {
         SCOPED_TRACE("Default tolerance");
-        auto const tol = Tolerances::from_default();
+        auto const tol = TolT::from_default();
         EXPECT_TRUE(tol);
         EXPECT_SOFT_NEAR(
             std::sqrt(std::numeric_limits<real_type>::epsilon()), tol.rel, 0.5);
@@ -48,19 +49,19 @@ TEST(OrangeTypes, tolerances)
     }
     {
         SCOPED_TRACE("Tolerance with other length scale");
-        auto const tol = Tolerances::from_default(1e-4);
+        auto const tol = TolT::from_default(1e-4);
         EXPECT_SOFT_EQ(1e-8, tol.rel);
         EXPECT_SOFT_EQ(1e-12, tol.abs);
     }
     {
         SCOPED_TRACE("Tolerance with arbitrary relative");
-        auto const tol = Tolerances::from_relative(1e-5);
+        auto const tol = TolT::from_relative(1e-5);
         EXPECT_SOFT_EQ(1e-5, tol.rel);
         EXPECT_SOFT_EQ(1e-5, tol.abs);
     }
     {
         SCOPED_TRACE("Tolerance with arbitrary relative and length scale");
-        auto const tol = Tolerances::from_relative(1e-5, 0.1);
+        auto const tol = TolT::from_relative(1e-5, 0.1);
         EXPECT_SOFT_EQ(1e-5, tol.rel);
         EXPECT_SOFT_EQ(1e-6, tol.abs);
     }

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -357,9 +357,12 @@ void SimpleUnitTrackerTest::HeuristicInitResult::print_expected() const
 
 TEST_F(DetailTest, bumpcalculator)
 {
-    detail::BumpCalculator calc_bump(this->host_params().scalars);
-    EXPECT_SOFT_EQ(1e-8, calc_bump(Real3{0, 0, 0}));
-    EXPECT_SOFT_EQ(1e-8, calc_bump(Real3{1e-14, 0, 0}));
+    detail::BumpCalculator calc_bump(
+        Tolerances<>::from_relative(1e-8, /* length = */ 0.1));
+    EXPECT_SOFT_EQ(1e-9, calc_bump(Real3{0, 0, 0}));
+    EXPECT_SOFT_EQ(1e-9, calc_bump(Real3{1e-14, 0, 0}));
+    EXPECT_SOFT_EQ(2e-8, calc_bump(Real3{0, 1, 2}));
+    EXPECT_SOFT_EQ(1e-6, calc_bump(Real3{-100, 1, 2}));
     EXPECT_SOFT_EQ(1e-2, calc_bump(Real3{0, 0, 1e6}));
     EXPECT_SOFT_EQ(1e1, calc_bump(Real3{0, 1e9, 1e6}));
 }

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -358,7 +358,7 @@ void SimpleUnitTrackerTest::HeuristicInitResult::print_expected() const
 TEST_F(DetailTest, bumpcalculator)
 {
     detail::BumpCalculator calc_bump(
-        Tolerances<>::from_relative(1e-8, /* length = */ 0.1));
+        Tolerance<>::from_relative(1e-8, /* length = */ 0.1));
     EXPECT_SOFT_EQ(1e-9, calc_bump(Real3{0, 0, 0}));
     EXPECT_SOFT_EQ(1e-9, calc_bump(Real3{1e-14, 0, 0}));
     EXPECT_SOFT_EQ(2e-8, calc_bump(Real3{0, 1, 2}));


### PR DESCRIPTION
This adds a single class responsible for setting relative and absolute error uniformly over ORANGE. The absolute error is set using a "length scale" (defaulting to 1, aka 1 cm when used by Shift and Celeritas) times the relative error. The default relative error is roughly the square root of machine precision: 1e-8 for double precision, 5e-4 for single precision.

I've also added a derivation for a reasonable rule for the approximating the second-order quadratic term as zero for near-parallel tracks: the previous default isn't quite consistent with the rest of the tolerances but I'm hesitant to change it at the moment.

I unified the bounding box, bumping, and quadric tolerances to all use this class.