### PR TITLE
Simplify geometry "volume" interface

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -65,7 +65,7 @@ how to structure the decorations.
 Submitting code changes
 -----------------------
 
-When you believe that you've made a substantive [#]_ and self-contained
+When you believe that you've made a substantive [subst]_ and self-contained
 improvement to the code, it's time to create a `pull request`_ (PR) to get
 feedback on your changes before they're merged into the code base. The pull
 request should be as close to a "single change" as possible (i.e., the short
@@ -99,15 +99,28 @@ to find older comments.)  You *can* merge the main upstream branch if
 your changes may interact with the upstream changes, and you *must* merge if
 they conflict.
 
-After the CI tests pass and the reviewers have approved your changes,
-your branch will be squashed and merged, and you will officially be a Celeritas
-:ref:`contributor <roles>`! Congratulations!
+The review is complete and your branch will be squashed and merged when:
 
-.. [#] All changes to the codebase must go through the pull request, but due to
+- All the CI tests pass,
+- All conversations have been resolved [resol]_, and
+- The reviewer has approved the changes.
+
+And you will officially be a Celeritas :ref:`contributor <roles>`!
+Congratulations!
+
+.. [subst] All changes to the codebase must go through the pull request, but
+   due to
    the overhead of reviewing, testing, merging, and documenting a PR, we'd like
    to avoid small changes that have almost no effect in terms of operation or
    readability. For example, if you find a typo in the documentation, check the
    rest of the docs for any other typos or improvements you'd like to make, and
    submit a single PR with those changes.
+
+.. [resol] When you've fully implemented the reviewer's comment, you may mark
+   it as resolved without commenting.  Do not resolve a conversation if you
+   disagree with the feed: instead, post your view in a follow-on comment and
+   wait for the reviewer to respond. If you comment, whether to supplement your
+   change or to iterate with the reviewer, please do not resolve the
+   conversation since that makes it hard to find your comment.
 
 .. _pull request: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests

--- a/app/celer-geo/Runner.cc
+++ b/app/celer-geo/Runner.cc
@@ -94,10 +94,10 @@ std::vector<std::string> Runner::get_volumes(Geometry g) const&
     CELER_EXPECT(geo_cache_[g]);
 
     auto const& geo = *geo_cache_[g];
-    std::vector<std::string> result(geo.num_volumes());
+    std::vector<std::string> result(geo.volumes().size());
     for (auto i : range<VolumeId::size_type>(result.size()))
     {
-        result[i] = geo.id_to_label(VolumeId{i}).name;
+        result[i] = geo.volumes().at(VolumeId{i}).name;
     }
     return result;
 }

--- a/doc/appendix/administration.rst
+++ b/doc/appendix/administration.rst
@@ -135,6 +135,10 @@ substantive enough to merit a new pull request. Perfect is the enemy of good.
 Check that the title meets the requirements below, that the description is
 adequate, and that the appropriate labels are set.
 
+Mark your comments as resolved only if the other person was the last to
+comment. Other reviewers can reopen the conversation to comment on it. All
+conversations must be resolved for the merge to be approved.
+
 By the time you've finished the code review, you should understand the code
 well enough to maintain it (by extension or modification) in the future.
 
@@ -257,6 +261,8 @@ The GitHub settings for Celeritas currently require that before merging:
     combinations that cover most potential build issues. These do not *execute*
     GPU code but they will build it and ensure that the tests pass when
     the Celeritas device capability is disabled.
+3.  All conversations must be resolved (see the "reviewing" section above and
+    the contributing guidelines).
 
 Celeritas uses the "squash and merge" process to ensure continuity of the code
 history and provide easy bisecting because all commits pass all tests.

--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -110,7 +110,7 @@ void log_state(Logger::Message& msg,
     if (core_params && kce.volume())
     {
         auto const& geo_params = *core_params->geometry();
-        msg << "\n- Volume: " << geo_params.id_to_label(kce.volume())
+        msg << "\n- Volume: " << geo_params.volumes().at(kce.volume())
             << " (ID=" << kce.volume() << ')';
     }
     else
@@ -123,7 +123,7 @@ void log_state(Logger::Message& msg,
         if (auto* geo = dynamic_cast<GeoParamsSurfaceInterface const*>(
                 core_params->geometry().get()))
         {
-            msg << "\n- Surface: " << geo->id_to_label(kce.surface())
+            msg << "\n- Surface: " << geo->surfaces().at(kce.surface())
                 << " (ID=" << kce.surface() << ')';
         }
     }

--- a/src/accel/GeantSimpleCalo.cc
+++ b/src/accel/GeantSimpleCalo.cc
@@ -197,7 +197,7 @@ void GeantSimpleCalo::output(JsonPimpl* j) const
         {
             auto id = geo.find_volume(volumes_[idx]);
             ids[idx] = id.unchecked_get();
-            labels[idx] = geo.id_to_label(id);
+            labels[idx] = geo.volumes().at(id);
         }
         obj["volume_ids"] = std::move(ids);
         obj["volume_labels"] = std::move(labels);

--- a/src/accel/detail/SensDetInserter.cc
+++ b/src/accel/detail/SensDetInserter.cc
@@ -33,7 +33,7 @@ void SensDetInserter::operator()(G4LogicalVolume const* lv,
         CELER_LOG(debug) << "Mapped sensitive detector \"" << sd->GetName()
                          << "\" on logical volume " << PrintableLV{lv}
                          << " to " << celeritas_core_geo << " volume \""
-                         << geo_.id_to_label(id)
+                         << geo_.volumes().at(id)
                          << "\" (ID=" << id.unchecked_get() << ')';
     }
 }
@@ -50,7 +50,7 @@ void SensDetInserter::operator()(G4LogicalVolume const* lv)
     {
         CELER_LOG(debug) << "Mapped unspecified detector on logical volume "
                          << PrintableLV{lv} << " to " << celeritas_core_geo
-                         << " volume \"" << geo_.id_to_label(id)
+                         << " volume \"" << geo_.volumes().at(id)
                          << "\" (ID=" << id.unchecked_get() << ')';
     }
 }
@@ -84,7 +84,7 @@ VolumeId SensDetInserter::insert_impl(G4LogicalVolume const* lv)
         if (iter->second != lv)
         {
             CELER_LOG(warning)
-                << "Celeritas volume \"" << geo_.id_to_label(id)
+                << "Celeritas volume \"" << geo_.volumes().at(id)
                 << "\" is mapped to two different volumes with "
                    "sensitive detectors: "
                 << PrintableLV{lv} << " and " << PrintableLV{iter->second};

--- a/src/celeritas/ext/GeantVolumeMapper.cc
+++ b/src/celeritas/ext/GeantVolumeMapper.cc
@@ -42,7 +42,7 @@ VolumeId GeantVolumeMapper::operator()(G4LogicalVolume const& lv) const
     }
 
     auto const& volumes = geo.volumes();
-    if (auto id = volumes.find(label))
+    if (auto id = volumes.find_exact(label))
     {
         // Exact match
         return id;

--- a/src/celeritas/ext/GeantVolumeMapper.cc
+++ b/src/celeritas/ext/GeantVolumeMapper.cc
@@ -41,20 +41,21 @@ VolumeId GeantVolumeMapper::operator()(G4LogicalVolume const& lv) const
         label = Label::from_geant(make_gdml_name(lv));
     }
 
-    if (auto id = geo.find_volume(label))
+    auto const& volumes = geo.volumes();
+    if (auto id = volumes.find(label))
     {
         // Exact match
         return id;
     }
 
     // Fall back to skipping the extension: look for all possible matches
-    auto all_ids = geo.find_volumes(label.name);
+    auto all_ids = volumes.find_all(label.name);
     if (all_ids.size() == 1)
     {
         CELER_LOG(warning) << "Failed to exactly match " << celeritas_core_geo
                            << " volume from Geant4 volume '" << lv.GetName()
                            << "'@" << static_cast<void const*>(&lv)
-                           << "; found '" << geo.id_to_label(all_ids.front())
+                           << "; found '" << volumes.at(all_ids.front())
                            << "' by omitting the extension";
         return all_ids.front();
     }
@@ -63,7 +64,7 @@ VolumeId GeantVolumeMapper::operator()(G4LogicalVolume const& lv) const
     // address attached (in case an original GDML volume name already
     // had a pointer suffix and LoadGdml added another)
     label = Label::from_geant(make_gdml_name(lv));
-    all_ids = geo.find_volumes(label.name);
+    all_ids = volumes.find_all(label.name);
     if (all_ids.size() > 1)
     {
         CELER_LOG(warning)
@@ -71,9 +72,7 @@ VolumeId GeantVolumeMapper::operator()(G4LogicalVolume const& lv) const
             << join(all_ids.begin(),
                     all_ids.end(),
                     "', '",
-                    [&geo = this->geo](VolumeId v) {
-                        return geo.id_to_label(v);
-                    })
+                    [&volumes](VolumeId v) { return volumes.at(v); })
             << "' match the Geant4 volume with extension omitted: returning "
                "the last one";
         return all_ids.back();

