### PR TITLE
Add JSON output for CSG objects

### DIFF
--- a/src/corecel/cont/SpanIO.json.hh
+++ b/src/corecel/cont/SpanIO.json.hh
@@ -1,0 +1,31 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/cont/SpanIO.json.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "Span.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Write a span to a JSON file.
+ */
+template<class T, std::size_t N>
+void to_json(nlohmann::json& j, Span<T, N> const& value)
+{
+    j = nlohmann::json::array();
+    for (std::size_t i = 0; i != value.size(); ++i)
+    {
+        j.push_back(value[i]);
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/io/JsonPimpl.hh
+++ b/src/corecel/io/JsonPimpl.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "celeritas_config.h"
+#include "corecel/Assert.hh"
 
 #if CELERITAS_USE_JSON
 #    include <nlohmann/json.hpp>
@@ -41,6 +42,23 @@ struct JsonPimpl
     JsonPimpl() = delete;
 #endif
 };
+
+//---------------------------------------------------------------------------//
+/*!
+ * Helper function to write an object to JSON.
+ *
+ * This hides the "not configured" boilerplate.
+ */
+template<class T>
+void to_json_pimpl(JsonPimpl* jp, T const& self)
+{
+#if CELERITAS_USE_JSON
+    CELER_EXPECT(jp);
+    to_json(jp->obj, self);
+#else
+    CELER_NOT_CONFIGURED("JSON");
+#endif
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -67,6 +67,7 @@ if(CELERITAS_USE_JSON)
     OrangeInputIO.json.cc
     detail/OrangeInputIOImpl.json.cc
     orangeinp/CsgTreeIO.json.cc
+    orangeinp/ObjectIO.json.cc
   )
   list(APPEND PRIVATE_DEPS nlohmann_json::nlohmann_json)
 endif()

--- a/src/orange/OrangeTypes.cc
+++ b/src/orange/OrangeTypes.cc
@@ -109,6 +109,20 @@ char const* to_cstring(SurfaceType value)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get a string corresponding to a transform type.
+ */
+char const* to_cstring(TransformType value)
+{
+    static EnumStringMapper<TransformType> const to_cstring_impl{
+        "no_transformation",
+        "translation",
+        "transformation",
+    };
+    return to_cstring_impl(value);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Get a printable character corresponding to a z ordering.
  */
 char to_char(ZOrder zo)

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -444,6 +444,9 @@ inline constexpr char to_char(Sense s)
 // Get a string corresponding to a surface type
 char const* to_cstring(SurfaceType);
 
+// Get a string corresponding to a transform type
+char const* to_cstring(TransformType);
+
 // Get a string corresponding to a surface state
 inline char const* to_cstring(SurfaceState s)
 {

--- a/src/orange/orangeinp/ConvexRegion.cc
+++ b/src/orange/orangeinp/ConvexRegion.cc
@@ -11,6 +11,7 @@
 
 #include "corecel/Constants.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/io/JsonPimpl.hh"
 #include "geocel/BoundingBox.hh"
 #include "geocel/Types.hh"
 #include "orange/surf/ConeAligned.hh"
@@ -20,6 +21,10 @@
 #include "orange/surf/SphereCentered.hh"
 
 #include "ConvexSurfaceBuilder.hh"
+
+#if CELERITAS_USE_JSON
+#    include "ObjectIO.json.hh"
+#endif
 
 namespace celeritas
 {
@@ -73,6 +78,15 @@ void Box::build(ConvexSurfaceBuilder& insert_surface) const
     insert_surface(Sense::inside, PlaneY{hw_[Y]});
     insert_surface(Sense::outside, PlaneZ{-hw_[Z]});
     insert_surface(Sense::inside, PlaneZ{hw_[Z]});
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void Box::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
 }
 
 //---------------------------------------------------------------------------//
@@ -168,6 +182,15 @@ void Cone::build(ConvexSurfaceBuilder& insert_surface) const
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void Cone::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
+}
+
+//---------------------------------------------------------------------------//
 // CYLINDER
 //---------------------------------------------------------------------------//
 /*!
@@ -189,6 +212,15 @@ void Cylinder::build(ConvexSurfaceBuilder& insert_surface) const
     insert_surface(Sense::outside, PlaneZ{-hh_});
     insert_surface(Sense::inside, PlaneZ{hh_});
     insert_surface(CCylZ{radius_});
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void Cylinder::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
 }
 
 //---------------------------------------------------------------------------//
@@ -247,6 +279,15 @@ void Ellipsoid::build(ConvexSurfaceBuilder& insert_surface) const
         r *= 1 / constants::sqrt_three;
     }
     insert_surface(Sense::outside, BBox{-inner_radii, inner_radii});
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void Ellipsoid::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
 }
 
 //---------------------------------------------------------------------------//
@@ -320,6 +361,15 @@ void Prism::build(ConvexSurfaceBuilder& insert_surface) const
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void Prism::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
+}
+
+//---------------------------------------------------------------------------//
 // SPHERE
 //---------------------------------------------------------------------------//
 /*!
@@ -337,6 +387,15 @@ Sphere::Sphere(real_type radius) : radius_{radius}
 void Sphere::build(ConvexSurfaceBuilder& insert_surface) const
 {
     insert_surface(SphereCentered{radius_});
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void Sphere::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/ConvexRegion.hh
+++ b/src/orange/orangeinp/ConvexRegion.hh
@@ -65,6 +65,11 @@ class Box final : public ConvexRegionInterface
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
 
+    //// ACCESSORS ////
+
+    //! Half-width for each axis
+    Real3 const& halfwidths() const { return hw_; }
+
   private:
     Real3 hw_;
 };
@@ -100,6 +105,14 @@ class Cone final : public ConvexRegionInterface
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
 
+    //// ACCESSORS ////
+
+    //! Lower and upper radii
+    Real2 const& radii() const { return radii_; }
+
+    //! Half-height along Z
+    real_type halfheight() const { return hh_; }
+
   private:
     Real2 radii_;
     real_type hh_;
@@ -118,6 +131,14 @@ class Cylinder final : public ConvexRegionInterface
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
 
+    //// ACCESSORS ////
+
+    //! Radius
+    real_type radius() const { return radius_; }
+
+    //! Half-height along Z
+    real_type halfheight() const { return hh_; }
+
   private:
     real_type radius_;
     real_type hh_;
@@ -135,6 +156,11 @@ class Ellipsoid final : public ConvexRegionInterface
 
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
+
+    //// ACCESSORS ////
+
+    //! Radius along each axis
+    Real3 const& radii() const { return radii_; }
 
   private:
     Real3 radii_;
@@ -171,6 +197,17 @@ class Prism final : public ConvexRegionInterface
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
 
+    //// ACCESSORS ////
+
+    //! Number of sides
+    int num_sides() const { return num_sides_; }
+    //! Inner radius
+    real_type apothem() const { return apothem_; }
+    //! Half the Z height
+    real_type halfheight() const { return hh_; }
+    //! Rotation factor
+    real_type orientation() const { return orientation_; }
+
   private:
     // Number of sides
     int num_sides_;
@@ -197,6 +234,11 @@ class Sphere final : public ConvexRegionInterface
 
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
+
+    //// ACCESSORS ////
+
+    //! Radius
+    real_type radius() const { return radius_; }
 
   private:
     real_type radius_;

--- a/src/orange/orangeinp/ConvexRegion.hh
+++ b/src/orange/orangeinp/ConvexRegion.hh
@@ -14,6 +14,8 @@
 
 namespace celeritas
 {
+struct JsonPimpl;
+
 namespace orangeinp
 {
 class ConvexSurfaceBuilder;
@@ -43,6 +45,9 @@ class ConvexRegionInterface
     //! Construct surfaces that are AND-ed into this region
     virtual void build(ConvexSurfaceBuilder&) const = 0;
 
+    //! Write the region to a JSON object
+    virtual void output(JsonPimpl*) const = 0;
+
   protected:
     //!@{
     //! Allow construction and assignment only through daughter classes
@@ -64,6 +69,9 @@ class Box final : public ConvexRegionInterface
 
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
+
+    // Output to JSON
+    void output(JsonPimpl*) const final;
 
     //// ACCESSORS ////
 
@@ -105,6 +113,9 @@ class Cone final : public ConvexRegionInterface
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
 
+    // Output to JSON
+    void output(JsonPimpl*) const final;
+
     //// ACCESSORS ////
 
     //! Lower and upper radii
@@ -131,6 +142,9 @@ class Cylinder final : public ConvexRegionInterface
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
 
+    // Output to JSON
+    void output(JsonPimpl*) const final;
+
     //// ACCESSORS ////
 
     //! Radius
@@ -156,6 +170,9 @@ class Ellipsoid final : public ConvexRegionInterface
 
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
+
+    // Output to JSON
+    void output(JsonPimpl*) const final;
 
     //// ACCESSORS ////
 
@@ -197,6 +214,9 @@ class Prism final : public ConvexRegionInterface
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
 
+    // Output to JSON
+    void output(JsonPimpl*) const final;
+
     //// ACCESSORS ////
 
     //! Number of sides
@@ -234,6 +254,9 @@ class Sphere final : public ConvexRegionInterface
 
     // Build surfaces
     void build(ConvexSurfaceBuilder&) const final;
+
+    // Output to JSON
+    void output(JsonPimpl*) const final;
 
     //// ACCESSORS ////
 

--- a/src/orange/orangeinp/CsgObject.cc
+++ b/src/orange/orangeinp/CsgObject.cc
@@ -9,8 +9,14 @@
 
 #include <utility>
 
+#include "corecel/io/JsonPimpl.hh"
+
 #include "detail/CsgUnitBuilder.hh"
 #include "detail/VolumeBuilder.hh"
+
+#if CELERITAS_USE_JSON
+#    include "ObjectIO.json.hh"
+#endif
 
 namespace celeritas
 {
@@ -47,6 +53,15 @@ NodeId NegatedObject::build(VolumeBuilder& vb) const
     auto daughter_id = obj_->build(vb);
     // Add the new region (or anti-region)
     return vb.insert_region(Label{label_}, Negated{daughter_id});
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Output to JSON.
+ */
+void NegatedObject::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
 }
 
 //---------------------------------------------------------------------------//
@@ -89,6 +104,16 @@ NodeId JoinObjects<Op>::build(VolumeBuilder& vb) const
 
     // Add the combined region
     return vb.insert_region(Label{label_}, Joined{op_token, std::move(nodes)});
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Output to JSON.
+ */
+template<OperatorToken Op>
+void JoinObjects<Op>::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/CsgObject.hh
+++ b/src/orange/orangeinp/CsgObject.hh
@@ -39,6 +39,9 @@ class NegatedObject : public ObjectInterface
     // Construct a volume from this object
     NodeId build(VolumeBuilder&) const final;
 
+    // Write the object to JSON
+    void output(JsonPimpl*) const final;
+
   private:
     std::string label_;
     SPConstObject obj_;
@@ -74,6 +77,9 @@ class JoinObjects : public ObjectInterface
 
     // Construct a volume from this object
     NodeId build(VolumeBuilder&) const final;
+
+    // Write the object to JSON
+    void output(JsonPimpl*) const final;
 
   private:
     std::string label_;

--- a/src/orange/orangeinp/CsgObject.hh
+++ b/src/orange/orangeinp/CsgObject.hh
@@ -30,6 +30,9 @@ class NegatedObject : public ObjectInterface
     // Construct with a name and object
     NegatedObject(std::string&& label, SPConstObject obj);
 
+    //! Access the daughter object
+    SPConstObject const& daughter() const { return obj_; }
+
     //! Get the user-provided label
     std::string_view label() const final { return label_; }
 

--- a/src/orange/orangeinp/ObjectIO.json.cc
+++ b/src/orange/orangeinp/ObjectIO.json.cc
@@ -1,0 +1,180 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/ObjectIO.json.cc
+//---------------------------------------------------------------------------//
+#include "ObjectIO.json.hh"
+
+#include <memory>
+
+#include "corecel/cont/ArrayIO.json.hh"
+#include "corecel/cont/SpanIO.json.hh"
+#include "corecel/io/JsonPimpl.hh"
+
+#include "ConvexRegion.hh"
+#include "CsgObject.hh"
+#include "ObjectInterface.hh"
+#include "Shape.hh"
+#include "Transformed.hh"
+
+#define SIO_ATTR_PAIR(OBJ, ATTR) \
+    {                            \
+        #ATTR, OBJ.ATTR()        \
+    }
+
+namespace nlohmann
+{
+//---------------------------------------------------------------------------//
+// Support serialization of shared pointers to ORANGE objects
+using SPObjConst = std::shared_ptr<celeritas::orangeinp::ObjectInterface const>;
+using VarTransform = celeritas::VariantTransform;
+
+template<>
+struct adl_serializer<SPObjConst>
+{
+    static void to_json(json& j, SPObjConst const& oi)
+    {
+        if (oi)
+        {
+            celeritas::JsonPimpl json_wrap;
+            oi->output(&json_wrap);
+            j = std::move(json_wrap.obj);
+        }
+        else
+        {
+            j = nullptr;
+        }
+    }
+};
+
+template<>
+struct adl_serializer<VarTransform>
+{
+    static void to_json(json& j, VarTransform const& vt)
+    {
+        std::visit(
+            [&j](auto&& tr) {
+                j = {{"_type", to_cstring(tr.transform_type())},
+                     {"data", tr.data()}};
+            },
+            vt);
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace nlohmann
+
+namespace celeritas
+{
+namespace orangeinp
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+//! Get a user-facing string for a Joined type
+char const* to_type_str(OperatorToken Op)
+{
+    return Op == op_and ? "all" : Op == op_or ? "any" : "<error>";
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get a JSON string representing an object.
+ *
+ * \see ObjectInterface.hh
+ */
+std::string to_string(ObjectInterface const& obj)
+{
+    JsonPimpl json_wrap;
+    obj.output(&json_wrap);
+    return json_wrap.obj.dump();
+}
+
+//---------------------------------------------------------------------------//
+//!@{
+//! Write objects to JSON
+template<OperatorToken Op>
+void to_json(nlohmann::json& j, JoinObjects<Op> const& obj)
+{
+    j = {{"_type", to_type_str(Op)},
+         SIO_ATTR_PAIR(obj, label),
+         SIO_ATTR_PAIR(obj, daughters)};
+}
+template void to_json(nlohmann::json&, JoinObjects<op_and> const&);
+template void to_json(nlohmann::json&, JoinObjects<op_or> const&);
+
+void to_json(nlohmann::json& j, NegatedObject const& obj)
+{
+    j = {{"_type", "negated"},
+         SIO_ATTR_PAIR(obj, label),
+         SIO_ATTR_PAIR(obj, daughter)};
+}
+
+void to_json(nlohmann::json& j, ShapeBase const& obj)
+{
+    j = {{"_type", "shape"},
+         SIO_ATTR_PAIR(obj, label),
+         SIO_ATTR_PAIR(obj, interior)};
+}
+
+void to_json(nlohmann::json& j, Transformed const& obj)
+{
+    j = {{"_type", "transformed"},
+         /* no label needed */
+         SIO_ATTR_PAIR(obj, daughter),
+         SIO_ATTR_PAIR(obj, transform)};
+}
+//!@}
+
+//---------------------------------------------------------------------------//
+//!@{
+//! Write convex regions to JSON
+void to_json(nlohmann::json& j, ConvexRegionInterface const& cr)
+{
+    celeritas::JsonPimpl json_wrap;
+    cr.output(&json_wrap);
+    j = std::move(json_wrap.obj);
+}
+
+void to_json(nlohmann::json& j, Box const& cr)
+{
+    j = {{"_type", "box"}, SIO_ATTR_PAIR(cr, halfwidths)};
+}
+void to_json(nlohmann::json& j, Cone const& cr)
+{
+    j = {{"_type", "cone"},
+         SIO_ATTR_PAIR(cr, radii),
+         SIO_ATTR_PAIR(cr, halfheight)};
+}
+void to_json(nlohmann::json& j, Cylinder const& cr)
+{
+    j = {{"_type", "cylinder"},
+         SIO_ATTR_PAIR(cr, radius),
+         SIO_ATTR_PAIR(cr, halfheight)};
+}
+void to_json(nlohmann::json& j, Ellipsoid const& cr)
+{
+    j = {{"_type", "ellipsoid"}, SIO_ATTR_PAIR(cr, radii)};
+}
+void to_json(nlohmann::json& j, Prism const& cr)
+{
+    j = {{"_type", "prism"},
+         SIO_ATTR_PAIR(cr, num_sides),
+         SIO_ATTR_PAIR(cr, apothem),
+         SIO_ATTR_PAIR(cr, halfheight),
+         SIO_ATTR_PAIR(cr, orientation)};
+}
+void to_json(nlohmann::json& j, Sphere const& cr)
+{
+    j = {{"_type", "sphere"}, SIO_ATTR_PAIR(cr, radius)};
+}
+//!@}
+
+//---------------------------------------------------------------------------//
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/src/orange/orangeinp/ObjectIO.json.hh
+++ b/src/orange/orangeinp/ObjectIO.json.hh
@@ -1,0 +1,58 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/ObjectIO.json.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "CsgTypes.hh"
+
+namespace celeritas
+{
+namespace orangeinp
+{
+//---------------------------------------------------------------------------//
+class ObjectInterface;
+
+template<OperatorToken Op>
+class JoinObjects;
+class NegatedObject;
+class ShapeBase;
+class Transformed;
+
+class ConvexRegionInterface;
+class Box;
+class Cone;
+class Cylinder;
+class Ellipsoid;
+class Prism;
+class Sphere;
+
+//---------------------------------------------------------------------------//
+
+// Dump an object to a string
+std::string to_string(ObjectInterface const&);
+
+// Write objects to JSON
+template<OperatorToken Op>
+void to_json(nlohmann::json& j, JoinObjects<Op> const& sb);
+void to_json(nlohmann::json& j, NegatedObject const& sb);
+void to_json(nlohmann::json& j, ShapeBase const& sb);
+void to_json(nlohmann::json& j, Transformed const& sb);
+
+// Write convex regions to JSON
+void to_json(nlohmann::json& j, ConvexRegionInterface const& cr);
+void to_json(nlohmann::json& j, Box const& cr);
+void to_json(nlohmann::json& j, Cone const& cr);
+void to_json(nlohmann::json& j, Cylinder const& cr);
+void to_json(nlohmann::json& j, Ellipsoid const& cr);
+void to_json(nlohmann::json& j, Prism const& cr);
+void to_json(nlohmann::json& j, Sphere const& cr);
+
+//---------------------------------------------------------------------------//
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/src/orange/orangeinp/ObjectInterface.hh
+++ b/src/orange/orangeinp/ObjectInterface.hh
@@ -8,16 +8,21 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <string_view>
 
+#include "celeritas_config.h"
 #include "corecel/Macros.hh"
 
 #include "CsgTypes.hh"
 
 namespace celeritas
 {
+struct JsonPimpl;
+
 namespace orangeinp
 {
+//---------------------------------------------------------------------------//
 namespace detail
 {
 class VolumeBuilder;
@@ -43,6 +48,9 @@ class ObjectInterface
     //! Construct a volume from this object
     virtual NodeId build(VolumeBuilder&) const = 0;
 
+    //! Write the region to a JSON object
+    virtual void output(JsonPimpl*) const = 0;
+
   protected:
     //!@{
     //! Allow construction and assignment only through daughter classes
@@ -51,6 +59,18 @@ class ObjectInterface
     CELER_DEFAULT_COPY_MOVE(ObjectInterface);
     //!@}
 };
+
+//---------------------------------------------------------------------------//
+// Get a JSON string representing an object
+std::string to_string(ObjectInterface const&);
+
+#if !CELERITAS_USE_JSON
+//! If JSON is unavailable, print a string. Otherwise, use ObjectIO.json.cc.
+inline std::string to_string(ObjectInterface const&)
+{
+    return "\"output unavailable\"";
+}
+#endif
 
 //---------------------------------------------------------------------------//
 }  // namespace orangeinp

--- a/src/orange/orangeinp/Shape.cc
+++ b/src/orange/orangeinp/Shape.cc
@@ -32,7 +32,7 @@ NodeId ShapeBase::build(VolumeBuilder& vb) const
 
     // Construct surfaces
     auto sb = ConvexSurfaceBuilder(&vb.unit_builder(), &css);
-    this->build_interior(sb);
+    this->interior().build(sb);
 
     // Intersect the given surfaces to create a new CSG node
     return vb.insert_region(Label{std::move(css.object_name)},

--- a/src/orange/orangeinp/Shape.cc
+++ b/src/orange/orangeinp/Shape.cc
@@ -7,12 +7,18 @@
 //---------------------------------------------------------------------------//
 #include "Shape.hh"
 
+#include "corecel/io/JsonPimpl.hh"
+
 #include "ConvexSurfaceBuilder.hh"
 #include "CsgTreeUtils.hh"
 
 #include "detail/ConvexSurfaceState.hh"
 #include "detail/CsgUnitBuilder.hh"
 #include "detail/VolumeBuilder.hh"
+
+#if CELERITAS_USE_JSON
+#    include "ObjectIO.json.hh"
+#endif
 
 namespace celeritas
 {
@@ -38,6 +44,15 @@ NodeId ShapeBase::build(VolumeBuilder& vb) const
     return vb.insert_region(Label{std::move(css.object_name)},
                             Joined{op_and, std::move(css.nodes)},
                             calc_merged_bzone(css));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Output to JSON.
+ */
+void ShapeBase::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/Shape.hh
+++ b/src/orange/orangeinp/Shape.hh
@@ -39,6 +39,9 @@ class ShapeBase : public ObjectInterface
     // Construct a volume from this object
     NodeId build(VolumeBuilder&) const final;
 
+    // Write the shape to JSON
+    void output(JsonPimpl*) const final;
+
     //! Interior convex region interface for construction and access
     virtual ConvexRegionInterface const& interior() const = 0;
 

--- a/src/orange/orangeinp/Shape.hh
+++ b/src/orange/orangeinp/Shape.hh
@@ -39,6 +39,9 @@ class ShapeBase : public ObjectInterface
     // Construct a volume from this object
     NodeId build(VolumeBuilder&) const final;
 
+    //! Interior convex region interface for construction and access
+    virtual ConvexRegionInterface const& interior() const = 0;
+
   protected:
     //!@{
     //! Allow construction and assignment only through daughter classes
@@ -46,9 +49,6 @@ class ShapeBase : public ObjectInterface
     virtual ~ShapeBase() = default;
     CELER_DEFAULT_COPY_MOVE(ShapeBase);
     //!@}
-
-    //! Daughter class interface
-    virtual void build_interior(ConvexSurfaceBuilder&) const = 0;
 };
 
 //---------------------------------------------------------------------------//
@@ -86,11 +86,8 @@ class Shape final : public ShapeBase
     //! Get the user-provided label
     std::string_view label() const final { return label_; }
 
-    //! Forward the construction call to the convex region
-    void build_interior(ConvexSurfaceBuilder& csb) const final
-    {
-        return region_.build(csb);
-    }
+    //! Interior convex region
+    ConvexRegionInterface const& interior() const final { return region_; }
 
   private:
     std::string label_;

--- a/src/orange/orangeinp/Transformed.cc
+++ b/src/orange/orangeinp/Transformed.cc
@@ -7,8 +7,14 @@
 //---------------------------------------------------------------------------//
 #include "Transformed.hh"
 
+#include "corecel/io/JsonPimpl.hh"
+
 #include "detail/CsgUnitBuilder.hh"
 #include "detail/VolumeBuilder.hh"
+
+#if CELERITAS_USE_JSON
+#    include "ObjectIO.json.hh"
+#endif
 
 namespace celeritas
 {
@@ -20,6 +26,8 @@ namespace orangeinp
  *
  * The input transform should *not* be "no transform" because that would be
  * silly.
+ *
+ * TODO: require that the input is simplified as well?
  */
 Transformed::Transformed(SPConstObject obj, VariantTransform&& transform)
     : obj_{std::move(obj)}, transform_{std::move(transform)}
@@ -38,6 +46,15 @@ NodeId Transformed::build(VolumeBuilder& vb) const
     // Apply the transform through the life of this object
     auto scoped_transform = vb.make_scoped_transform(transform_);
     return obj_->build(vb);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Output to JSON.
+ */
+void Transformed::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/Transformed.hh
+++ b/src/orange/orangeinp/Transformed.hh
@@ -25,6 +25,12 @@ class Transformed final : public ObjectInterface
     // Construct with daughter object and transform
     Transformed(SPConstObject obj, VariantTransform&& transform);
 
+    //! Access the daughter object
+    SPConstObject const& daughter() const { return obj_; }
+
+    //! Access the transform
+    VariantTransform const& transform() const { return transform_; }
+
     //! Get the user-provided label
     std::string_view label() const final { return obj_->label(); }
 

--- a/src/orange/orangeinp/Transformed.hh
+++ b/src/orange/orangeinp/Transformed.hh
@@ -37,6 +37,9 @@ class Transformed final : public ObjectInterface
     // Construct a volume from this object
     NodeId build(VolumeBuilder&) const final;
 
+    // Write the object to JSON
+    void output(JsonPimpl*) const final;
+
   private:
     SPConstObject obj_;
     VariantTransform transform_;

--- a/test/orange/orangeinp/ConvexRegion.test.cc
+++ b/test/orange/orangeinp/ConvexRegion.test.cc
@@ -8,6 +8,7 @@
 #include "orange/orangeinp/ConvexRegion.hh"
 
 #include "orange/BoundingBoxUtils.hh"
+#include "orange/MatrixUtils.hh"
 #include "orange/orangeinp/ConvexSurfaceBuilder.hh"
 #include "orange/orangeinp/CsgTreeUtils.hh"
 #include "orange/orangeinp/detail/ConvexSurfaceState.hh"

--- a/test/orange/orangeinp/Shape.test.cc
+++ b/test/orange/orangeinp/Shape.test.cc
@@ -139,6 +139,13 @@ TEST_F(ShapeTest, multiple)
     {
         EXPECT_JSON_EQ(expected_tree_string, tree_string(u));
     }
+
+    if (CELERITAS_USE_JSON)
+    {
+        EXPECT_JSON_EQ(
+            R"json({"_type":"shape","interior":{"_type":"box","halfwidths":[1.0,1.0,2.0]},"label":"box"})json",
+            to_string(BoxShape{"box", Real3{1, 1, 2}}));
+    }
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
CHAINED on #1130.

Example:
```json
{
  "_type": "all",
  "daughters": [
    {
      "_type": "shape",
      "interior": {
        "_type": "cone",
        "halfheight": 2.0,
        "radii": [
          1.0,
          0.5
        ]
      },
      "label": "cone"
    },
    {
      "_type": "transformed",
      "daughter": {
        "_type": "shape",
        "interior": {
          "_type": "cylinder",
          "halfheight": 2.0,
          "radius": 1.0
        },
        "label": "cyl"
      },
      "transform": {
        "_type": "transformation",
        "data": [
          1.0,
          0.0,
          0.0,
          0.0,
          0.7071067811865475,
          -0.7071067811865475,
          0.0,
          0.7071067811865475,
          0.7071067811865475,
          1.0,
          2.0,
          3.0
        ]
      }
    },
    {
      "_type": "shape",
      "interior": {
        "_type": "ellipsoid",
        "radii": [
          1.0,
          2.0,
          3.0
        ]
      },
      "label": "ell"
    },
    {
      "_type": "transformed",
      "daughter": {
        "_type": "shape",
        "interior": {
          "_type": "sphere",
          "radius": 1.25
        },
        "label": "sph"
      },
      "transform": {
        "_type": "translation",
        "data": [
          1.0,
          2.0,
          3.0
        ]
      }
    }
  ],
  "label": "all_quadric"
}
```