### PR TITLE
Refactor "touchable updater" that uses a navigator

### DIFF
--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -26,8 +26,8 @@ list(APPEND SOURCES
   detail/GeantSimpleCaloSD.cc
   detail/HitManager.cc
   detail/HitProcessor.cc
+  detail/NaviTouchableUpdater.cc
   detail/SensDetInserter.cc
-  detail/TouchableUpdater.cc
 )
 
 celeritas_polysource(ExceptionConverter)

--- a/src/accel/HepMC3PrimaryGenerator.cc
+++ b/src/accel/HepMC3PrimaryGenerator.cc
@@ -9,7 +9,6 @@
 
 #include <mutex>
 #include <G4PhysicalConstants.hh>
-#include <G4TransportationManager.hh>
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/GenParticle.h>
 #include <HepMC3/GenVertex.h>
@@ -18,6 +17,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/io/Logger.hh"
+#include "geocel/GeantGeoUtils.hh"
 #include "celeritas/io/EventReader.hh"
 
 namespace celeritas
@@ -87,10 +87,7 @@ class PrimaryInserter
  */
 G4VSolid* get_world_solid()
 {
-    auto* nav = G4TransportationManager::GetTransportationManager()
-                    ->GetNavigatorForTracking();
-    CELER_ASSERT(nav);
-    auto* world = nav->GetWorldVolume();
+    auto* world = geant_world_volume();
     CELER_VALIDATE(world,
                    << "detector geometry was not initialized before "
                       "HepMC3PrimaryGenerator was instantiated");

--- a/src/accel/HepMC3PrimaryGenerator.cc
+++ b/src/accel/HepMC3PrimaryGenerator.cc
@@ -8,7 +8,10 @@
 #include "HepMC3PrimaryGenerator.hh"
 
 #include <mutex>
+#include <G4LogicalVolume.hh>
 #include <G4PhysicalConstants.hh>
+#include <G4VPhysicalVolume.hh>
+#include <G4VSolid.hh>
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/GenParticle.h>
 #include <HepMC3/GenVertex.h>

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -180,7 +180,7 @@ void LocalTransporter::InitializeEvent(int id)
     CELER_EXPECT(*this);
     CELER_EXPECT(id >= 0);
 
-    event_id_ = UniqueEventId(id);
+    event_id_ = id_cast<UniqueEventId>(id);
 
     if (!(G4Threading::IsMultithreadedApplication()
           && G4MTRunManager::SeedOncePerCommunication()))

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -41,6 +41,9 @@ struct AlongStepFactoryInput;
  *   when the combination of options is enabled
  * - Track and Parent IDs will \em never be a valid value since Celeritas track
  *   counters are independent from Geant4 track counters.
+ * - Some within-step properties (material, material cuts couple, and
+ *   sensitive detector) are always updated. Post-step values for those are not
+ *   set.
  */
 struct SDSetupOptions
 {

--- a/src/accel/detail/HitManager.cc
+++ b/src/accel/detail/HitManager.cc
@@ -96,7 +96,8 @@ HitManager::HitManager(GeoParams const& geo,
  * Create local hit processor.
  *
  * Due to Geant4 multithread semantics, this \b must be done on the same CPU
- * thread on which the resulting processor used.
+ * thread on which the resulting processor used. It must be done once per
+ * thread and can be done separtely.
  */
 auto HitManager::make_local_processor(StreamId sid) -> SPProcessor
 {
@@ -104,17 +105,9 @@ auto HitManager::make_local_processor(StreamId sid) -> SPProcessor
     CELER_EXPECT(!processors_[sid.get()]);
 
     auto result = std::make_shared<HitProcessor>(
-        geant_vols_, particles_, selection_, locate_touchable_, sid);
-    {
-        static std::mutex mutex;
-        std::scoped_lock lock{mutex};
-
-        CELER_ASSERT(!processors_[sid.get()]);
-        processor_weakptrs_[sid.get()] = result;
-        processors_[sid.get()] = result.get();
-    }
-
-    CELER_ENSURE(processors_[sid.get()]);
+        geant_vols_, particles_, selection_, locate_touchable_);
+    processor_weakptrs_[sid.get()] = result;
+    processors_[sid.get()] = result.get();
     return result;
 }
 

--- a/src/accel/detail/HitManager.cc
+++ b/src/accel/detail/HitManager.cc
@@ -97,7 +97,7 @@ HitManager::HitManager(GeoParams const& geo,
  *
  * Due to Geant4 multithread semantics, this \b must be done on the same CPU
  * thread on which the resulting processor used. It must be done once per
- * thread and can be done separtely.
+ * thread and can be done separately.
  */
 auto HitManager::make_local_processor(StreamId sid) -> SPProcessor
 {

--- a/src/accel/detail/HitManager.hh
+++ b/src/accel/detail/HitManager.hh
@@ -64,7 +64,7 @@ class HitManager final : public StepInterface
                SDSetupOptions const& setup,
                StreamId::size_type num_streams);
 
-    CELER_DELETE_COPY_MOVE(HitManager);
+    CELER_DEFAULT_MOVE_DELETE_COPY(HitManager);
 
     // Default destructor
     ~HitManager();

--- a/src/accel/detail/HitManager.hh
+++ b/src/accel/detail/HitManager.hh
@@ -37,11 +37,11 @@ class HitProcessor;
  * - Finds *all* logical volumes that have SDs attached (TODO: add list of
  *   exclusions for SDs that are implemented natively on GPU)
  * - Maps those volumes to VecGeom geometry
- * - Creates a HitProcessor for each Geant4 thread
  *
- * \warning Because of low-level problems with Geant4 allocators, the hit
- * processors must be allocated and deallocated on the same thread in which
- * they're used.
+ * Because of low-level use of Geant4 allocators through the associated Geant4
+ * objects, the hit processors \em must be allocated and deallocated on the
+ * same thread in which they're used, so \c make_local_processor is deferred
+ * until after construction and called in the \c LocalTransporter constructor.
  */
 class HitManager final : public StepInterface
 {
@@ -64,11 +64,13 @@ class HitManager final : public StepInterface
                SDSetupOptions const& setup,
                StreamId::size_type num_streams);
 
-    // Create local hit processor
-    SPProcessor make_local_processor(StreamId sid);
+    CELER_DELETE_COPY_MOVE(HitManager);
 
     // Default destructor
     ~HitManager();
+
+    // Create local hit processor
+    SPProcessor make_local_processor(StreamId sid);
 
     // Selection of data required for this interface
     Filters filters() const final;

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -46,11 +46,9 @@ namespace detail
 HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
                            VecParticle const& particles,
                            StepSelection const& selection,
-                           bool locate_touchable,
-                           StreamId stream)
-    : detector_volumes_(std::move(detector_volumes)), stream_{stream}
+                           bool locate_touchable)
+    : detector_volumes_(std::move(detector_volumes))
 {
-    CELER_EXPECT(stream_);
     CELER_EXPECT(detector_volumes_ && !detector_volumes_->empty());
     CELER_VALIDATE(!locate_touchable || selection.points[StepPoint::pre].pos,
                    << "cannot set 'locate_touchable' because the pre-step "
@@ -59,9 +57,9 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
                    << "cannot set 'locate_touchable' because the pre-step "
                       "position is not being collected");
 
-    CELER_LOG_LOCAL(debug)
-        << "Setting up hit processor for " << detector_volumes_->size()
-        << " sensitive detectors on stream " << stream_.get();
+    CELER_LOG_LOCAL(debug) << "Setting up hit processor for "
+                           << detector_volumes_->size()
+                           << " sensitive detectors";
 
     // Create step and step-owned structures
     step_ = std::make_unique<G4Step>();
@@ -139,8 +137,7 @@ HitProcessor::~HitProcessor()
 {
     try
     {
-        CELER_LOG_LOCAL(debug) << "Deallocating hit processor from stream "
-                               << stream_.unchecked_get();
+        CELER_LOG_LOCAL(debug) << "Deallocating hit processor";
     }
     catch (...)
     {

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -11,10 +11,10 @@
 #include <utility>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <G4LogicalVolume.hh>
-#include <G4Navigator.hh>
 #include <G4Step.hh>
 #include <G4StepPoint.hh>
 #include <G4ThreeVector.hh>
+#include <G4TouchableHandle.hh>
 #include <G4TouchableHistory.hh>
 #include <G4Track.hh>
 #include <G4TransportationManager.hh>
@@ -94,15 +94,10 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
                      && selection.points[StepPoint::pre].dir);
 
         // Create navigator
-        G4VPhysicalVolume* world_volume
-            = G4TransportationManager::GetTransportationManager()
-                  ->GetNavigatorForTracking()
-                  ->GetWorldVolume();
-        navi_ = std::make_unique<G4Navigator>();
-        navi_->SetWorldVolume(world_volume);
-
         touch_handle_ = new G4TouchableHistory;
         step_->GetPreStepPoint()->SetTouchableHandle(touch_handle_);
+        update_touchable_
+            = std::make_unique<NaviTouchableUpdater>(touch_handle_());
     }
 
     // Create track if user requested particle types
@@ -129,6 +124,7 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
     }
 
     CELER_ENSURE(!detectors_.empty());
+    CELER_ENSURE(static_cast<bool>(update_touchable_) == locate_touchable);
 }
 
 //---------------------------------------------------------------------------//
