### PR TITLE
Support sensitive detectors in replica/parameterized volumes

### DIFF
--- a/src/celeritas/ext/detail/LevelTouchableUpdater.cc
+++ b/src/celeritas/ext/detail/LevelTouchableUpdater.cc
@@ -11,6 +11,7 @@
 #include <G4VTouchable.hh>
 
 #include "geocel/GeantGeoUtils.hh"
+#include "geocel/GeoParamsInterface.hh"
 #include "geocel/GeoTraits.hh"
 #include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
 #include "celeritas/user/DetectorSteps.hh"
@@ -60,23 +61,23 @@ bool LevelTouchableUpdater::operator()(SpanVolInst ids,
     CELER_EXPECT(touchable);
     CELER_EXPECT(!ids.empty() && ids.front());
 
-    // Update phys_vol_ from geometry and volume instance id
-    phys_vol_.clear();
+    // Update phys_inst_ from geometry and volume instance id
+    phys_inst_.clear();
     for (auto vi_id : ids)
     {
         if (!vi_id)
             break;
-        auto pv = geo_->id_to_pv(vi_id);
+        auto phys_inst = geo_->id_to_geant(vi_id);
         CELER_VALIDATE(
-            pv,
+            phys_inst,
             << "no Geant4 physical volume is attached to volume instance "
             << vi_id.get() << "='" << geo_->volume_instances().at(vi_id)
             << "' (geometry type: " << GeoTraits<GeoParams>::name << ')');
-        phys_vol_.push_back(pv);
+        phys_inst_.push_back(phys_inst);
     }
-    CELER_ASSERT(!phys_vol_.empty());
+    CELER_ASSERT(!phys_inst_.empty());
 
-    set_history(make_span(phys_vol_), nav_hist_.get());
+    set_history(make_span(phys_inst_), nav_hist_.get());
     touchable->UpdateYourself(nav_hist_->GetTopVolume(), nav_hist_.get());
     return true;
 }

--- a/src/celeritas/ext/detail/LevelTouchableUpdater.hh
+++ b/src/celeritas/ext/detail/LevelTouchableUpdater.hh
@@ -60,7 +60,7 @@ class LevelTouchableUpdater final : public TouchableUpdaterInterface
     // Geometry for doing G4PV translation
     SPConstGeo geo_;
     // Temporary storage for physical volumes
-    std::vector<G4VPhysicalVolume const*> phys_vol_;
+    std::vector<GeantPhysicalInstance> phys_inst_;
     // Temporary history
     std::unique_ptr<G4NavigationHistory> nav_hist_;
 };

--- a/src/geocel/GeantGeoUtils.cc
+++ b/src/geocel/GeantGeoUtils.cc
@@ -197,6 +197,16 @@ G4VPhysicalVolume const* geant_world_volume()
 
 //---------------------------------------------------------------------------//
 /*!
+ * Whether a physical volume is parameterized or replicated.
+ */
+bool is_replica(G4VPhysicalVolume const& pv)
+{
+    auto vt = pv.VolumeType();
+    return (vt == EVolume::kReplica || vt == EVolume::kParameterised);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Find Geant4 logical volumes corresponding to a list of names.
  *
  * If logical volumes with duplicate names are present, they will all show up

--- a/src/geocel/GeantGeoUtils.cc
+++ b/src/geocel/GeantGeoUtils.cc
@@ -38,6 +38,7 @@
 #include "corecel/math/Algorithms.hh"
 #include "orange/g4org/Converter.hh"
 
+#include "GeoParamsInterface.hh"
 #include "g4/VisitVolumes.hh"
 
 #include "detail/MakeLabelVector.hh"
@@ -312,11 +313,21 @@ std::vector<Label> make_physical_vol_labels(G4VPhysicalVolume const& world)
  * \note The stack should have the same semantics as \c LevelId, i.e. the
  * initial entry is the "most global" level.
  */
-void set_history(Span<G4VPhysicalVolume const*> stack, G4NavigationHistory* nav)
+void set_history(Span<GeantPhysicalInstance const> stack,
+                 G4NavigationHistory* nav)
 {
     CELER_EXPECT(!stack.empty());
     CELER_EXPECT(std::all_of(stack.begin(), stack.end(), LogicalTrue{}));
     CELER_EXPECT(nav);
+
+    if (std::any_of(
+            stack.begin(), stack.end(), [](GeantPhysicalInstance const& gpi) {
+                return static_cast<bool>(gpi.replica);
+            }))
+    {
+        CELER_NOT_IMPLEMENTED(
+            "sensitive detectors inside of replica/parameterized volumes");
+    }
 
     size_type level = 0;
     auto nav_stack_size
@@ -327,7 +338,7 @@ void set_history(Span<G4VPhysicalVolume const*> stack, G4NavigationHistory* nav)
          level != end_level;
          ++level)
     {
-        if (nav->GetVolume(level) != stack[level])
+        if (nav->GetVolume(level) != stack[level].pv)
         {
             break;
         }
@@ -338,7 +349,7 @@ void set_history(Span<G4VPhysicalVolume const*> stack, G4NavigationHistory* nav)
         // Top level disagrees (rare? should always be world):
         // reset to top level
         nav->Reset();
-        nav->SetFirstEntry(const_cast<G4VPhysicalVolume*>(stack[0]));
+        nav->SetFirstEntry(const_cast<G4VPhysicalVolume*>(stack[0].pv));
         ++level;
     }
     else if (level < nav_stack_size())
@@ -351,7 +362,7 @@ void set_history(Span<G4VPhysicalVolume const*> stack, G4NavigationHistory* nav)
     // Add all remaining levels
     for (auto end_level = stack.size(); level != end_level; ++level)
     {
-        G4VPhysicalVolume const* pv = stack[level];
+        G4VPhysicalVolume const* pv = stack[level].pv;
         constexpr auto volume_type = EVolume::kNormal;
         CELER_VALIDATE(pv->VolumeType() == volume_type,
                        << "sensitive detectors inside of "

--- a/src/geocel/GeantGeoUtils.cc
+++ b/src/geocel/GeantGeoUtils.cc
@@ -22,10 +22,12 @@
 #include <G4PhysicalVolumeStore.hh>
 #include <G4ReflectionFactory.hh>
 #include <G4RegionStore.hh>
+#include <G4ReplicaNavigation.hh>
 #include <G4SolidStore.hh>
 #include <G4Threading.hh>
 #include <G4TouchableHistory.hh>
 #include <G4TransportationManager.hh>
+#include <G4VPVParameterisation.hh>
 #include <G4VPhysicalVolume.hh>
 #include <G4Version.hh>
 #include <G4ios.hh>
@@ -52,6 +54,8 @@ static_assert(G4VERSION_NUMBER
               "CMake-reported Geant4 version does not match installed "
               "<G4Version.hh>: compare to 'corecel/Config.hh'");
 
+using ReplicaId = celeritas::GeantPhysicalInstance::ReplicaId;
+
 namespace celeritas
 {
 namespace
@@ -73,6 +77,25 @@ void free_and_clear(std::vector<T*>* table)
     CELER_ASSERT(std::all_of(
         table->begin(), table->end(), [](T* ptr) { return ptr == nullptr; }));
     table->clear();
+}
+
+void update_replica(G4VPhysicalVolume* pv, ReplicaId replica)
+{
+    CELER_EXPECT(pv);
+    CELER_EXPECT(replica);
+    static G4ThreadLocal G4ReplicaNavigation nav_;
+    nav_.ComputeTransformation(replica.get(), pv);
+    pv->SetCopyNo(replica.get());
+}
+
+void update_parameterised(G4VPhysicalVolume* pv, ReplicaId replica)
+{
+    CELER_EXPECT(pv);
+    CELER_EXPECT(replica);
+    auto* param = pv->GetParameterisation();
+    CELER_ASSERT(param);
+    param->ComputeTransformation(replica.get(), pv);
+    pv->SetCopyNo(replica.get());
 }
 
 //---------------------------------------------------------------------------//
@@ -318,8 +341,6 @@ std::vector<Label> make_physical_vol_labels(G4VPhysicalVolume const& world)
 /*!
  * Update a nav history to match the given pv stack.
  *
- * \warning The stack cannot have a parameterized/replicated volume.
- *
  * \note The stack should have the same semantics as \c LevelId, i.e. the
  * initial entry is the "most global" level.
  */
@@ -330,15 +351,6 @@ void set_history(Span<GeantPhysicalInstance const> stack,
     CELER_EXPECT(std::all_of(stack.begin(), stack.end(), LogicalTrue{}));
     CELER_EXPECT(nav);
 
-    if (std::any_of(
-            stack.begin(), stack.end(), [](GeantPhysicalInstance const& gpi) {
-                return static_cast<bool>(gpi.replica);
-            }))
-    {
-        CELER_NOT_IMPLEMENTED(
-            "sensitive detectors inside of replica/parameterized volumes");
-    }
-
     size_type level = 0;
     auto nav_stack_size
         = [nav] { return static_cast<size_type>(nav->GetDepth()) + 1; };
@@ -348,7 +360,8 @@ void set_history(Span<GeantPhysicalInstance const> stack,
          level != end_level;
          ++level)
     {
-        if (nav->GetVolume(level) != stack[level].pv)
+        auto* nav_pv = nav->GetVolume(level);
+        if (nav_pv != stack[level].pv || stack[level].replica)
         {
             break;
         }
@@ -369,18 +382,32 @@ void set_history(Span<GeantPhysicalInstance const> stack,
         CELER_ASSERT(nav_stack_size() == level);
     }
 
-    // Add all remaining levels
+    // Add all remaining levels: see G4Navigator::LocateGLobalPoint
     for (auto end_level = stack.size(); level != end_level; ++level)
     {
-        G4VPhysicalVolume const* pv = stack[level].pv;
-        constexpr auto volume_type = EVolume::kNormal;
-        CELER_VALIDATE(pv->VolumeType() == volume_type,
-                       << "sensitive detectors inside of "
-                          "replica/parameterized volumes are not supported: '"
-                       << pv->GetName() << "' inside "
-                       << PrintableNavHistory{nav});
-        nav->NewLevel(
-            const_cast<G4VPhysicalVolume*>(pv), volume_type, pv->GetCopyNo());
+        auto* pv = const_cast<G4VPhysicalVolume*>(stack[level].pv);
+        auto vol_type = pv->VolumeType();
+        auto replica = stack[level].replica;
+        switch (vol_type)
+        {
+            case EVolume::kNormal:
+                CELER_ASSERT(!replica);
+                replica = id_cast<ReplicaId>(pv->GetCopyNo());
+                break;
+            case EVolume::kReplica:
+                update_replica(pv, replica);
+                break;
+            case EVolume::kParameterised:
+                update_parameterised(pv, replica);
+                break;
+            default:
+                CELER_LOG_LOCAL(error)
+                    << R"(Encountered abnormal Geant4 volume inside navigation history: )"
+                    << pv->GetName() << "' inside "
+                    << PrintableNavHistory{nav};
+                break;
+        }
+        nav->NewLevel(pv, vol_type, replica.get());
     }
 
     CELER_ENSURE(nav_stack_size() == stack.size());

--- a/src/geocel/GeantGeoUtils.cc
+++ b/src/geocel/GeantGeoUtils.cc
@@ -261,9 +261,9 @@ std::vector<Label> make_logical_vol_labels(G4VPhysicalVolume const& world)
         },
         world);
 
-    return detail::make_label_vector<G4LogicalVolume>(
+    return detail::make_label_vector<G4LogicalVolume const*>(
         std::move(names),
-        [](G4LogicalVolume const& lv) { return lv.GetInstanceID(); });
+        [](G4LogicalVolume const* lv) { return lv->GetInstanceID(); });
 }
 
 //---------------------------------------------------------------------------//
@@ -298,9 +298,9 @@ std::vector<Label> make_physical_vol_labels(G4VPhysicalVolume const& world)
         },
         world);
 
-    return detail::make_label_vector<G4VPhysicalVolume>(
+    return detail::make_label_vector<G4VPhysicalVolume const*>(
         std::move(names),
-        [](G4VPhysicalVolume const& lv) { return lv.GetInstanceID(); });
+        [](G4VPhysicalVolume const* pv) { return pv->GetInstanceID(); });
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/GeantGeoUtils.hh
+++ b/src/geocel/GeantGeoUtils.hh
@@ -80,6 +80,10 @@ Span<G4LogicalVolume*> geant_logical_volumes();
 G4VPhysicalVolume const* geant_world_volume();
 
 //---------------------------------------------------------------------------//
+// Whether the volume is a replica/parameterization
+bool is_replica(G4VPhysicalVolume const&);
+
+//---------------------------------------------------------------------------//
 // Find Geant4 logical volumes corresponding to a list of names
 std::unordered_set<G4LogicalVolume const*>
     find_geant_volumes(std::unordered_set<std::string>);

