### PR TITLE
Add test for assertion messages

### DIFF
--- a/src/corecel/Assert.cc
+++ b/src/corecel/Assert.cc
@@ -64,7 +64,7 @@ std::string build_runtime_error_msg(RuntimeErrorDetails const& d)
     msg << "celeritas: " << color_code('R')
         << (d.which.empty() ? "unknown" : d.which)
         << " error: " << color_code(' ');
-    if (d.which == "configuration")
+    if (d.which == "not configured")
     {
         msg << "required dependency is disabled in this build: ";
     }
@@ -82,9 +82,15 @@ std::string build_runtime_error_msg(RuntimeErrorDetails const& d)
         {
             msg << ':' << d.line;
         }
+
+        msg << ':' << color_code(' ');
         if (!d.condition.empty())
         {
-            msg << ':' << color_code(' ') << " '" << d.condition << "' failed";
+            msg << " '" << d.condition << '\'' << " failed";
+        }
+        else
+        {
+            msg << " " << d.which;
         }
     }
 

--- a/src/corecel/Assert.cc
+++ b/src/corecel/Assert.cc
@@ -77,8 +77,9 @@ std::string build_runtime_error_msg(RuntimeErrorDetails const& d)
     if (verbose_message || d.what.empty() || d.which != "runtime")
     {
         msg << '\n'
-            << color_code('W') << (d.file.empty() ? "unknown source" : d.file);
-        if (d.line)
+            << color_code(d.condition.empty() ? 'x' : 'W')
+            << (d.file.empty() ? "unknown source" : d.file);
+        if (d.line && !d.file.empty())
         {
             msg << ':' << d.line;
         }
@@ -90,7 +91,7 @@ std::string build_runtime_error_msg(RuntimeErrorDetails const& d)
         }
         else
         {
-            msg << " " << d.which;
+            msg << " failure";
         }
     }
 

--- a/src/corecel/Assert.cc
+++ b/src/corecel/Assert.cc
@@ -64,11 +64,11 @@ std::string build_runtime_error_msg(RuntimeErrorDetails const& d)
     msg << "celeritas: " << color_code('R')
         << (d.which.empty() ? "unknown" : d.which)
         << " error: " << color_code(' ');
-    if (d.which == "not configured")
+    if (d.which == "configuration")
     {
         msg << "required dependency is disabled in this build: ";
     }
-    else if (d.which == "not implemented")
+    else if (d.which == "implementation")
     {
         msg << "feature is not yet implemented: ";
     }

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -237,7 +237,7 @@
 #endif
 
 #define CELER_NOT_CONFIGURED(WHAT) \
-    CELER_RUNTIME_THROW("configuration", WHAT, {})
+    CELER_RUNTIME_THROW("not configured", WHAT, {})
 #define CELER_NOT_IMPLEMENTED(WHAT) \
     CELER_RUNTIME_THROW("not implemented", WHAT, {})
 

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -237,9 +237,9 @@
 #endif
 
 #define CELER_NOT_CONFIGURED(WHAT) \
-    CELER_RUNTIME_THROW("not configured", WHAT, {})
+    CELER_RUNTIME_THROW("configuration", WHAT, {})
 #define CELER_NOT_IMPLEMENTED(WHAT) \
-    CELER_RUNTIME_THROW("not implemented", WHAT, {})
+    CELER_RUNTIME_THROW("implementation", WHAT, {})
 
 /*!
  * \def CELER_CUDA_CALL

--- a/src/corecel/io/Join.hh
+++ b/src/corecel/io/Join.hh
@@ -22,9 +22,10 @@ namespace celeritas
    cout << celeritas::join(foo.begin(), foo.end(), ", ") << endl
    \endcode
  *
- * The result is a thin class that is implicitly convertible to a std::string
- * and is streamable. (It can explicitly be converted to a string with the
- * \c .str() method). By doing this instead of returning a std::string, large
+ * The result is a thin class that is streamable. (It can explicitly be
+ * converted to a string with the
+ * \c to_string method). By doing this instead of returning a std::string,
+ large
  * and dynamic containers can be e.g. saved to disk.
  */
 template<class InputIterator, class Conjunction>

--- a/src/corecel/io/detail/ReprImpl.hh
+++ b/src/corecel/io/detail/ReprImpl.hh
@@ -9,6 +9,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <type_traits>
 
@@ -56,6 +57,18 @@ std::ostream& operator<<(std::ostream& os, Repr<T> const& s)
         os << '}';
     }
     return os;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write a streamable object to a stream.
