### PR TITLE
Improve gentrap documentation and fix typos

### DIFF
--- a/src/corecel/io/Join.hh
+++ b/src/corecel/io/Join.hh
@@ -25,8 +25,7 @@ namespace celeritas
  * The result is a thin class that is streamable. (It can explicitly be
  * converted to a string with the
  * \c to_string method). By doing this instead of returning a std::string,
- large
- * and dynamic containers can be e.g. saved to disk.
+ * large and dynamic containers can be e.g. saved to disk.
  */
 template<class InputIterator, class Conjunction>
 detail::Joined<InputIterator, Conjunction, detail::StreamValue>

--- a/src/orange/orangeinp/ConvexRegion.cc
+++ b/src/orange/orangeinp/ConvexRegion.cc
@@ -337,6 +337,7 @@ GenTrap::GenTrap(real_type halfz, VecReal2 const& lo, VecReal2 const& hi)
     CELER_VALIDATE(detail::is_convex(make_span(hi_)),
                    << "+Z polygon is not convex");
 
+    // TODO: Temporarily ensure that all side faces are planar
     for (auto i : range(lo_.size()))
     {
         auto j = (i + 1) % lo_.size();
@@ -381,8 +382,7 @@ void GenTrap::build(ConvexSurfaceBuilder& insert_surface) const
         CELER_ASSERT(SoftZero<real_type>{}(dot_product(d - a, normal)));
 
         // Insert the plane
-        auto sense = (offset < 0 ? Sense::outside : Sense::inside);
-        insert_surface(sense, Plane{normal, offset});
+        insert_surface(Sense::inside, Plane{normal, offset});
     }
 }
 

--- a/src/orange/orangeinp/ConvexRegion.cc
+++ b/src/orange/orangeinp/ConvexRegion.cc
@@ -337,7 +337,6 @@ GenTrap::GenTrap(real_type halfz, VecReal2 const& lo, VecReal2 const& hi)
     CELER_VALIDATE(detail::is_convex(make_span(hi_)),
                    << "+Z polygon is not convex");
 
-    // TODO: Temporarily ensure that all side faces are planar
     for (auto i : range(lo_.size()))
     {
         auto j = (i + 1) % lo_.size();
@@ -382,7 +381,8 @@ void GenTrap::build(ConvexSurfaceBuilder& insert_surface) const
         CELER_ASSERT(SoftZero<real_type>{}(dot_product(d - a, normal)));
 
         // Insert the plane
-        insert_surface(Sense::inside, Plane{normal, offset});
+        auto sense = (offset < 0 ? Sense::outside : Sense::inside);
+        insert_surface(sense, Plane{normal, offset});
     }
 }
 

--- a/src/orange/orangeinp/ConvexRegion.hh
+++ b/src/orange/orangeinp/ConvexRegion.hh
@@ -201,11 +201,9 @@ class Ellipsoid final : public ConvexRegionInterface
  * A generalized trapezoid, inspired by VecGeom's GenTrap and also ROOT's Arb8.
  *
  * A GenTrap represents a general trapezoidal volume with up to eight vertices,
- * or two 4-point sitting on two parallel planes perpendicular to Z axis.
- * Both sets of up to four points provided need to be in counter-clockwise
- * ordering. This ensures that the -z face will have an outward normal, and
- * that the +z face points will correspond to their -z face counterparts for
- * each side face.
+ * or two 4-point sets, sitting on two parallel planes perpendicular to Z axis.
+ * The points in each set might be correspondingly ordered, in such a way to
+ * properly define the side faces.
  * TODO: Add a check for this.
  * TODO: Add proper treatment for degenerate cases.
  */

--- a/src/orange/orangeinp/detail/SenseEvaluator.hh
+++ b/src/orange/orangeinp/detail/SenseEvaluator.hh
@@ -21,7 +21,7 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Evalate whether a point is inside a CSG tree node.
+ * Evaluate whether a point is inside a CSG tree node.
  *
  * This is a construction-time helper that combines \c SenseCalculator with \c
  * LogicEvaluator. Its intended use is primarily for testing.

--- a/test/orange/orangeinp/ConvexRegion.test.cc
+++ b/test/orange/orangeinp/ConvexRegion.test.cc
@@ -495,7 +495,7 @@ TEST_F(GenTrapTest, triang_prism)
     auto result = this->test(
         GenTrap(3, {{-1, -1}, {-1, 1}, {2, 0}}, {{-1, -1}, {-1, 1}, {2, 0}}));
 
