### PR TITLE
Use programmatic optical counters instead of absurdly verbose printout

### DIFF
--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -65,7 +65,18 @@ Runner::Runner(RunnerInput const& old_inp)
 
     use_device_ = old_inp.use_device;
 
-    this->build_transporter_input(old_inp);
+    CELER_VALIDATE(old_inp.max_steps > 0,
+                   << "nonpositive max_steps=" << old_inp.max_steps);
+    transporter_input_ = std::make_shared<TransporterInput>();
+    transporter_input_->optical = std::move(loaded.problem.optical_collector);
+    transporter_input_->params = core_params_;
+
+    transporter_input_->max_steps = old_inp.max_steps;
+    transporter_input_->store_track_counts = old_inp.write_track_counts;
+    transporter_input_->store_step_times = old_inp.write_step_times;
+    transporter_input_->action_times = old_inp.action_times;
+    transporter_input_->log_progress = old_inp.log_progress;
+
     transporters_.resize(this->num_streams());
 
     CELER_ENSURE(core_params_);
@@ -159,24 +170,6 @@ auto Runner::get_action_times() const -> MapStrDouble
     }
 
     return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct transporter input parameters.
- */
-void Runner::build_transporter_input(RunnerInput const& inp)
-{
-    CELER_VALIDATE(inp.max_steps > 0,
-                   << "nonpositive max_steps=" << inp.max_steps);
-
-    transporter_input_ = std::make_shared<TransporterInput>();
-    transporter_input_->max_steps = inp.max_steps;
-    transporter_input_->store_track_counts = inp.write_track_counts;
-    transporter_input_->store_step_times = inp.write_step_times;
-    transporter_input_->action_times = inp.action_times;
-    transporter_input_->params = core_params_;
-    transporter_input_->log_progress = inp.log_progress;
 }
 
 //---------------------------------------------------------------------------//

--- a/app/celer-sim/Runner.hh
+++ b/app/celer-sim/Runner.hh
@@ -99,7 +99,6 @@ class Runner
 
     //// HELPER FUNCTIONS ////
 
-    void build_transporter_input(RunnerInput const&);
     TransporterBase& get_transporter(StreamId);
     TransporterBase const* get_transporter_ptr(StreamId) const;
 };

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -203,22 +203,34 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries) -> TransporterResult
     // Get optical counters
     if (optical_)
     {
-        auto counters
-            = optical_->exchange_counters(stepper_->sp_state()->aux());
+        auto& aux = stepper_->sp_state()->aux();
+        auto counters = optical_->exchange_counters(aux);
         auto const& gen = counters.generators;
 
-        OpticalCounts oc{
-            /* tracks = */ gen.photons,
-            /* generators = */ gen.cherenkov + gen.scintillation,
-            /* steps = */ counters.steps,
-            /* step_iters = */ counters.step_iters,
-            /* flushes = */ counters.flushes,
-        };
+        OpticalCounts oc;
+        oc.tracks = gen.photons;
+        oc.generators = gen.cherenkov + gen.scintillation;
+        oc.steps = counters.steps;
+        oc.step_iters = counters.step_iters;
+        oc.flushes = counters.flushes;
+
         CELER_LOG_LOCAL(debug)
             << "Tracked " << oc.tracks << " photons from " << oc.generators
             << " distributions for " << oc.steps << " steps, using "
             << counters.step_iters << " step iterations over " << oc.flushes
             << " flushes";
+
+        auto const& buffer_counts = optical_->buffer_counts(aux);
+        if (!buffer_counts.empty())
+        {
+            CELER_LOG_LOCAL(warning)
+                << "Not all optical photons were tracked "
+                   "at the end of the stepping loop: "
+                << buffer_counts.photons << " queued photons from "
+                << buffer_counts.cherenkov << " Cherenkov distributions and "
+                << buffer_counts.scintillation
+                << " scintillation distributions";
+        }
 
         result.num_optical = std::move(oc);
     }

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -25,6 +25,7 @@
 #include "celeritas/global/ActionSequence.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/Stepper.hh"
+#include "celeritas/optical/OpticalCollector.hh"
 #include "celeritas/phys/Model.hh"
 
 #include "StepTimer.hh"
@@ -59,7 +60,8 @@ TransporterBase::~TransporterBase() = default;
  */
 template<MemSpace M>
 Transporter<M>::Transporter(TransporterInput inp)
-    : max_steps_(inp.max_steps)
+    : optical_{std::move(inp.optical)}
+    , max_steps_(inp.max_steps)
     , num_streams_(inp.params->max_streams())
     , log_progress_(inp.log_progress)
     , store_track_counts_(inp.store_track_counts)
