### PR TITLE
Support spline interpolation on a nonuniform grid

### DIFF
--- a/src/celeritas/grid/NonuniformGridBuilder.cc
+++ b/src/celeritas/grid/NonuniformGridBuilder.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "NonuniformGridBuilder.hh"
 
+#include "corecel/grid/VectorUtils.hh"
 #include "celeritas/io/ImportPhysicsVector.hh"
 
 namespace celeritas
@@ -15,7 +16,16 @@ namespace celeritas
  * Construct with pointers to data that will be modified.
  */
 NonuniformGridBuilder::NonuniformGridBuilder(Items<real_type>* reals)
-    : reals_{reals}
+    : NonuniformGridBuilder(reals, BC::size_)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with pointers to data and boundary condtions.
+ */
+NonuniformGridBuilder::NonuniformGridBuilder(Items<real_type>* reals, BC bc)
+    : values_(*reals), reals_{reals}, bc_(bc)
 {
     CELER_EXPECT(reals);
 }
@@ -65,6 +75,14 @@ auto NonuniformGridBuilder::insert_impl(Span<T const> grid,
     Grid result;
     result.grid = reals_.insert_back(grid.begin(), grid.end());
     result.value = reals_.insert_back(values.begin(), values.end());
+    if (bc_ != BC::size_)
+    {
+        // Calculate second derivatives for cubic spline interpolation
+        CELER_ASSERT(is_monotonic_increasing(grid));
+        auto deriv = SplineDerivCalculator(bc_)(values_[result.grid],
+                                                values_[result.value]);
+        result.derivative = reals_.insert_back(deriv.begin(), deriv.end());
+    }
 
     CELER_ENSURE(result);
     return result;

--- a/src/celeritas/grid/NonuniformGridBuilder.hh
+++ b/src/celeritas/grid/NonuniformGridBuilder.hh
@@ -10,6 +10,7 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/DedupeCollectionBuilder.hh"
 #include "corecel/grid/NonuniformGridData.hh"
+#include "corecel/grid/SplineDerivCalculator.hh"
 
 namespace celeritas
 {
@@ -27,6 +28,7 @@ class NonuniformGridBuilder
     //! \name Type aliases
     template<class T>
     using Items = Collection<T, Ownership::value, MemSpace::host>;
+    using BC = SplineDerivCalculator::BoundaryCondition;
     using Grid = NonuniformGridRecord;
     using SpanConstFlt = Span<float const>;
     using SpanConstDbl = Span<double const>;
@@ -35,6 +37,9 @@ class NonuniformGridBuilder
   public:
     // Construct with pointers to data that will be modified
     explicit NonuniformGridBuilder(Items<real_type>* reals);
+
+    // Construct with pointers to data and spline boundary conditions
+    NonuniformGridBuilder(Items<real_type>* reals, BC bc);
 
     // Add a grid of generic data with linear interpolation
     Grid operator()(SpanConstFlt grid, SpanConstFlt values);
@@ -46,7 +51,9 @@ class NonuniformGridBuilder
     Grid operator()(ImportPhysicsVector const&);
 
   private:
+    Items<real_type> const& values_;
     DedupeCollectionBuilder<real_type> reals_;
+    BC bc_;
 
     // Insert with floating point conversion if needed
     template<class T>

--- a/src/celeritas/grid/NonuniformGridCalculator.hh
+++ b/src/celeritas/grid/NonuniformGridCalculator.hh
@@ -88,6 +88,7 @@ class NonuniformGridCalculator
 CELER_FUNCTION NonuniformGridCalculator NonuniformGridCalculator::from_inverse(
     NonuniformGridRecord const& grid, Values const& reals)
 {
+    CELER_EXPECT(grid.derivative.empty());
     return NonuniformGridCalculator{reals, grid.value, grid.grid, {}};
 }
 
@@ -175,6 +176,7 @@ NonuniformGridCalculator::grid() const
 CELER_FUNCTION NonuniformGridCalculator
 NonuniformGridCalculator::make_inverse() const
 {
+    CELER_EXPECT(deriv_offset_.empty());
     return NonuniformGridCalculator{reals_, y_offset_, x_grid_.offset(), {}};
 }
 

--- a/src/celeritas/grid/NonuniformGridCalculator.hh
+++ b/src/celeritas/grid/NonuniformGridCalculator.hh
@@ -14,6 +14,7 @@
 #include "corecel/grid/Interpolator.hh"
 #include "corecel/grid/NonuniformGrid.hh"
 #include "corecel/grid/NonuniformGridData.hh"
+#include "corecel/grid/SplineInterpolator.hh"
 
 namespace celeritas
 {
@@ -67,13 +68,15 @@ class NonuniformGridCalculator
     Values const& reals_;
     Grid x_grid_;
     RealIds y_offset_;
+    RealIds deriv_offset_;
 
     //// HELPER FUNCTIONS ////
 
     // Private constructor implementation
     inline CELER_FUNCTION NonuniformGridCalculator(Values const& reals,
                                                    RealIds x_grid,
-                                                   RealIds y_grid);
+                                                   RealIds y_grid,
+                                                   RealIds deriv);
 };
 
 //---------------------------------------------------------------------------//
@@ -85,7 +88,7 @@ class NonuniformGridCalculator
 CELER_FUNCTION NonuniformGridCalculator NonuniformGridCalculator::from_inverse(
     NonuniformGridRecord const& grid, Values const& reals)
 {
-    return NonuniformGridCalculator{reals, grid.value, grid.grid};
+    return NonuniformGridCalculator{reals, grid.value, grid.grid, {}};
 }
 
 //---------------------------------------------------------------------------//
@@ -95,7 +98,7 @@ CELER_FUNCTION NonuniformGridCalculator NonuniformGridCalculator::from_inverse(
 CELER_FUNCTION
 NonuniformGridCalculator::NonuniformGridCalculator(
     NonuniformGridRecord const& grid, Values const& reals)
-    : NonuniformGridCalculator{reals, grid.grid, grid.value}
+    : NonuniformGridCalculator{reals, grid.grid, grid.value, grid.derivative}
 {
     CELER_EXPECT(grid);
 }
@@ -120,11 +123,25 @@ CELER_FUNCTION real_type NonuniformGridCalculator::operator()(real_type x) const
     size_type lower_idx = x_grid_.find(x);
     CELER_ASSERT(lower_idx + 1 < x_grid_.size());
 
-    // Interpolate *linearly* on x using the bin data.
-    LinearInterpolator<real_type> interpolate_xs(
-        {x_grid_[lower_idx], (*this)[lower_idx]},
-        {x_grid_[lower_idx + 1], (*this)[lower_idx + 1]});
-    return interpolate_xs(x);
+    real_type result;
+    if (deriv_offset_.empty())
+    {
+        // Interpolate *linearly* on x using the bin data.
+        result = LinearInterpolator<real_type>(
+            {x_grid_[lower_idx], (*this)[lower_idx]},
+            {x_grid_[lower_idx + 1], (*this)[lower_idx + 1]})(x);
+    }
+    else
+    {
+        // Use cubic spline interpolation
+        real_type lower_deriv = reals_[deriv_offset_[lower_idx]];
+        real_type upper_deriv = reals_[deriv_offset_[lower_idx + 1]];
+
+        result = SplineInterpolator<real_type>(
+            {x_grid_[lower_idx], (*this)[lower_idx], lower_deriv},
+            {x_grid_[lower_idx + 1], (*this)[lower_idx + 1], upper_deriv})(x);
+    }
+    return result;
 }
 
 //---------------------------------------------------------------------------//
@@ -152,11 +169,13 @@ NonuniformGridCalculator::grid() const
  * Make a calculator with x and y flipped.
  *
  * \pre The y values must be monotonic increasing.
+ *
+ * \note Spline interpolation will not be used on an inverse grid.
  */
 CELER_FUNCTION NonuniformGridCalculator
 NonuniformGridCalculator::make_inverse() const
 {
-    return NonuniformGridCalculator{reals_, y_offset_, x_grid_.offset()};
+    return NonuniformGridCalculator{reals_, y_offset_, x_grid_.offset(), {}};
 }
 
 //---------------------------------------------------------------------------//
@@ -168,12 +187,17 @@ NonuniformGridCalculator::make_inverse() const
 CELER_FUNCTION
 NonuniformGridCalculator::NonuniformGridCalculator(Values const& reals,
                                                    RealIds x_grid,
-                                                   RealIds y_grid)
-    : reals_{reals}, x_grid_{x_grid, reals_}, y_offset_{y_grid}
+                                                   RealIds y_grid,
+                                                   RealIds deriv)
+    : reals_{reals}
+    , x_grid_{x_grid, reals_}
+    , y_offset_{y_grid}
+    , deriv_offset_(deriv)
 {
     CELER_EXPECT(!x_grid.empty() && x_grid.size() == y_grid.size());
     CELER_EXPECT(*x_grid.end() <= reals_.size()
                  && *y_grid.end() <= reals_.size());
+    CELER_EXPECT(deriv.empty() || deriv.size() == x_grid.size());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/grid/NonuniformGridData.hh
+++ b/src/corecel/grid/NonuniformGridData.hh
@@ -13,17 +13,23 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * A grid of increasing, sorted 1D data with linear-linear interpolation.
+ * A grid of increasing, sorted 1D data.
+ *
+ * \c derivative stores the second derivative of the interpolating cubic
+ * spline. If it is non-empty, cubic spline interpolation will be used.
+ * Otherwise the interpolation will be linear-linear.
  */
 struct NonuniformGridRecord
 {
     ItemRange<real_type> grid;  //!< x grid
     ItemRange<real_type> value;  //!< f(x) value
+    ItemRange<real_type> derivative;
 
     //! Whether the record is initialized and valid
     explicit CELER_FUNCTION operator bool() const
     {
-        return grid.size() >= 2 && value.size() == grid.size();
+        return grid.size() >= 2 && value.size() == grid.size()
+               && (derivative.empty() || grid.size() == derivative.size());
     }
 };
 


### PR DESCRIPTION
This is a little update to support cubic spline interpolation on a nonuniform grid, which could be used e.g. for the Livermore photoelectric cross sections.