### PR TITLE
Update single and multiple Coulomb scattering configurations in `GeantPhysicsList`

### DIFF
--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -44,7 +44,7 @@ physics_options = {
     'ionization': True,
     'annihilation': True,
     'brems': "all",
-    'msc': "urban_extended" if core_geo == "vecgeom" else "none",
+    'msc': "urban" if core_geo == "vecgeom" else "none",
     'eloss_fluctuation': True,
     'lpm': True,
 }

--- a/doc/main/overview.rst
+++ b/doc/main/overview.rst
@@ -53,35 +53,39 @@ and their corresponding Geant4 classes are documented in :ref:`celeritas_physics
 
    .. table:: Electromagnetic physics processes and models available in Celeritas.
 
-      +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      | **Particle**   | **Processes**       |  **Models**                 | **Celeritas Implementation**                       | **Applicability**        |
-      +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      | :math:`e^-`    | Ionisation          |  Møller                     | :cpp:class:`celeritas::MollerBhabhaInteractor`     |       0--100 TeV         |
-      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      |                | Bremsstrahlung      |  Seltzer--Berger            | :cpp:class:`celeritas::SeltzerBergerInteractor`    |       0--1 GeV           |
-      |                |                     +-----------------------------+----------------------------------------------------+--------------------------+
-      |                |                     |  Relativistic               | :cpp:class:`celeritas::RelativisticBremInteractor` |   1 GeV -- 100 TeV       |
-      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      |                | Coulomb scattering  |  Urban                      | :cpp:class:`celeritas::UrbanMscScatter`            |   100 eV -- 100 TeV      |
-      +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      | :math:`e^+`    | Ionisation          |  Bhabha                     | :cpp:class:`celeritas::MollerBhabhaInteractor`     |       0--100 TeV         |
-      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      |                | Bremsstrahlung      |  Seltzer-Berger             | :cpp:class:`celeritas::SeltzerBergerInteractor`    |       0--1 GeV           |
-      |                |                     +-----------------------------+----------------------------------------------------+--------------------------+
-      |                |                     |  Relativistic               | :cpp:class:`celeritas::RelativisticBremInteractor` |   1 GeV -- 100 TeV       |
-      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      |                | Coulomb scattering  |  Urban                      | :cpp:class:`celeritas::UrbanMscScatter`            |   100 eV -- 100 TeV      |
-      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      |                | Annihilation        | :math:`e^+,e^- \to 2\gamma` | :cpp:class:`celeritas::EPlusGGInteractor`          |       0--100 TeV         |
-      +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      | :math:`\gamma` | Photoelectric       |  Livermore                  | :cpp:class:`celeritas::LivermorePEInteractor`      |       0--100 TeV         |
-      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      |                | Compton scattering  |  Klein--Nishina             | :cpp:class:`celeritas::KleinNishinaInteractor`     |       0--100 TeV         |
-      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      |                | Pair production     |  Bethe--Heitler             | :cpp:class:`celeritas::BetheHeitlerInteractor`     |       0--100 TeV         |
-      |                +---------------------+-----------------------------+----------------------------------------------------+--------------------------+
-      |                | Rayleigh scattering |  Livermore                  | :cpp:class:`celeritas::RayleighInteractor`         |       0--100 TeV         |
-      +----------------+---------------------+-----------------------------+----------------------------------------------------+--------------------------+
+      +----------------+---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      | **Particle**   | **Processes**       |  **Models**                 | **Celeritas Implementation**                        | **Applicability**        |
+      +----------------+---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      | :math:`e^-`    | Ionisation          |  Møller                     | :cpp:class:`celeritas::MollerBhabhaInteractor`      |       0--100 TeV         |
+      |                +---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      |                | Bremsstrahlung      |  Seltzer--Berger            | :cpp:class:`celeritas::SeltzerBergerInteractor`     |       0--1 GeV           |
+      |                |                     +-----------------------------+-----------------------------------------------------+--------------------------+
+      |                |                     |  Relativistic               | :cpp:class:`celeritas::RelativisticBremInteractor`  |   1 GeV -- 100 TeV       |
+      |                +---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      |                | Coulomb scattering  |  Urban                      | :cpp:class:`celeritas::UrbanMscScatter`             |   100 eV -- 100 TeV      |
+      |                |                     +-----------------------------+-----------------------------------------------------+--------------------------+
+      |                |                     |  Coulomb                    | :cpp:class:`celeritas::CoulombScatteringInteractor` |       0--100 TeV         |
+      +----------------+---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      | :math:`e^+`    | Ionisation          |  Bhabha                     | :cpp:class:`celeritas::MollerBhabhaInteractor`      |       0--100 TeV         |
+      |                +---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      |                | Bremsstrahlung      |  Seltzer-Berger             | :cpp:class:`celeritas::SeltzerBergerInteractor`     |       0--1 GeV           |
+      |                |                     +-----------------------------+-----------------------------------------------------+--------------------------+
+      |                |                     |  Relativistic               | :cpp:class:`celeritas::RelativisticBremInteractor`  |   1 GeV -- 100 TeV       |
+      |                +---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      |                | Coulomb scattering  |  Urban                      | :cpp:class:`celeritas::UrbanMscScatter`             |   100 eV -- 100 TeV      |
+      |                |                     +-----------------------------+-----------------------------------------------------+--------------------------+
+      |                |                     |  Coulomb                    | :cpp:class:`celeritas::CoulombScatteringInteractor` |       0--100 TeV         |
+      |                +---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      |                | Annihilation        | :math:`e^+,e^- \to 2\gamma` | :cpp:class:`celeritas::EPlusGGInteractor`           |       0--100 TeV         |
+      +----------------+---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      | :math:`\gamma` | Photoelectric       |  Livermore                  | :cpp:class:`celeritas::LivermorePEInteractor`       |       0--100 TeV         |
+      |                +---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      |                | Compton scattering  |  Klein--Nishina             | :cpp:class:`celeritas::KleinNishinaInteractor`      |       0--100 TeV         |
+      |                +---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      |                | Pair production     |  Bethe--Heitler             | :cpp:class:`celeritas::BetheHeitlerInteractor`      |       0--100 TeV         |
+      |                +---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
+      |                | Rayleigh scattering |  Livermore                  | :cpp:class:`celeritas::RayleighInteractor`          |       0--100 TeV         |
+      +----------------+---------------------+-----------------------------+-----------------------------------------------------+--------------------------+
 
 .. only:: latex
 
@@ -92,33 +96,38 @@ and their corresponding Geant4 classes are documented in :ref:`celeritas_physics
         \begin{threeparttable}
         \begin{tabular}{| l | l | l | l | r | }
           \hline
