### PR TITLE
Loosen numerically iffy test tolerance

### DIFF
--- a/src/corecel/math/detail/SoftEqualTraits.hh
+++ b/src/corecel/math/detail/SoftEqualTraits.hh
@@ -44,7 +44,7 @@ struct SoftEqualTraits<double>
 {
     using value_type = double;
     static CELER_CONSTEXPR_FUNCTION value_type sqrt_prec() { return 1.0e-6; }
-    static CELER_CONSTEXPR_FUNCTION value_type rel_prec() { return 1.0e-12; }
+    static CELER_CONSTEXPR_FUNCTION value_type rel_prec() { return 1.0e-8; }
     static CELER_CONSTEXPR_FUNCTION value_type abs_thresh() { return 1.0e-14; }
 };
 

--- a/src/corecel/math/detail/SoftEqualTraits.hh
+++ b/src/corecel/math/detail/SoftEqualTraits.hh
@@ -44,7 +44,7 @@ struct SoftEqualTraits<double>
 {
     using value_type = double;
     static CELER_CONSTEXPR_FUNCTION value_type sqrt_prec() { return 1.0e-6; }
-    static CELER_CONSTEXPR_FUNCTION value_type rel_prec() { return 1.0e-8; }
+    static CELER_CONSTEXPR_FUNCTION value_type rel_prec() { return 1.0e-12; }
     static CELER_CONSTEXPR_FUNCTION value_type abs_thresh() { return 1.0e-14; }
 };
 

--- a/test/orange/surf/detail/InvoluteSolver.test.cc
+++ b/test/orange/surf/detail/InvoluteSolver.test.cc
@@ -355,6 +355,9 @@ TEST(SolveSurface, three_roots)
 }
 TEST(SolveSurface, tangents)
 {
+    // TODO: can we make the solver more numerically stable and replace
+    // EXPECT_SOFT_NEAR with EXPECT_SOFT_EQ?
+
     // Solve for 0.5*pi tangents for rb = 1.0 a = 0 sign = CCW
     // Direction (0,1)
     real_type r_b = 1.0;
@@ -389,7 +392,7 @@ TEST(SolveSurface, tangents)
         // Float and double produce different results
         if constexpr (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
         {
-            EXPECT_SOFT_EQ(0.0017713715293786088, dist_on[0]);
+            EXPECT_SOFT_NEAR(0.0017713715293786088, dist_on[0], 1e-10);
             EXPECT_SOFT_EQ(no_intersection(), dist_on[1]);
             EXPECT_SOFT_EQ(no_intersection(), dist_on[2]);
         }
@@ -406,7 +409,7 @@ TEST(SolveSurface, tangents)
         // Float and double produce different results
         if constexpr (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
         {
-            EXPECT_SOFT_EQ(0.0017713715293786088, dist_off[0]);
+            EXPECT_SOFT_NEAR(0.0017713715293786088, dist_off[0], 1e-10);
             EXPECT_SOFT_EQ(no_intersection(), dist_off[1]);
             EXPECT_SOFT_EQ(no_intersection(), dist_off[2]);
         }
@@ -429,7 +432,7 @@ TEST(SolveSurface, tangents)
         // Float and double produce different results
         if constexpr (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
         {
-            EXPECT_SOFT_EQ(0.00053216327674743909, dist_on[0]);
+            EXPECT_SOFT_NEAR(0.00053216327674743909, dist_on[0], 1e-8);
             EXPECT_SOFT_EQ(no_intersection(), dist_on[1]);
             EXPECT_SOFT_EQ(no_intersection(), dist_on[2]);
         }
@@ -446,7 +449,7 @@ TEST(SolveSurface, tangents)
         // Float and double produce different results
         if constexpr (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
         {
-            EXPECT_SOFT_EQ(0.00053216327674743909, dist_off[0]);
+            EXPECT_SOFT_NEAR(0.00053216327674743909, dist_off[0], 1e-8);
             EXPECT_SOFT_EQ(no_intersection(), dist_off[1]);
             EXPECT_SOFT_EQ(no_intersection(), dist_off[2]);
         }
@@ -570,7 +573,7 @@ TEST(SolveSurface, tangents)
         // Float and double produce different results
         if constexpr (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
         {
-            EXPECT_SOFT_EQ(0.0019504376639951655, dist_on[0]);
+            EXPECT_SOFT_NEAR(0.0019504376639951655, dist_on[0], 1e-10);
             EXPECT_SOFT_EQ(no_intersection(), dist_on[1]);
             EXPECT_SOFT_EQ(no_intersection(), dist_on[2]);
         }
@@ -587,7 +590,7 @@ TEST(SolveSurface, tangents)
         // Float and double produce different results
         if constexpr (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
         {
-            EXPECT_SOFT_EQ(0.0019504376639951655, dist_off[0]);
+            EXPECT_SOFT_NEAR(0.0019504376639951655, dist_off[0], 1e-10);
             EXPECT_SOFT_EQ(no_intersection(), dist_off[1]);
             EXPECT_SOFT_EQ(no_intersection(), dist_off[2]);
         }


### PR DESCRIPTION
The `InvoluteSolver` test fails on Perlmutter because the precision is too strict. 

```
/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/test/orange/surf/detail/InvoluteSolver.test.cc:392: Failure
Value of: dist_on[0]
  Actual: 0.0017713715293239856
Expected: 0.0017713715293786088
Which is: 0.0017713715293786088
(Relative error -3.0836664554021502e-11 exceeds tolerance 9.9999999999999998e-13)

/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/test/orange/surf/detail/InvoluteSolver.test.cc:409: Failure
Value of: dist_off[0]
  Actual: 0.0017713715293239856
Expected: 0.0017713715293786088
Which is: 0.0017713715293786088
(Relative error -3.0836664554021502e-11 exceeds tolerance 9.9999999999999998e-13)

/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/test/orange/surf/detail/InvoluteSolver.test.cc:432: Failure
Value of: dist_on[0]
  Actual: 0.00053216327768802003
Expected: 0.00053216327674743909
Which is: 0.00053216327674743909
(Relative error 1.7674668425285303e-09 exceeds tolerance 9.9999999999999998e-13)

/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/test/orange/surf/detail/InvoluteSolver.test.cc:449: Failure
Value of: dist_off[0]
  Actual: 0.00053216327768802003
Expected: 0.00053216327674743909
Which is: 0.00053216327674743909
(Relative error 1.7674668425285303e-09 exceeds tolerance 9.9999999999999998e-13)

/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/test/orange/surf/detail/InvoluteSolver.test.cc:573: Failure
Value of: dist_on[0]
  Actual: 0.00195043766381975
Expected: 0.0019504376639951655
Which is: 0.0019504376639951655
(Relative error -8.9936457836800689e-11 exceeds tolerance 9.9999999999999998e-13)

/global/cfs/cdirs/atlas/esseivaj/devel/celeritas/test/orange/surf/detail/InvoluteSolver.test.cc:590: Failure
Value of: dist_off[0]
  Actual: 0.00195043766381975
Expected: 0.0019504376639951655
Which is: 0.0019504376639951655
(Relative error -8.9936457836800689e-11 exceeds tolerance 9.9999999999999998e-13)
```

I have to significantly reduce the precision for the test to pass. Maybe we can refactor the computation so that we don't lose that much precision?
