### PR TITLE
Improve geometry testing

### DIFF
--- a/src/corecel/math/NumericLimits.hh
+++ b/src/corecel/math/NumericLimits.hh
@@ -22,6 +22,10 @@ namespace celeritas
  * \note \c CUDART_NAN and \c CUDART_INF are not \c constexpr in CUDA 10 at
  *   least, so we have replaced those with compiler built-ins that work in GCC,
  *   Clang, and MSVC.
+ *
+ * \deprecated The name of this class will change to NumericLimits to conform
+ * to the Celeritas naming system, since it is not a complete replacement for
+ * the \c std implementation.
  */
 template<class Numeric>
 struct numeric_limits;
@@ -103,4 +107,9 @@ struct numeric_limits<unsigned long long>
 };
 
 #undef SCCEF_
+
+//! Forward-compatible alias for v1.0
+template<class T>
+using NumericLimits = numeric_limits<T>;
+
 }  // namespace celeritas

--- a/src/corecel/sys/KernelLauncher.device.hh
+++ b/src/corecel/sys/KernelLauncher.device.hh
@@ -46,12 +46,11 @@ namespace celeritas
  *
  * Example:
  * \code
- void FooAction::launch_kernel(size_type count) const
+ void launch_kernel(DeviceParams const& params, size_type count) const
  {
-    auto execute_thread = make_blah_executor(blah);
-    static KernelLauncher<decltype(execute_thread)> const
- launch_kernel("blah");
-    launch_kernel(state, execute_thread);
+    auto execute_thread = BlahExecutor{params};
+    static KernelLauncher<decltype(execute_thread)> const launch("blah");
+    launch_kernel(count, StreamId{}, execute_thread);
  }
  * \endcode
  */

--- a/src/corecel/sys/ScopedLimitSaver.cuda.cc
+++ b/src/corecel/sys/ScopedLimitSaver.cuda.cc
@@ -11,12 +11,15 @@
 
 namespace celeritas
 {
+namespace
+{
 //---------------------------------------------------------------------------//
-// Static data
-Array<cudaLimit, 2> const ScopedLimitSaver::cuda_attrs_{
+Array<cudaLimit, 2> const g_attrs{
     {cudaLimitStackSize, cudaLimitMallocHeapSize}};
-Array<char const*, 2> const ScopedLimitSaver::cuda_attr_labels_{
-    {"stack size", "heap size"}};
+Array<char const*, 2> const g_labels{{"stack size", "heap size"}};
+
+//---------------------------------------------------------------------------//
+}  // namespace
 
 //---------------------------------------------------------------------------//
 /*!
@@ -24,9 +27,11 @@ Array<char const*, 2> const ScopedLimitSaver::cuda_attr_labels_{
  */
 ScopedLimitSaver::ScopedLimitSaver()
 {
+    static_assert(g_attrs.size() == orig_limits_.size()
+                  && g_labels.size() == orig_limits_.size());
     for (auto i : range(orig_limits_.size()))
     {
-        CELER_CUDA_CALL(cudaDeviceGetLimit(&orig_limits_[i], cuda_attrs_[i]));
+        CELER_CUDA_CALL(cudaDeviceGetLimit(&orig_limits_[i], g_attrs[i]));
     }
 }
 
@@ -41,15 +46,15 @@ ScopedLimitSaver::~ScopedLimitSaver()
         for (auto i : range(orig_limits_.size()))
         {
             std::size_t temp;
-            CELER_CUDA_CALL(cudaDeviceGetLimit(&temp, cuda_attrs_[i]));
+            CELER_CUDA_CALL(cudaDeviceGetLimit(&temp, g_attrs[i]));
             if (temp != orig_limits_[i])
             {
                 CELER_LOG(info)
-                    << "CUDA " << cuda_attr_labels_[i] << " was changed from "
+                    << "CUDA " << g_labels[i] << " was changed from "
                     << orig_limits_[i] << " to " << temp
                     << "; restoring to original values";
                 CELER_CUDA_CALL(
-                    cudaDeviceSetLimit(cuda_attrs_[i], orig_limits_[i]));
+                    cudaDeviceSetLimit(g_attrs[i], orig_limits_[i]));
             }
         }
     }

--- a/src/corecel/sys/ScopedLimitSaver.cuda.cc
+++ b/src/corecel/sys/ScopedLimitSaver.cuda.cc
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #include "ScopedLimitSaver.hh"
 
