### PR TITLE
Fix uninitialized memory access in `TrackInitParams`

### DIFF
--- a/src/celeritas/track/TrackInitParams.cc
+++ b/src/celeritas/track/TrackInitParams.cc
@@ -22,6 +22,7 @@ TrackInitParams::TrackInitParams(Input const& inp)
 {
     CELER_EXPECT(inp.capacity > 0);
     CELER_EXPECT(inp.max_events > 0);
+    CELER_EXPECT(inp.track_order < TrackOrder::size_);
 
     HostVal<TrackInitParamsData> host_data;
     host_data.capacity = inp.capacity;

--- a/src/celeritas/track/TrackInitParams.hh
+++ b/src/celeritas/track/TrackInitParams.hh
@@ -25,9 +25,9 @@ class TrackInitParams final : public ParamsDataInterface<TrackInitParamsData>
     //! Track initializer construction arguments
     struct Input
     {
-        size_type capacity;  //!< Max number of initializers
-        size_type max_events;  //!< Max number of events that can be run
-        TrackOrder track_order;  //!< How to sort tracks on gpu
+        size_type capacity{};  //!< Max number of initializers
+        size_type max_events{};  //!< Max number of events that can be run
+        TrackOrder track_order{TrackOrder::unsorted};  //!< How to sort tracks
     };
 
   public:

--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -124,6 +124,7 @@ auto GeantTestBase::build_init() -> SPConstTrackInit
     TrackInitParams::Input input;
     input.capacity = 4096 * 2;
     input.max_events = 4096;
+    input.track_order = TrackOrder::unsorted;
     return std::make_shared<TrackInitParams>(input);
 }
 

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -240,6 +240,7 @@ auto MockTestBase::build_init() -> SPConstTrackInit
     TrackInitParams::Input input;
     input.capacity = 4096;
     input.max_events = 4096;
+    input.track_order = TrackOrder::unsorted;
     return std::make_shared<TrackInitParams>(input);
 }
 

--- a/test/celeritas/SimpleTestBase.cc
+++ b/test/celeritas/SimpleTestBase.cc
@@ -168,6 +168,7 @@ auto SimpleTestBase::build_init() -> SPConstTrackInit
     TrackInitParams::Input input;
     input.capacity = 4096;
     input.max_events = 4096;
+    input.track_order = TrackOrder::unsorted;
     return std::make_shared<TrackInitParams>(input);
 }
 


### PR DESCRIPTION
Reading the uninitialized input could lead to test failures, e.g.:
```console
[ RUN      ] TestEm3DiagnosticTest.device
status: Celeritas core setup complete
status: Celeritas core state initialization complete
/home/alund/celeritas_project/celeritas/test/celeritas/user/Diagnostic.test.cc:239: Failure
Expected equality of these values:
  "{\"_index\":[\"particle\",\"action\"],\"actions\":[[0,0,0,0," "0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,0,9,0],[0,0,0,997,0,0,2,0,0,0," "0,21,508,0,0,0,0,0,0,0,520,0],[0,0,0,904,0,0,12,0,0,0,10,20," "572,0,0,0,0,0,0,0,518,0]]}"
    Which is: "{\"_index\":[\"particle\",\"action\"],\"actions\":[[0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,0,9,0],[0,0,0,997,0,0,2,0,0,0,0,21,508,0,0,0,0,0,0,0,520,0],[0,0,0,904,0,0,12,0,0,0,10,20,572,0,0,0,0,0,0,0,518,0]]}"
  this->action_output()
    Which is: "{\"_index\":[\"particle\",\"action\"],\"actions\":[[0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,0,9,0,0],[0,0,0,997,0,0,2,0,0,0,0,21,508,0,0,0,0,0,0,0,520,0,0],[0,0,0,904,0,0,12,0,0,0,10,20,572,0,0,0,0,0,0,0,518,0,0]]}"
Writing diagnostic output to em3diagnostic-device.json because test failed
[  FAILED  ] TestEm3DiagnosticTest.device (19 ms)
```
where there was an en extra "sort tracks" action because the garbage value happened to be a valid `TrackOrder`.