### PR TITLE
Update tests to pass with cuRAND

### DIFF
--- a/test/celeritas/geo/HeuristicGeoTestBase.cc
+++ b/test/celeritas/geo/HeuristicGeoTestBase.cc
@@ -68,7 +68,10 @@ void HeuristicGeoTestBase::run_host(size_type num_states, real_type tolerance)
         return;
     }
 
-    EXPECT_VEC_NEAR(ref_path, avg_path, tolerance);
+    if (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
+    {
+        EXPECT_VEC_NEAR(ref_path, avg_path, tolerance);
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -88,8 +91,11 @@ void HeuristicGeoTestBase::run_device(size_type num_states, real_type tolerance)
         heuristic_test_execute(params, state.ref());
     }
 
-    auto avg_path = this->get_avg_path(state.ref().accum_path, num_states);
-    EXPECT_VEC_NEAR(this->reference_avg_path(), avg_path, tolerance);
+    if (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
+    {
+        auto avg_path = this->get_avg_path(state.ref().accum_path, num_states);
+        EXPECT_VEC_NEAR(this->reference_avg_path(), avg_path, tolerance);
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -372,7 +372,7 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         auto result = this->run(inp, num_tracks);
         EXPECT_SOFT_NEAR(2.2870403276278, result.eloss, 5e-4);
         EXPECT_SOFT_NEAR(1.1622519442871, result.displacement, 5e-4);
-        EXPECT_SOFT_NEAR(0.85325942256503251, result.angle, 1e-3);
+        EXPECT_SOFT_NEAR(0.85325942256503251, result.angle, 5e-2);
         EXPECT_SOFT_NEAR(4.083585865972e-11, result.time, 1e-5);
         EXPECT_SOFT_NEAR(1.222780668781, result.step, 5e-4);
         EXPECT_EQ("eloss-range", result.action);
@@ -384,11 +384,11 @@ TEST_F(Em3AlongStepTest, msc_nofluct)
         inp.position = {0.0 - 0.25};
         inp.direction = {1, 0, 0};
         auto result = this->run(inp, num_tracks);
-        EXPECT_SOFT_NEAR(0.28579817262705, result.eloss, 5e-4);
-        EXPECT_SOFT_NEAR(0.13028709259427, result.displacement, 5e-4);
-        EXPECT_SOFT_NEAR(0.42060290539404, result.angle, 1e-3);
-        EXPECT_SOFT_EQ(5.3240431819014e-12, result.time);
-        EXPECT_SOFT_EQ(0.1502064087009, result.step);
+        EXPECT_SOFT_NEAR(0.28579817262705, result.eloss, 5e-2);
+        EXPECT_SOFT_NEAR(0.13028709259427, result.displacement, 1e-2);
+        EXPECT_SOFT_NEAR(0.42060290539404, result.angle, 5e-2);
+        EXPECT_SOFT_NEAR(5.3240431819014e-12, result.time, 5e-12);
+        EXPECT_SOFT_NEAR(0.1502064087009, result.step, 5e-2);
         EXPECT_EQ("msc-range", result.action);
     }
     {

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -299,18 +299,13 @@ TEST_F(SimpleComptonTest, host)
     Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
 
-    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
+    if (this->is_default_build())
     {
         EXPECT_EQ(919, result.num_step_iters());
         EXPECT_SOFT_EQ(53.8125, result.calc_avg_steps_per_primary());
-    }
-    else
-    {
-        EXPECT_EQ(743, result.num_step_iters());
-        EXPECT_SOFT_EQ(61.9375, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(RunResult::StepCount({1, 6}), result.calc_queue_hwm());
     }
     EXPECT_EQ(3, result.calc_emptying_step());
-    EXPECT_EQ(RunResult::StepCount({1, 6}), result.calc_queue_hwm());
 }
 
 TEST_F(SimpleComptonTest, TEST_IF_CELER_DEVICE(device))
@@ -320,13 +315,13 @@ TEST_F(SimpleComptonTest, TEST_IF_CELER_DEVICE(device))
 
     Stepper<MemSpace::device> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
-    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
+    if (this->is_default_build())
     {
         EXPECT_EQ(919, result.num_step_iters());
         EXPECT_SOFT_EQ(53.8125, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(RunResult::StepCount({1, 6}), result.calc_queue_hwm());
     }
     EXPECT_EQ(3, result.calc_emptying_step());
-    EXPECT_EQ(RunResult::StepCount({1, 6}), result.calc_queue_hwm());
 }
 
 //---------------------------------------------------------------------------//
@@ -461,12 +456,15 @@ TEST_F(TestEm3NoMsc, host_multi)
     // Add some more primaries
     primaries = this->make_primaries(num_primaries);
     counts = step(make_span(primaries));
-    EXPECT_EQ(24, counts.active);
-    EXPECT_EQ(24, counts.alive);
+    if (this->is_default_build())
+    {
+        EXPECT_EQ(24, counts.active);
+        EXPECT_EQ(24, counts.alive);
+    }
 
     // Transport existing tracks
     counts = step();
-    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
+    if (this->is_default_build())
     {
         EXPECT_EQ(44, counts.active);
         EXPECT_EQ(44, counts.alive);
@@ -570,7 +568,6 @@ TEST_F(TestEm3Msc, host)
 
     Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
-    EXPECT_SOFT_NEAR(45.125, result.calc_avg_steps_per_primary(), 0.10);
 
     if (this->is_ci_build())
     {
@@ -633,7 +630,6 @@ TEST_F(TestEm3MscNofluct, host)
 
     Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
-    EXPECT_SOFT_NEAR(58, result.calc_avg_steps_per_primary(), 0.10);
 
     if (this->is_ci_build())
     {
@@ -739,7 +735,6 @@ TEST_F(TestEm15FieldMsc, host)
 
     Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
     auto result = this->run(step, num_primaries);
-    EXPECT_SOFT_NEAR(35, result.calc_avg_steps_per_primary(), 0.10);
 
     if (this->is_ci_build())
     {

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -39,6 +39,14 @@ StepperTestBase::StepperTestBase()
 }
 
 //---------------------------------------------------------------------------//
+//! Whether the build uses the default real type and RNG.
+bool StepperTestBase::is_default_build()
+{
+    return CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
+           && CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW;
+}
+
+//---------------------------------------------------------------------------//
 //! Generate a stepper construction class
 StepperInput StepperTestBase::make_stepper_input(size_type tracks)
 {

--- a/test/celeritas/global/StepperTestBase.hh
+++ b/test/celeritas/global/StepperTestBase.hh
@@ -55,6 +55,9 @@ class StepperTestBase : virtual public GlobalTestBase
         void print_expected() const;
     };
 
+    // Whether the build uses the default real type and RNG
+    static bool is_default_build();
+
     struct RunResult
     {
         using StepCount = std::pair<size_type, size_type>;

--- a/test/celeritas/user/Diagnostic.test.cc
+++ b/test/celeritas/user/Diagnostic.test.cc
@@ -114,14 +114,18 @@ TEST_F(SimpleComptonDiagnosticTest, host)
            "geo-boundary gamma",
            "scat-klein-nishina gamma"};
     EXPECT_VEC_EQ(expected_nonzero_action_keys, result.nonzero_action_keys);
-    static size_type const expected_nonzero_action_counts[]
-        = {3780u, 525u, 3887u};
-    EXPECT_VEC_EQ(expected_nonzero_action_counts, result.nonzero_action_counts);
-    static size_type const expected_steps[]
-        = {0u, 0u, 0u, 87u, 30u, 10u, 2u, 0u, 1u, 0u,    0u, 3u, 0u, 0u, 0u,
-           0u, 0u, 0u, 0u,  0u,  0u,  1u, 0u, 0u, 1840u, 0u, 0u, 0u, 0u, 0u,
-           0u, 0u, 0u, 0u,  0u,  0u,  0u, 0u, 0u, 0u,    0u, 0u, 0u, 0u};
-    EXPECT_VEC_EQ(expected_steps, result.steps);
+    if (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
+    {
+        static size_type const expected_nonzero_action_counts[]
+            = {3780u, 525u, 3887u};
+        EXPECT_VEC_EQ(expected_nonzero_action_counts,
+                      result.nonzero_action_counts);
+        static size_type const expected_steps[] = {
+            0u, 0u, 0u, 87u, 30u, 10u, 2u, 0u, 1u, 0u,    0u, 3u, 0u, 0u, 0u,
+            0u, 0u, 0u, 0u,  0u,  0u,  1u, 0u, 0u, 1840u, 0u, 0u, 0u, 0u, 0u,
+            0u, 0u, 0u, 0u,  0u,  0u,  0u, 0u, 0u, 0u,    0u, 0u, 0u, 0u};
+        EXPECT_VEC_EQ(expected_steps, result.steps);
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -203,25 +207,25 @@ TEST_F(TestEm3DiagnosticTest, TEST_IF_CELER_DEVICE(device))
 {
     auto result = this->run<MemSpace::device>(1024, 4);
 
-    // Check action diagnostic results
-    static char const* const expected_nonzero_action_keys[]
-        = {"annihil-2-gamma e+",
-           "brems-combined e+",
-           "brems-combined e-",
-           "geo-boundary e+",
-           "geo-boundary e-",
-           "geo-boundary gamma",
-           "ioni-moller-bhabha e+",
-           "ioni-moller-bhabha e-",
-           "msc-range e+",
-           "msc-range e-",
-           "physics-integral-rejected e+",
-           "physics-integral-rejected e-",
-           "scat-klein-nishina gamma"};
-    EXPECT_VEC_EQ(expected_nonzero_action_keys, result.nonzero_action_keys);
-
     if (this->is_ci_build())
     {
+        // Check action diagnostic results
+        static char const* const expected_nonzero_action_keys[]
+            = {"annihil-2-gamma e+",
+               "brems-combined e+",
+               "brems-combined e-",
+               "geo-boundary e+",
+               "geo-boundary e-",
+               "geo-boundary gamma",
+               "ioni-moller-bhabha e+",
+               "ioni-moller-bhabha e-",
+               "msc-range e+",
+               "msc-range e-",
+               "physics-integral-rejected e+",
+               "physics-integral-rejected e-",
+               "scat-klein-nishina gamma"};
+        EXPECT_VEC_EQ(expected_nonzero_action_keys, result.nonzero_action_keys);
+
         static size_type const expected_nonzero_action_counts[] = {
             10u, 572u, 508u, 518u, 520u, 9u, 20u, 21u, 904u, 997u, 12u, 2u, 3u};
         EXPECT_VEC_EQ(expected_nonzero_action_counts,
@@ -249,6 +253,12 @@ TEST_F(TestEm3DiagnosticTest, TEST_IF_CELER_DEVICE(device))
                 "0,0,0,0]]}",
                 this->step_output());
         }
+    }
+    else
+    {
+        cout << "No output saved for combination of "
+             << test::PrintableBuildConf{} << std::endl;
+        result.print_expected();
     }
 }
 

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -208,31 +208,42 @@ TEST_F(KnMctruthTest, two_step)
 {
     auto result = this->run(4, 2);
 
-    // clang-format off
-    static const int expected_event[] = {0, 0, 1, 1, 2, 2, 3, 3};
+    static int const expected_event[] = {0, 0, 1, 1, 2, 2, 3, 3};
     EXPECT_VEC_EQ(expected_event, result.event);
-    static const int expected_track[] = {0, 0, 0, 0, 0, 0, 0, 0};
+    static int const expected_track[] = {0, 0, 0, 0, 0, 0, 0, 0};
     EXPECT_VEC_EQ(expected_track, result.track);
-    static const int expected_step[] = {1, 2, 1, 2, 1, 2, 1, 2};
+    static int const expected_step[] = {1, 2, 1, 2, 1, 2, 1, 2};
     EXPECT_VEC_EQ(expected_step, result.step);
     if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
     {
-        static const int expected_volume[] = {1, 1, 1, 1, 1, 2, 1, 2};
+        static int const expected_volume[] = {1, 1, 1, 1, 1, 2, 1, 2};
         EXPECT_VEC_EQ(expected_volume, result.volume);
     }
-    static const double expected_pos[] = {0, 0, 0, 2.6999255778482, 0, 0, 0, 0, 0, 3.5717683161497, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 5, 0, 0};
-    EXPECT_VEC_SOFT_EQ(expected_pos, result.pos);
-    static const double expected_dir[] = {1, 0, 0, 0.45619379667222, 0.14402721708137, -0.87814769863479, 1, 0, 0, 0.8985574206844, -0.27508545475671, -0.34193940152356, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0};
-    EXPECT_VEC_SOFT_EQ(expected_dir, result.dir);
-    // clang-format on
+    if (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
+    {
+        // clang-format off
+        static const double expected_pos[] = {0, 0, 0, 2.6999255778482, 0, 0, 0, 0, 0, 3.5717683161497, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 5, 0, 0};
+        EXPECT_VEC_SOFT_EQ(expected_pos, result.pos);
+        static const double expected_dir[] = {1, 0, 0, 0.45619379667222, 0.14402721708137, -0.87814769863479, 1, 0, 0, 0.8985574206844, -0.27508545475671, -0.34193940152356, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0};
+        EXPECT_VEC_SOFT_EQ(expected_dir, result.dir);
+        // clang-format on
+    }
 }
 
-TEST_F(KnCaloTest, single_event)
+TEST_F(KnCaloTest, single_track)
 {
     auto result = this->run<MemSpace::host>(1, 64);
 
-    static double const expected_edep[] = {0.00043564799352598};
-    EXPECT_VEC_SOFT_EQ(expected_edep, result.edep);
+    if (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
+    {
+        static double const expected_edep[] = {0.00043564799352598};
+        EXPECT_VEC_SOFT_EQ(expected_edep, result.edep);
+    }
+    else
+    {
+        static double const expected_edep[] = {0};
+        EXPECT_VEC_SOFT_EQ(expected_edep, result.edep);
+    }
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This makes a few minor changes to our unit tests so they all pass with both Celeritas core RNGs.