### PR TITLE
Remove unused data from ImportElement/Material

### DIFF
--- a/interface/celeritas.i
+++ b/interface/celeritas.i
@@ -97,6 +97,7 @@ namespace celeritas
 %celer_rename_to_cstring(vector_type, ImportPhysicsVectorType);
 %celer_rename_to_cstring(process_type, ImportProcessType);
 %celer_rename_to_cstring(process_class, ImportProcessClass);
+%celer_rename_to_cstring(material_state, ImportMaterialState);
 %celer_rename_to_cstring(model, ImportModelClass);
 %rename(process_class_to_geant_name) to_geant_name(ImportProcessClass);
 %rename(model_to_geant_name) to_geant_name(ImportModelClass);

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -46,6 +46,7 @@ list(APPEND SOURCES
   grid/ValueGridInserter.cc
   grid/VectorUtils.cc
   io/AtomicRelaxationReader.cc
+  io/ImportMaterial.cc
   io/ImportModel.cc
   io/ImportPhysicsTable.cc
   io/ImportPhysicsVector.cc

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -299,8 +299,6 @@ std::vector<ImportElement> import_elements()
         element.name = g4element->GetName();
         element.atomic_number = g4element->GetZ();
         element.atomic_mass = g4element->GetAtomicMassAmu();
-        element.radiation_length_tsai = g4element->GetfRadTsai() / (g / cm2);
-        element.coulomb_factor = g4element->GetfCoulomb();
 
         // Despite the function name, this is *NOT* a vector, it's an array
         double* const g4rel_abundance = g4element->GetRelativeAbundanceVector();
@@ -407,13 +405,8 @@ import_materials(GeantImporter::DataSelection::Flags particle_flags)
         material.name = g4material->GetName();
         material.state = to_material_state(g4material->GetState());
         material.temperature = g4material->GetTemperature();  // [K]
-        material.density = g4material->GetDensity() / (g / cm3);
-        material.electron_density = g4material->GetTotNbOfElectPerVolume()
-                                    / (1. / cm3);
         material.number_density = g4material->GetTotNbOfAtomsPerVolume()
                                   / (1. / cm3);
-        material.radiation_length = g4material->GetRadlen() / cm;
-        material.nuclear_int_length = g4material->GetNuclearInterLength() / cm;
 
         // Populate material production cut values
         for (auto const& idx_convert : cut_converters)
@@ -439,7 +432,6 @@ import_materials(GeantImporter::DataSelection::Flags particle_flags)
 
             ImportMatElemComponent elem_comp;
             elem_comp.element_id = g4element->GetIndex();
-            elem_comp.mass_fraction = g4material->GetFractionVector()[j];
             double elem_num_density = g4material->GetVecNbOfAtomsPerVolume()[j]
                                       / (1. / cm3);
             elem_comp.number_fraction = elem_num_density

--- a/src/celeritas/io/ImportElement.hh
+++ b/src/celeritas/io/ImportElement.hh
@@ -45,8 +45,6 @@ struct ImportElement
     std::string name;
     int atomic_number;
     double atomic_mass;  //!< [amu]
-    double radiation_length_tsai;  //!< [mass/length^2]
-    double coulomb_factor;
     VecIsotopeFrac isotopes_fractions;  //!< Isotopic fractional abundance
 };
 

--- a/src/celeritas/io/ImportMaterial.cc
+++ b/src/celeritas/io/ImportMaterial.cc
@@ -1,0 +1,26 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/io/ImportMaterial.cc
+//---------------------------------------------------------------------------//
+#include "ImportMaterial.hh"
+
+#include "corecel/io/EnumStringMapper.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Get a printable label for material state.
+ */
+char const* to_cstring(ImportMaterialState value)
+{
+    static EnumStringMapper<ImportMaterialState> const to_cstring_impl{
+        "other", "solid", "liquid", "gas"};
+    return to_cstring_impl(value);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/io/ImportMaterial.hh
+++ b/src/celeritas/io/ImportMaterial.hh
@@ -11,8 +11,6 @@
 #include <string>
 #include <vector>
 
-#include "corecel/Macros.hh"
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -45,8 +43,7 @@ struct ImportProductionCut
 struct ImportMatElemComponent
 {
     unsigned int element_id{};  //!< Index of element in ImportElement
-    double mass_fraction{};  //!< [mass/length^3]
-    double number_fraction{};
+    double number_fraction{};  //!< [unitless]
 };
 
 //---------------------------------------------------------------------------//
@@ -64,14 +61,17 @@ struct ImportMaterial
     std::string name{};
     ImportMaterialState state{ImportMaterialState::size_};
     double temperature;  //!< [K]
-    double density;  //!< [mass/length^3]
-    double electron_density;  //!< [1/length^3]
     double number_density;  //!< [1/length^3]
-    double radiation_length;  //!< [length]
-    double nuclear_int_length;  //!< [length]
     MapIntCutoff pdg_cutoffs;  //!< Cutoff per PDG
     VecComponent elements;
 };
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+
+// Get the string label for material state
+char const* to_cstring(ImportMaterialState s);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -406,7 +406,7 @@ TEST_F(FourSteelSlabsEmStandard, elements)
 
     std::vector<std::string> names;
     std::vector<int> atomic_numbers;
-    std::vector<double> atomic_masses, inv_rad_lengths_tsai, coulomb_factors;
+    std::vector<double> atomic_masses;
     std::vector<std::string> el_isotope_labels;
     std::vector<double> el_isotope_fractions;
 
