### PR TITLE
Add Wentzel OK&VI transport cross section calculator

### DIFF
--- a/src/celeritas/em/distribution/WentzelDistribution.hh
+++ b/src/celeritas/em/distribution/WentzelDistribution.hh
@@ -15,7 +15,7 @@
 #include "celeritas/em/data/WentzelData.hh"
 #include "celeritas/em/interactor/detail/PhysicsConstants.hh"
 #include "celeritas/em/xs/MottRatioCalculator.hh"
-#include "celeritas/em/xs/WentzelRatioCalculator.hh"
+#include "celeritas/em/xs/WentzelHelper.hh"
 #include "celeritas/mat/IsotopeView.hh"
 #include "celeritas/phys/ParticleTrackView.hh"
 #include "celeritas/random/distribution/BernoulliDistribution.hh"
@@ -78,8 +78,8 @@ class WentzelDistribution
     // Mott coefficients for the target element
     WentzelElementData const& element_data_;
 
-    // Ratio of elecron to total cross sections for the Wentzel model
-    WentzelRatioCalculator const calc_elec_ratio_;
+    // Helper for calculating xs ratio and other quantities
+    WentzelHelper const helper_;
 
     // Calculates the form factor from the scattered polar angle
     inline CELER_FUNCTION real_type calculate_form_factor(real_type cos_t) const;
