### PR TITLE
Fix tracking cut message

### DIFF
--- a/src/celeritas/global/DebugIO.json.cc
+++ b/src/celeritas/global/DebugIO.json.cc
@@ -132,7 +132,7 @@ void to_json_impl(nlohmann::json& j,
                   FromId from_id)
 {
     ASSIGN_TRANSFORMED(particle_id, from_id);
-    ASSIGN_TRANSFORMED(energy, Labeled{units::Mev::label()});
+    ASSIGN_TRANSFORMED(energy, passthrough);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/detail/TrackingCutExecutor.hh
+++ b/src/celeritas/phys/detail/TrackingCutExecutor.hh
@@ -60,8 +60,6 @@ TrackingCutExecutor::operator()(celeritas::CoreTrackView& track)
         // Energy conservation for killed positrons
         deposited += 2 * particle.mass().value();
     }
-    track.make_physics_step_view().deposit_energy(Energy{deposited});
-    particle.subtract_energy(particle.energy());
 
 #if !CELER_DEVICE_COMPILE
     {
@@ -77,6 +75,9 @@ TrackingCutExecutor::operator()(celeritas::CoreTrackView& track)
             << ' ' << Energy::unit_type::label();
     }
 #endif
+
+    track.make_physics_step_view().deposit_energy(Energy{deposited});
+    particle.subtract_energy(particle.energy());
 
     sim.status(TrackStatus::killed);
 }

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -173,7 +173,7 @@ TEST_F(SimpleComptonTest, fail_initialize)
 
         static char const* const expected_log_messages[] = {
             "Track started outside the geometry",
-            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[1001.0,0.0,0.0],"cm"]},"particle":{"energy":[[0.0,"MeV"],"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":15},"thread_id":31,"track_slot_id":31}: depositing 100 MeV)",
+            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[1001.0,0.0,0.0],"cm"]},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":15},"thread_id":31,"track_slot_id":31}: depositing 100 MeV)",
         };
         if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
             && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
@@ -294,8 +294,8 @@ TEST_F(SimpleComptonTest, kill_active)
     {
         static char const* const expected_log_messages[] = {
             "Killing 2 active tracks",
-            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner@0x0"},"particle":{"energy":[[0.0,"MeV"],"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
-            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner@0x0"},"particle":{"energy":[[0.0,"MeV"],"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
+            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner@0x0"},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
+            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner@0x0"},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
         };
         EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages())
             << scoped_log;
@@ -376,7 +376,7 @@ TEST_F(BadGeometryTest, no_volume_host)
     // clang-format off
     static char const* const expected_log_messages[] = {
         "Failed to initialize geometry state: could not find associated volume in universe 0 at local position {-5, 0, 0}",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[-5.0,0.0,0.0],"cm"]},"particle":{"energy":[[0.0,"MeV"],"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[-5.0,0.0,0.0],"cm"]},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
     // clang-format on
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
@@ -395,7 +395,7 @@ TEST_F(BadGeometryTest, no_material_host)
 
     static char const* const expected_log_messages[] = {
         "Track started in an unknown material",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":false,"pos":[[5.0,0.0,0.0],"cm"],"volume_id":"[missing material]@world"},"particle":{"energy":[[0.0,"MeV"],"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: lost 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":false,"pos":[[5.0,0.0,0.0],"cm"],"volume_id":"[missing material]@world"},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: lost 100 MeV)",
     };
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
@@ -413,7 +413,7 @@ TEST_F(BadGeometryTest, no_new_volume_host)
     static char const* const expected_log_messages[] = {
         "track failed to cross local surface 2 in universe 0 at local "
         "position {-6, 0, 0} along local direction {1, 0, 0}",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":true,"pos":[[-6.0,0.0,0.0],"cm"]},"particle":{"energy":[[0.0,"MeV"],"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.001000000000000334,"cm"],"time":[3.335640951982634e-14,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":true,"pos":[[-6.0,0.0,0.0],"cm"]},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.001000000000000334,"cm"],"time":[3.335640951982634e-14,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
@@ -431,7 +431,7 @@ TEST_F(BadGeometryTest, start_outside_host)
 
     static char const* const expected_log_messages[] = {
         "Track started outside the geometry",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[20.0,0.0,0.0],"cm"]},"particle":{"energy":[[0.0,"MeV"],"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[20.0,0.0,0.0],"cm"]},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE


### PR DESCRIPTION
Following on to #1451 , this waits to deposit the track's energy until *after* the cut message is displayed. It also fixes a duplicate printing of the MeV label.