### PR TITLE
Remove per-process switch for integral cross section method

### DIFF
--- a/src/celeritas/em/process/BremsstrahlungProcess.hh
+++ b/src/celeritas/em/process/BremsstrahlungProcess.hh
@@ -39,12 +39,10 @@ class BremsstrahlungProcess : public Process
     // TODO: update options based on ImportData
     struct Options
     {
-        bool combined_model{false};  //!> Use a unified relativistic/SB
-                                     //! interactor
-        bool enable_lpm{true};  //!> Account for LPM effect at very high
-                                //! energies
-        bool use_integral_xs{true};  //!> Use integral method for sampling
-                                     //! discrete interaction length
+        //! Use a unified relativistic/SB interactor
+        bool combined_model{false};
+        //! Account for LPM effect at very high energies
+        bool enable_lpm{true};
     };
 
   public:
@@ -61,8 +59,8 @@ class BremsstrahlungProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return options_.use_integral_xs; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return true; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return imported_.applies_at_rest(); }

--- a/src/celeritas/em/process/ComptonProcess.hh
+++ b/src/celeritas/em/process/ComptonProcess.hh
@@ -38,8 +38,8 @@ class ComptonProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applic) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return false; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return false; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return imported_.applies_at_rest(); }

--- a/src/celeritas/em/process/CoulombScatteringProcess.cc
+++ b/src/celeritas/em/process/CoulombScatteringProcess.cc
@@ -20,15 +20,13 @@ namespace celeritas
  */
 CoulombScatteringProcess::CoulombScatteringProcess(SPConstParticles particles,
                                                    SPConstMaterials materials,
-                                                   SPConstImported process_data,
-                                                   Options const& options)
+                                                   SPConstImported process_data)
     : particles_(std::move(particles))
     , materials_(std::move(materials))
     , imported_(process_data,
                 particles_,
                 ImportProcessClass::coulomb_scat,
                 {pdg::electron(), pdg::positron()})
-    , options_(options)
 {
     CELER_EXPECT(particles_);
     CELER_EXPECT(materials_);
@@ -61,16 +59,6 @@ auto CoulombScatteringProcess::step_limits(Applicability applic) const
 std::string_view CoulombScatteringProcess::label() const
 {
     return "Coulomb scattering";
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Whether to use the integral method to sample interaction length.
- * May be controlled via options provided in the constructor.
- */
-bool CoulombScatteringProcess::use_integral_xs() const
-{
-    return options_.use_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/CoulombScatteringProcess.hh
+++ b/src/celeritas/em/process/CoulombScatteringProcess.hh
@@ -32,18 +32,11 @@ class CoulombScatteringProcess : public Process
     using SPConstImported = std::shared_ptr<ImportedProcesses const>;
     //!@}
 
-    struct Options
-    {
-        //! Whether to use integral method to sample interaction length
-        bool use_integral_xs{true};
-    };
-
   public:
     //! Construct from Coulomb scattering data
     CoulombScatteringProcess(SPConstParticles particles,
                              SPConstMaterials materials,
-                             SPConstImported process_data,
-                             Options const& options);
+                             SPConstImported process_data);
 
     //! Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -51,8 +44,8 @@ class CoulombScatteringProcess : public Process
     //! Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final;
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return true; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return imported_.applies_at_rest(); }
@@ -64,7 +57,6 @@ class CoulombScatteringProcess : public Process
     SPConstParticles particles_;
     SPConstMaterials materials_;
     ImportedProcessAdapter imported_;
-    Options options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EIonizationProcess.cc
+++ b/src/celeritas/em/process/EIonizationProcess.cc
@@ -21,14 +21,12 @@ namespace celeritas
  * Construct process from host data.
  */
 EIonizationProcess::EIonizationProcess(SPConstParticles particles,
-                                       SPConstImported process_data,
-                                       Options options)
+                                       SPConstImported process_data)
     : particles_(std::move(particles))
     , imported_(process_data,
                 particles_,
                 ImportProcessClass::e_ioni,
                 {pdg::electron(), pdg::positron()})
-    , options_(options)
 {
     CELER_EXPECT(particles_);
 }

--- a/src/celeritas/em/process/EIonizationProcess.hh
+++ b/src/celeritas/em/process/EIonizationProcess.hh
@@ -28,18 +28,10 @@ class EIonizationProcess : public Process
     using SPConstImported = std::shared_ptr<ImportedProcesses const>;
     //!@}
 
