### PR TITLE
Fix redundant move warning

### DIFF
--- a/test/orange/g4org/ProtoConstructor.test.cc
+++ b/test/orange/g4org/ProtoConstructor.test.cc
@@ -46,7 +46,7 @@ class ProtoConstructorTest : public ::celeritas::test::Test
 
         EXPECT_TRUE(std::holds_alternative<NoTransformation>(world.transform));
         EXPECT_EQ(1, world.lv.use_count());
-        return std::move(*world.lv);
+        return *world.lv;
     }
 
     LogicalVolume load(std::string const& filename)


### PR DESCRIPTION
This is showing up as a warning with GCC 13.1.