### PR TITLE
Set SD track weight and warn if offload weight is not unity

### DIFF
--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -150,8 +150,8 @@ void LocalTransporter::Push(G4Track const& g4track)
 
     Primary track;
 
-    track.particle_id = particles_->find(
-        PDGNumber{g4track.GetDefinition()->GetPDGEncoding()});
+    PDGNumber const pdg{g4track.GetDefinition()->GetPDGEncoding()};
+    track.particle_id = particles_->find(pdg);
     track.energy = units::MevEnergy(
         convert_from_geant(g4track.GetKineticEnergy(), CLHEP::MeV));
 
@@ -163,6 +163,14 @@ void LocalTransporter::Push(G4Track const& g4track)
     track.position = convert_from_geant(g4track.GetPosition(), clhep_length);
     track.direction = convert_from_geant(g4track.GetMomentumDirection(), 1);
     track.time = convert_from_geant(g4track.GetGlobalTime(), clhep_time);
+
+    if (CELER_UNLIKELY(g4track.GetWeight() != 1.0))
+    {
+        // TODO: see issue #1268
+        CELER_LOG(error) << "incoming track (PDG " << pdg.get()
+                         << ", track ID " << g4track.GetTrackID()
+                         << ") has non-unit weight " << g4track.GetWeight();
+    }
 
     // TODO: Celeritas track IDs are independent from Geant4 track IDs, since
     // they must be sequential from zero for a given event. We may need to save

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -265,6 +265,10 @@ void HitProcessor::update_track(ParticleId id) const
         track.SetKineticEnergy(post_step->GetKineticEnergy());
         track.SetMomentumDirection(post_step->GetMomentumDirection());
     }
+
+    // TODO: Celeritas currently ignores incoming particle weight and does not
+    // perform any variance reduction. See issue #1268.
+    track.SetWeight(1.0);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This is a band-aid to issue #1268 that will at least fix callbacks to SDs in ATLAS simulations, which check the `G4Track`'s weight (which Geant4 defaults to zero). To ensure correctness, we log an "error" (i.e., the answer is wrong but we'll keep going) if the incident track doesn't have unit weight.