### PR TITLE
Fix warnings on updated Cray/ROCm toolchain

### DIFF
--- a/src/celeritas/random/CuHipRngData.hh
+++ b/src/celeritas/random/CuHipRngData.hh
@@ -31,12 +31,20 @@
 
 #    define CELER_RNG_PREFIX(TOK) cu##TOK
 #elif CELERITAS_USE_HIP
+#    if (HIP_VERSION_MAJOR > 5 \
+         || (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR >= 3))
 // Override an undocumented hipRAND API definition to enable usage in host
 // code.
-#    define FQUALIFIERS __forceinline__ __host__ __device__
+#        define QUALIFIERS __forceinline__ __host__ __device__
+#    else
+// Override an older version of that macro
+#        define FQUALIFIERS __forceinline__ __host__ __device__
+#    endif
 #    pragma clang diagnostic push
 // "Disabled inline asm, because the build target does not support it."
 #    pragma clang diagnostic ignored "-W#warnings"
+// "ignoring return value of function declared with 'nodiscard' attribute"
+#    pragma clang diagnostic ignored "-Wunused-result"
 #    include <hiprand/hiprand_kernel.h>
 #    pragma clang diagnostic pop
 #    define CELER_RNG_PREFIX(TOK) hip##TOK


### PR DESCRIPTION
These started showing up after the mid-July update to Frontier.

```
[173/355] Building CXX object src/cele...leritas.dir/random/CuHipRngParams.cc.o
In file included from /ccs/home/s3j/Code/celeritas-frontier/src/celeritas/random/CuHipRngParams.cc:8:
In file included from /ccs/home/s3j/Code/celeritas-frontier/src/celeritas/random/CuHipRngParams.hh:13:
In file included from /ccs/home/s3j/Code/celeritas-frontier/src/celeritas/random/CuHipRngData.hh:40:
In file included from /opt/rocm-5.7.1/include/hiprand/hiprand_kernel.h:64:
/opt/rocm-5.7.1/include/hiprand/hiprand_kernel_hcc.h:35:9: warning: 'FQUALIFIERS' macro redefined [-Wmacro-redefined]
        ^
/ccs/home/s3j/Code/celeritas-frontier/src/celeritas/random/CuHipRngData.hh:36:13: note: previous definition is here
            ^
In file included from /ccs/home/s3j/Code/celeritas-frontier/src/celeritas/random/CuHipRngParams.cc:8:
In file included from /ccs/home/s3j/Code/celeritas-frontier/src/celeritas/random/CuHipRngParams.hh:13:
In file included from /ccs/home/s3j/Code/celeritas-frontier/src/celeritas/random/CuHipRngData.hh:40:
In file included from /opt/rocm-5.7.1/include/hiprand/hiprand_kernel.h:64:
In file included from /opt/rocm-5.7.1/include/hiprand/hiprand_kernel_hcc.h:37:
In file included from /opt/rocm-5.7.1/include/rocrand/rocrand_kernel.h:32:
/opt/rocm-5.7.1/include/rocrand/rocrand_mtgp32.h:396:5: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
    hipMemcpy(d_state, h_state, sizeof(rocrand_state_mtgp32) * n, hipMemcpyHostToDevice);
    ^~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```