### PR TITLE
Refactor universe insertion and add universe accessors to orange params

### DIFF
--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -27,6 +27,7 @@ list(APPEND SOURCES
   detail/RectArrayInserter.cc
   detail/SurfacesRecordBuilder.cc
   detail/UnitInserter.cc
+  detail/UniverseInserter.cc
   surf/ConeAligned.cc
   surf/CylAligned.cc
   surf/GeneralQuadric.cc

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND SOURCES
   construct/CsgTree.cc
   construct/CsgTypes.cc
   construct/CsgTreeUtils.cc
+  construct/DepthCalculator.cc
   construct/detail/NodeSimplifier.cc
   detail/BIHBuilder.cc
   detail/BIHPartitioner.cc

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -30,6 +30,7 @@
 #include "construct/OrangeInput.hh"
 #include "detail/RectArrayInserter.hh"
 #include "detail/UnitInserter.hh"
+#include "detail/UniverseInserter.hh"
 #include "univ/detail/LogicStack.hh"
 
 #if CELERITAS_USE_JSON
@@ -81,7 +82,7 @@ OrangeInput input_from_json(std::string filename)
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate the maximum num of universe levels within the geometry
+ * Calculate the maximum num of universe levels within the geometry.
  *
  * A single-universe geometry will have a max_depth of 1.
  * The operator() is a recursive function, so for external callers, uid should
@@ -204,95 +205,31 @@ OrangeParams::OrangeParams(OrangeInput input)
     HostVal<OrangeParamsData> host_data;
     host_data.scalars.tol = input.tol;
 
-    // Calculate offsets for UniverseIndexerData
-    {
-        auto ui_surf = make_builder(&host_data.universe_indexer_data.surfaces);
-        auto ui_vol = make_builder(&host_data.universe_indexer_data.volumes);
-        ui_surf.push_back(0);
-        ui_vol.push_back(0);
-
-        auto get_num_surfaces = Overload{
-            [](UnitInput const& u) -> size_type { return u.surfaces.size(); },
-            [](RectArrayInput const& r) -> size_type {
-                return std::accumulate(r.grid.begin(),
-                                       r.grid.end(),
-                                       size_type(0),
-                                       [](size_type acc, const auto& vec) {
-                                           return acc + vec.size();
-                                       });
-            }};
-
-        auto get_num_volumes = Overload{
-            [](UnitInput const& u) -> size_type { return u.volumes.size(); },
-            [](RectArrayInput const& r) -> size_type {
-                return r.daughters.size();
-            }};
-
-        for (auto const& u : input.universes)
-        {
-            using AllVals = AllItems<size_type, MemSpace::native>;
-
-            auto surface_offset
-                = host_data.universe_indexer_data.surfaces[AllVals{}].back();
-            auto volume_offset
-                = host_data.universe_indexer_data.volumes[AllVals{}].back();
-
-            auto num_surfs = std::visit(get_num_surfaces, u);
-            auto num_vols = std::visit(get_num_volumes, u);
-
-            ui_surf.push_back(surface_offset + num_surfs);
-            ui_vol.push_back(volume_offset + num_vols);
-        }
-    }
-
-    // Create universe_types and universe_indices vectors
-    {
-        auto u_types_builder = make_builder(&host_data.universe_types);
-        auto u_indices_builder = make_builder(&host_data.universe_indices);
-
-        std::vector<size_type> current_indices(
-            static_cast<size_t>(UniverseType::size_), 0);
-
-        for (auto const& u : input.universes)
-        {
-            auto u_type_idx = u.index();
-            u_types_builder.push_back(static_cast<UniverseType>(u_type_idx));
-            u_indices_builder.push_back(current_indices[u_type_idx]++);
-        }
-    }
-
     // Insert all universes
     {
-        detail::UnitInserter insert_unit(&host_data);
-        detail::RectArrayInserter insert_rect_array(&host_data);
+        std::vector<Label> universe_labels;
+        std::vector<Label> surface_labels;
+        std::vector<Label> volume_labels;
 
-        auto insert_universe = Overload{
-            [&insert_unit](UnitInput const& u) {
-                CELER_VALIDATE(u,
-                               << "simple unit '" << u.label
-                               << "' is not properly constructed");
-
-                insert_unit(u);
-            },
-            [&insert_rect_array](RectArrayInput const& r) {
-                CELER_VALIDATE(r,
-                               << "rect array '" << r.label
-                               << "' is not properly constructed");
-
-                insert_rect_array(r);
-            },
-        };
+        detail::UniverseInserter insert_universe_base{
+            &universe_labels, &surface_labels, &volume_labels, &host_data};
+        Overload insert_universe{
+            detail::UnitInserter{&insert_universe_base, &host_data},
+            detail::RectArrayInserter{&insert_universe_base, &host_data}};
 
         for (auto const& u : input.universes)
         {
             std::visit(insert_universe, u);
         }
+
+        univ_labels_ = LabelIdMultiMap<UniverseId>{std::move(universe_labels)};
+        surf_labels_ = LabelIdMultiMap<SurfaceId>{std::move(surface_labels)};
+        vol_labels_ = LabelIdMultiMap<VolumeId>{std::move(volume_labels)};
     }
 
-    // Get surface/volume labels
-    this->process_metadata(input);
-
-    supports_safety_ = host_data.simple_units[SimpleUnitId{0}].simple_safety;
+    // Safety currently only works for the single-universe case
+    supports_safety_ = host_data.simple_units.size() == 1
+                       && host_data.simple_units[SimpleUnitId{0}].simple_safety;
 
     CELER_VALIDATE(std::holds_alternative<UnitInput>(input.universes.front()),
                    << "global universe is not a SimpleUnit");
@@ -394,89 +331,27 @@ SurfaceId OrangeParams::find_surface(std::string const& name) const
 }
 
 //---------------------------------------------------------------------------//
