### PR TITLE
Fix spurious vecgeom warning

### DIFF
--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -279,8 +279,15 @@ void VecgeomParams::build_volumes_geant4(G4VPhysicalVolume const* world)
     g4log_volid_map_.reserve(result.logical_volumes.size());
     for (auto vol_idx : range(result.logical_volumes.size()))
     {
-        auto&& [iter, inserted] = g4log_volid_map_.insert(
-            {result.logical_volumes[vol_idx], id_cast<VolumeId>(vol_idx)});
+        auto const* lv = result.logical_volumes[vol_idx];
+        if (lv == nullptr)
+        {
+            // VecGeom creates fake volumes for boolean volumes
+            continue;
+        }
+
+        auto&& [iter, inserted]
+            = g4log_volid_map_.insert({lv, id_cast<VolumeId>(vol_idx)});
         if (CELER_UNLIKELY(!inserted))
         {
             // This shouldn't happen...


### PR DESCRIPTION
This fixes a warning that occurs when boolean volumes are present in a converged Geant4 geometry:
```
src/geocel/vg/VecgeomParams.cc:287: warning: Geant4 logical volume {null G4LogicalVolume} maps to multiple volume IDs 
```

We can safely ignore volumes that don't map to Geant4 volumes.