### PR TITLE
Implement offload to Celeritas from Geant4 using G4VTrackingManager hook

### DIFF
--- a/doc/main/examples/geant4.rst
+++ b/doc/main/examples/geant4.rst
@@ -12,6 +12,7 @@ or multithreaded environment using:
 
 #. A concrete G4UserTrackingAction user action class
 #. A concrete G4VFastSimulationModel
+#. A concrete G4VTrackingManager
 
 The :ref:`accel` library is the only part of Celeritas that needs to be understood.
 The key components are global SetupOptions and SharedParams, coupled to thread-local
@@ -45,4 +46,10 @@ Offload using a concrete G4VFastSimulationModel
 -----------------------------------------------
 
 .. literalinclude:: ../../../example/accel/fastsim-offload.cc
+   :start-at: #include
+
+ Offload using a concrete G4VTrackingManager
+--------------------------------------------
+
+.. literalinclude:: ../../../example/accel/trackingmanager-offload.cc
    :start-at: #include

--- a/example/accel/CMakeLists.txt
+++ b/example/accel/CMakeLists.txt
@@ -52,38 +52,48 @@ endif()
 #-----------------------------------------------------------------------------#
 
 include(CTest)
-function(add_example target)
-  add_test(NAME "${target}" COMMAND "$<TARGET_FILE:${target}>")
-endfunction()
-
-set(_test_env)
+set(_g4data_env)
 foreach(_ds IN LISTS Geant4_DATASETS)
-  list(APPEND _test_env
+  list(APPEND _g4data_env
     "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}")
 endforeach()
+
+function(add_example target)
+  add_example_impl(${target} Serial)
+  if(Geant4_multithreaded_FOUND)
+    add_example_impl(${target} MT)
+    add_example_impl(${target} Tasking)
+  endif()
+endfunction()
+
+function(disable_example target)
+  set(_tests ${target}-Serial)
+  if(Geant4_multithreaded_FOUND)
+    list(APPEND _tests ${target}-MT ${target}-Tasking)
+  endif()
+  set_tests_properties(${_tests} PROPERTIES
+    DISABLED true
+  )
+endfunction()
+
+function(add_example_impl target rmtype)
+  set(_test_name "${target}-${rmtype}")
+  add_test(NAME "${_test_name}" COMMAND "$<TARGET_FILE:${target}>")
+  set_tests_properties(${_test_name} PROPERTIES
+    ENVIRONMENT "${_g4data_env};G4RUN_MANAGER_TYPE=${rmtype}"
+    LABELS "app"
+  )
+endfunction()
 
 #-----------------------------------------------------------------------------#
 
 add_example(simple-offload)
 add_example(fastsim-offload)
 
-set_tests_properties(simple-offload fastsim-offload PROPERTIES
-  ENVIRONMENT "${_test_env}"
-  LABELS "app"
-)
-
 if(Geant4_VERSION VERSION_LESS 11.1)
-  set_tests_properties(fastsim-offload PROPERTIES
-    DISABLED true
-  )
+  disable_example(fastsim-offload)
 endif()
 
 if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
   add_example(trackingmanager-offload)
-  set_tests_properties(trackingmanager-offload PROPERTIES
-    ENVIRONMENT "${_test_env}"
-    LABELS "app"
-  )
 endif()
-
-

--- a/example/accel/CMakeLists.txt
+++ b/example/accel/CMakeLists.txt
@@ -35,6 +35,16 @@ celeritas_target_link_libraries(fastsim-offload
   ${Geant4_LIBRARIES}
 )
 
+if(Geant4_VERSION VERSION_LESS 11.0)
+  message(WARNING "G4VTrackingManager offload requires Geant4 11.0 or higher")
+else()
+  add_executable(trackingmanager-offload trackingmanager-offload.cc)
+  celeritas_target_link_libraries(trackingmanager-offload
+    Celeritas::accel
+    ${Geant4_LIBRARIES}
+  )
+endif()
+
 # END EXAMPLE CODE
 
 #-----------------------------------------------------------------------------#
@@ -67,4 +77,13 @@ if(Geant4_VERSION VERSION_LESS 11.1)
     DISABLED true
   )
 endif()
+
+if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
+  add_example(trackingmanager-offload)
+  set_tests_properties(trackingmanager-offload PROPERTIES
+    ENVIRONMENT "${_test_env}"
+    LABELS "app"
+  )
+endif()
+
 

