### PR TITLE
Enable tracking through rectangular arrays

### DIFF
--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -122,10 +122,25 @@ class UniversesTest : public OrangeTest
     void SetUp() override { this->build_geometry("universes.org.json"); }
 };
 
+#define RectArrayTest TEST_IF_CELERITAS_JSON(RectArrayTest)
+class RectArrayTest : public OrangeTest
+{
+    void SetUp() override { this->build_geometry("rect_array.org.json"); }
+};
+
 #define HexArrayTest TEST_IF_CELERITAS_JSON(HexArrayTest)
 class HexArrayTest : public OrangeTest
 {
     void SetUp() override { this->build_geometry("hex_array.org.json"); }
+};
+
+#define NestedRectArraysTest TEST_IF_CELERITAS_JSON(NestedRectArraysTest)
+class NestedRectArraysTest : public OrangeTest
+{
+    void SetUp() override
+    {
+        this->build_geometry("nested_rect_arrays.org.json");
+    }
 };
 
 #define Geant4Testem15Test TEST_IF_CELERITAS_JSON(Geant4Testem15Test)
@@ -890,6 +905,82 @@ TEST_F(UniversesTest, cross_between_daughters)
 
     geo.move_to_boundary();
     EXPECT_EQ("bob.mz", this->params().id_to_label(geo.surface_id()).name);
