### PR TITLE
Add timers to accel integration classes

### DIFF
--- a/app/celer-g4/CMakeLists.txt
+++ b/app/celer-g4/CMakeLists.txt
@@ -20,7 +20,6 @@ if(CELERITAS_USE_Geant4)
     RunInputIO.json.cc
     SensitiveDetector.cc
     SensitiveHit.cc
-    TimerOutput.cc
     TrackingAction.cc
   )
   set(LIBRARIES Celeritas::accel nlohmann_json::nlohmann_json)

--- a/app/celer-g4/EventAction.cc
+++ b/app/celer-g4/EventAction.cc
@@ -77,7 +77,7 @@ void EventAction::EndOfEventAction(G4Event const* event)
     }
 
     // Record the time for this event
-    params_->timer()->record_event_time(get_event_time_());
+    params_->timer()->RecordEventTime(get_event_time_());
 
     CELER_LOG_LOCAL(debug) << "Finished event " << event->GetEventID();
 }

--- a/app/celer-g4/EventAction.cc
+++ b/app/celer-g4/EventAction.cc
@@ -11,6 +11,7 @@
 
 #include "corecel/Macros.hh"
 #include "accel/ExceptionConverter.hh"
+#include "accel/TimeOutput.hh"
 
 #include "GlobalSetup.hh"
 #include "RootIO.hh"
@@ -76,7 +77,7 @@ void EventAction::EndOfEventAction(G4Event const* event)
     }
 
     // Record the time for this event
-    diagnostics_->timer()->RecordEventTime(get_event_time_());
+    params_->timer()->record_event_time(get_event_time_());
 
     CELER_LOG_LOCAL(debug) << "Finished event " << event->GetEventID();
 }

--- a/app/celer-g4/GeantDiagnostics.cc
+++ b/app/celer-g4/GeantDiagnostics.cc
@@ -66,10 +66,6 @@ GeantDiagnostics::GeantDiagnostics(SharedParams const& params)
     CELER_ASSERT(output_reg);
     size_type num_threads = params.num_streams();
 
