### PR TITLE
Use canonical loop form with OpenMP

### DIFF
--- a/src/celeritas/global/ActionLauncher.hh
+++ b/src/celeritas/global/ActionLauncher.hh
@@ -43,10 +43,11 @@ void launch_core(std::string_view label,
                  F&& execute_thread)
 {
     MultiExceptionHandler capture_exception;
+    size_type const size = state.size();
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
-    for (size_type i = 0; i < state.size(); ++i)
+    for (size_type i = 0; i < size; ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             execute_thread(ThreadId{i}),

--- a/src/celeritas/global/ActionLauncher.hh
+++ b/src/celeritas/global/ActionLauncher.hh
@@ -46,7 +46,7 @@ void launch_core(std::string_view label,
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
-    for (size_type i = 0, size = state.size(); i != size; ++i)
+    for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE_CONTEXT(
             execute_thread(ThreadId{i}),

--- a/src/celeritas/optical/action/ActionLauncher.hh
+++ b/src/celeritas/optical/action/ActionLauncher.hh
@@ -41,7 +41,7 @@ void launch_action(CoreState<MemSpace::host>& state, F&& execute_thread)
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
-    for (size_type i = 0, size = state.size(); i != size; ++i)
+    for (size_type i = 0; i < state.size(); ++i)
     {
         CELER_TRY_HANDLE(execute_thread(ThreadId{i}), capture_exception);
     }

--- a/src/celeritas/optical/action/ActionLauncher.hh
+++ b/src/celeritas/optical/action/ActionLauncher.hh
@@ -38,10 +38,11 @@ template<class F>
 void launch_action(CoreState<MemSpace::host>& state, F&& execute_thread)
 {
     MultiExceptionHandler capture_exception;
+    size_type const size = state.size();
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
-    for (size_type i = 0; i < state.size(); ++i)
+    for (size_type i = 0; i < size; ++i)
     {
         CELER_TRY_HANDLE(execute_thread(ThreadId{i}), capture_exception);
     }

--- a/src/celeritas/optical/action/InitializeTracksAction.cc
+++ b/src/celeritas/optical/action/InitializeTracksAction.cc
@@ -102,7 +102,7 @@ void InitializeTracksAction::step_impl(CoreParams const& params,
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
-    for (size_type i = 0; i != num_new_tracks; ++i)
+    for (size_type i = 0; i < num_new_tracks; ++i)
     {
         CELER_TRY_HANDLE(execute_thread(ThreadId{i}), capture_exception);
     }

--- a/src/celeritas/track/ExtendFromPrimariesAction.cc
+++ b/src/celeritas/track/ExtendFromPrimariesAction.cc
@@ -220,10 +220,11 @@ void ExtendFromPrimariesAction::process_primaries(
         state.ptr(),
         state.counters(),
         primaries};
+    size_type const size = primaries.size();
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
-    for (size_type i = 0; i < primaries.size(); ++i)
+    for (size_type i = 0; i < size; ++i)
     {
         CELER_TRY_HANDLE(execute_thread(ThreadId{i}), capture_exception);
     }

--- a/src/celeritas/track/ExtendFromPrimariesAction.cc
+++ b/src/celeritas/track/ExtendFromPrimariesAction.cc
@@ -223,7 +223,7 @@ void ExtendFromPrimariesAction::process_primaries(
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
-    for (size_type i = 0, size = primaries.size(); i != size; ++i)
+    for (size_type i = 0; i < primaries.size(); ++i)
     {
         CELER_TRY_HANDLE(execute_thread(ThreadId{i}), capture_exception);
     }

--- a/src/celeritas/track/InitializeTracksAction.cc
+++ b/src/celeritas/track/InitializeTracksAction.cc
@@ -116,7 +116,7 @@ void InitializeTracksAction::step_impl(CoreParams const& core_params,
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
-    for (size_type i = 0; i != num_new_tracks; ++i)
+    for (size_type i = 0; i < num_new_tracks; ++i)
     {
         CELER_TRY_HANDLE(execute_thread(ThreadId{i}), capture_exception);
     }

--- a/src/celeritas/user/detail/SimpleCaloImpl.cc
+++ b/src/celeritas/user/detail/SimpleCaloImpl.cc
@@ -29,10 +29,11 @@ void simple_calo_accum(HostRef<StepStateData> const& step,
     CELER_EXPECT(step && calo);
     MultiExceptionHandler capture_exception;
     SimpleCaloExecutor execute{step, calo};
+    size_type const size = step.size();
 #if CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
-    for (ThreadId::size_type i = 0; i < step.size(); ++i)
+    for (ThreadId::size_type i = 0; i < size; ++i)
     {
         CELER_TRY_HANDLE(execute(ThreadId{i}), capture_exception);
     }

--- a/src/corecel/sys/KernelLauncher.hh
+++ b/src/corecel/sys/KernelLauncher.hh
@@ -38,7 +38,7 @@ void launch_kernel(size_type num_threads, F&& execute_thread)
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for
 #endif
-    for (size_type i = 0; i != num_threads; ++i)
+    for (size_type i = 0; i < num_threads; ++i)
     {
         CELER_TRY_HANDLE(execute_thread(ThreadId{i}), capture_exception);
     }


### PR DESCRIPTION
OpenMP requires the for loop following a directive to be in [canonical loop form](https://www.openmp.org/spec-html/5.2/openmpsu28.html#x58-600004.4.1), which does not support multiple variables in the initialization. Versions before 5.0 also do not allow `!=` in the termination condition.