### PR TITLE
Implement asynchronous `DeviceAllocation`

### DIFF
--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -19,6 +19,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/data/Copier.hh"
+#include "corecel/data/DeviceVector.hh"
 #include "corecel/data/ObserverPtr.device.hh"
 #include "corecel/data/ObserverPtr.hh"
 #include "corecel/sys/Device.hh"
@@ -77,26 +78,20 @@ void sort_impl(TrackSlots const& track_slots,
                ObserverPtr<ActionId const> actions,
                StreamId stream_id)
 {
-    auto stream = celeritas::device().stream(stream_id).get();
-    ActionId::size_type* reordered_actions;
-    // TODO: Replace with stream-aware container
-    CELER_DEVICE_CALL_PREFIX(
-        MallocAsync(&reordered_actions,
-                    sizeof(ActionId::size_type) * track_slots.size(),
-                    stream));
+    DeviceVector<ActionId::size_type> reordered_actions(track_slots.size(),
+                                                        stream_id);
     CELER_LAUNCH_KERNEL(reorder_actions,
                         celeritas::device().default_block_size(),
                         track_slots.size(),
-                        stream,
+                        celeritas::device().stream(stream_id).get(),
                         track_slots.data(),
                         actions,
-                        make_observer(reordered_actions),
+                        make_observer(reordered_actions.data()),
                         track_slots.size());
     thrust::sort_by_key(thrust_execute_on(stream_id),
-                        reordered_actions,
-                        reordered_actions + track_slots.size(),
+                        reordered_actions.data(),
+                        reordered_actions.data() + reordered_actions.size(),
                         device_pointer_cast(track_slots.data()));
-    CELER_DEVICE_CALL_PREFIX(FreeAsync(reordered_actions, stream));
     CELER_DEVICE_CHECK_ERROR();
 }
 

--- a/src/corecel/data/DeviceAllocation.cc
+++ b/src/corecel/data/DeviceAllocation.cc
@@ -19,7 +19,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Allocate a buffer with the given number of bytes.
+ * Construct in unallocated state
  */
 DeviceAllocation::DeviceAllocation(StreamId stream)
     : size_{0}, stream_{stream}, data_{nullptr, {stream}}

