### PR TITLE
Update externals and enforce G4VG version

### DIFF
--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Patch spack # To be deleted; see associated github pulls
         working-directory: spack-src
         run: |
-          for id in 48328 48332 48347 48844 49003 49195; do
+          for id in 48328 48332 48347 48844 49003 49110 49195; do
             curl -LfsS "https://github.com/spack/spack/pull/${id}.diff" | patch -p1
           done
       - name: Initialize spack environment

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -82,11 +82,9 @@ jobs:
       - name: Patch spack # To be deleted; see associated github pulls
         working-directory: spack-src
         run: |
-          curl -LfsS https://github.com/spack/spack/pull/48328.diff | patch -p1
-          curl -LfsS https://github.com/spack/spack/pull/48332.diff | patch -p1
-          curl -LfsS https://github.com/spack/spack/pull/48347.diff | patch -p1
-          curl -LfsS https://github.com/spack/spack/pull/48844.diff | patch -p1
-          curl -LfsS https://github.com/spack/spack/pull/49003.diff | patch -p1
+          for id in 48328 48332 48347 48844 49003 49195; do
+            curl -LfsS "https://github.com/spack/spack/pull/${id}.diff" | patch -p1
+          done
       - name: Initialize spack environment
         run: |
           sed -e 's/cxxstd=default/cxxstd=${{env.CXXSTD}}/' \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ if(CELERITAS_USE_CUDA)
     "Set to CMAKE_CXX_COMPILER by Celeritas CMakeLists"
   )
 endif()
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 ### Linking flags ###
 celeritas_set_default(BUILD_SHARED_LIBS ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,8 @@ if(CELERITAS_USE_VecGeom)
     set(VecGeom_LIBRARIES VecGeom::vecgeom)
   endif()
   if(CELERITAS_USE_Geant4)
-    celeritas_find_or_builtin_package(G4VG)
+    # Enforce minimum version
+    celeritas_find_or_builtin_package(G4VG 1.0.3)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 cmake_minimum_required(VERSION 3.18...3.31)
 
-# Set Celeritas_VERSION using git tags using the following format
-set(CGV_TAG_REGEX "v([0-9.]+)(-dev|-rc\\.[0-9]+)?")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/CgvFindVersion.cmake")
 cgv_find_version(Celeritas)
 

--- a/cmake/CgvFindVersion.cmake
+++ b/cmake/CgvFindVersion.cmake
@@ -42,8 +42,9 @@ CgvFindVersion
   *before* calling the CMake ``project`` command.
 
   The project version string uses an approximation to SemVer strings, appearing
-  as v0.1.2 if the version is actually a tagged release, or v0.1.3+abcdef if
-  it's not.
+  as v0.1.2 if the version is actually a tagged release, or v0.1.3-2+abcdef if
+  it's not. Pre-releases should be tagged as v1.0.0-rc.1, and subsequent commits
+  will show as v1.0.0-rc.1.23+abc123.
 
   If a non-tagged version is exported, or an untagged shallow git clone is used,
   it's impossible to determine the version from the tag, so a warning will be
@@ -79,9 +80,50 @@ function(_cgv_store_version string suffix hash)
   set(_CACHED_VERSION "${string}" "${suffix}" "${hash}")
   # Note: extra 'unset' is necessary if using CMake presets with
   # ${CGV_PROJECT}_GIT_DESCRIBE="", even with INTERNAL/FORCE
-  unset(${CGV_CACHE_VAR} CACHE)
-  set(${CGV_CACHE_VAR} "${_CACHED_VERSION}" CACHE INTERNAL
+  unset("${CGV_CACHE_VAR}" CACHE)
+  set("${CGV_CACHE_VAR}" "${_CACHED_VERSION}" CACHE INTERNAL
     "Version string and hash for ${CGV_PROJECT}")
+endfunction()
+
+#-----------------------------------------------------------------------------#
+# Process description tag: e.g. v0.4.0-2-gc4af497 or v0.4.0 or v2.0.0-rc.2
+
+function(_cgv_try_parse_git_describe version_string)
+  # Regex groups:
+  #  1: primary version (1.2.3)
+  #  2: pre-release: dev/alpha/rc annotation (-rc.1)
+  #  3: post-tag description (-123-gabcd123)
+  #  4: number of commits since (aka distance to) tag (123)
+  #  5: commit hash (abcd213)
+  set(_DESCR_REGEX "^${CGV_TAG_REGEX}(-([0-9]+)-g([0-9a-f]+))?")
+  string(REGEX MATCH "${_DESCR_REGEX}" _MATCH "${version_string}")
+  if(NOT _MATCH)
+    message(WARNING
+      "Failed to parse description '${version_string}' with regex '${_DESCR_REGEX}'"
+    )
+    return()
+  endif()
+
+  if(NOT CMAKE_MATCH_3)
+    # This is a tagged release!
+    _cgv_store_version("${CMAKE_MATCH_1}" "${CMAKE_MATCH_2}" "")
+    return()
+  endif()
+
+  if(CMAKE_MATCH_2)
+    # After a pre-release, e.g. -rc.1
+    set(_prerelease "${CMAKE_MATCH_2}.${CMAKE_MATCH_4}")
+  else()
+    # After a release, e.g. -123
+    set(_prerelease "-${CMAKE_MATCH_4}")
+  endif()
+
+  # Qualify the version number with the distance-to-tag and hash
+  _cgv_store_version(
+    "${CMAKE_MATCH_1}" # 1.2.3
+    "${_prerelease}" # -rc.2.3, -beta.1, -123
+    "${CMAKE_MATCH_5}" # abcdef
+  )
 endfunction()
 
 #-----------------------------------------------------------------------------#
@@ -92,23 +134,38 @@ function(_cgv_try_archive_md)
   set(_ARCHIVE_DESCR "$Format:%(describe:tags)$")
   set(_ARCHIVE_TAG "$Format:%D$")
   set(_ARCHIVE_HASH "$Format:%h$")
-  if(_ARCHIVE_HASH MATCHES "Format:%h")
+  if(_ARCHIVE_HASH MATCHES "^\\$.*\\$$")
     # Not a git archive
     return()
+  endif()
+
+  if(_ARCHIVE_DESCR)
+    _cgv_try_parse_git_describe("${_ARCHIVE_DESCR}")
+    if(${CGV_CACHE_VAR})
+      # Successfully parsed description
+      return()
+    endif()
   endif()
 
   string(REGEX MATCH "tag: *${CGV_TAG_REGEX}" _MATCH "${_ARCHIVE_TAG}")
   if(_MATCH)
     _cgv_store_version("${CMAKE_MATCH_1}" "${CMAKE_MATCH_2}" "")
-  else()
-    message(WARNING "Could not match a version tag for "
-      "git description '${_ARCHIVE_TAG}': perhaps this archive was not "
-      "exported from a tagged commit?")
-    string(REGEX MATCH " *([0-9a-f]+)" _MATCH "${_ARCHIVE_HASH}")
-    if(_MATCH)
-      _cgv_store_version("" "" "${CMAKE_MATCH_1}")
-    endif()
+    return()
   endif()
+
+  message(WARNING
+    "Could not match a version tag for "
+    "git description '${_ARCHIVE_TAG}': perhaps this archive was not "
+    "exported from a tagged commit?"
+  )
+  string(REGEX MATCH " *([0-9a-f]+)" _MATCH "${_ARCHIVE_HASH}")
+  if(NOT _MATCH)
+    # Could not even find a git hash
+    return()
+  endif()
+
+  # Found a hash but no version
+  _cgv_store_version("" "" "${CMAKE_MATCH_1}")
 endfunction()
 
 #-----------------------------------------------------------------------------#
@@ -133,8 +190,7 @@ function(_cgv_try_git_describe)
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if(_GIT_RESULT)
-    message(WARNING "No git tags in ${CGV_PROJECT} matched 'v*': "
-      "${_GIT_ERR}")
+    message(WARNING "No git tags in ${CGV_PROJECT} matched 'v*': ${_GIT_ERR}")
     return()
   elseif(NOT _VERSION_STRING)
     message(WARNING "Failed to get ${CGV_PROJECT} version from git: "
@@ -142,32 +198,7 @@ function(_cgv_try_git_describe)
     return()
   endif()
 
-  # Process description tag: e.g. v0.4.0-2-gc4af497 or v0.4.0 or v2.0.0-rc.2
-  set(_DESCR_REGEX "^${CGV_TAG_REGEX}(-([0-9]+)-g([0-9a-f]+))?")
-  string(REGEX MATCH "${_DESCR_REGEX}" _MATCH "${_VERSION_STRING}")
-  if(NOT _MATCH)
-    message(WARNING "Failed to parse description '${_VERSION_STRING}' "
-      "with regex '${_DESCR_REGEX}'"
-    )
-    return()
-  endif()
-
-  if(NOT CMAKE_MATCH_3)
-    # This is a tagged release!
-    _cgv_store_version("${CMAKE_MATCH_1}" "${CMAKE_MATCH_2}" "")
-  else()
-    if(CMAKE_MATCH_2)
-      set(_suffix ${CMAKE_MATCH_2}.${CMAKE_MATCH_4})
-    else()
-      set(_suffix -${CMAKE_MATCH_4})
-    endif()
-    # Qualify the version number and save the hash
-    _cgv_store_version(
-      "${CMAKE_MATCH_1}" # [0-9.]+
-      "${_suffix}" # (-dev[0-9.]*)? \. ([0-9]+)
-      "${CMAKE_MATCH_5}" ([0-9a-f]+)
-    )
-  endif()
+  _cgv_try_parse_git_describe("${_VERSION_STRING}")
 endfunction()
 
 #-----------------------------------------------------------------------------#
@@ -192,6 +223,31 @@ function(_cgv_try_git_hash)
   _cgv_store_version("" "" "${_VERSION_HASH}")
 endfunction()
 
+function(_cgv_try_all)
+  if(${CGV_CACHE_VAR})
+    # Previous configure already set the variable
+    return()
+  endif()
+
+  _cgv_try_archive_md()
+  if(${CGV_CACHE_VAR})
+    return()
+  endif()
+
+  _cgv_try_git_describe()
+  if(${CGV_CACHE_VAR})
+    return()
+  endif()
+
+  _cgv_try_git_hash()
+  if(${CGV_CACHE_VAR})
+    return()
+  endif()
+
+  # Fallback: no metadata detected
+  set(${CGV_CACHE_VAR} "" "-unknown" "")
+endfunction()
+
 #-----------------------------------------------------------------------------#
 
 function(cgv_find_version)
@@ -211,19 +267,8 @@ function(cgv_find_version)
 
   set(CGV_CACHE_VAR "${CGV_PROJECT}_GIT_DESCRIBE")
 
-  # Successively try archive metadata, git description, or just git hash
-  if(NOT ${CGV_CACHE_VAR})
-    _cgv_try_archive_md()
-    if(NOT ${CGV_CACHE_VAR})
-      _cgv_try_git_describe()
-      if(NOT ${CGV_CACHE_VAR})
-        _cgv_try_git_hash()
-        if(NOT ${CGV_CACHE_VAR})
-          set(${CGV_CACHE_VAR} "" "-unknown" "")
-        endif()
-      endif()
-    endif()
-  endif()
+  # Try all possible ways of obtaining metadata
+  _cgv_try_all()
 
   # Unpack stored version
   set(_CACHED_VERSION "${${CGV_CACHE_VAR}}")
@@ -262,4 +307,4 @@ if(CMAKE_SCRIPT_MODE_FILE)
   endif()
 endif()
 
-# cmake-git-version 1.1.2
+# cmake-git-version 1.1.3

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -30,6 +30,7 @@ if(CELERITAS_BUILTIN_nlohmann_json)
   FetchContent_Declare(
     nlohmann_json
     URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+    URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406
   )
   list(APPEND _celer_builtin_packages nlohmann_json)
 
@@ -59,6 +60,7 @@ if(CELERITAS_BUILTIN_G4VG)
   FetchContent_Declare(
     G4VG
     URL https://github.com/celeritas-project/g4vg/releases/download/v1.0.3/g4vg-1.0.3.tar.gz
+    URL_HASH SHA256=6f0920a9ad2e04a701bec636f117d4093be1e50761f091ec507efd078b659bcd
   )
   list(APPEND _celer_builtin_packages G4VG)
   foreach(_var BUILD_TESTS DEBUG)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -35,8 +35,9 @@ endif()
 if(CELERITAS_BUILTIN_nlohmann_json)
   FetchContent_Declare(
     nlohmann_json
-    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.gz
+    URL https://github.com/nlohmann/json/archive/v3.11.3.tar.gz
     URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406
+    DOWNLOAD_NO_PROGRESS TRUE
   )
   list(APPEND _celer_builtin_packages nlohmann_json)
 
@@ -54,6 +55,8 @@ if(CELERITAS_BUILTIN_Perfetto)
   FetchContent_Declare(
     Perfetto
     URL https://github.com/google/perfetto/archive/refs/tags/v49.0.tar.gz
+    URL_HASH SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    DOWNLOAD_NO_PROGRESS TRUE
   )
   list(APPEND _celer_builtin_packages Perfetto)
 endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 if(CELERITAS_BUILTIN_G4VG)
   FetchContent_Declare(
     G4VG
-    URL https://github.com/celeritas-project/g4vg/releases/download/v1.0.2/g4vg-1.0.2.tar.gz
+    URL https://github.com/celeritas-project/g4vg/releases/download/v1.0.3/g4vg-1.0.3.tar.gz
   )
   list(APPEND _celer_builtin_packages G4VG)
   foreach(_var BUILD_TESTS DEBUG)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 if(CELERITAS_BUILTIN_nlohmann_json)
   FetchContent_Declare(
     nlohmann_json
-    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.gz
     URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406
   )
   list(APPEND _celer_builtin_packages nlohmann_json)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -5,6 +5,10 @@
 
 set(_celer_builtin_packages)
 
+# Print extra information about downloading: hash failures, for example, are
+# silent otherwise
+set(CMAKE_MESSAGE_LOG_LEVEL VERBOSE)
+
 #-----------------------------------------------------------------------------#
 # GTest
 #-----------------------------------------------------------------------------#
@@ -13,6 +17,7 @@ if(CELERITAS_BUILTIN_GTest)
   FetchContent_Declare(
     GTest
     URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+    DOWNLOAD_NO_PROGRESS TRUE
   )
   list(APPEND _celer_builtin_packages GTest)
 
@@ -61,6 +66,7 @@ if(CELERITAS_BUILTIN_G4VG)
     G4VG
     URL https://github.com/celeritas-project/g4vg/releases/download/v1.0.3/g4vg-1.0.3.tar.gz
     URL_HASH SHA256=6f0920a9ad2e04a701bec636f117d4093be1e50761f091ec507efd078b659bcd
+    DOWNLOAD_NO_PROGRESS TRUE
   )
   list(APPEND _celer_builtin_packages G4VG)
   foreach(_var BUILD_TESTS DEBUG)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -16,7 +16,8 @@ set(CMAKE_MESSAGE_LOG_LEVEL VERBOSE)
 if(CELERITAS_BUILTIN_GTest)
   FetchContent_Declare(
     GTest
-    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+    URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz
+    URL_HASH SHA256=7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
     DOWNLOAD_NO_PROGRESS TRUE
   )
   list(APPEND _celer_builtin_packages GTest)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -3,24 +3,32 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 #-----------------------------------------------------------------------------#
 
-set(_celer_builtin_packages)
-
 # Print extra information about downloading: hash failures, for example, are
 # silent otherwise
 set(CMAKE_MESSAGE_LOG_LEVEL VERBOSE)
+
+# Download the package and add to a list
+set(_celer_builtin_packages)
+macro(celer_fetch_external name url sha)
+  FetchContent_Declare(
+    "${name}"
+    URL "${url}"
+    URL_HASH SHA256=${sha}
+    DOWNLOAD_NO_PROGRESS TRUE
+  )
+  list(APPEND _celer_builtin_packages "${name}")
+endmacro()
 
 #-----------------------------------------------------------------------------#
 # GTest
 #-----------------------------------------------------------------------------#
 
 if(CELERITAS_BUILTIN_GTest)
-  FetchContent_Declare(
+  celer_fetch_external(
     GTest
-    URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz
-    URL_HASH SHA256=7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
-    DOWNLOAD_NO_PROGRESS TRUE
+    "https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz"
+    7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
   )
-  list(APPEND _celer_builtin_packages GTest)
 
   set(BUILD_GMOCK OFF) # For compatibility
   set(INSTALL_GTEST OFF)
@@ -33,13 +41,11 @@ endif()
 #-----------------------------------------------------------------------------#
 
 if(CELERITAS_BUILTIN_nlohmann_json)
-  FetchContent_Declare(
+  celer_fetch_external(
     nlohmann_json
-    URL https://github.com/nlohmann/json/archive/v3.11.3.tar.gz
-    URL_HASH SHA256=0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406
-    DOWNLOAD_NO_PROGRESS TRUE
+    "https://github.com/nlohmann/json/archive/v3.11.3.tar.gz"
+    0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406
   )
-  list(APPEND _celer_builtin_packages nlohmann_json)
 
   set(JSON_Install ON)
 endif()
@@ -50,15 +56,13 @@ endif()
 
 if(CELERITAS_BUILTIN_Perfetto)
   if(PERFETTO_ROOT AND NOT FETCHCONTENT_SOURCE_DIR_PERFETTO)
-    set(FETCHCONTENT_SOURCE_DIR_PERFETTO ${PERFETTO_ROOT})
+    set(FETCHCONTENT_SOURCE_DIR_PERFETTO "${PERFETTO_ROOT}")
   endif()
-  FetchContent_Declare(
+  celer_fetch_external(
     Perfetto
-    URL https://github.com/google/perfetto/archive/refs/tags/v49.0.tar.gz
-    URL_HASH SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-    DOWNLOAD_NO_PROGRESS TRUE
+    "https://github.com/google/perfetto/archive/refs/tags/v49.0.tar.gz"
+    0871a92a162ac5655b7d724f9359b15a75c4e92472716edbc4227a64a4680be4
   )
-  list(APPEND _celer_builtin_packages Perfetto)
 endif()
 
 #-----------------------------------------------------------------------------#
@@ -66,13 +70,11 @@ endif()
 #-----------------------------------------------------------------------------#
 
 if(CELERITAS_BUILTIN_G4VG)
-  FetchContent_Declare(
+  celer_fetch_external(
     G4VG
-    URL https://github.com/celeritas-project/g4vg/releases/download/v1.0.3/g4vg-1.0.3.tar.gz
-    URL_HASH SHA256=6f0920a9ad2e04a701bec636f117d4093be1e50761f091ec507efd078b659bcd
-    DOWNLOAD_NO_PROGRESS TRUE
+    "https://github.com/celeritas-project/g4vg/releases/download/v1.0.3/g4vg-1.0.3.tar.gz"
+    6f0920a9ad2e04a701bec636f117d4093be1e50761f091ec507efd078b659bcd
   )
-  list(APPEND _celer_builtin_packages G4VG)
   foreach(_var BUILD_TESTS DEBUG)
     set(G4VG_${_var} CELERITAS_${_var})
   endforeach()

--- a/scripts/cmake-presets/ci-windows-github.json
+++ b/scripts/cmake-presets/ci-windows-github.json
@@ -30,7 +30,8 @@
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
         "CMAKE_CXX_FLAGS": "/W2 /WX",
         "CMAKE_CXX_STANDARD": "17",
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install"
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install",
+        "CMAKE_TLS_VERIFY":  {"type": "BOOL", "value": "OFF"}
       }
     },
     {


### PR DESCRIPTION
This updates the minimum required G4VG version to 1.0.3 (you may want to wait till https://github.com/spack/spack/pull/49195 is merged to update). It also sets the `CMAKE_CXX_SCAN_FOR_MODULES` variable to `OFF` to prevent extra build time since Celeritas does not consume or produce C++20 modules.