### PR TITLE
Refactor muon bremsstrahlung differential cross section calculation and add documentation

### DIFF
--- a/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
+++ b/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
@@ -179,14 +179,12 @@ template<class Engine>
 CELER_FUNCTION real_type MuBremsstrahlungInteractor::sample_cos_theta(
     real_type gamma_energy, Engine& rng) const
 {
-    real_type const gamma = particle_.lorentz_factor();
-    real_type const r_max
-        = gamma * constants::pi * real_type(0.5)
-          * min(real_type(1.0),
-                gamma * value_as<Mass>(particle_.mass()) / gamma_energy - 1);
-    real_type const r_max_sq = ipow<2>(r_max);
-
-    real_type const a = generate_canonical(rng) * r_max_sq / (1 + r_max_sq);
+    real_type gamma = particle_.lorentz_factor();
+    real_type r_max_sq = ipow<2>(
+        gamma * constants::pi * real_type(0.5)
+        * min(real_type(1.0),
+              gamma * value_as<Mass>(particle_.mass()) / gamma_energy - 1));
+    real_type a = generate_canonical(rng) * r_max_sq / (1 + r_max_sq);
 
     return std::cos(std::sqrt(a / (1 - a)) / gamma);
 }

--- a/src/celeritas/em/xs/MuBremsDiffXsCalculator.hh
+++ b/src/celeritas/em/xs/MuBremsDiffXsCalculator.hh
@@ -1,0 +1,154 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/em/xs/MuBremsDiffXsCalculator.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cmath>
+
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/math/Algorithms.hh"
+#include "corecel/math/Quantity.hh"
+#include "celeritas/Constants.hh"
+#include "celeritas/Quantities.hh"
+#include "celeritas/Types.hh"
+#include "celeritas/mat/ElementView.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate differential cross sections for muon bremsstrahlung.
+ */
+class MuBremsDiffXsCalculator
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Energy = units::MevEnergy;
+    using Mass = units::MevMass;
+    //!@}
+
+  public:
+    // Construct with incident particle data and current element
+    inline CELER_FUNCTION MuBremsDiffXsCalculator(ElementView const& element,
+                                                  Energy inc_energy,
+                                                  Mass inc_mass,
+                                                  Mass electron_mass);
+
+    // Compute cross section of exiting gamma energy
+    inline CELER_FUNCTION real_type operator()(Energy energy);
+
+  private:
+    //// DATA ////
+
+    // Shared problem data for the current element
+    ElementView const& element_;
+    // Energy of the incident particle
+    real_type inc_energy_;
+    // Mass of the incident particle
+    real_type inc_mass_;
+    // Total energy of the incident particle
+    real_type total_energy_;
+    // Mass of an electron
+    real_type electron_mass_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with incident particle data and current element.
+ */
+CELER_FUNCTION
+MuBremsDiffXsCalculator::MuBremsDiffXsCalculator(ElementView const& element,
+                                                 Energy inc_energy,
+                                                 Mass inc_mass,
+                                                 Mass electron_mass)
+    : element_(element)
+    , inc_energy_(value_as<Energy>(inc_energy))
+    , inc_mass_(value_as<Mass>(inc_mass))
+    , total_energy_(inc_energy_ + inc_mass_)
+    , electron_mass_(value_as<Mass>(electron_mass))
+{
+    CELER_EXPECT(inc_energy_ > 0);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Compute the differential cross section per atom at the given photon energy.
+ */
+CELER_FUNCTION
+real_type MuBremsDiffXsCalculator::operator()(Energy energy)
+{
+    CELER_EXPECT(energy > zero_quantity());
+
+    if (value_as<Energy>(energy) >= inc_energy_)
+    {
+        return 0;
+    }
+
+    int const atomic_number = element_.atomic_number().unchecked_get();
+    real_type const atomic_mass
+        = value_as<units::AmuMass>(element_.atomic_mass());
+    real_type const sqrt_e = std::sqrt(constants::euler);
+    real_type const rel_energy_transfer = value_as<Energy>(energy)
+                                          / total_energy_;
+    real_type const inc_mass_sq = ipow<2>(inc_mass_);
+    real_type const delta = real_type(0.5) * inc_mass_sq * rel_energy_transfer
+                            / (total_energy_ - value_as<Energy>(energy));
+
+    // TODO: precalculate these data per element
+    real_type d_n_prime, b, b1;
+    real_type const d_n = real_type(1.54)
+                          * std::pow(atomic_mass, real_type(0.27));
+
+    if (atomic_number == 1)
+    {
+        d_n_prime = d_n;
+        b = real_type(202.4);
+        b1 = 446;
+    }
+    else
+    {
+        d_n_prime = std::pow(d_n, 1 - real_type(1) / atomic_number);
+        b = 183;
+        b1 = 1429;
+    }
+
+    real_type const inv_cbrt_z = 1 / element_.cbrt_z();
+
+    real_type const phi_n = clamp_to_nonneg(std::log(
+        b * inv_cbrt_z * (inc_mass_ + delta * (d_n_prime * sqrt_e - 2))
+        / (d_n_prime * (electron_mass_ + delta * sqrt_e * b * inv_cbrt_z))));
+
+    real_type phi_e = 0;
+    real_type const epsilon_max_prime
+        = total_energy_
+          / (1
+             + real_type(0.5) * inc_mass_sq / (electron_mass_ * total_energy_));
+
+    if (value_as<Energy>(energy) < epsilon_max_prime)
+    {
+        real_type const inv_cbrt_z_sq = ipow<2>(inv_cbrt_z);
+        phi_e = clamp_to_nonneg(std::log(
+            b1 * inv_cbrt_z_sq * inc_mass_
+            / ((1 + delta * inc_mass_ / (ipow<2>(electron_mass_) * sqrt_e))
+               * (electron_mass_ + delta * sqrt_e * b1 * inv_cbrt_z_sq))));
+    }
+
+    return 16 * constants::alpha_fine_structure * constants::na_avogadro
+           * ipow<2>(electron_mass_ * constants::r_electron) * atomic_number
+           * (atomic_number * phi_n + phi_e)
+           * (1
+              - rel_energy_transfer
+                    * (1 - real_type(0.75) * rel_energy_transfer))
+           / (3 * inc_mass_sq * value_as<Energy>(energy) * atomic_mass);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/test/celeritas/em/MuBremsstrahlung.test.cc
+++ b/test/celeritas/em/MuBremsstrahlung.test.cc
@@ -24,7 +24,7 @@ namespace test
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class MuBremsstrahlungInteractorTest : public InteractorHostTestBase
+class MuBremsstrahlungTest : public InteractorHostTestBase
 {
     using Base = InteractorHostTestBase;
 
@@ -99,7 +99,40 @@ class MuBremsstrahlungInteractorTest : public InteractorHostTestBase
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST_F(MuBremsstrahlungInteractorTest, basic)
+TEST_F(MuBremsstrahlungTest, dcs)
+{
+    auto particle = this->particle_track();
+    auto element
+        = this->material_track().make_material_view().make_element_view(
+            ElementComponentId{0});
+
+    MuBremsDiffXsCalculator calc_dcs(
+        element, particle.energy(), particle.mass(), data_.electron_mass);
+
+    std::vector<real_type> dcs;
+    for (real_type gamma_energy :
+         {1e-3, 5e-3, 1e-2, 5e-2, 0.1, 1.0, 10.0, 1e2, 1e3, 1e4})
+    {
+        dcs.push_back(calc_dcs(MevEnergy{gamma_energy}));
+    }
+
+    // Note: these are "gold" differential cross sections by the photon energy
+    static double const expected_dcs[] = {
+        0.004767766673037,
+        0.00095316629837454,
+        0.00047634214548039,
+        9.4889763823363e-05,
+        4.7216419355064e-05,
+        4.4118702152857e-06,
+        3.4059618626578e-07,
+        1.8880368752007e-08,
+        1.2292516852155e-10,
+        0,
+    };
+    EXPECT_VEC_SOFT_EQ(expected_dcs, dcs);
+}
+
+TEST_F(MuBremsstrahlungTest, basic)
 {
     // Reserve 4 secondaries
     int num_samples = 4;
@@ -163,7 +196,7 @@ TEST_F(MuBremsstrahlungInteractorTest, basic)
     }
 }
 
-TEST_F(MuBremsstrahlungInteractorTest, stress_test)
+TEST_F(MuBremsstrahlungTest, stress_test)
 {
     unsigned int const num_samples = 10000;
     std::vector<real_type> avg_engine_samples;

--- a/test/celeritas/em/MuBremsstrahlung.test.cc
+++ b/test/celeritas/em/MuBremsstrahlung.test.cc
@@ -113,7 +113,8 @@ TEST_F(MuBremsstrahlungTest, dcs)
     for (real_type gamma_energy :
          {1e-3, 5e-3, 1e-2, 5e-2, 0.1, 1.0, 10.0, 1e2, 1e3, 1e4})
     {
-        dcs.push_back(calc_dcs(MevEnergy{gamma_energy}));
+        dcs.push_back(calc_dcs(MevEnergy{gamma_energy})
+                      / ipow<2>(units::centimeter));
     }
 
     // Note: these are "gold" differential cross sections by the photon energy


### PR DESCRIPTION
This moves the muon bremsstrahlung differential cross sectionn calculation into a helper class and adds some additional documentation and a test. This should be a pure refactor with no changes to the results.