### PR TITLE
Give priority to existing environment variables for G4 data location

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,9 +88,11 @@ if(CELERITAS_USE_Geant4)
   # Optional dependence on low-energy EM data and neutron data
   set(CELERITASTEST_G4ENV)
   foreach(_ds G4EMLOW G4ENSDFSTATE G4PARTICLEXS)
-    list(APPEND CELERITASTEST_G4ENV
-      "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
-    )
+    if(NOT DEFINED ENV{${Geant4_DATASET_${_ds}_ENVVAR}})
+      list(APPEND CELERITASTEST_G4ENV
+         "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
+       )
+    endif()
   endforeach()
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,7 +93,7 @@ if(CELERITAS_USE_Geant4)
          "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
        )
     else()
-      message(STATUS "Value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the enviroment rather than the Geant4 cmake fragment")
+      message(STATUS "Value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the environment rather than the Geant4 cmake fragment")
     endif()
   endforeach()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,6 +92,8 @@ if(CELERITAS_USE_Geant4)
       list(APPEND CELERITASTEST_G4ENV
          "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
        )
+    else()
+      message(STATUS "Value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the enviroment rather than the Geant4 cmake fragment")
     endif()
   endforeach()
 endif()


### PR DESCRIPTION
This is necessary for proper operation when building and testing Celeritas
in a ATLAS build environment.  In the ATLAS build environment the Geant4
cmake fragment contains incorrect information about the location of the
data file (it points to the long gone build directory) so we need
to trust the environment variables instead.