### PR TITLE
Add polyprism (G4Polyhedra)

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -521,34 +521,22 @@ auto SolidConverter::polyhedra(arg_type solid_base) -> result_type
         rmax[i] = scale_(params.Rmax[i]) * radius_factor;
     }
 
-    auto angle = make_wedge_azimuthal_poly(solid);
-
-    if (zs.size() == 2 && rmin[0] == rmin[1] && rmax[0] == rmax[1])
+    if (!any_positive(rmin))
     {
-        // A solid prism
-        double const hh = (zs[1] - zs[0]) / 2;
-        double const orientation
-            = std::fmod(params.numSide * angle.start().value(), real_type{1});
-
-        if (rmin[0] != 0.0 || angle)
-        {
-            CELER_NOT_IMPLEMENTED("prism solid");
-        }
-
-        result_type result = make_shape<Prism>(
-            solid, params.numSide, rmax[0], hh, orientation);
-
-        double dz = (zs[1] + zs[0]) / 2;
-        if (dz != 0)
-        {
-            result = std::make_shared<Transformed>(std::move(result),
-                                                   Translation{{0, 0, dz}});
-        }
-
-        return result;
+        // No interior shape
+        rmin.clear();
     }
 
-    CELER_NOT_IMPLEMENTED("polyhedra");
+    auto angle = make_wedge_azimuthal_poly(solid);
+    double const orientation
+        = std::fmod(params.numSide * angle.start().value(), real_type{1});
+
+    return PolyPrism::or_solid(
+        std::string{solid.GetName()},
+        PolySegments{std::move(rmin), std::move(rmax), std::move(zs)},
+        std::move(angle),
+        params.numSide,
+        orientation);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -732,6 +732,21 @@ void Prism::output(JsonPimpl* j) const
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Whether this encloses another sphere.
+ */
+bool Prism::encloses(Prism const& other) const
+{
+    if (num_sides_ != other.num_sides_ || orientation_ != other.orientation_)
+    {
+        CELER_NOT_IMPLEMENTED(
+            "hollow prism unless number of sides and orientation are "
+            "identical");
+    }
+    return apothem_ >= other.apothem() && hh_ >= other.halfheight();
+}
+
+//---------------------------------------------------------------------------//
 // SPHERE
 //---------------------------------------------------------------------------//
 /*!

--- a/src/orange/orangeinp/IntersectRegion.hh
+++ b/src/orange/orangeinp/IntersectRegion.hh
@@ -391,6 +391,11 @@ class Prism final : public IntersectRegionInterface
     // Output to JSON
     void output(JsonPimpl*) const final;
 
+    //// TEMPLATE INTERFACE ////
+
+    // Whether this encloses another cylinder
+    bool encloses(Prism const& other) const;
+
     //// ACCESSORS ////
 
     //! Number of sides

--- a/src/orange/orangeinp/ObjectIO.json.cc
+++ b/src/orange/orangeinp/ObjectIO.json.cc
@@ -128,6 +128,21 @@ void to_json(nlohmann::json& j, PolyCone const& obj)
     }
 }
 
+void to_json(nlohmann::json& j, PolyPrism const& obj)
+{
+    j = {
+        {"_type", "polyprism"},
+        SIO_ATTR_PAIR(obj, label),
+        SIO_ATTR_PAIR(obj, segments),
+        SIO_ATTR_PAIR(obj, num_sides),
+        SIO_ATTR_PAIR(obj, orientation),
+    };
+    if (auto sea = obj.enclosed_angle())
+    {
+        j["enclosed_angle"] = sea;
+    }
+}
+
 void to_json(nlohmann::json& j, ShapeBase const& obj)
 {
     j = {{"_type", "shape"},

--- a/src/orange/orangeinp/ObjectIO.json.hh
+++ b/src/orange/orangeinp/ObjectIO.json.hh
@@ -22,6 +22,7 @@ template<OperatorToken Op>
 class JoinObjects;
 class NegatedObject;
 class PolyCone;
+class PolyPrism;
 class ShapeBase;
 class SolidBase;
 class Transformed;
@@ -50,6 +51,7 @@ template<OperatorToken Op>
 void to_json(nlohmann::json& j, JoinObjects<Op> const&);
 void to_json(nlohmann::json& j, NegatedObject const&);
 void to_json(nlohmann::json& j, PolyCone const&);
+void to_json(nlohmann::json& j, PolyPrism const&);
 void to_json(nlohmann::json& j, ShapeBase const&);
 void to_json(nlohmann::json& j, SolidBase const&);
 void to_json(nlohmann::json& j, Transformed const&);

--- a/src/orange/orangeinp/PolySolid.cc
+++ b/src/orange/orangeinp/PolySolid.cc
@@ -142,7 +142,7 @@ PolySegments::PolySegments(VecReal&& inner, VecReal&& outer, VecReal&& z)
                    << "): expected " << z_.size());
 
     CELER_VALIDATE(is_monotonic_nondecreasing(make_span(z_)),
-                   << "axial grid has increasing grid points");
+                   << "axial grid has decreasing grid points");
     for (auto i : range(outer_.size()))
     {
         CELER_VALIDATE(outer_[i] >= 0, << "invalid outer radius " << outer_[i]);

--- a/src/orange/orangeinp/PolySolid.cc
+++ b/src/orange/orangeinp/PolySolid.cc
@@ -248,5 +248,116 @@ void PolyCone::output(JsonPimpl* j) const
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Return a polycone *or* a simplified version for only a single segment.
+ */
+auto PolyPrism::or_solid(std::string&& label,
+                         PolySegments&& segments,
+                         SolidEnclosedAngle&& enclosed,
+                         int num_sides,
+                         real_type orientation) -> SPConstObject
+{
+    if (segments.size() > 1)
+    {
+        // Can't be simplified: make a polycone
+        return std::make_shared<PolyPrism>(std::move(label),
+                                           std::move(segments),
+                                           std::move(enclosed),
+                                           num_sides,
+                                           orientation);
+    }
+
+    auto const [zlo, zhi] = segments.z(0);
+    real_type const hh = (zhi - zlo) / 2;
+
+    auto const [rlo, rhi] = segments.outer(0);
+    if (rlo != rhi)
+    {
+        CELER_NOT_IMPLEMENTED("prism with different lo/hi radii");
+    }
+
+    Prism outer{num_sides, rlo, hh, orientation};
+    std::optional<Prism> inner;
+    if (segments.has_exclusion())
+    {
+        auto const [rilo, rihi] = segments.inner(0);
+        if (rilo != rihi)
+        {
+            CELER_NOT_IMPLEMENTED("prism with different lo/hi radii");
+        }
+
+        inner = Prism{num_sides, rilo, hh, orientation};
+    }
+
+    auto result = PrismSolid::or_shape(std::move(label),
+                                       std::move(outer),
+                                       std::move(inner),
+                                       std::move(enclosed));
+    if (real_type dz = (zhi + zlo) / 2; dz != 0)
+    {
+        result = std::make_shared<Transformed>(std::move(result),
+                                               Translation{{0, 0, dz}});
+    }
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build with label, axial segments, optional restriction.
+ */
+PolyPrism::PolyPrism(std::string&& label,
+                     PolySegments&& segments,
+                     SolidEnclosedAngle&& enclosed,
+                     int num_sides,
+                     real_type orientation)
+    : PolySolidBase{std::move(label), std::move(segments), std::move(enclosed)}
+    , num_sides_{num_sides}
+    , orientation_{orientation}
+{
+    CELER_VALIDATE(num_sides_ >= 3,
+                   << "degenerate prism (num_sides = " << num_sides_ << ')');
+    CELER_VALIDATE(orientation_ >= 0 && orientation_ < 1,
+                   << "orientation is out of bounds [0, 1): " << orientation_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a volume from this shape.
+ */
+NodeId PolyPrism::build(VolumeBuilder& vb) const
+{
+    using Real2 = PolySegments::Real2;
+    auto build_prism = [this](Real2 const& radii, real_type hh) {
+        if (radii[0] != radii[1])
+        {
+            CELER_NOT_IMPLEMENTED("prism with different lo/hi radii");
+        }
+        return Prism{this->num_sides_, radii[0], hh, this->orientation_};
+    };
+
+    // Construct union of all cone segments
+    NodeId result = construct_segments(*this, build_prism, vb);
+
+    // TODO: after adding short-circuit logic to evaluator, add "acceleration"
+    // structures here, e.g. "inside(inner cylinder) || [inside(outer cylinder)
+    // && (original union)]"
+
+    // Construct azimuthal truncation if applicable
+    result = construct_enclosed_angle(*this, vb, result);
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write the shape to JSON.
+ */
+void PolyPrism::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace orangeinp
 }  // namespace celeritas

--- a/src/orange/orangeinp/PolySolid.hh
+++ b/src/orange/orangeinp/PolySolid.hh
@@ -25,7 +25,7 @@ namespace orangeinp
  *
  * Axial grid points must be nondecreasing. If "inner" points are specified,
  * they must be less than the outer points and more than zero. The inner list
- * is allowed to be empty indictating no inner (hollow) exclusion.
+ * is allowed to be empty indicating no inner (hollow) exclusion.
  */
 class PolySegments
 {

--- a/src/orange/orangeinp/PolySolid.hh
+++ b/src/orange/orangeinp/PolySolid.hh
@@ -171,5 +171,44 @@ class PolyCone final : public PolySolidBase
 };
 
 //---------------------------------------------------------------------------//
+/*!
+ * A series of stacked regular prisms or cone-y prisms.
+ */
+class PolyPrism final : public PolySolidBase
+{
+  public:
+    // Return a polyprism *or* a simplified version for only a single segment
+    static SPConstObject or_solid(std::string&& label,
+                                  PolySegments&& segments,
+                                  SolidEnclosedAngle&& enclosed,
+                                  int num_sides,
+                                  real_type orientation);
+
+    // Build with label, axial segments, parameters, optional restriction
+    PolyPrism(std::string&& label,
+              PolySegments&& segments,
+              SolidEnclosedAngle&& enclosed,
+              int num_sides,
+              real_type orientation);
+
+    // Construct a volume from this object
+    NodeId build(VolumeBuilder&) const final;
+
+    // Write the shape to JSON
+    void output(JsonPimpl*) const final;
+
+    //// ACCESSORS ////
+
+    //! Number of sides
+    int num_sides() const { return num_sides_; }
+    //! Rotation factor
+    real_type orientation() const { return orientation_; }
+
+  private:
+    int num_sides_;
+    real_type orientation_;
+};
+
+//---------------------------------------------------------------------------//
 }  // namespace orangeinp
 }  // namespace celeritas

--- a/src/orange/orangeinp/Solid.cc
+++ b/src/orange/orangeinp/Solid.cc
@@ -190,6 +190,7 @@ Solid<T>::Solid(std::string&& label, T&& interior, SolidEnclosedAngle&& enclosed
 
 template class Solid<Cone>;
 template class Solid<Cylinder>;
+template class Solid<Prism>;
 template class Solid<Sphere>;
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/Solid.hh
+++ b/src/orange/orangeinp/Solid.hh
@@ -184,6 +184,7 @@ Solid(std::string&&, T&&, Us...) -> Solid<T>;
 
 using ConeSolid = Solid<Cone>;
 using CylinderSolid = Solid<Cylinder>;
+using PrismSolid = Solid<Prism>;
 using SphereSolid = Solid<Sphere>;
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
The G4Polyhedra is a z-aligned stack of regular polygon shapes. Currently this doesn't support sloped sides, but we can if needed at some point. I haven't found any of our geometry models that have sloped sides.