--- a/src/celeritas/global/DebugIO.json.cc
+++ b/src/celeritas/global/DebugIO.json.cc
@@ -96,7 +96,7 @@ struct FromId
     nlohmann::json convert_impl(VolumeId id) const
     {
         auto const& params = *this->params->geometry();
-        return params.id_to_label(id);
+        return params.volumes().at(id);
     }
 };
 

--- a/src/celeritas/mat/MaterialParams.cc
+++ b/src/celeritas/mat/MaterialParams.cc
@@ -221,7 +221,7 @@ MaterialParams::MaterialParams(Input const& inp)
 Label const& MaterialParams::id_to_label(MaterialId mat) const
 {
     CELER_EXPECT(mat < mat_labels_.size());
-    return mat_labels_.get(mat);
+    return mat_labels_.at(mat);
 }
 
 //---------------------------------------------------------------------------//
@@ -260,7 +260,7 @@ auto MaterialParams::find_materials(std::string const& name) const
 Label const& MaterialParams::id_to_label(ElementId el) const
 {
     CELER_EXPECT(el < el_labels_.size());
-    return el_labels_.get(el);
+    return el_labels_.at(el);
 }
 
 //---------------------------------------------------------------------------//
@@ -296,7 +296,7 @@ auto MaterialParams::find_elements(std::string const& name) const
 Label const& MaterialParams::id_to_label(IsotopeId id) const
 {
     CELER_EXPECT(id < isot_labels_.size());
-    return isot_labels_.get(id);
+    return isot_labels_.at(id);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/mat/MaterialParams.hh
+++ b/src/celeritas/mat/MaterialParams.hh
@@ -40,6 +40,8 @@ struct ImportData;
  * Materials in Celeritas currently correspond to "material cut couples" in
  * Geant4, i.e. the outer product of geometry model-defined materials and
  * user-defined physics regions.
+ *
+ * \todo Replace id_to_label etc. with direct access to LabelIdMultiMap
  */
 class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 {

--- a/src/celeritas/user/SimpleCalo.cc
+++ b/src/celeritas/user/SimpleCalo.cc
@@ -30,14 +30,15 @@ namespace
 //---------------------------------------------------------------------------//
 VolumeId find_volume_fuzzy(GeoParamsInterface const& geo, Label const& label)
 {
-    if (auto id = geo.find_volume(label))
+    auto const& vols = geo.volumes();
+    if (auto id = vols.find(label))
     {
         // Exact match
         return id;
     }
 
     // Fall back to skipping the extension: look for all possible matches
-    auto all_ids = geo.find_volumes(label.name);
+    auto all_ids = vols.find_all(label.name);
     if (all_ids.size() == 1)
     {
         if (!label.ext.empty())
@@ -45,21 +46,19 @@ VolumeId find_volume_fuzzy(GeoParamsInterface const& geo, Label const& label)
             CELER_LOG(warning)
                 << "Failed to exactly match " << celeritas_core_geo
                 << " volume from volume '" << label << "'; found '"
-                << geo.id_to_label(all_ids.front())
-                << "' by omitting the extension";
+                << vols.at(all_ids.front()) << "' by omitting the extension";
         }
         return all_ids.front();
     }
     if (all_ids.size() > 1)
     {
-        CELER_LOG(warning)
-            << "Multiple volumes '"
-            << join(all_ids.begin(),
-                    all_ids.end(),
-                    "', '",
-                    [&geo](VolumeId v) { return geo.id_to_label(v); })
-            << "' match the name '" << label.name
-            << "': returning the last one";
+        CELER_LOG(warning) << "Multiple volumes '"
+                           << join(all_ids.begin(),
+                                   all_ids.end(),
+                                   "', '",
+                                   [&vols](VolumeId v) { return vols.at(v); })
+                           << "' match the name '" << label.name
+                           << "': returning the last one";
         return all_ids.back();
     }
     return {};

--- a/src/celeritas/user/SimpleCalo.cc
+++ b/src/celeritas/user/SimpleCalo.cc
@@ -31,7 +31,7 @@ namespace
 VolumeId find_volume_fuzzy(GeoParamsInterface const& geo, Label const& label)
 {
     auto const& vols = geo.volumes();
-    if (auto id = vols.find(label))
+    if (auto id = vols.find_exact(label))
     {
         // Exact match
         return id;

--- a/src/celeritas/user/StepCollector.cc
+++ b/src/celeritas/user/StepCollector.cc
@@ -80,9 +80,9 @@ StepCollector::StepCollector(VecInterface callbacks,
                 CELER_VALIDATE(inserted,
                                << "multiple step interfaces map single volume "
                                   "to a detector ('"
-                               << geo->id_to_label(prev->first) << "' -> "
+                               << geo->volumes().at(prev->first) << "' -> "
                                << prev->second.get() << " and '"
-                               << geo->id_to_label(kv.first) << "' -> "
+                               << geo->volumes().at(kv.first) << "' -> "
                                << kv.second.get() << ')');
             }
 
@@ -115,7 +115,8 @@ StepCollector::StepCollector(VecInterface callbacks,
         {
             // Assign detector IDs for each ("logical" in Geant4) volume
             CELER_EXPECT(geo);
-            std::vector<DetectorId> temp_det(geo->num_volumes(), DetectorId{});
+            std::vector<DetectorId> temp_det(geo->volumes().size(),
+                                             DetectorId{});
             for (auto const& kv : detector_map)
             {
                 CELER_ASSERT(kv.first < temp_det.size());

--- a/src/corecel/cont/LabelIdMultiMap.hh
+++ b/src/corecel/cont/LabelIdMultiMap.hh
@@ -41,7 +41,10 @@ namespace celeritas
  * or "false" OpaqueId will be returned.
  *
  * The three kinds of \c find methods are named differently to avoid ambiguity:
- * - \c find_all returns
+ * - \c find_all returns the full set of IDs that match the given name;
+ * - \c find_unique is a convenience accessor for locating a volume by name,
+ *   but it only works if there are no duplicates; and
+ * - \c find_exact looks for the full label, both name and extension.
  */
 template<class I>
 class LabelIdMultiMap

--- a/src/corecel/cont/LabelIdMultiMap.hh
+++ b/src/corecel/cont/LabelIdMultiMap.hh
@@ -73,6 +73,7 @@ class LabelIdMultiMap
 
     // Access the label+sublabel pair for an Id
     // DEPRECATED: remove in v0.6 (use 'at')
+    [[deprecated]]
     CELER_FORCEINLINE Label const& get(IdT id) const { return this->at(id); }
 
     // Access the label+sublabel pair for an Id

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -54,33 +54,39 @@ class GeoParamsInterface
     //// DEPRECATED: remove in v0.6 ////
 
     //! Number of volumes
+    [[deprecated]]
     VolumeId::size_type num_volumes() const { return this->volumes().size(); }
 
     //! Get the label for a placed volume ID
+    [[deprecated]]
     Label const& id_to_label(VolumeId vol_id) const
     {
         return this->volumes().at(vol_id);
     }
 
     //! Get the volume ID corresponding to a unique name
+    [[deprecated]]
     VolumeId find_volume(std::string const& name) const
     {
         return this->volumes().find_unique(name);
     }
 
     //! Get the volume ID corresponding to a unique label
+    [[deprecated]]
     VolumeId find_volume(Label const& label) const
     {
         return this->volumes().find(label);
     }
 
     //! Get the volume ID corresponding to a unique name
+    [[deprecated]]
     VolumeId find_volume(char const* name) const
     {
         return this->find_volume(std::string{name});
     }
 
     //! Get the volume ID corresponding to a unique name
+    [[deprecated]]
     SpanConstVolumeId find_volumes(std::string const& name) const
     {
         return this->volumes().find_all(name);
@@ -117,18 +123,21 @@ class GeoParamsSurfaceInterface : public GeoParamsInterface
     //// DEPRECATED: remove in v0.6 ////
 
     //! Get the label for a placed volume ID
+    [[deprecated]]
     Label const& id_to_label(SurfaceId surf_id) const
     {
         return this->surfaces().at(surf_id);
     }
 
     //! Get the surface ID corresponding to a unique label name
+    [[deprecated]]
     SurfaceId find_surface(std::string const& name) const
     {
         return this->surfaces().find(name);
     }
 
     //! Number of distinct surfaces
+    [[deprecated]]
     SurfaceId::size_type num_surfaces() const
     {
         return this->surfaces().size();

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -133,7 +133,7 @@ class GeoParamsSurfaceInterface : public GeoParamsInterface
     [[deprecated]]
     SurfaceId find_surface(std::string const& name) const
     {
-        return this->surfaces().find(name);
+        return this->surfaces().find_unique(name);
     }
 
     //! Number of distinct surfaces

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -75,14 +75,14 @@ class GeoParamsInterface
     [[deprecated]]
     VolumeId find_volume(Label const& label) const
     {
-        return this->volumes().find(label);
+        return this->volumes().find_exact(label);
     }
 
     //! Get the volume ID corresponding to a unique name
     [[deprecated]]
     VolumeId find_volume(char const* name) const
     {
-        return this->find_volume(std::string{name});
+        return this->volumes().find_unique(name);
     }
 
     //! Get the volume ID corresponding to a unique name

--- a/src/geocel/GeoParamsOutput.cc
+++ b/src/geocel/GeoParamsOutput.cc
@@ -48,9 +48,10 @@ void GeoParamsOutput::output(JsonPimpl* j) const
     {
         auto label = json::array();
 
-        for (auto id : range(VolumeId{geo_->num_volumes()}))
+        auto const& volumes = geo_->volumes();
+        for (auto id : range(VolumeId{volumes.size()}))
         {
-            label.push_back(geo_->id_to_label(id));
+            label.push_back(volumes.at(id));
         }
         obj["volumes"] = {
             {"label", std::move(label)},
@@ -63,9 +64,10 @@ void GeoParamsOutput::output(JsonPimpl* j) const
     {
         auto label = json::array();
 
-        for (auto id : range(SurfaceId{surf_geo->num_surfaces()}))
+        auto const& surfaces = surf_geo->surfaces();
+        for (auto id : range(SurfaceId{surfaces.size()}))
         {
-            label.push_back(surf_geo->id_to_label(id));
+            label.push_back(surfaces.at(id));
         }
         obj["surfaces"] = {
             {"label", std::move(label)},

--- a/src/geocel/g4/GeantGeoParams.cc
+++ b/src/geocel/g4/GeantGeoParams.cc
@@ -98,7 +98,7 @@ GeantGeoParams::GeantGeoParams(std::string const& filename)
     this->build_tracking();
     this->build_metadata();
 
-    CELER_ENSURE(this->num_volumes() > 0);
+    CELER_ENSURE(volumes_);
     CELER_ENSURE(host_ref_);
 }
 
@@ -142,7 +142,7 @@ GeantGeoParams::GeantGeoParams(G4VPhysicalVolume const* world)
     this->build_tracking();
     this->build_metadata();
 
-    CELER_ENSURE(this->num_volumes() > 0);
+    CELER_ENSURE(volumes_);
     CELER_ENSURE(host_ref_);
 }
 
@@ -172,7 +172,7 @@ VolumeId GeantGeoParams::find_volume(G4LogicalVolume const* volume) const
     auto inst_id = volume->GetInstanceID();
     CELER_ENSURE(inst_id >= 0);
     VolumeId result{static_cast<VolumeId::size_type>(inst_id)};
-    if (!(result < this->num_volumes()))
+    if (!(result < volumes_.size()))
     {
         // Volume is out of range: possibly an LV defined after this geometry
         // class was created
@@ -189,7 +189,7 @@ VolumeId GeantGeoParams::find_volume(G4LogicalVolume const* volume) const
  */
 G4LogicalVolume const* GeantGeoParams::id_to_lv(VolumeId id) const
 {
-    CELER_EXPECT(!id || id < this->num_volumes());
+    CELER_EXPECT(!id || id < volumes_.size());
     if (!id)
     {
         return nullptr;
@@ -231,7 +231,7 @@ void GeantGeoParams::build_metadata()
     CELER_ASSERT(world_lv);
 
     // Construct volume labels
-    vol_labels_ = LabelIdMultiMap<VolumeId>(
+    volumes_ = LabelIdMultiMap<VolumeId>(
         "volume", get_volume_labels(*world_lv, !loaded_gdml_));
 
     // Save world bbox (NOTE: assumes no transformation on PV?)

--- a/src/geocel/g4/GeantGeoParams.cc
+++ b/src/geocel/g4/GeantGeoParams.cc
@@ -164,41 +164,6 @@ GeantGeoParams::~GeantGeoParams()
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the label for a placed volume ID.
- */
-Label const& GeantGeoParams::id_to_label(VolumeId vol) const
-{
-    CELER_EXPECT(vol < vol_labels_.size());
-    return vol_labels_.get(vol);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the ID corresponding to a label.
- */
-auto GeantGeoParams::find_volume(std::string const& name) const -> VolumeId
-{
-    auto result = vol_labels_.find_all(name);
-    if (result.empty())
-        return {};
-    CELER_VALIDATE(result.size() == 1,
-                   << "volume '" << name << "' is not unique");
-    return result.front();
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Locate the volume ID corresponding to a label.
- *
- * If the label isn't in the geometry, a null ID will be returned.
- */
-VolumeId GeantGeoParams::find_volume(Label const& label) const
-{
-    return vol_labels_.find(label);
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Locate the volume ID corresponding to a Geant4 logical volume.
  */
 VolumeId GeantGeoParams::find_volume(G4LogicalVolume const* volume) const
@@ -214,19 +179,6 @@ VolumeId GeantGeoParams::find_volume(G4LogicalVolume const* volume) const
         result = {};
     }
     return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get zero or more volume IDs corresponding to a name.
- *
- * This is useful for volumes that are repeated in the geometry with different
- * uniquifying 'extensions' from Geant4.
- */
-auto GeantGeoParams::find_volumes(std::string const& name) const
-    -> SpanConstVolumeId
-{
-    return vol_labels_.find_all(name);
 }
 
 //---------------------------------------------------------------------------//
@@ -280,7 +232,7 @@ void GeantGeoParams::build_metadata()
 
     // Construct volume labels
     vol_labels_ = LabelIdMultiMap<VolumeId>(
-        get_volume_labels(*world_lv, !loaded_gdml_));
+        "volume", get_volume_labels(*world_lv, !loaded_gdml_));
 
     // Save world bbox (NOTE: assumes no transformation on PV?)
     bbox_ = [world_lv] {

--- a/src/geocel/g4/GeantGeoParams.hh
+++ b/src/geocel/g4/GeantGeoParams.hh
@@ -59,33 +59,17 @@ class GeantGeoParams final : public GeoParamsInterface,
 
     //// VOLUMES ////
 
-    //! Number of volumes
-    VolumeId::size_type num_volumes() const final
-    {
-        return vol_labels_.size();
-    }
-
-    // Get the label for a placed volume ID
-    Label const& id_to_label(VolumeId vol_id) const final;
-
-    //! \cond
-    using GeoParamsInterface::find_volume;
-    //! \endcond
-
-    // Get the volume ID corresponding to a unique label name
-    VolumeId find_volume(std::string const& name) const final;
-
-    // Get the volume ID corresponding to a unique label
-    VolumeId find_volume(Label const& label) const final;
+    // Get volume metadata
+    inline VolumeMap const& volumes() const final;
 
     // Get the volume ID corresponding to a Geant4 logical volume
     VolumeId find_volume(G4LogicalVolume const* volume) const final;
 
-    // Get zero or more volume IDs corresponding to a name
-    SpanConstVolumeId find_volumes(std::string const& name) const final;
-
     // Get the Geant4 logical volume corresponding to a volume ID
     G4LogicalVolume const* id_to_lv(VolumeId vol_id) const;
+
+    // DEPRECATED
+    using GeoParamsInterface::find_volume;
 
     //// DATA ACCESS ////
 
@@ -107,7 +91,7 @@ class GeantGeoParams final : public GeoParamsInterface,
     std::unique_ptr<ScopedGeantExceptionHandler> scoped_exceptions_;
 
     // Host metadata/access
-    LabelIdMultiMap<VolumeId> vol_labels_;
+    VolumeMap vol_labels_;
     BBox bbox_;
 
     // Host/device storage and reference
@@ -121,6 +105,17 @@ class GeantGeoParams final : public GeoParamsInterface,
     // Construct labels and other host-only metadata
     void build_metadata();
 };
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Get volume metadata.
+ */
+auto GeantGeoParams::volumes() const -> VolumeMap const&
+{
+    return vol_labels_;
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/g4/GeantGeoParams.hh
+++ b/src/geocel/g4/GeantGeoParams.hh
@@ -91,7 +91,7 @@ class GeantGeoParams final : public GeoParamsInterface,
     std::unique_ptr<ScopedGeantExceptionHandler> scoped_exceptions_;
 
     // Host metadata/access
-    VolumeMap vol_labels_;
+    VolumeMap volumes_;
     BBox bbox_;
 
     // Host/device storage and reference
@@ -114,7 +114,7 @@ class GeantGeoParams final : public GeoParamsInterface,
  */
 auto GeantGeoParams::volumes() const -> VolumeMap const&
 {
-    return vol_labels_;
+    return volumes_;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/vg/VecgeomParams.hh
+++ b/src/geocel/vg/VecgeomParams.hh
@@ -59,30 +59,14 @@ class VecgeomParams final : public GeoParamsInterface,
 
     //// VOLUMES ////
 
-    //! Number of volumes
-    VolumeId::size_type num_volumes() const final
-    {
-        return vol_labels_.size();
-    }
-
-    // Get the label for a placed volume ID
-    Label const& id_to_label(VolumeId vol_id) const final;
-
-    //! \cond
-    using GeoParamsInterface::find_volume;
-    //! \endcond
-
-    // Get the volume ID corresponding to a unique label name
-    VolumeId find_volume(std::string const& name) const final;
-
-    // Get the volume ID corresponding to a unique label
-    VolumeId find_volume(Label const& label) const final;
+    // Get volume metadata
+    inline VolumeMap const& volumes() const final;
 
     // Get the volume ID corresponding to a Geant4 logical volume
     VolumeId find_volume(G4LogicalVolume const* volume) const final;
 
-    // Get zero or more volume IDs corresponding to a name
-    SpanConstVolumeId find_volumes(std::string const& name) const final;
+    // DEPRECATED
+    using GeoParamsInterface::find_volume;
 
     //// DATA ACCESS ////
 
@@ -96,7 +80,7 @@ class VecgeomParams final : public GeoParamsInterface,
     //// DATA ////
 
     // Host metadata/access
-    LabelIdMultiMap<VolumeId> vol_labels_;
+    LabelIdMultiMap<VolumeId> volumes_;
     std::unordered_map<G4LogicalVolume const*, VolumeId> g4log_volid_map_;
 
     BBox bbox_;
@@ -122,6 +106,15 @@ class VecgeomParams final : public GeoParamsInterface,
     // Construct labels and other host-only metadata
     void build_metadata();
 };
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get volume metadata.
+ */
+auto VecgeomParams::volumes() const -> VolumeMap const&
+{
+    return volumes_;
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -174,9 +174,9 @@ OrangeParams::OrangeParams(OrangeInput&& input)
             std::visit(insert_universe, std::move(u));
         }
 
-        univ_labels_ = LabelIdMultiMap<UniverseId>{std::move(universe_labels)};
-        surf_labels_ = LabelIdMultiMap<SurfaceId>{std::move(surface_labels)};
-        vol_labels_ = LabelIdMultiMap<VolumeId>{std::move(volume_labels)};
+        surf_labels_ = SurfaceMap{"surface", std::move(surface_labels)};
+        univ_labels_ = UniverseMap{"universe", std::move(universe_labels)};
+        vol_labels_ = VolumeMap{"volume", std::move(volume_labels)};
     }
 
     // Simple safety if all SimpleUnits have simple safety and no RectArrays
@@ -202,107 +202,10 @@ OrangeParams::OrangeParams(OrangeInput&& input)
     CELER_ASSERT(host_data);
     data_ = CollectionMirror<OrangeParamsData>{std::move(host_data)};
 
+    CELER_ENSURE(surf_labels_ && univ_labels_ && vol_labels_);
     CELER_ENSURE(data_);
     CELER_ENSURE(vol_labels_.size() > 0);
     CELER_ENSURE(bbox_);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the label of a volume.
- */
-Label const& OrangeParams::id_to_label(VolumeId vol) const
-{
-    CELER_EXPECT(vol < vol_labels_.size());
-    return vol_labels_.get(vol);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Locate the volume ID corresponding to a unique name.
- *
- * If the name isn't in the geometry, a null ID will be returned. If the name
- * is not unique, a RuntimeError will be raised.
- */
-VolumeId OrangeParams::find_volume(std::string const& name) const
-{
-    auto result = vol_labels_.find_all(name);
-    if (result.empty())
-        return {};
-    CELER_VALIDATE(result.size() == 1,
-                   << "volume '" << name << "' is not unique");
-    return result.front();
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Locate the volume ID corresponding to a label.
- *
- * If the label isn't in the geometry, a null ID will be returned.
- */
-VolumeId OrangeParams::find_volume(Label const& label) const
-{
-    return vol_labels_.find(label);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get zero or more volume IDs corresponding to a name.
- *
- * This is useful for volumes that are repeated in the geometry with different
- * uniquifying 'extensions'.
- */
-auto OrangeParams::find_volumes(std::string const& name) const -> SpanConstVolumeId
-{
-    return vol_labels_.find_all(name);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the label of a surface.
- */
-Label const& OrangeParams::id_to_label(SurfaceId surf) const
-{
-    CELER_EXPECT(surf < surf_labels_.size());
-    return surf_labels_.get(surf);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Locate the surface ID corresponding to a label name.
- */
-SurfaceId OrangeParams::find_surface(std::string const& name) const
-{
-    auto result = surf_labels_.find_all(name);
-    if (result.empty())
-        return {};
-    CELER_VALIDATE(result.size() == 1,
-                   << "surface '" << name << "' is not unique");
-    return result.front();
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the label of a universe.
- */
-Label const& OrangeParams::id_to_label(UniverseId univ) const
-{
-    CELER_EXPECT(univ < univ_labels_.size());
-    return univ_labels_.get(univ);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Locate the universe ID corresponding to a label name.
- */
-UniverseId OrangeParams::find_universe(std::string const& name) const
-{
-    auto result = univ_labels_.find_all(name);
-    if (result.empty())
-        return {};
-    CELER_VALIDATE(result.size() == 1,
-                   << "universe '" << name << "' is not unique");
-    return result.front();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -38,6 +38,13 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
                            public ParamsDataInterface<OrangeParamsData>
 {
   public:
+    //!@{
+    //! \name Type aliases
+    using SurfaceMap = LabelIdMultiMap<SurfaceId>;
+    using UniverseMap = LabelIdMultiMap<UniverseId>;
+    //!@}
+
+  public:
     // Construct from a JSON or GDML file (if JSON or Geant4 are enabled)
     explicit OrangeParams(std::string const& filename);
 
@@ -56,51 +63,42 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     //! Maximum universe depth
     size_type max_depth() const { return this->host_ref().scalars.max_depth; }
 
-    //// VOLUMES ////
+    //// LABELS AND MAPPING ////
 
-    // Number of volumes
-    inline VolumeId::size_type num_volumes() const final;
+    // Get surface metadata
+    inline SurfaceMap const& surfaces() const final;
 
-    // Get the label for a volume ID
-    Label const& id_to_label(VolumeId vol_id) const final;
+    // Get universe metadata
+    inline UniverseMap const& universes() const;
 
-    //! \cond
-    using GeoParamsSurfaceInterface::find_volume;
-    //! \endcond
-
-    // Get the volume ID corresponding to a unique name
-    VolumeId find_volume(std::string const& name) const final;
-
-    // Get the volume ID corresponding to a unique label
-    VolumeId find_volume(Label const& label) const final;
+    // Get volume metadata
+    inline VolumeMap const& volumes() const final;
 
     // Get the volume ID corresponding to a Geant4 logical volume
     inline VolumeId find_volume(G4LogicalVolume const* volume) const final;
 
-    // Get zero or more volume IDs corresponding to a name
-    SpanConstVolumeId find_volumes(std::string const& name) const final;
+    //// DEPRECATED ////
 
-    //// SURFACES ////
-
-    // Get the label for a surface ID
-    Label const& id_to_label(SurfaceId surf_id) const final;
-
-    // Get the surface ID corresponding to a unique label name
-    SurfaceId find_surface(std::string const& name) const final;
-
-    // Number of distinct surfaces
-    inline SurfaceId::size_type num_surfaces() const final;
-
-    //// UNIVERSES ////
+    using GeoParamsSurfaceInterface::find_volume;
+    using GeoParamsSurfaceInterface::id_to_label;
 
     // Get the label for a universe ID
-    Label const& id_to_label(UniverseId surf_id) const;
+    Label const& id_to_label(UniverseId univ_id) const
+    {
+        return this->universes().at(univ_id);
+    }
 
     // Get the universe ID corresponding to a unique label name
-    UniverseId find_universe(std::string const& name) const;
+    UniverseId find_universe(std::string const& name) const
+    {
+        return this->universes().find(name);
+    }
 
     // Number of universes
-    inline UniverseId::size_type num_universes() const;
+    UniverseId::size_type num_universes() const
+    {
+        return this->universes().size();
+    }
 
     //// DATA ACCESS ////
 
@@ -112,9 +110,9 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
 
   private:
     // Host metadata/access
-    LabelIdMultiMap<UniverseId> univ_labels_;
-    LabelIdMultiMap<SurfaceId> surf_labels_;
-    LabelIdMultiMap<VolumeId> vol_labels_;
+    SurfaceMap surf_labels_;
+    UniverseMap univ_labels_;
+    VolumeMap vol_labels_;
     BBox bbox_;
     bool supports_safety_{};
 
@@ -126,40 +124,40 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
+ * Get surface metadata.
+ */
+auto OrangeParams::surfaces() const -> SurfaceMap const&
+{
+    return surf_labels_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get universe metadata.
+ */
+auto OrangeParams::universes() const -> UniverseMap const&
+{
+    return univ_labels_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get volume metadata.
+ */
+auto OrangeParams::volumes() const -> VolumeMap const&
+{
+    return vol_labels_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Locate the volume ID corresponding to a Geant4 volume.
  *
- * TODO: To be properly implemented, as it requires a future Geant4 converter.
+ * \todo Implement using \c g4org::Converter
  */
 VolumeId OrangeParams::find_volume(G4LogicalVolume const*) const
 {
     return VolumeId{};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Number of volumes.
- */
-VolumeId::size_type OrangeParams::num_volumes() const
-{
-    return vol_labels_.size();
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Number of surfaces.
- */
-SurfaceId::size_type OrangeParams::num_surfaces() const
-{
-    return surf_labels_.size();
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Number of universes.
- */
-UniverseId::size_type OrangeParams::num_universes() const
-{
-    return univ_labels_.size();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -83,18 +83,21 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     using GeoParamsSurfaceInterface::id_to_label;
 
     // Get the label for a universe ID
+    [[deprecated]]
     Label const& id_to_label(UniverseId univ_id) const
     {
         return this->universes().at(univ_id);
     }
 
     // Get the universe ID corresponding to a unique label name
+    [[deprecated]]
     UniverseId find_universe(std::string const& name) const
     {
         return this->universes().find(name);
     }
 
     // Number of universes
+    [[deprecated]]
     UniverseId::size_type num_universes() const
     {
         return this->universes().size();

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -93,7 +93,7 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     [[deprecated]]
     UniverseId find_universe(std::string const& name) const
     {
-        return this->universes().find(name);
+        return this->universes().find_unique(name);
     }
 
     // Number of universes

--- a/test/accel/detail/HitManager.test.cc
+++ b/test/accel/detail/HitManager.test.cc
@@ -70,7 +70,7 @@ class SimpleCmsTest : public ::celeritas::test::SDTestBase,
         std::vector<std::string> result;
         for (VolumeId vid : vols)
         {
-            result.push_back(geo.id_to_label(vid).name);
+            result.push_back(geo.volumes().at(vid).name);
         }
         return result;
     }

--- a/test/accel/detail/TouchableUpdater.test.cc
+++ b/test/accel/detail/TouchableUpdater.test.cc
@@ -66,7 +66,7 @@ class TouchableUpdaterTest : public ::celeritas::test::GeantGeoTestBase
     G4LogicalVolume const* find_lv(std::string const& name) const
     {
         auto const& geo = *this->geometry();
-        auto const* lv = geo.id_to_lv(geo.find_volume(name));
+        auto const* lv = geo.id_to_lv(geo.volumes().find(name));
         CELER_ENSURE(lv);
         return lv;
     }

--- a/test/accel/detail/TouchableUpdater.test.cc
+++ b/test/accel/detail/TouchableUpdater.test.cc
@@ -66,7 +66,7 @@ class TouchableUpdaterTest : public ::celeritas::test::GeantGeoTestBase
     G4LogicalVolume const* find_lv(std::string const& name) const
     {
         auto const& geo = *this->geometry();
-        auto const* lv = geo.id_to_lv(geo.volumes().find(name));
+        auto const* lv = geo.id_to_lv(geo.volumes().find_unique(name));
         CELER_ENSURE(lv);
         return lv;
     }

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -243,7 +243,7 @@ TEST_F(NestedTest, unique)
     {
         VolumeId vol_id = find_vol(*logical_[i]);
         ASSERT_NE(VolumeId{}, vol_id);
-        EXPECT_EQ(names_[i], geo_params_->id_to_label(vol_id).name);
+        EXPECT_EQ(names_[i], geo_params_->volumes().at(vol_id).name);
     }
 
     if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
@@ -285,7 +285,7 @@ TEST_F(NestedTest, SKIP_UNLESS_VECGEOM(duplicated))
     {
         VolumeId vol_id = find_vol(*logical_[i]);
         ASSERT_NE(VolumeId{}, vol_id);
-        EXPECT_EQ(names_[i], geo_params_->id_to_label(vol_id).name);
+        EXPECT_EQ(names_[i], geo_params_->volumes().at(vol_id).name);
     }
 
     // IDs for the unique LVs should be different
@@ -310,7 +310,7 @@ TEST_F(NestedTest, SKIP_UNLESS_VECGEOM(suffixed))
         VolumeId vol_id = find_vol(*logical_[i]);
         ASSERT_NE(VolumeId{}, vol_id);
         EXPECT_EQ(Label::from_geant(names_[i]),
-                  geo_params_->id_to_label(vol_id));
+                  geo_params_->volumes().at(vol_id));
     }
 }
 
@@ -327,7 +327,7 @@ TEST_F(NestedTest, SKIP_UNLESS_VECGEOM(duplicated_suffixed))
         VolumeId vol_id = find_vol(*logical_[i]);
         ASSERT_NE(VolumeId{}, vol_id);
         EXPECT_EQ(Label::from_geant(names_[i]),
-                  geo_params_->id_to_label(vol_id));
+                  geo_params_->volumes().at(vol_id));
     }
 }
 
@@ -343,7 +343,7 @@ TEST_F(NestedTest, SKIP_UNLESS_VECGEOM(double_prefixed))
         VolumeId vol_id = find_vol(*logical_[i]);
         ASSERT_NE(VolumeId{}, vol_id);
         EXPECT_EQ(Label::from_geant(names_[i]),
-                  geo_params_->id_to_label(vol_id));
+                  geo_params_->volumes().at(vol_id));
     }
 }
 
@@ -359,7 +359,7 @@ TEST_F(NestedTest, SKIP_UNLESS_VECGEOM(duplicated_double_prefixed))
         VolumeId vol_id = find_vol(*logical_[i]);
         ASSERT_NE(VolumeId{}, vol_id);
         EXPECT_EQ(Label::from_geant(names_[i]),
-                  geo_params_->id_to_label(vol_id));
+                  geo_params_->volumes().at(vol_id));
     }
 }
 

--- a/test/celeritas/geo/Geometry.test.cc
+++ b/test/celeritas/geo/Geometry.test.cc
@@ -34,7 +34,7 @@ class TestEm3Test : public HeuristicGeoTestBase
         HeuristicGeoScalars result;
         result.lower = {-19.77, -20, -20};
         result.upper = {19.43, 20, 20};
-        result.world_volume = this->geometry()->find_volume("world");
+        result.world_volume = this->geometry()->volumes().find("world");
         return result;
     }
 
@@ -111,7 +111,7 @@ class SimpleCmsTest : public HeuristicGeoTestBase
         result.upper = {30, 30, 700};
         result.log_min_step = std::log(1e-4);
         result.log_max_step = std::log(1e2);
-        result.world_volume = this->geometry()->find_volume("world");
+        result.world_volume = this->geometry()->volumes().find("world");
         return result;
     }
 

--- a/test/celeritas/geo/Geometry.test.cc
+++ b/test/celeritas/geo/Geometry.test.cc
@@ -34,7 +34,7 @@ class TestEm3Test : public HeuristicGeoTestBase
         HeuristicGeoScalars result;
         result.lower = {-19.77, -20, -20};
         result.upper = {19.43, 20, 20};
-        result.world_volume = this->geometry()->volumes().find("world");
+        result.world_volume = this->geometry()->volumes().find_unique("world");
         return result;
     }
 
@@ -111,7 +111,7 @@ class SimpleCmsTest : public HeuristicGeoTestBase
         result.upper = {30, 30, 700};
         result.log_min_step = std::log(1e-4);
         result.log_max_step = std::log(1e2);
-        result.world_volume = this->geometry()->volumes().find("world");
+        result.world_volume = this->geometry()->volumes().find_unique("world");
         return result;
     }
 

--- a/test/celeritas/geo/HeuristicGeoTestBase.cc
+++ b/test/celeritas/geo/HeuristicGeoTestBase.cc
@@ -168,7 +168,7 @@ auto HeuristicGeoTestBase::get_avg_path_impl(
     real_type const norm = 1 / real_type(num_states);
     for (auto i : range(ref_vol_labels.size()))
     {
-        auto vol_id = geo.volumes().find(ref_vol_labels[i]);
+        auto vol_id = geo.volumes().find_unique(ref_vol_labels[i]);
         if (vol_id)
         {
             result[i] = path[vol_id.unchecked_get()] * norm;

--- a/test/celeritas/geo/HeuristicGeoTestBase.cc
+++ b/test/celeritas/geo/HeuristicGeoTestBase.cc
@@ -108,7 +108,7 @@ auto HeuristicGeoTestBase::build_test_params()
 
     HeuristicGeoParamsData<Ownership::const_reference, M> result;
     result.s = this->build_scalars();
-    result.s.num_volumes = geo.num_volumes();
+    result.s.num_volumes = geo.volumes().size();
     result.s.ignore_zero_safety = geo.supports_safety();
     CELER_ASSERT(result.s);
 
@@ -135,7 +135,7 @@ auto HeuristicGeoTestBase::get_avg_path_impl(
     std::vector<real_type> const& path,
     size_type num_states) const -> std::vector<real_type>
 {
-    CELER_EXPECT(path.size() == this->geometry()->num_volumes());
+    CELER_EXPECT(path.size() == this->geometry()->volumes().size());
 
     auto const& geo = *this->geometry();
 
@@ -143,10 +143,10 @@ auto HeuristicGeoTestBase::get_avg_path_impl(
     SpanConstStr ref_vol_labels = this->reference_volumes();
     if (ref_vol_labels.empty())
     {
-        temp_labels.reserve(geo.num_volumes());
-        for (auto vid : range(VolumeId{geo.num_volumes()}))
+        temp_labels.reserve(geo.volumes().size());
+        for (auto vid : range(VolumeId{geo.volumes().size()}))
         {
-            std::string const& vol_name = geo.id_to_label(vid).name;
+            std::string const& vol_name = geo.volumes().at(vid).name;
             if (vol_name != "[EXTERIOR]")
             {
                 temp_labels.push_back(vol_name);
@@ -168,7 +168,7 @@ auto HeuristicGeoTestBase::get_avg_path_impl(
     real_type const norm = 1 / real_type(num_states);
     for (auto i : range(ref_vol_labels.size()))
     {
-        auto vol_id = geo.find_volume(ref_vol_labels[i]);
+        auto vol_id = geo.volumes().find(ref_vol_labels[i]);
         if (vol_id)
         {
             result[i] = path[vol_id.unchecked_get()] * norm;

--- a/test/corecel/cont/LabelIdMultiMap.test.cc
+++ b/test/corecel/cont/LabelIdMultiMap.test.cc
@@ -48,7 +48,7 @@ TEST(LabelIdMultiMapTest, empty)
     for (CatMultiMap const* cats : {&default_cats, &empty_cats})
     {
         EXPECT_EQ(0, cats->size());
-        EXPECT_EQ(CatId{}, cats->find(Label{"merry"}));
+        EXPECT_EQ(CatId{}, cats->find_exact(Label{"merry"}));
         EXPECT_EQ(0, cats->find_all("pippin").size());
         if (CELERITAS_DEBUG)
         {
@@ -63,11 +63,11 @@ TEST(LabelIdMultiMapTest, no_ext_with_duplicates)
         "cat", VecLabel{{"dexter", "andy", "loki", "bob", "bob", "bob"}}};
     EXPECT_TRUE(cats);
     EXPECT_EQ(6, cats.size());
-    EXPECT_EQ(CatId{}, cats.find("nyoka"));
-    EXPECT_EQ(CatId{0}, cats.find("dexter"));
-    EXPECT_EQ(CatId{1}, cats.find("andy"));
-    EXPECT_EQ(CatId{2}, cats.find("loki"));
-    EXPECT_EQ(CatId{2}, cats.find(Label{"loki"}));
+    EXPECT_EQ(CatId{}, cats.find_exact("nyoka"));
+    EXPECT_EQ(CatId{0}, cats.find_exact("dexter"));
+    EXPECT_EQ(CatId{1}, cats.find_exact("andy"));
+    EXPECT_EQ(CatId{2}, cats.find_exact("loki"));
+    EXPECT_EQ(CatId{2}, cats.find_exact(Label{"loki"}));
 
     EXPECT_EQ(CatId{}, cats.find_unique("nyoka"));
     EXPECT_EQ(CatId{2}, cats.find_unique("loki"));
@@ -92,8 +92,8 @@ TEST(LabelIdMultiMapTest, some_labels)
                        {"fluffy", "jr"},
                        {"fluffy", "sr"}}}};
     EXPECT_EQ(4, cats.size());
-    EXPECT_EQ(CatId{1}, cats.find(Label{"fluffy"}));
-    EXPECT_EQ(CatId{2}, cats.find(Label{"fluffy", "jr"}));
+    EXPECT_EQ(CatId{1}, cats.find_exact(Label{"fluffy"}));
+    EXPECT_EQ(CatId{2}, cats.find_exact(Label{"fluffy", "jr"}));
     {
         auto found = cats.find_all("fluffy");
         static CatId const expected_found[] = {CatId{1}, CatId{2}, CatId{3}};

--- a/test/corecel/cont/LabelIdMultiMap.test.cc
+++ b/test/corecel/cont/LabelIdMultiMap.test.cc
@@ -42,27 +42,36 @@ std::ostream& operator<<(std::ostream& os, CatId const& cat)
 TEST(LabelIdMultiMapTest, empty)
 {
     CatMultiMap const default_cats;
-    CatMultiMap const empty_cats(VecLabel{});
+    EXPECT_FALSE(default_cats);  // Uninitialized and empty
+    CatMultiMap const empty_cats("cat", VecLabel{});
+    EXPECT_TRUE(empty_cats);  // Initialized and empty
     for (CatMultiMap const* cats : {&default_cats, &empty_cats})
     {
         EXPECT_EQ(0, cats->size());
         EXPECT_EQ(CatId{}, cats->find(Label{"merry"}));
         EXPECT_EQ(0, cats->find_all("pippin").size());
-#if CELERITAS_DEBUG
-        EXPECT_THROW(cats->get(CatId{0}), DebugError);
-#endif
+        if (CELERITAS_DEBUG)
+        {
+            EXPECT_THROW(cats->at(CatId{0}), DebugError);
+        }
     }
 }
 
 TEST(LabelIdMultiMapTest, no_ext_with_duplicates)
 {
-    CatMultiMap cats{VecLabel{{"dexter", "andy", "loki", "bob", "bob", "bob"}}};
+    CatMultiMap cats{
+        "cat", VecLabel{{"dexter", "andy", "loki", "bob", "bob", "bob"}}};
+    EXPECT_TRUE(cats);
     EXPECT_EQ(6, cats.size());
     EXPECT_EQ(CatId{}, cats.find("nyoka"));
     EXPECT_EQ(CatId{0}, cats.find("dexter"));
     EXPECT_EQ(CatId{1}, cats.find("andy"));
     EXPECT_EQ(CatId{2}, cats.find("loki"));
     EXPECT_EQ(CatId{2}, cats.find(Label{"loki"}));
+
+    EXPECT_EQ(CatId{}, cats.find_unique("nyoka"));
+    EXPECT_EQ(CatId{2}, cats.find_unique("loki"));
+    EXPECT_THROW(cats.find_unique("bob"), RuntimeError);
 
     static CatId const expected_duplicates[] = {CatId{3}, CatId{4}, CatId{5}};
     EXPECT_VEC_EQ(expected_duplicates, cats.duplicates());
@@ -71,6 +80,7 @@ TEST(LabelIdMultiMapTest, no_ext_with_duplicates)
 TEST(LabelIdMultiMapTest, empty_duplicates)
 {
     CatMultiMap cats{VecLabel{{"dexter", "andy", "loki", "", ""}}};
+    EXPECT_TRUE(cats);
     EXPECT_EQ(5, cats.size());
     EXPECT_EQ(0, cats.duplicates().size());
 }
@@ -89,6 +99,8 @@ TEST(LabelIdMultiMapTest, some_labels)
         static CatId const expected_found[] = {CatId{1}, CatId{2}, CatId{3}};
         EXPECT_VEC_EQ(expected_found, found);
     }
+
+    EXPECT_THROW(cats.find_unique("fluffy"), RuntimeError);
 }
 
 TEST(LabelIdMultiMapTest, shuffled_labels)
@@ -102,12 +114,12 @@ TEST(LabelIdMultiMapTest, shuffled_labels)
         {"c", "1"},
     };
 
-    CatMultiMap cats{labels};
+    CatMultiMap cats{std::vector<Label>{labels}};
 
     // Check ordering of IDs
     for (auto i : range<CatId::size_type>(labels.size()))
     {
-        EXPECT_EQ(labels[i], cats.get(CatId{i}));
+        EXPECT_EQ(labels[i], cats.at(CatId{i}));
     }
 
     // Check discontinuous ID listing

--- a/test/geocel/GenericGeoTestBase.cc
+++ b/test/geocel/GenericGeoTestBase.cc
@@ -95,7 +95,7 @@ GeantVolResult GeantVolResult::from_import(GeoParamsInterface const& geom,
             CELER_ASSERT(i < result.volumes.size());
 
             auto label = Label::from_geant(name);
-            auto id = geom.find_volume(label);
+            auto id = geom.volumes().find(label);
             if (!id)
             {
                 result.volumes[i] = Result::missing;

--- a/test/geocel/GenericGeoTestBase.cc
+++ b/test/geocel/GenericGeoTestBase.cc
@@ -95,7 +95,7 @@ GeantVolResult GeantVolResult::from_import(GeoParamsInterface const& geom,
             CELER_ASSERT(i < result.volumes.size());
 
             auto label = Label::from_geant(name);
-            auto id = geom.volumes().find(label);
+            auto id = geom.volumes().find_exact(label);
             if (!id)
             {
                 result.volumes[i] = Result::missing;

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -77,7 +77,7 @@ std::string GenericGeoTestBase<HP>::volume_name(GeoTrackView const& geo) const
     {
         return "[OUTSIDE]";
     }
-    return this->geometry()->id_to_label(geo.volume_id()).name;
+    return this->geometry()->volumes().at(geo.volume_id()).name;
 }
 
 //---------------------------------------------------------------------------//
@@ -97,7 +97,7 @@ std::string GenericGeoTestBase<HP>::surface_name(GeoTrackView const& geo) const
     }
 
     // Only call this function if the geometry supports surfaces
-    return ptr->id_to_label(geo.surface_id()).name;
+    return ptr->surfaces().at(geo.surface_id()).name;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -68,12 +68,12 @@ TEST_F(FourLevelsTest, accessors)
     EXPECT_VEC_SOFT_EQ((Real3{-24., -24., -24.}), to_cm(bbox.lower()));
     EXPECT_VEC_SOFT_EQ((Real3{24., 24., 24.}), to_cm(bbox.upper()));
 
-    ASSERT_EQ(4, geom.num_volumes());
-    EXPECT_EQ("Shape2", geom.id_to_label(VolumeId{0}).name);
-    EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{1}).name);
-    EXPECT_EQ("Envelope", geom.id_to_label(VolumeId{2}).name);
-    EXPECT_EQ("World", geom.id_to_label(VolumeId{3}).name);
-    EXPECT_EQ(Label("World", "0xdeadbeef"), geom.id_to_label(VolumeId{3}));
+    ASSERT_EQ(4, geom.volumes().size());
+    EXPECT_EQ("Shape2", geom.volumes().at(VolumeId{0}).name);
+    EXPECT_EQ("Shape1", geom.volumes().at(VolumeId{1}).name);
+    EXPECT_EQ("Envelope", geom.volumes().at(VolumeId{2}).name);
+    EXPECT_EQ("World", geom.volumes().at(VolumeId{3}).name);
+    EXPECT_EQ(Label("World", "0xdeadbeef"), geom.volumes().at(VolumeId{3}));
 
     auto const* lv = geom.id_to_lv(VolumeId{2});
     ASSERT_TRUE(lv);
@@ -363,11 +363,11 @@ TEST_F(SolidsTest, accessors)
     // offset. This value will be zero if running the solids test as
     // standalone.
     int const offset = 4;
-    ASSERT_EQ(26 + offset, geom.num_volumes());
-    EXPECT_EQ("box500", geom.id_to_label(VolumeId{0 + offset}).name);
-    EXPECT_EQ("cone1", geom.id_to_label(VolumeId{1 + offset}).name);
-    EXPECT_EQ("World", geom.id_to_label(VolumeId{24 + offset}).name);
-    EXPECT_EQ("trd3_refl", geom.id_to_label(VolumeId{25 + offset}).name);
+    ASSERT_EQ(26 + offset, geom.volumes().size());
+    EXPECT_EQ("box500", geom.volumes().at(VolumeId{0 + offset}).name);
+    EXPECT_EQ("cone1", geom.volumes().at(VolumeId{1 + offset}).name);
+    EXPECT_EQ("World", geom.volumes().at(VolumeId{24 + offset}).name);
+    EXPECT_EQ("trd3_refl", geom.volumes().at(VolumeId{25 + offset}).name);
 }
 
 //---------------------------------------------------------------------------//
@@ -607,7 +607,7 @@ TEST_F(SolidsTest, reflected_vol)
 {
     auto geo = this->make_geo_track_view({-500, -125, 0}, {0, 1, 0});
     EXPECT_EQ(VolumeId{29}, geo.volume_id());
-    auto const& label = this->geometry()->id_to_label(geo.volume_id());
+    auto const& label = this->geometry()->volumes().at(geo.volume_id());
     EXPECT_EQ("trd3_refl", label.name);
     EXPECT_FALSE(ends_with(label.ext, "_refl"));
 }

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -149,7 +149,7 @@ TEST_F(SimpleCmsTest, accessors)
 {
     auto const& geom = *this->geometry();
     EXPECT_EQ(2, geom.max_depth());
-    EXPECT_EQ(7, geom.num_volumes());
+    EXPECT_EQ(7, geom.volumes().size());
 }
 
 //---------------------------------------------------------------------------//
@@ -307,12 +307,12 @@ TEST_F(FourLevelsTest, accessors)
     EXPECT_VEC_SOFT_EQ((Real3{-24.001, -24.001, -24.001}), to_cm(bbox.lower()));
     EXPECT_VEC_SOFT_EQ((Real3{24.001, 24.001, 24.001}), to_cm(bbox.upper()));
 
-    ASSERT_EQ(4, geom.num_volumes());
-    EXPECT_EQ("Shape2", geom.id_to_label(VolumeId{0}).name);
-    EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{1}).name);
-    EXPECT_EQ("Envelope", geom.id_to_label(VolumeId{2}).name);
-    EXPECT_EQ("World", geom.id_to_label(VolumeId{3}).name);
-    EXPECT_EQ(Label("World", "0xdeadbeef"), geom.id_to_label(VolumeId{3}));
+    ASSERT_EQ(4, geom.volumes().size());
+    EXPECT_EQ("Shape2", geom.volumes().at(VolumeId{0}).name);
+    EXPECT_EQ("Shape1", geom.volumes().at(VolumeId{1}).name);
+    EXPECT_EQ("Envelope", geom.volumes().at(VolumeId{2}).name);
+    EXPECT_EQ("World", geom.volumes().at(VolumeId{3}).name);
+    EXPECT_EQ(Label("World", "0xdeadbeef"), geom.volumes().at(VolumeId{3}));
 }
 
 //---------------------------------------------------------------------------//
@@ -690,10 +690,10 @@ TEST_F(SolidsTest, names)
 {
     auto const& geom = *this->geometry();
     std::vector<std::string> labels;
-    for (auto vid : range(VolumeId{geom.num_volumes()}))
+    for (auto vid : range(VolumeId{geom.volumes().size()}))
     {
         labels.push_back(
-            this->genericize_pointers(to_string(geom.id_to_label(vid))));
+            this->genericize_pointers(to_string(geom.volumes().at(vid))));
     }
 
     // clang-format off
@@ -938,7 +938,7 @@ TEST_F(SolidsTest, trace)
 TEST_F(SolidsTest, reflected_vol)
 {
     auto geo = this->make_geo_track_view({-500, -125, 0}, {0, 1, 0});
-    auto const& label = this->geometry()->id_to_label(geo.volume_id());
+    auto const& label = this->geometry()->volumes().at(geo.volume_id());
     // Note: through GDML there is only one trd3_refl
     EXPECT_EQ("trd3_refl", label.name);
     EXPECT_FALSE(ends_with(label.ext, "_refl"));
@@ -1092,11 +1092,11 @@ TEST_F(FourLevelsGeantTest, accessors)
     EXPECT_VEC_SOFT_EQ((Real3{-24.001, -24.001, -24.001}), to_cm(bbox.lower()));
     EXPECT_VEC_SOFT_EQ((Real3{24.001, 24.001, 24.001}), to_cm(bbox.upper()));
 
-    ASSERT_EQ(4, geom.num_volumes());
-    EXPECT_EQ("Shape2", geom.id_to_label(VolumeId{0}).name);
-    EXPECT_EQ("Shape1", geom.id_to_label(VolumeId{1}).name);
-    EXPECT_EQ("Envelope", geom.id_to_label(VolumeId{2}).name);
-    EXPECT_EQ("World", geom.id_to_label(VolumeId{3}).name);
+    ASSERT_EQ(4, geom.volumes().size());
+    EXPECT_EQ("Shape2", geom.volumes().at(VolumeId{0}).name);
+    EXPECT_EQ("Shape1", geom.volumes().at(VolumeId{1}).name);
+    EXPECT_EQ("Envelope", geom.volumes().at(VolumeId{2}).name);
+    EXPECT_EQ("World", geom.volumes().at(VolumeId{3}).name);
 }
 
 //---------------------------------------------------------------------------//
@@ -1244,10 +1244,10 @@ TEST_F(SolidsGeantTest, names)
 {
     auto const& geom = *this->geometry();
     std::vector<std::string> labels;
-    for (auto vid : range(VolumeId{geom.num_volumes()}))
+    for (auto vid : range(VolumeId{geom.volumes().size()}))
     {
         labels.push_back(
-            this->genericize_pointers(to_string(geom.id_to_label(vid))));
+            this->genericize_pointers(to_string(geom.volumes().at(vid))));
     }
 
     // clang-format off
@@ -1462,7 +1462,7 @@ TEST_F(SolidsGeantTest, reflected_vol)
 {
     auto geo = this->make_geo_track_view({-500, -125, 0}, {0, 1, 0});
     EXPECT_EQ(VolumeId{30}, geo.volume_id());
-    auto const& label = this->geometry()->id_to_label(geo.volume_id());
+    auto const& label = this->geometry()->volumes().at(geo.volume_id());
     EXPECT_EQ("trd3", label.name);
     EXPECT_TRUE(ends_with(label.ext, "_refl"));
 }

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -54,10 +54,10 @@ TEST_F(OneVolumeTest, params)
     EXPECT_TRUE(geo.supports_safety());
 
     EXPECT_EQ("one volume", geo.universes().at(UniverseId{0}).name);
-    EXPECT_EQ(UniverseId{0}, geo.universes().find("one volume"));
+    EXPECT_EQ(UniverseId{0}, geo.universes().find_unique("one volume"));
 
     EXPECT_EQ("infinite", geo.volumes().at(VolumeId{0}).name);
-    EXPECT_EQ(VolumeId{0}, geo.volumes().find("infinite"));
+    EXPECT_EQ(VolumeId{0}, geo.volumes().find_unique("infinite"));
 }
 
 TEST_F(OneVolumeTest, track_view)
@@ -150,7 +150,7 @@ TEST_F(TwoVolumeTest, params)
     EXPECT_TRUE(geo.supports_safety());
 
     EXPECT_EQ("sphere", geo.surfaces().at(SurfaceId{0}).name);
-    EXPECT_EQ(SurfaceId{0}, geo.surfaces().find("sphere"));
+    EXPECT_EQ(SurfaceId{0}, geo.surfaces().find_unique("sphere"));
 
     auto const& bbox = geo.bbox();
     EXPECT_VEC_SOFT_EQ((Real3{-1.5, -1.5, -1.5}), bbox.lower());

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -48,16 +48,16 @@ TEST_F(OneVolumeTest, params)
 {
     OrangeParams const& geo = this->params();
 
-    EXPECT_EQ(1, geo.num_universes());
-    EXPECT_EQ(1, geo.num_volumes());
-    EXPECT_EQ(0, geo.num_surfaces());
+    EXPECT_EQ(1, geo.universes().size());
+    EXPECT_EQ(1, geo.volumes().size());
+    EXPECT_EQ(0, geo.surfaces().size());
     EXPECT_TRUE(geo.supports_safety());
 
-    EXPECT_EQ("one volume", geo.id_to_label(UniverseId{0}).name);
-    EXPECT_EQ(UniverseId{0}, geo.find_universe("one volume"));
+    EXPECT_EQ("one volume", geo.universes().at(UniverseId{0}).name);
+    EXPECT_EQ(UniverseId{0}, geo.universes().find("one volume"));
 
-    EXPECT_EQ("infinite", geo.id_to_label(VolumeId{0}).name);
-    EXPECT_EQ(VolumeId{0}, geo.find_volume("infinite"));
+    EXPECT_EQ("infinite", geo.volumes().at(VolumeId{0}).name);
+    EXPECT_EQ(VolumeId{0}, geo.volumes().find("infinite"));
 }
 
 TEST_F(OneVolumeTest, track_view)
@@ -145,12 +145,12 @@ TEST_F(TwoVolumeTest, params)
 {
     OrangeParams const& geo = this->params();
 
-    EXPECT_EQ(2, geo.num_volumes());
-    EXPECT_EQ(1, geo.num_surfaces());
+    EXPECT_EQ(2, geo.volumes().size());
+    EXPECT_EQ(1, geo.surfaces().size());
     EXPECT_TRUE(geo.supports_safety());
 
-    EXPECT_EQ("sphere", geo.id_to_label(SurfaceId{0}).name);
-    EXPECT_EQ(SurfaceId{0}, geo.find_surface("sphere"));
+    EXPECT_EQ("sphere", geo.surfaces().at(SurfaceId{0}).name);
+    EXPECT_EQ(SurfaceId{0}, geo.surfaces().find("sphere"));
 
     auto const& bbox = geo.bbox();
     EXPECT_VEC_SOFT_EQ((Real3{-1.5, -1.5, -1.5}), bbox.lower());

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -235,7 +235,7 @@ void OrangeGeoTestBase::describe(std::ostream& os) const
     os << "# Surfaces\n";
 
     // Loop over all surfaces and apply
-    for (auto id : range(LocalSurfaceId{this->params().num_surfaces()}))
+    for (auto id : range(LocalSurfaceId{this->params().surfaces().size()}))
     {
         os << " - " << this->id_to_label(UniverseId{0}, id) << "(" << id.get()
            << "): ";
@@ -251,7 +251,7 @@ void OrangeGeoTestBase::describe(std::ostream& os) const
 VolumeId::size_type OrangeGeoTestBase::num_volumes() const
 {
     CELER_EXPECT(params_);
-    return params_->num_volumes();
+    return params_->volumes().size();
 }
 
 //---------------------------------------------------------------------------//
@@ -261,7 +261,7 @@ VolumeId::size_type OrangeGeoTestBase::num_volumes() const
 SurfaceId OrangeGeoTestBase::find_surface(std::string const& label) const
 {
     CELER_EXPECT(params_);
-    SurfaceId surface_id = params_->find_surface(label);
+    SurfaceId surface_id = params_->surfaces().find_unique(label);
     CELER_VALIDATE(surface_id,
                    << "nonexistent surface label '" << label << '\'');
     return surface_id;
@@ -274,7 +274,7 @@ SurfaceId OrangeGeoTestBase::find_surface(std::string const& label) const
 VolumeId OrangeGeoTestBase::find_volume(std::string const& label) const
 {
     CELER_EXPECT(params_);
-    VolumeId volume_id = params_->find_volume(label);
+    VolumeId volume_id = params_->volumes().find_unique(label);
     CELER_VALIDATE(volume_id, << "nonexistent volume label '" << label << '\'');
     return volume_id;
 }
@@ -290,7 +290,7 @@ OrangeGeoTestBase::id_to_label(UniverseId uid, LocalSurfaceId surfid) const
         return "[none]";
 
     detail::UniverseIndexer ui(this->params().host_ref().universe_indexer_data);
-    return params_->id_to_label(ui.global_surface(uid, surfid)).name;
+    return params_->surfaces().at(ui.global_surface(uid, surfid)).name;
 }
 
 //---------------------------------------------------------------------------//
@@ -313,7 +313,7 @@ OrangeGeoTestBase::id_to_label(UniverseId uid, LocalVolumeId volid) const
         return "[none]";
 
     detail::UniverseIndexer ui(this->params().host_ref().universe_indexer_data);
-    return params_->id_to_label(ui.global_volume(uid, volid)).name;
+    return params_->volumes().at(ui.global_volume(uid, volid)).name;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -59,8 +59,8 @@ TEST_F(FiveVolumesTest, params)
 {
     OrangeParams const& geo = this->params();
 
-    EXPECT_EQ(6, geo.num_volumes());
-    EXPECT_EQ(12, geo.num_surfaces());
+    EXPECT_EQ(6, geo.volumes().size());
+    EXPECT_EQ(12, geo.surfaces().size());
     EXPECT_FALSE(geo.supports_safety());
 }
 
@@ -73,8 +73,8 @@ class UniversesTest : public JsonOrangeTest
 TEST_F(UniversesTest, params)
 {
     OrangeParams const& geo = this->params();
-    EXPECT_EQ(12, geo.num_volumes());
-    EXPECT_EQ(25, geo.num_surfaces());
+    EXPECT_EQ(12, geo.volumes().size());
+    EXPECT_EQ(25, geo.surfaces().size());
     EXPECT_EQ(3, geo.max_depth());
     EXPECT_FALSE(geo.supports_safety());
 
@@ -94,9 +94,9 @@ TEST_F(UniversesTest, params)
                                          "[EXTERIOR]",
                                          "patty"};
     std::vector<std::string> actual;
-    for (auto const id : range(VolumeId{geo.num_volumes()}))
+    for (auto const id : range(VolumeId{geo.volumes().size()}))
     {
-        actual.push_back(geo.id_to_label(id).name);
+        actual.push_back(geo.volumes().at(id).name);
     }
 
     EXPECT_VEC_EQ(expected, actual);
@@ -196,7 +196,7 @@ TEST_F(UniversesTest, initialize_with_multiple_universes)
         other = OrangeTrackView::DetailedInitializer{geo, {1, 0, 0}};
         EXPECT_VEC_SOFT_EQ(Real3({0.625, -2, 1}), other.pos());
         EXPECT_VEC_SOFT_EQ(Real3({1, 0, 0}), other.dir());
-        EXPECT_EQ("c", this->params().id_to_label(other.volume_id()).name);
+        EXPECT_EQ("c", this->params().volumes().at(other.volume_id()).name);
         EXPECT_FALSE(other.is_outside());
         EXPECT_FALSE(other.is_on_boundary());
     }
@@ -481,8 +481,8 @@ class RectArrayTest : public JsonOrangeTest
 TEST_F(RectArrayTest, params)
 {
     OrangeParams const& geo = this->params();
-    EXPECT_EQ(35, geo.num_volumes());
-    EXPECT_EQ(22, geo.num_surfaces());
+    EXPECT_EQ(35, geo.volumes().size());
+    EXPECT_EQ(22, geo.surfaces().size());
     EXPECT_EQ(4, geo.max_depth());
     EXPECT_FALSE(geo.supports_safety());
 


### PR DESCRIPTION
In preparation for #1248 we will be adding `VolumeInstanceId` to universes. Rather than adding another set of multimap interfaces, let's just expose the `MultiMap` as the interface for volumes and surfaces. The volume instances will just be another multimap accessor.