@@ -196,6 +198,29 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries) -> TransporterResult
         // Reset the state data for the next event if the stepping loop was
         // aborted early
         step.reset_state();
+    }
+
+    // Get optical counters
+    if (optical_)
+    {
+        auto counters
+            = optical_->exchange_counters(stepper_->sp_state()->aux());
+        auto const& gen = counters.generators;
+
+        OpticalCounts oc{
+            /* tracks = */ gen.photons,
+            /* generators = */ gen.cherenkov + gen.scintillation,
+            /* steps = */ counters.steps,
+            /* step_iters = */ counters.step_iters,
+            /* flushes = */ counters.flushes,
+        };
+        CELER_LOG_LOCAL(debug)
+            << "Tracked " << oc.tracks << " photons from " << oc.generators
+            << " distributions for " << oc.steps << " steps, using "
+            << counters.step_iters << " step iterations over " << oc.flushes
+            << " flushes";
+
+        result.num_optical = std::move(oc);
     }
 
     return result;

--- a/app/celer-sim/Transporter.hh
+++ b/app/celer-sim/Transporter.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/app/celer-sim/Transporter.hh
+++ b/app/celer-sim/Transporter.hh
@@ -24,6 +24,7 @@ struct Primary;
 template<MemSpace M>
 class Stepper;
 class CoreParams;
+class OpticalCollector;
 }  // namespace celeritas
 
 namespace celeritas
@@ -36,6 +37,7 @@ struct TransporterInput
 {
     // Stepper input
     std::shared_ptr<CoreParams const> params;
+    std::shared_ptr<OpticalCollector const> optical;
     bool action_times{false};  //!< Whether to synchronize device between
                                //!< actions for timing
 
@@ -55,6 +57,19 @@ struct TransporterInput
 };
 
 //---------------------------------------------------------------------------//
+//! Tallied optical photons
+struct OpticalCounts
+{
+    using size_type = std::size_t;
+
+    size_type steps{};
+    size_type tracks{};
+    size_type generators{};
+
+    size_type step_iters{};
+    size_type flushes{};
+};
+
 /*!
  * Tallied result and timing from transporting a single event.
  */
@@ -76,6 +91,9 @@ struct TransporterResult
     size_type num_tracks{};  //!< Total number of tracks
     size_type num_aborted{};  //!< Number of unconverged tracks
     size_type max_queued{};  //!< Maximum track initializer count
+
+    // Optical photons
+    std::optional<OpticalCounts> num_optical;
 };
 
 //---------------------------------------------------------------------------//
@@ -135,6 +153,10 @@ class Transporter final : public TransporterBase
 
   private:
     std::shared_ptr<Stepper<M>> stepper_;
+    std::shared_ptr<OpticalCollector const> optical_;
+
+    OpticalCounts optical_count_;
+
     size_type max_steps_;
     size_type num_streams_;
     size_type log_progress_;

--- a/src/celeritas/global/CoreState.hh
+++ b/src/celeritas/global/CoreState.hh
@@ -54,6 +54,9 @@ class CoreStateInterface
     //! Access auxiliary state data
     virtual AuxStateVec const& aux() const = 0;
 
+    //! Access mutable auxiliary state data
+    virtual AuxStateVec& aux() = 0;
+
   protected:
     CoreStateInterface() = default;
     CELER_DEFAULT_COPY_MOVE(CoreStateInterface);
@@ -138,7 +141,7 @@ class CoreState final : public CoreStateInterface
     AuxStateVec const& aux() const final { return aux_state_; }
 
     //! Access auxiliary state data (mutable)
-    AuxStateVec& aux() { return aux_state_; }
+    AuxStateVec& aux() final { return aux_state_; }
 
     // Convenience function to access auxiliary "collection group" data
     template<template<Ownership, MemSpace> class S>

--- a/src/celeritas/optical/OffloadData.hh
+++ b/src/celeritas/optical/OffloadData.hh
@@ -42,6 +42,17 @@ struct OpticalOffloadCounters
     size_type photons{0};
 };
 
+//! Cumulative statistics of optical tracking
+struct OpticalAccumStats
+{
+    using size_type = std::size_t;
+
+    OpticalOffloadCounters<size_type> generators;
+
+    size_type steps{0};
+    size_type step_iters{0};
+};
+
 //---------------------------------------------------------------------------//
 /*!
  * Setup options for optical generation.

--- a/src/celeritas/optical/OffloadData.hh
+++ b/src/celeritas/optical/OffloadData.hh
@@ -51,6 +51,7 @@ struct OpticalAccumStats
 
     size_type steps{0};
     size_type step_iters{0};
+    size_type flushes{0};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/OffloadData.hh
+++ b/src/celeritas/optical/OffloadData.hh
@@ -23,13 +23,23 @@ namespace celeritas
 /*!
  * Current sizes of the buffers of distribution data.
  *
- * These sizes are updated by value on the host at each core step.
+ * These sizes are updated by value on the host at each core step. To allow
+ * accumulation over many steps which each may have many photons, the type is
+ * templated.
  */
