### PR TITLE
Update core advisors

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -37,6 +37,8 @@ jobs:
         # Turn warnings into errors only for PRs
         # Disable expensive graphs for PRs also
         run: |
+          # NOTE: tags have issues, see https://github.com/actions/checkout/issues/2041
+          git fetch --tags
           ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
           mkdir build && cd build
           cmake --preset=${CMAKE_PRESET} --log-level=VERBOSE \
@@ -83,6 +85,8 @@ jobs:
             pip install -r scripts/doc-requirements.txt
       - name: Configure celeritas
         run: |
+          # NOTE: tags have issues, see https://github.com/actions/checkout/issues/2041
+          git fetch --tags
           ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
           mkdir build && cd build
           cmake --preset=${CMAKE_PRESET} --log-level=VERBOSE \

--- a/doc/_static/ornltm-header-celeritas.tex
+++ b/doc/_static/ornltm-header-celeritas.tex
@@ -28,13 +28,7 @@
   Philippe Canal\affilnum{2}
   %%
   \and
-  Marcel Demarteau\affilnum{1}
-  %%
-  \and
   Thomas Evans\affilnum{1}
-  %%
-  \and
-  Paul Romano\affilnum{3}
 }%
 
 \affiliation{%

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,8 +26,6 @@ all_authors = [
  'Stefano C Tognini',
  # Core advisors
  'Thomas M Evans',
- 'Marcel Demarteau',
- 'Paul Romano',
 ]
 author = " and ".join(all_authors)
 copyright = '{:%Y}, UT–Battelle/ORNL and Celeritas team'.format(

--- a/doc/development/administration.rst
+++ b/doc/development/administration.rst
@@ -76,7 +76,12 @@ Contributor
 Role change process
 -------------------
 
-Adding or removing a member of the "core team" must be done by consensus of the
+Roles should be periodically reevaluated to reflect current participation in
+the project. It is recommended to re-evaluate core roles at the start of each
+calendar year based on the last year's participation and upcoming work plans.
+
+Adding or removing a member of the "core team" can be done at any time by
+consensus of the
 leadership team (or if the core team member wants to remove themself). Adding
 maintainers can be done at the whim of the code lead. The `team list`_ on
 GitHub is the official record of roles.


### PR DESCRIPTION
Reflecting the changing leadership roles over the last couple of years, with the end of the first SciDAC and the reduced involvement of the former PIs,  @paulromano and @mdemarteau are stepping down from their "official" title of [core advisors](https://celeritas-project.github.io/celeritas/user/development/administration.html#roles)  in https://github.com/orgs/celeritas-project/teams/core-advisor .