-// HELPER FUNCTIONS
+/*!
+ * Get the label of a universe.
+ */
+Label const& OrangeParams::id_to_label(UniverseId univ) const
+{
+    CELER_EXPECT(univ < univ_labels_.size());
+    return univ_labels_.get(univ);
+}
+
 //---------------------------------------------------------------------------//
 /*!
- * Get surface and volume labels for all universes.
+ * Locate the universe ID corresponding to a label name.
  */
-void OrangeParams::process_metadata(OrangeInput const& input)
+UniverseId OrangeParams::find_universe(std::string const& name) const
 {
-    std::vector<Label> surface_labels;
-    std::vector<Label> volume_labels;
-
-    auto GetVolumeLabels = Overload{
-        [&volume_labels](UnitInput const& u) {
-            for (auto const& v : u.volumes)
-            {
-                Label vl = v.label;
-                if (vl.ext.empty())
-                {
-                    vl.ext = u.label.name;
-                }
-                volume_labels.push_back(std::move(vl));
-            }
-        },
-        [&volume_labels](RectArrayInput const& r) {
-            for (auto i : range(r.grid[to_int(Axis::x)].size() - 1))
-            {
-                for (auto j : range(r.grid[to_int(Axis::y)].size() - 1))
-                {
-                    for (auto k : range(r.grid[to_int(Axis::z)].size() - 1))
-                    {
-                        Label vl;
-                        vl.name = std::string("{" + std::to_string(i) + ","
-                                              + std::to_string(j) + ","
-                                              + std::to_string(k) + "}");
-                        vl.ext = r.label.name;
-                        volume_labels.push_back(std::move(vl));
-                    }
-                }
-            }
-        }};
-
-    auto GetSurfaceLabels = Overload{
-        [&surface_labels](UnitInput const& u) {
-            CELER_EXPECT(u.surface_labels.empty()
-                         || u.surface_labels.size() == u.surfaces.size());
-            if (u.surface_labels.empty())
-            {
-                // Append the correct number of empty labels
-                surface_labels.resize(surface_labels.size()
-                                      + u.surfaces.size());
-            }
-
-            for (auto const& s : u.surface_labels)
-            {
-                Label surface_label = s;
-                if (surface_label.ext.empty())
-                {
-                    surface_label.ext = u.label.name;
-                }
-                surface_labels.push_back(std::move(surface_label));
-            }
-        },
-        [&surface_labels](RectArrayInput const& r) {
-            for (auto ax : range(Axis::size_))
-            {
-                for (auto i : range(r.grid[to_int(ax)].size()))
-                {
-                    Label sl;
-                    sl.name = std::string("{" + std::string(1, to_char(ax))
-                                          + "," + std::to_string(i) + "}");
-                    sl.ext = r.label.name;
-                    surface_labels.push_back(std::move(sl));
-                }
-            }
-        }};
-
-    for (auto const& u : input.universes)
-    {
-        std::visit(GetSurfaceLabels, u);
-        std::visit(GetVolumeLabels, u);
-    }
-
-    surf_labels_ = LabelIdMultiMap<SurfaceId>{std::move(surface_labels)};
-    vol_labels_ = LabelIdMultiMap<VolumeId>{std::move(volume_labels)};
+    auto result = univ_labels_.find_all(name);
+    if (result.empty())
+        return {};
+    CELER_VALIDATE(result.size() == 1,
+                   << "universe '" << name << "' is not unique");
+    return result.front();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -61,7 +61,7 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     // Number of volumes
     inline VolumeId::size_type num_volumes() const final;
 
-    // Get the label for a placed volume ID
+    // Get the label for a volume ID
     Label const& id_to_label(VolumeId vol_id) const final;
 
     //! \cond
@@ -82,14 +82,25 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
 
     //// SURFACES ////
 
-    // Get the label for a placed volume ID
+    // Get the label for a surface ID
     Label const& id_to_label(SurfaceId surf_id) const final;
 
     // Get the surface ID corresponding to a unique label name
     SurfaceId find_surface(std::string const& name) const final;
 
-    //! Number of distinct surfaces
+    // Number of distinct surfaces
     inline SurfaceId::size_type num_surfaces() const final;
+
+    //// UNIVERSES ////
+
+    // Get the label for a universe ID
+    Label const& id_to_label(UniverseId surf_id) const;
+
+    // Get the universe ID corresponding to a unique label name
+    UniverseId find_universe(std::string const& name) const;
+
+    // Number of universes
+    inline UniverseId::size_type num_universes() const;
 
     //// DATA ACCESS ////
 
@@ -101,6 +112,7 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
 
   private:
     // Host metadata/access
+    LabelIdMultiMap<UniverseId> univ_labels_;
     LabelIdMultiMap<SurfaceId> surf_labels_;
     LabelIdMultiMap<VolumeId> vol_labels_;
     BBox bbox_;
@@ -108,12 +120,6 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
 
     // Host/device storage and reference
     CollectionMirror<OrangeParamsData> data_;
-
-  private:
-    //// HELPER METHODS ////
-
-    // Get surface and volume labels for all universes.
-    void process_metadata(OrangeInput const& input);
 };
 
 //---------------------------------------------------------------------------//
