### PR TITLE
Avoid maybe_unused attribute because of old GCC

### DIFF
--- a/app/celer-g4/TimerOutput.cc
+++ b/app/celer-g4/TimerOutput.cc
@@ -53,7 +53,7 @@ void TimerOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/app/celer-g4/TimerOutput.cc
+++ b/app/celer-g4/TimerOutput.cc
@@ -53,7 +53,7 @@ void TimerOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/app/celer-g4/TimerOutput.cc
+++ b/app/celer-g4/TimerOutput.cc
@@ -53,7 +53,7 @@ void TimerOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -519,7 +519,7 @@ int Runner::get_num_streams(RunnerInput const& inp)
         return num_threads;
     }
 #else
-    CELER_NEVER_UNUSED(inp);
+    CELER_DISCARD(inp);
 #endif
     return 1;
 }

--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -519,7 +519,7 @@ int Runner::get_num_streams(RunnerInput const& inp)
         return num_threads;
     }
 #else
-    (void)sizeof(inp);
+    CELER_NEVER_UNUSED(inp)
 #endif
     return 1;
 }

--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -519,7 +519,7 @@ int Runner::get_num_streams(RunnerInput const& inp)
         return num_threads;
     }
 #else
-    CELER_NEVER_UNUSED(inp)
+    CELER_NEVER_UNUSED(inp);
 #endif
     return 1;
 }

--- a/app/celer-sim/RunnerOutput.cc
+++ b/app/celer-sim/RunnerOutput.cc
@@ -84,7 +84,7 @@ void RunnerOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/app/celer-sim/RunnerOutput.cc
+++ b/app/celer-sim/RunnerOutput.cc
@@ -84,7 +84,7 @@ void RunnerOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/app/celer-sim/RunnerOutput.cc
+++ b/app/celer-sim/RunnerOutput.cc
@@ -84,7 +84,7 @@ void RunnerOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/accel/GeantStepDiagnostic.cc
+++ b/src/accel/GeantStepDiagnostic.cc
@@ -57,7 +57,7 @@ void GeantStepDiagnostic::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/accel/GeantStepDiagnostic.cc
+++ b/src/accel/GeantStepDiagnostic.cc
@@ -57,7 +57,7 @@ void GeantStepDiagnostic::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/accel/GeantStepDiagnostic.cc
+++ b/src/accel/GeantStepDiagnostic.cc
@@ -57,7 +57,7 @@ void GeantStepDiagnostic::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/accel/HepMC3PrimaryGenerator.hh
+++ b/src/accel/HepMC3PrimaryGenerator.hh
@@ -79,9 +79,9 @@ class HepMC3PrimaryGenerator final : public G4VPrimaryGenerator
 inline HepMC3PrimaryGenerator::HepMC3PrimaryGenerator(std::string const&)
 {
     CELER_NOT_CONFIGURED("HepMC3");
-    (void)sizeof(world_solid_);
-    (void)sizeof(reader_);
-    (void)sizeof(read_mutex_);
+    CELER_NEVER_UNUSED(world_solid_)
+    CELER_NEVER_UNUSED(reader_)
+    CELER_NEVER_UNUSED(read_mutex_)
 }
 
 inline void HepMC3PrimaryGenerator::GeneratePrimaryVertex(G4Event*) {}

--- a/src/accel/HepMC3PrimaryGenerator.hh
+++ b/src/accel/HepMC3PrimaryGenerator.hh
@@ -79,9 +79,9 @@ class HepMC3PrimaryGenerator final : public G4VPrimaryGenerator
 inline HepMC3PrimaryGenerator::HepMC3PrimaryGenerator(std::string const&)
 {
     CELER_NOT_CONFIGURED("HepMC3");
-    CELER_NEVER_UNUSED(world_solid_);
-    CELER_NEVER_UNUSED(reader_);
-    CELER_NEVER_UNUSED(read_mutex_);
+    CELER_DISCARD(world_solid_);
+    CELER_DISCARD(reader_);
+    CELER_DISCARD(read_mutex_);
 }
 
 inline void HepMC3PrimaryGenerator::GeneratePrimaryVertex(G4Event*) {}

--- a/src/accel/HepMC3PrimaryGenerator.hh
+++ b/src/accel/HepMC3PrimaryGenerator.hh
@@ -79,9 +79,9 @@ class HepMC3PrimaryGenerator final : public G4VPrimaryGenerator
 inline HepMC3PrimaryGenerator::HepMC3PrimaryGenerator(std::string const&)
 {
     CELER_NOT_CONFIGURED("HepMC3");
-    CELER_NEVER_UNUSED(world_solid_)
-    CELER_NEVER_UNUSED(reader_)
-    CELER_NEVER_UNUSED(read_mutex_)
+    CELER_NEVER_UNUSED(world_solid_);
+    CELER_NEVER_UNUSED(reader_);
+    CELER_NEVER_UNUSED(read_mutex_);
 }
 
 inline void HepMC3PrimaryGenerator::GeneratePrimaryVertex(G4Event*) {}

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -519,7 +519,7 @@ auto import_processes(GeantImporter::DataSelection::Flags process_flags,
                 }
             }
 #else
-            CELER_NEVER_UNUSED(gg_process)
+            CELER_NEVER_UNUSED(gg_process);
             CELER_NOT_IMPLEMENTED("GammaGeneralProcess for Geant4 < 10.6");
 #endif
         }

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -519,7 +519,7 @@ auto import_processes(GeantImporter::DataSelection::Flags process_flags,
                 }
             }
 #else
-            (void)sizeof(gg_process);
+            CELER_NEVER_UNUSED(gg_process)
             CELER_NOT_IMPLEMENTED("GammaGeneralProcess for Geant4 < 10.6");
 #endif
         }

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -519,7 +519,7 @@ auto import_processes(GeantImporter::DataSelection::Flags process_flags,
                 }
             }
 #else
-            CELER_NEVER_UNUSED(gg_process);
+            CELER_DISCARD(gg_process);
             CELER_NOT_IMPLEMENTED("GammaGeneralProcess for Geant4 < 10.6");
 #endif
         }

--- a/src/celeritas/ext/GeantImporter.hh
+++ b/src/celeritas/ext/GeantImporter.hh
@@ -122,7 +122,7 @@ inline G4VPhysicalVolume const* GeantImporter::get_world_volume()
 
 inline GeantImporter::GeantImporter(G4VPhysicalVolume const*)
 {
-    CELER_NEVER_UNUSED(world_);
+    CELER_DISCARD(world_);
     CELER_NOT_CONFIGURED("Geant4");
 }
 

--- a/src/celeritas/ext/GeantImporter.hh
+++ b/src/celeritas/ext/GeantImporter.hh
@@ -122,7 +122,7 @@ inline G4VPhysicalVolume const* GeantImporter::get_world_volume()
 
 inline GeantImporter::GeantImporter(G4VPhysicalVolume const*)
 {
-    (void)sizeof(world_);
+    CELER_NEVER_UNUSED(world_)
     CELER_NOT_CONFIGURED("Geant4");
 }
 

