### PR TITLE
Add 'LogicalTrue' functor

### DIFF
--- a/src/celeritas/ext/detail/GeantOpticalModelImporter.cc
+++ b/src/celeritas/ext/detail/GeantOpticalModelImporter.cc
@@ -11,6 +11,7 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/math/Algorithms.hh"
 #include "celeritas/io/ImportMaterial.hh"
 
 #include "GeantMaterialPropertyGetter.hh"
@@ -50,10 +51,8 @@ GeantOpticalModelImporter::GeantOpticalModelImporter(
         opt_to_mat_[opt_id.get()] = material->GetMaterialPropertiesTable();
     }
 
-    CELER_ASSERT(std::all_of(
-        opt_to_mat_.begin(), opt_to_mat_.end(), [](auto const* mpt) {
-            return static_cast<bool>(mpt);
-        }));
+    CELER_ASSERT(
+        std::all_of(opt_to_mat_.begin(), opt_to_mat_.end(), LogicalTrue{}));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantProcessImporter.cc
+++ b/src/celeritas/ext/detail/GeantProcessImporter.cc
@@ -34,6 +34,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/data/HyperslabIndexer.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/math/Algorithms.hh"
 #include "celeritas/UnitTypes.hh"
 #include "celeritas/io/ImportUnits.hh"
 #include "celeritas/phys/PDGNumber.hh"
