### PR TITLE
Add support for Geant4@11.2

### DIFF
--- a/cmake/CeleritasUtils.cmake
+++ b/cmake/CeleritasUtils.cmake
@@ -435,7 +435,7 @@ endfunction()
 #-----------------------------------------------------------------------------#
 
 function(celeritas_version_to_hex var version)
-  if("TRUE") #NOT DEFINED "${version}_MAJOR")
+  if(NOT DEFINED "${version}_MAJOR" AND DEFINED "${version}")
     # Split version into components
     string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _match "${${version}}")
     if(NOT _match)
@@ -448,9 +448,9 @@ function(celeritas_version_to_hex var version)
     set(${version}_MINOR "${CMAKE_MATCH_2}")
     set(${version}_PATCH "${CMAKE_MATCH_3}")
   endif()
-  # Set any possibly empty values to zero
+  # Set any empty or undefined values to zero
   foreach(_ext MAJOR MINOR PATCH)
-    if(${version}_${_ext} STREQUAL "")
+    if(NOT ${version}_${_ext})
       set(${version}_${_ext} 0)
     endif()
   endforeach()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,16 @@ foreach(_var CLHEP_VERSION Geant4_VERSION VecGeom_VERSION)
 endforeach()
 celeritas_configure_file("celeritas_cmake_strings.h.in" "celeritas_cmake_strings.h" @ONLY)
 
+# Save dependency versions to sys_config
+set(CELERITAS_DEPENDENCY_VERSIONS)
+foreach(_dep Geant4 VecGeom HepMC3)
+  string(TOUPPER "${_dep}" _upper)
+  celeritas_version_to_hex(_temp_version_hex ${_dep}_VERSION)
+  list(APPEND CELERITAS_DEPENDENCY_VERSIONS
+    "#define CELERITAS_${_upper}_VERSION ${_temp_version_hex}"
+  )
+endforeach()
+string(JOIN "\n" CELERITAS_DEPENDENCY_VERSIONS ${CELERITAS_DEPENDENCY_VERSIONS})
 celeritas_configure_file("celeritas_sys_config.h.in" "celeritas_sys_config.h" @ONLY)
 
 #----------------------------------------------------------------------------#

--- a/src/accel/detail/TouchableUpdater.hh
+++ b/src/accel/detail/TouchableUpdater.hh
@@ -11,7 +11,7 @@
 #include "celeritas/Units.hh"
 
 class G4Navigator;
-class G4VTouchable;
+class G4TouchableHistory;
 class G4LogicalVolume;
 
 namespace celeritas
@@ -37,7 +37,7 @@ class TouchableUpdater
     }
 
     // Construct with thread-local navigator and touchable
-    inline TouchableUpdater(G4Navigator* navi, G4VTouchable* touchable);
+    inline TouchableUpdater(G4Navigator* navi, G4TouchableHistory* touchable);
 
     // Try to find the given point in the given logical volume
     bool
@@ -45,7 +45,7 @@ class TouchableUpdater
 
   private:
     G4Navigator* navi_;
-    G4VTouchable* touchable_;
+    G4TouchableHistory* touchable_;
 };
 
 //---------------------------------------------------------------------------//
@@ -54,7 +54,8 @@ class TouchableUpdater
 /*!
  * Construct with with thread-local navigator and touchable.
  */
-TouchableUpdater::TouchableUpdater(G4Navigator* navi, G4VTouchable* touchable)
+TouchableUpdater::TouchableUpdater(G4Navigator* navi,
+                                   G4TouchableHistory* touchable)
     : navi_{navi}, touchable_{touchable}
 {
     CELER_EXPECT(navi_);

--- a/src/accel/detail/TouchableUpdater.hh
+++ b/src/accel/detail/TouchableUpdater.hh
@@ -9,10 +9,7 @@
 
 #include "celeritas/Types.hh"
 #include "celeritas/Units.hh"
-
-class G4Navigator;
-class G4TouchableHistory;
-class G4LogicalVolume;
+#include "celeritas/ext/GeantGeoUtils.hh"
 
 namespace celeritas
 {
@@ -37,7 +34,7 @@ class TouchableUpdater
     }
 
     // Construct with thread-local navigator and touchable
-    inline TouchableUpdater(G4Navigator* navi, G4TouchableHistory* touchable);
+    inline TouchableUpdater(G4Navigator* navi, GeantTouchableBase* touchable);
 
     // Try to find the given point in the given logical volume
     bool
@@ -45,7 +42,7 @@ class TouchableUpdater
 
   private:
     G4Navigator* navi_;
-    G4TouchableHistory* touchable_;
+    GeantTouchableBase* touchable_;
 };
 
 //---------------------------------------------------------------------------//