--- a/src/celeritas/ext/GeantImporter.hh
+++ b/src/celeritas/ext/GeantImporter.hh
@@ -122,7 +122,7 @@ inline G4VPhysicalVolume const* GeantImporter::get_world_volume()
 
 inline GeantImporter::GeantImporter(G4VPhysicalVolume const*)
 {
-    CELER_NEVER_UNUSED(world_)
+    CELER_NEVER_UNUSED(world_);
     CELER_NOT_CONFIGURED("Geant4");
 }
 

--- a/src/celeritas/ext/ScopedRootErrorHandler.hh
+++ b/src/celeritas/ext/ScopedRootErrorHandler.hh
@@ -49,8 +49,8 @@ class ScopedRootErrorHandler
 inline void ScopedRootErrorHandler::disable_signal_handler() {}
 inline ScopedRootErrorHandler::ScopedRootErrorHandler()
 {
-    (void)sizeof(previous_);
-    (void)sizeof(prev_errored_);
+    CELER_NEVER_UNUSED(previous_)
+    CELER_NEVER_UNUSED(prev_errored_)
 }
 inline ScopedRootErrorHandler::~ScopedRootErrorHandler() {}
 inline void ScopedRootErrorHandler::throw_if_errors() const {}

--- a/src/celeritas/ext/ScopedRootErrorHandler.hh
+++ b/src/celeritas/ext/ScopedRootErrorHandler.hh
@@ -49,8 +49,8 @@ class ScopedRootErrorHandler
 inline void ScopedRootErrorHandler::disable_signal_handler() {}
 inline ScopedRootErrorHandler::ScopedRootErrorHandler()
 {
-    CELER_NEVER_UNUSED(previous_);
-    CELER_NEVER_UNUSED(prev_errored_);
+    CELER_DISCARD(previous_);
+    CELER_DISCARD(prev_errored_);
 }
 inline ScopedRootErrorHandler::~ScopedRootErrorHandler() {}
 inline void ScopedRootErrorHandler::throw_if_errors() const {}

--- a/src/celeritas/ext/ScopedRootErrorHandler.hh
+++ b/src/celeritas/ext/ScopedRootErrorHandler.hh
@@ -49,8 +49,8 @@ class ScopedRootErrorHandler
 inline void ScopedRootErrorHandler::disable_signal_handler() {}
 inline ScopedRootErrorHandler::ScopedRootErrorHandler()
 {
-    CELER_NEVER_UNUSED(previous_)
-    CELER_NEVER_UNUSED(prev_errored_)
+    CELER_NEVER_UNUSED(previous_);
+    CELER_NEVER_UNUSED(prev_errored_);
 }
 inline ScopedRootErrorHandler::~ScopedRootErrorHandler() {}
 inline void ScopedRootErrorHandler::throw_if_errors() const {}

--- a/src/celeritas/geo/GeoParamsOutput.cc
+++ b/src/celeritas/geo/GeoParamsOutput.cc
@@ -77,7 +77,7 @@ void GeoParamsOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/celeritas/geo/GeoParamsOutput.cc
+++ b/src/celeritas/geo/GeoParamsOutput.cc
@@ -77,7 +77,7 @@ void GeoParamsOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/celeritas/geo/GeoParamsOutput.cc
+++ b/src/celeritas/geo/GeoParamsOutput.cc
@@ -77,7 +77,7 @@ void GeoParamsOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/celeritas/global/ActionRegistryOutput.cc
+++ b/src/celeritas/global/ActionRegistryOutput.cc
@@ -56,7 +56,7 @@ void ActionRegistryOutput::output(JsonPimpl* j) const
         {"description", std::move(description)},
     };
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/celeritas/global/ActionRegistryOutput.cc
+++ b/src/celeritas/global/ActionRegistryOutput.cc
@@ -56,7 +56,7 @@ void ActionRegistryOutput::output(JsonPimpl* j) const
         {"description", std::move(description)},
     };
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/celeritas/global/ActionRegistryOutput.cc
+++ b/src/celeritas/global/ActionRegistryOutput.cc
@@ -56,7 +56,7 @@ void ActionRegistryOutput::output(JsonPimpl* j) const
         {"description", std::move(description)},
     };
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -108,7 +108,7 @@ void KernelContextException::output(JsonPimpl* json) const
 #    undef KCE_INSERT_IF_VALID
     json->obj = std::move(j);
 #else
-    CELER_NEVER_UNUSED(json);
+    CELER_DISCARD(json);
 #endif
 }
 

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -108,7 +108,7 @@ void KernelContextException::output(JsonPimpl* json) const
 #    undef KCE_INSERT_IF_VALID
     json->obj = std::move(j);
 #else
-    (void)sizeof(json);
+    CELER_NEVER_UNUSED(json)
 #endif
 }
 

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -108,7 +108,7 @@ void KernelContextException::output(JsonPimpl* json) const
 #    undef KCE_INSERT_IF_VALID
     json->obj = std::move(j);
 #else
-    CELER_NEVER_UNUSED(json)
+    CELER_NEVER_UNUSED(json);
 #endif
 }
 

--- a/src/celeritas/io/EventReader.hh
+++ b/src/celeritas/io/EventReader.hh
@@ -81,9 +81,9 @@ std::shared_ptr<HepMC3::Reader> open_hepmc3(std::string const& filename);
 #if !CELERITAS_USE_HEPMC3
 inline EventReader::EventReader(std::string const&, SPConstParticles)
 {
-    (void)sizeof(params_);
-    (void)sizeof(reader_);
-    (void)sizeof(event_count_);
+    CELER_NEVER_UNUSED(params_)
+    CELER_NEVER_UNUSED(reader_)
+    CELER_NEVER_UNUSED(event_count_)
     CELER_NOT_CONFIGURED("HepMC3");
 }
 

--- a/src/celeritas/io/EventReader.hh
+++ b/src/celeritas/io/EventReader.hh
@@ -81,9 +81,9 @@ std::shared_ptr<HepMC3::Reader> open_hepmc3(std::string const& filename);
 #if !CELERITAS_USE_HEPMC3
 inline EventReader::EventReader(std::string const&, SPConstParticles)
 {
-    CELER_NEVER_UNUSED(params_)
-    CELER_NEVER_UNUSED(reader_)
-    CELER_NEVER_UNUSED(event_count_)
+    CELER_NEVER_UNUSED(params_);
+    CELER_NEVER_UNUSED(reader_);
+    CELER_NEVER_UNUSED(event_count_);
     CELER_NOT_CONFIGURED("HepMC3");
 }
 

