### PR TITLE
Remove 'default_stream' option

### DIFF
--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -158,7 +158,6 @@ void GlobalSetup::ReadInput(std::string const& filename)
         options_->slot_diagnostic_prefix = input_.slot_diagnostic_prefix;
 
         options_->action_times = input_.action_times;
-        options_->default_stream = input_.default_stream;
         options_->track_order = input_.track_order;
     }
     else

--- a/app/celer-g4/RunInput.cc
+++ b/app/celer-g4/RunInput.cc
@@ -63,7 +63,6 @@ inp::Problem load_problem(RunInput const& ri)
     if (celeritas::Device::num_devices())
     {
         inp::DeviceDebug dd;
-        dd.default_stream = ri.default_stream;
         dd.sync_stream = ri.action_times;
         p.control.device_debug = std::move(dd);
     }

--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -86,7 +86,6 @@ struct RunInput
     size_type auto_flush{};  //!< Defaults to num_track_slots
 
     bool action_times{false};
-    bool default_stream{false};  //!< Launch all kernels on the default stream
 
     // Track reordering options
     TrackOrder track_order{Device::num_devices() ? TrackOrder::init_charge

--- a/app/celer-g4/RunInputIO.json.cc
+++ b/app/celer-g4/RunInputIO.json.cc
@@ -88,7 +88,10 @@ void from_json(nlohmann::json const& j, RunInput& v)
     RI_LOAD_OPTION(initializer_capacity);
     RI_LOAD_OPTION(secondary_stack_factor);
     RI_LOAD_OPTION(action_times);
-    RI_LOAD_OPTION(default_stream);
+    if (j.count("default_stream"))
+    {
+        CELER_LOG(warning) << "Ignoring removed option 'default_stream'";
+    }
     if (auto iter = j.find("auto_flush"); iter != j.end())
     {
         iter->get_to(v.auto_flush);
@@ -192,7 +195,6 @@ void to_json(nlohmann::json& j, RunInput const& v)
     RI_SAVE(initializer_capacity);
     RI_SAVE(secondary_stack_factor);
     RI_SAVE(action_times);
-    RI_SAVE(default_stream);
     RI_SAVE(auto_flush);
 
     RI_SAVE(track_order);

--- a/app/celer-sim/RunnerInput.cc
+++ b/app/celer-sim/RunnerInput.cc
@@ -177,7 +177,6 @@ inp::Problem load_problem(RunnerInput const& ri)
         {
             p.control.device_debug = [&ri] {
                 inp::DeviceDebug dd;
-                dd.default_stream = ri.default_stream;
                 dd.sync_stream = ri.action_times;
                 return dd;
             }();

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -94,7 +94,10 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_REQUIRED(use_device);
     LDIO_LOAD_OPTION(action_times);
     LDIO_LOAD_OPTION(merge_events);
-    LDIO_LOAD_OPTION(default_stream);
+    if (j.count("default_stream"))
+    {
+        CELER_LOG(warning) << "Ignoring removed option 'default_stream'";
+    }
     if (auto iter = j.find("warm_up"); iter != j.end())
     {
         iter->get_to(v.warm_up);
@@ -187,7 +190,6 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
     LDIO_SAVE(use_device);
     LDIO_SAVE(action_times);
     LDIO_SAVE(merge_events);
-    LDIO_SAVE(default_stream);
     LDIO_SAVE(warm_up);
 
     LDIO_SAVE_OPTION(field);

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -106,7 +106,7 @@ void run(std::shared_ptr<OutputRegistry>& output, std::string const& filename)
     output->insert(std::make_shared<OutputInterfaceAdapter<RunnerInput>>(
         OutputInterface::Category::input, "*", run_input));
 
-    // Allocate device streams, or use the default stream if there is only one.
+    // Allocate device streams
     size_type num_streams = run_stream.num_streams();
     if (run_input->use_device)
     {

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -108,7 +108,7 @@ void run(std::shared_ptr<OutputRegistry>& output, std::string const& filename)
 
     // Allocate device streams, or use the default stream if there is only one.
     size_type num_streams = run_stream.num_streams();
-    if (run_input->use_device && !run_input->default_stream && num_streams > 1)
+    if (run_input->use_device)
     {
         CELER_ASSERT(device());
         device().create_streams(num_streams);

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -102,7 +102,6 @@ void ProblemSetup::operator()(inp::Problem& p) const
     if (celeritas::Device::num_devices())
     {
         inp::DeviceDebug dd;
-        dd.default_stream = so.default_stream;
         dd.sync_stream = so.action_times;
 
         p.control.device_debug = std::move(dd);

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -216,7 +216,7 @@ struct SetupOptions
     size_type cuda_heap_size{};
     //! Sync the GPU at every kernel for timing
     bool action_times{false};
-    //! Launch all kernels on the default stream for debugging
+    //! Launch all kernels on the default stream for debugging (removed)
     bool default_stream{false};
     //!@}
 

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -216,7 +216,7 @@ struct SetupOptions
     size_type cuda_heap_size{};
     //! Sync the GPU at every kernel for timing
     bool action_times{false};
-    //! Launch all kernels on the default stream for debugging (removed)
+    //! Launch all kernels on the default stream for debugging (REMOVED)
     bool default_stream{false};
     //!@}
 

--- a/src/accel/SetupOptionsMessenger.cc
+++ b/src/accel/SetupOptionsMessenger.cc
@@ -220,7 +220,7 @@ SetupOptionsMessenger::SetupOptionsMessenger(SetupOptions* options)
                 "Add timers around every action (may reduce performance)");
         add_cmd(&options->default_stream,
                 "defaultStream",
-                "Launch all kernels on the default stream");
+                "Launch all kernels on the default stream (REMOVED)");
     }
 
     add_cmd(&options->slot_diagnostic_prefix,

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -665,11 +665,14 @@ void SharedParams::initialize_core(SetupOptions const& options)
     // Set state size
     params.tracks_per_stream = options.max_num_tracks;
 
-    // Allocate device streams, or use the default stream if there is only one.
-    if (celeritas::device() && !options.default_stream
-        && params.max_streams > 1)
+    // Allocate device streams
+    if (auto& d = celeritas::device())
     {
-        celeritas::device().create_streams(params.max_streams);
+        d.create_streams(params.max_streams);
+    }
+    if (options.default_stream)
+    {
+        CELER_LOG(warning) << "Ignoring removed option 'default_stream'";
     }
 
     // Construct along-step action

--- a/src/celeritas/inp/Control.hh
+++ b/src/celeritas/inp/Control.hh
@@ -102,8 +102,6 @@ struct OpticalStateCapacity : StateCapacity
  */
 struct DeviceDebug
 {
-    //! Launch all kernels on the default stream
-    bool default_stream{false};
     //! Synchronize the stream after every kernel launch
     std::optional<bool> sync_stream;
 };


### PR DESCRIPTION
In #777 the "default stream" was useful for performance comparisons of streaming. As part of a refactor to hide Thrust from the host compiler (necessary for new AMD builds, as @wdconinc discovered 😕 ) it will no longer be valid to ask for `StreamId{0}` if `create_streams` hasn't been called.