### PR TITLE
Fix trapezoid construction

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -640,13 +640,13 @@ auto SolidConverter::trap(arg_type solid_base) -> result_type
     lo.hy = scale_(solid.GetYHalfLength1());
     lo.hx_lo = scale_(solid.GetXHalfLength1());
     lo.hx_hi = scale_(solid.GetXHalfLength2());
-    lo.tan_alpha = alpha_1;
+    lo.alpha = native_value_to<Turn>(alpha_1);
 
     GenTrap::TrapFace hi;
     hi.hy = scale_(solid.GetYHalfLength2());
     hi.hx_lo = scale_(solid.GetXHalfLength3());
     hi.hx_hi = scale_(solid.GetXHalfLength4());
-    hi.tan_alpha = alpha_2;
+    hi.alpha = native_value_to<Turn>(alpha_2);
 
     return make_shape<GenTrap>(solid,
                                GenTrap::from_trap(hz, theta, phi, lo, hi));

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -383,12 +383,14 @@ GenTrap GenTrap::from_trap(
                        << "nonpositive upper x half-edge: " << face.hx_hi);
         CELER_VALIDATE(face.hy > 0,
                        << "nonpositive y half-distance: " << face.hy);
-        CELER_VALIDATE(!std::isinf(face.tan_alpha),
-                       << "infinite trapezoidal shear: " << face.tan_alpha);
+        CELER_VALIDATE(face.alpha > Turn{-0.25} && face.alpha < Turn{0.5},
+                       << "invalid trapezoidal shear: " << face.alpha.value()
+                       << " [turns]: must be in the range (-0.25, -0.25)");
 
         real_type const xoff = (i == 0 ? -dxdz_hz : dxdz_hz);
         real_type const yoff = (i == 0 ? -dydz_hz : dydz_hz);
-        real_type const shear = face.tan_alpha * face.hy;
+        real_type const shear = std::tan(native_value_from(face.alpha))
+                                * face.hy;
 
         // Construct points counterclockwise from lower left
         points[i] = {{xoff - shear - face.hx_lo, yoff - face.hy},

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -383,7 +383,7 @@ GenTrap GenTrap::from_trap(
                        << "nonpositive upper x half-edge: " << face.hx_hi);
         CELER_VALIDATE(face.hy > 0,
                        << "nonpositive y half-distance: " << face.hy);
-        CELER_VALIDATE(face.alpha > Turn{-0.25} && face.alpha < Turn{0.5},
+        CELER_VALIDATE(face.alpha > Turn{-0.25} && face.alpha < Turn{0.25},
                        << "invalid trapezoidal shear: " << face.alpha.value()
                        << " [turns]: must be in the range (-0.25, -0.25)");
 

--- a/src/orange/orangeinp/IntersectRegion.hh
+++ b/src/orange/orangeinp/IntersectRegion.hh
@@ -225,8 +225,8 @@ class GenTrap final : public IntersectRegionInterface
         real_type hx_lo{};
         //! Bottom horizontal edge half-length
         real_type hx_hi{};
-        //! Tangent of shear angle, between horizontal line centers and Y axis
-        real_type tan_alpha{};
+        //! Shear angle, between horizontal line centers and Y axis
+        Turn alpha;
     };
 
   public:

--- a/test/orange/CMakeLists.txt
+++ b/test/orange/CMakeLists.txt
@@ -137,10 +137,9 @@ celeritas_add_test(univ/detail/SenseCalculator.test.cc)
 #-----------------------------------------------------------------------------#
 # Geant4 construction
 if(_use_g4org)
-  
   celeritas_add_test(g4org/Converter.test.cc)
   celeritas_add_test(g4org/SolidConverter.test.cc
-    LINK_LIBRARIES ${_g4_geo_libs})
+    LINK_LIBRARIES ${_g4_geo_libs} Celeritas::celeritas)
   celeritas_add_test(g4org/PhysicalVolumeConverter.test.cc)
   celeritas_add_test(g4org/ProtoConstructor.test.cc)
   celeritas_add_test(g4org/Transformer.test.cc

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -26,6 +26,11 @@ std::ostream& operator<<(std::ostream& os, SignedSense s)
     return (os << to_cstring(s));
 }
 
