### PR TITLE
Add JSON test comparator to improve testing reliability

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,12 +13,18 @@ include(CeleritasAddTest)
 file(TO_CMAKE_PATH "${PROJECT_SOURCE_DIR}" CELERITAS_SOURCE_DIR)
 configure_file(celeritas_test_config.h.in celeritas_test_config.h @ONLY)
 
-celeritas_add_library(testcel_harness
+set(_harness_sources
   Test.cc
   testdetail/NonMasterResultPrinter.cc
   testdetail/TestMacrosImpl.cc
   testdetail/TestMainImpl.cc
 )
+if(CELERITAS_USE_JSON)
+  list(APPEND _harness_sources
+    testdetail/JsonComparer.json.cc
+  )
+endif()
+celeritas_add_library(testcel_harness ${_harness_sources})
 target_compile_features(testcel_harness PUBLIC cxx_std_17)
 celeritas_target_link_libraries(testcel_harness
   PUBLIC Celeritas::corecel GTest::GTest
@@ -71,5 +77,6 @@ endif()
 
 celeritas_setup_tests(SERIAL PREFIX testdetail)
 celeritas_add_test(TestMacros.test.cc)
+celeritas_add_test(JsonComparer.test.cc)
 
 #-----------------------------------------------------------------------------#

--- a/test/JsonComparer.test.cc
+++ b/test/JsonComparer.test.cc
@@ -32,7 +32,7 @@ TEST_F(JsonComparerTest, parse_errors)
 
 TEST_F(JsonComparerTest, scalars)
 {
-    JsonComparer compare{0.001};
+    JsonComparer compare{real_type(0.001)};
 
     EXPECT_TRUE(compare("null", "null"));
 
@@ -61,7 +61,7 @@ TEST_F(JsonComparerTest, array)
 
 TEST_F(JsonComparerTest, object)
 {
-    JsonComparer compare{0.001};
+    JsonComparer compare{real_type(0.001)};
 
     EXPECT_TRUE(compare(R"json({"a": 1, "b": 2})json"));
     EXPECT_TRUE(
@@ -75,7 +75,7 @@ TEST_F(JsonComparerTest, object)
 
 TEST_F(JsonComparerTest, stringification)
 {
-    JsonComparer compare{0.001};
+    JsonComparer compare{real_type(0.001)};
     auto r = compare(R"json({"a": 1, "b": [1, 2, [0]]})json",
                      R"json({"a": 2, "b": [2, 3, [4, 5]]})json");
     EXPECT_STREQ(R"(JSON objects differ:

--- a/test/JsonComparer.test.cc
+++ b/test/JsonComparer.test.cc
@@ -1,0 +1,79 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file JsonComparer.test.cc
+//---------------------------------------------------------------------------//
+#include "testdetail/JsonComparer.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace testdetail
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+class JsonComparerTest : public ::celeritas::test::Test
+{
+  protected:
+    void SetUp() override {}
+};
+
+TEST_F(JsonComparerTest, parse_errors)
+{
+    JsonComparer compare;
+    EXPECT_FALSE(compare("not valid json"));
+    EXPECT_FALSE(compare("null", "blorp"));
+}
+
+TEST_F(JsonComparerTest, scalars)
+{
+    JsonComparer compare{0.001};
+
+    EXPECT_TRUE(compare("null", "null"));
+
+    EXPECT_TRUE(compare("10"));
+    EXPECT_FALSE(compare("10", "11"));
+
+    EXPECT_TRUE(compare("10.0"));
+    EXPECT_TRUE(compare("10.0", "10.0001"));
+    EXPECT_FALSE(compare("10.0", "10.1"));
+    //
+    EXPECT_TRUE(compare("\"hi\"", "\"hi\""));
+    EXPECT_FALSE(compare("\"hi\"", "\"bye\""));
+
+    EXPECT_FALSE(compare("10.0", "10"));  // float to int
+    EXPECT_FALSE(compare("10", "null"));  // float to null
+}
+
+TEST_F(JsonComparerTest, array)
+{
+    JsonComparer compare;
+
+    EXPECT_TRUE(compare("[]", "[]"));
+    EXPECT_TRUE(compare("[1, 2, 3]", "[1, 2, 3]"));
+    EXPECT_FALSE(compare("[1, 2, 3]", "[2, 2, 3]"));
+}
+
+TEST_F(JsonComparerTest, object)
+{
+    JsonComparer compare{0.001};
+
+    EXPECT_TRUE(compare(R"json({"a": 1, "b": 2})json"));
+    EXPECT_TRUE(
+        compare(R"json({"a": 1, "b": 2})json", R"json({"b": 2, "a": 1})json"));
+    EXPECT_FALSE(compare(R"json({"a": 1})json", R"json({"a": 1, "c": 2})json"));
+    EXPECT_FALSE(
+        compare(R"json({"a": 1, "b": 2})json", R"json({"a": 1, "c": 2})json"));
+    EXPECT_FALSE(
+        compare(R"json({"a": 1, "b": 2})json", R"json({"a": 2, "b": 1})json"));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace testdetail
+}  // namespace celeritas

--- a/test/JsonComparer.test.cc
+++ b/test/JsonComparer.test.cc
@@ -73,6 +73,19 @@ TEST_F(JsonComparerTest, object)
         compare(R"json({"a": 1, "b": 2})json", R"json({"a": 2, "b": 1})json"));
 }
 
+TEST_F(JsonComparerTest, stringification)
+{
+    JsonComparer compare{0.001};
+    auto r = compare(R"json({"a": 1, "b": [1, 2, [0]]})json",
+                     R"json({"a": 2, "b": [2, 3, [4, 5]]})json");
+    EXPECT_STREQ(R"(JSON objects differ:
+  value in .["a"]: expected 1, but got 2
+  value in .["b"][0]: expected 1, but got 2
+  value in .["b"][1]: expected 2, but got 3
+  size in .["b"][2]: expected 1, but got 2)",
+                 r.message());
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace testdetail

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -261,11 +261,9 @@ class FourSteelSlabsEmStandard : public GeantImporterTest
         if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
         {
             nlohmann::json out = opts;
-            static char const expected[]
-                = R"json({"annihilation":true,"apply_cuts":false,"brems":"all","compton_scattering":true,"coulomb_scattering":false,"default_cutoff":0.1,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_conversion":true,"gamma_general":false,"integral_approach":true,"ionization":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban_extended","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"photoelectric":true,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json";
-            EXPECT_EQ(std::string(expected), std::string(out.dump()))
-                << "\n/*** REPLACE ***/\nR\"json(" << std::string(out.dump())
-                << ")json\"\n/******/";
+            EXPECT_JSON_EQ(
+                R"json({"annihilation":true,"apply_cuts":false,"brems":"all","compton_scattering":true,"coulomb_scattering":false,"default_cutoff":0.1,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_conversion":true,"gamma_general":false,"integral_approach":true,"ionization":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban_extended","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"photoelectric":true,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json",
+                std::string(out.dump()));
         }
 #endif
         return opts;

--- a/test/celeritas/geo/Geometry.test.cc
+++ b/test/celeritas/geo/Geometry.test.cc
@@ -270,19 +270,15 @@ TEST_F(SimpleCmsTest, output)
     }
     else if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM)
     {
-        EXPECT_EQ(
+        EXPECT_JSON_EQ(
             R"json({"bbox":[[-1000.001,-1000.001,-2000.001],[1000.001,1000.001,2000.001]],"supports_safety":true,"volumes":{"label":["vacuum_tube","si_tracker","em_calorimeter","had_calorimeter","sc_solenoid","fe_muon_chambers","world"]}})json",
-            to_string(out))
-            << "\n/*** REPLACE ***/\nR\"json(" << to_string(out)
-            << ")json\"\n/******/";
+            to_string(out));
     }
     else if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
     {
-        EXPECT_EQ(
+        EXPECT_JSON_EQ(
             R"json({"bbox":[[-1000.0,-1000.0,-2000.0],[1000.0,1000.0,2000.0]],"supports_safety":false,"surfaces":{"label":["world_box.mx@global","world_box.px@global","world_box.my@global","world_box.py@global","world_box.mz@global","world_box.pz@global","guide_tube.coz@global","crystal_em_calorimeter_outer.mz@global","crystal_em_calorimeter_outer.pz@global","silicon_tracker_outer.coz@global","crystal_em_calorimeter_outer.coz@global","hadron_calorimeter_outer.coz@global","superconducting_solenoid_outer.coz@global","iron_muon_chambers_outer.coz@global"]},"volumes":{"label":["[EXTERIOR]@global","vacuum_tube@global","si_tracker@global","em_calorimeter@global","had_calorimeter@global","sc_solenoid@global","fe_muon_chambers@global","world@global"]}})json",
-            to_string(out))
-            << "\n/*** REPLACE ***/\nR\"json(" << to_string(out)
-            << ")json\"\n/******/";
+            to_string(out));
     }
 }
 

--- a/test/celeritas/global/ActionRegistry.test.cc
+++ b/test/celeritas/global/ActionRegistry.test.cc
@@ -130,11 +130,9 @@ TEST_F(ActionRegistryTest, output)
 
     if (CELERITAS_USE_JSON)
     {
-        EXPECT_EQ(
+        EXPECT_JSON_EQ(
             R"json({"description":["","explicit action test","the second implicit action"],"label":["impl1","explicit","impl2"]})json",
-            to_string(out))
-            << "\n/*** REPLACE ***/\nR\"json(" << to_string(out)
-            << ")json\"\n/******/";
+            to_string(out));
     }
 }
 

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -152,7 +152,7 @@ TEST_F(KernelContextExceptionTest, typical)
             ss << R"json({"dir":[0.0,0.0,1.0],"energy":[10.0,"MeV"],"event":1,"label":"test-kernel","num_steps":1,"particle":0,"pos":[0.0,1.0,5.0],"surface":11,"thread":)json"
                << e.thread().unchecked_get()
                << R"json(,"track":3,"track_slot":15,"volume":2})json";
-            EXPECT_EQ(ss.str(), get_json_str(e));
+            EXPECT_JSON_EQ(ss.str(), get_json_str(e));
         }
     };
     // Since tracks are initialized back to front, the thread ID must be toward