--- a/src/celeritas/io/EventReader.hh
+++ b/src/celeritas/io/EventReader.hh
@@ -81,9 +81,9 @@ std::shared_ptr<HepMC3::Reader> open_hepmc3(std::string const& filename);
 #if !CELERITAS_USE_HEPMC3
 inline EventReader::EventReader(std::string const&, SPConstParticles)
 {
-    CELER_NEVER_UNUSED(params_);
-    CELER_NEVER_UNUSED(reader_);
-    CELER_NEVER_UNUSED(event_count_);
+    CELER_DISCARD(params_);
+    CELER_DISCARD(reader_);
+    CELER_DISCARD(event_count_);
     CELER_NOT_CONFIGURED("HepMC3");
 }
 

--- a/src/celeritas/io/EventWriter.hh
+++ b/src/celeritas/io/EventWriter.hh
@@ -91,10 +91,10 @@ inline EventWriter::EventWriter(std::string const& s, SPConstParticles p)
 }
 inline EventWriter::EventWriter(std::string const&, SPConstParticles, Format)
 {
-    (void)sizeof(particles_);
-    (void)sizeof(fmt_);
-    (void)sizeof(writer_);
-    (void)sizeof(event_count_);
+    CELER_NEVER_UNUSED(particles_)
+    CELER_NEVER_UNUSED(fmt_)
+    CELER_NEVER_UNUSED(writer_)
+    CELER_NEVER_UNUSED(event_count_)
     CELER_NOT_CONFIGURED("HepMC3");
 }
 

--- a/src/celeritas/io/EventWriter.hh
+++ b/src/celeritas/io/EventWriter.hh
@@ -91,10 +91,10 @@ inline EventWriter::EventWriter(std::string const& s, SPConstParticles p)
 }
 inline EventWriter::EventWriter(std::string const&, SPConstParticles, Format)
 {
-    CELER_NEVER_UNUSED(particles_);
-    CELER_NEVER_UNUSED(fmt_);
-    CELER_NEVER_UNUSED(writer_);
-    CELER_NEVER_UNUSED(event_count_);
+    CELER_DISCARD(particles_);
+    CELER_DISCARD(fmt_);
+    CELER_DISCARD(writer_);
+    CELER_DISCARD(event_count_);
     CELER_NOT_CONFIGURED("HepMC3");
 }
 

--- a/src/celeritas/io/EventWriter.hh
+++ b/src/celeritas/io/EventWriter.hh
@@ -91,10 +91,10 @@ inline EventWriter::EventWriter(std::string const& s, SPConstParticles p)
 }
 inline EventWriter::EventWriter(std::string const&, SPConstParticles, Format)
 {
-    CELER_NEVER_UNUSED(particles_)
-    CELER_NEVER_UNUSED(fmt_)
-    CELER_NEVER_UNUSED(writer_)
-    CELER_NEVER_UNUSED(event_count_)
+    CELER_NEVER_UNUSED(particles_);
+    CELER_NEVER_UNUSED(fmt_);
+    CELER_NEVER_UNUSED(writer_);
+    CELER_NEVER_UNUSED(event_count_);
     CELER_NOT_CONFIGURED("HepMC3");
 }
 

--- a/src/celeritas/io/RootEventReader.hh
+++ b/src/celeritas/io/RootEventReader.hh
@@ -77,11 +77,11 @@ class RootEventReader : public EventReaderInterface
 #if !CELERITAS_USE_ROOT
 inline RootEventReader::RootEventReader(std::string const&, SPConstParticles)
 {
-    CELER_NEVER_UNUSED(params_)
-    CELER_NEVER_UNUSED(entry_count_)
-    CELER_NEVER_UNUSED(num_entries_)
-    CELER_NEVER_UNUSED(tfile_)
-    CELER_NEVER_UNUSED(ttree_)
+    CELER_NEVER_UNUSED(params_);
+    CELER_NEVER_UNUSED(entry_count_);
+    CELER_NEVER_UNUSED(num_entries_);
+    CELER_NEVER_UNUSED(tfile_);
+    CELER_NEVER_UNUSED(ttree_);
     CELER_NOT_CONFIGURED("ROOT");
 }
 

--- a/src/celeritas/io/RootEventReader.hh
+++ b/src/celeritas/io/RootEventReader.hh
@@ -77,11 +77,11 @@ class RootEventReader : public EventReaderInterface
 #if !CELERITAS_USE_ROOT
 inline RootEventReader::RootEventReader(std::string const&, SPConstParticles)
 {
-    CELER_NEVER_UNUSED(params_);
-    CELER_NEVER_UNUSED(entry_count_);
-    CELER_NEVER_UNUSED(num_entries_);
-    CELER_NEVER_UNUSED(tfile_);
-    CELER_NEVER_UNUSED(ttree_);
+    CELER_DISCARD(params_);
+    CELER_DISCARD(entry_count_);
+    CELER_DISCARD(num_entries_);
+    CELER_DISCARD(tfile_);
+    CELER_DISCARD(ttree_);
     CELER_NOT_CONFIGURED("ROOT");
 }
 

--- a/src/celeritas/io/RootEventReader.hh
+++ b/src/celeritas/io/RootEventReader.hh
@@ -77,11 +77,11 @@ class RootEventReader : public EventReaderInterface
 #if !CELERITAS_USE_ROOT
 inline RootEventReader::RootEventReader(std::string const&, SPConstParticles)
 {
-    (void)sizeof(params_);
-    (void)sizeof(entry_count_);
-    (void)sizeof(num_entries_);
-    (void)sizeof(tfile_);
-    (void)sizeof(ttree_);
+    CELER_NEVER_UNUSED(params_)
+    CELER_NEVER_UNUSED(entry_count_)
+    CELER_NEVER_UNUSED(num_entries_)
+    CELER_NEVER_UNUSED(tfile_)
+    CELER_NEVER_UNUSED(ttree_)
     CELER_NOT_CONFIGURED("ROOT");
 }
 

--- a/src/celeritas/io/RootEventWriter.hh
+++ b/src/celeritas/io/RootEventWriter.hh
@@ -75,11 +75,11 @@ class RootEventWriter : public EventWriterInterface
 #if !CELERITAS_USE_ROOT
 inline RootEventWriter::RootEventWriter(SPRootFileManager, SPConstParticles)
 {
-    (void)sizeof(tfile_mgr_);
-    (void)sizeof(params_);
-    (void)sizeof(event_id_);
-    (void)sizeof(ttree_);
-    (void)sizeof(primary_);
+    CELER_NEVER_UNUSED(tfile_mgr_)
+    CELER_NEVER_UNUSED(params_)
+    CELER_NEVER_UNUSED(event_id_)
+    CELER_NEVER_UNUSED(ttree_)
+    CELER_NEVER_UNUSED(primary_)
     CELER_NOT_CONFIGURED("ROOT");
 }
 

