### PR TITLE
Anchor vtables to fix broken dynamic cast in tests

### DIFF
--- a/src/corecel/Assert.cc
+++ b/src/corecel/Assert.cc
@@ -153,6 +153,10 @@ DebugError::DebugError(DebugErrorDetails&& d)
 }
 
 //---------------------------------------------------------------------------//
+// Default destructor to anchor vtable
+DebugError::~DebugError() = default;
+
+//---------------------------------------------------------------------------//
 /*!
  * Construct a runtime error from detailed descriptions.
  */
@@ -160,6 +164,10 @@ RuntimeError::RuntimeError(RuntimeErrorDetails&& d)
     : std::runtime_error(build_runtime_error_msg(d)), details_(std::move(d))
 {
 }
+
+//---------------------------------------------------------------------------//
+// Default destructor to anchor vtable
+RuntimeError::~RuntimeError() = default;
 
 //---------------------------------------------------------------------------//
 // String constants for throwing

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -461,6 +461,10 @@ class DebugError : public std::logic_error
   public:
     // Construct from debug attributes
     explicit DebugError(DebugErrorDetails&&);
+    CELER_DEFAULT_COPY_MOVE(DebugError);
+
+    // Default destructor to anchor vtable
+    ~DebugError();
 
     //! Access the debug data
     DebugErrorDetails const& details() const { return details_; }
@@ -478,6 +482,10 @@ class RuntimeError : public std::runtime_error
   public:
     // Construct from details
     explicit RuntimeError(RuntimeErrorDetails&&);
+    CELER_DEFAULT_COPY_MOVE(RuntimeError);
+
+    // Default destructor to anchor vtable
+    ~RuntimeError();
 
     //! Access detailed information
     RuntimeErrorDetails const& details() const { return details_; }

--- a/src/corecel/data/AuxInterface.hh
+++ b/src/corecel/data/AuxInterface.hh
@@ -41,7 +41,7 @@ class AuxStateInterface
     //@}
 
   public:
-    // Virtual destructor for polymorphism
+    // Anchored virtual destructor for polymorphism
     virtual ~AuxStateInterface();
 
   protected:
@@ -71,7 +71,7 @@ class AuxParamsInterface
     //@}
 
   public:
-    // Virtual destructor for polymorphism
+    // Anchored virtual destructor for polymorphism
     virtual ~AuxParamsInterface();
 
     //! Index of this class instance in its registry

--- a/src/geocel/CMakeLists.txt
+++ b/src/geocel/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PUBLIC_DEPS Celeritas::corecel)
 
 list(APPEND SOURCES
   BoundingBoxIO.json.cc
+  GeoParamsInterface.cc
   GeoParamsOutput.cc
   rasterize/Color.cc
   rasterize/Image.cc

--- a/src/geocel/GeoParamsInterface.cc
+++ b/src/geocel/GeoParamsInterface.cc
@@ -1,0 +1,21 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/GeoParamsInterface.cc
+//---------------------------------------------------------------------------//
+#include "GeoParamsInterface.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+//! Default virtual destructor
+GeoParamsInterface::~GeoParamsInterface() = default;
+
+//---------------------------------------------------------------------------//
+//! Default virtual destructor
+GeoParamsSurfaceInterface::~GeoParamsSurfaceInterface() = default;
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -39,6 +39,9 @@ class GeoParamsInterface
     //!@}
 
   public:
+    // Anchor virtual destructor
+    virtual ~GeoParamsInterface() = 0;
+
     //! Whether safety distance calculations are accurate and precise
     virtual bool supports_safety() const = 0;
 
@@ -104,9 +107,6 @@ class GeoParamsInterface
     }
 
   protected:
-    // Protected destructor prevents deletion of pointer-to-interface
-    ~GeoParamsInterface() = default;
-
     GeoParamsInterface() = default;
     CELER_DEFAULT_COPY_MOVE(GeoParamsInterface);
 };
@@ -126,6 +126,9 @@ class GeoParamsSurfaceInterface : public GeoParamsInterface
     //!@}
 
   public:
+    // Default destructor
+    virtual ~GeoParamsSurfaceInterface() = 0;
+
     using GeoParamsInterface::id_to_label;
 
     //! Get surface metadata
@@ -153,6 +156,10 @@ class GeoParamsSurfaceInterface : public GeoParamsInterface
     {
         return this->surfaces().size();
     }
