### PR TITLE
Fix crash in multithreaded celer-g4

### DIFF
--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -229,6 +229,7 @@ auto DetectorConstruction::construct_field() const -> FieldData
     }
 
     CELER_VALIDATE(false, << "invalid field type '" << field_type << "'");
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/PGPrimaryGeneratorAction.hh
+++ b/app/celer-g4/PGPrimaryGeneratorAction.hh
@@ -47,10 +47,9 @@ class PGPrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
   private:
     using GeneratorImpl = celeritas::PrimaryGenerator;
 
-    GeneratorImpl::SPConstParticles particle_params_;
+    std::vector<PDGNumber> pdg_;
     GeneratorImpl generate_primaries_;
     G4ParticleGun gun_;
-    std::vector<G4ParticleDefinition*> particle_def_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PrimaryGenerator.cc
+++ b/src/celeritas/phys/PrimaryGenerator.cc
@@ -81,6 +81,7 @@ std::vector<ParticleId> make_particle_ids(std::vector<PDGNumber> const& pdgs,
                                           ParticleParams const& particles)
 {
     std::vector<ParticleId> result;
+    result.reserve(pdgs.size());
     for (auto const& pdg : pdgs)
     {
         result.push_back(particles.find(pdg));

--- a/src/celeritas/phys/PrimaryGenerator.cc
+++ b/src/celeritas/phys/PrimaryGenerator.cc
@@ -6,7 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "PrimaryGenerator.hh"
 
-#include <random>
+#include <utility>
 
 #include "corecel/cont/Range.hh"
 #include "corecel/cont/VariantUtils.hh"
@@ -74,6 +74,21 @@ auto make_direction_sampler(inp::AngleDistribution const& i)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Get a vector of particle IDs from PDG number.
+ */
+std::vector<ParticleId> make_particle_ids(std::vector<PDGNumber> const& pdgs,
+                                          ParticleParams const& particles)
+{
+    std::vector<ParticleId> result;
+    for (auto const& pdg : pdgs)
+    {
+        result.push_back(particles.find(pdg));
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace
 
 //---------------------------------------------------------------------------//
@@ -95,28 +110,34 @@ PrimaryGenerator::from_options(SPConstParticles particles,
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct with options and shared particle data.
+ * Construct with options and particle IDs.
  */
 PrimaryGenerator::PrimaryGenerator(Input const& i,
-                                   ParticleParams const& particles)
+                                   std::vector<ParticleId> particle_id)
     : num_events_{i.num_events}
     , primaries_per_event_{i.primaries_per_event}
     , seed_{i.seed}
     , sample_energy_{make_energy_sampler(i.energy)}
     , sample_pos_{make_position_sampler(i.shape)}
     , sample_dir_{make_direction_sampler(i.angle)}
+    , particle_id_(std::move(particle_id))
 {
     // TODO: seed based on event
     this->seed(UniqueEventId{0});
 
-    particle_id_.reserve(i.pdg.size());
-    for (auto const& pdg : i.pdg)
-    {
-        particle_id_.push_back(particles.find(pdg));
-    }
     CELER_VALIDATE(
         std::all_of(particle_id_.begin(), particle_id_.end(), LogicalTrue{}),
         << R"(invalid or missing particle types specified for primary generator)");
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with options and shared particle data.
+ */
+PrimaryGenerator::PrimaryGenerator(Input const& i,
+                                   ParticleParams const& particles)
+    : PrimaryGenerator(i, make_particle_ids(i.pdg, particles))
+{
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PrimaryGenerator.hh
+++ b/src/celeritas/phys/PrimaryGenerator.hh
@@ -62,6 +62,9 @@ class PrimaryGenerator : public EventReaderInterface
     // Construct from shared particle data and new input
     PrimaryGenerator(Input const&, ParticleParams const& particles);
 
+    // Construct from particle IDs and new input
+    PrimaryGenerator(Input const&, std::vector<ParticleId> particle_ids);
+
     //! Prevent copying and moving
     CELER_DELETE_COPY_MOVE(PrimaryGenerator);
     ~PrimaryGenerator() override = default;

--- a/src/celeritas/phys/PrimaryGeneratorOptions.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.cc
@@ -62,6 +62,7 @@ inp::EnergyDistribution inp_from_energy(DistributionOptions const& options)
                            << to_cstring(options.distribution) << "' for "
                            << sampler_name);
     }
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//
@@ -84,6 +85,7 @@ inp::ShapeDistribution inp_from_position(DistributionOptions const& options)
                            << to_cstring(options.distribution) << "' for "
                            << sampler_name);
     }
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//
@@ -105,6 +107,7 @@ inp::AngleDistribution inp_from_direction(DistributionOptions const& options)
                            << to_cstring(options.distribution) << "' for "
                            << sampler_name);
     }
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/OrangeInputIOImpl.json.cc
+++ b/src/orange/detail/OrangeInputIOImpl.json.cc
@@ -83,6 +83,7 @@ VariantTransform import_transform(nlohmann::json const& src)
                        << "invalid number of elements in transform: "
                        << data.size());
     }
+    CELER_ASSERT_UNREACHABLE();
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Multithreaded celer-g4 using the primary generator was crashing because the `PGPrimaryGeneratorAction` created a `ParticleParams` (which uses the not-thread-safe `ScopedMem` in the constructor) on each thread. Rather than use the `ParticleParams` in the Geant4 generator, this adds a constructor to the Celeritas `PrimaryGenerator` that takes particle IDs.