### PR TITLE
Define hypotenuse function using fma

### DIFF
--- a/src/celeritas/field/RZMapField.hh
+++ b/src/celeritas/field/RZMapField.hh
@@ -78,7 +78,7 @@ CELER_FUNCTION auto RZMapField::operator()(Real3 const& pos) const -> Real3
 
     Real3 value{0, 0, 0};
 
-    real_type r = std::sqrt(ipow<2>(pos[0]) + ipow<2>(pos[1]));
+    real_type r = hypot(pos[0], pos[1]);
 
     if (!params_.valid(pos[2], r))
         return value;

--- a/src/celeritas/neutron/interactor/detail/CascadeCollider.hh
+++ b/src/celeritas/neutron/interactor/detail/CascadeCollider.hh
@@ -12,6 +12,7 @@
 #include "corecel/grid/NonuniformGrid.hh"
 #include "corecel/grid/TwodGridCalculator.hh"
 #include "corecel/grid/TwodGridData.hh"
+#include "corecel/math/Algorithms.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Quantities.hh"
@@ -208,9 +209,8 @@ CELER_FUNCTION auto CascadeCollider::operator()(Engine& rng) -> FinalState
         result[0].four_vec = fv;
     }
 
-    result[1].four_vec
-        = {{-result[0].four_vec.mom},
-           std::sqrt(ipow<2>(cm_p_) + ipow<2>(value_as<Mass>(target_.mass)))};
+    result[1].four_vec = {{-result[0].four_vec.mom},
+                          hypot(cm_p_, value_as<Mass>(target_.mass))};
 
     // Convert the final state to the lab frame
     for (auto i : range(2))

--- a/src/celeritas/phys/FourVector.hh
+++ b/src/celeritas/phys/FourVector.hh
@@ -10,6 +10,7 @@
 #include <cmath>
 
 #include "corecel/cont/Array.hh"
+#include "corecel/math/Algorithms.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "geocel/Types.hh"

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -15,6 +15,8 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 
+#include "NumericLimits.hh"
+
 #include "detail/AlgorithmsImpl.hh"
 
 #if !defined(CELER_DEVICE_SOURCE) && !defined(CELERITAS_SINCOSPI_PREFIX)
