### PR TITLE
Add quantity support to FindInterp and template Turn

### DIFF
--- a/doc/implementation/units-constants.rst
+++ b/doc/implementation/units-constants.rst
@@ -61,8 +61,8 @@ An example quantity uses :math:`2\pi` as the unit type to allow integral values
 for turns. Using a Quantity also allows us to override the ``sincos`` function
 to use ``sincospi`` under the hood for improved precision.
 
-.. doxygentypedef:: celeritas::Turn
-.. doxygenfunction:: celeritas::sincos(Turn r, real_type* sinv, real_type* cosv)
+.. doxygentypedef:: celeritas::Turn_t
+.. doxygentypedef:: celeritas::RealTurn
 
 .. _api_units:
 

--- a/src/corecel/grid/FindInterp.hh
+++ b/src/corecel/grid/FindInterp.hh
@@ -51,10 +51,7 @@ find_interp(Grid const& grid, typename Grid::value_type value)
     CELER_ASSERT(result.index + 1 < grid.size());
     auto const lower_val = grid[result.index];
     auto const upper_val = grid[result.index + 1];
-    if (!CELER_UNLIKELY(lower_val == upper_val))
-    {
-        result.fraction = (value - lower_val) / (upper_val - lower_val);
-    }
+    result.fraction = (value - lower_val) / (upper_val - lower_val);
 
     return result;
 }

--- a/src/corecel/grid/FindInterp.hh
+++ b/src/corecel/grid/FindInterp.hh
@@ -37,7 +37,8 @@ struct FindInterp
  * result will always have an index such that its neighbor to the right is a
  * valid point on the grid, and the fraction between neghbors may be zero (in
  * the case where the value is exactly on a grid point) but is always less than
- * one.
+ * one. If the requested point is exactly on a coincident grid point, the lower
+ * point and a fraction of zero will result.
  */
 template<class Grid>
 inline CELER_FUNCTION FindInterp<typename Grid::value_type>
@@ -50,7 +51,10 @@ find_interp(Grid const& grid, typename Grid::value_type value)
     CELER_ASSERT(result.index + 1 < grid.size());
     auto const lower_val = grid[result.index];
     auto const upper_val = grid[result.index + 1];
-    result.fraction = (value - lower_val) / (upper_val - lower_val);
+    if (!CELER_UNLIKELY(lower_val == upper_val))
+    {
+        result.fraction = (value - lower_val) / (upper_val - lower_val);
+    }
 
     return result;
 }

--- a/src/corecel/grid/FindInterp.hh
+++ b/src/corecel/grid/FindInterp.hh
@@ -27,7 +27,7 @@ struct FindInterp
 };
 
 template<class T>
-FindInterp(size_type, T) -> FindInterp<T>;
+CELER_FUNCTION FindInterp(size_type, T) -> FindInterp<T>;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/corecel/grid/FindInterp.hh
+++ b/src/corecel/grid/FindInterp.hh
@@ -26,6 +26,9 @@ struct FindInterp
     T fraction{};  //!< Fraction of the value between its neighbors
 };
 
+template<class T>
+FindInterp(size_type, T) -> FindInterp<T>;
+
 //---------------------------------------------------------------------------//
 /*!
  * Find the index of the value and its fraction between neighboring points.
@@ -41,19 +44,16 @@ struct FindInterp
  * point and a fraction of zero will result.
  */
 template<class Grid>
