### PR TITLE
Use string view for interface labels and descriptions

### DIFF
--- a/app/celer-g4/TimerOutput.hh
+++ b/app/celer-g4/TimerOutput.hh
@@ -43,7 +43,7 @@ class TimerOutput final : public OutputInterface
     //! Category of data to write
     Category category() const final { return Category::result; }
     //! Key for the entry inside the category.
-    std::string label() const final { return "time"; }
+    std::string_view label() const final { return "time"; }
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;
     //!@}

--- a/app/celer-sim/RunnerOutput.hh
+++ b/app/celer-sim/RunnerOutput.hh
@@ -49,7 +49,7 @@ class RunnerOutput final : public OutputInterface
     Category category() const final { return Category::result; }
 
     //! Name of the entry inside the category.
-    std::string label() const final { return "runner"; }
+    std::string_view label() const final { return "runner"; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -88,6 +88,15 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
         result.alive.push_back(track_counts.alive);
     };
 
+    constexpr size_type min_alloc{65536};
+    result.initializers.reserve(std::min(min_alloc, max_steps_));
+    result.active.reserve(std::min(min_alloc, max_steps_));
+    result.alive.reserve(std::min(min_alloc, max_steps_));
+    if (store_step_times_)
+    {
+        result.step_times.reserve(std::min(min_alloc, max_steps_));
+    }
+
     // Abort cleanly for interrupt and user-defined signals
 #ifndef _WIN32
     ScopedSignalHandler interrupted{SIGINT, SIGUSR2};

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -165,8 +165,7 @@ void Transporter<M>::accum_action_times(MapStrDouble* result) const
         CELER_ASSERT(action_ptrs.size() == times.size());
         for (auto i : range(action_ptrs.size()))
         {
-            auto&& label = action_ptrs[i]->label();
-            (*result)[label] += times[i];
+            (*result)[std::string{action_ptrs[i]->label()}] += times[i];
         }
     }
 }

--- a/src/accel/GeantSimpleCalo.cc
+++ b/src/accel/GeantSimpleCalo.cc
@@ -172,7 +172,7 @@ auto GeantSimpleCalo::CalcTotalEnergyDeposition() const -> VecReal
 /*!
  * Return the key in the JSON output.
  */
-std::string GeantSimpleCalo::label() const
+std::string_view GeantSimpleCalo::label() const
 {
     return storage_->name;
 }

--- a/src/accel/GeantSimpleCalo.hh
+++ b/src/accel/GeantSimpleCalo.hh
@@ -65,7 +65,7 @@ class GeantSimpleCalo final : public OutputInterface
     //! Category of data to write
     Category category() const final { return Category::result; }
     // Key for the entry inside the category
-    std::string label() const final;
+    std::string_view label() const final;
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;
     //!@}

--- a/src/accel/GeantStepDiagnostic.hh
+++ b/src/accel/GeantStepDiagnostic.hh
@@ -44,7 +44,7 @@ class GeantStepDiagnostic final : public OutputInterface
     //! Category of data to write
     Category category() const final { return Category::result; }
     //! Key for the entry inside the category.
-    std::string label() const final { return "g4-step-diagnostic"; }
+    std::string_view label() const final { return "g4-step-diagnostic"; }
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;
     //!@}

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -262,8 +262,7 @@ auto LocalTransporter::GetActionTime() const -> MapStrReal
         CELER_ASSERT(action_ptrs.size() == time.size());
         for (auto i : range(action_ptrs.size()))
         {
-            auto&& label = action_ptrs[i]->label();
-            result[label] = time[i];
+            result[std::string{action_ptrs[i]->label()}] = time[i];
         }
     }
     return result;

--- a/src/celeritas/em/model/BetheHeitlerModel.hh
+++ b/src/celeritas/em/model/BetheHeitlerModel.hh
@@ -52,10 +52,10 @@ class BetheHeitlerModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "conv-bethe-heitler"; }
+    std::string_view label() const final { return "conv-bethe-heitler"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by Bethe-Heitler gamma conversion";
     }

--- a/src/celeritas/em/model/CombinedBremModel.hh
+++ b/src/celeritas/em/model/CombinedBremModel.hh
@@ -67,10 +67,10 @@ class CombinedBremModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "brems-combined"; }
+    std::string_view label() const final { return "brems-combined"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by bremsstrahlung (combined SB/relativistic, e+/-)";
     }

--- a/src/celeritas/em/model/CoulombScatteringModel.hh
+++ b/src/celeritas/em/model/CoulombScatteringModel.hh
@@ -77,10 +77,10 @@ class CoulombScatteringModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "coulomb-wentzel"; }
+    std::string_view label() const final { return "coulomb-wentzel"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by Coulomb scattering (Wentzel)";
     }

--- a/src/celeritas/em/model/EPlusGGModel.hh
+++ b/src/celeritas/em/model/EPlusGGModel.hh
@@ -41,10 +41,10 @@ class EPlusGGModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "annihil-2-gamma"; }
+    std::string_view label() const final { return "annihil-2-gamma"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by positron annihilation yielding two gammas";
     }

--- a/src/celeritas/em/model/KleinNishinaModel.hh
+++ b/src/celeritas/em/model/KleinNishinaModel.hh
@@ -39,10 +39,10 @@ class KleinNishinaModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "scat-klein-nishina"; }
+    std::string_view label() const final { return "scat-klein-nishina"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by Compton scattering (simple Klein-Nishina)";
     }

--- a/src/celeritas/em/model/LivermorePEModel.hh
+++ b/src/celeritas/em/model/LivermorePEModel.hh
@@ -57,10 +57,10 @@ class LivermorePEModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "photoel-livermore"; }
+    std::string_view label() const final { return "photoel-livermore"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by Livermore photoelectric effect";
     }

--- a/src/celeritas/em/model/MollerBhabhaModel.hh
+++ b/src/celeritas/em/model/MollerBhabhaModel.hh
@@ -40,10 +40,10 @@ class MollerBhabhaModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "ioni-moller-bhabha"; }
+    std::string_view label() const final { return "ioni-moller-bhabha"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by Moller+Bhabha ionization";
     }

--- a/src/celeritas/em/model/MuBremsstrahlungModel.hh
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.hh
@@ -51,10 +51,10 @@ class MuBremsstrahlungModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "brems-muon"; }
+    std::string_view label() const final { return "brems-muon"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by bremsstrahlung (muon)";
     }

