### PR TITLE
Drop trailing underscores for private functions and leading `this->` for private data

### DIFF
--- a/doc/appendices/development.rst
+++ b/doc/appendices/development.rst
@@ -198,8 +198,9 @@ Symbol names
 
 Functions should be verbs; classes should be names. As in standard Python
 (PEP-8-compliant) code, classes should use ``CapWordsStyle`` and variables use
-``snake_case_style``. Private data should have trailing underscores, and public
-member data in structs should not have trailing underscores.
+``snake_case_style``. A symbol should have a trailing underscore *always and
+only* if it is private member data: neither public member data nor private
+member functions should have them.
 
 Functors (classes whose instances act like a function) should be an *agent
 noun*: the noun form of an action verb. Instances of a functor should be a
@@ -368,8 +369,8 @@ Odds and ends
 Although ``struct`` and ``class`` are interchangeable for class definitions
 (modifying only the default visibility as public or private), use ``struct``
 for data-oriented classes that don't declare constructors and have only
-public data; and ``class`` for classes designed to encapsulate functionality
-and/or data.
+public data; and use ``class`` for classes designed to encapsulate
+functionality and/or data.
 
 With template parameters, ``typename T`` and ``class T`` are also
 interchangeable, but use ``template <class T>`` to be consistent internally and
@@ -377,6 +378,9 @@ with the standard library. (It's also possible to have ``template <typename``
 where ``typename`` *doesn't* mean a class: namely,
 ``template <typename U::value_type Value>``.)
 
+Use ``this->`` when calling member functions inside a class to convey that the
+``this`` pointer is implicitly being passed to the function and to make it
+easier to differentiate from a free function in the current scope.
 
 Data management in Celeritas
 ============================

