### PR TITLE
Override and save Geant4 dataset variables at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,18 +323,18 @@ if(CELERITAS_USE_Geant4 AND NOT Geant4_FOUND)
       "consider setting CELERITAS_OPENMP to \"event\" or disabling OpenMP"
     )
   endif()
-   # Set environment variables from Geant4-exported configuration
+  # Set environment variables from Geant4-exported configuration
   if(NOT DEFINED CELER_G4ENV)
     set(_CELER_G4ENV)
     foreach(_ds IN LISTS Geant4_DATASETS)
       if(NOT DEFINED ENV{${Geant4_DATASET_${_ds}_ENVVAR}})
         list(APPEND _CELER_G4ENV
-           "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
+          "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
         )
       else()
         message(STATUS "Set ${Geant4_DATASET_${_ds}_ENVVAR}=$ENV{${Geant4_DATASET_${_ds}_ENVVAR}} from the environment")
         list(APPEND _CELER_G4ENV
-           "${Geant4_DATASET_${_ds}_ENVVAR}=$ENV{${Geant4_DATASET_${_ds}_ENVVAR}}}"
+          "${Geant4_DATASET_${_ds}_ENVVAR}=$ENV{${Geant4_DATASET_${_ds}_ENVVAR}}}"
         )
       endif()
     endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ if(CELERITAS_USE_Geant4 AND NOT Geant4_FOUND)
            "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
         )
       else()
-        message(STATUS "Value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the environment rather than the Geant4 cmake fragment")
+        message(STATUS "Set ${Geant4_DATASET_${_ds}_ENVVAR}=$ENV{${Geant4_DATASET_${_ds}_ENVVAR}} from the environment")
         list(APPEND _CELER_G4ENV
            "${Geant4_DATASET_${_ds}_ENVVAR}=$ENV{${Geant4_DATASET_${_ds}_ENVVAR}}}"
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,23 @@ if(CELERITAS_USE_Geant4 AND NOT Geant4_FOUND)
       "consider setting CELERITAS_OPENMP to \"event\" or disabling OpenMP"
     )
   endif()
+   # Set environment variables from Geant4-exported configuration
+  if(NOT DEFINED CELER_G4ENV)
+    set(_CELER_G4ENV)
+    foreach(_ds IN LISTS Geant4_DATASETS)
+      if(NOT DEFINED ENV{${Geant4_DATASET_${_ds}_ENVVAR}})
+        list(APPEND _CELER_G4ENV
+           "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
+        )
+      else()
+        message(STATUS "Value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the environment rather than the Geant4 cmake fragment")
+        list(APPEND _CELER_G4ENV
+           "${Geant4_DATASET_${_ds}_ENVVAR}=$ENV{${Geant4_DATASET_${_ds}_ENVVAR}}}"
+        )
+      endif()
+    endforeach()
+    set(CELER_G4ENV "${_CELER_G4ENV}" CACHE INTERNAL "Environment variables used to run the Geant4 apps")
+  endif()
 endif()
 
 if(CELERITAS_USE_HepMC3)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -8,8 +8,13 @@ if(BUILD_TESTING)
   # Set environment variables from Geant4-exported configuration
   set(CELER_G4ENV)
   foreach(_ds IN LISTS Geant4_DATASETS)
-    list(APPEND CELER_G4ENV
-      "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}")
+    if(NOT DEFINED ENV{${Geant4_DATASET_${_ds}_ENVVAR}})
+      list(APPEND CELER_G4ENV
+         "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
+       )
+    else()
+      message(STATUS "For apps value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the environment rather than the Geant4 cmake fragment")
+    endif()
   endforeach()
 
   if(CELERITAS_USE_Python)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -15,6 +15,9 @@ if(BUILD_TESTING)
         )
       else()
         message(STATUS "For apps value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the environment rather than the Geant4 cmake fragment")
+        list(APPEND _CELER_G4ENV
+           "${Geant4_DATASET_${_ds}_ENVVAR}=$ENV{${Geant4_DATASET_${_ds}_ENVVAR}}}"
+        )
       endif()
     endforeach()
     set(CELER_G4ENV "${_CELER_G4ENV}" CACHE INTERNAL "Environment variables used to run the Geant4 apps")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -6,16 +6,19 @@
 
 if(BUILD_TESTING)
   # Set environment variables from Geant4-exported configuration
-  set(CELER_G4ENV)
-  foreach(_ds IN LISTS Geant4_DATASETS)
-    if(NOT DEFINED ENV{${Geant4_DATASET_${_ds}_ENVVAR}})
-      list(APPEND CELER_G4ENV
-         "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
-       )
-    else()
-      message(STATUS "For apps value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the environment rather than the Geant4 cmake fragment")
-    endif()
-  endforeach()
+  if(NOT DEFINED CELER_G4ENV)
+    set(_CELER_G4ENV)
+    foreach(_ds IN LISTS Geant4_DATASETS)
+      if(NOT DEFINED ENV{${Geant4_DATASET_${_ds}_ENVVAR}})
+        list(APPEND _CELER_G4ENV
+           "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
+        )
+      else()
+        message(STATUS "For apps value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the environment rather than the Geant4 cmake fragment")
+      endif()
+    endforeach()
+    set(CELER_G4ENV "${_CELER_G4ENV}" CACHE INTERNAL "Environment variables used to run the Geant4 apps")
+  endif()
 
   if(CELERITAS_USE_Python)
     set(CELER_PYTHON "$<TARGET_FILE:Python::Interpreter>")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -5,24 +5,6 @@
 #-----------------------------------------------------------------------------#
 
 if(BUILD_TESTING)