@@ -189,7 +189,7 @@ TEST_F(KernelContextExceptionTest, uninitialized_track)
             std::stringstream ss;
             ss << R"json({"label":"test-kernel","thread":)json"
                << e.thread().unchecked_get() << R"json(,"track_slot":1})json";
-            EXPECT_EQ(ss.str(), get_json_str(e));
+            EXPECT_JSON_EQ(ss.str(), get_json_str(e));
         }
     };
 
@@ -218,7 +218,8 @@ TEST_F(KernelContextExceptionTest, bad_thread)
         EXPECT_EQ(TrackSlotId{}, e.track_slot());
         if (CELERITAS_USE_JSON)
         {
-            EXPECT_EQ(R"json({"label":"dumb-kernel"})json", get_json_str(e));
+            EXPECT_JSON_EQ(R"json({"label":"dumb-kernel"})json",
+                           get_json_str(e));
         }
     };
     CELER_TRY_HANDLE_CONTEXT(

--- a/test/celeritas/mat/Material.test.cc
+++ b/test/celeritas/mat/Material.test.cc
@@ -307,7 +307,7 @@ TEST_F(MaterialTest, isotope_view)
     EXPECT_VEC_SOFT_EQ(expected_nuclear_masses, nuclear_masses);
 }
 
-TEST_F(MaterialTest, TEST_IF_CELERITAS_DOUBLE(output))
+TEST_F(MaterialTest, output)
 {
     MaterialParamsOutput out(params);
     EXPECT_EQ("material", out.label());

--- a/test/celeritas/phys/Particle.test.cc
+++ b/test/celeritas/phys/Particle.test.cc
@@ -86,18 +86,16 @@ TEST_F(ParticleTest, params_accessors)
     EXPECT_EQ(PDGNumber(11), defs.id_to_pdg(ParticleId(0)));
 }
 
