### PR TITLE
Warn and set default threads when OpenMP and Geant4 MT might collide

### DIFF
--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -45,6 +45,10 @@ if(CELERITAS_USE_HepMC3)
   list(APPEND SOURCES HepMC3PrimaryGenerator.cc)
 endif()
 
+if(CELERITAS_USE_OpenMP)
+  list(APPEND PRIVATE_DEPS OpenMP::OpenMP_CXX)
+endif()
+
 #-----------------------------------------------------------------------------#
 # Create library
 #-----------------------------------------------------------------------------#

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -8,15 +8,23 @@
 #include "LocalTransporter.hh"
 
 #include <csignal>
+#include <string>
 #include <type_traits>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <G4ParticleDefinition.hh>
+#include <G4Threading.hh>
 #include <G4ThreeVector.hh>
 #include <G4Track.hh>
 
+#ifdef _OPENMP
+#    include <omp.h>
+#endif
+
+#include "celeritas_config.h"
 #include "corecel/cont/Span.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/Environment.hh"
 #include "corecel/sys/ScopedSignalHandler.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/ext/Convert.geant.hh"
@@ -61,6 +69,30 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
         << "Geant4 ThreadID (" << thread_id
         << ") is out of range for the reported number of worker threads ("
         << params.Params()->max_streams() << ")");
+
+    // Check that OpenMP and Geant4 threading models don't collide
+    if (CELERITAS_USE_OPENMP && !celeritas::device()
+        && G4Threading::IsMultithreadedApplication())
+    {
+        auto msg = CELER_LOG(warning);
+        msg << "Using multithreaded Geant4 with Celeritas OpenMP";
+        if (std::string const& nt_str = celeritas::getenv("OMP_NUM_THREADS");
+            !nt_str.empty())
+        {
+            msg << "(OMP_NUM_THREADS=" << nt_str
+                << "): CPU threads may be oversubscribed";
+        }
+        else
+        {
+            msg << ": forcing 1 Celeritas thread on Geant4 worker "
+                << thread_id;
+#ifdef _OPENMP
+            omp_set_num_threads(1);
+#else
+            CELER_ASSERT_UNREACHABLE();
+#endif
+        }
+    }
 
     StepperInput inp;
     inp.params = params.Params();

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -74,7 +74,7 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
     if (CELERITAS_USE_OPENMP && !celeritas::device()
         && G4Threading::IsMultithreadedApplication())
     {
-        auto msg = CELER_LOG(warning);
+        auto msg = CELER_LOG_LOCAL(warning);
         msg << "Using multithreaded Geant4 with Celeritas OpenMP";
         if (std::string const& nt_str = celeritas::getenv("OMP_NUM_THREADS");
             !nt_str.empty())
@@ -84,8 +84,7 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
         }
         else
         {
-            msg << ": forcing 1 Celeritas thread on Geant4 worker "
-                << thread_id;
+            msg << ": forcing 1 Celeritas thread to Geant4 thread";
 #ifdef _OPENMP
             omp_set_num_threads(1);
 #else

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -19,10 +19,6 @@
 #include <G4RunManager.hh>
 #include <G4Threading.hh>
 
-#ifdef _OPENMP
-#    include <omp.h>
-#endif
-
 #include "celeritas_config.h"
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
@@ -213,29 +209,6 @@ SharedParams::SharedParams(SetupOptions const& options, SPOutputRegistry oreg)
         if (options.cuda_heap_size > 0)
         {
             celeritas::set_cuda_heap_size(options.cuda_heap_size);
-        }
-    }
-
-    // Check that OpenMP and Geant4 threading models don't collide
-    if (CELERITAS_USE_OPENMP && !celeritas::device()
-        && G4Threading::IsMultithreadedApplication())
-    {
-        auto msg = CELER_LOG(warning);
-        msg << "Using multithreaded Geant4 with Celeritas OpenMP";
-        std::string const& nt_str = celeritas::getenv("OMP_NUM_THREADS");
-        if (!nt_str.empty())
-        {
-            msg << "(OMP_NUM_THREADS=" << nt_str
-                << "): CPU threads may be oversubscribed";
-        }
-        else
-        {
-            msg << ": forcing 1 Celeritas thread per Geant4 thread";
-#ifdef _OPENMP
-            omp_set_num_threads(1);
-#else
-            CELER_ASSERT_UNREACHABLE();
-#endif
         }
     }
 


### PR DESCRIPTION
If using an OpenMP-enabled Celeritas with a multithreaded Geant4 application, (OMP_NUM_THREADS)*(Geant4 num threads) actual threads will be spawned without it being obvious. Generally it would be best to avoid building OpenMP when used with multithreaded Geant4, but it is convenient to be able to reuse the same library/executable for celer-sim and celer-g4.

This prints a warning if CPU+OpenMP+G4MT is in use; it will set the thread count to 1 if the `OMP_NUM_THREADS` environment variable isn't set (otherwise it defaults to "maximum threads").

@esseivaju or @amandalund could you please verify that your standalone tests show the "correct" behavior of 1 Celeritas thread to Geant4 thread when this is in use?