--- a/src/celeritas/em/model/RayleighModel.hh
+++ b/src/celeritas/em/model/RayleighModel.hh
@@ -58,10 +58,10 @@ class RayleighModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "scat-rayleigh"; }
+    std::string_view label() const final { return "scat-rayleigh"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by Rayleigh scattering";
     }

--- a/src/celeritas/em/model/RelativisticBremModel.hh
+++ b/src/celeritas/em/model/RelativisticBremModel.hh
@@ -61,10 +61,10 @@ class RelativisticBremModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "brems-rel"; }
+    std::string_view label() const final { return "brems-rel"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by relativistic bremsstrahlung";
     }

--- a/src/celeritas/em/model/SeltzerBergerModel.hh
+++ b/src/celeritas/em/model/SeltzerBergerModel.hh
@@ -81,10 +81,10 @@ class SeltzerBergerModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "brems-sb"; }
+    std::string_view label() const final { return "brems-sb"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by Seltzer-Berger bremsstrahlung";
     }

--- a/src/celeritas/em/process/BremsstrahlungProcess.cc
+++ b/src/celeritas/em/process/BremsstrahlungProcess.cc
@@ -113,7 +113,7 @@ auto BremsstrahlungProcess::step_limits(Applicability applic) const
 /*!
  * Name of the process.
  */
-std::string BremsstrahlungProcess::label() const
+std::string_view BremsstrahlungProcess::label() const
 {
     return "Bremsstrahlung";
 }

--- a/src/celeritas/em/process/BremsstrahlungProcess.hh
+++ b/src/celeritas/em/process/BremsstrahlungProcess.hh
@@ -69,7 +69,7 @@ class BremsstrahlungProcess : public Process
     bool use_integral_xs() const final { return options_.use_integral_xs; }
 
     // Name of the process
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     SPConstParticles particles_;

--- a/src/celeritas/em/process/ComptonProcess.cc
+++ b/src/celeritas/em/process/ComptonProcess.cc
@@ -53,7 +53,7 @@ auto ComptonProcess::step_limits(Applicability applic) const
 /*!
  * Name of the process.
  */
-std::string ComptonProcess::label() const
+std::string_view ComptonProcess::label() const
 {
     return "Compton scattering";
 }

--- a/src/celeritas/em/process/ComptonProcess.hh
+++ b/src/celeritas/em/process/ComptonProcess.hh
@@ -43,7 +43,7 @@ class ComptonProcess : public Process
     bool use_integral_xs() const final { return false; }
 
     // Name of the process
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     SPConstParticles particles_;

--- a/src/celeritas/em/process/CoulombScatteringProcess.cc
+++ b/src/celeritas/em/process/CoulombScatteringProcess.cc
@@ -62,7 +62,7 @@ auto CoulombScatteringProcess::step_limits(Applicability applic) const
 /*!
  * Name of the process.
  */
-std::string CoulombScatteringProcess::label() const
+std::string_view CoulombScatteringProcess::label() const
 {
     return "Coulomb scattering";
 }

--- a/src/celeritas/em/process/CoulombScatteringProcess.hh
+++ b/src/celeritas/em/process/CoulombScatteringProcess.hh
@@ -51,7 +51,7 @@ class CoulombScatteringProcess : public Process
     bool use_integral_xs() const final;
 
     // Name of the process
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     SPConstParticles particles_;

--- a/src/celeritas/em/process/EIonizationProcess.cc
+++ b/src/celeritas/em/process/EIonizationProcess.cc
@@ -57,7 +57,7 @@ auto EIonizationProcess::step_limits(Applicability applicability) const
 /*!
  * Name of the process.
  */
-std::string EIonizationProcess::label() const
+std::string_view EIonizationProcess::label() const
 {
     return "Electron/positron ionization";
 }

--- a/src/celeritas/em/process/EIonizationProcess.hh
+++ b/src/celeritas/em/process/EIonizationProcess.hh
@@ -52,7 +52,7 @@ class EIonizationProcess : public Process
     bool use_integral_xs() const final { return options_.use_integral_xs; }
 
     // Name of the process
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     SPConstParticles particles_;

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.cc
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.cc
@@ -63,7 +63,7 @@ auto EPlusAnnihilationProcess::step_limits(Applicability range) const
 /*!
  * Name of the process.
  */
-std::string EPlusAnnihilationProcess::label() const
+std::string_view EPlusAnnihilationProcess::label() const
 {
     return "Positron annihiliation";
 }

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.hh
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.hh
@@ -49,7 +49,7 @@ class EPlusAnnihilationProcess final : public Process
     bool use_integral_xs() const final { return options_.use_integral_xs; }
 
     // Name of the process
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     SPConstParticles particles_;

--- a/src/celeritas/em/process/GammaConversionProcess.cc
+++ b/src/celeritas/em/process/GammaConversionProcess.cc
@@ -59,7 +59,7 @@ auto GammaConversionProcess::step_limits(Applicability applic) const
 /*!
  * Name of the process.
  */
-std::string GammaConversionProcess::label() const
+std::string_view GammaConversionProcess::label() const
 {
     return "Photon annihiliation";
 }

--- a/src/celeritas/em/process/GammaConversionProcess.hh
+++ b/src/celeritas/em/process/GammaConversionProcess.hh
@@ -51,7 +51,7 @@ class GammaConversionProcess : public Process
     bool use_integral_xs() const final { return false; }
 
     // Name of the process
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     SPConstParticles particles_;

--- a/src/celeritas/em/process/PhotoelectricProcess.cc
+++ b/src/celeritas/em/process/PhotoelectricProcess.cc
@@ -62,7 +62,7 @@ auto PhotoelectricProcess::step_limits(Applicability applic) const
 /*!
  * Name of the process.
  */
-std::string PhotoelectricProcess::label() const
+std::string_view PhotoelectricProcess::label() const
 {
     return "Photoelectric effect";
 }

--- a/src/celeritas/em/process/PhotoelectricProcess.hh
+++ b/src/celeritas/em/process/PhotoelectricProcess.hh
@@ -53,7 +53,7 @@ class PhotoelectricProcess : public Process
     bool use_integral_xs() const final { return false; }
 
     // Name of the process
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     SPConstParticles particles_;

--- a/src/celeritas/em/process/RayleighProcess.cc
+++ b/src/celeritas/em/process/RayleighProcess.cc
@@ -57,7 +57,7 @@ auto RayleighProcess::step_limits(Applicability applic) const
 /*!
  * Name of the process.
  */
