### PR TITLE
Use spack-based workflow for address sanitizer

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -31,15 +31,10 @@ jobs:
           - buildtype: "debug"
             image: "centos-rocm" # Debug builds don't work with HIP
         include:
-          - special: "asan"
-            geometry: "orange"
-            buildtype: "reldeb"
-            image: "centos-rocm"
           - geometry: "vecgeom"
             buildtype: "reldeb"
             image: "ubuntu-cuda"
     env:
-      ASAN_OPTIONS: "detect_leaks=0"
       CELER_TEST_STRICT: 1
       CELER_DISABLE_DEVICE: 1 # IMPORTANT
       CMAKE_PRESET: >-
@@ -109,11 +104,9 @@ jobs:
           ./bin/celer-sim --version
       - name: Build examples
         # TODO: rocm+ndebug fails to propagate HIP library link
-        # TODO: ASAN requires flags downstream
         if: >-
           ${{
             !(matrix.image == 'centos-rocm' && matrix.buildtype == 'ndebug')
-            && (matrix.special != 'asan')
           }}
         run: |
           . /etc/profile

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -32,6 +32,9 @@ jobs:
           - geometry: "orange"
             special: "float"
             geant: "11.0"
+          - geometry: "orange"
+            special: "asanlite"
+            geant: null
           - geometry: "vecgeom"
             special: "clhep"
             geant: "11.0"
@@ -76,7 +79,7 @@ jobs:
           if [ "${{matrix.geometry}}" == "vecgeom" ]; then
             spack -e . add vecgeom
           fi
-          if [ "${{matrix.special}}" != "minimal" ]; then
+          if [ "${{matrix.special}}" != "minimal" ] && [  "${{matrix.special}}" != "asanlite" ] ; then
             spack -e . add root
           fi
           if [ "${{matrix.geant}}" != "" ]; then
@@ -160,6 +163,11 @@ jobs:
             build/Testing/Temporary/LastTest.log
             build/Testing/Temporary/LastTestsFailed.log
       - name: Check using build directory as install
+        # TODO: ASAN requires flags downstream
+        if: >-
+          ${{
+            (matrix.special != 'asanlite')
+          }}
         run: |
           . ${SPACK_VIEW}/rc
           CELER_INSTALL_DIR=${PWD}/build ./scripts/ci/test-examples.sh
@@ -176,6 +184,11 @@ jobs:
           done
           ./bin/celer-sim --version
       - name: Build examples
+        # TODO: ASAN requires flags downstream
+        if: >-
+          ${{
+            (matrix.special != 'asanlite')
+          }}
         run: |
           . ${SPACK_VIEW}/rc
           ./scripts/ci/test-examples.sh

--- a/scripts/cmake-presets/ci-centos-rocm.json
+++ b/scripts/cmake-presets/ci-centos-rocm.json
@@ -33,15 +33,6 @@
       }
     },
     {
-      "name": "reldeb-orange-asan",
-      "description": "Build with address sanitizer flags without hip",
-      "inherits": ["base", ".reldeb"],
-      "cacheVariables": {
-        "CELERITAS_USE_HIP": {"type": "BOOL", "value": "OFF"},
-        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fsanitize=address -fno-omit-frame-pointer"
-      }
-    },
-    {
       "name": "ndebug-orange-float",
       "description": "Build with single-precision arithmetic and HIP/ROCm",
       "inherits": [".ndebug", "base"],

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -143,12 +143,14 @@
       }
     },
     {
-      "name": "reldeb-orange-asan",
+      "name": "reldeb-orange-asanlite",
       "description": "Build with address sanitizer flags",
       "inherits": ["spack"],
       "cacheVariables": {
-        "CELERITAS_USE_HIP": {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_USE_ROOT": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "OFF"},
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fsanitize=address -fno-omit-frame-pointer"
       }


### PR DESCRIPTION
This adds an address sanitizer and leak checker to the spack builds and removes from the docker build. With geant4 off we can use leak detection.