### PR TITLE
Allow sim params without looping

### DIFF
--- a/src/celeritas/global/CoreTrackData.cc
+++ b/src/celeritas/global/CoreTrackData.cc
@@ -39,7 +39,7 @@ void resize(CoreStateData<Ownership::value, M>* state,
     resize(&state->particles, params.particles, size);
     resize(&state->physics, params.physics, size);
     resize(&state->rng, params.rng, stream_id, size);
-    resize(&state->sim, size);
+    resize(&state->sim, params.sim, size);
     resize(&state->init, params.init, stream_id, size);
     state->stream_id = stream_id;
 

--- a/src/celeritas/optical/TrackData.cc
+++ b/src/celeritas/optical/TrackData.cc
@@ -38,7 +38,7 @@ void resize(CoreStateData<Ownership::value, M>* state,
     resize(&state->materials, size);
     resize(&state->physics, params.physics, size);
     resize(&state->rng, params.rng, stream_id, size);
-    resize(&state->sim, size);
+    resize(&state->sim, params.sim, size);
     resize(&state->init, params.init, stream_id, size);
     state->stream_id = stream_id;
 

--- a/src/celeritas/optical/TrackData.hh
+++ b/src/celeritas/optical/TrackData.hh
@@ -77,6 +77,7 @@ struct CoreParamsData
     VolumeItems<OpticalMaterialId> materials;
     PhysicsParamsData<W, M> physics;
     RngParamsData<W, M> rng;
+    SimParamsData<W, M> sim;
     TrackInitParamsData<W, M> init;  // TODO: don't need max events
 
     CoreScalars scalars;
@@ -84,7 +85,7 @@ struct CoreParamsData
     //! True if all params are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return geometry && !materials.empty() && physics && rng && init
+        return geometry && !materials.empty() && physics && rng && sim && init
                && scalars;
     }
 
@@ -97,6 +98,7 @@ struct CoreParamsData
         materials = other.materials;
         physics = other.physics;
         rng = other.rng;
+        sim = other.sim;
         init = other.init;
         scalars = other.scalars;
         return *this;

--- a/src/celeritas/track/SimData.hh
+++ b/src/celeritas/track/SimData.hh
@@ -110,7 +110,10 @@ struct SimTrackInitializer
  * Data storage/access for simulation states.
  *
  * Unless otherwise specified, units are in the native system (time = s for
- * CGS).
+ * CGS, step length = cm).
+ *
+ * \c num_looping_steps will be empty if params doesn't specify any looping
+ * threshold.
  */
 template<Ownership W, MemSpace M>
 struct SimStateData
@@ -141,9 +144,9 @@ struct SimStateData
     explicit CELER_FUNCTION operator bool() const
     {
         return !track_ids.empty() && !parent_ids.empty() && !event_ids.empty()
-               && !num_steps.empty() && !num_looping_steps.empty()
-               && !time.empty() && !status.empty() && !step_length.empty()
-               && !post_step_action.empty() && !along_step_action.empty();
+               && !num_steps.empty() && !time.empty() && !status.empty()
+               && !step_length.empty() && !post_step_action.empty()
+               && !along_step_action.empty();
     }
 
     //! State size

--- a/src/celeritas/track/SimData.hh
+++ b/src/celeritas/track/SimData.hh
@@ -75,7 +75,7 @@ struct SimParamsData
     //// METHODS ////
 
     //! Whether the data are assigned
-    explicit CELER_FUNCTION operator bool() const { return !looping.empty(); }
+    explicit CELER_FUNCTION operator bool() const { return true; }
 
     //! Assign from another set of data
     template<Ownership W2, MemSpace M2>
@@ -176,7 +176,9 @@ struct SimStateData
  * Resize simulation states and set \c alive to be false.
  */
 template<MemSpace M>
