### PR TITLE
Regenerate ROOT data for celeritas tests if missing

### DIFF
--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -458,4 +458,11 @@ add_custom_target(update-root-test-data
   DEPENDS ${_root_data}
 )
 
+if(CELERITAS_USE_Geant4 AND CELERITAS_USE_ROOT)
+  # MscTestBase and other tests require ROOT data to be generated. If they're
+  # deleted by `ninja clean`, then this dependency reconstructs them if any
+  # test in this directory is built.
+  add_dependencies(testcel_celeritas update-root-test-data)
+endif()
+
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
I propose this as a simpler alternative to #1516. As the reviewers previously described on slack, running
```console
$ ninja clean
$ ninja
$ ctest
```
fails because the ROOT files are not regenerated.

With this, ROOT data is regenerated automatically as part of `celeritas/test/all` (or specifically, the `testcel_celeritas` library) if are absent when building. Importantly, running `ninja` doesn't renew the files if they already exist.