--- a/src/geocel/GeantGeoUtils.hh
+++ b/src/geocel/GeantGeoUtils.hh
@@ -32,6 +32,7 @@ class G4VTouchable;
 
 namespace celeritas
 {
+struct GeantPhysicalInstance;
 //---------------------------------------------------------------------------//
 #if CELERITAS_GEANT4_VERSION >= 0x0b0200
 //! Version-independent typedef to Geant4 touchable history
@@ -90,8 +91,8 @@ std::vector<Label> make_logical_vol_labels(G4VPhysicalVolume const& world);
 std::vector<Label> make_physical_vol_labels(G4VPhysicalVolume const& world);
 
 //---------------------------------------------------------------------------//
-// Update a nav history to match the given pv stack
-void set_history(Span<G4VPhysicalVolume const*> stack,
+// Update a nav history to match the given volume instance stack
+void set_history(Span<GeantPhysicalInstance const> stack,
                  G4NavigationHistory* nav);
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/detail/MakeLabelVector.hh
+++ b/src/geocel/detail/MakeLabelVector.hh
@@ -25,9 +25,9 @@ namespace detail
  * ID.
  */
 template<class T, class GetId>
-std::vector<Label> make_label_vector(
-    std::unordered_map<std::string, std::vector<T const*>> const& names,
-    GetId&& get_id)
+std::vector<Label>
+make_label_vector(std::unordered_map<std::string, std::vector<T>> const& names,
+                  GetId&& get_id)
 {
     std::vector<Label> result;
     auto add_label = [&result](std::size_t id, Label&& label) {
@@ -45,7 +45,7 @@ std::vector<Label> make_label_vector(
         {
             // Label is just the name since this item is unique
             CELER_ASSERT(items.front());
-            add_label(get_id(*items.front()), Label{name});
+            add_label(get_id(items.front()), Label{name});
             continue;
         }
 
@@ -53,7 +53,7 @@ std::vector<Label> make_label_vector(
         for (auto idx : range(items.size()))
         {
             CELER_ASSERT(items[idx]);
-            add_label(get_id(*items[idx]), Label{name, std::to_string(idx)});
+            add_label(get_id(items[idx]), Label{name, std::to_string(idx)});
         }
     }
     return result;

--- a/src/geocel/g4/GeantGeoParams.cc
+++ b/src/geocel/g4/GeantGeoParams.cc
@@ -165,8 +165,8 @@ VolumeId GeantGeoParams::find_volume(G4LogicalVolume const* volume) const
 /*!
  * Get the Geant4 physical volume corresponding to a volume instance ID.
  *
- * \warning For Geant4 paramterised/replicated volumes, external state (e.g.
- * the local navigation) *must* be used in concert with this method: i.e.,
+ * \warning For Geant4 parameterised/replicated volumes, external state (e.g.
+ * the local navigation) \em must be used in concert with this method: i.e.,
  * navigation on the current thread needs to have just "visited" the instance.
  *
  * \todo Create our own volume instance mapping for Geant4, where

--- a/src/geocel/g4/GeantGeoParams.cc
+++ b/src/geocel/g4/GeantGeoParams.cc
@@ -165,20 +165,39 @@ VolumeId GeantGeoParams::find_volume(G4LogicalVolume const* volume) const
 /*!
  * Get the Geant4 physical volume corresponding to a volume instance ID.
  *
- * If the input ID is false, a null pointer will be returned.
+ * \warning For Geant4 paramterised/replicated volumes, external state (e.g.
+ * the local navigation) *must* be used in concert with this method: i.e.,
+ * navigation on the current thread needs to have just "visited" the instance.
+ *
+ * \todo Create our own volume instance mapping for Geant4, where
+ * VolumeInstanceId corresponds to a (G4PV*, int) pair rather than just G4PV*
+ * (which in Geant4 is not sufficiently unique).
  */
-G4VPhysicalVolume const* GeantGeoParams::id_to_pv(VolumeInstanceId id) const
+GeantPhysicalInstance GeantGeoParams::id_to_geant(VolumeInstanceId id) const
 {
     CELER_EXPECT(!id || id < vol_instances_.size());
     if (!id)
     {
-        return nullptr;
+        return {};
     }
 
     G4PhysicalVolumeStore* pv_store = G4PhysicalVolumeStore::GetInstance();
     auto index = id.unchecked_get() - pv_offset_;
     CELER_ASSERT(index < pv_store->size());
-    return (*pv_store)[index];
+
+    GeantPhysicalInstance result;
+    result.pv = (*pv_store)[index];
+    CELER_ASSERT(result.pv);
+    if (result.pv->VolumeType() != EVolume::kNormal)
+    {
+        auto copy_no = result.pv->GetCopyNo();
+        // NOTE: if this line fails, Geant4 may be returning uninitialized
+        // memory on the local thread.
+        CELER_ASSERT(copy_no >= 0 && copy_no < result.pv->GetMultiplicity());
+        result.replica = id_cast<GeantPhysicalInstance::ReplicaId>(copy_no);
+    }
+
+    return result;
 }
 
 //---------------------------------------------------------------------------//
@@ -187,7 +206,7 @@ G4VPhysicalVolume const* GeantGeoParams::id_to_pv(VolumeInstanceId id) const
  *
  * If the input volume ID is unassigned, a null pointer will be returned.
  */
-G4LogicalVolume const* GeantGeoParams::id_to_lv(VolumeId id) const
+G4LogicalVolume const* GeantGeoParams::id_to_geant(VolumeId id) const
 {
     CELER_EXPECT(!id || id < volumes_.size());
     if (!id)

--- a/src/geocel/g4/GeantGeoParams.hh
+++ b/src/geocel/g4/GeantGeoParams.hh
@@ -74,10 +74,10 @@ class GeantGeoParams final : public GeoParamsInterface,
     VolumeId find_volume(G4LogicalVolume const* volume) const final;
 
     // Get the Geant4 physical volume corresponding to a volume instance ID
-    G4VPhysicalVolume const* id_to_pv(VolumeInstanceId vol_id) const final;
+    GeantPhysicalInstance id_to_geant(VolumeInstanceId vol_id) const final;
 
     // Get the Geant4 logical volume corresponding to a volume ID
-    G4LogicalVolume const* id_to_lv(VolumeId vol_id) const;
+    G4LogicalVolume const* id_to_geant(VolumeId vol_id) const;
 
     // DEPRECATED
     using GeoParamsInterface::find_volume;

--- a/src/geocel/g4/GeantGeoTrackView.hh
+++ b/src/geocel/g4/GeantGeoTrackView.hh
@@ -322,7 +322,6 @@ CELER_FORCEINLINE bool GeantGeoTrackView::is_on_boundary() const
     return safety_radius_ == 0.0;
 }
 
-
 //---------------------------------------------------------------------------//
 /*!
  * Get the navigation state.

--- a/src/geocel/g4/GeantGeoTrackView.hh
+++ b/src/geocel/g4/GeantGeoTrackView.hh
@@ -299,8 +299,8 @@ void GeantGeoTrackView::volume_instance_id(Span<VolumeInstanceId> levels) const
     for (auto lev : range(levels.size()))
     {
         G4VPhysicalVolume* pv = touch->GetVolume(max_depth - lev);
-        CELER_ASSERT(pv);
-        levels[lev] = id_cast<VolumeInstanceId>(pv->GetInstanceID());
+        levels[lev] = pv ? id_cast<VolumeInstanceId>(pv->GetInstanceID())
+                         : VolumeInstanceId{};
     }
 }
 

--- a/src/geocel/g4/GeantGeoTrackView.hh
+++ b/src/geocel/g4/GeantGeoTrackView.hh
@@ -95,7 +95,7 @@ class GeantGeoTrackView
     inline void volume_instance_id(Span<VolumeInstanceId> levels) const;
 
     //!@{
-    //! VecGeom states are never "on" a surface
+    //! Geant4 states are never "on" a surface
     SurfaceId surface_id() const { return {}; }
     SurfaceId next_surface_id() const { return {}; }
     //!@}
@@ -106,6 +106,9 @@ class GeantGeoTrackView
     inline bool is_on_boundary() const;
     //! Whether the last operation resulted in an error
     CELER_FORCEINLINE bool failed() const { return false; }
+
+    // Get the Geant4 navigation state
+    inline G4NavigationHistory const* nav_history() const;
 
     //// OPERATIONS ////
 
@@ -317,6 +320,18 @@ CELER_FORCEINLINE bool GeantGeoTrackView::is_outside() const
 CELER_FORCEINLINE bool GeantGeoTrackView::is_on_boundary() const
 {
     return safety_radius_ == 0.0;
+}
+
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the navigation state.
+ */
+G4NavigationHistory const* GeantGeoTrackView::nav_history() const
+{
+    auto* touch = touch_handle_();
+    CELER_ASSERT(touch);
+    return touch->GetHistory();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -309,14 +309,34 @@ VecgeomParams::~VecgeomParams()
 /*!
  * Get the Geant4 physical volume corresponding to a volume instance ID.
  */
-G4VPhysicalVolume const* VecgeomParams::id_to_pv(VolumeInstanceId viid) const
+GeantPhysicalInstance VecgeomParams::id_to_geant(VolumeInstanceId id) const
 {
-    CELER_EXPECT(viid);
-    if (viid < g4_pv_map_.size())
+    CELER_EXPECT(id < g4_pv_map_.size() || g4_pv_map_.empty());
+    if (g4_pv_map_.empty())
     {
-        return g4_pv_map_[viid.unchecked_get()];
+        // Model was loaded with VGDML
+        return {};
     }
-    return nullptr;
+
+    GeantPhysicalInstance result;
+    result.pv = g4_pv_map_[id.unchecked_get()];
+    if (result.pv && is_replica(*result.pv))
+    {
+        // VecGeom volume is a specific instance of a G4PV: get the replica
+        // number it corresponds to
+        auto& geo_manager = vecgeom::GeoManager::Instance();
+#if VECGEOM_USE_SURF
+        // TODO: this should use VECGEOM_VERSION >= 0x020000 once the
+        // changes get merged into master
+        auto* vgpv = geo_manager.GetPlacedVolume(id.get());
+#else
+        auto* vgpv = geo_manager.FindPlacedVolume(id.get());
+#endif
+        CELER_ASSERT(vgpv);
+        result.replica
+            = id_cast<GeantPhysicalInstance::ReplicaId>(vgpv->GetCopyNo());
+    }
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -135,8 +135,8 @@ std::vector<Label> make_logical_vol_labels(vecgeom::VPlacedVolume const& world)
         },
         world);
 
-    return detail::make_label_vector<VolT>(
-        std::move(names), [](VolT const& vol) { return vol.id(); });
+    return detail::make_label_vector<VolT const*>(
+        std::move(names), [](VolT const* vol) { return vol->id(); });
 }
 
 //---------------------------------------------------------------------------//
@@ -187,8 +187,8 @@ std::vector<Label> make_physical_vol_labels(vecgeom::VPlacedVolume const& world)
         },
         world);
 
-    return detail::make_label_vector<VolT>(
-        std::move(names), [](VolT const& vol) { return vol.id(); });
+    return detail::make_label_vector<VolT const*>(
+        std::move(names), [](VolT const* vol) { return vol->id(); });
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/vg/VecgeomParams.hh
+++ b/src/geocel/vg/VecgeomParams.hh
@@ -69,7 +69,7 @@ class VecgeomParams final : public GeoParamsInterface,
     VolumeId find_volume(G4LogicalVolume const* volume) const final;
 
     // Get the Geant4 physical volume corresponding to a volume instance ID
-    G4VPhysicalVolume const* id_to_pv(VolumeInstanceId vol_id) const final;
+    GeantPhysicalInstance id_to_geant(VolumeInstanceId vol_id) const final;
 
     // DEPRECATED
     using GeoParamsInterface::find_volume;

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -86,8 +86,8 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     inline VolumeId find_volume(G4LogicalVolume const* volume) const final;
 
     // Get the Geant4 physical volume corresponding to a volume instance ID
-    inline G4VPhysicalVolume const*
-    id_to_pv(VolumeInstanceId vol_id) const final;
+    inline GeantPhysicalInstance
+    id_to_geant(VolumeInstanceId vol_id) const final;
 
     //// DEPRECATED ////
 
@@ -205,9 +205,9 @@ VolumeId OrangeParams::find_volume(G4LogicalVolume const*) const
  *
  * \todo Implement using \c g4org::Converter
  */
-G4VPhysicalVolume const* OrangeParams::id_to_pv(VolumeInstanceId) const
+GeantPhysicalInstance OrangeParams::id_to_geant(VolumeInstanceId) const
 {
-    return nullptr;
+    return {};
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -209,9 +209,22 @@ if(CELERITAS_USE_Geant4)
   celeritas_add_test(ext/detail/HitProcessor.test.cc
     LINK_LIBRARIES testcel_celeritas_g4
     ENVIRONMENT "${CELER_G4ENV}")
+
+  set(_ltu_tests
+    "MultiLevelTest.*"
+  )
+  if(CELERITAS_CORE_GEO STREQUAL "VecGeom")
+    # Geant4 doesn't yet have independent volume instance IDs for replicas
+    list(APPEND _ltu_tests
+      "Replica.*"
+    )
+  elseif(CELERITAS_CORE_GEO STREQUAL "ORANGE")
+    set(_ltu_tests DISABLE)
+  endif()
+
   celeritas_add_test(ext/detail/LevelTouchableUpdater.test.cc
     LINK_LIBRARIES testcel_celeritas_g4
-    ${_needs_not_orange})
+    FILTER ${_ltu_tests})
   if(CELERITAS_REAL_TYPE STREQUAL "double")
     # This test requires Geant4 *geometry* which is incompatible
     # with single-precision

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -216,7 +216,7 @@ if(CELERITAS_USE_Geant4)
   if(CELERITAS_CORE_GEO STREQUAL "VecGeom")
     # Geant4 doesn't yet have independent volume instance IDs for replicas
     list(APPEND _ltu_tests
-      "Replica.*"
+      "ReplicaTest.*"
     )
   elseif(CELERITAS_CORE_GEO STREQUAL "ORANGE")
     set(_ltu_tests DISABLE)

--- a/test/celeritas/ext/detail/NaviTouchableUpdater.test.cc
+++ b/test/celeritas/ext/detail/NaviTouchableUpdater.test.cc
@@ -50,7 +50,7 @@ class NaviTouchableUpdaterBase : public ::celeritas::test::GeantGeoTestBase
     G4LogicalVolume const* find_lv(std::string const& name) const
     {
         auto const& geo = *this->geometry();
-        auto const* lv = geo.id_to_lv(geo.volumes().find_unique(name));
+        auto const* lv = geo.id_to_geant(geo.volumes().find_unique(name));
         CELER_ENSURE(lv);
         return lv;
     }

--- a/test/celeritas/user/ExampleInstanceCalo.cc
+++ b/test/celeritas/user/ExampleInstanceCalo.cc
@@ -154,13 +154,17 @@ void ExampleInstanceCalo::process_steps(DetectorStepOutput const& out)
             {
                 break;
             }
-            os << (id_index == 0 ? ':' : '/') << vi_labels.at(vi_id).name;
+            os << (id_index == 0 ? ':' : '/') << vi_labels.at(vi_id).label;
 #if CELERITAS_USE_GEANT4
-            if (G4VPhysicalVolume const* pv = geo_->id_to_pv(vi_id))
+            if (auto phys_inst = geo_->id_to_geant(vi_id))
             {
-                if (auto copy_num = pv->GetCopyNo())
+                if (phys_inst.replica)
                 {
-                    os << '@' << std::setw(2) << std::setfill('0') << copy_num;
+                    os << '@' << phys_inst.replica.get();
+                }
+                else if (auto copy_num = phys_inst.pv->GetCopyNo())
+                {
+                    os << '.' << std::setw(2) << std::setfill('0') << copy_num;
                 }
             }
 #endif

--- a/test/celeritas/user/ExampleInstanceCalo.cc
+++ b/test/celeritas/user/ExampleInstanceCalo.cc
@@ -154,7 +154,7 @@ void ExampleInstanceCalo::process_steps(DetectorStepOutput const& out)
             {
                 break;
             }
-            os << (id_index == 0 ? ':' : '/') << vi_labels.at(vi_id).label;
+            os << (id_index == 0 ? ':' : '/') << vi_labels.at(vi_id);
 #if CELERITAS_USE_GEANT4
             if (auto phys_inst = geo_->id_to_geant(vi_id))
             {

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -384,7 +384,7 @@ TEST_F(TestMultiEm3InstanceCaloTest, step_host)
 
     auto iter = std::find(result.instance.begin(),
                           result.instance.end(),
-                          "lar:world_PV/Calorimeter/Layer@01/lar_pv");
+                          "lar:world_PV/Calorimeter/Layer@0.01/lar_pv");
     EXPECT_TRUE(iter != result.instance.end()) << repr(result.instance);
 }
 

--- a/test/geocel/CMakeLists.txt
+++ b/test/geocel/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES
   MultiLevelGeoTest.cc
   SolidsGeoTest.cc
   TransformedBoxGeoTest.cc
+  GeoTests.cc
 )
 
 if(CELERITAS_USE_Geant4 AND CELERITAS_REAL_TYPE STREQUAL "double")

--- a/test/geocel/CmseGeoTest.hh
+++ b/test/geocel/CmseGeoTest.hh
@@ -17,7 +17,7 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 /*!
- * Test the transformed box geometry.
+ * Test the CMS polycone geometry.
  */
 class CmseGeoTest
 {
@@ -27,7 +27,6 @@ class CmseGeoTest
     //! Construct with a reference to the GoogleTest
     CmseGeoTest(GenericGeoTestInterface* geo_test) : test_{geo_test} {}
 
-    void test_accessors() const;
     inline void test_trace() const;
 
   private:

--- a/test/geocel/GeantGeoUtils.test.cc
+++ b/test/geocel/GeantGeoUtils.test.cc
@@ -10,9 +10,9 @@
 #include <initializer_list>
 #include <string_view>
 #include <G4LogicalVolume.hh>
+#include <G4NavigationHistory.hh>
 #include <G4ThreeVector.hh>
 #include <G4TouchableHistory.hh>
-#include <G4NavigationHistory.hh>
 
 #include "corecel/ScopedLogStorer.hh"
 #include "corecel/io/Logger.hh"
@@ -267,7 +267,6 @@ TEST_F(MultiLevelTest, set_history)
 class ReplicaTest : public GeantGeoUtilsTest
 {
     std::string geometry_basename() const override { return "replica"; }
-
 };
 
 TEST_F(ReplicaTest, is_replica)
@@ -297,7 +296,8 @@ TEST_F(ReplicaTest, is_replica)
     };
 
     {
-        static char const* const expected[] = {"HadCalColumn_PV", "HadCalCell_PV", "HadCalLayer_PV"};
+        static char const* const expected[]
+            = {"HadCalColumn_PV", "HadCalCell_PV", "HadCalLayer_PV"};
         auto actual = get_replicas({-400, 0.1, 650});
         EXPECT_VEC_EQ(expected, actual);
     }