@@ -509,6 +511,31 @@ template<class T, std::enable_if_t<!std::is_floating_point<T>::value, bool> = tr
 CELER_CONSTEXPR_FUNCTION T fma(T a, T b, T y)
 {
     return a * b + y;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate a hypotenuse.
+ *
+ * To improve accuracy we could use [1].
+ *
+ * [1] C.F. Borges, An Improved Algorithm for hypot(a,b), (2019).
+ *     http://arxiv.org/abs/1904.09481 (accessed November 19, 2024).
+ */
+template<class T>
+CELER_CONSTEXPR_FUNCTION T hypot(T a, T b)
+{
+    return std::sqrt(ipow<2>(a) + ipow<2>(b));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate a hypotenuse.
+ */
+template<class T>
+CELER_CONSTEXPR_FUNCTION T hypot(T a, T b, T c)
+{
+    return std::sqrt(ipow<2>(a) + ipow<2>(b) + ipow<2>(c));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -517,6 +517,10 @@ CELER_CONSTEXPR_FUNCTION T fma(T a, T b, T y)
 /*!
  * Calculate a hypotenuse.
  *
+ * This does \em not conform to IEEE754 by returning infinity in edge cases
+ * (e.g., one argument is infinite and the other NaN). Similarly, it is not
+ * symmetric with respect to the function arguments.
+ *
  * To improve accuracy we could use [1].
  *
  * [1] C.F. Borges, An Improved Algorithm for hypot(a,b), (2019).
@@ -525,7 +529,7 @@ CELER_CONSTEXPR_FUNCTION T fma(T a, T b, T y)
 template<class T>
 CELER_CONSTEXPR_FUNCTION T hypot(T a, T b)
 {
-    return std::sqrt(ipow<2>(a) + ipow<2>(b));
+    return std::sqrt(fma(b, b, ipow<2>(a)));
 }
 
 //---------------------------------------------------------------------------//
@@ -535,7 +539,9 @@ CELER_CONSTEXPR_FUNCTION T hypot(T a, T b)
 template<class T>
 CELER_CONSTEXPR_FUNCTION T hypot(T a, T b, T c)
 {
-    return std::sqrt(ipow<2>(a) + ipow<2>(b) + ipow<2>(c));
+    T result = fma(b, b, ipow<2>(a));
+    result = fma(c, c, result);
+    return std::sqrt(result);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/ArrayUtils.hh
+++ b/src/corecel/math/ArrayUtils.hh
@@ -73,6 +73,9 @@ rotate(Array<T, 3> const& dir, Array<T, 3> const& rot);
 //---------------------------------------------------------------------------//
 /*!
  * Increment a vector by another vector multiplied by a scalar.
+ *
+ * Note that this uses \c celeritas::fma which supports types other than
+ * floating point.
  */
 template<class T, size_type N>
 CELER_FUNCTION void axpy(T a, Array<T, N> const& x, Array<T, N>* y)
@@ -87,6 +90,9 @@ CELER_FUNCTION void axpy(T a, Array<T, N> const& x, Array<T, N>* y)
 //---------------------------------------------------------------------------//
 /*!
  * Dot product of two vectors.
+ *
+ * Note that this uses \c celeritas::fma which supports types other than
+ * floating point.
  */
 template<class T, size_type N>
 CELER_FUNCTION T dot_product(Array<T, N> const& x, Array<T, N> const& y)

--- a/src/corecel/math/ArrayUtils.hh
+++ b/src/corecel/math/ArrayUtils.hh
@@ -248,7 +248,7 @@ rotate(Array<T, 3> const& dir, Array<T, 3> const& rot)
     else if (sintheta > 0)
     {
         // Avoid catastrophic roundoff error by normalizing x/y components
-        cosphi = rot[X] / std::sqrt(ipow<2>(rot[X]) + ipow<2>(rot[Y]));
+        cosphi = rot[X] / hypot(rot[X], rot[Y]);
         sinphi = std::sqrt(1 - ipow<2>(cosphi));
     }
     else

--- a/src/orange/MatrixUtils.cc
+++ b/src/orange/MatrixUtils.cc
@@ -58,6 +58,9 @@ T trace(SquareMatrix<T, 3> const& mat)
  * use strides, or multiply by constants. All matrix orderings are C-style:
  * mat[i][j] is for row i, column j .
  *
+ * Note that this uses \c celeritas::fma which supports types other than
+ * floating point.
+ *
  * \warning This implementation is limited and slow.
  */
 template<class T, size_type N>

--- a/src/orange/surf/detail/InvoluteSolver.hh
+++ b/src/orange/surf/detail/InvoluteSolver.hh
@@ -170,7 +170,7 @@ InvoluteSolver::operator()(Real3 const& pos,
 
     // Conversion constant for 2-D distance to 3-D distance
 
-    real_type convert = 1 / std::sqrt(ipow<2>(v) + ipow<2>(u));
+    real_type convert = 1 / hypot(v, u);
     u *= convert;
     v *= convert;
 

--- a/test/celeritas/field/CMSParameterizedField.hh
+++ b/test/celeritas/field/CMSParameterizedField.hh
@@ -70,7 +70,7 @@ auto CMSParameterizedField::operator()(Real3 const& pos) const -> Real3
 
     Real3 value{0., 0., 0.};
 
-    real_type r = std::sqrt(ipow<2>(pos[0]) + ipow<2>(pos[1]));
+    real_type r = hypot(pos[0], pos[1]);
     Real3 bw = this->evaluate_field(r, pos[2]);
     real_type rinv = (r > 0) ? 1 / r : 0;
 

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -386,15 +386,21 @@ TEST(MathTest, hypot)
                 if (i & (1 << 3))
                     b = 1 / b;
 
-                EXPECT_EQ(hypot(a, b), hypot(b, a))
-                    << "a=" << repr(a) << ", b=" << repr(b);
                 EXPECT_DOUBLE_EQ(std::hypot(a, b), hypot(a, b))
                     << "a=" << repr(a) << ", b=" << repr(b);
 
                 auto af = static_cast<float>(a);
                 auto bf = static_cast<float>(b);
-                EXPECT_EQ(hypot(af, bf), hypot(bf, af))
-                    << "af=" << repr(af) << ", bf=" << repr(bf);
+                if (false)
+                {
+                    // The current implementation is not symmetric
+                    EXPECT_EQ(hypot(af, bf), hypot(bf, af))
+                        << "af=" << repr(af) << ", bf=" << repr(bf)
+                        << ", exact: "
+                        << repr(static_cast<float>(
+                               std::hypot(static_cast<double>(af),
+                                          static_cast<double>(bf))));
+                }
                 EXPECT_FLOAT_EQ(std::hypot(af, bf), hypot(af, bf))
                     << "af=" << repr(af) << ", bf=" << repr(bf);
             }

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -358,6 +358,59 @@ TEST(MathTest, fma)
 
 //---------------------------------------------------------------------------//
 
+TEST(MathTest, hypot)
+{
+    static double const nums[] = {
+        1.1e-10,
+        0.456e-7,
+        0.301e-5,
+        0.6789e-3,
+        0.1,
+        3.123,
+        -0.0,
+        0.0,
+    };
+    for (double a : nums)
+    {
+        for (double b : nums)
+        {
+            for (auto i : range(1 << 4))
+            {
+                // Do combinations of flipped signs and inverted
+                if (i & (1 << 0))
+                    a = -a;
+                if (i & (1 << 1))
+                    b = -b;
+                if (i & (1 << 2))
+                    a = 1 / a;
+                if (i & (1 << 3))
+                    b = 1 / b;
+
+                EXPECT_EQ(hypot(a, b), hypot(b, a))
+                    << "a=" << repr(a) << ", b=" << repr(b);
+                EXPECT_DOUBLE_EQ(std::hypot(a, b), hypot(a, b))
+                    << "a=" << repr(a) << ", b=" << repr(b);
+
+                auto af = static_cast<float>(a);
+                auto bf = static_cast<float>(b);
+                EXPECT_EQ(hypot(af, bf), hypot(bf, af))
+                    << "af=" << repr(af) << ", bf=" << repr(bf);
+                EXPECT_FLOAT_EQ(std::hypot(af, bf), hypot(af, bf))
+                    << "af=" << repr(af) << ", bf=" << repr(bf);
+            }
+        }
+    }
+    EXPECT_DOUBLE_EQ(5.0, hypot(3.0, 4.0));
+    EXPECT_FLOAT_EQ(5.0f, hypot(3.0f, 4.0f));
+}
+
+TEST(MathTest, hypot3)
+{
+    EXPECT_DOUBLE_EQ(std::hypot(1.0, 2.0, 3.0), hypot(1.0, 2.0, 3.0));
+}
+
+//---------------------------------------------------------------------------//
+
 TEST(MathTest, ceil_div)
 {
     EXPECT_EQ(0u, ceil_div(0u, 32u));

--- a/test/orange/surf/Involute.test.cc
+++ b/test/orange/surf/Involute.test.cc
@@ -106,14 +106,14 @@ TEST(Involute, solve_intersect)
 {
     // Only testing call of solver, more extensive test in InvoluteSolver
 
-    // CCW Involute  Test
+    // CCW Involute Test
     {
         Involute invo{{1, 1}, 1.1, 1.5 * pi, ccw, 0, 1.99 * pi};
 
         real_type u = 0.9933558377574788 * std::sin(1);
         real_type v = -0.11508335932330707 * std::sin(1);
         real_type w = std::cos(1);
-        real_type convert = 1 / std::sqrt(ipow<2>(v) + ipow<2>(u));
+        real_type convert = 1 / hypot(v, u);
 
         auto dist = invo.calc_intersections(
             Real3{-5.8653259986571326, -0.30468105643505367 + 1, 0},


### PR DESCRIPTION
Following on to #1510 this adds a `hypot` function to allow us to add a platform-independent and potentially higher accuracy definition. The current implementation uses std::fma rather than ipow to reduce the number of floating point operations and registers.