### PR TITLE
Rename `Generic` grid to `Nonuniform`

### DIFF
--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -50,7 +50,7 @@ list(APPEND SOURCES
   global/DebugIO.json.cc
   global/KernelContextException.cc
   global/Stepper.cc
-  grid/GenericGridBuilder.cc
+  grid/NonuniformGridBuilder.cc
   grid/SplineDerivCalculator.cc
   grid/TwodGridBuilder.cc
   grid/ValueGridBuilder.cc

--- a/src/celeritas/em/data/LivermorePEData.hh
+++ b/src/celeritas/em/data/LivermorePEData.hh
@@ -13,7 +13,7 @@
 #include "corecel/math/Quantity.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/NonuniformGridData.hh"
 
 namespace celeritas
 {
@@ -36,7 +36,7 @@ struct LivermoreSubshell
     Energy binding_energy;
 
     // Tabulated subshell photoionization cross section (used below 5 keV)
-    GenericGridRecord xs;
+    NonuniformGridRecord xs;
 
     // Fit parameters for the integrated subshell photoionization cross
     // sections in the two different energy ranges (used above 5 keV)
@@ -60,12 +60,12 @@ struct LivermoreElement
     // TOTAL CROSS SECTIONS
 
     // Total cross section below the K-shell energy. Uses linear interpolation.
-    GenericGridRecord xs_lo;
+    NonuniformGridRecord xs_lo;
 
     // Total cross section above the K-shell energy but below the energy
     // threshold for the parameterized cross sections. Uses spline
     // interpolation.
-    GenericGridRecord xs_hi;
+    NonuniformGridRecord xs_hi;
 
     // SUBSHELL CROSS SECTIONS
 

--- a/src/celeritas/em/interactor/LivermorePEInteractor.hh
+++ b/src/celeritas/em/interactor/LivermorePEInteractor.hh
@@ -15,7 +15,7 @@
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/LivermorePEData.hh"
 #include "celeritas/em/xs/LivermorePEMicroXsCalculator.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 #include "celeritas/phys/CutoffView.hh"
 #include "celeritas/phys/Interaction.hh"
 #include "celeritas/phys/InteractionUtils.hh"
@@ -250,7 +250,7 @@ CELER_FUNCTION SubshellId LivermorePEInteractor::sample_subshell(Engine& rng) co
             }
 
             // Use the tabulated subshell cross sections
-            GenericCalculator calc_xs(shell.xs, shared_.xs.reals);
+            NonuniformGridCalculator calc_xs(shell.xs, shared_.xs.reals);
             xs += inv_cube_energy * calc_xs(inc_energy_);
 
             if (xs > cutoff)

--- a/src/celeritas/em/model/detail/LivermoreXsInserter.hh
+++ b/src/celeritas/em/model/detail/LivermoreXsInserter.hh
@@ -8,7 +8,7 @@
 
 #include "corecel/data/CollectionBuilder.hh"
 #include "celeritas/em/data/LivermorePEData.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
+#include "celeritas/grid/NonuniformGridBuilder.hh"
 #include "celeritas/io/ImportLivermorePE.hh"
 #include "celeritas/io/ImportPhysicsVector.hh"
 
@@ -36,7 +36,7 @@ class LivermoreXsInserter
     inline void operator()(ImportLivermorePE const& inp);
 
   private:
-    GenericGridBuilder build_grid_;
+    NonuniformGridBuilder build_grid_;
 
     CollectionBuilder<LivermoreSubshell> shells_;
     CollectionBuilder<LivermoreElement, MemSpace::host, ElementId> elements_;

--- a/src/celeritas/em/params/detail/MscParamsHelper.cc
+++ b/src/celeritas/em/params/detail/MscParamsHelper.cc
@@ -101,8 +101,8 @@ void MscParamsHelper::build_xs(XsValues* scaled_xs, Values* reals) const
     xs.reserve(par_ids_.size() * num_materials);
 
     // TODO: simplify when refactoring ValueGridInserter, etc
-    ValueGridInserter::XsGridCollection xgc;
-    ValueGridInserter vgi{reals, &xgc};
+    ValueGridInserter::GridValues grids;
+    ValueGridInserter vgi{reals, &grids};
 
     for (size_type mat_idx : range(num_materials))
     {
@@ -122,7 +122,7 @@ void MscParamsHelper::build_xs(XsValues* scaled_xs, Values* reals) const
                                                        make_span(pvec.y));
             auto grid_id = vgb->build(vgi);
             CELER_ASSERT(grid_id.get() == xs.size());
-            xs.push_back(xgc[grid_id]);
+            xs.push_back(grids[grid_id]);
         }
     }
 }

