### PR TITLE
Uniquify ROOT file name when output is directed to stdout

### DIFF
--- a/app/celer-g4/RootIO.cc
+++ b/app/celer-g4/RootIO.cc
@@ -56,7 +56,7 @@ RootIO::RootIO()
 
     if (file_name_ == "-")
     {
-        file_name_ = "stdout-" + std::to_string(::getpid());
+        file_name_ = "stdout-" + std::to_string(::getpid()) + ".root";
     }
 
     if (G4Threading::IsWorkerThread())

--- a/app/celer-g4/RootIO.cc
+++ b/app/celer-g4/RootIO.cc
@@ -54,6 +54,11 @@ RootIO::RootIO()
         file_name_ = "celer-g4.root";
     }
 
+    if (file_name_ == "-")
+    {
+        file_name_ = "stdout-" + std::to_string(::getpid());
+    }
+
     if (G4Threading::IsWorkerThread())
     {
         file_name_ += std::to_string(G4Threading::G4GetThreadId());

--- a/app/celer-g4/RootIO.cc
+++ b/app/celer-g4/RootIO.cc
@@ -28,6 +28,10 @@
 #include "GlobalSetup.hh"
 #include "SensitiveHit.hh"
 
+#ifdef _WIN32
+#    include <process.h>
+#endif
+
 namespace celeritas
 {
 namespace app


### PR DESCRIPTION
Use `stdout-${PID}.root` for the ROOT outputname.