### PR TITLE
Support aliased nodes during CsgTree simplification

### DIFF
--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -102,11 +102,12 @@ CsgTree DeMorganSimplifier::operator()()
 template<class T>
 T const* DeMorganSimplifier::node_is(Node const& node) const
 {
-    if (auto* alias = std::get_if<Aliased>(&node))
+    Node const* target = &node;
+    while (auto* alias = std::get_if<Aliased>(target))
     {
-        return this->node_is<T>(tree_[alias->node]);
+        target = &tree_[alias->node];
     }
-    return std::get_if<T>(&node);
+    return std::get_if<T>(target);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -239,9 +239,9 @@ CsgTree DeMorganSimplifier::build_simplified_tree()
         // We might have to insert a negated version of that node
         if (new_negated_nodes_[node_id.get()])
         {
-            Node const* target_node{&tree_[this->dealias(node_id)]};
-            CELER_EXPECT(!std::get_if<Negated>(target_node)
-                         && !std::get_if<Joined>(target_node)
+            Node const& target_node{tree_[this->dealias(node_id)]};
+            CELER_EXPECT(!std::holds_alternative<Negated>(target_node)
+                         && !std::holds_alternative<Joined>(target_node)
                          && !trans.new_negation);
             auto [new_negated_node_id, negated_inserted]
                 = result.insert(Negated{new_id});

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -99,6 +99,7 @@ class DeMorganSimplifier
         size_type extent() const noexcept;
 
       private:
+        // TODO: sparse storage
         std::vector<bool> data_;
         size_type extent_;
     };

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -57,6 +57,9 @@ class DeMorganSimplifier
     //! node id >= 2
     static constexpr auto has_parents_index_{NodeId{1}};
 
+    //! First meaningfull node id in a CsgTree
+    static constexpr auto first_node_id_{NodeId{2}};
+
     //! Helper struct to translate ids from the original tree to ids in the
     //! simplified tree
     struct MatchingNodes
@@ -104,9 +107,8 @@ class DeMorganSimplifier
         size_type extent_;
     };
 
-    // Similar to get_if but dereference Aliased nodes
-    template<class T>
-    T const* node_is(Node const&) const;
+    // Dereference Aliased nodes
+    NodeId dealias(NodeId) const;
 
     // First pass to find negated set operations
     void find_join_negations();

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -103,6 +103,10 @@ class DeMorganSimplifier
         size_type extent_;
     };
 
+    // Similar to get_if but dereference Aliased nodes
+    template<class T>
+    T const* node_is(Node const&) const;
+
     // First pass to find negated set operations
     void find_join_negations();
 

--- a/test/orange/orangeinp/CsgTreeUtils.test.cc
+++ b/test/orange/orangeinp/CsgTreeUtils.test.cc
@@ -8,6 +8,7 @@
 #include "orange/orangeinp/CsgTreeUtils.hh"
 
 #include "orange/orangeinp/CsgTree.hh"
+#include "orange/orangeinp/CsgTypes.hh"
 #include "orange/orangeinp/detail/InternalSurfaceFlagger.hh"
 #include "orange/orangeinp/detail/PostfixLogicBuilder.hh"
 #include "orange/orangeinp/detail/SenseEvaluator.hh"
@@ -703,6 +704,24 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins_with_volumes)
     EXPECT_EQ(volumes[0], NodeId{20});
 }
 
+TEST_F(CsgTreeUtilsTest, transform_negated_joins_with_aliases)
+{
+    auto s0 = this->insert(Surface{S{0}});
+    auto s1 = this->insert(Surface{S{1}});
+    auto n0 = this->insert(Negated{s1});
+    auto j0 = this->insert(Joined{op_and, {s0, n0}});
+    auto a0 = this->insert(Aliased{j0});
+    this->insert(Negated{a0});
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: "
+        "all{2,4}, 6: ->{5}, 7: not{5}, }",
+        to_string(tree_));
+    auto simplified = transform_negated_joins(tree_);
+    EXPECT_EQ(
+        "{0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: "
+        "not{4}, 6: any{3,4}, 7: all{2,5}, }",
+        to_string(simplified));
+}
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace orangeinp


### PR DESCRIPTION
This is necessary when building `CsgUnit`. 