### PR TITLE
Pin sphinx version to fix documentation build

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx>=4.0.0
+Sphinx >= 4, < 7.3
 breathe
 furo
 sphinxcontrib-bibtex


### PR DESCRIPTION
Sphinx 7.3 was just released (https://github.com/sphinx-doc/sphinx/issues/12242) and causes our CI to fail (https://github.com/sphinx-doc/sphinx/issues/12291). This update rejects sphinx 7.3.0 so we can hopefully keep on CI-ing...