-TEST_F(ParticleTest, TEST_IF_CELERITAS_DOUBLE(output))
+TEST_F(ParticleTest, output)
 {
     ParticleParamsOutput out(this->particle_params);
     EXPECT_EQ("particle", out.label());
 
     if (CELERITAS_USE_JSON && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
-        EXPECT_EQ(
+        EXPECT_JSON_EQ(
             R"json({"_units":{"charge":"e","mass":"MeV/c^2"},"charge":[-1.0,0.0,0.0,1.0],"decay_constant":[0.0,0.0,0.0011371389583807142,0.0],"is_antiparticle":[false,false,false,true],"label":["electron","gamma","neutron","positron"],"mass":[0.5109989461,0.0,939.565413,0.5109989461],"pdg":[11,22,2112,-11]})json",
-            to_string(out))
-            << "\n/*** REPLACE ***/\nR\"json(" << to_string(out)
-            << ")json\"\n/******/";
+            to_string(out));
     }
 }
 

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -136,10 +136,6 @@ TEST_F(PhysicsParamsTest, output)
     PhysicsParamsOutput out(this->physics());
     EXPECT_EQ("physics", out.label());
 
-    if (CELERITAS_REAL_TYPE != CELERITAS_REAL_TYPE_DOUBLE)
-    {
-        GTEST_SKIP() << "Test results are based on double-precision data";
-    }
     if (CELERITAS_UNITS != CELERITAS_UNITS_CGS)
     {
         GTEST_SKIP() << "Test results are based on CGS units";

--- a/test/celeritas/phys/PrimaryGenerator.test.cc
+++ b/test/celeritas/phys/PrimaryGenerator.test.cc
@@ -136,9 +136,9 @@ TEST_F(PrimaryGeneratorTest, options)
 #if CELERITAS_USE_JSON
     {
         nlohmann::json out = opts;
-        static char const expected[]
-            = R"json({"direction":{"distribution":"isotropic","params":[]},"energy":{"distribution":"delta","params":[1.0]},"num_events":1,"pdg":[22],"position":{"distribution":"box","params":[-3.0,-3.0,-3.0,3.0,3.0,3.0]},"primaries_per_event":10,"seed":0})json";
-        EXPECT_EQ(std::string(expected), std::string(out.dump()));
+        EXPECT_JSON_EQ(
+            R"json({"direction":{"distribution":"isotropic","params":[]},"energy":{"distribution":"delta","params":[1.0]},"num_events":1,"pdg":[22],"position":{"distribution":"box","params":[-3.0,-3.0,-3.0,3.0,3.0,3.0]},"primaries_per_event":10,"seed":0})json",
+            std::string(out.dump()));
     }
 #endif
 }

