### PR TITLE
Add git pre-commit hook

### DIFF
--- a/scripts/dev/install-commit-hooks.sh
+++ b/scripts/dev/install-commit-hooks.sh
@@ -12,29 +12,43 @@ Install clang-format and update your paths.
   exit 1
 fi
 
+install_hook () {
+if [ ! -f "$1" ]; then
+  printf "\e[33mCreating post-commit hook at $1.\e[0m\n"
+  echo "#!/bin/sh" > "$1"
+  chmod a+x "$1"
+fi
+}
+
+add_hook_scripts () {
+  SUFFIX=$1
+  HOOK=$2
+  BASE=$(basename $HOOK)
+  if ! grep $SUFFIX ${HOOK} >/dev/null ; then
+    printf "\e[33mAppending ${SUFFIX} call to ${HOOK}\e[0m\n"
+    cat >> "${HOOK}" << EOF
+GCF="\$(git rev-parse --show-toplevel)/scripts/dev/$BASE.$SUFFIX"
+test -x "\${GCF}" && "\${GCF}" "\$@"
+EOF
+  fi
+}
+
 GIT_WORK_TREE="$(git rev-parse --show-toplevel)"
 POSTCOMMIT=${GIT_WORK_TREE}/.git/hooks/post-commit
+PRECOMMIT=${GIT_WORK_TREE}/.git/hooks/pre-commit
 
 # Ensure a post-commit hook exists (Git LFS might have created one).
-if [ ! -f "${POSTCOMMIT}" ]; then
-  printf "\e[33mCreating post-commit hook at ${POSTCOMMIT}.\e[0m\n"
-  echo "#!/bin/sh" > "${POSTCOMMIT}"
-  chmod a+x "${POSTCOMMIT}"
-fi
+install_hook "$POSTCOMMIT"
+install_hook "$PRECOMMIT"
 
 printf "\e[2;37mSetting clang format options in git config\e[0m\n"
 git config clangFormat.extension "cc,hh,h,cpp,hpp,cu,cuh"
 git config clangFormat.style "file"
 
-if ! grep 'git-clang-format' ${POSTCOMMIT} >/dev/null ; then
-  printf "\e[33mAppending git-clang-format call to ${POSTCOMMIT}\e[0m\n"
-  cat >> "${POSTCOMMIT}" << 'EOF'
-GCF="$(git rev-parse --show-toplevel)/scripts/dev/post-commit.git-clang-format"
-test -x "${GCF}" && "${GCF}" "$@"
-EOF
-fi
+add_hook_scripts "git-clang-format" "$POSTCOMMIT"
+add_hook_scripts "validate-source" "$PRECOMMIT"
 
-printf "\e[0;32mPre-commit hook successfully installed for ${GIT_WORK_TREE}\e[0m\n"
+printf "\e[0;32mCommit hooks successfully installed for ${GIT_WORK_TREE}\e[0m\n"
 
 ###############################################################################
 # end of scripts/dev/install-commit-hooks.sh

--- a/scripts/dev/pre-commit.validate-source
+++ b/scripts/dev/pre-commit.validate-source
@@ -1,9 +1,7 @@
 #!/bin/sh -e
-###############################################################################
-# File  : script/developer/pre-commit.validate-source
-#
-# Called by $SCALE/.git/hooks/pre-commit to apply various preliminary checks
-###############################################################################
+# Copyright 2021-2024 UT-Battelle, LLC, and other Celeritas developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 exit_with_message() {
   printf "\r\e[0;31m%s\e[0m\n" "$1"

