### PR TITLE
Define `id_cast` helper function

### DIFF
--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -511,8 +511,8 @@ import_optical(detail::GeoOpticalIdMap const& geo_to_opt)
         // Get Geant4 material properties
         G4Material const* material = mt[geo_mat_id.get()];
         CELER_ASSERT(material);
-        CELER_ASSERT(geo_mat_id.get()
-                     == static_cast<std::size_t>(material->GetIndex()));
+        CELER_ASSERT(geo_mat_id
+                     == id_cast<GeoMaterialId>(material->GetIndex()));
         auto const* mpt = material->GetMaterialPropertiesTable();
         CELER_ASSERT(mpt);
 
@@ -720,7 +720,7 @@ import_phys_materials(GeantImporter::DataSelection::Flags particle_flags,
         if (!geo_to_opt.empty())
         {
             if (auto opt_id
-                = geo_to_opt[GeoMaterialId{material.geo_material_id}])
+                = geo_to_opt[id_cast<GeoMaterialId>(g4material->GetIndex())])
             {
                 // Assign the optical material corresponding to the geometry
                 // material

--- a/src/celeritas/io/EventReader.cc
+++ b/src/celeritas/io/EventReader.cc
@@ -102,7 +102,7 @@ auto EventReader::operator()() -> result_type
 
     CELER_LOG(debug) << "Reading event " << event_count_;
     EventId const event_id{event_count_++};
-    if (static_cast<EventId::size_type>(evt.event_number()) != event_id.get())
+    if (id_cast<EventId>(evt.event_number()) != event_id)
     {
         CELER_LOG_LOCAL(warning)
             << "Overwriting event ID " << evt.event_number()

--- a/src/geocel/g4/GeantGeoParams.cc
+++ b/src/geocel/g4/GeantGeoParams.cc
@@ -204,9 +204,7 @@ VolumeId GeantGeoParams::find_volume(Label const& label) const
 VolumeId GeantGeoParams::find_volume(G4LogicalVolume const* volume) const
 {
     CELER_EXPECT(volume);
-    auto inst_id = volume->GetInstanceID();
-    CELER_ENSURE(inst_id >= 0);
-    VolumeId result{static_cast<VolumeId::size_type>(inst_id)};
+    auto result = id_cast<VolumeId>(volume->GetInstanceID());
     if (!(result < this->num_volumes()))
     {
         // Volume is out of range: possibly an LV defined after this geometry

--- a/src/geocel/g4/GeantGeoTrackView.hh
+++ b/src/geocel/g4/GeantGeoTrackView.hh
@@ -248,9 +248,7 @@ GeantGeoTrackView& GeantGeoTrackView::operator=(DetailedInitializer const& init)
 VolumeId GeantGeoTrackView::volume_id() const
 {
     CELER_EXPECT(!this->is_outside());
-    auto inst_id = this->volume()->GetInstanceID();
-    CELER_ENSURE(inst_id >= 0);
-    return VolumeId{static_cast<VolumeId::size_type>(inst_id)};
+    return id_cast<VolumeId>(this->volume()->GetInstanceID());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/vg/VecgeomTrackView.hh
+++ b/src/geocel/vg/VecgeomTrackView.hh
@@ -259,7 +259,7 @@ VecgeomTrackView& VecgeomTrackView::operator=(DetailedInitializer const& init)
 CELER_FUNCTION VolumeId VecgeomTrackView::volume_id() const
 {
     CELER_EXPECT(!this->is_outside());
-    return VolumeId{this->volume().id()};
+    return id_cast<VolumeId>(this->volume().id());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/BIHBuilder.cc
+++ b/src/orange/detail/BIHBuilder.cc
@@ -204,8 +204,7 @@ BIHBuilder::ArrangedNodes BIHBuilder::arrange_nodes(VecNodes const& nodes) const
     // Remap IDs. "parent" will only be undefined for the root node.
     auto remapped_id = [&new_indices](BIHNodeId old) {
         CELER_EXPECT(old < new_indices.size());
-        return BIHNodeId{
-            static_cast<size_type>(new_indices[old.unchecked_get()])};
+        return id_cast<BIHNodeId>(new_indices[old.unchecked_get()]);
     };
 
     for (auto& inner_node : inner_nodes)

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -350,7 +350,7 @@ UniverseId UnitInserter::operator()(UnitInput&& inp)
     // Save unit scalars
     if (inp.volumes.back().zorder == ZOrder::background)
     {
-        unit.background = LocalVolumeId(inp.volumes.size() - 1);
+        unit.background = id_cast<LocalVolumeId>(inp.volumes.size() - 1);
     }
 
     // Simple safety if all volumes provide support, excluding the external

--- a/src/orange/g4org/LogicalVolumeConverter.cc
+++ b/src/orange/g4org/LogicalVolumeConverter.cc
@@ -80,8 +80,7 @@ auto LogicalVolumeConverter::construct_impl(arg_type g4lv) -> SPLV
     // NOTE: this is *not* the physics material ("cut couple")
     if (auto* mat = g4lv.GetMaterial())
     {
-        result->material_id
-            = GeoMaterialId{static_cast<size_type>(mat->GetIndex())};
+        result->material_id = id_cast<GeoMaterialId>(mat->GetIndex());
     }
     else
     {

--- a/src/orange/orangeinp/CsgTree.cc
+++ b/src/orange/orangeinp/CsgTree.cc
@@ -94,7 +94,7 @@ auto CsgTree::insert(Node&& n) -> Insertion
     if (inserted)
     {
         // Save new node ID
-        iter->second = NodeId{static_cast<size_type>(nodes_.size())};
+        iter->second = id_cast<NodeId>(nodes_.size());
         // Add a copy of the new node
         nodes_.push_back(iter->first);
     }

--- a/test/corecel/OpaqueId.test.cc
+++ b/test/corecel/OpaqueId.test.cc
@@ -126,7 +126,7 @@ TEST(OpaqueIdTest, id_cast)
 
     if (CELERITAS_DEBUG)
     {
-        EXPECT_THROW(id_cast<IdT>(-12345678ull), DebugError);
+        EXPECT_THROW(id_cast<IdT>(-12345678ll), DebugError);
         EXPECT_THROW(id_cast<IdT>(-1), DebugError);
         EXPECT_THROW(id_cast<IdT>(IdT{}.unchecked_get()), DebugError);
         EXPECT_THROW(

--- a/test/corecel/OpaqueId.test.cc
+++ b/test/corecel/OpaqueId.test.cc
@@ -111,6 +111,31 @@ TEST(OpaqueIdTest, iota)
     }
 }
 
+TEST(OpaqueIdTest, id_cast)
+{
+    using IdT = OpaqueId<TestInstantiator, unsigned short int>;
+
+#ifdef CELERITAS_SHOULD_NOT_COMPILE
+    id_cast<IdT>("this shouldn't compile");
+    id_cast<IdT>(1e4);  // nor should this
+#endif
+
+    EXPECT_EQ(3, id_cast<IdT>(3).unchecked_get());
+    int const lvalue{254};
+    EXPECT_EQ(lvalue, id_cast<IdT>(lvalue).unchecked_get());
+
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(id_cast<IdT>(-12345678ull), DebugError);
+        EXPECT_THROW(id_cast<IdT>(-1), DebugError);
+        EXPECT_THROW(id_cast<IdT>(IdT{}.unchecked_get()), DebugError);
+        EXPECT_THROW(
+            id_cast<IdT>(static_cast<unsigned int>(IdT{}.unchecked_get()) + 1),
+            DebugError);
+        EXPECT_THROW(id_cast<IdT>(100000000l), DebugError);
+    }
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/geocel/MockGeoTrackView.hh
+++ b/test/geocel/MockGeoTrackView.hh
@@ -111,7 +111,7 @@ MockGeoTrackView::operator=(Initializer_t const& init)
 CELER_FUNCTION VolumeId MockGeoTrackView::volume_id() const
 {
     CELER_EXPECT(!this->is_outside());
-    return VolumeId{static_cast<size_type>(volume_id_)};
+    return id_cast<VolumeId>(volume_id_);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This adds a helper function that validates the argument against allowed values for an opaque ID. It particularly helps with conversions to/from signed integer from Geant4.