### PR TITLE
Support sorting tracks by particle types

### DIFF
--- a/src/celeritas/Types.cc
+++ b/src/celeritas/Types.cc
@@ -61,6 +61,7 @@ char const* to_cstring(TrackOrder value)
         "sort_along_step_action",
         "sort_step_limit_action",
         "sort_action",
+        "sort_particle_type",
     };
     return to_cstring_impl(value);
 }

--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -144,6 +144,7 @@ enum class TrackOrder
     sort_along_step_action,  //!< Sort only by the along-step action id
     sort_step_limit_action,  //!< Sort only by the step limit action id
     sort_action,  //!< Sort by along-step id, then post-step ID
+    sort_particle_type,  //!< Sort by particle type
     size_
 };
 

--- a/src/corecel/sys/KernelParamCalculator.device.hh
+++ b/src/corecel/sys/KernelParamCalculator.device.hh
@@ -44,6 +44,29 @@
         CELER_DEVICE_CHECK_ERROR();                                          \
     } while (0)
 
+/*!
+ * \def CELER_LAUNCH_KERNEL_TEMPLATE_1
+ *
+ * Create a kernel param calculator with the given kernel with
+ * one template parameter, assuming the unction itself has a \c _kernel
+ * suffix, and launch with the given block/thread sizes and arguments list.
+ */
+#define CELER_LAUNCH_KERNEL_TEMPLATE_1(NAME, T1, THREADS, STREAM, ...)       \
+    do                                                                       \
+    {                                                                        \
+        static const ::celeritas::KernelParamCalculator calc_launch_params_( \
+            #NAME, NAME##_kernel<T1>);                                       \
+        auto grid_ = calc_launch_params_(THREADS);                           \
+                                                                             \
+        CELER_LAUNCH_KERNEL_IMPL(NAME##_kernel,                              \
+                                 grid_.blocks_per_grid,                      \
+                                 grid_.threads_per_block,                    \
+                                 0,                                          \
+                                 STREAM,                                     \
+                                 __VA_ARGS__);                               \
+        CELER_DEVICE_CHECK_ERROR();                                          \
+    } while (0)
+
 #if CELERITAS_USE_CUDA
 #    define CELER_LAUNCH_KERNEL_IMPL(KERNEL, GRID, BLOCK, SHARED, STREAM, ...) \
         KERNEL<<<GRID, BLOCK, SHARED, STREAM>>>(__VA_ARGS__)


### PR DESCRIPTION
Add an option to sort tracks by particle types. Most of the existing code used to sort on `ActionId` can be reused, I just needed to had a macro to launch a kernel template.