### PR TITLE
Import muon pair production sampling table from Geant4

### DIFF
--- a/app/celer-dump-data.cc
+++ b/app/celer-dump-data.cc
@@ -706,6 +706,44 @@ void print_livermore_pe_data(ImportData::ImportLivermorePEMap const& lpe_map)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Print muon pair production sampling table.
+ */
+void print_mupp_data(ImportMuPairProductionTable const& mupp_data)
+{
+    if (!mupp_data)
+    {
+        CELER_LOG(info) << "Muon pair production sampling table not available";
+        return;
+    }
+
+    CELER_LOG(info) << "Loaded muon pair production sampling table with size "
+                    << mupp_data.physics_vectors.size();
+
+    cout << R"gfm(
+# Muon pair production sampling table
+
+| Atomic number | Endpoints (x, y, value)                                     |
+| ------------- | ----------------------------------------------------------- |
+)gfm";
+
+    for (auto i : range(mupp_data.atomic_number.size()))
+    {
+        auto z = mupp_data.atomic_number[i];
+        auto const& pv = mupp_data.physics_vectors[i];
+
+        cout << "| " << setw(13) << z << " | (" << setprecision(3) << setw(7)
+             << pv.x.front() << ", " << setprecision(3) << setw(7)
+             << pv.y.front() << ", " << setprecision(3) << setw(7)
+             << pv.value.front() << ") -> (" << setprecision(3) << setw(7)
+             << pv.x.back() << ", " << setprecision(3) << setw(7)
+             << pv.y.back() << ", " << setprecision(3) << setw(8)
+             << pv.value.back() << ") |\n";
+    }
+    cout << endl;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Print atomic relaxation map.
  */
 void print_atomic_relaxation_data(
@@ -921,6 +959,7 @@ int main(int argc, char* argv[])
 
     print_sb_data(data.sb_data);
     print_livermore_pe_data(data.livermore_pe_data);
+    print_mupp_data(data.mu_pair_production_data);
     print_atomic_relaxation_data(data.atomic_relaxation_data);
 
     print_em_params(data.em_params);

--- a/src/celeritas/em/model/CombinedBremModel.hh
+++ b/src/celeritas/em/model/CombinedBremModel.hh
@@ -22,7 +22,6 @@
 
 namespace celeritas
 {
-struct ImportSBTable;
 class MaterialParams;
 class ParticleParams;
 

--- a/src/celeritas/em/process/BremsstrahlungProcess.hh
+++ b/src/celeritas/em/process/BremsstrahlungProcess.hh
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include "celeritas/ext/GeantPhysicsOptions.hh"
+#include "celeritas/io/ImportSBTable.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/phys/Applicability.hh"
 #include "celeritas/phys/AtomicNumber.hh"
@@ -20,8 +21,6 @@
 
 namespace celeritas
 {
-struct ImportSBTable;
-
 //---------------------------------------------------------------------------//
 /*!
  * Bremsstrahlung process for electrons and positrons.

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -1080,9 +1080,10 @@ ImportMuPairProductionTable import_mupp_table(PDGNumber pdg)
     {
         if (G4Physics2DVector const* pv = el_data->GetElement2DData(z))
         {
+            using IU = ImportUnits;
             result.atomic_number.push_back(z);
-            result.physics_vectors.push_back(
-                detail::import_physics_2dvector(*pv));
+            result.physics_vectors.push_back(detail::import_physics_2dvector(
+                *pv, {IU::unitless, IU::mev, IU::mev_len_sq}));
         }
     }
     CELER_ENSURE(result);

--- a/src/celeritas/ext/RootInterfaceLinkDef.h
+++ b/src/celeritas/ext/RootInterfaceLinkDef.h
@@ -29,6 +29,7 @@
 #pragma link C++ class celeritas::ImportModel+;
 #pragma link C++ class celeritas::ImportModelMaterial+;
 #pragma link C++ class celeritas::ImportMscModel+;
+#pragma link C++ class celeritas::ImportMuPairProductionTable+;
 #pragma link C++ class celeritas::ImportOpticalAbsorption+;
 #pragma link C++ class celeritas::ImportOpticalMaterial+;
 #pragma link C++ class celeritas::ImportOpticalParameters+;
@@ -37,6 +38,7 @@
 #pragma link C++ class celeritas::ImportParticle+;
 #pragma link C++ class celeritas::ImportParticleScintSpectrum+;
 #pragma link C++ class celeritas::ImportPhysicsTable+;
+#pragma link C++ class celeritas::ImportPhysics2DVector+;
 #pragma link C++ class celeritas::ImportPhysicsVector+;
 #pragma link C++ class celeritas::ImportPhysMaterial+;
 #pragma link C++ class celeritas::ImportProcess+;

--- a/src/celeritas/ext/detail/CelerEmStandardPhysics.cc
+++ b/src/celeritas/ext/detail/CelerEmStandardPhysics.cc
@@ -466,6 +466,13 @@ void CelerEmStandardPhysics::add_e_processes(G4ParticleDefinition* p)
  * | Multiple scattering          | G4WentzelVIModel             |
  *
  * \note Currently all muon processes are disabled by default
+ *
+ * \todo Prior to version 11.1.0, Geant4 used the \c G4BetheBlochModel for muon
+ * ionization between 200 keV and 1 GeV and the \c G4MuBetheBlochModel above 1
+ * GeV. Since version 11.1.0, the \c G4MuBetheBlochModel is used for all
+ * energies above 200 keV.
+ *
+ * \todo Implement energy loss fluctuation models for muon ionization.
  */
 void CelerEmStandardPhysics::add_mu_processes(G4ParticleDefinition* p)
 {

--- a/src/celeritas/ext/detail/GeantProcessImporter.cc
+++ b/src/celeritas/ext/detail/GeantProcessImporter.cc
@@ -430,8 +430,14 @@ import_physics_vector(G4PhysicsVector const& g4v, Array<ImportUnits, 2> units)
 /*!
  * Import a 2D physics vector.
  */
-ImportPhysics2DVector import_physics_2dvector(G4Physics2DVector const& g4pv)
+ImportPhysics2DVector import_physics_2dvector(G4Physics2DVector const& g4pv,
+                                              Array<ImportUnits, 3> units)
 {
+    // Convert units
+    double const x_scaling = native_value_from_clhep(units[0]);
+    double const y_scaling = native_value_from_clhep(units[1]);
+    double const v_scaling = native_value_from_clhep(units[2]);
+
     ImportPhysics2DVector pv;
     pv.x.resize(g4pv.GetLengthX());
     pv.y.resize(g4pv.GetLengthY());
@@ -439,11 +445,11 @@ ImportPhysics2DVector import_physics_2dvector(G4Physics2DVector const& g4pv)
 
     for (auto i : range(pv.x.size()))
     {
-        pv.x[i] = g4pv.GetX(i);
+        pv.x[i] = g4pv.GetX(i) * x_scaling;
         for (auto j : range(pv.y.size()))
         {
-            pv.y[j] = g4pv.GetY(j);
-            pv.value[pv.y.size() * i + j] = g4pv.GetValue(i, j);
+            pv.y[j] = g4pv.GetY(j) * y_scaling;
+            pv.value[pv.y.size() * i + j] = g4pv.GetValue(i, j) * v_scaling;
         }
     }
     CELER_ENSURE(pv);

--- a/src/celeritas/ext/detail/GeantProcessImporter.cc
+++ b/src/celeritas/ext/detail/GeantProcessImporter.cc
@@ -18,6 +18,7 @@
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <G4ParticleDefinition.hh>
 #include <G4ParticleTable.hh>
+#include <G4Physics2DVector.hh>
 #include <G4PhysicsTable.hh>
 #include <G4PhysicsVector.hh>
 #include <G4PhysicsVectorType.hh>
@@ -423,6 +424,30 @@ import_physics_vector(G4PhysicsVector const& g4v, Array<ImportUnits, 2> units)
         import_vec.y[i] = g4v[i] * y_scaling;
     }
     return import_vec;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Import a 2D physics vector.
+ */
+ImportPhysics2DVector import_physics_2dvector(G4Physics2DVector const& g4pv)
+{
+    ImportPhysics2DVector pv;
+    pv.x.resize(g4pv.GetLengthX());
+    pv.y.resize(g4pv.GetLengthY());
+    pv.value.resize(pv.x.size() * pv.y.size());
+
+    for (auto i : range(pv.x.size()))
+    {
+        pv.x[i] = g4pv.GetX(i);
+        for (auto j : range(pv.y.size()))
+        {
+            pv.y[j] = g4pv.GetY(j);
+            pv.value[pv.y.size() * i + j] = g4pv.GetValue(i, j);
+        }
+    }
+    CELER_ENSURE(pv);
+    return pv;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantProcessImporter.hh
+++ b/src/celeritas/ext/detail/GeantProcessImporter.hh
@@ -26,6 +26,7 @@ class G4VMultipleScattering;
 class G4ParticleDefinition;
 class G4PhysicsTable;
 class G4PhysicsVector;
+class G4Physics2DVector;
 
 namespace celeritas
 {
@@ -117,6 +118,9 @@ class GeantProcessImporter
 // Import a physics vector with the given x, y units
 ImportPhysicsVector
 import_physics_vector(G4PhysicsVector const& g4v, Array<ImportUnits, 2> units);
+
+// Import a 2D physics vector
+ImportPhysics2DVector import_physics_2dvector(G4Physics2DVector const& g4pv);
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/ext/detail/GeantProcessImporter.hh
+++ b/src/celeritas/ext/detail/GeantProcessImporter.hh
@@ -120,7 +120,8 @@ ImportPhysicsVector
 import_physics_vector(G4PhysicsVector const& g4v, Array<ImportUnits, 2> units);
 
 // Import a 2D physics vector
-ImportPhysics2DVector import_physics_2dvector(G4Physics2DVector const& g4pv);
+ImportPhysics2DVector import_physics_2dvector(G4Physics2DVector const& g4pv,
+                                              Array<ImportUnits, 3> units);
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/io/ImportData.hh
+++ b/src/celeritas/io/ImportData.hh
@@ -14,6 +14,7 @@
 #include "ImportElement.hh"
 #include "ImportLivermorePE.hh"
 #include "ImportMaterial.hh"
+#include "ImportMuPairProductionTable.hh"
 #include "ImportOpticalMaterial.hh"
 #include "ImportParameters.hh"
 #include "ImportParticle.hh"
@@ -86,6 +87,7 @@ struct ImportData
     ImportLivermorePEMap livermore_pe_data;
     ImportNeutronElasticMap neutron_elastic_data;
     ImportAtomicRelaxationMap atomic_relaxation_data;
+    ImportMuPairProductionTable mu_pair_production_data;
     //!@}
 
     //!@{

--- a/src/celeritas/io/ImportMuPairProductionTable.hh
+++ b/src/celeritas/io/ImportMuPairProductionTable.hh
@@ -1,0 +1,45 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/io/ImportMuPairProductionTable.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+
+#include "ImportPhysicsVector.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Sampling table for electron-positron pair production by muons.
+ *
+ * This 3-dimensional table is used to sample the energy transfer to the
+ * electron-positron pair, \f$ \epsilon_p \f$. The outer grid stores the atomic
+ * number using 5 equally spaced points in \f$ \log Z \f$; the x grid tabulates
+ * the ratio \f$ \log \epsilon_p / T \f$, where \f$ T \f$ is the incident muon
+ * energy; the y grid stores the incident muon energy using equal spacing in
+ * \f$ \log T \f$.
+ */
+struct ImportMuPairProductionTable
+{
+    //!@{
+    //! \name Type aliases
+    using ZInt = int;
+    //!@}
+
+    std::vector<ZInt> atomic_number;
+    std::vector<ImportPhysics2DVector> physics_vectors;
+
+    explicit operator bool() const
+    {
+        return !atomic_number.empty()
+               && physics_vectors.size() == atomic_number.size();
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/io/ImportPhysicsVector.cc
+++ b/src/celeritas/io/ImportPhysicsVector.cc
@@ -14,6 +14,15 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Equality operator, mainly for debugging.
+ */
+bool operator==(ImportPhysics2DVector const& a, ImportPhysics2DVector const& b)
+{
+    return a.x == b.x && a.y == b.y && a.value == b.value;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Get the string value for a vector type.
  */
 char const* to_cstring(ImportPhysicsVectorType value)

--- a/src/celeritas/io/ImportPhysicsVector.hh
+++ b/src/celeritas/io/ImportPhysicsVector.hh
@@ -47,6 +47,27 @@ struct ImportPhysicsVector
 };
 
 //---------------------------------------------------------------------------//
+/*!
+ * Store imported 2D physics vector data (see Geant4's G4Physics2DVector.hh).
+ *
+ * This stores a 2D grid of generic data with linear interpolation.
+ */
+struct ImportPhysics2DVector
+{
+    std::vector<double> x;  //!< x grid
+    std::vector<double> y;  //!< y grid
+    std::vector<double> value;  //!< [x][y]
+
+    explicit operator bool() const
+    {
+        return !x.empty() && !y.empty() && value.size() == x.size() * y.size();
+    }
+};
+
+// Equality operator, mainly for debugging
+bool operator==(ImportPhysics2DVector const& a, ImportPhysics2DVector const& b);
+
+//---------------------------------------------------------------------------//
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//
 

--- a/src/celeritas/io/ImportSBTable.hh
+++ b/src/celeritas/io/ImportSBTable.hh
@@ -7,20 +7,19 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <vector>
+#include "ImportPhysicsVector.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
  * Seltzer Berger differential cross sections for a single element.
+ *
+ * This 2-dimensional table stores the scaled bremsstrahlung differential cross
+ * section [mb]. The x grid is the log energy of the incident particle [MeV],
+ * and the y grid is the ratio of the gamma energy to the incident energy.
  */
-struct ImportSBTable
-{
-    std::vector<double> x;  //!< Log energy of incident particle / MeV
-    std::vector<double> y;  //!< Ratio of gamma energy to incident energy
-    std::vector<double> value;  //!< Scaled DCS [mb] [ny * x + y]
-};
+using ImportSBTable = ImportPhysics2DVector;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/io/ImportUnits.cc
+++ b/src/celeritas/io/ImportUnits.cc
@@ -80,6 +80,7 @@ char const* to_cstring(ImportUnits value)
         "1/len-MeV",
         "MeV^2/len",
         "len^2",
+        "MeV-len^2",
         "time",
         "1/len^3",
         "len-time^2/mass",
@@ -118,6 +119,8 @@ double native_value_from(UnitSystem sys, ImportUnits q)
             return ipow<2>(mev) / len;
         case ImportUnits::len_sq:
             return ipow<2>(len);
+        case ImportUnits::mev_len_sq:
+            return mev * ipow<2>(len);
         case ImportUnits::time:
             return time;
         case ImportUnits::inv_len_cb:

--- a/src/celeritas/io/ImportUnits.hh
+++ b/src/celeritas/io/ImportUnits.hh
@@ -33,6 +33,7 @@ enum class ImportUnits
     len_mev_inv,  //!< Scaled (1/E) macroscopic xs [1/len-MeV]
     mev_sq_per_len,  //!< Scaled [E^2] macroscopic xs  [MeV^2/len]
     len_sq,  //!< Microscopic cross section [len^2]
+    mev_len_sq,  //!< [MeV-len^2]
     time,  //!< Time [time]
     inv_len_cb,  //!< Number density [1/len^3]
     len_time_sq_per_mass,  //!< Inverse pressure [len-time^2/mass]

--- a/src/celeritas/phys/ProcessBuilder.hh
+++ b/src/celeritas/phys/ProcessBuilder.hh
@@ -15,6 +15,7 @@
 
 #include "celeritas/ext/GeantPhysicsOptions.hh"
 #include "celeritas/io/ImportProcess.hh"
+#include "celeritas/io/ImportSBTable.hh"
 
 #include "AtomicNumber.hh"
 #include "Process.hh"
@@ -27,7 +28,6 @@ class MaterialParams;
 class ParticleParams;
 struct ImportData;
 struct ImportLivermorePE;
-struct ImportSBTable;
 
 //---------------------------------------------------------------------------//
 //! Options used for constructing built-in Celeritas processes

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -953,6 +953,8 @@ TEST_F(FourSteelSlabsEmStandard, mu_pair_production_data)
         table_value.push_back(pv.value.back() / barn);
     }
 
+    real_type const tol = geant4_version < Version(11, 1, 0) ? 1e-12 : 0.03;
+
     static double const expected_table_x[] = {
         -6.1928487397154,
         0,
@@ -979,19 +981,20 @@ TEST_F(FourSteelSlabsEmStandard, mu_pair_production_data)
     };
     static double const expected_table_value[] = {
         0,
-        24.363843626056,
+        0.24363843626056,
         0,
-        225.7683855817,
+        2.257683855817,
         0,
-        1898.3775898741,
+        18.983775898741,
         0,
-        8658.5529175975,
+        86.585529175975,
         0,
-        79341.396760823,
+        793.41396760823,
     };
-    EXPECT_VEC_SOFT_EQ(expected_table_x, table_x);
-    EXPECT_VEC_SOFT_EQ(expected_table_y, table_y);
-    EXPECT_VEC_SOFT_EQ(expected_table_value, table_value);
+    EXPECT_VEC_NEAR(expected_table_x, table_x, tol);
+    EXPECT_VEC_NEAR(expected_table_y, table_y, tol);
+    EXPECT_VEC_NEAR(
+        expected_table_value, table_value, this->comparison_tolerance());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -845,7 +845,7 @@ TEST_F(FourSteelSlabsEmStandard, muioni)
         static unsigned int const expected_size[] = {2u, 2u};
         EXPECT_VEC_EQ(expected_size, result.size);
         static double const expected_energy[] = {0.0001, 0.2, 0.0001, 0.2};
-        EXPECT_VEC_EQ(expected_energy, result.energy);
+        EXPECT_VEC_SOFT_EQ(expected_energy, result.energy);
     }
     if (geant4_version < Version(11, 1, 0))
     {
@@ -857,7 +857,7 @@ TEST_F(FourSteelSlabsEmStandard, muioni)
         static unsigned int const expected_size[] = {2u, 2u};
         EXPECT_VEC_EQ(expected_size, result.size);
         static double const expected_energy[] = {0.2, 1000, 0.2, 1000};
-        EXPECT_VEC_EQ(expected_energy, result.energy);
+        EXPECT_VEC_SOFT_EQ(expected_energy, result.energy);
     }
     {
         auto const& model = mu_minus.models.back();
@@ -871,13 +871,13 @@ TEST_F(FourSteelSlabsEmStandard, muioni)
         {
             static double const expected_energy[]
                 = {1000, 100000000, 1000, 100000000};
-            EXPECT_VEC_EQ(expected_energy, result.energy);
+            EXPECT_VEC_SOFT_EQ(expected_energy, result.energy);
         }
         else
         {
             static double const expected_energy[]
                 = {0.2, 100000000, 0.2, 100000000};
-            EXPECT_VEC_EQ(expected_energy, result.energy);
+            EXPECT_VEC_SOFT_EQ(expected_energy, result.energy);
         }
     }
 

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -568,8 +568,7 @@ TEST_F(FourSteelSlabsEmStandard, isotopes)
     EXPECT_VEC_EQ(expected_isotope_atomic_number, isotope_atomic_number);
     EXPECT_VEC_EQ(expected_isotope_atomic_mass_number,
                   isotope_atomic_mass_number);
-    EXPECT_VEC_SOFT_EQ(expected_isotope_nuclear_mass,
-                       expected_isotope_nuclear_mass);
+    EXPECT_VEC_SOFT_EQ(expected_isotope_nuclear_mass, isotope_nuclear_mass);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -386,7 +386,6 @@ TEST_F(FourSteelSlabsEmStandard, em_particles)
     };
     EXPECT_VEC_EQ(expected_processes, summary.processes);
     static char const* expected_models[] = {
-        "bethe_bloch",
         "urban_msc",
         "icru_73_qo",
         "bragg",
@@ -402,6 +401,15 @@ TEST_F(FourSteelSlabsEmStandard, em_particles)
         "mu_brems",
         "mu_pair_prod",
     };
+    if (geant4_version < Version(11, 1, 0))
+    {
+        // Older versions of Geant4 use the Bethe-Bloch model for muon
+        // ionization at intermediate energies
+        auto iter = std::find(
+            summary.models.begin(), summary.models.end(), "bethe_bloch");
+        EXPECT_TRUE(iter != summary.models.end());
+        summary.models.erase(iter, iter + 1);
+    }
     EXPECT_VEC_EQ(expected_models, summary.models);
 }
 
@@ -431,7 +439,6 @@ TEST_F(FourSteelSlabsEmStandard, em_hadronic)
     };
     EXPECT_VEC_EQ(expected_processes, summary.processes);
     static char const* expected_models[] = {
-        "bethe_bloch",
         "urban_msc",
         "icru_73_qo",
         "bragg",
@@ -447,6 +454,15 @@ TEST_F(FourSteelSlabsEmStandard, em_hadronic)
         "mu_brems",
         "mu_pair_prod",
     };
+    if (geant4_version < Version(11, 1, 0))
+    {
+        // Older versions of Geant4 use the Bethe-Bloch model for muon
+        // ionization at intermediate energies
+        auto iter = std::find(
+            summary.models.begin(), summary.models.end(), "bethe_bloch");
+        EXPECT_TRUE(iter != summary.models.end());
+        summary.models.erase(iter, iter + 1);
+    }
     EXPECT_VEC_EQ(expected_models, summary.models);
 }
 

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -247,13 +247,16 @@ class FourSteelSlabsEmStandard : public GeantImporterTest
     {
         GeantPhysicsOptions opts;
         opts.relaxation = RelaxationSelection::all;
+        opts.muon.ionization = true;
+        opts.muon.bremsstrahlung = true;
+        opts.muon.pair_production = true;
         opts.verbose = true;
         if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
         {
             nlohmann::json out = opts;
             out.erase("_version");
             EXPECT_JSON_EQ(
-                R"json({"_format":"geant-physics","_units":"cgs","angle_limit_factor":1.0,"annihilation":true,"apply_cuts":false,"brems":"all","compton_scattering":true,"coulomb_scattering":false,"default_cutoff":0.1,"eloss_fluctuation":true,"em_bins_per_decade":7,"form_factor":"exponential","gamma_conversion":true,"gamma_general":false,"integral_approach":true,"ionization":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"msc_step_algorithm":"safety","msc_theta_limit":3.141592653589793,"muon":{"bremsstrahlung":false,"coulomb":false,"ionization":false,"msc":false,"pair_production":false},"optical":null,"photoelectric":true,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json",
+                R"json({"_format":"geant-physics","_units":"cgs","angle_limit_factor":1.0,"annihilation":true,"apply_cuts":false,"brems":"all","compton_scattering":true,"coulomb_scattering":false,"default_cutoff":0.1,"eloss_fluctuation":true,"em_bins_per_decade":7,"form_factor":"exponential","gamma_conversion":true,"gamma_general":false,"integral_approach":true,"ionization":true,"linear_loss_limit":0.01,"lowest_electron_energy":[0.001,"MeV"],"lpm":true,"max_energy":[100000000.0,"MeV"],"min_energy":[0.0001,"MeV"],"msc":"urban","msc_lambda_limit":0.1,"msc_range_factor":0.04,"msc_safety_factor":0.6,"msc_step_algorithm":"safety","msc_theta_limit":3.141592653589793,"muon":{"bremsstrahlung":true,"coulomb":false,"ionization":true,"msc":false,"pair_production":true},"optical":null,"photoelectric":true,"rayleigh_scattering":true,"relaxation":"all","verbose":true})json",
                 std::string(out.dump()));
         }
         return opts;
@@ -366,25 +369,39 @@ TEST_F(FourSteelSlabsEmStandard, em_particles)
     auto&& imported = this->imported_data();
     auto summary = this->summarize(imported);
 
-    static char const* expected_particles[] = {"e+", "e-", "gamma"};
+    static char const* expected_particles[]
+        = {"e+", "e-", "gamma", "mu+", "mu-"};
     EXPECT_VEC_EQ(expected_particles, summary.particles);
-    static char const* expected_processes[] = {"e_ioni",
-                                               "e_brems",
-                                               "photoelectric",
-                                               "compton",
-                                               "conversion",
-                                               "rayleigh",
-                                               "annihilation"};
+    static char const* expected_processes[] = {
+        "e_ioni",
+        "e_brems",
+        "photoelectric",
+        "compton",
+        "conversion",
+        "rayleigh",
+        "annihilation",
+        "mu_ioni",
+        "mu_brems",
+        "mu_pair_prod",
+    };
     EXPECT_VEC_EQ(expected_processes, summary.processes);
-    static char const* expected_models[] = {"urban_msc",
-                                            "moller_bhabha",
-                                            "e_brems_sb",
-                                            "e_brems_lpm",
-                                            "e_plus_to_gg",
-                                            "livermore_photoelectric",
-                                            "klein_nishina",
-                                            "bethe_heitler_lpm",
-                                            "livermore_rayleigh"};
+    static char const* expected_models[] = {
+        "bethe_bloch",
+        "urban_msc",
+        "icru_73_qo",
+        "bragg",
+        "moller_bhabha",
+        "e_brems_sb",
+        "e_brems_lpm",
+        "e_plus_to_gg",
+        "livermore_photoelectric",
+        "klein_nishina",
+        "bethe_heitler_lpm",
+        "livermore_rayleigh",
+        "mu_bethe_bloch",
+        "mu_brems",
+        "mu_pair_prod",
+    };
     EXPECT_VEC_EQ(expected_models, summary.models);
 }
 
@@ -397,25 +414,39 @@ TEST_F(FourSteelSlabsEmStandard, em_hadronic)
     auto&& imported = this->imported_data();
     auto summary = this->summarize(imported);
 
-    static char const* expected_particles[] = {"e+", "e-", "gamma", "proton"};
+    static char const* expected_particles[]
+        = {"e+", "e-", "gamma", "mu+", "mu-", "proton"};
     EXPECT_VEC_EQ(expected_particles, summary.particles);
-    static char const* expected_processes[] = {"e_ioni",
-                                               "e_brems",
-                                               "photoelectric",
-                                               "compton",
-                                               "conversion",
-                                               "rayleigh",
-                                               "annihilation"};
+    static char const* expected_processes[] = {
+        "e_ioni",
+        "e_brems",
+        "photoelectric",
+        "compton",
+        "conversion",
+        "rayleigh",
+        "annihilation",
+        "mu_ioni",
+        "mu_brems",
+        "mu_pair_prod",
+    };
     EXPECT_VEC_EQ(expected_processes, summary.processes);
-    static char const* expected_models[] = {"urban_msc",
-                                            "moller_bhabha",
-                                            "e_brems_sb",
-                                            "e_brems_lpm",
-                                            "e_plus_to_gg",
-                                            "livermore_photoelectric",
-                                            "klein_nishina",
-                                            "bethe_heitler_lpm",
-                                            "livermore_rayleigh"};
+    static char const* expected_models[] = {
+        "bethe_bloch",
+        "urban_msc",
+        "icru_73_qo",
+        "bragg",
+        "moller_bhabha",
+        "e_brems_sb",
+        "e_brems_lpm",
+        "e_plus_to_gg",
+        "livermore_photoelectric",
+        "klein_nishina",
+        "bethe_heitler_lpm",
+        "livermore_rayleigh",
+        "mu_bethe_bloch",
+        "mu_brems",
+        "mu_pair_prod",
+    };
     EXPECT_VEC_EQ(expected_models, summary.models);
 }
 
@@ -842,7 +873,7 @@ TEST_F(FourSteelSlabsEmStandard, trans_parameters)
     auto&& import_data = this->imported_data();
 
     EXPECT_EQ(1000, import_data.trans_params.max_substeps);
-    EXPECT_EQ(3, import_data.trans_params.looping.size());
+    EXPECT_EQ(5, import_data.trans_params.looping.size());
     for (auto const& kv : import_data.trans_params.looping)
     {
         EXPECT_EQ(10, kv.second.threshold_trials);
@@ -894,6 +925,73 @@ TEST_F(FourSteelSlabsEmStandard, sb_data)
     EXPECT_VEC_EQ(expected_sb_table_x, sb_table_x);
     EXPECT_VEC_EQ(expected_sb_table_y, sb_table_y);
     EXPECT_VEC_EQ(expected_sb_table_value, sb_table_value);
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(FourSteelSlabsEmStandard, mu_pair_production_data)
+{
+    auto&& import_data = this->imported_data();
+
+    auto const& data = import_data.mu_pair_production_data;
+
+    int const expected_atomic_number[] = {1, 4, 13, 29, 92};
+    EXPECT_VEC_EQ(expected_atomic_number, data.atomic_number);
+
+    EXPECT_EQ(5, data.physics_vectors.size());
+
+    std::vector<double> table_x;
+    std::vector<double> table_y;
+    std::vector<double> table_value;
+
+    for (auto const& pv : data.physics_vectors)
+    {
+        table_x.push_back(pv.x.front());
+        table_y.push_back(pv.y.front());
+        table_value.push_back(pv.value.front() / barn);
+        table_x.push_back(pv.x.back());
+        table_y.push_back(pv.y.back());
+        table_value.push_back(pv.value.back() / barn);
+    }
+
+    static double const expected_table_x[] = {
+        -6.1928487397154,
+        0,
+        -6.1928487397154,
+        0,
+        -6.1928487397154,
+        0,
+        -6.1928487397154,
+        0,
+        -6.1928487397154,
+        0,
+    };
+    static double const expected_table_y[] = {
+        6.9077552789821,
+        18.420680743952,
+        6.9077552789821,
+        18.420680743952,
+        6.9077552789821,
+        18.420680743952,
+        6.9077552789821,
+        18.420680743952,
+        6.9077552789821,
+        18.420680743952,
+    };
+    static double const expected_table_value[] = {
+        0,
+        24.363843626056,
+        0,
+        225.7683855817,
+        0,
+        1898.3775898741,
+        0,
+        8658.5529175975,
+        0,
+        79341.396760823,
+    };
+    EXPECT_VEC_SOFT_EQ(expected_table_x, table_x);
+    EXPECT_VEC_SOFT_EQ(expected_table_y, table_y);
+    EXPECT_VEC_SOFT_EQ(expected_table_value, table_value);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/RootJsonDumper.test.cc
+++ b/test/celeritas/ext/RootJsonDumper.test.cc
@@ -415,6 +415,11 @@ TEST_F(RootJsonDumperTest, all)
 "livermore_pe_data" : [],
 "neutron_elastic_data" : [],
 "atomic_relaxation_data" : [],
+"mu_pair_production_data" : {
+  "_typename" : "celeritas::ImportMuPairProductionTable",
+  "atomic_number" : [],
+  "physics_vectors" : []
+},
 "em_params" : {
   "_typename" : "celeritas::ImportEmParameters",
   "energy_loss_fluct" : true,


### PR DESCRIPTION
This imports the table used for sampling the electron-positron pair energy from the Geant4 muon pair production model.