-void resize(SimStateData<Ownership::value, M>* data, size_type size)
+void resize(SimStateData<Ownership::value, M>* data,
+            HostCRef<SimParamsData> const& params,
+            size_type size)
 {
     CELER_EXPECT(size > 0);
 
@@ -184,7 +186,10 @@ void resize(SimStateData<Ownership::value, M>* data, size_type size)
     resize(&data->parent_ids, size);
     resize(&data->event_ids, size);
     resize(&data->num_steps, size);
-    resize(&data->num_looping_steps, size);
+    if (!params.looping.empty())
+    {
+        resize(&data->num_looping_steps, size);
+    }
     resize(&data->time, size);
 
     resize(&data->status, size);

--- a/src/celeritas/track/SimParams.cc
+++ b/src/celeritas/track/SimParams.cc
@@ -79,7 +79,7 @@ SimParams::SimParams(Input const& input)
 {
     CELER_EXPECT(input.particles);
 
-    HostValue host_data;
+    HostVal<SimParamsData> host_data;
 
     // Initialize with the default threshold values
     std::vector<LoopingThreshold> looping(input.particles->size());
@@ -96,6 +96,16 @@ SimParams::SimParams(Input const& input)
     make_builder(&host_data.looping).insert_back(looping.begin(), looping.end());
 
     data_ = CollectionMirror<SimParamsData>{std::move(host_data)};
+    CELER_ENSURE(data_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct without looping counters.
+ */
+SimParams::SimParams()
+{
+    data_ = CollectionMirror<SimParamsData>{{}};
     CELER_ENSURE(data_);
 }
 

--- a/src/celeritas/track/SimParams.hh
+++ b/src/celeritas/track/SimParams.hh
@@ -53,6 +53,9 @@ class SimParams final : public ParamsDataInterface<SimParamsData>
     // Construct with simulation input data
     explicit SimParams(Input const&);
 
+    // Construct without loop counters (for neutral-only simulations)
+    SimParams();
+
     //! Access data on host
     HostRef const& host_ref() const final { return data_.host_ref(); }
 
@@ -62,7 +65,6 @@ class SimParams final : public ParamsDataInterface<SimParamsData>
   private:
     // Host/device storage and reference
     CollectionMirror<SimParamsData> data_;
-    using HostValue = HostVal<SimParamsData>;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/SimTrackView.hh
+++ b/src/celeritas/track/SimTrackView.hh
@@ -53,7 +53,7 @@ class SimTrackView
     inline CELER_FUNCTION void add_time(real_type delta);
 
     // Increment the total number of steps
-    CELER_FORCEINLINE_FUNCTION void increment_num_steps();
+    inline CELER_FUNCTION void increment_num_steps();
 
     // Update the number of steps this track has been looping
     inline CELER_FUNCTION void update_looping(bool);
@@ -76,31 +76,31 @@ class SimTrackView
     //// DYNAMIC PROPERTIES ////
 
     // Unique track identifier
-    CELER_FORCEINLINE_FUNCTION TrackId track_id() const;
+    inline CELER_FUNCTION TrackId track_id() const;
 
     // Track ID of parent
-    CELER_FORCEINLINE_FUNCTION TrackId parent_id() const;
+    inline CELER_FUNCTION TrackId parent_id() const;
 
     // Event ID
-    CELER_FORCEINLINE_FUNCTION EventId event_id() const;
+    inline CELER_FUNCTION EventId event_id() const;
 
     // Total number of steps taken by the track
-    CELER_FORCEINLINE_FUNCTION size_type num_steps() const;
+    inline CELER_FUNCTION size_type num_steps() const;
 
     // Number of steps taken by the track since it was flagged as looping
-    CELER_FORCEINLINE_FUNCTION size_type num_looping_steps() const;
+    inline CELER_FUNCTION size_type num_looping_steps() const;
 
     // Time elapsed in the lab frame since the start of the event
-    CELER_FORCEINLINE_FUNCTION real_type time() const;
+    inline CELER_FUNCTION real_type time() const;
 
     // Whether the track is alive or inactive or dying
-    CELER_FORCEINLINE_FUNCTION TrackStatus status() const;
+    inline CELER_FUNCTION TrackStatus status() const;
 
     // Limiting step
-    CELER_FORCEINLINE_FUNCTION real_type step_length() const;
+    inline CELER_FUNCTION real_type step_length() const;
 
     // Update limiting step
-    CELER_FORCEINLINE_FUNCTION void step_length(real_type length);
+    inline CELER_FUNCTION void step_length(real_type length);
 
     // Access post-step action to take
     inline CELER_FUNCTION ActionId post_step_action() const;
@@ -117,8 +117,8 @@ class SimTrackView
     //// PARAMETER DATA ////
 
     // Particle-dependent parameters for killing looping tracks
-    CELER_FORCEINLINE_FUNCTION
-    LoopingThreshold const& looping_threshold(ParticleId) const;
+    inline CELER_FUNCTION LoopingThreshold const&
+        looping_threshold(ParticleId) const;
 
   private:
     SimParamsRef const& params_;
@@ -174,7 +174,7 @@ CELER_FUNCTION void SimTrackView::add_time(real_type delta)
 /*!
  * Increment the total number of steps.
  */
-CELER_FUNCTION void SimTrackView::increment_num_steps()
+CELER_FORCEINLINE_FUNCTION void SimTrackView::increment_num_steps()
 {
     ++states_.num_steps[track_slot_];
 }
@@ -185,6 +185,7 @@ CELER_FUNCTION void SimTrackView::increment_num_steps()
  */
 CELER_FUNCTION void SimTrackView::update_looping(bool is_looping)
 {
+    CELER_EXPECT(!params_.looping.empty());
     if (is_looping)
     {
         ++states_.num_looping_steps[track_slot_];
@@ -201,6 +202,7 @@ CELER_FUNCTION void SimTrackView::update_looping(bool is_looping)
  */
 CELER_FUNCTION bool SimTrackView::is_looping(ParticleId pid, Energy energy)
 {
+    CELER_EXPECT(!params_.looping.empty());
     auto const& looping = this->looping_threshold(pid);
     if (energy < looping.threshold_energy)
     {
@@ -280,7 +282,7 @@ CELER_FUNCTION bool SimTrackView::step_limit(StepLimit const& sl)
 /*!
  * Access post-step action to take.
  */
-CELER_FUNCTION ActionId SimTrackView::post_step_action() const
+CELER_FORCEINLINE_FUNCTION ActionId SimTrackView::post_step_action() const
 {
     return states_.post_step_action[track_slot_];
 }
@@ -289,7 +291,7 @@ CELER_FUNCTION ActionId SimTrackView::post_step_action() const
 /*!
  * Access along-step action to take.
  */
-CELER_FUNCTION ActionId SimTrackView::along_step_action() const
+CELER_FORCEINLINE_FUNCTION ActionId SimTrackView::along_step_action() const
 {
     return states_.along_step_action[track_slot_];
 }
@@ -298,7 +300,7 @@ CELER_FUNCTION ActionId SimTrackView::along_step_action() const
 /*!
  * Update along-step action to take.
  */
-CELER_FUNCTION void SimTrackView::along_step_action(ActionId action)
+CELER_FORCEINLINE_FUNCTION void SimTrackView::along_step_action(ActionId action)
 {
     states_.along_step_action[track_slot_] = action;
 }
@@ -319,7 +321,7 @@ CELER_FUNCTION void SimTrackView::status(TrackStatus status)
 /*!
  * Unique track identifier.
  */
-CELER_FUNCTION TrackId SimTrackView::track_id() const
+CELER_FORCEINLINE_FUNCTION TrackId SimTrackView::track_id() const
 {
     return states_.track_ids[track_slot_];
 }
@@ -328,7 +330,7 @@ CELER_FUNCTION TrackId SimTrackView::track_id() const
 /*!
  * Track ID of parent.
  */
-CELER_FUNCTION TrackId SimTrackView::parent_id() const
+CELER_FORCEINLINE_FUNCTION TrackId SimTrackView::parent_id() const
 {
     return states_.parent_ids[track_slot_];
 }
@@ -337,7 +339,7 @@ CELER_FUNCTION TrackId SimTrackView::parent_id() const
 /*!
  * Event ID.
  */
-CELER_FUNCTION EventId SimTrackView::event_id() const
+CELER_FORCEINLINE_FUNCTION EventId SimTrackView::event_id() const
 {
     return states_.event_ids[track_slot_];
 }
@@ -346,7 +348,7 @@ CELER_FUNCTION EventId SimTrackView::event_id() const
 /*!
  * Total number of steps taken by the track.
  */
-CELER_FUNCTION size_type SimTrackView::num_steps() const
+CELER_FORCEINLINE_FUNCTION size_type SimTrackView::num_steps() const
 {
     return states_.num_steps[track_slot_];
 }
@@ -355,7 +357,7 @@ CELER_FUNCTION size_type SimTrackView::num_steps() const
 /*!
  * Number of steps taken by the track since it was flagged as looping.
  */
-CELER_FUNCTION size_type SimTrackView::num_looping_steps() const
+CELER_FORCEINLINE_FUNCTION size_type SimTrackView::num_looping_steps() const
 {
     return states_.num_looping_steps[track_slot_];
 }
@@ -364,7 +366,7 @@ CELER_FUNCTION size_type SimTrackView::num_looping_steps() const
 /*!
  * Time elapsed in the lab frame since the start of the event [s].
  */
-CELER_FUNCTION real_type SimTrackView::time() const
+CELER_FORCEINLINE_FUNCTION real_type SimTrackView::time() const
 {
     return states_.time[track_slot_];
 }
@@ -373,7 +375,7 @@ CELER_FUNCTION real_type SimTrackView::time() const
 /*!
  * Whether the track is inactive, alive, or being killed.
  */
-CELER_FUNCTION TrackStatus SimTrackView::status() const
+CELER_FORCEINLINE_FUNCTION TrackStatus SimTrackView::status() const
 {
     return states_.status[track_slot_];
 }
@@ -382,7 +384,7 @@ CELER_FUNCTION TrackStatus SimTrackView::status() const
 /*!
  * Get the current limiting step.
  */
-CELER_FUNCTION real_type SimTrackView::step_length() const
+CELER_FORCEINLINE_FUNCTION real_type SimTrackView::step_length() const
 {
     return states_.step_length[track_slot_];
 }

--- a/src/celeritas/track/SimTrackView.hh
+++ b/src/celeritas/track/SimTrackView.hh
@@ -151,7 +151,10 @@ CELER_FUNCTION SimTrackView& SimTrackView::operator=(Initializer_t const& other)
     states_.parent_ids[track_slot_] = other.parent_id;
     states_.event_ids[track_slot_] = other.event_id;
     states_.num_steps[track_slot_] = 0;
-    states_.num_looping_steps[track_slot_] = 0;
+    if (!states_.num_looping_steps.empty())
+    {
+        states_.num_looping_steps[track_slot_] = 0;
+    }
     states_.time[track_slot_] = other.time;
     states_.status[track_slot_] = TrackStatus::initializing;
     states_.step_length[track_slot_] = {};

--- a/src/celeritas/track/TrackInitData.hh
+++ b/src/celeritas/track/TrackInitData.hh
@@ -157,7 +157,7 @@ struct TrackInitStateData
  * maximum number of track initializers (inactive/pending tracks) that we can
  * hold.
  *
- * \warning It's likely that for GPU runs, the capacity should be greater than
+ * \note It's likely that for GPU runs, the capacity should be greater than
  * the size, but that might not be the case universally, so it is not asserted.
  */
 template<MemSpace M>

--- a/test/celeritas/em/MscTestBase.cc
+++ b/test/celeritas/em/MscTestBase.cc
@@ -24,7 +24,7 @@ MscTestBase::MscTestBase()
         this->particle()->host_ref(), state_size);
     geo_state_
         = StateStore<GeoStateData>(this->geometry()->host_ref(), state_size);
-    sim_state_ = StateStore<SimStateData>(state_size);
+    sim_state_ = StateStore<SimStateData>(this->sim()->host_ref(), state_size);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/optical/OpticalTestBase.cc
+++ b/test/celeritas/optical/OpticalTestBase.cc
@@ -40,7 +40,9 @@ OpticalTestBase::OpticalTestBase()
 
     particle_state_
         = StateStore<ParticleStateData>(particle_params_->host_ref(), 1);
-    sim_state_ = StateStore<SimStateData>(1);
+
+    sim_params_ = std::make_shared<SimParams>();
+    sim_state_ = StateStore<SimStateData>(sim_params_->host_ref(), 1);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/track/Sim.test.cc
+++ b/test/celeritas/track/Sim.test.cc
@@ -43,7 +43,7 @@ class SimTest : public GeantTestBase
         auto state_size = 1;
         particle_state_
             = ParticleStateStore(this->particle()->host_ref(), state_size);
-        sim_state_ = SimStateStore(state_size);
+        sim_state_ = SimStateStore(this->sim()->host_ref(), state_size);
     }
 
     SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }


### PR DESCRIPTION
Small pull request to allow construction of SimParams without looping counters for problems without a magnetic field or without charged particles (i.e., optical physics).