--- a/test/geocel/GeantGeoUtils.test.cc
+++ b/test/geocel/GeantGeoUtils.test.cc
@@ -191,7 +191,7 @@ TEST_F(MultiLevelTest, printable_nav)
 {
     auto geo = this->make_geo_track_view();
     auto get_nav_str = [&geo](Real3 const& pos) {
-        geo = {to_cm(pos), Real3{1, 0, 0}};
+        geo = {from_cm(pos), Real3{1, 0, 0}};
         std::ostringstream os;
         os << PrintableNavHistory{geo.nav_history()};
         return std::move(os).str();
@@ -300,7 +300,7 @@ TEST_F(ReplicaTest, is_replica)
 {
     auto track = this->make_geo_track_view();
     auto get_replicas = [&track](Real3 const& pos) {
-        track = {to_cm(pos), Real3{0, 0, 1}};
+        track = {from_cm(pos), Real3{0, 0, 1}};
 
         auto* hist = track.nav_history();
         CELER_ASSERT(hist);

--- a/test/geocel/GeantGeoUtils.test.cc
+++ b/test/geocel/GeantGeoUtils.test.cc
@@ -16,6 +16,7 @@
 
 #include "corecel/ScopedLogStorer.hh"
 #include "corecel/io/Logger.hh"
+#include "geocel/GeoParamsInterface.hh"
 #include "geocel/g4/Convert.hh"
 
 #include "UnitUtils.hh"
@@ -60,7 +61,7 @@ class GeantGeoUtilsTest : public GeantGeoTestBase
 {
   public:
     using IListSView = std::initializer_list<std::string_view>;
-    using VecPVConst = std::vector<G4VPhysicalVolume const*>;
+    using VecPhysInst = std::vector<GeantPhysicalInstance>;
 
     SPConstGeo build_geometry() final
     {
@@ -73,12 +74,12 @@ class GeantGeoUtilsTest : public GeantGeoTestBase
         ASSERT_TRUE(this->geometry());
     }
 
-    VecPVConst find_pv_stack(IListSView names) const
+    VecPhysInst find_pv_stack(IListSView names) const
     {
         auto const& geo = *this->geometry();
         auto const& vol_inst = geo.volume_instances();
 
-        VecPVConst result;
+        VecPhysInst result;
         std::vector<std::string_view> missing;
         for (std::string_view sv : names)
         {
@@ -88,7 +89,7 @@ class GeantGeoUtilsTest : public GeantGeoTestBase
                 missing.push_back(sv);
                 continue;
             }
-            result.push_back(geo.id_to_pv(vi));
+            result.push_back(geo.id_to_geant(vi));
             CELER_ASSERT(result.back());
         }
         CELER_VALIDATE(missing.empty(),

--- a/test/geocel/GeantGeoUtils.test.cc
+++ b/test/geocel/GeantGeoUtils.test.cc
@@ -10,9 +10,9 @@
 #include <initializer_list>
 #include <string_view>
 #include <G4LogicalVolume.hh>
-#include <G4Navigator.hh>
 #include <G4ThreeVector.hh>
 #include <G4TouchableHistory.hh>
+#include <G4NavigationHistory.hh>
 
 #include "corecel/ScopedLogStorer.hh"
 #include "corecel/io/Logger.hh"
@@ -162,18 +162,11 @@ class MultiLevelTest : public GeantGeoUtilsTest
 
 TEST_F(MultiLevelTest, printable_nav)
 {
-    G4Navigator navi;
-    G4TouchableHistory touchable;
-    navi.SetWorldVolume(
-        const_cast<G4VPhysicalVolume*>(this->geometry()->world()));
-
-    auto get_nav_str = [&](Real3 const& pos) {
-        navi.LocateGlobalPointAndUpdateTouchable(
-            convert_to_geant(from_cm(pos), clhep_length),
-            G4ThreeVector(1, 0, 0),
-            &touchable);
+    auto geo = this->make_geo_track_view();
+    auto get_nav_str = [&geo](Real3 const& pos) {
+        geo = {pos, Real3{1, 0, 0}};
         std::ostringstream os;
-        os << PrintableNavHistory{touchable.GetHistory()};
+        os << PrintableNavHistory{geo.nav_history()};
         return std::move(os).str();
     };
 
@@ -268,6 +261,46 @@ TEST_F(MultiLevelTest, set_history)
 
     EXPECT_VEC_SOFT_EQ(expected_coords, coords);
     EXPECT_VEC_EQ(expected_replicas, replicas);
+}
+
+//---------------------------------------------------------------------------//
+class ReplicaTest : public GeantGeoUtilsTest
+{
+    std::string geometry_basename() const override { return "replica"; }
+
+};
+
+TEST_F(ReplicaTest, is_replica)
+{
+    auto track = this->make_geo_track_view();
+    auto get_replicas = [&track](Real3 const& pos) {
+        track = {pos, Real3{0, 0, 1}};
+
+        auto* hist = track.nav_history();
+        CELER_ASSERT(hist);
+
+        std::vector<std::string> replicas;
+        for (auto i : range(hist->GetDepth() + 1))
+        {
+            auto* pv = hist->GetVolume(i);
+            if (!pv)
+            {
+                replicas.push_back("<null>");
+                continue;
+            }
+            if (is_replica(*pv))
+            {
+                replicas.push_back(pv->GetName());
+            }
+        }
+        return replicas;
+    };
+
+    {
+        static char const* const expected[] = {"HadCalColumn_PV", "HadCalCell_PV", "HadCalLayer_PV"};
+        auto actual = get_replicas({-400, 0.1, 650});
+        EXPECT_VEC_EQ(expected, actual);
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/GeantGeoUtils.test.cc
+++ b/test/geocel/GeantGeoUtils.test.cc
@@ -11,6 +11,7 @@
 #include <string_view>
 #include <G4LogicalVolume.hh>
 #include <G4NavigationHistory.hh>
+#include <G4PhysicalVolumeStore.hh>
 #include <G4ThreeVector.hh>
 #include <G4TouchableHistory.hh>
 
@@ -62,6 +63,7 @@ class GeantGeoUtilsTest : public GeantGeoTestBase
   public:
     using IListSView = std::initializer_list<std::string_view>;
     using VecPhysInst = std::vector<GeantPhysicalInstance>;
+    using ReplicaId = GeantPhysicalInstance::ReplicaId;
 
     SPConstGeo build_geometry() final
     {
@@ -72,6 +74,15 @@ class GeantGeoUtilsTest : public GeantGeoTestBase
     {
         // Build geometry during setup
         ASSERT_TRUE(this->geometry());
+
+        // Clear all copy numbers
+        for (auto* pv : *G4PhysicalVolumeStore::GetInstance())
+        {
+            if (pv && pv->VolumeType() != EVolume::kNormal)
+            {
+                pv->SetCopyNo(0);
+            }
+        }
     }
 
     VecPhysInst find_pv_stack(IListSView names) const
@@ -83,13 +94,29 @@ class GeantGeoUtilsTest : public GeantGeoTestBase
         std::vector<std::string_view> missing;
         for (std::string_view sv : names)
         {
-            auto vi = vol_inst.find_exact(Label::from_separator(sv));
+            auto lab = Label::from_separator(sv);
+            ReplicaId replica;
+            if (auto pos = lab.ext.find('+'); pos != std::string::npos)
+            {
+                // Convert replica ID and erase remainder
+                replica
+                    = id_cast<ReplicaId>(std::stoi(lab.ext.substr(pos + 1)));
+                lab.ext.erase(pos, std::string::npos);
+            }
+
+            auto vi = vol_inst.find_exact(lab);
             if (!vi)
             {
                 missing.push_back(sv);
                 continue;
             }
-            result.push_back(geo.id_to_geant(vi));
+
+            auto phys_inst = geo.id_to_geant(vi);
+            if (replica)
+            {
+                phys_inst.replica = replica;
+            }
+            result.push_back(phys_inst);
             CELER_ASSERT(result.back());
         }
         CELER_VALIDATE(missing.empty(),
@@ -301,6 +328,105 @@ TEST_F(ReplicaTest, is_replica)
         auto actual = get_replicas({-400, 0.1, 650});
         EXPECT_VEC_EQ(expected, actual);
     }
+    {
+        static char const* const expected[]
+            = {"HadCalColumn_PV", "HadCalCell_PV", "HadCalLayer_PV"};
+        auto actual = get_replicas({-450, 0.1, 650});
+        EXPECT_VEC_EQ(expected, actual);
+    }
+    {
+        static char const* const expected[]
+            = {"HadCalColumn_PV", "HadCalCell_PV", "HadCalLayer_PV"};
+        auto actual = get_replicas({-450, 0.1, 700});
+        EXPECT_VEC_EQ(expected, actual);
+    }
+}
+
+//! Test set_history using some of the same properties that CMS HGcal needs
+TEST_F(ReplicaTest, set_history)
+{
+    // Note: the shuffled order is to check that we correctly update parent
+    // levels even if we're in the same LV/PV
+    static IListSView const all_level_names[] = {
+        {"world_PV", "fSecondArmPhys", "EMcalorimeter", "cell_param@+14"},
+        {"world_PV", "fSecondArmPhys", "EMcalorimeter", "cell_param@+6"},
+        {"world_PV",
+         "fSecondArmPhys",
+         "HadCalorimeter",
+         "HadCalColumn_PV@+4",
+         "HadCalCell_PV@+1",
+         "HadCalLayer_PV@+2"},
+        {"world_PV",
+         "fSecondArmPhys",
+         "HadCalorimeter",
+         "HadCalColumn_PV@+2",
+         "HadCalCell_PV@+1",
+         "HadCalLayer_PV@+7"},
+        {"world_PV",
+         "fSecondArmPhys",
+         "HadCalorimeter",
+         "HadCalColumn_PV@+3",
+         "HadCalCell_PV@+1",
+         "HadCalLayer_PV@+16"},
+    };
+
+    G4TouchableHistory touch;
+    G4NavigationHistory hist;
+    std::vector<double> coords;
+    std::vector<std::string> replicas;
+
+    for (IListSView level_names : all_level_names)
+    {
+        auto phys_vols = this->find_pv_stack(level_names);
+        CELER_ASSERT(phys_vols.size() == level_names.size());
+
+        // Set the navigation history
+        set_history(make_span(phys_vols), &hist);
+        touch.UpdateYourself(hist.GetTopVolume(), &hist);
+
+        // Get the local-to-global x/y translation coordinates
+        auto const& trans = touch.GetTranslation(0);
+        coords.insert(coords.end(), {trans.x(), trans.y()});
+
+        // Get the replica/copy numbers
+        replicas.push_back([&touch] {
+            std::ostringstream os;
+            os << touch.GetReplicaNumber(0);
+            for (auto i : range(1, touch.GetHistoryDepth() + 1))
+            {
+                os << ',' << touch.GetReplicaNumber(i);
+            }
+            return std::move(os).str();
+        }());
+    }
+
+    static double const expected_coords[] = {
+        -0,  -0,   -0,  -0,   -0,   -0,   100, 100, 125,  125, -75, 125,
+        125, -125, 100, -100, -100, -100, 75,  75,  -125, 75,  125, 75,
+        -75, 75,   -75, -125, -125, -75,  75,  -75, 125,  -75,
+    };
+    static char const* const expected_replicas[] = {
+        "0",
+        "0,0",
+        "0",
+        "21,0",
+        "31,21,0",
+        "31,22,0",
+        "31,24,0",
+        "24,0",
+        "23,0",
+        "32,21,0",
+        "32,22,0",
+        "1,21,0",
+        "1,22,0",
+        "31,23,0",
+        "32,23,0",
+        "32,24,0",
+        "1,24,0",
+    };
+
+    EXPECT_VEC_SOFT_EQ(expected_coords, coords);
+    EXPECT_VEC_EQ(expected_replicas, replicas);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/GeantGeoUtils.test.cc
+++ b/test/geocel/GeantGeoUtils.test.cc
@@ -191,7 +191,7 @@ TEST_F(MultiLevelTest, printable_nav)
 {
     auto geo = this->make_geo_track_view();
     auto get_nav_str = [&geo](Real3 const& pos) {
-        geo = {pos, Real3{1, 0, 0}};
+        geo = {to_cm(pos), Real3{1, 0, 0}};
         std::ostringstream os;
         os << PrintableNavHistory{geo.nav_history()};
         return std::move(os).str();
@@ -300,7 +300,7 @@ TEST_F(ReplicaTest, is_replica)
 {
     auto track = this->make_geo_track_view();
     auto get_replicas = [&track](Real3 const& pos) {
-        track = {pos, Real3{0, 0, 1}};
+        track = {to_cm(pos), Real3{0, 0, 1}};
 
         auto* hist = track.nav_history();
         CELER_ASSERT(hist);
@@ -365,6 +365,12 @@ TEST_F(ReplicaTest, set_history)
         {"world_PV",
          "fSecondArmPhys",
          "HadCalorimeter",
+         "HadCalColumn_PV@+2",
+         "HadCalCell_PV@+0",
+         "HadCalLayer_PV@+7"},
+        {"world_PV",
+         "fSecondArmPhys",
+         "HadCalorimeter",
          "HadCalColumn_PV@+3",
          "HadCalCell_PV@+1",
          "HadCalLayer_PV@+16"},
@@ -386,7 +392,7 @@ TEST_F(ReplicaTest, set_history)
 
         // Get the local-to-global x/y translation coordinates
         auto const& trans = touch.GetTranslation(0);
-        coords.insert(coords.end(), {trans.x(), trans.y()});
+        coords.insert(coords.end(), {trans.x(), trans.y(), trans.z()});
 
         // Get the replica/copy numbers
         replicas.push_back([&touch] {
@@ -401,28 +407,32 @@ TEST_F(ReplicaTest, set_history)
     }
 
     static double const expected_coords[] = {
-        -0,  -0,   -0,  -0,   -0,   -0,   100, 100, 125,  125, -75, 125,
-        125, -125, 100, -100, -100, -100, 75,  75,  -125, 75,  125, 75,
-        -75, 75,   -75, -125, -125, -75,  75,  -75, 125,  -75,
+        -4344.3747686898,
+        75,
+        5574.6778264911,
+        -4604.1823898252,
+        75,
+        5424.6778264911,
+        -3942.4038105677,
+        150,
+        6528.4437038563,
+        -4587.0190528383,
+        150,
+        6444.9500548025,
+        -4587.0190528383,
+        -150,
+        6444.9500548025,
+        -4552.211431703,
+        150,
+        6984.6614865054,
     };
     static char const* const expected_replicas[] = {
-        "0",
-        "0,0",
-        "0",
-        "21,0",
-        "31,21,0",
-        "31,22,0",
-        "31,24,0",
-        "24,0",
-        "23,0",
-        "32,21,0",
-        "32,22,0",
-        "1,21,0",
-        "1,22,0",
-        "31,23,0",
-        "32,23,0",
-        "32,24,0",
-        "1,24,0",
+        "14,0,0,0",
+        "6,0,0,0",
+        "2,1,4,0,0,0",
+        "7,1,2,0,0,0",
+        "7,0,2,0,0,0",
+        "16,1,3,0,0,0",
     };
 
     EXPECT_VEC_SOFT_EQ(expected_coords, coords);

--- a/test/geocel/GenericGeoTestBase.hh
+++ b/test/geocel/GenericGeoTestBase.hh
@@ -91,6 +91,7 @@ class GenericGeoTestBase : virtual public Test,
     // Find linear segments until outside or max_step count is reached
     TrackingResult
     track(Real3 const& pos_cm, Real3 const& dir, int max_step) final;
+    VolumeStackResult volume_stack(Real3 const& pos_cm) final;
 
   private:
     template<Ownership W, MemSpace M>

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -333,7 +333,7 @@ auto GenericGeoTestBase<HP>::volume_stack(Real3 const& pos) -> VolumeStackResult
             result.volume_instances[i] = "<null>";
             continue;
         }
-        result.volume_instances[i] = to_string(vol_inst.at(vi_id));
+        auto const& label = vol_inst.at(vi_id);
         if (auto phys_inst = geo_params.id_to_geant(vi_id))
         {
             if (phys_inst.replica)
@@ -341,6 +341,10 @@ auto GenericGeoTestBase<HP>::volume_stack(Real3 const& pos) -> VolumeStackResult
                 result.replicas[i] = phys_inst.replica.get();
             }
         }
+        // Only write extension if not a replica, because Geant4
+        // effectively gives multiple volume instances the same name+ext
+        result.volume_instances[i] = !result.replicas[i] ? to_string(label)
+                                                         : label.name;
     }
     return result;
 }

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -185,7 +185,8 @@ auto GenericGeoTestBase<HP>::track(Real3 const& pos,
     TrackingResult result;
 
     GeoTrackView geo = CheckedGeoTrackView{this->make_geo_track_view(pos, dir)};
-    auto const& vol_inst = this->geometry()->volume_instances();
+    auto const& geo_params = *this->geometry();
+    auto const& vol_inst = geo_params.volume_instances();
     real_type const inv_length = real_type{1} / this->unit_length();
 
     if (geo.is_outside())
@@ -211,6 +212,15 @@ auto GenericGeoTestBase<HP>::track(Real3 const& pos,
             if (auto vi_id = geo.volume_instance_id())
             {
                 result.volume_instances.push_back(vol_inst.at(vi_id).name);
+                if (auto phys_inst = geo_params.id_to_geant(vi_id))
+                {
+                    if (phys_inst.replica)
+                    {
+                        result.volume_instances.back() += '@';
+                        result.volume_instances.back()
+                            += std::to_string(phys_inst.replica.get());
+                    }
+                }
             }
             else
             {

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -188,6 +188,7 @@ auto GenericGeoTestBase<HP>::track(Real3 const& pos,
     auto const& geo_params = *this->geometry();
     auto const& vol_inst = geo_params.volume_instances();
     real_type const inv_length = real_type{1} / this->unit_length();
+    real_type const bump_tol = this->bump_tol() * this->unit_length();
 
     if (geo.is_outside())
     {
@@ -209,23 +210,23 @@ auto GenericGeoTestBase<HP>::track(Real3 const& pos,
         result.volumes.push_back(this->volume_name(geo));
         if (vol_inst)
         {
-            if (auto vi_id = geo.volume_instance_id())
-            {
-                result.volume_instances.push_back(vol_inst.at(vi_id).name);
+            result.volume_instances.push_back([&] {
+                auto vi_id = geo.volume_instance_id();
+                if (!vi_id)
+                {
+                    return std::string{"---"};
+                }
+                std::string s = vol_inst.at(vi_id).name;
                 if (auto phys_inst = geo_params.id_to_geant(vi_id))
                 {
                     if (phys_inst.replica)
                     {
-                        result.volume_instances.back() += '@';
-                        result.volume_instances.back()
-                            += std::to_string(phys_inst.replica.get());
+                        s += '@';
+                        s += std::to_string(phys_inst.replica.get());
                     }
                 }
-            }
-            else
-            {
-                result.volume_instances.push_back("---");
-            }
+                return s;
+            }());
         }
         auto next = geo.find_next_step();
         result.distances.push_back(next.distance * inv_length);
@@ -236,7 +237,22 @@ auto GenericGeoTestBase<HP>::track(Real3 const& pos,
             result.volumes.push_back("[NO INTERCEPT]");
             break;
         }
-        if (next.distance > real_type(from_cm(1e-7)))
+        if (next.distance < bump_tol)
+        {
+            // Don't add epsilon distances
+            result.distances.pop_back();
+            result.volumes.pop_back();
+            if (vol_inst)
+            {
+                result.volume_instances.pop_back();
+            }
+            // Instead add the point to the bump list
+            for (auto p : geo.pos())
+            {
+                result.bumps.push_back(p * inv_length);
+            }
+        }
+        else
         {
             geo.move_internal(next.distance / 2);
             try

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -305,6 +305,48 @@ auto GenericGeoTestBase<HP>::track(Real3 const& pos,
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get the volume instance stack at a position.
+ */
+template<class HP>
+auto GenericGeoTestBase<HP>::volume_stack(Real3 const& pos) -> VolumeStackResult
+{
+    auto geo = this->make_geo_track_view(pos, Real3{0, 0, 1});
+    auto const& geo_params = *this->geometry();
+    auto const& vol_inst = geo_params.volume_instances();
+
+    auto level = geo.level();
+    if (!level)
+    {
+        return {};
+    }
+    std::vector<VolumeInstanceId> inst_ids(level.get() + 1);
+    geo.volume_instance_id(make_span(inst_ids));
+
+    VolumeStackResult result;
+    result.volume_instances.resize(inst_ids.size());
+    result.replicas.assign(inst_ids.size(), -1);
+    for (auto i : range(inst_ids.size()))
+    {
+        auto vi_id = inst_ids[i];
+        if (!vi_id)
+        {
+            result.volume_instances[i] = "<null>";
+            continue;
+        }
+        result.volume_instances[i] = to_string(vol_inst.at(vi_id));
+        if (auto phys_inst = geo_params.id_to_geant(vi_id))
+        {
+            if (phys_inst.replica)
+            {
+                result.replicas[i] = phys_inst.replica.get();
+            }
+        }
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Get the label for this geometry: Geant4, VecGeom, ORANGE.
  */
 template<class HP>

--- a/test/geocel/GenericGeoTestInterface.cc
+++ b/test/geocel/GenericGeoTestInterface.cc
@@ -14,6 +14,8 @@
 #include "corecel/math/SoftEqual.hh"
 #include "geocel/GeantGeoUtils.hh"
 
+#include "testdetail/TestMacrosImpl.hh"
+
 #if CELERITAS_USE_GEANT4
 #    include <G4VPhysicalVolume.hh>
 #endif
@@ -23,30 +25,90 @@ namespace celeritas
 namespace test
 {
 //---------------------------------------------------------------------------//
+#define CELER_REF_ATTR(ATTR) "ref." #ATTR " = " << repr(this->ATTR) << ";\n"
 void GenericGeoTrackingResult::print_expected()
 {
-    using std::cout;
-    cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
-            "real_type const safety_tol = test_->safety_tol();\n"
-            "static char const* const expected_volumes[] = "
-         << repr(this->volumes)
-         << ";\n"
-            "EXPECT_VEC_EQ(expected_volumes, result.volumes);\n"
-            "static char const* const expected_volume_instances[] = "
-         << repr(this->volume_instances)
-         << ";\n"
-            "EXPECT_VEC_EQ(expected_volume_instances, "
-            "result.volume_instances);\n"
-            "static real_type const expected_distances[] = "
-         << repr(this->distances)
-         << ";\n"
-            "EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);\n"
-            "static real_type const expected_hw_safety[] = "
-         << repr(this->halfway_safeties)
-         << ";\n"
-            "EXPECT_VEC_NEAR(expected_hw_safety, result.halfway_safeties, "
-            "safety_tol);\n"
+    std::cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
+            "GenericGeoTrackingResult ref;\n"
+            CELER_REF_ATTR(volumes)
+            CELER_REF_ATTR(volume_instances)
+            CELER_REF_ATTR(distances)
+            CELER_REF_ATTR(halfway_safeties)
+            CELER_REF_ATTR(bumps)
+            "auto tol = GenericGeoTrackingTolerance::from_test(*test_);\n"
+            "EXPECT_RESULT_NEAR(ref, result, tol);\n"
             "/*** END CODE ***/\n";
+}
+
+GenericGeoTrackingTolerance
+GenericGeoTrackingTolerance::from_test(GenericGeoTestInterface const& test)
+{
+    GenericGeoTrackingTolerance tol;
+    tol.safety = test.safety_tol();
+    tol.distance = SoftEqual{}.rel();
+    return tol;
+}
+
+::testing::AssertionResult IsResultEqual(char const* expr1,
+                                         char const* expr2,
+                                         char const*,
+                                         GenericGeoTrackingResult const& val1,
+                                         GenericGeoTrackingResult const& val2,
+                                         GenericGeoTrackingTolerance const& tol)
+{
+    using ::celeritas::testdetail::IsVecEq;
+    using ::celeritas::testdetail::IsVecSoftEquiv;
+
+    // TODO: refine this and reuse in other cases
+    auto result = ::testing::AssertionSuccess();
+    auto fail = [&]() -> ::testing::AssertionResult& {
+        if (result)
+        {
+            result = ::testing::AssertionFailure();
+            result << "Expected: (" << expr1 << ") == (" << expr2 << "):\n";
+        }
+        else
+        {
+            result << '\n';
+        }
+        return result;
+    };
+
+#define IRE_VEC_EQ(ATTR)                                           \
+    if (auto result = IsVecEq(expr1, #ATTR, val1.ATTR, val2.ATTR); \
+        !static_cast<bool>(result))                                \
+    {                                                              \
+        fail() << result.message();                                \
+    }                                                              \
+    else                                                           \
+        (void)sizeof(char)
+#define IRE_VEC_SOFT_EQ(ATTR, TOL)                                       \
+    if (auto result                                                      \
+        = IsVecSoftEquiv(expr1, #ATTR, #TOL, val1.ATTR, val2.ATTR, TOL); \
+        !static_cast<bool>(result))                                      \
+    {                                                                    \
+        fail() << result.message();                                      \
+    }                                                                    \
+    else                                                                 \
+        (void)sizeof(char)
+#define IRE_VEC_SOFT_EQ2(ATTR, REL, ABS)                               \
+    if (auto result = IsVecSoftEquiv(                                  \
+            expr1, #ATTR, #REL, #ABS, val1.ATTR, val2.ATTR, REL, ABS); \
+        !static_cast<bool>(result))                                    \
+    {                                                                  \
+        fail() << result.message();                                    \
+    }                                                                  \
+    else                                                               \
+        (void)sizeof(char)
+
+    IRE_VEC_EQ(volumes);
+    IRE_VEC_EQ(volume_instances);
+    IRE_VEC_SOFT_EQ(distances, tol.distance);
+    IRE_VEC_SOFT_EQ2(halfway_safeties, tol.safety, tol.safety);
+    IRE_VEC_SOFT_EQ2(bumps, tol.safety, tol.safety);
+
+#undef IRE_COMPARE
+    return result;
 }
 
 //---------------------------------------------------------------------------//
@@ -56,8 +118,8 @@ void GenericGeoVolumeStackResult::print_expected()
     // clang-format off
     cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
             "GenericGeoVolumeStackResult ref;\n"
-            "ref.volume_instances = " << repr(this->volume_instances) << ";\n"
-            "ref.replicas = " << repr(this->replicas) << ";\n"
+            CELER_REF_ATTR(volume_instances)
+            CELER_REF_ATTR(replicas)
             "EXPECT_RESULT_EQ(ref, result);\n"
             "/*** END CODE ***/\n";
     // clang-format on
@@ -119,6 +181,17 @@ real_type GenericGeoTestInterface::safety_tol() const
 {
     constexpr SoftEqual<> default_seq{};
     return default_seq.rel();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the threshold for a movement being a "bump".
+ *
+ * This unitless tolerance is multiplied by the test's unit length when used.
+ */
+real_type GenericGeoTestInterface::bump_tol() const
+{
+    return 1e-7;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/GenericGeoTestInterface.cc
+++ b/test/geocel/GenericGeoTestInterface.cc
@@ -27,7 +27,7 @@ void GenericGeoTrackingResult::print_expected()
 {
     using std::cout;
     cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
-            "real_type const safety_tol = test_->safety_tol()\n;"
+            "real_type const safety_tol = test_->safety_tol();\n"
             "static char const* const expected_volumes[] = "
          << repr(this->volumes)
          << ";\n"
@@ -47,6 +47,55 @@ void GenericGeoTrackingResult::print_expected()
             "EXPECT_VEC_NEAR(expected_hw_safety, result.halfway_safeties, "
             "safety_tol);\n"
             "/*** END CODE ***/\n";
+}
+
+//---------------------------------------------------------------------------//
+void GenericGeoVolumeStackResult::print_expected()
+{
+    using std::cout;
+    // clang-format off
+    cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
+            "GenericGeoVolumeStackResult ref;\n"
+            "ref.volume_instances = " << repr(this->volume_instances) << ";\n"
+            "ref.replicas = " << repr(this->replicas) << ";\n"
+            "EXPECT_RESULT_EQ(ref, result);\n"
+            "/*** END CODE ***/\n";
+    // clang-format on
+}
+
+::testing::AssertionResult
+IsResultEqual(char const* expr1,
+              char const* expr2,
+              GenericGeoVolumeStackResult const& val1,
+              GenericGeoVolumeStackResult const& val2)
+{
+    // TODO: refine this and reuse in other cases
+    auto result = ::testing::AssertionSuccess();
+    auto fail = [&]() -> ::testing::AssertionResult& {
+        if (result)
+        {
+            result = ::testing::AssertionFailure();
+            result << "Expected: (" << expr1 << ") == (" << expr2 << "):\n";
+        }
+        else
+        {
+            result << '\n';
+        }
+        return result;
+    };
+
+#define IRE_COMPARE(ATTR)                                           \
+    if (val1.ATTR != val2.ATTR)                                     \
+    {                                                               \
+        fail() << "Actual " #ATTR ": " << repr(val1.ATTR) << " vs " \
+               << repr(val2.ATTR);                                  \
+    }                                                               \
+    else                                                            \
+        (void)sizeof(char)
+    IRE_COMPARE(volume_instances);
+    IRE_COMPARE(replicas);
+#undef IRE_COMPARE
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/GenericGeoTestInterface.cc
+++ b/test/geocel/GenericGeoTestInterface.cc
@@ -142,22 +142,28 @@ std::vector<std::string> GenericGeoTestInterface::get_g4pv_labels() const
         result.push_back([&] {
             using namespace std::literals;
 
-            G4VPhysicalVolume const* pv = geo.id_to_pv(VolumeInstanceId{vidx});
-            if (!pv)
+            auto phys_inst = geo.id_to_geant(VolumeInstanceId{vidx});
+            if (!phys_inst)
             {
                 return "<null>"s;
             }
-            auto id = static_cast<std::size_t>(pv->GetInstanceID());
+            auto id = static_cast<std::size_t>(phys_inst.pv->GetInstanceID());
             if (id >= pv_labels.size())
             {
-                return "<out of range: "s + pv->GetName() + ">"s;
+                return "<out of range: "s + phys_inst.pv->GetName() + ">"s;
             }
             auto const& label = pv_labels[id];
             if (label.empty())
             {
-                return "<not visited: "s + pv->GetName() + ">"s;
+                return "<not visited: "s + phys_inst.pv->GetName() + ">"s;
             }
-            return to_string(label);
+            auto result = to_string(label);
+            if (phys_inst.replica)
+            {
+                result += '@';
+                result += std::to_string(phys_inst.replica.get());
+            }
+            return result;
         }());
     }
     return result;

--- a/test/geocel/GenericGeoTestInterface.hh
+++ b/test/geocel/GenericGeoTestInterface.hh
@@ -9,12 +9,18 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <gtest/gtest.h>
 
 #include "geocel/GeoParamsInterface.hh"
 #include "geocel/Types.hh"
 #include "geocel/detail/LengthUnits.hh"
 
 class G4VPhysicalVolume;
+
+#ifndef EXPECT_RESULT_EQ
+#    define EXPECT_RESULT_EQ(expected, actual) \
+        EXPECT_PRED_FORMAT2(::celeritas::test::IsResultEqual, expected, actual)
+#endif
 
 namespace celeritas
 {
@@ -32,6 +38,22 @@ struct GenericGeoTrackingResult
 };
 
 //---------------------------------------------------------------------------//
+struct GenericGeoVolumeStackResult
+{
+    std::vector<std::string> volume_instances;
+    std::vector<int> replicas;
+
+    void print_expected();
+};
+
+//---------------------------------------------------------------------------//
+::testing::AssertionResult
+IsResultEqual(char const* expected_expr,
+              char const* actual_expr,
+              GenericGeoVolumeStackResult const& expected,
+              GenericGeoVolumeStackResult const& actual);
+
+//---------------------------------------------------------------------------//
 /*!
  * Access capabilities from any templated GenericGeo test.
  *
@@ -47,6 +69,7 @@ class GenericGeoTestInterface
     //!@{
     //! \name Type aliases
     using TrackingResult = GenericGeoTrackingResult;
+    using VolumeStackResult = GenericGeoVolumeStackResult;
     using SPConstGeoInterface = std::shared_ptr<GeoParamsInterface const>;
     //!@}
 
@@ -57,6 +80,11 @@ class GenericGeoTestInterface
     virtual TrackingResult
     track(Real3 const& pos_cm, Real3 const& dir, int max_step)
         = 0;
+    //!@}
+
+    //!@{
+    // Obtain the "touchable history" at a point
+    virtual VolumeStackResult volume_stack(Real3 const& pos_cm) = 0;
     //!@}
 
     //! Get the label for this geometry: Geant4, VecGeom, ORANGE

--- a/test/geocel/GenericGeoTestInterface.hh
+++ b/test/geocel/GenericGeoTestInterface.hh
@@ -18,14 +18,20 @@
 class G4VPhysicalVolume;
 
 #ifndef EXPECT_RESULT_EQ
-#    define EXPECT_RESULT_EQ(expected, actual) \
-        EXPECT_PRED_FORMAT2(::celeritas::test::IsResultEqual, expected, actual)
+#    define EXPECT_RESULT_EQ(EXPECTED, ACTUAL) \
+        EXPECT_PRED_FORMAT2(::celeritas::test::IsResultEqual, EXPECTED, ACTUAL)
+#    define EXPECT_RESULT_NEAR(EXPECTED, ACTUAL, TOL) \
+        EXPECT_PRED_FORMAT3(                          \
+            ::celeritas::test::IsResultEqual, EXPECTED, ACTUAL, TOL)
 #endif
 
 namespace celeritas
 {
 namespace test
 {
+
+class GenericGeoTestInterface;
+
 //---------------------------------------------------------------------------//
 struct GenericGeoTrackingResult
 {
@@ -33,8 +39,19 @@ struct GenericGeoTrackingResult
     std::vector<std::string> volume_instances;
     std::vector<real_type> distances;  //!< [cm]
     std::vector<real_type> halfway_safeties;  //!< [cm]
+    // Locations the particle had a very tiny distance in a volume
+    std::vector<real_type> bumps;  //!< [cm * 3]
 
     void print_expected();
+};
+
+struct GenericGeoTrackingTolerance
+{
+    real_type distance{0};
+    real_type safety{0};
+
+    static GenericGeoTrackingTolerance
+    from_test(GenericGeoTestInterface const&);
 };
 
 //---------------------------------------------------------------------------//
@@ -45,6 +62,26 @@ struct GenericGeoVolumeStackResult
 
     void print_expected();
 };
+
+//---------------------------------------------------------------------------//
+::testing::AssertionResult
+IsResultEqual(char const* expected_expr,
+              char const* actual_expr,
+              char const* tol_expr,
+              GenericGeoTrackingResult const& expected,
+              GenericGeoTrackingResult const& actual,
+              GenericGeoTrackingTolerance const& tol);
+
+//---------------------------------------------------------------------------//
+inline ::testing::AssertionResult
+IsResultEqual(char const* expected_expr,
+              char const* actual_expr,
+              GenericGeoTrackingResult const& expected,
+              GenericGeoTrackingResult const& actual)
+{
+    return IsResultEqual(
+        expected_expr, actual_expr, "default", expected, actual, {});
+}
 
 //---------------------------------------------------------------------------//
 ::testing::AssertionResult
@@ -98,6 +135,9 @@ class GenericGeoTestInterface
 
     // Get the safety tolerance (defaults to SoftEq tol)
     virtual real_type safety_tol() const;
+
+    // Get the threshold in "unit lengths" for a movement being a "bump"
+    virtual real_type bump_tol() const;
 
     //! Ignore the first N VolumeId
     virtual VolumeId::size_type volume_offset() const { return 0; }

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -1,0 +1,374 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/GeoTests.cc
+//---------------------------------------------------------------------------//
+#include "GeoTests.hh"
+
+#include <string_view>
+
+#include "corecel/cont/Range.hh"
+#include "corecel/math/Turn.hh"
+
+#include "GenericGeoTestInterface.hh"
+#include "TestMacros.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+void ReplicaGeoTest::test_trace() const
+{
+    {
+        SCOPED_TRACE("Center +z");
+        auto result = test_->track({0, 0.5, -990}, {0, 0, 1});
+        GenericGeoTrackingResult ref;
+        ref.volumes = {
+            "world",    "firstArm",   "hodoscope1", "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "world",    "magnetic",   "world",      "secondArm",
+            "chamber2", "wirePlane2", "chamber2",   "secondArm",
+            "world",
+        };
+        ref.volume_instances = {
+            "world_PV", "firstArm",   "hodoscope1", "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "world_PV", "magnetic",   "world_PV",   "fSecondArmPhys",
+            "chamber2", "wirePlane2", "chamber2",   "fSecondArmPhys",
+            "world_PV",
+        };
+        ref.distances = {
+            190,
+            149.5,
+            1,
+            48.5,
+            0.99,
+            0.019999999999991,
+            0.99000000000001,
+            48,
+            0.99,
+            0.019999999999991,
+            0.99000000000001,
+            48,
+            0.99,
+            0.019999999999991,
+            0.99000000000001,
+            48,
+            0.99,
+            0.019999999999991,
+            0.99000000000001,
+            48,
+            0.99,
+            0.019999999999991,
+            0.99000000000001,
+            199,
+            100,
+            200,
+            73.205080756887,
+            114.31535329955,
+            1.1431535329955,
+            0.023094010767563,
+            1.1431535329954,
+            110.17016486681,
+            600,
+        };
+        ref.halfway_safeties = {
+            95,
+            74.75,
+            0.5,
+            24.25,
+            0.495,
+            0.01,
+            0.495,
+            24,
+            0.495,
+            0.01,
+            0.495,
+            24,
+            0.495,
+            0.01,
+            0.495,
+            24,
+            0.495,
+            0.01,
+            0.495,
+            24,
+            0.495,
+            0.01,
+            0.495,
+            99.5,
+            50,
+            99.5,
+            31.698729810778,
+            49.5,
+            0.49499999999996,
+            0.0099999999999922,
+            0.49499999999997,
+            22.457458783298,
+            150,
+        };
+        ref.bumps = {};
+        auto tol = GenericGeoTrackingTolerance::from_test(*test_);
+        tol.distance *= 10;  // 2e-12 diff between g4, vg
+        EXPECT_RESULT_NEAR(ref, result, tol);
+    }
+    {
+        SCOPED_TRACE("Second arm");
+        Real3 dir{0, 0, 0};
+        sincos(Turn{-30.0 / 360.}, &dir[0], &dir[2]);
+        auto result = test_->track({0.125, 0.5, 0.0625}, dir);
+
+        GenericGeoTrackingResult ref;
+        ref.volumes = {
+            "magnetic",     "world",       "secondArm",    "chamber2",
+            "wirePlane2",   "chamber2",    "secondArm",    "chamber2",
+            "wirePlane2",   "chamber2",    "secondArm",    "chamber2",
+            "wirePlane2",   "chamber2",    "secondArm",    "chamber2",
+            "wirePlane2",   "chamber2",    "secondArm",    "chamber2",
+            "wirePlane2",   "chamber2",    "secondArm",    "hodoscope2",
+            "secondArm",    "cell",        "secondArm",    "HadCalLayer",
+            "HadCalScinti", "HadCalLayer", "HadCalScinti", "HadCalLayer",
+            "HadCalScinti", "HadCalLayer", "HadCalScinti", "HadCalLayer",
+            "HadCalScinti", "HadCalLayer", "HadCalScinti", "HadCalLayer",
+            "HadCalScinti", "HadCalLayer", "HadCalScinti", "HadCalLayer",
+            "HadCalScinti", "HadCalLayer", "HadCalScinti", "HadCalLayer",
+            "HadCalScinti", "HadCalLayer", "HadCalScinti", "HadCalLayer",
+            "HadCalScinti", "HadCalLayer", "HadCalScinti", "HadCalLayer",
+            "HadCalScinti", "HadCalLayer", "HadCalScinti", "HadCalLayer",
+            "HadCalScinti", "HadCalLayer", "HadCalScinti", "HadCalLayer",
+            "HadCalScinti", "HadCalLayer", "HadCalScinti", "world",
+        };
+        ref.volume_instances = {
+            "magnetic",          "world_PV",          "fSecondArmPhys",
+            "chamber2",          "wirePlane2",        "chamber2",
+            "fSecondArmPhys",    "chamber2",          "wirePlane2",
+            "chamber2",          "fSecondArmPhys",    "chamber2",
+            "wirePlane2",        "chamber2",          "fSecondArmPhys",
+            "chamber2",          "wirePlane2",        "chamber2",
+            "fSecondArmPhys",    "chamber2",          "wirePlane2",
+            "chamber2",          "fSecondArmPhys",    "hodoscope2",
+            "fSecondArmPhys",    "cell_param@42",     "fSecondArmPhys",
+            "HadCalLayer_PV@0",  "HadCalScinti",      "HadCalLayer_PV@1",
+            "HadCalScinti",      "HadCalLayer_PV@2",  "HadCalScinti",
+            "HadCalLayer_PV@3",  "HadCalScinti",      "HadCalLayer_PV@4",
+            "HadCalScinti",      "HadCalLayer_PV@5",  "HadCalScinti",
+            "HadCalLayer_PV@6",  "HadCalScinti",      "HadCalLayer_PV@7",
+            "HadCalScinti",      "HadCalLayer_PV@8",  "HadCalScinti",
+            "HadCalLayer_PV@9",  "HadCalScinti",      "HadCalLayer_PV@10",
+            "HadCalScinti",      "HadCalLayer_PV@11", "HadCalScinti",
+            "HadCalLayer_PV@12", "HadCalScinti",      "HadCalLayer_PV@13",
+            "HadCalScinti",      "HadCalLayer_PV@14", "HadCalScinti",
+            "HadCalLayer_PV@15", "HadCalScinti",      "HadCalLayer_PV@16",
+            "HadCalScinti",      "HadCalLayer_PV@17", "HadCalScinti",
+            "HadCalLayer_PV@18", "HadCalScinti",      "HadCalLayer_PV@19",
+            "HadCalScinti",      "world_PV",
+        };
+        ref.distances = {
+            100.00827610654,
+            50.000097305727,
+            99,
+            0.98999999999997,
+            0.020000000000008,
+            0.99,
+            48,
+            0.99000000000001,
+            0.019999999999994,
+            0.99000000000001,
+            48,
+            0.99000000000001,
+            0.019999999999994,
+            0.99000000000001,
+            48,
+            0.98999999999995,
+            0.019999999999994,
+            0.99000000000001,
+            48,
+            0.99000000000001,
+            0.019999999999994,
+            0.99000000000001,
+            48.5,
+            1,
+            184.5,
+            30,
+            35,
+            4,
+            0.99999999999999,
+            4,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4.0000000000001,
+            0.99999999999999,
+            4,
+            0.99999999999999,
+            304.61999618334,
+        };
+        ref.halfway_safeties = {
+            50.004040731528,
+            25.000029191686,
+            49.5,
+            0.49499999999999,
+            0.0099999999999814,
+            0.49499999999999,
+            24,
+            0.49499999999997,
+            0.0099999999999798,
+            0.49499999999997,
+            24,
+            0.49499999999997,
+            0.0099999999999798,
+            0.49499999999997,
+            24,
+            0.49499999999998,
+            0.0099999999999798,
+            0.49499999999997,
+            24,
+            0.49499999999997,
+            0.0099999999999798,
+            0.49499999999997,
+            24.25,
+            0.49999999999999,
+            92.25,
+            0.13950317547316,
+            17.5,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            0.13950317547311,
+            0.13950317547314,
+            131.90432759775,
+        };
+        ref.bumps = {};
+        auto tol = GenericGeoTrackingTolerance::from_test(*test_);
+        tol.distance *= 10;  // 2e-12 diff between g4, vg
+        EXPECT_RESULT_NEAR(ref, result, tol);
+    }
+}
+
+//---------------------------------------------------------------------------//
+void ReplicaGeoTest::test_volume_stack() const
+{
+    {
+        auto result = test_->volume_stack({-400, 0.1, 650});
+        GenericGeoVolumeStackResult ref;
+        ref.volume_instances = {
+            "world_PV",
+            "fSecondArmPhys",
+            "HadCalorimeter",
+            "HadCalColumn_PV",
+            "HadCalCell_PV",
+            "HadCalLayer_PV",
+        };
+        ref.replicas = {-1, -1, -1, 4, 1, 2};
+        EXPECT_RESULT_EQ(ref, result);
+    }
+    {
+        // Geant4 gets stuck here
+        auto result = test_->volume_stack({-342.5, 0.1, 593.22740159234});
+        GenericGeoVolumeStackResult ref;
+        ref.volume_instances = {
+            "world_PV",
+            "fSecondArmPhys",
+        };
+        ref.replicas = {-1, -1};
+        if (test_->geometry_type() == "Geant4")
+        {
+            ref.volume_instances.insert(ref.volume_instances.end(),
+                                        {"EMcalorimeter", "cell_param"});
+            ref.replicas.insert(ref.replicas.end(), {-1, 42});
+        }
+        EXPECT_RESULT_EQ(ref, result);
+    }
+    {
+        // A bit further along from the stuck point
+        auto result = test_->volume_stack({-343, 0.1, 596});
+        GenericGeoVolumeStackResult ref;
+        ref.volume_instances = {
+            "world_PV",
+            "fSecondArmPhys",
+            "EMcalorimeter",
+            "cell_param",
+        };
+        ref.replicas = {-1, -1, -1, 42};
+        EXPECT_RESULT_EQ(ref, result);
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -338,7 +338,7 @@ void ReplicaGeoTest::test_volume_stack() const
         EXPECT_RESULT_EQ(ref, result);
     }
     {
-        // Geant4 gets stuck here
+        // Geant4 gets stuck here (it's close to a boundary)
         auto result = test_->volume_stack({-342.5, 0.1, 593.22740159234});
         GenericGeoVolumeStackResult ref;
         ref.volume_instances = {

--- a/test/geocel/GeoTests.hh
+++ b/test/geocel/GeoTests.hh
@@ -1,0 +1,50 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/GeoTests.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string_view>
+
+#include "corecel/math/Turn.hh"
+
+#include "GenericGeoTestInterface.hh"
+#include "TestMacros.hh"
+
+// TODO: move the classes below into this file
+#include "CmsEeBackDeeGeoTest.hh"
+#include "CmseGeoTest.hh"
+#include "FourLevelsGeoTest.hh"
+#include "MultiLevelGeoTest.hh"
+#include "SolidsGeoTest.hh"
+#include "TransformedBoxGeoTest.hh"
+#include "ZnenvGeoTest.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Test the B5 (replica) geometry.
+ */
+class ReplicaGeoTest
+{
+  public:
+    static std::string_view geometry_basename() { return "replica"; }
+
+    //! Construct with a reference to the GoogleTest
+    ReplicaGeoTest(GenericGeoTestInterface* geo_test) : test_{geo_test} {}
+
+    void test_trace() const;
+    void test_volume_stack() const;
+
+  private:
+    GenericGeoTestInterface* test_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/geocel/ReplicaGeoTest.hh
+++ b/test/geocel/ReplicaGeoTest.hh
@@ -154,13 +154,12 @@ void ReplicaGeoTest::test_trace() const
             "wirePlane2",  "chamber2",    "secondArm",   "chamber2",
             "wirePlane2",  "chamber2",    "secondArm",   "chamber2",
             "wirePlane2",  "chamber2",    "secondArm",   "hodoscope2",
-            "secondArm",   "cell",        "secondArm",   "cell",
-            "cell",        "secondArm",   "HadCalLayer", "HadCalLayer",
+            "secondArm",   "cell",        "secondArm",   "HadCalLayer",
             "HadCalLayer", "HadCalLayer", "HadCalLayer", "HadCalLayer",
             "HadCalLayer", "HadCalLayer", "HadCalLayer", "HadCalLayer",
             "HadCalLayer", "HadCalLayer", "HadCalLayer", "HadCalLayer",
             "HadCalLayer", "HadCalLayer", "HadCalLayer", "HadCalLayer",
-            "HadCalLayer", "HadCalLayer", "world",
+            "HadCalLayer", "HadCalLayer", "HadCalLayer", "world",
         };
         EXPECT_VEC_EQ(expected_volumes, result.volumes);
         static char const* const expected_volume_instances[] = {
@@ -173,7 +172,6 @@ void ReplicaGeoTest::test_trace() const
             "fSecondArmPhys",    "chamber2",          "wirePlane2",
             "chamber2",          "fSecondArmPhys",    "hodoscope2",
             "fSecondArmPhys",    "cell_param@42",     "fSecondArmPhys",
-            "cell_param@42",     "cell_param@38",     "fSecondArmPhys",
             "HadCalLayer_PV@0",  "HadCalLayer_PV@1",  "HadCalLayer_PV@2",
             "HadCalLayer_PV@3",  "HadCalLayer_PV@4",  "HadCalLayer_PV@5",
             "HadCalLayer_PV@6",  "HadCalLayer_PV@7",  "HadCalLayer_PV@8",
@@ -187,53 +185,50 @@ void ReplicaGeoTest::test_trace() const
             100,
             50,
             99,
-            0.99,
-            0.020000000000036,
             0.99000000000001,
+            0.019999999999995,
+            0.99000000000002,
             48,
             0.99,
-            0.019999999999991,
-            0.99000000000001,
+            0.01999999999998,
+            0.99,
             48,
             0.99,
-            0.019999999999991,
-            0.99000000000001,
+            0.01999999999998,
+            0.99,
             48,
             0.99,
-            0.019999999999991,
-            0.99000000000001,
+            0.01999999999998,
+            0.99,
             48,
             0.99,
-            0.020000000000036,
-            0.99000000000005,
+            0.01999999999998,
+            0.99,
             48.5,
-            1.0000000000001,
+            0.99999999999999,
             184.5,
-            1e-13,
-            1e-13,
-            1e-13,
             30,
             35,
             5,
-            5,
-            5,
-            5,
             4.9999999999999,
-            5,
+            5.0000000000001,
             5,
             5,
             5,
             5,
             4.9999999999999,
+            5.0000000000001,
             5,
             5,
             5,
             5,
+            4.9999999999999,
+            5.0000000000001,
             5,
             5,
-            4.9999999999998,
             5,
             5,
+            4.9999999999999,
             304.70053837925,
         };
         EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
@@ -265,6 +260,10 @@ void ReplicaGeoTest::test_trace() const
         };
         EXPECT_VEC_NEAR(
             expected_hw_safety, result.halfway_safeties, safety_tol);
+        if (true)  // if (gest_->geometry_type() == "geant4")
+        {
+            EXPECT_EQ(0, result.bumps.size()) << repr(result.bumps);
+        }
     }
 }
 
@@ -292,9 +291,8 @@ void ReplicaGeoTest::test_volume_stack() const
             "world_PV",
             "fSecondArmPhys",
             "EMcalorimeter",
-            "cell_param",
         };
-        ref.replicas = {-1, -1, -1, 42};
+        ref.replicas = {-1, -1, -1};
         EXPECT_RESULT_EQ(ref, result);
     }
 }

--- a/test/geocel/ReplicaGeoTest.hh
+++ b/test/geocel/ReplicaGeoTest.hh
@@ -41,7 +41,7 @@ void ReplicaGeoTest::test_trace() const
 {
     {
         SCOPED_TRACE("Center +z");
-        auto result = test_->track({0, 0.1, -1000}, {0, 0, 1});
+        auto result = test_->track({0, 0.1, -990}, {0, 0, 1});
         real_type const safety_tol = test_->safety_tol();
         static char const* const expected_volumes[] = {
             "world",    "firstArm",   "hodoscope1", "firstArm",
@@ -68,7 +68,7 @@ void ReplicaGeoTest::test_trace() const
         };
         EXPECT_VEC_EQ(expected_volume_instances, result.volume_instances);
         static real_type const expected_distances[] = {
-            200,
+            190,
             149.5,
             1,
             48.5,
@@ -102,9 +102,9 @@ void ReplicaGeoTest::test_trace() const
             110.17016486681,
             600,
         };
-        EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
+        EXPECT_VEC_NEAR(expected_distances, result.distances, 1e-11);
         static real_type const expected_hw_safety[] = {
-            100,
+            95,
             74.75,
             0.5,
             24.25,

--- a/test/geocel/ReplicaGeoTest.hh
+++ b/test/geocel/ReplicaGeoTest.hh
@@ -1,0 +1,304 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/ReplicaGeoTest.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string_view>
+
+#include "corecel/math/Turn.hh"
+
+#include "GenericGeoTestInterface.hh"
+#include "TestMacros.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Test the B5 (replica) geometry.
+ */
+class ReplicaGeoTest
+{
+  public:
+    static std::string_view geometry_basename() { return "replica"; }
+
+    //! Construct with a reference to the GoogleTest
+    ReplicaGeoTest(GenericGeoTestInterface* geo_test) : test_{geo_test} {}
+
+    inline void test_trace() const;
+    inline void test_volume_stack() const;
+
+  private:
+    GenericGeoTestInterface* test_;
+};
+
+//---------------------------------------------------------------------------//
+void ReplicaGeoTest::test_trace() const
+{
+    {
+        SCOPED_TRACE("Center +z");
+        auto result = test_->track({0, 0.1, -1000}, {0, 0, 1});
+        real_type const safety_tol = test_->safety_tol();
+        static char const* const expected_volumes[] = {
+            "world",    "firstArm",   "hodoscope1", "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "world",    "magnetic",   "world",      "secondArm",
+            "chamber2", "wirePlane2", "chamber2",   "secondArm",
+            "world",
+        };
+        EXPECT_VEC_EQ(expected_volumes, result.volumes);
+        static char const* const expected_volume_instances[] = {
+            "world_PV", "firstArm",   "hodoscope1", "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "chamber1", "wirePlane1", "chamber1",   "firstArm",
+            "world_PV", "magnetic",   "world_PV",   "fSecondArmPhys",
+            "chamber2", "wirePlane2", "chamber2",   "fSecondArmPhys",
+            "world_PV",
+        };
+        EXPECT_VEC_EQ(expected_volume_instances, result.volume_instances);
+        static real_type const expected_distances[] = {
+            200,
+            149.5,
+            1,
+            48.5,
+            0.99,
+            0.020000000000036,
+            0.98999999999996,
+            48,
+            0.99,
+            0.020000000000036,
+            0.98999999999996,
+            48,
+            0.99,
+            0.020000000000036,
+            0.98999999999996,
+            48,
+            0.99,
+            0.020000000000036,
+            0.98999999999996,
+            48,
+            0.99,
+            0.019999999999991,
+            0.99000000000001,
+            199,
+            100,
+            200,
+            73.205080756887,
+            114.31535329955,
+            1.1431535329955,
+            0.023094010767522,
+            1.1431535329955,
+            110.17016486681,
+            600,
+        };
+        EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
+        static real_type const expected_hw_safety[] = {
+            100,
+            74.75,
+            0.5,
+            24.25,
+            0.49499999999998,
+            0.01,
+            0.49499999999998,
+            24,
+            0.49499999999998,
+            0.01,
+            0.49499999999998,
+            24,
+            0.49499999999998,
+            0.01,
+            0.49499999999998,
+            24,
+            0.49499999999998,
+            0.01,
+            0.49499999999998,
+            24,
+            0.49499999999998,
+            0.01,
+            0.49499999999998,
+            99.5,
+            50,
+            99.9,
+            31.698729810778,
+            49.5,
+            0.49499999999998,
+            0.01,
+            0.49499999999997,
+            22.457458783298,
+            150,
+        };
+        EXPECT_VEC_NEAR(
+            expected_hw_safety, result.halfway_safeties, safety_tol);
+    }
+    {
+        SCOPED_TRACE("Second arm");
+        Real3 dir{0, 0, 0};
+        sincos(Turn{-30.0 / 360.}, &dir[0], &dir[2]);
+        auto result = test_->track({0, 0.1, 0}, dir);
+        real_type const safety_tol = test_->safety_tol();
+        static char const* const expected_volumes[] = {
+            "magnetic",    "world",       "secondArm",   "chamber2",
+            "wirePlane2",  "chamber2",    "secondArm",   "chamber2",
+            "wirePlane2",  "chamber2",    "secondArm",   "chamber2",
+            "wirePlane2",  "chamber2",    "secondArm",   "chamber2",
+            "wirePlane2",  "chamber2",    "secondArm",   "chamber2",
+            "wirePlane2",  "chamber2",    "secondArm",   "hodoscope2",
+            "secondArm",   "cell",        "secondArm",   "cell",
+            "cell",        "secondArm",   "HadCalLayer", "HadCalLayer",
+            "HadCalLayer", "HadCalLayer", "HadCalLayer", "HadCalLayer",
+            "HadCalLayer", "HadCalLayer", "HadCalLayer", "HadCalLayer",
+            "HadCalLayer", "HadCalLayer", "HadCalLayer", "HadCalLayer",
+            "HadCalLayer", "HadCalLayer", "HadCalLayer", "HadCalLayer",
+            "HadCalLayer", "HadCalLayer", "world",
+        };
+        EXPECT_VEC_EQ(expected_volumes, result.volumes);
+        static char const* const expected_volume_instances[] = {
+            "magnetic",          "world_PV",          "fSecondArmPhys",
+            "chamber2",          "wirePlane2",        "chamber2",
+            "fSecondArmPhys",    "chamber2",          "wirePlane2",
+            "chamber2",          "fSecondArmPhys",    "chamber2",
+            "wirePlane2",        "chamber2",          "fSecondArmPhys",
+            "chamber2",          "wirePlane2",        "chamber2",
+            "fSecondArmPhys",    "chamber2",          "wirePlane2",
+            "chamber2",          "fSecondArmPhys",    "hodoscope2",
+            "fSecondArmPhys",    "cell_param@42",     "fSecondArmPhys",
+            "cell_param@42",     "cell_param@38",     "fSecondArmPhys",
+            "HadCalLayer_PV@0",  "HadCalLayer_PV@1",  "HadCalLayer_PV@2",
+            "HadCalLayer_PV@3",  "HadCalLayer_PV@4",  "HadCalLayer_PV@5",
+            "HadCalLayer_PV@6",  "HadCalLayer_PV@7",  "HadCalLayer_PV@8",
+            "HadCalLayer_PV@9",  "HadCalLayer_PV@10", "HadCalLayer_PV@11",
+            "HadCalLayer_PV@12", "HadCalLayer_PV@13", "HadCalLayer_PV@14",
+            "HadCalLayer_PV@15", "HadCalLayer_PV@16", "HadCalLayer_PV@17",
+            "HadCalLayer_PV@18", "HadCalLayer_PV@19", "world_PV",
+        };
+        EXPECT_VEC_EQ(expected_volume_instances, result.volume_instances);
+        static real_type const expected_distances[] = {
+            100,
+            50,
+            99,
+            0.99,
+            0.020000000000036,
+            0.99000000000001,
+            48,
+            0.99,
+            0.019999999999991,
+            0.99000000000001,
+            48,
+            0.99,
+            0.019999999999991,
+            0.99000000000001,
+            48,
+            0.99,
+            0.019999999999991,
+            0.99000000000001,
+            48,
+            0.99,
+            0.020000000000036,
+            0.99000000000005,
+            48.5,
+            1.0000000000001,
+            184.5,
+            1e-13,
+            1e-13,
+            1e-13,
+            30,
+            35,
+            5,
+            5,
+            5,
+            5,
+            4.9999999999999,
+            5,
+            5,
+            5,
+            5,
+            5,
+            4.9999999999999,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            4.9999999999998,
+            5,
+            5,
+            304.70053837925,
+        };
+        EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
+        static real_type const expected_hw_safety[] = {
+            50,    25,
+            49.5,  0.49499999999998,
+            0.01,  0.49499999999997,
+            24,    0.49499999999998,
+            0.01,  0.49499999999997,
+            24,    0.49499999999998,
+            0.01,  0.49499999999997,
+            24,    0.49499999999998,
+            0.01,  0.49499999999997,
+            24,    0.49499999999998,
+            0.01,  0.49499999999993,
+            24.25, 0.5,
+            92.25, 0,
+            17.5,  0,
+            0,     0,
+            0,     0,
+            0,     0,
+            0,     0,
+            0,     0,
+            0,     0,
+            0,     0,
+            0,     0,
+            0,     0,
+            0,     131.93920339161,
+        };
+        EXPECT_VEC_NEAR(
+            expected_hw_safety, result.halfway_safeties, safety_tol);
+    }
+}
+
+//---------------------------------------------------------------------------//
+void ReplicaGeoTest::test_volume_stack() const
+{
+    {
+        auto result = test_->volume_stack({-400, 0.1, 650});
+        GenericGeoVolumeStackResult ref;
+        ref.volume_instances = {
+            "world_PV",
+            "fSecondArmPhys",
+            "HadCalorimeter",
+            "HadCalColumn_PV",
+            "HadCalCell_PV",
+            "HadCalLayer_PV",
+        };
+        ref.replicas = {-1, -1, -1, 4, 1, 2};
+        EXPECT_RESULT_EQ(ref, result);
+    }
+    {
+        auto result = test_->volume_stack({-342.5, 0.0, 593.227402});
+        GenericGeoVolumeStackResult ref;
+        ref.volume_instances = {
+            "world_PV",
+            "fSecondArmPhys",
+            "EMcalorimeter",
+            "cell_param",
+        };
+        ref.replicas = {-1, -1, -1, 42};
+        EXPECT_RESULT_EQ(ref, result);
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/geocel/data/replica.gdml
+++ b/test/geocel/data/replica.gdml
@@ -1,0 +1,805 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+  <define/>
+
+  <materials>
+    <isotope N="12" Z="6" name="C120x15716fe80">
+      <atom unit="g/mole" value="12"/>
+    </isotope>
+    <isotope N="13" Z="6" name="C130x15716fee0">
+      <atom unit="g/mole" value="13.0034"/>
+    </isotope>
+    <element name="C0x15716ff30">
+      <fraction n="0.9893" ref="C120x15716fe80"/>
+      <fraction n="0.0107" ref="C130x15716fee0"/>
+    </element>
+    <isotope N="14" Z="7" name="N140x157170130">
+      <atom unit="g/mole" value="14.0031"/>
+    </isotope>
+    <isotope N="15" Z="7" name="N150x157170190">
+      <atom unit="g/mole" value="15.0001"/>
+    </isotope>
+    <element name="N0x1571701e0">
+      <fraction n="0.99632" ref="N140x157170130"/>
+      <fraction n="0.00368" ref="N150x157170190"/>
+    </element>
+    <isotope N="16" Z="8" name="O160x157170390">
+      <atom unit="g/mole" value="15.9949"/>
+    </isotope>
+    <isotope N="17" Z="8" name="O170x157170410">
+      <atom unit="g/mole" value="16.9991"/>
+    </isotope>
+    <isotope N="18" Z="8" name="O180x157170450">
+      <atom unit="g/mole" value="17.9992"/>
+    </isotope>
+    <element name="O0x157170490">
+      <fraction n="0.99757" ref="O160x157170390"/>
+      <fraction n="0.00038" ref="O170x157170410"/>
+      <fraction n="0.00205" ref="O180x157170450"/>
+    </element>
+    <isotope N="36" Z="18" name="Ar360x157170690">
+      <atom unit="g/mole" value="35.9675"/>
+    </isotope>
+    <isotope N="38" Z="18" name="Ar380x1571706d0">
+      <atom unit="g/mole" value="37.9627"/>
+    </isotope>
+    <isotope N="40" Z="18" name="Ar400x1571703d0">
+      <atom unit="g/mole" value="39.9624"/>
+    </isotope>
+    <element name="Ar0x1571707b0">
+      <fraction n="0.003365" ref="Ar360x157170690"/>
+      <fraction n="0.000632" ref="Ar380x1571706d0"/>
+      <fraction n="0.996003" ref="Ar400x1571703d0"/>
+    </element>
+    <material name="G4_AIR0x15716fd60" state="gas">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="85.7"/>
+      <D unit="g/cm3" value="0.00120479"/>
+      <fraction n="0.000124000124000124" ref="C0x15716ff30"/>
+      <fraction n="0.755267755267755" ref="N0x1571701e0"/>
+      <fraction n="0.231781231781232" ref="O0x157170490"/>
+      <fraction n="0.0128270128270128" ref="Ar0x1571707b0"/>
+    </material>
+    <isotope N="1" Z="1" name="H10x157171be0">
+      <atom unit="g/mole" value="1.00782503081372"/>
+    </isotope>
+    <isotope N="2" Z="1" name="H20x157171c20">
+      <atom unit="g/mole" value="2.01410199966617"/>
+    </isotope>
+    <element name="H0x157171c60">
+      <fraction n="0.999885" ref="H10x157171be0"/>
+      <fraction n="0.000115" ref="H20x157171c20"/>
+    </element>
+    <material name="G4_PLASTIC_SC_VINYLTOLUENE0x157171a90" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="64.7"/>
+      <D unit="g/cm3" value="1.032"/>
+      <fraction n="0.914708531800025" ref="C0x15716ff30"/>
+      <fraction n="0.0852914681999746" ref="H0x157171c60"/>
+    </material>
+    <material name="G4_Ar0x157170e80" state="gas">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="188"/>
+      <D unit="g/cm3" value="0.00166201"/>
+      <fraction n="1" ref="Ar0x1571707b0"/>
+    </material>
+    <isotope N="133" Z="55" name="Cs1330x1571722c0">
+      <atom unit="g/mole" value="132.905"/>
+    </isotope>
+    <element name="Cs0x157172590">
+      <fraction n="1" ref="Cs1330x1571722c0"/>
+    </element>
+    <isotope N="127" Z="53" name="I1270x1571727b0">
+      <atom unit="g/mole" value="126.904"/>
+    </isotope>
+    <element name="I0x157172800">
+      <fraction n="1" ref="I1270x1571727b0"/>
+    </element>
+    <material name="G4_CESIUM_IODIDE0x157171f90" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="553.1"/>
+      <D unit="g/cm3" value="4.51"/>
+      <fraction n="0.511548868591927" ref="Cs0x157172590"/>
+      <fraction n="0.488451131408073" ref="I0x157172800"/>
+    </material>
+    <isotope N="204" Z="82" name="Pb2040x1571730d0">
+      <atom unit="g/mole" value="203.973"/>
+    </isotope>
+    <isotope N="206" Z="82" name="Pb2060x157172bc0">
+      <atom unit="g/mole" value="205.974"/>
+    </isotope>
+    <isotope N="207" Z="82" name="Pb2070x157172c00">
+      <atom unit="g/mole" value="206.976"/>
+    </isotope>
+    <isotope N="208" Z="82" name="Pb2080x157170710">
+      <atom unit="g/mole" value="207.977"/>
+    </isotope>
+    <element name="Pb0x1571736a0">
+      <fraction n="0.014" ref="Pb2040x1571730d0"/>
+      <fraction n="0.241" ref="Pb2060x157172bc0"/>
+      <fraction n="0.221" ref="Pb2070x157172c00"/>
+      <fraction n="0.524" ref="Pb2080x157170710"/>
+    </element>
+    <material name="G4_Pb0x157173590" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="823"/>
+      <D unit="g/cm3" value="11.35"/>
+      <fraction n="1" ref="Pb0x1571736a0"/>
+    </material>
+  </materials>
+
+  <solids>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="magneticTubs0x157174c10" rmax="1000" rmin="0" startphi="0" z="2000"/>
+    <box lunit="mm" name="hodoscope1Box0x1571755f0" x="100" y="400" z="10"/>
+    <box lunit="mm" name="wirePlane1Box0x157176540" x="2000" y="600" z="0.2"/>
+    <box lunit="mm" name="chamber1Box0x157176000" x="2000" y="600" z="20"/>
+    <box lunit="mm" name="firstArmBox0x157174fe0" x="3000" y="2000" z="6000"/>
+    <box lunit="mm" name="hodoscope2Box0x1571767e0" x="100" y="400" z="10"/>
+    <box lunit="mm" name="wirePlane2Box0x157177c20" x="3000" y="600" z="0.2"/>
+    <box lunit="mm" name="chamber2Box0x157177760" x="3000" y="600" z="20"/>
+    <box lunit="mm" name="cellBox0x1571781a0" x="150" y="150" z="300"/>
+    <box lunit="mm" name="EMcalorimeterBox0x157177ec0" x="3000" y="600" z="300"/>
+    <box lunit="mm" name="HadCalScintiBox0x157178fe0" x="300" y="300" z="10"/>
+    <box lunit="mm" name="HadCalLayerBox0x157178cf0" x="300" y="300" z="50"/>
+    <box lunit="mm" name="HadCalCellBox0x157178a00" x="300" y="300" z="1000"/>
+    <box lunit="mm" name="HadCalColumnBox0x157178770" x="300" y="600" z="1000"/>
+    <box lunit="mm" name="HadCalorimeterBox0x157178440" x="3000" y="600" z="1000"/>
+    <box lunit="mm" name="secondArmBox0x157175310" x="4000" y="4000" z="7000"/>
+    <box lunit="mm" name="worldBox0x157173ff0" x="20000" y="6000" z="20000"/>
+  </solids>
+
+  <structure>
+    <volume name="magnetic0x157174d60">
+      <materialref ref="G4_AIR0x15716fd60"/>
+      <solidref ref="magneticTubs0x157174c10"/>
+    </volume>
+    <volume name="hodoscope10x1571756b0">
+      <materialref ref="G4_PLASTIC_SC_VINYLTOLUENE0x157171a90"/>
+      <solidref ref="hodoscope1Box0x1571755f0"/>
+    </volume>
+    <volume name="wirePlane10x1571765b0">
+      <materialref ref="G4_Ar0x157170e80"/>
+      <solidref ref="wirePlane1Box0x157176540"/>
+    </volume>
+    <volume name="chamber10x157176070">
+      <materialref ref="G4_Ar0x157170e80"/>
+      <solidref ref="chamber1Box0x157176000"/>
+      <physvol name="wirePlane10x1571766d0">
+        <volumeref ref="wirePlane10x1571765b0"/>
+      </physvol>
+    </volume>
+    <volume name="firstArm0x1571750c0">
+      <materialref ref="G4_AIR0x15716fd60"/>
+      <solidref ref="firstArmBox0x157174fe0"/>
+      <physvol name="hodoscope10x1571757a0">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x1571757a0_pos" unit="mm" x="-700" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="1" name="hodoscope10x157175870">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175870_pos" unit="mm" x="-600" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="2" name="hodoscope10x1571758f0">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x1571758f0_pos" unit="mm" x="-500" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="3" name="hodoscope10x1571759a0">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x1571759a0_pos" unit="mm" x="-400" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="4" name="hodoscope10x157175a10">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175a10_pos" unit="mm" x="-300" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="5" name="hodoscope10x157175b00">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175b00_pos" unit="mm" x="-200" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="6" name="hodoscope10x157175b50">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175b50_pos" unit="mm" x="-100" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="7" name="hodoscope10x157175ba0">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175ba0_pos" unit="mm" x="0" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="8" name="hodoscope10x157175c10">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175c10_pos" unit="mm" x="100" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="9" name="hodoscope10x157175d80">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175d80_pos" unit="mm" x="200" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="10" name="hodoscope10x157175aa0">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175aa0_pos" unit="mm" x="300" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="11" name="hodoscope10x157175df0">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175df0_pos" unit="mm" x="400" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="12" name="hodoscope10x157175e60">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175e60_pos" unit="mm" x="500" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="13" name="hodoscope10x157175ed0">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175ed0_pos" unit="mm" x="600" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="14" name="hodoscope10x157175f40">
+        <volumeref ref="hodoscope10x1571756b0"/>
+        <position name="hodoscope10x157175f40_pos" unit="mm" x="700" y="0" z="-1500"/>
+      </physvol>
+      <physvol name="chamber10x157176190">
+        <volumeref ref="chamber10x157176070"/>
+        <position name="chamber10x157176190_pos" unit="mm" x="0" y="0" z="-1000"/>
+      </physvol>
+      <physvol copynumber="1" name="chamber10x157176250">
+        <volumeref ref="chamber10x157176070"/>
+        <position name="chamber10x157176250_pos" unit="mm" x="0" y="0" z="-500"/>
+      </physvol>
+      <physvol copynumber="2" name="chamber10x1571763c0">
+        <volumeref ref="chamber10x157176070"/>
+      </physvol>
+      <physvol copynumber="3" name="chamber10x157176410">
+        <volumeref ref="chamber10x157176070"/>
+        <position name="chamber10x157176410_pos" unit="mm" x="0" y="0" z="500"/>
+      </physvol>
+      <physvol copynumber="4" name="chamber10x157176460">
+        <volumeref ref="chamber10x157176070"/>
+        <position name="chamber10x157176460_pos" unit="mm" x="0" y="0" z="1000"/>
+      </physvol>
+    </volume>
+    <volume name="hodoscope20x157176870">
+      <materialref ref="G4_PLASTIC_SC_VINYLTOLUENE0x157171a90"/>
+      <solidref ref="hodoscope2Box0x1571767e0"/>
+    </volume>
+    <volume name="wirePlane20x157177c90">
+      <materialref ref="G4_Ar0x157170e80"/>
+      <solidref ref="wirePlane2Box0x157177c20"/>
+    </volume>
+    <volume name="chamber20x1571777d0">
+      <materialref ref="G4_Ar0x157170e80"/>
+      <solidref ref="chamber2Box0x157177760"/>
+      <physvol name="wirePlane20x157177db0">
+        <volumeref ref="wirePlane20x157177c90"/>
+      </physvol>
+    </volume>
+    <volume name="cell0x157178220">
+      <materialref ref="G4_CESIUM_IODIDE0x157171f90"/>
+      <solidref ref="cellBox0x1571781a0"/>
+    </volume>
+    <volume name="EMcalorimeter0x157177f50">
+      <materialref ref="G4_CESIUM_IODIDE0x157171f90"/>
+      <solidref ref="EMcalorimeterBox0x157177ec0"/>
+      <paramvol ncopies="80">
+        <volumeref ref="cell0x157178220"/>
+        <parameterised_position_size>
+          <parameters number="1">
+            <position name="cell0x1571783500_pos" unit="mm" x="-1425" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="2">
+            <position name="cell0x1571783501_pos" unit="mm" x="-1425" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="3">
+            <position name="cell0x1571783502_pos" unit="mm" x="-1425" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="4">
+            <position name="cell0x1571783503_pos" unit="mm" x="-1425" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="5">
+            <position name="cell0x1571783504_pos" unit="mm" x="-1275" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="6">
+            <position name="cell0x1571783505_pos" unit="mm" x="-1275" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="7">
+            <position name="cell0x1571783506_pos" unit="mm" x="-1275" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="8">
+            <position name="cell0x1571783507_pos" unit="mm" x="-1275" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="9">
+            <position name="cell0x1571783508_pos" unit="mm" x="-1125" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="10">
+            <position name="cell0x1571783509_pos" unit="mm" x="-1125" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="11">
+            <position name="cell0x15717835010_pos" unit="mm" x="-1125" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="12">
+            <position name="cell0x15717835011_pos" unit="mm" x="-1125" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="13">
+            <position name="cell0x15717835012_pos" unit="mm" x="-975" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="14">
+            <position name="cell0x15717835013_pos" unit="mm" x="-975" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="15">
+            <position name="cell0x15717835014_pos" unit="mm" x="-975" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="16">
+            <position name="cell0x15717835015_pos" unit="mm" x="-975" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="17">
+            <position name="cell0x15717835016_pos" unit="mm" x="-825" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="18">
+            <position name="cell0x15717835017_pos" unit="mm" x="-825" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="19">
+            <position name="cell0x15717835018_pos" unit="mm" x="-825" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="20">
+            <position name="cell0x15717835019_pos" unit="mm" x="-825" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="21">
+            <position name="cell0x15717835020_pos" unit="mm" x="-675" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="22">
+            <position name="cell0x15717835021_pos" unit="mm" x="-675" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="23">
+            <position name="cell0x15717835022_pos" unit="mm" x="-675" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="24">
+            <position name="cell0x15717835023_pos" unit="mm" x="-675" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="25">
+            <position name="cell0x15717835024_pos" unit="mm" x="-525" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="26">
+            <position name="cell0x15717835025_pos" unit="mm" x="-525" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="27">
+            <position name="cell0x15717835026_pos" unit="mm" x="-525" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="28">
+            <position name="cell0x15717835027_pos" unit="mm" x="-525" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="29">
+            <position name="cell0x15717835028_pos" unit="mm" x="-375" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="30">
+            <position name="cell0x15717835029_pos" unit="mm" x="-375" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="31">
+            <position name="cell0x15717835030_pos" unit="mm" x="-375" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="32">
+            <position name="cell0x15717835031_pos" unit="mm" x="-375" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="33">
+            <position name="cell0x15717835032_pos" unit="mm" x="-225" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="34">
+            <position name="cell0x15717835033_pos" unit="mm" x="-225" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="35">
+            <position name="cell0x15717835034_pos" unit="mm" x="-225" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="36">
+            <position name="cell0x15717835035_pos" unit="mm" x="-225" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="37">
+            <position name="cell0x15717835036_pos" unit="mm" x="-75" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="38">
+            <position name="cell0x15717835037_pos" unit="mm" x="-75" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="39">
+            <position name="cell0x15717835038_pos" unit="mm" x="-75" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="40">
+            <position name="cell0x15717835039_pos" unit="mm" x="-75" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="41">
+            <position name="cell0x15717835040_pos" unit="mm" x="75" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="42">
+            <position name="cell0x15717835041_pos" unit="mm" x="75" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="43">
+            <position name="cell0x15717835042_pos" unit="mm" x="75" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="44">
+            <position name="cell0x15717835043_pos" unit="mm" x="75" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="45">
+            <position name="cell0x15717835044_pos" unit="mm" x="225" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="46">
+            <position name="cell0x15717835045_pos" unit="mm" x="225" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="47">
+            <position name="cell0x15717835046_pos" unit="mm" x="225" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="48">
+            <position name="cell0x15717835047_pos" unit="mm" x="225" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="49">
+            <position name="cell0x15717835048_pos" unit="mm" x="375" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="50">
+            <position name="cell0x15717835049_pos" unit="mm" x="375" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="51">
+            <position name="cell0x15717835050_pos" unit="mm" x="375" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="52">
+            <position name="cell0x15717835051_pos" unit="mm" x="375" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="53">
+            <position name="cell0x15717835052_pos" unit="mm" x="525" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="54">
+            <position name="cell0x15717835053_pos" unit="mm" x="525" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="55">
+            <position name="cell0x15717835054_pos" unit="mm" x="525" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="56">
+            <position name="cell0x15717835055_pos" unit="mm" x="525" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="57">
+            <position name="cell0x15717835056_pos" unit="mm" x="675" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="58">
+            <position name="cell0x15717835057_pos" unit="mm" x="675" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="59">
+            <position name="cell0x15717835058_pos" unit="mm" x="675" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="60">
+            <position name="cell0x15717835059_pos" unit="mm" x="675" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="61">
+            <position name="cell0x15717835060_pos" unit="mm" x="825" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="62">
+            <position name="cell0x15717835061_pos" unit="mm" x="825" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="63">
+            <position name="cell0x15717835062_pos" unit="mm" x="825" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="64">
+            <position name="cell0x15717835063_pos" unit="mm" x="825" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="65">
+            <position name="cell0x15717835064_pos" unit="mm" x="975" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="66">
+            <position name="cell0x15717835065_pos" unit="mm" x="975" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="67">
+            <position name="cell0x15717835066_pos" unit="mm" x="975" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="68">
+            <position name="cell0x15717835067_pos" unit="mm" x="975" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="69">
+            <position name="cell0x15717835068_pos" unit="mm" x="1125" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="70">
+            <position name="cell0x15717835069_pos" unit="mm" x="1125" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="71">
+            <position name="cell0x15717835070_pos" unit="mm" x="1125" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="72">
+            <position name="cell0x15717835071_pos" unit="mm" x="1125" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="73">
+            <position name="cell0x15717835072_pos" unit="mm" x="1275" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="74">
+            <position name="cell0x15717835073_pos" unit="mm" x="1275" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="75">
+            <position name="cell0x15717835074_pos" unit="mm" x="1275" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="76">
+            <position name="cell0x15717835075_pos" unit="mm" x="1275" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="77">
+            <position name="cell0x15717835076_pos" unit="mm" x="1425" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="78">
+            <position name="cell0x15717835077_pos" unit="mm" x="1425" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="79">
+            <position name="cell0x15717835078_pos" unit="mm" x="1425" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="80">
+            <position name="cell0x15717835079_pos" unit="mm" x="1425" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+        </parameterised_position_size>
+      </paramvol>
+    </volume>
+    <volume name="HadCalScinti0x1571790c0">
+      <materialref ref="G4_PLASTIC_SC_VINYLTOLUENE0x157171a90"/>
+      <solidref ref="HadCalScintiBox0x157178fe0"/>
+    </volume>
+    <volume name="HadCalLayer0x157178dd0">
+      <materialref ref="G4_Pb0x157173590"/>
+      <solidref ref="HadCalLayerBox0x157178cf0"/>
+      <physvol name="HadCalScinti0x1571791f0">
+        <volumeref ref="HadCalScinti0x1571790c0"/>
+        <position name="HadCalScinti0x1571791f0_pos" unit="mm" x="0" y="0" z="20"/>
+      </physvol>
+    </volume>
+    <volume name="HadCalCell0x157178ae0">
+      <materialref ref="G4_Pb0x157173590"/>
+      <solidref ref="HadCalCellBox0x157178a00"/>
+      <replicavol number="20">
+        <volumeref ref="HadCalLayer0x157178dd0"/>
+        <replicate_along_axis>
+          <direction z="1"/>
+          <width unit="mm" value="50"/>
+          <offset unit="mm" value="0"/>
+        </replicate_along_axis>
+      </replicavol>
+    </volume>
+    <volume name="HadCalColumn0x1571787f0">
+      <materialref ref="G4_Pb0x157173590"/>
+      <solidref ref="HadCalColumnBox0x157178770"/>
+      <replicavol number="2">
+        <volumeref ref="HadCalCell0x157178ae0"/>
+        <replicate_along_axis>
+          <direction y="1"/>
+          <width unit="mm" value="300"/>
+          <offset unit="mm" value="0"/>
+        </replicate_along_axis>
+      </replicavol>
+    </volume>
+    <volume name="HadCalorimeter0x157178520">
+      <materialref ref="G4_Pb0x157173590"/>
+      <solidref ref="HadCalorimeterBox0x157178440"/>
+      <replicavol number="10">
+        <volumeref ref="HadCalColumn0x1571787f0"/>
+        <replicate_along_axis>
+          <direction x="1"/>
+          <width unit="mm" value="300"/>
+          <offset unit="mm" value="0"/>
+        </replicate_along_axis>
+      </replicavol>
+    </volume>
+    <volume name="secondArm0x157175390">
+      <materialref ref="G4_AIR0x15716fd60"/>
+      <solidref ref="secondArmBox0x157175310"/>
+      <physvol name="hodoscope20x1571769a0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x1571769a0_pos" unit="mm" x="-1200" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="1" name="hodoscope20x157176a70">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176a70_pos" unit="mm" x="-1100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="2" name="hodoscope20x157176af0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176af0_pos" unit="mm" x="-1000" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="3" name="hodoscope20x157176ba0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176ba0_pos" unit="mm" x="-900" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="4" name="hodoscope20x157176c10">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176c10_pos" unit="mm" x="-800" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="5" name="hodoscope20x157176d00">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176d00_pos" unit="mm" x="-700" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="6" name="hodoscope20x157176d50">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176d50_pos" unit="mm" x="-600" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="7" name="hodoscope20x157176da0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176da0_pos" unit="mm" x="-500" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="8" name="hodoscope20x157176e10">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176e10_pos" unit="mm" x="-400" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="9" name="hodoscope20x157176f80">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176f80_pos" unit="mm" x="-300" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="10" name="hodoscope20x157176ca0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176ca0_pos" unit="mm" x="-200" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="11" name="hodoscope20x157176ff0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176ff0_pos" unit="mm" x="-100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="12" name="hodoscope20x157177060">
+        <volumeref ref="hodoscope20x157176870"/>
+      </physvol>
+      <physvol copynumber="13" name="hodoscope20x1571770d0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x1571770d0_pos" unit="mm" x="100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="14" name="hodoscope20x157177140">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157177140_pos" unit="mm" x="200" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="15" name="hodoscope20x1571771b0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x1571771b0_pos" unit="mm" x="300" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="16" name="hodoscope20x157177220">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157177220_pos" unit="mm" x="400" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="17" name="hodoscope20x157176e80">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176e80_pos" unit="mm" x="500" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="18" name="hodoscope20x157176ef0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157176ef0_pos" unit="mm" x="600" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="19" name="hodoscope20x157177490">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157177490_pos" unit="mm" x="700" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="20" name="hodoscope20x1571774e0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x1571774e0_pos" unit="mm" x="800" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="21" name="hodoscope20x157177550">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157177550_pos" unit="mm" x="900" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="22" name="hodoscope20x1571775c0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x1571775c0_pos" unit="mm" x="1000" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="23" name="hodoscope20x157177630">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x157177630_pos" unit="mm" x="1100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="24" name="hodoscope20x1571776a0">
+        <volumeref ref="hodoscope20x157176870"/>
+        <position name="hodoscope20x1571776a0_pos" unit="mm" x="1200" y="0" z="0"/>
+      </physvol>
+      <physvol name="chamber20x1571778f0">
+        <volumeref ref="chamber20x1571777d0"/>
+        <position name="chamber20x1571778f0_pos" unit="mm" x="0" y="0" z="-2500"/>
+      </physvol>
+      <physvol copynumber="1" name="chamber20x1571779b0">
+        <volumeref ref="chamber20x1571777d0"/>
+        <position name="chamber20x1571779b0_pos" unit="mm" x="0" y="0" z="-2000"/>
+      </physvol>
+      <physvol copynumber="2" name="chamber20x157177a20">
+        <volumeref ref="chamber20x1571777d0"/>
+        <position name="chamber20x157177a20_pos" unit="mm" x="0" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="3" name="chamber20x157177ab0">
+        <volumeref ref="chamber20x1571777d0"/>
+        <position name="chamber20x157177ab0_pos" unit="mm" x="0" y="0" z="-1000"/>
+      </physvol>
+      <physvol copynumber="4" name="chamber20x157177b20">
+        <volumeref ref="chamber20x1571777d0"/>
+        <position name="chamber20x157177b20_pos" unit="mm" x="0" y="0" z="-500"/>
+      </physvol>
+      <physvol name="EMcalorimeter0x157178080">
+        <volumeref ref="EMcalorimeter0x157177f50"/>
+        <position name="EMcalorimeter0x157178080_pos" unit="mm" x="0" y="0" z="2000"/>
+      </physvol>
+      <physvol name="HadCalorimeter0x157178650">
+        <volumeref ref="HadCalorimeter0x157178520"/>
+        <position name="HadCalorimeter0x157178650_pos" unit="mm" x="0" y="0" z="3000"/>
+      </physvol>
+    </volume>
+    <volume name="world">
+      <materialref ref="G4_AIR0x15716fd60"/>
+      <solidref ref="worldBox0x157173ff0"/>
+      <physvol name="magnetic0x157174ea0">
+        <volumeref ref="magnetic0x157174d60"/>
+        <rotation name="magnetic0x157174ea0_rot" unit="deg" x="90" y="0" z="0"/>
+      </physvol>
+      <physvol name="firstArm0x1571751f0">
+        <volumeref ref="firstArm0x1571750c0"/>
+        <position name="firstArm0x1571751f0_pos" unit="mm" x="0" y="0" z="-5000"/>
+      </physvol>
+      <physvol name="fSecondArmPhys0x1571754c0">
+        <volumeref ref="secondArm0x157175390"/>
+        <position name="fSecondArmPhys0x1571754c0_pos" unit="mm" x="-2500" y="0" z="4330.12701892219"/>
+        <rotation name="fSecondArmPhys0x1571754c0_rot" unit="deg" x="0" y="30" z="0"/>
+      </physvol>
+    </volume>
+  </structure>
+
+  <setup name="Default" version="1.0">
+    <world ref="world"/>
+  </setup>
+
+</gdml>

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -28,6 +28,7 @@
 #include "../FourLevelsGeoTest.hh"
 #include "../GenericGeoParameterizedTest.hh"
 #include "../MultiLevelGeoTest.hh"
+#include "../ReplicaGeoTest.hh"
 #include "../SolidsGeoTest.hh"
 #include "../TransformedBoxGeoTest.hh"
 #include "../ZnenvGeoTest.hh"
@@ -289,6 +290,19 @@ TEST_F(FourLevelsTest, levels)
     geo.cross_boundary();
 
     EXPECT_EQ("[OUTSIDE]", this->all_volume_instance_names(geo));
+}
+
+//---------------------------------------------------------------------------//
+using ReplicaTest = GenericGeoParameterizedTest<GeantGeoTest, ReplicaGeoTest>;
+
+TEST_F(ReplicaTest, trace)
+{
+    this->impl().test_trace();
+}
+
+TEST_F(ReplicaTest, volume_stack)
+{
+    this->impl().test_volume_stack();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -65,6 +65,41 @@ class GeantGeoTest : public GeantGeoTestBase
 };
 
 //---------------------------------------------------------------------------//
+using CmseTest = GenericGeoParameterizedTest<GeantGeoTest, CmseGeoTest>;
+
+TEST_F(CmseTest, trace)
+{
+    this->impl().test_trace();
+}
+
+TEST_F(CmseTest, imager)
+{
+    SafetyImager write_image{this->geometry()};
+
+    ImageInput inp;
+    inp.lower_left = from_cm({0, 0, 0});
+    inp.upper_right = from_cm({350, 0, 1700});
+    inp.rightward = {0.0, 0.0, 1.0};
+    inp.vertical_pixels = 8;
+
+    write_image(ImageParams{inp}, "g4-cmse-xz-mid.jsonl");
+}
+
+//---------------------------------------------------------------------------//
+using CmsEeBackDeeTest
+    = GenericGeoParameterizedTest<GeantGeoTest, CmsEeBackDeeGeoTest>;
+
+TEST_F(CmsEeBackDeeTest, accessors)
+{
+    this->impl().test_accessors();
+}
+
+TEST_F(CmsEeBackDeeTest, trace)
+{
+    this->impl().test_trace();
+}
+
+//---------------------------------------------------------------------------//
 using FourLevelsTest
     = GenericGeoParameterizedTest<GeantGeoTest, FourLevelsGeoTest>;
 
@@ -413,41 +448,6 @@ TEST_F(TransformedBoxTest, accessors)
 }
 
 TEST_F(TransformedBoxTest, trace)
-{
-    this->impl().test_trace();
-}
-
-//---------------------------------------------------------------------------//
-using CmseTest = GenericGeoParameterizedTest<GeantGeoTest, CmseGeoTest>;
-
-TEST_F(CmseTest, trace)
-{
-    this->impl().test_trace();
-}
-
-TEST_F(CmseTest, imager)
-{
-    SafetyImager write_image{this->geometry()};
-
-    ImageInput inp;
-    inp.lower_left = from_cm({0, 0, 0});
-    inp.upper_right = from_cm({350, 0, 1700});
-    inp.rightward = {0.0, 0.0, 1.0};
-    inp.vertical_pixels = 8;
-
-    write_image(ImageParams{inp}, "g4-cmse-xz-mid.jsonl");
-}
-
-//---------------------------------------------------------------------------//
-using CmsEeBackDeeTest
-    = GenericGeoParameterizedTest<GeantGeoTest, CmsEeBackDeeGeoTest>;
-
-TEST_F(CmsEeBackDeeTest, accessors)
-{
-    this->impl().test_accessors();
-}
-
-TEST_F(CmsEeBackDeeTest, trace)
 {
     this->impl().test_trace();
 }

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -58,41 +58,6 @@ class GeantGeoTest : public GeantGeoTestBase
 };
 
 //---------------------------------------------------------------------------//
-using CmseTest = GenericGeoParameterizedTest<GeantGeoTest, CmseGeoTest>;
-
-TEST_F(CmseTest, trace)
-{
-    this->impl().test_trace();
-}
-
-TEST_F(CmseTest, imager)
-{
-    SafetyImager write_image{this->geometry()};
-
-    ImageInput inp;
-    inp.lower_left = from_cm({0, 0, 0});
-    inp.upper_right = from_cm({350, 0, 1700});
-    inp.rightward = {0.0, 0.0, 1.0};
-    inp.vertical_pixels = 8;
-
-    write_image(ImageParams{inp}, "g4-cmse-xz-mid.jsonl");
-}
-
-//---------------------------------------------------------------------------//
-using CmsEeBackDeeTest
-    = GenericGeoParameterizedTest<GeantGeoTest, CmsEeBackDeeGeoTest>;
-
-TEST_F(CmsEeBackDeeTest, accessors)
-{
-    this->impl().test_accessors();
-}
-
-TEST_F(CmsEeBackDeeTest, trace)
-{
-    this->impl().test_trace();
-}
-
-//---------------------------------------------------------------------------//
 using FourLevelsTest
     = GenericGeoParameterizedTest<GeantGeoTest, FourLevelsGeoTest>;
 
@@ -321,71 +286,6 @@ TEST_F(FourLevelsTest, levels)
 }
 
 //---------------------------------------------------------------------------//
-using ReplicaTest = GenericGeoParameterizedTest<GeantGeoTest, ReplicaGeoTest>;
-
-TEST_F(ReplicaTest, trace)
-{
-    this->impl().test_trace();
-}
-
-TEST_F(ReplicaTest, volume_stack)
-{
-    this->impl().test_volume_stack();
-}
-
-TEST_F(ReplicaTest, level_strings)
-{
-    using R2 = Array<double, 2>;
-
-    auto const& geo_params = *this->geometry();
-    auto const& vol_inst = geo_params.volume_instances();
-
-    static R2 const points[] = {
-        {-435, 550},
-        {-460, 550},
-        {-400, 650},
-        {-450, 650},
-        {-450, 700},
-    };
-
-    std::vector<std::string> all_vol_inst;
-    for (R2 xz : points)
-    {
-        auto geo = this->make_geo_track_view({xz[0], 0.0, xz[1]}, {1, 0, 0});
-
-        auto level = geo.level();
-        CELER_ASSERT(level && level >= LevelId{0});
-        std::vector<VolumeInstanceId> inst_ids(level.get() + 1);
-        geo.volume_instance_id(make_span(inst_ids));
-        std::vector<std::string> names(inst_ids.size());
-        for (auto i : range(inst_ids.size()))
-        {
-            Label lab = vol_inst.at(inst_ids[i]);
-            if (auto phys_inst = geo_params.id_to_geant(inst_ids[i]))
-            {
-                if (phys_inst.replica)
-                {
-                    lab.ext += '+';
-                    lab.ext += std::to_string(phys_inst.replica.get());
-                }
-            }
-            names[i] = to_string(lab);
-        }
-        all_vol_inst.push_back(to_string(repr(names)));
-    }
-
-    static char const* const expected_all_vol_inst[] = {
-        R"({"world_PV", "fSecondArmPhys", "EMcalorimeter", "cell_param@+14"})",
-        R"({"world_PV", "fSecondArmPhys", "EMcalorimeter", "cell_param@+6"})",
-        R"({"world_PV", "fSecondArmPhys", "HadCalorimeter", "HadCalColumn_PV@+4", "HadCalCell_PV@+1", "HadCalLayer_PV@+2"})",
-        R"({"world_PV", "fSecondArmPhys", "HadCalorimeter", "HadCalColumn_PV@+2", "HadCalCell_PV@+1", "HadCalLayer_PV@+7"})",
-        R"({"world_PV", "fSecondArmPhys", "HadCalorimeter", "HadCalColumn_PV@+3", "HadCalCell_PV@+1", "HadCalLayer_PV@+16"})",
-    };
-
-    EXPECT_VEC_EQ(expected_all_vol_inst, all_vol_inst);
-}
-
-//---------------------------------------------------------------------------//
 class SolidsTest
     : public GenericGeoParameterizedTest<GeantGeoTest, SolidsGeoTest>
 {
@@ -454,6 +354,73 @@ TEST_F(SolidsTest, DISABLED_imager)
 }
 
 //---------------------------------------------------------------------------//
+// TODO: reorder or independently run tests; for now this has to go after the
+// Solids test
+using ReplicaTest = GenericGeoParameterizedTest<GeantGeoTest, ReplicaGeoTest>;
+
+TEST_F(ReplicaTest, trace)
+{
+    this->impl().test_trace();
+}
+
+TEST_F(ReplicaTest, volume_stack)
+{
+    this->impl().test_volume_stack();
+}
+
+TEST_F(ReplicaTest, level_strings)
+{
+    using R2 = Array<double, 2>;
+
+    auto const& geo_params = *this->geometry();
+    auto const& vol_inst = geo_params.volume_instances();
+
+    static R2 const points[] = {
+        {-435, 550},
+        {-460, 550},
+        {-400, 650},
+        {-450, 650},
+        {-450, 700},
+    };
+
+    std::vector<std::string> all_vol_inst;
+    for (R2 xz : points)
+    {
+        auto geo = this->make_geo_track_view({xz[0], 0.0, xz[1]}, {1, 0, 0});
+
+        auto level = geo.level();
+        CELER_ASSERT(level && level >= LevelId{0});
+        std::vector<VolumeInstanceId> inst_ids(level.get() + 1);
+        geo.volume_instance_id(make_span(inst_ids));
+        std::vector<std::string> names(inst_ids.size());
+        for (auto i : range(inst_ids.size()))
+        {
+            Label lab = vol_inst.at(inst_ids[i]);
+            if (auto phys_inst = geo_params.id_to_geant(inst_ids[i]))
+            {
+                if (phys_inst.replica)
+                {
+                    lab.ext += '+';
+                    lab.ext += std::to_string(phys_inst.replica.get());
+                }
+            }
+            names[i] = to_string(lab);
+        }
+        all_vol_inst.push_back(to_string(repr(names)));
+    }
+
+    static char const* const expected_all_vol_inst[] = {
+        R"({"world_PV", "fSecondArmPhys", "EMcalorimeter", "cell_param@+14"})",
+        R"({"world_PV", "fSecondArmPhys", "EMcalorimeter", "cell_param@+6"})",
+        R"({"world_PV", "fSecondArmPhys", "HadCalorimeter", "HadCalColumn_PV@+4", "HadCalCell_PV@+1", "HadCalLayer_PV@+2"})",
+        R"({"world_PV", "fSecondArmPhys", "HadCalorimeter", "HadCalColumn_PV@+2", "HadCalCell_PV@+1", "HadCalLayer_PV@+7"})",
+        R"({"world_PV", "fSecondArmPhys", "HadCalorimeter", "HadCalColumn_PV@+3", "HadCalCell_PV@+1", "HadCalLayer_PV@+16"})",
+    };
+
+    EXPECT_VEC_EQ(expected_all_vol_inst, all_vol_inst);
+}
+
+//---------------------------------------------------------------------------//
 class TilecalPlugTest : public GeantGeoTest
 {
     std::string geometry_basename() const final { return "tilecal-plug"; }
@@ -464,12 +431,10 @@ TEST_F(TilecalPlugTest, trace)
     {
         SCOPED_TRACE("+z");
         auto result = this->track({5.75, 0.01, -40}, {0, 0, 1});
-        static char const* const expected_volumes[] = {
-            "Tile_ITCModule",
-            "Tile_Plug1Module",
-            "Tile_Absorber",
-            "Tile_Plug1Module",
-        };
+        static char const* const expected_volumes[] = {"Tile_ITCModule",
+                                                       "Tile_Plug1Module",
+                                                       "Tile_Absorber",
+                                                       "Tile_Plug1Module"};
         EXPECT_VEC_EQ(expected_volumes, result.volumes);
         static real_type const expected_distances[] = {22.9425, 0.115, 42, 37};
         EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
@@ -495,6 +460,41 @@ TEST_F(TransformedBoxTest, accessors)
 }
 
 TEST_F(TransformedBoxTest, trace)
+{
+    this->impl().test_trace();
+}
+
+//---------------------------------------------------------------------------//
+using CmseTest = GenericGeoParameterizedTest<GeantGeoTest, CmseGeoTest>;
+
+TEST_F(CmseTest, trace)
+{
+    this->impl().test_trace();
+}
+
+TEST_F(CmseTest, imager)
+{
+    SafetyImager write_image{this->geometry()};
+
+    ImageInput inp;
+    inp.lower_left = from_cm({0, 0, 0});
+    inp.upper_right = from_cm({350, 0, 1700});
+    inp.rightward = {0.0, 0.0, 1.0};
+    inp.vertical_pixels = 8;
+
+    write_image(ImageParams{inp}, "g4-cmse-xz-mid.jsonl");
+}
+
+//---------------------------------------------------------------------------//
+using CmsEeBackDeeTest
+    = GenericGeoParameterizedTest<GeantGeoTest, CmsEeBackDeeGeoTest>;
+
+TEST_F(CmsEeBackDeeTest, accessors)
+{
+    this->impl().test_accessors();
+}
+
+TEST_F(CmsEeBackDeeTest, trace)
 {
     this->impl().test_trace();
 }

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -23,15 +23,8 @@
 
 #include "GeantGeoTestBase.hh"
 #include "celeritas_test.hh"
-#include "../CmsEeBackDeeGeoTest.hh"
-#include "../CmseGeoTest.hh"
-#include "../FourLevelsGeoTest.hh"
 #include "../GenericGeoParameterizedTest.hh"
-#include "../MultiLevelGeoTest.hh"
-#include "../ReplicaGeoTest.hh"
-#include "../SolidsGeoTest.hh"
-#include "../TransformedBoxGeoTest.hh"
-#include "../ZnenvGeoTest.hh"
+#include "../GeoTests.hh"
 
 namespace celeritas
 {

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -333,6 +333,58 @@ TEST_F(ReplicaTest, volume_stack)
     this->impl().test_volume_stack();
 }
 
+TEST_F(ReplicaTest, level_strings)
+{
+    using R2 = Array<double, 2>;
+
+    auto const& geo_params = *this->geometry();
+    auto const& vol_inst = geo_params.volume_instances();
+
+    static R2 const points[] = {
+        {-435, 550},
+        {-460, 550},
+        {-400, 650},
+        {-450, 650},
+        {-450, 700},
+    };
+
+    std::vector<std::string> all_vol_inst;
+    for (R2 xz : points)
+    {
+        auto geo = this->make_geo_track_view({xz[0], 0.0, xz[1]}, {1, 0, 0});
+
+        auto level = geo.level();
+        CELER_ASSERT(level && level >= LevelId{0});
+        std::vector<VolumeInstanceId> inst_ids(level.get() + 1);
+        geo.volume_instance_id(make_span(inst_ids));
+        std::vector<std::string> names(inst_ids.size());
+        for (auto i : range(inst_ids.size()))
+        {
+            Label lab = vol_inst.at(inst_ids[i]);
+            if (auto phys_inst = geo_params.id_to_geant(inst_ids[i]))
+            {
+                if (phys_inst.replica)
+                {
+                    lab.ext += '+';
+                    lab.ext += std::to_string(phys_inst.replica.get());
+                }
+            }
+            names[i] = to_string(lab);
+        }
+        all_vol_inst.push_back(to_string(repr(names)));
+    }
+
+    static char const* const expected_all_vol_inst[] = {
+        R"({"world_PV", "fSecondArmPhys", "EMcalorimeter", "cell_param@+14"})",
+        R"({"world_PV", "fSecondArmPhys", "EMcalorimeter", "cell_param@+6"})",
+        R"({"world_PV", "fSecondArmPhys", "HadCalorimeter", "HadCalColumn_PV@+4", "HadCalCell_PV@+1", "HadCalLayer_PV@+2"})",
+        R"({"world_PV", "fSecondArmPhys", "HadCalorimeter", "HadCalColumn_PV@+2", "HadCalCell_PV@+1", "HadCalLayer_PV@+7"})",
+        R"({"world_PV", "fSecondArmPhys", "HadCalorimeter", "HadCalColumn_PV@+3", "HadCalCell_PV@+1", "HadCalLayer_PV@+16"})",
+    };
+
+    EXPECT_VEC_EQ(expected_all_vol_inst, all_vol_inst);
+}
+
 //---------------------------------------------------------------------------//
 class SolidsTest
     : public GenericGeoParameterizedTest<GeantGeoTest, SolidsGeoTest>
@@ -412,10 +464,12 @@ TEST_F(TilecalPlugTest, trace)
     {
         SCOPED_TRACE("+z");
         auto result = this->track({5.75, 0.01, -40}, {0, 0, 1});
-        static char const* const expected_volumes[] = {"Tile_ITCModule",
-                                                       "Tile_Plug1Module",
-                                                       "Tile_Absorber",
-                                                       "Tile_Plug1Module"};
+        static char const* const expected_volumes[] = {
+            "Tile_ITCModule",
+            "Tile_Plug1Module",
+            "Tile_Absorber",
+            "Tile_Plug1Module",
+        };
         EXPECT_VEC_EQ(expected_volumes, result.volumes);
         static real_type const expected_distances[] = {22.9425, 0.115, 42, 37};
         EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -29,16 +29,9 @@
 
 #include "VecgeomTestBase.hh"
 #include "celeritas_test.hh"
-#include "../CmsEeBackDeeGeoTest.hh"
-#include "../CmseGeoTest.hh"
-#include "../FourLevelsGeoTest.hh"
 #include "../GeantImportVolumeResult.hh"
 #include "../GenericGeoParameterizedTest.hh"
-#include "../MultiLevelGeoTest.hh"
-#include "../ReplicaGeoTest.hh"
-#include "../SolidsGeoTest.hh"
-#include "../TransformedBoxGeoTest.hh"
-#include "../ZnenvGeoTest.hh"
+#include "../GeoTests.hh"
 
 #if CELERITAS_USE_GEANT4
 #    include <G4VPhysicalVolume.hh>

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -35,6 +35,7 @@
 #include "../GeantImportVolumeResult.hh"
 #include "../GenericGeoParameterizedTest.hh"
 #include "../MultiLevelGeoTest.hh"
+#include "../ReplicaGeoTest.hh"
 #include "../SolidsGeoTest.hh"
 #include "../TransformedBoxGeoTest.hh"
 #include "../ZnenvGeoTest.hh"
@@ -726,6 +727,23 @@ TEST_F(MultiLevelTest, accessors)
 TEST_F(MultiLevelTest, trace)
 {
     this->impl().test_trace();
+}
+
+//---------------------------------------------------------------------------//
+class ReplicaTest
+    : public GenericGeoParameterizedTest<VecgeomGeantTestBase, ReplicaGeoTest>
+{
+    real_type safety_tol() const final { return 1e-10; }
+};
+
+TEST_F(ReplicaTest, trace)
+{
+    this->impl().test_trace();
+}
+
+TEST_F(ReplicaTest, volume_stack)
+{
+    this->impl().test_volume_stack();
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Geant4 has mutable physical volumes ("replica" and "parameterised") that allow a single volume instance to appear as many different volume instances, with the idea of saving memory. It unfortunately complicates matters a lot because it requires updating the volume on the local thread during tracking. Generating VecGeom versions of these (by literally copy-pasting the volumes) was added in #1071 and https://github.com/celeritas-project/g4vg/pull/25 , but we punted on enabling level-based detector reconstruction (#1495) in such volumes. Unfortunately the B5 benchmark problem (https://github.com/celeritas-project/gpu-delta-review-2025/issues/2) has SDs in these volumes.

This PR:
- adds a new geometry test problem and new capabilities to the geometry test interface;
- changes the GeoParams interface so that VolumeInstanceId corresponds not to just  a `G4PV*` but to a `{G4PV*, int}` pair (written as a struct using an opaque ID) that embeds the copy number needed to update Geant4's geometry
- adds reconstruction support to the `set_history` helper and tests to the level updater

Closes #1637

--- 

ADDENDUM a month later: the discussion about a [touchable IDs user request](https://jira-geant4.kek.jp/browse/UR-100)  brings up this same issue:

> 
> ## An issue / problem
>  
> Looking at G4VPhysicalVolume type (header) reminded me of an inconvenient fact - that only G4PVPlacement volumes are uniquely identified by this instance ID.  Multiple slices in a single ‘Replica’ (or ‘Division’ ) will share this identifier, as they are represented by a single physical volume in memory.  Similarly all instances of a ‘physical volume Parameterisation’ share the same identifier. 
>  
> ### Open question(s):
> Do you allow a user to create a ‘Replica’ or ‘Division’ which slices the original volume into separate sub-volumes?   If so, they share the same physical volume pointer (a G4PVReplica or G4PVDivision) and as such would share the same Instance ID.  So a separate sub-solution would be required for these types.  It is possible to assertain whether a physical volume is one of these types - but likely you already know this during the construction of your geometry. 
>  
> ### Potential extension / solution
>  
> I can imagine a simple extension to the InstanceID which could be used to identify every physical volume uniquely.  For each repetetive volume (replica, division, parameterised volume) it would create a new id combining an offset plus its replica-number.   The offsets could be pre-calculated at the start of the application to provide enough ’space’ to ensure the new / revised identifier is unique, and that either no gaps are created (or that padding is minimal. )
>  
> I hope that I have summarised our discussions well, and provided the means to start a prototype using this ‘hidden’ part of the Geant4 implementation.