### PR TITLE
Improve performance with lower launch bounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,14 @@ celeritas_setup_option(CELERITAS_CORE_GEO ORANGE)
 celeritas_setup_option(CELERITAS_CORE_GEO Geant4 _allow_g4)
 celeritas_define_options(CELERITAS_CORE_GEO "Celeritas runtime geometry")
 
+if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
+  set(CELERITAS_MAX_BLOCK_SIZE 256
+    CACHE STRING "Threads-per-block launch bound for Celeritas action kernels"
+  )
+else()
+  set(CELERITAS_MAX_BLOCK_SIZE 0)
+endif()
+
 #----------------------------------------------------------------------------#
 # CMAKE VERSION CHECKS
 #----------------------------------------------------------------------------#

--- a/app/demo-interactor/KNDemoIO.cc
+++ b/app/demo-interactor/KNDemoIO.cc
@@ -19,13 +19,11 @@ namespace app
 //! I/O routines for JSON
 void to_json(nlohmann::json& j, DeviceGridParams const& v)
 {
-    j = nlohmann::json{{"threads_per_block", v.threads_per_block},
-                       {"sync", v.sync}};
+    j = nlohmann::json{{"sync", v.sync}};
 }
 
 void from_json(nlohmann::json const& j, DeviceGridParams& v)
 {
-    j.at("threads_per_block").get_to(v.threads_per_block);
     j.at("sync").get_to(v.sync);
 }
 

