### PR TITLE
Fix Doxygen member group formatting

### DIFF
--- a/app/celer-g4/TimerOutput.hh
+++ b/app/celer-g4/TimerOutput.hh
@@ -39,6 +39,7 @@ class TimerOutput final : public OutputInterface
 
     //!@{
     //! \name Output interface
+
     //! Category of data to write
     Category category() const final { return Category::result; }
     //! Key for the entry inside the category.

--- a/src/accel/GeantSimpleCalo.hh
+++ b/src/accel/GeantSimpleCalo.hh
@@ -61,6 +61,7 @@ class GeantSimpleCalo final : public OutputInterface
 
     //!@{
     //! \name Output interface
+
     //! Category of data to write
     Category category() const final { return Category::result; }
     // Key for the entry inside the category

--- a/src/accel/GeantStepDiagnostic.hh
+++ b/src/accel/GeantStepDiagnostic.hh
@@ -40,6 +40,7 @@ class GeantStepDiagnostic final : public OutputInterface
 
     //!@{
     //! \name Output interface
+
     //! Category of data to write
     Category category() const final { return Category::result; }
     //! Key for the entry inside the category.

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -129,6 +129,7 @@ struct SetupOptions
 
     //!@{
     //! \name I/O
+
     //! GDML filename (optional: defaults to exporting existing Geant4)
     std::string geometry_file;
     //! Filename for JSON diagnostic output
@@ -143,6 +144,7 @@ struct SetupOptions
 
     //!@{
     //! \name Celeritas stepper options
+
     //! Number of track "slots" to be transported simultaneously
     size_type max_num_tracks{};
     //! Maximum number of events in use (DEPRECATED: remove in v0.6)
@@ -161,6 +163,7 @@ struct SetupOptions
 
     //!@{
     //! \name Track reordering options
+
     TrackOrder track_order{Device::num_devices() ? TrackOrder::init_charge
                                                  : TrackOrder::none};
     //!@}
@@ -170,11 +173,13 @@ struct SetupOptions
 
     //!@{
     //! \name Stepping actions
+
     AlongStepFactory make_along_step;
     //!@}
 
     //!@{
     //! \name Field options
+
     size_type max_field_substeps{100};
     //!@}
 
@@ -183,12 +188,14 @@ struct SetupOptions
 
     //!@{
     //! \name Physics options
+
     //! Do not use Celeritas physics for the given Geant4 process names
     VecString ignore_processes;
     //!@}
 
     //!@{
     //! \name CUDA options
+
     //! Per-thread stack size (may be needed for VecGeom) [B]
     size_type cuda_stack_size{};
     //! Dynamic heap size (may be needed for VecGeom) [B]
@@ -201,6 +208,7 @@ struct SetupOptions
 
     //!@{
     //! \name Diagnostic setup
+
     //! Filename base for slot diagnostics
     std::string slot_diagnostic_prefix;
     //!@}

