### PR TITLE
Refactor muon bremsstrahlung angular distribution

### DIFF
--- a/doc/implementation/em-physics.rst
+++ b/doc/implementation/em-physics.rst
@@ -204,6 +204,11 @@ rejection sampling.
 
 .. doxygenclass:: celeritas::MuBremsDiffXsCalculator
 
+Muon bremsstrahlung and pair production use a simple distribution to sample the
+exiting polar angles.
+
+.. doxygenclass:: celeritas::MuBremsPPAngularDistribution
+
 Photon scattering
 -----------------
 

--- a/src/celeritas/em/distribution/MuBremsPPAngularDistribution.hh
+++ b/src/celeritas/em/distribution/MuBremsPPAngularDistribution.hh
@@ -1,0 +1,103 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/em/distribution/MuBremsPPAngularDistribution.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/math/Algorithms.hh"
+#include "celeritas/Constants.hh"
+#include "celeritas/Quantities.hh"
+#include "celeritas/random//distribution/GenerateCanonical.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Sample the polar angle for muon bremsstrahlung and pair production.
+ *
+ * The polar angle is sampled according to a simplified PDF
+ * \f[
+   f(r) \sim \frac{r}{(1 + r^2)^2}, \ r = frac{E\theta}{m}
+ * \f]
+ * by sampling
+ * \f[
+   \theta = r\frac{m}{E}
+ * \f]
+ * with
+ * \f[
+   r = \sqrt{frac{a}{1 - a}},
+   a = \xi \frac{r^2_{\text{max}}}{1 + r^2_{\text{max}}},
+   r_{\text{max}} = frac{\pi}{2} E' / m \min(1, E' / \epsilon),
+ * \f]
+ * and where \f$ m \f$ is the incident muon mass, \f$ E \f$ is incident energy,
+ * \$ \epsilon \f$ is the emitted energy, \f$ E' = E - \epsilon \f$, and \f$
+ * \xi \sim U(0,1) \f$.
+ *
+ * \note This performs the same sampling routine as in Geant4's \c
+ * G4ModifiedMephi class and documented in section 11.2.4 of the Geant4 Physics
+ * Reference (release 11.2).
+ */
+class MuBremsPPAngularDistribution
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Energy = units::MevEnergy;
+    using Mass = units::MevMass;
+    //!@}
+
+  public:
+    // Construct with incident and secondary particle quantities
+    inline CELER_FUNCTION MuBremsPPAngularDistribution(Energy inc_energy,
+                                                       Mass inc_mass,
+                                                       Energy energy);
+
+    // Sample the cosine of the polar angle of the secondary
+    template<class Engine>
+    inline CELER_FUNCTION real_type operator()(Engine& rng);
+
+  private:
+    // Incident particle Lorentz factor
+    real_type gamma_;
+    // r_max^2 / (1 + r_max^2)
+    real_type a_over_xi_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with incident and secondary particle.
+ */
+CELER_FUNCTION
+MuBremsPPAngularDistribution::MuBremsPPAngularDistribution(Energy inc_energy,
+                                                           Mass inc_mass,
+                                                           Energy energy)
+    : gamma_(1 + value_as<Energy>(inc_energy) / value_as<Mass>(inc_mass))
+{
+    real_type r_max_sq = ipow<2>(
+        gamma_ * constants::pi * real_type(0.5)
+        * min<real_type>(
+            1,
+            gamma_ * value_as<Mass>(inc_mass) / value_as<Energy>(energy) - 1));
+    a_over_xi_ = r_max_sq / (1 + r_max_sq);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample the cosine of the polar angle of the secondary.
+ */
+template<class Engine>
+CELER_FUNCTION real_type MuBremsPPAngularDistribution::operator()(Engine& rng)
+{
+    real_type a = generate_canonical(rng) * a_over_xi_;
+    return std::cos(std::sqrt(a / (1 - a)) / gamma_);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -16,8 +16,6 @@
 
 #include "corecel/cont/Range.hh"
 #include "corecel/data/Collection.hh"
-#include "corecel/data/CollectionBuilder.hh"
-#include "corecel/grid/TwodGridData.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "celeritas/em/data/ElectronBremsData.hh"
 #include "celeritas/em/executor/SeltzerBergerExecutor.hh"  // IWYU pragma: associated
@@ -26,13 +24,14 @@
 #include "celeritas/global/ActionLauncher.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/TrackExecutor.hh"
-#include "celeritas/grid/TwodGridBuilder.hh"
 #include "celeritas/io/ImportProcess.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/phys/InteractionApplier.hh"  // IWYU pragma: associated
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/ParticleView.hh"
+
+#include "detail/SBTableInserter.hh"
 
 namespace celeritas
 {
@@ -72,13 +71,11 @@ SeltzerBergerModel::SeltzerBergerModel(ActionId id,
     host_data.electron_mass = particles.get(host_data.ids.electron).mass();
 
     // Load differential cross sections
-    make_builder(&host_data.differential_xs.elements)
-        .reserve(materials.num_elements());
+    detail::SBTableInserter insert_element(&host_data.differential_xs);
     for (auto el_id : range(ElementId{materials.num_elements()}))
     {
-        auto element = materials.get(el_id);
-        this->append_table(load_sb_table(element.atomic_number()),
-                           &host_data.differential_xs);
+        AtomicNumber z = materials.get(el_id).atomic_number();
+        insert_element(load_sb_table(z));
     }
     CELER_ASSERT(host_data.differential_xs.elements.size()
                  == materials.num_elements());
@@ -143,50 +140,6 @@ void SeltzerBergerModel::step(CoreParams const&, CoreStateDevice&) const
     CELER_NOT_CONFIGURED("CUDA OR HIP");
 }
 #endif
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct differential cross section tables for a single element.
- *
- * Here, x = log of scaled incident energy (E / MeV)
- * and y = scaled exiting energy (E_gamma / E_inc)
- * and values are the cross sections.
- */
-void SeltzerBergerModel::append_table(ImportSBTable const& imported,
-                                      HostXsTables* tables) const
-{
-    CELER_EXPECT(imported);
-
-    size_type const num_x = imported.x.size();
-    size_type const num_y = imported.y.size();
-
-    SBElementTableData table;
-    table.grid = TwodGridBuilder{&tables->reals}(imported);
-
-    // Find the location of the highest cross section at each incident E
-    std::vector<size_type> argmax(num_x);
-    for (size_type i : range(num_x))
-    {
-        // Get the xs data for the given incident energy coordinate
-        real_type const* iter = &tables->reals[table.grid.at(i, 0)];
-
-        // Search for the highest cross section value
-        size_type max_el = std::max_element(iter, iter + num_y) - iter;
-        CELER_ASSERT(max_el < num_y);
-        // Save it!
-        argmax[i] = max_el;
-    }
-    table.argmax
-        = make_builder(&tables->sizes).insert_back(argmax.begin(), argmax.end());
-
-    // Add the table
-    make_builder(&tables->elements).push_back(table);
-
-    CELER_ENSURE(table.grid.x.size() == num_x);
-    CELER_ENSURE(table.grid.y.size() == num_y);
-    CELER_ENSURE(table.argmax.size() == num_x);
-    CELER_ENSURE(table.grid);
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -26,6 +26,7 @@
 #include "celeritas/global/ActionLauncher.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/TrackExecutor.hh"
+#include "celeritas/grid/TwodGridBuilder.hh"
 #include "celeritas/io/ImportProcess.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/phys/InteractionApplier.hh"  // IWYU pragma: associated
@@ -154,30 +155,16 @@ void SeltzerBergerModel::step(CoreParams const&, CoreStateDevice&) const
 void SeltzerBergerModel::append_table(ImportSBTable const& imported,
                                       HostXsTables* tables) const
 {
-    auto reals = make_builder(&tables->reals);
+    CELER_EXPECT(imported);
 
-    CELER_ASSERT(!imported.value.empty()
-                 && imported.value.size()
-                        == imported.x.size() * imported.y.size());
     size_type const num_x = imported.x.size();
     size_type const num_y = imported.y.size();
 
     SBElementTableData table;
-
-    //! \todo Refactor as a builder helper using DedupeCollectionBuilder
-
-    // Incident charged particle log energy grid
-    table.grid.x = reals.insert_back(imported.x.begin(), imported.x.end());
-
-    // Photon reduced energy grid
-    table.grid.y = reals.insert_back(imported.y.begin(), imported.y.end());
-
-    // 2D scaled DCS grid
-    table.grid.values
-        = reals.insert_back(imported.value.begin(), imported.value.end());
+    table.grid = TwodGridBuilder{&tables->reals}(imported);
 
     // Find the location of the highest cross section at each incident E
-    std::vector<size_type> argmax(table.grid.x.size());
+    std::vector<size_type> argmax(num_x);
     for (size_type i : range(num_x))
     {
         // Get the xs data for the given incident energy coordinate

--- a/src/celeritas/em/model/SeltzerBergerModel.hh
+++ b/src/celeritas/em/model/SeltzerBergerModel.hh
@@ -88,9 +88,6 @@ class SeltzerBergerModel final : public Model, public StaticConcreteAction
     CollectionMirror<SeltzerBergerData> data_;
 
     ImportedModelAdapter imported_;
-
-    using HostXsTables = HostVal<SeltzerBergerTableData>;
-    void append_table(ImportSBTable const& table, HostXsTables* tables) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/detail/SBTableInserter.hh
+++ b/src/celeritas/em/model/detail/SBTableInserter.hh
@@ -1,0 +1,105 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/em/model/detail/SBTableInserter.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/data/CollectionBuilder.hh"
+#include "celeritas/em/data/SeltzerBergerData.hh"
+#include "celeritas/grid/TwodGridBuilder.hh"
+#include "celeritas/io/ImportSBTable.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct Seltzer-Berger differential cross section data from imported data.
+ */
+class SBTableInserter
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Data = HostVal<SeltzerBergerTableData>;
+    //!@}
+
+  public:
+    // Construct with pointer to host data
+    explicit inline SBTableInserter(Data* data);
+
+    // Construct differential cross section table for a single element
+    inline void operator()(ImportSBTable const& inp);
+
+  private:
+    using Values = Collection<real_type, Ownership::value, MemSpace::host>;
+
+    TwodGridBuilder build_grid_;
+    CollectionBuilder<size_type> argmax_;
+    CollectionBuilder<SBElementTableData, MemSpace::host, ElementId> elements_;
+    Values const& reals_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with data.
+ */
+SBTableInserter::SBTableInserter(Data* data)
+    : build_grid_{&data->reals}
+    , argmax_{&data->sizes}
+    , elements_{&data->elements}
+    , reals_(data->reals)
+{
+    CELER_EXPECT(data);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct differential cross section tables for a single element.
+ *
+ * Here, x is the log of scaled incident energy (E / MeV), y is the scaled
+ * exiting energy (E_gamma / E_inc), and values are the cross sections.
+ */
+void SBTableInserter::operator()(ImportSBTable const& inp)
+{
+    CELER_EXPECT(inp);
+
+    SBElementTableData table;
+    table.grid = build_grid_(inp);
+
+    size_type const num_x = inp.x.size();
+    size_type const num_y = inp.y.size();
+
+    // Find the location of the highest cross section at each incident E
+    std::vector<size_type> argmax(num_x);
+    for (size_type i : range(num_x))
+    {
+        // Get the xs data for the given incident energy coordinate
+        real_type const* iter = &reals_[table.grid.at(i, 0)];
+
+        // Search for the highest cross section value
+        size_type max_el = std::max_element(iter, iter + num_y) - iter;
+        CELER_ASSERT(max_el < num_y);
+        // Save it!
+        argmax[i] = max_el;
+    }
+    table.argmax = argmax_.insert_back(argmax.begin(), argmax.end());
+
+    // Add the table
+    elements_.push_back(table);
+
+    CELER_ENSURE(table.grid.x.size() == num_x);
+    CELER_ENSURE(table.grid.y.size() == num_y);
+    CELER_ENSURE(table.argmax.size() == num_x);
+    CELER_ENSURE(table.grid);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/grid/TwodGridBuilder.cc
+++ b/src/celeritas/grid/TwodGridBuilder.cc
@@ -7,6 +7,8 @@
 //---------------------------------------------------------------------------//
 #include "TwodGridBuilder.hh"
 
+#include "celeritas/io/ImportPhysicsVector.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -38,6 +40,16 @@ auto TwodGridBuilder::operator()(SpanConstDbl grid_x,
                                  SpanConstDbl values) -> TwodGrid
 {
     return this->insert_impl(grid_x, grid_y, values);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add a grid from an imported physics vector.
+ */
+auto TwodGridBuilder::operator()(ImportPhysics2DVector const& pvec) -> TwodGrid
+{
+    return this->insert_impl(
+        make_span(pvec.x), make_span(pvec.y), make_span(pvec.value));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/grid/TwodGridBuilder.hh
+++ b/src/celeritas/grid/TwodGridBuilder.hh
@@ -14,6 +14,7 @@
 
 namespace celeritas
 {
+struct ImportPhysics2DVector;
 //---------------------------------------------------------------------------//
 /*!
  * Construct a generic 2D grid.
@@ -43,6 +44,9 @@ class TwodGridBuilder
     // Add a 2D grid of generic data with linear interpolation
     TwodGrid
     operator()(SpanConstDbl grid_x, SpanConstDbl grid_y, SpanConstDbl values);
+
+    // Add a grid from an imported physics vector
+    TwodGrid operator()(ImportPhysics2DVector const&);
 
   private:
     DedupeCollectionBuilder<real_type> reals_;

--- a/src/celeritas/io/ImportPhysicsVector.hh
+++ b/src/celeritas/io/ImportPhysicsVector.hh
@@ -60,7 +60,7 @@ struct ImportPhysics2DVector
 
     explicit operator bool() const
     {
-        return !x.empty() && !y.empty() && value.size() == x.size() * y.size();
+        return !value.empty() && value.size() == x.size() * y.size();
     }
 };
 

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -130,6 +130,7 @@ celeritas_add_test(decay/MuDecay.test.cc ${_needs_double})
 
 # Distributions
 celeritas_add_test(em/distribution/EnergyLossHelper.test.cc ${_fixme_single})
+celeritas_add_test(em/distribution/MuBremsPPAngularDistribution.test.cc ${_needs_double})
 celeritas_add_test(em/distribution/TsaiUrbanDistribution.test.cc ${_needs_double})
 
 # Cross section calculation

--- a/test/celeritas/em/BetheBloch.test.cc
+++ b/test/celeritas/em/BetheBloch.test.cc
@@ -251,9 +251,9 @@ TEST_F(BetheBlochTest, basic)
 TEST_F(BetheBlochTest, stress_test)
 {
     unsigned int const num_samples = 10000;
-    std::vector<real_type> avg_engine_samples;
-    std::vector<real_type> avg_energy;
-    std::vector<real_type> avg_costheta;
+    std::vector<double> avg_engine_samples;
+    std::vector<double> avg_energy;
+    std::vector<double> avg_costheta;
 
     for (real_type inc_e : {0.2, 1.0, 10.0, 1e2, 1e3, 1e4, 1e6, 1e8})
     {
@@ -262,8 +262,8 @@ TEST_F(BetheBlochTest, stress_test)
 
         RandomEngine& rng = this->rng();
         RandomEngine::size_type num_particles_sampled = 0;
-        real_type energy = 0;
-        real_type costheta = 0;
+        double energy = 0;
+        double costheta = 0;
 
         // Loop over several incident directions
         for (Real3 const& inc_dir :
@@ -300,6 +300,9 @@ TEST_F(BetheBlochTest, stress_test)
         avg_costheta.push_back(costheta / num_particles_sampled);
     }
 
+    // Looser tolerance for Windows build
+    double const tol = 1e-11;
+
     // Gold values for average number of calls to RNG
     static double const expected_avg_engine_samples[]
         = {6.0069, 6.011, 6.0185, 6.0071, 6.0002, 6, 6, 6};
@@ -325,7 +328,7 @@ TEST_F(BetheBlochTest, stress_test)
     };
 
     EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
-    EXPECT_VEC_NEAR(expected_avg_energy, avg_energy, 1e-11);
+    EXPECT_VEC_NEAR(expected_avg_energy, avg_energy, tol);
     EXPECT_VEC_SOFT_EQ(expected_avg_costheta, avg_costheta);
 }
 

--- a/test/celeritas/em/BetheBloch.test.cc
+++ b/test/celeritas/em/BetheBloch.test.cc
@@ -325,7 +325,7 @@ TEST_F(BetheBlochTest, stress_test)
     };
 
     EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
-    EXPECT_VEC_SOFT_EQ(expected_avg_energy, avg_energy);
+    EXPECT_VEC_NEAR(expected_avg_energy, avg_energy, 1e-11);
     EXPECT_VEC_SOFT_EQ(expected_avg_costheta, avg_costheta);
 }
 

--- a/test/celeritas/em/MuBetheBloch.test.cc
+++ b/test/celeritas/em/MuBetheBloch.test.cc
@@ -317,7 +317,7 @@ TEST_F(MuBetheBlochTest, stress_test)
                                                    0.060456801678551};
 
     EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
-    EXPECT_VEC_SOFT_EQ(expected_avg_energy, avg_energy);
+    EXPECT_VEC_NEAR(expected_avg_energy, avg_energy, 1e-11);
     EXPECT_VEC_SOFT_EQ(expected_avg_costheta, avg_costheta);
 }
 

--- a/test/celeritas/em/MuBetheBloch.test.cc
+++ b/test/celeritas/em/MuBetheBloch.test.cc
@@ -247,9 +247,9 @@ TEST_F(MuBetheBlochTest, basic)
 TEST_F(MuBetheBlochTest, stress_test)
 {
     unsigned int const num_samples = 10000;
-    std::vector<real_type> avg_engine_samples;
-    std::vector<real_type> avg_energy;
-    std::vector<real_type> avg_costheta;
+    std::vector<double> avg_engine_samples;
+    std::vector<double> avg_energy;
+    std::vector<double> avg_costheta;
 
     for (real_type inc_e : {0.2, 1.0, 10.0, 1e2, 1e3, 1e4, 1e6, 1e8})
     {
@@ -258,8 +258,8 @@ TEST_F(MuBetheBlochTest, stress_test)
 
         RandomEngine& rng = this->rng();
         RandomEngine::size_type num_particles_sampled = 0;
-        real_type energy = 0;
-        real_type costheta = 0;
+        double energy = 0;
+        double costheta = 0;
 
         // Loop over several incident directions
         for (Real3 const& inc_dir :
@@ -296,6 +296,9 @@ TEST_F(MuBetheBlochTest, stress_test)
         avg_costheta.push_back(costheta / num_particles_sampled);
     }
 
+    // Looser tolerance for Windows build
+    double const tol = 1e-11;
+
     // Gold values for average number of calls to RNG
     static double const expected_avg_engine_samples[]
         = {6.0069, 6.011, 6.0185, 6.0071, 6.043, 6.1304, 6.456, 6.9743};
@@ -317,7 +320,7 @@ TEST_F(MuBetheBlochTest, stress_test)
                                                    0.060456801678551};
 
     EXPECT_VEC_SOFT_EQ(expected_avg_engine_samples, avg_engine_samples);
-    EXPECT_VEC_NEAR(expected_avg_energy, avg_energy, 1e-11);
+    EXPECT_VEC_NEAR(expected_avg_energy, avg_energy, tol);
     EXPECT_VEC_SOFT_EQ(expected_avg_costheta, avg_costheta);
 }
 

--- a/test/celeritas/em/distribution/MuBremsPPAngularDistribution.test.cc
+++ b/test/celeritas/em/distribution/MuBremsPPAngularDistribution.test.cc
@@ -1,0 +1,70 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/em/distribution/MuBremsPPAngularDistribution.test.cc
+//---------------------------------------------------------------------------//
+#include "celeritas/em/distribution/MuBremsPPAngularDistribution.hh"
+
+#include <random>
+
+#include "celeritas/Constants.hh"
+#include "celeritas/Units.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+TEST(MuBremsPPAngularDistributionTest, costheta_dist)
+{
+    using Energy = units::MevEnergy;
+    using Mass = units::MevMass;
+
+    Mass muon_mass{105.6583745};
+    int num_samples = 1000;
+    std::vector<real_type> costheta;
+    std::mt19937 rng;
+
+    for (real_type inc_e : {0.1, 1.0, 1e2, 1e3, 1e6})
+    {
+        for (real_type eps : {0.001, 0.01, 0.1})
+        {
+            MuBremsPPAngularDistribution sample_costheta(
+                Energy{inc_e}, muon_mass, Energy{eps * inc_e});
+
+            real_type costheta_sum = 0;
+            for (int i = 0; i < num_samples; ++i)
+            {
+                costheta_sum += sample_costheta(rng);
+            }
+            costheta.push_back(costheta_sum / num_samples);
+        }
+    }
+
+    static double const expected_costheta[] = {
+        0.66083519018027,
+        0.66173952811755,
+        0.65245695633531,
+        0.6719537125096,
+        0.67562342951953,
+        0.65757823745541,
+        0.8155925513534,
+        0.81631291622027,
+        0.80747298359967,
+        0.98194125606697,
+        0.98314705599445,
+        0.98330789156202,
+        0.99999997035178,
+        0.99999996895068,
+        0.99999997195818,
+    };
+    EXPECT_VEC_SOFT_EQ(expected_costheta, costheta);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
This refactors the muon bremsstrahlung polar angle sampling into a separate class (which will also be used for pair production) and uses the `TwodGridBuilder` to build the SB DCS tables.