### PR TITLE
Fix range constexpr

### DIFF
--- a/src/corecel/cont/detail/RangeImpl.hh
+++ b/src/corecel/cont/detail/RangeImpl.hh
@@ -11,7 +11,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/OpaqueId.hh"
 
@@ -168,10 +167,7 @@ class range_iter
   public:
     //// CONSTRUCTOR ////
 
-    CELER_FORCEINLINE_FUNCTION range_iter(value_type value) : value_(value)
-    {
-        CELER_EXPECT(TraitsT::is_valid(value_));
-    }
+    CELER_CONSTEXPR_FUNCTION range_iter(value_type value) : value_(value) {}
 
     CELER_CONSTEXPR_FUNCTION range_iter() : value_(TraitsT::zero()) {}
 

--- a/src/corecel/cont/detail/RangeImpl.hh
+++ b/src/corecel/cont/detail/RangeImpl.hh
@@ -168,11 +168,12 @@ class range_iter
   public:
     //// CONSTRUCTOR ////
 
-    CELER_CONSTEXPR_FUNCTION range_iter(value_type value = TraitsT::zero())
-        : value_(value)
+    CELER_FORCEINLINE_FUNCTION range_iter(value_type value) : value_(value)
     {
         CELER_EXPECT(TraitsT::is_valid(value_));
     }
+
+    CELER_CONSTEXPR_FUNCTION range_iter() : value_(TraitsT::zero()) {}
 
     //// ACCESSORS ////
 

--- a/src/corecel/cont/detail/RangeImpl.hh
+++ b/src/corecel/cont/detail/RangeImpl.hh
@@ -11,6 +11,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/OpaqueId.hh"
 
@@ -167,7 +168,10 @@ class range_iter
   public:
     //// CONSTRUCTOR ////
 
-    CELER_CONSTEXPR_FUNCTION range_iter(value_type value) : value_(value) {}
+    CELER_FORCEINLINE_FUNCTION range_iter(value_type value) : value_(value)
+    {
+        CELER_EXPECT(TraitsT::is_valid(value_));
+    }
 
     CELER_CONSTEXPR_FUNCTION range_iter() : value_(TraitsT::zero()) {}
 

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -32,7 +32,7 @@ template<class T, class U>
 inline CELER_FUNCTION bool
 is_inside(BoundingBox<T> const& bbox, Array<U, 3> point)
 {
-    constexpr auto axes = range(to_int(Axis::size_));
+    auto axes = range(to_int(Axis::size_));
     return all_of(axes.begin(), axes.end(), [&point, &bbox](int ax) {
         return point[ax] >= bbox.lower()[ax] && point[ax] <= bbox.upper()[ax];
     });
@@ -67,7 +67,7 @@ inline bool is_degenerate(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
 
-    constexpr auto axes = range(to_int(Axis::size_));
+    auto axes = range(to_int(Axis::size_));
     return any_of(axes.begin(), axes.end(), [&bbox](int ax) {
         return bbox.lower()[ax] == bbox.upper()[ax];
     });

--- a/test/corecel/cont/Range.test.cc
+++ b/test/corecel/cont/Range.test.cc
@@ -193,9 +193,10 @@ TEST(RangeTest, enums)
         ++ctr;
     }
 
-#if CELERITAS_DEBUG
-    EXPECT_THROW(range(static_cast<pokemon::Pokemon>(100)), DebugError);
-#endif
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(range(static_cast<pokemon::Pokemon>(100)), DebugError);
+    }
 }
 
 TEST(RangeTest, different_enums)


### PR DESCRIPTION
The RangeIter constructor is constexpr but has an assertion in it. On CUDA with ndebug + celer_debug,
the assertion expands into a "trip" which isn't allowed.
```
/nashome/p/pcanal/geant/sources/celeritas/src/corecel/cont/detail/RangeImpl.hh(174): error: statement may not appear in a constexpr constructor
         ); __syncthreads(); asm("trap;"); } } while (0)
                             ^
          detected during:
            instantiation of "celeritas::Range<T>::Range(T) [with T=celeritas::size_type]" at line 202 of /nashome/p/pcanal/geant/sources/celeritas/src/corecel/cont/Range.hh
            instantiation of "celeritas::Range<T> celeritas::range(T) [with T=celeritas::size_type]" at line 297 of /nashome/p/pcanal/geant/sources/celeritas/src/celeritas/random/XorwowRngEngine.hh

1 error detected in the compilation of "/nashome/p/pcanal/geant/sources/celeritas/test/celeritas/geo/HeuristicGeoTestBase.cu".
```

I'm honestly surprised the `CELER_EXPECT` worked to begin with since I didn't think `throw` is allowable in constexpr...