### PR TITLE
Refactor action launcher components into kernel launcher

### DIFF
--- a/src/celeritas/em/model/BetheHeitlerModel.cu
+++ b/src/celeritas/em/model/BetheHeitlerModel.cu
@@ -29,7 +29,7 @@ void BetheHeitlerModel::step(CoreParams const& params,
         this->action_id(),
         InteractionApplier{BetheHeitlerExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/BraggModel.cu
+++ b/src/celeritas/em/model/BraggModel.cu
@@ -28,7 +28,7 @@ void BraggModel::step(CoreParams const& params, CoreStateDevice& state) const
         this->action_id(),
         InteractionApplier{BraggICRU73QOExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/CombinedBremModel.cu
+++ b/src/celeritas/em/model/CombinedBremModel.cu
@@ -29,7 +29,7 @@ void CombinedBremModel::step(CoreParams const& params,
         this->action_id(),
         InteractionApplier{CombinedBremExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/EPlusGGModel.cu
+++ b/src/celeritas/em/model/EPlusGGModel.cu
@@ -28,7 +28,7 @@ void EPlusGGModel::step(CoreParams const& params, CoreStateDevice& state) const
         this->action_id(),
         InteractionApplier{EPlusGGExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/ICRU73QOModel.cu
+++ b/src/celeritas/em/model/ICRU73QOModel.cu
@@ -28,7 +28,7 @@ void ICRU73QOModel::step(CoreParams const& params, CoreStateDevice& state) const
         this->action_id(),
         InteractionApplier{BraggICRU73QOExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/KleinNishinaModel.cu
+++ b/src/celeritas/em/model/KleinNishinaModel.cu
@@ -29,7 +29,7 @@ void KleinNishinaModel::step(CoreParams const& params,
         this->action_id(),
         InteractionApplier{KleinNishinaExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/LivermorePEModel.cu
+++ b/src/celeritas/em/model/LivermorePEModel.cu
@@ -29,7 +29,7 @@ void LivermorePEModel::step(CoreParams const& params,
         this->action_id(),
         InteractionApplier{LivermorePEExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/MollerBhabhaModel.cu
+++ b/src/celeritas/em/model/MollerBhabhaModel.cu
@@ -29,7 +29,7 @@ void MollerBhabhaModel::step(CoreParams const& params,
         this->action_id(),
         InteractionApplier{MollerBhabhaExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/MuBetheBlochModel.cu
+++ b/src/celeritas/em/model/MuBetheBlochModel.cu
@@ -29,7 +29,7 @@ void MuBetheBlochModel::step(CoreParams const& params,
         this->action_id(),
         InteractionApplier{MuBetheBlochExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/MuBremsstrahlungModel.cu
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.cu
@@ -29,7 +29,7 @@ void MuBremsstrahlungModel::step(CoreParams const& params,
         this->action_id(),
         InteractionApplier{MuBremsstrahlungExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/RayleighModel.cu
+++ b/src/celeritas/em/model/RayleighModel.cu
@@ -28,7 +28,7 @@ void RayleighModel::step(CoreParams const& params, CoreStateDevice& state) const
         this->action_id(),
         InteractionApplier{RayleighExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/RelativisticBremModel.cu
+++ b/src/celeritas/em/model/RelativisticBremModel.cu
@@ -29,7 +29,7 @@ void RelativisticBremModel::step(CoreParams const& params,
         this->action_id(),
         InteractionApplier{RelativisticBremExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/SeltzerBergerModel.cu
+++ b/src/celeritas/em/model/SeltzerBergerModel.cu
@@ -29,7 +29,7 @@ void SeltzerBergerModel::step(CoreParams const& params,
         this->action_id(),
         InteractionApplier{SeltzerBergerExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/geo/detail/BoundaryAction.cu
+++ b/src/celeritas/geo/detail/BoundaryAction.cu
@@ -30,7 +30,7 @@ void BoundaryAction::step(CoreParams const& params, CoreStateDevice& state) cons
                                               BoundaryExecutor{});
 
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -65,23 +65,23 @@ class ActionLauncher : public KernelLauncher<F>
     using ActionInterfaceT = CoreStepActionInterface;
 
   public:
-    // Create a launcher from a label, string, etc.
-    using KernelLauncher::KernelLauncher;
+    // Create a launcher from a string
+    using KernelLauncher<F>::KernelLauncher;
 
     //! Create a launcher from an action
     explicit ActionLauncher(ActionInterfaceT const& action)
-        : KernelLauncher{action.label()}
+        : ActionLauncher{action.label()}
     {
     }
 
     //! Create a launcher with a string extension
     ActionLauncher(ActionInterfaceT const& action, std::string_view ext)
-        : KernelLauncher{std::string(action.label()) + "-" + std::string(ext)}
+        : ActionLauncher{std::string(action.label()) + "-" + std::string(ext)}
     {
     }
 
     // Launch a kernel for a thread range, custom number of threads
-    using KernelLauncher::operator();
+    using KernelLauncher<F>::operator();
 
     //! Launch a kernel for the wrapped executor
     void operator()(CoreState<MemSpace::device> const& state,

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -71,9 +71,9 @@ class ActionLauncher : public KernelLauncher<F>
                     F const& call_thread) const;
 
     // Launch with reduced grid size for when tracks are sorted
-    void operator()(CoreParams const& params,
+    void operator()(StepActionT const& action,
+                    CoreParams const& params,
                     CoreState<MemSpace::device> const& state,
-                    StepActionT const& action,
                     F const& call_thread) const;
 };
 
@@ -114,12 +114,12 @@ void ActionLauncher<F>::operator()(CoreState<MemSpace::device> const& state,
 /*!
  * Launch with reduced grid size for when tracks are sorted.
  *
- * \todo Reorder arguments for consistency with ActionLauncher.hh
+ * These argument should be consistent with those in \c ActionLauncher.hh .
  */
 template<class F>
-void ActionLauncher<F>::operator()(CoreParams const& params,
+void ActionLauncher<F>::operator()(StepActionT const& action,
+                                   CoreParams const& params,
                                    CoreState<MemSpace::device> const& state,
-                                   StepActionT const& action,
                                    F const& call_thread) const
 {
     if (state.has_action_range()

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -121,16 +121,18 @@ void ActionLauncher<F>::operator()(CoreParams const& params,
                                    F const& call_thread) const
 {
     CELER_EXPECT(state.stream_id());
-    if (is_action_sorted(action.order(), params.init()->track_order()))
+    if (state.has_action_range()
+        && is_action_sorted(action.order(), params.init()->track_order()))
     {
+        // Launch on a subset of threads
         return (*this)(state.get_action_range(action.action_id()),
                        state.stream_id(),
                        call_thread);
     }
     else
     {
-        return (*this)(
-            range(ThreadId{state.size()}), state.stream_id(), call_thread);
+        // Not partitioned by action: launch on all threads
+        return (*this)(state, call_thread);
     }
 }
 

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -27,30 +27,19 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Profile and launch Celeritas kernels.
+ * Profile and launch core stepping loop kernels.
  *
- * The template argument \c F may define a member type named \c Applier.
- * \c F::Applier should have up to two static constexpr int variables named
- * \c max_block_size and/or \c min_warps_per_eu.
- * If present, the kernel will use appropriate \c __launch_bounds__.
- * If \c F::Applier::min_warps_per_eu exists then \c F::Applier::max_block_size
- * must also be present or we get a compile error.
- *
- * The semantics of the second \c __launch_bounds__ argument differs between
- * CUDA and HIP.  \c ActionLauncher expects HIP semantics. If Celeritas is
- * built targeting CUDA, it will automatically convert that argument to match
- * CUDA semantics.
- *
- * The CUDA-specific 3rd argument \c maxBlocksPerCluster is not supported.
+ * This is an extension to \c KernelLauncher which uses an action's label and
+ * takes core params/state to determine the launch size and/or action range.
  *
  * Example:
  * \code
  void FooAction::step(CoreParams const& params,
                       CoreStateDevice& state) const
  {
-    auto execute_thread = make_blah_executor(blah);
-    static ActionLauncher<decltype(execute_thread)> const launch_kernel(*this);
-    launch_kernel(state, execute_thread);
+   auto execute_thread = make_blah_executor(blah);
+   static ActionLauncher<decltype(execute_thread)> const launch_kernel(*this);
+   launch_kernel(state, execute_thread);
  }
  * \endcode
  */

--- a/src/celeritas/global/ActionLauncher.hh
+++ b/src/celeritas/global/ActionLauncher.hh
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <utility>
+
 #include "corecel/Config.hh"
 
 #include "corecel/Assert.hh"

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -143,6 +143,9 @@ class CoreState final : public CoreStateInterface
 
     //// TRACK SORTING ////
 
+    //! Return whether tracks can be sorted by action
+    bool has_action_range() const { return !offsets_.empty(); }
+
     // Get a range of sorted track slots about to undergo a given action
     Range<ThreadId> get_action_range(ActionId action_id) const;
 

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -27,6 +27,8 @@ namespace celeritas
  * Helper class to create views from core track data.
  *
  * TODO: const correctness? (Maybe have to wait till C++23's "deducing this"?)
+ *
+ * \todo Rename make_sim_view -> sim, etc.
  */
 class CoreTrackView
 {

--- a/src/celeritas/global/TrackExecutor.hh
+++ b/src/celeritas/global/TrackExecutor.hh
@@ -27,12 +27,11 @@ namespace celeritas
  *
  * This class can be used to call a functor that applies to \c CoreTrackView
  * using a \c ThreadId, so that the tracks can be easily looped over as a
- * group on CPU or GPU.
+ * group on CPU or GPU. It applies a remapping from \em thread to \em slot if
+ * the tracks are sorted. Otherwise, thread and track slot have the same
+ * numerical value.
  *
  * This is primarily used by \c ActionLauncher .
- *
- * TODO: maybe rename this \c ThreadExecutor (since it takes a thread?) and
- * call the embedded class a \c TrackExecutor (since it takes a CoreTrackView?)
  *
  * \code
 void foo_kernel(CoreParamsPtr const params,
@@ -46,6 +45,9 @@ void foo_kernel(CoreParamsPtr const params,
     }
 }
 \endcode
+ *
+ * \todo Rename to ThreadExecutor. The template parameter, which must operate
+ * on a core track view, is a track executor.
  */
 template<class T>
 class TrackExecutor
@@ -68,7 +70,7 @@ class TrackExecutor
     {
     }
 
-    //! Call the underlying function using the core track for this thread.
+    //! Call the underlying function, using indirection array if needed
     CELER_FUNCTION void operator()(ThreadId thread)
     {
         CELER_EXPECT(thread < state_->size());

--- a/src/celeritas/global/TrackExecutor.hh
+++ b/src/celeritas/global/TrackExecutor.hh
@@ -11,13 +11,11 @@
 #include "corecel/Types.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/sys/ThreadId.hh"
-#include "celeritas/track/SimTrackView.hh"
+#include "celeritas/track/SimFunctors.hh"
 
 #include "CoreTrackData.hh"
 #include "CoreTrackDataFwd.hh"
 #include "CoreTrackView.hh"
-
-#include "detail/TrackExecutorImpl.hh"
 
 namespace celeritas
 {
@@ -166,10 +164,8 @@ make_active_track_executor(CoreParamsPtr<MemSpace::native> params,
                            CoreStatePtr<MemSpace::native> const& state,
                            T&& apply_track)
 {
-    return ConditionalTrackExecutor{params,
-                                    state,
-                                    detail::AppliesValid{},
-                                    celeritas::forward<T>(apply_track)};
+    return ConditionalTrackExecutor{
+        params, state, AppliesValid{}, celeritas::forward<T>(apply_track)};
 }
 
 //---------------------------------------------------------------------------//
@@ -190,7 +186,7 @@ make_action_track_executor(CoreParamsPtr<MemSpace::native> params,
     CELER_EXPECT(action);
     return ConditionalTrackExecutor{params,
                                     state,
-                                    detail::IsStepActionEqual{action},
+                                    IsStepActionEqual{action},
                                     celeritas::forward<T>(apply_track)};
 }
 
@@ -208,7 +204,7 @@ make_along_step_track_executor(CoreParamsPtr<MemSpace::native> params,
     CELER_EXPECT(action);
     return ConditionalTrackExecutor{params,
                                     state,
-                                    detail::IsAlongStepActionEqual{action},
+                                    IsAlongStepActionEqual{action},
                                     celeritas::forward<T>(apply_track)};
 }
 

--- a/src/celeritas/global/TrackExecutor.hh
+++ b/src/celeritas/global/TrackExecutor.hh
@@ -88,8 +88,8 @@ class TrackExecutor
 /*!
  * Launch the track only when a certain condition applies to the sim state.
  *
- * The condition C must have the signature \code
- * <bool(SimTrackView const&)>
+ * The condition \c C must have the signature \code
+ * (SimTrackView const&) -> bool
   \endcode
  *
  * see \c make_active_track_executor for an example where this is used to apply

--- a/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepNeutralAction.cu
@@ -32,7 +32,7 @@ void AlongStepNeutralAction::step(CoreParams const& params,
                   detail::LinearPropagatorFactory{},
                   detail::NoELoss{}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepRZMapFieldMscAction.cu
@@ -44,7 +44,7 @@ void AlongStepRZMapFieldMscAction::step(CoreParams const& params,
                 field_->ref<MemSpace::native>()}});
         static ActionLauncher<decltype(execute_thread)> const launch_kernel(
             *this, "propagate-rzmap");
-        launch_kernel(params, state, *this, execute_thread);
+        launch_kernel(*this, params, state, execute_thread);
     }
     if (this->has_msc())
     {

--- a/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
+++ b/src/celeritas/global/alongstep/AlongStepUniformMscAction.cu
@@ -47,7 +47,7 @@ void AlongStepUniformMscAction::step(CoreParams const& params,
                 detail::UniformFieldPropagatorFactory{field_params_}});
         static ActionLauncher<decltype(execute_thread)> const launch_kernel(
             *this, "propagate");
-        launch_kernel(params, state, *this, execute_thread);
+        launch_kernel(*this, params, state, execute_thread);
     }
     if (this->has_msc())
     {

--- a/src/celeritas/global/alongstep/detail/AlongStepKernels.cu
+++ b/src/celeritas/global/alongstep/detail/AlongStepKernels.cu
@@ -45,7 +45,7 @@ void launch_limit_msc_step(CoreStepActionInterface const& action,
         detail::MscStepLimitApplier{UrbanMsc{msc_data}});
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(
         action, "limit-step-msc-urban");
-    launch_kernel(params, state, action, execute_thread);
+    launch_kernel(action, params, state, execute_thread);
 }
 
 //---------------------------------------------------------------------------//
@@ -62,7 +62,7 @@ void launch_propagate(CoreStepActionInterface const& action,
         detail::PropagationApplier{detail::LinearPropagatorFactory{}});
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(
         action, "propagate-linear");
-    launch_kernel(params, state, action, execute_thread);
+    launch_kernel(action, params, state, execute_thread);
 }
 
 //---------------------------------------------------------------------------//
@@ -80,7 +80,7 @@ void launch_apply_msc(CoreStepActionInterface const& action,
         detail::MscApplier{UrbanMsc{msc_data}});
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(
         action, "scatter-msc-urban");
-    launch_kernel(params, state, action, execute_thread);
+    launch_kernel(action, params, state, execute_thread);
 }
 
 //---------------------------------------------------------------------------//
@@ -97,7 +97,7 @@ void launch_update_time(CoreStepActionInterface const& action,
                                          detail::TimeUpdater{});
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(
         action, "update-time");
-    launch_kernel(params, state, action, execute_thread);
+    launch_kernel(action, params, state, execute_thread);
 }
 
 //---------------------------------------------------------------------------//
@@ -115,7 +115,7 @@ void launch_apply_eloss(CoreStepActionInterface const& action,
         detail::ElossApplier{detail::FluctELoss{fluct}});
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(
         action, "apply-eloss-fluct");
-    launch_kernel(params, state, action, execute_thread);
+    launch_kernel(action, params, state, execute_thread);
 }
 
 //---------------------------------------------------------------------------//
@@ -132,7 +132,7 @@ void launch_apply_eloss(CoreStepActionInterface const& action,
         detail::ElossApplier{detail::MeanELoss{}});
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(
         action, "apply-eloss-mean");
-    launch_kernel(params, state, action, execute_thread);
+    launch_kernel(action, params, state, execute_thread);
 }
 
 //---------------------------------------------------------------------------//
@@ -148,7 +148,7 @@ void launch_update_track(CoreStepActionInterface const& action,
                                          detail::TrackUpdater{});
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(
         action, "update-track");
-    launch_kernel(params, state, action, execute_thread);
+    launch_kernel(action, params, state, execute_thread);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/alongstep/detail/PropagationApplier.hh
+++ b/src/celeritas/global/alongstep/detail/PropagationApplier.hh
@@ -10,8 +10,8 @@
 #include <type_traits>
 
 #include "corecel/math/Algorithms.hh"
+#include "corecel/sys/KernelTraits.hh"
 #include "celeritas/global/CoreTrackView.hh"
-#include "celeritas/global/detail/ApplierTraits.hh"
 
 #if !CELER_DEVICE_COMPILE
 #    include "corecel/io/Logger.hh"

--- a/src/celeritas/global/detail/CoreStateThreadOffsets.hh
+++ b/src/celeritas/global/detail/CoreStateThreadOffsets.hh
@@ -52,6 +52,9 @@ class CoreStateThreadOffsets<MemSpace::host>
     //! Initialize using the number of actions
     void resize(size_type n) { celeritas::resize(&thread_offsets_, n); }
 
+    //! Whether any offsets are present
+    bool empty() const { return thread_offsets_.empty(); }
+
   private:
     NativeActionThreads thread_offsets_;
 };
@@ -92,6 +95,9 @@ class CoreStateThreadOffsets<MemSpace::device>
         celeritas::resize(&thread_offsets_, n);
         celeritas::resize(&host_thread_offsets_, n);
     }
+
+    //! Whether any offsets are present
+    bool empty() const { return thread_offsets_.empty(); }
 
   private:
     NativeActionThreads thread_offsets_;

--- a/src/celeritas/neutron/model/ChipsNeutronElasticModel.cu
+++ b/src/celeritas/neutron/model/ChipsNeutronElasticModel.cu
@@ -29,7 +29,7 @@ void ChipsNeutronElasticModel::step(CoreParams const& params,
         this->action_id(),
         InteractionApplier{ChipsNeutronElasticExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/InteractionApplier.hh
+++ b/src/celeritas/phys/InteractionApplier.hh
@@ -9,11 +9,11 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/sys/KernelTraits.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/geo/GeoFwd.hh"
 #include "celeritas/global/CoreTrackView.hh"
-#include "celeritas/global/detail/ApplierTraits.hh"
 #include "celeritas/track/SimTrackView.hh"
 
 #include "CutoffView.hh"
@@ -62,8 +62,7 @@ struct InteractionApplier : public InteractionApplierBaseImpl<F>
 };
 
 template<class F>
-struct InteractionApplier<F,
-                          std::enable_if_t<detail::kernel_max_blocks_min_warps<F>>>
+struct InteractionApplier<F, std::enable_if_t<kernel_max_blocks_min_warps<F>>>
     : public InteractionApplierBaseImpl<F>
 {
     static constexpr int max_block_size = F::max_block_size;
@@ -76,7 +75,7 @@ struct InteractionApplier<F,
 };
 
 template<class F>
-struct InteractionApplier<F, std::enable_if_t<detail::kernel_max_blocks<F>>>
+struct InteractionApplier<F, std::enable_if_t<kernel_max_blocks<F>>>
     : public InteractionApplierBaseImpl<F>
 {
     static constexpr int max_block_size = F::max_block_size;

--- a/src/celeritas/phys/detail/TrackingCutAction.cu
+++ b/src/celeritas/phys/detail/TrackingCutAction.cu
@@ -31,7 +31,7 @@ void TrackingCutAction::step(CoreParams const& params,
                                               TrackingCutExecutor{});
 
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(params, state, *this, execute);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/SimFunctors.hh
+++ b/src/celeritas/track/SimFunctors.hh
@@ -3,18 +3,17 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/global/detail/TrackExecutorImpl.hh
+//! \file celeritas/sim/SimFunctors.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include "corecel/Assert.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/track/SimTrackView.hh"
+
+#include "SimTrackView.hh"
 
 namespace celeritas
-{
-namespace detail
 {
 //---------------------------------------------------------------------------//
 // CONDITIONS
@@ -61,5 +60,4 @@ struct IsAlongStepActionEqual
 };
 
 //---------------------------------------------------------------------------//
-}  // namespace detail
 }  // namespace celeritas

--- a/src/celeritas/user/detail/SimpleCaloExecutor.hh
+++ b/src/celeritas/user/detail/SimpleCaloExecutor.hh
@@ -29,8 +29,8 @@ namespace detail
  */
 struct SimpleCaloExecutor
 {
-    NativeRef<StepStateData> const& step;
-    NativeRef<SimpleCaloStateData>& calo;
+    NativeRef<StepStateData> const step;
+    NativeRef<SimpleCaloStateData> calo;
 
     inline CELER_FUNCTION void operator()(TrackSlotId tid);
     CELER_FORCEINLINE_FUNCTION void operator()(ThreadId tid)

--- a/src/celeritas/user/detail/SimpleCaloImpl.cu
+++ b/src/celeritas/user/detail/SimpleCaloImpl.cu
@@ -10,14 +10,12 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelLauncher.device.hh"
 
-#include "SimpleCaloExecutor.hh"  // IWYU pragma: associated
+#include "SimpleCaloExecutor.hh"
 
 namespace celeritas
 {
 namespace detail
 {
-//---------------------------------------------------------------------------//
-// KERNEL INTERFACE
 //---------------------------------------------------------------------------//
 /*!
  * Accumulate energy deposition on device.

--- a/src/corecel/sys/KernelLauncher.device.hh
+++ b/src/corecel/sys/KernelLauncher.device.hh
@@ -117,6 +117,13 @@ void KernelLauncher<F>::operator()(Range<ThreadId> threads,
 //---------------------------------------------------------------------------//
 /*!
  * Launch a kernel with a custom number of threads.
+ *
+ * The launch arguments have the same ordering as CUDA/HIP kernel launch
+ * arguments.
+ *
+ * \param num_threads Total number of active consecutive threads
+ * \param stream_id Execute the kernel on this device stream
+ * \param call_thread Call the given functor with the thread ID
  */
 template<class F>
 void KernelLauncher<F>::operator()(size_type num_threads,

--- a/src/corecel/sys/KernelLauncher.device.hh
+++ b/src/corecel/sys/KernelLauncher.device.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/global/ActionLauncher.device.hh
+//! \file corecel/sys/KernelLauncher.device.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -15,13 +15,14 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/Range.hh"
-#include "corecel/sys/KernelLauncher.device.hh"
-#include "corecel/sys/ThreadId.hh"
-#include "celeritas/track/TrackInitParams.hh"
 
-#include "ActionInterface.hh"
-#include "CoreParams.hh"
-#include "CoreState.hh"
+#include "Device.hh"
+#include "KernelParamCalculator.device.hh"
+#include "KernelTraits.hh"
+#include "Stream.hh"
+#include "ThreadId.hh"
+
+#include "detail/KernelLauncherImpl.device.hh"
 
 namespace celeritas
 {
@@ -37,7 +38,7 @@ namespace celeritas
  * must also be present or we get a compile error.
  *
  * The semantics of the second \c __launch_bounds__ argument differs between
- * CUDA and HIP.  \c ActionLauncher expects HIP semantics. If Celeritas is
+ * CUDA and HIP.  \c KernelLauncher expects HIP semantics. If Celeritas is
  * built targeting CUDA, it will automatically convert that argument to match
  * CUDA semantics.
  *
@@ -45,71 +46,58 @@ namespace celeritas
  *
  * Example:
  * \code
- void FooAction::step(CoreParams const& params,
-                         CoreStateDevice& state) const
+ void FooAction::launch_kernel(size_type count) const
  {
     auto execute_thread = make_blah_executor(blah);
-    static ActionLauncher<decltype(execute_thread)> const launch_kernel(*this);
+    static KernelLauncher<decltype(execute_thread)> const launch_kernel(*this);
     launch_kernel(state, execute_thread);
  }
  * \endcode
  */
 template<class F>
-class ActionLauncher : public KernelLauncher<F>
+class KernelLauncher
 {
     static_assert((std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP
                    || CELER_COMPILER == CELER_COMPILER_CLANG)
                       && !std::is_pointer_v<F> && !std::is_reference_v<F>,
                   "Launched action must be a trivially copyable function "
                   "object");
-    using ActionInterfaceT = CoreStepActionInterface;
 
   public:
-    // Create a launcher from a label, string, etc.
-    using KernelLauncher::KernelLauncher;
-
-    //! Create a launcher from an action
-    explicit ActionLauncher(ActionInterfaceT const& action)
-        : KernelLauncher{action.label()}
+    //! Create a launcher from a label
+    explicit KernelLauncher(std::string_view name)
+        : calc_launch_params_{name, &detail::launch_action_impl<F>}
     {
     }
 
-    //! Create a launcher with a string extension
-    ActionLauncher(ActionInterfaceT const& action, std::string_view ext)
-        : KernelLauncher{std::string(action.label()) + "-" + std::string(ext)}
-    {
-    }
-
-    // Launch a kernel for a thread range, custom number of threads
-    using KernelLauncher::operator();
-
-    //! Launch a kernel for the wrapped executor
-    void operator()(CoreState<MemSpace::device> const& state,
+    //! Launch a kernel for a thread range
+    void operator()(Range<ThreadId> threads,
+                    StreamId stream_id,
                     F const& call_thread) const
     {
-        return (*this)(
-            range(ThreadId{state.size()}), state.stream_id(), call_thread);
+        if (!threads.empty())
+        {
+            using StreamT = CELER_DEVICE_PREFIX(Stream_t);
+            StreamT stream = celeritas::device().stream(stream_id).get();
+            auto config = calc_launch_params_(threads.size());
+            detail::launch_action_impl<F>
+                <<<config.blocks_per_grid, config.threads_per_block, 0, stream>>>(
+                    threads, call_thread);
+        }
     }
 
-    //! Launch with reduced grid size for when tracks are sorted
-    void operator()(CoreParams const& params,
-                    CoreState<MemSpace::device> const& state,
-                    ActionInterfaceT const& action,
+    //! Launch a kernel with a custom number of threads
+    void operator()(size_type num_threads,
+                    StreamId stream_id,
                     F const& call_thread) const
     {
-        CELER_EXPECT(state.stream_id());
-        if (is_action_sorted(action.order(), params.init()->track_order()))
-        {
-            return (*this)(state.get_action_range(action.action_id()),
-                           state.stream_id(),
-                           call_thread);
-        }
-        else
-        {
-            return (*this)(
-                range(ThreadId{state.size()}), state.stream_id(), call_thread);
-        }
+        CELER_EXPECT(num_threads > 0);
+        CELER_EXPECT(stream_id);
+        (*this)(range(ThreadId{num_threads}), stream_id, call_thread);
     }
+
+  private:
+    KernelParamCalculator calc_launch_params_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/KernelLauncher.device.hh
+++ b/src/corecel/sys/KernelLauncher.device.hh
@@ -49,19 +49,19 @@ namespace celeritas
  void FooAction::launch_kernel(size_type count) const
  {
     auto execute_thread = make_blah_executor(blah);
-    static KernelLauncher<decltype(execute_thread)> const launch_kernel(*this);
-    launch_kernel(state, execute_thread);
+    static KernelLauncher<decltype(execute_thread)> const
+ launch_kernel("blah"); launch_kernel(state, execute_thread);
  }
  * \endcode
  */
 template<class F>
 class KernelLauncher
 {
-    static_assert((std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP
-                   || CELER_COMPILER == CELER_COMPILER_CLANG)
-                      && !std::is_pointer_v<F> && !std::is_reference_v<F>,
-                  "Launched action must be a trivially copyable function "
-                  "object");
+    static_assert(
+        (std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP
+         || CELER_COMPILER == CELER_COMPILER_CLANG)
+            && !std::is_pointer_v<F> && !std::is_reference_v<F>,
+        R"(Launched action must be a trivially copyable function object)");
 
   public:
     // Create a launcher from a label
@@ -88,7 +88,7 @@ class KernelLauncher
  * Create a launcher from a label.
  */
 template<class F>
-explicit KernelLauncher<F>::KernelLauncher(std::string_view name)
+KernelLauncher<F>::KernelLauncher(std::string_view name)
     : calc_launch_params_{name, &detail::launch_action_impl<F>}
 {
 }

--- a/src/corecel/sys/KernelLauncher.device.hh
+++ b/src/corecel/sys/KernelLauncher.device.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <string_view>
 #include <type_traits>
 
 #include "corecel/DeviceRuntimeApi.hh"
@@ -18,7 +19,6 @@
 
 #include "Device.hh"
 #include "KernelParamCalculator.device.hh"
-#include "KernelTraits.hh"
 #include "Stream.hh"
 #include "ThreadId.hh"
 

--- a/src/corecel/sys/KernelLauncher.device.hh
+++ b/src/corecel/sys/KernelLauncher.device.hh
@@ -50,7 +50,8 @@ namespace celeritas
  {
     auto execute_thread = make_blah_executor(blah);
     static KernelLauncher<decltype(execute_thread)> const
- launch_kernel("blah"); launch_kernel(state, execute_thread);
+ launch_kernel("blah");
+    launch_kernel(state, execute_thread);
  }
  * \endcode
  */

--- a/src/corecel/sys/KernelParamCalculator.device.hh
+++ b/src/corecel/sys/KernelParamCalculator.device.hh
@@ -22,6 +22,7 @@
 #include "KernelAttributes.hh"
 #include "ThreadId.hh"  // IWYU pragma: export
 
+//---------------------------------------------------------------------------//
 /*!
  * \def CELER_LAUNCH_KERNEL
  *

--- a/src/corecel/sys/KernelTraits.hh
+++ b/src/corecel/sys/KernelTraits.hh
@@ -1,0 +1,29 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/KernelTraits.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "detail/KernelTraitsImpl.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+//! Predicates used for \c __launch_bounds__ arguments
+template<typename T>
+inline constexpr bool kernel_no_bound
+    = !detail::has_max_block_size_v<T> && !detail::has_min_warps_per_eu_v<T>;
+
+template<typename T>
+inline constexpr bool kernel_max_blocks
+    = detail::has_max_block_size_v<T> && !detail::has_min_warps_per_eu_v<T>;
+
+template<typename T>
+inline constexpr bool kernel_max_blocks_min_warps
+    = detail::has_max_block_size_v<T> && detail::has_min_warps_per_eu_v<T>;
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/sys/detail/KernelLauncherImpl.device.hh
+++ b/src/corecel/sys/detail/KernelLauncherImpl.device.hh
@@ -8,13 +8,13 @@
 #pragma once
 
 #include "corecel/Config.hh"
+#include "corecel/DeviceRuntimeApi.hh"
 
 #include "corecel/Macros.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
+#include "corecel/sys/KernelTraits.hh"
 #include "corecel/sys/ThreadId.hh"
-
-#include "ApplierTraits.hh"
 
 namespace celeritas
 {

--- a/src/corecel/sys/detail/KernelLauncherImpl.device.hh
+++ b/src/corecel/sys/detail/KernelLauncherImpl.device.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/global/detail/ActionLauncherKernel.device.hh
+//! \file corecel/sys/detail/KernelLauncherImpl.device.hh
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/corecel/sys/detail/KernelTraitsImpl.hh
+++ b/src/corecel/sys/detail/KernelTraitsImpl.hh
@@ -1,9 +1,9 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2023-2024 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/global/detail/ApplierTraits.hh
+//! \file corecel/sys/detail/KernelTraitsImpl.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -59,20 +59,6 @@ struct HasApplier<T, std::void_t<typename T::Applier>> : std::true_type
 
 template<typename T>
 inline constexpr bool has_applier_v = HasApplier<T>::value;
-
-//---------------------------------------------------------------------------//
-//! Predicates used for \c __launch_bounds__ arguments
-template<typename T>
-inline constexpr bool kernel_no_bound
-    = !has_max_block_size_v<T> && !has_min_warps_per_eu_v<T>;
-
-template<typename T>
-inline constexpr bool kernel_max_blocks
-    = has_max_block_size_v<T> && !has_min_warps_per_eu_v<T>;
-
-template<typename T>
-inline constexpr bool kernel_max_blocks_min_warps
-    = has_max_block_size_v<T> && has_min_warps_per_eu_v<T>;
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/geocel/rasterize/RaytraceImager.device.t.hh
+++ b/src/geocel/rasterize/RaytraceImager.device.t.hh
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 /*!
- * \file geocel/rasterize/RaytraceImager.cuda.t.hh
+ * \file geocel/rasterize/RaytraceImager.device.t.hh
  * \brief Template definition file for \c RaytraceImager .
  *
  * Include this file in a .cu file and instantiate it explicitly. When
@@ -16,32 +16,12 @@
 
 #include "geocel/rasterize/RaytraceImager.hh"
 
-#include "corecel/Config.hh"
-
-#include "corecel/Macros.hh"
-#include "corecel/sys/KernelParamCalculator.device.hh"
-#include "corecel/sys/ThreadId.hh"
+#include "corecel/sys/KernelLauncher.device.hh"
 
 #include "detail/RaytraceExecutor.hh"
 
 namespace celeritas
 {
-namespace
-{
-//---------------------------------------------------------------------------//
-template<class F>
-__global__ void __launch_bounds__(CELERITAS_MAX_BLOCK_SIZE)
-    raytrace_kernel(ThreadId::size_type num_threads, F execute_thread)
-{
-    auto tid = celeritas::KernelParamCalculator::thread_id();
-    if (!(tid < num_threads))
-        return;
-    execute_thread(tid);
-}
-
-//---------------------------------------------------------------------------//
-}  // namespace
-
 //---------------------------------------------------------------------------//
 /*!
  * Launch the raytrace kernel on device.
@@ -54,17 +34,13 @@ void RaytraceImager<G>::launch_raytrace_kernel(
     ImageStateRef<MemSpace::device> const& img_states) const
 {
     using CalcId = detail::VolumeIdCalculator;
-    using Executor = detail::RaytraceExecutor<GeoTrackView, CalcId>;
 
-    static KernelParamCalculator const calc_launch_params{
-        "raytrace", &raytrace_kernel<Executor>};
-    auto config = calc_launch_params(geo_states.size());
-    raytrace_kernel<Executor>
-        <<<config.blocks_per_grid, config.threads_per_block, 0>>>(
-            geo_states.size(),
-            Executor{geo_params, geo_states, img_params, img_states, CalcId{}});
+    detail::RaytraceExecutor<GeoTrackView, CalcId> execute_thread{
+        geo_params, geo_states, img_params, img_states, CalcId{}};
 
-    CELER_DEVICE_CALL_PREFIX(DeviceSynchronize());
+    static ActionLauncher<decltype(execute_thread)> const launch_kernel{
+        std::string{"raytrace-"} + GeoTraits<G>::name};
+    launch_kernel(geo_states.size(), StreamId{0}, execute_thread);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/rasterize/RaytraceImager.device.t.hh
+++ b/src/geocel/rasterize/RaytraceImager.device.t.hh
@@ -38,7 +38,7 @@ void RaytraceImager<G>::launch_raytrace_kernel(
     detail::RaytraceExecutor<GeoTrackView, CalcId> execute_thread{
         geo_params, geo_states, img_params, img_states, CalcId{}};
 
-    static ActionLauncher<decltype(execute_thread)> const launch_kernel{
+    static KernelLauncher<decltype(execute_thread)> const launch_kernel{
         std::string{"raytrace-"} + GeoTraits<G>::name};
     launch_kernel(geo_states.size(), StreamId{0}, execute_thread);
 }

--- a/src/geocel/vg/RaytraceImager.cu
+++ b/src/geocel/vg/RaytraceImager.cu
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "RaytraceImager.hh"
 
-#include "geocel/rasterize/RaytraceImager.cuda.t.hh"
+#include "geocel/rasterize/RaytraceImager.device.t.hh"
 
 #include "VecgeomData.hh"
 #include "VecgeomGeoTraits.hh"

--- a/src/orange/RaytraceImager.cu
+++ b/src/orange/RaytraceImager.cu
@@ -7,7 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "RaytraceImager.hh"
 
-#include "geocel/rasterize/RaytraceImager.cuda.t.hh"
+#include "geocel/rasterize/RaytraceImager.device.t.hh"
 
 #include "OrangeData.hh"
 #include "OrangeGeoTraits.hh"


### PR DESCRIPTION
This splits up the action launcher and traits into a generic "Kernel launcher", which contains all the complexity of thread ranges, block sizes, etc.; and "action launcher" which only applies to core data and extracts the state size/stream. The kernel launcher can be reused for things that *aren't* actions (e.g., raytrace and step collectors and **optical physics kernels**), and the kernel traits can now be safely reused without violating our "detail" convention.