### PR TITLE
Fix weak vtables causing dynamic_cast error in apple clang 16

### DIFF
--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -230,4 +230,11 @@ auto& CoreState<M>::native_action_thread_offsets()
 }
 
 //---------------------------------------------------------------------------//
+// EXPLICIT INSTANTIATION
+//---------------------------------------------------------------------------//
+
+extern template class CoreState<MemSpace::host>;
+extern template class CoreState<MemSpace::device>;
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -54,6 +54,9 @@ ScopeExit(F&& func) -> ScopeExit<F>;
 }  // namespace
 
 //---------------------------------------------------------------------------//
+StepperInterface::~StepperInterface() = default;
+
+//---------------------------------------------------------------------------//
 /*!
  * Construct with problem parameters and setup options.
  */

--- a/src/celeritas/global/Stepper.hh
+++ b/src/celeritas/global/Stepper.hh
@@ -92,6 +92,9 @@ class StepperInterface
     //!@}
 
   public:
+    // Default virtual destructor
+    virtual ~StepperInterface();
+
     // Warm up before stepping
     virtual void warm_up() = 0;
 
@@ -114,8 +117,8 @@ class StepperInterface
     virtual SPState sp_state() = 0;
 
   protected:
-    // Protected destructor prevents deletion of pointer-to-interface
-    ~StepperInterface() = default;
+    StepperInterface() = default;
+    CELER_DEFAULT_COPY_MOVE(StepperInterface);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/Stepper.hh
+++ b/src/celeritas/global/Stepper.hh
@@ -192,4 +192,11 @@ class Stepper final : public StepperInterface
 };
 
 //---------------------------------------------------------------------------//
+// EXPLICIT INSTANTIATION
+//---------------------------------------------------------------------------//
+
+extern template class Stepper<MemSpace::host>;
+extern template class Stepper<MemSpace::device>;
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/user/detail/StepGatherAction.hh
+++ b/src/celeritas/user/detail/StepGatherAction.hh
@@ -93,5 +93,12 @@ void step_gather_device(DeviceCRef<CoreParamsData> const&,
                         DeviceRef<StepStateData>&);
 
 //---------------------------------------------------------------------------//
+// EXPLICIT INSTANTIATION
+//---------------------------------------------------------------------------//
+
+extern template class StepGatherAction<StepPoint::pre>;
+extern template class StepGatherAction<StepPoint::post>;
+
+//---------------------------------------------------------------------------//
 }  // namespace detail
 }  // namespace celeritas

--- a/src/orange/orangeinp/Shape.cc
+++ b/src/orange/orangeinp/Shape.cc
@@ -45,6 +45,7 @@ template class Shape<Cone>;
 template class Shape<Cylinder>;
 template class Shape<Ellipsoid>;
 template class Shape<GenPrism>;
+template class Shape<Involute>;
 template class Shape<Parallelepiped>;
 template class Shape<Prism>;
 template class Shape<Sphere>;

--- a/src/orange/orangeinp/Shape.hh
+++ b/src/orange/orangeinp/Shape.hh
@@ -124,5 +124,19 @@ using PrismShape = Shape<Prism>;
 using SphereShape = Shape<Sphere>;
 
 //---------------------------------------------------------------------------//
+// EXPLICIT INSTANTIATION
+//---------------------------------------------------------------------------//
+
+extern template class Shape<Box>;
+extern template class Shape<Cone>;
+extern template class Shape<Cylinder>;
+extern template class Shape<Ellipsoid>;
+extern template class Shape<GenPrism>;
+extern template class Shape<Involute>;
+extern template class Shape<Parallelepiped>;
+extern template class Shape<Prism>;
+extern template class Shape<Sphere>;
+
+//---------------------------------------------------------------------------//
 }  // namespace orangeinp
 }  // namespace celeritas

--- a/src/orange/orangeinp/Shape.hh
+++ b/src/orange/orangeinp/Shape.hh
@@ -118,6 +118,7 @@ using ConeShape = Shape<Cone>;
 using CylinderShape = Shape<Cylinder>;
 using EllipsoidShape = Shape<Ellipsoid>;
 using GenPrismShape = Shape<GenPrism>;
+using InvoluteShape = Shape<Involute>;
 using ParallelepipedShape = Shape<Parallelepiped>;
 using PrismShape = Shape<Prism>;
 using SphereShape = Shape<Sphere>;

--- a/src/orange/orangeinp/Solid.hh
+++ b/src/orange/orangeinp/Solid.hh
@@ -188,6 +188,15 @@ using PrismSolid = Solid<Prism>;
 using SphereSolid = Solid<Sphere>;
 
 //---------------------------------------------------------------------------//
