### PR TITLE
Improve messages when multiple tracks fail in flight

### DIFF
--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -134,25 +134,14 @@ void KernelContextException::initialize(CoreTrackView const& core)
             }
             surface_ = geo.surface_id();
         }
-
-        if (!celeritas::getenv("CELERITAS_EXCEPTION_DEBUG").empty())
-        {
-            // This shouldn't *really* be necessary for full functionality of
-            // the exception, but adding a direct reference to the
-            // "debug_print" symbol allows it to be accessed in downstream
-            // frameworks that use Celeritas, even if they use LTO and
-            // -Wl,--exclude-libs,ALL
-            debug_print(core);
-        }
     }
     {
         // Construct std::exception message
         std::ostringstream os;
-        os << "kernel context: track slot " << track_slot_ << " in '" << label_
-           << "'";
+        os << "track slot " << track_slot_ << " in kernel '" << label_ << "'";
         if (track_)
         {
-            os << ", track " << track_ << " of event " << event_;
+            os << ": " << StreamableTrack{core};
         }
         what_ = os.str();
     }

--- a/src/corecel/io/LogContextException.cc
+++ b/src/corecel/io/LogContextException.cc
@@ -27,8 +27,7 @@ void LogContextException::operator()(std::exception_ptr eptr)
     }
     catch (RichContextException const& e)
     {
-        CELER_LOG_LOCAL(critical)
-            << "The following error is from: " << e.what();
+        CELER_LOG_LOCAL(critical) << "The following error is from " << e.what();
         try
         {
             std::rethrow_if_nested(e);

--- a/src/corecel/io/detail/LoggerMessage.hh
+++ b/src/corecel/io/detail/LoggerMessage.hh
@@ -30,7 +30,7 @@ class LoggerMessage
   public:
     //!@{
     //! \name Type aliases
-    using StreamManip = std::ostream& (*)(std::ostream&);
+    using StreamManip = std::ios_base& (*)(std::ios_base&);
     //!@}
 
   public:

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -118,17 +118,17 @@ TEST_F(KernelContextExceptionTest, typical)
     // Check for these values based on the step count and thread ID below
     this->check_kce = [&step](KernelContextException const& e) {
         auto simplified_str = StringSimplifier{3}(e.what());
-        if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
-        {
-            // NOTE: orange without geant4 uses a different volume name
-            simplified_str = std::regex_replace(
-                simplified_str, std::regex("@global"), "@world");
-        }
+        // Remove labels for reperoducibility
+        simplified_str = std::regex_replace(
+            simplified_str, std::regex("@(global|world)"), "");
 
-        EXPECT_EQ(
-            R"(track slot 15 in kernel 'test-kernel': {"geo":{"dir":[0.0,0.0,1.0],"is_on_boundary":true,"is_outside":false,"pos":[[0.0,1.0,5.0],"cm"],"volume_id":"world@world"},"mat":"hard vacuum","particle":{"energy":[10.0,"MeV"],"particle_id":"gamma"},"sim":{"along_step_action":"along-step-neutral","event_id":1,"num_steps":1,"parent_id":-1,"post_step_action":"geo-boundary","status":"alive","step_length":[5.0,"cm"],"time":[1.668e-10,"s"],"track_id":3},"thread_id":15,"track_slot_id":15})",
-            simplified_str)
-            << repr(simplified_str);
+        if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
+        {
+            EXPECT_EQ(
+                R"(track slot 15 in kernel 'test-kernel': {"geo":{"dir":[0.0,0.0,1.0],"is_on_boundary":true,"is_outside":false,"pos":[[0.0,1.0,5.0],"cm"],"volume_id":"world"},"mat":"hard vacuum","particle":{"energy":[10.0,"MeV"],"particle_id":"gamma"},"sim":{"along_step_action":"along-step-neutral","event_id":1,"num_steps":1,"parent_id":-1,"post_step_action":"geo-boundary","status":"alive","step_length":[5.0,"cm"],"time":[1.668e-10,"s"],"track_id":3},"thread_id":15,"track_slot_id":15})",
+                simplified_str)
+                << repr(simplified_str);
+        }
 
         EXPECT_EQ(find_thread(step.state_ref(), TrackSlotId{15}), e.thread());
         EXPECT_EQ(TrackSlotId{15}, e.track_slot());

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -6,13 +6,14 @@
 //---------------------------------------------------------------------------//
 #include "celeritas/global/KernelContextException.hh"
 
-#include <algorithm>
 #include <exception>
-#include <iterator>
+#include <regex>
 #include <sstream>
+#include <string>
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
+#include "corecel/StringSimplifier.hh"
 #include "corecel/io/JsonPimpl.hh"
 #include "geocel/UnitUtils.hh"
 #include "celeritas/SimpleTestBase.hh"
@@ -45,6 +46,7 @@ ThreadId find_thread(HostRef<CoreStateData> const& state, TrackSlotId track)
     CELER_EXPECT(state.track_slots.empty());
     return ThreadId{track.get()};
 }
+
 }  // namespace
 
 //---------------------------------------------------------------------------//
@@ -115,10 +117,18 @@ TEST_F(KernelContextExceptionTest, typical)
 
     // Check for these values based on the step count and thread ID below
     this->check_kce = [&step](KernelContextException const& e) {
-        EXPECT_STREQ(
-            "kernel context: track slot 15 in 'test-kernel', track 3 of event "
-            "1",
-            e.what());
+        auto simplified_str = StringSimplifier{3}(e.what());
+        if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
+        {
+            // NOTE: orange without geant4 uses a different volume name
+            simplified_str = std::regex_replace(
+                simplified_str, std::regex("@global"), "@world");
+        }
+
+        EXPECT_EQ(
+            R"(track slot 15 in kernel 'test-kernel': {"geo":{"dir":[0.0,0.0,1.0],"is_on_boundary":true,"is_outside":false,"pos":[[0.0,1.0,5.0],"cm"],"volume_id":"world@world"},"mat":"hard vacuum","particle":{"energy":[10.0,"MeV"],"particle_id":"gamma"},"sim":{"along_step_action":"along-step-neutral","event_id":1,"num_steps":1,"parent_id":-1,"post_step_action":"geo-boundary","status":"alive","step_length":[5.0,"cm"],"time":[1.668e-10,"s"],"track_id":3},"thread_id":15,"track_slot_id":15})",
+            simplified_str)
+            << repr(simplified_str);
 
         EXPECT_EQ(find_thread(step.state_ref(), TrackSlotId{15}), e.thread());
         EXPECT_EQ(TrackSlotId{15}, e.track_slot());
@@ -170,7 +180,7 @@ TEST_F(KernelContextExceptionTest, uninitialized_track)
     this->check_kce = [](KernelContextException const& e) {
         // Don't test this with vecgeom which has more assertions when
         // acquiring data
-        EXPECT_STREQ("kernel context: track slot 1 in 'test-kernel'", e.what());
+        EXPECT_STREQ("track slot 1 in kernel 'test-kernel'", e.what());
         EXPECT_EQ(TrackSlotId{1}, e.track_slot());
         EXPECT_EQ(EventId{}, e.event());
         EXPECT_EQ(TrackId{}, e.track());

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -187,10 +187,9 @@ TEST_F(SimpleComptonTest, fail_initialize)
 
         static char const* const expected_log_messages[] = {
             "Track started outside the geometry",
-            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[1001.0,0.0,0.0],"cm"]},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":15},"thread_id":31,"track_slot_id":31}: depositing 100 MeV)",
+            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[1001.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":15},"thread_id":31,"track_slot_id":31}: depositing 100 MeV)",
         };
-        if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
-            && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
+        if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
         {
             EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages());
         }
@@ -302,14 +301,13 @@ TEST_F(SimpleComptonTest, kill_active)
     counters = step();
     EXPECT_EQ(0, counters.alive);
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS
-        && CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
         && CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
         && CELERITAS_USE_GEANT4)
     {
         static char const* const expected_log_messages[] = {
             "Killing 2 active tracks",
-            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner@world"},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
-            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner@world"},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
+            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner@world"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
+            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner@world"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
         };
         EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages())
             << scoped_log;
