### PR TITLE
Fix static builds and CI reporting

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -63,19 +63,44 @@ jobs:
         with:
           fetch-depth: 383
           fetch-tags: true
+
+      ### CONFIGURE ###
+
       - name: Configure Celeritas
         run: |
           git config --global --add safe.directory ${PWD}
           ln -fs scripts/cmake-presets/ci-${{matrix.image}}.json CMakeUserPresets.json
           cmake --preset=${CMAKE_PRESET}
+
+      ### BUILD ###
+
       - name: Build Celeritas
         working-directory: build
         run: |
           ninja
+
+      ### TEST ###
+
       - name: Test Celeritas
         id: test
         run: |
           ctest --preset=base
+      - name: Upload test results
+        if: >-
+          ${{
+            always()
+            && (steps.test.outcome == 'success'
+                || steps.test.outcome == 'failure')
+          }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{matrix.image}}-${{env.CMAKE_PRESET}}
+          path: "test-output/**/*.xml"
+          if-no-files-found: error
+          retention-days: 1
+
+      ### INSTALL ###
+
       - name: Install Celeritas
         working-directory: build
         run: |
@@ -103,18 +128,5 @@ jobs:
               | awk '{print $3}'
           )
           ./scripts/ci/test-examples.sh
-      - name: Upload test results
-        if: >-
-          ${{
-            always()
-            && (steps.test.outcome == 'success'
-                || steps.test.outcome == 'failure')
-          }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results-${{matrix.image}}-${{env.CMAKE_PRESET}}
-          path: "test-output/**/*.xml"
-          if-no-files-found: error
-          retention-days: 1
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
-            ccache cmake ninja-build python3 \
+            ccache \
             nlohmann-json3-dev libgtest-dev libhepmc3-dev libpng-dev \
             ${{matrix.compiler}}-${{matrix.version}} \
             ${{matrix.compiler == 'gcc' && format('g++-{0}', matrix.version) || ''}}

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -91,12 +91,12 @@ jobs:
       - name: Run unit tests
         id: unittest
         run: |
-          ctest -LE app --preset=${CMAKE_PRESET}-unit
+          ctest --preset=${CMAKE_PRESET}-unit
       - name: Run app tests
         id: apptest
         if: ${{!cancelled() && steps.build.outcome == 'success'}}
         run: |
-          ctest -L app --preset=${CMAKE_PRESET}-app
+          ctest --preset=${CMAKE_PRESET}-app
       - name: Install
         working-directory: build
         run: |

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -51,6 +51,11 @@ jobs:
         || matrix.runner == 'noble-arm' && 'ubuntu-24.04-arm'
       }}
     steps:
+      - name: Check out Celeritas
+        uses: actions/checkout@v4
+
+      ### ENVIRONMENT ###
+
       - name: Install dependencies
         run: |
           sudo apt-get -q -y update
@@ -63,8 +68,20 @@ jobs:
           ld --version | head -1
           $CC --version | head -1
           $CXX --version | head -1
-      - name: Check out Celeritas
-        uses: actions/checkout@v4
+
+      ### CONFIGURE ###
+
+      - name: Configure Celeritas
+        run: |
+          ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
+          cmake --preset=${CMAKE_PRESET} \
+            ${{matrix.cxxstd && format('-DCMAKE_CXX_STANDARD={0} ', matrix.cxxstd) || ''}} \
+            -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
+              && format(';-pr.{0};', github.event.pull_request.number)
+              || format(';-{0};', github.ref_name)}}"
+
+      ### BUILD ###
+
       - name: Cache ccache
         uses: actions/cache@v4
         with:
@@ -75,19 +92,18 @@ jobs:
       - name: Zero ccache stats
         run: |
           ccache -z
-      - name: Configure Celeritas
-        run: |
-          ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
-          cmake --preset=${CMAKE_PRESET} \
-            ${{matrix.cxxstd && format('-DCMAKE_CXX_STANDARD={0} ', matrix.cxxstd) || ''}} \
-            -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
-              && format(';-pr.{0};', github.event.pull_request.number)
-              || format(';-{0};', github.ref_name)}}"
       - name: Build
         id: build
         working-directory: build
         run: |
           ninja
+      - name: Show ccache stats
+        if: ${{!cancelled()}}
+        run: |
+          ccache -s
+
+      ### TEST ###
+
       - name: Run unit tests
         id: unittest
         run: |
@@ -97,18 +113,6 @@ jobs:
         if: ${{!cancelled() && steps.build.outcome == 'success'}}
         run: |
           ctest --preset=${CMAKE_PRESET}-app
-      - name: Install
-        working-directory: build
-        run: |
-          ninja install
-      - name: Check installation
-        working-directory: install
-        run: |
-          ./bin/celer-sim --config
-      - name: Show ccache stats
-        if: ${{!cancelled()}}
-        run: |
-          ccache -s
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: >-
@@ -122,6 +126,18 @@ jobs:
           path: "test-output/**/*.xml"
           if-no-files-found: error
           retention-days: 1
+
+      ### INSTALL ###
+
+      - name: Install
+        working-directory: build
+        run: |
+          ninja install
+      - name: Check installation
+        working-directory: install
+        run: |
+          ./bin/celer-sim --config
+
   windows:
     defaults:
       run:
@@ -132,13 +148,26 @@ jobs:
       CMAKE_PRESET: fast
     runs-on: windows-latest
     steps:
+      - name: Check out Celeritas
+        uses: actions/checkout@v4
+
+      ### ENVIRONMENT ###
+
       - name: Install dependencies
         run: |
           choco install ninja ccache
-      - name: Check out Celeritas
-        uses: actions/checkout@v4
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
+      - name: Configure Celeritas
+        run: |
+          Copy-Item scripts/cmake-presets/ci-windows-github.json -Destination CMakeUserPresets.json
+          cmake --preset=$Env:CMAKE_PRESET `
+            -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
+              && format(';-pr.{0};', github.event.pull_request.number)
+              || format(';-{0};', github.ref_name)}}"
+
+      ### BUILD ###
+
       - name: Cache ccache
         uses: actions/cache@v4
         with:
@@ -149,17 +178,17 @@ jobs:
       - name: Zero ccache stats
         run: |
           ccache -z
-      - name: Configure Celeritas
-        run: |
-          Copy-Item scripts/cmake-presets/ci-windows-github.json -Destination CMakeUserPresets.json
-          cmake --preset=$Env:CMAKE_PRESET `
-            -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
-              && format(';-pr.{0};', github.event.pull_request.number)
-              || format(';-{0};', github.ref_name)}}"
       - name: Build
         id: build
         run: |
-          cmake --build --preset=$Env:CMAKE_PRESET 
+          cmake --build --preset=$Env:CMAKE_PRESET
+      - name: Show ccache stats
+        if: ${{!cancelled()}}
+        run: |
+          ccache -s
+
+      ### TEST ###
+
       - name: Run unit tests
         id: unittest
         continue-on-error: true
@@ -170,18 +199,6 @@ jobs:
         if: ${{!cancelled() && steps.build.outcome == 'success'}}
         run: |
           ctest --preset=$Env:CMAKE_PRESET-app
-      - name: Install
-        working-directory: build
-        run: |
-          cmake --install .
-      - name: Check installation
-        working-directory: install
-        run: |
-          ./bin/celer-sim --config
-      - name: Show ccache stats
-        if: ${{!cancelled()}}
-        run: |
-          ccache -s
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: >-
@@ -195,5 +212,16 @@ jobs:
           path: "test-output/**/*.xml"
           if-no-files-found: error
           retention-days: 1
+
+      ### INSTALL ###
+
+      - name: Install
+        working-directory: build
+        run: |
+          cmake --install .
+      - name: Check installation
+        working-directory: install
+        run: |
+          ./bin/celer-sim --config
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Configure Celeritas
         run: |
           ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
+          cmake --version
           cmake --preset=${CMAKE_PRESET} \
             ${{matrix.cxxstd && format('-DCMAKE_CXX_STANDARD={0} ', matrix.cxxstd) || ''}} \
             -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
@@ -181,6 +182,7 @@ jobs:
       - name: Build
         id: build
         run: |
+          cmake --version
           cmake --build --preset=$Env:CMAKE_PRESET
       - name: Show ccache stats
         if: ${{!cancelled()}}

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -85,7 +85,10 @@ jobs:
         with:
           fetch-depth: ${{format('{0}', matrix.special != 'clang-tidy' && 383 || 0)}}
           fetch-tags: true # to get version information
-      - name: Setup Spack
+
+      ### ENVIRONMENT ###
+      
+      - name: Check out Spack
         uses: spack/setup-spack@5792f7c7055c3707819380b5e3831d2be6e64b6c # 2024/12
         with:
           ref: ${{env.SPACK_REF}}
@@ -131,7 +134,7 @@ jobs:
       - name: Concretize
         run: |
           spack -e . -v concretize
-      - name: Install dependencies with Spack
+      - name: Install dependencies
         run: |
           spack -e . env depfile -o Makefile
           make -Orecurse -j $(($(nproc) + 1)) SPACK_INSTALL_FLAGS=--no-check-signature
@@ -150,17 +153,9 @@ jobs:
           echo "${SPACK_VIEW}/bin" >> $GITHUB_PATH
           echo "CMAKE_PREFIX_PATH=${SPACK_VIEW}:${CMAKE_PREFIX_PATH}" >> $GITHUB_ENV
           spack env activate . --sh > "${SPACK_VIEW}/rc"
