### PR TITLE
Add optical core track view and launcher

### DIFF
--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -77,9 +77,9 @@ list(APPEND SOURCES
   optical/CerenkovParams.cc
   optical/CoreParams.cc
   optical/CoreState.cc
+  optical/CoreTrackData.cc
   optical/OpticalCollector.cc
   optical/MaterialParams.cc
-  optical/TrackData.cc
   optical/TrackInitParams.cc
   optical/ScintillationParams.cc
   optical/action/ActionGroups.cc

--- a/src/celeritas/optical/CoreParams.hh
+++ b/src/celeritas/optical/CoreParams.hh
@@ -14,7 +14,7 @@
 #include "celeritas/geo/GeoFwd.hh"
 #include "celeritas/random/RngParamsFwd.hh"
 
-#include "TrackData.hh"
+#include "CoreTrackData.hh"
 
 namespace celeritas
 {

--- a/src/celeritas/optical/CoreState.hh
+++ b/src/celeritas/optical/CoreState.hh
@@ -14,7 +14,7 @@
 #include "celeritas/Types.hh"
 #include "celeritas/track/CoreStateCounters.hh"
 
-#include "TrackData.hh"
+#include "CoreTrackData.hh"
 #include "TrackInitializer.hh"
 
 namespace celeritas

--- a/src/celeritas/optical/CoreTrackData.cc
+++ b/src/celeritas/optical/CoreTrackData.cc
@@ -35,7 +35,6 @@ void resize(CoreStateData<Ownership::value, M>* state,
     // Geant4 state is stream-local
     resize(&state->geometry, params.geometry, stream_id, size);
 #endif
-    resize(&state->materials, size);
     resize(&state->physics, params.physics, size);
     resize(&state->rng, params.rng, stream_id, size);
     resize(&state->sim, params.sim, size);

--- a/src/celeritas/optical/CoreTrackData.cc
+++ b/src/celeritas/optical/CoreTrackData.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/optical/TrackData.cc
+//! \file celeritas/optical/CoreTrackData.cc
 //---------------------------------------------------------------------------//
-#include "TrackData.hh"
+#include "CoreTrackData.hh"
 
 #include "corecel/data/CollectionBuilder.hh"
 

--- a/src/celeritas/optical/CoreTrackData.hh
+++ b/src/celeritas/optical/CoreTrackData.hh
@@ -136,8 +136,7 @@ struct CoreStateData
     //! Whether the data are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return geometry && physics && rng && sim && init
-               && stream_id;
+        return geometry && physics && rng && sim && init && stream_id;
     }
 
     //! Assign from another set of data

--- a/src/celeritas/optical/CoreTrackData.hh
+++ b/src/celeritas/optical/CoreTrackData.hh
@@ -121,7 +121,7 @@ struct CoreStateData
     using Items = StateCollection<T, W, M>;
 
     GeoStateData<W, M> geometry;
-    Items<OpticalMaterialId> materials;
+    // TODO: should we cache the material ID?
     PhysicsStateData<W, M> physics;
     RngStateData<W, M> rng;
     SimStateData<W, M> sim;  // TODO: has a few things we don't need
@@ -136,7 +136,7 @@ struct CoreStateData
     //! Whether the data are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return geometry && !materials.empty() && physics && rng && sim && init
+        return geometry && physics && rng && sim && init
                && stream_id;
     }
 
@@ -146,7 +146,6 @@ struct CoreStateData
     {
         CELER_EXPECT(other);
         geometry = other.geometry;
-        materials = other.materials;
         physics = other.physics;
         rng = other.rng;
         sim = other.sim;

--- a/src/celeritas/optical/CoreTrackData.hh
+++ b/src/celeritas/optical/CoreTrackData.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/optical/TrackData.hh
+//! \file celeritas/optical/CoreTrackData.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -14,6 +14,7 @@
 #include "celeritas/random/RngData.hh"
 #include "celeritas/track/SimData.hh"
 
+#include "CoreTrackDataFwd.hh"
 #include "MaterialData.hh"
 #include "TrackInitData.hh"
 #include "Types.hh"

--- a/src/celeritas/optical/CoreTrackDataFwd.hh
+++ b/src/celeritas/optical/CoreTrackDataFwd.hh
@@ -1,0 +1,31 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2022-2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/optical/CoreTrackDataFwd.hh
+//! \brief Forward declarations for some structs defined in CoreTrackData.
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Types.hh"
+
+namespace celeritas
+{
+namespace optical
+{
+//---------------------------------------------------------------------------//
+template<Ownership W, MemSpace M>
+struct CoreParamsData;
+
+template<Ownership W, MemSpace M>
+struct CoreStateData;
+
+template<MemSpace M>
+using CoreParamsPtr = CRefPtr<CoreParamsData, M>;
+template<MemSpace M>
+using CoreStatePtr = RefPtr<CoreStateData, M>;
+
+//---------------------------------------------------------------------------//
+}  // namespace optical
+}  // namespace celeritas

--- a/src/celeritas/optical/CoreTrackView.hh
+++ b/src/celeritas/optical/CoreTrackView.hh
@@ -50,7 +50,7 @@ class CoreTrackView
     // Return a simulation management view
     inline CELER_FUNCTION SimTrackView sim() const;
 
-    // Return a particle view
+    // Return a physics view
     inline CELER_FUNCTION TrackView physics() const;
 
     // Return an RNG engine

--- a/src/celeritas/optical/CoreTrackView.hh
+++ b/src/celeritas/optical/CoreTrackView.hh
@@ -1,0 +1,186 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/optical/CoreTrackView.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "celeritas/geo/GeoTrackView.hh"
+#include "celeritas/random/RngEngine.hh"
+#include "celeritas/track/SimTrackView.hh"
+
+#include "CoreTrackData.hh"
+#include "MaterialView.hh"
+#include "TrackView.hh"
+
+namespace celeritas
+{
+namespace optical
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Access all core properties of a physics track.
+ */
+class CoreTrackView
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using ParamsRef = NativeCRef<CoreParamsData>;
+    using StateRef = NativeRef<CoreStateData>;
+    //!@}
+
+  public:
+    // Construct directly from a track slot ID
+    inline CELER_FUNCTION CoreTrackView(ParamsRef const& params,
+                                        StateRef const& states,
+                                        TrackSlotId slot);
+
+    // Return a geometry view
+    inline CELER_FUNCTION GeoTrackView geometry() const;
+
+    // Return a material view
+    inline CELER_FUNCTION MaterialView material() const;
+
+    // Return a material view (using an existing geo view
+    inline CELER_FUNCTION MaterialView material(GeoTrackView const&) const;
+
+    // Return a simulation management view
+    inline CELER_FUNCTION SimTrackView sim() const;
+
+    // Return a particle view
+    inline CELER_FUNCTION TrackView physics() const;
+
+    // Return an RNG engine
+    inline CELER_FUNCTION RngEngine rng() const;
+
+    // Get the track's index among the states
+    inline CELER_FUNCTION TrackSlotId track_slot_id() const;
+
+    // Action ID for encountering a geometry boundary
+    inline CELER_FUNCTION ActionId boundary_action() const;
+
+    // Flag a track for deletion
+    void apply_errored();
+
+  private:
+    ParamsRef const& params_;
+    StateRef const& states_;
+    TrackSlotId const track_slot_id_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with comprehensive param/state data and track slot.
+ *
+ * For optical tracks, the value of the track slot is the same as the track ID.
+ */
+CELER_FUNCTION
+CoreTrackView::CoreTrackView(ParamsRef const& params,
+                             StateRef const& states,
+                             TrackSlotId track_slot)
+    : params_(params), states_(states), track_slot_id_(track_slot)
+{
+    CELER_EXPECT(track_slot_id_ < states_.size());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a geometry view.
+ */
+CELER_FUNCTION auto CoreTrackView::geometry() const -> GeoTrackView
+{
+    return GeoTrackView{
+        params_.geometry, states_.geometry, this->track_slot_id()};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a material view.
+ */
+CELER_FORCEINLINE_FUNCTION auto CoreTrackView::material() const -> MaterialView
+{
+    return this->material(this->geometry());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a material view using an existing geo track view.
+ */
+CELER_FUNCTION auto
+CoreTrackView::material(GeoTrackView const& geo) const -> MaterialView
+{
+    CELER_EXPECT(!geo.is_outside());
+    return MaterialView{params_.material, geo.volume_id()};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a physics view.
+ */
+CELER_FUNCTION auto CoreTrackView::physics() const -> TrackView
+{
+    CELER_NOT_IMPLEMENTED("physics track view");
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return the RNG engine.
+ */
+CELER_FUNCTION auto CoreTrackView::rng() const -> RngEngine
+{
+    return RngEngine{params_.rng, states_.rng, this->track_slot_id()};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a simulation management view.
+ */
+CELER_FUNCTION SimTrackView CoreTrackView::sim() const
+{
+    return SimTrackView{params_.sim, states_.sim, this->track_slot_id()};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the track's index among the states.
+ */
+CELER_FORCEINLINE_FUNCTION TrackSlotId CoreTrackView::track_slot_id() const
+{
+    return track_slot_id_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the action ID for encountering a geometry boundary.
+ */
+CELER_FUNCTION ActionId CoreTrackView::boundary_action() const
+{
+    return params_.scalars.boundary_action;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set the 'errored' flag and tracking cut post-step action.
+ *
+ * \pre This cannot be applied if the current action is *after* post-step. (You
+ * can't guarantee for example that sensitive detectors will pick up the energy
+ * deposition.)
+ *
+ * \todo Add a tracking cut action? Currently the track is simply killed.
+ */
+CELER_FUNCTION void CoreTrackView::apply_errored()
+{
+    auto sim = this->sim();
+    CELER_EXPECT(is_track_valid(sim.status()));
+    sim.status(TrackStatus::killed);
+    sim.post_step_action({});
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace optical
+}  // namespace celeritas

--- a/src/celeritas/optical/TrackView.hh
+++ b/src/celeritas/optical/TrackView.hh
@@ -19,6 +19,7 @@ namespace optical
  * Temporary class for testing optical interactors.
  *
  * \todo Fill with actual code.
+ * \todo Rename ParticleTrackView (?) Should polarization live here as well?
  */
 class TrackView
 {

--- a/src/celeritas/optical/action/ActionLauncher.device.hh
+++ b/src/celeritas/optical/action/ActionLauncher.device.hh
@@ -1,0 +1,112 @@
+//---------------------------------*-CUDA-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/optical/action/ActionLauncher.device.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <type_traits>
+
+#include "corecel/DeviceRuntimeApi.hh"
+
+#include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/cont/Range.hh"
+#include "corecel/sys/KernelLauncher.device.hh"
+#include "corecel/sys/ThreadId.hh"
+#include "celeritas/optical/CoreParams.hh"
+#include "celeritas/optical/CoreState.hh"
+#include "celeritas/track/TrackInitParams.hh"
+
+#include "ActionInterface.hh"
+
+namespace celeritas
+{
+namespace optical
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Profile and launch optical stepping loop kernels.
+ *
+ * This is an extension to \c KernelLauncher which uses an action's label and
+ * takes the optical state to determine the launch size. The "call thread"
+ * operation (thread executor) should contain the params and state.
+ *
+ * Example:
+ * \code
+ void FooAction::step(CoreParams const& params,
+                      CoreStateDevice& state) const
+ {
+   auto execute_thread = make_blah_executor(blah);
+   static ActionLauncher<decltype(execute_thread)> const launch_kernel(*this);
+   launch_kernel(state, execute_thread);
+ }
+ * \endcode
+ */
+template<class F>
+class ActionLauncher : public KernelLauncher<F>
+{
+    static_assert(
+        (std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP
+         || CELER_COMPILER == CELER_COMPILER_CLANG)
+            && !std::is_pointer_v<F> && !std::is_reference_v<F>,
+        R"(Launched action must be a trivially copyable function object)");
+    using StepActionT = OpticalStepActionInterface;
+
+  public:
+    // Create a launcher from a string
+    using KernelLauncher<F>::KernelLauncher;
+
+    // Create a launcher from an action
+    explicit ActionLauncher(StepActionT const& action);
+
+    // Create a launcher with a string extension
+    ActionLauncher(StepActionT const& action, std::string_view ext);
+
+    // Launch a kernel for a thread range or number of threads
+    using KernelLauncher<F>::operator();
+
+    // Launch a kernel for the wrapped executor
+    void operator()(CoreState<MemSpace::device> const& state,
+                    F const& call_thread) const;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create a launcher from an action.
+ */
+template<class F>
+ActionLauncher<F>::ActionLauncher(StepActionT const& action)
+    : ActionLauncher{action.label()}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create a launcher with a string extension.
+ */
+template<class F>
+ActionLauncher<F>::ActionLauncher(StepActionT const& action,
+                                  std::string_view ext)
+    : ActionLauncher{std::string(action.label()) + "-" + std::string(ext)}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Launch a kernel for the wrapped executor.
+ */
+template<class F>
+void ActionLauncher<F>::operator()(CoreState<MemSpace::device> const& state,
+                                   F const& call_thread) const
+{
+    return (*this)(
+        range(ThreadId{state.size()}), state.stream_id(), call_thread);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace optical
+}  // namespace celeritas

--- a/src/celeritas/optical/action/ActionLauncher.hh
+++ b/src/celeritas/optical/action/ActionLauncher.hh
@@ -1,0 +1,53 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023-2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/optical/action/ActionLauncher.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <utility>
+
+#include "corecel/Config.hh"
+
+#include "corecel/Assert.hh"
+#include "corecel/Types.hh"
+#include "corecel/sys/MultiExceptionHandler.hh"
+#include "corecel/sys/ThreadId.hh"
+#include "celeritas/optical/CoreState.hh"
+
+namespace celeritas
+{
+namespace optical
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Helper function to run an action in parallel on CPU over all states.
+ *
+ * Example:
+ * \code
+ void FooAction::step(CoreParams const& params,
+                      CoreStateHost& state) const
+ {
+    launch_action(state, make_blah_executor(params, state, blah));
+ }
+ * \endcode
+ */
+template<class F>
+void launch_action(CoreState<MemSpace::host>& state, F&& execute_thread)
+{
+    MultiExceptionHandler capture_exception;
+#if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
+#    pragma omp parallel for
+#endif
+    for (size_type i = 0, size = state.size(); i != size; ++i)
+    {
+        CELER_TRY_HANDLE(execute_thread(ThreadId{i}), capture_exception);
+    }
+    log_and_rethrow(std::move(capture_exception));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace optical
+}  // namespace celeritas

--- a/src/celeritas/optical/action/BoundaryAction.cc
+++ b/src/celeritas/optical/action/BoundaryAction.cc
@@ -11,6 +11,11 @@
 #include "celeritas/optical/CoreParams.hh"
 #include "celeritas/optical/CoreState.hh"
 
+#include "ActionLauncher.hh"
+#include "TrackSlotExecutor.hh"
+
+#include "detail/BoundaryExecutor.hh"
+
 namespace celeritas
 {
 namespace optical
@@ -28,9 +33,13 @@ BoundaryAction::BoundaryAction(ActionId aid)
 /*!
  * Launch the boundary action on host.
  */
-void BoundaryAction::step(CoreParams const&, CoreStateHost&) const
+void BoundaryAction::step(CoreParams const& params, CoreStateHost& state) const
 {
-    CELER_LOG_LOCAL(error) << "Boundary action is not implemented";
+    auto execute = make_action_thread_executor(params.ptr<MemSpace::native>(),
+                                               state.ptr(),
+                                               this->action_id(),
+                                               detail::BoundaryExecutor{});
+    return launch_action(state, execute);
 }
 
 #if !CELER_USE_DEVICE

--- a/src/celeritas/optical/action/BoundaryAction.cu
+++ b/src/celeritas/optical/action/BoundaryAction.cu
@@ -11,6 +11,11 @@
 #include "celeritas/optical/CoreParams.hh"
 #include "celeritas/optical/CoreState.hh"
 
+#include "ActionLauncher.device.hh"
+#include "TrackSlotExecutor.hh"
+
+#include "detail/BoundaryExecutor.hh"
+
 namespace celeritas
 {
 namespace optical
@@ -21,7 +26,13 @@ namespace optical
  */
 void BoundaryAction::step(CoreParams const&, CoreStateDevice&) const
 {
-    CELER_LOG_LOCAL(error) << "Boundary action is not implemented";
+    auto execute = make_action_thread_executor(params.ptr<MemSpace::native>(),
+                                               state.ptr(),
+                                               this->action_id(),
+                                               detail::BoundaryExecutor{});
+
+    static ActionLauncher<decltype(execute)> const launch_kernel(*this);
+    launch_kernel(*this, params, state, execute);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/action/TrackSlotExecutor.hh
+++ b/src/celeritas/optical/action/TrackSlotExecutor.hh
@@ -1,0 +1,194 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/optical/action/TrackSlotExecutor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Assert.hh"
+#include "corecel/Types.hh"
+#include "corecel/sys/ThreadId.hh"
+#include "celeritas/optical/CoreTrackData.hh"
+#include "celeritas/optical/CoreTrackView.hh"
+#include "celeritas/track/SimFunctors.hh"
+#include "celeritas/track/SimTrackView.hh"
+
+namespace celeritas
+{
+namespace optical
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Transform a thread or track slot ID into a core track view.
+ *
+ * This class can be used to call a functor that applies to \c
+ * optical::CoreTrackView using a \c TrackSlotId, so that the tracks can be
+ * easily looped over as a group on CPU or GPU.
+ *
+ * To facilitate kernel launches, the class can also directly map \c ThreadId
+ * to \c TrackSlotId, which will have the same numerical value because optical
+ * photons do not implement sorting.
+ */
+template<class T>
+class TrackSlotExecutor
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using ParamsPtr = CoreParamsPtr<MemSpace::native>;
+    using StatePtr = CoreStatePtr<MemSpace::native>;
+    using Applier = T;
+    //!@}
+
+  public:
+    //! Construct with core data and executor
+    CELER_FUNCTION
+    TrackSlotExecutor(ParamsPtr params, StatePtr state, T&& execute_track)
+        : params_{params}
+        , state_{state}
+        , execute_track_{celeritas::forward<T>(execute_track)}
+    {
+    }
+
+    //! Call the underlying function based on the index in the state array
+    CELER_FUNCTION void operator()(TrackSlotId ts)
+    {
+        CELER_EXPECT(ts < state_->size());
+        CoreTrackView track(*params_, *state_, ts);
+        return execute_track_(track);
+    }
+
+    //! Call the underlying function using the thread index
+    CELER_FORCEINLINE_FUNCTION void operator()(ThreadId thread)
+    {
+        // For optical photons, thread index maps exactly to
+        return (*this)(TrackSlotId{thread.unchecked_get()});
+    }
+
+  private:
+    ParamsPtr const params_;
+    StatePtr const state_;
+    T execute_track_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Launch the track only when a certain condition applies to the sim state.
+ *
+ * The condition \c C must have the signature \code
+ * (SimTrackView const&) -> bool
+  \endcode
+ *
+ * see \c make_active_track_executor for an example where this is used to apply
+ * only to active (or killed) tracks.
+ */
+template<class C, class T>
+class ConditionalTrackSlotExecutor
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using ParamsPtr = CoreParamsPtr<MemSpace::native>;
+    using StatePtr = CoreStatePtr<MemSpace::native>;
+    using Applier = T;
+    //!@}
+
+  public:
+    //! Construct with condition and operator
+    CELER_FUNCTION
+    ConditionalTrackSlotExecutor(ParamsPtr params,
+                                 StatePtr state,
+                                 C&& applies,
+                                 T&& execute_track)
+        : params_{params}
+        , state_{state}
+        , applies_{celeritas::forward<C>(applies)}
+        , execute_track_{celeritas::forward<T>(execute_track)}
+    {
+    }
+
+    //! Launch the given thread if the track meets the condition
+    CELER_FUNCTION void operator()(TrackSlotId ts)
+    {
+        CELER_EXPECT(ts < state_->size());
+        CoreTrackView track(*params_, *state_, ts);
+        if (!applies_(track.sim()))
+        {
+            return;
+        }
+
+        return execute_track_(track);
+    }
+
+    //! Call the underlying function using the thread index
+    CELER_FORCEINLINE_FUNCTION void operator()(ThreadId thread)
+    {
+        // For optical photons, thread index maps exactly to
+        return (*this)(TrackSlotId{thread.unchecked_get()});
+    }
+
+  private:
+    ParamsPtr const params_;
+    StatePtr const state_;
+    C applies_;
+    T execute_track_;
+};
+
+//---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class T>
+CELER_FUNCTION TrackSlotExecutor(CoreParamsPtr<MemSpace::native>,
+                                 CoreStatePtr<MemSpace::native>,
+                                 T&&) -> TrackSlotExecutor<T>;
+
+template<class C, class T>
+CELER_FUNCTION
+ConditionalTrackSlotExecutor(CoreParamsPtr<MemSpace::native>,
+                             CoreStatePtr<MemSpace::native>,
+                             C&&,
+                             T&&) -> ConditionalTrackSlotExecutor<C, T>;
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Return a track executor that only applies to active, non-errored tracks.
+ */
+template<class T>
+inline CELER_FUNCTION decltype(auto)
+make_active_thread_executor(CoreParamsPtr<MemSpace::native> params,
+                            CoreStatePtr<MemSpace::native> const& state,
+                            T&& apply_track)
+{
+    return ConditionalTrackSlotExecutor{
+        params, state, AppliesValid{}, celeritas::forward<T>(apply_track)};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a track executor that only applies if the action ID matches.
+ *
+ * \note This should generally only be used for post-step actions and other
+ * cases where the IDs \em explicitly are set. Many explicit actions apply to
+ * all threads, active or not.
+ */
+template<class T>
+inline CELER_FUNCTION decltype(auto)
+make_action_thread_executor(CoreParamsPtr<MemSpace::native> params,
+                            CoreStatePtr<MemSpace::native> state,
+                            ActionId action,
+                            T&& apply_track)
+{
+    CELER_EXPECT(action);
+    return ConditionalTrackSlotExecutor{params,
+                                        state,
+                                        IsStepActionEqual{action},
+                                        celeritas::forward<T>(apply_track)};
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace optical
+}  // namespace celeritas

--- a/src/celeritas/optical/action/detail/BoundaryExecutor.hh
+++ b/src/celeritas/optical/action/detail/BoundaryExecutor.hh
@@ -1,0 +1,65 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/optical/action/detail/BoundaryExecutor.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+#include "celeritas/Types.hh"
+#include "celeritas/geo/GeoTrackView.hh"
+#include "celeritas/optical/CoreTrackView.hh"
+#include "celeritas/optical/MaterialView.hh"
+#include "celeritas/track/SimTrackView.hh"
+
+namespace celeritas
+{
+namespace optical
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Cross a geometry boundary.
+ *
+ * \pre The track must have already been physically moved to the correct point
+ * on the boundary.
+ */
+struct BoundaryExecutor
+{
+    inline CELER_FUNCTION void operator()(CoreTrackView& track);
+};
+
+//---------------------------------------------------------------------------//
+CELER_FUNCTION void BoundaryExecutor::operator()(CoreTrackView& track)
+{
+    CELER_EXPECT([track] {
+        auto sim = track.sim();
+        return sim.post_step_action() == track.boundary_action()
+               && sim.status() == TrackStatus::alive;
+    }());
+
+    auto geo = track.geometry();
+    CELER_EXPECT(geo.is_on_boundary());
+
+    // Particle entered a new volume before reaching the interaction point
+    geo.cross_boundary();
+    if (CELER_UNLIKELY(geo.failed()))
+    {
+        track.apply_errored();
+        return;
+    }
+    else
+    {
+        auto sim = track.sim();
+        sim.status(TrackStatus::killed);
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace optical
+}  // namespace celeritas

--- a/src/celeritas/optical/detail/CerenkovGeneratorAction.cc
+++ b/src/celeritas/optical/detail/CerenkovGeneratorAction.cc
@@ -18,8 +18,8 @@
 #include "celeritas/optical/CerenkovParams.hh"
 #include "celeritas/optical/CoreParams.hh"
 #include "celeritas/optical/CoreState.hh"
+#include "celeritas/optical/CoreTrackData.hh"
 #include "celeritas/optical/MaterialParams.hh"
-#include "celeritas/optical/TrackData.hh"
 
 #include "CerenkovGeneratorExecutor.hh"
 #include "OffloadParams.hh"

--- a/src/celeritas/optical/detail/ScintGeneratorAction.cc
+++ b/src/celeritas/optical/detail/ScintGeneratorAction.cc
@@ -17,8 +17,8 @@
 #include "celeritas/global/TrackExecutor.hh"
 #include "celeritas/optical/CoreParams.hh"
 #include "celeritas/optical/CoreState.hh"
+#include "celeritas/optical/CoreTrackData.hh"
 #include "celeritas/optical/ScintillationParams.hh"
-#include "celeritas/optical/TrackData.hh"
 
 #include "OffloadParams.hh"
 #include "OpticalGenAlgorithms.hh"

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -544,8 +544,6 @@ TEST_F(LArSphereOffloadTest, host_generate)
     static char const* const expected_log_messages[] = {
         "Celeritas optical state initialization complete",
         "Celeritas core state initialization complete",
-        "Boundary action is not implemented",
-        "Boundary action is not implemented",
         R"(Exceeded step count of 2: aborting optical transport loop with 0 tracks and 324193 queued)",
     };
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
@@ -553,7 +551,7 @@ TEST_F(LArSphereOffloadTest, host_generate)
         EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
     }
     static char const* const expected_log_levels[]
-        = {"status", "status", "error", "error", "error"};
+        = {"status", "status", "error"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
 
     EXPECT_EQ(2, result.optical_launch_step);
@@ -571,7 +569,7 @@ TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_generate))
     ScopedLogStorer scoped_log_{&celeritas::self_logger()};
     auto result = this->run<MemSpace::device>(1, 1024, 16);
     static char const* const expected_log_levels[]
-        = {"status", "status", "error", "error", "error"};
+        = {"status", "status", "error"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
 
     EXPECT_EQ(7, result.optical_launch_step);


### PR DESCRIPTION
This defines optical kernel launchers, track view, and executor. It uses these to implement a boundary crossing kernel for optical tracks.