### PR TITLE
Remove trackid counter from primary

### DIFF
--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -36,7 +36,16 @@ ActionInitialization::ActionInitialization(SPParams params)
     // Create Geant4 diagnostics to be shared across worker threads
     diagnostics_ = std::make_shared<GeantDiagnostics>();
 
-    num_events_ = GlobalSetup::Instance()->setup_options().max_num_events;
+    if (auto const& hepmc_gen = GlobalSetup::Instance()->hepmc_gen())
+    {
+        num_events_ = hepmc_gen->NumEvents();
+    }
+    else
+    {
+        num_events_
+            = GlobalSetup::Instance()->input().primary_options.num_events;
+    }
+
     CELER_ENSURE(num_events_ > 0);
 }
 
@@ -73,7 +82,7 @@ void ActionInitialization::Build() const
     CELER_LOG_LOCAL(status) << "Constructing user action";
 
     // Primary generator emits source particles
-    if (auto hepmc_gen = GlobalSetup::Instance()->hepmc_gen())
+    if (auto const& hepmc_gen = GlobalSetup::Instance()->hepmc_gen())
     {
         this->SetUserAction(new HepMC3PrimaryGeneratorAction(hepmc_gen));
     }

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -99,7 +99,7 @@ class GlobalSetup
     bool root_sd_io() const { return root_sd_io_; }
 
     //! Get HepMC3 primary generator
-    SPPrimaryGenerator hepmc_gen() const { return hepmc_gen_; }
+    SPPrimaryGenerator const& hepmc_gen() const { return hepmc_gen_; }
 
   private:
     // Private constructor since we're a singleton
@@ -108,7 +108,7 @@ class GlobalSetup
 
     // Data
     std::shared_ptr<SetupOptions> options_;
-    std::shared_ptr<HepMC3PrimaryGenerator> hepmc_gen_;
+    SPPrimaryGenerator hepmc_gen_;
     RunInput input_;
     Stopwatch get_setup_time_;
     bool root_sd_io_{false};

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -192,12 +192,8 @@ void LocalTransporter::Push(G4Track const& g4track)
     }
 
     /*!
-     * \todo Celeritas track IDs are independent from Geant4 track IDs, since
-     * they must be sequential from zero for a given event. We may need to save
-     * (and share with sensitive detectors!) a map of track IDs for calling
-     * back to Geant4.
+     * \todo Eliminate event ID from primary.
      */
-    track.track_id = TrackId{track_counter_++};
     track.event_id = EventId{0};
 
     buffer_.push_back(track);

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -147,7 +147,6 @@ void LocalTransporter::InitializeEvent(int id)
     CELER_EXPECT(id >= 0);
 
     event_id_ = UniqueEventId(id);
-    track_counter_ = 0;
 
     if (!(G4Threading::IsMultithreadedApplication()
           && G4MTRunManager::SeedOncePerCommunication()))

--- a/src/accel/LocalTransporter.hh
+++ b/src/accel/LocalTransporter.hh
@@ -100,7 +100,6 @@ class LocalTransporter
     std::shared_ptr<detail::HitProcessor> hit_processor_;
 
     UniqueEventId event_id_;
-    TrackId::size_type track_counter_{};
 
     size_type auto_flush_{};
     size_type max_steps_{};

--- a/src/celeritas/io/EventReader.cc
+++ b/src/celeritas/io/EventReader.cc
@@ -112,7 +112,6 @@ auto EventReader::operator()() -> result_type
     std::set<int> missing_pdg;
 
     result_type result;
-    int track_id = 0;
     for (auto const& par : evt.particles())
     {
         if (par->data().status != 1 || par->end_vertex())
@@ -139,7 +138,6 @@ auto EventReader::operator()() -> result_type
 
         // Set the event and track number
         primary.event_id = event_id;
-        primary.track_id = TrackId(track_id++);
 
         // Get the position of the vertex
         auto pos = par->production_vertex()->position();

--- a/src/celeritas/io/RootEventReader.cc
+++ b/src/celeritas/io/RootEventReader.cc
@@ -108,7 +108,6 @@ auto RootEventReader::operator()() -> result_type
     CELER_EXPECT(entry_count_ <= num_entries_);
 
     EventId expected_evt_id{0};
-    TrackId track_id{0};
     result_type primaries;
     ScopedRootErrorHandler scoped_root_error;
 
@@ -131,7 +130,6 @@ auto RootEventReader::operator()() -> result_type
         }
 
         Primary primary;
