### PR TITLE
Fix/standardize multi-level.gdml file and improve debug logging

### DIFF
--- a/src/corecel/io/Logger.cc
+++ b/src/corecel/io/Logger.cc
@@ -103,15 +103,26 @@ Logger::Logger(LogHandler handle) : handle_{std::move(handle)} {}
 //---------------------------------------------------------------------------//
 /*!
  * Get the log level from an environment variable.
+ *
+ * Default to \c Logger::default_level, which is 'info'.
  */
 LogLevel log_level_from_env(std::string const& level_env)
+{
+    return log_level_from_env(level_env, Logger::default_level());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the log level from an environment variable.
+ */
+LogLevel log_level_from_env(std::string const& level_env, LogLevel default_lev)
 {
     // Search for the provided environment variable to set the default
     // logging level using the `to_cstring` function in LoggerTypes.
     std::string const& env_value = celeritas::getenv(level_env);
     if (env_value.empty())
     {
-        return Logger::default_level();
+        return default_lev;
     }
 
     auto levels = range(LogLevel::size_);

--- a/src/corecel/io/Logger.hh
+++ b/src/corecel/io/Logger.hh
@@ -141,6 +141,7 @@ auto Logger::operator()(LogProvenance&& prov, LogLevel lev) -> Message
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//
 // Get the log level from an environment variable
+LogLevel log_level_from_env(std::string const&, LogLevel default_lev);
 LogLevel log_level_from_env(std::string const&);
 
 // Create loggers with reasonable default behaviors.

--- a/src/geocel/g4/GeantGeoParams.cc
+++ b/src/geocel/g4/GeantGeoParams.cc
@@ -304,6 +304,12 @@ void GeantGeoParams::build_metadata()
         CELER_ASSERT(pv_store && !pv_store->empty());
         return pv_store->front()->GetInstanceID();
     }();
+    if (lv_offset_ != 0 || pv_offset_ != 0)
+    {
+        CELER_LOG(debug) << "Building after volume stores were cleared: "
+                         << "lv_offset=" << lv_offset_
+                         << ", pv_offset=" << pv_offset_;
+    }
 
     // Construct volume labels
     volumes_ = VolumeMap{"volume",

--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -478,12 +478,7 @@ void VecgeomParams::build_volume_tracking()
             // available in very recent VecGeom). It's bad (but not really
             // necessary?) if cudaMemcpyFromSymbol fails when accessed from
             // Celeritas
-            auto msg = world_logger()(
-                CELER_CODE_PROVENANCE,
-                (ptrs.kernel == nullptr
-                 || (bvh_symbol_ptr && (ptrs.kernel != bvh_symbol_ptr)))
-                    ? LogLevel::error
-                    : LogLevel::debug);
+            auto msg = CELER_LOG(error);
             auto msg_pointer = [&msg](auto* p) {
                 if (p)
                 {

--- a/test/accel/detail/HitManager.test.cc
+++ b/test/accel/detail/HitManager.test.cc
@@ -155,9 +155,9 @@ TEST_F(SimpleCmsTest, delete_one)
 TEST_F(SimpleCmsTest, add_duplicate)
 {
     sd_setup_.force_volumes = find_geant_volumes({"em_calorimeter"});
-    celeritas::world_logger().level(LogLevel::debug);
+    scoped_log_.level(LogLevel::debug);
     HitManager man = this->make_hit_manager();
-    celeritas::world_logger().level(Logger::default_level());
+    scoped_log_.level(Logger::default_level());
 
     EXPECT_EQ(2, man.geant_vols()->size());
     auto vnames = this->volume_names(man.celer_vols());

--- a/test/corecel/ScopedLogStorer.hh
+++ b/test/corecel/ScopedLogStorer.hh
@@ -83,6 +83,12 @@ class ScopedLogStorer
         levels_.clear();
     }
 
+    //! Get the minimum level being recorded
+    LogLevel level() const { return min_level_; }
+
+    //! Change the level to record
+    void level(LogLevel lev) { min_level_ = lev; }
+
   private:
     Logger* logger_{nullptr};
     std::unique_ptr<Logger> saved_logger_;

--- a/test/corecel/ScopedLogStorer.hh
+++ b/test/corecel/ScopedLogStorer.hh
@@ -27,6 +27,9 @@ namespace test
  * Temporarily replace the given logger with this function. This removes ANSI
  * sequences and replaces pointer-like strings with 0x0.
  *
+ * You can use the \c CELER_LOG_SCOPED environment variable to print the
+ * captured log messages as they are written.
+ *
  * \code
     ScopedLogStorer scoped_log_{&celeritas::world_logger()};
     CELER_LOG(info) << "captured";
@@ -83,6 +86,7 @@ class ScopedLogStorer
   private:
     Logger* logger_{nullptr};
     std::unique_ptr<Logger> saved_logger_;
+    LogLevel min_level_;
     VecString messages_;
     VecString levels_;
 };

--- a/test/geocel/CMakeLists.txt
+++ b/test/geocel/CMakeLists.txt
@@ -82,6 +82,7 @@ if(CELERITAS_USE_VecGeom)
       # TODO: vecgeom surface doesn't support some of these shapes
       list(APPEND _vecgeom_tests
         "FourLevelsTest.*"
+        "MultiLevelTest.*"
         "SolidsTest.*"
         "CmseTest.*"
       )
@@ -90,6 +91,7 @@ if(CELERITAS_USE_VecGeom)
   if(CELERITAS_USE_Geant4)
     list(APPEND _vecgeom_tests
       "FourLevelsGeantTest.*"
+      "MultiLevelGeantTest.*"
       "SolidsGeantTest.*"
       "ZnenvGeantTest.*"
     )

--- a/test/geocel/GenericGeoTestBase.cc
+++ b/test/geocel/GenericGeoTestBase.cc
@@ -38,6 +38,11 @@ void GenericGeoTrackingResult::print_expected()
         << repr(this->volumes)
         << ";\n"
            "EXPECT_VEC_EQ(expected_volumes, result.volumes);\n"
+           "static char const* const expected_volume_instances[] = "
+        << repr(this->volume_instances)
+        << ";\n"
+           "EXPECT_VEC_EQ(expected_volume_instances, "
+           "result.volume_instances);\n"
            "static real_type const expected_distances[] = "
         << repr(this->distances)
         << ";\n"

--- a/test/geocel/GenericGeoTestBase.hh
+++ b/test/geocel/GenericGeoTestBase.hh
@@ -26,6 +26,7 @@ namespace test
 struct GenericGeoTrackingResult
 {
     std::vector<std::string> volumes;
+    std::vector<std::string> volume_instances;
     std::vector<real_type> distances;  //!< [cm]
     std::vector<real_type> halfway_safeties;  //!< [cm]
 

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -177,6 +177,7 @@ auto GenericGeoTestBase<HP>::track(Real3 const& pos,
     TrackingResult result;
 
     GeoTrackView geo = CheckedGeoTrackView{this->make_geo_track_view(pos, dir)};
+    auto const& vol_inst = this->geometry()->volume_instances();
     real_type const inv_length = 1 / this->unit_length();
 
     if (geo.is_outside())
@@ -197,6 +198,17 @@ auto GenericGeoTestBase<HP>::track(Real3 const& pos,
     while (!geo.is_outside() && max_step > 0)
     {
         result.volumes.push_back(this->volume_name(geo));
+        if (vol_inst)
+        {
+            if (auto vi_id = geo.volume_instance_id())
+            {
+                result.volume_instances.push_back(vol_inst.at(vi_id).name);
+            }
+            else
+            {
+                result.volume_instances.push_back("---");
+            }
+        }
         auto next = geo.find_next_step();
         result.distances.push_back(next.distance * inv_length);
         if (!next.boundary)

--- a/test/geocel/data/multi-level.gdml
+++ b/test/geocel/data/multi-level.gdml
@@ -12,17 +12,16 @@
   <structure>
     <volume name="sph">
       <solidref ref="sph"/>
-        <position unit="mm" x="5" y="5"/>
     </volume>
     <volume name="box">
       <solidref ref="box"/>
       <physvol copynumber="31" name="boxsph1">
         <volumeref ref="sph"/>
-        <position unit="mm" x="25" y="25"/>
+        <position unit="mm" x="25.0" y="25.0" z="0.0"/>
       </physvol>
       <physvol copynumber="32" name="boxsph2">
         <volumeref ref="sph"/>
-        <position unit="mm" x="-25" y="-25"/>
+        <position unit="mm" x="-25.0" y="-25.0" z="0.0"/>
       </physvol>
     </volume>
     <volume name="world">
@@ -32,19 +31,19 @@
       </physvol>
       <physvol copynumber="21" name="topbox1">
         <volumeref ref="box"/>
-        <position unit="mm" x="100" y="100"/>
+        <position unit="mm" x="100.0" y="100.0" z="0.0"/>
       </physvol>
       <physvol copynumber="22" name="topbox2">
         <volumeref ref="box"/>
-        <position unit="mm" x="-100" y="100"/>
+        <position unit="mm" x="-100.0" y="100.0" z="0.0"/>
       </physvol>
       <physvol copynumber="23" name="topbox3">
         <volumeref ref="box"/>
-        <position unit="mm" x="-100" y="-100"/>
+        <position unit="mm" x="-100.0" y="-100.0" z="0.0"/>
       </physvol>
       <physvol copynumber="12" name="topsph2">
         <volumeref ref="box"/>
-        <position unit="mm" x="100" y="-100"/>
+        <position unit="mm" x="100.0" y="-100.0" z="0.0"/>
       </physvol>
     </volume>
   </structure>

--- a/test/geocel/data/multi-level.gdml
+++ b/test/geocel/data/multi-level.gdml
@@ -17,33 +17,34 @@
       <solidref ref="box"/>
       <physvol copynumber="31" name="boxsph1">
         <volumeref ref="sph"/>
-        <position unit="mm" x="25.0" y="25.0" z="0.0"/>
+        <position name="bs1_pos" unit="mm" x="25.0" y="25.0" z="0.0"/>
       </physvol>
       <physvol copynumber="32" name="boxsph2">
         <volumeref ref="sph"/>
-        <position unit="mm" x="-25.0" y="-25.0" z="0.0"/>
+        <position name="bs2_pos" unit="mm" x="-25.0" y="-25.0" z="0.0"/>
       </physvol>
     </volume>
     <volume name="world">
       <solidref ref="worldbox"/>
       <physvol copynumber="11" name="topsph1">
         <volumeref ref="sph"/>
+        <position name="ts1_pos" unit="mm" x="0.0" y="0.0" z="0.0"/>
       </physvol>
       <physvol copynumber="21" name="topbox1">
         <volumeref ref="box"/>
-        <position unit="mm" x="100.0" y="100.0" z="0.0"/>
+        <position name="tb1_pos" unit="mm" x="100.0" y="100.0" z="0.0"/>
       </physvol>
       <physvol copynumber="22" name="topbox2">
         <volumeref ref="box"/>
-        <position unit="mm" x="-100.0" y="100.0" z="0.0"/>
+        <position name="tb2_pos" unit="mm" x="-100.0" y="100.0" z="0.0"/>
       </physvol>
       <physvol copynumber="23" name="topbox3">
         <volumeref ref="box"/>
-        <position unit="mm" x="-100.0" y="-100.0" z="0.0"/>
+        <position name="tb3_pos" unit="mm" x="-100.0" y="-100.0" z="0.0"/>
       </physvol>
       <physvol copynumber="12" name="topsph2">
         <volumeref ref="box"/>
-        <position unit="mm" x="100.0" y="-100.0" z="0.0"/>
+        <position name="ts2_pos" unit="mm" x="100.0" y="-100.0" z="0.0"/>
       </physvol>
     </volume>
   </structure>

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -957,6 +957,45 @@ class MultiLevelTest : public GeantGeoTest
     std::string geometry_basename() const override { return "multi-level"; }
 };
 
+TEST_F(MultiLevelTest, accessors)
+{
+    auto const& geo = *this->geometry();
+    EXPECT_EQ(3, geo.max_depth());
+
+    auto vol_names = [&geo] {
+        auto const& vols = geo.volumes();
+        std::vector<std::string> result;
+        for (auto vid : range(VolumeId{vols.size()}))
+        {
+            result.push_back(vols.at(vid).name);
+        }
+        return result;
+    }();
+    static char const* const expected_vol_names[] = {"sph", "box", "world"};
+    EXPECT_VEC_EQ(expected_vol_names, vol_names);
+
+    auto vol_inst_names = [&geo] {
+        auto const& vols = geo.volume_instances();
+        std::vector<std::string> result;
+        for (auto viid : range(VolumeInstanceId{vols.size()}))
+        {
+            result.push_back(vols.at(viid).name);
+        }
+        return result;
+    }();
+    static char const* const expected_vol_inst_names[] = {
+        "boxsph1",
+        "boxsph2",
+        "topsph1",
+        "topbox1",
+        "topbox2",
+        "topbox3",
+        "topsph2",
+        "world_PV",
+    };
+    EXPECT_VEC_EQ(expected_vol_inst_names, vol_inst_names);
+}
+
 TEST_F(MultiLevelTest, DISABLED_level_strings)
 {
     using R2 = Array<real_type, 2>;

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -996,6 +996,62 @@ TEST_F(MultiLevelTest, accessors)
     EXPECT_VEC_EQ(expected_vol_inst_names, vol_inst_names);
 }
 
+TEST_F(MultiLevelTest, trace)
+{
+    {
+        auto result = this->track({-19.9, 7.5, 0}, {1, 0, 0});
+
+        static char const* const expected_volumes[] = {
+            "world",
+            "box",
+            "sph",
+            "box",
+            "world",
+            "box",
+            "sph",
+            "box",
+            "world",
+        };
+        EXPECT_VEC_EQ(expected_volumes, result.volumes);
+        static char const* const expected_volume_instances[] = {
+            "world_PV",
+            "topbox2",
+            "boxsph2",
+            "topbox2",
+            "world_PV",
+            "topbox1",
+            "boxsph2",
+            "topbox1",
+            "world_PV",
+        };
+        EXPECT_VEC_EQ(expected_volume_instances, result.volume_instances);
+        static real_type const expected_distances[] = {
+            2.4,
+            3,
+            4,
+            8,
+            5,
+            3,
+            4,
+            8,
+            6.5,
+        };
+        EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
+        static real_type const expected_hw_safety[] = {
+            1.2,
+            1.5,
+            2,
+            3.0990195135928,
+            2.5,
+            1.5,
+            2,
+            3.0990195135928,
+            3.25,
+        };
+        EXPECT_VEC_SOFT_EQ(expected_hw_safety, result.halfway_safeties);
+    }
+}
+
 TEST_F(MultiLevelTest, DISABLED_level_strings)
 {
     using R2 = Array<real_type, 2>;

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -963,11 +963,12 @@ TEST_F(MultiLevelTest, accessors)
     EXPECT_EQ(3, geo.max_depth());
 
     auto vol_names = [&geo] {
+        size_type const offset = 72;
         auto const& vols = geo.volumes();
         std::vector<std::string> result;
-        for (auto vid : range(VolumeId{vols.size()}))
+        for (auto vid : range(offset, vols.size()))
         {
-            result.push_back(vols.at(vid).name);
+            result.push_back(vols.at(VolumeId{vid}).name);
         }
         return result;
     }();
@@ -975,11 +976,12 @@ TEST_F(MultiLevelTest, accessors)
     EXPECT_VEC_EQ(expected_vol_names, vol_names);
 
     auto vol_inst_names = [&geo] {
+        size_type const offset = 92;
         auto const& vols = geo.volume_instances();
         std::vector<std::string> result;
-        for (auto viid : range(VolumeInstanceId{vols.size()}))
+        for (auto viid : range(offset, vols.size()))
         {
-            result.push_back(vols.at(viid).name);
+            result.push_back(vols.at(VolumeInstanceId{viid}).name);
         }
         return result;
     }();

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -644,7 +644,8 @@ TEST_F(MultiLevelTest, accessors)
         }
         return result;
     }();
-    PRINT_EXPECTED(vol_names);
+    static std::string const expected_vol_names[] = {"sph", "box", "world"};
+    EXPECT_VEC_EQ(expected_vol_names, vol_names);
 
     auto vol_inst_names = [&geo] {
         auto const& vols = geo.volume_instances();
@@ -655,7 +656,17 @@ TEST_F(MultiLevelTest, accessors)
         }
         return result;
     }();
-    PRINT_EXPECTED(vol_inst_names);
+    static std::string const expected_vol_inst_names[] = {
+        "boxsph1",
+        "boxsph2",
+        "topsph1",
+        "topbox1",
+        "topbox2",
+        "topbox3",
+        "topsph2",
+        "world_PV",
+    };
+    EXPECT_VEC_EQ(expected_vol_inst_names, vol_inst_names);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -659,6 +659,63 @@ TEST_F(MultiLevelTest, accessors)
 }
 
 //---------------------------------------------------------------------------//
+
+TEST_F(MultiLevelTest, trace)
+{
+    {
+        auto result = this->track({-19.9, 7.5, 0}, {1, 0, 0});
+
+        static char const* const expected_volumes[] = {
+            "world",
+            "box",
+            "sph",
+            "box",
+            "world",
+            "box",
+            "sph",
+            "box",
+            "world",
+        };
+        EXPECT_VEC_EQ(expected_volumes, result.volumes);
+        static char const* const expected_volume_instances[] = {
+            "world_PV",
+            "topbox2",
+            "boxsph2",
+            "topbox2",
+            "world_PV",
+            "topbox1",
+            "boxsph2",
+            "topbox1",
+            "world_PV",
+        };
+        EXPECT_VEC_EQ(expected_volume_instances, result.volume_instances);
+        static real_type const expected_distances[] = {
+            2.4,
+            3,
+            4,
+            8,
+            5,
+            3,
+            4,
+            8,
+            6.5,
+        };
+        EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
+        static real_type const expected_hw_safety[] = {
+            1.2,
+            1.5,
+            2,
+            3.0990195135928,
+            2.5,
+            1.5,
+            2,
+            3.0990195135928,
+            3.25,
+        };
+        EXPECT_VEC_SOFT_EQ(expected_hw_safety, result.halfway_safeties);
+    }
+}
+//---------------------------------------------------------------------------//
 // SOLIDS TEST
 //---------------------------------------------------------------------------//
 

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -616,6 +616,49 @@ TEST_F(FourLevelsTest, TEST_IF_CELERITAS_CUDA(device))
 }
 
 //---------------------------------------------------------------------------//
+// MULTI-LEVEL TEST
+//---------------------------------------------------------------------------//
+
+class MultiLevelTest : public VecgeomVgdmlTestBase
+{
+  public:
+    SPConstGeo build_geometry() final
+    {
+        return this->load_vgdml("multi-level.gdml");
+    }
+};
+
+//---------------------------------------------------------------------------//
+
+TEST_F(MultiLevelTest, accessors)
+{
+    auto const& geo = *this->geometry();
+    EXPECT_EQ(3, geo.max_depth());
+
+    auto vol_names = [&geo] {
+        auto const& vols = geo.volumes();
+        std::vector<std::string> result;
+        for (auto vid : range(VolumeId{vols.size()}))
+        {
+            result.push_back(vols.at(vid).name);
+        }
+        return result;
+    }();
+    PRINT_EXPECTED(vol_names);
+
+    auto vol_inst_names = [&geo] {
+        auto const& vols = geo.volume_instances();
+        std::vector<std::string> result;
+        for (auto viid : range(VolumeInstanceId{vols.size()}))
+        {
+            result.push_back(vols.at(viid).name);
+        }
+        return result;
+    }();
+    PRINT_EXPECTED(vol_inst_names);
+}
+
+//---------------------------------------------------------------------------//
 // SOLIDS TEST
 //---------------------------------------------------------------------------//
 
@@ -1213,6 +1256,58 @@ TEST_F(FourLevelsGeantTest, levels)
     geo.cross_boundary();
 
     EXPECT_EQ("[OUTSIDE]", this->all_volume_instance_names(geo));
+}
+
+//---------------------------------------------------------------------------//
+
+class MultiLevelGeantTest : public VecgeomGeantTestBase
+{
+  public:
+    SPConstGeo build_geometry() final
+    {
+        return this->load_g4_gdml("multi-level.gdml");
+    }
+};
+
+//---------------------------------------------------------------------------//
+
+TEST_F(MultiLevelGeantTest, accessors)
+{
+    auto const& geo = *this->geometry();
+    EXPECT_EQ(3, geo.max_depth());
+
+    auto vol_names = [&geo] {
+        auto const& vols = geo.volumes();
+        std::vector<std::string> result;
+        for (auto vid : range(VolumeId{vols.size()}))
+        {
+            result.push_back(vols.at(vid).name);
+        }
+        return result;
+    }();
+    static char const* const expected_vol_names[] = {"sph", "box", "world"};
+    EXPECT_VEC_EQ(expected_vol_names, vol_names);
+
+    auto vol_inst_names = [&geo] {
+        auto const& vols = geo.volume_instances();
+        std::vector<std::string> result;
+        for (auto viid : range(VolumeInstanceId{vols.size()}))
+        {
+            result.push_back(vols.at(viid).name);
+        }
+        return result;
+    }();
+    static char const* const expected_vol_inst_names[] = {
+        "topsph1",
+        "boxsph1",
+        "boxsph2",
+        "topbox1",
+        "topbox2",
+        "topbox3",
+        "topsph2",
+        "world_PV",
+    };
+    EXPECT_VEC_EQ(expected_vol_inst_names, vol_inst_names);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
The `multi-level.gdml` file worked fine through Geant4's reader but deleted most volumes when read through VecGeom's GDML reader, because the 'empty' name field was being saved as a unique and global identifier.

I added additional testing for the multilevel geometry for VecGeom and Geant4, and also added a `CELER_LOG_SCOPED` environment variable for unit testing that allows "scoped" log messages through to the user.