--- a/src/corecel/data/DeviceAllocation.cc
+++ b/src/corecel/data/DeviceAllocation.cc
@@ -13,6 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/Stream.hh"
 
 namespace celeritas
 {
@@ -20,11 +21,25 @@ namespace celeritas
 /*!
  * Allocate a buffer with the given number of bytes.
  */
-DeviceAllocation::DeviceAllocation(size_type bytes) : size_(bytes)
+DeviceAllocation::DeviceAllocation(size_type bytes) : size_{bytes}
 {
     CELER_EXPECT(celeritas::device());
     void* ptr = nullptr;
     CELER_DEVICE_CALL_PREFIX(Malloc(&ptr, bytes));
+    data_.reset(static_cast<Byte*>(ptr));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Allocate a buffer with the given number of bytes.
+ */
+DeviceAllocation::DeviceAllocation(size_type bytes, StreamId stream)
+    : size_{bytes}, stream_{stream}, data_{nullptr, {stream}}
+{
+    CELER_EXPECT(celeritas::device());
+    void* ptr = nullptr;
+    CELER_DEVICE_CALL_PREFIX(
+        MallocAsync(&ptr, bytes, celeritas::device().stream(stream_).get()));
     data_.reset(static_cast<Byte*>(ptr));
 }
 
@@ -35,10 +50,23 @@ DeviceAllocation::DeviceAllocation(size_type bytes) : size_(bytes)
 void DeviceAllocation::copy_to_device(SpanConstBytes bytes)
 {
     CELER_EXPECT(bytes.size() == this->size());
-    CELER_DEVICE_CALL_PREFIX(Memcpy(data_.get(),
-                                    bytes.data(),
-                                    bytes.size(),
-                                    CELER_DEVICE_PREFIX(MemcpyHostToDevice)));
+    if (stream_)
+    {
+        CELER_DEVICE_CALL_PREFIX(
+            MemcpyAsync(data_.get(),
+                        bytes.data(),
+                        bytes.size(),
+                        CELER_DEVICE_PREFIX(MemcpyHostToDevice),
+                        celeritas::device().stream(stream_).get()));
+    }
+    else
+    {
+        CELER_DEVICE_CALL_PREFIX(
+            Memcpy(data_.get(),
+                   bytes.data(),
+                   bytes.size(),
+                   CELER_DEVICE_PREFIX(MemcpyHostToDevice)));
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -48,20 +76,41 @@ void DeviceAllocation::copy_to_device(SpanConstBytes bytes)
 void DeviceAllocation::copy_to_host(SpanBytes bytes) const
 {
     CELER_EXPECT(bytes.size() == this->size());
-    CELER_DEVICE_CALL_PREFIX(Memcpy(bytes.data(),
-                                    data_.get(),
-                                    this->size(),
-                                    CELER_DEVICE_PREFIX(MemcpyDeviceToHost)));
+    if (stream_)
+    {
+        CELER_DEVICE_CALL_PREFIX(
+            MemcpyAsync(bytes.data(),
+                        data_.get(),
+                        this->size(),
+                        CELER_DEVICE_PREFIX(MemcpyDeviceToHost),
+                        celeritas::device().stream(stream_).get()));
+    }
+    else
+    {
+        CELER_DEVICE_CALL_PREFIX(
+            Memcpy(bytes.data(),
+                   data_.get(),
+                   this->size(),
+                   CELER_DEVICE_PREFIX(MemcpyDeviceToHost)));
+    }
 }
 
 //---------------------------------------------------------------------------//
 //! Deleter frees data: prevent exceptions
 void DeviceAllocation::DeviceFreeDeleter::operator()(
-    [[maybe_unused]] Byte* ptr) const
+    [[maybe_unused]] Byte* ptr) const noexcept
 {
     try
     {
-        CELER_DEVICE_CALL_PREFIX(Free(ptr));
+        if (stream_)
+        {
+            CELER_DEVICE_CALL_PREFIX(
+                FreeAsync(ptr, celeritas::device().stream(stream_).get()));
+        }
+        else
+        {
+            CELER_DEVICE_CALL_PREFIX(Free(ptr));
+        }
     }
     catch (RuntimeError const& e)
     {

--- a/src/corecel/data/DeviceAllocation.cc
+++ b/src/corecel/data/DeviceAllocation.cc
@@ -98,7 +98,7 @@ void DeviceAllocation::copy_to_host(SpanBytes bytes) const
 //---------------------------------------------------------------------------//
 //! Deleter frees data: prevent exceptions
 void DeviceAllocation::DeviceFreeDeleter::operator()(
-    [[maybe_unused]] Byte* ptr) const noexcept
+    [[maybe_unused]] Byte* ptr) const noexcept(CELER_USE_DEVICE)
 {
     try
     {

--- a/src/corecel/data/DeviceAllocation.cc
+++ b/src/corecel/data/DeviceAllocation.cc
@@ -21,6 +21,14 @@ namespace celeritas
 /*!
  * Allocate a buffer with the given number of bytes.
  */
+DeviceAllocation::DeviceAllocation(StreamId stream)
+    : size_{0}, stream_{stream}, data_{nullptr, {stream}}
+{
+}
+
+/*!
+ * Allocate a buffer with the given number of bytes.
+ */
 DeviceAllocation::DeviceAllocation(size_type bytes) : size_{bytes}
 {
     CELER_EXPECT(celeritas::device());

--- a/src/corecel/data/DeviceAllocation.hh
+++ b/src/corecel/data/DeviceAllocation.hh
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/InitializedValue.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/sys/ThreadId.hh"
 
 namespace celeritas
 {
@@ -43,6 +44,9 @@ class DeviceAllocation
     // Construct and allocate a number of bytes
     DeviceAllocation(size_type num_bytes);
 
+    // Construct and allocate a number of bytes
+    DeviceAllocation(size_type num_bytes, StreamId stream);
+
     // Swap with another allocation
     inline void swap(DeviceAllocation& other) noexcept;
 
@@ -71,13 +75,15 @@ class DeviceAllocation
   private:
     struct DeviceFreeDeleter
     {
-        void operator()(Byte*) const;
+        StreamId stream_;
+        void operator()(Byte*) const noexcept;
     };
     using DeviceUniquePtr = std::unique_ptr<Byte[], DeviceFreeDeleter>;
 
     //// DATA ////
 
     InitializedValue<size_type> size_;
+    StreamId stream_;
     DeviceUniquePtr data_;
 };
 
@@ -95,6 +101,7 @@ void DeviceAllocation::swap(DeviceAllocation& other) noexcept
     using std::swap;
     swap(this->data_, other.data_);
     swap(this->size_, other.size_);
+    swap(this->stream_, other.stream_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/DeviceAllocation.hh
+++ b/src/corecel/data/DeviceAllocation.hh
@@ -11,6 +11,7 @@
 #include <memory>
 #include <utility>
 
+#include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/InitializedValue.hh"
 #include "corecel/cont/Span.hh"
@@ -76,7 +77,7 @@ class DeviceAllocation
     struct DeviceFreeDeleter
     {
         StreamId stream_;
-        void operator()(Byte*) const noexcept;
+        void operator()(Byte*) const noexcept(CELER_USE_DEVICE);
     };
     using DeviceUniquePtr = std::unique_ptr<Byte[], DeviceFreeDeleter>;
 

--- a/src/corecel/data/DeviceAllocation.hh
+++ b/src/corecel/data/DeviceAllocation.hh
@@ -42,8 +42,11 @@ class DeviceAllocation
     // Construct in unallocated state
     DeviceAllocation() = default;
 
+    // Construct in unallocated state
+    explicit DeviceAllocation(StreamId stream);
+
     // Construct and allocate a number of bytes
-    DeviceAllocation(size_type num_bytes);
+    explicit DeviceAllocation(size_type num_bytes);
 
     // Construct and allocate a number of bytes
     DeviceAllocation(size_type num_bytes, StreamId stream);

--- a/src/corecel/data/DeviceVector.hh
+++ b/src/corecel/data/DeviceVector.hh
@@ -11,6 +11,7 @@
 
 #include "corecel/cont/InitializedValue.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/sys/ThreadId.hh"
 
 #include "DeviceAllocation.hh"
 #include "ObserverPtr.hh"
@@ -57,8 +58,14 @@ class DeviceVector
     // Construct with no elements
     DeviceVector() = default;
 
+    // Construct with no elements
+    explicit DeviceVector(StreamId stream);
+
     // Construct with a number of elements
     explicit DeviceVector(size_type count);
+
+    // Construct with a number of elements
+    DeviceVector(size_type count, StreamId stream);
 
     // Swap with another vector
     inline void swap(DeviceVector& other) noexcept;
@@ -107,8 +114,25 @@ inline void swap(DeviceVector<T>& a, DeviceVector<T>& b) noexcept;
  * Construct with a number of allocated elements.
  */
 template<class T>
+DeviceVector<T>::DeviceVector(StreamId stream) : allocation_{stream}, size_{0}
+{
+}
+
+/*!
+ * Construct with a number of allocated elements.
+ */
+template<class T>
 DeviceVector<T>::DeviceVector(size_type count)
-    : allocation_(count * sizeof(T)), size_(count)
+    : allocation_{count * sizeof(T)}, size_{count}
+{
+}
+
+/*!
+ * Construct with a number of allocated elements.
+ */
+template<class T>
+DeviceVector<T>::DeviceVector(size_type count, StreamId stream)
+    : allocation_{count * sizeof(T), stream}, size_{count}
 {
 }
 

--- a/src/corecel/data/DeviceVector.hh
+++ b/src/corecel/data/DeviceVector.hh
@@ -26,6 +26,8 @@ namespace celeritas
  * define and copy over suitable data. For more complex data usage (dynamic
  * size increases and assignment without memory reallocation), use \c
  * thrust::device_vector.
+ * When a \c StreamId is passed as the last constructor argument,
+ * all memory operations are asynchronous and ordered within that stream.
  *
  * \code
     DeviceVector<double> myvec(100);


### PR DESCRIPTION
Add support for stream-ordered device allocation. The checks on whether we should use the sync or async device API are done at runtime to stay consistent with the `Copier` and `Filler` API though technically we could do everything at compile time with template specialization.

The next step is to update containers `Collection`, and `DeviceVector` to support stream-ordered semantics. Maybe for now we want to keep the implementation similar to the underlying components; add a constructor overload taking a stream.

The alternative would be to add a template argument (or Memspace / Ownership variant).