### PR TITLE
Unify names for celer-sim and celer-g4 input

### DIFF
--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -32,8 +32,6 @@ enum class PhysicsListSelection
 //---------------------------------------------------------------------------//
 /*!
  * Input for a single run.
- *
- * \todo Unify names with celer-sim and SetupOptions.
  */
 struct RunInput
 {
@@ -41,6 +39,10 @@ struct RunInput
 
     static constexpr Real3 no_field() { return Real3{0, 0, 0}; }
     static constexpr size_type unspecified{static_cast<size_type>(-1)};
+
+    // Global environment
+    size_type cuda_stack_size{};
+    size_type cuda_heap_size{};
 
     // Problem definition
     std::string geometry_file;  //!< Path to GDML file
@@ -55,8 +57,6 @@ struct RunInput
     size_type max_steps{unspecified};
     size_type initializer_capacity{};
     real_type secondary_stack_factor{};
-    size_type cuda_stack_size{};
-    size_type cuda_heap_size{};
     bool sync{false};
     bool default_stream{false};  //!< Launch all kernels on the default stream
 

--- a/app/celer-sim/RootOutput.cc
+++ b/app/celer-sim/RootOutput.cc
@@ -37,11 +37,11 @@ void write_to_root(RunnerInput const& cargs, RootFileManager* root_manager)
 
 #if CELERITAS_USE_JSON
     std::string str_input(nlohmann::json(cargs).dump());
-    std::string str_phys(nlohmann::json(cargs.geant_options).dump());
+    std::string str_phys(nlohmann::json(cargs.physics_options).dump());
 
     auto tree_input = root_manager->make_tree("input", "input");
     tree_input->Branch("input", &str_input);
-    tree_input->Branch("geant_options", &str_phys);
+    tree_input->Branch("physics_options", &str_phys);
     tree_input->Fill();  // Writing happens at destruction
 #else
     CELER_NOT_CONFIGURED("nlohmann_json");

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -46,20 +46,20 @@ struct RunnerInput
     Environment environ;  //!< Supplement existing env variables
 
     // Problem definition
-    std::string geometry_filename;  //!< Path to GDML file
-    std::string physics_filename;  //!< Path to ROOT exported Geant4 data
-    std::string event_filename;  //!< Path to input event data
+    std::string geometry_file;  //!< Path to GDML file
+    std::string physics_file;  //!< Path to ROOT exported Geant4 data
+    std::string event_file;  //!< Path to input event data
 
     // Optional setup options for generating primaries programmatically
-    PrimaryGeneratorOptions primary_gen_options;
+    PrimaryGeneratorOptions primary_options;
 
     // Diagnostics and output
-    std::string mctruth_filename;  //!< Path to ROOT MC truth event data
+    std::string mctruth_file;  //!< Path to ROOT MC truth event data
     SimpleRootFilterInput mctruth_filter;
     std::vector<Label> simple_calo;
     bool action_diagnostic{};
     bool step_diagnostic{};
-    size_type step_diagnostic_maxsteps{};
+    int step_diagnostic_bins{1000};
     bool write_track_counts{true};  //!< Output track counts for each step
 
     // Control
@@ -76,7 +76,7 @@ struct RunnerInput
     bool warm_up{CELER_USE_DEVICE};  //!< Run a nullop step first
 
     // Magnetic field vector [* 1/Tesla] and associated field options
-    Real3 mag_field{no_field()};
+    Real3 field{no_field()};
     FieldDriverOptions field_options;
 
     // Optional fixed-size step limiter for charged particles
@@ -90,18 +90,18 @@ struct RunnerInput
     TrackOrder track_order{TrackOrder::unsorted};
 
     // Optional setup options if loading directly from Geant4
-    GeantPhysicsOptions geant_options;
+    GeantPhysicsOptions physics_options;
 
     //! Whether the run arguments are valid
     explicit operator bool() const
     {
-        return !geometry_filename.empty()
-               && (primary_gen_options || !event_filename.empty())
+        return !geometry_file.empty()
+               && (primary_options || !event_file.empty())
                && num_track_slots > 0 && max_steps > 0
                && initializer_capacity > 0 && max_events > 0
                && secondary_stack_factor > 0
-               && (step_diagnostic_maxsteps > 0 || !step_diagnostic)
-               && (mag_field == no_field() || field_options);
+               && (step_diagnostic_bins > 0 || !step_diagnostic)
+               && (field == no_field() || field_options);
     }
 };
 

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -74,20 +74,31 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_OPTION(cuda_stack_size);
     LDIO_LOAD_OPTION(environ);
 
