### PR TITLE
Make boundary distance persistent to improve Shift performance

### DIFF
--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -418,6 +418,12 @@ struct OrangeStateData
     StateItems<Sense> sense;
     StateItems<BoundaryResult> boundary;
 
+    // "Local" state, needed for Shift {num_tracks}
+    StateItems<real_type> next_step;
+    StateItems<SurfaceId> next_surface;
+    StateItems<Sense> next_sense;
+    StateItems<LevelId> next_level;
+
     // State with dimensions {num_tracks, max_depth}
     Items<Real3> pos;
     Items<Real3> dir;
@@ -444,6 +450,10 @@ struct OrangeStateData
             && surf.size() == this->size()
             && sense.size() == this->size()
             && boundary.size() == this->size()
+            && next_step.size() == this->size()
+            && next_surface.size() == this->size()
+            && next_sense.size() == this->size()
+            && next_level.size() == this->size()
             && pos.size() == max_depth * this->size()
             && dir.size() == max_depth  * this->size()
             && vol.size() == max_depth  * this->size()
@@ -470,6 +480,11 @@ struct OrangeStateData
         surf = other.surf;
         sense = other.sense;
         boundary = other.boundary;
+
+        next_step = other.next_step;
+        next_surface = other.next_surface;
+        next_sense = other.next_sense;
+        next_level = other.next_level;
 
         pos = other.pos;
         dir = other.dir;
