### PR TITLE
Allow core and optical loops to have different numbers of track slots

### DIFF
--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -598,15 +598,19 @@ void Runner::build_optical_collector(RunnerInput const& inp,
     }
     CELER_ASSERT(inp.optical);
 
+    size_type num_streams = core_params_->max_streams();
+
     OpticalCollector::Input oc_inp;
     oc_inp.material = MaterialParams::from_import(
         imported, *core_params_->geomaterial(), *core_params_->material());
     oc_inp.cerenkov = std::make_shared<CerenkovParams>(oc_inp.material);
     oc_inp.scintillation
         = ScintillationParams::from_import(imported, core_params_->particle());
-    oc_inp.buffer_capacity = inp.optical.buffer_capacity;
-    oc_inp.primary_capacity = inp.optical.primary_capacity;
-    oc_inp.auto_flush = inp.optical.auto_flush;
+    oc_inp.num_track_slots = ceil_div(inp.optical.num_track_slots, num_streams);
+    oc_inp.buffer_capacity = ceil_div(inp.optical.buffer_capacity, num_streams);
+    oc_inp.initializer_capacity
+        = ceil_div(inp.optical.initializer_capacity, num_streams);
+    oc_inp.auto_flush = ceil_div(inp.optical.auto_flush, num_streams);
 
     CELER_ASSERT(oc_inp);
     optical_collector_

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -55,15 +55,17 @@ struct RunnerInput
 
     struct OpticalOptions
     {
+        // Sizes are divided among streams
+        size_type num_track_slots{};  //!< Number of optical loop tracks slots
         size_type buffer_capacity{};  //!< Number of steps that created photons
-        size_type primary_capacity{};  //!< Maximum number of pending primaries
+        size_type initializer_capacity{};  //!< Maximum queued tracks
         size_type auto_flush{};  //!< Threshold number of primaries for
                                  //!< launching optical tracking loop
 
         explicit operator bool() const
         {
-            return buffer_capacity > 0 && primary_capacity > 0
-                   && auto_flush > 0;
+            return num_track_slots > 0 && buffer_capacity > 0
+                   && initializer_capacity > 0 && auto_flush > 0;
         };
     };
     static constexpr Real3 no_field() { return Real3{0, 0, 0}; }

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -225,16 +225,23 @@ void to_json(nlohmann::json& j, app::RunnerInput::EventFileSampling const& efs)
 
 void from_json(nlohmann::json const& j, app::RunnerInput::OpticalOptions& oo)
 {
+    CELER_JSON_LOAD_DEPRECATED(j, oo, primary_capacity, initializer_capacity);
+
+    CELER_JSON_LOAD_REQUIRED(j, oo, num_track_slots);
     CELER_JSON_LOAD_REQUIRED(j, oo, buffer_capacity);
-    CELER_JSON_LOAD_REQUIRED(j, oo, primary_capacity);
+    if (!oo.initializer_capacity)
+    {
+        CELER_JSON_LOAD_REQUIRED(j, oo, initializer_capacity);
+    }
     CELER_JSON_LOAD_REQUIRED(j, oo, auto_flush);
 }
 
 void to_json(nlohmann::json& j, app::RunnerInput::OpticalOptions const& oo)
 {
     j = nlohmann::json{
+        CELER_JSON_PAIR(oo, num_track_slots),
         CELER_JSON_PAIR(oo, buffer_capacity),
-        CELER_JSON_PAIR(oo, primary_capacity),
+        CELER_JSON_PAIR(oo, initializer_capacity),
         CELER_JSON_PAIR(oo, auto_flush),
     };
 }

--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -83,8 +83,9 @@ if not use_device:
 
 # TODO: Update once tracking loop is implemented
 optical_options = {
+    'num_track_slots': num_tracks,
     'buffer_capacity': 3 * max_steps * num_tracks,
-    'primary_capacity': num_tracks,
+    'initializer_capacity': num_tracks,
     'auto_flush': 2**31, # Large enough to never launch optical loop
 }
 

--- a/src/celeritas/optical/OpticalCollector.cc
+++ b/src/celeritas/optical/OpticalCollector.cc
@@ -105,12 +105,13 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
     }
 
     // Create launch action with optical params+state and access to gen data