+ */
+template<class T>
+std::string to_string(Repr<T> const& s)
+{
+    std::ostringstream os;
+    os << s;
+    return os.str();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/detail/ReprImpl.hh
+++ b/src/corecel/io/detail/ReprImpl.hh
@@ -61,7 +61,7 @@ std::ostream& operator<<(std::ostream& os, Repr<T> const& s)
 
 //---------------------------------------------------------------------------//
 /*!
- * Write a streamable object to a stream.
+ * Convert a streamable object to a string.
  */
 template<class T>
 std::string to_string(Repr<T> const& s)

--- a/test/corecel/Assert.test.cc
+++ b/test/corecel/Assert.test.cc
@@ -24,14 +24,13 @@ namespace test
 class AssertTest : public ::celeritas::test::Test
 {
   protected:
-    void SetUp() override
+    static void SetUpTestSuite()
     {
-        if ((celeritas::getenv("CELER_COLOR").empty()
-             && celeritas::getenv("GTEST_COLOR").empty())
-            || celeritas::getenv("CELER_LOG").empty())
-        {
-            GTEST_SKIP() << "Expected environment variables are not set";
-        }
+        EXPECT_FALSE(celeritas::getenv("CELER_COLOR").empty()
+                     && celeritas::getenv("GTEST_COLOR").empty())
+            << "Color must be enabled for this test";
+        EXPECT_FALSE(celeritas::getenv("CELER_LOG").empty())
+            << "Logging (for verbose output) must be enabled for this test";
     }
 };
 
@@ -57,6 +56,8 @@ TEST_F(AssertTest, runtime_error)
     }
     catch (RuntimeError const& e)
     {
+        EXPECT_TRUE(std::string{e.what()}.find("configuration error:")
+                    != std::string::npos);
         EXPECT_TRUE(std::string{e.what()}.find("required dependency is "
                                                "disabled in this build: foo")
                     != std::string::npos)
@@ -68,6 +69,8 @@ TEST_F(AssertTest, runtime_error)
     }
     catch (RuntimeError const& e)
     {
+        EXPECT_TRUE(std::string{e.what()}.find("implementation error:")
+                    != std::string::npos);
         EXPECT_TRUE(std::string{e.what()}.find("feature is not yet "
                                                "implemented: bar")
                     != std::string::npos)
@@ -116,7 +119,6 @@ TEST_F(AssertTest, runtime_error_variations)
         // Generate the message
         RuntimeError err{std::move(details)};
         messages.push_back(err.what());
-        cout << err.what() << endl;
     }
     static std::string const expected_messages[] = {
         "celeritas: \x1b[31;1munknown error: \x1b[0m\n\x1b[37;2munknown "

--- a/test/corecel/Assert.test.cc
+++ b/test/corecel/Assert.test.cc
@@ -26,9 +26,12 @@ class AssertTest : public ::celeritas::test::Test
   protected:
     void SetUp() override
     {
-        auto& env = celeritas::environment();
-        env.insert({"CELER_COLOR", "1"});
-        env.insert({"CELER_LOG", "diagnostic"});
+        if ((celeritas::getenv("CELER_COLOR").empty()
+             && celeritas::getenv("GTEST_COLOR").empty())
+            || celeritas::getenv("CELER_LOG").empty())
+        {
+            GTEST_SKIP() << "Expected environment variables are not set";
+        }
     }
 };
 

--- a/test/corecel/Assert.test.cc
+++ b/test/corecel/Assert.test.cc
@@ -9,7 +9,6 @@
 
 #include <string>
 #include <vector>
-#include <gmock/gmock.h>
 
 #include "corecel/io/Repr.hh"
 #include "corecel/sys/Environment.hh"
@@ -49,16 +48,16 @@ TEST_F(AssertTest, debug_error)
 
 TEST_F(AssertTest, runtime_error)
 {
-    using ::testing::HasSubstr;
     try
     {
         CELER_NOT_CONFIGURED("foo");
     }
     catch (RuntimeError const& e)
     {
-        EXPECT_THAT(e.what(),
-                    HasSubstr("required dependency is disabled in this build: "
-                              "foo"));
+        EXPECT_TRUE(std::string{e.what()}.find("required dependency is "
+                                               "disabled in this build: foo")
+                    != std::string::npos)
+            << e.what();
     }
     try
     {
@@ -66,7 +65,10 @@ TEST_F(AssertTest, runtime_error)
     }
     catch (RuntimeError const& e)
     {
-        EXPECT_THAT(e.what(), HasSubstr("feature is not yet implemented: bar"));
+        EXPECT_TRUE(std::string{e.what()}.find("feature is not yet "
+                                               "implemented: bar")
+                    != std::string::npos)
+            << e.what();
     }
     try
     {
@@ -74,8 +76,10 @@ TEST_F(AssertTest, runtime_error)
     }
     catch (RuntimeError const& e)
     {
-        EXPECT_THAT(e.what(),
-                    HasSubstr("runtime error: \x1B[0mthis is not OK"));
+        EXPECT_TRUE(std::string{e.what()}.find("runtime error: \x1B[0mthis is "
+                                               "not OK")
+                    != std::string::npos)
+            << e.what();
     }
 }
 

