### PR TITLE
Add CITATION file with CHEP 2024 article

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,8 +25,8 @@ message: "Please cite the following article when referencing Celeritas in a publ
 title: "Celeritas"
 type: software
 license:
- - Apache-2.0
- - MIT
+  - Apache-2.0
+  - MIT
 authors:
   - family-names: Johnson
     given-names: Seth R.
@@ -101,9 +101,10 @@ preferred-citation:
       orcid: "https://orcid.org/0000-0002-1147-045X"
   title: "Celeritas: Accelerating Geant4 with GPUs"
   type: article
-  publisher: "EPJ Web of Conferences"
+  journal: "EPJ Web of Conferences"
   volume: 295
   pages: 11005
+  issue-title: "26th International Conference on Computing in High Energy and Nuclear Physics (CHEP 2023)"
   date-published: 2024
   identifiers:
     - type: doi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,36 @@
+references:
+  - title: >-
+      Celeritas: Accelerating Geant4 with GPUs
+    abstract: |
+      Celeritas [1] is a new Monte Carlo (MC) detector simulation code designed for computationally intensive applications (specifically, High Luminosity Large Hadron Collider (HL-LHC) simulation) on high-performance heterogeneous architectures. In the past two years Celeritas has advanced from prototyping a GPU-based single physics model in infinite medium to implementing a full set of electromagnetic (EM) physics processes in complex geometries. The current release of Celeritas, version 0.3, has incorporated full device-based navigation, an event loop in the presence of magnetic fields, and detector hit scoring. New functionality incorporates a scheduler to offload electromagnetic physics to the GPU within a Geant4-driven simulation, enabling integration of Celeritas into high energy physics (HEP) experimental frameworks such as CMSSW. On the Summit supercomputer, Celeritas performs EM physics between 6× and 32× faster using the machine’s Nvidia GPUs compared to using only CPUs. When running a multithreaded Geant4 ATLAS test beam application with full hadronic physics, using Celeritas to accelerate the EM physics results in an overall simulation speedup of 1.8–2.3× on GPU and 1.2× on CPU.
+    type: journalArticle
+    publisher: "EPJ Web of Conferences"
+    pages: 11005
+    volume: 295
+    authors: 
+      - family-names: Johnson
+        given-names: Seth R.
+      - family-names: Esseiva
+        given-names: Julien
+      - family-names: Biondo
+        given-names: Elliott
+      - family-names: Canal
+        given-names: Philippe
+      - family-names: Demarteau
+        given-names: Marcel
+      - family-names: Evans
+        given-names: Thomas
+      - family-names: Jun
+        given-names: Soon Yung
+      - family-names: Lima
+        given-names: Guilherme
+      - family-names: Lund
+        given-names: Amanda
+      - family-names: Romano
+        given-names: Paul
+      - family-names: Tognini
+        given-names: Stefano C.
+    date-published: 2024
+    identifiers: 
+      - type: doi
+        value: 10.1051/epjconf/202429511005

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,36 +1,61 @@
-references:
-  - title: >-
-      Celeritas: Accelerating Geant4 with GPUs
-    abstract: |
-      Celeritas [1] is a new Monte Carlo (MC) detector simulation code designed for computationally intensive applications (specifically, High Luminosity Large Hadron Collider (HL-LHC) simulation) on high-performance heterogeneous architectures. In the past two years Celeritas has advanced from prototyping a GPU-based single physics model in infinite medium to implementing a full set of electromagnetic (EM) physics processes in complex geometries. The current release of Celeritas, version 0.3, has incorporated full device-based navigation, an event loop in the presence of magnetic fields, and detector hit scoring. New functionality incorporates a scheduler to offload electromagnetic physics to the GPU within a Geant4-driven simulation, enabling integration of Celeritas into high energy physics (HEP) experimental frameworks such as CMSSW. On the Summit supercomputer, Celeritas performs EM physics between 6× and 32× faster using the machine’s Nvidia GPUs compared to using only CPUs. When running a multithreaded Geant4 ATLAS test beam application with full hadronic physics, using Celeritas to accelerate the EM physics results in an overall simulation speedup of 1.8–2.3× on GPU and 1.2× on CPU.
-    type: journalArticle
-    publisher: "EPJ Web of Conferences"
-    pages: 11005
-    volume: 295
-    authors: 
-      - family-names: Johnson
-        given-names: Seth R.
-      - family-names: Esseiva
-        given-names: Julien
-      - family-names: Biondo
-        given-names: Elliott
-      - family-names: Canal
-        given-names: Philippe
-      - family-names: Demarteau
-        given-names: Marcel
-      - family-names: Evans
-        given-names: Thomas
-      - family-names: Jun
-        given-names: Soon Yung
-      - family-names: Lima
-        given-names: Guilherme
-      - family-names: Lund
-        given-names: Amanda
-      - family-names: Romano
-        given-names: Paul
-      - family-names: Tognini
-        given-names: Stefano C.
-    date-published: 2024
-    identifiers: 
-      - type: doi
-        value: 10.1051/epjconf/202429511005
+# Pleace cite the following article when referencing Celeritas in a publication:
+#
+# (Plain text, Chicago author-date 17th ed):
+#   Johnson, Seth R., Amanda Lund, Philippe Canal, Stefano C. Tognini, Julien
+#   Esseiva, Soon Yung Jun, Guilherme Lima, et al. 2024. “Celeritas:
+#   Accelerating Geant4 with GPUs.” EPJ Web of Conferences 295:11005.
+#   https://doi.org/10.1051/epjconf/202429511005.
+#
+# (BibLaTeX):
+#    @article{celer-chep-2024,
+#      title = {Celeritas: {{Accelerating Geant4}} with {{GPUs}}},
+#      author = {Johnson, Seth R. and Lund, Amanda and Canal, Philippe and Tognini, Stefano C. and Esseiva, Julien and Jun, Soon Yung and Lima, Guilherme and Biondo, Elliott and Evans, Thomas and Demarteau, Marcel and Romano, Paul},
+#      date = {2024},
+#      journaltitle = {EPJ Web of Conferences},
+#      volume = {295},
+#      pages = {11005},
+#      doi = {10.1051/epjconf/202429511005}
+#    }
+#
+# (CFF):
+
+cff-version: 1.2.0
+type: software
+message: "Please cite the following article when referencing Celeritas in a publication."
+title: "Celeritas: Accelerating Geant4 with GPUs"
+abstract: >-
+  Celeritas [1] is a new Monte Carlo (MC) detector simulation code designed for computationally intensive applications (specifically, High Luminosity Large Hadron Collider (HL-LHC) simulation) on high-performance heterogeneous architectures. In the past two years Celeritas has advanced from prototyping a GPU-based single physics model in infinite medium to implementing a full set of electromagnetic (EM) physics processes in complex geometries. The current release of Celeritas, version 0.3, has incorporated full device-based navigation, an event loop in the presence of magnetic fields, and detector hit scoring. New functionality incorporates a scheduler to offload electromagnetic physics to the GPU within a Geant4-driven simulation, enabling integration of Celeritas into high energy physics (HEP) experimental frameworks such as CMSSW. On the Summit supercomputer, Celeritas performs EM physics between 6× and 32× faster using the machine’s Nvidia GPUs compared to using only CPUs. When running a multithreaded Geant4 ATLAS test beam application with full hadronic physics, using Celeritas to accelerate the EM physics results in an overall simulation speedup of 1.8–2.3× on GPU and 1.2× on CPU.
+preferred-citation:
+  authors:
+    - family-names: Johnson
+      given-names: Seth R.
+      orcid: "https://orcid.org/0000-0003-1504-8966"
+    - family-names: Lund
+      given-names: Amanda
+    - family-names: Canal
+      given-names: Philippe
+    - family-names: Tognini
+      given-names: Stefano C.
+    - family-names: Esseiva
+      given-names: Julien
+    - family-names: Jun
+      given-names: Soon Yung
+    - family-names: Lima
+      given-names: Guilherme
+    - family-names: Biondo
+      given-names: Elliott
+    - family-names: Evans
+      given-names: Thomas
+    - family-names: Demarteau
+      given-names: Marcel
+    - family-names: Romano
+      given-names: Paul
+  title: "Celeritas: Accelerating Geant4 with GPUs"
+  type: article
+  publisher: "EPJ Web of Conferences"
+  volume: 295
+  pages: 11005
+  date-published: 2024
+  identifiers:
+    - type: doi
+      value: 10.1051/epjconf/202429511005

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -103,8 +103,8 @@ preferred-citation:
   type: article
   journal: "EPJ Web of Conferences"
   volume: 295