-inline CELER_FUNCTION FindInterp<typename Grid::value_type>
+inline CELER_FUNCTION auto
 find_interp(Grid const& grid, typename Grid::value_type value)
 {
     CELER_EXPECT(value >= grid.front() && value < grid.back());
 
-    FindInterp<typename Grid::value_type> result;
-    result.index = grid.find(value);
-    CELER_ASSERT(result.index + 1 < grid.size());
-    auto const lower_val = grid[result.index];
-    auto const upper_val = grid[result.index + 1];
-    result.fraction = (value - lower_val) / (upper_val - lower_val);
-
-    return result;
+    auto index = grid.find(value);
+    CELER_ASSERT(index + 1 < grid.size());
+    auto const lower_val = grid[index];
+    auto const upper_val = grid[index + 1];
+    return FindInterp{index, (value - lower_val) / (upper_val - lower_val)};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -186,6 +186,13 @@ operator-(Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept
     return Quantity<U, std::common_type_t<T, T2>>{lhs.value() - rhs.value()};
 }
 
+template<class U, class T, class T2>
+CELER_CONSTEXPR_FUNCTION auto
+operator/(Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept
+{
+    return lhs.value() / rhs.value();
+}
+
 template<class U, class T>
 CELER_CONSTEXPR_FUNCTION auto operator-(Quantity<U, T> q) noexcept
 {

--- a/src/corecel/math/Turn.hh
+++ b/src/corecel/math/Turn.hh
@@ -112,5 +112,13 @@ CELER_CONSTEXPR_FUNCTION void sincos(IntQuarterTurn r, int* sinv, int* cosv)
 }
 //!@}
 
+//! Math functions that return turns from types
+template<class T>
+CELER_FORCEINLINE_FUNCTION Turn_t<T> atan2turn(T y, T x)
+{
+    // TODO: some OS/lib has this natively; use that instad
+    return native_value_to<Turn_t<T>>(std::atan2(y, x));
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/math/Turn.hh
+++ b/src/corecel/math/Turn.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cmath>
+#include <type_traits>
 
 #include "corecel/Constants.hh"
 #include "corecel/Types.hh"
@@ -47,46 +48,64 @@ struct HalfPi
  * Turns are a useful way of representing angles without the historical
  * arbitrariness of degrees or the roundoff errors of radians. See, for
  * example, https://www.computerenhance.com/p/turns-are-better-than-radians .
- *
- * \todo Template on real type and template the functions below.
  */
-using Turn = Quantity<TwoPi, real_type>;
+template<class T>
+using Turn_t = Quantity<TwoPi, T>;
+
+//! Turn with default precision (DEPRECATEDish)
+using Turn = Turn_t<real_type>;
+//! Turn with default precision
+using RealTurn = Turn_t<real_type>;
+
+//! Create a turn using template deduction
+template<class T>
+CELER_CONSTEXPR_FUNCTION Turn_t<T> make_turn(T value)
+{
+    static_assert(std::is_floating_point_v<T>,
+                  "turn type must be floating point");
+    return Turn_t<T>{value};
+}
 
 //---------------------------------------------------------------------------//
-//! Quantity for an integer number of turns for axis swapping
+//! Quantity for an integer number of turns for axis swapping (DEPRECATEDish)
 using QuarterTurn = Quantity<HalfPi, int>;
+//! Quantity for an integer number of turns for axis swapping
+using IntQuarterTurn = Quantity<HalfPi, int>;
 
 //---------------------------------------------------------------------------//
 //!@{
 //! Special overrides for math functions for more precise arithmetic
-CELER_FORCEINLINE_FUNCTION real_type sin(Turn r)
+template<class T>
+CELER_FORCEINLINE_FUNCTION T sin(Turn_t<T> r)
 {
     return sinpi(r.value() * 2);
 }
 
-CELER_FORCEINLINE_FUNCTION real_type cos(Turn r)
+template<class T>
+CELER_FORCEINLINE_FUNCTION T cos(Turn_t<T> r)
 {
     return cospi(r.value() * 2);
 }
 
-CELER_FORCEINLINE_FUNCTION void sincos(Turn r, real_type* sinv, real_type* cosv)
+template<class T>
+CELER_FORCEINLINE_FUNCTION void sincos(Turn_t<T> r, T* sinv, T* cosv)
 {
     return sincospi(r.value() * 2, sinv, cosv);
 }
 
-CELER_CONSTEXPR_FUNCTION int cos(QuarterTurn r)
+CELER_CONSTEXPR_FUNCTION int cos(IntQuarterTurn r)
 {
     constexpr int cosval[] = {1, 0, -1, 0};
     return cosval[(r.value() > 0 ? r.value() : -r.value()) % 4];
 }
 
-CELER_CONSTEXPR_FUNCTION int sin(QuarterTurn r)
+CELER_CONSTEXPR_FUNCTION int sin(IntQuarterTurn r)
 {
     // Define in terms of the symmetric "cos"
-    return cos(QuarterTurn{r.value() - 1});
+    return cos(IntQuarterTurn{r.value() - 1});
 }
 
-CELER_CONSTEXPR_FUNCTION void sincos(QuarterTurn r, int* sinv, int* cosv)
+CELER_CONSTEXPR_FUNCTION void sincos(IntQuarterTurn r, int* sinv, int* cosv)
 {
     *sinv = sin(r);
     *cosv = cos(r);

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -146,8 +146,8 @@ to_polar(G4ThreeVector const& axis) -> std::pair<Turn, Turn>
         is_soft_unit_vector(Array<double, 3>{axis.x(), axis.y(), axis.z()}));
 
     double const theta = std::acos(axis.z());
-    double const phi = std::atan2(axis.y(), axis.x());
-    return {native_value_to<Turn>(theta), native_value_to<Turn>(phi)};
+    return {native_value_to<Turn>(theta),
+            atan2turn<real_type>(axis.y(), axis.x())};
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/CMakeLists.txt
+++ b/test/corecel/CMakeLists.txt
@@ -48,6 +48,7 @@ celeritas_add_test(data/AuxInterface.test.cc
   SOURCES data/AuxMockParams.cc)
 
 # Grid
+celeritas_add_test(grid/FindInterp.test.cc)
 celeritas_add_test(grid/Interpolator.test.cc)
 celeritas_add_test(grid/NonuniformGrid.test.cc)
 celeritas_add_test(grid/SplineDerivCalculator.test.cc)

--- a/test/corecel/grid/FindInterp.test.cc
+++ b/test/corecel/grid/FindInterp.test.cc
@@ -1,0 +1,47 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/grid/FindInterp.test.cc
+//---------------------------------------------------------------------------//
+#include "corecel/grid/FindInterp.hh"
+
+#include "celeritas_test.hh"
+#include "corecel/grid/UniformGrid.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+TEST(FindInterpTest, uniform_real)
+{
+    auto data = UniformGridData::from_bounds(1.0, 5.0, 3);
+    UniformGrid const grid(data);
+
+    {
+        auto interp = find_interp(grid, 1.0);
+        EXPECT_EQ(0, interp.index);
+        EXPECT_SOFT_EQ(0.0, interp.fraction);
+    }
+    {
+        auto interp = find_interp(grid, 3.0);
+        EXPECT_EQ(1, interp.index);
+        EXPECT_SOFT_EQ(0.0, interp.fraction);
+    }
+    {
+        auto interp = find_interp(grid, 4.0);
+        EXPECT_EQ(1, interp.index);
+        EXPECT_SOFT_EQ(0.5, interp.fraction);
+    }
+#if CELERITAS_DEBUG
+    EXPECT_THROW(find_interp(grid, 0.999), DebugError);
+    EXPECT_THROW(find_interp(grid, 5.0), DebugError);
+    EXPECT_THROW(find_interp(grid, 5.001), DebugError);
+#endif
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/corecel/grid/FindInterp.test.cc
+++ b/test/corecel/grid/FindInterp.test.cc
@@ -10,6 +10,7 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/grid/NonuniformGrid.hh"
 #include "corecel/grid/UniformGrid.hh"
+#include "corecel/math/Turn.hh"
 
 #include "celeritas_test.hh"
 
@@ -110,6 +111,29 @@ TEST(FindInterpTest, nonuniform_int)
     EXPECT_THROW(find_interp(grid, -1), DebugError);
     EXPECT_THROW(find_interp(grid, 8), DebugError);
 #endif
+}
+
+TEST(FindInterpTest, Quantity)
+{
+    Collection<Turn, Ownership::value, MemSpace::host> data;
+    auto build = CollectionBuilder{&data};
+    auto const irange
+        = build.insert_back({Turn{0}, Turn{0.5}, Turn{0.75}, Turn{1}});
+    Collection<Turn, Ownership::const_reference, MemSpace::host> ref{data};
+    NonuniformGrid<Turn> grid(irange, ref);
+
+    {
+        auto interp = find_interp(grid, Turn{0});
+        EXPECT_EQ(0, interp.index);
+        EXPECT_EQ(0, interp.fraction);
+    }
+    {
+        auto interp = find_interp(grid, Turn{0.625});
+        EXPECT_EQ(1, interp.index);
+        EXPECT_TRUE((
+            std::is_same<decltype(interp.fraction), Turn::value_type>::value));
+        EXPECT_EQ(0.5, interp.fraction);
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/grid/FindInterp.test.cc
+++ b/test/corecel/grid/FindInterp.test.cc
@@ -40,11 +40,12 @@ TEST(FindInterpTest, uniform_real)
         EXPECT_EQ(1, interp.index);
         EXPECT_SOFT_EQ(0.5, interp.fraction);
     }
-#if CELERITAS_DEBUG
-    EXPECT_THROW(find_interp(grid, 0.999), DebugError);
-    EXPECT_THROW(find_interp(grid, 5.0), DebugError);
-    EXPECT_THROW(find_interp(grid, 5.001), DebugError);
-#endif
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(find_interp(grid, 0.999), DebugError);
+        EXPECT_THROW(find_interp(grid, 5.0), DebugError);
+        EXPECT_THROW(find_interp(grid, 5.001), DebugError);
+    }
 }
 
 // In this case, the fraction is always truncated by integer division to zero
@@ -73,10 +74,11 @@ TEST(FindInterpTest, nonuniform)
         EXPECT_EQ(3, interp.index);
         EXPECT_TRUE(std::isnan(interp.fraction)) << repr(interp.fraction);
     }
-#if CELERITAS_DEBUG
-    EXPECT_THROW(find_interp(grid, -3), DebugError);
-    EXPECT_THROW(find_interp(grid, 8), DebugError);
-#endif
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(find_interp(grid, -3), DebugError);
+        EXPECT_THROW(find_interp(grid, 8), DebugError);
+    }
 }
 
 // In this case, the fraction is always truncated by integer division to zero