+Turn atan_to_turn(real_type v)
+{
+    return native_value_to<Turn>(std::atan(v));
+}
+
 namespace orangeinp
 {
 namespace test
@@ -635,7 +640,7 @@ TEST_F(GenTrapTest, trapezoid_ccw)
 TEST_F(GenTrapTest, trap_theta)
 {
     auto result = this->test(GenTrap::from_trap(
-        40, Turn{0.125}, Turn{0}, {20, 10, 10, 0}, {20, 10, 10, 0}));
+        40, Turn{0.125}, Turn{0}, {20, 10, 10, Turn{}}, {20, 10, 10, Turn{}}));
 
     static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
     static char const* const expected_surfaces[]
@@ -655,8 +660,11 @@ TEST_F(GenTrapTest, trap_theta)
 
 TEST_F(GenTrapTest, trap_thetaphi)
 {
-    auto result = this->test(GenTrap::from_trap(
-        40, Turn{0.125}, Turn{0.25}, {20, 10, 10, 0}, {20, 10, 10, 0}));
+    auto result = this->test(GenTrap::from_trap(40,
+                                                Turn{0.125},
+                                                Turn{0.25},
+                                                {20, 10, 10, Turn{0}},
+                                                {20, 10, 10, Turn{0}}));
 
     static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
     static char const* const expected_surfaces[]
@@ -677,13 +685,12 @@ TEST_F(GenTrapTest, trap_thetaphi)
 TEST_F(GenTrapTest, trap_g4)
 {
     constexpr Turn degree{real_type{1} / 360};
-    real_type tan_alpha = std::tan(15 * native_value_from(degree));
 
     auto result = this->test(GenTrap::from_trap(4,
                                                 5 * degree,
                                                 10 * degree,
-                                                {2, 1, 1, tan_alpha},
-                                                {3, 1.5, 1.5, tan_alpha}));
+                                                {2, 1, 1, 15 * degree},
+                                                {3, 1.5, 1.5, 15 * degree}));
     static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
     static char const* const expected_surfaces[]
         = {"Plane: z=-4",
@@ -696,16 +703,20 @@ TEST_F(GenTrapTest, trap_g4)
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
     EXPECT_FALSE(result.interior) << result.interior;
-    EXPECT_VEC_SOFT_EQ((Real3{-1.95920952072934, -2.93923101204883, -4}),
+    EXPECT_VEC_SOFT_EQ((Real3{-1.9592095207293, -2.9392310120488, -4}),
                        result.exterior.lower());
-    EXPECT_VEC_SOFT_EQ((Real3{2.64848563385739, 3.06076898795117, 4}),
+    EXPECT_VEC_SOFT_EQ((Real3{2.6484856338574, 3.0607689879512, 4}),
                        result.exterior.upper());
 }
 
 TEST_F(GenTrapTest, trap_full)
 {
-    auto result = this->test(GenTrap::from_trap(
-        40, Turn{0.125}, Turn{0.125}, {20, 10, 10, 0.1}, {20, 10, 10, 0.1}));
+    auto result
+        = this->test(GenTrap::from_trap(40,
+                                        Turn{0.125},
+                                        Turn{0.125},
+                                        {20, 10, 10, atan_to_turn(0.1)},
+                                        {20, 10, 10, atan_to_turn(0.1)}));
 
     static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
     static char const* const expected_surfaces[]
@@ -765,8 +776,12 @@ TEST_F(GenTrapTest, full)
 
 TEST_F(GenTrapTest, full2)
 {
-    auto result = this->test(GenTrap::from_trap(
-        40, Turn{0.125}, Turn{0}, {20, 10, 10, 0.1}, {20, 10, 15, -0.2}));
+    auto result
+        = this->test(GenTrap::from_trap(40,
+                                        Turn{0.125},
+                                        Turn{0},
+                                        {20, 10, 10, atan_to_turn(0.1)},
+                                        {20, 10, 15, -atan_to_turn(0.2)}));
 
     static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
     static char const* const expected_surfaces[]


### PR DESCRIPTION
I introduced an error in #1221 when I forgot to complete the change from "tan_alpha" to "alpha". This completes the conversion so the trapezoid face input is specified as an angle rather than a tangent.

The "sampling" test I added to the solid converter also fails on the EMEC G4GenericTrap due to a separate issue to be resolved in a further pull request. For now I am skipping that one failure.