@@ -408,14 +406,11 @@ TEST_F(BadGeometryTest, no_volume_host)
 {
     auto scoped_log = this->run_one_failure<MemSpace::host>({-5, 0, 0});
 
-    // clang-format off
     static char const* const expected_log_messages[] = {
-        "Failed to initialize geometry state: could not find associated volume in universe 0 at local position {-5, 0, 0}",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[-5.0,0.0,0.0],"cm"]},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Failed to initialize geometry state: could not find associated volume in universe 0 at local position {-5, 0, 0})",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[-5.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
-    // clang-format on
-    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
-        && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
+    if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
         EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages());
     }
@@ -430,11 +425,10 @@ TEST_F(BadGeometryTest, no_material_host)
 
     static char const* const expected_log_messages[] = {
         "Track started in an unknown material",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":false,"pos":[[5.0,0.0,0.0],"cm"],"volume_id":"[missing material]@world"},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: lost 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":false,"pos":[[5.0,0.0,0.0],"cm"],"volume_id":"[missing material]@world"},"mat":"<invalid>","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: lost 100 MeV)",
     };
 
-    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
-        && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
+    if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
         EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages());
     }
@@ -448,11 +442,10 @@ TEST_F(BadGeometryTest, no_new_volume_host)
     static char const* const expected_log_messages[] = {
         "track failed to cross local surface 2 in universe 0 at local "
         "position {-6, 0, 0} along local direction {1, 0, 0}",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":true,"pos":[[-6.0,0.0,0.0],"cm"]},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0010,"cm"],"time":[3.3356e-14,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":true,"pos":[[-6.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0010,"cm"],"time":[3.3356e-14,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
 
-    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
-        && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
+    if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
         EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages());
     }
@@ -466,11 +459,10 @@ TEST_F(BadGeometryTest, start_outside_host)
 
     static char const* const expected_log_messages[] = {
         "Track started outside the geometry",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[20.0,0.0,0.0],"cm"]},"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[20.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
 
