### PR TITLE
Stop previous builds when new changes are pushed

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,4 +1,7 @@
 pipeline {
+  options {
+    disableConcurrentBuilds(abortPrevious: true)
+  }
   triggers {
     issueCommentTrigger('.*do: test')
   }


### PR DESCRIPTION
This should ease up Jenkins testing a bit in situations when a pull request is updated but the previous build hasn't finished yet.