### PR TITLE
Use fused multiply-add to improve performance and numerical accuracy

### DIFF
--- a/src/celeritas/grid/PolyEvaluator.hh
+++ b/src/celeritas/grid/PolyEvaluator.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <cmath>
 #include <type_traits>
 
 #include "corecel/Macros.hh"
@@ -81,7 +82,7 @@ class PolyEvaluator
     template<unsigned int M, std::enable_if_t<(M < N), bool> = true>
     CELER_CONSTEXPR_FUNCTION T calc_impl(T arg) const
     {
-        return coeffs_[M] + arg * calc_impl<M + 1>(arg);
+        return std::fma(arg, calc_impl<M + 1>(arg), coeffs_[M]);
     }
 
     template<unsigned int M, std::enable_if_t<(M == N), bool> = true>

--- a/src/celeritas/random/distribution/NormalDistribution.hh
+++ b/src/celeritas/random/distribution/NormalDistribution.hh
@@ -85,14 +85,15 @@ CELER_FUNCTION auto NormalDistribution<RealType>::operator()(Generator& rng)
     if (has_spare_)
     {
         has_spare_ = false;
-        return spare_ * stddev_ + mean_;
+        return std::fma(spare_, stddev_, mean_);
     }
 
-    real_type theta = 2 * constants::pi * generate_canonical(rng);
-    real_type r = std::sqrt(-2 * std::log(generate_canonical(rng)));
+    constexpr auto twopi = static_cast<real_type>(2 * m_pi);
+    real_type theta = twopi * generate_canonical<RealType>(rng);
+    real_type r = std::sqrt(-2 * std::log(generate_canonical<RealType>(rng)));
     spare_ = r * std::cos(theta);
     has_spare_ = true;
-    return r * std::sin(theta) * stddev_ + mean_;
+    return std::fma(r * std::sin(theta), stddev_, mean_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/random/distribution/UniformRealDistribution.hh
+++ b/src/celeritas/random/distribution/UniformRealDistribution.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <cmath>
+
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
@@ -95,7 +97,7 @@ template<class Generator>
 CELER_FUNCTION auto
 UniformRealDistribution<RealType>::operator()(Generator& rng) -> result_type
 {
-    return delta_ * generate_canonical<RealType>(rng) + a_;
+    return std::fma(delta_, generate_canonical<RealType>(rng), a_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/grid/Interpolator.hh
+++ b/src/corecel/grid/Interpolator.hh
@@ -131,7 +131,7 @@ CELER_FUNCTION auto Interpolator<XI, YI, T>::operator()(real_type x) const
 {
     CELER_EXPECT(XTraits_t::valid_domain(x));
     real_type result = YTraits_t::transform_inv(
-        intercept_ + slope_ * (XTraits_t::add_transformed(offset_, x)));
+        std::fma(slope_, XTraits_t::add_transformed(offset_, x), intercept_));
 
     CELER_ENSURE(!std::isnan(result));
     return result;

--- a/src/corecel/math/ArrayUtils.hh
+++ b/src/corecel/math/ArrayUtils.hh
@@ -88,7 +88,7 @@ CELER_FUNCTION void axpy(T a, Array<T, N> const& x, Array<T, N>* y)
     CELER_EXPECT(y);
     for (size_type i = 0; i != N; ++i)
     {
-        (*y)[i] += a * x[i];
+        (*y)[i] = std::fma(a, x[i], (*y)[i]);
     }
 }
 
@@ -102,7 +102,7 @@ CELER_FUNCTION T dot_product(Array<T, N> const& x, Array<T, N> const& y)
     T result{};
     for (size_type i = 0; i != N; ++i)
     {
-        result += x[i] * y[i];
+        result = std::fma(x[i], y[i], result);
     }
     return result;
 }

--- a/src/orange/MatrixUtils.cc
+++ b/src/orange/MatrixUtils.cc
@@ -58,7 +58,7 @@ gemm(SquareMatrix<T, N> const& a, SquareMatrix<T, N> const& b)
             // Accumulate dot products
             for (size_type k = 0; k != N; ++k)
             {
-                result[i][j] += b[k][j] * a[i][k];
+                result[i][j] = std::fma(b[k][j], a[i][k], result[i][j]);
             }
         }
     }
@@ -91,7 +91,7 @@ SquareMatrix<T, N> gemm(matrix::TransposePolicy,
             // Accumulate dot products
             for (size_type k = 0; k != N; ++k)
             {
-                result[i][j] += b[k][j] * a[k][i];
+                result[i][j] = std::fma(b[k][j], a[k][i], result[i][j]);
             }
         }
     }

--- a/src/orange/MatrixUtils.hh
+++ b/src/orange/MatrixUtils.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <cmath>
+
 #include "corecel/Macros.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/math/Turn.hh"
@@ -121,7 +123,7 @@ CELER_FUNCTION Array<T, N> gemv(T alpha,
         result[i] = beta * y[i];
         for (size_type j = 0; j != N; ++j)
         {
-            result[i] += alpha * (a[i][j] * x[j]);
+            result[i] = std::fma(alpha, a[i][j] * x[j], result[i]);
         }
     }
     return result;
@@ -157,7 +159,7 @@ CELER_FUNCTION Array<T, N> gemv(matrix::TransposePolicy,
     {
         for (size_type i = 0; i != N; ++i)
         {
-            result[i] += alpha * (a[j][i] * x[j]);
+            result[i] = std::fma(alpha, a[j][i] * x[j], result[i]);
         }
     }
     return result;


### PR DESCRIPTION
FMA introduces smaller errors in floating point arithmetic compared to manual $`x * y + z`$ calculations. This might help with stability of single-precision celeritas, and there's even a chance it'll make CPU code faster: it should at least make sure CPU and GPU are doing the same thing without having to add weird math flags. (Of course, we're memory latency limited, so it's unlikely to help much.)

Some interesting results from this change:
- Register usage goes down by 8 bytes in a few kernels (no change in occupancy though)
- Summit CPU performance *decreases* slightly in along-step kernel
- Frontier CPU performance *doubles* in some cases? but I think this may be a very odd timing issue looking into the results more closely...