### PR TITLE
Change PrimaryGeneratorAction to be a wrapper 

### DIFF
--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -7,7 +7,6 @@
 #include "ActionInitialization.hh"
 
 #include "corecel/io/Logger.hh"
-#include "celeritas/inp/Events.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
 #include "accel/ExceptionConverter.hh"
 #include "accel/HepMC3PrimaryGenerator.hh"
@@ -103,7 +102,7 @@ void ActionInitialization::Build() const
         ExceptionConverter call_g4exception{"celer0006"};
         CELER_TRY_HANDLE(
             generator_action = std::make_unique<PGPrimaryGeneratorAction>(
-                to_input(GlobalSetup::Instance()->input().primary_options)),
+                GlobalSetup::Instance()->input().primary_options),
             call_g4exception);
     }
     this->SetUserAction(generator_action.release());

--- a/app/celer-g4/ActionInitialization.cc
+++ b/app/celer-g4/ActionInitialization.cc
@@ -7,6 +7,8 @@
 #include "ActionInitialization.hh"
 
 #include "corecel/io/Logger.hh"
+#include "celeritas/inp/Events.hh"
+#include "celeritas/phys/PrimaryGeneratorOptions.hh"
 #include "accel/ExceptionConverter.hh"
 #include "accel/HepMC3PrimaryGenerator.hh"
 #include "accel/LocalTransporter.hh"
@@ -101,7 +103,7 @@ void ActionInitialization::Build() const
         ExceptionConverter call_g4exception{"celer0006"};
         CELER_TRY_HANDLE(
             generator_action = std::make_unique<PGPrimaryGeneratorAction>(
-                GlobalSetup::Instance()->input().primary_options),
+                to_input(GlobalSetup::Instance()->input().primary_options)),
             call_g4exception);
     }
     this->SetUserAction(generator_action.release());

--- a/app/celer-g4/PGPrimaryGeneratorAction.cc
+++ b/app/celer-g4/PGPrimaryGeneratorAction.cc
@@ -13,34 +13,59 @@
 #include "corecel/Macros.hh"
 #include "geocel/GeantUtils.hh"
 #include "geocel/g4/Convert.hh"
