### PR TITLE
Run "warmup step" to hide once-off overhead from total run time

### DIFF
--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -109,7 +109,7 @@ auto Runner::operator()(StreamId stream, EventId event) -> RunnerResult
     CELER_EXPECT(event < this->num_events());
 
     auto& transport = this->get_transporter(stream);
-    return (*transport)(make_span(events_[event.get()]));
+    return transport(make_span(events_[event.get()]));
 }
 
 //---------------------------------------------------------------------------//
@@ -121,7 +121,7 @@ auto Runner::operator()() -> RunnerResult
     CELER_EXPECT(events_.size() == 1);
 
     auto& transport = this->get_transporter(StreamId{0});
-    return (*transport)(make_span(events_.front()));
+    return transport(make_span(events_.front()));
 }
 
 //---------------------------------------------------------------------------//
@@ -154,12 +154,12 @@ auto Runner::get_action_times() -> MapStrReal
     auto& transport = this->get_transporter(StreamId{0});
     if (use_device_)
     {
-        return dynamic_cast<Transporter<MemSpace::device> const&>(*transport)
+        return dynamic_cast<Transporter<MemSpace::device> const&>(transport)
             .get_action_times();
     }
     else
     {
-        return dynamic_cast<Transporter<MemSpace::host> const&>(*transport)
+        return dynamic_cast<Transporter<MemSpace::host> const&>(transport)
             .get_action_times();
     }
 }
@@ -485,7 +485,7 @@ void Runner::build_diagnostics(RunnerInput const& inp)
 /*!
  * Get the transporter for the given stream, constructing if necessary.
  */
-auto Runner::get_transporter(StreamId stream) -> UPTransporterBase&
+auto Runner::get_transporter(StreamId stream) -> TransporterBase&
 {
     CELER_EXPECT(stream < this->num_streams());
 
@@ -513,7 +513,7 @@ auto Runner::get_transporter(StreamId stream) -> UPTransporterBase&
         }();
     }
     CELER_ENSURE(result);
