### PR TITLE
Add CSG wedge and helper functions

### DIFF
--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -497,14 +497,43 @@ template<class T>
 /*!
  * Calculate the difference of squares \f$ a^2 - b^2 \f$.
  *
- * The expression \f$ a^2 - b^2 \f$ exhibits catastrophic cancellation when \f$
- * a \f$ and \f$ b \f$ are close in magnitude. This can be avoided by
- * rearranging the formula as \f$ (a - b)(a + b) \f$.
+ * This calculation exchanges one multiplication for one addition, but it does
+ * not increase the accuracy of the computed result. It is used
+ * occasionally in Geant4 but is likely a premature optimization... see
+ * https://github.com/celeritas-project/celeritas/pull/1082
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION T diffsq(T a, T b)
 {
     return (a - b) * (a + b);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the Euclidian modulus of two numbers.
+ *
+ * If both numbers are positive, this should be the same as fmod. If the
+ * sign of the remainder and denominator don't match, the remainder will be
+ * remapped so that it is between zero and the denominator.
+ *
+ * This function is useful for normalizing user-provided angles.
+ */
+template<class T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+CELER_CONSTEXPR_FUNCTION T eumod(T numer, T denom)
+{
+    T r = std::fmod(numer, denom);
+    if (r < 0)
+    {
+        if (denom >= 0)
+        {
+            r += denom;
+        }
+        else
+        {
+            r -= denom;
+        }
+    }
+    return r;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -34,6 +34,7 @@ list(APPEND SOURCES
   orangeinp/Shape.cc
   orangeinp/Transformed.cc
   orangeinp/detail/BoundingZone.cc
+  orangeinp/detail/BuildConvexRegion.cc
   orangeinp/detail/ConvexSurfaceState.cc
   orangeinp/detail/CsgUnitBuilder.cc
   orangeinp/detail/LocalSurfaceInserter.cc

--- a/src/orange/orangeinp/ConvexRegion.cc
+++ b/src/orange/orangeinp/ConvexRegion.cc
@@ -297,11 +297,14 @@ void Ellipsoid::output(JsonPimpl* j) const
  * Construct from a starting angle and interior angle.
  */
 InfWedge::InfWedge(Turn start, Turn interior)
-    : start_{Turn{std::fmod(start.value(), real_type{1})}}, interior_{interior}
+    : start_{start}, interior_{interior}
 {
+    CELER_VALIDATE(start_ >= zero_quantity() && start_ < Turn{1},
+                   << "invalid start angle " << start_.value()
+                   << " [turns]: must be in the range [0, 1)");
     CELER_VALIDATE(interior_ > zero_quantity() && interior_ <= Turn{0.5},
                    << "invalid interior wedge angle " << interior.value()
-                   << " [turns]: must be positive and less than half a turn");
+                   << " [turns]: must be in the range (0, 0.5]");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/ConvexRegion.hh
+++ b/src/orange/orangeinp/ConvexRegion.hh
@@ -10,6 +10,7 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/cont/Array.hh"
+#include "corecel/math/Turn.hh"
 #include "orange/OrangeTypes.hh"
 
 namespace celeritas
@@ -181,6 +182,40 @@ class Ellipsoid final : public ConvexRegionInterface
 
   private:
     Real3 radii_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * An open wedge shape from the Z axis.
+ *
+ * The wedge is defined by an interior angle that *must* be less than or equal
+ * to 180 degrees (half a turn) and *must* be more than zero. It can be
+ * subtracted, or its negation can be subtracted. The start angle is mapped
+ * onto [0, 1) on construction.
+ */
+class InfWedge final : public ConvexRegionInterface
+{
+  public:
+    // Construct from a starting angle and interior angle
+    InfWedge(Turn start, Turn interior);
+
+    // Build surfaces
+    void build(ConvexSurfaceBuilder&) const final;
+
+    // Output to JSON
+    void output(JsonPimpl*) const final;
+
+    //// ACCESSORS ////
+
+    //! Starting angle
+    Turn start() const { return start_; }
+
+    //! Interior angle
+    Turn interior() const { return interior_; }
+
+  private:
+    Turn start_;
+    Turn interior_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/ObjectIO.json.cc
+++ b/src/orange/orangeinp/ObjectIO.json.cc
@@ -161,6 +161,12 @@ void to_json(nlohmann::json& j, Ellipsoid const& cr)
 {
     j = {{"_type", "ellipsoid"}, SIO_ATTR_PAIR(cr, radii)};
 }
+void to_json(nlohmann::json& j, InfWedge const& cr)
+{
+    j = {{"_type", "infwedge"},
+         {"start", cr.start().value()},
+         {"interior", cr.interior().value()}};
+}
 void to_json(nlohmann::json& j, Prism const& cr)
 {
     j = {{"_type", "prism"},

--- a/src/orange/orangeinp/ObjectIO.json.hh
+++ b/src/orange/orangeinp/ObjectIO.json.hh
@@ -29,6 +29,7 @@ class Box;
 class Cone;
 class Cylinder;
 class Ellipsoid;
+class InfWedge;
 class Prism;
 class Sphere;
 
@@ -50,6 +51,7 @@ void to_json(nlohmann::json& j, Box const& cr);
 void to_json(nlohmann::json& j, Cone const& cr);
 void to_json(nlohmann::json& j, Cylinder const& cr);
 void to_json(nlohmann::json& j, Ellipsoid const& cr);
+void to_json(nlohmann::json& j, InfWedge const& cr);
 void to_json(nlohmann::json& j, Prism const& cr);
 void to_json(nlohmann::json& j, Sphere const& cr);
 

--- a/src/orange/orangeinp/Shape.cc
+++ b/src/orange/orangeinp/Shape.cc
@@ -9,12 +9,7 @@
 
 #include "corecel/io/JsonPimpl.hh"
 
-#include "ConvexSurfaceBuilder.hh"
-#include "CsgTreeUtils.hh"
-
-#include "detail/ConvexSurfaceState.hh"
-#include "detail/CsgUnitBuilder.hh"
-#include "detail/VolumeBuilder.hh"
+#include "detail/BuildConvexRegion.hh"
 
 #if CELERITAS_USE_JSON
 #    include "ObjectIO.json.hh"
@@ -30,20 +25,8 @@ namespace orangeinp
  */
 NodeId ShapeBase::build(VolumeBuilder& vb) const
 {
-    // Set input attributes for surface state
-    detail::ConvexSurfaceState css;
-    css.transform = &vb.local_transform();
-    css.object_name = this->label();
-    css.make_face_name = {};  // No prefix for standalone shapes
-
-    // Construct surfaces
-    auto sb = ConvexSurfaceBuilder(&vb.unit_builder(), &css);
-    this->interior().build(sb);
-
-    // Intersect the given surfaces to create a new CSG node
-    return vb.insert_region(Label{std::move(css.object_name)},
-                            Joined{op_and, std::move(css.nodes)},
-                            calc_merged_bzone(css));
+    return detail::build_convex_region(
+        vb, std::string{this->label()}, {}, this->interior());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/Shape.hh
+++ b/src/orange/orangeinp/Shape.hh
@@ -58,9 +58,12 @@ class ShapeBase : public ObjectInterface
 /*!
  * Shape that holds a convex region and forwards construction args to it.
  *
- * Construct as:
- *
- *    BoxShape s{"mybox", Real3{1, 2, 3}};
+ * Construct as: \code
+    BoxShape s{"mybox", Real3{1, 2, 3}};
+ * \endcode
+ * or \code
+ *  Shape s{"mybox", Box{{1, 2, 3}}};
+ * \endcode
  *
  * See ConvexRegion.hh for a list of the regions and their construction
  * arguments.

--- a/src/orange/orangeinp/detail/BuildConvexRegion.cc
+++ b/src/orange/orangeinp/detail/BuildConvexRegion.cc
@@ -1,0 +1,52 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/detail/BuildConvexRegion.cc
+//---------------------------------------------------------------------------//
+#include "BuildConvexRegion.hh"
+
+#include "orange/orangeinp/ConvexRegion.hh"
+#include "orange/orangeinp/ConvexSurfaceBuilder.hh"
+#include "orange/surf/FaceNamer.hh"
+
+#include "ConvexSurfaceState.hh"
+#include "CsgUnitBuilder.hh"
+#include "VolumeBuilder.hh"
+
+namespace celeritas
+{
+namespace orangeinp
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Build a convex region.
+ */
+NodeId build_convex_region(VolumeBuilder& vb,
+                           std::string&& label,
+                           std::string&& face_prefix,
+                           ConvexRegionInterface const& region)
+{
+    // Set input attributes for surface state
+    ConvexSurfaceState css;
+    css.transform = &vb.local_transform();
+    css.object_name = std::move(label);
+    css.make_face_name = FaceNamer{std::move(face_prefix)};
+
+    // Construct surfaces
+    auto sb = ConvexSurfaceBuilder(&vb.unit_builder(), &css);
+    region.build(sb);
+
+    // Intersect the given surfaces to create a new CSG node
+    return vb.insert_region(Label{std::move(css.object_name)},
+                            Joined{op_and, std::move(css.nodes)},
+                            calc_merged_bzone(css));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/src/orange/orangeinp/detail/BuildConvexRegion.hh
+++ b/src/orange/orangeinp/detail/BuildConvexRegion.hh
@@ -1,0 +1,41 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/detail/BuildConvexRegion.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+
+#include "orange/orangeinp/CsgTypes.hh"
+
+namespace celeritas
+{
+namespace orangeinp
+{
+class ConvexRegionInterface;
+namespace detail
+{
+class VolumeBuilder;
+//---------------------------------------------------------------------------//
+
+// Build a convex region
+NodeId build_convex_region(VolumeBuilder& vb,
+                           std::string&& label,
+                           std::string&& face_prefix,
+                           ConvexRegionInterface const& region);
+
+//! Build a convex region with no face prefix
+inline NodeId build_convex_region(VolumeBuilder& vb,
+                                  std::string&& label,
+                                  ConvexRegionInterface const& region)
+{
+    return build_convex_region(vb, std::move(label), {}, region);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/src/orange/surf/FaceNamer.hh
+++ b/src/orange/surf/FaceNamer.hh
@@ -32,8 +32,8 @@ class FaceNamer
     // Construct with no prefix
     FaceNamer() = default;
 
-    //! Construct with prefix
-    explicit FaceNamer(std::string&& prefix) : prefix_{std::move(prefix)} {}
+    // Construct with prefix
+    explicit inline FaceNamer(std::string&& prefix);
 
     // Apply to a surface with known type
     template<class S>
@@ -85,6 +85,18 @@ class FaceNamer
         std::string operator()(GeneralQuadric const&) const;
     };
 };
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with prefix.
+ */
+FaceNamer::FaceNamer(std::string&& prefix) : prefix_{std::move(prefix)}
+{
+    if (!prefix_.empty() && prefix_.back() != '.')
+    {
+        prefix_.push_back('.');
+    }
+}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -340,6 +340,20 @@ TEST(MathTest, diffsq)
 
 //---------------------------------------------------------------------------//
 
+TEST(MathTest, eumod)
+{
+    // Wrap numbers to between [0, 360)
+    EXPECT_DOUBLE_EQ(270.0, eumod(-90.0 - 360.0, 360.0));
+    EXPECT_DOUBLE_EQ(270.0, eumod(-90.0, 360.0));
+    EXPECT_DOUBLE_EQ(0.0, eumod(0.0, 360.0));
+    EXPECT_DOUBLE_EQ(45.0, eumod(45.0, 360.0));
+    EXPECT_DOUBLE_EQ(0.0, eumod(360.0, 360.0));
+    EXPECT_DOUBLE_EQ(15.0, eumod(375.0, 360.0));
+    EXPECT_DOUBLE_EQ(30.0, eumod(720.0 + 30, 360.0));
+}
+
+//---------------------------------------------------------------------------//
+
 TEST(MathTest, sincos)
 {
     {

--- a/test/orange/orangeinp/ConvexRegion.test.cc
+++ b/test/orange/orangeinp/ConvexRegion.test.cc
@@ -371,6 +371,8 @@ TEST_F(InfWedgeTest, errors)
     EXPECT_THROW(InfWedge(Turn{0}, Turn{0.51}), RuntimeError);
     EXPECT_THROW(InfWedge(Turn{0}, Turn{0}), RuntimeError);
     EXPECT_THROW(InfWedge(Turn{0}, Turn{-0.5}), RuntimeError);
+    EXPECT_THROW(InfWedge(Turn{-0.1}, Turn{-0.5}), RuntimeError);
+    EXPECT_THROW(InfWedge(Turn{1.1}, Turn{-0.5}), RuntimeError);
 }
 
 TEST_F(InfWedgeTest, quarter_turn)
@@ -396,7 +398,7 @@ TEST_F(InfWedgeTest, quarter_turn)
     }
     {
         SCOPED_TRACE("fourth quadrant");
-        InfWedge wedge(Turn{1.75}, Turn{0.25});
+        InfWedge wedge(Turn{0.75}, Turn{0.25});
         EXPECT_SOFT_EQ(0.75, wedge.start().value());
         auto result = this->test(wedge);
         EXPECT_EQ("all(+1, -0)", result.node);
@@ -408,7 +410,7 @@ TEST_F(InfWedgeTest, quarter_turn)
     }
     {
         SCOPED_TRACE("east quadrant");
-        auto result = this->test(InfWedge(Turn{-0.125}, Turn{0.25}));
+        auto result = this->test(InfWedge(Turn{1 - 0.125}, Turn{0.25}));
         EXPECT_EQ("all(+2, +3)", result.node);
         static char const expected_node[] = "all(+2, +3)";
         EXPECT_EQ(expected_node, result.node);

--- a/test/orange/orangeinp/ConvexRegion.test.cc
+++ b/test/orange/orangeinp/ConvexRegion.test.cc
@@ -71,12 +71,9 @@ auto ConvexRegionTest::test(ConvexRegionInterface const& r,
     EXPECT_TRUE(encloses(css.local_bzone.exterior, css.local_bzone.interior));
     EXPECT_TRUE(encloses(css.global_bzone.exterior, css.global_bzone.interior));
 
-    bool multi_node = css.nodes.size() > 1;
-
     // Intersect the given surfaces
-    auto&& [node_id, inserted]
-        = unit_builder_.insert_csg(Joined{op_and, std::move(css.nodes)});
-    EXPECT_EQ(multi_node, inserted);
+    NodeId node_id
+        = unit_builder_.insert_csg(Joined{op_and, std::move(css.nodes)}).first;
 
     TestResult result;
     result.node = build_infix_string(unit_.tree, node_id);
@@ -362,6 +359,107 @@ TEST_F(EllipsoidTest, standard)
         result.interior.upper());
     EXPECT_VEC_SOFT_EQ((Real3{-3, -2, -1}), result.exterior.lower());
     EXPECT_VEC_SOFT_EQ((Real3{3, 2, 1}), result.exterior.upper());
+}
+
+//---------------------------------------------------------------------------//
+// INFWEDGE
+//---------------------------------------------------------------------------//
+using InfWedgeTest = ConvexRegionTest;
+
+TEST_F(InfWedgeTest, errors)
+{
+    EXPECT_THROW(InfWedge(Turn{0}, Turn{0.51}), RuntimeError);
+    EXPECT_THROW(InfWedge(Turn{0}, Turn{0}), RuntimeError);
+    EXPECT_THROW(InfWedge(Turn{0}, Turn{-0.5}), RuntimeError);
+}
+
+TEST_F(InfWedgeTest, quarter_turn)
+{
+    {
+        SCOPED_TRACE("first quadrant");
+        auto result = this->test(InfWedge(Turn{0}, Turn{0.25}));
+        static char const expected_node[] = "all(+0, +1)";
+        static char const* const expected_surfaces[]
+            = {"Plane: y=0", "Plane: x=0"};
+
+        EXPECT_EQ(expected_node, result.node);
+        EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+        EXPECT_VEC_SOFT_EQ((Real3{0, 0, -inf}), result.interior.lower());
+        EXPECT_VEC_SOFT_EQ((Real3{inf, inf, inf}), result.interior.upper());
+        EXPECT_VEC_SOFT_EQ((Real3{0, 0, -inf}), result.exterior.lower());
+        EXPECT_VEC_SOFT_EQ((Real3{inf, inf, inf}), result.exterior.upper());
+    }
+    {
+        SCOPED_TRACE("second quadrant");
+        auto result = this->test(InfWedge(Turn{.25}, Turn{0.25}));
+        EXPECT_EQ("all(+0, -1)", result.node);
+    }
+    {
+        SCOPED_TRACE("fourth quadrant");
+        InfWedge wedge(Turn{1.75}, Turn{0.25});
+        EXPECT_SOFT_EQ(0.75, wedge.start().value());
+        auto result = this->test(wedge);
+        EXPECT_EQ("all(+1, -0)", result.node);
+    }
+    {
+        SCOPED_TRACE("north quadrant");
+        auto result = this->test(InfWedge(Turn{0.125}, Turn{0.25}));
+        EXPECT_EQ("all(-2, +3)", result.node);
+    }
+    {
+        SCOPED_TRACE("east quadrant");
+        auto result = this->test(InfWedge(Turn{-0.125}, Turn{0.25}));
+        EXPECT_EQ("all(+2, +3)", result.node);
+        static char const expected_node[] = "all(+2, +3)";
+        EXPECT_EQ(expected_node, result.node);
+        EXPECT_FALSE(result.interior) << result.interior;
+        EXPECT_EQ(BBox::from_infinite(), result.exterior);
+    }
+    {
+        SCOPED_TRACE("west quadrant");
+        auto result = this->test(InfWedge(Turn{0.375}, Turn{0.25}));
+        static char const expected_node[] = "all(-2, -3)";
+        static char const* const expected_surfaces[]
+            = {"Plane: y=0",
+               "Plane: x=0",
+               "Plane: n={0.70711,-0.70711,0}, d=0",
+               "Plane: n={0.70711,0.70711,0}, d=0",
+               "Plane: n={0.70711,0.70711,0}, d=0",
+               "Plane: n={0.70711,-0.70711,0}, d=0"};
+
+        EXPECT_EQ(expected_node, result.node);
+        EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    }
+}
+
+TEST_F(InfWedgeTest, half_turn)
+{
+    {
+        SCOPED_TRACE("north half");
+        auto result = this->test(InfWedge(Turn{0}, Turn{0.5}));
+        EXPECT_EQ("+0", result.node);
+        EXPECT_VEC_SOFT_EQ((Real3{-inf, 0, -inf}), result.interior.lower());
+        EXPECT_VEC_SOFT_EQ((Real3{inf, inf, inf}), result.interior.upper());
+        EXPECT_VEC_SOFT_EQ((Real3{-inf, 0, -inf}), result.exterior.lower());
+        EXPECT_VEC_SOFT_EQ((Real3{inf, inf, inf}), result.exterior.upper());
+    }
+    {
+        SCOPED_TRACE("south half");
+        auto result = this->test(InfWedge(Turn{0.5}, Turn{0.5}));
+        EXPECT_EQ("-0", result.node);
+    }
+    {
+        SCOPED_TRACE("northeast half");
+        auto result = this->test(InfWedge(Turn{0.125}, Turn{0.5}));
+        static char const expected_node[] = "-1";
+        static char const* const expected_surfaces[]
+            = {"Plane: y=0",
+               "Plane: n={0.70711,-0.70711,0}, d=0",
+               "Plane: n={0.70711,-0.70711,0}, d=0"};
+
+        EXPECT_EQ(expected_node, result.node);
+        EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/orangeinp/ConvexSurfaceBuilder.test.cc
+++ b/test/orange/orangeinp/ConvexSurfaceBuilder.test.cc
@@ -33,7 +33,7 @@ class ConvexSurfaceBuilderTest : public ObjectTestBase
     {
         State result;
         result.transform = &transform_;
-        result.make_face_name = FaceNamer{"c:"};
+        result.make_face_name = FaceNamer{"c."};
         return result;
     }
 
@@ -127,8 +127,8 @@ TEST_F(ConvexSurfaceBuilderTest, no_transform)
     static char const* const expected_surface_strings[]
         = {"Plane: z=0", "Sphere: r=1", "Plane: x=-0.5", "Plane: x=0.5"};
     static char const* const expected_md_strings[] = {"", "",
-        "dh@c:pz,rh@c:mz,zh@c:pz", "", "dh@c:s,rh@c:s,zh@c:s", "", "sl@c:mx",
-        "sl@c:px", ""};
+        "dh@c.pz,rh@c.mz,zh@c.pz", "", "dh@c.s,rh@c.s,zh@c.s", "", "sl@c.mx",
+        "sl@c.px", ""};
     static char const expected_tree_string[]
         = R"json(["t",["~",0],["S",0],["~",2],["S",1],["~",4],["S",2],["S",3],["~",7]])json";
     // clang-format on
@@ -209,7 +209,7 @@ TEST_F(ConvexSurfaceBuilderTest, translate)
     static char const * const expected_surface_strings[] = {"Plane: x=0.5",
         "Plane: x=1.5", "Sphere: r=1 at {1,2,3}", "Plane: x=2.5"};
     static char const* const expected_md_strings[] = {
-        "", "", "sl@c:mx", "sl@c:px,ss@c:mx", "", "sph@c:s", "", "ss@c:px", ""};
+        "", "", "sl@c.mx", "sl@c.px,ss@c.mx", "", "sph@c.s", "", "ss@c.px", ""};
     static char const expected_tree_string[]
         = R"json(["t",["~",0],["S",0],["S",1],["~",3],["S",2],["~",5],["S",3],["~",7]])json";
 
@@ -254,7 +254,7 @@ TEST_F(ConvexSurfaceBuilderTest, transform)
     static char const expected_tree_string[]
         = R"json(["t",["~",0],["S",0],["S",1],["~",3]])json";
     static char const* const expected_md_strings[]
-        = {"", "", "h@c:pz", "h@c:s", ""};
+        = {"", "", "h@c.pz", "h@c.s", ""};
 
     auto const& u = this->unit();
     EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));

--- a/test/orange/surf/FaceNamer.test.cc
+++ b/test/orange/surf/FaceNamer.test.cc
@@ -55,7 +55,7 @@ TEST_F(FaceNamerTest, typed)
 
 TEST_F(FaceNamerTest, prefix)
 {
-    FaceNamer name_face{"obox."};
+    FaceNamer name_face{"obox"};
 
     EXPECT_EQ("obox.px", name_face(in, PlaneX(1)));
     EXPECT_EQ("obox.mx", name_face(out, PlaneX(1)));


### PR DESCRIPTION
This is in preparation for adding Geant4 "solid"s. The infinite wedge is used to cut out an azimuthal section of a Z-aligned shape: e.g., a cylindrical segment.