### PR TITLE
Fix performance regression on HIP

### DIFF
--- a/src/celeritas/global/alongstep/detail/UniformFieldPropagatorFactory.hh
+++ b/src/celeritas/global/alongstep/detail/UniformFieldPropagatorFactory.hh
@@ -25,7 +25,6 @@ struct UniformFieldPropagatorFactory
 {
 #if CELER_USE_DEVICE
     inline static constexpr int max_block_size = 256;
-    inline static constexpr int min_warps_per_eu = 8;
 #endif
 
     CELER_FUNCTION decltype(auto) operator()(CoreTrackView const& track) const


### PR DESCRIPTION
#853 seems to cause the local memory overflow to increase substantially, which in turn causes tracking performance to drop by a factor of 3 on crusher.

When compiling with CUDA the launch bound in the field propagator doesn't change the `max_blocks_per_cu` value in practice, in vecgeom or ORANGE. It *does* however force the occupancy in HIP to be way too high, reducing performance by a factor of 3. I've confirmed that the change in this PR resets the occupancy to a lower value with less spilling.

~~This doesn't explain why the non-field problems are so much slower on AMD than Nvidia though...~~
Somehow the last crusher run had absurdly long times for the first step, possibly indicative of some hardware fault. I'm rerunning before-and-after numbers.