### PR TITLE
Explicitely set shared mem carveout

### DIFF
--- a/src/corecel/sys/KernelAttributes.hh
+++ b/src/corecel/sys/KernelAttributes.hh
@@ -36,6 +36,9 @@ struct KernelAttributes
     int num_regs{0};  //!< Number of 32-bit registers per thread
     std::size_t const_mem{0};  //!< Amount of constant memory (per thread) [b]
     std::size_t local_mem{0};  //!< Amount of local memory (per thread) [b]
+    std::size_t shared_mem{0};  //!< Amount of shared memory (per block) [b]
+    int shared_mem_carveout{0};  //!< % of L1/shared mem attributed to shared
+                                 //!< mem
 
     unsigned int max_threads_per_block{0};  //!< Max allowed threads per block
     unsigned int max_blocks_per_cu{0};  //!< Occupancy (compute unit)
@@ -76,6 +79,8 @@ make_kernel_attributes(F* func, unsigned int threads_per_block = 0)
         result.num_regs = attr.numRegs;
         result.const_mem = attr.constSizeBytes;
         result.local_mem = attr.localSizeBytes;
+        result.shared_mem = attr.sharedSizeBytes;
+        result.shared_mem_carveout = attr.preferredShmemCarveout;
         result.max_threads_per_block = attr.maxThreadsPerBlock;
     }
 

--- a/src/corecel/sys/KernelParamCalculator.device.hh
+++ b/src/corecel/sys/KernelParamCalculator.device.hh
@@ -230,7 +230,7 @@ void KernelParamCalculator::set_carveout(F* kernel_func_ptr,
     if (!attrs.shared_mem)
     {
         CELER_DEVICE_CALL_PREFIX(FuncSetAttribute(
-            kernel_func_ptr,
+            reinterpret_cast<void const*>(kernel_func_ptr),
             CELER_DEVICE_PREFIX(FuncAttributePreferredSharedMemoryCarveout),
             0));
         attrs.shared_mem_carveout = 0;

--- a/src/corecel/sys/KernelParamCalculator.device.hh
+++ b/src/corecel/sys/KernelParamCalculator.device.hh
@@ -236,6 +236,9 @@ void KernelParamCalculator::set_carveout(F* kernel_func_ptr) const
             CELER_DEVICE_PREFIX(FuncAttributePreferredSharedMemoryCarveout),
             CELER_DEVICE_PREFIX(SharedmemCarveoutMaxL1)));
     }
+#else
+    CELER_DISCARD(kernel_func_ptr);
+    CELER_ASSERT_UNREACHABLE();
 #endif
 }
 

--- a/src/corecel/sys/KernelParamCalculator.device.hh
+++ b/src/corecel/sys/KernelParamCalculator.device.hh
@@ -237,6 +237,7 @@ void KernelParamCalculator::set_carveout(F* kernel_func_ptr,
     }
 #else
     CELER_DISCARD(kernel_func_ptr);
+    CELER_DISCARD(attrs);
     CELER_ASSERT_UNREACHABLE();
 #endif
 }

--- a/src/corecel/sys/KernelRegistry.cc
+++ b/src/corecel/sys/KernelRegistry.cc
@@ -100,12 +100,14 @@ std::ostream& operator<<(std::ostream& os, KernelMetadata const& md)
 {
     // clang-format off
     os << "{\n"
-        "  name: \""            << md.name              << "\",\n"
-        "  num_regs: "          << md.attributes.num_regs          << ",\n"
-        "  const_mem: "         << md.attributes.const_mem         << ",\n"
-        "  local_mem: "         << md.attributes.local_mem         << ",\n"
-        "  threads_per_block: " << md.attributes.threads_per_block << ",\n"
-        "  occupancy: "         << md.attributes.occupancy;
+        "  name: \""              << md.name              << "\",\n"
+        "  num_regs: "            << md.attributes.num_regs          << ",\n"
+        "  const_mem: "           << md.attributes.const_mem         << ",\n"
+        "  local_mem: "           << md.attributes.local_mem         << ",\n"
+        "  shared_mem: "          << md.attributes.shared_mem        << ",\n"
+        "  threads_per_block: "   << md.attributes.threads_per_block << ",\n"
+        "  occupancy: "           << md.attributes.occupancy         << ",\n"
+        "  shared_mem_carveout: " << md.attributes.shared_mem_carveout;
     if (KernelRegistry::profiling())
     {
         os << ",\n"

--- a/src/corecel/sys/KernelRegistryIO.json.cc
+++ b/src/corecel/sys/KernelRegistryIO.json.cc
@@ -29,12 +29,14 @@ void to_json(nlohmann::json& j, KernelAttributes const& attrs)
         {"num_regs", attrs.num_regs},
         {"const_mem", attrs.const_mem},
         {"local_mem", attrs.local_mem},
+        {"shared_mem", attrs.shared_mem},
         {"max_threads_per_block", attrs.max_threads_per_block},
         {"max_blocks_per_cu", attrs.max_blocks_per_cu},
         {"max_warps_per_eu", attrs.max_warps_per_eu},
         {"occupancy", attrs.occupancy},
         {"heap_size", attrs.heap_size},
         {"print_buffer_size", attrs.print_buffer_size},
+        {"shared_mem_carveout", attrs.shared_mem_carveout},
     };
     if constexpr (CELERITAS_USE_CUDA)
     {


### PR DESCRIPTION
Since Celeritas kernels don't use shared memory, explicitly set the shared memory carveout to 0 to maximize L1 cache size for devices sharing L1/shmem data cache. 

Still need to check the performance impact.