### PR TITLE
Define "static" concrete action for those with unique name/description

### DIFF
--- a/src/celeritas/em/model/BetheHeitlerModel.cc
+++ b/src/celeritas/em/model/BetheHeitlerModel.cc
@@ -30,9 +30,9 @@ BetheHeitlerModel::BetheHeitlerModel(ActionId id,
                                      ParticleParams const& particles,
                                      SPConstImported data,
                                      bool enable_lpm)
-    : ConcreteAction(id,
-                     "conv-bethe-heitler",
-                     "interact by Bethe-Heitler gamma conversion")
+    : StaticConcreteAction(id,
+                           "conv-bethe-heitler",
+                           "interact by Bethe-Heitler gamma conversion")
     , imported_(data,
                 particles,
                 ImportProcessClass::conversion,

--- a/src/celeritas/em/model/BetheHeitlerModel.hh
+++ b/src/celeritas/em/model/BetheHeitlerModel.hh
@@ -21,7 +21,7 @@ namespace celeritas
 /*!
  * Set up and launch the Bethe-Heitler model interaction.
  */
-class BetheHeitlerModel final : public Model, public ConcreteAction
+class BetheHeitlerModel final : public Model, public StaticConcreteAction
 {
   public:
     //!@{

--- a/src/celeritas/em/model/BraggModel.cc
+++ b/src/celeritas/em/model/BraggModel.cc
@@ -29,7 +29,8 @@ namespace celeritas
  * TODO: This model also applies to hadrons.
  */
 BraggModel::BraggModel(ActionId id, ParticleParams const& particles)
-    : ConcreteAction(id, "ioni-bragg", "interact by muon ionization (Bragg)")
+    : StaticConcreteAction(
+          id, "ioni-bragg", "interact by muon ionization (Bragg)")
 {
     CELER_EXPECT(id);
 

--- a/src/celeritas/em/model/BraggModel.hh
+++ b/src/celeritas/em/model/BraggModel.hh
@@ -18,7 +18,7 @@ class ParticleParams;
 /*!
  * Set up and launch the Bragg ionization model interaction.
  */
-class BraggModel final : public Model, public ConcreteAction
+class BraggModel final : public Model, public StaticConcreteAction
 {
   public:
     // Construct from model ID and other necessary data

--- a/src/celeritas/em/model/CombinedBremModel.cc
+++ b/src/celeritas/em/model/CombinedBremModel.cc
@@ -38,11 +38,10 @@ CombinedBremModel::CombinedBremModel(ActionId id,
                                      SPConstImported data,
                                      ReadData sb_table,
                                      bool enable_lpm)
-    : StaticConcreteAction(id,
-                           "brems-combined",
-                           "interact by bremsstrahlung (combined "
-                           "SB/relativistic, "
-                           "e+/-)")
+    : StaticConcreteAction(
+          id,
+          "brems-combined",
+          R"(interact by bremsstrahlung (combined SB/relativistic, e+/-))")
 {
     CELER_EXPECT(id);
     CELER_EXPECT(sb_table);

--- a/src/celeritas/em/model/CombinedBremModel.cc
+++ b/src/celeritas/em/model/CombinedBremModel.cc
@@ -38,10 +38,11 @@ CombinedBremModel::CombinedBremModel(ActionId id,
                                      SPConstImported data,
                                      ReadData sb_table,
                                      bool enable_lpm)
-    : ConcreteAction(id,
-                     "brems-combined",
-                     "interact by bremsstrahlung (combined SB/relativistic, "
-                     "e+/-)")
+    : StaticConcreteAction(id,
+                           "brems-combined",
+                           "interact by bremsstrahlung (combined "
+                           "SB/relativistic, "
+                           "e+/-)")
 {
     CELER_EXPECT(id);
     CELER_EXPECT(sb_table);

--- a/src/celeritas/em/model/CombinedBremModel.hh
+++ b/src/celeritas/em/model/CombinedBremModel.hh
@@ -31,7 +31,7 @@ class ParticleParams;
  * Set up and launch a combined model of SeltzerBergerModel at the low energy
  * and RelativisticBremModel at the high energy for e+/e- Bremsstrahlung.
  */
-class CombinedBremModel final : public Model, public ConcreteAction
+class CombinedBremModel final : public Model, public StaticConcreteAction
 {
   public:
     //@{

--- a/src/celeritas/em/model/CoulombScatteringModel.cc
+++ b/src/celeritas/em/model/CoulombScatteringModel.cc
@@ -50,10 +50,10 @@ CoulombScatteringModel::CoulombScatteringModel(ActionId id,
     data_.ids.electron = particles.find(pdg::electron());
     data_.ids.positron = particles.find(pdg::positron());
 
-    CELER_VALIDATE(data_.ids,
-                   << "missing electron and/or positron particles (required "
-                      "for "
-                   << this->description() << ")");
+    CELER_VALIDATE(
+        data_.ids,
+        << R"(missing electron and/or positron particles (required for )"
+        << this->description() << ")");
 
     // Get high/low energy limits
     energy_limit_

--- a/src/celeritas/em/model/CoulombScatteringModel.cc
+++ b/src/celeritas/em/model/CoulombScatteringModel.cc
@@ -37,7 +37,7 @@ CoulombScatteringModel::CoulombScatteringModel(ActionId id,
                                                ParticleParams const& particles,
                                                MaterialParams const& materials,
                                                SPConstImported data)
-    : ConcreteAction(
+    : StaticConcreteAction(
           id, "coulomb-wentzel", "interact by Coulomb scattering (Wentzel)")
     , imported_(data,
                 particles,

--- a/src/celeritas/em/model/CoulombScatteringModel.hh
+++ b/src/celeritas/em/model/CoulombScatteringModel.hh
@@ -24,7 +24,7 @@ class IsotopeView;
 /*!
  * Set up and launch the Wentzel Coulomb scattering model interaction.
  */
-class CoulombScatteringModel final : public Model, public ConcreteAction
+class CoulombScatteringModel final : public Model, public StaticConcreteAction
 {
   public:
     //!@{

--- a/src/celeritas/em/model/EPlusGGModel.cc
+++ b/src/celeritas/em/model/EPlusGGModel.cc
@@ -25,10 +25,10 @@ namespace celeritas
  * Construct from model ID and other necessary data.
  */
 EPlusGGModel::EPlusGGModel(ActionId id, ParticleParams const& particles)
-    : StaticConcreteAction(id,
-                           "annihil-2-gamma",
-                           "interact by positron annihilation yielding two "
-                           "gammas")
+    : StaticConcreteAction(
+          id,
+          "annihil-2-gamma",
+          R"(interact by positron annihilation yielding two gammas)")
 {
     CELER_EXPECT(id);
     data_.positron = particles.find(pdg::positron());

--- a/src/celeritas/em/model/EPlusGGModel.cc
+++ b/src/celeritas/em/model/EPlusGGModel.cc
@@ -25,9 +25,10 @@ namespace celeritas
  * Construct from model ID and other necessary data.
  */
 EPlusGGModel::EPlusGGModel(ActionId id, ParticleParams const& particles)
-    : ConcreteAction(id,
-                     "annihil-2-gamma",
-                     "interact by positron annihilation yielding two gammas")
+    : StaticConcreteAction(id,
+                           "annihil-2-gamma",
+                           "interact by positron annihilation yielding two "
+                           "gammas")
 {
     CELER_EXPECT(id);
     data_.positron = particles.find(pdg::positron());

--- a/src/celeritas/em/model/EPlusGGModel.hh
+++ b/src/celeritas/em/model/EPlusGGModel.hh
@@ -19,7 +19,7 @@ namespace celeritas
 /*!
  * Set up and launch two-gamma positron annihiliation.
  */
-class EPlusGGModel final : public Model, public ConcreteAction
+class EPlusGGModel final : public Model, public StaticConcreteAction
 {
   public:
     // Construct from model ID and other necessary data

--- a/src/celeritas/em/model/ICRU73QOModel.cc
+++ b/src/celeritas/em/model/ICRU73QOModel.cc
@@ -29,8 +29,8 @@ namespace celeritas
  * TODO: This model also applies to hadrons.
  */
 ICRU73QOModel::ICRU73QOModel(ActionId id, ParticleParams const& particles)
-    : ConcreteAction(
-        id, "ioni-icru73qo", "interact by muon ionization (ICRU73QO)")
+    : StaticConcreteAction(
+          id, "ioni-icru73qo", "interact by muon ionization (ICRU73QO)")
 {
     CELER_EXPECT(id);
 

--- a/src/celeritas/em/model/ICRU73QOModel.hh
+++ b/src/celeritas/em/model/ICRU73QOModel.hh
@@ -18,7 +18,7 @@ class ParticleParams;
 /*!
  * Set up and launch the ICRU73QO ionization model interaction.
  */
-class ICRU73QOModel final : public Model, public ConcreteAction
+class ICRU73QOModel final : public Model, public StaticConcreteAction
 {
   public:
     // Construct from model ID and other necessary data

--- a/src/celeritas/em/model/KleinNishinaModel.cc
+++ b/src/celeritas/em/model/KleinNishinaModel.cc
@@ -25,18 +25,17 @@ namespace celeritas
  */
 KleinNishinaModel::KleinNishinaModel(ActionId id,
                                      ParticleParams const& particles)
-    : StaticConcreteAction(id,
-                           "scat-klein-nishina",
-                           "interact by Compton scattering (simple "
-                           "Klein-Nishina)")
+    : StaticConcreteAction(
+          id,
+          "scat-klein-nishina",
+          R"(interact by Compton scattering (simple Klein-Nishina))")
 {
     CELER_EXPECT(id);
     data_.ids.electron = particles.find(pdg::electron());
     data_.ids.gamma = particles.find(pdg::gamma());
 
     CELER_VALIDATE(data_.ids.electron && data_.ids.gamma,
-                   << "missing electron, positron and/or gamma particles "
-                      "(required for "
+                   << R"(missing electron and/or gamma particles (required for )"
                    << this->description() << ")");
     data_.inv_electron_mass = 1
                               / value_as<KleinNishinaData::Mass>(

--- a/src/celeritas/em/model/KleinNishinaModel.cc
+++ b/src/celeritas/em/model/KleinNishinaModel.cc
@@ -25,9 +25,10 @@ namespace celeritas
  */
 KleinNishinaModel::KleinNishinaModel(ActionId id,
                                      ParticleParams const& particles)
-    : ConcreteAction(id,
-                     "scat-klein-nishina",
-                     "interact by Compton scattering (simple Klein-Nishina)")
+    : StaticConcreteAction(id,
+                           "scat-klein-nishina",
+                           "interact by Compton scattering (simple "
+                           "Klein-Nishina)")
 {
     CELER_EXPECT(id);
     data_.ids.electron = particles.find(pdg::electron());

--- a/src/celeritas/em/model/KleinNishinaModel.hh
+++ b/src/celeritas/em/model/KleinNishinaModel.hh
@@ -17,7 +17,7 @@ namespace celeritas
 /*!
  * Set up and launch the Klein-Nishina model interaction.
  */
-class KleinNishinaModel final : public Model, public ConcreteAction
+class KleinNishinaModel final : public Model, public StaticConcreteAction
 {
   public:
     // Construct from model ID and other necessary data

--- a/src/celeritas/em/model/LivermorePEModel.cc
+++ b/src/celeritas/em/model/LivermorePEModel.cc
@@ -41,7 +41,7 @@ LivermorePEModel::LivermorePEModel(ActionId id,
                                    ParticleParams const& particles,
                                    MaterialParams const& materials,
                                    ReadData load_data)
-    : ConcreteAction(
+    : StaticConcreteAction(
           id, "photoel-livermore", "interact by Livermore photoelectric effect")
 {
     CELER_EXPECT(id);

--- a/src/celeritas/em/model/LivermorePEModel.cc
+++ b/src/celeritas/em/model/LivermorePEModel.cc
@@ -53,8 +53,7 @@ LivermorePEModel::LivermorePEModel(ActionId id,
     host_data.ids.electron = particles.find(pdg::electron());
     host_data.ids.gamma = particles.find(pdg::gamma());
     CELER_VALIDATE(host_data.ids,
-                   << "missing electron and/or gamma particles "
-                      "(required for "
+                   << R"(missing electron and/or gamma particles (required for )"
                    << this->description() << ")");
 
     // Save particle properties

--- a/src/celeritas/em/model/LivermorePEModel.hh
+++ b/src/celeritas/em/model/LivermorePEModel.hh
@@ -25,7 +25,7 @@ class ParticleParams;
 /*!
  * Set up and launch the Livermore photoelectric model interaction.
  */
-class LivermorePEModel final : public Model, public ConcreteAction
+class LivermorePEModel final : public Model, public StaticConcreteAction
 {
   public:
     //!@{

--- a/src/celeritas/em/model/MollerBhabhaModel.cc
+++ b/src/celeritas/em/model/MollerBhabhaModel.cc
@@ -27,7 +27,7 @@ namespace celeritas
  */
 MollerBhabhaModel::MollerBhabhaModel(ActionId id,
                                      ParticleParams const& particles)
-    : ConcreteAction(
+    : StaticConcreteAction(
           id, "ioni-moller-bhabha", "interact by Moller+Bhabha ionization")
 {
     CELER_EXPECT(id);

--- a/src/celeritas/em/model/MollerBhabhaModel.cc
+++ b/src/celeritas/em/model/MollerBhabhaModel.cc
@@ -34,10 +34,10 @@ MollerBhabhaModel::MollerBhabhaModel(ActionId id,
     data_.ids.electron = particles.find(pdg::electron());
     data_.ids.positron = particles.find(pdg::positron());
 
-    CELER_VALIDATE(data_.ids.electron && data_.ids.positron,
-                   << "missing electron and/or positron particles "
-                      "(required for "
-                   << this->description() << ")");
+    CELER_VALIDATE(
+        data_.ids.electron && data_.ids.positron,
+        << R"(missing electron and/or positron particles (required for )"
+        << this->description() << ")");
 
     data_.electron_mass = particles.get(data_.ids.electron).mass();
 

--- a/src/celeritas/em/model/MollerBhabhaModel.hh
+++ b/src/celeritas/em/model/MollerBhabhaModel.hh
@@ -18,7 +18,7 @@ class ParticleParams;
 /*!
  * Set up and launch the Moller-Bhabha model interaction.
  */
-class MollerBhabhaModel final : public Model, public ConcreteAction
+class MollerBhabhaModel final : public Model, public StaticConcreteAction
 {
   public:
     // Construct from model ID and other necessary data

--- a/src/celeritas/em/model/MuBetheBlochModel.cc
+++ b/src/celeritas/em/model/MuBetheBlochModel.cc
@@ -28,9 +28,9 @@ namespace celeritas
  */
 MuBetheBlochModel::MuBetheBlochModel(ActionId id,
                                      ParticleParams const& particles)
-    : ConcreteAction(id,
-                     "ioni-mu-bethe-bloch",
-                     "interact by muon ionization (Bethe-Bloch)")
+    : StaticConcreteAction(id,
+                           "ioni-mu-bethe-bloch",
+                           "interact by muon ionization (Bethe-Bloch)")
 {
     CELER_EXPECT(id);
     data_.electron = particles.find(pdg::electron());

--- a/src/celeritas/em/model/MuBetheBlochModel.hh
+++ b/src/celeritas/em/model/MuBetheBlochModel.hh
@@ -18,7 +18,7 @@ class ParticleParams;
 /*!
  * Set up and launch the Bethe-Bloch muon ionization model interaction.
  */
-class MuBetheBlochModel final : public Model, public ConcreteAction
+class MuBetheBlochModel final : public Model, public StaticConcreteAction
 {
   public:
     // Construct from model ID and other necessary data

--- a/src/celeritas/em/model/MuBremsstrahlungModel.cc
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.cc
@@ -29,7 +29,8 @@ namespace celeritas
 MuBremsstrahlungModel::MuBremsstrahlungModel(ActionId id,
                                              ParticleParams const& particles,
                                              SPConstImported data)
-    : ConcreteAction(id, "brems-muon", "interact by bremsstrahlung (muon)")
+    : StaticConcreteAction(
+          id, "brems-muon", "interact by bremsstrahlung (muon)")
     , imported_(data,
                 particles,
                 ImportProcessClass::mu_brems,

--- a/src/celeritas/em/model/MuBremsstrahlungModel.hh
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.hh
@@ -21,7 +21,7 @@ namespace celeritas
 /*!
  * Set up and launch the Muon Bremsstrahlung model interaction.
  */
-class MuBremsstrahlungModel final : public Model, public ConcreteAction
+class MuBremsstrahlungModel final : public Model, public StaticConcreteAction
 {
   public:
     //!@{

--- a/src/celeritas/em/model/RayleighModel.cc
+++ b/src/celeritas/em/model/RayleighModel.cc
@@ -34,7 +34,8 @@ RayleighModel::RayleighModel(ActionId id,
                              ParticleParams const& particles,
                              MaterialParams const& materials,
                              SPConstImported data)
-    : ConcreteAction(id, "scat-rayleigh", "interact by Rayleigh scattering")
+    : StaticConcreteAction(
+          id, "scat-rayleigh", "interact by Rayleigh scattering")
     , imported_(data,
                 particles,
                 ImportProcessClass::rayleigh,

--- a/src/celeritas/em/model/RayleighModel.hh
+++ b/src/celeritas/em/model/RayleighModel.hh
@@ -25,7 +25,7 @@ class ParticleParams;
 /*!
  * Set up and launch Rayleigh scattering.
  */
-class RayleighModel final : public Model, public ConcreteAction
+class RayleighModel final : public Model, public StaticConcreteAction
 {
   public:
     //@{

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -56,7 +56,7 @@ RelativisticBremModel::RelativisticBremModel(ActionId id,
     host_ref.ids.gamma = particles.find(pdg::gamma());
 
     CELER_VALIDATE(host_ref.ids,
-                   << "missing IDs (required for " << this->description()
+                   << "missing particles (required for " << this->description()
                    << ")");
 
     // Save particle properties

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -39,7 +39,8 @@ RelativisticBremModel::RelativisticBremModel(ActionId id,
                                              MaterialParams const& materials,
                                              SPConstImported data,
                                              bool enable_lpm)
-    : ConcreteAction(id, "brems-rel", "interact by relativistic bremsstrahlung")
+    : StaticConcreteAction(
+          id, "brems-rel", "interact by relativistic bremsstrahlung")
     , imported_(data,
                 particles,
                 ImportProcessClass::e_brems,

--- a/src/celeritas/em/model/RelativisticBremModel.hh
+++ b/src/celeritas/em/model/RelativisticBremModel.hh
@@ -27,7 +27,7 @@ class ParticleParams;
  * Set up and launch the relativistic Bremsstrahlung model for high-energy
  * electrons and positrons with the Landau-Pomeranchuk-Migdal (LPM) effect
  */
-class RelativisticBremModel final : public Model, public ConcreteAction
+class RelativisticBremModel final : public Model, public StaticConcreteAction
 {
   public:
     //@{

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -64,9 +64,8 @@ SeltzerBergerModel::SeltzerBergerModel(ActionId id,
     host_data.ids.positron = particles.find(pdg::positron());
     host_data.ids.gamma = particles.find(pdg::gamma());
     CELER_VALIDATE(host_data.ids,
-                   << "missing electron, positron, and/or gamma particles "
-                      "(required for "
-                   << this->description() << ")");
+                   << "missing particles (required for " << this->description()
+                   << ")");
 
     // Save particle properties
     host_data.electron_mass = particles.get(host_data.ids.electron).mass();

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -44,7 +44,7 @@ SeltzerBergerModel::SeltzerBergerModel(ActionId id,
                                        MaterialParams const& materials,
                                        SPConstImported data,
                                        ReadData load_sb_table)
-    : ConcreteAction(
+    : StaticConcreteAction(
           id, "brems-sb", "interact by Seltzer-Berger bremsstrahlung")
     , imported_(data,
                 particles,

--- a/src/celeritas/em/model/SeltzerBergerModel.hh
+++ b/src/celeritas/em/model/SeltzerBergerModel.hh
@@ -46,7 +46,7 @@ class ParticleParams;
  * screened nuclei and orbital electrons of neutral atoms with Z = 1–100", At.
  * Data Nucl. Data Tables 35, 345–418.
  */
-class SeltzerBergerModel final : public Model, public ConcreteAction
+class SeltzerBergerModel final : public Model, public StaticConcreteAction
 {
   public:
     //!@{

--- a/src/celeritas/geo/detail/BoundaryAction.cc
+++ b/src/celeritas/geo/detail/BoundaryAction.cc
@@ -27,7 +27,7 @@ namespace detail
  * Construct with action ID.
  */
 BoundaryAction::BoundaryAction(ActionId aid)
-    : ConcreteAction(aid, "geo-boundary", "cross a geometry boundary")
+    : StaticConcreteAction(aid, "geo-boundary", "cross a geometry boundary")
 {
 }
 

--- a/src/celeritas/geo/detail/BoundaryAction.hh
+++ b/src/celeritas/geo/detail/BoundaryAction.hh
@@ -18,7 +18,7 @@ namespace detail
  * Move a track across a boundary.
  */
 class BoundaryAction final : public CoreStepActionInterface,
-                             public ConcreteAction
+                             public StaticConcreteAction
 {
   public:
     // Construct with ID

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -119,14 +119,14 @@ ActionId find_along_step_id(ActionRegistry const& reg)
 }
 
 //---------------------------------------------------------------------------//
-class PropagationLimitAction final : public ConcreteAction
+class PropagationLimitAction final : public StaticConcreteAction
 {
   public:
     //! Construct with ID
     explicit PropagationLimitAction(ActionId id)
-        : ConcreteAction(id,
-                         "geo-propagation-limit",
-                         "pause due to propagation misbehavior")
+        : StaticConcreteAction(id,
+                               "geo-propagation-limit",
+                               "pause due to propagation misbehavior")
     {
     }
 };

--- a/src/celeritas/neutron/model/ChipsNeutronElasticModel.cc
+++ b/src/celeritas/neutron/model/ChipsNeutronElasticModel.cc
@@ -33,9 +33,9 @@ ChipsNeutronElasticModel::ChipsNeutronElasticModel(
     ParticleParams const& particles,
     MaterialParams const& materials,
     ReadData load_data)
-    : ConcreteAction(id,
-                     "neutron-elastic-chips",
-                     "interact by neutron elastic scattering (CHIPS)")
+    : StaticConcreteAction(id,
+                           "neutron-elastic-chips",
+                           "interact by neutron elastic scattering (CHIPS)")
 {
     CELER_EXPECT(id);
     CELER_EXPECT(load_data);

--- a/src/celeritas/neutron/model/ChipsNeutronElasticModel.hh
+++ b/src/celeritas/neutron/model/ChipsNeutronElasticModel.hh
@@ -27,7 +27,7 @@ class ParticleParams;
 /*!
  * Set up and launch the neutron elastic CHIPS model interaction.
  */
-class ChipsNeutronElasticModel final : public Model, public ConcreteAction
+class ChipsNeutronElasticModel final : public Model, public StaticConcreteAction
 {
   public:
     //!@{

--- a/src/celeritas/neutron/model/NeutronInelasticModel.cc
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.cc
@@ -34,9 +34,9 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
                                              MaterialParams const& materials,
                                              CascadeOptions const& options,
                                              ReadData load_data)
-    : ConcreteAction(id,
-                     "neutron-inelastic-bertini",
-                     "interact by neutron inelastic (Bertini)")
+    : StaticConcreteAction(id,
+                           "neutron-inelastic-bertini",
+                           "interact by neutron inelastic (Bertini)")
 {
     CELER_EXPECT(id);
     CELER_EXPECT(load_data);

--- a/src/celeritas/neutron/model/NeutronInelasticModel.hh
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.hh
@@ -28,7 +28,7 @@ class ParticleParams;
 /*!
  * Set up and launch the neutron inelastic model interaction.
  */
-class NeutronInelasticModel final : public Model, public ConcreteAction
+class NeutronInelasticModel final : public Model, public StaticConcreteAction
 {
   public:
     //!@{

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -59,11 +59,11 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
-class ImplicitPhysicsAction final : public ConcreteAction
+class ImplicitPhysicsAction final : public StaticConcreteAction
 {
   public:
     // Construct with ID and label
-    using ConcreteAction::ConcreteAction;
+    using StaticConcreteAction::StaticConcreteAction;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsParams.hh
+++ b/src/celeritas/phys/PhysicsParams.hh
@@ -194,7 +194,7 @@ class PhysicsParams final : public ParamsDataInterface<PhysicsParamsData>
     DeviceRef const& device_ref() const final { return data_.device_ref(); }
 
   private:
-    using SPAction = std::shared_ptr<ConcreteAction>;
+    using SPAction = std::shared_ptr<StaticConcreteAction>;
     using VecModel = std::vector<std::pair<SPConstModel, ProcessId>>;
     using HostValue = celeritas::HostVal<PhysicsParamsData>;
 

--- a/src/celeritas/phys/detail/DiscreteSelectAction.cc
+++ b/src/celeritas/phys/detail/DiscreteSelectAction.cc
@@ -25,7 +25,7 @@ namespace detail
  * Construct with an action ID.
  */
 DiscreteSelectAction::DiscreteSelectAction(ActionId aid)
-    : ConcreteAction(
+    : StaticConcreteAction(
           aid, "physics-discrete-select", "select a discrete interaction")
 {
 }

--- a/src/celeritas/phys/detail/DiscreteSelectAction.hh
+++ b/src/celeritas/phys/detail/DiscreteSelectAction.hh
@@ -20,7 +20,7 @@ namespace detail
  * Select a model for tracks undergoing a discrete interaction.
  */
 class DiscreteSelectAction final : public CoreStepActionInterface,
-                                   public ConcreteAction
+                                   public StaticConcreteAction
 {
   public:
     // Construct with ID

--- a/src/celeritas/phys/detail/PreStepAction.cc
+++ b/src/celeritas/phys/detail/PreStepAction.cc
@@ -26,7 +26,7 @@ namespace detail
  * Construct with an action ID.
  */
 PreStepAction::PreStepAction(ActionId aid)
-    : ConcreteAction(aid, "pre-step", "update beginning-of-step state")
+    : StaticConcreteAction(aid, "pre-step", "update beginning-of-step state")
 {
 }
 

--- a/src/celeritas/phys/detail/PreStepAction.hh
+++ b/src/celeritas/phys/detail/PreStepAction.hh
@@ -22,7 +22,7 @@ namespace detail
  * - Sample the mean free path and calculate the physics step limits.
  */
 class PreStepAction final : public CoreStepActionInterface,
-                            public ConcreteAction
+                            public StaticConcreteAction
 {
   public:
     // Construct with ID

--- a/src/celeritas/phys/detail/TrackingCutAction.cc
+++ b/src/celeritas/phys/detail/TrackingCutAction.cc
@@ -27,7 +27,8 @@ namespace detail
  * Construct with action ID.
  */
 TrackingCutAction::TrackingCutAction(ActionId aid)
-    : ConcreteAction(aid, "tracking-cut", "kill a track and deposit its energy")
+    : StaticConcreteAction(
+          aid, "tracking-cut", "kill a track and deposit its energy")
 {
 }
 

--- a/src/celeritas/phys/detail/TrackingCutAction.hh
+++ b/src/celeritas/phys/detail/TrackingCutAction.hh
@@ -20,7 +20,7 @@ namespace detail
  * \sa CoreTrackView::tracking_cut_action
  */
 class TrackingCutAction final : public CoreStepActionInterface,
-                                public ConcreteAction
+                                public StaticConcreteAction
 {
   public:
     // Construct with ID

--- a/src/corecel/sys/ActionInterface.cc
+++ b/src/corecel/sys/ActionInterface.cc
@@ -15,13 +15,14 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 //! Default destructor.
-ActionInterface::~ActionInterface() = default;
+ActionInterface::~ActionInterface() noexcept = default;
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct a concrete action from a label and ID.
  */
-ConcreteAction::ConcreteAction(ActionId id, std::string label)
+ConcreteAction::ConcreteAction(ActionId id,
+                               std::string label) noexcept(!CELERITAS_DEBUG)
     : ConcreteAction{id, std::move(label), {}}
 {
 }
@@ -32,10 +33,38 @@ ConcreteAction::ConcreteAction(ActionId id, std::string label)
  */
 ConcreteAction::ConcreteAction(ActionId id,
                                std::string label,
-                               std::string description)
+                               std::string description) noexcept(!CELERITAS_DEBUG)
     : id_{std::move(id)}
     , label_{std::move(label)}
     , description_{std::move(description)}
+{
+    CELER_ASSERT(id_);
+    CELER_ASSERT(!label_.empty());
+}
+
+//---------------------------------------------------------------------------//
+//! Default destructor.
+ConcreteAction::~ConcreteAction() noexcept = default;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a concrete action from a label and ID.
+ */
+StaticConcreteAction::StaticConcreteAction(
+    ActionId id, std::string_view label) noexcept(!CELERITAS_DEBUG)
+    : StaticConcreteAction{id, label, {}}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a concrete action from an ID, a unique label, and a description.
+ */
+StaticConcreteAction::StaticConcreteAction(
+    ActionId id,
+    std::string_view label,
+    std::string_view description) noexcept(!CELERITAS_DEBUG)
+    : id_{id}, label_{label}, description_{description}
 {
     CELER_ASSERT(id_);
     CELER_ASSERT(!label_.empty());

--- a/src/corecel/sys/ActionInterface.hh
+++ b/src/corecel/sys/ActionInterface.hh
@@ -231,7 +231,7 @@ class ConcreteAction : virtual public ActionInterface
 
     // Default destructor
     ~ConcreteAction() noexcept;
-    CELER_DEFAULT_COPY_MOVE(ConcreteAction);
+    CELER_DELETE_COPY_MOVE(ConcreteAction);
 
     //! ID of this action for verification
     ActionId action_id() const final { return id_; }
@@ -273,7 +273,7 @@ class StaticConcreteAction : virtual public ActionInterface
 
     // Default destructor
     ~StaticConcreteAction() = default;
-    CELER_DEFAULT_COPY_MOVE(StaticConcreteAction);
+    CELER_DELETE_COPY_MOVE(StaticConcreteAction);
 
     //! ID of this action for verification
     ActionId action_id() const final { return id_; }

--- a/src/corecel/sys/ActionInterface.hh
+++ b/src/corecel/sys/ActionInterface.hh
@@ -56,7 +56,7 @@ enum class StepActionOrder
  * different reasons to pause the state or mark it for future modification
  * (range limitation, propagation loop limit).
  *
- * The \c ActionInterface provides a no-overhead virtual interface for
+ * The \c ActionInterface provides a clean virtual interface for
  * gathering metadata. The \c StepActionInterface provides additional
  * interfaces for launching kernels. The \c BeginRunActionInterface allows
  * actions to modify the state (or the class instance itself) at the beginning
@@ -64,7 +64,10 @@ enum class StepActionOrder
  * gather and merge multiple state information at the end.
  *
  * Using multiple inheritance, you can create an action that inherits from
- * multiple of these classes.
+ * multiple of these classes. Note also that the function signatures are
+ * similar to other high-level interfaces classes in Celeritas (e.g., \c
+ * AuxParamsInterface, \c OutputInterface), so one "label" can be used to
+ * satisfy multiple interfaces.
  *
  * The \c label should be a brief lowercase hyphen-separated string, usually a
  * noun, with perhaps some sort of category being the first token.
@@ -76,7 +79,7 @@ class ActionInterface
 {
   public:
     // Default virtual destructor allows deletion by pointer-to-interface
-    virtual ~ActionInterface();
+    virtual ~ActionInterface() noexcept = 0;
 
     //! ID of this action for verification and ordering
     virtual ActionId action_id() const = 0;
@@ -171,15 +174,13 @@ class BeginRunActionInterface : public ActionTypeTraits<P, S>,
  */
 template<class P, template<MemSpace M> class S>
 class StepActionInterface : public ActionTypeTraits<P, S>,
-                            public virtual ActionInterface
+                            virtual public ActionInterface
 {
   public:
     //! Dependency ordering of the action inside the step
     virtual StepActionOrder order() const = 0;
-
     //! Execute the action with host data
     virtual void step(P const&, S<MemSpace::host>&) const = 0;
-
     //! Execute the action with device data
     virtual void step(P const&, S<MemSpace::device>&) const = 0;
 };
@@ -210,15 +211,27 @@ class StepActionInterface : public ActionTypeTraits<P, S>,
       using ConcreteAction::ConcreteAction;
   };
  * \endcode
+ *
+ * The \c noexcept declarations improve code generation for the
+ * common use case of multiple inheritance.
+ *
+ * \note Use this class when multiple instances of the class may coexist in the
+ * same stepping loop.
  */
-class ConcreteAction : public virtual ActionInterface
+class ConcreteAction : virtual public ActionInterface
 {
   public:
     // Construct from ID, unique label
-    ConcreteAction(ActionId id, std::string label);
+    ConcreteAction(ActionId id, std::string label) noexcept(!CELERITAS_DEBUG);
 
     // Construct from ID, unique label, and description
-    ConcreteAction(ActionId id, std::string label, std::string description);
+    ConcreteAction(ActionId id,
+                   std::string label,
+                   std::string description) noexcept(!CELERITAS_DEBUG);
+
+    // Default destructor
+    ~ConcreteAction() noexcept;
+    CELER_DEFAULT_COPY_MOVE(ConcreteAction);
 
     //! ID of this action for verification
     ActionId action_id() const final { return id_; }
@@ -236,6 +249,49 @@ class ConcreteAction : public virtual ActionInterface
 };
 
 //---------------------------------------------------------------------------//
+/*!
+ * Concrete mixin utility class for managing an action with static strings.
+ *
+ * This is a typical use case for "singleton" actions where a maximum of one
+ * can exist per stepping loop. The action ID still must be supplied at
+ * runtime.
+ *
+ * \note Use this class when the label and description are compile-time
+ * constants.
+ */
+class StaticConcreteAction : virtual public ActionInterface
+{
+  public:
+    // Construct from ID, unique label
+    StaticConcreteAction(ActionId id,
+                         std::string_view label) noexcept(!CELERITAS_DEBUG);
+
+    // Construct from ID, unique label, and description
+    StaticConcreteAction(ActionId id,
+                         std::string_view label,
+                         std::string_view description) noexcept(!CELERITAS_DEBUG);
+
+    // Default destructor
+    ~StaticConcreteAction() = default;
+    CELER_DEFAULT_COPY_MOVE(StaticConcreteAction);
+
+    //! ID of this action for verification
+    ActionId action_id() const final { return id_; }
+
+    //! Short label
+    std::string_view label() const final { return label_; }
+
+    //! Descriptive label
+    std::string_view description() const final { return description_; }
+
+  private:
+    ActionId id_;
+    std::string_view label_;
+    std::string_view description_;
+};
+
+//---------------------------------------------------------------------------//
+
 //! Action order/ID tuple for comparison in sorting
 struct OrderedAction
 {

--- a/test/corecel/sys/ActionRegistry.test.cc
+++ b/test/corecel/sys/ActionRegistry.test.cc
@@ -74,11 +74,11 @@ class MyExplicitAction final : public MockStepActionInterface,
     mutable int device_count_{-100};
 };
 
-class MyImplicitAction final : public ConcreteAction
+class MyImplicitAction final : public StaticConcreteAction
 {
   public:
     // Construct with ID and label
-    using ConcreteAction::ConcreteAction;
+    using StaticConcreteAction::StaticConcreteAction;
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This is a small refactor to use string views instead of heap-allocated strings for actions that should only exist once in the stepping loop.