### PR TITLE
Hotfix: Disable ROCm due to now-unsupported CI OS image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,8 +8,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # TODO: this currently includes non-GPU builds as well
-  # and won't actually run on device
+  # TODO: since we don't build on GPU systems with cuda/rocm docker,
+  # none of the tests actually run on device
   gpu:
     name: >-
       ${{format('{0}{1}{2}-{3}-{4}',
@@ -24,7 +24,7 @@ jobs:
         special: [null]
         geometry: ["orange", "vecgeom"]
         buildtype: ["debug", "ndebug"]
-        image: ["ubuntu-cuda", "centos-rocm"]
+        image: ["ubuntu-cuda"] # TODO: upgrade CI images, add ["centos-rocm"]
         exclude:
           - geometry: "vecgeom"
             image: "centos-rocm" # VecGeom not installed on HIP
@@ -51,6 +51,7 @@ jobs:
              matrix.image == 'ubuntu-cuda' && 'ci-jammy-cuda11:2023-08-02'
           || matrix.image == 'centos-rocm' && 'ci-centos7-rocm5:2022-12-14.2'
         }}
+      # TODO: I think this will be fixed if we upgrade checkout
       # See https://github.com/actions/checkout/issues/956
       options: --user root
     steps:


### PR DESCRIPTION
It looks like Github finally got rid of some long-deprecated `node` versions so currently the rocm builds are failing:
```
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```