### PR TITLE
Lazily fetch volumes for UniformAlongStepFactory 

### DIFF
--- a/src/accel/AlongStepFactory.cc
+++ b/src/accel/AlongStepFactory.cc
@@ -78,13 +78,18 @@ auto UniformAlongStepFactory::operator()(
             {
                 CELER_ASSERT(lv);
                 auto vol = find_volume(*lv);
-                CELER_VALIDATE(
+		CELER_VALIDATE(
                     vol,
                     << "failed to find volume corresponding to Geant4 volume "
                     << lv->GetName() << " while setting up uniform field");
-                field.volumes.push_back(vol);
+                CELER_LOG(debug)
+		    << "Found volume "
+		    << lv->GetName()
+		    << " that will be assigned a uniform field";
+		field.volumes.push_back(vol);
             }
         }
+
 
         // Create a uniform field
         CELER_LOG(info)

--- a/src/accel/AlongStepFactory.cc
+++ b/src/accel/AlongStepFactory.cc
@@ -43,11 +43,11 @@ UniformAlongStepFactory::UniformAlongStepFactory(FieldFunction f)
  * Construct with field strength and the volumes where field is present.
  */
 UniformAlongStepFactory::UniformAlongStepFactory(FieldFunction f,
-                                                 VecVolume volumes)
-    : get_field_(std::move(f)), volumes_(std::move(volumes))
+                                                 VecVolumeFunction volumes)
+    : get_field_(std::move(f)), get_volumes_(std::move(volumes))
 {
     CELER_EXPECT(get_field_);
-    CELER_EXPECT(!volumes_.empty());
+    CELER_EXPECT(get_volumes_);
 }
 
 //---------------------------------------------------------------------------//