--- a/test/corecel/io/OutputRegistry.test.cc
+++ b/test/corecel/io/OutputRegistry.test.cc
@@ -145,7 +145,7 @@ TEST_F(OutputRegistryTest, minimal)
     std::string result = this->to_string(reg);
     if (CELERITAS_USE_JSON)
     {
-        EXPECT_EQ(
+        EXPECT_JSON_EQ(
             R"json({"input":{"input_value":42},"result":{"out":1,"timing":2}})json",
             result);
     }
@@ -177,7 +177,7 @@ TEST_F(OutputRegistryTest, exception_output)
     std::string result = this->to_string(reg);
     if (CELERITAS_USE_JSON)
     {
-        EXPECT_EQ(
+        EXPECT_JSON_EQ(
             R"json({"result":{"exception":{"condition":"false","file":"FILE","line":123,"type":"RuntimeError","what":"things went wrong","which":"runtime"}}})json",
             result);
     }
@@ -197,7 +197,7 @@ TEST_F(OutputRegistryTest, nested_exception_output)
     std::string result = this->to_string(reg);
     if (CELERITAS_USE_JSON)
     {
-        EXPECT_EQ(
+        EXPECT_JSON_EQ(
             R"json({"result":{"exception":{"condition":"false","context":{"event":2,"thread":123,"track":4567,"type":"MockKernelContextException"},"file":"FILE","line":123,"type":"RuntimeError","what":"things went wrong","which":"runtime"}}})json",
             result);
     }

--- a/test/corecel/sys/Environment.test.cc
+++ b/test/corecel/sys/Environment.test.cc
@@ -89,9 +89,9 @@ TEST(EnvironmentTest, TEST_IF_CELERITAS_JSON(json))
     {
         // Save environment
         nlohmann::json out{env};
-        static char const expected[]
-            = R"json([{"ENVTEST_CUSTOM":"custom","ENVTEST_ONE":"111111","ENVTEST_ZERO":"000000"}])json";
-        EXPECT_EQ(std::string(expected), std::string(out.dump()));
+        EXPECT_JSON_EQ(
+            R"json([{"ENVTEST_CUSTOM":"custom","ENVTEST_ONE":"111111","ENVTEST_ZERO":"000000"}])json",
+            out.dump());
     }
 #endif
 }

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -714,11 +714,9 @@ TEST_F(SolidsTest, output)
     {
         auto out_str = simplify_pointers(to_string(out));
 
-        EXPECT_EQ(
+        EXPECT_JSON_EQ(
             R"json({"bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"supports_safety":true,"volumes":{"label":["b500","b100","union1","b100","box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","trd3","trd3_refl","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","","trd3_refl"]}})json",
-            out_str)
-            << "\n/*** REPLACE ***/\nR\"json(" << out_str
-            << ")json\"\n/******/";
+            out_str);
     }
 }
 
