### PR TITLE
Fix GeantSimpleCalo output when Celeritas is enabled

### DIFF
--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -84,7 +84,7 @@ void ActionInitialization::BuildForMaster() const
  */
 void ActionInitialization::Build() const
 {
-    CELER_LOG_LOCAL(status) << "Constructing user actions on worker threads";
+    CELER_LOG_LOCAL(status) << "Constructing user action";
 
     // Primary generator emits source particles
     if (hepmc_gen_)

--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -292,7 +292,7 @@ void DetectorConstruction::ConstructSDandField()
             sd_manager->AddNewDetector(detector.release());
 
             // Add to ROOT output
-            if (RootIO::use_root())
+            if (GlobalSetup::Instance()->root_sd_io())
             {
                 RootIO::Instance()->AddSensitiveDetector(start->first);
             }

--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -262,9 +262,10 @@ void DetectorConstruction::ConstructSDandField()
     }
     else if (sd_type == SensitiveDetectorType::simple_calo)
     {
-        CELER_LOG_LOCAL(status) << "Attaching simple calorimeters";
         for (auto& calo : simple_calos_)
         {
+            CELER_LOG_LOCAL(status) << "Attaching simple calorimeter '"
+                << calo->label() << '\'';
             // Create and attach SD
             auto detector = calo->MakeSensitiveDetector();
             CELER_ASSERT(detector);

--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -264,8 +264,8 @@ void DetectorConstruction::ConstructSDandField()
     {
         for (auto& calo : simple_calos_)
         {
-            CELER_LOG_LOCAL(status) << "Attaching simple calorimeter '"
-                << calo->label() << '\'';
+            CELER_LOG_LOCAL(status)
+                << "Attaching simple calorimeter '" << calo->label() << '\'';
             // Create and attach SD
             auto detector = calo->MakeSensitiveDetector();
             CELER_ASSERT(detector);

--- a/app/celer-g4/EventAction.cc
+++ b/app/celer-g4/EventAction.cc
@@ -70,7 +70,7 @@ void EventAction::EndOfEventAction(G4Event const* event)
         CELER_TRY_HANDLE(transport_->Flush(), call_g4exception);
     }
 
-    if (RootIO::use_root())
+    if (GlobalSetup::Instance()->root_sd_io())
     {
         // Write sensitive hits
         RootIO::Instance()->Write(event);

--- a/app/celer-g4/ExceptionHandler.cc
+++ b/app/celer-g4/ExceptionHandler.cc
@@ -68,7 +68,7 @@ G4bool ExceptionHandler::Notify(char const* origin_of_exception,
                 }
                 else
                 {
-                    CELER_LOG_LOCAL(critical) << "Aborting run due to exception";
+                    CELER_LOG_LOCAL(critical) << "Aborting run due to exception (" << exception_code << ")";
                     run_man->AbortRun();
                 }
             }

--- a/app/celer-g4/GeantDiagnostics.cc
+++ b/app/celer-g4/GeantDiagnostics.cc
@@ -77,6 +77,10 @@ GeantDiagnostics::GeantDiagnostics(SharedParams const& params)
             celeritas::environment()));
 #endif
         output_reg->insert(std::make_shared<BuildOutput>());
+
+        // Save filename from global options (TODO: remove this hack)
+        const_cast<SharedParams&>(params).set_output_filename(
+            global_setup.setup_options().output_file);
     }
 
 #if CELERITAS_USE_JSON

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -16,6 +16,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Device.hh"
+#include "celeritas/ext/RootFileManager.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
 #include "accel/ExceptionConverter.hh"
 #include "accel/SetupOptionsMessenger.hh"
@@ -171,11 +172,18 @@ void GlobalSetup::ReadInput(std::string const& filename)
         options_->output_file = input_.output_file;
     }
 
-    if (input_.sd_type == SensitiveDetectorType::event_hit
-        && !RootIO::use_root())
+    if (input_.sd_type == SensitiveDetectorType::event_hit)
     {
-        CELER_LOG(warning) << "Collecting SD hit data that will not be "
-                              "written because ROOT is disabled";
+        root_sd_io_ = RootFileManager::use_root();
+        if (!root_sd_io_)
+        {
+            CELER_LOG(warning) << "Collecting SD hit data that will not be "
+                                  "written because ROOT is disabled";
+        }
+    }
+    else
+    {
+        root_sd_io_ = false;
     }
 
     // Start the timer for setup time

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -82,6 +82,9 @@ class GlobalSetup
 
     //// NEW INTERFACE ////
 
+    //! Get setup options
+    SetupOptions const& setup_options() const { return *options_; }
+
     //! Get user input options
     RunInput const& input() const { return input_; }
 

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -85,6 +85,9 @@ class GlobalSetup
     //! Get user input options
     RunInput const& input() const { return input_; }
 
+    //! Whether ROOT I/O for SDs is enabled
+    bool root_sd_io() const { return root_sd_io_; }
+
   private:
     // Private constructor since we're a singleton
     GlobalSetup();
@@ -94,6 +97,7 @@ class GlobalSetup
     std::shared_ptr<SetupOptions> options_;
     RunInput input_;
     Stopwatch get_setup_time_;
+    bool root_sd_io_{false};
 
     std::unique_ptr<G4GenericMessenger> messenger_;
 };

