### PR TITLE
Add `track_order` option to celer-g4 and default to partitioning by charge on GPU

### DIFF
--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -160,6 +160,7 @@ void GlobalSetup::ReadInput(std::string const& filename)
         options_->action_times = input_.action_times;
         options_->default_stream = input_.default_stream;
         options_->auto_flush = input_.auto_flush;
+        options_->track_order = input_.track_order;
         options_->max_field_substeps = input_.field_options.max_substeps;
     }
     else if (ends_with(filename, ".mac"))

--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -11,6 +11,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
+#include "corecel/sys/Device.hh"
 #include "celeritas/ext/GeantPhysicsOptions.hh"
 #include "celeritas/field/FieldDriverOptions.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
@@ -73,7 +74,8 @@ struct RunInput
     bool default_stream{false};  //!< Launch all kernels on the default stream
 
     // Track reordering options
-    TrackOrder track_order{TrackOrder::unsorted};
+    TrackOrder track_order{Device::num_devices() ? TrackOrder::partition_charge
+                                                 : TrackOrder::unsorted};
 
     // Physics setup options
     PhysicsListSelection physics_list{PhysicsListSelection::celer_ftfp_bert};

--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -72,6 +72,9 @@ struct RunInput
     bool action_times{false};
     bool default_stream{false};  //!< Launch all kernels on the default stream
 
+    // Track reordering options
+    TrackOrder track_order{TrackOrder::unsorted};
+
     // Physics setup options
     PhysicsListSelection physics_list{PhysicsListSelection::celer_ftfp_bert};
     GeantPhysicsOptions physics_options;

--- a/app/celer-g4/RunInputIO.json.cc
+++ b/app/celer-g4/RunInputIO.json.cc
@@ -13,28 +13,10 @@
 #include "corecel/io/StringEnumMapper.hh"
 #include "corecel/sys/Environment.hh"
 #include "celeritas/Types.hh"
+#include "celeritas/TypesIO.hh"
 #include "celeritas/ext/GeantPhysicsOptionsIO.json.hh"
 #include "celeritas/field/FieldDriverOptionsIO.json.hh"
 #include "celeritas/phys/PrimaryGeneratorOptionsIO.json.hh"
