### PR TITLE
Add CELER_NONFATAL_FLUSH to cleanly kill stuck tracks

### DIFF
--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -108,7 +108,7 @@ function(celer_app_test ext)
     if(CELER_DISABLE_DEVICE)
       list(APPEND _extra_props DISABLED true)
     endif()
-  elseif(ext STREQUAL "cpu")
+  elseif(ext MATCHES "^cpu")
     list(APPEND _extra_env "CELER_DISABLE_DEVICE=1")
   else()
     list(APPEND _extra_env "CELER_DISABLE=1")
@@ -130,6 +130,7 @@ endfunction()
 
 celer_app_test("gpu")
 celer_app_test("cpu")
+celer_app_test("cpu-nonfatal")
 celer_app_test("none")
 
 #-----------------------------------------------------------------------------#

--- a/app/celer-g4/test-harness.py
+++ b/app/celer-g4/test-harness.py
@@ -87,6 +87,14 @@ inp = {
     "step_diagnostic_bins": 8,
 }
 
+if ext == "cpu-nonfatal":
+    inp.update({
+        "max_steps": 30,
+        "environ": {
+            "CELER_NONFATAL_FLUSH": "1",
+        }
+    })
+
 kwargs = {}
 if use_celeritas:
     # IO through streams should work with celeritas or g4 as driver, but just

--- a/doc/introduction/usage/env.rst
+++ b/doc/introduction/usage/env.rst
@@ -24,7 +24,7 @@ tell what variables are in use or may be useful.
  CELER_DISABLE_PARALLEL  corecel   Disable MPI support
  CELER_DISABLE_ROOT      corecel   Disable ROOT I/O calls
  CELER_DEVICE_ASYNC      corecel   Flag for asynchronous memory allocation
- CELER_ENABLE_PROFILING  corecel   Set up NVTX/ROCTX profiling ranges [#pr]
+ CELER_ENABLE_PROFILING  corecel   Set up NVTX/ROCTX profiling ranges [#pr]_
  CELER_LOG               corecel   Set the "global" logger verbosity
  CELER_LOG_LOCAL         corecel   Set the "local" logger verbosity
  CELER_MEMPOOL... [#mp]_ corecel   Change ``cudaMemPoolAttrReleaseThreshold``
@@ -37,12 +37,18 @@ tell what variables are in use or may be useful.
  VECGEOM_VERBOSE         celeritas VecGeom CUDA verbosity
  CELER_DISABLE           accel     Disable Celeritas offloading entirely
  CELER_KILL_OFFLOAD      accel     Kill Celeritas-supported tracks in Geant4
+ CELER_NONFATAL_FLUSH    accel     Instead of crashing, kill tracks [#nf]_
  CELER_STRIP_SOURCEDIR   accel     Strip directories from exception output
  ======================= ========= ==========================================
 
 .. [#bs] CELER_PERFETTO_BUFFER_SIZE_MB
 .. [#mp] CELER_MEMPOOL_RELEASE_THRESHOLD
 .. [#pr] See :ref:`profiling`
+.. [#nf] Normally, exceeding the "maximum steps" or interrupting the stepping
+   loop will call G4Exception, which normally kills the code. (In external
+   frameworks this usually causes a stack trace and core dump.) Instead of
+   doing that, kill all the active tracks and print their state. If more tracks
+   are buffered, those will continue to transport.
 
 Some of the Celeritas-defined environment variables have prefixes from other
 libraries because they directly control the behavior of that library and


### PR DESCRIPTION
This adds a new environment variable that can be set to change the behavior of "max steps exceeded" and "interrupted". Normally, both of those call G4Exception which (when run through frameworks) kills the code. With the flag enabled, it will kill all active tracks (follow-on to #1451).