### PR TITLE
Use correct form of enable_if for functions

### DIFF
--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -303,7 +303,7 @@ CELER_FORCEINLINE_FUNCTION void sort(RandomAccessIt first, RandomAccessIt last)
 #ifndef __CUDA_ARCH__
 template<class T>
 #else
-template<class T, typename = std::enable_if_t<!std::is_arithmetic<T>::value>>
+template<class T, std::enable_if_t<!std::is_arithmetic<T>::value, bool> = true>
 #endif
 CELER_CONSTEXPR_FUNCTION T const& max(T const& a, T const& b) noexcept
 {
@@ -311,7 +311,7 @@ CELER_CONSTEXPR_FUNCTION T const& max(T const& a, T const& b) noexcept
 }
 
 #ifdef __CUDA_ARCH__
-template<class T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+template<class T, std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
 CELER_CONSTEXPR_FUNCTION T max(T a, T b) noexcept
 {
     return ::max(a, b);
@@ -328,7 +328,7 @@ CELER_CONSTEXPR_FUNCTION T max(T a, T b) noexcept
 #ifndef __CUDA_ARCH__
 template<class T>
 #else
-template<class T, typename = std::enable_if_t<!std::is_arithmetic<T>::value>>
+template<class T, std::enable_if_t<!std::is_arithmetic<T>::value, bool> = true>
 #endif
 CELER_CONSTEXPR_FUNCTION T const& min(T const& a, T const& b) noexcept
 {
@@ -336,7 +336,7 @@ CELER_CONSTEXPR_FUNCTION T const& min(T const& a, T const& b) noexcept
 }
 
 #ifdef __CUDA_ARCH__
-template<class T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+template<class T, std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
 CELER_CONSTEXPR_FUNCTION T min(T a, T b) noexcept
 {
     return ::min(a, b);
@@ -443,7 +443,7 @@ CELER_CONSTEXPR_FUNCTION T ipow(T v) noexcept
   assert(9.0 == fastpow(3.0, 2.0));
  \endcode
  */
-template<class T, typename = std::enable_if_t<std::is_floating_point<T>::value>>
+template<class T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
 inline CELER_FUNCTION T fastpow(T a, T b)
 {
     CELER_EXPECT(a > 0 || (a == 0 && b != 0));

--- a/src/corecel/sys/MpiOperations.hh
+++ b/src/corecel/sys/MpiOperations.hh
@@ -60,7 +60,7 @@ allreduce(MpiCommunicator const& comm, Operation op, Span<T, N> data);
 
 //---------------------------------------------------------------------------//
 // Perform reduction on a fundamental scalar and return the result
-template<class T, std::enable_if_t<std::is_fundamental<T>::value, T*> = nullptr>
+template<class T, std::enable_if_t<std::is_fundamental<T>::value, bool> = true>
 inline T allreduce(MpiCommunicator const& comm, Operation op, T const src);
 
 //---------------------------------------------------------------------------//
@@ -147,7 +147,7 @@ void allreduce(MpiCommunicator const& comm,
 /*!
  * Perform reduction on a fundamental scalar and return the result.
  */
-template<class T, std::enable_if_t<std::is_fundamental<T>::value, T*>>
+template<class T, std::enable_if_t<std::is_fundamental<T>::value, bool>>
 T allreduce(MpiCommunicator const& comm, Operation op, T const src)
 {
     T dst{};


### PR DESCRIPTION
This tiny PR normalizes the use of `std::enable_if` for functions [as suggested by cppreference](https://en.cppreference.com/w/cpp/types/enable_if#Notes). Basically instead of using `template<T, typename = std::enable_if_t<...>>`, we should be using `template<T, std::enable_if_t<..., bool> = true>`.