### PR TITLE
Use environment variables to control OpenMP behavior in `celer-sim`

### DIFF
--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -126,13 +126,7 @@ void run(std::istream* is, std::shared_ptr<OutputRegistry> output)
                           << " on " << num_streams << " threads";
         MultiExceptionHandler capture_exception;
 #ifdef _OPENMP
-        // Set the maximum number of nested parallel regions
-        // TODO: Enable nested OpenMP parallel regions for multithreaded CPU
-        // once the performance issues have been resolved. For now, limit the
-        // level of nesting to a single parallel region (over events) and
-        // deactivate any deeper nested parallel regions.
-        omp_set_max_active_levels(1);
-#    pragma omp parallel for num_threads(num_streams)
+#    pragma omp parallel for
 #endif
         for (size_type event = 0; event < run_stream.num_events(); ++event)
         {


### PR DESCRIPTION
This removes the hardcoded 'num_threads()" clause and `omp_set_max_active_levels()` call from celer-sim. It also changes the calculated number of streams when `OMP_NUM_THREADS` is unset from 1 to the (implementation defined) default (typically the maximum available).

I noticed with MT celer-sim on the CPU with `merge_events` off the performance was much worse when `OMP_NUM_THREADS` was not set than when it was explicitly set to 1. It looks like a parallel region with one thread is _not_ an active parallel level (even though it spawns a thread), so when `OMP_NUM_THREADS` was not set the inner loops over tracks were the first active parallel levels and were using the default (maximum available) number of threads -- i.e., we were actually parallelizing the track loops rather than the event loop. This change should give more reasonable/expected behavior and give us more control through `OMP_NUM_THREADS` and `OMP_MAX_ACTIVE_LEVELS` (though I'm still not entirely sure why the performance was _so_ much worse previously when the environment variable was not set).