### PR TITLE
Fix warning about missing low-energy cross sections

### DIFF
--- a/src/celeritas/io/LivermorePEReader.cc
+++ b/src/celeritas/io/LivermorePEReader.cc
@@ -117,7 +117,7 @@ LivermorePEReader::operator()(AtomicNumber atomic_number) const
                 infile >> result.xs_lo.x[i] >> result.xs_lo.y[i];
             }
         }
-        else if (atomic_number <= AtomicNumber{2})
+        else if (atomic_number > AtomicNumber{2})
         {
             // Total cross sections below the K-shell energy aren't present for
             // elements with only one subshell, but if another element is

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -11,6 +11,8 @@
 
 #include "celeritas_cmake_strings.h"
 #include "celeritas_config.h"
+#include "corecel/ScopedLogStorer.hh"
+#include "corecel/io/Logger.hh"
 #include "corecel/io/Repr.hh"
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Version.hh"
@@ -879,7 +881,9 @@ TEST_F(FourSteelSlabsEmStandard, sb_data)
 //---------------------------------------------------------------------------//
 TEST_F(FourSteelSlabsEmStandard, livermore_pe_data)
 {
+    ScopedLogStorer scoped_log{&celeritas::world_logger(), LogLevel::warning};
     auto&& import_data = this->imported_data();
+    EXPECT_TRUE(scoped_log.empty()) << scoped_log;
 
     auto const& lpe_map = import_data.livermore_pe_data;
     EXPECT_EQ(4, lpe_map.size());


### PR DESCRIPTION
This fixes the warning for missing low-energy Livermore PE cross sections, which should be for Z > 2.