### PR TITLE
Adapt to the new BVH navigator from VecGeom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,7 +270,7 @@ endif()
 
 if(CELERITAS_USE_VecGeom)
   if(NOT VecGeom_FOUND)
-    find_package(VecGeom 1.1.17 REQUIRED)
+    find_package(VecGeom 1.2.4 REQUIRED)
   endif()
 
   if(CELERITAS_USE_CUDA AND NOT VecGeom_CUDA_FOUND)

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -211,16 +211,9 @@ VecgeomTrackView::operator=(Initializer_t const& init)
     vecgeom::VPlacedVolume const* worldvol = params_.world_volume;
     bool const contains_point = true;
 
-    // Note that LocateGlobalPoint sets `vgstate_`. If `vgstate_` is outside
-    // (including possibly on the outside volume edge), the volume pointer it
-    // returns would be null at this point.
-#if VECGEOM_VERSION >= 0x020000
+    // LocatePointIn sets `vgstate_`
     BVHNavigator::LocatePointIn(
         worldvol, detail::to_vector(pos_), vgstate_, contains_point);
-#else
-    BVHNavigator::LocatePointIn(
-        worldvol, detail::to_vector(pos_), vgstate_, contains_point);
-#endif
     return *this;
 }
 

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -373,18 +373,18 @@ CELER_FUNCTION real_type VecgeomTrackView::find_safety(real_type max_radius)
     CELER_EXPECT(!this->is_on_boundary());
     CELER_EXPECT(max_radius > 0);
 
-    real_type safety = BVHNavigator::ComputeSafety(
-        detail::to_vector(this->pos()),
-        vgstate_
 #if VECGEOM_VERSION < 0x020000
-        ,
-        max_radius
+    real_type safety = BVHNavigator::ComputeSafety(
+        detail::to_vector(this->pos()), vgstate_, max_radius);
+#else
+    real_type safety = BVHNavigator::ComputeSafety(
+        detail::to_vector(this->pos()), vgstate_);
+    safety = min<real_type>(safety, max_radius);
 #endif
-    );
 
     // Since the reported "safety" is negative if we've moved slightly beyond
     // the boundary of a solid without crossing it, we must clamp to zero.
-    return max<real_type>(0., min<real_type>(safety, max_radius));
+    return max<real_type>(0., safety);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -27,10 +27,8 @@
 
 #if VECGEOM_VERSION >= 0x020000
 #    include <VecGeom/navigation/BVHNavigator.h>
-using BVHNavigator = vecgeom::BVHNavigator;
 #else
 #    include "detail/BVHNavigator.hh"
-using BVHNavigator = celeritas::detail::BVHNavigator;
 #endif
 namespace celeritas
 {
@@ -56,6 +54,11 @@ class VecgeomTrackView
     using Initializer_t = GeoTrackInitializer;
     using ParamsRef = NativeCRef<VecgeomParamsData>;
     using StateRef = NativeRef<VecgeomStateData>;
+#if VECGEOM_VERSION >= 0x020000
+    using BVHNavigator = vecgeom::BVHNavigator;
+#else
+    using BVHNavigator = celeritas::detail::BVHNavigator;
+#endif
     //!@}
 
     //! Helper struct for initializing from an existing geometry state
@@ -388,7 +391,7 @@ CELER_FUNCTION real_type VecgeomTrackView::find_safety(real_type max_radius)
 
     // Since the reported "safety" is negative if we've moved slightly beyond
     // the boundary of a solid without crossing it, we must clamp to zero.
-    return clamp(safety, 0., max_radius);
+    return max<real_type>(0., min<real_type>(safety, max_radius));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/VecgeomTrackView.hh
+++ b/src/celeritas/ext/VecgeomTrackView.hh
@@ -384,7 +384,7 @@ CELER_FUNCTION real_type VecgeomTrackView::find_safety(real_type max_radius)
 
     // Since the reported "safety" is negative if we've moved slightly beyond
     // the boundary of a solid without crossing it, we must clamp to zero.
-    return max<real_type>(0., safety);
+    return max<real_type>(safety, 0);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -139,11 +139,13 @@ class FourLevelsTest : public VecgeomTestBase
         return this->load_vgdml("four-levels.gdml");
     }
 
+#if VECGEOM_VERSION >= 0x020000
     SpanStringView expected_log_levels() const final
     {
         static std::string_view const levels[] = {"warning"};
         return make_span(levels);
     }
