### PR TITLE
Hotfix: build errors due to `if constexpr` on NVCC < 11.5

### DIFF
--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -425,6 +425,11 @@ CELER_CONSTEXPR_FUNCTION T ipow(T v) noexcept
     {
         return v * ipow<(N - 1) / 2>(v) * ipow<(N - 1) / 2>(v);
     }
+#if (__CUDACC_VER_MAJOR__ < 11) \
+    || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 5)
+    // "error: missing return statement at end of non-void function"
+    return T{};
+#endif
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/Thrust.device.hh
+++ b/src/corecel/sys/Thrust.device.hh
@@ -57,11 +57,16 @@ inline auto& thrust_execution_policy()
     {
         return thrust_native::par;
     }
+#if (__CUDACC_VER_MAJOR__ < 11) \
+    || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 5)
+    CELER_ASSERT_UNREACHABLE();
+#endif
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Returns an execution space for the given stream.
+ *
  * The template parameter defines whether the algorithm should be executed
  * synchronously or asynchrounously.
  */
@@ -80,6 +85,10 @@ inline auto thrust_execute_on(StreamId stream_id)
         return thrust_execution_policy<T>()(Alloc(&stream.memory_resource()))
             .on(stream.get());
     }
+#if (__CUDACC_VER_MAJOR__ < 11) \
+    || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 5)
+    CELER_ASSERT_UNREACHABLE();
+#endif
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Older NVCC has a lot of trouble with `if constexpr`. Two new changes (one from #910, one to fix MSVC in #930) are causing failures on Summit's CUDA 11.4.2 + GCC 11.2.0.

```
[50/125] Building CUDA object src/corecel/CMakeFiles/corecel_objects.dir/data/detail/Filler.cu.o
FAILED: src/corecel/CMakeFiles/corecel_objects.dir/data/detail/Filler.cu.o
/sw/summit/cuda/11.4.2/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/sw/summit/gcc/11.2.0-0/bin/g++ -DJSON_DIAGNOSTICS=0 -DJSON_USE_IMPLICIT_CONVERSIONS=1 -I/ccs/home/s3j/.local/src/celeritas-summit/src -I/gpfs/alpine/proj-shared/csc404/celeritas/build-ndebug/include -isystem=/gpfs/alpine/proj-shared/csc404/celeritas/spack/view/include -Werror all-warnings -Xcompiler -Wno-psabi -O3 -DNDEBUG --generate-code=arch=compute_70,code=[compute_70,sm_70] -Xcompiler=-fPIC -std=c++17 -MD -MT src/corecel/CMakeFiles/corecel_objects.dir/data/detail/Filler.cu.o -MF src/corecel/CMakeFiles/corecel_objects.dir/data/detail/Filler.cu.o.d -x cu -dc /ccs/home/s3j/.local/src/celeritas-summit/src/corecel/data/detail/Filler.cu -o src/corecel/CMakeFiles/corecel_objects.dir/data/detail/Filler.cu.o
/ccs/home/s3j/.local/src/celeritas-summit/src/corecel/sys/Thrust.device.hh(83): error: missing return statement at end of non-void function "celeritas::thrust_execute_on(celeritas::StreamId) [with T=celeritas::ThrustExecMode::Async]"
          detected during instantiation of "auto celeritas::thrust_execute_on(celeritas::StreamId) [with T=celeritas::ThrustExecMode::Async]"
/ccs/home/s3j/.local/src/celeritas-summit/src/corecel/data/detail/Filler.device.t.hh(30): here

/ccs/home/s3j/.local/src/celeritas-summit/src/corecel/sys/Thrust.device.hh(60): error: missing return statement at end of non-void function "celeritas::thrust_execution_policy() [with T=celeritas::ThrustExecMode::Sync]"
          detected during instantiation of "auto &celeritas::thrust_execution_policy() [with T=celeritas::ThrustExecMode::Sync]"
/ccs/home/s3j/.local/src/celeritas-summit/src/corecel/data/detail/Filler.device.t.hh(37): here
```
and
```
[88/125] Building CUDA object src/celeritas/CMakeFiles/celeritas_objects.dir/track/InitializeTracksAction.cu.o
FAILED: src/celeritas/CMakeFiles/celeritas_objects.dir/track/InitializeTracksAction.cu.o
/sw/summit/cuda/11.4.2/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/sw/summit/gcc/11.2.0-0/bin/g++ -DJSON_DIAGNOSTICS=0 -DJSON_USE_IMPLICIT_CONVERSIONS=1 -DVECCORE_ENABLE_CUDA -I/ccs/home/s3j/.local/src/celeritas-summit/src -I/gpfs/alpine/proj-shared/csc404/celeritas/build-ndebug/include -isystem=/gpfs/alpine/proj-shared/csc404/celeritas/spack/view/include -isystem=/gpfs/alpine/proj-shared/csc404/celeritas/spack/opt/gcc-11.2.0/xerces-c/febilzt/include -isystem=/sw/summit/cuda/11.4.2/include -Werror all-warnings -Xcompiler -Wno-psabi -O3 -DNDEBUG --generate-code=arch=compute_70,code=[compute_70,sm_70] -Xcompiler=-fPIC -Xcompiler=-faligned-new -Xnvlink --suppress-stack-size-warning -std=c++17 -MD -MT src/celeritas/CMakeFiles/celeritas_objects.dir/track/InitializeTracksAction.cu.o -MF src/celeritas/CMakeFiles/celeritas_objects.dir/track/InitializeTracksAction.cu.o.d -x cu -dc /ccs/home/s3j/.local/src/celeritas-summit/src/celeritas/track/InitializeTracksAction.cu -o src/celeritas/CMakeFiles/celeritas_objects.dir/track/InitializeTracksAction.cu.o
/ccs/home/s3j/.local/src/celeritas-summit/src/corecel/math/Algorithms.hh(428): error: missing return statement at end of non-void function "celeritas::ipow<N,T>(T) noexcept [with N=1U, T=celeritas::real_type]"
          detected during:
            instantiation of "T celeritas::ipow<N,T>(T) noexcept [with N=1U, T=celeritas::real_type]"
(422): here
            instantiation of "T celeritas::ipow<N,T>(T) noexcept [with N=2U, T=celeritas::real_type]"
/ccs/home/s3j/.local/src/celeritas-summit/src/celeritas/phys/ParticleTrackView.hh(297): here
/ccs/home/s3j/.local/src/celeritas-summit/src/corecel/math/Algorithms.hh(428): error: missing return statement at end of non-void function "celeritas::ipow<N,T>(T) noexcept [with N=2U, T=celeritas::real_type]"
          detected during instantiation of "T celeritas::ipow<N,T>(T) noexcept [with N=2U, T=celeritas::real_type]"
/ccs/home/s3j/.local/src/celeritas-summit/src/celeritas/phys/ParticleTrackView.hh(297): here

/ccs/home/s3j/.local/src/celeritas-summit/src/corecel/math/Algorithms.hh(428): error: missing return statement at end of non-void function "celeritas::ipow<N,T>(T) noexcept [with N=3U, T=celeritas::real_type]"
          detected during instantiation of "T celeritas::ipow<N,T>(T) noexcept [with N=3U, T=celeritas::real_type]"
/ccs/home/s3j/.local/src/celeritas-summit/src/celeritas/em/xs/LivermorePEMicroXsCalculator.hh(95): here

3 errors detected in the compilation of "/ccs/home/s3j/.local/src/celeritas-summit/src/celeritas/track/InitializeTracksAction.cu".
```