@@ -107,10 +109,11 @@ TEST(FindInterpTest, nonuniform_int)
         EXPECT_EQ(2, interp.index);
         EXPECT_EQ(0, interp.fraction);
     }
-#if CELERITAS_DEBUG
-    EXPECT_THROW(find_interp(grid, -1), DebugError);
-    EXPECT_THROW(find_interp(grid, 8), DebugError);
-#endif
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(find_interp(grid, -1), DebugError);
+        EXPECT_THROW(find_interp(grid, 8), DebugError);
+    }
 }
 
 TEST(FindInterpTest, Quantity)

--- a/test/corecel/grid/FindInterp.test.cc
+++ b/test/corecel/grid/FindInterp.test.cc
@@ -70,7 +70,7 @@ TEST(FindInterpTest, nonuniform)
     {
         auto interp = find_interp(grid, 2.0);
         EXPECT_EQ(3, interp.index);
-        EXPECT_DOUBLE_EQ(0, interp.fraction);
+        EXPECT_TRUE(std::isnan(interp.fraction)) << repr(interp.fraction);
     }
 #if CELERITAS_DEBUG
     EXPECT_THROW(find_interp(grid, -3), DebugError);
@@ -99,7 +99,9 @@ TEST(FindInterpTest, nonuniform_int)
         EXPECT_EQ(1, interp.index);
         EXPECT_EQ(0, interp.fraction);
     }