+
+  protected:
+    GeoParamsSurfaceInterface() = default;
+    CELER_DEFAULT_COPY_MOVE(GeoParamsSurfaceInterface);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND SOURCES
   orangeinp/InputBuilder.cc
   orangeinp/IntersectRegion.cc
   orangeinp/IntersectSurfaceBuilder.cc
+  orangeinp/ObjectInterface.cc
   orangeinp/ObjectIO.json.cc
   orangeinp/PolySolid.cc
   orangeinp/ProtoInterface.cc

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -218,5 +218,8 @@ OrangeParams::OrangeParams(OrangeInput&& input)
  */
 OrangeParams::~OrangeParams() = default;
 
+template class CollectionMirror<OrangeParamsData>;
+template class ParamsDataInterface<OrangeParamsData>;
+
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -209,4 +209,14 @@ OrangeParams::OrangeParams(OrangeInput&& input)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Default destructor to define vtable externally.
+ *
+ * Needed due to a buggy LLVM optimization that causes dynamic-casts in
+ * downstream libraries to fail: see
+ * https://github.com/celeritas-project/celeritas/pull/1436 .
+ */
+OrangeParams::~OrangeParams() = default;
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -54,6 +54,12 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     // ADVANCED usage: construct from explicit host data
     explicit OrangeParams(OrangeInput&& input);
 
+    // Default destructor to anchor vtable
+    ~OrangeParams();
+
+    // Moving would leave the class in an unspecified state
+    CELER_DELETE_COPY_MOVE(OrangeParams);
+
     //! Whether safety distance calculations are accurate and precise
     bool supports_safety() const final { return supports_safety_; }
 

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -138,6 +138,11 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
 };
 
 //---------------------------------------------------------------------------//
