### PR TITLE
Import and add nuclear binding energy to isotopes

### DIFF
--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -123,7 +123,7 @@ void print_isotopes(std::vector<ImportIsotope>& isotopes)
     cout << R"gfm(
 # Isotopes
 
-| Isotope ID | Name   | Atomic number | Atomic mass number | Nuclear mass (MeV) |
+| Isotope ID | Name   | Atomic number | Atomic mass number | Binding energy (MeV) | Nuclear mass (MeV) |
 | ---------- | ------ | ------------- | ------------------ | ------------------ |
 )gfm";
 
@@ -136,6 +136,7 @@ void print_isotopes(std::vector<ImportIsotope>& isotopes)
              << setw(6) << isotope.name << " | "
              << setw(13) << isotope.atomic_number << " | "
              << setw(18) << isotope.atomic_mass_number << " | "
+             << setw(20) << isotope.binding_energy << " | "
              << setw(18) << isotope.nuclear_mass << " |\n";
         // clang-format on
     }

--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -124,7 +124,7 @@ void print_isotopes(std::vector<ImportIsotope>& isotopes)
 # Isotopes
 
 | Isotope ID | Name   | Atomic number | Atomic mass number | Binding energy (MeV) | Nuclear mass (MeV) |
-| ---------- | ------ | ------------- | ------------------ | ------------------ |
+| ---------- | ------ | ------------- | ------------------ | -------------------- | ------------------ |
 )gfm";
 
     for (unsigned int isotope_id : range(isotopes.size()))

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -423,6 +423,8 @@ std::vector<ImportIsotope> import_isotopes()
         isotope.name = g4isotope.GetName();
         isotope.atomic_number = g4isotope.GetZ();
         isotope.atomic_mass_number = g4isotope.GetN();
+        isotope.binding_energy = G4NucleiProperties::GetBindingEnergy(
+            isotope.atomic_mass_number, isotope.atomic_number);
         isotope.nuclear_mass = G4NucleiProperties::GetNuclearMass(
             isotope.atomic_mass_number, isotope.atomic_number);
     }

--- a/src/celeritas/io/ImportElement.hh
+++ b/src/celeritas/io/ImportElement.hh
@@ -24,6 +24,7 @@ struct ImportIsotope
     std::string name;  //!< Isotope label
     int atomic_number;  //!< Atomic number Z
     int atomic_mass_number;  //!< Atomic number A
+    double binding_energy;  //!< Nuclear binding energy [MeV]
     double nuclear_mass;  //!< Sum of nucleons' mass + binding energy [MeV]
 };
 

--- a/src/celeritas/mat/IsotopeView.hh
+++ b/src/celeritas/mat/IsotopeView.hh
@@ -28,6 +28,7 @@ class IsotopeView
     //!@{
     //! \name Type aliases
     using MaterialParamsRef = NativeCRef<MaterialParamsData>;
+    using MevEnergy = units::MevEnergy;
     using MevMass = units::MevMass;
     using AtomicMassNumber = AtomicNumber;
     //!@}
@@ -45,6 +46,9 @@ class IsotopeView
 
     // Atomic number A
     CELER_FORCEINLINE_FUNCTION AtomicMassNumber atomic_mass_number() const;
+
+    // Nuclear binding energy
+    CELER_FORCEINLINE_FUNCTION MevEnergy binding_energy() const;
 
     // Sum of nucleons + binding energy
     CELER_FORCEINLINE_FUNCTION MevMass nuclear_mass() const;
