### PR TITLE
Fix Jenkins CI build and ccache use

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,7 @@
 
 # Title
 
-Should be an imperative statement (title-cased first word,
-no trailing punctuation) summarizing its effect on the user.  For example:
+Should be an imperative statement (title-cased first word, no trailing punctuation) summarizing its effect on the user.  For example:
  - Implement the FooBar model *[enhancement, physics]*
  - Handle errors in track initialization *[enhancement, orange]*
  - Fix sampling of low-energy Celeritons *[bug, physics]*
@@ -12,15 +11,13 @@ no trailing punctuation) summarizing its effect on the user.  For example:
 
 # Description
 
-The description should summarize or enumerate the main changes in the pull
-request. Illustrative images are recommended if possible!
+The description should summarize or enumerate the main changes in the pull request. Illustrative images are recommended if possible!
 
 # Labels
 
 If you're a core developer, add one of each label:
 
 - Change type: {bug, documentation, enhancement, minor}
-- Category: {app, core, external, field, orange, performance, physics,
-  user}
+- Category: {app, core, external, field, orange, performance, physics, user}
 
 See [https://github.com/celeritas-project/celeritas/blob/develop/doc/appendices/administration.rst#review-process](review process) for descriptions of the labels and requirements.

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -1,11 +1,11 @@
-# Build directly on the GitHub runner
-name: build-local
+# Build directly on the GitHub runner with caching
+name: build-fast
 on:
   workflow_dispatch:
   workflow_call:
 
 concurrency:
-  group: build-local-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
+  group: build-fast-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-local.yml
+++ b/.github/workflows/build-local.yml
@@ -64,7 +64,9 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -GNinja \
-            -DCeleritas_GIT_DESCRIBE=";-pr.${{github.event.pull_request.number}};" \
+            -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
+              && format(';-pr.{0};', github.event.pull_request.number)
+              || format(';-{0};', github.ref_name)}}" \
             -DCELERITAS_BUILD_DEMOS:BOOL=ON \
             -DCELERITAS_BUILD_TESTS:BOOL=ON \
             -DCELERITAS_USE_SWIG=OFF \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,10 +18,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-local:
-    uses: ./.github/workflows/build-local.yml
+  build-fast:
+    uses: ./.github/workflows/build-fast.yml
   all-prechecks:
-    needs: [build-local]
+    needs: [build-fast]
     runs-on: ubuntu-latest
     steps:
     - name: Success

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,14 +16,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-local:
-    uses: ./.github/workflows/build-local.yml
+  build-fast:
+    uses: ./.github/workflows/build-fast.yml
   build-full:
     uses: ./.github/workflows/build-full.yml
   doc:
     uses: ./.github/workflows/doc.yml
   all:
-    needs: [build-local, build-full, doc]
+    needs: [build-fast, build-full, doc]
     runs-on: ubuntu-latest
     steps:
     - name: Success

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,12 +16,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-local:
+    uses: ./.github/workflows/build-local.yml
+  build-full:
     uses: ./.github/workflows/build-full.yml
   doc:
     uses: ./.github/workflows/doc.yml
   all:
-    needs: [build, doc]
+    needs: [build-local, build-full, doc]
     runs-on: ubuntu-latest
     steps:
     - name: Success