--- a/src/celeritas/io/RootEventWriter.hh
+++ b/src/celeritas/io/RootEventWriter.hh
@@ -75,11 +75,11 @@ class RootEventWriter : public EventWriterInterface
 #if !CELERITAS_USE_ROOT
 inline RootEventWriter::RootEventWriter(SPRootFileManager, SPConstParticles)
 {
-    CELER_NEVER_UNUSED(tfile_mgr_);
-    CELER_NEVER_UNUSED(params_);
-    CELER_NEVER_UNUSED(event_id_);
-    CELER_NEVER_UNUSED(ttree_);
-    CELER_NEVER_UNUSED(primary_);
+    CELER_DISCARD(tfile_mgr_);
+    CELER_DISCARD(params_);
+    CELER_DISCARD(event_id_);
+    CELER_DISCARD(ttree_);
+    CELER_DISCARD(primary_);
     CELER_NOT_CONFIGURED("ROOT");
 }
 

--- a/src/celeritas/io/RootEventWriter.hh
+++ b/src/celeritas/io/RootEventWriter.hh
@@ -75,11 +75,11 @@ class RootEventWriter : public EventWriterInterface
 #if !CELERITAS_USE_ROOT
 inline RootEventWriter::RootEventWriter(SPRootFileManager, SPConstParticles)
 {
-    CELER_NEVER_UNUSED(tfile_mgr_)
-    CELER_NEVER_UNUSED(params_)
-    CELER_NEVER_UNUSED(event_id_)
-    CELER_NEVER_UNUSED(ttree_)
-    CELER_NEVER_UNUSED(primary_)
+    CELER_NEVER_UNUSED(tfile_mgr_);
+    CELER_NEVER_UNUSED(params_);
+    CELER_NEVER_UNUSED(event_id_);
+    CELER_NEVER_UNUSED(ttree_);
+    CELER_NEVER_UNUSED(primary_);
     CELER_NOT_CONFIGURED("ROOT");
 }
 

--- a/src/celeritas/mat/MaterialParamsOutput.cc
+++ b/src/celeritas/mat/MaterialParamsOutput.cc
@@ -182,7 +182,7 @@ void MaterialParamsOutput::output(JsonPimpl* j) const
     obj["_units"] = std::move(units);
     j->obj = std::move(obj);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/celeritas/mat/MaterialParamsOutput.cc
+++ b/src/celeritas/mat/MaterialParamsOutput.cc
@@ -182,7 +182,7 @@ void MaterialParamsOutput::output(JsonPimpl* j) const
     obj["_units"] = std::move(units);
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/celeritas/mat/MaterialParamsOutput.cc
+++ b/src/celeritas/mat/MaterialParamsOutput.cc
@@ -182,7 +182,7 @@ void MaterialParamsOutput::output(JsonPimpl* j) const
     obj["_units"] = std::move(units);
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/celeritas/phys/ParticleParamsOutput.cc
+++ b/src/celeritas/phys/ParticleParamsOutput.cc
@@ -73,7 +73,7 @@ void ParticleParamsOutput::output(JsonPimpl* j) const
         {"is_antiparticle", std::move(is_antiparticle)},
     };
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/celeritas/phys/ParticleParamsOutput.cc
+++ b/src/celeritas/phys/ParticleParamsOutput.cc
@@ -73,7 +73,7 @@ void ParticleParamsOutput::output(JsonPimpl* j) const
         {"is_antiparticle", std::move(is_antiparticle)},
     };
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/celeritas/phys/ParticleParamsOutput.cc
+++ b/src/celeritas/phys/ParticleParamsOutput.cc
@@ -73,7 +73,7 @@ void ParticleParamsOutput::output(JsonPimpl* j) const
         {"is_antiparticle", std::move(is_antiparticle)},
     };
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/celeritas/phys/PhysicsParamsOutput.cc
+++ b/src/celeritas/phys/PhysicsParamsOutput.cc
@@ -113,7 +113,7 @@ void PhysicsParamsOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/celeritas/phys/PhysicsParamsOutput.cc
+++ b/src/celeritas/phys/PhysicsParamsOutput.cc
@@ -113,7 +113,7 @@ void PhysicsParamsOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/celeritas/phys/PhysicsParamsOutput.cc
+++ b/src/celeritas/phys/PhysicsParamsOutput.cc
@@ -113,7 +113,7 @@ void PhysicsParamsOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/celeritas/user/ActionDiagnostic.cc
+++ b/src/celeritas/user/ActionDiagnostic.cc
@@ -116,7 +116,7 @@ void ActionDiagnostic::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/celeritas/user/ActionDiagnostic.cc
+++ b/src/celeritas/user/ActionDiagnostic.cc
@@ -116,7 +116,7 @@ void ActionDiagnostic::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/celeritas/user/ActionDiagnostic.cc
+++ b/src/celeritas/user/ActionDiagnostic.cc
@@ -116,7 +116,7 @@ void ActionDiagnostic::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/celeritas/user/SimpleCalo.cc
+++ b/src/celeritas/user/SimpleCalo.cc
@@ -191,7 +191,7 @@ void SimpleCalo::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/celeritas/user/SimpleCalo.cc
+++ b/src/celeritas/user/SimpleCalo.cc
@@ -191,7 +191,7 @@ void SimpleCalo::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/celeritas/user/SimpleCalo.cc
+++ b/src/celeritas/user/SimpleCalo.cc
@@ -191,7 +191,7 @@ void SimpleCalo::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/celeritas/user/StepDiagnostic.cc
+++ b/src/celeritas/user/StepDiagnostic.cc
@@ -110,7 +110,7 @@ void StepDiagnostic::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/celeritas/user/StepDiagnostic.cc
+++ b/src/celeritas/user/StepDiagnostic.cc
@@ -110,7 +110,7 @@ void StepDiagnostic::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/celeritas/user/StepDiagnostic.cc
+++ b/src/celeritas/user/StepDiagnostic.cc
@@ -110,7 +110,7 @@ void StepDiagnostic::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -253,11 +253,11 @@
             }                                                      \
         } while (0)
 #else
-#    define CELER_CUDA_CALL(STATEMENT)                     \
-        do                                                 \
-        {                                                  \
-            CELER_NOT_CONFIGURED("CUDA");                  \
-            (void)sizeof(celeritas_device_runtime_api_h_); \
+#    define CELER_CUDA_CALL(STATEMENT)                          \
+        do                                                      \
+        {                                                       \
+            CELER_NOT_CONFIGURED("CUDA");                       \
+            CELER_NEVER_UNUSED(celeritas_device_runtime_api_h_) \
         } while (0)
 #endif
 
@@ -295,11 +295,11 @@
             }                                                      \
         } while (0)
 #else
