### PR TITLE
Update and fix G4VG external integration

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -89,8 +89,8 @@ endif()
 if(CELERITAS_BUILTIN_G4VG)
   celer_fetch_external(
     G4VG
-    "https://github.com/celeritas-project/g4vg/releases/download/v1.0.3/g4vg-1.0.3.tar.gz"
-    6f0920a9ad2e04a701bec636f117d4093be1e50761f091ec507efd078b659bcd
+    "https://github.com/celeritas-project/g4vg/releases/download/v1.0.4/g4vg-1.0.4.tar.gz"
+    ac38878aedaf9fe628f498290cf4fa6cdd21980b7b83663ce8ef3c8f3ff31cb2
   )
   foreach(_var BUILD_TESTS DEBUG)
     set(G4VG_${_var} ${CELERITAS_${_var}})

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -93,7 +93,7 @@ if(CELERITAS_BUILTIN_G4VG)
     6f0920a9ad2e04a701bec636f117d4093be1e50761f091ec507efd078b659bcd
   )
   foreach(_var BUILD_TESTS DEBUG)
-    set(G4VG_${_var} CELERITAS_${_var})
+    set(G4VG_${_var} ${CELERITAS_${_var}})
   endforeach()
 endif()
 

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -90,7 +90,7 @@ list(APPEND CELERITAS_CMAKE_STRINGS "")
 # Save dependency versions as strings
 set(CUDA_VERSION_STRING "${CUDAToolkit_VERSION}")
 set(HIP_VERSION_STRING "${hip-lang_VERSION}")
-foreach(_pkg CLHEP CUDA HepMC3 HIP Geant4 ROOT Thrust VecGeom)
+foreach(_pkg CLHEP CUDA HepMC3 HIP Geant4 G4VG ROOT Thrust VecGeom)
   string(TOLOWER "${_pkg}" _lower)
   if(DEFINED ${_pkg}_VERSION_STRING)
     set(_value "${${_pkg}_VERSION_STRING}")

--- a/src/corecel/io/BuildOutput.cc
+++ b/src/corecel/io/BuildOutput.cc
@@ -72,13 +72,14 @@ void BuildOutput::output(JsonPimpl* j) const
     {                                                      \
         deps[#NAME] = std::string(cmake::LOWER##_version); \
     }
-            CO_ADD_COND_VERS(GEANT4, CLHEP, clhep);
-            CO_ADD_COND_VERS(GEANT4, Geant4, geant4);
             CO_ADD_COND_VERS(CUDA, CUDA, cuda);
             CO_ADD_COND_VERS(CUDA, Thrust, thrust);
+            CO_ADD_COND_VERS(GEANT4, CLHEP, clhep);
+            CO_ADD_COND_VERS(GEANT4, Geant4, geant4);
             CO_ADD_COND_VERS(HEPMC3, HepMC3, hepmc3);
             CO_ADD_COND_VERS(HIP, HIP, hip);
             CO_ADD_COND_VERS(ROOT, ROOT, root);
+            CO_ADD_COND_VERS(VECGEOM, G4VG, g4vg);
             CO_ADD_COND_VERS(VECGEOM, VecGeom, vecgeom);
 #undef CO_ADD_COND_VERS
             return deps;


### PR DESCRIPTION
When using G4VG as an "external", it was alway enabling debug and testing, which put an artifical GTest requirement on downstream systems.

This also updates the G4VG version to 1.0.4 which has a few minor RDC fixes and better version.

Finally, it adds build provenance to the config output.