### PR TITLE
Add cascade collider

### DIFF
--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -49,6 +49,7 @@ list(APPEND SOURCES
   global/detail/ActionSequence.cc
   global/detail/PinnedAllocator.cc
   grid/GenericGridBuilder.cc
+  grid/TwodGridBuilder.cc
   grid/ValueGridBuilder.cc
   grid/ValueGridInserter.cc
   grid/ValueGridType.cc

--- a/src/celeritas/grid/TwodGridBuilder.cc
+++ b/src/celeritas/grid/TwodGridBuilder.cc
@@ -1,0 +1,68 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/grid/TwodGridBuilder.cc
+//---------------------------------------------------------------------------//
+#include "TwodGridBuilder.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with pointers to data that will be modified.
+ */
+TwodGridBuilder::TwodGridBuilder(Items<real_type>* reals) : reals_{reals}
+{
+    CELER_EXPECT(reals);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add a 2D grid of float data.
+ */
+auto TwodGridBuilder::operator()(SpanConstFlt grid_x,
+                                 SpanConstFlt grid_y,
+                                 SpanConstFlt values) -> TwodGrid
+{
+    return this->insert_impl(grid_x, grid_y, values);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add a 2D grid of double data.
+ */
+auto TwodGridBuilder::operator()(SpanConstDbl grid_x,
+                                 SpanConstDbl grid_y,
+                                 SpanConstDbl values) -> TwodGrid
+{
+    return this->insert_impl(grid_x, grid_y, values);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add a 2D grid from container references.
+ */
+template<class T>
+auto TwodGridBuilder::insert_impl(Span<T const> grid_x,
+                                  Span<T const> grid_y,
+                                  Span<T const> values) -> TwodGrid
+{
+    CELER_EXPECT(grid_x.size() >= 2);
+    CELER_EXPECT(grid_x.front() <= grid_x.back());
+    CELER_EXPECT(grid_y.size() >= 2);
+    CELER_EXPECT(grid_y.front() <= grid_y.back());
+    CELER_EXPECT(values.size() == grid_x.size() * grid_y.size());
+
+    TwodGrid result;
+    result.x = reals_.insert_back(grid_x.begin(), grid_x.end());
+    result.y = reals_.insert_back(grid_y.begin(), grid_y.end());
+    result.values = reals_.insert_back(values.begin(), values.end());
+
+    CELER_ENSURE(result);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/grid/TwodGridBuilder.hh
+++ b/src/celeritas/grid/TwodGridBuilder.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/grid/GenericGridBuilder.hh
+//! \file celeritas/grid/TwodGridBuilder.hh
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/celeritas/grid/TwodGridBuilder.hh
+++ b/src/celeritas/grid/TwodGridBuilder.hh
@@ -1,0 +1,58 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/grid/GenericGridBuilder.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/data/Collection.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "corecel/data/DedupeCollectionBuilder.hh"
+#include "corecel/grid/TwodGridData.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a generic 2D grid.
+ *
+ * This uses a deduplicating inserter for real values to improve cacheing.
+ */
+class TwodGridBuilder
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    template<class T>
+    using Items = Collection<T, Ownership::value, MemSpace::host>;
+    using TwodGrid = TwodGridData;
+    using SpanConstFlt = Span<float const>;
+    using SpanConstDbl = Span<double const>;
+    //!@}
+
+  public:
+    // Construct with pointers to data that will be modified
+    explicit TwodGridBuilder(Items<real_type>* reals);
+
+    // Add a 2D grid of generic data with linear interpolation
+    TwodGrid
+    operator()(SpanConstFlt grid_x, SpanConstFlt grid_y, SpanConstFlt values);
+
+    // Add a 2D grid of generic data with linear interpolation
+    TwodGrid
+    operator()(SpanConstDbl grid_x, SpanConstDbl grid_y, SpanConstDbl values);
+
+  private:
+    DedupeCollectionBuilder<real_type> reals_;
+
+    // Insert with floating point conversion if needed
+    template<class T>
+    TwodGrid insert_impl(Span<T const> grid_x,
+                         Span<T const> grid_y,
+                         Span<T const> values);
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/neutron/data/NeutronInelasticData.hh
+++ b/src/celeritas/neutron/data/NeutronInelasticData.hh
@@ -10,6 +10,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
+#include "corecel/grid/TwodGridData.hh"
 #include "corecel/math/Quantity.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
@@ -32,7 +33,7 @@ struct NeutronInelasticScalars
     units::MevMass proton_mass;
 
     //! Number of nucleon-nucleon channels
-    static CELER_CONSTEXPR_FUNCTION size_type num_channels() { return 3; }
+    static CELER_CONSTEXPR_FUNCTION size_type num_channels() { return 2; }
 
     //! Model's maximum energy limit [MeV]
     static CELER_CONSTEXPR_FUNCTION units::MevEnergy max_valid_energy()
@@ -152,6 +153,9 @@ struct NeutronInelasticData
     // Parameters of necleon-nucleon cross sections below 10 MeV
     ChannelItems<StepanovParameters> xs_params;
 
+    // Tabulated nucleon-nucleon angular distribution data
+    ChannelItems<TwodGridData> angular_cdf;
+
     // Backend data
     Items<real_type> reals;
 
@@ -162,7 +166,8 @@ struct NeutronInelasticData
     explicit CELER_FUNCTION operator bool() const
     {
         return scalars && !micro_xs.empty() && !nucleon_xs.empty()
-               && !xs_params.empty() && !reals.empty() && nuclear_zones;
+               && !xs_params.empty() && !reals.empty() && nuclear_zones
+               && !angular_cdf.empty();
     }
 
     //! Assign from another set of data
@@ -176,6 +181,8 @@ struct NeutronInelasticData
         xs_params = other.xs_params;
         reals = other.reals;
         nuclear_zones = other.nuclear_zones;
+        angular_cdf = other.angular_cdf;
+
         return *this;
     }
 };

--- a/src/celeritas/neutron/interactor/ChipsNeutronElasticInteractor.hh
+++ b/src/celeritas/neutron/interactor/ChipsNeutronElasticInteractor.hh
@@ -143,7 +143,7 @@ CELER_FUNCTION Interaction ChipsNeutronElasticInteractor::operator()(Engine& rng
 
     FourVector lv({{0, 0, value_as<units::MevMomentum>(neutron_p_)},
                    neutron_energy_ + target_mass});
-    boost(boost_vector(lv), &nlv1);
+    lorentz::boost(lorentz::boost_vector(lv), &nlv1);
 
     result.direction = rotate(make_unit_vector(nlv1.mom), inc_direction_);
 

--- a/src/celeritas/neutron/interactor/ChipsNeutronElasticInteractor.hh
+++ b/src/celeritas/neutron/interactor/ChipsNeutronElasticInteractor.hh
@@ -143,7 +143,7 @@ CELER_FUNCTION Interaction ChipsNeutronElasticInteractor::operator()(Engine& rng
 
     FourVector lv({{0, 0, value_as<units::MevMomentum>(neutron_p_)},
                    neutron_energy_ + target_mass});
-    lorentz::boost(lorentz::boost_vector(lv), &nlv1);
+    boost(boost_vector(lv), &nlv1);
 
     result.direction = rotate(make_unit_vector(nlv1.mom), inc_direction_);
 

--- a/src/celeritas/neutron/interactor/detail/CascadeCollider.hh
+++ b/src/celeritas/neutron/interactor/detail/CascadeCollider.hh
@@ -109,7 +109,7 @@ CascadeCollider::CascadeCollider(NeutronInelasticRef const& shared,
     // Initialize the boost velocity and momentum in the center of mass frame
     FourVector sum_four_vec = bullet_.four_vec + target_.four_vec;
     cm_velocity_ = boost_vector(sum_four_vec);
-    cm_p_ = calc_cm_p(sum_four_vec);
+    cm_p_ = this->calc_cm_p(sum_four_vec);
 
     // Calculate the kinetic energy in the target rest frame
     FourVector bullet_p = bullet_.four_vec;
@@ -123,7 +123,7 @@ CascadeCollider::CascadeCollider(NeutronInelasticRef const& shared,
  * nucleon-nucleon collision in the center of mass (c.m.) frame and return
  * them after converting momentum to the lab frame. This performs the same
  * sampling routine as in Geant4's G4ElementaryParticleCollider, mainly
- * implemented in collider and generateSCMfinalState methods. The cos\theta
+ * implemented in collide and generateSCMfinalState methods. The cos\theta
  * distribution in c.m. is inversely sampled using the tabulated cumulative
  * distribution function (c.d.f) data in the kinetic energy and cos\theta bins
  * which are implemented in G4CascadeFinalStateAlgorithm::GenerateTwoBody and
@@ -215,7 +215,7 @@ CELER_FUNCTION auto CascadeCollider::operator()(Engine& rng) -> FinalState
 //---------------------------------------------------------------------------//
 /*!
  * Calculate the momentum magnitude of outgoing particles in the center of mass
- * (c.m.) frame. See Geant4's 4G4VHadDecayAlgorithm::TwoBodyMomentum method.
+ * (c.m.) frame. See Geant4's G4VHadDecayAlgorithm::TwoBodyMomentum method.
  */
 CELER_FUNCTION real_type CascadeCollider::calc_cm_p(FourVector const& v) const
 {
@@ -225,9 +225,9 @@ CELER_FUNCTION real_type CascadeCollider::calc_cm_p(FourVector const& v) const
     real_type m1 = value_as<MevMass>(bullet_.mass);
     real_type m2 = value_as<MevMass>(target_.mass);
 
-    real_type pc_squre = diffsq(m0, m1 - m2) * diffsq(m0, m1 + m2);
+    real_type pc_sq = diffsq(m0, m1 - m2) * diffsq(m0, m1 + m2);
 
-    return std::sqrt(clamp_to_nonneg(pc_squre)) / (2 * m0);
+    return std::sqrt(clamp_to_nonneg(pc_sq)) / (2 * m0);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/neutron/interactor/detail/CascadeCollider.hh
+++ b/src/celeritas/neutron/interactor/detail/CascadeCollider.hh
@@ -1,0 +1,234 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/neutron/interactor/detail/CascadeCollider.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/grid/NonuniformGrid.hh"
+#include "corecel/grid/TwodGridCalculator.hh"
+#include "corecel/grid/TwodGridData.hh"
+#include "corecel/math/ArrayOperators.hh"
+#include "corecel/math/ArrayUtils.hh"
+#include "celeritas/Quantities.hh"
+#include "celeritas/Types.hh"
+#include "celeritas/phys/FourVector.hh"
+#include "celeritas/random/distribution/GenerateCanonical.hh"
+#include "celeritas/random/distribution/UniformRealDistribution.hh"
+
+#include "CascadeParticle.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Helper class for the nucleon-nucleon intra-nucleus cascade collision.
+ */
+class CascadeCollider
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using FinalState = Array<CascadeParticle, 2>;
+    using MevMass = units::MevMass;
+    //!@}
+
+  public:
+    // Construct with shared data and colliding particles
+    inline CELER_FUNCTION CascadeCollider(NeutronInelasticRef const& shared,
+                                          CascadeParticle const& bullet,
+                                          CascadeParticle const& target);
+
+    // Sample the final state of the two-body intra-nucleus cascade collision
+    template<class Engine>
+    inline CELER_FUNCTION FinalState operator()(Engine& rng);
+
+  private:
+    //// TYPES ////
+
+    using Grid = NonuniformGrid<real_type>;
+    using UniformRealDist = UniformRealDistribution<real_type>;
+
+    //// DATA ////
+
+    // Shared constant data
+    NeutronInelasticRef const& shared_;
+    // Participating cascade particles
+    CascadeParticle const& bullet_;
+    CascadeParticle const& target_;
+
+    // Id for intra-nuclear channels
+    ChannelId ch_id_;
+    // Booster vector in the center of mass frame
+    Real3 cm_velocity_;
+    // Momentum magnitude in the center of mass frame
+    real_type cm_p_;
+    // Kinetic energy in the target rest frame
+    real_type kin_energy_;
+
+    // Sampler
+    UniformRealDist sample_phi_;
+
+    //// CONSTANTS ////
+
+    //! A criteria for coplanarity in the Lorentz transformation
+    static CELER_CONSTEXPR_FUNCTION real_type epsilon()
+    {
+        return real_type{1e-10};
+    }
+
+    //// HELPER FUNCTIONS ////
+
+    //! Calculate the momentum magnitude in the center of mass frame
+    inline CELER_FUNCTION real_type calc_cm_p(FourVector const& v) const;
+};
+
+//---------------------------------------------------------------------------//
+// Inline DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from share data and colliding nucleons in the lab frame.
+ */
+CELER_FUNCTION
+CascadeCollider::CascadeCollider(NeutronInelasticRef const& shared,
+                                 CascadeParticle const& bullet,
+                                 CascadeParticle const& target)
+    : shared_(shared)
+    , bullet_(bullet)
+    , target_(target)
+    , ch_id_(ChannelId{
+          static_cast<size_type>((bullet_.type == target_.type) ? 0 : 1)})
+    , sample_phi_(0, 2 * constants::pi)
+{
+    // Initialize the boost velocity and momentum in the center of mass frame
+    FourVector sum_vec4 = lorentz::add(bullet_.vec4, target_.vec4);
+    cm_velocity_ = lorentz::boost_vector(sum_vec4);
+    cm_p_ = calc_cm_p(sum_vec4);
+
+    // Calculate the kinetic energy in the target rest frame
+    FourVector bullet_p = bullet_.vec4;
+    lorentz::boost(-lorentz::boost_vector(target_.vec4), &bullet_p);
+    kin_energy_ = bullet_p.energy - lorentz::norm(bullet_p);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample the final state of outgoing particles from the two-body intra-nucleus
+ * nucleon-nucleon collision in the center of mass (c.m.) frame and return
+ * them after converting momentum to the lab frame. This performs the same
+ * sampling routine as in Geant4's G4ElementaryParticleCollider, mainly
+ * implemented in collider and generateSCMfinalState methods. The cos\theta
+ * distribution in c.m. is inversely sampled using the tabulated cumulative
+ * distribution function (c.d.f) data in the kinetic energy and cos\theta bins
+ * which are implemented in G4CascadeFinalStateAlgorithm::GenerateTwoBody and
+ * G4NumIntTwoBodyAngDst::GetCosTheta methods.
+ */
+template<class Engine>
+CELER_FUNCTION auto CascadeCollider::operator()(Engine& rng) -> FinalState
+{
+    // Sample cos\theta of outgoing particles in the center of mass frame
+    real_type cdf = generate_canonical(rng);
+    TwodGridData cdf_grid = shared_.angular_cdf[ch_id_];
+    Grid energy_grid(cdf_grid.x, shared_.reals);
+    real_type cos_theta{0};
+
+    if (kin_energy_ < energy_grid.back())
+    {
+        // Find cos\theta from tabulated angular data for a given c.d.f.
+        Grid cos_grid(cdf_grid.y, shared_.reals);
+        TwodGridCalculator calc_cdf(cdf_grid, shared_.reals);
+
+        size_type idx = cos_grid.size() - 2;
+        real_type cdf_upper = 0;
+        real_type cdf_lower = 1;
+
+        do
+        {
+            cdf_upper = cdf_lower;
+            cdf_lower = calc_cdf({kin_energy_, cos_grid[idx]});
+        } while (cdf_lower > cdf && idx-- > 0);
+
+        real_type frac = (cdf - cdf_lower) / (cdf_upper - cdf_lower);
+        cos_theta = fma(frac, cos_grid[idx + 1] - cos_grid[idx], cos_grid[idx]);
+    }
+    else
+    {
+        // Sample the angle outside tabulated data (unlikely)
+        real_type slope = 2 * energy_grid.back() * ipow<2>(cm_p_);
+        cos_theta = std::log(1 + cdf * std::expm1(2 * slope)) / slope - 1;
+    }
+
+    // Sample the momentum of outgoing particles in the center of mass frame
+    Real3 mom = cm_p_ * from_spherical(cos_theta, sample_phi_(rng));
+
+    // Rotate the momentum along the reference z-axis
+    FourVector fv = {mom,
+                     std::sqrt(dot_product(mom, mom)
+                               + ipow<2>(value_as<MevMass>(bullet_.mass)))};
+
+    // Find the final state of outgoing particles
+    FinalState result = {bullet_, target_};
+
+    FourVector cm_vec4 = target_.vec4;
+    lorentz::boost(-cm_velocity_, &cm_vec4);
+
+    Real3 cm_dir = make_unit_vector(-cm_vec4.mom);
+    real_type vel_parallel = dot_product(cm_velocity_, cm_dir);
+
+    // Degenerated if velocity perpendicular to the c.m. momentum is small
+    bool degenerated
+        = (dot_product(cm_velocity_, cm_velocity_) - ipow<2>(vel_parallel)
+           < this->epsilon());
+
+    if (!degenerated)
+    {
+        Real3 vscm = make_unit_vector(cm_velocity_ - vel_parallel * cm_dir);
+        Real3 vxcm = make_unit_vector(cross_product(cm_dir, cm_velocity_));
+        if (norm(vscm) > this->epsilon() && norm(vxcm) > this->epsilon())
+        {
+            result[0].vec4
+                = {{fv.mom[0] * vscm + fv.mom[1] * vxcm + fv.mom[2] * cm_dir},
+                   fv.energy};
+        }
+    }
+
+    result[1].vec4 = {{-result[0].vec4.mom},
+                      std::sqrt(dot_product(mom, mom)
+                                + ipow<2>(value_as<MevMass>(target_.mass)))};
+
+    // Convert the final state to the lab frame
+    for (auto i : range(2))
+    {
+        lorentz::boost(cm_velocity_, &result[i].vec4);
+    }
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the momentum magnitude of outgoing particles in the center of mass
+ * (c.m.) frame. See Geant4's 4G4VHadDecayAlgorithm::TwoBodyMomentum method.
+ */
+CELER_FUNCTION real_type CascadeCollider::calc_cm_p(FourVector const& v) const
+{
+    // The total energy in c.m.
+    real_type m0 = lorentz::norm(v);
+
+    real_type m1 = value_as<MevMass>(bullet_.mass);
+    real_type m2 = value_as<MevMass>(target_.mass);
+
+    real_type pc_squre = diffsq(m0, m1 - m2) * diffsq(m0, m1 + m2);
+
+    return std::sqrt(clamp_to_nonneg(pc_squre)) / (2 * m0);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/neutron/interactor/detail/CascadeCollider.hh
+++ b/src/celeritas/neutron/interactor/detail/CascadeCollider.hh
@@ -183,10 +183,10 @@ CELER_FUNCTION auto CascadeCollider::operator()(Engine& rng) -> FinalState
 
     Real3 vscm = cm_velocity_;
     axpy(-vel_parallel, cm_dir, &vscm);
-    vscm = make_unit_vector(vscm);
 
     if (norm(vscm) > this->epsilon())
     {
+        vscm = make_unit_vector(vscm);
         Real3 vxcm = make_unit_vector(cross_product(cm_dir, cm_velocity_));
         if (norm(vxcm) > this->epsilon())
         {

--- a/src/celeritas/neutron/interactor/detail/CascadeParticle.hh
+++ b/src/celeritas/neutron/interactor/detail/CascadeParticle.hh
@@ -1,0 +1,39 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/neutron/interactor/detail/CascadeParticle.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Types.hh"
+#include "celeritas/Quantities.hh"
+#include "celeritas/Types.hh"
+#include "celeritas/phys/FourVector.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Particle data to track the intra-nuclear cascade interactions.
+ */
+struct CascadeParticle
+{
+    //! Types of cascade particles in intra-nuclear interactions
+    enum class ParticleType
+    {
+        unknown,
+        proton,
+        neutron,
+        gamma
+    };
+
+    ParticleType type{ParticleType::unknown};  //!< Particle type
+    units::MevMass mass;  // !< Particle mass
+    FourVector vec4;  //!< Four momentum in natural MevMomentum and
+                      //!< MevEnergy units
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/neutron/interactor/detail/CascadeParticle.hh
+++ b/src/celeritas/neutron/interactor/detail/CascadeParticle.hh
@@ -31,8 +31,8 @@ struct CascadeParticle
 
     ParticleType type{ParticleType::unknown};  //!< Particle type
     units::MevMass mass;  // !< Particle mass
-    FourVector vec4;  //!< Four momentum in natural MevMomentum and
-                      //!< MevEnergy units
+    FourVector four_vec;  //!< Four momentum in natural MevMomentum and
+                          //!< MevEnergy units
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/neutron/model/NeutronInelasticModel.cc
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.cc
@@ -12,6 +12,7 @@
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
 #include "celeritas/grid/GenericGridBuilder.hh"
+#include "celeritas/grid/TwodGridBuilder.hh"
 #include "celeritas/io/ImportPhysicsVector.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/phys/InteractionApplier.hh"
@@ -65,25 +66,35 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
     }
     CELER_ASSERT(data.micro_xs.size() == materials.num_elements());
 
-    // Build nucleon-nucleon cross section data
+    // Build nucleon-nucleon cross section and angular distribution data
     size_type num_channels = data.scalars.num_channels();
     make_builder(&data.nucleon_xs).reserve(num_channels);
     auto xs_params = make_builder(&data.xs_params);
     xs_params.reserve(num_channels);
 
-    auto bins = this->get_channel_bins();
+    auto xs_energy_bins = this->get_xs_energy_bins();
+    auto cdf_energy_bins = this->get_cdf_energy_bins();
+    auto cos_theta_bins = this->get_cos_theta_bins();
+
     for (auto channel_id : range(ChannelId{num_channels}))
     {
         // Add nucleon-nucleon cross section parameters and data
-        ChannelXsData const& channel_data = this->get_channel_xs(channel_id);
+        ChannelData const& channel_data = this->get_channel_data(channel_id);
         CELER_ASSERT(channel_data.par.slope > 0);
         xs_params.push_back(channel_data.par);
 
         GenericGridBuilder build_grid{&data.reals};
         make_builder(&data.nucleon_xs)
-            .push_back(build_grid(bins, make_span(channel_data.xs)));
+            .push_back(build_grid(xs_energy_bins, make_span(channel_data.xs)));
+
+        // Add nucleon-nucleon two-body angular distribution data
+        TwodGridBuilder build_cdf_grid{&data.reals};
+        make_builder(&data.angular_cdf)
+            .push_back(build_cdf_grid(
+                cdf_energy_bins, cos_theta_bins, make_span(channel_data.cdf)));
     }
     CELER_ASSERT(data.nucleon_xs.size() == num_channels);
+    CELER_ASSERT(data.angular_cdf.size() == num_channels);
     CELER_ASSERT(data.xs_params.size() == data.nucleon_xs.size());
 
     // Build (A, Z)-dependent nuclear zone data
@@ -145,25 +156,29 @@ void NeutronInelasticModel::execute(CoreParams const&, CoreStateDevice&) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the particle-nucleon cross section (in barn) as a function of particle
- * energy. Only neutron-neutron, neutron-proton and proton-proton channels are
+ * Get the particle-nucleon cross section (in barn) and the c.d.f (cumulative
+ * distribution function) of cos \theta distribution as a function of particle
+ * energy. Only neutron-neutron (proton-proton) and neutron-proton channels are
  * tabulated in [10, 320] (MeV) where pion production is not likely. The cross
  * sections below 10 MeV will be calculated on the fly using the Stepanov's
  * function. Tabulated data of cross sections and parameters at the low energy
  * are from G4CascadePPChannel, G4CascadeNPChannel and G4CascadeNNChannel of
- * the Geant4 11.2 release. Also note that the channel cross sections of
- * nucleon-nucleon are same as their total cross sections in the energy range.
+ * the Geant4 11.2 release while angular c.d.f data are from G4PP2PPAngDst and
+ * G4NP2NPAngDst. Also note that the channel cross sections of nucleon-nucleon
+ * are same as their total cross sections in the energy range and the
+ * proton-proton channel is same as the neutron-neutron channel based on the
+ * charge-independence hypothesis of the nuclear force.
  *
  * H. W. Bertini, "Low-Energy Intranuclear Cascade Calculation", Phys. Rev.
  * Vol. 131, page 1801 (1963). W. Hess, "Summary of High-Energy Nucleon-
  * Nucleon Cross-Section Data", Rev. Mod. Phys. Vol. 30, page 368 (1958).
  */
-auto NeutronInelasticModel::get_channel_xs(ChannelId ch_id)
-    -> ChannelXsData const&
+auto NeutronInelasticModel::get_channel_data(ChannelId ch_id)
+    -> ChannelData const&
 {
     CELER_EXPECT(ch_id);
-    static ChannelXsData const channels[]
-        = {{{17.613, 4.00, {0.0069466, 9.0692, -5.0574}},
+    static ChannelData const channels[]
+        = {{{17.613, 4.00, {0.0069466, 9.0692, -5.0574}},  // neutron-neutron
             {0.8633,
              0.6746,
              0.4952,
@@ -176,8 +191,23 @@ auto NeutronInelasticModel::get_channel_xs(ChannelId ch_id)
              0.0552,
              0.0445,
              0.0388,
-             0.0351}},
-           {{20.360, 1.92, {0.0053107, 3.0885, -1.1748}},
+             0.0351},
+            {0.0000, 0.0075, 0.0300, 0.0670, 0.1170, 0.1785, 0.2500, 0.3290,
+             0.4130, 0.5000, 0.5870, 0.6710, 0.7500, 0.8215, 0.8830, 0.9330,
+             0.9700, 0.9925, 1.0000, 0.0000, 0.0095, 0.0361, 0.0766, 0.1284,
+             0.1902, 0.2605, 0.3370, 0.4174, 0.5000, 0.5826, 0.6630, 0.7395,
+             0.8098, 0.8716, 0.9234, 0.9638, 0.9905, 1.0000, 0.0000, 0.0104,
+             0.0388, 0.0808, 0.1334, 0.1954, 0.2652, 0.3405, 0.4193, 0.5000,
+             0.5807, 0.6595, 0.7348, 0.8046, 0.8666, 0.9192, 0.9611, 0.9896,
+             1.0000, 0.0000, 0.0102, 0.0374, 0.0776, 0.1290, 0.1906, 0.2610,
+             0.3375, 0.4177, 0.5000, 0.5823, 0.6625, 0.7390, 0.8094, 0.8710,
+             0.9224, 0.9626, 0.9898, 1.0000, 0.0000, 0.0099, 0.0353, 0.0730,
+             0.1227, 0.1837, 0.2549, 0.3331, 0.4154, 0.5000, 0.5846, 0.6669,
+             0.7451, 0.8163, 0.8773, 0.9270, 0.9647, 0.9901, 1.0000, 0.0000,
+             0.0102, 0.0364, 0.0750, 0.1255, 0.1869, 0.2580, 0.3355, 0.4167,
+             0.5000, 0.5833, 0.6645, 0.7420, 0.8131, 0.8745, 0.9250, 0.9636,
+             0.9898, 1.0000}},
+           {{20.360, 1.92, {0.0053107, 3.0885, -1.1748}},  // neutron-proton
             {0.3024,
              0.2359,
              0.1733,
@@ -190,21 +220,23 @@ auto NeutronInelasticModel::get_channel_xs(ChannelId ch_id)
              0.0278,
              0.0252,
              0.0240,
-             0.0233}},
-           {{17.613, 4.00, {0.0069466, 9.0692, -5.0574}},
-            {0.8633,
-             0.6746,
-             0.4952,
-             0.3760,
-             0.2854,
-             0.2058,
-             0.1357,
-             0.0937,
-             0.0691,
-             0.0552,
-             0.0445,
-             0.0388,
-             0.0351}}};
+             0.0233},
+            {0.0000, 0.0075, 0.0300, 0.0670, 0.1170, 0.1785, 0.2500, 0.3290,
+             0.4130, 0.5000, 0.5870, 0.6710, 0.7500, 0.8215, 0.8830, 0.9330,
+             0.9700, 0.9925, 1.0000, 0.0000, 0.0149, 0.0569, 0.1182, 0.1889,
+             0.2613, 0.3320, 0.3995, 0.4642, 0.5264, 0.5858, 0.6428, 0.6998,
+             0.7596, 0.8229, 0.8872, 0.9450, 0.9855, 1.0000, 0.0000, 0.0180,
+             0.0681, 0.1387, 0.2161, 0.2909, 0.3604, 0.4252, 0.4877, 0.5485,
+             0.6063, 0.6599, 0.7113, 0.7645, 0.8225, 0.8844, 0.9426, 0.9847,
+             1.0000, 0.0000, 0.0235, 0.0876, 0.1746, 0.2638, 0.3428, 0.4101,
+             0.4702, 0.5288, 0.5873, 0.6421, 0.6897, 0.7313, 0.7731, 0.8219,
+             0.8795, 0.9384, 0.9833, 1.0000, 0.0000, 0.0193, 0.0722, 0.1447,
+             0.2200, 0.2874, 0.3448, 0.3965, 0.4488, 0.5062, 0.5685, 0.6331,
+             0.6983, 0.7637, 0.8290, 0.8923, 0.9478, 0.9863, 1.0000, 0.0000,
+             0.0201, 0.0745, 0.1472, 0.2208, 0.2857, 0.3413, 0.3918, 0.4424,
+             0.4971, 0.5569, 0.6205, 0.6864, 0.7531, 0.8197, 0.8849, 0.9434,
+             0.9850, 1.0000}}};
+
     return channels[ch_id.unchecked_get()];
 }
 
@@ -214,10 +246,41 @@ auto NeutronInelasticModel::get_channel_xs(ChannelId ch_id)
  * from the G4PionNucSampler class. Note that the GeV unit is used in the
  * Bertini cascade G4NucleiModel class.
  */
-Span<double const> NeutronInelasticModel::get_channel_bins() const
+Span<double const> NeutronInelasticModel::get_xs_energy_bins() const
 {
-    static ChannelArray const bins
+    static Array<double, 13> const bins
         = {10, 13, 18, 24, 32, 42, 56, 75, 100, 130, 180, 240, 320};
+
+    return make_span(bins);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the energy bins of the two-body nucleon-nucleon angular distribution
+ * data in [0, 320] (MeV) from G4PP2PPAngDst and G4NP2NPAngDst classes. The
+ * number of bins and c.d.f values of the angular probability are reorganized
+ * with a common data structure.
+ */
+Span<double const> NeutronInelasticModel::get_cdf_energy_bins() const
+{
+    static Array<double, 6> const bins = {0, 90, 130, 200, 300, 320};
+
+    return make_span(bins);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the cos \theta bins of the nucleon-nucleon angular distribution data
+ * in [-1, 1] from G4PP2PPAngDst and G4NP2NPAngDst classes.
+ */
+Span<double const> NeutronInelasticModel::get_cos_theta_bins() const
+{
+    // clang-format off
+    static Array<double, 19> const bins
+        = {-1.000, -0.985, -0.940, -0.866, -0.766, -0.643, -0.500,
+           -0.342, -0.174,  0.000,  0.174,  0.342,  0.500,  0.643,
+            0.766,  0.866,  0.940,  0.985, 1.000};
+    // clang-format on
 
     return make_span(bins);
 }

--- a/src/celeritas/neutron/model/NeutronInelasticModel.cc
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.cc
@@ -76,22 +76,22 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
     auto cdf_energy_bins = this->get_cdf_energy_bins();
     auto cos_theta_bins = this->get_cos_theta_bins();
 
+    GenericGridBuilder build_xs_grid{&data.reals};
+    TwodGridBuilder build_cdf_grid{&data.reals};
+    CollectionBuilder nucleon_xs{&data.nucleon_xs};
+    CollectionBuilder angular_cdf{&data.angular_cdf};
     for (auto channel_id : range(ChannelId{num_channels}))
     {
         // Add nucleon-nucleon cross section parameters and data
         ChannelData const& channel_data = this->get_channel_data(channel_id);
         CELER_ASSERT(channel_data.par.slope > 0);
         xs_params.push_back(channel_data.par);
-
-        GenericGridBuilder build_grid{&data.reals};
-        make_builder(&data.nucleon_xs)
-            .push_back(build_grid(xs_energy_bins, make_span(channel_data.xs)));
+        nucleon_xs.push_back(
+            build_xs_grid(xs_energy_bins, make_span(channel_data.xs)));
 
         // Add nucleon-nucleon two-body angular distribution data
-        TwodGridBuilder build_cdf_grid{&data.reals};
-        make_builder(&data.angular_cdf)
-            .push_back(build_cdf_grid(
-                cdf_energy_bins, cos_theta_bins, make_span(channel_data.cdf)));
+        angular_cdf.push_back(build_cdf_grid(
+            cdf_energy_bins, cos_theta_bins, make_span(channel_data.cdf)));
     }
     CELER_ASSERT(data.nucleon_xs.size() == num_channels);
     CELER_ASSERT(data.angular_cdf.size() == num_channels);

--- a/src/celeritas/neutron/model/NeutronInelasticModel.hh
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.hh
@@ -74,18 +74,21 @@ class NeutronInelasticModel final : public Model, public ConcreteAction
     //// TYPES ////
 
     using HostXsData = HostVal<NeutronInelasticData>;
-    using ChannelArray = Array<double, 13>;
 
-    struct ChannelXsData
+    struct ChannelData
     {
         StepanovParameters par;
-        ChannelArray xs;
+        Array<double, 13> xs;
+        Array<double, 19 * 6> cdf;  //! c.d.f[cos_theta_bins][cdf_energy_bins]
     };
 
     //// HELPER FUNCTIONS ////
 
-    Span<double const> get_channel_bins() const;
-    static ChannelXsData const& get_channel_xs(ChannelId id);
+    Span<double const> get_xs_energy_bins() const;
+    static ChannelData const& get_channel_data(ChannelId id);
+
+    Span<double const> get_cdf_energy_bins() const;
+    Span<double const> get_cos_theta_bins() const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/neutron/model/NeutronInelasticModel.hh
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.hh
@@ -79,7 +79,7 @@ class NeutronInelasticModel final : public Model, public ConcreteAction
     {
         StepanovParameters par;
         Array<double, 13> xs;
-        Array<double, 19 * 6> cdf;  //! c.d.f[cos_theta_bins][cdf_energy_bins]
+        Array<double, 6 * 19> cdf;  //! [energy][angle]
     };
 
     //// HELPER FUNCTIONS ////

--- a/src/celeritas/phys/FourVector.hh
+++ b/src/celeritas/phys/FourVector.hh
@@ -28,6 +28,8 @@ struct FourVector
     real_type energy{0};  //!< Particle energy
 };
 
+namespace lorentz
+{
 //---------------------------------------------------------------------------//
 // INLINE UTILITY FUNCTIONS
 //---------------------------------------------------------------------------//
@@ -62,4 +64,26 @@ inline CELER_FUNCTION void boost(Real3 const& v, FourVector* p)
     p->energy = gamma * (p->energy + vp);
 }
 
+//---------------------------------------------------------------------------//
+/*!
+ * Add two four-vectors.
+ */
+inline CELER_FUNCTION FourVector add(FourVector const& a, FourVector const& b)
+{
+    FourVector result;
+    result.mom = a.mom + b.mom;
+    result.energy = a.energy + b.energy;
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the magnitude of a four vector.
+ */
+inline CELER_FUNCTION real_type norm(FourVector const& a)
+{
+    return std::sqrt(std::fabs(ipow<2>(a.energy) - dot_product(a.mom, a.mom)));
+}
+
+}  // namespace lorentz
 }  // namespace celeritas

--- a/src/celeritas/phys/FourVector.hh
+++ b/src/celeritas/phys/FourVector.hh
@@ -9,6 +9,7 @@
 
 #include "corecel/cont/Array.hh"
 #include "corecel/math/ArrayOperators.hh"
+#include "corecel/math/ArrayUtils.hh"
 #include "geocel/Types.hh"
 #include "celeritas/Types.hh"
 
@@ -26,12 +27,29 @@ struct FourVector
 
     Real3 mom{0, 0, 0};  //!< Particle momentum
     real_type energy{0};  //!< Particle energy
+
+    // Assignment operator (+=)
+    inline CELER_FUNCTION FourVector& operator+=(FourVector const& v)
+    {
+        mom += v.mom;
+        energy += v.energy;
+        return *this;
+    }
 };
 
-namespace lorentz
-{
 //---------------------------------------------------------------------------//
 // INLINE UTILITY FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Add two four-vectors.
+ */
+inline CELER_FUNCTION FourVector operator+(FourVector const& lhs,
+                                           FourVector const& rhs)
+{
+    FourVector result = lhs;
+    return std::move(result += rhs);
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Get the boost vector (\f$ \frac{\vec{mom}}/{energy} \f$) of a four-vector.
@@ -66,18 +84,6 @@ inline CELER_FUNCTION void boost(Real3 const& v, FourVector* p)
 
 //---------------------------------------------------------------------------//
 /*!
- * Add two four-vectors.
- */
-inline CELER_FUNCTION FourVector add(FourVector const& a, FourVector const& b)
-{
-    FourVector result;
-    result.mom = a.mom + b.mom;
-    result.energy = a.energy + b.energy;
-    return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Calculate the magnitude of a four vector.
  */
 inline CELER_FUNCTION real_type norm(FourVector const& a)
@@ -85,5 +91,4 @@ inline CELER_FUNCTION real_type norm(FourVector const& a)
     return std::sqrt(std::fabs(ipow<2>(a.energy) - dot_product(a.mom, a.mom)));
 }
 
-}  // namespace lorentz
 }  // namespace celeritas

--- a/src/celeritas/phys/FourVector.hh
+++ b/src/celeritas/phys/FourVector.hh
@@ -47,7 +47,7 @@ inline CELER_FUNCTION FourVector operator+(FourVector const& lhs,
                                            FourVector const& rhs)
 {
     FourVector result = lhs;
-    return std::move(result += rhs);
+    return result += rhs;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -302,6 +302,7 @@ celeritas_add_test(neutron/NeutronInelastic.test.cc ${_needs_double})
 #-----------------------------------------------------------------------------#
 # Phys
 celeritas_add_test(phys/CutoffParams.test.cc)
+celeritas_add_test(phys/FourVector.test.cc)
 celeritas_add_device_test(phys/Particle)
 celeritas_add_device_test(phys/Physics)
 celeritas_add_test(phys/InteractionUtils.test.cc)

--- a/test/celeritas/neutron/NeutronInelastic.test.cc
+++ b/test/celeritas/neutron/NeutronInelastic.test.cc
@@ -455,10 +455,10 @@ TEST_F(NeutronInelasticTest, cascade_collider)
 
     for (auto i : range(2))
     {
-        EXPECT_SOFT_EQ(expected_nn_energy[i], nn_result[i].vec4.energy);
-        EXPECT_SOFT_EQ(expected_np_energy[i], np_result[i].vec4.energy);
-        EXPECT_VEC_SOFT_EQ(expected_nn_mom[i], nn_result[i].vec4.mom);
-        EXPECT_VEC_SOFT_EQ(expected_np_mom[i], np_result[i].vec4.mom);
+        EXPECT_SOFT_EQ(expected_nn_energy[i], nn_result[i].four_vec.energy);
+        EXPECT_SOFT_EQ(expected_np_energy[i], np_result[i].four_vec.energy);
+        EXPECT_VEC_SOFT_EQ(expected_nn_mom[i], nn_result[i].four_vec.mom);
+        EXPECT_VEC_SOFT_EQ(expected_np_mom[i], np_result[i].four_vec.mom);
     }
 }
 

--- a/test/celeritas/phys/FourVector.test.cc
+++ b/test/celeritas/phys/FourVector.test.cc
@@ -37,8 +37,8 @@ TEST(FourVectorTest, basic)
 
     // Test boost_vector
     Real3 expected_boost_vector = {0.001, 0.002, 0.003};
-    EXPECT_EQ(a.mom / a.energy, boost_vector(a));
-    EXPECT_EQ(expected_boost_vector, boost_vector(a));
+    EXPECT_VEC_SOFT_EQ(a.mom / a.energy, boost_vector(a));
+    EXPECT_VEC_SOFT_EQ(expected_boost_vector, boost_vector(a));
 
     // Test boost
     boost(boost_vector(a), &b);

--- a/test/celeritas/phys/FourVector.test.cc
+++ b/test/celeritas/phys/FourVector.test.cc
@@ -1,0 +1,53 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/phys/FourVector.test.cc
+//---------------------------------------------------------------------------//
+#include "celeritas/phys/FourVector.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+
+TEST(FourVectorTest, basic)
+{
+    // Test addition
+    FourVector a{{1, 2, 3}, 1000};
+    FourVector b{{4, 5, 6}, 2000};
+    FourVector c = a + b;
+
+    Real3 expected_mom = {5, 7, 9};
+    EXPECT_DOUBLE_EQ(a.energy + b.energy, c.energy);
+    EXPECT_DOUBLE_EQ(3000, c.energy);
+    EXPECT_EQ(a.mom + b.mom, c.mom);
+    EXPECT_EQ(expected_mom, c.mom);
+
+    // Test norm
+    EXPECT_DOUBLE_EQ(std::sqrt(ipow<2>(c.energy) - dot_product(c.mom, c.mom)),
+                     norm(c));
+    EXPECT_DOUBLE_EQ(2999.9741665554388, norm(c));
+
+    // Test boost_vector
+    Real3 expected_boost_vector = {0.001, 0.002, 0.003};
+    EXPECT_EQ(a.mom / a.energy, boost_vector(a));
+    EXPECT_EQ(expected_boost_vector, boost_vector(a));
+
+    // Test boost
+    boost(boost_vector(a), &b);
+    Real3 expected_boosted_mom
+        = {6.0000300003150038, 9.0000600006300076, 12.000090000945011};
+    EXPECT_EQ(expected_boosted_mom, b.mom);
+    EXPECT_DOUBLE_EQ(2000.0460003710041, b.energy);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/phys/FourVector.test.cc
+++ b/test/celeritas/phys/FourVector.test.cc
@@ -33,7 +33,7 @@ TEST(FourVectorTest, basic)
     // Test norm
     EXPECT_DOUBLE_EQ(std::sqrt(ipow<2>(c.energy) - dot_product(c.mom, c.mom)),
                      norm(c));
-    EXPECT_DOUBLE_EQ(2999.9741665554388, norm(c));
+    EXPECT_SOFT_EQ(2999.9741665554388, norm(c));
 
     // Test boost_vector
     Real3 expected_boost_vector = {0.001, 0.002, 0.003};
@@ -44,8 +44,8 @@ TEST(FourVectorTest, basic)
     boost(boost_vector(a), &b);
     Real3 expected_boosted_mom
         = {6.0000300003150038, 9.0000600006300076, 12.000090000945011};
-    EXPECT_EQ(expected_boosted_mom, b.mom);
-    EXPECT_DOUBLE_EQ(2000.0460003710041, b.energy);
+    EXPECT_VEC_SOFT_EQ(expected_boosted_mom, b.mom);
+    EXPECT_SOFT_EQ(2000.0460003710041, b.energy);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
# Add a helper for intra-nucleus nucleon-nucleon collisions
 - Add TwodGridBuilder and angular distribution data for sampling cos\theta of the intra-nucleus nucleon-nucleon scattering.
 -  Add CascadeCollider and CascadeParticle for sampling the final state of the ntra-nucleus cascade collision and an associated test.
 - Add namespace lorentz for FourVector and a couple of utility functions

