### PR TITLE
Refactor primary generator using new `inp`

### DIFF
--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -7,6 +7,7 @@
 #include "ActionInitialization.hh"
 
 #include "corecel/io/Logger.hh"
+#include "celeritas/inp/Events.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
 #include "accel/ExceptionConverter.hh"
 #include "accel/HepMC3PrimaryGenerator.hh"
@@ -102,7 +103,7 @@ void ActionInitialization::Build() const
         ExceptionConverter call_g4exception{"celer0006"};
         CELER_TRY_HANDLE(
             generator_action = std::make_unique<PGPrimaryGeneratorAction>(
-                GlobalSetup::Instance()->input().primary_options),
+                to_input(GlobalSetup::Instance()->input().primary_options)),
             call_g4exception);
     }
     this->SetUserAction(generator_action.release());

--- a/app/celer-g4/PGPrimaryGeneratorAction.cc
+++ b/app/celer-g4/PGPrimaryGeneratorAction.cc
@@ -15,6 +15,7 @@
 #include "geocel/g4/Convert.hh"
 #include "celeritas/ext/GeantImporter.hh"
 #include "celeritas/ext/GeantUnits.hh"
+#include "celeritas/inp/Events.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/Primary.hh"
 
@@ -57,7 +58,7 @@ auto make_particles(std::vector<PDGNumber> const& all_pdg)
  */
 PGPrimaryGeneratorAction::PGPrimaryGeneratorAction(Input const& i)
     : particle_params_{make_particles(i.pdg)}
