### PR TITLE
Prevent a PR with failed actions from being merged

### DIFF
--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -37,6 +37,8 @@ jobs:
       CC: ${{matrix.compiler}}-${{matrix.version}}
       CXX: ${{matrix.compiler == 'gcc' && 'g++' || 'clang++'}}-${{matrix.version}}
     steps:
+      - name: Fail
+        run: false
       - name: Install dependencies
         run: |
           sudo apt-get -q -y update

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -37,8 +37,6 @@ jobs:
       CC: ${{matrix.compiler}}-${{matrix.version}}
       CXX: ${{matrix.compiler == 'gcc' && 'g++' || 'clang++'}}-${{matrix.version}}
     steps:
-      - name: Fail
-        run: false
       - name: Install dependencies
         run: |
           sudo apt-get -q -y update

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,13 +34,14 @@ jobs:
 
   # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
   all:
-    # Complete if jobs were skipped (but not if any failed or were cancelled)
-    if: ${{ always() && !failure() && !cancelled() }}
-    needs: [build]
+    if: ${{ always() }}
+    needs:
+    - build
     runs-on: ubuntu-latest
     steps:
-    - name: Success
-      run: |
-        echo 'Checks passed {"head_ref": "${{github.head_ref}}"}'
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,23 +34,14 @@ jobs:
 
   # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
   all:
-    if: always()
-    needs: [build]
+    if: ${{ always() }}
+    needs:
+    - build
     runs-on: ubuntu-latest
-    env:
-      FAILURE: ${{ failure() && "true" || "false" }}
-      CANCELLED: ${{ cancelled() && "true" || "false" }}
     steps:
-    - name: Result
-      run: |
-        if $FAILURE; then
-          echo 'Checks FAILED'
-          exit 1
-        elif $CANCELLED; then
-          echo 'Checks were CANCELLED'
-          exit 1
-        else
-          echo 'All is well!'
-        fi
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,14 +34,23 @@ jobs:
 
   # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
   all:
-    if: ${{ always() }}
-    needs:
-    - build
+    if: always()
+    needs: [build]
     runs-on: ubuntu-latest
+    env:
+      FAILURE: ${{ failure() && "true" || "false" }}
+      CANCELLED: ${{ cancelled() && "true" || "false" }}
     steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
+    - name: Result
+      run: |
+        if $FAILURE; then
+          echo 'Checks FAILED'
+          exit 1
+        elif $CANCELLED; then
+          echo 'Checks were CANCELLED'
+          exit 1
+        else
+          echo 'All is well!'
+        fi
 
 # vim: set nowrap tw=100:


### PR DESCRIPTION
In https://github.com/celeritas-project/celeritas/pull/1094 we discovered that the "all" job being skipped even though branch protection is enabled:
<img width="747" alt="settings" src="https://github.com/celeritas-project/celeritas/assets/741229/ab3d90bc-f483-4f9e-a807-639165a68584">

This is a known issue, and [this blogger](https://emmer.dev/blog/skippable-github-status-checks-aren-t-really-required/) recommends using [this action](https://github.com/marketplace/actions/alls-green).