### PR TITLE
Add a cheat-sheet to run app outside ctest

### DIFF
--- a/app/celer-g4/test-harness.py
+++ b/app/celer-g4/test-harness.py
@@ -116,6 +116,7 @@ with open(f"{problem_name}.inp.json", "w") as f:
     json.dump(inp, f, indent=1)
 
 print("Running", exe, inp_file, file=stderr)
+print(f"To run directly use: {exe} {problem_name}.inp.json", file=stderr)
 result = subprocess.run([exe, inp_file], **kwargs)
 
 if use_celeritas:


### PR DESCRIPTION
To make it easier to rerun outside of `ctest` the app runs using `test-harness.py` 