### PR TITLE
Clear along-step action when track is marked as errored

### DIFF
--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -340,6 +340,7 @@ CELER_FUNCTION void CoreTrackView::apply_errored()
     auto sim = this->make_sim_view();
     CELER_EXPECT(is_track_valid(sim.status()));
     sim.status(TrackStatus::errored);
+    sim.along_step_action({});
     sim.post_step_action(this->tracking_cut_action());
 }
 

--- a/src/celeritas/global/alongstep/detail/FluctELoss.hh
+++ b/src/celeritas/global/alongstep/detail/FluctELoss.hh
@@ -76,6 +76,11 @@ CELER_FUNCTION FluctELoss::FluctELoss(ParamsRef const& params)
  */
 CELER_FUNCTION bool FluctELoss::is_applicable(CoreTrackView const& track) const
 {
+    // The track can be marked as `errored` *within* the along-step kernel,
+    // during propagation
+    if (track.make_sim_view().status() == TrackStatus::errored)
+        return false;
+
     // Energy loss grid ID will be 'false' if inapplicable
     auto ppid = track.make_physics_view().eloss_ppid();
     return static_cast<bool>(ppid);

--- a/src/celeritas/global/alongstep/detail/MeanELoss.hh
+++ b/src/celeritas/global/alongstep/detail/MeanELoss.hh
@@ -48,6 +48,11 @@ class MeanELoss
  */
 CELER_FUNCTION bool MeanELoss::is_applicable(CoreTrackView const& track) const
 {
+    // The track can be marked as `errored` *within* the along-step kernel,
+    // during propagation
+    if (track.make_sim_view().status() == TrackStatus::errored)
+        return false;
+
     // Energy loss grid ID will be 'false' if inapplicable
     auto ppid = track.make_physics_view().eloss_ppid();
     return static_cast<bool>(ppid);

--- a/src/celeritas/global/alongstep/detail/TimeUpdater.hh
+++ b/src/celeritas/global/alongstep/detail/TimeUpdater.hh
@@ -27,6 +27,12 @@ struct TimeUpdater
 //---------------------------------------------------------------------------//
 CELER_FUNCTION void TimeUpdater::operator()(CoreTrackView const& track)
 {
+    auto sim = track.make_sim_view();
+
+    // The track errored within the along-step kernel
+    if (sim.status() == TrackStatus::errored)
+        return;
+
     auto particle = track.make_particle_view();
     real_type speed = native_value_from(particle.speed());
     CELER_ASSERT(speed >= 0);
@@ -34,7 +40,6 @@ CELER_FUNCTION void TimeUpdater::operator()(CoreTrackView const& track)
     {
         // For very small energies (< numeric_limits<real_type>::epsilon)
         // the calculated speed can be zero.
-        auto sim = track.make_sim_view();
         real_type delta_time = sim.step_length() / speed;
         sim.add_time(delta_time);
     }

--- a/src/celeritas/global/alongstep/detail/TrackUpdater.hh
+++ b/src/celeritas/global/alongstep/detail/TrackUpdater.hh
@@ -32,6 +32,11 @@ struct TrackUpdater
 CELER_FUNCTION void TrackUpdater::operator()(CoreTrackView const& track)
 {
     auto sim = track.make_sim_view();
+
+    // The track errored within the along-step kernel
+    if (sim.status() == TrackStatus::errored)
+        return;
+
     if (sim.status() == TrackStatus::alive)
     {
         CELER_ASSERT(sim.step_length() > 0

--- a/src/corecel/io/LoggerTypes.hh
+++ b/src/corecel/io/LoggerTypes.hh
@@ -10,6 +10,7 @@
 
 #include <cstdlib>  // IWYU pragma: keep
 #include <functional>
+#include <string>
 #include <string_view>
 
 namespace celeritas

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -214,7 +214,7 @@ if(CELERITAS_USE_Geant4 AND CELERITAS_REAL_TYPE STREQUAL "double")
     "SimpleCmsRZFieldAlongStepTest.msc_rzfield_finegrid"
   )
   set(_stepper_filter
-    "-TestEm*"
+    "-TestEm*:LeadBox*"
     "TestEm3Compton.*"
     "TestEm3NoMsc.*"
     "TestEm3Msc.*"
@@ -235,7 +235,7 @@ elseif(CELERITAS_USE_Geant4)
     "LeadBox*"
   )
   set(_stepper_filter
-    "-TestEm*"
+    "-TestEm*:LeadBox*"
     "TestEm3Compton.*"
     "TestEm3Msc.*"
     "TestEm3MscNofluct.*"

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -648,7 +648,7 @@ TEST_F(LeadBoxAlongStepTest, position_change)
         }
         EXPECT_SOFT_NEAR(expected_step_length, result.step, 1e-13);
         EXPECT_EQ(0, result.displacement);
-        EXPECT_EQ("eloss-range", result.action);
+        EXPECT_EQ("tracking-cut", result.action);
     }
     {
         SCOPED_TRACE("Electron changes position");

--- a/test/celeritas/global/StepperGeant.test.cc
+++ b/test/celeritas/global/StepperGeant.test.cc
@@ -25,6 +25,7 @@
 
 #include "StepperTestBase.hh"
 #include "celeritas_test.hh"
+#include "../LeadBoxTestBase.hh"
 #include "../OneSteelSphereBase.hh"
 #include "../TestEm15Base.hh"
 #include "../TestEm3Base.hh"
@@ -246,6 +247,32 @@ class OneSteelSphere : public OneSteelSphereBase, public StepperTestBase
             result[i].track_id = TrackId{i};
             result[i].direction = sample_dir(rng);
             result[i].particle_id = particles[i % particles.size()];
+        }
+        return result;
+    }
+
+    size_type max_average_steps() const override { return 500; }
+};
+
+//---------------------------------------------------------------------------//
+#define LeadBox TEST_IF_CELERITAS_GEANT(LeadBox)
+class LeadBox : public LeadBoxTestBase, public StepperTestBase
+{
+    //! Make electron that fails to change position after propagation
+    std::vector<Primary> make_primaries(size_type count) const override
+    {
+        Primary p;
+        p.particle_id = this->particle()->find(pdg::electron());
+        p.energy = MevEnergy{1};
+        p.position = {1e20, 0, 0};
+        p.direction = {-1, 0, 0};
+        p.time = 0;
+        p.event_id = EventId{0};
+
+        std::vector<Primary> result(count, p);
+        for (auto i : range(count))
+        {
+            result[i].track_id = TrackId{i};
         }
         return result;
     }
@@ -759,6 +786,23 @@ TEST_F(OneSteelSphere, host)
             FAIL() << "Updated stepper results are required for CI tests";
         }
     }
+}
+
+TEST_F(LeadBox, host)
+{
+    size_type num_primaries = 1;
+    size_type num_tracks = 8;
+
+    Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
+    auto result = this->run(step, num_primaries);
+
+    // Electron fails to change position in first step and is killed by
+    // tracking cut
+    EXPECT_EQ(1, result.calc_avg_steps_per_primary());
+    EXPECT_EQ(1, result.num_step_iters());
+    EXPECT_SOFT_EQ(1, result.calc_avg_steps_per_primary());
+    EXPECT_EQ(0, result.calc_emptying_step());
+    EXPECT_EQ(RunResult::StepCount({0, 0}), result.calc_queue_hwm());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -84,7 +84,7 @@ auto StepperTestBase::run(StepperInterface& step,
     CELER_TRY_HANDLE(counts = step(make_span(primaries)),
                      LogContextException{this->output_reg().get()});
     EXPECT_EQ(num_primaries, counts.active);
-    EXPECT_EQ(num_primaries, counts.alive);
+    EXPECT_GE(num_primaries, counts.alive);
 
     if (this->HasFailure())
     {

--- a/test/geocel/data/lead-box.gdml
+++ b/test/geocel/data/lead-box.gdml
@@ -48,8 +48,8 @@
   </materials>
 
   <solids>
-    <box lunit="mm" name="box" x="1e11" y="1e11" z="1e11"/>
-    <box lunit="mm" name="world" x="1e11" y="1e11" z="1e11"/>
+    <box lunit="mm" name="box" x="1e22" y="1e22" z="1e22"/>
+    <box lunit="mm" name="world" x="1e22" y="1e22" z="1e22"/>
   </solids>
 
   <structure>


### PR DESCRIPTION
With cms2018 we were occasionally hitting an assertion failure:
```json
{
  "condition": "AppliesValid{}(sim) == static_cast<bool>(sim.along_step_action())",
  "context": {
    "dir": [
      -0.05499329494344731,
      4.7255830867030864e-05,
      0.9984867226348828
    ],
    "energy": [
      0.15909047775592167,
      "MeV"
    ],
    "event": 6,
    "label": "along-step-neutral",
    "num_steps": 25,
    "parent": 15187800,
    "particle": 1,
    "pos": [
      -34.997497048433964,
      -96.15483293113718,
      1131.1294534893607
    ],
    "thread": 3673,
    "track": 15189690,
    "track_slot": 3673,
    "type": "KernelContextException",
    "volume": 4070
  },
  "file": "/home/alund/celeritas_project/celeritas/src/celeritas/global/detail/TrackExecutorImpl.hh",
  "line": 64,
  "type": "DebugError",
  "which": "precondition failed"
}
```
Turns out this happens in the unusual case a track gets stuck and marked as errored in the `PropagationApplier`. Because the track still has a valid along-step action ID but has an invalid status, the assertion in `IsAlongStepActionEqual` fails. This change simply clears the along step action when a track is marked as errored.