### PR TITLE
Require VecGeom 1.2.10 for CUDA RDC support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,7 +392,15 @@ if(CELERITAS_USE_ROOT)
 endif()
 
 if(CELERITAS_USE_VecGeom)
-  set(_min_vecgeom_version 1.2.10)
+  if(CELERITAS_USE_CUDA)
+    # 1.2.10 is needed due to the `no-as-needed` link feature
+    # requiring VecGeom to be build with a distinct object
+    # and final libraries
+    set(_min_vecgeom_version 1.2.10)
+  else()
+    # 1.2.8 is needed due to G4VG, which needs the logger.
+    set(_min_vecgeom_version 1.2.8)
+  endif()
   if(NOT VecGeom_FOUND)
     find_package(VecGeom ${_min_vecgeom_version} REQUIRED)
   elseif(VecGeom_VERSION VERSION_LESS _min_vecgeom_version)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,7 +392,7 @@ if(CELERITAS_USE_ROOT)
 endif()
 
 if(CELERITAS_USE_VecGeom)
-  set(_min_vecgeom_version 1.2.8)
+  set(_min_vecgeom_version 1.2.10)
   if(NOT VecGeom_FOUND)
     find_package(VecGeom ${_min_vecgeom_version} REQUIRED)
   elseif(VecGeom_VERSION VERSION_LESS _min_vecgeom_version)

--- a/scripts/docker/dev/rocky-cuda12.yaml
+++ b/scripts/docker/dev/rocky-cuda12.yaml
@@ -11,7 +11,7 @@ spack:
   - nlohmann-json
   - "python@3.6:"
   - "root@6.28: cxxstd=20"
-  - "vecgeom@1.2.8: +gdml cxxstd=20"
+  - "vecgeom@1.2.10: +gdml cxxstd=20"
   concretizer:
     unify: true
   packages:

--- a/scripts/docker/interactive/spack.yaml
+++ b/scripts/docker/interactive/spack.yaml
@@ -6,7 +6,7 @@ spack:
     - hepmc3
     - nlohmann-json
     - "root@6.24:"
-    - "vecgeom@1.2.8: +gdml"
+    - "vecgeom@1.2.10: +gdml"
   view: true
   concretizer:
     unify: true

--- a/scripts/spack.yaml
+++ b/scripts/spack.yaml
@@ -19,7 +19,7 @@ spack:
     - py-sphinxcontrib-bibtex
     - py-sphinxcontrib-mermaid
     - "root@6.28:"
-    - "vecgeom@1.2.8: +gdml"
+    - "vecgeom@1.2.10: +gdml"
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
With VecGeom 1.2.9, we get the following error:

```
CMake Error at /home/pcanal/geant/gcc13/build/celeritas/_deps/g4vg-src/test/CMakeLists.txt:17 (add_executable):
  Impossible to link target 'g4vg_test' because the link item
  'VecGeom::vecgeomcuda', specified with the feature 'rdc_no_as_needed', has
  already occurred without any feature or 'DEFAULT' feature, which is not
  allowed.
```

In that version (and older) the RDC ‘final’ library and the ‘object’ library are combined under one name and thus the final library is used without the link feature (when handled as the ‘object’ library) and with the link feature (when handled as the ’final library) leading to the error.

