### PR TITLE
Add clang 18 and gcc 14 builds to CI

### DIFF
--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
             ccache cmake ninja-build python3 \
-            nlohmann-json3-dev libgtest-dev libhepmc3-dev \
+            nlohmann-json3-dev libgtest-dev libhepmc3-dev libpng-dev \
             ${{matrix.compiler}}-${{matrix.version}} \
             ${{matrix.compiler == 'gcc' && format('g++-{0}', matrix.version) || ''}}
           echo "Installed toolchain:"

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -20,12 +20,18 @@ jobs:
           - runner: jammy
             compiler: gcc
             version: 12
+          - runner: noble
+            compiler: gcc
+            version: 14
           - runner: focal
             compiler: clang
             version: 10
           - runner: jammy
             compiler: clang
             version: 15
+          - runner: noble
+            compiler: clang
+            version: 18
     env:
       GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}"
       CCACHE_DIR: "${{github.workspace}}/.ccache"
@@ -36,6 +42,7 @@ jobs:
     runs-on: >-
       ${{  matrix.runner == 'focal' && 'ubuntu-20.04'
         || matrix.runner == 'jammy' && 'ubuntu-22.04'
+        || matrix.runner == 'noble' && 'ubuntu-24.04'
       }}
     steps:
       - name: Install dependencies

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -299,7 +299,7 @@ if(NOT CELERITAS_USE_OpenMP
     AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
          OR CMAKE_CXX_COMPILER_ID MATCHES "Clang$"))
   celeritas_target_compile_options(celeritas
-    PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>
+    PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>"
   )
 endif()
 if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
@@ -308,7 +308,6 @@ if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:/wd4267$<SEMICOLON>/wd4250>"
   )
 endif()
-
 
 celeritas_target_link_libraries(celeritas
   PRIVATE ${PRIVATE_DEPS}

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -217,6 +217,14 @@ if(WIN32)
     )
   endif()
 endif()
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+  # GCC 13 and 14 have *lots* of false positives, and not just on our project
+  # see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532
+  celeritas_target_compile_options(corecel
+    PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:-Wno-dangling-reference>"
+  )
+endif()
 
 
 celeritas_target_include_directories(corecel

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,9 +58,11 @@ celeritas_target_include_directories(testcel_harness
 )
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
-  # GCC 13 and 14 have false positives with array bounds checking
+  # GCC 13 and 14 have false positives with array bounds checking, string bounds
+  # checking, initialization checking, ...
   celeritas_target_compile_options(testcel_harness
-    PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:-Wno-array-bounds;-Wno-stringop-overflow>"
+    PUBLIC
+    "$<$<COMPILE_LANGUAGE:CXX>:-Wno-array-bounds;-Wno-stringop-overflow;-Wno-uninitialized>"
   )
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,14 @@ celeritas_target_include_directories(testcel_harness
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+  # GCC 13 and 14 have false positives with array bounds checking
+  celeritas_target_compile_options(testcel_harness
+    PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:-Wno-array-bounds;-Wno-stringop-overflow>"
+  )
+endif()
+
 
 #-----------------------------------------------------------------------------#
 # TEST OPTIONS

--- a/test/celeritas/em/MscTestBase.hh
+++ b/test/celeritas/em/MscTestBase.hh
@@ -50,7 +50,7 @@ class MscTestBase : public RootTestBase
     //!@{
     //! Initialize and destroy
     MscTestBase();
-    ~MscTestBase();
+    virtual ~MscTestBase();
     //!@}
 
     std::string_view geometry_basename() const final


### PR DESCRIPTION
Since github actions now includes [beta support for ubuntu 24.04 noble numbat](https://github.com/actions/runner-images?tab=readme-ov-file), we can add newer compilers using the vanilla apt-get servers. This adds the latest GCC (14) and Clang (18) versions available on the repository.