### PR TITLE
Implement second-order convex regions

### DIFF
--- a/src/orange/MatrixUtils.hh
+++ b/src/orange/MatrixUtils.hh
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file orange/MatrixUtils.hh
+// TODO: split into BLAS and host-only utils
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/orange/orangeinp/ConvexRegion.cc
+++ b/src/orange/orangeinp/ConvexRegion.cc
@@ -76,6 +76,178 @@ void Box::build(ConvexSurfaceBuilder& insert_surface) const
 }
 
 //---------------------------------------------------------------------------//
+// CONE
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with Z halfwidth and lo, hi radii.
+ */
+Cone::Cone(Real2 const& radii, real_type halfheight)
+    : radii_{radii}, hh_{halfheight}
+{
+    for (auto i : range(2))
+    {
+        CELER_VALIDATE(radii_[i] >= 0, << "negative radius: " << radii_[i]);
+    }
+    CELER_VALIDATE(radii_[0] != radii_[1], << "radii cannot be equal");
+    CELER_VALIDATE(hh_ > 0, << "nonpositive halfheight: " << hh_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build surfaces.
+ *
+ * The inner bounding box of a cone
+ */
+void Cone::build(ConvexSurfaceBuilder& insert_surface) const
+{
+    // Build the bottom and top planes
+    insert_surface(Sense::outside, PlaneZ{-hh_});
+    insert_surface(Sense::inside, PlaneZ{hh_});
+
+    // Calculate the cone using lo and hi radii
+    real_type const lo{radii_[0]};
+    real_type const hi{radii_[1]};
+
+    // Arctangent of the opening angle of the cone (opposite / adjacent)
+    real_type const tangent = std::fabs(lo - hi) / (2 * hh_);
+
+    // Calculate vanishing point (origin)
+    real_type vanish_z = 0;
+    if (lo > hi)
+    {
+        // Cone opens downward (base is on bottom)
+        vanish_z = -hh_ + lo / tangent;
+        CELER_ASSERT(vanish_z > 0);
+    }
+    else
+    {
+        // Cone opens upward
+        vanish_z = hh_ - hi / tangent;
+        CELER_ASSERT(vanish_z < 0);
+    }
+
+    // Build the cone surface along the given axis
+    ConeZ cone{Real3{0, 0, vanish_z}, tangent};
+    insert_surface(cone);
+
+    // Set radial extents of exterior bbox
+    insert_surface(Sense::inside, make_xyradial_bbox(std::fmax(lo, hi)));
+
+    // Calculating the interior bounding box:
+    // - Represent a radial slice of the cone as a right triangle with base b
+    //   (aka the higher radius) and height h (translated vanishing point)
+    // - An interior bounding box (along the xy diagonal cut!) will satisfy
+    //   r = b - tangent * z
+    // - Maximizing the area of that box gives r = b / 2, i.e. z = h / 2
+    // - Truncate z so that it's not outside of the half-height
+    // - project that radial slice onto the xz plane by multiplying 1/sqrt(2)
+    real_type const b = std::fmax(lo, hi);
+    real_type const h = b / tangent;
+    real_type const z = std::fmin(h / 2, 2 * hh_);
+    real_type const r = b - tangent * z;
+
+    // Now convert from "triangle above z=0" to "cone centered on z=0"
+    auto const [zmin, zmax] = [&]() -> std::pair<real_type, real_type> {
+        if (lo > hi)
+            return {-hh_, -hh_ + z};  // Base is on bottom
+        else
+            return {hh_ - z, hh_};  // Base is on top
+    }();
+    CELER_ASSERT(zmin < zmax);
+    real_type const rbox = (constants::sqrt_two / 2) * r;
+    BBox const interior_bbox{{-rbox, -rbox, zmin}, {rbox, rbox, zmax}};
+
+    // Check that the corners are actually inside the cone
+    CELER_ASSERT(cone.calc_sense(interior_bbox.lower() * real_type(1 - 1e-5))
+                 == SignedSense::inside);
+    CELER_ASSERT(cone.calc_sense(interior_bbox.upper() * real_type(1 - 1e-5))
+                 == SignedSense::inside);
+    insert_surface(Sense::outside, interior_bbox);
+}
+
+//---------------------------------------------------------------------------//
+// CYLINDER
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with radius.
+ */
+Cylinder::Cylinder(real_type radius, real_type halfheight)
+    : radius_{radius}, hh_{halfheight}
+{
+    CELER_VALIDATE(radius_ > 0, << "nonpositive radius: " << radius_);
+    CELER_VALIDATE(hh_ > 0, << "nonpositive half-height: " << hh_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build surfaces.
+ */
+void Cylinder::build(ConvexSurfaceBuilder& insert_surface) const
+{
+    insert_surface(Sense::outside, PlaneZ{-hh_});
+    insert_surface(Sense::inside, PlaneZ{hh_});
+    insert_surface(CCylZ{radius_});
+}
+
+//---------------------------------------------------------------------------//
+// ELLIPSOID
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with half-widths.
+ */
+Ellipsoid::Ellipsoid(Real3 const& radii) : radii_{radii}
+{
+    for (auto ax : range(Axis::size_))
+    {
+        CELER_VALIDATE(radii_[to_int(ax)] > 0,
+                       << "nonpositive radius " << to_char(ax)
+                       << " axis: " << radii_[to_int(ax)]);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build surfaces.
+ */
+void Ellipsoid::build(ConvexSurfaceBuilder& insert_surface) const
+{
+    // Second-order coefficients are product of the other two squared radii;
+    // Zeroth-order coefficient is the product of all three squared radii
+    Real3 rsq;
+    for (auto ax : range(to_int(Axis::size_)))
+    {
+        rsq[ax] = ipow<2>(radii_[ax]);
+    }
+
+    Real3 abc{1, 1, 1};
+    real_type g = -1;
+    for (auto ax : range(to_int(Axis::size_)))
+    {
+        g *= rsq[ax];
+        for (auto nax : range(to_int(Axis::size_)))
+        {
+            if (ax != nax)
+            {
+                abc[ax] *= rsq[nax];
+            }
+        }
+    }
+
+    insert_surface(SimpleQuadric{abc, Real3{0, 0, 0}, g});
+
+    // Set exterior bbox
+    insert_surface(Sense::inside, BBox{-radii_, radii_});
+
+    // Set an interior bbox with maximum volume: a scaled inscribed cube
+    Real3 inner_radii = radii_;
+    for (real_type& r : inner_radii)
+    {
+        r *= 1 / constants::sqrt_three;
+    }
+    insert_surface(Sense::outside, BBox{-inner_radii, inner_radii});
+}
+
+//---------------------------------------------------------------------------//
 // PRISM
 //---------------------------------------------------------------------------//
 /*!
@@ -143,6 +315,26 @@ void Prism::build(ConvexSurfaceBuilder& insert_surface) const
     interior_bbox.shrink(Bound::lo, Axis::z, -hh_);
     interior_bbox.shrink(Bound::hi, Axis::z, hh_);
     insert_surface(Sense::outside, interior_bbox);
+}
+
+//---------------------------------------------------------------------------//
+// SPHERE
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with radius.
+ */
+Sphere::Sphere(real_type radius) : radius_{radius}
+{
+    CELER_VALIDATE(radius_ > 0, << "nonpositive radius: " << radius_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build surfaces.
+ */
+void Sphere::build(ConvexSurfaceBuilder& insert_surface) const
+{
+    insert_surface(SphereCentered{radius_});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/ConvexRegion.hh
+++ b/src/orange/orangeinp/ConvexRegion.hh
@@ -71,11 +71,19 @@ class Box final : public ConvexRegionInterface
 
 //---------------------------------------------------------------------------//
 /*!
- * A truncated cone along the Z axis centered on the origin.
+ * A closed cone along the Z axis centered on the origin.
  *
- * The midpoint along the Z axis of the cone is the origin. A cone is *not*
- * allowed to have equal radii: for that, use a cylinder. This, along with the
- * Cylinder, is a base component of the G4Polycone (PCON).
+ * A quadric cone technically defines two opposing cones that touch at a single
+ * vanishing point, but this cone is required to be truncated so that the
+ * vanishing point is on our outside the cone.
+ *
+ * The midpoint along the Z axis of the cone is the origin. A cone is \em not
+ * allowed to have equal radii: for that, use a cylinder. However, it \em may
+ * have a single radius of zero, which puts the vanishing point on one end of
+ * the cone.
+ *
+ * This convex region, along with the Cylinder, is a base component of the
+ * G4Polycone (PCON).
  */
 class Cone final : public ConvexRegionInterface
 {
@@ -86,7 +94,7 @@ class Cone final : public ConvexRegionInterface
     //!@}
 
   public:
-    // Construct with Z halfwidth and lo, hi radii
+    // Construct with Z half-height and lo, hi radii
     Cone(Real2 const& radii, real_type halfheight);
 
     // Build surfaces

--- a/src/orange/orangeinp/ConvexRegion.hh
+++ b/src/orange/orangeinp/ConvexRegion.hh
@@ -71,6 +71,69 @@ class Box final : public ConvexRegionInterface
 
 //---------------------------------------------------------------------------//
 /*!
+ * A truncated cone along the Z axis centered on the origin.
+ *
+ * The midpoint along the Z axis of the cone is the origin. A cone is *not*
+ * allowed to have equal radii: for that, use a cylinder. This, along with the
+ * Cylinder, is a base component of the G4Polycone (PCON).
+ */
+class Cone final : public ConvexRegionInterface
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Real2 = Array<real_type, 2>;
+    //!@}
+
+  public:
+    // Construct with Z halfwidth and lo, hi radii
+    Cone(Real2 const& radii, real_type halfheight);
+
+    // Build surfaces
+    void build(ConvexSurfaceBuilder&) const final;
+
+  private:
+    Real2 radii_;
+    real_type hh_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * A Z-aligned cylinder centered on the origin.
+ */
+class Cylinder final : public ConvexRegionInterface
+{
+  public:
+    // Construct with radius
+    Cylinder(real_type radius, real_type halfheight);
+
+    // Build surfaces
+    void build(ConvexSurfaceBuilder&) const final;
+
+  private:
+    real_type radius_;
+    real_type hh_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * An axis-alligned ellipsoid centered at the origin.
+ */
+class Ellipsoid final : public ConvexRegionInterface
+{
+  public:
+    // Construct with radius
+    explicit Ellipsoid(Real3 const& radii);
+
+    // Build surfaces
+    void build(ConvexSurfaceBuilder&) const final;
+
+  private:
+    Real3 radii_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * A regular, z-extruded polygon centered on the origin.
  *
  * This is the base component of a G4Polyhedra (PGON). The default rotation is
@@ -112,6 +175,23 @@ class Prism final : public ConvexRegionInterface
 
     // Rotational offset (0 has bottom face at -Y, 1 is congruent)
     real_type orientation_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * A sphere centered on the origin.
+ */
+class Sphere final : public ConvexRegionInterface
+{
+  public:
+    // Construct with radius
+    explicit Sphere(real_type radius);
+
+    // Build surfaces
+    void build(ConvexSurfaceBuilder&) const final;
+
+  private:
+    real_type radius_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/ConvexSurfaceBuilder.hh
+++ b/src/orange/orangeinp/ConvexSurfaceBuilder.hh
@@ -36,6 +36,15 @@ struct ConvexSurfaceState;
  * - Metadata combining the surfaces names with the object name
  * - Bounding boxes (interior and exterior)
  *
+ * Internally, this class uses:
+ * - \c SurfaceClipper to update bounding boxes for closed quadric surfaces
+ *   (axis aligned cylinders, spheres, planes)
+ * - \c apply_transform (which calls \c detail::SurfaceTransformer and its
+ *   siblings) to generate new surfaces based on the local transformed
+ *   coordinate system
+ * - \c RecursiveSimplifier to take transformed or user-input surfaces and
+ *   reduce them to more compact quadric representations
+ *
  * \todo Should we require that the user implicitly guarantee that the result
  * is convex, e.g. prohibit quadrics outside "saddle" points? What about a
  * torus, which (unless degenerate) is never convex? Or should we just require

--- a/src/orange/surf/detail/QuadricConeConverter.hh
+++ b/src/orange/surf/detail/QuadricConeConverter.hh
@@ -105,18 +105,11 @@ QuadricConeConverter::operator()(AxisTag<T>, SimpleQuadric const& sq) const
     real_type const norm = (second[to_int(U)] + second[to_int(V)]) / 2;
     real_type const tsq = -second[to_int(T)] / norm;
 
-    // Calculate origin from first-order coefficients, protecting against
-    // signed zero
+    // Calculate origin from first-order coefficients
     Real3 origin = make_array(sq.first());
-    auto divide_origin_axis_by = [&origin](Axis ax, real_type value) {
-        if (origin[to_int(ax)] != 0)
-        {
-            origin[to_int(ax)] /= value;
-        }
-    };
-    divide_origin_axis_by(T, -2 * second[to_int(T)]);
-    divide_origin_axis_by(U, -2 * norm);
-    divide_origin_axis_by(V, -2 * norm);
+    origin[to_int(T)] /= -2 * second[to_int(T)];
+    origin[to_int(U)] /= -2 * norm;
+    origin[to_int(V)] /= -2 * norm;
 
     real_type const expected_h_b = -tsq * ipow<2>(origin[to_int(T)])
                                    + ipow<2>(origin[to_int(U)])
@@ -127,6 +120,8 @@ QuadricConeConverter::operator()(AxisTag<T>, SimpleQuadric const& sq) const
         return {};
     }
 
+    // Clear potential signed zeros before returning
+    origin += real_type{0};
     return ConeAligned<T>::from_tangent_sq(origin, tsq);
 }
 

--- a/src/orange/surf/detail/QuadricConeConverter.hh
+++ b/src/orange/surf/detail/QuadricConeConverter.hh
@@ -105,11 +105,18 @@ QuadricConeConverter::operator()(AxisTag<T>, SimpleQuadric const& sq) const
     real_type const norm = (second[to_int(U)] + second[to_int(V)]) / 2;
     real_type const tsq = -second[to_int(T)] / norm;
 
-    // Calculate origin from first-order coefficients
+    // Calculate origin from first-order coefficients, protecting against
+    // signed zero
     Real3 origin = make_array(sq.first());
-    origin[to_int(T)] /= -2 * second[to_int(T)];
-    origin[to_int(U)] /= -2 * norm;
-    origin[to_int(V)] /= -2 * norm;
+    auto divide_origin_axis_by = [&origin](Axis ax, real_type value) {
+        if (origin[to_int(ax)] != 0)
+        {
+            origin[to_int(ax)] /= value;
+        }
+    };
+    divide_origin_axis_by(T, -2 * second[to_int(T)]);
+    divide_origin_axis_by(U, -2 * norm);
+    divide_origin_axis_by(V, -2 * norm);
 
     real_type const expected_h_b = -tsq * ipow<2>(origin[to_int(T)])
                                    + ipow<2>(origin[to_int(U)])

--- a/src/orange/surf/detail/QuadricCylConverter.hh
+++ b/src/orange/surf/detail/QuadricCylConverter.hh
@@ -120,6 +120,9 @@ QuadricCylConverter::operator()(AxisTag<T>, SimpleQuadric const& sq) const
         // No real solution
         return {};
     }
+
+    // Clear potential signed zeros before returning
+    origin += real_type{0};
     return CylAligned<T>::from_radius_sq(origin, radius_sq);
 }
 

--- a/src/orange/surf/detail/QuadricSphereConverter.hh
+++ b/src/orange/surf/detail/QuadricSphereConverter.hh
@@ -103,6 +103,9 @@ QuadricSphereConverter::operator()(SimpleQuadric const& sq) const
         // No real solution
         return {};
     }
+
+    // Clear potential signed zeros before returning
+    origin += real_type{0};
     return Sphere::from_radius_sq(origin, radius_sq);
 }
 

--- a/test/orange/orangeinp/ConvexRegion.test.cc
+++ b/test/orange/orangeinp/ConvexRegion.test.cc
@@ -320,7 +320,7 @@ TEST_F(CylinderTest, transformed)
 
     static char const expected_node[] = "all(-0, +1, -2)";
     static char const* const expected_surfaces[]
-        = {"Plane: y=0.9", "Plane: y=-0.9", "Cyl y: r=0.75 at x=-0, z=1"};
+        = {"Plane: y=0.9", "Plane: y=-0.9", "Cyl y: r=0.75 at x=0, z=1"};
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);

--- a/test/orange/orangeinp/ConvexRegion.test.cc
+++ b/test/orange/orangeinp/ConvexRegion.test.cc
@@ -143,6 +143,226 @@ TEST_F(BoxTest, standard)
 }
 
 //---------------------------------------------------------------------------//
+// CONE
+//---------------------------------------------------------------------------//
+using ConeTest = ConvexRegionTest;
+
+TEST_F(ConeTest, errors)
+{
+    EXPECT_THROW(Cone({1.0, 1.0}, 0.5), RuntimeError);
+    EXPECT_THROW(Cone({-1, 1}, 1), RuntimeError);
+    EXPECT_THROW(Cone({0.5, 1}, 0), RuntimeError);
+}
+
+TEST_F(ConeTest, upward)
+{
+    auto result = this->test(Cone({1.5, 0}, 0.5));  // Lower r=1.5, height 1
+
+    static char const expected_node[] = "all(+0, -1, -2)";
+    static char const* const expected_surfaces[]
+        = {"Plane: z=-0.5", "Plane: z=0.5", "Cone z: t=1.5 at {0,0,0.5}"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ((Real3{-0.53033008588991, -0.53033008588991, -0.5}),
+                       result.interior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{0.53033008588991, 0.53033008588991, 0}),
+                       result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-1.5, -1.5, -0.5}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{1.5, 1.5, 0.5}), result.exterior.upper());
+}
+
+TEST_F(ConeTest, downward)
+{
+    auto result = this->test(Cone({0, 1.2}, 1.3 / 2));
+
+    static char const expected_node[] = "all(+0, -1, -2)";
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-0.65", "Plane: z=0.65", "Cone z: t=0.92308 at {0,0,-0.65}"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ((Real3{-0.42426406871193, -0.42426406871193, 0}),
+                       result.interior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{0.42426406871193, 0.42426406871193, 0.65}),
+                       result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-1.2, -1.2, -0.65}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{1.2, 1.2, 0.65}), result.exterior.upper());
+}
+
+TEST_F(ConeTest, truncated)
+{
+    auto result = this->test(Cone({0.5, 1.5}, 0.5));
+
+    static char const expected_node[] = "all(+0, -1, -2)";
+    static char const* const expected_surfaces[]
+        = {"Plane: z=-0.5", "Plane: z=0.5", "Cone z: t=1 at {0,0,-1}"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ((Real3{-0.53033008588991, -0.53033008588991, -0.25}),
+                       result.interior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{0.53033008588991, 0.53033008588991, 0.5}),
+                       result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-1.5, -1.5, -0.5}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{1.5, 1.5, 0.5}), result.exterior.upper());
+}
+
+TEST_F(ConeTest, almost_cyl)
+{
+    auto result = this->test(Cone({0.55, 0.45}, 10.0));
+
+    static char const expected_node[] = "all(+0, -1, -2)";
+    static char const* const expected_surfaces[]
+        = {"Plane: z=-10", "Plane: z=10", "Cone z: t=0.005 at {0,0,100}"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ((Real3{-0.31819805153395, -0.31819805153395, -10}),
+                       result.interior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{0.31819805153395, 0.31819805153395, 10}),
+                       result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-0.55, -0.55, -10}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{0.55, 0.55, 10}), result.exterior.upper());
+}
+
+TEST_F(ConeTest, translated)
+{
+    auto result = this->test(Cone({1.0, 0.5}, 2.0), Translation{{1, 2, 3}});
+
+    static char const expected_node[] = "all(+0, -1, -2)";
+    static char const* const expected_surfaces[]
+        = {"Plane: z=1", "Plane: z=5", "Cone z: t=0.125 at {1,2,9}"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ((Real3{0.64644660940673, 1.6464466094067, 1}),
+                       result.interior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{1.3535533905933, 2.3535533905933, 5}),
+                       result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{0, 1, 1}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{2, 3, 5}), result.exterior.upper());
+}
+
+TEST_F(ConeTest, transformed)
+{
+    auto result = this->test(
+        Cone({1.0, 0.5}, 2.0),
+        Transformation{make_rotation(Axis::z, Turn{0.125}),  // 45deg
+                       Real3{0, 0, 2.0}});
+
+    static char const expected_node[] = "all(+0, -1, -2)";
+    static char const* const expected_surfaces[]
+        = {"Plane: z=0", "Plane: z=4", "Cone z: t=0.125 at {0,0,8}"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ((Real3{-0.5, -0.5, 0}), result.interior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{0.5, 0.5, 4}), result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-1.4142135623731, -1.4142135623731, 0}),
+                       result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{1.4142135623731, 1.4142135623731, 4}),
+                       result.exterior.upper());
+}
+
+//---------------------------------------------------------------------------//
+// CYLINDER
+//---------------------------------------------------------------------------//
+using CylinderTest = ConvexRegionTest;
+
+TEST_F(CylinderTest, errors)
+{
+    EXPECT_THROW(Cylinder(0.0, 1.0), RuntimeError);
+    EXPECT_THROW(Cylinder(1.0, -1.0), RuntimeError);
+}
+
+TEST_F(CylinderTest, standard)
+{
+    auto result = this->test(Cylinder(0.75, 0.9));
+
+    static char const expected_node[] = "all(+0, -1, -2)";
+    static char const* const expected_surfaces[]
+        = {"Plane: z=-0.9", "Plane: z=0.9", "Cyl z: r=0.75"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ((Real3{-0.53033008588991, -0.53033008588991, -0.9}),
+                       result.interior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{0.53033008588991, 0.53033008588991, 0.9}),
+                       result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-0.75, -0.75, -0.9}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{0.75, 0.75, 0.9}), result.exterior.upper());
+}
+
+TEST_F(CylinderTest, translated)
+{
+    auto result = this->test(Cylinder(0.75, 0.9), Translation{{1, 2, 3}});
+
+    static char const expected_node[] = "all(+0, -1, -2)";
+    static char const* const expected_surfaces[]
+        = {"Plane: z=2.1", "Plane: z=3.9", "Cyl z: r=0.75 at x=1, y=2"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ((Real3{0.46966991411009, 1.4696699141101, 2.1}),
+                       result.interior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{1.5303300858899, 2.5303300858899, 3.9}),
+                       result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{0.25, 1.25, 2.1}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{1.75, 2.75, 3.9}), result.exterior.upper());
+}
+
+TEST_F(CylinderTest, transformed)
+{
+    auto result = this->test(
+        Cylinder(0.75, 0.9),
+        Transformation{make_rotation(Axis::x, Turn{0.25}), Real3{0, 0, 1.0}});
+
+    static char const expected_node[] = "all(-0, +1, -2)";
+    static char const* const expected_surfaces[]
+        = {"Plane: y=0.9", "Plane: y=-0.9", "Cyl y: r=0.75 at x=-0, z=1"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ((Real3{-0.53033008588991, -0.9, 0.46966991411009}),
+                       result.interior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{0.53033008588991, 0.9, 1.5303300858899}),
+                       result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-0.75, -0.9, 0.25}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{0.75, 0.9, 1.75}), result.exterior.upper());
+}
+
+//---------------------------------------------------------------------------//
+// ELLIPSOID
+//---------------------------------------------------------------------------//
+using EllipsoidTest = ConvexRegionTest;
+
+TEST_F(EllipsoidTest, errors)
+{
+    EXPECT_THROW(Ellipsoid({1, 0, 2}), RuntimeError);
+}
+
+TEST_F(EllipsoidTest, standard)
+{
+    auto result = this->test(Ellipsoid({3, 2, 1}));
+
+    static char const expected_node[] = "-0";
+    static char const* const expected_surfaces[]
+        = {"SQuadric: {4,9,36} {0,0,0} -36"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ(
+        (Real3{-1.7320508075688776, -1.1547005383792517, -0.57735026918962584}),
+        result.interior.lower());
+    EXPECT_VEC_SOFT_EQ(
+        (Real3{1.7320508075688776, 1.1547005383792517, 0.57735026918962584}),
+        result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-3, -2, -1}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{3, 2, 1}), result.exterior.upper());
+}
+
+//---------------------------------------------------------------------------//
 // PRISM
 //---------------------------------------------------------------------------//
 using PrismTest = ConvexRegionTest;
