### PR TITLE
Add preflight github action

### DIFF
--- a/.github/workflows/build-local.yml
+++ b/.github/workflows/build-local.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -GNinja \
+            -DCeleritas_GIT_DESCRIBE=";-pr.${{github.event.pull_request.number}};" \
             -DCELERITAS_BUILD_DEMOS:BOOL=ON \
             -DCELERITAS_BUILD_TESTS:BOOL=ON \
             -DCELERITAS_USE_SWIG=OFF \

--- a/.github/workflows/build-local.yml
+++ b/.github/workflows/build-local.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: build-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
+  group: build-local-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
   cancel-in-progress: true
 
 jobs:
@@ -51,9 +51,6 @@ jobs:
           $CXX --version | head -1
       - name: Check out Celeritas
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 255
-          fetch-tags: true
       - name: Cache ccache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-local.yml
+++ b/.github/workflows/build-local.yml
@@ -39,14 +39,16 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get -y update
-          sudo apt-get -y install \
+          sudo apt-get -q -y update
+          sudo apt-get -q -y install \
             ccache cmake ninja-build python3 \
             nlohmann-json3-dev libgtest-dev libhepmc3-dev \
-            ${{matrix.compiler}}-${{matrix.version}}
-          ld --version
-          $CC --version
-          $CXX --version
+            ${{matrix.compiler}}-${{matrix.version}} \
+            ${{matrix.compiler == 'gcc' && format('g++-{0}', matrix.version) || ''}}
+          echo "Installed toolchain:"
+          ld --version | head -1
+          $CC --version | head -1
+          $CXX --version | head -1
       - name: Check out Celeritas
         uses: actions/checkout@v4
         with:
@@ -72,7 +74,7 @@ jobs:
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/install" \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations" \
+            -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -Wno-error=deprecated-declarations" \
             ..
       - name: Build all
         working-directory: build

--- a/.github/workflows/build-local.yml
+++ b/.github/workflows/build-local.yml
@@ -12,19 +12,32 @@ jobs:
   linux:
     strategy:
       matrix:
-        # Newest supported OS/compilers
-        runner: ['ubuntu-22.04']
-        compiler: ['gcc-12', 'clang-15']
-        # Oldest supported OS/compilers
+        runner: []
+        compiler: []
+        version: []
         include:
-          - runner: 'ubuntu-20.04'
-            compiler: 'gcc-8'
-          - runner: 'ubuntu-20.04'
-            compiler: 'clang-10'
-    runs-on: ${{matrix.runner}}
+          - runner: focal
+            compiler: gcc
+            version: 8
+          - runner: jammy
+            compiler: gcc
+            version: 12
+          - runner: focal
+            compiler: clang
+            version: 10
+          - runner: jammy
+            compiler: clang
+            version: 15
+    runs-on: >-
+      ${{  matrix.runner == 'focal' && 'ubuntu-20.04'
+        || matrix.runner == 'jammy' && 'ubuntu-22.04'
+        || null
+      }}
     env:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
       CCACHE_MAXSIZE: "10G"
+      CC: ${{matrix.compiler}}-${{matrix.version}}
+      CXX: ${{matrix.compiler == 'gcc' && 'g++' || 'clang++'}}-${{matrix.version}}
     steps:
       - name: Install dependencies
         run: |
@@ -32,7 +45,10 @@ jobs:
           sudo apt-get -y install \
             ccache cmake ninja-build python3 \
             nlohmann-json3-dev libgtest-dev libhepmc3-dev \
-            ${{matrix.compiler}}
+            ${{matrix.compiler}}-${{matrix.version}}
+          ld --version
+          $CC --version
+          $CXX --version
       - name: Check out Celeritas
         uses: actions/checkout@v4
         with:
@@ -42,8 +58,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
-          key: ccache-${{runner}}-${{matrix.compiler}}-${{github.run_id}}
-          restore-keys: ccache-${{runner}}-${{matrix.compiler}}
+          key: ccache-${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}-${{github.run_id}}
+          restore-keys: ccache-${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}
       - name: Zero ccache stats
         run: |
           ccache -z

--- a/.github/workflows/build-local.yml
+++ b/.github/workflows/build-local.yml
@@ -10,11 +10,9 @@ concurrency:
 
 jobs:
   linux:
+    name: ${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}
     strategy:
       matrix:
-        runner: []
-        compiler: []
-        version: []
         include:
           - runner: focal
             compiler: gcc

--- a/.github/workflows/build-local.yml
+++ b/.github/workflows/build-local.yml
@@ -1,0 +1,76 @@
+# Build directly on the GitHub runner
+name: build-local
+on:
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: build-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
+  cancel-in-progress: true
+
+jobs:
+  ubuntu-latest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ['gcc-10', 'gcc-12', 'clang-11', 'clang-15']
+    env:
+      CCACHE_DIR: "${{github.workspace}}/.ccache"
+      CCACHE_MAXSIZE: "10G"
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install \
+            ccache cmake ninja-build python3 \
+            nlohmann-json3-dev libgtest-dev libhepmc3-dev \
+            ${{matrix.compiler}}
+      - name: Check out Celeritas
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 255
+          fetch-tags: true
+      - name: Cache ccache
+        uses: actions/cache@v3
+        with:
+          path: ${{env.CCACHE_DIR}}
+          key: ccache-${{github.job}}-${{matrix.compiler}}-${{github.run_id}}
+          restore-keys: ccache-${{github.job}}-${{matrix.compiler}}
+      - name: Zero ccache stats
+        run: |
+          ccache -z
+      - name: Configure Celeritas
+        run: |
+          mkdir build && cd build
+          cmake -GNinja \
+            -DCELERITAS_BUILD_DEMOS:BOOL=ON \
+            -DCELERITAS_BUILD_TESTS:BOOL=ON \
+            -DCELERITAS_USE_SWIG=OFF \
+            -DCELERITAS_DEBUG:BOOL=ON \
+            -DCMAKE_BUILD_TYPE="Release" \
+            -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/install" \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations" \
+            ..
+      - name: Build all
+        working-directory: build
+        run: |
+          ninja
+      - name: Run tests
+        working-directory: build
+        run: |
+          ctest --parallel 2 --timeout 15 --output-on-failure \
+            --test-output-size-passed=32768 --test-output-size-failed=1048576
+      - name: Install
+        working-directory: build
+        run: |
+          ninja install
+      - name: Check installation
+        working-directory: install
+        run: |
+          ./bin/celer-sim --version
+      - name: Show ccache stats
+        run: |
+          ccache -s
+
+# vim: set nowrap tw=100:

--- a/.github/workflows/build-local.yml
+++ b/.github/workflows/build-local.yml
@@ -9,11 +9,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ubuntu-latest:
-    runs-on: ubuntu-latest
+  linux:
     strategy:
       matrix:
-        compiler: ['gcc-10', 'gcc-12', 'clang-11', 'clang-15']
+        # Newest supported OS/compilers
+        runner: ['ubuntu-22.04']
+        compiler: ['gcc-12', 'clang-15']
+        # Oldest supported OS/compilers
+        include:
+          - runner: 'ubuntu-20.04'
+            compiler: 'gcc-8'
+          - runner: 'ubuntu-20.04'
+            compiler: 'clang-10'
+    runs-on: ${{matrix.runner}}
     env:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
       CCACHE_MAXSIZE: "10G"
@@ -34,8 +42,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
-          key: ccache-${{github.job}}-${{matrix.compiler}}-${{github.run_id}}
-          restore-keys: ccache-${{github.job}}-${{matrix.compiler}}
+          key: ccache-${{runner}}-${{matrix.compiler}}-${{github.run_id}}
+          restore-keys: ccache-${{runner}}-${{matrix.compiler}}
       - name: Zero ccache stats
         run: |
           ccache -z

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-local:
+    uses: ./.github/workflows/build-local.yml
+  all-prechecks:
+    needs: [build-local]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Success
+      run: "true"
   build:
+    needs: [all-prechecks]
     uses: ./.github/workflows/build-full.yml
 
   # Specifying a dependent job allows us to select a single "requires" check


### PR DESCRIPTION
This adds a preflight build for testing Celeritas cached on native GitHub hardware before proceeding to the full build. Because it uses ccache, it should only take a few seconds for each push, versus the 12 minutes or so for the cuda/hip builds (at least 2 minutes of which is downloading the docker images).

It uses a release build (to avoid debug symbols that increase cache size) and debug assertions (to catch simple issues during testing).