--- a/src/celeritas/em/xs/LivermorePEMicroXsCalculator.hh
+++ b/src/celeritas/em/xs/LivermorePEMicroXsCalculator.hh
@@ -14,7 +14,7 @@
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/em/data/LivermorePEData.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 
 namespace celeritas
 {
@@ -91,14 +91,14 @@ auto LivermorePEMicroXsCalculator::operator()(ElementId el_id) const -> BarnXs
     {
         // Use tabulated cross sections above K-shell energy but below energy
         // limit for parameterization
-        GenericCalculator calc_xs(el.xs_hi, shared_.xs.reals);
+        NonuniformGridCalculator calc_xs(el.xs_hi, shared_.xs.reals);
         result = ipow<3>(inv_energy) * calc_xs(energy.value());
     }
     else
     {
         CELER_ASSERT(el.xs_lo);
         // Use tabulated cross sections below K-shell energy
-        GenericCalculator calc_xs(el.xs_lo, shared_.xs.reals);
+        NonuniformGridCalculator calc_xs(el.xs_lo, shared_.xs.reals);
         result = ipow<3>(inv_energy) * calc_xs(energy.value());
     }
     return BarnXs{result};

--- a/src/celeritas/grid/NonuniformGridBuilder.cc
+++ b/src/celeritas/grid/NonuniformGridBuilder.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/grid/GenericGridBuilder.cc
+//! \file celeritas/grid/NonuniformGridBuilder.cc
 //---------------------------------------------------------------------------//
-#include "GenericGridBuilder.hh"
+#include "NonuniformGridBuilder.hh"
 
 #include "celeritas/io/ImportPhysicsVector.hh"
 
@@ -14,7 +14,8 @@ namespace celeritas
 /*!
  * Construct with pointers to data that will be modified.
  */
-GenericGridBuilder::GenericGridBuilder(Items<real_type>* reals) : reals_{reals}
+NonuniformGridBuilder::NonuniformGridBuilder(Items<real_type>* reals)
+    : reals_{reals}
 {
     CELER_EXPECT(reals);
 }
@@ -23,8 +24,8 @@ GenericGridBuilder::GenericGridBuilder(Items<real_type>* reals) : reals_{reals}
 /*!
  * Add a grid of generic data with linear interpolation.
  */
-auto GenericGridBuilder::operator()(SpanConstFlt grid,
-                                    SpanConstFlt values) -> Grid
+auto NonuniformGridBuilder::operator()(SpanConstFlt grid, SpanConstFlt values)
+    -> Grid
 {
     return this->insert_impl(grid, values);
 }
@@ -33,8 +34,8 @@ auto GenericGridBuilder::operator()(SpanConstFlt grid,
 /*!
  * Add a grid of generic data with linear interpolation.
  */
-auto GenericGridBuilder::operator()(SpanConstDbl grid,
-                                    SpanConstDbl values) -> Grid
+auto NonuniformGridBuilder::operator()(SpanConstDbl grid, SpanConstDbl values)
+    -> Grid
 {
     return this->insert_impl(grid, values);
 }
@@ -43,7 +44,7 @@ auto GenericGridBuilder::operator()(SpanConstDbl grid,
 /*!
  * Add a grid from an imported physics vector.
  */
-auto GenericGridBuilder::operator()(ImportPhysicsVector const& pvec) -> Grid
+auto NonuniformGridBuilder::operator()(ImportPhysicsVector const& pvec) -> Grid
 {
     CELER_EXPECT(pvec.vector_type == ImportPhysicsVectorType::free);
     return this->insert_impl(make_span(pvec.x), make_span(pvec.y));
@@ -54,8 +55,8 @@ auto GenericGridBuilder::operator()(ImportPhysicsVector const& pvec) -> Grid
  * Add a grid from container references.
  */
 template<class T>
-auto GenericGridBuilder::insert_impl(Span<T const> grid,
-                                     Span<T const> values) -> Grid
+auto NonuniformGridBuilder::insert_impl(Span<T const> grid,
+                                        Span<T const> values) -> Grid
 {
     CELER_EXPECT(grid.size() >= 2);
     CELER_EXPECT(grid.front() <= grid.back());

--- a/src/celeritas/grid/NonuniformGridBuilder.hh
+++ b/src/celeritas/grid/NonuniformGridBuilder.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/grid/GenericGridBuilder.hh
+//! \file celeritas/grid/NonuniformGridBuilder.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -10,7 +10,7 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/DedupeCollectionBuilder.hh"
 
-#include "GenericGridData.hh"
+#include "NonuniformGridData.hh"
 
 namespace celeritas
 {
@@ -21,21 +21,21 @@ struct ImportPhysicsVector;
  *
  * This uses a deduplicating inserter for real values to improve cacheing.
  */
-class GenericGridBuilder
+class NonuniformGridBuilder
 {
   public:
     //!@{
     //! \name Type aliases
     template<class T>
     using Items = Collection<T, Ownership::value, MemSpace::host>;
-    using Grid = GenericGridRecord;
+    using Grid = NonuniformGridRecord;
     using SpanConstFlt = Span<float const>;
     using SpanConstDbl = Span<double const>;
     //!@}
 
   public:
     // Construct with pointers to data that will be modified
-    explicit GenericGridBuilder(Items<real_type>* reals);
+    explicit NonuniformGridBuilder(Items<real_type>* reals);
 
     // Add a grid of generic data with linear interpolation
     Grid operator()(SpanConstFlt grid, SpanConstFlt values);

--- a/src/celeritas/grid/NonuniformGridCalculator.hh
+++ b/src/celeritas/grid/NonuniformGridCalculator.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/grid/GenericCalculator.hh
+//! \file celeritas/grid/NonuniformGridCalculator.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -14,7 +14,7 @@
 #include "corecel/grid/Interpolator.hh"
 #include "corecel/grid/NonuniformGrid.hh"
 
-#include "GenericGridData.hh"
+#include "NonuniformGridData.hh"
 
 namespace celeritas
 {
@@ -24,9 +24,9 @@ namespace celeritas
  *
  * The end points of the grid are extrapolated outward as constant values.
  *
- * \todo Rename NonuniformGridCalculator? Template on value type and/or units?
+ * \todo Template on value type and/or units?
  */
-class GenericCalculator
+class NonuniformGridCalculator
 {
   public:
     //@{
@@ -38,12 +38,13 @@ class GenericCalculator
 
   public:
     // Construct by *inverting* a monotonicially increasing generic grid
-    static inline CELER_FUNCTION GenericCalculator
-    from_inverse(GenericGridRecord const& grid, Reals const& storage);
+    static inline CELER_FUNCTION NonuniformGridCalculator
+    from_inverse(NonuniformGridRecord const& grid, Reals const& storage);
 
     // Construct from grid data and backend storage
     inline CELER_FUNCTION
-    GenericCalculator(GenericGridRecord const& grid, Reals const& storage);
+    NonuniformGridCalculator(NonuniformGridRecord const& grid,
+                             Reals const& storage);
 
     // Find and interpolate the y value from the given x value
     inline CELER_FUNCTION real_type operator()(real_type x) const;
@@ -55,7 +56,7 @@ class GenericCalculator
     inline CELER_FUNCTION Grid const& grid() const;
 
     // Make a calculator with x and y flipped
-    inline CELER_FUNCTION GenericCalculator make_inverse() const;
+    inline CELER_FUNCTION NonuniformGridCalculator make_inverse() const;
 
   private:
     //// TYPES ////
@@ -71,8 +72,9 @@ class GenericCalculator
     //// HELPERS ////
 
     // Private constructor implementation
-    inline CELER_FUNCTION
-    GenericCalculator(Reals const& storage, RealIds x_grid, RealIds y_grid);
+    inline CELER_FUNCTION NonuniformGridCalculator(Reals const& storage,
+                                                   RealIds x_grid,
+                                                   RealIds y_grid);
 };
 
 //---------------------------------------------------------------------------//
@@ -81,10 +83,10 @@ class GenericCalculator
 /*!
  * Construct by \em inverting a monotonicially increasing generic grid.
  */
-CELER_FUNCTION GenericCalculator GenericCalculator::from_inverse(
-    GenericGridRecord const& grid, Reals const& storage)
+CELER_FUNCTION NonuniformGridCalculator NonuniformGridCalculator::from_inverse(
+    NonuniformGridRecord const& grid, Reals const& storage)
 {
-    return GenericCalculator{storage, grid.value, grid.grid};
+    return NonuniformGridCalculator{storage, grid.value, grid.grid};
 }
 
 //---------------------------------------------------------------------------//
@@ -92,9 +94,9 @@ CELER_FUNCTION GenericCalculator GenericCalculator::from_inverse(
  * Construct from grid data and backend storage.
  */
 CELER_FUNCTION
-GenericCalculator::GenericCalculator(GenericGridRecord const& grid,
-                                     Reals const& storage)
-    : GenericCalculator{storage, grid.grid, grid.value}
+NonuniformGridCalculator::NonuniformGridCalculator(
+    NonuniformGridRecord const& grid, Reals const& storage)
+    : NonuniformGridCalculator{storage, grid.grid, grid.value}
 {
     CELER_EXPECT(grid);
 }
@@ -103,7 +105,7 @@ GenericCalculator::GenericCalculator(GenericGridRecord const& grid,
 /*!
  * Calculate the y value at the given x value.
  */
-CELER_FUNCTION real_type GenericCalculator::operator()(real_type x) const
+CELER_FUNCTION real_type NonuniformGridCalculator::operator()(real_type x) const
 {
     // Snap out-of-bounds values to closest grid points
     if (x <= x_grid_.front())
@@ -130,7 +132,7 @@ CELER_FUNCTION real_type GenericCalculator::operator()(real_type x) const
 /*!
  * Get the tabulated y value at a particular index.
  */
-CELER_FUNCTION real_type GenericCalculator::operator[](size_type index) const
+CELER_FUNCTION real_type NonuniformGridCalculator::operator[](size_type index) const
 {
     CELER_EXPECT(index < y_offset_.size());
     return reals_[y_offset_[index]];
@@ -141,7 +143,7 @@ CELER_FUNCTION real_type GenericCalculator::operator[](size_type index) const
  * Get the tabulated x values.
  */
 CELER_FORCEINLINE_FUNCTION NonuniformGrid<real_type> const&
-GenericCalculator::grid() const
+NonuniformGridCalculator::grid() const
 {
     return x_grid_;
 }
@@ -152,9 +154,10 @@ GenericCalculator::grid() const
  *
  * \pre The y values must be monotonic increasing.
  */
-CELER_FUNCTION GenericCalculator GenericCalculator::make_inverse() const
+CELER_FUNCTION NonuniformGridCalculator
+NonuniformGridCalculator::make_inverse() const
 {
-    return GenericCalculator{reals_, y_offset_, x_grid_.offset()};
+    return NonuniformGridCalculator{reals_, y_offset_, x_grid_.offset()};
 }
 
 //---------------------------------------------------------------------------//
@@ -164,9 +167,9 @@ CELER_FUNCTION GenericCalculator GenericCalculator::make_inverse() const
  * Construct from grid data and backend storage.
  */
 CELER_FUNCTION
-GenericCalculator::GenericCalculator(Reals const& storage,
-                                     RealIds x_grid,
-                                     RealIds y_grid)
+NonuniformGridCalculator::NonuniformGridCalculator(Reals const& storage,
+                                                   RealIds x_grid,
+                                                   RealIds y_grid)
     : reals_{storage}, x_grid_{x_grid, reals_}, y_offset_{y_grid}
 {
     CELER_EXPECT(!x_grid.empty() && x_grid.size() == y_grid.size());

--- a/src/celeritas/grid/NonuniformGridData.hh
+++ b/src/celeritas/grid/NonuniformGridData.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/grid/GenericGridData.hh
+//! \file celeritas/grid/NonuniformGridData.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -16,7 +16,7 @@ namespace celeritas
 /*!
  * A grid of increasing, sorted 1D data with linear-linear interpolation.
  */
-struct GenericGridRecord
+struct NonuniformGridRecord
 {
     ItemRange<real_type> grid;  //!< x grid
     ItemRange<real_type> value;  //!< f(x) value

--- a/src/celeritas/grid/ValueGridInserter.cc
+++ b/src/celeritas/grid/ValueGridInserter.cc
@@ -16,11 +16,10 @@ namespace celeritas
 /*!
  * Construct with a reference to mutable host data.
  */
-ValueGridInserter::ValueGridInserter(RealCollection* real_data,
-                                     XsGridCollection* xs_grid)
-    : values_(real_data), xs_grids_(xs_grid)
+ValueGridInserter::ValueGridInserter(Values* reals, GridValues* grids)
+    : values_(reals), xs_grids_(grids)
 {
-    CELER_EXPECT(real_data && xs_grid);
+    CELER_EXPECT(reals && grids);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/grid/ValueGridInserter.hh
+++ b/src/celeritas/grid/ValueGridInserter.hh
@@ -41,17 +41,15 @@ class ValueGridInserter
   public:
     //!@{
     //! \name Type aliases
-    using RealCollection
-        = Collection<real_type, Ownership::value, MemSpace::host>;
-    using XsGridCollection
-        = Collection<XsGridData, Ownership::value, MemSpace::host>;
+    using Values = Collection<real_type, Ownership::value, MemSpace::host>;
+    using GridValues = Collection<XsGridData, Ownership::value, MemSpace::host>;
     using SpanConstDbl = Span<double const>;
     using XsIndex = ItemId<XsGridData>;
     //!@}
 
   public:
     // Construct with a reference to mutable host data
-    ValueGridInserter(RealCollection* real_data, XsGridCollection* xs_grid);
+    ValueGridInserter(Values* reals, GridValues* grids);
 
     // Add a grid of xs-like data
     XsIndex operator()(UniformGridData const& log_grid,

--- a/src/celeritas/neutron/data/NeutronElasticData.hh
+++ b/src/celeritas/neutron/data/NeutronElasticData.hh
@@ -12,7 +12,7 @@
 #include "corecel/math/Quantity.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/NonuniformGridData.hh"
 
 namespace celeritas
 {
@@ -69,7 +69,7 @@ struct NeutronElasticData
     units::MevMass neutron_mass;
 
     //! Microscopic (element) cross section data (G4PARTICLEXS/neutron/elZ)
-    ElementItems<GenericGridRecord> micro_xs;
+    ElementItems<NonuniformGridRecord> micro_xs;
 
     //! A-dependent coefficients for the momentum transfer of the CHIPS model
     IsotopeItems<ChipsDiffXsCoefficients> coeffs;

--- a/src/celeritas/neutron/data/NeutronInelasticData.hh
+++ b/src/celeritas/neutron/data/NeutronInelasticData.hh
@@ -13,7 +13,7 @@
 #include "corecel/math/Quantity.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/NonuniformGridData.hh"
 
 namespace celeritas
 {
@@ -144,10 +144,10 @@ struct NeutronInelasticData
     NeutronInelasticScalars scalars;
 
     // Microscopic (element) cross section data (G4PARTICLEXS/neutron/inelZ)
-    ElementItems<GenericGridRecord> micro_xs;
+    ElementItems<NonuniformGridRecord> micro_xs;
 
     // Tabulated nucleon-nucleon cross section data
-    ChannelItems<GenericGridRecord> nucleon_xs;
+    ChannelItems<NonuniformGridRecord> nucleon_xs;
 
     // Parameters of necleon-nucleon cross sections below 10 MeV
     ChannelItems<StepanovParameters> xs_params;

--- a/src/celeritas/neutron/model/ChipsNeutronElasticModel.cc
+++ b/src/celeritas/neutron/model/ChipsNeutronElasticModel.cc
@@ -11,7 +11,7 @@
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
 #include "celeritas/global/TrackExecutor.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
+#include "celeritas/grid/NonuniformGridBuilder.hh"
 #include "celeritas/io/ImportPhysicsTable.hh"
 #include "celeritas/io/ImportPhysicsVector.hh"
 #include "celeritas/mat/MaterialParams.hh"
@@ -53,7 +53,7 @@ ChipsNeutronElasticModel::ChipsNeutronElasticModel(
 
     // Load neutron elastic cross section data
     CollectionBuilder micro_xs{&data.micro_xs};
-    GenericGridBuilder build_grid{&data.reals};
+    NonuniformGridBuilder build_grid{&data.reals};
     for (auto el_id : range(ElementId{materials.num_elements()}))
     {
         AtomicNumber z = materials.get(el_id).atomic_number();

--- a/src/celeritas/neutron/model/NeutronInelasticModel.cc
+++ b/src/celeritas/neutron/model/NeutronInelasticModel.cc
@@ -10,7 +10,7 @@
 #include "corecel/math/Quantity.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
+#include "celeritas/grid/NonuniformGridBuilder.hh"
 #include "celeritas/grid/TwodGridBuilder.hh"
 #include "celeritas/io/ImportPhysicsVector.hh"
 #include "celeritas/mat/MaterialParams.hh"
@@ -57,7 +57,7 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
 
     // Load neutron inelastic cross section data
     CollectionBuilder micro_xs{&data.micro_xs};
-    GenericGridBuilder build_grid{&data.reals};
+    NonuniformGridBuilder build_grid{&data.reals};
     for (auto el_id : range(ElementId{materials.num_elements()}))
     {
         AtomicNumber z = materials.get(el_id).atomic_number();
@@ -75,7 +75,7 @@ NeutronInelasticModel::NeutronInelasticModel(ActionId id,
     auto cdf_energy_bins = this->get_cdf_energy_bins();
     auto cos_theta_bins = this->get_cos_theta_bins();
 
-    GenericGridBuilder build_xs_grid{&data.reals};
+    NonuniformGridBuilder build_xs_grid{&data.reals};
     TwodGridBuilder build_cdf_grid{&data.reals};
     CollectionBuilder nucleon_xs{&data.nucleon_xs};
     CollectionBuilder angular_cdf{&data.angular_cdf};

--- a/src/celeritas/neutron/xs/NeutronElasticMicroXsCalculator.hh
+++ b/src/celeritas/neutron/xs/NeutronElasticMicroXsCalculator.hh
@@ -12,7 +12,7 @@
 #include "corecel/math/Quantity.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 #include "celeritas/neutron/data/NeutronElasticData.hh"
 
 namespace celeritas
@@ -68,7 +68,7 @@ auto NeutronElasticMicroXsCalculator::operator()(ElementId el_id) const -> BarnX
     CELER_EXPECT(el_id < shared_.micro_xs.size());
 
     // Calculate micro cross section at the given energy
-    GenericCalculator calc_xs(shared_.micro_xs[el_id], shared_.reals);
+    NonuniformGridCalculator calc_xs(shared_.micro_xs[el_id], shared_.reals);
     real_type result = calc_xs(inc_energy_);
 
     return BarnXs{result};

--- a/src/celeritas/neutron/xs/NeutronInelasticMicroXsCalculator.hh
+++ b/src/celeritas/neutron/xs/NeutronInelasticMicroXsCalculator.hh
@@ -12,7 +12,7 @@
 #include "corecel/math/Quantity.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 #include "celeritas/neutron/data/NeutronInelasticData.hh"
 
 namespace celeritas
@@ -69,10 +69,10 @@ auto NeutronInelasticMicroXsCalculator::operator()(ElementId el_id) const -> Bar
     CELER_EXPECT(el_id < shared_.micro_xs.size());
 
     // Get element cross section data
-    GenericGridRecord grid = shared_.micro_xs[el_id];
+    NonuniformGridRecord grid = shared_.micro_xs[el_id];
 
     // Calculate micro cross section at the given energy
-    GenericCalculator calc_xs(grid, shared_.reals);
+    NonuniformGridCalculator calc_xs(grid, shared_.reals);
     real_type result = calc_xs(inc_energy_);
 
     return BarnXs{result};

--- a/src/celeritas/neutron/xs/NucleonNucleonXsCalculator.hh
+++ b/src/celeritas/neutron/xs/NucleonNucleonXsCalculator.hh
@@ -12,7 +12,7 @@
 #include "corecel/math/Quantity.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 #include "celeritas/neutron/data/NeutronInelasticData.hh"
 
 namespace celeritas
@@ -106,10 +106,10 @@ auto NucleonNucleonXsCalculator::operator()(ChannelId ch_id,
     else
     {
         // Get tabulated NN cross section data for the given channel
-        GenericGridRecord grid = shared_.nucleon_xs[ch_id];
+        NonuniformGridRecord grid = shared_.nucleon_xs[ch_id];
 
         // Calculate NN cross section at the given energy
-        GenericCalculator calc_xs(grid, shared_.reals);
+        NonuniformGridCalculator calc_xs(grid, shared_.reals);
         result = calc_xs(energy.value());
     }
 

--- a/src/celeritas/optical/CherenkovData.hh
+++ b/src/celeritas/optical/CherenkovData.hh
@@ -10,7 +10,7 @@
 #include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/NonuniformGridData.hh"
 #include "celeritas/optical/Types.hh"
 
 namespace celeritas
@@ -31,7 +31,7 @@ struct CherenkovData
 
     //// MEMBER DATA ////
 
-    OpticalMaterialItems<GenericGridRecord> angle_integral;
+    OpticalMaterialItems<NonuniformGridRecord> angle_integral;
 
     // Backend data
     Items<real_type> reals;

--- a/src/celeritas/optical/CherenkovDndxCalculator.hh
+++ b/src/celeritas/optical/CherenkovDndxCalculator.hh
@@ -13,7 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/grid/VectorUtils.hh"
 #include "celeritas/Quantities.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 
 #include "CherenkovData.hh"
 #include "MaterialView.hh"
@@ -62,10 +62,10 @@ class CherenkovDndxCalculator
 
   private:
     // Calculate refractive index [MeV -> unitless]
-    GenericCalculator calc_refractive_index_;
+    NonuniformGridCalculator calc_refractive_index_;
 
     // Calculate the Cherenkov angle integral [MeV -> unitless]
-    GenericCalculator calc_integral_;
+    NonuniformGridCalculator calc_integral_;
 
     // Square of particle charge
     real_type zsq_;

--- a/src/celeritas/optical/CherenkovGenerator.hh
+++ b/src/celeritas/optical/CherenkovGenerator.hh
@@ -14,7 +14,7 @@
 #include "corecel/data/Collection.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 #include "celeritas/random/distribution/BernoulliDistribution.hh"
 #include "celeritas/random/distribution/RejectionSampler.hh"
 #include "celeritas/random/distribution/UniformRealDistribution.hh"
@@ -67,7 +67,7 @@ class CherenkovGenerator
     //// DATA ////
 
     GeneratorDistributionData const& dist_;
-    GenericCalculator calc_refractive_index_;
+    NonuniformGridCalculator calc_refractive_index_;
     UniformRealDist sample_phi_;
     UniformRealDist sample_num_photons_;
     UniformRealDist sample_energy_;

--- a/src/celeritas/optical/CherenkovParams.cc
+++ b/src/celeritas/optical/CherenkovParams.cc
@@ -16,8 +16,8 @@
 #include "corecel/math/CdfUtils.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericCalculator.hh"
-#include "celeritas/grid/GenericGridInserter.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
+#include "celeritas/grid/NonuniformGridInserter.hh"
 
 #include "MaterialParams.hh"
 #include "MaterialView.hh"
@@ -35,11 +35,11 @@ CherenkovParams::CherenkovParams(MaterialParams const& mats)
     SegmentIntegrator integrate_rindex{TrapezoidSegmentIntegrator{}};
 
     HostVal<CherenkovData> data;
-    GenericGridInserter insert_angle_integral(&data.reals,
-                                              &data.angle_integral);
+    NonuniformGridInserter insert_angle_integral(&data.reals,
+                                                 &data.angle_integral);
     for (auto mat_id : range(OpticalMaterialId(mats.num_materials())))
     {
-        GenericCalculator refractive_index
+        NonuniformGridCalculator refractive_index
             = MaterialView{mats.host_ref(), mat_id}
                   .make_refractive_index_calculator();
         Span<real_type const> energy = refractive_index.grid().values();

--- a/src/celeritas/optical/MaterialData.hh
+++ b/src/celeritas/optical/MaterialData.hh
@@ -10,7 +10,7 @@
 #include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/NonuniformGridData.hh"
 
 #include "Types.hh"
 
@@ -34,7 +34,7 @@ struct MaterialParamsData
 
     //// MEMBER DATA ////
 
-    OpticalMaterialItems<GenericGridRecord> refractive_index;
+    OpticalMaterialItems<NonuniformGridRecord> refractive_index;
     VolumeItems<OpticalMaterialId> optical_id;
     OpticalMaterialItems<CoreMaterialId> core_material_id;
 

--- a/src/celeritas/optical/MaterialParams.cc
+++ b/src/celeritas/optical/MaterialParams.cc
@@ -17,8 +17,8 @@
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/NonuniformGridBuilder.hh"
+#include "celeritas/grid/NonuniformGridData.hh"
 #include "celeritas/io/ImportData.hh"
 #include "celeritas/mat/MaterialParams.hh"
 
@@ -105,7 +105,7 @@ MaterialParams::MaterialParams(Input const& inp)
 
     HostVal<MaterialParamsData> data;
     CollectionBuilder refractive_index{&data.refractive_index};
-    GenericGridBuilder build_grid(&data.reals);
+    NonuniformGridBuilder build_grid(&data.reals);
     for (auto opt_mat_idx : range(inp.properties.size()))
     {
         auto const& mat = inp.properties[opt_mat_idx];

--- a/src/celeritas/optical/MaterialView.hh
+++ b/src/celeritas/optical/MaterialView.hh
@@ -9,7 +9,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 
 #include "MaterialData.hh"
 
@@ -51,7 +51,7 @@ class MaterialView
     //// PARAMETER DATA ////
 
     // Access energy-dependent refractive index
-    inline CELER_FUNCTION GenericCalculator
+    inline CELER_FUNCTION NonuniformGridCalculator
     make_refractive_index_calculator() const;
 
   private:
@@ -120,11 +120,12 @@ CELER_FUNCTION CoreMaterialId MaterialView::core_material_id() const
 /*!
  * Access energy-dependent refractive index.
  */
-CELER_FUNCTION GenericCalculator
+CELER_FUNCTION NonuniformGridCalculator
 MaterialView::make_refractive_index_calculator() const
 {
     CELER_EXPECT(*this);
-    return GenericCalculator(params_.refractive_index[mat_id_], params_.reals);
+    return NonuniformGridCalculator(params_.refractive_index[mat_id_],
+                                    params_.reals);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/MfpBuilder.hh
+++ b/src/celeritas/optical/MfpBuilder.hh
@@ -6,7 +6,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "celeritas/grid/GenericGridInserter.hh"
+#include "celeritas/grid/NonuniformGridInserter.hh"
 
 namespace celeritas
 {
@@ -24,17 +24,17 @@ class MfpBuilder
   public:
     //!@{
     //! \name Type aliases
-    using GridId = OpaqueId<GenericGridRecord>;
-    using GridInserter = GenericGridInserter<GridId>;
+    using GridId = OpaqueId<NonuniformGridRecord>;
+    using GridInserter = NonuniformGridInserter<GridId>;
     using GridIdRange = Range<GridId>;
 
-    using RealCollection = typename GridInserter::RealCollection;
-    using GridCollection = typename GridInserter::GenericGridCollection;
+    using Values = typename GridInserter::Values;
+    using GridValues = typename GridInserter::GridValues;
     //!@}
 
   public:
     // Construct with given inserter
-    inline MfpBuilder(RealCollection* real_data, GridCollection* grid_data);
+    inline MfpBuilder(Values* real_data, GridValues* grid_data);
 
     // Build the grid
     template<typename... Args>
@@ -45,7 +45,7 @@ class MfpBuilder
 
   private:
     GridInserter insert_grid_;
-    GridCollection* grid_data_;
+    GridValues* grid_data_;
     GridId const grid_id_first_;
 };
 
@@ -55,7 +55,7 @@ class MfpBuilder
 /*!
  * Construct with given collections.
  */
-MfpBuilder::MfpBuilder(RealCollection* real_data, GridCollection* grid_data)
+MfpBuilder::MfpBuilder(Values* real_data, GridValues* grid_data)
     : insert_grid_(real_data, grid_data)
     , grid_data_(grid_data)
     , grid_id_first_(grid_data->size())
@@ -66,7 +66,7 @@ MfpBuilder::MfpBuilder(RealCollection* real_data, GridCollection* grid_data)
 /*!
  * Build the grid.
  *
- * Passes its arguments directly to a GenericGridInserter.
+ * Passes its arguments directly to a \c NonuniformGridInserter.
  */
 template<typename... Args>
 void MfpBuilder::operator()(Args const&... args)

--- a/src/celeritas/optical/ScintillationData.hh
+++ b/src/celeritas/optical/ScintillationData.hh
@@ -10,7 +10,7 @@
 #include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/NonuniformGridData.hh"
 #include "celeritas/optical/Types.hh"
 
 namespace celeritas
@@ -77,7 +77,7 @@ struct MatScintSpectrumRecord
  */
 struct ParScintSpectrumRecord
 {
-    GenericGridRecord yield_per_energy;  //! [MeV] -> [1/MeV]
+    NonuniformGridRecord yield_per_energy;  //! [MeV] -> [1/MeV]
     ItemRange<real_type> yield_pdf;
     ItemRange<ScintRecord> components;
 

--- a/src/celeritas/optical/WavelengthShiftData.hh
+++ b/src/celeritas/optical/WavelengthShiftData.hh
@@ -10,7 +10,7 @@
 #include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/NonuniformGridData.hh"
 
 namespace celeritas
 {
@@ -49,7 +49,7 @@ struct WavelengthShiftData
     OpticalMaterialItems<WlsMaterialRecord> wls_record;
 
     // Cumulative probability of emission as a function of energy
-    OpticalMaterialItems<GenericGridRecord> energy_cdf;
+    OpticalMaterialItems<NonuniformGridRecord> energy_cdf;
 
     // Backend data
     Items<real_type> reals;

--- a/src/celeritas/optical/WavelengthShiftParams.cc
+++ b/src/celeritas/optical/WavelengthShiftParams.cc
@@ -11,8 +11,8 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/math/CdfUtils.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
-#include "celeritas/grid/GenericGridInserter.hh"
+#include "celeritas/grid/NonuniformGridBuilder.hh"
+#include "celeritas/grid/NonuniformGridInserter.hh"
 #include "celeritas/io/ImportData.hh"
 
 namespace celeritas
@@ -57,7 +57,7 @@ WavelengthShiftParams::WavelengthShiftParams(Input const& input)
 
     HostVal<WavelengthShiftData> data;
     CollectionBuilder wls_record{&data.wls_record};
-    GenericGridInserter insert_energy_cdf(&data.reals, &data.energy_cdf);
+    NonuniformGridInserter insert_energy_cdf(&data.reals, &data.energy_cdf);
     for (auto const& wls : input.data)
     {
         if (!wls)

--- a/src/celeritas/optical/interactor/WavelengthShiftInteractor.hh
+++ b/src/celeritas/optical/interactor/WavelengthShiftInteractor.hh
@@ -10,7 +10,7 @@
 #include "corecel/Types.hh"
 #include "corecel/data/StackAllocator.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 #include "celeritas/optical/Interaction.hh"
 #include "celeritas/optical/ParticleTrackView.hh"
 #include "celeritas/optical/TrackInitializer.hh"
@@ -73,7 +73,7 @@ class WavelengthShiftInteractor
     PoissonDistribution<real_type> sample_num_photons_;
     ExponentialDistribution<real_type> sample_time_;
     // Grid calculators
-    GenericCalculator calc_cdf_;
+    NonuniformGridCalculator calc_cdf_;
     // Allocate space for secondary particles
     SecondaryAllocator& allocate_;
 };
@@ -136,7 +136,7 @@ CELER_FUNCTION Interaction WavelengthShiftInteractor::operator()(Engine& rng)
     result.secondaries = {secondaries, num_photons};
 
     IsotropicDistribution sample_direction{};
-    GenericCalculator calc_energy = calc_cdf_.make_inverse();
+    NonuniformGridCalculator calc_energy = calc_cdf_.make_inverse();
     for (size_type i : range(num_photons))
     {
         // Sample the emitted energy from the inverse cumulative distribution

--- a/src/celeritas/optical/model/RayleighMfpCalculator.hh
+++ b/src/celeritas/optical/model/RayleighMfpCalculator.hh
@@ -10,7 +10,7 @@
 #include "corecel/Types.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/Quantities.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 #include "celeritas/io/ImportOpticalMaterial.hh"
 #include "celeritas/mat/MaterialView.hh"
 #include "celeritas/optical/detail/OpticalUtils.hh"
@@ -63,7 +63,7 @@ class RayleighMfpCalculator
     //!@{
     //! \name Type aliases
     using Energy = units::MevEnergy;
-    using Grid = typename GenericCalculator::Grid;
+    using Grid = typename NonuniformGridCalculator::Grid;
     //!@}
 
   public:
@@ -84,7 +84,7 @@ class RayleighMfpCalculator
 
   private:
     // Calculate refractive index [MeV -> unitless]
-    GenericCalculator calc_rindex_;
+    NonuniformGridCalculator calc_rindex_;
 
     // Constant prefactor at all energies
     real_type density_fluctuation_;

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -283,12 +283,12 @@ celeritas_add_test(global/StepperGeant.test.cc
 
 #-----------------------------------------------------------------------------#
 # Grid
-celeritas_add_test(grid/GenericCalculator.test.cc)
-celeritas_add_test(grid/GenericGridBuilder.test.cc)
-celeritas_add_test(grid/GenericGridInserter.test.cc)
 celeritas_add_test(grid/GridIdFinder.test.cc)
 celeritas_add_test(grid/InverseCdfFinder.test.cc)
 celeritas_add_test(grid/InverseRangeCalculator.test.cc)
+celeritas_add_test(grid/NonuniformGridCalculator.test.cc)
+celeritas_add_test(grid/NonuniformGridBuilder.test.cc)
+celeritas_add_test(grid/NonuniformGridInserter.test.cc)
 celeritas_add_test(grid/RangeCalculator.test.cc)
 celeritas_add_test(grid/SplineDerivCalculator.test.cc)
 celeritas_add_test(grid/SplineXsCalculator.test.cc)

--- a/test/celeritas/grid/NonuniformGridBuilder.test.cc
+++ b/test/celeritas/grid/NonuniformGridBuilder.test.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/grid/GenericGridBuilder.test.cc
+//! \file celeritas/grid/NonuniformGridBuilder.test.cc
 //---------------------------------------------------------------------------//
-#include "celeritas/grid/GenericGridBuilder.hh"
+#include "celeritas/grid/NonuniformGridBuilder.hh"
 
 #include <iostream>
 #include <vector>
@@ -23,10 +23,13 @@ namespace test
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class GenericGridBuilderTest : public ::celeritas::test::Test
+class NonuniformGridBuilderTest : public ::celeritas::test::Test
 {
   protected:
-    GenericGridBuilder make_builder() { return GenericGridBuilder(&scalars_); }
+    NonuniformGridBuilder make_builder()
+    {
+        return NonuniformGridBuilder(&scalars_);
+    }
 
     static Span<real_type const> span_grid() { return make_span(grid_); }
 
@@ -42,11 +45,11 @@ class GenericGridBuilderTest : public ::celeritas::test::Test
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST_F(GenericGridBuilderTest, build_span)
+TEST_F(NonuniformGridBuilderTest, build_span)
 {
     auto builder = make_builder();
 
-    GenericGridRecord grid_data = builder(span_grid(), span_values());
+    NonuniformGridRecord grid_data = builder(span_grid(), span_values());
 
     ASSERT_TRUE(grid_data);
     ASSERT_EQ(8, scalars_.size());
@@ -57,7 +60,7 @@ TEST_F(GenericGridBuilderTest, build_span)
     EXPECT_VEC_SOFT_EQ(values_, scalars_[grid_data.value]);
 }
 
-TEST_F(GenericGridBuilderTest, TEST_IF_CELERITAS_DOUBLE(build_vec))
+TEST_F(NonuniformGridBuilderTest, TEST_IF_CELERITAS_DOUBLE(build_vec))
 {
     ImportPhysicsVector vect;
     vect.vector_type = ImportPhysicsVectorType::free;
@@ -66,7 +69,7 @@ TEST_F(GenericGridBuilderTest, TEST_IF_CELERITAS_DOUBLE(build_vec))
 
     auto builder = make_builder();
 
-    GenericGridRecord grid_data = builder(vect);
+    NonuniformGridRecord grid_data = builder(vect);
 
     ASSERT_TRUE(grid_data);
     ASSERT_EQ(8, scalars_.size());

--- a/test/celeritas/grid/NonuniformGridCalculator.test.cc
+++ b/test/celeritas/grid/NonuniformGridCalculator.test.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/grid/GenericCalculator.test.cc
+//! \file celeritas/grid/NonuniformGridCalculator.test.cc
 //---------------------------------------------------------------------------//
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 
 #include <algorithm>
 #include <cmath>
@@ -12,7 +12,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/Ref.hh"
-#include "celeritas/grid/GenericGridBuilder.hh"
+#include "celeritas/grid/NonuniformGridBuilder.hh"
 
 #include "celeritas_test.hh"
 
@@ -24,7 +24,7 @@ namespace test
 // TEST HARNESS
 //---------------------------------------------------------------------------//
 
-class GenericCalculatorTest : public Test
+class NonuniformGridCalculatorTest : public Test
 {
   protected:
     template<class T>
@@ -35,7 +35,7 @@ class GenericCalculatorTest : public Test
 
     void build(Span<real_type const> x, Span<real_type const> y)
     {
-        GenericGridBuilder build_grid(&reals_);
+        NonuniformGridBuilder build_grid(&reals_);
         grid_ = build_grid(x, y);
         reals_ref_ = reals_;
 
@@ -43,7 +43,7 @@ class GenericCalculatorTest : public Test
         CELER_ENSURE(!reals_ref_.empty());
     }
 
-    GenericGridRecord grid_;
+    NonuniformGridRecord grid_;
     Items<real_type> reals_;
     ItemRef<real_type> reals_ref_;
 };
@@ -52,12 +52,12 @@ class GenericCalculatorTest : public Test
 // TESTS
 //---------------------------------------------------------------------------//
 
-TEST_F(GenericCalculatorTest, nonmonotonic)
+TEST_F(NonuniformGridCalculatorTest, nonmonotonic)
 {
     static real_type const grid[] = {1.0, 2.0, 1e2, 1e4};
     static real_type const value[] = {4.0, 8.0, 8.0, 2.0};
     this->build(grid, value);
-    GenericCalculator calc(grid_, reals_ref_);
+    NonuniformGridCalculator calc(grid_, reals_ref_);
 
     // Test accessing tabulated data
     EXPECT_EQ(4.0, calc[0]);
@@ -78,13 +78,13 @@ TEST_F(GenericCalculatorTest, nonmonotonic)
     EXPECT_SOFT_EQ(2.0, calc(1e7));
 }
 
-TEST_F(GenericCalculatorTest, inverse)
+TEST_F(NonuniformGridCalculatorTest, inverse)
 {
     static real_type const grid[] = {0.5, 1.0, 2.0, 4.0};
     static real_type const value[] = {-1, 0, 1, 2};
     this->build(grid, value);
 
-    auto calc = GenericCalculator::from_inverse(grid_, reals_ref_);
+    auto calc = NonuniformGridCalculator::from_inverse(grid_, reals_ref_);
     EXPECT_SOFT_EQ(0.5, calc(-2));
     EXPECT_SOFT_EQ(0.5, calc(-1));
     EXPECT_SOFT_EQ(0.75, calc(-0.5));

--- a/test/celeritas/grid/NonuniformGridInserter.test.cc
+++ b/test/celeritas/grid/NonuniformGridInserter.test.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/grid/GenericGridInserter.test.cc
+//! \file celeritas/grid/NonuniformGridInserter.test.cc
 //---------------------------------------------------------------------------//
-#include "celeritas/grid/GenericGridInserter.hh"
+#include "celeritas/grid/NonuniformGridInserter.hh"
 
 #include <array>
 
@@ -20,18 +20,18 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 
-class GenericGridInserterTest : public ::celeritas::test::Test
+class NonuniformGridInserterTest : public ::celeritas::test::Test
 {
   protected:
-    using GridIndexType = OpaqueId<struct GenericIndexTag_>;
+    using GridIndexType = OpaqueId<struct NonuniformIndexTag_>;
     using RandomEngine = DiagnosticRngEngine<std::mt19937>;
     using VecReal = std::vector<real_type>;
 
     void SetUp() override { rng_.reset_count(); }
 
-    GenericGridInserter<GridIndexType> make_inserter()
+    NonuniformGridInserter<GridIndexType> make_inserter()
     {
-        return GenericGridInserter<GridIndexType>(&scalars_, &grids_);
+        return NonuniformGridInserter<GridIndexType>(&scalars_, &grids_);
     }
 
     //! Construct an array of random, increasing data to test on
@@ -56,19 +56,19 @@ class GenericGridInserterTest : public ::celeritas::test::Test
         ASSERT_TRUE(id);
         ASSERT_LT(id.get(), grids_.size());
 
-        GenericGridRecord const& grid = grids_[id];
+        NonuniformGridRecord const& grid = grids_[id];
         EXPECT_VEC_EQ(xs, scalars_[grid.grid]);
         EXPECT_VEC_EQ(ys, scalars_[grid.value]);
     }
 
     Collection<real_type, Ownership::value, MemSpace::host> scalars_;
-    Collection<GenericGridRecord, Ownership::value, MemSpace::host, GridIndexType>
+    Collection<NonuniformGridRecord, Ownership::value, MemSpace::host, GridIndexType>
         grids_;
 
     RandomEngine rng_;
 };
 
-TEST_F(GenericGridInserterTest, simple)
+TEST_F(NonuniformGridInserterTest, simple)
 {
     constexpr size_t count = 105;
     auto const xs = build_random_array(count, -100.0);
@@ -84,7 +84,7 @@ TEST_F(GenericGridInserterTest, simple)
     check_grid(grid_index, xs, ys);
 }
 
-TEST_F(GenericGridInserterTest, many_no_repeats)
+TEST_F(NonuniformGridInserterTest, many_no_repeats)
 {
     constexpr size_t count = 58;
     auto inserter = make_inserter();
@@ -115,7 +115,7 @@ TEST_F(GenericGridInserterTest, many_no_repeats)
     }
 }
 
-TEST_F(GenericGridInserterTest, many_with_repeats)
+TEST_F(NonuniformGridInserterTest, many_with_repeats)
 {
     constexpr size_t count = 75;
     auto inserter = make_inserter();

--- a/test/celeritas/neutron/NeutronElastic.test.cc
+++ b/test/celeritas/neutron/NeutronElastic.test.cc
@@ -10,7 +10,6 @@
 #include "corecel/data/Ref.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Quantities.hh"
-#include "celeritas/grid/GenericGridData.hh"
 #include "celeritas/io/NeutronXsReader.hh"
 #include "celeritas/mat/MaterialTrackView.hh"
 #include "celeritas/neutron/NeutronTestBase.hh"

--- a/test/celeritas/neutron/NeutronInelastic.test.cc
+++ b/test/celeritas/neutron/NeutronInelastic.test.cc
@@ -11,7 +11,7 @@
 #include "corecel/grid/TwodGridCalculator.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "celeritas/Quantities.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/NonuniformGridData.hh"
 #include "celeritas/io/NeutronXsReader.hh"
 #include "celeritas/mat/MaterialTrackView.hh"
 #include "celeritas/neutron/NeutronTestBase.hh"
@@ -79,7 +79,7 @@ TEST_F(NeutronInelasticTest, micro_xs)
     // Check the size of the element cross section data (G4PARTICLEXS4.0)
     // The neutron/inelZ data are pruned by a factor of 5 for this test
     NeutronInelasticRef shared = model_->host_ref();
-    GenericGridRecord grid = shared.micro_xs[el_id];
+    NonuniformGridRecord grid = shared.micro_xs[el_id];
     EXPECT_EQ(grid.grid.size(), 61);
 
     // Microscopic cross section (units::BarnXs) in [1e-04:1e+4] (MeV)

--- a/test/celeritas/optical/ValidationUtils.cc
+++ b/test/celeritas/optical/ValidationUtils.cc
@@ -41,7 +41,7 @@ GridAccessor::operator()(ItemRange<real_type> const& real_ids) const
  * Retrieve a table of grid views built on the storage.
  *
  * Each grid view is a pair of spans representing the grid and value of a
- * \c GenericGridRecord.
+ * \c NonuniformGridRecord.
  */
 auto GridAccessor::operator()(ItemRange<Grid> grid_ids) const
     -> std::vector<GridView>

--- a/test/celeritas/optical/ValidationUtils.hh
+++ b/test/celeritas/optical/ValidationUtils.hh
@@ -13,7 +13,7 @@
 #include "corecel/cont/Span.hh"
 #include "corecel/data/Collection.hh"
 #include "celeritas/UnitTypes.hh"
-#include "celeritas/grid/GenericGridData.hh"
+#include "celeritas/grid/NonuniformGridData.hh"
 #include "celeritas/io/ImportPhysicsVector.hh"
 #include "celeritas/optical/MfpBuilder.hh"
 
@@ -72,7 +72,7 @@ class GridAccessor
   public:
     //!@{
     //! \name Type aliases
-    using Grid = GenericGridRecord;
+    using Grid = NonuniformGridRecord;
     using GridId = OpaqueId<Grid>;
     using ImportPhysicsTable = std::vector<ImportPhysicsVector>;
     using GridView = std::tuple<Span<real_type const>, Span<real_type const>>;

--- a/test/celeritas/optical/WavelengthShift.test.cc
+++ b/test/celeritas/optical/WavelengthShift.test.cc
@@ -9,7 +9,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/math/Quantity.hh"
 #include "celeritas/UnitTypes.hh"
-#include "celeritas/grid/GenericCalculator.hh"
+#include "celeritas/grid/NonuniformGridCalculator.hh"
 #include "celeritas/io/ImportOpticalMaterial.hh"
 #include "celeritas/optical/WavelengthShiftParams.hh"
 #include "celeritas/optical/interactor/WavelengthShiftInteractor.hh"
@@ -87,7 +87,8 @@ TEST_F(WavelengthShiftTest, data)
     // Test the vector property (emission spectrum) of WLS
 
     // Test the energy range and spectrum of emitted photons
-    GenericCalculator calc_cdf(data_.energy_cdf[material_id_], data_.reals);
+    NonuniformGridCalculator calc_cdf(data_.energy_cdf[material_id_],
+                                      data_.reals);
     auto const& energy = calc_cdf.grid();
     EXPECT_EQ(5, energy.size());
     EXPECT_SOFT_EQ(1.65e-6, energy.front());


### PR DESCRIPTION
This updates the name of the nonuniform grid data and associated classes.