### PR TITLE
Implement TrackerVisitor for multiply-dispatched tracker types

### DIFF
--- a/src/orange/univ/TrackerVisitor.hh
+++ b/src/orange/univ/TrackerVisitor.hh
@@ -3,32 +3,34 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/univ/UniverseVisitor.hh
+//! \file orange/univ/TrackerVisitor.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include "corecel/math/Algorithms.hh"
 #include "orange/OrangeData.hh"
 
+#include "RectArrayTracker.hh"
+#include "SimpleUnitTracker.hh"
 #include "UniverseTypeTraits.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Apply a functor to a simple or rect-array universe
+ * Apply a functor to a universe tracker of unknown type.
  *
  * An instance of this class is like \c std::visit but accepting a UniverseId
  * rather than a \c std::variant .
  *
  * Example: \code
- UniverseVisitor visit_universe{params_};
- auto new_pos = visit_universe(
+ TrackerVisitor visit_tracker{params_};
+ auto new_pos = visit_tracker(
     [&pos](auto&& u) { return u.initialize(pos); },
     uid);
  \endcode
  */
-class UniverseVisitor
+class TrackerVisitor
 {
   public:
     //!@{
@@ -38,14 +40,14 @@ class UniverseVisitor
 
   public:
     // Construct from ORANGE params
-    explicit inline CELER_FUNCTION UniverseVisitor(ParamsRef const& params);
+    explicit inline CELER_FUNCTION TrackerVisitor(ParamsRef const& params);
 
     // Apply the function to the universe specified by the given ID
     template<class F>
     CELER_FUNCTION decltype(auto) operator()(F&& func, UniverseId id);
 
   private:
-    ParamsRef params_;
+    ParamsRef const& params_;
 };
 
 //---------------------------------------------------------------------------//
@@ -54,18 +56,18 @@ class UniverseVisitor
 /*!
  * Construct from ORANGE params.
  */
-CELER_FUNCTION UniverseVisitor::UniverseVisitor(ParamsRef const& params)
+CELER_FUNCTION TrackerVisitor::TrackerVisitor(ParamsRef const& params)
     : params_(params)
 {
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Apply the function to the transform specified by the given ID.
+ * Apply the function to the universe specified by the given ID.
  */
 template<class F>
 CELER_FUNCTION decltype(auto)
-UniverseVisitor::operator()(F&& func, UniverseId id)
+TrackerVisitor::operator()(F&& func, UniverseId id)
 {
     CELER_EXPECT(id < params_.universe_types.size());
     size_type universe_idx = params_.universe_indices[id];

--- a/src/orange/univ/UniverseTypeTraits.hh
+++ b/src/orange/univ/UniverseTypeTraits.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "orange/OrangeTypes.hh"
+#include "orange/univ/RectArrayTracker.hh"
 
 namespace celeritas
 {
@@ -31,8 +32,35 @@ struct UniverseTypeTraits;
     }
 
 ORANGE_UNIV_TRAITS(simple, SimpleUnit);
+ORANGE_UNIV_TRAITS(rect_array, RectArray);
 
 #undef ORANGE_UNIV_TRAITS
+
+//---------------------------------------------------------------------------//
+/*!
+ * Expand a macro to a switch statement over all possible universe types.
+ *
+ * The \c func argument should be a functor that takes a single argument which
+ * is a UniverseypeTraits instance.
+ */
+template<class F>
+CELER_CONSTEXPR_FUNCTION decltype(auto)
+visit_universe_type(F&& func, UniverseType ut)
+{
+#define ORANGE_UT_VISIT_CASE(TYPE)          \
+    case UniverseType::TYPE:                \
+        return celeritas::forward<F>(func)( \
+            UniverseTypeTraits<UniverseType::TYPE>{})
+
+    switch (ut)
+    {
+        ORANGE_UT_VISIT_CASE(simple);
+        ORANGE_UT_VISIT_CASE(rect_array);
+        default:
+            CELER_ASSERT_UNREACHABLE();
+    }
+#undef ORANGE_UT_VISIT_CASE
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/univ/UniverseTypeTraits.hh
+++ b/src/orange/univ/UniverseTypeTraits.hh
@@ -8,13 +8,13 @@
 #pragma once
 
 #include "orange/OrangeTypes.hh"
-#include "orange/univ/RectArrayTracker.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 struct SimpleUnitRecord;
 class SimpleUnitTracker;
+class RectArrayTracker;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -41,7 +41,7 @@ ORANGE_UNIV_TRAITS(rect_array, RectArray);
  * Expand a macro to a switch statement over all possible universe types.
  *
  * The \c func argument should be a functor that takes a single argument which
- * is a UniverseypeTraits instance.
+ * is a UniverseTypeTraits instance.
  */
 template<class F>
 CELER_CONSTEXPR_FUNCTION decltype(auto)

--- a/src/orange/univ/UniverseVisitor.hh
+++ b/src/orange/univ/UniverseVisitor.hh
@@ -1,0 +1,85 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/univ/UniverseVisitor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/math/Algorithms.hh"
+#include "orange/OrangeData.hh"
+
+#include "UniverseTypeTraits.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Apply a functor to a simple or rect-array universe
+ *
+ * An instance of this class is like \c std::visit but accepting a UniverseId
+ * rather than a \c std::variant .
+ *
+ * Example: \code
+ UniverseVisitor visit_universe{params_};
+ auto new_pos = visit_universe(
+    [&pos](auto&& u) { return u.initialize(pos); },
+    uid);
+ \endcode
+ */
+class UniverseVisitor
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using ParamsRef = NativeCRef<OrangeParamsData>;
+    //!@}
+
+  public:
+    // Construct from ORANGE params
+    explicit inline CELER_FUNCTION UniverseVisitor(ParamsRef const& params);
+
+    // Apply the function to the universe specified by the given ID
+    template<class F>
+    CELER_FUNCTION decltype(auto) operator()(F&& func, UniverseId id);
+
+  private:
+    ParamsRef params_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from ORANGE params.
+ */
+CELER_FUNCTION UniverseVisitor::UniverseVisitor(ParamsRef const& params)
+    : params_(params)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Apply the function to the transform specified by the given ID.
+ */
+template<class F>
+CELER_FUNCTION decltype(auto)
+UniverseVisitor::operator()(F&& func, UniverseId id)
+{
+    CELER_EXPECT(id < params_.universe_types.size());
+    size_type universe_idx = params_.universe_indices[id];
+
+    // Apply type-deleted functor based on type
+    return visit_universe_type(
+        [&](auto u_traits) {
+            using UTraits = decltype(u_traits);
+            using UId = OpaqueId<typename UTraits::record_type>;
+            using Tracker = typename UTraits::tracker_type;
+            return func(Tracker{params_, UId{universe_idx}});
+        },
+        params_.universe_types[id]);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -254,6 +254,7 @@ celeritas_add_test(orange/univ/detail/SenseCalculator.test.cc)
 celeritas_add_test(orange/univ/VolumeView.test.cc)
 celeritas_add_test(orange/univ/RectArrayTracker.test.cc ${_needs_json})
 celeritas_add_device_test(orange/univ/SimpleUnitTracker)
+celeritas_add_test(orange/univ/TrackerVisitor.test.cc ${_needs_json})
 
 #-----------------------------------------------------------------------------#
 # CELERITAS TESTS

--- a/test/orange/univ/TrackerVisitor.test.cc
+++ b/test/orange/univ/TrackerVisitor.test.cc
@@ -1,0 +1,83 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2021-2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/univ/TrackerVisitor.test.cc
+//---------------------------------------------------------------------------//
+
+#include "orange/univ/TrackerVisitor.hh"
+
+#include "orange/OrangeGeoTestBase.hh"
+#include "orange/univ/detail/Types.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+// TEST FIXTURES
+//---------------------------------------------------------------------------//
+
+class TrackerVisitorTest : public OrangeGeoTestBase
+{
+  protected:
+    using LocalState = detail::LocalState;
+
+    void SetUp() override { this->build_geometry("rect_array.org.json"); }
+
+    LocalState make_state(Real3 pos, Real3 dir);
+};
+
+//---------------------------------------------------------------------------//
+// TEST FIXTURE IMPLEMENTATION
+//---------------------------------------------------------------------------//
+/*!
+ * Initialize without any logical state.
+ */
+detail::LocalState TrackerVisitorTest::make_state(Real3 pos, Real3 dir)
+{
+    normalize_direction(&dir);
+    detail::LocalState state;
+    state.pos = pos;
+    state.dir = dir;
+    state.volume = {};
+    state.surface = {};
+
+    auto const& hsref = this->host_state();
+    auto face_storage = hsref.temp_face[AllItems<FaceId>{}];
+    state.temp_sense = hsref.temp_sense[AllItems<Sense>{}];
+    state.temp_next.face = face_storage.data();
+    state.temp_next.distance
+        = hsref.temp_distance[AllItems<real_type>{}].data();
+    state.temp_next.isect = hsref.temp_isect[AllItems<size_type>{}].data();
+    state.temp_next.size = face_storage.size();
+    return state;
+}
+
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST_F(TrackerVisitorTest, initialize)
+{
+    TrackerVisitor visit_tracker{this->host_params()};
+
+    auto local = this->make_state({0.5, 0.5, 0.5}, {1, 0, 0});
+
+    auto init_functor = [&local](auto&& t) { return t.initialize(local); };
+
+    auto init_simple = visit_tracker(init_functor, UniverseId{0});
+    auto init_rect = visit_tracker(init_functor, UniverseId{2});
+    auto init_simple2 = visit_tracker(init_functor, UniverseId{3});
+
+    EXPECT_EQ("arrfill", this->id_to_label(UniverseId{0}, init_simple.volume));
+    EXPECT_EQ("{0,0,0}", this->id_to_label(UniverseId{2}, init_rect.volume));
+    EXPECT_EQ("Tfill", this->id_to_label(UniverseId{3}, init_simple2.volume));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
This PR adds a `TrackerVisitor` class to facilitate multiply-dispatched tracker types (i.e., SimpleUnitTracker, RectArrayTracker). This functionality can be "hooked up" by replacing tracker calls like so:

```
auto tracker = this->make_tracker(uid);
auto tinit = tracker.initialize(local);
```

becomes:

```
TrackerVisitor visit_tracker{params_};
detail::Initialization tinit;
visit_tracker([&local, &tinit](auto&& t) { tinit = t.initialize(local); }, uid);
```

However, this is not done in the PR, as it appears this add 60% overhead to tracking with a single universe type.