### PR TITLE
Remove deprecated code from v0.4

### DIFF
--- a/.github/pull_request_template.release.md
+++ b/.github/pull_request_template.release.md
@@ -11,6 +11,7 @@ Target: upstream/develop (always!)
 - [ ] Tag the develop branch with ``vX.Y.Z-rc.N`` where N starts with 1, and increment for every time you return to this step due to new pull requests.
 - [ ] Run performance regression tests on Summit, Crusher/Frontier, and an additional machine with debug assertions enabled (e.g., Wildstyle).
 - [ ] Update documentation with release notes from all pull requests newly included in the release.
+- [ ] Check for (and delete if found) code marked as "deprecated: to be removed in vX.Y".
 - [ ] Ensure the code documentation builds with as few warnings as possible in the `doc` workflow on the CI.
 
 ## Post-merge checklist

--- a/app/demo-geo-check/demo-geo-check.cc
+++ b/app/demo-geo-check/demo-geo-check.cc
@@ -56,7 +56,7 @@ void run(std::istream& is)
     GeoTrackInitializer trkinit;
     inp.at("pos").get_to(trkinit.pos);
     inp.at("dir").get_to(trkinit.dir);
-    normalize_direction(&trkinit.dir);
+    trkinit.dir = make_unit_vector(trkinit.dir);
 
     CELER_ASSERT(geo_params);
     int max_steps = inp.at("max_steps").get<int>();

--- a/app/demo-interactor/XsGridParams.hh
+++ b/app/demo-interactor/XsGridParams.hh
@@ -49,10 +49,10 @@ class XsGridParams
     explicit XsGridParams(Input const& input);
 
     // Access on-device data
-    DeviceRef const& device_ref() const { return data_.device(); }
+    DeviceRef const& device_ref() const { return data_.device_ref(); }
 
     // Get host-side data
-    HostRef const& host_ref() const { return data_.host(); }
+    HostRef const& host_ref() const { return data_.host_ref(); }
 
   private:
     CollectionMirror<TableData> data_;

--- a/app/demo-rasterizer/ImageStore.cc
+++ b/app/demo-rasterizer/ImageStore.cc
@@ -25,8 +25,7 @@ ImageStore::ImageStore(ImageRunArgs params)
     CELER_EXPECT(params.vertical_pixels > 0);
 
     // Normalize rightward axis
-    right_ax_ = params.rightward_ax;
-    normalize_direction(&right_ax_);
+    right_ax_ = make_unit_vector(params.rightward_ax);
 
     // Vector pointing toward the upper right from the lower left corner
     Real3 diagonal;
@@ -42,7 +41,7 @@ ImageStore::ImageStore(ImageRunArgs params)
     {
         down_ax_[i] = -diagonal[i] + projection * right_ax_[i];
     }
-    normalize_direction(&down_ax_);
+    down_ax_ = make_unit_vector(down_ax_);
 
     // Calculate length along each axis
     real_type width_x = dot_product(diagonal, right_ax_);

--- a/doc/appendix/administration.rst
+++ b/doc/appendix/administration.rst
@@ -283,41 +283,43 @@ or a "backport" branch (minor, patch).
 The following process must be followed (and may need iteration to converge) for
 each release.
 
-1.  Create a ``release-vX.Y.Z`` branch.
-2.  Ensure all CI jobs passed for the release in question. This is automatic
-    for releases from the ``develop`` branch (since every pull request must
-    pass) but should be checked manually for backports.
-3.  Update documentation with release notes from all pull requests newly
+1.  Ensure all CI jobs pass for the target branch. This is automatic
+    for releases from the ``develop`` branch, since every pull request must
+    pass, but should be checked manually for backports.
+2.  Create a ``release-vX.Y.Z`` branch from the target.
+3.  Tag the target branch with ``vX.Y.Z-rc.N`` where N starts with 1, and
+    increment for every time you return to this step due to new pull requests.
+    The tag can be pushed to your fork, or to the main repository if it should
+    be shared with other team members
+4.  Run performance regression tests on Summit/Perlmutter (for performance
+    testing), Crusher/Frontier (for HIP testing), and an additional machine
+    with debug assertions enabled (e.g., Wildstyle).
+5.  [TODO: define high-level validation tests like `geant-val`_ and a test
+    matrix correlating capability areas (code files/directories changed) to
+    test names.] Rerun and perform a cursory check on all validation tests that
+    might be affected by changes since the previous release. More complete
+    validation (since a change in results might not be an error) can be done
+    separately.
+6.  Postpone the release temporarily if major new bugs or performance
+    regressions are detected. Create new pull requests for the serious errors
+    using the standard :ref:`contributing <contributing>` process, and once the
+    fixes are merged into develop, merge develop into the release branch.
+    Return to step 2.
+7.  If only minor updates are needed to fix the build or tests on a particular
+    machine, include those as part of the release branch.
+8.  If this is a "major" release (see :ref:`deprecations`),
+    check for and remove code marked as ``DEPRECATED: to be removed
+    in vX.Y``.
+9.  Update documentation with release notes from all pull requests newly
     included in the release. *Make sure this happens after all pull requests
     targeted for this milestone have been merged*.
     Follow the format for previous releases: add a
     summary of highlights, and enumerate the pull requests (with PR numbers and
     authorship attribution) separated by features and bug requests. Use the
     `helper notebook`_ in the Celeritas documents repository to automate this.
-4.  Tag the branch on your fork with ``vX.Y.Z-rc.N`` where N starts with 1, and
-    increment for every time you return to this step due to new pull requests.
-5.  Run performance regression tests on Summit (for performance testing),
-    Crusher/Frontier (for HIP testing), and an additional machine with debug
-    assertions enabled (e.g., Wildstyle).
-6.  [TODO: define high-level validation tests like `geant-val`_ and a test
-    matrix correlating capability areas (code files/directories changed) to
-    test names.] Rerun and perform a cursory check on all validation tests that
-    might be affected by changes since the previous release. More complete
-    validation (since a change in results might not be an error) can be done
-    separately.
-7.  Postpone the release temporarily if major new bugs or performance
-    regressions are detected. Create new pull requests for the serious errors
-    using the standard :ref:`contributing <contributing>` process, and once the
-    fixes are merged into develop, merge develop into the release branch.
-    Return to step 3.
-8.  If only minor updates are needed to fix the build or tests on a particular
-    machine, include those as part of the "pre-release" pull request that
-    includes new documentation.
-9.  Ensure the code documentation builds, preferably without warnings, on a
-    configuration that has Sphinx, Doxygen, and Breathe active. [TODO: automate
-    this with CI for doc publishing]
 10. Submit a pull request with the newly added documentation and any
-    release-related tweaks, and wait until it's reviewed and merged.
+    release-related tweaks, and wait until it's reviewed and merged. The unit
+    tests and documentation should all build and pass the CI.
 11. If releasing a backported version branch, cherry-pick this documentation
     commit into the backport branch.
 12. Use the GitHub interface to create a new release with the documentation

--- a/src/accel/Logger.hh
+++ b/src/accel/Logger.hh
@@ -19,7 +19,7 @@ namespace celeritas
 Logger MakeMTLogger(G4RunManager const&);
 
 //---------------------------------------------------------------------------//
-//! Manually create a multithread-friendly logger (remove in v0.4)
+//! Manually create a multithread-friendly logger (remove in v1.0)
 [[deprecated]] inline Logger make_mt_logger(G4RunManager const& rm)
 {
     return MakeMTLogger(rm);

--- a/src/celeritas/em/AtomicRelaxationParams.hh
+++ b/src/celeritas/em/AtomicRelaxationParams.hh
@@ -56,10 +56,10 @@ class AtomicRelaxationParams final
     explicit AtomicRelaxationParams(Input const& inp);
 
     //! Access EADL data on the host
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access EADL data on the device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     // Whether to simulate non-radiative transitions

--- a/src/celeritas/em/FluctuationParams.hh
+++ b/src/celeritas/em/FluctuationParams.hh
@@ -29,10 +29,10 @@ class FluctuationParams final : public ParamsDataInterface<FluctuationData>
                       MaterialParams const& materials);
 
     //! Access physics properties on the host
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access physics properties on the device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     CollectionMirror<FluctuationData> data_;