-#    define CELER_HIP_CALL(STATEMENT)                      \
-        do                                                 \
-        {                                                  \
-            CELER_NOT_CONFIGURED("HIP");                   \
-            (void)sizeof(celeritas_device_runtime_api_h_); \
+#    define CELER_HIP_CALL(STATEMENT)                           \
+        do                                                      \
+        {                                                       \
+            CELER_NOT_CONFIGURED("HIP");                        \
+            CELER_NEVER_UNUSED(celeritas_device_runtime_api_h_) \
         } while (0)
 #endif
 
@@ -325,11 +325,11 @@
 #elif CELERITAS_USE_HIP
 #    define CELER_DEVICE_CALL_PREFIX(STMT) CELER_HIP_CALL(hip##STMT)
 #else
-#    define CELER_DEVICE_CALL_PREFIX(STMT)                 \
-        do                                                 \
-        {                                                  \
-            CELER_NOT_CONFIGURED("CUDA or HIP");           \
-            (void)sizeof(celeritas_device_runtime_api_h_); \
+#    define CELER_DEVICE_CALL_PREFIX(STMT)                      \
+        do                                                      \
+        {                                                       \
+            CELER_NOT_CONFIGURED("CUDA or HIP");                \
+            CELER_NEVER_UNUSED(celeritas_device_runtime_api_h_) \
         } while (0)
 #endif
 

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -253,11 +253,11 @@
             }                                                      \
         } while (0)
 #else
-#    define CELER_CUDA_CALL(STATEMENT)                          \
-        do                                                      \
-        {                                                       \
-            CELER_NOT_CONFIGURED("CUDA");                       \
-            CELER_NEVER_UNUSED(celeritas_device_runtime_api_h_) \
+#    define CELER_CUDA_CALL(STATEMENT)                     \
+        do                                                 \
+        {                                                  \
+            CELER_NOT_CONFIGURED("CUDA");                  \
+            CELER_DISCARD(celeritas_device_runtime_api_h_) \
         } while (0)
 #endif
 
@@ -295,11 +295,11 @@
             }                                                      \
         } while (0)
 #else
