### PR TITLE
Move physics lists out of details and rename tracking offload

### DIFF
--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -49,10 +49,10 @@
 #include "geocel/GeantUtils.hh"
 #include "geocel/ScopedGeantExceptionHandler.hh"
 #include "geocel/ScopedGeantLogger.hh"
+#include "celeritas/ext/EmPhysicsList.hh"
+#include "celeritas/ext/FtfpBertPhysicsList.hh"
 #include "celeritas/ext/GeantPhysicsOptions.hh"
 #include "celeritas/ext/ScopedRootErrorHandler.hh"
-#include "celeritas/ext/detail/CelerEmPhysicsList.hh"
-#include "celeritas/ext/detail/CelerFTFPBert.hh"
 #include "accel/SharedParams.hh"
 
 #include "ActionInitialization.hh"
@@ -189,13 +189,13 @@ void run(int argc, char** argv, std::shared_ptr<SharedParams> params)
         if (setup.input().physics_list == PhysicsListSelection::celer_ftfp_bert)
         {
             // FTFP BERT with Celeritas EM standard physics
-            auto pl = std::make_unique<detail::CelerFTFPBert>(opts);
+            auto pl = std::make_unique<celeritas::FtfpBertPhysicsList>(opts);
             run_manager->SetUserInitialization(pl.release());
         }
         else
         {
             // Celeritas EM standard physics only
-            auto pl = std::make_unique<detail::CelerEmPhysicsList>(opts);
+            auto pl = std::make_unique<celeritas::EmPhysicsList>(opts);
             run_manager->SetUserInitialization(pl.release());
         }
     }

--- a/example/accel/trackingmanager-offload.cc
+++ b/example/accel/trackingmanager-offload.cc
@@ -47,7 +47,7 @@
 #include <accel/SetupOptions.hh>
 #include <accel/SharedParams.hh>
 #include <accel/SimpleOffload.hh>
-#include <accel/TrackingManagerOffload.hh>
+#include <accel/TrackingManager.hh>
 #include <corecel/Assert.hh>
 #include <corecel/Macros.hh>
 #include <corecel/io/Logger.hh>
@@ -142,7 +142,7 @@ class EMPhysicsConstructor final : public G4EmStandardPhysics
         G4EmStandardPhysics::ConstructProcess();
 
         // Add Celeritas tracking manager to electron, positron, gamma.