--- a/src/celeritas/em/UrbanMscParams.hh
+++ b/src/celeritas/em/UrbanMscParams.hh
@@ -66,10 +66,10 @@ class UrbanMscParams final : public ParamsDataInterface<UrbanMscData>
     // along-step kernels?
 
     //! Access UrbanMsc data on the host
-    HostRef const& host_ref() const final { return mirror_.host(); }
+    HostRef const& host_ref() const final { return mirror_.host_ref(); }
 
     //! Access UrbanMsc data on the device
-    DeviceRef const& device_ref() const final { return mirror_.device(); }
+    DeviceRef const& device_ref() const final { return mirror_.device_ref(); }
 
   private:
     // Host/device storage and reference

--- a/src/celeritas/em/interactor/EPlusGGInteractor.hh
+++ b/src/celeritas/em/interactor/EPlusGGInteractor.hh
@@ -166,7 +166,7 @@ CELER_FUNCTION Interaction EPlusGGInteractor::operator()(Engine& rng)
             secondaries[1].direction[i] = eplus_moment * inc_direction_[i]
                                           - inc_energy_ * inc_direction_[i];
         }
-        normalize_direction(&secondaries[1].direction);
+        secondaries[1].direction = make_unit_vector(secondaries[1].direction);
     }
 
     return result;

--- a/src/celeritas/em/interactor/KleinNishinaInteractor.hh
+++ b/src/celeritas/em/interactor/KleinNishinaInteractor.hh
@@ -189,7 +189,8 @@ CELER_FUNCTION Interaction KleinNishinaInteractor::operator()(Engine& rng)
             = inc_direction_[i] * inc_energy_.value()
               - result.direction[i] * result.energy.value();
     }
-    normalize_direction(&electron_secondary->direction);
+    electron_secondary->direction
+        = make_unit_vector(electron_secondary->direction);
 
     return result;
 }

--- a/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
+++ b/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
@@ -184,7 +184,7 @@ CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
                                            * secondary_direction[i];
         inc_exiting_direction[i] = inc_momentum_ijk - secondary_momentum_ijk;
     }
-    normalize_direction(&inc_exiting_direction);
+    inc_exiting_direction = make_unit_vector(inc_exiting_direction);
 
     // Construct interaction for change to primary (incident) particle
     const real_type inc_exiting_energy = inc_energy_ - secondary_energy;

--- a/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
+++ b/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
@@ -150,7 +150,7 @@ CELER_FUNCTION Interaction MuBremsstrahlungInteractor::operator()(Engine& rng)
                                * inc_direction_[i]
                            - epsilon * gamma_dir[i];
     }
-    normalize_direction(&inc_direction);
+    inc_direction = make_unit_vector(inc_direction);
 
     // Construct interaction for change to primary (incident) particle
     Interaction result;

--- a/src/celeritas/em/interactor/detail/BremFinalStateHelper.hh
+++ b/src/celeritas/em/interactor/detail/BremFinalStateHelper.hh
@@ -112,7 +112,7 @@ CELER_FUNCTION Interaction BremFinalStateHelper::operator()(Engine& rng)
                                      * secondary_->direction[i];
         result.direction[i] = inc_momentum_i - gamma_momentum_i;
     }
-    normalize_direction(&result.direction);
+    result.direction = make_unit_vector(result.direction);
 
     secondary_->particle_id = gamma_id_;
     secondary_->energy = gamma_energy_;

--- a/src/celeritas/em/model/CombinedBremModel.hh
+++ b/src/celeritas/em/model/CombinedBremModel.hh
@@ -76,10 +76,10 @@ class CombinedBremModel final : public Model
     }
 
     //! Access data on the host
-    HostRef const& host_ref() const { return data_.host(); }
+    HostRef const& host_ref() const { return data_.host_ref(); }
 
     //! Access data on the device
-    DeviceRef const& device_ref() const { return data_.device(); }
+    DeviceRef const& device_ref() const { return data_.device_ref(); }
 
   private:
     //// DATA ////

--- a/src/celeritas/em/model/LivermorePEModel.hh
+++ b/src/celeritas/em/model/LivermorePEModel.hh
@@ -67,10 +67,10 @@ class LivermorePEModel final : public Model
     }
 
     //! Access data on the host
-    HostRef const& host_ref() const { return data_.host(); }
+    HostRef const& host_ref() const { return data_.host_ref(); }
 
     //! Access data on the device
-    DeviceRef const& device_ref() const { return data_.device(); }
+    DeviceRef const& device_ref() const { return data_.device_ref(); }
 
   private:
     // Host/device storage and reference

--- a/src/celeritas/em/model/RayleighModel.hh
+++ b/src/celeritas/em/model/RayleighModel.hh
@@ -67,10 +67,10 @@ class RayleighModel final : public Model
     }
 
     //! Access Rayleigh data on the host
-    HostRef const& host_ref() const { return mirror_.host(); }
+    HostRef const& host_ref() const { return mirror_.host_ref(); }
 
     //! Access Rayleigh data on the device
-    DeviceRef const& device_ref() const { return mirror_.device(); }
+    DeviceRef const& device_ref() const { return mirror_.device_ref(); }
 
   private:
     //// DATA ////

--- a/src/celeritas/em/model/RelativisticBremModel.hh
+++ b/src/celeritas/em/model/RelativisticBremModel.hh
@@ -70,10 +70,10 @@ class RelativisticBremModel final : public Model
     }
 
     //! Access data on the host
-    HostRef const& host_ref() const { return data_.host(); }
+    HostRef const& host_ref() const { return data_.host_ref(); }
 
     //! Access data on the device
-    DeviceRef const& device_ref() const { return data_.device(); }
+    DeviceRef const& device_ref() const { return data_.device_ref(); }
 
   private:
     //// DATA ////

--- a/src/celeritas/em/model/SeltzerBergerModel.hh
+++ b/src/celeritas/em/model/SeltzerBergerModel.hh
@@ -90,10 +90,10 @@ class SeltzerBergerModel final : public Model
     }
 
     //! Access SB data on the host
-    HostRef const& host_ref() const { return data_.host(); }
+    HostRef const& host_ref() const { return data_.host_ref(); }
 
     //! Access SB data on the device
-    DeviceRef const& device_ref() const { return data_.device(); }
+    DeviceRef const& device_ref() const { return data_.device_ref(); }
 
   private:
     // Host/device storage and reference

--- a/src/celeritas/em/model/WentzelModel.hh
+++ b/src/celeritas/em/model/WentzelModel.hh
@@ -85,8 +85,8 @@ class WentzelModel final : public Model
 
     //!@{
     //! Access model data
-    WentzelHostRef const& host_ref() const { return data_.host(); }
-    WentzelDeviceRef const& device_ref() const { return data_.device(); }
+    WentzelHostRef const& host_ref() const { return data_.host_ref(); }
+    WentzelDeviceRef const& device_ref() const { return data_.device_ref(); }
     //!@}
 
   private:

--- a/src/celeritas/ext/detail/GeantProcessImporter.hh
+++ b/src/celeritas/ext/detail/GeantProcessImporter.hh
@@ -31,6 +31,7 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
+// DEPRECATED: remove in v0.5
 enum class TableSelection
 {
     minimal,  //!< Store only lambda, dedx, and range
@@ -107,9 +108,6 @@ class GeantProcessImporter
     // Store material and element information for the element selector tables
     std::vector<ImportMaterial> const& materials_;
     std::vector<ImportElement> const& elements_;
-
-    // Whether to write tables that aren't used by physics
-    TableSelection which_tables_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -312,8 +312,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
     // Even though the along-substep movement was through chord lengths,
     // conserve momentum through the field change by updating the final
     // *direction* based on the state's momentum.
-    Real3 dir = state_.mom;
-    normalize_direction(&dir);
+    Real3 dir = make_unit_vector(state_.mom);
     geo_.set_dir(dir);
 
     if (CELER_UNLIKELY(result.distance == 0))

--- a/src/celeritas/field/RZMapFieldParams.hh
+++ b/src/celeritas/field/RZMapFieldParams.hh
@@ -36,10 +36,10 @@ class RZMapFieldParams final : public ParamsDataInterface<RZMapFieldParamsData>
     explicit RZMapFieldParams(Input const& inp);
 
     //! Access field map data on the host
-    HostRef const& host_ref() const final { return mirror_.host(); }
+    HostRef const& host_ref() const final { return mirror_.host_ref(); }
 
     //! Access field map data on the device
-    DeviceRef const& device_ref() const final { return mirror_.device(); }
+    DeviceRef const& device_ref() const final { return mirror_.device_ref(); }
 
   private:
     // Host/device storage and reference

--- a/src/celeritas/geo/GeoMaterialParams.hh
+++ b/src/celeritas/geo/GeoMaterialParams.hh
@@ -72,10 +72,10 @@ class GeoMaterialParams final
     explicit GeoMaterialParams(Input);
 
     //! Access material properties on the host
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access material properties on the device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     CollectionMirror<GeoMaterialParamsData> data_;

--- a/src/celeritas/io/EventReader.cc
+++ b/src/celeritas/io/EventReader.cc
@@ -126,10 +126,10 @@ auto EventReader::operator()() -> result_type
         // Get the direction of the primary
         auto mom = par->momentum();
         HepMC3::Units::convert(mom, evt.momentum_unit(), HepMC3::Units::MEV);
-        primary.direction = {static_cast<real_type>(mom.px()),
-                             static_cast<real_type>(mom.py()),
-                             static_cast<real_type>(mom.pz())};
-        normalize_direction(&primary.direction);
+        primary.direction
+            = make_unit_vector(Real3{static_cast<real_type>(mom.px()),
+                                     static_cast<real_type>(mom.py()),
+                                     static_cast<real_type>(mom.pz())});
 
         // Get the energy of the primary
         primary.energy = units::MevEnergy{static_cast<real_type>(mom.e())};

--- a/src/celeritas/io/ImportPhysicsTable.cc
+++ b/src/celeritas/io/ImportPhysicsTable.cc
@@ -23,16 +23,6 @@ char const* to_cstring(ImportTableType value)
         "dedx",
         "range",
         "msc_xs",
-
-        "dedx_process",
-        "dedx_unrestricted",
-        "csda_range",
-
-        "dedx_subsec",
-        "ionization_subsec",
-        "secondary_range",
-        "inverse_range",
-        "sublambda",
     };
     return to_cstring_impl(value);
 }

--- a/src/celeritas/io/ImportPhysicsTable.hh
+++ b/src/celeritas/io/ImportPhysicsTable.hh
@@ -35,19 +35,6 @@ enum class ImportTableType
     dedx,  //!< Energy loss summed over processes
     range,  //!< Integrated inverse energy loss
     msc_xs,  //!< Scaled transport cross section
-
-    //// DEPRECATED (remove in v0.4): Unused by celeritas ////
-    dedx_process,  //!< Energy loss table for a process
-    dedx_unrestricted,
-    csda_range,  //!< Continuous slowing down approximation
-
-    //// DEPRECATED (remove in v0.4): Removed in Geant4@11 ////
-    dedx_subsec,
-    ionization_subsec,
-    secondary_range,
-    inverse_range,  //!< Inverse mapping of range: (range -> energy)
-    sublambda,  //!< For subcutoff regions
-
     size_
 };
 

--- a/src/celeritas/mat/MaterialParams.hh
+++ b/src/celeritas/mat/MaterialParams.hh
@@ -164,10 +164,10 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
     inline bool is_missing_isotopes() const { return this->num_isotopes(); }
 
     //! Access material properties on the host
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access material properties on the device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     // Metadata

--- a/src/celeritas/phys/CutoffParams.hh
+++ b/src/celeritas/phys/CutoffParams.hh
@@ -88,10 +88,10 @@ class CutoffParams final : public ParamsDataInterface<CutoffParamsData>
     inline CutoffView get(MaterialId material) const;
 
     //! Access cutoff data on the host
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access cutoff data on the device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     // Host/device storage and reference

--- a/src/celeritas/phys/ParticleParams.hh
+++ b/src/celeritas/phys/ParticleParams.hh
@@ -89,10 +89,10 @@ class ParticleParams final : public ParamsDataInterface<ParticleParamsData>
     ParticleView get(ParticleId id) const;
 
     //! Access material properties on the host
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access material properties on the device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     // Saved copy of metadata

--- a/src/celeritas/phys/PhysicsParams.hh
+++ b/src/celeritas/phys/PhysicsParams.hh
@@ -171,10 +171,10 @@ class PhysicsParams final : public ParamsDataInterface<PhysicsParamsData>
     SpanConstProcessId processes(ParticleId) const;
 
     //! Access physics properties on the host
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access physics properties on the device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     using SPAction = std::shared_ptr<ConcreteAction>;

--- a/src/celeritas/random/CuHipRngParams.hh
+++ b/src/celeritas/random/CuHipRngParams.hh
@@ -28,10 +28,10 @@ class CuHipRngParams final : public ParamsDataInterface<CuHipRngParamsData>
     explicit CuHipRngParams(unsigned int seed);
 
     //! Access RNG properties for constructing RNG state
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access data on device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     // Host/device storage and reference

--- a/src/celeritas/random/XorwowRngParams.hh
+++ b/src/celeritas/random/XorwowRngParams.hh
@@ -30,10 +30,10 @@ class XorwowRngParams final : public ParamsDataInterface<XorwowRngParamsData>
     // explicit XorwowRngParams(const std::string& hexstring);
 
     //! Access material properties on the host
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access material properties on the device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     //// DATA ////

--- a/src/celeritas/track/SimParams.hh
+++ b/src/celeritas/track/SimParams.hh
@@ -49,10 +49,10 @@ class SimParams final : public ParamsDataInterface<SimParamsData>
     explicit SimParams(Input const&);
 
     //! Access data on host
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access data on device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     // Host/device storage and reference

--- a/src/celeritas/track/TrackInitParams.hh
+++ b/src/celeritas/track/TrackInitParams.hh
@@ -38,10 +38,10 @@ class TrackInitParams final : public ParamsDataInterface<TrackInitParamsData>
     size_type max_events() const { return host_ref().max_events; }
 
     //! Access primaries for contructing track initializer states
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Access data on device
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     // Host/device storage and reference

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -37,10 +37,6 @@ using ull_int = unsigned long long int;
 //---------------------------------------------------------------------------//
 // ENUMERATIONS
 //---------------------------------------------------------------------------//
-//! DEPRECATED: will be replaced with std::byte in v1
-using Byte = std::byte;
-
-//---------------------------------------------------------------------------//
 //! Memory location of data
 enum class MemSpace
 {

--- a/src/corecel/data/CollectionMirror.hh
+++ b/src/corecel/data/CollectionMirror.hh
@@ -40,7 +40,7 @@ namespace celeritas
  *
  *     const CollectionDeviceRef& device_ref() const
  *     {
- *         return data_.device();
+ *         return data_.device_ref();
  *     }
  *   private:
  *     CollectionMirror<FooData> data_;
@@ -67,12 +67,6 @@ class CollectionMirror : public ParamsDataInterface<P>
 
     //! Whether the data is assigned
     explicit operator bool() const { return static_cast<bool>(host_); }
-
-    //!@{
-    //! Deprecated alias to ref
-    HostRef const& host() const { return this->host_ref(); }
-    DeviceRef const& device() const { return this->device_ref(); }
-    //!@}
 
     //! Access data on host
     HostRef const& host_ref() const final { return host_ref_; }

--- a/src/corecel/data/DeviceAllocation.cc
+++ b/src/corecel/data/DeviceAllocation.cc
@@ -34,7 +34,7 @@ DeviceAllocation::DeviceAllocation(size_type bytes) : size_{bytes}
     CELER_EXPECT(celeritas::device());
     void* ptr = nullptr;
     CELER_DEVICE_CALL_PREFIX(Malloc(&ptr, bytes));
-    data_.reset(static_cast<Byte*>(ptr));
+    data_.reset(static_cast<std::byte*>(ptr));
 }
 
 //---------------------------------------------------------------------------//
@@ -47,7 +47,7 @@ DeviceAllocation::DeviceAllocation(size_type bytes, StreamId stream)
     CELER_EXPECT(celeritas::device());
     void* ptr = celeritas::device().stream(stream_).malloc_async(bytes);
     CELER_ASSERT(ptr);
-    data_.reset(static_cast<Byte*>(ptr));
+    data_.reset(static_cast<std::byte*>(ptr));
 }
 
 //---------------------------------------------------------------------------//