-#    define CELER_HIP_CALL(STATEMENT)                           \
-        do                                                      \
-        {                                                       \
-            CELER_NOT_CONFIGURED("HIP");                        \
-            CELER_NEVER_UNUSED(celeritas_device_runtime_api_h_) \
+#    define CELER_HIP_CALL(STATEMENT)                      \
+        do                                                 \
+        {                                                  \
+            CELER_NOT_CONFIGURED("HIP");                   \
+            CELER_DISCARD(celeritas_device_runtime_api_h_) \
         } while (0)
 #endif
 
@@ -325,11 +325,11 @@
 #elif CELERITAS_USE_HIP
 #    define CELER_DEVICE_CALL_PREFIX(STMT) CELER_HIP_CALL(hip##STMT)
 #else
-#    define CELER_DEVICE_CALL_PREFIX(STMT)                      \
-        do                                                      \
-        {                                                       \
-            CELER_NOT_CONFIGURED("CUDA or HIP");                \
-            CELER_NEVER_UNUSED(celeritas_device_runtime_api_h_) \
+#    define CELER_DEVICE_CALL_PREFIX(STMT)                 \
+        do                                                 \
+        {                                                  \
+            CELER_NOT_CONFIGURED("CUDA or HIP");           \
+            CELER_DISCARD(celeritas_device_runtime_api_h_) \
         } while (0)
 #endif
 

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -231,6 +231,6 @@
  * The argument is an unevaluated operand which will generate no code but force
  * the expression to be used.
  */
-#define CELER_NEVER_UNUSED(CODE) static_cast<void>(sizeof(CODE))
+#define CELER_NEVER_UNUSED(CODE) static_cast<void>(sizeof(CODE));
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -225,4 +225,12 @@
     CLS(CLS&&) = delete;                 \
     CLS& operator=(CLS&&) = delete
 
+/*!
+ * \def CELER_MARK_USED
+ *
+ * The argument is an unevaluated operand which will generate no code but force
+ * the expression to be used.
+ */
+#define CELER_NEVER_UNUSED(CODE) static_cast<void>(sizeof(CODE))
+
 //---------------------------------------------------------------------------//

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -231,6 +231,6 @@
  * The argument is an unevaluated operand which will generate no code but force
  * the expression to be used.
  */
-#define CELER_NEVER_UNUSED(CODE) static_cast<void>(sizeof(CODE));
+#define CELER_DISCARD(CODE) static_cast<void>(sizeof(CODE));
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -225,16 +225,4 @@
     CLS(CLS&&) = delete;                 \
     CLS& operator=(CLS&&) = delete
 
-/*!
- * \def CELER_UNUSED_UNLESS_DEVICE
- *
- * GCC 8 and 9 are known to print a warning for "maybe unused" variables that
- * are actually used (after preprocessor logic).
- */
-#if CELER_USE_DEVICE
-#    define CELER_UNUSED_UNLESS_DEVICE
-#else
-#    define CELER_UNUSED_UNLESS_DEVICE [[maybe_unused]]
-#endif
-
 //---------------------------------------------------------------------------//

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -226,10 +226,12 @@
     CLS& operator=(CLS&&) = delete
 
 /*!
- * \def CELER_MARK_USED
+ * \def CELER_DISCARD
  *
  * The argument is an unevaluated operand which will generate no code but force
- * the expression to be used.
+ * the expression to be used. This is used in place of the \code
+ * [[maybe_unused]] \endcode attribute, which actually generates warnings in
+ * older versions of GCC.
  */
 #define CELER_DISCARD(CODE) static_cast<void>(sizeof(CODE));
 

--- a/src/corecel/data/Copier.cc
+++ b/src/corecel/data/Copier.cc
@@ -70,7 +70,7 @@ void copy_bytes(MemSpace dstmem,
         std::memcpy(dst, src, count);
         return;
     }
-    CELER_NEVER_UNUSED(stream)
+    CELER_NEVER_UNUSED(stream);
     CELER_DEVICE_CALL_PREFIX(
         MemcpyAsync(dst,
                     src,

--- a/src/corecel/data/Copier.cc
+++ b/src/corecel/data/Copier.cc
@@ -18,6 +18,7 @@ namespace celeritas
 {
 namespace
 {
+//---------------------------------------------------------------------------//
 
 #if CELER_USE_DEVICE
 inline auto to_memcpy_kind(MemSpace src, MemSpace dst)
@@ -62,13 +63,14 @@ void copy_bytes(MemSpace dstmem,
                 MemSpace srcmem,
                 void const* src,
                 std::size_t count,
-                CELER_UNUSED_UNLESS_DEVICE StreamId stream)
+                StreamId stream)
 {
     if (srcmem == MemSpace::host && dstmem == MemSpace::host)
     {
         std::memcpy(dst, src, count);
         return;
     }
+    (void)sizeof(stream);
     CELER_DEVICE_CALL_PREFIX(
         MemcpyAsync(dst,
                     src,

--- a/src/corecel/data/Copier.cc
+++ b/src/corecel/data/Copier.cc
@@ -70,7 +70,7 @@ void copy_bytes(MemSpace dstmem,
         std::memcpy(dst, src, count);
         return;
     }
-    CELER_NEVER_UNUSED(stream);
+    CELER_DISCARD(stream);
     CELER_DEVICE_CALL_PREFIX(
         MemcpyAsync(dst,
                     src,

--- a/src/corecel/data/Copier.cc
+++ b/src/corecel/data/Copier.cc
@@ -70,7 +70,7 @@ void copy_bytes(MemSpace dstmem,
         std::memcpy(dst, src, count);
         return;
     }
-    (void)sizeof(stream);
+    CELER_NEVER_UNUSED(stream)
     CELER_DEVICE_CALL_PREFIX(
         MemcpyAsync(dst,
                     src,

--- a/src/corecel/io/BuildOutput.cc
+++ b/src/corecel/io/BuildOutput.cc
@@ -65,7 +65,7 @@ void BuildOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/corecel/io/BuildOutput.cc
+++ b/src/corecel/io/BuildOutput.cc
@@ -65,7 +65,7 @@ void BuildOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/corecel/io/BuildOutput.cc
+++ b/src/corecel/io/BuildOutput.cc
@@ -65,7 +65,7 @@ void BuildOutput::output(JsonPimpl* j) const
 
     j->obj = std::move(obj);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/corecel/io/ExceptionOutput.cc
+++ b/src/corecel/io/ExceptionOutput.cc
@@ -122,7 +122,7 @@ void ExceptionOutput::output(JsonPimpl* j) const
     CELER_EXPECT(output_);
     j->obj = output_->obj;
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
 #endif
 }
 

--- a/src/corecel/io/ExceptionOutput.cc
+++ b/src/corecel/io/ExceptionOutput.cc
@@ -122,7 +122,7 @@ void ExceptionOutput::output(JsonPimpl* j) const
     CELER_EXPECT(output_);
     j->obj = output_->obj;
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
 #endif
 }
 

--- a/src/corecel/io/ExceptionOutput.cc
+++ b/src/corecel/io/ExceptionOutput.cc
@@ -122,7 +122,7 @@ void ExceptionOutput::output(JsonPimpl* j) const
     CELER_EXPECT(output_);
     j->obj = output_->obj;
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
 #endif
 }
 

--- a/src/corecel/io/JsonPimpl.hh
+++ b/src/corecel/io/JsonPimpl.hh
@@ -28,7 +28,7 @@ namespace celeritas
 #if CELERITAS_USE_JSON
         json->obj = value_;
 #else
-        CELER_NEVER_UNUSED(json);
+        CELER_DISCARD(json);
 #endif
     }
  * \endcode

--- a/src/corecel/io/JsonPimpl.hh
+++ b/src/corecel/io/JsonPimpl.hh
@@ -28,7 +28,7 @@ namespace celeritas
 #if CELERITAS_USE_JSON
         json->obj = value_;
 #else
-        (void)sizeof(json);
+        CELER_NEVER_UNUSED(json)
 #endif
     }
  * \endcode

--- a/src/corecel/io/JsonPimpl.hh
+++ b/src/corecel/io/JsonPimpl.hh
@@ -28,7 +28,7 @@ namespace celeritas
 #if CELERITAS_USE_JSON
         json->obj = value_;
 #else
-        CELER_NEVER_UNUSED(json)
+        CELER_NEVER_UNUSED(json);
 #endif
     }
  * \endcode

--- a/src/corecel/io/OutputInterface.cc
+++ b/src/corecel/io/OutputInterface.cc
@@ -45,7 +45,7 @@ std::string to_string(OutputInterface const& output)
     output.output(&json_wrap);
     return json_wrap.obj.dump();
 #else
-    CELER_NEVER_UNUSED(output)
+    CELER_NEVER_UNUSED(output);
     return "\"output unavailable\"";
 #endif
 }

--- a/src/corecel/io/OutputInterface.cc
+++ b/src/corecel/io/OutputInterface.cc
@@ -45,7 +45,7 @@ std::string to_string(OutputInterface const& output)
     output.output(&json_wrap);
     return json_wrap.obj.dump();
 #else
-    CELER_NEVER_UNUSED(output);
+    CELER_DISCARD(output);
     return "\"output unavailable\"";
 #endif
 }

--- a/src/corecel/io/OutputInterface.cc
+++ b/src/corecel/io/OutputInterface.cc
@@ -45,7 +45,7 @@ std::string to_string(OutputInterface const& output)
     output.output(&json_wrap);
     return json_wrap.obj.dump();
 #else
-    (void)sizeof(output);
+    CELER_NEVER_UNUSED(output)
     return "\"output unavailable\"";
 #endif
 }

--- a/src/corecel/io/OutputRegistry.cc
+++ b/src/corecel/io/OutputRegistry.cc
@@ -88,7 +88,7 @@ void OutputRegistry::output(JsonPimpl* j) const
 
     j->obj = std::move(result);
 #else
-    (void)sizeof(j);
+    CELER_NEVER_UNUSED(j)
     CELER_NOT_CONFIGURED("nljson");
 #endif
 }

--- a/src/corecel/io/OutputRegistry.cc
+++ b/src/corecel/io/OutputRegistry.cc
@@ -88,7 +88,7 @@ void OutputRegistry::output(JsonPimpl* j) const
 
     j->obj = std::move(result);
 #else
-    CELER_NEVER_UNUSED(j)
+    CELER_NEVER_UNUSED(j);
     CELER_NOT_CONFIGURED("nljson");
 #endif
 }

--- a/src/corecel/io/OutputRegistry.cc
+++ b/src/corecel/io/OutputRegistry.cc
@@ -88,7 +88,7 @@ void OutputRegistry::output(JsonPimpl* j) const
 
     j->obj = std::move(result);
 #else
-    CELER_NEVER_UNUSED(j);
+    CELER_DISCARD(j);
     CELER_NOT_CONFIGURED("nljson");
 #endif
 }

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -414,7 +414,7 @@ CELER_CONSTEXPR_FUNCTION T ipow(T v) noexcept
 {
     if constexpr (N == 0)
     {
-        CELER_NEVER_UNUSED(v)  // Suppress warning in older compilers
+        CELER_DISCARD(v)  // Suppress warning in older compilers
         return 1;
     }
     else if constexpr (N % 2 == 0)

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -414,7 +414,7 @@ CELER_CONSTEXPR_FUNCTION T ipow(T v) noexcept
 {
     if constexpr (N == 0)
     {
-        (void)sizeof(v);  // Suppress warning in older compilers
+        CELER_NEVER_UNUSED(v)  // Suppress warning in older compilers
         return 1;
     }
     else if constexpr (N % 2 == 0)

--- a/src/corecel/sys/KernelAttributes.hh
+++ b/src/corecel/sys/KernelAttributes.hh
@@ -106,7 +106,7 @@ KernelAttributes make_kernel_attributes(F* func, unsigned int threads_per_block)
         &result.heap_size, CELER_DEVICE_PREFIX(LimitMallocHeapSize)));
 
 #else
