### PR TITLE
Add always-on basic diagnostics to celer-sim

### DIFF
--- a/app/celer-sim/RunnerOutput.cc
+++ b/app/celer-sim/RunnerOutput.cc
@@ -49,14 +49,25 @@ void RunnerOutput::output(JsonPimpl* j) const
     auto alive = json::array();
     auto initializers = json::array();
     auto num_track_slots = json::array();
+    auto num_step_iterations = json::array();
+    auto num_steps = json::array();
+    auto num_aborted = json::array();
+    auto max_queued = json::array();
     auto step_times = json::array();
 
     for (auto const& event : result_.events)
     {
-        active.push_back(event.active);
-        alive.push_back(event.alive);
-        initializers.push_back(event.initializers);
+        if (!event.active.empty())
+        {
+            active.push_back(event.active);
+            alive.push_back(event.alive);
+            initializers.push_back(event.initializers);
+        }
         num_track_slots.push_back(event.num_track_slots);
+        num_step_iterations.push_back(event.num_step_iterations);
+        num_steps.push_back(event.num_steps);
+        num_aborted.push_back(event.num_aborted);
+        max_queued.push_back(event.max_queued);
         if (!event.step_times.empty())
         {
             step_times.push_back(event.step_times);
@@ -67,6 +78,10 @@ void RunnerOutput::output(JsonPimpl* j) const
     obj["alive"] = std::move(alive);
     obj["initializers"] = std::move(initializers);
     obj["num_track_slots"] = std::move(num_track_slots);
+    obj["num_step_iterations"] = std::move(num_step_iterations);
+    obj["num_steps"] = std::move(num_steps);
+    obj["num_aborted"] = std::move(num_aborted);
+    obj["max_queued"] = std::move(max_queued);
     obj["time"] = {
         {"steps", std::move(step_times)},
         {"actions", result_.action_times},

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "Transporter.hh"
 
+#include <algorithm>
 #include <csignal>
 #include <memory>
 #include <utility>
@@ -82,10 +83,17 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
 {
     // Initialize results
     TransporterResult result;
-    auto append_track_counts = [&result](StepperResult const& track_counts) {
-        result.initializers.push_back(track_counts.queued);
-        result.active.push_back(track_counts.active);
-        result.alive.push_back(track_counts.alive);
+    auto append_track_counts = [&](StepperResult const& track_counts) {
+        if (store_track_counts_)
+        {
+            result.initializers.push_back(track_counts.queued);
+            result.active.push_back(track_counts.active);
+            result.alive.push_back(track_counts.alive);
+        }
+        ++result.num_step_iterations;
+        result.num_steps += track_counts.active;
+        result.num_aborted = track_counts.alive + track_counts.queued;
+        result.max_queued = std::max(result.max_queued, track_counts.queued);
     };
 
     // Abort cleanly for interrupt and user-defined signals
@@ -103,10 +111,7 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
     auto& step = *stepper_;
     // Copy primaries to device and transport the first step
     auto track_counts = step(primaries);
-    if (store_track_counts_)
-    {
-        append_track_counts(track_counts);
-    }
+    append_track_counts(track_counts);
     if (store_step_times_)
     {
         result.step_times.push_back(get_step_time());
@@ -132,10 +137,7 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
         get_step_time = {};
         track_counts = step();
 
-        if (store_track_counts_)
-        {
-            append_track_counts(track_counts);
-        }
+        append_track_counts(track_counts);
         if (store_step_times_)
         {
             result.step_times.push_back(get_step_time());

--- a/app/celer-sim/Transporter.hh
+++ b/app/celer-sim/Transporter.hh
@@ -63,11 +63,18 @@ struct TransporterResult
     using VecReal = std::vector<real_type>;
     using VecCount = std::vector<size_type>;
 
+    // Per-step diagnostics
     VecCount initializers;  //!< Num starting track initializers
     VecCount active;  //!< Num tracks active at beginning of step
     VecCount alive;  //!< Num living tracks at end of step
     VecReal step_times;  //!< Real time per step
+
+    // Always-on basic diagnostics
     size_type num_track_slots{};  //!< Number of total track slots
+    size_type num_step_iterations{};  //!< Total number of step iterations
+    size_type num_steps{};  //!< Total number of steps
+    size_type num_aborted{};  //!< Number of unconverged tracks
+    size_type max_queued{};  //!< Maximum track initializer count
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
The diagnostics for #1211 are easy to add to our existing runner output, but I can try to think of how we could refactor this to work with celer-g4 as well if you'd like.