@@ -105,7 +105,7 @@ void DeviceAllocation::copy_to_host(SpanBytes bytes) const
 //---------------------------------------------------------------------------//
 //! Deleter frees data: prevent exceptions
 void DeviceAllocation::DeviceFreeDeleter::operator()(
-    [[maybe_unused]] Byte* ptr) const noexcept(CELER_USE_DEVICE)
+    [[maybe_unused]] std::byte* ptr) const noexcept(CELER_USE_DEVICE)
 {
     try
     {

--- a/src/corecel/data/DeviceAllocation.hh
+++ b/src/corecel/data/DeviceAllocation.hh
@@ -34,8 +34,8 @@ class DeviceAllocation
     //!@{
     //! \name Type aliases
     using size_type = std::size_t;
-    using SpanBytes = Span<Byte>;
-    using SpanConstBytes = Span<Byte const>;
+    using SpanBytes = Span<std::byte>;
+    using SpanConstBytes = Span<std::byte const>;
     //!@}
 
   public:
@@ -80,9 +80,9 @@ class DeviceAllocation
     struct DeviceFreeDeleter
     {
         StreamId stream_;
-        void operator()(Byte*) const noexcept(CELER_USE_DEVICE);
+        void operator()(std::byte*) const noexcept(CELER_USE_DEVICE);
     };
-    using DeviceUniquePtr = std::unique_ptr<Byte[], DeviceFreeDeleter>;
+    using DeviceUniquePtr = std::unique_ptr<std::byte[], DeviceFreeDeleter>;
 
     //// DATA ////
 

--- a/src/corecel/data/DeviceVector.hh
+++ b/src/corecel/data/DeviceVector.hh
@@ -158,8 +158,8 @@ template<class T>
 void DeviceVector<T>::copy_to_device(SpanConstT data)
 {
     CELER_EXPECT(data.size() == this->size());
-    allocation_.copy_to_device(
-        {reinterpret_cast<Byte const*>(data.data()), data.size() * sizeof(T)});
+    allocation_.copy_to_device({reinterpret_cast<std::byte const*>(data.data()),
+                                data.size() * sizeof(T)});
 }
 
 //---------------------------------------------------------------------------//
@@ -171,7 +171,7 @@ void DeviceVector<T>::copy_to_host(SpanT data) const
 {
     CELER_EXPECT(data.size() == this->size());
     allocation_.copy_to_host(
-        {reinterpret_cast<Byte*>(data.data()), data.size() * sizeof(T)});
+        {reinterpret_cast<std::byte*>(data.data()), data.size() * sizeof(T)});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/ArrayUtils.hh
+++ b/src/corecel/math/ArrayUtils.hh
@@ -55,11 +55,6 @@ template<class T, size_type N>
                                                Array<T, N> const& y);
 
 //---------------------------------------------------------------------------//
-// Divide the given vector by its Euclidian norm
-template<class T>
-inline CELER_FUNCTION void normalize_direction(Array<T, 3>* direction);
-
-//---------------------------------------------------------------------------//
 // Calculate a cartesian unit vector from spherical coordinates
 template<class T>
 [[nodiscard]] inline CELER_FUNCTION Array<T, 3>
@@ -165,19 +160,6 @@ CELER_FUNCTION T distance(Array<T, N> const& x, Array<T, N> const& y)
 
 //---------------------------------------------------------------------------//
 /*!
- * Divide the given vector by its Euclidian norm.
- *
- * \deprecated replace with \c make_unit_vector
- */
-template<class T>
-CELER_FUNCTION void normalize_direction(Array<T, 3>* direction)
-{
-    CELER_EXPECT(direction);
-    *direction = make_unit_vector(*direction);
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Calculate a Cartesian vector from spherical coordinates.
  *
  * Theta is the angle between the Z axis and the outgoing vector, and phi is
@@ -279,8 +261,7 @@ rotate(Array<T, 3> const& dir, Array<T, 3> const& rot)
            -sintheta * dir[X] + rot[Z] * dir[Z]};
 
     // Always normalize to prevent roundoff error from propagating
-    normalize_direction(&result);
-    return result;
+    return make_unit_vector(result);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -105,10 +105,10 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     //// DATA ACCESS ////
 
     //! Reference to CPU geometry data
-    HostRef const& host_ref() const final { return data_.host(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
 
     //! Reference to managed GPU geometry data
-    DeviceRef const& device_ref() const final { return data_.device(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
     // Host metadata/access

--- a/src/orange/construct/detail/OrangeInputIOImpl.json.cc
+++ b/src/orange/construct/detail/OrangeInputIOImpl.json.cc
@@ -46,11 +46,11 @@ struct SurfaceEmplacer
         return visit_surface_type(
             [this, data](auto st_constant) {
                 using Surface = typename decltype(st_constant)::type;
-                using Storage = typename Surface::Storage;
+                using StorageSpan = typename Surface::StorageSpan;
 
                 // Construct the variant on the back of the vector
                 surfaces->emplace_back(std::in_place_type<Surface>,
-                                       Storage{data.data(), data.size()});
+                                       StorageSpan{data.data(), data.size()});
             },
             st);
     }

--- a/src/orange/surf/ConeAligned.hh
+++ b/src/orange/surf/ConeAligned.hh
@@ -36,8 +36,7 @@ class ConeAligned
     //@{
     //! \name Type aliases
     using Intersections = Array<real_type, 2>;
-    using StorageSpan = Span<const real_type, 4>;
-    using Storage = StorageSpan;  // DEPRECATED
+    using StorageSpan = Span<real_type const, 4>;
     //@}
 
   private:
@@ -82,7 +81,7 @@ class ConeAligned
     CELER_FUNCTION real_type tangent_sq() const { return tsq_; }
 
     //! Get a view to the data for type-deleted storage
-    CELER_FUNCTION Storage data() const { return {&origin_[0], 4}; }
+    CELER_FUNCTION StorageSpan data() const { return {&origin_[0], 4}; }
 
     //// CALCULATION ////
 

--- a/src/orange/surf/ConeAligned.hh
+++ b/src/orange/surf/ConeAligned.hh
@@ -225,8 +225,7 @@ CELER_FUNCTION Real3 ConeAligned<T>::calc_normal(Real3 const& pos) const
     }
     norm[to_int(T)] *= -tsq_;
 
-    normalize_direction(&norm);
-    return norm;
+    return make_unit_vector(norm);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/CylAligned.hh
+++ b/src/orange/surf/CylAligned.hh
@@ -71,8 +71,7 @@ class CylAligned
     //@{
     //! \name Type aliases
     using Intersections = Array<real_type, 2>;
-    using StorageSpan = Span<const real_type, 3>;
-    using Storage = StorageSpan;  // DEPRECATED
+    using StorageSpan = Span<real_type const, 3>;
     //@}
 
   private:
@@ -123,7 +122,7 @@ class CylAligned
     CELER_FUNCTION real_type radius_sq() const { return radius_sq_; }
 
     //! Get a view to the data for type-deleted storage
-    CELER_FUNCTION Storage data() const { return {&origin_u_, 3}; }
+    CELER_FUNCTION StorageSpan data() const { return {&origin_u_, 3}; }
 
     // Helper function to get the origin as a 3-vector
     Real3 calc_origin() const;

--- a/src/orange/surf/CylAligned.hh
+++ b/src/orange/surf/CylAligned.hh
@@ -259,8 +259,7 @@ CELER_FUNCTION Real3 CylAligned<T>::calc_normal(Real3 const& pos) const
     norm[to_int(U)] = pos[to_int(U)] - origin_u_;
     norm[to_int(V)] = pos[to_int(V)] - origin_v_;
 
-    normalize_direction(&norm);
-    return norm;
+    return make_unit_vector(norm);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/CylCentered.hh
+++ b/src/orange/surf/CylCentered.hh
@@ -227,8 +227,7 @@ CELER_FUNCTION Real3 CylCentered<T>::calc_normal(Real3 const& pos) const
     norm[to_int(U)] = pos[to_int(U)];
     norm[to_int(V)] = pos[to_int(V)];
 
-    normalize_direction(&norm);
-    return norm;
+    return make_unit_vector(norm);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/CylCentered.hh
+++ b/src/orange/surf/CylCentered.hh
@@ -42,8 +42,7 @@ class CylCentered
     //@{
     //! \name Type aliases
     using Intersections = Array<real_type, 2>;
-    using StorageSpan = Span<const real_type, 1>;
-    using Storage = StorageSpan;  // DEPRECATED
+    using StorageSpan = Span<real_type const, 1>;
     //@}
 
   private:
@@ -85,7 +84,7 @@ class CylCentered
     CELER_FUNCTION real_type radius_sq() const { return radius_sq_; }
 
     //! Get a view to the data for type-deleted storage
-    CELER_FUNCTION Storage data() const { return {&radius_sq_, 1}; }
+    CELER_FUNCTION StorageSpan data() const { return {&radius_sq_, 1}; }
 
     //// CALCULATION ////
 

--- a/src/orange/surf/GeneralQuadric.hh
+++ b/src/orange/surf/GeneralQuadric.hh
@@ -218,8 +218,7 @@ CELER_FUNCTION Real3 GeneralQuadric::calc_normal(Real3 const& pos) const
     norm[1] = 2 * b_ * y + d_ * x + e_ * z + h_;
     norm[2] = 2 * c_ * z + e_ * y + f_ * x + i_;
 
-    normalize_direction(&norm);
-    return norm;
+    return make_unit_vector(norm);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/GeneralQuadric.hh
+++ b/src/orange/surf/GeneralQuadric.hh
@@ -41,8 +41,7 @@ class GeneralQuadric
     //@{
     //! Type aliases
     using Intersections = Array<real_type, 2>;
-    using StorageSpan = Span<const real_type, 10>;
-    using Storage = StorageSpan;  // DEPRECATED
+    using StorageSpan = Span<real_type const, 10>;
     using SpanConstReal3 = Span<const real_type, 3>;
     //@}
 
@@ -88,7 +87,7 @@ class GeneralQuadric
     CELER_FUNCTION real_type zeroth() const { return j_; }
 
     //! Get a view to the data for type-deleted storage
-    CELER_FUNCTION Storage data() const { return {&a_, 10}; }
+    CELER_FUNCTION StorageSpan data() const { return {&a_, 10}; }
 
     //// CALCULATION ////
 

--- a/src/orange/surf/Plane.hh
+++ b/src/orange/surf/Plane.hh
@@ -33,8 +33,7 @@ class Plane
     //@{
     //! \name Type aliases
     using Intersections = Array<real_type, 1>;
-    using StorageSpan = Span<const real_type, 4>;
-    using Storage = StorageSpan;  // DEPRECATED
+    using StorageSpan = Span<real_type const, 4>;
     //@}
 
     //// CLASS ATTRIBUTES ////
@@ -74,7 +73,7 @@ class Plane
     CELER_FUNCTION real_type displacement() const { return d_; }
 
     //! Get a view to the data for type-deleted storage
-    CELER_FUNCTION Storage data() const { return {&normal_[0], 4}; }
+    CELER_FUNCTION StorageSpan data() const { return {&normal_[0], 4}; }
 
     //// CALCULATION ////
 

--- a/src/orange/surf/PlaneAligned.hh
+++ b/src/orange/surf/PlaneAligned.hh
@@ -25,8 +25,7 @@ class PlaneAligned
     //@{
     //! \name Type aliases
     using Intersections = Array<real_type, 1>;
-    using StorageSpan = Span<const real_type, 1>;
-    using Storage = StorageSpan;  // DEPRECATED
+    using StorageSpan = Span<real_type const, 1>;
     //@}
 
     //// CLASS ATTRIBUTES ////
@@ -53,7 +52,7 @@ class PlaneAligned
     CELER_FUNCTION real_type position() const { return position_; }
 
     //! Get a view to the data for type-deleted storage
-    CELER_FUNCTION Storage data() const { return {&position_, 1}; }
+    CELER_FUNCTION StorageSpan data() const { return {&position_, 1}; }
 
     // Construct outward normal vector
     inline CELER_FUNCTION Real3 calc_normal() const;

--- a/src/orange/surf/SimpleQuadric.hh
+++ b/src/orange/surf/SimpleQuadric.hh
@@ -209,8 +209,7 @@ CELER_FUNCTION Real3 SimpleQuadric::calc_normal(Real3 const& pos) const
     real_type const z = pos[to_int(Axis::z)];
 
     Real3 norm{2 * a_ * x + d_, 2 * b_ * y + e_, 2 * c_ * z + f_};
-    normalize_direction(&norm);
-    return norm;
+    return make_unit_vector(norm);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/SimpleQuadric.hh
+++ b/src/orange/surf/SimpleQuadric.hh
@@ -42,8 +42,7 @@ class SimpleQuadric
     //@{
     //! \name Type aliases
     using Intersections = Array<real_type, 2>;
-    using StorageSpan = Span<const real_type, 7>;
-    using Storage = StorageSpan;  // DEPRECATED
+    using StorageSpan = Span<real_type const, 7>;
     using SpanConstReal3 = Span<const real_type, 3>;
     //@}
 
@@ -95,7 +94,7 @@ class SimpleQuadric
     CELER_FUNCTION real_type zeroth() const { return g_; }
 
     //! Get a view to the data for type-deleted storage
-    CELER_FUNCTION Storage data() const { return {&a_, 7}; }
+    CELER_FUNCTION StorageSpan data() const { return {&a_, 7}; }
 
     //// CALCULATION ////
 

--- a/src/orange/surf/Sphere.hh
+++ b/src/orange/surf/Sphere.hh
@@ -34,8 +34,7 @@ class Sphere
     //@{
     //! Type aliases
     using Intersections = Array<real_type, 2>;
-    using StorageSpan = Span<const real_type, 4>;
-    using Storage = StorageSpan;  // DEPRECATED
+    using StorageSpan = Span<real_type const, 4>;
     //@}
 
     //// CLASS ATTRIBUTES ////
@@ -74,7 +73,7 @@ class Sphere
     CELER_FUNCTION real_type radius_sq() const { return radius_sq_; }
 
     //! Get a view to the data for type-deleted storage
-    CELER_FUNCTION Storage data() const { return {origin_.data(), 4}; }
+    CELER_FUNCTION StorageSpan data() const { return {origin_.data(), 4}; }
 
     //// CALCULATION ////
 

--- a/src/orange/surf/Sphere.hh
+++ b/src/orange/surf/Sphere.hh
@@ -158,9 +158,8 @@ CELER_FUNCTION auto Sphere::calc_intersections(Real3 const& pos,
  */
 CELER_FUNCTION Real3 Sphere::calc_normal(Real3 const& pos) const
 {
-    Real3 tpos{pos[0] - origin_[0], pos[1] - origin_[1], pos[2] - origin_[2]};
-    normalize_direction(&tpos);
-    return tpos;
+    return make_unit_vector(
+        Real3{pos[0] - origin_[0], pos[1] - origin_[1], pos[2] - origin_[2]});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/SphereCentered.hh
+++ b/src/orange/surf/SphereCentered.hh
@@ -154,9 +154,7 @@ SphereCentered::calc_intersections(Real3 const& pos,
  */
 CELER_FUNCTION Real3 SphereCentered::calc_normal(Real3 const& pos) const
 {
-    Real3 result{pos};
-    normalize_direction(&result);
-    return result;
+    return make_unit_vector(pos);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/SphereCentered.hh
+++ b/src/orange/surf/SphereCentered.hh
@@ -27,8 +27,7 @@ class SphereCentered
     //@{
     //! \name Type aliases
     using Intersections = Array<real_type, 2>;
-    using StorageSpan = Span<const real_type, 1>;
-    using Storage = StorageSpan;  // DEPRECATED
+    using StorageSpan = Span<real_type const, 1>;
     //@}
 
     //// CLASS ATTRIBUTES ////
@@ -61,7 +60,7 @@ class SphereCentered
     CELER_FUNCTION real_type radius_sq() const { return radius_sq_; }
 
     //! Get a view to the data for type-deleted storage
-    CELER_FUNCTION Storage data() const { return {&radius_sq_, 1}; }
+    CELER_FUNCTION StorageSpan data() const { return {&radius_sq_, 1}; }
 
     //// CALCULATION ////
 

--- a/test/celeritas/GenericGeoTestBase.cc
+++ b/test/celeritas/GenericGeoTestBase.cc
@@ -254,10 +254,8 @@ template<class HP>
 auto GenericGeoTestBase<HP>::make_geo_track_view(Real3 const& pos, Real3 dir)
     -> GeoTrackView
 {
-    normalize_direction(&dir);
-
     auto geo = this->make_geo_track_view();
-    geo = GeoTrackInitializer{pos, dir};
+    geo = GeoTrackInitializer{pos, make_unit_vector(dir)};
     return geo;
 }
 

--- a/test/celeritas/em/MollerBhabha.test.cc
+++ b/test/celeritas/em/MollerBhabha.test.cc
@@ -126,8 +126,7 @@ TEST_F(MollerBhabhaInteractorTest, basic)
 
     for (SampleInit const& init : samples)
     {
-        Real3 dir = init.dir;
-        normalize_direction(&dir);
+        Real3 dir = make_unit_vector(init.dir);
         this->set_inc_direction(dir);
 
         for (auto p : {pdg::electron(), pdg::positron()})
@@ -228,8 +227,7 @@ TEST_F(MollerBhabhaInteractorTest, cutoff_1MeV)
 
     for (SampleInit const& init : samples)
     {
-        Real3 dir = init.dir;
-        normalize_direction(&dir);
+        Real3 dir = make_unit_vector(init.dir);
         this->set_inc_direction(dir);
 
         for (auto p : {pdg::electron(), pdg::positron()})

--- a/test/celeritas/geo/GeoMaterial.test.cc
+++ b/test/celeritas/geo/GeoMaterial.test.cc
@@ -55,8 +55,7 @@ auto GeoMaterialTestBase::trace_materials(Real3 const& pos, Real3 dir)
     // comparison of material IDs encountered.
     VecString result;
 
-    normalize_direction(&dir);
-    geo = {pos, dir};
+    geo = {pos, make_unit_vector(dir)};
     while (!geo.is_outside())
     {
         result.push_back(

--- a/test/celeritas/phys/InteractorHostTestBase.cc
+++ b/test/celeritas/phys/InteractorHostTestBase.cc
@@ -246,8 +246,7 @@ void InteractorHostTestBase::set_inc_direction(Real3 const& dir)
 {
     CELER_EXPECT(norm(dir) > 0);
 
-    inc_direction_ = dir;
-    normalize_direction(&inc_direction_);
+    inc_direction_ = make_unit_vector(dir);
 }
 
 //---------------------------------------------------------------------------//
@@ -357,7 +356,7 @@ void InteractorHostTestBase::check_momentum_conservation(
         EXPECT_SOFT_NEAR(
             parent_momentum_mag, exit_momentum_mag, default_tol * 10000);
 
-        normalize_direction(&exit_momentum);
+        exit_momentum = make_unit_vector(exit_momentum);
         EXPECT_SOFT_NEAR(real_type(1),
                          dot_product(inc_direction_, exit_momentum),
                          3 * default_tol)

--- a/test/corecel/cont/InitializedValue.test.cc
+++ b/test/corecel/cont/InitializedValue.test.cc
@@ -23,8 +23,8 @@ TEST(InitializedValue, no_finalizer)
 
     // Use operator new to test that the int is being initialized properly by
     // constructing into data space that's been set to a different value
-    alignas(int) Byte buf[sizeof(InitValueInt)];
-    std::fill(std::begin(buf), std::end(buf), Byte(-1));
+    alignas(int) std::byte buf[sizeof(InitValueInt)];
+    std::fill(std::begin(buf), std::end(buf), std::byte(-1));
     InitValueInt* ival = new (buf) InitValueInt{};
     EXPECT_EQ(0, *ival);
 

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -457,7 +457,7 @@ TEST_F(CollectionTest, host)
     host_state_ref.matid[TrackSlotId{0}] = MockMaterialId{1};
 
     // Create view
-    MockTrackView mock(mock_params.host(), host_state_ref, TrackSlotId{0});
+    MockTrackView mock(mock_params.host_ref(), host_state_ref, TrackSlotId{0});
     EXPECT_EQ(1, mock.matid().unchecked_get());
 }
 
@@ -470,7 +470,7 @@ TEST_F(CollectionTest, TEST_IF_CELER_DEVICE(device))
     DeviceVector<double> device_result(device_states.size());
 
     CTestInput kernel_input;
-    kernel_input.params = this->mock_params.device();
+    kernel_input.params = this->mock_params.device_ref();
     kernel_input.states = device_states;
     kernel_input.result = device_result.device_ref();
 

--- a/test/corecel/data/DeviceAllocation.test.cc
+++ b/test/corecel/data/DeviceAllocation.test.cc
@@ -45,8 +45,8 @@ TEST(DeviceAllocationTest, TEST_IF_CELER_DEVICE(device))
 
     {
         DeviceAllocation other(128);
-        Byte* orig_alloc = alloc.device_ref().data();
-        Byte* orig_other = other.device_ref().data();
+        std::byte* orig_alloc = alloc.device_ref().data();
+        std::byte* orig_other = other.device_ref().data();
         swap(alloc, other);
         EXPECT_EQ(1024, other.size());
         EXPECT_EQ(orig_other, alloc.device_ref().data());
@@ -54,20 +54,20 @@ TEST(DeviceAllocationTest, TEST_IF_CELER_DEVICE(device))
     }
     EXPECT_EQ(128, alloc.size());
 
-    std::vector<Byte> data(alloc.size());
-    data.front() = Byte(1);
-    data.back() = Byte(127);
+    std::vector<std::byte> data(alloc.size());
+    data.front() = std::byte(1);
+    data.back() = std::byte(127);
 
     alloc.copy_to_device(make_span(data));
 
-    std::vector<Byte> newdata(alloc.size());
+    std::vector<std::byte> newdata(alloc.size());
     alloc.copy_to_host(make_span(newdata));
-    EXPECT_EQ(Byte(1), newdata.front());
-    EXPECT_EQ(Byte(127), newdata.back());
+    EXPECT_EQ(std::byte(1), newdata.front());
+    EXPECT_EQ(std::byte(127), newdata.back());
 
     // Test move construction/assignment
     {
-        Byte* orig_ptr = alloc.device_ref().data();
+        std::byte* orig_ptr = alloc.device_ref().data();
         DeviceAllocation other(std::move(alloc));
         EXPECT_EQ(128, other.size());
         EXPECT_EQ(0, alloc.size());
@@ -82,7 +82,7 @@ TEST(DeviceAllocationTest, TEST_IF_CELER_DEVICE(empty))
     EXPECT_EQ(0, alloc.size());
     EXPECT_EQ(nullptr, alloc.device_ref().data());
 
-    std::vector<Byte> newdata(alloc.size());
+    std::vector<std::byte> newdata(alloc.size());
     alloc.copy_to_device(make_span(newdata));
     alloc.copy_to_host(make_span(newdata));
 }

--- a/test/corecel/data/LdgIterator.test.cc
+++ b/test/corecel/data/LdgIterator.test.cc
@@ -122,23 +122,24 @@ TEST_F(LdgIteratorTest, opaqueid_t)
 
 TEST_F(LdgIteratorTest, byte_t)
 {
-    using VecByte = std::vector<Byte>;
-    VecByte const some_data = {Byte{1}, Byte{2}, Byte{3}, Byte{4}};
+    using VecByte = std::vector<std::byte>;
+    VecByte const some_data
+        = {std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
     auto n = some_data.size();
     auto ldg_start = make_ldg_iterator(some_data.data());
     auto ldg_end = make_ldg_iterator(some_data.data() + n);
     LdgIterator ctad_itr{some_data.data()};
     EXPECT_TRUE((std::is_same_v<decltype(ctad_itr), decltype(ldg_start)>));
     using ptr_type = typename decltype(ldg_start)::pointer;
-    EXPECT_TRUE((std::is_same_v<ptr_type, Byte const*>));
+    EXPECT_TRUE((std::is_same_v<ptr_type, std::byte const*>));
     EXPECT_TRUE(ldg_start);
     EXPECT_NE(ldg_start, nullptr);
     EXPECT_NE(nullptr, ldg_start);
     EXPECT_EQ(static_cast<ptr_type>(ldg_start), some_data.data());
-    EXPECT_EQ(*ldg_start++, Byte{1});
-    EXPECT_EQ(*ldg_start--, Byte{2});
-    EXPECT_EQ(*++ldg_start, Byte{2});
-    EXPECT_EQ(*--ldg_start, Byte{1});
+    EXPECT_EQ(*ldg_start++, std::byte{1});
+    EXPECT_EQ(*ldg_start--, std::byte{2});
+    EXPECT_EQ(*++ldg_start, std::byte{2});
+    EXPECT_EQ(*--ldg_start, std::byte{1});
     EXPECT_EQ(ldg_start[n - 1], some_data.back());
     EXPECT_GT(ldg_end, ldg_start);
     auto ldg_start_copy = ldg_start;

--- a/test/corecel/math/ArrayUtils.test.cc
+++ b/test/corecel/math/ArrayUtils.test.cc
@@ -73,7 +73,7 @@ TEST(ArrayUtilsTest, distance)
 
 TEST(ArrayUtilsTest, make_unit_vector)
 {
-    Dbl3 direction = make_unit_vector(Real3{1, 2, 3});
+    Dbl3 direction = make_unit_vector(Dbl3{1, 2, 3});
     double const norm = 1 / std::sqrt(1 + 4 + 9);
     static double const expected[] = {1 * norm, 2 * norm, 3 * norm};
     EXPECT_VEC_SOFT_EQ(expected, direction);
@@ -97,7 +97,7 @@ TEST(ArrayUtilsTest, is_soft_unit_vector)
 
 TEST(ArrayUtilsTest, rotate)
 {
-    Dbl3 vec = make_unit_vector(Real3{-1.1, 2.3, 0.9});
+    Dbl3 vec = make_unit_vector(Dbl3{-1.1, 2.3, 0.9});
 
     // transform through some directions
     double costheta = std::cos(2.0 / 3.0);
@@ -123,15 +123,15 @@ TEST(ArrayUtilsTest, rotate)
     EXPECT_VEC_SOFT_EQ(expected, rotate(scatter, {0.0, 0.0, 1.0}));
 
     // Transform almost degenerate vector
-    vec = make_unit_vector(Real3{3e-8, 4e-8, 1});
+    vec = make_unit_vector(Dbl3{3e-8, 4e-8, 1});
     EXPECT_VEC_SOFT_EQ(
-        (Real3{-0.613930085414816, 0.0739664834328671, 0.785887275346237}),
+        (Dbl3{-0.613930085414816, 0.0739664834328671, 0.785887275346237}),
         rotate(scatter, vec));
 
     // Transform a range of more almost-degenerate vectors
     for (auto eps : {1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8})
     {
-        vec = make_unit_vector(Real3{-eps, 2 * eps, 1 - eps * eps});
+        vec = make_unit_vector(Dbl3{-eps, 2 * eps, 1 - eps * eps});
         Dbl3 result = rotate(scatter, vec);
         EXPECT_SOFT_EQ(1.0, dot_product(result, result))
             << "for eps=" << eps << " => vec=" << vec;
@@ -148,9 +148,9 @@ TEST(ArrayUtilsTest, rotate)
         // The expected value below is from using the regular/non-fallback
         // calculation normalized to a unit vector
         EXPECT_VEC_NEAR(
-            (Real3{-0.952973648767149, 0.0195839636531213, -0.302419730049247}),
+            (Dbl3{-0.952973648767149, 0.0195839636531213, -0.302419730049247}),
             result,
-            20 * SoftEqual<real_type>{}.rel());
+            20 * SoftEqual<double>{}.rel());
     }
 
     // Switch scattered z direction

--- a/test/corecel/math/ArrayUtils.test.cc
+++ b/test/corecel/math/ArrayUtils.test.cc
@@ -71,20 +71,17 @@ TEST(ArrayUtilsTest, distance)
         distance(Array<double, 3>{3, 4, 5}, Array<double, 3>{1, 1, 1}));
 }
 
-TEST(ArrayUtilsTest, normalize_direction)
+TEST(ArrayUtilsTest, make_unit_vector)
 {
-    Dbl3 direction{1, 2, 3};
-    double norm = 1 / std::sqrt(1 + 4 + 9);
-    normalize_direction(&direction);
-
+    Dbl3 direction = make_unit_vector(Real3{1, 2, 3});
+    double const norm = 1 / std::sqrt(1 + 4 + 9);
     static double const expected[] = {1 * norm, 2 * norm, 3 * norm};
     EXPECT_VEC_SOFT_EQ(expected, direction);
 }
 
 TEST(ArrayUtilsTest, is_soft_unit_vector)
 {
-    Real3 dir{1, 2, 3};
-    normalize_direction(&dir);
+    Real3 dir = make_unit_vector(Real3{1, 2, 3});
     EXPECT_SOFT_EQ(1, dot_product(dir, dir));
     EXPECT_TRUE(is_soft_unit_vector(dir));
     constexpr real_type eps = SoftEqual<real_type>{}.rel();
@@ -100,8 +97,7 @@ TEST(ArrayUtilsTest, is_soft_unit_vector)
 
 TEST(ArrayUtilsTest, rotate)
 {
-    Dbl3 vec = {-1.1, 2.3, 0.9};
-    normalize_direction(&vec);
+    Dbl3 vec = make_unit_vector(Real3{-1.1, 2.3, 0.9});
 
     // transform through some directions
     double costheta = std::cos(2.0 / 3.0);
@@ -127,8 +123,7 @@ TEST(ArrayUtilsTest, rotate)
     EXPECT_VEC_SOFT_EQ(expected, rotate(scatter, {0.0, 0.0, 1.0}));
 
     // Transform almost degenerate vector
-    vec = {3e-8, 4e-8, 1};
-    normalize_direction(&vec);
+    vec = make_unit_vector(Real3{3e-8, 4e-8, 1});
     EXPECT_VEC_SOFT_EQ(
         (Real3{-0.613930085414816, 0.0739664834328671, 0.785887275346237}),
         rotate(scatter, vec));
@@ -136,8 +131,7 @@ TEST(ArrayUtilsTest, rotate)
     // Transform a range of more almost-degenerate vectors
     for (auto eps : {1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8})
     {
-        vec = {-eps, 2 * eps, 1 - eps * eps};
-        normalize_direction(&vec);
+        vec = make_unit_vector(Real3{-eps, 2 * eps, 1 - eps * eps});
         Dbl3 result = rotate(scatter, vec);
         EXPECT_SOFT_EQ(1.0, dot_product(result, result))
             << "for eps=" << eps << " => vec=" << vec;

--- a/test/orange/detail/UniverseIndexer.test.cc
+++ b/test/orange/detail/UniverseIndexer.test.cc
@@ -26,7 +26,7 @@ class UniverseIndexerTest : public Test
         = UniverseIndexerData<Ownership::const_reference, MemSpace::host>;
     using VecSize = std::vector<size_type>;
 
-    CollectionHostRef const& host_ref() const { return data_.host(); }
+    CollectionHostRef const& host_ref() const { return data_.host_ref(); }
 
     void set_data(VecSize surfaces, VecSize volumes)
     {

--- a/test/orange/surf/ConeAligned.test.cc
+++ b/test/orange/surf/ConeAligned.test.cc
@@ -66,11 +66,8 @@ TEST(ConeAlignedTest, normal)
 {
     ConeX cone{{2, 3, 4}, 0.5};
 
-    Real3 pos{2 + 2, 3 + 1, 4 + 0};
-
-    Real3 expected{-1, 2, 0};
-    normalize_direction(&expected);
-    EXPECT_VEC_SOFT_EQ(expected, cone.calc_normal(pos));
+    EXPECT_VEC_SOFT_EQ(make_unit_vector(Real3{-1, 2, 0}),
+                       cone.calc_normal({2 + 2, 3 + 1, 4 + 0}));
 }
 
 TEST(ConeAlignedTest, intersection_typical)
@@ -103,8 +100,7 @@ TEST(ConeAlignedTest, intersection_along_surface)
     ConeX cone{{1.1, 2.2, 3.3}, 2. / 3.};
 
     // Along the cone edge heading up and right
-    Real3 dir{3.0, 2.0, 0.0};
-    normalize_direction(&dir);
+    Real3 dir = make_unit_vector(Real3{3.0, 2.0, 0.0});
 
     // Below lower left sheet
     Real3 pos{1.1 - 3, 2.2 - 2 - 1, 3.3};

--- a/test/orange/surf/CylCentered.test.cc
+++ b/test/orange/surf/CylCentered.test.cc
@@ -36,7 +36,7 @@ using VecReal = std::vector<real_type>;
 //---------------------------------------------------------------------------//
 TEST_F(CCylXTest, construction)
 {
-    EXPECT_EQ(1, CCylX::Storage::extent);
+    EXPECT_EQ(1, CCylX::StorageSpan::extent);
     EXPECT_EQ(2, CCylX::Intersections{}.size());
 
     CCylX c(4.0);

--- a/test/orange/surf/CylCentered.test.cc
+++ b/test/orange/surf/CylCentered.test.cc
@@ -389,7 +389,7 @@ TEST_F(CCylZTest, TEST_IF_CELERITAS_DOUBLE(multi_along_intersect))
                  })
             {
                 Real3 pos = orig_pos;
-                normalize_direction(&dir);
+                dir = make_unit_vector(dir);
 
                 // Transport to inside of cylinder
                 real_type d

--- a/test/orange/surf/GeneralQuadric.test.cc
+++ b/test/orange/surf/GeneralQuadric.test.cc
@@ -54,7 +54,7 @@ TEST(GeneralQuadricTest, construction)
 TEST(GeneralQuadricTest, all)
 {
     EXPECT_EQ(SurfaceType::gq, GeneralQuadric::surface_type());
-    EXPECT_EQ(10, GeneralQuadric::Storage::extent);
+    EXPECT_EQ(10, GeneralQuadric::StorageSpan::extent);
     EXPECT_EQ(2, GeneralQuadric::Intersections{}.size());
 
     const Real3 second{10.3125, 22.9375, 15.75};

--- a/test/orange/surf/Plane.test.cc
+++ b/test/orange/surf/Plane.test.cc
@@ -64,20 +64,17 @@ TEST_F(PlaneTest, tracking)
     EXPECT_EQ(SignedSense::outside, p.calc_sense(x));
 
     // Calc intersections
-    Real3 dir = {-0.70710678, -0.70710678, 0.0};
-    normalize_direction(&dir);
+    Real3 dir = make_unit_vector(Real3{-0.70710678, -0.70710678, 0.0});
     EXPECT_SOFT_NEAR(
         2.0, calc_intersection(p, x, dir, SurfaceState::off), 1.e-6);
 
     // Pick a direction such that n\cdot\Omega > 0
-    dir = {1.0, 2.0, 3.0};
-    normalize_direction(&dir);
+    dir = make_unit_vector(Real3{1.0, 2.0, 3.0});
     EXPECT_EQ(no_intersection(),
               calc_intersection(p, x, dir, SurfaceState::off));
 
     // Pick a direction that hits the plane
-    dir = {-1, 0.1, 3.0};
-    normalize_direction(&dir);
+    dir = make_unit_vector(Real3{-1, 0.1, 3.0});
     EXPECT_SOFT_NEAR(9.9430476983098171,
                      calc_intersection(p, x, dir, SurfaceState::off),
                      1.e-6);
@@ -87,14 +84,12 @@ TEST_F(PlaneTest, tracking)
     EXPECT_EQ(SignedSense::inside, p.calc_sense(x));
 
     // Pick a direction such that n\cdot\Omega < 0
-    dir = {-1.0, -2.0, 3.0};
-    normalize_direction(&dir);
+    dir = make_unit_vector(Real3{-1.0, -2.0, 3.0});
     EXPECT_EQ(no_intersection(),
               calc_intersection(p, x, dir, SurfaceState::off));
 
     // Pick a direction that hits the plane
-    dir = {1, 0.1, 3.0};
-    normalize_direction(&dir);
+    dir = make_unit_vector(Real3{1, 0.1, 3.0});
     EXPECT_SOFT_NEAR(12.202831266107504,
                      calc_intersection(p, x, dir, SurfaceState::off),
                      1.e-6);

--- a/test/orange/surf/Sphere.test.cc
+++ b/test/orange/surf/Sphere.test.cc
@@ -49,7 +49,7 @@ TEST_F(SphereTest, construction)
 TEST_F(SphereTest, basic)
 {
     EXPECT_EQ(SurfaceType::s, Sphere::surface_type());
-    EXPECT_EQ(4, Sphere::Storage::extent);
+    EXPECT_EQ(4, Sphere::StorageSpan::extent);
     EXPECT_EQ(2, Sphere::Intersections{}.size());
 
     const Real3 origin{-1.1, 2.2, -3.3};
@@ -83,7 +83,7 @@ TEST_F(SphereTest, basic)
 TEST_F(SphereTest, TEST_IF_CELERITAS_DOUBLE(degenerate))
 {
     EXPECT_EQ(SurfaceType::s, Sphere::surface_type());
-    EXPECT_EQ(4, Sphere::Storage::extent);
+    EXPECT_EQ(4, Sphere::StorageSpan::extent);
     EXPECT_EQ(2, Sphere::Intersections{}.size());
 
     Real3 const origin{-1.1, 2.2, -3.3};

--- a/test/orange/surf/SphereCentered.test.cc
+++ b/test/orange/surf/SphereCentered.test.cc
@@ -31,7 +31,7 @@ class SphereCenteredTest : public Test
 TEST_F(SphereCenteredTest, construction)
 {
     EXPECT_EQ(SurfaceType::sc, SphereCentered::surface_type());
-    EXPECT_EQ(1, SphereCentered::Storage::extent);
+    EXPECT_EQ(1, SphereCentered::StorageSpan::extent);
     EXPECT_EQ(2, SphereCentered::Intersections{}.size());
 
     SphereCentered s{3};

--- a/test/orange/surf/SurfaceSimplifier.test.cc
+++ b/test/orange/surf/SurfaceSimplifier.test.cc
@@ -165,13 +165,11 @@ TEST_F(SurfaceSimplifierTest, plane)
                               Plane{{sqrt_three / 2, 0.5, 0.0}, 0});
 
     // Check vector/displacement normalization
-    Real3 n{1, 0, 1e-4};
-    normalize_direction(&n);
+    Real3 n = make_unit_vector(Real3{1, 0, 1e-4});
     this->check_simplifies_to(Plane{n, {5.0, 0, 0}}, PlaneX{5.0});
 
     // First pass should clip zeros and normalize
-    n = {-1, 0, 1e-7};
-    normalize_direction(&n);
+    n = make_unit_vector(Real3{-1, 0, 1e-7});
     this->check_simplifies_to(
         Plane{n, {5.0, 0, 0}}, Plane{{1, 0, 0}, {5, 0, 0}}, Sense::outside);
 }

--- a/test/orange/univ/RectArrayTracker.test.cc
+++ b/test/orange/univ/RectArrayTracker.test.cc
@@ -70,10 +70,9 @@ class RectArrayTrackerTest : public OrangeGeoTestBase
  */
 LocalState RectArrayTrackerTest::make_state(Real3 pos, Real3 dir)
 {
-    normalize_direction(&dir);
     LocalState state;
     state.pos = pos;
-    state.dir = dir;
+    state.dir = make_unit_vector(dir);
     state.volume = {};
     state.surface = {};
 

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -136,10 +136,9 @@ class FiveVolumesTest : public SimpleUnitTrackerTest
  */
 LocalState SimpleUnitTrackerTest::make_state(Real3 pos, Real3 dir)
 {
-    normalize_direction(&dir);
     LocalState state;
     state.pos = pos;
-    state.dir = dir;
+    state.dir = make_unit_vector(dir);
     state.volume = {};
     state.surface = {};
 

--- a/test/orange/univ/TrackerVisitor.test.cc
+++ b/test/orange/univ/TrackerVisitor.test.cc
@@ -39,10 +39,9 @@ class TrackerVisitorTest : public OrangeGeoTestBase
  */
 detail::LocalState TrackerVisitorTest::make_state(Real3 pos, Real3 dir)
 {
-    normalize_direction(&dir);
     detail::LocalState state;
     state.pos = pos;
-    state.dir = dir;
+    state.dir = make_unit_vector(dir);
     state.volume = {};
     state.surface = {};
 


### PR DESCRIPTION
These should have been removed as part of the 0.4 release. I added documentation for future releases to prevent this from happening again, and I've postponed the only external-facing deprecation (mt_logger) till v1.0 . 

Deprecated code removed are:
- `normalize_direction`
- `host` and `device` accessor names from CollectionMirror
- import tables that we'll never use (some of which were removed from geant4@11)
- `Storage` type alias from ORANGE
- `Bytes` (replaced with `std::byte`)