### PR TITLE
Define optical MaterialView and rename MaterialParams

### DIFF
--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -48,7 +48,7 @@
 #include "celeritas/io/RootEventReader.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/optical/CerenkovParams.hh"
-#include "celeritas/optical/MaterialPropertyParams.hh"
+#include "celeritas/optical/MaterialParams.hh"
 #include "celeritas/optical/OpticalCollector.hh"
 #include "celeritas/optical/ScintillationParams.hh"
 #include "celeritas/phys/CutoffParams.hh"
@@ -560,7 +560,7 @@ void Runner::build_optical_collector(RunnerInput const& inp,
                                      ImportData const& imported)
 {
     using optical::CerenkovParams;
-    using optical::MaterialPropertyParams;
+    using optical::MaterialParams;
     using optical::ScintillationParams;
 
     //! \todo Update conditionals after implementing CelerOpticalPhysicsList
@@ -575,8 +575,8 @@ void Runner::build_optical_collector(RunnerInput const& inp,
     auto const& optical_data = imported.optical.begin()->second;
     if (optical_data.properties)
     {
-        oc_inp.properties = MaterialPropertyParams::from_import(imported);
-        oc_inp.cerenkov = std::make_shared<CerenkovParams>(oc_inp.properties);
+        oc_inp.material = MaterialParams::from_import(imported);
+        oc_inp.cerenkov = std::make_shared<CerenkovParams>(oc_inp.material);
     }
     if (optical_data.scintillation)
     {

--- a/scripts/cmake-presets/goldfinger.json
+++ b/scripts/cmake-presets/goldfinger.json
@@ -26,7 +26,7 @@
         "CMAKE_FIND_FRAMEWORK": {"type": "STRING", "value": "LAST"},
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}",
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fno-inline -fno-omit-frame-pointer",
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-error=deprecated -pedantic -fdiagnostics-color=always"
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror -Wno-error=deprecated -pedantic -fdiagnostics-color=always -ffile-prefix-map=${sourceDir}/=./"
       }
     },
     {

--- a/scripts/cmake-presets/goldfinger.json
+++ b/scripts/cmake-presets/goldfinger.json
@@ -14,6 +14,7 @@
         "CELERITAS_USE_HIP":     {"type": "BOOL",   "value": "OFF"},
         "CELERITAS_USE_Geant4":  {"type": "BOOL",   "value": "ON"},
         "CELERITAS_USE_MPI":     {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_OpenMP":  {"type": "BOOL",   "value": "OFF"},
         "CELERITAS_USE_ROOT":    {"type": "BOOL",   "value": "ON"},
         "CELERITAS_USE_SWIG":    {"type": "BOOL",   "value": "OFF"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL",   "value": "OFF"},
@@ -44,7 +45,8 @@
       "inherits": [".base", ".debug", "default"],
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-        "CELERITAS_USE_SWIG":    {"type": "BOOL",   "value": "ON"},
+        "CELERITAS_USE_ROOT":    {"type": "BOOL",   "value": "OFF"},
+        "CMAKE_CXX_COMPILER_LAUNCHER": "/opt/homebrew/bin/ccache",
         "CMAKE_SWIG_CXX_FLAGS": "-Wno-unused-parameter;-Wno-deprecated-declarations",
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install"
       }

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -74,7 +74,7 @@ list(APPEND SOURCES
   neutron/process/NeutronInelasticProcess.cc
   optical/CerenkovParams.cc
   optical/OpticalCollector.cc
-  optical/MaterialPropertyParams.cc
+  optical/MaterialParams.cc
   optical/TrackData.cc
   optical/ScintillationParams.cc
   optical/detail/OffloadParams.cc

--- a/src/celeritas/io/ImportData.hh
+++ b/src/celeritas/io/ImportData.hh
@@ -37,6 +37,11 @@ namespace celeritas
  * Each entity's id is defined by its vector position. An \c ImportElement with
  * id = 3 is stored at \c elements[3] . Same for materials and volumes.
  *
+ * The \c processes field may be empty for testing applications.
+ *
+ * Optical material is optionally loaded into the \c optical field for each
+ * \c geo_material_id .
+ *
  * Seltzer-Berger, Livermore PE, and atomic relaxation data are loaded based on
  * atomic numbers, and thus are stored in maps. To retrieve specific data use
  * \c find(atomic_number) .
@@ -46,8 +51,6 @@ namespace celeritas
  * "CLHEP" the units are CLHEP. The \c convert_to_native function will
  * convert a data structure in place and update the units label. Refer to \c
  * base/Units.hh for further information on unit systems.
- *
- * The "processes" field may be empty for testing applications.
  */
 struct ImportData
 {

--- a/src/celeritas/optical/CerenkovDndxCalculator.hh
+++ b/src/celeritas/optical/CerenkovDndxCalculator.hh
@@ -62,7 +62,7 @@ class CerenkovDndxCalculator
     inline CELER_FUNCTION real_type operator()(units::LightSpeed beta);
 
   private:
-    // Calcaulte refractive index [MeV -> unitless]
+    // Calculate refractive index [MeV -> unitless]
     GenericCalculator calc_refractive_index_;
 
     // Calculate the Cerenkov angle integral [MeV -> unitless]

--- a/src/celeritas/optical/CerenkovDndxCalculator.hh
+++ b/src/celeritas/optical/CerenkovDndxCalculator.hh
@@ -17,7 +17,7 @@
 #include "celeritas/grid/GenericCalculator.hh"
 
 #include "CerenkovData.hh"
-#include "MaterialData.hh"
+#include "MaterialView.hh"
 
 namespace celeritas
 {
@@ -54,18 +54,21 @@ class CerenkovDndxCalculator
   public:
     // Construct from optical materials and Cerenkov angle integrals
     inline CELER_FUNCTION
-    CerenkovDndxCalculator(NativeCRef<MaterialParamsData> const& materials,
+    CerenkovDndxCalculator(MaterialView const& material,
                            NativeCRef<CerenkovData> const& shared,
-                           OpticalMaterialId material,
                            units::ElementaryCharge charge);
 
     // Calculate the mean number of Cerenkov photons produced per unit length
     inline CELER_FUNCTION real_type operator()(units::LightSpeed beta);
 
   private:
-    NativeCRef<MaterialParamsData> const& material_;
-    NativeCRef<CerenkovData> const& shared_;
-    OpticalMaterialId matid_;
+    // Calcaulte refractive index [MeV -> unitless]
+    GenericCalculator calc_refractive_index_;
+
+    // Calculate the Cerenkov angle integral [MeV -> unitless]
+    GenericCalculator calc_integral_;
+
+    // Square of particle charge
     real_type zsq_;
 };
 
@@ -77,59 +80,46 @@ class CerenkovDndxCalculator
  */
 CELER_FUNCTION
 CerenkovDndxCalculator::CerenkovDndxCalculator(
-    NativeCRef<MaterialParamsData> const& materials,
+    MaterialView const& material,
     NativeCRef<CerenkovData> const& shared,
-    OpticalMaterialId material,
     units::ElementaryCharge charge)
-    : material_(materials)
-    , shared_(shared)
-    , matid_(material)
+    : calc_refractive_index_(material.make_refractive_index_calculator())
+    , calc_integral_{shared.angle_integral[material.material_id()],
+                     shared.reals}
     , zsq_(ipow<2>(charge.value()))
 {
-    CELER_EXPECT(material_);
-    CELER_EXPECT(shared_);
-    CELER_EXPECT(matid_ < shared_.angle_integral.size());
     CELER_EXPECT(charge != zero_quantity());
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Calculate the mean number of Cerenkov photons produced per unit length.
+ *
+ * \todo define a "generic grid extents" class for finding the lower/upper x/y
+ * coordinates on grid data. In the future we could cache these if the memory
+ * lookups result in too much indirection.
  */
 CELER_FUNCTION real_type
 CerenkovDndxCalculator::operator()(units::LightSpeed beta)
 {
     CELER_EXPECT(beta.value() > 0 && beta.value() <= 1);
 
-    if (!shared_.angle_integral[matid_])
-    {
-        // No optical materials for this material
-        return 0;
-    }
-
-    CELER_ASSERT(matid_ < material_.refractive_index.size());
     real_type inv_beta = 1 / beta.value();
-    GenericCalculator calc_refractive_index(material_.refractive_index[matid_],
-                                            material_.reals);
-    real_type energy_max = calc_refractive_index.grid().back();
-    if (inv_beta > calc_refractive_index(energy_max))
+    real_type energy_max = calc_refractive_index_.grid().back();
+    if (inv_beta > calc_refractive_index_(energy_max))
     {
         // Incident particle energy is below the threshold for Cerenkov
         // emission (i.e., beta < 1 / n_max)
         return 0;
     }
 
-    // Calculate the Cerenkov angle integral [MeV]
-    GenericCalculator calc_integral(shared_.angle_integral[matid_],
-                                    shared_.reals);
-
     // Calculate \f$ \int_{\epsilon_\text{min}}^{\epsilon_\text{max}}
     // \dif\epsilon \left(1 - \frac{1}{n^2\beta^2}\right) \f$
     real_type energy;
-    if (inv_beta < calc_refractive_index[0])
+    if (inv_beta < calc_refractive_index_[0])
     {
-        energy = energy_max - calc_refractive_index.grid().front()
-                 - calc_integral(energy_max) * ipow<2>(inv_beta);
+        energy = energy_max - calc_refractive_index_.grid().front()
+                 - calc_integral_(energy_max) * ipow<2>(inv_beta);
     }
     else
     {
@@ -137,9 +127,9 @@ CerenkovDndxCalculator::operator()(units::LightSpeed beta)
         // Both energy and refractive index are monotonically increasing, so
         // the grid and values can be swapped and the energy can be calculated
         // from a given index of refraction
-        real_type energy_min = calc_refractive_index.make_inverse()(inv_beta);
+        real_type energy_min = calc_refractive_index_.make_inverse()(inv_beta);
         energy = energy_max - energy_min
-                 - (calc_integral(energy_max) - calc_integral(energy_min))
+                 - (calc_integral_(energy_max) - calc_integral_(energy_min))
                        * ipow<2>(inv_beta);
     }
 

--- a/src/celeritas/optical/CerenkovGenerator.hh
+++ b/src/celeritas/optical/CerenkovGenerator.hh
@@ -17,7 +17,7 @@
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/grid/GenericCalculator.hh"
 #include "celeritas/random/distribution/BernoulliDistribution.hh"
-#include "celeritas/random/distribution/RejectionSampler.hh"
+#include "celeritas/random/distribution/GenerateCanonical.hh"
 #include "celeritas/random/distribution/UniformRealDistribution.hh"
 
 #include "CerenkovDndxCalculator.hh"
@@ -42,8 +42,8 @@ namespace optical
  *
  * An incident charged particle with speed \f$ \beta \f$ will emit photons at
  * an angle \f$ \theta \f$ given by \f$ \cos\theta = 1 / (\beta n) \f$ where
- * \f$ n \f$ is the index of refraction of the matarial. The photon energy
- * \f$ \epsilon \f$ is sampled from the PDF \f[
+ * \f$ n \f$ is the index of refraction of the matarial. The photon energy \f$
+ * \epsilon \f$ is sampled from the PDF \f[
    f(\epsilon) = \left[1 - \frac{1}{n^2(\epsilon)\beta^2}\right]
  * \f]
  */
@@ -104,7 +104,8 @@ CerenkovGenerator::CerenkovGenerator(MaterialView const& material,
     CELER_EXPECT(photons_.size() == dist_.num_photons);
     CELER_EXPECT(material.material_id() == dist_.material);
 
-    using LS = units::LightSpeed;
+    auto const& energy_grid = calc_refractive_index_.grid();
+    sample_energy_ = UniformRealDist(energy_grid.front(), energy_grid.back());
 
     // Calculate the mean number of photons produced per unit length at the
     // pre- and post-step energies
@@ -117,14 +118,8 @@ CerenkovGenerator::CerenkovGenerator(MaterialView const& material,
     // Helper used to sample the displacement
     sample_num_photons_ = UniformRealDist(0, max(dndx_pre_, dndx_post));
 
-    // Helper to sample exiting photon energies
-    auto const& energy_grid = calc_refractive_index_.grid();
-    sample_energy_ = UniformRealDist(energy_grid.front(), energy_grid.back());
-
     // Calculate 1 / beta and the max sin^2 theta
-    inv_beta_
-        = 2 / (value_as<LS>(pre_step.speed) + value_as<LS>(post_step.speed));
-    CELER_ASSERT(inv_beta_ > 1);
+    inv_beta_ = 2 / (pre_step.speed.value() + post_step.speed.value());
     real_type cos_max = inv_beta_ / calc_refractive_index_(energy_grid.back());
     sin_max_sq_ = 1 - ipow<2>(cos_max);
 
@@ -152,24 +147,12 @@ CELER_FUNCTION Span<Primary> CerenkovGenerator::operator()(Generator& rng)
         real_type sin_theta_sq;
         do
         {
-            // Sample an energy uniformly within the grid bounds, rejecting
-            // if the refractive index at the sampled energy is such that the
-            // incident particle's average speed is subluminal at that photon
-            // wavelength.
-            // We could improve sampling efficiency for this edge case by
-            // reducing the maximum energy (searching `energy_grid` with
-            // `lower_bound`) to where the refractive index satisfies this
-            // condition, but fewer photons are emitted at lower energies so
-            // it should take a relatively small fraction of time.
-            do
-            {
-                energy = sample_energy_(rng);
-                cos_theta = inv_beta_ / calc_refractive_index_(energy);
-            } while (cos_theta > 1);
-            sin_theta_sq = 1 - ipow<2>(cos_theta);
-        } while (RejectionSampler{sin_theta_sq, sin_max_sq_}(rng));
-
-        // Sample azimuthal photon direction
+            // Sample an energy uniformly within the grid bounds
+            energy = sample_energy_(rng);
+            // Note that cos(theta) can be slightly larger than 1
+            cos_theta = inv_beta_ / calc_refractive_index_(energy);
+            sin_theta_sq = diffsq(real_type(1), cos_theta);
+        } while (generate_canonical(rng) * sin_max_sq_ > sin_theta_sq);
         real_type phi = sample_phi_(rng);
         photons_[i].direction = rotate(from_spherical(cos_theta, phi), dir_);
         photons_[i].energy = units::MevEnergy(energy);
@@ -178,12 +161,11 @@ CELER_FUNCTION Span<Primary> CerenkovGenerator::operator()(Generator& rng)
         photons_[i].polarization
             = rotate(from_spherical(-std::sqrt(sin_theta_sq), phi), dir_);
 
-        // Sample position and time uniformly along the step
-        UniformRealDistribution sample_step_fraction;
+        // Sample position and time
         real_type u;
         do
         {
-            u = sample_step_fraction(rng);
+            u = generate_canonical(rng);
         } while (sample_num_photons_(rng) > dndx_pre_ + u * delta_num_photons_);
         real_type delta_time
             = u * dist_.step_length

--- a/src/celeritas/optical/CerenkovOffload.hh
+++ b/src/celeritas/optical/CerenkovOffload.hh
@@ -16,7 +16,7 @@
 #include "CerenkovData.hh"
 #include "CerenkovDndxCalculator.hh"
 #include "GeneratorDistributionData.hh"
-#include "MaterialData.hh"
+#include "MaterialView.hh"
 #include "OffloadData.hh"
 
 namespace celeritas
@@ -42,8 +42,8 @@ class CerenkovOffload
     inline CELER_FUNCTION
     CerenkovOffload(ParticleTrackView const& particle,
                     SimTrackView const& sim,
+                    optical::MaterialView const& mat,
                     Real3 const& pos,
-                    NativeCRef<optical::MaterialParamsData> const& material,
                     NativeCRef<optical::CerenkovData> const& shared,
                     OffloadPreStepData const& step_data);
 
@@ -66,13 +66,13 @@ class CerenkovOffload
 /*!
  * Construct with optical material, Cerenkov, and step information.
  */
-CELER_FUNCTION CerenkovOffload::CerenkovOffload(
-    ParticleTrackView const& particle,
-    SimTrackView const& sim,
-    Real3 const& pos,
-    NativeCRef<optical::MaterialParamsData> const& material,
-    NativeCRef<optical::CerenkovData> const& shared,
-    OffloadPreStepData const& step_data)
+CELER_FUNCTION
+CerenkovOffload::CerenkovOffload(ParticleTrackView const& particle,
+                                 SimTrackView const& sim,
+                                 optical::MaterialView const& mat,
+                                 Real3 const& pos,
+                                 NativeCRef<optical::CerenkovData> const& shared,
+                                 OffloadPreStepData const& step_data)
     : charge_(particle.charge())
     , step_length_(sim.step_length())
     , pre_step_(step_data)
@@ -85,8 +85,7 @@ CELER_FUNCTION CerenkovOffload::CerenkovOffload(
     units::LightSpeed beta(
         real_type{0.5} * (pre_step_.speed.value() + post_step_.speed.value()));
 
-    optical::CerenkovDndxCalculator calculate_dndx(
-        material, shared, pre_step_.opt_mat, charge_);
+    optical::CerenkovDndxCalculator calculate_dndx(mat, shared, charge_);
     num_photons_per_len_ = calculate_dndx(beta);
 }
 

--- a/src/celeritas/optical/CerenkovOffload.hh
+++ b/src/celeritas/optical/CerenkovOffload.hh
@@ -114,7 +114,7 @@ CerenkovOffload::operator()(Generator& rng)
         data.time = pre_step_.time;
         data.step_length = step_length_;
         data.charge = charge_;
-        data.material = pre_step_.opt_mat;
+        data.material = pre_step_.material;
         data.points[StepPoint::pre].speed = pre_step_.speed;
         data.points[StepPoint::pre].pos = pre_step_.pos;
         data.points[StepPoint::post] = post_step_;

--- a/src/celeritas/optical/CerenkovOffload.hh
+++ b/src/celeritas/optical/CerenkovOffload.hh
@@ -16,7 +16,7 @@
 #include "CerenkovData.hh"
 #include "CerenkovDndxCalculator.hh"
 #include "GeneratorDistributionData.hh"
-#include "MaterialPropertyData.hh"
+#include "MaterialData.hh"
 #include "OffloadData.hh"
 
 namespace celeritas
@@ -38,12 +38,12 @@ namespace celeritas
 class CerenkovOffload
 {
   public:
-    // Construct with optical properties, Cerenkov, and step data
+    // Construct with optical material, Cerenkov, and step data
     inline CELER_FUNCTION
     CerenkovOffload(ParticleTrackView const& particle,
                     SimTrackView const& sim,
                     Real3 const& pos,
-                    NativeCRef<optical::MaterialPropertyData> const& properties,
+                    NativeCRef<optical::MaterialParamsData> const& material,
                     NativeCRef<optical::CerenkovData> const& shared,
                     OffloadPreStepData const& step_data);
 
@@ -64,13 +64,13 @@ class CerenkovOffload
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Construct with optical properties, Cerenkov, and step information.
+ * Construct with optical material, Cerenkov, and step information.
  */
 CELER_FUNCTION CerenkovOffload::CerenkovOffload(
     ParticleTrackView const& particle,
     SimTrackView const& sim,
     Real3 const& pos,
-    NativeCRef<optical::MaterialPropertyData> const& properties,
+    NativeCRef<optical::MaterialParamsData> const& material,
     NativeCRef<optical::CerenkovData> const& shared,
     OffloadPreStepData const& step_data)
     : charge_(particle.charge())
@@ -86,7 +86,7 @@ CELER_FUNCTION CerenkovOffload::CerenkovOffload(
         real_type{0.5} * (pre_step_.speed.value() + post_step_.speed.value()));
 
     optical::CerenkovDndxCalculator calculate_dndx(
-        properties, shared, pre_step_.opt_mat, charge_);
+        material, shared, pre_step_.opt_mat, charge_);
     num_photons_per_len_ = calculate_dndx(beta);
 }
 

--- a/src/celeritas/optical/CerenkovParams.cc
+++ b/src/celeritas/optical/CerenkovParams.cc
@@ -18,7 +18,7 @@
 #include "celeritas/Types.hh"
 #include "celeritas/grid/GenericGridInserter.hh"
 
-#include "MaterialPropertyParams.hh"
+#include "MaterialParams.hh"
 
 namespace celeritas
 {
@@ -28,10 +28,10 @@ namespace optical
 /*!
  * Construct with optical property data.
  */
-CerenkovParams::CerenkovParams(SPConstProperties properties)
+CerenkovParams::CerenkovParams(SPConstMaterial material)
 {
-    CELER_EXPECT(properties);
-    auto const& host_ref = properties->host_ref();
+    CELER_EXPECT(material);
+    auto const& host_ref = material->host_ref();
 
     HostVal<CerenkovData> data;
     GenericGridInserter insert_angle_integral(&data.reals,

--- a/src/celeritas/optical/CerenkovParams.cc
+++ b/src/celeritas/optical/CerenkovParams.cc
@@ -41,12 +41,7 @@ CerenkovParams::CerenkovParams(SPConstMaterial material)
          range(OpticalMaterialId(host_ref.refractive_index.size())))
     {
         auto const& ri_grid = host_ref.refractive_index[mat_id];
-        if (!ri_grid)
-        {
-            // No refractive index data stored for this material
-            insert_angle_integral();
-            continue;
-        }
+        CELER_ASSERT(ri_grid);
 
         // Calculate the Cerenkov angle integral
         auto const&& refractive_index = host_ref.reals[ri_grid.value];

--- a/src/celeritas/optical/CerenkovParams.hh
+++ b/src/celeritas/optical/CerenkovParams.hh
@@ -17,7 +17,7 @@ namespace celeritas
 {
 namespace optical
 {
-class MaterialPropertyParams;
+class MaterialParams;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -28,17 +28,17 @@ class CerenkovParams final : public ParamsDataInterface<CerenkovData>
   public:
     //!@{
     //! \name Type aliases
-    using SPConstProperties = std::shared_ptr<MaterialPropertyParams const>;
+    using SPConstMaterial = std::shared_ptr<MaterialParams const>;
     //!@}
 
   public:
     // Construct with optical property data
-    explicit CerenkovParams(SPConstProperties properties);
+    explicit CerenkovParams(SPConstMaterial material);
 
-    //! Access physics properties on the host
+    //! Access physics material on the host
     HostRef const& host_ref() const final { return data_.host_ref(); }
 
-    //! Access physics properties on the device
+    //! Access physics material on the device
     DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:

--- a/src/celeritas/optical/MaterialData.hh
+++ b/src/celeritas/optical/MaterialData.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/optical/MaterialPropertyData.hh
+//! \file celeritas/optical/MaterialData.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -12,7 +12,8 @@
 #include "corecel/data/Collection.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/grid/GenericGridData.hh"
-#include "celeritas/optical/Types.hh"
+
+#include "Types.hh"
 
 namespace celeritas
 {
@@ -20,12 +21,10 @@ namespace optical
 {
 //---------------------------------------------------------------------------//
 /*!
- * Shared optical properties data.
- *
- * TODO: Placeholder for optical property data; modify or replace as needed.
+ * Shared optical material properties.
  */
 template<Ownership W, MemSpace M>
-struct MaterialPropertyData
+struct MaterialParamsData
 {
     template<class T>
     using Items = Collection<T, W, M>;
@@ -49,7 +48,7 @@ struct MaterialPropertyData
 
     //! Assign from another set of data
     template<Ownership W2, MemSpace M2>
-    MaterialPropertyData& operator=(MaterialPropertyData<W2, M2> const& other)
+    MaterialParamsData& operator=(MaterialParamsData<W2, M2> const& other)
     {
         CELER_EXPECT(other);
         refractive_index = other.refractive_index;

--- a/src/celeritas/optical/MaterialParams.cc
+++ b/src/celeritas/optical/MaterialParams.cc
@@ -13,6 +13,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/grid/VectorUtils.hh"
+#include "corecel/io/Logger.hh"
 #include "corecel/math/Algorithms.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
@@ -80,6 +81,10 @@ MaterialParams::MaterialParams(Input const& inp)
         CELER_VALIDATE(is_monotonic_increasing(make_span(ri_vec.y)),
                        << "refractive index values are not monotonically "
                           "increasing");
+        if (ri_vec.y.front() < 1)
+        {
+            CELER_LOG(warning) << "Encountered refractive index below unity";
+        }
 
         refractive_index.push_back(build_grid(ri_vec));
     }

--- a/src/celeritas/optical/MaterialParams.cc
+++ b/src/celeritas/optical/MaterialParams.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/optical/MaterialPropertyParams.cc
+//! \file celeritas/optical/MaterialParams.cc
 //---------------------------------------------------------------------------//
-#include "MaterialPropertyParams.hh"
+#include "MaterialParams.hh"
 
 #include <algorithm>
 #include <utility>
@@ -28,8 +28,8 @@ namespace optical
 /*!
  * Construct with imported data.
  */
-std::shared_ptr<MaterialPropertyParams>
-MaterialPropertyParams::from_import(ImportData const& data)
+std::shared_ptr<MaterialParams>
+MaterialParams::from_import(ImportData const& data)
 {
     CELER_EXPECT(!data.optical.empty());
 
@@ -45,21 +45,23 @@ MaterialPropertyParams::from_import(ImportData const& data)
     Input input;
     for (auto const& mat : data.optical)
     {
-        input.data.push_back(mat.second.properties);
+        input.properties.push_back(mat.second.properties);
     }
-    return std::make_shared<MaterialPropertyParams>(std::move(input));
+    return std::make_shared<MaterialParams>(std::move(input));
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct with optical property data.
  */
-MaterialPropertyParams::MaterialPropertyParams(Input const& inp)
+MaterialParams::MaterialParams(Input const& inp)
 {
-    HostVal<MaterialPropertyData> data;
+    CELER_EXPECT(!inp.properties.empty());
+
+    HostVal<MaterialParamsData> data;
     CollectionBuilder refractive_index{&data.refractive_index};
     GenericGridBuilder build_grid(&data.reals);
-    for (auto const& mat : inp.data)
+    for (auto const& mat : inp.properties)
     {
         // Store refractive index tabulated as a function of photon energy
         auto const& ri_vec = mat.refractive_index;
@@ -81,10 +83,10 @@ MaterialPropertyParams::MaterialPropertyParams(Input const& inp)
 
         refractive_index.push_back(build_grid(ri_vec));
     }
-    CELER_ASSERT(refractive_index.size() == inp.data.size());
+    CELER_ASSERT(refractive_index.size() == inp.properties.size());
 
-    data_ = CollectionMirror<MaterialPropertyData>{std::move(data)};
-    CELER_ENSURE(data_ || inp.data.empty());
+    data_ = CollectionMirror<MaterialParamsData>{std::move(data)};
+    CELER_ENSURE(data_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/MaterialParams.hh
+++ b/src/celeritas/optical/MaterialParams.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/optical/MaterialPropertyParams.hh
+//! \file celeritas/optical/MaterialParams.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -14,7 +14,7 @@
 #include "corecel/data/ParamsDataInterface.hh"
 #include "celeritas/io/ImportOpticalMaterial.hh"
 
-#include "MaterialPropertyData.hh"
+#include "MaterialData.hh"
 
 namespace celeritas
 {
@@ -27,40 +27,42 @@ namespace optical
 /*!
  * Manage properties for optical materials.
  *
- * More than one "geometry material" (i.e. \c G4Material or material defined in
- * the geometry model input) can point to a single optical material.
+ * Each "geometry material" (i.e. \c G4Material or material defined in
+ * the geometry model input) can map to a single optical material. (In the
+ * future we might broaden this to allow \c regions to define different
+ * materials as well.) Many "geometry materials"---especially those in
+ * mechanical structures and components not optically connected to the
+ * detector---may have no optical properties at all.
  *
  * Optical volume and surface properties are imported from Geant4 into the \c
  * ImportData container. The \c celeritas::MaterialParams class loads the
  * mapping of \c GeoMaterialId to \c OpticalMaterialId and makes it accessible
  * via the main loop's material view.
  */
-class MaterialPropertyParams final
-    : public ParamsDataInterface<MaterialPropertyData>
+class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 {
   public:
-    // Shared optical properties, indexed by \c OpticalMaterialId
     struct Input
     {
-        std::vector<ImportOpticalProperty> data;
+        //! Shared optical material, indexed by \c OpticalMaterialId
+        std::vector<ImportOpticalProperty> properties;
     };
 
   public:
     // Construct with imported data
-    static std::shared_ptr<MaterialPropertyParams>
-    from_import(ImportData const& data);
+    static std::shared_ptr<MaterialParams> from_import(ImportData const& data);
 
     // Construct with optical property data
-    explicit MaterialPropertyParams(Input const& inp);
+    explicit MaterialParams(Input const& inp);
 
-    //! Access optical properties on the host
+    //! Access optical material on the host
     HostRef const& host_ref() const final { return data_.host_ref(); }
 
-    //! Access optical properties on the device
+    //! Access optical material on the device
     DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
-    CollectionMirror<MaterialPropertyData> data_;
+    CollectionMirror<MaterialParamsData> data_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/MaterialView.hh
+++ b/src/celeritas/optical/MaterialView.hh
@@ -1,0 +1,89 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/mat/MaterialView.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "celeritas/Types.hh"
+#include "celeritas/grid/GenericCalculator.hh"
+
+#include "MaterialData.hh"
+
+namespace celeritas
+{
+namespace optical
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Access optical material properties.
+ */
+class MaterialView
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using ParamsRef = NativeCRef<MaterialParamsData>;
+    using MaterialId = OpticalMaterialId;
+    //!@}
+
+  public:
+    // Construct from params and material ID
+    inline CELER_FUNCTION MaterialView(ParamsRef const& params, MaterialId id);
+
+    //// MATERIAL DATA ////
+
+    // ID of this optical material
+    CELER_FORCEINLINE_FUNCTION MaterialId material_id() const;
+
+    //// PARAMETER DATA ////
+
+    // Access energy-dependent refractive index
+    GenericCalculator make_refractive_index_calculator() const;
+
+  private:
+    //// DATA ////
+
+    ParamsRef const& params_;
+    MaterialId mat_id_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from dynamic and static particle properties.
+ */
+CELER_FUNCTION
+MaterialView::MaterialView(ParamsRef const& params, MaterialId id)
+    : params_(params), mat_id_(id)
+{
+    CELER_EXPECT(id < params_.refractive_index.size());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the optical material id.
+ */
+CELER_FUNCTION auto MaterialView::material_id() const -> MaterialId
+{
+    return mat_id_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access energy-dependent refractive index.
+ */
+CELER_FUNCTION GenericCalculator
+MaterialView::make_refractive_index_calculator() const
+{
+    return GenericCalculator(params_.refractive_index[mat_id_], params_.reals);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace optical
+}  // namespace celeritas

--- a/src/celeritas/optical/MaterialView.hh
+++ b/src/celeritas/optical/MaterialView.hh
@@ -43,7 +43,8 @@ class MaterialView
     //// PARAMETER DATA ////
 
     // Access energy-dependent refractive index
-    GenericCalculator make_refractive_index_calculator() const;
+    inline CELER_FUNCTION GenericCalculator
+    make_refractive_index_calculator() const;
 
   private:
     //// DATA ////

--- a/src/celeritas/optical/OffloadData.hh
+++ b/src/celeritas/optical/OffloadData.hh
@@ -16,7 +16,6 @@
 
 #include "CerenkovData.hh"
 #include "GeneratorDistributionData.hh"
-#include "MaterialPropertyData.hh"
 #include "ScintillationData.hh"
 
 namespace celeritas

--- a/src/celeritas/optical/OffloadData.hh
+++ b/src/celeritas/optical/OffloadData.hh
@@ -91,12 +91,12 @@ struct OffloadPreStepData
     units::LightSpeed speed;
     Real3 pos{};
     real_type time{};
-    OpticalMaterialId opt_mat;
+    OpticalMaterialId material;
 
     //! Check whether the data are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return opt_mat && speed > zero_quantity();
+        return material && speed > zero_quantity();
     }
 };
 

--- a/src/celeritas/optical/OpticalCollector.cc
+++ b/src/celeritas/optical/OpticalCollector.cc
@@ -11,7 +11,7 @@
 #include "celeritas/global/ActionRegistry.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/optical/CerenkovParams.hh"
-#include "celeritas/optical/MaterialPropertyParams.hh"
+#include "celeritas/optical/MaterialParams.hh"
 #include "celeritas/optical/OffloadData.hh"
 #include "celeritas/optical/ScintillationParams.hh"
 
@@ -28,7 +28,7 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
     CELER_EXPECT(inp);
 
     OffloadOptions setup;
-    setup.cerenkov = inp.cerenkov && inp.properties;
+    setup.cerenkov = inp.cerenkov && inp.material;
     setup.scintillation = static_cast<bool>(inp.scintillation);
     setup.capacity = inp.buffer_capacity;
 
@@ -50,7 +50,7 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
             = std::make_shared<detail::CerenkovOffloadAction>(
                 actions.next_id(),
                 gen_params_->aux_id(),
-                std::move(inp.properties),
+                std::move(inp.material),
                 std::move(inp.cerenkov));
         actions.insert(cerenkov_offload_action_);
     }

--- a/src/celeritas/optical/OpticalCollector.hh
+++ b/src/celeritas/optical/OpticalCollector.hh
@@ -23,9 +23,13 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 class ActionRegistry;
 class CerenkovParams;
-class MaterialPropertyParams;
 class ScintillationParams;
 class CoreParams;
+
+namespace optical
+{
+class MaterialParams;
+}
 
 namespace detail
 {
@@ -52,16 +56,15 @@ class OpticalCollector
     //!@{
     //! \name Type aliases
     using SPConstCerenkov = std::shared_ptr<optical::CerenkovParams const>;
-    using SPConstProperties
-        = std::shared_ptr<optical::MaterialPropertyParams const>;
+    using SPConstMaterial = std::shared_ptr<optical::MaterialParams const>;
     using SPConstScintillation
         = std::shared_ptr<optical::ScintillationParams const>;
     //!@}
 
     struct Input
     {
-        //! Optical physics properties for materials
-        SPConstProperties properties;
+        //! Optical physics material for materials
+        SPConstMaterial material;
         SPConstCerenkov cerenkov;
         SPConstScintillation scintillation;
 
@@ -71,7 +74,7 @@ class OpticalCollector
         //! True if all input is assigned and valid
         explicit operator bool() const
         {
-            return (scintillation || (cerenkov && properties))
+            return (scintillation || (cerenkov && material))
                    && buffer_capacity > 0;
         }
     };

--- a/src/celeritas/optical/ScintillationOffload.hh
+++ b/src/celeritas/optical/ScintillationOffload.hh
@@ -16,7 +16,6 @@
 #include "celeritas/track/SimTrackView.hh"
 
 #include "GeneratorDistributionData.hh"
-#include "MaterialPropertyData.hh"
 #include "OffloadData.hh"
 #include "ScintillationData.hh"
 

--- a/src/celeritas/optical/ScintillationOffload.hh
+++ b/src/celeritas/optical/ScintillationOffload.hh
@@ -59,7 +59,7 @@ class ScintillationOffload
     OffloadPreStepData const& pre_step_;
     optical::GeneratorStepData post_step_;
     NativeCRef<optical::ScintillationData> const& shared_;
-    real_type mean_num_photons_;
+    real_type mean_num_photons_{0};
 
     static CELER_CONSTEXPR_FUNCTION real_type poisson_threshold()
     {
@@ -99,13 +99,15 @@ CELER_FUNCTION ScintillationOffload::ScintillationOffload(
     else
     {
         // Scintillation will be performed on materials only
-        CELER_ASSERT(pre_step_.opt_mat < shared_.materials.size());
-        auto const& material = shared_.materials[pre_step_.opt_mat];
+        CELER_ASSERT(pre_step_.material < shared_.materials.size());
+        auto const& material = shared_.materials[pre_step_.material];
 
         // TODO: Use visible energy deposition when Birks law is implemented
-        mean_num_photons_ = material ? material.yield_per_energy
-                                           * energy_deposition.value()
-                                     : 0;
+        if (material)
+        {
+            mean_num_photons_ = material.yield_per_energy
+                                * energy_deposition.value();
+        }
     }
 }
 
@@ -122,7 +124,7 @@ ScintillationOffload::operator()(Generator& rng)
     optical::GeneratorDistributionData result;
     if (mean_num_photons_ > poisson_threshold())
     {
-        real_type sigma = shared_.resolution_scale[pre_step_.opt_mat]
+        real_type sigma = shared_.resolution_scale[pre_step_.material]
                           * std::sqrt(mean_num_photons_);
         result.num_photons = static_cast<size_type>(clamp_to_nonneg(
             NormalDistribution<real_type>(mean_num_photons_, sigma)(rng)
@@ -140,7 +142,7 @@ ScintillationOffload::operator()(Generator& rng)
         result.time = pre_step_.time;
         result.step_length = step_length_;
         result.charge = charge_;
-        result.material = pre_step_.opt_mat;
+        result.material = pre_step_.material;
         result.points[StepPoint::pre].speed = pre_step_.speed;
         result.points[StepPoint::pre].pos = pre_step_.pos;
         result.points[StepPoint::post] = post_step_;

--- a/src/celeritas/optical/detail/CerenkovOffloadAction.cu
+++ b/src/celeritas/optical/detail/CerenkovOffloadAction.cu
@@ -14,7 +14,7 @@
 #include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackExecutor.hh"
 #include "celeritas/optical/CerenkovParams.hh"
-#include "celeritas/optical/MaterialPropertyParams.hh"
+#include "celeritas/optical/MaterialParams.hh"
 
 #include "CerenkovOffloadExecutor.hh"
 #include "OffloadParams.hh"
@@ -36,7 +36,7 @@ void CerenkovOffloadAction::pre_generate(CoreParams const& core_params,
     TrackExecutor execute{
         core_params.ptr<MemSpace::native>(),
         core_state.ptr(),
-        detail::CerenkovOffloadExecutor{properties_->device_ref(),
+        detail::CerenkovOffloadExecutor{material_->device_ref(),
                                         cerenkov_->device_ref(),
                                         state.store.ref(),
                                         state.buffer_size}};

--- a/src/celeritas/optical/detail/CerenkovOffloadAction.hh
+++ b/src/celeritas/optical/detail/CerenkovOffloadAction.hh
@@ -22,7 +22,7 @@ namespace celeritas
 namespace optical
 {
 class CerenkovParams;
-class MaterialPropertyParams;
+class MaterialParams;
 }  // namespace optical
 
 namespace detail
@@ -39,16 +39,16 @@ class CerenkovOffloadAction final : public ExplicitCoreActionInterface
     //! \name Type aliases
     using SPConstCerenkov
         = std::shared_ptr<celeritas::optical::CerenkovParams const>;
-    using SPConstProperties
-        = std::shared_ptr<celeritas::optical::MaterialPropertyParams const>;
+    using SPConstMaterial
+        = std::shared_ptr<celeritas::optical::MaterialParams const>;
     using SPGenStorage = std::shared_ptr<detail::OpticalGenStorage>;
     //!@}
 
   public:
-    // Construct with action ID, optical properties, and storage
+    // Construct with action ID, optical material, and storage
     CerenkovOffloadAction(ActionId id,
                           AuxId data_id,
-                          SPConstProperties properties,
+                          SPConstMaterial material,
                           SPConstCerenkov cerenkov);
 
     // Launch kernel with host data
@@ -74,7 +74,7 @@ class CerenkovOffloadAction final : public ExplicitCoreActionInterface
 
     ActionId id_;
     AuxId data_id_;
-    SPConstProperties properties_;
+    SPConstMaterial material_;
     SPConstCerenkov cerenkov_;
 
     //// HELPER FUNCTIONS ////

--- a/src/celeritas/optical/detail/CerenkovOffloadExecutor.hh
+++ b/src/celeritas/optical/detail/CerenkovOffloadExecutor.hh
@@ -28,7 +28,7 @@ struct CerenkovOffloadExecutor
     inline CELER_FUNCTION void
     operator()(celeritas::CoreTrackView const& track);
 
-    NativeCRef<celeritas::optical::MaterialParamsData> const properties;
+    NativeCRef<celeritas::optical::MaterialParamsData> const material;
     NativeCRef<celeritas::optical::CerenkovData> const cerenkov;
     NativeRef<OffloadStateData> const state;
     OffloadBufferSize size;
@@ -45,7 +45,7 @@ CerenkovOffloadExecutor::operator()(CoreTrackView const& track)
 {
     CELER_EXPECT(state);
     CELER_EXPECT(cerenkov);
-    CELER_EXPECT(properties);
+    CELER_EXPECT(material);
 
     using DistId = ItemId<celeritas::optical::GeneratorDistributionData>;
 

--- a/src/celeritas/optical/detail/CerenkovOffloadExecutor.hh
+++ b/src/celeritas/optical/detail/CerenkovOffloadExecutor.hh
@@ -72,10 +72,10 @@ CerenkovOffloadExecutor::operator()(CoreTrackView const& track)
     if (particle.charge() != zero_quantity())
     {
         Real3 const& pos = track.make_geo_view().pos();
+        optical::MaterialView opt_mat{material, step.material};
         auto rng = track.make_rng_engine();
 
-        CerenkovOffload generate(
-            particle, sim, pos, properties, cerenkov, step);
+        CerenkovOffload generate(particle, sim, opt_mat, pos, cerenkov, step);
         cerenkov_dist = generate(rng);
     }
 }

--- a/src/celeritas/optical/detail/CerenkovOffloadExecutor.hh
+++ b/src/celeritas/optical/detail/CerenkovOffloadExecutor.hh
@@ -28,7 +28,7 @@ struct CerenkovOffloadExecutor
     inline CELER_FUNCTION void
     operator()(celeritas::CoreTrackView const& track);
 
-    NativeCRef<celeritas::optical::MaterialPropertyData> const properties;
+    NativeCRef<celeritas::optical::MaterialParamsData> const properties;
     NativeCRef<celeritas::optical::CerenkovData> const cerenkov;
     NativeRef<OffloadStateData> const state;
     OffloadBufferSize size;

--- a/src/celeritas/optical/detail/OffloadGatherExecutor.hh
+++ b/src/celeritas/optical/detail/OffloadGatherExecutor.hh
@@ -48,7 +48,7 @@ OffloadGatherExecutor::operator()(CoreTrackView const& track)
     step.speed = track.make_particle_view().speed();
     step.pos = track.make_geo_view().pos();
     step.time = track.make_sim_view().time();
-    step.opt_mat
+    step.material
         = track.make_material_view().make_material_view().optical_material_id();
 }
 

--- a/test/celeritas/GlobalTestBase.hh
+++ b/test/celeritas/GlobalTestBase.hh
@@ -40,7 +40,7 @@ class OutputRegistry;
 namespace optical
 {
 class CerenkovParams;
-class MaterialPropertyParams;
+class MaterialParams;
 class ScintillationParams;
 }  // namespace optical
 
@@ -80,7 +80,7 @@ class GlobalTestBase : public Test
     using SPUserRegistry = SP<AuxParamsRegistry>;
 
     using SPConstCerenkov = SP<optical::CerenkovParams const>;
-    using SPConstProperties = SP<optical::MaterialPropertyParams const>;
+    using SPConstOpticalMaterial = SP<optical::MaterialParams const>;
     using SPConstScintillation = SP<optical::ScintillationParams const>;
     //!@}
 
@@ -109,7 +109,7 @@ class GlobalTestBase : public Test
     inline SPUserRegistry const& aux_reg();
     inline SPConstCore const& core();
     inline SPConstCerenkov const& cerenkov();
-    inline SPConstProperties const& properties();
+    inline SPConstOpticalMaterial const& optical_material();
     inline SPConstScintillation const& scintillation();
 
     inline SPConstGeo const& geometry() const;
@@ -127,7 +127,7 @@ class GlobalTestBase : public Test
     inline SPUserRegistry const& aux_reg() const;
     inline SPConstCore const& core() const;
     inline SPConstCerenkov const& cerenkov() const;
-    inline SPConstProperties const& properties() const;
+    inline SPConstOpticalMaterial const& optical_material() const;
     inline SPConstScintillation const& scintillation() const;
     //!@}
 
@@ -150,7 +150,7 @@ class GlobalTestBase : public Test
     [[nodiscard]] virtual SPConstWentzelOKVI build_wentzel() = 0;
     [[nodiscard]] virtual SPConstAction build_along_step() = 0;
     [[nodiscard]] virtual SPConstCerenkov build_cerenkov() = 0;
-    [[nodiscard]] virtual SPConstProperties build_properties() = 0;
+    [[nodiscard]] virtual SPConstOpticalMaterial build_optical_material() = 0;
     [[nodiscard]] virtual SPConstScintillation build_scintillation() = 0;
 
     // Do not insert StatusChecker
@@ -179,7 +179,7 @@ class GlobalTestBase : public Test
     SPConstCore core_;
     SPOutputRegistry output_reg_;
     SPConstCerenkov cerenkov_;
-    SPConstProperties properties_;
+    SPConstOpticalMaterial optical_material_;
     SPConstScintillation scintillation_;
     bool insert_status_checker_{true};
 };
@@ -218,7 +218,7 @@ DEF_GTB_ACCESSORS(SPActionRegistry, action_reg)
 DEF_GTB_ACCESSORS(SPUserRegistry, aux_reg)
 DEF_GTB_ACCESSORS(SPConstCore, core)
 DEF_GTB_ACCESSORS(SPConstCerenkov, cerenkov)
-DEF_GTB_ACCESSORS(SPConstProperties, properties)
+DEF_GTB_ACCESSORS(SPConstOpticalMaterial, optical_material)
 DEF_GTB_ACCESSORS(SPConstScintillation, scintillation)
 auto GlobalTestBase::wentzel() -> SPConstWentzelOKVI const&
 {

--- a/test/celeritas/ImportedDataTestBase.cc
+++ b/test/celeritas/ImportedDataTestBase.cc
@@ -12,7 +12,7 @@
 #include "celeritas/io/ImportData.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/optical/CerenkovParams.hh"
-#include "celeritas/optical/MaterialPropertyParams.hh"
+#include "celeritas/optical/MaterialParams.hh"
 #include "celeritas/optical/ScintillationParams.hh"
 #include "celeritas/phys/CutoffParams.hh"
 #include "celeritas/phys/ParticleParams.hh"
@@ -133,13 +133,13 @@ auto ImportedDataTestBase::build_physics() -> SPConstPhysics
 //---------------------------------------------------------------------------//
 auto ImportedDataTestBase::build_cerenkov() -> SPConstCerenkov
 {
-    return std::make_shared<optical::CerenkovParams>(this->properties());
+    return std::make_shared<optical::CerenkovParams>(this->optical_material());
 }
 
 //---------------------------------------------------------------------------//
-auto ImportedDataTestBase::build_properties() -> SPConstProperties
+auto ImportedDataTestBase::build_optical_material() -> SPConstOpticalMaterial
 {
-    return optical::MaterialPropertyParams::from_import(this->imported_data());
+    return optical::MaterialParams::from_import(this->imported_data());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ImportedDataTestBase.hh
+++ b/test/celeritas/ImportedDataTestBase.hh
@@ -52,7 +52,7 @@ class ImportedDataTestBase : virtual public GlobalGeoTestBase
     SPConstSim build_sim() override;
     SPConstWentzelOKVI build_wentzel() override;
     SPConstCerenkov build_cerenkov() override;
-    SPConstProperties build_properties() override;
+    SPConstOpticalMaterial build_optical_material() override;
     SPConstScintillation build_scintillation() override;
 };
 

--- a/test/celeritas/OnlyCoreTestBase.hh
+++ b/test/celeritas/OnlyCoreTestBase.hh
@@ -24,7 +24,7 @@ class OnlyCoreTestBase : virtual public GlobalTestBase
 {
   public:
     SPConstCerenkov build_cerenkov() override { CELER_ASSERT_UNREACHABLE(); }
-    SPConstProperties build_properties() override
+    SPConstOpticalMaterial build_optical_material() override
     {
         CELER_ASSERT_UNREACHABLE();
     }

--- a/test/celeritas/optical/Cerenkov.test.cc
+++ b/test/celeritas/optical/Cerenkov.test.cc
@@ -440,7 +440,7 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
         EXPECT_SOFT_EQ(10.609603075017075, avg_engine_samples);
     }
 
-    // 500 keV e-: 1/beta_avg ~ 1.336
+    // 500 keV e-: 1/beta ~ 1.336
     {
         // Pre-step values
         OffloadPreStepData pre_step;
@@ -449,7 +449,7 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
         pre_step.time = 0;
         pre_step.material = material_id;
 
-        // Post-step values (150 keV)
+        // Post-step values
         auto particle
             = this->make_particle_track_view(Energy(0.15), pdg::electron());
         EXPECT_SOFT_EQ(0.63431981443206786,
@@ -458,22 +458,22 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
         Real3 pos = {sim.step_length(), 0, 0};
 
         static double const expected_costheta_dist[]
-            = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 991};
+            = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 946};
         static double const expected_energy_dist[]
-            = {0, 0, 0, 0, 4, 14, 29, 26, 48, 51, 77, 103, 129, 132, 174, 204};
+            = {0, 0, 0, 0, 10, 13, 24, 29, 47, 54, 81, 85, 120, 119, 176, 188};
         static double const expected_displacement_dist[] = {
-            123, 114, 103, 102, 83, 81, 80, 57, 60, 59, 31, 29, 36, 14, 16, 3};
+            108, 108, 90, 105, 83, 88, 85, 65, 49, 43, 31, 29, 31, 16, 13, 2};
 
         sample(pre_step, particle, sim, pos, num_samples);
 
         EXPECT_VEC_EQ(expected_costheta_dist, costheta_dist);
         EXPECT_VEC_EQ(expected_energy_dist, energy_dist);
         EXPECT_VEC_EQ(expected_displacement_dist, displacement_dist);
-        EXPECT_SOFT_EQ(0.95045221539598979, avg_costheta);
-        EXPECT_SOFT_EQ(5.5902203966702514e-06, avg_energy);
-        EXPECT_SOFT_EQ(0.049715603846029896, avg_displacement);
-        EXPECT_SOFT_EQ(15.484375, total_num_photons / num_samples);
-        EXPECT_SOFT_EQ(25.077699293642784, avg_engine_samples);
+        EXPECT_SOFT_EQ(0.95069574770853793, avg_costheta);
+        EXPECT_SOFT_EQ(5.5675610907221099e-06, avg_energy);
+        EXPECT_SOFT_EQ(0.049432369852608751, avg_displacement);
+        EXPECT_SOFT_EQ(14.78125, total_num_photons / num_samples);
+        EXPECT_SOFT_EQ(27.162790697674417, avg_engine_samples);
     }
 }
 

--- a/test/celeritas/optical/Cerenkov.test.cc
+++ b/test/celeritas/optical/Cerenkov.test.cc
@@ -149,7 +149,7 @@ class CerenkovTest : public OpticalTestBase
 
     std::shared_ptr<MaterialParams const> material;
     std::shared_ptr<CerenkovParams const> params;
-    OpticalMaterialId opt_mat{0};
+    OpticalMaterialId material_id{0};
 };
 
 //---------------------------------------------------------------------------//
@@ -227,7 +227,7 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(pre_generator))
         pre_step.pos = {0, 0, 0};
         pre_step.speed = units::LightSpeed{0.63431981443206786};
         pre_step.time = 0;
-        pre_step.opt_mat = opt_mat;
+        pre_step.material = material_id;
 
         // Post-step values
         auto particle
@@ -253,7 +253,7 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(pre_generator))
             // Remaining values are assigned to result from input data
             EXPECT_EQ(pre_step.time, result.time);
             EXPECT_EQ(particle.charge().value(), result.charge.value());
-            EXPECT_EQ(opt_mat, result.material);
+            EXPECT_EQ(material_id, result.material);
             EXPECT_EQ(sim.step_length(), result.step_length);
             EXPECT_EQ(pre_step.speed.value(),
                       result.points[StepPoint::pre].speed.value());
@@ -276,7 +276,7 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(pre_generator))
         pre_step.pos = {0, 0, 0};
         pre_step.speed = units::LightSpeed{0.55};
         pre_step.time = 0;
-        pre_step.opt_mat = opt_mat;
+        pre_step.material = material_id;
 
         // Post-step values
         auto particle
@@ -416,7 +416,7 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
         pre_step.pos = {0, 0, 0};
         pre_step.speed = units::LightSpeed{0.99999999869453382};  // 10 GeV
         pre_step.time = 0;
-        pre_step.opt_mat = opt_mat;
+        pre_step.material = material_id;
 
         // Post-step values
         auto particle
@@ -454,7 +454,7 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
         pre_step.pos = {0, 0, 0};
         pre_step.speed = units::LightSpeed(0.86286196322132458);  // 500 keV
         pre_step.time = 0;
-        pre_step.opt_mat = opt_mat;
+        pre_step.material = material_id;
 
         // Post-step values (150 keV)
         auto particle

--- a/test/celeritas/optical/Cerenkov.test.cc
+++ b/test/celeritas/optical/Cerenkov.test.cc
@@ -447,7 +447,7 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
         EXPECT_SOFT_EQ(10.609603075017075, avg_engine_samples);
     }
 
-    // 500 keV e-: 1/beta ~ 1.336
+    // 500 keV e-: 1/beta_avg ~ 1.336
     {
         // Pre-step values
         OffloadPreStepData pre_step;
@@ -456,7 +456,7 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
         pre_step.time = 0;
         pre_step.opt_mat = opt_mat;
 
-        // Post-step values
+        // Post-step values (150 keV)
         auto particle
             = this->make_particle_track_view(Energy(0.15), pdg::electron());
         EXPECT_SOFT_EQ(0.63431981443206786,
@@ -465,22 +465,22 @@ TEST_F(CerenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
         Real3 pos = {sim.step_length(), 0, 0};
 
         static double const expected_costheta_dist[]
-            = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 946};
+            = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 991};
         static double const expected_energy_dist[]
-            = {0, 0, 0, 0, 10, 13, 24, 29, 47, 54, 81, 85, 120, 119, 176, 188};
+            = {0, 0, 0, 0, 4, 14, 29, 26, 48, 51, 77, 103, 129, 132, 174, 204};
         static double const expected_displacement_dist[] = {
-            108, 108, 90, 105, 83, 88, 85, 65, 49, 43, 31, 29, 31, 16, 13, 2};
+            123, 114, 103, 102, 83, 81, 80, 57, 60, 59, 31, 29, 36, 14, 16, 3};
 
         sample(pre_step, particle, sim, pos, num_samples);
 
         EXPECT_VEC_EQ(expected_costheta_dist, costheta_dist);
         EXPECT_VEC_EQ(expected_energy_dist, energy_dist);
         EXPECT_VEC_EQ(expected_displacement_dist, displacement_dist);
-        EXPECT_SOFT_EQ(0.95069574770853793, avg_costheta);
-        EXPECT_SOFT_EQ(5.5675610907221099e-06, avg_energy);
-        EXPECT_SOFT_EQ(0.049432369852608751, avg_displacement);
-        EXPECT_SOFT_EQ(14.78125, total_num_photons / num_samples);
-        EXPECT_SOFT_EQ(27.162790697674417, avg_engine_samples);
+        EXPECT_SOFT_EQ(0.95045221539598979, avg_costheta);
+        EXPECT_SOFT_EQ(5.5902203966702514e-06, avg_energy);
+        EXPECT_SOFT_EQ(0.049715603846029896, avg_displacement);
+        EXPECT_SOFT_EQ(15.484375, total_num_photons / num_samples);
+        EXPECT_SOFT_EQ(25.077699293642784, avg_engine_samples);
     }
 }
 

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -152,7 +152,7 @@ void LArSphereOffloadTest::build_optical_collector()
     OpticalCollector::Input inp;
     if (use_cerenkov_)
     {
-        inp.properties = this->properties();
+        inp.material = this->optical_material();
         inp.cerenkov = this->cerenkov();
     }
     if (use_scintillation_)

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -34,6 +34,7 @@ namespace celeritas
 {
 namespace test
 {
+// TODO: replace this with explicit namespace importing
 using namespace celeritas::optical;
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/optical/Scintillation.test.cc
+++ b/test/celeritas/optical/Scintillation.test.cc
@@ -72,7 +72,7 @@ class ScintillationTestBase : public OpticalTestBase
         pre_step.speed = LightSpeed(0.99862874144970537);  // 10 MeV
         pre_step.pos = {0, 0, 0};
         pre_step.time = 0;
-        pre_step.opt_mat = opt_mat_;
+        pre_step.material = opt_mat_;
         return pre_step;
     }
 


### PR DESCRIPTION
This renames `MaterialProperties` to `MaterialParams` and defines a `MaterialView` class. As discussed on slack, it also now validates that the refractive index is defined in all the optical materials.