### PR TITLE
Enable optical stepping loop

### DIFF
--- a/src/celeritas/optical/CoreTrackView.hh
+++ b/src/celeritas/optical/CoreTrackView.hh
@@ -221,8 +221,8 @@ CELER_FUNCTION void CoreTrackView::apply_errored()
 {
     auto sim = this->sim();
     CELER_EXPECT(is_track_valid(sim.status()));
-    sim.status(TrackStatus::killed);
-    sim.post_step_action({});
+    sim.status(TrackStatus::errored);
+    sim.post_step_action(params_.scalars.tracking_cut_action);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/action/detail/PreStepExecutor.hh
+++ b/src/celeritas/optical/action/detail/PreStepExecutor.hh
@@ -32,6 +32,11 @@ struct PreStepExecutor
 CELER_FUNCTION void PreStepExecutor::operator()(CoreTrackView const& track)
 {
     auto sim = track.sim();
+    if (sim.status() == TrackStatus::killed)
+    {
+        // Deactivate tracks killed in previous loop
+        sim.status(TrackStatus::inactive);
+    }
     if (sim.status() == TrackStatus::inactive)
     {
         // Clear step limit and actions for an empty track slot

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -151,7 +151,7 @@ void OpticalLaunchAction::execute_impl(CoreParams const&,
     CELER_ASSERT(offload_state);
     CELER_ASSERT(optical_state.size() > 0);
 
-    constexpr size_type max_step_iters{1};
+    constexpr size_type max_step_iters{1024};
     size_type num_step_iters{0};
     size_type num_steps{0};
 

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -518,8 +518,7 @@ TEST_F(LArSphereOffloadTest, host_generate_small)
         "Celeritas core state initialization complete",
         "No Cherenkov photons to generate",
         "Generated 964 Scintillation photons from 2 distributions",
-        R"(Exceeded step count of 1: aborting optical transport loop with 32 active tracks, 0 alive tracks, 32 vacancies, and 932 queued)",
-        R"(Generated 964 optical photons which completed 32 total steps over 1 iterations)",
+        R"(Generated 964 optical photons which completed 964 total steps over 31 iterations)",
         "Deallocating host core state (stream 0)",
     };
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
@@ -527,7 +526,7 @@ TEST_F(LArSphereOffloadTest, host_generate_small)
         EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
     }
     static char const* const expected_log_levels[]
-        = {"status", "status", "debug", "debug", "error", "debug", "debug"};
+        = {"status", "status", "debug", "debug", "debug", "debug"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
 }
 
@@ -548,15 +547,15 @@ TEST_F(LArSphereOffloadTest, host_generate)
         "Celeritas core state initialization complete",
         "Generated 4258 Cherenkov photons from 4 distributions",
         "Generated 319935 Scintillation photons from 4 distributions",
-        R"(Exceeded step count of 1: aborting optical transport loop with 262144 active tracks, 0 alive tracks, 262144 vacancies, and 62049 queued)",
-        R"(Generated 324193 optical photons which completed 262144 total steps over 1 iterations)",
-        "Deallocating host core state (stream 0)"};
+        R"(Generated 324193 optical photons which completed 324193 total steps over 2 iterations)",
+        "Deallocating host core state (stream 0)",
+    };
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
     }
     static char const* const expected_log_levels[]
-        = {"status", "status", "debug", "debug", "error", "debug", "debug"};
+        = {"status", "status", "debug", "debug", "debug", "debug"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
 
     EXPECT_EQ(2, result.optical_launch_step);


### PR DESCRIPTION
This activates (and fixes) the optical stepping loop by updating the track status at the beginning of the step. We don't need an "initialize vacancies" action like with the main stepping loop because we won't manage secondaries the same way (see https://github.com/celeritas-project/celeritas/issues/1538#issuecomment-2536912759 ). Instead, the "initialize track" action will reset the status to "initializing" for any new tracks, and the "pre-step" action will set the status to "inactive" for any tracks that died in the previous iteration but weren't replaced with newly generated photons.

With this change we're actually stepping photons outside of the geometry! (With no physics or interactions.)