### PR TITLE
Fix link errors with CUDA RDC and `--as-needed` flag

### DIFF
--- a/cmake/CudaRdcUtils.cmake
+++ b/cmake/CudaRdcUtils.cmake
@@ -925,9 +925,7 @@ function(cuda_rdc_target_link_libraries target)
         set_target_properties(${_target_final} PROPERTIES CUDA_RUNTIME_LIBRARY "Shared")
         set_target_properties(${_target_object} PROPERTIES CUDA_RUNTIME_LIBRARY "Shared")
       endif()
-      get_target_property(_link_libraries_final ${_target_final} INTERFACE_LINK_LIBRARIES)
-      list(APPEND _link_libraries_final ${CMAKE_DL_LIBS})
-      set_target_properties(${_target_final} PROPERTIES LINK_LIBRARIES "${_link_libraries_final}")
+      set_property(TARGET ${_target_final} APPEND PROPERTY LINK_LIBRARIES ${CMAKE_DL_LIBS})
     endif()
   else() # We could restrict to the case where the dependent is a static library ... maybe
     set_target_properties(${target} PROPERTIES

--- a/cmake/CudaRdcUtils.cmake
+++ b/cmake/CudaRdcUtils.cmake
@@ -925,6 +925,9 @@ function(cuda_rdc_target_link_libraries target)
         set_target_properties(${_target_final} PROPERTIES CUDA_RUNTIME_LIBRARY "Shared")
         set_target_properties(${_target_object} PROPERTIES CUDA_RUNTIME_LIBRARY "Shared")
       endif()
+      get_target_property(_link_libraries_final ${_target_final} INTERFACE_LINK_LIBRARIES)
+      list(APPEND _link_libraries_final ${CMAKE_DL_LIBS})
+      set_target_properties(${_target_final} PROPERTIES LINK_LIBRARIES "${_link_libraries_final}")
     endif()
   else() # We could restrict to the case where the dependent is a static library ... maybe
     set_target_properties(${target} PROPERTIES

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -213,6 +213,10 @@ if(CELERITAS_USE_CUDA)
     sys/ScopedLimitSaver.cuda.cc
     sys/ScopedProfiling.cuda.cc
   )
+  # NVTX requires `-ldl`
+  # This does not appears to be needed anymore with
+  # CMake 3.26.5 and CUDA sdk 12.6.
+  list(APPEND PRIVATE_DEPS ${CMAKE_DL_LIBS})
 endif()
 
 if(CELERITAS_USE_HIP)

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -213,8 +213,6 @@ if(CELERITAS_USE_CUDA)
     sys/ScopedLimitSaver.cuda.cc
     sys/ScopedProfiling.cuda.cc
   )
-  # NVTX requires `-ldl`
-  list(APPEND PRIVATE_DEPS ${CMAKE_DL_LIBS})
 endif()
 
 if(CELERITAS_USE_HIP)


### PR DESCRIPTION
`-ldl` is neeeded for any library/executable that included the result of nvlink.  Rather than relying on the user to add it, let's add it as part the RDC wrappers.

Note: Without this Celeritas failed to link many exectuable if the user had set LD_FLAGS to include `-Wl,--as-needed\' (some conda environemnt do that ... )

