### PR TITLE
Add missing <algorithm> include needed in GCC 14

### DIFF
--- a/src/celeritas/phys/PrimaryGeneratorOptions.hh
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.hh
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <random>
+#include <algorithm>
 
 #include "corecel/io/StringEnumMapper.hh"
 #include "geocel/Types.hh"


### PR DESCRIPTION
# Add missing <algorithm> include needed in GCC 14

`std::all_of` in `src/celeritas/phys/PrimaryGeneratorOptions.hh` requires the `algorithm` header.

# Description

Without this header GCC 14 (pre-release) fails to build:

```
In file included from /home/vmuser/celeritas/src/celeritas/phys/PrimaryGenerator.hh:18,
                 from /home/vmuser/celeritas/src/celeritas/phys/PrimaryGenerator.cc:8:
/home/vmuser/celeritas/src/celeritas/phys/PrimaryGeneratorOptions.hh: In member function 'celeritas::PrimaryGeneratorOptions::operator bool() const':
/home/vmuser/celeritas/src/celeritas/phys/PrimaryGeneratorOptions.hh:75:24: error: 'all_of' is not a member of 'std'
   75 |                && std::all_of(pdg.begin(),
      |                        ^~~~~~
```

# Labels

If you're a core developer, add one of each label:

- Change type: {bug, documentation, enhancement, minor}
- Category: {app, core, external, field, orange, performance, physics, user}

See [review process](https://github.com/celeritas-project/celeritas/blob/develop/doc/appendix/administration.rst#code-review) for descriptions of the labels and requirements.