--- a/scripts/dev/pre-commit.validate-source
+++ b/scripts/dev/pre-commit.validate-source
@@ -11,12 +11,12 @@ exit_with_message() {
 }
 
 check_corecel_dependencies() {
-  CMD="grep -n -E"
+  CMD="grep -nHE"
   IDX_FILE=0
   IDX_LINE_NO=1
   IDX_LINE_TXT=2
 
-  # use ripgrep is available, it's faster
+  # use ripgrep if available, it's faster
   if command -v rg >/dev/null; then
     CMD="rg --vimgrep -e"
     IDX_LINE_TXT=3
@@ -25,7 +25,7 @@ check_corecel_dependencies() {
   cd "$(git rev-parse --show-toplevel)" || exit_with_message "Couldnt checkout to toplevel dir"
   # list modified files in src/corecel
   STAGED_FILES=
-  for f in $(git diff --name-only --cached --diff-filter=ACM src/corecel); do
+  for f in $(git diff --name-only --cached --diff-filter=ACM src/corecel | grep -E '.*\.(cc|cu|hh)'); do
     # file should always exist because of diff-filter
     [[ -f $f ]] && STAGED_FILES="$STAGED_FILES $f"
   done

--- a/scripts/dev/pre-commit.validate-source
+++ b/scripts/dev/pre-commit.validate-source
@@ -1,0 +1,47 @@
+#!/bin/bash
+###############################################################################
+# File  : script/developer/pre-commit.validate-source
+#
+# Called by $SCALE/.git/hooks/pre-commit to apply various preliminary checks
+###############################################################################
+
+exit_with_message() {
+  printf "\r\e[0;31m$1\e[0m\n"
+  exit 1
+}
+
+check_corecel_dependencies() {
+  command -v rg >/dev/null
+  HAS_RG=$?
+  if [[ "$HAS_RG" ]]; then
+    cd "$(git rev-parse --show-toplevel)" || exit_with_message "Couldnt checkout to toplevel dir"
+    # list modified files in src/corecel
+    STAGED_FILES=
+    for f in $(git diff --name-only --cached src/corecel); do
+      STAGED_FILES="$STAGED_FILES $f"
+    done
+    # return if no file to check
+    [[ -z $STAGED_FILES ]] && return 0
+
+    # search for accel, celeritas, geocel, orange in corecel
+    CHECK_INCLUDES=$(rg --vimgrep -e '^#include ["<](accel|celeritas|geocel|orange)/.*[">]' $STAGED_FILES)
+    MATCH=${CHECK_INCLUDES:+x}
+
+    # print files:line if we found any match
+    if [[ "$MATCH" ]]; then
+      printf "\r\e[0;33mcorecel can't depend on accel, celeritas, geocel or orange:\n"
+      IFS=$'\n'
+      for e in $CHECK_INCLUDES; do
+        IFS=':' read -r -a fields <<<"$e"
+        printf '%s in %s:%s' "${fields[3]}" "${fields[0]}" "${fields[1]}"
+      done
+      printf "\e[0m\n"
+      return 1
+    fi
+  else
+    echo "ripgrep is not installed, can't perform corecel dependency check..."
+  fi
+  return 0
+}
+
+check_corecel_dependencies || exit_with_message "Precommit failed at check_corecel_dependencies"

--- a/scripts/dev/pre-commit.validate-source
+++ b/scripts/dev/pre-commit.validate-source
@@ -25,7 +25,7 @@ check_corecel_dependencies() {
     [[ -z $STAGED_FILES ]] && return 0
 
     # search for accel, celeritas, geocel, orange in corecel
-    CHECK_INCLUDES=$(rg --vimgrep -e '^#include ["<](accel|celeritas|geocel|orange)/.*[">]' $STAGED_FILES)
+    CHECK_INCLUDES=$(rg --vimgrep -e '^[ \t]*#[ \t]*include[ \t]*["<](accel|celeritas|geocel|orange)/.*[">]' $STAGED_FILES)
     MATCH=${CHECK_INCLUDES:+x}
 
     # print files:line if we found any match

--- a/scripts/dev/pre-commit.validate-source
+++ b/scripts/dev/pre-commit.validate-source
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh -e
 ###############################################################################
 # File  : script/developer/pre-commit.validate-source
 #
@@ -31,10 +31,11 @@ check_corecel_dependencies() {
   done
   # return if no file to check
   [[ -z $STAGED_FILES ]] && return 0
-
+  # grep, rg return 1 if no match, so we ignore it
+  set +e
   # search for accel, celeritas, geocel, orange in corecel
   CHECK_INCLUDES=$($CMD '^[ \t]*#[ \t]*include[ \t]*["<](accel|celeritas|geocel|orange)/.*[">]' $STAGED_FILES)
-
+  set -e
   # print files:line if we found any match
   if [[ "$CHECK_INCLUDES" ]]; then
     printf "\r\e[0;33mcorecel can't depend on accel, celeritas, geocel or orange:\n"

--- a/scripts/dev/pre-commit.validate-source
+++ b/scripts/dev/pre-commit.validate-source
@@ -17,8 +17,9 @@ check_corecel_dependencies() {
     cd "$(git rev-parse --show-toplevel)" || exit_with_message "Couldnt checkout to toplevel dir"
     # list modified files in src/corecel
     STAGED_FILES=
-    for f in $(git diff --name-only --cached src/corecel); do
-      STAGED_FILES="$STAGED_FILES $f"
+    for f in $(git diff --name-only --cached --diff-filter=ACM src/corecel); do
+      # file should always exist because of diff-filter
+      [[ -f $f ]] && STAGED_FILES="$STAGED_FILES $f"
     done
     # return if no file to check
     [[ -z $STAGED_FILES ]] && return 0

--- a/scripts/dev/pre-commit.validate-source
+++ b/scripts/dev/pre-commit.validate-source
@@ -6,7 +6,7 @@
 ###############################################################################
 
 exit_with_message() {
-  printf "\r\e[0;31m$1\e[0m\n"
+  printf "\r\e[0;31m%s\e[0m\n" "$1"
   exit 1
 }
 
@@ -33,7 +33,7 @@ check_corecel_dependencies() {
       IFS=$'\n'
       for e in $CHECK_INCLUDES; do
         IFS=':' read -r -a fields <<<"$e"
-        printf '%s in %s:%s' "${fields[3]}" "${fields[0]}" "${fields[1]}"
+        printf 'In %s:%s: %s' "${fields[0]}" "${fields[1]}" "${fields[3]}"
       done
       printf "\e[0m\n"
       return 1

--- a/scripts/dev/pre-commit.validate-source
+++ b/scripts/dev/pre-commit.validate-source
@@ -11,36 +11,40 @@ exit_with_message() {
 }
 
 check_corecel_dependencies() {
-  command -v rg >/dev/null
-  HAS_RG=$?
-  if [[ "$HAS_RG" ]]; then
-    cd "$(git rev-parse --show-toplevel)" || exit_with_message "Couldnt checkout to toplevel dir"
-    # list modified files in src/corecel
-    STAGED_FILES=
-    for f in $(git diff --name-only --cached --diff-filter=ACM src/corecel); do
-      # file should always exist because of diff-filter
-      [[ -f $f ]] && STAGED_FILES="$STAGED_FILES $f"
+  CMD="grep -n -E"
+  IDX_FILE=0
+  IDX_LINE_NO=1
+  IDX_LINE_TXT=2
+
+  # use ripgrep is available, it's faster
+  if command -v rg >/dev/null; then
+    CMD="rg --vimgrep -e"
+    IDX_LINE_TXT=3
+  fi
+
+  cd "$(git rev-parse --show-toplevel)" || exit_with_message "Couldnt checkout to toplevel dir"
+  # list modified files in src/corecel
+  STAGED_FILES=
+  for f in $(git diff --name-only --cached --diff-filter=ACM src/corecel); do
+    # file should always exist because of diff-filter
+    [[ -f $f ]] && STAGED_FILES="$STAGED_FILES $f"
+  done
+  # return if no file to check
+  [[ -z $STAGED_FILES ]] && return 0
+
+  # search for accel, celeritas, geocel, orange in corecel
+  CHECK_INCLUDES=$($CMD '^[ \t]*#[ \t]*include[ \t]*["<](accel|celeritas|geocel|orange)/.*[">]' $STAGED_FILES)
+
+  # print files:line if we found any match
+  if [[ "$CHECK_INCLUDES" ]]; then
+    printf "\r\e[0;33mcorecel can't depend on accel, celeritas, geocel or orange:\n"
+    IFS=$'\n'
+    for e in $CHECK_INCLUDES; do
+      IFS=':' read -r -a fields <<<"$e"
+      printf 'In %s:%s: %s\n' "${fields[IDX_FILE]}" "${fields[IDX_LINE_NO]}" "${fields[IDX_LINE_TXT]}"
     done
-    # return if no file to check
-    [[ -z $STAGED_FILES ]] && return 0
-
-    # search for accel, celeritas, geocel, orange in corecel
-    CHECK_INCLUDES=$(rg --vimgrep -e '^[ \t]*#[ \t]*include[ \t]*["<](accel|celeritas|geocel|orange)/.*[">]' $STAGED_FILES)
-    MATCH=${CHECK_INCLUDES:+x}
-
-    # print files:line if we found any match
-    if [[ "$MATCH" ]]; then
-      printf "\r\e[0;33mcorecel can't depend on accel, celeritas, geocel or orange:\n"
-      IFS=$'\n'
-      for e in $CHECK_INCLUDES; do
-        IFS=':' read -r -a fields <<<"$e"
-        printf 'In %s:%s: %s' "${fields[0]}" "${fields[1]}" "${fields[3]}"
-      done
-      printf "\e[0m\n"
-      return 1
-    fi
-  else
-    echo "ripgrep is not installed, can't perform corecel dependency check..."
+    printf "\e[0m"
+    return 1
   fi
   return 0
 }


### PR DESCRIPTION
Some errors are easy to overlook during review but could be validated with a git hook. Add a pre-commit script that will parse staged files in `corecel` for includes of any upstream library. This could easily be extended with more checks. Alternatively, this could be added to the CI