+}
+
+TEST_F(RectArrayTest, params)
+{
+    OrangeParams const& geo = this->params();
+    EXPECT_EQ(35, geo.num_volumes());
+    EXPECT_EQ(22, geo.num_surfaces());
+    EXPECT_EQ(4, geo.max_depth());
+    EXPECT_FALSE(geo.supports_safety());
+
+    EXPECT_VEC_SOFT_EQ(Real3({-12, -4, -5}), geo.bbox().lower());
+    EXPECT_VEC_SOFT_EQ(Real3({12, 10, 5}), geo.bbox().upper());
+}
+
+TEST_F(RectArrayTest, tracking)
+{
+    auto geo = this->make_track_view();
+    geo = Initializer_t{{-1, 1, -1}, {1, 0, 0}};
+
+    EXPECT_VEC_SOFT_EQ(Real3({-1, 1, -1}), geo.pos());
+    EXPECT_VEC_SOFT_EQ(Real3({1, 0, 0}), geo.dir());
+    EXPECT_EQ("Hfill", this->params().id_to_label(geo.volume_id()).name);
+}
+
+TEST_F(NestedRectArraysTest, tracking)
+{
+    auto geo = this->make_track_view();
+    geo = Initializer_t{{1.5, 0.5, 0.5}, {1, 0, 0}};
+
+    EXPECT_VEC_SOFT_EQ(Real3({1.5, 0.5, 0.5}), geo.pos());
+    EXPECT_VEC_SOFT_EQ(Real3({1, 0, 0}), geo.dir());
+    EXPECT_EQ("Afill", this->params().id_to_label(geo.volume_id()).name);
+
+    auto next = geo.find_next_step();
+    EXPECT_SOFT_EQ(0.5, next.distance);
+
+    geo.move_to_boundary();
+    EXPECT_EQ("{x,1}", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("Afill", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, 0.5, 0.5}), geo.pos());
+
+    // Cross universe boundary
+    geo.cross_boundary();
+    EXPECT_EQ("{x,1}", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("Bfill", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({2, 0.5, 0.5}), geo.pos());
+
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(1, next.distance);
+}
+
+TEST_F(NestedRectArraysTest, leaving)
+{
+    auto geo = this->make_track_view();
+    geo = Initializer_t{{3.5, 1.5, 0.5}, {1, 0, 0}};
+
+    EXPECT_VEC_SOFT_EQ(Real3({3.5, 1.5, 0.5}), geo.pos());
+    EXPECT_VEC_SOFT_EQ(Real3({1, 0, 0}), geo.dir());
+    EXPECT_EQ("Bfill", this->params().id_to_label(geo.volume_id()).name);
+
+    auto next = geo.find_next_step();
+    EXPECT_SOFT_EQ(0.5, next.distance);
+
+    geo.move_to_boundary();
+    EXPECT_EQ("arrfill.px", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("Bfill", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({4, 1.5, 0.5}), geo.pos());
+
+    // Cross universe boundary
+    geo.cross_boundary();
+    EXPECT_EQ("arrfill.px", this->params().id_to_label(geo.surface_id()).name);
+    EXPECT_EQ("interior", this->params().id_to_label(geo.volume_id()).name);
+    EXPECT_VEC_SOFT_EQ(Real3({4, 1.5, 0.5}), geo.pos());
+
+    next = geo.find_next_step();
+    EXPECT_SOFT_EQ(16, next.distance);
 }
 
 TEST_F(Geant4Testem15Test, safety)

--- a/test/orange/data/nested_rect_arrays.org.json
+++ b/test/orange/data/nested_rect_arrays.org.json
@@ -1,0 +1,660 @@
+{
+"_format": "SCALE ORANGE",
+"_version": 0,
+"materials": {
+"cell_to_mat": [
+-1,
+-1,
+0,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+-1,
+2,
+-1,
+1
+],
+"names": [
+"0",
+"1",
+"2"
+]
+},
+"universes": [
+{
+"_type": "simple unit",
+"bbox": [
+[
+-20.0,
+-20.0,
+-20.0
+],
+[
+20.0,
+20.0,
+20.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"arrfill",
+"interior"
+],
+"cells": [
+{
+"bbox": [
+[
+-1.7976931348623157e+308,
+-1.7976931348623157e+308,
+-1.7976931348623157e+308
+],
+[
+1.7976931348623157e+308,
+1.7976931348623157e+308,
+1.7976931348623157e+308
+]
+],
+"faces": [
+0,
+1,
+2,
+3,
+4,
+5
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ & ~",
+"num_intersections": 6,
+"zorder": 2
+},
+{
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+4.0,
+4.0,
+1.0
+]
+],
+"faces": [
+6,
+7,
+8,
+9,
+10,
+11
+],
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ &",
+"num_intersections": 6,
+"zorder": 2
+},
+{
+"bbox": [
+[
+-20.0,
+-20.0,
+-20.0
+],
+[
+20.0,
+20.0,
+20.0
+]
+],
+"faces": [
+0,
+1,
+2,
+3,
+4,
+5,
+6,
+7,
+8,
+9,
+10,
+11
+],
+"flags": 1,
+"logic": "0 1 ~ & 2 & 3 ~ & 4 & 5 ~ & 6 7 ~ & 8 & 9 ~ & 10 & 11 ~ & ~ &",
+"num_intersections": 12,
+"zorder": 2
+}
+],
+"daughters": [
+1
+],
+"md": {
+"name": "global",
+"provenance": "nested_rect_arrays.org.omn:43"
+},
+"parent_cells": [
+1
+],
+"surface_names": [
+"outer.mx",
+"outer.px",
+"outer.my",
+"outer.py",
+"outer.mz",
+"outer.pz",
+"arrfill.mx",
+"arrfill.px",
+"arrfill.my",
+"arrfill.py",
+"arrfill.mz",
+"arrfill.pz"
+],
+"surfaces": {
+"data": [
+-20.0,
+20.0,
+-20.0,
+20.0,
+-20.0,
+20.0,
+0.0,
+4.0,
+0.0,
+4.0,
+0.0,
+1.0
+],
+"sizes": [
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1,
+1
+],
+"types": [
+"px",
+"px",
+"py",
+"py",
+"pz",
+"pz",
+"px",
+"px",
+"py",
+"py",
+"pz",
+"pz"
+]
+},
+"translations": [
+0.0,
+0.0,
+0.0
+]
+},
+{
+"_type": "simple unit",
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+4.0,
+4.0,
+1.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"parent+"
+],
+"cells": [
+{
+"bbox": [
+[
+-1.7976931348623157e+308,
+-1.7976931348623157e+308,
+-1.7976931348623157e+308
+],
+[
+1.7976931348623157e+308,
+1.7976931348623157e+308,
+1.7976931348623157e+308
+]
+],
+"faces": [],
+"flags": 2,
+"logic": "* ~",
+"num_intersections": 0,
+"zorder": 65534
+},
+{
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+4.0,
+4.0,
+1.0
+]
+],
+"faces": [],
+"logic": "*",
+"num_intersections": 0,
+"zorder": 3
+}
+],
+"daughters": [
+2
+],
+"md": {
+"name": "parent",
+"provenance": "nested_rect_arrays.org.omn:36"
+},
+"parent_cells": [
+1
+],
+"surface_names": [],
+"surfaces": {
+"data": [],
+"sizes": [],
+"types": []
+},
+"translations": [
+0.0,
+0.0,
+0.0
+]
+},
+{
+"_type": "rectangular array",
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+4.0,
+4.0,
+1.0
+]
+],
+"cell_names": [
+"{0,0,0}",
+"{0,1,0}",
+"{1,0,0}",
+"{1,1,0}"
+],
+"daughters": [
+3,
+3,
+3,
+3
+],
+"md": {
+"description": "Embedded unplaced array",
+"name": "parent+",
+"provenance": "nested_rect_arrays.org.omn:36"
+},
+"parent_cells": [
+0,
+2,
+1,
+3
+],
+"surface_names": [
+"-x",
+"+x",
+"-y",
+"+y",
+"-z",
+"+z"
+],
+"translations": [
+0.0,
+0.0,
+0.0,
+2.0,
+0.0,
+0.0,
+0.0,
+2.0,
+0.0,
+2.0,
+2.0,
+0.0
+],
+"x": [
+0.0,
+2.0,
+4.0
+],
+"y": [
+0.0,
+2.0,
+4.0
+],
+"z": [
+0.0,
+1.0
+]
+},
+{
+"_type": "simple unit",
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+2.0,
+2.0,
+1.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"arr+"
+],
+"cells": [
+{
+"bbox": [
+[
+-1.7976931348623157e+308,
+-1.7976931348623157e+308,
+-1.7976931348623157e+308
+],
+[
+1.7976931348623157e+308,
+1.7976931348623157e+308,
+1.7976931348623157e+308
+]
+],
+"faces": [],
+"flags": 2,
+"logic": "* ~",
+"num_intersections": 0,
+"zorder": 65534
+},
+{
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+2.0,
+2.0,
+1.0
+]
+],
+"faces": [],
+"logic": "*",
+"num_intersections": 0,
+"zorder": 3
+}
+],
+"daughters": [
+4
+],
+"md": {
+"name": "arr",
+"provenance": "nested_rect_arrays.org.omn:29"
+},
+"parent_cells": [
+1
+],
+"surface_names": [],
+"surfaces": {
+"data": [],
+"sizes": [],
+"types": []
+},
+"translations": [
+0.0,
+0.0,
+0.0
+]
+},
+{
+"_type": "rectangular array",
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+2.0,
+2.0,
+1.0
+]
+],
+"cell_names": [
+"{0,0,0}",
+"{0,1,0}",
+"{1,0,0}",
+"{1,1,0}"
+],
+"daughters": [
+5,
+6,
+6,
+5
+],
+"md": {
+"description": "Embedded unplaced array",
+"name": "arr+",
+"provenance": "nested_rect_arrays.org.omn:29"
+},
+"parent_cells": [
+0,
+2,
+1,
+3
+],
+"surface_names": [
+"-x",
+"+x",
+"-y",
+"+y",
+"-z",
+"+z"
+],
+"translations": [
+0.0,
+0.0,
+0.0,
+1.0,
+0.0,
+0.0,
+0.0,
+1.0,
+0.0,
+1.0,
+1.0,
+0.0
+],
+"x": [
+0.0,
+1.0,
+2.0
+],
+"y": [
+0.0,
+1.0,
+2.0
+],
+"z": [
+0.0,
+1.0
+]
+},
+{
+"_type": "simple unit",
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+1.0,
+1.0,
+1.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"Bfill"
+],
+"cells": [
+{
+"bbox": [
+[
+-1.7976931348623157e+308,
+-1.7976931348623157e+308,
+-1.7976931348623157e+308
+],
+[
+1.7976931348623157e+308,
+1.7976931348623157e+308,
+1.7976931348623157e+308
+]
+],
+"faces": [],
+"flags": 2,
+"logic": "* ~",
+"num_intersections": 0,
+"zorder": 65534
+},
+{
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+1.0,
+1.0,
+1.0
+]
+],
+"faces": [],
+"logic": "*",
+"num_intersections": 0,
+"zorder": 2
+}
+],
+"daughters": [],
+"md": {
+"name": "B",
+"provenance": "nested_rect_arrays.org.omn:17"
+},
+"parent_cells": [],
+"surface_names": [],
+"surfaces": {
+"data": [],
+"sizes": [],
+"types": []
+},
+"translations": []
+},
+{
+"_type": "simple unit",
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+1.0,
+1.0,
+1.0
+]
+],
+"cell_names": [
+"[EXTERIOR]",
+"Afill"
+],
+"cells": [
+{
+"bbox": [
+[
+-1.7976931348623157e+308,
+-1.7976931348623157e+308,
+-1.7976931348623157e+308
+],
+[
+1.7976931348623157e+308,
+1.7976931348623157e+308,
+1.7976931348623157e+308
+]
+],
+"faces": [],
+"flags": 2,
+"logic": "* ~",
+"num_intersections": 0,
+"zorder": 65534
+},
+{
+"bbox": [
+[
+0.0,
+0.0,
+0.0
+],
+[
+1.0,
+1.0,
+1.0
+]
+],
+"faces": [],
+"logic": "*",
+"num_intersections": 0,
+"zorder": 2
+}
+],
+"daughters": [],
+"md": {
+"name": "A",
+"provenance": "nested_rect_arrays.org.omn:6"
+},
+"parent_cells": [],
+"surface_names": [],
+"surfaces": {
+"data": [],
+"sizes": [],
+"types": []
+},
+"translations": []
+}
+]
+}

