### PR TITLE
Use default field driver options in celer-g4 test

### DIFF
--- a/app/celer-g4/test-harness.py
+++ b/app/celer-g4/test-harness.py
@@ -82,10 +82,10 @@ inp = {
      1.0
     ],
     "field_options": {
-     "minimum_step": 0.0001,
+     "minimum_step": 0.000001,
      "delta_chord": 0.025,
-     "delta_intersection": 0.001,
-     "epsilon_step": 0.01
+     "delta_intersection": 0.00001,
+     "epsilon_step": 0.00001
     },
     "step_diagnostic": ext == "none",
     "step_diagnostic_bins": 10


### PR DESCRIPTION
I looks like when we added the celer-g4 test harness in #1007 the input field driver options were changed, and that's why the celer-g4 GPU test is failing (sometimes, since it's not yet reproducible ;)). We should probably make sure our field propagator works as expected for reasonable choices of these values, but for the test I think it's fine to just use the defaults.