### PR TITLE
Refactor CMake test name generation to be based on path

### DIFF
--- a/cmake/CeleritasAddTest.cmake
+++ b/cmake/CeleritasAddTest.cmake
@@ -221,8 +221,12 @@ function(celeritas_setup_tests)
     ${ARGN}
   )
 
+  # Set the directory relative to the "test" directory
+  file(RELATIVE_PATH PARSE_DIR
+    "${PROJECT_SOURCE_DIR}/test" "${CMAKE_CURRENT_SOURCE_DIR}")
+
   # Set special variables
-  foreach(_var LINK_LIBRARIES ADD_DEPENDENCIES PREFIX)
+  foreach(_var LINK_LIBRARIES ADD_DEPENDENCIES PREFIX DIR)
     set(CELERITASTEST_${_var} "${PARSE_${_var}}" PARENT_SCOPE)
   endforeach()
 
@@ -278,14 +282,27 @@ function(celeritas_add_test SOURCE_FILE)
 
   # Add prefix to test name and possibly dependent name
   get_filename_component(_BASENAME "${SOURCE_FILE}" NAME_WE)
+  get_filename_component(_BASEDIR "${SOURCE_FILE}" DIRECTORY)
+  if(_BASEDIR)
+    set(_BASENAME "${_BASEDIR}/${_BASENAME}")
+  endif()
+  set(_TARGET "${_BASENAME}")
   if(CELERITASTEST_PREFIX)
-    set(_TARGET "${CELERITASTEST_PREFIX}/${_BASENAME}")
-    string(REGEX REPLACE "[^a-zA-Z0-9_]+" "_" _TARGET "${_TARGET}")
+    set(_TARGET "${CELERITASTEST_PREFIX}/${_TARGET}")
     if(PARSE_DEPTEST)
       set(PARSE_DEPTEST "${CELERITASTEST_PREFIX}/${PARSE_DEPTEST}")
     endif()
     set(_PREFIX "${CELERITASTEST_PREFIX}/")
   endif()
+  set(_OUTPUT_NAME "${_TARGET}")
+  if(CELERITASTEST_DIR)
+    set(_TARGET "${CELERITASTEST_DIR}/${_TARGET}")
+    if(PARSE_DEPTEST)
+      set(PARSE_DEPTEST "${CELERITASTEST_DIR}/${PARSE_DEPTEST}")
+    endif()
+    set(_PREFIX "${CELERITASTEST_DIR}/${CELERITASTEST_PREFIX}")
+  endif()
+
   if(PARSE_SUFFIX)
     set(_TARGET "${_TARGET}_${PARSE_SUFFIX}")
     if(PARSE_DEPTEST)
@@ -293,6 +310,9 @@ function(celeritas_add_test SOURCE_FILE)
     endif()
     set(_SUFFIX "/${PARSE_SUFFIX}")
   endif()
+
+  string(REGEX REPLACE "[^a-zA-Z0-9_]+" "_" _TARGET "${_TARGET}")
+  string(REGEX REPLACE "[^a-zA-Z0-9_]+" "_" _OUTPUT_NAME "${_OUTPUT_NAME}")
 
   if(_CELERITASTEST_IS_PYTHON)
     get_filename_component(SOURCE_FILE "${SOURCE_FILE}" ABSOLUTE)
@@ -315,6 +335,10 @@ function(celeritas_add_test SOURCE_FILE)
 
     # Create an executable and link libraries against it
     add_executable(${_TARGET} "${SOURCE_FILE}" ${PARSE_SOURCES})
