### PR TITLE
Support JSON via stdin for celer-g4

### DIFF
--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -76,6 +76,7 @@ void print_usage(std::string_view exec_name)
 {
     // clang-format off
     std::cerr << "usage: " << exec_name << " {input}.json\n"
+                 "       " << exec_name << " -\n"
                  "       " << exec_name << " {commands}.mac\n"
                  "       " << exec_name << " --interactive\n"
                  "       " << exec_name << " [--help|-h]\n"

--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -129,8 +129,6 @@ if result.returncode:
 
 print("Received {} bytes of data".format(len(result.stdout)), file=stderr)
 out_text = result.stdout.decode()
-# Filter out spurious HepMC3 output
-out_text = out_text[out_text.find('\n{') + 1:]
 try:
     j = json.loads(out_text)
 except json.decoder.JSONDecodeError as e:

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -215,8 +215,17 @@ SharedParams::SharedParams(SetupOptions const& options, SPOutputRegistry oreg)
     // Construct core data
     this->initialize_core(options);
 
-    // Set up output after params are constructed
-    this->try_output();
+    if (output_filename_ != "-")
+    {
+        // Write output after params are constructed before anything can go
+        // wrong
+        this->try_output();
+    }
+    else
+    {
+        CELER_LOG(debug) << "Skipping 'startup' JSON output since writing to "
+                            "stdout";
+    }
 
     if (!options.offload_output_file.empty())
     {


### PR DESCRIPTION
This fully supports the stdin/stdout use case for celer-g4: input can be passed via JSON with the `-` argument, and this fixes the `accel` output so that the "pre-run" JSON output is not written to stdout.