### PR TITLE
Add an option to enable status checker through celer-sim

### DIFF
--- a/app/celer-sim/RunnerInput.cc
+++ b/app/celer-sim/RunnerInput.cc
@@ -147,6 +147,7 @@ inp::Problem load_problem(RunnerInput const& ri)
         }
         d.counters.step = ri.write_track_counts;
         d.counters.event = ri.transporter_result;
+        d.status_checker = ri.status_checker;
     }
 
     // Control

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -104,6 +104,7 @@ struct RunnerInput
     bool write_track_counts{true};  //!< Output track counts for each step
     bool write_step_times{true};  //!< Output elapsed times for each step
     bool transporter_result{true};  //!< Output transporter result event data
+    bool status_checker{false}; //!< Detailed debug checking of track states
     size_type log_progress{1};  //!< CELER_LOG progress every N events
 
     // Control

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -104,7 +104,7 @@ struct RunnerInput
     bool write_track_counts{true};  //!< Output track counts for each step
     bool write_step_times{true};  //!< Output elapsed times for each step
     bool transporter_result{true};  //!< Output transporter result event data
-    bool status_checker{false}; //!< Detailed debug checking of track states
+    bool status_checker{false};  //!< Detailed debug checking of track states
     size_type log_progress{1};  //!< CELER_LOG progress every N events
 
     // Control

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -79,6 +79,7 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_OPTION(write_track_counts);
     LDIO_LOAD_OPTION(write_step_times);
     LDIO_LOAD_OPTION(transporter_result);
+    LDIO_LOAD_OPTION(status_checker);
     LDIO_LOAD_OPTION(log_progress);
 
     LDIO_LOAD_DEPRECATED(max_num_tracks, num_track_slots);
@@ -174,6 +175,7 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE(write_track_counts);
     LDIO_SAVE(write_step_times);
     LDIO_SAVE(transporter_result);
+    LDIO_SAVE(status_checker);
     LDIO_SAVE(log_progress);
 
     LDIO_SAVE(seed);

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -33,7 +33,7 @@
 #include "corecel/sys/ScopedMem.hh"
 #include "geocel/GeoParamsOutput.hh"
 #include "celeritas/alongstep/AlongStepNeutralAction.hh"
-#include "celeritas/em/params/WentzelOKVIParams.hh"
+#include "celeritas/em/params/WentzelOKVIParams.hh" // IWYU pragma: keep
 #include "celeritas/geo/GeoMaterialParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/detail/BoundaryAction.hh"
@@ -58,10 +58,10 @@
 #include "detail/CoreSizes.json.hh"
 
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
-#    include "orange/OrangeParams.hh"
+#    include "orange/OrangeParams.hh" // IWYU pragma: keep
 #    include "orange/OrangeParamsOutput.hh"
 #elif CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM
-#    include "geocel/vg/VecgeomParams.hh"
+#    include "geocel/vg/VecgeomParams.hh" // IWYU pragma: keep
 #    include "geocel/vg/VecgeomParamsOutput.hh"
 #endif
 
@@ -363,7 +363,7 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
         std::make_shared<VecgeomParamsOutput>(input_.geometry));
 #endif
 
-    // TODO: add output from auxiliary params/data
+        // TODO: add output from auxiliary params/data
 
     CELER_LOG(status) << "Celeritas core setup complete";
 

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -33,7 +33,7 @@
 #include "corecel/sys/ScopedMem.hh"
 #include "geocel/GeoParamsOutput.hh"
 #include "celeritas/alongstep/AlongStepNeutralAction.hh"
-#include "celeritas/em/params/WentzelOKVIParams.hh" // IWYU pragma: keep
+#include "celeritas/em/params/WentzelOKVIParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/GeoMaterialParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/GeoParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/detail/BoundaryAction.hh"
@@ -58,10 +58,10 @@
 #include "detail/CoreSizes.json.hh"
 
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
-#    include "orange/OrangeParams.hh" // IWYU pragma: keep
+#    include "orange/OrangeParams.hh"  // IWYU pragma: keep
 #    include "orange/OrangeParamsOutput.hh"
 #elif CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM
-#    include "geocel/vg/VecgeomParams.hh" // IWYU pragma: keep
+#    include "geocel/vg/VecgeomParams.hh"  // IWYU pragma: keep
 #    include "geocel/vg/VecgeomParamsOutput.hh"
 #endif
 
@@ -363,7 +363,7 @@ CoreParams::CoreParams(Input input) : input_(std::move(input))
         std::make_shared<VecgeomParamsOutput>(input_.geometry));
 #endif
 
-        // TODO: add output from auxiliary params/data
+    // TODO: add output from auxiliary params/data
 
     CELER_LOG(status) << "Celeritas core setup complete";
 

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -18,7 +18,6 @@
 #include "celeritas/optical/CoreState.hh"
 #include "celeritas/optical/TrackInitParams.hh"
 #include "celeritas/optical/action/ActionGroups.hh"
-#include "celeritas/optical/action/BoundaryAction.hh"
 #include "celeritas/track/TrackInitParams.hh"
 
 #include "OffloadParams.hh"

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -132,8 +132,9 @@ std::string_view OpticalLaunchAction::description() const
 /*!
  * Build state data for a stream.
  */
