### PR TITLE
Parse log levels from Geant4 scoped logger

### DIFF
--- a/src/corecel/io/StringUtils.hh
+++ b/src/corecel/io/StringUtils.hh
@@ -27,7 +27,7 @@ bool is_ignored_trailing(unsigned char c);
 
 //---------------------------------------------------------------------------//
 // Return a string view with leading and trailing whitespace removed
-std::string_view trim(std::string_view input);
+[[nodiscard]] std::string_view trim(std::string_view input);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/ScopedGeantLogger.cc
+++ b/src/geocel/ScopedGeantLogger.cc
@@ -52,7 +52,8 @@ std::string_view to_string_view(std::sub_match<T> const& cs)
 G4int log_impl(G4String const& str, LogLevel level)
 {
     static std::regex const err_warn_regex{
-        R"regex(^\W*(\w+)?\W*(warning|error)\W+)regex", std::regex::icase};
+        R"regex(^\W*(\w+)?\s*(warning|error|!+|\*+)\W+)regex",
+        std::regex::icase};
 
     static std::regex const info_regex{R"regex(^(\w+):\s+)regex"};
 
@@ -72,11 +73,11 @@ G4int log_impl(G4String const& str, LogLevel level)
         msg = to_string_view(m.suffix());
         // Update the warning level
         auto first_char = std::tolower(static_cast<unsigned char>(*m[2].first));
-        if (first_char == 'w')
+        if (first_char == 'w' || first_char == '*')
         {
             level = LogLevel::warning;
         }
-        else if (first_char == 'e')
+        else if (first_char == 'e' || first_char == '!')
         {
             level = LogLevel::error;
         }

--- a/src/geocel/ScopedGeantLogger.cc
+++ b/src/geocel/ScopedGeantLogger.cc
@@ -10,6 +10,7 @@
 #include <cctype>
 #include <memory>
 #include <mutex>
+#include <regex>
 #include <G4String.hh>
 #include <G4Threading.hh>
 #include <G4Types.hh>
@@ -33,13 +34,70 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
+//! Get a string view matched by a regular expression
+template<class T>
+std::string_view to_string_view(std::sub_match<T> const& cs)
+{
+    if (!cs.matched)
+    {
+        return {};
+    }
+    return {&(*cs.first), static_cast<std::size_t>(cs.length())};
+}
+
+//---------------------------------------------------------------------------//
 /*!
  * Log the actual message.
  */
 G4int log_impl(G4String const& str, LogLevel level)
 {
+    static std::regex const err_warn_regex{
+        R"regex(^\W*(\w+)?\W*(warning|error)\W+)regex", std::regex::icase};
+
+    static std::regex const info_regex{R"regex(^(\w+):\s+)regex"};
+
+    std::smatch m;
+    std::string_view msg;
+    std::string_view source{"Geant4"};
+    if (std::regex_search(str, m, err_warn_regex))
+    {
+        CELER_ASSERT(m.size() == 3);
+        if (m[1].matched)
+        {
+            // Warning is coming from somewhere in particular
+            source = to_string_view(m[1]);
+        }
+
+        // Strip the beginning text from the err/warning
+        msg = to_string_view(m.suffix());
+        // Update the warning level
+        auto first_char = std::tolower(static_cast<unsigned char>(*m[2].first));
+        if (first_char == 'w')
+        {
+            level = LogLevel::warning;
+        }
+        else if (first_char == 'e')
+        {
+            level = LogLevel::error;
+        }
+        else
+        {
+            CELER_ASSERT_UNREACHABLE();
+        }
+    }
+    else if (std::regex_search(str, m, info_regex))
+    {
+        CELER_ASSERT(m.size() == 2);
+        source = to_string_view(m[1]);
+        msg = to_string_view(m.suffix());
+    }
+    else
+    {
+        msg = str;
+    }
+
     // Output with dummy file/line
-    ::celeritas::world_logger()({"Geant4", 0}, level) << trim(str);
+    ::celeritas::world_logger()({source, 0}, level) << trim(msg);
 
     // 0 for success, -1 for failure
     return 0;

--- a/test/geocel/CMakeLists.txt
+++ b/test/geocel/CMakeLists.txt
@@ -8,6 +8,7 @@ if(NOT CELERITAS_USE_Geant4)
   set(_needs_geant4 DISABLE)
 else()
   celeritas_get_g4libs(_g4_geo_libs geometry)
+  celeritas_get_g4libs(_g4_global_libs global)
 endif()
 
 if(CELERITAS_UNITS STREQUAL "CGS")
@@ -102,11 +103,13 @@ if(CELERITAS_USE_VecGeom)
   )
 endif()
 
+if(CELERITAS_USE_Geant4)
+  celeritas_add_test(GeantGeoUtils.test.cc LINK_LIBRARIES ${_g4_geo_libs})
+  celeritas_add_test(ScopedGeantLogger.test.cc LINK_LIBRARIES ${_g4_global_libs})
+endif()
+
 if(CELERITAS_USE_Geant4 AND CELERITAS_REAL_TYPE STREQUAL "double")
   celeritas_add_test(g4/GeantGeo.test.cc
-    LINK_LIBRARIES ${_g4_geo_libs}
-  )
-  celeritas_add_test(GeantGeoUtils.test.cc
     LINK_LIBRARIES ${_g4_geo_libs}
   )
 endif()

