### PR TITLE
Fix build with latest Geant4 develop

### DIFF
--- a/src/geocel/GeantGeoUtils.cc
+++ b/src/geocel/GeantGeoUtils.cc
@@ -257,7 +257,7 @@ void reset_geant_geometry()
         G4ReflectionFactory::Instance()->Clean();
 #endif
         free_and_clear(G4Material::GetMaterialTable());
-        free_and_clear(G4Element::GetElementTable());
+        free_and_clear(const_cast<std::vector<G4Element*>*>(G4Element::GetElementTable()));
         free_and_clear(const_cast<std::vector<G4Isotope*>*>(
             G4Isotope::GetIsotopeTable()));
         msg = scoped_log.str();


### PR DESCRIPTION
`G4Element::GetElementTable` now returns a `const` pointer.