### PR TITLE
Trim export data for unit tests

### DIFF
--- a/app/celer-export-geant.cc
+++ b/app/celer-export-geant.cc
@@ -28,6 +28,7 @@
 #include "celeritas/ext/RootExporter.hh"
 #include "celeritas/ext/RootJsonDumper.hh"
 #include "celeritas/ext/ScopedRootErrorHandler.hh"
+#include "celeritas/io/ImportDataTrimmer.hh"
 
 namespace celeritas
 {
@@ -82,8 +83,15 @@ GeantPhysicsOptions load_options(std::string const& option_filename)
 void run(std::string const& gdml_filename,
          std::string const& opts_filename,
          std::string const& out_filename,
-         GeantImporter::DataSelection selection)
+         bool gen_test)
 {
+    // TODO: expose data selection to JSON users?
+    GeantImporter::DataSelection selection;
+    selection.particles = GeantImporter::DataSelection::em
+                          | GeantImporter::DataSelection::optical;
+    selection.processes = selection.particles;
+    selection.reader_data = !gen_test;
+
     // Construct options, set up Geant4, read data
     auto imported = [&] {
         GeantImporter import(
@@ -91,7 +99,21 @@ void run(std::string const& gdml_filename,
         return import(selection);
     }();
 
+    // TODO: expose trim data rather than bool 'gen_test'
+    if (gen_test)
+    {
+        ImportDataTrimmer::Input options;
+        options.max_size = 3;
+        ImportDataTrimmer trim(options);
+        trim(&imported);
+    }
+
     ScopedRootErrorHandler scoped_root_error;
+
+    if (gen_test)
+    {
+        CELER_LOG(info) << "Trimming data for testing";
+    }
 
     if (ends_with(out_filename, ".root"))
     {
@@ -164,17 +186,12 @@ int main(int argc, char* argv[])
         return 2;
     }
 
-    GeantImporter::DataSelection selection;
-    selection.particles = GeantImporter::DataSelection::em
-                          | GeantImporter::DataSelection::optical;
-    selection.processes = selection.particles;
-    selection.reader_data = true;
-
+    bool gen_test{false};
     if (args.size() == 4)
     {
         if (args.back() == "--gen-test")
         {
-            selection.reader_data = false;
+            gen_test = true;
         }
         else
         {
@@ -186,7 +203,7 @@ int main(int argc, char* argv[])
 
     try
     {
-        run(args[0], args[1], args[2], selection);
+        run(args[0], args[1], args[2], gen_test);
     }
     catch (RuntimeError const& e)
     {

--- a/app/celer-export-geant.cc
+++ b/app/celer-export-geant.cc
@@ -103,7 +103,7 @@ void run(std::string const& gdml_filename,
     if (gen_test)
     {
         ImportDataTrimmer::Input options;
-        options.max_size = 3;
+        options.mupp = true;
         ImportDataTrimmer trim(options);
         trim(&imported);
     }

--- a/app/celer-export-geant.cc
+++ b/app/celer-export-geant.cc
@@ -105,7 +105,7 @@ void run(std::string const& gdml_filename,
         ImportDataTrimmer::Input options;
         options.mupp = true;
         ImportDataTrimmer trim(options);
-        trim(&imported);
+        trim(imported);
     }
 
     ScopedRootErrorHandler scoped_root_error;

--- a/doc/development/style.rst
+++ b/doc/development/style.rst
@@ -177,8 +177,11 @@ underscores). Prefer enumerations to boolean values in function interfaces
 definition to understand).
 
 
-Function arguments and return values
-------------------------------------
+Function inputs and outputs
+---------------------------
+
+The following rules are mostly derived from the `Google style guide`_, so refer
+to that reference if not specified here.
 
 - Always pass value types for arguments when the data is small (``sizeof(arg)
   <= sizeof(void*)``). Using values instead of pointers/references allows the
@@ -186,24 +189,25 @@ Function arguments and return values
   make a local copy anyway, it's OK to make the function argument a value (and
   use ``std::move`` internally as needed, but this is a more complicated
   topic).
-- In general, avoid ``const`` values (e.g. ``const int``), because the decision
-  to modify a local variable or not is an implementation detail of the
-  function, not part of its interface.
 - Use const *references* for types that are nontrivial and that you only need
   to access or pass to other const-reference functions.
-- Prefer return values or structs rather than mutable function arguments. This
+- Prefer return values or structs rather return-by-reference. This
   makes it clear that there are no preconditions on the input value's state.
-- In Celeritas we use the google style of passing mutable pointers instead of
-  mutable references, so that it's more obvious to the calling code that a
-  value is going to be modified. Add ``CELER_EXPECT(input);`` to make it clear
-  that the pointer needs to be valid, and add any other preconditions.
+- In Celeritas we *formerly* used the google style of passing mutable pointers
+  instead of mutable references, so that it's more obvious to the calling code
+  that a value is going to be modified. The Google style changed and this has
+  fallen out of favor; **USE REFERENCES** except for the very rare case of
+  *optional* return values.
 - Host-only (e.g., runtime setup) code should almost never return raw pointers;
   use shared pointers instead to make the ownership semantics clear. When
   interfacing with older libraries such as Geant4, try to use ``unique_ptr``
   and its ``release``/``get`` semantics to indicate the transfer of pointer
   ownership.
-- Since we don't yet support C++17's ``string_view`` it's OK to use ``const
-  char*`` to indicate a read-only string.
+- Avoid ``const`` *values* (e.g. ``const int``), because the decision
+  to modify a local variable or not is an implementation detail of the
+  function, not part of its interface. Clang-tidy will warn about this.
+
+.. _Google style guide: https://google.github.io/styleguide/cppguide.html#Inputs_and_Outputs
 
 Memory is always managed from host code, since on-device data management can be
 tricky, proprietary, and inefficient. There are no shared or unique pointers,

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -57,6 +57,7 @@ list(APPEND SOURCES
   grid/ValueGridType.cc
   io/AtomicRelaxationReader.cc
   io/ImportData.cc
+  io/ImportDataTrimmer.cc
   io/ImportMaterial.cc
   io/ImportModel.cc
   io/ImportOpticalModel.cc

--- a/src/celeritas/ext/RootInterfaceLinkDef.h
+++ b/src/celeritas/ext/RootInterfaceLinkDef.h
@@ -44,7 +44,6 @@
 #pragma link C++ class celeritas::ImportProcess+;
 #pragma link C++ class celeritas::ImportProductionCut+;
 #pragma link C++ class celeritas::ImportRegion+;
-#pragma link C++ class celeritas::ImportSBTable+;
 #pragma link C++ class celeritas::ImportScintComponent+;
 #pragma link C++ class celeritas::ImportScintData+;
 #pragma link C++ class celeritas::ImportTransParameters+;

--- a/src/celeritas/io/ImportData.cc
+++ b/src/celeritas/io/ImportData.cc
@@ -28,8 +28,8 @@ void convert_to_native(ImportData* data)
     // Convert data
     if (data->units.empty())
     {
-        CELER_LOG(warning) << "Unit system missing from import data: assuming "
-                              "CGS";
+        CELER_LOG(warning)
+            << R"(Unit system missing from import data: assuming CGS)";
         data->units = to_cstring(UnitSystem::cgs);
     }
 

--- a/src/celeritas/io/ImportData.hh
+++ b/src/celeritas/io/ImportData.hh
@@ -20,7 +20,6 @@
 #include "ImportParameters.hh"
 #include "ImportParticle.hh"
 #include "ImportProcess.hh"
-#include "ImportSBTable.hh"
 #include "ImportVolume.hh"
 // IWYU pragma: end_exports
 
@@ -58,7 +57,7 @@ struct ImportData
     //! \name Type aliases
     using ZInt = int;
     using GeoMatIndex = unsigned int;
-    using ImportSBMap = std::map<ZInt, ImportSBTable>;
+    using ImportSBMap = std::map<ZInt, ImportPhysics2DVector>;
     using ImportLivermorePEMap = std::map<ZInt, ImportLivermorePE>;
     using ImportAtomicRelaxationMap = std::map<ZInt, ImportAtomicRelaxation>;
     using ImportNeutronElasticMap = std::map<ZInt, ImportPhysicsVector>;

--- a/src/celeritas/io/ImportDataTrimmer.cc
+++ b/src/celeritas/io/ImportDataTrimmer.cc
@@ -7,6 +7,9 @@
 //---------------------------------------------------------------------------//
 #include "ImportDataTrimmer.hh"
 
+#include <algorithm>
+#include <utility>
+
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
 
@@ -15,11 +18,11 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 struct ImportDataTrimmer::GridFilterer
 {
-    std::size_t stride;
-    std::size_t orig_size;
+    size_type stride;
+    size_type orig_size;
 
     // Whether to keep the data at this index
-    inline bool operator()(std::size_t i) const;
+    inline bool operator()(size_type i) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -362,7 +365,7 @@ void ImportDataTrimmer::operator()(std::map<K, T, C, A>* m)
 /*!
  * Whether to keep the data at this index.
  */
-auto ImportDataTrimmer::make_filterer(std::size_t vec_size) const -> GridFilterer
+auto ImportDataTrimmer::make_filterer(size_type vec_size) const -> GridFilterer
 {
     auto stride = vec_size >= 2 ? vec_size / (options_.max_size - 1) : 1;
 
@@ -373,7 +376,7 @@ auto ImportDataTrimmer::make_filterer(std::size_t vec_size) const -> GridFiltere
 /*!
  * Whether to keep the data at this index.
  */
-bool ImportDataTrimmer::GridFilterer::operator()(std::size_t i) const
+bool ImportDataTrimmer::GridFilterer::operator()(size_type i) const
 {
     return i % stride == 0 || i + 1 == orig_size;
 }

--- a/src/celeritas/io/ImportDataTrimmer.cc
+++ b/src/celeritas/io/ImportDataTrimmer.cc
@@ -41,6 +41,8 @@ void ImportDataTrimmer::operator()(ImportData* data)
         (*this)(&data->geo_materials);
         (*this)(&data->phys_materials);
         (*this)(&data->optical_materials);
+        (*this)(&data->neutron_elastic_data);
+        (*this)(&data->atomic_relaxation_data);
     }
 
     if (options_.physics)
@@ -50,6 +52,11 @@ void ImportDataTrimmer::operator()(ImportData* data)
         (*this)(&data->msc_models);
         (*this)(&data->regions);
         (*this)(&data->volumes);
+    }
+
+    if (options_.mupp)
+    {
+        (*this)(&data->mu_pair_production_data);
     }
 
     for (auto& e : data->elements)
@@ -79,9 +86,15 @@ void ImportDataTrimmer::operator()(ImportData* data)
 
     (*this)(&data->sb_data);
     (*this)(&data->livermore_pe_data);
-    (*this)(&data->neutron_elastic_data);
-    (*this)(&data->atomic_relaxation_data);
-    (*this)(&data->mu_pair_production_data);
+
+    if (this->options_.physics)
+    {
+        for (auto&& kv : data->neutron_elastic_data)
+        {
+            (*this)(&kv.second);
+        }
+        // TODO: trim relaxation shells
+    }
 
     for (auto& m : data->optical_models)
     {
@@ -305,8 +318,14 @@ void ImportDataTrimmer::operator()(std::vector<T>* vec)
 {
     CELER_EXPECT(vec);
 
+    if (options_.max_size == numeric_limits<size_type>::max())
+    {
+        // Don't trim
+        return;
+    }
+
     std::vector<T> result;
-    result.reserve(options_.max_size);
+    result.reserve(std::min(options_.max_size + 1, vec->size()));
 
     auto filter = this->make_filterer(vec->size());
     for (auto i : range(vec->size()))

--- a/src/celeritas/io/ImportDataTrimmer.cc
+++ b/src/celeritas/io/ImportDataTrimmer.cc
@@ -39,75 +39,50 @@ void ImportDataTrimmer::operator()(ImportData* data)
 {
     if (options_.materials)
     {
+        // Reduce the number of materials, elements, etc.
         (*this)(&data->isotopes);
         (*this)(&data->elements);
         (*this)(&data->geo_materials);
         (*this)(&data->phys_materials);
-        (*this)(&data->optical_materials);
+
+        (*this)(&data->regions);
+        (*this)(&data->volumes);
+
+        (*this)(&data->sb_data);
+        (*this)(&data->livermore_pe_data);
         (*this)(&data->neutron_elastic_data);
         (*this)(&data->atomic_relaxation_data);
+
+        (*this)(&data->optical_materials);
     }
 
     if (options_.physics)
     {
+        // Reduce the number of physics processes
         (*this)(&data->particles);
         (*this)(&data->processes);
         (*this)(&data->msc_models);
-        (*this)(&data->regions);
-        (*this)(&data->volumes);
     }
 
     if (options_.mupp)
     {
+        // Reduce the resolution of the muon pair production table
         (*this)(&data->mu_pair_production_data);
     }
 
-    for (auto& e : data->elements)
-    {
-        (*this)(&e);
-    }
+    this->for_each(&data->elements);
+    this->for_each(&data->geo_materials);
+    this->for_each(&data->phys_materials);
 
-    for (auto& m : data->geo_materials)
-    {
-        (*this)(&m);
-    }
+    this->for_each(&data->processes);
+    this->for_each(&data->msc_models);
+    this->for_each(&data->sb_data);
+    this->for_each(&data->livermore_pe_data);
+    this->for_each(&data->neutron_elastic_data);
+    this->for_each(&data->atomic_relaxation_data);
 
-    for (auto& m : data->phys_materials)
-    {
-        (*this)(&m);
-    }
-
-    for (auto& p : data->processes)
-    {
-        (*this)(&p);
-    }
-
-    for (auto& m : data->msc_models)
-    {
-        (*this)(&m);
-    }
-
-    (*this)(&data->sb_data);
-    (*this)(&data->livermore_pe_data);
-
-    if (this->options_.physics)
-    {
-        for (auto&& kv : data->neutron_elastic_data)
-        {
-            (*this)(&kv.second);
-        }
-        // TODO: trim relaxation shells
-    }
-
-    for (auto& m : data->optical_models)
-    {
-        (*this)(&m);
-    }
-
-    for (auto& m : data->optical_materials)
-    {
-        (*this)(&m);
-    }
+    this->for_each(&data->optical_models);
+    this->for_each(&data->optical_materials);
 }
 
 //---------------------------------------------------------------------------//
@@ -158,10 +133,7 @@ void ImportDataTrimmer::operator()(ImportOpticalModel* data)
         (*this)(&data->mfp_table);
     }
 
-    for (auto& mfp_grid : data->mfp_table)
-    {
-        (*this)(&mfp_grid);
-    }
+    this->for_each(data->mfp_table);
 }
 
 //---------------------------------------------------------------------------//
@@ -176,10 +148,7 @@ void ImportDataTrimmer::operator()(ImportModelMaterial* data)
         (*this)(&data->micro_xs);
     }
 
-    for (auto& xs_vec : data->micro_xs)
-    {
-        (*this)(&xs_vec);
-    }
+    this->for_each(data->micro_xs);
 }
 
 //---------------------------------------------------------------------------//
@@ -192,10 +161,7 @@ void ImportDataTrimmer::operator()(ImportModel* data)
         (*this)(&data->materials);
     }
 
-    for (auto& mm : data->materials)
-    {
-        (*this)(&mm);
-    }
+    this->for_each(data->materials);
 }
 
 //---------------------------------------------------------------------------//
@@ -219,10 +185,7 @@ void ImportDataTrimmer::operator()(ImportMuPairProductionTable* data)
     (*this)(&data->atomic_number);
     (*this)(&data->physics_vectors);
 
-    for (auto& pv : data->physics_vectors)
-    {
-        (*this)(&pv);
-    }
+    this->for_each(&data->physics_vectors);
 
     CELER_ENSURE(*data);
 }