-std::string RayleighProcess::label() const
+std::string_view RayleighProcess::label() const
 {
     return "Rayleigh scattering";
 }

--- a/src/celeritas/em/process/RayleighProcess.hh
+++ b/src/celeritas/em/process/RayleighProcess.hh
@@ -47,7 +47,7 @@ class RayleighProcess : public Process
     bool use_integral_xs() const final { return false; }
 
     // Name of the process
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     SPConstParticles particles_;

--- a/src/celeritas/global/ActionInterface.hh
+++ b/src/celeritas/global/ActionInterface.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 #include "celeritas/Types.hh"  // IWYU pragma: export
 
@@ -58,10 +59,10 @@ class ActionInterface
     virtual ActionId action_id() const = 0;
 
     //! Short unique label of the action
-    virtual std::string label() const = 0;
+    virtual std::string_view label() const = 0;
 
     //! Description of the action
-    virtual std::string description() const = 0;
+    virtual std::string_view description() const = 0;
 
   protected:
     //!@{
@@ -194,10 +195,10 @@ class ConcreteAction : public virtual ActionInterface
     ActionId action_id() const final { return id_; }
 
     //! Short label
-    std::string label() const final { return label_; }
+    std::string_view label() const final { return label_; }
 
     //! Descriptive label
-    std::string description() const final { return description_; }
+    std::string_view description() const final { return description_; }
 
   private:
     ActionId id_;

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -75,7 +75,7 @@ class ActionLauncher
 
     //! Create a launcher with a string extension
     ActionLauncher(ExplicitActionInterface const& action, std::string_view ext)
-        : ActionLauncher{action.label() + "-" + std::string(ext)}
+        : ActionLauncher{std::string(action.label()) + "-" + std::string(ext)}
     {
     }
 

--- a/src/celeritas/global/ActionRegistry.cc
+++ b/src/celeritas/global/ActionRegistry.cc
@@ -49,7 +49,7 @@ void ActionRegistry::insert_const_impl(SPConstAction&& action)
  */
 void ActionRegistry::insert_impl(SPConstAction&& action)
 {
-    auto label = action->label();
+    auto label = std::string{action->label()};
     CELER_VALIDATE(!label.empty(), << "action label is empty");
 
     auto id = action->action_id();

--- a/src/celeritas/global/ActionRegistryOutput.hh
+++ b/src/celeritas/global/ActionRegistryOutput.hh
@@ -34,7 +34,7 @@ class ActionRegistryOutput final : public OutputInterface
     Category category() const final { return Category::internal; }
 
     //! Name of the entry inside the category.
-    std::string label() const final { return "actions"; }
+    std::string_view label() const final { return "actions"; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -46,8 +46,8 @@ KernelContextException::KernelContextException(
     HostCRef<CoreParamsData> const& params,
     HostRef<CoreStateData> const& states,
     ThreadId thread,
-    std::string&& label)
-    : thread_(thread), label_(std::move(label))
+    std::string_view label)
+    : thread_(thread), label_{label}
 {
     try
     {

--- a/src/celeritas/global/KernelContextException.hh
+++ b/src/celeritas/global/KernelContextException.hh
@@ -7,7 +7,10 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <string_view>
+
 #include "corecel/Assert.hh"
+#include "corecel/io/JsonPimpl.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
 
@@ -47,7 +50,7 @@ class KernelContextException : public RichContextException
     KernelContextException(HostCRef<CoreParamsData> const& params,
                            HostRef<CoreStateData> const& states,
                            ThreadId tid,
-                           std::string&& label);
+                           std::string_view label);
 
     // This class type
     char const* type() const final;

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.hh
@@ -68,10 +68,13 @@ class AlongStepGeneralLinearAction final : public ExplicitCoreActionInterface
     ActionId action_id() const final { return id_; }
 
     //! Short name for the along-step kernel
-    std::string label() const final { return "along-step-general-linear"; }
+    std::string_view label() const final
+    {
+        return "along-step-general-linear";
+    }
 
     //! Short description of the action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "apply along-step for particles with no field";
     }

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.hh
@@ -38,10 +38,10 @@ class AlongStepNeutralAction final : public ExplicitCoreActionInterface
     ActionId action_id() const final { return id_; }
 
     //! Short name for the along-step kernel
-    std::string label() const final { return "along-step-neutral"; }
+    std::string_view label() const final { return "along-step-neutral"; }
 
     //! Short description of the action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "apply along-step for neutral particles";
     }

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.hh
@@ -67,10 +67,10 @@ class AlongStepRZMapFieldMscAction final : public ExplicitCoreActionInterface
     ActionId action_id() const final { return id_; }
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "along-step-rzmap-msc"; }
+    std::string_view label() const final { return "along-step-rzmap-msc"; }
 
     //! Short description of the action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "apply along-step in a R-Z map field with Urban MSC";
     }

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.hh
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.hh
@@ -67,10 +67,10 @@ class AlongStepUniformMscAction final : public ExplicitCoreActionInterface
     ActionId action_id() const final { return id_; }
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "along-step-uniform-msc"; }
+    std::string_view label() const final { return "along-step-uniform-msc"; }
 
     //! Short description of the action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "apply along-step in a uniform field with Urban MSC";
     }

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -89,7 +89,7 @@ void ActionSequence<Params>::begin_run(Params const& params, State<M>& state)
 {
     for (auto const& sp_action : begin_run_)
     {
-        ScopedProfiling profile_this{sp_action->label()};
+        ScopedProfiling profile_this{std::string{sp_action->label()}};
         sp_action->begin_run(params, state);
     }
 }
@@ -113,7 +113,7 @@ void ActionSequence<Params>::execute(Params const& params, State<M>& state)
         // Execute all actions and record the time elapsed
         for (auto i : range(actions_.size()))
         {
-            ScopedProfiling profile_this{actions_[i]->label()};
+            ScopedProfiling profile_this{std::string{actions_[i]->label()}};
             Stopwatch get_time;
             actions_[i]->execute(params, state);
             if (M == MemSpace::device)
@@ -128,7 +128,7 @@ void ActionSequence<Params>::execute(Params const& params, State<M>& state)
         // Just loop over the actions
         for (auto const& sp_action : actions_)
         {
-            ScopedProfiling profile_this{sp_action->label()};
+            ScopedProfiling profile_this{std::string{sp_action->label()}};
             sp_action->execute(params, state);
         }
     }

