### PR TITLE
Skip indirection array for sorted track slots

### DIFF
--- a/src/celeritas/geo/detail/BoundaryExecutor.hh
+++ b/src/celeritas/geo/detail/BoundaryExecutor.hh
@@ -34,13 +34,12 @@ namespace detail
  */
 struct BoundaryExecutor
 {
-    inline CELER_FUNCTION void
-    operator()(celeritas::CoreTrackView const& track);
+    inline CELER_FUNCTION void operator()(celeritas::CoreTrackView& track);
 };
 
 //---------------------------------------------------------------------------//
 CELER_FUNCTION void
-BoundaryExecutor::operator()(celeritas::CoreTrackView const& track)
+BoundaryExecutor::operator()(celeritas::CoreTrackView& track)
 {
     CELER_EXPECT([track] {
         auto sim = track.make_sim_view();
@@ -64,9 +63,7 @@ BoundaryExecutor::operator()(celeritas::CoreTrackView const& track)
             CELER_LOG_LOCAL(error) << "Track entered a volume without an "
                                       "associated material";
 #endif
-            auto sim = track.make_sim_view();
-            sim.status(TrackStatus::errored);
-            sim.post_step_action(track.tracking_cut_action());
+            track.apply_errored();
             return;
         }
         auto mat = track.make_material_view();

--- a/src/celeritas/global/CoreTrackData.cc
+++ b/src/celeritas/global/CoreTrackData.cc
@@ -39,14 +39,18 @@ void resize(CoreStateData<Ownership::value, M>* state,
     resize(&state->rng, params.rng, stream_id, size);
     resize(&state->sim, size);
     resize(&state->init, params.init, size);
-    resize(&state->track_slots, size);
     state->stream_id = stream_id;
 
-    Span track_slots{state->track_slots[AllItems<TrackSlotId::size_type, M>{}]};
-    detail::fill_track_slots<M>(track_slots, stream_id);
-    if (params.init.track_order == TrackOrder::shuffled)
+    if (params.init.track_order != TrackOrder::unsorted)
     {
-        detail::shuffle_track_slots<M>(track_slots, stream_id);
+        resize(&state->track_slots, size);
+        Span track_slots{
+            state->track_slots[AllItems<TrackSlotId::size_type, M>{}]};
+        detail::fill_track_slots<M>(track_slots, stream_id);
+        if (params.init.track_order == TrackOrder::shuffled)
+        {
+            detail::shuffle_track_slots<M>(track_slots, stream_id);
+        }
     }
 
     CELER_ENSURE(state);

--- a/src/celeritas/global/CoreTrackData.hh
+++ b/src/celeritas/global/CoreTrackData.hh
@@ -116,6 +116,8 @@ struct CoreStateData
     RngStateData<W, M> rng;
     SimStateData<W, M> sim;
     TrackInitStateData<W, M> init;
+
+    //! Indirection array for sorting (empty if unsorted)
     ThreadItems<TrackSlotId::size_type> track_slots;
 
     //! Unique identifier for "thread-local" data.

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -264,7 +264,7 @@ CELER_FUNCTION auto CoreTrackView::make_rng_engine() const -> RngEngine
  */
 CELER_FORCEINLINE_FUNCTION ThreadId CoreTrackView::thread_id() const
 {
-    CELER_ENSURE(thread_id_);
+    CELER_EXPECT(thread_id_);
     return thread_id_;
 }
 

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -25,6 +25,8 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Helper class to create views from core track data.
+ *
+ * TODO: const correctness? (Maybe have to wait till C++23's "deducing this"?)
  */
 class CoreTrackView
 {
@@ -40,6 +42,11 @@ class CoreTrackView
     inline CELER_FUNCTION CoreTrackView(ParamsRef const& params,
                                         StateRef const& states,
                                         ThreadId thread);
+
+    // Construct directly from a track slot ID
+    inline CELER_FUNCTION CoreTrackView(ParamsRef const& params,
+                                        StateRef const& states,
+                                        TrackSlotId slot);
 
     // Return a simulation management view
     inline CELER_FUNCTION SimTrackView make_sim_view() const;
@@ -71,8 +78,8 @@ class CoreTrackView
     // Return an RNG engine
     inline CELER_FUNCTION RngEngine make_rng_engine() const;
 
-    //! Get the index of the current thread in the current kernel
-    CELER_FUNCTION ThreadId thread_id() const { return thread_; }
+    // Get the index of the current thread in the current kernel
+    inline CELER_FUNCTION ThreadId thread_id() const;
 
     // Get the track's index among the states
     inline CELER_FUNCTION TrackSlotId track_slot_id() const;
@@ -89,10 +96,16 @@ class CoreTrackView
     // HACK: return scalars (maybe have a struct for all actions?)
     inline CELER_FUNCTION CoreScalars const& core_scalars() const;
 
+    //// MUTATORS ////
+
+    // Set the 'errored' flag and tracking cut post-step action
+    inline CELER_FUNCTION void apply_errored();
+
   private:
     StateRef const& states_;
     ParamsRef const& params_;
-    ThreadId const thread_;
+    ThreadId const thread_id_;
+    TrackSlotId track_slot_id_;
 };
 
 //---------------------------------------------------------------------------//
@@ -100,14 +113,39 @@ class CoreTrackView
 //---------------------------------------------------------------------------//
 /*!
  * Construct with comprehensive param/state data and thread.
+ *
+ * TODO: if params is 'unsorted', we could leave the
+ * "track slots" vector empty and set \code
+ *  track_slot_id_ = TrackSlotId{states_.track_slots.empty()
+ *              ? thread_id_.get()
+ *              : states_.track_slots[thread_id_]};
+ * \endcode
  */
 CELER_FUNCTION
 CoreTrackView::CoreTrackView(ParamsRef const& params,
                              StateRef const& states,
                              ThreadId thread)
-    : states_(states), params_(params), thread_(thread)
+    : states_(states), params_(params), thread_id_(thread)
 {
-    CELER_EXPECT(thread_ < states_.size());
+    CELER_EXPECT(thread_id_ < states_.track_slots.size());
+    track_slot_id_ = TrackSlotId{states_.track_slots[thread_id_]};
+    CELER_ENSURE(track_slot_id_ < states_.size());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with comprehensive param/state data and track slot.
+ *
+ * This signature is used for creating a view of a \em second track in a kernel
+ * for initialization.
+ */
+CELER_FUNCTION
+CoreTrackView::CoreTrackView(ParamsRef const& params,
+                             StateRef const& states,
+                             TrackSlotId track_slot)
+    : states_(states), params_(params), track_slot_id_(track_slot)
+{
+    CELER_EXPECT(track_slot_id_ < states_.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -218,18 +256,29 @@ CELER_FUNCTION auto CoreTrackView::make_rng_engine() const -> RngEngine
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the track's index among the states.
+ * Get the index of the current thread in the current kernel.
  *
- * TODO: if params is 'unsorted', would it be an optimization if we leave the
- * "track slots" vector empty and return \code
- *  TrackSlotId{states_.track_slots.empty()
- *              ? thread_.get()
- *              : states_.track_slots[thread_]}
- * \endcode
+ * \warning If the kernel calling this function is not applied to \em all
+ * tracks, then comparing against a particular thread ID (e.g. zero for a
+ * once-per-kernel initialization) may result in an error.
+ *
+ * \pre The thread ID is only set if the class is initialized with the thread
+ * ID (e.g. from \c TrackExecutor ), which is not the case in track
+ * initialization (where the "core track" is constructed from a vacancy).
  */
-CELER_FUNCTION TrackSlotId CoreTrackView::track_slot_id() const
+CELER_FORCEINLINE_FUNCTION ThreadId CoreTrackView::thread_id() const
 {
-    return TrackSlotId{states_.track_slots[thread_]};
+    CELER_ENSURE(thread_id_);
+    return thread_id_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the track's index among the states.
+ */
+CELER_FORCEINLINE_FUNCTION TrackSlotId CoreTrackView::track_slot_id() const
+{
+    return track_slot_id_;
 }
 
 //---------------------------------------------------------------------------//
@@ -274,7 +323,8 @@ CELER_FUNCTION ActionId CoreTrackView::tracking_cut_action() const
 /*!
  * Get access to all the core scalars.
  *
- * TODO: maybe have a struct for all actions to simplify the class?
+ * TODO: maybe have a struct for all actions to simplify the class? (Action
+ * view?)
  */
 CELER_FUNCTION CoreScalars const& CoreTrackView::core_scalars() const
 {

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -332,4 +332,20 @@ CELER_FUNCTION CoreScalars const& CoreTrackView::core_scalars() const
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Set the 'errored' flag and tracking cut post-step action.
+ *
+ * \pre This cannot be applied if the current action is *after* post-step. (You
+ * can't guarantee for example that sensitive detectors will pick up the energy
+ * deposition.)
+ */
+CELER_FUNCTION void CoreTrackView::apply_errored()
+{
+    auto sim = this->make_sim_view();
+    CELER_EXPECT(is_track_valid(sim.status()));
+    sim.status(TrackStatus::errored);
+    sim.post_step_action(this->tracking_cut_action());
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -113,13 +113,6 @@ class CoreTrackView
 //---------------------------------------------------------------------------//
 /*!
  * Construct with comprehensive param/state data and thread.
- *
- * TODO: if params is 'unsorted', we could leave the
- * "track slots" vector empty and set \code
- *  track_slot_id_ = TrackSlotId{states_.track_slots.empty()
- *              ? thread_id_.get()
- *              : states_.track_slots[thread_id_]};
- * \endcode
  */
 CELER_FUNCTION
 CoreTrackView::CoreTrackView(ParamsRef const& params,
@@ -127,8 +120,11 @@ CoreTrackView::CoreTrackView(ParamsRef const& params,
                              ThreadId thread)
     : states_(states), params_(params), thread_id_(thread)
 {
-    CELER_EXPECT(thread_id_ < states_.track_slots.size());
-    track_slot_id_ = TrackSlotId{states_.track_slots[thread_id_]};
+    CELER_EXPECT(states_.track_slots.empty()
+                 || thread_id_ < states_.track_slots.size());
+    track_slot_id_ = TrackSlotId{states_.track_slots.empty()
+                                     ? thread_id_.get()
+                                     : states_.track_slots[thread_id_]};
     CELER_ENSURE(track_slot_id_ < states_.size());
 }
 

--- a/src/celeritas/global/TrackExecutor.hh
+++ b/src/celeritas/global/TrackExecutor.hh
@@ -71,7 +71,7 @@ class TrackExecutor
     CELER_FUNCTION void operator()(ThreadId thread)
     {
         CELER_EXPECT(thread < state_->size());
-        CoreTrackView const track(*params_, *state_, thread);
+        CoreTrackView track(*params_, *state_, thread);
         return execute_track_(track);
     }
 
@@ -121,7 +121,7 @@ class ConditionalTrackExecutor
     CELER_FUNCTION void operator()(ThreadId thread)
     {
         CELER_EXPECT(thread < state_->size());
-        CoreTrackView const track(*params_, *state_, thread);
+        CoreTrackView track(*params_, *state_, thread);
         if (!applies_(track.make_sim_view()))
         {
             return;

--- a/src/celeritas/global/alongstep/AlongStep.hh
+++ b/src/celeritas/global/alongstep/AlongStep.hh
@@ -30,7 +30,7 @@ namespace celeritas
 template<class MH, class MP, class EH>
 struct AlongStep
 {
-    inline CELER_FUNCTION void operator()(CoreTrackView const& track);
+    inline CELER_FUNCTION void operator()(CoreTrackView& track);
 
     MH msc;
     MP make_propagator;
@@ -47,8 +47,7 @@ CELER_FUNCTION AlongStep(MH&&, MP&&, EH&&) -> AlongStep<MH, MP, EH>;
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 template<class MH, class MP, class EH>
-CELER_FUNCTION void
-AlongStep<MH, MP, EH>::operator()(CoreTrackView const& track)
+CELER_FUNCTION void AlongStep<MH, MP, EH>::operator()(CoreTrackView& track)
 {
     detail::MscStepLimitApplier{msc}(track);
     detail::PropagationApplier{make_propagator}(track);

--- a/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepGeneralLinearAction.cc
@@ -91,7 +91,7 @@ void AlongStepGeneralLinearAction::execute(CoreParams const& params,
                 std::forward<decltype(execute_track)>(execute_track)));
     };
 
-    launch_impl([&](CoreTrackView const& track) {
+    launch_impl([&](CoreTrackView& track) {
         if (this->has_msc())
         {
             MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}}(track);

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cc
@@ -93,7 +93,7 @@ void AlongStepRZMapFieldMscAction::execute(CoreParams const& params,
                 std::forward<decltype(execute_track)>(execute_track)));
     };
 
-    launch_impl([&](CoreTrackView const& track) {
+    launch_impl([&](CoreTrackView& track) {
         if (this->has_msc())
         {
             MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}}(track);

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cc
@@ -104,7 +104,7 @@ void AlongStepUniformMscAction::execute(CoreParams const& params,
                 std::forward<decltype(execute_track)>(execute_track)));
     };
 
-    launch_impl([&](CoreTrackView const& track) {
+    launch_impl([&](CoreTrackView& track) {
         if (this->has_msc())
         {
             MscStepLimitApplier{UrbanMsc{msc_->ref<MemSpace::native>()}}(track);

--- a/src/celeritas/global/alongstep/detail/PropagationApplier.hh
+++ b/src/celeritas/global/alongstep/detail/PropagationApplier.hh
@@ -29,7 +29,7 @@ namespace detail
 template<class MP>
 struct PropagationApplierBaseImpl
 {
-    inline CELER_FUNCTION void operator()(CoreTrackView const& track);
+    inline CELER_FUNCTION void operator()(CoreTrackView& track);
 
     MP make_propagator;
 };
@@ -92,7 +92,7 @@ CELER_FUNCTION PropagationApplier(MP&&) -> PropagationApplier<MP>;
 //---------------------------------------------------------------------------//
 template<class MP>
 CELER_FUNCTION void
-PropagationApplierBaseImpl<MP>::operator()(CoreTrackView const& track)
+PropagationApplierBaseImpl<MP>::operator()(CoreTrackView& track)
 {
     auto sim = track.make_sim_view();
     if (sim.step_length() == 0)
@@ -136,8 +136,8 @@ PropagationApplierBaseImpl<MP>::operator()(CoreTrackView const& track)
                                 : "")
                 << " failed to change position";
 #    endif
-            sim.status(TrackStatus::errored);
-            sim.post_step_action(track.tracking_cut_action());
+            track.apply_errored();
+            return;
         }
 #endif
     }

--- a/src/celeritas/phys/detail/TrackingCutExecutor.hh
+++ b/src/celeritas/phys/detail/TrackingCutExecutor.hh
@@ -42,13 +42,12 @@ namespace detail
  */
 struct TrackingCutExecutor
 {
-    inline CELER_FUNCTION void
-    operator()(celeritas::CoreTrackView const& track);
+    inline CELER_FUNCTION void operator()(celeritas::CoreTrackView& track);
 };
 
 //---------------------------------------------------------------------------//
 CELER_FUNCTION void
-TrackingCutExecutor::operator()(celeritas::CoreTrackView const& track)
+TrackingCutExecutor::operator()(celeritas::CoreTrackView& track)
 {
     using Energy = ParticleTrackView::Energy;
 
@@ -68,7 +67,7 @@ TrackingCutExecutor::operator()(celeritas::CoreTrackView const& track)
 #if !CELER_DEVICE_COMPILE
     if (sim.status() == TrackStatus::errored)
     {
-        auto geo = track.make_geo_view();
+        auto const geo = track.make_geo_view();
         auto msg = CELER_LOG_LOCAL(error);
         msg << "Tracking error (track ID " << sim.track_id().get()
             << ", track slot " << track.track_slot_id().get() << ") at "

--- a/src/celeritas/track/SortTracksAction.cc
+++ b/src/celeritas/track/SortTracksAction.cc
@@ -40,6 +40,7 @@ bool is_sort_trackorder(TrackOrder to)
            != std::end(allowed);
 }
 
+//---------------------------------------------------------------------------//
 /*!
  * Checks whether the TrackOrder sort tracks using an ActionId.
  */
@@ -88,7 +89,7 @@ SortTracksAction::SortTracksAction(ActionId id, TrackOrder track_order)
 
 //---------------------------------------------------------------------------//
 /*!
- * Short name for the action
+ * Short name for the action.
  */
 std::string_view SortTracksAction::label() const
 {

--- a/src/celeritas/track/detail/InitTracksExecutor.hh
+++ b/src/celeritas/track/detail/InitTracksExecutor.hh
@@ -78,7 +78,6 @@ CELER_FUNCTION void InitTracksExecutor::operator()(ThreadId tid) const
     // parent they can copy the geometry state from.
     auto const& data = state->init;
     ItemId<TrackInitializer> idx{index_before(counters.num_initializers, tid)};
-    TrackInitializer const& init = data.initializers[idx];
 
     // View to the new track to be initialized
     CoreTrackView vacancy{
@@ -87,7 +86,8 @@ CELER_FUNCTION void InitTracksExecutor::operator()(ThreadId tid) const
             return data.vacancies[idx];
         }()};
 
-    // Initialize the simulation state
+    // Initialize the simulation state and particle attributes
+    TrackInitializer const& init = data.initializers[idx];
     vacancy.make_sim_view() = init.sim;
     vacancy.make_particle_view() = init.particle;
 

--- a/src/celeritas/track/detail/InitTracksExecutor.hh
+++ b/src/celeritas/track/detail/InitTracksExecutor.hh
@@ -113,9 +113,7 @@ CELER_FUNCTION void InitTracksExecutor::operator()(ThreadId tid) const
 #if !CELER_DEVICE_COMPILE
                 CELER_LOG_LOCAL(error) << "Track started outside the geometry";
 #endif
-                auto sim = vacancy.make_sim_view();
-                sim.status(TrackStatus::errored);
-                sim.post_step_action(params->scalars.tracking_cut_action);
+                vacancy.apply_errored();
                 return;
             }
         }

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -43,14 +43,11 @@ std::string get_json_str(KernelContextException const& e)
 
 ThreadId find_thread(HostRef<CoreStateData> const& state, TrackSlotId track)
 {
-    Span track_slots{state.track_slots[AllItems<TrackSlotId::size_type>{}]};
-    auto idx = std::distance(
-        track_slots.begin(),
-        std::find(track_slots.begin(), track_slots.end(), track.get()));
-    EXPECT_NE(track_slots.size(), idx);
-    return ThreadId{static_cast<ThreadId::size_type>(idx)};
+    CELER_EXPECT(state.track_slots.empty());
+    return ThreadId{track.get()};
 }
 }  // namespace
+
 //---------------------------------------------------------------------------//
 
 class KernelContextExceptionTest : public SimpleTestBase, public StepperTestBase

--- a/test/celeritas/user/Diagnostic.test.cc
+++ b/test/celeritas/user/Diagnostic.test.cc
@@ -249,7 +249,7 @@ TEST_F(TestEm3DiagnosticTest, TEST_IF_CELER_DEVICE(device))
         EXPECT_VEC_EQ(expected_steps, result.steps);
 
         EXPECT_JSON_EQ(
-            R"json({"_category":"result","_index":["particle","action"],"_label":"action-diagnostic","actions":[[0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,0,0,9,0],[0,0,0,996,0,0,2,0,0,0,0,20,509,0,0,0,0,0,0,0,0,521,0],[0,0,0,902,0,0,10,0,0,0,9,20,577,0,0,0,0,0,0,0,0,518,0]]})json",
+            R"json({"_category":"result","_index":["particle","action"],"_label":"action-diagnostic","actions":[[0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,0,9,0,0],[0,0,0,996,0,0,2,0,0,0,0,20,509,0,0,0,0,0,0,0,521,0,0],[0,0,0,902,0,0,10,0,0,0,9,20,577,0,0,0,0,0,0,0,518,0,0]]})json",
             this->action_output());
         EXPECT_JSON_EQ(
             R"json({"_category":"result","_index":["particle","num_steps"],"_label":"step-diagnostic","steps":[[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],[0,0,5,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]]})json",


### PR DESCRIPTION
This updates the core state to avoid allocating or accessing a track slot array in the usual case that we're not sorting tracks. It also defines a constructor directly from track slot ID which we can use to simplify the track initialization kernel. Finally, it adds a core track helper function to simultaneously mark a track as "errored" and to set the post-step action to kill it. I've made this function non-const, which requires updating a number of function signatures to make it mutable.