-        primary.track_id = track_id;
         primary.event_id = expected_evt_id;
         primary.particle_id = params_->find(
             PDGNumber{from_leaf<int>(*ttree_->GetLeaf("particle"))});
@@ -141,8 +139,6 @@ auto RootEventReader::operator()() -> result_type
         primary.position = from_array_leaf(*ttree_->GetLeaf("pos"));
         primary.direction = from_array_leaf(*ttree_->GetLeaf("dir"));
         primaries.push_back(std::move(primary));
-
-        track_id++;
     }
 
     scoped_root_error.throw_if_errors();

--- a/src/celeritas/phys/Primary.hh
+++ b/src/celeritas/phys/Primary.hh
@@ -28,7 +28,6 @@ struct Primary
     Real3 direction{0, 0, 0};
     real_type time{};
     EventId event_id;
-    TrackId track_id;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PrimaryGenerator.cc
+++ b/src/celeritas/phys/PrimaryGenerator.cc
@@ -84,7 +84,6 @@ auto PrimaryGenerator::operator()() -> result_type
         p.direction = sample_dir_(rng_);
         p.time = 0;
         p.event_id = EventId{event_count_};
-        p.track_id = TrackId{i};
     }
     ++event_count_;
     return result;

--- a/src/celeritas/track/ExtendFromPrimariesAction.cc
+++ b/src/celeritas/track/ExtendFromPrimariesAction.cc
@@ -209,14 +209,17 @@ void ExtendFromPrimariesAction::step_impl(CoreParams const& params,
  * we do not use \c launch_core or \c launch_action .
  */
 void ExtendFromPrimariesAction::process_primaries(
-    CoreParams const&,
+    CoreParams const& params,
     CoreStateHost& state,
     PrimaryStateData<MemSpace::host> const& pstate) const
 {
     MultiExceptionHandler capture_exception;
     auto primaries = pstate.primaries();
     detail::ProcessPrimariesExecutor execute_thread{
-        state.ptr(), primaries, state.counters()};
+        params.ptr<MemSpace::native>(),
+        state.ptr(),
+        state.counters(),
+        primaries};
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif

--- a/src/celeritas/track/ExtendFromPrimariesAction.cu
+++ b/src/celeritas/track/ExtendFromPrimariesAction.cu
@@ -26,7 +26,10 @@ void ExtendFromPrimariesAction::process_primaries(
 {
     auto primaries = pstate.primaries();
     detail::ProcessPrimariesExecutor execute_thread{
-        state.ptr(), primaries, state.counters()};
+        params.ptr<MemSpace::native>(),
+        state.ptr(),
+        state.counters(),
+        primaries};
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(*this);
     if (!primaries.empty())
     {

--- a/src/celeritas/track/ExtendFromPrimariesAction.cu
+++ b/src/celeritas/track/ExtendFromPrimariesAction.cu
@@ -20,7 +20,7 @@ namespace celeritas
  * Launch a kernel to create track initializers from primary particles.
  */
 void ExtendFromPrimariesAction::process_primaries(
-    CoreParams const&,
+    CoreParams const& params,
     CoreStateDevice& state,
     PrimaryStateData<MemSpace::device> const& pstate) const
 {

--- a/src/celeritas/track/detail/ProcessSecondariesExecutor.hh
+++ b/src/celeritas/track/detail/ProcessSecondariesExecutor.hh
@@ -10,7 +10,6 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/cont/Span.hh"
-#include "corecel/math/Atomics.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
@@ -80,7 +79,7 @@ ProcessSecondariesExecutor::operator()(TrackSlotId tid) const
     }
 
     // Offset in the vector of track initializers
-    auto const& data = state->init;
+    auto& data = state->init;
     CELER_ASSERT(data.secondary_counts[tid] <= counters.num_secondaries);
     size_type offset = counters.num_secondaries - data.secondary_counts[tid];
 
@@ -104,20 +103,9 @@ ProcessSecondariesExecutor::operator()(TrackSlotId tid) const
             GeoTrackView geo(params->geometry, state->geometry, tid);
             CELER_ASSERT(!geo.is_on_boundary());
 
-            /*!
-             * Increment the total number of tracks created for this event and
-             * calculate the track ID of the secondary.
-             *
-             * \todo This is nondeterministic; we need to calculate the track
-             * ID in a reproducible way.
-             */
-            CELER_ASSERT(sim.event_id() < data.track_counters.size());
-            TrackId::size_type track_id = atomic_add(
-                &data.track_counters[sim.event_id()], size_type{1});
-
             // Create a track initializer from the secondary
             TrackInitializer ti;
-            ti.sim.track_id = TrackId{track_id};
+            ti.sim.track_id = make_track_id(params->init, data, sim.event_id());
             ti.sim.parent_id = parent_id;
             ti.sim.event_id = sim.event_id();
             ti.sim.time = sim.time();

--- a/src/celeritas/track/detail/TrackInitAlgorithms.hh
+++ b/src/celeritas/track/detail/TrackInitAlgorithms.hh
@@ -14,6 +14,7 @@
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/track/CoreStateCounters.hh"
+#include "celeritas/track/TrackInitData.hh"
 
 #include "Utils.hh"
 

--- a/src/celeritas/track/detail/Utils.hh
+++ b/src/celeritas/track/detail/Utils.hh
@@ -11,9 +11,11 @@
 #include "corecel/OpaqueId.hh"
 #include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
+#include "corecel/math/Atomics.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/global/CoreTrackData.hh"
 #include "celeritas/phys/ParticleView.hh"
+#include "celeritas/track/TrackInitData.hh"
 
 namespace celeritas
 {
@@ -93,6 +95,24 @@ CELER_FORCEINLINE_FUNCTION size_type index_partitioned(size_type num_new_tracks,
 
     return get_from_front ? index_before(num_new_tracks, tid)
                           : index_before(num_vacancies, tid);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create a unique track ID for the given event.
+ *
+ * \todo This is nondeterministic; we need to calculate the track ID in a
+ * reproducible way.
+ */
+inline CELER_FUNCTION TrackId
+make_track_id(NativeCRef<TrackInitParamsData> const&,
+              NativeRef<TrackInitStateData>& state,
+              EventId event)
+{
+    CELER_EXPECT(event < state.track_counters.size());
+    auto result
+        = atomic_add(&state.track_counters[event], TrackId::size_type{1});
+    return TrackId{result};
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -55,7 +55,6 @@ auto AlongStepTestBase::run(Input const& inp, size_type num_tracks) -> RunResult
         for (auto i : range(num_tracks))
         {
             primaries[i].event_id = EventId{i};
-            primaries[i].track_id = TrackId{i};
         }
 
         // Construct track initializers

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -69,7 +69,6 @@ class KernelContextExceptionTest : public SimpleTestBase, public StepperTestBase
         for (auto i : range(count))
         {
             result[i].event_id = EventId{i / (count / 2)};
-            result[i].track_id = TrackId{i % (count / 2)};
         }
         return result;
     }

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -52,7 +52,6 @@ class SimpleComptonTest : public SimpleTestBase, public StepperTestBase
         p.particle_id = this->particle()->find(pdg::gamma());
         CELER_ASSERT(p.particle_id);
         p.energy = units::MevEnergy{100};
-        p.track_id = TrackId{0};
         p.position = from_cm(Real3{-22, 0, 0});
         p.direction = {1, 0, 0};
         p.time = 0;
@@ -114,7 +113,6 @@ class BadGeometryTest : public InvalidOrangeTestBase
         CELER_ASSERT(p.particle_id);
         p.energy = units::MevEnergy{100};
         p.event_id = EventId{0};
-        p.track_id = TrackId{0};
         p.position = pos;
         p.direction = {1, 0, 0};
         p.time = 0;

--- a/test/celeritas/global/StepperGeant.test.cc
+++ b/test/celeritas/global/StepperGeant.test.cc
@@ -53,7 +53,6 @@ class TestEm3StepperTestBase : public TestEm3Base, public StepperTestBase
         p.particle_id = this->particle()->find(particle);
         CELER_ASSERT(p.particle_id);
         p.energy = energy;
-        p.track_id = TrackId{0};
         p.position = from_cm(Real3{-22, 0, 0});
         p.direction = {1, 0, 0};
         p.time = 0;
@@ -194,7 +193,6 @@ class TestEm15FieldMsc : public TestEm15Base, public StepperTestBase
         p.energy = MevEnergy{10};
         p.position = {0, 0, 0};
         p.time = 0;
-        p.track_id = TrackId{0};
 
         Array<ParticleId, 2> const particles = {
             this->particle()->find(pdg::electron()),
@@ -244,7 +242,6 @@ class OneSteelSphere : public OneSteelSphereBase, public StepperTestBase
 
         for (auto i : range(count))
         {
-            result[i].track_id = TrackId{i};
             result[i].direction = sample_dir(rng);
             result[i].particle_id = particles[i % particles.size()];
         }
@@ -270,10 +267,6 @@ class LeadBox : public LeadBoxTestBase, public StepperTestBase
         p.event_id = EventId{0};
 
         std::vector<Primary> result(count, p);
-        for (auto i : range(count))
-        {
-            result[i].track_id = TrackId{i};
-        }
         return result;
     }
 

--- a/test/celeritas/io/EventIO.test.cc
+++ b/test/celeritas/io/EventIO.test.cc
@@ -98,8 +98,6 @@ TEST_P(EventIOTest, variety_rwr)
     EXPECT_VEC_SOFT_EQ(expected_time, result.time);
     static int const expected_event[] = {0, 0, 0, 1, 1, 1, 2, 2, 2};
     EXPECT_VEC_EQ(expected_event, result.event);
-    static int const expected_track[] = {0, 1, 2, 0, 1, 2, 0, 1, 2};
-    EXPECT_VEC_EQ(expected_track, result.track);
     // clang-format on
 
     // Event reader should keep returning an empty vector
@@ -160,9 +158,6 @@ TEST_P(EventIOTest, no_vertex_rwr)
     static int const expected_event[] = {0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2,
         2, 2};
     EXPECT_VEC_EQ(expected_event, result.event);
-    static int const expected_track[] = {0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2,
-        3, 4};
-    EXPECT_VEC_EQ(expected_track, result.track);
     // clang-format on
 }
 
@@ -213,7 +208,6 @@ TEST_P(EventIOTest, edge_case)
         p.energy = units::MevEnergy{1};
         p.position = {0, 0, 0};
         p.direction = {1, 0, 0};
-        p.track_id = TrackId{0};
         p.event_id = EventId{0};
         std::vector<Primary> event(4, p);
         EventWriter write_event(filename, this->particles());

--- a/test/celeritas/io/EventIOTestBase.cc
+++ b/test/celeritas/io/EventIOTestBase.cc
@@ -51,10 +51,6 @@ void EventIOTestBase::ReadAllResult::print_expected() const
          << repr(this->event)
          << ";\n"
             "EXPECT_VEC_EQ(expected_event, result.event);\n"
-            "static int const expected_track[] = "
-         << repr(this->track)
-         << ";\n"
-            "EXPECT_VEC_EQ(expected_track, result.track);\n"
             "/*** END CODE ***/\n";
 }
 
@@ -115,7 +111,6 @@ auto EventIOTestBase::read_all(Reader& read_event) const -> ReadAllResult
                 result.dir.end(), p.direction.begin(), p.direction.end());
             result.time.push_back(p.time / units::second);
             result.event.push_back(p.event_id.unchecked_get());
-            result.track.push_back(p.track_id.unchecked_get());
         }
     }
     return result;