-  pages: 11005
-  issue-title: "26th International Conference on Computing in High Energy and Nuclear Physics (CHEP 2023)"
+  number: 11005
+  issue: "26th International Conference on Computing in High Energy and Nuclear Physics (CHEP 2023)"
   date-published: 2024
   identifiers:
     - type: doi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -104,7 +104,7 @@ preferred-citation:
   journal: "EPJ Web of Conferences"
   volume: 295
   number: 11005
-  issue: "26th International Conference on Computing in High Energy and Nuclear Physics (CHEP 2023)"
+  issue-title: "26th International Conference on Computing in High Energy and Nuclear Physics (CHEP 2023)"
   date-published: 2024
   identifiers:
     - type: doi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,9 +22,51 @@
 cff-version: 1.2.0
 type: software
 message: "Please cite the following article when referencing Celeritas in a publication."
-title: "Celeritas: Accelerating Geant4 with GPUs"
-abstract: >-
-  Celeritas [1] is a new Monte Carlo (MC) detector simulation code designed for computationally intensive applications (specifically, High Luminosity Large Hadron Collider (HL-LHC) simulation) on high-performance heterogeneous architectures. In the past two years Celeritas has advanced from prototyping a GPU-based single physics model in infinite medium to implementing a full set of electromagnetic (EM) physics processes in complex geometries. The current release of Celeritas, version 0.3, has incorporated full device-based navigation, an event loop in the presence of magnetic fields, and detector hit scoring. New functionality incorporates a scheduler to offload electromagnetic physics to the GPU within a Geant4-driven simulation, enabling integration of Celeritas into high energy physics (HEP) experimental frameworks such as CMSSW. On the Summit supercomputer, Celeritas performs EM physics between 6× and 32× faster using the machine’s Nvidia GPUs compared to using only CPUs. When running a multithreaded Geant4 ATLAS test beam application with full hadronic physics, using Celeritas to accelerate the EM physics results in an overall simulation speedup of 1.8–2.3× on GPU and 1.2× on CPU.
+title: "Celeritas"
+type: software
+license:
+ - Apache-2.0
+ - MIT
+authors:
+  - family-names: Johnson
+    given-names: Seth R.
+    orcid: "https://orcid.org/0000-0003-1504-8966"
+  - family-names: Lund
+    given-names: Amanda
+    orcid: "https://orcid.org/0000-0002-8316-0709"
+  - family-names: Jun
+    given-names: Soon Yung
+    orcid: "https://orcid.org/0000-0003-3370-6109"
+  - family-names: Tognini
+    given-names: Stefano
+    orcid: "https://orcid.org/0000-0001-9741-6608"
+  - family-names: Lima
+    given-names: Guilherme
+    orcid: "https://orcid.org/0000-0003-4585-0546"
+  - family-names: Canal
+    given-names: Philippe
+    orcid: "https://orcid.org/0000-0002-7748-7887"
+  - family-names: Morgan
+    given-names: Ben
+  - family-names: Evans
+    given-names: Tom
+    orcid: "https://orcid.org/0000-0001-5743-3788"
+  - family-names: Esseiva
+    given-names: Julien
+date-released: 2022
+url: https://doi.org/10.11578/dc.20221011.1
+identifiers:
+  - type: doi
+    value: 10.11578/dc.20221011.1
+keywords:
+  - monte carlo
+  - particle transport
+  - high energy physics
+  - detector simulation
+  - computational physics
+  - hep
+  - cuda
+  - hip
 preferred-citation:
   authors:
     - family-names: Johnson