-          \textbf{Particle}         & \textbf{Processes}              & \textbf{Models}      & \textbf{Celeritas Implementation}                          & \textbf{Applicability} \\
+          \textbf{Particle}         & \textbf{Processes}                  & \textbf{Models}      & \textbf{Celeritas Implementation}                           & \textbf{Applicability} \\
           \hline
-          \multirow{4}{*}{$e^-$}    & Ionisation                      & Møller               & \texttt{\scriptsize celeritas::MollerBhabhaInteractor}     & 0--100 TeV \\
+          \multirow{4}{*}{$e^-$}    & Ionisation                          & Møller               & \texttt{\scriptsize celeritas::MollerBhabhaInteractor}      & 0--100 TeV \\
                                     \cline{2-5}
-                                    & \multirow{2}{*}{Bremsstrahlung} & Seltzer--Berger      & \texttt{\scriptsize celeritas::SeltzerBergerInteractor}    & 0--1 GeV \\
-                                                                      \cline{3-5}
-                                    &                                 & Relativistic         & \texttt{\scriptsize celeritas::RelativisticBremInteractor} & 1 GeV -- 100 TeV \\
+                                    & \multirow{2}{*}{Bremsstrahlung}     & Seltzer--Berger      & \texttt{\scriptsize celeritas::SeltzerBergerInteractor}     & 0--1 GeV \\
+                                                                          \cline{3-5}
+                                    &                                     & Relativistic         & \texttt{\scriptsize celeritas::RelativisticBremInteractor}  & 1 GeV -- 100 TeV \\
                                     \cline{2-5}
