### PR TITLE
Export ORANGE input from JSON and add full support for transforms

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -34,6 +34,17 @@ endif()
 # Geant4/ROOT data interface
 #-----------------------------------------------------------------------------#
 
+# Orange JSON updater script
+celeritas_add_executable(orange-update orange-update.cc)
+celeritas_target_link_libraries(orange-update
+  Celeritas::orange
+)
+if(CELERITAS_USE_JSON)
+  celeritas_target_link_libraries(orange-update
+    nlohmann_json::nlohmann_json
+  )
+endif()
+
 # Exporter
 celeritas_add_executable(celer-export-geant celer-export-geant.cc)
 celeritas_target_link_libraries(celer-export-geant

--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -621,7 +621,7 @@ void print_atomic_relaxation_data(
 
 //---------------------------------------------------------------------------//
 /*!
- * Dump the contents of a ROOT file writen by celer-export-geant.
+ * Execute and run.
  */
 int main(int argc, char* argv[])
 {

--- a/app/celer-export-geant.cc
+++ b/app/celer-export-geant.cc
@@ -95,11 +95,7 @@ GeantPhysicsOptions load_options(std::string const& option_filename)
 
 //---------------------------------------------------------------------------//
 /*!
- * This application exports particles, processes, models, XS physics
- * tables, material, and volume information constructed by the physics list and
- * loaded by the GDML geometry.
- *
- * The data is stored into a ROOT file as an \c ImportData struct.
+ * Execute and run.
  */
 int main(int argc, char* argv[])
 {

--- a/app/orange-update.cc
+++ b/app/orange-update.cc
@@ -1,0 +1,146 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange-update.cc
+//---------------------------------------------------------------------------//
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "celeritas_config.h"
+#include "corecel/Assert.hh"
+#include "corecel/io/Logger.hh"
+#include "corecel/sys/MpiCommunicator.hh"
+#include "corecel/sys/ScopedMpiInit.hh"
+
+#if CELERITAS_USE_JSON
+#    include <fstream>
+#    include <nlohmann/json.hpp>
+
+#    include "orange/construct/OrangeInputIO.json.hh"
+#endif
+
+namespace celeritas
+{
+namespace app
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+void print_usage(char const* exec_name)
+{
+    std::cerr << "usage: " << exec_name
+              << " {input}.org.json {output}.org.json\n";
+}
+
+//---------------------------------------------------------------------------//
+std::string run(std::istream* is)
+{
+#if CELERITAS_USE_JSON
+    OrangeInput inp;
+    nlohmann::json::parse(*is).get_to(inp);
+
+    return nlohmann::json(inp).dump(/* indent = */ 0);
+#else
+    CELER_DISCARD(is);
+    CELER_NOT_CONFIGURED("JSON");
+#endif
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace
+}  // namespace app
+}  // namespace celeritas
+
+//---------------------------------------------------------------------------//
+/*!
+ * This application exports particles, processes, models, XS physics
+ * tables, material, and volume information constructed by the physics list and
+ * loaded by the GDML geometry.
+ *
+ * The data is stored into a ROOT file as an \c ImportData struct.
+ */
+int main(int argc, char* argv[])
+{
+    using namespace celeritas;
+    using namespace celeritas::app;
+
+    ScopedMpiInit scoped_mpi(&argc, &argv);
+    if (ScopedMpiInit::status() == ScopedMpiInit::Status::initialized
+        && MpiCommunicator::comm_world().size() > 1)
+    {
+        CELER_LOG(critical) << "This app cannot run in parallel";
+        return EXIT_FAILURE;
+    }
+
+    std::vector<std::string> args(argv + 1, argv + argc);
+    if (args.size() == 1 && (args.front() == "--help" || args.front() == "-h"))
+    {
+        print_usage(argv[0]);
+        return EXIT_SUCCESS;
+    }
+    if (args.size() != 2)
+    {
+        // Incorrect number of arguments: print help and exit
+        print_usage(argv[0]);
+        return 2;
+    }
+
+    // Set up input/output files
+    std::ifstream infile;
+    std::istream* instream = nullptr;
+    if (args[0] == "-")
+    {
+        instream = &std::cin;
+    }
+    else
+    {
+        // Open the specified file
+        infile.open(args[0]);
+        if (!infile)
+        {
+            CELER_LOG(critical) << "Failed to open '" << args[0] << "'";
+            return EXIT_FAILURE;
+        }
+        instream = &infile;
+    }
+
+    std::string result;
+    try
+    {
+        result = celeritas::app::run(instream);
+    }
+    catch (RuntimeError const& e)
+    {
+        CELER_LOG(critical) << "Runtime error: " << e.what();
+        return EXIT_FAILURE;
+    }
+    catch (DebugError const& e)
+    {
+        CELER_LOG(critical) << "Assertion failure: " << e.what();
+        return EXIT_FAILURE;
+    }
+
+    if (args[1] == "-")
+    {
+        std::cout << result;
+    }
+    else
+    {
+        // Open the specified file
+        std::ofstream outfile{args[1]};
+        if (!outfile)
+        {
+            CELER_LOG(critical)
+                << "Failed to open '" << args[1] << "' for writing";
+            return EXIT_FAILURE;
+        }
+        outfile << result;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/app/orange-update.cc
+++ b/app/orange-update.cc
@@ -58,11 +58,7 @@ std::string run(std::istream* is)
 
 //---------------------------------------------------------------------------//
 /*!
- * This application exports particles, processes, models, XS physics
- * tables, material, and volume information constructed by the physics list and
- * loaded by the GDML geometry.
- *
- * The data is stored into a ROOT file as an \c ImportData struct.
+ * Execute and run.
  */
 int main(int argc, char* argv[])
 {

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -131,14 +131,20 @@ Integrated Geant4 application (celer-g4)
 The ``celer-g4`` app is a Geant4 application that offloads EM tracks to
 Celeritas. It takes as input a GDML file with the detector description and
 sensitive detectors marked via an ``auxiliary`` annotation. The input particles
-must be specified with a HepMC3-compatible file.
+must be specified with a HepMC3-compatible file or with a JSON-specified
+"particle gun."
 
 Usage::
 
-  celer-g4 {commands}.mac
+  celer-g4 {input}.json
+           {commands}.mac
+           --interactive
 
 Input
 -----
+
+.. note:: The macro file usage is in the process of being replaced by JSON
+   input for improved automation.
 
 The input is a Geant4 macro file for executing the program. Celeritas defines
 several macros in the ``/celer`` and (if CUDA is available) ``/celer/cuda/``
@@ -149,15 +155,19 @@ The ``celer-g4`` app defines several additional configuration commands under
 
 .. table:: Geant4 UI commands defined by ``celer-g4``.
 
- ============== ===============================================
- Command        Description
- ============== ===============================================
- geometryFile   Filename of the GDML detector geometry
- eventFile      Filename of the event input read by HepMC3
- rootBufferSize Buffer size of output root file [bytes]
- writeSDHits    Write a ROOT output file with hits from the SDs
- magFieldZ      Set Z-axis magnetic field strength (T)
- ============== ===============================================
+ ================== ==================================================
+ Command            Description
+ ================== ==================================================
+ geometryFile       Filename of the GDML detector geometry
+ eventFile          Filename of the event input read by HepMC3
+ rootBufferSize     Buffer size of output root file [bytes]
+ writeSDHits        Write a ROOT output file with hits from the SDs
+ stepDiagnostic     Collect the distribution of steps per Geant4 track
+ stepDiagnosticBins Collect the distribution of steps per Geant4 track
+ fieldType          Select the field type [rzmap|uniform]
+ fieldFile          Filename of the rz-map loaded by RZMapFieldInput
+ magFieldZ          Set Z-axis magnetic field strength (T)
+ ================== ==================================================
 
 In addition to these input parameters, :ref:`environment` can be specified to
 change the program behavior.
@@ -220,6 +230,23 @@ Usage::
 
 output
   A ROOT file containing exported :ref:`api_importdata`.
+
+
+orange-update
+-------------
+
+Read an ORANGE JSON input file and write it out again. This is used for
+updating from an older version of the input to a newer version.
+
+----
+
+Usage::
+
+   orange-update {input}.org.json {output}.org.json
+
+Either of the filenames can be replaced by ``-`` to read from stdin or write to
+stdout.
+
 
 .. _environment:
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -163,7 +163,7 @@ The ``celer-g4`` app defines several additional configuration commands under
  rootBufferSize     Buffer size of output root file [bytes]
  writeSDHits        Write a ROOT output file with hits from the SDs
  stepDiagnostic     Collect the distribution of steps per Geant4 track
- stepDiagnosticBins Collect the distribution of steps per Geant4 track
+ stepDiagnosticBins Number of bins for the Geant4 step diagnostic
  fieldType          Select the field type [rzmap|uniform]
  fieldFile          Filename of the rz-map loaded by RZMapFieldInput
  magFieldZ          Set Z-axis magnetic field strength (T)

--- a/scripts/cmake-presets/goldfinger.json
+++ b/scripts/cmake-presets/goldfinger.json
@@ -17,7 +17,7 @@
         "CELERITAS_USE_SWIG":    {"type": "BOOL",   "value": "OFF"},
         "CMAKE_BUILD_TYPE":      {"type": "STRING", "value": "Debug"},
         "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL",   "value": "ON"},
-        "CMAKE_OSX_DEPLOYMENT_TARGET": {"type": "STRING", "value": "13"},
+        "CMAKE_OSX_DEPLOYMENT_TARGET": {"type": "STRING", "value": "14"},
         "CMAKE_CXX_STANDARD":   {"type": "STRING",   "value": "17"},
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL",   "value": "OFF"},
         "CMAKE_FIND_FRAMEWORK": {"type": "STRING", "value": "LAST"},

--- a/src/orange/BoundingBox.hh
+++ b/src/orange/BoundingBox.hh
@@ -110,7 +110,7 @@ operator==(BoundingBox<T> const& lhs, BoundingBox<T> const& rhs)
 /*!
  * Test inequality of two bounding boxes.
  */
-template<class T, size_type N>
+template<class T>
 CELER_CONSTEXPR_FUNCTION bool
 operator!=(BoundingBox<T> const& lhs, BoundingBox<T> const& rhs)
 {

--- a/src/orange/OrangeTypes.cc
+++ b/src/orange/OrangeTypes.cc
@@ -108,6 +108,58 @@ char const* to_cstring(SurfaceType value)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Get a printable character corresponding to a z ordering.
+ */
+char to_char(ZOrder zo)
+{
+    switch (zo)
+    {
+        case ZOrder::invalid:
+            return '!';
+        case ZOrder::background:
+            return 'B';
+        case ZOrder::media:
+            return 'M';
+        case ZOrder::array:
+            return 'A';
+        case ZOrder::hole:
+            return 'H';
+        case ZOrder::implicit_exterior:
+            return 'x';
+        case ZOrder::exterior:
+            return 'X';
+    };
+    return '?';
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get a printable character corresponding to a z ordering.
+ */
+ZOrder to_zorder(char c)
+{
+    switch (c)
+    {
+        case '!':
+            return ZOrder::invalid;
+        case 'B':
+            return ZOrder::background;
+        case 'M':
+            return ZOrder::media;
+        case 'A':
+            return ZOrder::array;
+        case 'H':
+            return ZOrder::hole;
+        case 'x':
+            return ZOrder::implicit_exterior;
+        case 'X':
+            return ZOrder::exterior;
+    };
+    return ZOrder::invalid;
+}
+
+//---------------------------------------------------------------------------//
 // EXPLICIT INSTANTIATION
 //---------------------------------------------------------------------------//
 

--- a/src/orange/OrangeTypes.cc
+++ b/src/orange/OrangeTypes.cc
@@ -135,7 +135,7 @@ char to_char(ZOrder zo)
 
 //---------------------------------------------------------------------------//
 /*!
- * Get a printable character corresponding to a z ordering.
+ * Convert a printable character to a z ordering.
  */
 ZOrder to_zorder(char c)
 {

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -236,6 +236,24 @@ enum OperatorToken : logic_int
 }  // namespace logic
 
 //---------------------------------------------------------------------------//
+/*!
+ * Masking priority.
+ *
+ * This is currently not implemented in GPU ORANGE except for the special
+ * "background" cell and "exterior".
+ */
+enum class ZOrder : size_type
+{
+    invalid = 0,  //!< Invalid region
+    background,  //!< Implicit fill
+    media,  //!< Material-filled region or array
+    array,  //!< Lattice array of nested arrangement
+    hole,  //!< Another universe masking this one
+    implicit_exterior = size_type(-2),  //!< Exterior in lower universe
+    exterior = size_type(-1),  //!< The global problem boundary
+};
+
+//---------------------------------------------------------------------------//
 // STRUCTS
 //---------------------------------------------------------------------------//
 /*!
@@ -435,6 +453,12 @@ inline constexpr char to_char(OperatorToken tok)
     return is_operator_token(tok) ? "*|&~"[tok - lbegin] : '\a';
 }
 }  // namespace logic
+
+// Get a printable character corresponding to a z ordering
+char to_char(ZOrder z);
+
+// Convert a printable character to a z ordering
+ZOrder to_zorder(char c);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/construct/OrangeInput.hh
+++ b/src/orange/construct/OrangeInput.hh
@@ -17,6 +17,7 @@
 #include "orange/OrangeData.hh"
 #include "orange/OrangeTypes.hh"
 #include "orange/surf/VariantSurface.hh"
+#include "orange/transform/VariantTransform.hh"
 
 namespace celeritas
 {
@@ -40,13 +41,14 @@ struct VolumeInput
 
     //! Special flags
     logic_int flags{0};
-    //! Masking priority (2 for regular, 1 for background)
-    int zorder{};
+    //! Masking priority
+    ZOrder zorder{};
 
     //! Whether the volume definition is valid
     explicit operator bool() const
     {
-        return !logic.empty() || (flags & Flags::implicit_vol);
+        return (!logic.empty() || (flags & Flags::implicit_vol))
+               && zorder != ZOrder::invalid;
     }
 };
 

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -66,8 +66,10 @@ void from_json(nlohmann::json const& j, VolumeInput& value)
     }
 
     // Convert logic string to vector
-    auto const& temp_logic = j.at("logic").get<std::string>();
-    value.logic = detail::parse_logic(temp_logic.c_str());
+    if (auto iter = j.find("logic"); iter != j.end())
+    {
+        value.logic = detail::string_to_logic(iter->get<std::string>());
+    }
 
     // Parse bbox
     if (j.contains("bbox"))

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -375,7 +375,7 @@ void from_json(nlohmann::json const& j, RectArrayInput& value)
         auto translations = j.at("translations").get<std::vector<real_type>>();
 
         CELER_VALIDATE(3 * daughters.size() == translations.size(),
-                       << "field 'daughters' is not 3x length of "
+                       << "field 'translations' is not 3x length of "
                           "'daughters'");
 
         value.daughters.resize(daughters.size());

--- a/src/orange/construct/OrangeInputIO.json.cc
+++ b/src/orange/construct/OrangeInputIO.json.cc
@@ -8,6 +8,7 @@
 #include "OrangeInputIO.json.hh"
 
 #include <algorithm>
+#include <initializer_list>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -22,6 +23,7 @@
 #include "corecel/cont/Span.hh"
 #include "corecel/io/Label.hh"
 #include "corecel/io/LabelIO.json.hh"
+#include "corecel/io/Logger.hh"
 #include "orange/BoundingBoxIO.json.hh"
 #include "orange/OrangeTypes.hh"
 #include "orange/construct/OrangeInput.hh"
@@ -43,6 +45,37 @@ decltype(auto) slice(Span<T> data, size_type i)
     CELER_ASSERT(N * (i + 1) <= data.size());
     Array<std::remove_const_t<T>, N> result;
     std::copy_n(data.data() + i * N, N, result.begin());
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a transform from a simple translation.
+ */
+VariantTransform make_transform(Real3 const& translation)
+{
+    if (CELER_UNLIKELY(translation == (Real3{0, 0, 0})))
+    {
+        return NoTransformation{};
+    }
+    return Translation{translation};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a vector of variants to a json array.
+ */
+template<class T>
+nlohmann::json variants_to_json(std::vector<T> const& values)
+{
+    auto result = nlohmann::json::array();
+    for (auto const& var : values)
+    {
+        auto j = nlohmann::json::object();
+        std::visit([&j](auto&& u) { to_json(j, u); }, var);
+        result.push_back(std::move(j));
+    }
+
     return result;
 }
 
@@ -82,34 +115,107 @@ void from_json(nlohmann::json const& j, VolumeInput& value)
     }
 
     // Read scalars, including optional flags
-    auto flag_iter = j.find("flags");
-    value.flags = (flag_iter == j.end() ? 0 : flag_iter->get<int>());
-    j.at("zorder").get_to(value.zorder);
+    if (auto iter = j.find("flags"); iter != j.end())
+    {
+        iter->get_to(value.flags);
+    }
+    else
+    {
+        value.flags = 0;
+    }
+
+    if (auto iter = j.find("zorder"); iter != j.end())
+    {
+        iter->get_to(value.zorder);
+    }
+    else
+    {
+        value.zorder = ZOrder::media;
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write cell/volume data to an ORANGE JSON file.
+ */
+void to_json(nlohmann::json& j, VolumeInput const& value)
+{
+    CELER_EXPECT(value);
+
+    // Convert faces from OpaqueId
+    std::vector<LocalSurfaceId::size_type> temp_faces;
+    temp_faces.reserve(value.faces.size());
+    for (auto surfid : value.faces)
+    {
+        temp_faces.emplace_back(surfid.unchecked_get());
+    }
+    j["faces"] = std::move(temp_faces);
+
+    // Convert logic string to vector
+    if (!value.logic.empty())
+    {
+        j["logic"] = detail::logic_to_string(value.logic);
+    }
+
+    // Write optional values
+    if (value.bbox != BBox::from_infinite())
+    {
+        j["bbox"] = value.bbox;
+    }
+    if (value.flags != 0)
+    {
+        j["flags"] = value.flags;
+    }
+    if (value.zorder != ZOrder::media)
+    {
+        j["zorder"] = std::string(1, to_char(value.zorder));
+    }
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Read a unit definition from an ORANGE input file.
+ *
+ * NOTE: 'cell' nomenclature is from SCALE export (version 0)
  */
 void from_json(nlohmann::json const& j, UnitInput& value)
 {
-    using VecLabel = std::vector<Label>;
-    value.surfaces = detail::read_surfaces(j.at("surfaces"));
-    j.at("cells").get_to(value.volumes);
     j.at("md").at("name").get_to(value.label);
+
+    value.surfaces = detail::import_zipped_surfaces(j.at("surfaces"));
+    for (char const* key : {"volumes", "cells"})
+    {
+        auto iter = j.find(key);
+        if (iter != j.end())
+        {
+            iter->get_to(value.volumes);
+            break;
+        }
+    }
 
     {
         // Move labels into lower-level data structures
-        auto labels = j.at("cell_names").get<VecLabel>();
-        CELER_VALIDATE(labels.size() == value.volumes.size(),
-                       << "incorrect size for volume labels");
+        std::vector<Label> labels;
+        for (char const* key : {"volume_names", "cell_names"})
+        {
+            auto iter = j.find(key);
+            if (iter != j.end())
+            {
+                iter->get_to(labels);
+                break;
+            }
+        }
+        CELER_VALIDATE(labels.size() == value.volumes.size() || labels.empty(),
+                       << "incorrect size for volume labels: got "
+                       << labels.size() << ", expected "
+                       << value.volumes.size());
         for (auto i : range(labels.size()))
         {
             value.volumes[i].label = std::move(labels[i]);
         }
-
-        j.at("surface_names").get_to(value.surface_labels);
     }
+
+    j.at("surface_names").get_to(value.surface_labels);
     if (j.contains("bbox"))
     {
         j.at("bbox").get_to(value.bbox);
@@ -119,36 +225,103 @@ void from_json(nlohmann::json const& j, UnitInput& value)
         value.bbox = BBox::from_infinite();
     }
 
-    if (j.contains("parent_cells"))
+    for (char const* key : {"parent_volumes", "parent_cells"})
     {
-        auto const& parent_cells
-            = j.at("parent_cells").get<std::vector<size_type>>();
+        auto iter = j.find(key);
+        if (iter == j.end())
+        {
+            continue;
+        }
+        auto const& parent_vols = iter->get<std::vector<size_type>>();
 
         auto const& daughters = j.at("daughters").get<std::vector<size_type>>();
-        CELER_VALIDATE(parent_cells.size() == daughters.size(),
-                       << "fields 'parent_cells' and 'daughters' have "
-                          "different lengths");
+        CELER_VALIDATE(parent_vols.size() == daughters.size(),
+                       << "fields '" << key
+                       << "' and 'daughters' have different lengths");
 
-        if (j.contains("transforms"))
+        std::vector<VariantTransform> transforms;  // SCALE ORANGE v0
+        if (auto iter = j.find("transforms"); iter != j.end())
         {
-            CELER_NOT_IMPLEMENTED("transforms from JSON I/O");
+            for (auto const& t : *iter)
+            {
+                transforms.push_back(detail::import_transform(t));
+            }
         }
+        else if (auto iter = j.find("translations"); iter != j.end())
+        {
+            auto translations = iter->get<std::vector<real_type>>();
+            CELER_VALIDATE(3 * parent_vols.size() == translations.size(),
+                           << "field 'translations' is not 3x length of '"
+                           << key << "'");
+            // Convert translations
+            for (auto i : range(parent_vols.size()))
+            {
+                transforms.push_back(
+                    make_transform(slice<3>(make_span(translations), i)));
+            }
+        }
+        else
+        {
+            CELER_VALIDATE(false, << "missing 'transforms' or 'translations'");
+        }
+        CELER_ASSERT(transforms.size() == parent_vols.size());
 
-        auto const& translations
-            = j.at("translations").get<std::vector<real_type>>();
-        CELER_VALIDATE(3 * parent_cells.size() == translations.size(),
-                       << "field 'translations' is not 3x length of "
-                          "'parent_cells'");
-
-        for (auto i : range(parent_cells.size()))
+        for (auto i : range(parent_vols.size()))
         {
             DaughterInput daughter;
             daughter.universe_id = UniverseId{daughters[i]};
-            daughter.transform
-                = detail::make_transform(slice<3>(make_span(translations), i));
-            value.daughter_map.emplace(LocalVolumeId{parent_cells[i]},
+            daughter.transform = std::move(transforms[i]);
+            value.daughter_map.emplace(LocalVolumeId{parent_vols[i]},
                                        std::move(daughter));
         }
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write a unit definition to an ORANGE input file.
+ */
+void to_json(nlohmann::json& j, UnitInput const& value)
+{
+    CELER_EXPECT(value);
+
+    j["_type"] = "unit";
+    j["md"]["name"] = value.label;
+    j["surfaces"] = detail::export_zipped_surfaces(value.surfaces);
+    j["volumes"] = value.volumes;
+
+    j["surface_names"] = value.surface_labels;
+
+    j["volume_names"] = [&value] {
+        auto volume_names = nlohmann::json::array();
+        for (auto const& v : value.volumes)
+        {
+            volume_names.push_back(v.label);
+        }
+        return volume_names;
+    }();
+
+    if (value.bbox != BBox::from_infinite())
+    {
+        j["bbox"] = value.bbox;
+    }
+
+    if (!value.daughter_map.empty())
+    {
+        std::vector<size_type> parent_cells;
+        auto daughters = nlohmann::json::array();
+        auto transforms = nlohmann::json::array();
+
+        for (auto const& [local_vol, daughter_inp] : value.daughter_map)
+        {
+            parent_cells.push_back(local_vol.unchecked_get());
+            daughters.push_back(daughter_inp.universe_id.unchecked_get());
+            transforms.push_back(
+                detail::export_transform(daughter_inp.transform));
+        }
+        j["parent_cells"] = std::move(parent_cells);
+        j["daughters"] = std::move(daughters);
+        j["transforms"] = std::move(transforms);
     }
 }
 
@@ -176,13 +349,17 @@ void from_json(nlohmann::json const& j, RectArrayInput& value)
             CELER_NOT_IMPLEMENTED("transforms from JSON I/O");
         }
 
-        auto parents = j.at("parent_cells").get<std::vector<size_type>>();
+        std::vector<size_type> parents;
+        if (auto iter = j.find("parent_cells"); iter != j.end())
+        {
+            iter->get_to(parents);
+        }
         auto daughters = j.at("daughters").get<std::vector<size_type>>();
         auto translations = j.at("translations").get<std::vector<real_type>>();
 
         CELER_VALIDATE(3 * daughters.size() == translations.size(),
                        << "field 'daughters' is not 3x length of "
-                          "'parent_cells'");
+                          "'daughters'");
 
         value.daughters.resize(daughters.size());
 
@@ -190,12 +367,61 @@ void from_json(nlohmann::json const& j, RectArrayInput& value)
         {
             DaughterInput daughter;
             daughter.universe_id = UniverseId{daughters[i]};
+
+            // Read and convert transform
             daughter.transform
-                = detail::make_transform(slice<3>(make_span(translations), i));
+                = make_transform(slice<3>(make_span(translations), i));
 
             // Save daughter
-            value.daughters[parents[i]] = std::move(daughter);
+            size_type parent = parents.empty() ? i : parents[i];
+            value.daughters[parent] = std::move(daughter);
         }
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write a rectangular array universe definition to an ORANGE input file.
+ */
+void to_json(nlohmann::json& j, RectArrayInput const& value)
+{
+    CELER_EXPECT(value);
+
+    j["_type"] = "rectarray";
+    j["md"] = nlohmann::json::object({{"name", value.label}});
+
+    for (auto ax : range(Axis::size_))
+    {
+        j[std::string(1, to_char(ax))] = value.grid[to_int(ax)];
+    }
+
+    // Write daughters universes/translations
+    {
+        std::vector<size_type> daughters;
+        std::vector<real_type> translations;
+
+        for (auto const& d : value.daughters)
+        {
+            daughters.push_back(d.universe_id.unchecked_get());
+            if (auto* tr = std::get_if<Translation>(&d.transform))
+            {
+                translations.insert(translations.end(),
+                                    tr->translation().begin(),
+                                    tr->translation().end());
+            }
+            else if (std::holds_alternative<NoTransformation>(d.transform))
+            {
+                using R = real_type;
+                translations.insert(translations.end(), {R{0}, R{0}, R{0}});
+            }
+            else
+            {
+                CELER_NOT_IMPLEMENTED("writing rect arrays with transforms");
+            }
+        }
+
+        j["daughters"] = daughters;
+        j["translations"] = translations;
     }
 }
 
@@ -203,7 +429,8 @@ void from_json(nlohmann::json const& j, RectArrayInput& value)
 /*!
  * Read tolerances.
  */
-void from_json(nlohmann::json const& j, Tolerance<>& value)
+template<class T>
+void from_json(nlohmann::json const& j, Tolerance<T>& value)
 {
     j.at("rel").get_to(value.rel);
     CELER_VALIDATE(value.rel > 0 && value.rel < 1,
@@ -216,30 +443,57 @@ void from_json(nlohmann::json const& j, Tolerance<>& value)
                    << " is out of range [must be greater than zero]");
 }
 
+template void from_json(nlohmann::json const&, Tolerance<real_type>&);
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write tolerances.
+ */
+template<class T>
+void to_json(nlohmann::json& j, Tolerance<T> const& value)
+{
+    CELER_EXPECT(value);
+
+    j = {
+        {"rel", value.rel},
+        {"abs", value.abs},
+    };
+}
+
+template void to_json(nlohmann::json&, Tolerance<real_type> const&);
+
 //---------------------------------------------------------------------------//
 /*!
  * Read a partially preprocessed geometry definition from an ORANGE JSON file.
  */
 void from_json(nlohmann::json const& j, OrangeInput& value)
 {
-    auto const& universes = j.at("universes");
+    CELER_VALIDATE(j.contains("_format"),
+                   << "invalid ORANGE JSON input: no '_format' found");
+    auto const& fmt = j.at("_format").get<std::string>();
+    CELER_VALIDATE(fmt == "SCALE ORANGE" || fmt == "ORANGE",
+                   << "invalid ORANGE JSON input: unknown format '" << fmt
+                   << "'");
+    std::string version{"<unknown>"};
+    if (auto iter = j.find("version"); iter != j.end())
+    {
+        version = std::to_string(iter->get<int>());
+    }
+    CELER_LOG(debug) << "Reading '" << fmt << "' input version " << version;
 
+    auto const& universes = j.at("universes");
     value.universes.reserve(universes.size());
 
     for (auto const& uni : universes)
     {
         auto const& uni_type = uni.at("_type").get<std::string>();
-        if (uni_type == "simple unit")
+        if (uni_type == "unit" || uni_type == "simple unit")
         {
             value.universes.push_back(uni.get<UnitInput>());
         }
-        else if (uni_type == "rectangular array")
+        else if (uni_type == "rectarray" || uni_type == "rectangular array")
         {
             value.universes.push_back(uni.get<RectArrayInput>());
-        }
-        else if (uni_type == "hexagonal array")
-        {
-            CELER_NOT_IMPLEMENTED("hexagonal array universes");
         }
         else
         {
@@ -255,21 +509,23 @@ void from_json(nlohmann::json const& j, OrangeInput& value)
 }
 
 //---------------------------------------------------------------------------//
-// WRITERS
-//---------------------------------------------------------------------------//
 /*!
- * Write tolerances.
+ * Write an ORANGE input file.
  */
-template<class T>
-void to_json(nlohmann::json& j, Tolerance<T> const& value)
+void to_json(nlohmann::json& j, OrangeInput const& value)
 {
-    j = {
-        {"rel", value.rel},
-        {"abs", value.abs},
-    };
-}
+    CELER_EXPECT(value);
 
-template void to_json(nlohmann::json&, Tolerance<real_type> const&);
+    j = nlohmann::json::object({
+        {"_format", "ORANGE"},
+        {"_version", 0},
+        {"universes", variants_to_json(value.universes)},
+    });
+    if (value.tol)
+    {
+        j["tol"] = value.tol;
+    }
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/construct/OrangeInputIO.json.hh
+++ b/src/orange/construct/OrangeInputIO.json.hh
@@ -17,17 +17,21 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 
 void from_json(nlohmann::json const& j, VolumeInput& value);
+void to_json(nlohmann::json& j, VolumeInput const& value);
 
 void from_json(nlohmann::json const& j, UnitInput& value);
+void to_json(nlohmann::json& j, UnitInput const& value);
 
 void from_json(nlohmann::json const& j, RectArrayInput& value);
+void to_json(nlohmann::json& j, RectArrayInput const& value);
 
 template<class T>
-void from_json(nlohmann::json const& j, Tolerance<T>& value);
+void from_json(nlohmann::json const& j, Tolerance<>& value);
 template<class T>
 void to_json(nlohmann::json& j, Tolerance<T> const& value);
 
 void from_json(nlohmann::json const& j, OrangeInput& value);
+void to_json(nlohmann::json& j, OrangeInput const& value);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/construct/detail/OrangeInputIOImpl.json.cc
+++ b/src/orange/construct/detail/OrangeInputIOImpl.json.cc
@@ -9,12 +9,15 @@
 
 #include <vector>
 
+#include "corecel/cont/Range.hh"
+#include "corecel/io/Join.hh"
 #include "corecel/io/StringEnumMapper.hh"
-#include "orange/OrangeTypes.hh"
 
 namespace celeritas
 {
 namespace detail
+{
+namespace
 {
 //---------------------------------------------------------------------------//
 /*!
@@ -55,9 +58,77 @@ struct SurfaceEmplacer
 
 //---------------------------------------------------------------------------//
 /*!
+ * Convert a logic token to a string.
+ */
+void logic_to_stream(std::ostream& os, logic_int val)
+{
+    if (logic::is_operator_token(val))
+    {
+        os << to_char(static_cast<logic::OperatorToken>(val));
+    }
+    else
+    {
+        // Just a face ID
+        os << val;
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Read a transform from a JSON object
+ */
+VariantTransform import_transform(nlohmann::json const& src)
+{
+    std::vector<real_type> data;
+    src.get_to(data);
+    if (data.size() == 0)
+    {
+        return NoTransformation{};
+    }
+    else if (data.size() == 3)
+    {
+        return Translation{Translation::StorageSpan{make_span(data)}};
+    }
+    else if (data.size() == 12)
+    {
+        return Transformation{Transformation::StorageSpan{make_span(data)}};
+    }
+    else
+    {
+        CELER_VALIDATE(false,
+                       << "invalid number of elements in transform: "
+                       << data.size());
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write a transform to arrays suitable for JSON export.
+ */
+nlohmann::json export_transform(VariantTransform const& t)
+{
+    // Append the transform data as a single array. Rely on the size to
+    // unpack it.
+    return std::visit(
+        [](auto&& tr) -> nlohmann::json {
+            auto result = nlohmann::json::array();
+            for (auto v : tr.data())
+            {
+                result.push_back(v);
+            }
+            return result;
+        },
+        t);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Read surface data from an ORANGE JSON file.
  */
-std::vector<VariantSurface> read_surfaces(nlohmann::json const& j)
+std::vector<VariantSurface> import_zipped_surfaces(nlohmann::json const& j)
 {
     // Read and convert types
     auto const& type_labels = j.at("types").get<std::vector<std::string>>();
@@ -79,6 +150,35 @@ std::vector<VariantSurface> read_surfaces(nlohmann::json const& j)
         data_idx += sizes[i];
     }
     return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write surface data to a JSON object.
+ */
+nlohmann::json export_zipped_surfaces(std::vector<VariantSurface> const& all_s)
+{
+    std::vector<std::string> surface_types;
+    std::vector<real_type> surface_data;
+    std::vector<size_type> surface_sizes;
+
+    for (auto const& var_s : all_s)
+    {
+        std::visit(
+            [&](auto&& s) {
+                auto d = s.data();
+                surface_types.push_back(to_cstring(s.surface_type()));
+                surface_data.insert(surface_data.end(), d.begin(), d.end());
+                surface_sizes.push_back(d.size());
+            },
+            var_s);
+    }
+
+    return nlohmann::json::object({
+        {"types", std::move(surface_types)},
+        {"data", std::move(surface_data)},
+        {"sizes", std::move(surface_sizes)},
+    });
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/construct/detail/OrangeInputIOImpl.json.hh
+++ b/src/orange/construct/detail/OrangeInputIOImpl.json.hh
@@ -13,21 +13,30 @@
 
 #include "orange/OrangeTypes.hh"
 #include "orange/surf/VariantSurface.hh"
+#include "orange/transform/VariantTransform.hh"
 
 namespace celeritas
 {
 namespace detail
 {
 //---------------------------------------------------------------------------//
+// Read a transform from a JSON object
+VariantTransform import_transform(nlohmann::json const& src);
 
-// Read a vector of surfaces
-std::vector<VariantSurface> read_surfaces(nlohmann::json const& j);
+// Write a transform to arrays suitable for JSON export.
+nlohmann::json export_transform(VariantTransform const& t);
+
+// Read surface data from a JSON object
+std::vector<VariantSurface> import_zipped_surfaces(nlohmann::json const& j);
+
+// Write surface data to a JSON object
+nlohmann::json export_zipped_surfaces(std::vector<VariantSurface> const& s);
 
 // Build a logic definition from a C string.
 std::vector<logic_int> string_to_logic(std::string const& s);
 
-// Construct a transform from a translation.
-VariantTransform make_transform(Real3 const& translation);
+// Convert a logic vector to a string
+std::string logic_to_string(std::vector<logic_int> const&);
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/orange/construct/detail/OrangeInputIOImpl.json.hh
+++ b/src/orange/construct/detail/OrangeInputIOImpl.json.hh
@@ -24,7 +24,7 @@ namespace detail
 std::vector<VariantSurface> read_surfaces(nlohmann::json const& j);
 
 // Build a logic definition from a C string.
-std::vector<logic_int> parse_logic(char const*);
+std::vector<logic_int> string_to_logic(std::string const& s);
 
 // Construct a transform from a translation.
 VariantTransform make_transform(Real3 const& translation);

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -276,15 +276,14 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
     auto input_logic = make_span(v.logic);
     if (v.zorder == ZOrder::background)
     {
-        // Currently SCALE ORANGE writes background volumes as having "empty"
-        // logic, whereas we really want them to be "nowhere" (at least
-        // nowhere *explicitly* using the 'inside' logic). It gets away with
-        // this because it always uses BVH to initialize, and the implicit
-        // volumes get an empty bbox. To avoid special cases in Celeritas, set
-        // the logic to be explicitly "not true".
-        CELER_EXPECT(input_logic.empty());
+        // "Background" volumes should not be explicitly reachable by logic or
+        // by the BVH
         static const logic_int nowhere_logic[] = {logic::ltrue, logic::lnot};
-        input_logic = make_span(nowhere_logic);
+        CELER_EXPECT(std::equal(input_logic.begin(),
+                                input_logic.end(),
+                                std::begin(nowhere_logic),
+                                std::end(nowhere_logic)));
+        CELER_EXPECT(is_infinite(v.bbox));
     }
 
     VolumeRecord output;

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -277,7 +277,7 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
     if (v.zorder == ZOrder::background)
     {
         // "Background" volumes should not be explicitly reachable by logic or
-        // by the BVH
+        // BIH
         static const logic_int nowhere_logic[] = {logic::ltrue, logic::lnot};
         CELER_EXPECT(std::equal(input_logic.begin(),
                                 input_logic.end(),

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -235,7 +235,7 @@ SimpleUnitId UnitInserter::operator()(UnitInput const& inp)
     }
 
     // Save unit scalars
-    if (inp.volumes.back().zorder == 1)
+    if (inp.volumes.back().zorder == ZOrder::background)
     {
         unit.background = LocalVolumeId(inp.volumes.size() - 1);
     }
@@ -274,7 +274,7 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
     }
 
     auto input_logic = make_span(v.logic);
-    if (v.zorder == 1)
+    if (v.zorder == ZOrder::background)
     {
         // Currently SCALE ORANGE writes background volumes as having "empty"
         // logic, whereas we really want them to be "nowhere" (at least

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -183,6 +183,7 @@ void NestedTest::build_orange()
         // Insert volume
         VolumeInput vi;
         vi.label = name;
+        vi.zorder = ZOrder::media;
         if (daughter)
         {
             vi.logic = {1, logic::lnot, 0, logic::land};

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -107,6 +107,7 @@ void OrangeGeoTestBase::build_geometry(OneVolInput inp)
         vi.flags = (inp.complex_tracking ? static_cast<logic_int>(
                         VolumeInput::Flags::internal_surfaces)
                                          : 0);
+        vi.zorder = ZOrder::media;
         vi.label = "infinite";
         return vi;
     }()};
@@ -134,6 +135,7 @@ void OrangeGeoTestBase::build_geometry(TwoVolInput inp)
         std::vector<VolumeInput> result;
         VolumeInput vi;
         vi.faces = {LocalSurfaceId{0}};
+        vi.zorder = ZOrder::media;
 
         // Outside
         vi.logic = {0};

--- a/test/orange/OrangeTypes.test.cc
+++ b/test/orange/OrangeTypes.test.cc
@@ -18,8 +18,6 @@ namespace test
 
 class OrangeTypesTest : public ::celeritas::test::Test
 {
-  protected:
-    void SetUp() override {}
 };
 
 TEST_F(OrangeTypesTest, tolerances)
@@ -58,6 +56,21 @@ TEST_F(OrangeTypesTest, tolerances)
         auto const tol = TolT::from_relative(1e-5, 0.1);
         EXPECT_SOFT_EQ(1e-5, tol.rel);
         EXPECT_SOFT_EQ(1e-6, tol.abs);
+    }
+}
+
+TEST_F(OrangeTypesTest, zorder)
+{
+    // Test round-tripping of zorder
+    for (auto zo : {ZOrder::invalid,
+                    ZOrder::background,
+                    ZOrder::media,
+                    ZOrder::array,
+                    ZOrder::hole,
+                    ZOrder::implicit_exterior,
+                    ZOrder::exterior})
+    {
+        EXPECT_EQ(zo, to_zorder(to_char(zo)));
     }
 }
 

--- a/test/orange/surf/LocalSurfaceVisitor.test.cc
+++ b/test/orange/surf/LocalSurfaceVisitor.test.cc
@@ -83,6 +83,7 @@ class SurfaceActionTest : public OrangeGeoTestBase
             }
             v.logic.insert(v.logic.end(), {logic::ltrue, logic::lor});
             v.bbox = {{-1, -1, -1}, {1, 1, 1}};
+            v.zorder = ZOrder::media;
             return v;
         }()};
 


### PR DESCRIPTION
This will replace the `Json_Exporter` in SCALE by just creating an ORANGE input struct and writing it via JSON. There are a few changes in the JSON output:
- "cell" → "volume"
- "name" → "label"
- materials are no longer written since they're not used by the celeritas geometry
- certain fields are omitted from output if they're empty
- the format is now "ORANGE" instead of "SCALE ORANGE" (version 0 now)
- unit input now writes explicit transformations for each daughter, not a compressed vector of translations

There is a new app `orange-update` that takes an ORANGE (or older SCALE ORANGE) input file and exports it as a new JSON file.