@@ -32,24 +74,31 @@ preferred-citation:
       orcid: "https://orcid.org/0000-0003-1504-8966"
     - family-names: Lund
       given-names: Amanda
+      orcid: "https://orcid.org/0000-0002-8316-0709"
     - family-names: Canal
       given-names: Philippe
+      orcid: "https://orcid.org/0000-0002-7748-7887"
     - family-names: Tognini
       given-names: Stefano C.
+      orcid: "https://orcid.org/0000-0001-9741-6608"
     - family-names: Esseiva
       given-names: Julien
     - family-names: Jun
       given-names: Soon Yung
+      orcid: "https://orcid.org/0000-0003-3370-6109"
     - family-names: Lima
       given-names: Guilherme
+      orcid: "https://orcid.org/0000-0003-4585-0546"
     - family-names: Biondo
       given-names: Elliott
     - family-names: Evans
       given-names: Thomas
+      orcid: "https://orcid.org/0000-0001-5743-3788"
     - family-names: Demarteau
       given-names: Marcel
     - family-names: Romano
       given-names: Paul
+      orcid: "https://orcid.org/0000-0002-1147-045X"
   title: "Celeritas: Accelerating Geant4 with GPUs"
   type: article
   publisher: "EPJ Web of Conferences"
@@ -59,3 +108,5 @@ preferred-citation:
   identifiers:
     - type: doi
       value: 10.1051/epjconf/202429511005
