### PR TITLE
Move offload template into a celeritas::example namespace

### DIFF
--- a/example/offload-template/main.cc
+++ b/example/offload-template/main.cc
@@ -5,6 +5,7 @@
 //! \file offload-template/main.cc
 //! \brief Minimal Geant4 application with Celeritas offloading
 //---------------------------------------------------------------------------//
+#include <iostream>
 #include <memory>
 #include <FTFP_BERT.hh>
 #include <G4RunManagerFactory.hh>
@@ -29,6 +30,8 @@ int main(int argc, char* argv[])
         std::cout << "Usage: " << argv[0] << std::endl;
         return EXIT_FAILURE;
     }
+
+    using namespace celeritas::example;
 
     std::unique_ptr<G4RunManager> run_manager;
     run_manager.reset(

--- a/example/offload-template/src/ActionInitialization.cc
+++ b/example/offload-template/src/ActionInitialization.cc
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file example/offload-template/src/ActionInitialization.cc
+//! \file offload-template/src/ActionInitialization.cc
 //---------------------------------------------------------------------------//
 #include "ActionInitialization.hh"
 
@@ -11,6 +11,10 @@
 #include "PrimaryGeneratorAction.hh"
 #include "RunAction.hh"
 
+namespace celeritas
+{
+namespace example
+{
 //---------------------------------------------------------------------------//
 /*!
  * Construct empty.
@@ -44,3 +48,6 @@ void ActionInitialization::Build() const
     this->SetUserAction(new RunAction());
     this->SetUserAction(new PrimaryGeneratorAction());
 }
+
+}  // namespace example
+}  // namespace celeritas

--- a/example/offload-template/src/ActionInitialization.cc
+++ b/example/offload-template/src/ActionInitialization.cc
@@ -29,7 +29,7 @@ ActionInitialization::ActionInitialization() : G4VUserActionInitialization() {}
 void ActionInitialization::BuildForMaster() const
 {
     // Set up Celeritas integration
-    celeritas::TrackingManagerIntegration::Instance().BuildForMaster();
+    TrackingManagerIntegration::Instance().BuildForMaster();
 
     // RunAction is responsible for initializing Celeritas
     this->SetUserAction(new RunAction());
@@ -42,7 +42,7 @@ void ActionInitialization::BuildForMaster() const
 void ActionInitialization::Build() const
 {
     // Set up Celeritas integration
-    celeritas::TrackingManagerIntegration::Instance().Build();
+    TrackingManagerIntegration::Instance().Build();
 
     // Initialize Geant4 user actions
     this->SetUserAction(new RunAction());

--- a/example/offload-template/src/ActionInitialization.cc
+++ b/example/offload-template/src/ActionInitialization.cc
@@ -29,7 +29,7 @@ ActionInitialization::ActionInitialization() : G4VUserActionInitialization() {}
 void ActionInitialization::BuildForMaster() const
 {
     // Set up Celeritas integration
-    TrackingManagerIntegration::Instance().BuildForMaster();
+    celeritas::TrackingManagerIntegration::Instance().BuildForMaster();
 
     // RunAction is responsible for initializing Celeritas
     this->SetUserAction(new RunAction());
@@ -42,7 +42,7 @@ void ActionInitialization::BuildForMaster() const
 void ActionInitialization::Build() const
 {
     // Set up Celeritas integration
-    TrackingManagerIntegration::Instance().Build();
+    celeritas::TrackingManagerIntegration::Instance().Build();
 
     // Initialize Geant4 user actions
     this->SetUserAction(new RunAction());

--- a/example/offload-template/src/ActionInitialization.hh
+++ b/example/offload-template/src/ActionInitialization.hh
@@ -2,12 +2,16 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file example/offload-template/src/ActionInitialization.hh
+//! \file offload-template/src/ActionInitialization.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include <G4VUserActionInitialization.hh>
 
+namespace celeritas
+{
+namespace example
+{
 //---------------------------------------------------------------------------//
 /*!
  * Initialize all user action classes, set up Celeritas offloading interface,
@@ -26,3 +30,5 @@ class ActionInitialization final : public G4VUserActionInitialization
     // Worker thread actions and Celeritas offload interface
     void Build() const final;
 };
+}  // namespace example
+}  // namespace celeritas

--- a/example/offload-template/src/DetectorConstruction.cc
+++ b/example/offload-template/src/DetectorConstruction.cc
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file example/offload-template/src/DetectorConstruction.cc
+//! \file offload-template/src/DetectorConstruction.cc
 //---------------------------------------------------------------------------//
 #include "DetectorConstruction.hh"
 
@@ -17,6 +17,10 @@
 
 #include "SensitiveDetector.hh"
 
+namespace celeritas
+{
+namespace example
+{
 //---------------------------------------------------------------------------//
 /*!
  * Construct empty.
@@ -57,3 +61,6 @@ void DetectorConstruction::ConstructSDandField()
     G4SDManager::GetSDMpointer()->AddNewDetector(world_sd);
     G4VUserDetectorConstruction::SetSensitiveDetector("world_lv", world_sd);
 }
+
+}  // namespace example
+}  // namespace celeritas

--- a/example/offload-template/src/DetectorConstruction.hh
+++ b/example/offload-template/src/DetectorConstruction.hh
@@ -2,12 +2,16 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file example/offload-template/src/DetectorConstruction.hh
+//! \file offload-template/src/DetectorConstruction.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include <G4VUserDetectorConstruction.hh>
 
+namespace celeritas
+{
+namespace example
+{
 //---------------------------------------------------------------------------//
 /*!
  * Construct detector geometry.
@@ -24,3 +28,6 @@ class DetectorConstruction final : public G4VUserDetectorConstruction
     // Sensitive detectors are the only Celeritas interface with Geant4
     void ConstructSDandField() final;
 };
+
+}  // namespace example
+}  // namespace celeritas

--- a/example/offload-template/src/MakeCelerOptions.cc
+++ b/example/offload-template/src/MakeCelerOptions.cc
@@ -9,6 +9,10 @@
 #include <accel/AlongStepFactory.hh>
 #include <accel/SetupOptions.hh>
 
+namespace celeritas
+{
+namespace example
+{
 //---------------------------------------------------------------------------//
 /*!
  * Build options to set up Celeritas.
@@ -30,3 +34,6 @@ celeritas::SetupOptions MakeCelerOptions()
 
     return opts;
 }
+
+}  // namespace example
+}  // namespace celeritas

--- a/example/offload-template/src/MakeCelerOptions.cc
+++ b/example/offload-template/src/MakeCelerOptions.cc
@@ -17,9 +17,9 @@ namespace example
 /*!
  * Build options to set up Celeritas.
  */
-SetupOptions MakeCelerOptions()
+celeritas::SetupOptions MakeCelerOptions()
 {
-    SetupOptions opts;
+    celeritas::SetupOptions opts;
 
     opts.max_num_tracks = 1024 * 16;
     opts.initializer_capacity = 1024 * 128 * 4;
@@ -27,7 +27,7 @@ SetupOptions MakeCelerOptions()
     opts.ignore_processes = {"CoulombScat"};
 
     // Set along-step factory with zero field
-    opts.make_along_step = UniformAlongStepFactory();
+    opts.make_along_step = celeritas::UniformAlongStepFactory();
 
     // Save diagnostic information
     opts.output_file = "celeritas-offload-diagnostic.json";

--- a/example/offload-template/src/MakeCelerOptions.cc
+++ b/example/offload-template/src/MakeCelerOptions.cc
@@ -17,9 +17,9 @@ namespace example
 /*!
  * Build options to set up Celeritas.
  */
-celeritas::SetupOptions MakeCelerOptions()
+SetupOptions MakeCelerOptions()
 {
-    celeritas::SetupOptions opts;
+    SetupOptions opts;
 
     opts.max_num_tracks = 1024 * 16;
     opts.initializer_capacity = 1024 * 128 * 4;
@@ -27,7 +27,7 @@ celeritas::SetupOptions MakeCelerOptions()
     opts.ignore_processes = {"CoulombScat"};
 
     // Set along-step factory with zero field
-    opts.make_along_step = celeritas::UniformAlongStepFactory();
+    opts.make_along_step = UniformAlongStepFactory();
 
     // Save diagnostic information
     opts.output_file = "celeritas-offload-diagnostic.json";

--- a/example/offload-template/src/MakeCelerOptions.hh
+++ b/example/offload-template/src/MakeCelerOptions.hh
@@ -8,5 +8,12 @@
 
 #include <accel/SetupOptions.hh>
 
+namespace celeritas
+{
+namespace example
+{
 // Build options to set up Celeritas
 celeritas::SetupOptions MakeCelerOptions();
+
+}  // namespace example
+}  // namespace celeritas

--- a/example/offload-template/src/MakeCelerOptions.hh
+++ b/example/offload-template/src/MakeCelerOptions.hh
@@ -13,7 +13,7 @@ namespace celeritas
 namespace example
 {
 // Build options to set up Celeritas
-SetupOptions MakeCelerOptions();
+celeritas::SetupOptions MakeCelerOptions();
 
 }  // namespace example
 }  // namespace celeritas

--- a/example/offload-template/src/MakeCelerOptions.hh
+++ b/example/offload-template/src/MakeCelerOptions.hh
@@ -13,7 +13,7 @@ namespace celeritas
 namespace example
 {
 // Build options to set up Celeritas
-celeritas::SetupOptions MakeCelerOptions();
+SetupOptions MakeCelerOptions();
 
 }  // namespace example
 }  // namespace celeritas

--- a/example/offload-template/src/PrimaryGeneratorAction.cc
+++ b/example/offload-template/src/PrimaryGeneratorAction.cc
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file example/offload-template/src/PrimaryGeneratorAction.cc
+//! \file offload-template/src/PrimaryGeneratorAction.cc
 //---------------------------------------------------------------------------//
 #include "PrimaryGeneratorAction.hh"
 
@@ -12,6 +12,10 @@
 
 #include "DetectorConstruction.hh"
 
+namespace celeritas
+{
+namespace example
+{
 //---------------------------------------------------------------------------//
 /*!
  * Construct empty.
@@ -35,3 +39,6 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
     particle_gun.SetParticleMomentumDirection(G4ThreeVector(1, 0, 0));  // +x
     particle_gun.GeneratePrimaryVertex(event);
 }
+
+}  // namespace example
+}  // namespace celeritas

--- a/example/offload-template/src/PrimaryGeneratorAction.hh
+++ b/example/offload-template/src/PrimaryGeneratorAction.hh
@@ -2,12 +2,16 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file example/offload-template/src/PrimaryGeneratorAction.hh
+//! \file offload-template/src/PrimaryGeneratorAction.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include <G4VUserPrimaryGeneratorAction.hh>
 
+namespace celeritas
+{
+namespace example
+{
 //---------------------------------------------------------------------------//
 /*!
  * Generate primaries.
@@ -21,3 +25,6 @@ class PrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
     // Place primaries in the event simulation
     void GeneratePrimaries(G4Event* event) final;
 };
+
+}  // namespace example
+}  // namespace celeritas

--- a/example/offload-template/src/RunAction.cc
+++ b/example/offload-template/src/RunAction.cc
@@ -2,12 +2,16 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file example/offload-template/src/RunAction.cc
+//! \file offload-template/src/RunAction.cc
 //---------------------------------------------------------------------------//
 #include "RunAction.hh"
 
 #include <accel/TrackingManagerIntegration.hh>
 
+namespace celeritas
+{
+namespace example
+{
 //---------------------------------------------------------------------------//
 /*!
  * Construct empty.
@@ -31,3 +35,6 @@ void RunAction::EndOfRunAction(G4Run const* run)
 {
     celeritas::TrackingManagerIntegration::Instance().EndOfRunAction(run);
 }
+
+}  // namespace example
+}  // namespace celeritas

--- a/example/offload-template/src/RunAction.cc
+++ b/example/offload-template/src/RunAction.cc
@@ -24,7 +24,7 @@ RunAction::RunAction() : G4UserRunAction() {}
  */
 void RunAction::BeginOfRunAction(G4Run const* run)
 {
-    celeritas::TrackingManagerIntegration::Instance().BeginOfRunAction(run);
+    TrackingManagerIntegration::Instance().BeginOfRunAction(run);
 }
 
 //---------------------------------------------------------------------------//
@@ -33,7 +33,7 @@ void RunAction::BeginOfRunAction(G4Run const* run)
  */
 void RunAction::EndOfRunAction(G4Run const* run)
 {
-    celeritas::TrackingManagerIntegration::Instance().EndOfRunAction(run);
+    TrackingManagerIntegration::Instance().EndOfRunAction(run);
 }
 
 }  // namespace example

--- a/example/offload-template/src/RunAction.cc
+++ b/example/offload-template/src/RunAction.cc
@@ -24,7 +24,7 @@ RunAction::RunAction() : G4UserRunAction() {}
  */
 void RunAction::BeginOfRunAction(G4Run const* run)
 {
-    TrackingManagerIntegration::Instance().BeginOfRunAction(run);
+    celeritas::TrackingManagerIntegration::Instance().BeginOfRunAction(run);
 }
 
 //---------------------------------------------------------------------------//
@@ -33,7 +33,7 @@ void RunAction::BeginOfRunAction(G4Run const* run)
  */
 void RunAction::EndOfRunAction(G4Run const* run)
 {
-    TrackingManagerIntegration::Instance().EndOfRunAction(run);
+    celeritas::TrackingManagerIntegration::Instance().EndOfRunAction(run);
 }
 
 }  // namespace example

--- a/example/offload-template/src/RunAction.hh
+++ b/example/offload-template/src/RunAction.hh
@@ -2,12 +2,16 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file example/offload-template/src/RunAction.hh
+//! \file offload-template/src/RunAction.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include <G4UserRunAction.hh>
 
+namespace celeritas
+{
+namespace example
+{
 //---------------------------------------------------------------------------//
 /*!
  * Initialize Celeritas offloading interface.
@@ -24,3 +28,6 @@ class RunAction : public G4UserRunAction
     // Finalize Celeritas offloading interface
     void EndOfRunAction(G4Run const* run) final;
 };
+
+}  // namespace example
+}  // namespace celeritas

--- a/scripts/dev/celeritas-gen.py
+++ b/scripts/dev/celeritas-gen.py
@@ -502,10 +502,8 @@ def generate(repodir, filename, namespace):
 
     if namespace is None:
         namespace = 'celeritas'
-        if all_dirs[0] == 'app':
-            namespace += '::app'
-        elif all_dirs[0] == 'test':
-            namespace += '::test'
+        if all_dirs[0] in ('app', 'test', 'example'):
+            namespace += '::' + all_dirs[0]
         if all_dirs[-1] == 'detail':
             namespace += '::detail'
 
@@ -566,6 +564,15 @@ def generate(repodir, filename, namespace):
     return filename
 
 
+def get_main_repo():
+    try:
+        out = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'])
+    except subprocess.SubprocessError as e:
+        return ".."
+
+    return out.decode().strip()
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description=__doc__)
@@ -583,10 +590,7 @@ def main():
         default=None,
         help='C++ namespace to generate')
     args = parser.parse_args()
-    repodir = args.repodir or (
-        subprocess.check_output(['git', 'rev-parse', '--show-toplevel'])
-        .decode().strip()
-    )
+    repodir = args.repodir or get_main_repo()
     generated = []
     for fn in args.filename:
         fn = generate(repodir, fn, args.namespace)


### PR DESCRIPTION
In preparation for a new rather complicated class in the template, I'd like to move the example code into a sub-namespace to avoid potential conflicts and as a best practice.