### PR TITLE
Define geometry traits

### DIFF
--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/Macros.hh"
 #include "corecel/cont/Span.hh"  // IWYU pragma: export
 #include "corecel/io/Label.hh"  // IWYU pragma: export
 
@@ -64,6 +65,9 @@ class GeoParamsInterface
   protected:
     // Protected destructor prevents deletion of pointer-to-interface
     ~GeoParamsInterface() = default;
+
+    GeoParamsInterface() = default;
+    CELER_DEFAULT_COPY_MOVE(GeoParamsInterface);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/GeoTraits.hh
+++ b/src/geocel/GeoTraits.hh
@@ -21,7 +21,6 @@ class GeoParamsInterface;
  * Traits class for defining params and device data.
  * \tparam G Geometry params class, e.g. VecgeomParams
  *
- *
  * This traits class \em must be defined for all geometry types. The generic
  * instance here is provided as a synopsis and to improve error checking.
  */
@@ -30,7 +29,7 @@ struct GeoTraits
 {
     static_assert(std::is_base_of_v<GeoParamsInterface, G>,
                   "G must be a geometry params, not params data");
-    static_assert(sizeof(G) == 0, "Geo traits must be specialized");
+    static_assert(std::is_void_v<G>, "Geo traits must be specialized");
 
     //! Params data used during runtime
     template<Ownership W, MemSpace M>

--- a/src/geocel/GeoTraits.hh
+++ b/src/geocel/GeoTraits.hh
@@ -9,6 +9,8 @@
 
 #include <type_traits>
 
+#include "corecel/Types.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//

--- a/src/geocel/GeoTraits.hh
+++ b/src/geocel/GeoTraits.hh
@@ -1,0 +1,52 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/GeoTraits.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <type_traits>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+class GeoParamsInterface;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Traits class for defining params and device data.
+ * \tparam G Geometry params class, e.g. VecgeomParams
+ *
+ *
+ * This traits class \em must be defined for all geometry types. The generic
+ * instance here is provided as a synopsis and to improve error checking.
+ */
+template<class G>
+struct GeoTraits
+{
+    static_assert(std::is_base_of_v<GeoParamsInterface, G>,
+                  "G must be a geometry params, not params data");
+    static_assert(sizeof(G) == 0, "Geo traits must be specialized");
+
+    //! Params data used during runtime
+    template<Ownership W, MemSpace M>
+    using ParamsData = void;
+
+    //! State data used during runtime
+    template<Ownership W, MemSpace M>
+    using StateData = void;
+
+    //! Geometry track view
+    using TrackView = void;
+
+    //! Descriptive name for the geometry
+    static inline char const* name = nullptr;
+
+    //! TO BE REMOVED: "native" file extension for this geometry
+    static inline char const* ext = nullptr;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/g4/GeantGeoTraits.hh
+++ b/src/geocel/g4/GeantGeoTraits.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/g4/GeantGeoTraits.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "geocel/GeoTraits.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+class GeantGeoParams;
+class GeantGeoTrackView;
+template<Ownership W, MemSpace M>
+struct GeantGeoParamsData;
+template<Ownership W, MemSpace M>
+struct GeantGeoStateData;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Traits specialization for Geant4 geometry.
+ */
+template<>
+struct GeoTraits<GeantGeoParams>
+{
+    //! Params data used during runtime
+    template<Ownership W, MemSpace M>
+    using ParamsData = GeantGeoParamsData<W, M>;
+
+    //! State data used during runtime
+    template<Ownership W, MemSpace M>
+    using StateData = GeantGeoStateData<W, M>;
+
+    //! Geometry track view
+    using TrackView = GeantGeoTrackView;
+
+    //! Descriptive name for the geometry
+    static inline char const* name = "Geant4";
+
+    //! TO BE REMOVED: "native" file extension for this geometry
+    static inline char const* ext = ".gdml";
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/vg/VecgeomGeoTraits.hh
+++ b/src/geocel/vg/VecgeomGeoTraits.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/vg/VecgeomGeoTraits.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "geocel/GeoTraits.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+class VecgeomParams;
+class VecgeomTrackView;
+template<Ownership W, MemSpace M>
+struct VecgeomParamsData;
+template<Ownership W, MemSpace M>
+struct VecgeomStateData;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Traits specialization for VecGeom geometry.
+ */
+template<>
+struct GeoTraits<VecgeomParams>
+{
+    //! Params data used during runtime
+    template<Ownership W, MemSpace M>
+    using ParamsData = VecgeomParamsData<W, M>;
+
+    //! State data used during runtime
+    template<Ownership W, MemSpace M>
+    using StateData = VecgeomStateData<W, M>;
+
+    //! Geometry track view
+    using TrackView = VecgeomTrackView;
+
+    //! Descriptive name for the geometry
+    static inline char const* name = "VecGeom";
+
+    //! TO BE REMOVED: "native" file extension for this geometry
+    static inline char const* ext = ".gdml";
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/orange/OrangeGeoTraits.hh
+++ b/src/orange/OrangeGeoTraits.hh
@@ -1,0 +1,48 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/OrangeGeoTraits.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "geocel/GeoTraits.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+class OrangeParams;
+class OrangeTrackView;
+template<Ownership W, MemSpace M>
+struct OrangeParamsData;
+template<Ownership W, MemSpace M>
+struct OrangeStateData;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Traits specialization for ORANGE geometry.
+ */
+template<>
+struct GeoTraits<OrangeParams>
+{
+    //! Params data used during runtime
+    template<Ownership W, MemSpace M>
+    using ParamsData = OrangeParamsData<W, M>;
+
+    //! State data used during runtime
+    template<Ownership W, MemSpace M>
+    using StateData = OrangeStateData<W, M>;
+
+    //! Geometry track view
+    using TrackView = OrangeTrackView;
+
+    //! Descriptive name for the geometry
+    static inline char const* name = "ORANGE";
+
+    //! TO BE REMOVED: "native" file extension for this geometry
+    static inline char const* ext = ".org.json";
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/test/celeritas/AllGeoTypedTestBase.hh
+++ b/test/celeritas/AllGeoTypedTestBase.hh
@@ -60,7 +60,7 @@ class AllGeoTypedTestBase : public GenericGeoTestBase<HP>
   public:
     using SPConstGeo = typename GenericGeoTestBase<HP>::SPConstGeo;
 
-    static std::string geo_name() { return GenericGeoTraits<HP>::name; }
+    static std::string geo_name() { return GeoTraits<HP>::name; }
 
     SPConstGeo build_geometry() override
     {
@@ -87,7 +87,7 @@ struct AllGeoTestingTypeNames
     template<class U>
     static std::string GetName(int)
     {
-        return GenericGeoTraits<U>::name;
+        return GeoTraits<U>::name;
     }
 };
 

--- a/test/geocel/g4/GeantGeoTestBase.hh
+++ b/test/geocel/g4/GeantGeoTestBase.hh
@@ -11,25 +11,13 @@
 #include "geocel/g4/GeantGeoData.hh"
 #include "geocel/g4/GeantGeoParams.hh"
 #include "geocel/g4/GeantGeoTrackView.hh"
+#include "geocel/g4/GeantGeoTraits.hh"
 
 namespace celeritas
 {
-//---------------------------------------------------------------------------//
-class GeantGeoTrackView;
-
 namespace test
 {
 //---------------------------------------------------------------------------//
-template<>
-struct GenericGeoTraits<GeantGeoParams>
-{
-    template<MemSpace M>
-    using StateStore = CollectionStateStore<GeantGeoStateData, M>;
-    using TrackView = GeantGeoTrackView;
-    static inline char const* ext = ".gdml";
-    static inline char const* name = "Geant4";
-};
-
 using GeantGeoTestBase = GenericGeoTestBase<GeantGeoParams>;
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/vg/VecgeomTestBase.hh
+++ b/test/geocel/vg/VecgeomTestBase.hh
@@ -9,6 +9,7 @@
 
 #include "geocel/GenericGeoTestBase.hh"
 #include "geocel/vg/VecgeomData.hh"
+#include "geocel/vg/VecgeomGeoTraits.hh"
 #include "geocel/vg/VecgeomParams.hh"
 #include "geocel/vg/VecgeomTrackView.hh"
 
@@ -17,16 +18,6 @@ namespace celeritas
 namespace test
 {
 //---------------------------------------------------------------------------//
-template<>
-struct GenericGeoTraits<VecgeomParams>
-{
-    template<MemSpace M>
-    using StateStore = CollectionStateStore<VecgeomStateData, M>;
-    using TrackView = VecgeomTrackView;
-    static inline char const* ext = ".gdml";
-    static inline char const* name = "VecGeom";
-};
-
 using VecgeomTestBase = GenericGeoTestBase<VecgeomParams>;
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeTestBase.hh
+++ b/test/orange/OrangeTestBase.hh
@@ -9,6 +9,7 @@
 
 #include "geocel/GenericGeoTestBase.hh"
 #include "orange/OrangeData.hh"
+#include "orange/OrangeGeoTraits.hh"
 #include "orange/OrangeParams.hh"
 #include "orange/OrangeTrackView.hh"
 
@@ -17,17 +18,6 @@ namespace celeritas
 namespace test
 {
 //---------------------------------------------------------------------------//
-template<>
-struct GenericGeoTraits<OrangeParams>
-{
-    template<MemSpace M>
-    using StateStore = CollectionStateStore<OrangeStateData, M>;
-
-    using TrackView = OrangeTrackView;
-    static inline char const* ext = ".org.json";
-    static inline char const* name = "ORANGE";
-};
-
 using OrangeTestBase = GenericGeoTestBase<OrangeParams>;
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This provides a uniform interface for instantiating and creating geometry classes. This will be used by the ray tracer to support multiple raytrace geometries with the same installation.