-    CELER_NEVER_UNUSED(func)
+    CELER_NEVER_UNUSED(func);
     CELER_ASSERT_UNREACHABLE();
 #endif
     return result;

--- a/src/corecel/sys/KernelAttributes.hh
+++ b/src/corecel/sys/KernelAttributes.hh
@@ -106,7 +106,7 @@ KernelAttributes make_kernel_attributes(F* func, unsigned int threads_per_block)
         &result.heap_size, CELER_DEVICE_PREFIX(LimitMallocHeapSize)));
 
 #else
-    CELER_NEVER_UNUSED(func);
+    CELER_DISCARD(func);
     CELER_ASSERT_UNREACHABLE();
 #endif
     return result;

--- a/src/corecel/sys/KernelAttributes.hh
+++ b/src/corecel/sys/KernelAttributes.hh
@@ -106,7 +106,7 @@ KernelAttributes make_kernel_attributes(F* func, unsigned int threads_per_block)
         &result.heap_size, CELER_DEVICE_PREFIX(LimitMallocHeapSize)));
 
 #else
-    (void)sizeof(func);
+    CELER_NEVER_UNUSED(func)
     CELER_ASSERT_UNREACHABLE();
 #endif
     return result;

--- a/src/corecel/sys/KernelParamCalculator.device.hh
+++ b/src/corecel/sys/KernelParamCalculator.device.hh
@@ -55,7 +55,7 @@
         CELER_NOT_CONFIGURED("CUDA or HIP");                                   \
         CELER_NEVER_UNUSED(GRID)                                               \
         CELER_NEVER_UNUSED(KERNEL)                                             \
-        CELER_NEVER_UNUSED(__VA_ARGS__)
+        CELER_NEVER_UNUSED(__VA_ARGS__);
 #endif
 
 namespace celeritas

--- a/src/corecel/sys/KernelParamCalculator.device.hh
+++ b/src/corecel/sys/KernelParamCalculator.device.hh
@@ -53,9 +53,9 @@
 #else
 #    define CELER_LAUNCH_KERNEL_IMPL(KERNEL, GRID, BLOCK, SHARED, STREAM, ...) \
         CELER_NOT_CONFIGURED("CUDA or HIP");                                   \
-        (void)sizeof(GRID);                                                    \
-        (void)sizeof(KERNEL);                                                  \
-        (void)sizeof(__VA_ARGS__);
+        CELER_NEVER_UNUSED(GRID)                                               \
+        CELER_NEVER_UNUSED(KERNEL)                                             \
+        CELER_NEVER_UNUSED(__VA_ARGS__)
 #endif
 
 namespace celeritas

--- a/src/corecel/sys/KernelParamCalculator.device.hh
+++ b/src/corecel/sys/KernelParamCalculator.device.hh
@@ -53,9 +53,9 @@
 #else
 #    define CELER_LAUNCH_KERNEL_IMPL(KERNEL, GRID, BLOCK, SHARED, STREAM, ...) \
         CELER_NOT_CONFIGURED("CUDA or HIP");                                   \
-        CELER_NEVER_UNUSED(GRID)                                               \
-        CELER_NEVER_UNUSED(KERNEL)                                             \
-        CELER_NEVER_UNUSED(__VA_ARGS__);
+        CELER_DISCARD(GRID)                                                    \
+        CELER_DISCARD(KERNEL)                                                  \
+        CELER_DISCARD(__VA_ARGS__);
 #endif
 
 namespace celeritas

