### PR TITLE
Fix build errors on macOS

### DIFF
--- a/app/celer-g4/TimerOutput.hh
+++ b/app/celer-g4/TimerOutput.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <unordered_map>
 #include <vector>
 #include <G4Event.hh>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,22 +23,13 @@ celeritas_add_library(testcel_harness
 target_compile_features(testcel_harness PUBLIC cxx_std_14)
 celeritas_target_link_libraries(testcel_harness
   PUBLIC Celeritas::corecel GTest::GTest
+  PRIVATE ${nlohmann_json_LIBRARIES}
 )
 celeritas_target_include_directories(testcel_harness
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
-
-if (CELERITAS_USE_JSON)
-  celeritas_target_include_directories(testcel_harness
-    PUBLIC
-      $<BUILD_INTERFACE:${NLOHMANN_INCLUDE_DIR}>
-  )
-  celeritas_target_link_libraries(testcel_harness
-    PUBLIC nlohmann_json::nlohmann_json
-  )
-endif()
 
 #-----------------------------------------------------------------------------#
 # HIP SUPPORT

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,16 @@ celeritas_target_include_directories(testcel_harness
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
 
+if (CELERITAS_USE_JSON)
+  celeritas_target_include_directories(testcel_harness
+    PUBLIC
+      $<BUILD_INTERFACE:${NLOHMANN_INCLUDE_DIR}>
+  )
+  celeritas_target_link_libraries(testcel_harness
+    PUBLIC nlohmann_json::nlohmann_json
+  )
+endif()
+
 #-----------------------------------------------------------------------------#
 # HIP SUPPORT
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
This PR fixes two build errors on macOS:

```
test/testdetail/TestMacrosImpl.cc:19:14: fatal error: 'nlohmann/json.hpp' file not found
#    include <nlohmann/json.hpp>
             ^~~~~~~~~~~~~~~~~~~
```

```
app/celer-g4/TimerOutput.hh:34:29: error: no template named 'unordered_map' in namespace 'std'
    using MapStrReal = std::unordered_map<std::string, real_type>;
                       ~~~~~^
```