### PR TITLE
Add deduplicating transform inserter

### DIFF
--- a/src/corecel/math/HashUtils.hh
+++ b/src/corecel/math/HashUtils.hh
@@ -33,8 +33,8 @@ using Hasher = detail::FnvHasher<std::size_t>;
  * is \c true, because e.g. structs have padding so this may result in reading
  * uninitialized data or giving two equal structs different hashes.
  */
-template<class T>
-std::size_t hash_as_bytes(Span<T const> s)
+template<class T, std::size_t N>
+std::size_t hash_as_bytes(Span<T const, N> s)
 {
     std::size_t result{};
     Hasher hash{&result};

--- a/src/corecel/math/HashUtils.hh
+++ b/src/corecel/math/HashUtils.hh
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file corecel/math/HashUtils.hh
-// TODO: rename to Hasher.hh
+// TODO for v1.0: rename to Hasher.hh
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -32,6 +32,7 @@ list(APPEND SOURCES
   orangeinp/detail/CsgUnitBuilder.cc
   orangeinp/detail/LocalSurfaceInserter.cc
   orangeinp/detail/NodeSimplifier.cc
+  orangeinp/detail/TransformInserter.cc
   surf/ConeAligned.cc
   surf/CylAligned.cc
   surf/FaceNamer.cc

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -48,6 +48,7 @@ list(APPEND SOURCES
   surf/detail/SurfaceTranslator.cc
   surf/detail/SurfaceTransformer.cc
   transform/SignedPermutation.cc
+  transform/TransformHasher.cc
   transform/TransformIO.cc
   transform/Transformation.cc
   transform/VariantTransform.cc

--- a/src/orange/orangeinp/detail/CsgUnit.hh
+++ b/src/orange/orangeinp/detail/CsgUnit.hh
@@ -15,6 +15,7 @@
 #include "geocel/BoundingBox.hh"
 #include "orange/OrangeTypes.hh"
 #include "orange/surf/VariantSurface.hh"
+#include "orange/transform/VariantTransform.hh"
 
 #include "../CsgTree.hh"
 #include "../CsgTypes.hh"

--- a/src/orange/orangeinp/detail/TransformInserter.cc
+++ b/src/orange/orangeinp/detail/TransformInserter.cc
@@ -1,0 +1,74 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/detail/TransformInserter.cc
+//---------------------------------------------------------------------------//
+#include "TransformInserter.hh"
+
+#include "orange/transform/TransformHasher.hh"
+
+namespace celeritas
+{
+namespace orangeinp
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with a pointer to the transform vector.
+ */
+TransformInserter::TransformInserter(VecTransform* transforms)
+    : transform_{transforms}
+    , cache_{0, HashTransform{transforms}, EqualTransform{transforms}}
+{
+    CELER_EXPECT(transform_);
+    CELER_EXPECT(transform_->empty());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a transform with deduplication.
+ */
+TransformId TransformInserter::operator()(VariantTransform&& vt)
+{
+    CELER_ASSUME(!vt.valueless_by_exception());
+    TransformId result = this->size_id();
+    transform_->push_back(std::move(vt));
+    auto [iter, inserted] = cache_.insert(result);
+    if (!inserted)
+    {
+        // Roll back the change by erasing the last element
+        transform_->pop_back();
+        // Return the existing ID
+        return *iter;
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the hash of a transform.
+ */
+std::size_t TransformInserter::HashTransform::operator()(TransformId id) const
+{
+    CELER_EXPECT(storage && id < storage->size());
+    return visit(TransformHasher{}, (*storage)[id.unchecked_get()]);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Compare two transform IDs for equality in a common container.
+ */
+bool TransformInserter::EqualTransform::operator()(TransformId a,
+                                                   TransformId b) const
+{
+    CELER_EXPECT(storage && a < storage->size() && b < storage->size());
+    return (*storage)[a.unchecked_get()] == (*storage)[b.unchecked_get()];
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/src/orange/orangeinp/detail/TransformInserter.hh
+++ b/src/orange/orangeinp/detail/TransformInserter.hh
@@ -43,6 +43,7 @@ class TransformInserter
 
   private:
     //// TYPES ////
+
     struct HashTransform
     {
         VecTransform* storage{nullptr};
@@ -58,6 +59,8 @@ class TransformInserter
 
     VecTransform* transform_;
     std::unordered_set<TransformId, HashTransform, EqualTransform> cache_;
+
+    //// HELPER FUNCTIONS ////
 
     //! Get the ID of the next transform to be inserted
     TransformId size_id() const { return TransformId(transform_->size()); }

--- a/src/orange/orangeinp/detail/TransformInserter.hh
+++ b/src/orange/orangeinp/detail/TransformInserter.hh
@@ -1,0 +1,69 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/detail/TransformInserter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <unordered_set>
+#include <vector>
+
+#include "orange/transform/VariantTransform.hh"
+
+namespace celeritas
+{
+namespace orangeinp
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Deduplicate transforms as they're being built.
+ *
+ * This currently only works for *exact* transforms rather than *almost exact*
+ * transforms. We may eventually want to add a "transform simplifier" and
+ * "transform soft equal".
+ */
+class TransformInserter
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using VecTransform = std::vector<VariantTransform>;
+    //!@}
+
+  public:
+    // Construct with a pointer to the transform vector
+    explicit TransformInserter(VecTransform* transforms);
+
+    // Construct a transform with deduplication
+    TransformId operator()(VariantTransform&& vt);
+
+  private:
+    //// TYPES ////
+    struct HashTransform
+    {
+        VecTransform* storage{nullptr};
+        std::size_t operator()(TransformId) const;
+    };
+    struct EqualTransform
+    {
+        VecTransform* storage{nullptr};
+        bool operator()(TransformId, TransformId) const;
+    };
+
+    //// DATA ////
+
+    VecTransform* transform_;
+    std::unordered_set<TransformId, HashTransform, EqualTransform> cache_;
+
+    //! Get the ID of the next transform to be inserted
+    TransformId size_id() const { return TransformId(transform_->size()); }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/src/orange/transform/NoTransformation.hh
+++ b/src/orange/transform/NoTransformation.hh
@@ -68,4 +68,22 @@ class NoTransformation
 };
 
 //---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+//!@{
+//! Host-only comparators
+inline constexpr bool
+operator==(NoTransformation const&, NoTransformation const&)
+{
+    return true;
+}
+
+inline constexpr bool
+operator!=(NoTransformation const&, NoTransformation const&)
+{
+    return false;
+}
+//!@}
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/transform/SignedPermutation.hh
+++ b/src/orange/transform/SignedPermutation.hh
@@ -80,6 +80,12 @@ class SignedPermutation
     // Get a view to the data for type-deleted storage
     DataArray data() const;
 
+    // Equality
+    inline bool operator==(SignedPermutation const& other) const;
+
+    // Inequality
+    inline bool operator!=(SignedPermutation const& other) const;
+
     //// CALCULATION ////
 
     // Transform from daughter to parent
@@ -128,6 +134,24 @@ CELER_FUNCTION SignedPermutation::SignedPermutation(StorageSpan s)
     : compressed_{static_cast<UIntT>(s[0])}
 {
     CELER_EXPECT(s[0] >= 0 && s[0] <= static_cast<real_type>(max_value()));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Equality.
+ */
+bool SignedPermutation::operator==(SignedPermutation const& other) const
+{
+    return compressed_ == other.compressed_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Inequality.
+ */
+bool SignedPermutation::operator!=(SignedPermutation const& other) const
+{
+    return !(*this == other);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/transform/TransformHasher.cc
+++ b/src/orange/transform/TransformHasher.cc
@@ -60,9 +60,11 @@ visit(TransformHasher const& th, VariantTransform const& transform)
 //---------------------------------------------------------------------------//
 // EXPLICIT INSTANTIATION
 //---------------------------------------------------------------------------//
+//! \cond
 
 template std::size_t TransformHasher::operator()(Translation const&) const;
 template std::size_t TransformHasher::operator()(Transformation const&) const;
 
+//! \endcond
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/transform/TransformHasher.cc
+++ b/src/orange/transform/TransformHasher.cc
@@ -1,0 +1,61 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/transform/TransformHasher.cc
+//---------------------------------------------------------------------------//
+#include "TransformHasher.hh"
+
+#include <functional>
+
+#include "corecel/Assert.hh"
+#include "corecel/math/HashUtils.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * By default, calculate a hash based on the stored data.
+ */
+template<class T>
+auto TransformHasher::operator()(T const& t) const -> result_type
+{
+    return hash_as_bytes(t.data());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Special hash for "no transformation".
+ */
+auto TransformHasher::operator()(NoTransformation const&) const -> result_type
+{
+    return std::hash<result_type>{}(0);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Special hash for "signed permutation".
+ */
+auto TransformHasher::operator()(SignedPermutation const& t) const
+    -> result_type
+{
+    auto v = t.value();
+    return std::hash<decltype(v)>{}(v);
+}
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate a hash for a variant transform.
+ */
+TransformHasher::result_type
+visit(TransformHasher const& th, VariantTransform const& transform)
+{
+    CELER_ASSUME(!transform.valueless_by_exception());
+    return std::visit(th, transform);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/transform/TransformHasher.cc
+++ b/src/orange/transform/TransformHasher.cc
@@ -58,4 +58,11 @@ visit(TransformHasher const& th, VariantTransform const& transform)
 }
 
 //---------------------------------------------------------------------------//
+// EXPLICIT INSTANTIATION
+//---------------------------------------------------------------------------//
+
+template std::size_t TransformHasher::operator()(Translation const&) const;
+template std::size_t TransformHasher::operator()(Transformation const&) const;
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/transform/TransformHasher.hh
+++ b/src/orange/transform/TransformHasher.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/transform/TransformHasher.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cstdlib>
+
+#include "VariantTransform.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate a hash value of a transform for deduplication.
+ */
+class TransformHasher
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using result_type = std::size_t;
+    //!@}
+
+  public:
+    // By default, calculate a hash based on the stored data
+    template<class T>
+    result_type operator()(T const&) const;
+
+    // Special hash for "no transformation"
+    result_type operator()(NoTransformation const&) const;
+
+    // Special hash for "signed permutation"
+    result_type operator()(SignedPermutation const&) const;
+};
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+// Calculate a hash for a variant transform
+TransformHasher::result_type
+visit(TransformHasher const&, VariantTransform const& transform);
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/transform/Transformation.hh
+++ b/src/orange/transform/Transformation.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <algorithm>
+
 #include "corecel/cont/Span.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "geocel/Types.hh"
@@ -115,7 +117,22 @@ class Transformation
 };
 
 //---------------------------------------------------------------------------//
-// INLINE FUNCTIONS
+//!@{
+//! Host-only comparators
+inline bool operator==(Transformation const& a, Transformation const& b)
+{
+    auto a_data = a.data();
+    return std::equal(a_data.begin(), a_data.end(), b.data().begin());
+}
+
+inline bool operator!=(Transformation const& a, Transformation const& b)
+{
+    return !(a == b);
+}
+//!@}
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
  * Construct inline from storage.

--- a/src/orange/transform/Translation.hh
+++ b/src/orange/transform/Translation.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <algorithm>
+
 #include "corecel/cont/Span.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/ArrayOperators.hh"
@@ -74,6 +76,25 @@ class Translation
     Real3 tra_;
 };
 
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+//!@{
+//! Host-only comparators
+inline bool operator==(Translation const& a, Translation const& b)
+{
+    auto a_data = a.data();
+    return std::equal(a_data.begin(), a_data.end(), b.data().begin());
+}
+
+inline bool operator!=(Translation const& a, Translation const& b)
+{
+    return !(a == b);
+}
+//!@}
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
  * Construct inline from storage.

--- a/src/orange/transform/VariantTransform.hh
+++ b/src/orange/transform/VariantTransform.hh
@@ -12,6 +12,7 @@
 #include "corecel/cont/VariantUtils.hh"
 
 #include "NoTransformation.hh"
+#include "SignedPermutation.hh"
 #include "TransformTypeTraits.hh"
 #include "Transformation.hh"
 #include "Translation.hh"

--- a/test/orange/CMakeLists.txt
+++ b/test/orange/CMakeLists.txt
@@ -58,6 +58,7 @@ celeritas_add_test(orangeinp/CsgTreeUtils.test.cc)
 celeritas_add_test(orangeinp/detail/BoundingZone.test.cc)
 celeritas_add_test(orangeinp/detail/CsgUnitBuilder.test.cc)
 celeritas_add_test(orangeinp/detail/LocalSurfaceInserter.test.cc)
+celeritas_add_test(orangeinp/detail/TransformInserter.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Transforms

--- a/test/orange/orangeinp/detail/TransformInserter.test.cc
+++ b/test/orange/orangeinp/detail/TransformInserter.test.cc
@@ -1,0 +1,57 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/detail/TransformInserter.test.cc
+//---------------------------------------------------------------------------//
+#include "orange/orangeinp/detail/TransformInserter.hh"
+
+#include "orange/MatrixUtils.hh"
+#include "orange/transform/VariantTransform.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace orangeinp
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+
+class TransformInserterTest : public ::celeritas::test::Test
+{
+  protected:
+    void SetUp() override {}
+};
+
+TEST_F(TransformInserterTest, all)
+{
+    std::vector<VariantTransform> transforms;
+    TransformInserter insert(&transforms);
+
+    EXPECT_EQ(TransformId{0},
+              insert(VariantTransform{std::in_place_type<NoTransformation>}));
+    EXPECT_EQ(TransformId{0},
+              insert(VariantTransform{std::in_place_type<NoTransformation>}));
+    EXPECT_EQ(TransformId{1},
+              insert(VariantTransform{std::in_place_type<Translation>,
+                                      Real3{1, 2, 3}}));
+    EXPECT_EQ(TransformId{2},
+              insert(VariantTransform{std::in_place_type<Transformation>,
+                                      make_rotation(Axis::z, Turn{0}),
+                                      Real3{1, 2, 3}}));
+    EXPECT_EQ(TransformId{1},
+              insert(VariantTransform{std::in_place_type<Translation>,
+                                      Real3{1, 2, 3}}));
+    EXPECT_EQ(TransformId{0},
+              insert(VariantTransform{std::in_place_type<NoTransformation>}));
+
+    EXPECT_EQ(3, transforms.size());
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/test/orange/transform/VariantTransform.test.cc
+++ b/test/orange/transform/VariantTransform.test.cc
@@ -8,6 +8,7 @@
 #include "orange/transform/VariantTransform.hh"
 
 #include "geocel/BoundingBox.hh"
+#include "orange/transform/TransformHasher.hh"
 #include "orange/transform/Transformation.hh"
 #include "orange/transform/Translation.hh"
 #include "orange/transform/detail/TransformTransformer.hh"
@@ -145,6 +146,31 @@ TEST_F(VariantTransformTest, bbox)
         bb);  // final bbox
     EXPECT_VEC_SOFT_EQ(Real3({-2, -3, 8}), bb.lower());
     EXPECT_VEC_SOFT_EQ(Real3({4, 3, 14}), bb.upper());
+}
+
+TEST_F(VariantTransformTest, hash)
+{
+    using SignedAxes = SignedPermutation::SignedAxes;
+
+    TransformHasher calc_hash;
+    NoTransformation const nt{};
+    SignedPermutation const sp{
+        SignedAxes{{{'-', Axis::y}, {'-', Axis::z}, {'+', Axis::x}}}};
+    Translation const tl{Real3{0, 1, 0}};
+    Transformation const tf{make_rotation(Axis::z, Turn{0.25}), Real3{0, 0, 2}};
+
+    EXPECT_EQ(calc_hash(nt), calc_hash(nt));
+    EXPECT_EQ(calc_hash(sp), calc_hash(sp));
+    EXPECT_EQ(calc_hash(tl), calc_hash(tl));
+    EXPECT_EQ(calc_hash(tf), calc_hash(tf));
+
+    // Compare against different values
+    EXPECT_NE(calc_hash(nt), calc_hash(SignedPermutation{}));
+    EXPECT_NE(calc_hash(sp), calc_hash(SignedPermutation{}));
+    EXPECT_NE(calc_hash(tl), calc_hash(Translation{Real3{0, 1.1, 0}}));
+    EXPECT_NE(calc_hash(tf),
+              calc_hash(Transformation{make_rotation(Axis::z, Turn{0.5}),
+                                       Real3{1, 0, 2}}));
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This is an `orangeinp` helper class for adding `VariantTransform` instances to a vector with deduplication. Same transforms will be combined to the same object. This differs from the `TransformRecordInserter` in that it actually deduplicates the object, not just the `real_type` data underneath, and it's going to be used locally to a single universe. Unlike the surface deduplication, this does *not* currently do any soft equivalence; it requires byte-for-byte identical results, which I think will be good enough for immediate use cases.