### PR TITLE
Add Orange Shift tracking flow control test

### DIFF
--- a/scripts/cmake-presets/gondolin.json
+++ b/scripts/cmake-presets/gondolin.json
@@ -1,0 +1,73 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {"major": 3, "minor": 21, "patch": 0},
+  "configurePresets": [
+    {
+      "name": ".gondolin-spack-base",
+      "description": "Setup for using Gondolin spack environment",
+      "hidden": true,
+      "environment": {
+        "PATH": "$env{SPACK_ROOT}/var/spack/environments/exnihilo-prod/.spack-env/view/bin:$penv{PATH}",
+        "CMAKE_PREFIX_PATH": "$env{SPACK_ROOT}/var/spack/environments/exnihilo-prod/.spack-env/view"
+      },
+      "condition": {
+        "lhs": "$env{SPACK_ROOT}",
+        "type": "notEquals",
+        "rhs": ""
+      }
+    },
+    {
+      "name": ".base",
+      "generator": "Ninja",
+      "inherits": [".gondolin-spack-base"],
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "cacheVariables": {
+        "CELERITAS_USE_CUDA":    {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_HIP":     {"type": "BOOL",   "value": "OFF"},
+        "CMAKE_BUILD_TYPE":      {"type": "STRING", "value": "Debug"},
+        "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL",   "value": "ON"},
+        "CMAKE_CXX_STANDARD":   {"type": "STRING",   "value": "17"},
+        "CMAKE_CXX_EXTENSIONS": {"type": "BOOL",   "value": "OFF"},
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-error=deprecated -pedantic -fdiagnostics-color=always"
+      }
+    },
+    {
+      "name": "iwyu",
+      "displayName": "Include what you use",
+      "inherits": [".base", "minimal"],
+      "cacheVariables": {
+        "CELERITAS_BUILD_DEMOS": {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_JSON":    {"type": "BOOL", "value": "ON"},
+        "CMAKE_CXX_INCLUDE_WHAT_YOU_USE": "$env{IWYU_ROOT}/bin/include-what-you-use;-Xiwyu;--no_fwd_decls;-Xiwyu;--no_comments;-Xiwyu;--transitive_includes_only"
+      }
+    },
+    {
+      "name": "base",
+      "displayName": "Gondolin default options",
+      "inherits": [".base", "default"],
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CELERITAS_USE_MPI":     {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_SWIG":    {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_VecGeom": {"type": "BOOL",   "value": "OFF"}
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base",
+      "configurePreset": "base",
+      "jobs": 8,
+      "nativeToolOptions": ["-k0"]
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "configurePreset": "base",
+      "output": {"outputOnFailure": true},
+      "execution": {"noTestsAction": "error", "stopOnFailure": false, "jobs": 8}
+    }
+  ]
+}

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -95,6 +95,62 @@ class HexArrayTest : public OrangeTest
     void SetUp() override { this->build_geometry("hex_array.org.json"); }
 };
 
