### PR TITLE
Fix missing explicit instantiations in ORANGE CSB

### DIFF
--- a/src/orange/orangeinp/ConvexSurfaceBuilder.cc
+++ b/src/orange/orangeinp/ConvexSurfaceBuilder.cc
@@ -141,5 +141,28 @@ void visit(ConvexSurfaceBuilder& csb, Sense sense, VariantSurface const& surf)
 }
 
 //---------------------------------------------------------------------------//
+// EXPLICIT INSTANTIATIONS
+//---------------------------------------------------------------------------//
+#define CSB_INSTANTIATE(SURF) \
+    template void ConvexSurfaceBuilder::operator()(Sense, SURF const&);
+CSB_INSTANTIATE(PlaneAligned<Axis::x>);
+CSB_INSTANTIATE(PlaneAligned<Axis::y>);
+CSB_INSTANTIATE(PlaneAligned<Axis::z>);
+CSB_INSTANTIATE(CylCentered<Axis::x>);
+CSB_INSTANTIATE(CylCentered<Axis::y>);
+CSB_INSTANTIATE(CylCentered<Axis::z>);
+CSB_INSTANTIATE(SphereCentered);
+CSB_INSTANTIATE(CylAligned<Axis::x>);
+CSB_INSTANTIATE(CylAligned<Axis::y>);
+CSB_INSTANTIATE(CylAligned<Axis::z>);
+CSB_INSTANTIATE(Plane);
+CSB_INSTANTIATE(Sphere);
+CSB_INSTANTIATE(ConeAligned<Axis::x>);
+CSB_INSTANTIATE(ConeAligned<Axis::y>);
+CSB_INSTANTIATE(ConeAligned<Axis::z>);
+CSB_INSTANTIATE(SimpleQuadric);
+CSB_INSTANTIATE(GeneralQuadric);
+#undef CSB_INSTANTIATE
+
 }  // namespace orangeinp
 }  // namespace celeritas

--- a/src/orange/orangeinp/ConvexSurfaceBuilder.cc
+++ b/src/orange/orangeinp/ConvexSurfaceBuilder.cc
@@ -143,6 +143,7 @@ void visit(ConvexSurfaceBuilder& csb, Sense sense, VariantSurface const& surf)
 //---------------------------------------------------------------------------//
 // EXPLICIT INSTANTIATIONS
 //---------------------------------------------------------------------------//
+//! \cond
 #define CSB_INSTANTIATE(SURF) \
     template void ConvexSurfaceBuilder::operator()(Sense, SURF const&);
 CSB_INSTANTIATE(PlaneAligned<Axis::x>);
@@ -163,6 +164,7 @@ CSB_INSTANTIATE(ConeAligned<Axis::z>);
 CSB_INSTANTIATE(SimpleQuadric);
 CSB_INSTANTIATE(GeneralQuadric);
 #undef CSB_INSTANTIATE
+//! \endcond
 
 }  // namespace orangeinp
 }  // namespace celeritas


### PR DESCRIPTION
It turns out that implicitly instantiating templates in a translation unit does *not* prevent those templates from being inlined, so the symbols won't necessarily be available when optimizations are turned on. (Using `std::visit` to easily instantiate function calls has been [tried](https://indii.org/blog/combinatorial-instantiation-of-templates-with-std-variant/) and [documented as failing](https://indii.org/blog/revisited-combinatorial-instantiation-of-templates-with-std-variant/), but the fix there uses non-standard extensions which I don't want to.)

This just adds explicit instantiations for the function calls in the convex surface builder.