--- a/.jenkins
+++ b/.jenkins
@@ -9,53 +9,7 @@ pipeline {
   stages {
     stage('Build') {
       parallel {
-        stage('clang-minimal') {
-          agent {
-            docker {
-              image 'celeritas/ci-centos7-rocm5:2022-12-14.2'
-              // Note: this image does not require CUDA or HIP
-            }
-          }
-          steps {
-            sh 'entrypoint-shell ./scripts/ci/run-ci.sh  centos-rocm debug-orange'
-          }
-          post {
-            always {
-              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
-            }
-          }
-        }
-        stage('clang-asan') {
-          agent {
-            docker {
-              image 'celeritas/ci-centos7-rocm5:2022-12-14.2'
-            }
-          }
-          steps {
-            sh 'entrypoint-shell ./scripts/ci/run-ci.sh centos-rocm asan-orange'
-          }
-          post {
-            always {
-              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
-            }
-          }
-        }
-        stage('clang-float') {
-          agent {
-            docker {
-              image 'celeritas/ci-centos7-rocm5:2022-12-14.2'
-            }
-          }
-          steps {
-            sh 'entrypoint-shell ./scripts/ci/run-ci.sh centos-rocm debug-orange-float'
-          }
-          post {
-            always {
-              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
-            }
-          }
-        }
-        stage('hip-ndebug') {
+        stage('rocm-ndebug-orange') {
           agent {
             docker {
               image 'celeritas/ci-centos7-rocm5:2022-12-14.2'
@@ -72,7 +26,24 @@ pipeline {
             }
           }
         }
-        stage('full-novg') {
+        stage('rocm-ndebug-orange-float') {
+          agent {
+            docker {
+              image 'celeritas/ci-centos7-rocm5:2022-12-14.2'
+              label 'AMD_Radeon_Instinct_MI100 && rocm-docker'
+              args '--device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined'
+            }
+          }
+          steps {
+            sh 'entrypoint-shell ./scripts/ci/run-ci.sh centos-rocm ndebug-orange-float'
+          }
+          post {
+            always {
+              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
+            }
+          }
+        }
+        stage('cuda-debug-orange') {
           agent {
             docker {
               image 'celeritas/ci-jammy-cuda11:2023-08-02'
@@ -88,7 +59,7 @@ pipeline {
             }
           }
         }
-        stage('full-novg-ndebug') {
+        stage('cuda-ndebug-orange') {
           agent {
             docker {
               image 'celeritas/ci-jammy-cuda11:2023-08-02'
@@ -104,39 +75,7 @@ pipeline {
             }
           }
         }
-        stage('vecgeom-reldeb') {
-          agent {
-            docker {
-              image 'celeritas/ci-jammy-cuda11:2023-08-02'
-              label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
-            }
-          }
-          steps {
-            sh 'entrypoint-shell ./scripts/ci/run-ci.sh ubuntu-cuda reldeb-vecgeom'
-          }
-          post {
-            always {
-              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
-            }
-          }
-        }
-        stage('vecgeom-demos') {
-          agent {
-            docker {
-              image 'celeritas/ci-jammy-cuda11:2023-08-02'
-              label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
-            }
-          }
-          steps {
-            sh 'entrypoint-shell ./scripts/ci/run-ci.sh ubuntu-cuda ndebug-vecgeom'
-          }
-          post {
-            always {
-              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
-            }
-          }
-        }
-        stage('vecgeom-tests') {
+        stage('cuda-debug-vecgeom') {
           agent {
             docker {
               image 'celeritas/ci-jammy-cuda11:2023-08-02'
@@ -152,19 +91,35 @@ pipeline {
             }
           }
         }
-        stage('clang-geant4') {
+        stage('cuda-reldeb-vecgeom') {
           agent {
             docker {
-              image 'celeritas/ci-centos7-rocm5:2022-12-14.2'
-              // Note: this image does not require CUDA or HIP
+              image 'celeritas/ci-jammy-cuda11:2023-08-02'
+              label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
             }
           }
           steps {
-            sh 'entrypoint-shell ./scripts/ci/run-ci.sh  centos-rocm reldeb-geant4'
+            sh 'entrypoint-shell ./scripts/ci/run-ci.sh ubuntu-cuda reldeb-vecgeom'
           }
           post {
             always {
-              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
+              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
+            }
+          }
+        }
+        stage('cuda-ndebug-vecgeom') {
+          agent {
+            docker {
+              image 'celeritas/ci-jammy-cuda11:2023-08-02'
+              label 'NVIDIA_Tesla_V100-PCIE-32GB && nvidia-docker && large_images'
+            }
+          }
+          steps {
+            sh 'entrypoint-shell ./scripts/ci/run-ci.sh ubuntu-cuda ndebug-vecgeom'
+          }
+          post {
+            always {
+              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
             }
           }
         }


### PR DESCRIPTION
The Jenkins runner came back online this  morning, and the jenkins file is broken due to #1020 and subsequent github CI changes.

Also, [caching](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key) is apparently unable to use cache from another incoming PR or other branch; so I think we need to enable the "fast" builds on develop so that the cache will be ready for the branches.