### PR TITLE
Add quick-start documentation for integrating

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,78 @@ If you need to set a default configuration
 $ spack install celeritas +cuda cuda_arch=80
 ```
 
-Then see the "Software library" section of the [installation
-documentation][install] for how to use Celeritas in your application or framework.
-
 [spack-start]: https://spack.readthedocs.io/en/latest/getting_started.html
 [install]: https://celeritas-project.github.io/celeritas/user/usage/installation.html
+
+# Integrating into a Geant4 app
+
+In the simplest case, integration requires a small change to your project's
+CMake file:
+```diff
++find_package(Celeritas 0.6 REQUIRED)
+ find_package(Geant4 REQUIRED)
+@@ -36,3 +37,4 @@ else()
+   add_executable(trackingmanager-offload trackingmanager-offload.cc)
+-  target_link_libraries(trackingmanager-offload
++  celeritas_target_link_libraries(trackingmanager-offload
++    Celeritas::accel
+     ${Geant4_LIBRARIES}
+```
+
+a few includes:
+```diff
+--- example/accel/trackingmanager-offload.cc
++++ example/accel/trackingmanager-offload.cc
+@@ -36,2 +36,10 @@
+
++// Celeritas
++#include <accel/AlongStepFactory.hh>
++#include <accel/SetupOptions.hh>
++#include <accel/TrackingManagerConstructor.hh>
++#include <accel/TrackingManagerIntegration.hh>
++
++using TMI = celeritas::TrackingManagerIntegration;
++
+ namespace
+```
+
+minor additions to the user actions:
+```diff
+--- example/accel/trackingmanager-offload.cc
++++ example/accel/trackingmanager-offload.cc
+@@ -134,2 +142,3 @@ class RunAction final : public G4UserRunAction
+     void BeginOfRunAction(G4Run const* run) final {
++        TMI::Instance().BeginOfRunAction(run);
+     }
+@@ -137,2 +146,3 @@ class RunAction final : public G4UserRunAction
+     void EndOfRunAction(G4Run const* run) final {
++        TMI::Instance().EndOfRunAction(run);
+     }
+@@ -179,2 +189,3 @@ class ActionInitialization final : public G4VUserActionInitialization
+      void BuildForMaster() const final {
++        TMI::Instance().BuildForMaster();
+     }
+@@ -185,2 +197,3 @@ class ActionInitialization final : public G4VUserActionInitialization
+     void Build() const final{
++        TMI::Instance().Build();
+     }
+```
+and addition to the physics list:
+```diff
+--- example/accel/trackingmanager-offload.cc
++++ example/accel/trackingmanager-offload.cc
+@@ -203,4 +235,8 @@ int main()
+
++    auto& tmi = TMI::Instance();
++
+     // Use FTFP_BERT, but use Celeritas tracking for e-/e+/g
+     auto* physics_list = new FTFP_BERT{/* verbosity = */ 0};
++    physics_list->RegisterPhysics(
++        new celeritas::TrackingManagerConstructor(&tmi));
+```
+
+See the "Software library" section of the [installation
+documentation][install] for details of using Celeritas in your application or framework.
 
 # Installation for developers
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,15 @@ $ spack install celeritas +cuda cuda_arch=80
 ```
 
 [spack-start]: https://spack.readthedocs.io/en/latest/getting_started.html
-[install]: https://celeritas-project.github.io/celeritas/user/usage/installation.html
 
 # Integrating into a Geant4 app
 
-In the simplest case, integration requires a small change to your project's
-CMake file:
+In the simplest case, integration requires a few small changes to your user
+applications, with many more details described in
+[integration overview][integration].
+
+You first need to find Celeritas in your project's CMake file, and change
+library calls to support VecGeom's use of CUDA RDC:
 ```diff
 +find_package(Celeritas 0.6 REQUIRED)
  find_package(Geant4 REQUIRED)
@@ -84,7 +87,7 @@ CMake file:
      ${Geant4_LIBRARIES}
 ```
 
-a few includes:
+A few includes expose Celeritas classes to the user code:
 ```diff
 --- example/accel/trackingmanager-offload.cc
 +++ example/accel/trackingmanager-offload.cc
@@ -101,7 +104,7 @@ a few includes:
  namespace
 ```
 
-minor additions to the user actions:
+Celeritas uses the build/run actions to set up and tear down cleanly:
 ```diff
 --- example/accel/trackingmanager-offload.cc
 +++ example/accel/trackingmanager-offload.cc
@@ -122,7 +125,9 @@ minor additions to the user actions:
 +        TMI::Instance().Build();
      }
 ```
-and addition to the physics list:
+
+And integrates into the tracking loop primarily using the `G4TrackingManager`
+interface:
 ```diff
 --- example/accel/trackingmanager-offload.cc
 +++ example/accel/trackingmanager-offload.cc
@@ -136,13 +141,13 @@ and addition to the physics list:
 +        new celeritas::TrackingManagerConstructor(&tmi));
 ```
 
-See the "Software library" section of the [installation
-documentation][install] for details of using Celeritas in your application or framework.
+
+[integration]: https://celeritas-project.github.io/celeritas/user/usage/integration.html
 
 # Installation for developers
 
-Since Celeritas is still under heavy development, you may be installing it
-for development purposes. The [installation documentation][install] has a
+Since Celeritas is still under very active development, you may be installing it
+for development purposes. The [installation documentation][installation] has a
 complete description of the code's dependencies and installation process for
 development.
 
@@ -203,8 +208,8 @@ other compilers *should* work.
 The full set of configurations is viewable on CI platform [GitHub Actions][gha]).
 Compatibility fixes that do not cause newer versions to fail are welcome.
 
+[installation]: https://celeritas-project.github.io/celeritas/user/usage/installation.html
 [spack]: https://github.com/spack/spack
-[install]: https://celeritas-project.github.io/celeritas/user/usage/installation.html
 [gha]: https://github.com/celeritas-project/celeritas/actions
 
 # Development

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ If you need to set a default configuration
 $ spack install celeritas +cuda cuda_arch=80
 ```
 
-
-Then see the "Downstream usage as a library" section of the [installation
+Then see the "Software library" section of the [installation
 documentation][install] for how to use Celeritas in your application or framework.
 
 [spack-start]: https://spack.readthedocs.io/en/latest/getting_started.html
@@ -75,9 +74,8 @@ documentation][install] for how to use Celeritas in your application or framewor
 
 # Installation for developers
 
-Since Celeritas is still under heavy development and is not yet full-featured
-for downstream integration, you are likely installing it for development
-purposes. The [installation documentation][install] has a
+Since Celeritas is still under heavy development, you may be installing it
+for development purposes. The [installation documentation][install] has a
 complete description of the code's dependencies and installation process for
 development.
 

--- a/doc/implementation/geant4-interface/setup.rst
+++ b/doc/implementation/geant4-interface/setup.rst
@@ -50,6 +50,8 @@ fields (see :ref:`api_accel_adapters`).
 
 .. doxygenclass:: celeritas::CylMapFieldAlongStepFactory
 
+.. _g4_ui_macros:
+
 Macro UI Options
 ----------------
 

--- a/doc/usage/integration.rst
+++ b/doc/usage/integration.rst
@@ -8,8 +8,15 @@
 Software library
 ================
 
-Using Celeritas in a downstream Geant4 application is meant to be as easy
-possible.
+The main current use case for Celeritas as a library is to integrate with user
+Geant4 applications. The interface for Geant4 integration is quite stable, and
+additional lower level code, described in :ref:`api`, is also stable.
+
+Usage overview
+--------------
+
+This describes the main points of integrating using the tracking interface,
+recommended for all applications that support Geant4 11.0 or higher.
 
 1. Find and link in your CMake project:
 
@@ -37,12 +44,6 @@ The changes for a simple application look like:
 
 .. literalinclude:: ../../example/accel/add-celer.diff
    :language: diff
-
-More details of integration are described below.
-
-The most stable part of Celeritas is the high-level :ref:`api_g4_interface`.
-Other components of the API are stable and documented in the :code:`api`
-section.
 
 CMake integration
 -----------------

--- a/doc/usage/integration.rst
+++ b/doc/usage/integration.rst
@@ -8,9 +8,41 @@
 Software library
 ================
 
-The most stable part of Celeritas is, at the present time, the high-level
-:ref:`api_g4_interface`. However, many other
-components of the API are stable and documented in the :code:`api` section.
+Using Celeritas in a downstream Geant4 application is meant to be as easy
+possible.
+
+1. Find and link in your CMake project:
+
+   - Find the Celeritas package.
+   - Link ``Celeritas::accel`` .
+   - Use ``celeritas_target_link_libraries`` instead of
+     ``target_link_libraries`` when both VecGeom and CUDA are enabled.
+
+2. Set up physics offloading in your "main" function.
+
+   - Register the ``TrackingManagerConstructor``, which tells Geant4 to send EM
+     tracks to Celeritas rather than the main tracking loop.
+   - Tweak the ``SetupOptions`` based on problem requirements, or use the
+     :ref:`g4_ui_macros`.
+
+3. Add hooks to safely set up and tear down Celeritas and its GPU code.
+
+   - Initialize logging in ``UserActionInitialization``, using
+     ``BuildForMaster`` (MT mode) or ``Build`` (serial).
+   - In ``UserRunAction``, ``BeginOfRunAction`` initializes problem data
+     (master or serial) and local state (worker or serial), and
+     ``EndOfRunAction`` safely deallocates everything.
+
+The changes for a simple application look like:
+
+.. literalinclude:: ../../example/accel/add-celer.diff
+   :language: diff
+
+More details of integration are described below.
+
+The most stable part of Celeritas is the high-level :ref:`api_g4_interface`.
+Other components of the API are stable and documented in the :code:`api`
+section.
 
 CMake integration
 -----------------
@@ -44,7 +76,8 @@ The special ``cuda_rdc_`` commands are needed when Celeritas is built with both
 CUDA and the current version of VecGeom, which uses a special but messy feature
 called CUDA Relocatable Device Code (RDC).
 As the ``cuda_rdc_...`` functions decay to the wrapped CMake commands if CUDA
-and VecGeom are disabled, you can directly use them to safely build and link nearly all targets
+and VecGeom are disabled, you can directly use them to safely build and link
+nearly all targets
 consuming Celeritas in your project, but the ``celeritas_`` versions will
 result in a slightly faster (and possibly safer) configuration when VecGeom or
 CUDA are disabled.
@@ -113,6 +146,9 @@ setting up:
 - "Global" data structures for shared problem data such as geometry (see
   :cpp:class:`celeritas::SharedParams`)
 - Per-worker (i.e., ``G4ThreadLocal`` using Geant4 manager/worker semantics)
-  data structures that hold the track states (see :cpp:class:`celeritas::LocalTransporter`).
+  data structures that hold the track states (see
+  :cpp:class:`celeritas::LocalTransporter`).
 
-See :ref:`example_geant` for examples of integrating Geant4, and :ref:`api_g4_interface` for detailed documentation of the Geant4 integration interface.
+See :ref:`example_geant` for examples of integrating Geant4, and
+:ref:`api_g4_interface` for detailed documentation of the Geant4 integration
+interface.

--- a/example/accel/CMakeLists.txt
+++ b/example/accel/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.18)
 project(CeleritasAccelExample VERSION 0.0.1 LANGUAGES CXX)
 cmake_policy(VERSION 3.12...3.30)
 
+find_package(Celeritas 0.6 REQUIRED)
 find_package(Geant4 REQUIRED)
 
 if(NOT CELERITAS_USE_Geant4)
@@ -34,7 +35,8 @@ if(Geant4_VERSION VERSION_LESS 11.0)
   message(WARNING "G4VTrackingManager offload requires Geant4 11.0 or higher")
 else()
   add_executable(trackingmanager-offload trackingmanager-offload.cc)
-  target_link_libraries(trackingmanager-offload
+  celeritas_target_link_libraries(trackingmanager-offload
+    Celeritas::accel
     ${Geant4_LIBRARIES}
   )
 endif()

--- a/example/accel/CMakeLists.txt
+++ b/example/accel/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.18)
 project(CeleritasAccelExample VERSION 0.0.1 LANGUAGES CXX)
 cmake_policy(VERSION 3.12...3.30)
 
-find_package(Celeritas 0.6 REQUIRED)
 find_package(Geant4 REQUIRED)
 
 if(NOT CELERITAS_USE_Geant4)
@@ -35,8 +34,7 @@ if(Geant4_VERSION VERSION_LESS 11.0)
   message(WARNING "G4VTrackingManager offload requires Geant4 11.0 or higher")
 else()
   add_executable(trackingmanager-offload trackingmanager-offload.cc)
-  celeritas_target_link_libraries(trackingmanager-offload
-    Celeritas::accel
+  target_link_libraries(trackingmanager-offload
     ${Geant4_LIBRARIES}
   )
 endif()

--- a/example/accel/add-celer.diff
+++ b/example/accel/add-celer.diff
@@ -1,0 +1,82 @@
+diff --git example/accel/CMakeLists.txt example/accel/CMakeLists.txt
+index 6534685d8..7f68a5f26 100644
+--- example/accel/CMakeLists.txt
++++ example/accel/CMakeLists.txt
+@@ -9,2 +9,3 @@ cmake_policy(VERSION 3.12...3.30)
+ 
++find_package(Celeritas 0.6 REQUIRED)
+ find_package(Geant4 REQUIRED)
+@@ -36,3 +37,4 @@ else()
+   add_executable(trackingmanager-offload trackingmanager-offload.cc)
+-  target_link_libraries(trackingmanager-offload
++  celeritas_target_link_libraries(trackingmanager-offload
++    Celeritas::accel
+     ${Geant4_LIBRARIES}
+diff --git example/accel/trackingmanager-offload.cc example/accel/trackingmanager-offload.cc
+index 8d25b1160..47fc4521e 100644
+--- example/accel/trackingmanager-offload.cc
++++ example/accel/trackingmanager-offload.cc
+@@ -36,2 +36,10 @@
+ 
++// Celeritas
++#include <accel/AlongStepFactory.hh>
++#include <accel/SetupOptions.hh>
++#include <accel/TrackingManagerConstructor.hh>
++#include <accel/TrackingManagerIntegration.hh>
++
++using TMI = celeritas::TrackingManagerIntegration;
++
+ namespace
+@@ -134,2 +142,3 @@ class RunAction final : public G4UserRunAction
+     {
++        TMI::Instance().BeginOfRunAction(run);
+     }
+@@ -137,2 +146,3 @@ class RunAction final : public G4UserRunAction
+     {
++        TMI::Instance().EndOfRunAction(run);
+     }
+@@ -179,2 +189,4 @@ class ActionInitialization final : public G4VUserActionInitialization
+     {
++        TMI::Instance().BuildForMaster();
++
+         CELER_LOG_LOCAL(status) << "Constructing user actions";
+@@ -185,2 +197,4 @@ class ActionInitialization final : public G4VUserActionInitialization
+     {
++        TMI::Instance().Build();
++
+         CELER_LOG_LOCAL(status) << "Constructing user actions";
+@@ -193,2 +207,20 @@ class ActionInitialization final : public G4VUserActionInitialization
+ 
++celeritas::SetupOptions MakeOptions()
++{
++    celeritas::SetupOptions opts;
++    // NOTE: these numbers are appropriate for CPU execution and can be set
++    // through the UI using `/celer/
++    opts.max_num_tracks = 2024;
++    opts.initializer_capacity = 2024 * 128;
++    // Celeritas does not support EmStandard MSC physics above 200 MeV
++    opts.ignore_processes = {"CoulombScat"};
++
++    // Use a uniform (zero) magnetic field
++    opts.make_along_step = celeritas::UniformAlongStepFactory();
++
++    // Save diagnostic file to a unique name
++    opts.output_file = "trackingmanager-offload.out.json";
++    return opts;
++}
++
+ //---------------------------------------------------------------------------//
+@@ -203,4 +235,8 @@ int main()
+ 
++    auto& tmi = TMI::Instance();
++
+     // Use FTFP_BERT, but use Celeritas tracking for e-/e+/g
+     auto* physics_list = new FTFP_BERT{/* verbosity = */ 0};
++    physics_list->RegisterPhysics(
++        new celeritas::TrackingManagerConstructor(&tmi));
+     run_manager->SetUserInitialization(physics_list);
+@@ -208,2 +244,4 @@ int main()
+ 
++    tmi.SetOptions(MakeOptions());
++
+     run_manager->Initialize();