+// EXPLICIT INSTANTIATION
+//---------------------------------------------------------------------------//
+
+extern template class Solid<Cone>;
+extern template class Solid<Cylinder>;
+extern template class Solid<Prism>;
+extern template class Solid<Sphere>;
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/test/orange/orangeinp/Solid.test.cc
+++ b/test/orange/orangeinp/Solid.test.cc
@@ -8,6 +8,7 @@
 #include "orange/orangeinp/Solid.hh"
 
 #include "orange/orangeinp/Shape.hh"
+#include "corecel/sys/TypeDemangler.hh"
 
 #include "CsgTestUtils.hh"
 #include "ObjectTestBase.hh"
@@ -300,11 +301,13 @@ TEST_F(SolidTest, cyl)
 
 TEST_F(SolidTest, or_shape)
 {
+    TypeDemangler<ObjectInterface> demangle_shape;
     {
         auto shape = ConeSolid::or_shape(
             "cone", Cone{{1, 2}, 10.0}, std::nullopt, SolidEnclosedAngle{});
         EXPECT_TRUE(shape);
-        EXPECT_TRUE(dynamic_cast<ConeShape const*>(shape.get()));
+        EXPECT_TRUE(dynamic_cast<ConeShape const*>(shape.get()))
+            << "actual shape: " << demangle_shape(*shape);
     }
     {
         auto solid = ConeSolid::or_shape("cone",
@@ -312,7 +315,8 @@ TEST_F(SolidTest, or_shape)
                                          Cone{{0.9, 1.9}, 10.0},
                                          SolidEnclosedAngle{});
         EXPECT_TRUE(solid);
-        EXPECT_TRUE(dynamic_cast<ConeSolid const*>(solid.get()));
+        EXPECT_TRUE(dynamic_cast<ConeSolid const*>(solid.get()))
+            << demangle_shape(*solid);
     }
 }
 


### PR DESCRIPTION
There's something wrong with the dynamic cast when using `-O1` or higher on apple clang 16 (i.e. XCode 16 aka the one targeting Sequoia):
```
test/orange/orangeinp/Solid.test.cc:309: Failure
Value of: dynamic_cast<ConeShape const*>(shape.get())
  Actual: false
Expected: true
actual shape: celeritas::orangeinp::Shape<celeritas::orangeinp::Cone>
```
for code
```c++
    {
        auto shape = ConeSolid::or_shape(
            "cone", Cone{{1, 2}, 10.0}, std::nullopt, SolidEnclosedAngle{});
        EXPECT_TRUE(shape);
        EXPECT_TRUE(dynamic_cast<ConeShape const*>(shape.get()))
            << "actual shape: " << demangle_shape(*shape);
    }
```

Moving the dynamic-cast code from the test to the library works:
```c++
ConeShape const* dyncast_cone_shape(ObjectInterface const* obj)
{
    return dynamic_cast<ConeShape const*>(obj);
}
```
and generates identical assembly to the function if added to the test binary:
```asm
celeritas::orangeinp::test::dyncast_cone_shape_2(celeritas::orangeinp::ObjectInterface const*): ; @_ZN9celeritas9orangeinp4test20dyncast_cone_shape_2EPKNS0_15ObjectInterfaceE
Lfunc_begin77:
	cbz	x0, LBB77_2
	ldr	x8, [x0]
	adrp	x9, vtable for celeritas::orangeinp::Shape<celeritas::orangeinp::Cone>@GOTPAGE
	ldr	x9, [x9, vtable for celeritas::orangeinp::Shape<celeritas::orangeinp::Cone>@GOTPAGEOFF]
	add	x9, x9, #16
	cmp	x8, x9
	b.eq	LBB77_3
LBB77_2:
	.loc	1 0 12 is_stmt 0                ; ./test/orange/orangeinp/Solid.test.cc:0:12
	mov	x0, #0                          ; =0x0
LBB77_3:
	.loc	1 304 5                         ; ./test/orange/orangeinp/Solid.test.cc:304:5
	ret
```
Note the above code loads the vtable for the object, and simply compares the vtable address to that of the pointer. Interestingly, the vtable shows up in both the library and the test: so we conclude that the vtable for the pointer created by the library is *not* the same vtable known to the unit test!!

This seems to be related to a new Clang optimization, https://reviews.llvm.org/D154658 (aka https://github.com/llvm/llvm-project/commit/9d525bf94b255df89587db955b5fa2d3c03c2c3e), perhaps also the cause of https://github.com/llvm/llvm-project/issues/71196 . Adding `-fno-assume-unique-vtables` as documented by the new feature causes the tests to work again.

This seems to be because the class being compared is `final` but since it's templated, *because it's instantiated in the main library but not declared external*, the vtable appears both in the library and test so the address is different between the two of them. Adding an `extern template` declaration fixes this.