### PR TITLE
Update Celeritas CMake defaults and add documentation build

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,7 +24,12 @@ jobs:
       - name: Configure celeritas
         run: |
           mkdir build && cd build
-          cmake -DCELERITAS_BUILD_DOCS=ON -GNinja ..
+          cmake \
+            -DCELERITAS_BUILD_DOCS=ON \
+            -DDOXYGEN_WARN_AS_ERROR="YES" \
+            -DDOXYGEN_QUIET="NO" \
+            -GNinja \
+            ..
       - name: Build documentation
         working-directory: build
         run: |
@@ -33,7 +38,7 @@ jobs:
         id: upload-pages-user
         uses: actions/upload-pages-artifact@v2
         with:
-          path: build/doxygen/html
+          path: build/doc/doxygen
   user:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,9 +2,6 @@ name: doc
 on:
   workflow_dispatch:
   workflow_call:
-  push:
-    branches:
-      - release-v*
 
 concurrency:
   group: doc-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
@@ -53,7 +50,7 @@ jobs:
         id: upload-pages-dev
         uses: actions/upload-pages-artifact@v2
         with:
-          path: build/doc/doxgen
+          path: build/doc/doxygen
 #TODO: deploy with actions/deploy-pages@v2 ?
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,6 @@ jobs:
           mkdir build && cd build
           cmake \
             -DCELERITAS_BUILD_DOCS=ON \
-            -DDOXYGEN_QUIET="NO" \
             -GNinja \
             ..
       - name: Build documentation
@@ -39,7 +38,7 @@ jobs:
         id: upload-pages-user
         uses: actions/upload-pages-artifact@v2
         with:
-          path: build/doc/doxygen
+          path: build/doc/doxygen-html
   user:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -8,8 +8,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  dev:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+            sudo apt-get -y update
+            sudo apt-get -y install \
+                cmake graphviz ninja-build doxygen gcc
+      - name: Check out Celeritas
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 255
+          fetch-tags: true
+      - name: Configure celeritas
+        run: |
+          mkdir build && cd build
+          cmake -DCELERITAS_BUILD_DOCS=ON -GNinja ..
+      - name: Build documentation
+        working-directory: build
+        run: |
+          ninja doxygen
+      - name: Upload pages artifacts
+        id: upload-pages-user
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: build/doxygen/html
   user:
-    name: user
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
@@ -37,20 +62,11 @@ jobs:
         working-directory: build
         run: |
           ninja doc
-      - name: Build developer documentation
-        working-directory: build
-        run: |
-          ninja doxygen
-      - name: Upload user artifacts
+      - name: Upload pages artifacts
         id: upload-pages-user
         uses: actions/upload-pages-artifact@v2
         with:
           path: build/doc/html
-      - name: Upload developer artifacts
-        id: upload-pages-dev
-        uses: actions/upload-pages-artifact@v2
-        with:
-          path: build/doc/doxygen
 #TODO: deploy with actions/deploy-pages@v2 ?
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,15 +36,24 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DCELERITAS_BUILD_DOCS=ON -GNinja ..
-      - name: Build documentation
+      - name: Build user documentation
         working-directory: build
         run: |
           ninja doc
-      - name: Upload pages artifacts
-        id: upload-pages
+      - name: Build developer documentation
+        working-directory: build
+        run: |
+          ninja doxygen
+      - name: Upload user artifacts
+        id: upload-pages-user
         uses: actions/upload-pages-artifact@v2
         with:
           path: build/doc/html
+      - name: Upload developer artifacts
+        id: upload-pages-dev
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: build/doc/doxgen
 #TODO: deploy with actions/deploy-pages@v2 ?
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,11 +22,12 @@ jobs:
           fetch-depth: 255
           fetch-tags: true
       - name: Configure celeritas
+        # TODO: decltype(auto) breaks doxygen :(
+        #    -DDOXYGEN_WARN_AS_ERROR="YES" \
         run: |
           mkdir build && cd build
           cmake \
             -DCELERITAS_BUILD_DOCS=ON \