-    LDIO_LOAD_DEPRECATED(hepmc3_filename, event_filename);
+    LDIO_LOAD_DEPRECATED(hepmc3_filename, event_file);
+    LDIO_LOAD_DEPRECATED(event_filename, event_file);
+    LDIO_LOAD_DEPRECATED(geometry_filename, geometry_file);
+    LDIO_LOAD_DEPRECATED(physics_filename, physics_file);
 
-    LDIO_LOAD_REQUIRED(geometry_filename);
-    LDIO_LOAD_OPTION(physics_filename);
-    LDIO_LOAD_OPTION(event_filename);
+    if (v.geometry_file.empty())
+    {
+        LDIO_LOAD_REQUIRED(geometry_file);
+    }
+    LDIO_LOAD_OPTION(physics_file);
+    LDIO_LOAD_OPTION(event_file);
 
-    LDIO_LOAD_OPTION(primary_gen_options);
+    LDIO_LOAD_DEPRECATED(primary_gen_options, primary_options);
 
-    LDIO_LOAD_OPTION(mctruth_filename);
+    LDIO_LOAD_OPTION(primary_options);
+
+    LDIO_LOAD_DEPRECATED(mctruth_filename, mctruth_file);
+    LDIO_LOAD_DEPRECATED(step_diagnostic_maxsteps, step_diagnostic_bins);
+
+    LDIO_LOAD_OPTION(mctruth_file);
     LDIO_LOAD_OPTION(mctruth_filter);
     LDIO_LOAD_OPTION(simple_calo);
     LDIO_LOAD_OPTION(action_diagnostic);
     LDIO_LOAD_OPTION(step_diagnostic);
-    LDIO_LOAD_OPTION(step_diagnostic_maxsteps);
+    LDIO_LOAD_OPTION(step_diagnostic_bins);
     LDIO_LOAD_OPTION(write_track_counts);
 
     LDIO_LOAD_DEPRECATED(max_num_tracks, num_track_slots);
@@ -104,27 +115,31 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_OPTION(default_stream);
     LDIO_LOAD_OPTION(warm_up);
 
-    LDIO_LOAD_OPTION(mag_field);
+    LDIO_LOAD_DEPRECATED(mag_field, field);
+
+    LDIO_LOAD_OPTION(field);
     LDIO_LOAD_OPTION(field_options);
+
+    LDIO_LOAD_DEPRECATED(geant_options, physics_options);
 
     LDIO_LOAD_OPTION(step_limiter);
     LDIO_LOAD_OPTION(brem_combined);
     LDIO_LOAD_OPTION(track_order);
-    LDIO_LOAD_OPTION(geant_options);
+    LDIO_LOAD_OPTION(physics_options);
 
 #undef LDIO_LOAD_OPTION
 #undef LDIO_LOAD_REQUIRED
 
-    CELER_VALIDATE(v.event_filename.empty() != !v.primary_gen_options,
+    CELER_VALIDATE(v.event_file.empty() != !v.primary_options,
                    << "either a event filename or options to generate "
                       "primaries must be provided (but not both)");
-    CELER_VALIDATE(!v.mctruth_filter || !v.mctruth_filename.empty(),
+    CELER_VALIDATE(!v.mctruth_filter || !v.mctruth_file.empty(),
                    << "'mctruth_filter' cannot be specified without providing "
-                      "'mctruth_filename'");
-    CELER_VALIDATE(v.mag_field != RunnerInput::no_field()
+                      "'mctruth_file'");
+    CELER_VALIDATE(v.field != RunnerInput::no_field()
                        || !j.contains("field_options"),
                    << "'field_options' cannot be specified without providing "
-                      "'mag_field'");
+                      "'field'");
 }
 
 //---------------------------------------------------------------------------//
@@ -149,23 +164,23 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE_OPTION(cuda_stack_size);
     LDIO_SAVE_REQUIRED(environ);
 
-    LDIO_SAVE_REQUIRED(geometry_filename);
-    LDIO_SAVE_REQUIRED(physics_filename);
-    LDIO_SAVE_OPTION(event_filename);
-    if (v.event_filename.empty())
+    LDIO_SAVE_REQUIRED(geometry_file);
+    LDIO_SAVE_REQUIRED(physics_file);
+    LDIO_SAVE_OPTION(event_file);
+    if (v.event_file.empty())
     {
-        LDIO_SAVE_REQUIRED(primary_gen_options);
+        LDIO_SAVE_REQUIRED(primary_options);
     }
 
