### PR TITLE
Support using VecGeom without VGDML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,21 +332,21 @@ if(CELERITAS_USE_VecGeom)
 
   if(CELERITAS_USE_CUDA AND NOT VecGeom_CUDA_FOUND)
     celeritas_error_incompatible_option(
-      "VecGeom installation at ${VECGEOM_INSTALL_DIR} is not CUDA-enabled"
+      "VecGeom installation at \"${VecGeom_DIR}\" is not CUDA-enabled"
       CELERITAS_USE_CUDA
       "${VecGeom_CUDA_FOUND}"
     )
   endif()
   if(CELERITAS_REAL_TYPE STREQUAL "float" AND NOT VecGeom_single_precision_FOUND)
     celeritas_error_incompatible_option(
-      "VecGeom installation at ${VECGEOM_INSTALL_DIR} uses double precision"
+      "VecGeom installation at \"${VecGeom_DIR}\" uses double precision"
       CELERITAS_REAL_TYPE
       "double"
     )
   endif()
   if(CELERITAS_REAL_TYPE STREQUAL "double" AND VecGeom_single_precision_FOUND)
     celeritas_error_incompatible_option(
-      "VecGeom installation at ${VECGEOM_INSTALL_DIR} uses single precision"
+      "VecGeom installation at \"${VecGeom_DIR}\" uses single precision"
       CELERITAS_REAL_TYPE
       "float"
     )
@@ -354,7 +354,7 @@ if(CELERITAS_USE_VecGeom)
   if(CELERITAS_BUILD_TESTS AND NOT VecGeom_GDML_FOUND
       AND CELERITAS_CORE_GEO STREQUAL "VecGeom")
     celeritas_error_incompatible_option(
-      "VecGeom installation at ${VECGEOM_INSTALL_DIR} was not built with VGDML:
+      "VecGeom installation at \"${VecGeom_DIR}\" was not built with VGDML:
       celer-sim and many tests will fail"
       CELERITAS_BUILD_TESTS
       OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,8 +318,16 @@ if(CELERITAS_USE_SWIG)
 endif()
 
 if(CELERITAS_USE_VecGeom)
+  set(_min_vecgeom_version 1.2.4)
   if(NOT VecGeom_FOUND)
-    find_package(VecGeom 1.2.4 REQUIRED)
+    find_package(VecGeom ${_min_vecgeom_version} REQUIRED)
+  elseif(VecGeom_VERSION VERSION_LESS _min_vecgeom_version)
+    # Another package, probably Geant4, is already using vecgeom
+    celeritas_error_incompatible_option(
+      "VecGeom version \"${VecGeom_VERSION}\" at \"${VecGeom_DIR}\" is too old for Celeritas to use: you must update to ${_min_vecgeom_version} or higher"
+      CELERITAS_USE_VecGeom
+      OFF
+    )
   endif()
 
   if(CELERITAS_USE_CUDA AND NOT VecGeom_CUDA_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,9 +343,6 @@ if(CELERITAS_USE_VecGeom)
       "float"
     )
   endif()
-  if(NOT VecGeom_GDML_FOUND)
-    message(SEND_ERROR "VecGeom GDML capability is required for Celeritas")
-  endif()
 endif()
 
 if(CELERITAS_BUILD_DEMOS AND NOT CELERITAS_USE_JSON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,15 @@ if(CELERITAS_USE_VecGeom)
       "float"
     )
   endif()
+  if(CELERITAS_BUILD_TESTS AND NOT VecGeom_GDML_FOUND
+      AND CELERITAS_CORE_GEO STREQUAL "VecGeom")
+    celeritas_error_incompatible_option(
+      "VecGeom installation at ${VECGEOM_INSTALL_DIR} was not built with VGDML:
+      celer-sim and many tests will fail"
+      CELERITAS_BUILD_TESTS
+      OFF
+    )
+  endif()
 endif()
 
 if(CELERITAS_BUILD_DEMOS AND NOT CELERITAS_USE_JSON)

--- a/app/celer-sim/CMakeLists.txt
+++ b/app/celer-sim/CMakeLists.txt
@@ -63,7 +63,8 @@ set(_env
 )
 
 if(CELERITAS_USE_Geant4 AND CELERITAS_USE_HepMC3 AND CELERITAS_USE_Python
-    AND (NOT CELERITAS_CORE_GEO STREQUAL "Geant4"))
+    AND (NOT CELERITAS_CORE_GEO STREQUAL "Geant4")
+    AND (VecGeom_GDML_FOUND OR NOT (CELERITAS_CORE_GEO STREQUAL "VecGeom")))
   set(_needs_deps)
 else()
   set(_needs_deps DISABLED true)

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -231,6 +231,7 @@ endif()
 if(CELERITAS_USE_VecGeom)
   list(APPEND SOURCES
     ext/VecgeomParams.cc
+    ext/VecgeomParamsOutput.cc
     ext/detail/VecgeomNavCollection.cc
   )
   if(VecGeom_GDML_FOUND)

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -233,7 +233,9 @@ if(CELERITAS_USE_VecGeom)
     ext/VecgeomParams.cc
     ext/detail/VecgeomNavCollection.cc
   )
