### PR TITLE
Workaround missing G4persistency target bug in Geant4 11.2

### DIFF
--- a/cmake/CeleritasUtils.cmake
+++ b/cmake/CeleritasUtils.cmake
@@ -647,6 +647,10 @@ function(celeritas_get_g4libs var)
     foreach(_lib IN LISTS ARGN)
       set(_lib Geant4::G4${_lib}${_ext})
 
+      # Tasking was merged into core management
+      if(_lib MATCHES "tasking" AND NOT TARGET "${_lib}")
+        continue()
+      endif()
       # Workaround for differing target names in 11.2.0,1 for G4persistency
       # We do this here and not in FindGeant4 because we have no
       # guarantee projects using Celeritas and Geant4 won't mess with target

--- a/cmake/CeleritasUtils.cmake
+++ b/cmake/CeleritasUtils.cmake
@@ -646,10 +646,23 @@ function(celeritas_get_g4libs var)
 
     foreach(_lib IN LISTS ARGN)
       set(_lib Geant4::G4${_lib}${_ext})
-      if(NOT TARGET "${_lib}")
-        message(AUTHOR_WARNING "No Geant4 library '${_lib}' exists")
+
+      # Workaround for differing target names in 11.2.0,1 for G4persistency
+      # We do this here and not in FindGeant4 because we have no
+      # guarantee projects using Celeritas and Geant4 won't mess with target
+      # names themselves (and if we had to create a "celeritas::" target,
+      # we'd still have to specialize here).
+      if(_lib MATCHES "persistency" AND NOT TARGET "${_lib}")
+        list(APPEND _result Geant4::G4mctruth${_ext} Geant4::G4geomtext${_ext})
+        if(TARGET "Geant4::G4gdml${_ext}")
+          list(APPEND _result Geant4::G4gdml${_ext})
+        endif()
       else()
-        list(APPEND _result "${_lib}")
+        if(NOT TARGET "${_lib}")
+          message(AUTHOR_WARNING "No Geant4 library '${_lib}' exists")
+        else()
+          list(APPEND _result "${_lib}")
+        endif()
       endif()
     endforeach()
   endif()


### PR DESCRIPTION
As reported on Slack, and the same report on [VecGeom JIRA](https://its.cern.ch/jira/browse/VECGEOM-621), Geant4 11.2 split the `G4persistency` target into subcomponents:

- `G4mctruth`
- `G4geomtext`
- `G4gdml` (optional, only if Geant4 built with GDML support)

and so projects use the direct CMake targets will fail to link with these versions. A bug fix will be made in Geant4 itself to address this, but we'll still need to support the affected versions of 11.2.

Workaround this issue in Celeritas by translating request for `persistency` target in `celeritas_get_g4libs` to appropriate underlying targets. Translation rather than creation of our own imported target was chosen to:

- Avoid possible (albeit unlikely) clashes with other projects that might create the same target (and likewise not mess with the `Geant4::` CMake namespace).
- Reduce dependence on use of Celeritas' FindGeant4 wrapper by downstream projects.
