### PR TITLE
Add hit manager output diagnostic

### DIFF
--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -24,6 +24,7 @@ list(APPEND SOURCES
   SimpleOffload.cc
   detail/GeantSimpleCaloSD.cc
   detail/HitManager.cc
+  detail/HitManagerOutput.cc
   detail/HitProcessor.cc
   detail/LevelTouchableUpdater.cc
   detail/NaviTouchableUpdater.cc

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -64,6 +64,7 @@
 #include "SetupOptions.hh"
 
 #include "detail/HitManager.hh"
+#include "detail/HitManagerOutput.hh"
 #include "detail/OffloadWriter.hh"
 
 namespace celeritas
@@ -649,6 +650,8 @@ void SharedParams::initialize_core(SetupOptions const& options)
                                                    params_->max_streams());
         step_collector_
             = StepCollector::make_and_insert(*params_, {hit_manager_});
+        output_reg_->insert(
+            std::make_shared<detail::HitManagerOutput>(hit_manager_));
     }
 
     // Add diagnostics

--- a/src/accel/detail/HitManager.hh
+++ b/src/accel/detail/HitManager.hh
@@ -95,6 +95,9 @@ class HitManager final : public StepInterface
     //! Access mapped particles if recreating G4Tracks later
     VecParticle const& geant_particles() const { return particles_; }
 
+    //! Whether detailed volume information is reconstructed
+    bool locate_touchable() const { return locate_touchable_; }
+
   private:
     using VecLV = std::vector<G4LogicalVolume const*>;
 

--- a/src/accel/detail/HitManagerOutput.cc
+++ b/src/accel/detail/HitManagerOutput.cc
@@ -1,0 +1,96 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/detail/HitManagerOutput.cc
+//---------------------------------------------------------------------------//
+#include "HitManagerOutput.hh"
+
+#include <G4LogicalVolume.hh>
+#include <G4VSensitiveDetector.hh>
+#include <nlohmann/json.hpp>
+
+#include "corecel/cont/Range.hh"
+#include "corecel/io/JsonPimpl.hh"
+#include "corecel/sys/TypeDemangler.hh"
+
+#include "HitManager.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from hit manager.
+ */
+HitManagerOutput::HitManagerOutput(SPConstHitManager hits)
+    : hits_(std::move(hits))
+{
+    CELER_EXPECT(hits_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void HitManagerOutput::output(JsonPimpl* j) const
+{
+    using json = nlohmann::json;
+
+    auto result = json::object();
+
+    // Save detectors
+    {
+        auto const& celer_vols = hits_->celer_vols();
+        auto const& geant_vols = *hits_->geant_vols();
+        TypeDemangler<G4VSensitiveDetector> demangle_sd;
+
+        auto vol_ids = json::array();
+        auto gv_names = json::array();
+        auto sd_names = json::array();
+        auto sd_types = json::array();
+
+        for (auto i : range(celer_vols.size()))
+        {
+            vol_ids.push_back(celer_vols[i].get());
+
+            auto const* lv = geant_vols[i];
+            G4VSensitiveDetector const* sd{nullptr};
+            if (lv)
+            {
+                gv_names.push_back(lv->GetName());
+                sd = lv->GetSensitiveDetector();
+            }
+            else
+            {
+                gv_names.push_back(nullptr);
+            }
+
+            if (sd)
+            {
+                sd_names.push_back(sd->GetName());
+                sd_types.push_back(demangle_sd(*sd));
+            }
+            else
+            {
+                sd_names.push_back(nullptr);
+                sd_types.push_back(nullptr);
+            }
+        }
+
+        result["vol_id"] = std::move(vol_ids);
+        result["lv_name"] = std::move(gv_names);
+        result["sd_name"] = std::move(sd_names);
+        result["sd_type"] = std::move(sd_types);
+    }
+
+    // TODO: save filter selection
+    result["locate_touchable"] = hits_->locate_touchable();
+
+    j->obj = std::move(result);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/accel/detail/HitManagerOutput.hh
+++ b/src/accel/detail/HitManagerOutput.hh
@@ -1,0 +1,50 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/detail/HitManagerOutput.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+
+#include "corecel/io/OutputInterface.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+class HitManager;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Save debugging information about sensitive detector mappings.
+ */
+class HitManagerOutput final : public OutputInterface
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using SPConstHitManager = std::shared_ptr<HitManager const>;
+    //!@}
+
+  public:
+    // Construct from shared hit manager
+    explicit HitManagerOutput(SPConstHitManager hits);
+
+    //! Category of data to write
+    Category category() const final { return Category::internal; }
+
+    //! Name of the entry inside the category.
+    std::string_view label() const final { return "hit-manager"; }
+
+    // Write output to the given JSON object
+    void output(JsonPimpl*) const final;
+
+  private:
+    SPConstHitManager hits_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/accel/detail/SensDetInserter.cc
+++ b/src/accel/detail/SensDetInserter.cc
@@ -61,7 +61,7 @@ VolumeId SensDetInserter::insert_impl(G4LogicalVolume const* lv)
     {
         CELER_LOG(debug)
             << "Skipping automatic SD callback for logical volume \""
-            << lv->GetName() << "\" due to user option";
+            << PrintableLV{lv} << "\" due to user option";
         return {};
     }
 
@@ -78,7 +78,7 @@ VolumeId SensDetInserter::insert_impl(G4LogicalVolume const* lv)
     // Add Geant4 volume and corresponding volume ID to list
     auto [iter, inserted] = found_->insert({id, lv});
 
-    if (CELER_UNLIKELY(!inserted))  // && iter->second != lv))
+    if (CELER_UNLIKELY(!inserted))
     {
         if (iter->second != lv)
         {

--- a/test/accel/detail/HitManager.test.cc
+++ b/test/accel/detail/HitManager.test.cc
@@ -21,6 +21,7 @@
 #include "celeritas/geo/GeoParams.hh"
 #include "accel/SDTestBase.hh"
 #include "accel/SetupOptions.hh"
+#include "accel/detail/HitManagerOutput.hh"
 
 #include "celeritas_test.hh"
 
@@ -101,6 +102,13 @@ class SimpleCmsTest : public ::celeritas::test::SDTestBase,
         return result;
     }
 
+    std::string get_diagnostics(HitManager const& hm)
+    {
+        HitManagerOutput out(
+            std::shared_ptr<HitManager const>(&hm, [](HitManager const*) {}));
+        return to_string(out);
+    }
+
   protected:
     SDSetupOptions sd_setup_;
     ::celeritas::test::ScopedLogStorer scoped_log_{&celeritas::world_logger()};
@@ -124,6 +132,10 @@ TEST_F(SimpleCmsTest, no_change)
     {
         EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
     }
+
+    EXPECT_JSON_EQ(
+        R"json({"_category":"internal","_label":"hit-manager","locate_touchable":true,"lv_name":["em_calorimeter","had_calorimeter"],"sd_name":["em_calorimeter","had_calorimeter"],"sd_type":["celeritas::test::SimpleSensitiveDetector","celeritas::test::SimpleSensitiveDetector"],"vol_id":[3,4]})json",
+        this->get_diagnostics(man));
 }
 
 TEST_F(SimpleCmsTest, delete_one)
@@ -149,6 +161,13 @@ TEST_F(SimpleCmsTest, delete_one)
     if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
     {
         EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
+    }
+
+    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
+    {
+        EXPECT_JSON_EQ(
+            R"json({"_category":"internal","_label":"hit-manager","locate_touchable":true,"lv_name":["em_calorimeter"],"sd_name":["em_calorimeter"],"sd_type":["celeritas::test::SimpleSensitiveDetector"],"vol_id":[3]})json",
+            this->get_diagnostics(man));
     }
 }
 
@@ -180,6 +199,13 @@ TEST_F(SimpleCmsTest, add_duplicate)
             = {"debug", "debug", "debug"};
         EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
     }
+
+    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
+    {
+        EXPECT_JSON_EQ(
+            R"json({"_category":"internal","_label":"hit-manager","locate_touchable":true,"lv_name":["em_calorimeter","had_calorimeter"],"sd_name":["em_calorimeter","had_calorimeter"],"sd_type":["celeritas::test::SimpleSensitiveDetector","celeritas::test::SimpleSensitiveDetector"],"vol_id":[3,4]})json",
+            this->get_diagnostics(man));
+    }
 }
 
 TEST_F(SimpleCmsTest, add_one)
