### PR TITLE
Refactor TrackSortUtils

### DIFF
--- a/src/celeritas/track/detail/TrackSortUtils.cc
+++ b/src/celeritas/track/detail/TrackSortUtils.cc
@@ -80,15 +80,14 @@ void sort_tracks(HostRef<CoreStateData> const& states, TrackOrder order)
     {
         case TrackOrder::partition_status:
             return partition_impl(states.track_slots,
-                                  alive_predicate{states.sim.status.data()});
+                                  AlivePredicate{states.sim.status.data()});
         case TrackOrder::sort_along_step_action:
         case TrackOrder::sort_step_limit_action:
             return sort_impl(states.track_slots,
-                             id_comparator{get_action_ptr(states, order)});
+                             IdComparator{get_action_ptr(states, order)});
         case TrackOrder::sort_particle_type:
-            return sort_impl(
-                states.track_slots,
-                id_comparator{states.particles.particle_id.data()});
+            return sort_impl(states.track_slots,
+                             IdComparator{states.particles.particle_id.data()});
         default:
             CELER_ASSERT_UNREACHABLE();
     }
@@ -136,6 +135,10 @@ void count_tracks_per_action(
     backfill_action_count(offsets, size);
 }
 
+//---------------------------------------------------------------------------//
+/*!
+ * Fill missing action offsets.
+ */
 void backfill_action_count(Span<ThreadId> offsets, size_type num_actions)
 {
     CELER_EXPECT(offsets.size() >= 2);

--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -46,7 +46,9 @@ using ThreadItems
 using TrackSlots = ThreadItems<TrackSlotId::size_type>;
 
 //---------------------------------------------------------------------------//
-
+/*!
+ * Partition track_slots based on predicate.
+ */
 template<class F>
 void partition_impl(TrackSlots const& track_slots, F&& func, StreamId stream_id)
 {
@@ -59,7 +61,10 @@ void partition_impl(TrackSlots const& track_slots, F&& func, StreamId stream_id)
 }
 
 //---------------------------------------------------------------------------//
-
+/*!
+ * Reorder OpaqueId's based on track_slots so that track_slots[tid] correspond
+ * to ids[tid] instead of ids[tacks_slots[tid]].
+ */
 template<class Id>
 __global__ void
 reorder_ids_kernel(ObserverPtr<TrackSlotId::size_type const> track_slots,
@@ -75,6 +80,10 @@ reorder_ids_kernel(ObserverPtr<TrackSlotId::size_type const> track_slots,
     }
 }
 
+//---------------------------------------------------------------------------//
+/*!
+ * Sort track slots using ids as keys.
+ */
 template<class Id, class IdT = typename Id::size_type>
 void sort_impl(TrackSlots const& track_slots,
                ObserverPtr<Id const> ids,
@@ -96,7 +105,11 @@ void sort_impl(TrackSlots const& track_slots,
     CELER_DEVICE_CHECK_ERROR();
 }
 
-// PRE: actions are sorted
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate thread boundaries based on action ID.
+ * \pre actions are sorted
+ */
 __global__ void
 tracks_per_action_kernel(ObserverPtr<ActionId const> actions,
                          ObserverPtr<TrackSlotId::size_type const> track_slots,
@@ -175,7 +188,7 @@ void sort_tracks(DeviceRef<CoreStateData> const& states, TrackOrder order)
     {
         case TrackOrder::partition_status:
             return partition_impl(states.track_slots,
-                                  alive_predicate{states.sim.status.data()},
+                                  AlivePredicate{states.sim.status.data()},
                                   states.stream_id);
         case TrackOrder::sort_along_step_action:
         case TrackOrder::sort_step_limit_action:

--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -208,8 +208,7 @@ void count_tracks_per_action(
 {
     CELER_ASSERT(order == TrackOrder::sort_along_step_action
                  || order == TrackOrder::sort_step_limit_action);
-    // dispatch in the kernel since CELER_LAUNCH_KERNEL doesn't work
-    // with templated kernels
+
     auto start = device_pointer_cast(make_observer(offsets.data()));
     thrust::fill(thrust_execute_on(states.stream_id),
                  start,

--- a/src/celeritas/track/detail/TrackSortUtils.cu
+++ b/src/celeritas/track/detail/TrackSortUtils.cu
@@ -96,13 +96,15 @@ void sort_impl(TrackSlots const& track_slots,
     CELER_DEVICE_CHECK_ERROR();
 }
 
-// PRE: get_action is sorted, i.e. i <= j ==> get_action(i) <=
-// get_action(j)
-template<class F>
-__device__ void
-tracks_per_action_impl(Span<ThreadId> offsets, size_type size, F&& get_action)
+// PRE: actions are sorted
+__global__ void
+tracks_per_action_kernel(ObserverPtr<ActionId const> actions,
+                         ObserverPtr<TrackSlotId::size_type const> track_slots,
+                         Span<ThreadId> offsets,
+                         size_type size)
 {
     ThreadId tid = celeritas::KernelParamCalculator::thread_id();
+    ActionAccessor get_action{actions, track_slots};
 
     if ((tid < size) && tid != ThreadId{0})
     {
@@ -120,30 +122,6 @@ tracks_per_action_impl(Span<ThreadId> offsets, size_type size, F&& get_action)
         {
             offsets[first.unchecked_get()] = tid;
         }
-    }
-}
-
-__global__ void tracks_per_action_kernel(DeviceRef<CoreStateData> const states,
-                                         Span<ThreadId> offsets,
-                                         size_type size,
-                                         TrackOrder order)
-{
-    switch (order)
-    {
-        case TrackOrder::sort_along_step_action:
-            return tracks_per_action_impl(
-                offsets,
-                size,
-                ActionAccessor{states.sim.along_step_action.data(),
-                               states.track_slots.data()});
-        case TrackOrder::sort_step_limit_action:
-            return tracks_per_action_impl(
-                offsets,
-                size,
-                ActionAccessor{states.sim.post_step_action.data(),
-                               states.track_slots.data()});
-        default:
-            CELER_ASSERT_UNREACHABLE();
     }
 }
 
@@ -199,20 +177,11 @@ void sort_tracks(DeviceRef<CoreStateData> const& states, TrackOrder order)
             return partition_impl(states.track_slots,
                                   alive_predicate{states.sim.status.data()},
                                   states.stream_id);
-        case TrackOrder::sort_along_step_action: {
-            using Id =
-                typename decltype(states.sim.along_step_action)::value_type;
-            return sort_impl<Id>(states.track_slots,
-                                 states.sim.along_step_action.data(),
-                                 states.stream_id);
-        }
-        case TrackOrder::sort_step_limit_action: {
-            using Id =
-                typename decltype(states.sim.post_step_action)::value_type;
-            return sort_impl<Id>(states.track_slots,
-                                 states.sim.post_step_action.data(),
-                                 states.stream_id);
-        }
+        case TrackOrder::sort_along_step_action:
+        case TrackOrder::sort_step_limit_action:
+            return sort_impl(states.track_slots,
+                             get_action_ptr(states, order),
+                             states.stream_id);
         case TrackOrder::sort_particle_type: {
             using Id =
                 typename decltype(states.particles.particle_id)::value_type;
@@ -237,34 +206,32 @@ void count_tracks_per_action(
     Collection<ThreadId, Ownership::value, MemSpace::mapped, ActionId>& out,
     TrackOrder order)
 {
-    if (order == TrackOrder::sort_along_step_action
-        || order == TrackOrder::sort_step_limit_action)
-    {
-        // dispatch in the kernel since CELER_LAUNCH_KERNEL doesn't work
-        // with templated kernels
-        auto start = device_pointer_cast(make_observer(offsets.data()));
-        thrust::fill(thrust_execute_on(states.stream_id),
-                     start,
-                     start + offsets.size(),
-                     ThreadId{});
-        CELER_DEVICE_CHECK_ERROR();
-        auto* stream = celeritas::device().stream(states.stream_id).get();
-        CELER_LAUNCH_KERNEL(tracks_per_action,
-                            states.size(),
-                            stream,
-                            states,
-                            offsets,
-                            states.size(),
-                            order);
+    CELER_ASSERT(order == TrackOrder::sort_along_step_action
+                 || order == TrackOrder::sort_step_limit_action);
+    // dispatch in the kernel since CELER_LAUNCH_KERNEL doesn't work
+    // with templated kernels
+    auto start = device_pointer_cast(make_observer(offsets.data()));
+    thrust::fill(thrust_execute_on(states.stream_id),
+                 start,
+                 start + offsets.size(),
+                 ThreadId{});
+    CELER_DEVICE_CHECK_ERROR();
+    auto* stream = celeritas::device().stream(states.stream_id).get();
+    CELER_LAUNCH_KERNEL(tracks_per_action,
+                        states.size(),
+                        stream,
+                        get_action_ptr(states, order),
+                        states.track_slots.data(),
+                        offsets,
+                        states.size());
 
-        Span<ThreadId> sout = out[AllItems<ThreadId, MemSpace::mapped>{}];
-        Copier<ThreadId, MemSpace::host> copy_to_host{sout, states.stream_id};
-        copy_to_host(MemSpace::device, offsets);
+    Span<ThreadId> sout = out[AllItems<ThreadId, MemSpace::mapped>{}];
+    Copier<ThreadId, MemSpace::host> copy_to_host{sout, states.stream_id};
+    copy_to_host(MemSpace::device, offsets);
 
-        // Copies must be complete before backfilling
-        CELER_DEVICE_CALL_PREFIX(StreamSynchronize(stream));
-        backfill_action_count(sout, states.size());
-    }
+    // Copies must be complete before backfilling
+    CELER_DEVICE_CALL_PREFIX(StreamSynchronize(stream));
+    backfill_action_count(sout, states.size());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/detail/TrackSortUtils.hh
+++ b/src/celeritas/track/detail/TrackSortUtils.hh
@@ -57,7 +57,6 @@ void sort_tracks(DeviceRef<CoreStateData> const&, TrackOrder);
 
 //---------------------------------------------------------------------------//
 // Count tracks associated to each action
-
 void count_tracks_per_action(
     HostRef<CoreStateData> const&,
     Span<ThreadId>,
@@ -70,12 +69,14 @@ void count_tracks_per_action(
     Collection<ThreadId, Ownership::value, MemSpace::mapped, ActionId>&,
     TrackOrder);
 
+//---------------------------------------------------------------------------//
+// Fill missing action offsets.
 void backfill_action_count(Span<ThreadId>, size_type);
 
 //---------------------------------------------------------------------------//
 // HELPER CLASSES AND FUNCTIONS
 //---------------------------------------------------------------------------//
-struct alive_predicate
+struct AlivePredicate
 {
     ObserverPtr<TrackStatus const> status_;
 
@@ -86,7 +87,7 @@ struct alive_predicate
 };
 
 template<class Id>
-struct id_comparator
+struct IdComparator
 {
     ObserverPtr<Id const> ids_;
 
@@ -107,6 +108,8 @@ struct ActionAccessor
     }
 };
 
+//---------------------------------------------------------------------------//
+// Return the correct action pointer based on the track sort order
 template<Ownership W, MemSpace M>
 CELER_FUNCTION ObserverPtr<ActionId const>
 get_action_ptr(CoreStateData<W, M> const& states, TrackOrder order)
@@ -127,7 +130,7 @@ get_action_ptr(CoreStateData<W, M> const& states, TrackOrder order)
 //---------------------------------------------------------------------------//
 
 template<class Id>
-id_comparator(ObserverPtr<Id>) -> id_comparator<Id>;
+IdComparator(ObserverPtr<Id>) -> IdComparator<Id>;
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/src/corecel/sys/KernelParamCalculator.device.hh
+++ b/src/corecel/sys/KernelParamCalculator.device.hh
@@ -58,7 +58,7 @@
             #NAME, NAME##_kernel<T1>);                                       \
         auto grid_ = calc_launch_params_(THREADS);                           \
                                                                              \
-        CELER_LAUNCH_KERNEL_IMPL(NAME##_kernel,                              \
+        CELER_LAUNCH_KERNEL_IMPL(NAME##_kernel<T1>,                          \
                                  grid_.blocks_per_grid,                      \
                                  grid_.threads_per_block,                    \
                                  0,                                          \


### PR DESCRIPTION
Simplify the `TrackSortUtils` implementation:
- Extract common behavior to helper functions
- Remove unecessary template arguments of function template
- Remove unnecssary streamid in host-only helper functions
- Add track sorting by particle type on host (missed in #1044)
- Remove count_tracks_per_action impl