### PR TITLE
Improve CPU along-step performance

### DIFF
--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
@@ -91,26 +91,27 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
                 std::forward<decltype(execute_track)>(execute_track)));
     };
 
-    if (this->has_msc())
-    {
-        launch_impl(
-            MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}});
-    }
-    launch_impl(PropagationApplier{LinearPropagatorFactory{}});
-    if (this->has_msc())
-    {
-        launch_impl(MscApplier{UrbanMsc{msc_->ref<MemSpace::native>()}});
-    }
-    launch_impl(detail::TimeUpdater{});
-    if (this->has_fluct())
-    {
-        launch_impl(ElossApplier{FluctELoss{fluct_->ref<MemSpace::native>()}});
-    }
-    else
-    {
-        launch_impl(ElossApplier{MeanELoss{}});
-    }
-    launch_impl(TrackUpdater{});
+    launch_impl([&](CoreTrackView const& track) {
+        if (this->has_msc())
+        {
+            MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}}(track);
+        }
+        PropagationApplier{LinearPropagatorFactory{}}(track);
+        if (this->has_msc())
+        {
+            MscApplier{UrbanMsc{msc_->ref<MemSpace::native>()}}(track);
+        }
+        TimeUpdater{}(track);
+        if (this->has_fluct())
+        {
+            ElossApplier{FluctELoss{fluct_->ref<MemSpace::native>()}}(track);
+        }
+        else
+        {
+            ElossApplier{MeanELoss{}}(track);
+        }
+        TrackUpdater{}(track);
+    });
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
@@ -92,27 +92,28 @@ void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
                 std::forward<decltype(execute_track)>(execute_track)));
     };
 
-    if (this->has_msc())
-    {
-        launch_impl(
-            MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}});
-    }
-    launch_impl(PropagationApplier{
-        RZMapFieldPropagatorFactory{field_->ref<MemSpace::native>()}});
-    if (this->has_msc())
-    {
-        launch_impl(MscApplier{UrbanMsc{msc_->ref<MemSpace::native>()}});
-    }
-    launch_impl(detail::TimeUpdater{});
-    if (this->has_fluct())
-    {
-        launch_impl(ElossApplier{FluctELoss{fluct_->ref<MemSpace::native>()}});
-    }
-    else
-    {
-        launch_impl(ElossApplier{MeanELoss{}});
-    }
-    launch_impl(TrackUpdater{});
+    launch_impl([&](CoreTrackView const& track) {
+        if (this->has_msc())
+        {
+            MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}}(track);
+        }
+        PropagationApplier{RZMapFieldPropagatorFactory{
+            field_->ref<MemSpace::native>()}}(track);
+        if (this->has_msc())
+        {
+            MscApplier{UrbanMsc{msc_->ref<MemSpace::native>()}}(track);
+        }
+        TimeUpdater{}(track);
+        if (this->has_fluct())
+        {
+            ElossApplier{FluctELoss{fluct_->ref<MemSpace::native>()}}(track);
+        }
+        else
+        {
+            ElossApplier{MeanELoss{}}(track);
+        }
+        TrackUpdater{}(track);
+    });
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
@@ -92,27 +92,27 @@ void AlongStepUniformMscAction::execute(CoreParams const& params,
                 std::forward<decltype(execute_track)>(execute_track)));
     };
 
-    if (this->has_msc())
-    {
-        launch_impl(
-            MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}});
-    }
-    launch_impl(
-        PropagationApplier{UniformFieldPropagatorFactory{field_params_}});
-    if (this->has_msc())
-    {
-        launch_impl(MscApplier{UrbanMsc{msc_->ref<MemSpace::native>()}});
-    }
-    launch_impl(detail::TimeUpdater{});
-    if (this->has_fluct())
-    {
-        launch_impl(ElossApplier{FluctELoss{fluct_->ref<MemSpace::native>()}});
-    }
-    else
-    {
-        launch_impl(ElossApplier{MeanELoss{}});
-    }
-    launch_impl(TrackUpdater{});
+    launch_impl([&](CoreTrackView const& track) {
+        if (this->has_msc())
+        {
+            MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}}(track);
+        }
+        PropagationApplier{UniformFieldPropagatorFactory{field_params_}}(track);
+        if (this->has_msc())
+        {
+            MscApplier{UrbanMsc{msc_->ref<MemSpace::native>()}}(track);
+        }
+        TimeUpdater{}(track);
+        if (this->has_fluct())
+        {
+            ElossApplier{FluctELoss{fluct_->ref<MemSpace::native>()}}(track);
+        }
+        else
+        {
+            ElossApplier{MeanELoss{}}(track);
+        }
+        TrackUpdater{}(track);
+    });
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
As @sethrj [pointed out](https://github.com/celeritas-project/celeritas/pull/954#discussion_r1334929718), we probably want to have a single along-step "kernel" on the CPU with all the along-step logic inside a single loop over tracks. That's done here for the general linear, uniform msc, and rzmap field kernels. Rerunning the regression suite with this change shows improved along-step performance in every problem:
```
problem                            total speedup  along-step speedup
cms2018+field+msc-vecgeom-cpu      1.05           1.17 
cms2018-vecgeom-cpu                1.05           1.43 
simple-cms+field+msc-orange-cpu    1.11           1.26 
simple-cms+field+msc-vecgeom-cpu   1.03           1.24 
simple-cms+field-orange-cpu        0.94           1.16 
simple-cms+msc-orange-cpu          1.06           1.33 
testem15+field+msc-orange-cpu      0.88           1.19 
testem15+field+msc-vecgeom-cpu     0.83           1.18 
testem15+field-orange-cpu          1.15           1.32 
testem15-orange-cpu                1.09           1.34 
testem3-flat+field+msc-orange-cpu  0.90           1.15 
testem3-flat+field+msc-vecgeom-cpu 0.95           1.16 
testem3-flat+field-orange-cpu      0.97           1.24 
testem3-flat+msc-orange-cpu        1.16           1.29 
testem3-flat-orange-cpu            1.11           1.64 
testem3-flat-vecgeom-cpu           0.96           1.58 
```