@@ -140,11 +146,20 @@ VolumeId::size_type OrangeParams::num_volumes() const
 
 //---------------------------------------------------------------------------//
 /*!
- * Number of distinct surfaces.
+ * Number of surfaces.
  */
 SurfaceId::size_type OrangeParams::num_surfaces() const
 {
     return surf_labels_.size();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Number of universes.
+ */
+UniverseId::size_type OrangeParams::num_universes() const
+{
+    return univ_labels_.size();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -274,7 +274,7 @@ OrangeTrackView::operator=(Initializer_t const& init)
         auto tinit = visit_tracker(
             [&local](auto&& t) { return t.initialize(local); }, uid);
 
-        // TODO: error correction/graceful failure if initialiation failed
+        // TODO: error correction/graceful failure if initialization failed
         CELER_ASSERT(tinit.volume && !tinit.surface);
 
         auto lsa = this->make_lsa(LevelId{level});

--- a/src/orange/construct/DepthCalculator.cc
+++ b/src/orange/construct/DepthCalculator.cc
@@ -1,0 +1,77 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/construct/DepthCalculator.cc
+//---------------------------------------------------------------------------//
+#include "DepthCalculator.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with a reference to all universe inputs.
+ */
+DepthCalculator::DepthCalculator(VecVarUniv const& inp)
+    : visit_univ_{inp}, num_univ_{inp.size()}
+{
+    CELER_EXPECT(num_univ_ > 0);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the depth of a unit.
+ */
+size_type DepthCalculator::operator()(UnitInput const& u)
+{
+    // Calculate the depth of the deepest daughter
+    size_type max_daughter{0};
+    for (auto&& [vol, daughter] : u.daughter_map)
+    {
+        max_daughter = std::max(max_daughter, (*this)(daughter.universe_id));
+    }
+
+    // Add one for the current universe
+    return max_daughter + 1;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the depth of a rect array.
+ */
+size_type DepthCalculator::operator()(RectArrayInput const& u)
+{
+    // Calculate the depth of the deepest daughter
+    size_type max_daughter{0};
+    for (auto&& daughter : u.daughters)
+    {
+        max_daughter = std::max(max_daughter, (*this)(daughter.universe_id));
+    }
+
+    // Add one for the current universe
+    return max_daughter + 1;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Check cache or calculate.
+ */
+size_type DepthCalculator::operator()(UniverseId uid)
+{
+    CELER_EXPECT(uid < num_univ_);
+    // Check for cached value
+    auto&& [iter, inserted] = depths_.insert({uid, {}});
+    if (inserted)
+    {
+        // Visit and save value
+        iter->second = visit_univ_(*this, uid.unchecked_get());
+    }
+
+    // Return cached value
+    CELER_ENSURE(iter->second > 0);
+    return iter->second;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/construct/DepthCalculator.hh
+++ b/src/orange/construct/DepthCalculator.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <vector>
 
 #include "corecel/cont/VariantUtils.hh"
 
@@ -42,7 +43,7 @@ class DepthCalculator
 
   private:
     ContainerVisitor<VecVarUniv const&> visit_univ_;
-    size_type num_univ_;
+    std::size_t num_univ_;
     std::unordered_map<UniverseId, size_type> depths_;
 
     // Check cache or calculate

--- a/src/orange/construct/DepthCalculator.hh
+++ b/src/orange/construct/DepthCalculator.hh
@@ -1,0 +1,53 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/construct/DepthCalculator.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <unordered_map>
+
+#include "corecel/cont/VariantUtils.hh"
+
+#include "OrangeInput.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the maximum number of levels deep in a geometry.
+ */
+class DepthCalculator
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using VecVarUniv = std::vector<VariantUniverseInput>;
+    //!@}
+
+  public:
+    // Construct with a reference to all universe inputs
+    explicit DepthCalculator(VecVarUniv const&);
+
+    //! Calculate the depth of the global unit
+    size_type operator()() { return this->visit_univ_(*this, 0); }
+
+    // Calculate the depth of a unit
+    size_type operator()(UnitInput const& u);
+
+    // Calculate the depth of a rect array
+    size_type operator()(RectArrayInput const& u);
+
+  private:
+    ContainerVisitor<VecVarUniv const&> visit_univ_;
+    size_type num_univ_;
+    std::unordered_map<UniverseId, size_type> depths_;
+
+    // Check cache or calculate
+    size_type operator()(UniverseId uid);
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/detail/RectArrayInserter.cc
+++ b/src/orange/detail/RectArrayInserter.cc
@@ -13,21 +13,55 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/data/Collection.hh"
-#include "corecel/data/CollectionBuilder.hh"
 #include "orange/construct/OrangeInput.hh"
+
+#include "UniverseInserter.hh"
 
 namespace celeritas
 {
 namespace detail
 {
+namespace
+{
+//---------------------------------------------------------------------------//
+//! Return correctly sized volume labels
+std::vector<Label> make_volume_labels(RectArrayInput const& inp)
+{
+    std::vector<Label> result;
+    for (auto i : range(inp.grid[to_int(Axis::x)].size() - 1))
+    {
+        for (auto j : range(inp.grid[to_int(Axis::y)].size() - 1))
+        {
+            for (auto k : range(inp.grid[to_int(Axis::z)].size() - 1))
+            {
+                Label vl;
+                vl.name = std::string("{" + std::to_string(i) + ","
+                                      + std::to_string(j) + ","
+                                      + std::to_string(k) + "}");
+                vl.ext = inp.label.name;
+                result.push_back(std::move(vl));
+            }
+        }
+    }
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct from full parameter data.
  */
-RectArrayInserter::RectArrayInserter(Data* orange_data)
+RectArrayInserter::RectArrayInserter(UniverseInserter* insert_universe,
+                                     Data* orange_data)
     : orange_data_(orange_data)
     , insert_transform_{&orange_data_->transforms, &orange_data_->reals}
+    , insert_universe_{insert_universe}
+    , rect_arrays_{&orange_data_->rect_arrays}
+    , reals_{&orange_data_->reals}
+    , daughters_{&orange_data_->daughters}
 {
     CELER_EXPECT(orange_data);
 }
@@ -36,12 +70,15 @@ RectArrayInserter::RectArrayInserter(Data* orange_data)
 /*!
  * Create a rect array unit and return its ID.
  */
-RectArrayId RectArrayInserter::operator()(RectArrayInput const& inp)
+UniverseId RectArrayInserter::operator()(RectArrayInput const& inp)
 {
+    CELER_VALIDATE(
+        inp, << "rect array '" << inp.label << "' is not properly constructed");
+
     RectArrayRecord record;
     RectArrayRecord::SurfaceIndexerData::Sizes sizes;
 
-    auto reals_builder = make_builder(&orange_data_->reals);
+    std::vector<Label> surface_labels;
     size_type num_volumes = 1;
 
     for (auto ax : range(Axis::size_))
@@ -64,8 +101,17 @@ RectArrayId RectArrayInserter::operator()(RectArrayInput const& inp)
         record.dims[to_int(ax)] = grid.size() - 1;
         num_volumes *= grid.size() - 1;
 
-        record.grid[to_int(ax)]
-            = reals_builder.insert_back(grid.begin(), grid.end());
+        record.grid[to_int(ax)] = reals_.insert_back(grid.begin(), grid.end());
+
+        // Create surface labels
+        for (auto i : range(inp.grid[to_int(ax)].size()))
+        {
+            Label sl;
+            sl.name = std::string("{" + std::string(1, to_char(ax)) + ","
+                                  + std::to_string(i) + "}");
+            sl.ext = inp.label.name;
+            surface_labels.push_back(std::move(sl));
+        }
     }
 
     record.surface_indexer_data
@@ -77,6 +123,7 @@ RectArrayId RectArrayInserter::operator()(RectArrayInput const& inp)
                    << "' does not match number of volumes (" << num_volumes
                    << ")");
 
+    // Construct daughters
     std::vector<Daughter> daughters;
     for (auto const& daughter_input : inp.daughters)
     {
@@ -85,14 +132,18 @@ RectArrayId RectArrayInserter::operator()(RectArrayInput const& inp)
         d.transform_id = insert_transform_(daughter_input.transform);
         daughters.push_back(d);
     }
-
     record.daughters = ItemMap<LocalVolumeId, DaughterId>(
-        make_builder(&orange_data_->daughters)
-            .insert_back(daughters.begin(), daughters.end()));
+        daughters_.insert_back(daughters.begin(), daughters.end()));
 
+    // Add rect array record
     CELER_ASSERT(record);
-    return RectArrayId(
-        make_builder(&orange_data_->rect_arrays).push_back(record).get());
+    rect_arrays_.push_back(record);
+
+    // Construct universe
+    return (*insert_universe_)(UniverseType::simple,
+                               inp.label,
+                               std::move(surface_labels),
+                               make_volume_labels(inp));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/RectArrayInserter.cc
+++ b/src/orange/detail/RectArrayInserter.cc
@@ -44,6 +44,7 @@ std::vector<Label> make_volume_labels(RectArrayInput const& inp)
         }
     }
 
+    CELER_ENSURE(result.size() == inp.daughters.size());
     return result;
 }
 
@@ -140,7 +141,7 @@ UniverseId RectArrayInserter::operator()(RectArrayInput const& inp)
     rect_arrays_.push_back(record);
 
     // Construct universe
-    return (*insert_universe_)(UniverseType::simple,
+    return (*insert_universe_)(UniverseType::rect_array,
                                inp.label,
                                std::move(surface_labels),
                                make_volume_labels(inp));

--- a/src/orange/detail/RectArrayInserter.hh
+++ b/src/orange/detail/RectArrayInserter.hh
@@ -8,6 +8,8 @@
 #pragma once
 
 #include "corecel/Types.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "corecel/data/DedupeCollectionBuilder.hh"
 #include "orange/OrangeData.hh"
 #include "orange/OrangeTypes.hh"
 #include "orange/construct/OrangeInput.hh"
@@ -18,6 +20,7 @@ namespace celeritas
 {
 namespace detail
 {
+class UniverseInserter;
 //---------------------------------------------------------------------------//
 /*!
  * Convert a RectArrayInput a RectArrayRecord.
@@ -31,15 +34,20 @@ class RectArrayInserter
     //!@}
 
   public:
-    // Construct from full parameter data
-    RectArrayInserter(Data* orange_data);
+    // Construct with universe inserter and parameter data
+    RectArrayInserter(UniverseInserter* insert_universe, Data* orange_data);
 
     // Create a simple unit and return its ID
-    RectArrayId operator()(RectArrayInput const& inp);
+    UniverseId operator()(RectArrayInput const& inp);
 
   private:
     Data* orange_data_{nullptr};
     TransformInserter insert_transform_;
+    UniverseInserter* insert_universe_;
+
+    CollectionBuilder<RectArrayRecord> rect_arrays_;
+    DedupeCollectionBuilder<real_type> reals_;
+    CollectionBuilder<Daughter> daughters_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/SurfacesRecordBuilder.cc
+++ b/src/orange/detail/SurfacesRecordBuilder.cc
@@ -54,8 +54,8 @@ auto SurfacesRecordBuilder::operator()(VecSurface const& surfaces)
     }
 
     result_type result;
-    result.surfaces.types = {begin_types, types_.size_id()};
-    result.surfaces.data_offsets = {begin_real_ids, real_ids_.size_id()};
+    result.types = {begin_types, types_.size_id()};
+    result.data_offsets = {begin_real_ids, real_ids_.size_id()};
 
     CELER_ENSURE(types_.size() == real_ids_.size());
     return result;

--- a/src/orange/detail/SurfacesRecordBuilder.hh
+++ b/src/orange/detail/SurfacesRecordBuilder.hh
@@ -24,7 +24,7 @@ namespace detail
 /*!
  * Convert a vector of surfaces into type-deleted local surface data.
  *
- * TODO: deduplicate local surfaces and global surface data.
+ * The input surfaces should already be deduplicated.
  */
 class SurfacesRecordBuilder
 {
@@ -35,14 +35,8 @@ class SurfacesRecordBuilder
     using Items = Collection<T, Ownership::value, MemSpace::host>;
     using RealId = OpaqueId<real_type>;
     using VecSurface = std::vector<VariantSurface>;
+    using result_type = SurfacesRecord;
     //!@}
-
-    struct result_type
-    {
-        SurfacesRecord surfaces;
-        // TODO: deduplicating will remap input surface indices to LSIds
-        std::vector<LocalSurfaceId> local_ids;
-    };
 
   public:
     // Construct with pointers to the underlying storage

--- a/src/orange/detail/UnitInserter.hh
+++ b/src/orange/detail/UnitInserter.hh
@@ -7,8 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <vector>
-
 #include "corecel/Types.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/DedupeCollectionBuilder.hh"
@@ -24,6 +22,7 @@ namespace celeritas
 {
 namespace detail
 {
+class UniverseInserter;
 //---------------------------------------------------------------------------//
 /*!
  * Convert a unit input to params data.
@@ -40,16 +39,17 @@ class UnitInserter
 
   public:
     // Construct from full parameter data
-    explicit UnitInserter(Data* orange_data);
+    UnitInserter(UniverseInserter* insert_universe, Data* orange_data);
 
     // Create a simple unit and store in in OrangeParamsData
-    SimpleUnitId operator()(UnitInput const& inp);
+    UniverseId operator()(UnitInput const& inp);
 
   private:
     Data* orange_data_{nullptr};
     BIHBuilder build_bih_tree_;
     TransformInserter insert_transform_;
     SurfacesRecordBuilder build_surfaces_;
+    UniverseInserter* insert_universe_;
 
     CollectionBuilder<SimpleUnitRecord> simple_units_;
 

--- a/src/orange/detail/UniverseInserter.cc
+++ b/src/orange/detail/UniverseInserter.cc
@@ -1,0 +1,102 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/detail/UniverseInserter.cc
+//---------------------------------------------------------------------------//
+#include "UniverseInserter.hh"
+
+#include <algorithm>
+#include <iterator>
+#include <numeric>
+
+namespace celeritas
+{
+namespace detail
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+template<class T>
+void move_back(std::vector<T>& dst, std::vector<T>&& src)
+{
+    dst.insert(dst.end(),
+               std::make_move_iterator(src.begin()),
+               std::make_move_iterator(src.end()));
+    src.clear();
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Initialize with metadata and data.
+ *
+ * Push back initial zeros on construction.
+ */
+UniverseInserter::UniverseInserter(VecLabel* universe_labels,
+                                   VecLabel* surface_labels,
+                                   VecLabel* volume_labels,
+                                   Data* data)
+    : universe_labels_{universe_labels}
+    , surface_labels_{surface_labels}
+    , volume_labels_{volume_labels}
+    , types_(&data->universe_types)
+    , indices_(&data->universe_indices)
+    , surfaces_{&data->universe_indexer_data.surfaces}
+    , volumes_{&data->universe_indexer_data.volumes}
+{
+    CELER_EXPECT(universe_labels_ && surface_labels_ && volume_labels_ && data);
+    CELER_EXPECT(types_.size() == 0);
+    CELER_EXPECT(surfaces_.size() == 0);
+
+    std::fill(num_universe_types_.begin(), num_universe_types_.end(), 0u);
+
+    // Add initial zero offset for universe indexer
+    surfaces_.push_back(accum_surface_);
+    volumes_.push_back(accum_volume_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Accumulate the number of local surfaces and volumes.
+ */
+UniverseId UniverseInserter::operator()(UniverseType type,
+                                        Label univ_label,
+                                        VecLabel surface_labels,
+                                        VecLabel volume_labels)
+{
+    CELER_EXPECT(type != UniverseType::size_);
+    CELER_EXPECT(!volume_labels.empty());
+
+    UniverseId result = types_.size_id();
+
+    // Add universe type and index
+    types_.push_back(type);
+    indices_.push_back(num_universe_types_[type]++);
+
+    // Accumulate and append surface/volumes to universe indexer
+    accum_surface_ += surface_labels.size();
+    accum_volume_ += volume_labels.size();
+    surfaces_.push_back(accum_surface_);
+    volumes_.push_back(accum_volume_);
+
+    // Append metadata
+    universe_labels_->push_back(std::move(univ_label));
+    move_back(*surface_labels_, std::move(surface_labels));
+    move_back(*volume_labels_, std::move(volume_labels));
+
+    CELER_ENSURE(std::accumulate(num_universe_types_.begin(),
+                                 num_universe_types_.end(),
+                                 size_type(0))
+                 == types_.size());
+    CELER_ENSURE(surfaces_.size() == types_.size() + 1);
+    CELER_ENSURE(volumes_.size() == surfaces_.size());
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/orange/detail/UniverseInserter.hh
+++ b/src/orange/detail/UniverseInserter.hh
@@ -1,0 +1,64 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/detail/UniverseInserter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Types.hh"
+#include "corecel/cont/EnumArray.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "corecel/io/Label.hh"
+#include "orange/OrangeData.hh"
+#include "orange/OrangeTypes.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a universe entry.
+ */
+class UniverseInserter
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Data = HostVal<OrangeParamsData>;
+    using VecLabel = std::vector<Label>;
+    //!@}
+
+  public:
+    // Construct from full parameter data
+    UniverseInserter(VecLabel* universe_labels,
+                     VecLabel* surface_labels,
+                     VecLabel* volume_labels,
+                     Data* data);
+
+    // Append the number of local surfaces and volumes
+    UniverseId operator()(UniverseType type,
+                          Label univ_label,
+                          VecLabel surface_labels,
+                          VecLabel volume_labels);
+
+  private:
+    VecLabel* universe_labels_;
+    VecLabel* surface_labels_;
+    VecLabel* volume_labels_;
+
+    CollectionBuilder<UniverseType, MemSpace::host, UniverseId> types_;
+    CollectionBuilder<size_type, MemSpace::host, UniverseId> indices_;
+    CollectionBuilder<size_type> surfaces_;
+    CollectionBuilder<size_type> volumes_;
+
+    EnumArray<UniverseType, size_type> num_universe_types_{};
+    size_type accum_surface_{0};
+    size_type accum_volume_{0};
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -116,9 +116,13 @@ TEST_F(OneVolumeTest, params)
 {
     OrangeParams const& geo = this->params();
 
+    EXPECT_EQ(1, geo.num_universes());
     EXPECT_EQ(1, geo.num_volumes());
     EXPECT_EQ(0, geo.num_surfaces());
     EXPECT_TRUE(geo.supports_safety());
+
+    EXPECT_EQ("one volume", geo.id_to_label(UniverseId{0}).name);
+    EXPECT_EQ(UniverseId{0}, geo.find_universe("one volume"));
 
     EXPECT_EQ("infinite", geo.id_to_label(VolumeId{0}).name);
     EXPECT_EQ(VolumeId{0}, geo.find_volume("infinite"));


### PR DESCRIPTION
This improves the construction of universe types (unit, rect array) from orange params by moving type-specific dispatch code from OrangeParams into the builders themselves.  Variants are super nice to work with, and this uses more of them.