-                                    & Coulomb scattering              & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter}            & 100 eV -- 100 TeV \\
+                                    & \multirow{2}{*}{Coulomb scattering} & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter}             & 100 eV -- 100 TeV \\
+                                                                          \cline{3-5}
+                                    &                                     & Coulomb              & \texttt{\scriptsize celeritas::CoulombScatteringInteractor} & 0--100 TeV \\
+                                    \cline{2-5}
           \hline
-          \multirow{5}{*}{$e^+$}    & Ionisation                      & Bhabha               & \texttt{\scriptsize celeritas::MollerBhabhaInteractor}     & 0--100 TeV \\
+          \multirow{5}{*}{$e^+$}    & Ionisation                          & Bhabha               & \texttt{\scriptsize celeritas::MollerBhabhaInteractor}      & 0--100 TeV \\
                                     \cline{2-5}
-                                    & \multirow{2}{*}{Bremsstrahlung} & Seltzer--Berger      & \texttt{\scriptsize celeritas::SeltzerBergerInteractor}    & 0--1 GeV \\
-                                                                      \cline{3-5}
-                                    &                                 & Relativistic         & \texttt{\scriptsize celeritas::RelativisticBremInteractor} & 1 GeV -- 100 TeV \\
+                                    & \multirow{2}{*}{Bremsstrahlung}     & Seltzer--Berger      & \texttt{\scriptsize celeritas::SeltzerBergerInteractor}     & 0--1 GeV \\
+                                                                          \cline{3-5}
+                                    &                                     & Relativistic         & \texttt{\scriptsize celeritas::RelativisticBremInteractor}  & 1 GeV -- 100 TeV \\
                                     \cline{2-5}
-                                    & Coulomb scattering              & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter}            & 100 eV -- 100 TeV \\
+                                    & \multirow{2}{*}{Coulomb scattering} & Urban                & \texttt{\scriptsize celeritas::UrbanMscScatter}             & 100 eV -- 100 TeV \\
+                                                                          \cline{3-5}
+                                    &                                     & Coulomb              & \texttt{\scriptsize celeritas::CoulombScatteringInteractor} & 0--100 TeV \\
                                     \cline{2-5}
-                                    & Annihilation                    & $e^+,e^-\to 2\gamma$ & \texttt{\scriptsize celeritas::EPlusGGInteractor}          & 0--100 TeV \\
+                                    & Annihilation                        & $e^+,e^-\to 2\gamma$ & \texttt{\scriptsize celeritas::EPlusGGInteractor}           & 0--100 TeV \\
           \hline
-          \multirow{4}{*}{$\gamma$} & Photoelectric                   & Livermore            & \texttt{\scriptsize celeritas::LivermorePEInteractor}      & 0--100 TeV \\
+          \multirow{4}{*}{$\gamma$} & Photoelectric                       & Livermore            & \texttt{\scriptsize celeritas::LivermorePEInteractor}       & 0--100 TeV \\
                                     \cline{2-5}
-                                    & Compton scattering              & Klein--Nishina       & \texttt{\scriptsize celeritas::KleinNishinaInteractor}     & 0--100 TeV \\
+                                    & Compton scattering                  & Klein--Nishina       & \texttt{\scriptsize celeritas::KleinNishinaInteractor}      & 0--100 TeV \\
                                     \cline{2-5}
-                                    & Pair production                 & Bethe--Heitler       & \texttt{\scriptsize celeritas::BetheHeitlerInteractor}     & 0--100 TeV \\
+                                    & Pair production                     & Bethe--Heitler       & \texttt{\scriptsize celeritas::BetheHeitlerInteractor}      & 0--100 TeV \\
                                     \cline{2-5}
-                                    & Rayleigh scattering             & Livermore            & \texttt{\scriptsize celeritas::RayleighInteractor}         & 0--100 TeV \\
+                                    & Rayleigh scattering                 & Livermore            & \texttt{\scriptsize celeritas::RayleighInteractor}          & 0--100 TeV \\
           \hline
         \end{tabular}
         \end{threeparttable}
@@ -136,6 +145,30 @@ The implemented physics models are meant to match the defaults constructed in
 * Celeritas imports tracking cutoffs and other parameters from
   ``G4EmParameters``, but some custom model cutoffs are not accessible to
   Celeritas.