-    // Create the timer output and add to output registry
-    timer_output_ = std::make_shared<TimerOutput>(num_threads);
-    output_reg->insert(timer_output_);
-
     auto& global_setup = *GlobalSetup::Instance();
     if (global_setup.StepDiagnostic())
     {

--- a/app/celer-g4/GeantDiagnostics.hh
+++ b/app/celer-g4/GeantDiagnostics.hh
@@ -15,8 +15,6 @@
 #include "accel/GeantStepDiagnostic.hh"
 #include "accel/SharedParams.hh"
 
-#include "TimerOutput.hh"
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -44,7 +42,6 @@ class GeantDiagnostics
     using SPMultiExceptionHandler = std::shared_ptr<MultiExceptionHandler>;
     using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
     using SPStepDiagnostic = std::shared_ptr<GeantStepDiagnostic>;
-    using SPTimerOutput = std::shared_ptr<TimerOutput>;
     using VecOutputInterface = std::vector<SPConstOutput>;
     //!@}
 
@@ -67,21 +64,16 @@ class GeantDiagnostics
     // Access the step diagnostic
     inline SPStepDiagnostic const& step_diagnostic() const;
 
-    // Access the timer output
-    inline SPTimerOutput const& timer() const;
-
     // Access the exception handler
     inline SPMultiExceptionHandler const& multi_exception_handler() const;
 
     //! Whether this instance is initialized
-    explicit operator bool() const { return static_cast<bool>(timer_output_); }
+    explicit operator bool() const { return static_cast<bool>(meh_); }
 
   private:
     //// DATA ////
 
-    SPOutputRegistry output_reg_;
     SPStepDiagnostic step_diagnostic_;
-    SPTimerOutput timer_output_;
     SPMultiExceptionHandler meh_;
 
     static VecOutputInterface& queued_output();
@@ -104,17 +96,6 @@ auto GeantDiagnostics::step_diagnostic() const -> SPStepDiagnostic const&
 {
     CELER_EXPECT(*this);
     return step_diagnostic_;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Access the timer output.
- */
-auto GeantDiagnostics::timer() const -> SPTimerOutput const&
-{
-    CELER_EXPECT(*this);
-    CELER_EXPECT(timer_output_);
-    return timer_output_;
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-g4/RunAction.cc
+++ b/app/celer-g4/RunAction.cc
@@ -74,7 +74,7 @@ void RunAction::BeginOfRunAction(G4Run const* run)
         CELER_TRY_HANDLE(diagnostics_->Initialize(*params_), call_g4exception);
         CELER_ASSERT(*diagnostics_);
 
-        params_->timer()->record_setup_time(
+        params_->timer()->RecordSetupTime(
             GlobalSetup::Instance()->GetSetupTime());
         get_transport_time_ = {};
     }
@@ -127,11 +127,11 @@ void RunAction::EndOfRunAction(G4Run const*)
 
     if (transport_ && *transport_)
     {
-        params_->timer()->record_action_time(transport_->GetActionTime());
+        params_->timer()->RecordActionTime(transport_->GetActionTime());
     }
     if (init_shared_)
     {
-        params_->timer()->record_total_time(get_transport_time_());
+        params_->timer()->RecordTotalTime(get_transport_time_());
     }
 
     if (params_->mode() == SharedParams::Mode::enabled)

--- a/app/celer-g4/RunAction.cc
+++ b/app/celer-g4/RunAction.cc
@@ -22,6 +22,7 @@
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "celeritas/ext/GeantSetup.hh"
 #include "accel/ExceptionConverter.hh"
+#include "accel/TimeOutput.hh"
 
 #include "ExceptionHandler.hh"
 #include "GeantDiagnostics.hh"
@@ -73,7 +74,7 @@ void RunAction::BeginOfRunAction(G4Run const* run)
         CELER_TRY_HANDLE(diagnostics_->Initialize(*params_), call_g4exception);
         CELER_ASSERT(*diagnostics_);
 
-        diagnostics_->timer()->RecordSetupTime(
+        params_->timer()->record_setup_time(
             GlobalSetup::Instance()->GetSetupTime());
         get_transport_time_ = {};
     }
@@ -126,11 +127,11 @@ void RunAction::EndOfRunAction(G4Run const*)
 
     if (transport_ && *transport_)
     {
-        diagnostics_->timer()->RecordActionTime(transport_->GetActionTime());
+        params_->timer()->record_action_time(transport_->GetActionTime());
     }
     if (init_shared_)
     {
-        diagnostics_->timer()->RecordTotalTime(get_transport_time_());
+        params_->timer()->record_total_time(get_transport_time_());
     }
 
     if (params_->mode() == SharedParams::Mode::enabled)

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -33,6 +33,7 @@ list(APPEND SOURCES
   SetupOptionsMessenger.cc
   SharedParams.cc
   SimpleOffload.cc
+  TimeOutput.cc
   UserActionIntegration.cc
   detail/GeantSimpleCaloSD.cc
   detail/IntegrationSingleton.cc

--- a/src/accel/FastSimulationIntegration.cc
+++ b/src/accel/FastSimulationIntegration.cc
@@ -8,7 +8,10 @@
 
 #include <G4Threading.hh>
 
+#include "corecel/sys/Stopwatch.hh"
+
 #include "ExceptionConverter.hh"
+#include "TimeOutput.hh"
 
 #include "detail/IntegrationSingleton.hh"
 
@@ -44,6 +47,8 @@ FastSimulationIntegration& FastSimulationIntegration::Instance()
  */
 void FastSimulationIntegration::BeginOfRunAction(G4Run const*)
 {
+    Stopwatch get_setup_time;
+
     auto& singleton = detail::IntegrationSingleton::instance();
 
     if (G4Threading::IsMasterThread())
@@ -60,6 +65,12 @@ void FastSimulationIntegration::BeginOfRunAction(G4Run const*)
 
         CELER_TRY_HANDLE(verify_fast_sim(),
                          ExceptionConverter{"celer.init.verify"});
+    }
+
+    if (G4Threading::IsMasterThread())
+    {
+        singleton.shared_params().timer()->record_setup_time(get_setup_time());
+        singleton.start_timer();
     }
 }
 

--- a/src/accel/FastSimulationIntegration.cc
+++ b/src/accel/FastSimulationIntegration.cc
@@ -69,7 +69,7 @@ void FastSimulationIntegration::BeginOfRunAction(G4Run const*)
 
     if (G4Threading::IsMasterThread())
     {
-        singleton.shared_params().timer()->record_setup_time(get_setup_time());
+        singleton.shared_params().timer()->RecordSetupTime(get_setup_time());
         singleton.start_timer();
     }
 }

--- a/src/accel/IntegrationBase.cc
+++ b/src/accel/IntegrationBase.cc
@@ -91,7 +91,7 @@ void IntegrationBase::EndOfRunAction(G4Run const*)
 
     if (G4Threading::IsMasterThread())
     {
-        singleton.shared_params().timer()->record_total_time(time);
+        singleton.shared_params().timer()->RecordTotalTime(time);
         singleton.finalize_shared_params();
     }
 }

--- a/src/accel/IntegrationBase.cc
+++ b/src/accel/IntegrationBase.cc
@@ -11,6 +11,7 @@
 #include "corecel/Assert.hh"
 
 #include "ExceptionConverter.hh"
+#include "TimeOutput.hh"
 
 #include "detail/IntegrationSingleton.hh"
 
@@ -82,11 +83,15 @@ void IntegrationBase::EndOfRunAction(G4Run const*)
 
     auto& singleton = IntegrationSingleton::instance();
 
+    // Record the run time
+    auto time = singleton.stop_timer();
+
     // Remove local transporter
     singleton.finalize_local_transporter();
 
     if (G4Threading::IsMasterThread())
     {
+        singleton.shared_params().timer()->record_total_time(time);
         singleton.finalize_shared_params();
     }
 }

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -73,6 +73,7 @@
 
 #include "AlongStepFactory.hh"
 #include "SetupOptions.hh"