+    if (false)
     {
+        // Disabled: results in UB due to integer division
         auto interp = find_interp(grid, 6);
         EXPECT_EQ(2, interp.index);
         EXPECT_EQ(0, interp.fraction);

--- a/test/corecel/grid/FindInterp.test.cc
+++ b/test/corecel/grid/FindInterp.test.cc
@@ -6,8 +6,12 @@
 //---------------------------------------------------------------------------//
 #include "corecel/grid/FindInterp.hh"
 
-#include "celeritas_test.hh"
+#include "corecel/data/Collection.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "corecel/grid/NonuniformGrid.hh"
 #include "corecel/grid/UniformGrid.hh"
+
+#include "celeritas_test.hh"
 
 namespace celeritas
 {
@@ -39,6 +43,70 @@ TEST(FindInterpTest, uniform_real)
     EXPECT_THROW(find_interp(grid, 0.999), DebugError);
     EXPECT_THROW(find_interp(grid, 5.0), DebugError);
     EXPECT_THROW(find_interp(grid, 5.001), DebugError);
+#endif
+}
+
+// In this case, the fraction is always truncated by integer division to zero
+// If we actually care about this in the future we can return a rational number
+// for the "value"
+TEST(FindInterpTest, nonuniform)
+{
+    Collection<double, Ownership::value, MemSpace::host> data;
+    auto build = CollectionBuilder{&data};
+    auto const irange = build.insert_back({-2.0, -1.5, 1.5, 2.0, 2.0, 8.0});
+    Collection<double, Ownership::const_reference, MemSpace::host> ref{data};
+    NonuniformGrid<double> grid(irange, ref);
+
+    {
+        auto interp = find_interp(grid, -2);
+        EXPECT_EQ(0, interp.index);
+        EXPECT_DOUBLE_EQ(0, interp.fraction);
+    }
+    {
+        auto interp = find_interp(grid, 0.0);
+        EXPECT_EQ(1, interp.index);
+        EXPECT_DOUBLE_EQ(.5, interp.fraction);
+    }
+    {
+        auto interp = find_interp(grid, 2.0);
+        EXPECT_EQ(3, interp.index);
+        EXPECT_DOUBLE_EQ(0, interp.fraction);
+    }
+#if CELERITAS_DEBUG
+    EXPECT_THROW(find_interp(grid, -3), DebugError);
+    EXPECT_THROW(find_interp(grid, 8), DebugError);
+#endif
+}
+
+// In this case, the fraction is always truncated by integer division to zero
+// If we actually care about this in the future we can return a rational number
+// for the "value"
+TEST(FindInterpTest, nonuniform_int)
+{
+    Collection<int, Ownership::value, MemSpace::host> data;
+    auto build = CollectionBuilder{&data};
+    auto const irange = build.insert_back({0, 2, 6, 6, 8});
+    Collection<int, Ownership::const_reference, MemSpace::host> ref{data};
+    NonuniformGrid<int> grid(irange, ref);
+
+    {
+        auto interp = find_interp(grid, 0);
+        EXPECT_EQ(0, interp.index);
+        EXPECT_EQ(0, interp.fraction);
+    }
+    {
+        auto interp = find_interp(grid, 4);
+        EXPECT_EQ(1, interp.index);
+        EXPECT_EQ(0, interp.fraction);
+    }
+    {
+        auto interp = find_interp(grid, 6);
+        EXPECT_EQ(2, interp.index);
+        EXPECT_EQ(0, interp.fraction);
+    }
+#if CELERITAS_DEBUG
+    EXPECT_THROW(find_interp(grid, -1), DebugError);
+    EXPECT_THROW(find_interp(grid, 8), DebugError);
 #endif
 }
 

--- a/test/corecel/grid/FindInterp.test.cc
+++ b/test/corecel/grid/FindInterp.test.cc
@@ -48,9 +48,6 @@ TEST(FindInterpTest, uniform_real)
     }
 }
 