+
+Coulomb scattering
+------------------
+
+Elastic scattering of charged particles can be simulated in three ways:
+
+* A detailed single scattering model in which each scattering interaction is
+  sampled
+* A multiple scattering approach which calculates global effects from many
+  collisions
+* A combination of the two
+
+Though it is the most accurate, the single Coulomb scattering model is too
+computationally expensive to be used in most applications as the number of
+collisions can be extremely large. Instead, a "condensed" simulation algorithm
+is typically used to determine the net energy loss, displacement, and direction
+change from many collisions after a given path length. The Urban model is the
+default multiple scattering model in Celeritas for all energies and in Geant4
+below 100 MeV. A third "mixed" simulation approach uses multiple scattering to
+simulate interactions with scattering angles below a given polar angle limit
+and single scattering for large angles. The Wentzel VI model, used together
+with the single Coulomb scattering model, is an implementation of the mixed
+simulation algorithm. It is the default model in Geant4 above 100 MeV and
+currently under development in Celeritas.
 
 Geometry
 ========

--- a/src/celeritas/ext/GeantPhysicsOptions.cc
+++ b/src/celeritas/ext/GeantPhysicsOptions.cc
@@ -35,10 +35,9 @@ char const* to_cstring(MscModelSelection value)
     static EnumStringMapper<MscModelSelection> const to_cstring_impl{
         "none",
         "urban",
-        "urban_extended",
-        "wentzel_vi",
-        "urban_wentzel",
-        "goudsmit_saunderson",
+        "wentzelvi",
+        "urban_wentzelvi",
+        "gs_wentzelvi",
     };
     return to_cstring_impl(value);
 }

--- a/src/celeritas/ext/GeantPhysicsOptions.cc
+++ b/src/celeritas/ext/GeantPhysicsOptions.cc
@@ -37,7 +37,6 @@ char const* to_cstring(MscModelSelection value)
         "urban",
         "wentzelvi",
         "urban_wentzelvi",
-        "gs_wentzelvi",
     };
     return to_cstring_impl(value);
 }

--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -30,8 +30,7 @@ enum class MscModelSelection
     none,
     urban,  //!< Urban for all energies
     wentzelvi,  //!< Wentzel VI for all energies
-    urban_wentzelvi,  //!< Urban below 100 MeV, Wentzel VI abpve
-    gs_wentzelvi,  //!< Goudsmit-Saunderson below 100 MeV, Wentzel VI above
+    urban_wentzelvi,  //!< Urban below 100 MeV, Wentzel VI above
     size_
 };
 

--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -28,11 +28,10 @@ enum class BremsModelSelection
 enum class MscModelSelection
 {
     none,
-    urban,
-    urban_extended,  //!< Use 100 TeV as upper bound instead of 100 MeV
-    wentzel_vi,
-    urban_wentzel,  //!< Urban for low-E, Wentzel_VI for high-E
-    goudsmit_saunderson,
+    urban,  //!< Urban for all energies
+    wentzelvi,  //!< Wentzel VI for all energies
+    urban_wentzelvi,  //!< Urban below 100 MeV, Wentzel VI abpve
+    gs_wentzelvi,  //!< Goudsmit-Saunderson below 100 MeV, Wentzel VI above
     size_
 };
 
@@ -82,7 +81,7 @@ struct GeantPhysicsOptions
     //! Enable bremsstrahlung and select a model
     BremsModelSelection brems{BremsModelSelection::all};
     //! Enable multiple coulomb scattering and select a model
-    MscModelSelection msc{MscModelSelection::urban_extended};
+    MscModelSelection msc{MscModelSelection::urban};
     //! Enable atomic relaxation and select a model
     RelaxationSelection relaxation{RelaxationSelection::none};
     //!@}

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -339,8 +339,7 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
 
     // Energy limit between MSC models when multiple models are used
     double msc_energy_limit = G4EmParameters::Instance()->MscEnergyLimit();
-    bool set_energy_limit = options_.msc == MMS::urban_wentzelvi
-                            || options_.msc == MMS::gs_wentzelvi;
+    bool set_energy_limit = options_.msc == MMS::urban_wentzelvi;
 
     if (options_.coulomb_scattering)
     {
@@ -405,20 +404,6 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
             }
             CELER_LOG(debug) << "Loaded multiple scattering with "
                                 "G4WentzelVIModel from "
