### PR TITLE
Replace "volid" with "vol_id" throughout ORANGE

### DIFF
--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -152,12 +152,12 @@ struct OrientedBoundingZoneRecord
 
     // Transformation from the OBZ coordinate system to the unit coordinate
     // system
-    TransformId transform_id;
+    TransformId trans_id;
 
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return offset_ids[0] && offset_ids[1] && transform_id;
+        return offset_ids[0] && offset_ids[1] && trans_id;
     }
 };
 
@@ -337,11 +337,11 @@ struct BIHTreeData
 /*!
  * Persistent data used by ORANGE implementation.
  *
- * Most data will be accessed through the individual units, which reference data
- * in the "storage" below. The type and index for a universe ID will determine
- * the class type and data of the Tracker to instantiate. If *only* simple
- * units are present, then the \c simple_units data structure will just be
- * equal to a range (with the total number of universes present). Use
+ * Most data will be accessed through the individual units, which reference
+ * data in the "storage" below. The type and index for a universe ID will
+ * determine the class type and data of the Tracker to instantiate. If *only*
+ * simple units are present, then the \c simple_units data structure will just
+ * be equal to a range (with the total number of universes present). Use
  * `universe_types` to switch on the type of universe; then `universe_indices`
  * to index into `simple_units` or `rect_arrays` or ...
  */

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -337,7 +337,7 @@ struct BIHTreeData
 /*!
  * Persistent data used by ORANGE implementation.
  *
- * Most data will be accessed through the invidual units, which reference data
+ * Most data will be accessed through the individual units, which reference data
  * in the "storage" below. The type and index for a universe ID will determine
  * the class type and data of the Tracker to instantiate. If *only* simple
  * units are present, then the \c simple_units data structure will just be

--- a/src/orange/OrangeInput.hh
+++ b/src/orange/OrangeInput.hh
@@ -33,10 +33,10 @@ struct OrientedBoundingZoneInput
     //! Outer bounding box
     BBox outer;
     //! Local to global transformation
-    TransformId transform_id;
+    TransformId trans_id;
 
     //! Whether the obz definition is valid
-    explicit operator bool() const { return inner && outer && transform_id; }
+    explicit operator bool() const { return inner && outer && trans_id; }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeInputIO.json.cc
+++ b/src/orange/OrangeInputIO.json.cc
@@ -106,10 +106,10 @@ void from_json(nlohmann::json const& j, VolumeInput& value)
     std::vector<LocalSurfaceId::size_type> temp_faces;
     j.at("faces").get_to(temp_faces);
     value.faces.reserve(temp_faces.size());
-    for (auto surfid : temp_faces)
+    for (auto surf_id : temp_faces)
     {
-        CELER_ASSERT(surfid != LocalSurfaceId{}.unchecked_get());
-        value.faces.emplace_back(surfid);
+        CELER_ASSERT(surf_id != LocalSurfaceId{}.unchecked_get());
+        value.faces.emplace_back(surf_id);
     }
 
     // Read scalars, including optional flags
@@ -180,9 +180,9 @@ void to_json(nlohmann::json& j, VolumeInput const& value)
     // Convert faces from OpaqueId
     std::vector<LocalSurfaceId::size_type> temp_faces;
     temp_faces.reserve(value.faces.size());
-    for (auto surfid : value.faces)
+    for (auto surf_id : value.faces)
     {
-        temp_faces.emplace_back(surfid.unchecked_get());
+        temp_faces.emplace_back(surf_id.unchecked_get());
     }
     j["faces"] = std::move(temp_faces);
 

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -284,14 +284,14 @@ OrangeTrackView::operator=(Initializer_t const& init)
     };
 
     // Recurse into daughter universes starting with the outermost universe
-    UniverseId uid = top_universe_id();
+    UniverseId univ_id = top_universe_id();
     DaughterId daughter_id;
     LevelId level{0};
     do
     {
         TrackerVisitor visit_tracker{params_};
         auto tinit = visit_tracker(
-            [&local](auto&& t) { return t.initialize(local); }, uid);
+            [&local](auto&& t) { return t.initialize(local); }, univ_id);
 
         if (!tinit.volume || tinit.surface)
         {
@@ -307,7 +307,7 @@ OrangeTrackView::operator=(Initializer_t const& init)
                 msg << "started on a surface ("
                     << tinit.surface.id().unchecked_get() << ")";
             }
-            msg << " in universe " << uid.unchecked_get()
+            msg << " in universe " << univ_id.unchecked_get()
                 << " at local position " << repr(local.pos);
 #endif
             // Mark as failed and place in local "exterior" to end the search
@@ -320,10 +320,10 @@ OrangeTrackView::operator=(Initializer_t const& init)
         lsa.vol() = tinit.volume;
         lsa.pos() = local.pos;
         lsa.dir() = local.dir;
-        lsa.universe() = uid;
+        lsa.universe() = univ_id;
 
         daughter_id = visit_tracker(
-            [&tinit](auto&& t) { return t.daughter(tinit.volume); }, uid);
+            [&tinit](auto&& t) { return t.daughter(tinit.volume); }, univ_id);
 
         if (daughter_id)
         {
@@ -331,7 +331,7 @@ OrangeTrackView::operator=(Initializer_t const& init)
             // Apply "transform down" based on stored transform
             apply_transform(transform_down_local, daughter.transform_id);
             // Update universe and increase level depth
-            uid = daughter.universe_id;
+            univ_id = daughter.universe_id;
             ++level;
         }
 
@@ -964,15 +964,15 @@ OrangeTrackView::find_next_step_impl(detail::Intersection isect)
     LevelId min_level{0};
 
     // Find the nearest intersection from level 0 to current level
-    // inclusive, prefering the shallowest level (i.e., lowest uid)
+    // inclusive, prefering the shallowest level (i.e., lowest univ_id)
     for (auto levelid : range(LevelId{1}, this->level() + 1))
     {
-        auto uid = this->make_lsa(levelid).universe();
+        auto univ_id = this->make_lsa(levelid).universe();
         auto local_isect = visit_tracker(
             [local_state = this->make_local_state(levelid), &isect](auto&& t) {
                 return t.intersect(local_state, isect.distance);
             },
-            uid);
+            univ_id);
 
         if (local_isect.distance < isect.distance)
         {
@@ -1156,8 +1156,8 @@ CELER_FORCEINLINE_FUNCTION auto OrangeTrackView::make_lsa() const -> LSA
 /*!
  * Make a LevelStateAccessor for the current thread and a given level.
  */