-    // Options for electron and positron ionization
-    struct Options
-    {
-        bool use_integral_xs{true};  //!> Use integral method for sampling
-                                     //! discrete interaction length
-    };
-
   public:
     // Construct with imported data
     EIonizationProcess(SPConstParticles particles,
-                       SPConstImported process_data,
-                       Options options);
+                       SPConstImported process_data);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -47,8 +39,8 @@ class EIonizationProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applicability) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return options_.use_integral_xs; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return true; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return imported_.applies_at_rest(); }
@@ -59,7 +51,6 @@ class EIonizationProcess : public Process
   private:
     SPConstParticles particles_;
     ImportedProcessAdapter imported_;
-    Options options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.cc
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.cc
@@ -24,11 +24,9 @@ namespace celeritas
  * Construct from host data.
  */
 EPlusAnnihilationProcess::EPlusAnnihilationProcess(SPConstParticles particles,
-                                                   SPConstImported process_data,
-                                                   Options options)
+                                                   SPConstImported process_data)
     : particles_(std::move(particles))
     , positron_id_(particles_->find(pdg::positron()))
-    , options_(options)
     , applies_at_rest_(ImportedProcessAdapter(process_data,
                                               particles_,
                                               ImportProcessClass::annihilation,

--- a/src/celeritas/em/process/EPlusAnnihilationProcess.hh
+++ b/src/celeritas/em/process/EPlusAnnihilationProcess.hh
@@ -28,18 +28,10 @@ class EPlusAnnihilationProcess final : public Process
     using SPConstImported = std::shared_ptr<ImportedProcesses const>;
     //!@}
 
-    // Options for electron-positron annihilation
-    struct Options
-    {
-        bool use_integral_xs{true};  //!> Use integral method for sampling
-                                     //! discrete interaction length
-    };
-
   public:
     // Construct from particle data
     explicit EPlusAnnihilationProcess(SPConstParticles particles,
-                                      SPConstImported process_data,
-                                      Options options);
+                                      SPConstImported process_data);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -47,8 +39,8 @@ class EPlusAnnihilationProcess final : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return options_.use_integral_xs; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return true; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return applies_at_rest_; }
@@ -59,7 +51,6 @@ class EPlusAnnihilationProcess final : public Process
   private:
     SPConstParticles particles_;
     ParticleId positron_id_;
-    Options options_;
     bool applies_at_rest_;
 };
 

--- a/src/celeritas/em/process/GammaConversionProcess.hh
+++ b/src/celeritas/em/process/GammaConversionProcess.hh
@@ -31,7 +31,8 @@ class GammaConversionProcess : public Process
     // Options for pair production
     struct Options
     {
-        bool enable_lpm{true};  //!< Account for LPM effect at high energies
+        //! Account for LPM effect at high energies
+        bool enable_lpm{true};
     };
 
   public:
@@ -46,8 +47,8 @@ class GammaConversionProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applic) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return false; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return false; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return imported_.applies_at_rest(); }

--- a/src/celeritas/em/process/MuBremsstrahlungProcess.cc
+++ b/src/celeritas/em/process/MuBremsstrahlungProcess.cc
@@ -21,14 +21,12 @@ namespace celeritas
  * Construct from host data.
  */
 MuBremsstrahlungProcess::MuBremsstrahlungProcess(SPConstParticles particles,
-                                                 SPConstImported process_data,
-                                                 Options options)
+                                                 SPConstImported process_data)
     : particles_(std::move(particles))
     , imported_(process_data,
                 particles_,
                 ImportProcessClass::mu_brems,
                 {pdg::mu_minus(), pdg::mu_plus()})
-    , options_(options)
 {
     CELER_EXPECT(particles_);
 }

--- a/src/celeritas/em/process/MuBremsstrahlungProcess.hh
+++ b/src/celeritas/em/process/MuBremsstrahlungProcess.hh
@@ -29,18 +29,10 @@ class MuBremsstrahlungProcess : public Process
     using SPConstImported = std::shared_ptr<ImportedProcesses const>;
     //!@}
 
-    // Options for the Bremsstrahlung process
-    struct Options
-    {
-        bool use_integral_xs{true};  //!> Use integral method for sampling
-                                     //! discrete interaction length
-    };
-
   public:
     // Construct from Bremsstrahlung data
     MuBremsstrahlungProcess(SPConstParticles particles,
-                            SPConstImported process_data,
-                            Options options);
+                            SPConstImported process_data);
 
     // Construct the models associated with this process
     VecModel build_models(ActionIdIter start_id) const final;
@@ -48,8 +40,8 @@ class MuBremsstrahlungProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return options_.use_integral_xs; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return true; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return imported_.applies_at_rest(); }
@@ -60,7 +52,6 @@ class MuBremsstrahlungProcess : public Process
   private:
     SPConstParticles particles_;
     ImportedProcessAdapter imported_;
