### PR TITLE
Reduce default maximum substeps in field propagator

### DIFF
--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -62,7 +62,7 @@ struct FieldDriverOptions
     short int max_nsteps = 100;
 
     //! Maximum number of substeps in the field propagator
-    short int max_substeps = 100;
+    short int max_substeps = 10;
 
     //! Initial step tolerance
     static constexpr inline real_type initial_step_tol = 1e-6;

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1257,6 +1257,7 @@ TEST_F(SimpleCmsTest, TEST_IF_CELERITAS_DOUBLE(vecgeom_failure))
 {
     UniformZField field(1 * units::tesla);
     FieldDriverOptions driver_options;
+    driver_options.max_substeps = 100;
 
     auto geo = this->make_geo_track_view({1.23254142755319734e+02,
                                           -2.08186543568394598e+01,

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -241,7 +241,12 @@ TEST_F(TwoBoxesTest, electron_interior)
         SCOPED_TRACE("Half turn");
         stepper.reset_count();
         result = propagate(pi * radius);
-        EXPECT_SOFT_EQ(pi * radius, result.distance);
+        // The maximum substep limit in the field propagator was reached before
+        // traveling the full distance; propagate again to reach the end
+        real_type partial_distance = 8.7323805094658429;
+        EXPECT_SOFT_EQ(partial_distance, result.distance);
+        result = propagate(pi * radius - partial_distance);
+        EXPECT_SOFT_EQ(pi * radius - partial_distance, result.distance);
         EXPECT_LT(distance(Real3({radius, 0, 0}), geo.pos()), 1e-5);
         EXPECT_SOFT_EQ(1.0, dot_product(Real3({0, 1, 0}), geo.dir()));
         EXPECT_EQ(40, stepper.count());
@@ -675,6 +680,8 @@ TEST_F(TwoBoxesTest, electron_cross)
     {
         SCOPED_TRACE("Return to start (2/3 turn)");
 
+        FieldDriverOptions driver_options;
+        driver_options.max_substeps = 100;
         auto geo = this->make_geo_track_view();
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
             field, driver_options, particle, geo);
@@ -730,6 +737,8 @@ TEST_F(TwoBoxesTest, electron_tangent_cross)
 
         real_type dy = 0.9 * driver_options.delta_chord;
 
+        FieldDriverOptions driver_options;
+        driver_options.max_substeps = 100;
         auto geo = this->make_geo_track_view({1, 4 + dy, 0}, {0, 1, 0});
         auto propagate = make_mag_field_propagator<DormandPrinceStepper>(
             field, driver_options, particle, geo);
@@ -1016,6 +1025,7 @@ TEST_F(TwoBoxesTest,
         auto stepper = make_mag_field_stepper<DiagnosticDPStepper>(
             field, particle.charge());
         FieldDriverOptions driver_options;
+        driver_options.max_substeps = 100;
         auto propagate
             = make_field_propagator(stepper, driver_options, particle, geo);
         for (int i : range(2))
@@ -1386,6 +1396,7 @@ TEST_F(CmseTest, coarse)
     FieldDriverOptions driver_options;
     driver_options.delta_intersection = 0.001;
     driver_options.delta_chord = 0.1;
+    driver_options.max_substeps = 100;
 
     std::vector<int> num_boundary;
     std::vector<int> num_step;

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -275,10 +275,10 @@ TEST_F(MockAlongStepFieldTest, TEST_IF_CELERITAS_DOUBLE(basic))
         inp.phys_mfp = 100;
         auto result = this->run(inp, num_tracks);
         EXPECT_SOFT_EQ(0.001, result.eloss);
-        EXPECT_SOFT_NEAR(0.014775335072293276, result.displacement, 1e-10);
-        EXPECT_SOFT_NEAR(-0.57704594283791188, result.angle, 1e-10);
-        EXPECT_SOFT_EQ(5.5782056196201597e-09, result.time);
-        EXPECT_SOFT_EQ(7.4731670215320127, result.step);
+        EXPECT_SOFT_NEAR(0.0036768333578785931, result.displacement, 1e-10);
+        EXPECT_SOFT_NEAR(0.65590801657964626, result.angle, 1e-10);
+        EXPECT_SOFT_EQ(6.9431339225049422e-10, result.time);
+        EXPECT_SOFT_EQ(0.930177246841563, result.step);
         EXPECT_SOFT_EQ(0, result.mfp);
         EXPECT_SOFT_EQ(1, result.alive);
         EXPECT_EQ("physics-discrete-select", result.action);
@@ -509,7 +509,7 @@ TEST_F(SimpleCmsAlongStepTest, msc_field)
                          -0.0391118941072485030};
         // Step limited by distance to interaction = 2.49798914193346685e21
         auto result = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(27.208989423735016, result.step);
+        EXPECT_SOFT_EQ(2.7199323076809536, result.step);
         EXPECT_EQ(0, result.eloss);
         EXPECT_EQ(0, result.mfp);
         EXPECT_EQ("geo-propagation-limit", result.action);
@@ -571,8 +571,9 @@ TEST_F(SimpleCmsRZFieldAlongStepTest, msc_rzfield)
                          -0.0391118941072485030};
 
         auto result = this->run(inp, num_tracks);
-        EXPECT_SOFT_EQ(4.1632772063250023, result.displacement);
-        EXPECT_SOFT_NEAR(-0.59445532857679839, result.angle, 1e-11);
+        EXPECT_SOFT_EQ(0.5515596670659112, result.displacement);
+        EXPECT_SOFT_NEAR(0.095167236229178429, result.angle, 1e-11);
+        EXPECT_EQ("geo-propagation-limit", result.action);
     }
 }
 