@@ -1282,11 +1280,9 @@ TEST_F(SolidsGeantTest, output)
     {
         auto out_str = simplify_pointers(to_string(out));
 
-        EXPECT_EQ(
+        EXPECT_JSON_EQ(
             R"json({"bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"supports_safety":true,"volumes":{"label":["box500@0x0","cone1@0x0","para1@0x0","sphere1@0x0","parabol1@0x0","trap1@0x0","trd1@0x0","trd2@0x0","trd3@0x0","trd3_refl@0x0","tube100@0x0","","","","","boolean1@0x0","polycone1@0x0","genPocone1@0x0","ellipsoid1@0x0","tetrah1@0x0","orb1@0x0","polyhedr1@0x0","hype1@0x0","elltube1@0x0","ellcone1@0x0","arb8b@0x0","arb8a@0x0","xtru1@0x0","World@0x0","","trd3@0x0_refl"]}})json",
-            out_str)
-            << "\n/*** REPLACE ***/\nR\"json(" << out_str
-            << ")json\"\n/******/";
+            out_str);
     }
 }
 

--- a/test/testdetail/JsonComparer.hh
+++ b/test/testdetail/JsonComparer.hh
@@ -1,0 +1,78 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file testdetail/JsonComparer.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include "celeritas_config.h"
+#include "corecel/math/SoftEqual.hh"
+
+namespace celeritas
+{
+namespace testdetail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Perform an equality test (or soft equality) on two JSON objects.
+ */
+class JsonComparer
+{
+  public:
+    using result_type = ::testing::AssertionResult;
+
+  public:
+    //! Construct with optional tolerance
+    template<class... C>
+    JsonComparer(C&&... args) : compare_{std::forward<C>(args)...}
+    {
+    }
+
+    // Compare two strings for equality
+    result_type operator()(std::string_view expected, std::string_view actual);
+
+    // Compare the same strings for equality (testing)
+    result_type operator()(std::string_view expected)
+    {
+        return (*this)(expected, expected);
+    }
+
+  private:
+    struct Failure
+    {
+        std::string where;
+        std::string what;
+        std::string expected;
+        std::string actual;
+    };
+
+    using Compare = EqualOr<SoftEqual<real_type>>;
+    using VecFailure = std::vector<Failure>;
+
+    Compare compare_;
+    struct Impl;
+};
+
+#if !CELERITAS_USE_JSON
+inline auto JsonComparer::operator()(std::string_view expected,
+                                     std::string_view actual) -> result_type
+{
+    CELER_DISCARD(expected);
+    CELER_DISCARD(actual);
+    auto result = ::testing::AssertionFailure();
+    result << "JSON is not enabled: "
+              "wrap this test in 'if (CELERITAS_USE_JSON)'";
+    return result;
+}
+#endif
+
+//---------------------------------------------------------------------------//
+}  // namespace testdetail
+}  // namespace celeritas

--- a/test/testdetail/JsonComparer.json.cc
+++ b/test/testdetail/JsonComparer.json.cc
@@ -9,8 +9,6 @@
 
 #include <nlohmann/json.hpp>
 
-#include "corecel/io/Join.hh"
-
 using nlohmann::json;
 
 namespace celeritas