-auto OpticalLaunchAction::create_state(MemSpace m, StreamId sid, size_type) const
-    -> UPState
+auto OpticalLaunchAction::create_state(MemSpace m,
+                                       StreamId sid,
+                                       size_type) const -> UPState
 {
     if (m == MemSpace::host)
     {

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -15,11 +15,9 @@
 #include "corecel/Config.hh"
 
 #include "corecel/cont/VariantUtils.hh"
-#include "corecel/cont/detail/VariantUtilsImpl.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/OutputRegistry.hh"
 #include "corecel/math/Algorithms.hh"
-#include "corecel/math/Constant.hh"
 #include "corecel/sys/ActionRegistry.hh"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/Environment.hh"
@@ -64,6 +62,7 @@
 #include "celeritas/phys/ProcessBuilder.hh"
 #include "celeritas/random/RngParams.hh"
 #include "celeritas/track/SimParams.hh"
+#include "celeritas/track/StatusChecker.hh"
 #include "celeritas/track/TrackInitParams.hh"
 #include "celeritas/user/ActionDiagnostic.hh"
 #include "celeritas/user/RootStepWriter.hh"
@@ -445,6 +444,13 @@ problem(inp::Problem const& p, ImportData const& imported)
     if (p.diagnostics.action)
     {
         ActionDiagnostic::make_and_insert(*core_params);
+    }
+
+    if (p.diagnostics.status_checker)
+    {
+        // Add detailed debugging of track states
+        // TODO: this environment variable will be replaced by celer::inp soon!
+        StatusChecker::make_and_insert(*core_params);
     }
 
     if (p.diagnostics.step)

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -449,7 +449,6 @@ problem(inp::Problem const& p, ImportData const& imported)
     if (p.diagnostics.status_checker)
     {
         // Add detailed debugging of track states
-        // TODO: this environment variable will be replaced by celer::inp soon!
         StatusChecker::make_and_insert(*core_params);
     }
 

--- a/src/celeritas/track/StatusChecker.cc
+++ b/src/celeritas/track/StatusChecker.cc
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #include "StatusChecker.hh"
 
+#include <mutex>
+
 #include "corecel/data/AuxParamsRegistry.hh"
 #include "corecel/data/AuxStateVec.hh"
 #include "corecel/data/Copier.hh"
@@ -144,30 +146,39 @@ void StatusChecker::step(ActionId prev_action,
  */
 void StatusChecker::begin_run_impl(CoreParams const& params)
 {
-    auto const& reg = *params.action_reg();
-
-    HostVal<StatusCheckParamsData> host_val;
-    auto build_orders = CollectionBuilder{&host_val.orders};
-
-    // Loop over all action IDs
-    for (auto aidx : range(reg.num_actions()))
+    if (!data_)
     {
-        // Get abstract action shared pointer and see if it's explicit
-        auto const& base = reg.action(ActionId{aidx});
-        if (auto const* expl
-            = dynamic_cast<CoreStepActionInterface const*>(base.get()))
+        static std::mutex initialize_mutex;
+        std::lock_guard<std::mutex> scoped_lock{initialize_mutex};
+
+        if (!data_)
         {
-            build_orders.push_back(expl->order());
-        }
-        else
-        {
-            build_orders.push_back(host_val.implicit_order);
+            auto const& reg = *params.action_reg();
+
+            HostVal<StatusCheckParamsData> host_val;
+            auto build_orders = CollectionBuilder{&host_val.orders};
+
+            // Loop over all action IDs
+            for (auto aidx : range(reg.num_actions()))
+            {
+                // Get abstract action shared pointer and see if it's explicit
+                auto const& base = reg.action(ActionId{aidx});
+                if (auto const* expl
+                    = dynamic_cast<CoreStepActionInterface const*>(base.get()))
+                {
+                    build_orders.push_back(expl->order());
+                }
+                else
+                {
+                    build_orders.push_back(host_val.implicit_order);
+                }
+            }
+            CELER_ASSERT(build_orders.size() == reg.num_actions());
+
+            // Construct host/device data
+            data_ = CollectionMirror{std::move(host_val)};
         }
     }
-    CELER_ASSERT(build_orders.size() == reg.num_actions());
-
-    // Construct host/device data
-    data_ = CollectionMirror{std::move(host_val)};
 
     CELER_ENSURE(data_);
 }

--- a/src/celeritas/track/StatusChecker.cc
+++ b/src/celeritas/track/StatusChecker.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "StatusChecker.hh"
 
+#include "corecel/data/AuxParamsRegistry.hh"
 #include "corecel/data/AuxStateVec.hh"
 #include "corecel/data/Copier.hh"
 #include "corecel/sys/ActionRegistry.hh"
@@ -36,6 +37,23 @@ void copy_in_memspace(Collection<T, W, M, I> const& src,
 
 //---------------------------------------------------------------------------//
 }  // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct and add to core params.
+ */
+std::shared_ptr<StatusChecker>
+StatusChecker::make_and_insert(CoreParams const& core)
+{
+    ActionRegistry& actions = *core.action_reg();
+    AuxParamsRegistry& aux = *core.aux_reg();
+    auto result
+        = std::make_shared<StatusChecker>(actions.next_id(), aux.next_id());
+
+    actions.insert(result);
+    aux.insert(result);
+    return result;
+}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/track/StatusChecker.hh
+++ b/src/celeritas/track/StatusChecker.hh
@@ -41,6 +41,10 @@ class StatusChecker final : public AuxParamsInterface,
                             public ParamsDataInterface<StatusCheckParamsData>
 {
   public:
+    // Construct and add to core params
+    static std::shared_ptr<StatusChecker>
+    make_and_insert(CoreParams const& core);
+
     // Construct with IDs
     StatusChecker(ActionId action_id, AuxId aux_id);
 


### PR DESCRIPTION
The status checker was added in #1303 but is currently only enabled for unit tests. This adds an option to build it from the front end and use in multithread contexts.