### PR TITLE
Add infix string builder

### DIFF
--- a/src/orange/orangeinp/CsgTreeUtils.cc
+++ b/src/orange/orangeinp/CsgTreeUtils.cc
@@ -107,7 +107,7 @@ void simplify(CsgTree* tree, NodeId start)
 /*!
  * Convert a node to postfix notation.
  */
-std::vector<LocalSurfaceId::size_type>
+[[nodiscard]] std::vector<LocalSurfaceId::size_type>
 build_postfix(CsgTree const& tree, NodeId n)
 {
     CELER_EXPECT(n < tree.size());
@@ -122,7 +122,7 @@ build_postfix(CsgTree const& tree, NodeId n)
 /*!
  * Convert a node to an infix string expression.
  */
-std::string build_infix_string(CsgTree const& tree, NodeId n)
+[[nodiscard]] std::string build_infix_string(CsgTree const& tree, NodeId n)
 {
     CELER_EXPECT(n < tree.size());
     std::ostringstream os;
@@ -140,7 +140,7 @@ std::string build_infix_string(CsgTree const& tree, NodeId n)
  * Thanks to the CSG tree's deduplication, each surface should appear in the
  * tree at most once.
  */
-std::vector<LocalSurfaceId> calc_surfaces(CsgTree const& tree)
+[[nodiscard]] std::vector<LocalSurfaceId> calc_surfaces(CsgTree const& tree)
 {
     std::vector<LocalSurfaceId> result;
     for (auto node_id : range(NodeId{tree.size()}))

--- a/src/orange/orangeinp/CsgTreeUtils.cc
+++ b/src/orange/orangeinp/CsgTreeUtils.cc
@@ -14,6 +14,7 @@
 
 #include "corecel/cont/Range.hh"
 
+#include "detail/InfixStringBuilder.hh"
 #include "detail/NodeReplacementInserter.hh"
 #include "detail/PostfixLogicBuilder.hh"
 
@@ -115,6 +116,20 @@ build_postfix(CsgTree const& tree, NodeId n)
 
     build_impl(n);
     return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a node to an infix string expression.
+ */
+std::string build_infix_string(CsgTree const& tree, NodeId n)
+{
+    CELER_EXPECT(n < tree.size());
+    std::ostringstream os;
+    detail::InfixStringBuilder build_impl{tree, &os};
+
+    build_impl(n);
+    return os.str();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/CsgTreeUtils.hh
+++ b/src/orange/orangeinp/CsgTreeUtils.hh
@@ -32,14 +32,15 @@ orangeinp::NodeId simplify_up(CsgTree* tree, orangeinp::NodeId start);
 void simplify(CsgTree* tree, orangeinp::NodeId start);
 
 // Convert a node to postfix notation
-std::vector<LocalSurfaceId::size_type>
+[[nodiscard]] std::vector<LocalSurfaceId::size_type>
 build_postfix(CsgTree const& tree, orangeinp::NodeId n);
 
 // Transform a CSG node into a string expression
-std::string build_infix_string(CsgTree const& tree, orangeinp::NodeId n);
+[[nodiscard]] std::string
+build_infix_string(CsgTree const& tree, orangeinp::NodeId n);
 
 // Get the set of unsimplified surfaces in a tree
-std::vector<LocalSurfaceId> calc_surfaces(CsgTree const& tree);
+[[nodiscard]] std::vector<LocalSurfaceId> calc_surfaces(CsgTree const& tree);
 
 //---------------------------------------------------------------------------//
 }  // namespace orangeinp

--- a/src/orange/orangeinp/CsgTreeUtils.hh
+++ b/src/orange/orangeinp/CsgTreeUtils.hh
@@ -35,6 +35,9 @@ void simplify(CsgTree* tree, orangeinp::NodeId start);
 std::vector<LocalSurfaceId::size_type>
 build_postfix(CsgTree const& tree, orangeinp::NodeId n);
 
+// Transform a CSG node into a string expression
+std::string build_infix_string(CsgTree const& tree, orangeinp::NodeId n);
+
 // Get the set of unsimplified surfaces in a tree
 std::vector<LocalSurfaceId> calc_surfaces(CsgTree const& tree);
 

--- a/src/orange/orangeinp/detail/InfixStringBuilder.hh
+++ b/src/orange/orangeinp/detail/InfixStringBuilder.hh
@@ -22,6 +22,18 @@ namespace detail
 //---------------------------------------------------------------------------//
 /*!
  * Transform a CSG node into a string expression.
+ *
+ * The string will be a combination of:
+ * - an \c any function for a union of all listed components
+ * - an \c all function for an intersection of all listed components
+ * - a \c ! negation operator applied to the left of an operation or other
+ *   negation
+ * - a surface ID preceded by a \c - or \c + indicating "inside" or "outside",
+ *   respectively.
+ *
+ * Example of a cylindrical shell: \verbatim
+   all(all(+0, -1, -3), !all(+0, -1, -2))
+ * \endverbatim
  */
 class InfixStringBuilder
 {
@@ -113,7 +125,8 @@ void InfixStringBuilder::operator()(Surface const& s)
 /*!
  * Push an aliased node.
  *
- * TODO: aliased node shouldn't be reachable if we're fully simplified.
+ * Note: aliased node won't be reachable if a tree is fully simplified, *but* a
+ * node can be printed for testing before it's simplified.
  */
 void InfixStringBuilder::operator()(Aliased const& n)
 {
@@ -128,7 +141,8 @@ void InfixStringBuilder::operator()(Negated const& n)
 {
     if (negated_)
     {
-        // Shoudn't happen for simplified expressions
+        // Note: this won't happen for simplified expressions but can be for
+        // testing unsimplified expressions.
         *os_ << '!';
     }
     negated_ = true;

--- a/src/orange/orangeinp/detail/InfixStringBuilder.hh
+++ b/src/orange/orangeinp/detail/InfixStringBuilder.hh
@@ -1,0 +1,168 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/detail/InfixStringBuilder.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <ostream>
+
+#include "corecel/cont/VariantUtils.hh"
+
+#include "../CsgTree.hh"
+
+namespace celeritas
+{
+namespace orangeinp
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Transform a CSG node into a string expression.
+ */
+class InfixStringBuilder
+{
+  public:
+    // Construct with tree and a stream to write to
+    explicit inline InfixStringBuilder(CsgTree const& tree, std::ostream* os);
+
+    //! Build from a node ID
+    inline void operator()(NodeId const& n);
+
+    //!@{
+    //! \name Visit a node directly
+    // Append 'true'
+    inline void operator()(True const&);
+    // False is never explicitly part of the node tree
+    inline void operator()(False const&);
+    // Append a surface ID
+    inline void operator()(Surface const&);
+    // Aliased nodes should never be reachable explicitly
+    inline void operator()(Aliased const&);
+    // Visit a negated node and append 'not'
+    inline void operator()(Negated const&);
+    // Visit daughter nodes and append the conjunction.
+    inline void operator()(Joined const&);
+    //!@}
+
+  private:
+    ContainerVisitor<CsgTree const&, NodeId> visit_node_;
+    std::ostream* os_;
+    bool negated_{false};
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with a reference to an output stream.
+ */
+InfixStringBuilder::InfixStringBuilder(CsgTree const& tree, std::ostream* os)
+    : visit_node_{tree}, os_{os}
+{
+    CELER_EXPECT(os_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build from a node ID.
+ */
+void InfixStringBuilder::operator()(NodeId const& n)
+{
+    visit_node_(*this, n);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Append the "true" token.
+ */
+void InfixStringBuilder::operator()(True const&)
+{
+    *os_ << (negated_ ? 'F' : 'T');
+    negated_ = false;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Explicit "False" should never be possible for a CSG cell.
+ *
+ * The 'false' standin is always aliased to "not true" in the CSG tree.
+ */
+void InfixStringBuilder::operator()(False const&)
+{
+    CELER_ASSERT_UNREACHABLE();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Push a surface ID.
+ */
+void InfixStringBuilder::operator()(Surface const& s)
+{
+    CELER_EXPECT(s.id < logic::lbegin);
+
+    static_assert(to_sense(true) == Sense::outside);
+    *os_ << (negated_ ? '-' : '+') << s.id.unchecked_get();
+    negated_ = false;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Push an aliased node.
+ *
+ * TODO: aliased node shouldn't be reachable if we're fully simplified.
+ */
+void InfixStringBuilder::operator()(Aliased const& n)
+{
+    (*this)(n.node);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Visit a negated node and append 'not'.
+ */
+void InfixStringBuilder::operator()(Negated const& n)
+{
+    if (negated_)
+    {
+        // Shoudn't happen for simplified expressions
+        *os_ << '!';
+    }
+    negated_ = true;
+    (*this)(n.node);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Visit daughter nodes and append the conjunction.
+ */
+void InfixStringBuilder::operator()(Joined const& n)
+{
+    CELER_EXPECT(n.nodes.size() > 1);
+
+    if (negated_)
+    {
+        *os_ << '!';
+    }
+    negated_ = false;
+    *os_ << (n.op == op_and ? "all" : n.op == op_or ? "any" : "XXX") << '(';
+
+    // Visit first node, then add conjunction for subsequent nodes
+    auto iter = n.nodes.begin();
+    (*this)(*iter++);
+
+    while (iter != n.nodes.end())
+    {
+        *os_ << ", ";
+        (*this)(*iter++);
+    }
+    *os_ << ')';
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/test/orange/orangeinp/CsgTreeUtils.test.cc
+++ b/test/orange/orangeinp/CsgTreeUtils.test.cc
@@ -94,6 +94,7 @@ TEST_F(CsgTreeUtilsTest, postfix_simplify)
         static size_type const expected_lgc[]
             = {0u, 1u, logic::lnot, logic::land, 2u, logic::lnot, logic::land};
         EXPECT_VEC_EQ(expected_lgc, lgc);
+        EXPECT_EQ("all(+0, -1, -2)", build_infix_string(tree_, inner_cyl));
     }
     {
         auto lgc = build_postfix(tree_, shell);
@@ -114,12 +115,15 @@ TEST_F(CsgTreeUtilsTest, postfix_simplify)
                                                  logic::lnot,
                                                  logic::land};
         EXPECT_VEC_EQ(expected_lgc, lgc);
+        EXPECT_EQ("all(all(+0, -1, -3), !all(+0, -1, -2))",
+                  build_infix_string(tree_, shell));
     }
     {
         auto lgc = build_postfix(tree_, bdy);
         static size_type const expected_lgc[]
             = {0u, 1u, logic::lnot, logic::land, 4u, logic::land};
         EXPECT_VEC_EQ(expected_lgc, lgc);
+        EXPECT_EQ("all(+0, -1, +4)", build_infix_string(tree_, bdy));
     }
 
     // Imply inside boundary
@@ -135,14 +139,17 @@ TEST_F(CsgTreeUtilsTest, postfix_simplify)
     // Simplify once: first simplification is the inner cylinder
     min_node = simplify_up(&tree_, min_node);
     EXPECT_EQ(NodeId{7}, min_node);
+    EXPECT_EQ("all(-3, !-2)", build_infix_string(tree_, shell));
 
     // Simplify again: the shell is simplified this time
     min_node = simplify_up(&tree_, min_node);
     EXPECT_EQ(NodeId{11}, min_node);
+    EXPECT_EQ("all(+2, -3)", build_infix_string(tree_, shell));
 
     // Simplify one final time: nothing further is simplified
     min_node = simplify_up(&tree_, min_node);
     EXPECT_EQ(NodeId{}, min_node);
+    EXPECT_EQ("all(+2, -3)", build_infix_string(tree_, shell));
 
     EXPECT_EQ(
         "{0: true, 1: not{0}, 2: ->{0}, 3: ->{1}, 4: ->{0}, 5: surface 2, 6: "


### PR DESCRIPTION
This is a utility intended for testing, broken off of #1119. It converts a CSG node to a string to easily read the logic expression.