### PR TITLE
Add G4Ellipsoid without bottom/top cuts

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -360,8 +360,20 @@ auto SolidConverter::displaced(arg_type solid_base) -> result_type
 auto SolidConverter::ellipsoid(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4Ellipsoid const&>(solid_base);
-    CELER_DISCARD(solid);
-    CELER_NOT_IMPLEMENTED("ellipsoid");
+
+    auto rad_z = solid.GetSemiAxisMax(to_int(Axis::z));
+
+    if (!(soft_equal(-rad_z, solid.GetZBottomCut())
+          && soft_equal(rad_z, solid.GetZTopCut())))
+    {
+        CELER_NOT_IMPLEMENTED("ellipsoids with bottom/top cuts");
+    }
+
+    auto radii = scale_.to<Real3>(solid.GetSemiAxisMax(to_int(Axis::x)),
+                                  solid.GetSemiAxisMax(to_int(Axis::y)),
+                                  rad_z);
+
+    return make_shape<Ellipsoid>(solid, radii);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -237,6 +237,14 @@ TEST_F(SolidConverterTest, displaced)
         {{1, 2, 3}, {2, 2, 3}, {3, 0, 0}});
 }
 
+TEST_F(SolidConverterTest, ellipsoid)
+{
+    this->build_and_test(
+        G4Ellipsoid("testEllipsoid", 10 * cm, 20 * cm, 30 * cm),
+        R"json({"_type":"shape","interior":{"_type":"ellipsoid","radii":[10.0,20.0,30.0]},"label":"testEllipsoid"})json",
+        {{0., 0., 0.}, {9.95, 19.95, 29.95}, {10.05, 20.05, 30.05}});
+}
+
 TEST_F(SolidConverterTest, generictrap)
 {
     this->build_and_test(G4GenericTrap("boxGenTrap",


### PR DESCRIPTION
This small MR adds supports for `G4Ellipsoids` in the case where there is no top/bottom cut. `G4Ellipsoids` and `G4EllipticalCones` can be truncated by top/bottom z-planes, instead of being truncated by an azimuthal wedge like other solids. I can certainly add support for these cuts, but I figured I'd punt until we can formulate a plan that will work for other solids with additional arguments as well. For example `G4CutTubs` can be truncated both with an azimuthal wedge and non-axis-aligned top/bottom planes.