-            -DDOXYGEN_WARN_AS_ERROR="YES" \
             -DDOXYGEN_QUIET="NO" \
             -GNinja \
             ..

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,50 @@
+name: doc
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches:
+      - release-v*
+
+concurrency:
+  group: doc-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+jobs:
+  user:
+    name: user
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+            sudo apt-get -y update
+            sudo apt-get -y install \
+                cmake graphviz ninja-build doxygen gcc
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+      - name: Check out Celeritas
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 255
+          fetch-tags: true
+      - name: Install Python packages
+        run: |
+            pip install --upgrade pip
+            pip install -r scripts/requirements.txt
+      - name: Configure celeritas
+        run: |
+          mkdir build && cd build
+          cmake -DCELERITAS_BUILD_DOCS=ON -GNinja ..
+      - name: Build documentation
+        working-directory: build
+        run: |
+          ninja doc
+      - name: Upload pages artifacts
+        id: upload-pages
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: build/doc/html
+#TODO: deploy with actions/deploy-pages@v2 ?
+
+# vim: set nowrap tw=100:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,17 +21,19 @@ jobs:
   build:
     uses: ./.github/workflows/build-full.yml
   doc:
-    if: ${{ contains(github.ref_name, 'release-v')
-           || contains(github.ref_name, 'doc-') }}
+    if: ${{ contains(github.head_ref, 'release-v')
+           || contains(github.head_ref, 'doc-') }}
     uses: ./.github/workflows/doc.yml
 
   # Specifying a dependent job allows us to select a single "requires" check
   all:
+    # Complete if jobs were skipped (but not if any failed or were cancelled)
     if: ${{ always() && !failure() && !cancelled() }}
     needs: [build, doc]
     runs-on: ubuntu-latest
     steps:
     - name: Success
-      run: "true"
+      run: |
+        echo 'Checks passed {"head_ref": "${{github.head_ref}}"}'
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,10 +21,13 @@ jobs:
   build:
     uses: ./.github/workflows/build-full.yml
   doc:
+    if: ${{ contains(github.ref_name, 'release-v')
+           || contains(github.ref_name, 'doc-') }}
     uses: ./.github/workflows/doc.yml
 
   # Specifying a dependent job allows us to select a single "requires" check
   all:
+    if: ${{ always() && !failure() && !cancelled() }}
     needs: [build, doc]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,8 +21,7 @@ jobs:
   build:
     uses: ./.github/workflows/build-full.yml
   doc:
-    if: ${{ contains(github.head_ref, 'release-v')
-           || contains(github.head_ref, 'doc-') }}
+    if: ${{contains(github.head_ref, 'release-v') || contains(github.head_ref, 'doc-')}}
     uses: ./.github/workflows/doc.yml
 
   # Specifying a dependent job allows us to select a single "requires" check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,10 +20,12 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/build-full.yml
+  doc:
+    uses: ./.github/workflows/doc.yml
 
   # Specifying a dependent job allows us to select a single "requires" check
   all:
-    needs: [build]
+    needs: [build, doc]
     runs-on: ubuntu-latest
     steps:
     - name: Success

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,13 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/build-full.yml
-  # TODO: build and push documentation
+  doc:
+    uses: ./.github/workflows/doc.yml
+  all:
+    needs: [build, doc]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Success
+      run: "true"
 
 # vim: set nowrap tw=100:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ celeritas_optional_package(ROOT "Enable ROOT I/O")
 celeritas_optional_package(VecGeom "Use VecGeom geometry")
 
 if(CELERITAS_USE_Python)
-  celeritas_optional_package(SWIG "Build SWIG Python bindings")
+  celeritas_optional_package(SWIG SWIG@4.1 "Build SWIG Python bindings")
 endif()
 
 # Components

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,11 @@ endif()
 
 # Components
 option(CELERITAS_BUILD_DOCS "Build Celeritas documentation" OFF)
-option(CELERITAS_BUILD_DEMOS "Build Celeritas demonstration mini-apps"
-  ${CELERITAS_USE_JSON})
-option(CELERITAS_BUILD_TESTS "Build Celeritas unit tests" ON)
+option(CELERITAS_BUILD_DEMOS "Build Celeritas demonstration mini-apps" OFF)
+option(CELERITAS_BUILD_TESTS "Build Celeritas unit tests" OFF)
 
 # Assertion handling