-struct OffloadBufferSize
+template<class T = ::celeritas::size_type>
+struct OpticalOffloadCounters
 {
+    using size_type = T;
+
+    //!@{
+    //! Number of generators
     size_type cherenkov{0};
     size_type scintillation{0};
-    size_type num_photons{0};
+    //!@}
+
+    //! Number of generated tracks
+    size_type photons{0};
 };
 
 //---------------------------------------------------------------------------//
@@ -108,6 +118,8 @@ struct OffloadPreStepData
  * indexed by the current buffer size plus the track slot ID. The data is
  * compacted at the end of each step by removing all invalid distributions. The
  * order of the distributions in the buffers is guaranteed to be reproducible.
+ *
+ * This class is attached to the core state using \c OpticalOffloadState .
  */
 template<Ownership W, MemSpace M>
 struct OffloadStateData

--- a/src/celeritas/optical/OffloadData.hh
+++ b/src/celeritas/optical/OffloadData.hh
@@ -40,6 +40,12 @@ struct OpticalOffloadCounters
 
     //! Number of generated tracks
     size_type photons{0};
+
+    //! True if any queued generators/tracks exist
+    CELER_FUNCTION bool empty() const
+    {
+        return cherenkov == 0 && scintillation == 0 && photons == 0;
+    }
 };
 
 //! Cumulative statistics of optical tracking

