### PR TITLE
Add unified memory support

### DIFF
--- a/src/celeritas/global/CoreState.cc
+++ b/src/celeritas/global/CoreState.cc
@@ -76,43 +76,6 @@ void CoreState<M>::insert_primaries(Span<Primary const> host_primaries)
 
 //---------------------------------------------------------------------------//
 /*!
- * Reference to the host ActionThread collection for holding result of action
- * counting
- */
-template<MemSpace M>
-auto CoreState<M>::action_thread_offsets() -> ActionThreads<MemSpace::host>&
-{
-    if constexpr (M == MemSpace::device)
-    {
-        return host_thread_offsets_;
-    }
-    else
-    {
-        return thread_offsets_;
-    }
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Const reference to the host ActionThread collection for holding result of
- * action counting
- */
-template<MemSpace M>
-auto CoreState<M>::action_thread_offsets() const
-    -> ActionThreads<MemSpace::host> const&
-{
-    if constexpr (M == MemSpace::device)
-    {
-        return host_thread_offsets_;
-    }
-    else
-    {
-        return thread_offsets_;
-    }
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Reference to the ActionThread collection matching the state memory space
  */
 template<MemSpace M>

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -126,31 +126,11 @@ class CoreState final : public CoreStateInterface
 
     // Reference to the host ActionThread collection for holding result of
     // action counting
-    auto& action_thread_offsets()
-    {
-        if constexpr (M == MemSpace::device)
-        {
-            return host_thread_offsets_;
-        }
-        else
-        {
-            return thread_offsets_;
-        }
-    }
+    inline auto& action_thread_offsets();
 
     // Const reference to the host ActionThread collection for holding result
     // of action counting
-    auto const& action_thread_offsets() const
-    {
-        if constexpr (M == MemSpace::device)
-        {
-            return host_thread_offsets_;
-        }
-        else
-        {
-            return thread_offsets_;
-        }
-    }
+    inline auto const& action_thread_offsets() const;
 
     // Reference to the ActionThread collection matching the state memory
     // space
@@ -197,6 +177,42 @@ template<MemSpace M>
 auto CoreState<M>::primary_storage() const -> PrimaryCRef
 {
     return PrimaryCRef{primaries_};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Reference to the host ActionThread collection for holding result of
+ * action counting
+ */
+template<MemSpace M>
+auto& CoreState<M>::action_thread_offsets()
+{
+    if constexpr (M == MemSpace::device)
+    {
+        return host_thread_offsets_;
+    }
+    else
+    {
+        return thread_offsets_;
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Const reference to the host ActionThread collection for holding result
+ * of action counting
+ */
+template<MemSpace M>
+auto const& CoreState<M>::action_thread_offsets() const
+{
+    if constexpr (M == MemSpace::device)
+    {
+        return host_thread_offsets_;
+    }
+    else
+    {
+        return thread_offsets_;
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -126,11 +126,31 @@ class CoreState final : public CoreStateInterface
 
     // Reference to the host ActionThread collection for holding result of
     // action counting
-    ActionThreads<MemSpace::host>& action_thread_offsets();
+    auto& action_thread_offsets()
+    {
+        if constexpr (M == MemSpace::device)
+        {
+            return host_thread_offsets_;
+        }
+        else
+        {
+            return thread_offsets_;
+        }
+    }
 
     // Const reference to the host ActionThread collection for holding result
     // of action counting
-    ActionThreads<MemSpace::host> const& action_thread_offsets() const;
+    auto const& action_thread_offsets() const
+    {
+        if constexpr (M == MemSpace::device)
+        {
+            return host_thread_offsets_;
+        }
+        else
+        {
+            return thread_offsets_;
+        }
+    }
 
     // Reference to the ActionThread collection matching the state memory
     // space
@@ -144,7 +164,7 @@ class CoreState final : public CoreStateInterface
     ActionThreads<M> thread_offsets_;
 
     // Only used if M == device for D2H copy of thread_offsets_
-    ActionThreads<MemSpace::host> host_thread_offsets_;
+    ActionThreads<MemSpace::mapped> host_thread_offsets_;
 
     // Primaries to be added
     Collection<Primary, Ownership::value, M> primaries_;

--- a/src/celeritas/global/detail/PinnedAllocator.cc
+++ b/src/celeritas/global/detail/PinnedAllocator.cc
@@ -18,6 +18,7 @@ namespace celeritas
 template struct PinnedAllocator<Real3>;
 template struct PinnedAllocator<DetectorStepPointOutput::Energy>;
 template struct PinnedAllocator<DetectorId>;
+template struct PinnedAllocator<ThreadId>;
 template struct PinnedAllocator<TrackId>;
 template struct PinnedAllocator<EventId>;
 template struct PinnedAllocator<ParticleId>;

--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -220,7 +220,7 @@ void sort_tracks(DeviceRef<CoreStateData> const& states, TrackOrder order)
 void count_tracks_per_action(
     DeviceRef<CoreStateData> const& states,
     Span<ThreadId> offsets,
-    Collection<ThreadId, Ownership::value, MemSpace::host, ActionId>& out,
+    Collection<ThreadId, Ownership::value, MemSpace::mapped, ActionId>& out,
     TrackOrder order)
 {
     if (order == TrackOrder::sort_along_step_action
@@ -244,7 +244,7 @@ void count_tracks_per_action(
                             states.size(),
                             order);
 
-        Span<ThreadId> sout = out[AllItems<ThreadId, MemSpace::host>{}];
+        Span<ThreadId> sout = out[AllItems<ThreadId, MemSpace::mapped>{}];
         Copier<ThreadId, MemSpace::host> copy_to_host{sout, states.stream_id};
         copy_to_host(MemSpace::device, offsets);
 

--- a/src/celeritas/track/detail/TrackSortUtils.hh
+++ b/src/celeritas/track/detail/TrackSortUtils.hh
@@ -71,7 +71,7 @@ void count_tracks_per_action(
 void count_tracks_per_action(
     DeviceRef<CoreStateData> const&,
     Span<ThreadId>,
-    Collection<ThreadId, Ownership::value, MemSpace::host, ActionId>&,
+    Collection<ThreadId, Ownership::value, MemSpace::mapped, ActionId>&,
     TrackOrder);
 
 void backfill_action_count(Span<ThreadId>, size_type);
@@ -136,7 +136,7 @@ inline void sort_tracks(DeviceRef<CoreStateData> const&, TrackOrder)
 inline void count_tracks_per_action(
     DeviceRef<CoreStateData> const&,
     Span<ThreadId>,
-    Collection<ThreadId, Ownership::value, MemSpace::host, ActionId>&,
+    Collection<ThreadId, Ownership::value, MemSpace::mapped, ActionId>&,
     TrackOrder)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -42,6 +42,7 @@ enum class MemSpace
 {
     host,
     device,
+    mapped,
 #ifdef CELER_DEVICE_SOURCE
     native = device,  // Included by a CUDA/HIP file
 #else

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -210,6 +210,19 @@ struct AllItems
  * we always want to build host code in C++ files for development ease and to
  * allow testing when CUDA is disabled.)
  *
+ * A \c MemSpace::Mapped collection will be accessible on the host and the
+ * device. Unified addressing must be supported by the current device or an
+ * exception will be thrown when using the collection. Mapped pinned memory
+ * (i.e. zero-copy memory) is allocated, pages will always reside on host
+ * memory and each access from device code will require a slow memory transfer.
+ * Allocating pinned memory is slow and reduce the memory available to the
+ * system: only allocate the smallest amount needed with the longest possible
+ * lifetime. Frequently accessing data from device code will result in low
+ * performance. Usecase for this MemSapce are: as a src / dst memory space for
+ * asynchronous operations, on integrated GPU architecture, or a single
+ * coalesced read or write from device code.
+ * https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#zero-copy
+ *
  * \todo It would be easy to specialize the traits for the const_reference
  * ownership so that for device primitive data types (int, double) we access
  * via __ldg -- speeding up everywhere in the code without any invasive

--- a/src/corecel/data/Copier.cc
+++ b/src/corecel/data/Copier.cc
@@ -23,9 +23,9 @@ namespace
 #if CELER_USE_DEVICE
 inline auto to_memcpy_kind(MemSpace src, MemSpace dst)
 {
-    if (src == MemSpace::host && dst == MemSpace::device)
+    if (src != MemSpace::device && dst == MemSpace::device)
         return CELER_DEVICE_PREFIX(MemcpyHostToDevice);
-    else if (src == MemSpace::device && dst == MemSpace::host)
+    else if (src == MemSpace::device && dst != MemSpace::device)
         return CELER_DEVICE_PREFIX(MemcpyDeviceToHost);
     else if (src == MemSpace::device && dst == MemSpace::device)
         return CELER_DEVICE_PREFIX(MemcpyDeviceToDevice);
@@ -46,7 +46,7 @@ void copy_bytes(MemSpace dstmem,
                 void const* src,
                 std::size_t count)
 {
-    if (srcmem == MemSpace::host && dstmem == MemSpace::host)
+    if (srcmem != MemSpace::device && dstmem != MemSpace::device)
     {
         std::memcpy(dst, src, count);
         return;
@@ -65,7 +65,7 @@ void copy_bytes(MemSpace dstmem,
                 std::size_t count,
                 StreamId stream)
 {
-    if (srcmem == MemSpace::host && dstmem == MemSpace::host)
+    if (srcmem != MemSpace::device && dstmem != MemSpace::device)
     {
         std::memcpy(dst, src, count);
         return;

--- a/src/corecel/data/detail/CollectionImpl.hh
+++ b/src/corecel/data/detail/CollectionImpl.hh
@@ -225,11 +225,17 @@ struct CollectionAssigner<Ownership::value, MemSpace::device>
 template<>
 struct CollectionAssigner<Ownership::value, MemSpace::mapped>
 {
+    CollectionAssigner()
+    {
+        CELER_VALIDATE(celeritas::device().support_unified_addressing(),
+                       << "Device " << celeritas::device().device_id()
+                       << " doesn't support unified addressing");
+    }
+
     template<class T, Ownership W2, MemSpace M2>
     auto operator()(CollectionStorage<T, W2, M2> const& source)
         -> CollectionStorage<T, Ownership::value, M2>
     {
-        CELER_EXPECT(celeritas::device().support_mapped_memory());
         return {{source.data.data(), source.data.data() + source.data.size()}};
     }
 };

--- a/src/corecel/data/detail/CollectionImpl.hh
+++ b/src/corecel/data/detail/CollectionImpl.hh
@@ -227,7 +227,7 @@ struct CollectionAssigner<Ownership::value, MemSpace::mapped>
 {
     CollectionAssigner()
     {
-        CELER_VALIDATE(celeritas::device().support_unified_addressing(),
+        CELER_VALIDATE(celeritas::device().can_map_host_memory(),
                        << "Device " << celeritas::device().device_id()
                        << " doesn't support unified addressing");
     }

--- a/src/corecel/data/detail/FillInvalid.hh
+++ b/src/corecel/data/detail/FillInvalid.hh
@@ -111,26 +111,27 @@ struct InvalidValueTraits<T, typename std::enable_if<std::is_trivial<T>::value>:
 /*!
  * Fill a collection with an invalid value (host only).
  */
+
 template<MemSpace M>
 struct InvalidFiller
 {
-    template<class T>
-    void operator()(T*)
-    {
-    }
-};
-
-template<>
-struct InvalidFiller<MemSpace::host>
-{
     template<class T, Ownership W, class I>
-    void operator()(Collection<T, W, MemSpace::host, I>* c)
+    void operator()(Collection<T, W, M, I>* c)
     {
         CELER_EXPECT(c);
 
         T val = InvalidValueTraits<T>::value();
         auto items = (*c)[AllItems<T>{}];
         std::fill(items.begin(), items.end(), val);
+    }
+};
+
+template<>
+struct InvalidFiller<MemSpace::device>
+{
+    template<class T>
+    void operator()(T*)
+    {
     }
 };
 

--- a/src/corecel/data/detail/Filler.hh
+++ b/src/corecel/data/detail/Filler.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <algorithm>
+
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
@@ -18,21 +20,16 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
-template<class T, MemSpace M>
-struct Filler;
 
-//! Assign on host
-template<class T>
-struct Filler<T, MemSpace::host>
+//! Assign on host or mapped / managed memory
+template<class T, MemSpace M>
+struct Filler
 {
     T const& value;
 
     void operator()(Span<T> data) const
     {
-        for (T& v : data)
-        {
-            v = value;
-        }
+        std::fill(data.begin(), data.end(), value);
     }
 };
 

--- a/src/corecel/data/detail/RefImpl.hh
+++ b/src/corecel/data/detail/RefImpl.hh
@@ -15,11 +15,9 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 //! Store a value/reference and dispatch function name based on MemSpace.
-template<class T, MemSpace M>
-struct RefGetter;
 
-template<class T>
-struct RefGetter<T, MemSpace::host>
+template<class T, MemSpace M>
+struct RefGetter
 {
     T obj_;
 

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -144,20 +144,20 @@ Device::Device(int id) : id_{id}, streams_{new detail::StreamStorage{}}
     CELER_LOG_LOCAL(debug) << "Constructing device ID " << id;
 
     unsigned int max_threads_per_block = 0;
+    int attr{0};
 #if CELER_USE_DEVICE
 #    if CELERITAS_USE_CUDA
     cudaDeviceProp props;
+    CELER_CUDA_CALL(
+        cudaDeviceGetAttribute(&attr, cudaDevAttrCanMapHostMemory, id));
 #    elif CELERITAS_USE_HIP
     hipDeviceProp_t props;
+    CELER_HIP_CALL(
+        hipDeviceGetAttribute(&attr, hipDeviceAttributeCanMapHostMemory, id));
 #    endif
 
-    CELER_DEVICE_CALL_PREFIX(GetDeviceProperties(&props, id));
-    int attr{0};
-    CELER_DEVICE_CALL_PREFIX(DeviceGetAttribute(
-        &attr, CELER_DEVICE_PREFIX(DevAttrCanMapHostMemory), id));
     support_mapped_memory_ = attr != 0;
-    CELER_LOG_LOCAL(info) << "Can map host memory ? " << support_mapped_memory_
-                          << std::endl;
+    CELER_DEVICE_CALL_PREFIX(GetDeviceProperties(&props, id));
     name_ = props.name;
     total_global_mem_ = props.totalGlobalMem;
     max_threads_per_block_ = props.maxThreadsDim[0];

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -158,7 +158,7 @@ Device::Device(int id) : id_{id}, streams_{new detail::StreamStorage{}}
     max_blocks_per_grid_ = props.maxGridSize[0];
     max_threads_per_cu_ = props.maxThreadsPerMultiProcessor;
     threads_per_warp_ = props.warpSize;
-    unified_addressing_ = props.unifiedAddressing != 0;
+    can_map_host_memory_ = props.canMapHostMemory != 0;
 #    if CELERITAS_USE_HIP
     if (name_.empty())
     {

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -145,18 +145,12 @@ Device::Device(int id) : id_{id}, streams_{new detail::StreamStorage{}}
 
     unsigned int max_threads_per_block = 0;
 #if CELER_USE_DEVICE
-    int attr{0};
 #    if CELERITAS_USE_CUDA
     cudaDeviceProp props;
-    CELER_CUDA_CALL(
-        cudaDeviceGetAttribute(&attr, cudaDevAttrCanMapHostMemory, id));
 #    elif CELERITAS_USE_HIP
     hipDeviceProp_t props;
-    CELER_HIP_CALL(
-        hipDeviceGetAttribute(&attr, hipDeviceAttributeCanMapHostMemory, id));
 #    endif
 
-    support_mapped_memory_ = attr != 0;
     CELER_DEVICE_CALL_PREFIX(GetDeviceProperties(&props, id));
     name_ = props.name;
     total_global_mem_ = props.totalGlobalMem;
@@ -164,6 +158,7 @@ Device::Device(int id) : id_{id}, streams_{new detail::StreamStorage{}}
     max_blocks_per_grid_ = props.maxGridSize[0];
     max_threads_per_cu_ = props.maxThreadsPerMultiProcessor;
     threads_per_warp_ = props.warpSize;
+    unified_addressing_ = props.unifiedAddressing != 0;
 #    if CELERITAS_USE_HIP
     if (name_.empty())
     {

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -152,6 +152,12 @@ Device::Device(int id) : id_{id}, streams_{new detail::StreamStorage{}}
 #    endif
 
     CELER_DEVICE_CALL_PREFIX(GetDeviceProperties(&props, id));
+    int attr{0};
+    CELER_DEVICE_CALL_PREFIX(DeviceGetAttribute(
+        &attr, CELER_DEVICE_PREFIX(DevAttrCanMapHostMemory), id));
+    support_mapped_memory_ = attr != 0;
+    CELER_LOG_LOCAL(info) << "Can map host memory ? " << support_mapped_memory_
+                          << std::endl;
     name_ = props.name;
     total_global_mem_ = props.totalGlobalMem;
     max_threads_per_block_ = props.maxThreadsDim[0];

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -144,8 +144,8 @@ Device::Device(int id) : id_{id}, streams_{new detail::StreamStorage{}}
     CELER_LOG_LOCAL(debug) << "Constructing device ID " << id;
 
     unsigned int max_threads_per_block = 0;
-    int attr{0};
 #if CELER_USE_DEVICE
+    int attr{0};
 #    if CELERITAS_USE_CUDA
     cudaDeviceProp props;
     CELER_CUDA_CALL(

--- a/src/corecel/sys/Device.hh
+++ b/src/corecel/sys/Device.hh
@@ -108,6 +108,9 @@ class Device
     //! Default number of threads per block
     unsigned int default_block_size() const { return default_block_size_; }
 
+    //! Check that the device supports mapped pinned memory
+    bool support_mapped_memory() const { return support_mapped_memory_; }
+
     //! Additional potentially interesting diagnostics
     MapStrInt const& extra() const { return extra_; }
 
@@ -129,6 +132,7 @@ class Device
     using UPStreamStorage
         = std::unique_ptr<detail::StreamStorage, StreamStorageDeleter>;
 
+    bool support_mapped_memory_ = true;
     int id_ = -1;
     std::string name_ = "<DISABLED>";
     std::size_t total_global_mem_ = 0;

--- a/src/corecel/sys/Device.hh
+++ b/src/corecel/sys/Device.hh
@@ -109,7 +109,7 @@ class Device
     unsigned int default_block_size() const { return default_block_size_; }
 
     //! Check that the device supports mapped pinned memory
-    bool support_unified_addressing() const { return unified_addressing_; }
+    bool can_map_host_memory() const { return can_map_host_memory_; }
 
     //! Additional potentially interesting diagnostics
     MapStrInt const& extra() const { return extra_; }
@@ -132,7 +132,7 @@ class Device
     using UPStreamStorage
         = std::unique_ptr<detail::StreamStorage, StreamStorageDeleter>;
 
-    bool unified_addressing_ = true;
+    bool can_map_host_memory_ = true;
     int id_ = -1;
     std::string name_ = "<DISABLED>";
     std::size_t total_global_mem_ = 0;

--- a/src/corecel/sys/Device.hh
+++ b/src/corecel/sys/Device.hh
@@ -109,7 +109,7 @@ class Device
     unsigned int default_block_size() const { return default_block_size_; }
 
     //! Check that the device supports mapped pinned memory
-    bool support_mapped_memory() const { return support_mapped_memory_; }
+    bool support_unified_addressing() const { return unified_addressing_; }
 
     //! Additional potentially interesting diagnostics
     MapStrInt const& extra() const { return extra_; }
@@ -132,7 +132,7 @@ class Device
     using UPStreamStorage
         = std::unique_ptr<detail::StreamStorage, StreamStorageDeleter>;
 
-    bool support_mapped_memory_ = true;
+    bool unified_addressing_ = true;
     int id_ = -1;
     std::string name_ = "<DISABLED>";
     std::size_t total_global_mem_ = 0;

--- a/src/corecel/sys/DeviceIO.json.cc
+++ b/src/corecel/sys/DeviceIO.json.cc
@@ -33,7 +33,7 @@ void to_json(nlohmann::json& j, Device const& d)
             {"threads_per_warp", d.threads_per_warp()},
             {"eu_per_cu", d.eu_per_cu()},
             {"default_block_size", d.default_block_size()},
-            {"support_unified_addressing", d.support_unified_addressing()},
+            {"can_map_host_memory", d.can_map_host_memory()},
         };
 
 #if CELERITAS_USE_CUDA

--- a/src/corecel/sys/DeviceIO.json.cc
+++ b/src/corecel/sys/DeviceIO.json.cc
@@ -33,6 +33,7 @@ void to_json(nlohmann::json& j, Device const& d)
             {"threads_per_warp", d.threads_per_warp()},
             {"eu_per_cu", d.eu_per_cu()},
             {"default_block_size", d.default_block_size()},
+            {"support_unified_addressing", d.support_unified_addressing()},
         };
 
 #if CELERITAS_USE_CUDA

--- a/test/celeritas/track/TrackSort.test.cc
+++ b/test/celeritas/track/TrackSort.test.cc
@@ -132,13 +132,12 @@ class TestActionCountEm3Stepper : public TestEm3NoMsc, public TrackSortTestBase
         return std::make_shared<TrackInitParams>(input);
     }
 
-    template<MemSpace M>
-    void check_action_count(ActionThreads<MemSpace::host> const& items,
-                            Stepper<M> const& step)
+    template<MemSpace M, MemSpace M2>
+    void
+    check_action_count(ActionThreads<M2> const& items, Stepper<M> const& step)
     {
         auto total_threads = 0;
-        Span<ThreadId const> items_span
-            = items[ActionThreadsItems<MemSpace::host>{}];
+        Span<ThreadId const> items_span = items[ActionThreadsItems<M2>{}];
         auto pos = std::find(items_span.begin(), items_span.end(), ThreadId{});
         ASSERT_EQ(pos, items_span.end());
         for (size_type i = 0; i < items.size() - 1; ++i)
@@ -379,7 +378,7 @@ TEST_F(TestActionCountEm3Stepper, TEST_IF_CELER_DEVICE(device_count_actions))
     // can't access the collection in CoreState, so test do the counting in a
     // temporary instead
     ActionThreads<MemSpace::device> buffer_d;
-    ActionThreads<MemSpace::host> buffer_h;
+    ActionThreads<MemSpace::mapped> buffer_h;
     resize(&buffer_d, num_actions + 1);
     resize(&buffer_h, num_actions + 1);
 


### PR DESCRIPTION
Add a `mapped` memspace that can be used on host and device. The device must support [unified addressing](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__UNIFIED.html#group__CUDART__UNIFIED). 