### PR TITLE
Add always-on celer-sim diagnostic to count total number of tracks

### DIFF
--- a/app/celer-sim/RunnerOutput.cc
+++ b/app/celer-sim/RunnerOutput.cc
@@ -44,6 +44,7 @@ void RunnerOutput::output(JsonPimpl* j) const
     auto initializers = json::array();
     auto num_track_slots = json::array();
     auto num_step_iterations = json::array();
+    auto num_tracks = json::array();
     auto num_steps = json::array();
     auto num_aborted = json::array();
     auto max_queued = json::array();
@@ -59,6 +60,7 @@ void RunnerOutput::output(JsonPimpl* j) const
         }
         num_track_slots.push_back(event.num_track_slots);
         num_step_iterations.push_back(event.num_step_iterations);
+        num_tracks.push_back(event.num_tracks);
         num_steps.push_back(event.num_steps);
         num_aborted.push_back(event.num_aborted);
         max_queued.push_back(event.max_queued);
@@ -97,6 +99,7 @@ void RunnerOutput::output(JsonPimpl* j) const
          {"initializers", std::move(initializers)},
          {"num_track_slots", std::move(num_track_slots)},
          {"num_step_iterations", std::move(num_step_iterations)},
+         {"num_tracks", std::move(num_tracks)},
          {"num_steps", std::move(num_steps)},
          {"num_aborted", std::move(num_aborted)},
          {"max_queued", std::move(max_queued)},

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -10,10 +10,12 @@
 #include <algorithm>
 #include <csignal>
 #include <memory>
+#include <numeric>
 #include <utility>
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/data/CollectionAlgorithms.hh"
 #include "corecel/data/Ref.hh"
 #include "corecel/grid/VectorUtils.hh"
 #include "corecel/io/Logger.hh"
@@ -158,6 +160,9 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries) -> TransporterResult
         record_step_time();
     }
 
+    auto counters = copy_to_host(stepper_->state_ref().init.track_counters);
+    result.num_tracks = std::accumulate(
+        counters.data().get(), counters.data().get() + counters.size(), 0);
     result.num_aborted = track_counts.alive + track_counts.queued;
     result.num_track_slots = stepper_->state().size();
 

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -161,8 +161,9 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries) -> TransporterResult
     }
 
     auto counters = copy_to_host(stepper_->state_ref().init.track_counters);
-    result.num_tracks = std::accumulate(
-        counters.data().get(), counters.data().get() + counters.size(), 0);
+    result.num_tracks = std::accumulate(counters.data().get(),
+                                        counters.data().get() + counters.size(),
+                                        size_type(0));
     result.num_aborted = track_counts.alive + track_counts.queued;
     result.num_track_slots = stepper_->state().size();
 

--- a/app/celer-sim/Transporter.hh
+++ b/app/celer-sim/Transporter.hh
@@ -73,6 +73,7 @@ struct TransporterResult
     size_type num_track_slots{};  //!< Number of total track slots
     size_type num_step_iterations{};  //!< Total number of step iterations
     size_type num_steps{};  //!< Total number of steps
+    size_type num_tracks{};  //!< Total number of tracks
     size_type num_aborted{};  //!< Number of unconverged tracks
     size_type max_queued{};  //!< Maximum track initializer count
 };

--- a/src/corecel/data/CollectionAlgorithms.hh
+++ b/src/corecel/data/CollectionAlgorithms.hh
@@ -66,7 +66,7 @@ void copy_to_host(Collection<T, W, M, I> const& src, Span<T, E> dst)
  *
  * This is useful for debugging.
  */
-template<class T, Ownership W, MemSpace M, class I, std::size_t E>
+template<class T, Ownership W, MemSpace M, class I>
 auto copy_to_host(Collection<T, W, M, I> const& src)
 {
     Collection<T, Ownership::value, MemSpace::host, I> result;


### PR DESCRIPTION
Could be useful sometimes to get the total number of tracks simulated without e.g. enabling the step diagnostic.