@@ -135,23 +130,17 @@ void EventIOTestBase::write_test_event(Writer& write_event) const
                       from_cm(Real3{2, 4, 5}),
                       Real3{1, 0, 0},
                       5.67e-9 * units::second,
-                      EventId{0},
-                      TrackId{}};
+                      EventId{0}};
         Primary proton{proton_id,
                        MevEnergy{2.34},
                        from_cm(Real3{3, 5, 8}),
                        Real3{0, 1, 0},
                        5.78e-9 * units::second,
-                       EventId{0},
-                       TrackId{}};
+                       EventId{0}};
         std::vector<Primary> primaries{gamma, proton, gamma, proton};
         primaries[1].position = from_cm(Real3{-3, -4, 5});
         primaries[3].position = primaries[2].position;
         primaries[3].time = primaries[2].time;
-        for (auto i : range(primaries.size()))
-        {
-            primaries[i].track_id = TrackId(i * 2);
-        }
         return primaries;
     }();
 
@@ -199,7 +188,6 @@ void EventIOTestBase::read_check_test_event(Reader& read_event) const
     static real_type const expected_time[] = {5.67e-09, 5.78e-09, 5.67e-09,
         5.67e-09, 5.67e-09, 5.78e-09, 5.67e-09, 5.67e-09, 5.67e-09, 5.67e-09};
     static int const expected_event[] = {0, 0, 0, 0, 1, 1, 1, 1, 1, 2};
