### PR TITLE
Set step length and other data in reconstructed tracks

### DIFF
--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -39,6 +39,7 @@ auto to_input(SDSetupOptions const& sd)
 
     result.ignore_zero_deposition = sd.ignore_zero_deposition;
     result.energy_deposition = sd.energy_deposition;
+    result.step_length = sd.step_length;
     result.locate_touchable = sd.locate_touchable;
     result.track = sd.track;
     result.pre = to_input(sd.pre);

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -90,6 +90,8 @@ struct SDSetupOptions
     bool ignore_zero_deposition{true};
     //! Save energy deposition
     bool energy_deposition{true};
+    //! Save physical step length
+    bool step_length{true};
     //! Set TouchableHandle for PreStepPoint
     bool locate_touchable{true};
     //! Create a track with the dynamic particle type and post-step data

--- a/src/accel/detail/HitManager.cc
+++ b/src/accel/detail/HitManager.cc
@@ -66,6 +66,7 @@ HitManager::HitManager(SPConstGeo geo,
     // Convert setup options to step data
     selection_.particle = setup.track;
     selection_.energy_deposition = setup.energy_deposition;
+    selection_.step_length = setup.step_length;
     update_selection(&selection_.points[StepPoint::pre], setup.pre);
     update_selection(&selection_.points[StepPoint::post], setup.post);
     if (locate_touchable_)

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -105,6 +105,26 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
         }
     }
 
