### PR TITLE
Check units in JSON input

### DIFF
--- a/interface/celeritas.i
+++ b/interface/celeritas.i
@@ -57,6 +57,7 @@ struct hash;
 };
 
 %ignore *::operator++;
+%ignore *::operator--;
 
 //---------------------------------------------------------------------------//
 // CORECEL
@@ -179,6 +180,18 @@ namespace celeritas
 %}
 
 %include "celeritas/io/LivermorePEReader.hh"
+
+//---------------------------------------------------------------------------//
+namespace celeritas
+{
+class ImporterInterface
+{
+  public:
+    virtual ImportData operator()() = 0;
+  private:
+    ~ImporterInterface() = delete;
+};
+}
 
 //---------------------------------------------------------------------------//
 // EXT

--- a/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
+++ b/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
@@ -18,7 +18,7 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-static char const format_str[] = "GeantPhysicsOptions";
+static char const format_str[] = "geant-physics";
 
 //---------------------------------------------------------------------------//
 void from_json(nlohmann::json const& j, MscModelSelection& value)

--- a/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
+++ b/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
@@ -18,6 +18,9 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+static char const format_str[] = "GeantPhysicsOptions";
+
+//---------------------------------------------------------------------------//
 void from_json(nlohmann::json const& j, MscModelSelection& value)
 {
     static auto const from_string
@@ -90,8 +93,8 @@ void to_json(nlohmann::json& j, NuclearFormFactorType const& value)
 void from_json(nlohmann::json const& j, GeantPhysicsOptions& options)
 {
 #define GPO_LOAD_OPTION(NAME) CELER_JSON_LOAD_OPTION(j, options, NAME)
-
-    options = {};
+    check_format(j, format_str);
+    check_units(j, format_str);
 
     GPO_LOAD_OPTION(coulomb_scattering);
     GPO_LOAD_OPTION(compton_scattering);
@@ -134,47 +137,47 @@ void from_json(nlohmann::json const& j, GeantPhysicsOptions& options)
 /*!
  * Write options to JSON.
  */
-void to_json(nlohmann::json& j, GeantPhysicsOptions const& options)
+void to_json(nlohmann::json& j, GeantPhysicsOptions const& inp)
 {
-#define GPO_SAVE_OPTION(NAME) CELER_JSON_SAVE(j, options, NAME)
+    j = {
+        CELER_JSON_PAIR(inp, coulomb_scattering),
+        CELER_JSON_PAIR(inp, compton_scattering),
+        CELER_JSON_PAIR(inp, photoelectric),
+        CELER_JSON_PAIR(inp, rayleigh_scattering),
+        CELER_JSON_PAIR(inp, gamma_conversion),
+        CELER_JSON_PAIR(inp, gamma_general),
 
-    j = nlohmann::json::object();
+        CELER_JSON_PAIR(inp, ionization),
+        CELER_JSON_PAIR(inp, annihilation),
+        CELER_JSON_PAIR(inp, brems),
+        CELER_JSON_PAIR(inp, msc),
+        CELER_JSON_PAIR(inp, relaxation),
 
-    GPO_SAVE_OPTION(coulomb_scattering);
-    GPO_SAVE_OPTION(compton_scattering);
-    GPO_SAVE_OPTION(photoelectric);
-    GPO_SAVE_OPTION(rayleigh_scattering);
-    GPO_SAVE_OPTION(gamma_conversion);
-    GPO_SAVE_OPTION(gamma_general);
+        CELER_JSON_PAIR(inp, em_bins_per_decade),
+        CELER_JSON_PAIR(inp, eloss_fluctuation),
+        CELER_JSON_PAIR(inp, lpm),
+        CELER_JSON_PAIR(inp, integral_approach),
 
-    GPO_SAVE_OPTION(ionization);
-    GPO_SAVE_OPTION(annihilation);
-    GPO_SAVE_OPTION(brems);
-    GPO_SAVE_OPTION(msc);
-    GPO_SAVE_OPTION(relaxation);
+        CELER_JSON_PAIR(inp, min_energy),
+        CELER_JSON_PAIR(inp, max_energy),
+        CELER_JSON_PAIR(inp, linear_loss_limit),
+        CELER_JSON_PAIR(inp, lowest_electron_energy),
+        CELER_JSON_PAIR(inp, apply_cuts),
+        CELER_JSON_PAIR(inp, default_cutoff),
 
-    GPO_SAVE_OPTION(em_bins_per_decade);
-    GPO_SAVE_OPTION(eloss_fluctuation);
-    GPO_SAVE_OPTION(lpm);
-    GPO_SAVE_OPTION(integral_approach);
+        CELER_JSON_PAIR(inp, msc_range_factor),
+        CELER_JSON_PAIR(inp, msc_safety_factor),
+        CELER_JSON_PAIR(inp, msc_lambda_limit),
+        CELER_JSON_PAIR(inp, msc_theta_limit),
+        CELER_JSON_PAIR(inp, angle_limit_factor),
+        CELER_JSON_PAIR(inp, msc_step_algorithm),
+        CELER_JSON_PAIR(inp, form_factor),
 
-    GPO_SAVE_OPTION(min_energy);
-    GPO_SAVE_OPTION(max_energy);
-    GPO_SAVE_OPTION(linear_loss_limit);
-    GPO_SAVE_OPTION(lowest_electron_energy);
-    GPO_SAVE_OPTION(apply_cuts);
-    GPO_SAVE_OPTION(default_cutoff);
+        CELER_JSON_PAIR(inp, verbose),
+    };
 
-    GPO_SAVE_OPTION(msc_range_factor);
-    GPO_SAVE_OPTION(msc_safety_factor);
-    GPO_SAVE_OPTION(msc_lambda_limit);
-    GPO_SAVE_OPTION(msc_theta_limit);
-    GPO_SAVE_OPTION(angle_limit_factor);
-    GPO_SAVE_OPTION(msc_step_algorithm);
-    GPO_SAVE_OPTION(form_factor);
-
-    GPO_SAVE_OPTION(verbose);
-#undef GPO_SAVE_OPTION
+    save_format(j, format_str);
+    save_units(j);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/FieldDriverOptionsIO.json.cc
+++ b/src/celeritas/field/FieldDriverOptionsIO.json.cc
@@ -17,17 +17,18 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+static char const format_str[] = "FieldDriverOptions";
+
+//---------------------------------------------------------------------------//
 /*!
  * Read options from JSON.
  */
 void from_json(nlohmann::json const& j, FieldDriverOptions& opts)
 {
-#define FDO_INPUT(NAME)                    \
-    do                                     \
-    {                                      \
-        if (j.contains(#NAME))             \
-            j.at(#NAME).get_to(opts.NAME); \
-    } while (0)
+#define FDO_INPUT(NAME) CELER_JSON_LOAD_OPTION(j, opts, NAME)
+
+    check_format(j, format_str);
+    check_units(j, format_str);
 
     FDO_INPUT(minimum_step);
     FDO_INPUT(delta_chord);
@@ -67,6 +68,9 @@ void to_json(nlohmann::json& j, FieldDriverOptions const& opts)
         CELER_JSON_PAIR(opts, max_nsteps),
         CELER_JSON_PAIR(opts, max_substeps),
     };
+
+    save_format(j, format_str);
+    save_units(j);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/FieldDriverOptionsIO.json.cc
+++ b/src/celeritas/field/FieldDriverOptionsIO.json.cc
@@ -17,7 +17,7 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-static char const format_str[] = "FieldDriverOptions";
+static char const format_str[] = "field-driver";
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/field/RZMapFieldInputIO.json.cc
+++ b/src/celeritas/field/RZMapFieldInputIO.json.cc
@@ -24,7 +24,7 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-static char const format_str[] = "RZMapFieldInput";
+static char const format_str[] = "rz-map-field";
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/field/RZMapFieldInputIO.json.cc
+++ b/src/celeritas/field/RZMapFieldInputIO.json.cc
@@ -24,6 +24,9 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+static char const format_str[] = "RZMapFieldInput";
+
+//---------------------------------------------------------------------------//
 /*!
  * Read field from JSON.
  */
@@ -31,6 +34,9 @@ void from_json(nlohmann::json const& j, RZMapFieldInput& inp)
 {
 #define RZFI_LOAD(NAME) j.at(#NAME).get_to(inp.NAME)
     using namespace celeritas::units;
+
+    check_format(j, format_str);
+    check_units(j, format_str);
 
     RZFI_LOAD(num_grid_z);
     RZFI_LOAD(num_grid_r);
@@ -145,7 +151,8 @@ void from_json(nlohmann::json const& j, RZMapFieldInput& inp)
 void to_json(nlohmann::json& j, RZMapFieldInput const& inp)
 {
     j = {
-        {"_units", units::NativeTraits::label()},
+        {"_format", "RZMapField"},
+        {"_version", 0},
         CELER_JSON_PAIR(inp, num_grid_z),
         CELER_JSON_PAIR(inp, num_grid_r),
         CELER_JSON_PAIR(inp, min_z),
@@ -156,6 +163,8 @@ void to_json(nlohmann::json& j, RZMapFieldInput const& inp)
         CELER_JSON_PAIR(inp, field_r),
         CELER_JSON_PAIR(inp, driver_options),
     };
+    save_format(j, format_str);
+    save_units(j);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
@@ -24,7 +24,7 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-static char const format_str[] = "PrimaryGeneratorOptions";
+static char const format_str[] = "primary-generator";
 
 //---------------------------------------------------------------------------//
 // JSON serializers

--- a/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptionsIO.json.cc
@@ -14,6 +14,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/ArrayIO.json.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/io/JsonUtils.json.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringEnumMapper.hh"
 
@@ -22,6 +23,9 @@
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+static char const format_str[] = "PrimaryGeneratorOptions";
+
 //---------------------------------------------------------------------------//
 // JSON serializers
 //---------------------------------------------------------------------------//
@@ -64,9 +68,12 @@ void to_json(nlohmann::json& j, DistributionOptions const& opts)
  */
 void from_json(nlohmann::json const& j, PrimaryGeneratorOptions& opts)
 {
-    if (j.contains("seed"))
+    check_format(j, format_str);
+    check_units(j, format_str);
+
+    if (auto iter = j.find("seed"); iter != j.end())
     {
-        j.at("seed").get_to(opts.seed);
+        iter->get_to(opts.seed);
     }
     else
     {
@@ -92,8 +99,10 @@ void from_json(nlohmann::json const& j, PrimaryGeneratorOptions& opts)
         opts.pdg.push_back(p);
         CELER_VALIDATE(p, << "invalid PDG number " << i);
     }
-    j.at("num_events").get_to(opts.num_events);
-    j.at("primaries_per_event").get_to(opts.primaries_per_event);
+
+    CELER_JSON_LOAD_REQUIRED(j, opts, num_events);
+    CELER_JSON_LOAD_REQUIRED(j, opts, primaries_per_event);
+
     auto&& energy_input = j.at("energy");
     if (energy_input.is_object())
     {
@@ -140,13 +149,19 @@ void to_json(nlohmann::json& j, PrimaryGeneratorOptions const& opts)
         opts.pdg.begin(), opts.pdg.end(), pdg.begin(), [](PDGNumber p) {
             return p.unchecked_get();
         });
-    j = nlohmann::json{{"seed", opts.seed},
-                       {"pdg", pdg},
-                       {"num_events", opts.num_events},
-                       {"primaries_per_event", opts.primaries_per_event},
-                       {"energy", opts.energy},
-                       {"position", opts.position},
-                       {"direction", opts.direction}};
+
+    j = nlohmann::json{
+        {"pdg", pdg},
+        CELER_JSON_PAIR(opts, seed),
+        CELER_JSON_PAIR(opts, num_events),
+        CELER_JSON_PAIR(opts, primaries_per_event),
+        CELER_JSON_PAIR(opts, energy),
+        CELER_JSON_PAIR(opts, position),
+        CELER_JSON_PAIR(opts, direction),
+    };
+
+    save_format(j, format_str);
+    save_units(j);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/JsonUtils.json.cc
+++ b/src/corecel/io/JsonUtils.json.cc
@@ -29,6 +29,10 @@ void warn_deprecated_json_option(char const* old_name, char const* new_name)
 //---------------------------------------------------------------------------//
 /*!
  * Save a format and version marker.
+ *
+ * This should be only used for JSON structs intended for \em input in addition
+ * to output. Format strings should be all lowercase with hyphens for
+ * consistency.
  */
 void save_format(nlohmann::json& j, std::string const& format)
 {

--- a/src/corecel/io/JsonUtils.json.cc
+++ b/src/corecel/io/JsonUtils.json.cc
@@ -9,6 +9,7 @@
 #include "JsonUtils.json.hh"
 
 #include "corecel/Assert.hh"
+#include "corecel/Types.hh"
 #include "corecel/sys/Version.hh"
 
 #include "Logger.hh"
@@ -31,15 +32,26 @@ void warn_deprecated_json_option(char const* old_name, char const* new_name)
  */
 void save_format(nlohmann::json& j, std::string const& format)
 {
+    CELER_EXPECT(j.is_object());
     j["_format"] = format;
     j["_version"] = to_string(celer_version());
 }
 
 //---------------------------------------------------------------------------//
 /*!
+ * Save units for provenance/reproducibility.
+ */
+void save_units(nlohmann::json& j)
+{
+    CELER_EXPECT(j.is_object());
+    j["_units"] = to_cstring(UnitSystem::native);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Load and check for a format and compatible version marker.
  */
-void check_format(nlohmann::json const& j, std::string const& format)
+void check_format(nlohmann::json const& j, std::string_view format)
 {
     if (auto iter = j.find("_version"); iter != j.end())
     {
@@ -59,6 +71,23 @@ void check_format(nlohmann::json const& j, std::string const& format)
         CELER_VALIDATE(format_str == format,
                        << "invalid format for \"" << format << "\" input: \""
                        << format_str << "\"");
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Check units for consistency.
+ */
+void check_units(nlohmann::json const& j, std::string_view format)
+{
+    if (auto iter = j.find("_units"); iter != j.end())
+    {
+        CELER_VALIDATE(
+            to_unit_system(iter->get<std::string>()) == UnitSystem::native,
+            << "incompatible unit system in " << format
+            << " JSON file: constructed with " << iter->get<std::string>()
+            << " units, but current executable requires "
+            << to_cstring(UnitSystem::native));
     }
 }
 

--- a/src/corecel/io/JsonUtils.json.hh
+++ b/src/corecel/io/JsonUtils.json.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <string_view>
 #include <nlohmann/json.hpp>
 
 //---------------------------------------------------------------------------//
@@ -90,8 +91,14 @@ void warn_deprecated_json_option(char const* old_name, char const* new_name);
 // Save a format and version marker
 void save_format(nlohmann::json& j, std::string const& format);
 
+// Save units
+void save_units(nlohmann::json& j);
+
 // Load and check for a format and compatible version marker
-void check_format(nlohmann::json const& j, std::string const& format);
+void check_format(nlohmann::json const& j, std::string_view format);
+
+// Check units for consistency
+void check_units(nlohmann::json const& j, std::string_view format);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/rasterize/ImageIO.json.cc
+++ b/src/geocel/rasterize/ImageIO.json.cc
@@ -20,7 +20,7 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-static char const format_str[] = "ImageInput";
+static char const format_str[] = "image-input";
 
 //---------------------------------------------------------------------------//
 //!@{

--- a/src/geocel/rasterize/ImageIO.json.cc
+++ b/src/geocel/rasterize/ImageIO.json.cc
@@ -20,6 +20,9 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+static char const format_str[] = "ImageInput";
+
+//---------------------------------------------------------------------------//
 //!@{
 //! I/O routines for JSON
 #define IM_LOAD_OPTION(NAME) CELER_JSON_LOAD_OPTION(j, v, NAME)
@@ -27,6 +30,8 @@ namespace celeritas
 
 void from_json(nlohmann::json const& j, ImageInput& v)
 {
+    check_format(j, format_str);
+
     IM_LOAD_REQUIRED(lower_left);
     IM_LOAD_REQUIRED(upper_right);
     IM_LOAD_REQUIRED(rightward);
@@ -66,8 +71,10 @@ void to_json(nlohmann::json& j, ImageInput const& v)
         CELER_JSON_PAIR(v, rightward),
         CELER_JSON_PAIR(v, vertical_pixels),
         CELER_JSON_PAIR(v, horizontal_divisor),
-        {"_units", to_cstring(UnitSystem::native)},
     };
+
+    save_format(j, format_str);
+    save_units(j);
 }
 
 void to_json(nlohmann::json& j, ImageParams const& p)
@@ -80,8 +87,9 @@ void to_json(nlohmann::json& j, ImageParams const& p)
         CELER_JSON_PAIR(scalars, pixel_width),
         CELER_JSON_PAIR(scalars, dims),
         CELER_JSON_PAIR(scalars, max_length),
-        {"_units", to_cstring(UnitSystem::native)},
     };
+
+    save_units(j);
 }
 
 #undef IM_LOAD_OPTION

--- a/src/orange/OrangeInputIO.json.cc
+++ b/src/orange/OrangeInputIO.json.cc
@@ -21,6 +21,7 @@
 #include "corecel/cont/ArrayIO.json.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/io/JsonUtils.json.hh"
 #include "corecel/io/Label.hh"
 #include "corecel/io/LabelIO.json.hh"
 #include "corecel/io/Logger.hh"
@@ -28,8 +29,9 @@
 
 #include "OrangeInput.hh"
 #include "OrangeTypes.hh"
-#include "detail/OrangeInputIOImpl.json.hh"
 #include "surf/SurfaceTypeTraits.hh"
+
+#include "detail/OrangeInputIOImpl.json.hh"
 
 namespace celeritas
 {
@@ -525,16 +527,7 @@ void from_json(nlohmann::json const& j, OrangeInput& value)
     }
     CELER_LOG(debug) << "Reading '" << fmt << "' input version " << version;
 
-    if (auto iter = j.find("_units"); iter != j.end())
-    {
-        CELER_VALIDATE(
-            to_unit_system(iter->get<std::string>()) == UnitSystem::native,
-            << "incompatible unit system in ORANGE JSON file: constructed "
-               "with "
-            << iter->get<std::string>()
-            << " units, but current executable requires "
-            << to_cstring(UnitSystem::native));
-    }
+    check_units(j, "ORANGE");
 
     auto const& universes = j.at("universes");
     value.universes.reserve(universes.size());
@@ -581,13 +574,13 @@ void to_json(nlohmann::json& j, OrangeInput const& value)
     j = nlohmann::json::object({
         {"_format", "ORANGE"},
         {"_version", 0},
-        {"_units", to_cstring(UnitSystem::native)},
         {"universes", variants_to_json(value.universes)},
     });
     if (value.tol)
     {
         j["tol"] = value.tol;
     }
+    save_units(j);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeInputIO.json.cc
+++ b/src/orange/OrangeInputIO.json.cc
@@ -517,7 +517,7 @@ void from_json(nlohmann::json const& j, OrangeInput& value)
     CELER_VALIDATE(j.contains("_format"),
                    << "invalid ORANGE JSON input: no '_format' found");
     auto const& fmt = j.at("_format").get<std::string>();
-    CELER_VALIDATE(fmt == "SCALE ORANGE" || fmt == "ORANGE",
+    CELER_VALIDATE(fmt == "orange" || fmt == "ORANGE" || fmt == "SCALE ORANGE",
                    << "invalid ORANGE JSON input: unknown format '" << fmt
                    << "'");
     std::string version{"<unknown>"};

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -252,8 +252,9 @@ class FourSteelSlabsEmStandard : public GeantImporterTest
         if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
         {
             nlohmann::json out = opts;
+            out.erase("_version");
             EXPECT_JSON_EQ(
-                R"json({"angle_limit_factor":1.0,"annihilation":true,"apply_cuts":false,"brems":"all","compton_scattering":true,"coulomb_scattering":false,"default_cutoff":0.1,"eloss_fluctuation":true,"em_bins_per_decade":7,"form_factor":"exponential","gamma_conversion":true,"gamma_general":false,"integral_approach":true,"ionization":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"msc_step_algorithm":"safety","msc_theta_limit":3.141592653589793,"photoelectric":true,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json",
+                R"json({"_format":"geant-physics","_units":"cgs","angle_limit_factor":1.0,"annihilation":true,"apply_cuts":false,"brems":"all","compton_scattering":true,"coulomb_scattering":false,"default_cutoff":0.1,"eloss_fluctuation":true,"em_bins_per_decade":7,"form_factor":"exponential","gamma_conversion":true,"gamma_general":false,"integral_approach":true,"ionization":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"msc_step_algorithm":"safety","msc_theta_limit":3.141592653589793,"photoelectric":true,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json",
                 std::string(out.dump()));
         }
         return opts;

--- a/test/celeritas/phys/PrimaryGenerator.test.cc
+++ b/test/celeritas/phys/PrimaryGenerator.test.cc
@@ -133,8 +133,10 @@ TEST_F(PrimaryGeneratorTest, options)
 
     {
         nlohmann::json out = opts;
+        out.erase("_units");
+        out.erase("_version");
         EXPECT_JSON_EQ(
-            R"json({"direction":{"distribution":"isotropic","params":[]},"energy":{"distribution":"delta","params":[1.0]},"num_events":1,"pdg":[22],"position":{"distribution":"box","params":[-3.0,-3.0,-3.0,3.0,3.0,3.0]},"primaries_per_event":10,"seed":0})json",
+            R"json({"_format":"primary-generator","direction":{"distribution":"isotropic","params":[]},"energy":{"distribution":"delta","params":[1.0]},"num_events":1,"pdg":[22],"position":{"distribution":"box","params":[-3.0,-3.0,-3.0,3.0,3.0,3.0]},"primaries_per_event":10,"seed":0})json",
             std::string(out.dump()));
     }
 }

--- a/test/orange/CMakeLists.txt
+++ b/test/orange/CMakeLists.txt
@@ -74,7 +74,8 @@ celeritas_add_test(orangeinp/PolySolid.test.cc)
 celeritas_add_test(orangeinp/Shape.test.cc)
 celeritas_add_test(orangeinp/Solid.test.cc)
 celeritas_add_test(orangeinp/Transformed.test.cc)
-celeritas_add_test(orangeinp/UnitProto.test.cc)
+celeritas_add_test(orangeinp/UnitProto.test.cc
+  LINK_LIBRARIES nlohmann_json::nlohmann_json)
 
 celeritas_add_test(orangeinp/detail/BoundingZone.test.cc)
 celeritas_add_test(orangeinp/detail/PolygonUtils.test.cc)

--- a/test/orange/orangeinp/UnitProto.test.cc
+++ b/test/orange/orangeinp/UnitProto.test.cc
@@ -15,6 +15,7 @@
 #include "corecel/io/Join.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
+#include "orange/OrangeInputIO.json.hh"
 #include "orange/orangeinp/CsgObject.hh"
 #include "orange/orangeinp/InputBuilder.hh"
 #include "orange/orangeinp/Shape.hh"
@@ -449,9 +450,13 @@ class InputBuilderTest : public UnitProtoTest
         std::string const base_path = this->test_data_path("orange", "");
         std::string const ref_path = base_path + output_base + ".org.json";
 
-        // Export input to JSON
-        std::ostringstream actual;
-        actual << inp;
+        // Export input to JSON, erasing units since these particular
+        // geometries are unitless
+        std::string actual = [&inp] {
+            nlohmann::json obj = inp;
+            obj.erase("_units");
+            return obj.dump(0);
+        }();
 
         // Read 'gold' file
         std::ifstream ref{ref_path};
@@ -465,13 +470,13 @@ class InputBuilderTest : public UnitProtoTest
             CELER_VALIDATE(out,
                            << "failed to open gold file '" << ref_path
                            << "' for writing");
-            out << actual.str();
+            out << actual;
             return;
         }
 
         std::stringstream expected;
         expected << ref.rdbuf();
-        EXPECT_JSON_EQ(expected.str(), actual.str())
+        EXPECT_JSON_EQ(expected.str(), actual)
             << "update the file at " << ref_path;
     }
 };


### PR DESCRIPTION
This writes units and version metadata to some of the JSON I/O objects in Celeritas. This helps ensure consistency between intended user input and the actual runtime Celeritas.