-        auto* celer_tracking = new celeritas::TrackingManagerOffload(
+        auto* celer_tracking = new celeritas::TrackingManager(
             &shared_params, &local_transporter);
         G4Electron::Definition()->SetTrackingManager(celer_tracking);
         G4Positron::Definition()->SetTrackingManager(celer_tracking);
@@ -156,7 +156,7 @@ class PrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
   public:
     PrimaryGeneratorAction()
     {
-        auto g4particle_def
+        auto* g4particle_def
             = G4ParticleTable::GetParticleTable()->FindParticle(2112);
         gun_.SetParticleDefinition(g4particle_def);
         gun_.SetParticleEnergy(100 * GeV);
@@ -255,7 +255,7 @@ int main()
 
     // Use FTFP_BERT, but replace EM constructor with our own that
     // overrides ConstructProcess to use Celeritas tracking for e-/e+/g
-    auto physics_list = new FTFP_BERT{/* verbosity = */ 0};
+    auto* physics_list = new FTFP_BERT{/* verbosity = */ 0};
     physics_list->ReplacePhysics(new EMPhysicsConstructor);
     run_manager->SetUserInitialization(physics_list);
 

--- a/example/offload-template/src/ActionInitialization.cc
+++ b/example/offload-template/src/ActionInitialization.cc
@@ -6,7 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "ActionInitialization.hh"
 
-#include <accel/TrackingManagerOffload.hh>
+#include <accel/TrackingManager.hh>
 
 #include "Celeritas.hh"
 #include "EventAction.hh"
@@ -48,11 +48,11 @@ void ActionInitialization::Build() const
         &CelerSetupOptions(), &CelerSharedParams(), &CelerLocalTransporter());
 
     // Add Celeritas tracking manager to electrons, positrons, and gammas.
-    // celeritas::TrackingManagerOffload automatically assigns available
+    // celeritas::TrackingManager automatically assigns available
     // physics processes to the selected particles and offloads them to
     // Celeritas by updating their G4TrackStatus to fStopAndKill in Geant4 and
     // creating a new track in Celeritas.
-    auto* celer_tracking = new celeritas::TrackingManagerOffload(
+    auto* celer_tracking = new celeritas::TrackingManager(
         &CelerSharedParams(), &CelerLocalTransporter());
     G4Electron::Definition()->SetTrackingManager(celer_tracking);
     G4Positron::Definition()->SetTrackingManager(celer_tracking);

--- a/example/offload-template/src/Celeritas.cc
+++ b/example/offload-template/src/Celeritas.cc
@@ -18,6 +18,7 @@ using namespace celeritas;
 //---------------------------------------------------------------------------//
 /*!
  * Globally shared setup options.
+ *
  * Setup options are constructed the first time this method is invoked.
  */
 SetupOptions& CelerSetupOptions()

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -34,8 +34,10 @@ list(APPEND SOURCES
 
 celeritas_polysource(ExceptionConverter)
 
-if(Geant4_VERSION VERSION_GREATER_EQUAL 11.1)
-  list(APPEND SOURCES TrackingManager.cc)
+if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
+  list(APPEND SOURCES
+    TrackingManager.cc
+  )
 endif()
 
 if(CELERITAS_USE_HepMC3)

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -34,8 +34,8 @@ list(APPEND SOURCES
 
 celeritas_polysource(ExceptionConverter)
 
-if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
-  list(APPEND SOURCES TrackingManagerOffload.cc)
+if(Geant4_VERSION VERSION_GREATER_EQUAL 11.1)
+  list(APPEND SOURCES TrackingManager.cc)
 endif()
 
 if(CELERITAS_USE_HepMC3)

--- a/src/accel/TrackingManager.hh
+++ b/src/accel/TrackingManager.hh
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <G4Version.hh>
-#if G4VERSION_NUMBER < 1110
-#    error "Tracking manager offload requires Geant4 11.1 or higher"
+#if G4VERSION_NUMBER < 1100
+#    error "Tracking manager offload requires Geant4 11.0 or higher"
 #endif
 
 #include <G4VTrackingManager.hh>

--- a/src/accel/TrackingManager.hh
+++ b/src/accel/TrackingManager.hh
@@ -1,0 +1,65 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/TrackingManager.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <G4Version.hh>
+#if G4VERSION_NUMBER < 1110
+#    error "Tracking manager offload requires Geant4 11.1 or higher"
+#endif
+
+#include <G4VTrackingManager.hh>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+
+class SharedParams;
+class LocalTransporter;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Offload to Celeritas via the per-particle Geant4 "tracking manager".
+ *
+ * Tracking managers are to be created during worker action initialization and
+ * are thus thread-local.  Construction/addition to \c G4ParticleDefinition
+ * appears to take place on the master thread, typically
+ * in the ConstructProcess method, but the tracking manager pointer is part of
+ * the split-class data for the particle. It's observed that different threads
+ * have distinct pointers to a LocalTransporter instance, and that these match
+ * those of the global thread-local instances in test problems.
+ *
+ * \note As of Geant4 11.3, instances of this class (one per thread) will never
+ * be deleted.
+ */
+class TrackingManager final : public G4VTrackingManager
+{
+  public:
+    // Construct with shared (across threads) params, and thread-local
+    // transporter.
+    TrackingManager(SharedParams const* params, LocalTransporter* local);
+
+    // Prepare cross-section tables for rebuild (e.g. if new materials have
+    // been defined).
+    void PreparePhysicsTable(G4ParticleDefinition const&) final;
+
+    // Rebuild physics cross-section tables (e.g. if new materials have been
+    // defined).
+    void BuildPhysicsTable(G4ParticleDefinition const&) final;
+
+    // Hand over passed track to this tracking manager.
+    void HandOverOneTrack(G4Track* aTrack) final;
+
+    // Complete processing of any buffered tracks.
+    void FlushEvent() final;
+
+  private:
+    SharedParams const* params_{nullptr};
+    LocalTransporter* transport_{nullptr};
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/accel/TrackingManagerOffload.hh
+++ b/src/accel/TrackingManagerOffload.hh
@@ -6,41 +6,12 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <G4VTrackingManager.hh>
+#include "TrackingManagerOffload.hh"
 
 namespace celeritas
 {
-class SharedParams;
-class LocalTransporter;
 
-//---------------------------------------------------------------------------//
-/*!
- * Offload tracks to Celeritas via the per-particle G4VTrackingManager
- * interface
- */
-class TrackingManagerOffload final : public G4VTrackingManager
-{
-  public:
-    // Construct with shared (across threads) params, and thread-local
-    // transporter.
-    TrackingManagerOffload(SharedParams const* params, LocalTransporter* local);
+// TODO: Remove in v0.7
+using TrackingManagerOffload [[deprecated]] = TrackingManager;
 
-    // Prepare cross-section tables for rebuild (e.g. if new materials have
-    // been defined).
-    void PreparePhysicsTable(G4ParticleDefinition const&) final;
-
-    // Rebuild physics cross-section tables (e.g. if new materials have been
-    // defined).
-    void BuildPhysicsTable(G4ParticleDefinition const&) final;
-
-    // Hand over passed track to this tracking manager.
-    void HandOverOneTrack(G4Track* aTrack) final;
-
-    // Complete processing of any buffered tracks.
-    void FlushEvent() final;
-
-  private:
-    SharedParams const* params_{nullptr};
-    LocalTransporter* transport_{nullptr};
-};
 }  // namespace celeritas

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -139,13 +139,12 @@ endif()
 
 if(CELERITAS_USE_Geant4)
   set(_cg4_sources
+    ext/EmPhysicsList.cc
+    ext/FtfpBertPhysicsList.cc
     ext/GeantImporter.cc
     ext/GeantSetup.cc
     ext/GeantVolumeMapper.cc
-    ext/detail/CelerEmPhysicsList.cc
-    ext/detail/CelerEmStandardPhysics.cc
-    ext/detail/CelerFTFPBert.cc
-    ext/detail/CelerOpticalPhysics.cc
+    ext/detail/EmStandardPhysics.cc
     ext/detail/GeantBremsstrahlungProcess.cc
     ext/detail/GeantMicroXsCalculator.cc
     ext/detail/GeantModelImporter.cc
@@ -153,6 +152,7 @@ if(CELERITAS_USE_Geant4)
     ext/detail/GeantProcessImporter.cc
     ext/detail/GeoOpticalIdMap.cc
     ext/detail/MuHadEmStandardPhysics.cc
+    ext/detail/OpticalPhysics.cc
   )
   celeritas_get_g4libs(_cg4_libs
     global geometry materials processes run physicslists tasking

--- a/src/celeritas/ext/EmPhysicsList.cc
+++ b/src/celeritas/ext/EmPhysicsList.cc
@@ -12,6 +12,7 @@
 
 #include "detail/EmStandardPhysics.hh"
 #include "detail/OpticalPhysics.hh"
+#include "detail/PhysicsListUtils.hh"
 
 namespace celeritas
 {
@@ -28,15 +29,12 @@ EmPhysicsList::EmPhysicsList(Options const& options)
         native_value_to<ClhepLen>(options.default_cutoff).value());
 
     // Celeritas-supported EM Physics
-    auto em_standard = std::make_unique<detail::EmStandardPhysics>(options);
-    RegisterPhysics(em_standard.release());
+    detail::emplace_physics<detail::EmStandardPhysics>(*this, options);
 
     if (options.optical)
     {
         // Celeritas-supported Optical Physics
-        auto optical_physics
-            = std::make_unique<detail::OpticalPhysics>(options.optical);
-        RegisterPhysics(optical_physics.release());
+        detail::emplace_physics<detail::OpticalPhysics>(*this, options.optical);
     }
 }
 

--- a/src/celeritas/ext/EmPhysicsList.cc
+++ b/src/celeritas/ext/EmPhysicsList.cc
@@ -2,26 +2,24 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/CelerEmPhysicsList.cc
+//! \file celeritas/ext/EmPhysicsList.cc
 //---------------------------------------------------------------------------//
-#include "CelerEmPhysicsList.hh"
+#include "EmPhysicsList.hh"
 
 #include <memory>
 
 #include "celeritas/Quantities.hh"
 
-#include "CelerEmStandardPhysics.hh"
-#include "CelerOpticalPhysics.hh"
+#include "detail/EmStandardPhysics.hh"
+#include "detail/OpticalPhysics.hh"
 
 namespace celeritas
-{
-namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
  * Construct with physics options.
  */
-CelerEmPhysicsList::CelerEmPhysicsList(Options const& options)
+EmPhysicsList::EmPhysicsList(Options const& options)
 {
     using ClhepLen = Quantity<units::ClhepTraits::Length, double>;
 
@@ -30,18 +28,17 @@ CelerEmPhysicsList::CelerEmPhysicsList(Options const& options)
         native_value_to<ClhepLen>(options.default_cutoff).value());
 
     // Celeritas-supported EM Physics
-    auto em_standard = std::make_unique<CelerEmStandardPhysics>(options);
+    auto em_standard = std::make_unique<detail::EmStandardPhysics>(options);
     RegisterPhysics(em_standard.release());
 
     if (options.optical)
     {
         // Celeritas-supported Optical Physics
         auto optical_physics
-            = std::make_unique<CelerOpticalPhysics>(options.optical);
+            = std::make_unique<detail::OpticalPhysics>(options.optical);
         RegisterPhysics(optical_physics.release());
     }
 }
 
 //---------------------------------------------------------------------------//
-}  // namespace detail
 }  // namespace celeritas

--- a/src/celeritas/ext/EmPhysicsList.hh
+++ b/src/celeritas/ext/EmPhysicsList.hh
@@ -2,41 +2,32 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/CelerOpticalPhysics.hh
+//! \file celeritas/ext/EmPhysicsList.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <G4VPhysicsConstructor.hh>
+#include <G4VModularPhysicsList.hh>
 
-#include "../GeantOpticalPhysicsOptions.hh"
+#include "GeantPhysicsOptions.hh"
 
 namespace celeritas
 {
-namespace detail
-{
 //---------------------------------------------------------------------------//
 /*!
- * Construct Celeritas-supported Optical physics.
+ * Construct highly configurable EM-only physics.
  */
-class CelerOpticalPhysics : public G4VPhysicsConstructor
+class EmPhysicsList : public G4VModularPhysicsList
 {
   public:
     //!@{
     //! \name Type aliases
-    using Options = GeantOpticalPhysicsOptions;
+    using Options = GeantPhysicsOptions;
     //!@}
 
   public:
     // Set up during construction
-    explicit CelerOpticalPhysics(Options const& options);
-
-    // Set up minimal EM particle list
-    void ConstructParticle() override;
-    // Set up process list
-    void ConstructProcess() override;
-
-  private:
-    Options options_;
+    explicit EmPhysicsList(Options const& options);
 };
-}  // namespace detail
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/ext/FtfpBertPhysicsList.cc
+++ b/src/celeritas/ext/FtfpBertPhysicsList.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/CelerFTFPBert.cc
+//! \file celeritas/ext/FtfpBertPhysicsList.cc
 //---------------------------------------------------------------------------//
-#include "CelerFTFPBert.hh"
+#include "FtfpBertPhysicsList.hh"
 
 #include <memory>
 #include <G4DecayPhysics.hh>
@@ -19,19 +19,17 @@
 
 #include "celeritas/Quantities.hh"
 
-#include "CelerEmStandardPhysics.hh"
-#include "CelerOpticalPhysics.hh"
-#include "MuHadEmStandardPhysics.hh"
+#include "detail/EmStandardPhysics.hh"
+#include "detail/MuHadEmStandardPhysics.hh"
+#include "detail/OpticalPhysics.hh"
 
 namespace celeritas
 {
-namespace detail
-{
 //---------------------------------------------------------------------------//
 /*!
- * Construct the FTFP BERT physics list with modified EM standard physics.
+ * Construct the FTFP_BERT physics list with modified EM standard physics.
  */
-CelerFTFPBert::CelerFTFPBert(Options const& options)
+FtfpBertPhysicsList::FtfpBertPhysicsList(Options const& options)
 {
     using ClhepLen = Quantity<units::ClhepTraits::Length, double>;
 
@@ -41,19 +39,19 @@ CelerFTFPBert::CelerFTFPBert(Options const& options)
         native_value_to<ClhepLen>(options.default_cutoff).value());
 
     // Celeritas-supported EM physics
-    auto celer_em = std::make_unique<CelerEmStandardPhysics>(options);
+    auto celer_em = std::make_unique<detail::EmStandardPhysics>(options);
     RegisterPhysics(celer_em.release());
 
     // Celeritas-supported Optical Physics
     if (options.optical)
     {
         auto optical_physics
-            = std::make_unique<CelerOpticalPhysics>(options.optical);
+            = std::make_unique<detail::OpticalPhysics>(options.optical);
         RegisterPhysics(optical_physics.release());
     }
 
     // Muon and hadrom EM standard physics not supported in Celeritas
-    auto muhad_em = std::make_unique<MuHadEmStandardPhysics>(verbosity);
+    auto muhad_em = std::make_unique<detail::MuHadEmStandardPhysics>(verbosity);
     RegisterPhysics(muhad_em.release());
 
     // Synchroton radiation & GN physics
@@ -86,5 +84,4 @@ CelerFTFPBert::CelerFTFPBert(Options const& options)
 }
 
 //---------------------------------------------------------------------------//
-}  // namespace detail
 }  // namespace celeritas

--- a/src/celeritas/ext/FtfpBertPhysicsList.cc
+++ b/src/celeritas/ext/FtfpBertPhysicsList.cc
@@ -22,6 +22,7 @@
 #include "detail/EmStandardPhysics.hh"
 #include "detail/MuHadEmStandardPhysics.hh"
 #include "detail/OpticalPhysics.hh"
+#include "detail/PhysicsListUtils.hh"
 
 namespace celeritas
 {
@@ -39,48 +40,37 @@ FtfpBertPhysicsList::FtfpBertPhysicsList(Options const& options)
         native_value_to<ClhepLen>(options.default_cutoff).value());
 
     // Celeritas-supported EM physics
-    auto celer_em = std::make_unique<detail::EmStandardPhysics>(options);
-    RegisterPhysics(celer_em.release());
+    detail::emplace_physics<detail::EmStandardPhysics>(*this, options);
 
     // Celeritas-supported Optical Physics
     if (options.optical)
     {
-        auto optical_physics
-            = std::make_unique<detail::OpticalPhysics>(options.optical);
-        RegisterPhysics(optical_physics.release());
+        detail::emplace_physics<detail::OpticalPhysics>(*this, options.optical);
     }
 
     // Muon and hadrom EM standard physics not supported in Celeritas
-    auto muhad_em = std::make_unique<detail::MuHadEmStandardPhysics>(verbosity);
-    RegisterPhysics(muhad_em.release());
+    detail::emplace_physics<detail::MuHadEmStandardPhysics>(*this, verbosity);
 
     // Synchroton radiation & GN physics
-    auto em_extra = std::make_unique<G4EmExtraPhysics>(verbosity);
-    RegisterPhysics(em_extra.release());
+    detail::emplace_physics<G4EmExtraPhysics>(*this, verbosity);
 
     // Decays
-    auto decay = std::make_unique<G4DecayPhysics>(verbosity);
-    RegisterPhysics(decay.release());
+    detail::emplace_physics<G4DecayPhysics>(*this, verbosity);
 
     // Hadron elastic scattering
-    auto hadron_elastic = std::make_unique<G4HadronElasticPhysics>(verbosity);
-    RegisterPhysics(hadron_elastic.release());
+    detail::emplace_physics<G4HadronElasticPhysics>(*this, verbosity);
 
     // Hadron physics
-    auto hadron = std::make_unique<G4HadronPhysicsFTFP_BERT>(verbosity);
-    RegisterPhysics(hadron.release());
+    detail::emplace_physics<G4HadronPhysicsFTFP_BERT>(*this, verbosity);
 
     // Stopping physics
-    auto stopping = std::make_unique<G4StoppingPhysics>(verbosity);
-    RegisterPhysics(stopping.release());
+    detail::emplace_physics<G4StoppingPhysics>(*this, verbosity);
 
     // Ion physics
-    auto ion = std::make_unique<G4IonPhysics>(verbosity);
-    RegisterPhysics(ion.release());
+    detail::emplace_physics<G4IonPhysics>(*this, verbosity);
 
     // Neutron tracking cut
-    auto neutron_cut = std::make_unique<G4NeutronTrackingCut>(verbosity);
-    RegisterPhysics(neutron_cut.release());
+    detail::emplace_physics<G4NeutronTrackingCut>(*this, verbosity);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/FtfpBertPhysicsList.hh
+++ b/src/celeritas/ext/FtfpBertPhysicsList.hh
@@ -2,24 +2,21 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/CelerEmPhysicsList.hh
-//! \todo Move out of detail since this is used by celer-g4
+//! \file celeritas/ext/FtfpBertPhysicsList.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include <G4VModularPhysicsList.hh>
 
-#include "../GeantPhysicsOptions.hh"
+#include "GeantPhysicsOptions.hh"
 
 namespace celeritas
 {
-namespace detail
-{
 //---------------------------------------------------------------------------//
 /*!
- * Construct a user-defined physics list of particles and physics processes.
+ * Construct the FTFP_BERT physics list with configurable EM standard physics.
  */
-class CelerEmPhysicsList : public G4VModularPhysicsList
+class FtfpBertPhysicsList : public G4VModularPhysicsList
 {
   public:
     //!@{
@@ -28,10 +25,9 @@ class CelerEmPhysicsList : public G4VModularPhysicsList
     //!@}
 
   public:
-    // Set up during construction
-    explicit CelerEmPhysicsList(Options const& options);
+    // Construct with physics options
+    explicit FtfpBertPhysicsList(Options const& options);
 };
 
 //---------------------------------------------------------------------------//
-}  // namespace detail
 }  // namespace celeritas

--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -89,8 +89,8 @@ operator==(GeantMuonPhysicsOptions const& a, GeantMuonPhysicsOptions const& b)
  * Construction options for Geant physics.
  *
  * These options attempt to default to our closest match to \c
- * G4StandardEmPhysics. They are passed to the \c detail::CelerEmPhysicsList
- * and \c detail::CelerFTFPBert physics lists to provide an easy way to set up
+ * G4StandardEmPhysics. They are passed to the \c EmPhysicsList
+ * and \c FtfpBert physics lists to provide an easy way to set up
  * physics options.
  */
 struct GeantPhysicsOptions

--- a/src/celeritas/ext/GeantSetup.cc
+++ b/src/celeritas/ext/GeantSetup.cc
@@ -30,7 +30,7 @@
 #include "geocel/ScopedGeantExceptionHandler.hh"
 #include "geocel/ScopedGeantLogger.hh"
 
-#include "detail/CelerEmPhysicsList.hh"
+#include "EmPhysicsList.hh"
 
 namespace celeritas
 {
@@ -102,7 +102,7 @@ GeantSetup::GeantSetup(std::string const& gdml_filename, Options options)
     ScopedGeantExceptionHandler scoped_exceptions;
 
     {
-        CELER_LOG(status) << "Initializing Geant4 geometry";
+        CELER_LOG(status) << "Initializing Geant4 geometry and physics list";
 
         // Load GDML and save a copy of the pointer
         world_ = load_geant_geometry(gdml_filename);
@@ -113,8 +113,7 @@ GeantSetup::GeantSetup(std::string const& gdml_filename, Options options)
         run_manager_->SetUserInitialization(detector.release());
 
         // Construct the physics
-        auto physics_list
-            = std::make_unique<detail::CelerEmPhysicsList>(options);
+        auto physics_list = std::make_unique<EmPhysicsList>(options);
         run_manager_->SetUserInitialization(physics_list.release());
     }
 

--- a/src/celeritas/ext/detail/EmStandardPhysics.cc
+++ b/src/celeritas/ext/detail/EmStandardPhysics.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/CelerEmStandardPhysics.cc
+//! \file celeritas/ext/detail/EmStandardPhysics.cc
 //---------------------------------------------------------------------------//
-#include "CelerEmStandardPhysics.hh"
+#include "EmStandardPhysics.hh"
 
 #include <memory>
 #include <CLHEP/Units/SystemOfUnits.h>
@@ -100,7 +100,7 @@ from_form_factor_type(NuclearFormFactorType const& form_factor)
 /*!
  * Construct with physics options.
  */
-CelerEmStandardPhysics::CelerEmStandardPhysics(Options const& options)
+EmStandardPhysics::EmStandardPhysics(Options const& options)
     : options_(options)
 {
     // Set EM options using limits from G4EmParameters
@@ -162,7 +162,7 @@ CelerEmStandardPhysics::CelerEmStandardPhysics(Options const& options)
  * Currently only instantiating e+, e-, gamma, mu-, mu+, and proton (the latter
  * is needed for msc)
  */
-void CelerEmStandardPhysics::ConstructParticle()
+void EmStandardPhysics::ConstructParticle()
 {
     G4Gamma::GammaDefinition();
     G4Electron::ElectronDefinition();
@@ -182,7 +182,7 @@ void CelerEmStandardPhysics::ConstructParticle()
 /*!
  * Build list of available processes and models.
  */
-void CelerEmStandardPhysics::ConstructProcess()
+void EmStandardPhysics::ConstructProcess()
 {
     // Add E.M. processes for photons, electrons, and positrons
     this->add_gamma_processes();
@@ -213,7 +213,7 @@ void CelerEmStandardPhysics::ConstructProcess()
  * calculates a combined total cross section. It's faster in Geant4 but
  * shouldn't result in different answers.
  */
-void CelerEmStandardPhysics::add_gamma_processes()
+void EmStandardPhysics::add_gamma_processes()
 {
     auto* physics_list = G4PhysicsListHelper::GetPhysicsListHelper();
     auto* gamma = G4Gamma::Gamma();
@@ -307,7 +307,7 @@ void CelerEmStandardPhysics::add_gamma_processes()
  * - Coulomb scattering and multiple scattering (high E) are currently
  *   disabled.
  */
-void CelerEmStandardPhysics::add_e_processes(G4ParticleDefinition* p)
+void EmStandardPhysics::add_e_processes(G4ParticleDefinition* p)
 {
     auto* physics_list = G4PhysicsListHelper::GetPhysicsListHelper();
 
@@ -480,7 +480,7 @@ void CelerEmStandardPhysics::add_e_processes(G4ParticleDefinition* p)
  *
  * \todo Implement energy loss fluctuation models for muon ionization.
  */
-void CelerEmStandardPhysics::add_mu_processes(G4ParticleDefinition* p)
+void EmStandardPhysics::add_mu_processes(G4ParticleDefinition* p)
 {
     auto* physics_list = G4PhysicsListHelper::GetPhysicsListHelper();
 

--- a/src/celeritas/ext/detail/EmStandardPhysics.hh
+++ b/src/celeritas/ext/detail/EmStandardPhysics.hh
@@ -1,0 +1,52 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/detail/EmStandardPhysics.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <G4ParticleDefinition.hh>
+#include <G4VPhysicsConstructor.hh>
+
+#include "../GeantPhysicsOptions.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct Celeritas-supported EM standard physics.
+ */
+class EmStandardPhysics : public G4VPhysicsConstructor
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Options = GeantPhysicsOptions;
+    //!@}
+
+  public:
+    // Set up during construction
+    explicit EmStandardPhysics(Options const& options);
+
+    // Set up minimal EM particle list
+    void ConstructParticle() override;
+    // Set up process list
+    void ConstructProcess() override;
+
+  private:
+    Options options_;
+
+    // Add EM processes for photons
+    void add_gamma_processes();
+    // Add EM processes for electrons and positrons
+    void add_e_processes(G4ParticleDefinition* p);
+    // Add EM processes for muons
+    void add_mu_processes(G4ParticleDefinition* p);
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/ext/detail/OpticalPhysics.cc
+++ b/src/celeritas/ext/detail/OpticalPhysics.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/CelerOpticalPhysics.cc
+//! \file celeritas/ext/detail/OpticalPhysics.cc
 //---------------------------------------------------------------------------//
-#include "CelerOpticalPhysics.hh"
+#include "OpticalPhysics.hh"
 
 #include <memory>
 #include <G4Cerenkov.hh>
@@ -120,9 +120,8 @@ G4String optical_process_type_to_geant_name(OpticalProcessType value)
  * Use `G4OpticalParameters` when available, otherwise use hardcoded
  * checks.
  */
-bool process_is_active(
-    OpticalProcessType process,
-    [[maybe_unused]] CelerOpticalPhysics::Options const& options)
+bool process_is_active(OpticalProcessType process,
+                       [[maybe_unused]] OpticalPhysics::Options const& options)
 {
 #if G4VERSION_NUMBER >= 1070
     auto* params = G4OpticalParameters::Instance();
@@ -160,8 +159,7 @@ bool process_is_active(
 /*!
  * Construct with physics options.
  */
-CelerOpticalPhysics::CelerOpticalPhysics(Options const& options)
-    : options_(options)
+OpticalPhysics::OpticalPhysics(Options const& options) : options_(options)
 {
 #if G4VERSION_NUMBER >= 1070
     // Use of G4OpticalParameters only from Geant4 10.7
@@ -217,7 +215,7 @@ CelerOpticalPhysics::CelerOpticalPhysics(Options const& options)
 /*!
  * Build list of available particles.
  */
-void CelerOpticalPhysics::ConstructParticle()
+void OpticalPhysics::ConstructParticle()
 {
     // Eventually nothing to do here as Celeritas OpPhys won't generate
     // G4OpticalPhotons
@@ -228,7 +226,7 @@ void CelerOpticalPhysics::ConstructParticle()
 /*!
  * Build list of available processes and models.
  */
-void CelerOpticalPhysics::ConstructProcess()
+void OpticalPhysics::ConstructProcess()
 {
     auto* process_manager
         = G4OpticalPhoton::OpticalPhoton()->GetProcessManager();

--- a/src/celeritas/ext/detail/OpticalPhysics.hh
+++ b/src/celeritas/ext/detail/OpticalPhysics.hh
@@ -2,14 +2,13 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/CelerEmStandardPhysics.hh
+//! \file celeritas/ext/detail/OpticalPhysics.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <G4ParticleDefinition.hh>
 #include <G4VPhysicsConstructor.hh>
 
-#include "../GeantPhysicsOptions.hh"
+#include "../GeantOpticalPhysicsOptions.hh"
 
 namespace celeritas
 {
@@ -17,19 +16,19 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct Celeritas-supported EM standard physics.
+ * Construct Celeritas-supported Optical physics.
  */
-class CelerEmStandardPhysics : public G4VPhysicsConstructor
+class OpticalPhysics : public G4VPhysicsConstructor
 {
   public:
     //!@{
     //! \name Type aliases
-    using Options = GeantPhysicsOptions;
+    using Options = GeantOpticalPhysicsOptions;
     //!@}
 
   public:
     // Set up during construction
-    explicit CelerEmStandardPhysics(Options const& options);
+    explicit OpticalPhysics(Options const& options);
 
     // Set up minimal EM particle list
     void ConstructParticle() override;
@@ -38,13 +37,6 @@ class CelerEmStandardPhysics : public G4VPhysicsConstructor
 
   private:
     Options options_;
-
-    // Add EM processes for photons
-    void add_gamma_processes();
-    // Add EM processes for electrons and positrons
-    void add_e_processes(G4ParticleDefinition* p);
-    // Add EM processes for muons
-    void add_mu_processes(G4ParticleDefinition* p);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/PhysicsListUtils.hh
+++ b/src/celeritas/ext/detail/PhysicsListUtils.hh
@@ -6,11 +6,25 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <G4VModularPhysicsList.hh>
+
 namespace celeritas
 {
 namespace detail
 {
 //---------------------------------------------------------------------------//
+/*!
+ * Create a suitably owned physics class and add it to the physics list.
+ */
+template<class PL, class... T>
+void emplace_physics(G4VModularPhysicsList& list, T&&... args)
+{
+    // Construct physics
+    auto phys = std::make_unique<PL>(std::forward<T>(args)...);
+
+    // Register, passing ownership to the list
+    list.RegisterPhysics(phys.release());
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/celeritas/ext/detail/PhysicsListUtils.hh
+++ b/src/celeritas/ext/detail/PhysicsListUtils.hh
@@ -2,35 +2,15 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/CelerFTFPBert.hh
-//! \todo Move out of detail since this is used by celer-g4
+//! \file celeritas/ext/detail/PhysicsListUtils.hh
 //---------------------------------------------------------------------------//
 #pragma once
-
-#include <G4VModularPhysicsList.hh>
-
-#include "../GeantPhysicsOptions.hh"
 
 namespace celeritas
 {
 namespace detail
 {
 //---------------------------------------------------------------------------//
-/*!
- * Construct the FTFP_BERT physics list with modified EM standard physics.
- */
-class CelerFTFPBert : public G4VModularPhysicsList
-{
-  public:
-    //!@{
-    //! \name Type aliases
-    using Options = GeantPhysicsOptions;
-    //!@}
-
-  public:
-    // Construct with physics options
-    explicit CelerFTFPBert(Options const& options);
-};
 
 //---------------------------------------------------------------------------//
 }  // namespace detail


### PR DESCRIPTION
Split from #1602, this renames some "detail" classes that we want to be available to users and other parts of Celeritas. It also drops the potentially confusing `Offload` part of the Celeritas tracking manager.

There's an inconsistency in our naming/paths now, that the `celeritas::FooPhysicsList` classes don't have a `g4` or `Geant`-qualified filename or directory, but you can't include them without having Geant4 enabled. However I think it's better to have `celeritas::Bar` or `celeritas::FooBar` (where `Bar` is a Geant4 virtual base class and/or `Foo` is the celeritas implementation) rather than `celeritas::GeantFooBar`. This is consistent with the new `celeritas::TrackingManager` rename. We may want to rename (or refactor to move) things for v1.0 (see https://github.com/celeritas-project/celeritas/issues/1263).