### PR TITLE
Fix conversion of boolean solids when the "left" solid is displaced

### DIFF
--- a/src/celeritas/ext/g4vg/SolidConverter.cc
+++ b/src/celeritas/ext/g4vg/SolidConverter.cc
@@ -713,8 +713,12 @@ auto SolidConverter::convert_bool_impl(G4BooleanSolid const& bs)
 
         // Construct name
         std::ostringstream label;
-        label << "[TEMP]@" << bs.GetName() << '/' << lr[i] << '/'
-              << solids[i]->GetName();
+        label << "[TEMP]@" << bs.GetName() << '/' << lr[i];
+        if (trans)
+        {
+            label << '*';
+        }
+        label << '/' << solids[i]->GetName();
 
         // Create temporary LV from converted solid
         auto* temp_lv = new LogicalVolume(label.str().c_str(), converted);

--- a/src/celeritas/ext/g4vg/SolidConverter.cc
+++ b/src/celeritas/ext/g4vg/SolidConverter.cc
@@ -701,12 +701,10 @@ auto SolidConverter::convert_bool_impl(G4BooleanSolid const& bs)
         std::unique_ptr<Transformation3D> trans;
         if (auto* displaced = dynamic_cast<G4DisplacedSolid const*>(solid))
         {
-            if (auto* moved = displaced->GetConstituentMovedSolid())
-            {
-                solid = moved;
-                trans = std::make_unique<Transformation3D>(
-                    convert_transform_(displaced->GetTransform().Invert()));
-            }
+            solid = displaced->GetConstituentMovedSolid();
+            CELER_ASSERT(solid);
+            trans = std::make_unique<Transformation3D>(
+                convert_transform_(displaced->GetTransform().Invert()));
         }
 
         VUnplacedVolume const* converted = (*this)(*solid);

--- a/src/celeritas/ext/g4vg/SolidConverter.cc
+++ b/src/celeritas/ext/g4vg/SolidConverter.cc
@@ -689,26 +689,27 @@ auto SolidConverter::convert_bool_impl(G4BooleanSolid const& bs)
     Array<G4VSolid const*, 2> solids{
         {bs.GetConstituentSolid(0), bs.GetConstituentSolid(1)}};
 
-    Transformation3D inverse;
-    {
-        // The "right" shape should be a G4DisplacedSolid which holds the
-        // matrix: replace solid and get inverse transform
-        CELER_EXPECT(!dynamic_cast<G4DisplacedSolid const*>(solids[0]));
-        CELER_EXPECT(dynamic_cast<G4DisplacedSolid const*>(solids[1]));
-        auto* displaced = static_cast<G4DisplacedSolid const*>(solids[1]);
-        solids[1] = displaced->GetConstituentMovedSolid();
-        inverse = convert_transform_(displaced->GetTransform().Invert());
-    }
-
     static Array<char const*, 2> const lr = {{"left", "right"}};
-    Array<Transformation3D const*, 2> transforms
-        = {{&Transformation3D::kIdentity, &inverse}};
     PlacedBoolVolumes result;
 
     for (auto i : range(solids.size()))
     {
-        // Convert solid
-        VUnplacedVolume const* converted = (*this)(*solids[i]);
+        G4VSolid const* solid = bs.GetConstituentSolid(i);
+        CELER_ASSERT(solid);
+
+        // Expand the possibly transformed solid into a transform
+        std::unique_ptr<Transformation3D> trans;
+        if (auto* displaced = dynamic_cast<G4DisplacedSolid const*>(solid))
+        {
+            if (auto* moved = displaced->GetConstituentMovedSolid())
+            {
+                solid = moved;
+                trans = std::make_unique<Transformation3D>(
+                    convert_transform_(displaced->GetTransform().Invert()));
+            }
+        }
+
+        VUnplacedVolume const* converted = (*this)(*solid);
 
         // Construct name
         std::ostringstream label;
@@ -718,7 +719,8 @@ auto SolidConverter::convert_bool_impl(G4BooleanSolid const& bs)
         // Create temporary LV from converted solid
         auto* temp_lv = new LogicalVolume(label.str().c_str(), converted);
         // Place the transformed LV
-        result[i] = temp_lv->Place(transforms[i]);
+        result[i] = temp_lv->Place(trans ? trans.get()
+                                         : &Transformation3D::kIdentity);
     }
 
     CELER_ENSURE(result[0] && result[1]);

--- a/src/celeritas/ext/g4vg/SolidConverter.cc
+++ b/src/celeritas/ext/g4vg/SolidConverter.cc
@@ -686,13 +686,10 @@ auto SolidConverter::unionsolid(arg_type solid_base) -> result_type
 auto SolidConverter::convert_bool_impl(G4BooleanSolid const& bs)
     -> PlacedBoolVolumes
 {
-    Array<G4VSolid const*, 2> solids{
-        {bs.GetConstituentSolid(0), bs.GetConstituentSolid(1)}};
-
     static Array<char const*, 2> const lr = {{"left", "right"}};
     PlacedBoolVolumes result;
 
-    for (auto i : range(solids.size()))
+    for (auto i : range(lr.size()))
     {
         G4VSolid const* solid = bs.GetConstituentSolid(i);
         CELER_ASSERT(solid);
@@ -716,7 +713,7 @@ auto SolidConverter::convert_bool_impl(G4BooleanSolid const& bs)
         {
             label << '*';
         }
-        label << '/' << solids[i]->GetName();
+        label << '/' << solid->GetName();
 
         // Create temporary LV from converted solid
         auto* temp_lv = new LogicalVolume(label.str().c_str(), converted);


### PR DESCRIPTION
The first iteration of the vecgeom converter assumed (presumably based on G4GDML output?) that only the "right" boolean solid was displaced. This isn't the case for solids exported from ROOT:
```
LogicalVolume [459] "QCLint0x6000029e8b40":
   UnplacedBooleanVol<Union>{fLeft=[102]<[TEMP]@intTrousersC/left*/displaced_QCLint>, fRight=[103]<[TEMP]@intTrousersC/right*/placedB>}
fLeft:  [102] UnplacedCone {rmin1 0.00, rmax1 10.60, rmin2 0.00, rmax2 2.70, dz 44.44, phistart 0.00, deltaphi 6.28}
fRight: [103] UnplacedCone {rmin1 0.00, rmax1 10.60, rmin2 0.00, rmax2 2.70, dz 44.44, phistart 0.00, deltaphi 6.28}
```

See #1068