### PR TITLE
Force loading of the dl library -- needed in some configs with gcc13

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,7 +49,13 @@ function(celeritas_add_device_test base)
   if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
     set(_cuda_args GPU SOURCES "${base}.test.cu")
   endif()
-  celeritas_add_test("${base}.test.cc" ${_cuda_args} ${ARGN})
+    # GCC 13 requires some tests to have -ldl explicitely added
+    if(${base} MATCHES "Range"
+      OR ${base} MATCHES "StackAllocator"
+      OR ${base} MATCHES "ObserverPtr")
+          set(ARGN LINK_LIBRARIES dl)
+    endif()
+    celeritas_add_test("${base}.test.cc" ${_cuda_args} ${ARGN})
 endfunction()
 
 if(CELERITAS_UNITS STREQUAL "CGS")


### PR DESCRIPTION
This change fixes some build errors seen in Perlmutter, using gcc13:
```console
/usr/lib64/gcc/x86_64-suse-linux/13/../../../../x86_64-suse-linux/bin/ld: test/corecel/CMakeFiles/corecel_data_ObserverPtr.dir/data/ObserverPtr.test.cu.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/lib64/gcc/x86_64-suse-linux/13/../../../../x86_64-suse-linux/bin/ld: /lib64/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
It then affected Range, StackAllocator and ObserverPtr tests.

I first saw this a couple weeks ago, and fixed it with this change.  I thought this was fixed some other way, as I cannot see the original problem anymore with current heads of Celeritas (commit f96ecb87) and VecGeom (commit c3ee06912).  But yesterday Soon reported seeing the same error, and this change also fixed his problem.

Should this be merged?