### PR TITLE
Add multithread exception support and logging to Geant4 app

### DIFF
--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CELERITAS_USE_Geant4)
     ActionInitialization.cc
     DetectorConstruction.cc
     EventAction.cc
+    ExceptionHandler.cc
     GeantDiagnostics.cc
     GlobalSetup.cc
     HepMC3PrimaryGeneratorAction.cc

--- a/app/celer-g4/EventAction.cc
+++ b/app/celer-g4/EventAction.cc
@@ -11,6 +11,7 @@
 #include <G4Event.hh>
 
 #include "corecel/Macros.hh"
+#include "accel/ExceptionConverter.hh"
 
 #include "GlobalSetup.hh"
 #include "RootIO.hh"
@@ -49,7 +50,9 @@ void EventAction::BeginOfEventAction(G4Event const* event)
         return;
 
     // Set event ID in local transporter
-    transport_->SetEventId(event->GetEventID());
+    ExceptionConverter call_g4exception{"celer0002"};
+    CELER_TRY_HANDLE(transport_->SetEventId(event->GetEventID()),
+                     call_g4exception);
 }
 
 //---------------------------------------------------------------------------//
@@ -63,7 +66,8 @@ void EventAction::EndOfEventAction(G4Event const* event)
     if (!SharedParams::CeleritasDisabled())
     {
         // Transport any tracks left in the buffer
-        transport_->Flush();
+        ExceptionConverter call_g4exception{"celer0004", params_.get()};
+        CELER_TRY_HANDLE(transport_->Flush(), call_g4exception);
     }
 
     if (RootIO::use_root())

--- a/app/celer-g4/EventAction.cc
+++ b/app/celer-g4/EventAction.cc
@@ -77,7 +77,7 @@ void EventAction::EndOfEventAction(G4Event const* event)
     }
 
     // Record the time for this event
-    diagnostics_->Timer()->RecordEventTime(get_event_time_());
+    diagnostics_->timer()->RecordEventTime(get_event_time_());
 
     CELER_LOG_LOCAL(debug) << "Finished event " << event->GetEventID();
 }

