### PR TITLE
Refactor detector construction and SharedParams output

### DIFF
--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -24,12 +24,13 @@ namespace app
 //---------------------------------------------------------------------------//
 /*!
  * Construct global data to be shared across Celeritas workers.
+ *
+ * The parameters will be distributed to worker threads and all the actions.
  */
-ActionInitialization::ActionInitialization()
-    : init_celeritas_{true}, init_diagnostics_{true}
+ActionInitialization::ActionInitialization(SPParams params)
+    : params_{std::move(params)}, init_celeritas_{true}, init_diagnostics_{true}
 {
-    // Create params to be shared across worker threads
-    params_ = std::make_shared<SharedParams>();
+    CELER_EXPECT(params_);
     // Create Geant4 diagnostics to be shared across worker threads
     diagnostics_ = std::make_shared<GeantDiagnostics>();
 }

--- a/app/celer-g4/ActionInitialization.hh
+++ b/app/celer-g4/ActionInitialization.hh
@@ -32,7 +32,7 @@ class ActionInitialization final : public G4VUserActionInitialization
     //!@}
 
   public:
-    ActionInitialization();
+    ActionInitialization(SPParams params);
     void BuildForMaster() const final;
     void Build() const final;
 

--- a/app/celer-g4/ActionInitialization.hh
+++ b/app/celer-g4/ActionInitialization.hh
@@ -32,7 +32,7 @@ class ActionInitialization final : public G4VUserActionInitialization
     //!@}
 
   public:
-    ActionInitialization(SPParams params);
+    explicit ActionInitialization(SPParams params);
     void BuildForMaster() const final;
     void Build() const final;
 

--- a/app/celer-g4/ActionInitialization.hh
+++ b/app/celer-g4/ActionInitialization.hh
@@ -39,8 +39,7 @@ class ActionInitialization final : public G4VUserActionInitialization
   private:
     SPParams params_;
     SPDiagnostics diagnostics_;
-    mutable bool init_celeritas_;
-    mutable bool init_diagnostics_;
+    mutable bool init_shared_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -91,10 +91,7 @@ configure_file(
   "simple-cms-test.inp.json.in"
   "simple-cms-test.inp.json" @ONLY
 )
