### PR TITLE
Reorganize JSON input and unit test for ORANGE

### DIFF
--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -50,6 +50,7 @@ if(CELERITAS_USE_JSON)
     BoundingBoxIO.json.cc
     construct/CsgTreeIO.json.cc
     construct/OrangeInputIO.json.cc
+    construct/detail/OrangeInputIOImpl.json.cc
   )
   list(APPEND PRIVATE_DEPS nlohmann_json::nlohmann_json)
 endif()

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -22,81 +22,16 @@
 #include "corecel/cont/Span.hh"
 #include "corecel/io/Label.hh"
 #include "corecel/io/LabelIO.json.hh"
-#include "corecel/io/StringEnumMapper.hh"
 #include "orange/BoundingBoxIO.json.hh"
 #include "orange/OrangeTypes.hh"
 #include "orange/construct/OrangeInput.hh"
+
+#include "detail/OrangeInputIOImpl.json.hh"
 
 namespace celeritas
 {
 namespace
 {
-//---------------------------------------------------------------------------//
-/*!
- * Convert a surface type string to an enum for I/O.
- */
-SurfaceType to_surface_type(std::string const& s)
-{
-    static auto const from_string
-        = StringEnumMapper<SurfaceType>::from_cstring_func(to_cstring,
-                                                           "surface type");
-    return from_string(s);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Build a volume from a C string.
- *
- * A valid string satisfies the regex "[0-9~!| ]+", but the result may
- * not be a valid logic expression. (The volume inserter will ensure that the
- * logic expression at least is consistent for a CSG region definition.)
- *
- * Example:
- * \code
-
-     parse_logic("4 ~ 5 & 6 &");
-
-   \endcode
- */
-std::vector<logic_int> parse_logic(char const* c)
-{
-    std::vector<logic_int> result;
-    logic_int s = 0;
-    while (char v = *c++)
-    {
-        if (v >= '0' && v <= '9')
-        {
-            // Parse a surface number. 'Push' this digit onto the surface ID by
-            // multiplying the existing ID by 10.
-            s = 10 * s + (v - '0');
-
-            char const next = *c;
-            if (next == ' ' || next == '\0')
-            {
-                // Next char is end of word or end of string
-                result.push_back(s);
-                s = 0;
-            }
-        }
-        else
-        {
-            // Parse a logic token
-            switch (v)
-            {
-                // clang-format off
-                case ' ': break;
-                case '*': result.push_back(logic::ltrue); break;
-                case '|': result.push_back(logic::lor);   break;
-                case '&': result.push_back(logic::land);  break;
-                case '~': result.push_back(logic::lnot);  break;
-                default:  CELER_ASSERT_UNREACHABLE();
-                    // clang-format on
-            }
-        }
-    }
-    return result;
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Get the i'th slice of a span of data.
@@ -125,7 +60,7 @@ void from_json(nlohmann::json const& j, SurfaceInput& value)
     std::transform(type_labels.begin(),
                    type_labels.end(),
                    value.types.begin(),
-                   &to_surface_type);
+                   &detail::to_surface_type);
 
     j.at("data").get_to(value.data);
     j.at("sizes").get_to(value.sizes);
@@ -149,7 +84,7 @@ void from_json(nlohmann::json const& j, VolumeInput& value)
 
     // Convert logic string to vector
     auto const& temp_logic = j.at("logic").get<std::string>();
-    value.logic = parse_logic(temp_logic.c_str());
+    value.logic = detail::parse_logic(temp_logic.c_str());
 
     // Parse bbox
     if (j.contains("bbox"))

--- a/src/orange/construct/OrangeInputIO.json.hh
+++ b/src/orange/construct/OrangeInputIO.json.hh
@@ -18,12 +18,17 @@ namespace celeritas
 
 void from_json(nlohmann::json const& j, SurfaceInput& value);
 void from_json(nlohmann::json const& j, VolumeInput& value);
+
 void from_json(nlohmann::json const& j, UnitInput& value);
-void from_json(nlohmann::json const& j, Tolerance<>& value);
-void from_json(nlohmann::json const& j, OrangeInput& value);
+
+void from_json(nlohmann::json const& j, RectArrayInput& value);
 
 template<class T>
+void from_json(nlohmann::json const& j, Tolerance<T>& value);
+template<class T>
 void to_json(nlohmann::json& j, Tolerance<T> const& value);
+
+void from_json(nlohmann::json const& j, OrangeInput& value);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/construct/detail/OrangeInputIOImpl.json.cc
+++ b/src/orange/construct/detail/OrangeInputIOImpl.json.cc
@@ -1,0 +1,87 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/construct/detail/OrangeInputIOImpl.json.cc
+//---------------------------------------------------------------------------//
+#include "OrangeInputIOImpl.json.hh"
+
+#include <vector>
+
+#include "corecel/io/StringEnumMapper.hh"
+#include "orange/OrangeTypes.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a surface type string to an enum for I/O.
+ */
+SurfaceType to_surface_type(std::string const& s)
+{
+    static auto const from_string
+        = StringEnumMapper<SurfaceType>::from_cstring_func(to_cstring,
+                                                           "surface type");
+    return from_string(s);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build a volume from a C string.
+ *
+ * A valid string satisfies the regex "[0-9~!| ]+", but the result may
+ * not be a valid logic expression. (The volume inserter will ensure that the
+ * logic expression at least is consistent for a CSG region definition.)
+ *
+ * Example:
+ * \code
+
+     parse_logic("4 ~ 5 & 6 &");
+
+   \endcode
+ */
+std::vector<logic_int> parse_logic(char const* c)
+{
+    std::vector<logic_int> result;
+    logic_int s = 0;
+    while (char v = *c++)
+    {
+        if (v >= '0' && v <= '9')
+        {
+            // Parse a surface number. 'Push' this digit onto the surface ID by
+            // multiplying the existing ID by 10.
+            s = 10 * s + (v - '0');
+
+            char const next = *c;
+            if (next == ' ' || next == '\0')
+            {
+                // Next char is end of word or end of string
+                result.push_back(s);
+                s = 0;
+            }
+        }
+        else
+        {
+            // Parse a logic token
+            switch (v)
+            {
+                // clang-format off
+                case ' ': break;
+                case '*': result.push_back(logic::ltrue); break;
+                case '|': result.push_back(logic::lor);   break;
+                case '&': result.push_back(logic::land);  break;
+                case '~': result.push_back(logic::lnot);  break;
+                default:  CELER_ASSERT_UNREACHABLE();
+                    // clang-format on
+            }
+        }
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/orange/construct/detail/OrangeInputIOImpl.json.hh
+++ b/src/orange/construct/detail/OrangeInputIOImpl.json.hh
@@ -1,0 +1,29 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/construct/detail/OrangeInputIOImpl.json.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+#include <vector>
+#include <nlohmann/json.hpp>
+
+#include "orange/OrangeTypes.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+// Convert a surface type string to an enum for I/O.
+SurfaceType to_surface_type(std::string const& s);
+
+// Build a logic definition from a C string.
+std::vector<logic_int> parse_logic(char const*);
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -208,6 +208,7 @@ celeritas_add_test(orange/CsgTree.test.cc
   LINK_LIBRARIES ${nlohmann_json_LIBRARIES})
 celeritas_add_test(orange/CsgTreeUtils.test.cc)
 celeritas_add_test(orange/MatrixUtils.test.cc)
+celeritas_add_test(orange/OrangeTypes.test.cc)
 celeritas_add_device_test(orange/Orange)
 
 # Base detail

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -29,45 +29,6 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 
-TEST(OrangeTypes, tolerances)
-{
-    using TolT = Tolerance<>;
-    EXPECT_FALSE(TolT{});
-
-    EXPECT_SOFT_EQ(1e-10, ipow<2>(TolT::sqrt_quadratic()));
-
-    {
-        SCOPED_TRACE("Default tolerance");
-        auto const tol = TolT::from_default();
-        EXPECT_TRUE(tol);
-        EXPECT_SOFT_NEAR(
-            std::sqrt(std::numeric_limits<real_type>::epsilon()), tol.rel, 0.5);
-        EXPECT_SOFT_EQ(tol.rel, tol.abs);
-        if constexpr (std::is_same_v<real_type, double>)
-        {
-            EXPECT_SOFT_EQ(1e-8, tol.rel);
-        }
-    }
-    {
-        SCOPED_TRACE("Tolerance with other length scale");
-        auto const tol = TolT::from_default(1e-4);
-        EXPECT_SOFT_EQ(1e-8, tol.rel);
-        EXPECT_SOFT_EQ(1e-12, tol.abs);
-    }
-    {
-        SCOPED_TRACE("Tolerance with arbitrary relative");
-        auto const tol = TolT::from_relative(1e-5);
-        EXPECT_SOFT_EQ(1e-5, tol.rel);
-        EXPECT_SOFT_EQ(1e-5, tol.abs);
-    }
-    {
-        SCOPED_TRACE("Tolerance with arbitrary relative and length scale");
-        auto const tol = TolT::from_relative(1e-5, 0.1);
-        EXPECT_SOFT_EQ(1e-5, tol.rel);
-        EXPECT_SOFT_EQ(1e-6, tol.abs);
-    }
-}
-
 class OrangeTest : public OrangeGeoTestBase
 {
   protected:

--- a/test/orange/OrangeTypes.test.cc
+++ b/test/orange/OrangeTypes.test.cc
@@ -1,0 +1,66 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/OrangeTypes.test.cc
+//---------------------------------------------------------------------------//
+#include "orange/OrangeTypes.hh"
+
+#include "celeritas_test.hh"
+// #include "OrangeTypes.test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+class OrangeTypesTest : public ::celeritas::test::Test
+{
+  protected:
+    void SetUp() override {}
+};
+
+TEST_F(OrangeTypesTest, tolerances)
+{
+    using TolT = Tolerance<>;
+    EXPECT_FALSE(TolT{});
+
+    EXPECT_SOFT_EQ(1e-10, ipow<2>(TolT::sqrt_quadratic()));
+
+    {
+        SCOPED_TRACE("Default tolerance");
+        auto const tol = TolT::from_default();
+        EXPECT_TRUE(tol);
+        EXPECT_SOFT_NEAR(
+            std::sqrt(std::numeric_limits<real_type>::epsilon()), tol.rel, 0.5);
+        EXPECT_SOFT_EQ(tol.rel, tol.abs);
+        if constexpr (std::is_same_v<real_type, double>)
+        {
+            EXPECT_SOFT_EQ(1e-8, tol.rel);
+        }
+    }
+    {
+        SCOPED_TRACE("Tolerance with other length scale");
+        auto const tol = TolT::from_default(1e-4);
+        EXPECT_SOFT_EQ(1e-8, tol.rel);
+        EXPECT_SOFT_EQ(1e-12, tol.abs);
+    }
+    {
+        SCOPED_TRACE("Tolerance with arbitrary relative");
+        auto const tol = TolT::from_relative(1e-5);
+        EXPECT_SOFT_EQ(1e-5, tol.rel);
+        EXPECT_SOFT_EQ(1e-5, tol.abs);
+    }
+    {
+        SCOPED_TRACE("Tolerance with arbitrary relative and length scale");
+        auto const tol = TolT::from_relative(1e-5, 0.1);
+        EXPECT_SOFT_EQ(1e-5, tol.rel);
+        EXPECT_SOFT_EQ(1e-6, tol.abs);
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
This moves a couple of functions into separate files for improved readability for an upcoming JSON change. (The utility functions were growing too big.) There is zero change to the code itself, just putting functions in a detail namespace.