### PR TITLE
Fix initialization of geometry state when inserting multiple sets of primaries

### DIFF
--- a/src/celeritas/track/ExtendFromPrimariesAction.cc
+++ b/src/celeritas/track/ExtendFromPrimariesAction.cc
@@ -9,6 +9,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
+#include "corecel/data/CollectionAlgorithms.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "celeritas/global/ActionLauncher.hh"
 #include "celeritas/global/CoreParams.hh"
@@ -58,6 +59,12 @@ void ExtendFromPrimariesAction::execute_impl(CoreParams const& params,
 
     // Mark that the primaries have been processed
     state.clear_primaries();
+
+    // Clear the track slot IDs of the track initializers' parent tracks. This
+    // is necessary when new primaries are inserted in the middle of a
+    // simulation and the parent IDs of secondaries produced in the previous
+    // step have been stored.
+    fill(TrackSlotId{}, &state.ref().init.parents);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/detail/Filler.cu
+++ b/src/corecel/data/detail/Filler.cu
@@ -15,6 +15,7 @@ namespace detail
 template struct Filler<real_type, MemSpace::device>;
 template struct Filler<size_type, MemSpace::device>;
 template struct Filler<int, MemSpace::device>;
+template struct Filler<TrackSlotId, MemSpace::device>;
 //---------------------------------------------------------------------------//
 }  // namespace detail
 }  // namespace celeritas

--- a/src/corecel/data/detail/Filler.hh
+++ b/src/corecel/data/detail/Filler.hh
@@ -59,6 +59,7 @@ void Filler<T, MemSpace::device>::operator()(Span<T>) const
 extern template struct Filler<real_type, MemSpace::device>;
 extern template struct Filler<size_type, MemSpace::device>;
 extern template struct Filler<int, MemSpace::device>;
+extern template struct Filler<TrackSlotId, MemSpace::device>;
 #endif
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/global/StepperGeant.test.cc
+++ b/test/celeritas/global/StepperGeant.test.cc
@@ -391,8 +391,8 @@ TEST_F(TestEm3NoMsc, host_multi)
     counts = step();
     if (this->is_default_build())
     {
-        EXPECT_EQ(44, counts.active);
-        EXPECT_EQ(43, counts.alive);
+        EXPECT_EQ(36, counts.active);
+        EXPECT_EQ(35, counts.alive);
     }
 }
 


### PR DESCRIPTION
This fixes a bug where a new track's geometry was detail-initialized using the geometry state of the incorrect parent track. This occurred when new primaries were inserted in the middle of a simulation and initialized using the parent IDs of secondaries produced in the previous step.