### PR TITLE
Fix CI for "push" events

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
+  group: build-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/merge_group.yml
+++ b/.github/workflows/merge_group.yml
@@ -1,0 +1,26 @@
+name: merge_group
+run-name: >-
+  Pending merge
+  to ${{github.event.merge_group.base_ref}}
+  by @${{github.event.sender.login}}
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+concurrency:
+  group: mg-${{github.ref}}-${{github.workflow}}
+  cancel-in-progress: true
+
+jobs:
+  # TODO: use a more limited build for merge group? (or for PR?)
+  build:
+    uses: ./.github/workflows/build-full.yml
+  all:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Success
+      run: "true"
+
+# vim: set nowrap tw=100:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,12 +20,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    uses: ./.github/workflows/build-full.yml
+
+  # Specifying a dependent job allows us to select a single "requires" check
   all:
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
-    - name: Print event
-      run: echo "${{toJSON(github.event)}}"
-    - name: Fail
-      run: "false"
+    - name: Success
+      run: "true"
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
 
   # Specifying a dependent job allows us to select a single "requires" check
   all:
-    needs: [ build ]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
     - name: Success

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,5 @@
 name: pr
+run-name: "#${{github.event.pull_request.number}} (@${{github.actor}}): ${{github.ref_name}}"
 
 on:
   pull_request:
@@ -13,7 +14,7 @@ on:
     types: [checks_requested]
 
 concurrency:
-  group: ${{github.ref}}-${{github.event.pull_request.number}}-${{github.workflow}}
+  group: pr-${{github.ref}}-${{github.event.pull_request.number}}-${{github.workflow}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,7 @@
 name: pr
-run-name: "#${{github.event.pull_request.number}} (@${{github.actor}}): ${{github.ref_name}}"
+run-name: >-
+  ${{github.event.pull_request.title}}
+  (#${{github.event.pull_request.number}})
 
 on:
   pull_request:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: pr
 run-name: >-
   ${{github.event.pull_request.title}}
-  (#${{github.event.pull_request.number}})
+  (#${{github.event.number}})
 
 on:
   pull_request:
@@ -12,11 +12,9 @@ on:
       - '**.rst'
       - '**.md'
       - 'scripts/dev'
-  merge_group:
-    types: [checks_requested]
 
 concurrency:
-  group: pr-${{github.ref}}-${{github.event.pull_request.number}}-${{github.workflow}}
+  group: pr-${{github.ref}}-${{github.event.number}}-${{github.workflow}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,15 +20,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    uses: ./.github/workflows/build-full.yml
-
-  # Specifying a dependent job allows us to select a single "requires" check
   all:
-    needs: [build]
     runs-on: ubuntu-latest
     steps:
-    - name: Success
-      run: "true"
+    - name: Print event
+      run: echo "${{toJSON(github.event)}}"
+    - name: Fail
+      run: "false"
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,14 +10,19 @@ on:
     branches:
       - develop
       - backports/**
+      - fix-push-ci
 
 concurrency:
   group: push-${{github.ref}}-${{github.run_number}}-${{github.workflow}}
   cancel-in-progress: true
 
 jobs:
-  build:
-    uses: ./.github/workflows/build-full.yml
-  # TODO: build and push documentation
+  all:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Print event
+      run: echo "${{toJSON(github.event)}}"
+    - name: Fail
+      run: "false"
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - develop
       - backports/**
-      - fix-push-ci
 
 concurrency:
   group: push-${{github.ref}}-${{github.run_number}}-${{github.workflow}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,5 @@
 name: push
+# TODO: improve run name using commit title (`message` includes details as well)
 # run-name: >-
 #   ${{github.ref_name}}:
 #   ${{github.event.head_commit.message}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - backports/**
+      - fix-push-ci
 
 concurrency:
   group: ${{github.ref}}-${{github.run_number}}-${{github.workflow}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,19 +10,14 @@ on:
     branches:
       - develop
       - backports/**
-      - fix-push-ci
 
 concurrency:
   group: push-${{github.ref}}-${{github.run_number}}-${{github.workflow}}
   cancel-in-progress: true
 
 jobs:
-  all:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Print event
-      run: echo "${{toJSON(github.event)}}"
-    - name: Fail
-      run: "false"
+  build:
+    uses: ./.github/workflows/build-full.yml
+  # TODO: build and push documentation
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,5 @@
 name: push
+run-name: "${{github.ref_name}} (@${{github.actor}})"
 
 on:
   push:
@@ -8,7 +9,7 @@ on:
       - fix-push-ci
 
 concurrency:
-  group: ${{github.ref}}-${{github.run_number}}-${{github.workflow}}
+  group: push-${{github.ref}}-${{github.run_number}}-${{github.workflow}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,8 @@
 name: push
-run-name: "${{github.ref_name}} (@${{github.actor}})"
+# run-name: >-
+#   ${{github.ref_name}}:
+#   ${{github.event.head_commit.message}}
+#   (${{github.event.pusher.name}})
 
 on:
   push:


### PR DESCRIPTION
This fixes the duplicate values for `concurrency` (thanks @pcanal ) and improves the titles that show up in the [actions tab](https://github.com/celeritas-project/celeritas/actions), although it's not possible to get the "title" of a commit message. See [the run push actions](https://github.com/sethrj/celeritas/actions/).