### PR TITLE
Refactor `ActionSequence` to be templated on Params

### DIFF
--- a/src/celeritas/global/Stepper.hh
+++ b/src/celeritas/global/Stepper.hh
@@ -138,22 +138,22 @@ class Stepper final : public StepperInterface
     ~Stepper();
 
     // Transport existing states
-    StepperResult operator()() override final;
+    StepperResult operator()() final;
 
     // Transport existing states and these new primaries
-    StepperResult operator()(SpanConstPrimary primaries) override final;
+    StepperResult operator()(SpanConstPrimary primaries) final;
 
     // Reseed the RNGs at the start of an event for reproducibility
-    void reseed(EventId event_id) override final;
+    void reseed(EventId event_id) final;
 
     //! Get action sequence for timing diagnostics
-    ActionSequence const& actions() const override final { return *actions_; }
+    ActionSequence const& actions() const final { return *actions_; }
 
     //! Access core data, primarily for debugging
     StateRef const& state_ref() const { return state_.ref(); }
 
     //! Get the core state interface for diagnostic output
-    CoreStateInterface const& state() const override final { return state_; }
+    CoreStateInterface const& state() const final { return state_; }
 
   private:
     // Params and call sequence

--- a/src/celeritas/global/Stepper.hh
+++ b/src/celeritas/global/Stepper.hh
@@ -30,6 +30,7 @@ struct Primary;
 
 namespace detail
 {
+template<class Params>
 class ActionSequence;
 }
 
@@ -78,7 +79,7 @@ class StepperInterface
     //!@{
     //! \name Type aliases
     using Input = StepperInput;
-    using ActionSequence = detail::ActionSequence;
+    using ActionSequence = detail::ActionSequence<CoreParams>;
     using SpanConstPrimary = Span<Primary const>;
     using result_type = StepperResult;
     //!@}
@@ -137,27 +138,27 @@ class Stepper final : public StepperInterface
     ~Stepper();
 
     // Transport existing states
-    StepperResult operator()() final;
+    StepperResult operator()() override final;
 
     // Transport existing states and these new primaries
-    StepperResult operator()(SpanConstPrimary primaries) final;
+    StepperResult operator()(SpanConstPrimary primaries) override final;
 
     // Reseed the RNGs at the start of an event for reproducibility
-    void reseed(EventId event_id) final;
+    void reseed(EventId event_id) override final;
 
     //! Get action sequence for timing diagnostics
-    ActionSequence const& actions() const final { return *actions_; }
+    ActionSequence const& actions() const override final { return *actions_; }
 
     //! Access core data, primarily for debugging
     StateRef const& state_ref() const { return state_.ref(); }
 
     //! Get the core state interface for diagnostic output
-    CoreStateInterface const& state() const final { return state_; }
+    CoreStateInterface const& state() const override final { return state_; }
 
   private:
     // Params and call sequence
     std::shared_ptr<CoreParams const> params_;