-  list(APPEND PRIVATE_DEPS VecGeom::vgdml)
+  if(VecGeom_GDML_FOUND)
+    list(APPEND PRIVATE_DEPS VecGeom::vgdml)
+  endif()
   if(VecGeom_CUDA_FOUND AND VecGeom_SURF_FOUND)
     # Special routines needed for surface
     list(APPEND SOURCES

--- a/src/celeritas/ext/GeantGeoUtils.cc
+++ b/src/celeritas/ext/GeantGeoUtils.cc
@@ -54,11 +54,8 @@ load_geant_geometry_impl(std::string const& filename, bool strip_pointer_ext)
     {
         // Always-on debug assertion (not a "runtime" error but a
         // subtle programming logic error that always causes a crash)
-        throw DebugError({DebugErrorType::precondition,
-                          "Geant4 geometry cannot be loaded from a worker "
-                          "thread",
-                          __FILE__,
-                          __LINE__});
+        CELER_DEBUG_FAIL(
+            "Geant4 geometry cannot be loaded from a worker thread", internal);
     }
 
     ScopedMem record_mem("load_geant_geometry");

--- a/src/celeritas/ext/GeantGeoUtils.cc
+++ b/src/celeritas/ext/GeantGeoUtils.cc
@@ -61,14 +61,6 @@ load_geant_geometry_impl(std::string const& filename, bool strip_pointer_ext)
     ScopedMem record_mem("load_geant_geometry");
     ScopedTimeLog scoped_time;
 
-    {
-        // Creating the GDML parser resets the ScopedGeantLogger on its first
-        // instantiation (geant4@11.0), possibly due to the constructor
-        // initializing the UI manager, which through
-        // G4LocalThreadCoutMessenger seems to alter the cout state
-        G4GDMLParser temp_parser_init;
-    }
-
     ScopedGeantLogger scoped_logger;
     ScopedGeantExceptionHandler scoped_exceptions;
 

--- a/src/celeritas/ext/ScopedGeantLogger.cc
+++ b/src/celeritas/ext/ScopedGeantLogger.cc
@@ -77,11 +77,10 @@ GeantLoggerAdapter::GeantLoggerAdapter()
     {
         // Always-on debug assertion (not a "runtime" error but a
         // subtle programming logic error that always causes a crash)
-        throw DebugError({DebugErrorType::precondition,
-                          "Geant4 logging cannot be changed after G4UImanager "
-                          "has been destroyed",
-                          __FILE__,
-                          __LINE__});
+        CELER_DEBUG_FAIL(
+            "Geant4 logging cannot be changed after G4UImanager has been "
+            "destroyed",
+            precondition);
     }
 
 #if CELER_G4SSBUF

--- a/src/celeritas/ext/ScopedGeantLogger.cc
+++ b/src/celeritas/ext/ScopedGeantLogger.cc
@@ -11,7 +11,9 @@
 #include <memory>
 #include <mutex>
 #include <G4String.hh>
+#include <G4Threading.hh>
 #include <G4Types.hh>
+#include <G4UImanager.hh>
 #include <G4Version.hh>
 #include <G4coutDestination.hh>
 #if G4VERSION_NUMBER >= 1120
@@ -22,6 +24,7 @@
 #    define CELER_G4SSBUF 1
 #endif
 
+#include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringUtils.hh"
 
@@ -70,6 +73,17 @@ class GeantLoggerAdapter : public G4coutDestination
  */
 GeantLoggerAdapter::GeantLoggerAdapter()
 {
+    if (!G4UImanager::GetUIpointer())
+    {
+        // Always-on debug assertion (not a "runtime" error but a
+        // subtle programming logic error that always causes a crash)
+        throw DebugError({DebugErrorType::precondition,
+                          "Geant4 logging cannot be changed after G4UImanager "
+                          "has been destroyed",
+                          __FILE__,
+                          __LINE__});
+    }
+
 #if CELER_G4SSBUF
     saved_cout_ = G4coutbuf.GetDestination();
     saved_cerr_ = G4cerrbuf.GetDestination();

--- a/src/celeritas/ext/VecgeomParams.cc
+++ b/src/celeritas/ext/VecgeomParams.cc
@@ -31,18 +31,19 @@
 #include "corecel/device_runtime_api.h"
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
-#include "corecel/sys/Environment.hh"
-#include "corecel/sys/ScopedLimitSaver.hh"
-#include "corecel/sys/ScopedProfiling.hh"
-#include "celeritas/ext/detail/VecgeomCompatibility.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/ScopedTimeAndRedirect.hh"
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/Environment.hh"
+#include "corecel/sys/ScopedLimitSaver.hh"
 #include "corecel/sys/ScopedMem.hh"
+#include "corecel/sys/ScopedProfiling.hh"
+#include "celeritas/ext/detail/VecgeomCompatibility.hh"
 
+#include "GeantGeoUtils.hh"
 #include "VecgeomData.hh"  // IWYU pragma: associated
 #include "g4vg/Converter.hh"
 
@@ -121,6 +122,19 @@ bool VecgeomParams::use_surface_tracking()
 
 //---------------------------------------------------------------------------//
 /*!
+ * Whether VecGeom GDML is used to load the geometry.
+ */
+bool VecgeomParams::use_vgdml()
+{
+#ifdef VECGEOM_GDML
+    return true;
+#else
+    return false;
+#endif
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct from a GDML input.
  */
 VecgeomParams::VecgeomParams(std::string const& filename)
@@ -132,15 +146,24 @@ VecgeomParams::VecgeomParams(std::string const& filename)
     }
 
     ScopedMem record_mem("VecgeomParams.construct");
+
+    if (VecgeomParams::use_vgdml())
     {
-        ScopedProfiling profile_this{"load-vecgeom"};
-        ScopedMem record_mem("VecgeomParams.load_geant_geometry");
-        ScopedTimeAndRedirect time_and_output_("vgdml::Frontend");
-#ifdef VECGEOM_GDML
-        vgdml::Frontend::Load(filename, /* validate_xml_schema = */ false);
-#else
-        CELER_NOT_CONFIGURED("VecGeom with VGDML");
-#endif
+        this->build_volumes_vgdml(filename);
+    }
+    else if (CELERITAS_USE_GEANT4)
+    {
+        CELER_LOG(warning)
+            << "VecGeom GDML is disabled: using Geant4 to load and "
+               "G4VG to convert";
+        auto* world = load_geant_geometry(filename);
+        CELER_ASSERT(world);
+        loaded_geant4_gdml_ = true;
+        this->build_volumes_geant4(world);
+    }
+    else
+    {
+        CELER_NOT_CONFIGURED("VGDML or Geant4");
     }
 
     this->build_tracking();
@@ -160,25 +183,7 @@ VecgeomParams::VecgeomParams(G4VPhysicalVolume const* world)
     CELER_EXPECT(world);
     ScopedMem record_mem("VecgeomParams.construct");
 
-    {
-        // Convert the geometry to VecGeom
-        ScopedProfiling profile_this{"load-vecgeom"};
-        g4vg::Converter::Options opts;
-        opts.compare_volumes
-            = !celeritas::getenv("G4VG_COMPARE_VOLUMES").empty();
-        g4vg::Converter convert{opts};
-        auto result = convert(world);
-        CELER_ASSERT(result.world != nullptr);
-        g4log_volid_map_ = std::move(result.volumes);
-
-        // Set as world volume
-        auto& vg_manager = vecgeom::GeoManager::Instance();
-        vg_manager.RegisterPlacedVolume(result.world);
-        vg_manager.SetWorldAndClose(result.world);
-
-        // NOTE: setting and closing changes the world
-        CELER_ASSERT(vg_manager.GetWorld() != nullptr);
-    }
+    this->build_volumes_geant4(world);
 
     this->build_tracking();
     this->build_data();
@@ -216,6 +221,11 @@ VecgeomParams::~VecgeomParams()
 
     CELER_LOG(debug) << "Clearing VecGeom CPU data";
     vecgeom::GeoManager::Instance().Clear();
+
+    if (loaded_geant4_gdml_)
+    {
+        reset_geant_geometry();
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -284,7 +294,48 @@ auto VecgeomParams::find_volumes(std::string const& name) const
 
 //---------------------------------------------------------------------------//
 /*!
- * After loading solids, set up VecGeom tracking data and copy to GPU.
+ * Construct VecGeom objects using the VGDML reader.
+ */
+void VecgeomParams::build_volumes_vgdml(std::string const& filename)
+{
+    ScopedProfiling profile_this{"load-vecgeom"};
+    ScopedMem record_mem("VecgeomParams.load_geant_geometry");
+    ScopedTimeAndRedirect time_and_output_("vgdml::Frontend");
+#ifdef VECGEOM_GDML
+    vgdml::Frontend::Load(filename, /* validate_xml_schema = */ false);
+#else
+    CELER_DISCARD(filename);
+    CELER_NOT_CONFIGURED("VGDML");
+#endif
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct VecGeom objects using Geant4 objects in memory.
+ */
+void VecgeomParams::build_volumes_geant4(G4VPhysicalVolume const* world)
+{
+    // Convert the geometry to VecGeom
+    ScopedProfiling profile_this{"load-vecgeom"};
+    g4vg::Converter::Options opts;
+    opts.compare_volumes = !celeritas::getenv("G4VG_COMPARE_VOLUMES").empty();
+    g4vg::Converter convert{opts};
+    auto result = convert(world);
+    CELER_ASSERT(result.world != nullptr);
+    g4log_volid_map_ = std::move(result.volumes);
+
+    // Set as world volume
+    auto& vg_manager = vecgeom::GeoManager::Instance();
+    vg_manager.RegisterPlacedVolume(result.world);
+    vg_manager.SetWorldAndClose(result.world);
+
+    // NOTE: setting and closing changes the world
+    CELER_ASSERT(vg_manager.GetWorld() != nullptr);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * After loading solids+volumes, set up VecGeom tracking data and copy to GPU.
  */
 void VecgeomParams::build_tracking()
 {

--- a/src/celeritas/ext/VecgeomParams.cc
+++ b/src/celeritas/ext/VecgeomParams.cc
@@ -11,20 +11,12 @@
 #include <vector>
 #include <VecGeom/base/Config.h>
 #include <VecGeom/base/Cuda.h>
-#include <VecGeom/gdml/Frontend.h>
 #include <VecGeom/management/ABBoxManager.h>
 #include <VecGeom/management/BVHManager.h>
 #include <VecGeom/management/GeoManager.h>
 #include <VecGeom/volumes/PlacedVolume.h>
 
 #include "celeritas_config.h"
-#include "corecel/device_runtime_api.h"
-#include "corecel/Assert.hh"
-#include "corecel/Macros.hh"
-#include "corecel/sys/Environment.hh"
-#include "corecel/sys/ScopedLimitSaver.hh"
-#include "corecel/sys/ScopedProfiling.hh"
-#include "celeritas/ext/detail/VecgeomCompatibility.hh"
 #if CELERITAS_USE_CUDA
 #    include <VecGeom/management/CudaManager.h>
 #    include <cuda_runtime_api.h>
@@ -32,7 +24,17 @@
 #ifdef VECGEOM_USE_SURF
 #    include <VecGeom/surfaces/BrepHelper.h>
 #endif
+#ifdef VECGEOM_GDML
+#include <VecGeom/gdml/Frontend.h>
+#endif
 
+#include "corecel/device_runtime_api.h"
+#include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+#include "corecel/sys/Environment.hh"
+#include "corecel/sys/ScopedLimitSaver.hh"
+#include "corecel/sys/ScopedProfiling.hh"
+#include "celeritas/ext/detail/VecgeomCompatibility.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
@@ -134,7 +136,11 @@ VecgeomParams::VecgeomParams(std::string const& filename)
         ScopedProfiling profile_this{"load-vecgeom"};
         ScopedMem record_mem("VecgeomParams.load_geant_geometry");
         ScopedTimeAndRedirect time_and_output_("vgdml::Frontend");
+#ifdef VECGEOM_GDML
         vgdml::Frontend::Load(filename, /* validate_xml_schema = */ false);
+#else
+        CELER_NOT_CONFIGURED("VecGeom with VGDML");
+#endif
     }
 
     this->build_tracking();

--- a/src/celeritas/ext/VecgeomParams.cc
+++ b/src/celeritas/ext/VecgeomParams.cc
@@ -25,7 +25,7 @@
 #    include <VecGeom/surfaces/BrepHelper.h>
 #endif
 #ifdef VECGEOM_GDML
-#include <VecGeom/gdml/Frontend.h>
+#    include <VecGeom/gdml/Frontend.h>
 #endif
 
 #include "corecel/device_runtime_api.h"
@@ -151,19 +151,9 @@ VecgeomParams::VecgeomParams(std::string const& filename)
     {
         this->build_volumes_vgdml(filename);
     }
-    else if (CELERITAS_USE_GEANT4)
-    {
-        CELER_LOG(warning)
-            << "VecGeom GDML is disabled: using Geant4 to load and "
-               "G4VG to convert";
-        auto* world = load_geant_geometry(filename);
-        CELER_ASSERT(world);
-        loaded_geant4_gdml_ = true;
-        this->build_volumes_geant4(world);
-    }
     else
     {
-        CELER_NOT_CONFIGURED("VGDML or Geant4");
+        CELER_NOT_CONFIGURED("VGDML");
     }
 
     this->build_tracking();

--- a/src/celeritas/ext/VecgeomParams.hh
+++ b/src/celeritas/ext/VecgeomParams.hh
@@ -36,6 +36,9 @@ class VecgeomParams final : public GeoParamsInterface,
     // Whether surface tracking is being used
     static bool use_surface_tracking();
 
+    // Whether VecGeom GDML is being used to load the geometry
+    static bool use_vgdml();
+
     // Construct from a GDML filename
     explicit VecgeomParams(std::string const& gdml_filename);
 
@@ -102,9 +105,14 @@ class VecgeomParams final : public GeoParamsInterface,
     HostRef host_ref_;
     DeviceRef device_ref_;
 
+    // If VGDML is unavailable and Geant4 is, we load and
+    bool loaded_geant4_gdml_{false};
+
     //// HELPER FUNCTIONS ////
 
     // Construct VecGeom tracking data and copy to GPU
+    void build_volumes_vgdml(std::string const& filename);
+    void build_volumes_geant4(G4VPhysicalVolume const* world);
     void build_tracking();
     void build_surface_tracking();
     void build_volume_tracking();

--- a/src/celeritas/ext/VecgeomParamsOutput.cc
+++ b/src/celeritas/ext/VecgeomParamsOutput.cc
@@ -1,0 +1,52 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/VecgeomParamsOutput.cc
+//---------------------------------------------------------------------------//
+#include "VecgeomParamsOutput.hh"
+
+#include "celeritas_config.h"
+#include "corecel/cont/Range.hh"
+#include "corecel/io/JsonPimpl.hh"
+
+#include "VecgeomParams.hh"  // IWYU pragma: keep
+#if CELERITAS_USE_JSON
+#    include <nlohmann/json.hpp>
+#endif
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from shared vecgeom data.
+ */
+VecgeomParamsOutput::VecgeomParamsOutput(SPConstVecgeomParams vecgeom)
+    : vecgeom_(std::move(vecgeom))
+{
+    CELER_EXPECT(vecgeom_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void VecgeomParamsOutput::output(JsonPimpl* j) const
+{
+#if CELERITAS_USE_JSON
+    using json = nlohmann::json;
+
+    auto scalars = json::object({
+        {"max_depth", vecgeom_->max_depth()},
+        {"use_vgdml", vecgeom_->use_vgdml()},
+        {"use_surface_tracking", vecgeom_->use_surface_tracking()},
+    });
+    j->obj = json::object({{"scalars", std::move(scalars)}});
+#else
+    (void)sizeof(j);
+#endif
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/ext/VecgeomParamsOutput.hh
+++ b/src/celeritas/ext/VecgeomParamsOutput.hh
@@ -1,0 +1,51 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/VecgeomParamsOutput.hh
+//---------------------------------------------------------------------------//
+#pragma once
+#include <memory>
+
+#include "corecel/io/OutputInterface.hh"
+
+namespace celeritas
+{
+class VecgeomParams;
+//---------------------------------------------------------------------------//
+/*!
+ * Save extra debugging information about the VecGeom geometry.
+ *
+ * This is to be used in *addition* to the standard bbox/volume/surface data
+ * saved by GeoParamsOutput.
+ *
+ * \sa celeritas/geo/GeoParamsOutput.hh
+ */
+class VecgeomParamsOutput final : public OutputInterface
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using SPConstVecgeomParams = std::shared_ptr<VecgeomParams const>;
+    //!@}
+
+  public:
+    // Construct from shared geometry data
+    explicit VecgeomParamsOutput(SPConstVecgeomParams vecgeom);
+
+    //! Category of data to write
+    Category category() const final { return Category::internal; }
+
+    //! Name of the entry inside the category.
+    std::string label() const final { return "vecgeom"; }
+
+    // Write output to the given JSON object
+    void output(JsonPimpl*) const final;
+
+  private:
+    SPConstVecgeomParams vecgeom_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/ext/g4vg/Converter.cc
+++ b/src/celeritas/ext/g4vg/Converter.cc
@@ -14,7 +14,7 @@
 #include <G4PVPlacement.hh>
 #include <G4ReflectionFactory.hh>
 #include <G4VPhysicalVolume.hh>
-#include <VecGeom/gdml/ReflFactory.h>
+#include <VecGeom/management/ReflFactory.h>
 #include <VecGeom/volumes/LogicalVolume.h>
 #include <VecGeom/volumes/PlacedVolume.h>
 
@@ -190,7 +190,7 @@ auto Converter::build_with_daughters(G4LogicalVolume const* mother_g4lv)
 
         // Use the VGDML reflection factory to place the daughter in the mother
         // (it must *always* be used, in case parent is reflected)
-        vgdml::ReflFactory::Instance().Place(
+        vecgeom::ReflFactory::Instance().Place(
             (*this->convert_transform_)(g4pv->GetTranslation(),
                                         g4pv->GetRotation()),
             vecgeom::Vector3D<double>{1.0, 1.0, flip_z ? -1.0 : 1.0},

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -22,8 +22,6 @@
 #include "corecel/sys/KernelRegistry.hh"
 #include "corecel/sys/MemRegistry.hh"
 #include "corecel/sys/ScopedMem.hh"
-#include "orange/OrangeParams.hh"
-#include "orange/OrangeParamsOutput.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/GeoParamsOutput.hh"
@@ -54,6 +52,14 @@
 #    include "corecel/sys/EnvironmentIO.json.hh"
 #    include "corecel/sys/KernelRegistryIO.json.hh"
 #    include "corecel/sys/MemRegistryIO.json.hh"
+#endif
+
+#if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
+#    include "orange/OrangeParams.hh"
+#    include "orange/OrangeParamsOutput.hh"
+#elif CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM
+#    include "celeritas/ext/VecgeomParams.hh"
+#    include "celeritas/ext/VecgeomParamsOutput.hh"
 #endif
 
 namespace celeritas
@@ -305,6 +311,9 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
     input_.output_reg->insert(
         std::make_shared<OrangeParamsOutput>(input_.geometry));
+#elif CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM
+    input_.output_reg->insert(
+        std::make_shared<VecgeomParamsOutput>(input_.geometry));
 #endif
 
     CELER_LOG(status) << "Celeritas core setup complete";

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -94,6 +94,13 @@
  * \endcode
  */
 /*!
+ * \def CELER_DEBUG_FAIL
+ *
+ * Throw a debug assertion regardless of the \c CELERITAS_DEBUG setting. This
+ * is used internally but is also useful for catching subtle programming errors
+ * in downstream code.
+ */
+/*!
  * \def CELER_ASSERT_UNREACHABLE
  *
  * Throw an assertion if the code point is reached. When debug assertions are
@@ -160,12 +167,6 @@
             CELER_DEBUG_THROW_(#COND, WHICH); \
         }                                     \
     } while (0)
-#define CELER_DEBUG_FAIL_(MSG, WHICH)   \
-    do                                  \
-    {                                   \
-        CELER_DEBUG_THROW_(MSG, WHICH); \
-        ::celeritas::unreachable();     \
-    } while (0)
 #define CELER_NDEBUG_ASSUME_(COND)      \
     do                                  \
     {                                   \
@@ -181,13 +182,20 @@
     } while (0)
 //! \endcond
 
+#define CELER_DEBUG_FAIL(MSG, WHICH)   \
+    do                                  \
+    {                                   \
+        CELER_DEBUG_THROW_(MSG, WHICH); \
+        ::celeritas::unreachable();     \
+    } while (0)
+
 #if CELERITAS_DEBUG
 #    define CELER_EXPECT(COND) CELER_DEBUG_ASSERT_(COND, precondition)
 #    define CELER_ASSERT(COND) CELER_DEBUG_ASSERT_(COND, internal)
 #    define CELER_ENSURE(COND) CELER_DEBUG_ASSERT_(COND, postcondition)
 #    define CELER_ASSUME(COND) CELER_DEBUG_ASSERT_(COND, assumption)
 #    define CELER_ASSERT_UNREACHABLE() \
-        CELER_DEBUG_FAIL_("unreachable code point encountered", unreachable)
+        CELER_DEBUG_FAIL("unreachable code point encountered", unreachable)
 #else
 #    define CELER_EXPECT(COND) CELER_NOASSERT_(COND)
 #    define CELER_ASSERT(COND) CELER_NOASSERT_(COND)
@@ -210,12 +218,12 @@
         } while (0)
 #else
 #    define CELER_VALIDATE(COND, MSG)                                         \
-        CELER_DEBUG_FAIL_("CELER_VALIDATE cannot be called from device code", \
+        CELER_DEBUG_FAIL("CELER_VALIDATE cannot be called from device code", \
                           unreachable);
 #endif
 
-#define CELER_NOT_CONFIGURED(WHAT) CELER_DEBUG_FAIL_(WHAT, unconfigured)
-#define CELER_NOT_IMPLEMENTED(WHAT) CELER_DEBUG_FAIL_(WHAT, unimplemented)
+#define CELER_NOT_CONFIGURED(WHAT) CELER_DEBUG_FAIL(WHAT, unconfigured)
+#define CELER_NOT_IMPLEMENTED(WHAT) CELER_DEBUG_FAIL(WHAT, unimplemented)
 
 /*!
  * \def CELER_CUDA_CALL

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -367,22 +367,29 @@ set(CELERITASTEST_PREFIX celeritas/ext)
 if(CELERITAS_USE_VecGeom)
   # Vecgeom uses global counters that interfere with copying data to GPU and
   # change the internal numbering.
-  set(_vecgeom_tests
-    "SimpleCmsTest.*"
-  )
-  if(NOT VecGeom_SURF_FOUND)
-    # TODO: vecgeom surface doesn't support some of these shapes
+  set(_vecgeom_tests)
+  if(VecGeom_GDML_FOUND)
     list(APPEND _vecgeom_tests
-      "FourLevelsTest.*"
-      "SolidsTest.*"
-      "CmseTest.*"
+      "SimpleCmsTest.*"
     )
+    if(NOT VecGeom_SURF_FOUND)
+      # TODO: vecgeom surface doesn't support some of these shapes
+      list(APPEND _vecgeom_tests
+        "FourLevelsTest.*"
+        "SolidsTest.*"
+        "CmseTest.*"
+      )
+    endif()
   endif()
   if(CELERITAS_USE_Geant4)
     list(APPEND _vecgeom_tests
       "FourLevelsGeantTest.*"
       "SolidsGeantTest.*"
     )
+  endif()
+  if(NOT _vecgeom_tests)
+    # Bad: no way of setting up geometry!
+    set(_vecgeom_tests DISABLE)
   endif()
   celeritas_add_device_test(celeritas/ext/Vecgeom
     FILTER


### PR DESCRIPTION
The default CMS build does not enable VecGeom's GDML reader. When using celer-g4 or the `accel` library, we also don't need to use it since we rely on the in-memory Geant4-vecgeom converter. The main change is to update the ReflFactory to its newer path (requires VecGeom 1.2.3 or higher, but we have a new minimum of 1.2.4), then disable the built-from-gdml support in VecgeomParams.

Because most of the "core" celeritas unit tests require building through the standalone VecGeom ".gdml" input, I tried to support building through the G4GDMLParser. Unfortunately that crashes the code:
- Instantiating the parser instantiates G4GDMLMessenger
- Its constructor adds code to the G4UImanager (`G4UIcommand::G4UIcommandCommonConstructorCode`)
- `G4UImanager::GetUIpointer` has code to check if it's been destroyed and if so return a null pointer which crashes
It crashed in the relevant cases because GeantSetup had been called which destroys the run manager. I've added error checking code to the relevant places to keep this crash from happening again.  Digging into this also lets me remove a line of hacky code from the `load_geant_geometry` call.

So instead, since this is an unusual case, I've prevented building the unit tests when VGDML is unavailable. **However**, you can still check that celeritas is working correctly through the Geant4 converter by defining `BUILD_TESTING=ON` and running the `celer-g4` test.