### PR TITLE
Refactor types to reduce duplication and cyclic dependencies

### DIFF
--- a/src/celeritas/grid/GridIdFinder.hh
+++ b/src/celeritas/grid/GridIdFinder.hh
@@ -10,6 +10,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/data/LdgIterator.hh"
 #include "corecel/math/Algorithms.hh"
 
 namespace celeritas

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -98,7 +98,7 @@ class OpaqueId
     CELER_CONSTEXPR_FUNCTION size_type unchecked_get() const { return value_; }
 
     //! Access the underlying data for more efficient loading from memory
-    size_type const* data() const { return &value_; }
+    CELER_CONSTEXPR_FUNCTION size_type const* data() const { return &value_; }
 
   private:
     size_type value_;

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -17,12 +17,6 @@
 
 namespace celeritas
 {
-namespace detail
-{
-template<class, class>
-struct LdgLoader;
-}  // namespace detail
-
 //---------------------------------------------------------------------------//
 /*!
  * Type-safe index for accessing an array or collection of data.
@@ -103,6 +97,9 @@ class OpaqueId
     //! Get the value without checking for validity (atypical)
     CELER_CONSTEXPR_FUNCTION size_type unchecked_get() const { return value_; }
 
+    //! Access the underlying data for more efficient loading from memory
+    size_type const* data() const { return &value_; }
+
   private:
     size_type value_;
 
@@ -113,7 +110,6 @@ class OpaqueId
     {
         return static_cast<size_type>(-1);
     }
-    friend detail::LdgLoader<OpaqueId<value_type, size_type> const, void>;
 };
 
 //---------------------------------------------------------------------------//
@@ -139,6 +135,7 @@ CELER_DEFINE_OPAQUEID_CMP(>=)
 
 #undef CELER_DEFINE_OPAQUEID_CMP
 
+//---------------------------------------------------------------------------//
 //! Allow less-than comparison with *integer* for container comparison
 template<class V, class S, class U>
 CELER_CONSTEXPR_FUNCTION bool operator<(OpaqueId<V, S> lhs, U rhs)
@@ -147,6 +144,7 @@ CELER_CONSTEXPR_FUNCTION bool operator<(OpaqueId<V, S> lhs, U rhs)
     return lhs && (U(lhs.unchecked_get()) < rhs);
 }
 
+//---------------------------------------------------------------------------//
 //! Allow less-than-equal comparison with *integer* for container comparison
 template<class V, class S, class U>
 CELER_CONSTEXPR_FUNCTION bool operator<=(OpaqueId<V, S> lhs, U rhs)
@@ -155,6 +153,7 @@ CELER_CONSTEXPR_FUNCTION bool operator<=(OpaqueId<V, S> lhs, U rhs)
     return lhs && (U(lhs.unchecked_get()) <= rhs);
 }
 
+//---------------------------------------------------------------------------//
 //! Get the distance between two opaque IDs
 template<class V, class S>
 inline CELER_FUNCTION S operator-(OpaqueId<V, S> self, OpaqueId<V, S> other)
@@ -164,6 +163,7 @@ inline CELER_FUNCTION S operator-(OpaqueId<V, S> self, OpaqueId<V, S> other)
     return self.unchecked_get() - other.unchecked_get();
 }
 
+//---------------------------------------------------------------------------//
 //! Increment an opaque ID by an offset
 template<class V, class S>
 inline CELER_FUNCTION OpaqueId<V, S>
@@ -174,6 +174,7 @@ operator+(OpaqueId<V, S> id, std::make_signed_t<S> offset)
     return OpaqueId<V, S>{id.unchecked_get() + static_cast<S>(offset)};
 }
 
+//---------------------------------------------------------------------------//
 //! Decrement an opaque ID by an offset
 template<class V, class S>
 inline CELER_FUNCTION OpaqueId<V, S>
@@ -184,25 +185,7 @@ operator-(OpaqueId<V, S> id, std::make_signed_t<S> offset)
     return OpaqueId<V, S>{id.unchecked_get() - static_cast<S>(offset)};
 }
 
-namespace detail
-{
-//! Template matching to determine if T is an OpaqueId
-template<class T>
-struct IsOpaqueId : std::false_type
-{
-};
-template<class V, class S>
-struct IsOpaqueId<OpaqueId<V, S>> : std::true_type
-{
-};
-template<class V, class S>
-struct IsOpaqueId<OpaqueId<V, S> const> : std::true_type
-{
-};
-template<class T>
-inline constexpr bool is_opaque_id_v = IsOpaqueId<T>::value;
 //---------------------------------------------------------------------------//
-}  // namespace detail
 }  // namespace celeritas
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -10,9 +10,8 @@
 #include <cstddef>
 #include <type_traits>
 
-#include "corecel/data/LdgIterator.hh"
-
 #include "Array.hh"
+
 #include "detail/SpanImpl.hh"
 
 namespace celeritas
@@ -189,10 +188,6 @@ class Span
 template<class T, std::size_t N>
 constexpr std::size_t Span<T, N>::extent;
 
-//! Alias for a Span iterating over values read using __ldg
-template<class T, std::size_t Extent = dynamic_extent>
-using LdgSpan = Span<LdgValue<T>, Extent>;
-
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//
@@ -239,27 +234,6 @@ CELER_FUNCTION Span<typename T::value_type const> make_span(T const& cont)
 //! Construct an array from a fixed-size span
 template<class T, std::size_t N>
 CELER_CONSTEXPR_FUNCTION auto make_array(Span<T, N> const& s)
-{
-    Array<std::remove_cv_t<T>, N> result{};
-    for (std::size_t i = 0; i < N; ++i)
-    {
-        result[i] = s[i];
-    }
-    return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct an array from a fixed-size span, removing LdgValue marker.
- *
- * Note: \code make_array(Span<T,N> const&) \endcode is not reused because:
- * 1. Using this overload reads input data using \c __ldg
- * 2. \code return make_array<T, N>(s) \endcode results in segfault (gcc 11.3).
- *    This might be a compiler bug because temporary lifetime should be
- *    extended until the end of the expression and we return a copy...
- */
-template<class T, std::size_t N>
-CELER_CONSTEXPR_FUNCTION auto make_array(LdgSpan<T, N> const& s)
 {
     Array<std::remove_cv_t<T>, N> result{};
     for (std::size_t i = 0; i < N; ++i)

--- a/src/corecel/cont/detail/SpanImpl.hh
+++ b/src/corecel/cont/detail/SpanImpl.hh
@@ -13,10 +13,16 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/OpaqueId.hh"
-#include "corecel/data/LdgIterator.hh"
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+template<class T>
+struct LdgValue;
+template<class T>
+class LdgIterator;
+
+//---------------------------------------------------------------------------//
 namespace detail
 {
 //---------------------------------------------------------------------------//
@@ -58,7 +64,7 @@ struct SpanTraits<LdgValue<T>>
 
 //---------------------------------------------------------------------------//
 //! Sentinel value for span of dynamic type
-constexpr std::size_t dynamic_extent = std::size_t(-1);
+inline constexpr std::size_t dynamic_extent = std::size_t(-1);
 
 //---------------------------------------------------------------------------//
 //! Calculate the return type for a subspan

--- a/src/corecel/data/detail/CollectionImpl.hh
+++ b/src/corecel/data/detail/CollectionImpl.hh
@@ -22,7 +22,7 @@
 #include "corecel/sys/Device.hh"
 
 #include "DisabledStorage.hh"
-#include "LdgIteratorImpl.hh"
+#include "TypeTraits.hh"
 #include "../Copier.hh"
 #include "../LdgIterator.hh"
 #include "../PinnedAllocator.hh"

--- a/src/corecel/data/detail/LdgIteratorImpl.hh
+++ b/src/corecel/data/detail/LdgIteratorImpl.hh
@@ -47,6 +47,8 @@ CELER_CONSTEXPR_FUNCTION T ldg(T const* ptr)
 template<class T, typename = void>
 struct LdgLoader
 {
+    static_assert(std::is_const_v<T>, "Only const data are supported by __ldg");
+
     using value_type = std::remove_const_t<T>;
     using pointer = std::add_pointer_t<value_type const>;
     using reference = value_type;
@@ -87,7 +89,7 @@ struct LdgLoader<Quantity<I, T> const, void>
 
     CELER_CONSTEXPR_FUNCTION static reference read(pointer p)
     {
-        return ldg(p->data());
+        return value_type{ldg(p->data())};
     }
 };
 

--- a/src/corecel/data/detail/TypeTraits.hh
+++ b/src/corecel/data/detail/TypeTraits.hh
@@ -1,0 +1,74 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/data/detail/TypeTraits.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <type_traits>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+template<class ValueT, class SizeT>
+class OpaqueId;
+
+template<class UnitT, class ValueT>
+class Quantity;
+
+namespace detail
+{
+//---------------------------------------------------------------------------//
+//! Template matching to determine if T is an OpaqueId
+template<class T>
+struct IsOpaqueId : std::false_type
+{
+};
+
+template<class V, class S>
+struct IsOpaqueId<OpaqueId<V, S>> : std::true_type
+{
+};
+
+template<class V, class S>
+struct IsOpaqueId<OpaqueId<V, S> const> : std::true_type
+{
+};
+
+//! Template matching to determine if T is a Quantity
+template<class T>
+struct IsQuantity : std::false_type
+{
+};
+template<class V, class S>
+struct IsQuantity<Quantity<V, S>> : std::true_type
+{
+};
+template<class V, class S>
+struct IsQuantity<Quantity<V, S> const> : std::true_type
+{
+};
+
+//---------------------------------------------------------------------------//
+//! True if T is an OpaqueID
+template<class T>
+inline constexpr bool is_opaque_id_v = IsOpaqueId<T>::value;
+
+//---------------------------------------------------------------------------//
+//! True if T is a Quantity
+template<class T>
+inline constexpr bool is_quantity_v = IsQuantity<T>::value;
+
+//---------------------------------------------------------------------------//
+//! True if T is supported by a LdgLoader specialization
+template<class T>
+inline constexpr bool is_ldg_supported_v
+    = std::is_const_v<T>
+      && (std::is_arithmetic_v<T> || is_opaque_id_v<T> || is_quantity_v<T>
+          || std::is_enum_v<T>);
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -17,13 +17,6 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-namespace detail
-{
-template<class, class>
-struct LdgLoader;
-}
-
-//---------------------------------------------------------------------------//
 /*!
  * A numerical value tagged with a unit.
  * \tparam UnitT  unit tag class
@@ -121,10 +114,11 @@ class Quantity
 #undef CELER_DEFINE_QACCESS
     //!@}
 
+    //! Access the underlying data for more efficient loading from memory
+    value_type const* data() const { return &value_; }
+
   private:
     value_type value_{};
-
-    friend detail::LdgLoader<Quantity<unit_type, value_type> const, void>;
 };
 
 //---------------------------------------------------------------------------//
@@ -328,24 +322,5 @@ inline char const* accessor_unit_label()
     return detail::AccessorResultType<T>::unit_type::label();
 }
 
-namespace detail
-{
-//! Template matching to determine if T is a Quantity
-template<class T>
-struct IsQuantity : std::false_type
-{
-};
-template<class V, class S>
-struct IsQuantity<Quantity<V, S>> : std::true_type
-{
-};
-template<class V, class S>
-struct IsQuantity<Quantity<V, S> const> : std::true_type
-{
-};
-template<class T>
-inline constexpr bool is_quantity_v = IsQuantity<T>::value;
-
 //---------------------------------------------------------------------------//
-}  // namespace detail
 }  // namespace celeritas

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -115,7 +115,7 @@ class Quantity
     //!@}
 
     //! Access the underlying data for more efficient loading from memory
-    value_type const* data() const { return &value_; }
+    CELER_CONSTEXPR_FUNCTION value_type const* data() const { return &value_; }
 
   private:
     value_type value_{};

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -27,7 +27,7 @@ class GeoParamsInterface
   public:
     //!@{
     //! \name Type aliases
-    using SpanConstVolumeId = LdgSpan<VolumeId const>;
+    using SpanConstVolumeId = Span<VolumeId const>;
     //!@}
 
   public:

--- a/src/geocel/Types.hh
+++ b/src/geocel/Types.hh
@@ -18,8 +18,14 @@ namespace celeritas
 // TYPE ALIASES
 //---------------------------------------------------------------------------//
 
-//! Fixed-size array for 3D space
+//! Three-dimensional cartesian coordinates
 using Real3 = Array<real_type, 3>;
+
+//! Two-dimensional cartesian coordinates
+using Real2 = Array<real_type, 2>;
+
+//! Two-dimensional extents
+using Size2 = Array<size_type, 2>;
 
 //! Alias for a small square dense matrix
 template<class T, size_type N>
@@ -31,7 +37,6 @@ using SquareMatrixReal3 = SquareMatrix<real_type, 3>;
 //---------------------------------------------------------------------------//
 
 //! Identifier for a material fill
-// TODO: rename MaterialId, see celeritas/Types.hh
 using GeoMaterialId = OpaqueId<struct GeoMaterial_>;
 
 //! Identifier for a surface (for surface-based geometries)

--- a/src/geocel/rasterize/ImageData.hh
+++ b/src/geocel/rasterize/ImageData.hh
@@ -33,8 +33,6 @@ namespace celeritas
  */
 struct ImageParamsScalars
 {
-    using Size2 = Array<size_type, 2>;
-
     Real3 origin{};  //!< Upper left corner
     Real3 down{};  //!< Downward basis vector
     Real3 right{};  //!< Rightward basis vector (increasing i, track movement)

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -314,10 +314,10 @@ auto SolidConverter::cons(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Cons const&>(solid_base);
 
-    auto const outer_r = scale_.to<Cone::Real2>(solid.GetOuterRadiusMinusZ(),
-                                                solid.GetOuterRadiusPlusZ());
-    auto const inner_r = scale_.to<Cone::Real2>(solid.GetInnerRadiusMinusZ(),
-                                                solid.GetInnerRadiusPlusZ());
+    auto const outer_r = scale_.to<Real2>(solid.GetOuterRadiusMinusZ(),
+                                          solid.GetOuterRadiusPlusZ());
+    auto const inner_r = scale_.to<Real2>(solid.GetInnerRadiusMinusZ(),
+                                          solid.GetInnerRadiusPlusZ());
     auto hh = scale_(solid.GetZHalfLength());
 
     std::optional<Cone> inner;
@@ -409,11 +409,11 @@ auto SolidConverter::generictrap(arg_type solid_base) -> result_type
     auto const& vtx = solid.GetVertices();
     CELER_ASSERT(vtx.size() == 8);
 
-    std::vector<GenTrap::Real2> lower(4), upper(4);
+    std::vector<Real2> lower(4), upper(4);
     for (auto i : range(4))
     {
-        lower[i] = scale_.to<GenTrap::Real2>(vtx[i].x(), vtx[i].y());
-        upper[i] = scale_.to<GenTrap::Real2>(vtx[i + 4].x(), vtx[i + 4].y());
+        lower[i] = scale_.to<Real2>(vtx[i].x(), vtx[i].y());
+        upper[i] = scale_.to<Real2>(vtx[i + 4].x(), vtx[i + 4].y());
     }
     real_type hh = scale_(solid.GetZHalfLength());
 

--- a/src/orange/orangeinp/IntersectRegion.hh
+++ b/src/orange/orangeinp/IntersectRegion.hh
@@ -103,12 +103,6 @@ class Box final : public IntersectRegionInterface
 class Cone final : public IntersectRegionInterface
 {
   public:
-    //!@{
-    //! \name Type aliases
-    using Real2 = Array<real_type, 2>;
-    //!@}
-
-  public:
     // Construct with Z half-height and lo, hi radii
     Cone(Real2 const& radii, real_type halfheight);
 
@@ -216,7 +210,6 @@ class GenTrap final : public IntersectRegionInterface
   public:
     //!@{
     //! \name Type aliases
-    using Real2 = Array<real_type, 2>;
     using VecReal2 = std::vector<Real2>;
     //!@}
 

--- a/src/orange/orangeinp/PolySolid.cc
+++ b/src/orange/orangeinp/PolySolid.cc
@@ -217,7 +217,6 @@ PolyCone::PolyCone(std::string&& label,
  */
 NodeId PolyCone::build(VolumeBuilder& vb) const
 {
-    using Real2 = PolySegments::Real2;
     auto build_cone = [](Real2 const& radii, real_type hh) {
         return Cone{radii, hh};
     };
@@ -324,7 +323,6 @@ PolyPrism::PolyPrism(std::string&& label,
  */
 NodeId PolyPrism::build(VolumeBuilder& vb) const
 {
-    using Real2 = PolySegments::Real2;
     auto build_prism = [this](Real2 const& radii, real_type hh) {
         if (radii[0] != radii[1])
         {

--- a/src/orange/orangeinp/PolySolid.hh
+++ b/src/orange/orangeinp/PolySolid.hh
@@ -33,7 +33,6 @@ class PolySegments
     //!@{
     //! \name Type aliases
     using VecReal = std::vector<real_type>;
-    using Real2 = celeritas::Array<real_type, 2>;
     //!@}
 
   public:

--- a/src/orange/orangeinp/detail/PolygonUtils.hh
+++ b/src/orange/orangeinp/detail/PolygonUtils.hh
@@ -25,9 +25,6 @@ namespace orangeinp
 namespace detail
 {
 //---------------------------------------------------------------------------//
-using Real2 = Array<real_type, 2>;
-
-//---------------------------------------------------------------------------//
 /*!
  *  Polygon orientation based on ordering of vertices.
  */

--- a/src/orange/univ/detail/InfixEvaluator.hh
+++ b/src/orange/univ/detail/InfixEvaluator.hh
@@ -9,6 +9,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/data/LdgIterator.hh"
 #include "orange/OrangeTypes.hh"
 
 namespace celeritas

--- a/src/orange/univ/detail/LogicEvaluator.hh
+++ b/src/orange/univ/detail/LogicEvaluator.hh
@@ -9,6 +9,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/data/LdgIterator.hh"
 #include "orange/OrangeTypes.hh"
 
 #include "LogicStack.hh"

--- a/src/orange/univ/detail/RaggedRightIndexer.hh
+++ b/src/orange/univ/detail/RaggedRightIndexer.hh
@@ -11,6 +11,7 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/Range.hh"
+#include "geocel/Types.hh"
 #include "orange/OrangeData.hh"
 
 namespace celeritas
@@ -19,7 +20,7 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Index into flattened, ragged-right, 2D data, from index to coords
+ * Index into flattened, ragged-right, 2D data, from index to coords.
  *
  * For example, consider three arrays of different sizes:
  *  A = [a1, a2]
@@ -38,7 +39,7 @@ class RaggedRightIndexer
   public:
     //!@{
     //! \name Type aliases
-    using Coords = Array<size_type, 2>;
+    using Coords = Size2;
     //!@}
 
   public:
@@ -59,7 +60,7 @@ class RaggedRightIndexer
 
 //---------------------------------------------------------------------------//
 /*!
- * Index into flattened, ragged-right, 2D data, from coords to index
+ * Index into flattened, ragged-right, 2D data, from coords to index.
  *
  * For example, consider three arrays of different sizes:
  *  A = [a1, a2]
@@ -86,14 +87,10 @@ class RaggedRightInverseIndexer
     explicit inline CELER_FUNCTION
     RaggedRightInverseIndexer(RaggedRightIndexerData<N> const& rrd);
 
-    //// METHODS ////
-
     // Convert a flattened index into ragged indices
     inline CELER_FUNCTION Coords operator()(size_type index) const;
 
   private:
-    //// DATA ////
-
     RaggedRightIndexerData<N> const& rrd_;
 };
 
@@ -101,7 +98,7 @@ class RaggedRightInverseIndexer
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Construct fom RaggedRightIndexerData
+ * Construct fom RaggedRightIndexerData.
  */
 template<size_type N>
 CELER_FUNCTION
@@ -126,7 +123,7 @@ CELER_FUNCTION size_type RaggedRightIndexer<N>::operator()(Coords coords) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct fom RaggedRightIndexerData
+ * Construct fom RaggedRightIndexerData.
  */
 template<size_type N>
 CELER_FUNCTION RaggedRightInverseIndexer<N>::RaggedRightInverseIndexer(

--- a/test/corecel/data/LdgIterator.test.cc
+++ b/test/corecel/data/LdgIterator.test.cc
@@ -37,8 +37,8 @@ TEST_F(LdgIteratorTest, arithmetic_t)
     auto n = some_data.size();
     auto start = some_data.begin();
     auto end = some_data.end();
-    auto ldg_start = make_ldg_iterator(some_data.data());
-    auto ldg_end = make_ldg_iterator(some_data.data() + n);
+    auto ldg_start = LdgIterator(some_data.data());
+    auto ldg_end = LdgIterator(some_data.data() + n);
     LdgIterator ctad_itr{some_data.data()};
     EXPECT_TRUE((std::is_same_v<decltype(ctad_itr), decltype(ldg_start)>));
     using ptr_type = typename decltype(ldg_start)::pointer;
@@ -82,8 +82,8 @@ TEST_F(LdgIteratorTest, opaqueid_t)
     using VecId = std::vector<TestId>;
     VecId const some_data = {TestId{1}, TestId{2}, TestId{3}, TestId{4}};
     auto n = some_data.size();
-    auto ldg_start = make_ldg_iterator(some_data.data());
-    auto ldg_end = make_ldg_iterator(some_data.data() + n);
+    auto ldg_start = LdgIterator(some_data.data());
+    auto ldg_end = LdgIterator(some_data.data() + n);
     LdgIterator ctad_itr{some_data.data()};
     EXPECT_TRUE((std::is_same_v<decltype(ctad_itr), decltype(ldg_start)>));
     using ptr_type = typename decltype(ldg_start)::pointer;
@@ -126,8 +126,8 @@ TEST_F(LdgIteratorTest, byte_t)
     VecByte const some_data
         = {std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
     auto n = some_data.size();
-    auto ldg_start = make_ldg_iterator(some_data.data());
-    auto ldg_end = make_ldg_iterator(some_data.data() + n);
+    auto ldg_start = LdgIterator(some_data.data());
+    auto ldg_end = LdgIterator(some_data.data() + n);
     LdgIterator ctad_itr{some_data.data()};
     EXPECT_TRUE((std::is_same_v<decltype(ctad_itr), decltype(ldg_start)>));
     using ptr_type = typename decltype(ldg_start)::pointer;

--- a/test/geocel/rasterize/Image.test.cc
+++ b/test/geocel/rasterize/Image.test.cc
@@ -20,8 +20,6 @@ namespace test
 class ImageTest : public ::celeritas::test::Test
 {
   protected:
-    using Size2 = ImageParamsScalars::Size2;
-
     void SetUp() override {}
 };
 

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -452,7 +452,6 @@ TEST_F(EllipsoidTest, standard)
 class GenTrapTest : public IntersectRegionTest
 {
   protected:
-    using Real2 = GenTrap::Real2;
     using VecReal = std::vector<real_type>;
 
     // NOTE: this only works for trapezoids centered on the z axis (a

--- a/test/orange/orangeinp/PolySolid.test.cc
+++ b/test/orange/orangeinp/PolySolid.test.cc
@@ -21,8 +21,6 @@ namespace orangeinp
 {
 namespace test
 {
-using Real2 = PolySegments::Real2;
-
 //---------------------------------------------------------------------------//
 TEST(PolySegmentsTest, errors)
 {


### PR DESCRIPTION
While rearranging some IO subroutines I inadvertently caused a circular dependency between collection/ldg/span/quantity/opaqueID. This moves all LDG related definitions and specializations to the "most downstream" compared to the primary implementation. I also reduced some type duplication in `geocel`/`orange` by defining Real2/Size2 in `geocel/Types.hh`. This also fixes an inadvertent find/replace error in GeoParamsInterface in #1000 .