--- a/example/accel/trackingmanager-offload.cc
+++ b/example/accel/trackingmanager-offload.cc
@@ -91,6 +91,7 @@ class EMPhysicsConstructor final : public G4EmStandardPhysics
 
     void ConstructProcess() override
     {
+        CELER_LOG_LOCAL(status) << "Setting up tracking manager offload";
         G4EmStandardPhysics::ConstructProcess();
 
         // Add Celeritas tracking manager to electron, positron, gamma.

--- a/example/accel/trackingmanager-offload.cc
+++ b/example/accel/trackingmanager-offload.cc
@@ -1,0 +1,209 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file example/accel/trackingmanager-offload.cc
+//---------------------------------------------------------------------------//
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <FTFP_BERT.hh>
+#include <G4Box.hh>
+#include <G4Electron.hh>
+#include <G4EmStandardPhysics.hh>
+#include <G4Gamma.hh>
+#include <G4LogicalVolume.hh>
+#include <G4Material.hh>
+#include <G4PVPlacement.hh>
+#include <G4ParticleDefinition.hh>
+#include <G4ParticleGun.hh>
+#include <G4ParticleTable.hh>
+#include <G4Positron.hh>
+#include <G4Region.hh>
+#include <G4RegionStore.hh>
+#include <G4RunManagerFactory.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4Threading.hh>
+#include <G4ThreeVector.hh>
+#include <G4Track.hh>
+#include <G4TrackStatus.hh>
+#include <G4Types.hh>
+#include <G4UserEventAction.hh>
+#include <G4UserRunAction.hh>
+#include <G4UserTrackingAction.hh>
+#include <G4VUserActionInitialization.hh>
+#include <G4VUserDetectorConstruction.hh>
+#include <G4VUserPrimaryGeneratorAction.hh>
+#include <accel/AlongStepFactory.hh>
+#include <accel/LocalTransporter.hh>
+#include <accel/SetupOptions.hh>
+#include <accel/SharedParams.hh>
+#include <accel/SimpleOffload.hh>
+#include <accel/TrackingManagerOffload.hh>
+#include <corecel/Macros.hh>
+#include <corecel/io/Logger.hh>
+
+namespace
+{
+//---------------------------------------------------------------------------//
+// Global shared setup options
+celeritas::SetupOptions setup_options;
+// Shared data and GPU setup
+celeritas::SharedParams shared_params;
+// Thread-local transporter
+G4ThreadLocal celeritas::LocalTransporter local_transporter;
+
+// Simple interface to running celeritas
+G4ThreadLocal celeritas::SimpleOffload simple_offload;
+
+//---------------------------------------------------------------------------//
+class DetectorConstruction final : public G4VUserDetectorConstruction
+{
+  public:
+    DetectorConstruction()
+        : aluminum_{new G4Material{
+            "Aluminium", 13., 26.98 * g / mole, 2.700 * g / cm3}}
+    {
+        setup_options.make_along_step = celeritas::UniformAlongStepFactory();
+    }
+
+    G4VPhysicalVolume* Construct() final
+    {
+        CELER_LOG_LOCAL(status) << "Setting up detector";
+        auto* box = new G4Box("world", 1000 * cm, 1000 * cm, 1000 * cm);
+        auto* lv = new G4LogicalVolume(box, aluminum_, "world");
+        auto* pv = new G4PVPlacement(
+            0, G4ThreeVector{}, lv, "world", nullptr, false, 0);
+        return pv;
+    }
+
+  private:
+    G4Material* aluminum_;
+};
+
+//---------------------------------------------------------------------------//
+class EMPhysicsConstructor final : public G4EmStandardPhysics
+{
+  public:
+    using G4EmStandardPhysics::G4EmStandardPhysics;
+
+    void ConstructProcess() override
+    {
+        G4EmStandardPhysics::ConstructProcess();
+
+        // Add Celeritas tracking manager to electron, positron, gamma.
+        auto* celer_tracking = new celeritas::TrackingManagerOffload(
+            &shared_params, &local_transporter);
+        G4Electron::Definition()->SetTrackingManager(celer_tracking);
+        G4Positron::Definition()->SetTrackingManager(celer_tracking);
+        G4Gamma::Definition()->SetTrackingManager(celer_tracking);
+    }
+};
+
+//---------------------------------------------------------------------------//
+class PrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
+{
+  public:
+    PrimaryGeneratorAction()
+    {
+        auto g4particle_def
+            = G4ParticleTable::GetParticleTable()->FindParticle(2112);
+        gun_.SetParticleDefinition(g4particle_def);
+        gun_.SetParticleEnergy(100 * GeV);
+        gun_.SetParticlePosition(G4ThreeVector{0, 0, 0});  // origin
+        gun_.SetParticleMomentumDirection(G4ThreeVector{1, 0, 0});  // +x
+    }
+
+    // Generate 100 GeV neutrons
+    void GeneratePrimaries(G4Event* event) final
+    {
+        CELER_LOG_LOCAL(status) << "Generating primaries";
+        gun_.GeneratePrimaryVertex(event);
+    }
+
+  private:
+    G4ParticleGun gun_;
+};
+
+//---------------------------------------------------------------------------//
+class RunAction final : public G4UserRunAction
+{
+  public:
+    void BeginOfRunAction(G4Run const* run) final
+    {
+        simple_offload.BeginOfRunAction(run);
+    }
+    void EndOfRunAction(G4Run const* run) final
+    {
+        simple_offload.EndOfRunAction(run);
+    }
+};
+
+//---------------------------------------------------------------------------//
+class EventAction final : public G4UserEventAction
+{
+  public:
+    void BeginOfEventAction(G4Event const* event) final
+    {
+        simple_offload.BeginOfEventAction(event);
+    }
+};
+
+//---------------------------------------------------------------------------//
+class ActionInitialization final : public G4VUserActionInitialization
+{
+  public:
+    void BuildForMaster() const final
+    {
+        simple_offload.BuildForMaster(&setup_options, &shared_params);
+
+        CELER_LOG_LOCAL(status) << "Constructing user actions";
+
+        this->SetUserAction(new RunAction{});
+    }
+    void Build() const final
+    {
+        simple_offload.Build(
+            &setup_options, &shared_params, &local_transporter);
+
+        CELER_LOG_LOCAL(status) << "Constructing user actions";
+
+        this->SetUserAction(new PrimaryGeneratorAction{});
+        this->SetUserAction(new RunAction{});
+        this->SetUserAction(new EventAction{});
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace
+
+int main()
+{
+    std::unique_ptr<G4RunManager> run_manager{
+        G4RunManagerFactory::CreateRunManager()};  // G4RunManagerType::SerialOnly)};
+
+    run_manager->SetUserInitialization(new DetectorConstruction{});
+
+    // Use FTFP_BERT, but replace EM constructor with our own that
+    // overrides ConstructProcess to use Celeritas tracking for e-/e+/g
+    auto physics_list = new FTFP_BERT{/* verbosity = */ 0};
+    physics_list->ReplacePhysics(new EMPhysicsConstructor);
+    run_manager->SetUserInitialization(physics_list);
+
+    run_manager->SetUserInitialization(new ActionInitialization());
+
+    // NOTE: these numbers are appropriate for CPU execution
+    setup_options.max_num_tracks = 1024;
+    setup_options.initializer_capacity = 1024 * 128;
+    // This parameter will eventually be removed
+    setup_options.max_num_events = 1024;
+    // Celeritas does not support EmStandard MSC physics above 100 MeV
+    setup_options.ignore_processes = {"CoulombScat"};
+
+    run_manager->Initialize();
+    run_manager->BeamOn(1);
+
+    return 0;
+}

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -32,6 +32,10 @@ list(APPEND SOURCES
 
 celeritas_polysource(ExceptionConverter)
 
+if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
+  list(APPEND SOURCES TrackingManagerOffload.cc)
+endif()
+
 if(CELERITAS_USE_JSON)
   list(APPEND PRIVATE_DEPS nlohmann_json::nlohmann_json)
 endif()

--- a/src/accel/TrackingManagerOffload.cc
+++ b/src/accel/TrackingManagerOffload.cc
@@ -19,18 +19,6 @@
 
 namespace celeritas
 {
-namespace
-{
-bool is_applicable_to(G4ParticleDefinition const& part,
-                      SharedParams const* params)
-{
-    return std::find(params->OffloadParticles().begin(),
-                     params->OffloadParticles().end(),
-                     &part)
-           != params->OffloadParticles().end();
-}
-}  // namespace
-
 //---------------------------------------------------------------------------//
 /*!
  * Construct a tracking manager with data needed to offload to Celeritas
@@ -67,11 +55,6 @@ TrackingManagerOffload::TrackingManagerOffload(SharedParams const* params,
  */
 void TrackingManagerOffload::BuildPhysicsTable(G4ParticleDefinition const& part)
 {
-    // Difficult to check this elsewhere, other than PreparePhysicsTable
-    CELER_VALIDATE(is_applicable_to(part, params_),
-                   << "cannot use TrackingManagerOffload for Geant4 particle '"
-                   << part.GetParticleName() << "'");
-
     G4ProcessManager* pManager = part.GetProcessManager();
     G4ProcessManager* pManagerShadow = part.GetMasterProcessManager();
 
@@ -104,10 +87,6 @@ void TrackingManagerOffload::BuildPhysicsTable(G4ParticleDefinition const& part)
  */
 void TrackingManagerOffload::PreparePhysicsTable(G4ParticleDefinition const& part)
 {
-    CELER_VALIDATE(is_applicable_to(part, params_),
-                   << "cannot use TrackingManagerOffload for Geant4 particle '"
-                   << part.GetParticleName() << "'");
-
     G4ProcessManager* pManager = part.GetProcessManager();
     G4ProcessManager* pManagerShadow = part.GetMasterProcessManager();
 

--- a/src/accel/TrackingManagerOffload.cc
+++ b/src/accel/TrackingManagerOffload.cc
@@ -21,7 +21,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct a tracking manager with data needed to offload to Celeritas
+ * Construct a tracking manager with data needed to offload to Celeritas.
  *
  * TODO: Clarify thread-locality. Construction/addition to \c
  * G4ParticleDefinition appears to take place on the master thread, typically
@@ -40,7 +40,7 @@ TrackingManagerOffload::TrackingManagerOffload(SharedParams const* params,
 
 //---------------------------------------------------------------------------//
 /*!
- * Build physics tables for this particle
+ * Build physics tables for this particle.
  *
  * Messaged by the \c G4ParticleDefinition who stores us whenever cross-section
  * tables have to be rebuilt (i.e. if new materials have been defined). An
@@ -74,7 +74,7 @@ void TrackingManagerOffload::BuildPhysicsTable(G4ParticleDefinition const& part)
 
 //---------------------------------------------------------------------------//
 /*!
- * Prepare physics tables for this particle
+ * Prepare physics tables for this particle.
  *
  * Messaged by the \c G4ParticleDefinition who stores us whenever cross-section
  * tables have to be rebuilt (i.e. if new materials have been defined). As with

--- a/src/accel/TrackingManagerOffload.cc
+++ b/src/accel/TrackingManagerOffload.cc
@@ -12,6 +12,7 @@
 #include <G4Track.hh>
 
 #include "corecel/Assert.hh"
+#include "corecel/cont/Range.hh"
 
 #include "ExceptionConverter.hh"
 #include "LocalTransporter.hh"
@@ -55,19 +56,22 @@ TrackingManagerOffload::TrackingManagerOffload(SharedParams const* params,
  */
 void TrackingManagerOffload::BuildPhysicsTable(G4ParticleDefinition const& part)
 {
-    G4ProcessManager* pManager = part.GetProcessManager();
     G4ProcessManager* pManagerShadow = part.GetMasterProcessManager();
+    G4ProcessManager* pManager = part.GetProcessManager();
+    CELER_ASSERT(pManager);
 
     G4ProcessVector* pVector = pManager->GetProcessList();
-    for (std::size_t j = 0; j < pVector->size(); ++j)
+    CELER_ASSERT(pVector);
+    for (auto j : range(pVector->size()))
     {
+        G4VProcess* proc = (*pVector)[j];
         if (pManagerShadow == pManager)
         {
-            (*pVector)[j]->BuildPhysicsTable(part);
+            proc->BuildPhysicsTable(part);
         }
         else
         {
-            (*pVector)[j]->BuildWorkerPhysicsTable(part);
+            proc->BuildWorkerPhysicsTable(part);
         }
     }
 }
@@ -87,19 +91,22 @@ void TrackingManagerOffload::BuildPhysicsTable(G4ParticleDefinition const& part)
  */
 void TrackingManagerOffload::PreparePhysicsTable(G4ParticleDefinition const& part)
 {
-    G4ProcessManager* pManager = part.GetProcessManager();
     G4ProcessManager* pManagerShadow = part.GetMasterProcessManager();
+    G4ProcessManager* pManager = part.GetProcessManager();
+    CELER_ASSERT(pManager);
 
     G4ProcessVector* pVector = pManager->GetProcessList();
-    for (std::size_t j = 0; j < pVector->size(); ++j)
+    CELER_ASSERT(pVector);
+    for (auto j : range(pVector->size()))
     {
+        G4VProcess* proc = (*pVector)[j];
         if (pManagerShadow == pManager)
         {
-            (*pVector)[j]->PreparePhysicsTable(part);
+            proc->PreparePhysicsTable(part);
         }
         else
         {
-            (*pVector)[j]->PrepareWorkerPhysicsTable(part);
+            proc->PrepareWorkerPhysicsTable(part);
         }
     }
 }

--- a/src/accel/TrackingManagerOffload.hh
+++ b/src/accel/TrackingManagerOffload.hh
@@ -1,0 +1,47 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/TrackingManagerOffload.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <G4VTrackingManager.hh>
+
+namespace celeritas
+{
+class SharedParams;
+class LocalTransporter;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Offload tracks to Celeritas via the per-particle G4VTrackingManager
+ * interface
+ */
+class TrackingManagerOffload final : public G4VTrackingManager
+{
+  public:
+    // Construct with shared (across threads) params, and thread-local
+    // transporter.
+    TrackingManagerOffload(SharedParams const* params, LocalTransporter* local);
+
+    // Prepare cross-section tables for rebuild (e.g. if new materials have
+    // been defined).
+    void PreparePhysicsTable(G4ParticleDefinition const&) override;
+
+    // Rebuild physics cross-section tables (e.g. if new materials have been
+    // defined).
+    void BuildPhysicsTable(G4ParticleDefinition const&) override;
+
+    // Hand over passed track to this tracking manager.
+    void HandOverOneTrack(G4Track* aTrack) override;
+
+    // Complete processing of any buffered tracks.
+    void FlushEvent() override;
+
+  private:
+    SharedParams const* params_{nullptr};
+    LocalTransporter* transport_{nullptr};
+};
+}  // namespace celeritas


### PR DESCRIPTION
This implements a minimal concrete class of the `G4VTrackingManager` interface for offloading Geant4 tracks to Celeritas, complementing the existing user tracking action and fast simulation strategies. Introduced in Geant4 11.0, a `G4VTrackingManager` instance can be added to one or more `G4ParticleDefinition` instances to customise how tracks of that particle the will be handled. Overviews of this capability, and an example are documented at these links:

- [Specialized Tracking Managers in Geant4](https://indico.cern.ch/event/1073798/contributions/4516033/attachments/2304502/3920446/specialized-tracking-manager.pdf)
- [G4HepEm and Specialized Stepping/Tracking in Geant4](https://indico.cern.ch/event/1052654/contributions/4524767/attachments/2309218/3929219/G4HepEm_SpecTracking_MNovak.pdf)
- [Geant4 runAndEvent RE07 Example](https://indico.cern.ch/event/1156193/contributions/5048470/attachments/2514883/4326508/20220927_Hahnfeld_RE07.pdf)
  - [Current implementation in Geant4 11.1](https://gitlab.cern.ch/geant4/geant4/-/tree/v11.1.3/examples/extended/runAndEvent/RE07?ref_type=tags)

Because implementation requires inheritance from a class only available from Geant4 v11.0, the build/use has been restricted to that version or newer for now.

The implementation here for the offload/flush is largely the same as in `FastSimulationOffload`, using `SharedParams` and `LocalTransporter`. 

The main detail is the necessity to implement the `Prepare/BuildPhysicsTable` member functions as per-particle tracking managers completely overrides physic building for the particle in question (see [here](https://gitlab.cern.ch/geant4/geant4/-/blob/v11.1.3/source/run/src/G4VUserPhysicsList.cc?ref_type=tags#L793-799), and [here](https://gitlab.cern.ch/geant4/geant4/-/blob/v11.1.3/source/run/src/G4VUserPhysicsList.cc?ref_type=tags#L644-658) in `G4VUserPhysicsList`). If we don't do this, no Geant4 physics data is available for that particle, so Celeritas can't construct its physics properly. `Prepare/BuildPhysicsTable` are therefore implemented to follow the default in `G4VUserPhysicsList`, as is also shown in [the runAndEvent/RE07 example](https://gitlab.cern.ch/geant4/geant4/-/blob/v11.1.3/examples/extended/runAndEvent/RE07/src/SpecializedTrackingManager.cc?ref_type=tags). _Aside: this rebuild of the physics data would also allow filtering in `HandOffOneTrack` to pass back to general tracking if certain preconditions are met, much like in fast simulation as well._

Like `FastSimulationOffload`, the current implementation does rely on the setup and use of `SimpleOffload`s Run and Event actions to properly setup/teardown params and transporter(s). An example of the use of `TrackingManagerOffload` is shown in a new program in `example/accel` which is identical to the others in problem setup, just using the new offload mechanism. This has also been documented.

Possible TODO: the example shows that the custom tracking manager is constructed and added to the particle definitions in the `ConstructProcess` member function. AFAICT this is only called on the master thread and thus with the `LocalTransporter` for that thread. However, local tests showed (via logging the address) that the correct thread-local instances are all used on the worker threads. The `G4VTrackingManager` instance held by `G4ParticleDefinition` _is_ part of the split data for that class, so seems to work correctly, but I'd still like to understand this better!

Addresses: #1035 