--- a/src/corecel/sys/Stream.cc
+++ b/src/corecel/sys/Stream.cc
@@ -25,7 +25,7 @@ template<class Pointer>
 auto AsyncMemoryResource<Pointer>::do_allocate(std::size_t bytes, std::size_t)
     -> pointer
 {
-    (void)sizeof(bytes);
+    CELER_NEVER_UNUSED(bytes)
     void* ret;
     CELER_DEVICE_CALL_PREFIX(MallocAsync(&ret, bytes, stream_));
     return static_cast<pointer>(ret);
@@ -40,7 +40,7 @@ void AsyncMemoryResource<Pointer>::do_deallocate(pointer p,
                                                  std::size_t,
                                                  std::size_t)
 {
-    (void)sizeof(p);
+    CELER_NEVER_UNUSED(p)
     try
     {
         CELER_DEVICE_CALL_PREFIX(FreeAsync(p, stream_));

--- a/src/corecel/sys/Stream.cc
+++ b/src/corecel/sys/Stream.cc
@@ -22,9 +22,10 @@ namespace celeritas
  * Allocate device memory.
  */
 template<class Pointer>
-auto AsyncMemoryResource<Pointer>::do_allocate(
-    CELER_UNUSED_UNLESS_DEVICE std::size_t bytes, std::size_t) -> pointer
+auto AsyncMemoryResource<Pointer>::do_allocate(std::size_t bytes, std::size_t)
+    -> pointer
 {
+    (void)sizeof(bytes);
     void* ret;
     CELER_DEVICE_CALL_PREFIX(MallocAsync(&ret, bytes, stream_));
     return static_cast<pointer>(ret);
@@ -35,9 +36,11 @@ auto AsyncMemoryResource<Pointer>::do_allocate(
  * Deallocate device memory.
  */
 template<class Pointer>
-void AsyncMemoryResource<Pointer>::do_deallocate(
-    CELER_UNUSED_UNLESS_DEVICE pointer p, std::size_t, std::size_t)
+void AsyncMemoryResource<Pointer>::do_deallocate(pointer p,
+                                                 std::size_t,
+                                                 std::size_t)
 {
+    (void)sizeof(p);
     try
     {
         CELER_DEVICE_CALL_PREFIX(FreeAsync(p, stream_));

--- a/src/corecel/sys/Stream.cc
+++ b/src/corecel/sys/Stream.cc
@@ -25,7 +25,7 @@ template<class Pointer>
 auto AsyncMemoryResource<Pointer>::do_allocate(std::size_t bytes, std::size_t)
     -> pointer
 {
-    CELER_NEVER_UNUSED(bytes);
+    CELER_DISCARD(bytes);
     void* ret;
     CELER_DEVICE_CALL_PREFIX(MallocAsync(&ret, bytes, stream_));
     return static_cast<pointer>(ret);
@@ -40,7 +40,7 @@ void AsyncMemoryResource<Pointer>::do_deallocate(pointer p,
                                                  std::size_t,
                                                  std::size_t)
 {
-    CELER_NEVER_UNUSED(p);
+    CELER_DISCARD(p);
     try
     {
         CELER_DEVICE_CALL_PREFIX(FreeAsync(p, stream_));

--- a/src/corecel/sys/Stream.cc
+++ b/src/corecel/sys/Stream.cc
@@ -25,7 +25,7 @@ template<class Pointer>
 auto AsyncMemoryResource<Pointer>::do_allocate(std::size_t bytes, std::size_t)
     -> pointer
 {
-    CELER_NEVER_UNUSED(bytes)
+    CELER_NEVER_UNUSED(bytes);
     void* ret;
     CELER_DEVICE_CALL_PREFIX(MallocAsync(&ret, bytes, stream_));
     return static_cast<pointer>(ret);
@@ -40,7 +40,7 @@ void AsyncMemoryResource<Pointer>::do_deallocate(pointer p,
                                                  std::size_t,
                                                  std::size_t)
 {
-    CELER_NEVER_UNUSED(p)
+    CELER_NEVER_UNUSED(p);
     try
     {
         CELER_DEVICE_CALL_PREFIX(FreeAsync(p, stream_));

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -203,7 +203,7 @@ void NestedTest::build_orange()
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
     geo_params_ = std::move(geo);
 #else
-    (void)sizeof(geo);
+    CELER_NEVER_UNUSED(geo)
 #endif
 }
 

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -156,7 +156,8 @@ void NestedTest::build_vecgeom()
 #if CELERITAS_USE_VECGEOM
     auto geo = std::make_shared<VecgeomParams>(physical_.front());
 #else
-    [[maybe_unused]] int geo;
+    int geo;
+    CELER_NEVER_UNUSED(geo);
 #endif
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM
     geo_params_ = std::move(geo);

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -204,7 +204,7 @@ void NestedTest::build_orange()
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
     geo_params_ = std::move(geo);
 #else
-    CELER_NEVER_UNUSED(geo)
+    CELER_NEVER_UNUSED(geo);
 #endif
 }
 

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -157,7 +157,7 @@ void NestedTest::build_vecgeom()
     auto geo = std::make_shared<VecgeomParams>(physical_.front());
 #else
     int geo;
-    CELER_NEVER_UNUSED(geo);
+    CELER_DISCARD(geo);
 #endif
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM
     geo_params_ = std::move(geo);
@@ -204,7 +204,7 @@ void NestedTest::build_orange()
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
     geo_params_ = std::move(geo);
 #else
-    CELER_NEVER_UNUSED(geo);
+    CELER_DISCARD(geo);
 #endif
 }
 

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -40,7 +40,7 @@ std::string get_json_str(KernelContextException const& e)
     e.output(&jp);
     return jp.obj.dump();
 #else
-    CELER_NEVER_UNUSED(e)
+    CELER_NEVER_UNUSED(e);
     return {};
 #endif
 }

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -40,7 +40,7 @@ std::string get_json_str(KernelContextException const& e)
     e.output(&jp);
     return jp.obj.dump();
 #else
-    CELER_NEVER_UNUSED(e);
+    CELER_DISCARD(e);
     return {};
 #endif
 }

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -40,7 +40,7 @@ std::string get_json_str(KernelContextException const& e)
     e.output(&jp);
     return jp.obj.dump();
 #else
-    (void)sizeof(e);
+    CELER_NEVER_UNUSED(e)
     return {};
 #endif
 }

--- a/test/corecel/io/OutputRegistry.test.cc
+++ b/test/corecel/io/OutputRegistry.test.cc
@@ -40,8 +40,8 @@ class TestInterface final : public OutputInterface
 #if CELERITAS_USE_JSON
         json->obj = value_;
 #else
-        (void)sizeof(json);
-        (void)sizeof(value_);
+        CELER_NEVER_UNUSED(json)
+        CELER_NEVER_UNUSED(value_)
 #endif
     }
 
@@ -71,10 +71,10 @@ class MockKernelContextException : public RichContextException
         json->obj["event"] = event_;
         json->obj["track"] = track_;
 #else
-        (void)sizeof(json);
-        (void)sizeof(thread_);
-        (void)sizeof(event_);
-        (void)sizeof(track_);
+        CELER_NEVER_UNUSED(json)
+        CELER_NEVER_UNUSED(thread_)
+        CELER_NEVER_UNUSED(event_)
+        CELER_NEVER_UNUSED(track_)
 #endif
     }
 

--- a/test/corecel/io/OutputRegistry.test.cc
+++ b/test/corecel/io/OutputRegistry.test.cc
@@ -40,8 +40,8 @@ class TestInterface final : public OutputInterface
 #if CELERITAS_USE_JSON
         json->obj = value_;
 #else
-        CELER_NEVER_UNUSED(json);
-        CELER_NEVER_UNUSED(value_);
+        CELER_DISCARD(json);
+        CELER_DISCARD(value_);
 #endif
     }
 
@@ -71,10 +71,10 @@ class MockKernelContextException : public RichContextException
         json->obj["event"] = event_;
         json->obj["track"] = track_;
 #else
-        CELER_NEVER_UNUSED(json);
-        CELER_NEVER_UNUSED(thread_);
-        CELER_NEVER_UNUSED(event_);
-        CELER_NEVER_UNUSED(track_);
+        CELER_DISCARD(json);
+        CELER_DISCARD(thread_);
+        CELER_DISCARD(event_);
+        CELER_DISCARD(track_);
 #endif
     }
 

--- a/test/corecel/io/OutputRegistry.test.cc
+++ b/test/corecel/io/OutputRegistry.test.cc
@@ -40,8 +40,8 @@ class TestInterface final : public OutputInterface
 #if CELERITAS_USE_JSON
         json->obj = value_;
 #else
-        CELER_NEVER_UNUSED(json)
-        CELER_NEVER_UNUSED(value_)
+        CELER_NEVER_UNUSED(json);
+        CELER_NEVER_UNUSED(value_);
 #endif
     }
 
@@ -71,10 +71,10 @@ class MockKernelContextException : public RichContextException
         json->obj["event"] = event_;
         json->obj["track"] = track_;
 #else
-        CELER_NEVER_UNUSED(json)
-        CELER_NEVER_UNUSED(thread_)
-        CELER_NEVER_UNUSED(event_)
-        CELER_NEVER_UNUSED(track_)
+        CELER_NEVER_UNUSED(json);
+        CELER_NEVER_UNUSED(thread_);
+        CELER_NEVER_UNUSED(event_);
+        CELER_NEVER_UNUSED(track_);
 #endif
     }
 


### PR DESCRIPTION
Several GCC versions that aren't used by our CI warn whenever a "maybe unused" variable is actually used, which is stupid because the point of the decorator is to disable warnings. This PR defines a new macro `CELER_NEVER_UNUSED(EXPRESSION)` that can be used to force the compiler to parse but not evaluate the given expression. It replaces all the `(void)sizeof(expr)` as well to improve readability. 