### PR TITLE
Document and slightly refactor Bethe-Heitler interactor

### DIFF
--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -94,13 +94,13 @@ class BetheHeitlerInteractor
     // Minimum epsilon, m_e*c^2/E_gamma; kinematical limit for Y -> e+e-
     real_type epsilon0_;
     // 136/Z^1/3 factor on the screening variable, or zero for low energy
-    real_type screening_;
+    real_type screen_delta_;
     real_type f_z_;
 
     //// CONSTANTS ////
 
-    //! Energy below which nucleus is effectively fully screened
-    static CELER_CONSTEXPR_FUNCTION Energy full_screening_threshold()
+    //! Energy below which screening can be neglected
+    static CELER_CONSTEXPR_FUNCTION Energy no_screening_threshold()
     {
         return units::MevEnergy{2};
     }
@@ -159,15 +159,15 @@ CELER_FUNCTION BetheHeitlerInteractor::BetheHeitlerInteractor(
     epsilon0_ = value_as<Mass>(shared_.electron_mass)
                 / value_as<Energy>(inc_energy_);
 
-    if (inc_energy_ < full_screening_threshold())
+    if (inc_energy_ < no_screening_threshold())
     {
         // Don't reject: just sample uniformly
-        screening_ = 0;
+        screen_delta_ = 0;
         f_z_ = 0;
     }
     else
     {
-        screening_ = epsilon0_ * 136 / element.cbrt_z();
+        screen_delta_ = epsilon0_ * 136 / element.cbrt_z();
         f_z_ = real_type(8) / real_type(3) * element.log_z();
         if (inc_energy_ > coulomb_corr_threshold())
         {
@@ -196,7 +196,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
 
     // Sample fraction of energy given to electron
     real_type epsilon;
-    if (screening_ == 0)
+    if (screen_delta_ == 0)
     {
         // If E_gamma < 2 MeV, rejection not needed -- just sample uniformly
         UniformRealDistribution<real_type> sample_eps(epsilon0_, half);
@@ -207,7 +207,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         // Calculate the minimum (when \epsilon = 1/2) and maximum (when
         // \epsilon = \epsilon_1) values of screening variable, \delta. Above
         // 50 MeV, a Coulomb correction function is introduced.
-        real_type const delta_min = 4 * screening_;
+        real_type const delta_min = 4 * screen_delta_;
         real_type const delta_max
             = std::exp((real_type(42.038) - f_z_) / real_type(8.29))
               - real_type(0.958);
@@ -346,7 +346,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
 CELER_FUNCTION real_type
 BetheHeitlerInteractor::impact_parameter(real_type eps) const
 {
-    return screening_ / (eps * (1 - eps));
+    return screen_delta_ / (eps * (1 - eps));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -123,10 +123,10 @@ class BetheHeitlerInteractor
     inline CELER_FUNCTION real_type impact_parameter(real_type eps) const;
 
     // Calculate the screening functions \f$ \Phi_1 \f$ and \f$ \Phi_2 \f$
-    inline CELER_FUNCTION Real2 screening_phi(real_type delta) const;
+    static inline CELER_FUNCTION Real2 screening_phi(real_type delta);
 
     // Calculate the auxiliary screening functions \f$ F_1 \f$ and \f$ F_2 \f$
-    inline CELER_FUNCTION Real2 screening_f(real_type delta) const;
+    static inline CELER_FUNCTION Real2 screening_f(real_type delta);
 };
 
 //---------------------------------------------------------------------------//
@@ -355,10 +355,10 @@ BetheHeitlerInteractor::impact_parameter(real_type eps) const
  *
  * These correspond to \em f in Butcher: the first screening function is based
  * on the bremsstrahlung cross sections, and the second is due to pair
- * production.
+ * production. The values are improved function fits by M Novak (Geant4).
  */
 CELER_FUNCTION auto
-BetheHeitlerInteractor::screening_phi(real_type delta) const -> Real2
+BetheHeitlerInteractor::screening_phi(real_type delta) -> Real2
 {
     using R = real_type;
 
@@ -393,7 +393,7 @@ BetheHeitlerInteractor::screening_phi(real_type delta) const -> Real2
  * subtraction should be addition.
  */
 CELER_FUNCTION auto
-BetheHeitlerInteractor::screening_f(real_type delta) const -> Real2
+BetheHeitlerInteractor::screening_f(real_type delta) -> Real2
 {
     using R = real_type;
     auto temp = screening_phi(delta);

--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -82,7 +82,7 @@ class BetheHeitlerInteractor
     // Shared model data
     BetheHeitlerData const& shared_;
     // Incident gamma energy
-    real_type const inc_energy_;
+    Energy const inc_energy_;
     // Incident direction
     Real3 const& inc_direction_;
     // Allocate space for a secondary particle
@@ -98,6 +98,12 @@ class BetheHeitlerInteractor
     real_type f_z_;
 
     //// CONSTANTS ////
+
+    //! Energy below which nucleus is effectively fully screened
+    static CELER_CONSTEXPR_FUNCTION Energy full_screening_threshold()
+    {
+        return units::MevEnergy{2};
+    }
 
     //! Energy above which the Coulomb correction is applied [MeV]
     static CELER_CONSTEXPR_FUNCTION Energy coulomb_corr_threshold()
@@ -139,22 +145,21 @@ CELER_FUNCTION BetheHeitlerInteractor::BetheHeitlerInteractor(
     MaterialView const& material,
     ElementView const& element)
     : shared_(shared)
-    , inc_energy_(value_as<Energy>(particle.energy()))
+    , inc_energy_(particle.energy())
     , inc_direction_(inc_direction)
     , allocate_(allocate)
-    , enable_lpm_(shared.enable_lpm
-                  && inc_energy_ > value_as<Energy>(lpm_threshold()))
-    , calc_lpm_functions_(material,
-                          element,
-                          shared_.dielectric_suppression(),
-                          Energy{inc_energy_})
+    , enable_lpm_(shared.enable_lpm && inc_energy_ > lpm_threshold())
+    , calc_lpm_functions_(
+          material, element, shared_.dielectric_suppression(), inc_energy_)
 {
     CELER_EXPECT(particle.particle_id() == shared_.ids.gamma);
-    CELER_EXPECT(inc_energy_ >= 2 * value_as<Mass>(shared_.electron_mass));
+    CELER_EXPECT(value_as<Energy>(inc_energy_)
+                 >= 2 * value_as<Mass>(shared_.electron_mass));
 
-    epsilon0_ = value_as<Mass>(shared_.electron_mass) / inc_energy_;
+    epsilon0_ = value_as<Mass>(shared_.electron_mass)
+                / value_as<Energy>(inc_energy_);
 
-    if (inc_energy_ < value_as<Energy>(units::MevEnergy{2}))
+    if (inc_energy_ < full_screening_threshold())
     {
         // Don't reject: just sample uniformly
         screening_ = 0;
@@ -164,9 +169,9 @@ CELER_FUNCTION BetheHeitlerInteractor::BetheHeitlerInteractor(
     {
         screening_ = epsilon0_ * 136 / element.cbrt_z();
         f_z_ = real_type(8) / real_type(3) * element.log_z();
-        if (inc_energy_ > value_as<Energy>(coulomb_corr_threshold()))
+        if (inc_energy_ > coulomb_corr_threshold())
         {
-            // Apply Coulomg correction function
+            // Apply Coulomb correction function
             f_z_ += 8 * element.coulomb_correction();
         }
     }
@@ -189,10 +194,11 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
 
     constexpr real_type half = 0.5;
 
-    // If E_gamma < 2 MeV, rejection not needed -- just sample uniformly
+    // Sample fraction of energy given to electron
     real_type epsilon;
     if (screening_ == 0)
     {
+        // If E_gamma < 2 MeV, rejection not needed -- just sample uniformly
         UniformRealDistribution<real_type> sample_eps(epsilon0_, half);
         epsilon = sample_eps(rng);
     }
@@ -214,12 +220,12 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         // introduced, where \epsilon_1 is the solution to
         // \Phi(\delta(\epsilon)) - F(Z)/2 = 0.
         real_type const epsilon1
-            = half - half * std::sqrt(1 - delta_min / delta_max);
+            = half * (1 - std::sqrt(1 - delta_min / delta_max));
         real_type const epsilon_min = celeritas::max(epsilon0_, epsilon1);
 
-        // Decide to choose f1, g1 or f2, g2 based on N1, N2 (factors from
-        // corrected Bethe-Heitler cross section; c.f. Eq. 6.6 of Geant4
-        // Physics Reference 10.6)
+        // Decide to choose f1, g1 [brems] or f2, g2 [pair production]
+        // based on N1, N2 (factors from corrected Bethe-Heitler cross section;
+        // c.f. Eq. 6.6 of Geant4 Physics Reference 10.6)
         Real2 const fmin = this->screening_f(delta_min) - f_z_;
         BernoulliDistribution choose_f1g1(
             ipow<2>(half - epsilon_min) * fmin[0], real_type(1.5) * fmin[1]);
@@ -261,8 +267,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
             else
             {
                 // Used to sample from f2
-                epsilon = epsilon_min
-                          + (half - epsilon_min) * generate_canonical(rng);
+                epsilon = UniformRealDistribution{epsilon_min, half}(rng);
                 CELER_ASSERT(epsilon >= epsilon_min && epsilon <= half);
 
                 // Calculate delta given the element atomic number and sampled
@@ -286,7 +291,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
                 g /= fmin[1];
                 CELER_ASSERT(g > 0);
             }
-            // TODO: use rejection
+            // TODO: use rejection?
         } while (g < generate_canonical(rng));
     }
 
@@ -298,9 +303,9 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
     secondaries[0].particle_id = shared_.ids.electron;
     secondaries[1].particle_id = shared_.ids.positron;
 
-    secondaries[0].energy = Energy{(1 - epsilon) * inc_energy_
+    secondaries[0].energy = Energy{(1 - epsilon) * value_as<Energy>(inc_energy_)
                                    - value_as<Mass>(shared_.electron_mass)};
-    secondaries[1].energy = Energy{epsilon * inc_energy_
+    secondaries[1].energy = Energy{epsilon * value_as<Energy>(inc_energy_)
                                    - value_as<Mass>(shared_.electron_mass)};
 
     // Select charges for child particles (e-, e+) randomly
@@ -311,21 +316,23 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
 
     // Sample secondary directions.  Note that momentum is not exactly
     // conserved.
-    real_type phi
+    real_type const phi
         = UniformRealDistribution<real_type>(0, 2 * constants::pi)(rng);
+    auto sample_angle = [&](Energy e) {
+        return TsaiUrbanDistribution{e, shared_.electron_mass}(rng);
+    };
 
     // Electron
-    TsaiUrbanDistribution sample_electron_angle(secondaries[0].energy,
-                                                shared_.electron_mass);
-    real_type cost = sample_electron_angle(rng);
     secondaries[0].direction
-        = rotate(from_spherical(cost, phi), inc_direction_);
-    // Positron
-    TsaiUrbanDistribution sample_positron_angle(secondaries[1].energy,
-                                                shared_.electron_mass);
-    cost = sample_positron_angle(rng);
+        = rotate(from_spherical(sample_angle(secondaries[0].energy), phi),
+                 inc_direction_);
+
+    // Positron (opposite azimuthal angle)
     secondaries[1].direction
-        = rotate(from_spherical(cost, phi + constants::pi), inc_direction_);
+        = rotate(from_spherical(sample_angle(secondaries[1].energy),
+                                phi + constants::pi),
+                 inc_direction_);
+
     return result;
 }
 
@@ -346,7 +353,9 @@ BetheHeitlerInteractor::impact_parameter(real_type eps) const
 /*!
  * Screening functions \f$ \Phi_1(\delta) \f$ and \f$ \Phi_2(\delta) \f$.
  *
- * These correspond to \em f in Butcher
+ * These correspond to \em f in Butcher: the first screening function is based
+ * on the bremsstrahlung cross sections, and the second is due to pair
+ * production.
  */
 CELER_FUNCTION auto
 BetheHeitlerInteractor::screening_phi(real_type delta) const -> Real2

--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -85,14 +85,15 @@ class BetheHeitlerInteractor
     Real3 const& inc_direction_;
     // Allocate space for a secondary particle
     StackAllocator<Secondary>& allocate_;
-    // Element properties for calculating screening functions and variables
-    ElementView const& element_;
     // Whether LPM supression is applied
     bool const enable_lpm_;
     // Used to calculate the LPM suppression functions
     LPMCalculator calc_lpm_functions_;
-    // Cached minimum epsilon, m_e*c^2/E_gamma; kinematical limit for Y -> e+e-
+    // Minimum epsilon, m_e*c^2/E_gamma; kinematical limit for Y -> e+e-
     real_type epsilon0_;
+    // 136/Z^1/3 factor on the screening variable, or zero for low energy
+    real_type screening_;
+    real_type f_z_;
 
     //// CONSTANTS ////
 
@@ -143,11 +144,10 @@ CELER_FUNCTION BetheHeitlerInteractor::BetheHeitlerInteractor(
     , inc_energy_(value_as<Energy>(particle.energy()))
     , inc_direction_(inc_direction)
     , allocate_(allocate)
-    , element_(element)
     , enable_lpm_(shared.enable_lpm
                   && inc_energy_ > value_as<Energy>(lpm_threshold()))
     , calc_lpm_functions_(material,
-                          element_,
+                          element,
                           shared_.dielectric_suppression(),
                           Energy{inc_energy_})
 {
@@ -155,6 +155,23 @@ CELER_FUNCTION BetheHeitlerInteractor::BetheHeitlerInteractor(
     CELER_EXPECT(inc_energy_ >= 2 * value_as<Mass>(shared_.electron_mass));
 
     epsilon0_ = value_as<Mass>(shared_.electron_mass) / inc_energy_;
+
+    if (inc_energy_ < value_as<Energy>(units::MevEnergy{2}))
+    {
+        // Don't reject: just sample uniformly
+        screening_ = 0;
+        f_z_ = 0;
+    }
+    else
+    {
+        screening_ = epsilon0_ * 136 / element.cbrt_z();
+        f_z_ = real_type(8) / real_type(3) * element.log_z();
+        if (inc_energy_ > value_as<Energy>(coulomb_corr_threshold()))
+        {
+            // Apply Coulomg correction function
+            f_z_ += 8 * element.coulomb_correction();
+        }
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -176,7 +193,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
 
     // If E_gamma < 2 MeV, rejection not needed -- just sample uniformly
     real_type epsilon;
-    if (inc_energy_ < value_as<Energy>(units::MevEnergy{2}))
+    if (screening_ == 0)
     {
         UniformRealDistribution<real_type> sample_eps(epsilon0_, half);
         epsilon = sample_eps(rng);
@@ -186,14 +203,9 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         // Calculate the minimum (when \epsilon = 1/2) and maximum (when
         // \epsilon = \epsilon_1) values of screening variable, \delta. Above
         // 50 MeV, a Coulomb correction function is introduced.
-        real_type const delta_min = 4 * 136 / element_.cbrt_z() * epsilon0_;
-        real_type f_z = real_type(8) / real_type(3) * element_.log_z();
-        if (inc_energy_ > value_as<Energy>(coulomb_corr_threshold()))
-        {
-            f_z += 8 * element_.coulomb_correction();
-        }
+        real_type const delta_min = 4 * screening_;
         real_type const delta_max
-            = std::exp((real_type(42.038) - f_z) / real_type(8.29))
+            = std::exp((real_type(42.038) - f_z_) / real_type(8.29))
               - real_type(0.958);
         CELER_ASSERT(delta_min <= delta_max);
 
@@ -210,8 +222,8 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         // Decide to choose f1, g1 or f2, g2 based on N1, N2 (factors from
         // corrected Bethe-Heitler cross section; c.f. Eq. 6.6 of Geant4
         // Physics Reference 10.6)
-        real_type const f10 = this->screening_f1(delta_min) - f_z;
-        real_type const f20 = this->screening_f2(delta_min) - f_z;
+        real_type const f10 = this->screening_f1(delta_min) - f_z_;
+        real_type const f20 = this->screening_f2(delta_min) - f_z_;
         BernoulliDistribution choose_f1g1(ipow<2>(half - epsilon_min) * f10,
                                           real_type(1.5) * f20);
 
@@ -240,13 +252,13 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
                     auto lpm = calc_lpm_functions_(epsilon);
                     g = lpm.xi
                         * ((2 * lpm.phi + lpm.g) * screening.phi1
-                           - lpm.g * screening.phi2 - lpm.phi * f_z)
-                        / f10;
+                           - lpm.g * screening.phi2 - lpm.phi * f_z_);
                 }
                 else
                 {
-                    g = (this->screening_f1(delta) - f_z) / f10;
+                    g = this->screening_f1(delta) - f_z_;
                 }
+                g /= f10;
                 CELER_ASSERT(g > 0);
             }
             else
@@ -266,18 +278,18 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
                 {
                     auto screening = screening_phi1_phi2(delta);
                     auto lpm = calc_lpm_functions_(epsilon);
-                    g = lpm.xi
-                        * ((lpm.phi + half * lpm.g) * screening.phi1
-                           + half * lpm.g * screening.phi2
-                           - half * (lpm.g + lpm.phi) * f_z)
-                        / f20;
+                    g = half * lpm.xi
+                        * ((2 * lpm.phi + lpm.g) * screening.phi1
+                           + lpm.g * screening.phi2 - (lpm.g + lpm.phi) * f_z_);
                 }
                 else
                 {
-                    g = (this->screening_f2(delta) - f_z) / f20;
+                    g = this->screening_f2(delta) - f_z_;
                 }
+                g /= f20;
                 CELER_ASSERT(g > 0);
             }
+            // TODO: use rejection
         } while (g < generate_canonical(rng));
     }
 
@@ -330,7 +342,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
 CELER_FUNCTION real_type
 BetheHeitlerInteractor::impact_parameter(real_type eps) const
 {
-    return 136 / element_.cbrt_z() * epsilon0_ / (eps * (1 - eps));
+    return screening_ / (eps * (1 - eps));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -120,7 +120,7 @@ class BetheHeitlerInteractor
     inline CELER_FUNCTION Real2 screening_phi(real_type delta) const;
 
     // Calculate the auxiliary screening functions \f$ F_1 \f$ and \f$ F_2 \f$
-    inline CELER_FUNCTION Real2 screening_f(Real2 const& phi) const;
+    inline CELER_FUNCTION Real2 screening_f(real_type delta) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -220,8 +220,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         // Decide to choose f1, g1 or f2, g2 based on N1, N2 (factors from
         // corrected Bethe-Heitler cross section; c.f. Eq. 6.6 of Geant4
         // Physics Reference 10.6)
-        Real2 const fmin = this->screening_f(this->screening_phi(delta_min))
-                           - f_z_;
+        Real2 const fmin = this->screening_f(delta_min) - f_z_;
         BernoulliDistribution choose_f1g1(
             ipow<2>(half - epsilon_min) * fmin[0], real_type(1.5) * fmin[1]);
 
@@ -230,17 +229,34 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         real_type g;
         do
         {
-            // Sample screening from Brems (f1 & phi1, index 0)
-            // or pair production (f2 & phi2, index 1)
-            int const process_index = choose_f1g1(rng) ? 0 : 1;
-
-            if (process_index == 0)
+            if (choose_f1g1(rng))
             {
                 // Used to sample from f1
                 epsilon = half
                           - (half - epsilon_min)
                                 * std::cbrt(generate_canonical(rng));
                 CELER_ASSERT(epsilon >= epsilon_min && epsilon <= half);
+
+                // Calculate delta from element atomic number and sampled
+                // epsilon
+                real_type delta = this->impact_parameter(epsilon);
+                CELER_ASSERT(delta <= delta_max && delta >= delta_min);
+
+                // Calculate g_1 rejection function
+                if (enable_lpm_)
+                {
+                    auto screening = screening_phi(delta);
+                    auto lpm = calc_lpm_functions_(epsilon);
+                    g = lpm.xi
+                        * ((2 * lpm.phi + lpm.g) * screening[0]
+                           - lpm.g * screening[1] - lpm.phi * f_z_);
+                }
+                else
+                {
+                    g = this->screening_f(delta)[0] - f_z_;
+                }
+                g /= fmin[0];
+                CELER_ASSERT(g > 0);
             }
             else
             {
@@ -248,38 +264,28 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
                 epsilon = epsilon_min
                           + (half - epsilon_min) * generate_canonical(rng);
                 CELER_ASSERT(epsilon >= epsilon_min && epsilon <= half);
-            }
 
-            // Calculate delta from element atomic number and sampled
-            // epsilon
-            real_type delta = this->impact_parameter(epsilon);
-            CELER_ASSERT(delta <= delta_max && delta >= delta_min);
+                // Calculate delta given the element atomic number and sampled
+                // epsilon
+                real_type delta = this->impact_parameter(epsilon);
+                CELER_ASSERT(delta <= delta_max && delta >= delta_min);
 
-            // Calculate rejection function
-            auto screening = screening_phi(delta);
-            if (enable_lpm_)
-            {
-                auto lpm = calc_lpm_functions_(epsilon);
-                if (process_index == 0)
+                // Calculate g_2 rejection function
+                if (enable_lpm_)
                 {
-                    g = lpm.xi
-                        * ((2 * lpm.phi + lpm.g) * screening[0]
-                           - lpm.g * screening[1] - lpm.phi * f_z_);
-                }
-                else
-                {
+                    auto screening = screening_phi(delta);
+                    auto lpm = calc_lpm_functions_(epsilon);
                     g = half * lpm.xi
                         * ((2 * lpm.phi + lpm.g) * screening[0]
                            + lpm.g * screening[1] - (lpm.g + lpm.phi) * f_z_);
                 }
+                else
+                {
+                    g = this->screening_f(delta)[1] - f_z_;
+                }
+                g /= fmin[1];
+                CELER_ASSERT(g > 0);
             }
-            else
-            {
-                g = this->screening_f(screening)[process_index] - f_z_;
-            }
-            g /= fmin[process_index];
-            CELER_ASSERT(g > 0);
-
             // TODO: use rejection
         } while (g < generate_canonical(rng));
     }
@@ -378,10 +384,11 @@ BetheHeitlerInteractor::screening_phi(real_type delta) const -> Real2
  * subtraction should be addition.
  */
 CELER_FUNCTION auto
-BetheHeitlerInteractor::screening_f(Real2 const& phi) const -> Real2
+BetheHeitlerInteractor::screening_f(real_type delta) const -> Real2
 {
     using R = real_type;
-    return {3 * phi[0] - phi[1], R{1.5} * phi[0] + R{0.5} * phi[1]};
+    auto temp = screening_phi(delta);
+    return {3 * temp[0] - temp[1], R{1.5} * temp[0] + R{0.5} * temp[1]};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -11,12 +11,14 @@
 #include "corecel/Types.hh"
 #include "corecel/data/StackAllocator.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/BetheHeitlerData.hh"
 #include "celeritas/em/distribution/TsaiUrbanDistribution.hh"
 #include "celeritas/em/xs/LPMCalculator.hh"
+#include "celeritas/grid/PolyEvaluator.hh"
 #include "celeritas/mat/ElementView.hh"
 #include "celeritas/phys/Interaction.hh"
 #include "celeritas/phys/ParticleTrackView.hh"
@@ -41,6 +43,11 @@ namespace celeritas
  * G4PairProductionRelModel, as documented in sections 6.5 (gamma conversion)
  * and 10.2.2 (LPM effect) of the Geant4 Physics Reference Manual (release
  * 10.7)
+ *
+ * For additional context on the derivation see:
+ *     Butcher, J.C., and H. Messel. “Electron Number Distribution in
+ *     Electron-Photon Showers in Air and Aluminium Absorbers.” Nuclear Physics
+ *     20 (October 1960): 15–128. https://doi.org/10.1016/0029-5582(60)90162-0.
  */
 class BetheHeitlerInteractor
 {
@@ -68,12 +75,7 @@ class BetheHeitlerInteractor
   private:
     //// TYPES ////
 
-    //! Screening functions \f$ \Phi_1 \f$ and \f$ \Phi_2 \f$
-    struct ScreeningFunctions
-    {
-        real_type phi1;
-        real_type phi2;
-    };
+    using Real2 = Array<real_type, 2>;
 
     //// DATA ////
 
@@ -115,14 +117,10 @@ class BetheHeitlerInteractor
     inline CELER_FUNCTION real_type impact_parameter(real_type eps) const;
 
     // Calculate the screening functions \f$ \Phi_1 \f$ and \f$ \Phi_2 \f$
-    inline CELER_FUNCTION ScreeningFunctions
-    screening_phi1_phi2(real_type delta) const;
+    inline CELER_FUNCTION Real2 screening_phi(real_type delta) const;
 
-    // Calculate the auxiliary screening function \f$ F_1 \f$
-    inline CELER_FUNCTION real_type screening_f1(real_type delta) const;
-
-    // Calculate the auxiliary screening function \f$ F_2 \f$
-    inline CELER_FUNCTION real_type screening_f2(real_type delta) const;
+    // Calculate the auxiliary screening functions \f$ F_1 \f$ and \f$ F_2 \f$
+    inline CELER_FUNCTION Real2 screening_f(real_type delta) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -222,10 +220,9 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         // Decide to choose f1, g1 or f2, g2 based on N1, N2 (factors from
         // corrected Bethe-Heitler cross section; c.f. Eq. 6.6 of Geant4
         // Physics Reference 10.6)
-        real_type const f10 = this->screening_f1(delta_min) - f_z_;
-        real_type const f20 = this->screening_f2(delta_min) - f_z_;
-        BernoulliDistribution choose_f1g1(ipow<2>(half - epsilon_min) * f10,
-                                          real_type(1.5) * f20);
+        Real2 const fmin = this->screening_f(delta_min) - f_z_;
+        BernoulliDistribution choose_f1g1(
+            ipow<2>(half - epsilon_min) * fmin[0], real_type(1.5) * fmin[1]);
 
         // Rejection function g_1 or g_2. Note the it's possible for g to be
         // greater than one
@@ -248,17 +245,17 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
                 // Calculate g_1 rejection function
                 if (enable_lpm_)
                 {
-                    auto screening = screening_phi1_phi2(delta);
+                    auto screening = screening_phi(delta);
                     auto lpm = calc_lpm_functions_(epsilon);
                     g = lpm.xi
-                        * ((2 * lpm.phi + lpm.g) * screening.phi1
-                           - lpm.g * screening.phi2 - lpm.phi * f_z_);
+                        * ((2 * lpm.phi + lpm.g) * screening[0]
+                           - lpm.g * screening[1] - lpm.phi * f_z_);
                 }
                 else
                 {
-                    g = this->screening_f1(delta) - f_z_;
+                    g = this->screening_f(delta)[0] - f_z_;
                 }
-                g /= f10;
+                g /= fmin[0];
                 CELER_ASSERT(g > 0);
             }
             else
@@ -276,17 +273,17 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
                 // Calculate g_2 rejection function
                 if (enable_lpm_)
                 {
-                    auto screening = screening_phi1_phi2(delta);
+                    auto screening = screening_phi(delta);
                     auto lpm = calc_lpm_functions_(epsilon);
                     g = half * lpm.xi
-                        * ((2 * lpm.phi + lpm.g) * screening.phi1
-                           + lpm.g * screening.phi2 - (lpm.g + lpm.phi) * f_z_);
+                        * ((2 * lpm.phi + lpm.g) * screening[0]
+                           + lpm.g * screening[1] - (lpm.g + lpm.phi) * f_z_);
                 }
                 else
                 {
-                    g = this->screening_f2(delta) - f_z_;
+                    g = this->screening_f(delta)[1] - f_z_;
                 }
-                g /= f20;
+                g /= fmin[1];
                 CELER_ASSERT(g > 0);
             }
             // TODO: use rejection
@@ -348,22 +345,25 @@ BetheHeitlerInteractor::impact_parameter(real_type eps) const
 //---------------------------------------------------------------------------//
 /*!
  * Screening functions \f$ \Phi_1(\delta) \f$ and \f$ \Phi_2(\delta) \f$.
+ *
+ * These correspond to \em f in Butcher
  */
-CELER_FUNCTION auto BetheHeitlerInteractor::screening_phi1_phi2(
-    real_type delta) const -> ScreeningFunctions
+CELER_FUNCTION auto
+BetheHeitlerInteractor::screening_phi(real_type delta) const -> Real2
 {
     using R = real_type;
 
-    ScreeningFunctions result;
+    Real2 result;
     if (delta > R(1.4))
     {
-        result.phi1 = R(21.0190) - R(4.145) * std::log(delta + R(0.958));
-        result.phi2 = result.phi1;
+        result[0] = R(21.0190) - R(4.145) * std::log(delta + R(0.958));
+        result[1] = result[0];
     }
     else
     {
-        result.phi1 = R(20.806) - delta * (R(3.190) - R(0.5710) * delta);
-        result.phi2 = R(20.234) - delta * (R(2.126) - R(0.0903) * delta);
+        using PolyQuad = PolyEvaluator<real_type, 2>;
+        result[0] = PolyQuad{20.806, -3.190, 0.5710}(delta);
+        result[1] = PolyQuad{20.234, -2.126, 0.0903}(delta);
     }
     return result;
 }
@@ -373,27 +373,23 @@ CELER_FUNCTION auto BetheHeitlerInteractor::screening_phi1_phi2(
  * Auxiliary screening functions \f$ F_1(\delta) \f$ and \f$ F_2(\delta) \f$.
  *
  * The functions \f$ F_1 = 3 \Phi_1(\delta) - \Phi_2(\delta) \f$
- * and \f$ F_2 = 1.5\Phi_1(\delta) - 0.5\Phi_2(\delta) \f$
+ * and \f$ F_2 = 1.5\Phi_1(\delta) + 0.5\Phi_2(\delta) \f$
  * are decreasing functions of \f$ \delta \f$ for all \f$ \delta \f$
  * in \f$ [\delta_\textrm{min}, \delta_\textrm{max}] \f$.
  * They reach their maximum value at
  * \f$ \delta_\textrm{min} = \delta(\epsilon = 1/2)\f$. They are used in the
  * composition + rejection technique for sampling \f$ \epsilon \f$.
+ *
+ * Note that there's a typo in the Geant4 manual in the formula for F2:
+ * subtraction should be addition.
  */
-CELER_FUNCTION real_type BetheHeitlerInteractor::screening_f1(real_type delta) const
+CELER_FUNCTION auto
+BetheHeitlerInteractor::screening_f(real_type delta) const -> Real2
 {
     using R = real_type;
-
-    return delta > R(1.4) ? R(42.038) - R(8.29) * std::log(delta + R(0.958))
-                          : R(42.184) - delta * (R(7.444) - R(1.623) * delta);
+    auto temp = screening_phi(delta);
+    return {3 * temp[0] - temp[1], R{1.5} * temp[0] + R{0.5} * temp[1]};
 }
 
-CELER_FUNCTION real_type BetheHeitlerInteractor::screening_f2(real_type delta) const
-{
-    using R = real_type;
-
-    return delta > R(1.4) ? R(42.038) - R(8.29) * std::log(delta + R(0.958))
-                          : R(41.326) - delta * (R(5.848) - R(0.902) * delta);
-}
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -299,37 +299,34 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
     Interaction result = Interaction::from_absorption();
     result.secondaries = {secondaries, 2};
 
-    // Outgoing secondaries are electron and positron
+    // Outgoing secondaries are electron and positron with randomly selected
+    // charges
     secondaries[0].particle_id = shared_.ids.electron;
     secondaries[1].particle_id = shared_.ids.positron;
 
+    // Incident energy split between the particles, with rest mass subtracted
     secondaries[0].energy = Energy{(1 - epsilon) * value_as<Energy>(inc_energy_)
                                    - value_as<Mass>(shared_.electron_mass)};
     secondaries[1].energy = Energy{epsilon * value_as<Energy>(inc_energy_)
                                    - value_as<Mass>(shared_.electron_mass)};
-
-    // Select charges for child particles (e-, e+) randomly
     if (BernoulliDistribution(half)(rng))
     {
         trivial_swap(secondaries[0].energy, secondaries[1].energy);
     }
 
-    // Sample secondary directions.  Note that momentum is not exactly
-    // conserved.
+    // Sample secondary directions: note that momentum is not exactly conserved
     real_type const phi
         = UniformRealDistribution<real_type>(0, 2 * constants::pi)(rng);
-    auto sample_angle = [&](Energy e) {
+    auto sample_costheta = [&](Energy e) {
         return TsaiUrbanDistribution{e, shared_.electron_mass}(rng);
     };
 
-    // Electron
+    // Note that positron has opposite azimuthal angle
     secondaries[0].direction
-        = rotate(from_spherical(sample_angle(secondaries[0].energy), phi),
+        = rotate(from_spherical(sample_costheta(secondaries[0].energy), phi),
                  inc_direction_);
-
-    // Positron (opposite azimuthal angle)
     secondaries[1].direction
-        = rotate(from_spherical(sample_angle(secondaries[1].energy),
+        = rotate(from_spherical(sample_costheta(secondaries[1].energy),
                                 phi + constants::pi),
                  inc_direction_);
 

--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -120,7 +120,7 @@ class BetheHeitlerInteractor
     inline CELER_FUNCTION Real2 screening_phi(real_type delta) const;
 
     // Calculate the auxiliary screening functions \f$ F_1 \f$ and \f$ F_2 \f$
-    inline CELER_FUNCTION Real2 screening_f(real_type delta) const;
+    inline CELER_FUNCTION Real2 screening_f(Real2 const& phi) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -220,7 +220,8 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         // Decide to choose f1, g1 or f2, g2 based on N1, N2 (factors from
         // corrected Bethe-Heitler cross section; c.f. Eq. 6.6 of Geant4
         // Physics Reference 10.6)
-        Real2 const fmin = this->screening_f(delta_min) - f_z_;
+        Real2 const fmin = this->screening_f(this->screening_phi(delta_min))
+                           - f_z_;
         BernoulliDistribution choose_f1g1(
             ipow<2>(half - epsilon_min) * fmin[0], real_type(1.5) * fmin[1]);
 
@@ -229,34 +230,17 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         real_type g;
         do
         {
-            if (choose_f1g1(rng))
+            // Sample screening from Brems (f1 & phi1, index 0)
+            // or pair production (f2 & phi2, index 1)
+            int const process_index = choose_f1g1(rng) ? 0 : 1;
+
+            if (process_index == 0)
             {
                 // Used to sample from f1
                 epsilon = half
                           - (half - epsilon_min)
                                 * std::cbrt(generate_canonical(rng));
                 CELER_ASSERT(epsilon >= epsilon_min && epsilon <= half);
-
-                // Calculate delta from element atomic number and sampled
-                // epsilon
-                real_type delta = this->impact_parameter(epsilon);
-                CELER_ASSERT(delta <= delta_max && delta >= delta_min);
-
-                // Calculate g_1 rejection function
-                if (enable_lpm_)
-                {
-                    auto screening = screening_phi(delta);
-                    auto lpm = calc_lpm_functions_(epsilon);
-                    g = lpm.xi
-                        * ((2 * lpm.phi + lpm.g) * screening[0]
-                           - lpm.g * screening[1] - lpm.phi * f_z_);
-                }
-                else
-                {
-                    g = this->screening_f(delta)[0] - f_z_;
-                }
-                g /= fmin[0];
-                CELER_ASSERT(g > 0);
             }
             else
             {
@@ -264,28 +248,38 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
                 epsilon = epsilon_min
                           + (half - epsilon_min) * generate_canonical(rng);
                 CELER_ASSERT(epsilon >= epsilon_min && epsilon <= half);
+            }
 
-                // Calculate delta given the element atomic number and sampled
-                // epsilon
-                real_type delta = this->impact_parameter(epsilon);
-                CELER_ASSERT(delta <= delta_max && delta >= delta_min);
+            // Calculate delta from element atomic number and sampled
+            // epsilon
+            real_type delta = this->impact_parameter(epsilon);
+            CELER_ASSERT(delta <= delta_max && delta >= delta_min);
 
-                // Calculate g_2 rejection function
-                if (enable_lpm_)
+            // Calculate rejection function
+            auto screening = screening_phi(delta);
+            if (enable_lpm_)
+            {
+                auto lpm = calc_lpm_functions_(epsilon);
+                if (process_index == 0)
                 {
-                    auto screening = screening_phi(delta);
-                    auto lpm = calc_lpm_functions_(epsilon);
+                    g = lpm.xi
+                        * ((2 * lpm.phi + lpm.g) * screening[0]
+                           - lpm.g * screening[1] - lpm.phi * f_z_);
+                }
+                else
+                {
                     g = half * lpm.xi
                         * ((2 * lpm.phi + lpm.g) * screening[0]
                            + lpm.g * screening[1] - (lpm.g + lpm.phi) * f_z_);
                 }
-                else
-                {
-                    g = this->screening_f(delta)[1] - f_z_;
-                }
-                g /= fmin[1];
-                CELER_ASSERT(g > 0);
             }
+            else
+            {
+                g = this->screening_f(screening)[process_index] - f_z_;
+            }
+            g /= fmin[process_index];
+            CELER_ASSERT(g > 0);
+
             // TODO: use rejection
         } while (g < generate_canonical(rng));
     }
@@ -384,11 +378,10 @@ BetheHeitlerInteractor::screening_phi(real_type delta) const -> Real2
  * subtraction should be addition.
  */
 CELER_FUNCTION auto
-BetheHeitlerInteractor::screening_f(real_type delta) const -> Real2
+BetheHeitlerInteractor::screening_f(Real2 const& phi) const -> Real2
 {
     using R = real_type;
-    auto temp = screening_phi(delta);
-    return {3 * temp[0] - temp[1], R{1.5} * temp[0] + R{0.5} * temp[1]};
+    return {3 * phi[0] - phi[1], R{1.5} * phi[0] + R{0.5} * phi[1]};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/xs/LPMCalculator.hh
+++ b/src/celeritas/em/xs/LPMCalculator.hh
@@ -47,12 +47,12 @@ namespace celeritas
 class LPMCalculator
 {
   public:
-    //! Evaluated LPM suppression functions
+    //! Evaluated LPM suppression functions default to "low energy" values
     struct LPMFunctions
     {
-        real_type xi;  //!< Near-unity logarithmic factor
-        real_type g;  //!< Pair production factor
-        real_type phi;
+        real_type xi{1};  //!< Near-unity logarithmic factor
+        real_type g{1};  //!< Pair production factor
+        real_type phi{1};
     };
 
   public:
@@ -149,7 +149,6 @@ CELER_FUNCTION auto LPMCalculator::operator()(real_type epsilon) -> LPMFunctions
 
         // Recalculate \f$ \xi \$ from the modified suppression variable (Eq.
         // 16 in Stanev)
-        xi = 2;
         if (s > 1)
         {
             xi = 1;
@@ -157,6 +156,10 @@ CELER_FUNCTION auto LPMCalculator::operator()(real_type epsilon) -> LPMFunctions
         else if (s > s1)
         {
             xi = 1 + std::log(s) / std::log(s1);
+        }
+        else
+        {
+            xi = 2;
         }
     }
 


### PR DESCRIPTION
I started playing around with the BH code some months ago during a refactor and finally am closing it out. There are some approximate fitting functions that I first rewrote with `PolyEvaluator` and combined with a few other expressions. In doing so I identified a typo in the geant4 physics manual and got some better provenance on the methods/fits in the interactor.

It's possible to combine some of the sampling code even further (bf4927b5b9f4d35ddc0d230beb8f4de1cf932088) but it doesn't necessarily increase clarity and performance doesn't really matter.