### PR TITLE
Move unit enumeration to corecel and improve assertion flexibility 

### DIFF
--- a/app/celer-g4/ExceptionHandler.cc
+++ b/app/celer-g4/ExceptionHandler.cc
@@ -44,8 +44,15 @@ G4bool ExceptionHandler::Notify(char const* origin_of_exception,
     CELER_EXPECT(exception_code);
 
     // Construct message
-    auto err = RuntimeError::from_geant_exception(
-        origin_of_exception, exception_code, description);
+    auto err = RuntimeError{[&] {
+        RuntimeErrorDetails details;
+        details.which = "Geant4";
+        details.what = description;
+        details.condition = exception_code;
+        details.file = origin_of_exception;
+        return details;
+    }()};
+
     bool must_abort{false};
 
     switch (severity)

--- a/src/celeritas/Types.cc
+++ b/src/celeritas/Types.cc
@@ -8,40 +8,11 @@
 #include "Types.hh"
 
 #include "corecel/io/EnumStringMapper.hh"
-#include "corecel/io/StringEnumMapper.hh"
 
 #include "UnitTypes.hh"
 
 namespace celeritas
 {
-//---------------------------------------------------------------------------//
-/*!
- * Get a string corresponding to a unit system.
- */
-char const* to_cstring(UnitSystem value)
-{
-    static_assert(static_cast<int>(UnitSystem::cgs) == CELERITAS_UNITS_CGS);
-    static_assert(static_cast<int>(UnitSystem::si) == CELERITAS_UNITS_SI);
-    static_assert(static_cast<int>(UnitSystem::clhep) == CELERITAS_UNITS_CLHEP);
-    static_assert(static_cast<int>(UnitSystem::native) == CELERITAS_UNITS);
-
-    static EnumStringMapper<UnitSystem> const to_cstring_impl{
-        "none", "cgs", "si", "clhep"};
-    return to_cstring_impl(value);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get a unit system corresponding to a string value.
- */
-UnitSystem to_unit_system(std::string const& s)
-{
-    static auto const from_string
-        = StringEnumMapper<UnitSystem>::from_cstring_func(to_cstring,
-                                                          "unit system");
-    return from_string(s);
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Get a string corresponding to an interpolation.

--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -78,18 +78,6 @@ using ChannelId = OpaqueId<struct Channel_>;
 //---------------------------------------------------------------------------//
 // ENUMERATIONS
 //---------------------------------------------------------------------------//
-//! Unit system used by Celeritas
-enum class UnitSystem
-{
-    none,  //!< Invalid unit system
-    cgs,  //!< Gaussian CGS
-    si,  //!< International System
-    clhep,  //!< Geant4 native
-    size_,
-    native = CELERITAS_UNITS,  //!< Compile time selected system
-};
-
-//---------------------------------------------------------------------------//
 //! Interpolation type
 enum class Interp
 {
@@ -193,14 +181,8 @@ struct StepLimit
 // HELPER FUNCTIONS (HOST)
 //---------------------------------------------------------------------------//
 
-// Get a string corresponding to a unit system
-char const* to_cstring(UnitSystem);
-
 // Get a string corresponding to an interpolation
 char const* to_cstring(Interp);
-
-// Get a unit system corresponding to a string
-UnitSystem to_unit_system(std::string const& s);
 
 // Get a string corresponding to a material state
 char const* to_cstring(MatterState);

--- a/src/celeritas/ext/ScopedRootErrorHandler.cc
+++ b/src/celeritas/ext/ScopedRootErrorHandler.cc
@@ -58,7 +58,13 @@ void RootErrorHandler(Int_t rootlevel,
 
     if (must_abort)
     {
-        throw RuntimeError::from_root_error(location, msg);
+        throw RuntimeError{[&] {
+            RuntimeErrorDetails details;
+            details.which = "ROOT";
+            details.what = msg;
+            details.file = location;
+            return details;
+        }()};
     }
     else
     {

--- a/src/celeritas/field/RZMapFieldInputIO.json.cc
+++ b/src/celeritas/field/RZMapFieldInputIO.json.cc
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "corecel/Types.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/io/JsonUtils.json.hh"
 #include "corecel/io/Logger.hh"

--- a/src/corecel/Assert.cc
+++ b/src/corecel/Assert.cc
@@ -61,18 +61,31 @@ std::string build_runtime_error_msg(RuntimeErrorDetails const& d)
 
     std::ostringstream msg;
 
-    msg << "celeritas: " << color_code('R') << to_cstring(d.which)
-        << " error: " << color_code(' ') << d.what;
-
-    if (verbose_message || d.which != RuntimeErrorType::validate
-        || d.what.empty())
+    msg << "celeritas: " << color_code('R')
+        << (d.which.empty() ? "unknown" : d.which)
+        << " error: " << color_code(' ');
+    if (d.which == "configuration")
     {
-        msg << '\n' << color_code('W') << d.file;
+        msg << "required dependency is disabled in this build: ";
+    }
+    else if (d.which == "not implemented")
+    {
+        msg << "feature is not yet implemented: ";
+    }
+    msg << d.what;
+
+    if (verbose_message || d.what.empty() || d.which != "runtime")
+    {
+        msg << '\n'
+            << color_code('W') << (d.file.empty() ? "unknown source" : d.file);
         if (d.line)
         {
             msg << ':' << d.line;
         }
-        msg << ':' << color_code(' ') << " '" << d.condition << "' failed";
+        if (!d.condition.empty())
+        {
+            msg << ':' << color_code(' ') << " '" << d.condition << "' failed";
+        }
     }
 
     return msg.str();
@@ -94,10 +107,6 @@ char const* to_cstring(DebugErrorType which)
             return "internal assertion failed";
         case DebugErrorType::unreachable:
             return "unreachable code point";
-        case DebugErrorType::unconfigured:
-            return "required dependency is disabled in this build";
-        case DebugErrorType::unimplemented:
-            return "feature is not yet implemented";
         case DebugErrorType::postcondition:
             return "postcondition failed";
         case DebugErrorType::assumption:
@@ -108,118 +117,37 @@ char const* to_cstring(DebugErrorType which)
 
 //---------------------------------------------------------------------------//
 /*!
- * Get a human-readable string describing a runtime error.
+ * Get an MPI error string.
  */
-char const* to_cstring(RuntimeErrorType which)
+std::string mpi_error_to_string(int errorcode)
 {
-    switch (which)
-    {
-        case RuntimeErrorType::validate:
-            return "runtime";
-        case RuntimeErrorType::device:
-#if CELERITAS_USE_CUDA
-            return "CUDA";
+#if CELERITAS_USE_MPI
+    std::string error_string;
+    error_string.resize(MPI_MAX_ERROR_STRING);
+    int length = 0;
+    MPI_Error_string(errorcode, &error_string.front(), &length);
+    error_string.resize(length);
+    return error_string;
 #else
-            return "device";
+    CELER_DISCARD(errorcode);
+    CELER_NOT_CONFIGURED("MPI");
 #endif
-        case RuntimeErrorType::mpi:
-            return "MPI";
-        case RuntimeErrorType::geant:
-            return "Geant4";
-        case RuntimeErrorType::root:
-            return "ROOT";
-    }
-    return "";
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct a debug exception from detailed attributes.
  */
-DebugError::DebugError(DebugErrorDetails d)
+DebugError::DebugError(DebugErrorDetails&& d)
     : std::logic_error(build_debug_error_msg(d)), details_(std::move(d))
 {
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct a runtime exception from a validation failure.
- */
-RuntimeError RuntimeError::from_validate(std::string what,
-                                         char const* code,
-                                         char const* file,
-                                         int line)
-{
-    return RuntimeError{{RuntimeErrorType::validate, what, code, file, line}};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct a runtime exception from a CUDA/HIP runtime failure.
- */
-RuntimeError RuntimeError::from_device_call(char const* error_string,
-                                            char const* code,
-                                            char const* file,
-                                            int line)
-{
-    return RuntimeError{
-        {RuntimeErrorType::device, error_string, code, file, line}};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct a message and throw an error from a runtime MPI failure.
- */
-RuntimeError RuntimeError::from_mpi_call([[maybe_unused]] int errorcode,
-                                         char const* code,
-                                         char const* file,
-                                         int line)
-{
-    std::string error_string;
-#if CELERITAS_USE_MPI
-    {
-        error_string.resize(MPI_MAX_ERROR_STRING);
-        int length = 0;
-        MPI_Error_string(errorcode, &error_string.front(), &length);
-        error_string.resize(length);
-    }
-#endif
-    return RuntimeError{
-        {RuntimeErrorType::mpi, error_string, code, file, line}};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct an error message from a Geant4 exception.
- *
- * \param origin Usually the function that throws
- * \param code A computery error code
- * \param desc Description of the failure
- */
-RuntimeError RuntimeError::from_geant_exception(char const* origin,
-                                                char const* code,
-                                                char const* desc)
-{
-    return RuntimeError{{RuntimeErrorType::geant, desc, code, origin, 0}};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct an error message from a Geant4 exception.
- *
- * \param origin Usually the function that throws
- * \param msg Description of the failure
- */
-RuntimeError RuntimeError::from_root_error(char const* origin, char const* msg)
-{
-    return RuntimeError{{RuntimeErrorType::root, msg, nullptr, origin, 0}};
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Construct a runtime error from detailed descriptions.
  */
-RuntimeError::RuntimeError(RuntimeErrorDetails d)
+RuntimeError::RuntimeError(RuntimeErrorDetails&& d)
     : std::runtime_error(build_runtime_error_msg(d)), details_(std::move(d))
 {
 }

--- a/src/corecel/AssertIO.json.cc
+++ b/src/corecel/AssertIO.json.cc
@@ -39,7 +39,7 @@ void to_json(nlohmann::json& j, DebugErrorDetails const& d)
 void to_json(nlohmann::json& j, RuntimeErrorDetails const& d)
 {
     j["what"] = d.what;
-    j["which"] = to_cstring(d.which);
+    j["which"] = d.which;
     if (!d.condition.empty())
     {
         j["condition"] = d.condition;

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -14,9 +14,9 @@ set(PUBLIC_DEPS)
 
 list(APPEND SOURCES
   Assert.cc
-  PinnedAllocator.cc
   data/Copier.cc
   data/DeviceAllocation.cc
+  data/PinnedAllocator.cc
   io/BuildOutput.cc
   io/ColorUtils.cc
   io/ExceptionOutput.cc

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PUBLIC_DEPS)
 
 list(APPEND SOURCES
   Assert.cc
+  Types.cc
   data/Copier.cc
   data/DeviceAllocation.cc
   data/PinnedAllocator.cc

--- a/src/corecel/Types.cc
+++ b/src/corecel/Types.cc
@@ -1,0 +1,55 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/Types.cc
+//---------------------------------------------------------------------------//
+#include "Types.hh"
+
+#include "corecel/io/EnumStringMapper.hh"
+#include "corecel/io/StringEnumMapper.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Get a string corresponding to a memory space.
+ */
+char const* to_cstring(MemSpace value)
+{
+    static EnumStringMapper<MemSpace> const to_cstring_impl{
+        "host", "device", "mapped"};
+    return to_cstring_impl(value);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get a string corresponding to a unit system.
+ */
+char const* to_cstring(UnitSystem value)
+{
+    static_assert(static_cast<int>(UnitSystem::cgs) == CELERITAS_UNITS_CGS);
+    static_assert(static_cast<int>(UnitSystem::si) == CELERITAS_UNITS_SI);
+    static_assert(static_cast<int>(UnitSystem::clhep) == CELERITAS_UNITS_CLHEP);
+    static_assert(static_cast<int>(UnitSystem::native) == CELERITAS_UNITS);
+
+    static EnumStringMapper<UnitSystem> const to_cstring_impl{
+        "none", "cgs", "si", "clhep"};
+    return to_cstring_impl(value);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get a unit system corresponding to a string value.
+ */
+UnitSystem to_unit_system(std::string const& s)
+{
+    static auto const from_string
+        = StringEnumMapper<UnitSystem>::from_cstring_func(to_cstring,
+                                                          "unit system");
+    return from_string(s);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -3,12 +3,20 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/Types.hh
-//! \brief Type definitions for common Celeritas functionality
+/*!
+ * \file corecel/Types.hh
+ * \brief Type definitions for common Celeritas functionality.
+ *
+ * This file includes types and properties particular to the build
+ * configuration.
+ */
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include <cstddef>
+#include <string>
+
+#include "celeritas_config.h"
 
 #include "Macros.hh"
 
@@ -43,12 +51,12 @@ enum class MemSpace
     host,  //!< CPU memory
     device,  //!< GPU memory
     mapped,  //!< Unified virtual address space (both host and device)
+    size_,
 #ifdef CELER_DEVICE_SOURCE
     native = device,  //!< When included by a CUDA/HIP file; else 'host'
 #else
     native = host,
 #endif
-    size_
 };
 
 //! Data ownership flag
@@ -57,6 +65,18 @@ enum class Ownership
     value,  //!< Ownership of the data, only on host
     reference,  //!< Mutable reference to the data
     const_reference,  //!< Immutable reference to the data
+};
+
+//---------------------------------------------------------------------------//
+//! Unit system used by Celeritas
+enum class UnitSystem
+{
+    none,  //!< Invalid unit system
+    cgs,  //!< Gaussian CGS
+    si,  //!< International System
+    clhep,  //!< Geant4 native
+    size_,
+    native = CELERITAS_UNITS,  //!< Compile time selected system
 };
 
 #if !defined(SWIG) || SWIG_VERSION > 0x050000
@@ -105,14 +125,14 @@ using RefPtr = ObserverPtr<S<Ownership::reference, M>, M>;
 // HELPER FUNCTIONS (HOST)
 //---------------------------------------------------------------------------//
 
-//! Get a string corresponding to a memory space
-inline constexpr char const* to_cstring(MemSpace m)
-{
-    return m == MemSpace::host     ? "host"
-           : m == MemSpace::device ? "device"
-           : m == MemSpace::mapped ? "mapped"
-                                   : nullptr;
-}
+// Get a string corresponding to a memory space
+char const* to_cstring(MemSpace m);
+
+// Get a string corresponding to a unit system
+char const* to_cstring(UnitSystem);
+
+// Get a unit system corresponding to a string
+UnitSystem to_unit_system(std::string const& s);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -48,6 +48,7 @@ enum class MemSpace
 #else
     native = host,
 #endif
+    size_
 };
 
 //! Data ownership flag

--- a/src/corecel/data/PinnedAllocator.cc
+++ b/src/corecel/data/PinnedAllocator.cc
@@ -3,11 +3,11 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/PinnedAllocator.cc
+//! \file corecel/data/PinnedAllocator.cc
 //---------------------------------------------------------------------------//
+#include "corecel/Types.hh"
 
-#include "Types.hh"
-#include "data/PinnedAllocator.t.hh"
+#include "PinnedAllocator.t.hh"
 
 namespace celeritas
 {

--- a/src/corecel/io/EnumStringMapper.hh
+++ b/src/corecel/io/EnumStringMapper.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <type_traits>
+
 #include "corecel/Assert.hh"
 #include "corecel/cont/Array.hh"
 

--- a/src/geocel/ScopedGeantExceptionHandler.cc
+++ b/src/geocel/ScopedGeantExceptionHandler.cc
@@ -53,8 +53,14 @@ G4bool GeantExceptionHandler::Notify(char const* origin_of_exception,
     CELER_EXPECT(exception_code);
 
     // Construct message
-    auto err = RuntimeError::from_geant_exception(
-        origin_of_exception, exception_code, description);
+    auto err = RuntimeError{[&] {
+        RuntimeErrorDetails details;
+        details.which = "Geant4";
+        details.what = description;
+        details.condition = exception_code;
+        details.file = origin_of_exception;
+        return details;
+    }()};
 
     switch (severity)
     {

--- a/test/corecel/sys/MultiExceptionHandler.test.cc
+++ b/test/corecel/sys/MultiExceptionHandler.test.cc
@@ -41,9 +41,8 @@ TEST_F(MultiExceptionHandlerTest, single)
 {
     MultiExceptionHandler capture_exception;
     EXPECT_TRUE(capture_exception.empty());
-    CELER_TRY_HANDLE(
-        throw RuntimeError::from_validate("first exception", "", "here", 1),
-        capture_exception);
+    CELER_TRY_HANDLE(CELER_RUNTIME_THROW("runtime", "first exception", ""),
+                     capture_exception);
     EXPECT_FALSE(capture_exception.empty());
 
     EXPECT_THROW(log_and_rethrow(std::move(capture_exception)), RuntimeError);
@@ -52,14 +51,13 @@ TEST_F(MultiExceptionHandlerTest, single)
 TEST_F(MultiExceptionHandlerTest, multi)
 {
     MultiExceptionHandler capture_exception;
-    CELER_TRY_HANDLE(
-        throw RuntimeError::from_validate("first exception", "", "here", 1),
-        capture_exception);
+    CELER_TRY_HANDLE(CELER_RUNTIME_THROW("runtime", "first exception", ""),
+                     capture_exception);
     for (auto i : range(3))
     {
         DebugErrorDetails deets{
             DebugErrorType::internal, "false", "test.cc", i};
-        CELER_TRY_HANDLE(throw DebugError(deets), capture_exception);
+        CELER_TRY_HANDLE(throw DebugError(std::move(deets)), capture_exception);
     }
     EXPECT_THROW(log_and_rethrow(std::move(capture_exception)), RuntimeError);
 
@@ -81,12 +79,13 @@ TEST_F(MultiExceptionHandlerTest, multi_nested)
 {
     MultiExceptionHandler capture_exception;
     CELER_TRY_HANDLE_CONTEXT(
-        throw RuntimeError::from_validate("first exception", "", "here", 1),
+        CELER_RUNTIME_THROW("runtime", "first exception", ""),
         capture_exception,
         MockContextException{});
     DebugErrorDetails deets{DebugErrorType::internal, "false", "test.cc", 2};
-    CELER_TRY_HANDLE_CONTEXT(
-        throw DebugError(deets), capture_exception, MockContextException{});
+    CELER_TRY_HANDLE_CONTEXT(throw DebugError(std::move(deets)),
+                             capture_exception,
+                             MockContextException{});
     EXPECT_THROW(log_and_rethrow(std::move(capture_exception)),
                  MockContextException);
 

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -276,7 +276,7 @@ TEST_F(SolidConverterTest, sphere)
         {{-3, 0.05, 0}, {3, 0.5, 0}, {0, -0.01, 4.9}});
     EXPECT_THROW(
         this->build_and_test(G4Sphere("sn12", 0, 50, 0, twopi, 0., 0.25 * pi)),
-        DebugError);
+        RuntimeError);
 
     this->build_and_test(
         G4Sphere("Spherical Shell", 45, 50, 0, twopi, 0, pi),
@@ -285,7 +285,7 @@ TEST_F(SolidConverterTest, sphere)
     EXPECT_THROW(
         this->build_and_test(G4Sphere(
             "Band (theta segment1)", 45, 50, 0, twopi, pi * 3 / 4, pi / 4)),
-        DebugError);
+        RuntimeError);
 
     this->build_and_test(
         G4Sphere("Band (phi segment)", 5, 50, -pi, 3. * pi / 2., 0, twopi),
@@ -293,7 +293,7 @@ TEST_F(SolidConverterTest, sphere)
     EXPECT_THROW(
         this->build_and_test(G4Sphere(
             "Patch (phi/theta seg)", 45, 50, -pi / 4, halfpi, pi / 4, halfpi)),
-        DebugError);
+        RuntimeError);
 
     this->build_and_test(
         G4Sphere("John example", 300, 500, 0, 5.76, 0, pi),

--- a/test/orange/orangeinp/ConvexRegion.test.cc
+++ b/test/orange/orangeinp/ConvexRegion.test.cc
@@ -403,7 +403,7 @@ using GenTrapTest = ConvexRegionTest;
 
 TEST_F(GenTrapTest, construct)
 {
-    // validate contruction parameters
+    // Validate contruction parameters
     EXPECT_THROW(GenTrap(-3,
                          {{-1, -1}, {-1, 1}, {1, 1}, {1, -1}},
                          {{-2, -2}, {-2, 2}, {2, 2}, {2, -2}}),
@@ -417,12 +417,11 @@ TEST_F(GenTrapTest, construct)
                          {{-2, -2}, {-2, 2}, {2, 2}, {2, -2}}),
                  RuntimeError);  // non-convex
 
-    // a general, non-planar GenTrap, with 'twisted' faces - not yet
-    // implemented
+    // General non-planar GenTrap with 'twisted' faces is not yet implemented
     EXPECT_THROW(GenTrap(3,
                          {{-10, -10}, {-10, 10}, {10, 10}, {9, -11}},
                          {{-10, -10}, {-10, 10}, {10, 10}, {10, -10}}),
-                 DebugError);
+                 RuntimeError);
 }
 
 TEST_F(GenTrapTest, box_like)


### PR DESCRIPTION
I'm extracting a few changes from #1194 that I added for the raytrace work (to improve feedback to the user). The Celeritas unit system enum now lives in `corecel/Types`, so that it can be used by `geocel`. I also refactored the runtime assertion errors for readability, and I've changed "not configured" and "not implemented" to runtime errors, since we might want to let users encounter those naturally rather than adding additional validation checks. (For example, it's easier to let the code hit a `NOT_CONFIGURED("Vecgeom")` then have that as a debug check *and* do an additional validation on the user input.)