### PR TITLE
Fix build errors in SCALE CI

### DIFF
--- a/src/corecel/math/detail/FnvHasher.hh
+++ b/src/corecel/math/detail/FnvHasher.hh
@@ -88,16 +88,16 @@ class FnvHasher
 
   public:
     // Construct with a reference to the hashed value which we initialize
-    explicit inline CELER_FUNCTION FnvHasher(value_type* hash_result);
+    explicit inline FnvHasher(value_type* hash_result);
 
     // Hash a byte of data
-    CELER_FORCEINLINE_FUNCTION void operator()(std::byte b) const;
+    CELER_FORCEINLINE void operator()(std::byte b) const;
 
     // Hash a size_t (useful for std::hash integration)
-    inline CELER_FUNCTION void operator()(std::size_t value) const;
+    inline void operator()(std::size_t value) const;
 
     // Hash a span of bytes
-    inline CELER_FUNCTION void operator()(Span<std::byte const> s) const;
+    inline void operator()(Span<std::byte const> s) const;
 
   private:
     using TraitsT = FnvHashTraits<sizeof(T)>;
@@ -111,8 +111,7 @@ class FnvHasher
  * Initialize the result on construction.
  */
 template<class T>
-CELER_FUNCTION FnvHasher<T>::FnvHasher(value_type* hash_result)
-    : hash_(hash_result)
+FnvHasher<T>::FnvHasher(value_type* hash_result) : hash_(hash_result)
 {
     CELER_EXPECT(hash_);
     *hash_ = TraitsT::initial_basis;
@@ -125,7 +124,7 @@ CELER_FUNCTION FnvHasher<T>::FnvHasher(value_type* hash_result)
  * The FNV1a algorithm is very simple.
  */
 template<class T>
-CELER_FORCEINLINE_FUNCTION void FnvHasher<T>::operator()(std::byte b) const
+CELER_FORCEINLINE void FnvHasher<T>::operator()(std::byte b) const
 {
     // XOR hash with the current byte
     *hash_ ^= std::to_integer<T>(b);
@@ -140,7 +139,7 @@ CELER_FORCEINLINE_FUNCTION void FnvHasher<T>::operator()(std::byte b) const
  * This is useful for std::hash integration.
  */
 template<class T>
-CELER_FUNCTION void FnvHasher<T>::operator()(std::size_t value) const
+void FnvHasher<T>::operator()(std::size_t value) const
 {
     for (std::size_t i = 0; i < sizeof(std::size_t); ++i)
     {
@@ -154,7 +153,7 @@ CELER_FUNCTION void FnvHasher<T>::operator()(std::size_t value) const
  * Hash a span of bytes.
  */
 template<class T>
-CELER_FUNCTION void FnvHasher<T>::operator()(Span<std::byte const> bytes) const
+void FnvHasher<T>::operator()(Span<std::byte const> bytes) const
 {
     for (auto b : bytes)
     {

--- a/src/orange/detail/UnitInserter.hh
+++ b/src/orange/detail/UnitInserter.hh
@@ -59,7 +59,7 @@ class UnitInserter
     DedupeCollectionBuilder<SurfaceType> surface_types_;
     CollectionBuilder<ConnectivityRecord> connectivity_records_;
     CollectionBuilder<VolumeRecord> volume_records_;
-    DedupeCollectionBuilder<Daughter> daughters_;
+    CollectionBuilder<Daughter> daughters_;
 
     //// HELPER METHODS ////
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -206,7 +206,7 @@ celeritas_add_test(orange/BoundingBoxUtils.test.cc)
 celeritas_add_test(orange/CsgTree.test.cc
   LINK_LIBRARIES ${nlohmann_json_LIBRARIES})
 celeritas_add_test(orange/MatrixUtils.test.cc)
-celeritas_add_test(orange/Orange.test.cc)
+celeritas_add_device_test(orange/Orange)
 
 # Base detail
 celeritas_add_test(orange/detail/BIHBuilder.test.cc)

--- a/test/orange/Orange.test.cu
+++ b/test/orange/Orange.test.cu
@@ -1,0 +1,13 @@
+//---------------------------------*-CUDA-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/Orange.test.cu
+//---------------------------------------------------------------------------//
+
+// Simply include these because SCALE does too :eyeroll:
+#include "orange/OrangeParams.hh"
+#include "orange/OrangeTrackView.hh"
+#include "orange/OrangeTypes.hh"
+#include "orange/construct/OrangeInput.hh"


### PR DESCRIPTION
This fixes two downstream problems with SCALE:
- use of a host-device function by host code (because SCALE builds everything with CUDA)
- use of implicit `operator==` for the daughter struct (not sure why this worked in the current version)

```
celeritas/src/corecel/math/detail/FnvHasher.hh(131): error #20013-D: calling a constexpr __host__ function("to_integer") from a __host__ __device__ function("operator()") is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
          detected during:
            instantiation of "void celeritas::detail::FnvHasher<T>::operator()(std::byte) const [with T=std::size_t]" 
(147): here
            instantiation of "void celeritas::detail::FnvHasher<T>::operator()(std::size_t) const [with T=std::size_t]" 
/home/s3j/.local/src/celeritas/src/corecel/math/HashUtils.hh(67): here
            instantiation of "std::size_t celeritas::hash_combine(const Args &...) [with Args=<std::__cxx11::string, std::__cxx11::string>]" 
/home/s3j/.local/src/celeritas/src/corecel/io/Label.hh(125): here

1 error detected in the compilation of "/home/s3j/.local/src/celeritas/test/orange/Orange.test.cu".
```