### PR TITLE
Set step point weights in addition to track weight

### DIFF
--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -201,6 +201,9 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
                    out.points[sp].energy,
                    CLHEP::MeV);
             HP_SET(points[sp]->SetMomentumDirection, out.points[sp].dir, 1);
+            // TODO: Celeritas currently ignores incoming particle weight and
+            // does not perform any variance reduction. See issue #1268.
+            points[sp]->SetWeight(1.0);
         }
 #undef HP_SET
 
@@ -264,11 +267,8 @@ void HitProcessor::update_track(ParticleId id) const
         track.SetPosition(post_step->GetPosition());
         track.SetKineticEnergy(post_step->GetKineticEnergy());
         track.SetMomentumDirection(post_step->GetMomentumDirection());
+        track.SetWeight(post_step->GetWeight());
     }
-
-    // TODO: Celeritas currently ignores incoming particle weight and does not
-    // perform any variance reduction. See issue #1268.
-    track.SetWeight(1.0);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Geant4 stores potentially different weights for the pre- and post-step points of a `G4Step`, and sensitive detectors may use both weights depending on their exact use case. Before a `G4Step` is passed to any sensitive detector, its associated `G4Track` is updated via `G4Step::UpdateTrack()` such that the track weight is set to that of the post-step point (see `G4SteppingManager::Stepping` and similar).

#1270 added support for setting the weight of reconstituted `G4Track`s but https://github.com/drbenmorgan/celer-adept/issues/4 shows that this does not work for sensitive detectors that consider step point weights as well. The changes here are a minor refactor of that to follow Geant4's pattern of setting step point weights with propagation of the post-step weight to the track. It should also allow easier support for non-uniform weights in future.

No change to #1270's expectation of incoming track weights being unity is required as this is still perfectly valid.