+    detail::OpticalLaunchAction::Input la_inp;
+    la_inp.material = inp.material;
+    la_inp.offload = offload_params_;
+    la_inp.num_track_slots = inp.num_track_slots;
+    la_inp.initializer_capacity = inp.initializer_capacity;
     launch_action_ = detail::OpticalLaunchAction::make_and_insert(
-        core,
-        inp.material,
-        offload_params_,
-        inp.num_track_slots,
-        inp.initializer_capacity);
+        core, std::move(la_inp));
 
     // Launch action must be *after* offload and generator actions
     CELER_ENSURE(!cerenkov_action_

--- a/src/celeritas/optical/OpticalCollector.cc
+++ b/src/celeritas/optical/OpticalCollector.cc
@@ -106,7 +106,11 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
 
     // Create launch action with optical params+state and access to gen data
     launch_action_ = detail::OpticalLaunchAction::make_and_insert(
-        core, inp.material, offload_params_, inp.primary_capacity);
+        core,
+        inp.material,
+        offload_params_,
+        inp.num_track_slots,
+        inp.initializer_capacity);
 
     // Launch action must be *after* offload and generator actions
     CELER_ENSURE(!cerenkov_action_

--- a/src/celeritas/optical/OpticalCollector.hh
+++ b/src/celeritas/optical/OpticalCollector.hh
@@ -75,11 +75,14 @@ class OpticalCollector
         SPConstCerenkov cerenkov;
         SPConstScintillation scintillation;
 
+        //! Number track slots in the optical loop
+        size_type num_track_slots{};
+
         //! Number of steps that have created optical particles
         size_type buffer_capacity{};
 
         //! Maximum number of buffered initializers in optical tracking loop
-        size_type primary_capacity{};
+        size_type initializer_capacity{};
 
         //! Threshold number of initializers for launching optical loop
         size_type auto_flush{};
@@ -88,8 +91,8 @@ class OpticalCollector
         explicit operator bool() const
         {
             return material && (scintillation || cerenkov)
-                   && buffer_capacity > 0 && primary_capacity > 0
-                   && auto_flush > 0;
+                   && num_track_slots > 0 && buffer_capacity > 0
+                   && initializer_capacity > 0 && auto_flush > 0;
         }
     };
 

--- a/src/celeritas/optical/action/detail/PreStepExecutor.hh
+++ b/src/celeritas/optical/action/detail/PreStepExecutor.hh
@@ -47,7 +47,8 @@ CELER_FUNCTION void PreStepExecutor::operator()(CoreTrackView const& track)
 
     CELER_ASSERT(sim.status() == TrackStatus::initializing
                  || sim.status() == TrackStatus::alive);
-    sim.status(TrackStatus::alive);
+    //! \todo Set to alive when loop is implemented; for now just kill tracks
+    sim.status(TrackStatus::inactive);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/detail/CerenkovGeneratorAction.cc
+++ b/src/celeritas/optical/detail/CerenkovGeneratorAction.cc
@@ -107,7 +107,8 @@ void CerenkovGeneratorAction::step_impl(CoreParams const& core_params,
                    << "insufficient capacity (" << initializers_size
                    << ") for optical photon initializers (total capacity "
                       "requirement of "
-                   << num_photons + num_new_photons << ")");
+                   << num_photons + num_new_photons << " and current size "
+                   << num_photons << ")");
 
     auto& offload = offload_state.store.ref();
     auto& buffer_size = offload_state.buffer_size.cerenkov;

--- a/src/celeritas/optical/detail/CerenkovGeneratorAction.cc
+++ b/src/celeritas/optical/detail/CerenkovGeneratorAction.cc
@@ -11,6 +11,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/data/AuxStateVec.hh"
+#include "corecel/io/Logger.hh"
 #include "celeritas/global/ActionLauncher.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
