### PR TITLE
Fix and avoid including algorithms header for ROOT/CLING

### DIFF
--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -23,6 +23,7 @@
 #include "corecel/cont/ArrayIO.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/OutputRegistry.hh"
+#include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
 #include "celeritas/field/RZMapFieldParams.hh"

--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -15,7 +15,6 @@
 #include "corecel/Macros.hh"
 #include "corecel/OpaqueId.hh"
 #include "corecel/Types.hh"
-#include "corecel/cont/Array.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "orange/Types.hh"
 // IWYU pragma: end_exports

--- a/src/celeritas/field/LinearPropagator.hh
+++ b/src/celeritas/field/LinearPropagator.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/math/Algorithms.hh"
 #include "orange/Types.hh"
 
 namespace celeritas

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -526,7 +526,7 @@ CELER_WRAP_MATH_FLOAT_DBL_1(, sinpi)
 CELER_WRAP_MATH_FLOAT_DBL_1(, cospi)
 CELER_WRAP_MATH_FLOAT_DBL_PTR_2(, sincospi)
 CELER_WRAP_MATH_FLOAT_DBL_PTR_2(, sincos)
-#elif __APPLE__
+#elif __APPLE__ && !defined(__CLING__)
 // Apple defines __sinpi, __sinpif, __sincospi, ...
 CELER_WRAP_MATH_FLOAT_DBL_1(__, sinpi)
 CELER_WRAP_MATH_FLOAT_DBL_1(__, cospi)

--- a/src/orange/BoundingBox.hh
+++ b/src/orange/BoundingBox.hh
@@ -12,6 +12,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/cont/Array.hh"
+#include "corecel/math/Algorithms.hh"
 #include "corecel/math/NumericLimits.hh"
 
 #include "OrangeTypes.hh"

--- a/src/orange/Types.hh
+++ b/src/orange/Types.hh
@@ -11,7 +11,6 @@
 #include "corecel/OpaqueId.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
-#include "corecel/math/ArrayUtils.hh"
 
 namespace celeritas
 {
@@ -59,13 +58,13 @@ enum class Axis
  */
 struct GeoTrackInitializer
 {
-    Real3 pos;
-    Real3 dir;
+    Real3 pos{0, 0, 0};
+    Real3 dir{0, 0, 0};
 
-    //! True if assigned and valid
+    //! True if assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return is_soft_unit_vector(dir);
+        return dir[0] != 0 || dir[1] != 0 || dir[2] != 0;
     }
 };
 

--- a/src/orange/surf/SurfaceTypeTraits.hh
+++ b/src/orange/surf/SurfaceTypeTraits.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "corecel/cont/EnumClassUtils.hh"
+#include "corecel/math/Algorithms.hh"
 #include "orange/OrangeTypes.hh"
 
 #include "SurfaceFwd.hh"

--- a/src/orange/transform/TransformTypeTraits.hh
+++ b/src/orange/transform/TransformTypeTraits.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/math/Algorithms.hh"
 #include "orange/OrangeTypes.hh"
 
 namespace celeritas

--- a/src/orange/univ/UniverseTypeTraits.hh
+++ b/src/orange/univ/UniverseTypeTraits.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/math/Algorithms.hh"
 #include "orange/OrangeTypes.hh"
 
 namespace celeritas


### PR DESCRIPTION
If ROOT touches Algorithms, it fails to compile due to missing `__sincospi` which is included by an apple header. This both removes the inclusion of `ArrayUtils` in `Types` and fixes the macros so that `__sincospi` is assumed not to exist when using ROOT.

```
/Users/seth/Code/celeritas-temp/src/corecel/math/Algorithms.hh:533:1: error: no member named '__sin>
CELER_WRAP_MATH_FLOAT_DBL_PTR_2(__, sincospi)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/seth/Code/celeritas-temp/src/corecel/math/Algorithms.hh:395:18: note: expanded from macro 'C>
        return ::PREFIX##FUNC##f(value, a, b);                               \
               ~~^
<scratch space>:206:1: note: expanded from here
__sincospif
^
In file included from input_line_9:3:
In file included from /Users/seth/Code/celeritas-temp/src/celeritas/io/ImportData.hh:25:
In file included from /Users/seth/Code/celeritas-temp/src/corecel/math/ArrayUtils.hh:17:
/Users/seth/Code/celeritas-temp/src/corecel/math/Algorithms.hh:533:1: error: no member named '__sin>
CELER_WRAP_MATH_FLOAT_DBL_PTR_2(__, sincospi)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/seth/Code/celeritas-temp/src/corecel/math/Algorithms.hh:399:18: note: expanded from macro 'C>
        return ::PREFIX##FUNC(value, a, b);                                  \
               ~~^
<scratch space>:207:1: note: expanded from here
__sincospi
^
Error: /opt/spack/var/spack/environments/celeritas/.spack-env/view/bin/rootcling: compilation failu>
```