### PR TITLE
Hotfix: windows build error and missing bbox construction

### DIFF
--- a/src/orange/construct/CsgTreeUtils.cc
+++ b/src/orange/construct/CsgTreeUtils.cc
@@ -7,8 +7,10 @@
 //---------------------------------------------------------------------------//
 #include "CsgTreeUtils.hh"
 
+#include <algorithm>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "corecel/cont/Range.hh"
 

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -156,6 +156,10 @@ void from_json(nlohmann::json const& j, VolumeInput& value)
     {
         j.at("bbox").get_to(value.bbox);
     }
+    else
+    {
+        value.bbox = BBox::from_infinite();
+    }
 
     // Read scalars, including optional flags
     auto flag_iter = j.find("flags");
@@ -186,8 +190,13 @@ void from_json(nlohmann::json const& j, UnitInput& value)
 
         j.at("surface_names").get_to(value.surfaces.labels);
     }
+    if (j.contains("bbox"))
     {
         j.at("bbox").get_to(value.bbox);
+    }
+    else
+    {
+        value.bbox = BBox::from_infinite();
     }
 
     if (j.contains("parent_cells"))

--- a/src/orange/detail/BIHBuilder.cc
+++ b/src/orange/detail/BIHBuilder.cc
@@ -53,6 +53,7 @@ BIHTree BIHBuilder::operator()(VecBBox bboxes)
         }
         else
         {
+            CELER_ASSERT(bboxes_[i]);
             inf_volids.push_back(id);
         }
     }


### PR DESCRIPTION
Fixes two errors:
- in #962 I didn't change the OrangeInput reader to set the bbox to infinite if absent: it currently results in a false bounding box
- in #939 there's a missing include causing a build failure on windows