### PR TITLE
Add more profiling ranges and fix return code checks

### DIFF
--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -37,6 +37,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Environment.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/TypeDemangler.hh"
 #include "celeritas/ext/GeantPhysicsOptions.hh"
 #include "celeritas/ext/ScopedRootErrorHandler.hh"
@@ -136,6 +137,7 @@ void run(int argc, char** argv)
     run_manager->SetUserInitialization(new ActionInitialization());
 
     // Initialize run and process events
+    ScopedProfiling profile_this{"celer-g4"};
     CELER_LOG(status) << "Initializing run manager";
     run_manager->Initialize();
 

--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -22,6 +22,7 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/Environment.hh"
 #include "corecel/sys/ScopedMem.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/Units.hh"
 #include "celeritas/em/UrbanMscParams.hh"
@@ -186,6 +187,7 @@ void Runner::build_core_params(RunnerInput const& inp,
 {
     CELER_LOG(status) << "Loading input and initializing problem data";
     ScopedMem record_mem("Runner.build_core_params");
+    ScopedProfiling profile_this{"construct-params"};
     CoreParams::Input params;
     ImportData const imported = [&inp] {
         if (ends_with(inp.physics_filename, ".root"))

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -77,7 +77,8 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
 {
     CELER_EXPECT(is);
 
-    ScopedMem record_mem("demo_loop.run");
+    ScopedProfiling profile_this{"celer-sim"};
+    ScopedMem record_mem("celer-sim.run");
 
     // Read input options and save a copy for output
     auto run_input = std::make_shared<RunnerInput>();
@@ -105,19 +106,16 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     }
     result.num_streams = num_streams;
 
+    // Start profiling *after* initialization (e.g. VecGeom) is complete
     Stopwatch get_transport_time;
     if (run_input->merge_events)
     {
-        ScopedProfiling profile_this{"celer-sim"};
-
         // Run all events simultaneously on a single stream
         result.events.front() = run_stream();
     }
     else
     {
         MultiExceptionHandler capture_exception;
-        ScopedProfiling profile_this{"celer-sim"};
-
 #ifdef _OPENMP
         // Set the maximum number of nested parallel regions
         // TODO: Enable nested OpenMP parallel regions for multithreaded CPU

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -242,7 +242,7 @@ tell what variables are in use or may be useful.
  CELER_DEBUG_DEVICE      corecel   Increase device error checking and output
  CELER_DISABLE_DEVICE    corecel   Disable CUDA/HIP support
  CELER_DISABLE_PARALLEL  corecel   Disable MPI support
- CELER_ENABLE_PROFILING  corecel   Set up NVTX/ROCTX profiling ranges
+ CELER_ENABLE_PROFILING  corecel   Set up NVTX/ROCTX profiling ranges [#pr]
  CELER_LOG               corecel   Set the "global" logger verbosity
  CELER_LOG_LOCAL         corecel   Set the "local" logger verbosity
  CELER_MEMPOOL... [#mp]_ celeritas Change ``cudaMemPoolAttrReleaseThreshold``
@@ -257,6 +257,7 @@ tell what variables are in use or may be useful.
  ======================= ========= ==========================================
 
 .. [#mp] CELER_MEMPOOL_RELEASE_THRESHOLD
+.. [#pr] See :ref:`profiling`
 
 Environment variables from external libraries can also be referenced by
 Celeritas or its apps:
@@ -298,3 +299,66 @@ diagnostic messages and higher.
  critical   Something went terribly wrong, program termination imminent
  ========== ==============================================================
 
+
+.. _profiling:
+
+Profiling
+=========
+
+Since the primary motivator of Celeritas is performance on GPU hardware,
+profiling is a necessity. Celeritas uses NVTX (or ROCTX when using AMD HIP)
+to annotate the different sections of the code, allowing for fine-grained
+profiling and improved visualization.
+
+Timelines
+---------
+
+A detailed timeline of the Celeritas construction, steps, and kernel launches
+can be gathered using `NVIDIA Nsight systems`_.
+
+.. _NVIDIA Nsight systems: https://docs.nvidia.com/nsight-systems/UserGuide/index.html
+
+Here is an example using the ``celer-sim`` app to generate a timeline:
+
+.. sourcecode:: console
+   :linenos:
+
+   $ CELER_ENABLE_PROFILING=1 \
+   > nsys profile \
+   > -c nvtx  --trace=cuda,nvtx,osrt
+   > -p celer-sim@celeritas
+   > --osrt-backtrace-stack-size=16384 --backtrace=fp
+   > -f true -o report.qdrep \
+   > celer-sim inp.json
+
+To use the NVTX ranges, you must enable the ``CELER_ENABLE_PROFILING`` variable
+and use the NVTX "capture" option (lines 1 and 3). The ``celer-sim`` range in
+the ``celeritas`` domain (line 4) enables profiling over the whole application.
+Additional system backtracing is specified in line 5; line 6 writes (and
+overwrites) to a particular output file; the final line invokes the
+application.
+
+Kernel profiling
+----------------
+
+Detailed kernel diagnostics including occupancy and memory bandwidth can be
+gathered with the `NVIDIA Compute systems`_ profiler.
+
+.. _NVIDIA Compute systems: https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html
+
+This example gathers kernel statistics for 10 "propagate" kernels (for both
+charged and uncharged particles) starting with the 300th launch.
+
+.. sourcecode:: console
+   :linenos:
+
+   $ CELER_ENABLE_PROFILING=1 \
+   > ncu \
+   > --nvtx --nvtx-include "celeritas@celer-sim/step/*/propagate" \
+   > --launch-skip 300 --launch-count 10 \
+   > -f -o propagate
+   > celer-sim inp.json
+
+It will write to :file:`propagate.ncu-rep` output file. Note that the domain
+and range are flipped compared to ``nsys`` since the kernel profiling allows
+detailed top-down stack specification.

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -28,6 +28,7 @@
 #include "corecel/sys/Environment.hh"
 #include "corecel/sys/KernelRegistry.hh"
 #include "corecel/sys/ScopedMem.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/ext/GeantImporter.hh"
 #include "celeritas/ext/GeantSetup.hh"
@@ -158,6 +159,7 @@ SharedParams::SharedParams(SetupOptions const& options)
     CELER_EXPECT(!*this);
 
     CELER_LOG_LOCAL(status) << "Initializing Celeritas shared data";
+    ScopedProfiling profile_this{"construct-params"};
     ScopedMem record_mem("SharedParams.construct");
     ScopedTimeLog scoped_time;
 

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -56,6 +56,7 @@
 #include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/math/SoftEqual.hh"
 #include "corecel/sys/ScopedMem.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/TypeDemangler.hh"
 #include "celeritas/ext/GeantSetup.hh"
 #include "celeritas/io/AtomicRelaxationReader.hh"
@@ -734,6 +735,7 @@ ImportData GeantImporter::operator()(DataSelection const& selected)
             || selected.processes == DataSelection::none,
         << "materials and particles must be enabled if requesting processes");
     ScopedMem record_mem("GeantImporter.load");
+    ScopedProfiling profile_this{"import-geant"};
     ImportData imported;
 
     {

--- a/src/celeritas/ext/GeantSetup.cc
+++ b/src/celeritas/ext/GeantSetup.cc
@@ -29,6 +29,7 @@
 #include "corecel/io/ScopedTimeAndRedirect.hh"
 #include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/sys/ScopedMem.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 
 #include "GeantGeoUtils.hh"
 #include "ScopedGeantExceptionHandler.hh"
@@ -102,6 +103,7 @@ void GeantSetup::disable_signal_handler()
 GeantSetup::GeantSetup(std::string const& gdml_filename, Options options)
 {
     CELER_LOG(status) << "Initializing Geant4 run manager";
+    ScopedProfiling profile_this{"initialize-geant"};
     ScopedMem record_setup_mem("GeantSetup.construct");
 
     {

--- a/src/celeritas/ext/VecgeomParams.cc
+++ b/src/celeritas/ext/VecgeomParams.cc
@@ -20,6 +20,7 @@
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
 #include "corecel/sys/Environment.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "celeritas/ext/detail/VecgeomCompatibility.hh"
 #if CELERITAS_USE_CUDA
 #    include <VecGeom/management/CudaManager.h>
@@ -53,6 +54,7 @@ VecgeomParams::VecgeomParams(std::string const& filename)
 
     ScopedMem record_mem("VecgeomParams.construct");
     {
+        ScopedProfiling profile_this{"load-vecgeom"};
         ScopedMem record_mem("VecgeomParams.load_geant_geometry");
         ScopedTimeAndRedirect time_and_output_("vgdml::Frontend");
         vgdml::Frontend::Load(filename, /* validate_xml_schema = */ false);
@@ -77,6 +79,7 @@ VecgeomParams::VecgeomParams(G4VPhysicalVolume const* world)
 
     {
         // Convert the geometry to VecGeom
+        ScopedProfiling profile_this{"load-vecgeom"};
         g4vg::Converter::Options opts;
         opts.compare_volumes
             = !celeritas::getenv("G4VG_COMPARE_VOLUMES").empty();
@@ -190,6 +193,7 @@ void VecgeomParams::build_tracking()
 {
     CELER_EXPECT(vecgeom::GeoManager::Instance().GetWorld());
     CELER_LOG(status) << "Initializing tracking information";
+    ScopedProfiling profile_this{"initialize-vecgeom"};
     ScopedMem record_mem("VecgeomParams.build_tracking");
     {
         ScopedTimeAndRedirect time_and_output_("vecgeom::ABBoxManager");

--- a/src/celeritas/ext/g4vg/Converter.cc
+++ b/src/celeritas/ext/g4vg/Converter.cc
@@ -22,6 +22,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/sys/ScopedMem.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/TypeDemangler.hh"
 #include "celeritas/ext/GeantGeoUtils.hh"
 
@@ -97,6 +98,7 @@ auto Converter::operator()(arg_type g4world) -> result_type
     CELER_EXPECT(g4world->GetTranslation() == G4ThreeVector(0, 0, 0));
 
     CELER_LOG(status) << "Converting Geant4 geometry";
+    ScopedProfiling profile_this{"import-geant-geo"};
     ScopedMem record_mem("Converter.convert");
     ScopedTimeLog scoped_time;
 

--- a/src/celeritas/global/CoreState.cc
+++ b/src/celeritas/global/CoreState.cc
@@ -9,6 +9,7 @@
 
 #include "corecel/data/Copier.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "celeritas/track/detail/TrackSortUtils.hh"
 
 #include "CoreParams.hh"
@@ -29,6 +30,8 @@ CoreState<M>::CoreState(CoreParams const& params,
                    << " is out of range: max streams is "
                    << params.max_streams());
     CELER_VALIDATE(num_track_slots > 0, << "number of track slots is not set");
+
+    ScopedProfiling profile_this{"construct-state"};
 
     states_ = CollectionStateStore<CoreStateData, M>(
         params.host_ref(), stream_id, num_track_slots);

--- a/src/celeritas/global/alongstep/detail/AlongStepKernels.cu
+++ b/src/celeritas/global/alongstep/detail/AlongStepKernels.cu
@@ -89,6 +89,7 @@ void launch_update_time(ExplicitActionInterface const& action,
                         CoreParams const& params,
                         CoreState<MemSpace::device>& state)
 {
+    ScopedProfiling profile_this{"update-time"};
     auto execute_thread
         = make_along_step_track_executor(params.ptr<MemSpace::native>(),
                                          state.ptr(),
@@ -106,6 +107,7 @@ void launch_apply_eloss(ExplicitActionInterface const& action,
                         CoreParams const& params,
                         CoreState<MemSpace::device>& state)
 {
+    ScopedProfiling profile_this{"apply-eloss-fluct"};
     auto execute_thread = make_along_step_track_executor(
         params.ptr<MemSpace::native>(),
         state.ptr(),
@@ -122,6 +124,7 @@ void launch_apply_eloss(ExplicitActionInterface const& action,
                         CoreParams const& params,
                         CoreState<MemSpace::device>& state)
 {
+    ScopedProfiling profile_this{"apply-eloss"};
     auto execute_thread = make_along_step_track_executor(
         params.ptr<MemSpace::native>(),
         state.ptr(),

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -16,7 +16,9 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/EnumArray.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/ScopedMem.hh"
 #include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/Stopwatch.hh"
 #include "corecel/sys/Stream.hh"
@@ -80,6 +82,12 @@ ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
 template<MemSpace M>
 void ActionSequence::begin_run(CoreParams const& params, CoreState<M>& state)
 {
+    // Execute beginning-of-run action
+    CELER_LOG_LOCAL(status) << "Initializing additional state data";
+    ScopedProfiling profile_this{"begin-run"};
+    ScopedMem record_mem("ActionSequence.begin_run");
+    ScopedTimeLog scoped_time;
+
     for (auto const& sp_action : begin_run_)
     {
         sp_action->begin_run(params, state);

--- a/src/celeritas/track/ExtendFromSecondariesAction.cc
+++ b/src/celeritas/track/ExtendFromSecondariesAction.cc
@@ -21,6 +21,15 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Get a long description of the action.
+ */
+std::string ExtendFromSecondariesAction::description() const
+{
+    return "create track initializers from secondaries";
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Execute the action with host data.
  */
 void ExtendFromSecondariesAction::execute(CoreParams const& params,
@@ -97,15 +106,6 @@ void ExtendFromSecondariesAction::locate_alive(CoreParams const& core_params,
 }
 
 //---------------------------------------------------------------------------//
-#if !CELER_USE_DEVICE
-void ExtendFromSecondariesAction::locate_alive(CoreParams const&,
-                                               CoreStateDevice&) const
-{
-    CELER_NOT_CONFIGURED("CUDA OR HIP");
-}
-#endif
-
-//---------------------------------------------------------------------------//
 /*!
  * Launch a (host) kernel to create track initializers from secondary
  * particles.
@@ -121,12 +121,26 @@ void ExtendFromSecondariesAction::process_secondaries(
 }
 
 //---------------------------------------------------------------------------//
+// DEVICE-DISABLED IMPLEMENTATION
+//---------------------------------------------------------------------------//
 #if !CELER_USE_DEVICE
+void ExtendFromSecondariesAction::begin_run(CoreParams const&, CoreStateDevice&)
+{
+    CELER_NOT_CONFIGURED("CUDA OR HIP");
+}
+
+void ExtendFromSecondariesAction::locate_alive(CoreParams const&,
+                                               CoreStateDevice&) const
+{
+    CELER_NOT_CONFIGURED("CUDA OR HIP");
+}
+
 void ExtendFromSecondariesAction::process_secondaries(CoreParams const&,
                                                       CoreStateDevice&) const
 {
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
+
 #endif
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/ExtendFromSecondariesAction.cu
+++ b/src/celeritas/track/ExtendFromSecondariesAction.cu
@@ -9,6 +9,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/Stream.hh"
 #include "celeritas/global/ActionLauncher.device.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
@@ -18,6 +19,21 @@
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+/*!
+ * Warm up asynchronous allocation.
+ *
+ * This just calls MallocAsync before the first step, since it's used by
+ * \c detail::remove_if_alive under the hood.
+ */
+void ExtendFromSecondariesAction::begin_run(CoreParams const&,
+                                            CoreStateDevice& core_state)
+{
+    Stream& s = device().stream(core_state.stream_id());
+    void* p = s.malloc_async(core_state.size() * sizeof(size_type));
+    s.free_async(p);
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Launch a kernel to locate alive particles.

--- a/src/celeritas/track/ExtendFromSecondariesAction.cu
+++ b/src/celeritas/track/ExtendFromSecondariesAction.cu
@@ -9,6 +9,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/Stream.hh"
 #include "celeritas/global/ActionLauncher.device.hh"
 #include "celeritas/global/CoreParams.hh"
@@ -29,6 +30,7 @@ namespace celeritas
 void ExtendFromSecondariesAction::begin_run(CoreParams const&,
                                             CoreStateDevice& core_state)
 {
+    ScopedProfiling profile_this{this->label()};
     Stream& s = device().stream(core_state.stream_id());
     void* p = s.malloc_async(core_state.size() * sizeof(size_type));
     s.free_async(p);
@@ -43,6 +45,7 @@ void ExtendFromSecondariesAction::begin_run(CoreParams const&,
 void ExtendFromSecondariesAction::locate_alive(CoreParams const& core_params,
                                                CoreStateDevice& core_state) const
 {
+    ScopedProfiling profile_this{"locate-alive"};
     using Executor = detail::LocateAliveExecutor;
     static ActionLauncher<Executor> launch(*this);
     launch(core_state,
@@ -56,6 +59,7 @@ void ExtendFromSecondariesAction::locate_alive(CoreParams const& core_params,
 void ExtendFromSecondariesAction::process_secondaries(
     CoreParams const& core_params, CoreStateDevice& core_state) const
 {
+    ScopedProfiling profile_this{"process-secondaries"};
     using Executor = detail::ProcessSecondariesExecutor;
     static ActionLauncher<Executor> launch(*this);
     launch(core_state,

--- a/src/celeritas/track/ExtendFromSecondariesAction.hh
+++ b/src/celeritas/track/ExtendFromSecondariesAction.hh
@@ -68,32 +68,40 @@ namespace celeritas
 
    \endverbatim
  */
-class ExtendFromSecondariesAction final : public ExplicitActionInterface
+class ExtendFromSecondariesAction final : public ExplicitActionInterface,
+                                          public BeginRunActionInterface
 {
   public:
     //! Construct with explicit Id
     explicit ExtendFromSecondariesAction(ActionId id) : id_(id) {}
 
-    // Execute the action with host data
-    void execute(CoreParams const& params, CoreStateHost& state) const final;
-
-    // Execute the action with device data
-    void execute(CoreParams const& params, CoreStateDevice& state) const final;
-
+    //!@{
+    //! \name Action interface
     //! ID of the action
     ActionId action_id() const final { return id_; }
-
     //! Short name for the action
     std::string label() const final { return "extend-from-secondaries"; }
-
-    //! Description of the action for user interaction
-    std::string description() const final
-    {
-        return "create track initializers from secondaries";
-    }
-
+    // Description of the action for user interaction
+    std::string description() const final;
     //! Dependency ordering of the action
     ActionOrder order() const final { return ActionOrder::end; }
+    //!@}
+
+    //!@{
+    //! \name ExplicitAction interface
+    // Launch kernel with host data
+    void execute(CoreParams const&, CoreStateHost&) const final;
+    // Launch kernel with device data
+    void execute(CoreParams const&, CoreStateDevice&) const final;
+    //!@}
+
+    //!@{
+    //! \name BeginRunAction interface
+    // No action necessary for host data
+    void begin_run(CoreParams const&, CoreStateHost&) final {}
+    // Warm up asynchronous allocation at beginning of run
+    void begin_run(CoreParams const&, CoreStateDevice&) final;
+    //!@}
 
   private:
     ActionId id_;

--- a/src/celeritas/track/detail/TrackInitAlgorithms.cu
+++ b/src/celeritas/track/detail/TrackInitAlgorithms.cu
@@ -15,6 +15,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/data/ObserverPtr.device.hh"
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/Stream.hh"
 #include "corecel/sys/Thrust.device.hh"
 
@@ -34,6 +35,7 @@ size_type remove_if_alive(
         vacancies,
     StreamId stream_id)
 {
+    ScopedProfiling profile_this{"remove-if-alive"};
     auto start = device_pointer_cast(vacancies.data());
     auto end = thrust::remove_if(thrust_execute_on(stream_id),
                                  start,
@@ -60,6 +62,7 @@ size_type exclusive_scan_counts(
         counts,
     StreamId stream_id)
 {
+    ScopedProfiling profile_this{"exclusive-scan-conts"};
     // Exclusive scan:
     auto data = device_pointer_cast(counts.data());
     auto stop = thrust::exclusive_scan(thrust_execute_on(stream_id),

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -21,21 +21,6 @@ namespace celeritas
 {
 namespace
 {
-
-//---------------------------------------------------------------------------//
-/*!
- * Global registry for strings used by NVTX.
- *
- * This is implemented as a free function instead of a class static member in
- * ScopedProfiling to hide the NVTX dependency from users of the
- * interface.
- */
-std::unordered_map<std::string, nvtxStringHandle_t>& message_registry()
-{
-    static std::unordered_map<std::string, nvtxStringHandle_t> registry;
-    return registry;
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Library-wide handle to the domain name.
@@ -54,7 +39,7 @@ nvtxDomainHandle_t domain_handle()
  */
 nvtxStringHandle_t message_handle_for(std::string const& message)
 {
-    auto& registry = message_registry();
+    static std::unordered_map<std::string, nvtxStringHandle_t> registry;
     static std::shared_mutex mutex;
 
     {
@@ -74,7 +59,7 @@ nvtxStringHandle_t message_handle_for(std::string const& message)
     }();
     if (inserted)
     {
-        // Register the
+        // Register the domain
         iter->second
             = nvtxDomainRegisterStringA(domain_handle(), message.c_str());
     }

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -42,7 +42,7 @@ std::unordered_map<std::string, nvtxStringHandle_t>& message_registry()
  */
 nvtxDomainHandle_t domain_handle()
 {
-    static nvtxDomainHandle_t domain = nvtxDomainCreateA("celeritas");
+    static nvtxDomainHandle_t const domain = nvtxDomainCreateA("celeritas");
     return domain;
 }
 
@@ -54,25 +54,27 @@ nvtxDomainHandle_t domain_handle()
  */
 nvtxStringHandle_t message_handle_for(std::string const& message)
 {
+    auto& registry = message_registry();
     static std::shared_mutex mutex;
 
     {
         std::shared_lock lock(mutex);
 
-        if (auto message_handle = message_registry().find(message);
-            message_handle != message_registry().end())
+        if (auto message_handle = registry.find(message);
+            message_handle != registry.end())
         {
             return message_handle->second;
         }
     }
 
     // We did not find the handle; try to insert it
-    auto [iter, inserted] = [&message] {
+    auto [iter, inserted] = [&message, &registry] {
         std::unique_lock lock(mutex);
-        return message_registry().insert({message, {}});
+        return registry.insert({message, {}});
     }();
     if (inserted)
     {
+        // Register the
         iter->second
             = nvtxDomainRegisterStringA(domain_handle(), message.c_str());
     }
@@ -85,11 +87,15 @@ nvtxStringHandle_t message_handle_for(std::string const& message)
  */
 nvtxEventAttributes_t make_attributes(ScopedProfiling::Input const& input)
 {
-    nvtxEventAttributes_t attributes;
+    nvtxEventAttributes_t attributes = {};  // Initialize all attributes to
+                                            // zero
     attributes.version = NVTX_VERSION;
     attributes.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-    attributes.colorType = NVTX_COLOR_ARGB;
-    attributes.color = input.color;
+    if (input.color)
+    {
+        attributes.colorType = NVTX_COLOR_ARGB;
+        attributes.color = input.color;
+    }
     attributes.messageType = NVTX_MESSAGE_TYPE_REGISTERED;
     attributes.message.registered = message_handle_for(input.name);
     attributes.payloadType = NVTX_PAYLOAD_TYPE_INT32;
@@ -126,16 +132,41 @@ bool ScopedProfiling::enable_profiling()
 //---------------------------------------------------------------------------//
 /*!
  * Activate nvtx profiling with options.
+ *
+ * The call to NVTX is checked for validity (it should return a nonnegative
+ * number) except that we ignore -1 because that seems to be returned even when
+ * the call produces correct ranges in the profiling output.
  */
 void ScopedProfiling::activate(Input const& input) noexcept
 {
-    nvtxEventAttributes_t attributes_ = make_attributes(input);
-    int result = nvtxDomainRangePushEx(domain_handle(), &attributes_);
-    if (result < 0)
+    nvtxEventAttributes_t attributes = make_attributes(input);
+    int depth = nvtxDomainRangePushEx(domain_handle(), &attributes);
+    if (depth < -1)
     {
         activated_ = false;
-        CELER_LOG(warning) << "Failed to activate profiling domain '"
-                           << input.name << "'";
+
+        // Warn about failures, but only twice
+        constexpr int max_warnings{2};
+        static int num_warnings{0};
+        if (num_warnings < max_warnings)
+        {
+            ++num_warnings;
+
+            CELER_LOG(warning)
+                << "Failed to activate profiling domain '" << input.name
+                << "' (error code " << depth << ")";
+            if (num_warnings == 1)
+            {
+                CELER_LOG(info) << "Perhaps you're not running through `nsys` "
+                                   "or using the `celeritas` domain?";
+            }
+
+            if (num_warnings == max_warnings)
+            {
+                CELER_LOG(info) << "Suppressing future scoped profiling "
+                                   "warnings";
+            }
+        }
     }
 }
 
@@ -146,9 +177,11 @@ void ScopedProfiling::activate(Input const& input) noexcept
 void ScopedProfiling::deactivate() noexcept
 {
     int result = nvtxDomainRangePop(domain_handle());
-    if (result < 0)
+    if (result < -1)
     {
-        CELER_LOG(warning) << "Failed to deactivate profiling domain";
+        CELER_LOG(warning)
+            << "Failed to deactivate profiling domain (error code " << result
+            << ")";
     }
 }
 

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -22,9 +22,9 @@ namespace celeritas
 struct ScopedProfilingInput
 {
     std::string name;  //!< Name of the range
-    uint32_t color{0xFF00FF00u};  //!< ARGB
-    int32_t payload{0};  //!< User data
-    uint32_t category{0};  //!< Category, used to group ranges together
+    uint32_t color{};  //!< ARGB
+    int32_t payload{};  //!< User data
+    uint32_t category{};  //!< Category, used to group ranges together
 
     ScopedProfilingInput(std::string const& name) : name{name} {}
 };


### PR DESCRIPTION
I didn't think to check #975 in a real use case, but it seems that NVTX (at least in CUDA 11.5 on wildstyle) always returns -1 for the push/pop, even though they register correctly. This fixes that.

I've also extended the scope of the profiling ranges so we can see e.g. the slow spots in loading Geant4 and VecGeom, as well as the cost of initializing.

Finally, I added a "begin run" setup for `extend_from_secondaries` so that the initial `cudaMallocAsync` is moved outside the initial step.

<img width="1267" alt="zoom-full" src="https://github.com/celeritas-project/celeritas/assets/741229/5f8fbaae-1d06-4854-9d6d-e21b6c729e8f">

<img width="1267" alt="zoom-construct" src="https://github.com/celeritas-project/celeritas/assets/741229/d068397c-890c-419c-9ba1-2b422083a886">

<img width="1267" alt="zoom-step" src="https://github.com/celeritas-project/celeritas/assets/741229/bf1275f1-46c7-494d-9646-363900fffdb7">