--- a/src/accel/RZMapMagneticField.hh
+++ b/src/accel/RZMapMagneticField.hh
@@ -71,8 +71,8 @@ RZMapMagneticField::RZMapMagneticField(SPConstFieldParams params)
 void RZMapMagneticField::GetFieldValue(double const pos[3], double* field) const
 {
     // Calculate the magnetic field value in the native Celeritas unit system
-    Real3 result = this->calc_field_(Real3{pos[0], pos[1], pos[2]}
-                                     * this->to_celer_cm());
+    Real3 result
+        = calc_field_(Real3{pos[0], pos[1], pos[2]} * this->to_celer_cm());
     for (auto i = 0; i < 3; ++i)
     {
         // Return values of the field vector in CLHEP::tesla for Geant4

--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -165,7 +165,7 @@ template<class Engine>
 CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
 {
     // Allocate space for the electron/positron pair
-    Secondary* secondaries = this->allocate_(2);
+    Secondary* secondaries = allocate_(2);
     if (secondaries == nullptr)
     {
         // Failed to allocate space for secondaries

--- a/src/celeritas/em/interactor/CombinedBremInteractor.hh
+++ b/src/celeritas/em/interactor/CombinedBremInteractor.hh
@@ -137,7 +137,7 @@ CELER_FUNCTION Interaction CombinedBremInteractor::operator()(Engine& rng)
     }
 
     // Allocate space for the brems photon
-    Secondary* secondaries = this->allocate_(1);
+    Secondary* secondaries = allocate_(1);
     if (secondaries == nullptr)
     {
         // Failed to allocate space for the secondary

--- a/src/celeritas/em/interactor/EPlusGGInteractor.hh
+++ b/src/celeritas/em/interactor/EPlusGGInteractor.hh
@@ -98,7 +98,7 @@ template<class Engine>
 CELER_FUNCTION Interaction EPlusGGInteractor::operator()(Engine& rng)
 {
     // Allocate space for two gammas
-    Secondary* secondaries = this->allocate_(2);
+    Secondary* secondaries = allocate_(2);
     if (secondaries == nullptr)
     {
         // Failed to allocate space for two secondaries

--- a/src/celeritas/em/interactor/KleinNishinaInteractor.hh
+++ b/src/celeritas/em/interactor/KleinNishinaInteractor.hh
@@ -105,7 +105,7 @@ CELER_FUNCTION Interaction KleinNishinaInteractor::operator()(Engine& rng)
     using Energy = units::MevEnergy;
 
     // Allocate space for the single electron to be emitted
-    Secondary* electron_secondary = this->allocate_(1);
+    Secondary* electron_secondary = allocate_(1);
     if (electron_secondary == nullptr)
     {
         // Failed to allocate space for a secondary

--- a/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
+++ b/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
@@ -125,7 +125,7 @@ CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
     }
 
     // Allocate memory for the produced electron
-    Secondary* electron_secondary = this->allocate_(1);
+    Secondary* electron_secondary = allocate_(1);
 
     if (electron_secondary == nullptr)
     {

--- a/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
+++ b/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
@@ -113,7 +113,7 @@ template<class Engine>
 CELER_FUNCTION Interaction MuBremsstrahlungInteractor::operator()(Engine& rng)
 {
     // Allocate space for gamma
-    Secondary* secondaries = this->allocate_(1);
+    Secondary* secondaries = allocate_(1);
     if (secondaries == nullptr)
     {
         // Failed to allocate space for a secondary

--- a/src/celeritas/em/interactor/RelativisticBremInteractor.hh
+++ b/src/celeritas/em/interactor/RelativisticBremInteractor.hh
@@ -124,7 +124,7 @@ template<class Engine>
 CELER_FUNCTION Interaction RelativisticBremInteractor::operator()(Engine& rng)
 {
     // Allocate space for the brems photon
-    Secondary* secondaries = this->allocate_(1);
+    Secondary* secondaries = allocate_(1);
     if (secondaries == nullptr)
     {
         // Failed to allocate space for the secondary

--- a/src/celeritas/em/interactor/SeltzerBergerInteractor.hh
+++ b/src/celeritas/em/interactor/SeltzerBergerInteractor.hh
@@ -150,7 +150,7 @@ CELER_FUNCTION Interaction SeltzerBergerInteractor::operator()(Engine& rng)
     }
 
     // Allocate space for the brems photon
-    Secondary* secondaries = this->allocate_(1);
+    Secondary* secondaries = allocate_(1);
     if (secondaries == nullptr)
     {
         // Failed to allocate space for the secondary

--- a/src/celeritas/ext/g4vg/LogicalVolumeConverter.cc
+++ b/src/celeritas/ext/g4vg/LogicalVolumeConverter.cc
@@ -79,7 +79,7 @@ auto LogicalVolumeConverter::construct_base(arg_type g4lv) -> result_type
     vecgeom::VUnplacedVolume const* shape = nullptr;
     try
     {
-        shape = this->convert_solid_(*g4lv.GetSolid());
+        shape = convert_solid_(*g4lv.GetSolid());
     }
     catch (celeritas::RuntimeError const& e)
     {

--- a/src/celeritas/ext/g4vg/SolidConverter.cc
+++ b/src/celeritas/ext/g4vg/SolidConverter.cc
@@ -235,9 +235,9 @@ auto SolidConverter::box(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Box const&>(solid_base);
     return GeoManager::MakeInstance<UnplacedBox>(
-        this->convert_scale_(solid.GetXHalfLength()),
-        this->convert_scale_(solid.GetYHalfLength()),
-        this->convert_scale_(solid.GetZHalfLength()));
+        convert_scale_(solid.GetXHalfLength()),
+        convert_scale_(solid.GetYHalfLength()),
+        convert_scale_(solid.GetZHalfLength()));
 }
 
 //---------------------------------------------------------------------------//
@@ -246,11 +246,11 @@ auto SolidConverter::cons(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Cons const&>(solid_base);
     return GeoManager::MakeInstance<UnplacedCone>(
-        this->convert_scale_(solid.GetInnerRadiusMinusZ()),
-        this->convert_scale_(solid.GetOuterRadiusMinusZ()),
-        this->convert_scale_(solid.GetInnerRadiusPlusZ()),
-        this->convert_scale_(solid.GetOuterRadiusPlusZ()),
-        this->convert_scale_(solid.GetZHalfLength()),
+        convert_scale_(solid.GetInnerRadiusMinusZ()),
+        convert_scale_(solid.GetOuterRadiusMinusZ()),
+        convert_scale_(solid.GetInnerRadiusPlusZ()),
+        convert_scale_(solid.GetOuterRadiusPlusZ()),
+        convert_scale_(solid.GetZHalfLength()),
         solid.GetStartPhiAngle(),
         solid.GetDeltaPhiAngle());
 }
@@ -263,9 +263,9 @@ auto SolidConverter::cuttubs(arg_type solid_base) -> result_type
     G4ThreeVector lowNorm = solid.GetLowNorm();
     G4ThreeVector hiNorm = solid.GetHighNorm();
     return GeoManager::MakeInstance<UnplacedCutTube>(
-        this->convert_scale_(solid.GetInnerRadius()),
-        this->convert_scale_(solid.GetOuterRadius()),
-        this->convert_scale_(solid.GetZHalfLength()),
+        convert_scale_(solid.GetInnerRadius()),
+        convert_scale_(solid.GetOuterRadius()),
+        convert_scale_(solid.GetZHalfLength()),
         solid.GetStartPhiAngle(),
         solid.GetDeltaPhiAngle(),
         Vector3D<Precision>(lowNorm[0], lowNorm[1], lowNorm[2]),
@@ -283,11 +283,11 @@ auto SolidConverter::ellipsoid(arg_type solid_base) -> result_type
 #    define SC_G4ACCESS(NEW, OLD) OLD
 #endif
     return GeoManager::MakeInstance<UnplacedEllipsoid>(
-        this->convert_scale_(solid.SC_G4ACCESS(GetDx(), GetSemiAxisMax(0))),
-        this->convert_scale_(solid.SC_G4ACCESS(GetDy(), GetSemiAxisMax(1))),
-        this->convert_scale_(solid.SC_G4ACCESS(GetDz(), GetSemiAxisMax(2))),
-        this->convert_scale_(solid.GetZBottomCut()),
-        this->convert_scale_(solid.GetZTopCut()));
+        convert_scale_(solid.SC_G4ACCESS(GetDx(), GetSemiAxisMax(0))),
+        convert_scale_(solid.SC_G4ACCESS(GetDy(), GetSemiAxisMax(1))),
+        convert_scale_(solid.SC_G4ACCESS(GetDz(), GetSemiAxisMax(2))),
+        convert_scale_(solid.GetZBottomCut()),
+        convert_scale_(solid.GetZTopCut()));
 #undef SC_G4ACCESS
 }
 
@@ -299,8 +299,8 @@ auto SolidConverter::ellipticalcone(arg_type solid_base) -> result_type
     return GeoManager::MakeInstance<UnplacedEllipticalCone>(
         solid.GetSemiAxisX(),
         solid.GetSemiAxisY(),
-        this->convert_scale_(solid.GetZMax()),
-        this->convert_scale_(solid.GetZTopCut()));
+        convert_scale_(solid.GetZMax()),
+        convert_scale_(solid.GetZTopCut()));
 }
 
 //---------------------------------------------------------------------------//
@@ -309,9 +309,9 @@ auto SolidConverter::ellipticaltube(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4EllipticalTube const&>(solid_base);
     return GeoManager::MakeInstance<UnplacedEllipticalTube>(
-        this->convert_scale_(solid.GetDx()),
-        this->convert_scale_(solid.GetDy()),
-        this->convert_scale_(solid.GetDz()));
+        convert_scale_(solid.GetDx()),
+        convert_scale_(solid.GetDy()),
+        convert_scale_(solid.GetDz()));
 }
 
 //---------------------------------------------------------------------------//
@@ -325,7 +325,7 @@ auto SolidConverter::extrudedsolid(arg_type solid_base) -> result_type
     std::vector<double> y(x.size());
     for (auto i : range(x.size()))
     {
-        std::tie(x[i], y[i]) = this->convert_scale_(solid.GetVertex(i));
+        std::tie(x[i], y[i]) = convert_scale_(solid.GetVertex(i));
     }
 
     // Convert Z sections
@@ -345,7 +345,7 @@ auto SolidConverter::extrudedsolid(arg_type solid_base) -> result_type
         CELER_VALIDATE(zsec.fOffset.x() == 0.0 && zsec.fOffset.y() == 0.0,
                        << "unsupported z section translation ("
                        << zsec.fOffset.x() << "," << zsec.fOffset.y() << ")");
-        z[i] = this->convert_scale_(zsec.fZ);
+        z[i] = convert_scale_(zsec.fZ);
     }
 
     return GeoManager::MakeInstance<UnplacedSExtruVolume>(
@@ -363,8 +363,8 @@ auto SolidConverter::genericpolycone(arg_type solid_base) -> result_type
     for (auto i : range(zs.size()))
     {
         G4PolyconeSideRZ const& rzCorner = solid.GetCorner(i);
-        zs[i] = this->convert_scale_(rzCorner.z);
-        rs[i] = this->convert_scale_(rzCorner.r);
+        zs[i] = convert_scale_(rzCorner.z);
+        rs[i] = convert_scale_(rzCorner.r);
     }
 
     return GeoManager::MakeInstance<UnplacedGenericPolycone>(
@@ -385,11 +385,11 @@ auto SolidConverter::generictrap(arg_type solid_base) -> result_type
     std::vector<double> vy(vx.size());
     for (auto i : range(vx.size()))
     {
-        std::tie(vx[i], vy[i]) = this->convert_scale_(solid.GetVertex(i));
+        std::tie(vx[i], vy[i]) = convert_scale_(solid.GetVertex(i));
     }
 
     return GeoManager::MakeInstance<UnplacedGenTrap>(
-        vx.data(), vy.data(), this->convert_scale_(solid.GetZHalfLength()));
+        vx.data(), vy.data(), convert_scale_(solid.GetZHalfLength()));
 }
 
 //---------------------------------------------------------------------------//
@@ -398,11 +398,11 @@ auto SolidConverter::hype(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Hype const&>(solid_base);
     return GeoManager::MakeInstance<UnplacedHype>(
-        this->convert_scale_(solid.GetInnerRadius()),
-        this->convert_scale_(solid.GetOuterRadius()),
+        convert_scale_(solid.GetInnerRadius()),
+        convert_scale_(solid.GetOuterRadius()),
         solid.GetInnerStereo(),
         solid.GetOuterStereo(),
-        this->convert_scale_(solid.GetZHalfLength()));
+        convert_scale_(solid.GetZHalfLength()));
 }
 
 //---------------------------------------------------------------------------//
@@ -420,7 +420,7 @@ auto SolidConverter::orb(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Orb const&>(solid_base);
     return GeoManager::MakeInstance<UnplacedOrb>(
-        this->convert_scale_(solid.GetRadius()));
+        convert_scale_(solid.GetRadius()));
 }
 
 //---------------------------------------------------------------------------//
@@ -437,9 +437,9 @@ auto SolidConverter::para(arg_type solid_base) -> result_type
     auto const [theta, phi] = calculate_theta_phi(solid.GetSymAxis());
 #endif
     return GeoManager::MakeInstance<UnplacedParallelepiped>(
-        this->convert_scale_(solid.GetXHalfLength()),
-        this->convert_scale_(solid.GetYHalfLength()),
-        this->convert_scale_(solid.GetZHalfLength()),
+        convert_scale_(solid.GetXHalfLength()),
+        convert_scale_(solid.GetYHalfLength()),
+        convert_scale_(solid.GetZHalfLength()),
         std::atan(solid.GetTanAlpha()),
         theta,
         phi);
@@ -451,9 +451,9 @@ auto SolidConverter::paraboloid(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Paraboloid const&>(solid_base);
     return GeoManager::MakeInstance<UnplacedParaboloid>(
-        this->convert_scale_(solid.GetRadiusMinusZ()),
-        this->convert_scale_(solid.GetRadiusPlusZ()),
-        this->convert_scale_(solid.GetZHalfLength()));
+        convert_scale_(solid.GetRadiusMinusZ()),
+        convert_scale_(solid.GetRadiusPlusZ()),
+        convert_scale_(solid.GetZHalfLength()));
 }
 
 //---------------------------------------------------------------------------//
@@ -468,9 +468,9 @@ auto SolidConverter::polycone(arg_type solid_base) -> result_type
     std::vector<double> rmaxs(zvals.size());
     for (auto i : range(zvals.size()))
     {
-        zvals[i] = this->convert_scale_(params.Z_values[i]);
-        rmins[i] = this->convert_scale_(params.Rmin[i]);
-        rmaxs[i] = this->convert_scale_(params.Rmax[i]);
+        zvals[i] = convert_scale_(params.Z_values[i]);
+        rmins[i] = convert_scale_(params.Rmin[i]);
+        rmaxs[i] = convert_scale_(params.Rmax[i]);
     }
     return GeoManager::MakeInstance<UnplacedPolycone>(params.Start_angle,
                                                       params.Opening_angle,
@@ -495,9 +495,9 @@ auto SolidConverter::polyhedra(arg_type solid_base) -> result_type
     std::vector<double> rmaxs(zs.size());
     for (auto i : range(zs.size()))
     {
-        zs[i] = this->convert_scale_(params.Z_values[i]);
-        rmins[i] = this->convert_scale_(params.Rmin[i] * radius_factor);
-        rmaxs[i] = this->convert_scale_(params.Rmax[i] * radius_factor);
+        zs[i] = convert_scale_(params.Z_values[i]);
+        rmins[i] = convert_scale_(params.Rmin[i] * radius_factor);
+        rmaxs[i] = convert_scale_(params.Rmax[i] * radius_factor);
     }
 
     auto phistart = std::fmod(params.Start_angle, 2 * constants::pi);
@@ -527,8 +527,8 @@ auto SolidConverter::sphere(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Sphere const&>(solid_base);
     return GeoManager::MakeInstance<UnplacedSphere>(
-        this->convert_scale_(solid.GetInnerRadius()),
-        this->convert_scale_(solid.GetOuterRadius()),
+        convert_scale_(solid.GetInnerRadius()),
+        convert_scale_(solid.GetOuterRadius()),
         solid.GetStartPhiAngle(),
         solid.GetDeltaPhiAngle(),
         solid.GetStartThetaAngle(),
@@ -561,9 +561,9 @@ auto SolidConverter::tessellatedsolid(arg_type solid_base) -> result_type
         for (auto iv : range(num_vtx))
         {
             auto vxg4 = facet.GetVertex(iv);
-            vtx[iv].Set(this->convert_scale_(vxg4.x()),
-                        this->convert_scale_(vxg4.y()),
-                        this->convert_scale_(vxg4.z()));
+            vtx[iv].Set(convert_scale_(vxg4.x()),
+                        convert_scale_(vxg4.y()),
+                        convert_scale_(vxg4.z()));
         }
 
         if (num_vtx == 3)
@@ -593,11 +593,10 @@ auto SolidConverter::tet(arg_type solid_base) -> result_type
     CELER_ASSERT(g4points.size() == 4);
     std::copy(g4points.begin(), g4points.end(), points.begin());
 #endif
-    return GeoManager::MakeInstance<UnplacedTet>(
-        this->convert_scale_(points[0]),
-        this->convert_scale_(points[1]),
-        this->convert_scale_(points[2]),
-        this->convert_scale_(points[3]));
+    return GeoManager::MakeInstance<UnplacedTet>(convert_scale_(points[0]),
+                                                 convert_scale_(points[1]),
+                                                 convert_scale_(points[2]),
+                                                 convert_scale_(points[3]));
 }
 
 //---------------------------------------------------------------------------//
@@ -606,9 +605,9 @@ auto SolidConverter::torus(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Torus const&>(solid_base);
     return GeoManager::MakeInstance<UnplacedTorus2>(
-        this->convert_scale_(solid.GetRmin()),
-        this->convert_scale_(solid.GetRmax()),
-        this->convert_scale_(solid.GetRtor()),
+        convert_scale_(solid.GetRmin()),
+        convert_scale_(solid.GetRmax()),
+        convert_scale_(solid.GetRtor()),
         solid.GetSPhi(),
         solid.GetDPhi());
 }
@@ -632,16 +631,16 @@ auto SolidConverter::trap(arg_type solid_base) -> result_type
 #endif
 
     return GeoManager::MakeInstance<UnplacedTrapezoid>(
-        this->convert_scale_(solid.GetZHalfLength()),
+        convert_scale_(solid.GetZHalfLength()),
         theta,
         phi,
-        this->convert_scale_(solid.GetYHalfLength1()),
-        this->convert_scale_(solid.GetXHalfLength1()),
-        this->convert_scale_(solid.GetXHalfLength2()),
+        convert_scale_(solid.GetYHalfLength1()),
+        convert_scale_(solid.GetXHalfLength1()),
+        convert_scale_(solid.GetXHalfLength2()),
         alpha_1,
-        this->convert_scale_(solid.GetYHalfLength2()),
-        this->convert_scale_(solid.GetXHalfLength3()),
-        this->convert_scale_(solid.GetXHalfLength4()),
+        convert_scale_(solid.GetYHalfLength2()),
+        convert_scale_(solid.GetXHalfLength3()),
+        convert_scale_(solid.GetXHalfLength4()),
         alpha_2);
 }
 
@@ -651,11 +650,11 @@ auto SolidConverter::trd(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Trd const&>(solid_base);
     return GeoManager::MakeInstance<UnplacedTrd>(
-        this->convert_scale_(solid.GetXHalfLength1()),
-        this->convert_scale_(solid.GetXHalfLength2()),
-        this->convert_scale_(solid.GetYHalfLength1()),
-        this->convert_scale_(solid.GetYHalfLength2()),
-        this->convert_scale_(solid.GetZHalfLength()));
+        convert_scale_(solid.GetXHalfLength1()),
+        convert_scale_(solid.GetXHalfLength2()),
+        convert_scale_(solid.GetYHalfLength1()),
+        convert_scale_(solid.GetYHalfLength2()),
+        convert_scale_(solid.GetZHalfLength()));
 }
 
 //---------------------------------------------------------------------------//
@@ -664,9 +663,9 @@ auto SolidConverter::tubs(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Tubs const&>(solid_base);
     return GeoManager::MakeInstance<UnplacedTube>(
-        this->convert_scale_(solid.GetInnerRadius()),
-        this->convert_scale_(solid.GetOuterRadius()),
-        this->convert_scale_(solid.GetZHalfLength()),
+        convert_scale_(solid.GetInnerRadius()),
+        convert_scale_(solid.GetOuterRadius()),
+        convert_scale_(solid.GetZHalfLength()),
         solid.GetStartPhiAngle(),
         solid.GetDeltaPhiAngle());
 }
@@ -754,7 +753,7 @@ void SolidConverter::compare_volumes(G4VSolid const& g4,
 double SolidConverter::calc_capacity(G4VSolid const& g4) const
 {
     return const_cast<G4VSolid&>(g4).GetCubicVolume()
-           * ipow<3>(this->convert_scale_(1.0));
+           * ipow<3>(convert_scale_(1.0));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/g4vg/Transformer.hh
+++ b/src/celeritas/ext/g4vg/Transformer.hh
@@ -71,9 +71,7 @@ Transformer::Transformer(Scaler const& convert_scale)
  */
 auto Transformer::operator()(G4ThreeVector const& t) const -> result_type
 {
-    return {this->convert_scale_(t[0]),
-            this->convert_scale_(t[1]),
-            this->convert_scale_(t[2])};
+    return {convert_scale_(t[0]), convert_scale_(t[1]), convert_scale_(t[2])};
 }
 
 //---------------------------------------------------------------------------//
@@ -83,9 +81,9 @@ auto Transformer::operator()(G4ThreeVector const& t) const -> result_type
 auto Transformer::operator()(G4ThreeVector const& t,
                              G4RotationMatrix const& rot) const -> result_type
 {
-    return {this->convert_scale_(t[0]),
-            this->convert_scale_(t[1]),
-            this->convert_scale_(t[2]),
+    return {convert_scale_(t[0]),
+            convert_scale_(t[1]),
+            convert_scale_(t[2]),
             rot.xx(),
             rot.yx(),
             rot.zx(),

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -127,7 +127,7 @@ bool ScopedProfiling::enable_profiling()
 /*!
  * Activate nvtx profiling with options.
  */
-void ScopedProfiling::activate_impl(Input const& input) noexcept
+void ScopedProfiling::activate(Input const& input) noexcept
 {
     nvtxEventAttributes_t attributes_ = make_attributes(input);
     int result = nvtxDomainRangePushEx(domain_handle(), &attributes_);
@@ -143,7 +143,7 @@ void ScopedProfiling::activate_impl(Input const& input) noexcept
 /*!
  * End the profiling range.
  */
-void ScopedProfiling::deactivate_impl() noexcept
+void ScopedProfiling::deactivate() noexcept
 {
     int result = nvtxDomainRangePop(domain_handle());
     if (result < 0)

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -127,7 +127,7 @@ bool ScopedProfiling::enable_profiling()
 /*!
  * Activate nvtx profiling with options.
  */
-void ScopedProfiling::activate_(Input const& input) noexcept
+void ScopedProfiling::activate_impl(Input const& input) noexcept
 {
     nvtxEventAttributes_t attributes_ = make_attributes(input);
     int result = nvtxDomainRangePushEx(domain_handle(), &attributes_);
@@ -143,7 +143,7 @@ void ScopedProfiling::activate_(Input const& input) noexcept
 /*!
  * End the profiling range.
  */
-void ScopedProfiling::deactivate_() noexcept
+void ScopedProfiling::deactivate_impl() noexcept
 {
     int result = nvtxDomainRangePop(domain_handle());
     if (result < 0)

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -81,8 +81,8 @@ class ScopedProfiling
   private:
     bool activated_;
 
-    void activate_(Input const& input) noexcept;
-    void deactivate_() noexcept;
+    void activate_impl(Input const& input) noexcept;
+    void deactivate_impl() noexcept;
 };
 
 //---------------------------------------------------------------------------//
@@ -96,7 +96,7 @@ ScopedProfiling::ScopedProfiling(Input const& input)
 {
     if (activated_)
     {
-        activate_(input);
+        this->activate_impl(input);
     }
 }
 
@@ -117,16 +117,16 @@ ScopedProfiling::~ScopedProfiling()
 {
     if (activated_)
     {
-        deactivate_();
+        this->deactivate_impl();
     }
 }
 
 #if !CELER_USE_DEVICE
-inline void ScopedProfiling::activate_(Input const&) noexcept
+inline void ScopedProfiling::activate_impl(Input const&) noexcept
 {
     CELER_UNREACHABLE;
 }
-inline void ScopedProfiling::deactivate_() noexcept
+inline void ScopedProfiling::deactivate_impl() noexcept
 {
     CELER_UNREACHABLE;
 }

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -81,8 +81,8 @@ class ScopedProfiling
   private:
     bool activated_;
 
-    void activate_impl(Input const& input) noexcept;
-    void deactivate_impl() noexcept;
+    void activate(Input const& input) noexcept;
+    void deactivate() noexcept;
 };
 
 //---------------------------------------------------------------------------//
@@ -96,7 +96,7 @@ ScopedProfiling::ScopedProfiling(Input const& input)
 {
     if (activated_)
     {
-        this->activate_impl(input);
+        this->activate(input);
     }
 }
 
@@ -117,16 +117,16 @@ ScopedProfiling::~ScopedProfiling()
 {
     if (activated_)
     {
-        this->deactivate_impl();
+        this->deactivate();
     }
 }
 
 #if !CELER_USE_DEVICE
-inline void ScopedProfiling::activate_impl(Input const&) noexcept
+inline void ScopedProfiling::activate(Input const&) noexcept
 {
     CELER_UNREACHABLE;
 }
-inline void ScopedProfiling::deactivate_impl() noexcept
+inline void ScopedProfiling::deactivate() noexcept
 {
     CELER_UNREACHABLE;
 }

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -96,7 +96,7 @@ ScopedProfiling::ScopedProfiling(Input const& input)
 {
     if (activated_)
     {
-        this->activate_(input);
+        activate_(input);
     }
 }
 
@@ -117,7 +117,7 @@ ScopedProfiling::~ScopedProfiling()
 {
     if (activated_)
     {
-        this->deactivate_();
+        deactivate_();
     }
 }
 

--- a/src/corecel/sys/ScopedProfiling.hip.cc
+++ b/src/corecel/sys/ScopedProfiling.hip.cc
@@ -52,7 +52,7 @@ bool ScopedProfiling::enable_profiling()
 /*!
  * Activate profiling.
  */
-void ScopedProfiling::activate_(Input const& input) noexcept
+void ScopedProfiling::activate_impl(Input const& input) noexcept
 {
     int result = 0;
 #if CELERITAS_HAVE_ROCTX
@@ -70,7 +70,7 @@ void ScopedProfiling::activate_(Input const& input) noexcept
 /*!
  * End the profiling range.
  */
-void ScopedProfiling::deactivate_() noexcept
+void ScopedProfiling::deactivate_impl() noexcept
 {
     int result = 0;
 #if CELERITAS_HAVE_ROCTX

--- a/src/corecel/sys/ScopedProfiling.hip.cc
+++ b/src/corecel/sys/ScopedProfiling.hip.cc
@@ -52,7 +52,7 @@ bool ScopedProfiling::enable_profiling()
 /*!
  * Activate profiling.
  */
-void ScopedProfiling::activate_impl(Input const& input) noexcept
+void ScopedProfiling::activate(Input const& input) noexcept
 {
     int result = 0;
 #if CELERITAS_HAVE_ROCTX
@@ -70,7 +70,7 @@ void ScopedProfiling::activate_impl(Input const& input) noexcept
 /*!
  * End the profiling range.
  */
-void ScopedProfiling::deactivate_impl() noexcept
+void ScopedProfiling::deactivate() noexcept
 {
     int result = 0;
 #if CELERITAS_HAVE_ROCTX

--- a/src/orange/construct/detail/PostfixLogicBuilder.hh
+++ b/src/orange/construct/detail/PostfixLogicBuilder.hh
@@ -82,7 +82,7 @@ PostfixLogicBuilder::PostfixLogicBuilder(CsgTree const& tree, VecLogic* logic)
  */
 void PostfixLogicBuilder::operator()(NodeId const& n)
 {
-    this->visit_node_(*this, n);
+    visit_node_(*this, n);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/SoftSurfaceEqual.cc
+++ b/src/orange/surf/SoftSurfaceEqual.cc
@@ -50,7 +50,7 @@ template<Axis T>
 bool SoftSurfaceEqual::operator()(CylCentered<T> const& a,
                                   CylCentered<T> const& b) const
 {
-    return soft_eq_sq_(a.radius_sq(), b.radius_sq());
+    return this->soft_eq_sq(a.radius_sq(), b.radius_sq());
 }
 
 //! \cond
@@ -64,7 +64,7 @@ ORANGE_INSTANTIATE_OP(CylCentered);
 bool SoftSurfaceEqual::operator()(SphereCentered const& a,
                                   SphereCentered const& b) const
 {
-    return soft_eq_sq_(a.radius_sq(), b.radius_sq());
+    return this->soft_eq_sq(a.radius_sq(), b.radius_sq());
 }
 
 //---------------------------------------------------------------------------//
@@ -75,8 +75,8 @@ template<Axis T>
 bool SoftSurfaceEqual::operator()(CylAligned<T> const& a,
                                   CylAligned<T> const& b) const
 {
-    return soft_eq_sq_(a.radius_sq(), b.radius_sq())
-           && soft_eq_distance_(a.calc_origin(), b.calc_origin());
+    return this->soft_eq_sq(a.radius_sq(), b.radius_sq())
+           && this->soft_eq_distance(a.calc_origin(), b.calc_origin());
 }
 
 //! \cond
@@ -136,8 +136,8 @@ bool SoftSurfaceEqual::operator()(Plane const& a, Plane const& b) const
  */
 bool SoftSurfaceEqual::operator()(Sphere const& a, Sphere const& b) const
 {
-    return soft_eq_sq_(a.radius_sq(), b.radius_sq())
-           && soft_eq_distance_(a.origin(), b.origin());
+    return this->soft_eq_sq(a.radius_sq(), b.radius_sq())
+           && this->soft_eq_distance(a.origin(), b.origin());
 }
 
 //---------------------------------------------------------------------------//
@@ -148,8 +148,8 @@ template<Axis T>
 bool SoftSurfaceEqual::operator()(ConeAligned<T> const& a,
                                   ConeAligned<T> const& b) const
 {
-    return soft_eq_sq_(a.tangent_sq(), b.tangent_sq())
-           && soft_eq_distance_(a.origin(), b.origin());
+    return this->soft_eq_sq(a.tangent_sq(), b.tangent_sq())
+           && this->soft_eq_distance(a.origin(), b.origin());
 }
 
 //! \cond
@@ -163,8 +163,10 @@ ORANGE_INSTANTIATE_OP(ConeAligned);
 bool SoftSurfaceEqual::operator()(SimpleQuadric const& a,
                                   SimpleQuadric const& b) const
 {
-    return soft_eq_distance_(make_array(a.second()), make_array(b.second()))
-           && soft_eq_distance_(make_array(a.first()), make_array(b.first()))
+    return this->soft_eq_distance(make_array(a.second()),
+                                  make_array(b.second()))
+           && this->soft_eq_distance(make_array(a.first()),
+                                     make_array(b.first()))
            && soft_eq_(a.zeroth(), b.zeroth());
 }
 
@@ -175,9 +177,12 @@ bool SoftSurfaceEqual::operator()(SimpleQuadric const& a,
 bool SoftSurfaceEqual::operator()(GeneralQuadric const& a,
                                   GeneralQuadric const& b) const
 {
-    return soft_eq_distance_(make_array(a.second()), make_array(b.second()))
-           && soft_eq_distance_(make_array(a.cross()), make_array(b.cross()))
-           && soft_eq_distance_(make_array(a.first()), make_array(b.first()))
+    return this->soft_eq_distance(make_array(a.second()),
+                                  make_array(b.second()))
+           && this->soft_eq_distance(make_array(a.cross()),
+                                     make_array(b.cross()))
+           && this->soft_eq_distance(make_array(a.first()),
+                                     make_array(b.first()))
            && soft_eq_(a.zeroth(), b.zeroth());
 }
 
@@ -187,7 +192,7 @@ bool SoftSurfaceEqual::operator()(GeneralQuadric const& a,
 /*!
  * Compare the square of values for soft equality.
  */
-bool SoftSurfaceEqual::soft_eq_sq_(real_type a, real_type b) const
+bool SoftSurfaceEqual::soft_eq_sq(real_type a, real_type b) const
 {
     return soft_eq_(std::sqrt(a), std::sqrt(b));
 }
@@ -201,7 +206,7 @@ bool SoftSurfaceEqual::soft_eq_sq_(real_type a, real_type b) const
  \f]
  * which translates exactly to vector math.
  */
-bool SoftSurfaceEqual::soft_eq_distance_(Real3 const& a, Real3 const& b) const
+bool SoftSurfaceEqual::soft_eq_distance(Real3 const& a, Real3 const& b) const
 {
     // This is soft equal formula but using vector distance.
     real_type rel = soft_eq_.rel() * std::fmax(norm(a), norm(b));

--- a/src/orange/surf/SoftSurfaceEqual.hh
+++ b/src/orange/surf/SoftSurfaceEqual.hh
@@ -73,8 +73,8 @@ class SoftSurfaceEqual
   private:
     SoftEqual<real_type> soft_eq_;
 
-    bool soft_eq_sq_(real_type a, real_type b) const;
-    bool soft_eq_distance_(Real3 const& a, Real3 const& b) const;
+    bool soft_eq_sq(real_type a, real_type b) const;
+    bool soft_eq_distance(Real3 const& a, Real3 const& b) const;
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
See [this discussion](https://github.com/celeritas-project/celeritas/pull/975/files/72be472078f880103b46df4decbede307e2ad610#diff-f4f92746dc36c5dd3bb2b928d3b8ba45020acbb3bce852c6009bc59057826f83); fits under  #721