-
-namespace celeritas
-{
-//---------------------------------------------------------------------------//
-void from_json(nlohmann::json const& j, TrackOrder& value)
-{
-    static auto const from_string
-        = StringEnumMapper<TrackOrder>::from_cstring_func(to_cstring,
-                                                          "track order");
-    value = from_string(j.get<std::string>());
-}
-
-void to_json(nlohmann::json& j, TrackOrder const& value)
-{
-    j = std::string{to_cstring(value)};
-}
-
-//---------------------------------------------------------------------------//
-}  // namespace celeritas
 
 namespace celeritas
 {

--- a/app/celer-g4/RunInputIO.json.cc
+++ b/app/celer-g4/RunInputIO.json.cc
@@ -19,6 +19,25 @@
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+void from_json(nlohmann::json const& j, TrackOrder& value)
+{
+    static auto const from_string
+        = StringEnumMapper<TrackOrder>::from_cstring_func(to_cstring,
+                                                          "track order");
+    value = from_string(j.get<std::string>());
+}
+
+void to_json(nlohmann::json& j, TrackOrder const& value)
+{
+    j = std::string{to_cstring(value)};
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas
+
+namespace celeritas
+{
 namespace app
 {
 //---------------------------------------------------------------------------//
@@ -93,6 +112,8 @@ void from_json(nlohmann::json const& j, RunInput& v)
     {
         v.auto_flush = v.num_track_slots;
     }
+
+    RI_LOAD_OPTION(track_order);
 
     RI_LOAD_OPTION(physics_list);
     RI_LOAD_OPTION(physics_options);
@@ -184,6 +205,8 @@ void to_json(nlohmann::json& j, RunInput const& v)
     RI_SAVE(action_times);
     RI_SAVE(default_stream);
     RI_SAVE(auto_flush);
+
+    RI_SAVE(track_order);
 
     RI_SAVE(physics_list);
     if (v.physics_list != PhysicsListSelection::ftfp_bert)

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -105,7 +105,7 @@ struct RunnerInput
     bool action_times{};
     bool merge_events{false};  //!< Run all events at once on a single stream
     bool default_stream{false};  //!< Launch all kernels on the default stream
-    bool warm_up{CELER_USE_DEVICE};  //!< Run a nullop step first
+    bool warm_up{false};  //!< Run a nullop step first
 
     // Magnetic field vector [* 1/Tesla] and associated field options
     Real3 field{no_field()};
@@ -118,7 +118,7 @@ struct RunnerInput
     // Options for physics
     bool brem_combined{false};
 
-    // Track init options
+    // Track reordering options
     TrackOrder track_order{TrackOrder::unsorted};
 
     // Optional setup options if loading directly from Geant4

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -109,7 +109,14 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_OPTION(action_times);
     LDIO_LOAD_OPTION(merge_events);
     LDIO_LOAD_OPTION(default_stream);
-    LDIO_LOAD_OPTION(warm_up);
+    if (auto iter = j.find("warm_up"); iter != j.end())
+    {
+        iter->get_to(v.warm_up);
+    }
+    else if (v.use_device)
+    {
+        v.warm_up = true;
+    }
 
     LDIO_LOAD_DEPRECATED(mag_field, field);
 
@@ -120,7 +127,14 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
 
     LDIO_LOAD_OPTION(step_limiter);
     LDIO_LOAD_OPTION(brem_combined);
-    LDIO_LOAD_OPTION(track_order);
+    if (auto iter = j.find("track_order"); iter != j.end())
+    {
+        iter->get_to(v.track_order);
+    }
+    else if (v.use_device)
+    {
+        v.track_order = TrackOrder::partition_charge;
+    }
     LDIO_LOAD_OPTION(physics_options);
 
     LDIO_LOAD_OPTION(optical);

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -18,29 +18,11 @@
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/EnvironmentIO.json.hh"
 #include "celeritas/Types.hh"
+#include "celeritas/TypesIO.hh"
 #include "celeritas/ext/GeantPhysicsOptionsIO.json.hh"
 #include "celeritas/field/FieldDriverOptionsIO.json.hh"
 #include "celeritas/phys/PrimaryGeneratorOptionsIO.json.hh"
 #include "celeritas/user/RootStepWriterIO.json.hh"
-
-namespace celeritas
-{
-//---------------------------------------------------------------------------//
-void from_json(nlohmann::json const& j, TrackOrder& value)
-{
-    static auto const from_string
-        = StringEnumMapper<TrackOrder>::from_cstring_func(to_cstring,
-                                                          "track order");
-    value = from_string(j.get<std::string>());
-}
-
-void to_json(nlohmann::json& j, TrackOrder const& value)
-{
-    j = std::string{to_cstring(value)};
-}
-
-//---------------------------------------------------------------------------//
-}  // namespace celeritas
 
 namespace celeritas
 {

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -130,6 +130,11 @@ struct SetupOptions
     size_type auto_flush{};
     //!@}
 
+    //!@{
+    //! \name Track reordering options
+    TrackOrder track_order{TrackOrder::unsorted};
+    //!@}
+
     //! Set the number of streams (defaults to run manager # threads)
     IntAccessor get_num_streams;
 
@@ -162,11 +167,6 @@ struct SetupOptions
     bool action_times{false};
     //! Launch all kernels on the default stream
     bool default_stream{false};
-    //!@}
-
-    //!@{
-    //! \name Track init options
-    TrackOrder track_order{TrackOrder::unsorted};
     //!@}
 };
 

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -13,6 +13,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "corecel/sys/Device.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/global/ActionInterface.hh"
 
@@ -132,7 +133,8 @@ struct SetupOptions
 
     //!@{
     //! \name Track reordering options
-    TrackOrder track_order{TrackOrder::unsorted};
+    TrackOrder track_order{Device::num_devices() ? TrackOrder::partition_charge
+                                                 : TrackOrder::unsorted};
     //!@}
 
     //! Set the number of streams (defaults to run manager # threads)

--- a/src/celeritas/TypesIO.hh
+++ b/src/celeritas/TypesIO.hh
@@ -1,0 +1,40 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/TypesIO.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "corecel/io/JsonUtils.json.hh"
+
+#include "Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Read options from JSON.
+ */
+void from_json(nlohmann::json const& j, TrackOrder& value)
+{
+    static auto const from_string
+        = StringEnumMapper<TrackOrder>::from_cstring_func(to_cstring,
+                                                          "track order");
+    value = from_string(j.get<std::string>());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write options to JSON.
+ */
+void to_json(nlohmann::json& j, TrackOrder const& value)
+{
+    j = std::string{to_cstring(value)};
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas


### PR DESCRIPTION
This add the `track_order` option to celer-g4 and changes the default track order in celer-sim and celer-g4 from unsorted to partitioning by charge when running on the GPU (based on the results in #1322, #1233, and below). This is the change in throughput for celer-g4 with partitioning:
![rel-throughput-4xts-pc-g4](https://github.com/user-attachments/assets/9c3176a9-eef1-4bfd-a3e6-b09ba72306db)