--- a/app/celer-g4/ExceptionHandler.cc
+++ b/app/celer-g4/ExceptionHandler.cc
@@ -1,0 +1,88 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celer-g4/ExceptionHandler.cc
+//---------------------------------------------------------------------------//
+#include "ExceptionHandler.hh"
+
+#include <G4ExceptionSeverity.hh>
+#include <G4RunManager.hh>
+#include <G4StateManager.hh>
+#include <G4Types.hh>
+
+#include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+#include "corecel/io/Logger.hh"
+
+namespace celeritas
+{
+namespace app
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with an exception handler that can catch exceptions.
+ */
+ExceptionHandler::ExceptionHandler(StdExceptionHandler handle_exception)
+    : handle_{std::move(handle_exception)}
+{
+    CELER_EXPECT(handle_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Raise an exception, catch it with the handler, and abort.
+ */
+G4bool ExceptionHandler::Notify(char const* origin_of_exception,
+                                char const* exception_code,
+                                G4ExceptionSeverity severity,
+                                char const* description)
+{
+    CELER_EXPECT(origin_of_exception);
+    CELER_EXPECT(exception_code);
+
+    // Construct message
+    auto err = RuntimeError::from_geant_exception(
+        origin_of_exception, exception_code, description);
+    bool must_abort{false};
+
+    switch (severity)
+    {
+        case FatalException:
+        case FatalErrorInArgument:
+        case RunMustBeAborted:
+        case EventMustBeAborted:
+            CELER_TRY_HANDLE(throw err, handle_);
+            if (auto* run_man = G4RunManager::GetRunManager())
+            {
+                if (severity == EventMustBeAborted)
+                {
+                    run_man->AbortEvent();
+                }
+                else
+                {
+                    run_man->AbortRun(/* softAbort = */ true);
+                }
+            }
+            else
+            {
+                must_abort = true;
+            }
+            break;
+        case JustWarning:
+            // Display a message
+            CELER_LOG_LOCAL(error) << err.what();
+            break;
+        default:
+            CELER_ASSERT_UNREACHABLE();
+    }
+
+    // Return "true" to cause Geant4 to crash the program, or "false" to let it
+    // know that we've handled the exception.
+    return must_abort;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace app
+}  // namespace celeritas

--- a/app/celer-g4/ExceptionHandler.hh
+++ b/app/celer-g4/ExceptionHandler.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celer-g4/ExceptionHandler.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <exception>
+#include <functional>
+#include <G4ExceptionSeverity.hh>
+#include <G4StateManager.hh>
+#include <G4Types.hh>
+#include <G4VExceptionHandler.hh>
+
+namespace celeritas
+{
+namespace app
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Abort the event or run in case of an error.
+ */
+class ExceptionHandler : public G4VExceptionHandler
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using StdExceptionHandler = std::function<void(std::exception_ptr)>;
+    //!@}
+
+  public:
+    explicit ExceptionHandler(StdExceptionHandler handle_exception);
+
+    // Accept error codes from geant4
+    G4bool Notify(char const* originOfException,
+                  char const* exceptionCode,
+                  G4ExceptionSeverity severity,
+                  char const* description) final;
+
+  private:
+    StdExceptionHandler handle_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace app
+}  // namespace celeritas

--- a/app/celer-g4/GeantDiagnostics.cc
+++ b/app/celer-g4/GeantDiagnostics.cc
@@ -76,7 +76,7 @@ GeantDiagnostics::GeantDiagnostics(SharedParams const& params)
         output_reg->insert(std::make_shared<BuildOutput>());
     }
 
-    // Create shared exception handler (note: make_shared acts screwy here...)
+    // Create shared exception handler
     meh_ = std::make_shared<MultiExceptionHandler>();
 
     CELER_ENSURE(*this);

--- a/app/celer-g4/GeantDiagnostics.cc
+++ b/app/celer-g4/GeantDiagnostics.cc
@@ -15,7 +15,6 @@
 #include "celeritas/Types.hh"
 #include "celeritas/global/CoreParams.hh"
 
-#include "G4RunManager.hh"
 #include "GlobalSetup.hh"
 
 #if CELERITAS_USE_JSON
@@ -78,7 +77,7 @@ GeantDiagnostics::GeantDiagnostics(SharedParams const& params)
     }
 
     // Create shared exception handler (note: make_shared acts screwy here...)
-    meh_ = std::make_shared<::celeritas::MultiExceptionHandler>();
+    meh_ = std::make_shared<MultiExceptionHandler>();
 
     CELER_ENSURE(*this);
 }

--- a/app/celer-g4/GeantDiagnostics.cc
+++ b/app/celer-g4/GeantDiagnostics.cc
@@ -11,6 +11,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Environment.hh"
 #include "corecel/sys/MemRegistry.hh"
+#include "corecel/sys/MultiExceptionHandler.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/global/CoreParams.hh"
 
@@ -76,6 +77,9 @@ GeantDiagnostics::GeantDiagnostics(SharedParams const& params)
         output_reg->insert(std::make_shared<BuildOutput>());
     }
 
+    // Create shared exception handler (note: make_shared acts screwy here...)
+    meh_ = std::make_shared<::celeritas::MultiExceptionHandler>();
+
     CELER_ENSURE(*this);
 }
 
