### PR TITLE
Output diagnostic information about core sizes

### DIFF
--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -448,6 +448,12 @@ void Runner::build_core_params(RunnerInput const& inp,
                       "streams ("
                    << params.max_streams << " requested)");
 
+    // Store number of tracks per stream
+    CELER_VALIDATE(inp.num_track_slots > 0,
+                   << "nonpositive num_track_slots=" << inp.num_track_slots);
+    params.tracks_per_stream
+        = ceil_div(inp.num_track_slots, params.max_streams);
+
     // Construct track initialization params
     params.init = [&inp, &params, num_events] {
         CELER_VALIDATE(inp.initializer_capacity > 0,
@@ -469,14 +475,10 @@ void Runner::build_core_params(RunnerInput const& inp,
  */
 void Runner::build_transporter_input(RunnerInput const& inp)
 {
-    CELER_VALIDATE(inp.num_track_slots > 0,
-                   << "nonpositive num_track_slots=" << inp.num_track_slots);
     CELER_VALIDATE(inp.max_steps > 0,
                    << "nonpositive max_steps=" << inp.max_steps);
 
     transporter_input_ = std::make_shared<TransporterInput>();
-    transporter_input_->num_track_slots
-        = ceil_div(inp.num_track_slots, core_params_->max_streams());
     transporter_input_->max_steps = inp.max_steps;
     transporter_input_->store_track_counts = inp.write_track_counts;
     transporter_input_->store_step_times = inp.write_step_times;

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -72,7 +72,6 @@ Transporter<M>::Transporter(TransporterInput inp)
     CELER_LOG_LOCAL(status) << "Creating states";
     StepperInput step_input;
     step_input.params = inp.params;
-    step_input.num_track_slots = inp.num_track_slots;
     step_input.stream_id = inp.stream_id;
     step_input.action_times = inp.action_times;
     stepper_ = std::make_shared<Stepper<M>>(std::move(step_input));

--- a/app/celer-sim/Transporter.hh
+++ b/app/celer-sim/Transporter.hh
@@ -36,7 +36,6 @@ struct TransporterInput
 {
     // Stepper input
     std::shared_ptr<CoreParams const> params;
-    size_type num_track_slots{};  //!< AKA max_num_tracks
     bool action_times{false};  //!< Whether to synchronize device between
                                //!< actions for timing
 
@@ -51,8 +50,7 @@ struct TransporterInput
     //! True if all params are assigned
     explicit operator bool() const
     {
-        return params && num_track_slots > 0 && max_steps > 0
-               && log_progress > 0;
+        return params && max_steps > 0 && log_progress > 0;
     }
 };
 

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -143,7 +143,6 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
     StepperInput inp;
     inp.params = params.Params();
     inp.stream_id = stream_id;
-    inp.num_track_slots = options.max_num_tracks;
     inp.action_times = options.action_times;
 
     if (celeritas::device())

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -601,6 +601,9 @@ void SharedParams::initialize_core(SetupOptions const& options)
         params.max_streams = this->num_streams();
     }
 
+    // Set state size
+    params.tracks_per_stream = options.max_num_tracks;
+
     // Allocate device streams, or use the default stream if there is only one.
     if (celeritas::device() && !options.default_stream
         && params.max_streams > 1)

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -213,13 +213,18 @@ auto get_core_sizes(CoreParams const& cp)
     auto const& init = *cp.init();
 
     detail::CoreSizes result;
-    result.streams = cp.max_streams();
     result.processes = comm_world().size();
+    result.streams = cp.max_streams();
 
+    // NOTE: quantities are *per-process* quantities: integrated over streams,
+    // but not processes
     result.initializers = result.streams * init.capacity();
     result.tracks = result.streams * cp.tracks_per_stream();
+    // Number of secondaries is currently based on track size
     result.secondaries = cp.physics()->host_ref().scalars.secondary_stack_factor
                          * result.tracks;
+    // Event IDs are the same across all threads so this is *not* multiplied by
+    // streams
     result.events = init.max_events();
 
     return result;

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -221,8 +221,9 @@ auto get_core_sizes(CoreParams const& cp)
     result.initializers = result.streams * init.capacity();
     result.tracks = result.streams * cp.tracks_per_stream();
     // Number of secondaries is currently based on track size
-    result.secondaries = cp.physics()->host_ref().scalars.secondary_stack_factor
-                         * result.tracks;
+    result.secondaries = static_cast<size_type>(
+        cp.physics()->host_ref().scalars.secondary_stack_factor
+        * result.tracks);
     // Event IDs are the same across all threads so this is *not* multiplied by
     // streams
     result.events = init.max_events();

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -55,6 +55,8 @@
 
 #include "ActionInterface.hh"
 
+#include "detail/CoreSizes.json.hh"
+
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
 #    include "orange/OrangeParams.hh"
 #    include "orange/OrangeParamsOutput.hh"
@@ -206,6 +208,24 @@ CoreScalars build_actions(ActionRegistry* reg)
 }
 
 //---------------------------------------------------------------------------//
+auto get_core_sizes(CoreParams const& cp)
+{
+    auto const& init = *cp.init();
+
+    detail::CoreSizes result;
+    result.streams = cp.max_streams();
+    result.processes = comm_world().size();
+
+    result.initializers = result.streams * init.capacity();
+    result.tracks = result.streams * cp.tracks_per_stream();
+    result.secondaries = cp.physics()->host_ref().scalars.secondary_stack_factor
+                         * result.tracks;
+    result.events = init.max_events();
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace
 
 //---------------------------------------------------------------------------//
@@ -311,6 +331,11 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
     input_.output_reg->insert(OutputInterfaceAdapter<Environment>::from_const_ref(
         OutputInterface::Category::system, "environ", celeritas::environment()));
     input_.output_reg->insert(std::make_shared<BuildOutput>());
+    input_.output_reg->insert(
+        OutputInterfaceAdapter<detail::CoreSizes>::from_rvalue_ref(
+            OutputInterface::Category::internal,
+            "core_sizes",
+            get_core_sizes(*this)));
 
     // Save core diagnostic information
     input_.output_reg->insert(

--- a/src/celeritas/global/CoreParams.hh
+++ b/src/celeritas/global/CoreParams.hh
@@ -38,8 +38,8 @@ class WentzelOKVIParams;
 /*!
  * Global parameters required to run a problem.
  *
- * \todo Always \c tracks_per_stream to build actual states. Currently unit
- * tests build states independently.
+ * \todo Applications specify \c tracks_per_stream to build the states, but
+ * unit tests currently omit this option.
  */
 class CoreParams final : public ParamsDataInterface<CoreParamsData>
 {

--- a/src/celeritas/global/CoreParams.hh
+++ b/src/celeritas/global/CoreParams.hh
@@ -37,6 +37,9 @@ class WentzelOKVIParams;
 //---------------------------------------------------------------------------//
 /*!
  * Global parameters required to run a problem.
+ *
+ * \todo Always \c tracks_per_stream to build actual states. Currently unit
+ * tests build states independently.
  */
 class CoreParams final : public ParamsDataInterface<CoreParamsData>
 {
@@ -84,6 +87,9 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
 
         //! Maximum number of simultaneous threads/tasks per process
         StreamId::size_type max_streams{1};
+
+        //! Number of track slots per stream
+        StreamId::size_type tracks_per_stream{0};
 
         //! True if all params are assigned and valid
         explicit operator bool() const
@@ -134,6 +140,9 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
 
     //! Maximum number of streams
     size_type max_streams() const { return input_.max_streams; }
+
+    //! Number of track slots per stream
+    size_type tracks_per_stream() const { return input_.tracks_per_stream; }
 
   private:
     Input input_;

--- a/src/celeritas/global/CoreState.cc
+++ b/src/celeritas/global/CoreState.cc
@@ -24,6 +24,16 @@ CoreStateInterface::~CoreStateInterface() = default;
  * Construct from CoreParams.
  */
 template<MemSpace M>
+CoreState<M>::CoreState(CoreParams const& params, StreamId stream_id)
+    : CoreState{params, stream_id, params.tracks_per_stream()}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from CoreParams.
+ */
+template<MemSpace M>
 CoreState<M>::CoreState(CoreParams const& params,
                         StreamId stream_id,
                         size_type num_track_slots)

--- a/src/celeritas/global/CoreState.cc
+++ b/src/celeritas/global/CoreState.cc
@@ -31,7 +31,10 @@ CoreState<M>::CoreState(CoreParams const& params, StreamId stream_id)
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct from CoreParams.
+ * Construct with manual slot count.
+ *
+ * This is currently used for unit tests, and temporarily used by the \c
+ * Stepper constructor.
  */
 template<MemSpace M>
 CoreState<M>::CoreState(CoreParams const& params,

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -84,6 +84,9 @@ class CoreState final : public CoreStateInterface
 
   public:
     // Construct from CoreParams
+    CoreState(CoreParams const& params, StreamId stream_id);
+
+    // Construct witih manual slot count
     CoreState(CoreParams const& params,
               StreamId stream_id,
               size_type num_track_slots);

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -86,7 +86,7 @@ class CoreState final : public CoreStateInterface
     // Construct from CoreParams
     CoreState(CoreParams const& params, StreamId stream_id);
 
-    // Construct witih manual slot count
+    // Construct with manual slot count
     CoreState(CoreParams const& params,
               StreamId stream_id,
               size_type num_track_slots);

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -69,6 +69,10 @@ Stepper<M>::Stepper(Input input)
         return std::make_shared<ActionSequenceT>(*params_->action_reg(), opts);
     }()}
 {
+    // NOTE: if this fails, you're probably running from a unit test?
+    CELER_VALIDATE(params_->tracks_per_stream() > 0,
+                   << "core params `tracks_per_stream` was not set");
+
     // Save primary action: TODO this is a hack and should be refactored so
     // that we pass generators into the stepper and eliminate the call
     // signature with primaries
@@ -76,9 +80,15 @@ Stepper<M>::Stepper(Input input)
     CELER_VALIDATE(primaries_action_,
                    << "primary generator was not added to the stepping loop");
 
+    size_type const track_slots = (input.num_track_slots == 0
+                                       ? params_->tracks_per_stream()
+                                       : input.num_track_slots);
+    CELER_VALIDATE(track_slots > 0,
+                   << "track slots were specified neither in core params nor "
+                      "stepper input");
     // Create state, including aux data
     state_ = std::make_shared<CoreState<M>>(
-        *params_, input.stream_id, input.num_track_slots);
+        *params_, input.stream_id, track_slots);
 
     // Execute beginning-of-run action
     ScopedProfiling profile_this{"begin-run"};

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -69,10 +69,6 @@ Stepper<M>::Stepper(Input input)
         return std::make_shared<ActionSequenceT>(*params_->action_reg(), opts);
     }()}
 {
-    // NOTE: if this fails, you're probably running from a unit test?
-    CELER_VALIDATE(params_->tracks_per_stream() > 0,
-                   << "core params `tracks_per_stream` was not set");
-
     // Save primary action: TODO this is a hack and should be refactored so
     // that we pass generators into the stepper and eliminate the call
     // signature with primaries

--- a/src/celeritas/global/Stepper.hh
+++ b/src/celeritas/global/Stepper.hh
@@ -36,6 +36,7 @@ class ActionSequence;
  *
  * - \c params : Problem definition
  * - \c num_track_slots : Maximum number of threads to run in parallel on GPU
+ *   (optional, could be set by params)
  *   \c stream_id : Unique (thread/task) ID for this process
  * - \c action_times : Whether to synchronize device between actions for timing
  */
@@ -47,10 +48,7 @@ struct StepperInput
     bool action_times{false};
 
     //! True if defined
-    explicit operator bool() const
-    {
-        return params && stream_id && num_track_slots > 0;
-    }
+    explicit operator bool() const { return params && stream_id; }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/detail/CoreSizes.json.hh
+++ b/src/celeritas/global/detail/CoreSizes.json.hh
@@ -1,0 +1,48 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/global/detail/CoreSizes.json.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/io/JsonUtils.json.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Save state size/capacity counters.
+ *
+ * These should be *integrated* across streams, *per process*.
+ */
+struct CoreSizes
+{
+    size_type initializers{};
+    size_type tracks{};
+    size_type secondaries{};
+    size_type events{};
+
+    size_type streams{};
+    size_type processes{};
+};
+
+//---------------------------------------------------------------------------//
+
+void to_json(nlohmann::json& j, CoreSizes const& inp)
+{
+    j = {
+        CELER_JSON_PAIR(inp, initializers),
+        CELER_JSON_PAIR(inp, tracks),
+        CELER_JSON_PAIR(inp, secondaries),
+        CELER_JSON_PAIR(inp, events),
+        CELER_JSON_PAIR(inp, streams),
+        CELER_JSON_PAIR(inp, processes),
+    };
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/global/detail/CoreSizes.json.hh
+++ b/src/celeritas/global/detail/CoreSizes.json.hh
@@ -6,6 +6,9 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <nlohmann/json.hpp>
+
+#include "corecel/Types.hh"
 #include "corecel/io/JsonUtils.json.hh"
 
 namespace celeritas

--- a/src/celeritas/optical/Model.hh
+++ b/src/celeritas/optical/Model.hh
@@ -28,6 +28,15 @@ class MfpBuilder;
 class Model : public OpticalStepActionInterface, public ConcreteAction
 {
   public:
+    //!@{
+    //! \name Type aliases
+
+    //! Function to build optical models with a given action id
+    using ModelBuilder = std::function<std::shared_ptr<Model>(ActionId)>;
+
+    //!@}
+
+  public:
     using ConcreteAction::ConcreteAction;
 
     //! Action order for optical models is always post-step

--- a/src/celeritas/optical/ModelImporter.hh
+++ b/src/celeritas/optical/ModelImporter.hh
@@ -14,6 +14,7 @@
 
 #include "celeritas/io/ImportOpticalModel.hh"
 
+#include "Model.hh"
 #include "Types.hh"
 
 namespace celeritas
@@ -56,6 +57,7 @@ class ModelImporter
 
     //!@{
     //! \name User builder type aliases
+    using ModelBuilder = Model::ModelBuilder;
     using UserBuildFunction
         = std::function<std::optional<ModelBuilder>(UserBuildInput const&)>;
     using UserBuildMap = std::unordered_map<IMC, UserBuildFunction>;
@@ -107,6 +109,7 @@ struct WarnAndIgnoreModel
     //!@{
     //! \name Type aliases
     using UserBuildInput = ModelImporter::UserBuildInput;
+    using ModelBuilder = ModelImporter::ModelBuilder;
     //!@}
 
     // Warn about a missing optical model and ignore it

--- a/src/celeritas/optical/Types.hh
+++ b/src/celeritas/optical/Types.hh
@@ -29,12 +29,9 @@ using ParticleScintSpectrumId = OpaqueId<struct ParScintSpectrumRecord_>;
  */
 namespace optical
 {
-
+//---------------------------------------------------------------------------//
 //! Alias for MaterialId in core Celeritas namespace
 using CoreMaterialId = ::celeritas::MaterialId;
-
-//! Function to build optical models with a given action id
-using ModelBuilder = std::function<std::shared_ptr<class Model>(ActionId)>;
 
 //---------------------------------------------------------------------------//
 }  // namespace optical

--- a/src/celeritas/optical/model/AbsorptionModel.cc
+++ b/src/celeritas/optical/model/AbsorptionModel.cc
@@ -19,7 +19,7 @@ namespace optical
 /*!
  * Create a model builder for the optical absorption model.
  */
-ModelBuilder AbsorptionModel::make_builder(SPConstImported imported)
+auto AbsorptionModel::make_builder(SPConstImported imported) -> ModelBuilder
 {
     CELER_EXPECT(imported);
     return [i = std::move(imported)](ActionId id) {

--- a/src/celeritas/optical/model/RayleighModel.cc
+++ b/src/celeritas/optical/model/RayleighModel.cc
@@ -25,7 +25,8 @@ namespace optical
  * Create a model builder for Rayleigh scattering from imported data and
  * material parameters.
  */
-ModelBuilder RayleighModel::make_builder(SPConstImported imported, Input input)
+auto RayleighModel::make_builder(SPConstImported imported,
+                                 Input input) -> ModelBuilder
 {
     CELER_EXPECT(imported);
     return [imported = std::move(imported),


### PR DESCRIPTION
Based on the mess in https://github.com/celeritas-project/celeritas/pull/1577 and discussions in https://github.com/celeritas-project/celeritas/pull/1562 , we really need a definitive diagnostic about the state sizes.

The gotcha is that the number of states isn't previously known to the core params (it's passed on constructing the stepper or core state). With #1556 we want to transition to more tightly integrating the params and state, so for now I'm adding an optional "state size" to the params that can be used to create the core state. For now this state size is set by the apps (where we care about the diagnostic) but not the unit tests (which often reuse the same core params with different stepper sizes).