-                             << model->LowEnergyLimit() << " MeV to "
-                             << model->HighEnergyLimit() << " MeV";
-
-            process->SetEmModel(model.release());
-        }
-
-        if (options_.msc == MMS::gs_wentzelvi)
-        {
-            // Multiple scattering: Goudsmit-Saunderson (low E)
-            auto model = std::make_unique<G4GoudsmitSaundersonMscModel>();
-            model->SetHighEnergyLimit(msc_energy_limit);
-
-            CELER_LOG(debug) << "Loaded low-energy multiple scattering with "
-                                "G4GoudsmitSaundersonMscModel from "
                              << model->LowEnergyLimit() << " MeV to "
                              << model->HighEnergyLimit() << " MeV";
 

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -107,11 +107,6 @@ GeantPhysicsList::GeantPhysicsList(Options const& options) : options_(options)
     em_parameters.SetLowestElectronEnergy(
         value_as<Options::MevEnergy>(options.lowest_electron_energy)
         * CLHEP::MeV);
-    if (options_.msc == MscModelSelection::urban_extended)
-    {
-        CELER_LOG(debug) << "Extended low-energy MSC limit to 100 TeV";
-        em_parameters.SetMscEnergyLimit(100 * CLHEP::TeV);
-    }
     em_parameters.SetApplyCuts(options.apply_cuts);
     this->SetDefaultCutValue(
         native_value_to<ClhepLen>(options.default_cutoff).value());
@@ -340,57 +335,82 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
         }
     }
 
+    using MMS = MscModelSelection;
+
+    // Energy limit between MSC models when multiple models are used
+    double msc_energy_limit = G4EmParameters::Instance()->MscEnergyLimit();
+    bool set_energy_limit = options_.msc == MMS::urban_wentzelvi
+                            || options_.msc == MMS::gs_wentzelvi;
+
     if (options_.coulomb_scattering)
     {
         // Coulomb scattering: G4eCoulombScatteringModel
-        double msc_energy_limit = G4EmParameters::Instance()->MscEnergyLimit();
+        if (options_.msc == MMS::urban)
+        {
+            CELER_LOG(warning) << "Urban multiple scattering is used for all "
+                                  "energies: disabling "
+                                  "G4eCoulombScatteringModel";
+        }
+        else
+        {
+            auto process = std::make_unique<G4CoulombScattering>();
+            auto model = std::make_unique<G4eCoulombScatteringModel>(
+                /* isCombined = */ options_.msc != MMS::none);
+            if (set_energy_limit)
+            {
+                process->SetMinKinEnergy(msc_energy_limit);
+                model->SetLowEnergyLimit(msc_energy_limit);
+                model->SetActivationLowEnergyLimit(msc_energy_limit);
+            }
+            process->SetEmModel(model.release());
+            physics_list->RegisterProcess(process.release(), p);
 
-        auto process = std::make_unique<G4CoulombScattering>();
-        auto model = std::make_unique<G4eCoulombScatteringModel>();
-        process->SetMinKinEnergy(msc_energy_limit);
-        model->SetLowEnergyLimit(msc_energy_limit);
-        model->SetActivationLowEnergyLimit(msc_energy_limit);
-        process->SetEmModel(model.release());
-        physics_list->RegisterProcess(process.release(), p);
+            CELER_LOG(debug) << "Loaded single Coulomb scattering with "
+                                "G4eCoulombScatteringModel";
+        }
     }
 
