### PR TITLE
Improve PRINT_EXPECTED formatting for long strings and vectors

### DIFF
--- a/src/corecel/io/Repr.hh
+++ b/src/corecel/io/Repr.hh
@@ -252,6 +252,8 @@ struct ReprTraits<std::string_view>
 template<>
 struct ReprTraits<std::string>
 {
+    using value_type = std::string::value_type;
+
     static void print_type(std::ostream& os, char const* name = nullptr)
     {
         detail::print_simple_type(os, "std::string", name);
@@ -267,6 +269,8 @@ struct ReprTraits<std::string>
 template<>
 struct ReprTraits<char*>
 {
+    using value_type = char;
+
     static void print_type(std::ostream& os, char const* name = nullptr)
     {
         detail::print_simple_type(os, "char const*", name);
@@ -416,12 +420,10 @@ struct ContainerReprTraits
 
     static void print_value(std::ostream& os, Container const& data)
     {
-        auto orig_pos = os.tellp();
         os << '{'
            << join_stream(
                   std::begin(data), std::end(data), ", ", RT::print_value);
-        auto new_pos = os.tellp();
-        if (orig_pos >= 0 && new_pos >= 0 && new_pos - orig_pos > 160)
+        if (std::size(data) > 8)
         {
             // Add a trailing ',' to long outputs to help clang-format
             os << ',';

--- a/test/corecel/io/Repr.test.cc
+++ b/test/corecel/io/Repr.test.cc
@@ -14,6 +14,7 @@
 
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/io/StringUtils.hh"
 
 #include "celeritas_test.hh"
 
@@ -58,6 +59,10 @@ TEST(ReprTest, string)
     EXPECT_EQ("\"abcd\\a\"", repr_to_string(std::string("abcd\a")));
     EXPECT_EQ("std::string hi{\"hello\"}",
               repr_to_string(std::string("hello"), "hi"));
+
+    auto longstr = repr_to_string(std::string(100, 'x'));
+    EXPECT_TRUE(starts_with(longstr, "R\"(xxx")) << longstr;
+    EXPECT_TRUE(ends_with(longstr, "xxx)\"")) << longstr;
 }
 
 TEST(ReprTest, container)
@@ -73,6 +78,11 @@ TEST(ReprTest, container)
 
     std::string const strings[] = {"a", "", "special\nchars\t"};
     EXPECT_EQ("{\"a\", \"\", \"special\\nchars\\t\"}", repr_to_string(strings));
+
+    auto long_vec_str
+        = repr_to_string(std::vector<std::string>(10, std::string(75, 'x')));
+    cout << long_vec_str;
+    EXPECT_TRUE(ends_with(long_vec_str, ")\",}")) << long_vec_str;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/io/Repr.test.cc
+++ b/test/corecel/io/Repr.test.cc
@@ -79,10 +79,9 @@ TEST(ReprTest, container)
     std::string const strings[] = {"a", "", "special\nchars\t"};
     EXPECT_EQ("{\"a\", \"\", \"special\\nchars\\t\"}", repr_to_string(strings));
 
-    auto long_vec_str
-        = repr_to_string(std::vector<std::string>(10, std::string(75, 'x')));
-    cout << long_vec_str;
-    EXPECT_TRUE(ends_with(long_vec_str, ")\",}")) << long_vec_str;
+    std::vector<std::string> long_vec(20, std::string(10, 'x'));
+    auto long_vec_str = repr_to_string(long_vec);
+    EXPECT_TRUE(ends_with(long_vec_str, "\",}")) << long_vec_str;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This does two things to `repr` (used by PRINT_EXPECTED and other such utilities) to improve clang-formatting of the output:
1. Automatically format long strings (> 70) as [raw string literals](https://en.cppreference.com/w/cpp/language/string_literal) to keep clang-format from breaking them into multiple concatenated strings.
2. Add a trailing comma to containers that have a lot of characters, to force clang-format to indent them rather than to align them to the assignment operator.