### PR TITLE
Rename fast simulation offload

### DIFF
--- a/example/accel/fastsim-offload.cc
+++ b/example/accel/fastsim-offload.cc
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file example/accel/fastsim-offload.cc
+//! \file accel/fastsim-offload.cc
 //---------------------------------------------------------------------------//
 
 #include <algorithm>
@@ -42,7 +42,7 @@
 #endif
 
 #include <accel/AlongStepFactory.hh>
-#include <accel/FastSimulationOffload.hh>
+#include <accel/FastSimulationModel.hh>
 #include <accel/LocalTransporter.hh>
 #include <accel/SetupOptions.hh>
 #include <accel/SharedParams.hh>
@@ -90,16 +90,16 @@ class DetectorConstruction final : public G4VUserDetectorConstruction
 
     void ConstructSDandField() final
     {
-        CELER_LOG_LOCAL(status) << "Creating FastSimulationOffload for "
-                                   "default region";
+        CELER_LOG_LOCAL(status)
+            << R"(Creating FastSimulationModel for default region)";
         G4Region* default_region = G4RegionStore::GetInstance()->GetRegion(
             "DefaultRegionForTheWorld");
         // Underlying GVFastSimulationModel constructor handles ownership, so
-        // we can ignore the returned pointer...
-        new celeritas::FastSimulationOffload("accel::FastSimulationOffload",
-                                             default_region,
-                                             &shared_params,
-                                             &local_transporter);
+        // we must ignore the returned pointer...
+        new celeritas::FastSimulationModel("accel::FastSimulationModel",
+                                           default_region,
+                                           &shared_params,
+                                           &local_transporter);
     }
 
   private:

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -13,7 +13,7 @@ set(PUBLIC_DEPS Celeritas::celeritas Celeritas::corecel)
 
 list(APPEND SOURCES
   AlongStepFactory.cc
-  FastSimulationOffload.cc
+  FastSimulationModel.cc
   GeantSimpleCalo.cc
   GeantStepDiagnostic.cc
   Logger.cc

--- a/src/accel/FastSimulationModel.cc
+++ b/src/accel/FastSimulationModel.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file accel/FastSimulationOffload.cc
+//! \file accel/FastSimulationModel.cc
 //---------------------------------------------------------------------------//
-#include "FastSimulationOffload.hh"
+#include "FastSimulationModel.hh"
 
 #include "corecel/Assert.hh"
 
@@ -18,9 +18,9 @@ namespace celeritas
 /*!
  * Construct a model to be used in all volumes of the problem.
  */
-FastSimulationOffload::FastSimulationOffload(G4String const& name,
-                                             SharedParams const* params,
-                                             LocalTransporter* local)
+FastSimulationModel::FastSimulationModel(G4String const& name,
+                                         SharedParams const* params,
+                                         LocalTransporter* local)
     : G4VFastSimulationModel(name), params_(params), transport_(local)
 {
     CELER_VALIDATE(G4VERSION_NUMBER >= 1110,
@@ -38,10 +38,10 @@ FastSimulationOffload::FastSimulationOffload(G4String const& name,
  * The envelope cannot be \c nullptr as this will cause a segmentation fault
  * in the \c G4VFastSimulation base class constructor.
  */
-FastSimulationOffload::FastSimulationOffload(G4String const& name,
-                                             G4Envelope* region,
-                                             SharedParams const* params,
-                                             LocalTransporter* local)
+FastSimulationModel::FastSimulationModel(G4String const& name,
+                                         G4Envelope* region,
+                                         SharedParams const* params,
+                                         LocalTransporter* local)
     : G4VFastSimulationModel(name, region), params_(params), transport_(local)
 {
     CELER_VALIDATE(G4VERSION_NUMBER >= 1110,
@@ -61,7 +61,7 @@ FastSimulationOffload::FastSimulationOffload(G4String const& name,
  * Purely checks if the particle is one that Celeritas has been setup to
  * handle.
  */
-G4bool FastSimulationOffload::IsApplicable(G4ParticleDefinition const& particle)
+G4bool FastSimulationModel::IsApplicable(G4ParticleDefinition const& particle)
 {
     CELER_EXPECT(*params_);
 
@@ -79,7 +79,7 @@ G4bool FastSimulationOffload::IsApplicable(G4ParticleDefinition const& particle)
  * Always returns true because we only make the decision to offload to
  * Celeritas based on geometric region and particle type.
  */
-G4bool FastSimulationOffload::ModelTrigger(G4FastTrack const& /*track*/)
+G4bool FastSimulationModel::ModelTrigger(G4FastTrack const& /*track*/)
 {
     return true;
 }
@@ -88,7 +88,7 @@ G4bool FastSimulationOffload::ModelTrigger(G4FastTrack const& /*track*/)
 /*!
  * Offload the incoming track to Celeritas.
  */
-void FastSimulationOffload::DoIt(G4FastTrack const& track, G4FastStep& step)
+void FastSimulationModel::DoIt(G4FastTrack const& track, G4FastStep& step)
 {
     CELER_EXPECT(track.GetPrimaryTrack());
     CELER_EXPECT(*transport_);
@@ -114,7 +114,7 @@ void FastSimulationOffload::DoIt(G4FastTrack const& track, G4FastStep& step)
  * That is done to allow for models that may add "onload" particles back to
  * Geant4.
  */
-void FastSimulationOffload::Flush()
+void FastSimulationModel::Flush()
 {
     ExceptionConverter call_g4exception{"celer0002", params_};
     CELER_TRY_HANDLE(transport_->Flush(), call_g4exception);

--- a/src/accel/FastSimulationModel.hh
+++ b/src/accel/FastSimulationModel.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file accel/FastSimulationOffload.hh
+//! \file accel/FastSimulationModel.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -21,22 +21,24 @@ class LocalTransporter;
  * This class must be constructed locally on each worker thread/task, typically
  * within the application's concrete implementation of
  * `G4VUserDetectorConstruction::ConstructSDandField()`.
+ *
+ * Note that the argument \c G4Envelope is a type alias to \c G4Region.
  */
-class FastSimulationOffload final : public G4VFastSimulationModel
+class FastSimulationModel final : public G4VFastSimulationModel
 {
   public:
     // Construct with name, shared (across threads) params, and thread-local
     // transporter
-    FastSimulationOffload(G4String const& name,
-                          SharedParams const* params,
-                          LocalTransporter* local);
+    FastSimulationModel(G4String const& name,
+                        SharedParams const* params,
+                        LocalTransporter* local);
 
     // Construct with name, region, shared (across threads) params, and
     // thread-local transporter
-    FastSimulationOffload(G4String const& name,
-                          G4Envelope* region,
-                          SharedParams const* params,
-                          LocalTransporter* local);
+    FastSimulationModel(G4String const& name,
+                        G4Envelope* region,
+                        SharedParams const* params,
+                        LocalTransporter* local);
 
     // Return true if model is applicable to the `G4ParticleDefinition`
     G4bool IsApplicable(G4ParticleDefinition const& particle) final;

--- a/src/accel/FastSimulationOffload.cc
+++ b/src/accel/FastSimulationOffload.cc
@@ -105,7 +105,6 @@ void FastSimulationOffload::DoIt(G4FastTrack const& track, G4FastStep& step)
     step.ProposeTotalEnergyDeposited(0.0);
 }
 
-#if G4VERSION_NUMBER >= 1110
 //---------------------------------------------------------------------------//
 /*!
  * Complete processing of any buffered tracks.
@@ -120,6 +119,5 @@ void FastSimulationOffload::Flush()
     ExceptionConverter call_g4exception{"celer0002", params_};
     CELER_TRY_HANDLE(transport_->Flush(), call_g4exception);
 }
-#endif
 
 }  // namespace celeritas

--- a/src/accel/FastSimulationOffload.hh
+++ b/src/accel/FastSimulationOffload.hh
@@ -1,0 +1,17 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/FastSimulationOffload.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "FastSimulationOffload.hh"
+
+namespace celeritas
+{
+
+// TODO: Remove in v0.7
+using FastSimulationOffload [[deprecated]] = FastSimulationModel;
+
+}  // namespace celeritas

--- a/src/accel/FastSimulationOffload.hh
+++ b/src/accel/FastSimulationOffload.hh
@@ -16,7 +16,7 @@ class LocalTransporter;
 
 //---------------------------------------------------------------------------//
 /*!
- * Offload tracks to Celeritas via G4VFastSimulationModel interface
+ * Offload tracks to Celeritas via G4VFastSimulationModel interface.
  *
  * This class must be constructed locally on each worker thread/task, typically
  * within the application's concrete implementation of
@@ -47,10 +47,12 @@ class FastSimulationOffload final : public G4VFastSimulationModel
     // Apply model
     void DoIt(G4FastTrack const& track, G4FastStep& step) final;
 
+    // Complete processing of buffered tracks
+    void Flush()
 #if G4VERSION_NUMBER >= 1110
-    //! Complete processing of buffered tracks
-    void Flush() final;
+        final
 #endif
+        ;
 
   private:
     SharedParams const* params_{nullptr};


### PR DESCRIPTION
Follow-on to #1603 that makes the Celeritas object name consistent with the Geant4 name: `G4Foo` specialization becomes `celeritas::Foo`.