### PR TITLE
Hotfix: prevent vecgeom 2.0 in regular builds

### DIFF
--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -84,7 +84,7 @@ jobs:
           sed -e 's/cxxstd=default/cxxstd=${{env.CXXSTD}}/' \
             scripts/ci/spack.yaml > spack.yaml
           if ${{matrix.geometry == 'vecgeom'}}; then
-            spack -e . add vecgeom@1+gdml
+            spack -e . add vecgeom@1.2.10:1+gdml
           fi
           if ${{(matrix.special != 'minimal')
                 && (matrix.special != 'asanlite')

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -73,24 +73,18 @@ jobs:
           fetch-depth: ${{format('{0}', matrix.special != 'clang-tidy' && 383 || 0)}}
           fetch-tags: true # to get version information
       - name: Setup Spack
-        uses: spack/setup-spack@5792f7c7055c3707819380b5e3831d2be6e64b6c # 2024/12
+        uses: spack/setup-spack@a91f96292c5d999463818365a3dfdabacdd3a31b # develop@2025-03-06
         with:
           ref: ${{env.SPACK_REF}}
           buildcache: true
           color: true
           path: spack-src
-      - name: Patch spack # To be deleted; see associated github pulls
-        working-directory: spack-src
-        run: |
-          for id in 48328 48332 48347 48844 49003 49110 49195; do
-            curl -LfsS "https://github.com/spack/spack/pull/${id}.diff" | patch -p1
-          done
       - name: Initialize spack environment
         run: |
           sed -e 's/cxxstd=default/cxxstd=${{env.CXXSTD}}/' \
             scripts/ci/spack.yaml > spack.yaml
           if ${{matrix.geometry == 'vecgeom'}}; then
-            spack -e . add vecgeom+gdml
+            spack -e . add vecgeom~surface+gdml
           fi
           if ${{(matrix.special != 'minimal')
                 && (matrix.special != 'asanlite')

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -84,7 +84,7 @@ jobs:
           sed -e 's/cxxstd=default/cxxstd=${{env.CXXSTD}}/' \
             scripts/ci/spack.yaml > spack.yaml
           if ${{matrix.geometry == 'vecgeom'}}; then
-            spack -e . add vecgeom~surface+gdml
+            spack -e . add vecgeom@1+gdml
           fi
           if ${{(matrix.special != 'minimal')
                 && (matrix.special != 'asanlite')

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -13,7 +13,7 @@ concurrency:
   group: build-spack-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
 
 env:
-  SPACK_REF: 866785bd74964142e4b47bf71bee68d7426c84ee # develop@2024-12-31
+  SPACK_REF: a91f96292c5d999463818365a3dfdabacdd3a31b # develop@2025-03-06
 
 jobs:
   spack:
@@ -73,7 +73,7 @@ jobs:
           fetch-depth: ${{format('{0}', matrix.special != 'clang-tidy' && 383 || 0)}}
           fetch-tags: true # to get version information
       - name: Setup Spack
-        uses: spack/setup-spack@a91f96292c5d999463818365a3dfdabacdd3a31b # develop@2025-03-06
+        uses: spack/setup-spack@5792f7c7055c3707819380b5e3831d2be6e64b6c # 2024/12
         with:
           ref: ${{env.SPACK_REF}}
           buildcache: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,38 +32,7 @@ jobs:
       with:
         name: event-file
         path: ${{github.event_path}}
-  build-fast:
-    uses: ./.github/workflows/build-fast.yml
-  build-ultralite:
-    uses: ./.github/workflows/build-ultralite.yml
-  doc:
-    uses: ./.github/workflows/doc.yml
-  all-prechecks:
-    needs: [build-fast, build-ultralite, doc]
-    runs-on: ubuntu-24.04
-    steps:
-    - name: Success
-      run: "true"
-  build-docker:
-    # Since docker builds aren't cached and are large, don't run on draft
-    if: ${{github.event.pull_request.draft == false}}
-    needs: [all-prechecks]
-    uses: ./.github/workflows/build-docker.yml
   build-spack:
-    needs: [all-prechecks]
     uses: ./.github/workflows/build-spack.yml
-
-  # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
-  all:
-    if: ${{always()}}
-    needs:
-    - build-docker
-    - build-spack
-    runs-on: ubuntu-24.04
-    steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{toJSON(needs)}}
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,38 @@ jobs:
       with:
         name: event-file
         path: ${{github.event_path}}
+  build-fast:
+    uses: ./.github/workflows/build-fast.yml
+  build-ultralite:
+    uses: ./.github/workflows/build-ultralite.yml
+  doc:
+    uses: ./.github/workflows/doc.yml
+  all-prechecks:
+    needs: [build-fast, build-ultralite, doc]
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Success
+      run: "true"
+  build-docker:
+    # Since docker builds aren't cached and are large, don't run on draft
+    if: ${{github.event.pull_request.draft == false}}
+    needs: [all-prechecks]
+    uses: ./.github/workflows/build-docker.yml
   build-spack:
+    needs: [all-prechecks]
     uses: ./.github/workflows/build-spack.yml
+
+  # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
+  all:
+    if: ${{always()}}
+    needs:
+    - build-docker
+    - build-spack
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{toJSON(needs)}}
 
 # vim: set nowrap tw=100:

--- a/cmake/CgvFindVersion.cmake
+++ b/cmake/CgvFindVersion.cmake
@@ -104,7 +104,7 @@ endmacro()
 #-----------------------------------------------------------------------------#
 # Execute a command, logging verbosely, saving output
 macro(_cgv_git_call_output output_var)
-  message(VERBOSE "Executing ${GIT_EXECUTABLE} from ${CGV_SOURCE_DIR}: ${ARGV}")
+  message(VERBOSE "Executing ${GIT_EXECUTABLE} from ${CGV_SOURCE_DIR}: ${ARGN}")
   execute_process(
     COMMAND "${GIT_EXECUTABLE}" ${ARGN}
     WORKING_DIRECTORY "${CGV_SOURCE_DIR}"
@@ -440,4 +440,4 @@ if(CMAKE_SCRIPT_MODE_FILE)
   endif()
 endif()
 
-# cmake-git-version 1.2.1-4+main.86aa5ba
+# cmake-git-version 1.2.1-5+main.bdcc7d7

--- a/scripts/docker/interactive/spack.yaml
+++ b/scripts/docker/interactive/spack.yaml
@@ -5,7 +5,7 @@ spack:
     - "googletest@1.10:"
     - hepmc3
     - nlohmann-json
-    - "vecgeom@1.2.10: +gdml"
+    - "vecgeom@1.2.10:1 +gdml"
   view: true
   concretizer:
     unify: true

--- a/scripts/spack.yaml
+++ b/scripts/spack.yaml
@@ -19,7 +19,7 @@ spack:
     - py-sphinxcontrib-bibtex
     - py-sphinxcontrib-mermaid
     - "root@6.28:"
-    - "vecgeom@1.2.10: +gdml"
+    - "vecgeom@1.2.10:1 +gdml"
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
The last push I did to the Celeritas spack GHA buildcache included vecgeom 2.0, which is getting selected by default even though it's compatible with develop.