### PR TITLE
Update Perlmutter env

### DIFF
--- a/scripts/cmake-presets/perlmutter.json
+++ b/scripts/cmake-presets/perlmutter.json
@@ -19,6 +19,7 @@
         "CELERITAS_USE_MPI":    {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "ON"},
+        "CMAKE_EXE_LINKER_FLAGS": {"type": "STRING", "value": "-ldl"},
         "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wno-psabi -pedantic -pedantic-errors",
         "CMAKE_CUDA_FLAGS": "-lineinfo -Xptxas=-v -Xcompiler -Wno-psabi",
         "CMAKE_CUDA_ARCHITECTURES": {"type": "STRING", "value": "80"},

--- a/scripts/env/perlmutter.sh
+++ b/scripts/env/perlmutter.sh
@@ -6,7 +6,7 @@
 # --> the fix for now is to unload these modules and install our own cudatoolkit using Spack.
 module unload gpu
 module load PrgEnv-gnu
-
+module unload cray-libsci
 
 # Expects the spack git repo to have been cloned at _SPACK_INSTALL (default to $SPACK_ROOT)
 # The environment named celeritas must exists


### PR DESCRIPTION
`libsci` was being linked twice, from OpenMP and the libsci module. This caused a warning  at runtime which which was making the regression test fail to parse the JSON output... Disabling that module results in another error: a few CUDA test fail to link with the following error: 
`test/celeritas/CMakeFiles/celeritas_phys_Particle.dir/phys/Particle.test.cu.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'`. I looked at the symbol `Particle.test.cu.o` and there is indeed `dlclose`, it is not clear to me who is bringing that symbol there.

The failure only happens with VecGeom build, the ORANGE build has `-ldl` in the linker invocation, I don't know why it's different for VecGeom.  Just work around it by setting `CMAKE_EXE_LINKER_FLAGS`...