### PR TITLE
Convert Geant4 logical and physical volumes

### DIFF
--- a/src/geocel/detail/LengthUnits.hh
+++ b/src/geocel/detail/LengthUnits.hh
@@ -8,6 +8,9 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "celeritas_config.h"
+#include "corecel/Types.hh"
+
 #define CELER_ICRT inline constexpr real_type
 
 namespace celeritas
@@ -27,6 +30,8 @@ CELER_ICRT millimeter = 0.001;
 CELER_ICRT meter = 1000;
 CELER_ICRT centimeter = 10;
 CELER_ICRT millimeter = 1;
+#else
+#    error "CELERITAS_UNITS is undefined"
 #endif
 
 //---------------------------------------------------------------------------//

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -84,6 +84,7 @@ endif()
 
 if(CELERITAS_USE_Geant4 AND CELERITAS_REAL_TYPE STREQUAL "double")
   set( _cg4org_sources
+    g4org/LogicalVolumeConverter.cc
     g4org/SolidConverter.cc
   )
   celeritas_get_g4libs(_cg4org_libs geometry)

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -85,6 +85,7 @@ endif()
 if(CELERITAS_USE_Geant4 AND CELERITAS_REAL_TYPE STREQUAL "double")
   set( _cg4org_sources
     g4org/LogicalVolumeConverter.cc
+    g4org/PhysicalVolumeConverter.cc
     g4org/SolidConverter.cc
   )
   celeritas_get_g4libs(_cg4org_libs geometry)

--- a/src/orange/g4org/LogicalVolumeConverter.cc
+++ b/src/orange/g4org/LogicalVolumeConverter.cc
@@ -1,0 +1,100 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023-2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/g4org/LogicalVolumeConverter.cc
+//---------------------------------------------------------------------------//
+#include "LogicalVolumeConverter.hh"
+
+#include <G4LogicalVolume.hh>
+#include <G4MaterialCutsCouple.hh>
+#include <G4VSolid.hh>
+
+#include "corecel/Assert.hh"
+#include "corecel/io/Logger.hh"
+#include "geocel/GeantGeoUtils.hh"
+
+#include "SolidConverter.hh"
+#include "Volume.hh"
+
+namespace celeritas
+{
+namespace g4org
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with solid conversion helper.
+ */
+LogicalVolumeConverter::LogicalVolumeConverter(SolidConverter& convert_solid)
+    : convert_solid_(convert_solid)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a Geant4 logical volume to a VecGeom LogicalVolume.
+ *
+ * This uses a cache to look up any previously converted volume.
+ */
+auto LogicalVolumeConverter::operator()(arg_type lv) -> result_type
+{
+    auto [cache_iter, inserted] = cache_.insert({&lv, nullptr});
+    if (inserted)
+    {
+        // First time converting the volume
+        cache_iter->second = this->construct_impl(lv);
+    }
+
+    CELER_ENSURE(cache_iter->second);
+    return cache_iter->second;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert the raw logical volume without processing any daughters.
+ */
+auto LogicalVolumeConverter::construct_impl(arg_type g4lv) -> result_type
+{
+    auto result = std::make_shared<LogicalVolume>();
+    result->g4lv = &g4lv;
+
+    try
+    {
+        result->solid = convert_solid_(*g4lv.GetSolid());
+    }
+    catch (celeritas::RuntimeError const& e)
+    {
+        CELER_LOG(error) << "Failed to convert solid type '"
+                         << g4lv.GetSolid()->GetEntityType() << "' named '"
+                         << g4lv.GetSolid()->GetName()
+                         << "': " << e.details().what;
+        result->solid = this->convert_solid_.to_sphere(*g4lv.GetSolid());
+        CELER_LOG(warning) << "Replaced unknown solid with sphere ("
+                           << to_string(*result->solid) << ")";
+        CELER_LOG(info) << "Unsupported solid belongs to logical volume "
+                        << PrintableLV{&g4lv};
+    }
+
+    // Save material ID
+    if (auto* cuts = g4lv.GetMaterialCutsCouple())
+    {
+        auto idx = cuts->GetIndex();
+        CELER_ASSERT(idx >= 0);
+        result->material_id = MaterialId{static_cast<size_type>(idx)};
+    }
+
+    // Save name
+    result->name = g4lv.GetName();
+    if (result->name.find("0x") == std::string::npos)
+    {
+        // No pointer address: add one
+        result->name = make_gdml_name(g4lv);
+    }
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace g4org
+}  // namespace celeritas

--- a/src/orange/g4org/LogicalVolumeConverter.cc
+++ b/src/orange/g4org/LogicalVolumeConverter.cc
@@ -100,6 +100,15 @@ auto LogicalVolumeConverter::construct_impl(arg_type g4lv) -> SPLV
         CELER_LOG(info) << "Unsupported solid belongs to logical volume "
                         << PrintableLV{&g4lv};
     }
+    catch (celeritas::DebugError const& e)
+    {
+        CELER_LOG(error) << "Failed to convert solid type '"
+                         << g4lv.GetSolid()->GetEntityType() << "' named '"
+                         << g4lv.GetSolid()->GetName();
+        CELER_LOG(info) << "Unsupported solid belongs to logical volume "
+                        << PrintableLV{&g4lv};
+        throw;
+    }
 
     return result;
 }

--- a/src/orange/g4org/LogicalVolumeConverter.cc
+++ b/src/orange/g4org/LogicalVolumeConverter.cc
@@ -35,7 +35,7 @@ LogicalVolumeConverter::LogicalVolumeConverter(SolidConverter& convert_solid)
 
 //---------------------------------------------------------------------------//
 /*!
- * Convert a Geant4 logical volume to a VecGeom LogicalVolume.
+ * Convert a Geant4 logical volume to an ORANGE LogicalVolume.
  *
  * This uses a cache to look up any previously converted volume.
  */

--- a/src/orange/g4org/LogicalVolumeConverter.cc
+++ b/src/orange/g4org/LogicalVolumeConverter.cc
@@ -8,6 +8,7 @@
 #include "LogicalVolumeConverter.hh"
 
 #include <G4LogicalVolume.hh>
+#include <G4Material.hh>
 #include <G4MaterialCutsCouple.hh>
 #include <G4VSolid.hh>
 
@@ -77,11 +78,11 @@ auto LogicalVolumeConverter::construct_impl(arg_type g4lv) -> SPLV
     }
 
     // Save material ID
-    if (auto* cuts = g4lv.GetMaterialCutsCouple())
+    // NOTE: this is *not* the physics material ("cut couple")
+    if (auto* mat = g4lv.GetMaterial())
     {
-        auto idx = cuts->GetIndex();
-        CELER_ASSERT(idx >= 0);
-        result->material_id = MaterialId{static_cast<size_type>(idx)};
+        result->material_id
+            = MaterialId{static_cast<size_type>(mat->GetIndex())};
     }
 
     // Convert solid

--- a/src/orange/g4org/LogicalVolumeConverter.cc
+++ b/src/orange/g4org/LogicalVolumeConverter.cc
@@ -13,6 +13,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/sys/Environment.hh"
 #include "geocel/GeantGeoUtils.hh"
 
 #include "SolidConverter.hh"
@@ -107,7 +108,13 @@ auto LogicalVolumeConverter::construct_impl(arg_type g4lv) -> SPLV
                          << g4lv.GetSolid()->GetName();
         CELER_LOG(info) << "Unsupported solid belongs to logical volume "
                         << PrintableLV{&g4lv};
-        throw;
+
+        static bool const allow_errors
+            = !celeritas::getenv("G4ORG_ALLOW_ERRORS").empty();
+        if (!allow_errors)
+        {
+            throw;
+        }
     }
 
     return result;

--- a/src/orange/g4org/LogicalVolumeConverter.hh
+++ b/src/orange/g4org/LogicalVolumeConverter.hh
@@ -39,26 +39,28 @@ class LogicalVolumeConverter
     //!@{
     //! \name Type aliases
     using arg_type = G4LogicalVolume const&;
-    using result_type = std::shared_ptr<LogicalVolume>;
-    using MapLvVolId = std::unordered_map<G4LogicalVolume const*, VolumeId>;
+    using SPLV = std::shared_ptr<LogicalVolume>;
+    using result_type = std::pair<SPLV, bool>;
     //!@}
 
   public:
     explicit LogicalVolumeConverter(SolidConverter& convert_solid);
 
-    // Convert a volume
+    // Convert a volume, return result plus insertion
     result_type operator()(arg_type);
 
   private:
+    using WPLV = std::weak_ptr<LogicalVolume>;
+
     //// DATA ////
 
     SolidConverter& convert_solid_;