@@ -198,6 +224,12 @@ TEST_F(SimpleCmsTest, add_one)
     if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
     {
         EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
+    }
+    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
+    {
+        EXPECT_JSON_EQ(
+            R"json({"_category":"internal","_label":"hit-manager","locate_touchable":true,"lv_name":["si_tracker","em_calorimeter","had_calorimeter"],"sd_name":[null,"em_calorimeter","had_calorimeter"],"sd_type":[null,"celeritas::test::SimpleSensitiveDetector","celeritas::test::SimpleSensitiveDetector"],"vol_id":[2,3,4]})json",
+            this->get_diagnostics(man));
     }
 }
 

--- a/test/accel/detail/HitManager.test.cc
+++ b/test/accel/detail/HitManager.test.cc
@@ -133,9 +133,12 @@ TEST_F(SimpleCmsTest, no_change)
         EXPECT_TRUE(scoped_log_.empty()) << scoped_log_;
     }
 
-    EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"hit-manager","locate_touchable":true,"lv_name":["em_calorimeter","had_calorimeter"],"sd_name":["em_calorimeter","had_calorimeter"],"sd_type":["celeritas::test::SimpleSensitiveDetector","celeritas::test::SimpleSensitiveDetector"],"vol_id":[3,4]})json",
-        this->get_diagnostics(man));
+    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
+    {
+        EXPECT_JSON_EQ(
+            R"json({"_category":"internal","_label":"hit-manager","locate_touchable":true,"lv_name":["em_calorimeter","had_calorimeter"],"sd_name":["em_calorimeter","had_calorimeter"],"sd_type":["celeritas::test::SimpleSensitiveDetector","celeritas::test::SimpleSensitiveDetector"],"vol_id":[3,4]})json",
+            this->get_diagnostics(man));
+    }
 }
 
 TEST_F(SimpleCmsTest, delete_one)


### PR DESCRIPTION
It was super useful to have the SD information from Athena, since that helped point to the location of the relevant code in a *very* large code base. Instead of having to turn on debug logging and grep through the results, this now lets us programmatically pull the details of the mapped SDs: Celeritas volume ID (from which we can get a volume via the geo diagnostic), SD name given by the Geant4 app, SD C++ type, and the Geant4 volume it's connected to.
```json
{
  "_category": "internal",
  "_label": "hit-manager",
  "locate_touchable": true,
  "lv_name": [
    "em_calorimeter",
    "had_calorimeter"
  ],
  "sd_name": [
    "em_calorimeter",
    "had_calorimeter"
  ],
  "sd_type": [
    "celeritas::test::SimpleSensitiveDetector",
    "celeritas::test::SimpleSensitiveDetector"
  ],
  "vol_id": [
    3,
    4
  ]
}
```