--- a/src/celeritas/optical/OpticalCollector.cc
+++ b/src/celeritas/optical/OpticalCollector.cc
@@ -158,4 +158,16 @@ OpticalAccumStats OpticalCollector::exchange_counters(AuxStateVec& aux) const
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Get info on the number of tracks in the buffer.
+ */
+auto OpticalCollector::buffer_counts(AuxStateVec const& aux) const
+    -> OpticalBufferSize const&
+{
+    auto& state = dynamic_cast<detail::OpticalOffloadStateBase const&>(
+        aux.at(this->offload_aux_id()));
+    return state.buffer_size;
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/optical/OpticalCollector.cc
+++ b/src/celeritas/optical/OpticalCollector.cc
@@ -7,6 +7,7 @@
 #include "OpticalCollector.hh"
 
 #include "corecel/data/AuxParamsRegistry.hh"
+#include "corecel/data/AuxStateVec.hh"
 #include "corecel/sys/ActionRegistry.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/track/TrackInitParams.hh"
@@ -143,6 +144,17 @@ AuxId OpticalCollector::offload_aux_id() const
 AuxId OpticalCollector::optical_aux_id() const
 {
     return launch_action_->aux_id();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get and reset cumulative statistics on optical generation from a state.
+ */
+OpticalAccumStats OpticalCollector::exchange_counters(AuxStateVec& aux) const
+{
+    auto& state = dynamic_cast<detail::OpticalOffloadStateBase&>(
+        aux.at(this->offload_aux_id()));
+    return std::exchange(state.accum, {});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/OpticalCollector.hh
+++ b/src/celeritas/optical/OpticalCollector.hh
@@ -68,6 +68,7 @@ class OpticalCollector
     using SPConstMaterial = std::shared_ptr<optical::MaterialParams const>;
     using SPConstScintillation
         = std::shared_ptr<optical::ScintillationParams const>;
+    using OpticalBufferSize = OpticalOffloadCounters<size_type>;
     //!@}
 
     struct Input
@@ -114,6 +115,9 @@ class OpticalCollector
 
     // Get and reset cumulative statistics on optical tracks from a state
     OpticalAccumStats exchange_counters(AuxStateVec& aux) const;
+
+    // Get queued buffer sizes
+    OpticalBufferSize const& buffer_counts(AuxStateVec const& aux) const;
 
   private:
     //// TYPES ////

--- a/src/celeritas/optical/OpticalCollector.hh
+++ b/src/celeritas/optical/OpticalCollector.hh
@@ -18,6 +18,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 class ActionRegistry;
+class AuxStateVec;
 class CoreParams;
 
 namespace optical
@@ -110,6 +111,9 @@ class OpticalCollector
 
     // Aux ID for optical state data
     AuxId optical_aux_id() const;
+
+    // Get and reset cumulative statistics on optical tracks from a state
+    OpticalAccumStats exchange_counters(AuxStateVec& aux) const;
 
   private:
     //// TYPES ////

--- a/src/celeritas/optical/detail/CherenkovGeneratorAction.cc
+++ b/src/celeritas/optical/detail/CherenkovGeneratorAction.cc
@@ -96,19 +96,19 @@ void CherenkovGeneratorAction::step_impl(CoreParams const& core_params,
     auto& optical_state
         = get<optical::CoreState<M>>(core_state.aux(), optical_id_);
 
-    auto& num_photons = optical_state.counters().num_initializers;
-    auto& num_new_photons = offload_state.buffer_size.num_photons;
+    auto& photons = optical_state.counters().num_initializers;
+    auto& num_new_photons = offload_state.buffer_size.photons;
 
-    if (num_photons + num_new_photons < auto_flush_)
+    if (photons + num_new_photons < auto_flush_)
         return;
 
     auto initializers_size = optical_state.ref().init.initializers.size();
-    CELER_VALIDATE(num_photons + num_new_photons <= initializers_size,
+    CELER_VALIDATE(photons + num_new_photons <= initializers_size,
                    << "insufficient capacity (" << initializers_size
                    << ") for optical photon initializers (total capacity "
                       "requirement of "
-                   << num_photons + num_new_photons << " and current size "
-                   << num_photons << ")");
+                   << photons + num_new_photons << " and current size "
+                   << photons << ")");
 
     auto& offload = offload_state.store.ref();
     auto& buffer_size = offload_state.buffer_size.cherenkov;
@@ -133,7 +133,7 @@ void CherenkovGeneratorAction::step_impl(CoreParams const& core_params,
                            << " Cherenkov photons from " << buffer_size
                            << " distributions";
 
-    num_photons += count;
+    photons += count;
     num_new_photons -= count;
     buffer_size = 0;
 }

--- a/src/celeritas/optical/detail/CherenkovGeneratorAction.cc
+++ b/src/celeritas/optical/detail/CherenkovGeneratorAction.cc
@@ -115,7 +115,6 @@ void CherenkovGeneratorAction::step_impl(CoreParams const& core_params,
     if (buffer_size == 0)
     {
         // No new cherenkov photons: perhaps tracks are all subluminal
-        CELER_LOG_LOCAL(debug) << "No Cherenkov photons to generate";
         return;
     }
 
@@ -128,10 +127,6 @@ void CherenkovGeneratorAction::step_impl(CoreParams const& core_params,
 
     // Generate the optical photon initializers from the distribution data
     this->generate(core_params, core_state);
-
-    CELER_LOG_LOCAL(debug) << "Generated " << count
-                           << " Cherenkov photons from " << buffer_size
-                           << " distributions";
 
     // Update cumulative statistics
     offload_state.accum.generators.cherenkov += buffer_size;

--- a/src/celeritas/optical/detail/CherenkovGeneratorAction.cc
+++ b/src/celeritas/optical/detail/CherenkovGeneratorAction.cc
@@ -133,6 +133,10 @@ void CherenkovGeneratorAction::step_impl(CoreParams const& core_params,
                            << " Cherenkov photons from " << buffer_size
                            << " distributions";
 
+    // Update cumulative statistics
+    offload_state.accum.generators.cherenkov += buffer_size;
+    offload_state.accum.generators.photons += count;
+
     photons += count;
     num_new_photons -= count;
     buffer_size = 0;

--- a/src/celeritas/optical/detail/CherenkovGeneratorExecutor.hh
+++ b/src/celeritas/optical/detail/CherenkovGeneratorExecutor.hh
@@ -35,7 +35,7 @@ struct CherenkovGeneratorExecutor
     NativeCRef<celeritas::optical::CherenkovData> const cherenkov;
     NativeRef<OffloadStateData> const offload_state;
     RefPtr<celeritas::optical::CoreStateData, MemSpace::native> optical_state;
-    OffloadBufferSize size;
+    OpticalOffloadCounters<> size;
     CoreStateCounters counters;
 
     //// FUNCTIONS ////

--- a/src/celeritas/optical/detail/CherenkovOffloadAction.cc
+++ b/src/celeritas/optical/detail/CherenkovOffloadAction.cc
@@ -101,7 +101,7 @@ void CherenkovOffloadAction::step_impl(CoreParams const& core_params,
 
     // Count the number of optical photons that would be generated from the
     // distributions created in this step
-    state.buffer_size.num_photons += count_num_photons(
+    state.buffer_size.photons += count_num_photons(
         buffer, start, buffer_size, core_state.stream_id());
 }
 

--- a/src/celeritas/optical/detail/CherenkovOffloadExecutor.hh
+++ b/src/celeritas/optical/detail/CherenkovOffloadExecutor.hh
@@ -30,7 +30,7 @@ struct CherenkovOffloadExecutor
     NativeCRef<celeritas::optical::MaterialParamsData> const material;
     NativeCRef<celeritas::optical::CherenkovData> const cherenkov;
     NativeRef<OffloadStateData> const state;
-    OffloadBufferSize size;
+    OpticalOffloadCounters<> size;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/detail/OffloadParams.hh
+++ b/src/celeritas/optical/detail/OffloadParams.hh
@@ -55,13 +55,24 @@ class OffloadParams final : public AuxParamsInterface,
 
 //---------------------------------------------------------------------------//
 /*!
- * Manage optical generation states.
+ * Manage counters for optical generation states.
+ */
+struct OpticalOffloadStateBase : public AuxStateInterface
+{
+    //! Buffer sizes to be sent to GPU
+    OpticalOffloadCounters<size_type> buffer_size;
+    //! Counts accumulated over the event for diagnostics
+    OpticalOffloadCounters<std::size_t> accum;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Store optical generation states in aux data.
  */
 template<MemSpace M>
-struct OpticalOffloadState : public AuxStateInterface
+struct OpticalOffloadState : public OpticalOffloadStateBase
 {
     CollectionStateStore<OffloadStateData, M> store;
-    OffloadBufferSize buffer_size;
 
     //! True if states have been allocated
     explicit operator bool() const { return static_cast<bool>(store); }

--- a/src/celeritas/optical/detail/OffloadParams.hh
+++ b/src/celeritas/optical/detail/OffloadParams.hh
@@ -62,7 +62,7 @@ struct OpticalOffloadStateBase : public AuxStateInterface
     //! Buffer sizes to be sent to GPU
     OpticalOffloadCounters<size_type> buffer_size;
     //! Counts accumulated over the event for diagnostics
-    OpticalOffloadCounters<std::size_t> accum;
+    OpticalAccumStats accum;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/detail/OpticalGenAlgorithms.cu
+++ b/src/celeritas/optical/detail/OpticalGenAlgorithms.cu
@@ -35,7 +35,7 @@ struct GetNumPhotons
     CELER_FUNCTION size_type
     operator()(celeritas::optical::GeneratorDistributionData const& data) const
     {
-        return data.num_photons;
+        return data.photons;
     }
 };
 

--- a/src/celeritas/optical/detail/OpticalGenAlgorithms.cu
+++ b/src/celeritas/optical/detail/OpticalGenAlgorithms.cu
@@ -35,7 +35,7 @@ struct GetNumPhotons
     CELER_FUNCTION size_type
     operator()(celeritas::optical::GeneratorDistributionData const& data) const
     {
-        return data.photons;
+        return data.num_photons;
     }
 };
 

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -229,6 +229,7 @@ void OpticalLaunchAction::execute_impl(CoreParams const&,
 
     // TODO: generation is done *outside* of the optical tracking loop;
     // once we move it inside, update the generation count in the loop here
+    // TODO: is this correct if we abort the tracking loop early?
     counters.num_generated = 0;
 }
 

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -234,6 +234,10 @@ void OpticalLaunchAction::execute_impl(CoreParams const&,
         CELER_LOG_LOCAL(debug) << "No optical steps taken";
     }
 
+    // Update statistics
+    offload_state.accum.steps += num_steps;
+    offload_state.accum.step_iters += num_step_iters;
+
     // TODO: generation is done *outside* of the optical tracking loop;
     // once we move it inside, update the generation count in the loop here
     counters.num_generated = 0;

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -222,18 +222,6 @@ void OpticalLaunchAction::execute_impl(CoreParams const&,
         }
     }
 
-    if (num_step_iters > 0)
-    {
-        CELER_LOG_LOCAL(debug)
-            << "Generated " << counters.num_generated
-            << " optical photons which completed " << num_steps
-            << " total steps over " << num_step_iters << " iterations";
-    }
-    else
-    {
-        CELER_LOG_LOCAL(debug) << "No optical steps taken";
-    }
-
     // Update statistics
     offload_state.accum.steps += num_steps;
     offload_state.accum.step_iters += num_step_iters;

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -237,6 +237,7 @@ void OpticalLaunchAction::execute_impl(CoreParams const&,
     // Update statistics
     offload_state.accum.steps += num_steps;
     offload_state.accum.step_iters += num_step_iters;
+    ++offload_state.accum.flushes;
 
     // TODO: generation is done *outside* of the optical tracking loop;
     // once we move it inside, update the generation count in the loop here

--- a/src/celeritas/optical/detail/OpticalLaunchAction.hh
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.hh
@@ -110,7 +110,7 @@ class OpticalLaunchAction : public AuxParamsInterface,
     void step(CoreParams const&, CoreStateDevice&) const final;
     //!@}
 
-    // TODO: local end run to flush initializers??
+    // TODO: local end event to flush initializers??
 
     //!@{
     //! \name Accessors

--- a/src/celeritas/optical/detail/ScintGeneratorAction.cc
+++ b/src/celeritas/optical/detail/ScintGeneratorAction.cc
@@ -96,7 +96,9 @@ void ScintGeneratorAction::step_impl(CoreParams const& core_params,
     auto& num_new_photons = offload_state.buffer_size.photons;
 
     if (photons + num_new_photons < auto_flush_)
+    {
         return;
+    }
 
     auto initializers_size = optical_state.ref().init.initializers.size();
     CELER_VALIDATE(photons + num_new_photons <= initializers_size,
@@ -125,6 +127,10 @@ void ScintGeneratorAction::step_impl(CoreParams const& core_params,
     CELER_LOG_LOCAL(debug) << "Generated " << count
                            << " Scintillation photons from " << buffer_size
                            << " distributions";
+
+    // Update cumulative statistics
+    offload_state.accum.generators.scintillation += buffer_size;
+    offload_state.accum.generators.photons += count;
 
     photons += count;
     num_new_photons -= count;

--- a/src/celeritas/optical/detail/ScintGeneratorAction.cc
+++ b/src/celeritas/optical/detail/ScintGeneratorAction.cc
@@ -92,19 +92,19 @@ void ScintGeneratorAction::step_impl(CoreParams const& core_params,
     auto& optical_state
         = get<optical::CoreState<M>>(core_state.aux(), optical_id_);
 
-    auto& num_photons = optical_state.counters().num_initializers;
-    auto& num_new_photons = offload_state.buffer_size.num_photons;
+    auto& photons = optical_state.counters().num_initializers;
+    auto& num_new_photons = offload_state.buffer_size.photons;
 
-    if (num_photons + num_new_photons < auto_flush_)
+    if (photons + num_new_photons < auto_flush_)
         return;
 
     auto initializers_size = optical_state.ref().init.initializers.size();
-    CELER_VALIDATE(num_photons + num_new_photons <= initializers_size,
+    CELER_VALIDATE(photons + num_new_photons <= initializers_size,
                    << "insufficient capacity (" << initializers_size
                    << ") for optical photon initializers (total capacity "
                       "requirement of "
-                   << num_photons + num_new_photons << " and current size "
-                   << num_photons << ")");
+                   << photons + num_new_photons << " and current size "
+                   << photons << ")");
 
     auto& offload = offload_state.store.ref();
     auto& buffer_size = offload_state.buffer_size.scintillation;
@@ -126,7 +126,7 @@ void ScintGeneratorAction::step_impl(CoreParams const& core_params,
                            << " Scintillation photons from " << buffer_size
                            << " distributions";
 
-    num_photons += count;
+    photons += count;
     num_new_photons -= count;
     buffer_size = 0;
 }

--- a/src/celeritas/optical/detail/ScintGeneratorAction.cc
+++ b/src/celeritas/optical/detail/ScintGeneratorAction.cc
@@ -124,10 +124,6 @@ void ScintGeneratorAction::step_impl(CoreParams const& core_params,
     // Generate the optical photon initializers from the distribution data
     this->generate(core_params, core_state);
 
-    CELER_LOG_LOCAL(debug) << "Generated " << count
-                           << " Scintillation photons from " << buffer_size
-                           << " distributions";
-
     // Update cumulative statistics
     offload_state.accum.generators.scintillation += buffer_size;
     offload_state.accum.generators.photons += count;

--- a/src/celeritas/optical/detail/ScintGeneratorExecutor.hh
+++ b/src/celeritas/optical/detail/ScintGeneratorExecutor.hh
@@ -34,7 +34,7 @@ struct ScintGeneratorExecutor
     NativeCRef<celeritas::optical::ScintillationData> const scintillation;
     NativeRef<OffloadStateData> const offload_state;
     RefPtr<celeritas::optical::CoreStateData, MemSpace::native> optical_state;
-    OffloadBufferSize size;
+    OpticalOffloadCounters<> size;
     CoreStateCounters counters;
 
     //// FUNCTIONS ////

--- a/src/celeritas/optical/detail/ScintOffloadAction.cc
+++ b/src/celeritas/optical/detail/ScintOffloadAction.cc
@@ -96,7 +96,7 @@ void ScintOffloadAction::step_impl(CoreParams const& core_params,
 
     // Count the number of optical photons that would be generated from the
     // distributions created in this step
-    state.buffer_size.num_photons += count_num_photons(
+    state.buffer_size.photons += count_num_photons(
         buffer, start, buffer_size, core_state.stream_id());
 }
 

--- a/src/celeritas/optical/detail/ScintOffloadExecutor.hh
+++ b/src/celeritas/optical/detail/ScintOffloadExecutor.hh
@@ -33,7 +33,7 @@ struct ScintOffloadExecutor
 
     NativeCRef<celeritas::optical::ScintillationData> const scintillation;
     NativeRef<OffloadStateData> const state;
-    OffloadBufferSize size;
+    OpticalOffloadCounters<> size;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -64,6 +64,7 @@ class LArSphereOffloadTest : public LArSphereBase
         size_type num_photons{0};
         OffloadResult cherenkov;
         OffloadResult scintillation;
+        OpticalAccumStats accum;
 
         // Step iteration at which the optical tracking loop launched
         size_type optical_launch_step{0};
@@ -143,6 +144,21 @@ void LArSphereOffloadTest::RunResult::print_expected() const
          << ";\n"
             "EXPECT_VEC_EQ(expected_scintillation_charge, "
             "result.scintillation.charge);\n"
+            "EXPECT_EQ("
+         << this->accum.steps
+         << ", result.accum.steps);\n"
+            "EXPECT_EQ("
+         << this->accum.step_iters
+         << ", result.accum.step_iters);\n"
+            "EXPECT_EQ("
+         << this->accum.generators.cherenkov
+         << ", result.accum.generators.cherenkov);\n"
+            "EXPECT_EQ("
+         << this->accum.generators.scintillation
+         << ", result.accum.generators.scintillation);\n"
+            "EXPECT_EQ("
+         << this->accum.generators.photons
+         << ", result.accum.generators.photons);\n"
             "/*** END CODE ***/\n";
 }
 
@@ -314,6 +330,8 @@ auto LArSphereOffloadTest::run(size_type num_primaries,
     get_result(result.cherenkov, state.cherenkov, sizes.cherenkov);
     get_result(result.scintillation, state.scintillation, sizes.scintillation);
     result.num_photons = sizes.photons;
+
+    result.accum = collector_->exchange_counters(step.sp_state()->aux());
 
     return result;
 }
@@ -511,6 +529,13 @@ TEST_F(LArSphereOffloadTest, scintillation_distributions)
     {
         EXPECT_EQ(1639326, result.scintillation.total_num_photons);
         EXPECT_EQ(53, result.scintillation.num_photons.size());
+
+        // No steps ran
+        EXPECT_EQ(0, result.accum.steps);
+        EXPECT_EQ(0, result.accum.step_iters);
+        EXPECT_EQ(0, result.accum.generators.cherenkov);
+        EXPECT_EQ(0, result.accum.generators.scintillation);
+        EXPECT_EQ(0, result.accum.generators.photons);
     }
     else
     {
@@ -544,6 +569,12 @@ TEST_F(LArSphereOffloadTest, host_generate_small)
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
+
+        EXPECT_EQ(1028, result.accum.steps);
+        EXPECT_EQ(33, result.accum.step_iters);
+        EXPECT_EQ(0, result.accum.generators.cherenkov);
+        EXPECT_EQ(2, result.accum.generators.scintillation);
+        EXPECT_EQ(1028, result.accum.generators.photons);
     }
     static char const* const expected_log_levels[]
         = {"status", "status", "debug", "debug", "debug", "debug"};
@@ -573,6 +604,12 @@ TEST_F(LArSphereOffloadTest, host_generate)
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
+
+        EXPECT_EQ(324193, result.accum.steps);
+        EXPECT_EQ(2, result.accum.step_iters);
+        EXPECT_EQ(4, result.accum.generators.cherenkov);
+        EXPECT_EQ(4, result.accum.generators.scintillation);
+        EXPECT_EQ(324193, result.accum.generators.photons);
     }
     static char const* const expected_log_levels[]
         = {"status", "status", "debug", "debug", "debug", "debug"};
@@ -593,6 +630,8 @@ TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_generate))
 
     ScopedLogStorer scoped_log_{&celeritas::self_logger()};
     auto result = this->run<MemSpace::device>(1, num_track_slots_, 16);
+    result.print_expected();
+
     static char const* const expected_log_levels[] = {"status", "status"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
 

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -273,7 +273,7 @@ auto LArSphereOffloadTest::run(size_type num_primaries,
     size_type step_iter = 1;
     while (count && step_iter++ < num_steps)
     {
-        if (!offload_state.buffer_size.num_photons)
+        if (!offload_state.buffer_size.photons)
         {
             result.optical_launch_step = step_iter;
 
@@ -313,7 +313,7 @@ auto LArSphereOffloadTest::run(size_type num_primaries,
     auto const& sizes = offload_state.buffer_size;
     get_result(result.cherenkov, state.cherenkov, sizes.cherenkov);
     get_result(result.scintillation, state.scintillation, sizes.scintillation);
-    result.num_photons = sizes.num_photons;
+    result.num_photons = sizes.photons;
 
     return result;
 }

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -566,9 +566,6 @@ TEST_F(LArSphereOffloadTest, host_generate_small)
     static char const* const expected_log_messages[] = {
         "Celeritas optical state initialization complete",
         "Celeritas core state initialization complete",
-        "No Cherenkov photons to generate",
-        "Generated 1028 Scintillation photons from 2 distributions",
-        R"(Generated 1028 optical photons which completed 1028 total steps over 33 iterations)",
         "Deallocating host core state (stream 0)"};
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
@@ -582,7 +579,7 @@ TEST_F(LArSphereOffloadTest, host_generate_small)
         EXPECT_EQ(1028, result.accum.generators.photons);
     }
     static char const* const expected_log_levels[]
-        = {"status", "status", "debug", "debug", "debug", "debug"};
+        = {"status", "status", "debug"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
 }
 
@@ -601,9 +598,6 @@ TEST_F(LArSphereOffloadTest, host_generate)
     static char const* const expected_log_messages[] = {
         "Celeritas optical state initialization complete",
         "Celeritas core state initialization complete",
-        "Generated 4258 Cherenkov photons from 4 distributions",
-        "Generated 319935 Scintillation photons from 4 distributions",
-        R"(Generated 324193 optical photons which completed 324193 total steps over 2 iterations)",
         "Deallocating host core state (stream 0)",
     };
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
@@ -618,7 +612,7 @@ TEST_F(LArSphereOffloadTest, host_generate)
         EXPECT_EQ(324193, result.accum.generators.photons);
     }
     static char const* const expected_log_levels[]
-        = {"status", "status", "debug", "debug", "debug", "debug"};
+        = {"status", "status", "debug"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
 
     EXPECT_EQ(2, result.optical_launch_step);

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -151,6 +151,9 @@ void LArSphereOffloadTest::RunResult::print_expected() const
          << this->accum.step_iters
          << ", result.accum.step_iters);\n"
             "EXPECT_EQ("
+         << this->accum.flushes
+         << ", result.accum.flushes);\n"
+            "EXPECT_EQ("
          << this->accum.generators.cherenkov
          << ", result.accum.generators.cherenkov);\n"
             "EXPECT_EQ("
@@ -533,6 +536,7 @@ TEST_F(LArSphereOffloadTest, scintillation_distributions)
         // No steps ran
         EXPECT_EQ(0, result.accum.steps);
         EXPECT_EQ(0, result.accum.step_iters);
+        EXPECT_EQ(16, result.accum.flushes);
         EXPECT_EQ(0, result.accum.generators.cherenkov);
         EXPECT_EQ(0, result.accum.generators.scintillation);
         EXPECT_EQ(0, result.accum.generators.photons);
@@ -572,6 +576,7 @@ TEST_F(LArSphereOffloadTest, host_generate_small)
 
         EXPECT_EQ(1028, result.accum.steps);
         EXPECT_EQ(33, result.accum.step_iters);
+        EXPECT_EQ(1, result.accum.flushes);
         EXPECT_EQ(0, result.accum.generators.cherenkov);
         EXPECT_EQ(2, result.accum.generators.scintillation);
         EXPECT_EQ(1028, result.accum.generators.photons);
@@ -607,6 +612,7 @@ TEST_F(LArSphereOffloadTest, host_generate)
 
         EXPECT_EQ(324193, result.accum.steps);
         EXPECT_EQ(2, result.accum.step_iters);
+        EXPECT_EQ(1, result.accum.flushes);
         EXPECT_EQ(4, result.accum.generators.cherenkov);
         EXPECT_EQ(4, result.accum.generators.scintillation);
         EXPECT_EQ(324193, result.accum.generators.photons);


### PR DESCRIPTION
Following on to #1705 (but to be merged first) this accumulates optical counters for user-facing statistics over the course of the simulation, rather than printing verbose log messages at every core step. It also prints out warnings at the end of the transport loop if some photons were never tracked (a "bug" [it's intentional for now in the celer-sim test] which we need to fix!)