+
+    set_property(TARGET ${_TARGET}
+      PROPERTY OUTPUT_NAME "${_OUTPUT_NAME}"
+    )
 
     # Note: for static linking the library order is relevant.
     celeritas_target_link_libraries(${_TARGET}

--- a/test/accel/CMakeLists.txt
+++ b/test/accel/CMakeLists.txt
@@ -15,7 +15,7 @@ celeritas_target_link_libraries(testcel_accel
     ${Geant4_LIBRARIES}
 )
 
-celeritas_setup_tests(SERIAL PREFIX accel
+celeritas_setup_tests(SERIAL
   LINK_LIBRARIES
     testcel_accel testcel_core Celeritas::accel
 )

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -104,7 +104,7 @@ celeritas_target_link_libraries(testcel_celeritas
 # SETUP
 #-----------------------------------------------------------------------------#
 
-celeritas_setup_tests(SERIAL PREFIX celeritas
+celeritas_setup_tests(SERIAL
   LINK_LIBRARIES testcel_celeritas testcel_core
 )
 
@@ -118,7 +118,6 @@ celeritas_add_test(Units.test.cc)
 
 #-----------------------------------------------------------------------------#
 # EM
-set(CELERITASTEST_PREFIX celeritas/em)
 celeritas_add_test(em/Fluctuation.test.cc ${_fixme_single})
 celeritas_add_test(em/TsaiUrbanDistribution.test.cc ${_needs_double})
 
@@ -140,7 +139,6 @@ celeritas_add_test(em/UrbanMsc.test.cc ${_needs_root}
 
 #-----------------------------------------------------------------------------#
 # External
-set(CELERITASTEST_PREFIX celeritas/ext)
 
 celeritas_add_test(ext/GeantImporter.test.cc
   ${_needs_geant4}
@@ -158,7 +156,6 @@ celeritas_add_test(ext/RootImporter.test.cc ${_needs_root})
 
 #-----------------------------------------------------------------------------#
 # Field
-set(CELERITASTEST_PREFIX celeritas/field)
 
 celeritas_add_test(field/Fields.test.cc)
 celeritas_add_test(field/Steppers.test.cc ${_fixme_cgs})
@@ -173,7 +170,6 @@ celeritas_add_test(field/MagFieldEquation.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Geo
-set(CELERITASTEST_PREFIX celeritas/geo)
 
 set(_geo_args GPU ${_needs_geo} ${_needs_double} ${_fixme_cgs}
   LINK_LIBRARIES ${_all_geo_libs}
@@ -194,7 +190,6 @@ celeritas_add_test(geo/GeoMaterial.test.cc
 
 #-----------------------------------------------------------------------------#
 # Global
-set(CELERITASTEST_PREFIX celeritas/global)
 celeritas_add_test(global/ActionRegistry.test.cc)
 
 if(CELERITAS_USE_Geant4 AND CELERITAS_REAL_TYPE STREQUAL "double")
@@ -256,7 +251,6 @@ celeritas_add_test(global/Stepper.test.cc
 
 #-----------------------------------------------------------------------------#
 # Grid
-set(CELERITASTEST_PREFIX celeritas/grid)
 celeritas_add_test(grid/GenericCalculator.test.cc)
 celeritas_add_test(grid/GenericGridBuilder.test.cc)
 celeritas_add_test(grid/GenericGridInserter.test.cc)
@@ -270,7 +264,6 @@ celeritas_add_test(grid/XsCalculator.test.cc)
 
 #-----------------------------------------------------------------------------#
 # IO
-set(CELERITASTEST_PREFIX celeritas/io)
 celeritas_add_test(io/EventIO.test.cc ${_needs_hepmc}
   LINK_LIBRARIES ${HepMC3_LIBRARIES})
 celeritas_add_test(io/ImportUnits.test.cc)
@@ -279,27 +272,23 @@ celeritas_add_test(io/SeltzerBergerReader.test.cc ${_needs_geant4})
 
 #-----------------------------------------------------------------------------#
 # Optical
-set(CELERITASTEST_PREFIX celeritas/optical)
 celeritas_add_test(optical/Cerenkov.test.cc)
 celeritas_add_test(optical/OpticalCollector.test.cc ${_needs_geant4})
 celeritas_add_test(optical/Scintillation.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Mat
-set(CELERITASTEST_PREFIX celeritas/mat)
 celeritas_add_test(mat/IsotopeSelector.test.cc)
 celeritas_add_test(mat/ElementSelector.test.cc)
 celeritas_add_device_test(mat/Material)
 
 #-----------------------------------------------------------------------------#
 # Neutron
-set(CELERITASTEST_PREFIX celeritas/neutron)
 celeritas_add_test(neutron/NeutronElastic.test.cc ${_needs_double})
 celeritas_add_test(neutron/NeutronInelastic.test.cc ${_needs_double})
 
 #-----------------------------------------------------------------------------#
 # Phys
-set(CELERITASTEST_PREFIX celeritas/phys)
 celeritas_add_test(phys/CutoffParams.test.cc)
 celeritas_add_device_test(phys/Particle)
 celeritas_add_device_test(phys/Physics)
@@ -311,7 +300,6 @@ celeritas_add_test(phys/ProcessBuilder.test.cc ${_needs_root}
 
 #-----------------------------------------------------------------------------#
 # Random
-set(CELERITASTEST_PREFIX celeritas/random)
 
 celeritas_add_device_test(random/RngEngine)
 celeritas_add_test(random/Selector.test.cc)
@@ -339,7 +327,6 @@ endif()
 
 #-----------------------------------------------------------------------------#
 # Track
-set(CELERITASTEST_PREFIX celeritas/track)
 celeritas_add_test(track/Sim.test.cc ${_needs_geant4})
 celeritas_add_test(track/TrackSort.test.cc GPU ${_needs_geant4} ${_needs_geo})
 
@@ -358,7 +345,6 @@ celeritas_add_test(track/TrackInit.test.cc
 
 #-----------------------------------------------------------------------------#
 # User
-set(CELERITASTEST_PREFIX celeritas/user)
 
 if(CELERITAS_USE_Geant4)
   set(_diagnostic_filter

--- a/test/corecel/CMakeLists.txt
+++ b/test/corecel/CMakeLists.txt
@@ -11,7 +11,7 @@ celeritas_target_link_libraries(testcel_core
   PRIVATE testcel_harness Celeritas::corecel
 )
 
-celeritas_setup_tests(SERIAL PREFIX corecel
+celeritas_setup_tests(SERIAL
   LINK_LIBRARIES testcel_core Celeritas::corecel
 )
 
@@ -24,7 +24,6 @@ celeritas_add_test(Assert.test.cc
 celeritas_add_test(OpaqueId.test.cc)
 
 # Cont
-set(CELERITASTEST_PREFIX corecel/cont)
 celeritas_add_test(cont/Array.test.cc)
 celeritas_add_test(cont/InitializedValue.test.cc)
 celeritas_add_test(cont/Span.test.cc)
@@ -33,7 +32,6 @@ celeritas_add_test(cont/VariantUtils.test.cc)
 celeritas_add_device_test(cont/Range)
 
 # Data
-set(CELERITASTEST_PREFIX corecel/data)
 celeritas_add_device_test(data/Collection)
 celeritas_add_test(data/Copier.test.cc GPU)
 celeritas_add_test(data/DeviceAllocation.test.cc GPU)
@@ -44,7 +42,6 @@ celeritas_add_test(data/HyperslabIndexer.test.cc)
 celeritas_add_device_test(data/StackAllocator)
 
 # Grid
-set(CELERITASTEST_PREFIX corecel/grid)
 celeritas_add_test(grid/Interpolator.test.cc)
 celeritas_add_test(grid/NonuniformGrid.test.cc)
 celeritas_add_test(grid/TwodGridCalculator.test.cc)
@@ -52,7 +49,6 @@ celeritas_add_test(grid/UniformGrid.test.cc)
 celeritas_add_test(grid/VectorUtils.test.cc)
 
 # IO
-set(CELERITASTEST_PREFIX corecel/io)
 celeritas_add_test(io/EnumStringMapper.test.cc)
 celeritas_add_test(io/Label.test.cc)
 celeritas_add_test(io/Join.test.cc)
@@ -64,7 +60,6 @@ celeritas_add_test(io/StringEnumMapper.test.cc)
 celeritas_add_test(io/StringUtils.test.cc)
 
 # Math
-set(CELERITASTEST_PREFIX corecel/math)
 celeritas_add_test(math/Algorithms.test.cc)
 celeritas_add_test(math/ArrayOperators.test.cc)
 celeritas_add_test(math/ArrayUtils.test.cc)
@@ -75,7 +70,6 @@ celeritas_add_test(math/Quantity.test.cc
 celeritas_add_test(math/SoftEqual.test.cc)
 
 # Sys
-set(CELERITASTEST_PREFIX corecel/sys)
 celeritas_add_test(sys/Environment.test.cc
   ENVIRONMENT "ENVTEST_ONE=1;ENVTEST_ZERO=0;ENVTEST_EMPTY="
   LINK_LIBRARIES ${nlohmann_json_LIBRARIES}

--- a/test/geocel/CMakeLists.txt
+++ b/test/geocel/CMakeLists.txt
@@ -52,7 +52,6 @@ celeritas_target_link_libraries(testcel_geocel
 #-----------------------------------------------------------------------------#
 
 celeritas_setup_tests(SERIAL
-  PREFIX geocel
   LINK_LIBRARIES testcel_geocel testcel_core Celeritas::geocel
 )
 
@@ -117,7 +116,6 @@ endif()
 #-----------------------------------------------------------------------------#
 # Rasterization
 
-set(CELERITASTEST_PREFIX geocel/rasterize)
 
 celeritas_add_test(rasterize/Image.test.cc)
 celeritas_add_test(rasterize/Raytracer.test.cc)

--- a/test/orange/CMakeLists.txt
+++ b/test/orange/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 # SETUP
 #-----------------------------------------------------------------------------#
 
-celeritas_setup_tests(SERIAL PREFIX orange
+celeritas_setup_tests(SERIAL
   LINK_LIBRARIES testcel_orange Celeritas::orange
 )
 
@@ -63,14 +63,12 @@ celeritas_add_device_test(OrangeShift ${_needs_json})
 celeritas_add_test(detail/UniverseIndexer.test.cc)
 
 # Bounding interval hierarchy
-set(CELERITASTEST_PREFIX orange/bih)
 celeritas_add_test(detail/BIHBuilder.test.cc)
 celeritas_add_test(detail/BIHTraverser.test.cc)
 celeritas_add_test(detail/BIHUtils.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Input construction
-set(CELERITASTEST_PREFIX orange/orangeinp)
 celeritas_add_test(orangeinp/CsgObject.test.cc)
 celeritas_add_test(orangeinp/CsgTree.test.cc)
 celeritas_add_test(orangeinp/CsgTreeUtils.test.cc)
@@ -90,7 +88,6 @@ celeritas_add_test(orangeinp/detail/TransformInserter.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Transforms
-set(CELERITASTEST_PREFIX orange/transform)
 celeritas_add_test(transform/SignedPermutation.test.cc)
 celeritas_add_test(transform/TransformSimplifier.test.cc)
 celeritas_add_test(transform/Transformation.test.cc)
@@ -99,7 +96,6 @@ celeritas_add_test(transform/VariantTransform.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Surfaces
-set(CELERITASTEST_PREFIX orange/surf)
 celeritas_add_test(surf/ConeAligned.test.cc)
 celeritas_add_test(surf/CylAligned.test.cc)
 celeritas_add_test(surf/CylCentered.test.cc)
@@ -125,7 +121,6 @@ celeritas_add_test(surf/detail/SurfaceTransformer.test.cc)
 
 #-----------------------------------------------------------------------------#
 # Universe
-set(CELERITASTEST_PREFIX orange/univ)
 celeritas_add_test(univ/VolumeView.test.cc)
 celeritas_add_test(univ/RectArrayTracker.test.cc ${_needs_json})
 celeritas_add_device_test(univ/SimpleUnitTracker)
@@ -142,8 +137,7 @@ celeritas_add_test(univ/detail/SenseCalculator.test.cc)
 #-----------------------------------------------------------------------------#
 # Geant4 construction
 if(_use_g4org)
-  set(CELERITASTEST_PREFIX orange/g4org)
-
+  
   celeritas_add_test(g4org/Converter.test.cc)
   celeritas_add_test(g4org/SolidConverter.test.cc
     LINK_LIBRARIES ${_g4_geo_libs})


### PR DESCRIPTION
Very late follow-on to #1105 (and #1099 before that). This removes the duplicate path names in generated tests, and it ensures that the CTest name matches exactly the test path.