### PR TITLE
Remove dependency of orange test on celeritas

### DIFF
--- a/src/geocel/random/IsotropicDistribution.hh
+++ b/src/geocel/random/IsotropicDistribution.hh
@@ -8,11 +8,11 @@
 
 #include <cmath>
 
+#include "corecel/Constants.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "corecel/random/distribution/UniformRealDistribution.hh"
-#include "celeritas/Constants.hh"
 
 namespace celeritas
 {

--- a/src/geocel/random/UniformBoxDistribution.hh
+++ b/src/geocel/random/UniformBoxDistribution.hh
@@ -11,7 +11,6 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/random/distribution/UniformRealDistribution.hh"
-#include "celeritas/Constants.hh"
 
 namespace celeritas
 {

--- a/test/orange/CMakeLists.txt
+++ b/test/orange/CMakeLists.txt
@@ -144,7 +144,7 @@ celeritas_add_test(univ/detail/SenseCalculator.test.cc)
 if(_use_g4org)
   celeritas_add_test(g4org/Converter.test.cc)
   celeritas_add_test(g4org/SolidConverter.test.cc
-    LINK_LIBRARIES Celeritas::ExtGeant4Geo Celeritas::celeritas)
+    LINK_LIBRARIES Celeritas::ExtGeant4Geo)
   celeritas_add_test(g4org/PhysicalVolumeConverter.test.cc)
   celeritas_add_test(g4org/ProtoConstructor.test.cc)
   celeritas_add_test(g4org/Transformer.test.cc

--- a/test/orange/Orange.test.cc
+++ b/test/orange/Orange.test.cc
@@ -10,10 +10,10 @@
 
 #include "corecel/Constants.hh"
 #include "corecel/io/Label.hh"
+#include "geocel/Types.hh"
 #include "orange/OrangeParams.hh"
 #include "orange/OrangeTrackView.hh"
 #include "orange/OrangeTypes.hh"
-#include "celeritas/Types.hh"
 
 #include "OrangeGeoTestBase.hh"
 #include "TestMacros.hh"

--- a/test/orange/OrangeGeoTestBase.hh
+++ b/test/orange/OrangeGeoTestBase.hh
@@ -15,8 +15,8 @@
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/data/CollectionStateStore.hh"
+#include "geocel/Types.hh"
 #include "orange/OrangeData.hh"
-#include "celeritas/Types.hh"
 
 #include "OrangeTestBase.hh"
 #include "Test.hh"

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -16,7 +16,6 @@
 #include "orange/OrangeParams.hh"
 #include "orange/OrangeParamsOutput.hh"
 #include "orange/OrangeTrackView.hh"
-#include "celeritas/Types.hh"
 
 #include "OrangeGeoTestBase.hh"
 #include "TestMacros.hh"

--- a/test/orange/OrangeShift.test.cc
+++ b/test/orange/OrangeShift.test.cc
@@ -14,7 +14,6 @@
 #include "corecel/cont/Range.hh"
 #include "geocel/Types.hh"
 #include "orange/OrangeTrackView.hh"
-#include "celeritas/Types.hh"
 
 #include "OrangeGeoTestBase.hh"
 #include "TestMacros.hh"

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -11,8 +11,8 @@
 
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/CollectionMirror.hh"
+#include "geocel/Types.hh"
 #include "orange/detail/BIHData.hh"
-#include "celeritas/Types.hh"
 
 #include "celeritas_test.hh"
 

--- a/test/orange/detail/BIHEnclosingVolFinder.test.cc
+++ b/test/orange/detail/BIHEnclosingVolFinder.test.cc
@@ -8,9 +8,9 @@
 
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/CollectionMirror.hh"
+#include "geocel/Types.hh"
 #include "orange/detail/BIHBuilder.hh"
 #include "orange/detail/BIHData.hh"
-#include "celeritas/Types.hh"
 
 #include "celeritas_test.hh"
 

--- a/test/orange/detail/OrientedBoundingZone.test.cc
+++ b/test/orange/detail/OrientedBoundingZone.test.cc
@@ -11,8 +11,8 @@
 
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/Ref.hh"
+#include "geocel/Types.hh"
 #include "orange/detail/TransformRecordInserter.hh"
-#include "celeritas/Types.hh"
 
 #include "celeritas_test.hh"
 

--- a/test/orange/detail/UniverseIndexer.test.cc
+++ b/test/orange/detail/UniverseIndexer.test.cc
@@ -8,7 +8,7 @@
 
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/CollectionMirror.hh"
-#include "celeritas/Types.hh"
+#include "geocel/Types.hh"
 
 #include "celeritas_test.hh"
 

--- a/test/orange/orangeinp/CsgTestUtils.hh
+++ b/test/orange/orangeinp/CsgTestUtils.hh
@@ -8,8 +8,8 @@
 
 #include <string>
 
+#include "geocel/Types.hh"
 #include "orange/orangeinp/CsgTypes.hh"
-#include "celeritas/Types.hh"
 
 namespace celeritas
 {

--- a/test/orange/univ/RectArrayTracker.test.cc
+++ b/test/orange/univ/RectArrayTracker.test.cc
@@ -22,7 +22,6 @@
 #include "orange/OrangeGeoTestBase.hh"
 #include "orange/OrangeParams.hh"
 #include "orange/detail/UniverseIndexer.hh"
-#include "celeritas/Constants.hh"
 
 #include "SimpleUnitTracker.test.hh"
 #include "celeritas_test.hh"

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -23,7 +23,6 @@
 #include "orange/OrangeGeoTestBase.hh"
 #include "orange/OrangeParams.hh"
 #include "orange/detail/UniverseIndexer.hh"
-#include "celeritas/Constants.hh"
 
 #include "SimpleUnitTracker.test.hh"
 #include "celeritas_test.hh"


### PR DESCRIPTION
Because the RNGs lived downstream of ORANGE the test formerly had to link against the main celeritas library. After #1716 this is no longer needed. This also fixes the accidental use of `celeritas/` headers instead of `geocel` or `corecel`.