### PR TITLE
Fix optical import when unused materials are defined

### DIFF
--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -144,6 +144,7 @@ if(CELERITAS_USE_Geant4)
     ext/detail/GeantModelImporter.cc
     ext/detail/GeantOpticalModelImporter.cc
     ext/detail/GeantProcessImporter.cc
+    ext/detail/GeoOpticalIdMap.cc
     ext/detail/MuHadEmStandardPhysics.cc
   )
   celeritas_get_g4libs(_cg4_libs

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -481,47 +481,54 @@ std::vector<ImportElement> import_elements()
 /*!
  * Store material-dependent optical properties.
  *
- * This returns:
- * - A vector of optical materials corresponding to an "optical material ID",
- *   and
- * - A "map" (indirection vector) of the optical material ID for each "geometry
- *   material"
+ * This returns a vector of optical materials corresponding to an "optical
+ * material ID".
  */
-std::pair<std::vector<ImportOpticalMaterial>, std::vector<OpticalMaterialId>>
-import_optical()
+std::vector<ImportOpticalMaterial>
+import_optical(detail::GeoOpticalIdMap const& geo_to_opt)
 {
-    auto const& mt = *G4Material::GetMaterialTable();
-    CELER_ASSERT(mt.size() > 0);
+    if (geo_to_opt.empty())
+    {
+        CELER_LOG(warning)
+            << R"(Optical materials were requested but none are present)";
+        // No optical materials
+        return {};
+    }
 
-    std::vector<OpticalMaterialId> geo_to_opt(mt.size());
-    std::vector<ImportOpticalMaterial> result;
+    auto const& mt = *G4Material::GetMaterialTable();
+    CELER_ASSERT(mt.size() == geo_to_opt.num_geo());
+
+    std::vector<ImportOpticalMaterial> result(geo_to_opt.num_optical());
 
     // Loop over optical materials
-    for (auto mat_idx : range(mt.size()))
+    for (auto geo_mat_id : range(GeoMaterialId{geo_to_opt.num_geo()}))
     {
-        G4Material const* material = mt[mat_idx];
-        CELER_ASSERT(material);
-        CELER_ASSERT(mat_idx == static_cast<std::size_t>(material->GetIndex()));
-
-        // Add optical material properties, if any are present
-        auto const* mpt = material->GetMaterialPropertiesTable();
-        if (!mpt)
+        auto opt_mat_id = geo_to_opt[geo_mat_id];
+        if (!opt_mat_id)
         {
             continue;
         }
+        // Get Geant4 material properties
+        G4Material const* material = mt[geo_mat_id.get()];
+        CELER_ASSERT(material);
+        CELER_ASSERT(geo_mat_id.get()
+                     == static_cast<std::size_t>(material->GetIndex()));
+        auto const* mpt = material->GetMaterialPropertiesTable();
+        CELER_ASSERT(mpt);
 
-        ImportOpticalMaterial optical;
         detail::GeantMaterialPropertyGetter get_property{*mpt};
+
+        // Optical materials should map uniquely
+        ImportOpticalMaterial& optical = result[opt_mat_id.get()];
+        CELER_ASSERT(!optical);
 
         // Save common properties
         bool has_rindex = get_property(&optical.properties.refractive_index,
                                        "RINDEX",
                                        ImportUnits::unitless);
-        if (!has_rindex)
-        {
-            // Refractive index is required: assume the material isn't optical
-            continue;
-        }
+        // Existence of RINDEX should correspond to GeoOpticalIdMap
+        // construction
+        CELER_ASSERT(has_rindex);
 
         // Save scintillation properties
         get_property(&optical.scintillation.material.yield_per_energy,
@@ -567,13 +574,11 @@ import_optical()
         get_property(
             &optical.wls.component, "WLSCOMPONENT", ImportUnits::unitless);
 
-        // Save optical material ID and data
-        geo_to_opt[mat_idx] = OpticalMaterialId(result.size());
-        result.push_back(std::move(optical));
+        CELER_ASSERT(optical);
     }
 
     CELER_LOG(debug) << "Loaded " << result.size() << " optical materials";
-    return {std::move(result), std::move(geo_to_opt)};
+    return result;
 }
 
 //---------------------------------------------------------------------------//
@@ -652,7 +657,7 @@ std::vector<ImportGeoMaterial> import_geo_materials()
  */
 std::vector<ImportPhysMaterial>
 import_phys_materials(GeantImporter::DataSelection::Flags particle_flags,
-                      std::vector<OpticalMaterialId> const& geo_to_opt)
+                      detail::GeoOpticalIdMap const& geo_to_opt)
 {
     ParticleFilter include_particle{particle_flags};
     auto const& pct = *G4ProductionCutsTable::GetProductionCutsTable();
@@ -714,8 +719,8 @@ import_phys_materials(GeantImporter::DataSelection::Flags particle_flags,
         material.geo_material_id = g4material->GetIndex();
         if (!geo_to_opt.empty())
         {
-            CELER_ASSERT(material.geo_material_id < geo_to_opt.size());
-            if (auto opt_id = geo_to_opt[material.geo_material_id])
+            if (auto opt_id
+                = geo_to_opt[GeoMaterialId{material.geo_material_id}])
             {
                 // Assign the optical material corresponding to the geometry
                 // material
@@ -789,7 +794,8 @@ std::vector<ImportRegion> import_regions()
 auto import_processes(GeantImporter::DataSelection::Flags process_flags,
                       std::vector<ImportParticle> const& particles,
                       std::vector<ImportElement> const& elements,
-                      std::vector<ImportPhysMaterial> const& materials)
+                      std::vector<ImportPhysMaterial> const& materials,
+                      detail::GeoOpticalIdMap const& geo_to_opt)
     -> std::tuple<std::vector<ImportProcess>,
                   std::vector<ImportMscModel>,
                   std::vector<ImportOpticalModel>>
@@ -804,7 +810,7 @@ auto import_processes(GeantImporter::DataSelection::Flags process_flags,
     static celeritas::TypeDemangler<G4VProcess> const demangle_process;
     std::unordered_map<G4VProcess const*, G4ParticleDefinition const*> visited;
     detail::GeantProcessImporter import_process(materials, elements);
-    detail::GeantOpticalModelImporter import_optical_model(materials);
+    detail::GeantOpticalModelImporter import_optical_model(geo_to_opt);
 
     auto append_process = [&](G4ParticleDefinition const& particle,
                               G4VProcess const& process) -> void {
@@ -862,20 +868,23 @@ auto import_processes(GeantImporter::DataSelection::Flags process_flags,
                               std::make_move_iterator(new_msc_models.begin()),
                               std::make_move_iterator(new_msc_models.end()));
         }
-        else if (dynamic_cast<G4OpAbsorption const*>(&process))
+        else if (import_optical_model)
         {
-            optical_models.push_back(
-                import_optical_model(optical::ImportModelClass::absorption));
-        }
-        else if (dynamic_cast<G4OpRayleigh const*>(&process))
-        {
-            optical_models.push_back(
-                import_optical_model(optical::ImportModelClass::rayleigh));
-        }
-        else if (dynamic_cast<G4OpWLS const*>(&process))
-        {
-            optical_models.push_back(
-                import_optical_model(optical::ImportModelClass::wls));
+            if (dynamic_cast<G4OpAbsorption const*>(&process))
+            {
+                optical_models.push_back(import_optical_model(
+                    optical::ImportModelClass::absorption));
+            }
+            else if (dynamic_cast<G4OpRayleigh const*>(&process))
+            {
+                optical_models.push_back(
+                    import_optical_model(optical::ImportModelClass::rayleigh));
+            }
+            else if (dynamic_cast<G4OpWLS const*>(&process))
+            {
+                optical_models.push_back(
+                    import_optical_model(optical::ImportModelClass::wls));
+            }
         }
         else
         {
@@ -1153,17 +1162,19 @@ ImportData GeantImporter::operator()(DataSelection const& selected)
         ScopedGeantExceptionHandler scoped_exceptions;
         ScopedTimeLog scoped_time;
 
+        detail::GeoOpticalIdMap geo_to_opt;
+
         if (selected.particles != DataSelection::none)
         {
             imported.particles = import_particles(selected.particles);
         }
         if (selected.materials)
         {
-            std::vector<OpticalMaterialId> geo_to_opt;
             if (selected.processes & DataSelection::optical)
             {
-                std::tie(imported.optical_materials, geo_to_opt)
-                    = import_optical();
+                geo_to_opt
+                    = detail::GeoOpticalIdMap(*G4Material::GetMaterialTable());
+                imported.optical_materials = import_optical(geo_to_opt);
             }
 
             imported.isotopes = import_isotopes();
@@ -1180,7 +1191,8 @@ ImportData GeantImporter::operator()(DataSelection const& selected)
                 = import_processes(selected.processes,
                                    imported.particles,
                                    imported.elements,
-                                   imported.phys_materials);
+                                   imported.phys_materials,
+                                   geo_to_opt);
 
             if (have_process(ImportProcessClass::mu_pair_prod))
             {

--- a/src/celeritas/ext/detail/GeantOpticalModelImporter.hh
+++ b/src/celeritas/ext/detail/GeantOpticalModelImporter.hh
@@ -15,13 +15,13 @@
 #include "celeritas/Types.hh"
 #include "celeritas/io/ImportOpticalModel.hh"
 
+#include "GeoOpticalIdMap.hh"
+
 class G4VProcess;
 class G4MaterialPropertiesTable;
 
 namespace celeritas
 {
-struct ImportPhysMaterial;
-
 namespace detail
 {
 //---------------------------------------------------------------------------//
@@ -38,17 +38,20 @@ class GeantOpticalModelImporter
 
   public:
     // Construct model importer with given optical material mapping
-    GeantOpticalModelImporter(std::vector<ImportPhysMaterial> const& materials);
+    GeantOpticalModelImporter(GeoOpticalIdMap const& geo_to_opt);
 
     // Import model MFP table for given model class
     ImportOpticalModel operator()(IMC imc) const;
 
+    //! True if any optical materials are present
+    explicit operator bool() const { return !opt_to_mat_.empty(); }
+
   private:
+    std::vector<G4MaterialPropertiesTable const*> opt_to_mat_;
+
     // Import MFP table for the given property name
     std::vector<ImportPhysicsVector>
     import_mfps(std::string const& mfp_property_name) const;
-
-    std::vector<G4MaterialPropertiesTable const*> opt_to_mat_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeoOpticalIdMap.cc
+++ b/src/celeritas/ext/detail/GeoOpticalIdMap.cc
@@ -1,0 +1,55 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/detail/GeoOpticalIdMap.cc
+//---------------------------------------------------------------------------//
+#include "GeoOpticalIdMap.hh"
+
+#include <G4Material.hh>
+
+#include "corecel/cont/Range.hh"
+
+#include "GeantMaterialPropertyGetter.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from underlying Geant4 objects.
+ */
+GeoOpticalIdMap::GeoOpticalIdMap(G4MaterialTable const& mt)
+    : geo_to_opt_{mt.size()}
+{
+    OpticalMaterialId::size_type next_id{0};
+    for (auto mat_idx : range(geo_to_opt_.size()))
+    {
+        G4Material const* material = mt[mat_idx];
+        CELER_ASSERT(material);
+        CELER_ASSERT(mat_idx == static_cast<std::size_t>(material->GetIndex()));
+
+        // Add optical material properties, if any are present
+        if (auto* mpt = material->GetMaterialPropertiesTable())
+        {
+            if (mpt->GetProperty("RINDEX"))
+            {
+                geo_to_opt_[mat_idx] = OpticalMaterialId{next_id++};
+            }
+        }
+    }
+
+    num_optical_ = next_id;
+    if (next_id == 0)
+    {
+        // No optical materials: clear the array so we're "false"
+        geo_to_opt_ = {};
+    }
+    CELER_ENSURE(this->empty() == (num_optical_ == 0));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/ext/detail/GeoOpticalIdMap.hh
+++ b/src/celeritas/ext/detail/GeoOpticalIdMap.hh
@@ -1,0 +1,74 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/detail/GeoOpticalIdMap.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+#include <G4MaterialTable.hh>
+
+#include "geocel/Types.hh"
+#include "celeritas/Types.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct optical material IDs and map from a geometry material ID.
+ *
+ * This construct a material -> optical material mapping based on whether the
+ * \c RINDEX table is present on a Geant4 material.
+ *
+ * As a reminder, \em geometry materials correspond to \c G4Material and
+ * \em physics materials correspond to \c G4MaterialCutsCouple .
+ */
+class GeoOpticalIdMap
+{
+  public:
+    //! Construct without optical materials
+    GeoOpticalIdMap() = default;
+
+    // Construct from underlying Geant4 objects
+    explicit GeoOpticalIdMap(G4MaterialTable const&);
+
+    // Return the optical ID corresponding to a geo ID
+    inline OpticalMaterialId operator[](GeoMaterialId) const;
+
+    //! True if no optical materials are present
+    bool empty() const { return geo_to_opt_.empty(); }
+
+    //! Number of geometry materials
+    GeoMaterialId::size_type num_geo() const { return geo_to_opt_.size(); }
+
+    //! Number of optical materials
+    OpticalMaterialId::size_type num_optical() const { return num_optical_; }
+
+  private:
+    std::vector<OpticalMaterialId> geo_to_opt_;
+    OpticalMaterialId::size_type num_optical_{};
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Return the optical ID corresponding to a geo ID.
+ *
+ * The result \em may be a "null" ID if there's no associated optical physics.
+ */
+OpticalMaterialId GeoOpticalIdMap::operator[](GeoMaterialId m) const
+{
+    CELER_EXPECT(!this->empty());
+    CELER_EXPECT(m < this->num_geo());
+
+    return geo_to_opt_[m.get()];
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -154,6 +154,7 @@ set(_import_filter
   "OneSteelSphere.*"
   "OneSteelSphereGG.*"
   "LarSphere.*"
+  "LarSphereExtramat.*"
   "Solids.*"
 )
 if(Geant4_VERSION VERSION_LESS 11.0)

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -342,6 +342,24 @@ class LarSphere : public GeantImporterTest
 };
 
 //---------------------------------------------------------------------------//
+class LarSphereExtramat : public GeantImporterTest
+{
+  protected:
+    std::string_view geometry_basename() const override
+    {
+        return "lar-sphere-extramat"sv;
+    }
+
+    GeantPhysicsOptions build_geant_options() const override
+    {
+        auto opts = GeantImporterTest::build_geant_options();
+        opts.optical.absorption = true;
+        opts.optical.rayleigh_scattering = true;
+        return opts;
+    }
+};
+
+//---------------------------------------------------------------------------//
 class Solids : public GeantImporterTest
 {
   protected:
@@ -1780,6 +1798,53 @@ TEST_F(LarSphere, optical)
     EXPECT_DOUBLE_EQ(1.0597e-05, properties.refractive_index.x.back());
     EXPECT_DOUBLE_EQ(1.2221243542166, properties.refractive_index.y.front());
     EXPECT_DOUBLE_EQ(1.6167515615703, properties.refractive_index.y.back());
+}
+
+TEST_F(LarSphereExtramat, optical)
+{
+    auto&& imported = this->imported_data();
+    ASSERT_EQ(3, imported.optical_models.size());
+    ASSERT_EQ(1, imported.optical_materials.size());
+    ASSERT_EQ(3, imported.geo_materials.size());
+    ASSERT_EQ(2, imported.phys_materials.size());
+
+    // First material is vacuum, no optical properties
+    ASSERT_EQ(0, imported.phys_materials[0].geo_material_id);
+    EXPECT_EQ("vacuum", imported.geo_materials[0].name);
+    EXPECT_EQ(ImportPhysMaterial::unspecified,
+              imported.phys_materials[0].optical_material_id);
+
+    // Second material is liquid argon
+    ASSERT_EQ(1, imported.phys_materials[1].geo_material_id);
+    EXPECT_EQ("lAr", imported.geo_materials[1].name);
+    ASSERT_EQ(0, imported.phys_materials[1].optical_material_id);
+
+    // Check scintillation optical properties
+    auto const& optical = imported.optical_materials[0];
+    EXPECT_FALSE(optical.scintillation);
+
+    // Check Rayleigh optical properties
+    auto const& rayleigh_model = imported.optical_models[1];
+    EXPECT_EQ(optical::ImportModelClass::rayleigh, rayleigh_model.model_class);
+    ASSERT_EQ(1, rayleigh_model.mfps.size());
+
+    auto const& rayleigh_mfp = rayleigh_model.mfps.front();
+    EXPECT_EQ(2, rayleigh_mfp.x.size());
+    EXPECT_DOUBLE_EQ(1.55e-06, rayleigh_mfp.x.front());
+    EXPECT_DOUBLE_EQ(1.55e-05, rayleigh_mfp.x.back());
+    EXPECT_REAL_EQ(32142.9, to_cm(rayleigh_mfp.y.front()));
+    EXPECT_REAL_EQ(54.6429, to_cm(rayleigh_mfp.y.back()));
+
+    // Check common optical properties
+    // Refractive index data in the geometry comes from the refractive index
+    // database https://refractiveindex.info and was calculating using the
+    // methods described in: E. Grace, A. Butcher, J.  Monroe, J. A. Nikkel.
+    // Index of refraction, Rayleigh scattering length, and Sellmeier
+    // coefficients in solid and liquid argon and xenon, Nucl.  Instr. Meth.
+    // Phys. Res. A 867, 204-208 (2017)
+    auto const& properties = optical.properties;
+    EXPECT_TRUE(properties);
+    EXPECT_EQ(2, properties.refractive_index.x.size());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -1803,7 +1803,7 @@ TEST_F(LarSphere, optical)
 TEST_F(LarSphereExtramat, optical)
 {
     auto&& imported = this->imported_data();
-    ASSERT_EQ(3, imported.optical_models.size());
+    ASSERT_EQ(2, imported.optical_models.size());
     ASSERT_EQ(1, imported.optical_materials.size());
     ASSERT_EQ(3, imported.geo_materials.size());
     ASSERT_EQ(2, imported.phys_materials.size());

--- a/test/geocel/data/lar-sphere-extramat.gdml
+++ b/test/geocel/data/lar-sphere-extramat.gdml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+  <define>
+    <matrix name="RI" coldim="2" values="1.8785e-06 1.2221243542166 1.0597e-05 1.6167515615703"/>
+    <matrix name="RAY" coldim="2" values="1.55e-06 321429 1.55e-05 546.429"/>
+    <matrix name="ABS" coldim="2" values="1.3778e-06 864.473 1.55e-05 0.00296154"/>
+  </define>
+
+  <materials>
+    <isotope N="1" Z="1" name="H1">
+      <atom unit="g/mole" value="1.00782503081372"/>
+    </isotope>
+    <isotope N="2" Z="1" name="H2">
+      <atom unit="g/mole" value="2.01410199966617"/>
+    </isotope>
+    <element name="H">
+      <fraction n="0.999885" ref="H1"/>
+      <fraction n="0.000115" ref="H2"/>
+    </element>
+    <material name="vacuum" state="gas">
+      <T unit="K" value="2.73"/>
+      <P unit="pascal" value="3e-18"/>
+      <MEE unit="eV" value="21.8"/>
+      <D unit="g/cm3" value="1e-25"/>
+      <fraction n="1" ref="H"/>
+    </material>
+    <isotope N="36" Z="18" name="Ar36">
+      <atom unit="g/mole" value="35.9675"/>
+    </isotope>
+    <isotope N="38" Z="18" name="Ar38">
+      <atom unit="g/mole" value="37.9627"/>
+    </isotope>
+    <isotope N="40" Z="18" name="Ar40">
+      <atom unit="g/mole" value="39.9624"/>
+    </isotope>
+    <element name="Ar">
+      <fraction n="0.003365" ref="Ar36"/>
+      <fraction n="0.000632" ref="Ar38"/>
+      <fraction n="0.996003" ref="Ar40"/>
+    </element>
+    <material name="lAr" state="liquid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="188"/>
+      <D unit="g/cm3" value="1.396"/>
+      <fraction n="1" ref="Ar"/>
+      <property name="RINDEX" ref="RI"/>
+      <property name="RAYLEIGH" ref="RAY"/>
+      <property name="ABSLENGTH" ref="ABS"/>
+    </material>
+    <material name="lAr_unused" state="liquid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="188"/>
+      <D unit="g/cm3" value="1.396"/>
+      <fraction n="1" ref="Ar"/>
+    </material>
+  </materials>
+
+  <solids>
+    <sphere lunit="cm" name="sphere" rmax="100.0" deltaphi="360" deltatheta="180" aunit="deg"/>
+    <sphere lunit="cm" name="world_sphere" rmin="0.0" rmax="1000.0" deltaphi="360" deltatheta="180" aunit="deg"/>
+  </solids>
+
+  <structure>
+    <volume name="sphere">
+      <solidref ref="sphere"/>
+      <materialref ref="lAr"/>
+    </volume>
+    <volume name="world">
+      <solidref ref="world_sphere"/>
+      <materialref ref="vacuum"/>
+      <physvol>
+        <volumeref ref="sphere"/>
+      </physvol>
+    </volume>
+  </structure>
+
+  <setup name="Default" version="1.0">
+    <world ref="world"/>
+  </setup>
+
+</gdml>


### PR DESCRIPTION
This reproduces and fixes a crash seen during the initial ATLAS run inside of the `GeantOpticalModelImporter` constructor. In #1439, I didn't notice that the "physical material IDs" (aka "material cuts couple") were used instead of the "geometry material IDs" (aka "materials"), so there ended up being an out-of-bounds error because there were fewer physics materials compared to geometry materials. It was also improper to do the remapping during setup for problems that *don't* use optical processes, so this fixes that as well.