### PR TITLE
Improve Quantity for field conversions and non-real_type use cases

### DIFF
--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -133,7 +133,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
     }
     else if (field_type == "uniform")
     {
-        auto field = GlobalSetup::Instance()->GetMagFieldZTesla();
+        auto field = GlobalSetup::Instance()->GetMagFieldTesla();
         if (norm(field) > 0)
         {
             CELER_LOG_LOCAL(info)

--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -21,6 +21,7 @@
 #include <G4VPhysicalVolume.hh>
 
 #include "corecel/io/Logger.hh"
+#include "celeritas/Quantities.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
 #include "celeritas/field/RZMapFieldParams.hh"
 #include "celeritas/field/UniformFieldData.hh"
@@ -137,7 +138,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
         if (norm(field) > 0)
         {
             CELER_LOG_LOCAL(info)
-                << "Using a uniform field (0, 0, " << field[2] << ") in tesla";
+                << "Using a uniform field (0, 0, " << field[2] << ") [tesla]";
             mag_field_ = std::make_shared<G4UniformMagField>(
                 convert_to_geant(field, CLHEP::tesla));
         }
@@ -145,7 +146,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
         // Convert field units from tesla to native celeritas units
         for (real_type& v : field)
         {
-            v *= units::tesla;
+            v = native_value_from(units::FieldTesla{v});
         }
 
         UniformFieldParams input;

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -55,7 +55,7 @@ class GlobalSetup
     int GetStepDiagnosticBins() const { return input_.step_diagnostic_bins; }
     std::string const& GetFieldType() const { return input_.field_type; }
     std::string const& GetFieldFile() const { return input_.field_file; }
-    Real3 GetMagFieldZTesla() const { return input_.field; }
+    Real3 GetMagFieldTesla() const { return input_.field; }
     FieldDriverOptions const& GetFieldOptions() const
     {
         return input_.field_options;

--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -67,7 +67,7 @@ struct RunInput
     // Field setup options
     std::string field_type{"uniform"};
     std::string field_file;
-    Real3 field{no_field()};
+    Real3 field{no_field()};  //!< Field vector [T]
     FieldDriverOptions field_options;
 
     // Sensitive detector hit collection

--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -299,9 +299,9 @@ void Runner::build_core_params(RunnerInput const& inp,
         field_params.options = inp.field_options;
 
         // Interpret input in units of Tesla
-        for (real_type& f : field_params.field)
+        for (real_type& v : field_params.field)
         {
-            f *= units::tesla;
+            v = native_value_from(units::FieldTesla{v});
         }
 
         auto along_step = AlongStepUniformMscAction::from_params(

--- a/src/accel/RZMapMagneticField.hh
+++ b/src/accel/RZMapMagneticField.hh
@@ -13,6 +13,7 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/math/ArrayOperators.hh"
+#include "celeritas/Quantities.hh"
 #include "celeritas/ext/Convert.geant.hh"
 #include "celeritas/field/RZMapField.hh"
 #include "celeritas/field/RZMapFieldParams.hh"
@@ -61,11 +62,13 @@ RZMapMagneticField::RZMapMagneticField(SPConstFieldParams params)
 void RZMapMagneticField::GetFieldValue(double const pos[3], double* field) const
 {
     // Calculate the magnetic field value in the native Celeritas unit system
-    Real3 result = calc_field_(convert_from_geant(pos, CLHEP::cm));
+    Real3 result
+        = calc_field_(convert_from_geant(pos, CLHEP::cm) * units::centimeter);
     for (auto i = 0; i < 3; ++i)
     {
         // Return values of the field vector in CLHEP::tesla for Geant4
-        field[i] = convert_to_geant(result[i], CLHEP::tesla);
+        auto ft = native_value_to<units::FieldTesla>(result[i]);
+        field[i] = convert_to_geant(ft.value(), CLHEP::tesla);
     }
 }
 

--- a/src/accel/RZMapMagneticField.hh
+++ b/src/accel/RZMapMagneticField.hh
@@ -38,10 +38,7 @@ class RZMapMagneticField : public G4MagneticField
     inline void GetFieldValue(double const point[3], double* field) const;
 
     //// COMMON PROPERTIES ////
-    static constexpr double from_celer_tesla()
-    {
-        return CLHEP::tesla / celeritas::units::tesla;
-    }
+    static constexpr double from_celer_tesla() { return CLHEP::tesla; }
     static constexpr real_type to_celer_cm()
     {
         return celeritas::units::centimeter / CLHEP::cm;

--- a/src/accel/RZMapMagneticField.hh
+++ b/src/accel/RZMapMagneticField.hh
@@ -13,6 +13,7 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/math/ArrayOperators.hh"
+#include "celeritas/ext/Convert.geant.hh"
 #include "celeritas/field/RZMapField.hh"
 #include "celeritas/field/RZMapFieldParams.hh"
 
@@ -37,13 +38,6 @@ class RZMapMagneticField : public G4MagneticField
     // Calculate values of the magnetic field vector
     inline void GetFieldValue(double const point[3], double* field) const;
 
-    //// COMMON PROPERTIES ////
-    static constexpr double from_celer_tesla() { return CLHEP::tesla; }
-    static constexpr real_type to_celer_cm()
-    {
-        return celeritas::units::centimeter / CLHEP::cm;
-    }
-
   private:
     SPConstFieldParams params_;
     RZMapField calc_field_;
@@ -62,18 +56,16 @@ RZMapMagneticField::RZMapMagneticField(SPConstFieldParams params)
 
 //---------------------------------------------------------------------------//
 /*!
- * Evaluate values of the magnetic field vector at the given position
- * using the volume-based celetias::RZMapField.
+ * Calculate the magnetic field vector at the given position.
  */
 void RZMapMagneticField::GetFieldValue(double const pos[3], double* field) const
 {
     // Calculate the magnetic field value in the native Celeritas unit system
-    Real3 result
-        = calc_field_(Real3{pos[0], pos[1], pos[2]} * this->to_celer_cm());
+    Real3 result = calc_field_(convert_from_geant(pos, CLHEP::cm));
     for (auto i = 0; i < 3; ++i)
     {
         // Return values of the field vector in CLHEP::tesla for Geant4
-        field[i] = result[i] * this->from_celer_tesla();
+        field[i] = convert_to_geant(result[i], CLHEP::tesla);
     }
 }
 

--- a/src/celeritas/Quantities.hh
+++ b/src/celeritas/Quantities.hh
@@ -95,6 +95,13 @@ struct Millibarn
     }
 };
 
+//! Unit for field
+struct Tesla
+{
+    //! Conversion factor from the unit to CGS
+    static CELER_CONSTEXPR_FUNCTION real_type value() { return units::tesla; }
+};
+
 //---------------------------------------------------------------------------//
 //!@{
 //! \name Derivative units
@@ -120,6 +127,7 @@ using MevMomentum = Quantity<UnitDivide<Mev, CLight>>;
 using MevMomentumSq = Quantity<UnitDivide<UnitProduct<Mev, Mev>, CLightSq>>;
 using LightSpeed = Quantity<CLight>;
 using AmuMass = Quantity<Amu>;
+using FieldTesla = Quantity<Tesla>;
 //!@}
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/Convert.geant.hh
+++ b/src/celeritas/ext/Convert.geant.hh
@@ -29,6 +29,15 @@ constexpr inline T convert_from_geant(T const& val, T units)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Convert a value from Geant4 with CLHEP units.
+ */
+constexpr inline double convert_from_geant(double val, double units)
+{
+    return val / units;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Convert a 3-vector from Geant4/CLHEP to Celeritas native units.
  */
 inline Real3 convert_from_geant(G4ThreeVector const& vec, double units)
@@ -38,12 +47,32 @@ inline Real3 convert_from_geant(G4ThreeVector const& vec, double units)
 
 //---------------------------------------------------------------------------//
 /*!
- * Convert a native Celeritas quantity to a Geant4 value.
+ * Convert a C array from Geant4/CLHEP to Celeritas native units.
+ */
+inline Real3 convert_from_geant(double const vec[3], double units)
+{
+    return {static_cast<real_type>(vec[0] / units),
+            static_cast<real_type>(vec[1] / units),
+            static_cast<real_type>(vec[2] / units)};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a native Celeritas quantity to a Geant4 value with CLHEP units.
  */
 template<class T>
 constexpr inline T convert_to_geant(T const& val, T units)
 {
     return val * units;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a native Celeritas quantity to a Geant4 value.
+ */
+constexpr inline double convert_to_geant(real_type val, double units)
+{
+    return double{val} * units;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/RZMapFieldInput.hh
+++ b/src/celeritas/field/RZMapFieldInput.hh
@@ -24,7 +24,8 @@ namespace celeritas
  *
  * The magnetic field is discretized at nodes on an R-Z grid, and each point
  * the field vector is approximated by a 2-D vector in R-Z. The input units of
- * this filed are in tesla.
+ * this field are in *NATIVE UNITS* (gauss). An optional \c _units field in the
+ * input can specify whether the input is in tesla or native units.
  *
  * The field values are all indexed with R having stride 1: [Z][R]
  */
@@ -36,8 +37,8 @@ struct RZMapFieldInput
     double min_r{};  //!< Lower r coordinate [cm]
     double max_z{};  //!< Last z coordinate [cm]
     double max_r{};  //!< Last r coordinate [cm]
-    std::vector<double> field_z;  //!< Flattened Z field component [tesla]
-    std::vector<double> field_r;  //!< Flattened R field component [tesla]
+    std::vector<double> field_z;  //!< Flattened Z field component [gauss]
+    std::vector<double> field_r;  //!< Flattened R field component [gauss]
 
     FieldDriverOptions driver_options;
 

--- a/src/celeritas/field/RZMapFieldInputIO.json.cc
+++ b/src/celeritas/field/RZMapFieldInputIO.json.cc
@@ -12,6 +12,9 @@
 #include <string>
 #include <vector>
 
+#include "corecel/cont/Range.hh"
+#include "celeritas/Quantities.hh"
+
 #include "FieldDriverOptionsIO.json.hh"
 #include "RZMapFieldInput.hh"
 
@@ -36,6 +39,38 @@ void from_json(nlohmann::json const& j, RZMapFieldInput& inp)
     {
         RZFI_LOAD(driver_options);
     }
+
+    // Convert from tesla if explicitly specified *OR* if no _units given
+    bool convert_from_tesla{true};
+    if (auto iter = j.find("_units"); iter != j.end())
+    {
+        auto units = iter->get<std::string>();
+        if (units == "tesla" || units == "T")
+        {
+            convert_from_tesla = true;
+        }
+        else if (units == "native" || units == "gauss")
+        {
+            convert_from_tesla = false;
+        }
+        else
+        {
+            CELER_VALIDATE(false,
+                           << "unrecognized value '" << units
+                           << "' for \"_units\" field");
+        }
+    }
+    if (convert_from_tesla)
+    {
+        // Convert units from JSON tesla to input native
+        for (auto* f : {&inp.field_z, &inp.field_r})
+        {
+            for (real_type& v : *f)
+            {
+                v = native_value_from(units::FieldTesla{v});
+            }
+        }
+    }
 #undef RZFI_LOAD
 }
 
@@ -47,6 +82,7 @@ void to_json(nlohmann::json& j, RZMapFieldInput const& inp)
 {
 #define RZFI_KEY_VALUE(NAME) {#NAME, inp.NAME}
     j = {
+        {"_units", "gauss"},
         RZFI_KEY_VALUE(num_grid_z),
         RZFI_KEY_VALUE(num_grid_r),
         RZFI_KEY_VALUE(min_z),

--- a/src/celeritas/field/RZMapFieldParams.cc
+++ b/src/celeritas/field/RZMapFieldParams.cc
@@ -64,10 +64,10 @@ RZMapFieldParams::RZMapFieldParams(RZMapFieldInput const& inp)
         fieldmap.reserve(inp.field_z.size());
         for (auto i : range(inp.field_z.size()))
         {
-            // Save field vector, converting from Tesla to native units
+            // Save field vector
             FieldMapElement el;
-            el.value_z = inp.field_z[i] * units::tesla;
-            el.value_r = inp.field_r[i] * units::tesla;
+            el.value_z = inp.field_z[i];
+            el.value_r = inp.field_r[i];
             fieldmap.push_back(el);
         }
 

--- a/src/corecel/math/NumericLimits.hh
+++ b/src/corecel/math/NumericLimits.hh
@@ -31,6 +31,8 @@ template<>
 struct numeric_limits<float>
 {
     SCCEF_ float epsilon() { return FLT_EPSILON; }
+    SCCEF_ float lowest() { return -FLT_MAX; }
+    SCCEF_ float min() { return FLT_MIN; }
     SCCEF_ float max() { return FLT_MAX; }
     SCCEF_ float quiet_NaN() { return __builtin_nanf(""); }
     SCCEF_ float infinity() { return __builtin_huge_valf(); }
@@ -40,26 +42,58 @@ template<>
 struct numeric_limits<double>
 {
     SCCEF_ double epsilon() { return DBL_EPSILON; }
+    SCCEF_ double lowest() { return -DBL_MAX; }
+    SCCEF_ double min() { return DBL_MIN; }
     SCCEF_ double max() { return DBL_MAX; }
     SCCEF_ double quiet_NaN() { return __builtin_nan(""); }
     SCCEF_ double infinity() { return __builtin_huge_val(); }
 };
 
 template<>
+struct numeric_limits<int>
+{
+    SCCEF_ int lowest() { return INT_MIN; }
+    SCCEF_ int min() { return INT_MIN; }
+    SCCEF_ int max() { return INT_MAX; }
+};
+
+template<>
+struct numeric_limits<long>
+{
+    SCCEF_ long lowest() { return LONG_MIN; }
+    SCCEF_ long min() { return LONG_MIN; }
+    SCCEF_ long max() { return LONG_MAX; }
+};
+
+template<>
+struct numeric_limits<long long>
+{
+    SCCEF_ long long lowest() { return LLONG_MIN; }
+    SCCEF_ long long min() { return LLONG_MIN; }
+    SCCEF_ long long max() { return LLONG_MAX; }
+};
+
+template<>
 struct numeric_limits<unsigned int>
 {
+    SCCEF_ unsigned int lowest() { return 0; }
+    SCCEF_ unsigned int min() { return 0; }
     SCCEF_ unsigned int max() { return UINT_MAX; }
 };
 
 template<>
 struct numeric_limits<unsigned long>
 {
+    SCCEF_ unsigned long lowest() { return 0; }
+    SCCEF_ unsigned long min() { return 0; }
     SCCEF_ unsigned long max() { return ULONG_MAX; }
 };
 
 template<>
 struct numeric_limits<unsigned long long>
 {
+    SCCEF_ unsigned long long lowest() { return 0; }
+    SCCEF_ unsigned long long min() { return 0; }
     SCCEF_ unsigned long long max() { return ULLONG_MAX; }
 };
 

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -19,12 +19,38 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
-//! Implementation class for creating a nonnumeric value comparable to
-//! Quantity.
+//! Helper tag for special unitless values
+enum class QConstant
+{
+    neg_max = -1,
+    zero = 0,
+    max = 1
+};
+
+//! Convert unitless values into a particular type
 template<class T>
+CELER_CONSTEXPR_FUNCTION T get_constant(QConstant qc)
+{
+    if constexpr (std::is_floating_point_v<T>)
+    {
+        // Return +/- infinity
+        return qc == QConstant::neg_max ? -numeric_limits<T>::infinity()
+               : qc == QConstant::max   ? numeric_limits<T>::infinity()
+                                        : 0;
+    }
+    else
+    {
+        // Return lowest and highest values
+        return qc == QConstant::neg_max ? numeric_limits<T>::lowest()
+               : qc == QConstant::max   ? numeric_limits<T>::max()
+                                        : 0;
+    }
+}
+
+//! Tag class for creating a nonnumeric value comparable to Quantity.
+template<QConstant QC>
 struct UnitlessQuantity
 {
-    T value_;  //!< Special nonnumeric value
 };
 
 //! Helper class for getting attributes about a member function
@@ -114,7 +140,6 @@ class Quantity
     //! \name Type aliases
     using value_type = ValueT;
     using unit_type = UnitT;
-    using Unitless = detail::UnitlessQuantity<ValueT>;
     //!@}
 
   public:
@@ -128,7 +153,9 @@ class Quantity
     }
 
     //! Construct implicitly from a unitless quantity
-    CELER_CONSTEXPR_FUNCTION Quantity(Unitless uq) noexcept : value_(uq.value_)
+    template<detail::QConstant QC>
+    CELER_CONSTEXPR_FUNCTION Quantity(detail::UnitlessQuantity<QC>) noexcept
+        : value_(detail::get_constant<ValueT>(QC))
     {
     }
 
@@ -151,33 +178,34 @@ class Quantity
 
 //---------------------------------------------------------------------------//
 //! \cond
-#define CELER_DEFINE_QUANTITY_CMP(TOKEN)                                      \
-    template<class U, class T, class T2>                                      \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                             \
-        Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept                     \
-    {                                                                         \
-        return lhs.value() TOKEN rhs.value();                                 \
-    }                                                                         \
-    template<class U, class T>                                                \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                             \
-        Quantity<U, T> lhs, detail::UnitlessQuantity<T> rhs) noexcept         \
-    {                                                                         \
-        return lhs.value() TOKEN rhs.value_;                                  \
-    }                                                                         \
-    template<class U, class T>                                                \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                             \
-        detail::UnitlessQuantity<T> lhs, Quantity<U, T> rhs) noexcept         \
-    {                                                                         \
-        return lhs.value_ TOKEN rhs.value();                                  \
-    }                                                                         \
-    namespace detail                                                          \
-    {                                                                         \
-    template<class T>                                                         \
-    CELER_CONSTEXPR_FUNCTION bool                                             \
-    operator TOKEN(UnitlessQuantity<T> lhs, UnitlessQuantity<T> rhs) noexcept \
-    {                                                                         \
-        return lhs.value_ TOKEN rhs.value_;                                   \
-    }                                                                         \
+#define CELER_DEFINE_QUANTITY_CMP(TOKEN)                           \
+    template<class U, class T, class T2>                           \
+    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                  \
+        Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept          \
+    {                                                              \
+        return lhs.value() TOKEN rhs.value();                      \
+    }                                                              \
+    template<class U, class T, detail::QConstant QC>               \
+    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                  \
+        Quantity<U, T> lhs, detail::UnitlessQuantity<QC>) noexcept \
+    {                                                              \
+        return lhs.value() TOKEN detail::get_constant<T>(QC);      \
+    }                                                              \
+    template<class U, class T, detail::QConstant QC>               \
+    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                  \
+        detail::UnitlessQuantity<QC>, Quantity<U, T> rhs) noexcept \
+    {                                                              \
+        return detail::get_constant<T>(QC) TOKEN rhs.value();      \
+    }                                                              \
+    namespace detail                                               \
+    {                                                              \
+    template<detail::QConstant C1, detail::QConstant C2>           \
+    CELER_CONSTEXPR_FUNCTION bool                                  \
+    operator TOKEN(detail::UnitlessQuantity<C1>,                   \
+                   detail::UnitlessQuantity<C2>) noexcept          \
+    {                                                              \
+        return static_cast<int>(C1) TOKEN static_cast<int>(C2);    \
+    }                                                              \
     }
 
 //!@{
@@ -267,30 +295,27 @@ struct UnitProduct
 /*!
  * Get a zero quantity (analogous to nullptr).
  */
-CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type>
-zero_quantity() noexcept
+CELER_CONSTEXPR_FUNCTION auto zero_quantity() noexcept
 {
-    return {0};
+    return detail::UnitlessQuantity<detail::QConstant::zero>{};
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Get a quantitity greater than any other numeric quantity.
  */
-CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type>
-max_quantity() noexcept
+CELER_CONSTEXPR_FUNCTION auto max_quantity() noexcept
 {
-    return {numeric_limits<real_type>::infinity()};
+    return detail::UnitlessQuantity<detail::QConstant::max>{};
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Get a quantitity less than any other numeric quantity.
  */
-CELER_CONSTEXPR_FUNCTION detail::UnitlessQuantity<real_type>
-neg_max_quantity() noexcept
+CELER_CONSTEXPR_FUNCTION auto neg_max_quantity() noexcept
 {
-    return {-numeric_limits<real_type>::infinity()};
+    return detail::UnitlessQuantity<detail::QConstant::neg_max>{};
 }
 
 //---------------------------------------------------------------------------//

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -596,6 +596,7 @@ if(CELERITAS_USE_Geant4)
   celeritas_add_test(accel/ExceptionConverter.test.cc)
   celeritas_add_test(accel/HepMC3PrimaryGenerator.test.cc
     ENVIRONMENT "${_geant4_test_env}")
+  celeritas_add_test(accel/RZMapMagneticField.test.cc)
   celeritas_add_test(accel/detail/HitManager.test.cc
     ENVIRONMENT "${_geant4_test_env}")
   celeritas_add_test(accel/detail/HitProcessor.test.cc

--- a/test/accel/RZMapMagneticField.test.cc
+++ b/test/accel/RZMapMagneticField.test.cc
@@ -31,7 +31,7 @@ class RZMapMagneticFieldTest : public ::celeritas::test::Test
 TEST_F(RZMapMagneticFieldTest, uniform_z)
 {
     std::shared_ptr<RZMapFieldParams> params = [] {
-        // NOTE: RZ field map input is in tesla
+        // NOTE: RZ field map input is in native units
         RZMapFieldInput inp;
         inp.num_grid_z = 2;
         inp.num_grid_r = 2;

--- a/test/accel/RZMapMagneticField.test.cc
+++ b/test/accel/RZMapMagneticField.test.cc
@@ -48,13 +48,13 @@ TEST_F(RZMapMagneticFieldTest, uniform_z)
     G4ThreeVector g4point;
     G4ThreeVector g4field_value{0, 0, 0};
 
-    // Calculate inside the grid
+    // Calculate inside the grid, comparing result *IN TESLA*
     g4point = convert_to_geant(Real3{5, 1, 2}, CLHEP::cm);
     g4mag_field.GetFieldValue(&g4point[0], &g4field_value[0]);
-    EXPECT_VEC_SOFT_EQ((Real3{0, 0, 1 * units::tesla}),
+    EXPECT_VEC_SOFT_EQ((Real3{0, 0, 1}),
                        convert_from_geant(g4field_value, CLHEP::tesla));
 
-    // Calculate outside the grid
+    // Calculate outside the grid, comparing result *IN TESLA*
     g4point = convert_to_geant(Real3{12, 0, 0}, CLHEP::cm);
     g4mag_field.GetFieldValue(&g4point[0], &g4field_value[0]);
     EXPECT_VEC_SOFT_EQ((Real3{0, 0, 0}),

--- a/test/accel/RZMapMagneticField.test.cc
+++ b/test/accel/RZMapMagneticField.test.cc
@@ -31,6 +31,7 @@ class RZMapMagneticFieldTest : public ::celeritas::test::Test
 TEST_F(RZMapMagneticFieldTest, uniform_z)
 {
     std::shared_ptr<RZMapFieldParams> params = [] {
+        // NOTE: RZ field map input is in tesla
         RZMapFieldInput inp;
         inp.num_grid_z = 2;
         inp.num_grid_r = 2;
@@ -38,7 +39,7 @@ TEST_F(RZMapMagneticFieldTest, uniform_z)
         inp.min_r = 0;
         inp.max_z = 10.0 * units::centimeter;
         inp.max_r = 7.0 * units::centimeter;
-        inp.field_z.assign(4, 1.0);
+        inp.field_z.assign(4, 1.0 * units::tesla);
         inp.field_r.assign(4, 0.0);
         return std::make_shared<RZMapFieldParams>(std::move(inp));
     }();

--- a/test/accel/RZMapMagneticField.test.cc
+++ b/test/accel/RZMapMagneticField.test.cc
@@ -1,0 +1,66 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/RZMapMagneticField.test.cc
+//---------------------------------------------------------------------------//
+#include "accel/RZMapMagneticField.hh"
+
+#include <CLHEP/Units/SystemOfUnits.h>
+
+#include "celeritas/ext/Convert.geant.hh"
+#include "celeritas/field/RZMapField.hh"
+#include "celeritas/field/RZMapFieldInput.hh"
+#include "celeritas/field/RZMapFieldParams.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+class RZMapMagneticFieldTest : public ::celeritas::test::Test
+{
+  protected:
+    void SetUp() override {}
+};
+
+TEST_F(RZMapMagneticFieldTest, uniform_z)
+{
+    std::shared_ptr<RZMapFieldParams> params = [] {
+        RZMapFieldInput inp;
+        inp.num_grid_z = 2;
+        inp.num_grid_r = 2;
+        inp.min_z = -10.0 * units::centimeter;
+        inp.min_r = 0;
+        inp.max_z = 10.0 * units::centimeter;
+        inp.max_r = 7.0 * units::centimeter;
+        inp.field_z.assign(4, 1.0);
+        inp.field_r.assign(4, 0.0);
+        return std::make_shared<RZMapFieldParams>(std::move(inp));
+    }();
+
+    RZMapMagneticField g4mag_field{params};
+
+    G4ThreeVector g4point;
+    G4ThreeVector g4field_value{0, 0, 0};
+
+    // Calculate inside the grid
+    g4point = convert_to_geant(Real3{5, 1, 2}, CLHEP::cm);
+    g4mag_field.GetFieldValue(&g4point[0], &g4field_value[0]);
+    EXPECT_VEC_SOFT_EQ((Real3{0, 0, 1 * units::tesla}),
+                       convert_from_geant(g4field_value, CLHEP::tesla));
+
+    // Calculate outside the grid
+    g4point = convert_to_geant(Real3{12, 0, 0}, CLHEP::cm);
+    g4mag_field.GetFieldValue(&g4point[0], &g4field_value[0]);
+    EXPECT_VEC_SOFT_EQ((Real3{0, 0, 0}),
+                       convert_from_geant(g4field_value, CLHEP::tesla));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/Constants.test.cc
+++ b/test/celeritas/Constants.test.cc
@@ -15,7 +15,8 @@
 #include "celeritas_test.hh"
 
 #if CELERITAS_USE_GEANT4
-#    include "CLHEP/Units/PhysicalConstants.h"
+#    include <CLHEP/Units/PhysicalConstants.h>
+#    include <CLHEP/Units/SystemOfUnits.h>
 #endif
 
 namespace celeritas

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -93,6 +93,11 @@ TEST(QuantityTest, zeros)
     // Construct from a "zero" sentinel type
     zero_turn = zero_quantity();
     EXPECT_EQ(0, value_as<Revolution>(zero_turn));
+
+    // Check int/untyped commparisons
+    using Dozen = Quantity<DozenUnit, int>;
+    EXPECT_GT(Dozen{1}, zero_quantity());
+    EXPECT_LT(Dozen{1}, max_quantity());
 }
 
 TEST(QuantityTest, mixed_precision)


### PR DESCRIPTION
This defines a `FieldTesla` quantity and uses it to convert field units because we keep confusing ourselves. I've also added support to Quantity so that it works with non-`real_type` values since that's related.

The RZ field map input now takes everything in *native* units, but the JSON I/O supports a field for specifying that the inputs are in tesla. For backward compatibility, if this `_units` field is empty, it is assumed that the data is in T (@whokion this should let it work with the CMS field profiles you already have).