-    return result;
+    return *result;
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -99,6 +99,19 @@ Runner::Runner(RunnerInput const& inp, SPOutputRegistry output)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Run a single step with no active states to "warm up".
+ *
+ * This is to reduce the uncertainty in timing for problems, especially on AMD
+ * hardware.
+ */
+void Runner::warm_up()
+{
+    auto& transport = this->get_transporter(StreamId{0});
+    transport();
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Run on a single stream/thread, returning the transport result.
  *
  * This will partition the input primaries among all the streams.

--- a/app/celer-sim/Runner.hh
+++ b/app/celer-sim/Runner.hh
@@ -98,7 +98,7 @@ class Runner
     void build_transporter_input(RunnerInput const&);
     void build_events(RunnerInput const&);
     int get_num_streams(RunnerInput const&);
-    UPTransporterBase& get_transporter(StreamId);
+    TransporterBase& get_transporter(StreamId);
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-sim/Runner.hh
+++ b/app/celer-sim/Runner.hh
@@ -55,6 +55,9 @@ class Runner
     // Construct on all threads from a JSON input and shared output manager
     Runner(RunnerInput const& inp, SPOutputRegistry output);
 
+    // Warm up by running a single step with no active tracks
+    void warm_up();
+
     // Run on a single stream/thread, returning the transport result
     RunnerResult operator()(StreamId, EventId);
 

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "celeritas_config.h"
+#include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/io/Label.hh"
 #include "corecel/sys/Environment.hh"
@@ -71,6 +73,7 @@ struct RunnerInput
     bool sync{};
     bool merge_events{false};  //!< Run all events at once on a single stream
     bool default_stream{false};  //!< Launch all kernels on the default stream
+    bool warm_up{CELER_USE_DEVICE};  //!< Run a nullop step first
 
     // Magnetic field vector [* 1/Tesla] and associated field options
     Real3 mag_field{no_field()};

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -134,12 +134,14 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
 {
     j = nlohmann::json::object();
     RunnerInput const default_args;
+    //! Save if not unspecified or if applicable
 #define LDIO_SAVE_OPTION(NAME)           \
     do                                   \
     {                                    \
         if (v.NAME != default_args.NAME) \
             j[#NAME] = v.NAME;           \
     } while (0)
+    //! Always save
 #define LDIO_SAVE_REQUIRED(NAME) j[#NAME] = v.NAME
 
     LDIO_SAVE_OPTION(cuda_heap_size);
@@ -165,16 +167,16 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE_OPTION(step_diagnostic_maxsteps);
     LDIO_SAVE_OPTION(write_track_counts);
 
-    LDIO_SAVE_OPTION(seed);
-    LDIO_SAVE_OPTION(num_track_slots);
+    LDIO_SAVE_REQUIRED(seed);
+    LDIO_SAVE_REQUIRED(num_track_slots);
     LDIO_SAVE_OPTION(max_steps);
     LDIO_SAVE_REQUIRED(initializer_capacity);
     LDIO_SAVE_REQUIRED(max_events);
     LDIO_SAVE_REQUIRED(secondary_stack_factor);
     LDIO_SAVE_REQUIRED(use_device);
-    LDIO_SAVE_OPTION(sync);
-    LDIO_SAVE_OPTION(merge_events);
-    LDIO_SAVE_OPTION(default_stream);
+    LDIO_SAVE_REQUIRED(sync);
+    LDIO_SAVE_REQUIRED(merge_events);
+    LDIO_SAVE_REQUIRED(default_stream);
 
     LDIO_SAVE_OPTION(mag_field);
     if (v.mag_field != RunnerInput::no_field())
@@ -183,9 +185,9 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     }
 
     LDIO_SAVE_OPTION(step_limiter);
-    LDIO_SAVE_OPTION(brem_combined);
+    LDIO_SAVE_REQUIRED(brem_combined);
 
-    LDIO_SAVE_OPTION(track_order);
+    LDIO_SAVE_REQUIRED(track_order);
     if (v.physics_filename.empty() || !ends_with(v.physics_filename, ".root"))
     {
         LDIO_SAVE_REQUIRED(geant_options);

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -102,6 +102,7 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_OPTION(sync);
     LDIO_LOAD_OPTION(merge_events);
     LDIO_LOAD_OPTION(default_stream);
+    LDIO_LOAD_OPTION(warm_up);
 
     LDIO_LOAD_OPTION(mag_field);
     LDIO_LOAD_OPTION(field_options);
@@ -177,6 +178,7 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE_REQUIRED(sync);
     LDIO_SAVE_REQUIRED(merge_events);
     LDIO_SAVE_REQUIRED(default_stream);
+    LDIO_SAVE_REQUIRED(warm_up);
 
     LDIO_SAVE_OPTION(mag_field);
     if (v.mag_field != RunnerInput::no_field())

--- a/app/celer-sim/RunnerOutput.cc
+++ b/app/celer-sim/RunnerOutput.cc
@@ -72,6 +72,7 @@ void RunnerOutput::output(JsonPimpl* j) const
         {"actions", result_.action_times},
         {"total", result_.total_time},
         {"setup", result_.setup_time},
+        {"warmup", result_.warmup_time},
     };
     obj["num_streams"] = result_.num_streams;
 

--- a/app/celer-sim/RunnerOutput.hh
+++ b/app/celer-sim/RunnerOutput.hh
@@ -29,6 +29,7 @@ struct SimulationResult
 
     real_type total_time{};  //!< Total simulation time
     real_type setup_time{};  //!< One-time initialization cost
+    real_type warmup_time{};  //!< One-time warmup cost
     MapStrReal action_times{};  //!< Accumulated action timing
     std::vector<TransporterResult> events;  //!< Results tallied for each event
     size_type num_streams{};  //!< Number of CPU/OpenMP threads

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -15,6 +15,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/data/Ref.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/sys/ScopedSignalHandler.hh"
 #include "corecel/sys/Stopwatch.hh"
 #include "celeritas/Types.hh"
@@ -52,6 +53,22 @@ Transporter<M>::Transporter(TransporterInput inp)
     step_input.stream_id = inp.stream_id;
     step_input.sync = inp.sync;
     stepper_ = std::make_shared<Stepper<M>>(std::move(step_input));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Run a single step with no active states to "warm up".
+ *
+ * This is to reduce the uncertainty in timing for problems, especially on AMD
+ * hardware.
+ */
+template<MemSpace M>
+void Transporter<M>::operator()()
+{
+    CELER_LOG(status) << "Warming up";
+    ScopedTimeLog scoped_time;
+    StepperResult step_counts = (*stepper_)();
+    CELER_ENSURE(step_counts.alive == 0);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-sim/Transporter.hh
+++ b/app/celer-sim/Transporter.hh
@@ -93,6 +93,9 @@ class TransporterBase
   public:
     virtual ~TransporterBase() = 0;
 
+    // Run a single step with no active states to "warm up"
+    virtual void operator()() = 0;
+
     // Transport the input primaries and all secondaries produced
     virtual TransporterResult operator()(SpanConstPrimary primaries) = 0;
 };
@@ -113,6 +116,9 @@ class Transporter final : public TransporterBase
   public:
     // Construct from parameters
     explicit Transporter(TransporterInput inp);
+
+    // Run a single step with no active states to "warm up"
+    void operator()() final;
 
     // Transport the input primaries and all secondaries produced
     TransporterResult operator()(SpanConstPrimary primaries) final;

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -106,7 +106,12 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
     }
     result.num_streams = num_streams;
 
-    // Start profiling *after* initialization (e.g. VecGeom) is complete
+    if (run_input->warm_up)
+    {
+        run_stream.warm_up();
+    }
+
+    // Start profiling *after* initialization and warmup are complete
     Stopwatch get_transport_time;
     if (run_input->merge_events)
     {

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -108,7 +108,9 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
 
     if (run_input->warm_up)
     {
+        get_setup_time = {};
         run_stream.warm_up();
+        result.warmup_time = get_setup_time();
     }
 
     // Start profiling *after* initialization and warmup are complete

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -337,6 +337,28 @@ Additional system backtracing is specified in line 5; line 6 writes (and
 overwrites) to a particular output file; the final line invokes the
 application.
 
+Timelines can also be generated on AMD hardware using the ROCProfiler_
+applications. Here's an example that writes out timeline information:
+
+.. sourcecode:: console
+   :linenos:
+
+   $ CELER_ENABLE_PROFILING=1 \
+   > rocprof \
+   > --roctx-trace \
+   > --hip-trace \
+   > celer-sim inp.json
+
+.. _ROCProfiler: https://rocm.docs.amd.com/projects/rocprofiler/en/latest/rocprofv1.html#roctx-trace
+
+It will output a :file:`results.json` file that contains profiling data for
+both the Celeritas annotations (line 3) and HIP function calls (line 4) in
+a "trace event format" which can be viewed in the Perfetto_ data visualization
+tool.
+
+.. _Perfetto: https://ui.perfetto.dev/
+
+
 Kernel profiling
 ----------------
 

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -85,6 +85,12 @@ class CoreState final : public CoreStateInterface
     //! Number of track slots
     size_type size() const final { return states_.size(); }
 
+    //! Whether the state is being transported with no active particles
+    bool warming_up() const
+    {
+        return counters_.num_active == 0 && counters_.num_primaries == 0;
+    }
+
     //! Get a reference to the mutable state data
     Ref& ref() { return states_.ref(); }
 

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -11,6 +11,7 @@
 
 #include "corecel/cont/Range.hh"
 #include "corecel/data/Ref.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "orange/OrangeData.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/track/TrackInitParams.hh"
@@ -37,6 +38,7 @@ Stepper<M>::Stepper(Input input)
     }();
 
     // Execute beginning-of-run action
+    ScopedProfiling profile_this{"begin-run"};
     actions_->begin_run(*params_, state_);
 }
 