@@ -182,8 +178,8 @@ void HitProcessor::operator()(StepStateDeviceRef const& states)
 void HitProcessor::operator()(DetectorStepOutput const& out) const
 {
     CELER_EXPECT(!out.detector.empty());
-    CELER_ASSERT(!navi_ || !out.points[StepPoint::pre].pos.empty());
-    CELER_ASSERT(!navi_ || !out.points[StepPoint::pre].dir.empty());
+    CELER_ASSERT(!update_touchable_ || !out.points[StepPoint::pre].pos.empty());
+    CELER_ASSERT(!update_touchable_ || !out.points[StepPoint::pre].dir.empty());
     CELER_ASSERT(tracks_.empty() || !out.particle.empty());
 
     ScopedProfiling profile_this{"process-hits"};
@@ -227,15 +223,14 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
         }
 #undef HP_SET
 
-        if (navi_)
+        if (update_touchable_)
         {
             G4LogicalVolume const* lv = this->detector_volume(out.detector[i]);
 
             // Update navigation state
             constexpr auto sp = StepPoint::pre;
-            NaviTouchableUpdater update_touchable{navi_.get(), touch_handle_()};
 
-            bool success = update_touchable(
+            bool success = (*update_touchable_)(
                 out.points[sp].pos[i], out.points[sp].dir[i], lv);
             if (CELER_UNLIKELY(!success))
             {

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -33,7 +33,7 @@
 #include "celeritas/user/DetectorSteps.hh"
 #include "celeritas/user/StepData.hh"
 
-#include "TouchableUpdater.hh"
+#include "NaviTouchableUpdater.hh"
 
 namespace celeritas
 {
@@ -233,7 +233,7 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
 
             // Update navigation state
             constexpr auto sp = StepPoint::pre;
-            TouchableUpdater update_touchable{navi_.get(), touch_handle_()};
+            NaviTouchableUpdater update_touchable{navi_.get(), touch_handle_()};
 
             bool success = update_touchable(
                 out.points[sp].pos[i], out.points[sp].dir[i], lv);

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -96,8 +96,7 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
         // Create navigator
         touch_handle_ = new G4TouchableHistory;
         step_->GetPreStepPoint()->SetTouchableHandle(touch_handle_);
-        update_touchable_
-            = std::make_unique<NaviTouchableUpdater>(touch_handle_());
+        update_touchable_ = std::make_unique<NaviTouchableUpdater>();
     }
 
     // Create track if user requested particle types
@@ -230,8 +229,10 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
             // Update navigation state
             constexpr auto sp = StepPoint::pre;
 
-            bool success = (*update_touchable_)(
-                out.points[sp].pos[i], out.points[sp].dir[i], lv);
+            bool success = (*update_touchable_)(out.points[sp].pos[i],
+                                                out.points[sp].dir[i],
+                                                lv,
+                                                touch_handle_());
             if (CELER_UNLIKELY(!success))
             {
                 // Inconsistent touchable: skip this energy deposition

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -200,7 +200,28 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
         }                                            \
     } while (0)
 
+        G4LogicalVolume const* lv = this->detector_volume(out.detector[i]);
+
         HP_SET(step_->SetTotalEnergyDeposit, out.energy_deposition, CLHEP::MeV);
+
+        if (update_touchable_)
+        {
+            // Update navigation state
+            constexpr auto sp = StepPoint::pre;
+
+            bool success = (*update_touchable_)(out.points[sp].pos[i],
+                                                out.points[sp].dir[i],
+                                                lv,
+                                                touch_handle_());
+            if (CELER_UNLIKELY(!success))
+            {
+                // Inconsistent touchable: skip this energy deposition
+                CELER_LOG_LOCAL(error)
+                    << "Omitting energy deposition of "
+                    << step_->GetTotalEnergyDeposit() / CLHEP::MeV << " [MeV]";
+                continue;
+            }
+        }
 
         for (auto sp : range(StepPoint::size_))
         {
@@ -222,31 +243,12 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
         }
 #undef HP_SET
 
-        if (update_touchable_)
-        {
-            G4LogicalVolume const* lv = this->detector_volume(out.detector[i]);
-
-            // Update navigation state
-            constexpr auto sp = StepPoint::pre;
-
-            bool success = (*update_touchable_)(out.points[sp].pos[i],
-                                                out.points[sp].dir[i],
-                                                lv,
-                                                touch_handle_());
-            if (CELER_UNLIKELY(!success))
-            {
-                // Inconsistent touchable: skip this energy deposition
-                CELER_LOG_LOCAL(error)
-                    << "Omitting energy deposition of "
-                    << step_->GetTotalEnergyDeposit() / CLHEP::MeV << " [MeV]";
-                continue;
-            }
-
-            // Copy attributes from logical volume
-            points[sp]->SetMaterial(lv->GetMaterial());
-            points[sp]->SetMaterialCutsCouple(lv->GetMaterialCutsCouple());
-            points[sp]->SetSensitiveDetector(lv->GetSensitiveDetector());
-        }
+        // Copy attributes from logical volume
+        points[StepPoint::pre]->SetMaterial(lv->GetMaterial());
+        points[StepPoint::pre]->SetMaterialCutsCouple(
+            lv->GetMaterialCutsCouple());
+        points[StepPoint::pre]->SetSensitiveDetector(
+            lv->GetSensitiveDetector());
 
         if (!tracks_.empty())
         {

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -96,7 +96,8 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
         // Create navigator
         touch_handle_ = new G4TouchableHistory;
         step_->GetPreStepPoint()->SetTouchableHandle(touch_handle_);
-        update_touchable_ = std::make_unique<NaviTouchableUpdater>();
+        update_touchable_
+            = std::make_unique<NaviTouchableUpdater>(detector_volumes_);
     }
 
     // Create track if user requested particle types
@@ -207,12 +208,8 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
         if (update_touchable_)
         {
             // Update navigation state
-            constexpr auto sp = StepPoint::pre;
+            bool success = (*update_touchable_)(out, i, touch_handle_());
 
-            bool success = (*update_touchable_)(out.points[sp].pos[i],
-                                                out.points[sp].dir[i],
-                                                lv,
-                                                touch_handle_());
             if (CELER_UNLIKELY(!success))
             {
                 // Inconsistent touchable: skip this energy deposition

--- a/src/accel/detail/HitProcessor.hh
+++ b/src/accel/detail/HitProcessor.hh
@@ -65,8 +65,7 @@ class HitProcessor
     HitProcessor(SPConstVecLV detector_volumes,
                  VecParticle const& particles,
                  StepSelection const& selection,
-                 bool locate_touchable,
-                 StreamId stream);
+                 bool locate_touchable);
 
     // Log on destruction
     ~HitProcessor();
@@ -105,9 +104,6 @@ class HitProcessor
 
     //! Post-step selection for copying to track
     StepPointSelection post_step_selection_;
-
-    //! Stream ID
-    StreamId stream_;
 
     void update_track(ParticleId id) const;
 };

--- a/src/accel/detail/HitProcessor.hh
+++ b/src/accel/detail/HitProcessor.hh
@@ -30,6 +30,8 @@ struct DetectorStepOutput;
 
 namespace detail
 {
+class NaviTouchableUpdater;
+
 //---------------------------------------------------------------------------//
 /*!
  * Transfer Celeritas sensitive detector hits to Geant4.
@@ -97,10 +99,10 @@ class HitProcessor
     std::unique_ptr<G4Step> step_;
     //! Tracks for each particle type
     std::vector<std::unique_ptr<G4Track>> tracks_;
-    //! Navigator for finding points
-    std::unique_ptr<G4Navigator> navi_;
     //! Geant4 reference-counted pointer to a G4VTouchable
     G4TouchableHandle touch_handle_;
+    //! Navigator for finding points
+    std::unique_ptr<NaviTouchableUpdater> update_touchable_;
 
     //! Post-step selection for copying to track
     StepPointSelection post_step_selection_;

--- a/src/accel/detail/HitProcessor.hh
+++ b/src/accel/detail/HitProcessor.hh
@@ -49,6 +49,14 @@ class NaviTouchableUpdater;
  * - Update step attributes based on hit selection for the detector (TODO:
  *   selection is global for now)
  * - Call the local detector (based on detector ID from map) with the step
+ *
+ * Compare to Geant4 updating step/track info:
+ * - \c G4VParticleChange::UpdateStepInfo
+ * - \c G4ParticleChangeForTransport::UpdateStepForAlongStep
+ * - \c G4ParticleChangeForTransport::UpdateStepForPostStep
+ * - \c G4StackManager::PrepareNewEvent
+ * - \c G4SteppingManager::ProcessSecondariesFromParticleChange
+ * - \c G4Step::UpdateTrack
  */
 class HitProcessor
 {

--- a/src/accel/detail/NaviTouchableUpdater.cc
+++ b/src/accel/detail/NaviTouchableUpdater.cc
@@ -25,13 +25,10 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with touchable and world.
+ * Construct with world.
  */
-NaviTouchableUpdater::NaviTouchableUpdater(GeantTouchableBase* touchable,
-                                           G4VPhysicalVolume const* world)
-    : touchable_{touchable}
+NaviTouchableUpdater::NaviTouchableUpdater(G4VPhysicalVolume const* world)
 {
-    CELER_EXPECT(touchable_);
     CELER_EXPECT(world);
 
     navi_ = std::make_unique<G4Navigator>();
@@ -42,10 +39,10 @@ NaviTouchableUpdater::NaviTouchableUpdater(GeantTouchableBase* touchable,
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct with touchable and automatic navigation world.
+ * Construct with automatic navigation world.
  */
-NaviTouchableUpdater::NaviTouchableUpdater(GeantTouchableBase* touchable)
-    : NaviTouchableUpdater{touchable, geant_world_volume()}
+NaviTouchableUpdater::NaviTouchableUpdater()
+    : NaviTouchableUpdater{geant_world_volume()}
 {
 }
 
@@ -64,7 +61,8 @@ NaviTouchableUpdater::~NaviTouchableUpdater() = default;
  */
 bool NaviTouchableUpdater::operator()(Real3 const& pos,
                                       Real3 const& dir,
-                                      G4LogicalVolume const* lv)
+                                      G4LogicalVolume const* lv,
+                                      GeantTouchableBase* touchable)
 {
     auto g4pos = convert_to_geant(pos, clhep_length);
     auto g4dir = convert_to_geant(dir, 1);
@@ -72,11 +70,11 @@ bool NaviTouchableUpdater::operator()(Real3 const& pos,
     // Locate pre-step point
     navi_->LocateGlobalPointAndUpdateTouchable(g4pos,
                                                g4dir,
-                                               touchable_,
+                                               touchable,
                                                /* relative_search = */ false);
 
     // Check whether physical and logical volumes are consistent
-    G4VPhysicalVolume* pv = touchable_->GetVolume(0);
+    G4VPhysicalVolume* pv = touchable->GetVolume(0);
     CELER_ASSERT(pv);
     if (pv->GetLogicalVolume() == lv)
     {
@@ -108,7 +106,7 @@ bool NaviTouchableUpdater::operator()(Real3 const& pos,
             CELER_LOG_LOCAL(warning)
                 << "Bumping navigation state by " << repr(g4step)
                 << " [mm] at " << repr(g4pos) << " [mm] along " << repr(g4dir)
-                << " from " << PrintableNavHistory{touchable_->GetHistory()}
+                << " from " << PrintableNavHistory{touchable->GetHistory()}
                 << " to try to reach " << PrintableLV{lv};
         }
 
@@ -120,25 +118,25 @@ bool NaviTouchableUpdater::operator()(Real3 const& pos,
         navi_->LocateGlobalPointAndUpdateTouchable(
             g4pos,
             g4dir,
-            touchable_,
+            touchable,
             /* relative_search = */ true);
 
         // Update volume and return whether it's correct
-        pv = touchable_->GetVolume(0);
+        pv = touchable->GetVolume(0);
         CELER_ASSERT(pv);
 
         if (g4step > g4max_quiet_step)
         {
             CELER_LOG_LOCAL(diagnostic)
                 << "...bumped to "
-                << PrintableNavHistory{touchable_->GetHistory()};
+                << PrintableNavHistory{touchable->GetHistory()};
         }
         else if (pv->GetLogicalVolume() == lv)
         {
             CELER_LOG_LOCAL(debug)
                 << "Bumped navigation state by " << repr(g4step) << " to "
                 << repr(g4pos) << " to enter "
-                << PrintableNavHistory{touchable_->GetHistory()};
+                << PrintableNavHistory{touchable->GetHistory()};
         }
 
         return pv->GetLogicalVolume() == lv;
@@ -181,7 +179,7 @@ bool NaviTouchableUpdater::operator()(Real3 const& pos,
         << "Failed to bump navigation state up to a distance of " << g4max_step
         << " [mm] at " << repr(g4pos) << " [mm] along " << repr(g4dir)
         << " to try to reach " << PrintableLV{lv} << ": found "
-        << PrintableNavHistory{touchable_->GetHistory()};
+        << PrintableNavHistory{touchable->GetHistory()};
     return false;
 }
 

--- a/src/accel/detail/NaviTouchableUpdater.cc
+++ b/src/accel/detail/NaviTouchableUpdater.cc
@@ -16,7 +16,6 @@
 #include "corecel/io/Repr.hh"
 #include "geocel/GeantGeoUtils.hh"
 #include "geocel/g4/Convert.hh"
-#include "geocel/g4/GeantGeoParams.hh"
 #include "geocel/g4/Repr.hh"
 #include "celeritas/ext/GeantUnits.hh"
 
@@ -24,6 +23,36 @@ namespace celeritas
 {
 namespace detail
 {
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with touchable and world.
+ */
+NaviTouchableUpdater::NaviTouchableUpdater(GeantTouchableBase* touchable,
+                                           G4VPhysicalVolume const* world)
+    : touchable_{touchable}
+{
+    CELER_EXPECT(touchable_);
+    CELER_EXPECT(world);
+
+    navi_ = std::make_unique<G4Navigator>();
+    navi_->SetWorldVolume(const_cast<G4VPhysicalVolume*>(world));
+
+    CELER_ENSURE(navi_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with touchable and automatic navigation world.
+ */
+NaviTouchableUpdater::NaviTouchableUpdater(GeantTouchableBase* touchable)
+    : NaviTouchableUpdater{touchable, geant_world_volume()}
+{
+}
+
+//---------------------------------------------------------------------------//
+//! Default external deleter
+NaviTouchableUpdater::~NaviTouchableUpdater() = default;
+
 //---------------------------------------------------------------------------//
 /*!
  * Try to find the given point in the given logical volume.

--- a/src/accel/detail/NaviTouchableUpdater.cc
+++ b/src/accel/detail/NaviTouchableUpdater.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file accel/detail/TouchableUpdater.cc
+//! \file accel/detail/NaviTouchableUpdater.cc
 //---------------------------------------------------------------------------//
-#include "TouchableUpdater.hh"
+#include "NaviTouchableUpdater.hh"
 
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <G4Navigator.hh>
@@ -33,9 +33,9 @@ namespace detail
  * If that's the case, try bumping forward and backward to see if we can enter
  * the correct volume.
  */
-bool TouchableUpdater::operator()(Real3 const& pos,
-                                  Real3 const& dir,
-                                  G4LogicalVolume const* lv)
+bool NaviTouchableUpdater::operator()(Real3 const& pos,
+                                      Real3 const& dir,
+                                      G4LogicalVolume const* lv)
 {
     auto g4pos = convert_to_geant(pos, clhep_length);
     auto g4dir = convert_to_geant(dir, 1);

--- a/src/accel/detail/NaviTouchableUpdater.cc
+++ b/src/accel/detail/NaviTouchableUpdater.cc
@@ -18,6 +18,7 @@
 #include "geocel/g4/Convert.hh"
 #include "geocel/g4/Repr.hh"
 #include "celeritas/ext/GeantUnits.hh"
+#include "celeritas/user/DetectorSteps.hh"
 
 namespace celeritas
 {
@@ -25,13 +26,16 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with world.
+ * Construct with world and volumes.
  */
-NaviTouchableUpdater::NaviTouchableUpdater(G4VPhysicalVolume const* world)
+NaviTouchableUpdater::NaviTouchableUpdater(SPConstVecLV detector_volumes,
+                                           G4VPhysicalVolume const* world)
+    : navi_{std::make_unique<G4Navigator>()}
+    , detector_volumes_{std::move(detector_volumes)}
 {
     CELER_EXPECT(world);
+    CELER_EXPECT(detector_volumes_);
 
-    navi_ = std::make_unique<G4Navigator>();
     navi_->SetWorldVolume(const_cast<G4VPhysicalVolume*>(world));
 
     CELER_ENSURE(navi_);
@@ -41,14 +45,46 @@ NaviTouchableUpdater::NaviTouchableUpdater(G4VPhysicalVolume const* world)
 /*!
  * Construct with automatic navigation world.
  */
-NaviTouchableUpdater::NaviTouchableUpdater()
-    : NaviTouchableUpdater{geant_world_volume()}
+NaviTouchableUpdater::NaviTouchableUpdater(SPConstVecLV detector_volumes)
+    : NaviTouchableUpdater{std::move(detector_volumes), geant_world_volume()}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with explicit world.
+ */
+NaviTouchableUpdater::NaviTouchableUpdater(G4VPhysicalVolume const* world)
+    : NaviTouchableUpdater{
+          std::make_shared<std::vector<G4LogicalVolume const*>>(), world}
 {
 }
 
 //---------------------------------------------------------------------------//
 //! Default external deleter
 NaviTouchableUpdater::~NaviTouchableUpdater() = default;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Update from a particular detector step.
+ */
+bool NaviTouchableUpdater::operator()(DetectorStepOutput const& out,
+                                      size_type i,
+                                      GeantTouchableBase* touchable)
+{
+    CELER_EXPECT(i < out.size());
+    CELER_EXPECT(!out.points[StepPoint::pre].pos.empty());
+    CELER_EXPECT(!out.points[StepPoint::pre].dir.empty());
+    CELER_EXPECT(!out.detector.empty());
+    CELER_EXPECT(detector_volumes_
+                 && out.detector[i] < detector_volumes_->size());
+
+    G4LogicalVolume const* lv
+        = (*detector_volumes_)[out.detector[i].unchecked_get()];
+
+    auto const& point = out.points[StepPoint::pre];
+    return (*this)(point.pos[i], point.dir[i], lv, touchable);
+}
 
 //---------------------------------------------------------------------------//
 /*!
@@ -64,6 +100,9 @@ bool NaviTouchableUpdater::operator()(Real3 const& pos,
                                       G4LogicalVolume const* lv,
                                       GeantTouchableBase* touchable)
 {
+    CELER_EXPECT(lv);
+    CELER_EXPECT(touchable);
+
     auto g4pos = convert_to_geant(pos, clhep_length);
     auto g4dir = convert_to_geant(dir, 1);
 

--- a/src/accel/detail/NaviTouchableUpdater.hh
+++ b/src/accel/detail/NaviTouchableUpdater.hh
@@ -7,9 +7,14 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <memory>
+
 #include "geocel/GeantGeoUtils.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/Units.hh"
+
+class G4Navigator;
+class G4VPhysicalVolume;
 
 namespace celeritas
 {
@@ -33,32 +38,24 @@ class NaviTouchableUpdater
         return 1e-3 * units::millimeter;
     }
 
-    // Construct with thread-local navigator and touchable
-    inline NaviTouchableUpdater(G4Navigator* navi,
-                                GeantTouchableBase* touchable);
+    // Construct from touchable and navigator world
+    explicit NaviTouchableUpdater(GeantTouchableBase* touchable);
+
+    // Construct from touchable and explicit world
+    NaviTouchableUpdater(GeantTouchableBase* touchable,
+                         G4VPhysicalVolume const* world);
+
+    // Default external deleter
+    ~NaviTouchableUpdater();
 
     // Try to find the given point in the given logical volume
     bool
     operator()(Real3 const& pos, Real3 const& dir, G4LogicalVolume const* lv);
 
   private:
-    G4Navigator* navi_;
+    std::unique_ptr<G4Navigator> navi_;
     GeantTouchableBase* touchable_;
 };
-
-//---------------------------------------------------------------------------//
-// INLINE DEFINITIONS
-//---------------------------------------------------------------------------//
-/*!
- * Construct with with thread-local navigator and touchable.
- */
-NaviTouchableUpdater::NaviTouchableUpdater(G4Navigator* navi,
-                                           GeantTouchableBase* touchable)
-    : navi_{navi}, touchable_{touchable}
-{
-    CELER_EXPECT(navi_);
-    CELER_EXPECT(touchable_);
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/accel/detail/NaviTouchableUpdater.hh
+++ b/src/accel/detail/NaviTouchableUpdater.hh
@@ -38,23 +38,23 @@ class NaviTouchableUpdater
         return 1e-3 * units::millimeter;
     }
 
-    // Construct from touchable and navigator world
-    explicit NaviTouchableUpdater(GeantTouchableBase* touchable);
+    // Construct from navigator world
+    NaviTouchableUpdater();
 
     // Construct from touchable and explicit world
-    NaviTouchableUpdater(GeantTouchableBase* touchable,
-                         G4VPhysicalVolume const* world);
+    explicit NaviTouchableUpdater(G4VPhysicalVolume const* world);
 
     // Default external deleter
     ~NaviTouchableUpdater();
 
     // Try to find the given point in the given logical volume
-    bool
-    operator()(Real3 const& pos, Real3 const& dir, G4LogicalVolume const* lv);
+    bool operator()(Real3 const& pos,
+                    Real3 const& dir,
+                    G4LogicalVolume const* lv,
+                    GeantTouchableBase* touchable);
 
   private:
     std::unique_ptr<G4Navigator> navi_;
-    GeantTouchableBase* touchable_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/accel/detail/NaviTouchableUpdater.hh
+++ b/src/accel/detail/NaviTouchableUpdater.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file accel/detail/TouchableUpdater.hh
+//! \file accel/detail/NaviTouchableUpdater.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -21,7 +21,7 @@ namespace detail
  *
  * This is a helper class for \c HitProcessor.
  */
-class TouchableUpdater
+class NaviTouchableUpdater
 {
   public:
     //! Maximum step to try within the current volume [len]
@@ -34,7 +34,8 @@ class TouchableUpdater
     }
 
     // Construct with thread-local navigator and touchable
-    inline TouchableUpdater(G4Navigator* navi, GeantTouchableBase* touchable);
+    inline NaviTouchableUpdater(G4Navigator* navi,
+                                GeantTouchableBase* touchable);
 
     // Try to find the given point in the given logical volume
     bool
@@ -51,8 +52,8 @@ class TouchableUpdater
 /*!
  * Construct with with thread-local navigator and touchable.
  */
-TouchableUpdater::TouchableUpdater(G4Navigator* navi,
-                                   GeantTouchableBase* touchable)
+NaviTouchableUpdater::NaviTouchableUpdater(G4Navigator* navi,
+                                           GeantTouchableBase* touchable)
     : navi_{navi}, touchable_{touchable}
 {
     CELER_EXPECT(navi_);

--- a/src/accel/detail/NaviTouchableUpdater.hh
+++ b/src/accel/detail/NaviTouchableUpdater.hh
@@ -8,16 +8,21 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "geocel/GeantGeoUtils.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/Units.hh"
 
 class G4Navigator;
+class G4LogicalVolume;
 class G4VPhysicalVolume;
 
 namespace celeritas
 {
+//---------------------------------------------------------------------------//
+struct DetectorStepOutput;
+
 namespace detail
 {
 //---------------------------------------------------------------------------//
@@ -29,6 +34,13 @@ namespace detail
 class NaviTouchableUpdater
 {
   public:
+    //!@{
+    //! \name Type aliases
+    using SPConstVecLV
+        = std::shared_ptr<std::vector<G4LogicalVolume const*> const>;
+    //!@}
+
+  public:
     //! Maximum step to try within the current volume [len]
     static constexpr double max_step() { return 1 * units::millimeter; }
 
@@ -38,14 +50,23 @@ class NaviTouchableUpdater
         return 1e-3 * units::millimeter;
     }
 
-    // Construct from navigator world
-    NaviTouchableUpdater();
+    // Construct from detector LVs
+    explicit NaviTouchableUpdater(SPConstVecLV detector_volumes);
 
-    // Construct from touchable and explicit world
+    // Construct from explicit world without detectors for unit testing
     explicit NaviTouchableUpdater(G4VPhysicalVolume const* world);
+
+    // Construct from detector LVs and explicit world
+    NaviTouchableUpdater(SPConstVecLV detector_volumes,
+                         G4VPhysicalVolume const* world);
 
     // Default external deleter
     ~NaviTouchableUpdater();
+
+    // Update from a particular detector step
+    bool operator()(DetectorStepOutput const& out,
+                    size_type step_index,
+                    GeantTouchableBase* touchable);
 
     // Try to find the given point in the given logical volume
     bool operator()(Real3 const& pos,
@@ -55,6 +76,7 @@ class NaviTouchableUpdater
 
   private:
     std::unique_ptr<G4Navigator> navi_;
+    SPConstVecLV detector_volumes_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -1105,11 +1105,7 @@ ImportMuPairProductionTable import_mupp_table(PDGNumber pdg)
  */
 G4VPhysicalVolume const* GeantImporter::get_world_volume()
 {
-    auto* man = G4TransportationManager::GetTransportationManager();
-    CELER_ASSERT(man);
-    auto* nav = man->GetNavigatorForTracking();
-    CELER_ASSERT(nav);
-    auto* world = nav->GetWorldVolume();
+    auto* world = celeritas::geant_world_volume();
     CELER_VALIDATE(world,
                    << "no world volume has been defined in the navigator");
     return world;

--- a/src/geocel/GeantGeoUtils.cc
+++ b/src/geocel/GeantGeoUtils.cc
@@ -26,6 +26,7 @@
 #include <G4SolidStore.hh>
 #include <G4Threading.hh>
 #include <G4TouchableHistory.hh>
+#include <G4TransportationManager.hh>
 #include <G4VPhysicalVolume.hh>
 #include <G4Version.hh>
 #include <G4ios.hh>
@@ -37,6 +38,7 @@
 #include "corecel/io/ScopedStreamRedirect.hh"
 #include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/sys/ScopedMem.hh"
+#include "orange/g4org/Converter.hh"
 
 #include "ScopedGeantExceptionHandler.hh"
 #include "ScopedGeantLogger.hh"
@@ -48,7 +50,7 @@ static_assert(G4VERSION_NUMBER
                          + 10 * ((CELERITAS_GEANT4_VERSION / 0x100) % 0x100)
                          + (CELERITAS_GEANT4_VERSION % 0x100),
               "CMake-reported Geant4 version does not match installed "
-              "<G4Version.hh>: compare to 'celeritas_sys_config.h'");
+              "<G4Version.hh>: compare to 'corecel/Config.hh'");
 
 namespace celeritas
 {
@@ -285,6 +287,21 @@ Span<G4LogicalVolume*> geant_logical_volumes()
         ++start;
     }
     return {start, stop};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the world volume for the primary geometry.
+ *
+ * \return World volume if geometry has been initialized, nullptr otherwise.
+ */
+G4VPhysicalVolume const* geant_world_volume()
+{
+    auto* man = G4TransportationManager::GetTransportationManager();
+    CELER_ASSERT(man);
+    auto* nav = man->GetNavigatorForTracking();
+    CELER_ASSERT(nav);
+    return nav->GetWorldVolume();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/GeantGeoUtils.hh
+++ b/src/geocel/GeantGeoUtils.hh
@@ -82,6 +82,10 @@ void reset_geant_geometry();
 Span<G4LogicalVolume*> geant_logical_volumes();
 
 //---------------------------------------------------------------------------//
+// Get the world volume if the geometry has been set up
+G4VPhysicalVolume const* geant_world_volume();
+
+//---------------------------------------------------------------------------//
 // Find Geant4 logical volumes corresponding to a list of names
 std::unordered_set<G4LogicalVolume const*>
     find_geant_volumes(std::unordered_set<std::string>);

--- a/src/geocel/g4/GeantGeoParams.cc
+++ b/src/geocel/g4/GeantGeoParams.cc
@@ -167,13 +167,7 @@ GeantGeoParams::GeantGeoParams(G4VPhysicalVolume const* world)
     ScopedMem record_mem("GeantGeoParams.construct");
 
     // Verify consistency of the world volume
-    G4VPhysicalVolume const* nav_world = [] {
-        auto* man = G4TransportationManager::GetTransportationManager();
-        CELER_ASSERT(man);
-        auto* nav = man->GetNavigatorForTracking();
-        CELER_ENSURE(nav);
-        return nav->GetWorldVolume();
-    }();
+    G4VPhysicalVolume const* nav_world = geant_world_volume();
     if (world != nav_world)
     {
         auto msg = CELER_LOG(warning);

--- a/test/accel/detail/HitProcessor.test.cc
+++ b/test/accel/detail/HitProcessor.test.cc
@@ -112,8 +112,7 @@ auto SimpleCmsTest::make_hit_processor() -> HitProcessor
     return HitProcessor{this->make_detector_volumes(),
                         this->make_particles(),
                         selection_,
-                        locate_touchable_,
-                        StreamId{0}};
+                        locate_touchable_};
 }
 
 auto SimpleCmsTest::get_hits(std::string const& name) const

--- a/test/accel/detail/TouchableUpdater.test.cc
+++ b/test/accel/detail/TouchableUpdater.test.cc
@@ -70,8 +70,10 @@ class TouchableUpdaterTest : public ::celeritas::test::GeantGeoTestBase
     TouchableUpdater make_touchable_updater()
     {
         auto const& geo = *this->geometry();
-        return TouchableUpdater{touch_handle_(), geo.world()};
+        return TouchableUpdater{geo.world()};
     }
+
+    G4VTouchable* touchable_history() { return touch_handle_(); }
 
   private:
     G4TouchableHandle touch_handle_;
@@ -81,7 +83,10 @@ TEST_F(TouchableUpdaterTest, correct)
 {
     TouchableUpdater update = this->make_touchable_updater();
     auto update_cm = [&](Real3 const& pos_cm, std ::string lv_name) {
-        return update(from_cm(pos_cm), Real3{1, 0, 0}, this->find_lv(lv_name));
+        return update(from_cm(pos_cm),
+                      Real3{1, 0, 0},
+                      this->find_lv(lv_name),
+                      this->touchable_history());
     };
 
     EXPECT_TRUE(update_cm({15, 0, 0}, "vacuum_tube"));
@@ -95,15 +100,16 @@ TEST_F(TouchableUpdaterTest, just_inside)
     real_type const eps = 0.5 * TouchableUpdater::max_quiet_step();
     auto const* tracker_lv = this->find_lv("si_tracker");
     auto const* calo_lv = this->find_lv("em_calorimeter");
+    auto* th = this->touchable_history();
 
     ScopedLogStorer scoped_log_{&celeritas::self_logger(),
                                 LogLevel::diagnostic};
 
-    EXPECT_TRUE(update({from_cm(30) + eps, 0, 0}, {1, 0, 0}, tracker_lv));
-    EXPECT_TRUE(update({from_cm(125) - eps, 0, 0}, {1, 0, 0}, tracker_lv));
+    EXPECT_TRUE(update({from_cm(30) + eps, 0, 0}, {1, 0, 0}, tracker_lv, th));
+    EXPECT_TRUE(update({from_cm(125) - eps, 0, 0}, {1, 0, 0}, tracker_lv, th));
 
-    EXPECT_TRUE(update({from_cm(125) + eps, 0, 0}, {-1, 0, 0}, calo_lv));
-    EXPECT_TRUE(update({from_cm(175) - eps, 0, 0}, {-1, 0, 0}, calo_lv));
+    EXPECT_TRUE(update({from_cm(125) + eps, 0, 0}, {-1, 0, 0}, calo_lv, th));
+    EXPECT_TRUE(update({from_cm(175) - eps, 0, 0}, {-1, 0, 0}, calo_lv, th));
 
     EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
 }
@@ -111,15 +117,20 @@ TEST_F(TouchableUpdaterTest, just_inside)
 TEST_F(TouchableUpdaterTest, coincident)
 {
     TouchableUpdater update = this->make_touchable_updater();
+    auto* th = this->touchable_history();
+    auto update_x = [&](real_type xpos, real_type xdir, char const* name) {
+        return update({xpos, 0, 0}, {xdir, 0, 0}, this->find_lv(name), th);
+    };
+
     ScopedLogStorer scoped_log_{&celeritas::self_logger(),
                                 LogLevel::diagnostic};
 
     // Coincident point should work in either volume, in or out
     real_type const r = from_cm(125);
-    for (char const* lv : {"si_tracker", "em_calorimeter"})
+    for (char const* lvname : {"si_tracker", "em_calorimeter"})
     {
-        EXPECT_TRUE(update({r, 0, 0}, {1, 0, 0}, this->find_lv(lv)));
-        EXPECT_TRUE(update({r, 0, 0}, {-1, 0, 0}, this->find_lv(lv)));
+        EXPECT_TRUE(update_x(r, 1, lvname));
+        EXPECT_TRUE(update_x(r, -1, lvname));
     }
 
     EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
@@ -135,8 +146,10 @@ TEST_F(TouchableUpdaterTest, coincident_tangent)
     // TODO: we can't seem to test the volume on the other side of an exact
     // coincident surface on a tangent
     real_type const r = from_cm(125);
-    EXPECT_FALSE(update({r, 0, 0}, {0, 1, 0}, this->find_lv("si_tracker")));
-    EXPECT_TRUE(update({r, 0, 0}, {0, 1, 0}, this->find_lv("em_calorimeter")));
+    auto* th = this->touchable_history();
+    EXPECT_FALSE(update({r, 0, 0}, {0, 1, 0}, this->find_lv("si_tracker"), th));
+    EXPECT_TRUE(
+        update({r, 0, 0}, {0, 1, 0}, this->find_lv("em_calorimeter"), th));
 
     static char const* const expected_log_messages[] = {
         "Failed to bump navigation state up to a distance of 1 [mm] at {1250, "
@@ -152,16 +165,18 @@ TEST_F(TouchableUpdaterTest, just_outside_nowarn)
     TouchableUpdater update = this->make_touchable_updater();
     real_type const eps = 0.1 * TouchableUpdater::max_quiet_step();
     auto const* tracker_lv = this->find_lv("si_tracker");
+    auto* th = this->touchable_history();
+    auto update_x = [&](real_type xpos, real_type xdir) {
+        return update({xpos, 0, 0}, {xdir, 0, 0}, tracker_lv, th);
+    };
 
     ScopedLogStorer scoped_log_{&celeritas::self_logger(),
                                 LogLevel::diagnostic};
 
     for (real_type xdir : {1.0, -1.0})
     {
-        EXPECT_TRUE(
-            update({from_cm(30) - eps, 0, 0}, {xdir, 0, 0}, tracker_lv));
-        EXPECT_TRUE(
-            update({from_cm(125) + 2 * eps, 0, 0}, {-xdir, 0, 0}, tracker_lv));
+        EXPECT_TRUE(update_x(from_cm(30) - eps, xdir));
+        EXPECT_TRUE(update_x(from_cm(125) + 2 * eps, -xdir));
     }
 
     EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
@@ -172,16 +187,18 @@ TEST_F(TouchableUpdaterTest, just_outside_warn)
     TouchableUpdater update = this->make_touchable_updater();
     real_type const eps = 0.1 * TouchableUpdater::max_step();
     auto const* tracker_lv = this->find_lv("si_tracker");
+    auto* th = this->touchable_history();
+    auto update_x = [&](real_type xpos, real_type xdir) {
+        return update({xpos, 0, 0}, {xdir, 0, 0}, tracker_lv, th);
+    };
 
     ScopedLogStorer scoped_log_{&celeritas::self_logger(),
                                 LogLevel::diagnostic};
 
     for (real_type xdir : {1.0, -1.0})
     {
-        EXPECT_TRUE(
-            update({from_cm(30) - eps, 0, 0}, {xdir, 0, 0}, tracker_lv));
-        EXPECT_TRUE(
-            update({from_cm(125) + eps, 0, 0}, {-xdir, 0, 0}, tracker_lv));
+        EXPECT_TRUE(update_x(from_cm(30) - eps, xdir));
+        EXPECT_TRUE(update_x(from_cm(125) + eps, -xdir));
     }
 
     static char const* const expected_log_messages[]
@@ -221,31 +238,26 @@ TEST_F(TouchableUpdaterTest, too_far)
     TouchableUpdater update = this->make_touchable_updater();
     real_type const eps = 10 * TouchableUpdater::max_step();
     auto const* tracker_lv = this->find_lv("si_tracker");
+    auto* th = this->touchable_history();
+    auto update_x = [&](real_type xpos, real_type xdir) {
+        return update({xpos, 0, 0}, {xdir, 0, 0}, tracker_lv, th);
+    };
 
     ScopedLogStorer scoped_log_{&celeritas::self_logger(),
                                 LogLevel::diagnostic};
 
     for (real_type xdir : {1.0, -1.0})
     {
-        EXPECT_FALSE(
-            update({from_cm(30) - eps, 0, 0}, {xdir, 0, 0}, tracker_lv));
-        EXPECT_FALSE(
-            update({from_cm(125) + eps, 0, 0}, {-xdir, 0, 0}, tracker_lv));
+        EXPECT_FALSE(update_x(from_cm(30) - eps, xdir));
+        EXPECT_FALSE(update_x(from_cm(125) + eps, -xdir));
     }
 
     static char const* const expected_log_messages[] = {
-        "Failed to bump navigation state up to a distance of 1 [mm] at {290, "
-        "0, 0} [mm] along {1, 0, 0} to try to reach \"si_tracker\"@0x0 "
-        "(ID=1): found {{pv='vacuum_tube_pv', lv=0='vacuum_tube'}}",
-        "Failed to bump navigation state up to a distance of 1 [mm] at {1260, "
-        "0, 0} [mm] along {-1, 0, 0} to try to reach \"si_tracker\"@0x0 "
-        "(ID=1): found {{pv='em_calorimeter_pv', lv=2='em_calorimeter'}}",
-        "Failed to bump navigation state up to a distance of 1 [mm] at {290, "
-        "0, 0} [mm] along {-1, 0, 0} to try to reach \"si_tracker\"@0x0 "
-        "(ID=1): found {{pv='vacuum_tube_pv', lv=0='vacuum_tube'}}",
-        "Failed to bump navigation state up to a distance of 1 [mm] at {1260, "
-        "0, 0} [mm] along {1, 0, 0} to try to reach \"si_tracker\"@0x0 "
-        "(ID=1): found {{pv='em_calorimeter_pv', lv=2='em_calorimeter'}}"};
+        R"(Failed to bump navigation state up to a distance of 1 [mm] at {290, 0, 0} [mm] along {1, 0, 0} to try to reach "si_tracker"@0x0 (ID=1): found {{pv='vacuum_tube_pv', lv=0='vacuum_tube'}})",
+        R"(Failed to bump navigation state up to a distance of 1 [mm] at {1260, 0, 0} [mm] along {-1, 0, 0} to try to reach "si_tracker"@0x0 (ID=1): found {{pv='em_calorimeter_pv', lv=2='em_calorimeter'}})",
+        R"(Failed to bump navigation state up to a distance of 1 [mm] at {290, 0, 0} [mm] along {-1, 0, 0} to try to reach "si_tracker"@0x0 (ID=1): found {{pv='vacuum_tube_pv', lv=0='vacuum_tube'}})",
+        R"(Failed to bump navigation state up to a distance of 1 [mm] at {1260, 0, 0} [mm] along {1, 0, 0} to try to reach "si_tracker"@0x0 (ID=1): found {{pv='em_calorimeter_pv', lv=2='em_calorimeter'}})",
+    };
     EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
     static char const* const expected_log_levels[]
         = {"warning", "warning", "warning", "warning"};
@@ -257,6 +269,7 @@ TEST_F(TouchableUpdaterTest, regression)
     using Real2 = Array<real_type, 2>;
 
     TouchableUpdater update = this->make_touchable_updater();
+    auto* th = this->touchable_history();
     ScopedLogStorer scoped_log_{&celeritas::self_logger(),
                                 LogLevel::diagnostic};
 
@@ -292,8 +305,8 @@ TEST_F(TouchableUpdaterTest, regression)
         radius.push_back(std::hypot(v.pos[0], v.pos[1]));
         ndot.push_back(dot_product(make_unit_vector(Real2{v.pos[0], v.pos[1]}),
                                    Real2{v.dir[0], v.dir[1]}));
-        EXPECT_TRUE(
-            update(v.pos * units::millimeter, v.dir, this->find_lv(v.volume)))
+        EXPECT_TRUE(update(
+            v.pos * units::millimeter, v.dir, this->find_lv(v.volume), th))
             << "from " << repr(v.pos) << " along " << repr(v.dir);
     }
 

--- a/test/accel/detail/TouchableUpdater.test.cc
+++ b/test/accel/detail/TouchableUpdater.test.cc
@@ -5,8 +5,6 @@
 //---------------------------------------------------------------------------//
 //! \file accel/detail/TouchableUpdater.test.cc
 //---------------------------------------------------------------------------//
-#include "accel/detail/TouchableUpdater.hh"
-
 #include <cmath>
 #include <G4Navigator.hh>
 #include <G4TouchableHistory.hh>
@@ -19,6 +17,7 @@
 #include "geocel/g4/GeantGeoParams.hh"
 #include "geocel/g4/GeantGeoTestBase.hh"
 #include "celeritas/Units.hh"
+#include "accel/detail/NaviTouchableUpdater.hh"
 
 #include "celeritas_test.hh"
 
@@ -49,6 +48,8 @@ namespace test
 class TouchableUpdaterTest : public ::celeritas::test::GeantGeoTestBase
 {
   protected:
+    using TouchableUpdater = NaviTouchableUpdater;
+
     void SetUp() override
     {
         auto const& geo = *this->geometry();

--- a/test/accel/detail/TouchableUpdater.test.cc
+++ b/test/accel/detail/TouchableUpdater.test.cc
@@ -50,12 +50,7 @@ class TouchableUpdaterTest : public ::celeritas::test::GeantGeoTestBase
   protected:
     using TouchableUpdater = NaviTouchableUpdater;
 
-    void SetUp() override
-    {
-        auto const& geo = *this->geometry();
-        navi_.SetWorldVolume(const_cast<G4VPhysicalVolume*>(geo.world()));
-        touch_handle_ = new G4TouchableHistory;
-    }
+    void SetUp() override { touch_handle_ = new G4TouchableHistory; }
 
     SPConstGeo build_geometry() final
     {
@@ -74,11 +69,11 @@ class TouchableUpdaterTest : public ::celeritas::test::GeantGeoTestBase
 
     TouchableUpdater make_touchable_updater()
     {
-        return TouchableUpdater{&navi_, touch_handle_()};
+        auto const& geo = *this->geometry();
+        return TouchableUpdater{touch_handle_(), geo.world()};
     }
 
   private:
-    G4Navigator navi_;
     G4TouchableHandle touch_handle_;
 };
 


### PR DESCRIPTION
This is the penultimate PR for #1248. It refactors the touchable updater into a generic interface that works for both ORANGE and VecGeom. A new updater (the next pull request) will use the volume instance ID to reconstruct the touchable, rather than a navigator.

This also unconditionally enables updating of some pre-step LV properties which should be independent from the touchable state.