### PR TITLE
Store model action IDs in model class instead of in data

### DIFF
--- a/app/demo-interactor/HostKNDemoRunner.cc
+++ b/app/demo-interactor/HostKNDemoRunner.cc
@@ -50,7 +50,6 @@ HostKNDemoRunner::HostKNDemoRunner(constSPParticleParams particles,
     CELER_EXPECT(xsparams_);
 
     // Set up KN interactor data;
-    kn_data_.ids.action = ActionId{0};  // Unused but needed for error check
     kn_data_.ids.electron = pparams_->find(pdg::electron());
     kn_data_.ids.gamma = pparams_->find(pdg::gamma());
     kn_data_.inv_electron_mass

--- a/app/demo-interactor/KNDemoRunner.cc
+++ b/app/demo-interactor/KNDemoRunner.cc
@@ -32,7 +32,6 @@ KNDemoRunner::KNDemoRunner(constSPParticleParams particles,
 
     // Set up KN interactor data;
     namespace pdg = pdg;
-    kn_data_.ids.action = ActionId{0};  // Unused but needed for error check
     kn_data_.ids.electron = pparams_->find(pdg::electron());
     kn_data_.ids.gamma = pparams_->find(pdg::gamma());
     kn_data_.inv_electron_mass

--- a/src/celeritas/em/data/BetheHeitlerData.hh
+++ b/src/celeritas/em/data/BetheHeitlerData.hh
@@ -20,8 +20,6 @@ namespace celeritas
  */
 struct BetheHeitlerIds
 {
-    //! Model ID
-    ActionId action;
     //! ID of an electron
     ParticleId electron;
     //! ID of an positron
@@ -32,7 +30,7 @@ struct BetheHeitlerIds
     //! Check whether the IDs are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return action && electron && positron && gamma;
+        return electron && positron && gamma;
     }
 };
 

--- a/src/celeritas/em/data/CombinedBremData.hh
+++ b/src/celeritas/em/data/CombinedBremData.hh
@@ -24,12 +24,6 @@ namespace celeritas
 template<Ownership W, MemSpace M>
 struct CombinedBremData
 {
-    // Hack for having an "ids" field: same as model in rb_data
-    struct
-    {
-        ActionId action;
-    } ids;
-
     // Differential cross section data for SeltzerBerger
     SeltzerBergerTableData<W, M> sb_differential_xs;
 
@@ -39,7 +33,7 @@ struct CombinedBremData
     //! Whether all data are assigned and valid
     explicit CELER_FUNCTION operator bool() const
     {
-        return ids.action && sb_differential_xs && rb_data;
+        return sb_differential_xs && rb_data;
     }
 
     //! Assign from another set of data
@@ -47,7 +41,6 @@ struct CombinedBremData
     CombinedBremData& operator=(CombinedBremData<W2, M2> const& other)
     {
         CELER_EXPECT(other);
-        ids.action = other.ids.action;
         sb_differential_xs = other.sb_differential_xs;
         rb_data = other.rb_data;
         return *this;

--- a/src/celeritas/em/data/CoulombScatteringData.hh
+++ b/src/celeritas/em/data/CoulombScatteringData.hh
@@ -25,14 +25,14 @@ struct CoulombScatteringData
     // Particle IDs
     CoulombIds ids;
 
-    // Action ID
-    ActionId action;
-
     //! Cosine of the maximum scattering polar angle
     static CELER_CONSTEXPR_FUNCTION real_type cos_thetamax() { return -1; }
 
     // Check if the data is initialized
-    explicit CELER_FUNCTION operator bool() const { return ids && action; }
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return static_cast<bool>(ids);
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/data/EPlusGGData.hh
+++ b/src/celeritas/em/data/EPlusGGData.hh
@@ -22,24 +22,17 @@ struct EPlusGGData
 {
     using Mass = units::MevMass;
 
-    struct
-    {
-        //! Model ID
-        ActionId action;
-        //! ID of an positron
-        ParticleId positron;
-        //! ID of a gamma
-        ParticleId gamma;
-    } ids;
-
+    //! ID of an positron
+    ParticleId positron;
+    //! ID of a gamma
+    ParticleId gamma;
     //! Electron mass
     units::MevMass electron_mass;
 
     //! Check whether the data is assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return ids.action && ids.positron && ids.gamma
-               && electron_mass > zero_quantity();
+        return positron && gamma && electron_mass > zero_quantity();
     }
 };
 

--- a/src/celeritas/em/data/ElectronBremsData.hh
+++ b/src/celeritas/em/data/ElectronBremsData.hh
@@ -16,8 +16,6 @@ namespace celeritas
 //! IDs used by brems
 struct ElectronBremIds
 {
-    //! Model ID
-    ActionId action;
     //! ID of a gamma
     ParticleId gamma;
     //! ID of an electron
@@ -28,7 +26,7 @@ struct ElectronBremIds
     //! Whether the IDs are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return action && gamma && electron && positron;
+        return gamma && electron && positron;
     }
 };
 

--- a/src/celeritas/em/data/KleinNishinaData.hh
+++ b/src/celeritas/em/data/KleinNishinaData.hh
@@ -20,15 +20,11 @@ namespace celeritas
  */
 struct KleinNishinaIds
 {
-    ActionId action;
     ParticleId electron;
     ParticleId gamma;
 
     //! Check whether the data is assigned
-    explicit CELER_FUNCTION operator bool() const
-    {
-        return action && electron && gamma;
-    }
+    explicit CELER_FUNCTION operator bool() const { return electron && gamma; }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/data/LivermorePEData.hh
+++ b/src/celeritas/em/data/LivermorePEData.hh
@@ -132,18 +132,13 @@ struct LivermorePEXsData
  */
 struct LivermorePEIds
 {
-    //! Model ID
-    ActionId action;
     //! ID of an electron
     ParticleId electron;
     //! ID of a gamma
     ParticleId gamma;
 
     //! Whether the IDs are assigned
-    explicit CELER_FUNCTION operator bool() const
-    {
-        return action && electron && gamma;
-    }
+    explicit CELER_FUNCTION operator bool() const { return electron && gamma; }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/data/MollerBhabhaData.hh
+++ b/src/celeritas/em/data/MollerBhabhaData.hh
@@ -20,14 +20,13 @@ namespace celeritas
  */
 struct MollerBhabhaIds
 {
-    ActionId action;
     ParticleId electron;
     ParticleId positron;
 
     //! Whether the IDs are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return action && electron && positron;
+        return electron && positron;
     }
 };
 

--- a/src/celeritas/em/data/MuBremsstrahlungData.hh
+++ b/src/celeritas/em/data/MuBremsstrahlungData.hh
@@ -20,7 +20,6 @@ namespace celeritas
  */
 struct MuBremsstrahlungIds
 {
-    ActionId action;
     ParticleId gamma;
     ParticleId mu_minus;
     ParticleId mu_plus;
@@ -28,7 +27,7 @@ struct MuBremsstrahlungIds
     //! Whether the IDs are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return action && gamma && mu_minus && mu_plus;
+        return gamma && mu_minus && mu_plus;
     }
 };
 

--- a/src/celeritas/em/data/RayleighData.hh
+++ b/src/celeritas/em/data/RayleighData.hh
@@ -36,35 +36,21 @@ struct RayleighParameters
 
 //---------------------------------------------------------------------------//
 /*!
- * Model and particles IDs.
- */
-struct RayleighIds
-{
-    ActionId action;
-    ParticleId gamma;
-
-    //! Check whether the data is assigned
-    explicit CELER_FUNCTION operator bool() const { return action && gamma; }
-};
-
-//---------------------------------------------------------------------------//
-/*!
  * Device data for creating an interactor.
  */
 template<Ownership W, MemSpace M>
 struct RayleighData
 {
-    //! Model and particle IDs
-    RayleighIds ids;
-
     template<class T>
     using ElementItems = celeritas::Collection<T, W, M, ElementId>;
+
+    ParticleId gamma;
     ElementItems<RayleighParameters> params;
 
     //! Check whether the data is assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return ids && !params.empty();
+        return gamma && !params.empty();
     }
 
     //! Assign from another set of data
@@ -72,8 +58,7 @@ struct RayleighData
     RayleighData& operator=(RayleighData<W2, M2> const& other)
     {
         CELER_EXPECT(other);
-        ids.action = other.ids.action;
-        ids.gamma = other.ids.gamma;
+        gamma = other.gamma;
         params = other.params;
         return *this;
     }

--- a/src/celeritas/em/interactor/EPlusGGInteractor.hh
+++ b/src/celeritas/em/interactor/EPlusGGInteractor.hh
@@ -85,7 +85,7 @@ EPlusGGInteractor::EPlusGGInteractor(EPlusGGData const& shared,
     , inc_direction_(inc_direction)
     , allocate_(allocate)
 {
-    CELER_EXPECT(particle.particle_id() == shared_.ids.positron);
+    CELER_EXPECT(particle.particle_id() == shared_.positron);
 }
 
 //---------------------------------------------------------------------------//
@@ -110,7 +110,7 @@ CELER_FUNCTION Interaction EPlusGGInteractor::operator()(Engine& rng)
     result.secondaries = {secondaries, 2};
 
     // Sample two gammas
-    secondaries[0].particle_id = secondaries[1].particle_id = shared_.ids.gamma;
+    secondaries[0].particle_id = secondaries[1].particle_id = shared_.gamma;
 
     if (inc_energy_ == 0)
     {

--- a/src/celeritas/em/interactor/RayleighInteractor.hh
+++ b/src/celeritas/em/interactor/RayleighInteractor.hh
@@ -94,7 +94,7 @@ RayleighInteractor::RayleighInteractor(RayleighRef const& shared,
     , inc_direction_(direction)
     , element_id_(el_id)
 {
-    CELER_EXPECT(particle.particle_id() == shared_.ids.gamma);
+    CELER_EXPECT(particle.particle_id() == shared_.gamma);
     CELER_EXPECT(element_id_ < shared_.params.size());
 }
 

--- a/src/celeritas/em/model/BetheHeitlerModel.cc
+++ b/src/celeritas/em/model/BetheHeitlerModel.cc
@@ -30,14 +30,15 @@ BetheHeitlerModel::BetheHeitlerModel(ActionId id,
                                      ParticleParams const& particles,
                                      SPConstImported data,
                                      bool enable_lpm)
-    : imported_(data,
+    : ConcreteAction(
+        id, "conv-bethe-heitler", "interact by Bethe-Heitler gamma conversion")
+    , imported_(data,
                 particles,
                 ImportProcessClass::conversion,
                 ImportModelClass::bethe_heitler_lpm,
                 {pdg::gamma()})
 {
     CELER_EXPECT(id);
-    data_.ids.action = id;
     data_.ids.electron = particles.find(pdg::electron());
     data_.ids.positron = particles.find(pdg::positron());
     data_.ids.gamma = particles.find(pdg::gamma());
@@ -98,15 +99,6 @@ void BetheHeitlerModel::execute(CoreParams const&, CoreStateDevice&) const
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId BetheHeitlerModel::action_id() const
-{
-    return data_.ids.action;
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/model/BetheHeitlerModel.hh
+++ b/src/celeritas/em/model/BetheHeitlerModel.hh
@@ -21,7 +21,7 @@ namespace celeritas
 /*!
  * Set up and launch the Bethe-Heitler model interaction.
  */
-class BetheHeitlerModel final : public Model
+class BetheHeitlerModel final : public Model, public ConcreteAction
 {
   public:
     //!@{
@@ -47,18 +47,6 @@ class BetheHeitlerModel final : public Model
 
     // Apply the interaction kernel on device
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "conv-bethe-heitler"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by Bethe-Heitler gamma conversion";
-    }
 
     //!@{
     //! Access model data

--- a/src/celeritas/em/model/CombinedBremModel.cc
+++ b/src/celeritas/em/model/CombinedBremModel.cc
@@ -38,6 +38,10 @@ CombinedBremModel::CombinedBremModel(ActionId id,
                                      SPConstImported data,
                                      ReadData sb_table,
                                      bool enable_lpm)
+    : ConcreteAction(id,
+                     "brems-combined",
+                     "interact by bremsstrahlung (combined SB/relativistic, "
+                     "e+/-)")
 {
     CELER_EXPECT(id);
     CELER_EXPECT(sb_table);
@@ -51,7 +55,6 @@ CombinedBremModel::CombinedBremModel(ActionId id,
         id, particles, materials, data, enable_lpm);
 
     HostVal<CombinedBremData> host_ref;
-    host_ref.ids.action = id;
     host_ref.sb_differential_xs = sb_model_->host_ref().differential_xs;
     host_ref.rb_data = rb_model_->host_ref();
 
@@ -110,16 +113,7 @@ void CombinedBremModel::execute(CoreParams const&, CoreStateDevice&) const
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
 //!@}
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId CombinedBremModel::action_id() const
-{
-    return this->host_ref().rb_data.ids.action;
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/model/CombinedBremModel.hh
+++ b/src/celeritas/em/model/CombinedBremModel.hh
@@ -31,7 +31,7 @@ class ParticleParams;
  * Set up and launch a combined model of SeltzerBergerModel at the low energy
  * and RelativisticBremModel at the high energy for e+/e- Bremsstrahlung.
  */
-class CombinedBremModel final : public Model
+class CombinedBremModel final : public Model, public ConcreteAction
 {
   public:
     //@{
@@ -62,18 +62,6 @@ class CombinedBremModel final : public Model
 
     // Apply the interaction kernel to device data
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "brems-combined"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by bremsstrahlung (combined SB/relativistic, e+/-)";
-    }
 
     //! Access data on the host
     HostRef const& host_ref() const { return data_.host_ref(); }

--- a/src/celeritas/em/model/CoulombScatteringModel.cc
+++ b/src/celeritas/em/model/CoulombScatteringModel.cc
@@ -36,7 +36,9 @@ CoulombScatteringModel::CoulombScatteringModel(ActionId id,
                                                ParticleParams const& particles,
                                                MaterialParams const& materials,
                                                SPConstImported data)
-    : imported_(data,
+    : ConcreteAction(
+        id, "coulomb-wentzel", "interact by Coulomb scattering (Wentzel)")
+    , imported_(data,
                 particles,
                 ImportProcessClass::coulomb_scat,
                 ImportModelClass::e_coulomb_scattering,
@@ -44,7 +46,6 @@ CoulombScatteringModel::CoulombScatteringModel(ActionId id,
 {
     CELER_EXPECT(id);
 
-    data_.action = id;
     data_.ids.electron = particles.find(pdg::electron());
     data_.ids.positron = particles.find(pdg::positron());
 
@@ -126,15 +127,6 @@ void CoulombScatteringModel::execute(CoreParams const&, CoreStateDevice&) const
 }
 #endif
 //!@}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the action ID for this model.
- */
-ActionId CoulombScatteringModel::action_id() const
-{
-    return this->host_ref().action;
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/model/CoulombScatteringModel.hh
+++ b/src/celeritas/em/model/CoulombScatteringModel.hh
@@ -24,7 +24,7 @@ class IsotopeView;
 /*!
  * Set up and launch the Wentzel Coulomb scattering model interaction.
  */
-class CoulombScatteringModel final : public Model
+class CoulombScatteringModel final : public Model, public ConcreteAction
 {
   public:
     //!@{
@@ -50,18 +50,6 @@ class CoulombScatteringModel final : public Model
 
     // Apply the interaction kernel on device
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "coulomb-wentzel"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by Coulomb scattering (Wentzel)";
-    }
 
     //!@{
     //! Access model data

--- a/src/celeritas/em/model/EPlusGGModel.cc
+++ b/src/celeritas/em/model/EPlusGGModel.cc
@@ -25,16 +25,18 @@ namespace celeritas
  * Construct from model ID and other necessary data.
  */
 EPlusGGModel::EPlusGGModel(ActionId id, ParticleParams const& particles)
+    : ConcreteAction(id,
+                     "annihil-2-gamma",
+                     "interact by positron annihilation yielding two gammas")
 {
     CELER_EXPECT(id);
-    data_.ids.action = id;
-    data_.ids.positron = particles.find(pdg::positron());
-    data_.ids.gamma = particles.find(pdg::gamma());
+    data_.positron = particles.find(pdg::positron());
+    data_.gamma = particles.find(pdg::gamma());
 
-    CELER_VALIDATE(data_.ids.positron && data_.ids.gamma,
+    CELER_VALIDATE(data_.positron && data_.gamma,
                    << "missing positron and/or gamma particles (required for "
                    << this->description() << ")");
-    data_.electron_mass = particles.get(data_.ids.positron).mass();
+    data_.electron_mass = particles.get(data_.positron).mass();
     CELER_ENSURE(data_);
 }
 
@@ -45,7 +47,7 @@ EPlusGGModel::EPlusGGModel(ActionId id, ParticleParams const& particles)
 auto EPlusGGModel::applicability() const -> SetApplicability
 {
     Applicability applic;
-    applic.particle = data_.ids.positron;
+    applic.particle = data_.positron;
     applic.lower = zero_quantity();  // Valid at rest
     applic.upper = units::MevEnergy{1e8};  // 100 TeV
 
@@ -83,15 +85,6 @@ void EPlusGGModel::execute(CoreParams const&, CoreStateDevice&) const
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId EPlusGGModel::action_id() const
-{
-    return data_.ids.action;
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/model/EPlusGGModel.hh
+++ b/src/celeritas/em/model/EPlusGGModel.hh
@@ -19,7 +19,7 @@ namespace celeritas
 /*!
  * Set up and launch two-gamma positron annihiliation.
  */
-class EPlusGGModel final : public Model
+class EPlusGGModel final : public Model, public ConcreteAction
 {
   public:
     // Construct from model ID and other necessary data
@@ -36,18 +36,6 @@ class EPlusGGModel final : public Model
 
     // Apply the interaction kernel on device
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "annihil-2-gamma"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by positron annihilation yielding two gammas";
-    }
 
     //!@{
     //! Access model data

--- a/src/celeritas/em/model/KleinNishinaModel.cc
+++ b/src/celeritas/em/model/KleinNishinaModel.cc
@@ -25,9 +25,11 @@ namespace celeritas
  */
 KleinNishinaModel::KleinNishinaModel(ActionId id,
                                      ParticleParams const& particles)
+    : ConcreteAction(id,
+                     "scat-klein-nishina",
+                     "interact by Compton scattering (simple Klein-Nishina)")
 {
     CELER_EXPECT(id);
-    data_.ids.action = id;
     data_.ids.electron = particles.find(pdg::electron());
     data_.ids.gamma = particles.find(pdg::gamma());
 
@@ -88,16 +90,7 @@ void KleinNishinaModel::execute(CoreParams const&, CoreStateDevice&) const
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId KleinNishinaModel::action_id() const
-{
-    return data_.ids.action;
-}
-
 //!@}
+
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/model/KleinNishinaModel.hh
+++ b/src/celeritas/em/model/KleinNishinaModel.hh
@@ -17,7 +17,7 @@ namespace celeritas
 /*!
  * Set up and launch the Klein-Nishina model interaction.
  */
-class KleinNishinaModel final : public Model
+class KleinNishinaModel final : public Model, public ConcreteAction
 {
   public:
     // Construct from model ID and other necessary data
@@ -34,18 +34,6 @@ class KleinNishinaModel final : public Model
 
     // Apply the interaction kernel to device data
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "scat-klein-nishina"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by Compton scattering (simple Klein-Nishina)";
-    }
 
     //!@{
     //! Access model data

--- a/src/celeritas/em/model/LivermorePEModel.cc
+++ b/src/celeritas/em/model/LivermorePEModel.cc
@@ -40,6 +40,8 @@ LivermorePEModel::LivermorePEModel(ActionId id,
                                    ParticleParams const& particles,
                                    MaterialParams const& materials,
                                    ReadData load_data)
+    : ConcreteAction(
+        id, "photoel-livermore", "interact by Livermore photoelectric effect")
 {
     CELER_EXPECT(id);
     CELER_EXPECT(load_data);
@@ -47,7 +49,6 @@ LivermorePEModel::LivermorePEModel(ActionId id,
     HostVal<LivermorePEData> host_data;
 
     // Save IDs
-    host_data.ids.action = id;
     host_data.ids.electron = particles.find(pdg::electron());
     host_data.ids.gamma = particles.find(pdg::gamma());
     CELER_VALIDATE(host_data.ids,
@@ -122,16 +123,7 @@ void LivermorePEModel::execute(CoreParams const&, CoreStateDevice&) const
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
 //!@}
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId LivermorePEModel::action_id() const
-{
-    return this->host_ref().ids.action;
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/model/LivermorePEModel.hh
+++ b/src/celeritas/em/model/LivermorePEModel.hh
@@ -25,7 +25,7 @@ class ParticleParams;
 /*!
  * Set up and launch the Livermore photoelectric model interaction.
  */
-class LivermorePEModel final : public Model
+class LivermorePEModel final : public Model, public ConcreteAction
 {
   public:
     //!@{
@@ -52,18 +52,6 @@ class LivermorePEModel final : public Model
 
     // Apply the interaction kernel on device
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "photoel-livermore"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by Livermore photoelectric effect";
-    }
 
     //! Access data on the host
     HostRef const& host_ref() const { return data_.host_ref(); }

--- a/src/celeritas/em/model/MollerBhabhaModel.cc
+++ b/src/celeritas/em/model/MollerBhabhaModel.cc
@@ -27,9 +27,10 @@ namespace celeritas
  */
 MollerBhabhaModel::MollerBhabhaModel(ActionId id,
                                      ParticleParams const& particles)
+    : ConcreteAction(
+        id, "ioni-moller-bhabha", "interact by Moller+Bhabha ionization")
 {
     CELER_EXPECT(id);
-    data_.ids.action = id;
     data_.ids.electron = particles.find(pdg::electron());
     data_.ids.positron = particles.find(pdg::positron());
 
@@ -99,15 +100,6 @@ void MollerBhabhaModel::execute(CoreParams const&, CoreStateDevice&) const
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId MollerBhabhaModel::action_id() const
-{
-    return data_.ids.action;
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/model/MollerBhabhaModel.hh
+++ b/src/celeritas/em/model/MollerBhabhaModel.hh
@@ -18,7 +18,7 @@ class ParticleParams;
 /*!
  * Set up and launch the Moller-Bhabha model interaction.
  */
-class MollerBhabhaModel final : public Model
+class MollerBhabhaModel final : public Model, public ConcreteAction
 {
   public:
     // Construct from model ID and other necessary data
@@ -35,18 +35,6 @@ class MollerBhabhaModel final : public Model
 
     // Apply the interaction kernel on device
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "ioni-moller-bhabha"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by Moller+Bhabha ionization";
-    }
 
     //!@{
     //! Access model data

--- a/src/celeritas/em/model/MuBremsstrahlungModel.cc
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.cc
@@ -28,14 +28,14 @@ namespace celeritas
 MuBremsstrahlungModel::MuBremsstrahlungModel(ActionId id,
                                              ParticleParams const& particles,
                                              SPConstImported data)
-    : imported_(data,
+    : ConcreteAction(id, "brems-muon", "interact by bremsstrahlung (muon)")
+    , imported_(data,
                 particles,
                 ImportProcessClass::mu_brems,
                 ImportModelClass::mu_brems,
                 {pdg::mu_minus(), pdg::mu_plus()})
 {
     CELER_EXPECT(id);
-    data_.ids.action = id;
     data_.ids.gamma = particles.find(pdg::gamma());
     data_.ids.mu_minus = particles.find(pdg::mu_minus());
     data_.ids.mu_plus = particles.find(pdg::mu_plus());
@@ -102,14 +102,5 @@ void MuBremsstrahlungModel::execute(CoreParams const&, CoreStateDevice&) const
 #endif
 
 //!@}
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId MuBremsstrahlungModel::action_id() const
-{
-    return data_.ids.action;
-}
-
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/model/MuBremsstrahlungModel.hh
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.hh
@@ -21,7 +21,7 @@ namespace celeritas
 /*!
  * Set up and launch the Muon Bremsstrahlung model interaction.
  */
-class MuBremsstrahlungModel final : public Model
+class MuBremsstrahlungModel final : public Model, public ConcreteAction
 {
   public:
     //!@{
@@ -46,18 +46,6 @@ class MuBremsstrahlungModel final : public Model
 
     // Apply the interaction kernel on device
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "brems-muon"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by bremsstrahlung (muon)";
-    }
 
     //!@{
     //! Access model data

--- a/src/celeritas/em/model/RayleighModel.cc
+++ b/src/celeritas/em/model/RayleighModel.cc
@@ -34,7 +34,8 @@ RayleighModel::RayleighModel(ActionId id,
                              ParticleParams const& particles,
                              MaterialParams const& materials,
                              SPConstImported data)
-    : imported_(data,
+    : ConcreteAction(id, "scat-rayleigh", "interact by Rayleigh scattering")
+    , imported_(data,
                 particles,
                 ImportProcessClass::rayleigh,
                 ImportModelClass::livermore_rayleigh,
@@ -44,9 +45,8 @@ RayleighModel::RayleighModel(ActionId id,
 
     HostValue host_ref;
 
-    host_ref.ids.action = id;
-    host_ref.ids.gamma = particles.find(pdg::gamma());
-    CELER_VALIDATE(host_ref.ids.gamma,
+    host_ref.gamma = particles.find(pdg::gamma());
+    CELER_VALIDATE(host_ref.gamma,
                    << "missing gamma particles (required for "
                    << this->description() << ")");
 
@@ -65,7 +65,7 @@ RayleighModel::RayleighModel(ActionId id,
 auto RayleighModel::applicability() const -> SetApplicability
 {
     Applicability rayleigh_scattering;
-    rayleigh_scattering.particle = this->host_ref().ids.gamma;
+    rayleigh_scattering.particle = this->host_ref().gamma;
     rayleigh_scattering.lower = zero_quantity();
     rayleigh_scattering.upper = units::MevEnergy{1e+8};
 
@@ -102,15 +102,6 @@ void RayleighModel::execute(CoreParams const&, CoreStateDevice&) const
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId RayleighModel::action_id() const
-{
-    return this->host_ref().ids.action;
-}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/em/model/RayleighModel.hh
+++ b/src/celeritas/em/model/RayleighModel.hh
@@ -25,7 +25,7 @@ class ParticleParams;
 /*!
  * Set up and launch Rayleigh scattering.
  */
-class RayleighModel final : public Model
+class RayleighModel final : public Model, public ConcreteAction
 {
   public:
     //@{
@@ -53,18 +53,6 @@ class RayleighModel final : public Model
 
     // Apply the interaction kernel to device data
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "scat-rayleigh"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by Rayleigh scattering";
-    }
 
     //! Access Rayleigh data on the host
     HostRef const& host_ref() const { return mirror_.host_ref(); }

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -39,7 +39,8 @@ RelativisticBremModel::RelativisticBremModel(ActionId id,
                                              MaterialParams const& materials,
                                              SPConstImported data,
                                              bool enable_lpm)
-    : imported_(data,
+    : ConcreteAction(id, "brems-rel", "interact by relativistic bremsstrahlung")
+    , imported_(data,
                 particles,
                 ImportProcessClass::e_brems,
                 ImportModelClass::e_brems_lpm,
@@ -49,7 +50,6 @@ RelativisticBremModel::RelativisticBremModel(ActionId id,
 
     HostValue host_ref;
 
-    host_ref.ids.action = id;
     host_ref.ids.electron = particles.find(pdg::electron());
     host_ref.ids.positron = particles.find(pdg::positron());
     host_ref.ids.gamma = particles.find(pdg::gamma());
@@ -124,15 +124,6 @@ void RelativisticBremModel::execute(CoreParams const&, CoreStateDevice&) const
 #endif
 
 //!@}
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId RelativisticBremModel::action_id() const
-{
-    return this->host_ref().ids.action;
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Build RelativisticBremData (lpm_table and elem_data).

--- a/src/celeritas/em/model/RelativisticBremModel.hh
+++ b/src/celeritas/em/model/RelativisticBremModel.hh
@@ -27,7 +27,7 @@ class ParticleParams;
  * Set up and launch the relativistic Bremsstrahlung model for high-energy
  * electrons and positrons with the Landau-Pomeranchuk-Migdal (LPM) effect
  */
-class RelativisticBremModel final : public Model
+class RelativisticBremModel final : public Model, public ConcreteAction
 {
   public:
     //@{
@@ -56,18 +56,6 @@ class RelativisticBremModel final : public Model
 
     // Apply the interaction kernel to device data
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "brems-rel"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by relativistic bremsstrahlung";
-    }
 
     //! Access data on the host
     HostRef const& host_ref() const { return data_.host_ref(); }

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -43,7 +43,9 @@ SeltzerBergerModel::SeltzerBergerModel(ActionId id,
                                        MaterialParams const& materials,
                                        SPConstImported data,
                                        ReadData load_sb_table)
-    : imported_(data,
+    : ConcreteAction(
+        id, "brems-sb", "interact by Seltzer-Berger bremsstrahlung")
+    , imported_(data,
                 particles,
                 ImportProcessClass::e_brems,
                 ImportModelClass::e_brems_sb,
@@ -57,7 +59,6 @@ SeltzerBergerModel::SeltzerBergerModel(ActionId id,
     HostVal<SeltzerBergerData> host_data;
 
     // Save IDs
-    host_data.ids.action = id;
     host_data.ids.electron = particles.find(pdg::electron());
     host_data.ids.positron = particles.find(pdg::positron());
     host_data.ids.gamma = particles.find(pdg::gamma());
@@ -139,15 +140,6 @@ void SeltzerBergerModel::execute(CoreParams const&, CoreStateDevice&) const
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId SeltzerBergerModel::action_id() const
-{
-    return this->host_ref().ids.action;
-}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/em/model/SeltzerBergerModel.hh
+++ b/src/celeritas/em/model/SeltzerBergerModel.hh
@@ -46,7 +46,7 @@ class ParticleParams;
  * screened nuclei and orbital electrons of neutral atoms with Z = 1–100", At.
  * Data Nucl. Data Tables 35, 345–418.
  */
-class SeltzerBergerModel final : public Model
+class SeltzerBergerModel final : public Model, public ConcreteAction
 {
   public:
     //!@{
@@ -76,18 +76,6 @@ class SeltzerBergerModel final : public Model
 
     // Apply the interaction kernel
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "brems-sb"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by Seltzer-Berger bremsstrahlung";
-    }
 
     //! Access SB data on the host
     HostRef const& host_ref() const { return data_.host_ref(); }

--- a/src/celeritas/neutron/data/NeutronElasticData.hh
+++ b/src/celeritas/neutron/data/NeutronElasticData.hh
@@ -47,19 +47,6 @@ struct ChipsDiffXsCoefficients
 
 //---------------------------------------------------------------------------//
 /*!
- * Model and particles IDs for neutron--nucleus elastic scattering.
- */
-struct NeutronElasticIds
-{
-    ActionId action;
-    ParticleId neutron;
-
-    //! Whether the IDs are assigned
-    explicit CELER_FUNCTION operator bool() const { return action && neutron; }
-};
-
-//---------------------------------------------------------------------------//
-/*!
  * Device data for creating an interactor.
  */
 template<Ownership W, MemSpace M>
@@ -76,8 +63,8 @@ struct NeutronElasticData
 
     //// MEMBER DATA ////
 
-    //! Model and particle IDs
-    NeutronElasticIds ids;
+    //! ID of a neutron
+    ParticleId neutron;
 
     //! Particle mass * c^2 [MeV]
     units::MevMass neutron_mass;
@@ -107,7 +94,7 @@ struct NeutronElasticData
     //! Whether the data are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return ids && neutron_mass > zero_quantity() && !micro_xs.empty()
+        return neutron && neutron_mass > zero_quantity() && !micro_xs.empty()
                && !coeffs.empty() && !reals.empty();
     }
 
@@ -116,7 +103,7 @@ struct NeutronElasticData
     NeutronElasticData& operator=(NeutronElasticData<W2, M2> const& other)
     {
         CELER_EXPECT(other);
-        ids = other.ids;
+        neutron = other.neutron;
         neutron_mass = other.neutron_mass;
         micro_xs = other.micro_xs;
         coeffs = other.coeffs;

--- a/src/celeritas/neutron/data/NeutronInelasticData.hh
+++ b/src/celeritas/neutron/data/NeutronInelasticData.hh
@@ -23,8 +23,7 @@ namespace celeritas
  */
 struct NeutronInelasticScalars
 {
-    // Action and particle IDs
-    ActionId action_id;
+    // Particle IDs
     ParticleId neutron_id;
     ParticleId proton_id;
 
@@ -45,8 +44,7 @@ struct NeutronInelasticScalars
     //! Whether data are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return action_id && neutron_id && proton_id
-               && neutron_mass > zero_quantity()
+        return neutron_id && proton_id && neutron_mass > zero_quantity()
                && neutron_mass > zero_quantity();
     }
 };

--- a/src/celeritas/neutron/interactor/ChipsNeutronElasticInteractor.hh
+++ b/src/celeritas/neutron/interactor/ChipsNeutronElasticInteractor.hh
@@ -98,7 +98,7 @@ CELER_FUNCTION ChipsNeutronElasticInteractor::ChipsNeutronElasticInteractor(
     , sample_phi_(0, 2 * constants::pi)
     , sample_momentum_square_(shared_, target_, neutron_p_)
 {
-    CELER_EXPECT(particle.particle_id() == shared_.ids.neutron);
+    CELER_EXPECT(particle.particle_id() == shared_.neutron);
 }
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/neutron/model/ChipsNeutronElasticModel.cc
+++ b/src/celeritas/neutron/model/ChipsNeutronElasticModel.cc
@@ -33,6 +33,9 @@ ChipsNeutronElasticModel::ChipsNeutronElasticModel(
     ParticleParams const& particles,
     MaterialParams const& materials,
     ReadData load_data)
+    : ConcreteAction(id,
+                     "neutron-elastic-chips",
+                     "interact by neutron elastic scattering (CHIPS)")
 {
     CELER_EXPECT(id);
     CELER_EXPECT(load_data);
@@ -40,15 +43,14 @@ ChipsNeutronElasticModel::ChipsNeutronElasticModel(
     HostVal<NeutronElasticData> data;
 
     // Save IDs
-    data.ids.action = id;
-    data.ids.neutron = particles.find(pdg::neutron());
+    data.neutron = particles.find(pdg::neutron());
 
-    CELER_VALIDATE(data.ids.neutron,
+    CELER_VALIDATE(data.neutron,
                    << "missing neutron particles (required for "
                    << this->description() << ")");
 
     // Save particle properties
-    data.neutron_mass = particles.get(data.ids.neutron).mass();
+    data.neutron_mass = particles.get(data.neutron).mass();
 
     // Load neutron elastic cross section data
     CollectionBuilder micro_xs{&data.micro_xs};
@@ -81,7 +83,7 @@ ChipsNeutronElasticModel::ChipsNeutronElasticModel(
 auto ChipsNeutronElasticModel::applicability() const -> SetApplicability
 {
     Applicability neutron_applic;
-    neutron_applic.particle = this->host_ref().ids.neutron;
+    neutron_applic.particle = this->host_ref().neutron;
     neutron_applic.lower = this->host_ref().min_valid_energy();
     neutron_applic.upper = this->host_ref().max_valid_energy();
 
@@ -121,15 +123,6 @@ void ChipsNeutronElasticModel::execute(CoreParams const&, CoreStateDevice&) cons
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the model ID for this model.
- */
-ActionId ChipsNeutronElasticModel::action_id() const
-{
-    return this->host_ref().ids.action;
-}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/neutron/model/ChipsNeutronElasticModel.hh
+++ b/src/celeritas/neutron/model/ChipsNeutronElasticModel.hh
@@ -27,7 +27,7 @@ class ParticleParams;
 /*!
  * Set up and launch the neutron elastic CHIPS model interaction.
  */
-class ChipsNeutronElasticModel final : public Model
+class ChipsNeutronElasticModel final : public Model, public ConcreteAction
 {
   public:
     //!@{
@@ -56,18 +56,6 @@ class ChipsNeutronElasticModel final : public Model
 
     // Apply the interaction kernel to device data
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final { return "neutron-elastic-chips"; }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by neutron elastic scattering (CHIPS)";
-    }
 
     //!@{
     //! Access model data

--- a/src/celeritas/neutron/model/NeutronInelasticModel.cc
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.cc
@@ -33,6 +33,9 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
                                              MaterialParams const& materials,
                                              CascadeOptions const& options,
                                              ReadData load_data)
+    : ConcreteAction(id,
+                     "neutron-inelastic-bertini",
+                     "interact by neutron inelastic (Bertini)")
 {
     CELER_EXPECT(id);
     CELER_EXPECT(load_data);
@@ -40,7 +43,6 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
     HostVal<NeutronInelasticData> data;
 
     // Save IDs
-    data.scalars.action_id = id;
     data.scalars.neutron_id = particles.find(pdg::neutron());
     data.scalars.proton_id = particles.find(pdg::proton());
 
@@ -140,15 +142,6 @@ void NeutronInelasticModel::execute(CoreParams const&, CoreStateDevice&) const
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the acition ID for this model.
- */
-ActionId NeutronInelasticModel::action_id() const
-{
-    return this->host_ref().scalars.action_id;
-}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/neutron/model/NeutronInelasticModel.hh
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.hh
@@ -28,7 +28,7 @@ class ParticleParams;
 /*!
  * Set up and launch the neutron inelastic model interaction.
  */
-class NeutronInelasticModel final : public Model
+class NeutronInelasticModel final : public Model, public ConcreteAction
 {
   public:
     //!@{
@@ -58,21 +58,6 @@ class NeutronInelasticModel final : public Model
 
     // Apply the interaction kernel to device data
     void execute(CoreParams const&, CoreStateDevice&) const final;
-
-    // ID of the model
-    ActionId action_id() const final;
-
-    //! Short name for the interaction kernel
-    std::string_view label() const final
-    {
-        return "neutron-inelastic-bertini";
-    }
-
-    //! Short description of the post-step action
-    std::string_view description() const final
-    {
-        return "interact by neutron inelastic (Bertini)";
-    }
 
     //!@{
     //! Access model data

--- a/test/celeritas/em/EPlusGG.test.cc
+++ b/test/celeritas/em/EPlusGG.test.cc
@@ -32,8 +32,8 @@ class EPlusGGInteractorTest : public InteractorHostTestBase
     void SetUp() override
     {
         auto const& params = *this->particle_params();
-        data_.ids.positron = params.find(pdg::positron());
-        data_.ids.gamma = params.find(pdg::gamma());
+        data_.positron = params.find(pdg::positron());
+        data_.gamma = params.find(pdg::gamma());
         data_.electron_mass = params.get(params.find(pdg::electron())).mass();
 
         // Set default particle to incident 10 MeV positron
@@ -53,7 +53,7 @@ class EPlusGGInteractorTest : public InteractorHostTestBase
 
         auto const& gamma1 = interaction.secondaries.front();
         EXPECT_TRUE(gamma1);
-        EXPECT_EQ(data_.ids.gamma, gamma1.particle_id);
+        EXPECT_EQ(data_.gamma, gamma1.particle_id);
 
         EXPECT_GT(this->particle_track().energy().value()
                       + 2 * data_.electron_mass.value(),
@@ -63,7 +63,7 @@ class EPlusGGInteractorTest : public InteractorHostTestBase
 
         auto const& gamma2 = interaction.secondaries.back();
         EXPECT_TRUE(gamma2);
-        EXPECT_EQ(data_.ids.gamma, gamma2.particle_id);
+        EXPECT_EQ(data_.gamma, gamma2.particle_id);
         EXPECT_GT(this->particle_track().energy().value()
                       + 2 * data_.electron_mass.value(),
                   gamma2.energy.value());

--- a/test/celeritas/em/Rayleigh.test.cc
+++ b/test/celeritas/em/Rayleigh.test.cc
@@ -41,7 +41,7 @@ class RayleighInteractorTest : public InteractorHostTestBase
         Base::set_particle_params(
             {{"gamma", pdg::gamma(), zero, zero, stable_decay_constant}});
         auto const& particles = *this->particle_params();
-        model_ref_.ids.gamma = particles.find(pdg::gamma());
+        model_ref_.gamma = particles.find(pdg::gamma());
 
         // Setup MaterialView
         MaterialParams::Input inp;


### PR DESCRIPTION
As @sethrj pointed out, the only place we currently use the action IDs for the physics models is in the model class itself (where it's returned). This removes the action IDs from the model device data and stores them directly in the model class instead.