+    // Set invalid values for unsupported SD attributes
+    step_->SetNonIonizingEnergyDeposit(
+        -std::numeric_limits<double>::infinity());
+    for (G4StepPoint* p : {step_->GetPreStepPoint(), step_->GetPostStepPoint()})
+    {
+        if (!p)
+        {
+            continue;
+        }
+        // Time since track was created
+        p->SetLocalTime(std::numeric_limits<double>::infinity());
+        // Time in rest frame since track was created
+        p->SetProperTime(std::numeric_limits<double>::infinity());
+        // Speed
+        p->SetVelocity(std::numeric_limits<double>::infinity());
+        // Safety distance
+        p->SetSafety(std::numeric_limits<double>::infinity());
+        // Polarization (default to zero)
+    }
+
     // Create track if user requested particle types
     for (G4ParticleDefinition const* pd : particles)
     {
@@ -273,11 +293,18 @@ void HitProcessor::update_track(ParticleId id) const
     G4Track& track = *tracks_[id.unchecked_get()];
     step_->SetTrack(&track);
 
-    if (G4StepPoint* pre_step = step_->GetPreStepPoint())
+    G4ParticleDefinition const& pd = *track.GetParticleDefinition();
+
+    for (G4StepPoint* p : {step_->GetPreStepPoint(), step_->GetPostStepPoint()})
     {
-        // Copy data from track to pre-step
-        G4ParticleDefinition const& pd = *track.GetParticleDefinition();
-        pre_step->SetCharge(pd.GetPDGCharge());
+        if (!p)
+        {
+            continue;
+        }
+
+        // Copy data from track to step points
+        p->SetMass(pd.GetPDGMass());
+        p->SetCharge(pd.GetPDGCharge());
     }
     if (G4StepPoint* post_step = step_->GetPostStepPoint())
     {

--- a/src/accel/detail/HitProcessor.cc
+++ b/src/accel/detail/HitProcessor.cc
@@ -207,6 +207,7 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
         G4LogicalVolume const* lv = this->detector_volume(out.detector[i]);
 
         HP_SET(step_->SetTotalEnergyDeposit, out.energy_deposition, CLHEP::MeV);
+        HP_SET(step_->SetStepLength, out.step_length, clhep_length);
 
         if (update_touchable_)
         {

--- a/src/celeritas/inp/Scoring.hh
+++ b/src/celeritas/inp/Scoring.hh
@@ -87,6 +87,8 @@ struct GeantSensitiveDetector
     bool ignore_zero_deposition{true};
     //! Save energy deposition
     bool energy_deposition{true};
+    //! Save physical step length
+    bool step_length{true};
     //! Set TouchableHandle for PreStepPoint
     bool locate_touchable{true};
     //! Create a track with the dynamic particle type and post-step data

--- a/test/accel/SimpleSensitiveDetector.cc
+++ b/test/accel/SimpleSensitiveDetector.cc
@@ -33,6 +33,12 @@ void SimpleHitsResult::print_expected() const
             "EXPECT_VEC_SOFT_EQ(expected_energy_deposition, "
             "result.energy_deposition);\n"
 
+            "static double const expected_step_length[] = "
+         << repr(this->step_length)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_step_length, "
+            "result.step_length);\n"
+
             "static char const* const expected_particle[] = "
          << repr(this->particle)
          << ";\n"
@@ -76,6 +82,7 @@ bool SimpleSensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
 
     hits_.energy_deposition.push_back(step->GetTotalEnergyDeposit()
                                       / CLHEP::MeV);
+    hits_.step_length.push_back(step->GetStepLength() / CLHEP::cm);
     if (auto* track = step->GetTrack())
     {
         hits_.particle.push_back(track->GetDefinition()->GetParticleName());

--- a/test/accel/SimpleSensitiveDetector.hh
+++ b/test/accel/SimpleSensitiveDetector.hh
@@ -18,6 +18,7 @@ namespace test
 struct SimpleHitsResult
 {
     std::vector<double> energy_deposition;  // [MeV]
+    std::vector<double> step_length;  // [cm]
     std::vector<std::string> particle;
     std::vector<double> pre_energy;  // [MeV]
     std::vector<double> pre_pos;  // [cm]

--- a/test/accel/detail/HitProcessor.test.cc
+++ b/test/accel/detail/HitProcessor.test.cc
@@ -60,6 +60,7 @@ void SimpleCmsTest::SetUp()
 {
     // Create default step selection (see HitManager)
     selection_.energy_deposition = true;
+    selection_.step_length = true;
     selection_.points[StepPoint::pre].energy = true;
     selection_.points[StepPoint::pre].pos = true;
     selection_.points[StepPoint::post].time = true;
@@ -158,6 +159,14 @@ DetectorStepOutput SimpleCmsTest::make_dso() const
             MevEnergy{0.3},
         };
     }
+    if (selection_.step_length)
+    {
+        dso.step_length = {
+            from_cm(0.1),
+            from_cm(2.0),
+            from_cm(3.0),
+        };
+    }
     if (selection_.points[StepPoint::post].time)
     {
         using celeritas::units::second;
@@ -215,10 +224,17 @@ TEST_F(SimpleCmsTest, no_touchable)
     HitProcessor process_hits = this->make_hit_processor();
     auto dso_hits = this->make_dso();
     process_hits(dso_hits);
+
+    // Second hit
     dso_hits.energy_deposition = {
         MevEnergy{0.4},
         MevEnergy{0.5},
         MevEnergy{0.6},
+    };
+    dso_hits.step_length = {
+        from_cm(1.0),
+        from_cm(2.1),
+        from_cm(3.1),
     };
     process_hits(dso_hits);
 
@@ -227,6 +243,8 @@ TEST_F(SimpleCmsTest, no_touchable)
         static real_type const expected_energy_deposition[] = {0.1, 0.4};
         EXPECT_VEC_SOFT_EQ(expected_energy_deposition,
                            result.energy_deposition);
+        static real_type const expected_step_length[] = {0.1, 1.0};
+        EXPECT_VEC_SOFT_EQ(expected_step_length, result.step_length);
         static real_type const expected_pre_energy[] = {0, 0};
         EXPECT_VEC_SOFT_EQ(expected_pre_energy, result.pre_energy);
         static real_type const expected_pre_pos[] = {100, 0, 0, 100, 0, 0};


### PR DESCRIPTION
It looks like the failures in https://github.com/celeritas-project/celeritas/issues/1144#issuecomment-2614035073 were due to https://gitlab.cern.ch/atlas/athena/-/blob/main/LArCalorimeter/LArG4/LArG4Barrel/src/LArBarrelCalculator.cxx#L192 , where the hit is discarded if the step length is zero: and prior to now we didn't set the step length.

I looked at what else is set in the track/step/steppoint and set a couple of other attributes. Some attributes that we *don't* set I've set to nonsensical values that will hopefully cause something to blow up rather than silently discarding the hit.