-    Options options_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/MuIonizationProcess.hh
+++ b/src/celeritas/em/process/MuIonizationProcess.hh
@@ -36,8 +36,6 @@ class MuIonizationProcess : public Process
         Energy bragg_icru73qo_upper_limit{0.2};  //!< 200 keV
         //! Maximum energy for the Bethe-Bloch model
         Energy bethe_bloch_upper_limit{1e3};  //!< 1 GeV
-        //! Use integral method for sampling discrete interaction length
-        bool use_integral_xs{true};
     };
 
   public:
@@ -52,8 +50,8 @@ class MuIonizationProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability applicability) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return options_.use_integral_xs; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return true; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return imported_.applies_at_rest(); }

--- a/src/celeritas/em/process/MuPairProductionProcess.cc
+++ b/src/celeritas/em/process/MuPairProductionProcess.cc
@@ -22,14 +22,12 @@ namespace celeritas
  */
 MuPairProductionProcess::MuPairProductionProcess(SPConstParticles particles,
                                                  SPConstImported process_data,
-                                                 Options options,
                                                  SPConstImportTable table)
     : particles_(std::move(particles))
     , imported_(process_data,
                 particles_,
                 ImportProcessClass::mu_pair_prod,
                 {pdg::mu_minus(), pdg::mu_plus()})
-    , options_(options)
     , table_(std::move(table))
 {
     CELER_EXPECT(particles_);

--- a/src/celeritas/em/process/MuPairProductionProcess.hh
+++ b/src/celeritas/em/process/MuPairProductionProcess.hh
@@ -32,18 +32,10 @@ class MuPairProductionProcess : public Process
         = std::shared_ptr<ImportMuPairProductionTable const>;
     //!@}
 
-    // Options for the pair production process
-    struct Options
-    {
-        bool use_integral_xs{true};  //!> Use integral method for sampling
-                                     //! discrete interaction length
-    };
-
   public:
     // Construct from pair production data
     MuPairProductionProcess(SPConstParticles particles,
                             SPConstImported process_data,
-                            Options options,
                             SPConstImportTable table);
 
     // Construct the models associated with this process
@@ -52,8 +44,8 @@ class MuPairProductionProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return options_.use_integral_xs; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return true; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return imported_.applies_at_rest(); }
@@ -64,7 +56,6 @@ class MuPairProductionProcess : public Process
   private:
     SPConstParticles particles_;
     ImportedProcessAdapter imported_;
-    Options options_;
     SPConstImportTable table_;
 };
 

--- a/src/celeritas/em/process/PhotoelectricProcess.hh
+++ b/src/celeritas/em/process/PhotoelectricProcess.hh
@@ -48,8 +48,8 @@ class PhotoelectricProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return false; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return false; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return imported_.applies_at_rest(); }

--- a/src/celeritas/em/process/RayleighProcess.hh
+++ b/src/celeritas/em/process/RayleighProcess.hh
@@ -42,8 +42,8 @@ class RayleighProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return false; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return false; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return imported_.applies_at_rest(); }

--- a/src/celeritas/inp/PhysicsProcess.hh
+++ b/src/celeritas/inp/PhysicsProcess.hh
@@ -26,8 +26,6 @@ struct BremsProcess
 
     //! Use a unified relativistic/SB interactor
     bool combined_model{false};
