### PR TITLE
Increase ccache size for asanlite job

### DIFF
--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -51,7 +51,7 @@ jobs:
             geant: "11.2"
     env:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
-      CCACHE_MAXSIZE: "100Mi"
+      CCACHE_MAXSIZE: "${{matrix.special == 'asanlite' && '300' || '100'}}Mi"
       CMAKE_PRESET: >-
         ${{format('reldeb-{0}{1}{2}',
                   matrix.geometry,

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -51,7 +51,7 @@ jobs:
             geant: "11.2"
     env:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
-      CCACHE_MAXSIZE: "${{matrix.special == 'asanlite' && '300' || '100'}}Mi"
+      CCACHE_MAXSIZE: "${{matrix.special == 'asanlite' && '400' || '200'}}Mi"
       CMAKE_PRESET: >-
         ${{format('reldeb-{0}{1}{2}',
                   matrix.geometry,


### PR DESCRIPTION
The ccache size is too small for asanlite (which requires debug symbols) and windows.

https://github.com/celeritas-project/celeritas/actions/runs/13579213242/job/37962006131

```
Cacheable calls:    599 / 599 (100.0%)
  Hits:             187 / 599 (31.22%)
    Direct:          56 / 187 (29.95%)
    Preprocessed:   131 / 187 (70.05%)
  Misses:           412 / 599 (68.78%)
Local storage:
  Cache size (GiB): 0.1 / 0.1 (101.5%)
  Cleanups:         271
  Hits:             187 / 599 (31.22%)
  Misses:           412 / 599 (68.78%)
```