### PR TITLE
Simplify nearly-zero surface displacements to zero

### DIFF
--- a/src/orange/surf/SurfaceSimplifier.cc
+++ b/src/orange/surf/SurfaceSimplifier.cc
@@ -172,6 +172,12 @@ auto SurfaceSimplifier::operator()(Plane const& p)
         return Plane{n, d};
     }
 
+    if (d != 0 && SoftZero<>{tol_}(d))
+    {
+        // Snap zero-distances to zero
+        return Plane{n, 0};
+    }
+
     // No simplification performed
     return {};
 }

--- a/src/orange/surf/SurfaceSimplifier.cc
+++ b/src/orange/surf/SurfaceSimplifier.cc
@@ -111,6 +111,41 @@ ORANGE_INSTANTIATE_OP(CylCentered, CylAligned);
 
 //---------------------------------------------------------------------------//
 /*!
+ * A cone whose origin is close to any axis will be snapped to it.
+ *
+ * This uses a 1-norm for simplicity.
+ */
+template<Axis T>
+auto SurfaceSimplifier::operator()(ConeAligned<T> const& c) const
+    -> Optional<ConeAligned<T>>
+{
+    bool simplified = false;
+    Real3 origin = c.origin();
+    SoftZero const soft_zero{tol_};
+    for (auto ax : range(to_int(Axis::size_)))
+    {
+        if (origin[ax] != 0 && soft_zero(origin[ax]))
+        {
+            origin[ax] = 0;
+            simplified = true;
+        }
+    }
+
+    if (simplified)
+    {
+        return ConeAligned<T>::from_tangent_sq(origin, c.tangent_sq());
+    }
+
+    // No simplification performed
+    return {};
+}
+
+//! \cond
+ORANGE_INSTANTIATE_OP(ConeAligned, ConeAligned);
+//! \endcond
+
+//---------------------------------------------------------------------------//
+/*!
  * Plane may be flipped, adjusted, or become axis-aligned.
  *
  * If a plane has a normal of {-1, 0 + eps, 0}, it will first be truncated to

--- a/src/orange/surf/SurfaceSimplifier.hh
+++ b/src/orange/surf/SurfaceSimplifier.hh
@@ -53,6 +53,10 @@ class SurfaceSimplifier
     template<Axis T>
     Optional<CylCentered<T>> operator()(CylAligned<T> const&) const;
 
+    // Cone near origin will be snapped
+    template<Axis T>
+    Optional<ConeAligned<T>> operator()(ConeAligned<T> const&) const;
+
     // Plane may be flipped, adjusted, or become axis-aligned
     Optional<PlaneAligned<Axis::x>, PlaneAligned<Axis::y>, PlaneAligned<Axis::z>, Plane>
     operator()(Plane const&);

--- a/test/orange/surf/SurfaceSimplifier.test.cc
+++ b/test/orange/surf/SurfaceSimplifier.test.cc
@@ -190,6 +190,11 @@ TEST_F(SurfaceSimplifierTest, sphere)
 TEST_F(SurfaceSimplifierTest, cone_aligned)
 {
     this->check_unchanged(ConeX{{1, 2, 3}, 0.5});
+    this->check_simplifies_to(ConeX{{1e-7, -1e-7, 1e-9}, 0.5},
+                              ConeX{{0, 0, 0}, 0.5});
+    this->check_simplifies_to(ConeY{{10, -1e-7, 1}, 0.5},
+                              ConeY{{10, 0, 1}, 0.5});
+    this->check_unchanged(ConeX{{0, 0, 0}, 0.5});
 }
 
 TEST_F(SurfaceSimplifierTest, simple_quadric)

--- a/test/orange/surf/SurfaceSimplifier.test.cc
+++ b/test/orange/surf/SurfaceSimplifier.test.cc
@@ -20,6 +20,7 @@ namespace celeritas
 {
 namespace test
 {
+using constants::sqrt_three;
 using constants::sqrt_two;
 
 //---------------------------------------------------------------------------//
@@ -149,6 +150,7 @@ TEST_F(SurfaceSimplifierTest, cyl_aligned)
 TEST_F(SurfaceSimplifierTest, plane)
 {
     this->check_unchanged(Plane{{1 / sqrt_two, 0, 1 / sqrt_two}, 2.0});
+    this->check_unchanged(Plane{{1 / sqrt_two, 0, 1 / sqrt_two}, 0.0});
 
     this->check_round_trip<Plane>(PlaneX{4.0});
     this->check_round_trip<Plane>(PlaneY{-1.0});
@@ -158,6 +160,10 @@ TEST_F(SurfaceSimplifierTest, plane)
         Plane{{-1 / sqrt_two, -1 / sqrt_two, 0.0}, -2 * sqrt_two},
         Plane{{1 / sqrt_two, 1 / sqrt_two, 0.0}, 2 * sqrt_two},
         Sense::outside);
+
+    this->check_simplifies_to(
+        Plane{{sqrt_three / 2, 0.5, 0.0}, 1e-15},
+        Plane{{sqrt_three / 2, 0.5, 0.0}, 0 });
 
     // Check vector/displacement normalization
     Real3 n{1, 0, 1e-4};


### PR DESCRIPTION
This fixes a couple of unit tests in the SCALE surface branch because previously we were snapping nearly-zero displacements to zero, and I neglected to add that to the Celeritas surface simplifier.