### PR TITLE
Require `CELERITAS_DEBUG` be on to enable `CELERITAS_DEVICE_DEBUG`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ else()
 endif()
 cmake_dependent_option(CELERITAS_DEVICE_DEBUG
   "Use verbose debug assertions in device code" "OFF"
-  "_celeritas_use_device" OFF
+  "_celeritas_use_device;CELERITAS_DEBUG" OFF
 )
 
 # Secondary testing options (only applies to CTest)


### PR DESCRIPTION
Since we added a separate configure option for device assertions in #1394, some of the debug code in our kernels (e.g, [killing stuck tracks](https://github.com/celeritas-project/celeritas/blob/5a0178e78d8a4b6b68db1ab5890653a3bdea7f12/src/celeritas/global/alongstep/detail/PropagationApplier.hh#L113-L142)) won’t be executed if `CELERITAS_DEVICE_DEBUG`  is enabled but `CELERITAS_DEBUG` is not. This addresses that by simply requiring `CELERITAS_DEBUG` be on in order to enable device debug.