--- a/app/celer-g4/RootIO.cc
+++ b/app/celer-g4/RootIO.cc
@@ -34,18 +34,6 @@ namespace app
 {
 //---------------------------------------------------------------------------//
 /*!
- * Whether ROOT interfacing is enabled.
- *
- * This is true unless the \c CELER_DISABLE_ROOT environment variable is
- * set to a non-empty value.
- */
-bool RootIO::use_root()
-{
-    return RootFileManager::use_root();
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Create a ROOT output file for each worker thread in MT.
  */
 RootIO::RootIO()

--- a/app/celer-g4/RootIO.hh
+++ b/app/celer-g4/RootIO.hh
@@ -35,14 +35,6 @@ class RootIO
     friend class G4ThreadLocalSingleton<RootIO>;
 
   public:
-#if CELERITAS_USE_ROOT
-    // Whether ROOT output is enabled
-    static bool use_root();
-#else
-    // ROOT is never enabled if ROOT isn't available
-    constexpr static bool use_root() { return false; }
-#endif
-
     // Return non-owning pointer to a singleton
     static RootIO* Instance();
 

--- a/app/celer-g4/RunAction.cc
+++ b/app/celer-g4/RunAction.cc
@@ -68,7 +68,11 @@ void RunAction::BeginOfRunAction(G4Run const* run)
         {
             // This worker (or master thread) is responsible for initializing
             // celeritas: initialize shared data and setup GPU on all threads
-            CELER_TRY_HANDLE(params_->Initialize(*options_), call_g4exception);
+            // TODO: reusing the existing output registry is a hack needed to
+            // preserve the GeantSimpleCalo output. This will be fixed in 0.5
+            CELER_TRY_HANDLE(
+                params_->Initialize(*options_, params_->output_reg()),
+                call_g4exception);
             CELER_ASSERT(*params_);
         }
         else

--- a/app/celer-g4/RunAction.cc
+++ b/app/celer-g4/RunAction.cc
@@ -115,7 +115,7 @@ void RunAction::EndOfRunAction(G4Run const*)
 {
     ExceptionConverter call_g4exception{"celer0005"};
 
-    if (RootIO::use_root())
+    if (GlobalSetup::Instance()->root_sd_io())
     {
         // Close ROOT output of sensitive hits
         CELER_TRY_HANDLE(RootIO::Instance()->Close(), call_g4exception);

--- a/src/accel/GeantSimpleCalo.cc
+++ b/src/accel/GeantSimpleCalo.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "GeantSimpleCalo.hh"
 
+#include "celeritas_config.h"
 #include "corecel/cont/Range.hh"
 #include "corecel/io/Logger.hh"
 #include "celeritas/ext/GeantGeoParams.hh"
@@ -16,7 +17,6 @@
 #include "SharedParams.hh"
 #include "detail/GeantSimpleCaloSD.hh"
 #include "detail/GeantSimpleCaloStorage.hh"
-
 #if CELERITAS_USE_JSON
 #    include <nlohmann/json.hpp>
 

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -18,7 +18,6 @@
 #include <G4ParticleTable.hh>
 #include <G4RunManager.hh>
 #include <G4Threading.hh>
-#include <G4UImanager.hh>
 
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
@@ -251,6 +250,19 @@ void SharedParams::Initialize(SetupOptions const& options, SPOutputRegistry reg)
 {
     CELER_EXPECT(reg);
     *this = SharedParams(options, std::move(reg));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Save a diagnostic output filename from a Geant4 app when Celeritas is off.
+ *
+ * This will be overwritten when calling Initialized with setup options.
+ *
+ * TODO: this hack should be deleted in v0.5.
+ */
+void SharedParams::set_output_filename(std::string const& filename)
+{
+    output_filename_ = filename;
 }
 
 //---------------------------------------------------------------------------//
@@ -594,17 +606,8 @@ void SharedParams::try_output() const
     if (CELERITAS_USE_JSON && !params_ && filename.empty())
     {
         // Setup was not called but JSON is available: make a default filename
-        G4UImanager* ui = G4UImanager::GetUIpointer();
-        filename = ui->GetCurrentValues("/celer/outputFile");
-        if (!filename.empty())
-        {
-            CELER_LOG(debug) << "Set Celeritas output filename from G4UI";
-        }
-        else
-        {
-            filename = "celeritas.json";
-            CELER_LOG(debug) << "Set default Celeritas output filename";
-        }
+        filename = "celeritas.json";
+        CELER_LOG(debug) << "Set default Celeritas output filename";
     }
 
     if (filename.empty())

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -124,6 +124,9 @@ class SharedParams
     // Initialize shared data on the "master" thread with existing output
     // registry
     void Initialize(SetupOptions const& options, SPOutputRegistry reg);
+
+    // Set the output filename when celeritas is disabled
+    void set_output_filename(std::string const&);
     //!@}
 
   private:

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -116,6 +116,14 @@ class SharedParams
 
     // Geant geometry wrapper, lazily created
     SPConstGeantGeoParams const& geant_geo_params() const;
+
+    // NASTY HACK TO BE DELETED:
+    // Construct Celeritas using Geant4 data and existing output registry
+    SharedParams(SetupOptions const& options, SPOutputRegistry reg);
+
+    // Initialize shared data on the "master" thread with existing output
+    // registry
+    void Initialize(SetupOptions const& options, SPOutputRegistry reg);
     //!@}
 
   private:


### PR DESCRIPTION
The simple calorimeter SD implementation in #1014 was only tested with Geant4 disabled, so the call to `SharedParams::Initialize` would reset the output and prevent the calo from being printed at the end of the program run.

I also updated the local logger to use a mutex for output to avoid stepping on each other, and I fixed a few other small bugs while trying to get this to work.