### PR TITLE
Udate upload-artifact and download-artifact Github Actions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -126,7 +126,7 @@ jobs:
             && (steps.test.outcome == 'success'
                 || steps.test.outcome == 'failure')
           }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{matrix.image}}-${{env.CMAKE_PRESET}}
           path: "test-output/**/*.xml"

--- a/.github/workflows/pull_request_completed.yml
+++ b/.github/workflows/pull_request_completed.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download and Extract Artifacts
-      uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v6
+      uses: actions/download-artifact@v4
       with:
-        name: "(event-file|test-results-.*)"
-        name_is_regexp: true
-        run_id: ${{github.event.workflow_run.id}}
+        pattern: "(event-file|test-results-.*)"
+        merge-multiple: true
+        run-id: ${{github.event.workflow_run.id}}
         path: artifacts
     - name: Publish PR comment
       uses: EnricoMi/publish-unit-test-result-action@82082dac68ad6a19d980f8ce817e108b9f496c2a # v2.17.1


### PR DESCRIPTION
This was probably missed during an update, as everywhere else already uses `upload-artifact@v4`. [V3 will be deprecated soon](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/).