### PR TITLE
Update CMake policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 #----------------------------------------------------------------------------#
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.18...3.31)
 
 # Set Celeritas_VERSION using git tags using the following format
 set(CGV_TAG_REGEX "v([0-9.]+)(-dev|-rc.[0-9]+)?")
@@ -14,7 +14,6 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE
   "${CMAKE_CURRENT_LIST_DIR}/cmake/CeleritasMakeRulesOverride.cmake")
 
 project(Celeritas VERSION "${Celeritas_VERSION}" LANGUAGES CXX)
-cmake_policy(VERSION 3.18...3.28)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ Geant4:
 - 11.1-11.3: [no support for default Rayleigh scattering cross section](see
   https://github.com/celeritas-project/celeritas/issues/1091)
 
-Note also that navigation bugs in older versions of Geant4 and VecGeom can
-cause test failures in Celeritas.
+Note also that navigation bugs in Geant4 and VecGeom older than the versions
+listed above *will* cause failures in some geometry-related unit tests. Future
+behavior changes in external packages may also cause failures.
 
 Since we compile with extra warning flags and avoid non-portable code, most
 other compilers *should* work.

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -434,11 +434,6 @@ if(CELERITAS_USE_Geant4 AND CELERITAS_USE_ROOT)
     add_custom_command(
       TARGET update-root-test-data
       POST_BUILD
-      DEPENDS
-        celer-export-geant
-        "${_gdml}"
-        "${_basename}.geant.json"
-        "${PROJECT_SOURCE_DIR}/src/celeritas/ext/RootInterfaceLinkDef.h"
       COMMAND
         "${CMAKE_COMMAND}" "-E" "env" ${CELER_G4ENV}
         "$<TARGET_FILE:celer-export-geant>"


### PR DESCRIPTION
This updates the CMake support to bleeding-edge 3.31, and fixes an unwitting misuse of the cmake's [add_custom_command]( https://cmake.org/cmake/help/latest/command/add_custom_command.html#generating-files) which is probably why #1516 was so confusing.