-    std::shared_ptr<detail::ActionSequence> actions_;
+    std::shared_ptr<ActionSequence> actions_;
     // State data
     CoreState<M> state_;
 };

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -39,6 +39,7 @@ ActionSequence<Params>::ActionSequence(ActionRegistry const& reg,
                                        Options options)
     : options_(std::move(options))
 {
+    actions_.reserve(reg.num_actions());
     // Loop over all action IDs
     for (auto aidx : range(reg.num_actions()))
     {
@@ -52,6 +53,7 @@ ActionSequence<Params>::ActionSequence(ActionRegistry const& reg,
         }
     }
 
+    begin_run_.reserve(reg.mutable_actions().size());
     // Loop over all mutable actions
     for (auto const& base : reg.mutable_actions())
     {

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -136,8 +136,7 @@ void ActionSequence<Params>::execute(Params const& params, State<M>& state)
 // Explicit template instantiation
 //---------------------------------------------------------------------------//
 
-template ActionSequence<CoreParams>::ActionSequence(ActionRegistry const& reg,
-                                                    Options options);
+template class ActionSequence<CoreParams>;
 
 template void ActionSequence<CoreParams>::begin_run(CoreParams const&,
                                                     State<MemSpace::host>&);

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -11,6 +11,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <celeritas/global/CoreParams.hh>
 
 #include "corecel/device_runtime_api.h"
 #include "corecel/Types.hh"
@@ -21,7 +22,6 @@
 #include "corecel/sys/Stopwatch.hh"
 #include "corecel/sys/Stream.hh"
 
-#include "ParamsTraits.hh"
 #include "../ActionInterface.hh"
 #include "../ActionRegistry.hh"
 #include "../CoreState.hh"
@@ -34,7 +34,9 @@ namespace detail
 /*!
  * Construct from an action registry and sequence options.
  */
-ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
+template<class Params>
+ActionSequence<Params>::ActionSequence(ActionRegistry const& reg,
+                                       Options options)
     : options_(std::move(options))
 {
     // Loop over all action IDs
@@ -42,8 +44,8 @@ ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
     {
         // Get abstract action shared pointer and see if it's explicit
         auto const& base = reg.action(ActionId{aidx});
-        if (auto expl
-            = std::dynamic_pointer_cast<ExplicitActionInterface const>(base))
+        using element_type = typename SPConstSpecializedExplicit::element_type;
+        if (auto expl = std::dynamic_pointer_cast<element_type>(base))
         {
             // Add explicit action to our array
             actions_.push_back(std::move(expl));
@@ -63,7 +65,8 @@ ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
     // Sort actions by increasing order (and secondarily, increasing IDs)
     std::sort(actions_.begin(),
               actions_.end(),
-              [](SPConstExplicit const& a, SPConstExplicit const& b) {
+              [](SPConstSpecializedExplicit const& a,
+                 SPConstSpecializedExplicit const& b) {
                   return std::make_tuple(a->order(), a->action_id())
                          < std::make_tuple(b->order(), b->action_id());
               });
@@ -78,8 +81,9 @@ ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
 /*!
  * Initialize actions and states.
  */
+template<class Params>
 template<MemSpace M>
-void ActionSequence::begin_run(CoreParams const& params, CoreState<M>& state)
+void ActionSequence<Params>::begin_run(Params const& params, State<M>& state)
 {
     for (auto const& sp_action : begin_run_)
     {
@@ -92,15 +96,10 @@ void ActionSequence::begin_run(CoreParams const& params, CoreState<M>& state)
 /*!
  * Call all explicit actions with host or device data.
  */
-template<typename Params, template<MemSpace M> class State, MemSpace M>
-void ActionSequence::execute(Params const& params, State<M>& state)
+template<class Params>
+template<MemSpace M>
+void ActionSequence<Params>::execute(Params const& params, State<M>& state)
 {
-    using ExplicitAction = typename ParamsTraits<Params>::ExplicitAction;
-
-    static_assert(
-        std::is_same_v<State<M>, typename ParamsTraits<Params>::template State<M>>,
-        "The Params and State type are not matching.");
-
     [[maybe_unused]] Stream::StreamT stream = nullptr;
     if (M == MemSpace::device && options_.sync)
     {
@@ -114,9 +113,7 @@ void ActionSequence::execute(Params const& params, State<M>& state)
         {
             ScopedProfiling profile_this{actions_[i]->label()};
             Stopwatch get_time;
-            auto const& concrete_action
-                = dynamic_cast<ExplicitAction const&>(*actions_[i]);
-            concrete_action.execute(params, state);
+            actions_[i]->execute(params, state);
             if (M == MemSpace::device)
             {
                 CELER_DEVICE_CALL_PREFIX(StreamSynchronize(stream));
@@ -127,12 +124,10 @@ void ActionSequence::execute(Params const& params, State<M>& state)
     else
     {
         // Just loop over the actions
-        for (SPConstExplicit const& sp_action : actions_)
+        for (auto const& sp_action : actions_)
         {
             ScopedProfiling profile_this{sp_action->label()};
-            auto const& concrete_action
-                = dynamic_cast<ExplicitAction const&>(*sp_action);
-            concrete_action.execute(params, state);
+            sp_action->execute(params, state);
         }
     }
 }
@@ -141,15 +136,18 @@ void ActionSequence::execute(Params const& params, State<M>& state)
 // Explicit template instantiation
 //---------------------------------------------------------------------------//
 
-template void
-ActionSequence::begin_run(CoreParams const&, CoreState<MemSpace::host>&);
-template void
-ActionSequence::begin_run(CoreParams const&, CoreState<MemSpace::device>&);
+template ActionSequence<CoreParams>::ActionSequence(ActionRegistry const& reg,
+                                                    Options options);
+
+template void ActionSequence<CoreParams>::begin_run(CoreParams const&,
+                                                    State<MemSpace::host>&);
+template void ActionSequence<CoreParams>::begin_run(CoreParams const&,
+                                                    State<MemSpace::device>&);
 
 template void
-ActionSequence::execute(CoreParams const&, CoreState<MemSpace::host>&);
-template void
-ActionSequence::execute(CoreParams const&, CoreState<MemSpace::device>&);
+ActionSequence<CoreParams>::execute(CoreParams const&, State<MemSpace::host>&);
+template void ActionSequence<CoreParams>::execute(CoreParams const&,
+                                                  State<MemSpace::device>&);
 
 // TODO: add explicit template instantiation of execute for optical data
 

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -11,7 +11,6 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
-#include <celeritas/global/CoreParams.hh>
 
 #include "corecel/device_runtime_api.h"
 #include "corecel/Types.hh"
@@ -21,6 +20,7 @@
 #include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/Stopwatch.hh"
 #include "corecel/sys/Stream.hh"
+#include "celeritas/global/CoreParams.hh"
 
 #include "../ActionInterface.hh"
 #include "../ActionRegistry.hh"

--- a/src/celeritas/global/detail/ActionSequence.hh
+++ b/src/celeritas/global/detail/ActionSequence.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include "corecel/Types.hh"
@@ -49,6 +50,12 @@ class ActionSequence
         = std::vector<SPConstSpecializedExplicit>;
     using VecDouble = std::vector<double>;
     //!@}
+
+    // Verify that we have a valid explicit action type for the given Params
+    static_assert(
+        std::is_base_of_v<ExplicitActionInterface, SpecializedExplicitAction>,
+        "ParamTraits<Params> explicit action must be derived from "
+        "ExplicitActionInterface");
 
     //! Construction/execution options
     struct Options

--- a/src/celeritas/global/detail/ActionSequence.hh
+++ b/src/celeritas/global/detail/ActionSequence.hh
@@ -12,6 +12,7 @@
 
 #include "corecel/Types.hh"
 
+#include "ParamsTraits.hh"
 #include "../ActionInterface.hh"
 #include "../CoreTrackDataFwd.hh"
 
@@ -30,15 +31,22 @@ namespace detail
  * TODO accessors here are used by diagnostic output from celer-sim etc.;
  * perhaps make this public or add a diagnostic output for it?
  */
+template<class Params>
 class ActionSequence
 {
   public:
     //!@{
     //! \name Type aliases
+    template<MemSpace M>
+    using State = typename ParamsTraits<Params>::template State<M>;
+    using SpecializedExplicitAction =
+        typename ParamsTraits<Params>::ExplicitAction;
     using SPBegin = std::shared_ptr<BeginRunActionInterface>;
-    using SPConstExplicit = std::shared_ptr<ExplicitActionInterface const>;
+    using SPConstSpecializedExplicit
+        = std::shared_ptr<SpecializedExplicitAction const>;
     using VecBeginAction = std::vector<SPBegin>;
-    using VecExplicitAction = std::vector<SPConstExplicit>;
+    using VecSpecializedExplicitAction
+        = std::vector<SPConstSpecializedExplicit>;
     using VecDouble = std::vector<double>;
     //!@}
 
@@ -56,10 +64,10 @@ class ActionSequence
 
     // Launch all actions with the given memory space.
     template<MemSpace M>
-    void begin_run(CoreParams const& params, CoreState<M>& state);
+    void begin_run(Params const& params, State<M>& state);
 
     // Launch all actions with the given memory space.
-    template<typename Params, template<MemSpace M> class State, MemSpace M>
+    template<MemSpace M>
     void execute(Params const&, State<M>& state);
 
     //// ACCESSORS ////
@@ -71,7 +79,7 @@ class ActionSequence
     VecBeginAction const& begin_run_actions() const { return begin_run_; }
 
     //! Get the ordered vector of actions in the sequence
-    VecExplicitAction const& actions() const { return actions_; }
+    VecSpecializedExplicitAction const& actions() const { return actions_; }
 
     //! Get the corresponding accumulated time, if 'sync' or host called
     VecDouble const& accum_time() const { return accum_time_; }
@@ -79,7 +87,7 @@ class ActionSequence
   private:
     Options options_;
     VecBeginAction begin_run_;
-    VecExplicitAction actions_;
+    VecSpecializedExplicitAction actions_;
     VecDouble accum_time_;
 };
 


### PR DESCRIPTION
`ActionSequence` is now a class template on CoreParams / OpticalParams. This allows casting actions to the more specialized `ExplicitCoreActionInterface` or `ExplicitOpticalActionInterface` in the ctor instead of doing it in `ActionSequence::execute`.

This adds the constraint that a given `ActionSequence` instance operates only on either `ExplicitCoreActionInterface` or `ExplicitOpticalActionInterface` (or any other subtype of `ExplicitActionInterface`)