--- a/test/geocel/CMakeLists.txt
+++ b/test/geocel/CMakeLists.txt
@@ -104,14 +104,12 @@ if(CELERITAS_USE_VecGeom)
 endif()
 
 if(CELERITAS_USE_Geant4)
-  celeritas_add_test(GeantGeoUtils.test.cc LINK_LIBRARIES ${_g4_geo_libs})
   celeritas_add_test(ScopedGeantLogger.test.cc LINK_LIBRARIES ${_g4_global_libs})
 endif()
 
 if(CELERITAS_USE_Geant4 AND CELERITAS_REAL_TYPE STREQUAL "double")
-  celeritas_add_test(g4/GeantGeo.test.cc
-    LINK_LIBRARIES ${_g4_geo_libs}
-  )
+  celeritas_add_test(g4/GeantGeo.test.cc LINK_LIBRARIES ${_g4_geo_libs})
+  celeritas_add_test(GeantGeoUtils.test.cc LINK_LIBRARIES ${_g4_geo_libs})
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/test/geocel/ScopedGeantLogger.test.cc
+++ b/test/geocel/ScopedGeantLogger.test.cc
@@ -38,6 +38,11 @@ TEST_F(ScopedGeantLoggerTest, host)
     G4cout << "warning: from cout" << endl;
     G4cerr << "ERROR - derpaderp" << endl;
     G4cout << "G4Material warning: things are bad" << endl;
+    G4cerr << "!!! Csv file name not defined." << endl;
+    G4cerr << "ERROR : smish" << endl;
+    G4cerr << "*** oh boy ***" << endl;
+    G4cerr << "Error! -- 123 HCIO assignment failed" << endl;
+    G4cout << "G4GDML: doing things" << endl;
 
     static char const* const expected_log_messages[] = {
         "Standard output",
@@ -46,10 +51,26 @@ TEST_F(ScopedGeantLoggerTest, host)
         "from cout",
         "derpaderp",
         "things are bad",
+        "Csv file name not defined.",
+        "smish",
+        "oh boy ***",
+        "123 HCIO assignment failed",
+        "doing things",
     };
     EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
-    static char const* const expected_log_levels[]
-        = {"diagnostic", "info", "warning", "warning", "error", "warning"};
+    static char const* const expected_log_levels[] = {
+        "diagnostic",
+        "info",
+        "warning",
+        "warning",
+        "error",
+        "warning",
+        "error",
+        "error",
+        "warning",
+        "error",
+        "diagnostic",
+    };
     EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
 }
 

--- a/test/geocel/ScopedGeantLogger.test.cc
+++ b/test/geocel/ScopedGeantLogger.test.cc
@@ -1,0 +1,77 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/ScopedGeantLogger.test.cc
+//---------------------------------------------------------------------------//
+#include "geocel/ScopedGeantLogger.hh"
+
+#include <G4ios.hh>
+
+#include "corecel/ScopedLogStorer.hh"
+#include "corecel/io/Logger.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+class ScopedGeantLoggerTest : public ::celeritas::test::Test
+{
+  protected:
+    void SetUp() override {}
+};
+
+TEST_F(ScopedGeantLoggerTest, host)
+{
+    ScopedGeantLogger scoped_g4;
+    G4cout << "This is not be captured by scoped logger" << endl;
+
+    ScopedLogStorer scoped_log_{&celeritas::world_logger(), LogLevel::debug};
+    G4cout << "Standard output" << endl;
+    G4cerr << "Standard err" << endl;
+    G4cerr << "WARNING - nub nub" << endl;
+    G4cout << "warning: from cout" << endl;
+    G4cerr << "ERROR - derpaderp" << endl;
+    G4cout << "G4Material warning: things are bad" << endl;
+
+    static char const* const expected_log_messages[] = {
+        "Standard output",
+        "Standard err",
+        "nub nub",
+        "from cout",
+        "derpaderp",
+        "things are bad",
+    };
+    EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
+    static char const* const expected_log_levels[]
+        = {"diagnostic", "info", "warning", "warning", "error", "warning"};
+    EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
+}
+
+TEST_F(ScopedGeantLoggerTest, nesting)
+{
+    ScopedGeantLogger scoped_g4;
+    {
+        ScopedGeantLogger scoped_g4;
+        {
+            ScopedGeantLogger scoped_g4;
+            ScopedLogStorer scoped_log_{&celeritas::world_logger(),
+                                        LogLevel::debug};
+            G4cout << "This should still work" << endl;
+            static char const* const expected_log_messages[]
+                = {"This should still work"};
+            EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
+            static char const* const expected_log_levels[] = {"diagnostic"};
+            EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
The default behavior of hiding Geant4 "diagnostic" messages meant I missed important warnings about the geometry. This PR adds some regular expressions to try to parse the Geant4 error/output message to determine its origin and severity.