-CELER_FORCEINLINE_FUNCTION auto
-OrangeTrackView::make_lsa(LevelId level) const -> LSA
+CELER_FORCEINLINE_FUNCTION auto OrangeTrackView::make_lsa(LevelId level) const
+    -> LSA
 {
     return LSA(&states_, track_slot_, level);
 }

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -329,7 +329,7 @@ OrangeTrackView::operator=(Initializer_t const& init)
         {
             auto const& daughter = params_.daughters[daughter_id];
             // Apply "transform down" based on stored transform
-            apply_transform(transform_down_local, daughter.transform_id);
+            apply_transform(transform_down_local, daughter.trans_id);
             // Update universe and increase level depth
             univ_id = daughter.universe_id;
             ++level;
@@ -734,7 +734,7 @@ CELER_FUNCTION void OrangeTrackView::cross_boundary()
                 local.pos = t.transform_down(local.pos);
                 local.dir = t.rotate_down(local.dir);
             };
-            apply_transform(transform_down_local, daughter.transform_id);
+            apply_transform(transform_down_local, daughter.trans_id);
             universe = daughter.universe_id;
         }
 
@@ -1182,7 +1182,7 @@ CELER_FUNCTION DaughterId OrangeTrackView::get_daughter(LSA const& lsa)
 CELER_FUNCTION TransformId OrangeTrackView::get_transform(DaughterId daughter_id)
 {
     CELER_EXPECT(daughter_id);
-    return params_.daughters[daughter_id].transform_id;
+    return params_.daughters[daughter_id].trans_id;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -279,7 +279,7 @@ enum class ZOrder : size_type
 struct Daughter
 {
     UniverseId universe_id;
-    TransformId transform_id;
+    TransformId trans_id;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/BIHBuilder.cc
+++ b/src/orange/detail/BIHBuilder.cc
@@ -46,7 +46,7 @@ BIHTree BIHBuilder::operator()(VecBBox&& bboxes)
 
     // Separate infinite bounding boxes from finite
     VecIndices indices;
-    VecIndices inf_volids;
+    VecIndices inf_vol_ids;
     for (auto i : range(temp_.bboxes.size()))
     {
         LocalVolumeId id(i);
@@ -63,7 +63,7 @@ BIHTree BIHBuilder::operator()(VecBBox&& bboxes)
              * \todo make an exception for "EXTERIOR" volume and remove the
              * "infinite volume" exceptions?
              */
-            inf_volids.push_back(id);
+            inf_vol_ids.push_back(id);
         }
         else
         {
@@ -79,8 +79,8 @@ BIHTree BIHBuilder::operator()(VecBBox&& bboxes)
     tree.bboxes = ItemMap<LocalVolumeId, FastBBoxId>(
         bboxes_.insert_back(temp_.bboxes.begin(), temp_.bboxes.end()));
 
-    tree.inf_volids
-        = local_volume_ids_.insert_back(inf_volids.begin(), inf_volids.end());
+    tree.inf_vol_ids = local_volume_ids_.insert_back(inf_vol_ids.begin(),
+                                                     inf_vol_ids.end());
 
     if (!indices.empty())
     {

--- a/src/orange/detail/BIHData.hh
+++ b/src/orange/detail/BIHData.hh
@@ -95,7 +95,7 @@ struct BIHTree
     ItemRange<BIHLeafNode> leaf_nodes;
 
     //! Local volumes that have infinite bounding boxes
-    ItemRange<LocalVolumeId> inf_volids;
+    ItemRange<LocalVolumeId> inf_vol_ids;
 
     explicit CELER_FUNCTION operator bool() const
     {

--- a/src/orange/detail/BIHEnclosingVolFinder.hh
+++ b/src/orange/detail/BIHEnclosingVolFinder.hh
@@ -208,7 +208,7 @@ template<class F>
 CELER_FUNCTION LocalVolumeId BIHEnclosingVolFinder::visit_leaf(
     BIHLeafNode const& leaf_node, Real3 const& pos, F&& is_inside) const
 {
-    for (auto id : view_.leaf_volids(leaf_node))
+    for (auto id : view_.leaf_vol_ids(leaf_node))
     {
         if (this->visit_bbox(id, pos) && is_inside(id))
         {
@@ -226,7 +226,7 @@ template<class F>
 CELER_FUNCTION LocalVolumeId
 BIHEnclosingVolFinder::visit_inf_vols(F&& is_inside) const
 {
-    for (auto id : view_.inf_volids())
+    for (auto id : view_.inf_vol_ids())
     {
         if (is_inside(id))
         {

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -241,7 +241,7 @@ BIHIntersectingVolFinder::visit_leaf(BIHLeafNode const& leaf_node,
                                      Intersection min_intersection,
                                      F&& visit_vol) const -> Intersection
 {
-    for (auto id : view_.leaf_volids(leaf_node))
+    for (auto id : view_.leaf_vol_ids(leaf_node))
     {
         auto const& bbox = view_.bbox(id);
 
@@ -268,7 +268,7 @@ BIHIntersectingVolFinder::visit_inf_vols(Intersection min_intersection,
                                          BIHIntersectingVolFinder::Ray ray,
                                          F&& visit_vol) const -> Intersection
 {
-    for (auto id : view_.inf_volids())
+    for (auto id : view_.inf_vol_ids())
     {
         auto intersection = visit_vol(id, ray, min_intersection.distance);
         if (intersection && intersection.distance < min_intersection.distance)

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -41,12 +41,12 @@ class BIHView
     // Get the bbox for a given vol_id.
     inline CELER_FUNCTION FastBBox const& bbox(LocalVolumeId vol_id) const;
 
-    // Get the volids on a given leaf node
+    // Get the vol_ids on a given leaf node
     inline CELER_FUNCTION Span<LocalVolumeId const>
-    leaf_volids(BIHLeafNode const& leaf) const;
+    leaf_vol_ids(BIHLeafNode const& leaf) const;
 
-    // Get the inf_volids
-    inline CELER_FUNCTION Span<LocalVolumeId const> inf_volids() const;
+    // Get the inf_vol_ids
+    inline CELER_FUNCTION Span<LocalVolumeId const> inf_vol_ids() const;
 
   private:
     //// DATA ////
@@ -112,21 +112,21 @@ CELER_FUNCTION FastBBox const& BIHView::bbox(LocalVolumeId vol_id) const
 
 //---------------------------------------------------------------------------//
 /*!
- *  Get the volids on a given leaf node.
+ *  Get the vol_ids on a given leaf node.
  */
 CELER_FUNCTION Span<LocalVolumeId const>
-BIHView::leaf_volids(BIHLeafNode const& leaf) const
+BIHView::leaf_vol_ids(BIHLeafNode const& leaf) const
 {
     return storage_.local_volume_ids[leaf.vol_ids];
 }
 
 //---------------------------------------------------------------------------//
 /*!
- *  Get the inf_volids.
+ *  Get the inf_vol_ids.
  */
-CELER_FUNCTION Span<LocalVolumeId const> BIHView::inf_volids() const
+CELER_FUNCTION Span<LocalVolumeId const> BIHView::inf_vol_ids() const
 {
-    return storage_.local_volume_ids[tree_.inf_volids];
+    return storage_.local_volume_ids[tree_.inf_vol_ids];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/DepthCalculator.cc
+++ b/src/orange/detail/DepthCalculator.cc
@@ -67,15 +67,15 @@ size_type DepthCalculator::operator()(RectArrayInput const& u)
 /*!
  * Check cache or calculate.
  */
-size_type DepthCalculator::operator()(UniverseId uid)
+size_type DepthCalculator::operator()(UniverseId univ_id)
 {
-    CELER_EXPECT(uid < num_univ_);
+    CELER_EXPECT(univ_id < num_univ_);
     // Check for cached value
-    auto&& [iter, inserted] = depths_.insert({uid, {}});
+    auto&& [iter, inserted] = depths_.insert({univ_id, {}});
     if (inserted)
     {
         // Visit and save value
-        iter->second = visit_univ_(*this, uid.unchecked_get());
+        iter->second = visit_univ_(*this, univ_id.unchecked_get());
     }
 
     // Return cached value

--- a/src/orange/detail/DepthCalculator.hh
+++ b/src/orange/detail/DepthCalculator.hh
@@ -48,7 +48,7 @@ class DepthCalculator
     std::unordered_map<UniverseId, size_type> depths_;
 
     // Check cache or calculate
-    size_type operator()(UniverseId uid);
+    size_type operator()(UniverseId univ_id);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/OrientedBoundingZone.hh
+++ b/src/orange/detail/OrientedBoundingZone.hh
@@ -31,7 +31,7 @@ namespace detail
  * coordinate system.
  *
  * Consequently, points in the unit's coordinate system must be first
- * transformed by \c transform_id into the OBZ coordinate system (resulting in
+ * transformed by \c trans_id into the OBZ coordinate system (resulting in
  * "trans_pos"), then offset, i.e. translated, by \c inner_offset_id or
  * \c outer_offset_id into the inner or outer bbox coordinate system (resulting
  * in "offset_pos"). It is noted that these offset positions are always
@@ -266,7 +266,7 @@ CELER_FUNCTION Real3 OrientedBoundingZone::translate(Real3 const& pos)
     TransformVisitor apply_transform(*sp_.transforms, *sp_.reals);
     auto transform_down = [&pos](auto&& t) { return t.transform_down(pos); };
 
-    return apply_transform(transform_down, obz_record_.transform_id);
+    return apply_transform(transform_down, obz_record_.trans_id);
 }
 
 //---------------------------------------------------------------------------//
@@ -276,8 +276,8 @@ CELER_FUNCTION Real3 OrientedBoundingZone::translate(Real3 const& pos)
  * This function also reflects the point into quadrant one.
  */
 CELER_FUNCTION auto
-OrientedBoundingZone::apply_offset(Real3 const& trans_pos,
-                                   BBoxType bbt) -> OffsetPos
+OrientedBoundingZone::apply_offset(Real3 const& trans_pos, BBoxType bbt)
+    -> OffsetPos
 {
     TransformVisitor apply_transform(*sp_.transforms, *sp_.reals);
     auto transform_down

--- a/src/orange/detail/RectArrayInserter.cc
+++ b/src/orange/detail/RectArrayInserter.cc
@@ -129,7 +129,7 @@ UniverseId RectArrayInserter::operator()(RectArrayInput const& inp)
     {
         Daughter d;
         d.universe_id = daughter_input.universe_id;
-        d.transform_id = insert_transform_(daughter_input.transform);
+        d.trans_id = insert_transform_(daughter_input.transform);
         daughters.push_back(d);
     }
     record.daughters = ItemMap<LocalVolumeId, DaughterId>(

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -479,7 +479,7 @@ void UnitInserter::process_obz_record(VolumeRecord* vol_record,
     obz_record.offset_ids = {inner_offset_id, outer_offset_id};
 
     // Set transformation
-    obz_record.transform_id = obz_input.transform_id;
+    obz_record.trans_id = obz_input.trans_id;
 
     // Save the OBZ record to the volume record
     vol_record->obz_id = obz_records_.push_back(obz_record);
@@ -494,7 +494,7 @@ void UnitInserter::process_daughter(VolumeRecord* vol_record,
 {
     Daughter daughter;
     daughter.universe_id = daughter_input.universe_id;
-    daughter.transform_id = insert_transform_(daughter_input.transform);
+    daughter.trans_id = insert_transform_(daughter_input.transform);
 
     vol_record->daughter_id = daughters_.push_back(daughter);
     vol_record->flags |= VolumeRecord::embedded_universe;

--- a/src/orange/orangeinp/CsgTreeIO.json.cc
+++ b/src/orange/orangeinp/CsgTreeIO.json.cc
@@ -111,7 +111,7 @@ void to_json(nlohmann::json& j, CsgUnit const& unit)
         {
             auto entry = nlohmann::json{
                 {"exterior", reg.bounds.exterior},
-                {"transform", reg.transform_id.unchecked_get()},
+                {"transform", reg.trans_id.unchecked_get()},
             };
             if (reg.bounds.interior)
             {
@@ -141,7 +141,7 @@ void to_json(nlohmann::json& j, CsgUnit const& unit)
             else if (auto* d = std::get_if<Daughter>(&unit.fills[i]))
             {
                 entry["universe"] = d->universe_id.unchecked_get();
-                entry["transform"] = d->transform_id.unchecked_get();
+                entry["transform"] = d->trans_id.unchecked_get();
             }
             result.push_back(entry);
         }

--- a/src/orange/orangeinp/InputBuilder.cc
+++ b/src/orange/orangeinp/InputBuilder.cc
@@ -31,11 +31,11 @@ namespace
 void write_protos(detail::ProtoMap const& map, std::string const& filename)
 {
     auto result = nlohmann::json(std::vector<std::nullptr_t>(map.size()));
-    for (auto uid : range(UniverseId{map.size()}))
+    for (auto univ_id : range(UniverseId{map.size()}))
     {
         JsonPimpl j;
-        map.at(uid)->output(&j);
-        result[uid.get()] = std::move(j.obj);
+        map.at(univ_id)->output(&j);
+        result[univ_id.get()] = std::move(j.obj);
     }
 
     std::ofstream outf(filename);
@@ -61,10 +61,10 @@ class JsonProtoOutput
     }
 
     //! Save JSON
-    void operator()(UniverseId uid, JsonPimpl&& jpo)
+    void operator()(UniverseId univ_id, JsonPimpl&& jpo)
     {
-        CELER_EXPECT(uid < output_.size());
-        output_[uid.unchecked_get()] = std::move(jpo.obj);
+        CELER_EXPECT(univ_id < output_.size());
+        output_[univ_id.unchecked_get()] = std::move(jpo.obj);
     }
 
     //! Write debug information to a file
@@ -127,9 +127,9 @@ auto InputBuilder::operator()(ProtoInterface const& global) const -> result_type
         }
         return pbopts;
     }());
-    for (auto uid : range(UniverseId{protos.size()}))
+    for (auto univ_id : range(UniverseId{protos.size()}))
     {
-        protos.at(uid)->build(builder);
+        protos.at(univ_id)->build(builder);
     }
 
     if (!opts_.debug_output_file.empty())

--- a/src/orange/orangeinp/UnitProto.cc
+++ b/src/orange/orangeinp/UnitProto.cc
@@ -340,8 +340,8 @@ void UnitProto::build(ProtoBuilder& input) const
                 std::size_t daughter_index = iter->get<int>();
                 CELER_ASSERT(daughter_index < input_.daughters.size());
                 auto const& daughter = input_.daughters[daughter_index];
-                auto uid = input.find_universe_id(daughter.fill.get());
-                *iter = uid.unchecked_get();
+                auto univ_id = input.find_universe_id(daughter.fill.get());
+                *iter = univ_id.unchecked_get();
             }
         }
 

--- a/src/orange/orangeinp/UnitProto.cc
+++ b/src/orange/orangeinp/UnitProto.cc
@@ -190,7 +190,7 @@ void UnitProto::build(ProtoBuilder& input) const
         // Set bounding zone
         vi.obz.inner = region_iter->second.bounds.interior;
         vi.obz.outer = region_iter->second.bounds.exterior;
-        vi.obz.transform_id = region_iter->second.transform_id;
+        vi.obz.trans_id = region_iter->second.trans_id;
 
         /*!
          * \todo "simple safety" flag is set inside "unit inserter": move here
@@ -268,9 +268,9 @@ void UnitProto::build(ProtoBuilder& input) const
         // Save the transform
         auto const* fill = std::get_if<Daughter>(&csg_unit.fills[vol_id.get()]);
         CELER_ASSERT(fill);
-        auto transform_id = fill->transform_id;
-        CELER_ASSERT(transform_id < csg_unit.transforms.size());
-        iter->second.transform = csg_unit.transforms[transform_id.get()];
+        auto trans_id = fill->trans_id;
+        CELER_ASSERT(trans_id < csg_unit.transforms.size());
+        iter->second.transform = csg_unit.transforms[trans_id.get()];
 
         // Update bounding box of the daughter universe by inverting the
         // daughter-to-parent reference transform and applying it to the

--- a/src/orange/orangeinp/detail/CsgUnit.hh
+++ b/src/orange/orangeinp/detail/CsgUnit.hh
@@ -53,7 +53,7 @@ struct CsgUnit
     struct Region
     {
         BoundingZone bounds;  //!< Interior/exterior bbox
-        TransformId transform_id;  //!< Region-to-unit transform
+        TransformId trans_id;  //!< Region-to-unit transform
     };
 
     //// DATA ////

--- a/src/orange/orangeinp/detail/CsgUnitBuilder.cc
+++ b/src/orange/orangeinp/detail/CsgUnitBuilder.cc
@@ -90,7 +90,7 @@ void CsgUnitBuilder::insert_region(NodeId n,
                      == static_cast<bool>(existing.bounds.interior));
         CELER_ASSERT(static_cast<bool>(bzone.exterior)
                      == static_cast<bool>(existing.bounds.exterior));
-        if (trans_id != existing.transform_id)
+        if (trans_id != existing.trans_id)
         {
             /*! \todo We should implement transform soft equivalence.
              *  \todo Transformed shapes that are later defined as volumes (in
@@ -103,7 +103,7 @@ void CsgUnitBuilder::insert_region(NodeId n,
                 << "While re-inserting logically equivalent region '"
                 << join(md.begin(), md.end(), "' = '")
                 << "': existing transform "
-                << StreamableVariant{this->transform(existing.transform_id)}
+                << StreamableVariant{this->transform(existing.trans_id)}
                 << " differs from new transform "
                 << StreamableVariant{this->transform(trans_id)};
         }
@@ -184,8 +184,8 @@ void CsgUnitBuilder::fill_volume(LocalVolumeId v,
 
     Daughter new_daughter;
     new_daughter.universe_id = u;
-    new_daughter.transform_id = this->insert_transform(transform);
-    CELER_ASSERT(new_daughter.transform_id < unit_->transforms.size());
+    new_daughter.trans_id = this->insert_transform(transform);
+    CELER_ASSERT(new_daughter.trans_id < unit_->transforms.size());
 
     // Save fill
     unit_->fills[v.unchecked_get()] = std::move(new_daughter);

--- a/src/orange/orangeinp/detail/ProtoBuilder.cc
+++ b/src/orange/orangeinp/detail/ProtoBuilder.cc
@@ -45,10 +45,10 @@ ProtoBuilder::ProtoBuilder(OrangeInput* inp,
  * "holed" (placed) in different volumes with different bounds, so long as the
  * enclosures are within the extents of the child universe.
  */
-void ProtoBuilder::expand_bbox(UniverseId uid, BBox const& local_bbox)
+void ProtoBuilder::expand_bbox(UniverseId univ_id, BBox const& local_bbox)
 {
-    CELER_EXPECT(uid < bboxes_.size());
-    BBox& target = bboxes_[uid.get()];
+    CELER_EXPECT(univ_id < bboxes_.size());
+    BBox& target = bboxes_[univ_id.get()];
     target = calc_union(target, local_bbox);
 }
 

--- a/src/orange/orangeinp/detail/ProtoBuilder.hh
+++ b/src/orange/orangeinp/detail/ProtoBuilder.hh
@@ -106,10 +106,10 @@ UniverseId ProtoBuilder::find_universe_id(ProtoInterface const* p) const
 /*!
  * Get the bounding box of a universe.
  */
-BBox const& ProtoBuilder::bbox(UniverseId uid) const
+BBox const& ProtoBuilder::bbox(UniverseId univ_id) const
 {
-    CELER_EXPECT(uid < bboxes_.size());
-    return bboxes_[uid.get()];
+    CELER_EXPECT(univ_id < bboxes_.size());
+    return bboxes_[univ_id.get()];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/detail/ProtoMap.cc
+++ b/src/orange/orangeinp/detail/ProtoMap.cc
@@ -63,15 +63,15 @@ std::vector<ProtoInterface const*> build_ordering(ProtoInterface const& global)
 ProtoMap::ProtoMap(ProtoInterface const& global)
     : protos_{build_ordering(global)}
 {
-    uids_.reserve(protos_.size());
-    for (auto uid : range(UniverseId{this->size()}))
+    univ_ids_.reserve(protos_.size());
+    for (auto univ_id : range(UniverseId{this->size()}))
     {
-        ProtoInterface const* p = this->at(uid);
+        ProtoInterface const* p = this->at(univ_id);
         CELER_ASSERT(p);
-        auto&& [iter, inserted] = uids_.insert({p, uid});
+        auto&& [iter, inserted] = univ_ids_.insert({p, univ_id});
         CELER_ASSERT(inserted);
     }
-    CELER_ENSURE(uids_.size() == protos_.size());
+    CELER_ENSURE(univ_ids_.size() == protos_.size());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/detail/ProtoMap.hh
+++ b/src/orange/orangeinp/detail/ProtoMap.hh
@@ -48,7 +48,7 @@ class ProtoMap
 
   private:
     std::vector<ProtoInterface const*> protos_;
-    std::unordered_map<ProtoInterface const*, UniverseId> uids_;
+    std::unordered_map<ProtoInterface const*, UniverseId> univ_ids_;
 };
 
 //---------------------------------------------------------------------------//
@@ -57,10 +57,10 @@ class ProtoMap
 /*!
  * Get the proto corresponding to a universe ID.
  */
-ProtoInterface const* ProtoMap::at(UniverseId uid) const
+ProtoInterface const* ProtoMap::at(UniverseId univ_id) const
 {
-    CELER_EXPECT(uid < this->size());
-    return protos_[uid.unchecked_get()];
+    CELER_EXPECT(univ_id < this->size());
+    return protos_[univ_id.unchecked_get()];
 }
 
 //---------------------------------------------------------------------------//
@@ -70,8 +70,8 @@ ProtoInterface const* ProtoMap::at(UniverseId uid) const
 UniverseId ProtoMap::find(ProtoInterface const* proto) const
 {
     CELER_EXPECT(proto);
-    auto iter = uids_.find(proto);
-    CELER_EXPECT(iter != uids_.end());
+    auto iter = univ_ids_.find(proto);
+    CELER_EXPECT(iter != univ_ids_.end());
     return iter->second;
 }
 

--- a/src/orange/transform/TransformVisitor.hh
+++ b/src/orange/transform/TransformVisitor.hh
@@ -27,7 +27,7 @@ namespace celeritas
  TransformVisitor visit_transform{params_};
  auto new_pos = visit_transform(
     [&pos](auto&& t) { return t.transform_up(pos); },
-    daughter.transform_id);
+    daughter.trans_id);
  \endcode
  */
 class TransformVisitor

--- a/src/orange/univ/RectArrayTracker.hh
+++ b/src/orange/univ/RectArrayTracker.hh
@@ -231,12 +231,12 @@ RectArrayTracker::intersect(LocalState const& state,
  * always always occurs along a line parallel to an axis.
  */
 CELER_FUNCTION real_type RectArrayTracker::safety(Real3 const& pos,
-                                                  LocalVolumeId volid) const
+                                                  LocalVolumeId vol_id) const
 {
-    CELER_EXPECT(volid && volid.get() < this->num_volumes());
+    CELER_EXPECT(vol_id && vol_id.get() < this->num_volumes());
 
     VolumeInverseIndexer to_coords(record_.dims);
-    auto coords = to_coords(volid.unchecked_get());
+    auto coords = to_coords(vol_id.unchecked_get());
 
     real_type min_dist = numeric_limits<real_type>::infinity();
 

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -128,7 +128,8 @@ class SimpleUnitTracker
     inline CELER_FUNCTION LocalSurfaceVisitor make_surface_visitor() const;
 
     // Create a Volumes object from the params
-    inline CELER_FUNCTION VolumeView make_local_volume(LocalVolumeId vid) const;
+    inline CELER_FUNCTION VolumeView
+    make_local_volume(LocalVolumeId vol_id) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -199,7 +200,8 @@ SimpleUnitTracker::initialize(LocalState const& state) const -> Initialization
  * Find the local volume on the opposite side of a surface.
  */
 CELER_FUNCTION auto
-SimpleUnitTracker::cross_boundary(LocalState const& state) const -> Initialization
+SimpleUnitTracker::cross_boundary(LocalState const& state) const
+    -> Initialization
 {
     CELER_EXPECT(state.surface && state.volume);
     detail::SenseCalculator calc_senses(
@@ -256,8 +258,8 @@ SimpleUnitTracker::cross_boundary(LocalState const& state) const -> Initializati
 /*!
  * Calculate distance-to-intercept for the next surface.
  */
-CELER_FUNCTION auto
-SimpleUnitTracker::intersect(LocalState const& state) const -> Intersection
+CELER_FUNCTION auto SimpleUnitTracker::intersect(LocalState const& state) const
+    -> Intersection
 {
     Intersection result = this->intersect_impl(state, detail::IsFinite{});
     return result;
@@ -268,8 +270,8 @@ SimpleUnitTracker::intersect(LocalState const& state) const -> Intersection
  * Calculate distance-to-intercept for the next surface.
  */
 CELER_FUNCTION auto
-SimpleUnitTracker::intersect(LocalState const& state,
-                             real_type max_dist) const -> Intersection
+SimpleUnitTracker::intersect(LocalState const& state, real_type max_dist) const
+    -> Intersection
 {
     CELER_EXPECT(max_dist > 0);
     Intersection result
@@ -389,8 +391,8 @@ SimpleUnitTracker::find_volume_where(Real3 const& pos, F&& predicate) const
  */
 template<class F>
 CELER_FUNCTION auto
-SimpleUnitTracker::intersect_impl(LocalState const& state,
-                                  F&& is_valid) const -> Intersection
+SimpleUnitTracker::intersect_impl(LocalState const& state, F&& is_valid) const
+    -> Intersection
 {
     CELER_EXPECT(state.volume && !state.temp_sense.empty());
 
@@ -590,8 +592,10 @@ SimpleUnitTracker::complex_intersect(LocalState const& state,
  * volume (alternatively we could introduce a mapping between Face and
  * LocalSurfaceId).
  */
-CELER_FUNCTION auto SimpleUnitTracker::background_intersect(
-    LocalState const& state, size_type num_isect) const -> Intersection
+CELER_FUNCTION auto
+SimpleUnitTracker::background_intersect(LocalState const& state,
+                                        size_type num_isect) const
+    -> Intersection
 {
     // Calculate bump distance
     real_type const bump_dist
@@ -616,10 +620,10 @@ CELER_FUNCTION auto SimpleUnitTracker::background_intersect(
 
         // Loop over volumes connected to this surface.
         //! \todo Accelerate by intersecting neighbors with BVH grid
-        for (LocalVolumeId vid : this->get_neighbors(surface))
+        for (LocalVolumeId vol_id : this->get_neighbors(surface))
         {
-            CELER_ASSERT(vid != state.volume);
-            VolumeView vol = this->make_local_volume(vid);
+            CELER_ASSERT(vol_id != state.volume);
+            VolumeView vol = this->make_local_volume(vol_id);
             auto logic_state = detail::SenseCalculator{
                 this->make_surface_visitor(), pos, state.temp_sense}(vol);
 
@@ -659,9 +663,9 @@ SimpleUnitTracker::make_surface_visitor() const
  * Create a Volume view object from the params for this unit.
  */
 CELER_FORCEINLINE_FUNCTION VolumeView
-SimpleUnitTracker::make_local_volume(LocalVolumeId vid) const
+SimpleUnitTracker::make_local_volume(LocalVolumeId vol_id) const
 {
-    return VolumeView{params_, unit_record_, vid};
+    return VolumeView{params_, unit_record_, vol_id};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -293,11 +293,11 @@ SimpleUnitTracker::intersect(LocalState const& state,
  * necessarily slow down the simulation.
  */
 CELER_FUNCTION real_type SimpleUnitTracker::safety(Real3 const& pos,
-                                                   LocalVolumeId volid) const
+                                                   LocalVolumeId vol_id) const
 {
-    CELER_EXPECT(volid);
+    CELER_EXPECT(vol_id);
 
-    VolumeView vol = this->make_local_volume(volid);
+    VolumeView vol = this->make_local_volume(vol_id);
     if (!vol.simple_safety())
     {
         // Has a tricky surface: we can't use the simple algorithm to calculate

--- a/src/orange/univ/TrackerVisitor.hh
+++ b/src/orange/univ/TrackerVisitor.hh
@@ -26,7 +26,7 @@ namespace celeritas
  TrackerVisitor visit_tracker{params_};
  auto new_pos = visit_tracker(
     [&pos](auto&& u) { return u.initialize(pos); },
-    uid);
+    univ_id);
  \endcode
  */
 class TrackerVisitor

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -126,7 +126,7 @@ TEST_F(OneVolumeTest, obz)
     EXPECT_VEC_SOFT_EQ(Real3({3.1, 3.6, 4.1}), data.reals[outer_range]);
 
     // Check translation id
-    EXPECT_EQ(10, obz_record.transform_id.get());
+    EXPECT_EQ(10, obz_record.trans_id.get());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -307,22 +307,22 @@ std::string OrangeGeoTestBase::id_to_label(LocalSurfaceId surfid) const
  * Volume name (or sentinel if no volume).
  */
 std::string
-OrangeGeoTestBase::id_to_label(UniverseId uid, LocalVolumeId volid) const
+OrangeGeoTestBase::id_to_label(UniverseId uid, LocalVolumeId vol_id) const
 {
-    if (!volid)
+    if (!vol_id)
         return "[none]";
 
     detail::UniverseIndexer ui(this->params().host_ref().universe_indexer_data);
-    return params_->volumes().at(ui.global_volume(uid, volid)).name;
+    return params_->volumes().at(ui.global_volume(uid, vol_id)).name;
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Volume name (or sentinel if no volume) within UniverseId{0}.
  */
-std::string OrangeGeoTestBase::id_to_label(LocalVolumeId volid) const
+std::string OrangeGeoTestBase::id_to_label(LocalVolumeId vol_id) const
 {
-    return this->id_to_label(UniverseId{0}, volid);
+    return this->id_to_label(UniverseId{0}, vol_id);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeGeoTestBase.hh
+++ b/test/orange/OrangeGeoTestBase.hh
@@ -108,10 +108,10 @@ class OrangeGeoTestBase : public OrangeTestBase
     std::string id_to_label(LocalSurfaceId surfid) const;
 
     // Cell name (or sentinel if no surface)
-    std::string id_to_label(UniverseId uid, LocalVolumeId volid) const;
+    std::string id_to_label(UniverseId uid, LocalVolumeId vol_id) const;
 
     // Cell name (or sentinel if no surface) within UniverseId{0}
-    std::string id_to_label(LocalVolumeId volid) const;
+    std::string id_to_label(LocalVolumeId vol_id) const;
 
     // Print geometry description
     void describe(std::ostream& os) const;

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -84,9 +84,9 @@ TEST_F(BIHBuilderTest, basic)
 
     BIHBuilder build(&storage_);
     auto bih_tree = build(std::move(bboxes_));
-    ASSERT_EQ(1, bih_tree.inf_volids.size());
+    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
     EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_volids[0]]);
+              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
 
     // Test bounding box storage
     auto bbox1 = storage_.bboxes[bih_tree.bboxes[LocalVolumeId{2}]];
@@ -272,9 +272,9 @@ TEST_F(BIHBuilderTest, grid)
 
     BIHBuilder build(&storage_);
     auto bih_tree = build(std::move(bboxes_));
-    ASSERT_EQ(1, bih_tree.inf_volids.size());
+    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
     EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_volids[0]]);
+              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
 
     // Test nodes
     auto inner_nodes = bih_tree.inner_nodes;
@@ -481,7 +481,7 @@ TEST_F(BIHBuilderTest, single_finite_volume)
     BIHBuilder build(&storage_);
     auto bih_tree = build(std::move(bboxes_));
 
-    ASSERT_EQ(0, bih_tree.inf_volids.size());
+    ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
     ASSERT_EQ(0, bih_tree.inner_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
 
@@ -499,7 +499,7 @@ TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
     BIHBuilder build(&storage_);
     auto bih_tree = build(std::move(bboxes_));
 
-    ASSERT_EQ(0, bih_tree.inf_volids.size());
+    ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
     ASSERT_EQ(0, bih_tree.inner_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
 
@@ -519,10 +519,10 @@ TEST_F(BIHBuilderTest, single_infinite_volume)
 
     ASSERT_EQ(0, bih_tree.inner_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
-    ASSERT_EQ(1, bih_tree.inf_volids.size());
+    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
 
     EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_volids[0]]);
+              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
 }
 
 TEST_F(BIHBuilderTest, multiple_infinite_volumes)
@@ -535,12 +535,12 @@ TEST_F(BIHBuilderTest, multiple_infinite_volumes)
 
     ASSERT_EQ(0, bih_tree.inner_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
-    ASSERT_EQ(2, bih_tree.inf_volids.size());
+    ASSERT_EQ(2, bih_tree.inf_vol_ids.size());
 
     EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_volids[0]]);
+              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
     EXPECT_EQ(LocalVolumeId{1},
-              storage_.local_volume_ids[bih_tree.inf_volids[1]]);
+              storage_.local_volume_ids[bih_tree.inf_vol_ids[1]]);
 }
 
 TEST_F(BIHBuilderTest, TEST_IF_CELERITAS_DEBUG(semi_finite_volumes))

--- a/test/orange/detail/BIHEnclosingVolFinder.test.cc
+++ b/test/orange/detail/BIHEnclosingVolFinder.test.cc
@@ -34,11 +34,11 @@ class BIHEnclosingVolFinderTest : public Test
     BIHTreeData<Ownership::value, MemSpace::host> storage_;
     BIHTreeData<Ownership::const_reference, MemSpace::host> ref_storage_;
 
-    static constexpr bool valid_volid_(LocalVolumeId vol_id)
+    static constexpr bool valid_vol_id_(LocalVolumeId vol_id)
     {
         return static_cast<bool>(vol_id);
     };
-    static constexpr bool odd_volid_(LocalVolumeId vol_id)
+    static constexpr bool odd_vol_id_(LocalVolumeId vol_id)
     {
         return vol_id.unchecked_get() % 2 != 0;
     };
@@ -77,12 +77,12 @@ TEST_F(BIHEnclosingVolFinderTest, basic)
     ref_storage_ = storage_;
     BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
 
-    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.8, 0.5, 110}, valid_volid_));
-    EXPECT_EQ(LocalVolumeId{1}, find_volume({0.8, 0.5, 30}, valid_volid_));
-    EXPECT_EQ(LocalVolumeId{2}, find_volume({2.0, 0.6, 40}, valid_volid_));
-    EXPECT_EQ(LocalVolumeId{3}, find_volume({2.9, 0.7, 50}, valid_volid_));
-    EXPECT_EQ(LocalVolumeId{4}, find_volume({2.9, -0.7, 50}, valid_volid_));
-    EXPECT_EQ(LocalVolumeId{5}, find_volume({2.9, -0.7, 50}, odd_volid_));
+    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.8, 0.5, 110}, valid_vol_id_));
+    EXPECT_EQ(LocalVolumeId{1}, find_volume({0.8, 0.5, 30}, valid_vol_id_));
+    EXPECT_EQ(LocalVolumeId{2}, find_volume({2.0, 0.6, 40}, valid_vol_id_));
+    EXPECT_EQ(LocalVolumeId{3}, find_volume({2.9, 0.7, 50}, valid_vol_id_));
+    EXPECT_EQ(LocalVolumeId{4}, find_volume({2.9, -0.7, 50}, valid_vol_id_));
+    EXPECT_EQ(LocalVolumeId{5}, find_volume({2.9, -0.7, 50}, odd_vol_id_));
 }
 
 //---------------------------------------------------------------------------//
@@ -119,7 +119,7 @@ TEST_F(BIHEnclosingVolFinderTest, grid)
     ref_storage_ = storage_;
     BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
 
-    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.8, 0.5, 110}, valid_volid_));
+    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.8, 0.5, 110}, valid_vol_id_));
 
     size_type index{1};
     for (auto i : range(3))
@@ -128,7 +128,7 @@ TEST_F(BIHEnclosingVolFinderTest, grid)
         {
             constexpr real_type half{0.5};
             EXPECT_EQ(LocalVolumeId{index++},
-                      find_volume({half + i, half + j, 30}, valid_volid_));
+                      find_volume({half + i, half + j, 30}, valid_vol_id_));
         }
     }
 }
@@ -147,7 +147,7 @@ TEST_F(BIHEnclosingVolFinderTest, single_finite_volume)
     ref_storage_ = storage_;
     BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
 
-    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.5, 0.5, 0.5}, valid_volid_));
+    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.5, 0.5, 0.5}, valid_vol_id_));
 }
 
 TEST_F(BIHEnclosingVolFinderTest, multiple_nonpartitionable_volumes)
@@ -161,8 +161,8 @@ TEST_F(BIHEnclosingVolFinderTest, multiple_nonpartitionable_volumes)
     ref_storage_ = storage_;
     BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
 
-    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.5, 0.5, 0.5}, valid_volid_));
-    EXPECT_EQ(LocalVolumeId{1}, find_volume({0.5, 0.5, 0.5}, odd_volid_));
+    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.5, 0.5, 0.5}, valid_vol_id_));
+    EXPECT_EQ(LocalVolumeId{1}, find_volume({0.5, 0.5, 0.5}, odd_vol_id_));
 }
 
 TEST_F(BIHEnclosingVolFinderTest, single_infinite_volume)