--- a/test/celeritas/track/Sim.test.cc
+++ b/test/celeritas/track/Sim.test.cc
@@ -79,8 +79,8 @@ TEST_F(SimTest, looping)
 {
     LoopingThreshold expected;
     expected.threshold_energy = MevEnergy{250};
-    expected.max_steps = 100;
-    expected.max_subthreshold_steps = 10;
+    expected.max_steps = 1000;
+    expected.max_subthreshold_steps = 100;
 
     // Check looping threshold parameters for each particle
     SimTrackView sim(this->sim()->host_ref(), sim_state_.ref(), TrackSlotId{0});

--- a/test/celeritas/user/Diagnostic.test.cc
+++ b/test/celeritas/user/Diagnostic.test.cc
@@ -151,30 +151,29 @@ TEST_F(TestEm3DiagnosticTest, host)
                         "stuck on some builds but not others";
     }
 
-    // Check action diagnostic results
-    static char const* const expected_nonzero_action_keys[]
-        = {"annihil-2-gamma e+",
-           "brems-combined e+",
-           "brems-combined e-",
-           "conv-bethe-heitler gamma",
-           "eloss-range e+",
-           "eloss-range e-",
-           "geo-boundary e+",
-           "geo-boundary e-",
-           "geo-boundary gamma",
-           "ioni-moller-bhabha e+",
-           "ioni-moller-bhabha e-",
-           "msc-range e+",
-           "msc-range e-",
-           "photoel-livermore gamma",
-           "physics-integral-rejected e+",
-           "physics-integral-rejected e-",
-           "scat-klein-nishina gamma"};
-    EXPECT_VEC_EQ(expected_nonzero_action_keys, result.nonzero_action_keys);
-
     if (this->is_ci_build()
         && std::string(celeritas_geant4_version) == "11.0.4")
     {
+        static char const* const expected_nonzero_action_keys[]
+            = {"annihil-2-gamma e+",
+               "brems-combined e+",
+               "brems-combined e-",
+               "conv-bethe-heitler gamma",
+               "eloss-range e+",
+               "eloss-range e-",
+               "geo-boundary e+",
+               "geo-boundary e-",
+               "geo-boundary gamma",
+               "ioni-moller-bhabha e+",
+               "ioni-moller-bhabha e-",
+               "msc-range e+",
+               "msc-range e-",
+               "photoel-livermore gamma",
+               "physics-integral-rejected e+",
+               "physics-integral-rejected e-",
+               "scat-klein-nishina gamma"};
+        EXPECT_VEC_EQ(expected_nonzero_action_keys, result.nonzero_action_keys);
+
         static size_type const expected_nonzero_action_counts[] = {
             119u,
             398u,


### PR DESCRIPTION
Following up on #1236, this reduces the default maximum number of substeps (per step iteration) in the field propagator from 100 to 10. There's a tradeoff between tracks taking more substeps in fewer step iterations vs. fewer substeps in more step iterations, but the latter significantly improves load blancing in the along-step kernel, and the number of tracks taking many substeps to converge is small (e.g., <2% of tracks take more than 10 total substeps in cms2018). This shows the change in throughput and work for the field regression problems using 10 max substeps vs. 100:
![rel-throughput-maax-substeps](https://github.com/user-attachments/assets/807b0fe7-c47e-4819-9e5f-defe9b6e1d86)
![rel-work-max-substeps](https://github.com/user-attachments/assets/1bebec49-4790-4fc8-8585-a08ed53688bf)

I also gathered some information on the number of looping tracks killed before and after this change, and reducing the substep limit didn't seem to have a significant impact:

| Problem | Max substeps | Killed looping tracks | Fraction of total tracks | Energy deposited [MeV] |
| ------- | ------------ | --------------------- | ------------------------ | ---------------------------- |
| testem3-flat+field-orange | 10<br>100 | 1<br>0 | 3.36991985e-09<br>0.00000000e+00 | 0.0015739<br>0 |
| testem3-flat+field+msc-orange | 10<br>100 | 11<br>8 | 3.68980412e-08<br>2.68380684e-08 | 8.62542799<br>12.881228 |
| testem3-flat+field+msc-vecgeom | 10<br>100 | 7<br>5 | 2.34880847e-08<br>1.67727706e-08 | 11.822452<br>4.8461276 |
| testem3-expanded+field+msc-orange | 10<br>100 | 5<br>4 | 1.93177693e-08<br>1.54548461e-08 | 1.6958606<br>1.92713343 |
| testem3-expanded+field+msc-vecgeom | 10<br>100 | 6<br>10 | 2.31851377e-08<br>3.86507106e-08 | 10.431617<br>14.046066 |
| testem3-composite+field+msc-orange | 10<br>100 | 9<br>6 | 3.33513164e-08<br>2.22227110e-08 | 9.28268645<br>7.726298 |
| testem3-composite+field+msc-vecgeom | 10<br>100 | 9<br>4 | 3.33327147e-08<br>1.48183963e-08 | 15.615433<br>2.7987901 |
| cms2018+field+msc-vecgeom | 10<br>100 | 115<br>149 | 3.91912153e-07<br>5.07660725e-07 | 735.4356917<br>961.003735 |