### PR TITLE
Update perlmutter build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,10 +367,14 @@ if(CELERITAS_USE_VecGeom)
   set(_min_vecgeom_version 1.2.4)
   if(NOT VecGeom_FOUND)
     # TODO: remove once we require a veccore version including https://github.com/root-project/veccore/commit/743566fac1e9b2eaeb0f0b63242442ba430e0cc0
-    cmake_policy(PUSH)
-    cmake_policy(SET CMP0146 OLD)
-    find_package(VecGeom ${_min_vecgeom_version} REQUIRED)
-    cmake_policy(POP)
+    if(POLICY CMP0146 AND CELERITAS_USE_CUDA)
+      cmake_policy(PUSH)
+      cmake_policy(SET CMP0146 OLD)
+      find_package(VecGeom ${_min_vecgeom_version} REQUIRED)
+      cmake_policy(POP)
+    else()
+      find_package(VecGeom ${_min_vecgeom_version} REQUIRED)
+    endif()
   elseif(VecGeom_VERSION VERSION_LESS _min_vecgeom_version)
     # Another package, probably Geant4, is already using vecgeom
     celeritas_error_incompatible_option(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,7 @@ endif()
 if(CELERITAS_USE_VecGeom)
   set(_min_vecgeom_version 1.2.4)
   if(NOT VecGeom_FOUND)
+    # TODO: remove once we require a veccore version including https://github.com/root-project/veccore/commit/743566fac1e9b2eaeb0f0b63242442ba430e0cc0
     cmake_policy(PUSH)
     cmake_policy(SET CMP0146 OLD)
     find_package(VecGeom ${_min_vecgeom_version} REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,15 +366,7 @@ endif()
 if(CELERITAS_USE_VecGeom)
   set(_min_vecgeom_version 1.2.4)
   if(NOT VecGeom_FOUND)
-    # TODO: remove once we require a veccore version including https://github.com/root-project/veccore/commit/743566fac1e9b2eaeb0f0b63242442ba430e0cc0
-    if(POLICY CMP0146 AND CELERITAS_USE_CUDA)
-      cmake_policy(PUSH)
-      cmake_policy(SET CMP0146 OLD)
-      find_package(VecGeom ${_min_vecgeom_version} REQUIRED)
-      cmake_policy(POP)
-    else()
-      find_package(VecGeom ${_min_vecgeom_version} REQUIRED)
-    endif()
+    find_package(VecGeom ${_min_vecgeom_version} REQUIRED)
   elseif(VecGeom_VERSION VERSION_LESS _min_vecgeom_version)
     # Another package, probably Geant4, is already using vecgeom
     celeritas_error_incompatible_option(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,7 +366,10 @@ endif()
 if(CELERITAS_USE_VecGeom)
   set(_min_vecgeom_version 1.2.4)
   if(NOT VecGeom_FOUND)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0146 OLD)
     find_package(VecGeom ${_min_vecgeom_version} REQUIRED)
+    cmake_policy(POP)
   elseif(VecGeom_VERSION VERSION_LESS _min_vecgeom_version)
     # Another package, probably Geant4, is already using vecgeom
     celeritas_error_incompatible_option(

--- a/cmake/FindVecGeom.cmake
+++ b/cmake/FindVecGeom.cmake
@@ -12,7 +12,13 @@ Celeritas.
 
 #]=======================================================================]
 
+# TODO: remove once we require a veccore version including https://github.com/root-project/veccore/commit/743566fac1e9b2eaeb0f0b63242442ba430e0cc0
+cmake_policy(PUSH)
+if(POLICY CMP0146)
+  cmake_policy(SET CMP0146 OLD)
+endif()
 find_package(VecGeom QUIET CONFIG)
+cmake_policy(POP)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(VecGeom CONFIG_MODE)
 

--- a/scripts/cmake-presets/perlmutter.json
+++ b/scripts/cmake-presets/perlmutter.json
@@ -25,6 +25,9 @@
         "CMAKE_CUDA_ARCHITECTURES": {"type": "STRING", "value": "80"},
         "CMAKE_CXX_STANDARD": {"type": "STRING", "value": "17"},
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_C_COMPILER": {"type": "PATH", "value": "cc"},
+        "CMAKE_CXX_COMPILER": {"type": "PATH", "value": "CC"},
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}",
         "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=znver3 -mtune=znver3",
         "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"}

--- a/scripts/env/perlmutter.sh
+++ b/scripts/env/perlmutter.sh
@@ -4,12 +4,13 @@
 # If using Spack, this will cause a compile error in VecGeom+cuda.
 # Spack uses this CUDA install as external CUDA package and doesn't look in the math_libs directory for extra headers.
 # --> the fix for now is to unload these modules and install our own cudatoolkit using Spack.
-module unload gpu cudatoolkit
-module load PrgEnv-gnu/8.3.3
+module unload gpu
+module load PrgEnv-gnu
 
-# Spack module on Perlmutter currently fails to create the spack env from spack.yaml, we need Spack v0.18.0; use our own install instead.
-# Expects the spack git repo to have been cloned at _SPACK_INSTALL and the environment celeritas to exist
-_SPACK_INSTALL=${SCRATCH}/spack
+
+# Expects the spack git repo to have been cloned at _SPACK_INSTALL (default to $SPACK_ROOT)
+# The environment named celeritas must exists
+_SPACK_INSTALL=${SPACK_ROOT:-$SCRATCH/spack}
 _SPACK_SOURCE_FILE=${_SPACK_INSTALL}/share/spack/setup-env.sh
 if [ ! -f "${_SPACK_SOURCE_FILE}" ]; then
     echo "Expected to find a spack install at ${_SPACK_INSTALL}" >&2
@@ -18,4 +19,5 @@ fi
 
 . ${_SPACK_SOURCE_FILE}
 spack env activate celeritas
-export LD_LIBRARY_PATH=$SPACK_ENV/.spack-env/view/lib64:$LD_LIBRARY_PATH
+
+export PKG_CONFIG_PATH=/opt/cray/xpmem/default/lib64/pkgconfig:"${PKG_CONFIG_PATH}"


### PR DESCRIPTION
This updates the Perlmutter build script and fixes configure issues with xpmem module that is loaded by default. Also, use compiler wrapper and ccache.

In addition, fix a configure issue when using CMake 3.27 and VecGeom+cuda. CMake 3.27 introduces the policy CMP0146 removing the FindCuda module. Since #1253 we updated CMake policy support to 3.28, setting CMP0146 to NEW.  The latest VecCore (0.8.1) version still uses the old policy and will fail to find cuda with a recent version of CMake.