### PR TITLE
Hotfix: CUDA 12.3.52 build error

### DIFF
--- a/src/orange/surf/LocalSurfaceVisitor.hh
+++ b/src/orange/surf/LocalSurfaceVisitor.hh
@@ -131,15 +131,17 @@ LocalSurfaceVisitor::operator()(F&& func, LocalSurfaceId id)
 template<class T>
 CELER_FUNCTION T LocalSurfaceVisitor::make_surface(LocalSurfaceId id) const
 {
-    using ItemIdT = typename decltype(params_.reals)::ItemIdT;
+    using Reals = decltype(params_.reals);
+    using ItemIdT = typename Reals::ItemIdT;
+    using ItemRangeT = typename Reals::ItemRangeT;
     ItemIdT offset
         = this->get_item(params_.real_ids, surfaces_.data_offsets, id);
     constexpr size_type size{T::StorageSpan::extent};
     CELER_ASSERT(offset + size <= params_.reals.size());
-    // Construct a range used to index into collection using the appropriate
-    // operator[] overload then convert to a statically sized span using the
-    // first() member template function as required by surface ctor
-    return T{params_.reals[{offset, offset + size}].template first<size>()};
+    auto storage_span = params_.reals[ItemRangeT{offset, offset + size}];
+    // Convert to a statically sized span using the first() member template
+    // function, then construct a surface, for LdgSpan to work correctly.
+    return T{storage_span.template first<size>()};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/transform/TransformVisitor.hh
+++ b/src/orange/transform/TransformVisitor.hh
@@ -124,7 +124,7 @@ TransformVisitor::make_transform(OpaqueId<real_type> data_offset) const
     constexpr size_type size{T::StorageSpan::extent};
     CELER_ASSERT(data_offset + size <= reals_.size());
 
-    return T{reals_[{data_offset, data_offset + size}]};
+    return T{reals_[Reals::ItemRangeT{data_offset, data_offset + size}]};
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
I think there's a compiler bug because AllItemsT definitely can't be constructed from two values...
```
scale/external/celeritas/src/orange/transform/TransformVisitor.hh(127): error: more than one operator "[]" matches these operands:
            function "celeritas::Collection<T, W, M, I>::operator[](celeritas::Collection<T, W, M, I>::ItemRangeT) const [with T=celeritas::real_type, W=celeritas::Ownership::const_reference, M=celeritas::MemSpace::device, I=celeritas::OpaqueId<celeritas::real_type, celeritas::size_type>]" (declared at line 301 of /home/vmuser/build/rnsd/scale/external/celeritas/src/corecel/data/Collection.hh)
            function "celeritas::Collection<T, W, M, I>::operator[](celeritas::Collection<T, W, M, I>::AllItemsT) const [with T=celeritas::real_type, W=celeritas::Ownership::const_reference, M=celeritas::MemSpace::device, I=celeritas::OpaqueId<celeritas::real_type, celeritas::size_type>]" (declared at line 305 of /home/vmuser/build/rnsd/scale/external/celeritas/src/corecel/data/Collection.hh)
            operand types are: const celeritas::TransformVisitor::Reals [ {...} ]
      return T{reals_[{data_offset, data_offset + size}]};
                     ^
```

This showed up after merging #1018.