### PR TITLE
Automatically add Zotero publications to project site

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,8 +37,10 @@ jobs:
           ZOTERO_GROUP: 2380941
         run: |
           python scripts/generate-pubs.py -g $ZOTERO_GROUP -o publications.md
+          echo "DIFF_COUNT=$(git diff -- publications.md | wc -l)" >> $GITHUB_OUTPUT
       - name: Push updated publications
-        if: ${{steps.update.outcome != 'failure'}}
+        if: ${{steps.update.outcome != 'failure'
+          && fromJSON(steps.update.outputs.DIFF_COUNT) > 0}}
         continue-on-error: true
         run: |
           git config --global user.name "Github Actions"

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,10 +18,33 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-docs
     steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Check out Celeritas doc base
         uses: actions/checkout@v4
         with:
           ref: doc/gh-pages-base
+      - name: Install Python packages
+        run: |
+          pip install --upgrade pip
+          pip install -r scripts/requirements.txt
+      - name: Update publications
+        id: update
+        continue-on-error: true
+        env:
+          ZOTERO_TOKEN: ${{secrets.ZOTERO_TOKEN}}
+          ZOTERO_GROUP: 2380941
+        run: |
+          python scripts/generate-pubs.py -g $ZOTERO_GROUP -o publications.md
+      - name: Push updated publications
+        if: ${{steps.update.outcome != 'failure'}}
+        continue-on-error: true
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "${{github.triggering_actor}}@users.noreply.github.com"
+          git commit -am "Update publications"
+          git push
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Download doc and user artifacts

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -46,6 +46,7 @@ jobs:
         working-directory: build
         run: |
           ninja doxygen
+          find doc/doxygen-html -name '*.md5' -exec rm {} +
       - name: Upload artifacts
         if: ${{env.celer_upload_doc}}
         uses: actions/upload-artifact@v4
@@ -88,6 +89,7 @@ jobs:
         working-directory: build
         run: |
           ninja doc
+          find doc/html -name '*.md5' -exec rm {} +
       - name: Upload artifacts
         if: ${{env.celer_upload_doc}}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
I've updated `celeritas-project.github.io` to redirect to this code's github page. I also found that Zotero has a JSON API that can be used to extract publication data. Combining that with github actions, we can now get an updated publication list on our web site every time we push to develop 🎉 

Preview [the updated web site](https://sethrj.github.io/celeritas/index.html)

Note that most of the implementation of this is in [a script in the docs/gh-pages-base branch](https://github.com/celeritas-project/celeritas/blob/doc/gh-pages-base/scripts/generate-pubs.py)