@@ -247,15 +210,8 @@ void ImportDataTrimmer::operator()(ImportProcess* data)
         (*this)(&data->models);
     }
 
-    for (auto& m : data->models)
-    {
-        (*this)(&m);
-    }
-
-    for (auto& t : data->tables)
-    {
-        (*this)(&t);
-    }
+    this->for_each(&data->models);
+    this->for_each(&data->tables);
 
     CELER_ENSURE(*data);
 }
@@ -277,10 +233,7 @@ void ImportDataTrimmer::operator()(ImportPhysicsTable* data)
         (*this)(&data->physics_vectors);
     }
 
-    for (auto& pv : data->physics_vectors)
-    {
-        (*this)(&pv);
-    }
+    this->for_each(&data->physics_vectors);
 }
 
 //---------------------------------------------------------------------------//
@@ -316,6 +269,9 @@ void ImportDataTrimmer::operator()(ImportPhysics2DVector* data)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Trim the number of elements in a vector.
+ */
 template<class T>
 void ImportDataTrimmer::operator()(std::vector<T>* vec)
 {
@@ -342,6 +298,9 @@ void ImportDataTrimmer::operator()(std::vector<T>* vec)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Trim the number of elements in a map.
+ */
 template<class K, class T, class C, class A>
 void ImportDataTrimmer::operator()(std::map<K, T, C, A>* m)
 {
@@ -363,7 +322,37 @@ void ImportDataTrimmer::operator()(std::map<K, T, C, A>* m)
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether to keep the data at this index.
+ * Trim each element in a vector.
+ */
+template<class T>
+void ImportDataTrimmer::for_each(std::vector<T>* vec)
+{
+    CELER_EXPECT(vec);
+
+    for (auto& v : *vec)
+    {
+        (*this)(&v);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Trim each value in a map.
+ */
+template<class K, class T, class C, class A>
+void ImportDataTrimmer::for_each(std::map<K, T, C, A>* m)
+{
+    CELER_EXPECT(m);
+
+    for (auto&& kv : *m)
+    {
+        (*this)(&kv.second);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a filtering object.
  */
 auto ImportDataTrimmer::make_filterer(size_type vec_size) const -> GridFilterer
 {

--- a/src/celeritas/io/ImportDataTrimmer.cc
+++ b/src/celeritas/io/ImportDataTrimmer.cc
@@ -110,9 +110,13 @@ void ImportDataTrimmer::operator()(ImportPhysMaterial&)
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportOpticalMaterial&)
+void ImportDataTrimmer::operator()(ImportOpticalMaterial& data)
 {
-    // TODO: trim WLS components?
+    if (options_.physics)
+    {
+        (*this)(data.properties.refractive_index);
+        // TODO: trim WLS components?
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/io/ImportDataTrimmer.cc
+++ b/src/celeritas/io/ImportDataTrimmer.cc
@@ -1,0 +1,363 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/io/ImportDataTrimmer.cc
+//---------------------------------------------------------------------------//
+#include "ImportDataTrimmer.hh"
+
+#include "corecel/Assert.hh"
+#include "corecel/cont/Range.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+struct ImportDataTrimmer::GridFilterer
+{
+    std::size_t stride;
+    std::size_t orig_size;
+
+    // Whether to keep the data at this index
+    inline bool operator()(std::size_t i) const;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from input parameters.
+ */
+ImportDataTrimmer::ImportDataTrimmer(Input const& inp) : options_{inp}
+{
+    CELER_EXPECT(options_.max_size >= 2);
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportData* data)
+{
+    if (options_.materials)
+    {
+        (*this)(&data->isotopes);
+        (*this)(&data->elements);
+        (*this)(&data->geo_materials);
+        (*this)(&data->phys_materials);
+        (*this)(&data->optical_materials);
+    }
+
+    if (options_.physics)
+    {
+        (*this)(&data->particles);
+        (*this)(&data->processes);
+        (*this)(&data->msc_models);
+        (*this)(&data->regions);
+        (*this)(&data->volumes);
+    }
+
+    for (auto& e : data->elements)
+    {
+        (*this)(&e);
+    }
+
+    for (auto& m : data->geo_materials)
+    {
+        (*this)(&m);
+    }
+
+    for (auto& m : data->phys_materials)
+    {
+        (*this)(&m);
+    }
+
+    for (auto& p : data->processes)
+    {
+        (*this)(&p);
+    }
+
+    for (auto& m : data->msc_models)
+    {
+        (*this)(&m);
+    }
+
+    (*this)(&data->sb_data);
+    (*this)(&data->livermore_pe_data);
+    (*this)(&data->neutron_elastic_data);
+    (*this)(&data->atomic_relaxation_data);
+    (*this)(&data->mu_pair_production_data);
+
+    for (auto& m : data->optical_models)
+    {
+        (*this)(&m);
+    }
+
+    for (auto& m : data->optical_materials)
+    {
+        (*this)(&m);
+    }
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportElement* data)
+{
+    CELER_EXPECT(data);
+
+    if (options_.materials)
+    {
+        (*this)(&data->isotopes_fractions);
+    }
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportGeoMaterial* data)
+{
+    CELER_EXPECT(data);
+
+    if (options_.materials)
+    {
+        (*this)(&data->elements);
+    }
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportPhysMaterial* data)
+{
+    CELER_EXPECT(data);
+
+    // TODO: remap IDs?
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportOpticalMaterial* data)
+{
+    CELER_EXPECT(data);
+
+    // TODO: trim WLS components?
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportOpticalModel* data)
+{
+    CELER_EXPECT(data);
+
+    if (options_.materials)
+    {
+        (*this)(&data->mfp_table);
+    }
+
+    for (auto& mfp_grid : data->mfp_table)
+    {
+        (*this)(&mfp_grid);
+    }
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportModelMaterial* data)
+{
+    CELER_EXPECT(data);
+
+    (*this)(&data->energy);
+
+    if (options_.materials)
+    {
+        (*this)(&data->micro_xs);
+    }
+
+    for (auto& xs_vec : data->micro_xs)
+    {
+        (*this)(&xs_vec);
+    }
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportModel* data)
+{
+    CELER_EXPECT(data);
+
+    if (options_.materials)
+    {
+        (*this)(&data->materials);
+    }
+
+    for (auto& mm : data->materials)
+    {
+        (*this)(&mm);
+    }
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportMscModel* data)
+{
+    CELER_EXPECT(data);
+
+    (*this)(&data->xs_table);
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportMuPairProductionTable* data)
+{
+    CELER_EXPECT(data);
+
+    if (!*data)
+    {
+        return;
+    }
+
+    (*this)(&data->atomic_number);
+    (*this)(&data->physics_vectors);
+
+    for (auto& pv : data->physics_vectors)
+    {
+        (*this)(&pv);
+    }
+
+    CELER_ENSURE(*data);
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportParticle* data)
+{
+    CELER_EXPECT(data);
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportProcess* data)
+{
+    CELER_EXPECT(data);
+
+    if (options_.materials)
+    {
+        (*this)(&data->tables);
+    }
+    if (options_.physics)
+    {
+        (*this)(&data->models);
+    }
+
+    for (auto& m : data->models)
+    {
+        (*this)(&m);
+    }
+
+    for (auto& t : data->tables)
+    {
+        (*this)(&t);
+    }
+
+    CELER_ENSURE(*data);
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportPhysicsVector* data)
+{
+    CELER_EXPECT(data);
+    (*this)(&data->x);
+    (*this)(&data->y);
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportPhysicsTable* data)
+{
+    CELER_EXPECT(data);
+    if (options_.materials)
+    {
+        (*this)(&data->physics_vectors);
+    }
+
+    for (auto& pv : data->physics_vectors)
+    {
+        (*this)(&pv);
+    }
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportPhysics2DVector* data)
+{
+    auto x_filter = this->make_filterer(data->x.size());
+    auto y_filter = this->make_filterer(data->y.size());
+
+    // Trim x and y grid
+    (*this)(&data->x);
+    (*this)(&data->y);
+
+    std::vector<double> new_value;
+    new_value.reserve(data->x.size() * data->y.size());
+
+    auto src = data->value.cbegin();
+    for (auto i : range(x_filter.orig_size))
+    {
+        for (auto j : range(y_filter.orig_size))
+        {
+            if (x_filter(i) && y_filter(j))
+            {
+                new_value.push_back(*src);
+            }
+            ++src;
+        }
+    }
+    CELER_ASSERT(src == data->value.cend());
+
+    data->value = std::move(new_value);
+
+    CELER_ENSURE(*data);
+}
+
+//---------------------------------------------------------------------------//
+template<class T>
+void ImportDataTrimmer::operator()(std::vector<T>* vec)
+{
+    CELER_EXPECT(vec);
+
+    std::vector<T> result;
+    result.reserve(options_.max_size);
+
+    auto filter = this->make_filterer(vec->size());
+    for (auto i : range(vec->size()))
+    {
+        if (filter(i))
+        {
+            result.push_back((*vec)[i]);
+        }
+    }
+    *vec = std::move(result);
+}
+
+//---------------------------------------------------------------------------//
+template<class K, class T, class C, class A>
+void ImportDataTrimmer::operator()(std::map<K, T, C, A>* m)
+{
+    CELER_EXPECT(m);
+
+    std::map<K, T, C, A> result;
+    auto filter = this->make_filterer(m->size());
+    auto iter = m->begin();
+    for (auto i : range(filter.orig_size))
+    {
+        auto cur_iter = iter++;
+        if (filter(i))
+        {
+            result.insert(m->extract(cur_iter));
+        }
+    }
+    *m = std::move(result);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether to keep the data at this index.
+ */
+auto ImportDataTrimmer::make_filterer(std::size_t vec_size) const -> GridFilterer
+{
+    auto stride = vec_size >= 2 ? vec_size / (options_.max_size - 1) : 1;
+
+    return {stride, vec_size};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether to keep the data at this index.
+ */
+bool ImportDataTrimmer::GridFilterer::operator()(std::size_t i) const
+{
+    return i % stride == 0 || i + 1 == orig_size;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/io/ImportDataTrimmer.cc
+++ b/src/celeritas/io/ImportDataTrimmer.cc
@@ -35,221 +35,227 @@ ImportDataTrimmer::ImportDataTrimmer(Input const& inp) : options_{inp}
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportData* data)
+void ImportDataTrimmer::operator()(ImportData& data)
 {
     if (options_.materials)
     {
         // Reduce the number of materials, elements, etc.
-        (*this)(&data->isotopes);
-        (*this)(&data->elements);
-        (*this)(&data->geo_materials);
-        (*this)(&data->phys_materials);
+        (*this)(data.isotopes);
+        (*this)(data.elements);
+        (*this)(data.geo_materials);
+        (*this)(data.phys_materials);
 
-        (*this)(&data->regions);
-        (*this)(&data->volumes);
+        (*this)(data.regions);
+        (*this)(data.volumes);
 
-        (*this)(&data->sb_data);
-        (*this)(&data->livermore_pe_data);
-        (*this)(&data->neutron_elastic_data);
-        (*this)(&data->atomic_relaxation_data);
+        (*this)(data.sb_data);
+        (*this)(data.livermore_pe_data);
+        (*this)(data.neutron_elastic_data);
+        (*this)(data.atomic_relaxation_data);
 
-        (*this)(&data->optical_materials);
+        (*this)(data.optical_materials);
     }
 
     if (options_.physics)
     {
         // Reduce the number of physics processes
-        (*this)(&data->particles);
-        (*this)(&data->processes);
-        (*this)(&data->msc_models);
+        (*this)(data.particles);
+        (*this)(data.processes);
+        (*this)(data.msc_models);
     }
 
     if (options_.mupp)
     {
         // Reduce the resolution of the muon pair production table
-        (*this)(&data->mu_pair_production_data);
+        (*this)(data.mu_pair_production_data);
     }
 
-    this->for_each(&data->elements);
-    this->for_each(&data->geo_materials);
-    this->for_each(&data->phys_materials);
+    this->for_each(data.elements);
+    this->for_each(data.geo_materials);
+    this->for_each(data.phys_materials);
 
-    this->for_each(&data->processes);
-    this->for_each(&data->msc_models);
-    this->for_each(&data->sb_data);
-    this->for_each(&data->livermore_pe_data);
-    this->for_each(&data->neutron_elastic_data);
-    this->for_each(&data->atomic_relaxation_data);
+    this->for_each(data.processes);
+    this->for_each(data.msc_models);
+    this->for_each(data.sb_data);
+    this->for_each(data.livermore_pe_data);
+    this->for_each(data.neutron_elastic_data);
+    this->for_each(data.atomic_relaxation_data);
 
-    this->for_each(&data->optical_models);
-    this->for_each(&data->optical_materials);
+    this->for_each(data.optical_models);
+    this->for_each(data.optical_materials);
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportElement* data)
+void ImportDataTrimmer::operator()(ImportElement& data)
 {
-    CELER_EXPECT(data);
-
     if (options_.materials)
     {
-        (*this)(&data->isotopes_fractions);
+        (*this)(data.isotopes_fractions);
     }
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportGeoMaterial* data)
+void ImportDataTrimmer::operator()(ImportGeoMaterial& data)
 {
-    CELER_EXPECT(data);
-
     if (options_.materials)
     {
-        (*this)(&data->elements);
+        (*this)(data.elements);
     }
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportPhysMaterial* data)
+void ImportDataTrimmer::operator()(ImportPhysMaterial&)
 {
-    CELER_EXPECT(data);
-
     // TODO: remap IDs?
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportOpticalMaterial* data)
+void ImportDataTrimmer::operator()(ImportOpticalMaterial&)
 {
-    CELER_EXPECT(data);
-
     // TODO: trim WLS components?
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportOpticalModel* data)
+void ImportDataTrimmer::operator()(ImportOpticalModel& data)
 {
-    CELER_EXPECT(data);
+    if (options_.materials)
+    {
+        (*this)(data.mfp_table);
+    }
+
+    this->for_each(data.mfp_table);
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportModelMaterial& data)
+{
+    (*this)(data.energy);
 
     if (options_.materials)
     {
-        (*this)(&data->mfp_table);
+        (*this)(data.micro_xs);
     }
 
-    this->for_each(data->mfp_table);
+    this->for_each(data.micro_xs);
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportModelMaterial* data)
+void ImportDataTrimmer::operator()(ImportModel& data)
 {
-    CELER_EXPECT(data);
-
-    (*this)(&data->energy);
-
     if (options_.materials)
     {
-        (*this)(&data->micro_xs);
+        (*this)(data.materials);
     }
 
-    this->for_each(data->micro_xs);
+    this->for_each(data.materials);
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportModel* data)
+void ImportDataTrimmer::operator()(ImportMscModel& data)
 {
-    CELER_EXPECT(data);
-
-    if (options_.materials)
-    {
-        (*this)(&data->materials);
-    }
-
-    this->for_each(data->materials);
+    (*this)(data.xs_table);
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportMscModel* data)
+void ImportDataTrimmer::operator()(ImportMuPairProductionTable& data)
 {
-    CELER_EXPECT(data);
-
-    (*this)(&data->xs_table);
-}
-
-//---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportMuPairProductionTable* data)
-{
-    CELER_EXPECT(data);
-
-    if (!*data)
+    if (!data)
     {
         return;
     }
 
-    (*this)(&data->atomic_number);
-    (*this)(&data->physics_vectors);
+    (*this)(data.atomic_number);
+    (*this)(data.physics_vectors);
 
-    this->for_each(&data->physics_vectors);
+    this->for_each(data.physics_vectors);
 
-    CELER_ENSURE(*data);
+    CELER_ENSURE(data);
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportParticle* data)
+void ImportDataTrimmer::operator()(ImportLivermorePE& data)
 {
-    CELER_EXPECT(data);
+    if (options_.physics)
+    {
+        (*this)(data.xs_lo);
+        (*this)(data.xs_hi);
+        (*this)(data.shells);
+
+        this->for_each(data.shells);
+    }
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportProcess* data)
+void ImportDataTrimmer::operator()(ImportLivermoreSubshell& data)
 {
-    CELER_EXPECT(data);
+    if (options_.physics)
+    {
+        (*this)(data.param_lo);
+        (*this)(data.param_hi);
+        (*this)(data.xs);
+        (*this)(data.energy);
+    }
+}
 
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportAtomicRelaxation&)
+{
+    // TODO: reduce shells/transitions
+}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportParticle&) {}
+
+//---------------------------------------------------------------------------//
+void ImportDataTrimmer::operator()(ImportProcess& data)
+{
     if (options_.materials)
     {
-        (*this)(&data->tables);
+        (*this)(data.tables);
     }
     if (options_.physics)
     {
-        (*this)(&data->models);
+        (*this)(data.models);
     }
 
-    this->for_each(&data->models);
-    this->for_each(&data->tables);
+    this->for_each(data.models);
+    this->for_each(data.tables);
 
-    CELER_ENSURE(*data);
+    CELER_ENSURE(data);
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportPhysicsVector* data)
+void ImportDataTrimmer::operator()(ImportPhysicsVector& data)
 {
-    CELER_EXPECT(data);
-    (*this)(&data->x);
-    (*this)(&data->y);
+    (*this)(data.x);
+    (*this)(data.y);
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportPhysicsTable* data)
+void ImportDataTrimmer::operator()(ImportPhysicsTable& data)
 {
-    CELER_EXPECT(data);
     if (options_.materials)
     {
-        (*this)(&data->physics_vectors);
+        (*this)(data.physics_vectors);
     }
 
-    this->for_each(&data->physics_vectors);
+    this->for_each(data.physics_vectors);
 }
 
 //---------------------------------------------------------------------------//
-void ImportDataTrimmer::operator()(ImportPhysics2DVector* data)
+void ImportDataTrimmer::operator()(ImportPhysics2DVector& data)
 {
-    auto x_filter = this->make_filterer(data->x.size());
-    auto y_filter = this->make_filterer(data->y.size());
+    auto x_filter = this->make_filterer(data.x.size());
+    auto y_filter = this->make_filterer(data.y.size());
 
     // Trim x and y grid
-    (*this)(&data->x);
-    (*this)(&data->y);
+    (*this)(data.x);
+    (*this)(data.y);
 
     std::vector<double> new_value;
-    new_value.reserve(data->x.size() * data->y.size());
+    new_value.reserve(data.x.size() & data.y.size());
 
-    auto src = data->value.cbegin();
+    auto src = data.value.cbegin();
     for (auto i : range(x_filter.orig_size))
     {
         for (auto j : range(y_filter.orig_size))
@@ -261,11 +267,11 @@ void ImportDataTrimmer::operator()(ImportPhysics2DVector* data)
             ++src;
         }
     }
-    CELER_ASSERT(src == data->value.cend());
+    CELER_ASSERT(src == data.value.cend());
 
-    data->value = std::move(new_value);
+    data.value = std::move(new_value);
 
-    CELER_ENSURE(*data);
+    CELER_ENSURE(data);
 }
 
 //---------------------------------------------------------------------------//
@@ -273,10 +279,8 @@ void ImportDataTrimmer::operator()(ImportPhysics2DVector* data)
  * Trim the number of elements in a vector.
  */
 template<class T>
-void ImportDataTrimmer::operator()(std::vector<T>* vec)
+void ImportDataTrimmer::operator()(std::vector<T>& data)
 {
-    CELER_EXPECT(vec);
-
     if (options_.max_size == numeric_limits<size_type>::max())
     {
         // Don't trim
@@ -284,17 +288,17 @@ void ImportDataTrimmer::operator()(std::vector<T>* vec)
     }
 
     std::vector<T> result;
-    result.reserve(std::min(options_.max_size + 1, vec->size()));
+    result.reserve(std::min(options_.max_size + 1, data.size()));
 
-    auto filter = this->make_filterer(vec->size());
-    for (auto i : range(vec->size()))
+    auto filter = this->make_filterer(data.size());
+    for (auto i : range(data.size()))
     {
         if (filter(i))
         {
-            result.push_back((*vec)[i]);
+            result.push_back(data[i]);
         }
     }
-    *vec = std::move(result);
+    data = std::move(result);
 }
 
 //---------------------------------------------------------------------------//
@@ -302,22 +306,20 @@ void ImportDataTrimmer::operator()(std::vector<T>* vec)
  * Trim the number of elements in a map.
  */
 template<class K, class T, class C, class A>
-void ImportDataTrimmer::operator()(std::map<K, T, C, A>* m)
+void ImportDataTrimmer::operator()(std::map<K, T, C, A>& data)
 {
-    CELER_EXPECT(m);
-
     std::map<K, T, C, A> result;
-    auto filter = this->make_filterer(m->size());
-    auto iter = m->begin();
+    auto filter = this->make_filterer(data.size());
+    auto iter = data.begin();
     for (auto i : range(filter.orig_size))
     {
         auto cur_iter = iter++;
         if (filter(i))
         {
-            result.insert(m->extract(cur_iter));
+            result.insert(data.extract(cur_iter));
         }
     }
-    *m = std::move(result);
+    data = std::move(result);
 }
 
 //---------------------------------------------------------------------------//
@@ -325,13 +327,11 @@ void ImportDataTrimmer::operator()(std::map<K, T, C, A>* m)
  * Trim each element in a vector.
  */
 template<class T>
-void ImportDataTrimmer::for_each(std::vector<T>* vec)
+void ImportDataTrimmer::for_each(std::vector<T>& data)
 {
-    CELER_EXPECT(vec);
-
-    for (auto& v : *vec)
+    for (auto& v : data)
     {
-        (*this)(&v);
+        (*this)(v);
     }
 }
 
@@ -340,13 +340,11 @@ void ImportDataTrimmer::for_each(std::vector<T>* vec)
  * Trim each value in a map.
  */
 template<class K, class T, class C, class A>
-void ImportDataTrimmer::for_each(std::map<K, T, C, A>* m)
+void ImportDataTrimmer::for_each(std::map<K, T, C, A>& data)
 {
-    CELER_EXPECT(m);
-
-    for (auto&& kv : *m)
+    for (auto&& kv : data)
     {
-        (*this)(&kv.second);
+        (*this)(kv.second);
     }
 }
 

--- a/src/celeritas/io/ImportDataTrimmer.hh
+++ b/src/celeritas/io/ImportDataTrimmer.hh
@@ -27,8 +27,10 @@ class ImportDataTrimmer
         bool materials{false};
         //! Reduce the number of physics models and processes
         bool physics{false};
+        //! Reduce the MuPPET table fidelity
+        bool mupp{false};
         //! Maximum number of elements in a vector (approximate)
-        size_type max_size{numeric_limits<size_type>::max()};
+        std::size_t max_size{numeric_limits<std::size_t>::max()};
     };
 
   public:

--- a/src/celeritas/io/ImportDataTrimmer.hh
+++ b/src/celeritas/io/ImportDataTrimmer.hh
@@ -82,6 +82,12 @@ class ImportDataTrimmer
 
     template<class K, class T, class C, class A>
     void operator()(std::map<K, T, C, A>* m);
+
+    template<class T>
+    void for_each(std::vector<T>* vec);
+
+    template<class K, class T, class C, class A>
+    void for_each(std::map<K, T, C, A>* m);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/io/ImportDataTrimmer.hh
+++ b/src/celeritas/io/ImportDataTrimmer.hh
@@ -1,0 +1,82 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/io/ImportDataTrimmer.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Types.hh"
+#include "corecel/math/NumericLimits.hh"
+
+#include "ImportData.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Reduce the amount of imported/exported data for testing.
+ */
+class ImportDataTrimmer
+{
+  public:
+    struct Input
+    {
+        //! Remove materials/elements which might affect the problem
+        bool materials{false};
+        //! Reduce the number of physics models and processes
+        bool physics{false};
+        //! Maximum number of elements in a vector (approximate)
+        size_type max_size{numeric_limits<size_type>::max()};
+    };
+
+  public:
+    // Construct with a unit system
+    explicit ImportDataTrimmer(Input const& inp);
+
+    //!@{
+    //! Trim imported data
+    void operator()(ImportData* data);
+    void operator()(ImportElement* data);
+    void operator()(ImportGeoMaterial* data);
+    void operator()(ImportModel* data);
+    void operator()(ImportModelMaterial* data);
+    void operator()(ImportMscModel* data);
+    void operator()(ImportMuPairProductionTable* data);
+    void operator()(ImportOpticalMaterial* data);
+    void operator()(ImportOpticalModel* data);
+    void operator()(ImportParticle* data);
+    void operator()(ImportPhysMaterial* data);
+    void operator()(ImportProcess* data);
+    //!@}
+
+    //!@{
+    //! Trim objects
+    void operator()(ImportPhysicsVector* data);
+    void operator()(ImportPhysicsTable* data);
+    void operator()(ImportPhysics2DVector* data);
+    //!@}
+
+  private:
+    //// TYPES ////
+
+    struct GridFilterer;
+
+    //// DATA ////
+
+    Input options_;
+
+    //// HELPERS ////
+
+    GridFilterer make_filterer(std::size_t vec_size) const;
+
+    template<class T>
+    void operator()(std::vector<T>* vec);
+
+    template<class K, class T, class C, class A>
+    void operator()(std::map<K, T, C, A>* m);
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/io/ImportDataTrimmer.hh
+++ b/src/celeritas/io/ImportDataTrimmer.hh
@@ -7,7 +7,9 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/Types.hh"
+#include <map>
+#include <vector>
+
 #include "corecel/math/NumericLimits.hh"
 
 #include "ImportData.hh"
@@ -23,14 +25,15 @@ class ImportDataTrimmer
   public:
     struct Input
     {
+        //! Maximum number of elements in a vector (approximate)
+        std::size_t max_size{numeric_limits<std::size_t>::max()};
+
         //! Remove materials/elements which might affect the problem
         bool materials{false};
         //! Reduce the number of physics models and processes
         bool physics{false};
         //! Reduce the MuPPET table fidelity
         bool mupp{false};
-        //! Maximum number of elements in a vector (approximate)
-        std::size_t max_size{numeric_limits<std::size_t>::max()};
     };
 
   public:
@@ -63,6 +66,7 @@ class ImportDataTrimmer
   private:
     //// TYPES ////
 
+    using size_type = std::size_t;
     struct GridFilterer;
 
     //// DATA ////
@@ -71,7 +75,7 @@ class ImportDataTrimmer
 
     //// HELPERS ////
 
-    GridFilterer make_filterer(std::size_t vec_size) const;
+    GridFilterer make_filterer(size_type vec_size) const;
 
     template<class T>
     void operator()(std::vector<T>* vec);

--- a/src/celeritas/io/ImportDataTrimmer.hh
+++ b/src/celeritas/io/ImportDataTrimmer.hh
@@ -42,25 +42,28 @@ class ImportDataTrimmer
 
     //!@{
     //! Trim imported data
-    void operator()(ImportData* data);
-    void operator()(ImportElement* data);
-    void operator()(ImportGeoMaterial* data);
-    void operator()(ImportModel* data);
-    void operator()(ImportModelMaterial* data);
-    void operator()(ImportMscModel* data);
-    void operator()(ImportMuPairProductionTable* data);
-    void operator()(ImportOpticalMaterial* data);
-    void operator()(ImportOpticalModel* data);
-    void operator()(ImportParticle* data);
-    void operator()(ImportPhysMaterial* data);
-    void operator()(ImportProcess* data);
+    void operator()(ImportData& data);
+    void operator()(ImportElement& data);
+    void operator()(ImportGeoMaterial& data);
+    void operator()(ImportModel& data);
+    void operator()(ImportModelMaterial& data);
+    void operator()(ImportMscModel& data);
+    void operator()(ImportLivermorePE& data);
+    void operator()(ImportLivermoreSubshell& data);
+    void operator()(ImportAtomicRelaxation& data);
+    void operator()(ImportMuPairProductionTable& data);
+    void operator()(ImportOpticalMaterial& data);
+    void operator()(ImportOpticalModel& data);
+    void operator()(ImportParticle& data);
+    void operator()(ImportPhysMaterial& data);
+    void operator()(ImportProcess& data);
     //!@}
 
     //!@{
     //! Trim objects
-    void operator()(ImportPhysicsVector* data);
-    void operator()(ImportPhysicsTable* data);
-    void operator()(ImportPhysics2DVector* data);
+    void operator()(ImportPhysicsVector& data);
+    void operator()(ImportPhysicsTable& data);
+    void operator()(ImportPhysics2DVector& data);
     //!@}
 
   private:
@@ -78,16 +81,16 @@ class ImportDataTrimmer
     GridFilterer make_filterer(size_type vec_size) const;
 
     template<class T>
-    void operator()(std::vector<T>* vec);
+    void operator()(std::vector<T>& vec);
 
     template<class K, class T, class C, class A>
-    void operator()(std::map<K, T, C, A>* m);
+    void operator()(std::map<K, T, C, A>& m);
 
     template<class T>
-    void for_each(std::vector<T>* vec);
+    void for_each(std::vector<T>& vec);
 
     template<class K, class T, class C, class A>
-    void for_each(std::map<K, T, C, A>* m);
+    void for_each(std::map<K, T, C, A>& m);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/io/ImportOpticalMaterial.hh
+++ b/src/celeritas/io/ImportOpticalMaterial.hh
@@ -164,7 +164,8 @@ struct ImportWavelengthShift
 /*!
  * Store optical material properties.
  *
- * \todo boolean for enabling cerenkov in the material??
+ * \todo boolean for enabling cerenkov in the material?? DUNE e.g. disables
+ * cerenkov globally.
  */
 struct ImportOpticalMaterial
 {

--- a/src/celeritas/io/ImportSBTable.hh
+++ b/src/celeritas/io/ImportSBTable.hh
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file celeritas/io/ImportSBTable.hh
+//! \deprecated Remove in v1.0
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -18,6 +19,8 @@ namespace celeritas
  * This 2-dimensional table stores the scaled bremsstrahlung differential cross
  * section [mb]. The x grid is the log energy of the incident particle [MeV],
  * and the y grid is the ratio of the gamma energy to the incident energy.
+ *
+ * DEPRECATED: remove in v1.0.
  */
 using ImportSBTable = ImportPhysics2DVector;
 

--- a/test/celeritas/ext/RootJsonDumper.test.cc
+++ b/test/celeritas/ext/RootJsonDumper.test.cc
@@ -44,7 +44,7 @@ TEST_F(RootJsonDumperTest, all)
         inp.physics = true;
         inp.max_size = 2;
         ImportDataTrimmer trim{inp};
-        trim(&imported);
+        trim(imported);
     }
 
     std::string str = [&imported] {

--- a/test/celeritas/ext/RootJsonDumper.test.cc
+++ b/test/celeritas/ext/RootJsonDumper.test.cc
@@ -12,6 +12,7 @@
 #include "celeritas/ext/RootImporter.hh"
 #include "celeritas/ext/ScopedRootErrorHandler.hh"
 #include "celeritas/io/ImportData.hh"
+#include "celeritas/io/ImportDataTrimmer.hh"
 
 #include "celeritas_test.hh"
 
@@ -20,121 +21,39 @@ namespace celeritas
 namespace test
 {
 //---------------------------------------------------------------------------//
-template<class T>
-void trim(T*);
-
-template<class T>
-void trim(std::vector<T>* vec);
-
-template<class K, class T, class C, class A>
-void trim(std::map<K, T, C, A>* m);
-
-void trim(ImportModelMaterial* imm)
-{
-    CELER_EXPECT(imm);
-    trim(&imm->energy);
-    trim(&imm->micro_xs);
-}
-
-void trim(ImportModel* im)
-{
-    CELER_EXPECT(im);
-    trim(&im->materials);
-}
-
-void trim(ImportPhysicsVector* ipv)
-{
-    CELER_EXPECT(ipv);
-    trim(&ipv->x);
-    trim(&ipv->y);
-}
-
-void trim(ImportPhysicsTable* ipt)
-{
-    CELER_EXPECT(ipt);
-    trim(&ipt->physics_vectors);
-}
-
-void trim(ImportMscModel* im)
-{
-    CELER_EXPECT(im);
-    trim(&im->xs_table);
-}
-
-void trim(ImportProcess* ip)
-{
-    CELER_EXPECT(ip);
-    trim(&ip->models);
-    trim(&ip->tables);
-}
-
-template<class T>
-void trim(T*)
-{
-    // Null-op by default
-}
-
-template<class T>
-void trim(std::vector<T>* vec)
-{
-    CELER_EXPECT(vec);
-    if (vec->size() > 2)
-    {
-        vec->erase(vec->begin() + 1, vec->end() - 1);
-    }
-    for (auto& v : *vec)
-    {
-        trim(&v);
-    }
-}
-
-template<class K, class T, class C, class A>
-void trim(std::map<K, T, C, A>* m)
-{
-    CELER_EXPECT(m);
-    if (!m->empty())
-    {
-        auto iter = m->begin();
-        ++iter;
-        m->erase(iter, m->end());
-    }
-}
-
-//---------------------------------------------------------------------------//
 class RootJsonDumperTest : public ::celeritas::test::Test
 {
 };
 
 TEST_F(RootJsonDumperTest, all)
 {
-    ImportData imported;
-    {
+    // Import data
+    ImportData imported = [this] {
         ScopedRootErrorHandler scoped_root_error;
         RootImporter import(
             this->test_data_path("celeritas", "four-steel-slabs.root"));
-        imported = import();
+        auto result = import();
         scoped_root_error.throw_if_errors();
+        return result;
+    }();
+
+    // Trim data
+    {
+        ImportDataTrimmer::Input inp;
+        inp.materials = true;
+        inp.physics = true;
+        inp.max_size = 2;
+        ImportDataTrimmer trim{inp};
+        trim(&imported);
     }
 
-    // Reduce amount of data to check...
-    trim(&imported.particles);
-    trim(&imported.isotopes);
-    trim(&imported.elements);
-    trim(&imported.geo_materials);
-    trim(&imported.phys_materials);
-    trim(&imported.processes);
-    trim(&imported.msc_models);
-    trim(&imported.regions);
-    trim(&imported.volumes);
-    imported.sb_data = {};
-    imported.livermore_pe_data = {};
-
-    std::ostringstream os;
-    {
+    std::string str = [&imported] {
+        std::ostringstream os;
         ScopedRootErrorHandler scoped_root_error;
         RootJsonDumper{&os}(imported);
         scoped_root_error.throw_if_errors();
-    }
+        return std::move(os).str();
+    }();
 
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
@@ -171,14 +90,6 @@ TEST_F(RootJsonDumperTest, all)
     "second" : 0.05845
   }, {
     "_typename" : "pair<unsigned int,double>",
-    "first" : 1,
-    "second" : 0.91754
-  }, {
-    "_typename" : "pair<unsigned int,double>",
-    "first" : 2,
-    "second" : 0.02119
-  }, {
-    "_typename" : "pair<unsigned int,double>",
     "first" : 3,
     "second" : 0.00282
   }]
@@ -202,15 +113,11 @@ TEST_F(RootJsonDumperTest, all)
   "name" : "G4_STAINLESS-STEEL",
   "state" : 1,
   "temperature" : 293.15,
-  "number_density" : 86993489258991547580416,
+  "number_density" : 86993489258991530803200,
   "elements" : [{
     "_typename" : "celeritas::ImportMatElemComponent",
     "element_id" : 0,
     "number_fraction" : 0.74
-  }, {
-    "_typename" : "celeritas::ImportMatElemComponent",
-    "element_id" : 1,
-    "number_fraction" : 0.18
   }, {
     "_typename" : "celeritas::ImportMatElemComponent",
     "element_id" : 2,
@@ -387,7 +294,7 @@ TEST_F(RootJsonDumperTest, all)
       "_typename" : "celeritas::ImportPhysicsVector",
       "vector_type" : 2,
       "x" : [1e-4, 100],
-      "y" : [0.0919755519795959, 128.588033594672]
+      "y" : [0.0919755519795958, 128.588033594672]
     }]
   }
 }, {
@@ -470,7 +377,7 @@ TEST_F(RootJsonDumperTest, all)
 },
 "units" : "cgs"
 })json",
-            os.str());
+            str);
     }
 }
 


### PR DESCRIPTION
Following on to [a discussion](https://github.com/celeritas-project/celeritas/pull/1518#discussion_r1856602784) on #1518, this reduces the size of the MuPP table and has options for trimming additional elements. I don't have it enabled by default since it messes with the spacing of the physics vectors (and we don't yet support nonuniform sizes). However I use it to trim the ROOT JSON export test. We could extend it to simplify the Geant export test as well.