### PR TITLE
Fix GDML export messages and geometry-only use case

### DIFF
--- a/src/geocel/GeantGeoUtils.cc
+++ b/src/geocel/GeantGeoUtils.cc
@@ -201,6 +201,13 @@ void write_geant_geometry(G4VPhysicalVolume const* world,
 {
     CELER_EXPECT(world);
 
+    CELER_LOG(info) << "Writing Geant4 geometry to GDML at " << out_filename;
+    ScopedMem record_mem("write_geant_geometry");
+    ScopedTimeLog scoped_time;
+
+    ScopedGeantLogger scoped_logger;
+    ScopedGeantExceptionHandler scoped_exceptions;
+
     G4GDMLParser parser;
     parser.SetEnergyCutsExport(true);
     parser.SetSDExport(true);

--- a/src/geocel/GeantGeoUtils.cc
+++ b/src/geocel/GeantGeoUtils.cc
@@ -209,10 +209,20 @@ void write_geant_geometry(G4VPhysicalVolume const* world,
     ScopedGeantExceptionHandler scoped_exceptions;
 
     G4GDMLParser parser;
-    parser.SetEnergyCutsExport(true);
-    parser.SetSDExport(true);
     parser.SetOverlapCheck(false);
-    parser.SetRegionExport(true);
+
+    if (!world->GetLogicalVolume()->GetRegion())
+    {
+        CELER_LOG(warning) << "Geant4 regions have not been set up: skipping "
+                              "export of energy cuts and regions";
+    }
+    else
+    {
+        parser.SetEnergyCutsExport(true);
+        parser.SetRegionExport(true);
+    }
+
+    parser.SetSDExport(true);
     parser.SetStripFlag(false);
 #if G4VERSION_NUMBER >= 1070
     parser.SetOutputFileOverwrite(true);

--- a/test/geocel/GeantGeoUtils.test.cc
+++ b/test/geocel/GeantGeoUtils.test.cc
@@ -10,6 +10,9 @@
 #include <algorithm>
 #include <G4LogicalVolume.hh>
 
+#include "corecel/ScopedLogStorer.hh"
+#include "corecel/io/Logger.hh"
+
 #include "celeritas_test.hh"
 #include "g4/GeantGeoTestBase.hh"
 
@@ -56,6 +59,23 @@ class SolidsTest : public GeantGeoUtilsTest
 {
     std::string geometry_basename() const override { return "solids"; }
 };
+
+using GdmlTest = SolidsTest;
+
+TEST_F(GdmlTest, write)
+{
+    auto* world = this->geometry()->world();
+    ASSERT_TRUE(world);
+
+    ScopedLogStorer scoped_log_{&celeritas::world_logger(), LogLevel::warning};
+    write_geant_geometry(world, this->make_unique_filename(".gdml"));
+
+    static char const* const expected_log_messages[] = {
+        R"(Geant4 regions have not been set up: skipping export of energy cuts and regions)"};
+    EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
+    static char const* const expected_log_levels[] = {"warning"};
+    EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
+}
 
 using FindGeantVolumesTest = SolidsTest;
 


### PR DESCRIPTION
This cleans up output from the GDML exported in #1451 and fixes a crash when in "geometry-only" mode.