### PR TITLE
Fix duplicate libvecgeom.a in some components' build

### DIFF
--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -233,7 +233,7 @@ if(CELERITAS_USE_VecGeom)
     ext/VecgeomParams.cc
     ext/detail/VecgeomNavCollection.cc
   )
-  list(APPEND PRIVATE_DEPS VecGeom::vgdml VecGeom::vecgeom)
+  list(APPEND PRIVATE_DEPS VecGeom::vgdml)
   if(VecGeom_CUDA_FOUND AND VecGeom_SURF_FOUND)
     # Special routines needed for surface
     list(APPEND SOURCES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -326,8 +326,7 @@ celeritas_add_library(testcel_celeritas
   $<TARGET_OBJECTS:testcel_celeritas_geo>
 )
 celeritas_target_link_libraries(testcel_celeritas
-  PRIVATE ${_common_testcel_libs} ${nlohmann_json_LIBRARIES}
-  Celeritas::orange ${_geo_libs}
+  PRIVATE ${_common_testcel_libs} ${nlohmann_json_LIBRARIES} ${_geo_libs}
 )
 
 celeritas_setup_tests(SERIAL PREFIX celeritas
@@ -386,7 +385,6 @@ if(CELERITAS_USE_VecGeom)
     )
   endif()
   celeritas_add_device_test(celeritas/ext/Vecgeom
-    LINK_LIBRARIES VecGeom::vecgeom
     FILTER
       ${_vecgeom_tests}
   )
@@ -421,7 +419,7 @@ celeritas_add_test(celeritas/field/Fields.test.cc)
 celeritas_add_test(celeritas/field/Steppers.test.cc)
 celeritas_add_test(celeritas/field/FieldDriver.test.cc)
 celeritas_add_test(celeritas/field/FieldPropagator.test.cc
-  ${_needs_geo} LINK_LIBRARIES ${_core_geo_lib})
+  ${_needs_geo})
 celeritas_add_test(celeritas/field/LinearPropagator.test.cc
   ${_needs_geo} LINK_LIBRARIES ${_geo_libs})
 celeritas_add_test(celeritas/field/MagFieldEquation.test.cc)
@@ -436,7 +434,7 @@ if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
   list(APPEND _geo_args celeritas/geo/HeuristicGeoTestBase.cu)
 endif()
 celeritas_add_test(celeritas/geo/Geometry.test.cc
-  ${_geo_args} LINK_LIBRARIES ${_core_geo_lib})
+  ${_geo_args})
 
 if(NOT (CELERITAS_USE_Geant4 OR CELERITAS_USE_ROOT))
   set(_needs_geant_or_root DISABLE)


### PR DESCRIPTION
This PR fixes a bunch of `ignoring duplicate libraries` warnings that I get on a local CUDA=OFF build using OSX Ventura's clang compiler:
```
lima@mac-138926: build 🍺  ninja
[0/1] Re-running CMake...
-- Configuring done (0.5s)
-- Generating done (0.2s)
-- Build files have been written to: /Users/lima/work/cele/build
[40/75] Linking CXX shared library lib/libceleritas.dylib
ld: warning: ignoring duplicate libraries: '/opt/local/clang/vecgeom/v1.2.6/lib/libvecgeom.a'
[60/75] Linking CXX executable test/celeritas_geo_Geometry
ld: warning: ignoring duplicate libraries: '/opt/local/clang/vecgeom/v1.2.6/lib/libvecgeom.a'
[69/75] Linking CXX executable test/celeritas_field_FieldPropagator
ld: warning: ignoring duplicate libraries: '/opt/local/clang/vecgeom/v1.2.6/lib/libvecgeom.a'
[73/75] Linking CXX executable test/celeritas_ext_Vecgeom
ld: warning: ignoring duplicate libraries: '/opt/local/clang/vecgeom/v1.2.6/lib/libvecgeom.a'
[75/75] Linking CXX executable app/demo-geo-check/demo-geo-check
```
