### PR TITLE
Fix VecGeom middle library name.

### DIFF
--- a/cmake/CudaRdcUtils.cmake
+++ b/cmake/CudaRdcUtils.cmake
@@ -771,7 +771,7 @@ function(cuda_rdc_target_link_libraries target)
         # Note: we might be able to move this to cuda_rdc_target_link_libraries
         CUDA_RESOLVE_DEVICE_SYMBOLS OFF
       )
-      get_target_property(_final_target_type ${target} TYPE)
+      get_target_property(_final_target_type ${_finallibs} TYPE)
 
       get_target_property(_final_runtime ${_finallibs} CUDA_RUNTIME_LIBRARY)
       if(_final_runtime STREQUAL "Shared")

--- a/cmake/FindVecGeom.cmake
+++ b/cmake/FindVecGeom.cmake
@@ -31,7 +31,7 @@ if(VecGeom_FOUND AND TARGET VecGeom::vecgeomcuda)
   endif()
   set_target_properties(VecGeom::vecgeom PROPERTIES
     CUDA_RDC_STATIC_LIBRARY VecGeom::vecgeomcuda_static
-    CUDA_RDC_MIDDLE_LIBRARY VecGeom::vecgeomcuda
+    CUDA_RDC_MIDDLE_LIBRARY VecGeom::vecgeomcuda_static
     CUDA_RDC_FINAL_LIBRARY VecGeom::vecgeomcuda
   )
   set_target_properties(VecGeom::vecgeomcuda PROPERTIES
@@ -56,7 +56,7 @@ if(VecGeom_FOUND AND TARGET VecGeom::vecgeomcuda)
       VecGeom::vecgeomcuda_static)
     set_target_properties(${_lib} PROPERTIES
       CUDA_RDC_STATIC_LIBRARY VecGeom::vecgeomcuda_static
-      CUDA_RDC_MIDDLE_LIBRARY VecGeom::vecgeomcuda
+      CUDA_RDC_MIDDLE_LIBRARY VecGeom::vecgeomcuda_static
       CUDA_RDC_FINAL_LIBRARY VecGeom::vecgeomcuda
     )
   endforeach()


### PR DESCRIPTION
`libvecgeomcuda.[a|so]` is the final library and it includes the result
of nvlink.  It is not appropriate to use as the intermediary link library.

VecGeom also never produce a shared 'middle' library, so we just always
need to use**Please read, follow, and delete this text**

