### PR TITLE
Fix link errors during repeated builds when CUDA RDC is enabled

### DIFF
--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -54,11 +54,16 @@ if(CELERITAS_USE_ROOT AND CELERITAS_USE_Geant4)
     )
   endfunction(celeritas_local_root_generate_dictionary)
   celeritas_local_root_generate_dictionary(HitClassesRootInterfaces)
-  list(APPEND SOURCES
+  set(IOSOURCES
     "${CMAKE_CURRENT_BINARY_DIR}/HitClassesRootInterfaces.cxx"
     HitRootIO.cc
   )
   list(APPEND LIBRARIES ROOT::Tree)
+  celeritas_add_library(celer-g4-io ${IOSOURCES})
+  celeritas_target_link_libraries(celer-g4-io
+     ${LIBRARIES}
+  )
+  list(APPEND LIBRARIES celer-g4-io)
 endif()
 
 celeritas_add_executable(celer-g4 ${SOURCES})

--- a/cmake/CeleritasLibrary.cmake
+++ b/cmake/CeleritasLibrary.cmake
@@ -759,6 +759,9 @@ function(celeritas_target_link_libraries target)
             PRIVATE
             $<DEVICE_LINK:$<TARGET_FILE:${_libstatic}>>
           )
+          set_property(TARGET ${_target_final} APPEND
+            PROPERTY LINK_DEPENDS $<TARGET_FILE:${_libstatic}>
+          )
 
           # Also pass on the the options and definitions.
           celeritas_transfer_setting(${_libstatic} ${_target_final} COMPILE_OPTIONS)

--- a/cmake/CeleritasLibrary.cmake
+++ b/cmake/CeleritasLibrary.cmake
@@ -359,6 +359,7 @@ function(celeritas_rdc_add_library target)
   add_library(Celeritas::${target}_final ALIAS ${target}_final)
   set_target_properties(${target}_final PROPERTIES
     ${_common_props}
+    LINK_DEPENDS $<TARGET_FILE:${target}${_staticsuf}>
     CELERITAS_CUDA_LIBRARY_TYPE Final
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
     EXPORT_PROPERTIES "CELERITAS_CUDA_LIBRARY_TYPE;CELERITAS_CUDA_FINAL_LIBRARY;CELERITAS_CUDA_MIDDLE_LIBRARY;CELERITAS_CUDA_STATIC_LIBRARY"


### PR DESCRIPTION
Add explicit link dependency from ${target}_final to ${target_static}/

This allows the use of `CMAKE_LINK_DEPENDS_NO_SHARED=OFF` and still get a new linking of the final library (i.e. executing `nvlink`) if any of the RDC cuda file have changed (and thus the internal CUDA RDC infrastructure symbol have change ; they are seeded with a 'random' number which change at each compilation).