### PR TITLE
Reduce string duplication from assertion messages

### DIFF
--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -512,15 +512,17 @@ class RichContextException : public std::exception
 // INLINE FUNCTION DEFINITIONS
 //---------------------------------------------------------------------------//
 
+#if (defined(__CUDA_ARCH__) && defined(NDEBUG)) || defined(__HIP__)
+inline constexpr char device_assertion_str[]
+    = "%s:%u:\nceleritas: internal assertion failed: %s\n";
+#endif
+
 #if defined(__CUDA_ARCH__) && defined(NDEBUG)
 //! Host+device definition for CUDA when \c assert is unavailable
 inline __attribute__((noinline)) __host__ __device__ void device_debug_error(
     DebugErrorType, char const* condition, char const* file, int line)
 {
-    printf("%s:%u:\nceleritas: internal assertion failed: %s\n",
-           file,
-           line,
-           condition);
+    printf(device_assertion_str, file, line, condition);
     __trap();
 }
 #elif defined(__HIP__)
@@ -538,10 +540,7 @@ inline __host__ void device_debug_error(DebugErrorType which,
 inline __attribute__((noinline)) __device__ void device_debug_error(
     DebugErrorType, char const* condition, char const* file, int line)
 {
-    printf("%s:%u:\nceleritas: internal assertion failed: %s\n",
-           file,
-           line,
-           condition);
+    printf(device_assertion_str, file, line, condition);
     abort();
 }
 #endif

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -512,17 +512,15 @@ class RichContextException : public std::exception
 // INLINE FUNCTION DEFINITIONS
 //---------------------------------------------------------------------------//
 
-#if (defined(__CUDA_ARCH__) && defined(NDEBUG)) || defined(__HIP__)
-inline constexpr char device_assertion_str[]
-    = "%s:%u:\nceleritas: internal assertion failed: %s\n";
-#endif
-
 #if defined(__CUDA_ARCH__) && defined(NDEBUG)
 //! Host+device definition for CUDA when \c assert is unavailable
 inline __attribute__((noinline)) __host__ __device__ void device_debug_error(
     DebugErrorType, char const* condition, char const* file, int line)
 {
-    printf(device_assertion_str, file, line, condition);
+    printf("%s:%u:\nceleritas: internal assertion failed: %s\n",
+           file,
+           line,
+           condition);
     __trap();
 }
 #elif defined(__HIP__)
@@ -540,7 +538,10 @@ inline __host__ void device_debug_error(DebugErrorType which,
 inline __attribute__((noinline)) __device__ void device_debug_error(
     DebugErrorType, char const* condition, char const* file, int line)
 {
-    printf(device_assertion_str, file, line, condition);
+    printf("%s:%u:\nceleritas: internal assertion failed: %s\n",
+           file,
+           line,
+           condition);
     abort();
 }
 #endif

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -228,18 +228,20 @@
                 std::ostringstream celer_runtime_msg_;           \
                 celer_runtime_msg_ MSG;                          \
                 CELER_RUNTIME_THROW(                             \
-                    "runtime", celer_runtime_msg_.str(), #COND); \
+                    ::celeritas::RuntimeError::validate_err_str, \
+                    celer_runtime_msg_.str(),                    \
+                    #COND);                                      \
             }                                                    \
         } while (0)
 #else
-#    define CELER_VALIDATE(COND, MSG) \
-        CELER_RUNTIME_THROW("unreachable", "", #COND)
+#    define CELER_VALIDATE(COND, MSG) CELER_RUNTIME_THROW(nullptr, "", #COND)
 #endif
 
 #define CELER_NOT_CONFIGURED(WHAT) \
-    CELER_RUNTIME_THROW("configuration", WHAT, {})
+    CELER_RUNTIME_THROW(           \
+        ::celeritas::RuntimeError::not_config_err_str, WHAT, {})
 #define CELER_NOT_IMPLEMENTED(WHAT) \
-    CELER_RUNTIME_THROW("implementation", WHAT, {})
+    CELER_RUNTIME_THROW(::celeritas::RuntimeError::not_impl_err_str, WHAT, {})
 
 /*!
  * \def CELER_CUDA_CALL
@@ -417,7 +419,7 @@ struct DebugErrorDetails
 //! Detailed properties of a runtime error
 struct RuntimeErrorDetails
 {
-    std::string which{};  //!< Type of error (runtime, Geant4, MPI)
+    char const* which{nullptr};  //!< Type of error (runtime, Geant4, MPI)
     std::string what{};  //!< Descriptive message
     std::string condition{};  //!< Code/test that failed
     std::string file{};  //!< Source file
@@ -475,6 +477,13 @@ class RuntimeError : public std::runtime_error
 
     //! Access detailed information
     RuntimeErrorDetails const& details() const { return details_; }
+
+    //!@{
+    //! String constants for "which" error message
+    static char const validate_err_str[];
+    static char const not_config_err_str[];
+    static char const not_impl_err_str[];
+    //!@}
 
   private:
     RuntimeErrorDetails details_;

--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "GeantTestBase.hh"
 
+#include <cstring>
 #include <string>
 
 #include "corecel/Config.hh"


### PR DESCRIPTION
Inspired by @esseivaju 's example in #1325 , this defines external constant strings for "runtime error" types to both reduce library size and to avoid "magic constants" (i.e. requiring that special string values in one file match string values in another).

HIP/frontier (ORANGE ndebug):
| Library        | Before   | After    |
| -------------- | -------- | -------- |
| libcorecel.a   |  1613066 |  1606148 |
| libgeocel.a    |   902558 |   898838 |
| liborange.a    |  4122526 |  4095566 |
| libceleritas.a | 11385000 | 11295664 |
| libaccel.a     |   869100 |   863828 |

CUDA/wildstyle (ORANGE reldeb):
| Library        | Before    | After     |
| -------------- | --------- | --------- |
| libcorecel.a   |  17431736 |  17415056 |
| libgeocel.a    |  10777392 |  10776984 |
| liborange.a    |  54714576 |  54682904 |
| libceleritas.a | 182853472 | 181899976 |
| libaccel.a     |  21292144 |  21290984 |

Unfortunately I'm not able to use `static inline constexpr` for the CUDA/HIP printf statements:
```
/home/s3j/Code/celeritas/src/corecel/Assert.hh(516): error: An inline __device__/__constant__/__managed__ variable must have internal linkage when the program is compiled in whole program mode (-rdc=false)
```
see [this llvm bug report](https://reviews.llvm.org/D88786?id=295997) for details.