### PR TITLE
Fix hepmc3/macro initialization in celer-g4

### DIFF
--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -8,6 +8,7 @@
 #include "ActionInitialization.hh"
 
 #include "corecel/io/Logger.hh"
+#include "accel/ExceptionConverter.hh"
 #include "accel/HepMC3PrimaryGenerator.hh"
 #include "accel/LocalTransporter.hh"
 
@@ -36,14 +37,18 @@ ActionInitialization::ActionInitialization(SPParams params)
     // Create Geant4 diagnostics to be shared across worker threads
     diagnostics_ = std::make_shared<GeantDiagnostics>();
 
-    if (auto const& hepmc_gen = GlobalSetup::Instance()->hepmc_gen())
+    auto const& input = GlobalSetup::Instance()->input();
+    if (!input_.event_file.empty())
     {
+        ExceptionConverter call_g4exception{"celer0007"};
+        CELER_TRY_HANDLE(hepmc_gen_ = std::make_shared<HepMC3PrimaryGenerator>(
+                             input.event_file),
+                         call_g4exception);
         num_events_ = hepmc_gen->NumEvents();
     }
     else
     {
-        num_events_
-            = GlobalSetup::Instance()->input().primary_options.num_events;
+        num_events_ = input.primary_options.num_events;
     }
 
     CELER_ENSURE(num_events_ > 0);
@@ -83,10 +88,14 @@ void ActionInitialization::Build() const
 
     // Primary generator emits source particles
     std::unique_ptr<G4VUserPrimaryGeneratorAction> generator_action;