--- a/src/celeritas/global/detail/ActionSequence.cc
+++ b/src/celeritas/global/detail/ActionSequence.cc
@@ -89,7 +89,7 @@ void ActionSequence<Params>::begin_run(Params const& params, State<M>& state)
 {
     for (auto const& sp_action : begin_run_)
     {
-        ScopedProfiling profile_this{std::string{sp_action->label()}};
+        ScopedProfiling profile_this{sp_action->label()};
         sp_action->begin_run(params, state);
     }
 }
@@ -113,7 +113,7 @@ void ActionSequence<Params>::execute(Params const& params, State<M>& state)
         // Execute all actions and record the time elapsed
         for (auto i : range(actions_.size()))
         {
-            ScopedProfiling profile_this{std::string{actions_[i]->label()}};
+            ScopedProfiling profile_this{actions_[i]->label()};
             Stopwatch get_time;
             actions_[i]->execute(params, state);
             if (M == MemSpace::device)
@@ -128,7 +128,7 @@ void ActionSequence<Params>::execute(Params const& params, State<M>& state)
         // Just loop over the actions
         for (auto const& sp_action : actions_)
         {
-            ScopedProfiling profile_this{std::string{sp_action->label()}};
+            ScopedProfiling profile_this{sp_action->label()};
             sp_action->execute(params, state);
         }
     }

--- a/src/celeritas/mat/MaterialParamsOutput.hh
+++ b/src/celeritas/mat/MaterialParamsOutput.hh
@@ -34,7 +34,7 @@ class MaterialParamsOutput final : public OutputInterface
     Category category() const final { return Category::internal; }
 
     //! Name of the entry inside the category.
-    std::string label() const final { return "material"; }
+    std::string_view label() const final { return "material"; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;

--- a/src/celeritas/neutron/model/ChipsNeutronElasticModel.hh
+++ b/src/celeritas/neutron/model/ChipsNeutronElasticModel.hh
@@ -61,10 +61,10 @@ class ChipsNeutronElasticModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "neutron-elastic-chips"; }
+    std::string_view label() const final { return "neutron-elastic-chips"; }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by neutron elastic scattering (CHIPS)";
     }

--- a/src/celeritas/neutron/model/NeutronInelasticModel.hh
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.hh
@@ -61,10 +61,13 @@ class NeutronInelasticModel final : public Model
     ActionId action_id() const final;
 
     //! Short name for the interaction kernel
-    std::string label() const final { return "neutron-inelastic-bertini"; }
+    std::string_view label() const final
+    {
+        return "neutron-inelastic-bertini";
+    }
 
     //! Short description of the post-step action
-    std::string description() const final
+    std::string_view description() const final
     {
         return "interact by neutron inelastic (Bertini)";
     }

--- a/src/celeritas/neutron/process/NeutronElasticProcess.cc
+++ b/src/celeritas/neutron/process/NeutronElasticProcess.cc
@@ -61,7 +61,7 @@ auto NeutronElasticProcess::step_limits(Applicability applic) const
 /*!
  * Name of the process.
  */
-std::string NeutronElasticProcess::label() const
+std::string_view NeutronElasticProcess::label() const
 {
     return "Neutron elastic";
 }

--- a/src/celeritas/neutron/process/NeutronElasticProcess.hh
+++ b/src/celeritas/neutron/process/NeutronElasticProcess.hh
@@ -50,7 +50,7 @@ class NeutronElasticProcess : public Process
     bool use_integral_xs() const final { return false; }
 
     // Name of the process
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     SPConstParticles particles_;

--- a/src/celeritas/neutron/process/NeutronInelasticProcess.cc
+++ b/src/celeritas/neutron/process/NeutronInelasticProcess.cc
@@ -61,7 +61,7 @@ auto NeutronInelasticProcess::step_limits(Applicability applic) const
 /*!
  * Name of the process.
  */
-std::string NeutronInelasticProcess::label() const
+std::string_view NeutronInelasticProcess::label() const
 {
     return "Neutron inelastic";
 }

--- a/src/celeritas/neutron/process/NeutronInelasticProcess.hh
+++ b/src/celeritas/neutron/process/NeutronInelasticProcess.hh
@@ -50,7 +50,7 @@ class NeutronInelasticProcess : public Process
     bool use_integral_xs() const final { return false; }
 
     // Name of the process
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     SPConstParticles particles_;