-    std::unordered_map<G4LogicalVolume const*, result_type> cache_;
+    std::unordered_map<G4LogicalVolume const*, WPLV> cache_;
 
     //// HELPER FUNCTIONS ////
 
     // Convert an LV that's not in the cache
-    result_type construct_impl(arg_type);
+    SPLV construct_impl(arg_type);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/g4org/LogicalVolumeConverter.hh
+++ b/src/orange/g4org/LogicalVolumeConverter.hh
@@ -28,7 +28,7 @@ class SolidConverter;
 
 //---------------------------------------------------------------------------//
 /*!
- * Convert a Geant4 base LV to a VecGeom LV.
+ * Convert a Geant4 base LV to an ORANGE temporary LV.
  *
  * This does not convert or add any of the daughters, which must be placed as
  * physical volumes.

--- a/src/orange/g4org/LogicalVolumeConverter.hh
+++ b/src/orange/g4org/LogicalVolumeConverter.hh
@@ -1,0 +1,66 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023-2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/g4org/LogicalVolumeConverter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <unordered_map>
+
+#include "geocel/Types.hh"
+#include "orange/orangeinp/ObjectInterface.hh"
+
+//---------------------------------------------------------------------------//
+// Forward declarations
+//---------------------------------------------------------------------------//
+
+class G4LogicalVolume;
+
+namespace celeritas
+{
+namespace g4org
+{
+//---------------------------------------------------------------------------//
+struct LogicalVolume;
+class SolidConverter;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a Geant4 base LV to a VecGeom LV.
+ *
+ * This does not convert or add any of the daughters, which must be placed as
+ * physical volumes.
+ */
+class LogicalVolumeConverter
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using arg_type = G4LogicalVolume const&;
+    using result_type = std::shared_ptr<LogicalVolume>;
+    using MapLvVolId = std::unordered_map<G4LogicalVolume const*, VolumeId>;
+    //!@}
+
+  public:
+    explicit LogicalVolumeConverter(SolidConverter& convert_solid);
+
+    // Convert a volume
+    result_type operator()(arg_type);
+
+  private:
+    //// DATA ////
+
+    SolidConverter& convert_solid_;
+    std::unordered_map<G4LogicalVolume const*, result_type> cache_;
+
+    //// HELPER FUNCTIONS ////
+
+    // Convert an LV that's not in the cache
+    result_type construct_impl(arg_type);
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace g4org
+}  // namespace celeritas

