### PR TITLE
Prune primaries that start outside the world volume

### DIFF
--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -171,7 +171,7 @@ void LocalTransporter::InitializeEvent(int id)
     CELER_EXPECT(id >= 0);
 
     event_id_ = id_cast<UniqueEventId>(id);
-    ++accum_num_events_;
+    ++run_accum_.events;
 
     if (!(G4Threading::IsMultithreadedApplication()
           && G4MTRunManager::SeedOncePerCommunication()))
@@ -221,7 +221,7 @@ void LocalTransporter::Push(G4Track const& g4track)
     track.event_id = EventId{0};
 
     buffer_.push_back(track);
-    buffer_energy_ += track.energy.value();
+    buffer_accum_.energy += track.energy.value();
     if (buffer_.size() >= auto_flush_)
     {
         /*!
@@ -268,7 +268,8 @@ void LocalTransporter::Flush()
     {
         CELER_LOG_LOCAL(debug)
             << "Transporting " << buffer_.size() << " tracks ("
-            << buffer_energy_ << " MeV cumulative kinetic energy) from event "
+            << buffer_accum_.energy
+            << " MeV cumulative kinetic energy) from event "
             << event_id_.unchecked_get() << " with Celeritas";
     }
 
@@ -289,11 +290,11 @@ void LocalTransporter::Flush()
 
     // Copy buffered tracks to device and transport the first step
     auto track_counts = (*step_)(make_span(buffer_));
-    accum_num_steps_ += track_counts.active;
-    accum_num_primaries_ += buffer_.size();
+    run_accum_.steps += track_counts.active;
+    run_accum_.primaries += buffer_.size();
 
     buffer_.clear();
-    buffer_energy_ = 0;
+    buffer_accum_ = {};
 
     size_type step_iters = 1;
 
@@ -306,7 +307,7 @@ void LocalTransporter::Flush()
                                       *step_);
 
         track_counts = (*step_)();
-        accum_num_steps_ += track_counts.active;
+        run_accum_.steps += track_counts.active;
         ++step_iters;
 
         CELER_VALIDATE_OR_KILL_ACTIVE(
@@ -328,9 +329,9 @@ void LocalTransporter::Finalize()
                    << "offloaded tracks (" << buffer_.size()
                    << " in buffer) were not flushed");
 
-    CELER_LOG_LOCAL(info) << "Finalizing Celeritas after " << accum_num_steps_
-                          << " steps from " << accum_num_primaries_
-                          << " offloaded tracks over " << accum_num_events_
+    CELER_LOG_LOCAL(info) << "Finalizing Celeritas after " << run_accum_.steps
+                          << " steps from " << run_accum_.primaries
+                          << " offloaded tracks over " << run_accum_.events
                           << " events";
 
     if constexpr (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_GEANT4)

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -23,6 +23,7 @@
 
 #include "corecel/Config.hh"
 
+#include "corecel/cont/ArrayIO.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Device.hh"
@@ -96,6 +97,7 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
                       "offloading is disabled");
     particles_ = params.Params()->particle();
     CELER_ASSERT(particles_);
+    bbox_ = params.bbox();
 
     auto thread_id = get_geant_thread_id();
     CELER_VALIDATE(thread_id >= 0,
@@ -191,6 +193,23 @@ void LocalTransporter::Push(G4Track const& g4track)
 {
     CELER_EXPECT(*this);
 
+    if (Real3 pos = convert_from_geant(g4track.GetPosition(), 1);
+        !is_inside(bbox_, pos))
+    {
+        // Primary may have been created by a particle generator outside the
+        // geometry
+        double energy = g4track.GetKineticEnergy() / CLHEP::MeV;
+        CELER_LOG(debug)
+            << "Discarding track outside world: " << energy << " MeV from "
+            << g4track.GetDefinition()->GetParticleName() << " at " << pos
+            << " along "
+            << convert_from_geant(g4track.GetMomentumDirection(), 1);
+
+        buffer_accum_.lost_energy += energy;
+        ++buffer_accum_.lost_primaries;
+        return;
+    }
+
     Primary track;
 
     PDGNumber const pdg{g4track.GetDefinition()->GetPDGEncoding()};
@@ -271,6 +290,15 @@ void LocalTransporter::Flush()
             << buffer_accum_.energy
             << " MeV cumulative kinetic energy) from event "
             << event_id_.unchecked_get() << " with Celeritas";
+    }
+    if (buffer_accum_.lost_primaries > 0)
+    {
+        CELER_LOG_LOCAL(warning)
+            << "Lost " << buffer_accum_.lost_energy
+            << " MeV cumulative kinetic energy from "
+            << buffer_accum_.lost_primaries
+            << " primaries that started outside the geometry in event "
+            << event_id_.unchecked_get();
     }
 
     if (dump_primaries_)

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -293,7 +293,7 @@ void LocalTransporter::Flush()
     }
     if (buffer_accum_.lost_primaries > 0)
     {
-        CELER_LOG_LOCAL(warning)
+        CELER_LOG_LOCAL(info)
             << "Lost " << buffer_accum_.lost_energy
             << " MeV cumulative kinetic energy from "
             << buffer_accum_.lost_primaries
@@ -320,6 +320,7 @@ void LocalTransporter::Flush()
     auto track_counts = (*step_)(make_span(buffer_));
     run_accum_.steps += track_counts.active;
     run_accum_.primaries += buffer_.size();
+    run_accum_.lost_primaries += buffer_accum_.lost_primaries;
 
     buffer_.clear();
     buffer_accum_ = {};
@@ -361,6 +362,12 @@ void LocalTransporter::Finalize()
                           << " steps from " << run_accum_.primaries
                           << " offloaded tracks over " << run_accum_.events
                           << " events";
+    if (run_accum_.lost_primaries > 0)
+    {
+        CELER_LOG_LOCAL(warning)
+            << "Lost a total of " << run_accum_.lost_primaries
+            << " primaries that started outside the world";
+    }
 
     if constexpr (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_GEANT4)
     {

--- a/src/accel/LocalTransporter.hh
+++ b/src/accel/LocalTransporter.hh
@@ -92,7 +92,23 @@ class LocalTransporter
     explicit operator bool() const { return static_cast<bool>(step_); }
 
   private:
+    //// TYPES ////
+
     using SPOffloadWriter = std::shared_ptr<detail::OffloadWriter>;
+
+    struct BufferAccum
+    {
+        double energy{0};
+    };
+
+    struct RunAccum
+    {
+        std::size_t events{0};
+        std::size_t primaries{0};
+        std::size_t steps{0};
+    };
+
+    //// DATA ////
 
     std::shared_ptr<ParticleParams const> particles_;
     std::shared_ptr<StepperInterface> step_;
@@ -105,11 +121,9 @@ class LocalTransporter
 
     size_type auto_flush_{};
     size_type max_step_iters_{};
-    double buffer_energy_{0};
 
-    std::size_t accum_num_events_{0};
-    std::size_t accum_num_primaries_{0};
-    std::size_t accum_num_steps_{0};
+    BufferAccum buffer_accum_;
+    RunAccum run_accum_;
 
     // Shared across threads to write flushed particles
     SPOffloadWriter dump_primaries_;

--- a/src/accel/LocalTransporter.hh
+++ b/src/accel/LocalTransporter.hh
@@ -13,6 +13,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/io/Logger.hh"
+#include "geocel/BoundingBox.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/Stepper.hh"
@@ -95,10 +96,13 @@ class LocalTransporter
     //// TYPES ////
 
     using SPOffloadWriter = std::shared_ptr<detail::OffloadWriter>;
+    using BBox = BoundingBox<double>;
 
     struct BufferAccum
     {
-        double energy{0};
+        double energy{0};  // MeV
+        double lost_energy{0};  // MeV
+        std::size_t lost_primaries{0};
     };
 
     struct RunAccum
@@ -106,11 +110,15 @@ class LocalTransporter
         std::size_t events{0};
         std::size_t primaries{0};
         std::size_t steps{0};
+        std::size_t lost_primaries{0};
     };
 
     //// DATA ////
 
     std::shared_ptr<ParticleParams const> particles_;
+    BBox bbox_;
+
+    // Thread-local data
     std::shared_ptr<StepperInterface> step_;
     std::vector<Primary> buffer_;
     std::shared_ptr<detail::HitProcessor> hit_processor_;

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "corecel/Assert.hh"
+#include "geocel/BoundingBox.hh"
 
 class G4ParticleDefinition;
 
@@ -131,6 +132,7 @@ class SharedParams
     using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
     using SPState = std::shared_ptr<CoreStateInterface>;
     using SPConstGeantGeoParams = std::shared_ptr<GeantGeoParams const>;
+    using BBox = BoundingBox<double>;
 
     //! Initialization status and integration mode
     Mode mode() const { return mode_; }
@@ -152,6 +154,9 @@ class SharedParams
 
     // Geant geometry wrapper, lazily created
     SPConstGeantGeoParams const& geant_geo_params() const;
+
+    // Geometry bounding box (CLHEP units)
+    BBox const& bbox() const { return bbox_; }
     //!@}
 
   private:
@@ -170,6 +175,7 @@ class SharedParams
     // Lazily created
     SPOutputRegistry output_reg_;
     SPConstGeantGeoParams geant_geo_;
+    BBox bbox_;
 
     //// HELPER FUNCTIONS ////
 


### PR DESCRIPTION
This does a quick comparison on a "primary" (offloaded track)'s position to the world solid's extents. If outside, it accumulates the lost energy for printing, and skips adding it to the buffer. When it flushes and at the end of the run, the amount of lost energy and number of primaries lost are printed. The detailed information about the primary can be viewed by  setting the local logging level to debug.