@@ -55,6 +57,7 @@ Stepper<M>::~Stepper() = default;
 template<MemSpace M>
 auto Stepper<M>::operator()() -> result_type
 {
+    ScopedProfiling profile_this{"step"};
     actions_->execute(*params_, state_);
 
     // Get the number of track initializers and active tracks

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -16,7 +16,6 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/EnumArray.hh"
 #include "corecel/cont/Range.hh"
-#include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "corecel/sys/ScopedProfiling.hh"
@@ -83,13 +82,11 @@ template<MemSpace M>
 void ActionSequence::begin_run(CoreParams const& params, CoreState<M>& state)
 {
     // Execute beginning-of-run action
-    CELER_LOG_LOCAL(status) << "Initializing additional state data";
-    ScopedProfiling profile_this{"begin-run"};
     ScopedMem record_mem("ActionSequence.begin_run");
-    ScopedTimeLog scoped_time;
 
     for (auto const& sp_action : begin_run_)
     {
+        ScopedProfiling profile_this{sp_action->label()};
         sp_action->begin_run(params, state);
     }
 }
@@ -107,7 +104,6 @@ void ActionSequence::execute(CoreParams const& params, CoreState<M>& state)
         stream = celeritas::device().stream(state.stream_id()).get();
     }
 
-    ScopedProfiling profile_this{"step"};
     if (M == MemSpace::host || options_.sync)
     {
         // Execute all actions and record the time elapsed

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -17,7 +17,6 @@
 #include "corecel/cont/EnumArray.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/sys/Device.hh"
-#include "corecel/sys/ScopedMem.hh"
 #include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/Stopwatch.hh"
 #include "corecel/sys/Stream.hh"
@@ -81,9 +80,6 @@ ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
 template<MemSpace M>
 void ActionSequence::begin_run(CoreParams const& params, CoreState<M>& state)
 {
-    // Execute beginning-of-run action
-    ScopedMem record_mem("ActionSequence.begin_run");
-
     for (auto const& sp_action : begin_run_)
     {
         ScopedProfiling profile_this{sp_action->label()};

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -104,7 +104,7 @@ void ActionSequence::execute(CoreParams const& params, CoreState<M>& state)
         stream = celeritas::device().stream(state.stream_id()).get();
     }
 
-    if (M == MemSpace::host || options_.sync)
+    if ((M == MemSpace::host || options_.sync) && !state.warming_up())
     {
         // Execute all actions and record the time elapsed
         for (auto i : range(actions_.size()))

--- a/src/celeritas/track/ExtendFromPrimariesAction.cc
+++ b/src/celeritas/track/ExtendFromPrimariesAction.cc
@@ -46,7 +46,7 @@ void ExtendFromPrimariesAction::execute_impl(CoreParams const& params,
                                              CoreState<M>& state) const
 {
     auto primary_range = state.primary_range();
-    if (primary_range.empty())
+    if (primary_range.empty() && !state.warming_up())
         return;
 
     auto primaries = state.primary_storage()[primary_range];

--- a/src/celeritas/track/ExtendFromPrimariesAction.cu
+++ b/src/celeritas/track/ExtendFromPrimariesAction.cu
@@ -27,7 +27,10 @@ void ExtendFromPrimariesAction::process_primaries(
     detail::ProcessPrimariesExecutor execute_thread{
         state.ptr(), primaries, state.counters()};
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(*this);
-    launch_kernel(primaries.size(), state.stream_id(), execute_thread);
+    if (!primaries.empty())
+    {
+        launch_kernel(primaries.size(), state.stream_id(), execute_thread);
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/InitializeTracksAction.cc
+++ b/src/celeritas/track/InitializeTracksAction.cc
@@ -58,7 +58,7 @@ void InitializeTracksAction::execute_impl(CoreParams const& core_params,
     // empty slots in the track vector and the number of track initializers
     size_type num_new_tracks
         = std::min(counters.num_vacancies, counters.num_initializers);
-    if (num_new_tracks > 0)
+    if (num_new_tracks > 0 || core_state.warming_up())
     {
         // Launch a kernel to initialize tracks
         this->execute_impl(core_params, core_state, num_new_tracks);

--- a/src/celeritas/track/InitializeTracksAction.cu
+++ b/src/celeritas/track/InitializeTracksAction.cu
@@ -28,7 +28,10 @@ void InitializeTracksAction::execute_impl(CoreParams const& params,
                                               num_new_tracks,
                                               state.counters()};
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(*this);
-    launch_kernel(num_new_tracks, state.stream_id(), execute_thread);
+    if (num_new_tracks > 0)
+    {
+        launch_kernel(num_new_tracks, state.stream_id(), execute_thread);
+    }
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Our AMD run times for the very small performance benchmark problems have been terrible because there seems to be a 0.7s overhead for every call to `hipFuncGetAttributes`, as well as additional overhead that seems to come from the first kernel calls in the Thrust library. This adds a new option to `celer-sim` (on by default when building with device) that runs an initial stepping loop with zero active tracks.

Here's the beginning of TestEM3 with ORANGE in the CUDA systems profiler, with the first step doing no actual work (and not counting as part of the celeritas "total run time" counter):
<img width="1227" alt="cuda-systems-testem3" src="https://github.com/celeritas-project/celeritas/assets/741229/5d302891-ae7e-4379-9bf8-82be458d3ab1">

Besides initializing the static KernelParamsCalculator objects, it also hides the mysterious lag that in this case is showing up as part of `geo-boundary`.

Here's the visualization of Crusher running TestEM3 for 32 steps: the warmup "step" is highlighted in dark blue and takes up almost the entire simulation. Previously this overhead (due to `hipFuncGetAttributes`) was misattributed to the first step.
<img width="1260" alt="crusher-warmup" src="https://github.com/celeritas-project/celeritas/assets/741229/d80caa5a-0bbf-49da-a459-9f56e238f405">

In the shorter celeritas regression runs, this ends up giving a nontrivial performance boost: we're now up to 300× GPU:CPU core equivalence for some problems.
![speedup](https://github.com/celeritas-project/celeritas/assets/741229/6b5ffe6d-1978-4da4-8bd9-7db04df01c97)