### PR TITLE
Improve multithread GPU performance by removing subtle device sync

### DIFF
--- a/src/celeritas/track/detail/TrackInitAlgorithms.cu
+++ b/src/celeritas/track/detail/TrackInitAlgorithms.cu
@@ -74,7 +74,7 @@ size_type exclusive_scan_counts(
     CELER_DEVICE_CHECK_ERROR();
 
     // Copy the last element (accumulated total) back to host
-    return *(stop - 1);
+    return ItemCopier<size_type>{stream_id}(stop.get() - 1);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/Copier.hh
+++ b/src/corecel/data/Copier.hh
@@ -52,6 +52,31 @@ class Copier
 };
 
 //---------------------------------------------------------------------------//
+/*!
+ * Copy a value from device to host.
+ *
+ * The source of the data to copy is the function argument.
+ */
+template<class T>
+class ItemCopier
+{
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Data is not trivially copyable");
+
+  public:
+    //! Default constructor
+    ItemCopier() = default;
+
+    //! Also construct with a stream ID to use for async copy
+    explicit ItemCopier(StreamId stream) : stream_{stream} {};
+
+    inline T operator()(T const* src) const;
+
+  private:
+    StreamId stream_;
+};
+
+//---------------------------------------------------------------------------//
 // Copy bytes between two memory spaces
 void copy_bytes(MemSpace dstmem,
                 void* dst,
@@ -89,6 +114,26 @@ void Copier<T, M>::operator()(MemSpace srcmem, Span<T const> src) const
         copy_bytes(
             dstmem, dst_.data(), srcmem, src.data(), src.size() * sizeof(T));
     }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Copy a value from device to host.
+ */
+template<class T>
+T ItemCopier<T>::operator()(T const* src) const
+{
+    T dst;
+    if (stream_)
+    {
+        copy_bytes(
+            MemSpace::host, &dst, MemSpace::device, src, sizeof(T), stream_);
+    }
+    else
+    {
+        copy_bytes(MemSpace::host, &dst, MemSpace::device, src, sizeof(T));
+    }
+    return dst;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/data/Copier.test.cc
+++ b/test/corecel/data/Copier.test.cc
@@ -62,6 +62,22 @@ TEST(CopierTest, TEST_IF_CELER_DEVICE(device))
     EXPECT_EQ(1234, new_host_vec.back());
 }
 
+TEST(ItemCopierTest, TEST_IF_CELER_DEVICE(device))
+{
+    // Initialize data on device
+    std::vector<int> host_vec{0, 1, 2, 3, 4};
+    DeviceVector<int> device_vec(host_vec.size());
+    device_vec.copy_to_device(make_span(host_vec));
+
+    // Copy elements to host
+    ItemCopier<int> copy{};
+    for (int i : range(host_vec.size()))
+    {
+        int result = copy(device_vec.data() + i);
+        EXPECT_EQ(i, result);
+    }
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas


### PR DESCRIPTION
@esseivaju found in his profiling that in our "extend from secondaries" action there was a device synchronization:

> that’s what I was saying about having to synchronize each step. You can see that in the extend-from-secondaries action::remove-if-alive scope we have to synchronize with the device. So, we cannot push the last few kernels for that step or move on to the next step before the GPU has finished executing the current step. You can see in the top line there is a gap of ~1ms in the GPU utilization at the end of a step / between steps
![image](https://github.com/user-attachments/assets/bc413031-76d8-4d68-973e-8e78eab898f2)

@sethrj [questioned recently](https://github.com/celeritas-project/celeritas/pull/1399#discussion_r1757094890) whether the way we are copying the result of a scan to the host might be synchronous, and I think that is the culprit. This adds a little helper class to copy a single value to the host and does the copy of the scan result asynchronously.

I ran the regression problems with `merge_events` off; here’s the speedup in the throughput with this change relative to develop:
![rel-throughput-remove-sync](https://github.com/user-attachments/assets/8e2caf3d-b2cd-42d0-b831-3bf6353722af)
