### PR TITLE
Improve inlining and warning messages for scoped profiling

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -242,7 +242,7 @@ tell what variables are in use or may be useful.
  CELER_DEBUG_DEVICE      corecel   Increase device error checking and output
  CELER_DISABLE_DEVICE    corecel   Disable CUDA/HIP support
  CELER_DISABLE_PARALLEL  corecel   Disable MPI support
- CELER_ENABLE_PROFILING  corecel   Set up NVTX profiling ranges
+ CELER_ENABLE_PROFILING  corecel   Set up NVTX/ROCTX profiling ranges
  CELER_LOG               corecel   Set the "global" logger verbosity
  CELER_LOG_LOCAL         corecel   Set the "local" logger verbosity
  CELER_MEMPOOL... [#mp]_ celeritas Change ``cudaMemPoolAttrReleaseThreshold``

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -134,10 +134,16 @@ bool ScopedProfiling::enable_profiling()
 /*!
  * Activate nvtx profiling with options.
  */
-void ScopedProfiling::activate_(Input const& input)
+void ScopedProfiling::activate_(Input const& input) noexcept
 {
     nvtxEventAttributes_t attributes_ = make_attributes(input);
-    nvtxDomainRangePushEx(domain_handle(), &attributes_);
+    int result = nvtxDomainRangePushEx(domain_handle(), &attributes_);
+    if (result < 0)
+    {
+        activated_ = false;
+        CELER_LOG(warning) << "Failed to activate profiling domain '"
+                           << input.name << "'";
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -146,7 +152,11 @@ void ScopedProfiling::activate_(Input const& input)
  */
 void ScopedProfiling::deactivate_() noexcept
 {
-    nvtxDomainRangePop(domain_handle());
+    int result = nvtxDomainRangePop(domain_handle());
+    if (result < 0)
+    {
+        CELER_LOG(warning) << "Failed to deactivate profiling domain";
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -4,8 +4,8 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file corecel/sys/ScopedProfiling.cuda.cc
+//! \brief The nvtx implementation of \c ScopedProfiling
 //---------------------------------------------------------------------------//
-
 #include "ScopedProfiling.hh"
 
 #include <mutex>
@@ -15,7 +15,6 @@
 
 #include "corecel/io/Logger.hh"
 
-#include "Device.hh"
 #include "Environment.hh"
 
 namespace celeritas
@@ -114,12 +113,6 @@ bool ScopedProfiling::enable_profiling()
     static bool const result = [] {
         if (!celeritas::getenv("CELER_ENABLE_PROFILING").empty())
         {
-            if (!celeritas::device())
-            {
-                CELER_LOG(warning) << "Disabling profiling support "
-                                      "since no device is available";
-                return false;
-            }
             CELER_LOG(info) << "Enabling profiling support since the "
                                "'CELER_ENABLE_PROFILING' "
                                "environment variable is present and non-empty";

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -132,34 +132,19 @@ bool ScopedProfiling::enable_profiling()
 /*!
  * Activate nvtx profiling with options.
  */
-ScopedProfiling::ScopedProfiling(Input input)
+ScopedProfiling::activate_(Input const& input)
 {
-    if (ScopedProfiling::enable_profiling())
-    {
-        nvtxEventAttributes_t attributes_ = make_attributes(input);
-        nvtxDomainRangePushEx(domain_handle(), &attributes_);
-    }
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Activate nvtx profiling.
- */
-ScopedProfiling::ScopedProfiling(std::string const& name)
-    : ScopedProfiling{Input{name}}
-{
+    nvtxEventAttributes_t attributes_ = make_attributes(input);
+    nvtxDomainRangePushEx(domain_handle(), &attributes_);
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * End the profiling range.
  */
-ScopedProfiling::~ScopedProfiling()
+ScopedProfiling::deactivate_()
 {
-    if (ScopedProfiling::enable_profiling())
-    {
-        nvtxDomainRangePop(domain_handle());
-    }
+    nvtxDomainRangePop(domain_handle());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -15,6 +15,7 @@
 
 #include "corecel/io/Logger.hh"
 
+#include "Device.hh"
 #include "Environment.hh"
 
 namespace celeritas
@@ -67,9 +68,9 @@ nvtxStringHandle_t message_handle_for(std::string const& message)
     }
 
     // We did not find the handle; try to insert it
-    auto [iter, inserted] = [] {
+    auto [iter, inserted] = [&message] {
         std::unique_lock lock(mutex);
-        message_registry().insert({message, {}});
+        return message_registry().insert({message, {}});
     }();
     if (inserted)
     {
@@ -133,7 +134,7 @@ bool ScopedProfiling::enable_profiling()
 /*!
  * Activate nvtx profiling with options.
  */
-ScopedProfiling::activate_(Input const& input)
+void ScopedProfiling::activate_(Input const& input)
 {
     nvtxEventAttributes_t attributes_ = make_attributes(input);
     nvtxDomainRangePushEx(domain_handle(), &attributes_);
@@ -143,7 +144,7 @@ ScopedProfiling::activate_(Input const& input)
 /*!
  * End the profiling range.
  */
-ScopedProfiling::deactivate_()
+void ScopedProfiling::deactivate_() noexcept
 {
     nvtxDomainRangePop(domain_handle());
 }

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -81,7 +81,7 @@ class ScopedProfiling
   private:
     bool activated_;
 
-    void activate_(Input const& input);
+    void activate_(Input const& input) noexcept;
     void deactivate_() noexcept;
 };
 

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -15,7 +15,6 @@
 
 namespace celeritas
 {
-
 //---------------------------------------------------------------------------//
 /*!
  * Input arguments for the nvtx implementation.
@@ -40,8 +39,14 @@ struct ScopedProfilingInput
  * This is useful for wrapping specific code fragment in a range for profiling,
  * e.g. ignoring of VecGeom instantiation kernels, profiling a specific action
  * or loop on the CPU.
- * TODO: Template ScopedProfiling over profiling backend if we need to add a
- * new one
+ *
+ * \note The nvtx implementation of \c ScopedProfiling only does something when
+ * the application using Celeritas is ran through a tool that supports nvtx,
+ * e.g. nsight compute with the --nvtx argument. If this is not the case, API
+ * calls to nvtx are no-ops.
+ *
+ * \note The AMD roctx implementation requires the roctx library, which may not
+ * be available on all systems.
  */
 class ScopedProfiling
 {
@@ -52,29 +57,79 @@ class ScopedProfiling
     //!@}
 
   public:
+#if CELER_USE_DEVICE
     // Whether profiling is enabled
     static bool enable_profiling();
+#else
+    // Profiling is never enabled if CUDA isn't available
+    constexpr static bool enable_profiling() { return false; }
+#endif
 
     // Activate profiling with options
-    explicit ScopedProfiling(Input input);
-    // Activate profiling
-    explicit ScopedProfiling(std::string const& name);
+    explicit inline ScopedProfiling(Input const& input);
+    // Activate profiling with just a name
+    explicit inline ScopedProfiling(std::string const& name);
 
     // Deactivate profiling
-    ~ScopedProfiling();
+    inline ~ScopedProfiling();
 
     //!@{
     //! Prevent copying and moving for RAII class
     CELER_DELETE_COPY_MOVE(ScopedProfiling);
     //!@}
+
+  private:
+    bool activated_;
+
+    void activate_(Input const& input) noexcept;
+    void deactivate_() noexcept;
 };
 
 //---------------------------------------------------------------------------//
-#if !CELER_USE_DEVICE
-inline ScopedProfiling::ScopedProfiling(Input) {}
-inline ScopedProfiling::ScopedProfiling(std::string const&) {}
-inline ScopedProfiling::~ScopedProfiling() {}
-#endif
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Activate nvtx profiling with options.
+ */
+ScopedProfiling::ScopedProfiling(Input const& input)
+    : activated_{ScopedProfiling::enable_profiling()}
+{
+    if (activated_)
+    {
+        this->activate_(input);
+    }
+}
 
+//---------------------------------------------------------------------------//
+/*!
+ * Activate nvtx profiling with just a name.
+ */
+ScopedProfiling::ScopedProfiling(std::string const&)
+    : ScopedProfiling{Input{name}}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Deactivate a profiling scope.
+ */
+ScopedProfiling::~ScopedProfiling()
+{
+    if (activated_)
+    {
+        this->deactivate_();
+    }
+}
+
+#if !CELER_USE_DEVICE
+inline void activate_(Input const&)
+{
+    CELER_ASSERT_UNREACHABLE();
+}
+inline void deactivate_()
+{
+    CELER_ASSERT_UNREACHABLE();
+}
+#endif
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -81,7 +81,7 @@ class ScopedProfiling
   private:
     bool activated_;
 
-    void activate_(Input const& input) noexcept;
+    void activate_(Input const& input);
     void deactivate_() noexcept;
 };
 
@@ -104,7 +104,7 @@ ScopedProfiling::ScopedProfiling(Input const& input)
 /*!
  * Activate nvtx profiling with just a name.
  */
-ScopedProfiling::ScopedProfiling(std::string const&)
+ScopedProfiling::ScopedProfiling(std::string const& name)
     : ScopedProfiling{Input{name}}
 {
 }

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -89,7 +89,7 @@ class ScopedProfiling
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Activate nvtx profiling with options.
+ * Activate device profiling with options.
  */
 ScopedProfiling::ScopedProfiling(Input const& input)
     : activated_{ScopedProfiling::enable_profiling()}
@@ -102,7 +102,7 @@ ScopedProfiling::ScopedProfiling(Input const& input)
 
 //---------------------------------------------------------------------------//
 /*!
- * Activate nvtx profiling with just a name.
+ * Activate device profiling with just a name.
  */
 ScopedProfiling::ScopedProfiling(std::string const& name)
     : ScopedProfiling{Input{name}}
@@ -122,13 +122,13 @@ ScopedProfiling::~ScopedProfiling()
 }
 
 #if !CELER_USE_DEVICE
-inline void activate_(Input const&)
+inline void ScopedProfiling::activate_(Input const&) noexcept
 {
-    CELER_ASSERT_UNREACHABLE();
+    CELER_UNREACHABLE;
 }
-inline void deactivate_()
+inline void ScopedProfiling::deactivate_() noexcept
 {
-    CELER_ASSERT_UNREACHABLE();
+    CELER_UNREACHABLE;
 }
 #endif
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedProfiling.hip.cc
+++ b/src/corecel/sys/ScopedProfiling.hip.cc
@@ -6,13 +6,11 @@
 //! \file corecel/sys/ScopedProfiling.hip.cc
 //! \brief The roctx implementation of \c ScopedProfiling
 //---------------------------------------------------------------------------//
-
 #include "ScopedProfiling.hh"
 
 #include "celeritas_sys_config.h"
 #include "corecel/io/Logger.hh"
 
-#include "Device.hh"
 #include "Environment.hh"
 
 #if CELERITAS_HAVE_ROCTX
@@ -34,12 +32,6 @@ bool ScopedProfiling::enable_profiling()
     static bool const result = [] {
         if (!celeritas::getenv("CELER_ENABLE_PROFILING").empty())
         {
-            if (!celeritas::device())
-            {
-                CELER_LOG(warning) << "Disabling profiling support "
-                                      "since no device is available";
-                return false;
-            }
             if (!CELERITAS_HAVE_ROCTX)
             {
                 CELER_LOG(warning) << "Disabling profiling support "

--- a/src/corecel/sys/ScopedProfiling.hip.cc
+++ b/src/corecel/sys/ScopedProfiling.hip.cc
@@ -54,40 +54,26 @@ bool ScopedProfiling::enable_profiling()
 
 //---------------------------------------------------------------------------//
 /*!
- * Activate nvtx profiling with options.
+ * Activate profiling.
  */
-ScopedProfiling::ScopedProfiling(Input input)
+ScopedProfiling::activate_(Input const& input)
 {
 #if CELERITAS_HAVE_ROCTX
-    if (ScopedProfiling::enable_profiling())
-    {
-        roctxRangePush(input.name.c_str());
-    }
+    roctxRangePush(input.name.c_str());
 #else
     CELER_DISCARD(input);
+    CELER_ASSERT_UNREACHABLE();
 #endif
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Activate nvtx profiling.
- */
-ScopedProfiling::ScopedProfiling(std::string const& name)
-    : ScopedProfiling{Input{name}}
-{
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * End the profiling range.
  */
-ScopedProfiling::~ScopedProfiling()
+ScopedProfiling::deactivate_()
 {
 #if CELERITAS_HAVE_ROCTX
-    if (ScopedProfiling::enable_profiling())
-    {
-        roctxRangePop();
-    }
+    roctxRangePop();
 #endif
 }
 

--- a/src/corecel/sys/ScopedProfiling.hip.cc
+++ b/src/corecel/sys/ScopedProfiling.hip.cc
@@ -60,14 +60,18 @@ bool ScopedProfiling::enable_profiling()
 /*!
  * Activate profiling.
  */
-void ScopedProfiling::activate_(Input const& input)
+void ScopedProfiling::activate_(Input const& input) noexcept
 {
+    int result = 0;
 #if CELERITAS_HAVE_ROCTX
-    roctxRangePush(input.name.c_str());
-#else
-    CELER_DISCARD(input);
-    CELER_ASSERT_UNREACHABLE();
+    result = roctxRangePush(input.name.c_str());
 #endif
+    if (result < 0)
+    {
+        activated_ = false;
+        CELER_LOG(warning) << "Failed to activate profiling range '"
+                           << input.name << "'";
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -76,9 +80,15 @@ void ScopedProfiling::activate_(Input const& input)
  */
 void ScopedProfiling::deactivate_() noexcept
 {
+    int result = 0;
 #if CELERITAS_HAVE_ROCTX
-    roctxRangePop();
+    result = roctxRangePop();
 #endif
+    if (result < 0)
+    {
+        activated_ = false;
+        CELER_LOG(warning) << "Failed to deactivate profiling range";
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/ScopedProfiling.hip.cc
+++ b/src/corecel/sys/ScopedProfiling.hip.cc
@@ -12,6 +12,7 @@
 #include "celeritas_sys_config.h"
 #include "corecel/io/Logger.hh"
 
+#include "Device.hh"
 #include "Environment.hh"
 
 #if CELERITAS_HAVE_ROCTX
@@ -59,7 +60,7 @@ bool ScopedProfiling::enable_profiling()
 /*!
  * Activate profiling.
  */
-ScopedProfiling::activate_(Input const& input)
+void ScopedProfiling::activate_(Input const& input)
 {
 #if CELERITAS_HAVE_ROCTX
     roctxRangePush(input.name.c_str());
@@ -73,7 +74,7 @@ ScopedProfiling::activate_(Input const& input)
 /*!
  * End the profiling range.
  */
-ScopedProfiling::deactivate_()
+void ScopedProfiling::deactivate_() noexcept
 {
 #if CELERITAS_HAVE_ROCTX
     roctxRangePop();


### PR DESCRIPTION
This reduces a bit of the code duplication by checking for "enabled" in the header. We also now disable profiling and warn if the device is unavailable or disabled.