### PR TITLE
Implement G4Sphere conversion

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -508,8 +508,22 @@ auto SolidConverter::reflectedsolid(arg_type solid_base) -> result_type
 auto SolidConverter::sphere(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Sphere const&>(solid_base);
-    CELER_DISCARD(solid);
-    CELER_NOT_IMPLEMENTED("sphere");
+    std::optional<Sphere> inner;
+    if (double inner_r = solid.GetInnerRadius())
+    {
+        inner = Sphere{scale_(inner_r)};
+    }
+
+    auto polar_wedge = get_polar_wedge(solid);
+    if (!soft_equal(value_as<Turn>(polar_wedge.interior()), 0.5))
+    {
+        CELER_NOT_IMPLEMENTED("sphere with polar limits");
+    }
+
+    return make_solid(solid,
+                      Sphere{scale_(solid.GetOuterRadius())},
+                      std::move(inner),
+                      get_azimuthal_wedge(solid));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/ConvexRegion.cc
+++ b/src/orange/orangeinp/ConvexRegion.cc
@@ -634,5 +634,14 @@ void Sphere::output(JsonPimpl* j) const
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Whether this encloses another sphere.
+ */
+bool Sphere::encloses(Sphere const& other) const
+{
+    return radius_ >= other.radius();
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace orangeinp
 }  // namespace celeritas

--- a/src/orange/orangeinp/ConvexRegion.hh
+++ b/src/orange/orangeinp/ConvexRegion.hh
@@ -411,6 +411,11 @@ class Sphere final : public ConvexRegionInterface
     // Output to JSON
     void output(JsonPimpl*) const final;
 
+    //// TEMPLATE INTERFACE ////
+
+    // Whether this encloses another sphere
+    bool encloses(Sphere const& other) const;
+
     //// ACCESSORS ////
 
     //! Radius

--- a/src/orange/orangeinp/Solid.cc
+++ b/src/orange/orangeinp/Solid.cc
@@ -190,6 +190,7 @@ Solid<T>::Solid(std::string&& label, T&& interior, SolidEnclosedAngle&& enclosed
 
 template class Solid<Cone>;
 template class Solid<Cylinder>;
+template class Solid<Sphere>;
 
 //---------------------------------------------------------------------------//
 }  // namespace orangeinp

--- a/src/orange/orangeinp/Solid.hh
+++ b/src/orange/orangeinp/Solid.hh
@@ -181,6 +181,7 @@ Solid(std::string&&, T&&, Us...) -> Solid<T>;
 
 using ConeSolid = Solid<Cone>;
 using CylinderSolid = Solid<Cylinder>;
+using SphereSolid = Solid<Sphere>;
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -260,6 +260,41 @@ TEST_F(SolidConverterTest, polyhedra)
         {{6.18, 6.18, 0.05}, {0, 0, 0.06}, {7.15, 7.15, 0.05}, {6.18, 7.15, 0}});
 }
 
+TEST_F(SolidConverterTest, sphere)
+{
+    this->build_and_test(
+        G4Sphere("Solid G4Sphere", 0, 50, 0, twopi, 0, pi),
+        R"json({"_type":"shape","interior":{"_type":"sphere","radius":5.0},"label":"Solid G4Sphere"})json");
+    this->build_and_test(
+        G4Sphere("sn1", 0, 50, halfpi, 3. * halfpi, 0, pi),
+        R"json({"_type":"solid","enclosed_angle":{"interior":0.75,"start":0.25},"interior":{"_type":"sphere","radius":5.0},"label":"sn1"})json",
+        {{-3, 0.05, 0}, {3, 0.5, 0}, {0, -0.01, 4.9}});
+    EXPECT_THROW(
+        this->build_and_test(G4Sphere("sn12", 0, 50, 0, twopi, 0., 0.25 * pi)),
+        DebugError);
+
+    this->build_and_test(
+        G4Sphere("Spherical Shell", 45, 50, 0, twopi, 0, pi),
+        R"json({"_type":"solid","excluded":{"_type":"sphere","radius":4.5},"interior":{"_type":"sphere","radius":5.0},"label":"Spherical Shell"})json",
+        {{0, 0, 4.4}, {0, 0, 4.6}, {0, 0, 5.1}});
+    EXPECT_THROW(
+        this->build_and_test(G4Sphere(
+            "Band (theta segment1)", 45, 50, 0, twopi, pi * 3 / 4, pi / 4)),
+        DebugError);
+
+    this->build_and_test(
+        G4Sphere("Band (phi segment)", 5, 50, -pi, 3. * pi / 2., 0, twopi),
+        R"json({"_type":"solid","enclosed_angle":{"interior":0.75,"start":-0.5},"excluded":{"_type":"sphere","radius":0.5},"interior":{"_type":"sphere","radius":5.0},"label":"Band (phi segment)"})json");
+    EXPECT_THROW(
+        this->build_and_test(G4Sphere(
+            "Patch (phi/theta seg)", 45, 50, -pi / 4, halfpi, pi / 4, halfpi)),
+        DebugError);
+
+    this->build_and_test(
+        G4Sphere("John example", 300, 500, 0, 5.76, 0, pi),
+        R"json({"_type":"solid","enclosed_angle":{"interior":0.9167324722093171,"start":0.0},"excluded":{"_type":"sphere","radius":30.0},"interior":{"_type":"sphere","radius":50.0},"label":"John example"})json");
+}
+
 TEST_F(SolidConverterTest, subtractionsolid)
 {
     G4Tubs t1("Solid Tube #1", 0, 50., 50., 0., 360. * degree);


### PR DESCRIPTION
This implements conversion of the Sphere shape, as long as it doesn't have any polar segmentation.

See #1167

@mrguilima This is an example of how to add the GenTrap conversion with new tests (except of course you don't need to create a new Solid, you should just be able to use `make_shape`), so please do something similar in a new PR!