### PR TITLE
Add environment variable to disable broken HIP asynchronous allocation

### DIFF
--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -76,8 +76,7 @@ jobs:
       - name: Run tests
         working-directory: build
         run: |
-          ctest --parallel $(nproc) --timeout 15 --output-on-failure \
-            --test-output-size-passed=32768 --test-output-size-failed=1048576
+          ctest --parallel $(nproc) --timeout 15 --output-on-failure
       - name: Install
         working-directory: build
         run: |

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -147,8 +147,7 @@ jobs:
             # Note this is ignored for geant4, float, clhep
             export CELER_TEST_STRICT=1
           fi
-          ctest --parallel $(nproc) --timeout 15 --output-on-failure \
-            --test-output-size-passed=32768 --test-output-size-failed=1048576
+          ctest --parallel $(nproc) --timeout 15 --output-on-failure
       - name: Upload failed tests
         if: ${{steps.test.outcome == 'failure'}}
         uses: actions/upload-artifact@v4

--- a/doc/main/api/corecel.rst
+++ b/doc/main/api/corecel.rst
@@ -75,12 +75,18 @@ incorrect configuration or input values.
 .. doxygendefine:: CELER_NOT_CONFIGURED
 .. doxygendefine:: CELER_NOT_IMPLEMENTED
 
+.. _api_system:
+
 System
 ------
 
 .. doxygenclass:: celeritas::Device
 .. doxygenfunction:: celeritas::device
 .. doxygenfunction:: celeritas::activate_device()
+
+.. doxygenclass:: celeritas::Environment
+.. doxygenfunction:: celeritas::environment
+.. doxygenfunction:: celeritas::getenv
 
 Containers
 ----------

--- a/doc/main/api/corecel.rst
+++ b/doc/main/api/corecel.rst
@@ -87,6 +87,7 @@ System
 .. doxygenclass:: celeritas::Environment
 .. doxygenfunction:: celeritas::environment
 .. doxygenfunction:: celeritas::getenv
+.. doxygenfunction:: celeritas::getenv_flag
 
 Containers
 ----------

--- a/doc/main/usage.rst
+++ b/doc/main/usage.rst
@@ -336,13 +336,13 @@ tell what variables are in use or may be useful.
  CELER_DISABLE_DEVICE    corecel   Disable CUDA/HIP support
  CELER_DISABLE_PARALLEL  corecel   Disable MPI support
  CELER_DISABLE_ROOT      corecel   Disable ROOT I/O calls
