### PR TITLE
Add a helper function to copy a "collection group" back to the host

### DIFF
--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -376,8 +376,8 @@ using StateCollection = Collection<T, W, M, TrackSlotId>;
 template<class T, Ownership W, MemSpace M, class I>
 template<Ownership W2, MemSpace M2>
 Collection<T, W, M, I>::Collection(Collection<T, W2, M2, I> const& other)
-    : storage_(detail::CollectionAssigner<W, M>()(other.storage_))
 {
+    detail::copy_collection(other.storage_, &storage_);
     detail::CollectionStorageValidator<W2>()(this->size(),
                                              other.storage().size());
 }
@@ -385,8 +385,8 @@ Collection<T, W, M, I>::Collection(Collection<T, W2, M2, I> const& other)
 template<class T, Ownership W, MemSpace M, class I>
 template<Ownership W2, MemSpace M2>
 Collection<T, W, M, I>::Collection(Collection<T, W2, M2, I>& other)
-    : storage_(detail::CollectionAssigner<W, M>()(other.storage_))
 {
+    detail::copy_collection(other.storage_, &storage_);
     detail::CollectionStorageValidator<W2>()(this->size(),
                                              other.storage().size());
 }
@@ -396,7 +396,7 @@ template<Ownership W2, MemSpace M2>
 Collection<T, W, M, I>&
 Collection<T, W, M, I>::operator=(Collection<T, W2, M2, I> const& other)
 {
-    storage_ = detail::CollectionAssigner<W, M>()(other.storage_);
+    detail::copy_collection(other.storage_, &storage_);
     detail::CollectionStorageValidator<W2>()(this->size(),
                                              other.storage().size());
     return *this;
@@ -407,7 +407,7 @@ template<Ownership W2, MemSpace M2>
 Collection<T, W, M, I>&
 Collection<T, W, M, I>::operator=(Collection<T, W2, M2, I>& other)
 {
-    storage_ = detail::CollectionAssigner<W, M>()(other.storage_);
+    detail::copy_collection(other.storage_, &storage_);
     detail::CollectionStorageValidator<W2>()(this->size(),
                                              other.storage().size());
     return *this;

--- a/src/corecel/data/CollectionAlgorithms.hh
+++ b/src/corecel/data/CollectionAlgorithms.hh
@@ -40,4 +40,18 @@ void copy_to_host(Collection<T, W, M, I> const& src, Span<T, E> dst)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Create a new host collection from the given collection.
+ *
+ * This is useful for debugging.
+ */
+template<class T, Ownership W, MemSpace M, class I, std::size_t E>
+auto copy_to_host(Collection<T, W, M, I> const& src)
+{
+    Collection<T, Ownership::value, MemSpace::host, I> result;
+    result = src;
+    return result;
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/data/DeviceAllocation.cc
+++ b/src/corecel/data/DeviceAllocation.cc
@@ -57,7 +57,7 @@ DeviceAllocation::DeviceAllocation(size_type bytes, StreamId stream)
  */
 void DeviceAllocation::copy_to_device(SpanConstBytes bytes)
 {
-    CELER_EXPECT(bytes.size() == this->size());
+    CELER_EXPECT(bytes.size() <= this->size());
     if (stream_)
     {
         CELER_DEVICE_CALL_PREFIX(
@@ -83,7 +83,7 @@ void DeviceAllocation::copy_to_device(SpanConstBytes bytes)
  */
 void DeviceAllocation::copy_to_host(SpanBytes bytes) const
 {
-    CELER_EXPECT(bytes.size() == this->size());
+    CELER_EXPECT(bytes.size() <= this->size());
     if (stream_)
     {
         CELER_DEVICE_CALL_PREFIX(

--- a/src/corecel/data/DeviceAllocation.cc
+++ b/src/corecel/data/DeviceAllocation.cc
@@ -19,13 +19,14 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct in unallocated state
+ * Construct in unallocated state.
  */
 DeviceAllocation::DeviceAllocation(StreamId stream)
     : size_{0}, stream_{stream}, data_{nullptr, {stream}}
 {
 }
 
+//---------------------------------------------------------------------------//
 /*!
  * Allocate a buffer with the given number of bytes.
  */

--- a/src/corecel/data/DeviceAllocation.hh
+++ b/src/corecel/data/DeviceAllocation.hh
@@ -23,10 +23,13 @@ namespace celeritas
 /*!
  * Allocate raw uninitialized memory.
  *
- * This class is intended to be used by host-compiler `.hh` code as a bridge to
- * device memory. It allows Storage classes to allocate and manage device
- * memory without using `thrust`, which requires NVCC and propagates that
- * requirement into all upstream code.
+ * This class is intended to be used by host-compiler \c .hh code as a bridge
+ * to device memory. It allows Storage classes to allocate and manage device
+ * memory without using \c thrust, which requires NVCC and propagates that
+ * requirement into all downstream code.
+ *
+ * TODO: remove the stream constructor data members and rely on \c Copier or
+ * \c thrust to do streamed async operations?
  */
 class DeviceAllocation
 {
@@ -61,6 +64,9 @@ class DeviceAllocation
 
     //! Whether memory is allocated
     bool empty() const { return size_ == 0; }
+
+    //! Access the stream, set for asynchonous allocation/copy
+    StreamId stream_id() const { return stream_; }
 
     //// DEVICE ACCESSORS ////
 

--- a/src/corecel/data/DeviceVector.hh
+++ b/src/corecel/data/DeviceVector.hh
@@ -20,12 +20,16 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Host-compiler-friendly vector for uninitialized device-storage data.
+ * Host vector for managing uninitialized device-storage data.
  *
- * This class does *not* perform initialization on the data. The host code must
- * define and copy over suitable data. For more complex data usage (dynamic
- * size increases and assignment without memory reallocation), use \c
- * thrust::device_vector.
+ * This is a class used only in host memory (not passed to kernels) to manage
+ * device allocation and host/device copies.  It does \em not perform
+ * initialization on the data: the host code must define and copy over suitable
+ * data.
+ *
+ * For more complex data usage (dynamic size increases and assignment without
+ * memory reallocation), use \c thrust::device_vector inside a \c .cu file.
+ *
  * When a \c StreamId is passed as the last constructor argument,
  * all memory operations are asynchronous and ordered within that stream.
  *
@@ -34,6 +38,8 @@ namespace celeritas
     myvec.copy_to_device(make_span(hostvec));
     myvec.copy_to_host(make_span(hostvec));
    \endcode
+ *
+ * TODO: remove stream?
  */
 template<class T>
 class DeviceVector
@@ -71,6 +77,9 @@ class DeviceVector
 
     // Swap with another vector
     inline void swap(DeviceVector& other) noexcept;
+
+    // Allocate and copy from host pointers
+    void assign(T const* first, T const* last);
 
     //// ACCESSORS ////
 
@@ -113,13 +122,14 @@ inline void swap(DeviceVector<T>& a, DeviceVector<T>& b) noexcept;
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Construct with a number of allocated elements.
+ * Construct with a stream.
  */
 template<class T>
 DeviceVector<T>::DeviceVector(StreamId stream) : allocation_{stream}, size_{0}
 {
 }
 
+//---------------------------------------------------------------------------//
 /*!
  * Construct with a number of allocated elements.
  */
@@ -129,8 +139,9 @@ DeviceVector<T>::DeviceVector(size_type count)
 {
 }
 
+//---------------------------------------------------------------------------//
 /*!
- * Construct with a number of allocated elements.
+ * Construct with a number of allocated elements and a stream.
  */
 template<class T>
 DeviceVector<T>::DeviceVector(size_type count, StreamId stream)
@@ -148,6 +159,30 @@ void DeviceVector<T>::swap(DeviceVector& other) noexcept
     using std::swap;
     swap(size_, other.size_);
     swap(allocation_, other.allocation_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Allocate and copy from \em host pointers.
+ *
+ * Not exception safe: if the copy fails, the original contents are lost.
+ */
+template<class T>
+void DeviceVector<T>::assign(T const* first, T const* last)
+{
+    auto const new_size = static_cast<size_type>(last - first);
+    if (new_size > size_)
+    {
+        // Reallocate
+        *this = DeviceVector<T>(new_size, allocation_.stream_id());
+    }
+    else if (new_size == 0)
+    {
+        // Deallocate
+        *this = DeviceVector<T>(allocation_.stream_id());
+    }
+
+    this->copy_to_device({first, new_size});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/Ref.hh
+++ b/src/corecel/data/Ref.hh
@@ -73,4 +73,25 @@ decltype(auto) get_ref(T&& obj)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Copy an entire collection group to the host.
+ *
+ * This is mostly useful for debugging and testing. It is \em not performant
+ * and should not be used as part of the stepping loop, since it is likely to
+ * perform many allocations.
+ *
+ * \code
+   auto my_states = make_host_val(states.device_ref());
+ * \endcode
+ */
+template<template<Ownership, MemSpace> class CG, Ownership W, MemSpace M>
+inline auto make_host_val(CG<W, M> const& source)
+{
+    CG<Ownership::value, MemSpace::host> result;
+    // Assign from mutable value since the "state" collections require it
+    result = const_cast<CG<W, M>&>(source);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/data/detail/CollectionImpl.hh
+++ b/src/corecel/data/detail/CollectionImpl.hh
@@ -107,6 +107,9 @@ struct CollectionStorage
 {
     using type = typename CollectionTraits<T, W, M>::SpanT;
     type data;
+
+    inline static constexpr Ownership ownership = W;
+    inline static constexpr MemSpace memspace = M;
 };
 
 //---------------------------------------------------------------------------//
@@ -124,6 +127,9 @@ struct CollectionStorage<T, Ownership::value, MemSpace::host>
     using type = std::vector<T>;
 #endif
     type data;
+
+    inline static constexpr Ownership ownership = Ownership::value;
+    inline static constexpr MemSpace memspace = MemSpace::host;
 };
 
 //! Storage implementation for managed device data
@@ -138,6 +144,9 @@ struct CollectionStorage<T, Ownership::value, MemSpace::device>
     using type = DeviceVector<T>;
 #endif
     type data;
+
+    inline static constexpr Ownership ownership = Ownership::value;
+    inline static constexpr MemSpace memspace = MemSpace::device;
 };
 
 //! Storage implementation for mapped host/device data
@@ -154,6 +163,9 @@ struct CollectionStorage<T, Ownership::value, MemSpace::mapped>
     using type = std::vector<T, PinnedAllocator<T>>;
 #endif
     type data;
+
+    inline static constexpr Ownership ownership = Ownership::value;
+    inline static constexpr MemSpace memspace = MemSpace::mapped;
 };
 
 //---------------------------------------------------------------------------//
@@ -181,99 +193,52 @@ struct CollectionStorageValidator<Ownership::value>
 };
 
 //---------------------------------------------------------------------------//
-//! Assignment semantics for a collection
-template<Ownership W, MemSpace M>
-struct CollectionAssigner
+/*!
+ * Copy assign a collection via its storage.
+ */
+template<class S, class T, Ownership DW, MemSpace DM>
+void copy_collection(S& src, CollectionStorage<T, DW, DM>* dst)
 {
-    template<class T, Ownership W2, MemSpace M2>
-    CollectionStorage<T, W, M>
-    operator()(CollectionStorage<T, W2, M2> const& source)
-    {
-        static_assert(W != Ownership::reference || W2 == W,
-                      "Can't create a reference from a const reference");
-        static_assert(M == M2,
-                      "Collection assignment from a different memory space");
-        return {{source.data.data(), source.data.size()}};
-    }
+    constexpr MemSpace SM = std::remove_const_t<S>::memspace;
+    using DstStorageT = typename CollectionStorage<T, DW, DM>::type;
 
-    template<class T, Ownership W2, MemSpace M2>
-    CollectionStorage<T, W, M> operator()(CollectionStorage<T, W2, M2>& source)
+    auto* data = src.data.data();
+    size_type size = src.data.size();
+
+    if constexpr (DW == Ownership::value)
     {
-        static_assert(M == M2,
-                      "Collection assignment from a different memory space");
+        // Allocate and copy: destination "owns" the memory
+        if constexpr (DM == MemSpace::mapped)
+        {
+            CELER_VALIDATE(celeritas::device().can_map_host_memory(),
+                           << "device " << celeritas::device().device_id()
+                           << " doesn't support unified addressing");
+        }
+        dst->data.assign(data, data + size);
+    }
+    else if constexpr (DM == SM)
+    {
+        constexpr Ownership SW = std::remove_const_t<S>::ownership;
+
         static_assert(
-            !(W == Ownership::reference && W2 == Ownership::const_reference),
-            "Can't create a reference from a const reference");
-        return {{source.data.data(), source.data.size()}};
-    }
-};
+            !(SW == Ownership::const_reference && DW == Ownership::reference),
+            "cannot assign from const reference to reference");
 
-//---------------------------------------------------------------------------//
-//! Assignment semantics for copying to host memory
-template<>
-struct CollectionAssigner<Ownership::value, MemSpace::host>
-{
-    template<class T, Ownership W2>
-    CollectionStorage<T, Ownership::value, MemSpace::host>
-    operator()(CollectionStorage<T, W2, MemSpace::host> const& source)
+        // Copy pointers in same memspace
+        dst->data = DstStorageT{data, size};
+    }
+    else
     {
-        return {{source.data.data(), source.data.data() + source.data.size()}};
+        CELER_VALIDATE(dst->data.size() == size,
+                       << "collection assignment from " << to_cstring(SM)
+                       << " to " << to_cstring(DM)
+                       << " failed: cannot copy from source size " << size
+                       << " to destination size " << dst->data.size());
+
+        Copier<T, SM> copy_to_dst{make_span(dst->data)};
+        copy_to_dst(DM, {data, size});
     }
-
-    template<class T, Ownership W2>
-    CollectionStorage<T, Ownership::value, MemSpace::host>
-    operator()(CollectionStorage<T, W2, MemSpace::device> const& source)
-    {
-        CollectionStorage<T, Ownership::value, MemSpace::host> result{
-            std::vector<T>(source.data.size())};
-        Copier<T, MemSpace::host> copy{
-            {result.data.data(), result.data.size()}};
-        copy(MemSpace::device, {source.data.data(), source.data.size()});
-        return result;
-    }
-};
-
-//---------------------------------------------------------------------------//
-//! Assignment semantics for copying to device memory
-template<>
-struct CollectionAssigner<Ownership::value, MemSpace::device>
-{
-    template<class T>
-    using StorageValDev
-        = CollectionStorage<T, Ownership::value, MemSpace::device>;
-
-    template<class T, Ownership W2, MemSpace M2>
-    StorageValDev<T> operator()(CollectionStorage<T, W2, M2> const& source)
-    {
-        static_assert(M2 == MemSpace::host,
-                      "Can only assign by value from host to device");
-
-        StorageValDev<T> result{
-            typename StorageValDev<T>::type(source.data.size())};
-        result.data.copy_to_device({source.data.data(), source.data.size()});
-        return result;
-    }
-};
-
-//---------------------------------------------------------------------------//
-//! Assignment semantics for copying to mapped memory
-template<>
-struct CollectionAssigner<Ownership::value, MemSpace::mapped>
-{
-    CollectionAssigner()
-    {
-        CELER_VALIDATE(celeritas::device().can_map_host_memory(),
-                       << "Device " << celeritas::device().device_id()
-                       << " doesn't support unified addressing");
-    }
-
-    template<class T, Ownership W2, MemSpace M2>
-    auto operator()(CollectionStorage<T, W2, M2> const& source)
-        -> CollectionStorage<T, Ownership::value, M2>
-    {
-        return {{source.data.data(), source.data.data() + source.data.size()}};
-    }
-};
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/corecel/data/detail/DisabledStorage.hh
+++ b/src/corecel/data/detail/DisabledStorage.hh
@@ -58,6 +58,10 @@ class DisabledStorage
         CELER_ASSERT_UNREACHABLE();
         return nullptr;
     }
+    CELER_FORCEINLINE_FUNCTION void assign(T const*, T const*)
+    {
+        CELER_ASSERT_UNREACHABLE();
+    }
     CELER_FORCEINLINE_FUNCTION void copy_to_device(SpanConstT)
     {
         CELER_ASSERT_UNREACHABLE();

--- a/test/celeritas/geo/HeuristicGeoTestBase.cc
+++ b/test/celeritas/geo/HeuristicGeoTestBase.cc
@@ -11,8 +11,8 @@
 #include <iostream>
 
 #include "corecel/cont/Range.hh"
+#include "corecel/data/CollectionAlgorithms.hh"
 #include "corecel/data/CollectionStateStore.hh"
-#include "corecel/data/Copier.hh"
 #include "corecel/data/Ref.hh"
 #include "corecel/io/Join.hh"
 #include "corecel/io/Repr.hh"
@@ -126,8 +126,7 @@ auto HeuristicGeoTestBase::get_avg_path(PathLengthRef<M> path,
     -> std::vector<real_type>
 {
     std::vector<real_type> result(path.size());
-    Copier<real_type, MemSpace::host> copy_to_host{make_span(result)};
-    copy_to_host(M, path[AllItems<real_type, M>{}]);
+    copy_to_host(path, make_span(result));
 
     return this->get_avg_path_impl(result, num_states);
 }

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -454,15 +454,20 @@ TEST_F(AssignmentTest, TEST_IF_CELER_DEVICE(device_host))
 
         // Now copy correct size
         temp_ref = temp;
+        EXPECT_EQ(1, temp[ItemId<int>{1}]);
+        temp[ItemId<int>{2}] = -1;
         temp_ref = device_val;
+        EXPECT_EQ(2, temp[ItemId<int>{2}]);
     }
     {
         // Assignment from ref
         Value<host> temp;
+        resize(&temp, 4);
         EXPECT_EQ(4, temp.size());
 
         Ref<host> temp_ref{temp};
         temp_ref = device_val;
+        EXPECT_EQ(2, temp[ItemId<int>{2}]);
     }
 }
 

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -590,8 +590,19 @@ TEST_F(CollectionTest, TEST_IF_CELER_DEVICE(device))
 
     // For brevity, only check the first 6 values (they repeat after that)
     result.resize(6);
-    double const expected_result[] = {2.2, 41, 0, 3.333333333333, 41, 0};
+    static double const expected_result[] = {2.2, 41, 0, 3.333333333333, 41, 0};
     EXPECT_VEC_SOFT_EQ(expected_result, result);
+
+    {
+        // Create an in-memory copy of the entire collection group
+        auto host_states = make_host_val(device_states);
+        EXPECT_EQ(1024, host_states.size());
+
+        // Create a track view
+        auto host_ref = make_ref(host_states);
+        MockTrackView mtv{mock_params.host_ref(), host_ref, TrackSlotId{2}};
+        EXPECT_EQ(MockMaterialId{2}, mtv.matid());
+    }
 
     // Check that we can copy back to the device
     MockStateData<Ownership::value, MemSpace::host> host_states;

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -357,6 +357,116 @@ TEST_F(SimpleCollectionTest, TEST_IF_CELER_DEVICE(algo_device))
 }
 
 //---------------------------------------------------------------------------//
+// ASSIGNMENT TESTS
+//---------------------------------------------------------------------------//
+
+class AssignmentTest : public SimpleCollectionTest
+{
+  protected:
+    void SetUp()
+    {
+        CollectionBuilder{&host_val_}.insert_back({0, 1, 2, 3});
+        ASSERT_EQ(4, host_val_.size());
+        host_ref_ = host_val_;
+        ASSERT_EQ(4, host_ref_.size());
+        host_cref_ = host_val_;
+        ASSERT_EQ(4, host_cref_.size());
+    }
+
+    Value<host> host_val_;
+    Ref<host> host_ref_;
+    CRef<host> host_cref_;
+};
+
+TEST_F(AssignmentTest, host_host)
+{
+    {
+        // Assignment: ref -> value
+        Value<host> temp;
+        temp = host_ref_;
+        EXPECT_EQ(4, temp.size());
+    }
+    {
+        // Assignment: cref -> value
+        Value<host> temp;
+        temp = host_cref_;
+        EXPECT_EQ(4, temp.size());
+    }
+    {
+        // Assignment: value -> value
+        Value<host> temp;
+        temp = host_val_;
+        EXPECT_EQ(4, temp.size());
+    }
+    if constexpr (false)
+    {
+        // PROHIBITED: cref -> ref
+        Ref<host> temp;
+        temp = host_cref_;
+        EXPECT_EQ(4, temp.size());
+    }
+}
+
+TEST_F(AssignmentTest, TEST_IF_CELER_DEVICE(host_device))
+{
+    {
+        // Assignment: ref -> value
+        Value<device> temp;
+        temp = host_ref_;
+        EXPECT_EQ(4, temp.size());
+    }
+    {
+        // Assignment: cref -> value
+        Value<device> temp;
+        temp = host_cref_;
+        EXPECT_EQ(4, temp.size());
+    }
+    {
+        // Assignment: value -> value
+        Value<device> temp;
+        temp = host_val_;
+        EXPECT_EQ(4, temp.size());
+    }
+}
+
+TEST_F(AssignmentTest, TEST_IF_CELER_DEVICE(device_host))
+{
+    Value<device> device_val;
+    Ref<device> device_ref;
+    CRef<device> device_cref;
+
+    device_val = host_val_;
+    ASSERT_EQ(4, device_val.size());
+    device_ref = device_val;
+    ASSERT_EQ(4, device_ref.size());
+    device_cref = device_val;
+    ASSERT_EQ(4, device_cref.size());
+
+    {
+        // Assignment from value
+        Value<host> temp;
+        temp = device_val;
+        EXPECT_EQ(4, temp.size());
+
+        Ref<host> temp_ref;
+        // First copy to incorrectly sized vector
+        EXPECT_THROW(temp_ref = device_val, RuntimeError);
+
+        // Now copy correct size
+        temp_ref = temp;
+        temp_ref = device_val;
+    }
+    {
+        // Assignment from ref
+        Value<host> temp;
+        EXPECT_EQ(4, temp.size());
+
+        Ref<host> temp_ref{temp};
+        temp_ref = device_val;
+    }
+}
+
+//---------------------------------------------------------------------------//
 // COMPLEX TESTS
 //---------------------------------------------------------------------------//
 
@@ -505,6 +615,7 @@ TEST_F(CollectionTest, TEST_IF_CELER_DEVICE(device))
     device_state_ref = reference_device_test(device_states);
     EXPECT_EQ(4, device_state_ref.size());
 }
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/corecel/data/DeviceVector.test.cc
+++ b/test/corecel/data/DeviceVector.test.cc
@@ -63,6 +63,31 @@ TEST(DeviceVectorTest, all)
     }
 }
 
+TEST(DeviceVectorTest, TEST_IF_CELER_DEVICE(assign))
+{
+    using Vec_t = DeviceVector<int>;
+    Vec_t vec;
+
+    static int const mydata[] = {1, 3, 5, 8};
+    vec.assign(std::begin(mydata), std::end(mydata));
+    EXPECT_EQ(4, vec.size());
+
+    // Shouldn't reallocate
+    vec.assign(std::begin(mydata) + 2, std::end(mydata));
+    std::vector<int> out(vec.size());
+    vec.copy_to_host(make_span(out));
+
+    EXPECT_VEC_EQ((std::vector<int>{5, 8}), out);
+
+    // Should reallocate
+    static int const mylongdata[] = {1, 3, 5, 8, 13, 21};
+    vec.assign(std::begin(mylongdata), std::end(mylongdata));
+
+    out.resize(vec.size());
+    vec.copy_to_host(make_span(out));
+    EXPECT_VEC_EQ((std::vector<int>{5, 8}), out);
+}
+
 /*!
  * The following test code is intentionally commented out. Define
  * CELERITAS_SHOULD_NOT_COMPILE to check that the enclosed code results in

--- a/test/corecel/data/DeviceVector.test.cc
+++ b/test/corecel/data/DeviceVector.test.cc
@@ -85,7 +85,7 @@ TEST(DeviceVectorTest, TEST_IF_CELER_DEVICE(assign))
 
     out.resize(vec.size());
     vec.copy_to_host(make_span(out));
-    EXPECT_VEC_EQ((std::vector<int>{5, 8}), out);
+    EXPECT_VEC_EQ(mylongdata, out);
 }
 
 /*!


### PR DESCRIPTION
This refactors collection assignment semantics (the initial implementation wasn't allowed to use C++17's `if constexpr`) and adds a helper function to copy an entire *state collection group* back to the host for debugging.