-    , generate_primaries_{PrimaryGenerator::from_options(particle_params_, i)}
+    , generate_primaries_{i, *particle_params_}
 {
     // Generate one particle at each call to \c GeneratePrimaryVertex()
     gun_.SetNumberOfParticles(1);

--- a/app/celer-g4/PGPrimaryGeneratorAction.hh
+++ b/app/celer-g4/PGPrimaryGeneratorAction.hh
@@ -34,7 +34,7 @@ class PGPrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
   public:
     //!@{
     //! \name Type aliases
-    using Input = PrimaryGeneratorOptions;
+    using Input = inp::PrimaryGenerator;
     //!@}
 
   public:

--- a/src/celeritas/phys/PrimaryGenerator.hh
+++ b/src/celeritas/phys/PrimaryGenerator.hh
@@ -8,6 +8,7 @@
 
 #include <functional>
 #include <memory>
+#include <random>
 #include <vector>
 
 #include "celeritas/Types.hh"
@@ -21,6 +22,10 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 class ParticleParams;
 struct Primary;
+namespace inp
+{
+struct PrimaryGenerator;
+}
 
 //---------------------------------------------------------------------------//
 /*!
@@ -40,31 +45,22 @@ class PrimaryGenerator : public EventReaderInterface
   public:
     //!@{
     //! \name Type aliases
+    using PrimaryGeneratorEngine = std::mt19937;
     using EnergySampler = std::function<real_type(PrimaryGeneratorEngine&)>;
     using PositionSampler = std::function<Real3(PrimaryGeneratorEngine&)>;
     using DirectionSampler = std::function<Real3(PrimaryGeneratorEngine&)>;
     using SPConstParticles = std::shared_ptr<ParticleParams const>;
     using result_type = std::vector<Primary>;
+    using Input = inp::PrimaryGenerator;
     //!@}
 
-    struct Input
-    {
-        unsigned int seed{};
-        std::vector<PDGNumber> pdg;
-        size_type num_events{};
-        size_type primaries_per_event{};
-        EnergySampler sample_energy;
-        PositionSampler sample_pos;
-        DirectionSampler sample_dir;
-    };
-
   public:
-    // Construct from user input
+    // Construct from user input (deprecated)
     static PrimaryGenerator
     from_options(SPConstParticles, PrimaryGeneratorOptions const&);
 
-    // Construct with options and shared particle data
-    PrimaryGenerator(SPConstParticles, Input const&);
+    // Construct from shared particle data and new input
+    PrimaryGenerator(Input const&, ParticleParams const& particles);
 
     //! Prevent copying and moving
     CELER_DELETE_COPY_MOVE(PrimaryGenerator);

--- a/src/celeritas/phys/PrimaryGeneratorOptions.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.cc
@@ -8,9 +8,6 @@
 
 #include "corecel/io/EnumStringMapper.hh"
 #include "celeritas/inp/Events.hh"
-#include "celeritas/random/distribution/DeltaDistribution.hh"
-#include "celeritas/random/distribution/IsotropicDistribution.hh"
-#include "celeritas/random/distribution/UniformBoxDistribution.hh"
 
 namespace celeritas
 {
@@ -125,83 +122,6 @@ char const* to_cstring(DistributionSelection value)
         "box",
     };
     return to_cstring_impl(value);
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Return a distribution for sampling the energy.
- */
-std::function<real_type(PrimaryGeneratorEngine&)>
-make_energy_sampler(DistributionOptions options)
-{
-    CELER_EXPECT(options);
-
-    char const sampler_name[] = "energy";
-    check_params_size(sampler_name, 1, options);
-    auto const& p = options.params;
-    switch (options.distribution)
-    {
-        case DistributionSelection::delta:
-            return DeltaDistribution<real_type>(p[0]);
-        default:
-            CELER_VALIDATE(false,
-                           << "invalid distribution type '"
-                           << to_cstring(options.distribution) << "' for "
-                           << sampler_name);
-    }
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Return a distribution for sampling the position.
- */
-std::function<Real3(PrimaryGeneratorEngine&)>
-make_position_sampler(DistributionOptions options)
-{
-    CELER_EXPECT(options);
-
-    char const sampler_name[] = "position";
-    check_params_size(sampler_name, 3, options);
-    auto const& p = options.params;
-    switch (options.distribution)
-    {
-        case DistributionSelection::delta:
-            return DeltaDistribution<Real3>(Real3{p[0], p[1], p[2]});
-        case DistributionSelection::box:
-            return UniformBoxDistribution<real_type>(Real3{p[0], p[1], p[2]},
-                                                     Real3{p[3], p[4], p[5]});
-        default:
-            CELER_VALIDATE(false,
-                           << "invalid distribution type '"
-                           << to_cstring(options.distribution) << "' for "
-                           << sampler_name);
-    }
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Return a distribution for sampling the direction.
- */
-std::function<Real3(PrimaryGeneratorEngine&)>
-make_direction_sampler(DistributionOptions options)
-{
-    CELER_EXPECT(options);
-
-    char const sampler_name[] = "direction";
-    check_params_size(sampler_name, 3, options);
-    auto const& p = options.params;
-    switch (options.distribution)
-    {
-        case DistributionSelection::delta:
-            return DeltaDistribution<Real3>(Real3{p[0], p[1], p[2]});
-        case DistributionSelection::isotropic:
-            return IsotropicDistribution<real_type>();
-        default:
-            CELER_VALIDATE(false,
-                           << "invalid distribution type '"
-                           << to_cstring(options.distribution) << "' for "
-                           << sampler_name);
-    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PrimaryGeneratorOptions.hh
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.hh
@@ -7,8 +7,6 @@
 #pragma once
 
 #include <algorithm>
-#include <functional>
-#include <random>
 
 #include "corecel/io/StringEnumMapper.hh"
 #include "corecel/math/Algorithms.hh"
@@ -53,8 +51,6 @@ struct DistributionOptions
 /*!
  * Primary generator options.
  *
- * TODO: distributions should be std::variant (see ORANGE input)
- *
  * - \c seed: RNG seed
  * - \c pdg: PDG numbers of the primaries. An equal number of primaries of each
  *   type will be generated
@@ -63,6 +59,8 @@ struct DistributionOptions
  * - \c energy: energy distribution type and parameters
  * - \c position: spatial distribution type and parameters
  * - \c direction: angular distribution type and parameters
+ *
+ * \deprecated See inp::PrimaryGenerator
  */
 struct PrimaryGeneratorOptions
 {
@@ -84,10 +82,6 @@ struct PrimaryGeneratorOptions
     }
 };
 
-// TODO: move to PrimaryGenerator.hh
-
-using PrimaryGeneratorEngine = std::mt19937;
-
 //---------------------------------------------------------------------------//
 // Convert PrimaryGeneratorOptions to inp::PrimaryGenerator.
 inp::PrimaryGenerator to_input(PrimaryGeneratorOptions const&);
@@ -99,21 +93,5 @@ inp::PrimaryGenerator to_input(PrimaryGeneratorOptions const&);
 // Get a distribution name
 char const* to_cstring(DistributionSelection value);
 
-// TODO: move these to PrimaryGenerator.hh
-//! \cond
-
-// Return a distribution for sampling the energy
-std::function<real_type(PrimaryGeneratorEngine&)>
-make_energy_sampler(DistributionOptions options);
-
-// Return a distribution for sampling the position
-std::function<Real3(PrimaryGeneratorEngine&)>
-make_position_sampler(DistributionOptions options);
-
-// Return a distribution for sampling the direction
-std::function<Real3(PrimaryGeneratorEngine&)>
-make_direction_sampler(DistributionOptions options);
-
-//! \endcond
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/test/celeritas/phys/PrimaryGenerator.test.cc
+++ b/test/celeritas/phys/PrimaryGenerator.test.cc
@@ -7,6 +7,7 @@
 #include "celeritas/phys/PrimaryGenerator.hh"
 
 #include "corecel/math/ArrayUtils.hh"
+#include "celeritas/inp/Events.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/Primary.hh"
 #include "celeritas/phys/PrimaryGeneratorOptionsIO.json.hh"
@@ -58,10 +59,10 @@ TEST_F(PrimaryGeneratorTest, basic)
     inp.pdg = {pdg::gamma(), pdg::electron()};
     inp.num_events = 2;
     inp.primaries_per_event = 3;
-    inp.sample_energy = DeltaDistribution<real_type>(10);
-    inp.sample_pos = DeltaDistribution<Real3>(Real3{1, 2, 3});
-    inp.sample_dir = IsotropicDistribution<real_type>();
-    PrimaryGenerator generate_primaries(particles_, inp);
+    inp.energy = inp::Monoenergetic{units::MevEnergy{10}};
+    inp.shape = inp::PointShape{Real3{1, 2, 3}};
+    inp.angle = inp::IsotropicAngle{};
+    PrimaryGenerator generate_primaries(inp, *particles_);
     EXPECT_EQ(2, generate_primaries.num_events());
 
     std::vector<int> particle_id;


### PR DESCRIPTION
**chained** on #1562 . This refactors the PrimaryGenerator construction to use `inp` and serves as a template and demonstration for future refactors.