### PR TITLE
Allow G4 applications to query celeritas offload mode

### DIFF
--- a/example/accel/simple-offload.cc
+++ b/example/accel/simple-offload.cc
@@ -107,7 +107,27 @@ class RunAction final : public G4UserRunAction
   public:
     void BeginOfRunAction(G4Run const* run) final
     {
-        UserActionIntegration::Instance().BeginOfRunAction(run);
+        auto& uai = UserActionIntegration::Instance();
+        uai.BeginOfRunAction(run);
+
+        // Demonstrate offload mode query
+        using Mode = celeritas::OffloadMode;
+        auto msg = CELER_LOG(info);
+        msg << "Celeritas is ";
+        switch (uai.GetMode())
+        {
+            case Mode::disabled:
+                msg << "disabled: only Geant4 is tracking";
+                break;
+            case Mode::kill_offload:
+                msg << "killing EM tracks";
+                break;
+            case Mode::enabled:
+                msg << "active: EM tracks are sent from Geant4";
+                break;
+            default:
+                msg << "misbehaving, mode is unexpected!";
+        }
     }
     void EndOfRunAction(G4Run const* run) final
     {

--- a/src/accel/IntegrationBase.cc
+++ b/src/accel/IntegrationBase.cc
@@ -21,6 +21,17 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Access whether celeritas is set up, enabled, or uninitialized.
+ *
+ * This can be alled at any time.
+ */
+OffloadMode IntegrationBase::GetMode() const
+{
+    return IntegrationSingleton::instance().shared_params().mode();
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Set options before starting the run.
  *
  * This captures the input to indicate that options cannot be modified after

--- a/src/accel/IntegrationBase.cc
+++ b/src/accel/IntegrationBase.cc
@@ -21,9 +21,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Access whether celeritas is set up, enabled, or uninitialized.
- *
- * This can be alled at any time.
+ * Access whether Celeritas is set up, enabled, or uninitialized.
  */
 OffloadMode IntegrationBase::GetMode() const
 {

--- a/src/accel/IntegrationBase.hh
+++ b/src/accel/IntegrationBase.hh
@@ -8,6 +8,8 @@
 
 #include "corecel/Macros.hh"
 
+#include "Types.hh"
+
 class G4Run;
 
 namespace celeritas
@@ -34,6 +36,9 @@ class CoreParams;
 class IntegrationBase
 {
   public:
+    // Access whether celeritas is set up, enabled, or uninitialized
+    OffloadMode GetMode() const;
+
     // Set options before starting the run
     void SetOptions(SetupOptions&& opts);
 

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -13,6 +13,8 @@
 #include "corecel/Assert.hh"
 #include "geocel/BoundingBox.hh"
 
+#include "Types.hh"
+
 class G4ParticleDefinition;
 class G4VPhysicalVolume;
 
@@ -62,17 +64,8 @@ class SharedParams
     using SPParams = std::shared_ptr<CoreParams>;
     using SPConstParams = std::shared_ptr<CoreParams const>;
     using VecG4ParticleDef = std::vector<G4ParticleDefinition*>;
+    using Mode = OffloadMode;
     //!@}
-
-    //! Setup for Celeritas usage
-    enum class Mode
-    {
-        uninitialized,
-        disabled,
-        kill_offload,
-        enabled,
-        size_
-    };
 
   public:
     //!@{

--- a/src/accel/Types.hh
+++ b/src/accel/Types.hh
@@ -1,0 +1,23 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/Types.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+//! Setup mode for Celeritas usage
+enum class OffloadMode
+{
+    uninitialized,  //!< Celeritas has not been initialized
+    disabled,  //!< Offload is disabled
+    kill_offload,  //!< Tracks are killed instead of offloaded
+    enabled,  //!< Celeritas setup is complete
+    size_
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas


### PR DESCRIPTION
This gives apps a quick and dirty way of finding out if celeritas is enabled or if it's killing tracks or if it's disabled. Needed for #1708 test.