### PR TITLE
Update frontier toolchain for Feb 2025

### DIFF
--- a/scripts/env/frontier.sh
+++ b/scripts/env/frontier.sh
@@ -2,12 +2,12 @@
 
 fail_missing_var() {
   printf "\e[0;31m%s\e[0m\n" "Inconsistent environment: missing variable '$1'"
-  exit 1
+  return 1
 }
 
 fail_bad_path() {
   printf "\e[0;31m%s\e[0m\n" "Invalid path: '$1'"
-  exit 1
+  return 1
 }
 
 
@@ -15,8 +15,8 @@ PROJID=hep143
 _worldwork=${WORLDWORK}/${PROJID}
 _ccsproj=/ccs/proj/${PROJID}
 
-module load PrgEnv-amd/8.5.0 cpe/23.12 amd/5.7.1 rocm/5.7.1 craype-x86-trento \
-  libfabric/1.15.2.0 miniforge3/23.11.0
+module load PrgEnv-amd/8.5.0 cpe/24.11 amd/6.2.4 rocm/6.2.4 craype-x86-trento \
+  miniforge3/23.11.0
 # Disable warning "Using generic mem* routines instead of tuned routines"
 export RFE_811452_DISABLE=1
 
@@ -43,9 +43,9 @@ export CMAKE_PREFIX_PATH=${_worldwork}/opt-view:${CMAKE_PREFIX_PATH}
 export MODULEPATH=${_worldwork}/share/lmod/linux-sles15-x86_64/Core:${MODULEPATH}
 
 # Set up Geant4 data 
-module load geant4-data/11.0
-test -n "${G4ENSDFSTATEDATA}" || fail_missing_var G4ENSDFSTATEDATA
-test -e "${G4ENSDFSTATEDATA}" || fail_bad_path G4ENSDFSTATEDATA
+# module load geant4-data/11.3
+# test -n "${G4ENSDFSTATEDATA}" || fail_missing_var G4ENSDFSTATEDATA
+# test -e "${G4ENSDFSTATEDATA}" || fail_bad_path G4ENSDFSTATEDATA
 
 # Make llvm available
 test -n "${ROCM_PATH}" || fail_missing_var ROCM_PATH


### PR DESCRIPTION
Frontier was updated https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#id15 to use AMD 6.2.4.