### PR TITLE
Fix celer-g4 primary generator MT reproducibility

### DIFF
--- a/app/celer-g4/PGPrimaryGeneratorAction.hh
+++ b/app/celer-g4/PGPrimaryGeneratorAction.hh
@@ -58,8 +58,7 @@ class PGPrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
     EnergySampler sample_energy_;
     PositionSampler sample_pos_;
     DirectionSampler sample_dir_;
-    size_type primary_count_{0};
-    size_type event_count_{0};
+    size_type seed_{0};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PrimaryGenerator.cc
+++ b/src/celeritas/phys/PrimaryGenerator.cc
@@ -78,14 +78,13 @@ auto PrimaryGenerator::operator()() -> result_type
     for (auto i : range(primaries_per_event_))
     {
         Primary& p = result[i];
-        p.particle_id = particle_id_[primary_count_ % particle_id_.size()];
+        p.particle_id = particle_id_[i % particle_id_.size()];
         p.energy = units::MevEnergy{sample_energy_(rng_)};
         p.position = sample_pos_(rng_);
         p.direction = sample_dir_(rng_);
         p.time = 0;
         p.event_id = EventId{event_count_};
         p.track_id = TrackId{i};
-        ++primary_count_;
     }
     ++event_count_;
     return result;

--- a/src/celeritas/phys/PrimaryGenerator.hh
+++ b/src/celeritas/phys/PrimaryGenerator.hh
@@ -77,7 +77,6 @@ class PrimaryGenerator : public EventReaderInterface
     PositionSampler sample_pos_;
     DirectionSampler sample_dir_;
     std::vector<ParticleId> particle_id_;
-    size_type primary_count_{0};
     size_type event_count_{0};
     PrimaryGeneratorEngine rng_;
 };

--- a/test/celeritas/phys/PrimaryGenerator.test.cc
+++ b/test/celeritas/phys/PrimaryGenerator.test.cc
@@ -89,7 +89,7 @@ TEST_F(PrimaryGeneratorTest, basic)
     auto primaries = generate_primaries();
     EXPECT_TRUE(primaries.empty());
 
-    static int const expected_particle_id[] = {0, 1, 0, 1, 0, 1};
+    static int const expected_particle_id[] = {0, 1, 0, 0, 1, 0};
     static int const expected_event_id[] = {0, 0, 0, 1, 1, 1};
     static int const expected_track_id[] = {0, 1, 2, 0, 1, 2};
 


### PR DESCRIPTION
This reseeds the celer-g4 primary generator RNG for each event so MT results _without_ Celeritas offloading are reproducible. It also fixes the check that `num_events` have been generated (which was based on the per-thread count rather than the total count).