@@ -122,6 +123,9 @@ void CerenkovGeneratorAction::step_impl(CoreParams const& core_params,
 
     // Generate the optical photon initializers from the distribution data
     this->generate(core_params, core_state);
+
+    CELER_LOG(debug) << "Generated " << count << " Cerenkov photons from "
+                     << buffer_size << " distributions";
 
     num_photons += count;
     num_new_photons -= count;

--- a/src/celeritas/optical/detail/CerenkovGeneratorAction.cc
+++ b/src/celeritas/optical/detail/CerenkovGeneratorAction.cc
@@ -124,8 +124,9 @@ void CerenkovGeneratorAction::step_impl(CoreParams const& core_params,
     // Generate the optical photon initializers from the distribution data
     this->generate(core_params, core_state);
 
-    CELER_LOG(debug) << "Generated " << count << " Cerenkov photons from "
-                     << buffer_size << " distributions";
+    CELER_LOG_LOCAL(debug) << "Generated " << count
+                           << " Cerenkov photons from " << buffer_size
+                           << " distributions";
 
     num_photons += count;
     num_new_photons -= count;

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -34,7 +34,8 @@ std::shared_ptr<OpticalLaunchAction>
 OpticalLaunchAction::make_and_insert(CoreParams const& core,
                                      SPConstMaterial material,
                                      SPOffloadParams offload,
-                                     size_type primary_capacity)
+                                     size_type num_track_slots,
+                                     size_type initializer_capacity)
 {
     CELER_EXPECT(material);
     CELER_EXPECT(offload);
@@ -45,7 +46,8 @@ OpticalLaunchAction::make_and_insert(CoreParams const& core,
                                                         core,
                                                         std::move(material),
                                                         std::move(offload),
-                                                        primary_capacity);
+                                                        num_track_slots,
+                                                        initializer_capacity);
 
     actions.insert(result);
     aux.insert(result);
@@ -61,14 +63,17 @@ OpticalLaunchAction::OpticalLaunchAction(ActionId action_id,
                                          CoreParams const& core,
                                          SPConstMaterial material,
                                          SPOffloadParams offload,
-                                         size_type primary_capacity)
+                                         size_type num_track_slots,
+                                         size_type initializer_capacity)
     : action_id_{action_id}
     , aux_id_{data_id}
     , offload_params_{std::move(offload)}
