### PR TITLE
Fix prism orientation in Geant4 ORANGE solid converter

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -474,7 +474,8 @@ auto SolidConverter::polyhedra(arg_type solid_base) -> result_type
     {
         // A solid prism
         double const hh = (zs[1] - zs[0]) / 2;
-        double const orientation = startphi.value() / params.numSide;
+        double const orientation
+            = std::fmod(params.numSide * startphi.value(), real_type{1});
 
         if (rmin[0] != 0.0 || angle)
         {

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -257,7 +257,7 @@ TEST_F(SolidConverterTest, polyhedra)
     this->build_and_test(
         G4Polyhedra(
             "HGCalEEAbs", 330 * deg, 360 * deg, 6, std::size(z), z, rmin, rmax),
-        R"json({"_type":"shape","interior":{"_type":"prism","apothem":6.1850000000000005,"halfheight":0.06,"num_sides":6,"orientation":0.15277777777777776},"label":"HGCalEEAbs"})json",
+        R"json({"_type":"shape","interior":{"_type":"prism","apothem":6.1850000000000005,"halfheight":0.06,"num_sides":6,"orientation":0.5},"label":"HGCalEEAbs"})json",
         {{6.18, 6.18, 0.05},
          {0, 0, 0.06},
          {7.15, 7.15, 0.05},

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -253,11 +253,16 @@ TEST_F(SolidConverterTest, polyhedra)
     static double const z[] = {-0.6, 0.6};
     static double const rmin[] = {0, 0};
     static double const rmax[] = {61.85, 61.85};
+    // flat-top hexagon
     this->build_and_test(
         G4Polyhedra(
             "HGCalEEAbs", 330 * deg, 360 * deg, 6, std::size(z), z, rmin, rmax),
         R"json({"_type":"shape","interior":{"_type":"prism","apothem":6.1850000000000005,"halfheight":0.06,"num_sides":6,"orientation":0.15277777777777776},"label":"HGCalEEAbs"})json",
-        {{6.18, 6.18, 0.05}, {0, 0, 0.06}, {7.15, 7.15, 0.05}, {6.18, 7.15, 0}});
+        {{6.18, 6.18, 0.05},
+         {0, 0, 0.06},
+         {7.15, 7.15, 0.05},
+         {3.0, 6.01, 0},
+         {6.18, 7.15, 0}});
 }
 
 TEST_F(SolidConverterTest, sphere)


### PR DESCRIPTION
Add a new test showing the failure, and fix the failure.

Before:
![TBHGCal181Oct-unknown](https://github.com/celeritas-project/celeritas/assets/741229/8fb9012f-7bee-421f-9528-a4254696a8ec)

After:
![TBHGCal181Oct-unknown](https://github.com/celeritas-project/celeritas/assets/741229/9ca121a4-af8f-478c-8c30-3e1192d1d164)