+
+extern template class CollectionMirror<OrangeParamsData>;
+extern template class ParamsDataInterface<OrangeParamsData>;
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/orange/orangeinp/ObjectInterface.cc
+++ b/src/orange/orangeinp/ObjectInterface.cc
@@ -1,0 +1,20 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/ObjectInterface.cc
+//---------------------------------------------------------------------------//
+#include "ObjectInterface.hh"
+
+namespace celeritas
+{
+namespace orangeinp
+{
+//---------------------------------------------------------------------------//
+//! Anchored default destructor
+ObjectInterface::~ObjectInterface() = default;
+
+//---------------------------------------------------------------------------//
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/src/orange/orangeinp/ObjectInterface.hh
+++ b/src/orange/orangeinp/ObjectInterface.hh
@@ -43,6 +43,9 @@ class ObjectInterface
     //!@}
 
   public:
+    // Anchored default destructor
+    virtual ~ObjectInterface() = 0;
+
     //! Short unique name of this object
     virtual std::string_view label() const = 0;
 
@@ -56,7 +59,6 @@ class ObjectInterface
     //!@{
     //! Allow construction and assignment only through daughter classes
     ObjectInterface() = default;
-    virtual ~ObjectInterface() = default;
     CELER_DEFAULT_COPY_MOVE(ObjectInterface);
     //!@}
 };

--- a/src/orange/orangeinp/PolySolid.cc
+++ b/src/orange/orangeinp/PolySolid.cc
@@ -163,6 +163,10 @@ PolySolidBase::PolySolidBase(std::string&& label,
 }
 
 //---------------------------------------------------------------------------//
+//! Anchored default virtual destructor
+PolySolidBase::~PolySolidBase() = default;
+
+//---------------------------------------------------------------------------//
 /*!
  * Return a polycone *or* a simplified version for only a single segment.
  */

--- a/src/orange/orangeinp/PolySolid.hh
+++ b/src/orange/orangeinp/PolySolid.hh
@@ -119,6 +119,9 @@ auto PolySegments::z(size_type i) const -> Real2
 class PolySolidBase : public ObjectInterface
 {
   public:
+    // Anchored default virtual destructor
+    virtual ~PolySolidBase();
+
     //! Get the user-provided label
     std::string_view label() const final { return label_; }
 
@@ -135,7 +138,6 @@ class PolySolidBase : public ObjectInterface
 
     //!@{
     //! Allow construction and assignment only through daughter classes
-    virtual ~PolySolidBase() = default;
     CELER_DEFAULT_COPY_MOVE(PolySolidBase);
     //!@}
 

--- a/test/geocel/GenericGeoTestBase.hh
+++ b/test/geocel/GenericGeoTestBase.hh
@@ -135,10 +135,7 @@ class GenericGeoTestBase : virtual public Test, private LazyGeoManager
     SPConstGeo geo_;
     HostStateStore host_state_;
 
-    SPConstGeoI build_fresh_geometry(std::string_view)
-    {
-        return this->build_geometry();
-    }
+    SPConstGeoI build_fresh_geometry(std::string_view) override;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -267,5 +267,12 @@ auto GenericGeoTestBase<HP>::track(Real3 const& pos,
 }
 
 //---------------------------------------------------------------------------//
+template<class HP>
+auto GenericGeoTestBase<HP>::build_fresh_geometry(std::string_view) -> SPConstGeoI
+{
+    return this->build_geometry();
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -189,6 +189,7 @@ void OrangeGeoTestBase::build_geometry(UnitInput input)
 {
     CELER_EXPECT(input);
     params_ = std::make_unique<Params>(to_input(std::move(input)));
+    // Base class will construct geometry from this call via build_geometry
     ASSERT_TRUE(this->geometry());
 }
 

--- a/test/orange/OrangeTestBase.hh
+++ b/test/orange/OrangeTestBase.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "corecel/OpaqueId.hh"
+#include "geocel/CheckedGeoTrackView.hh"
 #include "geocel/GenericGeoTestBase.hh"
 #include "orange/OrangeData.hh"
 #include "orange/OrangeGeoTraits.hh"
@@ -20,6 +21,10 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 using OrangeTestBase = GenericGeoTestBase<OrangeParams>;
+
+//---------------------------------------------------------------------------//
+extern template class CheckedGeoTrackView<OrangeTrackView>;
+extern template class GenericGeoTestBase<OrangeParams>;
 
 //---------------------------------------------------------------------------//
 }  // namespace test


### PR DESCRIPTION
This follow-on to https://github.com/celeritas-project/celeritas/pull/1436 is to fix another manifestation of the bug caused by https://github.com/llvm/llvm-project/commit/9d525bf94b255df89587db955b5fa2d3c03c2c3e : in optimized mode, llvm fails to `dynamic_cast` classes that are declared `final` but have weak vtables. The weird part of fixing this instance was that to make the vtable strong, I had to anchor the `GeoParamsInterface` virtual destructor because that was in a separate library. (The GeantGeoParams and VecgeomParams worked because the inline virtual destructor was in the same library, so the final class had a "strong" vtable symbol.)

Before:
```console
$ ninja orange && nm lib/liborange.dylib | c++filt | grep 'vtable for celeritas::.*Orange.*' | cut -b 18- | sort
S vtable for celeritas::OrangeParamsOutput
S vtable for celeritas::RaytraceImager<celeritas::OrangeParams>
s vtable for celeritas::CollectionMirror<celeritas::OrangeParamsData>
s vtable for celeritas::OrangeParams
$ ninja geocel && nm lib/libgeocel.dylib | c++filt | grep 'vtable for celeritas::.*Params.*' | cut -b 18- | sort
S vtable for celeritas::GeantGeoParams
S vtable for celeritas::GeoParamsOutput
S vtable for celeritas::RaytraceImager<celeritas::GeantGeoParams>
S vtable for celeritas::RaytraceImager<celeritas::VecgeomParams>
S vtable for celeritas::VecgeomParams
S vtable for celeritas::VecgeomParamsOutput
s vtable for celeritas::CollectionMirror<celeritas::ImageParamsData>
s vtable for celeritas::ImageParams
```

After (note `celeritas::OrangeParams` changes from `s` to `S`:
```console
$ ninja orange && nm lib/liborange.dylib | c++filt | grep 'vtable for celeritas::.*Orange.*' | cut -b 18- | sort
S vtable for celeritas::CollectionMirror<celeritas::OrangeParamsData>
S vtable for celeritas::OrangeParams
S vtable for celeritas::OrangeParamsOutput
S vtable for celeritas::ParamsDataInterface<celeritas::OrangeParamsData>
S vtable for celeritas::RaytraceImager<celeritas::OrangeParams>
$ ninja geocel && nm lib/libgeocel.dylib | c++filt | grep 'vtable for celeritas::.*Params.*' | cut -b 18- | sort
S vtable for celeritas::GeantGeoParams
S vtable for celeritas::GeoParamsOutput
S vtable for celeritas::RaytraceImager<celeritas::GeantGeoParams>
S vtable for celeritas::RaytraceImager<celeritas::VecgeomParams>
S vtable for celeritas::VecgeomParams
S vtable for celeritas::VecgeomParamsOutput
s vtable for celeritas::CollectionMirror<celeritas::ImageParamsData>
s vtable for celeritas::ImageParams
```