### PR TITLE
Address minor documentation, contract fixes in CelerOpticalPhysics

### DIFF
--- a/src/celeritas/ext/GeantOpticalPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantOpticalPhysicsOptions.hh
@@ -94,7 +94,7 @@ constexpr bool operator==(ScintillationPhysicsOptions const& a,
 }
 
 //---------------------------------------------------------------------------//
-//! Optical Bounrary process options
+//! Optical Boundary process options
 struct BoundaryPhysicsOptions
 {
     //! Enable the process

--- a/src/celeritas/ext/detail/CelerOpticalPhysics.cc
+++ b/src/celeritas/ext/detail/CelerOpticalPhysics.cc
@@ -121,7 +121,8 @@ bool process_is_active(
         case OpticalProcessType::wavelength_shifting:
             return options.wavelength_shifting != WLSTimeProfileSelection::none;
         case OpticalProcessType::wavelength_shifting_2:
-            // Not supported pre 10.7
+            // Technically reachable, but practically not supported pre 10.7
+            CELER_ASSERT_UNREACHABLE();
         default:
             return false;
     }

--- a/src/celeritas/ext/detail/CelerOpticalPhysics.cc
+++ b/src/celeritas/ext/detail/CelerOpticalPhysics.cc
@@ -34,6 +34,13 @@ namespace detail
 {
 namespace
 {
+//---------------------------------------------------------------------------//
+/*!
+ * Optical physics process type.
+ *
+ * See Geant4's \c G4OpticalProcessIndex in G4OpticalParameters.hh for the
+ * equivalent enum.
+ */
 enum class OpticalProcessType
 {
     cerenkov,
@@ -260,9 +267,8 @@ void CelerOpticalPhysics::ConstructProcess()
     {
         process_manager->AddDiscreteProcess(wls2.release());
         // I need to check how this differs from G4OpWLS...
-        CELER_LOG(debug)
-            << "Loaded Optical wavelength shifting V2 with G4OpWLS2 "
-               "process";
+        CELER_LOG(debug) << "Loaded second optical wavelength shifting with "
+                            "G4OpWLS2 process ";
     }
 #endif
 


### PR DESCRIPTION
Some small review comments in #1348 were left dangling due to auto-merge, so this PR implements them. Per that review these are:

- Typos and Doxygen/Logging clarification fixes
- Mark WLS2 process as unreachable in Geant4 < 10.7
  - Even though a user could request WLS2 be active in Geant4 < 10.7 the setup in `CelerOpticalPhysics` should never trigger construction/use so this is a failsafe more than anything else (but good to have just in case we do end up supported pre-10.7...).