### PR TITLE
Fix clang-tidy weekly cron

### DIFF
--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           if [ "${{github.event_name}}" == "schedule" ]; then
             echo "Full clang-tidy check on scheduled run."
-            ninja -k0
+            ninja -Cbuild -k0
             exit $?
           fi
           BASE=$(git merge-base origin/${BASE_REF} HEAD)


### PR DESCRIPTION
The weekly cron [failed](https://github.com/celeritas-project/celeritas/actions/runs/12219611731) because we missed moving to the build directory