### PR TITLE
Change default field substeps in accel

### DIFF
--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -195,7 +195,7 @@ struct SetupOptions
     //!@{
     //! \name Field options
 
-    size_type max_field_substeps{100};
+    size_type max_field_substeps{10};
     //!@}
 
     //! Sensitive detector options


### PR DESCRIPTION
As discussed, we probably missed changing the default number of substeps in accel.