+  abstract: >-
+    Celeritas is a new Monte Carlo (MC) detector simulation code designed for computationally intensive applications (specifically, High Luminosity Large Hadron Collider (HL-LHC) simulation) on high-performance heterogeneous architectures. In the past two years Celeritas has advanced from prototyping a GPU-based single physics model in infinite medium to implementing a full set of electromagnetic (EM) physics processes in complex geometries. The current release of Celeritas, version 0.3, has incorporated full device-based navigation, an event loop in the presence of magnetic fields, and detector hit scoring. New functionality incorporates a scheduler to offload electromagnetic physics to the GPU within a Geant4-driven simulation, enabling integration of Celeritas into high energy physics (HEP) experimental frameworks such as CMSSW. On the Summit supercomputer, Celeritas performs EM physics between 6× and 32× faster using the machine’s Nvidia GPUs compared to using only CPUs. When running a multithreaded Geant4 ATLAS test beam application with full hadronic physics, using Celeritas to accelerate the EM physics results in an overall simulation speedup of 1.8–2.3× on GPU and 1.2× on CPU.

--- a/README.md
+++ b/README.md
@@ -124,17 +124,20 @@ details on coding in Celeritas, and [the administration guidelines][administrati
 | **doc**       | Code documentation and manual                         |
 | **example**   | Example applications and input files                  |
 | **external**  | Automatically fetched external CMake dependencies     |
-| **interface** | Wrapper interfaces to Celeritas library functions     |
 | **scripts**   | Development and continuous integration helper scripts |
 | **src**       | Library source code                                   |
 | **test**      | Unit tests                                            |
 
 # Citing Celeritas
 
-If using Celeritas in your work, we ask that you cite the code using its
-[DOECode](https://www.osti.gov/doecode/biblio/94866) registration:
+If using Celeritas in your work, we ask that you cite the following article:
 
-> Seth R. Johnson, Amanda Lund, Soon Yung Jun, Stefano Tognini, Guilherme Lima, Paul Romano, Philippe Canal, Ben Morgan, and Tom Evans. “Celeritas,” July 2022. https://doi.org/10.11578/dc.20221011.1.
+> Johnson, Seth R., Amanda Lund, Philippe Canal, Stefano C. Tognini, Julien Esseiva, Soon Yung Jun, Guilherme Lima, et al. 2024. “Celeritas: Accelerating Geant4 with GPUs.” EPJ Web of Conferences 295:11005. https://doi.org/10.1051/epjconf/202429511005.
+
+See also its [DOECode](https://www.osti.gov/doecode/biblio/94866) registration:
+
+> Johnson, Seth R., Amanda Lund, Soon Yung Jun, Stefano Tognini, Guilherme Lima, Philippe Canal, Ben Morgan, Tom Evans, and Julien Esseiva. 2022. “Celeritas.” https://doi.org/10.11578/dc.20221011.1.
 
 A continually evolving list of works authored by (or with content authored by)
-core team members is available in our [citation file](doc/_static/celeritas.bib).
+core team members is continually updated at [our publications page](https://github.com/celeritas-project/celeritas/blob/doc/gh-pages-base/publications.md)
+and displayed on [the official project web site](https://celeritas.ornl.gov/).


### PR DESCRIPTION
This adds a [Citation File Format](https://zenodo.org/records/5171937/preview/schema-guide.md) file with the (currently best) Celeritas reference. This [is rendered by github](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) as the following:
<img width="433" alt="github screenshot" src="https://github.com/user-attachments/assets/d56f924e-2309-458f-8a4e-a3fa31e0706c">