### PR TITLE
Support HIP 5.1.0 and add Frontier build scripts

### DIFF
--- a/scripts/cmake-presets/frontier.json
+++ b/scripts/cmake-presets/frontier.json
@@ -1,0 +1,97 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {"major": 3, "minor": 21, "patch": 0},
+  "configurePresets": [
+    {
+      "name": ".base",
+      "hidden": true,
+      "inherits": ["full"],
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CELERITAS_BUILD_DOCS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_HIP":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_JSON":    {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_MPI":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_SWIG":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_TEST_RESOURCE_LOCK": {"type": "BOOL", "value": "ON"},
+        "CMAKE_HIP_ARCHITECTURES":  {"type": "STRING", "value": "gfx90a"},
+        "CMAKE_HIP_FLAGS": "-munsafe-fp-atomics",
+        "CMAKE_EXE_LINKER_FLAGS": "-Wno-unused-command-line-argument",
+        "CMAKE_HIP_FLAGS_DEBUG": "-g -ggdb -O",
+        "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=znver3 -mtune=znver3",
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
+        "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"}
+      }
+    },
+    {
+      "name": "base",
+      "displayName": "Frontier default options (GCC, debug)",
+      "inherits": [".base"],
+      "binaryDir": "${sourceDir}/build"
+    },
+    {
+      "name": "mini",
+      "displayName": "Frontier default options (GCC, debug)",
+      "inherits": [".base"],
+      "binaryDir": "${sourceDir}/build-minimal",
+      "cacheVariables": {
+        "CELERITAS_BUILD_DOCS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_HIP":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_JSON":    {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_MPI":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_SWIG":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
+        "CMAKE_HIP_ARCHITECTURES":  {"type": "STRING", "value": "gfx90a"},
+        "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=znver3 -mtune=znver3",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"}
+      }
+    },
+    {
+      "name": "ndebug",
+      "displayName": "Frontier release mode",
+      "inherits": [".ndebug", ".base"],
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS":    {"type": "BOOL",   "value": "OFF"}
+      }
+    },
+    {
+      "name": "ndebug-serial",
+      "displayName": "Frontier release mode (no openmp)",
+      "inherits": [".ndebug", ".base"],
+      "cacheVariables": {
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_OpenMP": {"type": "BOOL", "value": "OFF"},
+        "BUILD_SHARED_LIBS": {"type": "BOOL",   "value": "OFF"}
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base",
+      "configurePreset": "base",
+      "jobs": 8,
+      "nativeToolOptions": ["-k0"]
+    },
+    {"name": "ndebug", "configurePreset": "ndebug", "inherits": "base"}
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "configurePreset": "base",
+      "output": {"outputOnFailure": true},
+      "execution": {"noTestsAction": "error", "stopOnFailure": false, "jobs": 8}
+    },
+    {"name": "ndebug", "configurePreset": "ndebug", "inherits": "base"}
+  ]
+}

--- a/scripts/env/frontier.sh
+++ b/scripts/env/frontier.sh
@@ -1,0 +1,38 @@
+#!/bin/sh -e
+
+_celer_base=$PROJWORK/csc404/celeritas-frontier
+
+# From spack compiler toolchain clang@14.0.0-rocm5.1.0
+module load amd/5.1.0 PrgEnv-amd/8.3.3 craype-x86-trento libfabric/1.15.2.0 cray-pmi/6.1.8
+export RFE_811452_DISABLE=1
+export LD_LIBRARY_PATH=/opt/cray/pe/pmi/6.1.8/lib:$LD_LIBRARY_PATH:/opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
+export LIBRARY_PATH=/opt/rocm-5.1.0/lib:/opt/rocm-5.1.0/lib64:$LIBRARY_PATH
+
+# TODO: Avoid linking multiple different libsci (one with openmp, one without)
+# module unload cray-libsci
+
+# Set up compilers
+test -n "${CRAYPE_DIR}"
+export CXX=${CRAYPE_DIR}/bin/CC
+export CC=${CRAYPE_DIR}/bin/cc
+
+# Do NOT load the accelerator target, because it adds
+# -fopenmp-targets=amdgcn-amd-amdhsa 
+# -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a
+# which implicitly defines __CUDA_ARCH__
+# module load craype-accel-amd-gfx90a
+
+# Set up celeritas
+export SPACK_ROOT=/ccs/proj/csc404/spack-frontier
+export PATH=${_celer_base}/spack/view/bin:$PATH
+export CMAKE_PREFIX_PATH=${_celer_base}/spack/view:${CMAKE_PREFIX_PATH}
+export MODULEPATH=${SPACK_ROOT}/share/spack/lmod/cray-sles15-x86_64/Core:${MODULEPATH}
+
+# Set up Geant4 data 
+module load geant4-data
+test -n "${G4ENSDFSTATEDATA}"
+test -e "${G4ENSDFSTATEDATA}"
+
+# Make llvm available
+test -n "${ROCM_PATH}"
+export PATH=$PATH:${ROCM_PATH}/llvm/bin