-    static int const expected_track[] = {0, 1, 2, 3, 0, 1, 2, 3, 4, 0};
     // clang-format on
 
     EXPECT_VEC_EQ(expected_pdg, result.pdg);
@@ -208,7 +196,6 @@ void EventIOTestBase::read_check_test_event(Reader& read_event) const
     EXPECT_VEC_SOFT_EQ(expected_dir, result.dir);
     EXPECT_VEC_NEAR(expected_time, result.time, real_type(1e-6));
     EXPECT_VEC_EQ(expected_event, result.event);
-    EXPECT_VEC_EQ(expected_track, result.track);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/io/EventIOTestBase.hh
+++ b/test/celeritas/io/EventIOTestBase.hh
@@ -47,7 +47,6 @@ class EventIOTestBase : public Test
         std::vector<double> dir;
         std::vector<double> time;
         std::vector<int> event;
-        std::vector<int> track;
 
         void print_expected() const;
     };

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -212,7 +212,6 @@ auto LArSphereOffloadTest::make_primaries(size_type count) -> VecPrimary
 
     for (auto i : range(count))
     {
-        result[i].track_id = TrackId{i};
         result[i].direction = sample_dir(rng);
         result[i].particle_id = particles[i % particles.size()];
     }

--- a/test/celeritas/phys/PrimaryGenerator.test.cc
+++ b/test/celeritas/phys/PrimaryGenerator.test.cc
@@ -67,7 +67,6 @@ TEST_F(PrimaryGeneratorTest, basic)
 
     std::vector<int> particle_id;
     std::vector<int> event_id;