-    if (auto const& hepmc_gen = GlobalSetup::Instance()->hepmc_gen())
+    auto const& input = GlobalSetup::Instance()->input();
+    if (hepmc_gen_)
     {
-        generator_action
-            = std::make_unique<HepMC3PrimaryGeneratorAction>(hepmc_gen);
+        ExceptionConverter call_g4exception{"celer0007"};
+        CELER_TRY_HANDLE(
+            generator_action
+            = std::make_unique<HepMC3PrimaryGeneratorAction>(hepmc_gen_),
+            call_g4exception);
     }
     else
     {

--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -13,6 +13,7 @@
 #include "accel/LocalTransporter.hh"
 
 #include "EventAction.hh"
+#include "GeantDiagnostics.hh"
 #include "GlobalSetup.hh"
 #include "HepMC3PrimaryGeneratorAction.hh"
 #include "PGPrimaryGeneratorAction.hh"
@@ -38,13 +39,13 @@ ActionInitialization::ActionInitialization(SPParams params)
     diagnostics_ = std::make_shared<GeantDiagnostics>();
 
     auto const& input = GlobalSetup::Instance()->input();
-    if (!input_.event_file.empty())
+    if (!input.event_file.empty())
     {
         ExceptionConverter call_g4exception{"celer0007"};
         CELER_TRY_HANDLE(hepmc_gen_ = std::make_shared<HepMC3PrimaryGenerator>(
                              input.event_file),
                          call_g4exception);
-        num_events_ = hepmc_gen->NumEvents();
+        num_events_ = hepmc_gen_->NumEvents();
     }
     else
     {
@@ -88,7 +89,6 @@ void ActionInitialization::Build() const
 
     // Primary generator emits source particles
     std::unique_ptr<G4VUserPrimaryGeneratorAction> generator_action;
-    auto const& input = GlobalSetup::Instance()->input();
     if (hepmc_gen_)
     {
         ExceptionConverter call_g4exception{"celer0007"};

--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -82,15 +82,21 @@ void ActionInitialization::Build() const
     CELER_LOG_LOCAL(status) << "Constructing user action";
 
     // Primary generator emits source particles
+    std::unique_ptr<G4VUserPrimaryGeneratorAction> generator_action;
     if (auto const& hepmc_gen = GlobalSetup::Instance()->hepmc_gen())
     {
-        this->SetUserAction(new HepMC3PrimaryGeneratorAction(hepmc_gen));
+        generator_action
+            = std::make_unique<HepMC3PrimaryGeneratorAction>(hepmc_gen);
     }
     else
     {
-        this->SetUserAction(new PGPrimaryGeneratorAction(
-            GlobalSetup::Instance()->input().primary_options));
+        ExceptionConverter call_g4exception{"celer0006"};
+        CELER_TRY_HANDLE(
+            generator_action = std::make_unique<PGPrimaryGeneratorAction>(
+                GlobalSetup::Instance()->input().primary_options),
+            call_g4exception);
     }
+    this->SetUserAction(generator_action.release());
 
     // Create thread-local transporter to share between actions
     auto transport = std::make_shared<LocalTransporter>();

--- a/app/celer-g4/ActionInitialization.hh
+++ b/app/celer-g4/ActionInitialization.hh
@@ -16,6 +16,8 @@
 
 namespace celeritas
 {
+class HepMC3PrimaryGenerator;
+
 namespace app
 {
 //---------------------------------------------------------------------------//
@@ -42,6 +44,7 @@ class ActionInitialization final : public G4VUserActionInitialization
   private:
     SPParams params_;
     SPDiagnostics diagnostics_;
+    SPPrimaryGenerator hepmc_gen_;
     int num_events_{0};
     mutable bool init_shared_{true};
 };

--- a/app/celer-g4/ActionInitialization.hh
+++ b/app/celer-g4/ActionInitialization.hh
@@ -12,14 +12,13 @@
 
 #include "accel/SharedParams.hh"
 
-#include "GeantDiagnostics.hh"
-
 namespace celeritas
 {
 class HepMC3PrimaryGenerator;
 
 namespace app
 {
+class GeantDiagnostics;
 //---------------------------------------------------------------------------//
 /*!
  * Set up demo-specific action initializations.
@@ -30,7 +29,6 @@ class ActionInitialization final : public G4VUserActionInitialization
     //!@{
     //! \name Type aliases
     using SPParams = std::shared_ptr<SharedParams>;
-    using SPDiagnostics = std::shared_ptr<GeantDiagnostics>;
     //!@}
 
   public:
@@ -43,8 +41,8 @@ class ActionInitialization final : public G4VUserActionInitialization
 
   private:
     SPParams params_;
-    SPDiagnostics diagnostics_;
-    SPPrimaryGenerator hepmc_gen_;
+    std::shared_ptr<GeantDiagnostics> diagnostics_;
+    std::shared_ptr<HepMC3PrimaryGenerator> hepmc_gen_;
     int num_events_{0};
     mutable bool init_shared_{true};
 };

--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -164,21 +164,9 @@ void GlobalSetup::ReadInput(std::string const& filename)
 
         // Apply Celeritas \c SetupOptions commands
         options_->max_num_tracks = input_.num_track_slots;
-        options_->max_num_events = [this] {
-            CELER_VALIDATE(input_.primary_options || !input_.event_file.empty(),
-                           << "no event input file nor primary options were "
-                              "specified");
-            if (!input_.event_file.empty())
-            {
-                hepmc_gen_ = std::make_shared<HepMC3PrimaryGenerator>(
-                    input_.event_file);
-                return static_cast<size_type>(hepmc_gen_->NumEvents());
-            }
-            else
-            {
-                return input_.primary_options.num_events;
-            }
-        }();
+        CELER_VALIDATE(input_.primary_options || !input_.event_file.empty(),
+                       << "no event input file nor primary options were "
+                          "specified");
         options_->max_steps = input_.max_steps;
         options_->initializer_capacity = input_.initializer_capacity;
         options_->secondary_stack_factor = input_.secondary_stack_factor;

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -23,7 +23,6 @@ class G4GenericMessenger;
 
 namespace celeritas
 {
-class HepMC3PrimaryGenerator;
 namespace app
 {
 //---------------------------------------------------------------------------//
@@ -98,9 +97,6 @@ class GlobalSetup
     //! Whether ROOT I/O for SDs is enabled
     bool root_sd_io() const { return root_sd_io_; }
 
-    //! Get HepMC3 primary generator
-    SPPrimaryGenerator const& hepmc_gen() const { return hepmc_gen_; }
-
   private:
     // Private constructor since we're a singleton
     GlobalSetup();
@@ -108,7 +104,6 @@ class GlobalSetup
 
     // Data
     std::shared_ptr<SetupOptions> options_;
-    SPPrimaryGenerator hepmc_gen_;
     RunInput input_;
     Stopwatch get_setup_time_;
     bool root_sd_io_{false};

--- a/app/celer-g4/GlobalSetup.hh
+++ b/app/celer-g4/GlobalSetup.hh
@@ -32,12 +32,6 @@ namespace app
 class GlobalSetup
 {
   public:
-    //!@{
-    //! \name Type aliases
-    using SPPrimaryGenerator = std::shared_ptr<HepMC3PrimaryGenerator>;
-    //!@}
-
-  public:
     // Return non-owning pointer to a singleton
     static GlobalSetup* Instance();
 

--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -77,7 +77,7 @@ struct RunInput
     size_type num_track_slots{};
     size_type max_steps{unspecified};
     size_type initializer_capacity{};
-    real_type secondary_stack_factor{};
+    real_type secondary_stack_factor{2};
     size_type auto_flush{};  //!< Defaults to num_track_slots
 
     bool action_times{false};

--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -38,6 +38,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/io/ExceptionOutput.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/io/OutputRegistry.hh"
 #include "corecel/io/ScopedTimeAndRedirect.hh"
 #include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/io/StringUtils.hh"

--- a/doc/introduction/usage/app.rst
+++ b/doc/introduction/usage/app.rst
@@ -80,8 +80,9 @@ specified with a combination of the ``field_type``, ``field``, and
 ``field_file`` keys, and detailed field driver configuration options are set
 with ``field_options`` corresponding to the ``FieldOptions`` class in :ref:`api_field_data`.
 
-.. note:: The macro file usage is in the process of being replaced by JSON
-   input for improved automation.
+.. deprecated:: The macro file usage is in the process of being replaced by JSON
+   input for improved automation.  Until then, refer
+   to the source code at :file:`app/celer-g4/RunInput.hh` .
 
 The input is a Geant4 macro file for executing the program. Celeritas defines
 several macros in the ``/celer`` and (if CUDA is available) ``/celer/cuda/``


### PR DESCRIPTION
@wdconinc encountered a few issues recently when trying to run `celer-g4` from scratch.
- Mark `.mac` file setup as deprecated since we're trying to transition `celer-g4` to JSON-only input
- Default secondary stack factor to 2; we're not enabling atomic relaxation by default we only need room for annihilation
- Wrap HepMC3 construction in exception conversion to catch errors while loading
- No longer set `num_events` since we're using the single-event model