--- a/scripts/env/frontier.sh
+++ b/scripts/env/frontier.sh
@@ -8,8 +8,8 @@ export RFE_811452_DISABLE=1
 export LD_LIBRARY_PATH=/opt/cray/pe/pmi/6.1.8/lib:$LD_LIBRARY_PATH:/opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
 export LIBRARY_PATH=/opt/rocm-5.1.0/lib:/opt/rocm-5.1.0/lib64:$LIBRARY_PATH
 
-# TODO: Avoid linking multiple different libsci (one with openmp, one without)
-# module unload cray-libsci
+# Avoid linking multiple different libsci (one with openmp, one without)
+module unload cray-libsci
 
 # Set up compilers
 test -n "${CRAYPE_DIR}"

--- a/src/corecel/data/DeviceAllocation.cc
+++ b/src/corecel/data/DeviceAllocation.cc
@@ -45,9 +45,8 @@ DeviceAllocation::DeviceAllocation(size_type bytes, StreamId stream)
     : size_{bytes}, stream_{stream}, data_{nullptr, {stream}}
 {
     CELER_EXPECT(celeritas::device());
-    void* ptr = nullptr;
-    CELER_DEVICE_CALL_PREFIX(
-        MallocAsync(&ptr, bytes, celeritas::device().stream(stream_).get()));
+    void* ptr = celeritas::device().stream(stream_).malloc_async(bytes);
+    CELER_ASSERT(ptr);
     data_.reset(static_cast<Byte*>(ptr));
 }
 
@@ -112,8 +111,7 @@ void DeviceAllocation::DeviceFreeDeleter::operator()(
     {
         if (stream_)
         {
-            CELER_DEVICE_CALL_PREFIX(
-                FreeAsync(ptr, celeritas::device().stream(stream_).get()));
+            celeritas::device().stream(stream_).free_async(ptr);
         }
         else
         {

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -28,6 +28,16 @@
 #include "Stream.hh"
 #include "detail/StreamStorage.hh"
 
+#if CELERITAS_USE_CUDA
+#    define CELER_DEVICE_SUPPORTS_MEMPOOL 1
+#elif CELERITAS_USE_HIP       \
+    && (HIP_VERSION_MAJOR > 5 \
+        || (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR >= 2))
+#    define CELER_DEVICE_SUPPORTS_MEMPOOL 1
+#else
+#    define CELER_DEVICE_SUPPORTS_MEMPOOL 0
+#endif
+
 namespace celeritas
 {
 namespace
@@ -194,7 +204,9 @@ Device::Device(int id) : id_{id}, streams_{new detail::StreamStorage{}}
 
     // Save for possible block size initialization
     max_threads_per_block = props.maxThreadsPerBlock;
+#endif
 
+#if CELER_DEVICE_SUPPORTS_MEMPOOL
     auto threshold = std::numeric_limits<uint64_t>::max();
     if (std::string var = celeritas::getenv("CELER_MEMPOOL_RELEASE_THRESHOLD");
         !var.empty())

--- a/src/corecel/sys/Stream.hh
+++ b/src/corecel/sys/Stream.hh
@@ -68,7 +68,9 @@ class AsyncMemoryResource final : public MockMemoryResource<Pointer>
 /*!
  * CUDA or HIP stream.
  *
- * This creates/destroys a stream on construction/destruction.
+ * This creates/destroys a stream on construction/destruction and provides
+ * accessors to low-level stream-related functionality. This class will
+ * typically be accessed only by low-level device implementations.
  */
 class Stream
 {
@@ -105,6 +107,12 @@ class Stream
 
     // Access the thrust resource allocator associated with the stream
     ResourceT& memory_resource() { return memory_resource_; }
+
+    // Allocate memory asynchronously on this stream if possible
+    void* malloc_async(std::size_t bytes) const;
+
+    // Free memory asynchronously on this stream if possible
+    void free_async(void* ptr) const;
 
   private:
     StreamT stream_{nullptr};


### PR DESCRIPTION
This adds build scripts for the Frontier toolchain I built using ROCm 5.1. I'll next look at adding a 5.3/5.5 toolchain since that's what @tmdelellis has been using more recently.