### PR TITLE
Insert SortTrackAction when sorting by particle type

### DIFF
--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -264,7 +264,9 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
             insert_sort_tracks_action(TrackOrder::sort_step_limit_action);
             insert_sort_tracks_action(TrackOrder::sort_along_step_action);
             break;
-        default:
+        case TrackOrder::unsorted:
+        case TrackOrder::shuffled:
+        case TrackOrder::size_:
             break;
     }
 

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -255,6 +255,7 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
         case TrackOrder::partition_status:
         case TrackOrder::sort_step_limit_action:
         case TrackOrder::sort_along_step_action:
+        case TrackOrder::sort_particle_type:
             // Sort with just the given track order
             insert_sort_tracks_action(track_order);
             break;

--- a/src/celeritas/global/CoreState.cc
+++ b/src/celeritas/global/CoreState.cc
@@ -79,23 +79,13 @@ void CoreState<M>::insert_primaries(Span<Primary const> host_primaries)
 
 //---------------------------------------------------------------------------//
 /*!
- * Reference to the ActionThread collection matching the state memory space
- */
-template<MemSpace M>
-auto CoreState<M>::native_action_thread_offsets() -> ActionThreads<M>&
-{
-    return thread_offsets_;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Get a range delimiting the [start, end) of the track partition assigned
  * action_id in track_slots
  */
 template<MemSpace M>
 Range<ThreadId> CoreState<M>::get_action_range(ActionId action_id) const
 {
-    auto const& thread_offsets = action_thread_offsets();
+    auto const& thread_offsets = offsets_.host_action_thread_offsets();
     CELER_EXPECT((action_id + 1) < thread_offsets.size());
     return {thread_offsets[action_id], thread_offsets[action_id + 1]};
 }
@@ -107,11 +97,7 @@ Range<ThreadId> CoreState<M>::get_action_range(ActionId action_id) const
 template<MemSpace M>
 void CoreState<M>::num_actions(size_type n)
 {
-    resize(&thread_offsets_, n);
-    if constexpr (M == MemSpace::device)
-    {
-        resize(&host_thread_offsets_, n);
-    }
+    offsets_.resize(n);
 }
 
 //---------------------------------------------------------------------------//
@@ -121,7 +107,7 @@ void CoreState<M>::num_actions(size_type n)
 template<MemSpace M>
 size_type CoreState<M>::num_actions() const
 {
-    return thread_offsets_.size();
+    return offsets_.host_action_thread_offsets().size();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -72,7 +72,7 @@ class CoreState final : public CoreStateInterface
     using PrimaryCRef = Collection<Primary, Ownership::const_reference, M>;
     template<MemSpace M2>
     using ActionThreads =
-        typename detail::CoreStateThreadOffsets<M>::ActionThreads<M2>;
+        typename detail::CoreStateThreadOffsets<M>::template ActionThreads<M2>;
     //!@}
 
   public:

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -213,7 +213,7 @@ auto const& CoreState<M>::action_thread_offsets() const
 template<MemSpace M>
 auto& CoreState<M>::native_action_thread_offsets()
 {
-    return offsets_.device_action_thread_offsets();
+    return offsets_.native_action_thread_offsets();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -16,6 +16,7 @@
 #include "corecel/data/Ref.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreTrackData.hh"
+#include "celeritas/global/detail/CoreStateThreadOffsets.hh"
 #include "celeritas/phys/Primary.hh"
 #include "celeritas/track/CoreStateCounters.hh"
 
@@ -70,7 +71,8 @@ class CoreState final : public CoreStateInterface
     using Ptr = ObserverPtr<Ref, M>;
     using PrimaryCRef = Collection<Primary, Ownership::const_reference, M>;
     template<MemSpace M2>
-    using ActionThreads = Collection<ThreadId, Ownership::value, M2, ActionId>;
+    using ActionThreads =
+        typename detail::CoreStateThreadOffsets<M>::ActionThreads<M2>;
     //!@}
 
   public:
@@ -140,17 +142,14 @@ class CoreState final : public CoreStateInterface
 
     // Reference to the ActionThread collection matching the state memory
     // space
-    ActionThreads<M>& native_action_thread_offsets();
+    inline auto& native_action_thread_offsets();
 
   private:
     // State data
     CollectionStateStore<CoreStateData, M> states_;
 
     // Indices of first thread assigned to a given action
-    ActionThreads<M> thread_offsets_;
-
-    // Only used if M == device for D2H copy of thread_offsets_
-    ActionThreads<MemSpace::mapped> host_thread_offsets_;
+    detail::CoreStateThreadOffsets<M> offsets_;
 
     // Primaries to be added
     Collection<Primary, Ownership::value, M> primaries_;
@@ -193,14 +192,7 @@ auto CoreState<M>::primary_storage() const -> PrimaryCRef
 template<MemSpace M>
 auto& CoreState<M>::action_thread_offsets()
 {
-    if constexpr (M == MemSpace::device)
-    {
-        return host_thread_offsets_;
-    }
-    else
-    {
-        return thread_offsets_;
-    }
+    return offsets_.host_action_thread_offsets();
 }
 
 //---------------------------------------------------------------------------//
@@ -211,14 +203,17 @@ auto& CoreState<M>::action_thread_offsets()
 template<MemSpace M>
 auto const& CoreState<M>::action_thread_offsets() const
 {
-    if constexpr (M == MemSpace::device)
-    {
-        return host_thread_offsets_;
-    }
-    else
-    {
-        return thread_offsets_;
-    }
+    return offsets_.host_action_thread_offsets();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Reference to the ActionThread collection matching the state memory space
+ */
+template<MemSpace M>
+auto& CoreState<M>::native_action_thread_offsets()
+{
+    return offsets_.device_action_thread_offsets();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/detail/CoreStateThreadOffsets.hh
+++ b/src/celeritas/global/detail/CoreStateThreadOffsets.hh
@@ -1,0 +1,93 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/detail/CoreStateThreadOffsets.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Types.hh"
+#include "corecel/data/Collection.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "corecel/sys/ThreadId.hh"
+#include "celeritas/Types.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+/*!
+ * Holds Collections used by CoreState to store thread offsets. This is
+ * specialized for device memory space as two collections are needed, one for
+ * the host and one for the device. Using pinned mapped memory would be less
+ * efficient.
+ */
+template<MemSpace M>
+class CoreStateThreadOffsets
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    template<MemSpace M2>
+    using ActionThreads = Collection<ThreadId, Ownership::value, M2, ActionId>;
+    //!@}
+
+  public:
+    constexpr auto& host_action_thread_offsets() { return thread_offsets_; }
+    constexpr auto const& host_action_thread_offsets() const
+    {
+        return thread_offsets_;
+    }
+    constexpr auto& device_action_thread_offsets()
+    {
+        return host_action_thread_offsets();
+    }
+    constexpr auto const& device_action_thread_offsets() const
+    {
+        return host_action_thread_offsets();
+    }
+    void resize(size_type n) { celeritas::resize(&thread_offsets_, n); }
+
+  private:
+    ActionThreads<M> thread_offsets_;
+};
+
+template<>
+class CoreStateThreadOffsets<MemSpace::device>
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    template<MemSpace M>
+    using ActionThreads = Collection<ThreadId, Ownership::value, M, ActionId>;
+    //!@}
+
+  public:
+    constexpr auto& host_action_thread_offsets()
+    {
+        return host_thread_offsets_;
+    }
+    constexpr auto const& host_action_thread_offsets() const
+    {
+        return host_thread_offsets_;
+    }
+    constexpr auto& device_action_thread_offsets() { return thread_offsets_; }
+    constexpr auto const& device_action_thread_offsets() const
+    {
+        return thread_offsets_;
+    }
+    void resize(size_type n)
+    {
+        celeritas::resize(&thread_offsets_, n);
+        celeritas::resize(&host_thread_offsets_, n);
+    }
+
+  private:
+    ActionThreads<MemSpace::device> thread_offsets_;
+    ActionThreads<MemSpace::mapped> host_thread_offsets_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/global/detail/CoreStateThreadOffsets.hh
+++ b/src/celeritas/global/detail/CoreStateThreadOffsets.hh
@@ -39,11 +39,11 @@ class CoreStateThreadOffsets
     {
         return thread_offsets_;
     }
-    constexpr auto& device_action_thread_offsets()
+    constexpr auto& native_action_thread_offsets()
     {
         return host_action_thread_offsets();
     }
-    constexpr auto const& device_action_thread_offsets() const
+    constexpr auto const& native_action_thread_offsets() const
     {
         return host_action_thread_offsets();
     }
@@ -72,8 +72,8 @@ class CoreStateThreadOffsets<MemSpace::device>
     {
         return host_thread_offsets_;
     }
-    constexpr auto& device_action_thread_offsets() { return thread_offsets_; }
-    constexpr auto const& device_action_thread_offsets() const
+    constexpr auto& native_action_thread_offsets() { return thread_offsets_; }
+    constexpr auto const& native_action_thread_offsets() const
     {
         return thread_offsets_;
     }

--- a/test/celeritas/track/TrackSort.test.cc
+++ b/test/celeritas/track/TrackSort.test.cc
@@ -131,7 +131,7 @@ class TestActionCountEm3Stepper : public TestEm3NoMsc, public TrackSortTestBase
 {
   protected:
     template<MemSpace M2>
-    using ActionThreads = typename CoreState<M>::ActionThreads<M2>;
+    using ActionThreads = typename CoreState<M>::template ActionThreads<M2>;
     template<MemSpace M2>
     using ActionThreadsItems = AllItems<ThreadId, M2>;
 


### PR DESCRIPTION
I didn't update the switch statement which is inserting the SortTracksAction in #1044. 

Also refactoring CoreState to only have the necessary thread_offsets_ collection, moving all the template code to the internal state struct `CoreStateThreadOffsets`.