--- a/app/demo-interactor/KNDemoKernel.cu
+++ b/app/demo-interactor/KNDemoKernel.cu
@@ -193,7 +193,7 @@ __global__ void cleanup_kernel(DeviceCRef<ParamsData> const params,
 // KERNEL INTERFACES
 //---------------------------------------------------------------------------//
 #define CDE_LAUNCH_KERNEL(NAME, BLOCK_SIZE, THREADS, ...) \
-    CELER_LAUNCH_KERNEL(NAME, BLOCK_SIZE, THREADS, 0, __VA_ARGS__)
+    CELER_LAUNCH_KERNEL(NAME, THREADS, 0, __VA_ARGS__)
 
 /*!
  * Initialize particle states.

--- a/app/demo-interactor/KNDemoKernel.cu
+++ b/app/demo-interactor/KNDemoKernel.cu
@@ -192,9 +192,6 @@ __global__ void cleanup_kernel(DeviceCRef<ParamsData> const params,
 //---------------------------------------------------------------------------//
 // KERNEL INTERFACES
 //---------------------------------------------------------------------------//
-#define CDE_LAUNCH_KERNEL(NAME, BLOCK_SIZE, THREADS, ...) \
-    CELER_LAUNCH_KERNEL(NAME, THREADS, 0, __VA_ARGS__)
-
 /*!
  * Initialize particle states.
  */
@@ -205,12 +202,7 @@ void initialize(DeviceGridParams const& opts,
 {
     CELER_EXPECT(states.alive.size() == states.size());
     CELER_EXPECT(states.rng.size() == states.size());
-    CDE_LAUNCH_KERNEL(initialize,
-                      opts.threads_per_block,
-                      states.size(),
-                      params,
-                      states,
-                      initial);
+    CELER_LAUNCH_KERNEL(initialize, states.size(), 0, params, states, initial);
 }
 
 //---------------------------------------------------------------------------//
@@ -222,12 +214,10 @@ void iterate(DeviceGridParams const& opts,
              DeviceRef<StateData> const& states)
 {
     // Move to the collision site
-    CDE_LAUNCH_KERNEL(
-        move, opts.threads_per_block, states.size(), params, states);
+    CELER_LAUNCH_KERNEL(move, states.size(), 0, params, states);
 
     // Perform the interaction
-    CDE_LAUNCH_KERNEL(
-        interact, opts.threads_per_block, states.size(), params, states);
+    CELER_LAUNCH_KERNEL(interact, states.size(), 0, params, states);
 
     if (opts.sync)
     {
@@ -245,14 +235,11 @@ void cleanup(DeviceGridParams const& opts,
              DeviceRef<StateData> const& states)
 {
     // Process hits from buffer to grid
-    CDE_LAUNCH_KERNEL(process_hits,
-                      opts.threads_per_block,
-                      states.detector.capacity(),
-                      params,
-                      states);
+    CELER_LAUNCH_KERNEL(
+        process_hits, states.detector.capacity(), 0, params, states);
 
     // Clear buffers
-    CDE_LAUNCH_KERNEL(cleanup, device().threads_per_warp(), 1, params, states);
+    CELER_LAUNCH_KERNEL(cleanup, 1, 0, params, states);
 
     if (opts.sync)
     {

--- a/app/demo-interactor/KNDemoKernel.hh
+++ b/app/demo-interactor/KNDemoKernel.hh
@@ -30,7 +30,6 @@ namespace app
 //! Kernel thread dimensions
 struct DeviceGridParams
 {
-    unsigned int threads_per_block = 256;  //!< Threads per block
     bool sync = false;  //!< Call synchronize after every kernel
 };
 

--- a/app/demo-interactor/KNDemoRunner.cc
+++ b/app/demo-interactor/KNDemoRunner.cc
@@ -29,7 +29,6 @@ KNDemoRunner::KNDemoRunner(constSPParticleParams particles,
 {
     CELER_EXPECT(pparams_);
     CELER_EXPECT(xsparams_);
-    CELER_EXPECT(launch_params_.threads_per_block > 0);
 
     // Set up KN interactor data;
     namespace pdg = pdg;

--- a/app/demo-rasterizer/RDemoKernel.cu
+++ b/app/demo-rasterizer/RDemoKernel.cu
@@ -120,13 +120,7 @@ void trace(GeoParamsCRefDevice const& geo_params,
 {
     CELER_EXPECT(image);
 
-    CELER_LAUNCH_KERNEL(trace,
-                        device().default_block_size(),
-                        image.dims[0],
-                        0,
-                        geo_params,
-                        geo_state,
-                        image);
+    CELER_LAUNCH_KERNEL(trace, image.dims[0], 0, geo_params, geo_state, image);
 
     CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
 }

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -237,7 +237,6 @@ tell what variables are in use or may be useful.
  ======================= ========= ==========================================
  Variable                Component Brief description
  ======================= ========= ==========================================
- CELER_BLOCK_SIZE        corecel   Change the default block size for kernels
  CELER_COLOR             corecel   Enable/disable ANSI color logging
  CELER_DEBUG_DEVICE      corecel   Increase device error checking and output
  CELER_DISABLE_DEVICE    corecel   Disable CUDA/HIP support

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -30,7 +30,6 @@
 
 namespace celeritas
 {
-
 //---------------------------------------------------------------------------//
 /*!
  * Profile and launch Celeritas kernels from inside an action.
@@ -68,31 +67,6 @@ class ActionLauncher
                   "Launched action must be a trivially copyable function "
                   "object");
 
-    // Alias F to avoid hard error as SFINAE only works in the immediate
-    // context
-    template<class F_ = F, std::enable_if_t<!detail::has_applier_v<F_>, bool> = true>
-    explicit ActionLauncher(std::string_view name)
-        : calc_launch_params_{name, &detail::launch_action_impl<F_>}
-    {
-    }
-
-    template<class F_ = F,
-             std::enable_if_t<detail::kernel_no_bound<typename F_::Applier>, bool>
-             = true>
-    explicit ActionLauncher(std::string_view name)
-        : calc_launch_params_{name, &detail::launch_action_impl<F_>}
-    {
-    }
-
-    template<class F_ = F,
-             class A_ = typename F_::Applier,
-             std::enable_if_t<detail::has_max_block_size_v<A_>, bool> = true>
-    explicit ActionLauncher(std::string_view name)
-        : calc_launch_params_{
-            name, &detail::launch_action_impl<F_>, A_::max_block_size}
-    {
-    }
-
   public:
     //! Create a launcher from an action
     explicit ActionLauncher(ExplicitActionInterface const& action)
@@ -113,8 +87,8 @@ class ActionLauncher
     {
         if (!threads.empty())
         {
-            CELER_DEVICE_PREFIX(Stream_t)
-            stream = celeritas::device().stream(stream_id).get();
+            using StreamT = CELER_DEVICE_PREFIX(Stream_t);
+            StreamT stream = celeritas::device().stream(stream_id).get();
             auto config = calc_launch_params_(threads.size());
             detail::launch_action_impl<F>
                 <<<config.blocks_per_grid, config.threads_per_block, 0, stream>>>(
@@ -140,10 +114,8 @@ class ActionLauncher
         (*this)(range(ThreadId{num_threads}), stream_id, call_thread);
     }
 
-    //! Launch a Kernel with reduced grid size if tracks are sorted using the
-    //! expected track order strategy.
-    //! TODO: Always use an ActionLauncher instance with the action passed as
-    //! constructor argument
+    //! Launch with reduced grid size for when tracks are sorted
+    // TODO: Reuse ActionLauncher order/ID from constructor argument
     void operator()(CoreParams const& params,
                     CoreState<MemSpace::device> const& state,
                     ExplicitActionInterface const& action,
@@ -166,6 +138,36 @@ class ActionLauncher
 
   private:
     KernelParamCalculator calc_launch_params_;
+
+    //// PRIVATE CONSTRUCTORS ////
+    // (Note: aliasing F is necessary for SFINAE to work)
+
+    //! Construct when no "Applier" member function is defined
+    template<class F_ = F, std::enable_if_t<!detail::has_applier_v<F_>, bool> = true>
+    explicit ActionLauncher(std::string_view name)
+        : calc_launch_params_{name, &detail::launch_action_impl<F_>}
+    {
+    }
+
+    //! Construct when an "Applier" member function doesn't define launch
+    //! bounds
+    template<class F_ = F,
+             std::enable_if_t<detail::kernel_no_bound<typename F_::Applier>, bool>
+             = true>
+    explicit ActionLauncher(std::string_view name)
+        : calc_launch_params_{name, &detail::launch_action_impl<F_>}
+    {
+    }
+
+    //! Construct when an "Applier" member function defines max block size
+    template<class F_ = F,
+             class A_ = typename F_::Applier,
+             std::enable_if_t<detail::has_max_block_size_v<A_>, bool> = true>
+    explicit ActionLauncher(std::string_view name)
+        : calc_launch_params_{
+            name, &detail::launch_action_impl<F_>, A_::max_block_size}
+    {
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -172,4 +172,3 @@ class ActionLauncher
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas
-// vim: set ft=cuda

--- a/src/celeritas/global/detail/ActionLauncherKernel.device.hh
+++ b/src/celeritas/global/detail/ActionLauncherKernel.device.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "celeritas_config.h"
 #include "corecel/Macros.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
@@ -40,17 +41,17 @@ launch_kernel_impl(Range<ThreadId> const& thread_range, F& execute_thread)
 
 // Instantiated if F doesn't define a member type F::Applier
 template<class F, std::enable_if_t<!has_applier_v<F>, bool> = true>
-__global__ void
-launch_action_impl(Range<ThreadId> const thread_range, F execute_thread)
+__global__ void __launch_bounds__(CELERITAS_MAX_BLOCK_SIZE)
+    launch_action_impl(Range<ThreadId> const thread_range, F execute_thread)
 {
     launch_kernel_impl(thread_range, execute_thread);
 }
 
-// Instantiated if F::Applier has no launch bounds
+// Instantiated if F::Applier has no manual launch bounds
 template<class F,
          std::enable_if_t<kernel_no_bound<typename F::Applier>, bool> = true>
-__global__ void
-launch_action_impl(Range<ThreadId> const thread_range, F execute_thread)
+__global__ void __launch_bounds__(CELERITAS_MAX_BLOCK_SIZE)
+    launch_action_impl(Range<ThreadId> const thread_range, F execute_thread)
 {
     launch_kernel_impl(thread_range, execute_thread);
 }
@@ -90,3 +91,4 @@ __global__ void __launch_bounds__(T_, B_)
 }  // namespace
 }  // namespace detail
 }  // namespace celeritas
+// vim: set ft=cuda :

--- a/src/celeritas/global/detail/ApplierTraits.hh
+++ b/src/celeritas/global/detail/ApplierTraits.hh
@@ -46,7 +46,7 @@ template<typename T>
 inline constexpr bool has_min_warps_per_eu_v = HasMinWarpsPerEU<T>::value;
 
 //---------------------------------------------------------------------------//
-//! Checks if type T declared an`Applier` member type
+//! Checks if type T declared an `Applier` member type
 template<typename T, typename = void>
 struct HasApplier : std::false_type
 {

--- a/src/celeritas/random/detail/CuHipRngStateInit.cu
+++ b/src/celeritas/random/detail/CuHipRngStateInit.cu
@@ -52,12 +52,7 @@ void rng_state_init(DeviceRef<CuHipRngStateData> const& rng,
                     DeviceCRef<CuHipRngInitData> const& seeds)
 {
     CELER_EXPECT(rng.size() == seeds.size());
-    CELER_LAUNCH_KERNEL(rng_state_init,
-                        celeritas::device().default_block_size(),
-                        seeds.size(),
-                        0,
-                        rng,
-                        seeds);
+    CELER_LAUNCH_KERNEL(rng_state_init, seeds.size(), 0, rng, seeds);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/ExtendFromSecondariesAction.cu
+++ b/src/celeritas/track/ExtendFromSecondariesAction.cu
@@ -28,7 +28,7 @@ void ExtendFromSecondariesAction::locate_alive(CoreParams const& core_params,
                                                CoreStateDevice& core_state) const
 {
     using Executor = detail::LocateAliveExecutor;
-    static ActionLauncher<Executor> launch(*this);
+    static ActionLauncher<Executor> launch(*this, "locate-alive");
     launch(core_state,
            Executor{core_params.ptr<MemSpace::native>(), core_state.ptr()});
 }
@@ -41,7 +41,7 @@ void ExtendFromSecondariesAction::process_secondaries(
     CoreParams const& core_params, CoreStateDevice& core_state) const
 {
     using Executor = detail::ProcessSecondariesExecutor;
-    static ActionLauncher<Executor> launch(*this);
+    static ActionLauncher<Executor> launch(*this, "process-secondaries");
     launch(core_state,
            Executor{core_params.ptr<MemSpace::native>(),
                     core_state.ptr(),

--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -81,7 +81,6 @@ void sort_impl(TrackSlots const& track_slots,
     DeviceVector<ActionId::size_type> reordered_actions(track_slots.size(),
                                                         stream_id);
     CELER_LAUNCH_KERNEL(reorder_actions,
-                        celeritas::device().default_block_size(),
                         track_slots.size(),
                         celeritas::device().stream(stream_id).get(),
                         track_slots.data(),
@@ -236,7 +235,6 @@ void count_tracks_per_action(
         CELER_DEVICE_CHECK_ERROR();
         auto* stream = celeritas::device().stream(states.stream_id).get();
         CELER_LAUNCH_KERNEL(tracks_per_action,
-                            celeritas::device().default_block_size(),
                             states.size(),
                             stream,
                             states,

--- a/src/celeritas/user/DetectorSteps.cu
+++ b/src/celeritas/user/DetectorSteps.cu
@@ -95,7 +95,6 @@ void gather_step(DeviceRef<StepStateData> const& state, size_type num_valid)
     }
 
     CELER_LAUNCH_KERNEL(gather_step,
-                        celeritas::device().default_block_size(),
                         num_valid,
                         celeritas::device().stream(state.stream_id).get(),
                         state,

--- a/src/celeritas/user/detail/SimpleCaloImpl.cu
+++ b/src/celeritas/user/detail/SimpleCaloImpl.cu
@@ -52,7 +52,6 @@ void simple_calo_accum(DeviceRef<StepStateData> const& step,
 {
     CELER_EXPECT(step && calo);
     CELER_LAUNCH_KERNEL(simple_calo_accum,
-                        celeritas::device().default_block_size(),
                         step.size(),
                         celeritas::device().stream(step.stream_id).get(),
                         step,

--- a/src/celeritas_config.h.in
+++ b/src/celeritas_config.h.in
@@ -30,4 +30,6 @@
 
 @CELERITAS_CORE_GEO_CONFIG@
 
+#define CELERITAS_MAX_BLOCK_SIZE @CELERITAS_MAX_BLOCK_SIZE@
+
 #endif /* celeritas_config_h */

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -156,12 +156,14 @@ Device::Device(int id) : id_{id}, streams_{new detail::StreamStorage{}}
     unsigned int max_threads_per_block = 0;
 #if CELER_USE_DEVICE
 #    if CELERITAS_USE_CUDA
-    cudaDeviceProp props;
+    using DevicePropT = cudaDeviceProp;
 #    elif CELERITAS_USE_HIP
-    hipDeviceProp_t props;
+    using DevicePropT = hipDeviceProp_t;
 #    endif
 
+    DevicePropT props;
     CELER_DEVICE_CALL_PREFIX(GetDeviceProperties(&props, id));
+
     name_ = props.name;
     total_global_mem_ = props.totalGlobalMem;
     max_threads_per_block_ = props.maxThreadsDim[0];

--- a/src/corecel/sys/Device.hh
+++ b/src/corecel/sys/Device.hh
@@ -106,9 +106,6 @@ class Device
     //! Number of execution units per compute unit (1 for NVIDIA, 4 for AMD)
     unsigned int eu_per_cu() const { return eu_per_cu_; }
 
-    //! Default number of threads per block
-    unsigned int default_block_size() const { return default_block_size_; }
-
     //! Additional potentially interesting diagnostics
     MapStrInt const& extra() const { return extra_; }
 
@@ -144,7 +141,6 @@ class Device
     unsigned int threads_per_warp_{};
     bool can_map_host_memory_{};
     unsigned int eu_per_cu_{};
-    unsigned int default_block_size_{};
     MapStrInt extra_;
     UPStreamStorage streams_;
 };

--- a/src/corecel/sys/Device.hh
+++ b/src/corecel/sys/Device.hh
@@ -130,16 +130,21 @@ class Device
     using UPStreamStorage
         = std::unique_ptr<detail::StreamStorage, StreamStorageDeleter>;
 
-    int id_ = -1;
-    std::string name_ = "<DISABLED>";
-    std::size_t total_global_mem_ = 0;
-    int max_threads_per_block_ = 0;
-    int max_blocks_per_grid_ = 0;
-    int max_threads_per_cu_ = 0;
-    unsigned int threads_per_warp_ = 0;
-    bool can_map_host_memory_ = true;
-    unsigned int eu_per_cu_ = 0;
-    unsigned int default_block_size_ = 256u;
+    //// DATA ////
+
+    // Required values for default constructor
+    int id_{-1};
+    std::string name_{"<DISABLED>"};
+
+    // Default values overridden in device-ID constructor
+    std::size_t total_global_mem_{};
+    int max_threads_per_block_{};
+    int max_blocks_per_grid_{};
+    int max_threads_per_cu_{};
+    unsigned int threads_per_warp_{};
+    bool can_map_host_memory_{};
+    unsigned int eu_per_cu_{};
+    unsigned int default_block_size_{};
     MapStrInt extra_;
     UPStreamStorage streams_;
 };

--- a/src/corecel/sys/DeviceIO.json.cc
+++ b/src/corecel/sys/DeviceIO.json.cc
@@ -32,7 +32,6 @@ void to_json(nlohmann::json& j, Device const& d)
             {"max_threads_per_cu", d.max_threads_per_cu()},
             {"threads_per_warp", d.threads_per_warp()},
             {"eu_per_cu", d.eu_per_cu()},
-            {"default_block_size", d.default_block_size()},
             {"can_map_host_memory", d.can_map_host_memory()},
         };
 

--- a/src/corecel/sys/KernelAttributes.hh
+++ b/src/corecel/sys/KernelAttributes.hh
@@ -57,9 +57,14 @@ struct KernelAttributes
  * This can only be called from CUDA/HIP code. It assumes that the block size
  * is constant across the execution of the program and that the kernel is only
  * called by the device that's active at this time.
+ *
+ * The special value of zero threads per block causes the kernel attributes to
+ * default to the *compile-time maximum* number of threads per block as
+ * specified by launch bounds.
  */
 template<class F>
-KernelAttributes make_kernel_attributes(F* func, unsigned int threads_per_block)
+KernelAttributes
+make_kernel_attributes(F* func, unsigned int threads_per_block = 0)
 {
     KernelAttributes result;
     result.threads_per_block = threads_per_block;
@@ -73,6 +78,10 @@ KernelAttributes make_kernel_attributes(F* func, unsigned int threads_per_block)
         result.const_mem = attr.constSizeBytes;
         result.local_mem = attr.localSizeBytes;
         result.max_threads_per_block = attr.maxThreadsPerBlock;
+    }
+    if (result.threads_per_block == 0)
+    {
+        result.threads_per_block = result.max_threads_per_block;
     }
 
     // Get maximum number of active blocks per SM

--- a/src/corecel/sys/KernelParamCalculator.device.hh
+++ b/src/corecel/sys/KernelParamCalculator.device.hh
@@ -28,11 +28,11 @@
  * function itself has a \c _kernel suffix, and launch with the given
  * block/thread sizes and arguments list.
  */
-#define CELER_LAUNCH_KERNEL(NAME, BLOCK_SIZE, THREADS, STREAM, ...)          \
+#define CELER_LAUNCH_KERNEL(NAME, THREADS, STREAM, ...)                      \
     do                                                                       \
     {                                                                        \
         static const ::celeritas::KernelParamCalculator calc_launch_params_( \
-            #NAME, NAME##_kernel, BLOCK_SIZE);                               \
+            #NAME, NAME##_kernel);                                           \
         auto grid_ = calc_launch_params_(THREADS);                           \
                                                                              \
         CELER_LAUNCH_KERNEL_IMPL(NAME##_kernel,                              \
@@ -148,14 +148,16 @@ CELER_FUNCTION auto KernelParamCalculator::thread_id() -> ThreadId
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct for the given global kernel F.
+ * Construct with the maximum threads per block for a given kernel.
  */
 template<class F>
 KernelParamCalculator::KernelParamCalculator(std::string_view name,
                                              F* kernel_func_ptr)
-    : KernelParamCalculator(
-        name, kernel_func_ptr, celeritas::device().default_block_size())
 {
+    auto attrs = make_kernel_attributes(kernel_func_ptr);
+    CELER_ASSERT(attrs.threads_per_block > 0);
+    block_size_ = attrs.threads_per_block;
+    this->register_kernel(name, std::move(attrs));
 }
 
 //---------------------------------------------------------------------------//
@@ -171,8 +173,9 @@ KernelParamCalculator::KernelParamCalculator(std::string_view name,
                                              dim_type threads_per_block)
     : block_size_(threads_per_block)
 {
-    CELER_EXPECT(threads_per_block % celeritas::device().threads_per_warp()
-                 == 0);
+    CELER_EXPECT(threads_per_block > 0
+                 && threads_per_block % celeritas::device().threads_per_warp()
+                        == 0);
 
     auto attrs = make_kernel_attributes(kernel_func_ptr, threads_per_block);
     CELER_VALIDATE(threads_per_block <= attrs.max_threads_per_block,

--- a/test/celeritas/ext/Vecgeom.test.cu
+++ b/test/celeritas/ext/Vecgeom.test.cu
@@ -78,7 +78,6 @@ VGGTestOutput vgg_test(VGGTestInput const& input)
 
     // Run kernel
     CELER_LAUNCH_KERNEL(vgg_test,
-                        celeritas::device().default_block_size(),
                         init.size(),
                         0,
                         input.params,

--- a/test/celeritas/geo/HeuristicGeoTestBase.cu
+++ b/test/celeritas/geo/HeuristicGeoTestBase.cu
@@ -42,12 +42,7 @@ heuristic_test_kernel(DeviceCRef<HeuristicGeoParamsData> const params,
 void heuristic_test_execute(DeviceCRef<HeuristicGeoParamsData> const& params,
                             DeviceRef<HeuristicGeoStateData> const& state)
 {
-    CELER_LAUNCH_KERNEL(heuristic_test,
-                        device().default_block_size(),
-                        state.size(),
-                        0,
-                        params,
-                        state);
+    CELER_LAUNCH_KERNEL(heuristic_test, state.size(), 0, params, state);
 
     CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
 }

--- a/test/celeritas/mat/Material.test.cu
+++ b/test/celeritas/mat/Material.test.cu
@@ -83,7 +83,6 @@ MTestOutput m_test(MTestInput const& input)
     thrust::device_vector<real_type> tot_z(input.size());
 
     CELER_LAUNCH_KERNEL(m_test,
-                        device().default_block_size(),
                         init.size(),
                         0,
                         init.size(),

--- a/test/celeritas/phys/Particle.test.cu
+++ b/test/celeritas/phys/Particle.test.cu
@@ -68,7 +68,6 @@ PTVTestOutput ptv_test(PTVTestInput input)
                                          * PTVTestOutput::props_per_thread());
 
     CELER_LAUNCH_KERNEL(ptv_test,
-                        device().default_block_size(),
                         init.size(),
                         0,
                         init.size(),

--- a/test/celeritas/phys/Physics.test.cu
+++ b/test/celeritas/phys/Physics.test.cu
@@ -48,8 +48,7 @@ void phys_cuda_test(PTestInput const& input)
 {
     CELER_ASSERT(input.inits.size() == input.states.size());
 
-    CELER_LAUNCH_KERNEL(
-        phys_test, device().default_block_size(), input.states.size(), 0, input);
+    CELER_LAUNCH_KERNEL(phys_test, input.states.size(), 0, input);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/random/RngEngine.test.cu
+++ b/test/celeritas/random/RngEngine.test.cu
@@ -62,7 +62,6 @@ std::vector<unsigned int> re_test_native(RngDeviceRef states)
     thrust::device_vector<unsigned int> samples(states.size());
 
     CELER_LAUNCH_KERNEL(sample_native,
-                        device().default_block_size(),
                         states.size(),
                         0,
                         states,
@@ -81,10 +80,8 @@ std::vector<T> re_test_canonical(RngDeviceRef states)
 {
     thrust::device_vector<T> samples(states.size());
 
-    static const KernelParamCalculator calc_launch_params(
-        "sample_canonical",
-        sample_canonical_kernel<T>,
-        device().default_block_size());
+    static KernelParamCalculator const calc_launch_params(
+        "sample_canonical", sample_canonical_kernel<T>);
     auto grid = calc_launch_params(states.size());
 
     CELER_LAUNCH_KERNEL_IMPL(sample_canonical_kernel<T>,

--- a/test/corecel/cont/Range.test.cc
+++ b/test/corecel/cont/Range.test.cc
@@ -415,7 +415,6 @@ TEST(TEST_IF_CELER_DEVICE(DeviceRangeTest), grid_stride)
         input.y[i] = i;
     }
     input.num_threads = device().threads_per_warp();
-    input.threads_per_block = 256;
 
     // Calculate saxpy using CPU
     std::vector<int> z_cpu(N, 0.0);

--- a/test/corecel/cont/Range.test.cu
+++ b/test/corecel/cont/Range.test.cu
@@ -41,7 +41,6 @@ RangeTestOutput rangedev_test(RangeTestInput input)
 
     // Test kernel
     CELER_LAUNCH_KERNEL(rangedev_test,
-                        input.threads_per_block,
                         input.num_threads,
                         0,
                         input.a,

--- a/test/corecel/cont/Range.test.hh
+++ b/test/corecel/cont/Range.test.hh
@@ -25,7 +25,6 @@ struct RangeTestInput
     std::vector<int> x;
     std::vector<int> y;
     unsigned int num_threads;
-    unsigned int threads_per_block;
 };
 
 //! Output data

--- a/test/corecel/data/Collection.test.cu
+++ b/test/corecel/data/Collection.test.cu
@@ -69,7 +69,6 @@ void col_cuda_test(CTestInput input)
 {
     CELER_EXPECT(input.states.size() > 0);
     CELER_LAUNCH_KERNEL(col_cuda_test,
-                        device().default_block_size(),
                         input.states.size(),
                         0,
                         input.params,

--- a/test/corecel/data/ObserverPtr.test.cu
+++ b/test/corecel/data/ObserverPtr.test.cu
@@ -43,13 +43,7 @@ void copy_test(ObserverPtr<int const, MemSpace::device> in_data,
                ObserverPtr<int, MemSpace::device> out_data,
                size_type size)
 {
-    CELER_LAUNCH_KERNEL(copy_test,
-                        device().default_block_size(),
-                        size,
-                        0,
-                        in_data,
-                        out_data,
-                        size);
+    CELER_LAUNCH_KERNEL(copy_test, size, 0, in_data, out_data, size);
 
     CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
 }

--- a/test/orange/surf/LocalSurfaceVisitor.test.cu
+++ b/test/orange/surf/LocalSurfaceVisitor.test.cu
@@ -39,8 +39,7 @@ __global__ void sa_test_kernel(SATestInput input)
 //! Run on device and return results
 void sa_test(SATestInput input)
 {
-    CELER_LAUNCH_KERNEL(
-        sa_test, device().default_block_size(), input.states.size(), 0, input);
+    CELER_LAUNCH_KERNEL(sa_test, input.states.size(), 0, input);
     CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
 }
 

--- a/test/orange/univ/SimpleUnitTracker.test.cu
+++ b/test/orange/univ/SimpleUnitTracker.test.cu
@@ -38,12 +38,7 @@ __global__ void initialize_kernel(ParamsRef<MemSpace::device> const params,
 void test_initialize(ParamsRef<MemSpace::device> const& params,
                      StateRef<MemSpace::device> const& state)
 {
-    CELER_LAUNCH_KERNEL(initialize,
-                        device().default_block_size(),
-                        state.size(),
-                        0,
-                        params,
-                        state);
+    CELER_LAUNCH_KERNEL(initialize, state.size(), 0, params, state);
     CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
 }
 


### PR DESCRIPTION
There should be no advantage to using the same environment-controlled "threads per block" but allowing the CUDA/ROCm compiler to "allow" a higher maximum launch count. This PR removes the environment variable and adds a CMake cache variable `CELERITAS_MAX_BLOCK_SIZE` that sets the default block size for kernels executed through `ActionLauncher`. The KernelAttributes collected during the first kernel launch are stored persistently as the block size.

## Occupancy

The occupancy increases for ORANGE boundary crossing and pre-step kernels and a couple others. Strangely the register usage decreases slightly in a few kernels despite no change in the occupancy...

Occupancy before and after show much better utilization on AMD:
![occupancy-before](https://github.com/celeritas-project/celeritas/assets/741229/cf22a223-66a7-44a7-bc57-f487a2a588c5)

![occpuancy-after](https://github.com/celeritas-project/celeritas/assets/741229/77c08594-9ced-412b-b276-b51155ab6a8a)

arch/geo/kernel/local spill (B)/register usage (B)/occupancy:
```diff
diff --git a/kernel-occupancy.md b/kernel-occupancy.md
index 857f705..f12508f 100644
--- a/kernel-occupancy.md
+++ b/kernel-occupancy.md
@@ -13,56 +13,56 @@
 | cuda | vecgeom | physics-discrete-select                     |     0 |      256 |     0.500 |
 | cuda | vecgeom | ioni-moller-bhabha                          |    48 |      236 |     0.500 |
 | cuda | vecgeom | brems-sb                                    |    48 |      304 |     0.375 |
-| cuda | vecgeom | brems-rel                                   |    48 |      296 |     0.375 |
+| cuda | vecgeom | brems-rel                                   |    48 |      440 |     0.250 |
 | cuda | vecgeom | photoel-livermore                           |    64 |      280 |     0.375 |
-| cuda | vecgeom | scat-klein-nishina                          |    48 |      232 |     0.500 |
+| cuda | vecgeom | scat-klein-nishina                          |    48 |      224 |     0.500 |
 | cuda | vecgeom | conv-bethe-heitler                          |    48 |      288 |     0.375 |
-| cuda | vecgeom | scat-rayleigh                               |   104 |      264 |     0.375 |
+| cuda | vecgeom | scat-rayleigh                               |   104 |      256 |     0.500 |
 | cuda | vecgeom | annihil-2-gamma                             |    48 |      224 |     0.500 |
 | cuda | vecgeom | geo-boundary                                |     0 |      880 |     0.125 |
-| cuda | vecgeom | extend-from-secondaries                     |     0 |      116 |     1.000 |
-| cuda | vecgeom | extend-from-secondaries                     |     0 |      176 |     0.625 |
+| cuda | vecgeom | extend-from-secondaries-locate-alive        |     0 |      116 |     1.000 |
+| cuda | vecgeom | extend-from-secondaries-process-secondaries |     0 |      176 |     0.625 |
 | cuda | orange  | extend-from-primaries                       |     0 |      112 |     1.000 |
 | cuda | orange  | initialize-tracks                           |   112 |      256 |     0.500 |
-| cuda | orange  | pre-step                                    |     0 |      260 |     0.375 |
-| cuda | orange  | along-step-uniform-msc-limit-step-msc-urban |    48 |      256 |     0.500 |
+| cuda | orange  | pre-step                                    |     0 |      256 |     0.500 |
+| cuda | orange  | along-step-uniform-msc-limit-step-msc-urban |    48 |      264 |     0.375 |
 | cuda | orange  | along-step-uniform-msc-propagate            |   240 |      512 |     0.250 |
-| cuda | orange  | along-step-uniform-msc-scatter-msc-urban    |    64 |      268 |     0.375 |
+| cuda | orange  | along-step-uniform-msc-scatter-msc-urban    |    64 |      296 |     0.375 |
 | cuda | orange  | along-step-uniform-msc-update-time          |     0 |       96 |     1.000 |
-| cuda | orange  | along-step-uniform-msc-apply-eloss-mean     |     0 |      224 |     0.500 |
+| cuda | orange  | along-step-uniform-msc-apply-eloss-mean     |     0 |      216 |     0.500 |
 | cuda | orange  | along-step-uniform-msc-update-track         |     0 |       64 |     1.000 |
-| cuda | orange  | along-step-neutral                          |     0 |      512 |     0.250 |
-| cuda | orange  | physics-discrete-select                     |     0 |      240 |     0.500 |
-| cuda | orange  | ioni-moller-bhabha                          |    64 |      240 |     0.500 |
-| cuda | orange  | brems-sb                                    |    64 |      320 |     0.375 |
-| cuda | orange  | brems-rel                                   |    64 |      308 |     0.375 |
+| cuda | orange  | along-step-neutral                          |     0 |      508 |     0.250 |
+| cuda | orange  | physics-discrete-select                     |     0 |      236 |     0.500 |
+| cuda | orange  | ioni-moller-bhabha                          |    64 |      236 |     0.500 |
+| cuda | orange  | brems-sb                                    |    64 |      304 |     0.375 |
+| cuda | orange  | brems-rel                                   |    64 |      292 |     0.375 |
 | cuda | orange  | photoel-livermore                           |    80 |      272 |     0.375 |
-| cuda | orange  | scat-klein-nishina                          |    64 |      236 |     0.500 |
-| cuda | orange  | conv-bethe-heitler                          |    64 |      296 |     0.375 |
-| cuda | orange  | scat-rayleigh                               |   104 |      264 |     0.375 |
-| cuda | orange  | annihil-2-gamma                             |    64 |      224 |     0.500 |
-| cuda | orange  | geo-boundary                                |   152 |      320 |     0.375 |
-| cuda | orange  | extend-from-secondaries                     |     0 |      116 |     1.000 |
-| cuda | orange  | extend-from-secondaries                     |     0 |      188 |     0.625 |
+| cuda | orange  | scat-klein-nishina                          |    64 |      232 |     0.500 |
+| cuda | orange  | conv-bethe-heitler                          |    64 |      272 |     0.375 |
+| cuda | orange  | scat-rayleigh                               |   104 |      252 |     0.500 |
+| cuda | orange  | annihil-2-gamma                             |    64 |      232 |     0.500 |
+| cuda | orange  | geo-boundary                                |   176 |      256 |     0.500 |
+| cuda | orange  | extend-from-secondaries-locate-alive        |     0 |      116 |     1.000 |
+| cuda | orange  | extend-from-secondaries-process-secondaries |     0 |      188 |     0.625 |
 | hip  | orange  | extend-from-primaries                       |     0 |       48 |     1.000 |
 | hip  | orange  | initialize-tracks                           |   120 |      360 |     0.625 |
 | hip  | orange  | pre-step                                    |     0 |      336 |     0.625 |
 | hip  | orange  | along-step-uniform-msc-limit-step-msc-urban |     0 |      452 |     0.500 |
 | hip  | orange  | along-step-uniform-msc-propagate            |    48 |      944 |     0.250 |
-| hip  | orange  | along-step-uniform-msc-scatter-msc-urban    |     0 |      452 |     0.250 |
+| hip  | orange  | along-step-uniform-msc-scatter-msc-urban    |     0 |      452 |     0.500 |
 | hip  | orange  | along-step-uniform-msc-update-time          |     0 |       80 |     1.000 |
 | hip  | orange  | along-step-uniform-msc-apply-eloss-mean     |     0 |      172 |     1.000 |
 | hip  | orange  | along-step-uniform-msc-update-track         |     0 |       44 |     1.000 |
-| hip  | orange  | along-step-neutral                          |    64 |      512 |     0.500 |
+| hip  | orange  | along-step-neutral                          |    16 |      640 |     0.375 |
 | hip  | orange  | physics-discrete-select                     |     0 |      248 |     1.000 |
-| hip  | orange  | ioni-moller-bhabha                          |    48 |      244 |     0.250 |
-| hip  | orange  | brems-sb                                    |    48 |      404 |     0.250 |
-| hip  | orange  | brems-rel                                   |    48 |      456 |     0.250 |
+| hip  | orange  | ioni-moller-bhabha                          |    48 |      244 |     1.000 |
+| hip  | orange  | brems-sb                                    |    48 |      404 |     0.500 |
+| hip  | orange  | brems-rel                                   |    48 |      496 |     0.500 |
 | hip  | orange  | photoel-livermore                           |    48 |      240 |     0.875 |
-| hip  | orange  | scat-klein-nishina                          |     0 |      272 |     0.250 |
+| hip  | orange  | scat-klein-nishina                          |     0 |      272 |     0.875 |
 | hip  | orange  | conv-bethe-heitler                          |     0 |      312 |     0.750 |
-| hip  | orange  | scat-rayleigh                               |    64 |      328 |     0.250 |
+| hip  | orange  | scat-rayleigh                               |    64 |      328 |     0.625 |
 | hip  | orange  | annihil-2-gamma                             |     0 |      312 |     0.750 |
 | hip  | orange  | geo-boundary                                |   304 |      368 |     0.625 |
-| hip  | orange  | extend-from-secondaries                     |     0 |      212 |     1.000 |
-| hip  | orange  | extend-from-secondaries                     |     0 |      240 |     0.250 |
+| hip  | orange  | extend-from-secondaries-locate-alive        |     0 |      212 |     1.000 |
+| hip  | orange  | extend-from-secondaries-process-secondaries |    35 |      256 |     1.000 |
```

## Performance

Unfortunately the Frontier performance statistics are borked by the first step, but the Summit results show ~10% improvement with ORANGE (but no change with VecGeom).


![speedup-after](https://github.com/celeritas-project/celeritas/assets/741229/a280c448-068e-483b-bfb5-0550a665a6bb)

```diff
diff --git a/results/summit/speedup.md b/results/summit/speedup.md
index 786deef..057661e 100644
--- a/results/summit/speedup.md
+++ b/results/summit/speedup.md
@@ -1,19 +1,19 @@
 | Problem                      | Geometry |      Speedup |
 | ---------------------------- | -------- | ------------ |
-| cms2018 [Z]                  | vecgeom  |  9.6× (±0.1) |
+| cms2018 [Z]                  | vecgeom  |  9.7× (±0.1) |
 | cms2018+field+msc [ZFM]      | vecgeom  |  6.7× (±0.1) |
-| simple-cms+field [BF]        | orange   | 24.8× (±2.3) |
-| simple-cms+field+msc [BFM]   | orange   | 29.0× (±1.9) |
-|                              | vecgeom  | 27.8× (±1.6) |
-| simple-cms+msc [BM]          | orange   | 26.5× (±0.2) |
-| testem15 [A]                 | orange   | 22.4× (±2.4) |
-| testem15+field [AF]          | orange   | 25.5× (±2.6) |
+| simple-cms+field [BF]        | orange   | 30.0× (±1.7) |
+| simple-cms+field+msc [BFM]   | orange   | 33.3× (±1.5) |
+|                              | vecgeom  | 29.7× (±1.2) |
+| simple-cms+msc [BM]          | orange   | 29.8× (±0.5) |
+| testem15 [A]                 | orange   | 24.2× (±0.1) |
+| testem15+field [AF]          | orange   | 32.4× (±2.3) |
 |                              | vecgeom  |  nan× (±nan) |
-| testem15+field+msc [AFM]     | orange   | 32.1× (±3.2) |
-|                              | vecgeom  | 31.0× (±2.1) |
-| testem3-flat [C]             | orange   | 24.2× (±0.3) |
-|                              | vecgeom  | 25.6× (±2.0) |
-| testem3-flat+field [CF]      | orange   | 23.0× (±0.6) |
-| testem3-flat+field+msc [CFM] | orange   | 26.9× (±1.1) |
-|                              | vecgeom  | 15.5× (±0.3) |
-| testem3-flat+msc [CM]        | orange   | 33.7× (±1.4) |
+| testem15+field+msc [AFM]     | orange   | 34.2× (±3.1) |
+|                              | vecgeom  | 32.0× (±2.1) |
+| testem3-flat [C]             | orange   | 27.1× (±0.2) |
+|                              | vecgeom  | 24.8× (±1.5) |
+| testem3-flat+field [CF]      | orange   | 24.8× (±0.7) |
+| testem3-flat+field+msc [CFM] | orange   | 29.3× (±0.6) |
+|                              | vecgeom  | 15.3× (±0.2) |
+| testem3-flat+msc [CM]        | orange   | 36.1× (±0.9) |
```