### PR TITLE
Add defaults and runtime checking to primary generator

### DIFF
--- a/src/celeritas/phys/PrimaryGeneratorOptions.hh
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.hh
@@ -84,6 +84,9 @@ using PrimaryGeneratorEngine = std::mt19937;
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//
 
+// Get a distribution name
+char const* to_cstring(DistributionSelection value);
+
 // Return a distribution for sampling the energy
 std::function<real_type(PrimaryGeneratorEngine&)>
 make_energy_sampler(DistributionOptions options);

--- a/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
@@ -40,7 +40,10 @@ void to_json(nlohmann::json& j, DistributionSelection const& value)
 void from_json(nlohmann::json const& j, DistributionOptions& opts)
 {
     j.at("distribution").get_to(opts.distribution);
-    j.at("params").get_to(opts.params);
+    if (j.contains("params"))
+    {
+        j.at("params").get_to(opts.params);
+    }
 }
 
 void to_json(nlohmann::json& j, DistributionOptions const& opts)

--- a/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
@@ -15,6 +15,7 @@
 #include "corecel/cont/ArrayIO.json.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/io/EnumStringMapper.hh"
+#include "corecel/io/Logger.hh"
 #include "corecel/io/StringEnumMapper.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
@@ -76,7 +77,16 @@ void to_json(nlohmann::json& j, DistributionOptions const& opts)
  */
 void from_json(nlohmann::json const& j, PrimaryGeneratorOptions& opts)
 {
-    j.at("seed").get_to(opts.seed);
+    if (j.contains("seed"))
+    {
+        j.at("seed").get_to(opts.seed);
+    }
+    else
+    {
+        CELER_LOG(warning) << "Primary generator options are missing 'seed': "
+                              "defaulting to "
+                           << opts.seed;
+    }
     std::vector<int> pdg;
     auto&& pdg_input = j.at("pdg");
     if (pdg_input.is_array())

--- a/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
@@ -14,7 +14,6 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/ArrayIO.json.hh"
 #include "corecel/cont/Range.hh"
-#include "corecel/io/EnumStringMapper.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringEnumMapper.hh"
 #include "celeritas/phys/PDGNumber.hh"
@@ -22,27 +21,6 @@
 
 namespace celeritas
 {
-namespace
-{
-//---------------------------------------------------------------------------//
-// HELPER FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- * Get a string corresponding to the distribution type.
- */
-char const* to_cstring(DistributionSelection value)
-{
-    static EnumStringMapper<DistributionSelection> const to_cstring_impl{
-        "delta",
-        "isotropic",
-        "box",
-    };
-    return to_cstring_impl(value);
-}
-
-//---------------------------------------------------------------------------//
-}  // namespace
-
 //---------------------------------------------------------------------------//
 // JSON serializers
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Enables existing celer-sim (mainly the regression suite) inputs to work with #914 by providing (but warning about) a default seed. Also allow "isotropic" without specifying an empty "params" list. Finally, always check the number of parameters even if debug assertions are off.