### PR TITLE
Define a "unique event ID" different from event counter

### DIFF
--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -146,7 +146,7 @@ void LocalTransporter::InitializeEvent(int id)
     CELER_EXPECT(*this);
     CELER_EXPECT(id >= 0);
 
-    event_id_ = EventId(id);
+    event_id_ = UniqueEventId(id);
     track_counter_ = 0;
 
     if (!(G4Threading::IsMultithreadedApplication()
@@ -166,7 +166,6 @@ void LocalTransporter::InitializeEvent(int id)
 void LocalTransporter::Push(G4Track const& g4track)
 {
     CELER_EXPECT(*this);
-    CELER_EXPECT(event_id_);
 
     Primary track;
 
@@ -199,7 +198,7 @@ void LocalTransporter::Push(G4Track const& g4track)
      * back to Geant4.
      */
     track.track_id = TrackId{track_counter_++};
-    track.event_id = event_id_;
+    track.event_id = EventId{event_id_.get()};
 
     buffer_.push_back(track);
     if (buffer_.size() >= auto_flush_)

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -198,7 +198,7 @@ void LocalTransporter::Push(G4Track const& g4track)
      * back to Geant4.
      */
     track.track_id = TrackId{track_counter_++};
-    track.event_id = EventId{event_id_.get()};
+    track.event_id = EventId{0};
 
     buffer_.push_back(track);
     if (buffer_.size() >= auto_flush_)

--- a/src/accel/LocalTransporter.hh
+++ b/src/accel/LocalTransporter.hh
@@ -99,7 +99,7 @@ class LocalTransporter
     std::vector<Primary> buffer_;
     std::shared_ptr<detail::HitProcessor> hit_processor_;
 
-    EventId event_id_;
+    UniqueEventId event_id_;
     TrackId::size_type track_counter_{};
 
     size_type auto_flush_{};

--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -29,8 +29,11 @@ namespace celeritas
 //! Opaque index to ElementRecord in the global vector of elements
 using ElementId = OpaqueId<struct ElementRecord>;
 
-//! Counter for the initiating event for a track
+//! Zero-indexed counter for the initiating event for a track
 using EventId = OpaqueId<struct Event_>;
+
+//! Unique identifier for an event used by external applications
+using UniqueEventId = OpaqueId<struct Event_, std::uint64_t>;
 
 //! Opaque index to IsotopeRecord in a vector
 using IsotopeId = OpaqueId<struct IsotopeRecord>;

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -172,9 +172,9 @@ auto Stepper<M>::operator()(SpanConstPrimary primaries) -> result_type
  * reproduced.
  */
 template<MemSpace M>
-void Stepper<M>::reseed(EventId event_id)
+void Stepper<M>::reseed(UniqueEventId event_id)
 {
-    reseed_rng(get_ref<M>(*params_->rng()), state_->ref().rng, event_id.get());
+    reseed_rng(get_ref<M>(*params_->rng()), state_->ref().rng, event_id);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/Stepper.hh
+++ b/src/celeritas/global/Stepper.hh
@@ -105,7 +105,7 @@ class StepperInterface
     virtual StepperResult operator()(SpanConstPrimary primaries) = 0;
 
     // Reseed the RNGs at the start of an event for reproducibility
-    virtual void reseed(EventId event_id) = 0;
+    virtual void reseed(UniqueEventId event_id) = 0;
 
     //! Get action sequence for timing diagnostics
     virtual ActionSequenceT const& actions() const = 0;
@@ -166,7 +166,7 @@ class Stepper final : public StepperInterface
     StepperResult operator()(SpanConstPrimary primaries) final;
 
     // Reseed the RNGs at the start of an event for reproducibility
-    void reseed(EventId event_id) final;
+    void reseed(UniqueEventId event_id) final;
 
     //! Get action sequence for timing diagnostics
     ActionSequenceT const& actions() const final { return *actions_; }

--- a/src/celeritas/random/RngReseed.cc
+++ b/src/celeritas/random/RngReseed.cc
@@ -24,9 +24,12 @@ namespace celeritas
  */
 void reseed_rng(HostCRef<RngParamsData> const& params,
                 HostRef<RngStateData> const& state,
-                size_type event_id)
+                UniqueEventId event_id)
 {
-    auto size = state.size();
+    CELER_EXPECT(event_id);
+    static_assert(sizeof(ull_int) == sizeof(UniqueEventId::size_type));
+
+    ull_int size = state.size();
 #if CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
@@ -34,7 +37,7 @@ void reseed_rng(HostCRef<RngParamsData> const& params,
     {
         RngEngine::Initializer_t init;
         init.seed = params.seed;
-        init.subsequence = event_id * size + i;
+        init.subsequence = event_id.unchecked_get() * size + i;
         RngEngine engine(params, state, TrackSlotId{i});
         engine = init;
     }

--- a/src/celeritas/random/RngReseed.cu
+++ b/src/celeritas/random/RngReseed.cu
@@ -27,7 +27,7 @@ namespace
  */
 __global__ void reseed_rng_kernel(DeviceCRef<RngParamsData> const params,
                                   DeviceRef<RngStateData> const state,
-                                  size_type event_id)
+                                  UniqueEventId::size_type event_id)
 {
     auto tid = TrackSlotId{
         celeritas::KernelParamCalculator::thread_id().unchecked_get()};
@@ -57,11 +57,12 @@ __global__ void reseed_rng_kernel(DeviceCRef<RngParamsData> const params,
  */
 void reseed_rng(DeviceCRef<RngParamsData> const& params,
                 DeviceRef<RngStateData> const& state,
-                size_type event_id)
+                UniqueEventId event_id)
 {
     CELER_EXPECT(state);
     CELER_EXPECT(params);
-    CELER_LAUNCH_KERNEL(reseed_rng, state.size(), 0, params, state, event_id);
+    CELER_LAUNCH_KERNEL(
+        reseed_rng, state.size(), 0, params, state, event_id.get());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/random/RngReseed.hh
+++ b/src/celeritas/random/RngReseed.hh
@@ -11,6 +11,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
+#include "celeritas/Types.hh"
 
 #include "RngData.hh"
 
@@ -20,11 +21,11 @@ namespace celeritas
 // Reinitialize the RNG states on host/device at the start of an event
 void reseed_rng(DeviceCRef<RngParamsData> const&,
                 DeviceRef<RngStateData> const&,
-                size_type);
+                UniqueEventId);
 
 void reseed_rng(HostCRef<RngParamsData> const&,
                 HostRef<RngStateData> const&,
-                size_type);
+                UniqueEventId);
 
 #if !CELER_USE_DEVICE
 //---------------------------------------------------------------------------//
@@ -33,7 +34,7 @@ void reseed_rng(HostCRef<RngParamsData> const&,
  */
 inline void reseed_rng(DeviceCRef<RngParamsData> const&,
                        DeviceRef<RngStateData> const&,
-                       size_type)
+                       UniqueEventId)
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/test/celeritas/random/RngReseed.test.cc
+++ b/test/celeritas/random/RngReseed.test.cc
@@ -37,7 +37,7 @@ TEST_F(RngReseedTest, reseed)
     RngHostStore states(params->host_ref(), StreamId{0}, size);
 
     size_type id = 8;
-    reseed_rng(params->host_ref(), states.ref(), id);
+    reseed_rng(params->host_ref(), states.ref(), UniqueEventId{id});
 
     RngEngine::Initializer_t init;
     init.seed = params->host_ref().seed;
@@ -55,7 +55,7 @@ TEST_F(RngReseedTest, reseed)
         ASSERT_EQ(skip_rng(), rng());
     }
 
-    reseed_rng(params->host_ref(), states.ref(), id);
+    reseed_rng(params->host_ref(), states.ref(), UniqueEventId{id});
     std::vector<unsigned int> values;
     for (auto i : range(states.size()).step(128u))
     {


### PR DESCRIPTION
ATLAS integration is currently failing because the framework is [now setting the Geant4 event ID](https://gitlab.cern.ch/atlas/athena/-/merge_requests/74551) based on the global event context, whose event number is a globally unique identifier. In contrast, Celeritas expected the event number to be a *counter* (and a thread-local one at that). Since there are far more than 4 billion total events simulated across all runs and all simulations, and each event should have a unique random sequence, we need to define a special long integer for seeding.

Since the unique event ID (aka the event ID from geant4) doesn't necessarily correlate to the event *counter*, I'm forcing the *EventId* that we use for the primary (used for track counting) to zero. This may hurt "debuggability" but means that we can eliminate the "max events" from Geant4 integration. A follow-on PR will add support a special mode for resetting the track counter at the beginning of each event (and having a single "global" event ID) rather than using a unique event-ID-based slot.

A follow-on pull request should map our *internal* "event ID" (which is consecutive from zero and local to a thread) to the *external* "event ID" (which is some arbitrary integer used to reference an event, whether from ATLAS or a HepMC3 file etc) for user output.

See #1144 , #1233