-      - name: Restore ccache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{env.CCACHE_DIR}}
-          key: ccache-${{env.CMAKE_PRESET}}-${{matrix.geant}}-${{github.run_id}}
-          restore-keys: |
-            ccache-${{env.CMAKE_PRESET}}-${{matrix.geant}}
-            ccache-${{env.CMAKE_PRESET}}
-      - name: Zero ccache stats
-        run: |
-          ccache -z
+
+      ### CONFIGURE ###
+      
       - name: Configure Celeritas
         run: |
           # NOTE: tags have issues, see https://github.com/actions/checkout/issues/2041
@@ -172,7 +167,18 @@ jobs:
             test -n "${G4LEDATA}"
           fi
           cmake --preset=${CMAKE_PRESET} --log-level=VERBOSE
-      - name: Run incremental clang-tidy
+
+      ### BUILD ###
+      
+      - name: Restore ccache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{env.CCACHE_DIR}}
+          key: ccache-${{env.CMAKE_PRESET}}-${{matrix.geant}}-${{github.run_id}}
+          restore-keys: |
+            ccache-${{env.CMAKE_PRESET}}-${{matrix.geant}}
+            ccache-${{env.CMAKE_PRESET}}
+      - name: Build incremental clang-tidy
         id: clang-tidy
         if: ${{matrix.special == 'clang-tidy'}}
         env:
@@ -208,13 +214,21 @@ jobs:
         if: ${{matrix.special != 'clang-tidy'}}
         working-directory: build
         run: |
+          ccache -z
           ninja -v -k0
+      - name: Show ccache stats
+        if: ${{!cancelled()}}
+        run: |
+          ccache -s
       - name: Save ccache
         if: ${{always() && steps.build.outcome == 'success'}}
         uses: actions/cache/save@v4
         with:
           path: ${{env.CCACHE_DIR}}
           key: ccache-${{env.CMAKE_PRESET}}-${{matrix.geant}}-${{github.run_id}}