-    std::vector<int> track_id;
 
     for (size_type i = 0; i < inp.num_events; ++i)
     {
@@ -82,7 +81,6 @@ TEST_F(PrimaryGeneratorTest, basic)
             EXPECT_TRUE(is_soft_unit_vector(p.direction));
             particle_id.push_back(p.particle_id.unchecked_get());
             event_id.push_back(p.event_id.unchecked_get());
-            track_id.push_back(p.track_id.unchecked_get());
         }
     }
     auto primaries = generate_primaries();
@@ -90,11 +88,9 @@ TEST_F(PrimaryGeneratorTest, basic)
 
     static int const expected_particle_id[] = {0, 1, 0, 0, 1, 0};
     static int const expected_event_id[] = {0, 0, 0, 1, 1, 1};
-    static int const expected_track_id[] = {0, 1, 2, 0, 1, 2};
 
     EXPECT_VEC_EQ(expected_particle_id, particle_id);
     EXPECT_VEC_EQ(expected_event_id, event_id);
-    EXPECT_VEC_EQ(expected_track_id, track_id);
 }
 
 TEST_F(PrimaryGeneratorTest, options)
@@ -118,7 +114,6 @@ TEST_F(PrimaryGeneratorTest, options)
     {
         auto const& p = primaries[i];
         EXPECT_EQ(ParticleId{0}, p.particle_id);
-        EXPECT_EQ(TrackId{i}, p.track_id);
         EXPECT_EQ(EventId{0}, p.event_id);
         EXPECT_EQ(MevEnergy{1}, p.energy);
         EXPECT_REAL_EQ(0.0, p.time);

--- a/test/celeritas/track/StatusChecker.test.cc
+++ b/test/celeritas/track/StatusChecker.test.cc
@@ -66,7 +66,6 @@ class StatusCheckerTest : public SimpleTestBase
             p.direction = {0, 0, 1};
             p.time = 0;
             p.event_id = EventId{0};
-            p.track_id = TrackId{i};
             result.push_back(p);
         }
         return result;

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -141,7 +141,6 @@ class TrackInitTestBase : public SimpleTestBase
             p.direction = {0, 0, 1};
             p.time = 0;
             p.event_id = EventId{0};
-            p.track_id = TrackId{i};
             result.push_back(p);
         }
         return result;
@@ -417,19 +416,38 @@ TYPED_TEST(TrackInitTest, primaries)
     }
 
     // Check the results
-    static int const expected_track_ids[]
-        = {8, 1, 9, 3, 10, 5, 11, 7, 12, 9, 13, 11, 14, 13, 15, 15};
+    static int const expected_track_ids[] = {
+        56,
+        1,
+        57,
+        3,
+        58,
+        5,
+        59,
+        7,
+        60,
+        9,
+        61,
+        11,
+        62,
+        13,
+        63,
+        15,
+    };
     static int const expected_parent_ids[]
         = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
     static int const expected_vacancies[] = {0, 2, 4, 6, 8, 10, 12, 14};
