### PR TITLE
Work around GCC 12.3 compiler bugs

### DIFF
--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -272,7 +272,7 @@ int main(int argc, char* argv[])
     }
     if (filename == "--dump-default"sv)
     {
-        std::cout << nlohmann::json(celeritas::app::RunInput{}).dump(1)
+        std::cout << nlohmann::json(celeritas::app::RunInput()).dump(1)
                   << std::endl;
         return EXIT_SUCCESS;
     }

--- a/test/corecel/data/DeviceVector.test.cc
+++ b/test/corecel/data/DeviceVector.test.cc
@@ -49,7 +49,8 @@ TEST(DeviceVectorTest, all)
     }
     EXPECT_EQ(128, vec.size());
 
-    std::vector<int> data(vec.size());
+    std::vector<int> data;
+    data.resize(vec.size());
     data.front() = 1;
     data.back() = 1234567;
 


### PR DESCRIPTION
This MR fixes a couple of compilation warning from gcc12.3 on perlmutter:

```
/global/homes/s/syjun/celeritas/src/celeritas/test/corecel/data/DeviceVector.test.cc:54:14: error: array subscript -1 is outside array bounds of 'int [2305843009213693951]' [-Werror=array-bounds]
  54 |   data.back() = 1234567;
   |   ~~~~~~~~~^~
```
and
```
In file included from /usr/include/c++/12/vector:64,
         from /global/homes/s/syjun/celeritas/src/celeritas/app/celer-g4/celer-g4.cc:15
:
In destructor 'std::vector<_Tp, _Alloc>::~vector() [with _Tp = double; _Alloc = std::allocator<double>]',
  inlined from 'int main(int, char**)' at /global/homes/s/syjun/celeritas/src/celeritas/app/celer-g4/celer-g4.cc:275:53:
/usr/include/c++/12/bits/stl_vector.h:730:22: error: '<unnamed>.celeritas::app::RunInput::primary_options.celeritas::PrimaryGeneratorOptions::direction.celeritas::DistributionOptions::params.std::vector<double>::<anonymous>.std::_Vector_base<double, std::allocator<double> >::_M_impl.std::_Vector_base<double, std::allocator<double> >::_Vector_impl::<anonymous>.std::_Vector_base<double, std::allocator<double> >::_Vector_impl_data::_M_start' may be used uninitialized [-Werror=maybe-uninitialized]
 730 |     std::_Destroy(this->_M_impl._M_start, this->_M_impl._M_finish,
   |     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 731 |            _M_get_Tp_allocator());
   |            ~~~~~~~~~~~~~~~~~~~~~~
/global/homes/s/syjun/celeritas/src/celeritas/app/celer-g4/celer-g4.cc: In function int main(int, char**)':
/global/homes/s/syjun/celeritas/src/celeritas/app/celer-g4/celer-g4.cc:275:62: note:'<anonymous>' declared here
 275 |     std::cout << nlohmann::json(celeritas::app::RunInput{}).dump(1)
   |                               ^
In destructor 'std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = double; _Alloc = std::allocator<double>]',
  inlined from 'std::vector<_Tp, _Alloc>::~vector() [with _Tp = double; _Alloc = std::allocator<double>]' at /usr/include/c++/12/bits/stl_vector.h:733:7,
  inlined from 'int main(int, char**)' at /global/homes/s/syjun/celeritas/src/celeritas/app/celer-g4/celer-g4.cc:275:53:
/usr/include/c++/12/bits/stl_vector.h:367:31: error: '<unnamed>.celeritas::app::RunInput::primary_options.celeritas::PrimaryGeneratorOptions::direction.celeritas::DistributionOptions::params.std::vector<double, std::allocator<double> >::<unnamed>.std::_Vector_base<double, std::allocator<double> >::_M_impl.std::_Vector_base<double, std::allocator<double> >::_Vector_impl::<anonymous>.std::_Vector_base<double, std::allocator<double> >::_Vector_impl_data::_M_end_of_storage' may be used uninitialized [-Werror=maybe-uninitialized]
 367 |            _M_impl._M_end_of_storage - _M_impl._M_start);
   |            ~~~~~~~~^~~~~~~~~~~~~~~~~
/global/homes/s/syjun/celeritas/src/celeritas/app/celer-g4/celer-g4.cc: In function int main(int, char**)':
/global/homes/s/syjun/celeritas/src/celeritas/app/celer-g4/celer-g4.cc:275:62: note:'<anonymous>' declared here
 275 |     std::cout << nlohmann::json(celeritas::app::RunInput{}).dump(1)
   |                               ^
```