-    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
-        && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
+    if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
         EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages());
     }

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -189,7 +189,8 @@ TEST_F(SimpleComptonTest, fail_initialize)
             "Track started outside the geometry",
             R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[1001.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":15},"thread_id":31,"track_slot_id":31}: depositing 100 MeV)",
         };
-        if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
+        if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
+            && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
         {
             EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages());
         }
@@ -301,6 +302,7 @@ TEST_F(SimpleComptonTest, kill_active)
     counters = step();
     EXPECT_EQ(0, counters.alive);
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS
+        && CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
         && CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
         && CELERITAS_USE_GEANT4)
     {
@@ -410,7 +412,8 @@ TEST_F(BadGeometryTest, no_volume_host)
         R"(Failed to initialize geometry state: could not find associated volume in universe 0 at local position {-5, 0, 0})",
         R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[-5.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
-    if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
+    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
+        && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
         EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages());
     }
@@ -445,7 +448,8 @@ TEST_F(BadGeometryTest, no_new_volume_host)
         R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":true,"pos":[[-6.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0010,"cm"],"time":[3.3356e-14,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
 
-    if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
+    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
+        && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
         EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages());
     }
@@ -462,7 +466,8 @@ TEST_F(BadGeometryTest, start_outside_host)
         R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[20.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
 
-    if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
+    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
+        && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
         EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages());
     }

--- a/test/corecel/sys/MultiExceptionHandler.test.cc
+++ b/test/corecel/sys/MultiExceptionHandler.test.cc
@@ -30,9 +30,9 @@ class MockContextException : public std::exception
 class MultiExceptionHandlerTest : public ::celeritas::test::Test
 {
   protected:
-    MultiExceptionHandlerTest() : store_log_(&celeritas::self_logger()) {}
+    MultiExceptionHandlerTest() : scoped_log_(&celeritas::self_logger()) {}
 
-    ScopedLogStorer store_log_;
+    ScopedLogStorer scoped_log_;
 };
 
 TEST_F(MultiExceptionHandlerTest, single)
