### PR TITLE
Add FourVector helper functions

### DIFF
--- a/src/celeritas/neutron/interactor/ChipsNeutronElasticInteractor.hh
+++ b/src/celeritas/neutron/interactor/ChipsNeutronElasticInteractor.hh
@@ -35,14 +35,6 @@ namespace celeritas
 class ChipsNeutronElasticInteractor
 {
   public:
-    //!@{
-    //! \name Type aliases
-    using Energy = units::MevEnergy;
-    using Mass = units::MevMass;
-    using Momentum = units::MevMomentum;
-    //!@}
-
-  public:
     // Construct from shared and state data
     inline CELER_FUNCTION
     ChipsNeutronElasticInteractor(NeutronElasticRef const& shared,
@@ -58,6 +50,9 @@ class ChipsNeutronElasticInteractor
     //// TYPES ////
 
     using UniformRealDist = UniformRealDistribution<real_type>;
+    using Energy = units::MevEnergy;
+    using Mass = units::MevMass;
+    using Momentum = units::MevMomentum;
 
     //// DATA ////
 
@@ -126,7 +121,7 @@ CELER_FUNCTION Interaction ChipsNeutronElasticInteractor::operator()(Engine& rng
     // The momentum magnitude in the c.m. frame
     real_type target_mass = value_as<Mass>(target_.nuclear_mass());
 
-    real_type cm_p = value_as<units::MevMomentum>(neutron_p_)
+    real_type cm_p = value_as<Momentum>(neutron_p_)
                      / std::sqrt(1 + ipow<2>(neutron_mass_ / target_mass)
                                  + 2 * neutron_energy_ / target_mass);
 
@@ -137,11 +132,12 @@ CELER_FUNCTION Interaction ChipsNeutronElasticInteractor::operator()(Engine& rng
     CELER_ASSERT(std::fabs(cos_theta) <= 1);
 
     // Boost to the center of mass (c.m.) frame
-    Real3 cm_mom = cm_p * from_spherical(cos_theta, sample_phi_(rng));
-    FourVector nlv1(
-        {cm_mom, std::sqrt(ipow<2>(cm_p) + ipow<2>(neutron_mass_))});
+    auto nlv1 = FourVector::from_mass_momentum(
+        Mass{neutron_mass_},
+        Momentum{cm_p},
+        from_spherical(cos_theta, sample_phi_(rng)));
 
-    FourVector lv({{0, 0, value_as<units::MevMomentum>(neutron_p_)},
+    FourVector lv({{0, 0, value_as<Momentum>(neutron_p_)},
                    neutron_energy_ + target_mass});
     boost(boost_vector(lv), &nlv1);
 

--- a/src/celeritas/neutron/interactor/detail/CascadeParticle.hh
+++ b/src/celeritas/neutron/interactor/detail/CascadeParticle.hh
@@ -30,9 +30,8 @@ struct CascadeParticle
     };
 
     ParticleType type{ParticleType::unknown};  //!< Particle type
-    units::MevMass mass;  // !< Particle mass
-    FourVector four_vec;  //!< Four momentum in natural MevMomentum and
-                          //!< MevEnergy units
+    units::MevMass mass;  //!< Particle mass
+    FourVector four_vec;  //!< Four momentum in natural units
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/FourVector.hh
+++ b/src/celeritas/phys/FourVector.hh
@@ -67,7 +67,8 @@ CELER_FUNCTION FourVector FourVector::from_mass_momentum(Mass m,
                                                          Momentum p,
                                                          Real3 const& direction)
 {
-    return {p.value() * direction, std::hypot(p.value(), m.value())};
+    return {p.value() * direction,
+            std::sqrt(ipow<2>(p.value()) + ipow<2>(m.value()))};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/FourVector.hh
+++ b/src/celeritas/phys/FourVector.hh
@@ -7,10 +7,13 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <cmath>
+
 #include "corecel/cont/Array.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "geocel/Types.hh"
+#include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
 
 namespace celeritas
@@ -20,14 +23,30 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * The momentum-energy four-vector (Lorentz vector).
+ *
+ * The units of this class are implicit: momentum is \c MevMomentum
+ * and energy is \c MevEnergy.
  */
 struct FourVector
 {
+    using Energy = units::MevEnergy;
+    using Momentum = units::MevMomentum;
+    using Mass = units::MevMass;
+
     Real3 mom{0, 0, 0};  //!< Particle momentum
     real_type energy{0};  //!< Particle total energy (\f$\sqrt{p^2 + m^2}\f$)
 
-    // Assignment operator (+=)
-    inline CELER_FUNCTION FourVector& operator+=(FourVector const& v)
+    // Construct from a particle and direction
+    template<class PTV>
+    static inline CELER_FUNCTION FourVector
+    from_particle(PTV const& particle, Real3 const& direction);
+
+    // Construct from momentum, rest mass, direction
+    static inline CELER_FUNCTION FourVector
+    from_mass_momentum(Mass m, Momentum p, Real3 const& direction);
+
+    //! In-place addition
+    CELER_FUNCTION FourVector& operator+=(FourVector const& v)
     {
         mom += v.mom;
         energy += v.energy;
@@ -37,6 +56,32 @@ struct FourVector
 
 //---------------------------------------------------------------------------//
 // INLINE UTILITY FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from rest mass, momentum, direction.
+ *
+ * Note that this uses \c std::hypot which yields more accurate answers if the
+ * magnitudes of the momentum and mass are very different.
+ */
+CELER_FUNCTION FourVector FourVector::from_mass_momentum(Mass m,
+                                                         Momentum p,
+                                                         Real3 const& direction)
+{
+    return {p.value() * direction, std::hypot(p.value(), m.value())};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a particle and direction.
+ */
+template<class PTV>
+CELER_FUNCTION FourVector FourVector::from_particle(PTV const& particle,
+                                                    Real3 const& direction)
+{
+    return {direction * value_as<Momentum>(particle.momentum()),
+            value_as<Energy>(particle.total_energy())};
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Add two four-vectors.
@@ -60,11 +105,15 @@ inline CELER_FUNCTION Real3 boost_vector(FourVector const& p)
 
 //---------------------------------------------------------------------------//
 /*!
- * Perform the Lorentz transformation (\f$ \Lambda^{\alpha}_{\beta} \f$) along
- * the boost vector (\f$ \vec{v} \f$) for a four-vector \f$ p^{\beta} \f$:
+ * Perform the Lorentz transformation along a boost vector.
  *
- * \f$ p^{\prime \beta} = \Lambda^{\alpha}_{\beta} (\vec{v}) p^{\beta} \f$.
+ * The transformation (\f$ \Lambda^{\alpha}_{\beta} \f$) along
+ * the boost vector (\f$ \vec{v} \f$) for a four-vector \f$ p^{\beta} \f$ is:
  *
+ * \f[ p^{\prime \beta} = \Lambda^{\alpha}_{\beta} (\vec{v}) p^{\beta} \f].
+ *
+ * \todo: define a boost function that takes a second FourVector for reduced
+ * register usage
  */
 inline CELER_FUNCTION void boost(Real3 const& v, FourVector* p)
 {

--- a/src/celeritas/phys/FourVector.hh
+++ b/src/celeritas/phys/FourVector.hh
@@ -60,8 +60,11 @@ struct FourVector
 /*!
  * Construct from rest mass, momentum, direction.
  *
- * Note that this uses \c std::hypot which yields more accurate answers if the
- * magnitudes of the momentum and mass are very different.
+ * Note that this could be improved by using \c std::hypot which yields more
+ * accurate answers if the magnitudes of the momentum and mass are very
+ * different. However, differences in the implementation of that function can
+ * lead to differences across platforms, compilers, and architectures, so for
+ * now we use a naive sqrt+ipow.
  */
 CELER_FUNCTION FourVector FourVector::from_mass_momentum(Mass m,
                                                          Momentum p,

--- a/src/celeritas/phys/ParticleTrackView.hh
+++ b/src/celeritas/phys/ParticleTrackView.hh
@@ -37,16 +37,22 @@ class ParticleTrackView
   public:
     //!@{
     //! \name Type aliases
-    using ParticleParamsRef = celeritas::NativeCRef<ParticleParamsData>;
-    using ParticleStateRef = celeritas::NativeRef<ParticleStateData>;
-    using Energy = units::MevEnergy;
+    using ParamsRef = celeritas::NativeCRef<ParticleParamsData>;
+    using StateRef = celeritas::NativeRef<ParticleStateData>;
     using Initializer_t = ParticleTrackInitializer;
+
+    using Charge = units::ElementaryCharge;
+    using Energy = units::MevEnergy;
+    using Mass = units::MevMass;
+    using Momentum = units::MevMomentum;
+    using MomentumSq = units::MevMomentumSq;
+    using Speed = units::LightSpeed;
     //!@}
 
   public:
     // Construct from "dynamic" state and "static" particle definitions
-    inline CELER_FUNCTION ParticleTrackView(ParticleParamsRef const& params,
-                                            ParticleStateRef const& states,
+    inline CELER_FUNCTION ParticleTrackView(ParamsRef const& params,
+                                            StateRef const& states,
                                             TrackSlotId id);
 
     // Initialize the particle
@@ -75,10 +81,10 @@ class ParticleTrackView
     CELER_FORCEINLINE_FUNCTION ParticleView particle_view() const;
 
     // Rest mass [MeV / c^2]
-    CELER_FORCEINLINE_FUNCTION units::MevMass mass() const;
+    CELER_FORCEINLINE_FUNCTION Mass mass() const;
 
     // Charge [elemental charge e+]
-    CELER_FORCEINLINE_FUNCTION units::ElementaryCharge charge() const;
+    CELER_FORCEINLINE_FUNCTION Charge charge() const;
 
     // Decay constant [1 / time]
     CELER_FORCEINLINE_FUNCTION real_type decay_constant() const;
@@ -98,20 +104,20 @@ class ParticleTrackView
     inline CELER_FUNCTION real_type beta_sq() const;
 
     // Speed [1/c]
-    inline CELER_FUNCTION units::LightSpeed speed() const;
+    inline CELER_FUNCTION Speed speed() const;
 
     // Lorentz factor [unitless]
     inline CELER_FUNCTION real_type lorentz_factor() const;
 
     // Relativistic momentum [MeV / c]
-    inline CELER_FUNCTION units::MevMomentum momentum() const;
+    inline CELER_FUNCTION Momentum momentum() const;
 
     // Relativistic momentum squared [MeV^2 / c^2]
-    inline CELER_FUNCTION units::MevMomentumSq momentum_sq() const;
+    inline CELER_FUNCTION MomentumSq momentum_sq() const;
 
   private:
-    ParticleParamsRef const& params_;
-    ParticleStateRef const& states_;
+    ParamsRef const& params_;
+    StateRef const& states_;
     TrackSlotId const track_slot_;
 };
 
@@ -122,8 +128,8 @@ class ParticleTrackView
  * Construct from dynamic and static particle properties.
  */
 CELER_FUNCTION
-ParticleTrackView::ParticleTrackView(ParticleParamsRef const& params,
-                                     ParticleStateRef const& states,
+ParticleTrackView::ParticleTrackView(ParamsRef const& params,
+                                     StateRef const& states,
                                      TrackSlotId tid)
     : params_(params), states_(states), track_slot_(tid)
 {
@@ -215,7 +221,7 @@ CELER_FUNCTION ParticleView ParticleTrackView::particle_view() const
 /*!
  * Rest mass [MeV / c^2].
  */
-CELER_FUNCTION units::MevMass ParticleTrackView::mass() const
+CELER_FUNCTION auto ParticleTrackView::mass() const -> Mass
 {
     return this->particle_view().mass();
 }
@@ -224,7 +230,7 @@ CELER_FUNCTION units::MevMass ParticleTrackView::mass() const
 /*!
  * Elementary charge.
  */
-CELER_FUNCTION units::ElementaryCharge ParticleTrackView::charge() const
+CELER_FUNCTION auto ParticleTrackView::charge() const -> Charge
 {
     return this->particle_view().charge();
 }
@@ -265,7 +271,7 @@ CELER_FUNCTION bool ParticleTrackView::is_stable() const
 CELER_FUNCTION auto ParticleTrackView::total_energy() const -> Energy
 {
     return Energy(value_as<Energy>(this->energy())
-                  + value_as<units::MevMass>(this->mass()));
+                  + value_as<Mass>(this->mass()));
 }
 
 //---------------------------------------------------------------------------//
@@ -317,7 +323,7 @@ CELER_FUNCTION real_type ParticleTrackView::beta_sq() const
  * Speed is calculated using beta so that the expression works for massless
  * particles.
  */
-CELER_FUNCTION units::LightSpeed ParticleTrackView::speed() const
+CELER_FUNCTION auto ParticleTrackView::speed() const -> Speed
 {
     return units::LightSpeed{std::sqrt(this->beta_sq())};
 }
@@ -374,12 +380,12 @@ CELER_FUNCTION real_type ParticleTrackView::lorentz_factor() const
  * p^2 = \frac{K^2}{c^2} + 2 * m * K
  * \f]
  */
-CELER_FUNCTION units::MevMomentumSq ParticleTrackView::momentum_sq() const
+CELER_FUNCTION auto ParticleTrackView::momentum_sq() const -> MomentumSq
 {
     real_type const energy = this->energy().value();
     real_type result = ipow<2>(energy) + 2 * this->mass().value() * energy;
     CELER_ENSURE(result >= 0);
-    return units::MevMomentumSq{result};
+    return MomentumSq{result};
 }
 
 //---------------------------------------------------------------------------//
@@ -388,9 +394,9 @@ CELER_FUNCTION units::MevMomentumSq ParticleTrackView::momentum_sq() const
  *
  * This is calculated by taking the root of the square of the momentum.
  */
-CELER_FUNCTION units::MevMomentum ParticleTrackView::momentum() const
+CELER_FUNCTION auto ParticleTrackView::momentum() const -> Momentum
 {
-    return units::MevMomentum{std::sqrt(this->momentum_sq().value())};
+    return Momentum{std::sqrt(this->momentum_sq().value())};
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/neutron/NeutronElastic.test.cc
+++ b/test/celeritas/neutron/NeutronElastic.test.cc
@@ -244,7 +244,7 @@ TEST_F(NeutronElasticTest, extended)
     for (auto i : range(10))
     {
         MevEnergy const inc_energy{
-            std::pow(real_type{10}, real_type{-5 + 1 * i})};
+            std::pow(real_type{10}, static_cast<real_type>(-5 + 1 * i))};
         this->set_inc_particle(pdg::neutron(), inc_energy);
         ChipsNeutronElasticInteractor interact(
             shared, this->particle_track(), this->direction(), isotope_he4);

--- a/test/celeritas/neutron/NeutronElastic.test.cc
+++ b/test/celeritas/neutron/NeutronElastic.test.cc
@@ -238,42 +238,48 @@ TEST_F(NeutronElasticTest, extended)
     RandomEngine& rng_engine = this->rng();
 
     // Produce four samples from the original incident energy/dir
-    std::vector<real_type> const expected_energy = {9.9158593229731196e-06,
-                                                    9.3982652856539062e-05,
-                                                    0.00098086065952429635,
-                                                    0.0098830010231267806,
-                                                    0.093829689366657476,
-                                                    0.96350809858199682,
-                                                    9.999775621044023,
-                                                    99.910768471827168,
-                                                    999.98224958135802,
-                                                    9999.9796839871542};
-    std::vector<real_type> const expected_angle = {0.73642517015232023,
-                                                   -0.93575721388581845,
-                                                   0.39720848171626949,
-                                                   0.63289309823793916,
-                                                   -0.98646693371059246,
-                                                   -0.15892409193659782,
-                                                   0.99930375891282708,
-                                                   0.97355882843189279,
-                                                   0.99963860089317569,
-                                                   0.99998997488584618};
+    std::vector<real_type> energy;
+    std::vector<real_type> angle;
 
-    real_type energy = 1e-5;
-    real_type const factor = 1e+1;
-    for (auto i : range(expected_energy.size()))
+    for (auto i : range(10))
     {
-        this->set_inc_particle(pdg::neutron(), MevEnergy{energy});
+        MevEnergy const inc_energy{std::pow(real_type{10}, -5 + 1 * i)};
+        this->set_inc_particle(pdg::neutron(), inc_energy);
         ChipsNeutronElasticInteractor interact(
             shared, this->particle_track(), this->direction(), isotope_he4);
         Interaction result = interact(rng_engine);
 
         // Check scattered energy and angle at each incident neutron energy
-        EXPECT_SOFT_EQ(result.energy.value(), expected_energy[i]);
-        EXPECT_SOFT_EQ(dot_product(result.direction, this->direction()),
-                       expected_angle[i]);
-        energy *= factor;
+        energy.push_back(value_as<MevEnergy>(result.energy));
+        angle.push_back(dot_product(result.direction, this->direction()));
     }
+
+    static double const expected_energy[] = {
+        9.9158593229731e-06,
+        9.3982652856539e-05,
+        0.0009808606595243,
+        0.0098830010231268,
+        0.093829689366657,
+        0.963508098582,
+        9.999775621044,
+        99.910768471827,
+        999.98224958136,
+        9999.9796839872,
+    };
+    static double const expected_angle[] = {
+        0.73642517015232,
+        -0.93575721388582,
+        0.39720848171627,
+        0.63289309823794,
+        -0.98646693371059,
+        -0.1589240919366,
+        0.99930375891283,
+        0.97355882843189,
+        0.99963860089318,
+        0.99998997488585,
+    };
+    EXPECT_VEC_SOFT_EQ(expected_energy, energy);
+    EXPECT_VEC_SOFT_EQ(expected_angle, angle);
 }
 
 TEST_F(NeutronElasticTest, stress_test)
@@ -291,18 +297,8 @@ TEST_F(NeutronElasticTest, stress_test)
     RandomEngine& rng_engine = this->rng();
 
     // Produce samples from the incident energy
-    std::vector<real_type> neutron_energy;
-    real_type const expected_energy[] = {9.6937900401599116e-05,
-                                         0.0096967590954386649,
-                                         0.96066635424842617,
-                                         99.915949160022208,
-                                         9999.9519447032781};
-    std::vector<real_type> cos_theta;
-    real_type const expected_angle[] = {-0.0062993051693811574,
-                                        0.0036712145032221713,
-                                        -0.29680452456419526,
-                                        0.97426025128623828,
-                                        0.9999755334707946};
+    std::vector<real_type> energy;
+    std::vector<real_type> angle;
 
     int const num_sample = 100;
     real_type const weight = 1.0 / static_cast<real_type>(num_sample);
@@ -327,10 +323,28 @@ TEST_F(NeutronElasticTest, stress_test)
             rng_engine.reset_count();
         }
         avg_rng_samples.push_back(sum_count / num_sample);
-        EXPECT_SOFT_EQ(weight * sum_energy, expected_energy[i]);
-        EXPECT_SOFT_EQ(weight * sum_angle, expected_angle[i]);
+        energy.push_back(weight * sum_energy);
+        angle.push_back(weight * sum_angle);
     }
+
+    static double const expected_energy[] = {
+        9.6937900401599e-05,
+        0.0096967590954387,
+        0.96066635424843,
+        99.915949160022,
+        9999.9519447033,
+    };
+    static double const expected_angle[] = {
+        -0.0062993051693812,
+        0.0036712145032222,
+        -0.2968045245642,
+        0.97426025128624,
+        0.99997553347079,
+    };
     static int const expected_avg_rng_samples[] = {4, 4, 6, 6, 6};
+
+    EXPECT_VEC_SOFT_EQ(expected_angle, angle);
+    EXPECT_VEC_SOFT_EQ(expected_energy, energy);
     EXPECT_VEC_EQ(expected_avg_rng_samples, avg_rng_samples);
 }
 

--- a/test/celeritas/neutron/NeutronElastic.test.cc
+++ b/test/celeritas/neutron/NeutronElastic.test.cc
@@ -243,7 +243,8 @@ TEST_F(NeutronElasticTest, extended)
 
     for (auto i : range(10))
     {
-        MevEnergy const inc_energy{std::pow(real_type{10}, -5 + 1 * i)};
+        MevEnergy const inc_energy{
+            std::pow(real_type{10}, real_type{-5 + 1 * i})};
         this->set_inc_particle(pdg::neutron(), inc_energy);
         ChipsNeutronElasticInteractor interact(
             shared, this->particle_track(), this->direction(), isotope_he4);

--- a/test/celeritas/phys/FourVector.test.cc
+++ b/test/celeritas/phys/FourVector.test.cc
@@ -7,45 +7,95 @@
 //---------------------------------------------------------------------------//
 #include "celeritas/phys/FourVector.hh"
 
+#include <cmath>
+
 #include "celeritas_test.hh"
 
 namespace celeritas
 {
 namespace test
 {
+
+class DummyParticleView
+{
+  public:
+    using Energy = units::MevEnergy;
+    using Mass = units::MevMass;
+    using Momentum = units::MevMomentum;
+
+    Momentum momentum() const
+    {
+        return Momentum{std::sqrt(ipow<2>(energy_) + 2 * mass_ * energy_)};
+    }
+    Energy total_energy() const { return Energy{mass_ + energy_}; }
+
+    Energy energy() const { return Energy{energy_}; }
+    Mass mass() const { return Mass{mass_}; }
+
+  private:
+    real_type mass_{0.1};
+    real_type energy_{1000};
+};
+
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
 
 TEST(FourVectorTest, basic)
 {
-    // Test addition
     FourVector a{{1, 2, 3}, 1000};
     FourVector b{{4, 5, 6}, 2000};
     FourVector c = a + b;
 
-    Real3 expected_mom = {5, 7, 9};
-    EXPECT_DOUBLE_EQ(a.energy + b.energy, c.energy);
-    EXPECT_DOUBLE_EQ(3000, c.energy);
+    Real3 const expected_mom = {5, 7, 9};
+    EXPECT_SOFT_EQ(a.energy + b.energy, c.energy);
+    EXPECT_SOFT_EQ(3000, c.energy);
     EXPECT_EQ(a.mom + b.mom, c.mom);
     EXPECT_EQ(expected_mom, c.mom);
-
-    // Test norm
     EXPECT_DOUBLE_EQ(std::sqrt(ipow<2>(c.energy) - dot_product(c.mom, c.mom)),
                      norm(c));
     EXPECT_SOFT_EQ(2999.9741665554388, norm(c));
 
-    // Test boost_vector
+    FourVector d = a;
+    d += b;
+    EXPECT_SOFT_EQ(a.energy + b.energy, d.energy);
+    EXPECT_SOFT_EQ(3000, d.energy);
+    EXPECT_EQ(a.mom + b.mom, d.mom);
+    EXPECT_EQ(expected_mom, d.mom);
+}
+
+TEST(FourVectorTest, boost_vector)
+{
+    FourVector a{{1, 2, 3}, 1000};
     Real3 expected_boost_vector = {0.001, 0.002, 0.003};
     EXPECT_VEC_SOFT_EQ(a.mom / a.energy, boost_vector(a));
     EXPECT_VEC_SOFT_EQ(expected_boost_vector, boost_vector(a));
+}
 
-    // Test boost
+TEST(FourVectorTest, boost)
+{
+    FourVector const a{{1, 2, 3}, 1000};
+    FourVector b{{4, 5, 6}, 2000};
     boost(boost_vector(a), &b);
-    Real3 expected_boosted_mom
-        = {6.0000300003150038, 9.0000600006300076, 12.000090000945011};
-    EXPECT_VEC_SOFT_EQ(expected_boosted_mom, b.mom);
+
+    EXPECT_VEC_SOFT_EQ(
+        (Real3{6.0000300003150038, 9.0000600006300076, 12.000090000945011}),
+        b.mom);
     EXPECT_SOFT_EQ(2000.0460003710041, b.energy);
+}
+
+TEST(FourVectorTest, constructors)
+{
+    DummyParticleView const p;
+
+    auto fv = FourVector::from_mass_momentum(
+        p.mass(), p.momentum(), Real3{0, 0, 1});
+    EXPECT_VEC_SOFT_EQ((Real3{0, 0, 1000.0999950005}), fv.mom);
+    EXPECT_SOFT_EQ(1000.1, fv.energy);
+
+    auto fv2 = FourVector::from_particle(p, Real3{0, 0, 1});
+    EXPECT_VEC_SOFT_EQ(fv.mom, fv2.mom);
+    EXPECT_SOFT_EQ(fv.energy, fv2.energy);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
While looking at adding CDF utilities for #1507 I noticed some common (and suboptimal) patterns for FourVector that could be simplified and clarified with helper functions.
- Add `from_particle` and `from_mass_momentum` constructors for FourVector
- Make "internal" typedefs private
- Use helper typedefs for particle class