### PR TITLE
Fix ROOT dictionary paths

### DIFF
--- a/app/celer-g4/RootIO.cc
+++ b/app/celer-g4/RootIO.cc
@@ -30,6 +30,8 @@
 
 #ifdef _WIN32
 #    include <process.h>
+#else
+#    include <unistd.h>
 #endif
 
 namespace celeritas

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -184,15 +184,15 @@ if(CELERITAS_USE_ROOT)
 
   # Generate the dictionary source file
   root_generate_dictionary(CeleritasRootInterface
-    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportData.hh"
-    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportElement.hh"
-    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportMaterial.hh"
-    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportParticle.hh"
-    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportPhysicsTable.hh"
-    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportPhysicsVector.hh"
-    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportProcess.hh"
-    "${CMAKE_CURRENT_SOURCE_DIR}/io/ImportVolume.hh"
-    "${CMAKE_CURRENT_SOURCE_DIR}/io/EventData.hh"
+    "celeritas/io/ImportData.hh"
+    "celeritas/io/ImportElement.hh"
+    "celeritas/io/ImportMaterial.hh"
+    "celeritas/io/ImportParticle.hh"
+    "celeritas/io/ImportPhysicsTable.hh"
+    "celeritas/io/ImportPhysicsVector.hh"
+    "celeritas/io/ImportProcess.hh"
+    "celeritas/io/ImportVolume.hh"
+    "celeritas/io/EventData.hh"
     NOINSTALL
     MODULE celeritas
     LINKDEF "${CMAKE_CURRENT_SOURCE_DIR}/ext/RootInterfaceLinkDef.h"


### PR DESCRIPTION
This allows to run code requiring the dictionary (eg. `celer-sim`) from the install directory (and when the source is not accessible)

In addition explicit include `<unistd.h>` for process id.