### PR TITLE
Update frontier toolchain and backward compatibility

### DIFF
--- a/app/celer-g4/RunInputIO.json.cc
+++ b/app/celer-g4/RunInputIO.json.cc
@@ -27,7 +27,17 @@ void from_json(nlohmann::json const& j, PhysicsListSelection& value)
     static auto const from_string
         = StringEnumMapper<PhysicsListSelection>::from_cstring_func(
             to_cstring, "physics list");
-    value = from_string(j.get<std::string>());
+    auto const& s = j.get<std::string>();
+    if (CELER_UNLIKELY(s == "geant_physics_list"))
+    {
+        CELER_LOG(warning) << "Deprecated option value '" << s
+                           << "': use 'celer_em' instead";
+        value = PhysicsListSelection::celer_em;
+    }
+    else
+    {
+        value = from_string(j.get<std::string>());
+    }
 }
 
 void to_json(nlohmann::json& j, PhysicsListSelection const& value)

--- a/scripts/cmake-presets/frontier.json
+++ b/scripts/cmake-presets/frontier.json
@@ -21,7 +21,7 @@
         "CELERITAS_TEST_RESOURCE_LOCK": {"type": "BOOL", "value": "ON"},
         "CMAKE_HIP_ARCHITECTURES":  {"type": "STRING", "value": "gfx90a"},
         "CMAKE_HIP_FLAGS": "-munsafe-fp-atomics",
-        "CMAKE_CXX_FLAGS": "-Wno-unused-command-line-argument -Wall -Wextra -pedantic -fcolor-diagnostics",
+        "CMAKE_CXX_FLAGS": "-Wno-unused-command-line-argument -Wno-nested-anon-types -Wno-gnu-anonymous-struct -Wall -Wextra -pedantic -fcolor-diagnostics",
         "CMAKE_EXE_LINKER_FLAGS": "-Wno-unused-command-line-argument",
         "CMAKE_HIP_FLAGS_DEBUG": "-g -ggdb -O",
         "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG -march=znver3 -mtune=znver3",

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -496,7 +496,7 @@ CELER_WRAP_MATH_FLOAT_DBL_1(, rsqrt)
 /*!
  * Calculate an inverse square root.
  */
-inline CELER_FUNCTION double rsqrt(double value)
+CELER_FORCEINLINE_FUNCTION double rsqrt(double value)
 {
     return 1.0 / std::sqrt(value);
 }
@@ -505,7 +505,7 @@ inline CELER_FUNCTION double rsqrt(double value)
 /*!
  * Calculate an inverse square root.
  */
-inline CELER_FUNCTION float rsqrt(float value)
+CELER_FORCEINLINE_FUNCTION float rsqrt(float value)
 {
     return 1.0f / std::sqrt(value);
 }
@@ -523,7 +523,7 @@ inline CELER_FUNCTION float rsqrt(float value)
  * std::fma directly in most cases.
  */
 template<class T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
-inline CELER_FUNCTION T fma(T a, T b, T y)
+CELER_FORCEINLINE_FUNCTION T fma(T a, T b, T y)
 {
     return std::fma(a, b, y);
 }
@@ -609,7 +609,7 @@ CELER_CONSTEXPR_FUNCTION T eumod(T numer, T denom)
  * \return -1 if negative, 0 if exactly zero (or NaN), 1 if positive
  */
 template<class T>
-CELER_FORCEINLINE int signum(T x)
+CELER_CONSTEXPR_FUNCTION int signum(T x)
 {
     return (0 < x) - (x < 0);
 }


### PR DESCRIPTION
A recent [system update on Frontier](https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#id17) required an updated toolchain. For some reason even though the same ROCm and HIP versions are being used, some new warnings have started showing up, but there are no changes in the answers.

While doing some very basic profiling of a tilecal run I noticed that `celeritas::fma` was showing up as a symbol, which means we're not inlining it like we should.

Finally to get the regression suite to run as is, I have temporarily restored (with a warning) the "geant physics" string option.