### PR TITLE
Rename `GenericXsCalculator`

### DIFF
--- a/src/celeritas/em/data/LivermorePEData.hh
+++ b/src/celeritas/em/data/LivermorePEData.hh
@@ -14,7 +14,7 @@
 #include "corecel/math/Quantity.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/XsGridData.hh"
+#include "celeritas/grid/GenericGridData.hh"
 
 namespace celeritas
 {

--- a/src/celeritas/em/interactor/LivermorePEInteractor.hh
+++ b/src/celeritas/em/interactor/LivermorePEInteractor.hh
@@ -15,7 +15,7 @@
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/LivermorePEData.hh"
 #include "celeritas/em/xs/LivermorePEMicroXsCalculator.hh"
-#include "celeritas/grid/GenericXsCalculator.hh"
+#include "celeritas/grid/GenericCalculator.hh"
 #include "celeritas/grid/PolyEvaluator.hh"
 #include "celeritas/phys/CutoffView.hh"
 #include "celeritas/phys/Interaction.hh"
@@ -249,7 +249,7 @@ CELER_FUNCTION SubshellId LivermorePEInteractor::sample_subshell(Engine& rng) co
             }
 
             // Use the tabulated subshell cross sections
-            GenericXsCalculator calc_xs(shell.xs, shared_.xs.reals);
+            GenericCalculator calc_xs(shell.xs, shared_.xs.reals);
             xs += inv_cube_energy * calc_xs(inc_energy_);
 
             if (xs > cutoff)

--- a/src/celeritas/em/xs/LivermorePEMicroXsCalculator.hh
+++ b/src/celeritas/em/xs/LivermorePEMicroXsCalculator.hh
@@ -14,7 +14,7 @@
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/em/data/LivermorePEData.hh"
-#include "celeritas/grid/GenericXsCalculator.hh"
+#include "celeritas/grid/GenericCalculator.hh"
 #include "celeritas/grid/PolyEvaluator.hh"
 
 namespace celeritas
@@ -91,14 +91,14 @@ real_type LivermorePEMicroXsCalculator::operator()(ElementId el_id) const
     {
         // Use tabulated cross sections above K-shell energy but below energy
         // limit for parameterization
-        GenericXsCalculator calc_xs(el.xs_hi, shared_.xs.reals);
+        GenericCalculator calc_xs(el.xs_hi, shared_.xs.reals);
         result = ipow<3>(inv_energy) * calc_xs(energy.value());
     }
     else
     {
         CELER_ASSERT(el.xs_lo);
         // Use tabulated cross sections below K-shell energy
-        GenericXsCalculator calc_xs(el.xs_lo, shared_.xs.reals);
+        GenericCalculator calc_xs(el.xs_lo, shared_.xs.reals);
         result = ipow<3>(inv_energy) * calc_xs(energy.value());
     }
     return result;

--- a/src/celeritas/grid/GenericGridData.hh
+++ b/src/celeritas/grid/GenericGridData.hh
@@ -1,0 +1,35 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/grid/GenericGridData.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Types.hh"
+#include "corecel/data/Collection.hh"
+#include "celeritas/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * A generic grid of 1D data with arbitrary interpolation.
+ */
+struct GenericGridData
+{
+    ItemRange<real_type> grid;  //!< x grid
+    ItemRange<real_type> value;  //!< f(x) value
+    Interp grid_interp;  //!< Interpolation along x
+    Interp value_interp;  //!< Interpolation along f(x)
+
+    //! Whether the interface is initialized and valid
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return (value.size() >= 2) && grid.size() == value.size();
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/grid/ValueGridInserter.hh
+++ b/src/celeritas/grid/ValueGridInserter.hh
@@ -17,6 +17,7 @@
 #include "corecel/grid/UniformGridData.hh"
 #include "celeritas/Types.hh"
 
+#include "GenericGridData.hh"
 #include "XsGridData.hh"
 
 namespace celeritas

--- a/src/celeritas/grid/XsGridData.hh
+++ b/src/celeritas/grid/XsGridData.hh
@@ -50,22 +50,4 @@ struct XsGridData
 };
 
 //---------------------------------------------------------------------------//
-/*!
- * A generic grid of 1D data with arbitrary interpolation.
- */
-struct GenericGridData
-{
-    ItemRange<real_type> grid;  //!< x grid
-    ItemRange<real_type> value;  //!< f(x) value
-    Interp grid_interp;  //!< Interpolation along x
-    Interp value_interp;  //!< Interpolation along f(x)
-
-    //! Whether the interface is initialized and valid
-    explicit CELER_FUNCTION operator bool() const
-    {
-        return (value.size() >= 2) && grid.size() == value.size();
-    }
-};
-
-//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -516,7 +516,7 @@ celeritas_add_test(celeritas/global/Stepper.test.cc
 #-------------------------------------#
 # Grid
 set(CELERITASTEST_PREFIX celeritas/grid)
-celeritas_add_test(celeritas/grid/GenericXsCalculator.test.cc)
+celeritas_add_test(celeritas/grid/GenericCalculator.test.cc)
 celeritas_add_test(celeritas/grid/GridIdFinder.test.cc)
 celeritas_add_test(celeritas/grid/InverseRangeCalculator.test.cc)
 celeritas_add_test(celeritas/grid/PolyEvaluator.test.cc)

--- a/test/celeritas/grid/GenericCalculator.test.cc
+++ b/test/celeritas/grid/GenericCalculator.test.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/grid/GenericXsCalculator.test.cc
+//! \file celeritas/grid/GenericCalculator.test.cc
 //---------------------------------------------------------------------------//
-#include "celeritas/grid/GenericXsCalculator.hh"
+#include "celeritas/grid/GenericCalculator.hh"
 
 #include <algorithm>
 #include <cmath>
@@ -24,7 +24,7 @@ namespace test
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class GenericXsCalculatorTest : public CalculatorTestBase
+class GenericCalculatorTest : public CalculatorTestBase
 {
   protected:
     void SetUp() override
@@ -51,9 +51,13 @@ class GenericXsCalculatorTest : public CalculatorTestBase
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST_F(GenericXsCalculatorTest, all)
+TEST_F(GenericCalculatorTest, all)
 {
-    GenericXsCalculator calc(data_, ref_);
+    GenericCalculator calc(data_, ref_);
+
+    // Test accessing tabulated data
+    EXPECT_EQ(4.0, calc[0]);
+    EXPECT_EQ(2.0, calc[3]);
 
     // Test on grid points
     EXPECT_SOFT_EQ(4.0, calc(1));


### PR DESCRIPTION
This can be used to calculate any quantities on a nonuniform grid, not just cross sections.