### PR TITLE
Fix library macro compatibility wrappers

### DIFF
--- a/cmake/CeleritasLibrary.cmake
+++ b/cmake/CeleritasLibrary.cmake
@@ -13,9 +13,8 @@ Deprecated file for use by downstream code. TODO: remove in v1.0.
 
 include("${CMAKE_CURRENT_LIST_DIR}/CudaRdcUtils.cmake")
 
-message(AUTHOR_WARNING "CeleritasLibrary has been replaced by CudaRdcUtils. Please include(CudaRdcUtils) and
-replace celeritas_(add_library|add_executable|target_link_libraries) with
-cuda_rdc_(...)")
+message(AUTHOR_WARNING "CeleritasLibrary has been replaced by CudaRdcUtils.
+Please include(CudaRdcUtils) and address the following warnings...")
 
 macro(celeritas_add_library)
   message(AUTHOR_WARNING "Replace with cuda_rdc_add_library")
@@ -27,7 +26,17 @@ macro(celeritas_add_executable)
   cuda_rdc_add_executable(${ARGV})
 endmacro()
 
-macro(celeritas_link_libraries)
-  message(AUTHOR_WARNING "Replace with cuda_rdc_link_libraries")
-  cuda_rdc_link_libraries(${ARGV})
+macro(celeritas_target_link_libraries)
+  message(AUTHOR_WARNING "Replace with cuda_rdc_target_link_libraries")
+  cuda_rdc_target_link_libraries(${ARGV})
+endmacro()
+
+macro(celeritas_target_compile_options)
+  message(AUTHOR_WARNING "Replace with cuda_rdc_target_compile_options")
+  cuda_rdc_target_compile_options(${ARGV})
+endmacro()
+
+macro(celeritas_set_target_properties)
+  message(AUTHOR_WARNING "Replace with cuda_rdc_set_target_properties")
+  cuda_rdc_set_target_properties(${ARGV})
 endmacro()

--- a/scripts/cmake-presets/goldfinger.json
+++ b/scripts/cmake-presets/goldfinger.json
@@ -24,6 +24,7 @@
         "CMAKE_CXX_STANDARD":   {"type": "STRING",   "value": "17"},
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL",   "value": "OFF"},
         "CMAKE_FIND_FRAMEWORK": {"type": "STRING", "value": "LAST"},
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}"
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fno-inline -fno-omit-frame-pointer",
         "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-error=deprecated -pedantic -fdiagnostics-color=always"
       }


### PR DESCRIPTION
This fixes the compatibility wrappers introduced in #1104 so that a downstream user code targeting Celeritas 0.4 will still work with 0.5.