--- a/test/orange/data/nested_rect_arrays.org.omn
+++ b/test/orange/data/nested_rect_arrays.org.omn
@@ -1,0 +1,54 @@
+
+[GEOMETRY]
+global "global"
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+[UNIVERSE=general A]
+interior "outer"
+
+[UNIVERSE][SHAPE=cuboid outer]
+faces 0 1 0 1 0 1
+
+[UNIVERSE][CELL Afill]
+comp 1
+shapes -outer
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+[UNIVERSE=general B]
+interior "outer"
+
+[UNIVERSE][SHAPE=cuboid outer]
+faces 0 1 0 1 0 1
+
+[UNIVERSE][CELL Bfill]
+comp 2
+shapes -outer
+
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+[UNIVERSE=array arr]
+nx 2
+ny 2
+nz 1
+fill  A B B A
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+[UNIVERSE=array parent]
+nx 2
+ny 2
+nz 1
+fill arr arr arr arr
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
+[UNIVERSE=general global]
+interior "outer"
+
+[UNIVERSE][SHAPE=cuboid outer]
+faces -20 20 -20 20 -20 20
+
+[UNIVERSE][HOLE arrfill]
+fill parent
+
+[UNIVERSE][CELL interior]
+comp 0
+shapes +arrfill -outer


### PR DESCRIPTION
This MR modifies OrangeTrackView to use the TrackerVisitor added in #959. This change does not impart any significant overhead, as evidenced by the plot below; running with pseudo array with and without static dispatch has no appreciable effect on timing.

<img width="872" alt="Screen Shot 2023-10-11 at 3 58 38 PM" src="https://github.com/celeritas-project/celeritas/assets/1749283/929f972d-e61e-4c69-b330-c92594a0c8db">
