### PR TITLE
Automatically calculate number of events in apps

### DIFF
--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -36,21 +36,7 @@ ActionInitialization::ActionInitialization(SPParams params)
     // Create Geant4 diagnostics to be shared across worker threads
     diagnostics_ = std::make_shared<GeantDiagnostics>();
 
-    auto const& inp = GlobalSetup::Instance()->input();
-    CELER_VALIDATE(inp.primary_options || !inp.event_file.empty(),
-                   << "no event input file nor primary options were "
-                      "specified");
-
-    if (!inp.event_file.empty())
-    {
-        hepmc_gen_ = std::make_shared<HepMC3PrimaryGenerator>(inp.event_file);
-        num_events_ = hepmc_gen_->NumEvents();
-    }
-    else
-    {
-        num_events_ = inp.primary_options.num_events;
-    }
-
+    num_events_ = GlobalSetup::Instance()->setup_options().max_num_events;
     CELER_ENSURE(num_events_ > 0);
 }
 
@@ -87,9 +73,9 @@ void ActionInitialization::Build() const
     CELER_LOG_LOCAL(status) << "Constructing user action";
 
     // Primary generator emits source particles
-    if (hepmc_gen_)
+    if (auto hepmc_gen = GlobalSetup::Instance()->hepmc_gen())
     {
-        this->SetUserAction(new HepMC3PrimaryGeneratorAction(hepmc_gen_));
+        this->SetUserAction(new HepMC3PrimaryGeneratorAction(hepmc_gen));
     }
     else
     {

--- a/app/celer-g4/ActionInitialization.hh
+++ b/app/celer-g4/ActionInitialization.hh
@@ -16,7 +16,6 @@
 
 namespace celeritas
 {
-class HepMC3PrimaryGenerator;
 namespace app
 {
 //---------------------------------------------------------------------------//
@@ -43,7 +42,6 @@ class ActionInitialization final : public G4VUserActionInitialization
   private:
     SPParams params_;
     SPDiagnostics diagnostics_;
-    std::shared_ptr<HepMC3PrimaryGenerator> hepmc_gen_;
     int num_events_{0};
     mutable bool init_shared_;
 };

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -153,10 +153,14 @@ void GlobalSetup::ReadInput(std::string const& filename)
         // Apply Celeritas \c SetupOptions commands
         options_->max_num_tracks = input_.num_track_slots;
         options_->max_num_events = [this] {
+            CELER_VALIDATE(input_.primary_options || !input_.event_file.empty(),
+                           << "no event input file nor primary options were "
+                              "specified");
             if (!input_.event_file.empty())
             {
-                return static_cast<size_type>(
-                    HepMC3PrimaryGenerator(input_.event_file).NumEvents());
+                hepmc_gen_ = std::make_shared<HepMC3PrimaryGenerator>(
+                    input_.event_file);
+                return static_cast<size_type>(hepmc_gen_->NumEvents());
             }
             else
             {

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -19,6 +19,7 @@
 #include "celeritas/ext/RootFileManager.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
 #include "accel/ExceptionConverter.hh"
+#include "accel/HepMC3PrimaryGenerator.hh"
 #include "accel/SetupOptionsMessenger.hh"
 
 #include "HepMC3PrimaryGeneratorAction.hh"
@@ -151,7 +152,17 @@ void GlobalSetup::ReadInput(std::string const& filename)
 
         // Apply Celeritas \c SetupOptions commands
         options_->max_num_tracks = input_.num_track_slots;
-        options_->max_num_events = input_.max_events;
+        options_->max_num_events = [this] {
+            if (!input_.event_file.empty())
+            {
+                return static_cast<size_type>(
+                    HepMC3PrimaryGenerator(input_.event_file).NumEvents());
+            }
+            else
+            {
+                return input_.primary_options.num_events;
+            }
+        }();
         options_->max_steps = input_.max_steps;
         options_->initializer_capacity = input_.initializer_capacity;
         options_->secondary_stack_factor = input_.secondary_stack_factor;

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -23,6 +23,7 @@ class G4GenericMessenger;
 
 namespace celeritas
 {
+class HepMC3PrimaryGenerator;
 namespace app
 {
 //---------------------------------------------------------------------------//
@@ -31,6 +32,12 @@ namespace app
  */
 class GlobalSetup
 {
+  public:
+    //!@{
+    //! \name Type aliases
+    using SPPrimaryGenerator = std::shared_ptr<HepMC3PrimaryGenerator>;
+    //!@}
+
   public:
     // Return non-owning pointer to a singleton
     static GlobalSetup* Instance();
@@ -91,6 +98,9 @@ class GlobalSetup
     //! Whether ROOT I/O for SDs is enabled
     bool root_sd_io() const { return root_sd_io_; }
 
+    //! Get HepMC3 primary generator
+    SPPrimaryGenerator hepmc_gen() const { return hepmc_gen_; }
+
   private:
     // Private constructor since we're a singleton
     GlobalSetup();
@@ -98,6 +108,7 @@ class GlobalSetup
 
     // Data
     std::shared_ptr<SetupOptions> options_;
+    std::shared_ptr<HepMC3PrimaryGenerator> hepmc_gen_;
     RunInput input_;
     Stopwatch get_setup_time_;
     bool root_sd_io_{false};

--- a/app/celer-g4/RunInput.cc
+++ b/app/celer-g4/RunInput.cc
@@ -50,7 +50,7 @@ RunInput::operator bool() const
     return !geometry_file.empty() && (primary_options || !event_file.empty())
            && physics_list < PhysicsListSelection::size_
            && (field == no_field() || field_options)
-           && ((num_track_slots > 0 && max_events > 0 && max_steps > 0
+           && ((num_track_slots > 0 && max_steps > 0
                 && initializer_capacity > 0 && secondary_stack_factor > 0)
                || SharedParams::CeleritasDisabled())
            && (step_diagnostic_bins > 0 || !step_diagnostic);

--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -64,7 +64,6 @@ struct RunInput
 
     // Control
     size_type num_track_slots{};
-    size_type max_events{};
     size_type max_steps{unspecified};
     size_type initializer_capacity{};
     real_type secondary_stack_factor{};

--- a/app/celer-g4/RunInputIO.json.cc
+++ b/app/celer-g4/RunInputIO.json.cc
@@ -67,7 +67,6 @@ void from_json(nlohmann::json const& j, RunInput& v)
     RI_LOAD_OPTION(primary_options);
 
     RI_LOAD_OPTION(num_track_slots);
-    RI_LOAD_OPTION(max_events);
     RI_LOAD_OPTION(max_steps);
     RI_LOAD_OPTION(initializer_capacity);
     RI_LOAD_OPTION(secondary_stack_factor);
@@ -156,7 +155,6 @@ void to_json(nlohmann::json& j, RunInput const& v)
     }
 
     RI_SAVE(num_track_slots);
-    RI_SAVE(max_events);
     RI_SAVE_OPTION(max_steps);
     RI_SAVE(initializer_capacity);
     RI_SAVE(secondary_stack_factor);

--- a/app/celer-g4/test-harness.py
+++ b/app/celer-g4/test-harness.py
@@ -71,7 +71,6 @@ inp = {
     "output_file": out_file,
     "offload_output_file": offload_file,
     "num_track_slots": max_tracks,
-    "max_events": 1024,
     "initializer_capacity": init_capacity,
     "secondary_stack_factor": 2,
     "physics_list": "ftfp_bert",

--- a/app/celer-sim/Runner.hh
+++ b/app/celer-sim/Runner.hh
@@ -22,6 +22,7 @@ namespace celeritas
 {
 class CoreParams;
 class OutputRegistry;
+class ParticleParams;
 class RootFileManager;
 class StepCollector;
 }  // namespace celeritas
@@ -77,6 +78,7 @@ class Runner
     //// TYPES ////
 
     using UPTransporterBase = std::unique_ptr<TransporterBase>;
+    using SPConstParticles = std::shared_ptr<ParticleParams const>;
     using VecPrimary = std::vector<Primary>;
     using VecEvent = std::vector<VecPrimary>;
 
@@ -99,8 +101,7 @@ class Runner
     void build_step_collectors(RunnerInput const&);
     void build_diagnostics(RunnerInput const&);
     void build_transporter_input(RunnerInput const&);
-    void build_events(RunnerInput const&);
-    int get_num_streams(RunnerInput const&);
+    size_type build_events(RunnerInput const&, SPConstParticles);
     TransporterBase& get_transporter(StreamId);
     TransporterBase const* get_transporter_ptr(StreamId) const;
 };

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -68,7 +68,6 @@ struct RunnerInput
     size_type num_track_slots{};  //!< Divided among streams
     size_type max_steps{unspecified};
     size_type initializer_capacity{};  //!< Divided among streams
-    size_type max_events{};
     real_type secondary_stack_factor{};
     bool use_device{};
     bool sync{};
@@ -99,8 +98,7 @@ struct RunnerInput
         return !geometry_file.empty()
                && (primary_options || !event_file.empty())
                && num_track_slots > 0 && max_steps > 0
-               && initializer_capacity > 0 && max_events > 0
-               && secondary_stack_factor > 0
+               && initializer_capacity > 0 && secondary_stack_factor > 0
                && (step_diagnostic_bins > 0 || !step_diagnostic)
                && (field == no_field() || field_options);
     }

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -98,7 +98,6 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_OPTION(num_track_slots);
     LDIO_LOAD_OPTION(max_steps);
     LDIO_LOAD_REQUIRED(initializer_capacity);
-    LDIO_LOAD_REQUIRED(max_events);
     LDIO_LOAD_REQUIRED(secondary_stack_factor);
     LDIO_LOAD_REQUIRED(use_device);
     LDIO_LOAD_OPTION(sync);
@@ -173,7 +172,6 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE(num_track_slots);
     LDIO_SAVE_OPTION(max_steps);
     LDIO_SAVE(initializer_capacity);
-    LDIO_SAVE(max_events);
     LDIO_SAVE(secondary_stack_factor);
     LDIO_SAVE(use_device);
     LDIO_SAVE(sync);

--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -91,7 +91,6 @@ inp = {
     'num_track_slots': num_tracks,
     'max_steps': max_steps,
     'initializer_capacity': 100 * max([num_tracks, num_primaries]),
-    'max_events': 1000,
     'secondary_stack_factor': 3,
     'action_diagnostic': True,
     'step_diagnostic': True,

--- a/src/accel/HepMC3PrimaryGenerator.cc
+++ b/src/accel/HepMC3PrimaryGenerator.cc
@@ -115,11 +115,24 @@ HepMC3PrimaryGenerator::HepMC3PrimaryGenerator(std::string const& filename)
         SPReader temp_reader = open_hepmc3(filename);
         CELER_ASSERT(temp_reader);
         size_type result = 0;
-        while (!temp_reader->failed())
+#if HEPMC3_VERSION_CODE < 3002000
+        HepMC3::GenEvent evt;
+        temp_reader->read_event(evt);
+#else
+        temp_reader->skip(0);
+#endif
+        CELER_VALIDATE(!temp_reader->failed(),
+                       << "event file '" << filename
+                       << "' did not contain any events");
+        do
         {
-            temp_reader->skip(1);
             result++;
-        }
+#if HEPMC3_VERSION_CODE < 3002000
+            temp_reader->read_event(evt);
+#else
+            temp_reader->skip(1);
+#endif
+        } while (!temp_reader->failed());
         CELER_LOG(debug) << "HepMC3 file has " << result << " events";
         return result;
     }();

--- a/src/celeritas/io/EventIOInterface.hh
+++ b/src/celeritas/io/EventIOInterface.hh
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "corecel/Macros.hh"
+#include "corecel/Types.hh"
 
 namespace celeritas
 {
@@ -59,6 +60,9 @@ class EventReaderInterface
 
     //! Read all primaries from a single event
     virtual result_type operator()() = 0;
+
+    //! Get total number of events
+    virtual size_type num_events() const = 0;
 
   protected:
     //!@{

--- a/src/celeritas/io/EventReader.cc
+++ b/src/celeritas/io/EventReader.cc
@@ -9,6 +9,7 @@
 
 #include <set>
 #include <HepMC3/GenEvent.h>
+#include <HepMC3/Reader.h>
 #include <HepMC3/ReaderFactory.h>
 #include <HepMC3/Setup.h>
 
@@ -29,10 +30,25 @@ namespace celeritas
 /*!
  * Construct from a filename.
  */
-EventReader::EventReader(std::string const& filename, SPConstParticles params)
-    : params_(std::move(params))
+EventReader::EventReader(std::string const& filename,
+                         SPConstParticles particles)
+    : particles_(std::move(particles))
 {
-    CELER_EXPECT(params_);
+    CELER_EXPECT(particles_);
+
+    // Fetch total number of events by opening a temporary reader
+    num_events_ = [&filename] {
+        SPReader temp_reader = open_hepmc3(filename);
+        CELER_ASSERT(temp_reader);
+        size_type result = 0;
+        while (!temp_reader->failed())
+        {
+            temp_reader->skip(1);
+            result++;
+        }
+        CELER_LOG(debug) << "HepMC3 file has " << result << " events";
+        return result;
+    }();
 
     // Determine the input file format and construct the appropriate reader
     reader_ = open_hepmc3(filename);
@@ -62,7 +78,6 @@ auto EventReader::operator()() -> result_type
     // Parse the next event from the record
     HepMC3::GenEvent evt;
     {
-        CELER_LOG(debug) << "Reading event " << event_count_;
         ScopedTimeAndRedirect temp_{"HepMC3"};
         reader_->read_event(evt);
     }
@@ -72,6 +87,7 @@ auto EventReader::operator()() -> result_type
         return {};
     }
 
+    CELER_LOG(debug) << "Reading event " << event_count_;
     EventId const event_id{event_count_++};
     if (static_cast<EventId::size_type>(evt.event_number()) != event_id.get())
     {
@@ -96,7 +112,7 @@ auto EventReader::operator()() -> result_type
         // Get the PDG code and check if this particle type is defined for
         // the current physics
         PDGNumber pdg{par->pid()};
-        ParticleId particle_id{params_->find(pdg)};
+        ParticleId particle_id{particles_->find(pdg)};
         if (CELER_UNLIKELY(!particle_id))
         {
             missing_pdg.insert(pdg.unchecked_get());

--- a/src/celeritas/io/EventReader.cc
+++ b/src/celeritas/io/EventReader.cc
@@ -41,11 +41,24 @@ EventReader::EventReader(std::string const& filename,
         SPReader temp_reader = open_hepmc3(filename);
         CELER_ASSERT(temp_reader);
         size_type result = 0;
-        while (!temp_reader->failed())
+#if HEPMC3_VERSION_CODE < 3002000
+        HepMC3::GenEvent evt;
+        temp_reader->read_event(evt);
+#else
+        temp_reader->skip(0);
+#endif
+        CELER_VALIDATE(!temp_reader->failed(),
+                       << "event file '" << filename
+                       << "' did not contain any events");
+        do
         {
-            temp_reader->skip(1);
             result++;
-        }
+#if HEPMC3_VERSION_CODE < 3002000
+            temp_reader->read_event(evt);
+#else
+            temp_reader->skip(1);
+#endif
+        } while (!temp_reader->failed());
         CELER_LOG(debug) << "HepMC3 file has " << result << " events";
         return result;
     }();

--- a/src/celeritas/io/EventReader.hh
+++ b/src/celeritas/io/EventReader.hh
@@ -50,7 +50,7 @@ class EventReader : public EventReaderInterface
 
   public:
     // Construct from a filename
-    EventReader(std::string const& filename, SPConstParticles params);
+    EventReader(std::string const& filename, SPConstParticles particles);
 
     //! Prevent copying and moving
     CELER_DELETE_COPY_MOVE(EventReader);
@@ -58,15 +58,23 @@ class EventReader : public EventReaderInterface
     // Read a single event from the event record
     result_type operator()() final;
 
+    //! Get total number of events
+    size_type num_events() const { return num_events_; }
+
   private:
+    using SPReader = std::shared_ptr<HepMC3::Reader>;
+
     // Shared standard model particle data
-    SPConstParticles params_;
+    SPConstParticles particles_;
 
     // HepMC3 event record reader
-    std::shared_ptr<HepMC3::Reader> reader_;
+    SPReader reader_;
 
     // Number of events read
     size_type event_count_{0};
+
+    // Total number of events in file
+    size_type num_events_;
 };
 
 //---------------------------------------------------------------------------//
@@ -83,9 +91,10 @@ std::shared_ptr<HepMC3::Reader> open_hepmc3(std::string const& filename);
 #if !CELERITAS_USE_HEPMC3
 inline EventReader::EventReader(std::string const&, SPConstParticles)
 {
-    CELER_DISCARD(params_);
+    CELER_DISCARD(particles_);
     CELER_DISCARD(reader_);
     CELER_DISCARD(event_count_);
+    CELER_DISCARD(num_events_);
     CELER_NOT_CONFIGURED("HepMC3");
 }
 

--- a/src/celeritas/io/EventReader.hh
+++ b/src/celeritas/io/EventReader.hh
@@ -59,7 +59,7 @@ class EventReader : public EventReaderInterface
     result_type operator()() final;
 
     //! Get total number of events
-    size_type num_events() const { return num_events_; }
+    size_type num_events() const final { return num_events_; }
 
   private:
     using SPReader = std::shared_ptr<HepMC3::Reader>;

--- a/src/celeritas/io/RootEventReader.cc
+++ b/src/celeritas/io/RootEventReader.cc
@@ -35,6 +35,12 @@ RootEventReader::RootEventReader(std::string const& filename,
     num_entries_ = ttree_->GetEntries();
     CELER_ASSERT(num_entries_ > 0);
 
+    // Get the number of events. Event IDs are sequential starting from zero.
+    // The last entry will contain the largest event ID.
+    ttree_->GetEntry(num_entries_ - 1);
+    num_events_ = this->from_leaf<size_type>("event_id") + 1;
+    CELER_LOG(debug) << "ROOT file has " << num_events_ << " events";
+
     scoped_root_error.throw_if_errors();
 }
 

--- a/src/celeritas/io/RootEventReader.hh
+++ b/src/celeritas/io/RootEventReader.hh
@@ -52,7 +52,7 @@ class RootEventReader : public EventReaderInterface
     result_type operator()() final;
 
     //! Get total number of events
-    size_type num_events() const { return num_events_; }
+    size_type num_events() const final { return num_events_; }
 
   private:
     //// DATA ////

--- a/src/celeritas/io/RootEventReader.hh
+++ b/src/celeritas/io/RootEventReader.hh
@@ -51,12 +51,16 @@ class RootEventReader : public EventReaderInterface
     // Read a single event from the ROOT file
     result_type operator()() final;
 
+    //! Get total number of events
+    size_type num_events() const { return num_events_; }
+
   private:
     //// DATA ////
 
     SPConstParticles params_;
     std::size_t entry_count_{0};  // Current TTree entry
     std::size_t num_entries_;  // Total number of entries in the TTree
+    size_type num_events_;  // Total number of events
     UPExtern<TFile> tfile_;
     UPExtern<TTree> ttree_;
 
@@ -80,6 +84,7 @@ inline RootEventReader::RootEventReader(std::string const&, SPConstParticles)
     CELER_DISCARD(params_);
     CELER_DISCARD(entry_count_);
     CELER_DISCARD(num_entries_);
+    CELER_DISCARD(num_events_);
     CELER_DISCARD(tfile_);
     CELER_DISCARD(ttree_);
     CELER_NOT_CONFIGURED("ROOT");

--- a/src/celeritas/phys/PrimaryGenerator.hh
+++ b/src/celeritas/phys/PrimaryGenerator.hh
@@ -70,6 +70,9 @@ class PrimaryGenerator : public EventReaderInterface
     // Generate primary particles from a single event
     result_type operator()() final;
 
+    //! Get total number of events
+    size_type num_events() const { return num_events_; }
+
   private:
     size_type num_events_{};
     size_type primaries_per_event_{};

--- a/test/celeritas/io/EventIO.test.cc
+++ b/test/celeritas/io/EventIO.test.cc
@@ -5,6 +5,8 @@
 //---------------------------------------------------------------------------//
 //! \file celeritas/io/EventIO.test.cc
 //---------------------------------------------------------------------------//
+#include <fstream>
+
 #include "celeritas_config.h"
 #include "celeritas/io/EventReader.hh"
 #include "celeritas/io/EventWriter.hh"

--- a/test/celeritas/io/EventIO.test.cc
+++ b/test/celeritas/io/EventIO.test.cc
@@ -61,6 +61,7 @@ TEST_P(EventIOTest, variety_rwr)
 
     // Determine the event record format and open the file
     EventReader read_event(out_filename, this->particles());
+    EXPECT_EQ(3, read_event.num_events());
 
     // Read events from the event record
     auto result = this->read_all(read_event);
@@ -115,6 +116,7 @@ TEST_P(EventIOTest, no_vertex_rwr)
 
     // Read it in and check
     EventReader read_event(out_filename, this->particles());
+    EXPECT_EQ(3, read_event.num_events());
     auto result = this->read_all(read_event);
 
     // clang-format off

--- a/test/celeritas/io/RootEventIO.test.cc
+++ b/test/celeritas/io/RootEventIO.test.cc
@@ -33,6 +33,7 @@ TEST_F(RootEventIOTest, write_read)
     }
 
     RootEventReader reader(filename, this->particles());
+    EXPECT_EQ(3, reader.num_events());
     this->read_check_test_event(reader);
 }
 

--- a/test/celeritas/phys/PrimaryGenerator.test.cc
+++ b/test/celeritas/phys/PrimaryGenerator.test.cc
@@ -65,6 +65,7 @@ TEST_F(PrimaryGeneratorTest, basic)
     inp.sample_pos = DeltaDistribution<Real3>(Real3{1, 2, 3});
     inp.sample_dir = IsotropicDistribution<real_type>();
     PrimaryGenerator generate_primaries(particles_, inp);
+    EXPECT_EQ(2, generate_primaries.num_events());
 
     std::vector<int> particle_id;
     std::vector<int> event_id;
@@ -111,6 +112,7 @@ TEST_F(PrimaryGeneratorTest, options)
     opts.direction = {DS::isotropic, {}};
 
     auto generate_primaries = PrimaryGenerator::from_options(particles_, opts);
+    EXPECT_EQ(1, generate_primaries.num_events());
     auto primaries = generate_primaries();
     EXPECT_EQ(10, primaries.size());
 


### PR DESCRIPTION
The removes the previously required `max_events` input option from `celer-sim` and `celer-g4`.