### PR TITLE
Add utilities to stabilize downstream use of ORANGE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ celeritas_optional_package(VecGeom "Use VecGeom geometry")
 option(CELERITAS_USE_Perfetto "Perfetto tracing library" OFF)
 
 # Components
+option(CELERITAS_BUILD_APPS "Build Celeritas executables (strongly recommended)" ON)
 option(CELERITAS_BUILD_DOCS "Build Celeritas documentation" OFF)
 option(CELERITAS_BUILD_TESTS "Build Celeritas unit tests" OFF)
 
@@ -82,6 +83,10 @@ if(CELERITAS_BUILD_TESTS)
   )
   mark_as_advanced(CELERITAS_TEST_XML)
 endif()
+
+# Automatic options
+set(CELERITAS_USE_CLI11 ${CELERITAS_BUILD_APPS})
+set(CELERITAS_USE_GTest ${CELERITAS_BUILD_TESTS})
 
 #----------------------------------------------------------------------------#
 # CELERITAS CORE IMPLEMENTATION OPTIONS
@@ -283,7 +288,9 @@ set(CELERITAS_RUNTIME_OUTPUT_DIRECTORY
 
 include(CeleritasUtils)
 
-celeritas_find_or_builtin_package(CLI11 2.4)
+if(CELERITAS_USE_CLI11)
+  celeritas_find_or_builtin_package(CLI11 2.4)
+endif()
 
 if(BUILD_TESTING)
   # Build the test tree for unit and/or app tests
@@ -497,7 +504,7 @@ if(CELERITAS_BUILD_DOCS)
   include(ExternalProject)
 endif()
 
-if(CELERITAS_BUILD_TESTS)
+if(CELERITAS_USE_GTest)
   celeritas_find_or_builtin_package(GTest 1.10)
 endif()
 
@@ -559,10 +566,12 @@ if(CELERITAS_BUILD_TESTS)
 endif()
 
 #----------------------------------------------------------------------------#
-# APPLICATIONS AND BINARIES
+# APPLICATIONS AND USER EXECUTABLES
 #----------------------------------------------------------------------------#
 
-add_subdirectory(app)
+if(CELERITAS_BUILD_APPS)
+  add_subdirectory(app)
+endif()
 
 #----------------------------------------------------------------------------#
 # DOCUMENTATION

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -155,7 +155,7 @@ bool Device::async()
 {
     if constexpr (CELER_STREAM_SUPPORTS_ASYNC)
     {
-        static bool const result = [] {
+        static bool const result = []() -> bool {
             constexpr bool default_val = CELERITAS_USE_CUDA
                                          || !CELER_BUGGY_HIP_ASYNC;
             auto result = getenv_flag("CELER_DEVICE_ASYNC", default_val);

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -42,6 +42,7 @@ list(APPEND SOURCES
   orangeinp/ProtoInterface.cc
   orangeinp/Shape.cc
   orangeinp/Solid.cc
+  orangeinp/ScaleUtils.cc
   orangeinp/Transformed.cc
   orangeinp/UnitProto.cc
   orangeinp/detail/BoundingZone.cc

--- a/src/orange/LevelStateAccessor.hh
+++ b/src/orange/LevelStateAccessor.hh
@@ -2,22 +2,19 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/LevelStateAccessor.hh
+//! \file orange/LevelStateAccessor.hh
+// NOTE: this file is used by SCALE ORANGE; leave it public
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/data/Collection.hh"
-
-#include "../OrangeData.hh"
-#include "../OrangeTypes.hh"
+#include "OrangeData.hh"
+#include "OrangeTypes.hh"
 
 namespace celeritas
 {
-namespace detail
-{
 //---------------------------------------------------------------------------//
 /*!
- * Accesss the 2D fields (i.e., {thread, level}) of OrangeStateData
+ * Accesss the 2D fields (i.e., {track slot, level}) of OrangeStateData.
  */
 class LevelStateAccessor
 {
@@ -124,5 +121,4 @@ LevelStateAccessor::operator=(LevelStateAccessor const& other)
 }
 
 //---------------------------------------------------------------------------//
-}  // namespace detail
 }  // namespace celeritas

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -11,6 +11,7 @@
 #include "corecel/cont/Array.hh"
 #include "corecel/sys/ThreadId.hh"
 
+#include "LevelStateAccessor.hh"
 #include "OrangeData.hh"
 #include "OrangeTypes.hh"
 #include "transform/TransformVisitor.hh"
@@ -19,7 +20,6 @@
 #include "univ/UniverseTypeTraits.hh"
 #include "univ/detail/Types.hh"
 
-#include "detail/LevelStateAccessor.hh"
 #include "detail/UniverseIndexer.hh"
 
 #if !CELER_DEVICE_COMPILE
@@ -151,7 +151,7 @@ class OrangeTrackView
   private:
     //// TYPES ////
 
-    using LSA = detail::LevelStateAccessor;
+    using LSA = LevelStateAccessor;
 
     //// DATA ////
 

--- a/src/orange/orangeinp/ScaleUtils.cc
+++ b/src/orange/orangeinp/ScaleUtils.cc
@@ -1,0 +1,30 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/ScaleUtils.cc
+//---------------------------------------------------------------------------//
+#include "ScaleUtils.hh"
+
+#include "orange/orangeinp/CsgTree.hh"
+
+#include "detail/CsgLogicUtils.hh"
+
+namespace celeritas
+{
+namespace orangeinp
+{
+//---------------------------------------------------------------------------//
+// Build postfix logic with original surface IDs intact
+std::vector<logic_int> build_postfix_logic(CsgTree const& tree, NodeId n)
+{
+    using celeritas::orangeinp::detail::PostfixBuildLogicPolicy;
+
+    PostfixBuildLogicPolicy policy{tree};
+    policy(n);
+    return std::move(policy).logic();
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/src/orange/orangeinp/ScaleUtils.hh
+++ b/src/orange/orangeinp/ScaleUtils.hh
@@ -11,6 +11,8 @@
 
 #include "CsgTypes.hh"
 
+#include "detail/NegatedSurfaceClipper.hh"
+
 namespace celeritas
 {
 namespace orangeinp
@@ -20,6 +22,9 @@ class CsgTree;
 //---------------------------------------------------------------------------//
 // Build postfix logic with original surface IDs intact
 std::vector<logic_int> build_postfix_logic(CsgTree const& tree, NodeId n);
+
+// NOTE: negated clipper must be accessible
+using detail::NegatedSurfaceClipper;
 
 //---------------------------------------------------------------------------//
 }  // namespace orangeinp

--- a/src/orange/orangeinp/ScaleUtils.hh
+++ b/src/orange/orangeinp/ScaleUtils.hh
@@ -1,0 +1,26 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file orange/orangeinp/ScaleUtils.hh
+//! \brief API compatibility functions for SCALE (https://scale.ornl.gov/)
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+
+#include "CsgTypes.hh"
+
+namespace celeritas
+{
+namespace orangeinp
+{
+class CsgTree;
+
+//---------------------------------------------------------------------------//
+// Build postfix logic with original surface IDs intact
+std::vector<logic_int> build_postfix_logic(CsgTree const& tree, NodeId n);
+
+//---------------------------------------------------------------------------//
+}  // namespace orangeinp
+}  // namespace celeritas

--- a/src/orange/surf/SurfaceClipper.hh
+++ b/src/orange/surf/SurfaceClipper.hh
@@ -6,7 +6,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/Assert.hh"
 #include "geocel/BoundingBox.hh"
 #include "orange/OrangeTypes.hh"
 

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -11,6 +11,7 @@
 
 #include "corecel/Config.hh"
 
+#include "corecel/Assert.hh"
 #include "corecel/data/CollectionAlgorithms.hh"
 #include "corecel/data/CollectionStateStore.hh"
 #include "corecel/data/Ref.hh"
@@ -275,8 +276,7 @@ auto SimpleUnitTrackerTest::setup_heuristic_states(size_type num_tracks) const
     IsotropicDistribution<> sample_isotropic;
     for (auto i : range(num_tracks))
     {
-        auto lsa = detail::LevelStateAccessor(
-            &result_ref, TrackSlotId{i}, LevelId{0});
+        auto lsa = LevelStateAccessor(&result_ref, TrackSlotId{i}, LevelId{0});
         lsa.pos() = sample_box(rng);
         lsa.dir() = sample_isotropic(rng);
     }
@@ -299,14 +299,14 @@ auto SimpleUnitTrackerTest::reduce_heuristic_init(
 {
     CELER_EXPECT(host);
     CELER_EXPECT(wall_time > 0);
+    CELER_EXPECT(this->geometry()->max_depth() == 1);
     std::vector<size_type> counts(this->num_volumes());
     size_type error_count{};
 
     for (auto i : range(host.size()))
     {
         auto tid = TrackSlotId{i};
-        // TODO Update for multiple universes
-        detail::LevelStateAccessor lsa(&host, tid, LevelId{0});
+        LevelStateAccessor lsa(&host, tid, LevelId{0});
         auto vol = lsa.vol();
 
         if (vol < counts.size())

--- a/test/orange/univ/SimpleUnitTracker.test.hh
+++ b/test/orange/univ/SimpleUnitTracker.test.hh
@@ -7,8 +7,8 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "orange/LevelStateAccessor.hh"
 #include "orange/OrangeData.hh"
-#include "orange/detail/LevelStateAccessor.hh"
 #include "orange/univ/SimpleUnitTracker.hh"
 #include "orange/univ/detail/Types.hh"
 
@@ -21,7 +21,6 @@ namespace test
 //---------------------------------------------------------------------------//
 
 using LocalState = detail::LocalState;
-using LSA = detail::LevelStateAccessor;
 
 template<MemSpace M>
 using ParamsRef = OrangeParamsData<Ownership::const_reference, M>;
@@ -50,7 +49,7 @@ inline CELER_FUNCTION LocalState build_local_state(ParamsRef<M> params,
     // Create local state from global memory
     LocalState lstate;
 
-    LSA lsa(&states, tid, LevelId{0});
+    LevelStateAccessor lsa(&states, tid, LevelId{0});
     lstate.pos = lsa.pos();
     lstate.dir = lsa.dir();
     lstate.volume = lsa.vol();
@@ -90,7 +89,7 @@ struct InitializingExecutor
 
         // TODO: for multiuniverses tests, we actually have to iterate
         // through daughter universes to assign the level and volume
-        LSA lsa(&states, tid, LevelId{0});
+        LevelStateAccessor lsa(&states, tid, LevelId{0});
         lsa.vol() = init.volume;
 
         lstate.volume = init.volume;


### PR DESCRIPTION
This adds some utility functions, changes namespaces, and adds validation, so that ORANGE can build again in SCALE in time for v0.6.0.