-    if (options_.msc != MscModelSelection::none)
+    if (options_.msc != MMS::none)
     {
-        // Multiple scattering: Urban (low E) and WentzelVI (high E) models
-        double msc_energy_limit = G4EmParameters::Instance()->MscEnergyLimit();
-
         auto process = std::make_unique<G4eMultipleScattering>();
 
-        if (options_.msc == MscModelSelection::urban
-            || options_.msc == MscModelSelection::urban_extended
-            || options_.msc == MscModelSelection::urban_wentzel)
+        if (options_.msc == MMS::urban || options_.msc == MMS::urban_wentzelvi)
         {
+            // Multiple scattering: Urban
             auto model = std::make_unique<G4UrbanMscModel>();
+            if (set_energy_limit)
+            {
+                model->SetHighEnergyLimit(msc_energy_limit);
+            }
+            process->SetEmModel(model.release());
+
+            CELER_LOG(debug) << "Loaded multiple scattering with "
+                                "G4UrbanMscModel";
+        }
+
+        if (options_.msc == MMS::wentzelvi
+            || options_.msc == MMS::urban_wentzelvi)
+        {
+            // Multiple scattering: WentzelVI
+            auto model = std::make_unique<G4WentzelVIModel>();
+            if (set_energy_limit)
+            {
+                model->SetLowEnergyLimit(msc_energy_limit);
+            }
+            process->SetEmModel(model.release());
+
+            CELER_LOG(debug) << "Loaded multiple scattering with "
+                                "G4WentzelVIModel";
+        }
+
+        if (options_.msc == MMS::gs_wentzelvi)
+        {
+            // Multiple scattering: Goudsmit-Saunderson (low E)
+            auto model = std::make_unique<G4GoudsmitSaundersonMscModel>();
             model->SetHighEnergyLimit(msc_energy_limit);
             process->SetEmModel(model.release());
 
             CELER_LOG(debug) << "Loaded low-energy multiple scattering with "
-                                "G4UrbanMscModel";
-        }
-
-        if (options_.msc == MscModelSelection::wentzel_vi
-            || options_.msc == MscModelSelection::urban_wentzel)
-        {
-            auto model = std::make_unique<G4WentzelVIModel>();
-            model->SetLowEnergyLimit(msc_energy_limit);
-            process->SetEmModel(model.release());
-
-            CELER_LOG(debug) << "Loaded high-energy multiple scattering with "
-                                "G4WentzelVIModel";
-        }
-
-        if (options_.msc == MscModelSelection::goudsmit_saunderson)
-        {
-            // Multiple scattering: Goudsmit-Saunderson (low E)
-            auto model = std::make_unique<G4GoudsmitSaundersonMscModel>();
-            process->SetEmModel(model.release());
-
-            CELER_LOG(debug) << "Loaded multiple scattering with "
                                 "G4GoudsmitSaundersonMscModel";
         }
 

--- a/src/celeritas/ext/detail/GeantPhysicsList.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsList.cc
@@ -347,9 +347,9 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
         // Coulomb scattering: G4eCoulombScatteringModel
         if (options_.msc == MMS::urban)
         {
-            CELER_LOG(warning) << "Urban multiple scattering is used for all "
-                                  "energies: disabling "
-                                  "G4eCoulombScatteringModel";
+            CELER_LOG(warning)
+                << "Urban multiple scattering is used for all "
+                   "energies: disabling G4eCoulombScatteringModel";
         }
         else
         {
@@ -362,11 +362,14 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
                 model->SetLowEnergyLimit(msc_energy_limit);
                 model->SetActivationLowEnergyLimit(msc_energy_limit);
             }
-            process->SetEmModel(model.release());
-            physics_list->RegisterProcess(process.release(), p);
 
             CELER_LOG(debug) << "Loaded single Coulomb scattering with "
-                                "G4eCoulombScatteringModel";
+                                "G4eCoulombScatteringModel from "
+                             << model->LowEnergyLimit() << " MeV to "
+                             << model->HighEnergyLimit() << " MeV";
+
+            process->SetEmModel(model.release());
+            physics_list->RegisterProcess(process.release(), p);
         }
     }
 
@@ -382,10 +385,13 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
             {
                 model->SetHighEnergyLimit(msc_energy_limit);
             }
-            process->SetEmModel(model.release());
 
             CELER_LOG(debug) << "Loaded multiple scattering with "
-                                "G4UrbanMscModel";
+                                "G4UrbanMscModel from "
+                             << model->LowEnergyLimit() << " MeV to "
+                             << model->HighEnergyLimit() << " MeV";
+
+            process->SetEmModel(model.release());
         }
 
         if (options_.msc == MMS::wentzelvi
@@ -397,10 +403,12 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
             {
                 model->SetLowEnergyLimit(msc_energy_limit);
             }
-            process->SetEmModel(model.release());
-
             CELER_LOG(debug) << "Loaded multiple scattering with "
-                                "G4WentzelVIModel";
+                                "G4WentzelVIModel from "
+                             << model->LowEnergyLimit() << " MeV to "
+                             << model->HighEnergyLimit() << " MeV";
+
+            process->SetEmModel(model.release());
         }
 
         if (options_.msc == MMS::gs_wentzelvi)