-    static int const expected_init_ids[] = {0, 1, 2, 3, 4, 5, 6, 7,
-                                            0, 1, 2, 3, 4, 5, 6, 7,
-                                            0, 1, 2, 3, 4, 5, 6, 7};
+    static int const expected_init_ids[] = {
+        16, 17, 18, 19, 20, 21, 22, 23, 32, 33, 34, 35,
+        36, 37, 38, 39, 48, 49, 50, 51, 52, 53, 54, 55,
+    };
     auto result = RunResult::from_state(this->state());
     EXPECT_VEC_EQ(expected_track_ids, result.track_ids);
+    PRINT_EXPECTED(result.track_ids);
     EXPECT_VEC_EQ(expected_parent_ids, result.parent_ids);
     EXPECT_VEC_EQ(expected_vacancies, result.vacancies);
     EXPECT_VEC_EQ(expected_init_ids, result.init_ids);
+    PRINT_EXPECTED(result.init_ids);
 }
 
 TYPED_TEST(TrackInitTest, extend_from_secondaries)

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -443,11 +443,9 @@ TYPED_TEST(TrackInitTest, primaries)
     };
     auto result = RunResult::from_state(this->state());
     EXPECT_VEC_EQ(expected_track_ids, result.track_ids);
-    PRINT_EXPECTED(result.track_ids);
     EXPECT_VEC_EQ(expected_parent_ids, result.parent_ids);
     EXPECT_VEC_EQ(expected_vacancies, result.vacancies);
     EXPECT_VEC_EQ(expected_init_ids, result.init_ids);
-    PRINT_EXPECTED(result.init_ids);
 }
 
 TYPED_TEST(TrackInitTest, extend_from_secondaries)

--- a/test/celeritas/track/TrackSort.test.cc
+++ b/test/celeritas/track/TrackSort.test.cc
@@ -97,7 +97,6 @@ class TestEm3NoMsc : public TrackSortTestBase, public TestEm3Base
     {
         Primary p;
         p.energy = units::MevEnergy{1000};
-        p.track_id = TrackId{0};
         p.position = from_cm({-22, 0, 0});
         p.direction = {1, 0, 0};
         p.time = 0;

--- a/test/celeritas/user/Diagnostic.test.cc
+++ b/test/celeritas/user/Diagnostic.test.cc
@@ -53,7 +53,6 @@ class SimpleComptonDiagnosticTest : public SimpleTestBase,
         for (auto i : range(count))
         {
             result[i].event_id = EventId{0};
-            result[i].track_id = TrackId{i};
             result[i].particle_id = gamma;
         }
         return result;
@@ -98,7 +97,6 @@ class TestEm3DiagnosticTest : public TestEm3Base, public DiagnosticTestBase
         for (auto i : range(count))
         {
             result[i].event_id = EventId{0};
-            result[i].track_id = TrackId{i};
             result[i].particle_id = (i % 2 == 0 ? electron : positron);
         }
         return result;

--- a/test/celeritas/user/SlotDiagnostic.test.cc
+++ b/test/celeritas/user/SlotDiagnostic.test.cc
@@ -168,7 +168,6 @@ class TestEm3SlotTest : virtual public TestEm3Base,
         std::vector<Primary> result(count, p);
         for (auto i : range(count))
         {
-            result[i].track_id = TrackId{i};
             result[i].particle_id = particles[i % particles.size()];
         }
         return result;

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -48,7 +48,6 @@ class KnSimpleLoopTestBase : public SimpleTestBase,
         p.particle_id = this->particle()->find(pdg::gamma());
         CELER_ASSERT(p.particle_id);
         p.energy = MevEnergy{10.0};
-        p.track_id = TrackId{0};
         p.position = {0, 0, 0};
         p.direction = {1, 0, 0};
         p.time = 0;
@@ -109,7 +108,6 @@ class TestEm3CollectorTestBase : public TestEm3Base,
         for (auto i : range(count))
         {
             result[i].event_id = EventId{0};
-            result[i].track_id = TrackId{i};
             result[i].particle_id = (i % 2 == 0 ? electron : positron);
         }
         return result;


### PR DESCRIPTION
Following up to #1477, it's bad for us to manually assign track IDs since these should be *internal counters*: assigning them outside of the internal initialization will almost certainly result in duplicate track IDs. This removes track IDs from the primaries.