### PR TITLE
Improve diagnostic output when offloading

### DIFF
--- a/src/accel/LocalTransporter.hh
+++ b/src/accel/LocalTransporter.hh
@@ -104,6 +104,10 @@ class LocalTransporter
     size_type max_step_iters_{};
     double buffer_energy_{0};
 
+    std::size_t accum_num_events_{0};
+    std::size_t accum_num_primaries_{0};
+    std::size_t accum_num_steps_{0};
+
     // Shared across threads to write flushed particles
     SPOffloadWriter dump_primaries_;
 };

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -133,7 +133,7 @@ struct SetupOptions
     //! GDML filename (optional: defaults to exporting existing Geant4)
     std::string geometry_file;
     //! Filename for JSON diagnostic output
-    std::string output_file;
+    std::string output_file{"celeritas.out.json"};
     //! Filename for ROOT dump of physics data
     std::string physics_output_file;
     //! Filename to dump a ROOT/HepMC3 copy of offloaded tracks as events

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -22,6 +22,7 @@
 #include <G4Threading.hh>
 
 #include "corecel/Config.hh"
+#include "corecel/Version.hh"
 
 #include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
@@ -213,7 +214,10 @@ SharedParams::SharedParams(SetupOptions const& options)
                       "Celeritas offloading is disabled via "
                       "\"CELER_DISABLE\"");
 
-    CELER_LOG_LOCAL(status) << "Initializing Celeritas shared data";
+    CELER_LOG_LOCAL(info) << "Activating Celeritas version "
+                          << celeritas_version << " on "
+                          << (Device::num_devices() > 0 ? "GPU" : "CPU");
+
     ScopedProfiling profile_this{"construct-params"};
     ScopedMem record_mem("SharedParams.construct");
     ScopedTimeLog scoped_time;
@@ -248,8 +252,8 @@ SharedParams::SharedParams(SetupOptions const& options)
     }
     else
     {
-        CELER_LOG(debug) << "Skipping 'startup' JSON output since writing to "
-                            "stdout";
+        CELER_LOG(debug)
+            << R"(Skipping 'startup' JSON output since writing to stdout)";
     }
 
     if (!options.offload_output_file.empty())
@@ -684,7 +688,7 @@ void SharedParams::set_num_streams(unsigned int num_streams)
  * Write available Celeritas output.
  *
  * This can be done multiple times, overwriting the same file so that we can
- * get output before construction and after
+ * get output before construction *and* after.
  */
 void SharedParams::try_output() const
 {
@@ -698,7 +702,8 @@ void SharedParams::try_output() const
     std::string filename = output_filename_;
     if (!params_ && filename.empty())
     {
-        // Setup was not called but JSON is available: make a default filename
+        // Setup was not called but we're outputting anyway (called by
+        // celer-g4?)
         filename = "celeritas.out.json";
         CELER_LOG(debug) << "Set default Celeritas output filename";
     }

--- a/src/accel/SimpleOffload.cc
+++ b/src/accel/SimpleOffload.cc
@@ -47,9 +47,16 @@ SimpleOffload::SimpleOffload(SetupOptions const* setup,
     }
     if (SharedParams::CeleritasDisabled())
     {
-        CELER_LOG_LOCAL(debug)
-            << "Disabling Celeritas offloading since the 'CELER_DISABLE' "
-               "environment variable is present and non-empty";
+        if (G4Threading::IsMasterThread())
+        {
+            CELER_LOG(info)
+                << "Disabling Celeritas offloading since the 'CELER_DISABLE' "
+                   "environment variable is present and non-empty";
+        }
+        else
+        {
+            CELER_LOG(debug) << "Disabling Celeritas offloading";
+        }
         *this = {};
         CELER_ENSURE(!*this);
     }


### PR DESCRIPTION
By default this writes a few more diagnostics for better visibility/reproducibility:
- By default, write the `celeritas.out.json` file when running from an integrated application.
- If disabled, write an informational message (and add debug information from worker threads).
- At the beginning of execution, write a message with the version and where it's executing.
- At the end of execution, print out cumulative number of steps, primaries, and events on each thread.