### PR TITLE
Fix CTest names

### DIFF
--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -115,7 +115,7 @@ celeritas_add_test(Units.test.cc)
 
 #-----------------------------------------------------------------------------#
 # EM
-set(CELERITASTEST_PREFIX em)
+set(CELERITASTEST_PREFIX celeritas/em)
 celeritas_add_test(em/Fluctuation.test.cc ${_fixme_single})
 celeritas_add_test(em/TsaiUrbanDistribution.test.cc ${_needs_double})
 
@@ -137,7 +137,7 @@ celeritas_add_test(em/UrbanMsc.test.cc ${_needs_root}
 
 #-----------------------------------------------------------------------------#
 # External
-set(CELERITASTEST_PREFIX ext)
+set(CELERITASTEST_PREFIX celeritas/ext)
 
 celeritas_add_test(ext/GeantImporter.test.cc
   ${_needs_geant4}
@@ -155,7 +155,7 @@ celeritas_add_test(ext/RootImporter.test.cc ${_needs_root})
 
 #-----------------------------------------------------------------------------#
 # Field
-set(CELERITASTEST_PREFIX field)
+set(CELERITASTEST_PREFIX celeritas/field)
 
 celeritas_add_test(field/Fields.test.cc)
 celeritas_add_test(field/Steppers.test.cc ${_fixme_cgs})
@@ -170,7 +170,7 @@ celeritas_add_test(field/MagFieldEquation.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Geo
-set(CELERITASTEST_PREFIX geo)
+set(CELERITASTEST_PREFIX celeritas/geo)
 
 set(_geo_args GPU ${_needs_geo} ${_needs_double}
   SOURCES geo/HeuristicGeoTestBase.cc)
@@ -190,7 +190,7 @@ celeritas_add_test(geo/GeoMaterial.test.cc
 
 #-----------------------------------------------------------------------------#
 # Global
-set(CELERITASTEST_PREFIX global)
+set(CELERITASTEST_PREFIX celeritas/global)
 celeritas_add_test(global/ActionRegistry.test.cc)
 
 if(CELERITAS_USE_Geant4 AND CELERITAS_REAL_TYPE STREQUAL "double")
@@ -252,7 +252,7 @@ celeritas_add_test(global/Stepper.test.cc
 
 #-----------------------------------------------------------------------------#
 # Grid
-set(CELERITASTEST_PREFIX grid)
+set(CELERITASTEST_PREFIX celeritas/grid)
 celeritas_add_test(grid/GenericCalculator.test.cc)
 celeritas_add_test(grid/GridIdFinder.test.cc)
 celeritas_add_test(grid/InverseRangeCalculator.test.cc)
@@ -265,7 +265,7 @@ celeritas_add_test(grid/XsCalculator.test.cc)
 
 #-----------------------------------------------------------------------------#
 # IO
-set(CELERITASTEST_PREFIX io)
+set(CELERITASTEST_PREFIX celeritas/io)
 celeritas_add_test(io/EventIO.test.cc ${_needs_hepmc}
   LINK_LIBRARIES ${HepMC3_LIBRARIES})
 celeritas_add_test(io/ImportUnits.test.cc)
@@ -274,20 +274,20 @@ celeritas_add_test(io/SeltzerBergerReader.test.cc ${_needs_geant4})
 
 #-----------------------------------------------------------------------------#
 # Optical
-set(CELERITASTEST_PREFIX optical)
+set(CELERITASTEST_PREFIX celeritas/optical)
 celeritas_add_test(optical/Cerenkov.test.cc)
 celeritas_add_test(optical/ScintillationGenerator.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Mat
-set(CELERITASTEST_PREFIX mat)
+set(CELERITASTEST_PREFIX celeritas/mat)
 celeritas_add_test(mat/IsotopeSelector.test.cc)
 celeritas_add_test(mat/ElementSelector.test.cc)
 celeritas_add_device_test(mat/Material)
 
 #-----------------------------------------------------------------------------#
 # Phys
-set(CELERITASTEST_PREFIX phys)
+set(CELERITASTEST_PREFIX celeritas/phys)
 celeritas_add_test(phys/CutoffParams.test.cc)
 celeritas_add_device_test(phys/Particle)
 celeritas_add_device_test(phys/Physics)
@@ -299,7 +299,7 @@ celeritas_add_test(phys/ProcessBuilder.test.cc ${_needs_root}
 
 #-----------------------------------------------------------------------------#
 # Random
-set(CELERITASTEST_PREFIX random)
+set(CELERITASTEST_PREFIX celeritas/random)
 
 celeritas_add_device_test(random/RngEngine)
 celeritas_add_test(random/Selector.test.cc)
@@ -327,7 +327,7 @@ endif()
 
 #-----------------------------------------------------------------------------#
 # Track
-set(CELERITASTEST_PREFIX track)
+set(CELERITASTEST_PREFIX celeritas/track)
 celeritas_add_test(track/Sim.test.cc ${_needs_geant4})
 celeritas_add_test(track/TrackSort.test.cc GPU ${_needs_geant4} ${_needs_geo})
 
@@ -346,7 +346,7 @@ celeritas_add_test(track/TrackInit.test.cc
 
 #-----------------------------------------------------------------------------#
 # User
-set(CELERITASTEST_PREFIX user)
+set(CELERITASTEST_PREFIX celeritas/user)
 
 if(CELERITAS_USE_Geant4)
   set(_diagnostic_filter

--- a/test/corecel/CMakeLists.txt
+++ b/test/corecel/CMakeLists.txt
@@ -21,7 +21,7 @@ celeritas_setup_tests(SERIAL PREFIX corecel
 celeritas_add_test(OpaqueId.test.cc)
 
 # Cont
-set(CELERITASTEST_PREFIX cont)
+set(CELERITASTEST_PREFIX corecel/cont)
 celeritas_add_test(cont/Array.test.cc)
 celeritas_add_test(cont/InitializedValue.test.cc)
 celeritas_add_test(cont/Span.test.cc)
@@ -30,7 +30,7 @@ celeritas_add_test(cont/VariantUtils.test.cc)
 celeritas_add_device_test(cont/Range)
 
 # Data
-set(CELERITASTEST_PREFIX data)
+set(CELERITASTEST_PREFIX corecel/data)
 celeritas_add_device_test(data/Collection)
 celeritas_add_test(data/Copier.test.cc GPU)
 celeritas_add_test(data/DeviceAllocation.test.cc GPU)
@@ -41,14 +41,14 @@ celeritas_add_test(data/HyperslabIndexer.test.cc)
 celeritas_add_device_test(data/StackAllocator)
 
 # Grid
-set(CELERITASTEST_PREFIX grid)
+set(CELERITASTEST_PREFIX corecel/grid)
 celeritas_add_test(grid/Interpolator.test.cc)
 celeritas_add_test(grid/NonuniformGrid.test.cc)
 celeritas_add_test(grid/TwodGridCalculator.test.cc)
 celeritas_add_test(grid/UniformGrid.test.cc)
 
 # IO
-set(CELERITASTEST_PREFIX io)
+set(CELERITASTEST_PREFIX corecel/io)
 celeritas_add_test(io/EnumStringMapper.test.cc)
 celeritas_add_test(io/Label.test.cc)
 celeritas_add_test(io/Join.test.cc)
@@ -60,7 +60,7 @@ celeritas_add_test(io/StringEnumMapper.test.cc)
 celeritas_add_test(io/StringUtils.test.cc)
 
 # Math
-set(CELERITASTEST_PREFIX math)
+set(CELERITASTEST_PREFIX corecel/math)
 celeritas_add_test(math/Algorithms.test.cc)
 celeritas_add_test(math/ArrayOperators.test.cc)
 celeritas_add_test(math/ArrayUtils.test.cc)
@@ -71,7 +71,7 @@ celeritas_add_test(math/Quantity.test.cc
 celeritas_add_test(math/SoftEqual.test.cc)
 
 # Sys
-set(CELERITASTEST_PREFIX sys)
+set(CELERITASTEST_PREFIX corecel/sys)
 celeritas_add_test(sys/Environment.test.cc
   ENVIRONMENT "ENVTEST_ONE=1;ENVTEST_ZERO=0;ENVTEST_EMPTY="
   LINK_LIBRARIES ${nlohmann_json_LIBRARIES}

--- a/test/orange/CMakeLists.txt
+++ b/test/orange/CMakeLists.txt
@@ -41,11 +41,13 @@ celeritas_add_test(MatrixUtils.test.cc)
 celeritas_add_test(OrangeTypes.test.cc)
 celeritas_add_device_test(Orange)
 
-# Base detail
+celeritas_add_test(detail/UniverseIndexer.test.cc)
+
+# Bounding interval hierarchy
+set(CELERITASTEST_PREFIX orange/bih)
 celeritas_add_test(detail/BIHBuilder.test.cc)
 celeritas_add_test(detail/BIHTraverser.test.cc)
 celeritas_add_test(detail/BIHUtils.test.cc)
-celeritas_add_test(detail/UniverseIndexer.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Transforms
@@ -68,6 +70,7 @@ celeritas_add_test(surf/SimpleQuadric.test.cc)
 celeritas_add_test(surf/Sphere.test.cc)
 celeritas_add_test(surf/SphereCentered.test.cc)
 
+# Surface utilities
 celeritas_add_test(surf/FaceNamer.test.cc)
 celeritas_add_test(surf/RecursiveSimplifier.test.cc)
 celeritas_add_test(surf/SoftSurfaceEqual.test.cc)
@@ -75,6 +78,7 @@ celeritas_add_test(surf/SurfaceClipper.test.cc)
 celeritas_add_test(surf/SurfaceSimplifier.test.cc)
 celeritas_add_device_test(surf/LocalSurfaceVisitor)
 
+# Surface details
 celeritas_add_test(surf/detail/QuadraticSolver.test.cc)
 celeritas_add_test(surf/detail/SurfaceTranslator.test.cc)
 celeritas_add_test(surf/detail/SurfaceTransformer.test.cc)
@@ -86,21 +90,25 @@ celeritas_add_test(construct/CsgTree.test.cc)
 celeritas_add_test(construct/CsgTreeUtils.test.cc)
 celeritas_add_test(construct/LocalSurfaceInserter.test.cc)
 
+#-----------------------------------------------------------------------------#
+# Input processing
 set(CELERITASTEST_PREFIX orange/orangeinp)
 celeritas_add_test(orangeinp/detail/BoundingZone.test.cc)
 celeritas_add_test(orangeinp/detail/CsgUnitBuilder.test.cc)
 
 #-----------------------------------------------------------------------------#
-# Universe details
+# Universe
 set(CELERITASTEST_PREFIX orange/univ)
+celeritas_add_test(univ/VolumeView.test.cc)
+celeritas_add_test(univ/RectArrayTracker.test.cc ${_needs_json})
+celeritas_add_device_test(univ/SimpleUnitTracker)
+celeritas_add_test(univ/TrackerVisitor.test.cc ${_needs_json})
+
+# Universe details
 celeritas_add_test(univ/detail/LogicEvaluator.test.cc)
 celeritas_add_test(univ/detail/LogicStack.test.cc)
 celeritas_add_test(univ/detail/RaggedRightIndexer.test.cc)
 celeritas_add_test(univ/detail/SurfaceFunctors.test.cc)
 celeritas_add_test(univ/detail/SenseCalculator.test.cc)
-celeritas_add_test(univ/VolumeView.test.cc)
-celeritas_add_test(univ/RectArrayTracker.test.cc ${_needs_json})
-celeritas_add_device_test(univ/SimpleUnitTracker)
-celeritas_add_test(univ/TrackerVisitor.test.cc ${_needs_json})
 
 #-----------------------------------------------------------------------------#

--- a/test/orange/CMakeLists.txt
+++ b/test/orange/CMakeLists.txt
@@ -49,7 +49,7 @@ celeritas_add_test(detail/UniverseIndexer.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Transforms
-set(CELERITASTEST_PREFIX transform)
+set(CELERITASTEST_PREFIX orange/transform)
 celeritas_add_test(transform/SignedPermutation.test.cc)
 celeritas_add_test(transform/Transformation.test.cc)
 celeritas_add_test(transform/Translation.test.cc)
@@ -57,7 +57,7 @@ celeritas_add_test(transform/VariantTransform.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Surfaces
-set(CELERITASTEST_PREFIX surf)
+set(CELERITASTEST_PREFIX orange/surf)
 celeritas_add_test(surf/ConeAligned.test.cc)
 celeritas_add_test(surf/CylAligned.test.cc)
 celeritas_add_test(surf/CylCentered.test.cc)
@@ -81,18 +81,18 @@ celeritas_add_test(surf/detail/SurfaceTransformer.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Construct
-set(CELERITASTEST_PREFIX construct)
+set(CELERITASTEST_PREFIX orange/construct)
 celeritas_add_test(construct/CsgTree.test.cc)
 celeritas_add_test(construct/CsgTreeUtils.test.cc)
 celeritas_add_test(construct/LocalSurfaceInserter.test.cc)
 
-set(CELERITASTEST_PREFIX orangeinp)
+set(CELERITASTEST_PREFIX orange/orangeinp)
 celeritas_add_test(orangeinp/detail/BoundingZone.test.cc)
 celeritas_add_test(orangeinp/detail/CsgUnitBuilder.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Universe details
-set(CELERITASTEST_PREFIX univ)
+set(CELERITASTEST_PREFIX orange/univ)
 celeritas_add_test(univ/detail/LogicEvaluator.test.cc)
 celeritas_add_test(univ/detail/LogicStack.test.cc)
 celeritas_add_test(univ/detail/RaggedRightIndexer.test.cc)


### PR DESCRIPTION
In #1099 I accidentally find-replaced away the leading `celeritas/`, `corecel/`, and `orange/`. This restores them.