### PR TITLE
Add a CI job for c++20

### DIFF
--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   linux:
-    name: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}"
+    name: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{ (matrix.cxx_std && matrix.cxx_std != '17') && format('-c++{0}', matrix.cxx_std) || ''}}"
     strategy:
       matrix:
         include:
@@ -23,7 +23,11 @@ jobs:
           - runner: noble
             compiler: gcc
             version: 14
-            cxx_std: [17, 20]
+            cxx_std: 17
+          - runner: noble
+            compiler: gcc
+            version: 14
+            cxx_std: 20
           - runner: focal
             compiler: clang
             version: 10
@@ -33,9 +37,13 @@ jobs:
           - runner: noble
             compiler: clang
             version: 18
-            cxx_std: [17, 20]
+            cxx_std: 17
+          - runner: noble
+            compiler: clang
+            version: 18
+            cxx_std: 20
     env:
-      GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{matrix.cxx_std != '17' && format('-c++{0}', matrix.cxx_std) || ''}}"
+      GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{ (matrix.cxx_std && matrix.cxx_std != '17') && format('-c++{0}', matrix.cxx_std) || ''}}"
       CCACHE_DIR: "${{github.workspace}}/.ccache"
       CCACHE_MAXSIZE: "100Mi"
       CMAKE_PRESET: fast

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -23,6 +23,7 @@ jobs:
           - runner: noble
             compiler: gcc
             version: 14
+            cxx_std: [17, 20]
           - runner: focal
             compiler: clang
             version: 10
@@ -32,8 +33,9 @@ jobs:
           - runner: noble
             compiler: clang
             version: 18
+            cxx_std: [17, 20]
     env:
-      GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}"
+      GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{matrix.cxx_std != '17' && format('-c++{0}', matrix.cxx_std) || ''}}"
       CCACHE_DIR: "${{github.workspace}}/.ccache"
       CCACHE_MAXSIZE: "100Mi"
       CMAKE_PRESET: fast
@@ -72,7 +74,7 @@ jobs:
       - name: Configure Celeritas
         run: |
           ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
-          cmake --preset=${CMAKE_PRESET} \
+          cmake ${{matrix.cxx_std && format('-DCMAKE_CXX_STANDARD={0} ', matrix.cxx_std) || ''}}--preset=${CMAKE_PRESET} \
             -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
               && format(';-pr.{0};', github.event.pull_request.number)
               || format(';-{0};', github.ref_name)}}"

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -121,7 +121,7 @@ jobs:
                 || steps.unittest.outcome == 'failure')
           }}
         with:
-          name: test-results-fast-${{matrix.compiler}}-${{matrix.version}}
+          name: test-results-fast-${{env.GHA_JOB_NAME}}
           path: "test-output/**/*.xml"
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   linux:
-    name: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{matrix.cxx_std && format('-c++{0}', matrix.cxx_std) || ''}}"
+    name: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{matrix.cxxstd && format('-c++{0}', matrix.cxxstd) || ''}}"
     strategy:
       matrix:
         include:
@@ -26,7 +26,7 @@ jobs:
           - runner: noble
             compiler: gcc
             version: 14
-            cxx_std: 20
+            cxxstd: 20
           - runner: focal
             compiler: clang
             version: 10
@@ -39,9 +39,9 @@ jobs:
           - runner: noble
             compiler: clang
             version: 18
-            cxx_std: 20
+            cxxstd: 20
     env:
-      GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{matrix.cxx_std && format('-c++{0}', matrix.cxx_std) || ''}}"
+      GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{matrix.cxxstd && format('-c++{0}', matrix.cxxstd) || ''}}"
       CCACHE_DIR: "${{github.workspace}}/.ccache"
       CCACHE_MAXSIZE: "100Mi"
       CMAKE_PRESET: fast
@@ -80,7 +80,8 @@ jobs:
       - name: Configure Celeritas
         run: |
           ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
-          cmake ${{matrix.cxx_std && format('-DCMAKE_CXX_STANDARD={0} ', matrix.cxx_std) || ''}}--preset=${CMAKE_PRESET} \
+          cmake --preset=${CMAKE_PRESET} \
+            ${{matrix.cxxstd && format('-DCMAKE_CXX_STANDARD={0} ', matrix.cxxstd) || ''}} \
             -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
               && format(';-pr.{0};', github.event.pull_request.number)
               || format(';-{0};', github.ref_name)}}"

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   linux:
-    name: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{ (matrix.cxx_std && matrix.cxx_std != '17') && format('-c++{0}', matrix.cxx_std) || ''}}"
+    name: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{matrix.cxx_std && format('-c++{0}', matrix.cxx_std) || ''}}"
     strategy:
       matrix:
         include:
@@ -23,7 +23,6 @@ jobs:
           - runner: noble
             compiler: gcc
             version: 14
-            cxx_std: 17
           - runner: noble
             compiler: gcc
             version: 14
@@ -37,13 +36,12 @@ jobs:
           - runner: noble
             compiler: clang
             version: 18
-            cxx_std: 17
           - runner: noble
             compiler: clang
             version: 18
             cxx_std: 20
     env:
-      GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{ (matrix.cxx_std && matrix.cxx_std != '17') && format('-c++{0}', matrix.cxx_std) || ''}}"
+      GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{matrix.cxx_std && format('-c++{0}', matrix.cxx_std) || ''}}"
       CCACHE_DIR: "${{github.workspace}}/.ccache"
       CCACHE_MAXSIZE: "100Mi"
       CMAKE_PRESET: fast


### PR DESCRIPTION
Even though we don't use c++20 yet, some clients might. Add fast CI jobs to check that we are compatible. 