+#endif
 };
 
 //---------------------------------------------------------------------------//
@@ -479,8 +481,12 @@ class SolidsTest : public VecgeomTestBase
 
     SpanStringView expected_log_levels() const final
     {
+#if VECGEOM_VERSION >= 0x020000
         static std::string_view const levels[]
             = {"warning", "warning", "warning"};
+#else
+        static std::string_view const levels[] = {"warning"};
+#endif
         return make_span(levels);
     }
 };
@@ -790,11 +796,13 @@ class CmseTest : public VecgeomTestBase
   public:
     SPConstGeo build_geometry() final { return this->load_vgdml("cmse.gdml"); }
 
+#if VECGEOM_VERSION >= 0x020000
     SpanStringView expected_log_levels() const final
     {
         static std::string_view const levels[] = {"warning"};
         return make_span(levels);
     }
+#endif
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -138,6 +138,12 @@ class FourLevelsTest : public VecgeomTestBase
     {
         return this->load_vgdml("four-levels.gdml");
     }
+
+    SpanStringView expected_log_levels() const final
+    {
+        static std::string_view const levels[] = {"warning"};
+        return make_span(levels);
+    }
 };
 
 //---------------------------------------------------------------------------//
@@ -473,7 +479,8 @@ class SolidsTest : public VecgeomTestBase
 
     SpanStringView expected_log_levels() const final
     {
-        static std::string_view const levels[] = {"warning"};
+        static std::string_view const levels[]
+            = {"warning", "warning", "warning"};
         return make_span(levels);
     }
 };
@@ -782,6 +789,12 @@ class CmseTest : public VecgeomTestBase
 {
   public:
     SPConstGeo build_geometry() final { return this->load_vgdml("cmse.gdml"); }
+
+    SpanStringView expected_log_levels() const final
+    {
+        static std::string_view const levels[] = {"warning"};
+        return make_span(levels);
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/Vecgeom.test.cc
+++ b/test/celeritas/ext/Vecgeom.test.cc
@@ -139,13 +139,18 @@ class FourLevelsTest : public VecgeomTestBase
         return this->load_vgdml("four-levels.gdml");
     }
 
-#if VECGEOM_VERSION >= 0x020000
     SpanStringView expected_log_levels() const final
     {
-        static std::string_view const levels[] = {"warning"};
-        return make_span(levels);
+        if (VECGEOM_VERSION >= 0x020000)
+        {
+            static std::string_view const levels[] = {"warning"};
+            return make_span(levels);
+        }
+        else
+        {
+            return {};
+        }
     }
-#endif
 };
 
 //---------------------------------------------------------------------------//
@@ -481,13 +486,17 @@ class SolidsTest : public VecgeomTestBase
 
     SpanStringView expected_log_levels() const final
     {
-#if VECGEOM_VERSION >= 0x020000
-        static std::string_view const levels[]
-            = {"warning", "warning", "warning"};
-#else
-        static std::string_view const levels[] = {"warning"};
-#endif
-        return make_span(levels);
+        if (VECGEOM_VERSION >= 0x020000)
+        {
+            static std::string_view const levels[]
+                = {"warning", "warning", "warning"};
+            return make_span(levels);
+        }
+        else
+        {
+            static std::string_view const levels[] = {"warning"};
+            return make_span(levels);
+        }
     }
 };
 
@@ -796,13 +805,18 @@ class CmseTest : public VecgeomTestBase
   public:
     SPConstGeo build_geometry() final { return this->load_vgdml("cmse.gdml"); }
 
-#if VECGEOM_VERSION >= 0x020000
     SpanStringView expected_log_levels() const final
     {
-        static std::string_view const levels[] = {"warning"};
-        return make_span(levels);
+        if (VECGEOM_VERSION >= 0x020000)
+        {
+            static std::string_view const levels[] = {"warning"};
+            return make_span(levels);
+        }
+        else
+        {
+            return {};
+        }
     }
-#endif
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
The AdePT BVH navigator was made available directly from VecGeom. This branch adapts Celeritas to use the BVHNavigator from VecGeom v2.x.

In case VecGeom v1.x  is used, based on the definition of VECGEOM_VERSION, the BVHNavigator from celeritas/ext/detail/BVHNavigator.hh will be used.