### PR TITLE
Refactor nuclear zone builder to separate numerical integration

### DIFF
--- a/src/corecel/math/Integrator.hh
+++ b/src/corecel/math/Integrator.hh
@@ -1,0 +1,127 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/math/Integrator.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cmath>
+
+#include "corecel/Assert.hh"
+#include "corecel/Types.hh"
+
+#include "Algorithms.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Perform numerical integration of a generic 1-D function.
+ *
+ * Currently this is a very simple Newton-Coates-like integrator extracted from
+ * NuclearZoneBuilder . It should be improved for robustness, accuracy, and
+ * efficiency, probably by using a Gauss-Legendre quadrature.
+ */
+template<class F>
+class Integrator
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using argument_type = real_type;
+    using result_type = real_type;
+    //!@}
+
+    //! Solver options
+    struct Options
+    {
+        real_type epsilon{1e-3}; //!< Convergence criterion
+        int max_depth{1000}; //!< Maximum number of divisions for integrating
+    };
+
+  public:
+    // Construct with the function and options
+    inline Integrator(F&& func, Options opts);
+
+    //! Construct with the function and default options
+    explicit Integrator(F&& func) : Integrator{std::forward<F>(func), {}} {}
+
+    // Calculate the integral over the given integral
+    inline result_type operator()(argument_type lo, argument_type hi);
+
+  private:
+    F eval_;
+    real_type epsilon_;
+    int max_depth_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with the function and options.
+ */
+template<class F>
+Integrator<F>::Integrator(F&& func, Options opts)
+    : eval_{std::forward<F>(func)}
+    , epsilon_{opts.epsilon}
+    , max_depth_{opts.max_depth}
+{
+    CELER_EXPECT(epsilon_ > 0);
+    CELER_EXPECT(max_depth_ > 0);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the integral over the given interval.
+ */
+template<class F>
+auto Integrator<F>::operator()(argument_type lo, argument_type hi) -> result_type
+{
+    constexpr real_type half{0.5};
+
+    real_type delta = hi - lo;
+    real_type prev = half * delta * (eval_(lo) + eval_(hi));
+
+    int depth = 1;
+    real_type interval = delta;
+    real_type result = 0;
+
+    bool succeeded = false;
+    int remaining_trials = max_depth_;
+    SoftEqual const soft_eq{epsilon_};
+
+    do
+    {
+        delta *= half;
+
+        real_type x = lo - delta;
+        real_type fi = 0;
+
+        for (int i = 0; i < depth; ++i)
+        {
+            x += interval;
+            fi += eval_(x);
+        }
+
+        result = half * prev + fi * delta;
+
+        if (std::fabs(result - prev) < epsilon_ * std::fabs(result))
+        {
+            succeeded = true;
+        }
+        else
+        {
+            depth *= 2;
+            interval = delta;
+            prev = result;
+        }
+    } while (!succeeded && --remaining_trials > 0);
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/math/Integrator.hh
+++ b/src/corecel/math/Integrator.hh
@@ -17,12 +17,22 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+//! Solver options
+struct IntegratorOptions
+{
+    real_type epsilon{1e-3};  //!< Convergence criterion
+    int max_depth{1000};  //!< Maximum number of divisions for integrating
+};
+
+//---------------------------------------------------------------------------//
 /*!
  * Perform numerical integration of a generic 1-D function.
  *
  * Currently this is a very simple Newton-Coates-like integrator extracted from
- * NuclearZoneBuilder . It should be improved for robustness, accuracy, and
+ * NuclearZoneBuilder. It should be improved for robustness, accuracy, and
  * efficiency, probably by using a Gauss-Legendre quadrature.
+ *
+ * This class is \em only to be used during setup.
  */
 template<class F>
 class Integrator
@@ -32,14 +42,8 @@ class Integrator
     //! \name Type aliases
     using argument_type = real_type;
     using result_type = real_type;
+    using Options = IntegratorOptions;
     //!@}
-
-    //! Solver options
-    struct Options
-    {
-        real_type epsilon{1e-3}; //!< Convergence criterion
-        int max_depth{1000}; //!< Maximum number of divisions for integrating
-    };
 
   public:
     // Construct with the function and options
@@ -56,6 +60,13 @@ class Integrator
     real_type epsilon_;
     int max_depth_;
 };
+
+//---------------------------------------------------------------------------//
+// TEMPLATE DEDUCTION
+//---------------------------------------------------------------------------//
+
+template<class F, class... Args>
+Integrator(F&&, Args...) -> Integrator<F>;
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
@@ -91,7 +102,6 @@ auto Integrator<F>::operator()(argument_type lo, argument_type hi) -> result_typ
 
     bool succeeded = false;
     int remaining_trials = max_depth_;
-    SoftEqual const soft_eq{epsilon_};
 
     do
     {

--- a/src/corecel/math/Integrator.hh
+++ b/src/corecel/math/Integrator.hh
@@ -24,7 +24,7 @@ struct IntegratorOptions
     using DepthInt = short unsigned int;
 
     real_type epsilon{1e-3};  //!< Convergence criterion
-    DepthInt max_depth{16};  //!< Maximum number of outer iterations
+    DepthInt max_depth{20};  //!< Maximum number of outer iterations
 
     //! Whether the options are valid
     explicit operator bool() const

--- a/test/corecel/CMakeLists.txt
+++ b/test/corecel/CMakeLists.txt
@@ -64,6 +64,7 @@ celeritas_add_test(math/Algorithms.test.cc)
 celeritas_add_test(math/ArrayOperators.test.cc)
 celeritas_add_test(math/ArrayUtils.test.cc)
 celeritas_add_test(math/HashUtils.test.cc)
+celeritas_add_test(math/Integrator.test.cc)
 celeritas_add_device_test(math/NumericLimits)
 celeritas_add_test(math/Quantity.test.cc
   LINK_LIBRARIES ${nlohmann_json_LIBRARIES})

--- a/test/corecel/math/Integrator.test.cc
+++ b/test/corecel/math/Integrator.test.cc
@@ -113,7 +113,18 @@ TEST(IntegratorTest, gauss)
     }
 }
 