@@ -100,6 +104,15 @@ CELER_FUNCTION IsotopeView::AtomicMassNumber
 IsotopeView::atomic_mass_number() const
 {
     return isotope_def().atomic_mass_number;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Nuclear binding energy.
+ */
+CELER_FUNCTION units::MevEnergy IsotopeView::binding_energy() const
+{
+    return isotope_def().binding_energy;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/mat/MaterialData.hh
+++ b/src/celeritas/mat/MaterialData.hh
@@ -33,6 +33,7 @@ struct IsotopeRecord
 
     AtomicNumber atomic_number;  //!< Atomic number Z
     AtomicMassNumber atomic_mass_number;  //!< Atomic number A
+    units::MevEnergy binding_energy;  //!< Nuclear binding energy
     units::MevMass nuclear_mass;  //!< Nucleons' mass + binding energy
 };
 

--- a/src/celeritas/mat/MaterialParams.cc
+++ b/src/celeritas/mat/MaterialParams.cc
@@ -24,6 +24,7 @@
 #include "celeritas/io/ImportData.hh"
 
 #include "MaterialData.hh"  // IWYU pragma: associated
+
 #include "detail/Utils.hh"
 
 namespace celeritas
@@ -75,6 +76,8 @@ MaterialParams::from_import(ImportData const& data)
         isotope_params.atomic_number = AtomicNumber{isotope.atomic_number};
         isotope_params.atomic_mass_number
             = AtomicNumber{isotope.atomic_mass_number};
+        isotope_params.binding_energy
+            = units::MevEnergy(isotope.binding_energy);
         // Convert from MeV (Geant4) to MeV/c^2 (Celeritas)
         isotope_params.nuclear_mass = units::MevMass(isotope.nuclear_mass);
 
@@ -369,6 +372,7 @@ void MaterialParams::append_isotope_def(IsotopeInput const& inp,
 {
     CELER_EXPECT(inp.atomic_number);
     CELER_EXPECT(inp.atomic_mass_number);
+    CELER_EXPECT(inp.binding_energy >= zero_quantity());
     CELER_EXPECT(inp.nuclear_mass > zero_quantity());
 
     IsotopeRecord result;
@@ -376,6 +380,7 @@ void MaterialParams::append_isotope_def(IsotopeInput const& inp,
     // Copy basic properties
     result.atomic_number = inp.atomic_number;
     result.atomic_mass_number = inp.atomic_mass_number;
+    result.binding_energy = inp.binding_energy;
     result.nuclear_mass = inp.nuclear_mass;
 
     // Add to host vector

--- a/src/celeritas/mat/MaterialParams.hh
+++ b/src/celeritas/mat/MaterialParams.hh
@@ -57,6 +57,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 
         AtomicNumber atomic_number;  //!< Atomic number Z
         AtomicMassNumber atomic_mass_number;  //!< Atomic number A
+        units::MevEnergy binding_energy;  //!< Nuclear binding energy
         units::MevMass nuclear_mass;  //!< Nucleons' mass + binding energy
         Label label;  //!< Isotope name
     };

--- a/src/celeritas/mat/MaterialParamsOutput.cc
+++ b/src/celeritas/mat/MaterialParamsOutput.cc
@@ -53,6 +53,7 @@ void MaterialParamsOutput::output(JsonPimpl* j) const
         auto label = json::array();
         auto atomic_number = json::array();
         auto atomic_mass_number = json::array();
+        auto binding_energy = json::array();
         auto nuclear_mass = json::array();
 
         for (auto id : range(IsotopeId{material_->num_isotopes()}))
@@ -62,14 +63,18 @@ void MaterialParamsOutput::output(JsonPimpl* j) const
             atomic_number.push_back(iso_view.atomic_number().unchecked_get());
             atomic_mass_number.push_back(
                 iso_view.atomic_mass_number().unchecked_get());
+            binding_energy.push_back(iso_view.binding_energy().value());
             nuclear_mass.push_back(iso_view.nuclear_mass().value());
         }
         obj["isotopes"] = {
             {"label", std::move(label)},
             {"atomic_number", std::move(atomic_number)},
             {"atomic_mass_number", std::move(atomic_mass_number)},
+            {"binding_energy", std::move(binding_energy)},
             {"nuclear_mass", std::move(nuclear_mass)},
         };
+        units["binding_energy"]
+            = accessor_unit_label<decltype(&IsotopeView::binding_energy)>();
         units["nuclear_mass"]
             = accessor_unit_label<decltype(&IsotopeView::nuclear_mass)>();
     }

--- a/test/celeritas/em/CoulombScattering.test.cc
+++ b/test/celeritas/em/CoulombScattering.test.cc
@@ -57,9 +57,16 @@ class CoulombScatteringTest : public InteractorHostTestBase
 
         // Set up shared material data
         MaterialParams::Input mat_inp;
-        mat_inp.isotopes
-            = {{AtomicNumber{29}, AtomicNumber{63}, MevMass{58618.5}, "63Cu"},
-               {AtomicNumber{29}, AtomicNumber{65}, MevMass{60479.8}, "65Cu"}};
+        mat_inp.isotopes = {{AtomicNumber{29},
+                             AtomicNumber{63},
+                             MevEnergy{551.384},
+                             MevMass{58618.5},
+                             "63Cu"},
+                            {AtomicNumber{29},
+                             AtomicNumber{65},
+                             MevEnergy{569.211},
+                             MevMass{60479.8},
+                             "65Cu"}};
         mat_inp.elements = {{AtomicNumber{29},
                              AmuMass{63.546},
                              {{IsotopeId{0}, 0.692}, {IsotopeId{1}, 0.308}},

--- a/test/celeritas/mat/Material.test.cc
+++ b/test/celeritas/mat/Material.test.cc
@@ -287,23 +287,28 @@ TEST_F(MaterialTest, isotope_view)
 {
     std::vector<int> atomic_numbers;
     std::vector<int> atomic_mass_numbers;
+    std::vector<real_type> binding_energies;
     std::vector<real_type> nuclear_masses;
     for (auto i : range(params->num_isotopes()))
     {
         auto iso_view = params->get(IsotopeId{i});
         atomic_numbers.push_back(iso_view.atomic_number().get());
         atomic_mass_numbers.push_back(iso_view.atomic_mass_number().get());
+        binding_energies.push_back(iso_view.binding_energy().value());
         nuclear_masses.push_back(iso_view.nuclear_mass().value());
     }
 
     static int const expected_atomic_numbers[] = {1, 1, 13, 13, 11, 53, 53, 53};
     static int const expected_atomic_mass_numbers[]
         = {1, 2, 27, 28, 23, 125, 126, 127};
+    static real_type const expected_binding_energies[]
+        = {0, 2.22457, 224.952, 232.677, 186.564, 1056.29, 1063.43, 1072.58};
     static real_type const expected_nuclear_masses[] = {
         938.272, 1875.61, 25126.5, 26058.3, 21409.2, 116321, 117253, 118184};
 
     EXPECT_VEC_EQ(expected_atomic_numbers, atomic_numbers);
     EXPECT_VEC_EQ(expected_atomic_mass_numbers, atomic_mass_numbers);
+    EXPECT_VEC_SOFT_EQ(expected_binding_energies, binding_energies);
     EXPECT_VEC_SOFT_EQ(expected_nuclear_masses, nuclear_masses);
 }
 
@@ -315,7 +320,7 @@ TEST_F(MaterialTest, output)
     if (CELERITAS_USE_JSON && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
         EXPECT_JSON_EQ(
-            R"json({"_category":"internal","_label":"material","_units":{"atomic_mass":"amu","mean_excitation_energy":"MeV","nuclear_mass":"MeV/c^2"},"elements":{"atomic_mass":[1.008,26.9815385,22.98976928,126.90447],"atomic_number":[1,13,11,53],"coulomb_correction":[6.400821803338426e-05,0.010734632775699565,0.00770256745342534,0.15954439947436763],"isotope_fractions":[[0.9,0.1],[0.7,0.3],[1.0],[0.05,0.15,0.8]],"isotope_ids":[[0,1],[2,3],[4],[5,6,7]],"label":["H","Al","Na","I"],"mass_radiation_coeff":[0.0158611264432063,0.04164723292591279,0.03605392839455309,0.11791841505608874]},"isotopes":{"atomic_mass_number":[1,2,27,28,23,125,126,127],"atomic_number":[1,1,13,13,11,53,53,53],"label":["1H","2H","27Al","28Al","23Na","125I","126I","127I"],"nuclear_mass":[938.272,1875.61,25126.5,26058.3,21409.2,116321.0,117253.0,118184.0]},"materials":{"density":[3.6700020622594716,0.0,0.00017976000000000003,0.00017943386624303615],"electron_density":[9.4365282069664e+23,0.0,1.073948435904467e+20,1.072e+20],"element_frac":[[0.5,0.5],[],[1.0],[1.0]],"element_id":[[2,3],[],[0],[0]],"label":["NaI","hard vacuum","H2@1","H2@2"],"matter_state":["solid","unspecified","gas","gas"],"mean_excitation_energy":[0.00040000760709482647,0.0,1.9199999999999986e-05,1.9199999999999986e-05],"number_density":[2.948915064677e+22,0.0,1.073948435904467e+20,1.072e+20],"radiation_length":[3.5393292693170424,null,350729.99844063615,351367.4750467326],"temperature":[293.0,0.0,100.0,110.0],"zeff":[32.0,0.0,1.0,1.0]}})json",
+            R"json({"_category":"internal","_label":"material","_units":{"atomic_mass":"amu","mean_excitation_energy":"MeV","binding_energy":"MeV","nuclear_mass":"MeV/c^2"},"elements":{"atomic_mass":[1.008,26.9815385,22.98976928,126.90447],"atomic_number":[1,13,11,53],"coulomb_correction":[6.400821803338426e-05,0.010734632775699565,0.00770256745342534,0.15954439947436763],"isotope_fractions":[[0.9,0.1],[0.7,0.3],[1.0],[0.05,0.15,0.8]],"isotope_ids":[[0,1],[2,3],[4],[5,6,7]],"label":["H","Al","Na","I"],"mass_radiation_coeff":[0.0158611264432063,0.04164723292591279,0.03605392839455309,0.11791841505608874]},"isotopes":{"atomic_mass_number":[1,2,27,28,23,125,126,127],"atomic_number":[1,1,13,13,11,53,53,53],"binding_energy":[0.0,2.22457,224.952,232.677,186.564,1056.29,1063.43,1072.58],"label":["1H","2H","27Al","28Al","23Na","125I","126I","127I"],"nuclear_mass":[938.272,1875.61,25126.5,26058.3,21409.2,116321.0,117253.0,118184.0]},"materials":{"density":[3.6700020622594716,0.0,0.00017976000000000003,0.00017943386624303615],"electron_density":[9.4365282069664e+23,0.0,1.073948435904467e+20,1.072e+20],"element_frac":[[0.5,0.5],[],[1.0],[1.0]],"element_id":[[2,3],[],[0],[0]],"label":["NaI","hard vacuum","H2@1","H2@2"],"matter_state":["solid","unspecified","gas","gas"],"mean_excitation_energy":[0.00040000760709482647,0.0,1.9199999999999986e-05,1.9199999999999986e-05],"number_density":[2.948915064677e+22,0.0,1.073948435904467e+20,1.072e+20],"radiation_length":[3.5393292693170424,null,350729.99844063615,351367.4750467326],"temperature":[293.0,0.0,100.0,110.0],"zeff":[32.0,0.0,1.0,1.0]}})json",
             to_string(out));
     }
 }

--- a/test/celeritas/mat/MaterialTestBase.hh
+++ b/test/celeritas/mat/MaterialTestBase.hh
@@ -27,19 +27,50 @@ class MaterialTestBase
         MaterialParams::Input inp;
 
         // Using nuclear masses provided by Geant4 11.0.3
-        inp.isotopes = {
-            // H
-            {AtomicNumber{1}, AtomicNumber{1}, MevMass{938.272}, "1H"},
-            {AtomicNumber{1}, AtomicNumber{2}, MevMass{1875.61}, "2H"},
-            // Al
-            {AtomicNumber{13}, AtomicNumber{27}, MevMass{25126.5}, "27Al"},
-            {AtomicNumber{13}, AtomicNumber{28}, MevMass{26058.3}, "28Al"},
-            // Na
-            {AtomicNumber{11}, AtomicNumber{23}, MevMass{21409.2}, "23Na"},
-            // I
-            {AtomicNumber{53}, AtomicNumber{125}, MevMass{116321}, "125I"},
-            {AtomicNumber{53}, AtomicNumber{126}, MevMass{117253}, "126I"},
-            {AtomicNumber{53}, AtomicNumber{127}, MevMass{118184}, "127I"}};
+        inp.isotopes = {// H
+                        {AtomicNumber{1},
+                         AtomicNumber{1},
+                         MevEnergy{0},
+                         MevMass{938.272},
+                         "1H"},
+                        {AtomicNumber{1},
+                         AtomicNumber{2},
+                         MevEnergy{2.22457},
+                         MevMass{1875.61},
+                         "2H"},
+                        // Al
+                        {AtomicNumber{13},
+                         AtomicNumber{27},
+                         MevEnergy{224.952},
+                         MevMass{25126.5},
+                         "27Al"},
+                        {AtomicNumber{13},
+                         AtomicNumber{28},
+                         MevEnergy{232.677},
+                         MevMass{26058.3},
+                         "28Al"},
+                        // Na
+                        {AtomicNumber{11},
+                         AtomicNumber{23},
+                         MevEnergy{186.564},
+                         MevMass{21409.2},
+                         "23Na"},
+                        // I
+                        {AtomicNumber{53},
+                         AtomicNumber{125},
+                         MevEnergy{1056.29},
+                         MevMass{116321},
+                         "125I"},
+                        {AtomicNumber{53},
+                         AtomicNumber{126},
+                         MevEnergy{1063.43},
+                         MevMass{117253},
+                         "126I"},
+                        {AtomicNumber{53},
+                         AtomicNumber{127},
+                         MevEnergy{1072.58},
+                         MevMass{118184},
+                         "127I"}};
 
         inp.elements = {
             // H

--- a/test/celeritas/neutron/NeutronTestBase.cc
+++ b/test/celeritas/neutron/NeutronTestBase.cc
@@ -38,11 +38,26 @@ NeutronTestBase::NeutronTestBase()
     MaterialParams::Input mat_inp;
 
     // Isotopes
-    mat_inp.isotopes = {
-        {AtomicNumber{2}, AtomicNumber{3}, units::MevMass{3016.0}, "3He"},
-        {AtomicNumber{2}, AtomicNumber{4}, units::MevMass{4002.6}, "4He"},
-        {AtomicNumber{29}, AtomicNumber{63}, units::MevMass{58618.5}, "63Cu"},
-        {AtomicNumber{29}, AtomicNumber{65}, units::MevMass{60479.8}, "65Cu"}};
+    mat_inp.isotopes = {{AtomicNumber{2},
+                         AtomicNumber{3},
+                         units::MevEnergy{7.71804},
+                         units::MevMass{3016.0},
+                         "3He"},
+                        {AtomicNumber{2},
+                         AtomicNumber{4},
+                         units::MevEnergy{28.2957},
+                         units::MevMass{4002.6},
+                         "4He"},
+                        {AtomicNumber{29},
+                         AtomicNumber{63},
+                         units::MevEnergy{551.384},
+                         units::MevMass{58618.5},
+                         "63Cu"},
+                        {AtomicNumber{29},
+                         AtomicNumber{65},
+                         units::MevEnergy{569.211},
+                         units::MevMass{60479.8},
+                         "65Cu"}};
 
     // Elements
     mat_inp.elements = {{AtomicNumber{2},


### PR DESCRIPTION
# Import the nuclear binding energy of isotopes from Geant4
The nuclear binding energy is needed for hadronic models and is added to MaterialData and IsotopeView
based on Geant4 [G4NucleiProperties](https://geant4.kek.jp/lxr/source/particles/management/src/G4NucleiProperties.cc#L229)
- Add the nuclear binding energy in the Isotope definition and import it from Geant4 
- Update IsotopeView and tests associated with the addition