--- a/src/orange/g4org/PhysicalVolumeConverter.cc
+++ b/src/orange/g4org/PhysicalVolumeConverter.cc
@@ -120,8 +120,13 @@ PhysicalVolumeConverter::Builder::make_pv(int depth,
         auto const& g4trans = g4pv.GetObjectTranslation();
         if (g4pv.GetFrameRotation())
         {
-            return this->data->make_transform(g4trans,
-                                              g4pv.GetObjectRotationValue());
+            // Get the daughter-to-parent rotation and check for being identity
+            // (parameterized volumes inject an identity matrix)
+            auto const& rot = g4pv.GetObjectRotationValue();
+            if (!rot.isIdentity())
+            {
+                return this->data->make_transform(g4trans, rot);
+            }
         }
         if (g4trans[0] != 0 || g4trans[1] != 0 || g4trans[2] != 0)
         {

--- a/src/orange/g4org/PhysicalVolumeConverter.cc
+++ b/src/orange/g4org/PhysicalVolumeConverter.cc
@@ -173,7 +173,9 @@ PhysicalVolumeConverter::Builder::make_pv(int depth,
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct children in a logical volume.
+ * Convert physical volumes that belong to a Geant4 LV.
+ *
+ * This adds the result to the ORANGE LogicalVolume.
  */
 void PhysicalVolumeConverter::Builder::place_child(
     int depth, G4VPhysicalVolume const& g4pv, LogicalVolume* lv)
@@ -195,7 +197,7 @@ void PhysicalVolumeConverter::Builder::place_child(
         // Loop over number of replicas
         for (auto j : range(g4pv.GetMultiplicity()))
         {
-            // Use the paramterization to *change* the physical volume's
+            // Use the parameterization to *change* the physical volume's
             // position (yes, this is how Geant4 does it too)
             param->ComputeTransformation(
                 j, const_cast<G4VPhysicalVolume*>(&g4pv));

--- a/src/orange/g4org/PhysicalVolumeConverter.cc
+++ b/src/orange/g4org/PhysicalVolumeConverter.cc
@@ -116,8 +116,17 @@ PhysicalVolumeConverter::Builder::make_pv(int depth,
 
     result.name = g4pv.GetName();
     result.copy_number = g4pv.GetCopyNo();
-    result.transform = this->data->make_transform(g4pv.GetObjectTranslation(),
-                                                  g4pv.GetFrameRotation());
+    if (g4pv.GetFrameRotation())
+    {
+        result.transform = this->data->make_transform(
+            g4pv.GetObjectTranslation(), g4pv.GetObjectRotationValue());
+    }
+    else
+    {
+        // Avoid constructing an identity matrix and transforming it
+        result.transform
+            = this->data->make_transform(g4pv.GetObjectTranslation());
+    }
 
     auto* g4lv = g4pv.GetLogicalVolume();
     if (auto* unrefl_g4lv

--- a/src/orange/g4org/PhysicalVolumeConverter.cc
+++ b/src/orange/g4org/PhysicalVolumeConverter.cc
@@ -76,10 +76,11 @@ struct PhysicalVolumeConverter::Builder
 /*!
  * Construct with options.
  */
-PhysicalVolumeConverter::PhysicalVolumeConverter(bool verbose)
+PhysicalVolumeConverter::PhysicalVolumeConverter(Options opts)
     : data_{std::make_unique<Data>()}
 {
-    data_->verbose = verbose;
+    data_->scale = Scaler{opts.scale};
+    data_->verbose = opts.verbose;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/g4org/PhysicalVolumeConverter.cc
+++ b/src/orange/g4org/PhysicalVolumeConverter.cc
@@ -1,0 +1,220 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/g4org/PhysicalVolumeConverter.cc
+//---------------------------------------------------------------------------//
+#include "PhysicalVolumeConverter.hh"
+
+#include <deque>
+#include <iomanip>
+#include <iostream>
+#include <unordered_set>
+#include <G4LogicalVolume.hh>
+#include <G4PVPlacement.hh>
+#include <G4ReflectionFactory.hh>
+#include <G4VPVParameterisation.hh>
+#include <G4VPhysicalVolume.hh>
+
+#include "corecel/cont/Range.hh"
+#include "corecel/io/Logger.hh"
+#include "corecel/io/ScopedTimeLog.hh"
+#include "corecel/sys/ScopedMem.hh"
+#include "corecel/sys/ScopedProfiling.hh"
+#include "corecel/sys/TypeDemangler.hh"
+#include "geocel/GeantGeoUtils.hh"
+
+#include "LogicalVolumeConverter.hh"
+#include "Scaler.hh"
+#include "SolidConverter.hh"
+#include "Transformer.hh"
+
+namespace celeritas
+{
+namespace g4org
+{
+//---------------------------------------------------------------------------//
+struct PhysicalVolumeConverter::Data
+{
+    // Scale with CLHEP units (mm)
+    Scaler scale;
+    // Transform using the scale
+    Transformer make_transform{scale};
+    // Convert a solid/shape
+    SolidConverter make_solid{scale, make_transform};
+    // Convert and cache a logical volume
+    LogicalVolumeConverter make_lv{make_solid};
+    // Whether to print extra output
+    bool verbose{false};
+};
+
+struct PhysicalVolumeConverter::Builder
+{
+    struct QueuedDaughter
+    {
+        int depth{};
+        G4VPhysicalVolume const* g4pv{nullptr};
+        std::shared_ptr<LogicalVolume> lv;
+    };
+
+    Data* data;
+    std::deque<QueuedDaughter> daughter_queue;
+
+    // Convert a physical volume, queuing daughters if needed
+    PhysicalVolume make_pv(int depth, G4VPhysicalVolume const& pv);
+
+    // Build a daughter
+    void
+    place_daughter(int depth, G4VPhysicalVolume const& g4pv, LogicalVolume* lv);
+
+    // Build all daughters in the queue
+    void build_daughters();
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with options.
+ */
+PhysicalVolumeConverter::PhysicalVolumeConverter(bool verbose)
+    : data_{std::make_unique<Data>()}
+{
+    data_->verbose = verbose;
+}
+
+//---------------------------------------------------------------------------//
+//! Default destructor
+PhysicalVolumeConverter::~PhysicalVolumeConverter() = default;
+
+//---------------------------------------------------------------------------//
+auto PhysicalVolumeConverter::operator()(arg_type g4world) -> result_type
+{
+    CELER_EXPECT(!g4world.GetRotation());
+    CELER_EXPECT(g4world.GetTranslation() == G4ThreeVector(0, 0, 0));
+
+    CELER_LOG(status) << "Converting Geant4 geometry";
+    ScopedProfiling profile_this{"import-geant-geo"};
+    ScopedMem record_mem("PhysicalVolumeConverter.convert");
+    ScopedTimeLog scoped_time;
+
+    // Construct world volume
+    Builder impl{data_.get(), {}};
+    auto world = impl.make_pv(0, g4world);
+    impl.build_daughters();
+    return world;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a physical volume without building daughters.
+ */
+PhysicalVolume
+PhysicalVolumeConverter::Builder::make_pv(int depth,
+                                          G4VPhysicalVolume const& g4pv)
+{
+    PhysicalVolume result;
+
+    result.name = g4pv.GetName();
+    result.copy_number = g4pv.GetCopyNo();
+    result.transform = this->data->make_transform(g4pv.GetFrameTranslation(),
+                                                  g4pv.GetFrameRotation());
+
+    auto* g4lv = g4pv.GetLogicalVolume();
+    if (auto* unrefl_g4lv
+        = G4ReflectionFactory::Instance()->GetConstituentLV(g4lv))
+    {
+        // Replace with constituent volume, and reflect across Z.
+        // See G4ReflectionFactory::CheckScale: the reflection value is
+        // hardcoded to {1, 1, -1}
+        g4lv = unrefl_g4lv;
+        CELER_NOT_IMPLEMENTED("reflecting a placed volume");
+    }
+
+    // Convert logical volume
+    if (CELER_UNLIKELY(data->verbose))
+    {
+        std::clog << std::string(depth, ' ') << "Converting "
+                  << g4lv->GetName() << std::endl;
+    }
+    auto&& [lv, inserted] = this->data->make_lv(*g4lv);
+    if (inserted)
+    {
+        // Queue up daughters for construction
+        auto num_daughters = g4lv->GetNoDaughters();
+        lv->daughters.reserve(num_daughters);
+        for (auto i : range(num_daughters))
+        {
+            G4VPhysicalVolume* g4pv = g4lv->GetDaughter(i);
+            CELER_ASSERT(g4pv);
+            daughter_queue.push_back({depth + 1, g4pv, lv});
+        }
+    }
+    result.lv = std::move(lv);
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct daughters in a logical volume.
+ */
+void PhysicalVolumeConverter::Builder::place_daughter(
+    int depth, G4VPhysicalVolume const& g4pv, LogicalVolume* lv)
+{
+    if (CELER_UNLIKELY(data->verbose))
+    {
+        std::clog << std::string(depth, ' ') << "Placing " << g4pv.GetName()
+                  << std::endl;
+    }
+
+    if (dynamic_cast<G4PVPlacement const*>(&g4pv))
+    {
+        // Place daughter, accounting for reflection
+        lv->daughters.push_back(this->make_pv(depth, g4pv));
+    }
+    else if (G4VPVParameterisation* param = g4pv.GetParameterisation())
+    {
+        // Loop over number of replicas
+        for (auto j : range(g4pv.GetMultiplicity()))
+        {
+            // Use the paramterization to *change* the physical volume's
+            // position (yes, this is how Geant4 does it too)
+            param->ComputeTransformation(
+                j, const_cast<G4VPhysicalVolume*>(&g4pv));
+
+            // Add a copy
+            lv->daughters.push_back(this->make_pv(depth, g4pv));
+        }
+    }
+    else
+    {
+        TypeDemangler<G4VPhysicalVolume> demangle_pv_type;
+        CELER_LOG(error)
+            << "Unsupported type '" << demangle_pv_type(g4pv)
+            << "' for physical volume '" << g4pv.GetName()
+            << "' (corresponding LV: " << PrintableLV{g4pv.GetLogicalVolume()}
+            << ")";
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct daughters in a logical volume.
+ */
+void PhysicalVolumeConverter::Builder::build_daughters()
+{
+    while (!daughter_queue.empty())
+    {
+        // Grab the front item and pop from the stack
+        auto front = std::move(daughter_queue.front());
+        daughter_queue.pop_front();
+
+        // Build daughters, potentially queueing more daughters
+        CELER_ASSERT(front.g4pv && front.lv);
+        this->place_daughter(front.depth, *front.g4pv, front.lv.get());
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace g4org
+}  // namespace celeritas

--- a/src/orange/g4org/PhysicalVolumeConverter.hh
+++ b/src/orange/g4org/PhysicalVolumeConverter.hh
@@ -20,7 +20,7 @@ namespace g4org
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct a "physical volume" and daughters from a Geant4 object.
+ * Construct a "physical volume" and its children from a Geant4 object.
  *
  * This recurses through the physical volume. It holds a weak-pointer cache of
  * logical volumes already created.

--- a/src/orange/g4org/PhysicalVolumeConverter.hh
+++ b/src/orange/g4org/PhysicalVolumeConverter.hh
@@ -1,0 +1,57 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/g4org/PhysicalVolumeConverter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+
+#include "Volume.hh"
+
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+
+namespace celeritas
+{
+namespace g4org
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a "physical volume" and daughters from a Geant4 object.
+ *
+ * This recurses through the physical volume. It holds a weak-pointer cache of
+ * logical volumes already created.
+ */
+class PhysicalVolumeConverter
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using arg_type = G4VPhysicalVolume const&;
+    using result_type = PhysicalVolume;
+    //!@}
+
+  public:
+    // Construct with options
+    explicit PhysicalVolumeConverter(bool verbose);
+
+    // Default destructor
+    ~PhysicalVolumeConverter();
+
+    // Convert a physical volume
+    result_type operator()(arg_type g4world);
+
+  private:
+    struct Data;
+    struct Builder;
+
+    // Cached data
+    std::unique_ptr<Data> data_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace g4org
+}  // namespace celeritas

--- a/src/orange/g4org/PhysicalVolumeConverter.hh
+++ b/src/orange/g4org/PhysicalVolumeConverter.hh
@@ -9,6 +9,8 @@
 
 #include <memory>
 
+#include "geocel/detail/LengthUnits.hh"
+
 #include "Volume.hh"
 
 class G4LogicalVolume;
@@ -34,9 +36,18 @@ class PhysicalVolumeConverter
     using result_type = PhysicalVolume;
     //!@}
 
+    //! Input options for the conversion
+    struct Options
+    {
+        //! Write output about volumes being converted
+        bool verbose{false};
+        //! Scale factor, customizable for unit testing
+        double scale = celeritas::lengthunits::millimeter;
+    };
+
   public:
     // Construct with options
-    explicit PhysicalVolumeConverter(bool verbose);
+    explicit PhysicalVolumeConverter(Options options);
 
     // Default destructor
     ~PhysicalVolumeConverter();

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -279,6 +279,9 @@ auto SolidConverter::displaced(arg_type solid_base) -> result_type
     G4VSolid* g4daughter = solid.GetConstituentMovedSolid();
     CELER_ASSERT(g4daughter);
     auto daughter = (*this)(*g4daughter);
+
+    // Note that GetDirectTransform is the combination of GetFrameTranslation
+    // and GetFrameRotation .
     return std::make_shared<Transformed>(
         daughter, transform_(solid.GetDirectTransform()));
 }

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -143,7 +143,7 @@ auto SolidConverter::operator()(arg_type solid_base) -> result_type
 
 //---------------------------------------------------------------------------//
 /*!
- * Convert a Geant4 solid to a VecGeom sphere with equivalent capacity.
+ * Convert a Geant4 solid to a sphere with equivalent capacity.
  */
 auto SolidConverter::to_sphere(arg_type solid_base) const -> result_type
 {

--- a/src/orange/g4org/Transformer.hh
+++ b/src/orange/g4org/Transformer.hh
@@ -101,20 +101,29 @@ auto Transformer::operator()(G4ThreeVector const& t) const -> Translation
 /*!
  * Create a transform from a translation plus rotation.
  */
-auto Transformer::operator()(G4ThreeVector const&,
-                             G4RotationMatrix const&) const -> Transformation
+auto Transformer::operator()(G4ThreeVector const& trans,
+                             G4RotationMatrix const& rot) const
+    -> Transformation
 {
-    CELER_NOT_IMPLEMENTED("transformer");
+    return Transformation{transposed_from_geant(rot), scale_.to<Real3>(trans)};
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Create a transform from a translation plus optional rotation.
  */
-auto Transformer::operator()(G4ThreeVector const&,
-                             G4RotationMatrix const*) const -> VariantTransform
+auto Transformer::operator()(G4ThreeVector const& trans,
+                             G4RotationMatrix const* rot) const
+    -> VariantTransform
 {
-    CELER_NOT_IMPLEMENTED("transformer");
+    if (rot)
+    {
+        return (*this)(trans, *rot);
+    }
+    else
+    {
+        return (*this)(trans);
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -124,8 +133,7 @@ auto Transformer::operator()(G4ThreeVector const&,
 auto Transformer::operator()(G4AffineTransform const& affine) const
     -> Transformation
 {
-    return Transformation{transposed_from_geant(affine.NetRotation()),
-                          scale_.to<Real3>(affine.NetTranslation())};
+    return (*this)(affine.NetTranslation(), affine.NetRotation());
 }
 
 //---------------------------------------------------------------------------//
@@ -145,6 +153,7 @@ SquareMatrixReal3 convert_from_geant(G4RotationMatrix const& rot)
  */
 SquareMatrixReal3 transposed_from_geant(G4RotationMatrix const& rot)
 {
+    // TODO: check normality? Orthogonalize?
     return {Real3{{rot.xx(), rot.yx(), rot.zx()}},
             Real3{{rot.xy(), rot.yy(), rot.zy()}},
             Real3{{rot.xz(), rot.yz(), rot.zz()}}};

--- a/src/orange/g4org/Transformer.hh
+++ b/src/orange/g4org/Transformer.hh
@@ -110,24 +110,6 @@ auto Transformer::operator()(G4ThreeVector const& trans,
 
 //---------------------------------------------------------------------------//
 /*!
- * Create a transform from a translation plus optional rotation.
- */
-auto Transformer::operator()(G4ThreeVector const& trans,
-                             G4RotationMatrix const* rot) const
-    -> VariantTransform
-{
-    if (rot)
-    {
-        return (*this)(trans, *rot);
-    }
-    else
-    {
-        return (*this)(trans);
-    }
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Create a transform from an affine transform.
  */
 auto Transformer::operator()(G4AffineTransform const& affine) const

--- a/src/orange/g4org/Transformer.hh
+++ b/src/orange/g4org/Transformer.hh
@@ -32,8 +32,8 @@ namespace g4org
  * matrix-vector multiply (aka \c gemv), this is *not* the same as the affine
  * transform's rotation, which applies the *inverse* of the stored matrix.
  *
- * All Celeritas transforms are "daughter to parent". The transforms returned
- * from this function \em must be daughter-to-parent!
+ * All ORANGE/Celeritas transforms are "daughter to parent". The transforms
+ * returned from this function \em must be daughter-to-parent!
  */
 class Transformer
 {

--- a/src/orange/g4org/Volume.hh
+++ b/src/orange/g4org/Volume.hh
@@ -29,7 +29,10 @@ struct LogicalVolume;
 
 //---------------------------------------------------------------------------//
 /*!
- * An unconstructed Object with a transform.
+ * An unconstructed ORANGE CSG Object with a transform.
+ *
+ * This holds equivalent information to a Geant4 \c G4VPhysicalVolume, but with
+ * \em only ORANGE data structures.
  */
 struct PhysicalVolume
 {
@@ -42,6 +45,9 @@ struct PhysicalVolume
 //---------------------------------------------------------------------------//
 /*!
  * A reusable Object that can be turned into a UnitProto or a Material.
+ *
+ * This holds equivalent information to a Geant4 \c G4LogicalVolume, but with
+ * \em only ORANGE data structures plus a reference to the original G4LV.
  */
 struct LogicalVolume
 {

--- a/src/orange/g4org/Volume.hh
+++ b/src/orange/g4org/Volume.hh
@@ -24,7 +24,20 @@ class ObjectInterface;
 
 namespace g4org
 {
+//---------------------------------------------------------------------------//
 struct LogicalVolume;
+
+//---------------------------------------------------------------------------//
+/*!
+ * An unconstructed Object with a transform.
+ */
+struct PhysicalVolume
+{
+    std::string name;
+    size_type copy_number{};
+    VariantTransform transform;
+    std::shared_ptr<LogicalVolume const> lv;
+};
 
 //---------------------------------------------------------------------------//
 /*!
@@ -36,12 +49,16 @@ struct LogicalVolume
 
     //! Associated Geant4 logical volume
     G4LogicalVolume const* g4lv{nullptr};
-    //! Filled material ID
-    MaterialId material_id;
-    //! "Unplaced" mother shape
-    SPConstObject solid;
+
     //! Logical volume name
     std::string name;
+    //! Filled material ID
+    MaterialId material_id;
+
+    //! "Unplaced" mother shape
+    SPConstObject solid;
+    //! Daughter volumes
+    std::vector<PhysicalVolume> daughters;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/g4org/Volume.hh
+++ b/src/orange/g4org/Volume.hh
@@ -55,10 +55,10 @@ struct LogicalVolume
     //! Filled material ID
     MaterialId material_id;
 
-    //! "Unplaced" mother shape
+    //! "Unplaced" parent shape
     SPConstObject solid;
-    //! Daughter volumes
-    std::vector<PhysicalVolume> daughters;
+    //! Embedded child volumes
+    std::vector<PhysicalVolume> children;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/g4org/Volume.hh
+++ b/src/orange/g4org/Volume.hh
@@ -1,0 +1,49 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/g4org/Volume.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "orange/OrangeTypes.hh"
+#include "orange/transform/VariantTransform.hh"
+
+class G4LogicalVolume;
+
+namespace celeritas
+{
+namespace orangeinp
+{
+class ObjectInterface;
+}
+
+namespace g4org
+{
+struct LogicalVolume;
+
+//---------------------------------------------------------------------------//
+/*!
+ * A reusable Object that can be turned into a UnitProto or a Material.
+ */
+struct LogicalVolume
+{
+    using SPConstObject = std::shared_ptr<orangeinp::ObjectInterface const>;
+
+    //! Associated Geant4 logical volume
+    G4LogicalVolume const* g4lv{nullptr};
+    //! Filled material ID
+    MaterialId material_id;
+    //! "Unplaced" mother shape
+    SPConstObject solid;
+    //! Logical volume name
+    std::string name;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace g4org
+}  // namespace celeritas

--- a/src/orange/transform/Transformation.cc
+++ b/src/orange/transform/Transformation.cc
@@ -40,14 +40,16 @@ Transformation::Transformation() : Transformation{Translation{}} {}
 /*!
  * Construct and check the input.
  *
- * The input rotation matrix should be an orthonormal matrix without
- * reflecting, thus having a determinant of unity. It is the caller's job to
- * ensure a user-provided low-precision matrix is orthonormalized.
+ * The input rotation matrix should be an orthonormal matrix. Its determinant
+ * is 1 if not reflecting (proper) or -1 if reflecting (improper).  It is the
+ * caller's job to ensure a user-provided low-precision matrix is
+ * orthonormal: see \c celeritas::orthonormalize .
  */
 Transformation::Transformation(Mat3 const& rot, Real3 const& trans)
     : rot_(rot), tra_(trans)
 {
-    CELER_EXPECT(soft_equal(determinant(rot_), real_type(1)));
+    // XXX: should this be a CELER_VALIDATE?
+    CELER_EXPECT(soft_equal(std::fabs(determinant(rot_)), real_type(1)));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/transform/Transformation.cc
+++ b/src/orange/transform/Transformation.cc
@@ -43,12 +43,13 @@ Transformation::Transformation() : Transformation{Translation{}} {}
  * The input rotation matrix should be an orthonormal matrix. Its determinant
  * is 1 if not reflecting (proper) or -1 if reflecting (improper).  It is the
  * caller's job to ensure a user-provided low-precision matrix is
- * orthonormal: see \c celeritas::orthonormalize .
+ * orthonormal: see \c celeritas::orthonormalize . (Add \c CELER_VALIDATE to
+ * the calling code if constructing a transformation matrix from user input or
+ * a suspect source.)
  */
 Transformation::Transformation(Mat3 const& rot, Real3 const& trans)
     : rot_(rot), tra_(trans)
 {
-    // XXX: should this be a CELER_VALIDATE?
     CELER_EXPECT(soft_equal(std::fabs(determinant(rot_)), real_type(1)));
 }
 

--- a/src/orange/transform/Transformation.hh
+++ b/src/orange/transform/Transformation.hh
@@ -22,7 +22,7 @@ class SignedPermutation;
 
 //---------------------------------------------------------------------------//
 /*!
- * Apply transformations with rotation.
+ * Apply transformations with rotation and/or reflection.
  *
  * \note The nomenclature in this class assumes the translation vector and
  * rotation matrix given represent "daughter-to-parent"! This is because we

--- a/test/Test.cc
+++ b/test/Test.cc
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cctype>
 #include <fstream>
+#include <regex>
 
 #include "celeritas_test_config.h"
 #include "corecel/Assert.hh"
@@ -39,6 +40,16 @@ Test::test_data_path(std::string_view subdir, std::string_view filename)
                        << "Failed to open test data file at '" << path << "'");
     }
     return path;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Replace pointer addresses with 0x0 for improved testability.
+ */
+[[nodiscard]] std::string Test::genericize_pointers(std::string const& s)
+{
+    static std::regex const subs_ptr("0x[0-9a-f]{2,}");
+    return std::regex_replace(s, subs_ptr, "0x0");
 }
 
 //---------------------------------------------------------------------------//

--- a/test/Test.hh
+++ b/test/Test.hh
@@ -45,6 +45,9 @@ class Test : public ::testing::Test
     static std::string
     test_data_path(std::string_view subdir, std::string_view filename);
 
+    // Replace pointer addresses with 0x0 for improved testability.
+    [[nodiscard]] static std::string genericize_pointers(std::string const& s);
+
     // True if CELER_TEST_STRICT is set (under CI)
     static bool strict_testing();
 

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -7,8 +7,6 @@
 //---------------------------------------------------------------------------//
 #include "celeritas/ext/GeantImporter.hh"
 
-#include <regex>
-
 #include "celeritas_cmake_strings.h"
 #include "celeritas_config.h"
 #include "corecel/ScopedLogStorer.hh"
@@ -47,12 +45,6 @@ std::vector<std::string> to_vec_string(Iter iter, Iter end)
         result.push_back(to_cstring(*iter));
     }
     return result;
-}
-
-std::string sub_pointer_string(std::string const& s)
-{
-    static std::regex const r("0x[0-9a-f]{2,}");
-    return std::regex_replace(s, r, "0x0");
 }
 
 double to_inv_cm(double v)
@@ -1112,7 +1104,7 @@ TEST_F(TestEm3, volume_names)
     std::vector<std::string> names;
     for (auto const& volume : volumes)
     {
-        names.push_back(sub_pointer_string(volume.name));
+        names.push_back(this->genericize_pointers(volume.name));
     }
 
     // clang-format off
@@ -1132,7 +1124,9 @@ TEST_F(TestEm3, unique_volumes)
 
     EXPECT_EQ(101, volumes.size());
     EXPECT_EQ("gap_00x0x0",
-              sub_pointer_string(sub_pointer_string(volumes.front().name)));
+              this->genericize_pointers(
+                  this->genericize_pointers(volumes.front().name)))
+        << "Front name: '" << volumes.front().name << "'";
 }
 
 //---------------------------------------------------------------------------//
@@ -1550,9 +1544,7 @@ TEST_F(Solids, volumes_unique)
     std::vector<std::string> names;
     for (auto const& volume : imported.volumes)
     {
-        static std::regex const subs_ptr("0x[0-9a-f]+");
-        auto name = std::regex_replace(volume.name, subs_ptr, "0x0");
-        names.push_back(name);
+        names.push_back(this->genericize_pointers(volume.name));
     }
     static char const* const expected_names[]
         = {"box5000x0",    "cone10x0",      "para10x0",

--- a/test/geocel/data/intersection-boxes.gdml
+++ b/test/geocel/data/intersection-boxes.gdml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+  <define>
+    <position name="translate" unit="cm" x="1" y="2" z="4"/>
+    <rotation name="rotate" unit="deg" x="0" y="30" z="0"/>
+  </define>
+  <solids>
+    <box lunit="cm" name="first" x="2" y="3" z="4"/>
+    <box lunit="cm" name="second" x="3" y="4" z="5"/>
+    <box lunit="cm" name="world_box" x="100" y="100" z="100"/>
+    <intersection name="isect">
+      <first ref="first"/>
+      <second ref="second"/>
+      <positionref ref="translate"/>
+      <rotationref ref="rotate"/>
+    </intersection>
+  </solids>
+  <structure>
+    <volume name="inner">
+      <solidref ref="isect"/>
+    </volume>
+    <volume name="world">
+      <solidref ref="world_box"/>
+      <physvol>
+        <volumeref ref="inner"/>
+      </physvol>
+    </volume>
+  </structure>
+  <setup name="default" version="1.0">
+    <world ref="world"/>
+  </setup>
+</gdml>

--- a/test/geocel/data/testem3.gdml
+++ b/test/geocel/data/testem3.gdml
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!-- SPDX-FileCopyrightText: 2022 CERN -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+  <define>
+    <position name="G4_Pb_pos" unit="mm" x="-2.85" y="0" z="0"/>
+    <position name="G4_lApos" unit="mm" x="1.15" y="0" z="0"/>
+  </define>
+
+  <materials>
+    <material name="G4_Galactic" state="gas">
+      <T unit="K" value="2.73"/>
+      <P unit="pascal" value="3e-18"/>
+      <MEE unit="eV" value="21.8"/>
+      <D unit="g/cm3" value="1e-25"/>
+      <fraction n="1" ref="H"/>
+    </material>
+    <isotope N="204" Z="82" name="Pb204">
+      <atom unit="g/mole" value="203.973"/>
+    </isotope>
+    <isotope N="206" Z="82" name="Pb206">
+      <atom unit="g/mole" value="205.974"/>
+    </isotope>
+    <isotope N="207" Z="82" name="Pb207">
+      <atom unit="g/mole" value="206.976"/>
+    </isotope>
+    <isotope N="208" Z="82" name="Pb208">
+      <atom unit="g/mole" value="207.977"/>
+    </isotope>
+    <element name="Pb">
+      <fraction n="0.014" ref="Pb204"/>
+      <fraction n="0.241" ref="Pb206"/>
+      <fraction n="0.221" ref="Pb207"/>
+      <fraction n="0.524" ref="Pb208"/>
+    </element>
+    <material name="G4_Pb" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="823"/>
+      <D unit="g/cm3" value="11.35"/>
+      <fraction n="1" ref="Pb"/>
+    </material>
+    <isotope N="36" Z="18" name="Ar36">
+      <atom unit="g/mole" value="35.9675"/>
+    </isotope>
+    <isotope N="38" Z="18" name="Ar38">
+      <atom unit="g/mole" value="37.9627"/>
+    </isotope>
+    <isotope N="40" Z="18" name="Ar40">
+      <atom unit="g/mole" value="39.9624"/>
+    </isotope>
+    <element name="Ar">
+      <fraction n="0.003365" ref="Ar36"/>
+      <fraction n="0.000632" ref="Ar38"/>
+      <fraction n="0.996003" ref="Ar40"/>
+    </element>
+    <material name="G4_lAr" state="liquid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="188"/>
+      <D unit="g/cm3" value="1.396"/>
+      <fraction n="1" ref="Ar"/>
+    </material>
+    <isotope N="1" Z="1" name="H1">
+      <atom unit="g/mole" value="1.00782503081372"/>
+    </isotope>
+    <isotope N="2" Z="1" name="H2">
+      <atom unit="g/mole" value="2.01410199966617"/>
+    </isotope>
+    <element name="H">
+      <fraction n="0.999885" ref="H1"/>
+      <fraction n="0.000115" ref="H2"/>
+    </element>
+  </materials>
+
+  <solids>
+    <box lunit="mm" name="Absorber1" x="2.3" y="400" z="400"/>
+    <box lunit="mm" name="Absorber2" x="5.7" y="400" z="400"/>
+    <box lunit="mm" name="Layer" x="8" y="400" z="400"/>
+    <box lunit="mm" name="Calorimeter" x="400" y="400" z="400"/>
+    <box lunit="mm" name="World" x="480" y="480" z="480"/>
+  </solids>
+
+  <structure>
+    <volume name="G4_Pb">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="Layer">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Calorimeter">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Calorimeter"/>
+      <physvol copynumber="1" name="Layer0x560dcd38d7b0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38d7b0_pos" unit="mm" x="-196" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="2" name="Layer0x560dcd38d8c0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38d8c0_pos" unit="mm" x="-188" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="3" name="Layer0x560dcd38d970">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38d970_pos" unit="mm" x="-180" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="4" name="Layer0x560dcd38da60">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38da60_pos" unit="mm" x="-172" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="5" name="Layer0x560dcd38daf0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38daf0_pos" unit="mm" x="-164" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="6" name="Layer0x560dcd38dc20">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38dc20_pos" unit="mm" x="-156" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="7" name="Layer0x560dcd38dc80">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38dc80_pos" unit="mm" x="-148" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="8" name="Layer0x560dcd38dce0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38dce0_pos" unit="mm" x="-140" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="9" name="Layer0x560dcd38dd70">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38dd70_pos" unit="mm" x="-132" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="10" name="Layer0x560dcd38df20">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38df20_pos" unit="mm" x="-124" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="11" name="Layer0x560dcd38dfb0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38dfb0_pos" unit="mm" x="-116" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="12" name="Layer0x560dcd38e040">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e040_pos" unit="mm" x="-108" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="13" name="Layer0x560dcd38e0d0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e0d0_pos" unit="mm" x="-100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="14" name="Layer0x560dcd38e160">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e160_pos" unit="mm" x="-92" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="15" name="Layer0x560dcd38e1f0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e1f0_pos" unit="mm" x="-84" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="16" name="Layer0x560dcd38e280">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e280_pos" unit="mm" x="-76" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="17" name="Layer0x560dcd38e310">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e310_pos" unit="mm" x="-68" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="18" name="Layer0x560dcd38e4b0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e4b0_pos" unit="mm" x="-60" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="19" name="Layer0x560dcd38e540">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e540_pos" unit="mm" x="-52" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="20" name="Layer0x560dcd38e5d0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e5d0_pos" unit="mm" x="-44" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="21" name="Layer0x560dcd38e660">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e660_pos" unit="mm" x="-36" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="22" name="Layer0x560dcd38e6f0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e6f0_pos" unit="mm" x="-28" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="23" name="Layer0x560dcd38e780">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e780_pos" unit="mm" x="-20" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="24" name="Layer0x560dcd38e810">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e810_pos" unit="mm" x="-12" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="25" name="Layer0x560dcd38e8a0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e8a0_pos" unit="mm" x="-4" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="26" name="Layer0x560dcd38e930">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e930_pos" unit="mm" x="4" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="27" name="Layer0x560dcd38e9c0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38e9c0_pos" unit="mm" x="12" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="28" name="Layer0x560dcd38ea50">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38ea50_pos" unit="mm" x="20" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="29" name="Layer0x560dcd38eae0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38eae0_pos" unit="mm" x="28" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="30" name="Layer0x560dcd38eb70">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38eb70_pos" unit="mm" x="36" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="31" name="Layer0x560dcd38ec00">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38ec00_pos" unit="mm" x="44" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="32" name="Layer0x560dcd38ec90">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38ec90_pos" unit="mm" x="52" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="33" name="Layer0x560dcd38ed20">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38ed20_pos" unit="mm" x="60" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="34" name="Layer0x560dcd38edb0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38edb0_pos" unit="mm" x="68" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="35" name="Layer0x560dcd38ee40">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38ee40_pos" unit="mm" x="76" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="36" name="Layer0x560dcd38eed0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38eed0_pos" unit="mm" x="84" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="37" name="Layer0x560dcd38ef60">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38ef60_pos" unit="mm" x="92" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="38" name="Layer0x560dcd38eff0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38eff0_pos" unit="mm" x="100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="39" name="Layer0x560dcd38f080">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f080_pos" unit="mm" x="108" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="40" name="Layer0x560dcd38f110">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f110_pos" unit="mm" x="116" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="41" name="Layer0x560dcd38f1a0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f1a0_pos" unit="mm" x="124" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="42" name="Layer0x560dcd38f230">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f230_pos" unit="mm" x="132" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="43" name="Layer0x560dcd38f2c0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f2c0_pos" unit="mm" x="140" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="44" name="Layer0x560dcd38f350">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f350_pos" unit="mm" x="148" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="45" name="Layer0x560dcd38f3e0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f3e0_pos" unit="mm" x="156" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="46" name="Layer0x560dcd38f470">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f470_pos" unit="mm" x="164" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="47" name="Layer0x560dcd38f500">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f500_pos" unit="mm" x="172" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="48" name="Layer0x560dcd38f590">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f590_pos" unit="mm" x="180" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="49" name="Layer0x560dcd38f620">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f620_pos" unit="mm" x="188" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="50" name="Layer0x560dcd38f6b0">
+        <volumeref ref="Layer"/>
+        <position name="Layer0x560dcd38f6b0_pos" unit="mm" x="196" y="0" z="0"/>
+      </physvol>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="0"/>
+    </volume>
+    <volume name="World">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="World"/>
+      <physvol name="Calorimeter">
+        <volumeref ref="Calorimeter"/>
+      </physvol>
+    </volume>
+  </structure>
+
+  <userinfo>
+    <auxiliary auxtype="Region" auxvalue="caloregion">
+      <auxiliary auxtype="volume" auxvalue="Calorimeter"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+  </userinfo>
+
+  <setup name="Default" version="1.0">
+    <world ref="World"/>
+  </setup>
+
+</gdml>

--- a/test/geocel/data/transformed-box.gdml
+++ b/test/geocel/data/transformed-box.gdml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+  <solids>
+    <box lunit="cm" name="simple_box" x="2" y="3" z="4"/>
+    <box lunit="cm" name="world_box" x="100" y="100" z="100"/>
+  </solids>
+  <structure>
+    <volume name="simple">
+      <solidref ref="simple_box"/>
+    </volume>
+    <volume name="world">
+      <solidref ref="world_box"/>
+      <physvol name="transrot">
+        <volumeref ref="simple"/>
+        <position unit="cm" x="0" y="0" z="-10"/>
+        <rotation unit="deg" x="0" y="30" z="0"/>
+      </physvol>
+      <physvol name="default">
+        <volumeref ref="simple"/>
+      </physvol>
+      <physvol name="trans">
+        <volumeref ref="simple"/>
+        <position unit="cm" x="0" y="0" z="10"/>
+      </physvol>
+    </volume>
+  </structure>
+  <setup name="default" version="1.0">
+    <world ref="world"/>
+  </setup>
+</gdml>

--- a/test/geocel/data/two-boxes.gdml
+++ b/test/geocel/data/two-boxes.gdml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <solids>
-    <box lunit="cm" name="inner_box" x="10" y="10" z="10" />
-    <box lunit="cm" name="world_box" x="1000" y="1000" z="1000" />
+    <box lunit="cm" name="inner_box" x="10" y="10" z="10"/>
+    <box lunit="cm" name="world_box" x="1000" y="1000" z="1000"/>
   </solids>
   <structure>
     <volume name="inner">

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #include "Vecgeom.test.hh"
 
-#include <regex>
 #include <string_view>
 
 #include "celeritas_cmake_strings.h"
@@ -47,12 +46,6 @@ namespace
 {
 auto const vecgeom_version
     = celeritas::Version::from_string(celeritas_vecgeom_version);
-
-std::string simplify_pointers(std::string const& s)
-{
-    static std::regex const subs_ptr("0x[0-9a-f]+");
-    return std::regex_replace(s, subs_ptr, "0x0");
-}
 }  // namespace
 
 //---------------------------------------------------------------------------//
@@ -690,7 +683,8 @@ TEST_F(SolidsTest, names)
     std::vector<std::string> labels;
     for (auto vid : range(VolumeId{geom.num_volumes()}))
     {
-        labels.push_back(simplify_pointers(to_string(geom.id_to_label(vid))));
+        labels.push_back(
+            this->genericize_pointers(to_string(geom.id_to_label(vid))));
     }
 
     // clang-format off
@@ -712,7 +706,7 @@ TEST_F(SolidsTest, output)
 
     if (CELERITAS_USE_JSON && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
-        auto out_str = simplify_pointers(to_string(out));
+        auto out_str = this->genericize_pointers(to_string(out));
 
         EXPECT_JSON_EQ(
             R"json({"bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"supports_safety":true,"volumes":{"label":["b500","b100","union1","b100","box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","trd3","trd3_refl","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","","trd3_refl"]}})json",
@@ -1255,7 +1249,8 @@ TEST_F(SolidsGeantTest, names)
     std::vector<std::string> labels;
     for (auto vid : range(VolumeId{geom.num_volumes()}))
     {
-        labels.push_back(simplify_pointers(to_string(geom.id_to_label(vid))));
+        labels.push_back(
+            this->genericize_pointers(to_string(geom.id_to_label(vid))));
     }
 
     // clang-format off
@@ -1278,7 +1273,7 @@ TEST_F(SolidsGeantTest, output)
 
     if (CELERITAS_USE_JSON && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
-        auto out_str = simplify_pointers(to_string(out));
+        auto out_str = this->genericize_pointers(to_string(out));
 
         EXPECT_JSON_EQ(
             R"json({"bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"supports_safety":true,"volumes":{"label":["box500@0x0","cone1@0x0","para1@0x0","sphere1@0x0","parabol1@0x0","trap1@0x0","trd1@0x0","trd2@0x0","trd3@0x0","trd3_refl@0x0","tube100@0x0","","","","","boolean1@0x0","polycone1@0x0","genPocone1@0x0","ellipsoid1@0x0","tetrah1@0x0","orb1@0x0","polyhedr1@0x0","hype1@0x0","elltube1@0x0","ellcone1@0x0","arb8b@0x0","arb8a@0x0","xtru1@0x0","World@0x0","","trd3@0x0_refl"]}})json",

--- a/test/orange/CMakeLists.txt
+++ b/test/orange/CMakeLists.txt
@@ -131,8 +131,9 @@ if(CELERITAS_USE_Geant4 AND CELERITAS_REAL_TYPE STREQUAL "double")
   set(CELERITASTEST_PREFIX orange/g4org)
   list(APPEND CELERITASTEST_LINK_LIBRARIES ${_g4_geo_libs})
 
-  celeritas_add_test(g4org/Transformer.test.cc)
   celeritas_add_test(g4org/SolidConverter.test.cc)
+  celeritas_add_test(g4org/PhysicalVolumeConverter.test.cc)
+  celeritas_add_test(g4org/Transformer.test.cc)
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/test/orange/g4org/PhysicalVolumeConverter.test.cc
+++ b/test/orange/g4org/PhysicalVolumeConverter.test.cc
@@ -1,0 +1,169 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/g4org/PhysicalVolumeConverter.test.cc
+//---------------------------------------------------------------------------//
+#include "orange/g4org/PhysicalVolumeConverter.hh"
+
+#include <regex>
+
+#include "corecel/io/StreamableVariant.hh"
+#include "geocel/GeantGeoUtils.hh"
+#include "geocel/LazyGeoManager.hh"
+#include "geocel/UnitUtils.hh"
+#include "orange/orangeinp/ObjectInterface.hh"
+#include "orange/transform/TransformIO.hh"
+
+#include "celeritas_test.hh"
+
+using celeritas::test::to_cm;
+
+namespace celeritas
+{
+namespace g4org
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+std::string simplify_pointers(std::string const& s)
+{
+    static std::regex const subs_ptr("0x[0-9a-f]+");
+    return std::regex_replace(s, subs_ptr, "0x0");
+}
+
+class PhysicalVolumeConverterTest : public ::celeritas::test::Test
+{
+  protected:
+    G4VPhysicalVolume const* load(std::string const& filename)
+    {
+        return ::celeritas::load_geant_geometry_native(
+            this->test_data_path("geocel", filename));
+    }
+
+    void TearDown() final { ::celeritas::reset_geant_geometry(); }
+};
+
+//---------------------------------------------------------------------------//
+TEST_F(PhysicalVolumeConverterTest, testem3)
+{
+    G4VPhysicalVolume const* g4world = this->load("testem3.gdml");
+    PhysicalVolumeConverter convert{/* verbose = */ true};
+
+    PhysicalVolume world = convert(*g4world);
+    EXPECT_EQ("World_PV", world.name);
+    EXPECT_EQ(0, world.copy_number);
+
+    ASSERT_TRUE(world.lv);
+    EXPECT_EQ(1, world.lv.use_count());
+    LogicalVolume const* lv = world.lv.get();
+
+    {
+        // Test world's logical volume
+        EXPECT_NE(nullptr, lv->g4lv);
+        EXPECT_EQ("World0x0", simplify_pointers(lv->name));
+        ASSERT_TRUE(lv->solid);
+        if (CELERITAS_USE_JSON)
+        {
+            EXPECT_JSON_EQ(
+                R"json({"_type":"shape","interior":{"_type":"box","halfwidths":[24.0,24.0,24.0]},"label":"World"})json",
+                to_string(*lv->solid));
+        }
+        ASSERT_EQ(1, lv->daughters.size());
+
+        auto const& calo_pv = lv->daughters.front();
+        EXPECT_EQ(1, calo_pv.lv.use_count());
+        ASSERT_TRUE(calo_pv.lv);
+        lv = calo_pv.lv.get();
+    }
+    {
+        // Test calorimeter
+        EXPECT_EQ("Calorimeter0x0", simplify_pointers(lv->name));
+        ASSERT_EQ(50, lv->daughters.size());
+
+        auto const& first_layer = lv->daughters.front();
+        EXPECT_EQ(1, first_layer.copy_number);
+        EXPECT_EQ(50, first_layer.lv.use_count());
+        if (auto* trans = std::get_if<Translation>(&first_layer.transform))
+        {
+            EXPECT_VEC_SOFT_EQ((Real3{-19.6, 0, 0}),
+                               to_cm(trans->translation()));
+        }
+        else
+        {
+            ADD_FAILURE() << "Unexpected transform type: "
+                          << StreamableVariant{first_layer.transform};
+        }
+
+        auto const& last_layer = lv->daughters.back();
+        EXPECT_EQ(50, last_layer.copy_number);
+        EXPECT_EQ(first_layer.lv.get(), last_layer.lv.get());
+
+        ASSERT_TRUE(first_layer.lv);
+        lv = first_layer.lv.get();
+    }
+    {
+        // Test layer
+        EXPECT_EQ("Layer0x0", simplify_pointers(lv->name));
+        ASSERT_EQ(2, lv->daughters.size());
+
+        ASSERT_TRUE(lv->solid);
+        if (CELERITAS_USE_JSON)
+        {
+            EXPECT_JSON_EQ(
+                R"json({"_type":"shape","interior":{"_type":"box","halfwidths":[0.4,20.0,20.0]},"label":"Layer"})json",
+                to_string(*lv->solid));
+        }
+
+        auto const& lead = lv->daughters.front();
+        EXPECT_EQ(1, lead.lv.use_count());
+
+        ASSERT_TRUE(lead.lv);
+        lv = lead.lv.get();
+    }
+    {
+        // Test lead
+        EXPECT_EQ("G4_Pb0x0", simplify_pointers(lv->name));
+        EXPECT_EQ(0, lv->daughters.size());
+    }
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(PhysicalVolumeConverterTest, DISABLED_four_levels)
+{
+    G4VPhysicalVolume const* g4world = this->load("four-levels.gdml");
+    PhysicalVolumeConverter convert{/* verbose = */ true};
+
+    PhysicalVolume world = convert(*g4world);
+    EXPECT_EQ("World_PV", world.name);
+    EXPECT_EQ(0, world.copy_number);
+
+    ASSERT_TRUE(world.lv);
+    EXPECT_EQ(1, world.lv.use_count());
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(PhysicalVolumeConverterTest, znenv)
+{
+    G4VPhysicalVolume const* g4world = this->load("znenv.gdml");
+
+    PhysicalVolumeConverter convert{/* verbose = */ true};
+
+    PhysicalVolume world = convert(*g4world);
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(PhysicalVolumeConverterTest, DISABLED_solids)
+{
+    G4VPhysicalVolume const* g4world = this->load("solids.gdml");
+
+    PhysicalVolumeConverter convert{/* verbose = */ true};
+
+    PhysicalVolume world = convert(*g4world);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace g4org
+}  // namespace celeritas

--- a/test/orange/g4org/PhysicalVolumeConverter.test.cc
+++ b/test/orange/g4org/PhysicalVolumeConverter.test.cc
@@ -56,6 +56,15 @@ TEST_F(PhysicalVolumeConverterTest, DISABLED_four_levels)
     PhysicalVolume world = convert(*g4world);
     EXPECT_EQ("World_PV", world.name);
     EXPECT_EQ(0, world.copy_number);
+    if (auto* trans = std::get_if<NoTransformation>(&world.transform))
+    {
+        // All good
+    }
+    else
+    {
+        ADD_FAILURE() << "Unexpected transform type: "
+                      << StreamableVariant{world.transform};
+    }
 
     ASSERT_TRUE(world.lv);
     EXPECT_EQ(1, world.lv.use_count());
@@ -221,10 +230,7 @@ TEST_F(PhysicalVolumeConverterTest, transformed_box)
     {
         auto const& pv = world.lv->daughters[1];
         EXPECT_EQ("default", pv.name);
-        if (auto* trans = std::get_if<Translation>(&pv.transform))
-        {
-            EXPECT_VEC_SOFT_EQ((Real3{0, 0, 0}), to_cm(trans->translation()));
-        }
+        if (auto* trans = std::get_if<NoTransformation>(&pv.transform)) {}
         else
         {
             ADD_FAILURE() << "Unexpected transform type: "

--- a/test/orange/g4org/PhysicalVolumeConverter.test.cc
+++ b/test/orange/g4org/PhysicalVolumeConverter.test.cc
@@ -10,7 +10,6 @@
 #include "corecel/io/StreamableVariant.hh"
 #include "corecel/sys/Environment.hh"
 #include "geocel/GeantGeoUtils.hh"
-#include "geocel/LazyGeoManager.hh"
 #include "orange/MatrixUtils.hh"
 #include "orange/orangeinp/ObjectInterface.hh"
 #include "orange/transform/TransformIO.hh"

--- a/test/orange/g4org/PhysicalVolumeConverter.test.cc
+++ b/test/orange/g4org/PhysicalVolumeConverter.test.cc
@@ -76,9 +76,9 @@ TEST_F(PhysicalVolumeConverterTest, intersection_boxes)
 
     ASSERT_TRUE(world.lv);
     EXPECT_EQ("world0x0", simplify_pointers(world.lv->name));
-    ASSERT_EQ(1, world.lv->daughters.size());
+    ASSERT_EQ(1, world.lv->children.size());
 
-    auto const& inner_pv = world.lv->daughters.front();
+    auto const& inner_pv = world.lv->children.front();
     ASSERT_TRUE(inner_pv.lv);
     EXPECT_EQ("inner0x0", simplify_pointers(inner_pv.lv->name));
     ASSERT_TRUE(inner_pv.lv->solid);
@@ -141,9 +141,9 @@ TEST_F(PhysicalVolumeConverterTest, testem3)
                 R"json({"_type":"shape","interior":{"_type":"box","halfwidths":[240.0,240.0,240.0]},"label":"World"})json",
                 to_string(*lv->solid));
         }
-        ASSERT_EQ(1, lv->daughters.size());
+        ASSERT_EQ(1, lv->children.size());
 
-        auto const& calo_pv = lv->daughters.front();
+        auto const& calo_pv = lv->children.front();
         EXPECT_EQ(1, calo_pv.lv.use_count());
         ASSERT_TRUE(calo_pv.lv);
         lv = calo_pv.lv.get();
@@ -151,9 +151,9 @@ TEST_F(PhysicalVolumeConverterTest, testem3)
     {
         // Test calorimeter
         EXPECT_EQ("Calorimeter0x0", simplify_pointers(lv->name));
-        ASSERT_EQ(50, lv->daughters.size());
+        ASSERT_EQ(50, lv->children.size());
 
-        auto const& first_layer = lv->daughters.front();
+        auto const& first_layer = lv->children.front();
         EXPECT_EQ(1, first_layer.copy_number);
         EXPECT_EQ(50, first_layer.lv.use_count());
         if (auto* trans = std::get_if<Translation>(&first_layer.transform))
@@ -167,7 +167,7 @@ TEST_F(PhysicalVolumeConverterTest, testem3)
                           << StreamableVariant{first_layer.transform};
         }
 
-        auto const& last_layer = lv->daughters.back();
+        auto const& last_layer = lv->children.back();
         EXPECT_EQ(50, last_layer.copy_number);
         EXPECT_EQ(first_layer.lv.get(), last_layer.lv.get());
 
@@ -177,7 +177,7 @@ TEST_F(PhysicalVolumeConverterTest, testem3)
     {
         // Test layer
         EXPECT_EQ("Layer0x0", simplify_pointers(lv->name));
-        ASSERT_EQ(2, lv->daughters.size());
+        ASSERT_EQ(2, lv->children.size());
 
         ASSERT_TRUE(lv->solid);
         if (CELERITAS_USE_JSON && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
@@ -187,7 +187,7 @@ TEST_F(PhysicalVolumeConverterTest, testem3)
                 to_string(*lv->solid));
         }
 
-        auto const& lead = lv->daughters.front();
+        auto const& lead = lv->children.front();
         EXPECT_EQ(1, lead.lv.use_count());
 
         ASSERT_TRUE(lead.lv);
@@ -196,7 +196,7 @@ TEST_F(PhysicalVolumeConverterTest, testem3)
     {
         // Test lead
         EXPECT_EQ("G4_Pb0x0", simplify_pointers(lv->name));
-        EXPECT_EQ(0, lv->daughters.size());
+        EXPECT_EQ(0, lv->children.size());
     }
 }
 
@@ -210,10 +210,10 @@ TEST_F(PhysicalVolumeConverterTest, transformed_box)
     EXPECT_EQ("world_PV", simplify_pointers(world.name));
 
     ASSERT_TRUE(world.lv);
-    ASSERT_EQ(3, world.lv->daughters.size());
+    ASSERT_EQ(3, world.lv->children.size());
 
     {
-        auto const& pv = world.lv->daughters[0];
+        auto const& pv = world.lv->children[0];
         EXPECT_EQ("transrot", pv.name);
         if (auto* trans = std::get_if<Transformation>(&pv.transform))
         {
@@ -230,7 +230,7 @@ TEST_F(PhysicalVolumeConverterTest, transformed_box)
         }
     }
     {
-        auto const& pv = world.lv->daughters[1];
+        auto const& pv = world.lv->children[1];
         EXPECT_EQ("default", pv.name);
         if (!std::holds_alternative<NoTransformation>(pv.transform))
         {
@@ -239,7 +239,7 @@ TEST_F(PhysicalVolumeConverterTest, transformed_box)
         }
     }
     {
-        auto const& pv = world.lv->daughters[2];
+        auto const& pv = world.lv->children[2];
         EXPECT_EQ("trans", pv.name);
         if (auto* trans = std::get_if<Translation>(&pv.transform))
         {

--- a/test/orange/g4org/PhysicalVolumeConverter.test.cc
+++ b/test/orange/g4org/PhysicalVolumeConverter.test.cc
@@ -7,8 +7,6 @@
 //---------------------------------------------------------------------------//
 #include "orange/g4org/PhysicalVolumeConverter.hh"
 
-#include <regex>
-
 #include "corecel/io/StreamableVariant.hh"
 #include "corecel/sys/Environment.hh"
 #include "geocel/GeantGeoUtils.hh"
@@ -34,12 +32,6 @@ auto make_options()
 }
 
 //---------------------------------------------------------------------------//
-std::string simplify_pointers(std::string const& s)
-{
-    static std::regex const subs_ptr("0x[0-9a-f]+");
-    return std::regex_replace(s, subs_ptr, "0x0");
-}
-
 class PhysicalVolumeConverterTest : public ::celeritas::test::Test
 {
   protected:
@@ -83,12 +75,12 @@ TEST_F(PhysicalVolumeConverterTest, intersection_boxes)
     PhysicalVolume world = convert(*g4world);
 
     ASSERT_TRUE(world.lv);
-    EXPECT_EQ("world0x0", simplify_pointers(world.lv->name));
+    EXPECT_EQ("world0x0", this->genericize_pointers(world.lv->name));
     ASSERT_EQ(1, world.lv->children.size());
 
     auto const& inner_pv = world.lv->children.front();
     ASSERT_TRUE(inner_pv.lv);
-    EXPECT_EQ("inner0x0", simplify_pointers(inner_pv.lv->name));
+    EXPECT_EQ("inner0x0", this->genericize_pointers(inner_pv.lv->name));
     ASSERT_TRUE(inner_pv.lv->solid);
     if (CELERITAS_USE_JSON)
     {
@@ -135,7 +127,7 @@ TEST_F(PhysicalVolumeConverterTest, testem3)
     {
         // Test world's logical volume
         EXPECT_NE(nullptr, lv->g4lv);
-        EXPECT_EQ("World0x0", simplify_pointers(lv->name));
+        EXPECT_EQ("World0x0", this->genericize_pointers(lv->name));
         ASSERT_TRUE(lv->solid);
         if (CELERITAS_USE_JSON)
         {
@@ -152,7 +144,7 @@ TEST_F(PhysicalVolumeConverterTest, testem3)
     }
     {
         // Test calorimeter
-        EXPECT_EQ("Calorimeter0x0", simplify_pointers(lv->name));
+        EXPECT_EQ("Calorimeter0x0", this->genericize_pointers(lv->name));
         ASSERT_EQ(50, lv->children.size());
 
         auto const& first_layer = lv->children.front();
@@ -177,7 +169,7 @@ TEST_F(PhysicalVolumeConverterTest, testem3)
     }
     {
         // Test layer
-        EXPECT_EQ("Layer0x0", simplify_pointers(lv->name));
+        EXPECT_EQ("Layer0x0", this->genericize_pointers(lv->name));
         ASSERT_EQ(2, lv->children.size());
 
         ASSERT_TRUE(lv->solid);
@@ -196,7 +188,7 @@ TEST_F(PhysicalVolumeConverterTest, testem3)
     }
     {
         // Test lead
-        EXPECT_EQ("G4_Pb0x0", simplify_pointers(lv->name));
+        EXPECT_EQ("G4_Pb0x0", this->genericize_pointers(lv->name));
         EXPECT_EQ(0, lv->children.size());
     }
 }
@@ -208,7 +200,7 @@ TEST_F(PhysicalVolumeConverterTest, transformed_box)
 
     PhysicalVolumeConverter convert{make_options()};
     PhysicalVolume world = convert(*g4world);
-    EXPECT_EQ("world_PV", simplify_pointers(world.name));
+    EXPECT_EQ("world_PV", this->genericize_pointers(world.name));
 
     ASSERT_TRUE(world.lv);
     ASSERT_EQ(3, world.lv->children.size());


### PR DESCRIPTION
This builds temporary ORANGE input structures out of Geant4 logical and physical volumes. The next step will be to collapse "used-once" logical volume and build protos/materials out of the physical volumes.