@@ -121,7 +121,7 @@ WentzelDistribution::WentzelDistribution(ParticleTrackView const& particle,
     , particle_(particle)
     , target_(target)
     , element_data_(element_data)
-    , calc_elec_ratio_(particle, target.atomic_number(), data, cutoff)
+    , helper_(particle, target.atomic_number(), data, cutoff)
 {
 }
 
@@ -133,10 +133,10 @@ template<class Engine>
 CELER_FUNCTION real_type WentzelDistribution::operator()(Engine& rng) const
 {
     real_type cos_theta = 1;
-    if (BernoulliDistribution(calc_elec_ratio_())(rng))
+    if (BernoulliDistribution(helper_.calc_xs_ratio())(rng))
     {
         // Scattered off of electrons
-        cos_theta = this->sample_cos_t(calc_elec_ratio_.cos_t_max_elec(), rng);
+        cos_theta = this->sample_cos_t(helper_.costheta_max_electron(), rng);
     }
     else
     {
@@ -259,7 +259,7 @@ CELER_FUNCTION real_type WentzelDistribution::sample_cos_t(real_type cos_t_max,
     // For incident electrons / positrons, theta_min = 0 always
     real_type const mu = real_type{0.5} * (1 - cos_t_max);
     real_type const xi = generate_canonical(rng);
-    real_type const sc = calc_elec_ratio_.screening_coefficient();
+    real_type const sc = helper_.screening_coefficient();
 
     return clamp(1 + 2 * sc * mu * (1 - xi) / (sc - mu * xi),
                  real_type{-1},

--- a/src/celeritas/em/distribution/WentzelDistribution.hh
+++ b/src/celeritas/em/distribution/WentzelDistribution.hh
@@ -56,7 +56,7 @@ class WentzelDistribution
     WentzelDistribution(ParticleTrackView const& particle,
                         IsotopeView const& target,
                         WentzelElementData const& element_data,
-                        real_type cutoff_energy,
+                        Energy cutoff,
                         WentzelRef const& data);
 
     // Sample the polar scattering angle
@@ -115,13 +115,13 @@ CELER_FUNCTION
 WentzelDistribution::WentzelDistribution(ParticleTrackView const& particle,
                                          IsotopeView const& target,
                                          WentzelElementData const& element_data,
-                                         real_type cutoff_energy,
+                                         Energy cutoff,
                                          WentzelRef const& data)
     : data_(data)
     , particle_(particle)
     , target_(target)
     , element_data_(element_data)
-    , calc_elec_ratio_(particle, target.atomic_number(), data, cutoff_energy)
+    , calc_elec_ratio_(particle, target.atomic_number(), data, cutoff)
 {
 }
 

--- a/src/celeritas/em/interactor/WentzelInteractor.hh
+++ b/src/celeritas/em/interactor/WentzelInteractor.hh
@@ -103,7 +103,7 @@ WentzelInteractor::WentzelInteractor(WentzelRef const& shared,
                    target,
                    shared.elem_data[el_id],
                    // TODO: Use proton when supported
-                   value_as<Energy>(cutoffs.energy(shared.ids.electron)),
+                   cutoffs.energy(shared.ids.electron),
                    shared)
 {
     CELER_EXPECT(particle_.particle_id() == shared.ids.electron

--- a/src/celeritas/em/xs/WentzelHelper.hh
+++ b/src/celeritas/em/xs/WentzelHelper.hh
@@ -22,6 +22,9 @@ namespace celeritas
  * This calculates the Moliere screening coefficient, the maximum scattering
  * angle off of electrons, and the ratio of the electron to total Wentzel cross
  * sections.
+ *
+ * References:
+ * [PRM] Geant4 Physics Reference Manual (Release 11.1) section 8.5.
  */
 class WentzelHelper
 {
@@ -150,14 +153,22 @@ CELER_FUNCTION real_type WentzelHelper::calc_screening_coefficient(
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate the screening R^2 coefficient for incident electrons.
+ * Calculate the constant factor of the screening coefficient.
  *
- * This is the constant prefactor of [PRM] eqn 8.51.
+ * This is the constant prefactor \f$ R^2 / Z^{2/3} \f$ of the screening
+ * coefficient for incident electrons (equation 8.51 in [PRM]). The screening
+ * radius \f$ R \f$ is given by:
+ * \f[
+   R = \frac{\hbar Z^{1/3}}{2C_{TF} a_0},
+ * \f]
+ * where the Thomas-Fermi constant \f$ C_{TF} \f$ is defined as
+ * \f[
+   C_{TF} = \frac{1}{2} \left(\frac{3\pi}{4}\right)^{2/3}.
+ * \f]
  */
 CELER_CONSTEXPR_FUNCTION real_type WentzelHelper::screen_r_sq_elec() const
 {
-    //! Thomas-Fermi constant C_TF
-    //! \f$ \frac{1}{2}\left(\frac{3\pi}{4}\right)^{2/3} \f$
+    //! Thomas-Fermi constant \f$ C_{TF} \f$
     constexpr real_type ctf = 0.8853413770001135;
 
     return native_value_to<MomentumSq>(

--- a/src/celeritas/em/xs/WentzelTransportXsCalculator.hh
+++ b/src/celeritas/em/xs/WentzelTransportXsCalculator.hh
@@ -1,0 +1,166 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/em/xs/WentzelTransportXsCalculator.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/cont/Span.hh"
+#include "celeritas/mat/MaterialView.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the transport cross section for the Wentzel OK and VI model.
+ *
+ * See G4WentzelOKandVIxSection::ComputeTransportCrossSectionPerAtom.
+ */
+class WentzelTransportXsCalculator
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using XsUnits = units::Native;  // [len^2]
+    using Charge = units::ElementaryCharge;
+    using Mass = units::MevMass;
+    using MomentumSq = units::MevMomentumSq;
+    //!@}
+
+  public:
+    // Construct with particle and element data
+    inline CELER_FUNCTION
+    WentzelTransportXsCalculator(ParticleTrackView const& particle,
+                                 AtomicNumber z,
+                                 real_type screening_coeff,
+                                 real_type costheta_max_elec);
+
+    // Calculate the transport cross section for the given angle [len^2]
+    inline CELER_FUNCTION real_type operator()(real_type costheta_max) const;
+
+  private:
+    //// DATA ////
+
+    AtomicNumber z_;
+    real_type screening_coeff_;
+    real_type costheta_max_elec_;
+    real_type spin_betasq_;
+    real_type xs_factor_;
+
+    //// HELPER FUNCTIONS ////
+
+    // Calculate the multiplicative factor for the transport cross section
+    real_type calc_xs_factor(ParticleTrackView const&) const;
+
+    // Calculate xs contribution from scattering off electrons or nucleus
+    real_type calc_xs_contribution(real_type costheta_max) const;
+
+    //! Limit on (1 - \c costheta_max) / \c screening_coeff
+    static CELER_CONSTEXPR_FUNCTION real_type limit() { return 0.1; }
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with particle and element data.
+ *
+ * \c beta_sq should be calculated from the incident particle energy and mass.
+ * \c screening_coeff and \c costheta_max_elec are calculated using the Wentzel
+ * OK and VI model in \c WentzelRatioCalculator and depend on properties of the
+ * incident particle, the energy cutoff in theh current material, and the
+ * target element.
+ */
+CELER_FUNCTION
+WentzelTransportXsCalculator::WentzelTransportXsCalculator(
+    ParticleTrackView const& particle,
+    AtomicNumber z,
+    real_type screening_coeff,
+    real_type costheta_max_elec)
+    : z_(z)
+    , screening_coeff_(screening_coeff)
+    , costheta_max_elec_(costheta_max_elec)
+    , spin_betasq_(real_type(0.5) * particle.beta_sq())
+    , xs_factor_(this->calc_xs_factor(particle))
+{
+    CELER_EXPECT(costheta_max_elec_ <= 1);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the transport cross section for the given angle [len^2].
+ */
+CELER_FUNCTION real_type
+WentzelTransportXsCalculator::operator()(real_type costheta_max) const
+{
+    CELER_EXPECT(costheta_max <= 1);
+
+    // Sum xs contributions from scattering off electrons and nucleus
+    real_type xs_nuc = this->calc_xs_contribution(costheta_max);
+    real_type xs_elec = costheta_max_elec_ > costheta_max
+                            ? this->calc_xs_contribution(costheta_max_elec_)
+                            : xs_nuc;
+    real_type result = xs_factor_ * (xs_elec + z_.get() * xs_nuc);
+
+    CELER_ENSURE(result >= 0);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the multiplicative factor for the transport cross section.
+ *
+ * This calculates the factor
+ * \f[
+   f = \frac{2 \pi m_e^2 r_e^2 Z q^2}{\beta^2 p^2},
+ * \f]
+ * where \f$ m_e, r_e, Z, q, \beta \f$, and \f$ p \f$ are the electron mass,
+ * classical electron radius, atomic number of the target atom, charge,
+ * relativistic speed, and momentum of the incident particle, respectively.
+ */
+CELER_FUNCTION real_type WentzelTransportXsCalculator::calc_xs_factor(
+    ParticleTrackView const& particle) const
+{
+    real_type constexpr twopi_mrsq
+        = 2 * constants::pi
+          * ipow<2>(native_value_to<Mass>(constants::electron_mass).value()
+                    * constants::r_electron);
+
+    return twopi_mrsq * z_.get() * ipow<2>(value_as<Charge>(particle.charge()))
+           / (particle.beta_sq()
+              * value_as<MomentumSq>(particle.momentum_sq()));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate contribution to xs from scattering off electrons or nucleus.
+ */
+CELER_FUNCTION real_type WentzelTransportXsCalculator::calc_xs_contribution(
+    real_type costheta_max) const
+{
+    real_type result = [&] {
+        real_type x = (1 - costheta_max) / screening_coeff_;
+        if (x < WentzelTransportXsCalculator::limit())
+        {
+            real_type x_sq = ipow<2>(x);
+            return real_type(0.5) * x_sq
+                   * ((1 - real_type(4) / 3 * x + real_type(1.5) * x_sq)
+                      - screening_coeff_ * spin_betasq_ * x
+                            * (real_type(2) / 3 - x));
+        }
+        real_type x_1 = x / (1 + x);
+        real_type log_x = std::log(1 + x);
+        return log_x - x_1
+               - screening_coeff_ * spin_betasq_ * (x + x_1 - 2 * log_x);
+    }();
+
+    return clamp_to_nonneg(result);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/em/xs/WentzelTransportXsCalculator.hh
+++ b/src/celeritas/em/xs/WentzelTransportXsCalculator.hh
@@ -21,7 +21,7 @@ namespace celeritas
 /*!
  * Calculate the transport cross section for the Wentzel OK and VI model.
  *
- * \note This performs the same calculation as Geant4's
+ * \note This performs the same calculation as the Geant4 method
  * G4WentzelOKandVIxSection::ComputeTransportCrossSectionPerAtom.
  */
 class WentzelTransportXsCalculator
@@ -50,7 +50,7 @@ class WentzelTransportXsCalculator
     AtomicNumber z_;
     real_type screening_coeff_;
     real_type costheta_max_elec_;
-    real_type spin_betasq_;
+    real_type beta_sq_;
     real_type xs_factor_;
 
     //// HELPER FUNCTIONS ////
@@ -82,7 +82,7 @@ WentzelTransportXsCalculator::WentzelTransportXsCalculator(
     : z_(helper.atomic_number())
     , screening_coeff_(helper.screening_coefficient())
     , costheta_max_elec_(helper.costheta_max_electron())
-    , spin_betasq_(real_type(0.5) * particle.beta_sq())
+    , beta_sq_(particle.beta_sq())
     , xs_factor_(this->calc_xs_factor(particle))
 {
 }
@@ -140,13 +140,14 @@ CELER_FUNCTION real_type WentzelTransportXsCalculator::calc_xs_contribution(
     real_type costheta_max) const
 {
     real_type result;
+    real_type const spin = real_type(0.5);
     real_type x = (1 - costheta_max) / screening_coeff_;
     if (x < WentzelTransportXsCalculator::limit())
     {
         real_type x_sq = ipow<2>(x);
         result = real_type(0.5) * x_sq
                  * ((1 - real_type(4) / 3 * x + real_type(1.5) * x_sq)
-                    - screening_coeff_ * spin_betasq_ * x
+                    - screening_coeff_ * spin * beta_sq_ * x
                           * (real_type(2) / 3 - x));
     }
     else
@@ -154,7 +155,7 @@ CELER_FUNCTION real_type WentzelTransportXsCalculator::calc_xs_contribution(
         real_type x_1 = x / (1 + x);
         real_type log_x = std::log(1 + x);
         result = log_x - x_1
-                 - screening_coeff_ * spin_betasq_ * (x + x_1 - 2 * log_x);
+                 - screening_coeff_ * spin * beta_sq_ * (x + x_1 - 2 * log_x);
     }
     return clamp_to_nonneg(result);
 }

--- a/test/celeritas/em/Wentzel.test.cc
+++ b/test/celeritas/em/Wentzel.test.cc
@@ -225,7 +225,7 @@ TEST_F(CoulombScatteringTest, wokvi_transport_xs)
         this->particle_track().particle_id());
 
     std::vector<real_type> xs;
-    for (real_type energy : {50, 100, 200, 1000, 13000})
+    for (real_type energy : {100, 200, 1000, 100000, 1000000})
     {
         this->set_inc_particle(pdg::electron(), MevEnergy{energy});
         auto const& particle = this->particle_track();
@@ -239,14 +239,7 @@ TEST_F(CoulombScatteringTest, wokvi_transport_xs)
             xs.push_back(calc_transport_xs(costheta_max) / units::barn);
         }
     }
-    static double const expected_xs[] = {0.71392734761369,
-                                         0.71230767959567,
-                                         0.70562884270985,
-                                         0.686593114859,
-                                         0.66218877689937,
-                                         0.52908150451115,
-                                         0,
-                                         0.19516611768754,
+    static double const expected_xs[] = {0.19516611768754,
                                          0.19475734301371,
                                          0.19307107844035,
                                          0.18826457727067,
@@ -267,12 +260,19 @@ TEST_F(CoulombScatteringTest, wokvi_transport_xs)
                                          0.0023404433473951,
                                          0.0020012556180187,
                                          0,
-                                         1.7967411080681e-05,
-                                         1.7942982771743e-05,
-                                         1.7842198780488e-05,
-                                         1.75549179749e-05,
-                                         1.7186602916614e-05,
-                                         1.5177682220057e-05,
+                                         3.4837670176241e-07,
+                                         3.4796383511025e-07,
+                                         3.4626046917181e-07,
+                                         3.4140509151026e-07,
+                                         3.3518014131324e-07,
+                                         3.0122705954759e-07,
+                                         0,
+                                         3.988372624941e-09,
+                                         3.9842439204449e-09,
+                                         3.9672101043866e-09,
+                                         3.9186558811768e-09,
+                                         3.8564058066393e-09,
+                                         3.516871865997e-09,
                                          0};
     EXPECT_VEC_SOFT_EQ(expected_xs, xs);
 }

--- a/test/celeritas/em/Wentzel.test.cc
+++ b/test/celeritas/em/Wentzel.test.cc
@@ -140,10 +140,9 @@ TEST_F(CoulombScatteringTest, wokvi_xs)
     AtomicNumber const target_z
         = this->material_params()->get(ElementId{0}).atomic_number();
 
-    real_type const cutoff_energy = value_as<units::MevEnergy>(
-        this->cutoff_params()
-            ->get(MaterialId{0})
-            .energy(this->particle_track().particle_id()));
+    MevEnergy const cutoff = this->cutoff_params()
+                                 ->get(MaterialId{0})
+                                 .energy(this->particle_track().particle_id());
 
     std::vector<real_type> const energies = {50, 100, 200, 1000, 13000};
 
@@ -171,7 +170,7 @@ TEST_F(CoulombScatteringTest, wokvi_xs)
         this->set_inc_particle(pdg::electron(), MevEnergy{energy});
 
         WentzelRatioCalculator calc(
-            particle_track(), target_z, data, cutoff_energy);
+            this->particle_track(), target_z, data, cutoff);
 
         xsecs.push_back(calc());
         cos_t_maxs.push_back(calc.cos_t_max_elec());
@@ -188,7 +187,8 @@ TEST_F(CoulombScatteringTest, mott_xs)
     WentzelHostRef const& data = model_->host_ref();
 
     WentzelElementData const& element_data = data.elem_data[ElementId(0)];
-    MottRatioCalculator xsec(element_data, sqrt(particle_track().beta_sq()));
+    MottRatioCalculator xsec(element_data,
+                             sqrt(this->particle_track().beta_sq()));
 
     static real_type const cos_ts[]
         = {1, 0.9, 0.5, 0.21, 0, -0.1, -0.6, -0.7, -0.9, -1};
@@ -292,13 +292,12 @@ TEST_F(CoulombScatteringTest, distribution)
                   .make_element_view(ElementComponentId{0})
                   .make_isotope_view(IsotopeComponentId{0});
 
-        real_type const cutoff_energy = value_as<units::MevEnergy>(
-            this->cutoff_params()
-                ->get(MaterialId{0})
-                .energy(ParticleId{0}));  // TODO: Use proton ParticleId{2}
+        // TODO: Use proton ParticleId{2}
+        MevEnergy const cutoff
+            = this->cutoff_params()->get(MaterialId{0}).energy(ParticleId{0});
 
         WentzelDistribution distrib(
-            particle_track(), isotope, element_data, cutoff_energy, data);
+            this->particle_track(), isotope, element_data, cutoff, data);
 
         RandomEngine& rng_engine = this->rng();
 

--- a/test/celeritas/em/Wentzel.test.cc
+++ b/test/celeritas/em/Wentzel.test.cc
@@ -170,12 +170,11 @@ TEST_F(CoulombScatteringTest, wokvi_xs)
     {
         this->set_inc_particle(pdg::electron(), MevEnergy{energy});
 
-        WentzelRatioCalculator calc(
-            this->particle_track(), target_z, data, cutoff);
+        WentzelHelper helper(this->particle_track(), target_z, data, cutoff);
 
-        xsecs.push_back(calc());
-        cos_t_maxs.push_back(calc.cos_t_max_elec());
-        screen_zs.push_back(calc.screening_coefficient());
+        xsecs.push_back(helper.calc_xs_ratio());
+        cos_t_maxs.push_back(helper.costheta_max_electron());
+        screen_zs.push_back(helper.screening_coefficient());
     }
 
     EXPECT_VEC_SOFT_EQ(expected_xsecs, xsecs);
@@ -231,14 +230,8 @@ TEST_F(CoulombScatteringTest, wokvi_transport_xs)
         this->set_inc_particle(pdg::electron(), MevEnergy{energy});
         auto const& particle = this->particle_track();
 
-        WentzelRatioCalculator calc_ratio(
-            particle, z, model_->host_ref(), cutoff);
-
-        WentzelTransportXsCalculator calc_transport_xs(
-            particle,
-            z,
-            calc_ratio.screening_coefficient(),
-            calc_ratio.cos_t_max_elec());
+        WentzelHelper helper(particle, z, model_->host_ref(), cutoff);
+        WentzelTransportXsCalculator calc_transport_xs(particle, helper);
 
         for (real_type costheta_max : {-1.0, -0.5, 0.0, 0.5, 0.75, 0.99, 1.0})
         {


### PR DESCRIPTION
This adds a Wentzel OK&VI transport cross section calculator (which will be needed for the Wentzel VI MSC model). It also renames the `WentzelRatioCalculator` so it's now a helper class.