@@ -262,6 +482,35 @@ TEST_F(PrismTest, rhex)
     EXPECT_VEC_SOFT_EQ((Real3{-1, -1.1547005383793, -2}),
                        result.exterior.lower());
     EXPECT_VEC_SOFT_EQ((Real3{1, 1.1547005383793, 2}), result.exterior.upper());
+}
+
+//---------------------------------------------------------------------------//
+// SPHERE
+//---------------------------------------------------------------------------//
+using SphereTest = ConvexRegionTest;
+
+TEST_F(SphereTest, errors)
+{
+    EXPECT_THROW(Sphere(-1), RuntimeError);
+}
+
+TEST_F(SphereTest, standard)
+{
+    auto result = this->test(Sphere(2.0));
+
+    static char const expected_node[] = "-0";
+    static char const* const expected_surfaces[] = {"Sphere: r=2"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_VEC_SOFT_EQ(
+        (Real3{-1.7320508075689, -1.7320508075689, -1.7320508075689}),
+        result.interior.lower());
+    EXPECT_VEC_SOFT_EQ(
+        (Real3{1.7320508075689, 1.7320508075689, 1.7320508075689}),
+        result.interior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-2, -2, -2}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{2, 2, 2}), result.exterior.upper());
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Follow-on to #1119.  This implements:
- Cone
- Cylinder
- Ellipsoid
- Sphere

There is a bugfix in the deduplication code (adding `+ 0.0` to clear any potential negative zero flag) to prevent simplified surfaces from having negative zeroes. This will make output more robust and hopefully do the same if `-ffast-math` is enabled.