### PR TITLE
Fix unnecessary use of inline constexpr

### DIFF
--- a/src/accel/SetupOptionsMessenger.cc
+++ b/src/accel/SetupOptionsMessenger.cc
@@ -28,7 +28,7 @@ struct UICommandTraits;
 template<>
 struct UICommandTraits<std::string>
 {
-    static inline constexpr char type_info = 's';
+    static constexpr char type_info = 's';
     static std::string const& to_string(G4String const& v) { return v; }
     static std::string from_string(G4String const& v) { return v; }
 };
@@ -36,7 +36,7 @@ struct UICommandTraits<std::string>
 template<>
 struct UICommandTraits<bool>
 {
-    static inline constexpr char type_info = 'b';
+    static constexpr char type_info = 'b';
     static G4String to_string(bool v)
     {
         return G4UIcommand::ConvertToString(v);
@@ -50,7 +50,7 @@ struct UICommandTraits<bool>
 template<class T>
 struct UICommandTraits<T, std::enable_if_t<std::is_integral_v<T>>>
 {
-    static inline constexpr char type_info = 'i';
+    static constexpr char type_info = 'i';
     static std::string to_string(T v) { return std::to_string(v); }
     static long from_string(G4String const& v)
     {
@@ -69,7 +69,7 @@ struct UICommandTraits<T, std::enable_if_t<std::is_integral_v<T>>>
 template<>
 struct UICommandTraits<double>
 {
-    static inline constexpr char type_info = 'd';
+    static constexpr char type_info = 'd';
     static G4String to_string(double v)
     {
         return G4UIcommand::ConvertToString(v);

--- a/src/celeritas/field/FieldDriverOptions.hh
+++ b/src/celeritas/field/FieldDriverOptions.hh
@@ -64,13 +64,13 @@ struct FieldDriverOptions
     short int max_substeps = 10;
 
     //! Initial step tolerance
-    static constexpr inline real_type initial_step_tol = 1e-6;
+    static constexpr real_type initial_step_tol = 1e-6;
 
     //! Chord distance fudge factor
-    static constexpr inline real_type dchord_tol = 1e-5 * units::millimeter;
+    static constexpr real_type dchord_tol = 1e-5 * units::millimeter;
 
     //! Lowest allowable scaling factor when searching for a chord
-    static constexpr inline real_type min_chord_shrink = 0.5;
+    static constexpr real_type min_chord_shrink = 0.5;
 
     //! Whether all data are assigned and valid
     explicit CELER_FUNCTION operator bool() const

--- a/src/celeritas/io/ImportMaterial.hh
+++ b/src/celeritas/io/ImportMaterial.hh
@@ -96,9 +96,7 @@ struct ImportPhysMaterial
     using MapIntCutoff = std::map<PdgInt, ImportProductionCut>;
     //!@}
 
-#ifndef SWIG
-    static inline constexpr Index unspecified = -1;
-#endif
+    static constexpr Index unspecified = -1;
 
     Index geo_material_id{};  //!< Index in geo_materials list
     Index optical_material_id{unspecified};  //!< Optional index in optical mat

--- a/src/celeritas/io/ImportVolume.hh
+++ b/src/celeritas/io/ImportVolume.hh
@@ -39,9 +39,7 @@ struct ImportVolume
     using Index = unsigned int;
     //!@}
 
-#ifndef SWIG
-    static inline constexpr Index unspecified = -1;
-#endif
+    static constexpr Index unspecified = -1;
 
     Index geo_material_id{unspecified};  //!< Material defined by geometry
     Index region_id{unspecified};  //!< Optional region associated

--- a/src/celeritas/track/StatusCheckData.hh
+++ b/src/celeritas/track/StatusCheckData.hh
@@ -24,8 +24,7 @@ struct StatusCheckParamsData
 
     celeritas::Collection<StepActionOrder, W, M, ActionId> orders;
 
-    static inline constexpr StepActionOrder implicit_order
-        = StepActionOrder::size_;
+    static constexpr StepActionOrder implicit_order = StepActionOrder::size_;
 
     //// METHODS ////
 

--- a/src/celeritas/user/RootStepWriter.hh
+++ b/src/celeritas/user/RootStepWriter.hh
@@ -27,7 +27,7 @@ class RootFileManager;
 //! Input to \c make_write_filter (below) for filtering ROOT MC truth output
 struct SimpleRootFilterInput
 {
-    static inline constexpr size_type unspecified{static_cast<size_type>(-1)};
+    static constexpr size_type unspecified{static_cast<size_type>(-1)};
 
     std::vector<size_type> track_id;
     size_type event_id = unspecified;
@@ -58,7 +58,7 @@ class RootStepWriter final : public StepInterface
 {
   public:
     // Unspecified step attribute data value
-    static inline constexpr size_type unspecified{static_cast<size_type>(-1)};
+    static constexpr size_type unspecified{static_cast<size_type>(-1)};
 
     //! Truth step point data; Naming convention must match StepPointStateData
     struct TStepPoint

--- a/src/corecel/cont/InitializedValue.hh
+++ b/src/corecel/cont/InitializedValue.hh
@@ -37,7 +37,7 @@ template<class T, class Finalizer = detail::DefaultFinalize<T>>
 class InitializedValue
 {
   private:
-    static inline constexpr bool ne_finalize_
+    static constexpr bool ne_finalize_
         = noexcept(std::declval<Finalizer>()(std::declval<T&>()));
 
   public:

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -266,8 +266,8 @@ class Collection
     using AllItemsT = AllItems<T, M>;
     //!@}
 
-    static constexpr inline Ownership ownership = W;
-    static constexpr inline MemSpace memspace = M;
+    static constexpr Ownership ownership = W;
+    static constexpr MemSpace memspace = M;
 
   public:
     //// CONSTRUCTION ////

--- a/src/corecel/math/BisectionRootFinder.hh
+++ b/src/corecel/math/BisectionRootFinder.hh
@@ -48,7 +48,7 @@ class BisectionRootFinder
     real_type tol_;
 
     // Maximum amount of iterations
-    static constexpr inline int max_iters_ = 50;
+    static constexpr int max_iters_ = 50;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/IllinoisRootFinder.hh
+++ b/src/corecel/math/IllinoisRootFinder.hh
@@ -43,7 +43,7 @@ class IllinoisRootFinder
     real_type tol_;
 
     // Maximum amount of iterations
-    static constexpr inline int max_iters_ = 50;
+    static constexpr int max_iters_ = 50;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/RegulaFalsiRootFinder.hh
+++ b/src/corecel/math/RegulaFalsiRootFinder.hh
@@ -49,7 +49,7 @@ class RegulaFalsiRootFinder
     real_type tol_;
 
     // Maximum amount of iterations
-    static constexpr inline int max_iters_ = 50;
+    static constexpr int max_iters_ = 50;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/TracingSession.hh
+++ b/src/corecel/sys/TracingSession.hh
@@ -60,7 +60,7 @@ class TracingSession
     CELER_DELETE_COPY_MOVE(TracingSession);
 
   private:
-    static inline constexpr int system_fd_{-1};
+    static constexpr int system_fd_{-1};
     struct Deleter
     {
         void operator()(perfetto::TracingSession*);

--- a/src/geocel/GeoTraits.hh
+++ b/src/geocel/GeoTraits.hh
@@ -42,10 +42,10 @@ struct GeoTraits
     using TrackView = void;
 
     //! Descriptive name for the geometry
-    static constexpr inline char const* name = nullptr;
+    static constexpr char const* name = nullptr;
 
     //! TO BE REMOVED: "native" file extension for this geometry
-    static constexpr inline char const* ext = nullptr;
+    static constexpr char const* ext = nullptr;
 };
 
 //---------------------------------------------------------------------------//
@@ -68,8 +68,8 @@ struct NotConfiguredGeoTraits
     template<Ownership W, MemSpace M>
     using StateData = void;
     using TrackView = void;
-    static constexpr inline char const* name = nullptr;
-    static constexpr inline char const* ext = nullptr;
+    static constexpr char const* name = nullptr;
+    static constexpr char const* ext = nullptr;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/g4/GeantGeoTraits.hh
+++ b/src/geocel/g4/GeantGeoTraits.hh
@@ -40,10 +40,10 @@ struct GeoTraits<GeantGeoParams>
     using TrackView = GeantGeoTrackView;
 
     //! Descriptive name for the geometry
-    static constexpr inline char const* name = "Geant4";
+    static constexpr char const* name = "Geant4";
 
     //! TO BE REMOVED: "native" file extension for this geometry
-    static constexpr inline char const* ext = ".gdml";
+    static constexpr char const* ext = ".gdml";
 };
 #else
 //! Geant4 is unavailable

--- a/src/geocel/vg/VecgeomGeoTraits.hh
+++ b/src/geocel/vg/VecgeomGeoTraits.hh
@@ -40,10 +40,10 @@ struct GeoTraits<VecgeomParams>
     using TrackView = VecgeomTrackView;
 
     //! Descriptive name for the geometry
-    static constexpr inline char const* name = "VecGeom";
+    static constexpr char const* name = "VecGeom";
 
     //! TO BE REMOVED: "native" file extension for this geometry
-    static constexpr inline char const* ext = ".gdml";
+    static constexpr char const* ext = ".gdml";
 };
 #else
 //! VecGeom is unavailable

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -28,10 +28,10 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 
 //! Local ID of exterior volume for unit-type universes
-static inline constexpr LocalVolumeId orange_exterior_volume{0};
+inline constexpr LocalVolumeId orange_exterior_volume{0};
 
 //! ID of the top-level (global/world, level=0) universe (scene)
-static inline constexpr UniverseId orange_global_universe{0};
+inline constexpr UniverseId orange_global_universe{0};
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/orange/OrangeGeoTraits.hh
+++ b/src/orange/OrangeGeoTraits.hh
@@ -37,10 +37,10 @@ struct GeoTraits<OrangeParams>
     using TrackView = OrangeTrackView;
 
     //! Descriptive name for the geometry
-    static constexpr inline char const* name = "ORANGE";
+    static constexpr char const* name = "ORANGE";
 
     //! TO BE REMOVED: "native" file extension for this geometry
-    static constexpr inline char const* ext = ".org.json";
+    static constexpr char const* ext = ".org.json";
 };
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/FaceNamer.test.cc
+++ b/test/orange/surf/FaceNamer.test.cc
@@ -20,8 +20,8 @@ namespace test
 class FaceNamerTest : public ::celeritas::test::Test
 {
   protected:
-    static inline constexpr auto in = Sense::inside;
-    static inline constexpr auto out = Sense::outside;
+    static constexpr auto in = Sense::inside;
+    static constexpr auto out = Sense::outside;
 };
 
 TEST_F(FaceNamerTest, typed)


### PR DESCRIPTION
As I learned from @esseivaju today, `inline` is implied for `static constexpr` class data.