### PR TITLE
Fix failures when integral approach is disabled

### DIFF
--- a/src/celeritas/em/interactor/CombinedBremInteractor.hh
+++ b/src/celeritas/em/interactor/CombinedBremInteractor.hh
@@ -117,7 +117,6 @@ CombinedBremInteractor::CombinedBremInteractor(
     CELER_EXPECT(particle.particle_id() == shared.rb_data.ids.electron
                  || particle.particle_id() == shared.rb_data.ids.positron);
     CELER_EXPECT(gamma_cutoff_ > zero_quantity());
-    CELER_EXPECT(particle_.energy() > gamma_cutoff_);
 }
 
 //---------------------------------------------------------------------------//
@@ -127,6 +126,15 @@ CombinedBremInteractor::CombinedBremInteractor(
 template<class Engine>
 CELER_FUNCTION Interaction CombinedBremInteractor::operator()(Engine& rng)
 {
+    if (particle_.energy() <= gamma_cutoff_)
+    {
+        /*!
+         * \todo Remove and replace with an assertion once material-dependent
+         * model bounds are supported
+         */
+        return Interaction::from_unchanged();
+    }
+
     // Allocate space for the brems photon
     Secondary* secondaries = allocate_(1);
     if (secondaries == nullptr)

--- a/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
+++ b/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
@@ -103,8 +103,6 @@ CELER_FUNCTION MollerBhabhaInteractor::MollerBhabhaInteractor(
 {
     CELER_EXPECT(particle.particle_id() == shared_.ids.electron
                  || particle.particle_id() == shared_.ids.positron);
-    CELER_EXPECT(inc_energy_
-                 > (inc_particle_is_electron_ ? 2 : 1) * electron_cutoff_);
 }
 
 //---------------------------------------------------------------------------//
@@ -117,6 +115,15 @@ CELER_FUNCTION MollerBhabhaInteractor::MollerBhabhaInteractor(
 template<class Engine>
 CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
 {
+    if (inc_energy_ <= (inc_particle_is_electron_ ? 2 : 1) * electron_cutoff_)
+    {
+        /*!
+         * \todo Remove and replace with an assertion once material-dependent
+         * model bounds are supported
+         */
+        return Interaction::from_unchanged();
+    }
+
     // Allocate memory for the produced electron
     Secondary* electron_secondary = allocate_(1);
 

--- a/src/celeritas/em/interactor/SeltzerBergerInteractor.hh
+++ b/src/celeritas/em/interactor/SeltzerBergerInteractor.hh
@@ -127,8 +127,7 @@ CELER_FUNCTION SeltzerBergerInteractor::SeltzerBergerInteractor(
     CELER_EXPECT(particle.particle_id() == shared_.ids.electron
                  || particle.particle_id() == shared_.ids.positron);
     CELER_EXPECT(gamma_cutoff_ > zero_quantity());
-    CELER_EXPECT(inc_energy_ > gamma_cutoff_
-                 && inc_energy_ < shared_.high_energy_limit);
+    CELER_EXPECT(inc_energy_ < shared_.high_energy_limit);
 }
 
 //---------------------------------------------------------------------------//
@@ -140,6 +139,15 @@ CELER_FUNCTION SeltzerBergerInteractor::SeltzerBergerInteractor(
 template<class Engine>
 CELER_FUNCTION Interaction SeltzerBergerInteractor::operator()(Engine& rng)
 {
+    if (inc_energy_ <= gamma_cutoff_)
+    {
+        /*!
+         * \todo Remove and replace with an assertion once material-dependent
+         * model bounds are supported
+         */
+        return Interaction::from_unchanged();
+    }
+
     // Allocate space for the brems photon
     Secondary* secondaries = allocate_(1);
     if (secondaries == nullptr)

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -325,6 +325,7 @@ if(CELERITAS_USE_Geant4 AND CELERITAS_REAL_TYPE STREQUAL "double")
     "TestEm3NoMsc.*"
     "TestEm3Msc.*"
     "TestEm3MscNofluct.*"
+    "TestEm3MscNoIntegral.*"
     "TestEm15FieldMsc.*"
   )
   if(Geant4_VERSION VERSION_LESS 11.0)

--- a/test/celeritas/global/StepperGeant.test.cc
+++ b/test/celeritas/global/StepperGeant.test.cc
@@ -220,7 +220,7 @@ class TestEm15FieldMsc : public TestEm15Base, public StepperTestBase
 class TestEm3MscNoIntegral : public TestEm3Msc
 {
   public:
-    //! Make 100 MeV electrons along +x
+    //! Make 10 MeV electrons along +x
     std::vector<Primary> make_primaries(size_type count) const override
     {
         return this->make_primaries_with_energy(count, MevEnergy{10});

--- a/test/celeritas/global/StepperGeant.test.cc
+++ b/test/celeritas/global/StepperGeant.test.cc
@@ -662,8 +662,10 @@ TEST_F(TestEm3MscNoIntegral, host)
 
     if (this->is_ci_build())
     {
-        EXPECT_EQ(87, result.num_step_iters());
-        EXPECT_EQ(54.75, result.calc_avg_steps_per_primary());
+        EXPECT_LE(86, result.num_step_iters());
+        EXPECT_GE(87, result.num_step_iters());
+        EXPECT_LE(54.7, result.calc_avg_steps_per_primary());
+        EXPECT_GE(54.75, result.calc_avg_steps_per_primary());
         EXPECT_EQ(8, result.calc_emptying_step());
         EXPECT_EQ(RunResult::StepCount({6, 15}), result.calc_queue_hwm());
     }

--- a/test/celeritas/global/StepperGeant.test.cc
+++ b/test/celeritas/global/StepperGeant.test.cc
@@ -216,6 +216,32 @@ class TestEm15FieldMsc : public TestEm15Base, public StepperTestBase
 };
 
 //---------------------------------------------------------------------------//
+#define TestEm3MscNoIntegral TEST_IF_CELERITAS_GEANT(TestEm3MscNoIntegral)
+class TestEm3MscNoIntegral : public TestEm3Msc
+{
+  public:
+    //! Make 100 MeV electrons along +x
+    std::vector<Primary> make_primaries(size_type count) const override
+    {
+        return this->make_primaries_with_energy(count, MevEnergy{10});
+    }
+
+    ProcessBuilderOptions build_process_options() const override
+    {
+        ProcessBuilderOptions opts = TestEm3Base::build_process_options();
+        opts.brem_combined = false;
+        return opts;
+    }
+
+    GeantPhysicsOptions build_geant_options() const override
+    {
+        auto opts = TestEm3Base::build_geant_options();
+        opts.integral_approach = false;
+        return opts;
+    }
+};
+
+//---------------------------------------------------------------------------//
 #define OneSteelSphere TEST_IF_CELERITAS_GEANT(OneSteelSphere)
 class OneSteelSphere : public OneSteelSphereBase, public StepperTestBase
 {
@@ -608,6 +634,38 @@ TEST_F(TestEm3MscNofluct, TEST_IF_CELER_DEVICE(device))
         EXPECT_GE(48.25, result.calc_avg_steps_per_primary());
         EXPECT_EQ(7, result.calc_emptying_step());
         EXPECT_EQ(RunResult::StepCount({5, 7}), result.calc_queue_hwm());
+    }
+    else
+    {
+        cout << "No output saved for combination of "
+             << test::PrintableBuildConf{} << std::endl;
+        result.print_expected();
+
+        if (this->strict_testing())
+        {
+            FAIL() << "Updated stepper results are required for CI tests";
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+// TESTEM15_MSC_NOINTEGRAL
+//---------------------------------------------------------------------------//
+
+TEST_F(TestEm3MscNoIntegral, host)
+{
+    size_type num_primaries = 24;
+    size_type num_tracks = 2048;
+
+    Stepper<MemSpace::host> step(this->make_stepper_input(num_tracks));
+    auto result = this->run(step, num_primaries);
+
+    if (this->is_ci_build())
+    {
+        EXPECT_EQ(87, result.num_step_iters());
+        EXPECT_EQ(54.75, result.calc_avg_steps_per_primary());
+        EXPECT_EQ(8, result.calc_emptying_step());
+        EXPECT_EQ(RunResult::StepCount({6, 15}), result.calc_queue_hwm());
     }
     else
     {


### PR DESCRIPTION
When the integral approach is disabled, the pre-step cross section is used to sample the process, and because we don't yet have material-dependent model bounds a model could be selected even when the track's energy was below the model limit. I've added a basic stepper test as well to run with integral approach off since we weren't testing it previously.