### PR TITLE
Fix dBVH memcpy size

### DIFF
--- a/src/geocel/vg/detail/VecgeomSetup.cu
+++ b/src/geocel/vg/detail/VecgeomSetup.cu
@@ -64,8 +64,11 @@ CudaPointers<vecgeom::cuda::BVH const> bvh_pointers_device()
     }
 
     // Copy from symbol using runtime API
-    CELER_CUDA_CALL(cudaMemcpyFromSymbol(
-        &result.symbol, vecgeom::cuda::dBVH, 1, 0, cudaMemcpyDeviceToHost));
+    CELER_CUDA_CALL(cudaMemcpyFromSymbol(&result.symbol,
+                                         vecgeom::cuda::dBVH,
+                                         sizeof(vecgeom::cuda::dBVH),
+                                         0,
+                                         cudaMemcpyDeviceToHost));
     CELER_CUDA_CALL(cudaDeviceSynchronize());
 
     return result;


### PR DESCRIPTION
Introduced in #1481, copy the entire pointer instead of 1 byte. 