@@ -506,6 +521,11 @@ inline void resize(OrangeStateData<Ownership::value, M>* data,
     resize(&data->surf, num_tracks);
     resize(&data->sense, num_tracks);
     resize(&data->boundary, num_tracks);
+
+    resize(&data->next_step, num_tracks);
+    resize(&data->next_surface, num_tracks);
+    resize(&data->next_sense, num_tracks);
+    resize(&data->next_level, num_tracks);
 
     size_type level_states = params.scalars.max_depth * num_tracks;
     resize(&data->pos, level_states);

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -406,29 +406,31 @@ struct OrangeStateData
 
     //// DATA ////
 
-    // Dimensions {num_tracks}
+    // Note: this is duplicated from the associated OrangeParamsData .
+    // It defines the stride into the preceding pseudo-2D Collections (pos,
+    // dir, ..., etc.)
+    size_type max_depth{0};
+
+    // State with dimensions {num_tracks}
     StateItems<LevelId> level;
     StateItems<LevelId> surface_level;
     StateItems<LocalSurfaceId> surf;
     StateItems<Sense> sense;
     StateItems<BoundaryResult> boundary;
 
-    // Dimensions {num_tracks, max_depth}
+    // State with dimensions {num_tracks, max_depth}
     Items<Real3> pos;
     Items<Real3> dir;
     Items<LocalVolumeId> vol;
     Items<UniverseId> universe;
 
-    // Note: this is duplicated from the associated OrangeParamsData .
-    // It defines the stride into the preceding pseudo-2D Collections (pos,
-    // dir, ..., etc.)
-    size_type max_depth{0};
+    // Scratch space with dimensions {track}{max_faces}
+    Items<Sense> temp_sense;
 
-    // Scratch space
-    Items<Sense> temp_sense;  // [track][max_faces]
-    Items<FaceId> temp_face;  // [track][max_intersections]
-    Items<real_type> temp_distance;  // [track][max_intersections]
-    Items<size_type> temp_isect;  // [track][max_intersections]
+    // Scratch space with dimensions {track}{max_intersections}
+    Items<FaceId> temp_face;
+    Items<real_type> temp_distance;
+    Items<size_type> temp_isect;
 
     //// METHODS ////
 
@@ -436,16 +438,16 @@ struct OrangeStateData
     explicit CELER_FUNCTION operator bool() const
     {
         // clang-format off
-        return !level.empty()
-            && surface_level.size() == level.size()
-            && surf.size() == level.size()
-            && sense.size() == level.size()
-            && boundary.size() == level.size()
-            && !pos.empty()
-            && dir.size() == pos.size()
-            && vol.size() == pos.size()
-            && universe.size() == pos.size()
-            && max_depth > 0
+        return max_depth > 0
+            && !level.empty()
+            && surface_level.size() == this->size()
+            && surf.size() == this->size()
+            && sense.size() == this->size()
+            && boundary.size() == this->size()
+            && pos.size() == max_depth * this->size()
+            && dir.size() == max_depth  * this->size()
+            && vol.size() == max_depth  * this->size()
+            && universe.size() == max_depth  * this->size()
             && !temp_sense.empty()
             && !temp_face.empty()
             && temp_distance.size() == temp_face.size()
@@ -461,18 +463,21 @@ struct OrangeStateData
     OrangeStateData& operator=(OrangeStateData<W2, M2>& other)
     {
         CELER_EXPECT(other);
+        max_depth = other.max_depth;
+
         level = other.level;
         surface_level = other.surface_level;
         surf = other.surf;
         sense = other.sense;
         boundary = other.boundary;
+
         pos = other.pos;
         dir = other.dir;
         vol = other.vol;
         universe = other.universe;
-        max_depth = other.max_depth;
 
         temp_sense = other.temp_sense;
+
         temp_face = other.temp_face;
         temp_distance = other.temp_distance;
         temp_isect = other.temp_isect;
@@ -494,19 +499,19 @@ inline void resize(OrangeStateData<Ownership::value, M>* data,
     CELER_EXPECT(data);
     CELER_EXPECT(num_tracks > 0);
 
+    data->max_depth = params.scalars.max_depth;
+
     resize(&data->level, num_tracks);
     resize(&data->surface_level, num_tracks);
     resize(&data->surf, num_tracks);
     resize(&data->sense, num_tracks);
     resize(&data->boundary, num_tracks);
 
-    data->max_depth = params.scalars.max_depth;
-    auto const size = data->max_depth * num_tracks;
-
-    resize(&data->pos, size);
-    resize(&data->dir, size);
-    resize(&data->vol, size);
-    resize(&data->universe, size);
+    size_type level_states = params.scalars.max_depth * num_tracks;
+    resize(&data->pos, level_states);
+    resize(&data->dir, level_states);
+    resize(&data->vol, level_states);
+    resize(&data->universe, level_states);
 
     size_type face_states = params.scalars.max_faces * num_tracks;
     resize(&data->temp_sense, face_states);

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -79,19 +79,19 @@ class OrangeTrackView
     //// ACCESSORS ////
 
     // The current position
-    CELER_FORCEINLINE_FUNCTION Real3 const& pos() const;
+    inline CELER_FUNCTION Real3 const& pos() const;
     // The current direction
-    CELER_FORCEINLINE_FUNCTION Real3 const& dir() const;
+    inline CELER_FUNCTION Real3 const& dir() const;
     // The current volume ID (null if outside)
-    CELER_FORCEINLINE_FUNCTION VolumeId volume_id() const;
+    inline CELER_FUNCTION VolumeId volume_id() const;
     // The current surface ID
-    CELER_FORCEINLINE_FUNCTION SurfaceId surface_id() const;
+    inline CELER_FUNCTION SurfaceId surface_id() const;
     // After 'find_next_step', the next straight-line surface
-    CELER_FORCEINLINE_FUNCTION SurfaceId next_surface_id() const;
+    inline CELER_FUNCTION SurfaceId next_surface_id() const;
     // Whether the track is outside the valid geometry region
-    CELER_FORCEINLINE_FUNCTION bool is_outside() const;
+    inline CELER_FUNCTION bool is_outside() const;
     // Whether the track is exactly on a surface
-    CELER_FORCEINLINE_FUNCTION bool is_on_boundary() const;
+    inline CELER_FUNCTION bool is_on_boundary() const;
 
     //// OPERATIONS ////
 
@@ -137,45 +137,45 @@ class OrangeTrackView
     //// PRIVATE STATE MUTATORS ////
 
     // The current level
-    CELER_FORCEINLINE_FUNCTION void level(LevelId);
+    inline CELER_FUNCTION void level(LevelId);
 
     // The boundary on the current surface level
-    CELER_FORCEINLINE_FUNCTION void boundary(BoundaryResult);
+    inline CELER_FUNCTION void boundary(BoundaryResult);
 
     // The next step distance, as stored on the state
-    CELER_FORCEINLINE_FUNCTION void next_step(real_type dist);
+    inline CELER_FUNCTION void next_step(real_type dist);
 
     // The next surface to be encounted
-    CELER_FORCEINLINE_FUNCTION void next_surface(detail::OnSurface const&);
+    inline CELER_FUNCTION void next_surface(detail::OnSurface const&);
 
     // The level of the next surface to be encounted
-    CELER_FORCEINLINE_FUNCTION void next_surface_level(LevelId);
+    inline CELER_FUNCTION void next_surface_level(LevelId);
 
     //// PRIVATE STATE ACCESSORS ////
 
     // The current level
-    CELER_FORCEINLINE_FUNCTION LevelId const& level() const;
+    inline CELER_FUNCTION LevelId const& level() const;
 
     // The current surface level
-    CELER_FORCEINLINE_FUNCTION LevelId const& surface_level() const;
+    inline CELER_FUNCTION LevelId const& surface_level() const;
 
     // The local surface on the current surface level
-    CELER_FORCEINLINE_FUNCTION LocalSurfaceId const& surf() const;
+    inline CELER_FUNCTION LocalSurfaceId const& surf() const;
 
     // The sense on the current surface level
-    CELER_FORCEINLINE_FUNCTION Sense const& sense() const;
+    inline CELER_FUNCTION Sense const& sense() const;
 
     // The boundary on the current surface level
-    CELER_FORCEINLINE_FUNCTION BoundaryResult const& boundary() const;
+    inline CELER_FUNCTION BoundaryResult const& boundary() const;
 
     // The next step distance, as stored on the state
-    CELER_FORCEINLINE_FUNCTION real_type const& next_step() const;
+    inline CELER_FUNCTION real_type const& next_step() const;
 
     // The next surface to be encounted
-    CELER_FORCEINLINE_FUNCTION detail::OnSurface const& next_surface() const;
+    inline CELER_FUNCTION detail::OnSurface const& next_surface() const;
 
     // The level of the next surface to be encounted
-    CELER_FORCEINLINE_FUNCTION LevelId const& next_surface_level() const;
+    inline CELER_FUNCTION LevelId const& next_surface_level() const;
 
     //// HELPER FUNCTIONS ////
 
@@ -192,7 +192,7 @@ class OrangeTrackView
     make_local_state(LevelId level) const;
 
     // Whether the next distance-to-boundary has been found
-    inline CELER_FUNCTION bool has_next_step() const;
+    CELER_FORCEINLINE_FUNCTION bool has_next_step() const;
 
     // Invalidate the next distance-to-boundary
     CELER_FORCEINLINE_FUNCTION void clear_next_step();
@@ -202,7 +202,7 @@ class OrangeTrackView
     surface(LevelId level, detail::OnLocalSurface surf);
 
     // Make a LevelStateAccessor for the current thread and level
-    inline CELER_FUNCTION LevelStateAccessor make_lsa() const;
+    CELER_FORCEINLINE_FUNCTION LevelStateAccessor make_lsa() const;
 
     // Make a LevelStateAccessor for the current thread and a given level
     inline CELER_FUNCTION LevelStateAccessor make_lsa(LevelId level) const;
@@ -431,7 +431,7 @@ CELER_FUNCTION bool OrangeTrackView::is_outside() const
 /*!
  * Whether the track is exactly on a surface.
  */
-CELER_FUNCTION bool OrangeTrackView::is_on_boundary() const
+CELER_FORCEINLINE_FUNCTION bool OrangeTrackView::is_on_boundary() const
 {
     return static_cast<bool>(this->surface_id());
 }
@@ -780,7 +780,7 @@ CELER_FUNCTION void OrangeTrackView::set_dir(Real3 const& newdir)
 /*!
  * The current level.
  */
-CELER_FUNCTION void OrangeTrackView::level(LevelId lev)
+CELER_FORCEINLINE_FUNCTION void OrangeTrackView::level(LevelId lev)
 {
     states_.level[track_slot_] = lev;
 }
@@ -788,7 +788,7 @@ CELER_FUNCTION void OrangeTrackView::level(LevelId lev)
 /*!
  * The boundary on the current surface level.
  */
-CELER_FUNCTION void OrangeTrackView::boundary(BoundaryResult br)
+CELER_FORCEINLINE_FUNCTION void OrangeTrackView::boundary(BoundaryResult br)
 {
     states_.boundary[track_slot_] = br;
 }
@@ -796,7 +796,7 @@ CELER_FUNCTION void OrangeTrackView::boundary(BoundaryResult br)
 /*!
  * The next step distance.
  */
-CELER_FUNCTION void OrangeTrackView::next_step(real_type dist)
+CELER_FORCEINLINE_FUNCTION void OrangeTrackView::next_step(real_type dist)
 {
     next_step_ = dist;
 }
@@ -804,7 +804,8 @@ CELER_FUNCTION void OrangeTrackView::next_step(real_type dist)
 /*!
  * The next surface to be encountered.
  */
-CELER_FUNCTION void OrangeTrackView::next_surface(detail::OnSurface const& s)
+CELER_FORCEINLINE_FUNCTION void
+OrangeTrackView::next_surface(detail::OnSurface const& s)
 {
     next_surface_ = s;
 }
@@ -812,7 +813,7 @@ CELER_FUNCTION void OrangeTrackView::next_surface(detail::OnSurface const& s)
 /*!
  * The level of the next surface to be encounted.
  */
-CELER_FUNCTION void OrangeTrackView::next_surface_level(LevelId lev)
+CELER_FORCEINLINE_FUNCTION void OrangeTrackView::next_surface_level(LevelId lev)
 {
     next_surface_level_ = lev;
 }
@@ -823,7 +824,7 @@ CELER_FUNCTION void OrangeTrackView::next_surface_level(LevelId lev)
 /*!
  * The current level.
  */
-CELER_FUNCTION LevelId const& OrangeTrackView::level() const
+CELER_FORCEINLINE_FUNCTION LevelId const& OrangeTrackView::level() const
 {
     return states_.level[track_slot_];
 }
@@ -831,7 +832,7 @@ CELER_FUNCTION LevelId const& OrangeTrackView::level() const
 /*!
  * The current surface level.
  */
-CELER_FUNCTION LevelId const& OrangeTrackView::surface_level() const
+CELER_FORCEINLINE_FUNCTION LevelId const& OrangeTrackView::surface_level() const
 {
     return states_.surface_level[track_slot_];
 }
@@ -839,7 +840,7 @@ CELER_FUNCTION LevelId const& OrangeTrackView::surface_level() const
 /*!
  * The local surface on the current surface level.
  */
-CELER_FUNCTION LocalSurfaceId const& OrangeTrackView::surf() const
+CELER_FORCEINLINE_FUNCTION LocalSurfaceId const& OrangeTrackView::surf() const
 {
     return states_.surf[track_slot_];
 }
@@ -847,7 +848,7 @@ CELER_FUNCTION LocalSurfaceId const& OrangeTrackView::surf() const
 /*!
  * The sense on the current surface level.
  */
-CELER_FUNCTION Sense const& OrangeTrackView::sense() const
+CELER_FORCEINLINE_FUNCTION Sense const& OrangeTrackView::sense() const
 {
     return states_.sense[track_slot_];
 }
@@ -855,7 +856,8 @@ CELER_FUNCTION Sense const& OrangeTrackView::sense() const
 /*!
  * The boundary on the current surface level.
  */
-CELER_FUNCTION BoundaryResult const& OrangeTrackView::boundary() const
+CELER_FORCEINLINE_FUNCTION BoundaryResult const&
+OrangeTrackView::boundary() const
 {
     return states_.boundary[track_slot_];
 }
@@ -863,7 +865,7 @@ CELER_FUNCTION BoundaryResult const& OrangeTrackView::boundary() const
 /*!
  * The next step distance.
  */
-CELER_FUNCTION real_type const& OrangeTrackView::next_step() const
+CELER_FORCEINLINE_FUNCTION real_type const& OrangeTrackView::next_step() const
 {
     return next_step_;
 }
@@ -871,7 +873,8 @@ CELER_FUNCTION real_type const& OrangeTrackView::next_step() const
 /*!
  * The next surface to be encountered.
  */
-CELER_FUNCTION detail::OnSurface const& OrangeTrackView::next_surface() const
+CELER_FORCEINLINE_FUNCTION detail::OnSurface const&
+OrangeTrackView::next_surface() const
 {
     return next_surface_;
 }
@@ -879,7 +882,8 @@ CELER_FUNCTION detail::OnSurface const& OrangeTrackView::next_surface() const
 /*!
  * The level of the next surface to be encounted.
  */
-CELER_FUNCTION LevelId const& OrangeTrackView::next_surface_level() const
+CELER_FORCEINLINE_FUNCTION LevelId const&
+OrangeTrackView::next_surface_level() const
 {
     return next_surface_level_;
 }
@@ -1050,7 +1054,7 @@ CELER_FORCEINLINE_FUNCTION void OrangeTrackView::clear_next_step()
 /*!
  * Assign the surface on the current level.
  */
-inline CELER_FUNCTION void
+CELER_FUNCTION void
 OrangeTrackView::surface(LevelId level, detail::OnLocalSurface surf)
 {
     states_.surface_level[track_slot_] = level;
@@ -1083,7 +1087,7 @@ OrangeTrackView::make_lsa(LevelId level) const
  *
  * \return DaughterId or {} if the current volume is a leaf.
  */
-CELER_FORCEINLINE_FUNCTION DaughterId
+CELER_FUNCTION DaughterId
 OrangeTrackView::get_daughter(LevelStateAccessor const& lsa)
 {
     TrackerVisitor visit_tracker{params_};
@@ -1095,8 +1099,7 @@ OrangeTrackView::get_daughter(LevelStateAccessor const& lsa)
 /*!
  * Get the transform ID for the given daughter.
  */
-CELER_FORCEINLINE_FUNCTION TransformId
-OrangeTrackView::get_transform(DaughterId daughter_id)
+CELER_FUNCTION TransformId OrangeTrackView::get_transform(DaughterId daughter_id)
 {
     CELER_EXPECT(daughter_id);
     return params_.daughters[daughter_id].transform_id;

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -129,11 +129,6 @@ class OrangeTrackView
     StateRef const& states_;
     TrackSlotId track_slot_;
 
-    // Temporary next-step data
-    real_type next_step_{0};
-    detail::OnSurface next_surface_{};
-    LevelId next_surface_level_{};
-
     //// PRIVATE STATE MUTATORS ////
 
     // The current level
@@ -172,7 +167,7 @@ class OrangeTrackView
     inline CELER_FUNCTION real_type const& next_step() const;
 
     // The next surface to be encounted
-    inline CELER_FUNCTION detail::OnSurface const& next_surface() const;
+    inline CELER_FUNCTION detail::OnSurface next_surface() const;
 
     // The level of the next surface to be encounted
     inline CELER_FUNCTION LevelId const& next_surface_level() const;
@@ -798,7 +793,7 @@ CELER_FORCEINLINE_FUNCTION void OrangeTrackView::boundary(BoundaryResult br)
  */
 CELER_FORCEINLINE_FUNCTION void OrangeTrackView::next_step(real_type dist)
 {
-    next_step_ = dist;
+    states_.next_step[track_slot_] = dist;
 }
 
 /*!
@@ -807,7 +802,8 @@ CELER_FORCEINLINE_FUNCTION void OrangeTrackView::next_step(real_type dist)
 CELER_FORCEINLINE_FUNCTION void
 OrangeTrackView::next_surface(detail::OnSurface const& s)
 {
-    next_surface_ = s;
+    states_.next_surface[track_slot_] = s.id();
+    states_.next_sense[track_slot_] = s.unchecked_sense();
 }
 
 /*!
@@ -815,7 +811,7 @@ OrangeTrackView::next_surface(detail::OnSurface const& s)
  */
 CELER_FORCEINLINE_FUNCTION void OrangeTrackView::next_surface_level(LevelId lev)
 {
-    next_surface_level_ = lev;
+    states_.next_level[track_slot_] = lev;
 }
 
 //---------------------------------------------------------------------------//
@@ -867,16 +863,16 @@ OrangeTrackView::boundary() const
  */
 CELER_FORCEINLINE_FUNCTION real_type const& OrangeTrackView::next_step() const
 {
-    return next_step_;
+    return states_.next_step[track_slot_];
 }
 
 /*!
  * The next surface to be encountered.
  */
-CELER_FORCEINLINE_FUNCTION detail::OnSurface const&
+CELER_FORCEINLINE_FUNCTION detail::OnSurface
 OrangeTrackView::next_surface() const
 {
-    return next_surface_;
+    return {states_.next_surface[track_slot_], states_.next_sense[track_slot_]};
 }
 
 /*!
@@ -885,7 +881,7 @@ OrangeTrackView::next_surface() const
 CELER_FORCEINLINE_FUNCTION LevelId const&
 OrangeTrackView::next_surface_level() const
 {
-    return next_surface_level_;
+    return states_.next_level[track_slot_];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -1031,7 +1031,7 @@ OrangeTrackView::make_local_state(LevelId level) const
  */
 CELER_FORCEINLINE_FUNCTION bool OrangeTrackView::has_next_step() const
 {
-    return next_step_ != 0;
+    return this->next_step() != 0;
 }
 
 //---------------------------------------------------------------------------//
@@ -1043,7 +1043,7 @@ CELER_FORCEINLINE_FUNCTION bool OrangeTrackView::has_next_step() const
  */
 CELER_FORCEINLINE_FUNCTION void OrangeTrackView::clear_next_step()
 {
-    next_step_ = 0;
+    this->next_step(0);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -227,8 +227,6 @@ OrangeTrackView::OrangeTrackView(ParamsRef const& params,
     CELER_EXPECT(params_);
     CELER_EXPECT(states_);
     CELER_EXPECT(track_slot_ < states.size());
-
-    this->next_step(0);
 }
 
 //---------------------------------------------------------------------------//
@@ -328,6 +326,9 @@ OrangeTrackView& OrangeTrackView::operator=(DetailedInitializer const& init)
             auto lsa = this->make_lsa(lev);
             lsa = init.other.make_lsa(lev);
         }
+
+        this->next_step(init.other.next_step());
+        this->next_surface_level(init.other.next_surface_level());
     }
 
     // Transform direction from global to local

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -127,14 +127,12 @@ class ShiftTrackerTest : public OrangeTest
     void move_to_point(real_type distance)
     {
         auto track = this->make_track_view();
-        track.find_next_step();
         track.move_internal(distance);
     }
 
     void move_across_surface(BoundaryState& boundary_state, unsigned int& cell)
     {
         auto track = this->make_track_view();
-        track.find_next_step();
         track.move_to_boundary();
         track.cross_boundary();
 


### PR DESCRIPTION
This will allow Shift to eliminate the redundant "find next distance" call in its "move to and cross boundary" kernel (and its "move to point kernel").  This cacheing isn't needed in Celeritas because we know at the start of the "find distance" kernel (aka propagate) that we will move to the boundary if it's shorter than the next distance:
| Function  |  Celeritas action  |  Shift kernel |
| -------- | --- | --- |
| `find_next_step` | `AlongStep` | `d2b_kernel` |
| `move_to_boundary` | `AlongStep` | `move_across_surface_kernel` |
| `move_internal` | `AlongStep` | `move_to_point_kernel` |
| `cross_boundary` | `Boundary` | `move_across_surface_kernel` |

I'm going to see if the "always store in global" implementation has any effect on performance. If not, we can merge this. If so, I'll try keeping the distance local and making the next-distance caching *optional* by using a parameter.