-    static char const expected_node[] = "all(+0, -1, +2, -3, -4)";
+    static char const expected_node[] = "all(+0, -1, -2, +3, +4)";
     static char const* const expected_surfaces[]
         = {"Plane: z=-3",
            "Plane: z=3",
@@ -506,31 +506,8 @@ TEST_F(GenTrapTest, triang_prism)
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
     EXPECT_FALSE(result.interior) << result.interior;
-    EXPECT_VEC_SOFT_EQ((Real3{-1, -inf, -3}), result.exterior.lower());
-    EXPECT_VEC_SOFT_EQ((Real3{inf, inf, 3}), result.exterior.upper());
-}
-
-TEST_F(GenTrapTest, trapezoid)
-{
-    auto result
-        = this->test(GenTrap(40,
-                             {{-19, -30}, {-19, 30}, {21, 30}, {21, -30}},
-                             {{-21, -30}, {-21, 30}, {19, 30}, {19, -30}}));
-
-    static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
-    static char const* const expected_surfaces[]
-        = {"Plane: z=-40",
-           "Plane: z=40",
-           "Plane: n={0.99969,-0,0.024992}, d=-19.994",
-           "Plane: y=30",
-           "Plane: n={0.99969,0,0.024992}, d=19.994",
-           "Plane: y=-30"};
-
-    EXPECT_EQ(expected_node, result.node);
-    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
-    EXPECT_FALSE(result.interior) << result.interior;
-    EXPECT_VEC_SOFT_EQ((Real3{-inf, -30, -40}), result.exterior.lower());
-    EXPECT_VEC_SOFT_EQ((Real3{inf, 30, 40}), result.exterior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-inf, -inf, -3}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{-1, inf, 3}), result.exterior.upper());
 }
 
 TEST_F(GenTrapTest, CCWtrap)

--- a/test/orange/orangeinp/ConvexRegion.test.cc
+++ b/test/orange/orangeinp/ConvexRegion.test.cc
@@ -495,7 +495,7 @@ TEST_F(GenTrapTest, triang_prism)
     auto result = this->test(
         GenTrap(3, {{-1, -1}, {-1, 1}, {2, 0}}, {{-1, -1}, {-1, 1}, {2, 0}}));
 
-    static char const expected_node[] = "all(+0, -1, -2, +3, +4)";
+    static char const expected_node[] = "all(+0, -1, +2, -3, -4)";
     static char const* const expected_surfaces[]
         = {"Plane: z=-3",
            "Plane: z=3",
@@ -506,8 +506,32 @@ TEST_F(GenTrapTest, triang_prism)
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
     EXPECT_FALSE(result.interior) << result.interior;
-    EXPECT_VEC_SOFT_EQ((Real3{-inf, -inf, -3}), result.exterior.lower());
-    EXPECT_VEC_SOFT_EQ((Real3{-1, inf, 3}), result.exterior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-1, -inf, -3}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{inf, inf, 3}), result.exterior.upper());
+}
+
+// TODO: find a valid set of points
+TEST_F(GenTrapTest, trapezoid)
+{
+    auto result
+        = this->test(GenTrap(40,
+                             {{-19, -30}, {-19, 30}, {21, 30}, {21, -30}},
+                             {{-21, -30}, {-21, 30}, {19, 30}, {19, -30}}));
+
+    static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
+    static char const* const expected_surfaces[]
+        = {"Plane: z=-40",
+           "Plane: z=40",
+           "Plane: n={0.99969,-0,0.024992}, d=-19.994",
+           "Plane: y=30",
+           "Plane: n={0.99969,0,0.024992}, d=19.994",
+           "Plane: y=-30"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_FALSE(result.interior) << result.interior;
+    EXPECT_VEC_SOFT_EQ((Real3{-inf, -30, -40}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{inf, 30, 40}), result.exterior.upper());
 }
 
 // TODO: this should be valid

--- a/test/orange/orangeinp/ConvexRegion.test.cc
+++ b/test/orange/orangeinp/ConvexRegion.test.cc
@@ -510,7 +510,6 @@ TEST_F(GenTrapTest, triang_prism)
     EXPECT_VEC_SOFT_EQ((Real3{inf, inf, 3}), result.exterior.upper());
 }
 
-// TODO: find a valid set of points
 TEST_F(GenTrapTest, trapezoid)
 {
     auto result
@@ -526,6 +525,29 @@ TEST_F(GenTrapTest, trapezoid)
            "Plane: y=30",
            "Plane: n={0.99969,0,0.024992}, d=19.994",
            "Plane: y=-30"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
+    EXPECT_FALSE(result.interior) << result.interior;
+    EXPECT_VEC_SOFT_EQ((Real3{-inf, -30, -40}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{inf, 30, 40}), result.exterior.upper());
+}
+
+TEST_F(GenTrapTest, CCWtrap)
+{
+    auto result
+        = this->test(GenTrap(40,
+                             {{-19, -30}, {21, -30}, {21, 30}, {-19, 30}},
+                             {{-21, -30}, {19, -30}, {19, 30}, {-21, 30}}));
+
+    static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
+    static char const* const expected_surfaces[]
+        = {"Plane: z=-40",
+           "Plane: z=40",
+           "Plane: y=-30",
+           "Plane: n={0.99969,-0,0.024992}, d=19.994",
+           "Plane: y=30",
+           "Plane: n={0.99969,0,0.024992}, d=-19.994"};
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);


### PR DESCRIPTION
Since the input lower points can be ordered in both CW or CCW orderings, the sense needs to take into account the sign of the plane offset with respect to the plane normal.

An extra test was added for opposite ordering of points (CCW ordering), and the documentation has been adjusted.

See [review process](https://github.com/celeritas-project/celeritas/blob/develop/doc/appendix/administration.rst#code-review) for descriptions of the labels and requirements.
