### PR TITLE
Count number of optical primaries to be generated from distributions

### DIFF
--- a/src/celeritas/optical/OffloadData.hh
+++ b/src/celeritas/optical/OffloadData.hh
@@ -30,6 +30,7 @@ struct OffloadBufferSize
 {
     size_type cerenkov{0};
     size_type scintillation{0};
+    size_type num_primaries{0};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/detail/CerenkovOffloadAction.cc
+++ b/src/celeritas/optical/detail/CerenkovOffloadAction.cc
@@ -95,9 +95,15 @@ void CerenkovOffloadAction::execute_impl(CoreParams const& core_params,
     // Generate the optical distribution data
     this->pre_generate(core_params, core_state);
 
-    // Compact the buffer
+    // Compact the buffer, returning the total number of valid distributions
+    size_type start = buffer_size;
     buffer_size = remove_if_invalid(
-        buffer, buffer_size, core_state.size(), core_state.stream_id());
+        buffer, start, start + core_state.size(), core_state.stream_id());
+
+    // Count the number of optical photons that would be generated from the
+    // distributions created in this step
+    state.buffer_size.num_primaries += count_num_photons(
+        buffer, start, buffer_size, core_state.stream_id());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/detail/CerenkovOffloadAction.hh
+++ b/src/celeritas/optical/detail/CerenkovOffloadAction.hh
@@ -27,7 +27,6 @@ class MaterialParams;
 
 namespace detail
 {
-struct OpticalGenStorage;
 //---------------------------------------------------------------------------//
 /*!
  * Generate optical distribution data.
@@ -41,7 +40,6 @@ class CerenkovOffloadAction final : public ExplicitCoreActionInterface
         = std::shared_ptr<celeritas::optical::CerenkovParams const>;
     using SPConstMaterial
         = std::shared_ptr<celeritas::optical::MaterialParams const>;
-    using SPGenStorage = std::shared_ptr<detail::OpticalGenStorage>;
     //!@}
 
   public:

--- a/src/celeritas/optical/detail/OffloadGatherAction.hh
+++ b/src/celeritas/optical/detail/OffloadGatherAction.hh
@@ -21,7 +21,7 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Generate optical distribution data.
+ * Collect pre-step data needed to generate optical distribution data.
  *
  * This pre-step action stores the optical material ID and other
  * beginning-of-step properties so that optical photons can be generated

--- a/src/celeritas/optical/detail/OffloadGatherAction.hh
+++ b/src/celeritas/optical/detail/OffloadGatherAction.hh
@@ -19,7 +19,6 @@ namespace celeritas
 {
 namespace detail
 {
-struct OpticalGenStorage;
 //---------------------------------------------------------------------------//
 /*!
  * Generate optical distribution data.
@@ -32,12 +31,6 @@ struct OpticalGenStorage;
  */
 class OffloadGatherAction final : public ExplicitCoreActionInterface
 {
-  public:
-    //!@{
-    //! \name Type aliases
-    using SPGenStorage = std::shared_ptr<detail::OpticalGenStorage>;
-    //!@}
-
   public:
     // Construct with action ID and storage
     OffloadGatherAction(ActionId id, AuxId data_id);
@@ -65,7 +58,6 @@ class OffloadGatherAction final : public ExplicitCoreActionInterface
 
     ActionId id_;
     AuxId data_id_;
-    SPGenStorage storage_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/detail/OpticalGenAlgorithms.cc
+++ b/src/celeritas/optical/detail/OpticalGenAlgorithms.cc
@@ -16,11 +16,14 @@ namespace celeritas
 {
 namespace detail
 {
+namespace
+{
 //---------------------------------------------------------------------------//
+
 struct AccumNumPhotons
 {
     // Accumulate the number of optical photons from the distribution data
-    CELER_FUNCTION size_type
+    size_type
     operator()(size_type count,
                celeritas::optical::GeneratorDistributionData const& data) const
     {
@@ -29,15 +32,16 @@ struct AccumNumPhotons
 };
 
 //---------------------------------------------------------------------------//
+}  // namespace
+
+//---------------------------------------------------------------------------//
 /*!
  * Remove all invalid distributions from the buffer.
  *
- * This returns the total number of valid distributions in the buffer.
+ * \return Total number of valid distributions in the buffer
  */
 size_type
-remove_if_invalid(Collection<celeritas::optical::GeneratorDistributionData,
-                             Ownership::reference,
-                             MemSpace::host> const& buffer,
+remove_if_invalid(GeneratorDistributionRef<MemSpace::host> const& buffer,
                   size_type offset,
                   size_type size,
                   StreamId)
@@ -53,9 +57,7 @@ remove_if_invalid(Collection<celeritas::optical::GeneratorDistributionData,
  * Count the number of optical photons in the distributions.
  */
 size_type
-count_num_photons(Collection<celeritas::optical::GeneratorDistributionData,
-                             Ownership::reference,
-                             MemSpace::host> const& buffer,
+count_num_photons(GeneratorDistributionRef<MemSpace::host> const& buffer,
                   size_type offset,
                   size_type size,
                   StreamId)

--- a/src/celeritas/optical/detail/OpticalGenAlgorithms.cu
+++ b/src/celeritas/optical/detail/OpticalGenAlgorithms.cu
@@ -23,7 +23,10 @@ namespace celeritas
 {
 namespace detail
 {
+namespace
+{
 //---------------------------------------------------------------------------//
+
 struct GetNumPhotons
 {
     // Return the number of photons to generate
@@ -35,15 +38,16 @@ struct GetNumPhotons
 };
 
 //---------------------------------------------------------------------------//
+}  // namespace
+
+//---------------------------------------------------------------------------//
 /*!
  * Remove all invalid distributions from the buffer.
  *
- * This returns the total number of valid distributions in the buffer.
+ * \return Total number of valid distributions in the buffer
  */
 size_type
-remove_if_invalid(Collection<celeritas::optical::GeneratorDistributionData,
-                             Ownership::reference,
-                             MemSpace::device> const& buffer,
+remove_if_invalid(GeneratorDistributionRef<MemSpace::device> const& buffer,
                   size_type offset,
                   size_type size,
                   StreamId stream)
@@ -61,9 +65,7 @@ remove_if_invalid(Collection<celeritas::optical::GeneratorDistributionData,
  * Count the number of optical photons in the distributions.
  */
 size_type
-count_num_photons(Collection<celeritas::optical::GeneratorDistributionData,
-                             Ownership::reference,
-                             MemSpace::device> const& buffer,
+count_num_photons(GeneratorDistributionRef<MemSpace::device> const& buffer,
                   size_type offset,
                   size_type size,
                   StreamId stream)

--- a/src/celeritas/optical/detail/OpticalGenAlgorithms.hh
+++ b/src/celeritas/optical/detail/OpticalGenAlgorithms.hh
@@ -45,11 +45,39 @@ remove_if_invalid(Collection<celeritas::optical::GeneratorDistributionData,
                   StreamId);
 
 //---------------------------------------------------------------------------//
+// Count the number of optical photons in the distributions.
+size_type
+count_num_photons(Collection<celeritas::optical::GeneratorDistributionData,
+                             Ownership::reference,
+                             MemSpace::host> const&,
+                  size_type,
+                  size_type,
+                  StreamId);
+size_type
+count_num_photons(Collection<celeritas::optical::GeneratorDistributionData,
+                             Ownership::reference,
+                             MemSpace::device> const&,
+                  size_type,
+                  size_type,
+                  StreamId);
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 #if !CELER_USE_DEVICE
 inline size_type
 remove_if_invalid(Collection<celeritas::optical::GeneratorDistributionData,
+                             Ownership::reference,
+                             MemSpace::device> const&,
+                  size_type,
+                  size_type,
+                  StreamId)
+{
+    CELER_NOT_CONFIGURED("CUDA OR HIP");
+}
+
+inline size_type
+count_num_photons(Collection<celeritas::optical::GeneratorDistributionData,
                              Ownership::reference,
                              MemSpace::device> const&,
                   size_type,

--- a/src/celeritas/optical/detail/OpticalGenAlgorithms.hh
+++ b/src/celeritas/optical/detail/OpticalGenAlgorithms.hh
@@ -17,6 +17,13 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
+template<MemSpace M>
+using GeneratorDistributionRef
+    = Collection<::celeritas::optical::GeneratorDistributionData,
+                 Ownership::reference,
+                 M>;
+
+//---------------------------------------------------------------------------//
 struct IsInvalid
 {
     // Check if the distribution data is valid
@@ -29,46 +36,32 @@ struct IsInvalid
 
 //---------------------------------------------------------------------------//
 // Remove all invalid distributions from the buffer.
-size_type
-remove_if_invalid(Collection<celeritas::optical::GeneratorDistributionData,
-                             Ownership::reference,
-                             MemSpace::host> const&,
-                  size_type,
-                  size_type,
-                  StreamId);
-size_type
-remove_if_invalid(Collection<celeritas::optical::GeneratorDistributionData,
-                             Ownership::reference,
-                             MemSpace::device> const&,
-                  size_type,
-                  size_type,
-                  StreamId);
+size_type remove_if_invalid(GeneratorDistributionRef<MemSpace::host> const&,
+                            size_type,
+                            size_type,
+                            StreamId);
+size_type remove_if_invalid(GeneratorDistributionRef<MemSpace::device> const&,
+                            size_type,
+                            size_type,
+                            StreamId);
 
 //---------------------------------------------------------------------------//
 // Count the number of optical photons in the distributions.
-size_type
-count_num_photons(Collection<celeritas::optical::GeneratorDistributionData,
-                             Ownership::reference,
-                             MemSpace::host> const&,
-                  size_type,
-                  size_type,
-                  StreamId);
-size_type
-count_num_photons(Collection<celeritas::optical::GeneratorDistributionData,
-                             Ownership::reference,
-                             MemSpace::device> const&,
-                  size_type,
-                  size_type,
-                  StreamId);
+size_type count_num_photons(GeneratorDistributionRef<MemSpace::host> const&,
+                            size_type,
+                            size_type,
+                            StreamId);
+size_type count_num_photons(GeneratorDistributionRef<MemSpace::device> const&,
+                            size_type,
+                            size_type,
+                            StreamId);
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 #if !CELER_USE_DEVICE
 inline size_type
-remove_if_invalid(Collection<celeritas::optical::GeneratorDistributionData,
-                             Ownership::reference,
-                             MemSpace::device> const&,
+remove_if_invalid(GeneratorDistributionRef<MemSpace::device> const&,
                   size_type,
                   size_type,
                   StreamId)
@@ -77,9 +70,7 @@ remove_if_invalid(Collection<celeritas::optical::GeneratorDistributionData,
 }
 
 inline size_type
-count_num_photons(Collection<celeritas::optical::GeneratorDistributionData,
-                             Ownership::reference,
-                             MemSpace::device> const&,
+count_num_photons(GeneratorDistributionRef<MemSpace::device> const&,
                   size_type,
                   size_type,
                   StreamId)

--- a/src/celeritas/optical/detail/ScintOffloadAction.cc
+++ b/src/celeritas/optical/detail/ScintOffloadAction.cc
@@ -90,9 +90,15 @@ void ScintOffloadAction::execute_impl(CoreParams const& core_params,
     // Generate the optical distribution data
     this->pre_generate(core_params, core_state);
 
-    // Compact the buffer
+    // Compact the buffer, returning the total number of valid distributions
+    size_type start = buffer_size;
     buffer_size = remove_if_invalid(
-        buffer, buffer_size, core_state.size(), core_state.stream_id());
+        buffer, start, start + core_state.size(), core_state.stream_id());
+
+    // Count the number of optical photons that would be generated from the
+    // distributions created in this step
+    state.buffer_size.num_primaries += count_num_photons(
+        buffer, start, buffer_size, core_state.stream_id());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/detail/ScintOffloadAction.hh
+++ b/src/celeritas/optical/detail/ScintOffloadAction.hh
@@ -26,7 +26,6 @@ class ScintillationParams;
 
 namespace detail
 {
-struct OpticalGenStorage;
 //---------------------------------------------------------------------------//
 /*!
  * Generate optical distribution data.
@@ -38,7 +37,6 @@ class ScintOffloadAction final : public ExplicitCoreActionInterface
     //! \name Type aliases
     using SPConstScintillation
         = std::shared_ptr<celeritas::optical::ScintillationParams const>;
-    using SPGenStorage = std::shared_ptr<detail::OpticalGenStorage>;
     //!@}
 
   public:

--- a/test/celeritas/global/StepperGeant.test.cc
+++ b/test/celeritas/global/StepperGeant.test.cc
@@ -800,7 +800,6 @@ TEST_F(LeadBox, host)
     // tracking cut
     EXPECT_EQ(1, result.calc_avg_steps_per_primary());
     EXPECT_EQ(1, result.num_step_iters());
-    EXPECT_SOFT_EQ(1, result.calc_avg_steps_per_primary());
     EXPECT_EQ(0, result.calc_emptying_step());
     EXPECT_EQ(RunResult::StepCount({0, 0}), result.calc_queue_hwm());
 }


### PR DESCRIPTION
This small update adds a reduction to the optical offload actions to count the number of primaries that would be generated from the distribution data. This will be used to determine when to generate the primaries and start the optical tracking loop.