### PR TITLE
Optimize ORANGE surface crossings and checks

### DIFF
--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -419,10 +419,10 @@ struct OrangeStateData
     StateItems<BoundaryResult> boundary;
 
     // "Local" state, needed for Shift {num_tracks}
-    StateItems<real_type> next_step;
-    StateItems<SurfaceId> next_surface;
-    StateItems<Sense> next_sense;
     StateItems<LevelId> next_level;
+    StateItems<real_type> next_step;
+    StateItems<LocalSurfaceId> next_surf;
+    StateItems<Sense> next_sense;
 
     // State with dimensions {num_tracks, max_depth}
     Items<Real3> pos;
@@ -450,10 +450,10 @@ struct OrangeStateData
             && surf.size() == this->size()
             && sense.size() == this->size()
             && boundary.size() == this->size()
-            && next_step.size() == this->size()
-            && next_surface.size() == this->size()
-            && next_sense.size() == this->size()
             && next_level.size() == this->size()
+            && next_step.size() == this->size()
+            && next_surf.size() == this->size()
+            && next_sense.size() == this->size()
             && pos.size() == max_depth * this->size()
             && dir.size() == max_depth  * this->size()
             && vol.size() == max_depth  * this->size()
@@ -481,10 +481,10 @@ struct OrangeStateData
         sense = other.sense;
         boundary = other.boundary;
 
-        next_step = other.next_step;
-        next_surface = other.next_surface;
-        next_sense = other.next_sense;
         next_level = other.next_level;
+        next_step = other.next_step;
+        next_surf = other.next_surf;
+        next_sense = other.next_sense;
 
         pos = other.pos;
         dir = other.dir;
@@ -522,10 +522,10 @@ inline void resize(OrangeStateData<Ownership::value, M>* data,
     resize(&data->sense, num_tracks);
     resize(&data->boundary, num_tracks);
 
-    resize(&data->next_step, num_tracks);
-    resize(&data->next_surface, num_tracks);
-    resize(&data->next_sense, num_tracks);
     resize(&data->next_level, num_tracks);
+    resize(&data->next_step, num_tracks);
+    resize(&data->next_surf, num_tracks);
+    resize(&data->next_sense, num_tracks);
 
     size_type level_states = params.scalars.max_depth * num_tracks;
     resize(&data->pos, level_states);

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -466,7 +466,7 @@ CELER_FUNCTION Propagation OrangeTrackView::find_next_step()
 
     Propagation result;
     result.distance = this->next_step();
-    result.boundary = static_cast<bool>(this->next_surf());
+    result.boundary = this->has_next_surface();
     return result;
 }
 
@@ -486,27 +486,14 @@ CELER_FUNCTION Propagation OrangeTrackView::find_next_step(real_type max_step)
         // On a boundary, headed back in: next step is zero
         return {0, true};
     }
-    else if (this->next_step() > max_step)
-    {
-        // Cached next step is beyond the given step
-        return {max_step, false};
-    }
-    else if (!this->has_next_surface() && this->next_step() < max_step)
-    {
-        // Reset a previously found truncated distance
-        this->clear_next();
-    }
 
-    if (!this->has_next_step())
-    {
-        // Find intersection at the top level: always the first simple unit
-        TrackerVisitor visit_tracker{params_};
-        auto isect = [this, &max_step] {
-            SimpleUnitTracker t{params_, SimpleUnitId{0}};
-            return t.intersect(this->make_local_state(LevelId{0}), max_step);
-        }();
-        this->find_next_step_impl(isect);
-    }
+    // Find intersection at the top level: always the first simple unit
+    auto isect = [this, &max_step] {
+        SimpleUnitTracker t{params_, SimpleUnitId{0}};
+        return t.intersect(this->make_local_state(LevelId{0}), max_step);
+    }();
+
+    this->find_next_step_impl(isect);
 
     Propagation result;
     result.distance = this->next_step();

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -292,12 +292,15 @@ OrangeTrackView::operator=(Initializer_t const& init)
 
     } while (daughter_id);
 
+    // Save fiound level
     this->level(LevelId{level});
-    this->surface({}, {});
+
+    // Set default boundary condition
     this->boundary(BoundaryResult::exiting);
 
-    this->next_step(0);
-    this->next_surface_level(LevelId{});
+    // Clear surface information
+    this->surface({}, {});
+    this->clear_next_step();
 
     CELER_ENSURE(!this->has_next_step());
     return *this;
@@ -314,11 +317,14 @@ OrangeTrackView& OrangeTrackView::operator=(DetailedInitializer const& init)
 
     if (this != &init.other)
     {
-        // Copy init track's position but update the direction
+        // Copy init track's position and logical state
         this->level(states_.level[init.other.track_slot_]);
         this->surface(init.other.surface_level(),
                       {init.other.surf(), init.other.sense()});
         this->boundary(init.other.boundary());
+
+        // Clear the next step information since we're changing direction
+        this->clear_next_step();
 
         for (auto lev : range(LevelId{this->level() + 1}))
         {
@@ -326,9 +332,6 @@ OrangeTrackView& OrangeTrackView::operator=(DetailedInitializer const& init)
             auto lsa = this->make_lsa(lev);
             lsa = init.other.make_lsa(lev);
         }
-
-        this->next_step(init.other.next_step());
-        this->next_surface_level(init.other.next_surface_level());
     }
 
     // Transform direction from global to local

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -680,8 +680,6 @@ CELER_FUNCTION void OrangeTrackView::cross_boundary()
         apply_transform(transform_down_local, daughter.transform_id);
         local.volume = {};
         local.surface = {};
-        // XXX I think the next line is redundant
-        local.temp_sense = this->make_temp_sense();
 
         // Initialize in daughter and get IDs of volume and potential daughter
         volume_id = visit_tracker(

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -330,9 +330,6 @@ OrangeTrackView& OrangeTrackView::operator=(DetailedInitializer const& init)
                       {init.other.surf(), init.other.sense()});
         this->boundary(init.other.boundary());
 
-        // Clear the next step information since we're changing direction
-        this->clear_next();
-
         for (auto lev : range(LevelId{this->level() + 1}))
         {
             // Copy all data accessed via LSA
@@ -340,6 +337,10 @@ OrangeTrackView& OrangeTrackView::operator=(DetailedInitializer const& init)
             lsa = init.other.make_lsa(lev);
         }
     }
+
+    // Clear the next step information since we're changing direction or
+    // initializing a new state
+    this->clear_next();
 
     // Transform direction from global to local
     Real3 localdir = init.dir;


### PR DESCRIPTION
This follow-on to #1002 does a few optimizations (avoid back-and-forth universe indexing) and code improvements (adding `clear_next` and `clear_surface` helper functions), and drops caching of `find_next(max_step)` calls, which will all hopefully mitigate the performance drop from #1002.

For TestEM3 on summit (with field plus msc) this results in a ~5% overall speedup compared to #1002 and a ~2% overall speedup compared to before that change.