### PR TITLE
Refactor GenericGrid classes to more closely mimic behavior of ValueGrid classes

### DIFF
--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -47,6 +47,7 @@ list(APPEND SOURCES
   global/detail/ActionSequence.cc
   global/detail/PinnedAllocator.cc
   grid/GenericGridBuilder.cc
+  grid/GenericGridInserter.cc
   grid/ValueGridBuilder.cc
   grid/ValueGridInserter.cc
   grid/ValueGridType.cc

--- a/src/celeritas/grid/GenericGridBuilder.cc
+++ b/src/celeritas/grid/GenericGridBuilder.cc
@@ -7,67 +7,25 @@
 //---------------------------------------------------------------------------//
 #include "GenericGridBuilder.hh"
 
-#include "celeritas/io/ImportPhysicsVector.hh"
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with pointers to data that will be modified.
+ * Construct the builder from imported Geant grids.
  */
-GenericGridBuilder::GenericGridBuilder(Items<real_type>* reals) : reals_{reals}
+std::unique_ptr<GenericGridBuilder>
+GenericGridBuilder::from_geant(SpanConstDbl grid, SpanConstDbl values)
 {
-    CELER_EXPECT(reals);
+    return std::make_unique<GenericGridBuilder>(grid, values);
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Add a grid of generic data with linear interpolation.
+ * Construct the builder directly from grids.
  */
-auto GenericGridBuilder::operator()(SpanConstFlt grid, SpanConstFlt values)
-    -> Grid
+GenericGridBuilder::GenericGridBuilder(SpanConstDbl grid, SpanConstDbl values)
+    : grid_(grid), values_(values)
 {
-    return this->insert_impl(grid, values);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Add a grid of generic data with linear interpolation.
- */
-auto GenericGridBuilder::operator()(SpanConstDbl grid, SpanConstDbl values)
-    -> Grid
-{
-    return this->insert_impl(grid, values);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Add a grid from an imported physics vector.
- */
-auto GenericGridBuilder::operator()(ImportPhysicsVector const& pvec) -> Grid
-{
-    CELER_EXPECT(pvec.vector_type == ImportPhysicsVectorType::free);
-    return this->insert_impl(make_span(pvec.x), make_span(pvec.y));
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Add a grid from container references.
- */
-template<class T>
-auto GenericGridBuilder::insert_impl(Span<T const> grid, Span<T const> values)
-    -> Grid
-{
-    CELER_EXPECT(grid.size() >= 2);
-    CELER_EXPECT(grid.front() <= grid.back());
-    CELER_EXPECT(values.size() == grid.size());
-
-    Grid result;
-    result.grid = reals_.insert_back(grid.begin(), grid.end());
-    result.value = reals_.insert_back(values.begin(), values.end());
-
-    CELER_ENSURE(result);
-    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/grid/GenericGridInserter.cc
+++ b/src/celeritas/grid/GenericGridInserter.cc
@@ -1,0 +1,83 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/grid/GenericGridInserter.cc
+//---------------------------------------------------------------------------//
+#include "GenericGridInserter.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with collections to be populated.
+ */
+GenericGridSingleInserter::GenericGridSingleInserter(RealCollection* reals)
+    : reals_(reals)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add a grid of generic data with linear interpolation.
+ */
+GenericGridData
+GenericGridSingleInserter::operator()(SpanConstFlt grid, SpanConstFlt values)
+{
+    return this->insert_impl(grid, values);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add a grid of generic data with linear interpolation.
+ */
+GenericGridData
+GenericGridSingleInserter::operator()(SpanConstDbl grid, SpanConstDbl values)
+{
+    return this->insert_impl(grid, values);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add an imported physics vector as a generic grid.
+ */
+GenericGridData
+GenericGridSingleInserter::operator()(ImportPhysicsVector const& vec)
+{
+    return this->insert_impl(make_span(vec.x), make_span(vec.y));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add an imported physics vector as a generic grid.
+ */
+GenericGridData GenericGridSingleInserter::operator()()
+{
+    return GenericGridData{};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add a grid of generic data with linear interpolation.
+ *
+ * This is templated to support real_type being single or double precision.
+ */
+template<class T>
+GenericGridData
+GenericGridSingleInserter::insert_impl(Span<T const> grid, Span<T const> values)
+{
+    CELER_EXPECT(grid.size() >= 2);
+    CELER_EXPECT(grid.front() <= grid.back());
+    CELER_EXPECT(values.size() == grid.size());
+
+    GenericGridData grid_data;
+    grid_data.grid = reals_.insert_back(grid.begin(), grid.end());
+    grid_data.value = reals_.insert_back(values.begin(), values.end());
+
+    CELER_ENSURE(grid_data);
+    return grid_data;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/neutron/model/ChipsNeutronElasticModel.cc
+++ b/src/celeritas/neutron/model/ChipsNeutronElasticModel.cc
@@ -12,7 +12,7 @@
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackExecutor.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
+#include "celeritas/grid/GenericGridInserter.hh"
 #include "celeritas/io/ImportPhysicsTable.hh"
 #include "celeritas/io/ImportPhysicsVector.hh"
 #include "celeritas/mat/MaterialParams.hh"
@@ -53,12 +53,14 @@ ChipsNeutronElasticModel::ChipsNeutronElasticModel(
     data.neutron_mass = particles.get(data.neutron).mass();
 
     // Load neutron elastic cross section data
-    CollectionBuilder micro_xs{&data.micro_xs};
-    GenericGridBuilder build_grid{&data.reals};
+    // CollectionBuilder micro_xs{&data.micro_xs};
+    // GenericGridBuilder build_grid{&data.reals};
+    GenericGridInserter insert_grid{&data.reals, &data.micro_xs};
     for (auto el_id : range(ElementId{materials.num_elements()}))
     {
         AtomicNumber z = materials.get(el_id).atomic_number();
-        micro_xs.push_back(build_grid(load_data(z)));
+        insert_grid(load_data(z));
+        // micro_xs.push_back(build_grid(load_data(z)));
     }
     CELER_ASSERT(data.micro_xs.size() == materials.num_elements());
 

--- a/src/celeritas/neutron/model/ChipsNeutronElasticModel.cc
+++ b/src/celeritas/neutron/model/ChipsNeutronElasticModel.cc
@@ -53,14 +53,11 @@ ChipsNeutronElasticModel::ChipsNeutronElasticModel(
     data.neutron_mass = particles.get(data.neutron).mass();
 
     // Load neutron elastic cross section data
-    // CollectionBuilder micro_xs{&data.micro_xs};
-    // GenericGridBuilder build_grid{&data.reals};
     GenericGridInserter insert_grid{&data.reals, &data.micro_xs};
     for (auto el_id : range(ElementId{materials.num_elements()}))
     {
         AtomicNumber z = materials.get(el_id).atomic_number();
         insert_grid(load_data(z));
-        // micro_xs.push_back(build_grid(load_data(z)));
     }
     CELER_ASSERT(data.micro_xs.size() == materials.num_elements());
 

--- a/src/celeritas/neutron/model/NeutronInelasticModel.cc
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.cc
@@ -11,7 +11,7 @@
 #include "corecel/math/Quantity.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
+#include "celeritas/grid/GenericGridInserter.hh"
 #include "celeritas/io/ImportPhysicsVector.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/phys/InteractionApplier.hh"
@@ -56,12 +56,14 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
     CELER_EXPECT(data.scalars);
 
     // Load neutron inelastic cross section data
-    CollectionBuilder micro_xs{&data.micro_xs};
-    GenericGridBuilder build_grid{&data.reals};
+    // CollectionBuilder micro_xs{&data.micro_xs};
+    // GenericGridBuilder build_grid{&data.reals};
+    GenericGridInserter insert_grid{&data.reals, &data.micro_xs};
     for (auto el_id : range(ElementId{materials.num_elements()}))
     {
         AtomicNumber z = materials.get(el_id).atomic_number();
-        micro_xs.push_back(build_grid(load_data(z)));
+        // micro_xs.push_back(build_grid(load_data(z)));
+        insert_grid(load_data(z));
     }
     CELER_ASSERT(data.micro_xs.size() == materials.num_elements());
 
@@ -79,9 +81,11 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
         CELER_ASSERT(channel_data.par.slope > 0);
         xs_params.push_back(channel_data.par);
 
-        GenericGridBuilder build_grid{&data.reals};
-        make_builder(&data.nucleon_xs)
-            .push_back(build_grid(bins, make_span(channel_data.xs)));
+        // GenericGridBuilder build_grid{&data.reals};
+        // make_builder(&data.nucleon_xs)
+        //     .push_back(build_grid(bins, make_span(channel_data.xs)));
+        GenericGridInserter insert_grid{&data.reals, &data.nucleon_xs};
+        insert_grid(bins, make_span(channel_data.xs));
     }
     CELER_ASSERT(data.nucleon_xs.size() == num_channels);
     CELER_ASSERT(data.xs_params.size() == data.nucleon_xs.size());

--- a/src/celeritas/neutron/model/NeutronInelasticModel.cc
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.cc
@@ -56,13 +56,10 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
     CELER_EXPECT(data.scalars);
 
     // Load neutron inelastic cross section data
-    // CollectionBuilder micro_xs{&data.micro_xs};
-    // GenericGridBuilder build_grid{&data.reals};
     GenericGridInserter insert_grid{&data.reals, &data.micro_xs};
     for (auto el_id : range(ElementId{materials.num_elements()}))
     {
         AtomicNumber z = materials.get(el_id).atomic_number();
-        // micro_xs.push_back(build_grid(load_data(z)));
         insert_grid(load_data(z));
     }
     CELER_ASSERT(data.micro_xs.size() == materials.num_elements());
@@ -81,9 +78,6 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
         CELER_ASSERT(channel_data.par.slope > 0);
         xs_params.push_back(channel_data.par);
 
-        // GenericGridBuilder build_grid{&data.reals};
-        // make_builder(&data.nucleon_xs)
-        //     .push_back(build_grid(bins, make_span(channel_data.xs)));
         GenericGridInserter insert_grid{&data.reals, &data.nucleon_xs};
         insert_grid(bins, make_span(channel_data.xs));
     }

--- a/src/celeritas/optical/OpticalPropertyParams.cc
+++ b/src/celeritas/optical/OpticalPropertyParams.cc
@@ -16,8 +16,7 @@
 #include "corecel/math/Algorithms.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/GenericGridInserter.hh"
 #include "celeritas/io/ImportData.hh"
 
 namespace celeritas
@@ -55,8 +54,8 @@ OpticalPropertyParams::from_import(ImportData const& data)
 OpticalPropertyParams::OpticalPropertyParams(Input const& inp)
 {
     HostVal<OpticalPropertyData> data;
-    CollectionBuilder refractive_index{&data.refractive_index};
-    GenericGridBuilder build_grid(&data.reals);
+    GenericGridInserter insert_refractive_index{&data.reals,
+                                                &data.refractive_index};
     for (auto const& mat : inp.data)
     {
         // Store refractive index tabulated as a function of photon energy
@@ -64,7 +63,7 @@ OpticalPropertyParams::OpticalPropertyParams(Input const& inp)
         if (ri_vec.x.empty())
         {
             // No refractive index data for this material
-            refractive_index.push_back({});
+            insert_refractive_index();
             continue;
         }
 
@@ -77,9 +76,11 @@ OpticalPropertyParams::OpticalPropertyParams(Input const& inp)
                        << "refractive index values are not monotonically "
                           "increasing");
 
-        refractive_index.push_back(build_grid(ri_vec));
+        // refractive_index.push_back(build_grid(ri_vec));
+        insert_refractive_index(ri_vec);
     }
-    CELER_ASSERT(refractive_index.size() == inp.data.size());
+    // CELER_ASSERT(refractive_index.size() == inp.data.size());
+    CELER_ASSERT(data.refractive_index.size() == inp.data.size());
 
     data_ = CollectionMirror<OpticalPropertyData>{std::move(data)};
     CELER_ENSURE(data_ || inp.data.empty());

--- a/src/celeritas/optical/OpticalPropertyParams.cc
+++ b/src/celeritas/optical/OpticalPropertyParams.cc
@@ -79,7 +79,6 @@ OpticalPropertyParams::OpticalPropertyParams(Input const& inp)
         // refractive_index.push_back(build_grid(ri_vec));
         insert_refractive_index(ri_vec);
     }
-    // CELER_ASSERT(refractive_index.size() == inp.data.size());
     CELER_ASSERT(data.refractive_index.size() == inp.data.size());
 
     data_ = CollectionMirror<OpticalPropertyData>{std::move(data)};

--- a/src/celeritas/optical/ScintillationParams.cc
+++ b/src/celeritas/optical/ScintillationParams.cc
@@ -14,7 +14,7 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/math/SoftEqual.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
+#include "celeritas/grid/GenericGridInserter.hh"
 #include "celeritas/io/ImportData.hh"
 #include "celeritas/phys/ParticleParams.hh"
 
@@ -182,7 +182,7 @@ ScintillationParams::ScintillationParams(Input const& input)
 
         // Store particle spectra
         CELER_EXPECT(!input.particles.empty());
-        GenericGridBuilder build_grid(&host_data.reals);
+        GenericGridSingleInserter insert_grid(&host_data.reals);
         CollectionBuilder build_particles(&host_data.particles);
 
         for (auto spec : input.particles)
@@ -191,7 +191,7 @@ ScintillationParams::ScintillationParams(Input const& input)
                            << "particle yield vector is not assigned "
                               "correctly");
             ParticleScintillationSpectrum part_spec;
-            part_spec.yield_vector = build_grid(spec.yield_vector);
+            part_spec.yield_vector = insert_grid(spec.yield_vector);
             auto comps = this->build_components(spec.components);
             part_spec.components
                 = build_components.insert_back(comps.begin(), comps.end());

--- a/test/celeritas/grid/GenericCalculator.test.cc
+++ b/test/celeritas/grid/GenericCalculator.test.cc
@@ -13,7 +13,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/Ref.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
+#include "celeritas/grid/GenericGridInserter.hh"
 
 #include "celeritas_test.hh"
 
@@ -36,8 +36,8 @@ class GenericCalculatorTest : public Test
         std::vector<real_type> const grid = {1.0, 2.0, 1e2, 1e4};
         std::vector<real_type> const value = {4.0, 8.0, 8.0, 2.0};
 
-        GenericGridBuilder build_grid(&reals_);
-        grid_ = build_grid(make_span(grid), make_span(value));
+        GenericGridSingleInserter insert_grid(&reals_);
+        grid_ = insert_grid(make_span(grid), make_span(value));
         CELER_ENSURE(grid_);
     }
 

--- a/test/celeritas/grid/GenericGridBuilder.test.cc
+++ b/test/celeritas/grid/GenericGridBuilder.test.cc
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <vector>
 
+#include "celeritas/grid/GenericGridInserter.hh"
 #include "celeritas/io/ImportPhysicsVector.hh"
 
 #include "celeritas_test.hh"
@@ -27,16 +28,33 @@ namespace test
 class GenericGridBuilderTest : public ::celeritas::test::Test
 {
   protected:
-    GenericGridBuilder make_builder() { return GenericGridBuilder(&scalars_); }
+    using GridIndex = OpaqueId<struct GenericGridTag_>;
 
     static Span<real_type const> span_grid() { return make_span(grid_); }
-
     static Span<real_type const> span_values() { return make_span(values_); }
 
     Collection<real_type, Ownership::value, MemSpace::host> scalars_;
+    Collection<GenericGridData, Ownership::value, MemSpace::host, GridIndex> grids_;
 
     constexpr static real_type grid_[] = {0.0, 0.4, 0.9, 1.3};
     constexpr static real_type values_[] = {-31.0, 12.1, 15.5, 92.0};
+
+    void check(GridIndex grid_index) const
+    {
+        ASSERT_TRUE(static_cast<bool>(grid_index));
+        ASSERT_EQ(1, grids_.size());
+        ASSERT_LT(grid_index, grids_.size());
+
+        GenericGridData const& grid_data = grids_[grid_index];
+
+        ASSERT_TRUE(grid_data);
+        ASSERT_EQ(8, scalars_.size());
+        ASSERT_EQ(4, grid_data.grid.size());
+        ASSERT_EQ(4, grid_data.value.size());
+
+        EXPECT_VEC_EQ(grid_, scalars_[grid_data.grid]);
+        EXPECT_VEC_EQ(values_, scalars_[grid_data.value]);
+    }
 };
 
 //---------------------------------------------------------------------------//
@@ -45,37 +63,20 @@ class GenericGridBuilderTest : public ::celeritas::test::Test
 
 TEST_F(GenericGridBuilderTest, build_span)
 {
-    auto builder = make_builder();
+    GenericGridBuilder builder(span_grid(), span_values());
+    GridIndex grid_index
+        = builder.build(GenericGridInserter{&scalars_, &grids_});
 
-    GenericGridData grid_data = builder(span_grid(), span_values());
-
-    ASSERT_TRUE(grid_data);
-    ASSERT_EQ(8, scalars_.size());
-    ASSERT_EQ(4, grid_data.grid.size());
-    ASSERT_EQ(4, grid_data.value.size());
-
-    EXPECT_VEC_SOFT_EQ(grid_, scalars_[grid_data.grid]);
-    EXPECT_VEC_SOFT_EQ(values_, scalars_[grid_data.value]);
+    check(grid_index);
 }
 
-TEST_F(GenericGridBuilderTest, TEST_IF_CELERITAS_DOUBLE(build_vec))
+TEST_F(GenericGridBuilderTest, TEST_IF_CELERITAS_DOUBLE(from_geant))
 {
-    ImportPhysicsVector vect;
-    vect.vector_type = ImportPhysicsVectorType::free;
-    vect.x = std::vector<double>(span_grid().begin(), span_grid().end());
-    vect.y = std::vector<double>(span_values().begin(), span_values().end());
+    auto builder = GenericGridBuilder::from_geant(span_grid(), span_values());
+    GridIndex grid_index
+        = builder->build(GenericGridInserter{&scalars_, &grids_});
 
-    auto builder = make_builder();
-
-    GenericGridData grid_data = builder(vect);
-
-    ASSERT_TRUE(grid_data);
-    ASSERT_EQ(8, scalars_.size());
-    ASSERT_EQ(4, grid_data.grid.size());
-    ASSERT_EQ(4, grid_data.value.size());
-
-    EXPECT_VEC_SOFT_EQ(grid_, scalars_[grid_data.grid]);
-    EXPECT_VEC_SOFT_EQ(values_, scalars_[grid_data.value]);
+    check(grid_index);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/grid/GenericGridBuilder.test.cc
+++ b/test/celeritas/grid/GenericGridBuilder.test.cc
@@ -30,14 +30,14 @@ class GenericGridBuilderTest : public ::celeritas::test::Test
   protected:
     using GridIndex = OpaqueId<struct GenericGridTag_>;
 
-    static Span<real_type const> span_grid() { return make_span(grid_); }
-    static Span<real_type const> span_values() { return make_span(values_); }
+    static Span<double const> span_grid() { return make_span(grid_); }
+    static Span<double const> span_values() { return make_span(values_); }
 
     Collection<real_type, Ownership::value, MemSpace::host> scalars_;
     Collection<GenericGridData, Ownership::value, MemSpace::host, GridIndex> grids_;
 
-    constexpr static real_type grid_[] = {0.0, 0.4, 0.9, 1.3};
-    constexpr static real_type values_[] = {-31.0, 12.1, 15.5, 92.0};
+    constexpr static double grid_[] = {0.0, 0.4, 0.9, 1.3};
+    constexpr static double values_[] = {-31.0, 12.1, 15.5, 92.0};
 
     void check(GridIndex grid_index) const
     {
@@ -70,7 +70,7 @@ TEST_F(GenericGridBuilderTest, build_span)
     check(grid_index);
 }
 
-TEST_F(GenericGridBuilderTest, TEST_IF_CELERITAS_DOUBLE(from_geant))
+TEST_F(GenericGridBuilderTest, from_geant)
 {
     auto builder = GenericGridBuilder::from_geant(span_grid(), span_values());
     GridIndex grid_index

--- a/test/celeritas/grid/GenericGridBuilder.test.cc
+++ b/test/celeritas/grid/GenericGridBuilder.test.cc
@@ -52,8 +52,8 @@ class GenericGridBuilderTest : public ::celeritas::test::Test
         ASSERT_EQ(4, grid_data.grid.size());
         ASSERT_EQ(4, grid_data.value.size());
 
-        EXPECT_VEC_EQ(grid_, scalars_[grid_data.grid]);
-        EXPECT_VEC_EQ(values_, scalars_[grid_data.value]);
+        EXPECT_VEC_SOFT_EQ(grid_, scalars_[grid_data.grid]);
+        EXPECT_VEC_SOFT_EQ(values_, scalars_[grid_data.value]);
     }
 };
 


### PR DESCRIPTION
Initially, the `GenericGridBuilder` was designed to accept a scalar `Collection` that it would immediately populate with generic grid data, and return a `GenericGridData`. This is the opposite of the `ValueGridBuilder` which we use in `StepLimitBuilders`, which caches the grids to be built and then populates a `Collection` when a `ValueGridInserter` is supplied. I later added the `GenericGridInserter` on top of this to combine the steps of building a `GenericGridData` grid and putting it into a grid `Collection`, returning its new ID in the collection.

To have optical physics more closely mimic the conventions of core physics, I've refactored some of the `GenericGrid` classes. All classes called `Builder` are now intermediate objects which will later supply their grids to classes called `Inserter`, which are responsible for the actual population of grids in a given `Collection`. 

* Previously `GenericGridBuilder` --> now `GenericGridSingleInserter`. The term `Single` is meant to signify that only the real scalar `Collection` is populated, and the direct `GenericGridData` object itself is returned.
* `GenericGridInserter` has mainly the same behavior. Instead of using `GenericGridBuilder` previously it's now updated to use the `GenericGridSingleInserter`.
* New `GenericGridBuilder`. As with `ValueGridBuilder` it caches the raw data for a generic grid and can be called later to populate a `Collection` in the usual `StepLimitBuilder` algorithm. Its `build` method is templated based on the inserter, so that a `GenericGridInserter` that uses different ID types will return the correct ID.

Appropriate changes in existing code have been made to use the right classes. 