@@ -408,10 +416,13 @@ void GeantPhysicsList::add_e_processes(G4ParticleDefinition* p)
             // Multiple scattering: Goudsmit-Saunderson (low E)
             auto model = std::make_unique<G4GoudsmitSaundersonMscModel>();
             model->SetHighEnergyLimit(msc_energy_limit);
-            process->SetEmModel(model.release());
 
             CELER_LOG(debug) << "Loaded low-energy multiple scattering with "
-                                "G4GoudsmitSaundersonMscModel";
+                                "G4GoudsmitSaundersonMscModel from "
+                             << model->LowEnergyLimit() << " MeV to "
+                             << model->HighEnergyLimit() << " MeV";
+
+            process->SetEmModel(model.release());
         }
 
         physics_list->RegisterProcess(process.release(), p);

--- a/src/celeritas/ext/detail/GeantProcessImporter.cc
+++ b/src/celeritas/ext/detail/GeantProcessImporter.cc
@@ -382,6 +382,10 @@ GeantProcessImporter::operator()(G4ParticleDefinition const& particle,
     {
         if (G4VEmModel* model = process.GetModelByIndex(i))
         {
+            CELER_LOG(debug) << "Saving MSC model '" << model->GetName()
+                             << "' for particle " << particle.GetParticleName()
+                             << " (" << particle.GetPDGEncoding() << ")";
+
             ImportMscModel imm;
             imm.particle_pdg = primary_pdg;
             try
@@ -391,7 +395,7 @@ GeantProcessImporter::operator()(G4ParticleDefinition const& particle,
             }
             catch (celeritas::RuntimeError const&)
             {
-                CELER_LOG(warning) << "Encountered unknown process '"
+                CELER_LOG(warning) << "Encountered unknown MSC model '"
                                    << model->GetName() << "'";
                 imm.model_class = ImportModelClass::other;
             }

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -256,7 +256,7 @@ class FourSteelSlabsEmStandard : public GeantImporterTest
         {
             nlohmann::json out = opts;
             EXPECT_JSON_EQ(
-                R"json({"annihilation":true,"apply_cuts":false,"brems":"all","compton_scattering":true,"coulomb_scattering":false,"default_cutoff":0.1,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_conversion":true,"gamma_general":false,"integral_approach":true,"ionization":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban_extended","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"msc_step_algorithm":"safety","photoelectric":true,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json",
+                R"json({"annihilation":true,"apply_cuts":false,"brems":"all","compton_scattering":true,"coulomb_scattering":false,"default_cutoff":0.1,"eloss_fluctuation":true,"em_bins_per_decade":7,"gamma_conversion":true,"gamma_general":false,"integral_approach":true,"ionization":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"msc_step_algorithm":"safety","photoelectric":true,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json",
                 std::string(out.dump()));
         }
 #endif
@@ -295,7 +295,7 @@ class OneSteelSphere : public GeantImporterTest
     GeantPhysicsOptions build_geant_options() const override
     {
         GeantPhysicsOptions opts;
-        opts.msc = MscModelSelection::urban_wentzel;
+        opts.msc = MscModelSelection::urban_wentzelvi;
         opts.relaxation = RelaxationSelection::none;
         opts.verbose = false;
         return opts;
@@ -318,7 +318,7 @@ class OneSteelSphereGG : public OneSteelSphere
     {
         auto opts = OneSteelSphere::build_geant_options();
         opts.gamma_general = true;
-        opts.msc = MscModelSelection::urban_extended;
+        opts.msc = MscModelSelection::urban;
         return opts;
     }
 };


### PR DESCRIPTION
- Allow single Coulomb scattering without MSC over all energies or with Wentzel VI MSC with the same energy limits
- Update the MSC model selection to be more consistent with the configurations in the Geant4 physics constructors