### PR TITLE
Add G4SD "simple calorimeter" that outputs to JSON

### DIFF
--- a/app/celer-g4/DetectorConstruction.hh
+++ b/app/celer-g4/DetectorConstruction.hh
@@ -20,6 +20,7 @@ class G4MagneticField;
 namespace celeritas
 {
 class SharedParams;
+class GeantSimpleCalo;
 
 namespace app
 {
@@ -49,6 +50,7 @@ class DetectorConstruction final : public G4VUserDetectorConstruction
     using MapDetectors = std::multimap<std::string, G4LogicalVolume*>;
     using AlongStepFactory = SetupOptions::AlongStepFactory;
     using SPMagneticField = std::shared_ptr<G4MagneticField>;
+    using SPSimpleCalo = std::shared_ptr<GeantSimpleCalo>;
 
     struct GeoData
     {
@@ -67,6 +69,7 @@ class DetectorConstruction final : public G4VUserDetectorConstruction
 
     MapDetectors detectors_;
     SPMagneticField mag_field_;
+    std::vector<SPSimpleCalo> simple_calos_;
 
     //// METHODS ////
 

--- a/app/celer-g4/RunInput.cc
+++ b/app/celer-g4/RunInput.cc
@@ -35,6 +35,7 @@ char const* to_cstring(SensitiveDetectorType value)
 {
     static EnumStringMapper<SensitiveDetectorType> const to_cstring_impl{
         "none",
+        "simple_calo",
         "event_hit",
     };
     return to_cstring_impl(value);

--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -33,6 +33,7 @@ enum class PhysicsListSelection
 enum class SensitiveDetectorType
 {
     none,  //!< No SDs
+    simple_calo,  //!< Integrated energy deposition over all events
     event_hit,  //!< Record basic hit data
     size_,
 };

--- a/app/celer-g4/test-harness.py
+++ b/app/celer-g4/test-harness.py
@@ -76,25 +76,22 @@ inp = {
     "secondary_stack_factor": 2,
     "physics_list": "ftfp_bert",
     "field_type": "uniform",
-    "field": [
-     0.0,
-     0.0,
-     1.0
-    ],
+    "field": [ 0.0, 0.0, 1.0 ],
     "field_options": {
      "minimum_step": 0.0001,
      "delta_chord": 0.025,
      "delta_intersection": 0.001,
-     "epsilon_step": 0.01
+     "epsilon_step": 0.01,
     },
+    "sd_type": "event_hit" if use_root else "simple_calo",
     "step_diagnostic": ext == "none",
-    "step_diagnostic_bins": 10
+    "step_diagnostic_bins": 8,
 }
 
 with open(inp_file, "w") as f:
     json.dump(inp, f, indent=1)
 
-print("Running", exe, file=stderr)
+print("Running", exe, inp_file, file=stderr)
 result = subprocess.run([exe, inp_file])
 
 if result.returncode:

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -15,6 +15,7 @@ set(PUBLIC_DEPS Celeritas::celeritas Celeritas::corecel ${Geant4_LIBRARIES})
 list(APPEND SOURCES
   AlongStepFactory.cc
   FastSimulationOffload.cc
+  GeantSimpleCalo.cc
   GeantStepDiagnostic.cc
   Logger.cc
   LocalTransporter.cc
@@ -22,6 +23,7 @@ list(APPEND SOURCES
   SetupOptionsMessenger.cc
   SharedParams.cc
   SimpleOffload.cc
+  detail/GeantSimpleCaloSD.cc
   detail/HitManager.cc
   detail/HitProcessor.cc
   detail/SensDetInserter.cc

--- a/src/accel/GeantSimpleCalo.cc
+++ b/src/accel/GeantSimpleCalo.cc
@@ -179,7 +179,7 @@ std::string GeantSimpleCalo::label() const
 
 //---------------------------------------------------------------------------//
 /*!
- * Allocate storage space for all threads.
+ * Write output to the given JSON object.
  */
 void GeantSimpleCalo::output(JsonPimpl* j) const
 {

--- a/src/accel/GeantSimpleCalo.cc
+++ b/src/accel/GeantSimpleCalo.cc
@@ -1,0 +1,248 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/GeantSimpleCalo.cc
+//---------------------------------------------------------------------------//
+#include "GeantSimpleCalo.hh"
+
+#include <mutex>
+
+#include "corecel/cont/Range.hh"
+#include "corecel/io/Logger.hh"
+#include "celeritas/ext/GeantGeoParams.hh"
+#include "celeritas/ext/GeantGeoUtils.hh"
+#include "celeritas/ext/GeantUtils.hh"
+
+#include "SharedParams.hh"
+#include "detail/GeantSimpleCaloSD.hh"
+#include "detail/GeantSimpleCaloStorage.hh"
+
+#if CELERITAS_USE_JSON
+#    include <nlohmann/json.hpp>
+
+#    include "corecel/io/JsonPimpl.hh"
+#    include "corecel/io/LabelIO.json.hh"
+#endif
+
+namespace celeritas
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+//! Sensitive detector present on manager thread (never used)
+class DummyGeantSimpleCaloSD : public G4VSensitiveDetector
+{
+  public:
+    // Construct with name and shared params
+    DummyGeantSimpleCaloSD(std::string const& name)
+        : G4VSensitiveDetector{name}
+    {
+    }
+
+  protected:
+    void Initialize(G4HCofThisEvent*) final {}
+    bool ProcessHits(G4Step*, G4TouchableHistory*) final
+    {
+        CELER_ASSERT_UNREACHABLE();
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with name and logical volume pointers.
+ */
+GeantSimpleCalo::GeantSimpleCalo(std::string name,
+                                 SPConstParams params,
+                                 VecLV volumes)
+    : params_{std::move(params)}
+    , volumes_{std::move(volumes)}
+    , storage_{std::make_shared<detail::GeantSimpleCaloStorage>()}
+{
+    CELER_EXPECT(!name.empty());
+    CELER_EXPECT(params_);
+    CELER_EXPECT(!volumes_.empty());
+
+    storage_->name = std::move(name);
+
+    // Create LV map
+    storage_->volume_to_index.reserve(volumes_.size());
+    for (auto i : range(volumes_.size()))
+    {
+        CELER_EXPECT(volumes_[i]);
+        auto&& [iter, inserted]
+            = storage_->volume_to_index.insert({volumes_[i], i});
+        CELER_VALIDATE(inserted,
+                       << "logical volume " << PrintableLV{iter->first}
+                       << " is duplicated in the list of volumes for "
+                          "GeantSimpleCalo '"
+                       << this->label() << "'");
+    }
+
+    CELER_ENSURE(!storage_->name.empty());
+    CELER_ENSURE(storage_->volume_to_index.size() == volumes_.size());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Emit a new detector for the local thread and attach to the stored LVs.
+ */
+auto GeantSimpleCalo::MakeSensitiveDetector() -> UPSensitiveDetector
+{
+    this->setup_storage();
+
+    UPSensitiveDetector detector;
+
+    // Get thread ID
+    auto thread_id = get_geant_thread_id();
+    if (thread_id < 0)
+    {
+        // Manager thread: use a dummy SD
+        detector = std::make_unique<DummyGeantSimpleCaloSD>(storage_->name);
+    }
+    else
+    {
+        CELER_ASSERT(static_cast<size_type>(thread_id) < storage_->num_threads);
+        CELER_VALIDATE(storage_->data[thread_id].empty(),
+                       << "tried to create multiple SDs for thread "
+                       << thread_id << " of simple calo '" << storage_->name
+                       << "'");
+
+        // Allocate and clear result
+        storage_->data[thread_id].assign(storage_->volume_to_index.size(), 0.0);
+
+        // Create SD
+        detector
+            = std::make_unique<detail::GeantSimpleCaloSD>(storage_, thread_id);
+    }
+
+    // Attach SD to LVs
+    for (auto const& lv_idx : storage_->volume_to_index)
+    {
+        CELER_LOG_LOCAL(debug)
+            << "Attaching '" << storage_->name << "'@" << detector.get()
+            << " to '" << lv_idx.first->GetName() << "'@"
+            << static_cast<void const*>(lv_idx.first);
+        lv_idx.first->SetSensitiveDetector(detector.get());
+    }
+    return detector;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate thread-integrated energy deposition.
+ *
+ * This function should only be called after all detector data has been
+ * collected.
+ */
+auto GeantSimpleCalo::CalcTotalEnergyDeposition() const -> VecReal
+{
+    VecReal result(volumes_.size(), 0.0);
+    if (storage_->data.empty())
+    {
+        CELER_LOG(warning) << "No SDs were created from GeantSimpleCalo '"
+                           << this->label() << "'";
+    }
+
+    for (auto thread_id : range(storage_->data.size()))
+    {
+        VecReal const& thread_data = storage_->data[thread_id];
+        if (thread_data.empty())
+        {
+            CELER_LOG(warning)
+                << "No SD was emitted from GeantSimpleCalo '" << this->label()
+                << "' for thread index " << thread_id;
+            continue;
+        }
+
+        for (auto vol_idx : range(thread_data.size()))
+        {
+            result[vol_idx] += thread_data[vol_idx];
+        }
+    }
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return the key in the JSON output.
+ */
+std::string GeantSimpleCalo::label() const
+{
+    return storage_->name;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Allocate storage space for all threads.
+ */
+void GeantSimpleCalo::output(JsonPimpl* j) const
+{
+#if CELERITAS_USE_JSON
+    using json = nlohmann::json;
+
+    auto obj = json::object();
+
+    // Save detector volumes
+    {
+        auto const& geo = *params_->geant_geo_params();
+        std::vector<int> ids(volumes_.size());
+        std::vector<Label> labels(volumes_.size());
+
+        for (auto idx : range(volumes_.size()))
+        {
+            auto id = geo.find_volume(volumes_[idx]);
+            ids[idx] = id.unchecked_get();
+            labels[idx] = geo.id_to_label(id);
+        }
+        obj["volume_ids"] = std::move(ids);
+        obj["volume_labels"] = std::move(labels);
+    }
+
+    // Save results
+    {
+        obj["energy_deposition"] = this->CalcTotalEnergyDeposition();
+        obj["_units"] = {
+            {"energy_deposition", EnergyUnits::label()},
+        };
+    }
+
+    j->obj = std::move(obj);
+#else
+    CELER_DISCARD(j);
+#endif
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Allocate storage space for all threads.
+ */
+void GeantSimpleCalo::setup_storage()
+{
+    if (storage_->num_threads == 0)
+    {
+        // Lock and check again
+        static std::mutex setup_mutex;
+        std::lock_guard scoped_lock{setup_mutex};
+        if (storage_->num_threads == 0)
+        {
+            // Resize data
+            storage_->num_threads = params_->num_streams();
+            storage_->data.resize(storage_->num_threads);
+
+            CELER_LOG_LOCAL(debug) << "Resized storage for '" << storage_->name
+                                   << "' to " << storage_->num_threads;
+        }
+    }
+
+    CELER_ENSURE(storage_->num_threads != 0);
+    CELER_ENSURE(storage_->data.size() == storage_->num_threads);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/accel/GeantSimpleCalo.hh
+++ b/src/accel/GeantSimpleCalo.hh
@@ -1,0 +1,83 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/GeantSimpleCalo.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "corecel/io/OutputInterface.hh"
+#include "celeritas/Quantities.hh"
+
+class G4LogicalVolume;
+class G4VSensitiveDetector;
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+class SharedParams;
+namespace detail
+{
+struct GeantSimpleCaloStorage;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Manage a simple calorimeter sensitive detector across threads.
+ *
+ * The factory should be created in DetectorConstruction or
+ * DetectorConstruction::Construct and added to the output parameters. Calling
+ * \c MakeSensitiveDetector will emit a sensitive detector for the local thread
+ * *and attach it* to the logical volumes on the local thread.
+ */
+class GeantSimpleCalo final : public OutputInterface
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using SPConstParams = std::shared_ptr<SharedParams const>;
+    using UPSensitiveDetector = std::unique_ptr<G4VSensitiveDetector>;
+    using VecLV = std::vector<G4LogicalVolume*>;
+    using VecReal = std::vector<double>;
+    using EnergyUnits = units::Mev;
+    //!@}
+
+  public:
+    // Construct with SD name and the volumes to attach the SD to
+    GeantSimpleCalo(std::string name, SPConstParams params, VecLV volumes);
+
+    // Emit a new detector for the local thread and attach to the stored LVs
+    UPSensitiveDetector MakeSensitiveDetector();
+
+    //! Get the list of volumes with this SD attached
+    VecLV const& Volumes() const { return volumes_; }
+
+    // Get accumulated energy deposition over all threads
+    VecReal CalcTotalEnergyDeposition() const;
+
+    //!@{
+    //! \name Output interface
+    //! Category of data to write
+    Category category() const final { return Category::result; }
+    // Key for the entry inside the category
+    std::string label() const final;
+    // Write output to the given JSON object
+    void output(JsonPimpl*) const final;
+    //!@}
+
+  private:
+    using SPStorage = std::shared_ptr<detail::GeantSimpleCaloStorage>;
+    SPConstParams params_;
+    VecLV volumes_;
+    SPStorage storage_;
+
+    void setup_storage();
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/accel/GeantSimpleCalo.hh
+++ b/src/accel/GeantSimpleCalo.hh
@@ -75,8 +75,6 @@ class GeantSimpleCalo final : public OutputInterface
     SPConstParams params_;
     VecLV volumes_;
     SPStorage storage_;
-
-    void setup_storage();
 };
 
 //---------------------------------------------------------------------------//

--- a/src/accel/detail/GeantSimpleCaloSD.cc
+++ b/src/accel/detail/GeantSimpleCaloSD.cc
@@ -37,8 +37,8 @@ GeantSimpleCaloSD::GeantSimpleCaloSD(SPStorage storage, size_type thread_id)
  */
 bool GeantSimpleCaloSD::ProcessHits(G4Step* g4step, G4TouchableHistory*)
 {
-    CELER_ASSERT(g4step);
-    CELER_ASSERT(g4step->GetPreStepPoint());
+    CELER_EXPECT(g4step);
+    CELER_EXPECT(g4step->GetPreStepPoint());
     double const edep = g4step->GetTotalEnergyDeposit();
 
     if (edep == 0)

--- a/src/accel/detail/GeantSimpleCaloSD.cc
+++ b/src/accel/detail/GeantSimpleCaloSD.cc
@@ -1,0 +1,65 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/detail/GeantSimpleCaloSD.cc
+//---------------------------------------------------------------------------//
+#include "GeantSimpleCaloSD.hh"
+
+#include "corecel/Assert.hh"
+#include "celeritas/ext/GeantGeoUtils.hh"
+
+#include "GeantSimpleCaloStorage.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with name and shared storage.
+ */
+GeantSimpleCaloSD::GeantSimpleCaloSD(SPStorage storage, size_type thread_id)
+    : G4VSensitiveDetector{storage->name}
+    , storage_{std::move(storage)}
+    , thread_id_{thread_id}
+{
+    CELER_EXPECT(storage_);
+    CELER_EXPECT(thread_id < storage_->data.size());
+    CELER_EXPECT(storage_->data[thread_id].size()
+                 == storage_->volume_to_index.size());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add energy deposition from this step to the corresponding logical volume.
+ */
+bool GeantSimpleCaloSD::ProcessHits(G4Step* g4step, G4TouchableHistory*)
+{
+    CELER_ASSERT(g4step);
+    CELER_ASSERT(g4step->GetPreStepPoint());
+    double const edep = g4step->GetTotalEnergyDeposit();
+
+    if (edep == 0)
+    {
+        return false;
+    }
+
+    auto const* pv = g4step->GetPreStepPoint()->GetPhysicalVolume();
+    CELER_ASSERT(pv);
+    auto det_id_iter = storage_->volume_to_index.find(pv->GetLogicalVolume());
+    CELER_VALIDATE(det_id_iter != storage_->volume_to_index.end(),
+                   << "logical volume " << PrintableLV{pv->GetLogicalVolume()}
+                   << " is not attached to simple calo '" << storage_->name
+                   << "'";);
+
+    auto& thread_data = storage_->data[thread_id_];
+    CELER_ASSERT(det_id_iter->second < thread_data.size());
+    thread_data[det_id_iter->second] += edep;
+    return true;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/accel/detail/GeantSimpleCaloSD.hh
+++ b/src/accel/detail/GeantSimpleCaloSD.hh
@@ -1,0 +1,49 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/detail/GeantSimpleCaloSD.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include <G4VSensitiveDetector.hh>
+
+#include "corecel/Types.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+struct GeantSimpleCaloStorage;
+//---------------------------------------------------------------------------//
+/*!
+ * Accumulate energy deposition in volumes.
+ *
+ * This SD is returned by \c GeantSimpleCalo.
+ */
+class GeantSimpleCaloSD : public G4VSensitiveDetector
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using SPStorage = std::shared_ptr<detail::GeantSimpleCaloStorage>;
+    //!@}
+
+  public:
+    // Construct with name and shared params
+    GeantSimpleCaloSD(SPStorage storage, size_type thread_id);
+
+  protected:
+    void Initialize(G4HCofThisEvent*) final {}
+    bool ProcessHits(G4Step*, G4TouchableHistory*) final;
+
+  private:
+    SPStorage storage_;
+    size_type thread_id_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/accel/detail/GeantSimpleCaloStorage.hh
+++ b/src/accel/detail/GeantSimpleCaloStorage.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/detail/GeantSimpleCaloStorage.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "corecel/Types.hh"
+#include "corecel/cont/Array.hh"
+
+class G4LogicalVolume;
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Shared storage for a single GeantSimpleCalo.
+ *
+ * This is created by the \c SharedGeantSimpleCalo and passed to all the \c
+ * G4VSensitiveDetector instances (one for each thread) for the calo.
+ */
+struct GeantSimpleCaloStorage
+{
+    using VecReal = std::vector<double>;
+    using VecVecReal = std::vector<VecReal>;
+    using MapVolumeIdx = std::unordered_map<G4LogicalVolume*, size_type>;
+
+    //! SD name
+    std::string name;
+    //! Number of threads
+    size_type num_threads{};
+    //! Map of logical volume to "detector ID" index
+    MapVolumeIdx volume_to_index;
+    //! Accumulated energy deposition [thread][volume]
+    VecVecReal data;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/accel/detail/GeantSimpleCaloStorage.hh
+++ b/src/accel/detail/GeantSimpleCaloStorage.hh
@@ -24,7 +24,7 @@ namespace detail
 /*!
  * Shared storage for a single GeantSimpleCalo.
  *
- * This is created by the \c SharedGeantSimpleCalo and passed to all the \c
+ * This is created by the \c GeantSimpleCalo and passed to all the \c
  * G4VSensitiveDetector instances (one for each thread) for the calo.
  */
 struct GeantSimpleCaloStorage

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -81,20 +81,19 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
     HP_SETUP_POINT(post, Post);
 #undef HP_SETUP_POINT
 #undef HP_CLEAR_STEP_POINT
-
-    // Create navigator
-    G4VPhysicalVolume* world_volume
-        = G4TransportationManager::GetTransportationManager()
-              ->GetNavigatorForTracking()
-              ->GetWorldVolume();
     if (locate_touchable)
     {
         CELER_ASSERT(selection.points[StepPoint::pre].pos
                      && selection.points[StepPoint::pre].dir);
+
+        // Create navigator
+        G4VPhysicalVolume* world_volume
+            = G4TransportationManager::GetTransportationManager()
+                  ->GetNavigatorForTracking()
+                  ->GetWorldVolume();
         navi_ = std::make_unique<G4Navigator>();
         navi_->SetWorldVolume(world_volume);
 
-        // Create "touchable handle" (shared pointer to G4TouchableHistory)
         touch_handle_ = new G4TouchableHistory;
         step_->GetPreStepPoint()->SetTouchableHandle(touch_handle_);
     }


### PR DESCRIPTION
This adds a "simple calorimeter" (event and thread integrated, differential per logical volume) detector that saves its output to JSON in the same format as the on-GPU calorimeters. This will let us do an accurate comparison of the cost for converting hits through the Geant4 layer versus directly storing on GPU.