### PR TITLE
Tweak documentation in CoreState

### DIFF
--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -94,13 +94,13 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries) -> TransporterResult
             {
                 auto stream_id
                     = std::to_string(stepper_->state_ref().stream_id.get());
-                trace_counter(std::string("active-" + stream_id).data(),
+                trace_counter(std::string("active-" + stream_id).c_str(),
                               track_counts.active);
-                trace_counter(std::string("alive-" + stream_id).data(),
+                trace_counter(std::string("alive-" + stream_id).c_str(),
                               track_counts.alive);
-                trace_counter(std::string("dead-" + stream_id).data(),
+                trace_counter(std::string("dead-" + stream_id).c_str(),
                               track_counts.active - track_counts.alive);
-                trace_counter(std::string("queued-" + stream_id).data(),
+                trace_counter(std::string("queued-" + stream_id).c_str(),
                               track_counts.queued);
             }
         }

--- a/src/celeritas/Types.cc
+++ b/src/celeritas/Types.cc
@@ -111,8 +111,9 @@ char const* to_cstring(NuclearFormFactorType value)
 //---------------------------------------------------------------------------//
 /*!
  * Checks that the TrackOrder will sort tracks by actions applied at the given
- * ActionOrder. This should match the mapping in the \c SortTracksAction
- * constructor.
+ * ActionOrder.
+ *
+ * This should match the mapping in the \c SortTracksAction constructor.
  *
  * TODO: Have a single source of truth for mapping TrackOrder to ActionOrder
  */

--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -139,9 +139,9 @@ enum class StepPoint
 enum class TrackOrder
 {
     unsorted,  //!< Don't do any sorting: tracks are in an arbitrary order
-    shuffled,  //!< Tracks are shuffled at the start of the simulation
-    partition_status,  //!< Tracks are partitioned by status at the start of
-                       //!< each step
+    shuffled,  //!< Shuffle at the start of the simulation
+
+    partition_status,  //!< Partition by status at the start of each step
     sort_along_step_action,  //!< Sort only by the along-step action id
     sort_step_limit_action,  //!< Sort only by the step limit action id
     sort_action,  //!< Sort by along-step id, then post-step ID
@@ -210,9 +210,15 @@ char const* to_cstring(MscStepLimitAlgorithm value);
 // Get a string corresponding to the nuclear form factor model
 char const* to_cstring(NuclearFormFactorType value);
 
-// Checks that the TrackOrder will sort tracks by actions applied at the given
+// Whether the TrackOrder will sort tracks by actions with the given
 // ActionOrder
 bool is_action_sorted(ActionOrder action, TrackOrder track);
+
+//! Whether track sorting is enabled
+inline constexpr bool is_action_sorted(TrackOrder track)
+{
+    return static_cast<int>(track) > static_cast<int>(TrackOrder::shuffled);
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/global/ActionInterface.hh
+++ b/src/celeritas/global/ActionInterface.hh
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file celeritas/global/ActionInterface.hh
+//! \todo Move non-core-specific code to corecel
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/celeritas/global/ActionRegistry.hh
+++ b/src/celeritas/global/ActionRegistry.hh
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file celeritas/global/ActionRegistry.hh
+//! \todo Move to corecel
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/celeritas/global/ActionRegistryOutput.hh
+++ b/src/celeritas/global/ActionRegistryOutput.hh
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file celeritas/global/ActionRegistryOutput.hh
+//! \todo Move to corecel
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -257,6 +257,9 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
     };
     switch (TrackOrder track_order = input_.init->host_ref().track_order)
     {
+        case TrackOrder::unsorted:
+        case TrackOrder::shuffled:
+            break;
         case TrackOrder::partition_status:
         case TrackOrder::sort_step_limit_action:
         case TrackOrder::sort_along_step_action:
@@ -269,10 +272,8 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
             insert_sort_tracks_action(TrackOrder::sort_step_limit_action);
             insert_sort_tracks_action(TrackOrder::sort_along_step_action);
             break;
-        case TrackOrder::unsorted:
-        case TrackOrder::shuffled:
         case TrackOrder::size_:
-            break;
+            CELER_ASSERT_UNREACHABLE();
     }
 
     // Save maximum number of streams

--- a/src/celeritas/global/CoreState.cc
+++ b/src/celeritas/global/CoreState.cc
@@ -79,8 +79,10 @@ void CoreState<M>::insert_primaries(Span<Primary const> host_primaries)
 
 //---------------------------------------------------------------------------//
 /*!
- * Get a range delimiting the [start, end) of the track partition assigned
- * action_id in track_slots
+ * Get a range of sorted track slots about to undergo a given action.
+ *
+ * The result delimits the [start, end) of the track partition assigned
+ * \c action_id in track_slots.
  */
 template<MemSpace M>
 Range<ThreadId> CoreState<M>::get_action_range(ActionId action_id) const
@@ -92,7 +94,7 @@ Range<ThreadId> CoreState<M>::get_action_range(ActionId action_id) const
 
 //---------------------------------------------------------------------------//
 /*!
- * resize ActionThreads collection to the number of actions
+ * Resize ActionThreads collection to the number of actions
  */
 template<MemSpace M>
 void CoreState<M>::num_actions(size_type n)

--- a/src/celeritas/global/CoreState.cc
+++ b/src/celeritas/global/CoreState.cc
@@ -94,7 +94,7 @@ Range<ThreadId> CoreState<M>::get_action_range(ActionId action_id) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Resize ActionThreads collection to the number of actions
+ * Resize action threads if sorting track slots.
  */
 template<MemSpace M>
 void CoreState<M>::num_actions(size_type n)
@@ -104,7 +104,7 @@ void CoreState<M>::num_actions(size_type n)
 
 //---------------------------------------------------------------------------//
 /*!
- * Return the number of actions, i.e. thread_offsets_ size
+ * Return the number of actions when sorting track slots.
  */
 template<MemSpace M>
 size_type CoreState<M>::num_actions() const

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -124,13 +124,7 @@ class CoreState final : public CoreStateInterface
     //! Clear primaries after constructing initializers from them
     void clear_primaries() { counters_.num_primaries = 0; }
 
-    //// ACTIONS ////
-
-    // Resize action threads if sorting track slots
-    void num_actions(size_type n);
-
-    // Return the number of actions
-    size_type num_actions() const;
+    //// TRACK SORTING ////
 
     // Get a range of sorted track slots about to undergo a given action
     Range<ThreadId> get_action_range(ActionId action_id) const;
@@ -187,8 +181,6 @@ auto CoreState<M>::primary_storage() const -> PrimaryCRef
 //---------------------------------------------------------------------------//
 /*!
  * Access the range of actions to apply for all track IDs.
- *
- * The result is size \c num_actions .
  */
 template<MemSpace M>
 auto& CoreState<M>::action_thread_offsets()
@@ -199,8 +191,6 @@ auto& CoreState<M>::action_thread_offsets()
 //---------------------------------------------------------------------------//
 /*!
  * Access the range of actions to apply for all track IDs.
- *
- * The result is size \c num_actions .
  */
 template<MemSpace M>
 auto const& CoreState<M>::action_thread_offsets() const

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -71,9 +71,6 @@ class CoreState final : public CoreStateInterface
     using Ref = CoreStateData<Ownership::reference, M>;
     using Ptr = ObserverPtr<Ref, M>;
     using PrimaryCRef = Collection<Primary, Ownership::const_reference, M>;
-    template<MemSpace M2>
-    using ActionThreads =
-        typename detail::CoreStateThreadOffsets<M>::template ActionThreads<M2>;
     //!@}
 
   public:
@@ -94,6 +91,8 @@ class CoreState final : public CoreStateInterface
         return counters_.num_active == 0 && counters_.num_primaries == 0;
     }
 
+    //// CORE DATA ////
+
     //! Get a reference to the mutable state data
     Ref& ref() { return states_.ref(); }
 
@@ -102,6 +101,8 @@ class CoreState final : public CoreStateInterface
 
     //! Get a native-memspace pointer to the mutable state data
     Ptr ptr() { return ptr_; }
+
+    //// COUNTERS ////
 
     //! Track initialization counters
     CoreStateCounters& counters() { return counters_; }
@@ -123,26 +124,24 @@ class CoreState final : public CoreStateInterface
     //! Clear primaries after constructing initializers from them
     void clear_primaries() { counters_.num_primaries = 0; }
 
-    // resize ActionThreads collection to the number of actions
+    //// ACTIONS ////
+
+    // Resize ActionThreads collection to the number of actions
     void num_actions(size_type n);
 
-    // Return the number of actions, i.e. thread_offsets_ size
+    // Return the number of actions
     size_type num_actions() const;
 
-    // Get a range delimiting the [start, end) of the track partition assigned
-    // action_id in track_slots
+    // Get a range of sorted track slots about to undergo a given action
     Range<ThreadId> get_action_range(ActionId action_id) const;
 
-    // Reference to the host ActionThread collection for holding result of
-    // action counting
+    // Access the range of actions to apply for all track IDs
     inline auto& action_thread_offsets();
 
-    // Const reference to the host ActionThread collection for holding result
-    // of action counting
+    // Access the range of actions to apply for all track IDs
     inline auto const& action_thread_offsets() const;
 
-    // Reference to the ActionThread collection matching the state memory
-    // space
+    // Access action offsets for computation (native memory space)
     inline auto& native_action_thread_offsets();
 
   private:
@@ -187,8 +186,9 @@ auto CoreState<M>::primary_storage() const -> PrimaryCRef
 
 //---------------------------------------------------------------------------//
 /*!
- * Reference to the host ActionThread collection for holding result of
- * action counting
+ * Access the range of actions to apply for all track IDs.
+ *
+ * The result is size \c num_actions .
  */
 template<MemSpace M>
 auto& CoreState<M>::action_thread_offsets()
@@ -198,8 +198,9 @@ auto& CoreState<M>::action_thread_offsets()
 
 //---------------------------------------------------------------------------//
 /*!
- * Const reference to the host ActionThread collection for holding result
- * of action counting
+ * Access the range of actions to apply for all track IDs.
+ *
+ * The result is size \c num_actions .
  */
 template<MemSpace M>
 auto const& CoreState<M>::action_thread_offsets() const
@@ -209,7 +210,7 @@ auto const& CoreState<M>::action_thread_offsets() const
 
 //---------------------------------------------------------------------------//
 /*!
- * Reference to the ActionThread collection matching the state memory space
+ * Access action offsets for computation (native memory space).
  */
 template<MemSpace M>
 auto& CoreState<M>::native_action_thread_offsets()

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -126,7 +126,7 @@ class CoreState final : public CoreStateInterface
 
     //// ACTIONS ////
 
-    // Resize ActionThreads collection to the number of actions
+    // Resize action threads if sorting track slots
     void num_actions(size_type n);
 
     // Return the number of actions

--- a/src/celeritas/global/detail/CoreStateThreadOffsets.hh
+++ b/src/celeritas/global/detail/CoreStateThreadOffsets.hh
@@ -17,11 +17,9 @@ namespace celeritas
 {
 namespace detail
 {
+//---------------------------------------------------------------------------//
 /*!
- * Holds Collections used by CoreState to store thread offsets. This is
- * specialized for device memory space as two collections are needed, one for
- * the host and one for the device. Using pinned mapped memory would be less
- * efficient.
+ * Holds Collections used by CoreState to store thread offsets.
  */
 template<MemSpace M>
 class CoreStateThreadOffsets
@@ -30,29 +28,36 @@ class CoreStateThreadOffsets
     //!@{
     //! \name Type aliases
     template<MemSpace M2>
-    using ActionThreads = Collection<ThreadId, Ownership::value, M2, ActionId>;
+    using ThreadActions = Collection<ThreadId, Ownership::value, M2, ActionId>;
     //!@}
 
   public:
-    constexpr auto& host_action_thread_offsets() { return thread_offsets_; }
-    constexpr auto const& host_action_thread_offsets() const
-    {
-        return thread_offsets_;
-    }
-    constexpr auto& native_action_thread_offsets()
+    auto& host_action_thread_offsets() { return thread_offsets_; }
+    auto const& host_action_thread_offsets() const { return thread_offsets_; }
+    auto& native_action_thread_offsets()
     {
         return host_action_thread_offsets();
     }
-    constexpr auto const& native_action_thread_offsets() const
+    auto const& native_action_thread_offsets() const
     {
         return host_action_thread_offsets();
     }
+
+    //! Initialize using the number of actions
     void resize(size_type n) { celeritas::resize(&thread_offsets_, n); }
 
   private:
-    ActionThreads<M> thread_offsets_;
+    ThreadActions<M> thread_offsets_;
 };
 
+//---------------------------------------------------------------------------//
+/*!
+ * Holds Collections used by CoreState to store thread offsets.
+ *
+ * This is specialized for device memory space as two collections are needed,
+ * one for the host and one for the device. Using pinned mapped memory would be
+ * less efficient.
+ */
 template<>
 class CoreStateThreadOffsets<MemSpace::device>
 {
@@ -60,20 +65,17 @@ class CoreStateThreadOffsets<MemSpace::device>
     //!@{
     //! \name Type aliases
     template<MemSpace M>
-    using ActionThreads = Collection<ThreadId, Ownership::value, M, ActionId>;
+    using ThreadActions = Collection<ThreadId, Ownership::value, M, ActionId>;
     //!@}
 
   public:
-    constexpr auto& host_action_thread_offsets()
+    auto& host_action_thread_offsets() { return host_thread_offsets_; }
+    auto const& host_action_thread_offsets() const
     {
         return host_thread_offsets_;
     }
-    constexpr auto const& host_action_thread_offsets() const
-    {
-        return host_thread_offsets_;
-    }
-    constexpr auto& native_action_thread_offsets() { return thread_offsets_; }
-    constexpr auto const& native_action_thread_offsets() const
+    auto& native_action_thread_offsets() { return thread_offsets_; }
+    auto const& native_action_thread_offsets() const
     {
         return thread_offsets_;
     }
@@ -84,8 +86,8 @@ class CoreStateThreadOffsets<MemSpace::device>
     }
 
   private:
-    ActionThreads<MemSpace::device> thread_offsets_;
-    ActionThreads<MemSpace::mapped> host_thread_offsets_;
+    ThreadActions<MemSpace::device> thread_offsets_;
+    ThreadActions<MemSpace::mapped> host_thread_offsets_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/detail/CoreStateThreadOffsets.hh
+++ b/src/celeritas/global/detail/CoreStateThreadOffsets.hh
@@ -43,13 +43,10 @@ class CoreStateThreadOffsets<MemSpace::host>
   public:
     auto& host_action_thread_offsets() { return thread_offsets_; }
     auto const& host_action_thread_offsets() const { return thread_offsets_; }
-    auto& native_action_thread_offsets()
-    {
-        return host_action_thread_offsets();
-    }
+    auto& native_action_thread_offsets() { return thread_offsets_; }
     auto const& native_action_thread_offsets() const
     {
-        return host_action_thread_offsets();
+        return thread_offsets_;
     }
 
     //! Initialize using the number of actions

--- a/src/celeritas/global/detail/CoreStateThreadOffsets.hh
+++ b/src/celeritas/global/detail/CoreStateThreadOffsets.hh
@@ -18,17 +18,26 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
+template<MemSpace M>
+class CoreStateThreadOffsets;
+
+//---------------------------------------------------------------------------//
 /*!
  * Holds Collections used by CoreState to store thread offsets.
+ *
+ * Note that \c ActionThreads is not "actions by thread" but is "threads by
+ * action": it's indexed into using the action ID, and its value is the thread
+ * ID at which the sorted state vector begins having an action.
  */
-template<MemSpace M>
-class CoreStateThreadOffsets
+template<>
+class CoreStateThreadOffsets<MemSpace::host>
 {
   public:
     //!@{
     //! \name Type aliases
-    template<MemSpace M2>
-    using ThreadActions = Collection<ThreadId, Ownership::value, M2, ActionId>;
+    using NativeActionThreads
+        = Collection<ThreadId, Ownership::value, MemSpace::host, ActionId>;
+    using HostActionThreads = NativeActionThreads;
     //!@}
 
   public:
@@ -47,7 +56,7 @@ class CoreStateThreadOffsets
     void resize(size_type n) { celeritas::resize(&thread_offsets_, n); }
 
   private:
-    ThreadActions<M> thread_offsets_;
+    NativeActionThreads thread_offsets_;
 };
 
 //---------------------------------------------------------------------------//
@@ -64,8 +73,10 @@ class CoreStateThreadOffsets<MemSpace::device>
   public:
     //!@{
     //! \name Type aliases
-    template<MemSpace M>
-    using ThreadActions = Collection<ThreadId, Ownership::value, M, ActionId>;
+    using NativeActionThreads
+        = Collection<ThreadId, Ownership::value, MemSpace::device, ActionId>;
+    using HostActionThreads
+        = Collection<ThreadId, Ownership::value, MemSpace::mapped, ActionId>;
     //!@}
 
   public:
@@ -86,8 +97,8 @@ class CoreStateThreadOffsets<MemSpace::device>
     }
 
   private:
-    ThreadActions<MemSpace::device> thread_offsets_;
-    ThreadActions<MemSpace::mapped> host_thread_offsets_;
+    NativeActionThreads thread_offsets_;
+    HostActionThreads host_thread_offsets_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/SortTracksAction.cc
+++ b/src/celeritas/track/SortTracksAction.cc
@@ -147,7 +147,11 @@ void SortTracksAction::execute(CoreParams const&, CoreStateDevice& state) const
  */
 void SortTracksAction::begin_run(CoreParams const& params, CoreStateHost& state)
 {
-    state.num_actions(params.action_reg()->num_actions() + 1);
+    CELER_VALIDATE(state.action_thread_offsets().size()
+                       == params.action_reg()->num_actions() + 1,
+                   << "state action size is incorrect: actions might have "
+                      "been added "
+                      "after creating states");
 }
 
 //---------------------------------------------------------------------------//
@@ -157,7 +161,11 @@ void SortTracksAction::begin_run(CoreParams const& params, CoreStateHost& state)
 void SortTracksAction::begin_run(CoreParams const& params,
                                  CoreStateDevice& state)
 {
-    state.num_actions(params.action_reg()->num_actions() + 1);
+    CELER_VALIDATE(state.action_thread_offsets().size()
+                       == params.action_reg()->num_actions() + 1,
+                   << "state action size is incorrect: actions might have "
+                      "been added "
+                      "after creating states");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/detail/FillInvalid.hh
+++ b/src/corecel/data/detail/FillInvalid.hh
@@ -109,9 +109,8 @@ struct InvalidValueTraits<T, typename std::enable_if<std::is_trivial<T>::value>:
 
 //---------------------------------------------------------------------------//
 /*!
- * Fill a collection with an invalid value (host only).
+ * Fill a collection with an invalid value (nullop if not host/mapped).
  */
-
 template<MemSpace M>
 struct InvalidFiller
 {
@@ -121,7 +120,7 @@ struct InvalidFiller
         CELER_EXPECT(c);
 
         T val = InvalidValueTraits<T>::value();
-        auto items = (*c)[AllItems<T>{}];
+        auto items = (*c)[AllItems<T, M>{}];
         std::fill(items.begin(), items.end(), val);
     }
 };
@@ -132,6 +131,7 @@ struct InvalidFiller<MemSpace::device>
     template<class T>
     void operator()(T*)
     {
+        /* Null-op */
     }
 };
 

--- a/test/celeritas/track/TrackSort.test.cc
+++ b/test/celeritas/track/TrackSort.test.cc
@@ -181,7 +181,6 @@ TEST_F(TestEm3NoMsc, host_is_sorting)
 
     auto primaries = this->make_primaries(state.size());
     state.insert_primaries(make_span(primaries));
-    state.num_actions(this->action_reg()->num_actions() + 1);
     execute("extend-from-primaries");
     execute("initialize-tracks");
     execute("pre-step");


### PR DESCRIPTION
This standardizes the formatting of the documentation in CoreState relating to the action diagnostics. It also removes a few unhelpful `constexpr` annotations, and corrects a semantic issue by changing a string `data` accessor to `c_str`.

(Split off from #1278 )