-  # Set environment variables from Geant4-exported configuration
-  if(NOT DEFINED CELER_G4ENV)
-    set(_CELER_G4ENV)
-    foreach(_ds IN LISTS Geant4_DATASETS)
-      if(NOT DEFINED ENV{${Geant4_DATASET_${_ds}_ENVVAR}})
-        list(APPEND _CELER_G4ENV
-           "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
-        )
-      else()
-        message(STATUS "For apps value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the environment rather than the Geant4 cmake fragment")
-        list(APPEND _CELER_G4ENV
-           "${Geant4_DATASET_${_ds}_ENVVAR}=$ENV{${Geant4_DATASET_${_ds}_ENVVAR}}}"
-        )
-      endif()
-    endforeach()
-    set(CELER_G4ENV "${_CELER_G4ENV}" CACHE INTERNAL "Environment variables used to run the Geant4 apps")
-  endif()
-
   if(CELERITAS_USE_Python)
     set(CELER_PYTHON "$<TARGET_FILE:Python::Interpreter>")
     set(CELER_NEEDS_PYTHON)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,20 +84,6 @@ function(celeritas_add_device_test base)
   celeritas_add_test("${base}.test.cc" ${_cuda_args} ${ARGN})
 endfunction()
 
-if(CELERITAS_USE_Geant4)
-  # Optional dependence on low-energy EM data and neutron data
-  set(CELERITASTEST_G4ENV)
-  foreach(_ds G4EMLOW G4ENSDFSTATE G4PARTICLEXS)
-    if(NOT DEFINED ENV{${Geant4_DATASET_${_ds}_ENVVAR}})
-      list(APPEND CELERITASTEST_G4ENV
-         "${Geant4_DATASET_${_ds}_ENVVAR}=${Geant4_DATASET_${_ds}_PATH}"
-       )
-    else()
-      message(STATUS "Value for ${Geant4_DATASET_${_ds}_ENVVAR} taken from the environment rather than the Geant4 cmake fragment")
-    endif()
-  endforeach()
-endif()
-
 if(CELERITAS_UNITS STREQUAL "CGS")
   set(_fixme_cgs)
 else()

--- a/test/accel/CMakeLists.txt
+++ b/test/accel/CMakeLists.txt
@@ -33,12 +33,12 @@ celeritas_setup_tests(SERIAL
 celeritas_add_test(ExceptionConverter.test.cc)
 celeritas_add_test(HepMC3PrimaryGenerator.test.cc
   ${_needs_hepmc}
-  ENVIRONMENT "${CELERITASTEST_G4ENV}")
+  ENVIRONMENT "${CELER_G4ENV}")
 celeritas_add_test(RZMapMagneticField.test.cc)
 celeritas_add_test(detail/HitManager.test.cc
-  ENVIRONMENT "${CELERITASTEST_G4ENV}")
+  ENVIRONMENT "${CELER_G4ENV}")
 celeritas_add_test(detail/HitProcessor.test.cc
-  ENVIRONMENT "${CELERITASTEST_G4ENV}")
+  ENVIRONMENT "${CELER_G4ENV}")
 if(CELERITAS_REAL_TYPE STREQUAL "double")
   # This test requires Geant4 *geometry* which is incompatible
   # with single-precision

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 if(NOT CELERITAS_USE_Geant4)
   set(_needs_geant4 DISABLE)
 else()
-  set(_optional_geant4_env ENVIRONMENT "${CELERITASTEST_G4ENV}")
+  set(_optional_geant4_env ENVIRONMENT "${CELER_G4ENV}")
   set(_needs_geant4 ${_optional_geant4_env})
 endif()
 
@@ -422,7 +422,7 @@ if(CELERITAS_USE_Geant4 AND CELERITAS_USE_ROOT)
         "${_basename}.geant.json"
         "${PROJECT_SOURCE_DIR}/src/celeritas/ext/RootInterfaceLinkDef.h"
       COMMAND
-        "${CMAKE_COMMAND}" "-E" "env" ${CELERITASTEST_G4ENV}
+        "${CMAKE_COMMAND}" "-E" "env" ${CELER_G4ENV}
         "$<TARGET_FILE:celer-export-geant>"
         "${_gdml}"
         "${_basename}.geant.json"


### PR DESCRIPTION

This is necessary for proper operation when building and testing Celeritas in a ATLAS build environment.  In the ATLAS build environment the Geant4 cmake fragment contains incorrect information about the location of the data file (it points to the long gone build directory) so we need to trust the environment variables instead.

This is essential the same as fe52da7ebaadce8f6fd3199a95490d048094c18a 