--- a/src/celeritas/optical/detail/PreGenAction.cc
+++ b/src/celeritas/optical/detail/PreGenAction.cc
@@ -50,7 +50,7 @@ PreGenAction::PreGenAction(ActionId id,
 /*!
  * Descriptive name of the action.
  */
-std::string PreGenAction::description() const
+std::string_view PreGenAction::description() const
 {
     return "generate Cerenkov and scintillation optical distribution data";
 }

--- a/src/celeritas/optical/detail/PreGenAction.hh
+++ b/src/celeritas/optical/detail/PreGenAction.hh
@@ -66,10 +66,13 @@ class PreGenAction final : public ExplicitCoreActionInterface
     ActionId action_id() const final { return id_; }
 
     //! Short name for the action
-    std::string label() const final { return "optical-pre-generator-post"; }
+    std::string_view label() const final
+    {
+        return "optical-pre-generator-post";
+    }
 
     // Name of the action (for user output)
-    std::string description() const final;
+    std::string_view description() const final;
 
     //! Dependency ordering of the action
     ActionOrder order() const final { return ActionOrder::post_post; }

--- a/src/celeritas/optical/detail/PreGenGatherAction.cc
+++ b/src/celeritas/optical/detail/PreGenGatherAction.cc
@@ -38,7 +38,7 @@ PreGenGatherAction::PreGenGatherAction(ActionId id, SPGenStorage storage)
 /*!
  * Descriptive name of the action.
  */
-std::string PreGenGatherAction::description() const
+std::string_view PreGenGatherAction::description() const
 {
     return "gather pre-step data to generate optical distributions";
 }

--- a/src/celeritas/optical/detail/PreGenGatherAction.hh
+++ b/src/celeritas/optical/detail/PreGenGatherAction.hh
@@ -45,10 +45,13 @@ class PreGenGatherAction final : public ExplicitCoreActionInterface
     ActionId action_id() const final { return id_; }
 
     //! Short name for the action
-    std::string label() const final { return "optical-pre-generator-pre"; }
+    std::string_view label() const final
+    {
+        return "optical-pre-generator-pre";
+    }
 
     // Name of the action (for user output)
-    std::string description() const final;
+    std::string_view description() const final;
 
     //! Dependency ordering of the action
     ActionOrder order() const final { return ActionOrder::pre; }

--- a/src/celeritas/phys/ParticleParamsOutput.hh
+++ b/src/celeritas/phys/ParticleParamsOutput.hh
@@ -34,7 +34,7 @@ class ParticleParamsOutput final : public OutputInterface
     Category category() const final { return Category::internal; }
 
     //! Name of the entry inside the category.
-    std::string label() const final { return "particle"; }
+    std::string_view label() const final { return "particle"; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;

--- a/src/celeritas/phys/PhysicsParamsOutput.hh
+++ b/src/celeritas/phys/PhysicsParamsOutput.hh
@@ -33,7 +33,7 @@ class PhysicsParamsOutput final : public OutputInterface
     Category category() const final { return Category::internal; }
 
     //! Name of the entry inside the category.
-    std::string label() const final { return "physics"; }
+    std::string_view label() const final { return "physics"; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;

--- a/src/celeritas/phys/Process.hh
+++ b/src/celeritas/phys/Process.hh
@@ -67,7 +67,7 @@ class Process
     virtual bool use_integral_xs() const = 0;
 
     //! Name of the process
-    virtual std::string label() const = 0;
+    virtual std::string_view label() const = 0;
 
   protected:
     //!@{

--- a/src/celeritas/track/ExtendFromPrimariesAction.hh
+++ b/src/celeritas/track/ExtendFromPrimariesAction.hh
@@ -38,10 +38,10 @@ class ExtendFromPrimariesAction final : public ExplicitCoreActionInterface
     ActionId action_id() const final { return id_; }
 
     //! Short name for the action
-    std::string label() const final { return "extend-from-primaries"; }
+    std::string_view label() const final { return "extend-from-primaries"; }
 
     //! Description of the action for user interaction
-    std::string description() const final
+    std::string_view description() const final
     {
         return "create track initializers from primaries";
     }

--- a/src/celeritas/track/ExtendFromSecondariesAction.cc
+++ b/src/celeritas/track/ExtendFromSecondariesAction.cc
@@ -23,7 +23,7 @@ namespace celeritas
 /*!
  * Get a long description of the action.
  */
-std::string ExtendFromSecondariesAction::description() const
+std::string_view ExtendFromSecondariesAction::description() const
 {
     return "create track initializers from secondaries";
 }

--- a/src/celeritas/track/ExtendFromSecondariesAction.hh
+++ b/src/celeritas/track/ExtendFromSecondariesAction.hh
@@ -87,9 +87,9 @@ class ExtendFromSecondariesAction final : public ExplicitCoreActionInterface,
     //! ID of the action
     ActionId action_id() const final { return id_; }
     //! Short name for the action
-    std::string label() const final { return "extend-from-secondaries"; }
+    std::string_view label() const final { return "extend-from-secondaries"; }
     // Description of the action for user interaction
-    std::string description() const final;
+    std::string_view description() const final;
     //! Dependency ordering of the action
     ActionOrder order() const final { return ActionOrder::end; }
     //!@}

--- a/src/celeritas/track/InitializeTracksAction.hh
+++ b/src/celeritas/track/InitializeTracksAction.hh
@@ -37,10 +37,13 @@ class InitializeTracksAction final : public ExplicitCoreActionInterface
     ActionId action_id() const final { return id_; }
 
     //! Short name for the action
-    std::string label() const final { return "initialize-tracks"; }
+    std::string_view label() const final { return "initialize-tracks"; }
 
     //! Description of the action for user interaction
-    std::string description() const final { return "initialize track states"; }
+    std::string_view description() const final
+    {
+        return "initialize track states";
+    }
 
     //! Dependency ordering of the action
     ActionOrder order() const final { return ActionOrder::start; }

--- a/src/celeritas/track/SortTracksAction.cc
+++ b/src/celeritas/track/SortTracksAction.cc
@@ -90,7 +90,7 @@ SortTracksAction::SortTracksAction(ActionId id, TrackOrder track_order)
 /*!
  * Short name for the action
  */
-std::string SortTracksAction::label() const
+std::string_view SortTracksAction::label() const
 {
     switch (track_order_)
     {

--- a/src/celeritas/track/SortTracksAction.hh
+++ b/src/celeritas/track/SortTracksAction.hh
@@ -52,10 +52,10 @@ class SortTracksAction final : public ExplicitCoreActionInterface,
     ActionId action_id() const final { return id_; }
 
     //! Short name for the action
-    std::string label() const final;
+    std::string_view label() const final;
 
     //! Description of the action for user interaction
-    std::string description() const final { return "sort tracks states"; }
+    std::string_view description() const final { return "sort tracks states"; }
 
     //! Dependency ordering of the action
     ActionOrder order() const final { return action_order_; }

--- a/src/celeritas/user/ActionDiagnostic.cc
+++ b/src/celeritas/user/ActionDiagnostic.cc
@@ -95,7 +95,7 @@ void ActionDiagnostic::execute(CoreParams const& params,
 /*!
  * Get a long description of the action.
  */
-std::string ActionDiagnostic::description() const
+std::string_view ActionDiagnostic::description() const
 {
     return "accumulate post-step action counters";
 }

--- a/src/celeritas/user/ActionDiagnostic.hh
+++ b/src/celeritas/user/ActionDiagnostic.hh
@@ -61,9 +61,9 @@ class ActionDiagnostic final : public ExplicitCoreActionInterface,
     //! ID of the action
     ActionId action_id() const final { return id_; }
     //! Short name for the action
-    std::string label() const final { return "action-diagnostic"; }
+    std::string_view label() const final { return "action-diagnostic"; }
     // Description of the action for user interaction
-    std::string description() const final;
+    std::string_view description() const final;
     //! Dependency ordering of the action
     ActionOrder order() const final { return ActionOrder::post; }
     //!@}

--- a/src/celeritas/user/SimpleCalo.hh
+++ b/src/celeritas/user/SimpleCalo.hh
@@ -77,7 +77,7 @@ class SimpleCalo final : public StepInterface, public OutputInterface
     // Category of data to write
     Category category() const final { return Category::result; }
     // Key for the entry inside the category.
-    std::string label() const final { return output_label_; }
+    std::string_view label() const final { return output_label_; }
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;
     //!@}

--- a/src/celeritas/user/StepDiagnostic.cc
+++ b/src/celeritas/user/StepDiagnostic.cc
@@ -89,7 +89,7 @@ void StepDiagnostic::execute(CoreParams const&, CoreStateDevice&) const
 /*!
  * Get a long description of the action.
  */
-std::string StepDiagnostic::description() const
+std::string_view StepDiagnostic::description() const
 {
     return "accumulate total step counters";
 }

--- a/src/celeritas/user/StepDiagnostic.hh
+++ b/src/celeritas/user/StepDiagnostic.hh
@@ -55,9 +55,9 @@ class StepDiagnostic final : public ExplicitCoreActionInterface,
     //! ID of the action
     ActionId action_id() const final { return id_; }
     //! Short name for the action
-    std::string label() const final { return "step-diagnostic"; }
+    std::string_view label() const final { return "step-diagnostic"; }
     // Description of the action for user interaction
-    std::string description() const final;
+    std::string_view description() const final;
     //! Dependency ordering of the action
     ActionOrder order() const final { return ActionOrder::post_post; }
     //!@}

--- a/src/celeritas/user/detail/StepGatherAction.cc
+++ b/src/celeritas/user/detail/StepGatherAction.cc
@@ -40,19 +40,11 @@ StepGatherAction<P>::StepGatherAction(ActionId id,
     CELER_EXPECT(id_);
     CELER_EXPECT(!callbacks_.empty() || P == StepPoint::pre);
     CELER_EXPECT(storage_);
-}
 
-//---------------------------------------------------------------------------//
-/*!
- * Descriptive name of the action.
- */
-template<StepPoint P>
-std::string StepGatherAction<P>::description() const
-{
-    std::string result = "gather ";
-    result += P == StepPoint::pre ? "pre" : "post";
-    result += "-step steps/hits";
-    return result;
+    description_ = "gather ";
+    description_ += (P == StepPoint::pre ? "pre" : "post");
+    description_ += "-step steps/hits";
+    CELER_ENSURE(!description_.empty());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/detail/StepGatherAction.hh
+++ b/src/celeritas/user/detail/StepGatherAction.hh
@@ -57,15 +57,15 @@ class StepGatherAction final : public ExplicitCoreActionInterface
     ActionId action_id() const final { return id_; }
 
     //! Short name for the action
-    std::string label() const final
+    std::string_view label() const final
     {
         return P == StepPoint::pre    ? "step-gather-pre"
                : P == StepPoint::post ? "step-gather-post"
-                                      : "";
+                                      : std::string_view{};
     }
 
     // Name of the action (for user output)
-    std::string description() const final;
+    std::string_view description() const final { return description_; }
 
     //! Dependency ordering of the action
     ActionOrder order() const final
@@ -81,6 +81,7 @@ class StepGatherAction final : public ExplicitCoreActionInterface
     ActionId id_;
     SPStepStorage storage_;
     VecInterface callbacks_;
+    std::string description_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/BuildOutput.hh
+++ b/src/corecel/io/BuildOutput.hh
@@ -22,7 +22,7 @@ class BuildOutput final : public OutputInterface
     Category category() const final { return Category::system; };
 
     //! Key for the entry inside the category.
-    std::string label() const final { return "build"; }
+    std::string_view label() const final { return "build"; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;

--- a/src/corecel/io/ExceptionOutput.hh
+++ b/src/corecel/io/ExceptionOutput.hh
@@ -46,7 +46,7 @@ class ExceptionOutput final : public OutputInterface
     Category category() const final { return Category::result; }
 
     // Key for the entry inside the category.
-    std::string label() const final { return "exception"; }
+    std::string_view label() const final { return "exception"; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;

--- a/src/corecel/io/OutputInterface.hh
+++ b/src/corecel/io/OutputInterface.hh
@@ -9,6 +9,7 @@
 
 #include <iosfwd>  // IWYU pragma: export
 #include <string>  // IWYU pragma: export
+#include <string_view>  // IWYU pragma: export
 
 namespace celeritas
 {
@@ -42,7 +43,7 @@ class OutputInterface
     virtual Category category() const = 0;
 
     //! Key for the entry inside the category.
-    virtual std::string label() const = 0;
+    virtual std::string_view label() const = 0;
 
     // Write output to the given JSON object
     virtual void output(JsonPimpl*) const = 0;

--- a/src/corecel/io/OutputInterfaceAdapter.hh
+++ b/src/corecel/io/OutputInterfaceAdapter.hh
@@ -51,7 +51,7 @@ class OutputInterfaceAdapter final : public OutputInterface
     Category category() const final { return cat_; }
 
     //! Label of the entry inside the category.
-    std::string label() const final { return label_; }
+    std::string_view label() const final { return label_; }
 
     // Write output to the given JSON object
     void output(JsonPimpl* jp) const final;

--- a/src/corecel/io/OutputRegistry.cc
+++ b/src/corecel/io/OutputRegistry.cc
@@ -41,7 +41,7 @@ void OutputRegistry::insert(SPConstInterface interface)
 
     Category cat = interface->category();
     auto [prev, inserted]
-        = interfaces_[cat].insert({std::move(label), std::move(interface)});
+        = interfaces_[cat].insert({std::string{label}, std::move(interface)});
     CELER_VALIDATE(inserted,
                    << "duplicate output entry '" << prev->first
                    << "' for category '" << to_cstring(cat) << "'");

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -37,7 +37,7 @@ nvtxDomainHandle_t domain_handle()
  *
  * Insert it if it doesn't already exist.
  */
-nvtxStringHandle_t message_handle_for(std::string const& message)
+nvtxStringHandle_t message_handle_for(std::string_view message)
 {
     static std::unordered_map<std::string, nvtxStringHandle_t> registry;
     static std::shared_mutex mutex;
@@ -53,15 +53,15 @@ nvtxStringHandle_t message_handle_for(std::string const& message)
     }
 
     // We did not find the handle; try to insert it
-    auto [iter, inserted] = [&message] {
+    auto [iter, inserted] = [message] {
         std::unique_lock lock(mutex);
-        return registry.insert({message, {}});
+        return registry.insert({std::string{message}, {}});
     }();
     if (inserted)
     {
         // Register the domain
         iter->second
-            = nvtxDomainRegisterStringA(domain_handle(), message.c_str());
+            = nvtxDomainRegisterStringA(domain_handle(), iter->first.c_str());
     }
     return iter->second;
 }

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -42,10 +42,11 @@ nvtxStringHandle_t message_handle_for(std::string_view message)
     static std::unordered_map<std::string, nvtxStringHandle_t> registry;
     static std::shared_mutex mutex;
 
+    std::string temp_message{message};
     {
         std::shared_lock lock(mutex);
 
-        if (auto message_handle = registry.find(message);
+        if (auto message_handle = registry.find(temp_message);
             message_handle != registry.end())
         {
             return message_handle->second;
@@ -53,9 +54,9 @@ nvtxStringHandle_t message_handle_for(std::string_view message)
     }
 
     // We did not find the handle; try to insert it
-    auto [iter, inserted] = [message] {
+    auto [iter, inserted] = [&temp_message] {
         std::unique_lock lock(mutex);
-        return registry.insert({std::string{message}, {}});
+        return registry.insert({std::move(temp_message), {}});
     }();
     if (inserted)
     {

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -21,12 +21,12 @@ namespace celeritas
  */
 struct ScopedProfilingInput
 {
-    std::string name;  //!< Name of the range
+    std::string_view name;  //!< Name of the range
     uint32_t color{};  //!< ARGB
     int32_t payload{};  //!< User data
     uint32_t category{};  //!< Category, used to group ranges together
 
-    ScopedProfilingInput(std::string const& name) : name{name} {}
+    ScopedProfilingInput(std::string_view n) : name{n} {}
 };
 
 //---------------------------------------------------------------------------//
@@ -68,7 +68,7 @@ class ScopedProfiling
     // Activate profiling with options
     explicit inline ScopedProfiling(Input const& input);
     // Activate profiling with just a name
-    explicit inline ScopedProfiling(std::string const& name);
+    explicit inline ScopedProfiling(std::string_view name);
 
     // Deactivate profiling
     inline ~ScopedProfiling();
@@ -104,7 +104,7 @@ ScopedProfiling::ScopedProfiling(Input const& input)
 /*!
  * Activate device profiling with just a name.
  */
-ScopedProfiling::ScopedProfiling(std::string const& name)
+ScopedProfiling::ScopedProfiling(std::string_view name)
     : ScopedProfiling{Input{name}}
 {
 }

--- a/src/corecel/sys/ScopedProfiling.hip.cc
+++ b/src/corecel/sys/ScopedProfiling.hip.cc
@@ -8,6 +8,8 @@
 //---------------------------------------------------------------------------//
 #include "ScopedProfiling.hh"
 
+#include <string>
+
 #include "celeritas_sys_config.h"
 #include "corecel/io/Logger.hh"
 
@@ -56,7 +58,8 @@ void ScopedProfiling::activate(Input const& input) noexcept
 {
     int result = 0;
 #if CELERITAS_HAVE_ROCTX
-    result = roctxRangePush(input.name.c_str());
+    std::string temp_name{input.name};
+    result = roctxRangePush(temp_name.c_str());
 #endif
     if (result < 0)
     {

--- a/src/geocel/GeoParamsOutput.hh
+++ b/src/geocel/GeoParamsOutput.hh
@@ -36,7 +36,7 @@ class GeoParamsOutput final : public OutputInterface
     Category category() const final { return Category::internal; }
 
     //! Name of the entry inside the category.
-    std::string label() const final { return "geometry"; }
+    std::string_view label() const final { return "geometry"; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;

--- a/src/geocel/vg/VecgeomParamsOutput.hh
+++ b/src/geocel/vg/VecgeomParamsOutput.hh
@@ -38,7 +38,7 @@ class VecgeomParamsOutput final : public OutputInterface
     Category category() const final { return Category::internal; }
 
     //! Name of the entry inside the category.
-    std::string label() const final { return "vecgeom"; }
+    std::string_view label() const final { return "vecgeom"; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;

--- a/src/orange/OrangeParamsOutput.hh
+++ b/src/orange/OrangeParamsOutput.hh
@@ -38,7 +38,7 @@ class OrangeParamsOutput final : public OutputInterface
     Category category() const final { return Category::internal; }
 
     //! Name of the entry inside the category.
-    std::string label() const final { return "orange"; }
+    std::string_view label() const final { return "orange"; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;

--- a/test/celeritas/global/ActionRegistry.test.cc
+++ b/test/celeritas/global/ActionRegistry.test.cc
@@ -33,8 +33,11 @@ class MyExplicitAction final : public ExplicitCoreActionInterface,
     }
 
     ActionId action_id() const final { return action_id_; }
-    std::string label() const final { return "explicit"; }
-    std::string description() const final { return "explicit action test"; }
+    std::string_view label() const final { return "explicit"; }
+    std::string_view description() const final
+    {
+        return "explicit action test";
+    }
 
     void begin_run(CoreParams const&, CoreStateHost&) final
     {

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -72,7 +72,7 @@ auto StepperTestBase::check_setup() -> SetupCheckResult
 
     for (auto process_id : range(ProcessId{p.num_processes()}))
     {
-        result.processes.push_back(p.process(process_id)->label());
+        result.processes.push_back(std::string{p.process(process_id)->label()});
     }
 
     // Create temporary host stepper to get action ordering
@@ -80,8 +80,8 @@ auto StepperTestBase::check_setup() -> SetupCheckResult
     auto const& action_seq = temp_stepper.actions();
     for (auto const& sp_action : action_seq.actions())
     {
-        result.actions.push_back(sp_action->label());
-        result.actions_desc.push_back(sp_action->description());
+        result.actions.push_back(std::string{sp_action->label()});
+        result.actions_desc.push_back(std::string{sp_action->description()});
     }
 
     return result;

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -72,7 +72,7 @@ auto StepperTestBase::check_setup() -> SetupCheckResult
 
     for (auto process_id : range(ProcessId{p.num_processes()}))
     {
-        result.processes.push_back(std::string{p.process(process_id)->label()});
+        result.processes.emplace_back(p.process(process_id)->label());
     }
 
     // Create temporary host stepper to get action ordering
@@ -80,8 +80,8 @@ auto StepperTestBase::check_setup() -> SetupCheckResult
     auto const& action_seq = temp_stepper.actions();
     for (auto const& sp_action : action_seq.actions())
     {
-        result.actions.push_back(std::string{sp_action->label()});
-        result.actions_desc.push_back(std::string{sp_action->description()});
+        result.actions.emplace_back(sp_action->label());
+        result.actions_desc.emplace_back(sp_action->description());
     }
 
     return result;

--- a/test/celeritas/phys/MockModel.cc
+++ b/test/celeritas/phys/MockModel.cc
@@ -23,6 +23,15 @@ MockModel::MockModel(Input data) : data_(std::move(data))
     CELER_EXPECT(data_.materials);
     CELER_EXPECT(data_.applic);
     CELER_EXPECT(data_.cb);
+    label_ = "mock-model-";
+    label_ += std::to_string(data_.id.get() - 4);
+
+    std::ostringstream os;
+    os << "MockModel(" << (data_.id.get() - 4)
+       << ", p=" << data_.applic.particle.get()
+       << ", emin=" << data_.applic.lower.value()
+       << ", emax=" << data_.applic.upper.value() << ")";
+    description_ = std::move(os).str();
 }
 
 auto MockModel::applicability() const -> SetApplicability
@@ -64,21 +73,6 @@ void MockModel::execute(CoreParams const&, CoreStateDevice&) const
 {
     // Inform calling test code that we've been executed
     data_.cb(this->action_id());
-}
-
-std::string MockModel::label() const
-{
-    return std::string("mock-model-") + std::to_string(data_.id.get() - 4);
-}
-
-std::string MockModel::description() const
-{
-    std::ostringstream os;
-    os << "MockModel(" << (data_.id.get() - 4)
-       << ", p=" << data_.applic.particle.get()
-       << ", emin=" << data_.applic.lower.value()
-       << ", emax=" << data_.applic.upper.value() << ")";
-    return os.str();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/phys/MockModel.hh
+++ b/test/celeritas/phys/MockModel.hh
@@ -51,11 +51,13 @@ class MockModel final : public Model
     void execute(CoreParams const&, CoreStateHost&) const final;
     void execute(CoreParams const&, CoreStateDevice&) const final;
     ActionId action_id() const final { return data_.id; }
-    std::string label() const final;
-    std::string description() const final;
+    std::string_view label() const final { return label_; }
+    std::string_view description() const final { return description_; }
 
   private:
     Input data_;
+    std::string label_;
+    std::string description_;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/phys/MockProcess.cc
+++ b/test/celeritas/phys/MockProcess.cc
@@ -101,7 +101,7 @@ bool MockProcess::use_integral_xs() const
 }
 
 //---------------------------------------------------------------------------//
-std::string MockProcess::label() const
+std::string_view MockProcess::label() const
 {
     return data_.label;
 }

--- a/test/celeritas/phys/MockProcess.hh
+++ b/test/celeritas/phys/MockProcess.hh
@@ -87,7 +87,7 @@ class MockProcess : public Process
     VecModel build_models(ActionIdIter start_id) const final;
     StepLimitBuilders step_limits(Applicability range) const final;
     bool use_integral_xs() const final;
-    std::string label() const final;
+    std::string_view label() const final;
 
   private:
     Input data_;

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -64,7 +64,7 @@ TEST_F(PhysicsParamsTest, accessors)
     std::vector<std::string> process_names;
     for (auto process_id : range(ProcessId{p.num_processes()}))
     {
-        process_names.push_back(std::string{p.process(process_id)->label()});
+        process_names.emplace_back(p.process(process_id)->label());
     }
     static char const* const expected_process_names[]
         = {"scattering", "absorption", "purrs", "hisses", "meows", "barks"};
@@ -76,8 +76,8 @@ TEST_F(PhysicsParamsTest, accessors)
     for (auto model_id : range(ModelId{p.num_models()}))
     {
         Model const& m = *p.model(model_id);
-        model_names.push_back(std::string{m.label()});
-        model_desc.push_back(std::string{m.description()});
+        model_names.emplace_back(m.label());
+        model_desc.emplace_back(m.description());
     }
 
     static std::string const expected_model_names[] = {

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -64,9 +64,9 @@ TEST_F(PhysicsParamsTest, accessors)
     std::vector<std::string> process_names;
     for (auto process_id : range(ProcessId{p.num_processes()}))
     {
-        process_names.push_back(p.process(process_id)->label());
+        process_names.push_back(std::string{p.process(process_id)->label()});
     }
-    std::string const expected_process_names[]
+    static char const* const expected_process_names[]
         = {"scattering", "absorption", "purrs", "hisses", "meows", "barks"};
     EXPECT_VEC_EQ(expected_process_names, process_names);
 
@@ -76,8 +76,8 @@ TEST_F(PhysicsParamsTest, accessors)
     for (auto model_id : range(ModelId{p.num_models()}))
     {
         Model const& m = *p.model(model_id);
-        model_names.push_back(m.label());
-        model_desc.push_back(m.description());
+        model_names.push_back(std::string{m.label()});
+        model_desc.push_back(std::string{m.description()});
     }
 
     static std::string const expected_model_names[] = {
@@ -252,7 +252,7 @@ class PhysicsTrackViewHostTest : public PhysicsParamsTest
 
     ParamsHostRef params_ref;
     StateStore state;
-    std::map<std::string, ProcessId> process_names;
+    std::map<std::string_view, ProcessId> process_names;
     RandomEngine rng_;
 };
 

--- a/test/celeritas/track/MockInteractAction.hh
+++ b/test/celeritas/track/MockInteractAction.hh
@@ -37,8 +37,11 @@ class MockInteractAction final : public ExplicitCoreActionInterface
     void execute(CoreParams const&, CoreStateDevice&) const final;
 
     ActionId action_id() const final { return id_; }
-    std::string label() const final { return "mock-interact"; }
-    std::string description() const final { return "mock interact kernel"; }
+    std::string_view label() const final { return "mock-interact"; }
+    std::string_view description() const final
+    {
+        return "mock interact kernel";
+    }
     ActionOrder order() const final { return ActionOrder::post; }
 
     // Get the number of secondaries

--- a/test/corecel/io/OutputRegistry.test.cc
+++ b/test/corecel/io/OutputRegistry.test.cc
@@ -33,7 +33,7 @@ class TestInterface final : public OutputInterface
     }
 
     Category category() const final { return cat_; }
-    std::string label() const final { return label_; }
+    std::string_view label() const final { return label_; }
 
     void output(JsonPimpl* json) const final
     {


### PR DESCRIPTION
This prevents repeated allocation/deallocation during the stepping loop as noticed by @esseivaju in #1172.