### PR TITLE
Escape semicolons in exported CMake variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -631,7 +631,9 @@ elseif(CELERITAS_USE_HIP)
   set(_celer_other_cmake_variables CMAKE_HIP_ARCHITECTURES)
 endif()
 foreach(_key IN LISTS CELERITAS_DEFAULT_VARIABLES _celer_other_cmake_variables)
-  list(APPEND CELERITAS_EXPORT_VARIABLES "set(CELERITAS_${_key} \"${${_key}}\")")
+  # Value of _key may be ;-separated list, so we need to escape the ; if present
+  string(REPLACE ";" "\;" _key_val "${${_key}}")
+  list(APPEND CELERITAS_EXPORT_VARIABLES "set(CELERITAS_${_key} \"${_key_val}\")")
 endforeach()
 
 # Add hints for direct dependencies and indirect geant dependencies

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 set(CELERITAS_CMAKE_STRINGS)
 macro(celeritas_append_cmake_string key value)
   list(APPEND CELERITAS_CMAKE_STRINGS
-    "inline constexpr char ${key}[] = \"${value}\"\;"
+    "inline constexpr char ${key}[] = R\"(${value})\"\;"
   )
 endmacro()
 

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -74,6 +74,8 @@ if(CELERITAS_USE_CUDA)
 elseif(CELERITAS_USE_HIP)
   set(_gpu_arch "${CMAKE_HIP_ARCHITECTURES}")
 endif()
+# Arch variable may be ;-separated list, so we need to escape the ;
+string(REPLACE ";" "\;" _gpu_arch "${_gpu_arch}")
 celeritas_append_cmake_string("celeritas_gpu_architectures" "${_gpu_arch}")
 
 list(APPEND CELERITAS_CMAKE_STRINGS "")


### PR DESCRIPTION
Noted in ATLAS builds that the export of `CMAKE_CUDA_ARCHITECTURES` to the `Config.hh` and `CeleritasConfig.cmake` files resulted in newlines replacing the semicolons when this variable is a proper CMake list. For example, running CMake as

```
$ cmake -DCMAKE_CUDA_ARCHITECTURES="50;61;72;80" ...
```

as in ATLAS builds created a `Config.hh` with:

```c++
inline constexpr char celeritas_gpu_architectures[] = "50
61
75
80";
```

and thus a compile-time error. Similarly, `CeleritasConfig.cmake` got

```cmake
set(CELERITAS_CMAKE_CUDA_ARCHITECTURES "50
61
75
80")
```

Assuming that we want to retain these as `"X;Y;Z"`, the changes here explicitly escape any semicolons in variables exported to CMake files to ensure their retention, and also the CUDA/HIP architecture variable exported to `Config.hh` to retain them and prevent compilation error.

