### PR TITLE
Fix celer-sim MC truth ROOT output file generation during tests

### DIFF
--- a/app/celer-sim/CMakeLists.txt
+++ b/app/celer-sim/CMakeLists.txt
@@ -102,7 +102,7 @@ function(celer_sim_test test_ext gdml_inp_name hepmc3_inp_name mctruth_name)
 
   add_test(NAME "app/celer-sim-${test_ext}:cpu"
     COMMAND "${CELER_PYTHON}"
-    "${_driver}" "${_gdml_inp}" "${_hepmc3_inp}" "${mctruth_out}"
+    "${_driver}" "${_gdml_inp}" "${_hepmc3_inp}" "${_mctruth_out}"
   )
   set(_env
     "CELERITAS_EXE=$<TARGET_FILE:celer-sim>"

--- a/src/celeritas/user/RootStepWriter.cc
+++ b/src/celeritas/user/RootStepWriter.cc
@@ -83,6 +83,12 @@ RootStepWriter::RootStepWriter(SPRootFileManager root_manager,
 {
     CELER_EXPECT(root_manager_);
 
+    // Disable volume instance id selections (not implemented by this class)
+    for (auto p : range(StepPoint::size_))
+    {
+        selection_.points[p].volume_instance_ids = false;
+    }
+
     if (!filter_)
     {
         // Write all data by default

--- a/src/celeritas/user/detail/StepParams.cc
+++ b/src/celeritas/user/detail/StepParams.cc
@@ -109,16 +109,16 @@ StepParams::StepParams(AuxId aux_id,
                 temp_det.begin(), temp_det.end());
 
             host_data.nonzero_energy_deposition = nonzero_energy_deposition;
+        }
 
-            if (selection.points[StepPoint::pre].volume_instance_ids
-                || selection.points[StepPoint::post].volume_instance_ids)
-            {
-                host_data.volume_instance_depth = geo.max_depth();
-                CELER_VALIDATE(host_data.volume_instance_depth > 0,
-                               << "geometry type does not support volume "
-                                  "instance IDs: max depth is "
-                               << host_data.volume_instance_depth);
-            }
+        if (selection.points[StepPoint::pre].volume_instance_ids
+            || selection.points[StepPoint::post].volume_instance_ids)
+        {
+            host_data.volume_instance_depth = geo.max_depth();
+            CELER_VALIDATE(host_data.volume_instance_depth > 0,
+                           << "geometry type does not support volume "
+                              "instance IDs: max depth is "
+                           << host_data.volume_instance_depth);
         }
 
         return host_data;


### PR DESCRIPTION
This PR fixes a few minor bugs:
- Assign volume instance ids even when there are no detector map entries in `StepParams`.
- Disable volume instance ids in `RootStepWriter`, as these are not implemented by the class.
- Fix a typo in `app/celer-sim/CMakeLists.txt` that prevented generating mctruth output files during `celer-sim` tests.