-TEST(IntegratorTest, TEST_IF_CELERITAS_DOUBLE(nasty))
+/*!
+ * Integrate a pathological function.
+ *
+ * This is disabled because:
+ * - The integrated result changes based on the executing system, possibly due
+ *   to fma implementation.
+ * - There is an overflow or NaN with single precision.
+ * - The convergence takes slightly different number of iterations on different
+ *   compilers.
+ * - The result is wrong anyway.
+ */
+TEST(IntegratorTest, DISABLED_nasty)
 {
     DiagnosticFunc f{[](real_type x) { return std::cos(std::exp(1 / x)); }};
     {

--- a/test/corecel/math/Integrator.test.cc
+++ b/test/corecel/math/Integrator.test.cc
@@ -117,15 +117,18 @@ TEST(IntegratorTest, nasty)
 {
     DiagnosticFunc f{[](real_type x) { return std::cos(std::exp(1 / x)); }};
     {
+        real_type const eps = IntegratorOptions{}.epsilon;
         Integrator integrate{f};
         if (CELERITAS_DEBUG)
         {
             // Out of range
             EXPECT_THROW(integrate(0, 1), DebugError);
         }
-        EXPECT_SOFT_EQ(-0.21782054493256212, integrate(0.1, 1));
+
+        EXPECT_SOFT_NEAR(-0.21782054493256212, integrate(0.1, 1), eps);
         EXPECT_EQ(516, f.exchange_count());
-        EXPECT_SOFT_EQ(-5.4049272068148396e-05, integrate(0.01, 0.1));
+        // Results are numerically unstable
+        EXPECT_SOFT_NEAR(0, integrate(0.01, 0.1), 0.01);
         EXPECT_EQ(1048577, f.exchange_count());
     }
 }

--- a/test/corecel/math/Integrator.test.cc
+++ b/test/corecel/math/Integrator.test.cc
@@ -1,0 +1,90 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/math/Integrator.test.cc
+//---------------------------------------------------------------------------//
+#include "corecel/math/Integrator.hh"
+
+#include <cmath>
+#include <utility>
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+template<class F>
+struct DiagnosticFunc
+{
+    explicit DiagnosticFunc(F&& eval) : eval_{std::forward<F>(eval)} {}
+
+    //! Evaluate the underlying function and increment the counter
+    real_type operator()(real_type v)
+    {
+        ++count_;
+        return eval_(v);
+    }
+
+    //! Get and reset the counter
+    size_type exchange_count() { return std::exchange(count_, 0); }
+
+    F eval_;
+    size_type count_{0};
+};
+
+TEST(IntegratorTest, constant)
+{
+    DiagnosticFunc f{[](real_type) { return 10; }};
+    {
+        Integrator integrate{f};
+        EXPECT_SOFT_EQ(10.0, integrate(1, 2));
+        EXPECT_EQ(3, f.exchange_count());
+        EXPECT_SOFT_EQ(10 * 10.0, integrate(2, 12));
+        EXPECT_EQ(3, f.exchange_count());
+    }
+}
+
+TEST(IntegratorTest, linear)
+{
+    DiagnosticFunc f{[](real_type x) { return 2 * x; }};
+    {
+        Integrator integrate{f};
+        EXPECT_SOFT_EQ(4 - 1, integrate(1, 2));
+        EXPECT_EQ(3, f.exchange_count());
+        EXPECT_SOFT_EQ(16 - 4, integrate(2, 4));
+        EXPECT_EQ(3, f.exchange_count());
+    }
+}
+
+TEST(IntegratorTest, quadratic)
+{
+    DiagnosticFunc f{[](real_type x) { return 3 * ipow<2>(x); }};
+    {
+        real_type const eps = IntegratorOptions{}.epsilon;
+        Integrator integrate{f};
+        EXPECT_SOFT_NEAR(8 - 1, integrate(1, 2), eps);
+        EXPECT_EQ(17, f.exchange_count());
+        EXPECT_SOFT_NEAR(64 - 8, integrate(2, 4), eps);
+        EXPECT_EQ(17, f.exchange_count());
+    }
+}
+
+TEST(IntegratorTest, gauss)
+{
+    DiagnosticFunc f{
+        [](real_type r) { return ipow<2>(r) * std::exp(-ipow<2>(r)); }};
+    {
+        Integrator integrate{f};
+        EXPECT_SOFT_EQ(0.057594067180233119, integrate(0, 0.597223));
+        EXPECT_EQ(33, f.exchange_count());
+        EXPECT_SOFT_EQ(0.16739988271111467, integrate(0.597223, 1.09726));
+        EXPECT_EQ(17, f.exchange_count());
+        EXPECT_SOFT_EQ(0.20618863449804861, integrate(1.09726, 2.14597));
+        EXPECT_EQ(5, f.exchange_count());
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/test/corecel/math/Integrator.test.cc
+++ b/test/corecel/math/Integrator.test.cc
@@ -69,6 +69,15 @@ TEST(IntegratorTest, quadratic)
         EXPECT_SOFT_NEAR(64 - 8, integrate(2, 4), eps);
         EXPECT_EQ(17, f.exchange_count());
     }
+    {
+        IntegratorOptions opts;
+        opts.epsilon = 1e-5;
+        Integrator integrate{f, opts};
+        EXPECT_SOFT_NEAR(8 - 1, integrate(1, 2), opts.epsilon);
+        EXPECT_EQ(257, f.exchange_count());
+        EXPECT_SOFT_NEAR(64 - 8, integrate(2, 4), opts.epsilon);
+        EXPECT_EQ(257, f.exchange_count());
+    }
 }
 
 TEST(IntegratorTest, gauss)

--- a/test/corecel/math/Integrator.test.cc
+++ b/test/corecel/math/Integrator.test.cc
@@ -113,7 +113,7 @@ TEST(IntegratorTest, gauss)
     }
 }
 
-TEST(IntegratorTest, nasty)
+TEST(IntegratorTest, TEST_IF_CELERITAS_DOUBLE(nasty))
 {
     DiagnosticFunc f{[](real_type x) { return std::cos(std::exp(1 / x)); }};
     {


### PR DESCRIPTION
This is a follow-on to discussion in #1269. It factors out the numeric integration, adds testing, and performs simplifications on the `NuclearZoneBuilder`.