### PR TITLE
Hotfix: remove Ubuntu 20 from CI configuration

### DIFF
--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -14,12 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: focal
-            compiler: gcc
-            version: 8
-          - runner: focal
-            compiler: clang
-            version: 10
           - runner: jammy
             compiler: gcc
             version: 12
@@ -52,8 +46,7 @@ jobs:
       CC: ${{matrix.compiler}}-${{matrix.version}}
       CXX: ${{matrix.compiler == 'gcc' && 'g++' || 'clang++'}}-${{matrix.version}}
     runs-on: >-
-      ${{  matrix.runner == 'focal' && 'ubuntu-20.04'
-        || matrix.runner == 'jammy' && 'ubuntu-22.04'
+      ${{  matrix.runner == 'jammy' && 'ubuntu-22.04'
         || matrix.runner == 'noble' && 'ubuntu-24.04'
         || matrix.runner == 'noble-arm' && 'ubuntu-24.04-arm'
       }}

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Celeritas guarantees full compatibility and correctness only on the
 combinations of compilers and dependencies tested under continuous integration.
 See the configure output from the [GitHub runners](https://github.com/celeritas-project/celeritas/actions/workflows/push.yml) for the full list of combinations.
 - Compilers
-    - GCC 8, 11, 12, 14
+    - GCC 11, 12, 14
     - Clang 10, 15, 18
     - MSVC 19
     - GCC 11.5 + NVCC 12.6
@@ -128,8 +128,6 @@ Partial compatibility and correctness is available for an extended range of
 Geant4:
 - 10.5-10.7: no support for tracking manager offload
 - 11.0: no support for fast simulation offload
-- 11.1-11.3: [no support for default Rayleigh scattering cross section](see
-  https://github.com/celeritas-project/celeritas/issues/1091)
 
 Note also that navigation bugs in Geant4 and VecGeom older than the versions
 listed above *will* cause failures in some geometry-related unit tests. Future
@@ -145,6 +143,8 @@ Compatibility fixes that do not cause newer versions to fail are welcome.
 [gha]: https://github.com/celeritas-project/celeritas/actions
 
 # Development
+
+<!-- This section should be kept in sync with the doc/development files -->
 
 See the [contribution guide][contributing-guidelines] for the contribution process,
 [the development guidelines][development-guidelines] for further

--- a/doc/development/administration.rst
+++ b/doc/development/administration.rst
@@ -1,6 +1,9 @@
 .. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 .. SPDX-License-Identifier: CC-BY-4.0
 
+.. **NOTE**: this file is referenced by README.md:
+.. if changing the former, update the latter!!
+
 .. _administration:
 
 **************

--- a/doc/development/coding.rst
+++ b/doc/development/coding.rst
@@ -1,6 +1,9 @@
 .. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 .. SPDX-License-Identifier: CC-BY-4.0
 
+.. **NOTE**: this file is referenced by README.md:
+.. if changing the former, update the latter!!
+
 .. _code_guidelines:
 
 Code development guidelines

--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -1,4 +1,7 @@
 .. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 .. SPDX-License-Identifier: CC-BY-4.0
 
+.. **NOTE**: this file is referenced by README.md:
+.. if changing the former, update the latter!!
+
 .. include:: ../../CONTRIBUTING.rst

--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -1,6 +1,9 @@
 .. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 .. SPDX-License-Identifier: CC-BY-4.0
 
+.. **NOTE**: this file is referenced by README.md:
+.. if changing the former, update the latter!!
+
 .. highlight:: cmake
 
 .. _infrastructure:


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/11101 which is temporarily breaking CI. We no longer test the "ancient" version of GCC 8, but since we periodically compile on Wildstyle etc., we'll try to update any failures as they occur.