+#define ShiftTrackerTest TEST_IF_CELERITAS_JSON(ShiftTrackerTest)
+class ShiftTrackerTest : public OrangeTest
+{
+  protected:
+    enum class BoundaryState
+    {
+        INSIDE = 0,
+        OUTSIDE = 1
+    };
+
+    void SetUp() override { this->build_geometry("hex_array.org.json"); }
+
+    CELER_FUNCTION static constexpr unsigned int invalid_id()
+    {
+        return static_cast<unsigned int>(-1);
+    }
+
+    void initialize(Real3 pos, Real3 dir)
+    {
+        auto track = this->make_track_view();
+        track = {pos, dir};
+    }
+
+    void distance_to_boundary(double& distance)
+    {
+        auto track = this->make_track_view();
+        distance = track.find_next_step().distance;
+    }
+
+    void move_to_point(double distance)
+    {
+        auto track = this->make_track_view();
+        track.find_next_step();
+        track.move_internal(distance);
+    }
+
+    void move_across_surface(BoundaryState& boundary_state, unsigned int& cell)
+    {
+        auto track = this->make_track_view();
+        track.find_next_step();
+        track.move_to_boundary();
+        track.cross_boundary();
+
+        if (!track.is_outside())
+        {
+            boundary_state = BoundaryState::INSIDE;
+            cell = track.volume_id().get();
+        }
+        else
+        {
+            boundary_state = BoundaryState::OUTSIDE;
+            cell = invalid_id();
+        }
+    }
+};
+
 #define NestedRectArraysTest TEST_IF_CELERITAS_JSON(NestedRectArraysTest)
 class NestedRectArraysTest : public OrangeTest
 {
@@ -1026,6 +1082,58 @@ TEST_F(HexArrayTest, track_out)
 
     EXPECT_VEC_EQ(refids, vids);
     EXPECT_VEC_CLOSE(d2b, refd2b, 1e-5, 1e-5);
+}
+
+TEST_F(ShiftTrackerTest, track)
+{
+    std::vector<Real3> pos = {{-0.5466, 1.1298, -1.8526},
+                              {1.5968, -4.3272, -3.0764},
+                              {-1.2053, -2.7582, -0.1715},
+                              {-2.3368, -1.7800, 1.2726},
+                              {4.0610, 1.5512, 2.8693},
+                              {-1.5469, 1.6592, -0.6909},
+                              {-3.6040, -0.7626, -1.7840},
+                              {4.3726, -2.5543, -0.0444},
+                              {1.7047, 1.6042, 4.4779},
+                              {-0.8630, -4.8264, 3.1796}};
+    std::vector<Real3> mu_phi = {{0.215991, 1.114365},
+                                 {-0.887921, 1.414178},
+                                 {0.727041, 5.874378},
+                                 {0.822052, 3.051407},
+                                 {0.576156, 3.585084},
+                                 {-0.243608, 0.901952},
+                                 {0.486739, 2.328782},
+                                 {0.966572, 4.876337},
+                                 {-0.798997, 0.149136},
+                                 {0.748980, 1.677583}};
+
+    std::vector<unsigned int> steps(10, 0);
+
+    for (auto n : range(pos.size()))
+    {
+        auto costheta = mu_phi[n][0];
+        auto sintheta = std::sqrt(1.0 - costheta * costheta);
+        auto phi = mu_phi[n][1];
+        Real3 dir
+            = {sintheta * std::cos(phi), sintheta * std::sin(phi), costheta};
+
+        this->initialize(pos[n], dir);
+
+        auto dbnd = std::numeric_limits<double>::max();
+        auto cell = this->invalid_id();
+        BoundaryState bnd_state = BoundaryState::INSIDE;
+
+        while (bnd_state == BoundaryState::INSIDE)
+        {
+            this->distance_to_boundary(dbnd);
+            this->move_across_surface(bnd_state, cell);
+
+            ++steps[n];
+        }
+    }
+
+    std::vector<unsigned int> ref_steps = {5, 3, 5, 5, 6, 5, 4, 4, 5, 3};
+    EXPECT_VEC_EQ(ref_steps, steps);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -118,13 +118,13 @@ class ShiftTrackerTest : public OrangeTest
         track = {pos, dir};
     }
 
-    void distance_to_boundary(double& distance)
+    void distance_to_boundary(real_type& distance)
     {
         auto track = this->make_track_view();
         distance = track.find_next_step().distance;
     }
 
-    void move_to_point(double distance)
+    void move_to_point(real_type distance)
     {
         auto track = this->make_track_view();
         track.find_next_step();
@@ -1054,9 +1054,8 @@ TEST_F(HexArrayTest, track_out)
     OrangeTrackView geo = this->make_track_view();
 
     // Initialize
-    Real3 pos
-        = {-6.9258369494022292, -4.9982766629573767, -10.8378536157757495};
-    Real3 dir = {0.6750034206933703, -0.3679917428721818, 0.6394939086732125};
+    Real3 pos{-6.9258369494022292, -4.9982766629573767, -10.8378536157757495};
+    Real3 dir{0.6750034206933703, -0.3679917428721818, 0.6394939086732125};
 
     geo = Initializer_t{pos, dir};
 
@@ -1066,8 +1065,8 @@ TEST_F(HexArrayTest, track_out)
                                                celeritas::VolumeId{57},
                                                celeritas::VolumeId{2}};
 
