### PR TITLE
Fix linking to CUDA toolkit when using VecGeom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,9 +353,7 @@ add_library(celeritas_device_toolkit INTERFACE)
 add_library(Celeritas::DeviceToolkit ALIAS celeritas_device_toolkit)
 
 if(CELERITAS_USE_CUDA)
-  target_include_directories(celeritas_device_toolkit
-    SYSTEM INTERFACE $<$<COMPILE_LANGUAGE:C,CXX>:${CUDAToolkit_INCLUDE_DIRS}>
-  )
+  target_link_libraries(celeritas_device_toolkit INTERFACE CUDA::toolkit)
 elseif(CELERITAS_USE_HIP)
   if(CMAKE_HIP_COMPILER_ROCM_ROOT)
     # Undocumented CMake variable

--- a/cmake/CeleritasLibrary.cmake
+++ b/cmake/CeleritasLibrary.cmake
@@ -364,7 +364,7 @@ function(celeritas_rdc_add_library target)
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
     EXPORT_PROPERTIES "CELERITAS_CUDA_LIBRARY_TYPE;CELERITAS_CUDA_FINAL_LIBRARY;CELERITAS_CUDA_MIDDLE_LIBRARY;CELERITAS_CUDA_STATIC_LIBRARY"
   )
-  target_link_libraries(${target}_final PUBLIC ${target})
+  target_link_libraries(${target}_final PUBLIC ${target} PRIVATE CUDA::toolkit)
   target_link_options(${target}_final
     PRIVATE $<DEVICE_LINK:$<TARGET_FILE:${target}${_staticsuf}>>
   )


### PR DESCRIPTION
Update how the main and final libraries are linked to cudart. Previously, the cuda rpath wasn't embedded in the main library unless a dependency required it. If the user environment wasn't configured to find cudart (ld.so.conf, ld_library_path, standard search path) and the application linking to the main/final library doesn't specify a rpath, we end up with an error. The final library needs to be explicitly linked to cudart again because Celeritas::DeviceToolkit is a private dependency of the main library.
```shell
# old
esseivaj@login13:/global/cfs/cdirs/atlas/esseivaj/devel/celeritas> readelf -d build-ndebug/lib64/libcorecel_final.so | grep RPATH
 0x000000000000000f (RPATH)              Library rpath: [/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/build-ndebug/lib64::]

# new
esseivaj@login13:/global/cfs/cdirs/atlas/esseivaj/devel/celeritas> readelf -d build-ndebug/lib64/libcorecel_final.so | grep RPATH
 0x000000000000000f (RPATH)              Library rpath: [/pscratch/sd/e/esseivaj/spack/var/spack/environments/celeritas/.spack-env/view/lib64:/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/build-ndebug/lib64::]
```