-    //! Use integral method for sampling discrete interaction length
-    bool integral_xs{true};
 };
 //---------------------------------------------------------------------------//
 /*!

--- a/src/celeritas/neutron/process/NeutronElasticProcess.hh
+++ b/src/celeritas/neutron/process/NeutronElasticProcess.hh
@@ -45,8 +45,8 @@ class NeutronElasticProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return false; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return false; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return false; }

--- a/src/celeritas/neutron/process/NeutronInelasticProcess.hh
+++ b/src/celeritas/neutron/process/NeutronInelasticProcess.hh
@@ -45,8 +45,8 @@ class NeutronInelasticProcess : public Process
     // Get the interaction cross sections for the given energy range
     StepLimitBuilders step_limits(Applicability range) const final;
 
-    //! Whether to use the integral method to sample interaction length
-    bool use_integral_xs() const final { return false; }
+    //! Whether the integral method can be used to sample interaction length
+    bool supports_integral_xs() const final { return false; }
 
     //! Whether the process applies when the particle is stopped
     bool applies_at_rest() const final { return false; }

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -570,7 +570,7 @@ void PhysicsParams::build_xs(Options const& opts,
             // Energy of maximum cross section for each material
             std::vector<real_type> energy_max_xs;
             bool use_integral_xs = !opts.disable_integral_xs
-                                   && proc.use_integral_xs();
+                                   && proc.supports_integral_xs();
             if (use_integral_xs)
             {
                 energy_max_xs.resize(mats.size());

--- a/src/celeritas/phys/Process.hh
+++ b/src/celeritas/phys/Process.hh
@@ -62,8 +62,8 @@ class Process
     //! Get the interaction cross sections for the given energy range
     virtual StepLimitBuilders step_limits(Applicability range) const = 0;
 
-    //! Whether to use the integral method to sample interaction length
-    virtual bool use_integral_xs() const = 0;
+    //! Whether the integral method can be used to sample interaction length
+    virtual bool supports_integral_xs() const = 0;
 
     //! Whether the process applies when the particle is stopped
     virtual bool applies_at_rest() const = 0;

--- a/src/celeritas/phys/ProcessBuilder.cc
+++ b/src/celeritas/phys/ProcessBuilder.cc
@@ -68,7 +68,6 @@ ProcessBuilder::ProcessBuilder(ImportData const& data,
     , user_build_map_(std::move(user_build))
     , brem_combined_(options.brem_combined)
     , enable_lpm_(data.em_params.lpm)
-    , use_integral_xs_(data.em_params.integral_approach)
 {
     CELER_EXPECT(input_.material);
     CELER_EXPECT(input_.particle);
@@ -164,11 +163,8 @@ auto ProcessBuilder::operator()(IPC ipc) -> SPProcess
 //---------------------------------------------------------------------------//
 auto ProcessBuilder::build_eioni() -> SPProcess
 {
-    EIonizationProcess::Options options;
-    options.use_integral_xs = use_integral_xs_;
-
-    return std::make_shared<EIonizationProcess>(
-        this->particle(), this->imported(), options);
+    return std::make_shared<EIonizationProcess>(this->particle(),
+                                                this->imported());
 }
 
 //---------------------------------------------------------------------------//
@@ -177,7 +173,6 @@ auto ProcessBuilder::build_ebrems() -> SPProcess
     BremsstrahlungProcess::Options options;
     options.combined_model = brem_combined_;
     options.enable_lpm = enable_lpm_;
-    options.use_integral_xs = use_integral_xs_;
 
     if (!read_sb_)
     {
@@ -238,51 +233,36 @@ auto ProcessBuilder::build_rayleigh() -> SPProcess
 //---------------------------------------------------------------------------//
 auto ProcessBuilder::build_annihilation() -> SPProcess
 {
-    EPlusAnnihilationProcess::Options options;
-    options.use_integral_xs = use_integral_xs_;
-
-    return std::make_shared<EPlusAnnihilationProcess>(
-        this->particle(), this->imported(), options);
+    return std::make_shared<EPlusAnnihilationProcess>(this->particle(),
+                                                      this->imported());
 }
 
 //---------------------------------------------------------------------------//
 auto ProcessBuilder::build_coulomb() -> SPProcess
 {
-    CoulombScatteringProcess::Options options;
-    options.use_integral_xs = use_integral_xs_;
-
     return std::make_shared<CoulombScatteringProcess>(
-        this->particle(), this->material(), this->imported(), options);
+        this->particle(), this->material(), this->imported());
 }
 
 //---------------------------------------------------------------------------//
 auto ProcessBuilder::build_mubrems() -> SPProcess
 {
-    MuBremsstrahlungProcess::Options options;
-    options.use_integral_xs = use_integral_xs_;
-
-    return std::make_shared<MuBremsstrahlungProcess>(
-        this->particle(), this->imported(), options);
+    return std::make_shared<MuBremsstrahlungProcess>(this->particle(),
+                                                     this->imported());
 }
 
 //---------------------------------------------------------------------------//
 auto ProcessBuilder::build_muioni() -> SPProcess
 {
-    MuIonizationProcess::Options options;
-    options.use_integral_xs = use_integral_xs_;
-
     return std::make_shared<MuIonizationProcess>(
-        this->particle(), this->imported(), options);
+        this->particle(), this->imported(), MuIonizationProcess::Options{});
 }
 
 //---------------------------------------------------------------------------//
 auto ProcessBuilder::build_mupairprod() -> SPProcess
 {
-    MuPairProductionProcess::Options options;
-    options.use_integral_xs = use_integral_xs_;
-
     return std::make_shared<MuPairProductionProcess>(
-        this->particle(), this->imported(), options, mu_pairprod_table_);
+        this->particle(), this->imported(), mu_pairprod_table_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/ProcessBuilder.hh
+++ b/src/celeritas/phys/ProcessBuilder.hh
@@ -112,7 +112,6 @@ class ProcessBuilder
 
     bool brem_combined_;
     bool enable_lpm_;
-    bool use_integral_xs_;
 
     //// HELPER FUNCTIONS ////
 

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -191,6 +191,7 @@ auto build_physics(inp::Problem const& p,
     }
     input.options.spline_eloss_order = p.physics.em->eloss_spline_order;
     input.options.linear_loss_limit = imported.em_params.linear_loss_limit;
+    input.options.disable_integral_xs = !imported.em_params.integral_approach;
     input.options.light.lowest_energy
         = ParticleOptions::Energy(imported.em_params.lowest_electron_energy);
     input.options.heavy.lowest_energy

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -158,7 +158,7 @@ auto MockTestBase::build_physics() -> SPConstPhysics
         inp.materials = this->material();
         inp.interact = interact;
         inp.label = "scattering";
-        inp.use_integral_xs = false;
+        inp.supports_integral_xs = false;
         inp.applic = {make_applicability("gamma", 1e-6, 100),
                       make_applicability("celeriton", 1, 100)};
         inp.xs = {Barn{1.0}, Barn{1.0}, Barn{1.0}};
@@ -170,7 +170,7 @@ auto MockTestBase::build_physics() -> SPConstPhysics
         inp.materials = this->material();
         inp.interact = interact;
         inp.label = "absorption";
-        inp.use_integral_xs = false;
+        inp.supports_integral_xs = false;
         inp.applic = {make_applicability("gamma", 1e-6, 100)};
         inp.xs = {Barn{2.0}, Barn{2.0}};
         inp.energy_loss = {};

--- a/test/celeritas/global/StepperGeant.test.cc
+++ b/test/celeritas/global/StepperGeant.test.cc
@@ -24,6 +24,7 @@
 #include "celeritas/global/Stepper.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"
+#include "celeritas/phys/PhysicsParams.hh"
 #include "celeritas/phys/Primary.hh"
 
 #include "StepperTestBase.hh"
@@ -233,10 +234,10 @@ class TestEm3MscNoIntegral : public TestEm3Msc
         return opts;
     }
 
-    GeantPhysicsOptions build_geant_options() const override
+    PhysicsParamsOptions build_physics_options() const override
     {
-        auto opts = TestEm3Base::build_geant_options();
-        opts.integral_approach = false;
+        auto opts = ImportedDataTestBase::build_physics_options();
+        opts.disable_integral_xs = true;
         return opts;
     }
 };

--- a/test/celeritas/phys/MockProcess.cc
+++ b/test/celeritas/phys/MockProcess.cc
@@ -89,9 +89,9 @@ auto MockProcess::step_limits(Applicability applic) const -> StepLimitBuilders
 }
 
 //---------------------------------------------------------------------------//
-bool MockProcess::use_integral_xs() const
+bool MockProcess::supports_integral_xs() const
 {
-    return data_.use_integral_xs;
+    return data_.supports_integral_xs;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/phys/MockProcess.hh
+++ b/test/celeritas/phys/MockProcess.hh
@@ -73,7 +73,7 @@ class MockProcess : public Process
     {
         SPConstMaterials materials;
         std::string label;
-        bool use_integral_xs{true};
+        bool supports_integral_xs{true};
         bool applies_at_rest{false};
         VecApplicability applic;  //!< Applicablity per model
         ModelCallback interact;  //!< MockModel::interact callback
@@ -86,7 +86,7 @@ class MockProcess : public Process
 
     VecModel build_models(ActionIdIter start_id) const final;
     StepLimitBuilders step_limits(Applicability range) const final;
-    bool use_integral_xs() const final;
+    bool supports_integral_xs() const final;
     bool applies_at_rest() const final;
     std::string_view label() const final;
 

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -847,11 +847,8 @@ auto EPlusAnnihilationTest::build_physics() -> SPConstPhysics
     physics_inp.options = this->build_physics_options();
     physics_inp.action_registry = this->action_reg().get();
 
-    EPlusAnnihilationProcess::Options epgg_options;
-    epgg_options.use_integral_xs = true;
-
     physics_inp.processes.push_back(std::make_shared<EPlusAnnihilationProcess>(
-        physics_inp.particles, this->build_imported(), epgg_options));
+        physics_inp.particles, this->build_imported()));
     return std::make_shared<PhysicsParams>(std::move(physics_inp));
 }
 


### PR DESCRIPTION
This removes the option to disable the integral approach on a per-process basis. We're unlikely to need this kind of granularity, and the functionality wasn't exposed to users anyway.