@@ -415,8 +415,6 @@ TEST_F(FourSteelSlabsEmStandard, elements)
         names.push_back(element.name);
         atomic_masses.push_back(element.atomic_mass);
         atomic_numbers.push_back(element.atomic_number);
-        coulomb_factors.push_back(element.coulomb_factor);
-        inv_rad_lengths_tsai.push_back(1 / element.radiation_length_tsai);
 
         for (auto const& key : element.isotopes_fractions)
         {
@@ -451,23 +449,11 @@ TEST_F(FourSteelSlabsEmStandard, elements)
     static int const expected_atomic_numbers[] = {26, 24, 28, 1};
     static double const expected_atomic_masses[] = {
         55.845110798, 51.996130137, 58.6933251009, 1.007940752665};  // [AMU]
-    static double const expected_coulomb_factors[] = {0.04197339849163,
-                                                      0.03592322294658,
-                                                      0.04844802666907,
-                                                      6.400838295295e-05};
-    // Check inverse radiation length since soft equal comparison is
-    // useless for extremely small values
-    static double const expected_inv_rad_lengths_tsai[] = {9.3141768784882e+40,
-                                                           1.0803147822537e+41,
-                                                           8.1192652842163e+40,
-                                                           2.3509634762707e+43};
 
     EXPECT_VEC_EQ(expected_names, names);
     EXPECT_VEC_EQ(expected_atomic_numbers, atomic_numbers);
     EXPECT_VEC_EQ(expected_el_isotope_labels, el_isotope_labels);
     EXPECT_VEC_SOFT_EQ(expected_atomic_masses, atomic_masses);
-    EXPECT_VEC_SOFT_EQ(expected_coulomb_factors, coulomb_factors);
-    EXPECT_VEC_SOFT_EQ(expected_inv_rad_lengths_tsai, inv_rad_lengths_tsai);
     EXPECT_VEC_SOFT_EQ(expected_el_isotope_fractions, el_isotope_fractions);
 }
 
@@ -527,19 +513,15 @@ TEST_F(FourSteelSlabsEmStandard, materials)
     std::vector<int> states;
     std::vector<int> pdgs;
     std::vector<double> cutoff_energies, cutoff_ranges;
-    std::vector<double> el_comps_ids, el_comps_mass_frac, el_comps_num_fracs;
-    std::vector<double> densities, num_densities, e_densities, temperatures,
-        rad_lengths, nuc_int_lengths;
+    std::vector<double> el_comps_ids, el_comps_num_fracs;
+    std::vector<double> num_densities;
+    std::vector<double> temperatures;
 
     for (auto const& material : materials)
     {
         names.push_back(material.name);
-        states.push_back((int)material.state);
-        densities.push_back(material.density);
-        e_densities.push_back(material.electron_density);
+        states.push_back(static_cast<int>(material.state));
         num_densities.push_back(material.number_density);
-        nuc_int_lengths.push_back(material.nuclear_int_length);
-        rad_lengths.push_back(material.radiation_length);
         temperatures.push_back(material.temperature);
 
         for (auto const& key : material.pdg_cutoffs)
@@ -552,7 +534,6 @@ TEST_F(FourSteelSlabsEmStandard, materials)
         for (auto const& el_comp : material.elements)
         {
             el_comps_ids.push_back(el_comp.element_id);
-            el_comps_mass_frac.push_back(el_comp.mass_fraction);
             el_comps_num_fracs.push_back(el_comp.number_fraction);
         }
     }
@@ -575,27 +556,13 @@ TEST_F(FourSteelSlabsEmStandard, materials)
     static double const expected_cutoff_ranges[]
         = {0.1, 0.1, 0.1, 0.1, 0.1, 0.1};
     EXPECT_VEC_SOFT_EQ(expected_cutoff_ranges, cutoff_ranges);
-    static double const expected_densities[] = {1e-25, 8};
-    EXPECT_VEC_SOFT_EQ(expected_densities, densities);
-    static double const expected_e_densities[]
-        = {0.05974697167543, 2.244432022882e+24};
-    EXPECT_VEC_SOFT_EQ(expected_e_densities, e_densities);
     static double const expected_num_densities[]
         = {0.05974697167543, 8.699348925899e+22};
     EXPECT_VEC_SOFT_EQ(expected_num_densities, num_densities);
-    static double const expected_nuc_int_lengths[]
-        = {3.500000280825e+26, 16.67805709739};
-    EXPECT_VEC_SOFT_EQ(expected_nuc_int_lengths, nuc_int_lengths);
-    static double const expected_rad_lengths[]
-        = {6.304350904227e+26, 1.738067064483};
-    EXPECT_VEC_SOFT_EQ(expected_rad_lengths, rad_lengths);
     static double const expected_temperatures[] = {2.73, 293.15};
     EXPECT_VEC_SOFT_EQ(expected_temperatures, temperatures);
     static double const expected_el_comps_ids[] = {3, 0, 1, 2};
     EXPECT_VEC_SOFT_EQ(expected_el_comps_ids, el_comps_ids);
-    static double const expected_el_comps_mass_frac[]
-        = {1, 0.7462128746215, 0.1690010443115, 0.08478608106695};
-    EXPECT_VEC_SOFT_EQ(expected_el_comps_mass_frac, el_comps_mass_frac);
     static double const expected_el_comps_num_fracs[] = {1, 0.74, 0.18, 0.08};
     EXPECT_VEC_SOFT_EQ(expected_el_comps_num_fracs, el_comps_num_fracs);
 }


### PR DESCRIPTION
These data aren't used by Celeritas; we reconstruct them from the important data (number density, etc.). Also units for some of the more obscure element data may have been wrong: Tsai radiation length seems to be number density rather than mass density?