-add_test(NAME "app/celer-g4"
-  COMMAND "$<TARGET_FILE:celer-g4>"
-  "simple-cms-test.inp.json"
-)
+
 set(_env
   ${CELER_G4ENV}
   "CELER_LOG_LOCAL=debug"
@@ -110,25 +107,60 @@ if(CELERITAS_USE_OpenMP)
 endif()
 
 if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
-  set(_props RESOURCE_LOCK gpu)
-  set(_labels app gpu)
+  set(_needs_device)
 else()
-  set(_props)
-  set(_labels app)
-endif()
-if(NOT CELERITAS_USE_HepMC3 OR NOT CELERITAS_USE_Geant4
-    OR CELERITAS_CORE_GEO STREQUAL "Geant4")
-  list(APPEND _props DISABLED true)
+  set(_needs_device DISABLED true)
 endif()
 
+set(_props)
+if(NOT CELERITAS_USE_HepMC3 OR NOT CELERITAS_USE_Geant4)
+  set(_props DISABLED true)
+endif()
+if(CELERITAS_CORE_GEO STREQUAL "Geant4")
+  # FIXME: geant4 navigator doesn't work at scale
+  set(_props DISABLED true)
+endif()
 if(CELERITAS_REAL_TYPE STREQUAL "float")
   # FIXME: propagation fails in single precision
-  list(APPEND _props DISABLED true)
+  set(_props DISABLED true)
 endif()
 
-set_tests_properties("app/celer-g4" PROPERTIES
+### CELERITAS OFFLOADING WITH GPU ###
+add_test(NAME "app/celer-g4:gpu"
+  COMMAND "$<TARGET_FILE:celer-g4>" "simple-cms-test.inp.json"
+)
+set_tests_properties("app/celer-g4:gpu" PROPERTIES
   ENVIRONMENT "${_env}"
-  LABELS "${_labels}"
+  RESOURCE_LOCK gpu
+  LABELS "app;nomemcheck;gpu"
+  ${_props}
+  ${_needs_device}
+)
+
+### CELERITAS OFFLOADING WITH CPU ###
+list(APPEND _env
+  "CELER_DISABLE_DEVICE=1"
+)
+add_test(NAME "app/celer-g4:cpu"
+  COMMAND "$<TARGET_FILE:celer-g4>" "simple-cms-test.inp.json"
+)
+set_tests_properties("app/celer-g4:cpu" PROPERTIES
+  ENVIRONMENT "${_env}"
+  RESOURCE_LOCK gpu
+  LABELS "app;nomemcheck"
+  ${_props}
+)
+
+### NO CELERITAS OFFLOADING ###
+list(APPEND _env
+  "CELER_DISABLE=1"
+)
+add_test(NAME "app/celer-g4:none"
+  COMMAND "$<TARGET_FILE:celer-g4>" "simple-cms-test.inp.json"
+)
+set_tests_properties("app/celer-g4:none" PROPERTIES
+  ENVIRONMENT "${_env}"
+  LABELS "app;nomemcheck"
   ${_props}
 )
 

--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -57,45 +57,25 @@ if(NOT CELERITAS_BUILD_TESTS)
   return()
 endif()
 
-if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
-  if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    set(CELERG4_MAX_NUM_TRACKS 524288)
-    set(CELERG4_INIT_CAPACITY 4194304)
-  else()
-    # Use smaller number of tracks when running on CPU
-    set(CELERG4_MAX_NUM_TRACKS 2048)
-    set(CELERG4_INIT_CAPACITY 65536)
-  endif()
-else()
-  # Use smaller number of tracks when running on CPU
-  set(CELERG4_MAX_NUM_TRACKS 1024)
-  set(CELERG4_INIT_CAPACITY 32768)
-endif()
-
+set(_driver "${CMAKE_CURRENT_SOURCE_DIR}/test-harness.py")
+set(_exe "$<TARGET_FILE:celer-g4>")
+set(_model "${CELER_APP_DATA_DIR}/simple-cms.gdml")
 if(NOT CELERITAS_DEBUG)
-  set(CELERG4_EVENTS
+  set(_events
     "${CELER_APP_DATA_DIR}/ttbarsplit-12evt-1108prim.hepmc3")
 else()
   # Use fewer events for debug
-  set(CELERG4_EVENTS
+  set(_events
     "${CELER_APP_DATA_DIR}/ttbarbits-12evt-118prim.hepmc3")
 endif()
-if(CELERITAS_USE_ROOT)
-  set(CELERG4_WRITE_SD_HITS "true")
-  set(CELERG4_OFFLOAD_FILE "simple-cms.offloaded.root")
-else()
-  set(CELERG4_WRITE_SD_HITS "false")
-  set(CELERG4_OFFLOAD_FILE "simple-cms.offloaded.hepmc3")
-endif()
-configure_file(
-  "simple-cms-test.inp.json.in"
-  "simple-cms-test.inp.json" @ONLY
-)
 
 set(_env
   ${CELER_G4ENV}
   "CELER_LOG_LOCAL=debug"
   "CELER_DISABLE_PARALLEL=1"
+  "CELER_DEBUG=${CELERITAS_DEBUG}"
+  "CELER_USE_ROOT=${CELERITAS_USE_ROOT}"
+  "CELER_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
 )
 if(Geant4_multithreaded_FOUND)
   list(APPEND _env
@@ -106,13 +86,8 @@ if(CELERITAS_USE_OpenMP)
   list(APPEND _env "OMP_NUM_THREADS=1")
 endif()
 
-if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
-  set(_needs_device)
-else()
-  set(_needs_device DISABLED true)
-endif()
-
-set(_props)
+set(_required_files "${_driver}" "${_exe}" "${_model}" "${_events}")
+set(_props ${CELER_NEEDS_PYTHON})
 if(NOT CELERITAS_USE_HepMC3 OR NOT CELERITAS_USE_Geant4)
   set(_props DISABLED true)
 endif()
@@ -125,43 +100,39 @@ if(CELERITAS_REAL_TYPE STREQUAL "float")
   set(_props DISABLED true)
 endif()
 
-### CELERITAS OFFLOADING WITH GPU ###
-add_test(NAME "app/celer-g4:gpu"
-  COMMAND "$<TARGET_FILE:celer-g4>" "simple-cms-test.inp.json"
-)
-set_tests_properties("app/celer-g4:gpu" PROPERTIES
-  ENVIRONMENT "${_env}"
-  RESOURCE_LOCK gpu
-  LABELS "app;nomemcheck;gpu"
-  ${_props}
-  ${_needs_device}
-)
+#-----------------------------------------------------------------------------#
+function(celer_app_test ext)
+  set(_labels app nomemcheck)
+  set(_extra_props)
+  set(_extra_env "CELER_TEST_EXT=${ext}")
+  if(ext STREQUAL "gpu")
+    list(APPEND _labels "gpu")
+    set(_extra_props RESOURCE_LOCK gpu)
+    if(NOT (CELERITAS_USE_CUDA OR CELERITAS_USE_HIP))
+      list(APPEND _extra_props DISABLED true)
+    endif()
+  elseif(ext STREQUAL "cpu")
+    list(APPEND _extra_env "CELER_DISABLE_DEVICE=1")
+  else()
+    list(APPEND _extra_env "CELER_DISABLE=1")
+  endif()
 
-### CELERITAS OFFLOADING WITH CPU ###
-list(APPEND _env
-  "CELER_DISABLE_DEVICE=1"
-)
-add_test(NAME "app/celer-g4:cpu"
-  COMMAND "$<TARGET_FILE:celer-g4>" "simple-cms-test.inp.json"
-)
-set_tests_properties("app/celer-g4:cpu" PROPERTIES
-  ENVIRONMENT "${_env}"
-  RESOURCE_LOCK gpu
-  LABELS "app;nomemcheck"
-  ${_props}
-)
+  add_test(NAME "app/celer-g4:${ext}"
+    COMMAND "${CELER_PYTHON}" "${_driver}" "${_exe}" "${_model}" "${_events}"
+  )
 
-### NO CELERITAS OFFLOADING ###
-list(APPEND _env
-  "CELER_DISABLE=1"
-)
-add_test(NAME "app/celer-g4:none"
-  COMMAND "$<TARGET_FILE:celer-g4>" "simple-cms-test.inp.json"
-)
-set_tests_properties("app/celer-g4:none" PROPERTIES
-  ENVIRONMENT "${_env}"
-  LABELS "app;nomemcheck"
-  ${_props}
-)
+  set_tests_properties("app/celer-g4:${ext}" PROPERTIES
+    ENVIRONMENT "${_env};${_extra_env}"
+    REQUIRED_FILES "${_required_files}"
+    LABELS "${_labels}"
+    ${_props} ${_extra_props}
+  )
+endfunction()
+
+#-----------------------------------------------------------------------------#
+
+celer_app_test("gpu")
+celer_app_test("cpu")
+celer_app_test("none")
 
 #-----------------------------------------------------------------------------#

--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -28,6 +28,7 @@
 #include "accel/AlongStepFactory.hh"
 #include "accel/RZMapMagneticField.hh"
 #include "accel/SetupOptions.hh"
+#include "accel/SharedParams.hh"
 
 #include "GlobalSetup.hh"
 #include "SensitiveDetector.hh"
@@ -42,7 +43,8 @@ namespace app
  *
  * This should be done only during the main/serial thread.
  */
-DetectorConstruction::DetectorConstruction()
+DetectorConstruction::DetectorConstruction(SPParams params)
+    : params_{std::move(params)}
 {
     auto& sd = celeritas::app::GlobalSetup::Instance()->GetSDSetupOptions();
 

--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -20,6 +20,7 @@
 #include <G4UniformMagField.hh>
 #include <G4VPhysicalVolume.hh>
 
+#include "corecel/cont/ArrayIO.hh"
 #include "corecel/io/Logger.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
@@ -66,6 +67,23 @@ DetectorConstruction::DetectorConstruction(SPParams params)
  */
 G4VPhysicalVolume* DetectorConstruction::Construct()
 {
+    auto geo = this->construct_geo();
+    CELER_ASSERT(geo.world);
+    detectors_ = std::move(geo.detectors);
+
+    auto field = this->construct_field();
+    CELER_ASSERT(field.along_step);
+    GlobalSetup::Instance()->SetAlongStepFactory(std::move(field.along_step));
+    mag_field_ = std::move(field.g4field);
+    return geo.world.release();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct shared geometry information.
+ */
+auto DetectorConstruction::construct_geo() const -> GeoData
+{
     CELER_LOG_LOCAL(status) << "Loading detector geometry";
 
     G4GDMLParser gdml_parser;
@@ -88,6 +106,8 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
     gdml_parser.Read(filename, validate_gdml_schema);
 
     auto& sd = celeritas::app::GlobalSetup::Instance()->GetSDSetupOptions();
+
+    MapDetectors detectors;
     if (sd.enabled)
     {
         // Find sensitive detectors
@@ -97,12 +117,12 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
             {
                 if (aux.type == "SensDet")
                 {
-                    detectors_.insert({aux.value, lv_vecaux.first});
+                    detectors.insert({aux.value, lv_vecaux.first});
                 }
             }
         }
 
-        if (detectors_.empty())
+        if (detectors.empty())
         {
             CELER_LOG(warning) << "No sensitive detectors were found in the "
                                   "GDML file";
@@ -110,7 +130,21 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
         }
     }
 
-    // Setup options for the magnetic field
+    // Claim ownership of world volume and pass it to the caller
+    return {std::move(detectors),
+            UPPhysicalVolume{gdml_parser.GetWorldVolume()}};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct shared magnetic field information.
+ *
+ * This creates the shared Celeritas object and saves some field information
+ * for later.
+ */
+auto DetectorConstruction::construct_field() const -> FieldData
+{
+    // Set up Celeritas magnetic field and save for Geant4
     auto field_type = GlobalSetup::Instance()->GetFieldType();
     if (field_type == "rzmap")
     {
@@ -125,48 +159,57 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
         CELER_LOG_LOCAL(info) << "Using RZMapField with " << map_filename;
 
         // Create celeritas::RZMapFieldParams from input
-        RZMapFieldInput rz_map;
-        std::ifstream(map_filename) >> rz_map;
-        rz_map.driver_options = GlobalSetup::Instance()->GetFieldOptions();
-        field_params_ = std::make_shared<RZMapFieldParams>(rz_map);
-        mag_field_ = std::make_shared<RZMapMagneticField>(field_params_);
+        auto rz_map = [&map_filename] {
+            RZMapFieldInput rz_map;
+            std::ifstream inp(map_filename);
+            CELER_VALIDATE(inp,
+                           << "failed to open field map file at '"
+                           << map_filename << "'");
+            inp >> rz_map;
+            return rz_map;
+        }();
 
-        GlobalSetup::Instance()->SetAlongStepFactory(
-            RZMapFieldAlongStepFactory([=] { return rz_map; }));
+        // Replace driver options with user options
+        rz_map.driver_options = GlobalSetup::Instance()->GetFieldOptions();
+        auto field_params = std::make_shared<RZMapFieldParams>(rz_map);
+
+        // Return celeritas and geant4 fields
+        return {RZMapFieldAlongStepFactory([rz_map] { return rz_map; }),
+                std::make_shared<RZMapMagneticField>(std::move(field_params))};
     }
     else if (field_type == "uniform")
     {
-        auto field = GlobalSetup::Instance()->GetMagFieldTesla();
-        if (norm(field) > 0)
+        SPMagneticField g4field;
+        auto field_val = GlobalSetup::Instance()->GetMagFieldTesla();
+        if (norm(field_val) > 0)
         {
             CELER_LOG_LOCAL(info)
-                << "Using a uniform field (0, 0, " << field[2] << ") [tesla]";
-            mag_field_ = std::make_shared<G4UniformMagField>(
-                convert_to_geant(field, CLHEP::tesla));
+                << "Using a uniform field " << field_val << " [tesla]";
+            g4field = std::make_shared<G4UniformMagField>(
+                convert_to_geant(field_val, CLHEP::tesla));
         }
 
         // Convert field units from tesla to native celeritas units
-        for (real_type& v : field)
+        for (real_type& v : field_val)
         {
             v = native_value_from(units::FieldTesla{v});
         }
 
         UniformFieldParams input;
-        input.field = field;
+        input.field = field_val;
         input.options = GlobalSetup::Instance()->GetFieldOptions();
-        GlobalSetup::Instance()->SetAlongStepFactory(
-            UniformAlongStepFactory([=] { return input; }));
-    }
-    else
-    {
-        CELER_VALIDATE(false, << "invalid field type '" << field_type << "'");
+
+        return {UniformAlongStepFactory([input] { return input; }),
+                std::move(g4field)};
     }
 
-    // Claim ownership of world volume and pass it to the caller
-    return gdml_parser.GetWorldVolume();
+    CELER_VALIDATE(false, << "invalid field type '" << field_type << "'");
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Construct thread-local sensitive detectors and field.
+ */
 void DetectorConstruction::ConstructSDandField()
 {
     if (mag_field_)

--- a/app/celer-g4/DetectorConstruction.hh
+++ b/app/celer-g4/DetectorConstruction.hh
@@ -12,12 +12,13 @@
 #include <string>
 #include <G4VUserDetectorConstruction.hh>
 
+#include "accel/SetupOptions.hh"
+
 class G4LogicalVolume;
 class G4MagneticField;
 
 namespace celeritas
 {
-class RZMapFieldParams;
 class SharedParams;
 
 namespace app
@@ -36,20 +37,41 @@ class DetectorConstruction final : public G4VUserDetectorConstruction
 
   public:
     // Set up global celeritas SD options during construction
-    DetectorConstruction(SPParams params);
+    explicit DetectorConstruction(SPParams params);
 
     G4VPhysicalVolume* Construct() final;
     void ConstructSDandField() final;
 
   private:
+    //// TYPES ////
+
+    using UPPhysicalVolume = std::unique_ptr<G4VPhysicalVolume>;
+    using MapDetectors = std::multimap<std::string, G4LogicalVolume*>;
+    using AlongStepFactory = SetupOptions::AlongStepFactory;
+    using SPMagneticField = std::shared_ptr<G4MagneticField>;
+
+    struct GeoData
+    {
+        MapDetectors detectors;
+        UPPhysicalVolume world;
+    };
+    struct FieldData
+    {
+        AlongStepFactory along_step;
+        SPMagneticField g4field;
+    };
+
+    //// DATA ////
+
     SPParams params_;
 
-    std::unique_ptr<G4VPhysicalVolume> world_;
-    std::multimap<std::string, G4LogicalVolume*> detectors_;
+    MapDetectors detectors_;
+    SPMagneticField mag_field_;
 
-    // Mangetic field
-    std::shared_ptr<RZMapFieldParams> field_params_;
-    std::shared_ptr<G4MagneticField> mag_field_;
+    //// METHODS ////
+
+    GeoData construct_geo() const;
+    FieldData construct_field() const;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/DetectorConstruction.hh
+++ b/app/celer-g4/DetectorConstruction.hh
@@ -18,6 +18,7 @@ class G4MagneticField;
 namespace celeritas
 {
 class RZMapFieldParams;
+class SharedParams;
 
 namespace app
 {
@@ -28,13 +29,21 @@ namespace app
 class DetectorConstruction final : public G4VUserDetectorConstruction
 {
   public:
+    //!@{
+    //! \name Type aliases
+    using SPParams = std::shared_ptr<SharedParams>;
+    //!@}
+
+  public:
     // Set up global celeritas SD options during construction
-    DetectorConstruction();
+    DetectorConstruction(SPParams params);
 
     G4VPhysicalVolume* Construct() final;
     void ConstructSDandField() final;
 
   private:
+    SPParams params_;
+
     std::unique_ptr<G4VPhysicalVolume> world_;
     std::multimap<std::string, G4LogicalVolume*> detectors_;
 

--- a/app/celer-g4/EventAction.cc
+++ b/app/celer-g4/EventAction.cc
@@ -11,7 +11,6 @@
 #include <G4Event.hh>
 
 #include "corecel/Macros.hh"
-#include "corecel/sys/Environment.hh"
 #include "accel/ExceptionConverter.hh"
 
 #include "GlobalSetup.hh"
@@ -31,7 +30,6 @@ EventAction::EventAction(SPConstParams params,
     : params_(params)
     , transport_(transport)
     , diagnostics_{std::move(diagnostics)}
-    , disable_offloading_(!celeritas::getenv("CELER_DISABLE").empty())
 {
     CELER_EXPECT(params_);
     CELER_EXPECT(transport_);
@@ -48,7 +46,7 @@ void EventAction::BeginOfEventAction(G4Event const* event)
 
     get_event_time_ = {};
 
-    if (disable_offloading_)
+    if (SharedParams::CeleritasDisabled())
         return;
 
     // Set event ID in local transporter
@@ -65,7 +63,7 @@ void EventAction::EndOfEventAction(G4Event const* event)
 {
     CELER_EXPECT(event);
 
-    if (!disable_offloading_)
+    if (!SharedParams::CeleritasDisabled())
     {
         // Transport any tracks left in the buffer
         ExceptionConverter call_g4exception{"celer0004", params_.get()};

--- a/app/celer-g4/EventAction.hh
+++ b/app/celer-g4/EventAction.hh
@@ -49,7 +49,6 @@ class EventAction final : public G4UserEventAction
     SPConstParams params_;
     SPTransporter transport_;
     SPDiagnostics diagnostics_;
-    bool disable_offloading_;
     Stopwatch get_event_time_;
 };
 

--- a/app/celer-g4/GeantDiagnostics.cc
+++ b/app/celer-g4/GeantDiagnostics.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "GeantDiagnostics.hh"
 
+#include "corecel/io/BuildOutput.hh"
 #include "corecel/io/Logger.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/global/CoreParams.hh"
@@ -29,7 +30,8 @@ namespace app
  */
 GeantDiagnostics::GeantDiagnostics(SharedParams const& params)
 {
-    CELER_EXPECT(params || SharedParams::CeleritasDisabled());
+    CELER_EXPECT(static_cast<bool>(params)
+                 == !SharedParams::CeleritasDisabled());
 
     CELER_LOG_LOCAL(status) << "Initializing Geant4 diagnostics";
 
@@ -47,6 +49,12 @@ GeantDiagnostics::GeantDiagnostics(SharedParams const& params)
         step_diagnostic_ = std::make_shared<GeantStepDiagnostic>(
             GlobalSetup::Instance()->GetStepDiagnosticBins(), num_threads);
         output_reg->insert(step_diagnostic_);
+    }
+
+    if (!params)
+    {
+        // Celeritas core params didn't add system metadata: do it ourselves
+        output_reg->insert(std::make_shared<BuildOutput>());
     }
 
     CELER_ENSURE(*this);

--- a/app/celer-g4/GeantDiagnostics.cc
+++ b/app/celer-g4/GeantDiagnostics.cc
@@ -49,55 +49,23 @@ GeantDiagnostics::GeantDiagnostics(SharedParams const& params)
         output_reg->insert(step_diagnostic_);
     }
 
-    if (!params)
-    {
-        // Write output on finalization
-        output_reg_ = std::move(output_reg);
-    }
-
     CELER_ENSURE(*this);
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Write out diagnostics if Celeritas offloading is disabled.
+ * Clear diagnostics at the end of the run.
  *
  * This must be executed exactly *once* across all threads and at the end of
  * the run.
  */
 void GeantDiagnostics::Finalize()
 {
-    CELER_EXPECT(*this);
+    // Reset all data
+    CELER_LOG_LOCAL(debug) << "Resetting diagnostics";
+    *this = {};
 
-    // Output written by \c SharedParams
-    if (!output_reg_)
-        return;
-
-    auto filename = GlobalSetup::Instance()->GetSetupOptions()->output_file;
-    if (filename.empty() && !CELERITAS_USE_JSON)
-    {
-        filename = "celeritas.json";
-        CELER_LOG(warning)
-            << "No diagnostic output filename specified: using '" << filename
-            << '"';
-    }
-
-    if (!CELERITAS_USE_JSON)
-    {
-        CELER_LOG(info) << "Writing Geant4 diagnostic output to \"" << filename
-                        << '"';
-
-        std::ofstream outf(filename);
-        CELER_VALIDATE(
-            outf, << "failed to open output file at \"" << filename << '"');
-        output_reg_->output(&outf);
-    }
-    else
-    {
-        CELER_LOG(warning) << "JSON support is not enabled, so no output will "
-                              "be written to \""
-                           << filename << '"';
-    }
+    CELER_ENSURE(!*this);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/GeantDiagnostics.hh
+++ b/app/celer-g4/GeantDiagnostics.hh
@@ -44,10 +44,10 @@ class GeantDiagnostics
     GeantDiagnostics() = default;
 
     // Construct from shared Celeritas params on the master thread
-    explicit GeantDiagnostics(SPConstParams params);
+    explicit GeantDiagnostics(SharedParams const& params);
 
     // Initialize diagnostics on the master thread
-    inline void Initialize(SPConstParams params);
+    inline void Initialize(SharedParams const& params);
 
     // Write (shared) diagnostic output
     void Finalize();
@@ -73,7 +73,7 @@ class GeantDiagnostics
 /*!
  * Initialize diagnostics on the master thread.
  */
-void GeantDiagnostics::Initialize(SPConstParams params)
+void GeantDiagnostics::Initialize(SharedParams const& params)
 {
     *this = GeantDiagnostics(params);
 }

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -17,7 +17,6 @@
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
-#include "accel/AlongStepFactory.hh"
 #include "accel/ExceptionConverter.hh"
 #include "accel/SetupOptionsMessenger.hh"
 

--- a/app/celer-g4/PGPrimaryGeneratorAction.cc
+++ b/app/celer-g4/PGPrimaryGeneratorAction.cc
@@ -13,6 +13,7 @@
 
 #include "corecel/Macros.hh"
 #include "celeritas/ext/Convert.geant.hh"
+#include "celeritas/ext/GeantUtils.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
 
 #include "GlobalSetup.hh"
@@ -33,12 +34,8 @@ PGPrimaryGeneratorAction::PGPrimaryGeneratorAction()
     auto options = GlobalSetup::Instance()->GetPrimaryGeneratorOptions();
     CELER_ASSERT(options);
 
-    auto seed = options.seed;
-    if (G4Threading::IsMultithreadedApplication())
-    {
-        seed += G4Threading::G4GetThreadId();
-    }
-    rng_.seed(seed);
+    // Seed with an independent value for each thread
+    rng_.seed(options.seed + get_thread_id());
 
     num_events_ = options.num_events;
     primaries_per_event_ = options.primaries_per_event;

--- a/app/celer-g4/PGPrimaryGeneratorAction.cc
+++ b/app/celer-g4/PGPrimaryGeneratorAction.cc
@@ -35,7 +35,7 @@ PGPrimaryGeneratorAction::PGPrimaryGeneratorAction()
     CELER_ASSERT(options);
 
     // Seed with an independent value for each thread
-    rng_.seed(options.seed + get_thread_id());
+    rng_.seed(options.seed + get_geant_thread_id());
 
     num_events_ = options.num_events;
     primaries_per_event_ = options.primaries_per_event;

--- a/app/celer-g4/RootIO.cc
+++ b/app/celer-g4/RootIO.cc
@@ -199,7 +199,7 @@ void RootIO::Close()
  */
 void RootIO::Merge()
 {
-    auto const nthreads = get_num_threads(*G4RunManager::GetRunManager());
+    auto const nthreads = get_geant_num_threads(*G4RunManager::GetRunManager());
     std::vector<TFile*> files;
     std::vector<TTree*> trees;
     std::unique_ptr<TList> list(new TList);

--- a/app/celer-g4/RootIO.cc
+++ b/app/celer-g4/RootIO.cc
@@ -20,7 +20,7 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/io/Logger.hh"
-#include "celeritas/ext/GeantSetup.hh"
+#include "celeritas/ext/GeantUtils.hh"
 #include "accel/ExceptionConverter.hh"
 #include "accel/SetupOptions.hh"
 

--- a/app/celer-g4/RunAction.cc
+++ b/app/celer-g4/RunAction.cc
@@ -127,12 +127,12 @@ void RunAction::EndOfRunAction(G4Run const*)
             // some geant4 thread-local allocators)
             CELER_TRY_HANDLE(transport_->Finalize(), call_g4exception);
         }
+    }
 
-        if (init_shared_)
-        {
-            // Clear shared data and write
-            CELER_TRY_HANDLE(params_->Finalize(), call_g4exception);
-        }
+    if (init_shared_)
+    {
+        // Clear shared data (if any) and write output (if any)
+        CELER_TRY_HANDLE(params_->Finalize(), call_g4exception);
     }
 }
 

--- a/app/celer-g4/RunAction.hh
+++ b/app/celer-g4/RunAction.hh
@@ -48,8 +48,7 @@ class RunAction final : public G4UserRunAction
               SPParams params,
               SPTransporter transport,
               SPDiagnostics diagnostics,
-              bool init_celeritas,
-              bool init_diagnostics);
+              bool init_shared);
 
     void BeginOfRunAction(G4Run const* run) final;
     void EndOfRunAction(G4Run const* run) final;
@@ -59,8 +58,7 @@ class RunAction final : public G4UserRunAction
     SPParams params_;
     SPTransporter transport_;
     SPDiagnostics diagnostics_;
-    bool init_celeritas_;
-    bool init_diagnostics_;
+    bool init_shared_;
     Stopwatch get_transport_time_;
 };
 

--- a/app/celer-g4/RunAction.hh
+++ b/app/celer-g4/RunAction.hh
@@ -61,7 +61,6 @@ class RunAction final : public G4UserRunAction
     SPDiagnostics diagnostics_;
     bool init_celeritas_;
     bool init_diagnostics_;
-    bool disable_offloading_;
     Stopwatch get_transport_time_;
 };
 

--- a/app/celer-g4/SensitiveDetector.cc
+++ b/app/celer-g4/SensitiveDetector.cc
@@ -59,7 +59,7 @@ void SensitiveDetector::Initialize(G4HCofThisEvent* hce)
         CELER_ASSERT(hcid_ >= 0);
     }
 
-    // Save a pointer to the collection we just made before tranferring
+    // Save a pointer to the collection we just made before transferring
     // ownership to the HC manager for the event.
     collection_ = collection.get();
     hce->AddHitsCollection(hcid_, collection.release());

--- a/app/celer-g4/TimerOutput.cc
+++ b/app/celer-g4/TimerOutput.cc
@@ -10,7 +10,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/io/JsonPimpl.hh"
-#include "accel/SetupOptions.hh"
+#include "celeritas/ext/GeantUtils.hh"
 
 #if CELERITAS_USE_JSON
 #    include <nlohmann/json.hpp>
@@ -63,7 +63,7 @@ void TimerOutput::output(JsonPimpl* j) const
  */
 void TimerOutput::RecordActionTime(MapStrReal&& time)
 {
-    size_type thread_id = GetThreadID();
+    size_type thread_id = get_thread_id();
     CELER_ASSERT(thread_id < action_time_.size());
     action_time_[thread_id] = std::move(time);
 }
@@ -74,7 +74,7 @@ void TimerOutput::RecordActionTime(MapStrReal&& time)
  */
 void TimerOutput::RecordEventTime(real_type time)
 {
-    size_type thread_id = GetThreadID();
+    size_type thread_id = get_thread_id();
     CELER_ASSERT(thread_id < event_time_.size());
     event_time_[thread_id].push_back(time);
 }

--- a/app/celer-g4/TimerOutput.cc
+++ b/app/celer-g4/TimerOutput.cc
@@ -63,7 +63,7 @@ void TimerOutput::output(JsonPimpl* j) const
  */
 void TimerOutput::RecordActionTime(MapStrReal&& time)
 {
-    size_type thread_id = get_thread_id();
+    size_type thread_id = get_geant_thread_id();
     CELER_ASSERT(thread_id < action_time_.size());
     action_time_[thread_id] = std::move(time);
 }
@@ -74,7 +74,7 @@ void TimerOutput::RecordActionTime(MapStrReal&& time)
  */
 void TimerOutput::RecordEventTime(real_type time)
 {
-    size_type thread_id = get_thread_id();
+    size_type thread_id = get_geant_thread_id();
     CELER_ASSERT(thread_id < event_time_.size());
     event_time_[thread_id].push_back(time);
 }

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -48,7 +48,7 @@ void TrackingAction::PreUserTrackingAction(G4Track const* track)
     CELER_EXPECT(track);
     CELER_EXPECT(static_cast<bool>(*params_)
                  == !SharedParams::CeleritasDisabled());
-    CELER_EXPECT(static_cast<bool>(*params_) == static_cast<bool>(transport_));
+    CELER_EXPECT(static_cast<bool>(*params_) == static_cast<bool>(*transport_));
 
     if (SharedParams::CeleritasDisabled())
         return;

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -10,10 +10,6 @@
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
-#include <G4Electron.hh>
-#include <G4Gamma.hh>
-#include <G4ParticleDefinition.hh>
-#include <G4Positron.hh>
 #include <G4Track.hh>
 #include <G4TrackStatus.hh>
 
@@ -56,12 +52,8 @@ void TrackingAction::PreUserTrackingAction(G4Track const* track)
     CELER_EXPECT(*params_);
     CELER_EXPECT(*transport_);
 
-    static G4ParticleDefinition const* const allowed_particles[] = {
-        G4Gamma::Gamma(),
-        G4Electron::Electron(),
-        G4Positron::Positron(),
-    };
 
+    auto const& allowed_particles = params_->OffloadParticles();
     if (std::find(std::begin(allowed_particles),
                   std::end(allowed_particles),
                   track->GetDefinition())

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -45,13 +45,13 @@ TrackingAction::TrackingAction(SPConstParams params,
  */
 void TrackingAction::PreUserTrackingAction(G4Track const* track)
 {
-    if (SharedParams::CeleritasDisabled())
-        return;
-
     CELER_EXPECT(track);
-    CELER_EXPECT(*params_);
-    CELER_EXPECT(*transport_);
+    CELER_EXPECT(static_cast<bool>(params_)
+                 == SharedParams::CeleritasDisabled());
+    CELER_EXPECT(static_cast<bool>(params_) == static_cast<bool>(transport_));
 
+    if (!params_)
+        return;
 
     auto const& allowed_particles = params_->OffloadParticles();
     if (std::find(std::begin(allowed_particles),

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -46,11 +46,11 @@ TrackingAction::TrackingAction(SPConstParams params,
 void TrackingAction::PreUserTrackingAction(G4Track const* track)
 {
     CELER_EXPECT(track);
-    CELER_EXPECT(static_cast<bool>(params_)
+    CELER_EXPECT(static_cast<bool>(*params_)
                  == !SharedParams::CeleritasDisabled());
-    CELER_EXPECT(static_cast<bool>(params_) == static_cast<bool>(transport_));
+    CELER_EXPECT(static_cast<bool>(*params_) == static_cast<bool>(transport_));
 
-    if (!params_)
+    if (SharedParams::CeleritasDisabled())
         return;
 
     auto const& allowed_particles = params_->OffloadParticles();

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -19,7 +19,6 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
-#include "corecel/sys/Environment.hh"
 #include "accel/ExceptionConverter.hh"
 
 namespace celeritas
@@ -33,10 +32,7 @@ namespace app
 TrackingAction::TrackingAction(SPConstParams params,
                                SPTransporter transport,
                                SPDiagnostics diagnostics)
-    : params_(params)
-    , transport_(transport)
-    , diagnostics_(diagnostics)
-    , disable_offloading_(!celeritas::getenv("CELER_DISABLE").empty())
+    : params_(params), transport_(transport), diagnostics_(diagnostics)
 {
     CELER_EXPECT(params_);
     CELER_EXPECT(transport_);
@@ -53,7 +49,7 @@ TrackingAction::TrackingAction(SPConstParams params,
  */
 void TrackingAction::PreUserTrackingAction(G4Track const* track)
 {
-    if (disable_offloading_)
+    if (SharedParams::CeleritasDisabled())
         return;
 
     CELER_EXPECT(track);

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -47,7 +47,7 @@ void TrackingAction::PreUserTrackingAction(G4Track const* track)
 {
     CELER_EXPECT(track);
     CELER_EXPECT(static_cast<bool>(params_)
-                 == SharedParams::CeleritasDisabled());
+                 == !SharedParams::CeleritasDisabled());
     CELER_EXPECT(static_cast<bool>(params_) == static_cast<bool>(transport_));
 
     if (!params_)

--- a/app/celer-g4/TrackingAction.hh
+++ b/app/celer-g4/TrackingAction.hh
@@ -49,7 +49,6 @@ class TrackingAction final : public G4UserTrackingAction
     SPConstParams params_;
     SPTransporter transport_;
     SPDiagnostics diagnostics_;
-    bool disable_offloading_;
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -146,13 +146,6 @@ void run(int argc, char** argv)
     CELER_LOG(status) << "Initializing run manager";
     run_manager->Initialize();
 
-    if (!celeritas::getenv("CELER_DISABLE").empty())
-    {
-        CELER_LOG(info)
-            << "Disabling Celeritas offloading since the 'CELER_DISABLE' "
-               "environment variable is present and non-empty";
-    }
-
     auto num_events = GlobalSetup::Instance()->GetNumEvents();
     CELER_LOG(status) << "Transporting " << num_events << " events";
     run_manager->BeamOn(num_events);

--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -18,6 +18,7 @@
 #include <G4Version.hh>
 
 #include "accel/HepMC3PrimaryGenerator.hh"
+#include "accel/SharedParams.hh"
 
 #include "GlobalSetup.hh"
 
@@ -110,8 +111,12 @@ void run(int argc, char** argv)
     }
     GlobalSetup::Instance()->SetIgnoreProcesses(ignore_processes);
 
+    // Create params, which need to be shared with detectors as well as
+    // initialization
+    auto params = std::make_shared<SharedParams>();
+
     // Construct geometry, SD factory, physics, actions
-    run_manager->SetUserInitialization(new DetectorConstruction{});
+    run_manager->SetUserInitialization(new DetectorConstruction{params});
     switch (GlobalSetup::Instance()->GetPhysicsList())
     {
         case PhysicsListSelection::ftfp_bert: {
@@ -134,7 +139,7 @@ void run(int argc, char** argv)
         default:
             CELER_ASSERT_UNREACHABLE();
     }
-    run_manager->SetUserInitialization(new ActionInitialization());
+    run_manager->SetUserInitialization(new ActionInitialization(params));
 
     // Initialize run and process events
     ScopedProfiling profile_this{"celer-g4"};

--- a/app/celer-g4/test-harness.py
+++ b/app/celer-g4/test-harness.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""
+Run celer-g4.
+"""
+import json
+import re
+import subprocess
+from os import environ, path
+from pprint import pprint
+from sys import exit, argv, stderr
+
+def strtobool(text):
+    text = text.lower()
+    if text in {"true", "on", "yes", "1"}:
+        return True
+    if text in {"false", "off", "no", "0"}:
+        return False
+    raise ValueError(text)
+
+#### LOAD OPTIONS ####
+
+# Load from environment
+use_device = not strtobool(environ.get("CELER_DISABLE_DEVICE", "false"))
+use_root = strtobool(environ["CELER_USE_ROOT"])
+use_celeritas = not strtobool(environ.get("CELER_DISABLE", "false"))
+build = environ.get("CELER_BUILD_TYPE", "unknown").lower()
+ext = environ.get("CELER_TEST_EXT", "unknown")
+
+# Load from arguments
+try:
+    (exe, model_file, events_file) = argv[1:]
+except ValueError:
+    print(f"usage: {argv[0]} celer-g4 inp.gdml inp.hepmc3")
+    exit(1)
+
+problem_name = "-".join([
+    path.splitext(path.basename(model_file))[0],
+    ext
+])
+
+#### BUILD INPUT  ####
+
+offload_file = ".".join([
+    problem_name,
+    "offloaded",
+    "root" if use_root else "hepmc3"
+])
+inp_file = f"{problem_name}.inp.json"
+out_file = f"{problem_name}.out.json"
+
+if use_device:
+    if build == "release":
+        # GPU release
+        max_tracks = 2**19
+        init_capacity = 2**22
+    else:
+        # GPU debug
+        max_tracks = 2**11
+        init_capacity = 2**16
+else:
+    # CPU
+    max_tracks = 2**10
+    init_capacity = 2**15
+
+inp = {
+    "geometry_file": model_file,
+    "event_file": events_file,
+    "output_file": out_file,
+    "offload_output_file": offload_file,
+    "num_track_slots": max_tracks,
+    "max_events": 1024,
+    "initializer_capacity": init_capacity,
+    "secondary_stack_factor": 2,
+    "physics_list": "ftfp_bert",
+    "field_type": "uniform",
+    "field": [
+     0.0,
+     0.0,
+     1.0
+    ],
+    "field_options": {
+     "minimum_step": 0.0001,
+     "delta_chord": 0.025,
+     "delta_intersection": 0.001,
+     "epsilon_step": 0.01
+    },
+    "root_buffer_size": 128000,
+    "write_sd_hits": use_root,
+    "step_diagnostic": False,
+    "step_diagnostic_bins": 200
+}
+
+with open(inp_file, "w") as f:
+    json.dump(inp, f, indent=1)
+
+print("Running", exe, file=stderr)
+result = subprocess.run([exe, inp_file])
+
+if result.returncode:
+    print("fatal: run failed with error", result.returncode)
+    exit(result.returncode)
+
+with open(out_file) as f:
+    result = json.load(f)
+
+pprint(result["result"])

--- a/app/celer-sim/CMakeLists.txt
+++ b/app/celer-sim/CMakeLists.txt
@@ -55,10 +55,6 @@ if(CELERITAS_USE_ROOT)
   set(_geant_exporter_env
     "CELER_EXPORT_GEANT_EXE=$<TARGET_FILE:celer-export-geant>")
 endif()
-add_test(NAME "app/celer-sim:device"
-  COMMAND "${CELER_PYTHON}"
-  "${_driver}" "${_gdml_inp}" "${_hepmc3_inp}" "${_mctruth_out}"
-)
 set(_env
   "CELERITAS_DEMO_EXE=$<TARGET_FILE:celer-sim>"
   "${_geant_exporter_env}"
@@ -83,6 +79,10 @@ if(CELERITAS_REAL_TYPE STREQUAL "float")
   set(_needs_deps DISABLED true)
 endif()
 
+add_test(NAME "app/celer-sim:device"
+  COMMAND "${CELER_PYTHON}"
+  "${_driver}" "${_gdml_inp}" "${_hepmc3_inp}" "${_mctruth_out}"
+)
 set_tests_properties("app/celer-sim:device" PROPERTIES
   ENVIRONMENT "${_env};${CELER_G4ENV}"
   RESOURCE_LOCK gpu

--- a/app/celer-sim/CMakeLists.txt
+++ b/app/celer-sim/CMakeLists.txt
@@ -90,6 +90,7 @@ set_tests_properties("app/celer-sim:device" PROPERTIES
   LABELS "app;nomemcheck;gpu"
   ${_needs_deps}
   ${_needs_device}
+  ${CELER_NEEDS_PYTHON}
 )
 
 # Enable ROOT output for the celer-sim-cpu test when ROOT is available

--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -8,7 +8,6 @@
 import json
 import re
 import subprocess
-from distutils.util import strtobool
 from os import environ, path
 from sys import exit, argv, stderr
 
@@ -17,6 +16,14 @@ try:
 except ValueError:
     print("usage: {} inp.gdml inp.hepmc3 mctruth.root (use '' for no ROOT output)".format(argv[0]))
     exit(1)
+
+def strtobool(text):
+    text = text.lower()
+    if text in {"true", "on", "yes", "1"}:
+        return True
+    if text in {"false", "off", "no", "0"}:
+        return False
+    raise ValueError(text)
 
 # We reuse the "disable device" environment variable, which prevents the GPU
 # from being initialized at runtime.

--- a/src/accel/GeantStepDiagnostic.cc
+++ b/src/accel/GeantStepDiagnostic.cc
@@ -76,7 +76,7 @@ void GeantStepDiagnostic::Update(G4Track const* track)
         return;
     }
 
-    auto thread_id = static_cast<size_type>(get_thread_id());
+    auto thread_id = static_cast<size_type>(get_geant_thread_id());
     CELER_ASSERT(thread_id < thread_store_.size());
 
     // Get the vector of counts for this particle

--- a/src/accel/GeantStepDiagnostic.cc
+++ b/src/accel/GeantStepDiagnostic.cc
@@ -15,8 +15,8 @@
 #include "corecel/Macros.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/io/JsonPimpl.hh"
+#include "celeritas/ext/GeantUtils.hh"
 #include "accel/ExceptionConverter.hh"
-#include "accel/SetupOptions.hh"
 
 #if CELERITAS_USE_JSON
 #    include <nlohmann/json.hpp>
@@ -76,7 +76,7 @@ void GeantStepDiagnostic::Update(G4Track const* track)
         return;
     }
 
-    size_type thread_id = GetThreadID();
+    auto thread_id = static_cast<size_type>(get_thread_id());
     CELER_ASSERT(thread_id < thread_store_.size());
 
     // Get the vector of counts for this particle

--- a/src/accel/HepMC3PrimaryGenerator.cc
+++ b/src/accel/HepMC3PrimaryGenerator.cc
@@ -246,8 +246,8 @@ auto HepMC3PrimaryGenerator::read_event(size_type event_id) -> SPHepEvt
         if (static_cast<size_type>(read_evt_id) != expected_id)
         {
             CELER_LOG(warning)
-                << "HepMC3 event IDs are not consecutive from zero: ID "
-                << read_evt_id << " is not expected ID " << expected_id;
+                << "HepMC3 event IDs are not consecutive from zero: read ID "
+                << read_evt_id << " but expected ID " << expected_id;
         }
     }
 

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -20,6 +20,7 @@
 #include "corecel/sys/ScopedSignalHandler.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/ext/Convert.geant.hh"
+#include "celeritas/ext/GeantUtils.hh"
 #include "celeritas/global/detail/ActionSequence.hh"
 #include "celeritas/io/EventWriter.hh"
 #include "celeritas/io/RootEventWriter.hh"
@@ -50,7 +51,7 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
                       "thread did not call BeginOfRunAction?");
     particles_ = params.Params()->particle();
 
-    auto thread_id = GetThreadID();
+    auto thread_id = get_thread_id();
     CELER_VALIDATE(thread_id >= 0,
                    << "Geant4 ThreadID (" << thread_id
                    << ") is invalid (perhaps LocalTransporter is being built "

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -51,7 +51,7 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
                       "thread did not call BeginOfRunAction?");
     particles_ = params.Params()->particle();
 
-    auto thread_id = get_thread_id();
+    auto thread_id = get_geant_thread_id();
     CELER_VALIDATE(thread_id >= 0,
                    << "Geant4 ThreadID (" << thread_id
                    << ") is invalid (perhaps LocalTransporter is being built "

--- a/src/accel/Logger.cc
+++ b/src/accel/Logger.cc
@@ -24,7 +24,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/io/LoggerTypes.hh"
 #include "corecel/sys/MpiCommunicator.hh"
-#include "celeritas/ext/GeantSetup.hh"
+#include "celeritas/ext/GeantUtils.hh"
 
 namespace celeritas
 {

--- a/src/accel/Logger.cc
+++ b/src/accel/Logger.cc
@@ -121,7 +121,7 @@ void MtLogger::operator()(Provenance prov, LogLevel lev, std::string msg)
  */
 Logger MakeMTLogger(G4RunManager const& runman)
 {
-    Logger log(MpiCommunicator{}, MtLogger{get_num_threads(runman)});
+    Logger log(MpiCommunicator{}, MtLogger{get_geant_num_threads(runman)});
 
     log.level(log_level_from_env("CELER_LOG_LOCAL"));
     return log;

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -7,8 +7,6 @@
 //---------------------------------------------------------------------------//
 #include "SetupOptions.hh"
 
-#include <G4Threading.hh>
-
 #include "celeritas/ext/GeantGeoUtils.hh"
 
 #include "ExceptionConverter.hh"
@@ -27,20 +25,6 @@ FindVolumes(std::unordered_set<std::string> names)
     CELER_TRY_HANDLE(result = find_geant_volumes(std::move(names)),
                      call_g4exception);
     return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the thread ID.
- */
-int GetThreadID()
-{
-    // Thread ID is -1 when running serially
-    if (G4Threading::IsMultithreadedApplication())
-    {
-        return G4Threading::G4GetThreadId();
-    }
-    return 0;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -171,8 +171,5 @@ struct SetupOptions
 std::unordered_set<G4LogicalVolume const*>
     FindVolumes(std::unordered_set<std::string>);
 
-// Get the thread ID
-int GetThreadID();
-
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/accel/SetupOptionsMessenger.cc
+++ b/src/accel/SetupOptionsMessenger.cc
@@ -89,6 +89,7 @@ class CelerCommand : public G4UIcommand
     using G4UIcommand::G4UIcommand;
 
     virtual void apply(G4String const& newValue) const = 0;
+    virtual G4String get() const = 0;
 };
 
 template<class T>
@@ -124,6 +125,8 @@ class CelerParamCommand final : public CelerCommand
         // TODO: validation for non-matching types, i.e. int to unsigned
         *this->dest_ = static_cast<T>(converted);
     }
+
+    G4String get() const final { return CmdTraits::to_string(*this->dest_); }
 
   private:
     T* dest_;
@@ -224,6 +227,14 @@ void SetupOptionsMessenger::SetNewValue(G4UIcommand* cmd, G4String val)
     CELER_EXPECT(celer_cmd);
 
     celer_cmd->apply(val);
+}
+
+//---------------------------------------------------------------------------//
+//! Get the value of the given command
+G4String SetupOptionsMessenger::GetCurrentValue(G4UIcommand* cmd)
+{
+    auto* celer_cmd = dynamic_cast<CelerCommand*>(cmd);
+    return celer_cmd->get();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/SetupOptionsMessenger.hh
+++ b/src/accel/SetupOptionsMessenger.hh
@@ -65,6 +65,7 @@ class SetupOptionsMessenger : public G4UImessenger
 
   protected:
     void SetNewValue(G4UIcommand* command, G4String newValue) override;
+    G4String GetCurrentValue(G4UIcommand* command) override;
 
   private:
     std::vector<std::unique_ptr<G4UIdirectory>> directories_;

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -146,6 +146,20 @@ build_g4_particles(std::shared_ptr<ParticleParams const> const& particles,
 //---------------------------------------------------------------------------//
 }  // namespace
 
+bool SharedParams::CeleritasDisabled()
+{
+    static bool const result = [] {
+        if (celeritas::getenv("CELER_DISABLE").empty())
+            return false;
+
+        CELER_LOG(info)
+            << "Disabling Celeritas offloading since the 'CELER_DISABLE' "
+               "environment variable is present and non-empty";
+        return true;
+    }();
+    return result;
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Set up Celeritas using Geant4 data.

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -33,7 +33,7 @@
 #include "celeritas/Types.hh"
 #include "celeritas/ext/GeantGeoParams.hh"
 #include "celeritas/ext/GeantImporter.hh"
-#include "celeritas/ext/GeantSetup.hh"
+#include "celeritas/ext/GeantUtils.hh"
 #include "celeritas/ext/RootExporter.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"
 #include "celeritas/geo/GeoParams.hh"

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -257,6 +257,8 @@ void SharedParams::InitializeWorker(SetupOptions const&)
  */
 void SharedParams::Finalize()
 {
+    std::lock_guard scoped_lock{updating_mutex()};
+
     // Output at end of run
     this->try_output();
 

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -303,7 +303,7 @@ int SharedParams::num_streams() const
                            << "G4RunManager was not created before "
                               "getting stream count from SharedParams");
             const_cast<SharedParams*>(this)->num_streams_
-                = celeritas::get_num_threads(*run_man);
+                = celeritas::get_geant_num_threads(*run_man);
         }
     }
 

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -183,6 +183,10 @@ bool SharedParams::CeleritasDisabled()
 SharedParams::SharedParams(SetupOptions const& options)
 {
     CELER_EXPECT(!*this);
+    CELER_VALIDATE(!CeleritasDisabled(),
+                   << "Celeritas shared params cannot be initialized when "
+                      "Celeritas offloading is disabled via "
+                      "\"CELER_DISABLE\"");
 
     CELER_LOG_LOCAL(status) << "Initializing Celeritas shared data";
     ScopedProfiling profile_this{"construct-params"};
@@ -245,6 +249,11 @@ SharedParams::SharedParams(SetupOptions const& options)
  */
 void SharedParams::InitializeWorker(SetupOptions const&)
 {
+    CELER_VALIDATE(!CeleritasDisabled(),
+                   << "Celeritas shared params cannot be initialized when "
+                      "Celeritas offloading is disabled via "
+                      "\"CELER_DISABLE\"");
+
     celeritas::activate_device_local();
 }
 

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -562,6 +562,13 @@ void SharedParams::try_output() const
         CELER_LOG(debug) << "Setting default Celeritas output filename";
     }
 
+    if (filename.empty())
+    {
+        CELER_LOG(debug) << "Skipping output: SetupOptions::output_file is "
+                            "empty";
+        return;
+    }
+
     if (CELERITAS_USE_JSON)
     {
         CELER_LOG(info) << "Writing Geant4 diagnostic output to \"" << filename

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -555,13 +555,21 @@ void SharedParams::try_output() const
         return;
     }
 
-    G4UImanager* ui = G4UImanager::GetUIpointer();
-    std::string filename = ui->GetCurrentValues("/celer/outputFile");
+    std::string filename = output_filename_;
     if (CELERITAS_USE_JSON && !params_ && filename.empty())
     {
         // Setup was not called but JSON is available: make a default filename
-        filename = "celeritas.json";
-        CELER_LOG(debug) << "Setting default Celeritas output filename";
+        G4UImanager* ui = G4UImanager::GetUIpointer();
+        filename = ui->GetCurrentValues("/celer/outputFile");
+        if (!filename.empty())
+        {
+            CELER_LOG(debug) << "Set Celeritas output filename from G4UI";
+        }
+        else
+        {
+            filename = "celeritas.json";
+            CELER_LOG(debug) << "Set default Celeritas output filename";
+        }
     }
 
     if (filename.empty())

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -18,6 +18,7 @@
 #include <G4ParticleTable.hh>
 #include <G4RunManager.hh>
 #include <G4Threading.hh>
+#include <G4UImanager.hh>
 
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
@@ -286,7 +287,7 @@ void SharedParams::Finalize()
 
 //---------------------------------------------------------------------------//
 /*!
- * Lazily created output registry.
+ * Lazily obtained number of streams.
  */
 int SharedParams::num_streams() const
 {
@@ -554,7 +555,8 @@ void SharedParams::try_output() const
         return;
     }
 
-    std::string filename = output_filename_;
+    G4UImanager* ui = G4UImanager::GetUIpointer();
+    std::string filename = ui->GetCurrentValues("/celer/outputFile");
     if (CELERITAS_USE_JSON && !params_ && filename.empty())
     {
         // Setup was not called but JSON is available: make a default filename

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -26,6 +26,7 @@ class CoreParams;
 struct Primary;
 struct SetupOptions;
 class StepCollector;
+class GeantGeoParams;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -87,6 +88,7 @@ class SharedParams
 
     using SPHitManager = std::shared_ptr<detail::HitManager>;
     using SPOffloadWriter = std::shared_ptr<detail::OffloadWriter>;
+    using SPConstGeantGeoParams = std::shared_ptr<GeantGeoParams const>;
 
     //! Hit manager, to be used only by LocalTransporter
     SPHitManager const& hit_manager() const { return hit_manager_; }
@@ -94,6 +96,8 @@ class SharedParams
     //! Optional offload writer, only for use by LocalTransporter
     SPOffloadWriter const& offload_writer() const { return offload_writer_; }
 
+    // Geant geometry wrapper, lazily created
+    SPConstGeantGeoParams const& geant_geo_params() const;
     //!@}
 
   private:
@@ -105,6 +109,7 @@ class SharedParams
     VecG4ParticleDef particles_;
     std::string output_filename_;
     SPOffloadWriter offload_writer_;
+    SPConstGeantGeoParams geant_geo_;
 
     //// HELPER FUNCTIONS ////
 

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -27,6 +27,7 @@ struct Primary;
 struct SetupOptions;
 class StepCollector;
 class GeantGeoParams;
+class OutputRegistry;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -86,10 +87,10 @@ class SharedParams
     // Access constructed Celeritas data
     inline SPConstParams Params() const;
 
-    //! Get a vector of particles supported by Celeritas offloading
+    // Get a vector of particles supported by Celeritas offloading
     inline VecG4ParticleDef const& OffloadParticles() const;
 
-    //! Whether this instance is initialized
+    //! Whether Celeritas core params have been created
     explicit operator bool() const { return static_cast<bool>(params_); }
 
     //!@}
@@ -98,30 +99,39 @@ class SharedParams
 
     using SPHitManager = std::shared_ptr<detail::HitManager>;
     using SPOffloadWriter = std::shared_ptr<detail::OffloadWriter>;
+    using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
     using SPConstGeantGeoParams = std::shared_ptr<GeantGeoParams const>;
 
-    //! Hit manager, to be used only by LocalTransporter
-    SPHitManager const& hit_manager() const { return hit_manager_; }
+    // Hit manager, to be used only by LocalTransporter
+    inline SPHitManager const& hit_manager() const;
 
-    //! Optional offload writer, only for use by LocalTransporter
-    SPOffloadWriter const& offload_writer() const { return offload_writer_; }
+    // Optional offload writer, only for use by LocalTransporter
+    inline SPOffloadWriter const& offload_writer() const;
+
+    // Number of streams, lazily obtained from run manager
+    int num_streams() const;
+
+    // Output registry, lazily created
+    SPOutputRegistry const& output_reg() const;
 
     // Geant geometry wrapper, lazily created
     SPConstGeantGeoParams const& geant_geo_params() const;
-
-    // Output params, lazily created (or built during construction)
-
     //!@}
 
   private:
     //// DATA ////
 
+    // Created during initialization
     std::shared_ptr<CoreParams> params_;
     SPHitManager hit_manager_;
     std::shared_ptr<StepCollector> step_collector_;
     VecG4ParticleDef particles_;
     std::string output_filename_;
     SPOffloadWriter offload_writer_;
+
+    // Lazily created
+    int num_streams_{0};
+    SPOutputRegistry output_reg_;
     SPConstGeantGeoParams geant_geo_;
 
     //// HELPER FUNCTIONS ////
@@ -161,6 +171,26 @@ auto SharedParams::OffloadParticles() const -> VecG4ParticleDef const&
 {
     CELER_EXPECT(*this);
     return particles_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Hit manager, to be used only by LocalTransporter.
+ */
+auto SharedParams::hit_manager() const -> SPHitManager const&
+{
+    CELER_EXPECT(*this);
+    return hit_manager_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Optional offload writer, only for use by LocalTransporter.
+ */
+auto SharedParams::offload_writer() const -> SPOffloadWriter const&
+{
+    CELER_EXPECT(*this);
+    return offload_writer_;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -32,6 +32,10 @@ class GeantGeoParams;
 /*!
  * Shared (one instance for all threads) Celeritas problem data.
  *
+ * The \c CeleritasDisabled accessor queries the \c CELER_DISABLE environment
+ * variable as a global option for disabling Celeritas offloading. This is
+ * implemented by \c SimpleOffload
+ *
  * This should be instantiated on the master thread during problem setup,
  * preferably as a shared pointer. The shared pointer should be
  * passed to a thread-local \c LocalTransporter instance. At the beginning of
@@ -40,6 +44,9 @@ class GeantGeoParams;
  * structures (geometry, physics). \c InitializeWorker must subsequently be
  * invoked on all worker threads to set up thread-local data (specifically,
  * CUDA device initialization).
+ *
+ * Some low-level objects, such as the output diagnostics and Geant4 geometry
+ * wrapper, can be created independently of Celeritas being enabled.
  */
 class SharedParams
 {
@@ -53,6 +60,9 @@ class SharedParams
   public:
     //!@{
     //! \name Construction
+
+    // True if Celeritas is globally disabled using the CELER_DISABLE env
+    static bool CeleritasDisabled();
 
     // Construct in an uninitialized state
     SharedParams() = default;
@@ -98,6 +108,9 @@ class SharedParams
 
     // Geant geometry wrapper, lazily created
     SPConstGeantGeoParams const& geant_geo_params() const;
+
+    // Output params, lazily created (or built during construction)
+
     //!@}
 
   private:

--- a/src/accel/SimpleOffload.cc
+++ b/src/accel/SimpleOffload.cc
@@ -46,12 +46,9 @@ SimpleOffload::SimpleOffload(SetupOptions const* setup,
             celeritas::self_logger() = celeritas::MakeMTLogger(*run_man);
         }
     }
-    if (!celeritas::getenv("CELER_DISABLE").empty())
+    if (SharedParams::CeleritasDisabled())
     {
-        using LL = celeritas::LogLevel;
-        celeritas::self_logger()(CELER_CODE_PROVENANCE,
-                                 G4Threading::IsMasterThread() ? LL::info
-                                                               : LL::debug)
+        CELER_LOG_LOCAL(debug)
             << "Disabling Celeritas offloading since the 'CELER_DISABLE' "
                "environment variable is present and non-empty";
         *this = {};

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -117,6 +117,7 @@ if(CELERITAS_USE_Geant4)
     ext/GeantGeoUtils.cc
     ext/GeantImporter.cc
     ext/GeantSetup.cc
+    ext/GeantUtils.cc
     ext/GeantVolumeMapper.cc
     ext/ScopedGeantExceptionHandler.cc
     ext/ScopedGeantLogger.cc

--- a/src/celeritas/ext/GeantSetup.cc
+++ b/src/celeritas/ext/GeantSetup.cc
@@ -10,19 +10,15 @@
 #include <memory>
 #include <utility>
 #include <G4ParticleTable.hh>
+#include <G4RunManager.hh>
 #include <G4VPhysicalVolume.hh>
 #include <G4VUserDetectorConstruction.hh>
 #include <G4Version.hh>
-
 #if G4VERSION_NUMBER >= 1070
 #    include <G4Backtrace.hh>
-#else
-#    include <G4MTRunManager.hh>
 #endif
 #if G4VERSION_NUMBER >= 1100
 #    include <G4RunManagerFactory.hh>
-#else
-#    include <G4RunManager.hh>
 #endif
 
 #include "corecel/io/Logger.hh"
@@ -60,28 +56,6 @@ class DetectorConstruction : public G4VUserDetectorConstruction
 
 //---------------------------------------------------------------------------//
 }  // namespace
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the number of threads in a version-portable way.
- *
- * G4RunManager::GetNumberOfThreads isn't virtual before Geant4 v10.7.0 so we
- * need to explicitly dynamic cast to G4MTRunManager to get the number of
- * threads.
- */
-int get_num_threads(G4RunManager const& runman)
-{
-#if G4VERSION_NUMBER >= 1070
-    return runman.GetNumberOfThreads();
-#else
-    if (auto const* runman_mt = dynamic_cast<G4MTRunManager const*>(&runman))
-    {
-        return runman_mt->GetNumberOfThreads();
-    }
-    // Not multithreaded
-    return 1;
-#endif
-}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/ext/GeantSetup.hh
+++ b/src/celeritas/ext/GeantSetup.hh
@@ -80,9 +80,6 @@ class GeantSetup
 
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS
-//---------------------------------------------------------------------------//
-// Get the number of threads in a version-portable way
-int get_num_threads(G4RunManager const&);
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
@@ -107,11 +104,6 @@ inline GeantSetup::GeantSetup(std::string const&, Options)
 inline GeantSetup::~GeantSetup() = default;
 
 inline void GeantSetup::RMDeleter::operator()(G4RunManager*) const
-{
-    CELER_ASSERT_UNREACHABLE();
-}
-
-inline int get_num_threads(G4RunManager const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/ext/GeantUtils.cc
+++ b/src/celeritas/ext/GeantUtils.cc
@@ -27,7 +27,7 @@ namespace celeritas
  * need to explicitly dynamic cast to G4MTRunManager to get the number of
  * threads.
  */
-int get_num_threads(G4RunManager const& runman)
+int get_geant_num_threads(G4RunManager const& runman)
 {
     // Default is 1 if not multithreaded
     int result{1};
@@ -47,7 +47,7 @@ int get_num_threads(G4RunManager const& runman)
 /*!
  * Get the Geant4 thread ID.
  */
-int get_thread_id()
+int get_geant_thread_id()
 {
     // Thread ID is -1 when running serially
     if (G4Threading::IsMultithreadedApplication())

--- a/src/celeritas/ext/GeantUtils.cc
+++ b/src/celeritas/ext/GeantUtils.cc
@@ -1,0 +1,61 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/GeantUtils.cc
+//---------------------------------------------------------------------------//
+#include "GeantUtils.hh"
+
+#include <G4RunManager.hh>
+#include <G4Threading.hh>
+#include <G4Version.hh>
+
+#if G4VERSION_NUMBER < 1070
+#    include <G4MTRunManager.hh>
+#endif
+
+#include "corecel/Assert.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Get the number of threads in a version-portable way.
+ *
+ * G4RunManager::GetNumberOfThreads isn't virtual before Geant4 v10.7.0 so we
+ * need to explicitly dynamic cast to G4MTRunManager to get the number of
+ * threads.
+ */
+int get_num_threads(G4RunManager const& runman)
+{
+    // Default is 1 if not multithreaded
+    int result{1};
+#if G4VERSION_NUMBER >= 1070
+    result = runman.GetNumberOfThreads();
+#else
+    if (auto const* runman_mt = dynamic_cast<G4MTRunManager const*>(&runman))
+    {
+        result = runman_mt->GetNumberOfThreads();
+    }
+#endif
+    CELER_ENSURE(result > 0);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the Geant4 thread ID.
+ */
+int get_thread_id()
+{
+    // Thread ID is -1 when running serially
+    if (G4Threading::IsMultithreadedApplication())
+    {
+        return G4Threading::G4GetThreadId();
+    }
+    return 0;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/ext/GeantUtils.hh
+++ b/src/celeritas/ext/GeantUtils.hh
@@ -16,22 +16,22 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 // Get the number of threads in a version-portable way
-int get_num_threads(G4RunManager const&);
+int get_geant_num_threads(G4RunManager const&);
 
 //---------------------------------------------------------------------------//
 // Get the current thread ID (zero if serial)
-int get_thread_id();
+int get_geant_thread_id();
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_GEANT4
-inline int get_num_threads(G4RunManager const&)
+inline int get_geant_num_threads(G4RunManager const&)
 {
     CELER_NOT_CONFIGURED("Geant4");
 }
 
-inline int get_thread_id()
+inline int get_geant_thread_id()
 {
     CELER_NOT_CONFIGURED("Geant4");
 }

--- a/src/celeritas/ext/GeantUtils.hh
+++ b/src/celeritas/ext/GeantUtils.hh
@@ -1,0 +1,40 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/GeantUtils.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "celeritas_config.h"
+#include "corecel/Assert.hh"
+
+class G4RunManager;
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+// Get the number of threads in a version-portable way
+int get_num_threads(G4RunManager const&);
+
+//---------------------------------------------------------------------------//
+// Get the current thread ID (zero if serial)
+int get_thread_id();
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+#if !CELERITAS_USE_GEANT4
+inline int get_num_threads(G4RunManager const&)
+{
+    CELER_NOT_CONFIGURED("Geant4");
+}
+
+inline int get_thread_id()
+{
+    CELER_NOT_CONFIGURED("Geant4");
+}
+#endif
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/ext/detail/GeantGeoNavCollection.cc
+++ b/src/celeritas/ext/detail/GeantGeoNavCollection.cc
@@ -40,7 +40,7 @@ void GeantGeoNavCollection<Ownership::value, MemSpace::host>::resize(
     size_type size, G4VPhysicalVolume* world, StreamId sid)
 {
     CELER_EXPECT(world);
-    CELER_EXPECT(sid.get() == static_cast<size_type>(get_thread_id()));
+    CELER_EXPECT(sid.get() == static_cast<size_type>(get_geant_thread_id()));
 
     // Add navigation states to collection
     this->touch_handles.resize(size);

--- a/src/celeritas/ext/detail/GeantGeoNavCollection.cc
+++ b/src/celeritas/ext/detail/GeantGeoNavCollection.cc
@@ -8,12 +8,12 @@
 #include "GeantGeoNavCollection.hh"
 
 #include <G4Navigator.hh>
-#include <G4Threading.hh>
 #include <G4TouchableHandle.hh>
 #include <G4TouchableHistory.hh>
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
+#include "celeritas/ext/GeantUtils.hh"
 
 namespace celeritas
 {
@@ -40,9 +40,7 @@ void GeantGeoNavCollection<Ownership::value, MemSpace::host>::resize(
     size_type size, G4VPhysicalVolume* world, StreamId sid)
 {
     CELER_EXPECT(world);
-    CELER_EXPECT(
-        !G4Threading::IsMultithreadedApplication()
-        || sid.get() == static_cast<size_type>(G4Threading::G4GetThreadId()));
+    CELER_EXPECT(sid.get() == static_cast<size_type>(get_thread_id()));
 
     // Add navigation states to collection
     this->touch_handles.resize(size);

--- a/src/celeritas/user/SimpleCalo.cc
+++ b/src/celeritas/user/SimpleCalo.cc
@@ -16,7 +16,7 @@
 #include "corecel/io/Join.hh"
 #include "corecel/io/Label.hh"
 #include "corecel/io/Logger.hh"
-#include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
+#include "orange/GeoParamsInterface.hh"  // IWYU pragma: keep
 
 #include "detail/SimpleCaloImpl.hh"
 
@@ -32,7 +32,7 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
-VolumeId find_volume_fuzzy(GeoParams const& geo, Label const& label)
+VolumeId find_volume_fuzzy(GeoParamsInterface const& geo, Label const& label)
 {
     if (auto id = geo.find_volume(label))
     {
@@ -76,11 +76,13 @@ VolumeId find_volume_fuzzy(GeoParams const& geo, Label const& label)
 /*!
  * Construct with sensitive regions.
  */
-SimpleCalo::SimpleCalo(VecLabel labels,
-                       GeoParams const& geo,
+SimpleCalo::SimpleCalo(std::string output_label,
+                       VecLabel labels,
+                       GeoParamsInterface const& geo,
                        size_type num_streams)
-    : volume_labels_{std::move(labels)}
+    : output_label_{std::move(output_label)}, volume_labels_{std::move(labels)}
 {
+    CELER_EXPECT(!output_label_.empty());
     CELER_EXPECT(!volume_labels_.empty());
     CELER_EXPECT(num_streams > 0);
 

--- a/src/celeritas/user/SimpleCalo.hh
+++ b/src/celeritas/user/SimpleCalo.hh
@@ -9,12 +9,13 @@
 
 #include <vector>
 
+#include "corecel/Types.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/data/StreamStore.hh"
+#include "corecel/io/Label.hh"
 #include "corecel/io/OutputInterface.hh"
 #include "celeritas/Quantities.hh"
-#include "celeritas/geo/GeoFwd.hh"
 #include "celeritas/user/StepInterface.hh"
 
 #include "SimpleCaloData.hh"
@@ -22,11 +23,14 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-struct Label;
+class GeoParamsInterface;
 
 //---------------------------------------------------------------------------//
 /*!
  * Accumulate energy deposition in volumes.
+ *
+ * \todo Add a "begin run" interface to set up the stream store, rather than
+ * passing in number of streams at construction time.
  */
 class SimpleCalo final : public StepInterface, public OutputInterface
 {
@@ -42,8 +46,19 @@ class SimpleCalo final : public StepInterface, public OutputInterface
     //!@}
 
   public:
-    // Construct with sensitive regions
-    SimpleCalo(VecLabel labels, GeoParams const& geo, size_type max_streams);
+    // Construct with all requirements
+    SimpleCalo(std::string output_label,
+               VecLabel labels,
+               GeoParamsInterface const& geo,
+               size_type max_streams);
+
+    //! Construct with default label
+    SimpleCalo(VecLabel labels,
+               GeoParamsInterface const& geo,
+               size_type max_streams)
+        : SimpleCalo{"simple_calo", std::move(labels), geo, max_streams}
+    {
+    }
 
     //!@{
     //! \name Step interface
@@ -62,7 +77,7 @@ class SimpleCalo final : public StepInterface, public OutputInterface
     // Category of data to write
     Category category() const final { return Category::result; }
     // Key for the entry inside the category.
-    std::string label() const final { return "simple_calo"; }
+    std::string label() const final { return output_label_; }
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;
     //!@}
@@ -87,6 +102,7 @@ class SimpleCalo final : public StepInterface, public OutputInterface
   private:
     using StoreT = StreamStore<SimpleCaloParamsData, SimpleCaloStateData>;
 
+    std::string output_label_;
     VecLabel volume_labels_;
     std::vector<VolumeId> volume_ids_;
     StoreT store_;

--- a/src/celeritas/user/StepCollector.hh
+++ b/src/celeritas/user/StepCollector.hh
@@ -39,6 +39,9 @@ struct StepStorage;
  * detectors" (mapping volume IDs to detector IDs and ignoring unmapped
  * volumes) and supporting unfiltered output for "MC truth" . Right now only
  * one or the other can be used, not both.
+ *
+ * \todo Add a "begin run" interface to set up the stream store, rather than
+ * passing in number of streams at construction time.
  */
 class StepCollector
 {

--- a/test/celeritas/user/CaloTestBase.cc
+++ b/test/celeritas/user/CaloTestBase.cc
@@ -10,10 +10,9 @@
 #include <iostream>
 
 #include "corecel/cont/Span.hh"
+#include "celeritas/geo/GeoParams.hh"
 #include "celeritas/user/SimpleCalo.hh"
 #include "celeritas/user/StepCollector.hh"
-
-using std::cout;
 
 namespace celeritas
 {
@@ -50,6 +49,8 @@ void CaloTestBase::SetUp()
 //! Print the expected result
 void CaloTestBase::RunResult::print_expected() const
 {
+    using std::cout;
+
     cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
             "static const double expected_edep[] = "
          << repr(this->edep)

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -10,6 +10,7 @@
 #include "corecel/cont/Span.hh"
 #include "corecel/io/LogContextException.hh"
 #include "celeritas/em/UrbanMscParams.hh"
+#include "celeritas/geo/GeoParams.hh"
 #include "celeritas/global/ActionRegistry.hh"
 #include "celeritas/global/Stepper.hh"
 #include "celeritas/global/alongstep/AlongStepUniformMscAction.hh"


### PR DESCRIPTION
This is a minor refactor of the `celer-g4` app's `DetectorConstruction` in preparation for adding a Celeritas-based simple calorimeter (which will still work with Celeritas disabled). Changes include:
- `SharedParams` can now "lazily" create several helper objects (Geant geometry wrapper, output registry, stream count) that are needed by Celeritas classes that can be used in standalone Geant4
- `SharedParams::Finalize()` should now be called even when Celeritas is disabled: this now writes diagnostic output, and defaults to a `celeritas.json` filename if none is available
- Geant diagnostics now outputs the build information if Celeritas is disabled
- A new `static bool SharedParams::CeleritasDisabled` hides and standardizes the `CELER_DISABLE` environment variable

As part of the simple calorimeter work:
- Simple calo now allows an optional label rather than a hardcoded one
- Detector construction now takes shared params
- The `DetectorContsruction::Construct()` method has been split up into functions for loading geometry and field

I also moved `GetThreadId` out of `SetupOptions` into a separate celeritas utility, consolidating it with `get_num_threads` formerly in `GeantSetup`, and moving both into a new `celeritas/ext/GeantUtils.hh` directory.