@@ -82,7 +80,17 @@ auto JsonComparer::operator()(std::string_view expected,
     if (!failures.empty())
     {
         result = ::testing::AssertionFailure();
-        // TODO: convert failures to output
+        result << "JSON objects differ:";
+        for (auto const& f : failures)
+        {
+            result << "\n  ";
+            result << f.what << " in " << f.where << ": expected "
+                   << f.expected;
+            if (!f.actual.empty())
+            {
+                result << ", but got " << f.actual;
+            }
+        }
     }
     return result;
 }
@@ -154,7 +162,10 @@ void JsonComparer::Impl::add_failure(std::string&& what,
                                      std::string&& actual) const
 {
     Failure f;
-    /* f.where = TODO: key stack*/;
+    for (auto const& s : key_stack)
+    {
+        f.where += s;
+    }
     f.what = std::move(what);
     f.expected = std::move(expected);
     f.actual = std::move(actual);

--- a/test/testdetail/JsonComparer.json.cc
+++ b/test/testdetail/JsonComparer.json.cc
@@ -1,0 +1,166 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file testdetail/JsonComparer.json.cc
+//---------------------------------------------------------------------------//
+#include "JsonComparer.hh"
+
+#include <nlohmann/json.hpp>
+
+#include "corecel/io/Join.hh"
+
+using nlohmann::json;
+
+namespace celeritas
+{
+namespace testdetail
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+void convert(char const* label,
+             std::string_view s,
+             json* result,
+             ::testing::AssertionResult* failure)
+{
+    try
+    {
+        *result = json::parse(s.begin(), s.end());
+    }
+    catch (json::parse_error const& j)
+    {
+        *failure = ::testing::AssertionFailure();
+        (*failure) << "Failed to parse " << label << ": " << j.what();
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Implementation class for comparison.
+ */
+struct JsonComparer::Impl
+{
+    JsonComparer::Compare const& soft_eq;
+    JsonComparer::VecFailure* failures{nullptr};
+    std::vector<std::string> key_stack;
+
+    // Recursively test for equality
+    void operator()(json& expected, json& actual);
+
+    void add_failure(std::string&& what,
+                     std::string&& expected,
+                     std::string&& actual) const;
+};
+
+//---------------------------------------------------------------------------//
+auto JsonComparer::operator()(std::string_view expected,
+                              std::string_view actual) -> result_type
+{
+    ::testing::AssertionResult result = ::testing::AssertionSuccess();
+    json exp_j;
+    convert("expected", expected, &exp_j, &result);
+    if (!result)
+    {
+        return result;
+    }
+    json act_j;
+    convert("actual", actual, &act_j, &result);
+    if (!result)
+    {
+        return result;
+    }
+
+    VecFailure failures;
+    Impl compare_impl{compare_, &failures, {"."}};
+    compare_impl(exp_j, act_j);
+
+    if (!failures.empty())
+    {
+        result = ::testing::AssertionFailure();
+        // TODO: convert failures to output
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with defaults.
+ */
+void JsonComparer::Impl::operator()(json& a, json& b)
+{
+    using std::to_string;
+
+    if (a.type() != b.type())
+    {
+        this->add_failure("type", a.type_name(), b.type_name());
+    }
+    else if (a.size() != b.size())
+    {
+        this->add_failure("size", to_string(a.size()), to_string(b.size()));
+        // TODO: for objects, print set operation on keys?
+    }
+    else if (a.is_object())
+    {
+        for (auto const& [key, a_value] : a.items())
+        {
+            auto b_iter = b.find(key);
+            if (b_iter == b.end())
+            {
+                this->add_failure("missing key", std::string(key), {});
+                continue;
+            }
+            this->key_stack.push_back("[\"" + key + "\"]");
+            (*this)(a_value, *b_iter);
+            this->key_stack.pop_back();
+        }
+    }
+    else if (a.is_array())
+    {
+        for (std::size_t i = 0; i < a.size(); ++i)
+        {
+            this->key_stack.push_back("[" + std::to_string(i) + "]");
+            (*this)(a[i], b[i]);
+            this->key_stack.pop_back();
+        }
+    }
+    else if (a.is_number_float())
+    {
+        // Compare with "native" tolerance
+        // using FloatT = json::number_float_t;
+        if (!this->soft_eq(a.get<real_type>(), b.get<real_type>()))
+        {
+            this->add_failure("value",
+                              to_string(a.get<real_type>()),
+                              to_string(b.get<real_type>()));
+        }
+    }
+    else if (a != b)
+    {
+        this->add_failure("value", a.dump(), b.dump());
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Push a failure onto the stack.
+ */
+void JsonComparer::Impl::add_failure(std::string&& what,
+                                     std::string&& expected,
+                                     std::string&& actual) const
+{
+    Failure f;
+    /* f.where = TODO: key stack*/;
+    f.what = std::move(what);
+    f.expected = std::move(expected);
+    f.actual = std::move(actual);
+    failures->push_back(std::move(f));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace testdetail
+}  // namespace celeritas

--- a/test/testdetail/TestMacrosImpl.cc
+++ b/test/testdetail/TestMacrosImpl.cc
@@ -74,7 +74,14 @@ trunc_string(unsigned int digits, char const* str, char const* trunc)
                                     std::string_view actual)
 {
     JsonComparer compare{};
-    return compare(expected, actual);
+    auto result = compare(expected, actual);
+    if (!result)
+    {
+        // Print actual result for copy-pasting into "expected" expression
+        result << "\n/*** ACTUAL ***/\nR\"json(" << actual
+               << ")json\"\n/******/";
+    }
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/testdetail/TestMacrosImpl.cc
+++ b/test/testdetail/TestMacrosImpl.cc
@@ -15,9 +15,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/io/ColorUtils.hh"
 
-#if CELERITAS_USE_JSON
-#    include <nlohmann/json.hpp>
-#endif
+#include "JsonComparer.hh"
 
 namespace celeritas
 {
@@ -69,32 +67,14 @@ trunc_string(unsigned int digits, char const* str, char const* trunc)
 //---------------------------------------------------------------------------//
 /*!
  * Compare two JSON objects.
- *
- * \todo for now this just does string equality, but could do a recursive
- * visitor to compare actual values, and do soft equivalence for floating
- * points.
  */
 ::testing::AssertionResult IsJsonEq(char const*,
                                     char const*,
-                                    [[maybe_unused]] std::string_view expected,
-                                    [[maybe_unused]] std::string_view actual)
+                                    std::string_view expected,
+                                    std::string_view actual)
 {
-#if CELERITAS_USE_JSON
-    if (expected == actual)
-    {
-        return ::testing::AssertionSuccess();
-    }
-
-    auto result = ::testing::AssertionFailure();
-    result << "Expected:\n  R\"json(" << expected << ")json\"";
-    result << "\nActual:\n  R\"json(" << actual << ")json\"";
-    return result;
-#else
-    auto result = ::testing::AssertionFailure();
-    result << "JSON is not enabled: wrap this test in 'if "
-              "(CELERITAS_USE_JSON)'";
-    return result;
-#endif
+    JsonComparer compare{};
+    return compare(expected, actual);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/testdetail/TestMacrosImpl.hh
+++ b/test/testdetail/TestMacrosImpl.hh
@@ -199,8 +199,7 @@ struct TCT
     using common_type =
         typename std::common_type<first_type, second_type>::type;
 
-    using Failed_Value_t = FailedValue<first_type, second_type>;
-    using Failed_Vec_t = std::vector<Failed_Value_t>;
+    using VecFailedValue = std::vector<FailedValue<first_type, second_type>>;
 };
 
 // Failed value iterator traits
@@ -457,7 +456,7 @@ template<class ContainerE, class ContainerA>
 {
     using Traits_t = TCT<ContainerE, ContainerA>;
 
-    typename Traits_t::Failed_Vec_t failures;
+    typename Traits_t::VecFailedValue failures;
 
     ::testing::AssertionResult result
         = IsRangeEqImpl(std::begin(expected),
@@ -500,7 +499,7 @@ template<class ContainerE, class ContainerA>
     using value_type_E = typename Traits_t::first_type;
     using value_type_A = typename Traits_t::second_type;
 
-    typename Traits_t::Failed_Vec_t failures;
+    typename Traits_t::VecFailedValue failures;
 
     static_assert(can_soft_equiv<value_type_E, value_type_A>(),
                   "Invalid types for soft equivalence");


### PR DESCRIPTION
A couple of tests (notably the Material test) seem to fail on some platforms due to differences in JSON output of floating point numbers. This implements a recursive comparator for JSON strings that includes soft equivalence.