-    std::vector<double> d2b;
-    std::vector<double> refd2b = {1.99143, 5.30607, 0.306368, 5.98808};
+    std::vector<real_type> d2b;
+    std::vector<real_type> refd2b = {1.99143, 5.30607, 0.306368, 5.98808};
 
     while (!geo.is_outside())
     {
@@ -1081,45 +1080,49 @@ TEST_F(HexArrayTest, track_out)
     }
 
     EXPECT_VEC_EQ(refids, vids);
-    EXPECT_VEC_CLOSE(d2b, refd2b, 1e-5, 1e-5);
+    EXPECT_VEC_CLOSE(d2b, refd2b, real_type(1e-5), real_type(1e-5));
 }
 
-TEST_F(ShiftTrackerTest, track)
+TEST_F(ShiftTrackerTest, host)
 {
-    std::vector<Real3> pos = {{-0.5466, 1.1298, -1.8526},
-                              {1.5968, -4.3272, -3.0764},
-                              {-1.2053, -2.7582, -0.1715},
-                              {-2.3368, -1.7800, 1.2726},
-                              {4.0610, 1.5512, 2.8693},
-                              {-1.5469, 1.6592, -0.6909},
-                              {-3.6040, -0.7626, -1.7840},
-                              {4.3726, -2.5543, -0.0444},
-                              {1.7047, 1.6042, 4.4779},
-                              {-0.8630, -4.8264, 3.1796}};
-    std::vector<Real3> mu_phi = {{0.215991, 1.114365},
-                                 {-0.887921, 1.414178},
-                                 {0.727041, 5.874378},
-                                 {0.822052, 3.051407},
-                                 {0.576156, 3.585084},
-                                 {-0.243608, 0.901952},
-                                 {0.486739, 2.328782},
-                                 {0.966572, 4.876337},
-                                 {-0.798997, 0.149136},
-                                 {0.748980, 1.677583}};
+    std::vector<Real3> pos{
+        {-0.5466, 1.1298, -1.8526},
+        {1.5968, -4.3272, -3.0764},
+        {-1.2053, -2.7582, -0.1715},
+        {-2.3368, -1.7800, 1.2726},
+        {4.0610, 1.5512, 2.8693},
+        {-1.5469, 1.6592, -0.6909},
+        {-3.6040, -0.7626, -1.7840},
+        {4.3726, -2.5543, -0.0444},
+        {1.7047, 1.6042, 4.4779},
+        {-0.8630, -4.8264, 3.1796},
+    };
+    std::vector<Array<real_type, 2>> mu_phi{
+        {0.215991, 1.114365},
+        {-0.887921, 1.414178},
+        {0.727041, 5.874378},
+        {0.822052, 3.051407},
+        {0.576156, 3.585084},
+        {-0.243608, 0.901952},
+        {0.486739, 2.328782},
+        {0.966572, 4.876337},
+        {-0.798997, 0.149136},
+        {0.748980, 1.677583},
+    };
 
     std::vector<unsigned int> steps(10, 0);
 
     for (auto n : range(pos.size()))
     {
         auto costheta = mu_phi[n][0];
-        auto sintheta = std::sqrt(1.0 - costheta * costheta);
+        auto sintheta = std::sqrt(1 - costheta * costheta);
         auto phi = mu_phi[n][1];
         Real3 dir
             = {sintheta * std::cos(phi), sintheta * std::sin(phi), costheta};
 
         this->initialize(pos[n], dir);
 
-        auto dbnd = std::numeric_limits<double>::max();
+        auto dbnd = std::numeric_limits<real_type>::max();
         auto cell = this->invalid_id();
         BoundaryState bnd_state = BoundaryState::INSIDE;
 


### PR DESCRIPTION
This adds a simple test to `Orange.test.cc` that mirrors the Orange tracking sequence on the GPU, but in a CPU-only, single threaded test:

```cpp
while (bnd_state == BoundaryState::INSIDE)
{
    this->distance_to_boundary(dbnd);
    this->move_across_surface(bnd_state, cell);
    ++steps[n];
}