@@ -55,7 +52,7 @@ class TouchableUpdater
  * Construct with with thread-local navigator and touchable.
  */
 TouchableUpdater::TouchableUpdater(G4Navigator* navi,
-                                   G4TouchableHistory* touchable)
+                                   GeantTouchableBase* touchable)
     : navi_{navi}, touchable_{touchable}
 {
     CELER_EXPECT(navi_);

--- a/src/celeritas/ext/GeantGeoUtils.cc
+++ b/src/celeritas/ext/GeantGeoUtils.cc
@@ -90,7 +90,7 @@ std::ostream& operator<<(std::ostream& os, PrintableNavHistory const& pnh)
     CELER_EXPECT(pnh.touch);
     os << '{';
 
-    G4VTouchable& touch = const_cast<G4VTouchable&>(*pnh.touch);
+    auto& touch = const_cast<GeantTouchableBase&>(*pnh.touch);
     for (int depth : range(touch.GetHistoryDepth()))
     {
         G4VPhysicalVolume* vol = touch.GetVolume(depth);

--- a/src/celeritas/ext/GeantGeoUtils.hh
+++ b/src/celeritas/ext/GeantGeoUtils.hh
@@ -12,20 +12,38 @@
 #include <unordered_set>
 
 #include "celeritas_config.h"
+#include "celeritas_sys_config.h"
 #include "corecel/Assert.hh"
 #include "corecel/cont/Span.hh"
 
+//---------------------------------------------------------------------------//
+// Forward declarations
 class G4LogicalVolume;
 class G4VPhysicalVolume;
+class G4Navigator;
+
+#if CELERITAS_GEANT4_VERSION >= 0x0b0200
+// Geant4 11.2 removed G4VTouchable
 class G4TouchableHistory;
+#else
+class G4VTouchable;
+#endif
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+#if CELERITAS_GEANT4_VERSION >= 0x0b0200
+//! Version-independent typedef to Geant4 touchable history
+using GeantTouchableBase = G4TouchableHistory;
+#else
+using GeantTouchableBase = G4VTouchable;
+#endif
+
+//---------------------------------------------------------------------------//
 //! Wrap around a touchable to get a descriptive output.
 struct PrintableNavHistory
 {
-    G4TouchableHistory const* touch{nullptr};
+    GeantTouchableBase const* touch{nullptr};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantGeoUtils.hh
+++ b/src/celeritas/ext/GeantGeoUtils.hh
@@ -17,7 +17,7 @@
 
 class G4LogicalVolume;
 class G4VPhysicalVolume;
-class G4VTouchable;
+class G4TouchableHistory;
 
 namespace celeritas
 {
@@ -25,7 +25,7 @@ namespace celeritas
 //! Wrap around a touchable to get a descriptive output.
 struct PrintableNavHistory
 {
-    G4VTouchable const* touch{nullptr};
+    G4TouchableHistory const* touch{nullptr};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantBremsstrahlungProcess.cc
+++ b/src/celeritas/ext/detail/GeantBremsstrahlungProcess.cc
@@ -108,6 +108,9 @@ void GeantBremsstrahlungProcess::InitialiseEnergyLossProcess(
         em_model->SetLowEnergyLimit(energy_min);
         em_model->SetHighEnergyLimit(energy_limit);
         em_model->SetSecondaryThreshold(em_parameters->BremsstrahlungTh());
+#if G4VERSION_NUMBER < 1120
+        em_model->SetLPMFlag(false);
+#endif
         G4VEnergyLossProcess::AddEmModel(1, em_model, fluctuation_model);
 
         ++model_index;

--- a/src/celeritas/ext/detail/GeantBremsstrahlungProcess.cc
+++ b/src/celeritas/ext/detail/GeantBremsstrahlungProcess.cc
@@ -21,6 +21,7 @@
 #include <G4SeltzerBergerModel.hh>
 #include <G4VEmFluctuationModel.hh>
 #include <G4VEmModel.hh>
+#include <G4Version.hh>
 #include <G4eBremsstrahlungRelModel.hh>
 
 #include "corecel/Assert.hh"
@@ -107,7 +108,6 @@ void GeantBremsstrahlungProcess::InitialiseEnergyLossProcess(
         em_model->SetLowEnergyLimit(energy_min);
         em_model->SetHighEnergyLimit(energy_limit);
         em_model->SetSecondaryThreshold(em_parameters->BremsstrahlungTh());
-        G4EmParameters::Instance()->SetLPM(false);
         G4VEnergyLossProcess::AddEmModel(1, em_model, fluctuation_model);
 
         ++model_index;
@@ -128,6 +128,9 @@ void GeantBremsstrahlungProcess::InitialiseEnergyLossProcess(
             em_model->SetLowEnergyLimit(energy_limit);
             em_model->SetHighEnergyLimit(energy_max);
             em_model->SetSecondaryThreshold(em_parameters->BremsstrahlungTh());
+#if G4VERSION_NUMBER < 1120
+            em_model->SetLPMFlag(em_parameters->LPM());
+#endif
             G4VEnergyLossProcess::AddEmModel(1, em_model, fluctuation_model);
         }
     }

--- a/src/celeritas/ext/detail/GeantBremsstrahlungProcess.cc
+++ b/src/celeritas/ext/detail/GeantBremsstrahlungProcess.cc
@@ -107,7 +107,7 @@ void GeantBremsstrahlungProcess::InitialiseEnergyLossProcess(
         em_model->SetLowEnergyLimit(energy_min);
         em_model->SetHighEnergyLimit(energy_limit);
         em_model->SetSecondaryThreshold(em_parameters->BremsstrahlungTh());
-        em_model->SetLPMFlag(false);
+        G4EmParameters::Instance()->SetLPM(false);
         G4VEnergyLossProcess::AddEmModel(1, em_model, fluctuation_model);
 
         ++model_index;
@@ -128,7 +128,6 @@ void GeantBremsstrahlungProcess::InitialiseEnergyLossProcess(
             em_model->SetLowEnergyLimit(energy_limit);
             em_model->SetHighEnergyLimit(energy_max);
             em_model->SetSecondaryThreshold(em_parameters->BremsstrahlungTh());
-            em_model->SetLPMFlag(em_parameters->LPM());
             G4VEnergyLossProcess::AddEmModel(1, em_model, fluctuation_model);
         }
     }

--- a/src/celeritas/ext/detail/GeantGeoNavCollection.cc
+++ b/src/celeritas/ext/detail/GeantGeoNavCollection.cc
@@ -26,7 +26,7 @@ void G4ExternDeleter<T>::operator()(T* ptr) noexcept
     delete ptr;
 }
 
-template struct G4ExternDeleter<TouchHandle>;
+template struct G4ExternDeleter<GeantTouchableHandle>;
 template struct G4ExternDeleter<G4Navigator>;
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantGeoNavCollection.hh
+++ b/src/celeritas/ext/detail/GeantGeoNavCollection.hh
@@ -14,11 +14,10 @@
 #include "corecel/cont/Span.hh"
 #include "corecel/sys/ThreadId.hh"
 
+#include "../GeantGeoUtils.hh"
+
 template<class>
 class G4ReferenceCountedHandle;
-class G4VPhysicalVolume;
-class G4TouchableHistory;
-class G4Navigator;
 
 namespace celeritas
 {
@@ -54,9 +53,9 @@ struct G4ExternDeleter
 
 //---------------------------------------------------------------------------//
 
-using TouchHandle = G4ReferenceCountedHandle<G4TouchableHistory>;
-using UPTouchHandle
-    = std::unique_ptr<TouchHandle, G4ExternDeleter<TouchHandle>>;
+using GeantTouchableHandle = G4ReferenceCountedHandle<GeantTouchableBase>;
+using UPTouchHandle = std::unique_ptr<GeantTouchableHandle,
+                                      G4ExternDeleter<GeantTouchableHandle>>;
 using UPNavigator = std::unique_ptr<G4Navigator, G4ExternDeleter<G4Navigator>>;
 
 //---------------------------------------------------------------------------//
@@ -105,7 +104,7 @@ struct GeantGeoNavCollection<Ownership::reference, MemSpace::host>
     GeantGeoNavCollection& operator=(GeantGeoNavCollection const&) = default;
 
     // Get the navigation state for a given track slot
-    TouchHandle& touch_handle(TrackSlotId tid) const;
+    GeantTouchableHandle& touch_handle(TrackSlotId tid) const;
     // Get the navigation state for a given track slot
     G4Navigator& navigator(TrackSlotId tid) const;
 

--- a/src/celeritas/ext/detail/GeantGeoNavCollection.hh
+++ b/src/celeritas/ext/detail/GeantGeoNavCollection.hh
@@ -17,7 +17,7 @@
 template<class>
 class G4ReferenceCountedHandle;
 class G4VPhysicalVolume;
-class G4VTouchable;
+class G4TouchableHistory;
 class G4Navigator;
 
 namespace celeritas
@@ -54,7 +54,7 @@ struct G4ExternDeleter
 
 //---------------------------------------------------------------------------//
 
-using TouchHandle = G4ReferenceCountedHandle<G4VTouchable>;
+using TouchHandle = G4ReferenceCountedHandle<G4TouchableHistory>;
 using UPTouchHandle
     = std::unique_ptr<TouchHandle, G4ExternDeleter<TouchHandle>>;
 using UPNavigator = std::unique_ptr<G4Navigator, G4ExternDeleter<G4Navigator>>;

--- a/src/celeritas_sys_config.h.in
+++ b/src/celeritas_sys_config.h.in
@@ -11,4 +11,6 @@
 
 #cmakedefine01 CELERITAS_HAVE_ROCTX
 
+@CELERITAS_DEPENDENCY_VERSIONS@
+
 #endif /* celeritas_sys_config_h */

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -346,7 +346,15 @@ TEST_F(Em3AlongStepTest, nofluct_nomsc)
             inp.phys_mfp = 100;
 
             auto result = this->run(inp, num_tracks);
-            EXPECT_SOFT_EQ(0.0099999992401263, result.eloss);
+            if (is_ci_build())
+            {
+                EXPECT_SOFT_EQ(0.0099999992401263, result.eloss);
+            }
+            else
+            {
+                // Changed in Geant4 11.2
+                EXPECT_SOFT_NEAR(0.0099999989996113689, result.eloss, 1e-7);
+            }
             EXPECT_SOFT_EQ(0.00028363764374689, result.displacement);
             EXPECT_SOFT_EQ(1, result.angle);
             EXPECT_SOFT_EQ(4.8522211972805e-14, result.time);
@@ -516,9 +524,15 @@ TEST_F(SimpleCmsAlongStepTest, msc_field_finegrid)
         inp.direction = {
             -0.333769826820287552, 0.641464235110772663, -0.690739703345700562};
         auto result = this->run(inp, num_tracks);
-        // Range = 6.41578930992857482e-06
-        EXPECT_SOFT_EQ(6.41578930992857482e-6, result.step);
-        EXPECT_SOFT_EQ(inp.energy.value(), result.eloss);
+        if (is_ci_build())
+        {
+            // Range = 6.41578930992857482e-06
+            EXPECT_SOFT_EQ(6.41578930992857482e-6, result.step);
+        }
+        else
+        {
+            EXPECT_SOFT_EQ(inp.energy.value(), result.eloss);
+        }
         EXPECT_EQ("eloss-range", result.action);
         EXPECT_REAL_EQ(0, result.alive);
     }
@@ -561,7 +575,15 @@ TEST_F(SimpleCmsRZFieldAlongStepTest, msc_rzfield_finegrid)
         inp.direction = {
             -0.333769826820287552, 0.641464235110772663, -0.690739703345700562};
         auto result = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(6.113290482072715e-07, result.displacement);
+        if (is_ci_build())
+        {
+            EXPECT_SOFT_EQ(6.113290482072715e-07, result.displacement);
+        }
+        else
+        {
+            // Changed in Geant4 11.2
+            EXPECT_SOFT_NEAR(6.1133229218682668e-07, result.displacement, 1e-5);
+        }
         EXPECT_SOFT_EQ(0.99999999288499986, result.angle);
     }
 }


### PR DESCRIPTION
# Updates for Geant4 11.2 
 - Change G4VTouchable to G4TouchableHistory 
 - Use G4EmParameters::Instance()->SetLPM instead of G4EmModel::SetLPMFlag

# Description
This MR updates compatibility of celeritas to the new version of Geant4 11.2

Fixes #1074 