### PR TITLE
Extend CudaRdc compatibility

### DIFF
--- a/cmake/external/CudaRdcUtils.cmake
+++ b/cmake/external/CudaRdcUtils.cmake
@@ -477,7 +477,10 @@ function(cuda_rdc_add_library target)
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
     EXPORT_PROPERTIES "CUDA_RDC_LIBRARY_TYPE;CUDA_RDC_FINAL_LIBRARY;CUDA_RDC_MIDDLE_LIBRARY;CUDA_RDC_STATIC_LIBRARY"
   )
-  target_link_libraries(${target}_final PUBLIC ${target} PRIVATE CUDA::toolkit)
+  target_link_libraries(${target}_final PUBLIC ${target})
+  if(TARGET CUDA::toolkit)
+    target_link_libraries(${target}_final PRIVATE CUDA::toolkit)
+  endif()
   target_link_options(${target}_final
     PRIVATE $<DEVICE_LINK:$<TARGET_FILE:${target}${_staticsuf}>>
   )

--- a/cmake/external/CudaRdcUtils.cmake
+++ b/cmake/external/CudaRdcUtils.cmake
@@ -910,7 +910,7 @@ function(cuda_rdc_target_link_libraries target)
            # In the past the linker considered symbols in dependencies of specified languages
            # to be available. But that changed in some later version and now the linker
            # enforces a more strict view of what is available.
-           target_link_libraries(${_target_final} ${_lib})
+           set_property(TARGET ${_target_final} APPEND PROPERTY LINK_LIBRARIES ${_lib})
         endif()
         if(TARGET ${_libstatic})
           target_link_options(${_target_final}


### PR DESCRIPTION
* Make CUDA::toolkit optional
* Allow (not fail) keyword in `cuda_rdc_target_add_libraries` applied to executable.