### PR TITLE
Detect and use all CPUs in GitHub CI

### DIFF
--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -76,6 +76,9 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -Wno-error=deprecated-declarations" \
             ..
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v2
+        id: cpus
       - name: Build all
         working-directory: build
         run: |
@@ -83,7 +86,8 @@ jobs:
       - name: Run tests
         working-directory: build
         run: |
-          ctest --parallel 2 --timeout 15 --output-on-failure \
+          ctest --parallel ${{steps.cpus.outputs.count}} \
+            --timeout 15 --output-on-failure \
             --test-output-size-passed=32768 --test-output-size-failed=1048576
       - name: Install
         working-directory: build

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -86,14 +86,18 @@ jobs:
           git config --global --add safe.directory ${PWD}
           ln -fs scripts/cmake-presets/ci-${{matrix.image}}.json CMakeUserPresets.json
           cmake --preset=${CMAKE_PRESET}
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v2
+        id: cpus
       - name: Build Celeritas
         working-directory: build
         run: |
-          ninja
+          ninja -j${{steps.cpus.outputs.count}}
       - name: Test Celeritas
         working-directory: build
         run: |
-          ctest --parallel 2 --timeout 180 --output-on-failure \
+          ctest --parallel ${{steps.cpus.outputs.count}} \
+            --timeout 180 --output-on-failure \
             --test-output-size-passed=65536 --test-output-size-failed=1048576
       - name: Install Celeritas
         working-directory: build


### PR DESCRIPTION
Recently the [default Ubuntu Github Runners now have 4 cores](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/) instead of the previous 2. Add some code to detect and use the right number of cores during testing.