-    LDIO_SAVE_OPTION(mctruth_filename);
-    if (!v.mctruth_filename.empty())
+    LDIO_SAVE_OPTION(mctruth_file);
+    if (!v.mctruth_file.empty())
     {
         LDIO_SAVE_REQUIRED(mctruth_filter);
     }
     LDIO_SAVE_OPTION(simple_calo);
     LDIO_SAVE_OPTION(action_diagnostic);
     LDIO_SAVE_OPTION(step_diagnostic);
-    LDIO_SAVE_OPTION(step_diagnostic_maxsteps);
+    LDIO_SAVE_OPTION(step_diagnostic_bins);
     LDIO_SAVE_OPTION(write_track_counts);
 
     LDIO_SAVE_REQUIRED(seed);
@@ -180,8 +195,8 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE_REQUIRED(default_stream);
     LDIO_SAVE_REQUIRED(warm_up);
 
-    LDIO_SAVE_OPTION(mag_field);
-    if (v.mag_field != RunnerInput::no_field())
+    LDIO_SAVE_OPTION(field);
+    if (v.field != RunnerInput::no_field())
     {
         LDIO_SAVE_REQUIRED(field_options);
     }
@@ -190,9 +205,9 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE_REQUIRED(brem_combined);
 
     LDIO_SAVE_REQUIRED(track_order);
-    if (v.physics_filename.empty() || !ends_with(v.physics_filename, ".root"))
+    if (v.physics_file.empty() || !ends_with(v.physics_file, ".root"))
     {
-        LDIO_SAVE_REQUIRED(geant_options);
+        LDIO_SAVE_REQUIRED(physics_options);
     }
 
 #undef LDIO_SAVE_OPTION

--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -27,7 +27,7 @@ geant_exp_exe = environ.get('CELER_EXPORT_GEANT_EXE', './celer-export-geant')
 run_name = (path.splitext(path.basename(geometry_filename))[0]
             + ('-gpu' if use_device else '-cpu'))
 
-geant_options = {
+physics_options = {
     'coulomb_scattering': False,
     'compton_scattering': True,
     'photoelectric': True,
@@ -47,7 +47,7 @@ if geant_exp_exe:
     print("Running", geant_exp_exe, file=stderr)
     result_ge = subprocess.run(
         [geant_exp_exe, geometry_filename, "-", physics_filename],
-        input=json.dumps(geant_options).encode()
+        input=json.dumps(physics_options).encode()
     )
 
     if result_ge.returncode:
@@ -67,7 +67,7 @@ if not rootout_filename:
 
 num_tracks = 128*32 if use_device else 32
 num_primaries = 3 * 15 # assuming test hepmc input
-max_steps = 512 if geant_options['msc'] else 128
+max_steps = 512 if physics_options['msc'] else 128
 
 if not use_device:
     # Way more steps are needed since we're not tracking in parallel, but
@@ -76,10 +76,10 @@ if not use_device:
 
 inp = {
     'use_device': use_device,
-    'geometry_filename': geometry_filename,
-    'physics_filename': physics_filename,
-    'event_filename': event_filename,
-    'mctruth_filename': rootout_filename,
+    'geometry_file': geometry_filename,
+    'physics_file': physics_filename,
+    'event_file': event_filename,
+    'mctruth_file': rootout_filename,
     'seed': 12345,
     'num_track_slots': num_tracks,
     'max_steps': max_steps,
@@ -88,13 +88,13 @@ inp = {
     'secondary_stack_factor': 3,
     'action_diagnostic': True,
     'step_diagnostic': True,
-    'step_diagnostic_maxsteps': 200,
+    'step_diagnostic_bins': 200,
     'simple_calo': simple_calo,
     'sync': True,
     'merge_events': False,
     'default_stream': False,
     'brem_combined': True,
-    'geant_options': geant_options,
+    'physics_options': physics_options,
 }
 
 with open(f'{run_name}.inp.json', 'w') as f:


### PR DESCRIPTION
This modifies the app input to use the same name for equivalent celer-sim and celer-g4 input options where we weren't already. I stuck with the more recent celer-g4 names, but @sethrj you probably have stronger opinions on the naming than I do, so let me know if you have different preferences. These are the changes:

| Old | New |
|----|-----|
| `*_filename` | `*_file` |
| `primary_gen_options` | `primary_options` |
| `step_diagnostic_maxsteps` | `step_diagnostic_bins` | 
| `geant_options` | `physics_options` |
| `mag_field` | `field` |

I should probably make sure the accel `SetupOptions` are consistent too...