+ CELER_DEVICE_ASYNC      corecel   Flag for asyncronous memory allocation
  CELER_ENABLE_PROFILING  corecel   Set up NVTX/ROCTX profiling ranges [#pr]
  CELER_LOG               corecel   Set the "global" logger verbosity
  CELER_LOG_LOCAL         corecel   Set the "local" logger verbosity
  CELER_MEMPOOL... [#mp]_ corecel   Change ``cudaMemPoolAttrReleaseThreshold``
  CELER_PERFETT... [#bs]_ corecel   Set the in-process tracing buffer size
  CELER_PROFILE_DEVICE    corecel   Record extra kernel launch information
- DEVICE_DISABLE_ASYNC    corecel   Disable asyncronous memory allocation
  CUDA_HEAP_SIZE          geocel    Change ``cudaLimitMallocHeapSize`` (VG)
  CUDA_STACK_SIZE         geocel    Change ``cudaLimitStackSize`` for VecGeom
  G4VG_COMPARE_VOLUMES    geocel    Check G4VG volume capacity when converting
@@ -359,8 +359,9 @@ tell what variables are in use or may be useful.
 
 Some of the Celeritas-defined environment variables have prefixes from other
 libraries because they directly control the behavior of that library and
-nothing else. The ``DEVICE_DISABLE_ASYNC`` may be needed when running HIP 5.7
-or later due to the "beta" nature of hipMallocAsync_.
+nothing else. The ``CELER_DEVICE_ASYNC`` may be needed when running HIP 5.7
+or later due to the "beta" nature of hipMallocAsync_: it defaults to "true"
+*except* for HIP less than 5.2 (where it is not implemented) or greater than 5.6.
 
 .. _hipMallocAsync: https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___stream_o.html
 

--- a/doc/main/usage.rst
+++ b/doc/main/usage.rst
@@ -336,7 +336,7 @@ tell what variables are in use or may be useful.
  CELER_DISABLE_DEVICE    corecel   Disable CUDA/HIP support
  CELER_DISABLE_PARALLEL  corecel   Disable MPI support
  CELER_DISABLE_ROOT      corecel   Disable ROOT I/O calls
- CELER_DEVICE_ASYNC      corecel   Flag for asyncronous memory allocation
+ CELER_DEVICE_ASYNC      corecel   Flag for asynchronous memory allocation
  CELER_ENABLE_PROFILING  corecel   Set up NVTX/ROCTX profiling ranges [#pr]
  CELER_LOG               corecel   Set the "global" logger verbosity
  CELER_LOG_LOCAL         corecel   Set the "local" logger verbosity

--- a/doc/main/usage.rst
+++ b/doc/main/usage.rst
@@ -372,6 +372,13 @@ Celeritas or its apps:
  OMP_NUM_THREADS          OpenMP    Number of threads per process
  ======================== ========= ==========================================
 
+.. note::
+
+   For frameworks integrating Celeritas, these options are configurable via the
+   Celeritas API. Before Celeritas is set up for the first time, on a single
+   thread access the ``celeritas::environment()`` struct (see
+   :ref:`api_system`), and call ``insert`` for the desired key/value pairs.
+
 .. _logging:
 
 Logging

--- a/doc/main/usage.rst
+++ b/doc/main/usage.rst
@@ -342,9 +342,10 @@ tell what variables are in use or may be useful.
  CELER_MEMPOOL... [#mp]_ corecel   Change ``cudaMemPoolAttrReleaseThreshold``
  CELER_PERFETT... [#bs]_ corecel   Set the in-process tracing buffer size
  CELER_PROFILE_DEVICE    corecel   Record extra kernel launch information
- CUDA_HEAP_SIZE          celeritas Change ``cudaLimitMallocHeapSize`` (VG)
- CUDA_STACK_SIZE         celeritas Change ``cudaLimitStackSize`` for VecGeom
- G4VG_COMPARE_VOLUMES    celeritas Check G4VG volume capacity when converting
+ DEVICE_DISABLE_ASYNC    corecel   Disable asyncronous memory allocation
+ CUDA_HEAP_SIZE          geocel    Change ``cudaLimitMallocHeapSize`` (VG)
+ CUDA_STACK_SIZE         geocel    Change ``cudaLimitStackSize`` for VecGeom
+ G4VG_COMPARE_VOLUMES    geocel    Check G4VG volume capacity when converting
  HEPMC3_VERBOSE          celeritas HepMC3 debug verbosity
  VECGEOM_VERBOSE         celeritas VecGeom CUDA verbosity
  CELER_DISABLE           accel     Disable Celeritas offloading entirely
@@ -355,6 +356,13 @@ tell what variables are in use or may be useful.
 .. [#bs] CELER_PERFETTO_BUFFER_SIZE_MB
 .. [#mp] CELER_MEMPOOL_RELEASE_THRESHOLD
 .. [#pr] See :ref:`profiling`
+
+Some of the Celeritas-defined environment variables have prefixes from other
+libraries because they directly control the behavior of that library and
+nothing else. The ``DEVICE_DISABLE_ASYNC`` may be needed when running HIP 5.7
+or later due to the "beta" nature of hipMallocAsync_.
+
+.. _hipMallocAsync: https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___stream_o.html
 
 Environment variables from external libraries can also be referenced by
 Celeritas or its apps:

--- a/src/corecel/sys/DeviceIO.json.cc
+++ b/src/corecel/sys/DeviceIO.json.cc
@@ -12,9 +12,11 @@
 #include "celeritas_config.h"
 
 #include "Device.hh"
+#include "Stream.hh"
 
 namespace celeritas
 {
+#define CELER_DIO_PAIR(ATTR) {#ATTR, d.ATTR()}
 //---------------------------------------------------------------------------//
 /*!
  * Write device diagnostics out to JSON.
@@ -24,22 +26,24 @@ void to_json(nlohmann::json& j, Device const& d)
     if (d)
     {
         j = nlohmann::json{
-            {"device_id", d.device_id()},
-            {"name", d.name()},
-            {"total_global_mem", d.total_global_mem()},
-            {"max_threads_per_block", d.max_threads_per_block()},
-            {"max_blocks_per_grid", d.max_blocks_per_grid()},
-            {"max_threads_per_cu", d.max_threads_per_cu()},
-            {"threads_per_warp", d.threads_per_warp()},
-            {"eu_per_cu", d.eu_per_cu()},
-            {"can_map_host_memory", d.can_map_host_memory()},
+            CELER_DIO_PAIR(device_id),
+            CELER_DIO_PAIR(name),
+            CELER_DIO_PAIR(total_global_mem),
+            CELER_DIO_PAIR(max_threads_per_block),
+            CELER_DIO_PAIR(max_blocks_per_grid),
+            CELER_DIO_PAIR(max_threads_per_cu),
+            CELER_DIO_PAIR(threads_per_warp),
+            CELER_DIO_PAIR(eu_per_cu),
+            CELER_DIO_PAIR(can_map_host_memory),
+            // Static data
+            CELER_DIO_PAIR(debug),
+            CELER_DIO_PAIR(num_devices),
         };
 
-#if CELERITAS_USE_CUDA
-        j["platform"] = "cuda";
-#elif CELERITAS_USE_HIP
-        j["platform"] = "hip";
-#endif
+        j["platform"] = CELERITAS_USE_CUDA  ? "cuda"
+                        : CELERITAS_USE_HIP ? "hip"
+                                            : "none";
+        j["stream_async"] = Stream::async();
 
         for (auto const& kv : d.extra())
         {
@@ -51,6 +55,8 @@ void to_json(nlohmann::json& j, Device const& d)
         j = nlohmann::json{};
     }
 }
+
+#undef CELER_DIO_PAIR
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/sys/Environment.cc
+++ b/src/corecel/sys/Environment.cc
@@ -44,10 +44,15 @@ Environment& environment()
 //---------------------------------------------------------------------------//
 /*!
  * Thread-safe access to global modified environment variables.
+ *
+ * This function will \em insert the current value of the key into the
+ * environment, which remains immutable over the lifetime of the program
+ * (allowing the use of <code>static const</code> data to be set from the
+ * environment).
  */
 std::string const& getenv(std::string const& key)
 {
-    std::lock_guard<std::mutex> scoped_lock{getenv_mutex()};
+    std::scoped_lock lock_{getenv_mutex()};
     return environment()[key];
 }
 
@@ -67,7 +72,7 @@ std::string const& getenv(std::string const& key)
  */
 GetenvFlagResult getenv_flag(std::string const& key, bool default_val)
 {
-    std::lock_guard<std::mutex> scoped_lock{getenv_mutex()};
+    std::scoped_lock lock_{getenv_mutex()};
     bool inserted = environment().insert({key, default_val ? "1" : "0"});
     if (inserted)
     {

--- a/src/corecel/sys/Environment.cc
+++ b/src/corecel/sys/Environment.cc
@@ -85,8 +85,10 @@ auto Environment::load_from_getenv(key_type const& key) -> mapped_type const&
  * Set a single environment variable that hasn't yet been set.
  *
  * Existing environment variables will *not* be overwritten.
+ *
+ * \return Whether insertion took place
  */
-void Environment::insert(value_type const& value)
+bool Environment::insert(value_type const& value)
 {
     auto [iter, inserted] = vars_.insert(value);
     if (inserted)
@@ -94,6 +96,7 @@ void Environment::insert(value_type const& value)
         ordered_.push_back(std::ref(*iter));
     }
     CELER_ENSURE(ordered_.size() == vars_.size());
+    return inserted;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/Environment.cc
+++ b/src/corecel/sys/Environment.cc
@@ -55,9 +55,15 @@ std::string const& getenv(std::string const& key)
 /*!
  * Get a true/false flag with a default value.
  *
- * The return value is a combination of the transformed environment value,
- * and a flag specifying whether the environment variable was inserted or
- * otherwise uses the default value.
+ * The return value is a pair that has (1) the flag as determined by the
+ * environment variable or default value, and (2) an "insertion" flag
+ * specifying whether the default was used. The insertion result can be useful
+ * for providing a diagnostic message to the user.
+ *
+ * - Allowed true values: <code>"1", "t", "yes", "true", "True"</code>
+ * - Allowed false values: <code>"0", "f", "no", "false", "False"</code>
+ * - Empty value returns the default
+ * - Other value warns and returns the default
  */
 GetenvFlagResult getenv_flag(std::string const& key, bool default_val)
 {

--- a/src/corecel/sys/Environment.hh
+++ b/src/corecel/sys/Environment.hh
@@ -55,7 +55,7 @@ class Environment
     // Get an environment variable from current or system environments
     inline mapped_type const& operator[](key_type const&);
 
-    // Insert possibly new environment variables (not thread-safe)
+    // Insert possibly new environment variables
     bool insert(value_type const& value);
 
     //! Get an ordered (by access) vector of key/value pairs
@@ -74,6 +74,12 @@ class Environment
     mapped_type const& load_from_getenv(key_type const&);
 };
 
+struct GetenvFlagResult
+{
+    bool value{};
+    bool defaulted{};
+};
+
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//
@@ -83,6 +89,9 @@ Environment& environment();
 
 // Thread-safe access to environment variables
 std::string const& getenv(std::string const& key);
+
+// Thread-safe flag access to environment variables
+GetenvFlagResult getenv_flag(std::string const& key, bool default_val);
 
 // Write the accessed environment variables to a stream
 std::ostream& operator<<(std::ostream&, Environment const&);

--- a/src/corecel/sys/Environment.hh
+++ b/src/corecel/sys/Environment.hh
@@ -32,6 +32,13 @@ namespace celeritas
  * \note This class is not thread-safe on its own. The \c celeritas::getenv
  * free function however is safe, although it should only be used in setup
  * (single-thread) steps.
+ *
+ * \note Once inserted into the environment map, values cannot be changed.
+ * Standard practice in the code is to evaluate the environment variable
+ * exactly \em once and cache the result as a static const variable. If you
+ * really wanted to, you could call <code> celeritas::environment() = {};
+ * </code> but that could result in the end-of-run diagnostic reporting
+ * different values than the ones actually used during the code's setup.
  */
 class Environment
 {
@@ -74,6 +81,7 @@ class Environment
     mapped_type const& load_from_getenv(key_type const&);
 };
 
+//---------------------------------------------------------------------------//
 //! Return result from \c getenv_flag
 struct GetenvFlagResult
 {

--- a/src/corecel/sys/Environment.hh
+++ b/src/corecel/sys/Environment.hh
@@ -20,14 +20,14 @@ namespace celeritas
 /*!
  * Interrogate and extend environment variables.
  *
- * This makes it easier to generate reproducible runs or launch Celeritas
- * remotely: the environment variables may be encoded as JSON input to
- * supplement or override system environment variables. Later it can be
- * interrogated to find which environment variables were accessed.
+ * This makes it easier to generate reproducible runs, launch Celeritas
+ * remotely, or integrate with application drivers. The environment variables
+ * may be encoded as JSON input to supplement or override system environment
+ * variables, or set programmatically via this API call. Later the environment
+ * class can be interrogated to find which environment variables were accessed.
  *
  * Unlike the standard environment which returns a null pointer for an *unset*
- * variable, this returns an empty string. When we switch to C++17 we can
- * return a `std::optional<std::string>` if this behavior isn't appropriate.
+ * variable, this returns an empty string.
  *
  * \note This class is not thread-safe on its own. The \c celeritas::getenv
  * free function however is safe, although it should only be used in setup
@@ -56,7 +56,7 @@ class Environment
     inline mapped_type const& operator[](key_type const&);
 
     // Insert possibly new environment variables (not thread-safe)
-    void insert(value_type const& value);
+    bool insert(value_type const& value);
 
     //! Get an ordered (by access) vector of key/value pairs
     VecKVRef const& ordered_environment() const { return ordered_; }

--- a/src/corecel/sys/Environment.hh
+++ b/src/corecel/sys/Environment.hh
@@ -74,10 +74,11 @@ class Environment
     mapped_type const& load_from_getenv(key_type const&);
 };
 
+//! Return result from \c getenv_flag
 struct GetenvFlagResult
 {
-    bool value{};
-    bool defaulted{};
+    bool value{};  //!< Determined by user or default
+    bool defaulted{};  //!< True if no valid user value was present
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/Stream.cc
+++ b/src/corecel/sys/Stream.cc
@@ -40,9 +40,7 @@ void* malloc_async_impl(std::size_t bytes, Stream::StreamT s)
 #if CELER_STREAM_SUPPORTS_ASYNC
         CELER_DEVICE_CALL_PREFIX(MallocAsync(&ptr, bytes, s));
 #else
-        CELER_DISCARD(ptr);
-        CELER_DISCARD(bytes);
-        CELER_DISCARD(s);
+        CELER_DISCARD((ptr, bytes, s));
         CELER_ASSERT_UNREACHABLE();
 #endif
     }
@@ -62,8 +60,7 @@ void free_async_impl(void* ptr, Stream::StreamT s)
 #if CELER_STREAM_SUPPORTS_ASYNC
         CELER_DEVICE_CALL_PREFIX(FreeAsync(ptr, s));
 #else
-        CELER_DISCARD(ptr);
-        CELER_DISCARD(s);
+        CELER_DISCARD((ptr, s));
         CELER_ASSERT_UNREACHABLE();
 #endif
     }

--- a/src/corecel/sys/Stream.cc
+++ b/src/corecel/sys/Stream.cc
@@ -40,7 +40,9 @@ void* malloc_async_impl(std::size_t bytes, Stream::StreamT s)
 #if CELER_STREAM_SUPPORTS_ASYNC
         CELER_DEVICE_CALL_PREFIX(MallocAsync(&ptr, bytes, s));
 #else
-        CELER_DISCARD((ptr, bytes, s));
+        CELER_DISCARD(ptr);
+        CELER_DISCARD(bytes);
+        CELER_DISCARD(s);
         CELER_ASSERT_UNREACHABLE();
 #endif
     }
@@ -60,7 +62,8 @@ void free_async_impl(void* ptr, Stream::StreamT s)
 #if CELER_STREAM_SUPPORTS_ASYNC
         CELER_DEVICE_CALL_PREFIX(FreeAsync(ptr, s));
 #else
-        CELER_DISCARD((ptr, s));
+        CELER_DISCARD(ptr);
+        CELER_DISCARD(s);
         CELER_ASSERT_UNREACHABLE();
 #endif
     }

--- a/src/corecel/sys/Stream.cc
+++ b/src/corecel/sys/Stream.cc
@@ -120,8 +120,9 @@ void AsyncMemoryResource<Pointer>::do_deallocate(pointer p,
 /*!
  * Whether asynchronous operations are supported.
  *
- * This is true if CUDA or HIP>=5.2 is in use, and can be disabled by setting
- * the \c DEVICE_DISABLE_ASYNC environment variable.
+ * This is true by default if CUDA or HIP (5.2 <= HIP_VERSION < 5.7) is in use,
+ * and can be disabled by setting the \c CELER_DEVICE_ASYNC environment
+ * variable.
  */
 bool Stream::async()
 {

--- a/src/corecel/sys/Stream.cc
+++ b/src/corecel/sys/Stream.cc
@@ -40,6 +40,8 @@ void* malloc_async_impl(std::size_t bytes, Stream::StreamT s)
 #if CELER_STREAM_SUPPORTS_ASYNC
         CELER_DEVICE_CALL_PREFIX(MallocAsync(&ptr, bytes, s));
 #else
+        CELER_DISCARD(ptr);
+        CELER_DISCARD(bytes);
         CELER_DISCARD(s);
         CELER_ASSERT_UNREACHABLE();
 #endif
@@ -60,6 +62,7 @@ void free_async_impl(void* ptr, Stream::StreamT s)
 #if CELER_STREAM_SUPPORTS_ASYNC
         CELER_DEVICE_CALL_PREFIX(FreeAsync(ptr, s));
 #else
+        CELER_DISCARD(ptr);
         CELER_DISCARD(s);
         CELER_ASSERT_UNREACHABLE();
 #endif

--- a/src/corecel/sys/Stream.hh
+++ b/src/corecel/sys/Stream.hh
@@ -86,6 +86,9 @@ class Stream
     //!@}
 
   public:
+    // Whether asynchronous operations are supported
+    static bool async();
+
     // Construct by creating a stream
     Stream();
 

--- a/test/celeritas/track/StatusChecker.test.cc
+++ b/test/celeritas/track/StatusChecker.test.cc
@@ -223,6 +223,11 @@ TEST_F(StatusCheckerTest, TEST_IF_CELER_DEVICE(device))
     post_step[target_track] = this->find_action("physics-discrete-select");
     copy_to_device(post_step, state.ref().sim.post_step_action);
 
+    if constexpr (CELERITAS_USE_HIP)
+    {
+        GTEST_SKIP() << "HIP debug calls 'abort' rather than asserting";
+    }
+
     EXPECT_THROW(
         status_checker_->execute(
             this->find_action("scat-klein-nishina"), *this->core(), state),

--- a/test/corecel/sys/Environment.test.cc
+++ b/test/corecel/sys/Environment.test.cc
@@ -16,6 +16,10 @@
 
 namespace celeritas
 {
+inline bool operator==(GetenvFlagResult a, GetenvFlagResult b)
+{
+    return a.value == b.value && a.defaulted == b.defaulted;
+}
 namespace test
 {
 //---------------------------------------------------------------------------//
@@ -47,7 +51,29 @@ TEST(EnvironmentTest, local)
 TEST(EnvironmentTest, global)
 {
     EXPECT_EQ("1", environment()["ENVTEST_ONE"]);
+    EXPECT_EQ("0", getenv("ENVTEST_ZERO"));
     EXPECT_EQ("1", getenv("ENVTEST_ONE"));
+    EXPECT_EQ("", getenv("ENVTEST_EMPTY"));
+
+    EXPECT_EQ((GetenvFlagResult{false, false}),
+              getenv_flag("ENVTEST_ZERO", false));
+    EXPECT_EQ((GetenvFlagResult{true, false}),
+              getenv_flag("ENVTEST_ONE", false));
+    EXPECT_EQ((GetenvFlagResult{false, true}),
+              getenv_flag("ENVTEST_EMPTY", false));
+    EXPECT_EQ((GetenvFlagResult{true, true}),
+              getenv_flag("ENVTEST_EMPTY", true));
+    EXPECT_EQ((GetenvFlagResult{true, true}),
+              getenv_flag("ENVTEST_NEW_T", true));
+    EXPECT_EQ((GetenvFlagResult{false, true}),
+              getenv_flag("ENVTEST_NEW_F", false));
+
+    environment().insert({"ENVTEST_FALSE", "false"});
+    environment().insert({"ENVTEST_TRUE", "true"});
+    EXPECT_EQ((GetenvFlagResult{false, false}),
+              getenv_flag("ENVTEST_FALSE", false));
+    EXPECT_EQ((GetenvFlagResult{true, false}),
+              getenv_flag("ENVTEST_TRUE", false));
 }
 
 TEST(EnvironmentTest, merge)

--- a/test/corecel/sys/Environment.test.cc
+++ b/test/corecel/sys/Environment.test.cc
@@ -30,7 +30,7 @@ TEST(EnvironmentTest, local)
     EXPECT_EQ("", env["ENVTEST_UNSET"]);
 
     // Insert shouldn't override existing value
-    env.insert({"ENVTEST_ZERO", "2"});
+    EXPECT_FALSE(env.insert({"ENVTEST_ZERO", "2"}));
     EXPECT_EQ("0", env["ENVTEST_ZERO"]);
 
     std::ostringstream os;
@@ -53,7 +53,7 @@ TEST(EnvironmentTest, global)
 TEST(EnvironmentTest, merge)
 {
     Environment sys;
-    sys.insert({"FOO", "foo"});
+    EXPECT_TRUE(sys.insert({"FOO", "foo"}));
     sys.insert({"BAR", "bar"});
     Environment input;
     input.insert({"FOO", "foo2"});
@@ -85,9 +85,9 @@ TEST(EnvironmentTest, json)
     }
     {
         // Save environment
-        nlohmann::json out{env};
+        nlohmann::json out = env;
         EXPECT_JSON_EQ(
-            R"json([{"ENVTEST_CUSTOM":"custom","ENVTEST_ONE":"111111","ENVTEST_ZERO":"000000"}])json",
+            R"json({"ENVTEST_CUSTOM":"custom","ENVTEST_ONE":"111111","ENVTEST_ZERO":"000000"})json",
             out.dump());
     }
 }


### PR DESCRIPTION
This adds a runtime selectable environment variable `CELER_DEVICE_ASYNC` to let the user *force* synchronous memory allocations, since asynchronous malloc seems to be broken on newer ROCm versions (see #1313).

It also fixes the "status checker" test on HIP since it seems like "abort" on HIP platforms results in a SIGSEGV.

NOTE: this also fixes a CI failure with the latest GitHub actions image: apparently `--option=value` isn't valid in CTest and it's just been ignoring the argument until now. See https://gitlab.kitware.com/cmake/cmake/-/issues/24227, https://gitlab.kitware.com/cmake/cmake/-/issues/24215