@@ -59,18 +59,18 @@ TEST_F(MultiExceptionHandlerTest, multi)
     }
     EXPECT_THROW(log_and_rethrow(std::move(capture_exception)), RuntimeError);
 
-    static char const* const expected_messages[]
-        = {"ignoring exception: test.cc:0:\nceleritas: internal assertion "
-           "failed: false",
-           "ignoring exception: test.cc:1:\nceleritas: internal assertion "
-           "failed: false",
-           "ignoring exception: test.cc:2:\nceleritas: internal assertion "
-           "failed: false"};
-    EXPECT_VEC_EQ(expected_messages, store_log_.messages());
-
+    static char const* const expected_log_messages[] = {
+        R"(Suppressed exception from parallel thread: test.cc:0:
+celeritas: internal assertion failed: false)",
+        R"(Suppressed exception from parallel thread: test.cc:1:
+celeritas: internal assertion failed: false)",
+        R"(Suppressed exception from parallel thread: test.cc:2:
+celeritas: internal assertion failed: false)",
+    };
+    EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
     static char const* const expected_log_levels[]
         = {"critical", "critical", "critical"};
-    EXPECT_VEC_EQ(expected_log_levels, store_log_.levels());
+    EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
 }
 
 TEST_F(MultiExceptionHandlerTest, multi_nested)
@@ -81,16 +81,25 @@ TEST_F(MultiExceptionHandlerTest, multi_nested)
         capture_exception,
         MockContextException{});
     DebugErrorDetails deets{DebugErrorType::internal, "false", "test.cc", 2};
+    for (auto i = 0; i < 4; ++i)
+    {
     CELER_TRY_HANDLE_CONTEXT(throw DebugError(std::move(deets)),
                              capture_exception,
                              MockContextException{});
+    }
+
     EXPECT_THROW(log_and_rethrow(std::move(capture_exception)),
                  MockContextException);
 
-    static char const* const expected_messages[]
-        = {"ignoring exception: test.cc:2:\nceleritas: internal assertion "
-           "failed: false\n... from: some context"};
-    EXPECT_VEC_EQ(expected_messages, store_log_.messages());
+    static char const* const expected_log_messages[] = {
+        R"(Suppressed exception from parallel thread: test.cc:2:
+celeritas: internal assertion failed: false
+... from some context)",
+        "Suppressed 3 similar exceptions",
+    };
+    EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
+    static char const* const expected_log_levels[] = {"critical", "warning"};
+    EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
 }
 
 // Failure case can't be tested as part of the rest of the suite

--- a/test/corecel/sys/MultiExceptionHandler.test.cc
+++ b/test/corecel/sys/MultiExceptionHandler.test.cc
@@ -83,9 +83,9 @@ TEST_F(MultiExceptionHandlerTest, multi_nested)
     DebugErrorDetails deets{DebugErrorType::internal, "false", "test.cc", 2};
     for (auto i = 0; i < 4; ++i)
     {
-    CELER_TRY_HANDLE_CONTEXT(throw DebugError(std::move(deets)),
-                             capture_exception,
-                             MockContextException{});
+        CELER_TRY_HANDLE_CONTEXT(throw DebugError(std::move(deets)),
+                                 capture_exception,
+                                 MockContextException{});
     }
 
     EXPECT_THROW(log_and_rethrow(std::move(capture_exception)),


### PR DESCRIPTION
This improves messages from the multi exception handler, and for the particle debug output, so that we only have to see a few messages (if all tracks fail) rather than a thousand. It also prints the full track state. The debug track output now also prints the material that the track is in.

A new test helper class `StringSimplifier` combines the functionality of removing pointers and ANSI codes with the new ability to round floating point values to reduce the number of slight variants in output between systems.

Here, 1024 threads are failing in the same way. A single failure (on the first thread) is thrown at the end; and before it's thrown, all the other threads' debug messages are consolidated into a single output with a message about the suppression.
<img width="729" alt="Screenshot 2025-04-03 at 08 47 37" src="https://github.com/user-attachments/assets/90ad42c8-5213-4c82-9cf4-757499c1e0f1" />
