### PR TITLE
Fix Spack CI

### DIFF
--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -8,7 +8,7 @@ concurrency:
   group: build-spack-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
 
 env:
-  SPACK_REF: 968ad02473b12f6305cc1fe19f2a0d706f171154 # develop-2024-03-10-70-g968ad02473
+  SPACK_REF: 5fe93fee1eec46a0750bd340198bffcb92ff9eec # v0.22.0
 
 jobs:
   spack:
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 255
           fetch-tags: true # to get version information
       - name: Setup Spack
-        uses: spack/setup-spack@5ab3c91bdefffffad9a7e45d1d156146afebb3a7
+        uses: spack/setup-spack@0ce61628ed8a32a5664cf01a0e0b5a4834a3b413 # 2024/03
         with:
           ref: ${{env.SPACK_REF}}
           buildcache: true
@@ -67,6 +67,8 @@ jobs:
           path: spack-src
       - name: Initialize spack environment
         run: |
+          # TODO: https://github.com/spack/spack/pull/43136
+          curl -LfsS https://github.com/spack/spack/pull/43136.patch | git -C spack-src apply -
           cp scripts/ci/spack.yaml .
           if [ "${{matrix.geometry}}" == "vecgeom" ]; then
             spack -e . add vecgeom

--- a/scripts/spack.yaml
+++ b/scripts/spack.yaml
@@ -2,7 +2,7 @@ spack:
   specs: 
     - cmake
     - doxygen
-    - "geant4@11 cxxstd=17"
+    - "geant4@11"
     - git
     - git-lfs
     - "googletest@1.10:"
@@ -16,9 +16,9 @@ spack:
     - py-sphinx
     - py-sphinxcontrib-bibtex
     - py-sphinxcontrib-mermaid
-    - "root@6.24: cxxstd=17"
+    - "root@6.28:"
     - "swig@4.1:"
-    - "vecgeom@1.2.4: +gdml cxxstd=17"
+    - "vecgeom@1.2.4: +gdml"
   view: true
   concretizer:
     unify: true
@@ -27,10 +27,6 @@ spack:
       # Note: ~gsl and ~math are removed because dd4hep requires them
       variants: ~aqua ~davix ~examples ~opengl ~x ~tbb
     all:
-      providers:
-        blas: [openblas]
-        lapack: [openblas]
-        mpi: [openmpi]
-      # Uncomment to enable cuda build or run within the spack env:
+      # Note: for CUDA support run this command in your environment:
       # spack config add packages:all:variants:"cxxstd=17 +cuda cuda_arch=<ARCH>"
-      variants: cxxstd=17 # +cuda cuda_arch=<ARCH>
+      variants: cxxstd=17


### PR DESCRIPTION
Replaces part of #1240. This is a quick update due to https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240514.2 which removed GCC 13, which our spack build implicitly depended on (via the libc++ installation apparently).