-#include "celeritas/phys/PrimaryGeneratorOptions.hh"
+#include "celeritas/ext/GeantImporter.hh"
+#include "celeritas/ext/GeantUnits.hh"
+#include "celeritas/inp/Events.hh"
+#include "celeritas/phys/ParticleParams.hh"
+#include "celeritas/phys/Primary.hh"
 
 namespace celeritas
 {
 namespace app
 {
+namespace
+{
+//---------------------------------------------------------------------------//
+auto make_particles(std::vector<PDGNumber> const& all_pdg)
+{
+    CELER_VALIDATE(!all_pdg.empty(),
+                   << "primary generator has no input particles");
+
+    auto* par_table = G4ParticleTable::GetParticleTable();
+    CELER_ASSERT(par_table);
+
+    // Find and convert Geant4 particles
+    ParticleParams::Input inp;
+    for (auto pdg : all_pdg)
+    {
+        CELER_EXPECT(pdg);
+        auto* p = par_table->FindParticle(pdg.get());
+        CELER_VALIDATE(
+            p, << "particle with PDG " << pdg.get() << " is not loaded");
+        inp.push_back(
+            ParticleParams::ParticleInput::from_import(import_particle(*p)));
+    }
+
+    return std::make_shared<ParticleParams>(std::move(inp));
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace
+
 //---------------------------------------------------------------------------//
 /*!
  * Construct primary action.
  */
-PGPrimaryGeneratorAction::PGPrimaryGeneratorAction(
-    PrimaryGeneratorOptions const& options)
+PGPrimaryGeneratorAction::PGPrimaryGeneratorAction(Input const& i)
+    : particle_params_{make_particles(i.pdg)}
+    , generate_primaries_{i, *particle_params_}
 {
-    CELER_EXPECT(options);
-
     // Generate one particle at each call to \c GeneratePrimaryVertex()
     gun_.SetNumberOfParticles(1);
 
-    seed_ = options.seed;
-    num_events_ = options.num_events;
-    primaries_per_event_ = options.primaries_per_event;
-    sample_energy_ = make_energy_sampler(options.energy);
-    sample_pos_ = make_position_sampler(options.position);
-    sample_dir_ = make_direction_sampler(options.direction);
-
-    // Set the particle definitions
-    particle_def_.reserve(options.pdg.size());
-    for (auto const& pdg : options.pdg)
+    // Save the particle definitions corresponding to particle IDs
+    particle_def_.reserve(i.pdg.size());
+    for (auto const& pdg : i.pdg)
     {
         particle_def_.push_back(
             G4ParticleTable::GetParticleTable()->FindParticle(pdg.get()));
@@ -56,28 +81,23 @@ void PGPrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
     CELER_EXPECT(event);
     CELER_EXPECT(event->GetEventID() >= 0);
 
-    size_type event_id = event->GetEventID();
-    if (event_id >= num_events_)
-    {
-        return;
-    }
-
     // Seed with an independent value for each event. Since Geant4 schedules
     // events dynamically, the same event ID may not be mapped to the same
     // thread across multiple runs. For reproducibility, Geant4 reseeds each
     // worker thread's RNG at the start of each event with a seed calculated
     // from the event ID.
-    rng_.seed(seed_ + event_id);
+    generate_primaries_.seed(id_cast<UniqueEventId>(event->GetEventID()));
 
-    for (size_type i = 0; i < primaries_per_event_; ++i)
+    auto primaries = generate_primaries_();
+
+    for (auto const& p : primaries)
     {
-        gun_.SetParticleDefinition(particle_def_[i % particle_def_.size()]);
-        gun_.SetParticlePosition(
-            convert_to_geant(sample_pos_(rng_), clhep_length));
-        gun_.SetParticleMomentumDirection(
-            convert_to_geant(sample_dir_(rng_), 1));
-        gun_.SetParticleEnergy(
-            convert_to_geant(sample_energy_(rng_), CLHEP::MeV));
+        CELER_ASSERT(p.particle_id < particle_def_.size());
+        gun_.SetParticleDefinition(
+            particle_def_[p.particle_id.unchecked_get()]);
+        gun_.SetParticlePosition(convert_to_geant(p.position, clhep_length));
+        gun_.SetParticleMomentumDirection(convert_to_geant(p.direction, 1));
+        gun_.SetParticleEnergy(convert_to_geant(p.energy, CLHEP::MeV));
         gun_.GeneratePrimaryVertex(event);
 
         if (CELERITAS_DEBUG)
@@ -88,7 +108,7 @@ void PGPrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
     }
 
     CELER_ENSURE(event->GetNumberOfPrimaryVertex()
-                 == static_cast<int>(primaries_per_event_));
+                 == static_cast<int>(primaries.size()));
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/PGPrimaryGeneratorAction.cc
+++ b/app/celer-g4/PGPrimaryGeneratorAction.cc
@@ -15,7 +15,6 @@
 #include "geocel/g4/Convert.hh"
 #include "celeritas/ext/GeantImporter.hh"
 #include "celeritas/ext/GeantUnits.hh"
-#include "celeritas/inp/Events.hh"
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/Primary.hh"
 
@@ -58,7 +57,7 @@ auto make_particles(std::vector<PDGNumber> const& all_pdg)
  */
 PGPrimaryGeneratorAction::PGPrimaryGeneratorAction(Input const& i)
     : particle_params_{make_particles(i.pdg)}
-    , generate_primaries_{i, *particle_params_}
+    , generate_primaries_{PrimaryGenerator::from_options(particle_params_, i)}
 {
     // Generate one particle at each call to \c GeneratePrimaryVertex()
     gun_.SetNumberOfParticles(1);

--- a/app/celer-g4/PGPrimaryGeneratorAction.hh
+++ b/app/celer-g4/PGPrimaryGeneratorAction.hh
@@ -6,7 +6,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <functional>
 #include <G4Event.hh>
 #include <G4ParticleDefinition.hh>
 #include <G4ParticleGun.hh>
@@ -14,8 +13,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
-#include "geocel/Types.hh"
-#include "celeritas/phys/PrimaryGeneratorOptions.hh"
+#include "celeritas/phys/PrimaryGenerator.hh"
 
 namespace celeritas
 {
@@ -36,28 +34,23 @@ class PGPrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
   public:
     //!@{
     //! \name Type aliases
-    using EnergySampler = std::function<real_type(PrimaryGeneratorEngine&)>;
-    using PositionSampler = std::function<Real3(PrimaryGeneratorEngine&)>;
-    using DirectionSampler = std::function<Real3(PrimaryGeneratorEngine&)>;
+    using Input = inp::PrimaryGenerator;
     //!@}
 
   public:
     // Construct primary action
-    explicit PGPrimaryGeneratorAction(PrimaryGeneratorOptions const& opts);
+    explicit PGPrimaryGeneratorAction(Input const& opts);
 
     // Generate events
     void GeneratePrimaries(G4Event* event) final;
 
   private:
+    using GeneratorImpl = celeritas::PrimaryGenerator;
+
+    GeneratorImpl::SPConstParticles particle_params_;
+    GeneratorImpl generate_primaries_;
     G4ParticleGun gun_;
-    PrimaryGeneratorEngine rng_;
-    size_type num_events_{};
-    size_type primaries_per_event_{};
     std::vector<G4ParticleDefinition*> particle_def_;
-    EnergySampler sample_energy_;
-    PositionSampler sample_pos_;
-    DirectionSampler sample_dir_;
-    size_type seed_{0};
 };
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/PGPrimaryGeneratorAction.hh
+++ b/app/celer-g4/PGPrimaryGeneratorAction.hh
@@ -34,7 +34,7 @@ class PGPrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
   public:
     //!@{
     //! \name Type aliases
-    using Input = inp::PrimaryGenerator;
+    using Input = PrimaryGeneratorOptions;
     //!@}
 
   public:

--- a/src/celeritas/ext/GeantImporter.hh
+++ b/src/celeritas/ext/GeantImporter.hh
@@ -17,6 +17,7 @@
 
 // Geant4 forward declaration
 class G4VPhysicalVolume;  // IWYU pragma: keep
+class G4ParticleDefinition;  // IWYU pragma: keep
 
 namespace celeritas
 {
@@ -96,11 +97,14 @@ class GeantImporter final : public ImporterInterface
     GeantSetup setup_;
     // World physical volume
     G4VPhysicalVolume const* world_{nullptr};
-
-    //// HELPER FUNCTIONS ////
-
-    std::vector<ImportVolume> import_volumes(bool unique_volumes) const;
 };
+
+//---------------------------------------------------------------------------//
+
+std::vector<ImportVolume>
+import_volumes(G4VPhysicalVolume const& world, bool unique_volumes);
+
+ImportParticle import_particle(G4ParticleDefinition const& p);
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/src/celeritas/phys/ParticleParams.cc
+++ b/src/celeritas/phys/ParticleParams.cc
@@ -87,6 +87,9 @@ ParticleParams::ParticleParams(Input const& input)
     detail::ParticleInserter insert_particle(&host_data);
     for (auto const& particle : input)
     {
+        CELER_VALIDATE(particle.pdg_code,
+                       << "input particle '" << particle.name
+                       << "' was not assigned a PDG code");
         CELER_EXPECT(!particle.name.empty());
 
         ParticleId id = insert_particle(particle);
@@ -94,9 +97,16 @@ ParticleParams::ParticleParams(Input const& input)
         // Add host metadata
         md_.push_back({particle.name, particle.pdg_code});
         bool inserted = name_to_id_.insert({particle.name, id}).second;
-        CELER_ASSERT(inserted);
+        CELER_VALIDATE(inserted,
+                       << "multiple particles share the name '"
+                       << particle.name << "'");
         inserted = pdg_to_id_.insert({particle.pdg_code, id}).second;
-        CELER_ASSERT(inserted);
+        if (!inserted)
+        {
+            CELER_LOG(warning)
+                       << "multiple particles share the PDG code "
+                       << particle.pdg_code.get());
+        }
     }
 
     // Move to mirrored data, copying to device

--- a/src/celeritas/phys/ParticleParams.cc
+++ b/src/celeritas/phys/ParticleParams.cc
@@ -13,6 +13,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionBuilder.hh"
+#include "corecel/io/Logger.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "celeritas/io/ImportData.hh"
 
@@ -26,6 +27,28 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Conversion function.
+ */
+auto ParticleParams::ParticleInput::from_import(ImportParticle const& ip)
+    -> ParticleInput
+{
+    ParticleInput result;
+
+    // Convert metadata
+    result.name = ip.name;
+    result.pdg_code = PDGNumber{ip.pdg};
+
+    // Convert data
+    result.mass = units::MevMass(ip.mass);
+    result.charge = units::ElementaryCharge(ip.charge);
+    result.decay_constant
+        = (ip.is_stable ? constants::stable_decay_constant : 1 / ip.lifetime);
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct with imported data.
  */
 std::shared_ptr<ParticleParams>
@@ -33,24 +56,10 @@ ParticleParams::from_import(ImportData const& data)
 {
     CELER_EXPECT(!data.particles.empty());
 
-    Input defs(data.particles.size());
-
-    for (auto i : range(data.particles.size()))
+    Input defs;
+    for (auto const& ip : data.particles)
     {
-        auto const& particle = data.particles.at(i);
-        CELER_ASSERT(!particle.name.empty());
-
-        // Convert metadata
-        defs[i].name = particle.name;
-        defs[i].pdg_code = PDGNumber{particle.pdg};
-        CELER_ASSERT(defs[i].pdg_code);
-
-        // Convert data
-        defs[i].mass = units::MevMass(particle.mass);
-        defs[i].charge = units::ElementaryCharge(particle.charge);
-        defs[i].decay_constant = (particle.is_stable
-                                      ? constants::stable_decay_constant
-                                      : 1 / particle.lifetime);
+        defs.push_back(ParticleInput::from_import(ip));
     }
 
     // Sort by increasing mass, then by PDG code (positive before negative of
@@ -103,9 +112,8 @@ ParticleParams::ParticleParams(Input const& input)
         inserted = pdg_to_id_.insert({particle.pdg_code, id}).second;
         if (!inserted)
         {
-            CELER_LOG(warning)
-                       << "multiple particles share the PDG code "
-                       << particle.pdg_code.get());
+            CELER_LOG(warning) << "multiple particles share the PDG code "
+                               << particle.pdg_code.get();
         }
     }
 

--- a/src/celeritas/phys/ParticleParams.hh
+++ b/src/celeritas/phys/ParticleParams.hh
@@ -26,6 +26,7 @@
 namespace celeritas
 {
 struct ImportData;
+struct ImportParticle;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -52,6 +53,9 @@ class ParticleParams final : public ParamsDataInterface<ParticleParamsData>
         units::MevMass mass;  //!< Rest mass [MeV / c^2]
         units::ElementaryCharge charge;  //!< Charge in units of [e]
         real_type decay_constant{};  //!< Decay constant [1/time]
+
+        // Conversion function
+        static ParticleInput from_import(ImportParticle const&);
     };
 
     //! Input data to construct this class

--- a/src/celeritas/phys/ParticleParams.hh
+++ b/src/celeritas/phys/ParticleParams.hh
@@ -51,7 +51,7 @@ class ParticleParams final : public ParamsDataInterface<ParticleParamsData>
         PDGNumber pdg_code;  //!< See "Review of Particle Physics"
         units::MevMass mass;  //!< Rest mass [MeV / c^2]
         units::ElementaryCharge charge;  //!< Charge in units of [e]
-        real_type decay_constant;  //!< Decay constant [1/time]
+        real_type decay_constant{};  //!< Decay constant [1/time]
     };
 
     //! Input data to construct this class
@@ -143,6 +143,9 @@ ParticleId ParticleParams::find(std::string const& name) const
 //---------------------------------------------------------------------------//
 /*!
  * Find the ID from a PDG code.
+ *
+ * \todo Multiple particles can share a "generic" PDG code so this should be a
+ * multimap.
  */
 ParticleId ParticleParams::find(PDGNumber pdg_code) const
 {

--- a/src/celeritas/phys/PrimaryGenerator.cc
+++ b/src/celeritas/phys/PrimaryGenerator.cc
@@ -48,13 +48,16 @@ PrimaryGenerator::from_options(SPConstParticles particles,
 PrimaryGenerator::PrimaryGenerator(SPConstParticles particles, Input const& inp)
     : num_events_(inp.num_events)
     , primaries_per_event_(inp.primaries_per_event)
+    , seed_{inp.seed}
     , sample_energy_(inp.sample_energy)
     , sample_pos_(inp.sample_pos)
     , sample_dir_(inp.sample_dir)
 {
     CELER_EXPECT(particles);
 
-    rng_.seed(inp.seed);
+    // TODO: seed based on event
+    this->seed(UniqueEventId{0});
+
     particle_id_.reserve(inp.pdg.size());
     for (auto const& pdg : inp.pdg)
     {
@@ -86,6 +89,16 @@ auto PrimaryGenerator::operator()() -> result_type
     }
     ++event_count_;
     return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Reseed RNG for interaction with celer-g4.
+ */
+void PrimaryGenerator::seed(UniqueEventId uid)
+{
+    CELER_EXPECT(uid);
+    rng_.seed(seed_ + uid.unchecked_get());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PrimaryGenerator.hh
+++ b/src/celeritas/phys/PrimaryGenerator.hh
@@ -31,6 +31,9 @@ struct Primary;
  * distributions. If more than one PDG number is specified, an equal number of
  * each particle type will be produced. Each \c operator() call will return a
  * single event until \c num_events events have been generated.
+ *
+ * \todo Refactor generators so that event ID is an input and vector of
+ * primaries (which won't have an event ID) is output.
  */
 class PrimaryGenerator : public EventReaderInterface
 {
@@ -73,9 +76,13 @@ class PrimaryGenerator : public EventReaderInterface
     //! Get total number of events
     size_type num_events() const override { return num_events_; }
 
+    // Reseed RNG for interaction with celer-g4
+    void seed(UniqueEventId);
+
   private:
     size_type num_events_{};
     size_type primaries_per_event_{};
+    unsigned int seed_{};
     EnergySampler sample_energy_;
     PositionSampler sample_pos_;
     DirectionSampler sample_dir_;


### PR DESCRIPTION
This prerequisite for #1583  simplifies the generator action so that it simply wraps the other Celeritas class. In the future we could make some minor changes to make this a generalized wrapper for any Celeritas primary generator.