+#include "corecel/DeviceRuntimeApi.hh"
+
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
 
@@ -27,8 +29,8 @@ Array<char const*, 2> const g_labels{{"stack size", "heap size"}};
  */
 ScopedLimitSaver::ScopedLimitSaver()
 {
-    static_assert(g_attrs.size() == orig_limits_.size()
-                  && g_labels.size() == orig_limits_.size());
+    static_assert(g_attrs.size() == decltype(orig_limits_){}.size()
+                  && g_labels.size() == g_attrs.size());
     for (auto i : range(orig_limits_.size()))
     {
         CELER_CUDA_CALL(cudaDeviceGetLimit(&orig_limits_[i], g_attrs[i]));

--- a/src/corecel/sys/ScopedLimitSaver.hh
+++ b/src/corecel/sys/ScopedLimitSaver.hh
@@ -8,8 +8,6 @@
 
 #include <cstddef>
 
-#include "corecel/DeviceRuntimeApi.hh"
-
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/cont/Array.hh"
@@ -22,7 +20,8 @@ namespace celeritas
  * Save and restore CUDA limits inside the current scope.
  *
  * This is useful for calling poorly behaved external libraries that change
- * CUDA limits unexpectedly.
+ * CUDA limits unexpectedly. We don't use this with HIP because it's only
+ * needed at present for VecGeom.
  */
 class ScopedLimitSaver
 {
@@ -36,14 +35,6 @@ class ScopedLimitSaver
     //!@}
 
   private:
-#if CELER_USE_DEVICE
-    using Limit_t = CELER_DEVICE_PREFIX(Limit);
-#else
-    using Limit_t = int;
-#endif
-
-    static Array<Limit_t, 2> const cuda_attrs_;
-    static Array<char const*, 2> const cuda_attr_labels_;
     Array<std::size_t, 2> orig_limits_;
 };
 
@@ -55,9 +46,10 @@ class ScopedLimitSaver
 inline ScopedLimitSaver::ScopedLimitSaver()
 {
     CELER_DISCARD(orig_limits_);
-#    if CELERITAS_USE_HIP
-    CELER_NOT_IMPLEMENTED("HIP limit restoration");
-#    endif
+    if constexpr (CELERITAS_USE_HIP)
+    {
+        CELER_NOT_IMPLEMENTED("HIP limit restoration");
+    }
 }
 
 // Destruction is a null-op since we only save with CUDA

--- a/test/celeritas/geo/Geometry.test.cc
+++ b/test/celeritas/geo/Geometry.test.cc
@@ -10,15 +10,43 @@
 #include "celeritas/geo/GeoParams.hh"
 
 #include "HeuristicGeoTestBase.hh"
+#include "TestMacros.hh"
 #include "celeritas_test.hh"
 
 namespace celeritas
 {
 namespace test
 {
-constexpr bool not_orange_geo
-    = (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE);
+constexpr bool using_orange_geo
+    = (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE);
+
 //---------------------------------------------------------------------------//
+class GeometryTest : public HeuristicGeoTestBase
+{
+  public:
+    using VecReal = std::vector<real_type>;
+    static void TearDownTestSuite() { last_path() = {}; }
+
+    static void compare_against_previous(SpanConstReal values)
+    {
+        auto& lp = GeometryTest::last_path();
+        if (lp.empty())
+        {
+            lp.assign(values.begin(), values.end());
+        }
+        else
+        {
+            EXPECT_VEC_SOFT_EQ(lp, values);
+        }
+    }
+
+  private:
+    static VecReal& last_path()
+    {
+        static VecReal p;
+        return p;
+    }
+};
 
 class TestEm3Test : public HeuristicGeoTestBase
 {
@@ -225,7 +253,7 @@ auto CmseTest::reference_avg_path() const -> SpanConstReal
 // TESTEM3
 //---------------------------------------------------------------------------//
 
-TEST_F(TestEm3Test, host)
+TEST_F(TestEm3Test, run)
 {
     if (CELERITAS_USE_GEANT4 || CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
     {
@@ -236,32 +264,19 @@ TEST_F(TestEm3Test, host)
         // ORANGE from JSON file doesn't support safety
         EXPECT_FALSE(this->geometry()->supports_safety());
     }
-    real_type tol = not_orange_geo ? 0.35 : 1e-3;
-    this->run_host(512, tol);
-}
-
-TEST_F(TestEm3Test, TEST_IF_CELER_DEVICE(device))
-{
-    real_type tol = not_orange_geo ? 0.25 : 1e-3;
-    this->run_device(512, tol);
+    real_type tol = using_orange_geo ? 1e-3 : 0.35;
+    this->run(1024, tol);
 }
 
 //---------------------------------------------------------------------------//
 // SIMPLECMS
 //---------------------------------------------------------------------------//
 
-TEST_F(SimpleCmsTest, host)
+TEST_F(SimpleCmsTest, avg_path)
 {
     // Results were generated with ORANGE
-    real_type tol = not_orange_geo ? 0.05 : 1e-3;
-    this->run_host(512, tol);
-}
-
-TEST_F(SimpleCmsTest, TEST_IF_CELER_DEVICE(device))
-{
-    // Results were generated with ORANGE
-    real_type tol = not_orange_geo ? 0.025 : 1e-3;
-    this->run_device(512, tol);
+    real_type tol = using_orange_geo ? 1e-3 : 0.05;
+    this->run(512, tol);
 }
 
 TEST_F(SimpleCmsTest, output)
@@ -294,26 +309,19 @@ TEST_F(SimpleCmsTest, output)
 // THREE_SPHERES
 //---------------------------------------------------------------------------//
 
-TEST_F(ThreeSpheresTest, host)
+TEST_F(ThreeSpheresTest, avg_path)
 {
     // Results were generated with ORANGE
-    real_type tol = not_orange_geo ? 0.05 : 1e-3;
+    real_type tol = using_orange_geo ? 1e-3 : 0.05;
     EXPECT_TRUE(this->geometry()->supports_safety());
-    this->run_host(512, tol);
-}
-
-TEST_F(ThreeSpheresTest, TEST_IF_CELER_DEVICE(device))
-{
-    // Results were generated with ORANGE
-    real_type tol = not_orange_geo ? 0.025 : 1e-3;
-    this->run_device(512, tol);
+    this->run(512, tol);
 }
 
 //---------------------------------------------------------------------------//
 // CMSE
 //---------------------------------------------------------------------------//
 // TODO: ensure reference values are the same for all CI platforms (see #1570)
-TEST_F(CmseTest, DISABLED_host)
+TEST_F(CmseTest, DISABLED_avg_path)
 {
     auto const& bbox = this->geometry()->bbox();
     real_type const geo_eps
@@ -326,12 +334,7 @@ TEST_F(CmseTest, DISABLED_host)
 
     real_type tol = CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM ? 0.005
                                                                      : 0.35;
-    this->run_host(512, tol);
-}
-
-TEST_F(CmseTest, TEST_IF_CELER_DEVICE(device))
-{
-    this->run_device(512, 0.005);
+    this->run(512, tol);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/geo/Geometry.test.cc
+++ b/test/celeritas/geo/Geometry.test.cc
@@ -265,7 +265,7 @@ TEST_F(TestEm3Test, run)
         EXPECT_FALSE(this->geometry()->supports_safety());
     }
     real_type tol = using_orange_geo ? 1e-3 : 0.35;
-    this->run(1024, tol);
+    this->run(512, tol);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/geo/HeuristicGeoData.hh
+++ b/test/celeritas/geo/HeuristicGeoData.hh
@@ -11,11 +11,10 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
-#include "corecel/cont/Array.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/data/CollectionAlgorithms.hh"
-#include "corecel/math/ArrayUtils.hh"
-#include "corecel/math/Atomics.hh"
+#include "geocel/Types.hh"
+#include "celeritas/Units.hh"
 #include "celeritas/geo/GeoData.hh"
 #include "celeritas/random/RngData.hh"
 
@@ -33,6 +32,9 @@ struct HeuristicGeoScalars
     Real3 upper{0, 0, 0};
     real_type log_min_step{-16.11809565095832};  // 1 nm
     real_type log_max_step{2.302585092994046};  // 10 cm
+
+    static constexpr real_type safety_tol = 0.01;
+    static constexpr real_type geom_limit = 5e-8 * units::millimeter;
 
     // Set from geometry
     VolumeId::size_type num_volumes{};

--- a/test/celeritas/geo/HeuristicGeoTestBase.cc
+++ b/test/celeritas/geo/HeuristicGeoTestBase.cc
@@ -29,7 +29,7 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 /*!
- * Run tracks on host and compare the resulting path length.
+ * Run tracks on host and device, and compare the resulting path length.
  */
 void HeuristicGeoTestBase::run(size_type num_states, real_type tolerance)
 {
@@ -77,7 +77,7 @@ void HeuristicGeoTestBase::run(size_type num_states, real_type tolerance)
 
 //---------------------------------------------------------------------------//
 /*!
- * Run tracks on device and compare the resulting path length.
+ * Run tracks on host *or* device and return the resulting path lengths.
  */
 template<MemSpace M>
 auto HeuristicGeoTestBase::run_impl(size_type num_states) -> VecReal

--- a/test/celeritas/geo/HeuristicGeoTestBase.cc
+++ b/test/celeritas/geo/HeuristicGeoTestBase.cc
@@ -9,10 +9,12 @@
 #include <iomanip>
 #include <iostream>
 
+#include "corecel/Types.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionStateStore.hh"
 #include "corecel/data/Ref.hh"
 #include "corecel/io/Join.hh"
+#include "corecel/io/Logger.hh"
 #include "corecel/io/Repr.hh"
 #include "corecel/io/ScopedStreamFormat.hh"
 #include "celeritas/geo/GeoParams.hh"
@@ -29,24 +31,11 @@ namespace test
 /*!
  * Run tracks on host and compare the resulting path length.
  */
-void HeuristicGeoTestBase::run_host(size_type num_states, real_type tolerance)
+void HeuristicGeoTestBase::run(size_type num_states, real_type tolerance)
 {
-    size_type const num_steps = this->num_steps();
-    auto params = this->build_test_params<MemSpace::host>();
-    StateStore<MemSpace::host> state{params, num_states};
+    auto host_path = this->run_impl<MemSpace::host>(num_states);
 
-    HeuristicGeoExecutor execute{params, state.ref()};
-    for (auto tid : range(TrackSlotId{num_states}))
-    {
-        for ([[maybe_unused]] auto step : range(num_steps))
-        {
-            execute(tid);
-        }
-    }
-
-    auto avg_path = this->get_avg_path(state.ref().accum_path, num_states);
     auto ref_path = this->reference_avg_path();
-
     if (ref_path.empty())
     {
         ScopedStreamFormat save_fmt(&std::cout);
@@ -60,16 +49,29 @@ void HeuristicGeoTestBase::run_host(size_type num_states, real_type tolerance)
         std::cout << "/* REFERENCE PATH LENGTHS */\n"
                      "static real_type const paths[] = {"
                   << std::setprecision(precision_digits)
-                  << join(avg_path.begin(), avg_path.end(), ", ")
+                  << join(host_path.begin(), host_path.end(), ", ")
                   << "};\n"
                      "/* END REFERENCE PATH LENGTHS */\n";
-
-        return;
+    }
+    else if (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
+    {
+        EXPECT_VEC_NEAR(ref_path, host_path, tolerance)
+            << "Host results differ from reference";
+    }
+    else
+    {
+        std::cout << "Skipping reference comparison: non-default RNG\n";
     }
 
-    if (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
+    if (celeritas::device())
     {
-        EXPECT_VEC_NEAR(ref_path, avg_path, tolerance);
+        auto dvc_path = this->run_impl<MemSpace::device>(num_states);
+        EXPECT_VEC_SOFT_EQ(host_path, dvc_path)
+            << R"(GPU and CPU produced different results)";
+    }
+    else
+    {
+        std::cout << "Skipping device comparison: device not active\n";
     }
 }
 
@@ -77,24 +79,39 @@ void HeuristicGeoTestBase::run_host(size_type num_states, real_type tolerance)
 /*!
  * Run tracks on device and compare the resulting path length.
  */
-void HeuristicGeoTestBase::run_device(size_type num_states, real_type tolerance)
+template<MemSpace M>
+auto HeuristicGeoTestBase::run_impl(size_type num_states) -> VecReal
 {
     size_type const num_steps = this->num_steps();
 
-    auto params = this->build_test_params<MemSpace::device>();
-    StateStore<MemSpace::device> state{
-        this->build_test_params<MemSpace::host>(), num_states};
+    StateStore<M> state{this->build_test_params<MemSpace::host>(), num_states};
 
-    for ([[maybe_unused]] auto step : range(num_steps))
+    auto params = this->build_test_params<M>();
+
+    CELER_LOG(status) << "Running heuristic test on " << to_cstring(M);
+
+    if constexpr (M == MemSpace::host)
     {
-        heuristic_test_execute(params, state.ref());
+        HeuristicGeoExecutor execute{params, state.ref()};
+        for (auto tid : range(TrackSlotId{num_states}))
+        {
+            for ([[maybe_unused]] auto step : range(num_steps))
+            {
+                execute(tid);
+            }
+        }
+    }
+    else
+    {
+        for ([[maybe_unused]] auto step : range(num_steps))
+        {
+            heuristic_test_execute(params, state.ref());
+        }
     }
 
-    if (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
-    {
-        auto avg_path = this->get_avg_path(state.ref().accum_path, num_states);
-        EXPECT_VEC_NEAR(this->reference_avg_path(), avg_path, tolerance);
-    }
+    VecReal host_accum_path(state.ref().accum_path.size());
+    copy_to_host(state.ref().accum_path, make_span(host_accum_path));
+    return this->get_avg_path_impl(host_accum_path, num_states);
 }
 
 //---------------------------------------------------------------------------//
@@ -118,21 +135,8 @@ auto HeuristicGeoTestBase::build_test_params()
 
 //---------------------------------------------------------------------------//
 
-template<MemSpace M>
-auto HeuristicGeoTestBase::get_avg_path(
-    PathLengthRef<M> path, size_type num_states) const -> std::vector<real_type>
-{
-    std::vector<real_type> result(path.size());
-    copy_to_host(path, make_span(result));
-
-    return this->get_avg_path_impl(result, num_states);
-}
-
-//---------------------------------------------------------------------------//
-
 auto HeuristicGeoTestBase::get_avg_path_impl(
-    std::vector<real_type> const& path,
-    size_type num_states) const -> std::vector<real_type>
+    VecReal const& path, size_type num_states) const -> VecReal
 {
     CELER_EXPECT(path.size() == this->geometry()->volumes().size());
 
@@ -162,7 +166,7 @@ auto HeuristicGeoTestBase::get_avg_path_impl(
         ref_vol_labels = make_span(temp_labels);
     }
 
-    std::vector<real_type> result(ref_vol_labels.size());
+    VecReal result(ref_vol_labels.size());
 
     real_type const norm = 1 / real_type(num_states);
     for (auto i : range(ref_vol_labels.size()))

--- a/test/celeritas/geo/HeuristicGeoTestBase.hh
+++ b/test/celeritas/geo/HeuristicGeoTestBase.hh
@@ -61,23 +61,24 @@ class HeuristicGeoTestBase : public GlobalGeoTestBase,
     //// TEST EXECUTION ////
 
     //!@{
-    //! Run tracks on device or host and compare the resulting path length
-    void run_host(size_type num_states, real_type tolerance);
-    void run_device(size_type num_states, real_type tolerance);
+    //! Run tracks on device and host and compare the resulting path length
+    void run(size_type num_states, real_type tolerance);
     //!@}
 
   private:
+    using VecReal = std::vector<real_type>;
     //// HELPER FUNCTIONS ////
+    template<MemSpace M>
+    VecReal run_impl(size_type num_states);
 
     template<MemSpace M>
     HeuristicGeoParamsData<Ownership::const_reference, M> build_test_params();
 
     template<MemSpace M>
-    std::vector<real_type>
-    get_avg_path(PathLengthRef<M> path, size_type num_states) const;
+    VecReal get_avg_path(PathLengthRef<M> path, size_type num_states) const;
 
-    std::vector<real_type> get_avg_path_impl(std::vector<real_type> const& path,
-                                             size_type num_states) const;
+    VecReal get_avg_path_impl(std::vector<real_type> const& path,
+                              size_type num_states) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -306,7 +306,7 @@ TEST_F(FourLevelsVgdmlTest, consecutive_compute)
 {
     auto geo = this->make_geo_track_view({-9, -10, -10}, {1, 0, 0});
     ASSERT_FALSE(geo.is_outside());
-    EXPECT_EQ(VolumeId{0}, geo.volume_id());
+    EXPECT_EQ("Shape2", this->volume_name(geo));
     EXPECT_FALSE(geo.is_on_boundary());
 
     auto next = geo.find_next_step(from_cm(10.0));
@@ -328,7 +328,7 @@ TEST_F(FourLevelsVgdmlTest, detailed_track)
         SCOPED_TRACE("rightward along corner");
         auto geo = this->make_geo_track_view({-10, -10, -10}, {1, 0, 0});
         ASSERT_FALSE(geo.is_outside());
-        EXPECT_EQ(VolumeId{0}, geo.volume_id());
+        EXPECT_EQ("Shape2", this->volume_name(geo));
         EXPECT_FALSE(geo.is_on_boundary());
 
         // Check for surfaces up to a distance of 4 units away
@@ -346,9 +346,9 @@ TEST_F(FourLevelsVgdmlTest, detailed_track)
         EXPECT_SOFT_EQ(1.5, to_cm(next.distance));
         EXPECT_TRUE(next.boundary);
         geo.move_to_boundary();
-        EXPECT_EQ(VolumeId{0}, geo.volume_id());
+        EXPECT_EQ("Shape2", this->volume_name(geo));
         geo.cross_boundary();
-        EXPECT_EQ(VolumeId{1}, geo.volume_id());
+        EXPECT_EQ("Shape1", this->volume_name(geo));
         EXPECT_TRUE(geo.is_on_boundary());
 
         // Find the next boundary and make sure that nearer distances aren't
@@ -374,13 +374,13 @@ TEST_F(FourLevelsVgdmlTest, detailed_track)
         EXPECT_TRUE(geo.is_outside());
         geo.cross_boundary();
         EXPECT_FALSE(geo.is_outside());
-        EXPECT_EQ(VolumeId{3}, geo.volume_id());
+        EXPECT_EQ("World", this->volume_name(geo));
     }
     {
         SCOPED_TRACE("inside out");
         auto geo = this->make_geo_track_view({-23.5, 6.5, 6.5}, {-1, 0, 0});
         EXPECT_FALSE(geo.is_outside());
-        EXPECT_EQ(VolumeId{3}, geo.volume_id());
+        EXPECT_EQ("World", this->volume_name(geo));
 
         auto next = geo.find_next_step(from_cm(2));
         EXPECT_SOFT_EQ(0.5, to_cm(next.distance));
@@ -422,7 +422,8 @@ TEST_F(FourLevelsVgdmlTest, reentrant_boundary)
 
     // Move to the sphere boundary then scatter still into the sphere
     next = geo.find_next_step(from_cm(10.0));
-    EXPECT_SOFT_EQ(1e-8, next.distance);
+    auto expected_distance = to_cm(CELERITAS_VECGEOM_SURFACE ? 1e-13 : 1e-8);
+    EXPECT_SOFT_EQ(expected_distance, next.distance);
     EXPECT_TRUE(next.boundary);
     geo.move_to_boundary();
     EXPECT_TRUE(geo.is_on_boundary());
@@ -434,8 +435,11 @@ TEST_F(FourLevelsVgdmlTest, reentrant_boundary)
 
     // Travel nearly tangent to the right edge of the sphere, then scatter to
     // still outside
+    // TODO: understand difference in distance for surface implementation
     next = geo.find_next_step(from_cm(1.0));
-    EXPECT_SOFT_EQ(0.00031622777925735285, to_cm(next.distance));
+    EXPECT_SOFT_EQ(CELERITAS_VECGEOM_SURFACE ? 9.9737647358664937e-07
+                                             : 0.00031622777925735285,
+                   to_cm(next.distance));
     geo.move_to_boundary();
     EXPECT_TRUE(geo.is_on_boundary());
     geo.set_dir({1, 0, 0});
@@ -594,27 +598,6 @@ TEST_F(SolidsVgdmlTest, accessors)
     EXPECT_VEC_SOFT_EQ((Real3{600.001, 300.001, 75.001}), to_cm(bbox.upper()));
 }
 
-TEST_F(SolidsVgdmlTest, names)
-{
-    auto const& geom = *this->geometry();
-    std::vector<std::string> labels;
-    for (auto vid : range(VolumeId{geom.volumes().size()}))
-    {
-        labels.push_back(
-            this->genericize_pointers(to_string(geom.volumes().at(vid))));
-    }
-
-    // clang-format off
-    static char const* const expected_labels[] = {"", "", "",
-        "", "box500", "cone1", "para1", "sphere1", "parabol1", "trap1",
-        "trd1", "trd2", "", "trd3_refl@1", "tube100", "boolean1",
-        "polycone1", "genPocone1", "ellipsoid1", "tetrah1", "orb1",
-        "polyhedr1", "hype1", "elltube1", "ellcone1", "arb8b", "arb8a",
-        "xtru1", "World", "", "trd3_refl@0"};
-    // clang-format on
-    EXPECT_VEC_EQ(expected_labels, labels);
-}
-
 TEST_F(SolidsVgdmlTest, output)
 {
     GeoParamsOutput out(this->geometry());
@@ -622,11 +605,9 @@ TEST_F(SolidsVgdmlTest, output)
 
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
-        auto out_str = this->genericize_pointers(to_string(out));
-
         EXPECT_JSON_EQ(
             R"json({"_category":"internal","_label":"geometry","bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"max_depth":2,"supports_safety":true,"volumes":{"label":["","","","","box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","","trd3_refl@1","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","","trd3_refl@0"]}})json",
-            out_str);
+            to_string(out));
     }
 }
 
@@ -663,6 +644,25 @@ using CmseTest = GenericGeoParameterizedTest<VecgeomGeantTestBase, CmseGeoTest>;
 TEST_F(CmseTest, trace)
 {
     this->impl().test_trace();
+}
+
+TEST_F(CmseTest, imager)
+{
+    SafetyImager write_image{this->geometry()};
+
+    ImageInput inp;
+    inp.lower_left = from_cm({-550, 0, -4000});
+    inp.upper_right = from_cm({550, 0, 2000});
+    inp.rightward = {0.0, 0.0, 1.0};
+    inp.vertical_pixels = 8;
+
+    std::string prefix = "vg";
+    if (VecgeomParams::use_surface_tracking())
+    {
+        prefix += "surf";
+    }
+
+    write_image(ImageParams{inp}, prefix + "-cmse.jsonl");
 }
 
 //---------------------------------------------------------------------------//
@@ -829,7 +829,7 @@ TEST_F(SolidsTest, reflected_vol)
     EXPECT_EQ("trd3_refl@0", to_string(label));
 }
 
-TEST_F(SolidsTest, DISABLED_imager)
+TEST_F(SolidsTest, imager)
 {
     SafetyImager write_image{this->geometry()};
 
@@ -837,12 +837,18 @@ TEST_F(SolidsTest, DISABLED_imager)
     inp.lower_left = from_cm({-550, -250, 5});
     inp.upper_right = from_cm({550, 250, 5});
     inp.rightward = {1.0, 0.0, 0.0};
-    inp.vertical_pixels = 256;
+    inp.vertical_pixels = 8;
 
-    write_image(ImageParams{inp}, "vg-solids-xy-hi.jsonl");
+    std::string prefix = "vg";
+    if (VecgeomParams::use_surface_tracking())
+    {
+        prefix += "surf";
+    }
+
+    write_image(ImageParams{inp}, prefix + "-solids-xy-hi.jsonl");
 
     inp.lower_left[2] = inp.upper_right[2] = from_cm(-5);
-    write_image(ImageParams{inp}, "vg-solids-xy-lo.jsonl");
+    write_image(ImageParams{inp}, prefix + "-solids-xy-lo.jsonl");
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -422,7 +422,7 @@ TEST_F(FourLevelsVgdmlTest, reentrant_boundary)
 
     // Move to the sphere boundary then scatter still into the sphere
     next = geo.find_next_step(from_cm(10.0));
-    auto expected_distance = to_cm(CELERITAS_VECGEOM_SURFACE ? 1e-13 : 1e-8);
+    auto expected_distance = to_cm(1e-8);
     EXPECT_SOFT_EQ(expected_distance, next.distance);
     EXPECT_TRUE(next.boundary);
     geo.move_to_boundary();
@@ -435,11 +435,8 @@ TEST_F(FourLevelsVgdmlTest, reentrant_boundary)
 
     // Travel nearly tangent to the right edge of the sphere, then scatter to
     // still outside
-    // TODO: understand difference in distance for surface implementation
     next = geo.find_next_step(from_cm(1.0));
-    EXPECT_SOFT_EQ(CELERITAS_VECGEOM_SURFACE ? 9.9737647358664937e-07
-                                             : 0.00031622777925735285,
-                   to_cm(next.distance));
+    EXPECT_SOFT_EQ(0.00031622777925735285, to_cm(next.distance));
     geo.move_to_boundary();
     EXPECT_TRUE(geo.is_on_boundary());
     geo.set_dir({1, 0, 0});


### PR DESCRIPTION
This pulls another couple of small changes from #1422 . The geometry heuristic test now guarantees reproducibility between CPU and GPU. The VecGeom test is now somewhat simplified. Finally the `ScopedLimitSaver` used by VecgeomParams is now cleaned up a bit.