+
+      ### TEST ###
+      
       - name: Regenerate ROOT test data
         if: >-
           ${{
@@ -269,6 +283,9 @@ jobs:
           path: "test-output/**/*.xml"
           if-no-files-found: error
           retention-days: 1
+
+      ### INSTALL ###
+      
       - name: Check using build directory as install
         # TODO: ASAN requires flags downstream
         if: >-
@@ -302,15 +319,14 @@ jobs:
           done
           ./bin/celer-sim --config
       - name: Build examples
-        # TODO: ASAN requires flags downstream
         env:
           CELER_DISABLE_ACCEL_EXAMPLES: >-
             ${{
-              (   (matrix.special == 'minimal')
-               || (matrix.special == 'float')
+              (   (matrix.special == 'float')
                || !matrix.geant
               ) && '1' || ''
             }}
+        # TODO: ASAN requires flags downstream
         if: >-
           ${{
             (matrix.special != 'asanlite')
@@ -320,9 +336,5 @@ jobs:
           . ${SPACK_VIEW}/rc
           export G4VERSION_NUMBER=$(echo "${{matrix.geant}}" | awk '{printf "%.0f", $1 * 100}')
           ./scripts/ci/test-examples.sh
-      - name: Show ccache stats
-        if: ${{!cancelled()}}
-        run: |
-          ccache -s
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -257,7 +257,7 @@ jobs:
             # Note this is ignored for non-primary geometry implementations
             export CELER_TEST_STRICT=1
           fi
-          ctest -LE app --preset=spack-unit
+          ctest --preset=spack-unit
       - name: Run app tests
         id: apptest
         if: ${{!cancelled()
@@ -265,7 +265,7 @@ jobs:
             && steps.build.outcome == 'success'}}
         continue-on-error: ${{matrix.geant == '10.6'}} # TODO: rogue output from G4DeexPrecoParameters
         run: |
-          ctest -L app --preset=spack-app
+          ctest --preset=spack-app
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: >- # not skipped, new geant4, not experimental vecgeom

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -27,11 +27,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        build_type: ["reldeb"]
+        geometry: ["vecgeom"]
+        special: [null]
+        geant: ["10.5", "10.6", "10.7", "11.0", "11.1", "11.2", "11.3"]
         include:
+          - geometry: "orange"
+            special: "minimal"
+            geant: null
+          - geometry: "orange"
+            special: "float"
+            geant: "11.0"
           - geometry: "orange"
             special: "static"
             geant: "11.0"
             build_type: "ndebug"
+          - geometry: "orange"
+            special: "asanlite"
+            geant: null
+          - geometry: "vecgeom"
+            special: "clhep"
+            geant: "11.0"
+          - geometry: "vgsurf"
+            special: null
+            geant: "11.0"
+          - geometry: "vecgeom2"
+            special: null
+            geant: "11.0"
+          - geometry: "geant4"
+            special: null
+            geant: "11.0"
+          - geometry: "vecgeom"
+            special: "clang-tidy"
+            geant: "11.2"
     env:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
       CCACHE_MAXSIZE: "${{matrix.special == 'asanlite' && '400' || '200'}}Mi"

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -27,39 +27,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: ["reldeb"]
-        geometry: ["vecgeom"]
-        special: [null]
-        geant: ["10.5", "10.6", "10.7", "11.0", "11.1", "11.2", "11.3"]
         include:
-          - geometry: "orange"
-            special: "minimal"
-            geant: null
-          - geometry: "orange"
-            special: "float"
-            geant: "11.0"
           - geometry: "orange"
             special: "static"
             geant: "11.0"
             build_type: "ndebug"
-          - geometry: "orange"
-            special: "asanlite"
-            geant: null
-          - geometry: "vecgeom"
-            special: "clhep"
-            geant: "11.0"
-          - geometry: "vgsurf"
-            special: null
-            geant: "11.0"
-          - geometry: "vecgeom2"
-            special: null
-            geant: "11.0"
-          - geometry: "geant4"
-            special: null
-            geant: "11.0"
-          - geometry: "vecgeom"
-            special: "clang-tidy"
-            geant: "11.2"
     env:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
       CCACHE_MAXSIZE: "${{matrix.special == 'asanlite' && '400' || '200'}}Mi"

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -241,6 +241,7 @@ jobs:
           ${{
             matrix.geant == '11.0'
             && matrix.special != 'minimal'
+            && matrix.special != 'static'
           }}
         working-directory: build
         run: |
@@ -267,9 +268,12 @@ jobs:
           ctest --preset=spack-unit
       - name: Run app tests
         id: apptest
-        if: ${{!cancelled()
+        if: >-
+          ${{
+            !cancelled()
             && matrix.special != 'clang-tidy'
-            && steps.build.outcome == 'success'}}
+            && steps.build.outcome == 'success'
+          }}
         continue-on-error: ${{matrix.geant == '10.6'}} # TODO: rogue output from G4DeexPrecoParameters
         run: |
           ctest --preset=spack-app
@@ -297,8 +301,10 @@ jobs:
         # TODO: ASAN requires flags downstream
         if: >-
           ${{
-            (matrix.special != 'asanlite')
-            && (matrix.special != 'clang-tidy')
+            !cancelled()
+            && steps.build.outcome == 'success'
+            && matrix.special != 'asanlite'
+            && matrix.special != 'clang-tidy'
           }}
         env:
           CELER_DISABLE_ACCEL_EXAMPLES: 1 # Only run minimal example
@@ -317,7 +323,11 @@ jobs:
         run: |
           ninja install
       - name: Check installation
-        if: ${{steps.install.outcome == 'success'}}
+        if: >-
+          ${{
+            !cancelled()
+            && steps.install.outcome == 'success'
+          }}
         working-directory: install
         run: |
           for exe in orange-update celer-export-geant celer-dump-data \
@@ -328,16 +338,15 @@ jobs:
       - name: Build examples
         env:
           CELER_DISABLE_ACCEL_EXAMPLES: >-
-            ${{
-              (   (matrix.special == 'float')
-               || !matrix.geant
-              ) && '1' || ''
-            }}
+            ${{(
+              matrix.special == 'float'
+              || !matrix.geant
+            ) && '1' || ''}}
         # TODO: ASAN requires flags downstream
         if: >-
           ${{
-            (matrix.special != 'asanlite')
-            && (matrix.special != 'clang-tidy')
+            matrix.special != 'asanlite'
+            && matrix.special != 'clang-tidy'
           }}
         run: |
           . ${SPACK_VIEW}/rc

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -27,6 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        build_type: ["reldeb"]
         geometry: ["vecgeom"]
         special: [null]
         geant: ["10.5", "10.6", "10.7", "11.0", "11.1", "11.2", "11.3"]
@@ -37,6 +38,10 @@ jobs:
           - geometry: "orange"
             special: "float"
             geant: "11.0"
+          - geometry: "orange"
+            special: "static"
+            geant: "11.0"
+            build_type: "ndebug"
           - geometry: "orange"
             special: "asanlite"
             geant: null
@@ -59,7 +64,8 @@ jobs:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
       CCACHE_MAXSIZE: "${{matrix.special == 'asanlite' && '400' || '200'}}Mi"
       CMAKE_PRESET: >-
-        ${{format('reldeb-{0}{1}{2}',
+        ${{format('{0}-{1}{2}{3}',
+                  matrix.build_type,
                   matrix.geometry,
                   matrix.special && '-' || '',
                   matrix.special)}}
@@ -98,6 +104,7 @@ jobs:
           fi
           if ${{(matrix.special != 'minimal')
                 && (matrix.special != 'asanlite')
+                && (matrix.special != 'static')
                 && (env.CXXSTD == '20')}}; then
             spack -e . add root
           fi
@@ -218,7 +225,11 @@ jobs:
           ninja -v -k0 update-root-test-data
       - name: Run unit tests
         id: unittest
-        if: ${{matrix.special != 'clang-tidy'}}
+        if: >-
+          ${{
+            matrix.special != 'clang-tidy'
+            && matrix.special != 'static'
+          }}
         continue-on-error: >- # TODO: fix failing tests
           ${{
             fromJSON(matrix.geant || '0') < 11

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -32,33 +32,40 @@ jobs:
         special: [null]
         geant: ["10.5", "10.6", "10.7", "11.0", "11.1", "11.2", "11.3"]
         include:
-          - geometry: "orange"
+          - build_type: "reldeb"
+            geometry: "orange"
             special: "minimal"
             geant: null
-          - geometry: "orange"
+          - build_type: "reldeb"
+            geometry: "orange"
             special: "float"
             geant: "11.0"
-          - geometry: "orange"
+          - build_type: "ndebug"
+            geometry: "orange"
             special: "static"
             geant: "11.0"
-            build_type: "ndebug"
-          - geometry: "orange"
+          - build_type: "reldebinfo"
+            geometry: "orange"
             special: "asanlite"
             geant: null
-            build_type: "reldebinfo"
-          - geometry: "vecgeom"
+          - build_type: "reldeb"
+            geometry: "vecgeom"
             special: "clhep"
             geant: "11.0"
-          - geometry: "vgsurf"
+          - build_type: "reldeb"
+            geometry: "vgsurf"
             special: null
             geant: "11.0"
-          - geometry: "vecgeom2"
+          - build_type: "reldeb"
+            geometry: "vecgeom2"
             special: null
             geant: "11.0"
-          - geometry: "geant4"
+          - build_type: "reldeb"
+            geometry: "geant4"
             special: null
             geant: "11.0"
-          - geometry: "vecgeom"
+          - build_type: "reldeb"
+            geometry: "vecgeom"
             special: "clang-tidy"
             geant: "11.2"
     env:
@@ -87,7 +94,7 @@ jobs:
           fetch-tags: true # to get version information
 
       ### ENVIRONMENT ###
-      
+
       - name: Check out Spack
         uses: spack/setup-spack@5792f7c7055c3707819380b5e3831d2be6e64b6c # 2024/12
         with:
@@ -155,7 +162,7 @@ jobs:
           spack env activate . --sh > "${SPACK_VIEW}/rc"
 
       ### CONFIGURE ###
-      
+
       - name: Configure Celeritas
         run: |
           # NOTE: tags have issues, see https://github.com/actions/checkout/issues/2041
@@ -169,7 +176,7 @@ jobs:
           cmake --preset=${CMAKE_PRESET} --log-level=VERBOSE
 
       ### BUILD ###
-      
+
       - name: Restore ccache
         uses: actions/cache/restore@v4
         with:
@@ -228,7 +235,7 @@ jobs:
           key: ccache-${{env.CMAKE_PRESET}}-${{matrix.geant}}-${{github.run_id}}
 
       ### TEST ###
-      
+
       - name: Regenerate ROOT test data
         if: >-
           ${{
@@ -285,7 +292,7 @@ jobs:
           retention-days: 1
 
       ### INSTALL ###
-      
+
       - name: Check using build directory as install
         # TODO: ASAN requires flags downstream
         if: >-

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -45,6 +45,7 @@ jobs:
           - geometry: "orange"
             special: "asanlite"
             geant: null
+            build_type: "reldebinfo"
           - geometry: "vecgeom"
             special: "clhep"
             geant: "11.0"
@@ -62,7 +63,7 @@ jobs:
             geant: "11.2"
     env:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
-      CCACHE_MAXSIZE: "${{matrix.special == 'asanlite' && '400' || '200'}}Mi"
+      CCACHE_MAXSIZE: "${{matrix.build_type == 'reldebinfo' && '400' || '200'}}Mi"
       CMAKE_PRESET: >-
         ${{format('{0}-{1}{2}{3}',
                   matrix.build_type,

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
-            ccache cmake ninja-build nlohmann-json3-dev libpng-dev
+            ccache nlohmann-json3-dev libpng-dev
 
       ### CONFIGURE ###
 

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -17,13 +17,29 @@ jobs:
       CMAKE_PRESET: ultralite
     runs-on: ubuntu-24.04
     steps:
+      - name: Check out Celeritas
+        uses: actions/checkout@v4
+
+      ### ENVIRONMENT ###
+
       - name: Install dependencies
         run: |
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
             ccache cmake ninja-build nlohmann-json3-dev libpng-dev
-      - name: Check out Celeritas
-        uses: actions/checkout@v4
+
+      ### CONFIGURE ###
+
+      - name: Configure Celeritas
+        run: |
+          ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
+          cmake --preset=${CMAKE_PRESET} \
+            -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
+              && format(';-pr.{0};', github.event.pull_request.number)
+              || format(';-{0};', github.ref_name)}}"
+
+      ### BUILD ###
+
       - name: Cache ccache
         uses: actions/cache@v4
         with:
@@ -34,31 +50,11 @@ jobs:
       - name: Zero ccache stats
         run: |
           ccache -z
-      - name: Configure Celeritas
-        run: |
-          ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
-          cmake --preset=${CMAKE_PRESET} \
-            -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
-              && format(';-pr.{0};', github.event.pull_request.number)
-              || format(';-{0};', github.ref_name)}}"
       - name: Build
         id: build
         working-directory: build
         run: |
           ninja
-      - name: Run tests
-        id: test
-        run: |
-          ctest --preset=${CMAKE_PRESET} 
-      - name: Install
-        working-directory: build
-        run: |
-          ninja install
-      - name: Check installation
-        working-directory: install
-        run: |
-          ./bin/celer-sim --version
-          ./bin/celer-sim --config
       - name: Show ccache stats
         if: ${{!cancelled()}}
         run: |
@@ -71,19 +67,38 @@ jobs:
           name: ccache-debug-${{github.job}}
           overwrite: true
           retention-days: 7
+
+      ### TEST ###
+
+      - name: Run tests
+        id: test
+        run: |
+          ctest --preset=${CMAKE_PRESET}
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: >-
           ${{
             always()
-            && (steps.unittest.outcome == 'success'
-                || steps.unittest.outcome == 'failure')
+            && (steps.test.outcome == 'success'
+                || steps.test.outcome == 'failure')
           }}
         with:
           name: test-results-ultralite-ubuntu
           path: "test-output/**/*.xml"
           if-no-files-found: error
           retention-days: 1
+
+      ### INSTALL ###
+
+      - name: Install
+        working-directory: build
+        run: |
+          ninja install
+      - name: Check installation
+        working-directory: install
+        run: |
+          ./bin/celer-sim --version
+          ./bin/celer-sim --config
   windows:
     name: ultralite-windows
     env:
@@ -92,13 +107,30 @@ jobs:
       CMAKE_PRESET: ultralite
     runs-on: windows-latest
     steps:
+      - name: Check out Celeritas
+        uses: actions/checkout@v4
+
+      ### ENVIRONMENT ###
+
       - name: Install dependencies
         run: |
           choco install ninja ccache
-      - name: Check out Celeritas
-        uses: actions/checkout@v4
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
+
+      ### CONFIGURE ###
+
+      - name: Configure Celeritas
+        shell: pwsh
+        run: |
+          Copy-Item scripts/cmake-presets/ci-windows-github.json -Destination CMakeUserPresets.json
+          cmake --preset=$Env:CMAKE_PRESET `
+            -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
+              && format(';-pr.{0};', github.event.pull_request.number)
+              || format(';-{0};', github.ref_name)}}"
+
+      ### BUILD ###
+
       - name: Cache ccache
         uses: actions/cache@v4
         with:
@@ -109,21 +141,9 @@ jobs:
       - name: Zero ccache stats
         run: |
           ccache -z
-      - name: Configure Celeritas
-        shell: pwsh
-        run: |
-          Copy-Item scripts/cmake-presets/ci-windows-github.json -Destination CMakeUserPresets.json
-          cmake --preset=$Env:CMAKE_PRESET `
-            -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
-              && format(';-pr.{0};', github.event.pull_request.number)
-              || format(';-{0};', github.ref_name)}}"
       - name: Build all
         run: |
-          cmake --build --preset=$Env:CMAKE_PRESET 
-      - name: Test all
-        id: test
-        run: |
-          ctest --preset=$Env:CMAKE_PRESET
+          cmake --build --preset=$Env:CMAKE_PRESET
       - name: Show ccache stats
         if: ${{!cancelled()}}
         run: |
@@ -136,13 +156,20 @@ jobs:
           name: ccache-debug-${{github.job}}
           overwrite: true
           retention-days: 7
+
+      ### TEST ###
+
+      - name: Test all
+        id: test
+        run: |
+          ctest --preset=$Env:CMAKE_PRESET
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: >-
           ${{
             always()
-            && (steps.unittest.outcome == 'success'
-                || steps.unittest.outcome == 'failure')
+            && (steps.test.outcome == 'success'
+                || steps.test.outcome == 'failure')
           }}
         with:
           name: test-results-ultralite-windows

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Configure Celeritas
         run: |
           ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
+          cmake --version
           cmake --preset=${CMAKE_PRESET} \
             -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
               && format(';-pr.{0};', github.event.pull_request.number)
@@ -124,6 +125,7 @@ jobs:
         shell: pwsh
         run: |
           Copy-Item scripts/cmake-presets/ci-windows-github.json -Destination CMakeUserPresets.json
+          cmake --version
           cmake --preset=$Env:CMAKE_PRESET `
             -DCeleritas_GIT_DESCRIBE="${{github.event.pull_request
               && format(';-pr.{0};', github.event.pull_request.number)

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -35,3 +35,5 @@ jobs:
                 })
               }
             }
+
+# vim: set nowrap tw=100:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -73,7 +73,7 @@ jobs:
                 cmake graphviz ninja-build doxygen nlohmann-json3-dev
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10' 
+          python-version: '3.10'
       - name: Check out Celeritas
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,38 +32,7 @@ jobs:
       with:
         name: event-file
         path: ${{github.event_path}}
-  build-fast:
-    uses: ./.github/workflows/build-fast.yml
-  build-ultralite:
-    uses: ./.github/workflows/build-ultralite.yml
-  doc:
-    uses: ./.github/workflows/doc.yml
-  all-prechecks:
-    needs: [build-fast, build-ultralite, doc]
-    runs-on: ubuntu-24.04
-    steps:
-    - name: Success
-      run: "true"
-  build-docker:
-    # Since docker builds aren't cached and are large, don't run on draft
-    if: ${{github.event.pull_request.draft == false}}
-    needs: [all-prechecks]
-    uses: ./.github/workflows/build-docker.yml
   build-spack:
-    needs: [all-prechecks]
     uses: ./.github/workflows/build-spack.yml
-
-  # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
-  all:
-    if: ${{always()}}
-    needs:
-    - build-docker
-    - build-spack
-    runs-on: ubuntu-24.04
-    steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{toJSON(needs)}}
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,38 @@ jobs:
       with:
         name: event-file
         path: ${{github.event_path}}
+  build-fast:
+    uses: ./.github/workflows/build-fast.yml
+  build-ultralite:
+    uses: ./.github/workflows/build-ultralite.yml
+  doc:
+    uses: ./.github/workflows/doc.yml
+  all-prechecks:
+    needs: [build-fast, build-ultralite, doc]
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Success
+      run: "true"
+  build-docker:
+    # Since docker builds aren't cached and are large, don't run on draft
+    if: ${{github.event.pull_request.draft == false}}
+    needs: [all-prechecks]
+    uses: ./.github/workflows/build-docker.yml
   build-spack:
+    needs: [all-prechecks]
     uses: ./.github/workflows/build-spack.yml
+
+  # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
+  all:
+    if: ${{always()}}
+    needs:
+    - build-docker
+    - build-spack
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{toJSON(needs)}}
 
 # vim: set nowrap tw=100:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,8 @@ set(CELERITAS_RUNTIME_OUTPUT_DIRECTORY
 #----------------------------------------------------------------------------#
 # DEPENDENCIES
 # NOTE: when adding a new dependency, update the CMakeConfig "find_dependency"
+# and check the dependency code in the CMakeConfig setup at the bottom of this
+# file
 #----------------------------------------------------------------------------#
 
 include(CeleritasUtils)
@@ -585,8 +587,8 @@ set(_cmake_files
   # For now, include in case downstream projects do `include(CudaRdcUtils)`.
   "${_LOCAL_RDCUTILS_FILENAME}"
 )
-foreach(_dep Geant4 HepMC3 ROOT Thrust VecGeom)
-  if(CELERITAS_USE_${_dep})
+foreach(_dep CLI11 Geant4 G4VG HepMC3 Perfetto ROOT Thrust VecGeom)
+  if(CELERITAS_USE_${_dep} AND NOT CELERITAS_BUILTIN_${_dep})
     list(APPEND _cmake_files "${PROJECT_SOURCE_DIR}/cmake/Find${_dep}.cmake")
   endif()
 endforeach()

--- a/cmake/CeleritasConfig.cmake.in
+++ b/cmake/CeleritasConfig.cmake.in
@@ -124,6 +124,10 @@ if(CELERITAS_USE_OpenMP)
   find_dependency(OpenMP REQUIRED)
 endif()
 
+if(CELERITAS_USE_Perfetto AND NOT CELERITAS_BUILTIN_Perfetto)
+  find_dependency(Perfetto REQUIRED)
+endif()
+
 if(CELERITAS_USE_PNG)
   find_dependency(PNG REQUIRED)
 endif()

--- a/cmake/FindPerfetto.cmake
+++ b/cmake/FindPerfetto.cmake
@@ -1,0 +1,17 @@
+#------------------------------- -*- cmake -*- -------------------------------#
+# Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#[=======================================================================[.rst:
+
+FindPerfetto
+------------
+
+Find the Perfetto performance analysis library.
+
+#]=======================================================================]
+
+find_package(Perfetto QUIET CONFIG)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Perfetto CONFIG_MODE)
+
+#-----------------------------------------------------------------------------#

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -137,6 +137,10 @@ if(CELERITAS_BUILTIN_Perfetto AND perfetto_POPULATED)
   add_library(perfetto STATIC ${Perfetto_INCLUDE_DIR}/perfetto.cc)
   target_include_directories(perfetto INTERFACE ${Perfetto_INCLUDE_DIR})
   add_library(Celeritas::perfetto ALIAS perfetto)
+  install(TARGETS perfetto
+    EXPORT celeritas-targets
+    COMPONENT runtime
+  )
 endif()
 
 if(CELERITAS_BUILTIN_CLI11)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -134,8 +134,9 @@ endforeach()
 
 if(CELERITAS_BUILTIN_Perfetto AND perfetto_POPULATED)
   set(Perfetto_INCLUDE_DIR ${perfetto_SOURCE_DIR}/sdk)
-  add_library(celeritas_perfetto STATIC ${Perfetto_INCLUDE_DIR}/perfetto.cc)
-  target_include_directories(celeritas_perfetto INTERFACE ${Perfetto_INCLUDE_DIR})
+  add_library(perfetto STATIC ${Perfetto_INCLUDE_DIR}/perfetto.cc)
+  target_include_directories(perfetto INTERFACE ${Perfetto_INCLUDE_DIR})
+  add_library(Celeritas::perfetto ALIAS perfetto)
 endif()
 
 if(CELERITAS_BUILTIN_CLI11)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -133,9 +133,11 @@ endforeach()
 #-----------------------------------------------------------------------------#
 
 if(CELERITAS_BUILTIN_Perfetto AND perfetto_POPULATED)
-  set(Perfetto_INCLUDE_DIR ${perfetto_SOURCE_DIR}/sdk)
-  add_library(perfetto STATIC ${Perfetto_INCLUDE_DIR}/perfetto.cc)
-  target_include_directories(perfetto INTERFACE ${Perfetto_INCLUDE_DIR})
+  set(Perfetto_INCLUDE_DIR "${perfetto_SOURCE_DIR}/sdk")
+  add_library(perfetto STATIC "${Perfetto_INCLUDE_DIR}/perfetto.cc")
+  target_include_directories(perfetto
+    INTERFACE "$<BUILD_INTERFACE:${Perfetto_INCLUDE_DIR}>"
+  )
   add_library(Celeritas::perfetto ALIAS perfetto)
   install(TARGETS perfetto
     EXPORT celeritas-targets

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -21,6 +21,7 @@
         "CELERITAS_USE_HIP":     {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_MPI":     {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_Perfetto":{"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_PNG":     {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_Python":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "OFF"},
@@ -96,7 +97,6 @@
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "ON"},
-        "CELERITAS_USE_Perfetto":    {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"},
         "CMAKE_CXX_SCAN_FOR_MODULES":  {"type": "BOOL", "value": "OFF"},
         "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"},
@@ -130,11 +130,22 @@
     },
     {
       "name": "ndebug-vecgeom",
-      "description": "Build release with vecgeom for testing *only* demos",
+      "description": "Build release with vecgeom for testing *only* apps",
       "inherits": [".ndebug", ".vecgeom", "spack"],
       "cacheVariables": {
         "BUILD_TESTING":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
+      "name": "ndebug-orange-static",
+      "description": "Build with static libraries and perfetto",
+      "inherits": [".ndebug", "spack"],
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_Perfetto":{"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_ROOT":{"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "OFF"}
       }
     },
     {
@@ -173,7 +184,7 @@
     },
     {
       "name": "reldeb-orange-float",
-      "description": "Build with single-precision arithmetic and perfetto",
+      "description": "Build with single-precision arithmetic",
       "inherits": ["spack"],
       "cacheVariables": {
         "CELERITAS_REAL_TYPE": "float"

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -45,24 +45,6 @@
       }
     },
     {
-      "name": "fast",
-      "inherits": ["base"],
-      "displayName": "CONFIG: fast build using apt-get",
-      "cacheVariables": {
-        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"}
-      }
-    },
-    {
-      "name": "ultralite",
-      "inherits": ["base"],
-      "displayName": "CONFIG: ultralite build with no externals",
-      "cacheVariables": {
-        "BUILD_TESTING": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
-      }
-    },
-    {
       "name": "base-spack",
       "hidden": true,
       "inherits": ["base"],
@@ -99,6 +81,24 @@
         "BUILD_TESTING":         {"type": "BOOL", "value": "ON"},
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
         "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "Release"},
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
+      "name": "fast",
+      "inherits": ["type-reldeb", "base"],
+      "displayName": "FINAL: fast build using apt-get",
+      "cacheVariables": {
+        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"}
+      }
+    },
+    {
+      "name": "ultralite",
+      "inherits": ["type-ndebug", "base"],
+      "displayName": "FINAL: ultralite build with no externals",
+      "cacheVariables": {
+        "BUILD_TESTING":         {"type": "BOOL", "value": "ON"},
+        "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
       }
     },
@@ -240,9 +240,6 @@
         "exclude": {
           "label": "app"
         }
-      },
-      "output": {
-        "outputJUnitFile": "$env{GITHUB_WORKSPACE}/test-output/ctest/unit.xml"
       }
     },
     {
@@ -271,12 +268,12 @@
     },
     {
       "name": "fast-unit",
-      "configurePreset": ["unit", "fast"],
-      "inherits": "base"
+      "configurePreset":  "fast",
+      "inherits": ["unit", "base"]
     },
     {
       "name": "fast-app",
-      "configurePreset": ["app", "fast"],
+      "configurePreset":  "fast",
       "inherits": ["app", "base"]
     },
     {

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -1,6 +1,6 @@
 {
   "version": 6,
-  "cmakeMinimumRequired": {"major": 3, "minor": 23, "patch": 0},
+  "cmakeMinimumRequired": {"major": 3, "minor": 25, "patch": 0},
   "configurePresets": [
     {
       "name": "base",
@@ -223,7 +223,6 @@
       "execution": {
         "noTestsAction": "error",
         "stopOnFailure": false,
-        "timeout": 15,
         "jobs": 4
       },
       "output": {
@@ -233,18 +232,37 @@
       }
     },
     {
+      "name": "unit",
+      "execution": {
+        "timeout": 15
+      },
+      "filter": {
+        "exclude": {
+          "label": "app"
+        }
+      },
+      "output": {
+        "outputJUnitFile": "$env{GITHUB_WORKSPACE}/test-output/ctest/unit.xml"
+      }
+    },
+    {
       "name": "app",
       "execution": {
         "timeout": 30
       },
+      "filter": {
+        "include": {
+          "label": "app"
+        }
+      },
       "output": {
-        "outputJUnitFile": "$env{GITHUB_WORKSPACE}/test-output/ctest/all.xml"
+        "outputJUnitFile": "$env{GITHUB_WORKSPACE}/test-output/ctest/app.xml"
       }
     },
     {
       "name": "spack-unit",
       "configurePreset": "base-spack",
-      "inherits": ".base"
+      "inherits": ["unit", "base"]
     },
     {
       "name": "spack-app",
@@ -253,12 +271,12 @@
     },
     {
       "name": "fast-unit",
-      "configurePreset": "fast",
+      "configurePreset": ["unit", "fast"],
       "inherits": "base"
     },
     {
       "name": "fast-app",
-      "configurePreset": "fast",
+      "configurePreset": ["app", "fast"],
       "inherits": ["app", "base"]
     },
     {

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -233,6 +233,7 @@
     },
     {
       "name": "unit",
+      "configurePreset": "base",
       "execution": {
         "timeout": 15
       },
@@ -244,6 +245,7 @@
     },
     {
       "name": "app",
+      "configurePreset": "base",
       "execution": {
         "timeout": 30
       },

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -63,7 +63,7 @@
       }
     },
     {
-      "name": ".spack",
+      "name": "base-spack",
       "hidden": true,
       "inherits": ["base"],
       "displayName": "CONFIG: use full spack toolchain",
@@ -75,16 +75,16 @@
       }
     },
     {
-      "name": ".vecgeom",
+      "name": "base-vecgeom",
       "hidden": true,
       "description": "CONFIG: options to enable VecGeom on Ubuntu",
-      "inherits": [".spack"],
+      "inherits": ["base-spack"],
       "cacheVariables": {
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "ON"}
       }
     },
     {
-      "name": ".reldeb",
+      "name": "type-reldeb",
       "description": "TYPE: debug assertions but no debug symbols",
       "cacheVariables": {
         "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
@@ -93,7 +93,7 @@
       }
     },
     {
-      "name": ".ndebug",
+      "name": "type-ndebug",
       "description": "TYPE: release build for testing *only* apps",
       "cacheVariables": {
         "BUILD_TESTING":         {"type": "BOOL", "value": "ON"},
@@ -105,12 +105,12 @@
     {
       "name": "reldeb-orange",
       "description": "FINAL: ORANGE",
-      "inherits": [".reldeb", ".spack"]
+      "inherits": ["type-reldeb", "base-spack"]
     },
     {
       "name": "reldeb-vecgeom-clang-tidy",
       "description": "FINAL: VecGeom and clang-tidy checks",
-      "inherits": [".reldeb", ".vecgeom"],
+      "inherits": ["type-reldeb", "base-vecgeom"],
       "cacheVariables": {
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
@@ -124,7 +124,7 @@
     {
       "name": "reldeb-vecgeom-clhep",
       "description": "FINAL: VecGeom and CLHEP units",
-      "inherits": [".reldeb", ".vecgeom"],
+      "inherits": ["type-reldeb", "base-vecgeom"],
       "cacheVariables": {
         "CELERITAS_UNITS": "CLHEP"
       }
@@ -132,27 +132,27 @@
     {
       "name": "reldeb-vecgeom",
       "description": "FINAL: release, assertions, VecGeom",
-      "inherits": [".reldeb", ".vecgeom"]
+      "inherits": ["type-reldeb", "base-vecgeom"]
     },
     {
       "name": "reldeb-vgsurf",
       "description": "FINAL: release, assertions, VecGeom 2+surf",
-      "inherits": [".reldeb", ".vecgeom"]
+      "inherits": ["type-reldeb", "base-vecgeom"]
     },
     {
       "name": "reldeb-vecgeom2",
       "description": "FINAL: release, assertions, VecGeom 2~surf",
-      "inherits": [".reldeb", ".vecgeom"]
+      "inherits": ["type-reldeb", "base-vecgeom"]
     },
     {
       "name": "ndebug-vecgeom",
       "description": "FINAL: vecgeom app only",
-      "inherits": [".ndebug", ".vecgeom"]
+      "inherits": ["type-ndebug", "base-vecgeom"]
     },
     {
       "name": "ndebug-orange-static",
       "description": "FINAL: static libraries and perfetto, no tests",
-      "inherits": [".ndebug", ".spack"],
+      "inherits": ["type-ndebug", "base-spack"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Perfetto":{"type": "BOOL", "value": "ON"},
@@ -163,7 +163,7 @@
     {
       "name": "reldeb-geant4",
       "description": "FINAL: Geant4 geometry",
-      "inherits": [".reldeb", ".spack"],
+      "inherits": ["type-reldeb", "base-spack"],
       "cacheVariables": {
         "CELERITAS_CORE_GEO": "Geant4",
         "CELERITAS_UNITS": "CLHEP"
@@ -172,7 +172,7 @@
     {
       "name": "reldeb-orange-minimal",
       "description": "FINAL: minimal reasonable dependencies",
-      "inherits": [".reldeb", ".spack"],
+      "inherits": ["type-reldeb", "base-spack"],
       "cacheVariables": {
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
@@ -184,7 +184,7 @@
     {
       "name": "reldebinfo-orange-asanlite",
       "description": "FINAL: address sanitizer flags and debug symbols",
-      "inherits": [".spack"],
+      "inherits": ["base-spack"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
@@ -198,7 +198,7 @@
     {
       "name": "reldeb-orange-float",
       "description": "FINAL: single-precision arithmetic",
-      "inherits": [".reldeb", ".spack"],
+      "inherits": ["type-reldeb", "base-spack"],
       "cacheVariables": {
         "CELERITAS_REAL_TYPE": "float"
       }
@@ -243,12 +243,12 @@
     },
     {
       "name": "spack-unit",
-      "configurePreset": ".spack",
+      "configurePreset": "base-spack",
       "inherits": ".base"
     },
     {
       "name": "spack-app",
-      "configurePreset": ".spack",
+      "configurePreset": "base-spack",
       "inherits": [".app", ".base"]
     },
     {

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -218,7 +218,7 @@
   ],
   "testPresets": [
     {
-      "name": ".base",
+      "name": "base",
       "configurePreset": "base",
       "execution": {
         "noTestsAction": "error",
@@ -233,7 +233,7 @@
       }
     },
     {
-      "name": ".app",
+      "name": "app",
       "execution": {
         "timeout": 30
       },
@@ -249,22 +249,22 @@
     {
       "name": "spack-app",
       "configurePreset": "base-spack",
-      "inherits": [".app", ".base"]
+      "inherits": ["app", "base"]
     },
     {
       "name": "fast-unit",
       "configurePreset": "fast",
-      "inherits": ".base"
+      "inherits": "base"
     },
     {
       "name": "fast-app",
       "configurePreset": "fast",
-      "inherits": [".app", ".base"]
+      "inherits": ["app", "base"]
     },
     {
       "name": "ultralite",
       "configurePreset": "ultralite",
-      "inherits": ".base"
+      "inherits": "base"
     }
   ]
 }

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -218,7 +218,7 @@
   ],
   "testPresets": [
     {
-      "name": "base",
+      "name": ".base",
       "configurePreset": "base",
       "execution": {
         "noTestsAction": "error",
@@ -232,7 +232,7 @@
       }
     },
     {
-      "name": "unit",
+      "name": ".unit",
       "configurePreset": "base",
       "execution": {
         "timeout": 15
@@ -244,7 +244,7 @@
       }
     },
     {
-      "name": "app",
+      "name": ".app",
       "configurePreset": "base",
       "execution": {
         "timeout": 30
@@ -261,12 +261,12 @@
     {
       "name": "spack-unit",
       "configurePreset": "base-spack",
-      "inherits": ["unit", "base"]
+      "inherits": [".unit", ".base"]
     },
     {
       "name": "spack-app",
       "configurePreset": "base-spack",
-      "inherits": ["app", "base"]
+      "inherits": [".app", ".base"]
     },
     {
       "name": "fast-unit",
@@ -281,7 +281,7 @@
     {
       "name": "ultralite",
       "configurePreset": "ultralite",
-      "inherits": "base"
+      "inherits": ".base"
     }
   ]
 }

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -271,12 +271,12 @@
     {
       "name": "fast-unit",
       "configurePreset":  "fast",
-      "inherits": ["unit", "base"]
+      "inherits": [".unit", ".base"]
     },
     {
       "name": "fast-app",
       "configurePreset":  "fast",
-      "inherits": ["app", "base"]
+      "inherits": [".app", ".base"]
     },
     {
       "name": "ultralite",

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -45,8 +45,7 @@
       }
     },
     {
-      "name": "base-spack",
-      "hidden": true,
+      "name": "spack",
       "inherits": ["base"],
       "displayName": "CONFIG: use full spack toolchain",
       "cacheVariables": {
@@ -57,10 +56,8 @@
       }
     },
     {
-      "name": "base-vecgeom",
-      "hidden": true,
+      "name": ".vecgeom",
       "description": "CONFIG: options to enable VecGeom on Ubuntu",
-      "inherits": ["base-spack"],
       "cacheVariables": {
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "ON"}
       }
@@ -105,12 +102,12 @@
     {
       "name": "reldeb-orange",
       "description": "FINAL: ORANGE",
-      "inherits": ["type-reldeb", "base-spack"]
+      "inherits": ["type-reldeb", "spack"]
     },
     {
       "name": "reldeb-vecgeom-clang-tidy",
       "description": "FINAL: VecGeom and clang-tidy checks",
-      "inherits": ["type-reldeb", "base-vecgeom"],
+      "inherits": ["type-reldeb", ".vecgeom", "spack"],
       "cacheVariables": {
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
@@ -124,7 +121,7 @@
     {
       "name": "reldeb-vecgeom-clhep",
       "description": "FINAL: VecGeom and CLHEP units",
-      "inherits": ["type-reldeb", "base-vecgeom"],
+      "inherits": ["type-reldeb", ".vecgeom", "spack"],
       "cacheVariables": {
         "CELERITAS_UNITS": "CLHEP"
       }
@@ -132,27 +129,27 @@
     {
       "name": "reldeb-vecgeom",
       "description": "FINAL: release, assertions, VecGeom",
-      "inherits": ["type-reldeb", "base-vecgeom"]
+      "inherits": ["type-reldeb", ".vecgeom", "spack"]
     },
     {
       "name": "reldeb-vgsurf",
       "description": "FINAL: release, assertions, VecGeom 2+surf",
-      "inherits": ["type-reldeb", "base-vecgeom"]
+      "inherits": ["type-reldeb", ".vecgeom", "spack"]
     },
     {
       "name": "reldeb-vecgeom2",
       "description": "FINAL: release, assertions, VecGeom 2~surf",
-      "inherits": ["type-reldeb", "base-vecgeom"]
+      "inherits": ["type-reldeb", ".vecgeom", "spack"]
     },
     {
       "name": "ndebug-vecgeom",
       "description": "FINAL: vecgeom app only",
-      "inherits": ["type-ndebug", "base-vecgeom"]
+      "inherits": ["type-ndebug", ".vecgeom", "spack"]
     },
     {
       "name": "ndebug-orange-static",
       "description": "FINAL: static libraries and perfetto, no tests",
-      "inherits": ["type-ndebug", "base-spack"],
+      "inherits": ["type-ndebug", "spack"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Perfetto":{"type": "BOOL", "value": "ON"},
@@ -163,7 +160,7 @@
     {
       "name": "reldeb-geant4",
       "description": "FINAL: Geant4 geometry",
-      "inherits": ["type-reldeb", "base-spack"],
+      "inherits": ["type-reldeb", "spack"],
       "cacheVariables": {
         "CELERITAS_CORE_GEO": "Geant4",
         "CELERITAS_UNITS": "CLHEP"
@@ -172,7 +169,7 @@
     {
       "name": "reldeb-orange-minimal",
       "description": "FINAL: minimal reasonable dependencies",
-      "inherits": ["type-reldeb", "base-spack"],
+      "inherits": ["type-reldeb", "spack"],
       "cacheVariables": {
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
@@ -184,7 +181,7 @@
     {
       "name": "reldebinfo-orange-asanlite",
       "description": "FINAL: address sanitizer flags and debug symbols",
-      "inherits": ["base-spack"],
+      "inherits": ["spack"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
@@ -198,7 +195,7 @@
     {
       "name": "reldeb-orange-float",
       "description": "FINAL: single-precision arithmetic",
-      "inherits": ["type-reldeb", "base-spack"],
+      "inherits": ["type-reldeb", "spack"],
       "cacheVariables": {
         "CELERITAS_REAL_TYPE": "float"
       }
@@ -260,12 +257,12 @@
     },
     {
       "name": "spack-unit",
-      "configurePreset": "base-spack",
+      "configurePreset": "spack",
       "inherits": [".unit", ".base"]
     },
     {
       "name": "spack-app",
-      "configurePreset": "base-spack",
+      "configurePreset": "spack",
       "inherits": [".app", ".base"]
     },
     {

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -281,7 +281,13 @@
     {
       "name": "ultralite",
       "configurePreset": "ultralite",
-      "inherits": ".base"
+      "inherits": ".base",
+      "execution": {
+        "timeout": 30
+      },
+      "output": {
+        "outputJUnitFile": "$env{GITHUB_WORKSPACE}/test-output/ctest/all.xml"
+      }
     }
   ]
 }

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -4,16 +4,14 @@
   "configurePresets": [
     {
       "name": "base",
-      "displayName": "ubuntu options for clang/gcc",
+      "displayName": "CONFIG: ubuntu options for clang/gcc",
       "inherits": ["default"],
       "binaryDir": "${sourceDir}/build",
       "generator": "Ninja",
       "cacheVariables": {
-        "BUILD_SHARED_LIBS":     {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILTIN_CLI11": {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_DEBUG":       {"type": "BOOL", "value": "ON"},
         "CELERITAS_TEST_VERBOSE":{"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_CUDA":    {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "OFF"},
@@ -28,7 +26,6 @@
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_HOSTNAME": "ubuntu-github",
         "CELERITAS_TEST_XML": "$env{GITHUB_WORKSPACE}/test-output/google/",
-        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
         "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations",
@@ -39,18 +36,37 @@
     {
       "name": "doc",
       "inherits": ["base"],
-      "displayName": "Build only documentation",
+      "displayName": "CONFIG: build only documentation",
       "cacheVariables": {
         "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_DOXYGEN_BUILD_TESTS":  {"type": "BOOL", "value": "ON"},
+        "CELERITAS_DOXYGEN_BUILD_TESTS": {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_PNG":     {"type": "BOOL", "value": "OFF"}
       }
     },
     {
-      "name": "spack",
+      "name": "fast",
       "inherits": ["base"],
-      "displayName": "use spack toolchain",
+      "displayName": "CONFIG: fast build using apt-get",
+      "cacheVariables": {
+        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"}
+      }
+    },
+    {
+      "name": "ultralite",
+      "inherits": ["base"],
+      "displayName": "CONFIG: ultralite build with no externals",
+      "cacheVariables": {
+        "BUILD_TESTING": {"type": "BOOL", "value": "ON"},
+        "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
+      "name": ".spack",
+      "hidden": true,
+      "inherits": ["base"],
+      "displayName": "CONFIG: use full spack toolchain",
       "cacheVariables": {
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"},
@@ -59,40 +75,42 @@
       }
     },
     {
-      "name": "fast",
-      "inherits": ["base"],
-      "displayName": "fast build using apt-get",
-      "cacheVariables": {
-        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"}
-      }
-    },
-    {
-      "name": "ultralite",
-      "inherits": ["base"],
-      "displayName": "ultralite build with no externals",
-      "cacheVariables": {
-        "BUILD_TESTING": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
-      }
-    },
-    {
       "name": ".vecgeom",
       "hidden": true,
-      "description": "Options to enable VecGeom on Ubuntu",
+      "description": "CONFIG: options to enable VecGeom on Ubuntu",
+      "inherits": [".spack"],
       "cacheVariables": {
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "ON"}
       }
     },
     {
+      "name": ".reldeb",
+      "description": "TYPE: debug assertions but no debug symbols",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
+        "CELERITAS_DEBUG":  {"type": "BOOL",   "value": "ON"},
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": ".ndebug",
+      "description": "TYPE: release build for testing *only* apps",
+      "cacheVariables": {
+        "BUILD_TESTING":         {"type": "BOOL", "value": "ON"},
+        "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
+        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "Release"},
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
       "name": "reldeb-orange",
-      "description": "Build with ORANGE",
-      "inherits": ["spack"]
+      "description": "FINAL: ORANGE",
+      "inherits": [".reldeb", ".spack"]
     },
     {
       "name": "reldeb-vecgeom-clang-tidy",
-      "description": "Build with VecGeom and clang-tidy checks",
-      "inherits": [".vecgeom", "spack"],
+      "description": "FINAL: VecGeom and clang-tidy checks",
+      "inherits": [".reldeb", ".vecgeom"],
       "cacheVariables": {
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
@@ -105,42 +123,36 @@
     },
     {
       "name": "reldeb-vecgeom-clhep",
-      "description": "Build with VecGeom and CLHEP units",
-      "inherits": [".vecgeom", "spack"],
+      "description": "FINAL: VecGeom and CLHEP units",
+      "inherits": [".reldeb", ".vecgeom"],
       "cacheVariables": {
         "CELERITAS_UNITS": "CLHEP"
       }
     },
     {
       "name": "reldeb-vecgeom",
-      "description": "Build with release, assertions, VecGeom",
-      "inherits": [".vecgeom", "spack"],
-      "cacheVariables": {
-      }
+      "description": "FINAL: release, assertions, VecGeom",
+      "inherits": [".reldeb", ".vecgeom"]
     },
     {
       "name": "reldeb-vgsurf",
-      "description": "Build with release, assertions, VecGeom 2+surf",
-      "inherits": [".vecgeom", "spack"]
+      "description": "FINAL: release, assertions, VecGeom 2+surf",
+      "inherits": [".reldeb", ".vecgeom"]
     },
     {
       "name": "reldeb-vecgeom2",
-      "description": "Build with release, assertions, VecGeom 2~surf",
-      "inherits": [".vecgeom", "spack"]
+      "description": "FINAL: release, assertions, VecGeom 2~surf",
+      "inherits": [".reldeb", ".vecgeom"]
     },
     {
       "name": "ndebug-vecgeom",
-      "description": "Build release with vecgeom for testing *only* apps",
-      "inherits": [".ndebug", ".vecgeom", "spack"],
-      "cacheVariables": {
-        "BUILD_TESTING":  {"type": "BOOL", "value": "ON"},
-        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
-      }
+      "description": "FINAL: vecgeom app only",
+      "inherits": [".ndebug", ".vecgeom"]
     },
     {
       "name": "ndebug-orange-static",
-      "description": "Build with static libraries and perfetto",
-      "inherits": [".ndebug", "spack"],
+      "description": "FINAL: static libraries and perfetto, no tests",
+      "inherits": [".ndebug", ".spack"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Perfetto":{"type": "BOOL", "value": "ON"},
@@ -150,8 +162,8 @@
     },
     {
       "name": "reldeb-geant4",
-      "description": "Build with Geant4 geometry",
-      "inherits": ["spack"],
+      "description": "FINAL: Geant4 geometry",
+      "inherits": [".reldeb", ".spack"],
       "cacheVariables": {
         "CELERITAS_CORE_GEO": "Geant4",
         "CELERITAS_UNITS": "CLHEP"
@@ -159,8 +171,8 @@
     },
     {
       "name": "reldeb-orange-minimal",
-      "description": "Build with minimal reasonable dependencies",
-      "inherits": ["spack"],
+      "description": "FINAL: minimal reasonable dependencies",
+      "inherits": [".reldeb", ".spack"],
       "cacheVariables": {
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
@@ -170,10 +182,11 @@
       }
     },
     {
-      "name": "reldeb-orange-asanlite",
-      "description": "Build with address sanitizer flags",
-      "inherits": ["spack"],
+      "name": "reldebinfo-orange-asanlite",
+      "description": "FINAL: address sanitizer flags and debug symbols",
+      "inherits": [".spack"],
       "cacheVariables": {
+        "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
@@ -184,8 +197,8 @@
     },
     {
       "name": "reldeb-orange-float",
-      "description": "Build with single-precision arithmetic",
-      "inherits": ["spack"],
+      "description": "FINAL: single-precision arithmetic",
+      "inherits": [".reldeb", ".spack"],
       "cacheVariables": {
         "CELERITAS_REAL_TYPE": "float"
       }
@@ -205,7 +218,7 @@
   ],
   "testPresets": [
     {
-      "name": "base",
+      "name": ".base",
       "configurePreset": "base",
       "execution": {
         "noTestsAction": "error",
@@ -220,32 +233,38 @@
       }
     },
     {
-      "name": "spack-unit",
-      "configurePreset": "spack",
-      "inherits": "base"
-    },
-    {
-      "name": "spack-app",
-      "configurePreset": "spack",
-      "inherits": "base",
+      "name": ".app",
+      "execution": {
+        "timeout": 30
+      },
       "output": {
         "outputJUnitFile": "$env{GITHUB_WORKSPACE}/test-output/ctest/all.xml"
       }
     },
     {
+      "name": "spack-unit",
+      "configurePreset": ".spack",
+      "inherits": ".base"
+    },
+    {
+      "name": "spack-app",
+      "configurePreset": ".spack",
+      "inherits": [".app", ".base"]
+    },
+    {
       "name": "fast-unit",
       "configurePreset": "fast",
-      "inherits": "base"
+      "inherits": ".base"
     },
     {
       "name": "fast-app",
       "configurePreset": "fast",
-      "inherits": "spack-app"
+      "inherits": [".app", ".base"]
     },
     {
       "name": "ultralite",
       "configurePreset": "ultralite",
-      "inherits": "base"
+      "inherits": ".base"
     }
   ]
 }

--- a/scripts/cmake-presets/ci-windows-github.json
+++ b/scripts/cmake-presets/ci-windows-github.json
@@ -70,8 +70,7 @@
       "execution": {
         "noTestsAction": "error",
         "stopOnFailure": false,
-        "jobs": 4,
-        "timeout": 180
+        "jobs": 4
       },
       "output": {
         "maxFailedTestOutputSize": 1048576,
@@ -80,17 +79,39 @@
       }
     },
     {
+      "name": "unit",
+      "execution": {
+        "timeout": 30
+      },
+      "filter": {
+        "exclude": {
+          "label": "app"
+        }
+      }
+    },
+    {
+      "name": "app",
+      "execution": {
+        "timeout": 90
+      },
+      "filter": {
+        "include": {
+          "label": "app"
+        }
+      },
+      "output": {
+        "outputJUnitFile": "$env{GITHUB_WORKSPACE}/test-output/ctest/app.xml"
+      }
+    },
+    {
       "name": "fast-unit",
       "configurePreset": "fast",
-      "inherits": "base"
+      "inherits": ["unit", "base"]
     },
     {
       "name": "fast-app",
       "configurePreset": "fast",
-      "inherits": "base",
-      "output": {
-        "outputJUnitFile": "$env{GITHUB_WORKSPACE}/test-output/ctest/all.xml"
-      }
+      "inherits": ["app", "base"]
     },
     {"name": "ultralite", "configurePreset": "ultralite", "inherits": "base"}
   ]

--- a/scripts/cmake-presets/ci-windows-github.json
+++ b/scripts/cmake-presets/ci-windows-github.json
@@ -65,7 +65,7 @@
   ],
   "testPresets": [
     {
-      "name": "base",
+      "name": ".base",
       "configurePreset": "base",
       "execution": {
         "noTestsAction": "error",
@@ -79,7 +79,7 @@
       }
     },
     {
-      "name": "unit",
+      "name": ".unit",
       "configurePreset": "base",
       "execution": {
         "timeout": 30
@@ -91,7 +91,7 @@
       }
     },
     {
-      "name": "app",
+      "name": ".app",
       "configurePreset": "base",
       "execution": {
         "timeout": 90
@@ -108,13 +108,13 @@
     {
       "name": "fast-unit",
       "configurePreset": "fast",
-      "inherits": ["unit", "base"]
+      "inherits": [".unit", ".base"]
     },
     {
       "name": "fast-app",
       "configurePreset": "fast",
-      "inherits": ["app", "base"]
+      "inherits": [".app", ".base"]
     },
-    {"name": "ultralite", "configurePreset": "ultralite", "inherits": "base"}
+    {"name": "ultralite", "configurePreset": "ultralite", "inherits": ".base"}
   ]
 }

--- a/scripts/cmake-presets/ci-windows-github.json
+++ b/scripts/cmake-presets/ci-windows-github.json
@@ -1,6 +1,6 @@
 {
   "version": 6,
-  "cmakeMinimumRequired": {"major": 3, "minor": 21, "patch": 0},
+  "cmakeMinimumRequired": {"major": 3, "minor": 25, "patch": 0},
   "configurePresets": [
     {
       "name": "base",
@@ -115,6 +115,16 @@
       "configurePreset": "fast",
       "inherits": [".app", ".base"]
     },
-    {"name": "ultralite", "configurePreset": "ultralite", "inherits": ".base"}
+    {
+      "name": "ultralite",
+      "configurePreset": "ultralite",
+      "inherits": ".base",
+      "execution": {
+        "timeout": 30
+      },
+      "output": {
+        "outputJUnitFile": "$env{GITHUB_WORKSPACE}/test-output/ctest/all.xml"
+      }
+    }
   ]
 }

--- a/scripts/cmake-presets/ci-windows-github.json
+++ b/scripts/cmake-presets/ci-windows-github.json
@@ -80,6 +80,7 @@
     },
     {
       "name": "unit",
+      "configurePreset": "base",
       "execution": {
         "timeout": 30
       },
@@ -91,6 +92,7 @@
     },
     {
       "name": "app",
+      "configurePreset": "base",
       "execution": {
         "timeout": 90
       },

--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -13,6 +13,7 @@
       },
       "cacheVariables": {
         "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_CLI11": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_MPI":     {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
@@ -124,6 +125,15 @@
       "name": "ndebug-vgsurf",
       "displayName": "Everything in release mode with debug symbols and assertions",
       "inherits": [".ndebug", "vgsurf"]
+    },
+    {
+      "name": "vecgeom-v1",
+      "displayName": "Ndebug with VecGeom v1",
+      "inherits": [".ndebug", "vecgeom"],
+      "environment": {
+        "PATH": "$env{SPACK_ROOT}/var/spack/environments/celeritas-old/.spack-env/view/bin:/usr/local/cuda-11.5/bin:$penv{PATH}",
+        "CMAKE_PREFIX_PATH": "$env{SPACK_ROOT}/var/spack/environments/celeritas-old/.spack-env/view"
+      }
     },
     {
       "name": "reldeb-serial",

--- a/scripts/dev/analyze-cmake-trace.py
+++ b/scripts/dev/analyze-cmake-trace.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import sys
+import re
+from collections import Counter
+
+def main():
+    # Regex to extract filename and line number.
+    pattern = re.compile(r'^(.*?)\((\d+)\):')
+    counts = Counter()
+
+    # Read lines from standard input.
+    for line in sys.stdin:
+        m = pattern.match(line)
+        if m:
+            filename = m.group(1)
+            lineno = int(m.group(2))
+            counts[(filename, lineno)] += 1
+
+    # Create list of tuples (filename, line, count) and sort:
+    # sort primarily by decreasing count, then filename and line number.
+    entries = [(fn, ln, cnt) for (fn, ln), cnt in counts.items()]
+    entries.sort(key=lambda x: (-x[2], x[0], x[1]))
+
+    # Group sequential lines from the same file with identical hit counts.
+    groups = []
+    if entries:
+        current_fn, current_ln, current_cnt = entries[0]
+        start_ln = current_ln
+        end_ln = current_ln
+
+        for fn, ln, cnt in entries[1:]:
+            if fn == current_fn and cnt == current_cnt and ln == end_ln + 1:
+                end_ln = ln
+            else:
+                groups.append((current_fn, start_ln, end_ln, current_cnt))
+                current_fn, current_ln, current_cnt = fn, ln, cnt
+                start_ln = ln
+                end_ln = ln
+        groups.append((current_fn, start_ln, end_ln, current_cnt))
+
+    # Print the results.
+    for fn, start, end, cnt in groups:
+        if cnt == 1:
+            continue
+        line_range = f"{start}" if start == end else f"{start}-{end}"
+        print(f"{fn}({line_range}): {cnt}")
+
+if __name__ == '__main__':
+    main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,7 +119,7 @@ endif()
 
 celer_add_ext_library(Perfetto)
 if(CELERITAS_BUILTIN_Perfetto)
-  target_link_libraries(ExtPerfetto Celeritas::perfetto)
+  target_link_libraries(ExtPerfetto INTERFACE Celeritas::perfetto)
 endif()
 
 celeritas_add_interface_library(ExtGeant4Geo)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,11 +117,6 @@ if(CELERITAS_USE_CUDA)
   target_link_libraries(ExtVecGeom INTERFACE Celeritas::ExtDeviceApi)
 endif()
 
-celer_add_ext_library(Perfetto)
-if(CELERITAS_BUILTIN_Perfetto)
-  target_link_libraries(ExtPerfetto Celeritas::perfetto)
-endif()
-
 celeritas_add_interface_library(ExtGeant4Geo)
 if(CELERITAS_USE_Geant4)
   celeritas_get_g4libs(_cg4_libs geometry)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,11 @@ if(CELERITAS_USE_CUDA)
   target_link_libraries(ExtVecGeom INTERFACE Celeritas::ExtDeviceApi)
 endif()
 
+celer_add_ext_library(Perfetto)
+if(CELERITAS_BUILTIN_Perfetto)
+  target_link_libraries(ExtPerfetto Celeritas::perfetto)
+endif()
+
 celeritas_add_interface_library(ExtGeant4Geo)
 if(CELERITAS_USE_Geant4)
   celeritas_get_g4libs(_cg4_libs geometry)

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -253,7 +253,7 @@ if(CELERITAS_USE_Perfetto)
   # Perfetto is required to build these classes
   celeritas_add_object_library(corecel_perfetto_obj
     sys/TraceCounter.perfetto.cc
-    sys/TracingSession.cc
+    sys/TracingSession.perfetto.cc
   )
   celeritas_target_link_libraries(corecel_perfetto_obj
     PRIVATE Celeritas::perfetto Celeritas::BuildFlags

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -256,7 +256,7 @@ if(CELERITAS_USE_Perfetto)
     sys/TracingSession.cc
   )
   celeritas_target_link_libraries(corecel_perfetto_obj
-    PRIVATE Celeritas::ExtPerfetto Celeritas::BuildFlags
+    PRIVATE Celeritas::perfetto Celeritas::BuildFlags
   )
   list(APPEND SOURCES $<TARGET_OBJECTS:corecel_perfetto_obj>)
   list(APPEND PRIVATE_DEPS corecel_perfetto_obj)

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -211,7 +211,6 @@ list(APPEND SOURCES
   sys/MemRegistry.cc
   sys/MemRegistryIO.json.cc
   sys/ScopedMem.cc
-  sys/ScopedProfiling.cc
   sys/ScopedSignalHandler.cc
   sys/TypeDemangler.cc
   sys/Version.cc
@@ -249,18 +248,21 @@ list(APPEND PRIVATE_DEPS corecel_mpi_obj)
 
 #-----------------------------------------------------------------------------#
 
+set(_profiling_sources
+  sys/ScopedProfiling.cc
+)
 if(CELERITAS_USE_Perfetto)
-  # Perfetto is required to build these classes
-  celeritas_add_object_library(corecel_perfetto_obj
+  list(APPEND _profiling_sources
     sys/TraceCounter.perfetto.cc
     sys/TracingSession.perfetto.cc
   )
-  celeritas_target_link_libraries(corecel_perfetto_obj
-    PRIVATE Celeritas::perfetto Celeritas::BuildFlags
-  )
-  list(APPEND SOURCES $<TARGET_OBJECTS:corecel_perfetto_obj>)
-  list(APPEND PRIVATE_DEPS corecel_perfetto_obj)
 endif()
+celeritas_add_object_library(corecel_profiling_obj ${_profiling_sources})
+celeritas_target_link_libraries(corecel_profiling_obj
+  PRIVATE Celeritas::ExtPerfetto Celeritas::BuildFlags
+)
+list(APPEND SOURCES $<TARGET_OBJECTS:corecel_profiling_obj>)
+list(APPEND PRIVATE_DEPS corecel_profiling_obj)
 
 #-----------------------------------------------------------------------------#
 # CUDA/HIP code

--- a/src/corecel/io/BuildOutput.cc
+++ b/src/corecel/io/BuildOutput.cc
@@ -81,12 +81,13 @@ void BuildOutput::output(JsonPimpl* j) const
             CO_ADD_COND_VERS(ROOT, ROOT, root);
             CO_ADD_COND_VERS(VECGEOM, VecGeom, vecgeom);
 #undef CO_ADD_COND_VERS
-            if constexpr (CELERITAS_USE_VECGEOM)
-            {
-                deps["vecgeom_options"] = std::string(cmake::vecgeom_options);
-            }
             return deps;
         }();
+
+        if constexpr (CELERITAS_USE_VECGEOM)
+        {
+            cfg["vecgeom"] = std::string(cmake::vecgeom_options);
+        }
 
         return cfg;
     }();

--- a/src/corecel/sys/TracingSession.perfetto.cc
+++ b/src/corecel/sys/TracingSession.perfetto.cc
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/sys/TracingSession.cc
+//! \file corecel/sys/TracingSession.perfetto.cc
 //! \brief RAII class for managing a perfetto session and its resources.
 //---------------------------------------------------------------------------//
 #include "TracingSession.hh"


### PR DESCRIPTION
Because static builds require propagating all their dependencies, we have to make sure that all our built-in libraries are installed.

This adds a static build to the CI and rearrange some of the GitHub action workflow code, as well as fixing some of the test reporting. It also slightly shifts the location of the vecgeom options in the output, enables more CI jobs to give useful output on failure, and adds a script for profiling cmake. 