### PR TITLE
Hotfix: untested CUDA code in #1424

### DIFF
--- a/src/celeritas/optical/CoreTrackView.hh
+++ b/src/celeritas/optical/CoreTrackView.hh
@@ -63,7 +63,7 @@ class CoreTrackView
     inline CELER_FUNCTION ActionId boundary_action() const;
 
     // Flag a track for deletion
-    void apply_errored();
+    inline CELER_FUNCTION void apply_errored();
 
   private:
     ParamsRef const& params_;

--- a/src/celeritas/optical/action/BoundaryAction.cu
+++ b/src/celeritas/optical/action/BoundaryAction.cu
@@ -24,7 +24,7 @@ namespace optical
 /*!
  * Launch the boundary action on device.
  */
-void BoundaryAction::step(CoreParams const&, CoreStateDevice&) const
+void BoundaryAction::step(CoreParams const& params, CoreStateDevice& state) const
 {
     auto execute = make_action_thread_executor(params.ptr<MemSpace::native>(),
                                                state.ptr(),
@@ -32,7 +32,7 @@ void BoundaryAction::step(CoreParams const&, CoreStateDevice&) const
                                                detail::BoundaryExecutor{});
 
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
-    launch_kernel(*this, params, state, execute);
+    launch_kernel(state, execute);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
When I merged #1424 I told it to skip the full checks because the only change from the previous "successful" run was a typo. This was dumb because the last test ran when it was draft, which excluded the docker builds. I tested this build on wildstyle and will merge when all the tests pass...