### PR TITLE
Disable ROCm builds because of constant failures

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -10,40 +10,6 @@ pipeline {
   stages {
     stage('Build') {
       parallel {
-        stage('rocm-ndebug-orange') {
-          agent {
-            docker {
-              image 'celeritas/ci-centos7-rocm5:2022-12-14.2'
-              label 'AMD_Radeon_Instinct_MI100 && rocm-docker'
-              args '--device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined'
-            }
-          }
-          steps {
-            sh 'entrypoint-shell ./scripts/ci/run-ci.sh centos-rocm ndebug-orange'
-          }
-          post {
-            always {
-              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
-            }
-          }
-        }
-        stage('rocm-ndebug-orange-float') {
-          agent {
-            docker {
-              image 'celeritas/ci-centos7-rocm5:2022-12-14.2'
-              label 'AMD_Radeon_Instinct_MI100 && rocm-docker'
-              args '--device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined'
-            }
-          }
-          steps {
-            sh 'entrypoint-shell ./scripts/ci/run-ci.sh centos-rocm ndebug-orange-float'
-          }
-          post {
-            always {
-              xunit reduceLog: false, tools:[CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build/Testing/**/*.xml', skipNoTestFiles: false, stopProcessingIfError: true)]
-            }
-          }
-        }
         stage('cuda-debug-orange') {
           agent {
             docker {


### PR DESCRIPTION
The Jenkins CI has been failing intermittently, probably about half the time per ROCM GPU job. I've confirmed this is a problem with the CI hardware itself (Kokkos is seeing it too) and not something we've done.

This removes those jobs so that a red ❌  is actually meaningful. Even though we won't *run* ROCm code, our github workflow will still build it, so we won't accidentally introduce any non-HIP issues.