+    , num_track_slots_{num_track_slots}
 {
     CELER_EXPECT(material);
     CELER_EXPECT(offload_params_);
-    CELER_EXPECT(primary_capacity > 0);
+    CELER_EXPECT(num_track_slots_ > 0);
+    CELER_EXPECT(initializer_capacity > 0);
 
     // Create optical core params
     optical_params_ = std::make_shared<optical::CoreParams>([&] {
@@ -77,7 +82,8 @@ OpticalLaunchAction::OpticalLaunchAction(ActionId action_id,
         inp.material = std::move(material);
         // TODO: unique RNG streams for optical loop
         inp.rng = core.rng();
-        inp.init = std::make_shared<optical::TrackInitParams>(primary_capacity);
+        inp.init
+            = std::make_shared<optical::TrackInitParams>(initializer_capacity);
         inp.action_reg = std::make_shared<ActionRegistry>();
         inp.max_streams = core.max_streams();
         CELER_ENSURE(inp);
@@ -107,19 +113,18 @@ std::string_view OpticalLaunchAction::description() const
 /*!
  * Build state data for a stream.
  */
-auto OpticalLaunchAction::create_state(MemSpace m,
-                                       StreamId sid,
-                                       size_type size) const -> UPState
+auto OpticalLaunchAction::create_state(MemSpace m, StreamId sid, size_type) const
+    -> UPState
 {
     if (m == MemSpace::host)
     {
         return std::make_unique<optical::CoreState<MemSpace::host>>(
-            *optical_params_, sid, size);
+            *optical_params_, sid, num_track_slots_);
     }
     else if (m == MemSpace::device)
     {
         return std::make_unique<optical::CoreState<MemSpace::device>>(
-            *optical_params_, sid, size);
+            *optical_params_, sid, num_track_slots_);
     }
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -31,23 +31,13 @@ namespace detail
  * Construct and add to core params.
  */
 std::shared_ptr<OpticalLaunchAction>
-OpticalLaunchAction::make_and_insert(CoreParams const& core,
-                                     SPConstMaterial material,
-                                     SPOffloadParams offload,
-                                     size_type num_track_slots,
-                                     size_type initializer_capacity)
+OpticalLaunchAction::make_and_insert(CoreParams const& core, Input&& input)
 {
-    CELER_EXPECT(material);
-    CELER_EXPECT(offload);
+    CELER_EXPECT(input);
     ActionRegistry& actions = *core.action_reg();
     AuxParamsRegistry& aux = *core.aux_reg();
-    auto result = std::make_shared<OpticalLaunchAction>(actions.next_id(),
-                                                        aux.next_id(),
-                                                        core,
-                                                        std::move(material),
-                                                        std::move(offload),
-                                                        num_track_slots,
-                                                        initializer_capacity);
+    auto result = std::make_shared<OpticalLaunchAction>(
+        actions.next_id(), aux.next_id(), core, std::move(input));
 
     actions.insert(result);
     aux.insert(result);
@@ -61,29 +51,26 @@ OpticalLaunchAction::make_and_insert(CoreParams const& core,
 OpticalLaunchAction::OpticalLaunchAction(ActionId action_id,
                                          AuxId data_id,
                                          CoreParams const& core,
-                                         SPConstMaterial material,
-                                         SPOffloadParams offload,
-                                         size_type num_track_slots,
-                                         size_type initializer_capacity)
+                                         Input&& input)
     : action_id_{action_id}
     , aux_id_{data_id}
-    , offload_params_{std::move(offload)}
-    , num_track_slots_{num_track_slots}
+    , offload_params_{std::move(input.offload)}
+    , state_size_{input.num_track_slots}
 {
-    CELER_EXPECT(material);
     CELER_EXPECT(offload_params_);
-    CELER_EXPECT(num_track_slots_ > 0);
-    CELER_EXPECT(initializer_capacity > 0);
+    CELER_EXPECT(state_size_ > 0);
+    CELER_EXPECT(input.material);
+    CELER_EXPECT(input.initializer_capacity > 0);
 
     // Create optical core params
     optical_params_ = std::make_shared<optical::CoreParams>([&] {
         optical::CoreParams::Input inp;
         inp.geometry = core.geometry();
-        inp.material = std::move(material);
+        inp.material = std::move(input.material);
         // TODO: unique RNG streams for optical loop
         inp.rng = core.rng();
-        inp.init
-            = std::make_shared<optical::TrackInitParams>(initializer_capacity);
+        inp.init = std::make_shared<optical::TrackInitParams>(
+            input.initializer_capacity);
         inp.action_reg = std::make_shared<ActionRegistry>();
         inp.max_streams = core.max_streams();
         CELER_ENSURE(inp);
@@ -119,12 +106,12 @@ auto OpticalLaunchAction::create_state(MemSpace m, StreamId sid, size_type) cons
     if (m == MemSpace::host)
     {
         return std::make_unique<optical::CoreState<MemSpace::host>>(
-            *optical_params_, sid, num_track_slots_);
+            *optical_params_, sid, state_size_);
     }
     else if (m == MemSpace::device)
     {
         return std::make_unique<optical::CoreState<MemSpace::device>>(
-            *optical_params_, sid, num_track_slots_);
+            *optical_params_, sid, state_size_);
     }
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -151,7 +151,7 @@ void OpticalLaunchAction::execute_impl(CoreParams const&,
     CELER_ASSERT(offload_state);
     CELER_ASSERT(optical_state.size() > 0);
 
-    constexpr size_type max_steps{2};
+    constexpr size_type max_steps{1};
     size_type remaining_steps = max_steps;
 
     // Loop while photons are yet to be tracked

--- a/src/celeritas/optical/detail/OpticalLaunchAction.hh
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.hh
@@ -54,23 +54,28 @@ class OpticalLaunchAction : public AuxParamsInterface,
     using SPConstMaterial = std::shared_ptr<optical::MaterialParams const>;
     //!@}
 
+    struct Input
+    {
+        SPConstMaterial material;
+        SPOffloadParams offload;
+        size_type num_track_slots{};
+        size_type initializer_capacity{};
+
+        //! True if all input is assigned and valid
+        explicit operator bool() const
+        {
+            return material && offload && num_track_slots > 0
+                   && initializer_capacity > 0;
+        }
+    };
+
   public:
     // Construct and add to core params
     static std::shared_ptr<OpticalLaunchAction>
-    make_and_insert(CoreParams const& core,
-                    SPConstMaterial material,
-                    SPOffloadParams offload,
-                    size_type num_track_slots,
-                    size_type initializer_capacity);
+    make_and_insert(CoreParams const&, Input&&);
 
     // Construct with IDs, core for copying params, offload gen data
-    OpticalLaunchAction(ActionId id,
-                        AuxId data_id,
-                        CoreParams const& core,
-                        SPConstMaterial material,
-                        SPOffloadParams offload,
-                        size_type num_track_slots,
-                        size_type iniitializer_capacity);
+    OpticalLaunchAction(ActionId, AuxId, CoreParams const&, Input&&);
 
     //!@{
     //! \name Aux/action metadata interface
@@ -114,7 +119,7 @@ class OpticalLaunchAction : public AuxParamsInterface,
     SPOffloadParams offload_params_;
     SPOpticalParams optical_params_;
     SPActionGroups optical_actions_;
-    size_type num_track_slots_;
+    size_type state_size_;
 
     //// HELPERS ////
 

--- a/src/celeritas/optical/detail/OpticalLaunchAction.hh
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.hh
@@ -60,7 +60,8 @@ class OpticalLaunchAction : public AuxParamsInterface,
     make_and_insert(CoreParams const& core,
                     SPConstMaterial material,
                     SPOffloadParams offload,
-                    size_type primary_capacity);
+                    size_type num_track_slots,
+                    size_type initializer_capacity);
 
     // Construct with IDs, core for copying params, offload gen data
     OpticalLaunchAction(ActionId id,
@@ -68,7 +69,8 @@ class OpticalLaunchAction : public AuxParamsInterface,
                         CoreParams const& core,
                         SPConstMaterial material,
                         SPOffloadParams offload,
-                        size_type primary_capacity);
+                        size_type num_track_slots,
+                        size_type iniitializer_capacity);
 
     //!@{
     //! \name Aux/action metadata interface
@@ -112,6 +114,7 @@ class OpticalLaunchAction : public AuxParamsInterface,
     SPOffloadParams offload_params_;
     SPOpticalParams optical_params_;
     SPActionGroups optical_actions_;
+    size_type num_track_slots_;
 
     //// HELPERS ////
 

--- a/src/celeritas/optical/detail/ScintGeneratorAction.cc
+++ b/src/celeritas/optical/detail/ScintGeneratorAction.cc
@@ -103,7 +103,8 @@ void ScintGeneratorAction::step_impl(CoreParams const& core_params,
                    << "insufficient capacity (" << initializers_size
                    << ") for optical photon initializers (total capacity "
                       "requirement of "
-                   << num_photons + num_new_photons << ")");
+                   << num_photons + num_new_photons << " and current size "
+                   << num_photons << ")");
 
     auto& offload = offload_state.store.ref();
     auto& buffer_size = offload_state.buffer_size.scintillation;

--- a/src/celeritas/optical/detail/ScintGeneratorAction.cc
+++ b/src/celeritas/optical/detail/ScintGeneratorAction.cc
@@ -122,8 +122,9 @@ void ScintGeneratorAction::step_impl(CoreParams const& core_params,
     // Generate the optical photon initializers from the distribution data
     this->generate(core_params, core_state);
 
-    CELER_LOG(debug) << "Generated " << count << " Scintillation photons from "
-                     << buffer_size << " distributions";
+    CELER_LOG_LOCAL(debug) << "Generated " << count
+                           << " Scintillation photons from " << buffer_size
+                           << " distributions";
 
     num_photons += count;
     num_new_photons -= count;

--- a/src/celeritas/optical/detail/ScintGeneratorAction.cc
+++ b/src/celeritas/optical/detail/ScintGeneratorAction.cc
@@ -11,6 +11,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/data/AuxStateVec.hh"
+#include "corecel/io/Logger.hh"
 #include "celeritas/global/ActionLauncher.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
@@ -120,6 +121,9 @@ void ScintGeneratorAction::step_impl(CoreParams const& core_params,
 
     // Generate the optical photon initializers from the distribution data
     this->generate(core_params, core_state);
+
+    CELER_LOG(debug) << "Generated " << count << " Scintillation photons from "
+                     << buffer_size << " distributions";
 
     num_photons += count;
     num_new_photons -= count;

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -509,7 +509,7 @@ TEST_F(LArSphereOffloadTest, host_generate)
     static char const* const expected_log_messages[] = {
         "Celeritas optical state initialization complete",
         "Celeritas core state initialization complete",
-        R"(Exceeded step count of 2: aborting optical transport loop with 262144 active tracks, 262144 alive tracks, 0 vacancies, and 62049 queued)",
+        R"(Exceeded step count of 1: aborting optical transport loop with 262144 active tracks, 0 alive tracks, 262144 vacancies, and 62049 queued)",
     };
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -93,8 +93,9 @@ class LArSphereOffloadTest : public LArSphereBase
     // Optical collector options
     bool use_scintillation_{true};
     bool use_cerenkov_{true};
+    size_type num_track_slots_{4096};
     size_type buffer_capacity_{256};
-    size_type primary_capacity_{8192};
+    size_type initializer_capacity_{8192};
     size_type auto_flush_{4096};
 
     std::shared_ptr<OpticalCollector> collector_;
@@ -180,8 +181,9 @@ void LArSphereOffloadTest::build_optical_collector()
     {
         inp.scintillation = this->scintillation();
     }
+    inp.num_track_slots = num_track_slots_;
     inp.buffer_capacity = buffer_capacity_;
-    inp.primary_capacity = primary_capacity_;
+    inp.initializer_capacity = initializer_capacity_;
     inp.auto_flush = auto_flush_;
 
     collector_
@@ -310,9 +312,10 @@ template LArSphereOffloadTest::RunResult
 TEST_F(LArSphereOffloadTest, host_distributions)
 {
     auto_flush_ = size_type(-1);
+    num_track_slots_ = 4;
     this->build_optical_collector();
 
-    auto result = this->run<MemSpace::host>(4, 4, 64);
+    auto result = this->run<MemSpace::host>(4, num_track_slots_, 64);
 
     EXPECT_EQ(result.cerenkov.total_num_photons
                   + result.scintillation.total_num_photons,
@@ -370,9 +373,10 @@ TEST_F(LArSphereOffloadTest, host_distributions)
 TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_distributions))
 {
     auto_flush_ = size_type(-1);
+    num_track_slots_ = 8;
     this->build_optical_collector();
 
-    auto result = this->run<MemSpace::device>(8, 8, 32);
+    auto result = this->run<MemSpace::device>(8, num_track_slots_, 32);
 
     EXPECT_EQ(result.cerenkov.total_num_photons
                   + result.scintillation.total_num_photons,
@@ -446,9 +450,10 @@ TEST_F(LArSphereOffloadTest, cerenkov_distributiona)
 {
     use_scintillation_ = false;
     auto_flush_ = size_type(-1);
+    num_track_slots_ = 4;
     this->build_optical_collector();
 
-    auto result = this->run<MemSpace::host>(4, 4, 16);
+    auto result = this->run<MemSpace::host>(4, num_track_slots_, 16);
 
     EXPECT_EQ(0, result.scintillation.total_num_photons);
     EXPECT_EQ(0, result.scintillation.num_photons.size());
@@ -469,9 +474,10 @@ TEST_F(LArSphereOffloadTest, scintillation_distributions)
 {
     use_cerenkov_ = false;
     auto_flush_ = size_type(-1);
+    num_track_slots_ = 4;
     this->build_optical_collector();
 
-    auto result = this->run<MemSpace::host>(4, 4, 16);
+    auto result = this->run<MemSpace::host>(4, num_track_slots_, 16);
 
     EXPECT_EQ(0, result.cerenkov.total_num_photons);
     EXPECT_EQ(0, result.cerenkov.num_photons.size());
@@ -490,18 +496,20 @@ TEST_F(LArSphereOffloadTest, scintillation_distributions)
 
 TEST_F(LArSphereOffloadTest, host_generate)
 {
+    num_track_slots_ = 1 << 18;
     buffer_capacity_ = 1024;
-    primary_capacity_ = 524288;
+    initializer_capacity_ = 524288;
     auto_flush_ = 16384;
     this->build_optical_collector();
 
+    // Run with 512 core track slots and 2^18 optical track slots
     ScopedLogStorer scoped_log_{&celeritas::self_logger()};
     auto result = this->run<MemSpace::host>(4, 512, 16);
 
     static char const* const expected_log_messages[] = {
         "Celeritas optical state initialization complete",
         "Celeritas core state initialization complete",
-        R"(Exceeded step count of 2: aborting optical transport loop with 512 active tracks, 512 alive tracks, 0 vacancies, and 323681 queued)",
+        R"(Exceeded step count of 2: aborting optical transport loop with 262144 active tracks, 262144 alive tracks, 0 vacancies, and 62049 queued)",
     };
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
@@ -518,13 +526,14 @@ TEST_F(LArSphereOffloadTest, host_generate)
 
 TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_generate))
 {
+    num_track_slots_ = 1024;
     buffer_capacity_ = 2048;
-    primary_capacity_ = 524288;
+    initializer_capacity_ = 524288;
     auto_flush_ = 262144;
     this->build_optical_collector();
 
     ScopedLogStorer scoped_log_{&celeritas::self_logger()};
-    auto result = this->run<MemSpace::device>(1, 1024, 16);
+    auto result = this->run<MemSpace::device>(1, num_track_slots_, 16);
     static char const* const expected_log_levels[]
         = {"status", "status", "error"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());


### PR DESCRIPTION
This lets us set the number of track slots in the optical stepping loop to something different from the core loop.