--- a/example/accel/fastsim-offload.cc
+++ b/example/accel/fastsim-offload.cc
@@ -35,7 +35,7 @@
 #include <G4VUserDetectorConstruction.hh>
 #include <G4VUserPrimaryGeneratorAction.hh>
 #include <G4Version.hh>
-#if G4VERSION_NUMBER >= 1200
+#if G4VERSION_NUMBER >= 1100
 #    include <G4RunManagerFactory.hh>
 #else
 #    include <G4MTRunManager.hh>
@@ -182,7 +182,7 @@ celeritas::SetupOptions MakeOptions()
 int main()
 {
     auto run_manager = [] {
-#if G4VERSION_NUMBER >= 1200
+#if G4VERSION_NUMBER >= 1100
         return std::unique_ptr<G4RunManager>{
             G4RunManagerFactory::CreateRunManager()};
 #else

--- a/example/accel/fastsim-offload.cc
+++ b/example/accel/fastsim-offload.cc
@@ -170,7 +170,7 @@ celeritas::SetupOptions MakeOptions()
     opts.make_along_step = celeritas::UniformAlongStepFactory();
 
     // Export a GDML file with the problem setup and SDs
-    opts.geometry_output_file = "simple-example.gdml";
+    opts.geometry_output_file = "fastsim-offload.gdml";
     // Save diagnostic file to a unique name
     opts.output_file = "fastsim-offload.out.json";
     return opts;

--- a/example/accel/simple-offload.cc
+++ b/example/accel/simple-offload.cc
@@ -206,7 +206,16 @@ celeritas::SetupOptions MakeOptions()
     opts.ignore_processes = {"CoulombScat"};
 
     // Save GDML file
-    opts.geometry_output_file = "simple-offload.gdml";
+    if (G4VERSION_NUMBER >= 1070)
+    {
+        opts.geometry_output_file = "simple-offload.gdml";
+    }
+    else
+    {
+        CELER_LOG(info) << "Not setting simple offload: older versions of "
+                           "Geant4 may fail on CI due to files stepping on "
+                           "each other";
+    }
 
     opts.output_file = "simple-offload.out.json";
     return opts;

--- a/example/accel/simple-offload.cc
+++ b/example/accel/simple-offload.cc
@@ -32,7 +32,7 @@
 #include <G4VUserDetectorConstruction.hh>
 #include <G4VUserPrimaryGeneratorAction.hh>
 #include <G4Version.hh>
-#if G4VERSION_NUMBER >= 1200
+#if G4VERSION_NUMBER >= 1100
 #    include <G4RunManagerFactory.hh>
 #else
 #    include <G4MTRunManager.hh>
@@ -218,7 +218,7 @@ celeritas::SetupOptions MakeOptions()
 int main()
 {
     auto run_manager = [] {
-#if G4VERSION_NUMBER >= 1200
+#if G4VERSION_NUMBER >= 1100
         return std::unique_ptr<G4RunManager>{
             G4RunManagerFactory::CreateRunManager()};
 #else

--- a/example/accel/simple-offload.cc
+++ b/example/accel/simple-offload.cc
@@ -205,6 +205,9 @@ celeritas::SetupOptions MakeOptions()
     // Celeritas does not support EmStandard MSC physics above 200 MeV
     opts.ignore_processes = {"CoulombScat"};
 
+    // Save GDML file
+    opts.geometry_output_file = "simple-offload.gdml";
+
     opts.output_file = "simple-offload.out.json";
     return opts;
 }

--- a/example/accel/trackingmanager-offload.cc
+++ b/example/accel/trackingmanager-offload.cc
@@ -29,16 +29,16 @@
 #include <G4VUserPrimaryGeneratorAction.hh>
 #include <G4Version.hh>
 
-// Celeritas
-#include <accel/AlongStepFactory.hh>
-#include <accel/LocalTransporter.hh>
-#include <accel/SetupOptions.hh>
-#include <accel/SharedParams.hh>
-#include <accel/TrackingManagerConstructor.hh>
-#include <accel/TrackingManagerIntegration.hh>
+// Celeritas convenience utils
 #include <corecel/Assert.hh>
 #include <corecel/Macros.hh>
 #include <corecel/io/Logger.hh>
+
+// Celeritas
+#include <accel/AlongStepFactory.hh>
+#include <accel/SetupOptions.hh>
+#include <accel/TrackingManagerConstructor.hh>
+#include <accel/TrackingManagerIntegration.hh>
 
 using TMI = celeritas::TrackingManagerIntegration;
 
@@ -205,14 +205,11 @@ class ActionInitialization final : public G4VUserActionInitialization
     }
 };
 
-//---------------------------------------------------------------------------//
-/*!
- * Construct options for Celeritas.
- */
 celeritas::SetupOptions MakeOptions()
 {
     celeritas::SetupOptions opts;
-    // NOTE: these numbers are appropriate for CPU execution
+    // NOTE: these numbers are appropriate for CPU execution and can be set
+    // through the UI using `/celer/
     opts.max_num_tracks = 2024;
     opts.initializer_capacity = 2024 * 128;
     // Celeritas does not support EmStandard MSC physics above 200 MeV
@@ -221,8 +218,6 @@ celeritas::SetupOptions MakeOptions()
     // Use a uniform (zero) magnetic field
     opts.make_along_step = celeritas::UniformAlongStepFactory();
 
-    // Export a GDML file with the problem setup and SDs
-    opts.geometry_output_file = "simple-example.gdml";
     // Save diagnostic file to a unique name
     opts.output_file = "trackingmanager-offload.out.json";
     return opts;

--- a/example/accel/trackingmanager-offload.cc
+++ b/example/accel/trackingmanager-offload.cc
@@ -130,12 +130,8 @@ class PrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
 class RunAction final : public G4UserRunAction
 {
   public:
-    void BeginOfRunAction(G4Run const* run) final
-    {
-    }
-    void EndOfRunAction(G4Run const* run) final
-    {
-    }
+    void BeginOfRunAction(G4Run const* run) final {}
+    void EndOfRunAction(G4Run const* run) final {}
 };
 
 //---------------------------------------------------------------------------//

--- a/example/accel/trackingmanager-offload.cc
+++ b/example/accel/trackingmanager-offload.cc
@@ -34,14 +34,6 @@
 #include <corecel/Macros.hh>
 #include <corecel/io/Logger.hh>
 
-// Celeritas
-#include <accel/AlongStepFactory.hh>
-#include <accel/SetupOptions.hh>
-#include <accel/TrackingManagerConstructor.hh>
-#include <accel/TrackingManagerIntegration.hh>
-
-using TMI = celeritas::TrackingManagerIntegration;
-
 namespace
 {
 //---------------------------------------------------------------------------//
@@ -140,11 +132,9 @@ class RunAction final : public G4UserRunAction
   public:
     void BeginOfRunAction(G4Run const* run) final
     {
-        TMI::Instance().BeginOfRunAction(run);
     }
     void EndOfRunAction(G4Run const* run) final
     {
-        TMI::Instance().EndOfRunAction(run);
     }
 };
 
@@ -187,16 +177,12 @@ class ActionInitialization final : public G4VUserActionInitialization
   public:
     void BuildForMaster() const final
     {
-        TMI::Instance().BuildForMaster();
-
         CELER_LOG_LOCAL(status) << "Constructing user actions";
 
         this->SetUserAction(new RunAction{});
     }
     void Build() const final
     {
-        TMI::Instance().Build();
-
         CELER_LOG_LOCAL(status) << "Constructing user actions";
 
         this->SetUserAction(new PrimaryGeneratorAction{});
@@ -204,24 +190,6 @@ class ActionInitialization final : public G4VUserActionInitialization
         this->SetUserAction(new EventAction{});
     }
 };
-
-celeritas::SetupOptions MakeOptions()
-{
-    celeritas::SetupOptions opts;
-    // NOTE: these numbers are appropriate for CPU execution and can be set
-    // through the UI using `/celer/
-    opts.max_num_tracks = 2024;
-    opts.initializer_capacity = 2024 * 128;
-    // Celeritas does not support EmStandard MSC physics above 200 MeV
-    opts.ignore_processes = {"CoulombScat"};
-
-    // Use a uniform (zero) magnetic field
-    opts.make_along_step = celeritas::UniformAlongStepFactory();
-
-    // Save diagnostic file to a unique name
-    opts.output_file = "trackingmanager-offload.out.json";
-    return opts;
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace
@@ -233,16 +201,10 @@ int main()
 
     run_manager->SetUserInitialization(new DetectorConstruction{});
 
-    auto& tmi = TMI::Instance();
-
     // Use FTFP_BERT, but use Celeritas tracking for e-/e+/g
     auto* physics_list = new FTFP_BERT{/* verbosity = */ 0};
-    physics_list->RegisterPhysics(
-        new celeritas::TrackingManagerConstructor(&tmi));
     run_manager->SetUserInitialization(physics_list);
     run_manager->SetUserInitialization(new ActionInitialization());
-
-    tmi.SetOptions(MakeOptions());
 
     run_manager->Initialize();
 

--- a/example/accel/trackingmanager-offload.cc
+++ b/example/accel/trackingmanager-offload.cc
@@ -34,6 +34,14 @@
 #include <corecel/Macros.hh>
 #include <corecel/io/Logger.hh>
 
+// Celeritas
+#include <accel/AlongStepFactory.hh>
+#include <accel/SetupOptions.hh>
+#include <accel/TrackingManagerConstructor.hh>
+#include <accel/TrackingManagerIntegration.hh>
+
+using TMI = celeritas::TrackingManagerIntegration;
+
 namespace
 {
 //---------------------------------------------------------------------------//
@@ -130,8 +138,14 @@ class PrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction
 class RunAction final : public G4UserRunAction
 {
   public:
-    void BeginOfRunAction(G4Run const* run) final {}
-    void EndOfRunAction(G4Run const* run) final {}
+    void BeginOfRunAction(G4Run const* run) final
+    {
+        TMI::Instance().BeginOfRunAction(run);
+    }
+    void EndOfRunAction(G4Run const* run) final
+    {
+        TMI::Instance().EndOfRunAction(run);
+    }
 };
 
 //---------------------------------------------------------------------------//
@@ -173,12 +187,16 @@ class ActionInitialization final : public G4VUserActionInitialization
   public:
     void BuildForMaster() const final
     {
+        TMI::Instance().BuildForMaster();
+
         CELER_LOG_LOCAL(status) << "Constructing user actions";
 
         this->SetUserAction(new RunAction{});
     }
     void Build() const final
     {
+        TMI::Instance().Build();
+
         CELER_LOG_LOCAL(status) << "Constructing user actions";
 
         this->SetUserAction(new PrimaryGeneratorAction{});
@@ -186,6 +204,24 @@ class ActionInitialization final : public G4VUserActionInitialization
         this->SetUserAction(new EventAction{});
     }
 };
+
+celeritas::SetupOptions MakeOptions()
+{
+    celeritas::SetupOptions opts;
+    // NOTE: these numbers are appropriate for CPU execution and can be set
+    // through the UI using `/celer/
+    opts.max_num_tracks = 2024;
+    opts.initializer_capacity = 2024 * 128;
+    // Celeritas does not support EmStandard MSC physics above 200 MeV
+    opts.ignore_processes = {"CoulombScat"};
+
+    // Use a uniform (zero) magnetic field
+    opts.make_along_step = celeritas::UniformAlongStepFactory();
+
+    // Save diagnostic file to a unique name
+    opts.output_file = "trackingmanager-offload.out.json";
+    return opts;
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace
@@ -197,10 +233,16 @@ int main()
 
     run_manager->SetUserInitialization(new DetectorConstruction{});
 
+    auto& tmi = TMI::Instance();
+
     // Use FTFP_BERT, but use Celeritas tracking for e-/e+/g
     auto* physics_list = new FTFP_BERT{/* verbosity = */ 0};
+    physics_list->RegisterPhysics(
+        new celeritas::TrackingManagerConstructor(&tmi));
     run_manager->SetUserInitialization(physics_list);
     run_manager->SetUserInitialization(new ActionInitialization());
+
+    tmi.SetOptions(MakeOptions());
 
     run_manager->Initialize();
 

--- a/scripts/ci/test-examples.sh
+++ b/scripts/ci/test-examples.sh
@@ -49,14 +49,12 @@ if [ -z "${CELER_DISABLE_ACCEL_EXAMPLES}" ]; then
     echo "Set G4VERSION_NUMBER=\"${G4VERSION_NUMBER}\""
   fi
 
-  # Run small accel examples
+  # Run small accel examples, ensuring the documentation diff is still valid
   cd "${CELER_SOURCE_DIR}/example/accel"
-  build_local
-  ctest -V --no-tests=error
-
-  # Ensure the diff is still valid
   patch -p2 -R < add-celer.diff
   patch -p2 < add-celer.diff
+  build_local
+  ctest -V --no-tests=error
 
   if [ "${G4VERSION_NUMBER}" -ge 1100 ]; then
     # Run offload-template only on Geant4 v11

--- a/scripts/ci/test-examples.sh
+++ b/scripts/ci/test-examples.sh
@@ -54,6 +54,10 @@ if [ -z "${CELER_DISABLE_ACCEL_EXAMPLES}" ]; then
   build_local
   ctest -V --no-tests=error
 
+  # Ensure the diff is still valid
+  patch -p2 -R < add-celer.diff
+  patch -p2 < add-celer.diff
+
   if [ "${G4VERSION_NUMBER}" -ge 1100 ]; then
     # Run offload-template only on Geant4 v11
     cd "${CELER_SOURCE_DIR}/example/offload-template"


### PR DESCRIPTION
There was no simple consolidated explanation of adding Celeritas to a Geant4 app. This adds a small "diff" and explanation showing what needs to be added in the simple case, and a quick start in the README.