-option(CELERITAS_DEBUG "Enable runtime assertions" ON)
+option(CELERITAS_DEBUG "Enable runtime assertions" OFF)
 
 # Secondary testing options (only applies to CTest)
 if(NOT CELERITAS_DEBUG OR CELERITAS_USE_VecGeom)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,8 +10,9 @@
       "generator": "Ninja",
       "cacheVariables": {
         "Celeritas_GIT_DESCRIBE": "",
-        "CELERITAS_BUILD_TESTS":{"type": "BOOL",   "value": "ON"},
-        "CELERITAS_USE_SWIG":   {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_BUILD_DEMOS":{"type": "BOOL", "value": "ON"},
+        "CELERITAS_BUILD_TESTS":{"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_SWIG":   {"type": "BOOL", "value": "OFF"},
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}"
       }
     },

--- a/cmake/CeleritasUtils.cmake
+++ b/cmake/CeleritasUtils.cmake
@@ -25,7 +25,9 @@ CMake configuration utility functions for Celeritas.
 
   This won't be used for all Celeritas options or even all external dependent
   packages. If given, the ``<find_package>`` package name will searched for
-  instead of ``<package>``.
+  instead of ``<package>``, and an ``@`` symbol can be used to find a specific
+  version (e.g. ``Geant4@11.0``) which will be passed to the ``find_package``
+  command.
 
 .. command:: celeritas_set_default
 
@@ -173,9 +175,15 @@ endfunction()
 macro(celeritas_optional_package package)
   if("${ARGC}" EQUAL 2)
     set(_findpkg "${package}")
+    set(_findversion)
     set(_docstring "${ARGV1}")
   else()
     set(_findpkg "${ARGV1}")
+    set(_findversion)
+    if(_findpkg MATCHES "([^@]+)@([^@]+)")
+      set(_findpkg ${CMAKE_MATCH_1})
+      set(_findversion ${CMAKE_MATCH_2})
+    endif()
     set(_docstring "${ARGV2}")
   endif()
 
@@ -186,7 +194,7 @@ macro(celeritas_optional_package package)
     set(_reset_found OFF)
     list(GET _findpkg 0 _findpkg)
     if(NOT DEFINED ${_findpkg}_FOUND)
-      find_package(${_findpkg} QUIET)
+      find_package(${_findpkg} ${_findversion} QUIET)
       set(_reset_found ON)
     endif()
     celeritas_to_onoff(_val ${${_findpkg}_FOUND})

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -60,13 +60,8 @@ set(DOXYGEN_PREDEFINED "__DOXYGEN__")
 set(DOXYGEN_USE_MATHJAX YES)
 
 # Verbosity/warning levels