+#include "TimeOutput.hh"
 
 #include "detail/OffloadWriter.hh"
 
@@ -273,6 +274,10 @@ SharedParams::SharedParams(SetupOptions const& options)
         output_reg_ = std::make_shared<OutputRegistry>();
         output_filename_ = options.output_file;
 
+        // Create the timing output
+        timer_
+            = std::make_shared<TimeOutput>(celeritas::get_geant_num_threads());
+
         if (!output_filename_.empty())
         {
             CELER_LOG(debug)
@@ -291,6 +296,7 @@ SharedParams::SharedParams(SetupOptions const& options)
                     "environ",
                     celeritas::environment()));
             output_reg_->insert(std::make_shared<BuildOutput>());
+            output_reg_->insert(timer_);
         }
 
         return;
@@ -719,6 +725,10 @@ void SharedParams::initialize_core(SetupOptions const& options)
     {
         options.add_user_actions(*params_);
     }
+
+    // Add timing output
+    timer_ = std::make_shared<TimeOutput>(this->num_streams());
+    output_reg_->insert(timer_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -30,6 +30,7 @@ struct SetupOptions;
 class StepCollector;
 class GeantGeoParams;
 class OutputRegistry;
+class TimeOutput;
 class GeantSd;
 
 //---------------------------------------------------------------------------//
@@ -131,6 +132,7 @@ class SharedParams
     using SPGeantSd = std::shared_ptr<GeantSd>;
     using SPOffloadWriter = std::shared_ptr<detail::OffloadWriter>;
     using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
+    using SPTimeOutput = std::shared_ptr<TimeOutput>;
     using SPState = std::shared_ptr<CoreStateInterface>;
     using SPConstGeantGeoParams = std::shared_ptr<GeantGeoParams const>;
     using BBox = BoundingBox<double>;
@@ -146,6 +148,9 @@ class SharedParams
 
     // Output registry
     inline SPOutputRegistry const& output_reg() const;
+
+    // Access the timer
+    inline SPTimeOutput const& timer() const;
 
     // Let LocalTransporter register the thread's state
     void set_state(unsigned int stream_id, SPState&&);
@@ -172,11 +177,12 @@ class SharedParams
     std::string output_filename_;
     SPOffloadWriter offload_writer_;
     std::vector<std::shared_ptr<CoreStateInterface>> states_;
+    SPOutputRegistry output_reg_;
+    SPTimeOutput timer_;
+    BBox bbox_;
 
     // Lazily created
-    SPOutputRegistry output_reg_;
     SPConstGeantGeoParams geant_geo_;
-    BBox bbox_;
 
     //// HELPER FUNCTIONS ////
 
@@ -260,6 +266,17 @@ auto SharedParams::output_reg() const -> SPOutputRegistry const&
 {
     CELER_EXPECT(*this);
     return output_reg_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access the timer.
+ */
+auto SharedParams::timer() const -> SPTimeOutput const&
+{
+    CELER_EXPECT(*this);
+    CELER_EXPECT(timer_);
+    return timer_;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/TimeOutput.cc
+++ b/src/accel/TimeOutput.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celer-g4/TimerOutput.cc
+//! \file accel/TimeOutput.cc
 //---------------------------------------------------------------------------//
-#include "TimerOutput.hh"
+#include "TimeOutput.hh"
 
 #include <nlohmann/json.hpp>
 
@@ -15,13 +15,11 @@
 
 namespace celeritas
 {
-namespace app
-{
 //---------------------------------------------------------------------------//
 /*!
  * Construct with number of threads.
  */
-TimerOutput::TimerOutput(size_type num_threads)
+TimeOutput::TimeOutput(size_type num_threads)
 {
     CELER_EXPECT(num_threads > 0);
 
@@ -33,7 +31,7 @@ TimerOutput::TimerOutput(size_type num_threads)
 /*!
  * Write output to the given JSON object.
  */
-void TimerOutput::output(JsonPimpl* j) const
+void TimeOutput::output(JsonPimpl* j) const
 {
     using json = nlohmann::json;
 
@@ -54,7 +52,7 @@ void TimerOutput::output(JsonPimpl* j) const
 /*!
  * Record the accumulated action times.
  */
-void TimerOutput::RecordActionTime(MapStrReal&& time)
+void TimeOutput::record_action_time(MapStrReal&& time)
 {
     size_type thread_id = get_geant_thread_id();
     CELER_ASSERT(thread_id < action_time_.size());
@@ -65,7 +63,7 @@ void TimerOutput::RecordActionTime(MapStrReal&& time)
 /*!
  * Record the time for the event.
  */
-void TimerOutput::RecordEventTime(real_type time)
+void TimeOutput::record_event_time(real_type time)
 {
     size_type thread_id = get_geant_thread_id();
     CELER_ASSERT(thread_id < event_time_.size());
@@ -74,11 +72,11 @@ void TimerOutput::RecordEventTime(real_type time)
 
 //---------------------------------------------------------------------------//
 /*!
- * Record the time for setup.
+ * Record the time for setting up Celeritas.
  *
  * This should be called once by the master thread.
  */
-void TimerOutput::RecordSetupTime(real_type time)
+void TimeOutput::record_setup_time(real_type time)
 {
     setup_time_ = time;
 }
@@ -89,11 +87,10 @@ void TimerOutput::RecordSetupTime(real_type time)
  *
  * This should be called once by the master thread.
  */
-void TimerOutput::RecordTotalTime(real_type time)
+void TimeOutput::record_total_time(real_type time)
 {
     total_time_ = time;
 }
 
 //---------------------------------------------------------------------------//
-}  // namespace app
 }  // namespace celeritas

--- a/src/accel/TimeOutput.cc
+++ b/src/accel/TimeOutput.cc
@@ -12,6 +12,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/io/JsonPimpl.hh"
 #include "geocel/GeantUtils.hh"
+#include "celeritas/Quantities.hh"
 
 namespace celeritas
 {
@@ -34,10 +35,12 @@ TimeOutput::TimeOutput(size_type num_threads)
 void TimeOutput::output(JsonPimpl* j) const
 {
     using json = nlohmann::json;
+    using TimeSecond = RealQuantity<units::Second>;
 
     auto obj = json::object();
 
     obj = {
+        {"_units", TimeSecond::unit_type::label()},
         {"_index", "thread"},
         {"actions", action_time_},
         {"events", event_time_},
@@ -52,7 +55,7 @@ void TimeOutput::output(JsonPimpl* j) const
 /*!
  * Record the accumulated action times.
  */
-void TimeOutput::record_action_time(MapStrReal&& time)
+void TimeOutput::RecordActionTime(MapStrReal&& time)
 {
     size_type thread_id = get_geant_thread_id();
     CELER_ASSERT(thread_id < action_time_.size());
@@ -63,7 +66,7 @@ void TimeOutput::record_action_time(MapStrReal&& time)
 /*!
  * Record the time for the event.
  */
-void TimeOutput::record_event_time(real_type time)
+void TimeOutput::RecordEventTime(real_type time)
 {
     size_type thread_id = get_geant_thread_id();
     CELER_ASSERT(thread_id < event_time_.size());
@@ -76,7 +79,7 @@ void TimeOutput::record_event_time(real_type time)
  *
  * This should be called once by the master thread.
  */
-void TimeOutput::record_setup_time(real_type time)
+void TimeOutput::RecordSetupTime(real_type time)
 {
     setup_time_ = time;
 }
@@ -87,7 +90,7 @@ void TimeOutput::record_setup_time(real_type time)
  *
  * This should be called once by the master thread.
  */
-void TimeOutput::record_total_time(real_type time)
+void TimeOutput::RecordTotalTime(real_type time)
 {
     total_time_ = time;
 }

--- a/src/accel/TimeOutput.hh
+++ b/src/accel/TimeOutput.hh
@@ -2,30 +2,28 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celer-g4/TimerOutput.hh
+//! \file accel/TimeOutput.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include <unordered_map>
 #include <vector>
-#include <G4Event.hh>
 
 #include "corecel/Types.hh"
 #include "corecel/io/OutputInterface.hh"
 
 namespace celeritas
 {
-namespace app
-{
 //---------------------------------------------------------------------------//
 /*!
  * Collect timing results and output at the end of a run.
  *
- * Setup time, total time, and time per event are always recorded. The
- * accumulated action times are recorded when running on the host or on the
- * device with synchronization enabled.
+ * Setup time and total time are always recorded. Event time is recorded of \c
+ * BeginOfEventAction and \c EndOfEventAction are called. The accumulated
+ * action times are recorded when running on the host or on the device with
+ * synchronization enabled.
  */
-class TimerOutput final : public OutputInterface
+class TimeOutput final : public OutputInterface
 {
   public:
     //!@{
@@ -34,8 +32,8 @@ class TimerOutput final : public OutputInterface
     //!@}
 
   public:
-    // Construct with number of threads
-    explicit TimerOutput(size_type num_threads);
+    // Construct with number of CPU threads
+    explicit TimeOutput(size_type num_threads);
 
     //!@{
     //! \name Output interface
@@ -49,16 +47,16 @@ class TimerOutput final : public OutputInterface
     //!@}
 
     // Record the accumulated action times
-    void RecordActionTime(MapStrReal&& time);
+    void record_action_time(MapStrReal&& time);
 
     // Record the time for the event
-    void RecordEventTime(real_type time);
+    void record_event_time(real_type time);
 
-    // Record the setup time
-    void RecordSetupTime(real_type time);
+    // Record the Celeritas setup time
+    void record_setup_time(real_type time);
 
     // Record the total time for the run
-    void RecordTotalTime(real_type time);
+    void record_total_time(real_type time);
 
   private:
     using VecReal = std::vector<real_type>;
@@ -70,5 +68,4 @@ class TimerOutput final : public OutputInterface
 };
 
 //---------------------------------------------------------------------------//
-}  // namespace app
 }  // namespace celeritas

--- a/src/accel/TimeOutput.hh
+++ b/src/accel/TimeOutput.hh
@@ -18,10 +18,12 @@ namespace celeritas
 /*!
  * Collect timing results and output at the end of a run.
  *
- * Setup time and total time are always recorded. Event time is recorded of \c
+ * Setup time and total time are always recorded. Event time is recorded if \c
  * BeginOfEventAction and \c EndOfEventAction are called. The accumulated
  * action times are recorded when running on the host or on the device with
  * synchronization enabled.
+ *
+ * All results are in units of seconds.
  */
 class TimeOutput final : public OutputInterface
 {
@@ -47,16 +49,16 @@ class TimeOutput final : public OutputInterface
     //!@}
 
     // Record the accumulated action times
-    void record_action_time(MapStrReal&& time);
+    void RecordActionTime(MapStrReal&& time);
 
     // Record the time for the event
-    void record_event_time(real_type time);
+    void RecordEventTime(real_type time);
 
     // Record the Celeritas setup time
-    void record_setup_time(real_type time);
+    void RecordSetupTime(real_type time);
 
     // Record the total time for the run
-    void record_total_time(real_type time);
+    void RecordTotalTime(real_type time);
 
   private:
     using VecReal = std::vector<real_type>;

--- a/src/accel/TrackingManagerIntegration.cc
+++ b/src/accel/TrackingManagerIntegration.cc
@@ -166,7 +166,7 @@ void TrackingManagerIntegration::BeginOfRunAction(G4Run const*)
 
     if (G4Threading::IsMasterThread())
     {
-        singleton.shared_params().timer()->record_setup_time(get_setup_time());
+        singleton.shared_params().timer()->RecordSetupTime(get_setup_time());
         singleton.start_timer();
     }
 }

--- a/src/accel/TrackingManagerIntegration.cc
+++ b/src/accel/TrackingManagerIntegration.cc
@@ -11,10 +11,12 @@
 #include <G4Threading.hh>
 
 #include "corecel/io/Join.hh"
+#include "corecel/sys/Stopwatch.hh"
 #include "corecel/sys/TypeDemangler.hh"
 #include "geocel/GeantUtils.hh"
 
 #include "ExceptionConverter.hh"
+#include "TimeOutput.hh"
 #include "TrackingManager.hh"
 #include "TrackingManagerConstructor.hh"
 
@@ -137,6 +139,8 @@ TrackingManagerIntegration& TrackingManagerIntegration::Instance()
  */
 void TrackingManagerIntegration::BeginOfRunAction(G4Run const*)
 {
+    Stopwatch get_setup_time;
+
     auto& singleton = detail::IntegrationSingleton::instance();
 
     if (G4Threading::IsMasterThread())
@@ -158,6 +162,12 @@ void TrackingManagerIntegration::BeginOfRunAction(G4Run const*)
                 singleton.shared_params(),
                 singleton.local_transporter()),
             ExceptionConverter{"celer.init.verify"});
+    }
+
+    if (G4Threading::IsMasterThread())
+    {
+        singleton.shared_params().timer()->record_setup_time(get_setup_time());
+        singleton.start_timer();
     }
 }
 

--- a/src/accel/UserActionIntegration.cc
+++ b/src/accel/UserActionIntegration.cc
@@ -48,7 +48,7 @@ void UserActionIntegration::BeginOfRunAction(G4Run const*)
 
     if (G4Threading::IsMasterThread())
     {
-        singleton.shared_params().timer()->record_setup_time(get_setup_time());
+        singleton.shared_params().timer()->RecordSetupTime(get_setup_time());
         singleton.start_timer();
     }
 }
@@ -117,7 +117,7 @@ void UserActionIntegration::EndOfEventAction(G4Event const*)
         ExceptionConverter("celer.event.flush", &singleton.shared_params()));
 
     // Record the time for this event
-    singleton.shared_params().timer()->record_event_time(get_event_time_());
+    singleton.shared_params().timer()->RecordEventTime(get_event_time_());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/UserActionIntegration.cc
+++ b/src/accel/UserActionIntegration.cc
@@ -10,7 +10,10 @@
 #include <G4Threading.hh>
 #include <G4Track.hh>
 
+#include "corecel/sys/Stopwatch.hh"
+
 #include "ExceptionConverter.hh"
+#include "TimeOutput.hh"
 
 #include "detail/IntegrationSingleton.hh"
 
@@ -32,6 +35,8 @@ UserActionIntegration& UserActionIntegration::Instance()
  */
 void UserActionIntegration::BeginOfRunAction(G4Run const*)
 {
+    Stopwatch get_setup_time;
+
     auto& singleton = detail::IntegrationSingleton::instance();
 
     if (G4Threading::IsMasterThread())
@@ -40,6 +45,12 @@ void UserActionIntegration::BeginOfRunAction(G4Run const*)
     }
 
     singleton.initialize_local_transporter();
+
+    if (G4Threading::IsMasterThread())
+    {
+        singleton.shared_params().timer()->record_setup_time(get_setup_time());
+        singleton.start_timer();
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -48,6 +59,8 @@ void UserActionIntegration::BeginOfRunAction(G4Run const*)
  */
 void UserActionIntegration::BeginOfEventAction(G4Event const* event)
 {
+    get_event_time_ = {};
+
     auto& local = detail::IntegrationSingleton::local_transporter();
     if (!local)
         return;
@@ -102,6 +115,9 @@ void UserActionIntegration::EndOfEventAction(G4Event const*)
     CELER_TRY_HANDLE(
         local.Flush(),
         ExceptionConverter("celer.event.flush", &singleton.shared_params()));
+
+    // Record the time for this event
+    singleton.shared_params().timer()->record_event_time(get_event_time_());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/UserActionIntegration.hh
+++ b/src/accel/UserActionIntegration.hh
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/sys/Stopwatch.hh"
+
 #include "IntegrationBase.hh"
 
 class G4Event;
@@ -63,6 +65,8 @@ class UserActionIntegration final : public IntegrationBase
   private:
     // Only allow the singleton to construct
     UserActionIntegration();
+
+    Stopwatch get_event_time_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/accel/detail/IntegrationSingleton.cc
+++ b/src/accel/detail/IntegrationSingleton.cc
@@ -12,10 +12,11 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/sys/ScopedMpiInit.hh"
 #include "accel/ExceptionConverter.hh"
 #include "accel/Logger.hh"
 #include "accel/SetupOptionsMessenger.hh"
-#include "corecel/sys/ScopedMpiInit.hh"
+#include "accel/TimeOutput.hh"
 
 namespace celeritas
 {
@@ -208,6 +209,7 @@ void IntegrationSingleton::finalize_local_transporter()
                            << "local thread "
                            << G4Threading::G4GetThreadId() + 1
                            << " cannot be finalized more than once");
+            params_.timer()->record_action_time(lt.GetActionTime());
             lt.Finalize();
         },
         ExceptionConverter("celer.finalize.local"));
@@ -227,6 +229,24 @@ void IntegrationSingleton::finalize_shared_params()
             params_.Finalize();
         },
         ExceptionConverter("celer.finalize.global"));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Start the timer.
+ */
+void IntegrationSingleton::start_timer()
+{
+    get_time_ = {};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Stop the timer and return the elapsed time.
+ */
+real_type IntegrationSingleton::stop_timer()
+{
+    return get_time_();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/detail/IntegrationSingleton.cc
+++ b/src/accel/detail/IntegrationSingleton.cc
@@ -209,7 +209,7 @@ void IntegrationSingleton::finalize_local_transporter()
                            << "local thread "
                            << G4Threading::G4GetThreadId() + 1
                            << " cannot be finalized more than once");
-            params_.timer()->record_action_time(lt.GetActionTime());
+            params_.timer()->RecordActionTime(lt.GetActionTime());
             lt.Finalize();
         },
         ExceptionConverter("celer.finalize.local"));
@@ -229,24 +229,6 @@ void IntegrationSingleton::finalize_shared_params()
             params_.Finalize();
         },
         ExceptionConverter("celer.finalize.global"));
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Start the timer.
- */
-void IntegrationSingleton::start_timer()
-{
-    get_time_ = {};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Stop the timer and return the elapsed time.
- */
-real_type IntegrationSingleton::stop_timer()
-{
-    return get_time_();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/detail/IntegrationSingleton.hh
+++ b/src/accel/detail/IntegrationSingleton.hh
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <memory>
+
+#include "corecel/sys/Stopwatch.hh"
 #include "accel/LocalTransporter.hh"
 #include "accel/SetupOptions.hh"
 #include "accel/SharedParams.hh"
@@ -83,6 +85,12 @@ class IntegrationSingleton
     // Destroy params
     void finalize_shared_params();
 
+    // Start the transport timer
+    void start_timer();
+
+    // Get the transport time
+    real_type stop_timer();
+
   private:
     // Only this class can construct
     IntegrationSingleton();
@@ -93,6 +101,7 @@ class IntegrationSingleton
     SharedParams params_;
     std::unique_ptr<ScopedMpiInit> scoped_mpi_;
     std::unique_ptr<SetupOptionsMessenger> messenger_;
+    Stopwatch get_time_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/accel/detail/IntegrationSingleton.hh
+++ b/src/accel/detail/IntegrationSingleton.hh
@@ -85,11 +85,11 @@ class IntegrationSingleton
     // Destroy params
     void finalize_shared_params();
 
-    // Start the transport timer
-    void start_timer();
+    // Start the transport timer [s]
+    void start_timer() { get_time_ = {}; }
 
-    // Get the transport time
-    real_type stop_timer();
+    // Stop the timer and return the elapsed time [s]
+    real_type stop_timer() { return get_time_(); }
 
   private:
     // Only this class can construct


### PR DESCRIPTION
This move the timer output class from celer-g4 to our accel library and adds timers to the integration classes.