### PR TITLE
Add option to disable track count output in celer-sim

### DIFF
--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -350,6 +350,7 @@ void Runner::build_transporter_input(RunnerInput const& inp)
     transporter_input_->num_track_slots
         = ceil_div(inp.num_track_slots, core_params_->max_streams());
     transporter_input_->max_steps = inp.max_steps;
+    transporter_input_->store_track_counts = inp.write_track_counts;
     transporter_input_->sync = inp.sync;
     transporter_input_->params = core_params_;
 }

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -58,6 +58,7 @@ struct RunnerInput
     bool action_diagnostic{};
     bool step_diagnostic{};
     size_type step_diagnostic_maxsteps{};
+    bool write_track_counts{true};  //!< Output track counts for each step
 
     // Control
     unsigned int seed{};

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -88,6 +88,7 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_OPTION(action_diagnostic);
     LDIO_LOAD_OPTION(step_diagnostic);
     LDIO_LOAD_OPTION(step_diagnostic_maxsteps);
+    LDIO_LOAD_OPTION(write_track_counts);
 
     LDIO_LOAD_DEPRECATED(max_num_tracks, num_track_slots);
 
@@ -162,6 +163,7 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE_OPTION(action_diagnostic);
     LDIO_SAVE_OPTION(step_diagnostic);
     LDIO_SAVE_OPTION(step_diagnostic_maxsteps);
+    LDIO_SAVE_OPTION(write_track_counts);
 
     LDIO_SAVE_OPTION(seed);
     LDIO_SAVE_OPTION(num_track_slots);

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -37,7 +37,9 @@ TransporterBase::~TransporterBase() = default;
  */
 template<MemSpace M>
 Transporter<M>::Transporter(TransporterInput inp)
-    : max_steps_(inp.max_steps), num_streams_(inp.params->max_streams())
+    : max_steps_(inp.max_steps)
+    , num_streams_(inp.params->max_streams())
+    , store_track_counts_(inp.store_track_counts)
 {
     CELER_EXPECT(inp);
 
@@ -80,7 +82,10 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
     auto& step = *stepper_;
     // Copy primaries to device and transport the first step
     auto track_counts = step(primaries);
-    append_track_counts(track_counts);
+    if (store_track_counts_)
+    {
+        append_track_counts(track_counts);
+    }
     if (num_streams_ == 1)
     {
         result.step_times.push_back(get_step_time());
@@ -104,7 +109,10 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
 
         get_step_time = {};
         track_counts = step();
-        append_track_counts(track_counts);
+        if (store_track_counts_)
+        {
+            append_track_counts(track_counts);
+        }
         if (num_streams_ == 1)
         {
             result.step_times.push_back(get_step_time());

--- a/app/celer-sim/Transporter.hh
+++ b/app/celer-sim/Transporter.hh
@@ -42,6 +42,7 @@ struct TransporterInput
 
     // Loop control
     size_type max_steps{};
+    bool store_track_counts{};  //!< Store track counts at each step
 
     StreamId stream_id{0};
 
@@ -123,6 +124,7 @@ class Transporter final : public TransporterBase
     std::shared_ptr<Stepper<M>> stepper_;
     size_type max_steps_;
     size_type num_streams_;
+    bool store_track_counts_;
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
The celer-sim output can get quite large for some problems when writing the initializer, alive, and active tracks counts at each step (and for each event). This lets us optionally disable that output.