### PR TITLE
Fix minor compile error/warning with nvcc+clang

### DIFF
--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -212,7 +212,8 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             --remaining_substeps;
         }
         else if (CELER_UNLIKELY(result.boundary
-                                && this->bump_distance() > linear_step.distance))
+                                && (linear_step.distance)
+                                       < this->bump_distance()))
         {
             // Likely heading back into the old volume when starting on a
             // surface (this can happen when tracking through a volume at a

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -212,7 +212,7 @@ CELER_FUNCTION auto FieldPropagator<DriverT, GTV>::operator()(real_type step)
             --remaining_substeps;
         }
         else if (CELER_UNLIKELY(result.boundary
-                                && linear_step.distance < this->bump_distance()))
+                                && this->bump_distance() > linear_step.distance))
         {
             // Likely heading back into the old volume when starting on a
             // surface (this can happen when tracking through a volume at a

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -63,7 +63,8 @@ namespace celeritas
 template<class F>
 class ActionLauncher
 {
-    static_assert((std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP)
+    static_assert((std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP
+                   || __clang__)
                       && !std::is_pointer_v<F> && !std::is_reference_v<F>,
                   "Launched action must be a trivially copyable function "
                   "object");

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -65,7 +65,7 @@ template<class F>
 class ActionLauncher
 {
     static_assert((std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP
-                   || CELER_COMP_HOST == CELER_COMP_CLANG)
+                   || CELER_COMPILER == CELER_COMPILER_CLANG)
                       && !std::is_pointer_v<F> && !std::is_reference_v<F>,
                   "Launched action must be a trivially copyable function "
                   "object");

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -12,6 +12,7 @@
 #include "corecel/DeviceRuntimeApi.hh"
 
 #include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/sys/Device.hh"
@@ -64,7 +65,7 @@ template<class F>
 class ActionLauncher
 {
     static_assert((std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP
-                   || __clang__)
+                   || CELER_COMP_HOST == CELER_COMP_CLANG)
                       && !std::is_pointer_v<F> && !std::is_reference_v<F>,
                   "Launched action must be a trivially copyable function "
                   "object");

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -47,7 +47,7 @@
 #define CELER_COMP_GCC 2
 #define CELER_COMP_INTEL 3
 #define CELER_COMP_MSVC 4
-#define CELER_COMP_NVCPP 4
+#define CELER_COMP_NVCPP 5
 
 /*!
  * \def CELER_COMP_HOST

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -42,31 +42,23 @@
 #    define CELER_FORCEINLINE inline
 #endif
 
-#define CELER_COMP_UNKNOWN 0
-#define CELER_COMP_CLANG 1
-#define CELER_COMP_GCC 2
-#define CELER_COMP_INTEL 3
-#define CELER_COMP_MSVC 4
-#define CELER_COMP_NVCPP 5
+//! Detection for the current compiler isn't supported yet
+#define CELER_COMPILER_UNKNOWN 0
+//! Compiling with clang, or a clang-based compiler defining __clang__ (hipcc)
+#define CELER_COMPILER_CLANG 1
 
 /*!
- * \def CELER_COMP_HOST
+ * \def CELER_COMPILER
  *
- * Set to the value of one of the CELER_COMP_<compiler> macros.
- * Allows checking if a specific compiler is used.
+ * Compare to on of the CELER_COMPILER_<compiler> macros to check
+ * which compiler is in use.
+ *
+ * TODO: add and test more compilers as needed.
  */
 #if defined(__clang__)
-#    define CELER_COMP_HOST CELER_COMP_CLANG
-#elif defined(__GNUC__)
-#    define CELER_COMP_HOST CELER_COMP_GCC
-#elif defined(__INTEL_COMPILER)
-#    define CELER_COMP_HOST CELER_COMP_INTEL
-#elif defined(_MSC_VER)
-#    define CELER_COMP_HOST CELER_COMP_MSVC
-#elif defined(__NVCOMPILER)
-#    define CELER_COMP_HOST CELER_COMP_NVCPP
+#    define CELER_COMPILER CELER_COMPILER_CLANG
 #else
-#    define CELER_COMP_HOST CELER_COMP_UNKNOWN
+#    define CELER_COMPILER CELER_COMPILER_UNKNOWN
 #endif
 
 /*!

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -42,6 +42,33 @@
 #    define CELER_FORCEINLINE inline
 #endif
 
+#define CELER_COMP_UNKNOWN 0
+#define CELER_COMP_CLANG 1
+#define CELER_COMP_GCC 2
+#define CELER_COMP_INTEL 3
+#define CELER_COMP_MSVC 4
+#define CELER_COMP_NVCPP 4
+
+/*!
+ * \def CELER_COMP_HOST
+ *
+ * Set to the value of one of the CELER_COMP_<compiler> macros.
+ * Allows checking if a specific compiler is used.
+ */
+#if defined(__clang__)
+#    define CELER_COMP_HOST CELER_COMP_CLANG
+#elif defined(__GNUC__)
+#    define CELER_COMP_HOST CELER_COMP_GCC
+#elif defined(__INTEL_COMPILER)
+#    define CELER_COMP_HOST CELER_COMP_INTEL
+#elif defined(_MSC_VER)
+#    define CELER_COMP_HOST CELER_COMP_MSVC
+#elif defined(__NVCOMPILER)
+#    define CELER_COMP_HOST CELER_COMP_NVCPP
+#else
+#    define CELER_COMP_HOST CELER_COMP_UNKNOWN
+#endif
+
 /*!
  * \def CELER_FORCEINLINE_FUNCTION
  *

--- a/test/celeritas/random/curand/CurandPerformance.test.cu
+++ b/test/celeritas/random/curand/CurandPerformance.test.cu
@@ -160,7 +160,6 @@ TestOutput curand_test<curandStateMtgp32>(TestParams params)
 template TestOutput curand_test<curandState>(TestParams);
 template TestOutput curand_test<curandStateMRG32k3a>(TestParams);
 template TestOutput curand_test<curandStatePhilox4_32_10_t>(TestParams);
-template TestOutput curand_test<curandStateMtgp32>(TestParams);
 
 //---------------------------------------------------------------------------//
 }  // namespace test


### PR DESCRIPTION
Fix a few issues so that we can build Celeritas using nvcc+clang:
- Clang has `-Winstantiation-after-specialization` related to [temp.explicit/7](http://eel.is/c++draft/temp.explicit#7)
- Disable `std::is_trivially_copyable_v` when using `clang` instead of only checking for `CELERITAS_USE_HIP`
- Clang seems to parse `linear_step.distance` as a template name instead of a value and `<` as a bracket instead of an operator. This must be a compiler bug as it should only be parsed as a template when using the `template` keyword. This only shows up with nvcc+clang as the host compiler so it's unclear who's at fault. Compile error for reference:

```FAILED: src/celeritas/CMakeFiles/celeritas.dir/global/alongstep/AlongStepUniformMscAction.cu.o 
/pscratch/sd/e/esseivaj/spack/var/spack/environments/celeritas/.spack-env/view/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/global/common/software/nersc/pe/gpu/llvm/17.0.6/bin/clang++ -Dceleritas_EXPORTS -I/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/src -I/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/build-novg/include -isystem /pscratch/sd/e/esseivaj/spack/var/spack/environments/celeritas/.spack-env/view/include -lineinfo -Xptxas=-v -Xcompiler -Wno-psabi -g -std=c++17 "--generate-code=arch=compute_80,code=[compute_80,sm_80]" -Xcompiler=-fPIC -MD -MT src/celeritas/CMakeFiles/celeritas.dir/global/alongstep/AlongStepUniformMscAction.cu.o -MF src/celeritas/CMakeFiles/celeritas.dir/global/alongstep/AlongStepUniformMscAction.cu.o.d -x cu -c /global/cfs/cdirs/atlas/esseivaj/devel/celeritas/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu -o src/celeritas/CMakeFiles/celeritas.dir/global/alongstep/AlongStepUniformMscAction.cu.o
/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/src/celeritas/field/FieldPropagator.hh(215): error: expression must have integral or enum type
          else if (__builtin_expect(!!(result.boundary && linear_step.distance < this->bump_distance()), 0))
                                                                                 ^

/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/src/celeritas/field/FieldPropagator.hh(215): error: expected a ">"
          else if (__builtin_expect(!!(result.boundary && linear_step.distance < this->bump_distance()), 0))
                                                                                                      ^

2 errors detected in the compilation of "/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu".
```
