### PR TITLE
Fix pedantic warning in tests

### DIFF
--- a/test/corecel/StringSimplifier.cc
+++ b/test/corecel/StringSimplifier.cc
@@ -43,7 +43,7 @@ void erase_exp_zeros(std::string& s)
     s.erase(exp_iter, end_iter);
 }
 
-};  // namespace
+}  // namespace
 //---------------------------------------------------------------------------//
 /*!
  * Simplify.


### PR DESCRIPTION
Semicolons after namespaces causes a build error when compiling with `-Werror=pedantic`.