@@ -233,9 +234,7 @@ void append_table(G4PhysicsTable const* g4table,
 template<class T>
 bool all_are_assigned(std::vector<T> const& arr)
 {
-    return std::all_of(arr.begin(), arr.end(), [](T const& v) {
-        return static_cast<bool>(v);
-    });
+    return std::all_of(arr.begin(), arr.end(), LogicalTrue<T>{});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/MaterialParams.cc
+++ b/src/celeritas/optical/MaterialParams.cc
@@ -40,9 +40,7 @@ MaterialParams::from_import(ImportData const& data,
 
     CELER_VALIDATE(std::all_of(data.optical_materials.begin(),
                                data.optical_materials.end(),
-                               [](ImportOpticalMaterial const& m) {
-                                   return static_cast<bool>(m);
-                               }),
+                               LogicalTrue{}),
                    << "one or more optical materials lack required data");
 
     Input inp;

--- a/src/celeritas/phys/ImportedProcessAdapter.cc
+++ b/src/celeritas/phys/ImportedProcessAdapter.cc
@@ -14,6 +14,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/OpaqueId.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/math/Algorithms.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/grid/ValueGridBuilder.hh"
 #include "celeritas/grid/ValueGridType.hh"
@@ -46,9 +47,7 @@ ImportedProcesses::from_import(ImportData const& data,
                                SPConstParticles particle_params)
 {
     CELER_EXPECT(std::all_of(
-        data.processes.begin(),
-        data.processes.end(),
-        [](ImportProcess const& ip) { return static_cast<bool>(ip); }));
+        data.processes.begin(), data.processes.end(), LogicalTrue{}));
     CELER_EXPECT(particle_params);
 
     // Sort processes based on particle def IDs, process types, etc.

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -23,6 +23,7 @@
 #include "corecel/grid/UniformGrid.hh"
 #include "corecel/io/Label.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/math/Algorithms.hh"
 #include "corecel/sys/ActionRegistry.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "celeritas/Types.hh"
@@ -84,9 +85,8 @@ PhysicsParams::PhysicsParams(Input inp)
     , relaxation_(std::move(inp.relaxation))
 {
     CELER_EXPECT(!processes_.empty());
-    CELER_EXPECT(std::all_of(processes_.begin(),
-                             processes_.end(),
-                             [](SPConstProcess const& p) { return bool(p); }));
+    CELER_EXPECT(
+        std::all_of(processes_.begin(), processes_.end(), LogicalTrue{}));
     CELER_EXPECT(inp.particles);
     CELER_EXPECT(inp.materials);
     CELER_EXPECT(inp.action_registry);

--- a/src/celeritas/phys/PrimaryGeneratorOptions.hh
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.hh
@@ -11,6 +11,7 @@
 #include <random>
 
 #include "corecel/io/StringEnumMapper.hh"
+#include "corecel/math/Algorithms.hh"
 #include "geocel/Types.hh"
 
 #include "PDGNumber.hh"
@@ -72,9 +73,7 @@ struct PrimaryGeneratorOptions
     explicit operator bool() const
     {
         return !pdg.empty()
-               && std::all_of(pdg.begin(),
-                              pdg.end(),
-                              [](PDGNumber p) { return static_cast<bool>(p); })
+               && std::all_of(pdg.begin(), pdg.end(), LogicalTrue{})
                && num_events > 0 && primaries_per_event > 0 && energy
                && position && direction;
     }

--- a/src/celeritas/user/StepCollector.cc
+++ b/src/celeritas/user/StepCollector.cc
@@ -46,10 +46,8 @@ StepCollector::StepCollector(SPConstGeo geo,
                              ActionRegistry* action_registry)
 {
     CELER_EXPECT(!callbacks.empty());
-    CELER_EXPECT(std::all_of(
-        callbacks.begin(), callbacks.end(), [](SPStepInterface const& i) {
-            return static_cast<bool>(i);
-        }));
+    CELER_EXPECT(
+        std::all_of(callbacks.begin(), callbacks.end(), LogicalTrue{}));
     CELER_EXPECT(geo);
     CELER_EXPECT(aux_registry);
     CELER_EXPECT(action_registry);

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -115,6 +115,32 @@ struct Less<void>
 };
 
 //---------------------------------------------------------------------------//
+/*!
+ * Evaluate whether the argument is "true".
+ *
+ * This is useful for calls to \c std::all_of .
+ */
+template<class T = void>
+struct LogicalTrue
+{
+    CELER_CONSTEXPR_FUNCTION bool operator()(T const& value) const noexcept
+    {
+        return static_cast<bool>(value);
+    }
+};
+
+//! Specialization of LogicalTrue with template deduction
+template<>
+struct LogicalTrue<void>
+{
+    template<class T>
+    CELER_CONSTEXPR_FUNCTION bool operator()(T const& value) const noexcept
+    {
+        return static_cast<bool>(value);
+    }
+};
+
+//---------------------------------------------------------------------------//
 // Replace/extend <algorithm>
 //---------------------------------------------------------------------------//
 /*!

--- a/src/geocel/GeantGeoUtils.cc
+++ b/src/geocel/GeantGeoUtils.cc
@@ -36,6 +36,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/io/ScopedStreamRedirect.hh"
 #include "corecel/io/ScopedTimeLog.hh"
+#include "corecel/math/Algorithms.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "orange/g4org/Converter.hh"
 
@@ -393,8 +394,7 @@ std::string make_gdml_name(G4LogicalVolume const& lv)
 void set_history(Span<G4VPhysicalVolume const*> stack, G4NavigationHistory* nav)
 {
     CELER_EXPECT(!stack.empty());
-    CELER_EXPECT(std::all_of(
-        stack.begin(), stack.end(), [](auto* v) -> bool { return v; }));
+    CELER_EXPECT(std::all_of(stack.begin(), stack.end(), LogicalTrue{}));
     CELER_EXPECT(nav);
 
     size_type level = 0;

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -328,9 +328,7 @@ UniverseId UnitInserter::operator()(UnitInput&& inp)
         volume_records_.insert_back(vol_records.begin(), vol_records.end()));
 
     // Create BIH tree
-    CELER_VALIDATE(std::all_of(bboxes.begin(),
-                               bboxes.end(),
-                               [](FastBBox const& b) { return b; }),
+    CELER_VALIDATE(std::all_of(bboxes.begin(), bboxes.end(), LogicalTrue{}),
                    << "not all bounding boxes have been assigned");
     unit.bih_tree = build_bih_tree_(std::move(bboxes));
 

--- a/src/orange/orangeinp/CsgObject.cc
+++ b/src/orange/orangeinp/CsgObject.cc
@@ -98,10 +98,7 @@ JoinObjects<Op>::JoinObjects(std::string&& label, VecObject&& objects)
     : label_{std::move(label)}, objects_{std::move(objects)}
 {
     CELER_EXPECT(!label_.empty());
-    CELER_EXPECT(std::all_of(
-        objects_.begin(), objects_.end(), [](SPConstObject const& obj) {
-            return static_cast<bool>(obj);
-        }));
+    CELER_EXPECT(std::all_of(objects_.begin(), objects_.end(), LogicalTrue{}));
     CELER_EXPECT(!objects_.empty());
 }
 

--- a/src/orange/orangeinp/UnitProto.cc
+++ b/src/orange/orangeinp/UnitProto.cc
@@ -48,15 +48,11 @@ UnitProto::UnitProto(Input&& inp) : input_{std::move(inp)}
     CELER_VALIDATE(input_, << "no fill, daughters, or volumes are defined");
     CELER_VALIDATE(std::all_of(input_.materials.begin(),
                                input_.materials.begin(),
-                               [](MaterialInput const& m) {
-                                   return static_cast<bool>(m);
-                               }),
+                               LogicalTrue{}),
                    << "incomplete material definition(s)");
     CELER_VALIDATE(std::all_of(input_.daughters.begin(),
                                input_.daughters.begin(),
-                               [](DaughterInput const& d) {
-                                   return static_cast<bool>(d);
-                               }),
+                               LogicalTrue{}),
                    << "incomplete daughter definition(s)");
     CELER_VALIDATE(input_.boundary.zorder == ZOrder::media
                        || input_.boundary.zorder == ZOrder::exterior,

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -85,7 +85,7 @@ TEST(UtilityTest, exchange)
 TEST(AlgorithmsTest, all_of)
 {
     static bool const items[] = {true, false, true, true};
-    auto is_true = [](bool b) { return b; };
+    LogicalTrue<bool> is_true;
     EXPECT_TRUE(all_of(std::begin(items), std::begin(items), is_true));
     EXPECT_FALSE(all_of(std::begin(items), std::end(items), is_true));
     EXPECT_TRUE(all_of(std::begin(items) + 2, std::end(items), is_true));
@@ -94,7 +94,7 @@ TEST(AlgorithmsTest, all_of)
 TEST(AlgorithmsTest, any_of)
 {
     static bool const items[] = {false, true, false, false};
-    auto is_true = [](bool b) { return b; };
+    LogicalTrue<> is_true;
     EXPECT_FALSE(any_of(std::begin(items), std::begin(items), is_true));
     EXPECT_TRUE(any_of(std::begin(items), std::end(items), is_true));
     EXPECT_FALSE(any_of(std::begin(items) + 2, std::end(items), is_true));


### PR DESCRIPTION
We often have to define `[](Foo const& foo) { return static_cast<bool>(foo); }` for checking things in a `std::all_of`. This adds a helper along the lines of the std library's `logical_not` to do the cast for us.