--- a/test/corecel/Assert.test.cc
+++ b/test/corecel/Assert.test.cc
@@ -24,7 +24,7 @@ namespace test
 class AssertTest : public ::celeritas::test::Test
 {
   protected:
-    static void SetUpTestSuite()
+    static void SetupTestSuite()
     {
         auto& env = celeritas::environment();
         env.insert({"CELER_COLOR", "1"});

--- a/test/corecel/Assert.test.cc
+++ b/test/corecel/Assert.test.cc
@@ -24,7 +24,7 @@ namespace test
 class AssertTest : public ::celeritas::test::Test
 {
   protected:
-    static void SetupTestSuite()
+    void SetUp() override
     {
         auto& env = celeritas::environment();
         env.insert({"CELER_COLOR", "1"});
@@ -113,6 +113,7 @@ TEST_F(AssertTest, runtime_error_variations)
         // Generate the message
         RuntimeError err{std::move(details)};
         messages.push_back(err.what());
+        cout << err.what() << endl;
     }
     static std::string const expected_messages[] = {
         "celeritas: \x1b[31;1munknown error: \x1b[0m\n\x1b[37;2munknown "

--- a/test/corecel/Assert.test.cc
+++ b/test/corecel/Assert.test.cc
@@ -1,0 +1,151 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/Assert.test.cc
+//---------------------------------------------------------------------------//
+#include "corecel/Assert.hh"
+
+#include <string>
+#include <vector>
+#include <gmock/gmock.h>
+
+#include "corecel/io/Repr.hh"
+#include "corecel/sys/Environment.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+class AssertTest : public ::celeritas::test::Test
+{
+  protected:
+    static void SetUpTestSuite()
+    {
+        auto& env = celeritas::environment();
+        env.insert({"CELER_COLOR", "1"});
+        env.insert({"CELER_LOG", "diagnostic"});
+    }
+};
+
+TEST_F(AssertTest, debug_error)
+{
+    DebugErrorDetails details;
+    details.which = DebugErrorType::internal;
+    details.condition = "2 + 2 == 5";
+    details.file = "Assert.test.cc";
+    details.line = 123;
+
+    EXPECT_STREQ(
+        "\x1B[37;1mAssert.test.cc:123:\x1B[0m\nceleritas: \x1B[31;1minternal "
+        "assertion failed: \x1B[37;2m2 + 2 == 5\x1B[0m",
+        DebugError{std::move(details)}.what());
+}
+
+TEST_F(AssertTest, runtime_error)
+{
+    using ::testing::HasSubstr;
+    try
+    {
+        CELER_NOT_CONFIGURED("foo");
+    }
+    catch (RuntimeError const& e)
+    {
+        EXPECT_THAT(e.what(),
+                    HasSubstr("required dependency is disabled in this build: "
+                              "foo"));
+    }
+    try
+    {
+        CELER_NOT_IMPLEMENTED("bar");
+    }
+    catch (RuntimeError const& e)
+    {
+        EXPECT_THAT(e.what(), HasSubstr("feature is not yet implemented: bar"));
+    }
+    try
+    {
+        CELER_VALIDATE(false, << "this is not OK");
+    }
+    catch (RuntimeError const& e)
+    {
+        EXPECT_THAT(e.what(),
+                    HasSubstr("runtime error: \x1B[0mthis is not OK"));
+    }
+}
+
+TEST_F(AssertTest, runtime_error_variations)
+{
+    std::vector<std::string> messages;
+    // Loop over all combinations of missing data
+    for (auto bitmask : range(1 << 4))
+    {
+        RuntimeErrorDetails details;
+        if (bitmask & 0x1)
+        {
+            details.which = "runtime";
+        }
+        if (bitmask & 0x2)
+        {
+            details.what = "bad things happened";
+        }
+        if (bitmask & 0x4)
+        {
+            details.condition = "2 + 2 == 5";
+        }
+        if (bitmask & 0x8)
+        {
+            details.file = "Assert.test.cc";
+            if (bitmask & 0x1)
+            {
+                details.line = 123;
+            }
+        }
+        // Generate the message
+        RuntimeError err{std::move(details)};
+        messages.push_back(err.what());
+    }
+    static std::string const expected_messages[] = {
+        "celeritas: \x1b[31;1munknown error: \x1b[0m\n\x1b[37;2munknown "
+        "source:\x1b[0m failure",
+        "celeritas: \x1b[31;1mruntime error: \x1b[0m\n\x1b[37;2munknown "
+        "source:\x1b[0m failure",
+        "celeritas: \x1b[31;1munknown error: \x1b[0mbad things "
+        "happened\n\x1b[37;2munknown source:\x1b[0m failure",
+        "celeritas: \x1b[31;1mruntime error: \x1b[0mbad things "
+        "happened\n\x1b[37;2munknown source:\x1b[0m failure",
+        "celeritas: \x1b[31;1munknown error: \x1b[0m\n\x1b[37;1munknown "
+        "source:\x1b[0m '2 + 2 == 5' failed",
+        "celeritas: \x1b[31;1mruntime error: \x1b[0m\n\x1b[37;1munknown "
+        "source:\x1b[0m '2 + 2 == 5' failed",
+        "celeritas: \x1b[31;1munknown error: \x1b[0mbad things "
+        "happened\n\x1b[37;1munknown source:\x1b[0m '2 + 2 == 5' failed",
+        "celeritas: \x1b[31;1mruntime error: \x1b[0mbad things "
+        "happened\n\x1b[37;1munknown source:\x1b[0m '2 + 2 == 5' failed",
+        "celeritas: \x1b[31;1munknown error: "
+        "\x1b[0m\n\x1b[37;2mAssert.test.cc:\x1b[0m failure",
+        "celeritas: \x1b[31;1mruntime error: "
+        "\x1b[0m\n\x1b[37;2mAssert.test.cc:123:\x1b[0m failure",
+        "celeritas: \x1b[31;1munknown error: \x1b[0mbad things "
+        "happened\n\x1b[37;2mAssert.test.cc:\x1b[0m failure",
+        "celeritas: \x1b[31;1mruntime error: \x1b[0mbad things "
+        "happened\n\x1b[37;2mAssert.test.cc:123:\x1b[0m failure",
+        "celeritas: \x1b[31;1munknown error: "
+        "\x1b[0m\n\x1b[37;1mAssert.test.cc:\x1b[0m '2 + 2 == 5' failed",
+        "celeritas: \x1b[31;1mruntime error: "
+        "\x1b[0m\n\x1b[37;1mAssert.test.cc:123:\x1b[0m '2 + 2 == 5' failed",
+        "celeritas: \x1b[31;1munknown error: \x1b[0mbad things "
+        "happened\n\x1b[37;1mAssert.test.cc:\x1b[0m '2 + 2 == 5' failed",
+        "celeritas: \x1b[31;1mruntime error: \x1b[0mbad things "
+        "happened\n\x1b[37;1mAssert.test.cc:123:\x1b[0m '2 + 2 == 5' failed"};
+    EXPECT_VEC_EQ(expected_messages, messages);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/corecel/CMakeLists.txt
+++ b/test/corecel/CMakeLists.txt
@@ -18,6 +18,7 @@ celeritas_setup_tests(SERIAL PREFIX corecel
 #-----------------------------------------------------------------------------#
 # TESTS
 #-----------------------------------------------------------------------------#
+celeritas_add_test(Assert.test.cc)
 celeritas_add_test(OpaqueId.test.cc)
 
 # Cont

--- a/test/corecel/CMakeLists.txt
+++ b/test/corecel/CMakeLists.txt
@@ -18,7 +18,9 @@ celeritas_setup_tests(SERIAL PREFIX corecel
 #-----------------------------------------------------------------------------#
 # TESTS
 #-----------------------------------------------------------------------------#
-celeritas_add_test(Assert.test.cc)
+celeritas_add_test(Assert.test.cc
+  ENVIRONMENT "CELER_COLOR=1;CELER_LOG=debug"
+)
 celeritas_add_test(OpaqueId.test.cc)
 
 # Cont


### PR DESCRIPTION
This follow-on to #1197 adds some testing of the various combinations of debug and runtime assertion messages. There was an unclosed color change in the last one that caused not-configured messages to make everything bold.

New messages (from unit test):
<img width="336" alt="325307403-d9b485bd-ea8b-4117-aab8-f5b70b6e70f5" src="https://github.com/celeritas-project/celeritas/assets/741229/0fe94800-1774-48c4-a9c2-23e35125dfd3">


Failure message sent into `CELER_LOG(error)` during raytrace (before):
<img width="1187" alt="Screenshot 2024-04-24 at 13 11 35" src="https://github.com/celeritas-project/celeritas/assets/741229/c18de5fc-e32f-404f-b272-42dedf50715d">


After:
<img width="1199" alt="Screenshot 2024-04-24 at 13 10 01" src="https://github.com/celeritas-project/celeritas/assets/741229/7ffa439a-6816-4d14-a212-a3690b13cf64">

