### PR TITLE
Fix accumulated action times in celer-sim

### DIFF
--- a/app/celer-g4/TimerOutput.cc
+++ b/app/celer-g4/TimerOutput.cc
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
@@ -43,7 +43,7 @@ void TimerOutput::output(JsonPimpl* j) const
 
     auto obj = json::object();
 
-    obj["time"] = {
+    obj = {
         {"_index", "thread"},
         {"actions", action_time_},
         {"events", event_time_},

--- a/app/celer-g4/TimerOutput.hh
+++ b/app/celer-g4/TimerOutput.hh
@@ -1,5 +1,5 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//

--- a/app/celer-sim/Runner.hh
+++ b/app/celer-sim/Runner.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -44,8 +45,8 @@ class Runner
   public:
     //!@{
     //! \name Type aliases
-
     using Input = RunnerInput;
+    using MapStrReal = std::unordered_map<std::string, real_type>;
     using RunnerResult = TransporterResult;
     using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
     //!@}
@@ -65,6 +66,9 @@ class Runner
 
     // Total number of events
     size_type num_events() const;
+
+    // Get the accumulated action times
+    MapStrReal get_action_times();
 
   private:
     //// TYPES ////
@@ -94,7 +98,7 @@ class Runner
     void build_transporter_input(RunnerInput const&);
     void build_events(RunnerInput const&);
     int get_num_streams(RunnerInput const&);
-    UPTransporterBase& build_transporter(StreamId);
+    UPTransporterBase& get_transporter(StreamId);
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-sim/RunnerOutput.cc
+++ b/app/celer-sim/RunnerOutput.cc
@@ -43,8 +43,6 @@ void RunnerOutput::output(JsonPimpl* j) const
 #if CELERITAS_USE_JSON
     using json = nlohmann::json;
 
-    using MapStrReal = std::unordered_map<std::string, real_type>;
-
     auto obj = json::object();
 
     auto active = json::array();
@@ -52,7 +50,6 @@ void RunnerOutput::output(JsonPimpl* j) const
     auto initializers = json::array();
     auto num_track_slots = json::array();
     auto step_times = json::array();
-    MapStrReal action_times;
 
     for (auto const& event : result_.events)
     {
@@ -64,10 +61,6 @@ void RunnerOutput::output(JsonPimpl* j) const
         {
             step_times.push_back(event.step_times);
         }
-        for (auto& [key, val] : event.action_times)
-        {
-            action_times[key] += val;
-        }
     }
     obj["_index"] = {"event", "step"};
     obj["active"] = std::move(active);
@@ -76,7 +69,7 @@ void RunnerOutput::output(JsonPimpl* j) const
     obj["num_track_slots"] = std::move(num_track_slots);
     obj["time"] = {
         {"steps", std::move(step_times)},
-        {"actions", std::move(action_times)},
+        {"actions", result_.action_times},
         {"total", result_.total_time},
         {"setup", result_.setup_time},
     };

--- a/app/celer-sim/RunnerOutput.hh
+++ b/app/celer-sim/RunnerOutput.hh
@@ -23,10 +23,13 @@ namespace app
  */
 struct SimulationResult
 {
+    using MapStrReal = std::unordered_map<std::string, real_type>;
+
     //// DATA ////
 
     real_type total_time{};  //!< Total simulation time
     real_type setup_time{};  //!< One-time initialization cost
+    MapStrReal action_times{};  //!< Accumulated action timing
     std::vector<TransporterResult> events;  //!< Results tallied for each event
     size_type num_streams{};  //!< Number of CPU/OpenMP threads
 };

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -111,8 +111,21 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
         }
     }
 
-    // Save kernel timing if running with a single stream and if either on the
+    result.num_track_slots = stepper_->state().size();
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Transport the input primaries and all secondaries produced.
+ */
+template<MemSpace M>
+auto Transporter<M>::get_action_times() const -> MapStrReal
+{
+    // Get kernel timing if running with a single stream and if either on the
     // device with synchronization enabled or on the host
+    MapStrReal result;
+    auto const& step = *stepper_;
     auto const& action_seq = step.actions();
     if (num_streams_ == 1 && (M == MemSpace::host || action_seq.sync()))
     {
@@ -123,10 +136,9 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
         for (auto i : range(action_ptrs.size()))
         {
             auto&& label = action_ptrs[i]->label();
-            result.action_times[label] = times[i];
+            result[label] = times[i];
         }
     }
-    result.num_track_slots = stepper_->state().size();
     return result;
 }
 

--- a/app/celer-sim/Transporter.hh
+++ b/app/celer-sim/Transporter.hh
@@ -58,14 +58,12 @@ struct TransporterInput
  */
 struct TransporterResult
 {
-    using MapStrReal = std::unordered_map<std::string, real_type>;
     using VecReal = std::vector<real_type>;
     using VecCount = std::vector<size_type>;
 
     VecCount initializers;  //!< Num starting track initializers
     VecCount active;  //!< Num tracks active at beginning of step
     VecCount alive;  //!< Num living tracks at end of step
-    MapStrReal action_times{};  //!< Accumulated action timing
     VecReal step_times;  //!< Real time per step
     size_type num_track_slots{};  //!< Number of total track slots
 };
@@ -106,11 +104,20 @@ template<MemSpace M>
 class Transporter final : public TransporterBase
 {
   public:
+    //!@{
+    //! \name Type aliases
+    using MapStrReal = std::unordered_map<std::string, real_type>;
+    //!@}
+
+  public:
     // Construct from parameters
     explicit Transporter(TransporterInput inp);
 
     // Transport the input primaries and all secondaries produced
     TransporterResult operator()(SpanConstPrimary primaries) final;
+
+    // Get the accumulated action times
+    MapStrReal get_action_times() const;
 
   private:
     std::shared_ptr<Stepper<M>> stepper_;

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -138,6 +138,7 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
         }
         log_and_rethrow(std::move(capture_exception));
     }
+    result.action_times = run_stream.get_action_times();
     result.total_time = get_transport_time();
     record_mem = {};
     output->insert(std::make_shared<RunnerOutput>(std::move(result)));

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -210,8 +210,8 @@ auto LocalTransporter::GetActionTime() const -> MapStrReal
     auto const& action_seq = step_->actions();
     if (action_seq.sync() || !celeritas::device())
     {
-        // Save kernel timing if running with a single stream and if either on
-        // the device with synchronization enabled or on the host
+        // Save kernel timing if either on the device with synchronization
+        // enabled or on the host
         auto const& action_ptrs = action_seq.actions();
         auto const& time = action_seq.accum_time();
 


### PR DESCRIPTION
This fixes a problem with the accumulated action times in celer-sim (from #774) when running with a single stream and `merge_events = false`. Fortunately our regression timing results weren't affected by this since we merge the events.