### PR TITLE
Rename `CoreTrackView` methods

### DIFF
--- a/src/celeritas/alongstep/detail/FluctELoss.hh
+++ b/src/celeritas/alongstep/detail/FluctELoss.hh
@@ -77,11 +77,11 @@ CELER_FUNCTION bool FluctELoss::is_applicable(CoreTrackView const& track) const
 {
     // The track can be marked as `errored` *within* the along-step kernel,
     // during propagation
-    if (track.make_sim_view().status() == TrackStatus::errored)
+    if (track.sim().status() == TrackStatus::errored)
         return false;
 
     // Energy loss grid ID is 'false'
-    return static_cast<bool>(track.make_physics_view().energy_loss_grid());
+    return static_cast<bool>(track.physics().energy_loss_grid());
 }
 
 //---------------------------------------------------------------------------//
@@ -103,8 +103,8 @@ CELER_FUNCTION auto FluctELoss::calc_eloss(CoreTrackView const& track,
 {
     CELER_EXPECT(step > 0);
 
-    auto particle = track.make_particle_view();
-    auto phys = track.make_physics_view();
+    auto particle = track.particle();
+    auto phys = track.physics();
 
     if (apply_cut && particle.energy() < phys.particle_scalars().lowest_energy)
     {
@@ -119,13 +119,13 @@ CELER_FUNCTION auto FluctELoss::calc_eloss(CoreTrackView const& track,
     if (eloss < particle.energy())
     {
         // Apply energy loss fluctuations
-        auto cutoffs = track.make_cutoff_view();
-        auto material = track.make_material_view();
+        auto cutoffs = track.cutoff();
+        auto material = track.material();
 
         EnergyLossHelper loss_helper(
             fluct_params_, cutoffs, material, particle, eloss, step);
 
-        auto rng = track.make_rng_engine();
+        auto rng = track.rng();
         switch (loss_helper.model())
         {
 #define ASU_SAMPLE_ELOSS(MODEL)                                              \
@@ -170,7 +170,7 @@ CELER_FUNCTION auto FluctELoss::calc_eloss(CoreTrackView const& track,
 
     CELER_ASSERT(eloss <= particle.energy());
     CELER_ENSURE(eloss != particle.energy() || apply_cut
-                 || track.make_sim_view().post_step_action()
+                 || track.sim().post_step_action()
                         == phys.scalars().range_action());
     return eloss;
 }

--- a/src/celeritas/alongstep/detail/LinearPropagatorFactory.hh
+++ b/src/celeritas/alongstep/detail/LinearPropagatorFactory.hh
@@ -23,7 +23,7 @@ struct LinearPropagatorFactory
 {
     CELER_FUNCTION decltype(auto) operator()(CoreTrackView const& track) const
     {
-        return LinearPropagator{track.make_geo_view()};
+        return LinearPropagator{track.geometry()};
     }
 
     static CELER_CONSTEXPR_FUNCTION bool tracks_can_loop() { return false; }

--- a/src/celeritas/alongstep/detail/MeanELoss.hh
+++ b/src/celeritas/alongstep/detail/MeanELoss.hh
@@ -49,11 +49,11 @@ CELER_FUNCTION bool MeanELoss::is_applicable(CoreTrackView const& track) const
 {
     // The track can be marked as `errored` *within* the along-step kernel,
     // during propagation
-    if (track.make_sim_view().status() == TrackStatus::errored)
+    if (track.sim().status() == TrackStatus::errored)
         return false;
 
     // Energy loss grid ID is 'false'
-    return static_cast<bool>(track.make_physics_view().energy_loss_grid());
+    return static_cast<bool>(track.physics().energy_loss_grid());
 }
 
 //---------------------------------------------------------------------------//
@@ -66,8 +66,8 @@ CELER_FUNCTION auto MeanELoss::calc_eloss(CoreTrackView const& track,
 {
     CELER_EXPECT(step > 0);
 
-    auto particle = track.make_particle_view();
-    auto phys = track.make_physics_view();
+    auto particle = track.particle();
+    auto phys = track.physics();
 
     if (apply_cut && particle.energy() < phys.particle_scalars().lowest_energy)
     {
@@ -87,7 +87,7 @@ CELER_FUNCTION auto MeanELoss::calc_eloss(CoreTrackView const& track,
 
     CELER_ENSURE(eloss <= particle.energy());
     CELER_ENSURE(eloss != particle.energy()
-                 || track.make_sim_view().post_step_action()
+                 || track.sim().post_step_action()
                         == phys.scalars().range_action());
     return eloss;
 }

--- a/src/celeritas/alongstep/detail/MscApplier.hh
+++ b/src/celeritas/alongstep/detail/MscApplier.hh
@@ -42,13 +42,13 @@ CELER_FUNCTION MscApplier(MH&&) -> MscApplier<MH>;
 template<class MH>
 CELER_FUNCTION void MscApplier<MH>::operator()(CoreTrackView const& track)
 {
-    if (track.make_sim_view().status() != TrackStatus::alive)
+    if (track.sim().status() != TrackStatus::alive)
     {
         // Active track killed during propagation or erroneous: don't apply MSC
         return;
     }
 
-    if (track.make_physics_step_view().msc_step().geom_path > 0)
+    if (track.physics_step().msc_step().geom_path > 0)
     {
         // Scatter the track and transform the "geometrical" step back to
         // "physical" step

--- a/src/celeritas/alongstep/detail/MscStepLimitApplier.hh
+++ b/src/celeritas/alongstep/detail/MscStepLimitApplier.hh
@@ -43,19 +43,19 @@ template<class MH>
 CELER_FUNCTION void
 MscStepLimitApplier<MH>::operator()(CoreTrackView const& track)
 {
-    if (msc.is_applicable(track, track.make_sim_view().step_length()))
+    if (msc.is_applicable(track, track.sim().step_length()))
     {
         // Apply MSC step limiters and transform "physical" step (with MSC) to
         // "geometrical" step (smooth curve)
         msc.limit_step(track);
 
-        auto step_view = track.make_physics_step_view();
+        auto step_view = track.physics_step();
         CELER_ASSERT(step_view.msc_step().geom_path > 0);
     }
     else
     {
         // TODO: hack flag for saving "use_msc"
-        auto step_view = track.make_physics_step_view();
+        auto step_view = track.physics_step();
         step_view.msc_step().geom_path = 0;
     }
 }

--- a/src/celeritas/alongstep/detail/RZMapFieldPropagatorFactory.hh
+++ b/src/celeritas/alongstep/detail/RZMapFieldPropagatorFactory.hh
@@ -26,8 +26,8 @@ struct RZMapFieldPropagatorFactory
         return make_mag_field_propagator<DormandPrinceStepper>(
             RZMapField{field},
             field.options,
-            track.make_particle_view(),
-            track.make_geo_view());
+            track.particle(),
+            track.geometry());
     }
 
     static CELER_CONSTEXPR_FUNCTION bool tracks_can_loop() { return true; }

--- a/src/celeritas/alongstep/detail/TimeUpdater.hh
+++ b/src/celeritas/alongstep/detail/TimeUpdater.hh
@@ -26,13 +26,13 @@ struct TimeUpdater
 //---------------------------------------------------------------------------//
 CELER_FUNCTION void TimeUpdater::operator()(CoreTrackView const& track)
 {
-    auto sim = track.make_sim_view();
+    auto sim = track.sim();
 
     // The track errored within the along-step kernel
     if (sim.status() == TrackStatus::errored)
         return;
 
-    auto particle = track.make_particle_view();
+    auto particle = track.particle();
     real_type speed = native_value_from(particle.speed());
     CELER_ASSERT(speed >= 0);
     if (speed > 0)

--- a/src/celeritas/alongstep/detail/TrackUpdater.hh
+++ b/src/celeritas/alongstep/detail/TrackUpdater.hh
@@ -34,7 +34,7 @@ struct TrackUpdater
 //---------------------------------------------------------------------------//
 CELER_FUNCTION void TrackUpdater::operator()(CoreTrackView& track)
 {
-    auto sim = track.make_sim_view();
+    auto sim = track.sim();
 
     // The track errored within the along-step kernel
     if (sim.status() == TrackStatus::errored)
@@ -45,10 +45,9 @@ CELER_FUNCTION void TrackUpdater::operator()(CoreTrackView& track)
 
     if (sim.status() == TrackStatus::alive)
     {
-        CELER_ASSERT(sim.step_length() > 0
-                     || track.make_particle_view().is_stopped());
+        CELER_ASSERT(sim.step_length() > 0 || track.particle().is_stopped());
         CELER_ASSERT(sim.post_step_action());
-        auto phys = track.make_physics_view();
+        auto phys = track.physics();
 
         if (sim.num_steps() == sim.max_steps()
             && sim.post_step_action() != track.tracking_cut_action())
@@ -70,7 +69,7 @@ CELER_FUNCTION void TrackUpdater::operator()(CoreTrackView& track)
             // collision point but has undergone too many steps), it's OK to
             // set the interaction MFP to zero (but avoid during debug mode due
             // to the additional error checking).
-            auto step = track.make_physics_step_view();
+            auto step = track.physics_step();
             real_type mfp = phys.interaction_mfp()
                             - sim.step_length() * step.macro_xs();
             CELER_ASSERT(mfp > 0);

--- a/src/celeritas/alongstep/detail/UniformFieldPropagatorFactory.hh
+++ b/src/celeritas/alongstep/detail/UniformFieldPropagatorFactory.hh
@@ -31,8 +31,8 @@ struct UniformFieldPropagatorFactory
         return make_mag_field_propagator<DormandPrinceStepper>(
             UniformField(field.field),
             field.options,
-            track.make_particle_view(),
-            track.make_geo_view());
+            track.particle(),
+            track.geometry());
     }
 
     static CELER_CONSTEXPR_FUNCTION bool tracks_can_loop() { return true; }

--- a/src/celeritas/decay/executor/MuDecayExecutor.hh
+++ b/src/celeritas/decay/executor/MuDecayExecutor.hh
@@ -28,13 +28,12 @@ struct MuDecayExecutor
  */
 CELER_FUNCTION Interaction MuDecayExecutor::operator()(CoreTrackView const& track)
 {
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
-    auto particle = track.make_particle_view();
-    auto const& dir = track.make_geo_view().dir();
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
+    auto particle = track.particle();
+    auto const& dir = track.geometry().dir();
 
     MuDecayInteractor interact(data, particle, dir, allocate_secondaries);
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/distribution/EnergyLossHelper.hh
+++ b/src/celeritas/em/distribution/EnergyLossHelper.hh
@@ -234,7 +234,7 @@ EnergyLossHelper::EnergyLossHelper(FluctuationRef const& shared,
     // assuming implicit 1/c^2 in the formula
     bohr_var_ = 2 * constants::pi * ipow<2>(constants::r_electron)
                 * value_as<Mass>(shared_.electron_mass)
-                * material_.make_material_view().electron_density()
+                * material_.material_record().electron_density()
                 * ipow<2>(value_as<Charge>(particle.charge())) * max_energy_
                 * step_length * (1 / beta_sq_ - half);
 

--- a/src/celeritas/em/distribution/EnergyLossUrbanDistribution.hh
+++ b/src/celeritas/em/distribution/EnergyLossUrbanDistribution.hh
@@ -161,7 +161,7 @@ CELER_FUNCTION EnergyLossUrbanDistribution::EnergyLossUrbanDistribution(
 
     // Calculate the excitation macroscopic cross sections and apply the width
     // correction
-    auto const& mat = cur_mat.make_material_view();
+    auto const& mat = cur_mat.material_record();
     if (max_energy_ > value_as<Energy>(mat.mean_excitation_energy()))
     {
         // Common term in the numerator and denominator of PRM Eq. 7.10

--- a/src/celeritas/em/executor/BetheHeitlerExecutor.hh
+++ b/src/celeritas/em/executor/BetheHeitlerExecutor.hh
@@ -36,20 +36,18 @@ struct BetheHeitlerExecutor
 CELER_FUNCTION Interaction
 BetheHeitlerExecutor::operator()(CoreTrackView const& track)
 {
-    auto material_track = track.make_material_view();
-    auto material = material_track.make_material_view();
-    auto particle = track.make_particle_view();
-    auto elcomp_id = track.make_physics_step_view().element();
+    auto material = track.material().material_record();
+    auto particle = track.particle();
+    auto elcomp_id = track.physics_step().element();
     CELER_ASSERT(elcomp_id);
-    auto element = material.make_element_view(elcomp_id);
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
-    auto const& dir = track.make_geo_view().dir();
+    auto element = material.element_record(elcomp_id);
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
+    auto const& dir = track.geometry().dir();
 
     BetheHeitlerInteractor interact(
         params, particle, dir, allocate_secondaries, material, element);
 
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/executor/CombinedBremExecutor.hh
+++ b/src/celeritas/em/executor/CombinedBremExecutor.hh
@@ -37,17 +37,16 @@ CELER_FUNCTION Interaction
 CombinedBremExecutor::operator()(CoreTrackView const& track)
 {
     // Select material track view
-    auto material = track.make_material_view().make_material_view();
+    auto material = track.material().material_record();
 
     // Assume only a single element in the material, for now
     CELER_ASSERT(material.num_elements() == 1);
     ElementComponentId const selected_element{0};
 
-    auto particle = track.make_particle_view();
-    auto const& dir = track.make_geo_view().dir();
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
-    auto cutoff = track.make_cutoff_view();
+    auto particle = track.particle();
+    auto const& dir = track.geometry().dir();
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
+    auto cutoff = track.cutoff();
 
     CombinedBremInteractor interact(params,
                                     particle,
@@ -57,7 +56,7 @@ CombinedBremExecutor::operator()(CoreTrackView const& track)
                                     material,
                                     selected_element);
 
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/executor/CoulombScatteringExecutor.hh
+++ b/src/celeritas/em/executor/CoulombScatteringExecutor.hh
@@ -39,21 +39,21 @@ CELER_FUNCTION Interaction
 CoulombScatteringExecutor::operator()(CoreTrackView const& track)
 {
     // Incident particle quantities
-    auto particle = track.make_particle_view();
-    auto const& dir = track.make_geo_view().dir();
+    auto particle = track.particle();
+    auto const& dir = track.geometry().dir();
 
     // Material and target quantities
-    auto material = track.make_material_view().make_material_view();
-    auto elcomp_id = track.make_physics_step_view().element();
+    auto material = track.material().material_record();
+    auto elcomp_id = track.physics_step().element();
     auto element_id = material.element_id(elcomp_id);
-    auto cutoffs = track.make_cutoff_view();
+    auto cutoffs = track.cutoff();
 
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
 
     // Select isotope
-    ElementView element = material.make_element_view(elcomp_id);
+    ElementView element = material.element_record(elcomp_id);
     IsotopeSelector iso_select(element);
-    IsotopeView target = element.make_isotope_view(iso_select(rng));
+    IsotopeView target = element.isotope_record(iso_select(rng));
 
     // Construct the interactor
     CoulombScatteringInteractor interact(

--- a/src/celeritas/em/executor/EPlusGGExecutor.hh
+++ b/src/celeritas/em/executor/EPlusGGExecutor.hh
@@ -28,13 +28,12 @@ struct EPlusGGExecutor
  */
 CELER_FUNCTION Interaction EPlusGGExecutor::operator()(CoreTrackView const& track)
 {
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
-    auto particle = track.make_particle_view();
-    auto const& dir = track.make_geo_view().dir();
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
+    auto particle = track.particle();
+    auto const& dir = track.geometry().dir();
 
     EPlusGGInteractor interact(params, particle, dir, allocate_secondaries);
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/executor/KleinNishinaExecutor.hh
+++ b/src/celeritas/em/executor/KleinNishinaExecutor.hh
@@ -29,14 +29,13 @@ struct KleinNishinaExecutor
 CELER_FUNCTION Interaction
 KleinNishinaExecutor::operator()(CoreTrackView const& track)
 {
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
-    auto particle = track.make_particle_view();
-    auto const& dir = track.make_geo_view().dir();
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
+    auto particle = track.particle();
+    auto const& dir = track.geometry().dir();
 
     KleinNishinaInteractor interact(
         params, particle, dir, allocate_secondaries);
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/executor/MollerBhabhaExecutor.hh
+++ b/src/celeritas/em/executor/MollerBhabhaExecutor.hh
@@ -31,15 +31,14 @@ struct MollerBhabhaExecutor
 CELER_FUNCTION Interaction
 MollerBhabhaExecutor::operator()(CoreTrackView const& track)
 {
-    auto particle = track.make_particle_view();
-    auto cutoff = track.make_cutoff_view();
-    auto const& dir = track.make_geo_view().dir();
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
+    auto particle = track.particle();
+    auto cutoff = track.cutoff();
+    auto const& dir = track.geometry().dir();
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
 
     MollerBhabhaInteractor interact(
         params, particle, cutoff, dir, allocate_secondaries);
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/executor/MuBremsstrahlungExecutor.hh
+++ b/src/celeritas/em/executor/MuBremsstrahlungExecutor.hh
@@ -35,21 +35,19 @@ struct MuBremsstrahlungExecutor
 CELER_FUNCTION Interaction
 MuBremsstrahlungExecutor::operator()(CoreTrackView const& track)
 {
-    auto cutoff = track.make_cutoff_view();
-    auto material_track = track.make_material_view();
-    auto material = material_track.make_material_view();
-    auto particle = track.make_particle_view();
+    auto cutoff = track.cutoff();
+    auto material = track.material().material_record();
+    auto particle = track.particle();
 
-    auto elcomp_id = track.make_physics_step_view().element();
+    auto elcomp_id = track.physics_step().element();
     CELER_ASSERT(elcomp_id);
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
-    auto const& dir = track.make_geo_view().dir();
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
+    auto const& dir = track.geometry().dir();
 
     MuBremsstrahlungInteractor interact(
         params, particle, dir, cutoff, allocate_secondaries, material, elcomp_id);
 
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/executor/MuHadIonizationExecutor.hh
+++ b/src/celeritas/em/executor/MuHadIonizationExecutor.hh
@@ -33,15 +33,14 @@ template<class ES>
 CELER_FUNCTION Interaction
 MuHadIonizationExecutor<ES>::operator()(CoreTrackView const& track)
 {
-    auto particle = track.make_particle_view();
-    auto cutoff = track.make_cutoff_view();
-    auto const& dir = track.make_geo_view().dir();
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
+    auto particle = track.particle();
+    auto cutoff = track.cutoff();
+    auto const& dir = track.geometry().dir();
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
 
     MuHadIonizationInteractor<ES> interact(
         params, particle, cutoff, dir, allocate_secondaries);
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/executor/MuPairProductionExecutor.hh
+++ b/src/celeritas/em/executor/MuPairProductionExecutor.hh
@@ -35,21 +35,18 @@ struct MuPairProductionExecutor
 CELER_FUNCTION Interaction
 MuPairProductionExecutor::operator()(CoreTrackView const& track)
 {
-    auto cutoff = track.make_cutoff_view();
-    auto particle = track.make_particle_view();
-    auto elcomp_id = track.make_physics_step_view().element();
+    auto cutoff = track.cutoff();
+    auto particle = track.particle();
+    auto elcomp_id = track.physics_step().element();
     CELER_ASSERT(elcomp_id);
-    auto element
-        = track.make_material_view().make_material_view().make_element_view(
-            elcomp_id);
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
-    auto const& dir = track.make_geo_view().dir();
+    auto element = track.material().material_record().element_record(elcomp_id);
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
+    auto const& dir = track.geometry().dir();
 
     MuPairProductionInteractor interact(
         params, particle, cutoff, element, dir, allocate_secondaries);
 
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/executor/RayleighExecutor.hh
+++ b/src/celeritas/em/executor/RayleighExecutor.hh
@@ -36,17 +36,17 @@ struct RayleighExecutor
 CELER_FUNCTION Interaction
 RayleighExecutor::operator()(CoreTrackView const& track)
 {
-    auto material = track.make_material_view().make_material_view();
-    auto particle = track.make_particle_view();
+    auto material = track.material().material_record();
+    auto particle = track.particle();
 
-    auto elcomp_id = track.make_physics_step_view().element();
+    auto elcomp_id = track.physics_step().element();
     CELER_ASSERT(elcomp_id);
     auto el_id = material.element_id(elcomp_id);
-    auto const& dir = track.make_geo_view().dir();
+    auto const& dir = track.geometry().dir();
 
     RayleighInteractor interact(params, particle, dir, el_id);
 
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/executor/RelativisticBremExecutor.hh
+++ b/src/celeritas/em/executor/RelativisticBremExecutor.hh
@@ -30,20 +30,19 @@ struct RelativisticBremExecutor
 CELER_FUNCTION Interaction
 RelativisticBremExecutor::operator()(CoreTrackView const& track)
 {
-    auto cutoff = track.make_cutoff_view();
-    auto material = track.make_material_view().make_material_view();
-    auto particle = track.make_particle_view();
+    auto cutoff = track.cutoff();
+    auto material = track.material().material_record();
+    auto particle = track.particle();
 
-    auto elcomp_id = track.make_physics_step_view().element();
+    auto elcomp_id = track.physics_step().element();
     CELER_ASSERT(elcomp_id);
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
-    auto const& dir = track.make_geo_view().dir();
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
+    auto const& dir = track.geometry().dir();
 
     RelativisticBremInteractor interact(
         params, particle, dir, cutoff, allocate_secondaries, material, elcomp_id);
 
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/executor/SeltzerBergerExecutor.hh
+++ b/src/celeritas/em/executor/SeltzerBergerExecutor.hh
@@ -35,20 +35,19 @@ struct SeltzerBergerExecutor
 CELER_FUNCTION Interaction
 SeltzerBergerExecutor::operator()(CoreTrackView const& track)
 {
-    auto cutoff = track.make_cutoff_view();
-    auto material = track.make_material_view().make_material_view();
-    auto particle = track.make_particle_view();
+    auto cutoff = track.cutoff();
+    auto material = track.material().material_record();
+    auto particle = track.particle();
 
-    auto elcomp_id = track.make_physics_step_view().element();
+    auto elcomp_id = track.physics_step().element();
     CELER_ASSERT(elcomp_id);
-    auto allocate_secondaries
-        = track.make_physics_step_view().make_secondary_allocator();
-    auto const& dir = track.make_geo_view().dir();
+    auto allocate_secondaries = track.physics_step().make_secondary_allocator();
+    auto const& dir = track.geometry().dir();
 
     SeltzerBergerInteractor interact(
         params, particle, dir, cutoff, allocate_secondaries, material, elcomp_id);
 
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
     return interact(rng);
 }
 

--- a/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
+++ b/src/celeritas/em/interactor/MuBremsstrahlungInteractor.hh
@@ -103,7 +103,7 @@ CELER_FUNCTION MuBremsstrahlungInteractor::MuBremsstrahlungInteractor(
     : shared_(shared)
     , inc_direction_(inc_direction)
     , allocate_(allocate)
-    , element_(material.make_element_view(elcomp_id))
+    , element_(material.element_record(elcomp_id))
     , particle_(particle)
     , calc_dcs_(
           element_, particle.energy(), particle.mass(), shared.electron_mass)

--- a/src/celeritas/em/interactor/detail/SBEnergySampler.hh
+++ b/src/celeritas/em/interactor/detail/SBEnergySampler.hh
@@ -131,7 +131,7 @@ CELER_FUNCTION auto SBEnergySampler::operator()(Engine& rng) -> Energy
         SBEnergyDistribution<SBPositronXsCorrector> sample_gamma_energy(
             sb_helper,
             {inc_mass_,
-             material_.make_element_view(elcomp_id_),
+             material_.element_record(elcomp_id_),
              gamma_cutoff_,
              inc_energy_});
         gamma_exit_energy = sample_gamma_energy(rng);

--- a/src/celeritas/em/params/WentzelOKVIParams.cc
+++ b/src/celeritas/em/params/WentzelOKVIParams.cc
@@ -147,8 +147,7 @@ void WentzelOKVIParams::build_data(HostVal<WentzelOKVIData>& host_data,
             for (auto elcomp_id : range(ElementComponentId(mat.num_elements())))
             {
                 auto const& el_comp = mat.elements()[elcomp_id.get()];
-                auto atomic_mass
-                    = mat.make_element_view(elcomp_id).atomic_mass();
+                auto atomic_mass = mat.element_record(elcomp_id).atomic_mass();
                 inv_mass_cbrt_sq[mat_id.get()]
                     += el_comp.fraction
                        / std::pow(atomic_mass.value(), real_type(2) / 3);

--- a/src/celeritas/em/xs/RBDiffXsCalculator.hh
+++ b/src/celeritas/em/xs/RBDiffXsCalculator.hh
@@ -120,7 +120,7 @@ RBDiffXsCalculator::RBDiffXsCalculator(RelativisticBremRef const& shared,
                                        ElementComponentId elcomp_id)
     : elem_data_(shared.elem_data[material.element_id(elcomp_id)])
     , material_(material)
-    , element_(material.make_element_view(elcomp_id))
+    , element_(material.element_record(elcomp_id))
     , total_energy_(value_as<Energy>(particle.total_energy()))
     , dielectric_suppression_(shared.dielectric_suppression())
 {

--- a/src/celeritas/em/xs/WentzelMacroXsCalculator.hh
+++ b/src/celeritas/em/xs/WentzelMacroXsCalculator.hh
@@ -87,7 +87,7 @@ WentzelMacroXsCalculator::operator()(real_type cos_theta) const
 
     for (auto elcomp_id : range(ElementComponentId(material_.num_elements())))
     {
-        AtomicNumber z = material_.make_element_view(elcomp_id).atomic_number();
+        AtomicNumber z = material_.element_record(elcomp_id).atomic_number();
         WentzelHelper helper(particle_, material_, z, wentzel_, ids_, cutoff_);
 
         real_type cos_thetamax = helper.cos_thetamax_nuclear();

--- a/src/celeritas/geo/detail/BoundaryExecutor.hh
+++ b/src/celeritas/geo/detail/BoundaryExecutor.hh
@@ -41,12 +41,12 @@ CELER_FUNCTION void
 BoundaryExecutor::operator()(celeritas::CoreTrackView& track)
 {
     CELER_EXPECT([track] {
-        auto sim = track.make_sim_view();
+        auto sim = track.sim();
         return sim.post_step_action() == track.boundary_action()
                && sim.status() == TrackStatus::alive;
     }());
 
-    auto geo = track.make_geo_view();
+    auto geo = track.geometry();
     CELER_EXPECT(geo.is_on_boundary());
 
     // Particle entered a new volume before reaching the interaction point
@@ -59,7 +59,7 @@ BoundaryExecutor::operator()(celeritas::CoreTrackView& track)
     else if (!geo.is_outside())
     {
         // Update the material in the new region
-        auto geo_mat = track.make_geo_material_view();
+        auto geo_mat = track.geo_material();
         auto matid = geo_mat.material_id(geo.volume_id());
         if (CELER_UNLIKELY(!matid))
         {
@@ -70,14 +70,14 @@ BoundaryExecutor::operator()(celeritas::CoreTrackView& track)
             track.apply_errored();
             return;
         }
-        auto mat = track.make_material_view();
+        auto mat = track.material();
         mat = {matid};
 
         CELER_ENSURE(geo.is_on_boundary());
     }
     else
     {
-        auto sim = track.make_sim_view();
+        auto sim = track.sim();
         sim.status(TrackStatus::killed);
     }
 }

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -95,6 +95,20 @@ class CoreTrackView
     // HACK: return scalars (maybe have a struct for all actions?)
     inline CELER_FUNCTION CoreScalars const& core_scalars() const;
 
+    // clang-format off
+    // DEPRECATED: remove in v0.7
+    [[deprecated]] CELER_FUNCTION SimTrackView make_sim_view() const { return this->sim(); }
+    [[deprecated]] CELER_FUNCTION GeoTrackView make_geo_view() const { return this->geometry(); }
+    [[deprecated]] CELER_FUNCTION GeoMaterialView make_geo_material_view() const { return this->geo_material(); }
+    [[deprecated]] CELER_FUNCTION MaterialTrackView make_material_view() const { return this->material(); }
+    [[deprecated]] CELER_FUNCTION ParticleTrackView make_particle_view() const { return this->particle(); }
+    [[deprecated]] CELER_FUNCTION ParticleView make_particle_view(ParticleId pid) const { return this->particle_record(pid); }
+    [[deprecated]] CELER_FUNCTION CutoffView make_cutoff_view() const { return this->cutoff(); }
+    [[deprecated]] CELER_FUNCTION PhysicsTrackView make_physics_view() const { return this->physics(); }
+    [[deprecated]] CELER_FUNCTION PhysicsStepView make_physics_step_view() const { return this->physics_step(); }
+    [[deprecated]] CELER_FUNCTION RngEngine make_rng_engine() const { return this->rng(); }
+    // clang-format on
+
     //// MUTATORS ////
 
     // Set the 'errored' flag and tracking cut post-step action

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -26,8 +26,6 @@ namespace celeritas
  * Helper class to create views from core track data.
  *
  * TODO: const correctness? (Maybe have to wait till C++23's "deducing this"?)
- *
- * \todo Rename make_sim_view -> sim, etc.
  */
 class CoreTrackView
 {
@@ -50,34 +48,34 @@ class CoreTrackView
                                         TrackSlotId slot);
 
     // Return a simulation management view
-    inline CELER_FUNCTION SimTrackView make_sim_view() const;
+    inline CELER_FUNCTION SimTrackView sim() const;
 
     // Return a geometry view
-    inline CELER_FUNCTION GeoTrackView make_geo_view() const;
+    inline CELER_FUNCTION GeoTrackView geometry() const;
 
     // Return a geometry-material view
-    inline CELER_FUNCTION GeoMaterialView make_geo_material_view() const;
+    inline CELER_FUNCTION GeoMaterialView geo_material() const;
 
     // Return a material view
-    inline CELER_FUNCTION MaterialTrackView make_material_view() const;
+    inline CELER_FUNCTION MaterialTrackView material() const;
 
     // Return a particle view
-    inline CELER_FUNCTION ParticleTrackView make_particle_view() const;
+    inline CELER_FUNCTION ParticleTrackView particle() const;
 
     // Return a particle view of another particle type
-    inline CELER_FUNCTION ParticleView make_particle_view(ParticleId) const;
+    inline CELER_FUNCTION ParticleView particle_record(ParticleId) const;
 
     // Return a cutoff view
-    inline CELER_FUNCTION CutoffView make_cutoff_view() const;
+    inline CELER_FUNCTION CutoffView cutoff() const;
 
     // Return a physics view
-    inline CELER_FUNCTION PhysicsTrackView make_physics_view() const;
+    inline CELER_FUNCTION PhysicsTrackView physics() const;
 
     // Return a view to temporary physics data
-    inline CELER_FUNCTION PhysicsStepView make_physics_step_view() const;
+    inline CELER_FUNCTION PhysicsStepView physics_step() const;
 
     // Return an RNG engine
-    inline CELER_FUNCTION RngEngine make_rng_engine() const;
+    inline CELER_FUNCTION RngEngine rng() const;
 
     // Get the index of the current thread in the current kernel
     inline CELER_FUNCTION ThreadId thread_id() const;
@@ -149,7 +147,7 @@ CoreTrackView::CoreTrackView(ParamsRef const& params,
 /*!
  * Return a simulation management view.
  */
-CELER_FUNCTION SimTrackView CoreTrackView::make_sim_view() const
+CELER_FUNCTION SimTrackView CoreTrackView::sim() const
 {
     return SimTrackView{params_.sim, states_.sim, this->track_slot_id()};
 }
@@ -158,7 +156,7 @@ CELER_FUNCTION SimTrackView CoreTrackView::make_sim_view() const
 /*!
  * Return a geometry view.
  */
-CELER_FUNCTION auto CoreTrackView::make_geo_view() const -> GeoTrackView
+CELER_FUNCTION auto CoreTrackView::geometry() const -> GeoTrackView
 {
     return GeoTrackView{
         params_.geometry, states_.geometry, this->track_slot_id()};
@@ -168,8 +166,7 @@ CELER_FUNCTION auto CoreTrackView::make_geo_view() const -> GeoTrackView
 /*!
  * Return a geometry-material view.
  */
-CELER_FUNCTION auto
-CoreTrackView::make_geo_material_view() const -> GeoMaterialView
+CELER_FUNCTION auto CoreTrackView::geo_material() const -> GeoMaterialView
 {
     return GeoMaterialView{params_.geo_mats};
 }
@@ -178,8 +175,7 @@ CoreTrackView::make_geo_material_view() const -> GeoMaterialView
 /*!
  * Return a material view.
  */
-CELER_FUNCTION auto
-CoreTrackView::make_material_view() const -> MaterialTrackView
+CELER_FUNCTION auto CoreTrackView::material() const -> MaterialTrackView
 {
     return MaterialTrackView{
         params_.materials, states_.materials, this->track_slot_id()};
@@ -189,8 +185,7 @@ CoreTrackView::make_material_view() const -> MaterialTrackView
 /*!
  * Return a particle view.
  */
-CELER_FUNCTION auto
-CoreTrackView::make_particle_view() const -> ParticleTrackView
+CELER_FUNCTION auto CoreTrackView::particle() const -> ParticleTrackView
 {
     return ParticleTrackView{
         params_.particles, states_.particles, this->track_slot_id()};
@@ -200,8 +195,8 @@ CoreTrackView::make_particle_view() const -> ParticleTrackView
 /*!
  * Return a particle view of another particle type.
  */
-CELER_FUNCTION auto
-CoreTrackView::make_particle_view(ParticleId pid) const -> ParticleView
+CELER_FUNCTION auto CoreTrackView::particle_record(ParticleId pid) const
+    -> ParticleView
 {
     return ParticleView{params_.particles, pid};
 }
@@ -210,9 +205,9 @@ CoreTrackView::make_particle_view(ParticleId pid) const -> ParticleView
 /*!
  * Return a cutoff view.
  */
-CELER_FUNCTION auto CoreTrackView::make_cutoff_view() const -> CutoffView
+CELER_FUNCTION auto CoreTrackView::cutoff() const -> CutoffView
 {
-    MaterialId mat_id = this->make_material_view().material_id();
+    MaterialId mat_id = this->material().material_id();
     CELER_ASSERT(mat_id);
     return CutoffView{params_.cutoffs, mat_id};
 }
@@ -221,11 +216,11 @@ CELER_FUNCTION auto CoreTrackView::make_cutoff_view() const -> CutoffView
 /*!
  * Return a physics view.
  */
-CELER_FUNCTION auto CoreTrackView::make_physics_view() const -> PhysicsTrackView
+CELER_FUNCTION auto CoreTrackView::physics() const -> PhysicsTrackView
 {
-    MaterialId mat_id = this->make_material_view().material_id();
+    MaterialId mat_id = this->material().material_id();
     CELER_ASSERT(mat_id);
-    auto par = this->make_particle_view();
+    auto par = this->particle();
     return PhysicsTrackView{
         params_.physics, states_.physics, par, mat_id, this->track_slot_id()};
 }
@@ -234,8 +229,7 @@ CELER_FUNCTION auto CoreTrackView::make_physics_view() const -> PhysicsTrackView
 /*!
  * Return a physics view.
  */
-CELER_FUNCTION auto
-CoreTrackView::make_physics_step_view() const -> PhysicsStepView
+CELER_FUNCTION auto CoreTrackView::physics_step() const -> PhysicsStepView
 {
     return PhysicsStepView{
         params_.physics, states_.physics, this->track_slot_id()};
@@ -245,7 +239,7 @@ CoreTrackView::make_physics_step_view() const -> PhysicsStepView
 /*!
  * Return the RNG engine.
  */
-CELER_FUNCTION auto CoreTrackView::make_rng_engine() const -> RngEngine
+CELER_FUNCTION auto CoreTrackView::rng() const -> RngEngine
 {
     return RngEngine{params_.rng, states_.rng, this->track_slot_id()};
 }
@@ -337,7 +331,7 @@ CELER_FUNCTION CoreScalars const& CoreTrackView::core_scalars() const
  */
 CELER_FUNCTION void CoreTrackView::apply_errored()
 {
-    auto sim = this->make_sim_view();
+    auto sim = this->sim();
     CELER_EXPECT(is_track_valid(sim.status()));
     sim.status(TrackStatus::errored);
     sim.along_step_action({});

--- a/src/celeritas/global/DebugIO.json.cc
+++ b/src/celeritas/global/DebugIO.json.cc
@@ -166,16 +166,16 @@ void to_json(nlohmann::json& j, CoreTrackView const& view)
     ASSIGN_TRANSFORMED(track_slot_id, to_int);
 
     FromId from_id{view.core_scalars().host_core_params.get()};
-    to_json_impl(j["sim"], view.make_sim_view(), from_id);
+    to_json_impl(j["sim"], view.sim(), from_id);
 
-    if (view.make_sim_view().status() == TrackStatus::inactive)
+    if (view.sim().status() == TrackStatus::inactive)
     {
         // Skip all other output since the track is inactive
         return;
     }
 
-    to_json_impl(j["geo"], view.make_geo_view(), from_id);
-    to_json_impl(j["particle"], view.make_particle_view(), from_id);
+    to_json_impl(j["geo"], view.geometry(), from_id);
+    to_json_impl(j["particle"], view.particle(), from_id);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -112,7 +112,7 @@ void KernelContextException::output(JsonPimpl* json) const
 void KernelContextException::initialize(CoreTrackView const& core)
 {
     track_slot_ = core.track_slot_id();
-    auto const&& sim = core.make_sim_view();
+    auto const&& sim = core.sim();
     if (sim.status() != TrackStatus::inactive)
     {
         event_ = sim.event_id();
@@ -120,12 +120,12 @@ void KernelContextException::initialize(CoreTrackView const& core)
         parent_ = sim.parent_id();
         num_steps_ = sim.num_steps();
         {
-            auto const&& par = core.make_particle_view();
+            auto const&& par = core.particle();
             particle_ = par.particle_id();
             energy_ = par.energy();
         }
         {
-            auto const&& geo = core.make_geo_view();
+            auto const&& geo = core.geometry();
             pos_ = geo.pos();
             dir_ = geo.dir();
             if (!geo.is_outside())

--- a/src/celeritas/global/TrackExecutor.hh
+++ b/src/celeritas/global/TrackExecutor.hh
@@ -122,7 +122,7 @@ class ConditionalTrackExecutor
     {
         CELER_EXPECT(thread < state_->size());
         CoreTrackView track(*params_, *state_, thread);
-        if (!applies_(track.make_sim_view()))
+        if (!applies_(track.sim()))
         {
             return;
         }

--- a/src/celeritas/global/detail/KillActive.hh
+++ b/src/celeritas/global/detail/KillActive.hh
@@ -44,7 +44,7 @@ void kill_active(CoreParams const& params, CoreState<MemSpace::device>& state);
 CELER_FUNCTION void
 KillActiveExecutor::operator()(celeritas::CoreTrackView& track)
 {
-    if (track.make_sim_view().status() != TrackStatus::inactive)
+    if (track.sim().status() != TrackStatus::inactive)
     {
         track.apply_errored();
     }

--- a/src/celeritas/mat/ElementSelector.hh
+++ b/src/celeritas/mat/ElementSelector.hh
@@ -42,7 +42,7 @@ namespace celeritas
     ElementComponentId id = select_element(rng);
     real_type selected_micro_xs
         = select_element.elemental_micro_xs()[el.get()];
-    ElementView el = mat.make_element_view(id);
+    ElementView el = mat.element_record(id);
     // use el.Z(), etc.
    \endcode
  *

--- a/src/celeritas/mat/ElementView.hh
+++ b/src/celeritas/mat/ElementView.hh
@@ -57,8 +57,7 @@ class ElementView
     inline CELER_FUNCTION IsotopeComponentId::size_type num_isotopes() const;
 
     // View properties of a specific isotope
-    inline CELER_FUNCTION IsotopeView
-    make_isotope_view(IsotopeComponentId id) const;
+    inline CELER_FUNCTION IsotopeView isotope_record(IsotopeComponentId id) const;
 
     // ID of an isotope component of this element
     inline CELER_FUNCTION IsotopeId isotope_id(IsotopeComponentId id) const;
@@ -123,8 +122,7 @@ CELER_FUNCTION IsotopeComponentId::size_type ElementView::num_isotopes() const
 /*!
  * Get isotope properties for a given index.
  */
-CELER_FUNCTION IsotopeView
-ElementView::make_isotope_view(IsotopeComponentId id) const
+CELER_FUNCTION IsotopeView ElementView::isotope_record(IsotopeComponentId id) const
 {
     CELER_EXPECT(id < this->num_isotopes());
     return IsotopeView(params_, this->isotope_id(id));

--- a/src/celeritas/mat/MaterialTrackView.hh
+++ b/src/celeritas/mat/MaterialTrackView.hh
@@ -63,7 +63,7 @@ class MaterialTrackView
     //// STATIC PROPERTIES ////
 
     // Get a view to material properties
-    CELER_FORCEINLINE_FUNCTION MaterialView make_material_view() const;
+    CELER_FORCEINLINE_FUNCTION MaterialView material_record() const;
 
     // Access scratch space with at least one real per element component
     inline CELER_FUNCTION Span<real_type> element_scratch();
@@ -116,7 +116,7 @@ CELER_FUNCTION MaterialId MaterialTrackView::material_id() const
 /*!
  * Get material properties for the current material.
  */
-CELER_FUNCTION MaterialView MaterialTrackView::make_material_view() const
+CELER_FUNCTION MaterialView MaterialTrackView::material_record() const
 {
     return MaterialView(params_, this->material_id());
 }

--- a/src/celeritas/mat/MaterialView.hh
+++ b/src/celeritas/mat/MaterialView.hh
@@ -62,8 +62,7 @@ class MaterialView
     inline CELER_FUNCTION ElementComponentId::size_type num_elements() const;
 
     // Element properties for a material-specific index
-    inline CELER_FUNCTION ElementView
-    make_element_view(ElementComponentId id) const;
+    inline CELER_FUNCTION ElementView element_record(ElementComponentId id) const;
 
     // ID of a component element in this material
     inline CELER_FUNCTION ElementId element_id(ElementComponentId id) const;
@@ -184,8 +183,7 @@ CELER_FUNCTION ElementComponentId::size_type MaterialView::num_elements() const
 /*!
  * Get element properties from a material-specific index.
  */
-CELER_FUNCTION ElementView
-MaterialView::make_element_view(ElementComponentId id) const
+CELER_FUNCTION ElementView MaterialView::element_record(ElementComponentId id) const
 {
     CELER_EXPECT(id < this->material_def().elements.size());
     return ElementView(params_, this->element_id(id));

--- a/src/celeritas/neutron/executor/ChipsNeutronElasticExecutor.hh
+++ b/src/celeritas/neutron/executor/ChipsNeutronElasticExecutor.hh
@@ -35,29 +35,29 @@ struct ChipsNeutronElasticExecutor
 CELER_FUNCTION Interaction
 ChipsNeutronElasticExecutor::operator()(CoreTrackView const& track)
 {
-    auto particle = track.make_particle_view();
-    auto const& dir = track.make_geo_view().dir();
-    auto rng = track.make_rng_engine();
+    auto particle = track.particle();
+    auto const& dir = track.geometry().dir();
+    auto rng = track.rng();
 
     // Select a target element
-    auto material = track.make_material_view().make_material_view();
-    auto elcomp_id = track.make_physics_step_view().element();
+    auto material = track.material().material_record();
+    auto elcomp_id = track.physics_step().element();
     if (!elcomp_id)
     {
         // Sample an element (based on element cross sections on the fly)
         ElementSelector select_el(
             material,
             NeutronElasticMicroXsCalculator{params, particle.energy()},
-            track.make_material_view().element_scratch());
+            track.material().element_scratch());
         elcomp_id = select_el(rng);
         CELER_ASSERT(elcomp_id);
-        track.make_physics_step_view().element(elcomp_id);
+        track.physics_step().element(elcomp_id);
     }
-    ElementView element = material.make_element_view(elcomp_id);
+    ElementView element = material.element_record(elcomp_id);
 
     // Select a target nucleus
     IsotopeSelector iso_select(element);
-    IsotopeView target = element.make_isotope_view(iso_select(rng));
+    IsotopeView target = element.isotope_record(iso_select(rng));
 
     // Construct the interactor
     ChipsNeutronElasticInteractor interact(params, particle, dir, target);

--- a/src/celeritas/neutron/executor/NeutronInelasticExecutor.hh
+++ b/src/celeritas/neutron/executor/NeutronInelasticExecutor.hh
@@ -33,22 +33,22 @@ struct NeutronInelasticExecutor
 CELER_FUNCTION Interaction
 NeutronInelasticExecutor::operator()(CoreTrackView const& track)
 {
-    auto particle = track.make_particle_view();
-    auto rng = track.make_rng_engine();
+    auto particle = track.particle();
+    auto rng = track.rng();
 
     // Select a target element
-    auto material = track.make_material_view().make_material_view();
-    auto elcomp_id = track.make_physics_step_view().element();
+    auto material = track.material().material_record();
+    auto elcomp_id = track.physics_step().element();
     if (!elcomp_id)
     {
         // Sample an element (based on element cross sections on the fly)
         ElementSelector select_el(
             material,
             NeutronInelasticMicroXsCalculator{params, particle.energy()},
-            track.make_material_view().element_scratch());
+            track.material().element_scratch());
         elcomp_id = select_el(rng);
         CELER_ASSERT(elcomp_id);
-        track.make_physics_step_view().element(elcomp_id);
+        track.physics_step().element(elcomp_id);
     }
 
     // Construct the interactor

--- a/src/celeritas/optical/CoreTrackView.hh
+++ b/src/celeritas/optical/CoreTrackView.hh
@@ -49,10 +49,10 @@ class CoreTrackView
     inline CELER_FUNCTION GeoTrackView geometry() const;
 
     // Return a material view
-    inline CELER_FUNCTION MaterialView material() const;
+    inline CELER_FUNCTION MaterialView material_record() const;
 
     // Return a material view (using an existing geo view
-    inline CELER_FUNCTION MaterialView material(GeoTrackView const&) const;
+    inline CELER_FUNCTION MaterialView material_record(GeoTrackView const&) const;
 
     // Return a simulation management view
     inline CELER_FUNCTION SimTrackView sim() const;
@@ -145,9 +145,10 @@ CELER_FUNCTION auto CoreTrackView::geometry() const -> GeoTrackView
 /*!
  * Return a material view.
  */
-CELER_FORCEINLINE_FUNCTION auto CoreTrackView::material() const -> MaterialView
+CELER_FORCEINLINE_FUNCTION auto CoreTrackView::material_record() const
+    -> MaterialView
 {
-    return this->material(this->geometry());
+    return this->material_record(this->geometry());
 }
 
 //---------------------------------------------------------------------------//
@@ -155,7 +156,7 @@ CELER_FORCEINLINE_FUNCTION auto CoreTrackView::material() const -> MaterialView
  * Return a material view using an existing geo track view.
  */
 CELER_FUNCTION auto
-CoreTrackView::material(GeoTrackView const& geo) const -> MaterialView
+CoreTrackView::material_record(GeoTrackView const& geo) const -> MaterialView
 {
     CELER_EXPECT(!geo.is_outside());
     return MaterialView{params_.material, geo.volume_id()};

--- a/src/celeritas/optical/detail/CherenkovGeneratorExecutor.hh
+++ b/src/celeritas/optical/detail/CherenkovGeneratorExecutor.hh
@@ -76,7 +76,7 @@ CherenkovGeneratorExecutor::operator()(CoreTrackView const& track) const
     size_type local_work = LocalWorkCalculator<size_type>{
         total_work, state->size()}(track.thread_id().get());
 
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
 
     for (auto i : range(local_work))
     {

--- a/src/celeritas/optical/detail/CherenkovOffloadExecutor.hh
+++ b/src/celeritas/optical/detail/CherenkovOffloadExecutor.hh
@@ -55,7 +55,7 @@ CherenkovOffloadExecutor::operator()(CoreTrackView const& track)
     // Clear distribution data
     cherenkov_dist = {};
 
-    auto sim = track.make_sim_view();
+    auto sim = track.sim();
     auto const& step = state.step[tsid];
 
     if (!step || sim.status() == TrackStatus::inactive)
@@ -65,14 +65,14 @@ CherenkovOffloadExecutor::operator()(CoreTrackView const& track)
         return;
     }
 
-    auto particle = track.make_particle_view();
+    auto particle = track.particle();
 
     // Get the distribution data used to generate Cherenkov optical photons
     if (particle.charge() != zero_quantity())
     {
-        Real3 const& pos = track.make_geo_view().pos();
+        Real3 const& pos = track.geometry().pos();
         optical::MaterialView opt_mat{material, step.material};
-        auto rng = track.make_rng_engine();
+        auto rng = track.rng();
 
         CherenkovOffload generate(particle, sim, opt_mat, pos, cherenkov, step);
         cherenkov_dist = generate(rng);

--- a/src/celeritas/optical/detail/OffloadGatherExecutor.hh
+++ b/src/celeritas/optical/detail/OffloadGatherExecutor.hh
@@ -44,11 +44,10 @@ OffloadGatherExecutor::operator()(CoreTrackView const& track)
     CELER_EXPECT(track.track_slot_id() < state.step.size());
 
     OffloadPreStepData& step = state.step[track.track_slot_id()];
-    step.speed = track.make_particle_view().speed();
-    step.pos = track.make_geo_view().pos();
-    step.time = track.make_sim_view().time();
-    step.material
-        = track.make_material_view().make_material_view().optical_material_id();
+    step.speed = track.particle().speed();
+    step.pos = track.geometry().pos();
+    step.time = track.sim().time();
+    step.material = track.material().material_record().optical_material_id();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/detail/ScintGeneratorExecutor.hh
+++ b/src/celeritas/optical/detail/ScintGeneratorExecutor.hh
@@ -74,7 +74,7 @@ ScintGeneratorExecutor::operator()(CoreTrackView const& track) const
     size_type local_work = LocalWorkCalculator<size_type>{
         total_work, state->size()}(track.thread_id().get());
 
-    auto rng = track.make_rng_engine();
+    auto rng = track.rng();
 
     for (auto i : range(local_work))
     {

--- a/src/celeritas/optical/detail/ScintOffloadExecutor.hh
+++ b/src/celeritas/optical/detail/ScintOffloadExecutor.hh
@@ -56,7 +56,7 @@ CELER_FUNCTION void ScintOffloadExecutor::operator()(CoreTrackView const& track)
     // Clear distribution data
     scintillation_dist = {};
 
-    auto sim = track.make_sim_view();
+    auto sim = track.sim();
     auto const& step = state.step[tsid];
 
     if (!step || sim.status() == TrackStatus::inactive)
@@ -66,10 +66,10 @@ CELER_FUNCTION void ScintOffloadExecutor::operator()(CoreTrackView const& track)
         return;
     }
 
-    Real3 const& pos = track.make_geo_view().pos();
-    auto edep = track.make_physics_step_view().energy_deposition();
-    auto particle = track.make_particle_view();
-    auto rng = track.make_rng_engine();
+    Real3 const& pos = track.geometry().pos();
+    auto edep = track.physics_step().energy_deposition();
+    auto particle = track.particle();
+    auto rng = track.rng();
 
     // Get the distribution data used to generate scintillation optical photons
     ScintillationOffload generate(

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -110,13 +110,13 @@ calc_physics_step_limit(MaterialTrackView const& material,
             // If the integral approach is used and this particle has an energy
             // loss process, estimate the maximum cross section over the step
             process_xs = physics.calc_max_xs(
-                process, ppid, material.make_material_view(), particle.energy());
+                process, ppid, material.material_record(), particle.energy());
         }
         else
         {
             // Calculate the macroscopic cross section for this process
             process_xs = physics.calc_xs(
-                ppid, material.make_material_view(), particle.energy());
+                ppid, material.material_record(), particle.energy());
         }
         // Accumulate process cross section into the total cross section and
         // save it for later

--- a/src/celeritas/phys/detail/DiscreteSelectExecutor.hh
+++ b/src/celeritas/phys/detail/DiscreteSelectExecutor.hh
@@ -36,25 +36,25 @@ struct DiscreteSelectExecutor
 CELER_FUNCTION void
 DiscreteSelectExecutor::operator()(celeritas::CoreTrackView const& track)
 {
-    CELER_EXPECT(track.make_sim_view().status() == TrackStatus::alive);
-    CELER_EXPECT(track.make_sim_view().post_step_action()
-                 == track.make_physics_view().scalars().discrete_action());
+    CELER_EXPECT(track.sim().status() == TrackStatus::alive);
+    CELER_EXPECT(track.sim().post_step_action()
+                 == track.physics().scalars().discrete_action());
     // Reset the MFP counter, to be resampled if the track survives the
     // interaction
-    auto phys = track.make_physics_view();
+    auto phys = track.physics();
     phys.reset_interaction_mfp();
 
-    auto particle = track.make_particle_view();
+    auto particle = track.particle();
     {
         // Select the action to take
-        auto mat = track.make_material_view().make_material_view();
-        auto rng = track.make_rng_engine();
-        auto step = track.make_physics_step_view();
+        auto mat = track.material().material_record();
+        auto rng = track.rng();
+        auto step = track.physics_step();
         auto action
             = select_discrete_interaction(mat, particle, phys, step, rng);
         CELER_ASSERT(action);
         // Save it as the next kernel
-        auto sim = track.make_sim_view();
+        auto sim = track.sim();
         sim.post_step_action(action);
     }
 

--- a/src/celeritas/phys/detail/TrackingCutExecutor.hh
+++ b/src/celeritas/phys/detail/TrackingCutExecutor.hh
@@ -49,8 +49,8 @@ TrackingCutExecutor::operator()(celeritas::CoreTrackView& track)
 {
     using Energy = ParticleTrackView::Energy;
 
-    auto particle = track.make_particle_view();
-    auto sim = track.make_sim_view();
+    auto particle = track.particle();
+    auto sim = track.sim();
 
     // Deposit the remaining energy locally
     auto deposited = particle.energy().value();
@@ -64,7 +64,7 @@ TrackingCutExecutor::operator()(celeritas::CoreTrackView& track)
     {
         // Print a debug message if track is just being cut; error message if
         // an error occurred
-        auto const geo = track.make_geo_view();
+        auto const geo = track.geometry();
         auto msg = self_logger()(CELER_CODE_PROVENANCE,
                                  sim.status() == TrackStatus::errored
                                      ? LogLevel::error
@@ -75,7 +75,7 @@ TrackingCutExecutor::operator()(celeritas::CoreTrackView& track)
     }
 #endif
 
-    track.make_physics_step_view().deposit_energy(Energy{deposited});
+    track.physics_step().deposit_energy(Energy{deposited});
     particle.subtract_energy(particle.energy());
 
     sim.status(TrackStatus::killed);

--- a/src/celeritas/track/detail/InitTracksExecutor.hh
+++ b/src/celeritas/track/detail/InitTracksExecutor.hh
@@ -107,12 +107,12 @@ CELER_FUNCTION void InitTracksExecutor::operator()(ThreadId tid) const
         }()};
 
     // Initialize the simulation state and particle attributes
-    vacancy.make_sim_view() = init.sim;
-    vacancy.make_particle_view() = init.particle;
+    vacancy.sim() = init.sim;
+    vacancy.particle() = init.particle;
 
     // Initialize the geometry
     {
-        auto geo = vacancy.make_geo_view();
+        auto geo = vacancy.geometry();
         auto parent_id = [&] {
             if (!(tid < counters.num_secondaries))
             {
@@ -156,8 +156,7 @@ CELER_FUNCTION void InitTracksExecutor::operator()(ThreadId tid) const
         }
 
         // Initialize the material
-        auto matid
-            = vacancy.make_geo_material_view().material_id(geo.volume_id());
+        auto matid = vacancy.geo_material().material_id(geo.volume_id());
         if (CELER_UNLIKELY(!matid))
         {
 #if !CELER_DEVICE_COMPILE
@@ -166,11 +165,11 @@ CELER_FUNCTION void InitTracksExecutor::operator()(ThreadId tid) const
             vacancy.apply_errored();
             return;
         }
-        vacancy.make_material_view() = {matid};
+        vacancy.material() = {matid};
     }
 
     // Initialize the physics state
-    vacancy.make_physics_view() = {};
+    vacancy.physics() = {};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/detail/StatusCheckExecutor.hh
+++ b/src/celeritas/track/detail/StatusCheckExecutor.hh
@@ -77,7 +77,7 @@ CELER_FUNCTION void StatusCheckExecutor::operator()(CoreTrackView const& track)
     CELER_EXPECT(state.action);
 
     auto tsid = track.track_slot_id();
-    auto sim = track.make_sim_view();
+    auto sim = track.sim();
 
     if (state.order > StepActionOrder::start
         && state.order < StepActionOrder::end)
@@ -126,7 +126,7 @@ CELER_FUNCTION void StatusCheckExecutor::operator()(CoreTrackView const& track)
         CELER_FAIL_IF(!sim.along_step_action(), "missing along-step action");
 
         // All 'alive' tracks should be inside the geometry
-        CELER_FAIL_IF(track.make_geo_view().is_outside(),
+        CELER_FAIL_IF(track.geometry().is_outside(),
                       "track is outside the geometry but still 'alive'");
     }
 

--- a/src/celeritas/user/detail/ActionDiagnosticExecutor.hh
+++ b/src/celeritas/user/detail/ActionDiagnosticExecutor.hh
@@ -51,9 +51,9 @@ ActionDiagnosticExecutor::operator()(CoreTrackView const& track)
 
     using BinId = ItemId<size_type>;
 
-    auto action = track.make_sim_view().post_step_action();
+    auto action = track.sim().post_step_action();
     CELER_ASSERT(action);
-    auto particle = track.make_particle_view().particle_id();
+    auto particle = track.particle().particle_id();
     CELER_ASSERT(particle);
 
     BinId bin{particle.unchecked_get() * params.num_bins

--- a/src/celeritas/user/detail/SlotDiagnosticExecutor.hh
+++ b/src/celeritas/user/detail/SlotDiagnosticExecutor.hh
@@ -41,7 +41,7 @@ CELER_FUNCTION void
 SlotDiagnosticExecutor::operator()(CoreTrackView const& track)
 {
     int result = [&track] {
-        auto sim = track.make_sim_view();
+        auto sim = track.sim();
         if (sim.status() == TrackStatus::inactive)
         {
             return -1;
@@ -51,7 +51,7 @@ SlotDiagnosticExecutor::operator()(CoreTrackView const& track)
             return -2;
         }
         // Save particle ID
-        return static_cast<int>(track.make_particle_view().particle_id().get());
+        return static_cast<int>(track.particle().particle_id().get());
     }();
 
     size_type const index = track.track_slot_id().get();

--- a/src/celeritas/user/detail/StepDiagnosticExecutor.hh
+++ b/src/celeritas/user/detail/StepDiagnosticExecutor.hh
@@ -41,7 +41,7 @@ StepDiagnosticExecutor::operator()(CoreTrackView const& track)
     using BinId = ItemId<size_type>;
 
     // Tally the number of steps if the track was killed
-    auto sim = track.make_sim_view();
+    auto sim = track.sim();
     if (sim.status() == TrackStatus::killed)
     {
         // TODO: Add an ndarray-type class?
@@ -53,7 +53,7 @@ StepDiagnosticExecutor::operator()(CoreTrackView const& track)
 
         size_type num_steps
             = celeritas::min(sim.num_steps(), params.num_bins - 1);
-        auto particle = track.make_particle_view().particle_id();
+        auto particle = track.particle().particle_id();
 
         // Increment the bin corresponding to the given particle and step count
         auto& bin = get(particle.get(), num_steps);

--- a/src/celeritas/user/detail/StepGatherExecutor.hh
+++ b/src/celeritas/user/detail/StepGatherExecutor.hh
@@ -45,7 +45,7 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
     CELER_EXPECT(params && state);
 
     {
-        auto const sim = track.make_sim_view();
+        auto const sim = track.sim();
         bool inactive = (sim.status() == TrackStatus::inactive
                          || sim.status() == TrackStatus::errored);
 
@@ -75,7 +75,7 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
         // stepping)
         if (P == StepPoint::pre)
         {
-            auto const geo = track.make_geo_view();
+            auto const geo = track.geometry();
             CELER_ASSERT(!geo.is_outside());
             VolumeId vol = geo.volume_id();
             CELER_ASSERT(vol);
@@ -94,7 +94,7 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
         if (P == StepPoint::post && this->params.nonzero_energy_deposition)
         {
             // Filter out tracks that didn't deposit energy over the step
-            auto const pstep = track.make_physics_step_view();
+            auto const pstep = track.physics_step();
             if (pstep.energy_deposition() == zero_quantity())
             {
                 // Clear detector ID and stop recording
@@ -125,7 +125,7 @@ StepGatherExecutor<P>::fill(celeritas::CoreTrackView const& track)
     } while (0)
 
     {
-        auto const sim = track.make_sim_view();
+        auto const sim = track.sim();
 
         SGL_SET_IF_SELECTED(points[P].time, sim.time());
         if constexpr (P == StepPoint::post)
@@ -140,7 +140,7 @@ StepGatherExecutor<P>::fill(celeritas::CoreTrackView const& track)
     }
 
     {
-        auto const geo = track.make_geo_view();
+        auto const geo = track.geometry();
 
         SGL_SET_IF_SELECTED(points[P].pos, geo.pos());
         SGL_SET_IF_SELECTED(points[P].dir, geo.dir());
@@ -184,11 +184,11 @@ StepGatherExecutor<P>::fill(celeritas::CoreTrackView const& track)
     }
 
     {
-        auto const par = track.make_particle_view();
+        auto const par = track.particle();
 
         if constexpr (P == StepPoint::post)
         {
-            auto const pstep = track.make_physics_step_view();
+            auto const pstep = track.physics_step();
             SGL_SET_IF_SELECTED(energy_deposition, pstep.energy_deposition());
             SGL_SET_IF_SELECTED(particle, par.particle_id());
         }

--- a/test/celeritas/em/BetheHeitler.test.cc
+++ b/test/celeritas/em/BetheHeitler.test.cc
@@ -92,8 +92,8 @@ TEST_F(BetheHeitlerInteractorTest, basic)
     this->resize_secondaries(2 * num_samples);
 
     // Get views to the current material and element
-    auto const material = this->material_track().make_material_view();
-    auto const element = material.make_element_view(ElementComponentId{0});
+    auto const material = this->material_track().material_record();
+    auto const element = material.element_record(ElementComponentId{0});
 
     // Create the interactor
     BetheHeitlerInteractor interact(data_,
@@ -171,9 +171,8 @@ TEST_F(BetheHeitlerInteractorTest, stress_test)
             this->resize_secondaries(2 * num_samples);
 
             // Get views to the current material and element
-            auto const material = this->material_track().make_material_view();
-            auto const element
-                = material.make_element_view(ElementComponentId{0});
+            auto const material = this->material_track().material_record();
+            auto const element = material.element_record(ElementComponentId{0});
 
             // Create interactor
             BetheHeitlerInteractor interact(data_,
@@ -214,8 +213,8 @@ TEST_F(BetheHeitlerInteractorTest, distributions)
     this->set_inc_direction(inc_direction);
 
     // Get views to the current material and element
-    auto const material = this->material_track().make_material_view();
-    auto const element = material.make_element_view(ElementComponentId{0});
+    auto const material = this->material_track().material_record();
+    auto const element = material.element_record(ElementComponentId{0});
 
     auto bin_epsilon = [&](real_type inc_energy) -> std::vector<int> {
         this->set_inc_particle(pdg::gamma(), MevEnergy{inc_energy});

--- a/test/celeritas/em/CombinedBrem.test.cc
+++ b/test/celeritas/em/CombinedBrem.test.cc
@@ -128,7 +128,7 @@ TEST_F(CombinedBremTest, basic_seltzer_berger)
     this->resize_secondaries(num_samples);
 
     // Production cuts
-    auto material_view = this->material_track().make_material_view();
+    auto material_view = this->material_track().material_record();
     auto cutoffs = this->cutoff_params()->get(MaterialId{0});
 
     // Create the interactor
@@ -192,7 +192,7 @@ TEST_F(CombinedBremTest, basic_relativistic_brem)
     this->resize_secondaries(num_samples);
 
     // Production cuts
-    auto material_view = this->material_track().make_material_view();
+    auto material_view = this->material_track().material_record();
     auto cutoffs = this->cutoff_params()->get(MaterialId{0});
 
     // Set the incident particle energy
@@ -259,7 +259,7 @@ TEST_F(CombinedBremTest, stress_test_combined)
 
     // Views
     auto cutoffs = this->cutoff_params()->get(MaterialId{0});
-    auto material_view = this->material_track().make_material_view();
+    auto material_view = this->material_track().material_record();
 
     // Loop over a set of incident gamma energies
     real_type const test_energy[]

--- a/test/celeritas/em/CoulombScattering.test.cc
+++ b/test/celeritas/em/CoulombScattering.test.cc
@@ -176,7 +176,7 @@ TEST_F(CoulombScatteringTest, helper)
 
     auto wentzel = this->make_wentzel_params();
 
-    auto const material = this->material_track().make_material_view();
+    auto const material = this->material_track().material_record();
     AtomicNumber const target_z
         = this->material_params()->get(el_id_).atomic_number();
 
@@ -322,7 +322,7 @@ TEST_F(CoulombScatteringTest, wokvi_transport_xs)
 {
     auto wentzel = this->make_wentzel_params();
 
-    auto const material = this->material_track().make_material_view();
+    auto const material = this->material_track().material_record();
     AtomicNumber const z = this->material_params()->get(el_id_).atomic_number();
 
     // Incident particle energy cutoff
@@ -393,9 +393,9 @@ TEST_F(CoulombScatteringTest, simple_scattering)
 {
     int const num_samples = 1024;
 
-    auto const material = this->material_track().make_material_view();
+    auto const material = this->material_track().material_record();
     IsotopeView const isotope
-        = material.make_element_view(elcomp_id_).make_isotope_view(isocomp_id_);
+        = material.element_record(elcomp_id_).isotope_record(isocomp_id_);
     auto cutoffs = this->cutoff_params()->get(mat_id_);
 
     auto& rng_engine = this->rng();
@@ -502,9 +502,9 @@ TEST_F(CoulombScatteringTest, distribution)
 {
     auto wentzel = this->make_wentzel_params();
 
-    auto const material = this->material_track().make_material_view();
+    auto const material = this->material_track().material_record();
     IsotopeView const isotope
-        = material.make_element_view(elcomp_id_).make_isotope_view(isocomp_id_);
+        = material.element_record(elcomp_id_).isotope_record(isocomp_id_);
 
     // TODO: Use proton ParticleId{2}
     MevEnergy const cutoff

--- a/test/celeritas/em/EPlusGG.test.cc
+++ b/test/celeritas/em/EPlusGG.test.cc
@@ -228,7 +228,7 @@ TEST_F(EPlusGGInteractorTest, macro_xs)
 {
     using units::MevEnergy;
 
-    auto material = this->material_track().make_material_view();
+    auto material = this->material_track().material_record();
     EPlusGGMacroXsCalculator calc_macro_xs(data_, material);
 
     int num_vals = 20;

--- a/test/celeritas/em/LivermorePE.test.cc
+++ b/test/celeritas/em/LivermorePE.test.cc
@@ -481,7 +481,7 @@ TEST_F(LivermorePETest, distributions_radiative)
 
 TEST_F(LivermorePETest, macro_xs)
 {
-    auto material = this->material_track().make_material_view();
+    auto material = this->material_track().material_record();
     auto calc_macro_xs = MacroXsCalculator<LivermorePEMicroXsCalculator>(
         model_->host_ref(), material);
 

--- a/test/celeritas/em/MuBremsstrahlung.test.cc
+++ b/test/celeritas/em/MuBremsstrahlung.test.cc
@@ -101,9 +101,8 @@ class MuBremsstrahlungTest : public InteractorHostTestBase
 TEST_F(MuBremsstrahlungTest, dcs)
 {
     auto particle = this->particle_track();
-    auto element
-        = this->material_track().make_material_view().make_element_view(
-            ElementComponentId{0});
+    auto element = this->material_track().material_record().element_record(
+        ElementComponentId{0});
 
     MuBremsDiffXsCalculator calc_dcs(
         element, particle.energy(), particle.mass(), data_.electron_mass);
@@ -138,7 +137,7 @@ TEST_F(MuBremsstrahlungTest, basic)
     int num_samples = 4;
     this->resize_secondaries(num_samples);
 
-    auto material = this->material_track().make_material_view();
+    auto material = this->material_track().material_record();
 
     // Create the interactor
     MuBremsstrahlungInteractor interact(
@@ -225,7 +224,7 @@ TEST_F(MuBremsstrahlungTest, stress_test)
                 this->set_inc_direction(inc_dir);
                 this->resize_secondaries(num_samples);
 
-                auto material = this->material_track().make_material_view();
+                auto material = this->material_track().material_record();
 
                 // Create interactor
                 MuBremsstrahlungInteractor interact(

--- a/test/celeritas/em/MuPairProduction.test.cc
+++ b/test/celeritas/em/MuPairProduction.test.cc
@@ -124,9 +124,8 @@ TEST_F(MuPairProductionTest, distribution)
         = 2 * value_as<units::MevMass>(model_->host_ref().electron_mass);
 
     // Get view to the current element
-    auto element
-        = this->material_track().make_material_view().make_element_view(
-            ElementComponentId{0});
+    auto element = this->material_track().material_record().element_record(
+        ElementComponentId{0});
 
     // Get the production cuts
     auto cutoff = this->cutoff_params()->get(MaterialId{0});
@@ -219,9 +218,8 @@ TEST_F(MuPairProductionTest, basic)
     this->resize_secondaries(2 * num_samples);
 
     // Get view to the current element
-    auto element
-        = this->material_track().make_material_view().make_element_view(
-            ElementComponentId{0});
+    auto element = this->material_track().material_record().element_record(
+        ElementComponentId{0});
 
     // Get the production cuts
     auto cutoff = this->cutoff_params()->get(MaterialId{0});
@@ -290,9 +288,8 @@ TEST_F(MuPairProductionTest, stress_test)
     std::vector<double> avg_costheta;
 
     // Get view to the current element
-    auto element
-        = this->material_track().make_material_view().make_element_view(
-            ElementComponentId{0});
+    auto element = this->material_track().material_record().element_record(
+        ElementComponentId{0});
 
     // Get the production cuts
     auto cutoff = this->cutoff_params()->get(MaterialId{0});

--- a/test/celeritas/em/RelativisticBrem.test.cc
+++ b/test/celeritas/em/RelativisticBrem.test.cc
@@ -120,7 +120,7 @@ TEST_F(RelativisticBremTest, dxsec)
     real_type const all_energy[] = {1, 2, 5, 10, 20, 50, 100, 200, 500, 1000};
 
     // Production cuts
-    auto material_view = this->material_track().make_material_view();
+    auto material_view = this->material_track().material_record();
 
     // Create the differential cross section
     RBDiffXsCalculator dxsec_lpm(model_lpm_->host_ref(),
@@ -182,7 +182,7 @@ TEST_F(RelativisticBremTest, basic_without_lpm)
     this->resize_secondaries(num_samples);
 
     // Production cuts
-    auto material_view = this->material_track().make_material_view();
+    auto material_view = this->material_track().material_record();
     auto cutoffs = this->cutoff_params()->get(MaterialId{0});
 
     // Create the interactor
@@ -247,7 +247,7 @@ TEST_F(RelativisticBremTest, basic_with_lpm)
     this->resize_secondaries(num_samples);
 
     // Production cuts
-    auto material_view = this->material_track().make_material_view();
+    auto material_view = this->material_track().material_record();
     auto cutoffs = this->cutoff_params()->get(MaterialId{0});
 
     // Create the interactor
@@ -304,7 +304,7 @@ TEST_F(RelativisticBremTest, stress_with_lpm)
     this->resize_secondaries(num_samples);
 
     // Production cuts
-    auto material_view = this->material_track().make_material_view();
+    auto material_view = this->material_track().material_record();
     auto cutoffs = this->cutoff_params()->get(MaterialId{0});
 
     // Create the interactor

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -315,7 +315,7 @@ TEST_F(SeltzerBergerTest, basic)
     this->resize_secondaries(num_samples);
 
     // Production cuts
-    auto material_view = this->material_track().make_material_view();
+    auto material_view = this->material_track().material_record();
     auto cutoffs = this->cutoff_params()->get(MaterialId{0});
 
     // Create the interactor
@@ -378,7 +378,7 @@ TEST_F(SeltzerBergerTest, stress_test)
 
     // Views
     auto cutoffs = this->cutoff_params()->get(MaterialId{0});
-    auto material_view = this->material_track().make_material_view();
+    auto material_view = this->material_track().material_record();
 
     // Loop over a set of incident gamma energies
     for (auto particle : {pdg::electron(), pdg::positron()})

--- a/test/celeritas/global/AlongStepTestBase.cc
+++ b/test/celeritas/global/AlongStepTestBase.cc
@@ -70,7 +70,7 @@ auto AlongStepTestBase::run(Input const& inp, size_type num_tracks) -> RunResult
     for (auto tid : range(ThreadId{num_tracks}))
     {
         CoreTrackView track{core_params, core_states, tid};
-        auto phys = track.make_physics_view();
+        auto phys = track.physics();
         phys.interaction_mfp(inp.phys_mfp);
         if (inp.msc_range)
         {
@@ -92,10 +92,10 @@ auto AlongStepTestBase::run(Input const& inp, size_type num_tracks) -> RunResult
     for (auto tid : range(ThreadId{num_tracks}))
     {
         CoreTrackView track{core_params, core_states, tid};
-        auto sim = track.make_sim_view();
-        auto particle = track.make_particle_view();
-        auto geo = track.make_geo_view();
-        auto phys = track.make_physics_view();
+        auto sim = track.sim();
+        auto particle = track.particle();
+        auto geo = track.geometry();
+        auto phys = track.physics();
 
         result.eloss += value_as<MevEnergy>(inp.energy)
                         - value_as<MevEnergy>(particle.energy());

--- a/test/celeritas/mat/IsotopeSelector.test.cc
+++ b/test/celeritas/mat/IsotopeSelector.test.cc
@@ -53,7 +53,7 @@ class IsotopeSelectorTest : public MaterialTestBase, public Test
 TEST_F(IsotopeSelectorTest, single_isotope)
 {
     MaterialView material(host_mats, mats->find_material("NaI"));
-    auto const& element_na = material.make_element_view(ElementComponentId{0});
+    auto const& element_na = material.element_record(ElementComponentId{0});
     IsotopeSelector select_iso(element_na);
 
     // Must always return the same isotope
@@ -69,7 +69,7 @@ TEST_F(IsotopeSelectorTest, multiple_isotopes)
 
     // Diatomic hydrogen: two isotopes (fractions 0.9 and 0.1)
     MaterialView mat_h2(host_mats, MaterialId{2});
-    auto const& element_h = mat_h2.make_element_view(ElementComponentId{0});
+    auto const& element_h = mat_h2.element_record(ElementComponentId{0});
     IsotopeSelector select_iso_h(element_h);
 
     double sampled_frac_1h = 0;
@@ -94,7 +94,7 @@ TEST_F(IsotopeSelectorTest, multiple_isotopes)
 
     // Sodium iodide: Iodide has 3 isotopes (fractions 0.05, 0.15, and 0.8)
     MaterialView mat_nai(host_mats, mats->find_material("NaI"));
-    auto const& element_i = mat_nai.make_element_view(ElementComponentId{1});
+    auto const& element_i = mat_nai.element_record(ElementComponentId{1});
     IsotopeSelector select_iso_i(element_i);
 
     double sampled_frac_125i = 0;

--- a/test/celeritas/mat/Material.test.cc
+++ b/test/celeritas/mat/Material.test.cc
@@ -274,7 +274,7 @@ TEST_F(MaterialTest, element_view)
         std::vector<int> atomic_mass_numbers;
         for (auto id : range(el.num_isotopes()))
         {
-            auto iso_view = el.make_isotope_view(IsotopeComponentId{id});
+            auto iso_view = el.isotope_record(IsotopeComponentId{id});
             atomic_mass_numbers.push_back(iso_view.atomic_mass_number().get());
         }
         static int const expected_atomic_mass_numbers[] = {27, 28};

--- a/test/celeritas/mat/Material.test.cu
+++ b/test/celeritas/mat/Material.test.cu
@@ -49,7 +49,7 @@ __global__ void m_test_kernel(unsigned int const size,
     CELER_ASSERT(mat_track.material_id() == init[tid.get()].material_id);
 
     // Get material properties
-    auto const& mat = mat_track.make_material_view();
+    auto const& mat = mat_track.material_record();
     temperatures[tid.get()] = mat.temperature();
     rad_len[tid.get()]
         = native_value_to<units::CmLength>(mat.radiation_length()).value();
@@ -60,7 +60,7 @@ __global__ void m_test_kernel(unsigned int const size,
     for (auto ec : range(mat.num_elements()))
     {
         // Pretend to calculate cross section for the ec'th element
-        auto const& element = mat.make_element_view(ElementComponentId{ec});
+        auto const& element = mat.element_record(ElementComponentId{ec});
         scratch[ec]
             = static_cast<real_type>(element.atomic_number().unchecked_get());
     }

--- a/test/celeritas/neutron/NeutronElastic.test.cc
+++ b/test/celeritas/neutron/NeutronElastic.test.cc
@@ -101,7 +101,7 @@ TEST_F(NeutronElasticTest, macro_xs)
 {
     // Calculate the CHIPS elastic neutron-nucleus macroscopic cross section
     // (\f$ cm^{-1} \f$) in the valid range [1e-5:2000] (MeV)
-    auto material = this->material_track().make_material_view();
+    auto material = this->material_track().material_record();
     auto calc_xs = MacroXsCalculator<NeutronElasticMicroXsCalculator>(
         model_->host_ref(), material);
 
@@ -165,17 +165,17 @@ TEST_F(NeutronElasticTest, basic)
 
     // Sample neutron-He4 interactions
     IsotopeView isotope_he4 = this->material_track()
-                                  .make_material_view()
-                                  .make_element_view(ElementComponentId{0})
-                                  .make_isotope_view(IsotopeComponentId{1});
+                                  .material_record()
+                                  .element_record(ElementComponentId{0})
+                                  .isotope_record(IsotopeComponentId{1});
     ChipsNeutronElasticInteractor interact_light_target(
         shared, this->particle_track(), this->direction(), isotope_he4);
 
     // Sample neutron-Cu63 interactions
     IsotopeView isotope_cu63 = this->material_track()
-                                   .make_material_view()
-                                   .make_element_view(ElementComponentId{1})
-                                   .make_isotope_view(IsotopeComponentId{0});
+                                   .material_record()
+                                   .element_record(ElementComponentId{1})
+                                   .isotope_record(IsotopeComponentId{0});
     ChipsNeutronElasticInteractor interact_heavy_target(
         shared, this->particle_track(), this->direction(), isotope_cu63);
 
@@ -228,9 +228,9 @@ TEST_F(NeutronElasticTest, extended)
     ElementComponentId el_id{1};
     IsotopeComponentId iso_id{0};
     IsotopeView const isotope_he4 = this->material_track()
-                                        .make_material_view()
-                                        .make_element_view(el_id)
-                                        .make_isotope_view(iso_id);
+                                        .material_record()
+                                        .element_record(el_id)
+                                        .isotope_record(iso_id);
     // Sample interaction
     NeutronElasticRef shared = model_->host_ref();
     RandomEngine& rng_engine = this->rng();
@@ -287,9 +287,9 @@ TEST_F(NeutronElasticTest, stress_test)
     ElementComponentId el_id{1};
     IsotopeComponentId iso_id{1};
     IsotopeView const isotope = this->material_track()
-                                    .make_material_view()
-                                    .make_element_view(el_id)
-                                    .make_isotope_view(iso_id);
+                                    .material_record()
+                                    .element_record(el_id)
+                                    .isotope_record(iso_id);
 
     // Sample interaction
     NeutronElasticRef shared = model_->host_ref();

--- a/test/celeritas/neutron/NeutronInelastic.test.cc
+++ b/test/celeritas/neutron/NeutronInelastic.test.cc
@@ -109,7 +109,7 @@ TEST_F(NeutronInelasticTest, micro_xs)
 TEST_F(NeutronInelasticTest, macro_xs)
 {
     // Calculate the inelastic neutron-nucleus macroscopic cross section
-    auto material = this->material_track().make_material_view();
+    auto material = this->material_track().material_record();
     auto calc_xs = MacroXsCalculator<NeutronInelasticMicroXsCalculator>(
         model_->host_ref(), material);
 

--- a/test/celeritas/track/MockInteractExecutor.hh
+++ b/test/celeritas/track/MockInteractExecutor.hh
@@ -30,7 +30,7 @@ struct MockInteractExecutor
  */
 CELER_FUNCTION void MockInteractExecutor::operator()(CoreTrackView const& track)
 {
-    auto sim = track.make_sim_view();
+    auto sim = track.sim();
     CELER_ASSERT(sim.status() == TrackStatus::alive);
     if (!data.alive[track.track_slot_id()])
     {
@@ -39,7 +39,7 @@ CELER_FUNCTION void MockInteractExecutor::operator()(CoreTrackView const& track)
     }
 
     // Create secondaries
-    auto phys_step = track.make_physics_step_view();
+    auto phys_step = track.physics_step();
     size_type num_secondaries = data.num_secondaries[track.track_slot_id()];
     if (num_secondaries > 0)
     {


### PR DESCRIPTION
This renames `make_something_view()` -> `something()` to match the newer method names in the optical `CoreTrackView`.