--- a/src/celeritas/ext/GeantOpticalPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantOpticalPhysicsOptions.hh
@@ -128,6 +128,7 @@ struct GeantOpticalPhysicsOptions
 {
     //!@{
     //! \name Optical photon creation physics
+
     //! Cherenkov radiation options
     CherenkovPhysicsOptions cherenkov;
     //! Scintillation options
@@ -136,6 +137,7 @@ struct GeantOpticalPhysicsOptions
 
     //!@{
     //! \name Optical photon physics
+
     //! Enable wavelength shifting and select a time profile
     WLSTimeProfileSelection wavelength_shifting{WLSTimeProfileSelection::delta};
     //! Enable second wavelength shifting type and select a time profile (TODO:

--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -99,6 +99,7 @@ struct GeantPhysicsOptions
 
     //!@{
     //! \name Gamma physics
+
     //! Enable Compton scattering
     bool compton_scattering{true};
     //! Enable the photoelectric effect
@@ -113,6 +114,7 @@ struct GeantPhysicsOptions
 
     //!@{
     //! \name Electron and positron physics
+
     //! Enable discrete Coulomb
     bool coulomb_scattering{false};
     //! Enable e- and e+ ionization
@@ -132,6 +134,7 @@ struct GeantPhysicsOptions
 
     //!@{
     //! \name Physics options
+
     //! Number of log-spaced bins per factor of 10 in energy
     int em_bins_per_decade{7};
     //! Enable universal energy fluctuations
@@ -144,6 +147,7 @@ struct GeantPhysicsOptions
 
     //!@{
     //! \name Cutoff options
+
     //! Lowest energy of any EM physics process
     MevEnergy min_energy{0.1 * 1e-3};  // 0.1 keV
     //! Highest energy of any EM physics process
@@ -160,6 +164,7 @@ struct GeantPhysicsOptions
 
     //!@{
     //! \name Multiple scattering configuration
+
     //! E-/e+ range factor for MSC models
     double msc_range_factor{0.04};
     //! Safety factor for MSC models

--- a/src/celeritas/global/KernelContextException.hh
+++ b/src/celeritas/global/KernelContextException.hh
@@ -64,6 +64,7 @@ class KernelContextException : public RichContextException
 
     //!@{
     //! \name Track accessors
+
     //! Kernel thread ID
     ThreadId thread() const { return thread_; }
     //! Track slot ID

--- a/src/celeritas/io/ImportElement.hh
+++ b/src/celeritas/io/ImportElement.hh
@@ -39,7 +39,7 @@ struct ImportIsotope
 struct ImportElement
 {
     //!@{
-    //! \name type aliases
+    //! \name Type aliases
     using IsotopeIndex = unsigned int;
     using IsotopeFrac = std::pair<IsotopeIndex, double>;
     using VecIsotopeFrac = std::vector<IsotopeFrac>;

--- a/src/celeritas/mat/MaterialParams.hh
+++ b/src/celeritas/mat/MaterialParams.hh
@@ -112,6 +112,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 
     //!@{
     //! \name Material metadata
+
     //! Number of materials
     MaterialId::size_type num_materials() const { return mat_labels_.size(); }
 
@@ -127,6 +128,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 
     //!@{
     //! \name Element metadata
+
     //! Number of distinct elements definitions
     ElementId::size_type num_elements() const { return el_labels_.size(); }
 
@@ -142,6 +144,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 
     //!@{
     //! \name Isotope metadata
+
     //! Number of distinct isotope definitions
     IsotopeId::size_type num_isotopes() const { return isot_labels_.size(); }
 

--- a/src/celeritas/optical/CoreParams.hh
+++ b/src/celeritas/optical/CoreParams.hh
@@ -75,6 +75,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
 
     //!@{
     //! \name Data interface
+
     //! Access data on the host
     HostRef const& host_ref() const final { return host_ref_; }
     //! Access data on the device

--- a/src/celeritas/optical/detail/OffloadParams.hh
+++ b/src/celeritas/optical/detail/OffloadParams.hh
@@ -30,6 +30,7 @@ class OffloadParams final : public AuxParamsInterface,
 
     //!@{
     //! \name Aux interface
+
     //! Short name for the action
     std::string_view label() const final { return "optical-offload"; }
     //! Index of this class instance in its registry
@@ -40,6 +41,7 @@ class OffloadParams final : public AuxParamsInterface,
 
     //!@{
     //! \name Data interface
+
     //! Access data on host
     HostRef const& host_ref() const final { return data_.host_ref(); }
     //! Access data on device

--- a/src/celeritas/optical/detail/OpticalLaunchAction.hh
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.hh
@@ -78,6 +78,7 @@ class OpticalLaunchAction : public AuxParamsInterface,
 
     //!@{
     //! \name Aux/action metadata interface
+
     //! Short name for the action
     std::string_view label() const final { return "optical-offload-launch"; }
     // Name of the action (for user output)
@@ -86,6 +87,7 @@ class OpticalLaunchAction : public AuxParamsInterface,
 
     //!@{
     //! \name Aux interface
+
     //! Index of this class instance in its registry
     AuxId aux_id() const final { return aux_id_; }
     // Build optical core state data for a stream
@@ -94,6 +96,7 @@ class OpticalLaunchAction : public AuxParamsInterface,
 
     //!@{
     //! \name Action interface
+
     //! ID of the model
     ActionId action_id() const final { return action_id_; }
     //! Dependency ordering of the action

--- a/src/celeritas/track/ExtendFromPrimariesAction.hh
+++ b/src/celeritas/track/ExtendFromPrimariesAction.hh
@@ -53,6 +53,7 @@ class ExtendFromPrimariesAction final : public CoreStepActionInterface,
 
     //!@{
     //! \name Metadata interface
+
     //! Label for the auxiliary data and action
     std::string_view label() const final { return sad_.label(); }
     // Description of the action
@@ -61,6 +62,7 @@ class ExtendFromPrimariesAction final : public CoreStepActionInterface,
 
     //!@{
     //! \name Step action interface
+
     //! ID of the action
     ActionId action_id() const final { return sad_.action_id(); }
     //! Dependency ordering of the action
@@ -73,6 +75,7 @@ class ExtendFromPrimariesAction final : public CoreStepActionInterface,
 
     //!@{
     //! \name Aux params interface
+
     //! Index of this class instance in its registry
     AuxId aux_id() const final { return aux_id_; }
     // Build state data for a stream

--- a/src/celeritas/track/ExtendFromSecondariesAction.hh
+++ b/src/celeritas/track/ExtendFromSecondariesAction.hh
@@ -76,6 +76,7 @@ class ExtendFromSecondariesAction final : public CoreStepActionInterface,
 
     //!@{
     //! \name Action interface
+
     //! ID of the action
     ActionId action_id() const final { return id_; }
     //! Short name for the action
@@ -88,6 +89,7 @@ class ExtendFromSecondariesAction final : public CoreStepActionInterface,
 
     //!@{
     //! \name ExplicitAction interface
+
     // Launch kernel with host data
     void step(CoreParams const&, CoreStateHost&) const final;
     // Launch kernel with device data
@@ -96,6 +98,7 @@ class ExtendFromSecondariesAction final : public CoreStepActionInterface,
 
     //!@{
     //! \name BeginRunAction interface
+
     // No action necessary for host data
     void begin_run(CoreParams const&, CoreStateHost&) final {}
     // Warm up asynchronous allocation at beginning of run

--- a/src/celeritas/track/StatusChecker.hh
+++ b/src/celeritas/track/StatusChecker.hh
@@ -46,6 +46,7 @@ class StatusChecker final : public AuxParamsInterface,
 
     //!@{
     //! \name Aux/action metadata interface
+
     //! Label for the auxiliary data and action
     std::string_view label() const final { return "status-check"; }
     // Description of the action
@@ -54,6 +55,7 @@ class StatusChecker final : public AuxParamsInterface,
 
     //!@{
     //! \name Aux params interface
+
     //! Index of this class instance in its registry
     AuxId aux_id() const final { return aux_id_; }
     // Build state data for a stream
@@ -62,6 +64,7 @@ class StatusChecker final : public AuxParamsInterface,
 
     //!@{
     //! \name Begin run interface
+
     //! Index of this class instance in its registry
     ActionId action_id() const final { return action_id_; }
     // Set host data at the beginning of a run
@@ -72,6 +75,7 @@ class StatusChecker final : public AuxParamsInterface,
 
     //!@{
     //! \name Data interface
+
     //! Access data on host
     HostRef const& host_ref() const final { return data_.host_ref(); }
     //! Access data on device

--- a/src/celeritas/user/ActionDiagnostic.hh
+++ b/src/celeritas/user/ActionDiagnostic.hh
@@ -66,6 +66,7 @@ class ActionDiagnostic final : public CoreStepActionInterface,
 
     //!@{
     //! \name Action interface
+
     //! ID of the action
     ActionId action_id() const final { return id_; }
     //! Short name for the action
@@ -78,6 +79,7 @@ class ActionDiagnostic final : public CoreStepActionInterface,
 
     //!@{
     //! \name BeginRunAction interface
+
     // Set host data at the beginning of a run
     void begin_run(CoreParams const&, CoreStateHost&) final;
     // Set device data at the beginning of a run
@@ -86,6 +88,7 @@ class ActionDiagnostic final : public CoreStepActionInterface,
 
     //!@{
     //! \name ExplicitAction interface
+
     // Launch kernel with host data
     void step(CoreParams const&, CoreStateHost&) const final;
     // Launch kernel with device data
@@ -94,6 +97,7 @@ class ActionDiagnostic final : public CoreStepActionInterface,
 
     //!@{
     //! \name Output interface
+
     //! Category of data to write
     Category category() const final { return Category::result; }
     // Write output to the given JSON object

--- a/src/celeritas/user/SimpleCalo.hh
+++ b/src/celeritas/user/SimpleCalo.hh
@@ -61,6 +61,7 @@ class SimpleCalo final : public StepInterface, public OutputInterface
 
     //!@{
     //! \name Step interface
+
     // Map volume names to detector IDs and exclude tracks with no deposition
     Filters filters() const final;
     // Save energy deposition and pre-step volume
@@ -73,6 +74,7 @@ class SimpleCalo final : public StepInterface, public OutputInterface
 
     //!@{
     //! \name Output interface
+
     // Category of data to write
     Category category() const final { return Category::result; }
     // Key for the entry inside the category.

--- a/src/celeritas/user/SlotDiagnostic.hh
+++ b/src/celeritas/user/SlotDiagnostic.hh
@@ -64,6 +64,7 @@ class SlotDiagnostic final : public CoreStepActionInterface,
 
     //!@{
     //! \name Metadata interface
+
     //! Label for the auxiliary data and action
     std::string_view label() const final { return sad_.label(); }
     // Description of the action
@@ -72,6 +73,7 @@ class SlotDiagnostic final : public CoreStepActionInterface,
 
     //!@{
     //! \name Step action interface
+
     //! Index of this class instance in its registry
     ActionId action_id() const final { return sad_.action_id(); }
     //! Index of this class instance in its registry
@@ -84,6 +86,7 @@ class SlotDiagnostic final : public CoreStepActionInterface,
 
     //!@{
     //! \name Aux params interface
+
     //! Index of this class instance in its registry
     AuxId aux_id() const final { return aux_id_; }
     // Build state data for a stream

--- a/src/celeritas/user/StepDiagnostic.hh
+++ b/src/celeritas/user/StepDiagnostic.hh
@@ -55,6 +55,7 @@ class StepDiagnostic final : public CoreStepActionInterface,
 
     //!@{
     //! \name ExplicitAction interface
+
     // Launch kernel with host data
     void step(CoreParams const&, CoreStateHost&) const final;
     // Launch kernel with device data
@@ -71,6 +72,7 @@ class StepDiagnostic final : public CoreStepActionInterface,
 
     //!@{
     //! \name Output interface
+
     //! Category of data to write
     Category category() const final { return Category::result; }
     // Write output to the given JSON object

--- a/src/celeritas/user/detail/StepParams.hh
+++ b/src/celeritas/user/detail/StepParams.hh
@@ -45,6 +45,7 @@ class StepParams : public ParamsDataInterface<StepParamsData>,
 
     //!@{
     //! \name Aux interface
+
     //! Short name for the aux data
     std::string_view label() const final { return "detector-step"; }
     //! Index of this class instance in its registry
@@ -55,6 +56,7 @@ class StepParams : public ParamsDataInterface<StepParamsData>,
 
     //!@{
     //! \name Data interface
+
     //! Access physics properties on the host
     HostRef const& host_ref() const final { return mirror_.host_ref(); }
     //! Access physics properties on the device

--- a/src/corecel/cont/Array.hh
+++ b/src/corecel/cont/Array.hh
@@ -108,6 +108,7 @@ struct Array
 
     //!@{
     //! \name  Operations
+
     //! Fill the array with a constant value
     CELER_CONSTEXPR_FUNCTION void fill(const_reference value)
     {

--- a/src/orange/orangeinp/IntersectSurfaceBuilder.hh
+++ b/src/orange/orangeinp/IntersectSurfaceBuilder.hh
@@ -48,7 +48,7 @@ class IntersectSurfaceBuilder
 {
   public:
     //!@{
-    //! \name Types
+    //! \name Type aliases
     using Tol = Tolerance<>;
     //!@}
 

--- a/src/orange/orangeinp/detail/BuildLogicUtils.hh
+++ b/src/orange/orangeinp/detail/BuildLogicUtils.hh
@@ -281,13 +281,15 @@ class PostfixBuildLogicPolicy
     //!@{
     //! \name Visit a node directly
     using BaseBuildLogicPolicy::operator();
-    // Visit a negated node and append 'not'
+
+    //! Visit a negated node and append 'not'.
     void operator()(Negated const& n)
     {
         (*this)(n.node);
         logic().push_back(logic::lnot);
     }
-    // Visit daughter nodes and append the conjunction.
+
+    //! Visit daughter nodes and append the conjunction.
     void operator()(Joined const& n)
     {
         CELER_EXPECT(n.nodes.size() > 1);
@@ -302,6 +304,7 @@ class PostfixBuildLogicPolicy
             logic().push_back(n.op);
         }
     }
+    //!@}
 };
 
 //---------------------------------------------------------------------------//
@@ -332,7 +335,8 @@ class InfixBuildLogicPolicy : public BaseBuildLogicPolicy<InfixBuildLogicPolicy>
     //!@{
     //! \name Visit a node directly
     using BaseBuildLogicPolicy::operator();
-    //! Append 'not' and visit a negated node
+
+    //! Append 'not' and visit a negated node.
     void operator()(Negated const& n)
     {
         this->logic().push_back(logic::lnot);

--- a/src/orange/orangeinp/detail/InfixStringBuilder.hh
+++ b/src/orange/orangeinp/detail/InfixStringBuilder.hh
@@ -46,6 +46,7 @@ class InfixStringBuilder
 
     //!@{
     //! \name Visit a node directly
+
     // Append 'true'
     inline void operator()(True const&);
     // False is never explicitly part of the node tree

--- a/src/orange/orangeinp/detail/InternalSurfaceFlagger.hh
+++ b/src/orange/orangeinp/detail/InternalSurfaceFlagger.hh
@@ -37,6 +37,7 @@ class InternalSurfaceFlagger
 
     //!@{
     //! \name Visit a node directly
+
     // No surface crossings
     bool operator()(True const&) { return simple; }
     // False is never explicitly part of the node tree

--- a/src/orange/orangeinp/detail/IntersectSurfaceState.hh
+++ b/src/orange/orangeinp/detail/IntersectSurfaceState.hh
@@ -32,6 +32,7 @@ struct IntersectSurfaceState
 {
     //!@{
     //! \name Input state
+
     //! Local-to-global transform
     VariantTransform const* transform{nullptr};
     //! Name of the object being built
@@ -42,6 +43,7 @@ struct IntersectSurfaceState
 
     //!@{
     //! \name Output state
+
     //! Local (to intersecting surface state) interior/exterior
     BoundingZone local_bzone = BoundingZone::from_infinite();
     //! Global (to unit) interior/exterior

--- a/src/orange/orangeinp/detail/SenseEvaluator.hh
+++ b/src/orange/orangeinp/detail/SenseEvaluator.hh
@@ -45,6 +45,7 @@ class SenseEvaluator
 
     //!@{
     //! \name Visit a node directly
+
     //! Point is always inside
     result_type operator()(True const&) const { return SignedSense::inside; }
     //! Point is always outside

--- a/src/orange/surf/detail/InvolutePoint.hh
+++ b/src/orange/surf/detail/InvolutePoint.hh
@@ -32,8 +32,9 @@ class InvolutePoint
 {
   public:
     //!@{
-    //! \name Type alias
+    //! \name Type aliases
     using Real2 = Array<real_type, 2>;
+    //!@}
 
   public:
     // Construct involute from parameters
@@ -50,6 +51,7 @@ class InvolutePoint
 
   private:
     //// DATA ////
+
     // Involute parameters
     real_type r_b_;
     real_type a_;


### PR DESCRIPTION
This fixes a number of instances in the documentation where the description of a member following the `\name` command was being interpreted as the group description, e.g.
<img width="573" alt="before" src="https://github.com/user-attachments/assets/f2812c7c-3cc0-4494-86df-4e15dbb25c2a" />
is now
<img width="572" alt="after" src="https://github.com/user-attachments/assets/46bc488a-b76d-4039-a941-33c23ee7083a" />