@@ -64,14 +64,17 @@ auto UniformAlongStepFactory::operator()(
     auto field = this->get_field();
     auto magnitude = norm(field.strength);
 
+    // Get the volumes where field is present
+    auto volumes = this->get_volumes(); 
+
     if (magnitude > 0)
     {
         // Get the IDs of the volumes with field
-        if (!volumes_.empty())
+        if (!volumes.empty())
         {
-            field.volumes.reserve(volumes_.size());
+            field.volumes.reserve(volumes.size());
             GeantVolumeMapper find_volume(*input.geometry);
-            for (auto const* lv : volumes_)
+            for (auto const* lv : volumes)
             {
                 CELER_ASSERT(lv);
                 auto vol = find_volume(*lv);
@@ -87,7 +90,7 @@ auto UniformAlongStepFactory::operator()(
         CELER_LOG(info)
             << "Creating along-step action with field strength " << magnitude
             << " T in "
-            << (field.volumes.empty() ? "all" : std::to_string(volumes_.size()))
+            << (field.volumes.empty() ? "all" : std::to_string(volumes.size()))
             << " volumes";
 
         return celeritas::AlongStepUniformMscAction::from_params(
@@ -120,6 +123,15 @@ auto UniformAlongStepFactory::operator()(
 auto UniformAlongStepFactory::get_field() const -> FieldInput
 {
     return get_field_ ? get_field_() : FieldInput{};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the volumes where field is present
+ */
+auto UniformAlongStepFactory::get_volumes() const -> VecVolume
+{
+    return get_volumes_ ? get_volumes_() : VecVolume{};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/AlongStepFactory.cc
+++ b/src/accel/AlongStepFactory.cc
@@ -65,7 +65,7 @@ auto UniformAlongStepFactory::operator()(
     auto magnitude = norm(field.strength);
 
     // Get the volumes where field is present
-    auto volumes = this->get_volumes(); 
+    auto volumes = this->get_volumes();
 
     if (magnitude > 0)
     {
@@ -78,18 +78,15 @@ auto UniformAlongStepFactory::operator()(
             {
                 CELER_ASSERT(lv);
                 auto vol = find_volume(*lv);
-		CELER_VALIDATE(
+                CELER_VALIDATE(
                     vol,
                     << "failed to find volume corresponding to Geant4 volume "
                     << lv->GetName() << " while setting up uniform field");
-                CELER_LOG(debug)
-		    << "Found volume "
-		    << lv->GetName()
-		    << " that will be assigned a uniform field";
-		field.volumes.push_back(vol);
+                CELER_LOG(debug) << "Found volume " << lv->GetName()
+                                 << " that will be assigned a uniform field";
+                field.volumes.push_back(vol);
             }
         }
-
 
         // Create a uniform field
         CELER_LOG(info)

--- a/src/accel/AlongStepFactory.hh
+++ b/src/accel/AlongStepFactory.hh
@@ -113,6 +113,7 @@ class UniformAlongStepFactory final : public AlongStepFactoryInterface
     using FieldInput = inp::UniformField;
     using FieldFunction = std::function<FieldInput()>;
     using VecVolume = std::vector<G4LogicalVolume const*>;
+    using VecVolumeFunction = std::function<VecVolume()>;
     //!@}
 
   public:
@@ -123,7 +124,7 @@ class UniformAlongStepFactory final : public AlongStepFactoryInterface
     explicit UniformAlongStepFactory(FieldFunction f);
 
     // Construct with field strength and volumes where field is present
-    UniformAlongStepFactory(FieldFunction f, VecVolume volumes);
+    UniformAlongStepFactory(FieldFunction f, VecVolumeFunction volumes);
 
     // Emit an along-step action
     result_type operator()(argument_type input) const final;
@@ -131,9 +132,12 @@ class UniformAlongStepFactory final : public AlongStepFactoryInterface
     // Get the field params (used for converting to celeritas::inp)
     FieldInput get_field() const;
 
+    // Get the volumes where field is present
+    VecVolume get_volumes() const;
+
   private:
     FieldFunction get_field_;
-    VecVolume volumes_;
+    VecVolumeFunction get_volumes_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -117,10 +117,12 @@ void ProblemSetup::operator()(inp::Problem& p) const
         // Check if magnitude is zero
         auto field = u->get_field();
         auto field_val = norm(field.strength);
-        if (field_val > 0)
+	auto volumes = u->get_volumes();
+        if (field_val > 0 && !volumes.empty())
         {
             CELER_LOG(info) << "Using a uniform field: " << field_val << " [T]";
             p.field = std::move(field);
+	    p.volumes = std::move(volumes);
         }
         else
         {

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -119,7 +119,17 @@ void ProblemSetup::operator()(inp::Problem& p) const
         auto field_val = norm(field.strength);
         if (field_val > 0)
         {
-            CELER_LOG(info) << "Using a uniform field: " << field_val << " [T]";
+            auto msg = CELER_LOG(info);
+            msg << "Using a uniform field: " << field_val << " [T] in ";
+            if (field.volumes.empty())
+            {
+                msg << "all";
+            }
+            else
+            {
+                msg << field.volumes.size();
+            }
+            msg << " volumes";
             p.field = std::move(field);
         }
         else

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -117,12 +117,11 @@ void ProblemSetup::operator()(inp::Problem& p) const
         // Check if magnitude is zero
         auto field = u->get_field();
         auto field_val = norm(field.strength);
-	auto volumes = u->get_volumes();
-        if (field_val > 0 && !volumes.empty())
+        if (field_val > 0)
         {
             CELER_LOG(info) << "Using a uniform field: " << field_val << " [T]";
             p.field = std::move(field);
-	    p.volumes = std::move(volumes);
+	    p.volumes = u->get_volumes();
         }
         else
         {

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -121,7 +121,6 @@ void ProblemSetup::operator()(inp::Problem& p) const
         {
             CELER_LOG(info) << "Using a uniform field: " << field_val << " [T]";
             p.field = std::move(field);
-	    p.volumes = u->get_volumes();
         }
         else
         {

--- a/src/celeritas/inp/Problem.hh
+++ b/src/celeritas/inp/Problem.hh
@@ -52,8 +52,6 @@ struct Problem
     Physics physics;
     //! Set up the magnetic field
     Field field;
-    //! Set up the volumes where field will be present
-    std::vector<G4LogicalVolume const*> volumes;   
     //! Manage scoring of hits and other quantities
     Scoring scoring;
     //! Tuning options that affect the physics

--- a/src/celeritas/inp/Problem.hh
+++ b/src/celeritas/inp/Problem.hh
@@ -52,6 +52,8 @@ struct Problem
     Physics physics;
     //! Set up the magnetic field
     Field field;
+    //! Set up the volumes where field will be present
+    std::vector<G4LogicalVolume const*> volumes;   
     //! Manage scoring of hits and other quantities
     Scoring scoring;
     //! Tuning options that affect the physics


### PR DESCRIPTION

Enable UniformAlongStepFactory to take a function instead of a vector of volumes. This is because the required logical volumes are not initialized at the level where the factory is initialized. This builds on https://github.com/celeritas-project/celeritas/pull/1659.