@@ -90,6 +94,10 @@ void GeantDiagnostics::Finalize()
 {
     // Reset all data
     CELER_LOG_LOCAL(debug) << "Resetting diagnostics";
+    if (meh_)
+    {
+        log_and_rethrow(std::move(*meh_));
+    }
     *this = {};
 
     CELER_ENSURE(!*this);

--- a/app/celer-g4/GeantDiagnostics.hh
+++ b/app/celer-g4/GeantDiagnostics.hh
@@ -19,6 +19,7 @@
 
 namespace celeritas
 {
+class MultiExceptionHandler;
 namespace app
 {
 //---------------------------------------------------------------------------//
@@ -37,6 +38,7 @@ class GeantDiagnostics
     using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
     using SPStepDiagnostic = std::shared_ptr<GeantStepDiagnostic>;
     using SPTimerOutput = std::shared_ptr<TimerOutput>;
+    using SPMultiExceptionHandler = std::shared_ptr<MultiExceptionHandler>;
     //!@}
 
   public:
@@ -58,6 +60,9 @@ class GeantDiagnostics
     // Access the timer output
     inline SPTimerOutput const& Timer() const;
 
+    // Access the exception handler
+    inline SPMultiExceptionHandler const& MultiExceptionHandler() const;
+
     //! Whether this instance is initialized
     explicit operator bool() const { return static_cast<bool>(timer_output_); }
 
@@ -67,6 +72,7 @@ class GeantDiagnostics
     SPOutputRegistry output_reg_;
     SPStepDiagnostic step_diagnostic_;
     SPTimerOutput timer_output_;
+    SPMultiExceptionHandler meh_;
 };
 
 //---------------------------------------------------------------------------//
@@ -97,6 +103,18 @@ auto GeantDiagnostics::Timer() const -> SPTimerOutput const&
     CELER_EXPECT(*this);
     CELER_EXPECT(timer_output_);
     return timer_output_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access the multi-exception handler.
+ */
+auto GeantDiagnostics::MultiExceptionHandler() const
+    -> SPMultiExceptionHandler const&
+{
+    CELER_EXPECT(*this);
+    CELER_EXPECT(meh_);
+    return meh_;
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/GeantDiagnostics.hh
+++ b/app/celer-g4/GeantDiagnostics.hh
@@ -55,13 +55,13 @@ class GeantDiagnostics
     void Finalize();
 
     // Access the step diagnostic
-    inline SPStepDiagnostic const& StepDiagnostic() const;
+    inline SPStepDiagnostic const& step_diagnostic() const;
 
     // Access the timer output
-    inline SPTimerOutput const& Timer() const;
+    inline SPTimerOutput const& timer() const;
 
     // Access the exception handler
-    inline SPMultiExceptionHandler const& MultiExceptionHandler() const;
+    inline SPMultiExceptionHandler const& multi_exception_handler() const;
 
     //! Whether this instance is initialized
     explicit operator bool() const { return static_cast<bool>(timer_output_); }
@@ -88,7 +88,7 @@ void GeantDiagnostics::Initialize(SharedParams const& params)
 /*!
  * Access the step diagnostic.
  */
-auto GeantDiagnostics::StepDiagnostic() const -> SPStepDiagnostic const&
+auto GeantDiagnostics::step_diagnostic() const -> SPStepDiagnostic const&
 {
     CELER_EXPECT(*this);
     return step_diagnostic_;
@@ -98,7 +98,7 @@ auto GeantDiagnostics::StepDiagnostic() const -> SPStepDiagnostic const&
 /*!
  * Access the timer output.
  */
-auto GeantDiagnostics::Timer() const -> SPTimerOutput const&
+auto GeantDiagnostics::timer() const -> SPTimerOutput const&
 {
     CELER_EXPECT(*this);
     CELER_EXPECT(timer_output_);
@@ -109,7 +109,7 @@ auto GeantDiagnostics::Timer() const -> SPTimerOutput const&
 /*!
  * Access the multi-exception handler.
  */
-auto GeantDiagnostics::MultiExceptionHandler() const
+auto GeantDiagnostics::multi_exception_handler() const
     -> SPMultiExceptionHandler const&
 {
     CELER_EXPECT(*this);

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -17,6 +17,7 @@
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Device.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
+#include "accel/ExceptionConverter.hh"
 #include "accel/SetupOptionsMessenger.hh"
 
 #include "HepMC3PrimaryGeneratorAction.hh"

--- a/app/celer-g4/HepMC3PrimaryGeneratorAction.cc
+++ b/app/celer-g4/HepMC3PrimaryGeneratorAction.cc
@@ -10,6 +10,7 @@
 #include <G4Event.hh>
 
 #include "corecel/Macros.hh"
+#include "accel/ExceptionConverter.hh"
 #include "accel/HepMC3PrimaryGenerator.hh"
 
 #include "GlobalSetup.hh"
@@ -34,7 +35,9 @@ HepMC3PrimaryGeneratorAction::HepMC3PrimaryGeneratorAction(SPGenerator gen)
  */
 void HepMC3PrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
 {
-    generator_->GeneratePrimaryVertex(event);
+    ExceptionConverter call_g4exception{"celer0000"};
+    CELER_TRY_HANDLE(generator_->GeneratePrimaryVertex(event),
+                     call_g4exception);
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/RootIO.cc
+++ b/app/celer-g4/RootIO.cc
@@ -22,6 +22,7 @@
 #include "corecel/io/Logger.hh"
 #include "celeritas/ext/GeantUtils.hh"
 #include "celeritas/ext/RootFileManager.hh"
+#include "accel/ExceptionConverter.hh"
 #include "accel/SetupOptions.hh"
 
 #include "GlobalSetup.hh"

--- a/app/celer-g4/RunAction.cc
+++ b/app/celer-g4/RunAction.cc
@@ -91,7 +91,7 @@ void RunAction::BeginOfRunAction(G4Run const* run)
         CELER_TRY_HANDLE(diagnostics_->Initialize(*params_), call_g4exception);
         CELER_ASSERT(*diagnostics_);
 
-        diagnostics_->Timer()->RecordSetupTime(
+        diagnostics_->timer()->RecordSetupTime(
             GlobalSetup::Instance()->GetSetupTime());
         get_transport_time_ = {};
     }
@@ -101,7 +101,7 @@ void RunAction::BeginOfRunAction(G4Run const* run)
     orig_eh_ = G4StateManager::GetStateManager()->GetExceptionHandler();
     static std::mutex exception_handle_mutex;
     exception_handler_ = std::make_shared<ExceptionHandler>(
-        [meh = diagnostics_->MultiExceptionHandler()](std::exception_ptr ptr) {
+        [meh = diagnostics_->multi_exception_handler()](std::exception_ptr ptr) {
             std::lock_guard scoped_lock{exception_handle_mutex};
             return (*meh)(ptr);
         });
@@ -126,11 +126,11 @@ void RunAction::EndOfRunAction(G4Run const*)
 
     if (transport_ && !SharedParams::CeleritasDisabled())
     {
-        diagnostics_->Timer()->RecordActionTime(transport_->GetActionTime());
+        diagnostics_->timer()->RecordActionTime(transport_->GetActionTime());
     }
     if (init_shared_)
     {
-        diagnostics_->Timer()->RecordTotalTime(get_transport_time_());
+        diagnostics_->timer()->RecordTotalTime(get_transport_time_());
 
         CELER_TRY_HANDLE(diagnostics_->Finalize(), call_g4exception);
     }

--- a/app/celer-g4/RunAction.cc
+++ b/app/celer-g4/RunAction.cc
@@ -8,18 +8,23 @@
 #include "RunAction.hh"
 
 #include <functional>
+#include <mutex>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <G4RunManager.hh>
+#include <G4StateManager.hh>
 
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/sys/MultiExceptionHandler.hh"
 #include "celeritas/ext/GeantSetup.hh"
 #include "accel/ExceptionConverter.hh"
 
+#include "ExceptionHandler.hh"
+#include "GeantDiagnostics.hh"
 #include "GlobalSetup.hh"
 #include "RootIO.hh"
 
@@ -90,6 +95,16 @@ void RunAction::BeginOfRunAction(G4Run const* run)
             GlobalSetup::Instance()->GetSetupTime());
         get_transport_time_ = {};
     }
+
+    // Create a G4VExceptionHandler that dispatches to the shared
+    // MultiException
+    orig_eh_ = G4StateManager::GetStateManager()->GetExceptionHandler();
+    static std::mutex exception_handle_mutex;
+    exception_handler_ = std::make_shared<ExceptionHandler>(
+        [meh = diagnostics_->MultiExceptionHandler()](std::exception_ptr ptr) {
+            std::lock_guard scoped_lock{exception_handle_mutex};
+            return (*meh)(ptr);
+        });
 }
 
 //---------------------------------------------------------------------------//
@@ -106,6 +121,9 @@ void RunAction::EndOfRunAction(G4Run const*)
         CELER_TRY_HANDLE(RootIO::Instance()->Close(), call_g4exception);
     }
 
+    // Reset exception handler before finalizing diagnostics
+    G4StateManager::GetStateManager()->SetExceptionHandler(orig_eh_);
+
     if (transport_ && !SharedParams::CeleritasDisabled())
     {
         diagnostics_->Timer()->RecordActionTime(transport_->GetActionTime());
@@ -113,6 +131,7 @@ void RunAction::EndOfRunAction(G4Run const*)
     if (init_shared_)
     {
         diagnostics_->Timer()->RecordTotalTime(get_transport_time_());
+
         CELER_TRY_HANDLE(diagnostics_->Finalize(), call_g4exception);
     }
 

--- a/app/celer-g4/RunAction.hh
+++ b/app/celer-g4/RunAction.hh
@@ -15,12 +15,14 @@
 #include "accel/SetupOptions.hh"
 #include "accel/SharedParams.hh"
 
-#include "GeantDiagnostics.hh"
+class G4VExceptionHandler;
 
 namespace celeritas
 {
 namespace app
 {
+class ExceptionHandler;
+class GeantDiagnostics;
 //---------------------------------------------------------------------------//
 /*!
  * Set up and tear down Celeritas.
@@ -58,8 +60,10 @@ class RunAction final : public G4UserRunAction
     SPParams params_;
     SPTransporter transport_;
     SPDiagnostics diagnostics_;
+    std::shared_ptr<ExceptionHandler> exception_handler_;
     bool init_shared_;
     Stopwatch get_transport_time_;
+    G4VExceptionHandler* orig_eh_{nullptr};
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -53,14 +53,6 @@ void TrackingAction::PreUserTrackingAction(G4Track const* track)
     if (SharedParams::CeleritasDisabled())
         return;
 
-    {
-        ExceptionConverter call_g4exception{"celer0003", params_.get()};
-        CELER_TRY_HANDLE(
-            CELER_VALIDATE(false,
-                           << "thread ID is " << G4Threading::G4GetThreadId()),
-            call_g4exception);
-    }
-
     auto const& allowed_particles = params_->OffloadParticles();
     if (std::find(std::begin(allowed_particles),
                   std::end(allowed_particles),

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -53,6 +53,14 @@ void TrackingAction::PreUserTrackingAction(G4Track const* track)
     if (SharedParams::CeleritasDisabled())
         return;
 
+    {
+        ExceptionConverter call_g4exception{"celer0003", params_.get()};
+        CELER_TRY_HANDLE(
+            CELER_VALIDATE(false,
+                           << "thread ID is " << G4Threading::G4GetThreadId()),
+            call_g4exception);
+    }
+
     auto const& allowed_particles = params_->OffloadParticles();
     if (std::find(std::begin(allowed_particles),
                   std::end(allowed_particles),

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -72,9 +72,9 @@ void TrackingAction::PreUserTrackingAction(G4Track const* track)
  */
 void TrackingAction::PostUserTrackingAction(G4Track const* track)
 {
-    if (diagnostics_->StepDiagnostic())
+    if (diagnostics_->step_diagnostic())
     {
-        diagnostics_->StepDiagnostic()->Update(track);
+        diagnostics_->step_diagnostic()->Update(track);
     }
 }
 

--- a/app/celer-g4/TrackingAction.cc
+++ b/app/celer-g4/TrackingAction.cc
@@ -15,6 +15,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
+#include "accel/ExceptionConverter.hh"
 
 namespace celeritas
 {
@@ -59,7 +60,8 @@ void TrackingAction::PreUserTrackingAction(G4Track const* track)
         != std::end(allowed_particles))
     {
         // Celeritas is transporting this track
-        transport_->Push(*track);
+        ExceptionConverter call_g4exception{"celer0003", params_.get()};
+        CELER_TRY_HANDLE(transport_->Push(*track), call_g4exception);
         const_cast<G4Track*>(track)->SetTrackStatus(fStopAndKill);
     }
 }

--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -183,7 +183,7 @@ void ExceptionConverter::operator()(std::exception_ptr eptr) const
     {
         // Translate a runtime error into a G4Exception call
         std::ostringstream where;
-        if (e.details().file)
+        if (!e.details().file.empty())
         {
             where << strip_source_dir(e.details().file);
         }

--- a/src/celeritas/ext/ScopedGeantExceptionHandler.hh
+++ b/src/celeritas/ext/ScopedGeantExceptionHandler.hh
@@ -23,6 +23,10 @@ namespace celeritas
  * Note that creating a \c G4RunManagerKernel resets the exception
  * handler, so errors thrown during setup *CANNOT* be caught by Celeritas, and
  * this class can only be used after creating the \c G4RunManager.
+ *
+ * \note This error is suitable only for single-threaded runs and multithreaded
+ * manager thread. The exceptions it throws will terminate a Geant4 worker
+ * thread.
  */
 class ScopedGeantExceptionHandler
 {

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -413,8 +413,8 @@ struct RuntimeErrorDetails
 {
     RuntimeErrorType which{RuntimeErrorType::validate};
     std::string what{};
-    char const* condition{nullptr};
-    char const* file{nullptr};
+    std::string condition{};
+    std::string file{};
     int line{0};
 };
 

--- a/src/corecel/AssertIO.json.cc
+++ b/src/corecel/AssertIO.json.cc
@@ -11,11 +11,11 @@
 
 namespace celeritas
 {
-namespace
-{
 //---------------------------------------------------------------------------//
-template<class T>
-void details_to_json(nlohmann::json& j, T const& d)
+/*!
+ * Write details of a debug error to JSON output.
+ */
+void to_json(nlohmann::json& j, DebugErrorDetails const& d)
 {
     j["which"] = to_cstring(d.which);
     if (d.condition)
@@ -33,25 +33,25 @@ void details_to_json(nlohmann::json& j, T const& d)
 }
 
 //---------------------------------------------------------------------------//
-}  // namespace
-
-//---------------------------------------------------------------------------//
-/*!
- * Write details of a debug error to JSON output.
- */
-void to_json(nlohmann::json& j, DebugErrorDetails const& d)
-{
-    details_to_json(j, d);
-}
-
-//---------------------------------------------------------------------------//
 /*!
  * Write details of a runtime error to JSON output.
  */
 void to_json(nlohmann::json& j, RuntimeErrorDetails const& d)
 {
     j["what"] = d.what;
-    details_to_json(j, d);
+    j["which"] = to_cstring(d.which);
+    if (!d.condition.empty())
+    {
+        j["condition"] = d.condition;
+    }
+    if (!d.file.empty())
+    {
+        j["file"] = d.file;
+    }
+    if (d.line != 0)
+    {
+        j["line"] = d.line;
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/MultiExceptionHandler.hh
+++ b/src/corecel/sys/MultiExceptionHandler.hh
@@ -32,6 +32,12 @@ namespace celeritas
     }
     log_and_rethrow(std::move(capture_exception));
  * \endcode
+ *
+ * \note This class implements an OpenMP \c critical mutex, not a \c std
+ * mutex. If using this class in a \c std::thread context, wrap the call
+ * operator in a lambda with a \c std::scoped_lock . We could refactor as a
+ * CRTP class with a protected \c push_back function that lets us specialize
+ * the mutex implementation.
  */
 class MultiExceptionHandler
 {


### PR DESCRIPTION
In #1013 I didn't realize that allowing exceptions to propagate out of worker threads would simply call `std::terminate` due to C++ exception handling rules. I also neglected to add exception handlers and logging redirection to the worker thread.

This fixes both of those implementations:
- Restore wrapping of `CELER_TRY_HANDLE(..., call_g4exception)` around potentially-throwing Celeritas code
- Add a `MultiExceptionHandler` instance to the `GeantDiagnostics` class
- Construct a thread-local `ExceptionHandler` class (which implements the Geant4 `G4Exception` notification interface) given that instance
- Store the given `G4Exception` and call `G4RunManager::AbortRun` in that exception handler
- When finalizing `GeantDiagnostics` on the manager thread, check for exceptions, log all but one (depending on how many threads died), and throw the last one, which will be caught by `celer-g4.cc`.