-// In this case, the fraction is always truncated by integer division to zero
-// If we actually care about this in the future we can return a rational number
-// for the "value"
 TEST(FindInterpTest, nonuniform)
 {
     Collection<double, Ownership::value, MemSpace::host> data;

--- a/test/corecel/grid/TwodGridCalculator.test.cc
+++ b/test/corecel/grid/TwodGridCalculator.test.cc
@@ -16,42 +16,6 @@
 
 namespace celeritas
 {
-namespace detail
-{
-namespace test
-{
-//---------------------------------------------------------------------------//
-
-TEST(Detail, FindInterp)
-{
-    auto data = UniformGridData::from_bounds(1.0, 5.0, 3);
-    UniformGrid const grid(data);
-
-    {
-        auto interp = find_interp(grid, 1.0);
-        EXPECT_EQ(0, interp.index);
-        EXPECT_SOFT_EQ(0.0, interp.fraction);
-    }
-    {
-        auto interp = find_interp(grid, 3.0);
-        EXPECT_EQ(1, interp.index);
-        EXPECT_SOFT_EQ(0.0, interp.fraction);
-    }
-    {
-        auto interp = find_interp(grid, 4.0);
-        EXPECT_EQ(1, interp.index);
-        EXPECT_SOFT_EQ(0.5, interp.fraction);
-    }
-#if CELERITAS_DEBUG
-    EXPECT_THROW(find_interp(grid, 0.999), DebugError);
-    EXPECT_THROW(find_interp(grid, 5.0), DebugError);
-    EXPECT_THROW(find_interp(grid, 5.001), DebugError);
-#endif
-}  // namespace test
-//---------------------------------------------------------------------------//
-}  // namespace test
-}  // namespace detail
-
 namespace test
 {
 //---------------------------------------------------------------------------//

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -55,7 +55,7 @@ TEST(QuantityTest, usage)
 {
     // Since powers of 2 are exactly represented in IEEE arithimetic, we can
     // exactly operate on data (e.g. in this case where a user wants a radial
-    // mesh that spans half a turn, i.e. pi)
+    // mesh that spans half a Realturn, i.e. pi)
     Revolution user_input{0.5};
     double dtheta = user_input.value() / 8;
     EXPECT_EQ(1.0 / 16.0, dtheta);
@@ -259,25 +259,37 @@ TEST(QuantityTest, io)
 
 TEST(TurnTest, basic)
 {
-    EXPECT_STREQ("tr", Turn::unit_type::label());
-    EXPECT_SOFT_EQ(0.5, Turn{0.5}.value());
-    EXPECT_REAL_EQ(static_cast<real_type>(2 * pi), native_value_from(Turn{1}));
+    EXPECT_STREQ("tr", RealTurn::unit_type::label());
+    EXPECT_SOFT_EQ(0.5, RealTurn{0.5}.value());
+    EXPECT_REAL_EQ(static_cast<real_type>(2 * pi),
+                   native_value_from(RealTurn{1}));
 }
 
 TEST(TurnTest, math)
 {
-    EXPECT_EQ(real_type(1), sin(Turn{0.25}));
-    EXPECT_EQ(real_type(-1), cos(Turn{0.5}));
-    EXPECT_EQ(real_type(0), sin(Turn{0}));
+    EXPECT_EQ(double(1), sin(make_turn(0.25)));
+    EXPECT_EQ(double(-1), cos(make_turn(0.5)));
+    {
+        auto result = sin(make_turn(0.0));
+        EXPECT_TRUE((std::is_same_v<decltype(result), double>));
+        EXPECT_EQ(double(0), result);
+    }
+    {
+        auto turn = make_turn(2.0f);
+        EXPECT_TRUE((std::is_same_v<decltype(turn), Turn_t<float>>));
+        auto result = sin(turn);
+        EXPECT_TRUE((std::is_same_v<decltype(result), float>));
+        EXPECT_EQ(float(0), result);
+    }
 }
 
 TEST(QuarterTurnTest, basic)
 {
-    EXPECT_STREQ("qtr", QuarterTurn::unit_type::label());
-    EXPECT_EQ(-1, QuarterTurn{-1}.value());
-    EXPECT_EQ(1, QuarterTurn{1}.value());
+    EXPECT_STREQ("qtr", IntQuarterTurn::unit_type::label());
+    EXPECT_EQ(-1, IntQuarterTurn{-1}.value());
+    EXPECT_EQ(1, IntQuarterTurn{1}.value());
     EXPECT_DOUBLE_EQ(static_cast<double>(2 * pi),
-                     static_cast<double>(native_value_from(QuarterTurn{4})));
+                     static_cast<double>(native_value_from(IntQuarterTurn{4})));
 }
 
 TEST(QuarterTurnTest, sincos)
@@ -285,16 +297,16 @@ TEST(QuarterTurnTest, sincos)
     std::vector<int> result;
     for (auto i : range(-4, 5))
     {
-        result.push_back(sin(QuarterTurn{i}));
-        result.push_back(cos(QuarterTurn{i}));
+        result.push_back(sin(IntQuarterTurn{i}));
+        result.push_back(cos(IntQuarterTurn{i}));
     }
     // clang-format off
     static int const expected_result[]
-        = {  0,  1, // -1 turn
-             1,  0, // -3/4 turn
-             0, -1, // -1/2 turn
-            -1,  0, // -1/4 turn
-             0,  1, // 0 turn
+        = {  0,  1, // -1 Realturn
+             1,  0, // -3/4 Realturn
+             0, -1, // -1/2 Realturn
+            -1,  0, // -1/4 Realturn
+             0,  1, // 0 Realturn
              1,  0, // 1/4
              0, -1, // 1/2
             -1,  0, // 3/4

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -55,7 +55,7 @@ TEST(QuantityTest, usage)
 {
     // Since powers of 2 are exactly represented in IEEE arithimetic, we can
     // exactly operate on data (e.g. in this case where a user wants a radial
-    // mesh that spans half a Realturn, i.e. pi)
+    // mesh that spans half a turn, i.e. pi)
     Revolution user_input{0.5};
     double dtheta = user_input.value() / 8;
     EXPECT_EQ(1.0 / 16.0, dtheta);
@@ -315,11 +315,11 @@ TEST(QuarterTurnTest, sincos)
     }
     // clang-format off
     static int const expected_result[]
-        = {  0,  1, // -1 Realturn
-             1,  0, // -3/4 Realturn
-             0, -1, // -1/2 Realturn
-            -1,  0, // -1/4 Realturn
-             0,  1, // 0 Realturn
+        = {  0,  1, // -1 turn
+             1,  0, // -3/4 turn
+             0, -1, // -1/2 turn
+            -1,  0, // -1/4 turn
+             0,  1, // 0 turn
              1,  0, // 1/4
              0, -1, // 1/2
             -1,  0, // 3/4

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -185,6 +185,12 @@ TEST(QuantityTest, math)
         EXPECT_DOUBLE_EQ(3, divd.value());
     }
 
+    {
+        auto divd = RevDbl{12} / RevDbl{3};
+        EXPECT_TRUE((std::is_same<decltype(divd), double>::value));
+        EXPECT_DOUBLE_EQ(4, divd);
+    }
+
     // Test mixed integer/double
     {
         EXPECT_DOUBLE_EQ(static_cast<double>(4 * pi),

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -281,6 +281,19 @@ TEST(TurnTest, math)
         EXPECT_TRUE((std::is_same_v<decltype(result), float>));
         EXPECT_EQ(float(0), result);
     }
+    {
+        auto ta = atan2turn(0.0, 0.001);  // y, x
+        EXPECT_TRUE((std::is_same<decltype(ta), Turn_t<double>>::value));
+        EXPECT_DOUBLE_EQ(0.0, ta.value());
+        ta = atan2turn(1.0, 0.0);
+        EXPECT_DOUBLE_EQ(0.25, ta.value());
+        ta = atan2turn(0.0, -1.0);
+        EXPECT_DOUBLE_EQ(0.5, ta.value());
+        ta = atan2turn(-0.0, -1.0);
+        EXPECT_DOUBLE_EQ(-0.5, ta.value());
+        ta = atan2turn(-1.0, 0.0);
+        EXPECT_DOUBLE_EQ(-0.25, ta.value());
+    }
 }
 
 TEST(QuarterTurnTest, basic)


### PR DESCRIPTION
To support #1662 this adds support for Quantity division (unit / unit = unitless) . It also templates the `Turn` function so that we can use single-precision turns. A new function `acos2turn` returns `acos2` converted to Turn units. 