@@ -175,7 +175,7 @@ TEST_F(BIHEnclosingVolFinderTest, single_infinite_volume)
     ref_storage_ = storage_;
     BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
 
-    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.5, 0.5, 0.5}, valid_volid_));
+    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.5, 0.5, 0.5}, valid_vol_id_));
 }
 
 TEST_F(BIHEnclosingVolFinderTest, multiple_infinite_volumes)
@@ -189,8 +189,8 @@ TEST_F(BIHEnclosingVolFinderTest, multiple_infinite_volumes)
     ref_storage_ = storage_;
     BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
 
-    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.5, 0.5, 0.5}, valid_volid_));
-    EXPECT_EQ(LocalVolumeId{1}, find_volume({0.5, 0.5, 0.5}, odd_volid_));
+    EXPECT_EQ(LocalVolumeId{0}, find_volume({0.5, 0.5, 0.5}, valid_vol_id_));
+    EXPECT_EQ(LocalVolumeId{1}, find_volume({0.5, 0.5, 0.5}, odd_vol_id_));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/orangeinp/CsgTestUtils.cc
+++ b/test/orange/orangeinp/CsgTestUtils.cc
@@ -170,7 +170,7 @@ std::vector<std::string> transform_strings(CsgUnit const& u)
     {
         std::ostringstream os;
         os << node.unchecked_get() << ": t=";
-        if (auto t = reg.transform_id)
+        if (auto t = reg.trans_id)
         {
             os << t.unchecked_get();
             if (t < u.transforms.size())
@@ -235,7 +235,7 @@ std::vector<std::string> fill_strings(CsgUnit const& u)
                 os << "<MISSING>";
             }
             os << ", t=";
-            if (auto t = d->transform_id)
+            if (auto t = d->trans_id)
             {
                 os << t.unchecked_get();
             }

--- a/test/orange/univ/RectArrayTracker.test.cc
+++ b/test/orange/univ/RectArrayTracker.test.cc
@@ -55,7 +55,7 @@ class RectArrayTrackerTest : public OrangeGeoTestBase
     // Prepare for initialization across a surface
     LocalState make_state_crossing(Real3 pos,
                                    Real3 dir,
-                                   LocalVolumeId volid,
+                                   LocalVolumeId vol_id,
                                    LocalSurfaceId surfid,
                                    Sense sense);
 
@@ -92,10 +92,10 @@ LocalState RectArrayTrackerTest::make_state(Real3 pos, Real3 dir)
  * Initialize inside a volume.
  */
 LocalState
-RectArrayTrackerTest::make_state(Real3 pos, Real3 dir, LocalVolumeId volid)
+RectArrayTrackerTest::make_state(Real3 pos, Real3 dir, LocalVolumeId vol_id)
 {
     LocalState state = this->make_state(pos, dir);
-    state.volume = volid;
+    state.volume = vol_id;
     return state;
 }
 
@@ -107,11 +107,11 @@ RectArrayTrackerTest::make_state(Real3 pos, Real3 dir, LocalVolumeId volid)
  */
 LocalState RectArrayTrackerTest::make_state_crossing(Real3 pos,
                                                      Real3 dir,
-                                                     LocalVolumeId volid,
+                                                     LocalVolumeId vol_id,
                                                      LocalSurfaceId surfid,
                                                      Sense sense)
 {
-    LocalState state = this->make_state(pos, dir, volid);
+    LocalState state = this->make_state(pos, dir, vol_id);
     state.surface = {surfid, sense};
     return state;
 }
@@ -333,26 +333,26 @@ TEST_F(RectArrayTrackerTest, safety)
 
     SCOPED_TRACE("In volume {0, 0, 0}");
     {
-        auto volid = LocalVolumeId{0};
+        auto vol_id = LocalVolumeId{0};
 
-        EXPECT_SOFT_EQ(2.5, tracker.safety({0.11, 0.5, 0.5}, volid));
-        EXPECT_SOFT_EQ(0.08, tracker.safety({2.92, 0.5, 0.5}, volid));
-        EXPECT_SOFT_EQ(2.5, tracker.safety({0.5, 0.11, 0.5}, volid));
-        EXPECT_SOFT_EQ(0.08, tracker.safety({0.5, 2.92, 0.5}, volid));
-        EXPECT_SOFT_EQ(2.5, tracker.safety({0.5, 0.11, 0.01}, volid));
-        EXPECT_SOFT_EQ(0.02, tracker.safety({0.5, 2.92, 4.98}, volid));
+        EXPECT_SOFT_EQ(2.5, tracker.safety({0.11, 0.5, 0.5}, vol_id));
+        EXPECT_SOFT_EQ(0.08, tracker.safety({2.92, 0.5, 0.5}, vol_id));
+        EXPECT_SOFT_EQ(2.5, tracker.safety({0.5, 0.11, 0.5}, vol_id));
+        EXPECT_SOFT_EQ(0.08, tracker.safety({0.5, 2.92, 0.5}, vol_id));
+        EXPECT_SOFT_EQ(2.5, tracker.safety({0.5, 0.11, 0.01}, vol_id));
+        EXPECT_SOFT_EQ(0.02, tracker.safety({0.5, 2.92, 4.98}, vol_id));
     }
 
     SCOPED_TRACE("In volume {2, 2, 1}");
     {
-        auto volid = LocalVolumeId{21};
+        auto vol_id = LocalVolumeId{21};
 
-        EXPECT_SOFT_EQ(0.04, tracker.safety({6.04, 6.5, 5.5}, volid));
-        EXPECT_SOFT_EQ(0.02, tracker.safety({11.98, 6.5, 5.02}, volid));
-        EXPECT_SOFT_EQ(0.04, tracker.safety({6.5, 6.04, 5.5}, volid));
-        EXPECT_SOFT_EQ(0.02, tracker.safety({6.5, 8.98, 5.5}, volid));
-        EXPECT_SOFT_EQ(0.01, tracker.safety({6.5, 6.04, 5.01}, volid));
-        EXPECT_SOFT_EQ(0.01, tracker.safety({6.01, 8.98, 9.99}, volid));
+        EXPECT_SOFT_EQ(0.04, tracker.safety({6.04, 6.5, 5.5}, vol_id));
+        EXPECT_SOFT_EQ(0.02, tracker.safety({11.98, 6.5, 5.02}, vol_id));
+        EXPECT_SOFT_EQ(0.04, tracker.safety({6.5, 6.04, 5.5}, vol_id));
+        EXPECT_SOFT_EQ(0.02, tracker.safety({6.5, 8.98, 5.5}, vol_id));
+        EXPECT_SOFT_EQ(0.01, tracker.safety({6.5, 6.04, 5.01}, vol_id));
+        EXPECT_SOFT_EQ(0.01, tracker.safety({6.01, 8.98, 9.99}, vol_id));
     }
 }
 


### PR DESCRIPTION
This MR updates all files within ORANGE to use the form "vol_id" for variable names instead of "volid", for consistency with other opaque IDs such as `universe_id`, `transform_id`, `level_id`, etc.