-if(NOT DEFINED DOXYGEN_QUIET)
-  set(DOXYGEN_QUIET YES)
-endif()
-if(NOT DEFINED DOXYGEN_WARN_IF_UNDOCUMENTED)
-  # Missing parameters and members have many false positives
-  set(DOXYGEN_WARN_IF_UNDOCUMENTED NO)
-endif()
+celeritas_set_default(DOXYGEN_QUIET YES)
+celeritas_set_default(DOXYGEN_WARN_IF_UNDOCUMENTED NO)
 
 # Output options
 set(DOXYGEN_PROJECT_LOGO

--- a/scripts/dev/run-cloc.sh
+++ b/scripts/dev/run-cloc.sh
@@ -21,10 +21,10 @@ function run_cloc() {
 
 cd $SOURCE_DIR
 comment "Library code"
-run_cloc --exclude-dir=app,generated,scripts,test $@
-comment "Auto-generated code"
-run_cloc --match-d='generated' $@
+run_cloc --exclude-dir=app,example,scripts,test $@
 comment "App code"
 run_cloc --fullpath --match-d='/app/' $@
+comment "Example code"
+run_cloc --fullpath --match-d='/example/' $@
 comment "Test code"
 run_cloc --fullpath --match-d='/test/' $@

--- a/scripts/env/crusher.sh
+++ b/scripts/env/crusher.sh
@@ -2,12 +2,13 @@
 
 _celer_base=$PROJWORK/csc404/celeritas-crusher
 
-# From %clang@14.0.0-rocm5.1.0 in OLCF's spack compilers:
-module load PrgEnv-amd/8.3.3 amd/5.1.0 craype-x86-trento libfabric \
+# From %clang@14.0.0-rocm5.6.0 in OLCF's spack compilers
+# but upgraded to newer amd
+module load PrgEnv-amd/8.3.3 amd/5.6.0 craype-x86-trento libfabric \
   cray-pmi/6.1.2 cray-python/3.9.13.1
 export RFE_811452_DISABLE=1
 export LD_LIBRARY_PATH=/opt/cray/pe/pmi/6.1.2/lib:$LD_LIBRARY_PATH:/opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.0.0/lib64
-export LIBRARY_PATH=/opt/rocm-5.1.0/lib:/opt/rocm-5.1.0/lib64:$LIBRARY_PATH
+export LIBRARY_PATH=/opt/rocm-5.6.0/lib:$LIBRARY_PATH
 
 # Avoid linking multiple different libsci (one with openmp, one without)
 module unload cray-libsci

--- a/scripts/env/frontier.sh
+++ b/scripts/env/frontier.sh
@@ -2,11 +2,11 @@
 
 _celer_base=$PROJWORK/csc404/celeritas-frontier
 
-# From spack compiler toolchain clang@14.0.0-rocm5.1.0
-module load amd/5.1.0 PrgEnv-amd/8.3.3 craype-x86-trento libfabric/1.15.2.0 cray-pmi/6.1.8
+# From spack compiler toolchain
+module load amd/5.6.0 PrgEnv-amd/8.3.3 craype-x86-trento libfabric/1.15.2.0 cray-pmi/6.1.8
 export RFE_811452_DISABLE=1
 export LD_LIBRARY_PATH=/opt/cray/pe/pmi/6.1.8/lib:$LD_LIBRARY_PATH:/opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
-export LIBRARY_PATH=/opt/rocm-5.1.0/lib:/opt/rocm-5.1.0/lib64:$LIBRARY_PATH
+export LIBRARY_PATH=/opt/rocm-5.6.0/lib:/opt/rocm-5.6.0/lib64:$LIBRARY_PATH
 
 # Avoid linking multiple different libsci (one with openmp, one without)
 module unload cray-libsci

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+Sphinx>=4.0.0
+breathe
+furo
+sphinxcontrib-bibtex

--- a/src/celeritas/ext/VecgeomParams.surface.cu
+++ b/src/celeritas/ext/VecgeomParams.surface.cu
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/track/detail/VecgeomParams.surface.cu
+//! \file celeritas/ext/detail/VecgeomParams.surface.cu
 //---------------------------------------------------------------------------//
 #include "VecgeomParams.hh"
 

--- a/src/celeritas/ext/VecgeomParams.surface.cu
+++ b/src/celeritas/ext/VecgeomParams.surface.cu
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/VecgeomParams.surface.cu
+//! \file celeritas/ext/VecgeomParams.surface.cu
 //---------------------------------------------------------------------------//
 #include "VecgeomParams.hh"
 

--- a/src/celeritas/mat/IsotopeView.hh
+++ b/src/celeritas/mat/IsotopeView.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/mat/Isotopeview.hh
+//! \file celeritas/mat/IsotopeView.hh
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/celeritas_config.h.in
+++ b/src/celeritas_config.h.in
@@ -6,10 +6,11 @@
 /*! \file celeritas_config.h
  * Configuration-specific options for Celeritas.
  *
- * Note that the nonzero values for \c CELERITAS_CORE_RNG and \c CELERITAS_CORE_GEO
- * values *must not* be used directly: only compare between (e.g.)
- * \c CELERITAS_CORE_RNG and \c CELERITAS_CORE_RNG_HIPRAND; options that are *invalid*
- * (e.g.  for missing libraries such as HIP) will have a value of zero.
+ * Note that the nonzero values for \c CELERITAS_CORE_RNG and \c
+ * CELERITAS_CORE_GEO values *must not* be used directly: only compare between
+ * (e.g.) \c CELERITAS_CORE_RNG and \c CELERITAS_CORE_RNG_HIPRAND; options that
+ * are *invalid* (e.g. for missing libraries such as HIP) will have a value of
+ * zero.
  *---------------------------------------------------------------------------*/
 #ifndef celeritas_config_h
 #define celeritas_config_h

--- a/src/celeritas_version.h.in
+++ b/src/celeritas_version.h.in
@@ -13,9 +13,13 @@
  * component: (major * 256 + minor) * 256 + patch. */
 #define CELERITAS_VERSION @CELERITAS_VERSION@
 
+//! Celeritas version string with git metadata
 static const char celeritas_version[]    = "@Celeritas_VERSION_STRING@";
+//! Celeritas major version
 static const int celeritas_version_major = @PROJECT_VERSION_MAJOR@;
+//! Celeritas minor version
 static const int celeritas_version_minor = @PROJECT_VERSION_MINOR@;
+//! Celeritas patch version
 static const int celeritas_version_patch = @PROJECT_VERSION_PATCH@;
 
 #endif /* celeritas_version_h */

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -15,8 +15,8 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-#if CELER_USE_DEVICE
-//! Standard type for container sizes, optimized for GPU use.
+#if CELER_USE_DEVICE || defined(__DOXYGEN__)
+//! Standard type for container sizes, optimized for GPU use
 using size_type = unsigned int;
 #else
 using size_type = std::size_t;
@@ -37,17 +37,18 @@ using ull_int = unsigned long long int;
 //---------------------------------------------------------------------------//
 // ENUMERATIONS
 //---------------------------------------------------------------------------//
+//! DEPRECATED: will be replaced with std::byte in v1
 using Byte = std::byte;
 
 //---------------------------------------------------------------------------//
 //! Memory location of data
 enum class MemSpace
 {
-    host,
-    device,
-    mapped,
+    host,  //!< CPU memory
+    device,  //!< GPU memory
+    mapped,  //!< Unified virtual address space (both host and device)
 #ifdef CELER_DEVICE_SOURCE
-    native = device,  // Included by a CUDA/HIP file
+    native = device,  //!< When included by a CUDA/HIP file; else 'host'
 #else
     native = host,
 #endif
@@ -112,6 +113,7 @@ inline constexpr char const* to_cstring(MemSpace m)
 {
     return m == MemSpace::host     ? "host"
            : m == MemSpace::device ? "device"
+           : m == MemSpace::mapped ? "mapped"
                                    : nullptr;
 }
 

--- a/src/corecel/cont/detail/SpanImpl.hh
+++ b/src/corecel/cont/detail/SpanImpl.hh
@@ -19,6 +19,7 @@ namespace celeritas
 {
 namespace detail
 {
+//---------------------------------------------------------------------------//
 /*!
  * Default type aliases for Span.
  */
@@ -34,8 +35,11 @@ struct SpanTraits
     using const_reference = std::add_lvalue_reference_t<element_type const>;
 };
 
+//---------------------------------------------------------------------------//
 /*!
- * Type aliases when data is read using __ldg. \c LdgValue checks that T is a
+ * Type aliases when data is read using __ldg.
+ *
+ * \c LdgValue checks that T is a
  * valid type (const arithmetic or OpaqueId). Since \c LdgIterator returns a
  * copy of the data read, we can't return a reference to the original data, we
  * need to return a copy as well.
@@ -43,8 +47,7 @@ struct SpanTraits
 template<class T>
 struct SpanTraits<LdgValue<T>>
 {
-    // element_type is always const
-    using element_type = typename LdgValue<T>::value_type;
+    using element_type = typename LdgValue<T>::value_type;  // Always const!
     using pointer = std::add_pointer_t<element_type const>;
     using const_pointer = pointer;
     using iterator = LdgIterator<element_type const>;
@@ -52,6 +55,7 @@ struct SpanTraits<LdgValue<T>>
     using reference = std::remove_const_t<element_type>;
     using const_reference = std::remove_const_t<element_type>;
 };
+
 //---------------------------------------------------------------------------//
 //! Sentinel value for span of dynamic type
 constexpr std::size_t dynamic_extent = std::size_t(-1);

--- a/src/corecel/data/detail/LdgIteratorImpl.hh
+++ b/src/corecel/data/detail/LdgIteratorImpl.hh
@@ -110,7 +110,8 @@ struct LdgLoader<T const, std::enable_if_t<std::is_enum_v<T>>>
     }
 };
 
-// True if T is supported by a LdgLoader specialization
+//---------------------------------------------------------------------------//
+//! True if T is supported by a LdgLoader specialization
 template<class T>
 inline constexpr bool is_ldg_supported_v
     = std::is_const_v<T>


### PR DESCRIPTION
This changes the default CMake options for Celeritas:
- Tests and demos (interactor and raytrace) are off by default so that the build is more suitable for "end users" than developers.
- Debug is also off by default for the same reason; this results in the default build type being "Release".
- The SWIG auto-finding now only looks for 4.1 and higher, so that users with SWIG 4.0 or less won't see an error on their first Celeritas configuration.
- Frontier and Crusher now use the ROCm 5.6 toolchain.

I've also added a GHA workflow for building documentation. Later it will be extended to automatically upload to the github pages site on successful merges to `develop`.