### PR TITLE
Set global execution timeout for automated testing on Jenkins

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,7 @@ on:
       - '**.rst'
       - '**.md'
       - 'scripts/dev'
+      - '.jenkins'
 
 concurrency:
   group: pr-${{github.ref}}-${{github.event.number}}-${{github.workflow}}

--- a/.jenkins
+++ b/.jenkins
@@ -2,6 +2,7 @@ pipeline {
   options {
     disableConcurrentBuilds(abortPrevious: true)
     newContainerPerStage()
+    timeout(time: 6, unit: 'HOURS')
   }
   triggers {
     issueCommentTrigger('.*do: test')

--- a/.jenkins
+++ b/.jenkins
@@ -2,7 +2,7 @@ pipeline {
   options {
     disableConcurrentBuilds(abortPrevious: true)
     newContainerPerStage()
-    timeout(time: 6, unit: 'HOURS')
+    timeout(time: 2, unit: 'HOURS')
   }
   triggers {
     issueCommentTrigger('.*do: test')


### PR DESCRIPTION
Set a period timeout after which the Jenkins server will abort the pipeline run.  Without it, a jobs that somehow gets stuck may run for days before it is manually killed by an admin.
Feel free to adjust the time value.