### PR TITLE
Add ARM runner to CI

### DIFF
--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -40,6 +40,10 @@ jobs:
             compiler: clang
             version: 18
             cxxstd: 20
+          - runner: noble-arm
+            compiler: clang
+            version: 18
+            cxxstd: 20
     env:
       GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{matrix.cxxstd && format('-c++{0}', matrix.cxxstd) || ''}}"
       CCACHE_DIR: "${{github.workspace}}/.ccache"
@@ -51,6 +55,7 @@ jobs:
       ${{  matrix.runner == 'focal' && 'ubuntu-20.04'
         || matrix.runner == 'jammy' && 'ubuntu-22.04'
         || matrix.runner == 'noble' && 'ubuntu-24.04'
+        || matrix.runner == 'noble-arm' && 'ubuntu-24.04-arm'
       }}
     steps:
       - name: Install dependencies

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -17,25 +17,25 @@ jobs:
           - runner: focal
             compiler: gcc
             version: 8
-          - runner: jammy
-            compiler: gcc
-            version: 12
-          - runner: noble
-            compiler: gcc
-            version: 14
-          - runner: noble
-            compiler: gcc
-            version: 14
-            cxxstd: 20
           - runner: focal
             compiler: clang
             version: 10
           - runner: jammy
+            compiler: gcc
+            version: 12
+          - runner: jammy
             compiler: clang
             version: 15
           - runner: noble
+            compiler: gcc
+            version: 14
+          - runner: noble
             compiler: clang
             version: 18
+          - runner: noble
+            compiler: gcc
+            version: 14
+            cxxstd: 20
           - runner: noble
             compiler: clang
             version: 18

--- a/README.md
+++ b/README.md
@@ -109,11 +109,16 @@ $ make && ctest
 Celeritas guarantees full compatibility and correctness only on the
 combinations of compilers and dependencies tested under continuous integration.
 See the configure output from the [GitHub runners](https://github.com/celeritas-project/celeritas/actions/workflows/push.yml) for the full list of combinations.
-- Compilers and standard:
+- Compilers
     - GCC 8, 11, 12, 14
     - Clang 10, 15, 18
+    - MSVC 19
     - GCC 11.5 + NVCC 12.6
     - ROCm Clang 18
+- Platforms
+    - Linux x86_64, ARM
+    - Windows x86_64
+- C++ standard
     - C++17 and C++20
 - Dependencies:
     - Geant4 11.0.4


### PR DESCRIPTION
This increases testing by adding support for GitHub's [newly released](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) ARM runner preview.