### PR TITLE
Hotfix: work around ROCm failures due to Node20 incompatibility

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -45,6 +45,7 @@ jobs:
                 matrix.geometry,
                 matrix.special && '-' || '',
                 matrix.special)}}
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true # TODO: DELETEME, see #1305
     runs-on: ubuntu-latest
     container:
       image: >-

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -24,7 +24,7 @@ jobs:
         special: [null]
         geometry: ["orange", "vecgeom"]
         buildtype: ["debug", "ndebug"]
-        image: ["ubuntu-cuda", "centos-rocm"]
+        image: ["centos-rocm"]
         exclude:
           - geometry: "vecgeom"
             image: "centos-rocm" # VecGeom not installed on HIP
@@ -35,9 +35,6 @@ jobs:
             geometry: "orange"
             buildtype: "reldeb"
             image: "centos-rocm"
-          - geometry: "vecgeom"
-            buildtype: "reldeb"
-            image: "ubuntu-cuda"
     env:
       ASAN_OPTIONS: "detect_leaks=0"
       CELER_TEST_STRICT: 1

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -24,7 +24,7 @@ jobs:
         special: [null]
         geometry: ["orange", "vecgeom"]
         buildtype: ["debug", "ndebug"]
-        image: ["centos-rocm"]
+        image: ["ubuntu-cuda", "centos-rocm"]
         exclude:
           - geometry: "vecgeom"
             image: "centos-rocm" # VecGeom not installed on HIP
@@ -35,6 +35,9 @@ jobs:
             geometry: "orange"
             buildtype: "reldeb"
             image: "centos-rocm"
+          - geometry: "vecgeom"
+            buildtype: "reldeb"
+            image: "ubuntu-cuda"
     env:
       ASAN_OPTIONS: "detect_leaks=0"
       CELER_TEST_STRICT: 1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,36 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-fast:
-    uses: ./.github/workflows/build-fast.yml
-  build-ultralite:
-    uses: ./.github/workflows/build-ultralite.yml
-  doc:
-    uses: ./.github/workflows/doc.yml
-  all-prechecks:
-    needs: [build-fast, build-ultralite, doc]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Success
-      run: "true"
   build-docker:
-    needs: [all-prechecks]
     uses: ./.github/workflows/build-docker.yml
-  build-spack:
-    needs: [all-prechecks]
-    uses: ./.github/workflows/build-spack.yml
-
-  # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
-  all:
-    if: ${{always()}}
-    needs:
-    - build-docker
-    - build-spack
-    runs-on: ubuntu-latest
-    steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{toJSON(needs)}}
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-fast:
+    uses: ./.github/workflows/build-fast.yml
+  build-ultralite:
+    uses: ./.github/workflows/build-ultralite.yml
+  doc:
+    uses: ./.github/workflows/doc.yml
+  all-prechecks:
+    needs: [build-fast, build-ultralite, doc]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Success
+      run: "true"
   build-docker:
+    needs: [all-prechecks]
     uses: ./.github/workflows/build-docker.yml
+  build-spack:
+    needs: [all-prechecks]
+    uses: ./.github/workflows/build-spack.yml
+
+  # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
+  all:
+    if: ${{always()}}
+    needs:
+    - build-docker
+    - build-spack
+    runs-on: ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{toJSON(needs)}}
 
 # vim: set nowrap tw=100:


### PR DESCRIPTION
Docker announced [seven months ago](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) that they're updating a dependency. As of today this results in a failure of our CentOS7 images to check out:
```
Run actions/checkout@v3
 *SNIP*
/usr/bin/docker exec  221dcddabe4baef3675f9ed47bd01bf16f18f1eef9cb6042dd045ff3c82483f7 sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```

See also https://github.com/actions/runner/issues/2906

There's a [temporary solution](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) but we better upgrade our CI images ASAP...