### PR TITLE
Rename material ID types

### DIFF
--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -38,8 +38,7 @@ using UniqueEventId = OpaqueId<struct Event_, std::uint64_t>;
 using IsotopeId = OpaqueId<struct IsotopeRecord>;
 
 //! Opaque index of a material modified by physics options
-// TODO: rename to PhysMatId; equivalent to "material cuts couple"
-using MaterialId = OpaqueId<struct Material_>;
+using PhysicsMaterialId = OpaqueId<struct PhysicsMaterial_>;
 
 //! Opaque index of model in the list of physics processes
 using ModelId = OpaqueId<struct Model_>;

--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -38,13 +38,13 @@ using UniqueEventId = OpaqueId<struct Event_, std::uint64_t>;
 using IsotopeId = OpaqueId<struct IsotopeRecord>;
 
 //! Opaque index of a material modified by physics options
-using PhysicsMaterialId = OpaqueId<struct PhysicsMaterial_>;
+using PhysMatId = OpaqueId<struct PhysicsMaterial_>;
 
 //! Opaque index of model in the list of physics processes
 using ModelId = OpaqueId<struct Model_>;
 
 //! Opaque index to a material with optical properties
-using OpticalMaterialId = OpaqueId<struct OpticalMaterial_>;
+using OptMatId = OpaqueId<struct OpticalMaterial_>;
 
 //! Opaque index to ParticleRecord in a vector: represents a particle type
 using ParticleId = OpaqueId<struct Particle_>;

--- a/src/celeritas/em/data/FluctuationData.hh
+++ b/src/celeritas/em/data/FluctuationData.hh
@@ -37,7 +37,7 @@ template<Ownership W, MemSpace M>
 struct FluctuationData
 {
     template<class T>
-    using MaterialItems = Collection<T, W, M, PhysicsMaterialId>;
+    using MaterialItems = Collection<T, W, M, PhysMatId>;
     using Mass = units::MevMass;
 
     //// MEMBER DATA ////

--- a/src/celeritas/em/data/FluctuationData.hh
+++ b/src/celeritas/em/data/FluctuationData.hh
@@ -37,7 +37,7 @@ template<Ownership W, MemSpace M>
 struct FluctuationData
 {
     template<class T>
-    using MaterialItems = Collection<T, W, M, MaterialId>;
+    using MaterialItems = Collection<T, W, M, PhysicsMaterialId>;
     using Mass = units::MevMass;
 
     //// MEMBER DATA ////

--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -141,7 +141,7 @@ struct UrbanMscData
     template<class T>
     using Items = Collection<T, W, M>;
     template<class T>
-    using MaterialItems = Collection<T, W, M, PhysicsMaterialId>;
+    using MaterialItems = Collection<T, W, M, PhysMatId>;
     template<class T>
     using ParticleItems = Collection<T, W, M, ParticleId>;
 

--- a/src/celeritas/em/data/UrbanMscData.hh
+++ b/src/celeritas/em/data/UrbanMscData.hh
@@ -141,7 +141,7 @@ struct UrbanMscData
     template<class T>
     using Items = Collection<T, W, M>;
     template<class T>
-    using MaterialItems = Collection<T, W, M, MaterialId>;
+    using MaterialItems = Collection<T, W, M, PhysicsMaterialId>;
     template<class T>
     using ParticleItems = Collection<T, W, M, ParticleId>;
 

--- a/src/celeritas/em/data/WentzelOKVIData.hh
+++ b/src/celeritas/em/data/WentzelOKVIData.hh
@@ -89,7 +89,7 @@ struct WentzelOKVIData
     template<class T>
     using IsotopeItems = celeritas::Collection<T, W, M, IsotopeId>;
     template<class T>
-    using MaterialItems = Collection<T, W, M, MaterialId>;
+    using MaterialItems = Collection<T, W, M, PhysicsMaterialId>;
 
     //// DATA ////
 

--- a/src/celeritas/em/data/WentzelOKVIData.hh
+++ b/src/celeritas/em/data/WentzelOKVIData.hh
@@ -89,7 +89,7 @@ struct WentzelOKVIData
     template<class T>
     using IsotopeItems = celeritas::Collection<T, W, M, IsotopeId>;
     template<class T>
-    using MaterialItems = Collection<T, W, M, PhysicsMaterialId>;
+    using MaterialItems = Collection<T, W, M, PhysMatId>;
 
     //// DATA ////
 

--- a/src/celeritas/em/model/CoulombScatteringModel.cc
+++ b/src/celeritas/em/model/CoulombScatteringModel.cc
@@ -55,8 +55,8 @@ CoulombScatteringModel::CoulombScatteringModel(ActionId id,
         << this->description() << ")");
 
     // Get high/low energy limits
-    energy_limit_ = imported_.energy_grid_bounds(data_.ids.electron,
-                                                 PhysicsMaterialId{0});
+    energy_limit_
+        = imported_.energy_grid_bounds(data_.ids.electron, PhysMatId{0});
 
     // Check that the bounds are the same for all particles/materials
     // TODO: This is only expected when using Coulomb scattering with the
@@ -65,7 +65,7 @@ CoulombScatteringModel::CoulombScatteringModel(ActionId id,
     // require material-dependent applicability
     for (auto pid : {data_.ids.electron, data_.ids.positron})
     {
-        for (auto mid : range(PhysicsMaterialId{materials.num_materials()}))
+        for (auto mid : range(PhysMatId{materials.num_materials()}))
         {
             CELER_VALIDATE(
                 energy_limit_ == imported_.energy_grid_bounds(pid, mid),

--- a/src/celeritas/em/model/CoulombScatteringModel.cc
+++ b/src/celeritas/em/model/CoulombScatteringModel.cc
@@ -55,8 +55,8 @@ CoulombScatteringModel::CoulombScatteringModel(ActionId id,
         << this->description() << ")");
 
     // Get high/low energy limits
-    energy_limit_
-        = imported_.energy_grid_bounds(data_.ids.electron, MaterialId{0});
+    energy_limit_ = imported_.energy_grid_bounds(data_.ids.electron,
+                                                 PhysicsMaterialId{0});
 
     // Check that the bounds are the same for all particles/materials
     // TODO: This is only expected when using Coulomb scattering with the
@@ -65,7 +65,7 @@ CoulombScatteringModel::CoulombScatteringModel(ActionId id,
     // require material-dependent applicability
     for (auto pid : {data_.ids.electron, data_.ids.positron})
     {
-        for (auto mid : range(MaterialId{materials.num_materials()}))
+        for (auto mid : range(PhysicsMaterialId{materials.num_materials()}))
         {
             CELER_VALIDATE(
                 energy_limit_ == imported_.energy_grid_bounds(pid, mid),

--- a/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
@@ -52,7 +52,7 @@ class UrbanMscSafetyStepLimit
                             UrbanMscHelper const& helper,
                             ParticleTrackView const& particle,
                             PhysicsTrackView* physics,
-                            MaterialId matid,
+                            PhysicsMaterialId matid,
                             bool on_boundary,
                             real_type safety,
                             real_type phys_step);
@@ -109,7 +109,7 @@ UrbanMscSafetyStepLimit::UrbanMscSafetyStepLimit(
     UrbanMscHelper const& helper,
     ParticleTrackView const& particle,
     PhysicsTrackView* physics,
-    MaterialId matid,
+    PhysicsMaterialId matid,
     bool on_boundary,
     real_type safety,
     real_type phys_step)

--- a/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
@@ -52,7 +52,7 @@ class UrbanMscSafetyStepLimit
                             UrbanMscHelper const& helper,
                             ParticleTrackView const& particle,
                             PhysicsTrackView* physics,
-                            PhysicsMaterialId matid,
+                            PhysMatId matid,
                             bool on_boundary,
                             real_type safety,
                             real_type phys_step);
@@ -109,7 +109,7 @@ UrbanMscSafetyStepLimit::UrbanMscSafetyStepLimit(
     UrbanMscHelper const& helper,
     ParticleTrackView const& particle,
     PhysicsTrackView* physics,
-    PhysicsMaterialId matid,
+    PhysMatId matid,
     bool on_boundary,
     real_type safety,
     real_type phys_step)

--- a/src/celeritas/em/params/AtomicRelaxationParams.cc
+++ b/src/celeritas/em/params/AtomicRelaxationParams.cc
@@ -65,7 +65,7 @@ AtomicRelaxationParams::AtomicRelaxationParams(Input const& inp)
     size_type num_elements = inp.materials->num_elements();
     std::vector<MevEnergy> electron_cutoff(num_elements, max_quantity());
     std::vector<MevEnergy> gamma_cutoff(num_elements, max_quantity());
-    for (auto mat_id : range(MaterialId{inp.materials->num_materials()}))
+    for (auto mat_id : range(PhysicsMaterialId{inp.materials->num_materials()}))
     {
         // Electron and photon energy cutoffs for this material
         auto cutoffs = inp.cutoffs->get(mat_id);

--- a/src/celeritas/em/params/AtomicRelaxationParams.cc
+++ b/src/celeritas/em/params/AtomicRelaxationParams.cc
@@ -65,7 +65,7 @@ AtomicRelaxationParams::AtomicRelaxationParams(Input const& inp)
     size_type num_elements = inp.materials->num_elements();
     std::vector<MevEnergy> electron_cutoff(num_elements, max_quantity());
     std::vector<MevEnergy> gamma_cutoff(num_elements, max_quantity());
-    for (auto mat_id : range(PhysicsMaterialId{inp.materials->num_materials()}))
+    for (auto mat_id : range(PhysMatId{inp.materials->num_materials()}))
     {
         // Electron and photon energy cutoffs for this material
         auto cutoffs = inp.cutoffs->get(mat_id);

--- a/src/celeritas/em/params/FluctuationParams.cc
+++ b/src/celeritas/em/params/FluctuationParams.cc
@@ -40,7 +40,7 @@ FluctuationParams::FluctuationParams(ParticleParams const& particles,
 
     // Loop over materials
     auto urban = make_builder(&data.urban);
-    for (auto mat_id : range(MaterialId{materials.size()}))
+    for (auto mat_id : range(PhysicsMaterialId{materials.size()}))
     {
         auto const&& mat = materials.get(mat_id);
 

--- a/src/celeritas/em/params/FluctuationParams.cc
+++ b/src/celeritas/em/params/FluctuationParams.cc
@@ -40,7 +40,7 @@ FluctuationParams::FluctuationParams(ParticleParams const& particles,
 
     // Loop over materials
     auto urban = make_builder(&data.urban);
-    for (auto mat_id : range(PhysicsMaterialId{materials.size()}))
+    for (auto mat_id : range(PhysMatId{materials.size()}))
     {
         auto const&& mat = materials.get(mat_id);
 

--- a/src/celeritas/em/params/UrbanMscParams.cc
+++ b/src/celeritas/em/params/UrbanMscParams.cc
@@ -119,7 +119,7 @@ UrbanMscParams::UrbanMscParams(ParticleParams const& particles,
     mdata.reserve(materials.num_materials());
     pmdata.reserve(host_data.num_par_mat * materials.num_materials());
 
-    for (auto mat_id : range(MaterialId{materials.num_materials()}))
+    for (auto mat_id : range(PhysicsMaterialId{materials.num_materials()}))
     {
         auto&& mat = materials.get(mat_id);
 

--- a/src/celeritas/em/params/UrbanMscParams.cc
+++ b/src/celeritas/em/params/UrbanMscParams.cc
@@ -119,7 +119,7 @@ UrbanMscParams::UrbanMscParams(ParticleParams const& particles,
     mdata.reserve(materials.num_materials());
     pmdata.reserve(host_data.num_par_mat * materials.num_materials());
 
-    for (auto mat_id : range(PhysicsMaterialId{materials.num_materials()}))
+    for (auto mat_id : range(PhysMatId{materials.num_materials()}))
     {
         auto&& mat = materials.get(mat_id);
 

--- a/src/celeritas/em/params/WentzelOKVIParams.cc
+++ b/src/celeritas/em/params/WentzelOKVIParams.cc
@@ -141,7 +141,7 @@ void WentzelOKVIParams::build_data(HostVal<WentzelOKVIData>& host_data,
     if (host_data.params.is_combined)
     {
         std::vector<real_type> inv_mass_cbrt_sq(materials.num_materials(), 0);
-        for (auto mat_id : range(MaterialId(materials.num_materials())))
+        for (auto mat_id : range(PhysicsMaterialId(materials.num_materials())))
         {
             auto mat = materials.get(mat_id);
             for (auto elcomp_id : range(ElementComponentId(mat.num_elements())))

--- a/src/celeritas/em/params/WentzelOKVIParams.cc
+++ b/src/celeritas/em/params/WentzelOKVIParams.cc
@@ -141,7 +141,7 @@ void WentzelOKVIParams::build_data(HostVal<WentzelOKVIData>& host_data,
     if (host_data.params.is_combined)
     {
         std::vector<real_type> inv_mass_cbrt_sq(materials.num_materials(), 0);
-        for (auto mat_id : range(PhysicsMaterialId(materials.num_materials())))
+        for (auto mat_id : range(PhysMatId(materials.num_materials())))
         {
             auto mat = materials.get(mat_id);
             for (auto elcomp_id : range(ElementComponentId(mat.num_elements())))

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -512,7 +512,7 @@ import_optical(detail::GeoOpticalIdMap const& geo_to_opt)
     std::vector<ImportOpticalMaterial> result(geo_to_opt.num_optical());
 
     // Loop over optical materials
-    for (auto geo_mat_id : range(GeoMaterialId{geo_to_opt.num_geo()}))
+    for (auto geo_mat_id : range(GeoMatId{geo_to_opt.num_geo()}))
     {
         auto opt_mat_id = geo_to_opt[geo_mat_id];
         if (!opt_mat_id)
@@ -522,8 +522,7 @@ import_optical(detail::GeoOpticalIdMap const& geo_to_opt)
         // Get Geant4 material properties
         G4Material const* material = mt[geo_mat_id.get()];
         CELER_ASSERT(material);
-        CELER_ASSERT(geo_mat_id
-                     == id_cast<GeoMaterialId>(material->GetIndex()));
+        CELER_ASSERT(geo_mat_id == id_cast<GeoMatId>(material->GetIndex()));
         auto const* mpt = material->GetMaterialPropertiesTable();
         CELER_ASSERT(mpt);
 
@@ -733,7 +732,7 @@ import_phys_materials(GeantImporter::DataSelection::Flags particle_flags,
         if (!geo_to_opt.empty())
         {
             if (auto opt_id
-                = geo_to_opt[id_cast<GeoMaterialId>(g4material->GetIndex())])
+                = geo_to_opt[id_cast<GeoMatId>(g4material->GetIndex())])
             {
                 // Assign the optical material corresponding to the geometry
                 // material

--- a/src/celeritas/ext/detail/GeantOpticalModelImporter.cc
+++ b/src/celeritas/ext/detail/GeantOpticalModelImporter.cc
@@ -37,7 +37,7 @@ GeantOpticalModelImporter::GeantOpticalModelImporter(
     }
 
     auto const& mt = *G4Material::GetMaterialTable();
-    for (auto geo_mat_id : range(GeoMaterialId(mt.size())))
+    for (auto geo_mat_id : range(GeoMatId(mt.size())))
     {
         auto opt_id = geo_to_opt[geo_mat_id];
         if (!opt_id)

--- a/src/celeritas/ext/detail/GeoOpticalIdMap.cc
+++ b/src/celeritas/ext/detail/GeoOpticalIdMap.cc
@@ -23,7 +23,7 @@ namespace detail
 GeoOpticalIdMap::GeoOpticalIdMap(G4MaterialTable const& mt)
     : geo_to_opt_{mt.size()}
 {
-    OpticalMaterialId::size_type next_id{0};
+    OptMatId::size_type next_id{0};
     for (auto mat_idx : range(geo_to_opt_.size()))
     {
         G4Material const* material = mt[mat_idx];
@@ -35,7 +35,7 @@ GeoOpticalIdMap::GeoOpticalIdMap(G4MaterialTable const& mt)
         {
             if (mpt->GetProperty("RINDEX"))
             {
-                geo_to_opt_[mat_idx] = OpticalMaterialId{next_id++};
+                geo_to_opt_[mat_idx] = OptMatId{next_id++};
             }
         }
     }

--- a/src/celeritas/ext/detail/GeoOpticalIdMap.hh
+++ b/src/celeritas/ext/detail/GeoOpticalIdMap.hh
@@ -36,20 +36,20 @@ class GeoOpticalIdMap
     explicit GeoOpticalIdMap(G4MaterialTable const&);
 
     // Return the optical ID corresponding to a geo ID
-    inline OpticalMaterialId operator[](GeoMaterialId) const;
+    inline OptMatId operator[](GeoMatId) const;
 
     //! True if no optical materials are present
     bool empty() const { return geo_to_opt_.empty(); }
 
     //! Number of geometry materials
-    GeoMaterialId::size_type num_geo() const { return geo_to_opt_.size(); }
+    GeoMatId::size_type num_geo() const { return geo_to_opt_.size(); }
 
     //! Number of optical materials
-    OpticalMaterialId::size_type num_optical() const { return num_optical_; }
+    OptMatId::size_type num_optical() const { return num_optical_; }
 
   private:
-    std::vector<OpticalMaterialId> geo_to_opt_;
-    OpticalMaterialId::size_type num_optical_{};
+    std::vector<OptMatId> geo_to_opt_;
+    OptMatId::size_type num_optical_{};
 };
 
 //---------------------------------------------------------------------------//
@@ -60,7 +60,7 @@ class GeoOpticalIdMap
  *
  * The result \em may be a "null" ID if there's no associated optical physics.
  */
-OpticalMaterialId GeoOpticalIdMap::operator[](GeoMaterialId m) const
+OptMatId GeoOpticalIdMap::operator[](GeoMatId m) const
 {
     CELER_EXPECT(!this->empty());
     CELER_EXPECT(m < this->num_geo());

--- a/src/celeritas/geo/GeoMaterialData.hh
+++ b/src/celeritas/geo/GeoMaterialData.hh
@@ -22,7 +22,7 @@ struct GeoMaterialParamsData
     template<class T>
     using VolumeItems = celeritas::Collection<T, W, M, VolumeId>;
 
-    VolumeItems<PhysicsMaterialId> materials;
+    VolumeItems<PhysMatId> materials;
 
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const

--- a/src/celeritas/geo/GeoMaterialData.hh
+++ b/src/celeritas/geo/GeoMaterialData.hh
@@ -22,7 +22,7 @@ struct GeoMaterialParamsData
     template<class T>
     using VolumeItems = celeritas::Collection<T, W, M, VolumeId>;
 
-    VolumeItems<MaterialId> materials;
+    VolumeItems<PhysicsMaterialId> materials;
 
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const

--- a/src/celeritas/geo/GeoMaterialParams.cc
+++ b/src/celeritas/geo/GeoMaterialParams.cc
@@ -30,7 +30,7 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
-using MapLabelMatId = std::unordered_map<Label, PhysicsMaterialId>;
+using MapLabelMatId = std::unordered_map<Label, PhysMatId>;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -41,15 +41,15 @@ using MapLabelMatId = std::unordered_map<Label, PhysicsMaterialId>;
  */
 MapLabelMatId build_label_map(MaterialParams const& mat_params,
                               std::vector<Label>&& labels,
-                              std::vector<PhysicsMaterialId> const& materials)
+                              std::vector<PhysMatId> const& materials)
 {
     CELER_EXPECT(materials.size() == labels.size());
     CELER_EXPECT(std::all_of(
-        materials.begin(), materials.end(), [&mat_params](PhysicsMaterialId m) {
+        materials.begin(), materials.end(), [&mat_params](PhysMatId m) {
             return !m || m < mat_params.num_materials();
         }));
 
-    std::unordered_map<Label, PhysicsMaterialId> lab_to_id;
+    std::unordered_map<Label, PhysMatId> lab_to_id;
     std::set<Label> duplicates;
 
     // Remap materials to volume IDs using given volume names:
@@ -89,7 +89,7 @@ class MaterialFinder
     {
     }
 
-    PhysicsMaterialId operator()(VolumeId const& volume_id)
+    PhysMatId operator()(VolumeId const& volume_id)
     {
         Label const& vol_label = geo_.volumes().at(volume_id);
 
@@ -116,7 +116,7 @@ class MaterialFinder
             return {};
         }
 
-        std::set<PhysicsMaterialId> found_mat;
+        std::set<PhysMatId> found_mat;
         for (auto iter = start; iter != stop; ++iter)
         {
             found_mat.insert(iter->second.second);
@@ -141,7 +141,7 @@ class MaterialFinder
     GeoParams const& geo_;
     MapLabelMatId const& materials_;
 
-    using PairExtMatid = std::pair<std::string, PhysicsMaterialId>;
+    using PairExtMatid = std::pair<std::string, PhysMatId>;
     std::multimap<std::string, PairExtMatid> mat_labels_;
 
     void build_mat_labels()
@@ -170,12 +170,12 @@ bool ignore_volume_name(std::string const& name)
 /*!
  * Construct a label -> material map from the input.
  */
-std::vector<PhysicsMaterialId>
+std::vector<PhysMatId>
 build_vol_to_mat(GeoParams const& geo, MapLabelMatId const& materials)
 {
     auto const& vols = geo.volumes();
     std::vector<Label> missing_volumes;
-    std::vector<PhysicsMaterialId> result(vols.size(), PhysicsMaterialId{});
+    std::vector<PhysMatId> result(vols.size(), PhysMatId{});
 
     // Make sure at least one volume maps correctly
     VolumeId::size_type num_missing{0};
@@ -261,7 +261,7 @@ GeoMaterialParams::from_import(ImportData const& data,
             continue;
 
         input.volume_to_mat[volume_idx]
-            = PhysicsMaterialId(data.volumes[volume_idx].phys_material_id);
+            = PhysMatId(data.volumes[volume_idx].phys_material_id);
     }
 
     // Assume that since Geant4 is using internal geometry and

--- a/src/celeritas/geo/GeoMaterialParams.cc
+++ b/src/celeritas/geo/GeoMaterialParams.cc
@@ -30,7 +30,7 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
-using MapLabelMatId = std::unordered_map<Label, MaterialId>;
+using MapLabelMatId = std::unordered_map<Label, PhysicsMaterialId>;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -41,15 +41,15 @@ using MapLabelMatId = std::unordered_map<Label, MaterialId>;
  */
 MapLabelMatId build_label_map(MaterialParams const& mat_params,
                               std::vector<Label>&& labels,
-                              std::vector<MaterialId> const& materials)
+                              std::vector<PhysicsMaterialId> const& materials)
 {
     CELER_EXPECT(materials.size() == labels.size());
     CELER_EXPECT(std::all_of(
-        materials.begin(), materials.end(), [&mat_params](MaterialId m) {
+        materials.begin(), materials.end(), [&mat_params](PhysicsMaterialId m) {
             return !m || m < mat_params.num_materials();
         }));
 
-    std::unordered_map<Label, MaterialId> lab_to_id;
+    std::unordered_map<Label, PhysicsMaterialId> lab_to_id;
     std::set<Label> duplicates;
 
     // Remap materials to volume IDs using given volume names:
@@ -89,7 +89,7 @@ class MaterialFinder
     {
     }
 
-    MaterialId operator()(VolumeId const& volume_id)
+    PhysicsMaterialId operator()(VolumeId const& volume_id)
     {
         Label const& vol_label = geo_.volumes().at(volume_id);
 
@@ -116,7 +116,7 @@ class MaterialFinder
             return {};
         }
 
-        std::set<MaterialId> found_mat;
+        std::set<PhysicsMaterialId> found_mat;
         for (auto iter = start; iter != stop; ++iter)
         {
             found_mat.insert(iter->second.second);
@@ -141,7 +141,7 @@ class MaterialFinder
     GeoParams const& geo_;
     MapLabelMatId const& materials_;
 
-    using PairExtMatid = std::pair<std::string, MaterialId>;
+    using PairExtMatid = std::pair<std::string, PhysicsMaterialId>;
     std::multimap<std::string, PairExtMatid> mat_labels_;
 
     void build_mat_labels()
@@ -170,12 +170,12 @@ bool ignore_volume_name(std::string const& name)
 /*!
  * Construct a label -> material map from the input.
  */
-std::vector<MaterialId>
+std::vector<PhysicsMaterialId>
 build_vol_to_mat(GeoParams const& geo, MapLabelMatId const& materials)
 {
     auto const& vols = geo.volumes();
     std::vector<Label> missing_volumes;
-    std::vector<MaterialId> result(vols.size(), MaterialId{});
+    std::vector<PhysicsMaterialId> result(vols.size(), PhysicsMaterialId{});
 
     // Make sure at least one volume maps correctly
     VolumeId::size_type num_missing{0};
@@ -261,7 +261,7 @@ GeoMaterialParams::from_import(ImportData const& data,
             continue;
 
         input.volume_to_mat[volume_idx]
-            = MaterialId(data.volumes[volume_idx].phys_material_id);
+            = PhysicsMaterialId(data.volumes[volume_idx].phys_material_id);
     }
 
     // Assume that since Geant4 is using internal geometry and

--- a/src/celeritas/geo/GeoMaterialParams.hh
+++ b/src/celeritas/geo/GeoMaterialParams.hh
@@ -56,7 +56,7 @@ class GeoMaterialParams final
     {
         SPConstGeo geometry;
         SPConstMaterial materials;
-        std::vector<PhysicsMaterialId> volume_to_mat;
+        std::vector<PhysMatId> volume_to_mat;
         std::vector<Label> volume_labels;  // Optional
     };
 
@@ -80,7 +80,7 @@ class GeoMaterialParams final
     inline VolumeId::size_type num_volumes() const;
 
     // Get the material ID corresponding to a volume ID
-    inline PhysicsMaterialId material_id(VolumeId v) const;
+    inline PhysMatId material_id(VolumeId v) const;
 
   private:
     CollectionMirror<GeoMaterialParamsData> data_;
@@ -105,7 +105,7 @@ VolumeId::size_type GeoMaterialParams::num_volumes() const
  *
  * Some "virtual" volumes may have a null ID.
  */
-PhysicsMaterialId GeoMaterialParams::material_id(VolumeId v) const
+PhysMatId GeoMaterialParams::material_id(VolumeId v) const
 {
     CELER_EXPECT(v < this->num_volumes());
 

--- a/src/celeritas/geo/GeoMaterialParams.hh
+++ b/src/celeritas/geo/GeoMaterialParams.hh
@@ -27,8 +27,8 @@ struct ImportData;
 /*!
  * Map a track's geometry state to a material ID.
  *
- * For the forseeable future this class should just be a vector of MaterialIds,
- * one per volume.
+ * For the forseeable future this class should just be a vector of
+ * PhysicsMaterialIds, one per volume.
  *
  * The constructor takes an array of material IDs for every volume. Missing
  * material IDs may be allowed if they correspond to unreachable volume IDs. If
@@ -56,7 +56,7 @@ class GeoMaterialParams final
     {
         SPConstGeo geometry;
         SPConstMaterial materials;
-        std::vector<MaterialId> volume_to_mat;
+        std::vector<PhysicsMaterialId> volume_to_mat;
         std::vector<Label> volume_labels;  // Optional
     };
 
@@ -80,7 +80,7 @@ class GeoMaterialParams final
     inline VolumeId::size_type num_volumes() const;
 
     // Get the material ID corresponding to a volume ID
-    inline MaterialId material_id(VolumeId v) const;
+    inline PhysicsMaterialId material_id(VolumeId v) const;
 
   private:
     CollectionMirror<GeoMaterialParamsData> data_;
@@ -105,7 +105,7 @@ VolumeId::size_type GeoMaterialParams::num_volumes() const
  *
  * Some "virtual" volumes may have a null ID.
  */
-MaterialId GeoMaterialParams::material_id(VolumeId v) const
+PhysicsMaterialId GeoMaterialParams::material_id(VolumeId v) const
 {
     CELER_EXPECT(v < this->num_volumes());
 

--- a/src/celeritas/geo/GeoMaterialView.hh
+++ b/src/celeritas/geo/GeoMaterialView.hh
@@ -27,7 +27,7 @@ class GeoMaterialView
     inline CELER_FUNCTION GeoMaterialView(GeoMaterialData const& params);
 
     // Return material for the given volume
-    inline CELER_FUNCTION MaterialId material_id(VolumeId volume) const;
+    inline CELER_FUNCTION PhysicsMaterialId material_id(VolumeId volume) const;
 
   private:
     GeoMaterialData const& params_;
@@ -52,7 +52,7 @@ GeoMaterialView::GeoMaterialView(GeoMaterialData const& params)
  * Note that this will *fail* if the particle is outside -- the volume ID will
  * be false.
  */
-CELER_FUNCTION MaterialId GeoMaterialView::material_id(VolumeId volume) const
+CELER_FUNCTION PhysicsMaterialId GeoMaterialView::material_id(VolumeId volume) const
 {
     CELER_EXPECT(volume < params_.materials.size());
     return params_.materials[volume];

--- a/src/celeritas/geo/GeoMaterialView.hh
+++ b/src/celeritas/geo/GeoMaterialView.hh
@@ -27,7 +27,7 @@ class GeoMaterialView
     inline CELER_FUNCTION GeoMaterialView(GeoMaterialData const& params);
 
     // Return material for the given volume
-    inline CELER_FUNCTION PhysicsMaterialId material_id(VolumeId volume) const;
+    inline CELER_FUNCTION PhysMatId material_id(VolumeId volume) const;
 
   private:
     GeoMaterialData const& params_;
@@ -52,7 +52,7 @@ GeoMaterialView::GeoMaterialView(GeoMaterialData const& params)
  * Note that this will *fail* if the particle is outside -- the volume ID will
  * be false.
  */
-CELER_FUNCTION PhysicsMaterialId GeoMaterialView::material_id(VolumeId volume) const
+CELER_FUNCTION PhysMatId GeoMaterialView::material_id(VolumeId volume) const
 {
     CELER_EXPECT(volume < params_.materials.size());
     return params_.materials[volume];

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -221,7 +221,7 @@ CoreTrackView::particle_record(ParticleId pid) const -> ParticleView
  */
 CELER_FUNCTION auto CoreTrackView::cutoff() const -> CutoffView
 {
-    MaterialId mat_id = this->material().material_id();
+    PhysicsMaterialId mat_id = this->material().material_id();
     CELER_ASSERT(mat_id);
     return CutoffView{params_.cutoffs, mat_id};
 }
@@ -232,7 +232,7 @@ CELER_FUNCTION auto CoreTrackView::cutoff() const -> CutoffView
  */
 CELER_FUNCTION auto CoreTrackView::physics() const -> PhysicsTrackView
 {
-    MaterialId mat_id = this->material().material_id();
+    PhysicsMaterialId mat_id = this->material().material_id();
     CELER_ASSERT(mat_id);
     auto par = this->particle();
     return PhysicsTrackView{

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -221,7 +221,7 @@ CoreTrackView::particle_record(ParticleId pid) const -> ParticleView
  */
 CELER_FUNCTION auto CoreTrackView::cutoff() const -> CutoffView
 {
-    PhysicsMaterialId mat_id = this->material().material_id();
+    PhysMatId mat_id = this->material().material_id();
     CELER_ASSERT(mat_id);
     return CutoffView{params_.cutoffs, mat_id};
 }
@@ -232,7 +232,7 @@ CELER_FUNCTION auto CoreTrackView::cutoff() const -> CutoffView
  */
 CELER_FUNCTION auto CoreTrackView::physics() const -> PhysicsTrackView
 {
-    PhysicsMaterialId mat_id = this->material().material_id();
+    PhysMatId mat_id = this->material().material_id();
     CELER_ASSERT(mat_id);
     auto par = this->particle();
     return PhysicsTrackView{

--- a/src/celeritas/global/DebugIO.json.cc
+++ b/src/celeritas/global/DebugIO.json.cc
@@ -102,7 +102,7 @@ struct FromId
     }
 
     //! Transform to a material label
-    nlohmann::json convert_impl(PhysicsMaterialId id) const
+    nlohmann::json convert_impl(PhysMatId id) const
     {
         auto const& params = *this->params->material();
         return params.id_to_label(id);

--- a/src/celeritas/global/DebugIO.json.cc
+++ b/src/celeritas/global/DebugIO.json.cc
@@ -102,7 +102,7 @@ struct FromId
     }
 
     //! Transform to a material label
-    nlohmann::json convert_impl(MaterialId id) const
+    nlohmann::json convert_impl(PhysicsMaterialId id) const
     {
         auto const& params = *this->params->material();
         return params.id_to_label(id);

--- a/src/celeritas/mat/MaterialData.hh
+++ b/src/celeritas/mat/MaterialData.hh
@@ -138,13 +138,13 @@ struct MaterialParamsData
     template<class T>
     using Items = Collection<T, W, M>;
     template<class T>
-    using MaterialItems = Collection<T, W, M, MaterialId>;
+    using MaterialItems = Collection<T, W, M, PhysicsMaterialId>;
 
     Items<IsotopeRecord> isotopes;
     Items<ElementRecord> elements;
     Items<ElIsotopeComponent> isocomponents;
     Items<MatElementComponent> elcomponents;
-    Collection<MaterialRecord, W, M, MaterialId> materials;
+    Collection<MaterialRecord, W, M, PhysicsMaterialId> materials;
     IsotopeComponentId::size_type max_isotope_components{};
     ElementComponentId::size_type max_element_components{};
     MaterialItems<OpticalMaterialId> optical_id;
@@ -182,7 +182,7 @@ struct MaterialParamsData
  */
 struct MaterialTrackState
 {
-    MaterialId material_id;  //!< Current material being tracked
+    PhysicsMaterialId material_id;  //!< Current material being tracked
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/mat/MaterialData.hh
+++ b/src/celeritas/mat/MaterialData.hh
@@ -138,16 +138,16 @@ struct MaterialParamsData
     template<class T>
     using Items = Collection<T, W, M>;
     template<class T>
-    using MaterialItems = Collection<T, W, M, PhysicsMaterialId>;
+    using MaterialItems = Collection<T, W, M, PhysMatId>;
 
     Items<IsotopeRecord> isotopes;
     Items<ElementRecord> elements;
     Items<ElIsotopeComponent> isocomponents;
     Items<MatElementComponent> elcomponents;
-    Collection<MaterialRecord, W, M, PhysicsMaterialId> materials;
+    Collection<MaterialRecord, W, M, PhysMatId> materials;
     IsotopeComponentId::size_type max_isotope_components{};
     ElementComponentId::size_type max_element_components{};
-    MaterialItems<OpticalMaterialId> optical_id;
+    MaterialItems<OptMatId> optical_id;
 
     //// MEMBER FUNCTIONS ////
 
@@ -182,7 +182,7 @@ struct MaterialParamsData
  */
 struct MaterialTrackState
 {
-    PhysicsMaterialId material_id;  //!< Current material being tracked
+    PhysMatId material_id;  //!< Current material being tracked
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/mat/MaterialParams.cc
+++ b/src/celeritas/mat/MaterialParams.cc
@@ -195,7 +195,7 @@ MaterialParams::MaterialParams(Input const& inp)
         mat_labels[i] = inp.materials[i].label;
         this->append_material_def(inp.materials[i], &host_data);
     }
-    mat_labels_ = LabelIdMultiMap<PhysicsMaterialId>(std::move(mat_labels));
+    mat_labels_ = LabelIdMultiMap<MaterialId>(std::move(mat_labels));
 
     // Mapping of material to optical data
     make_builder(&host_data.optical_id)
@@ -217,7 +217,7 @@ MaterialParams::MaterialParams(Input const& inp)
 /*!
  * Get the label of a material.
  */
-Label const& MaterialParams::id_to_label(PhysicsMaterialId mat) const
+Label const& MaterialParams::id_to_label(MaterialId mat) const
 {
     CELER_EXPECT(mat < mat_labels_.size());
     return mat_labels_.at(mat);
@@ -229,7 +229,7 @@ Label const& MaterialParams::id_to_label(PhysicsMaterialId mat) const
  *
  * If the label isn't among the materials, a null ID will be returned.
  */
-PhysicsMaterialId MaterialParams::find_material(std::string const& name) const
+auto MaterialParams::find_material(std::string const& name) const -> MaterialId
 {
     auto result = mat_labels_.find_all(name);
     if (result.empty())
@@ -247,7 +247,7 @@ PhysicsMaterialId MaterialParams::find_material(std::string const& name) const
  * uniquifying 'extensions'.
  */
 auto MaterialParams::find_materials(std::string const& name) const
-    -> SpanConstPhysicsMaterialId
+    -> SpanConstMaterialId
 {
     return mat_labels_.find_all(name);
 }

--- a/src/celeritas/mat/MaterialParams.cc
+++ b/src/celeritas/mat/MaterialParams.cc
@@ -195,7 +195,7 @@ MaterialParams::MaterialParams(Input const& inp)
         mat_labels[i] = inp.materials[i].label;
         this->append_material_def(inp.materials[i], &host_data);
     }
-    mat_labels_ = LabelIdMultiMap<MaterialId>(std::move(mat_labels));
+    mat_labels_ = LabelIdMultiMap<PhysicsMaterialId>(std::move(mat_labels));
 
     // Mapping of material to optical data
     make_builder(&host_data.optical_id)
@@ -217,7 +217,7 @@ MaterialParams::MaterialParams(Input const& inp)
 /*!
  * Get the label of a material.
  */
-Label const& MaterialParams::id_to_label(MaterialId mat) const
+Label const& MaterialParams::id_to_label(PhysicsMaterialId mat) const
 {
     CELER_EXPECT(mat < mat_labels_.size());
     return mat_labels_.at(mat);
@@ -229,7 +229,7 @@ Label const& MaterialParams::id_to_label(MaterialId mat) const
  *
  * If the label isn't among the materials, a null ID will be returned.
  */
-MaterialId MaterialParams::find_material(std::string const& name) const
+PhysicsMaterialId MaterialParams::find_material(std::string const& name) const
 {
     auto result = mat_labels_.find_all(name);
     if (result.empty())
@@ -247,7 +247,7 @@ MaterialId MaterialParams::find_material(std::string const& name) const
  * uniquifying 'extensions'.
  */
 auto MaterialParams::find_materials(std::string const& name) const
-    -> SpanConstMaterialId
+    -> SpanConstPhysicsMaterialId
 {
     return mat_labels_.find_all(name);
 }

--- a/src/celeritas/mat/MaterialParams.cc
+++ b/src/celeritas/mat/MaterialParams.cc
@@ -109,8 +109,7 @@ MaterialParams::from_import(ImportData const& data)
     if (!data.optical_materials.empty())
     {
         // Initialize optical material array with "not an optical material"
-        input.mat_to_optical.assign(data.phys_materials.size(),
-                                    OpticalMaterialId{});
+        input.mat_to_optical.assign(data.phys_materials.size(), OptMatId{});
     }
 
     // Populate input.materials *using physics material ID* but with *geo
@@ -146,7 +145,7 @@ MaterialParams::from_import(ImportData const& data)
             CELER_VALIDATE(opt_mat_idx < data.optical_materials.size(),
                            << "optical material id " << opt_mat_idx
                            << " is out of range");
-            input.mat_to_optical[mat_idx] = OpticalMaterialId{opt_mat_idx};
+            input.mat_to_optical[mat_idx] = OptMatId{opt_mat_idx};
         }
     }
 
@@ -195,7 +194,7 @@ MaterialParams::MaterialParams(Input const& inp)
         mat_labels[i] = inp.materials[i].label;
         this->append_material_def(inp.materials[i], &host_data);
     }
-    mat_labels_ = LabelIdMultiMap<MaterialId>(std::move(mat_labels));
+    mat_labels_ = LabelIdMultiMap<MatId>(std::move(mat_labels));
 
     // Mapping of material to optical data
     make_builder(&host_data.optical_id)
@@ -217,7 +216,7 @@ MaterialParams::MaterialParams(Input const& inp)
 /*!
  * Get the label of a material.
  */
-Label const& MaterialParams::id_to_label(MaterialId mat) const
+Label const& MaterialParams::id_to_label(MatId mat) const
 {
     CELER_EXPECT(mat < mat_labels_.size());
     return mat_labels_.at(mat);
@@ -229,7 +228,7 @@ Label const& MaterialParams::id_to_label(MaterialId mat) const
  *
  * If the label isn't among the materials, a null ID will be returned.
  */
-auto MaterialParams::find_material(std::string const& name) const -> MaterialId
+auto MaterialParams::find_material(std::string const& name) const -> MatId
 {
     auto result = mat_labels_.find_all(name);
     if (result.empty())

--- a/src/celeritas/mat/MaterialParams.hh
+++ b/src/celeritas/mat/MaterialParams.hh
@@ -48,7 +48,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
   public:
     //!@{
     //! \name Type aliases
-    using SpanConstMaterialId = Span<MaterialId const>;
+    using SpanConstPhysicsMaterialId = Span<PhysicsMaterialId const>;
     using SpanConstElementId = Span<ElementId const>;
     using SpanConstIsotopeId = Span<IsotopeId const>;
     //!@}
@@ -109,22 +109,25 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
     explicit MaterialParams(Input const& inp);
 
     //! Number of material definitions
-    MaterialId::size_type size() const { return mat_labels_.size(); }
+    PhysicsMaterialId::size_type size() const { return mat_labels_.size(); }
 
     //!@{
     //! \name Material metadata
 
     //! Number of materials
-    MaterialId::size_type num_materials() const { return mat_labels_.size(); }
+    PhysicsMaterialId::size_type num_materials() const
+    {
+        return mat_labels_.size();
+    }
 
     // Get material name
-    Label const& id_to_label(MaterialId id) const;
+    Label const& id_to_label(PhysicsMaterialId id) const;
 
     // Find a material from a name
-    MaterialId find_material(std::string const& name) const;
+    PhysicsMaterialId find_material(std::string const& name) const;
 
     // Find all materials that share a name
-    SpanConstMaterialId find_materials(std::string const& name) const;
+    SpanConstPhysicsMaterialId find_materials(std::string const& name) const;
     //!@}
 
     //!@{
@@ -160,7 +163,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
     //!@}
 
     // Access material definitions on host
-    inline MaterialView get(MaterialId id) const;
+    inline MaterialView get(PhysicsMaterialId id) const;
 
     // Access element definitions on host
     inline ElementView get(ElementId id) const;
@@ -185,7 +188,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 
   private:
     // Metadata
-    LabelIdMultiMap<MaterialId> mat_labels_;
+    LabelIdMultiMap<PhysicsMaterialId> mat_labels_;
     LabelIdMultiMap<ElementId> el_labels_;
     LabelIdMultiMap<IsotopeId> isot_labels_;
 
@@ -207,7 +210,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 /*!
  * Get material properties for the given material.
  */
-MaterialView MaterialParams::get(MaterialId id) const
+MaterialView MaterialParams::get(PhysicsMaterialId id) const
 {
     CELER_EXPECT(id < this->host_ref().materials.size());
     return MaterialView(this->host_ref(), id);

--- a/src/celeritas/mat/MaterialParams.hh
+++ b/src/celeritas/mat/MaterialParams.hh
@@ -48,7 +48,8 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
   public:
     //!@{
     //! \name Type aliases
-    using SpanConstPhysicsMaterialId = Span<PhysicsMaterialId const>;
+    using MaterialId = PhysicsMaterialId;
+    using SpanConstMaterialId = Span<MaterialId const>;
     using SpanConstElementId = Span<ElementId const>;
     using SpanConstIsotopeId = Span<IsotopeId const>;
     //!@}
@@ -109,25 +110,22 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
     explicit MaterialParams(Input const& inp);
 
     //! Number of material definitions
-    PhysicsMaterialId::size_type size() const { return mat_labels_.size(); }
+    MaterialId::size_type size() const { return mat_labels_.size(); }
 
     //!@{
     //! \name Material metadata
 
     //! Number of materials
-    PhysicsMaterialId::size_type num_materials() const
-    {
-        return mat_labels_.size();
-    }
+    MaterialId::size_type num_materials() const { return mat_labels_.size(); }
 
     // Get material name
-    Label const& id_to_label(PhysicsMaterialId id) const;
+    Label const& id_to_label(MaterialId id) const;
 
     // Find a material from a name
-    PhysicsMaterialId find_material(std::string const& name) const;
+    MaterialId find_material(std::string const& name) const;
 
     // Find all materials that share a name
-    SpanConstPhysicsMaterialId find_materials(std::string const& name) const;
+    SpanConstMaterialId find_materials(std::string const& name) const;
     //!@}
 
     //!@{
@@ -163,7 +161,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
     //!@}
 
     // Access material definitions on host
-    inline MaterialView get(PhysicsMaterialId id) const;
+    inline MaterialView get(MaterialId id) const;
 
     // Access element definitions on host
     inline ElementView get(ElementId id) const;
@@ -188,7 +186,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 
   private:
     // Metadata
-    LabelIdMultiMap<PhysicsMaterialId> mat_labels_;
+    LabelIdMultiMap<MaterialId> mat_labels_;
     LabelIdMultiMap<ElementId> el_labels_;
     LabelIdMultiMap<IsotopeId> isot_labels_;
 
@@ -210,7 +208,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 /*!
  * Get material properties for the given material.
  */
-MaterialView MaterialParams::get(PhysicsMaterialId id) const
+MaterialView MaterialParams::get(MaterialId id) const
 {
     CELER_EXPECT(id < this->host_ref().materials.size());
     return MaterialView(this->host_ref(), id);

--- a/src/celeritas/mat/MaterialParams.hh
+++ b/src/celeritas/mat/MaterialParams.hh
@@ -48,8 +48,8 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
   public:
     //!@{
     //! \name Type aliases
-    using MaterialId = PhysicsMaterialId;
-    using SpanConstMaterialId = Span<MaterialId const>;
+    using MatId = PhysMatId;
+    using SpanConstMaterialId = Span<MatId const>;
     using SpanConstElementId = Span<ElementId const>;
     using SpanConstIsotopeId = Span<IsotopeId const>;
     //!@}
@@ -99,7 +99,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
         std::vector<IsotopeInput> isotopes;
         std::vector<ElementInput> elements;
         std::vector<MaterialInput> materials;
-        std::vector<OpticalMaterialId> mat_to_optical;
+        std::vector<OptMatId> mat_to_optical;
     };
 
   public:
@@ -110,19 +110,19 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
     explicit MaterialParams(Input const& inp);
 
     //! Number of material definitions
-    MaterialId::size_type size() const { return mat_labels_.size(); }
+    MatId::size_type size() const { return mat_labels_.size(); }
 
     //!@{
     //! \name Material metadata
 
     //! Number of materials
-    MaterialId::size_type num_materials() const { return mat_labels_.size(); }
+    MatId::size_type num_materials() const { return mat_labels_.size(); }
 
     // Get material name
-    Label const& id_to_label(MaterialId id) const;
+    Label const& id_to_label(MatId id) const;
 
     // Find a material from a name
-    MaterialId find_material(std::string const& name) const;
+    MatId find_material(std::string const& name) const;
 
     // Find all materials that share a name
     SpanConstMaterialId find_materials(std::string const& name) const;
@@ -161,7 +161,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
     //!@}
 
     // Access material definitions on host
-    inline MaterialView get(MaterialId id) const;
+    inline MaterialView get(MatId id) const;
 
     // Access element definitions on host
     inline ElementView get(ElementId id) const;
@@ -186,7 +186,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 
   private:
     // Metadata
-    LabelIdMultiMap<MaterialId> mat_labels_;
+    LabelIdMultiMap<MatId> mat_labels_;
     LabelIdMultiMap<ElementId> el_labels_;
     LabelIdMultiMap<IsotopeId> isot_labels_;
 
@@ -208,7 +208,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 /*!
  * Get material properties for the given material.
  */
-MaterialView MaterialParams::get(MaterialId id) const
+MaterialView MaterialParams::get(MatId id) const
 {
     CELER_EXPECT(id < this->host_ref().materials.size());
     return MaterialView(this->host_ref(), id);

--- a/src/celeritas/mat/MaterialParamsOutput.cc
+++ b/src/celeritas/mat/MaterialParamsOutput.cc
@@ -144,7 +144,7 @@ void MaterialParamsOutput::output(JsonPimpl* j) const
         auto element_id = json::array();
         auto element_frac = json::array();
 
-        for (auto id : range(PhysicsMaterialId{material_->num_materials()}))
+        for (auto id : range(PhysMatId{material_->num_materials()}))
         {
             MaterialView const mat_view = material_->get(id);
             label.push_back(material_->id_to_label(id));

--- a/src/celeritas/mat/MaterialParamsOutput.cc
+++ b/src/celeritas/mat/MaterialParamsOutput.cc
@@ -144,7 +144,7 @@ void MaterialParamsOutput::output(JsonPimpl* j) const
         auto element_id = json::array();
         auto element_frac = json::array();
 
-        for (auto id : range(MaterialId{material_->num_materials()}))
+        for (auto id : range(PhysicsMaterialId{material_->num_materials()}))
         {
             MaterialView const mat_view = material_->get(id);
             label.push_back(material_->id_to_label(id));

--- a/src/celeritas/mat/MaterialTrackView.hh
+++ b/src/celeritas/mat/MaterialTrackView.hh
@@ -58,7 +58,7 @@ class MaterialTrackView
     //// DYNAMIC PROPERTIES (pure accessors, free) ////
 
     // Current material identifier
-    CELER_FORCEINLINE_FUNCTION MaterialId material_id() const;
+    CELER_FORCEINLINE_FUNCTION PhysicsMaterialId material_id() const;
 
     //// STATIC PROPERTIES ////
 
@@ -107,7 +107,7 @@ MaterialTrackView::operator=(Initializer_t const& other)
 /*!
  * Current material identifier.
  */
-CELER_FUNCTION MaterialId MaterialTrackView::material_id() const
+CELER_FUNCTION PhysicsMaterialId MaterialTrackView::material_id() const
 {
     return this->state().material_id;
 }

--- a/src/celeritas/mat/MaterialTrackView.hh
+++ b/src/celeritas/mat/MaterialTrackView.hh
@@ -58,7 +58,7 @@ class MaterialTrackView
     //// DYNAMIC PROPERTIES (pure accessors, free) ////
 
     // Current material identifier
-    CELER_FORCEINLINE_FUNCTION PhysicsMaterialId material_id() const;
+    CELER_FORCEINLINE_FUNCTION PhysMatId material_id() const;
 
     //// STATIC PROPERTIES ////
 
@@ -107,7 +107,7 @@ MaterialTrackView::operator=(Initializer_t const& other)
 /*!
  * Current material identifier.
  */
-CELER_FUNCTION PhysicsMaterialId MaterialTrackView::material_id() const
+CELER_FUNCTION PhysMatId MaterialTrackView::material_id() const
 {
     return this->state().material_id;
 }

--- a/src/celeritas/mat/MaterialView.hh
+++ b/src/celeritas/mat/MaterialView.hh
@@ -32,17 +32,18 @@ class MaterialView
     //!@{
     //! \name Type aliases
     using MaterialParamsRef = NativeCRef<MaterialParamsData>;
+    using MaterialId = PhysicsMaterialId;
     //!@}
 
   public:
     // Construct from params and material ID
     inline CELER_FUNCTION
-    MaterialView(MaterialParamsRef const& params, PhysicsMaterialId id);
+    MaterialView(MaterialParamsRef const& params, MaterialId id);
 
     //// MATERIAL DATA ////
 
     // ID of this Material
-    CELER_FORCEINLINE_FUNCTION PhysicsMaterialId material_id() const;
+    CELER_FORCEINLINE_FUNCTION MaterialId material_id() const;
 
     // Number density [1/len^3]
     CELER_FORCEINLINE_FUNCTION real_type number_density() const;
@@ -97,7 +98,7 @@ class MaterialView
 
   private:
     MaterialParamsRef const& params_;
-    PhysicsMaterialId material_;
+    MaterialId material_;
 
     // HELPER FUNCTIONS
 
@@ -111,8 +112,7 @@ class MaterialView
  * Construct from dynamic and static particle properties.
  */
 CELER_FUNCTION
-MaterialView::MaterialView(MaterialParamsRef const& params,
-                           PhysicsMaterialId id)
+MaterialView::MaterialView(MaterialParamsRef const& params, MaterialId id)
     : params_(params), material_(id)
 {
     CELER_EXPECT(id < params.materials.size());
@@ -122,7 +122,7 @@ MaterialView::MaterialView(MaterialParamsRef const& params,
 /*!
  * Get the material id being viewed.
  */
-CELER_FUNCTION PhysicsMaterialId MaterialView::material_id() const
+CELER_FUNCTION auto MaterialView::material_id() const -> MaterialId
 {
     return material_;
 }

--- a/src/celeritas/mat/MaterialView.hh
+++ b/src/celeritas/mat/MaterialView.hh
@@ -32,18 +32,18 @@ class MaterialView
     //!@{
     //! \name Type aliases
     using MaterialParamsRef = NativeCRef<MaterialParamsData>;
-    using MaterialId = PhysicsMaterialId;
+    using MatId = PhysMatId;
     //!@}
 
   public:
     // Construct from params and material ID
     inline CELER_FUNCTION
-    MaterialView(MaterialParamsRef const& params, MaterialId id);
+    MaterialView(MaterialParamsRef const& params, MatId id);
 
     //// MATERIAL DATA ////
 
     // ID of this Material
-    CELER_FORCEINLINE_FUNCTION MaterialId material_id() const;
+    CELER_FORCEINLINE_FUNCTION MatId material_id() const;
 
     // Number density [1/len^3]
     CELER_FORCEINLINE_FUNCTION real_type number_density() const;
@@ -55,7 +55,7 @@ class MaterialView
     CELER_FORCEINLINE_FUNCTION MatterState matter_state() const;
 
     // ID of the optical properties for this material, if any
-    CELER_FORCEINLINE_FUNCTION OpticalMaterialId optical_material_id() const;
+    CELER_FORCEINLINE_FUNCTION OptMatId optical_material_id() const;
 
     //// ELEMENT ACCESS ////
 
@@ -98,7 +98,7 @@ class MaterialView
 
   private:
     MaterialParamsRef const& params_;
-    MaterialId material_;
+    MatId material_;
 
     // HELPER FUNCTIONS
 
@@ -112,7 +112,7 @@ class MaterialView
  * Construct from dynamic and static particle properties.
  */
 CELER_FUNCTION
-MaterialView::MaterialView(MaterialParamsRef const& params, MaterialId id)
+MaterialView::MaterialView(MaterialParamsRef const& params, MatId id)
     : params_(params), material_(id)
 {
     CELER_EXPECT(id < params.materials.size());
@@ -122,7 +122,7 @@ MaterialView::MaterialView(MaterialParamsRef const& params, MaterialId id)
 /*!
  * Get the material id being viewed.
  */
-CELER_FUNCTION auto MaterialView::material_id() const -> MaterialId
+CELER_FUNCTION auto MaterialView::material_id() const -> MatId
 {
     return material_;
 }
@@ -161,7 +161,7 @@ CELER_FUNCTION MatterState MaterialView::matter_state() const
  * This will return an invalid ID if the material has no optical properties
  * attached.
  */
-CELER_FUNCTION OpticalMaterialId MaterialView::optical_material_id() const
+CELER_FUNCTION OptMatId MaterialView::optical_material_id() const
 {
     if (params_.optical_id.empty())
     {

--- a/src/celeritas/mat/MaterialView.hh
+++ b/src/celeritas/mat/MaterialView.hh
@@ -37,12 +37,12 @@ class MaterialView
   public:
     // Construct from params and material ID
     inline CELER_FUNCTION
-    MaterialView(MaterialParamsRef const& params, MaterialId id);
+    MaterialView(MaterialParamsRef const& params, PhysicsMaterialId id);
 
     //// MATERIAL DATA ////
 
     // ID of this Material
-    CELER_FORCEINLINE_FUNCTION MaterialId material_id() const;
+    CELER_FORCEINLINE_FUNCTION PhysicsMaterialId material_id() const;
 
     // Number density [1/len^3]
     CELER_FORCEINLINE_FUNCTION real_type number_density() const;
@@ -97,7 +97,7 @@ class MaterialView
 
   private:
     MaterialParamsRef const& params_;
-    MaterialId material_;
+    PhysicsMaterialId material_;
 
     // HELPER FUNCTIONS
 
@@ -111,7 +111,8 @@ class MaterialView
  * Construct from dynamic and static particle properties.
  */
 CELER_FUNCTION
-MaterialView::MaterialView(MaterialParamsRef const& params, MaterialId id)
+MaterialView::MaterialView(MaterialParamsRef const& params,
+                           PhysicsMaterialId id)
     : params_(params), material_(id)
 {
     CELER_EXPECT(id < params.materials.size());
@@ -121,7 +122,7 @@ MaterialView::MaterialView(MaterialParamsRef const& params, MaterialId id)
 /*!
  * Get the material id being viewed.
  */
-CELER_FUNCTION MaterialId MaterialView::material_id() const
+CELER_FUNCTION PhysicsMaterialId MaterialView::material_id() const
 {
     return material_;
 }

--- a/src/celeritas/optical/CherenkovData.hh
+++ b/src/celeritas/optical/CherenkovData.hh
@@ -28,7 +28,7 @@ struct CherenkovData
     template<class T>
     using Items = Collection<T, W, M>;
     template<class T>
-    using OpticalMaterialItems = Collection<T, W, M, OpticalMaterialId>;
+    using OpticalMaterialItems = Collection<T, W, M, OptMatId>;
 
     //// MEMBER DATA ////
 

--- a/src/celeritas/optical/CherenkovParams.cc
+++ b/src/celeritas/optical/CherenkovParams.cc
@@ -37,7 +37,7 @@ CherenkovParams::CherenkovParams(MaterialParams const& mats)
     HostVal<CherenkovData> data;
     NonuniformGridInserter insert_angle_integral(&data.reals,
                                                  &data.angle_integral);
-    for (auto mat_id : range(OpticalMaterialId(mats.num_materials())))
+    for (auto mat_id : range(OptMatId(mats.num_materials())))
     {
         NonuniformGridCalculator refractive_index
             = MaterialView{mats.host_ref(), mat_id}

--- a/src/celeritas/optical/CoreTrackView.hh
+++ b/src/celeritas/optical/CoreTrackView.hh
@@ -182,7 +182,7 @@ CELER_FUNCTION auto CoreTrackView::particle() const -> ParticleTrackView
  */
 CELER_FUNCTION auto CoreTrackView::physics() const -> PhysicsTrackView
 {
-    OpticalMaterialId mat_id = this->material_record().material_id();
+    OptMatId mat_id = this->material_record().material_id();
     CELER_ASSERT(mat_id);
     return PhysicsTrackView{
         params_.physics, states_.physics, mat_id, this->track_slot_id()};

--- a/src/celeritas/optical/GeneratorDistributionData.hh
+++ b/src/celeritas/optical/GeneratorDistributionData.hh
@@ -47,7 +47,7 @@ struct GeneratorDistributionData
     real_type time{};  //!< Pre-step time
     real_type step_length{};
     units::ElementaryCharge charge;
-    OpticalMaterialId material;
+    OptMatId material;
     EnumArray<StepPoint, GeneratorStepData> points;
 
     //! Check whether the data are assigned

--- a/src/celeritas/optical/ImportedMaterials.cc
+++ b/src/celeritas/optical/ImportedMaterials.cc
@@ -30,7 +30,7 @@ ImportedMaterials::from_import(ImportData const& data)
         return nullptr;
     }
 
-    OpticalMaterialId::size_type num_materials = data.optical_materials.size();
+    OptMatId::size_type num_materials = data.optical_materials.size();
 
     // Copy over Rayleigh and WLS data
 
@@ -69,7 +69,7 @@ ImportedMaterials::ImportedMaterials(std::vector<ImportOpticalRayleigh> rayleigh
 /*!
  * Number of imported optical materials.
  */
-OpticalMaterialId::size_type ImportedMaterials::num_materials() const
+OptMatId::size_type ImportedMaterials::num_materials() const
 {
     return rayleigh_.size();
 }
@@ -78,8 +78,7 @@ OpticalMaterialId::size_type ImportedMaterials::num_materials() const
 /*!
  * Get imported Rayleigh properties for the given material.
  */
-ImportOpticalRayleigh const&
-ImportedMaterials::rayleigh(OpticalMaterialId mat) const
+ImportOpticalRayleigh const& ImportedMaterials::rayleigh(OptMatId mat) const
 {
     CELER_EXPECT(mat < this->num_materials());
     return rayleigh_[mat.get()];
@@ -89,7 +88,7 @@ ImportedMaterials::rayleigh(OpticalMaterialId mat) const
 /*!
  * Get imported wavelength shifting properties for the given material.
  */
-ImportWavelengthShift const& ImportedMaterials::wls(OpticalMaterialId mat) const
+ImportWavelengthShift const& ImportedMaterials::wls(OptMatId mat) const
 {
     CELER_EXPECT(mat < this->num_materials());
     return wls_[mat.get()];

--- a/src/celeritas/optical/ImportedMaterials.hh
+++ b/src/celeritas/optical/ImportedMaterials.hh
@@ -37,13 +37,13 @@ class ImportedMaterials
                       std::vector<ImportWavelengthShift> wls);
 
     // Get number of imported optical materials
-    OpticalMaterialId::size_type num_materials() const;
+    OptMatId::size_type num_materials() const;
 
     // Get imported Rayleigh material parameters
-    ImportOpticalRayleigh const& rayleigh(OpticalMaterialId mat) const;
+    ImportOpticalRayleigh const& rayleigh(OptMatId mat) const;
 
     // Get imported wavelength shifting material parameters
-    ImportWavelengthShift const& wls(OpticalMaterialId mat) const;
+    ImportWavelengthShift const& wls(OptMatId mat) const;
 
   private:
     std::vector<ImportOpticalRayleigh> rayleigh_;

--- a/src/celeritas/optical/ImportedModelAdapter.cc
+++ b/src/celeritas/optical/ImportedModelAdapter.cc
@@ -134,7 +134,7 @@ ImportedModelAdapter::ImportedModelAdapter(ImportModelClass imc,
 /*!
  * Get MFP table for the given optical material.
  */
-inp::Grid const& ImportedModelAdapter::mfp(OpticalMaterialId id) const
+inp::Grid const& ImportedModelAdapter::mfp(OptMatId id) const
 {
     CELER_EXPECT(id < this->model().mfp_table.size());
     return this->model().mfp_table[id.get()];
@@ -144,7 +144,7 @@ inp::Grid const& ImportedModelAdapter::mfp(OpticalMaterialId id) const
 /*!
  * Get number of optical materials that have MFPs for this model.
  */
-OpticalMaterialId::size_type ImportedModelAdapter::num_materials() const
+OptMatId::size_type ImportedModelAdapter::num_materials() const
 {
     return this->model().mfp_table.size();
 }

--- a/src/celeritas/optical/ImportedModelAdapter.hh
+++ b/src/celeritas/optical/ImportedModelAdapter.hh
@@ -67,7 +67,7 @@ class ImportedModelAdapter
   public:
     //!@{
     //! \name Type aliases
-    using ImportedModelId = typename ImportedModels::ImportedModelId;
+    using ImportedModelId = ImportedModels::ImportedModelId;
     using SPConstImported = std::shared_ptr<ImportedModels const>;
     //!@}
 

--- a/src/celeritas/optical/ImportedModelAdapter.hh
+++ b/src/celeritas/optical/ImportedModelAdapter.hh
@@ -79,10 +79,10 @@ class ImportedModelAdapter
     ImportedModelAdapter(ImportModelClass imc, SPConstImported imported);
 
     // Get MFP grid for the optical material
-    inp::Grid const& mfp(OpticalMaterialId id) const;
+    inp::Grid const& mfp(OptMatId id) const;
 
     // Get number of optical materials
-    OpticalMaterialId::size_type num_materials() const;
+    OptMatId::size_type num_materials() const;
 
   private:
     // Get imported model referred to by this adapter

--- a/src/celeritas/optical/MaterialData.hh
+++ b/src/celeritas/optical/MaterialData.hh
@@ -36,7 +36,7 @@ struct MaterialParamsData
 
     OpticalMaterialItems<NonuniformGridRecord> refractive_index;
     VolumeItems<OpticalMaterialId> optical_id;
-    OpticalMaterialItems<CoreMaterialId> core_material_id;
+    OpticalMaterialItems<CorePhysicsMaterialId> core_material_id;
 
     // Backend data
     Items<real_type> reals;

--- a/src/celeritas/optical/MaterialData.hh
+++ b/src/celeritas/optical/MaterialData.hh
@@ -36,7 +36,7 @@ struct MaterialParamsData
 
     OpticalMaterialItems<NonuniformGridRecord> refractive_index;
     VolumeItems<OptMatId> optical_id;
-    OpticalMaterialItems<CorePhysicsMaterialId> core_material_id;
+    OpticalMaterialItems<PhysMatId> core_material_id;
 
     // Backend data
     Items<real_type> reals;

--- a/src/celeritas/optical/MaterialData.hh
+++ b/src/celeritas/optical/MaterialData.hh
@@ -28,14 +28,14 @@ struct MaterialParamsData
     template<class T>
     using Items = Collection<T, W, M>;
     template<class T>
-    using OpticalMaterialItems = Collection<T, W, M, OpticalMaterialId>;
+    using OpticalMaterialItems = Collection<T, W, M, OptMatId>;
     template<class T>
     using VolumeItems = celeritas::Collection<T, W, M, VolumeId>;
 
     //// MEMBER DATA ////
 
     OpticalMaterialItems<NonuniformGridRecord> refractive_index;
-    VolumeItems<OpticalMaterialId> optical_id;
+    VolumeItems<OptMatId> optical_id;
     OpticalMaterialItems<CorePhysicsMaterialId> core_material_id;
 
     // Backend data

--- a/src/celeritas/optical/MaterialParams.cc
+++ b/src/celeritas/optical/MaterialParams.cc
@@ -57,7 +57,7 @@ MaterialParams::from_import(ImportData const& data,
     bool has_opt_mat{false};
     for (auto vid : range(VolumeId{geo_mat.num_volumes()}))
     {
-        OpticalMaterialId optmat;
+        OptMatId optmat;
         if (auto matid = geo_mat.material_id(vid))
         {
             auto mat_view = mat.get(matid);
@@ -155,7 +155,7 @@ MaterialParams::MaterialParams(Input const& inp)
 /*!
  * Construct a material view for the given identifier.
  */
-MaterialView MaterialParams::get(OpticalMaterialId mat) const
+MaterialView MaterialParams::get(OptMatId mat) const
 {
     return MaterialView(this->host_ref(), mat);
 }

--- a/src/celeritas/optical/MaterialParams.cc
+++ b/src/celeritas/optical/MaterialParams.cc
@@ -75,9 +75,9 @@ MaterialParams::from_import(ImportData const& data,
     CELER_ENSURE(inp.volume_to_mat.size() == geo_mat.num_volumes());
 
     // Construct optical to core material mapping
-    inp.optical_to_core
-        = std::vector<CoreMaterialId>(inp.properties.size(), CoreMaterialId{});
-    for (auto core_id : range(CoreMaterialId{mat.num_materials()}))
+    inp.optical_to_core = std::vector<CorePhysicsMaterialId>(
+        inp.properties.size(), CorePhysicsMaterialId{});
+    for (auto core_id : range(CorePhysicsMaterialId{mat.num_materials()}))
     {
         if (auto opt_mat_id = mat.get(core_id).optical_material_id())
         {

--- a/src/celeritas/optical/MaterialParams.cc
+++ b/src/celeritas/optical/MaterialParams.cc
@@ -75,9 +75,9 @@ MaterialParams::from_import(ImportData const& data,
     CELER_ENSURE(inp.volume_to_mat.size() == geo_mat.num_volumes());
 
     // Construct optical to core material mapping
-    inp.optical_to_core = std::vector<CorePhysicsMaterialId>(
-        inp.properties.size(), CorePhysicsMaterialId{});
-    for (auto core_id : range(CorePhysicsMaterialId{mat.num_materials()}))
+    inp.optical_to_core
+        = std::vector<PhysMatId>(inp.properties.size(), PhysMatId{});
+    for (auto core_id : range(PhysMatId{mat.num_materials()}))
     {
         if (auto opt_mat_id = mat.get(core_id).optical_material_id())
         {

--- a/src/celeritas/optical/MaterialParams.hh
+++ b/src/celeritas/optical/MaterialParams.hh
@@ -54,7 +54,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
         //! Map logical volume ID to optical material ID
         std::vector<OptMatId> volume_to_mat;
         //! Map optical material ID to core material ID
-        std::vector<CorePhysicsMaterialId> optical_to_core;
+        std::vector<PhysMatId> optical_to_core;
     };
 
   public:

--- a/src/celeritas/optical/MaterialParams.hh
+++ b/src/celeritas/optical/MaterialParams.hh
@@ -35,10 +35,11 @@ namespace optical
  *
  * Optical volume properties are imported from Geant4 into the \c
  * ImportData container. The \c celeritas::MaterialParams class loads the
- * mapping of \c MaterialId to \c OpticalMaterialId and makes it accessible
- * via the main loop's material view. By combining that with the \c
- * GeoMaterialParams which maps volumes to \c MaterialId, this class maps the
- * geometry volumes to optical materials for use in the optical tracking loop.
+ * mapping of \c PhysicsMaterialId to \c OpticalMaterialId and makes it
+ * accessible via the main loop's material view. By combining that with the \c
+ * GeoMaterialParams which maps volumes to \c PhysicsMaterialId, this class
+ * maps the geometry volumes to optical materials for use in the optical
+ * tracking loop.
  *
  * When surface models are implemented, surface properties will also be added
  * to this class.
@@ -53,7 +54,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
         //! Map logical volume ID to optical material ID
         std::vector<OpticalMaterialId> volume_to_mat;
         //! Map optical material ID to core material ID
-        std::vector<CoreMaterialId> optical_to_core;
+        std::vector<CorePhysicsMaterialId> optical_to_core;
     };
 
   public:

--- a/src/celeritas/optical/MaterialParams.hh
+++ b/src/celeritas/optical/MaterialParams.hh
@@ -35,9 +35,9 @@ namespace optical
  *
  * Optical volume properties are imported from Geant4 into the \c
  * ImportData container. The \c celeritas::MaterialParams class loads the
- * mapping of \c PhysicsMaterialId to \c OpticalMaterialId and makes it
+ * mapping of \c PhysMatId to \c OptMatId and makes it
  * accessible via the main loop's material view. By combining that with the \c
- * GeoMaterialParams which maps volumes to \c PhysicsMaterialId, this class
+ * GeoMaterialParams which maps volumes to \c PhysMatId, this class
  * maps the geometry volumes to optical materials for use in the optical
  * tracking loop.
  *
@@ -49,10 +49,10 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
   public:
     struct Input
     {
-        //! Shared optical material, indexed by \c OpticalMaterialId
+        //! Shared optical material, indexed by \c OptMatId
         std::vector<ImportOpticalProperty> properties;
         //! Map logical volume ID to optical material ID
-        std::vector<OpticalMaterialId> volume_to_mat;
+        std::vector<OptMatId> volume_to_mat;
         //! Map optical material ID to core material ID
         std::vector<CorePhysicsMaterialId> optical_to_core;
     };
@@ -68,10 +68,10 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
     explicit MaterialParams(Input const& inp);
 
     // Number of optical materials
-    inline OpticalMaterialId::size_type num_materials() const;
+    inline OptMatId::size_type num_materials() const;
 
     // Construct a material view for the given identifier
-    MaterialView get(OpticalMaterialId mat) const;
+    MaterialView get(OptMatId mat) const;
 
     //! Access optical material on the host
     HostRef const& host_ref() const final { return data_.host_ref(); }
@@ -89,7 +89,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
 /*!
  * Number of optical materials.
  */
-OpticalMaterialId::size_type MaterialParams::num_materials() const
+OptMatId::size_type MaterialParams::num_materials() const
 {
     return this->host_ref().refractive_index.size();
 }

--- a/src/celeritas/optical/MaterialView.hh
+++ b/src/celeritas/optical/MaterialView.hh
@@ -45,8 +45,8 @@ class MaterialView
     // ID of this optical material
     CELER_FORCEINLINE_FUNCTION MatId material_id() const;
 
-    // ID of the associated core material
-    CELER_FORCEINLINE_FUNCTION CorePhysicsMaterialId core_material_id() const;
+    // ID of the associated core physics material
+    CELER_FORCEINLINE_FUNCTION PhysMatId core_material_id() const;
 
     //// PARAMETER DATA ////
 
@@ -111,7 +111,7 @@ CELER_FUNCTION auto MaterialView::material_id() const -> MatId
 /*!
  * Get the id of the core material associated with this optical material.
  */
-CELER_FUNCTION CorePhysicsMaterialId MaterialView::core_material_id() const
+CELER_FUNCTION PhysMatId MaterialView::core_material_id() const
 {
     return params_.core_material_id[mat_id_];
 }

--- a/src/celeritas/optical/MaterialView.hh
+++ b/src/celeritas/optical/MaterialView.hh
@@ -27,12 +27,12 @@ class MaterialView
     //!@{
     //! \name Type aliases
     using ParamsRef = NativeCRef<MaterialParamsData>;
-    using MaterialId = OpticalMaterialId;
+    using MatId = OptMatId;
     //!@}
 
   public:
     // Construct from params and material ID
-    inline CELER_FUNCTION MaterialView(ParamsRef const& params, MaterialId id);
+    inline CELER_FUNCTION MaterialView(ParamsRef const& params, MatId id);
 
     // Construct from params and volume ID
     inline CELER_FUNCTION MaterialView(ParamsRef const& params, VolumeId vol);
@@ -43,7 +43,7 @@ class MaterialView
     //// MATERIAL DATA ////
 
     // ID of this optical material
-    CELER_FORCEINLINE_FUNCTION MaterialId material_id() const;
+    CELER_FORCEINLINE_FUNCTION MatId material_id() const;
 
     // ID of the associated core material
     CELER_FORCEINLINE_FUNCTION CorePhysicsMaterialId core_material_id() const;
@@ -58,7 +58,7 @@ class MaterialView
     //// DATA ////
 
     ParamsRef const& params_;
-    MaterialId mat_id_;
+    MatId mat_id_;
 };
 
 //---------------------------------------------------------------------------//
@@ -68,7 +68,7 @@ class MaterialView
  * Construct from an optical material.
  */
 CELER_FUNCTION
-MaterialView::MaterialView(ParamsRef const& params, MaterialId id)
+MaterialView::MaterialView(ParamsRef const& params, MatId id)
     : params_(params), mat_id_(id)
 {
     CELER_EXPECT(id < params_.refractive_index.size());
@@ -102,7 +102,7 @@ CELER_FORCEINLINE_FUNCTION MaterialView::operator bool() const
 /*!
  * Get the optical material id.
  */
-CELER_FUNCTION auto MaterialView::material_id() const -> MaterialId
+CELER_FUNCTION auto MaterialView::material_id() const -> MatId
 {
     return mat_id_;
 }

--- a/src/celeritas/optical/MaterialView.hh
+++ b/src/celeritas/optical/MaterialView.hh
@@ -46,7 +46,7 @@ class MaterialView
     CELER_FORCEINLINE_FUNCTION MaterialId material_id() const;
 
     // ID of the associated core material
-    CELER_FORCEINLINE_FUNCTION CoreMaterialId core_material_id() const;
+    CELER_FORCEINLINE_FUNCTION CorePhysicsMaterialId core_material_id() const;
 
     //// PARAMETER DATA ////
 
@@ -111,7 +111,7 @@ CELER_FUNCTION auto MaterialView::material_id() const -> MaterialId
 /*!
  * Get the id of the core material associated with this optical material.
  */
-CELER_FUNCTION CoreMaterialId MaterialView::core_material_id() const
+CELER_FUNCTION CorePhysicsMaterialId MaterialView::core_material_id() const
 {
     return params_.core_material_id[mat_id_];
 }

--- a/src/celeritas/optical/Model.hh
+++ b/src/celeritas/optical/Model.hh
@@ -43,7 +43,7 @@ class Model : public OpticalStepActionInterface, public ConcreteAction
     StepActionOrder order() const override { return StepActionOrder::post; }
 
     //! Build mean free path grids for all optical materials
-    virtual void build_mfps(OpticalMaterialId mat, MfpBuilder& build) const = 0;
+    virtual void build_mfps(OptMatId mat, MfpBuilder& build) const = 0;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/OffloadData.hh
+++ b/src/celeritas/optical/OffloadData.hh
@@ -119,7 +119,7 @@ struct OffloadPreStepData
     units::LightSpeed speed;
     Real3 pos{};
     real_type time{};
-    OpticalMaterialId material;
+    OptMatId material;
 
     //! Check whether the data are assigned
     explicit CELER_FUNCTION operator bool() const

--- a/src/celeritas/optical/PhysicsData.hh
+++ b/src/celeritas/optical/PhysicsData.hh
@@ -36,7 +36,7 @@ struct PhysicsParamsScalars
     ModelId::size_type num_models{};
 
     //! Number of optical materials
-    OpticalMaterialId::size_type num_materials{};
+    OptMatId::size_type num_materials{};
 
     //! Offset to create an ActionId from a ModelId
     ActionId::size_type model_to_action{};

--- a/src/celeritas/optical/PhysicsParams.cc
+++ b/src/celeritas/optical/PhysicsParams.cc
@@ -97,7 +97,7 @@ void PhysicsParams::build_mfps(MaterialParams const& mats, HostValue& data) cons
     {
         // Build all MFP tables for the model
         MfpBuilder builder(&data.reals, &data.grids);
-        for (auto opt_mat : range(OpticalMaterialId{mats.num_materials()}))
+        for (auto opt_mat : range(OptMatId{mats.num_materials()}))
         {
             model->build_mfps(opt_mat, builder);
         }

--- a/src/celeritas/optical/PhysicsTrackView.hh
+++ b/src/celeritas/optical/PhysicsTrackView.hh
@@ -45,7 +45,7 @@ class PhysicsTrackView
     // Construct from params, state, and material ID for a given track
     inline CELER_FUNCTION PhysicsTrackView(PhysicsParamsRef const&,
                                            PhysicsStateRef const&,
-                                           OpticalMaterialId,
+                                           OptMatId,
                                            TrackSlotId);
 
     // Initialize the physics for the track
@@ -98,7 +98,7 @@ class PhysicsTrackView
   private:
     PhysicsParamsRef const& params_;
     PhysicsStateRef const& states_;
-    OpticalMaterialId const opt_material_;
+    OptMatId const opt_material_;
     TrackSlotId const track_id_;
 };
 
@@ -111,7 +111,7 @@ class PhysicsTrackView
 CELER_FUNCTION
 PhysicsTrackView::PhysicsTrackView(PhysicsParamsRef const& params,
                                    PhysicsStateRef const& states,
-                                   OpticalMaterialId opt_mat,
+                                   OptMatId opt_mat,
                                    TrackSlotId track_id)
     : params_(params)
     , states_(states)

--- a/src/celeritas/optical/ScintillationData.hh
+++ b/src/celeritas/optical/ScintillationData.hh
@@ -102,13 +102,13 @@ struct ParScintSpectrumRecord
  *
  * - \c pid_to_scintpid returns a \c ScintillationParticleId given a
  *   \c ParticleId .
- * - \c resolution_scale is indexed by \c OpticalMaterialId .
+ * - \c resolution_scale is indexed by \c OptMatId .
  * - \c materials stores material-only scintillation data. Indexed by
- *   \c OpticalMaterialId
+ *   \c OptMatId
  * - \c particles stores scintillation spectrum for each particle type for each
  *   material, being a grid of size `num_particles * num_materials`. Therefore
  *   it is indexed by \c ParticleScintSpectrumId , which combines
- *   \c ScintillationParticleId and \c OpticalMaterialId . Use the
+ *   \c ScintillationParticleId and \c OptMatId . Use the
  *   \c spectrum_index() function to retrieve the correct index.
  */
 template<Ownership W, MemSpace M>
@@ -117,7 +117,7 @@ struct ScintillationData
     template<class T>
     using Items = Collection<T, W, M>;
     template<class T>
-    using OpticalMaterialItems = Collection<T, W, M, OpticalMaterialId>;
+    using OpticalMaterialItems = Collection<T, W, M, OptMatId>;
     template<class T>
     using ScintPidItems = Collection<T, W, M, ParticleScintSpectrumId>;
 
@@ -160,7 +160,7 @@ struct ScintillationData
 
     //! Retrieve spectrum index given optical particle and material ids
     ParticleScintSpectrumId
-    spectrum_index(ScintillationParticleId pid, OpticalMaterialId mat_id) const
+    spectrum_index(ScintillationParticleId pid, OptMatId mat_id) const
     {
         // Resolution scale exists independent of material-only data and it's
         // indexed by optical material id

--- a/src/celeritas/optical/ScintillationParams.hh
+++ b/src/celeritas/optical/ScintillationParams.hh
@@ -42,7 +42,7 @@ class ScintillationParams final : public ParamsDataInterface<ScintillationData>
     //! Scintillation data for all materials and particles
     struct Input
     {
-        using VecOptMatId = std::vector<OpticalMaterialId>;
+        using VecOptMatId = std::vector<OptMatId>;
         using VecSPId = std::vector<ScintillationParticleId>;
 
         std::vector<double> resolution_scale;

--- a/src/celeritas/optical/Types.hh
+++ b/src/celeritas/optical/Types.hh
@@ -21,18 +21,4 @@ using ScintillationParticleId = OpaqueId<struct ScintillationParticle_>;
 using ParticleScintSpectrumId = OpaqueId<struct ParScintSpectrumRecord_>;
 
 //---------------------------------------------------------------------------//
-/*!
- * Physics classes used inside the optical physics loop.
- *
- * Interface classes that integrate with the main Celeritas stepping loop are
- * in the main namespace.
- */
-namespace optical
-{
-//---------------------------------------------------------------------------//
-//! Alias for PhysMatId in core Celeritas namespace
-using CorePhysicsMaterialId = ::celeritas::PhysMatId;
-
-//---------------------------------------------------------------------------//
-}  // namespace optical
 }  // namespace celeritas

--- a/src/celeritas/optical/Types.hh
+++ b/src/celeritas/optical/Types.hh
@@ -30,8 +30,8 @@ using ParticleScintSpectrumId = OpaqueId<struct ParScintSpectrumRecord_>;
 namespace optical
 {
 //---------------------------------------------------------------------------//
-//! Alias for MaterialId in core Celeritas namespace
-using CoreMaterialId = ::celeritas::MaterialId;
+//! Alias for PhysicsMaterialId in core Celeritas namespace
+using CorePhysicsMaterialId = ::celeritas::PhysicsMaterialId;
 
 //---------------------------------------------------------------------------//
 }  // namespace optical

--- a/src/celeritas/optical/Types.hh
+++ b/src/celeritas/optical/Types.hh
@@ -30,8 +30,8 @@ using ParticleScintSpectrumId = OpaqueId<struct ParScintSpectrumRecord_>;
 namespace optical
 {
 //---------------------------------------------------------------------------//
-//! Alias for PhysicsMaterialId in core Celeritas namespace
-using CorePhysicsMaterialId = ::celeritas::PhysicsMaterialId;
+//! Alias for PhysMatId in core Celeritas namespace
+using CorePhysicsMaterialId = ::celeritas::PhysMatId;
 
 //---------------------------------------------------------------------------//
 }  // namespace optical

--- a/src/celeritas/optical/WavelengthShiftData.hh
+++ b/src/celeritas/optical/WavelengthShiftData.hh
@@ -42,7 +42,7 @@ struct WavelengthShiftData
     template<class T>
     using Items = Collection<T, W, M>;
     template<class T>
-    using OpticalMaterialItems = Collection<T, W, M, OpticalMaterialId>;
+    using OpticalMaterialItems = Collection<T, W, M, OptMatId>;
 
     //// MEMBER DATA ////
 

--- a/src/celeritas/optical/WavelengthShiftParams.hh
+++ b/src/celeritas/optical/WavelengthShiftParams.hh
@@ -27,7 +27,7 @@ class WavelengthShiftParams final
     : public ParamsDataInterface<WavelengthShiftData>
 {
   public:
-    //! Material-dependent WLS data, indexed by \c OpticalMaterialId
+    //! Material-dependent WLS data, indexed by \c OptMatId
     struct Input
     {
         std::vector<ImportWavelengthShift> data;

--- a/src/celeritas/optical/detail/MatScintSpecInserter.hh
+++ b/src/celeritas/optical/detail/MatScintSpecInserter.hh
@@ -41,7 +41,7 @@ class MatScintSpecInserter
     auto operator()(ImportMaterialScintSpectrum const& mat);
 
   private:
-    using MatId = OpticalMaterialId;
+    using MatId = OptMatId;
 
     CollectionBuilder<MatScintSpectrumRecord, MemSpace::host, MatId> materials_;
     DedupeCollectionBuilder<real_type> reals_;

--- a/src/celeritas/optical/interactor/WavelengthShiftInteractor.hh
+++ b/src/celeritas/optical/interactor/WavelengthShiftInteractor.hh
@@ -57,7 +57,7 @@ class WavelengthShiftInteractor
     inline CELER_FUNCTION
     WavelengthShiftInteractor(ParamsRef const& shared,
                               ParticleTrackView const& particle,
-                              OpticalMaterialId const& mat_id,
+                              OptMatId const& mat_id,
                               SecondaryAllocator& allocate);
 
     // Sample an interaction with the given RNG
@@ -88,7 +88,7 @@ CELER_FUNCTION
 WavelengthShiftInteractor::WavelengthShiftInteractor(
     ParamsRef const& shared,
     ParticleTrackView const& particle,
-    OpticalMaterialId const& mat_id,
+    OptMatId const& mat_id,
     SecondaryAllocator& allocate)
     : inc_energy_(particle.energy())
     , sample_num_photons_(shared.wls_record[mat_id].mean_num_photons)

--- a/src/celeritas/optical/model/AbsorptionModel.cc
+++ b/src/celeritas/optical/model/AbsorptionModel.cc
@@ -46,7 +46,7 @@ AbsorptionModel::AbsorptionModel(ActionId id, SPConstImported imported)
 /*!
  * Build the mean free paths for the model.
  */
-void AbsorptionModel::build_mfps(OpticalMaterialId mat, MfpBuilder& build) const
+void AbsorptionModel::build_mfps(OptMatId mat, MfpBuilder& build) const
 {
     CELER_EXPECT(mat < imported_.num_materials());
     build(imported_.mfp(mat));

--- a/src/celeritas/optical/model/AbsorptionModel.hh
+++ b/src/celeritas/optical/model/AbsorptionModel.hh
@@ -34,7 +34,7 @@ class AbsorptionModel final : public Model
     AbsorptionModel(ActionId id, SPConstImported imported);
 
     // Build the mean free paths for this model
-    void build_mfps(OpticalMaterialId mat, MfpBuilder&) const final;
+    void build_mfps(OptMatId mat, MfpBuilder&) const final;
 
     // Execute the model with host data
     void step(CoreParams const&, CoreStateHost&) const final;

--- a/src/celeritas/optical/model/RayleighModel.cc
+++ b/src/celeritas/optical/model/RayleighModel.cc
@@ -57,7 +57,7 @@ RayleighModel::RayleighModel(ActionId id, SPConstImported imported, Input input)
                  || input_.materials->num_materials()
                         == imported_.num_materials());
 
-    for (auto mat : range(OpticalMaterialId(imported_.num_materials())))
+    for (auto mat : range(OptMatId(imported_.num_materials())))
     {
         if (input_)
         {
@@ -80,7 +80,7 @@ RayleighModel::RayleighModel(ActionId id, SPConstImported imported, Input input)
 /*!
  * Build the mean free paths for the model.
  */
-void RayleighModel::build_mfps(OpticalMaterialId mat, MfpBuilder& build) const
+void RayleighModel::build_mfps(OptMatId mat, MfpBuilder& build) const
 {
     CELER_EXPECT(mat < imported_.num_materials());
 

--- a/src/celeritas/optical/model/RayleighModel.hh
+++ b/src/celeritas/optical/model/RayleighModel.hh
@@ -57,7 +57,7 @@ class RayleighModel : public Model
     RayleighModel(ActionId id, SPConstImported imported, Input input);
 
     // Build the mean free paths for this model
-    void build_mfps(OpticalMaterialId, MfpBuilder&) const final;
+    void build_mfps(OptMatId, MfpBuilder&) const final;
 
     // Execute the model with host data
     void step(CoreParams const&, CoreStateHost&) const final;

--- a/src/celeritas/phys/Applicability.hh
+++ b/src/celeritas/phys/Applicability.hh
@@ -34,7 +34,7 @@ struct Applicability
     using EnergyUnits = units::Mev;
     using Energy = RealQuantity<EnergyUnits>;
 
-    MaterialId material{};
+    PhysicsMaterialId material{};
     ParticleId particle{};
     Energy lower = zero_quantity();
     Energy upper = max_quantity();

--- a/src/celeritas/phys/Applicability.hh
+++ b/src/celeritas/phys/Applicability.hh
@@ -34,7 +34,7 @@ struct Applicability
     using EnergyUnits = units::Mev;
     using Energy = RealQuantity<EnergyUnits>;
 
-    PhysicsMaterialId material{};
+    PhysMatId material{};
     ParticleId particle{};
     Energy lower = zero_quantity();
     Energy upper = max_quantity();

--- a/src/celeritas/phys/CutoffData.hh
+++ b/src/celeritas/phys/CutoffData.hh
@@ -63,7 +63,8 @@ struct CutoffParamsData
     ParticleItems<size_type> id_to_index;
 
     ParticleId::size_type num_particles;  //!< Particles with production cuts
-    MaterialId::size_type num_materials;  //!< All materials in the problem
+    PhysicsMaterialId::size_type num_materials;  //!< All materials in the
+                                                 //!< problem
 
     bool apply_post_interaction{false};  //!< Apply cutoff post-interaction
     CutoffIds ids;  //!< Secondaries that can be killed post-interaction if

--- a/src/celeritas/phys/CutoffData.hh
+++ b/src/celeritas/phys/CutoffData.hh
@@ -63,8 +63,8 @@ struct CutoffParamsData
     ParticleItems<size_type> id_to_index;
 
     ParticleId::size_type num_particles;  //!< Particles with production cuts
-    PhysicsMaterialId::size_type num_materials;  //!< All materials in the
-                                                 //!< problem
+    PhysMatId::size_type num_materials;  //!< All materials in the
+                                         //!< problem
 
     bool apply_post_interaction{false};  //!< Apply cutoff post-interaction
     CutoffIds ids;  //!< Secondaries that can be killed post-interaction if

--- a/src/celeritas/phys/CutoffData.hh
+++ b/src/celeritas/phys/CutoffData.hh
@@ -63,8 +63,7 @@ struct CutoffParamsData
     ParticleItems<size_type> id_to_index;
 
     ParticleId::size_type num_particles;  //!< Particles with production cuts
-    PhysMatId::size_type num_materials;  //!< All materials in the
-                                         //!< problem
+    PhysMatId::size_type num_materials;  //!< All materials in the problem
 
     bool apply_post_interaction{false};  //!< Apply cutoff post-interaction
     CutoffIds ids;  //!< Secondaries that can be killed post-interaction if

--- a/src/celeritas/phys/CutoffParams.hh
+++ b/src/celeritas/phys/CutoffParams.hh
@@ -85,7 +85,7 @@ class CutoffParams final : public ParamsDataInterface<CutoffParamsData>
     explicit CutoffParams(Input const& input);
 
     // Access cutoffs on host
-    inline CutoffView get(MaterialId material) const;
+    inline CutoffView get(PhysicsMaterialId material) const;
 
     //! Access cutoff data on the host
     HostRef const& host_ref() const final { return data_.host_ref(); }
@@ -110,7 +110,7 @@ class CutoffParams final : public ParamsDataInterface<CutoffParamsData>
 /*!
  * Access cutoffs on host.
  */
-CutoffView CutoffParams::get(MaterialId material) const
+CutoffView CutoffParams::get(PhysicsMaterialId material) const
 {
     CELER_EXPECT(material < this->host_ref().num_materials);
     return CutoffView(this->host_ref(), material);

--- a/src/celeritas/phys/CutoffParams.hh
+++ b/src/celeritas/phys/CutoffParams.hh
@@ -85,7 +85,7 @@ class CutoffParams final : public ParamsDataInterface<CutoffParamsData>
     explicit CutoffParams(Input const& input);
 
     // Access cutoffs on host
-    inline CutoffView get(PhysicsMaterialId material) const;
+    inline CutoffView get(PhysMatId material) const;
 
     //! Access cutoff data on the host
     HostRef const& host_ref() const final { return data_.host_ref(); }
@@ -110,7 +110,7 @@ class CutoffParams final : public ParamsDataInterface<CutoffParamsData>
 /*!
  * Access cutoffs on host.
  */
-CutoffView CutoffParams::get(PhysicsMaterialId material) const
+CutoffView CutoffParams::get(PhysMatId material) const
 {
     CELER_EXPECT(material < this->host_ref().num_materials);
     return CutoffView(this->host_ref(), material);

--- a/src/celeritas/phys/CutoffView.hh
+++ b/src/celeritas/phys/CutoffView.hh
@@ -38,7 +38,7 @@ class CutoffView
   public:
     // Construct for the given particle and material ids
     inline CELER_FUNCTION
-    CutoffView(CutoffData const& params, MaterialId material);
+    CutoffView(CutoffData const& params, PhysicsMaterialId material);
 
     // Return energy cutoff value
     inline CELER_FUNCTION Energy energy(ParticleId particle) const;
@@ -54,7 +54,7 @@ class CutoffView
 
   private:
     CutoffData const& params_;
-    MaterialId material_;
+    PhysicsMaterialId material_;
 
     //// HELPER FUNCTIONS ////
 
@@ -69,7 +69,7 @@ class CutoffView
  * Construct view from host/device for the given material id.
  */
 CELER_FUNCTION
-CutoffView::CutoffView(CutoffData const& params, MaterialId material)
+CutoffView::CutoffView(CutoffData const& params, PhysicsMaterialId material)
     : params_(params), material_(material)
 {
     CELER_EXPECT(params_);

--- a/src/celeritas/phys/CutoffView.hh
+++ b/src/celeritas/phys/CutoffView.hh
@@ -38,7 +38,7 @@ class CutoffView
   public:
     // Construct for the given particle and material ids
     inline CELER_FUNCTION
-    CutoffView(CutoffData const& params, PhysicsMaterialId material);
+    CutoffView(CutoffData const& params, PhysMatId material);
 
     // Return energy cutoff value
     inline CELER_FUNCTION Energy energy(ParticleId particle) const;
@@ -54,7 +54,7 @@ class CutoffView
 
   private:
     CutoffData const& params_;
-    PhysicsMaterialId material_;
+    PhysMatId material_;
 
     //// HELPER FUNCTIONS ////
 
@@ -69,7 +69,7 @@ class CutoffView
  * Construct view from host/device for the given material id.
  */
 CELER_FUNCTION
-CutoffView::CutoffView(CutoffData const& params, PhysicsMaterialId material)
+CutoffView::CutoffView(CutoffData const& params, PhysMatId material)
     : params_(params), material_(material)
 {
     CELER_EXPECT(params_);

--- a/src/celeritas/phys/ImportedModelAdapter.cc
+++ b/src/celeritas/phys/ImportedModelAdapter.cc
@@ -96,8 +96,8 @@ auto ImportedModelAdapter::micro_xs(Applicability applic) const -> MicroXsBuilde
 /*!
  * Get the xs energy grid bounds for the given material and particle.
  */
-auto ImportedModelAdapter::energy_grid_bounds(
-    ParticleId pid, PhysicsMaterialId mid) const -> EnergyBounds
+auto ImportedModelAdapter::energy_grid_bounds(ParticleId pid,
+                                              PhysMatId mid) const -> EnergyBounds
 {
     CELER_EXPECT(pid && mid);
 

--- a/src/celeritas/phys/ImportedModelAdapter.cc
+++ b/src/celeritas/phys/ImportedModelAdapter.cc
@@ -97,7 +97,7 @@ auto ImportedModelAdapter::micro_xs(Applicability applic) const -> MicroXsBuilde
  * Get the xs energy grid bounds for the given material and particle.
  */
 auto ImportedModelAdapter::energy_grid_bounds(
-    ParticleId pid, MaterialId mid) const -> EnergyBounds
+    ParticleId pid, PhysicsMaterialId mid) const -> EnergyBounds
 {
     CELER_EXPECT(pid && mid);
 

--- a/src/celeritas/phys/ImportedModelAdapter.hh
+++ b/src/celeritas/phys/ImportedModelAdapter.hh
@@ -63,7 +63,7 @@ class ImportedModelAdapter
     MicroXsBuilders micro_xs(Applicability range) const;
 
     // Get the xs energy grid bounds for the given material and particle
-    EnergyBounds energy_grid_bounds(ParticleId, PhysicsMaterialId) const;
+    EnergyBounds energy_grid_bounds(ParticleId, PhysMatId) const;
 
     // Get the low energy limit for the given particle
     Energy low_energy_limit(ParticleId) const;

--- a/src/celeritas/phys/ImportedModelAdapter.hh
+++ b/src/celeritas/phys/ImportedModelAdapter.hh
@@ -63,7 +63,7 @@ class ImportedModelAdapter
     MicroXsBuilders micro_xs(Applicability range) const;
 
     // Get the xs energy grid bounds for the given material and particle
-    EnergyBounds energy_grid_bounds(ParticleId, MaterialId) const;
+    EnergyBounds energy_grid_bounds(ParticleId, PhysicsMaterialId) const;
 
     // Get the low energy limit for the given particle
     Energy low_energy_limit(ParticleId) const;

--- a/src/celeritas/phys/ImportedProcessAdapter.cc
+++ b/src/celeritas/phys/ImportedProcessAdapter.cc
@@ -47,7 +47,7 @@ bool is_contiguous_increasing(inp::UniformGrid const& lower,
 //---------------------------------------------------------------------------//
 IPAContextException::IPAContextException(ParticleId id,
                                          ImportProcessClass ipc,
-                                         MaterialId mid)
+                                         PhysicsMaterialId mid)
 {
     std::stringstream os;
     os << "Particle ID=" << id.unchecked_get() << ", process '"

--- a/src/celeritas/phys/ImportedProcessAdapter.cc
+++ b/src/celeritas/phys/ImportedProcessAdapter.cc
@@ -47,7 +47,7 @@ bool is_contiguous_increasing(inp::UniformGrid const& lower,
 //---------------------------------------------------------------------------//
 IPAContextException::IPAContextException(ParticleId id,
                                          ImportProcessClass ipc,
-                                         PhysicsMaterialId mid)
+                                         PhysMatId mid)
 {
     std::stringstream os;
     os << "Particle ID=" << id.unchecked_get() << ", process '"

--- a/src/celeritas/phys/ImportedProcessAdapter.hh
+++ b/src/celeritas/phys/ImportedProcessAdapter.hh
@@ -34,9 +34,7 @@ struct ImportData;
 class IPAContextException : public RichContextException
 {
   public:
-    IPAContextException(ParticleId id,
-                        ImportProcessClass ipc,
-                        PhysicsMaterialId mid);
+    IPAContextException(ParticleId id, ImportProcessClass ipc, PhysMatId mid);
 
     //! This class type
     char const* type() const final { return "ImportProcessAdapterContext"; }

--- a/src/celeritas/phys/ImportedProcessAdapter.hh
+++ b/src/celeritas/phys/ImportedProcessAdapter.hh
@@ -34,7 +34,9 @@ struct ImportData;
 class IPAContextException : public RichContextException
 {
   public:
-    IPAContextException(ParticleId id, ImportProcessClass ipc, MaterialId mid);
+    IPAContextException(ParticleId id,
+                        ImportProcessClass ipc,
+                        PhysicsMaterialId mid);
 
     //! This class type
     char const* type() const final { return "ImportProcessAdapterContext"; }

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -339,7 +339,7 @@ struct PhysicsParamsScalars
  * range tables ordered by [particle][material][energy].
  *
  * So the first applicable process (ProcessId{0}) for an arbitrary particle
- * (ParticleId{1}) in material 2 (PhysicsMaterialId{2}) will have the following
+ * (ParticleId{1}) in material 2 (PhysMatId{2}) will have the following
  * ID and cross section grid: \code
    ProcessId proc_id = params.particle[1].processes[0];
    const UniformGridData& grid

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -339,7 +339,7 @@ struct PhysicsParamsScalars
  * range tables ordered by [particle][material][energy].
  *
  * So the first applicable process (ProcessId{0}) for an arbitrary particle
- * (ParticleId{1}) in material 2 (MaterialId{2}) will have the following
+ * (ParticleId{1}) in material 2 (PhysicsMaterialId{2}) will have the following
  * ID and cross section grid: \code
    ProcessId proc_id = params.particle[1].processes[0];
    const UniformGridData& grid

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -593,9 +593,10 @@ void PhysicsParams::build_xs(Options const& opts,
             }
 
             // Loop over materials
-            for (auto mat_idx : range(MaterialId::size_type{mats.size()}))
+            for (auto mat_idx :
+                 range(PhysicsMaterialId::size_type{mats.size()}))
             {
-                applic.material = MaterialId(mat_idx);
+                applic.material = PhysicsMaterialId(mat_idx);
 
                 // Construct step limit builders
                 auto builders = proc.step_limits(applic);
@@ -734,7 +735,7 @@ void PhysicsParams::build_model_xs(MaterialParams const& mats,
         // Loop over applicable particles
         for (Applicability applic : model.applicability())
         {
-            for (auto mat_id : range(MaterialId{mats.size()}))
+            for (auto mat_id : range(PhysicsMaterialId{mats.size()}))
             {
                 applic.material = mat_id;
                 auto material = mats.get(mat_id);
@@ -789,7 +790,8 @@ void PhysicsParams::build_model_xs(MaterialParams const& mats,
     for (auto& model_table : temp_grid_ids)
     {
         std::vector<ValueTableId> temp_table_ids(model_table.size());
-        for (auto mat_idx : range<MaterialId::size_type>(model_table.size()))
+        for (auto mat_idx :
+             range<PhysicsMaterialId::size_type>(model_table.size()))
         {
             auto& grid_ids = model_table[mat_idx];
             if (grid_ids.empty())
@@ -814,7 +816,8 @@ void PhysicsParams::build_model_xs(MaterialParams const& mats,
                 = data->value_grids[grid_ids[0]].lower.value.size();
 
             // Calculate the cross section CDF
-            auto const&& elements = mats.get(MaterialId{mat_idx}).elements();
+            auto const&& elements
+                = mats.get(PhysicsMaterialId{mat_idx}).elements();
             for (auto bin_idx : range(num_bins))
             {
                 real_type cum_xs{0};

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -593,10 +593,9 @@ void PhysicsParams::build_xs(Options const& opts,
             }
 
             // Loop over materials
-            for (auto mat_idx :
-                 range(PhysicsMaterialId::size_type{mats.size()}))
+            for (auto mat_idx : range(PhysMatId::size_type{mats.size()}))
             {
-                applic.material = PhysicsMaterialId(mat_idx);
+                applic.material = PhysMatId(mat_idx);
 
                 // Construct step limit builders
                 auto builders = proc.step_limits(applic);
@@ -735,7 +734,7 @@ void PhysicsParams::build_model_xs(MaterialParams const& mats,
         // Loop over applicable particles
         for (Applicability applic : model.applicability())
         {
-            for (auto mat_id : range(PhysicsMaterialId{mats.size()}))
+            for (auto mat_id : range(PhysMatId{mats.size()}))
             {
                 applic.material = mat_id;
                 auto material = mats.get(mat_id);
@@ -790,8 +789,7 @@ void PhysicsParams::build_model_xs(MaterialParams const& mats,
     for (auto& model_table : temp_grid_ids)
     {
         std::vector<ValueTableId> temp_table_ids(model_table.size());
-        for (auto mat_idx :
-             range<PhysicsMaterialId::size_type>(model_table.size()))
+        for (auto mat_idx : range<PhysMatId::size_type>(model_table.size()))
         {
             auto& grid_ids = model_table[mat_idx];
             if (grid_ids.empty())
@@ -816,8 +814,7 @@ void PhysicsParams::build_model_xs(MaterialParams const& mats,
                 = data->value_grids[grid_ids[0]].lower.value.size();
 
             // Calculate the cross section CDF
-            auto const&& elements
-                = mats.get(PhysicsMaterialId{mat_idx}).elements();
+            auto const&& elements = mats.get(PhysMatId{mat_idx}).elements();
             for (auto bin_idx : range(num_bins))
             {
                 real_type cum_xs{0};

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -51,7 +51,7 @@ class PhysicsTrackView
     inline CELER_FUNCTION PhysicsTrackView(PhysicsParamsRef const& params,
                                            PhysicsStateRef const& states,
                                            ParticleTrackView const& particle,
-                                           PhysicsMaterialId material,
+                                           PhysMatId material,
                                            TrackSlotId tid);
 
     // Initialize the track view
@@ -84,7 +84,7 @@ class PhysicsTrackView
     CELER_FORCEINLINE_FUNCTION MscRange const& msc_range() const;
 
     // Current material identifier
-    CELER_FORCEINLINE_FUNCTION PhysicsMaterialId material_id() const;
+    CELER_FORCEINLINE_FUNCTION PhysMatId material_id() const;
 
     //// PROCESSES (depend on particle type and possibly material) ////
 
@@ -171,7 +171,7 @@ class PhysicsTrackView
     PhysicsParamsRef const& params_;
     PhysicsStateRef const& states_;
     ParticleId const particle_;
-    PhysicsMaterialId const material_;
+    PhysMatId const material_;
     TrackSlotId const track_slot_;
     bool is_heavy_;
 
@@ -195,7 +195,7 @@ CELER_FUNCTION
 PhysicsTrackView::PhysicsTrackView(PhysicsParamsRef const& params,
                                    PhysicsStateRef const& states,
                                    ParticleTrackView const& particle,
-                                   PhysicsMaterialId mid,
+                                   PhysMatId mid,
                                    TrackSlotId tid)
     : params_(params)
     , states_(states)
@@ -269,7 +269,7 @@ CELER_FUNCTION void PhysicsTrackView::msc_range(MscRange const& msc_range)
 /*!
  * Current material identifier.
  */
-CELER_FUNCTION PhysicsMaterialId PhysicsTrackView::material_id() const
+CELER_FUNCTION PhysMatId PhysicsTrackView::material_id() const
 {
     return material_;
 }

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -51,7 +51,7 @@ class PhysicsTrackView
     inline CELER_FUNCTION PhysicsTrackView(PhysicsParamsRef const& params,
                                            PhysicsStateRef const& states,
                                            ParticleTrackView const& particle,
-                                           MaterialId material,
+                                           PhysicsMaterialId material,
                                            TrackSlotId tid);
 
     // Initialize the track view
@@ -84,7 +84,7 @@ class PhysicsTrackView
     CELER_FORCEINLINE_FUNCTION MscRange const& msc_range() const;
 
     // Current material identifier
-    CELER_FORCEINLINE_FUNCTION MaterialId material_id() const;
+    CELER_FORCEINLINE_FUNCTION PhysicsMaterialId material_id() const;
 
     //// PROCESSES (depend on particle type and possibly material) ////
 
@@ -171,7 +171,7 @@ class PhysicsTrackView
     PhysicsParamsRef const& params_;
     PhysicsStateRef const& states_;
     ParticleId const particle_;
-    MaterialId const material_;
+    PhysicsMaterialId const material_;
     TrackSlotId const track_slot_;
     bool is_heavy_;
 
@@ -195,7 +195,7 @@ CELER_FUNCTION
 PhysicsTrackView::PhysicsTrackView(PhysicsParamsRef const& params,
                                    PhysicsStateRef const& states,
                                    ParticleTrackView const& particle,
-                                   MaterialId mid,
+                                   PhysicsMaterialId mid,
                                    TrackSlotId tid)
     : params_(params)
     , states_(states)
@@ -269,7 +269,7 @@ CELER_FUNCTION void PhysicsTrackView::msc_range(MscRange const& msc_range)
 /*!
  * Current material identifier.
  */
-CELER_FUNCTION MaterialId PhysicsTrackView::material_id() const
+CELER_FUNCTION PhysicsMaterialId PhysicsTrackView::material_id() const
 {
     return material_;
 }

--- a/src/geocel/Types.hh
+++ b/src/geocel/Types.hh
@@ -39,7 +39,7 @@ using SquareMatrixReal3 = SquareMatrix<real_type, 3>;
 using LevelId = OpaqueId<struct Level_>;
 
 //! Identifier for a material fill
-using GeoMaterialId = OpaqueId<struct GeoMaterial_>;
+using GeoMatId = OpaqueId<struct GeoMaterial_>;
 
 //! Identifier for a surface (for surface-based geometries)
 using SurfaceId = OpaqueId<struct Surface_>;

--- a/src/orange/g4org/LogicalVolumeConverter.cc
+++ b/src/orange/g4org/LogicalVolumeConverter.cc
@@ -88,13 +88,13 @@ auto LogicalVolumeConverter::construct_impl(arg_type g4lv) -> SPLV
     // NOTE: this is *not* the physics material ("cut couple")
     if (auto* mat = g4lv.GetMaterial())
     {
-        result->material_id = id_cast<GeoMaterialId>(mat->GetIndex());
+        result->material_id = id_cast<GeoMatId>(mat->GetIndex());
     }
     else
     {
         CELER_LOG(warning) << "Logical volume '" << result->label
                            << "' has no associated material";
-        result->material_id = GeoMaterialId{0};
+        result->material_id = GeoMatId{0};
     }
 
     // Convert solid

--- a/src/orange/g4org/Volume.hh
+++ b/src/orange/g4org/Volume.hh
@@ -59,7 +59,7 @@ struct LogicalVolume
     //! Logical volume name and optional uniquifying extension
     Label label;
     //! Filled material ID
-    GeoMaterialId material_id;
+    GeoMatId material_id;
 
     //! "Unplaced" parent shape
     SPConstObject solid;

--- a/src/orange/orangeinp/CsgTreeIO.json.cc
+++ b/src/orange/orangeinp/CsgTreeIO.json.cc
@@ -134,7 +134,7 @@ void to_json(nlohmann::json& j, CsgUnit const& unit)
         {
             auto entry
                 = nlohmann::json{{"csg_node", unit.tree.volumes()[i].get()}};
-            if (auto* m = std::get_if<GeoMaterialId>(&unit.fills[i]))
+            if (auto* m = std::get_if<GeoMatId>(&unit.fills[i]))
             {
                 entry["material"] = m->unchecked_get();
             }

--- a/src/orange/orangeinp/UnitProto.hh
+++ b/src/orange/orangeinp/UnitProto.hh
@@ -80,7 +80,7 @@ class UnitProto : public ProtoInterface
     //! Optional "background" inside of exterior, outside of all mat/daughter
     struct BackgroundInput
     {
-        GeoMaterialId fill{};
+        GeoMatId fill{};
         Label label;
 
         // True if fill or label is specified
@@ -91,7 +91,7 @@ class UnitProto : public ProtoInterface
     struct MaterialInput
     {
         SPConstObject interior;
-        GeoMaterialId fill;
+        GeoMatId fill;
         Label label;
 
         // True if fully defined

--- a/src/orange/orangeinp/detail/CsgUnit.hh
+++ b/src/orange/orangeinp/detail/CsgUnit.hh
@@ -47,7 +47,7 @@ struct CsgUnit
 
     using Metadata = Label;
     using SetMd = std::set<Metadata>;
-    using Fill = std::variant<std::monostate, GeoMaterialId, Daughter>;
+    using Fill = std::variant<std::monostate, GeoMatId, Daughter>;
 
     //! Attributes about a closed volume of space
     struct Region
@@ -76,7 +76,7 @@ struct CsgUnit
     //! \name Volumes
     //! Vector is indexed by LocalVolumeId.
     std::vector<Fill> fills;  //!< Content of each volume
-    GeoMaterialId background;  //!< Optional background fill
+    GeoMatId background;  //!< Optional background fill
     //!@}
 
     //!@{

--- a/src/orange/orangeinp/detail/CsgUnitBuilder.cc
+++ b/src/orange/orangeinp/detail/CsgUnitBuilder.cc
@@ -160,7 +160,7 @@ void CsgUnitBuilder::fill_exterior()
 /*!
  * Fill a volume node with a material.
  */
-void CsgUnitBuilder::fill_volume(LocalVolumeId v, GeoMaterialId m)
+void CsgUnitBuilder::fill_volume(LocalVolumeId v, GeoMatId m)
 {
     CELER_EXPECT(v < unit_->fills.size());
     CELER_EXPECT(m);

--- a/src/orange/orangeinp/detail/CsgUnitBuilder.hh
+++ b/src/orange/orangeinp/detail/CsgUnitBuilder.hh
@@ -100,7 +100,7 @@ class CsgUnitBuilder
     void fill_exterior();
 
     // Fill a volume node with a material
-    void fill_volume(LocalVolumeId, GeoMaterialId);
+    void fill_volume(LocalVolumeId, GeoMatId);
 
     // Fill a volume node with a daughter using the local transform
     void

--- a/test/celeritas/InvalidOrangeTestBase.cc
+++ b/test/celeritas/InvalidOrangeTestBase.cc
@@ -42,14 +42,12 @@ make_sph(std::string&& label, real_type radius, Real3 const& trans)
         make_sph(std::move(label), radius), Translation{trans});
 }
 
-auto make_material(std::string&& label,
-                   GeoMaterialId::size_type m,
-                   SPConstObject obj)
+auto make_material(std::string&& label, GeoMatId::size_type m, SPConstObject obj)
 {
     CELER_EXPECT(obj);
     orangeinp::UnitProto::MaterialInput result;
     result.interior = std::move(obj);
-    result.fill = GeoMaterialId{m};
+    result.fill = GeoMatId{m};
     result.label = std::move(label);
     return result;
 }
@@ -115,11 +113,11 @@ auto InvalidOrangeTestBase::build_geomaterial() -> SPConstGeoMaterial
     input.geometry = this->geometry();
     input.materials = this->material();
     input.volume_to_mat = {
-        PhysicsMaterialId{0},
-        PhysicsMaterialId{0},
-        PhysicsMaterialId{1},
-        PhysicsMaterialId{},
-        PhysicsMaterialId{},
+        PhysMatId{0},
+        PhysMatId{0},
+        PhysMatId{1},
+        PhysMatId{},
+        PhysMatId{},
     };
     input.volume_labels = {
         Label{"interior"},

--- a/test/celeritas/InvalidOrangeTestBase.cc
+++ b/test/celeritas/InvalidOrangeTestBase.cc
@@ -115,11 +115,11 @@ auto InvalidOrangeTestBase::build_geomaterial() -> SPConstGeoMaterial
     input.geometry = this->geometry();
     input.materials = this->material();
     input.volume_to_mat = {
-        MaterialId{0},
-        MaterialId{0},
-        MaterialId{1},
-        MaterialId{},
-        MaterialId{},
+        PhysicsMaterialId{0},
+        PhysicsMaterialId{0},
+        PhysicsMaterialId{1},
+        PhysicsMaterialId{},
+        PhysicsMaterialId{},
     };
     input.volume_labels = {
         Label{"interior"},

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -91,8 +91,10 @@ auto MockTestBase::build_geomaterial() -> SPConstGeoMaterial
     GeoMaterialParams::Input input;
     input.geometry = this->geometry();
     input.materials = this->material();
-    input.volume_to_mat
-        = {MaterialId{0}, MaterialId{2}, MaterialId{1}, MaterialId{3}};
+    input.volume_to_mat = {PhysicsMaterialId{0},
+                           PhysicsMaterialId{2},
+                           PhysicsMaterialId{1},
+                           PhysicsMaterialId{3}};
     input.volume_labels
         = {Label{"inner"}, Label{"middle"}, Label{"outer"}, Label{"world"}};
     return std::make_shared<GeoMaterialParams>(std::move(input));

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -91,10 +91,8 @@ auto MockTestBase::build_geomaterial() -> SPConstGeoMaterial
     GeoMaterialParams::Input input;
     input.geometry = this->geometry();
     input.materials = this->material();
-    input.volume_to_mat = {PhysicsMaterialId{0},
-                           PhysicsMaterialId{2},
-                           PhysicsMaterialId{1},
-                           PhysicsMaterialId{3}};
+    input.volume_to_mat
+        = {PhysMatId{0}, PhysMatId{2}, PhysMatId{1}, PhysMatId{3}};
     input.volume_labels
         = {Label{"inner"}, Label{"middle"}, Label{"outer"}, Label{"world"}};
     return std::make_shared<GeoMaterialParams>(std::move(input));

--- a/test/celeritas/SimpleTestBase.cc
+++ b/test/celeritas/SimpleTestBase.cc
@@ -49,8 +49,7 @@ auto SimpleTestBase::build_geomaterial() -> SPConstGeoMaterial
     GeoMaterialParams::Input input;
     input.geometry = this->geometry();
     input.materials = this->material();
-    input.volume_to_mat
-        = {PhysicsMaterialId{0}, PhysicsMaterialId{1}, PhysicsMaterialId{}};
+    input.volume_to_mat = {PhysMatId{0}, PhysMatId{1}, PhysMatId{}};
     input.volume_labels = {Label{"inner"}, Label{"world"}, Label{"[EXTERIOR]"}};
     return std::make_shared<GeoMaterialParams>(std::move(input));
 }

--- a/test/celeritas/SimpleTestBase.cc
+++ b/test/celeritas/SimpleTestBase.cc
@@ -49,7 +49,8 @@ auto SimpleTestBase::build_geomaterial() -> SPConstGeoMaterial
     GeoMaterialParams::Input input;
     input.geometry = this->geometry();
     input.materials = this->material();
-    input.volume_to_mat = {MaterialId{0}, MaterialId{1}, MaterialId{}};
+    input.volume_to_mat
+        = {PhysicsMaterialId{0}, PhysicsMaterialId{1}, PhysicsMaterialId{}};
     input.volume_labels = {Label{"inner"}, Label{"world"}, Label{"[EXTERIOR]"}};
     return std::make_shared<GeoMaterialParams>(std::move(input));
 }

--- a/test/celeritas/em/BetheBloch.test.cc
+++ b/test/celeritas/em/BetheBloch.test.cc
@@ -176,7 +176,7 @@ TEST_F(BetheBlochTest, basic)
     MuHadIonizationInteractor<BetheBlochEnergyDistribution> interact(
         model_->host_ref(),
         this->particle_track(),
-        this->cutoff_params()->get(PhysicsMaterialId{0}),
+        this->cutoff_params()->get(PhysMatId{0}),
         this->direction(),
         this->secondary_allocator());
     RandomEngine& rng = this->rng();
@@ -237,7 +237,7 @@ TEST_F(BetheBlochTest, basic)
         MuHadIonizationInteractor<BetheBlochEnergyDistribution> interact(
             model_->host_ref(),
             this->particle_track(),
-            this->cutoff_params()->get(PhysicsMaterialId{0}),
+            this->cutoff_params()->get(PhysMatId{0}),
             this->direction(),
             this->secondary_allocator());
 
@@ -276,7 +276,7 @@ TEST_F(BetheBlochTest, stress_test)
             MuHadIonizationInteractor<BetheBlochEnergyDistribution> interact(
                 model_->host_ref(),
                 this->particle_track(),
-                this->cutoff_params()->get(PhysicsMaterialId{0}),
+                this->cutoff_params()->get(PhysMatId{0}),
                 this->direction(),
                 this->secondary_allocator());
 

--- a/test/celeritas/em/BetheBloch.test.cc
+++ b/test/celeritas/em/BetheBloch.test.cc
@@ -176,7 +176,7 @@ TEST_F(BetheBlochTest, basic)
     MuHadIonizationInteractor<BetheBlochEnergyDistribution> interact(
         model_->host_ref(),
         this->particle_track(),
-        this->cutoff_params()->get(MaterialId{0}),
+        this->cutoff_params()->get(PhysicsMaterialId{0}),
         this->direction(),
         this->secondary_allocator());
     RandomEngine& rng = this->rng();
@@ -237,7 +237,7 @@ TEST_F(BetheBlochTest, basic)
         MuHadIonizationInteractor<BetheBlochEnergyDistribution> interact(
             model_->host_ref(),
             this->particle_track(),
-            this->cutoff_params()->get(MaterialId{0}),
+            this->cutoff_params()->get(PhysicsMaterialId{0}),
             this->direction(),
             this->secondary_allocator());
 
@@ -276,7 +276,7 @@ TEST_F(BetheBlochTest, stress_test)
             MuHadIonizationInteractor<BetheBlochEnergyDistribution> interact(
                 model_->host_ref(),
                 this->particle_track(),
-                this->cutoff_params()->get(MaterialId{0}),
+                this->cutoff_params()->get(PhysicsMaterialId{0}),
                 this->direction(),
                 this->secondary_allocator());
 

--- a/test/celeritas/em/BraggICRU73QO.test.cc
+++ b/test/celeritas/em/BraggICRU73QO.test.cc
@@ -195,7 +195,7 @@ TEST_F(BraggICRU73QOTest, basic)
         MuHadIonizationInteractor<BraggICRU73QOEnergyDistribution> interact(
             data,
             this->particle_track(),
-            this->cutoff_params()->get(PhysicsMaterialId{0}),
+            this->cutoff_params()->get(PhysMatId{0}),
             this->direction(),
             this->secondary_allocator());
         RandomEngine& rng = this->rng();
@@ -230,7 +230,7 @@ TEST_F(BraggICRU73QOTest, basic)
             MuHadIonizationInteractor<BraggICRU73QOEnergyDistribution> interact(
                 data,
                 this->particle_track(),
-                this->cutoff_params()->get(PhysicsMaterialId{0}),
+                this->cutoff_params()->get(PhysMatId{0}),
                 this->direction(),
                 this->secondary_allocator());
 
@@ -312,7 +312,7 @@ TEST_F(BraggICRU73QOTest, stress_test)
                 MuHadIonizationInteractor<BraggICRU73QOEnergyDistribution>
                     interact(data,
                              this->particle_track(),
-                             this->cutoff_params()->get(PhysicsMaterialId{0}),
+                             this->cutoff_params()->get(PhysMatId{0}),
                              this->direction(),
                              this->secondary_allocator());
 

--- a/test/celeritas/em/BraggICRU73QO.test.cc
+++ b/test/celeritas/em/BraggICRU73QO.test.cc
@@ -195,7 +195,7 @@ TEST_F(BraggICRU73QOTest, basic)
         MuHadIonizationInteractor<BraggICRU73QOEnergyDistribution> interact(
             data,
             this->particle_track(),
-            this->cutoff_params()->get(MaterialId{0}),
+            this->cutoff_params()->get(PhysicsMaterialId{0}),
             this->direction(),
             this->secondary_allocator());
         RandomEngine& rng = this->rng();
@@ -230,7 +230,7 @@ TEST_F(BraggICRU73QOTest, basic)
             MuHadIonizationInteractor<BraggICRU73QOEnergyDistribution> interact(
                 data,
                 this->particle_track(),
-                this->cutoff_params()->get(MaterialId{0}),
+                this->cutoff_params()->get(PhysicsMaterialId{0}),
                 this->direction(),
                 this->secondary_allocator());
 
@@ -312,7 +312,7 @@ TEST_F(BraggICRU73QOTest, stress_test)
                 MuHadIonizationInteractor<BraggICRU73QOEnergyDistribution>
                     interact(data,
                              this->particle_track(),
-                             this->cutoff_params()->get(MaterialId{0}),
+                             this->cutoff_params()->get(PhysicsMaterialId{0}),
                              this->direction(),
                              this->secondary_allocator());
 

--- a/test/celeritas/em/CombinedBrem.test.cc
+++ b/test/celeritas/em/CombinedBrem.test.cc
@@ -95,7 +95,7 @@ class CombinedBremTest : public InteractorHostTestBase
         this->set_material("Cu");
     }
 
-    EnergySq density_correction(MaterialId matid, Energy e) const
+    EnergySq density_correction(PhysicsMaterialId matid, Energy e) const
     {
         CELER_EXPECT(matid);
         CELER_EXPECT(e > zero_quantity());
@@ -130,7 +130,7 @@ TEST_F(CombinedBremTest, basic_seltzer_berger)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Create the interactor
     CombinedBremInteractor interact(model_->host_ref(),
@@ -194,7 +194,7 @@ TEST_F(CombinedBremTest, basic_relativistic_brem)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Set the incident particle energy
     this->set_inc_particle(pdg::electron(), MevEnergy{25000});
@@ -259,7 +259,7 @@ TEST_F(CombinedBremTest, stress_test_combined)
     std::vector<double> avg_energy_samples;
 
     // Views
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
     auto material_view = this->material_track().material_record();
 
     // Loop over a set of incident gamma energies

--- a/test/celeritas/em/CombinedBrem.test.cc
+++ b/test/celeritas/em/CombinedBrem.test.cc
@@ -95,7 +95,7 @@ class CombinedBremTest : public InteractorHostTestBase
         this->set_material("Cu");
     }
 
-    EnergySq density_correction(PhysicsMaterialId matid, Energy e) const
+    EnergySq density_correction(PhysMatId matid, Energy e) const
     {
         CELER_EXPECT(matid);
         CELER_EXPECT(e > zero_quantity());
@@ -130,7 +130,7 @@ TEST_F(CombinedBremTest, basic_seltzer_berger)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
 
     // Create the interactor
     CombinedBremInteractor interact(model_->host_ref(),
@@ -194,7 +194,7 @@ TEST_F(CombinedBremTest, basic_relativistic_brem)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
 
     // Set the incident particle energy
     this->set_inc_particle(pdg::electron(), MevEnergy{25000});
@@ -259,7 +259,7 @@ TEST_F(CombinedBremTest, stress_test_combined)
     std::vector<double> avg_energy_samples;
 
     // Views
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
     auto material_view = this->material_track().material_record();
 
     // Loop over a set of incident gamma energies

--- a/test/celeritas/em/CoulombScattering.test.cc
+++ b/test/celeritas/em/CoulombScattering.test.cc
@@ -158,7 +158,7 @@ class CoulombScatteringTest : public InteractorHostTestBase
     IsotopeComponentId isocomp_id_{0};
     ElementComponentId elcomp_id_{0};
     ElementId el_id_{0};
-    PhysicsMaterialId mat_id_{0};
+    PhysMatId mat_id_{0};
 };
 
 TEST_F(CoulombScatteringTest, helper)

--- a/test/celeritas/em/CoulombScattering.test.cc
+++ b/test/celeritas/em/CoulombScattering.test.cc
@@ -158,7 +158,7 @@ class CoulombScatteringTest : public InteractorHostTestBase
     IsotopeComponentId isocomp_id_{0};
     ElementComponentId elcomp_id_{0};
     ElementId el_id_{0};
-    MaterialId mat_id_{0};
+    PhysicsMaterialId mat_id_{0};
 };
 
 TEST_F(CoulombScatteringTest, helper)

--- a/test/celeritas/em/LivermorePE.test.cc
+++ b/test/celeritas/em/LivermorePE.test.cc
@@ -143,7 +143,7 @@ TEST_F(LivermorePETest, basic)
     ElementId el_id{0};
 
     // Production cuts
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
 
     // Helper for simulating atomic relaxation
     AtomicRelaxationHelper relaxation(
@@ -212,7 +212,7 @@ TEST_F(LivermorePETest, stress_test)
     ElementId el_id{0};
 
     // Production cuts
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
 
     // Helper for simulating atomic relaxation
     AtomicRelaxationHelper relaxation(
@@ -306,7 +306,7 @@ TEST_F(LivermorePETest, distributions_all)
     ElementId el_id{0};
 
     // Production cuts
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
 
     // Load atomic relaxation data
     relax_inp_.is_auger_enabled = true;
@@ -402,7 +402,7 @@ TEST_F(LivermorePETest, distributions_radiative)
     ElementId el_id{0};
 
     // Production cuts
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
 
     // Load atomic relaxation data
     relax_inp_.is_auger_enabled = false;

--- a/test/celeritas/em/LivermorePE.test.cc
+++ b/test/celeritas/em/LivermorePE.test.cc
@@ -143,7 +143,7 @@ TEST_F(LivermorePETest, basic)
     ElementId el_id{0};
 
     // Production cuts
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Helper for simulating atomic relaxation
     AtomicRelaxationHelper relaxation(
@@ -212,7 +212,7 @@ TEST_F(LivermorePETest, stress_test)
     ElementId el_id{0};
 
     // Production cuts
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Helper for simulating atomic relaxation
     AtomicRelaxationHelper relaxation(
@@ -306,7 +306,7 @@ TEST_F(LivermorePETest, distributions_all)
     ElementId el_id{0};
 
     // Production cuts
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Load atomic relaxation data
     relax_inp_.is_auger_enabled = true;
@@ -402,7 +402,7 @@ TEST_F(LivermorePETest, distributions_radiative)
     ElementId el_id{0};
 
     // Production cuts
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Load atomic relaxation data
     relax_inp_.is_auger_enabled = false;

--- a/test/celeritas/em/MollerBhabha.test.cc
+++ b/test/celeritas/em/MollerBhabha.test.cc
@@ -121,7 +121,8 @@ TEST_F(MollerBhabhaInteractorTest, basic)
                                   {1e5, {3, 7, -6}}};
     // clang-format on
 
-    CutoffView cutoff_view(this->cutoff_params()->host_ref(), MaterialId{0});
+    CutoffView cutoff_view(this->cutoff_params()->host_ref(),
+                           PhysicsMaterialId{0});
 
     for (SampleInit const& init : samples)
     {
@@ -226,7 +227,8 @@ TEST_F(MollerBhabhaInteractorTest, cutoff_1MeV)
     cutoff_inp.cutoffs.insert({pdg::positron(), material_cutoffs});
     this->set_cutoff_params(cutoff_inp);
 
-    CutoffView cutoff_view(this->cutoff_params()->host_ref(), MaterialId{0});
+    CutoffView cutoff_view(this->cutoff_params()->host_ref(),
+                           PhysicsMaterialId{0});
 
     for (SampleInit const& init : samples)
     {
@@ -313,7 +315,8 @@ TEST_F(MollerBhabhaInteractorTest, stress_test)
     int const num_samples = 10000;
     std::vector<double> avg_engine_samples;
 
-    CutoffView cutoff_view(this->cutoff_params()->host_ref(), MaterialId{0});
+    CutoffView cutoff_view(this->cutoff_params()->host_ref(),
+                           PhysicsMaterialId{0});
 
     // Moller's max energy fraction is 0.5, which leads to E_K > 2e-3
     // Bhabha's max energy fraction is 1.0, which leads to E_K > 1e-3

--- a/test/celeritas/em/MollerBhabha.test.cc
+++ b/test/celeritas/em/MollerBhabha.test.cc
@@ -121,8 +121,7 @@ TEST_F(MollerBhabhaInteractorTest, basic)
                                   {1e5, {3, 7, -6}}};
     // clang-format on
 
-    CutoffView cutoff_view(this->cutoff_params()->host_ref(),
-                           PhysicsMaterialId{0});
+    CutoffView cutoff_view(this->cutoff_params()->host_ref(), PhysMatId{0});
 
     for (SampleInit const& init : samples)
     {
@@ -227,8 +226,7 @@ TEST_F(MollerBhabhaInteractorTest, cutoff_1MeV)
     cutoff_inp.cutoffs.insert({pdg::positron(), material_cutoffs});
     this->set_cutoff_params(cutoff_inp);
 
-    CutoffView cutoff_view(this->cutoff_params()->host_ref(),
-                           PhysicsMaterialId{0});
+    CutoffView cutoff_view(this->cutoff_params()->host_ref(), PhysMatId{0});
 
     for (SampleInit const& init : samples)
     {
@@ -315,8 +313,7 @@ TEST_F(MollerBhabhaInteractorTest, stress_test)
     int const num_samples = 10000;
     std::vector<double> avg_engine_samples;
 
-    CutoffView cutoff_view(this->cutoff_params()->host_ref(),
-                           PhysicsMaterialId{0});
+    CutoffView cutoff_view(this->cutoff_params()->host_ref(), PhysMatId{0});
 
     // Moller's max energy fraction is 0.5, which leads to E_K > 2e-3
     // Bhabha's max energy fraction is 1.0, which leads to E_K > 1e-3

--- a/test/celeritas/em/MuBetheBloch.test.cc
+++ b/test/celeritas/em/MuBetheBloch.test.cc
@@ -176,7 +176,7 @@ TEST_F(MuBetheBlochTest, basic)
     MuHadIonizationInteractor<MuBBEnergyDistribution> interact(
         model_->host_ref(),
         this->particle_track(),
-        this->cutoff_params()->get(PhysicsMaterialId{0}),
+        this->cutoff_params()->get(PhysMatId{0}),
         this->direction(),
         this->secondary_allocator());
     RandomEngine& rng = this->rng();
@@ -233,7 +233,7 @@ TEST_F(MuBetheBlochTest, basic)
         MuHadIonizationInteractor<MuBBEnergyDistribution> interact(
             model_->host_ref(),
             this->particle_track(),
-            this->cutoff_params()->get(PhysicsMaterialId{0}),
+            this->cutoff_params()->get(PhysMatId{0}),
             this->direction(),
             this->secondary_allocator());
 
@@ -272,7 +272,7 @@ TEST_F(MuBetheBlochTest, stress_test)
             MuHadIonizationInteractor<MuBBEnergyDistribution> interact(
                 model_->host_ref(),
                 this->particle_track(),
-                this->cutoff_params()->get(PhysicsMaterialId{0}),
+                this->cutoff_params()->get(PhysMatId{0}),
                 this->direction(),
                 this->secondary_allocator());
 

--- a/test/celeritas/em/MuBetheBloch.test.cc
+++ b/test/celeritas/em/MuBetheBloch.test.cc
@@ -176,7 +176,7 @@ TEST_F(MuBetheBlochTest, basic)
     MuHadIonizationInteractor<MuBBEnergyDistribution> interact(
         model_->host_ref(),
         this->particle_track(),
-        this->cutoff_params()->get(MaterialId{0}),
+        this->cutoff_params()->get(PhysicsMaterialId{0}),
         this->direction(),
         this->secondary_allocator());
     RandomEngine& rng = this->rng();
@@ -233,7 +233,7 @@ TEST_F(MuBetheBlochTest, basic)
         MuHadIonizationInteractor<MuBBEnergyDistribution> interact(
             model_->host_ref(),
             this->particle_track(),
-            this->cutoff_params()->get(MaterialId{0}),
+            this->cutoff_params()->get(PhysicsMaterialId{0}),
             this->direction(),
             this->secondary_allocator());
 
@@ -272,7 +272,7 @@ TEST_F(MuBetheBlochTest, stress_test)
             MuHadIonizationInteractor<MuBBEnergyDistribution> interact(
                 model_->host_ref(),
                 this->particle_track(),
-                this->cutoff_params()->get(MaterialId{0}),
+                this->cutoff_params()->get(PhysicsMaterialId{0}),
                 this->direction(),
                 this->secondary_allocator());
 

--- a/test/celeritas/em/MuBremsstrahlung.test.cc
+++ b/test/celeritas/em/MuBremsstrahlung.test.cc
@@ -144,7 +144,7 @@ TEST_F(MuBremsstrahlungTest, basic)
         data_,
         this->particle_track(),
         this->direction(),
-        this->cutoff_params()->get(MaterialId{0}),
+        this->cutoff_params()->get(PhysicsMaterialId{0}),
         this->secondary_allocator(),
         material,
         ElementComponentId{0});
@@ -231,7 +231,7 @@ TEST_F(MuBremsstrahlungTest, stress_test)
                     data_,
                     this->particle_track(),
                     this->direction(),
-                    this->cutoff_params()->get(MaterialId{0}),
+                    this->cutoff_params()->get(PhysicsMaterialId{0}),
                     this->secondary_allocator(),
                     material,
                     ElementComponentId{0});

--- a/test/celeritas/em/MuBremsstrahlung.test.cc
+++ b/test/celeritas/em/MuBremsstrahlung.test.cc
@@ -144,7 +144,7 @@ TEST_F(MuBremsstrahlungTest, basic)
         data_,
         this->particle_track(),
         this->direction(),
-        this->cutoff_params()->get(PhysicsMaterialId{0}),
+        this->cutoff_params()->get(PhysMatId{0}),
         this->secondary_allocator(),
         material,
         ElementComponentId{0});
@@ -231,7 +231,7 @@ TEST_F(MuBremsstrahlungTest, stress_test)
                     data_,
                     this->particle_track(),
                     this->direction(),
-                    this->cutoff_params()->get(PhysicsMaterialId{0}),
+                    this->cutoff_params()->get(PhysMatId{0}),
                     this->secondary_allocator(),
                     material,
                     ElementComponentId{0});

--- a/test/celeritas/em/MuPairProduction.test.cc
+++ b/test/celeritas/em/MuPairProduction.test.cc
@@ -129,7 +129,7 @@ TEST_F(MuPairProductionTest, distribution)
         ElementComponentId{0});
 
     // Get the production cuts
-    auto cutoff = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoff = this->cutoff_params()->get(PhysMatId{0});
 
     RandomEngine& rng = InteractorHostBase::rng();
 
@@ -222,7 +222,7 @@ TEST_F(MuPairProductionTest, basic)
         ElementComponentId{0});
 
     // Get the production cuts
-    auto cutoff = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoff = this->cutoff_params()->get(PhysMatId{0});
 
     // Create the interactor
     MuPairProductionInteractor interact(model_->host_ref(),
@@ -292,7 +292,7 @@ TEST_F(MuPairProductionTest, stress_test)
         ElementComponentId{0});
 
     // Get the production cuts
-    auto cutoff = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoff = this->cutoff_params()->get(PhysMatId{0});
 
     for (real_type inc_e : {1e3, 1e4, 1e5, 1e6, 1e7})
     {

--- a/test/celeritas/em/MuPairProduction.test.cc
+++ b/test/celeritas/em/MuPairProduction.test.cc
@@ -129,7 +129,7 @@ TEST_F(MuPairProductionTest, distribution)
         ElementComponentId{0});
 
     // Get the production cuts
-    auto cutoff = this->cutoff_params()->get(MaterialId{0});
+    auto cutoff = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     RandomEngine& rng = InteractorHostBase::rng();
 
@@ -222,7 +222,7 @@ TEST_F(MuPairProductionTest, basic)
         ElementComponentId{0});
 
     // Get the production cuts
-    auto cutoff = this->cutoff_params()->get(MaterialId{0});
+    auto cutoff = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Create the interactor
     MuPairProductionInteractor interact(model_->host_ref(),
@@ -292,7 +292,7 @@ TEST_F(MuPairProductionTest, stress_test)
         ElementComponentId{0});
 
     // Get the production cuts
-    auto cutoff = this->cutoff_params()->get(MaterialId{0});
+    auto cutoff = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     for (real_type inc_e : {1e3, 1e4, 1e5, 1e6, 1e7})
     {

--- a/test/celeritas/em/RelativisticBrem.test.cc
+++ b/test/celeritas/em/RelativisticBrem.test.cc
@@ -184,7 +184,7 @@ TEST_F(RelativisticBremTest, basic_without_lpm)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Create the interactor
     RelativisticBremInteractor interact(model_->host_ref(),
@@ -249,7 +249,7 @@ TEST_F(RelativisticBremTest, basic_with_lpm)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Create the interactor
     RelativisticBremInteractor interact(model_lpm_->host_ref(),
@@ -306,7 +306,7 @@ TEST_F(RelativisticBremTest, stress_with_lpm)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Create the interactor
     RelativisticBremInteractor interact(model_lpm_->host_ref(),

--- a/test/celeritas/em/RelativisticBrem.test.cc
+++ b/test/celeritas/em/RelativisticBrem.test.cc
@@ -184,7 +184,7 @@ TEST_F(RelativisticBremTest, basic_without_lpm)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
 
     // Create the interactor
     RelativisticBremInteractor interact(model_->host_ref(),
@@ -249,7 +249,7 @@ TEST_F(RelativisticBremTest, basic_with_lpm)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
 
     // Create the interactor
     RelativisticBremInteractor interact(model_lpm_->host_ref(),
@@ -306,7 +306,7 @@ TEST_F(RelativisticBremTest, stress_with_lpm)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
 
     // Create the interactor
     RelativisticBremInteractor interact(model_lpm_->host_ref(),

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -104,7 +104,7 @@ class SeltzerBergerTest : public InteractorHostTestBase
         this->set_material("Cu");
     }
 
-    EnergySq density_correction(MaterialId matid, Energy e) const
+    EnergySq density_correction(PhysicsMaterialId matid, Energy e) const
     {
         CELER_EXPECT(matid);
         CELER_EXPECT(e > zero_quantity());
@@ -228,7 +228,7 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
             model_->host_ref().differential_xs,
             Energy{inc_energy},
             ElementId{0},
-            this->density_correction(MaterialId{0}, Energy{inc_energy}),
+            this->density_correction(PhysicsMaterialId{0}, Energy{inc_energy}),
             gamma_cutoff);
         max_xs.push_back(edist_helper.max_xs().value());
 
@@ -264,7 +264,7 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
             model_->host_ref().differential_xs,
             Energy{inc_energy},
             ElementId{0},
-            this->density_correction(MaterialId{0}, Energy{inc_energy}),
+            this->density_correction(PhysicsMaterialId{0}, Energy{inc_energy}),
             gamma_cutoff);
 
         // Sample with a "correction" that's constant, which shouldn't change
@@ -317,7 +317,7 @@ TEST_F(SeltzerBergerTest, basic)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
 
     // Create the interactor
     SeltzerBergerInteractor interact(model_->host_ref(),
@@ -378,7 +378,7 @@ TEST_F(SeltzerBergerTest, stress_test)
     std::vector<real_type> avg_engine_samples;
 
     // Views
-    auto cutoffs = this->cutoff_params()->get(MaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
     auto material_view = this->material_track().material_record();
 
     // Loop over a set of incident gamma energies

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -104,7 +104,7 @@ class SeltzerBergerTest : public InteractorHostTestBase
         this->set_material("Cu");
     }
 
-    EnergySq density_correction(PhysicsMaterialId matid, Energy e) const
+    EnergySq density_correction(PhysMatId matid, Energy e) const
     {
         CELER_EXPECT(matid);
         CELER_EXPECT(e > zero_quantity());
@@ -228,7 +228,7 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
             model_->host_ref().differential_xs,
             Energy{inc_energy},
             ElementId{0},
-            this->density_correction(PhysicsMaterialId{0}, Energy{inc_energy}),
+            this->density_correction(PhysMatId{0}, Energy{inc_energy}),
             gamma_cutoff);
         max_xs.push_back(edist_helper.max_xs().value());
 
@@ -264,7 +264,7 @@ TEST_F(SeltzerBergerTest, sb_energy_dist)
             model_->host_ref().differential_xs,
             Energy{inc_energy},
             ElementId{0},
-            this->density_correction(PhysicsMaterialId{0}, Energy{inc_energy}),
+            this->density_correction(PhysMatId{0}, Energy{inc_energy}),
             gamma_cutoff);
 
         // Sample with a "correction" that's constant, which shouldn't change
@@ -317,7 +317,7 @@ TEST_F(SeltzerBergerTest, basic)
 
     // Production cuts
     auto material_view = this->material_track().material_record();
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
 
     // Create the interactor
     SeltzerBergerInteractor interact(model_->host_ref(),
@@ -378,7 +378,7 @@ TEST_F(SeltzerBergerTest, stress_test)
     std::vector<real_type> avg_engine_samples;
 
     // Views
-    auto cutoffs = this->cutoff_params()->get(PhysicsMaterialId{0});
+    auto cutoffs = this->cutoff_params()->get(PhysMatId{0});
     auto material_view = this->material_track().material_record();
 
     // Loop over a set of incident gamma energies

--- a/test/celeritas/em/WentzelVIMsc.test.cc
+++ b/test/celeritas/em/WentzelVIMsc.test.cc
@@ -63,7 +63,7 @@ class WentzelVIMscTest : public MscTestBase
   protected:
     std::shared_ptr<WentzelVIMscParams const> msc_params_;
     std::shared_ptr<WentzelOKVIParams const> wentzel_params_;
-    PhysicsMaterialId mat_id_;
+    PhysMatId mat_id_;
 };
 
 //---------------------------------------------------------------------------//
@@ -88,9 +88,9 @@ TEST_F(WentzelVIMscTest, params)
     }
     EXPECT_EQ(2, wentzel.inv_mass_cbrt_sq.size());
     EXPECT_SOFT_EQ(9.947409502757395e-1,
-                   wentzel.inv_mass_cbrt_sq[PhysicsMaterialId(0)]);
+                   wentzel.inv_mass_cbrt_sq[PhysMatId(0)]);
     EXPECT_SOFT_EQ(6.8867357655995998e-2,
-                   wentzel.inv_mass_cbrt_sq[PhysicsMaterialId(1)]);
+                   wentzel.inv_mass_cbrt_sq[PhysMatId(1)]);
 }
 
 TEST_F(WentzelVIMscTest, TEST_IF_CELERITAS_DOUBLE(total_xs))

--- a/test/celeritas/em/WentzelVIMsc.test.cc
+++ b/test/celeritas/em/WentzelVIMsc.test.cc
@@ -63,7 +63,7 @@ class WentzelVIMscTest : public MscTestBase
   protected:
     std::shared_ptr<WentzelVIMscParams const> msc_params_;
     std::shared_ptr<WentzelOKVIParams const> wentzel_params_;
-    MaterialId mat_id_;
+    PhysicsMaterialId mat_id_;
 };
 
 //---------------------------------------------------------------------------//
@@ -88,9 +88,9 @@ TEST_F(WentzelVIMscTest, params)
     }
     EXPECT_EQ(2, wentzel.inv_mass_cbrt_sq.size());
     EXPECT_SOFT_EQ(9.947409502757395e-1,
-                   wentzel.inv_mass_cbrt_sq[MaterialId(0)]);
+                   wentzel.inv_mass_cbrt_sq[PhysicsMaterialId(0)]);
     EXPECT_SOFT_EQ(6.8867357655995998e-2,
-                   wentzel.inv_mass_cbrt_sq[MaterialId(1)]);
+                   wentzel.inv_mass_cbrt_sq[PhysicsMaterialId(1)]);
 }
 
 TEST_F(WentzelVIMscTest, TEST_IF_CELERITAS_DOUBLE(total_xs))

--- a/test/celeritas/em/distribution/EnergyLossHelper.test.cc
+++ b/test/celeritas/em/distribution/EnergyLossHelper.test.cc
@@ -121,7 +121,7 @@ TEST_F(MockFluctuationTest, data)
 
     {
         // Celerogen: Z=1, I=19.2 eV
-        auto const& params = urban[MaterialId{0}];
+        auto const& params = urban[PhysicsMaterialId{0}];
         EXPECT_SOFT_EQ(1, params.oscillator_strength[0]);
         EXPECT_SOFT_EQ(0, params.oscillator_strength[1]);
         EXPECT_SOFT_EQ(19.2e-6, params.binding_energy[0]);
@@ -129,7 +129,7 @@ TEST_F(MockFluctuationTest, data)
     }
     {
         // Celer composite: Z_eff = 10.3, I=150.7 eV
-        auto const& params = urban[MaterialId{2}];
+        auto const& params = urban[PhysicsMaterialId{2}];
         EXPECT_SOFT_EQ(0.80582524271844658, params.oscillator_strength[0]);
         EXPECT_SOFT_EQ(0.1941747572815534, params.oscillator_strength[1]);
         EXPECT_SOFT_EQ(9.4193231228829647e-5, params.binding_energy[0]);
@@ -146,8 +146,8 @@ TEST_F(EnergyLossDistributionTest, none)
     particle = {ParticleId{0}, MevEnergy{1e-2}};
     MaterialTrackView material(
         materials->host_ref(), material_state.ref(), TrackSlotId{0});
-    material = {MaterialId{0}};
-    CutoffView cutoff(cutoffs->host_ref(), MaterialId{0});
+    material = {PhysicsMaterialId{0}};
+    CutoffView cutoff(cutoffs->host_ref(), PhysicsMaterialId{0});
     MevEnergy mean_loss{2e-6};
 
     // Tiny step, little energy loss
@@ -168,8 +168,8 @@ TEST_F(EnergyLossDistributionTest, gaussian)
     particle = {ParticleId{1}, MevEnergy{1e-2}};
     MaterialTrackView material(
         materials->host_ref(), material_state.ref(), TrackSlotId{0});
-    material = {MaterialId{0}};
-    CutoffView cutoff(cutoffs->host_ref(), MaterialId{0});
+    material = {PhysicsMaterialId{0}};
+    CutoffView cutoff(cutoffs->host_ref(), PhysicsMaterialId{0});
     MevEnergy mean_loss{0.1};
 
     int num_samples = 5000;
@@ -242,8 +242,8 @@ TEST_F(EnergyLossDistributionTest, urban)
     particle = {ParticleId{0}, MevEnergy{100}};
     MaterialTrackView material(
         materials->host_ref(), material_state.ref(), TrackSlotId{0});
-    material = {MaterialId{0}};
-    CutoffView cutoff(cutoffs->host_ref(), MaterialId{0});
+    material = {PhysicsMaterialId{0}};
+    CutoffView cutoff(cutoffs->host_ref(), PhysicsMaterialId{0});
     MevEnergy mean_loss{0.01};
     real_type step = 0.01 * units::centimeter;
 

--- a/test/celeritas/em/distribution/EnergyLossHelper.test.cc
+++ b/test/celeritas/em/distribution/EnergyLossHelper.test.cc
@@ -121,7 +121,7 @@ TEST_F(MockFluctuationTest, data)
 
     {
         // Celerogen: Z=1, I=19.2 eV
-        auto const& params = urban[PhysicsMaterialId{0}];
+        auto const& params = urban[PhysMatId{0}];
         EXPECT_SOFT_EQ(1, params.oscillator_strength[0]);
         EXPECT_SOFT_EQ(0, params.oscillator_strength[1]);
         EXPECT_SOFT_EQ(19.2e-6, params.binding_energy[0]);
@@ -129,7 +129,7 @@ TEST_F(MockFluctuationTest, data)
     }
     {
         // Celer composite: Z_eff = 10.3, I=150.7 eV
-        auto const& params = urban[PhysicsMaterialId{2}];
+        auto const& params = urban[PhysMatId{2}];
         EXPECT_SOFT_EQ(0.80582524271844658, params.oscillator_strength[0]);
         EXPECT_SOFT_EQ(0.1941747572815534, params.oscillator_strength[1]);
         EXPECT_SOFT_EQ(9.4193231228829647e-5, params.binding_energy[0]);
@@ -146,8 +146,8 @@ TEST_F(EnergyLossDistributionTest, none)
     particle = {ParticleId{0}, MevEnergy{1e-2}};
     MaterialTrackView material(
         materials->host_ref(), material_state.ref(), TrackSlotId{0});
-    material = {PhysicsMaterialId{0}};
-    CutoffView cutoff(cutoffs->host_ref(), PhysicsMaterialId{0});
+    material = {PhysMatId{0}};
+    CutoffView cutoff(cutoffs->host_ref(), PhysMatId{0});
     MevEnergy mean_loss{2e-6};
 
     // Tiny step, little energy loss
@@ -168,8 +168,8 @@ TEST_F(EnergyLossDistributionTest, gaussian)
     particle = {ParticleId{1}, MevEnergy{1e-2}};
     MaterialTrackView material(
         materials->host_ref(), material_state.ref(), TrackSlotId{0});
-    material = {PhysicsMaterialId{0}};
-    CutoffView cutoff(cutoffs->host_ref(), PhysicsMaterialId{0});
+    material = {PhysMatId{0}};
+    CutoffView cutoff(cutoffs->host_ref(), PhysMatId{0});
     MevEnergy mean_loss{0.1};
 
     int num_samples = 5000;
@@ -242,8 +242,8 @@ TEST_F(EnergyLossDistributionTest, urban)
     particle = {ParticleId{0}, MevEnergy{100}};
     MaterialTrackView material(
         materials->host_ref(), material_state.ref(), TrackSlotId{0});
-    material = {PhysicsMaterialId{0}};
-    CutoffView cutoff(cutoffs->host_ref(), PhysicsMaterialId{0});
+    material = {PhysMatId{0}};
+    CutoffView cutoff(cutoffs->host_ref(), PhysMatId{0});
     MevEnergy mean_loss{0.01};
     real_type step = 0.01 * units::centimeter;
 

--- a/test/celeritas/geo/GeoMaterial.test.cc
+++ b/test/celeritas/geo/GeoMaterial.test.cc
@@ -31,7 +31,7 @@ class GeoMaterialTestBase : virtual public GlobalTestBase
     using VecString = std::vector<std::string>;
 
   protected:
-    std::string material_name(MaterialId matid) const
+    std::string material_name(PhysicsMaterialId matid) const
     {
         if (!matid)
             return "---";

--- a/test/celeritas/geo/GeoMaterial.test.cc
+++ b/test/celeritas/geo/GeoMaterial.test.cc
@@ -31,7 +31,7 @@ class GeoMaterialTestBase : virtual public GlobalTestBase
     using VecString = std::vector<std::string>;
 
   protected:
-    std::string material_name(PhysicsMaterialId matid) const
+    std::string material_name(PhysMatId matid) const
     {
         if (!matid)
             return "---";

--- a/test/celeritas/mat/Material.test.cc
+++ b/test/celeritas/mat/Material.test.cc
@@ -31,14 +31,14 @@ using celeritas::units::GramCcDensity;
 using celeritas::units::InvCcDensity;
 using celeritas::units::MevEnergy;
 using celeritas::units::MolCcDensity;
-using MaterialId = celeritas::PhysicsMaterialId;
+using MatId = celeritas::PhysMatId;
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-std::ostream& operator<<(std::ostream& os, MaterialId const& mat)
+std::ostream& operator<<(std::ostream& os, MatId const& mat)
 {
-    os << "MaterialId{";
+    os << "MatId{";
     if (mat)
         os << mat.unchecked_get();
     os << "}";
@@ -130,15 +130,15 @@ TEST_F(MaterialTest, params)
     EXPECT_EQ(4, params->num_elements());
     EXPECT_EQ(8, params->num_isotopes());
 
-    EXPECT_EQ(MaterialId{0}, params->find_material("NaI"));
-    EXPECT_EQ(MaterialId{1}, params->find_material("hard vacuum"));
+    EXPECT_EQ(MatId{0}, params->find_material("NaI"));
+    EXPECT_EQ(MatId{1}, params->find_material("hard vacuum"));
     EXPECT_THROW(params->find_material("H2"), RuntimeError);
     {
         auto found = params->find_materials("H2");
-        MaterialId const expected[] = {MaterialId{2}, MaterialId{3}};
+        MatId const expected[] = {MatId{2}, MatId{3}};
         EXPECT_VEC_EQ(expected, found);
     }
-    EXPECT_EQ(MaterialId{}, params->find_material("nonexistent material"));
+    EXPECT_EQ(MatId{}, params->find_material("nonexistent material"));
 
     // Isotopes
     EXPECT_EQ("1H", params->id_to_label(IsotopeId{0}).name);
@@ -153,10 +153,10 @@ TEST_F(MaterialTest, params)
     EXPECT_EQ(ElementId{1}, params->find_element("Al"));
 
     // Materials
-    EXPECT_EQ("NaI", params->id_to_label(MaterialId{0}).name);
-    EXPECT_EQ("hard vacuum", params->id_to_label(MaterialId{1}).name);
-    EXPECT_EQ(Label("H2", "1"), params->id_to_label(MaterialId{2}));
-    EXPECT_EQ(Label("H2", "2"), params->id_to_label(MaterialId{3}));
+    EXPECT_EQ("NaI", params->id_to_label(MatId{0}).name);
+    EXPECT_EQ("hard vacuum", params->id_to_label(MatId{1}).name);
+    EXPECT_EQ(Label("H2", "1"), params->id_to_label(MatId{2}));
+    EXPECT_EQ(Label("H2", "2"), params->id_to_label(MatId{3}));
 
     EXPECT_EQ(2, params->max_element_components());
     EXPECT_EQ(3, params->max_isotope_components());
@@ -171,7 +171,7 @@ TEST_F(MaterialTest, material_view)
 
     {
         // NaI
-        MaterialView mat = params->get(MaterialId{0});
+        MaterialView mat = params->get(MatId{0});
         EXPECT_SOFT_EQ(2.948915064677e+22, mat.number_density());
         EXPECT_SOFT_EQ(293.0, mat.temperature());
         EXPECT_EQ(MatterState::solid, mat.matter_state());
@@ -194,7 +194,7 @@ TEST_F(MaterialTest, material_view)
     }
     {
         // vacuum
-        MaterialView mat = params->get(MaterialId{1});
+        MaterialView mat = params->get(MatId{1});
         EXPECT_EQ(0, mat.number_density());
         EXPECT_EQ(0, mat.temperature());
         EXPECT_EQ(MatterState::unspecified, mat.matter_state());
@@ -213,7 +213,7 @@ TEST_F(MaterialTest, material_view)
     }
     {
         // H2
-        MaterialView mat = params->get(MaterialId{2});
+        MaterialView mat = params->get(MatId{2});
         EXPECT_SOFT_EQ(1.0739484359044669e+20, mat.number_density());
         EXPECT_SOFT_EQ(100, mat.temperature());
         EXPECT_EQ(MatterState::gas, mat.matter_state());
@@ -231,7 +231,7 @@ TEST_F(MaterialTest, material_view)
     }
     {
         // H2_3
-        MaterialView mat = params->get(MaterialId{3});
+        MaterialView mat = params->get(MatId{3});
         EXPECT_SOFT_EQ(
             1.072e+20,
             native_value_to<InvCcDensity>(mat.number_density()).value());
@@ -347,9 +347,9 @@ TEST_F(MaterialParamsImportTest, TEST_IF_CELERITAS_USE_ROOT(root_materials))
     auto const material_params = MaterialParams::from_import(data);
     ASSERT_TRUE(material_params);
     // Material labels
-    EXPECT_EQ("G4_Galactic", material_params->id_to_label(MaterialId{0}).name);
+    EXPECT_EQ("G4_Galactic", material_params->id_to_label(MatId{0}).name);
     EXPECT_EQ("G4_STAINLESS-STEEL",
-              material_params->id_to_label(MaterialId{1}).name);
+              material_params->id_to_label(MatId{1}).name);
 
     /*!
      * Material
@@ -358,7 +358,7 @@ TEST_F(MaterialParamsImportTest, TEST_IF_CELERITAS_USE_ROOT(root_materials))
      * Celeritas constants results in the slightly different numerical values
      * calculated by Celeritas.
      */
-    MaterialView mat(material_params->host_ref(), MaterialId{1});
+    MaterialView mat(material_params->host_ref(), MatId{1});
 
     EXPECT_EQ(MatterState::solid, mat.matter_state());
     EXPECT_SOFT_EQ(293.15, mat.temperature());  // [K]
@@ -431,16 +431,14 @@ TEST_F(MaterialParamsImportTest, optical_materials)
         return om;
     }());
 
-    constexpr MaterialId vacuum_id{0};
-    constexpr MaterialId lar_id{1};
+    constexpr MatId vacuum_id{0};
+    constexpr MatId lar_id{1};
 
     // Check optical material ID
     auto materials = MaterialParams::from_import(data);
     ASSERT_TRUE(materials);
-    EXPECT_EQ(OpticalMaterialId{},
-              materials->get(vacuum_id).optical_material_id());
-    EXPECT_EQ(OpticalMaterialId{0},
-              materials->get(lar_id).optical_material_id());
+    EXPECT_EQ(OptMatId{}, materials->get(vacuum_id).optical_material_id());
+    EXPECT_EQ(OptMatId{0}, materials->get(lar_id).optical_material_id());
 }
 
 //---------------------------------------------------------------------------//
@@ -458,8 +456,7 @@ class MaterialDeviceTest : public MaterialTest
 TEST_F(MaterialDeviceTest, TEST_IF_CELER_DEVICE(all))
 {
     MTestInput input;
-    input.init
-        = {{MaterialId{0}}, {MaterialId{1}}, {MaterialId{2}}, {MaterialId{3}}};
+    input.init = {{MatId{0}}, {MatId{1}}, {MatId{2}}, {MatId{3}}};
 
     CollectionStateStore<MaterialStateData, MemSpace::device> states(
         params->host_ref(), input.init.size());

--- a/test/celeritas/mat/Material.test.cc
+++ b/test/celeritas/mat/Material.test.cc
@@ -31,13 +31,14 @@ using celeritas::units::GramCcDensity;
 using celeritas::units::InvCcDensity;
 using celeritas::units::MevEnergy;
 using celeritas::units::MolCcDensity;
+using MaterialId = celeritas::PhysicsMaterialId;
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-std::ostream& operator<<(std::ostream& os, PhysicsMaterialId const& mat)
+std::ostream& operator<<(std::ostream& os, MaterialId const& mat)
 {
-    os << "PhysicsMaterialId{";
+    os << "MaterialId{";
     if (mat)
         os << mat.unchecked_get();
     os << "}";
@@ -129,17 +130,15 @@ TEST_F(MaterialTest, params)
     EXPECT_EQ(4, params->num_elements());
     EXPECT_EQ(8, params->num_isotopes());
 
-    EXPECT_EQ(PhysicsMaterialId{0}, params->find_material("NaI"));
-    EXPECT_EQ(PhysicsMaterialId{1}, params->find_material("hard vacuum"));
+    EXPECT_EQ(MaterialId{0}, params->find_material("NaI"));
+    EXPECT_EQ(MaterialId{1}, params->find_material("hard vacuum"));
     EXPECT_THROW(params->find_material("H2"), RuntimeError);
     {
         auto found = params->find_materials("H2");
-        PhysicsMaterialId const expected[]
-            = {PhysicsMaterialId{2}, PhysicsMaterialId{3}};
+        MaterialId const expected[] = {MaterialId{2}, MaterialId{3}};
         EXPECT_VEC_EQ(expected, found);
     }
-    EXPECT_EQ(PhysicsMaterialId{},
-              params->find_material("nonexistent material"));
+    EXPECT_EQ(MaterialId{}, params->find_material("nonexistent material"));
 
     // Isotopes
     EXPECT_EQ("1H", params->id_to_label(IsotopeId{0}).name);
@@ -154,10 +153,10 @@ TEST_F(MaterialTest, params)
     EXPECT_EQ(ElementId{1}, params->find_element("Al"));
 
     // Materials
-    EXPECT_EQ("NaI", params->id_to_label(PhysicsMaterialId{0}).name);
-    EXPECT_EQ("hard vacuum", params->id_to_label(PhysicsMaterialId{1}).name);
-    EXPECT_EQ(Label("H2", "1"), params->id_to_label(PhysicsMaterialId{2}));
-    EXPECT_EQ(Label("H2", "2"), params->id_to_label(PhysicsMaterialId{3}));
+    EXPECT_EQ("NaI", params->id_to_label(MaterialId{0}).name);
+    EXPECT_EQ("hard vacuum", params->id_to_label(MaterialId{1}).name);
+    EXPECT_EQ(Label("H2", "1"), params->id_to_label(MaterialId{2}));
+    EXPECT_EQ(Label("H2", "2"), params->id_to_label(MaterialId{3}));
 
     EXPECT_EQ(2, params->max_element_components());
     EXPECT_EQ(3, params->max_isotope_components());
@@ -172,7 +171,7 @@ TEST_F(MaterialTest, material_view)
 
     {
         // NaI
-        MaterialView mat = params->get(PhysicsMaterialId{0});
+        MaterialView mat = params->get(MaterialId{0});
         EXPECT_SOFT_EQ(2.948915064677e+22, mat.number_density());
         EXPECT_SOFT_EQ(293.0, mat.temperature());
         EXPECT_EQ(MatterState::solid, mat.matter_state());
@@ -195,7 +194,7 @@ TEST_F(MaterialTest, material_view)
     }
     {
         // vacuum
-        MaterialView mat = params->get(PhysicsMaterialId{1});
+        MaterialView mat = params->get(MaterialId{1});
         EXPECT_EQ(0, mat.number_density());
         EXPECT_EQ(0, mat.temperature());
         EXPECT_EQ(MatterState::unspecified, mat.matter_state());
@@ -214,7 +213,7 @@ TEST_F(MaterialTest, material_view)
     }
     {
         // H2
-        MaterialView mat = params->get(PhysicsMaterialId{2});
+        MaterialView mat = params->get(MaterialId{2});
         EXPECT_SOFT_EQ(1.0739484359044669e+20, mat.number_density());
         EXPECT_SOFT_EQ(100, mat.temperature());
         EXPECT_EQ(MatterState::gas, mat.matter_state());
@@ -232,7 +231,7 @@ TEST_F(MaterialTest, material_view)
     }
     {
         // H2_3
-        MaterialView mat = params->get(PhysicsMaterialId{3});
+        MaterialView mat = params->get(MaterialId{3});
         EXPECT_SOFT_EQ(
             1.072e+20,
             native_value_to<InvCcDensity>(mat.number_density()).value());
@@ -348,10 +347,9 @@ TEST_F(MaterialParamsImportTest, TEST_IF_CELERITAS_USE_ROOT(root_materials))
     auto const material_params = MaterialParams::from_import(data);
     ASSERT_TRUE(material_params);
     // Material labels
-    EXPECT_EQ("G4_Galactic",
-              material_params->id_to_label(PhysicsMaterialId{0}).name);
+    EXPECT_EQ("G4_Galactic", material_params->id_to_label(MaterialId{0}).name);
     EXPECT_EQ("G4_STAINLESS-STEEL",
-              material_params->id_to_label(PhysicsMaterialId{1}).name);
+              material_params->id_to_label(MaterialId{1}).name);
 
     /*!
      * Material
@@ -360,7 +358,7 @@ TEST_F(MaterialParamsImportTest, TEST_IF_CELERITAS_USE_ROOT(root_materials))
      * Celeritas constants results in the slightly different numerical values
      * calculated by Celeritas.
      */
-    MaterialView mat(material_params->host_ref(), PhysicsMaterialId{1});
+    MaterialView mat(material_params->host_ref(), MaterialId{1});
 
     EXPECT_EQ(MatterState::solid, mat.matter_state());
     EXPECT_SOFT_EQ(293.15, mat.temperature());  // [K]
@@ -433,8 +431,8 @@ TEST_F(MaterialParamsImportTest, optical_materials)
         return om;
     }());
 
-    constexpr PhysicsMaterialId vacuum_id{0};
-    constexpr PhysicsMaterialId lar_id{1};
+    constexpr MaterialId vacuum_id{0};
+    constexpr MaterialId lar_id{1};
 
     // Check optical material ID
     auto materials = MaterialParams::from_import(data);
@@ -460,10 +458,8 @@ class MaterialDeviceTest : public MaterialTest
 TEST_F(MaterialDeviceTest, TEST_IF_CELER_DEVICE(all))
 {
     MTestInput input;
-    input.init = {{PhysicsMaterialId{0}},
-                  {PhysicsMaterialId{1}},
-                  {PhysicsMaterialId{2}},
-                  {PhysicsMaterialId{3}}};
+    input.init
+        = {{MaterialId{0}}, {MaterialId{1}}, {MaterialId{2}}, {MaterialId{3}}};
 
     CollectionStateStore<MaterialStateData, MemSpace::device> states(
         params->host_ref(), input.init.size());

--- a/test/celeritas/mat/Material.test.cc
+++ b/test/celeritas/mat/Material.test.cc
@@ -35,9 +35,9 @@ using celeritas::units::MolCcDensity;
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-std::ostream& operator<<(std::ostream& os, MaterialId const& mat)
+std::ostream& operator<<(std::ostream& os, PhysicsMaterialId const& mat)
 {
-    os << "MaterialId{";
+    os << "PhysicsMaterialId{";
     if (mat)
         os << mat.unchecked_get();
     os << "}";
@@ -129,15 +129,17 @@ TEST_F(MaterialTest, params)
     EXPECT_EQ(4, params->num_elements());
     EXPECT_EQ(8, params->num_isotopes());
 
-    EXPECT_EQ(MaterialId{0}, params->find_material("NaI"));
-    EXPECT_EQ(MaterialId{1}, params->find_material("hard vacuum"));
+    EXPECT_EQ(PhysicsMaterialId{0}, params->find_material("NaI"));
+    EXPECT_EQ(PhysicsMaterialId{1}, params->find_material("hard vacuum"));
     EXPECT_THROW(params->find_material("H2"), RuntimeError);
     {
         auto found = params->find_materials("H2");
-        MaterialId const expected[] = {MaterialId{2}, MaterialId{3}};
+        PhysicsMaterialId const expected[]
+            = {PhysicsMaterialId{2}, PhysicsMaterialId{3}};
         EXPECT_VEC_EQ(expected, found);
     }
-    EXPECT_EQ(MaterialId{}, params->find_material("nonexistent material"));
+    EXPECT_EQ(PhysicsMaterialId{},
+              params->find_material("nonexistent material"));
 
     // Isotopes
     EXPECT_EQ("1H", params->id_to_label(IsotopeId{0}).name);
@@ -152,10 +154,10 @@ TEST_F(MaterialTest, params)
     EXPECT_EQ(ElementId{1}, params->find_element("Al"));
 
     // Materials
-    EXPECT_EQ("NaI", params->id_to_label(MaterialId{0}).name);
-    EXPECT_EQ("hard vacuum", params->id_to_label(MaterialId{1}).name);
-    EXPECT_EQ(Label("H2", "1"), params->id_to_label(MaterialId{2}));
-    EXPECT_EQ(Label("H2", "2"), params->id_to_label(MaterialId{3}));
+    EXPECT_EQ("NaI", params->id_to_label(PhysicsMaterialId{0}).name);
+    EXPECT_EQ("hard vacuum", params->id_to_label(PhysicsMaterialId{1}).name);
+    EXPECT_EQ(Label("H2", "1"), params->id_to_label(PhysicsMaterialId{2}));
+    EXPECT_EQ(Label("H2", "2"), params->id_to_label(PhysicsMaterialId{3}));
 
     EXPECT_EQ(2, params->max_element_components());
     EXPECT_EQ(3, params->max_isotope_components());
@@ -170,7 +172,7 @@ TEST_F(MaterialTest, material_view)
 
     {
         // NaI
-        MaterialView mat = params->get(MaterialId{0});
+        MaterialView mat = params->get(PhysicsMaterialId{0});
         EXPECT_SOFT_EQ(2.948915064677e+22, mat.number_density());
         EXPECT_SOFT_EQ(293.0, mat.temperature());
         EXPECT_EQ(MatterState::solid, mat.matter_state());
@@ -193,7 +195,7 @@ TEST_F(MaterialTest, material_view)
     }
     {
         // vacuum
-        MaterialView mat = params->get(MaterialId{1});
+        MaterialView mat = params->get(PhysicsMaterialId{1});
         EXPECT_EQ(0, mat.number_density());
         EXPECT_EQ(0, mat.temperature());
         EXPECT_EQ(MatterState::unspecified, mat.matter_state());
@@ -212,7 +214,7 @@ TEST_F(MaterialTest, material_view)
     }
     {
         // H2
-        MaterialView mat = params->get(MaterialId{2});
+        MaterialView mat = params->get(PhysicsMaterialId{2});
         EXPECT_SOFT_EQ(1.0739484359044669e+20, mat.number_density());
         EXPECT_SOFT_EQ(100, mat.temperature());
         EXPECT_EQ(MatterState::gas, mat.matter_state());
@@ -230,7 +232,7 @@ TEST_F(MaterialTest, material_view)
     }
     {
         // H2_3
-        MaterialView mat = params->get(MaterialId{3});
+        MaterialView mat = params->get(PhysicsMaterialId{3});
         EXPECT_SOFT_EQ(
             1.072e+20,
             native_value_to<InvCcDensity>(mat.number_density()).value());
@@ -346,9 +348,10 @@ TEST_F(MaterialParamsImportTest, TEST_IF_CELERITAS_USE_ROOT(root_materials))
     auto const material_params = MaterialParams::from_import(data);
     ASSERT_TRUE(material_params);
     // Material labels
-    EXPECT_EQ("G4_Galactic", material_params->id_to_label(MaterialId{0}).name);
+    EXPECT_EQ("G4_Galactic",
+              material_params->id_to_label(PhysicsMaterialId{0}).name);
     EXPECT_EQ("G4_STAINLESS-STEEL",
-              material_params->id_to_label(MaterialId{1}).name);
+              material_params->id_to_label(PhysicsMaterialId{1}).name);
 
     /*!
      * Material
@@ -357,7 +360,7 @@ TEST_F(MaterialParamsImportTest, TEST_IF_CELERITAS_USE_ROOT(root_materials))
      * Celeritas constants results in the slightly different numerical values
      * calculated by Celeritas.
      */
-    MaterialView mat(material_params->host_ref(), MaterialId{1});
+    MaterialView mat(material_params->host_ref(), PhysicsMaterialId{1});
 
     EXPECT_EQ(MatterState::solid, mat.matter_state());
     EXPECT_SOFT_EQ(293.15, mat.temperature());  // [K]
@@ -430,8 +433,8 @@ TEST_F(MaterialParamsImportTest, optical_materials)
         return om;
     }());
 
-    constexpr MaterialId vacuum_id{0};
-    constexpr MaterialId lar_id{1};
+    constexpr PhysicsMaterialId vacuum_id{0};
+    constexpr PhysicsMaterialId lar_id{1};
 
     // Check optical material ID
     auto materials = MaterialParams::from_import(data);
@@ -457,8 +460,10 @@ class MaterialDeviceTest : public MaterialTest
 TEST_F(MaterialDeviceTest, TEST_IF_CELER_DEVICE(all))
 {
     MTestInput input;
-    input.init
-        = {{MaterialId{0}}, {MaterialId{1}}, {MaterialId{2}}, {MaterialId{3}}};
+    input.init = {{PhysicsMaterialId{0}},
+                  {PhysicsMaterialId{1}},
+                  {PhysicsMaterialId{2}},
+                  {PhysicsMaterialId{3}}};
 
     CollectionStateStore<MaterialStateData, MemSpace::device> states(
         params->host_ref(), input.init.size());

--- a/test/celeritas/optical/Absorption.test.cc
+++ b/test/celeritas/optical/Absorption.test.cc
@@ -80,7 +80,7 @@ TEST_F(AbsorptionModelTest, interaction_mfp)
     auto model = create_model();
     auto builder = storage.create_mfp_builder();
 
-    for (auto mat : range(OpticalMaterialId(this->num_optical_materials())))
+    for (auto mat : range(OptMatId(this->num_optical_materials())))
     {
         model->build_mfps(mat, builder);
     }

--- a/test/celeritas/optical/Cherenkov.test.cc
+++ b/test/celeritas/optical/Cherenkov.test.cc
@@ -144,7 +144,7 @@ class CherenkovTest : public ::celeritas::test::OpticalTestBase
         MaterialParams::Input input;
         input.properties.push_back(std::move(water));
         input.volume_to_mat = {OptMatId{0}};
-        input.optical_to_core = {CorePhysicsMaterialId{0}};
+        input.optical_to_core = {PhysMatId{0}};
         material = std::make_shared<MaterialParams>(std::move(input));
 
         // Build Cherenkov data

--- a/test/celeritas/optical/Cherenkov.test.cc
+++ b/test/celeritas/optical/Cherenkov.test.cc
@@ -144,7 +144,7 @@ class CherenkovTest : public ::celeritas::test::OpticalTestBase
         MaterialParams::Input input;
         input.properties.push_back(std::move(water));
         input.volume_to_mat = {OpticalMaterialId{0}};
-        input.optical_to_core = {CoreMaterialId{0}};
+        input.optical_to_core = {CorePhysicsMaterialId{0}};
         material = std::make_shared<MaterialParams>(std::move(input));
 
         // Build Cherenkov data

--- a/test/celeritas/optical/Cherenkov.test.cc
+++ b/test/celeritas/optical/Cherenkov.test.cc
@@ -143,7 +143,7 @@ class CherenkovTest : public ::celeritas::test::OpticalTestBase
 
         MaterialParams::Input input;
         input.properties.push_back(std::move(water));
-        input.volume_to_mat = {OpticalMaterialId{0}};
+        input.volume_to_mat = {OptMatId{0}};
         input.optical_to_core = {CorePhysicsMaterialId{0}};
         material = std::make_shared<MaterialParams>(std::move(input));
 
@@ -153,7 +153,7 @@ class CherenkovTest : public ::celeritas::test::OpticalTestBase
 
     std::shared_ptr<MaterialParams const> material;
     std::shared_ptr<CherenkovParams const> params;
-    OpticalMaterialId material_id{0};
+    OptMatId material_id{0};
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/optical/ImportedMaterials.test.cc
+++ b/test/celeritas/optical/ImportedMaterials.test.cc
@@ -39,8 +39,7 @@ TEST_F(ImportedMaterialsTest, simple)
 {
     ASSERT_TRUE(imported_materials);
 
-    for (auto opt_mat :
-         range(OpticalMaterialId{imported_materials->num_materials()}))
+    for (auto opt_mat : range(OptMatId{imported_materials->num_materials()}))
     {
         // Rayleigh data
         {

--- a/test/celeritas/optical/ImportedModelAdapter.test.cc
+++ b/test/celeritas/optical/ImportedModelAdapter.test.cc
@@ -106,7 +106,7 @@ TEST_F(ImportedModelAdapterTest, adapter_mfps)
         auto const& expected_model = expected_models[model_id.get()];
 
         ASSERT_EQ(expected_model.mfp_table.size(), adapter.num_materials());
-        for (auto mat_id : range(OpticalMaterialId{adapter.num_materials()}))
+        for (auto mat_id : range(OptMatId{adapter.num_materials()}))
         {
             EXPECT_GRID_EQ(expected_model.mfp_table[mat_id.get()],
                            adapter.mfp(mat_id));

--- a/test/celeritas/optical/ModelImporter.test.cc
+++ b/test/celeritas/optical/ModelImporter.test.cc
@@ -69,8 +69,8 @@ class ModelImporterTest : public OpticalMockTestBase
         // Build imported tables
         OwningGridAccessor storage;
         auto mfp_builder = storage.create_mfp_builder();
-        for (auto mat : range(
-                 OpticalMaterialId{this->optical_material()->num_materials()}))
+        for (auto mat :
+             range(OptMatId{this->optical_material()->num_materials()}))
         {
             model->build_mfps(mat, mfp_builder);
         }

--- a/test/celeritas/optical/OpticalMockModels.hh
+++ b/test/celeritas/optical/OpticalMockModels.hh
@@ -31,7 +31,7 @@ template<class FX, class FY>
 ModelMatGrid build_expected_grids(FX const& get_x, FY const& get_y)
 {
     ModelId::size_type num_models = 4;
-    OpticalMaterialId::size_type num_materials = 5;
+    OptMatId::size_type num_materials = 5;
 
     ModelMatGrid grids;
     grids.reserve(num_models);
@@ -39,7 +39,7 @@ ModelMatGrid build_expected_grids(FX const& get_x, FY const& get_y)
     {
         MatGrid mat_grids;
         mat_grids.reserve(num_materials);
-        for (auto mat : range(OpticalMaterialId{num_materials}))
+        for (auto mat : range(OptMatId{num_materials}))
         {
             size_type n = (model.get() + 1) * 10 + mat.get();
             inp::Grid grid;
@@ -61,7 +61,7 @@ ModelMatGrid build_expected_grids(FX const& get_x, FY const& get_y)
 /*!
  * Mock MFP grid for the given material and model.
  */
-inp::Grid const& expected_mfp_grid(OpticalMaterialId mat, ModelId model)
+inp::Grid const& expected_mfp_grid(OptMatId mat, ModelId model)
 {
     static ModelMatGrid grids;
 
@@ -94,7 +94,7 @@ class MockModel : public Model
     {
     }
 
-    void build_mfps(OpticalMaterialId mat, MfpBuilder& build) const final
+    void build_mfps(OptMatId mat, MfpBuilder& build) const final
     {
         ModelId model_id{this->action_id().get() - 1};
         build(expected_mfp_grid(mat, model_id));

--- a/test/celeritas/optical/OpticalMockTestBase.cc
+++ b/test/celeritas/optical/OpticalMockTestBase.cc
@@ -104,11 +104,11 @@ auto OpticalMockTestBase::build_optical_material() -> SPConstOpticalMaterial
     for (auto opt_mat : range(8))
     {
         input.volume_to_mat.push_back(
-            OpticalMaterialId(opt_mat % input.properties.size()));
+            OptMatId(opt_mat % input.properties.size()));
     }
 
-    // mock PhysicsMaterialId == OpticalMaterialId
-    for (auto mat : range(PhysicsMaterialId(input.properties.size())))
+    // mock PhysMatId == OptMatId
+    for (auto mat : range(PhysMatId(input.properties.size())))
     {
         input.optical_to_core.push_back(mat);
     }
@@ -144,8 +144,8 @@ auto OpticalMockTestBase::build_material() -> SPConstMaterial
             {},
             std::to_string(i).c_str()});
 
-        // mock PhysicsMaterialId == OpticalMaterialId
-        input.mat_to_optical.push_back(OpticalMaterialId(i));
+        // mock PhysMatId == OptMatId
+        input.mat_to_optical.push_back(OptMatId(i));
     }
 
     return std::make_shared<::celeritas::MaterialParams const>(

--- a/test/celeritas/optical/OpticalMockTestBase.cc
+++ b/test/celeritas/optical/OpticalMockTestBase.cc
@@ -107,8 +107,8 @@ auto OpticalMockTestBase::build_optical_material() -> SPConstOpticalMaterial
             OpticalMaterialId(opt_mat % input.properties.size()));
     }
 
-    // mock MaterialId == OpticalMaterialId
-    for (auto mat : range(MaterialId(input.properties.size())))
+    // mock PhysicsMaterialId == OpticalMaterialId
+    for (auto mat : range(PhysicsMaterialId(input.properties.size())))
     {
         input.optical_to_core.push_back(mat);
     }
@@ -144,7 +144,7 @@ auto OpticalMockTestBase::build_material() -> SPConstMaterial
             {},
             std::to_string(i).c_str()});
 
-        // mock MaterialId == OpticalMaterialId
+        // mock PhysicsMaterialId == OpticalMaterialId
         input.mat_to_optical.push_back(OpticalMaterialId(i));
     }
 

--- a/test/celeritas/optical/OpticalMockTestBase.hh
+++ b/test/celeritas/optical/OpticalMockTestBase.hh
@@ -38,7 +38,7 @@ class OpticalMockTestBase : public GlobalTestBase
     ImportOpticalModel const& import_model_by_class(ImportModelClass) const;
 
     //! Number of mock optical materials
-    OpticalMaterialId::size_type num_optical_materials() const
+    OptMatId::size_type num_optical_materials() const
     {
         return this->imported_data().optical_materials.size();
     }

--- a/test/celeritas/optical/Physics.test.cc
+++ b/test/celeritas/optical/Physics.test.cc
@@ -56,7 +56,7 @@ class OpticalPhysicsTest : public OpticalMockTestBase
     }
 
     PhysicsTrackView
-    make_track_view(OpticalMaterialId mat, TrackSlotId slot = TrackSlotId{0})
+    make_track_view(OptMatId mat, TrackSlotId slot = TrackSlotId{0})
     {
         CELER_EXPECT(mat < this->num_optical_materials());
         return PhysicsTrackView(this->optical_physics()->host_ref(),
@@ -89,10 +89,10 @@ class OpticalPhysicsTest : public OpticalMockTestBase
      * over a different ID.
      */
     template<class T>
-    OpticalMaterialId cycle_material_id(T other_id)
+    OptMatId cycle_material_id(T other_id)
     {
-        return OpticalMaterialId{(2 * other_id.get() + 3)
-                                 % this->num_optical_materials()};
+        return OptMatId{(2 * other_id.get() + 3)
+                        % this->num_optical_materials()};
     }
 
   private:
@@ -157,7 +157,7 @@ TEST_F(OpticalPhysicsTest, physics_params)
 // Test sampling discrete interactions by per model cross sections
 TEST_F(OpticalPhysicsTest, TEST_IF_CELERITAS_DOUBLE(select_discrete))
 {
-    PhysicsTrackView physics = this->make_track_view(OpticalMaterialId{3});
+    PhysicsTrackView physics = this->make_track_view(OptMatId{3});
     RngEngine rng_engine;
 
     // Populate XS scratch space used for each model
@@ -197,7 +197,7 @@ TEST_F(OpticalPhysicsTest, TEST_IF_CELERITAS_DOUBLE(select_discrete))
 // Test expected step limits and calculation cross sections
 TEST_F(OpticalPhysicsTest, calc_step_limits)
 {
-    PhysicsTrackView physics = this->make_track_view(OpticalMaterialId{2});
+    PhysicsTrackView physics = this->make_track_view(OptMatId{2});
     ParticleTrackView particle = this->make_particle_view();
 
     static std::vector<real_type> energies{0.1, 1, 5, 10};
@@ -256,7 +256,7 @@ TEST_F(OpticalPhysicsTest, track_view_actions)
 {
     // Note that there shouldn't be material or track dependence on the
     // model-action accessors
-    PhysicsTrackView physics = this->make_track_view(OpticalMaterialId{0});
+    PhysicsTrackView physics = this->make_track_view(OptMatId{0});
 
     // Model-Action mapping
 
@@ -333,8 +333,7 @@ TEST_F(OpticalPhysicsTest, track_view_grids)
 
     for (auto track_id : range(TrackSlotId{num_tracks}))
     {
-        for (auto mat_id :
-             range(OpticalMaterialId{this->num_optical_materials()}))
+        for (auto mat_id : range(OptMatId{this->num_optical_materials()}))
         {
             auto const physics = this->make_track_view(mat_id, track_id);
 

--- a/test/celeritas/optical/Rayleigh.test.cc
+++ b/test/celeritas/optical/Rayleigh.test.cc
@@ -161,7 +161,7 @@ TEST_F(RayleighModelTest, interaction_mfp)
     auto model = create_model();
     auto builder = storage.create_mfp_builder();
 
-    for (auto mat : range(OpticalMaterialId(this->num_optical_materials())))
+    for (auto mat : range(OptMatId(this->num_optical_materials())))
     {
         model->build_mfps(mat, builder);
     }

--- a/test/celeritas/optical/RayleighMfpCalculator.test.cc
+++ b/test/celeritas/optical/RayleighMfpCalculator.test.cc
@@ -55,7 +55,8 @@ TEST_F(RayleighMfpCalculatorTest, mfp_table)
         RayleighMfpCalculator calc_mfp(
             this->optical_material()->get(opt_mat),
             rayleigh,
-            this->material()->get(::celeritas::MaterialId(opt_mat.get())));
+            this->material()->get(
+                ::celeritas::PhysicsMaterialId(opt_mat.get())));
 
         auto energies = calc_mfp.grid().values();
         for (auto i : range(energies.size()))

--- a/test/celeritas/optical/RayleighMfpCalculator.test.cc
+++ b/test/celeritas/optical/RayleighMfpCalculator.test.cc
@@ -48,15 +48,14 @@ TEST_F(RayleighMfpCalculatorTest, mfp_table)
     std::vector<real_type> mfps;
     mfps.reserve(expected_mfps.size());
 
-    for (auto opt_mat : range(OpticalMaterialId(opt_materials.size())))
+    for (auto opt_mat : range(OptMatId(opt_materials.size())))
     {
         auto const& rayleigh = opt_materials[opt_mat.get()].rayleigh;
 
         RayleighMfpCalculator calc_mfp(
             this->optical_material()->get(opt_mat),
             rayleigh,
-            this->material()->get(
-                ::celeritas::PhysicsMaterialId(opt_mat.get())));
+            this->material()->get(::celeritas::PhysMatId(opt_mat.get())));
 
         auto energies = calc_mfp.grid().values();
         for (auto i : range(energies.size()))

--- a/test/celeritas/optical/Scintillation.test.cc
+++ b/test/celeritas/optical/Scintillation.test.cc
@@ -67,7 +67,7 @@ class ScintillationTestBase : public ::celeritas::test::OpticalTestBase
     }
 
   protected:
-    OpticalMaterialId opt_mat_{0};
+    OptMatId opt_mat_{0};
 
     // Post-step values
     Real3 post_pos_{0, 0, from_cm(1)};

--- a/test/celeritas/optical/WavelengthShift.test.cc
+++ b/test/celeritas/optical/WavelengthShift.test.cc
@@ -67,7 +67,7 @@ class WavelengthShiftTest : public InteractorHostTestBase
         data_ = params_->host_ref();
     }
 
-    OpticalMaterialId material_id_{0};
+    OptMatId material_id_{0};
     std::shared_ptr<WavelengthShiftParams const> params_;
     HostDataCRef data_;
 };

--- a/test/celeritas/phys/CutoffParams.test.cc
+++ b/test/celeritas/phys/CutoffParams.test.cc
@@ -104,7 +104,7 @@ TEST_F(CutoffParamsTest, empty_cutoffs)
     std::vector<real_type> energies, ranges;
     for (auto const pid : range(ParticleId{particles->size()}))
     {
-        for (auto const mid : range(PhysicsMaterialId{materials->size()}))
+        for (auto const mid : range(PhysMatId{materials->size()}))
         {
             CutoffView cutoffs(cutoff.host_ref(), mid);
             if (pid != particles->find(pdg::proton()))
@@ -143,7 +143,7 @@ TEST_F(CutoffParamsTest, electron_cutoffs)
     std::vector<real_type> energies, ranges;
     for (auto const pid : range(ParticleId{particles->size()}))
     {
-        for (auto const mid : range(PhysicsMaterialId{materials->size()}))
+        for (auto const mid : range(PhysMatId{materials->size()}))
         {
             CutoffView cutoffs(cutoff.host_ref(), mid);
             if (pid != particles->find(pdg::proton()))
@@ -177,7 +177,7 @@ TEST_F(CutoffParamsTest, apply_post_interaction)
     input.apply_post_interaction = true;
     CutoffParams cutoff(input);
 
-    CutoffView cutoffs(cutoff.host_ref(), PhysicsMaterialId{0});
+    CutoffView cutoffs(cutoff.host_ref(), PhysMatId{0});
     EXPECT_TRUE(cutoffs.apply_post_interaction());
 
     Secondary secondary;
@@ -221,8 +221,7 @@ TEST_F(CutoffParamsImportTest, import_cutoffs)
                            this->particle()->find(pdg::gamma()),
                            this->particle()->find(pdg::positron())})
     {
-        for (auto const mid :
-             range(PhysicsMaterialId{this->material()->size()}))
+        for (auto const mid : range(PhysMatId{this->material()->size()}))
         {
             CutoffView cutoffs(this->cutoff()->host_ref(), mid);
             energies.push_back(cutoffs.energy(pid).value());

--- a/test/celeritas/phys/CutoffParams.test.cc
+++ b/test/celeritas/phys/CutoffParams.test.cc
@@ -104,7 +104,7 @@ TEST_F(CutoffParamsTest, empty_cutoffs)
     std::vector<real_type> energies, ranges;
     for (auto const pid : range(ParticleId{particles->size()}))
     {
-        for (auto const mid : range(MaterialId{materials->size()}))
+        for (auto const mid : range(PhysicsMaterialId{materials->size()}))
         {
             CutoffView cutoffs(cutoff.host_ref(), mid);
             if (pid != particles->find(pdg::proton()))
@@ -143,7 +143,7 @@ TEST_F(CutoffParamsTest, electron_cutoffs)
     std::vector<real_type> energies, ranges;
     for (auto const pid : range(ParticleId{particles->size()}))
     {
-        for (auto const mid : range(MaterialId{materials->size()}))
+        for (auto const mid : range(PhysicsMaterialId{materials->size()}))
         {
             CutoffView cutoffs(cutoff.host_ref(), mid);
             if (pid != particles->find(pdg::proton()))
@@ -177,7 +177,7 @@ TEST_F(CutoffParamsTest, apply_post_interaction)
     input.apply_post_interaction = true;
     CutoffParams cutoff(input);
 
-    CutoffView cutoffs(cutoff.host_ref(), MaterialId{0});
+    CutoffView cutoffs(cutoff.host_ref(), PhysicsMaterialId{0});
     EXPECT_TRUE(cutoffs.apply_post_interaction());
 
     Secondary secondary;
@@ -221,7 +221,8 @@ TEST_F(CutoffParamsImportTest, import_cutoffs)
                            this->particle()->find(pdg::gamma()),
                            this->particle()->find(pdg::positron())})
     {
-        for (auto const mid : range(MaterialId{this->material()->size()}))
+        for (auto const mid :
+             range(PhysicsMaterialId{this->material()->size()}))
         {
             CutoffView cutoffs(this->cutoff()->host_ref(), mid);
             energies.push_back(cutoffs.energy(pid).value());

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -197,8 +197,7 @@ class PhysicsTrackViewHostTest : public PhysicsParamsTest
         }
     }
 
-    PhysicsTrackView
-    make_track_view(char const* particle, PhysicsMaterialId mid)
+    PhysicsTrackView make_track_view(char const* particle, PhysMatId mid)
     {
         CELER_EXPECT(particle && mid);
 
@@ -263,10 +262,8 @@ class PhysicsTrackViewHostTest : public PhysicsParamsTest
 
 TEST_F(PhysicsTrackViewHostTest, track_view)
 {
-    PhysicsTrackView gamma
-        = this->make_track_view("gamma", PhysicsMaterialId{0});
-    PhysicsTrackView celer
-        = this->make_track_view("celeriton", PhysicsMaterialId{1});
+    PhysicsTrackView gamma = this->make_track_view("gamma", PhysMatId{0});
+    PhysicsTrackView celer = this->make_track_view("celeriton", PhysMatId{1});
     PhysicsTrackView const& gamma_cref = gamma;
 
     // Interaction MFP
@@ -372,7 +369,7 @@ TEST_F(PhysicsTrackViewHostTest, processes)
     // Gamma
     {
         PhysicsTrackView const phys
-            = this->make_track_view("gamma", PhysicsMaterialId{0});
+            = this->make_track_view("gamma", PhysMatId{0});
 
         EXPECT_EQ(2, phys.num_particle_processes());
         ParticleProcessId const scat_ppid{0};
@@ -385,7 +382,7 @@ TEST_F(PhysicsTrackViewHostTest, processes)
     // Celeriton
     {
         PhysicsTrackView const phys
-            = this->make_track_view("celeriton", PhysicsMaterialId{0});
+            = this->make_track_view("celeriton", PhysMatId{0});
 
         EXPECT_EQ(3, phys.num_particle_processes());
         ParticleProcessId const scat_ppid{0};
@@ -400,7 +397,7 @@ TEST_F(PhysicsTrackViewHostTest, processes)
     // Anti-celeriton
     {
         PhysicsTrackView const phys
-            = this->make_track_view("anti-celeriton", PhysicsMaterialId{1});
+            = this->make_track_view("anti-celeriton", PhysMatId{1});
 
         EXPECT_EQ(2, phys.num_particle_processes());
         ParticleProcessId const hiss_ppid{0};
@@ -414,7 +411,7 @@ TEST_F(PhysicsTrackViewHostTest, processes)
     {
         // No at-rest interaction
         PhysicsTrackView const phys
-            = this->make_track_view("electron", PhysicsMaterialId{1});
+            = this->make_track_view("electron", PhysMatId{1});
         EXPECT_EQ(ParticleProcessId{}, phys.at_rest_process());
     }
 }
@@ -429,7 +426,7 @@ TEST_F(PhysicsTrackViewHostTest, value_grids)
 
     for (char const* particle : {"gamma", "celeriton", "anti-celeriton"})
     {
-        for (auto mat_id : range(PhysicsMaterialId{this->material()->size()}))
+        for (auto mat_id : range(PhysMatId{this->material()->size()}))
         {
             PhysicsTrackView const phys
                 = this->make_track_view(particle, mat_id);
@@ -461,7 +458,7 @@ TEST_F(PhysicsTrackViewHostTest, calc_xs)
     std::vector<real_type> xs;
     for (char const* particle : {"gamma", "celeriton"})
     {
-        for (auto mat_id : range(PhysicsMaterialId{this->material()->size()}))
+        for (auto mat_id : range(PhysMatId{this->material()->size()}))
         {
             PhysicsTrackView const phys
                 = this->make_track_view(particle, mat_id);
@@ -492,7 +489,7 @@ TEST_F(PhysicsTrackViewHostTest, calc_eloss_range)
     for (char const* particle : {"celeriton", "anti-celeriton"})
     {
         PhysicsTrackView const phys
-            = this->make_track_view(particle, PhysicsMaterialId{0});
+            = this->make_track_view(particle, PhysMatId{0});
 
         auto eloss_id = phys.energy_loss_grid();
         ASSERT_TRUE(eloss_id);
@@ -545,27 +542,25 @@ TEST_F(PhysicsTrackViewHostTest, use_integral)
 {
     {
         // No energy loss tables
-        auto const phys
-            = this->make_track_view("celeriton", PhysicsMaterialId{2});
+        auto const phys = this->make_track_view("celeriton", PhysMatId{2});
         auto ppid = this->find_ppid(phys, "scattering");
         ASSERT_TRUE(ppid);
         EXPECT_FALSE(phys.integral_xs_process(ppid));
 
-        MaterialView material = this->material()->get(PhysicsMaterialId{2});
+        MaterialView material = this->material()->get(PhysMatId{2});
         EXPECT_SOFT_EQ(
             0.1, to_inv_cm(phys.calc_xs(ppid, material, MevEnergy{1.0})));
     }
     {
         // Energy loss tables and energy-dependent macro xs
         std::vector<real_type> xs, max_xs;
-        auto const phys
-            = this->make_track_view("electron", PhysicsMaterialId{2});
+        auto const phys = this->make_track_view("electron", PhysMatId{2});
         auto ppid = this->find_ppid(phys, "barks");
         ASSERT_TRUE(ppid);
         auto const& integral_proc = phys.integral_xs_process(ppid);
         EXPECT_TRUE(integral_proc);
 
-        MaterialView material = this->material()->get(PhysicsMaterialId{2});
+        MaterialView material = this->material()->get(PhysMatId{2});
         for (real_type energy : {0.001, 0.01, 0.1, 0.11, 10.0})
         {
             xs.push_back(
@@ -583,7 +578,7 @@ TEST_F(PhysicsTrackViewHostTest, use_integral)
 TEST_F(PhysicsTrackViewHostTest, model_finder)
 {
     PhysicsTrackView const phys
-        = this->make_track_view("celeriton", PhysicsMaterialId{0});
+        = this->make_track_view("celeriton", PhysMatId{0});
     auto purr_ppid = this->find_ppid(phys, "purrs");
     ASSERT_TRUE(purr_ppid);
     auto find_model = phys.make_model_finder(purr_ppid);
@@ -599,7 +594,7 @@ TEST_F(PhysicsTrackViewHostTest, model_finder)
 TEST_F(PhysicsTrackViewHostTest, element_selector)
 {
     MevEnergy energy{2};
-    PhysicsMaterialId mid{2};
+    PhysMatId mid{2};
 
     // Get the sampled process (constant micro xs)
     PhysicsTrackView const phys = this->make_track_view("celeriton", mid);
@@ -633,7 +628,7 @@ TEST_F(PhysicsTrackViewHostTest, element_selector)
     // Material composed of a single element
     {
         PhysicsTrackView phys
-            = this->make_track_view("celeriton", PhysicsMaterialId{1});
+            = this->make_track_view("celeriton", PhysMatId{1});
         auto table_id = phys.value_table(pmid);
         EXPECT_FALSE(table_id);
     }
@@ -644,8 +639,7 @@ TEST_F(PhysicsTrackViewHostTest, cuda_surrogate)
     std::vector<real_type> step;
     for (char const* particle : {"gamma", "anti-celeriton"})
     {
-        PhysicsTrackView phys
-            = this->make_track_view(particle, PhysicsMaterialId{1});
+        PhysicsTrackView phys = this->make_track_view(particle, PhysMatId{1});
         PhysicsStepView pstep = this->make_step_view(particle);
 
         for (real_type energy : {1e-5, 1e-3, 1., 100., 1e5})
@@ -708,7 +702,7 @@ TEST_F(PHYS_DEVICE_TEST, all)
         PhysTestInit thread_init;
         for (unsigned int matid : {0, 2})
         {
-            thread_init.mat = PhysicsMaterialId{matid};
+            thread_init.mat = PhysMatId{matid};
             for (real_type energy : {1e-5, 1e-3, 1., 100., 1e5})
             {
                 thread_init.energy = MevEnergy{energy};
@@ -882,7 +876,7 @@ TEST_F(EPlusAnnihilationTest, host_track_view)
     par = ParticleTrackView::Initializer_t{pid, MevEnergy{1}};
 
     ParticleProcessId const ppid{0};
-    PhysicsMaterialId const matid{0};
+    PhysMatId const matid{0};
 
     PhysicsTrackView phys(params_ref, state.ref(), par, matid, TrackSlotId{0});
     phys = PhysicsTrackInitializer{};
@@ -893,7 +887,7 @@ TEST_F(EPlusAnnihilationTest, host_track_view)
     EXPECT_EQ(ModelId{0}, phys.hardwired_model(ppid, MevEnergy{0}));
 
     // Check cross section
-    MaterialView material_view = this->material()->get(PhysicsMaterialId{0});
+    MaterialView material_view = this->material()->get(PhysMatId{0});
     EXPECT_SOFT_EQ(
         5.1172452607412999e-05,
         to_inv_cm(phys.calc_xs(ppid, material_view, MevEnergy{0.1})));

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -197,7 +197,8 @@ class PhysicsTrackViewHostTest : public PhysicsParamsTest
         }
     }
 
-    PhysicsTrackView make_track_view(char const* particle, MaterialId mid)
+    PhysicsTrackView
+    make_track_view(char const* particle, PhysicsMaterialId mid)
     {
         CELER_EXPECT(particle && mid);
 
@@ -262,8 +263,10 @@ class PhysicsTrackViewHostTest : public PhysicsParamsTest
 
 TEST_F(PhysicsTrackViewHostTest, track_view)
 {
-    PhysicsTrackView gamma = this->make_track_view("gamma", MaterialId{0});
-    PhysicsTrackView celer = this->make_track_view("celeriton", MaterialId{1});
+    PhysicsTrackView gamma
+        = this->make_track_view("gamma", PhysicsMaterialId{0});
+    PhysicsTrackView celer
+        = this->make_track_view("celeriton", PhysicsMaterialId{1});
     PhysicsTrackView const& gamma_cref = gamma;
 
     // Interaction MFP
@@ -369,7 +372,7 @@ TEST_F(PhysicsTrackViewHostTest, processes)
     // Gamma
     {
         PhysicsTrackView const phys
-            = this->make_track_view("gamma", MaterialId{0});
+            = this->make_track_view("gamma", PhysicsMaterialId{0});
 
         EXPECT_EQ(2, phys.num_particle_processes());
         ParticleProcessId const scat_ppid{0};
@@ -382,7 +385,7 @@ TEST_F(PhysicsTrackViewHostTest, processes)
     // Celeriton
     {
         PhysicsTrackView const phys
-            = this->make_track_view("celeriton", MaterialId{0});
+            = this->make_track_view("celeriton", PhysicsMaterialId{0});
 
         EXPECT_EQ(3, phys.num_particle_processes());
         ParticleProcessId const scat_ppid{0};
@@ -397,7 +400,7 @@ TEST_F(PhysicsTrackViewHostTest, processes)
     // Anti-celeriton
     {
         PhysicsTrackView const phys
-            = this->make_track_view("anti-celeriton", MaterialId{1});
+            = this->make_track_view("anti-celeriton", PhysicsMaterialId{1});
 
         EXPECT_EQ(2, phys.num_particle_processes());
         ParticleProcessId const hiss_ppid{0};
@@ -411,7 +414,7 @@ TEST_F(PhysicsTrackViewHostTest, processes)
     {
         // No at-rest interaction
         PhysicsTrackView const phys
-            = this->make_track_view("electron", MaterialId{1});
+            = this->make_track_view("electron", PhysicsMaterialId{1});
         EXPECT_EQ(ParticleProcessId{}, phys.at_rest_process());
     }
 }
@@ -426,7 +429,7 @@ TEST_F(PhysicsTrackViewHostTest, value_grids)
 
     for (char const* particle : {"gamma", "celeriton", "anti-celeriton"})
     {
-        for (auto mat_id : range(MaterialId{this->material()->size()}))
+        for (auto mat_id : range(PhysicsMaterialId{this->material()->size()}))
         {
             PhysicsTrackView const phys
                 = this->make_track_view(particle, mat_id);
@@ -458,7 +461,7 @@ TEST_F(PhysicsTrackViewHostTest, calc_xs)
     std::vector<real_type> xs;
     for (char const* particle : {"gamma", "celeriton"})
     {
-        for (auto mat_id : range(MaterialId{this->material()->size()}))
+        for (auto mat_id : range(PhysicsMaterialId{this->material()->size()}))
         {
             PhysicsTrackView const phys
                 = this->make_track_view(particle, mat_id);
@@ -489,7 +492,7 @@ TEST_F(PhysicsTrackViewHostTest, calc_eloss_range)
     for (char const* particle : {"celeriton", "anti-celeriton"})
     {
         PhysicsTrackView const phys
-            = this->make_track_view(particle, MaterialId{0});
+            = this->make_track_view(particle, PhysicsMaterialId{0});
 
         auto eloss_id = phys.energy_loss_grid();
         ASSERT_TRUE(eloss_id);
@@ -542,25 +545,27 @@ TEST_F(PhysicsTrackViewHostTest, use_integral)
 {
     {
         // No energy loss tables
-        auto const phys = this->make_track_view("celeriton", MaterialId{2});
+        auto const phys
+            = this->make_track_view("celeriton", PhysicsMaterialId{2});
         auto ppid = this->find_ppid(phys, "scattering");
         ASSERT_TRUE(ppid);
         EXPECT_FALSE(phys.integral_xs_process(ppid));
 
-        MaterialView material = this->material()->get(MaterialId{2});
+        MaterialView material = this->material()->get(PhysicsMaterialId{2});
         EXPECT_SOFT_EQ(
             0.1, to_inv_cm(phys.calc_xs(ppid, material, MevEnergy{1.0})));
     }
     {
         // Energy loss tables and energy-dependent macro xs
         std::vector<real_type> xs, max_xs;
-        auto const phys = this->make_track_view("electron", MaterialId{2});
+        auto const phys
+            = this->make_track_view("electron", PhysicsMaterialId{2});
         auto ppid = this->find_ppid(phys, "barks");
         ASSERT_TRUE(ppid);
         auto const& integral_proc = phys.integral_xs_process(ppid);
         EXPECT_TRUE(integral_proc);
 
-        MaterialView material = this->material()->get(MaterialId{2});
+        MaterialView material = this->material()->get(PhysicsMaterialId{2});
         for (real_type energy : {0.001, 0.01, 0.1, 0.11, 10.0})
         {
             xs.push_back(
@@ -578,7 +583,7 @@ TEST_F(PhysicsTrackViewHostTest, use_integral)
 TEST_F(PhysicsTrackViewHostTest, model_finder)
 {
     PhysicsTrackView const phys
-        = this->make_track_view("celeriton", MaterialId{0});
+        = this->make_track_view("celeriton", PhysicsMaterialId{0});
     auto purr_ppid = this->find_ppid(phys, "purrs");
     ASSERT_TRUE(purr_ppid);
     auto find_model = phys.make_model_finder(purr_ppid);
@@ -594,7 +599,7 @@ TEST_F(PhysicsTrackViewHostTest, model_finder)
 TEST_F(PhysicsTrackViewHostTest, element_selector)
 {
     MevEnergy energy{2};
-    MaterialId mid{2};
+    PhysicsMaterialId mid{2};
 
     // Get the sampled process (constant micro xs)
     PhysicsTrackView const phys = this->make_track_view("celeriton", mid);
@@ -628,7 +633,7 @@ TEST_F(PhysicsTrackViewHostTest, element_selector)
     // Material composed of a single element
     {
         PhysicsTrackView phys
-            = this->make_track_view("celeriton", MaterialId{1});
+            = this->make_track_view("celeriton", PhysicsMaterialId{1});
         auto table_id = phys.value_table(pmid);
         EXPECT_FALSE(table_id);
     }
@@ -639,7 +644,8 @@ TEST_F(PhysicsTrackViewHostTest, cuda_surrogate)
     std::vector<real_type> step;
     for (char const* particle : {"gamma", "anti-celeriton"})
     {
-        PhysicsTrackView phys = this->make_track_view(particle, MaterialId{1});
+        PhysicsTrackView phys
+            = this->make_track_view(particle, PhysicsMaterialId{1});
         PhysicsStepView pstep = this->make_step_view(particle);
 
         for (real_type energy : {1e-5, 1e-3, 1., 100., 1e5})
@@ -702,7 +708,7 @@ TEST_F(PHYS_DEVICE_TEST, all)
         PhysTestInit thread_init;
         for (unsigned int matid : {0, 2})
         {
-            thread_init.mat = MaterialId{matid};
+            thread_init.mat = PhysicsMaterialId{matid};
             for (real_type energy : {1e-5, 1e-3, 1., 100., 1e5})
             {
                 thread_init.energy = MevEnergy{energy};
@@ -876,7 +882,7 @@ TEST_F(EPlusAnnihilationTest, host_track_view)
     par = ParticleTrackView::Initializer_t{pid, MevEnergy{1}};
 
     ParticleProcessId const ppid{0};
-    MaterialId const matid{0};
+    PhysicsMaterialId const matid{0};
 
     PhysicsTrackView phys(params_ref, state.ref(), par, matid, TrackSlotId{0});
     phys = PhysicsTrackInitializer{};
@@ -887,7 +893,7 @@ TEST_F(EPlusAnnihilationTest, host_track_view)
     EXPECT_EQ(ModelId{0}, phys.hardwired_model(ppid, MevEnergy{0}));
 
     // Check cross section
-    MaterialView material_view = this->material()->get(MaterialId{0});
+    MaterialView material_view = this->material()->get(PhysicsMaterialId{0});
     EXPECT_SOFT_EQ(
         5.1172452607412999e-05,
         to_inv_cm(phys.calc_xs(ppid, material_view, MevEnergy{0.1})));

--- a/test/celeritas/phys/Physics.test.hh
+++ b/test/celeritas/phys/Physics.test.hh
@@ -33,7 +33,7 @@ namespace test
 struct PhysTestInit
 {
     units::MevEnergy energy;
-    MaterialId mat;
+    PhysicsMaterialId mat;
     ParticleId particle;
 };
 

--- a/test/celeritas/phys/Physics.test.hh
+++ b/test/celeritas/phys/Physics.test.hh
@@ -33,7 +33,7 @@ namespace test
 struct PhysTestInit
 {
     units::MevEnergy energy;
-    PhysicsMaterialId mat;
+    PhysMatId mat;
     ParticleId particle;
 };
 

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -57,7 +57,7 @@ class PhysicsStepUtilsTest : public MockTestBase
     RandomEngine& rng() { return rng_; }
 
     PhysicsTrackView init_track(MaterialTrackView* mat,
-                                PhysicsMaterialId mid,
+                                PhysMatId mid,
                                 ParticleTrackView* par,
                                 char const* name,
                                 MevEnergy energy)
@@ -116,7 +116,7 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
     // Test a variety of energies and multiple material IDs
     {
         PhysicsTrackView phys = this->init_track(
-            &material, PhysicsMaterialId{0}, &particle, "gamma", MevEnergy{1});
+            &material, PhysMatId{0}, &particle, "gamma", MevEnergy{1});
         phys.interaction_mfp(1);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -124,11 +124,8 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
         EXPECT_SOFT_EQ(1. / 3.e-4, to_cm(step.step));
     }
     {
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{1},
-                                                 &particle,
-                                                 "celeriton",
-                                                 MevEnergy{10});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{1}, &particle, "celeriton", MevEnergy{10});
         phys.interaction_mfp(1e-4);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -142,11 +139,8 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
         EXPECT_SOFT_EQ(0.48856714661867118, to_cm(step.step));
     }
     {
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{1},
-                                                 &particle,
-                                                 "celeriton",
-                                                 MevEnergy{1e-2});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{1}, &particle, "celeriton", MevEnergy{1e-2});
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
         EXPECT_EQ(range_action, step.action);
@@ -154,7 +148,7 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
     }
     {
         PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{2},
+                                                 PhysMatId{2},
                                                  &particle,
                                                  "anti-celeriton",
                                                  MevEnergy{1e-2});
@@ -171,22 +165,16 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
         EXPECT_SOFT_EQ(1.5714285714285705e-05, to_cm(step.step));
     }
     {
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{2},
-                                                 &particle,
-                                                 "anti-celeriton",
-                                                 MevEnergy{10});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{2}, &particle, "anti-celeriton", MevEnergy{10});
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
         EXPECT_EQ(range_action, step.action);
         EXPECT_SOFT_EQ(0.014287142857142861, to_cm(step.step));
     }
     {
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{1},
-                                                 &particle,
-                                                 "celeriton",
-                                                 MevEnergy{10});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{1}, &particle, "celeriton", MevEnergy{10});
         phys.interaction_mfp(1e-4);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -201,11 +189,8 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
     }
     {
         // Test absurdly low energy (1 + E = 1)
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{1},
-                                                 &particle,
-                                                 "celeriton",
-                                                 MevEnergy{1e-18});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{1}, &particle, "celeriton", MevEnergy{1e-18});
         phys.interaction_mfp(1e-10);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -214,11 +199,8 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
     }
     {
         // Celerino should have infinite step with no action
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{0},
-                                                 &particle,
-                                                 "celerino",
-                                                 MevEnergy{1});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{0}, &particle, "celerino", MevEnergy{1});
         phys.interaction_mfp(1.234);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -250,7 +232,7 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
 
     {
         PhysicsTrackView phys = this->init_track(
-            &material, PhysicsMaterialId{0}, &particle, "gamma", MevEnergy{1});
+            &material, PhysMatId{0}, &particle, "gamma", MevEnergy{1});
         if (CELERITAS_DEBUG)
         {
             // Can't calc eloss for photons
@@ -258,11 +240,8 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
         }
     }
     {
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{0},
-                                                 &particle,
-                                                 "celeriton",
-                                                 MevEnergy{10});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{0}, &particle, "celeriton", MevEnergy{10});
         real_type const eloss_rate = (0.2 + 0.4);  // MeV / cm
 
         // Tiny step: should still be linear loss (single process)
@@ -281,11 +260,8 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
         EXPECT_SOFT_EQ(9.99, calc_eloss(phys, step));
     }
     {
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{0},
-                                                 &particle,
-                                                 "electron",
-                                                 MevEnergy{1e-3});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{0}, &particle, "electron", MevEnergy{1e-3});
         real_type const eloss_rate = 0.5;  // MeV / cm
 
         // Low energy particle which loses all its energy over the step will
@@ -311,10 +287,9 @@ TEST_F(PhysicsStepUtilsTest,
 
     // Test a variety of energy ranges and multiple material IDs
     {
-        MaterialView mat_view(this->material()->host_ref(),
-                              PhysicsMaterialId{0});
+        MaterialView mat_view(this->material()->host_ref(), PhysMatId{0});
         PhysicsTrackView phys = this->init_track(
-            &material, PhysicsMaterialId{0}, &particle, "gamma", MevEnergy{1});
+            &material, PhysMatId{0}, &particle, "gamma", MevEnergy{1});
         phys.interaction_mfp(1);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -338,13 +313,9 @@ TEST_F(PhysicsStepUtilsTest,
     }
 
     {
-        MaterialView mat_view(this->material()->host_ref(),
-                              PhysicsMaterialId{1});
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{1},
-                                                 &particle,
-                                                 "celeriton",
-                                                 MevEnergy{10});
+        MaterialView mat_view(this->material()->host_ref(), PhysMatId{1});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{1}, &particle, "celeriton", MevEnergy{10});
         phys.interaction_mfp(1);
 
         StepLimit step
@@ -385,10 +356,9 @@ TEST_F(PhysicsStepUtilsTest,
 
         for (auto i : range(inc_energy.size()))
         {
-            MaterialView mat_view(this->material()->host_ref(),
-                                  PhysicsMaterialId{0});
+            MaterialView mat_view(this->material()->host_ref(), PhysMatId{0});
             PhysicsTrackView phys = this->init_track(&material,
-                                                     PhysicsMaterialId{0},
+                                                     PhysMatId{0},
                                                      &particle,
                                                      "electron",
                                                      MevEnergy{inc_energy[i]});
@@ -459,7 +429,7 @@ TEST_F(StepLimiterTest, calc_physics_step_limit)
         // Gammas should not be limited since they have no energy loss
         // processes
         PhysicsTrackView phys = this->init_track(
-            &material, PhysicsMaterialId{0}, &particle, "gamma", MevEnergy{1});
+            &material, PhysMatId{0}, &particle, "gamma", MevEnergy{1});
         phys.interaction_mfp(1);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -467,11 +437,8 @@ TEST_F(StepLimiterTest, calc_physics_step_limit)
         EXPECT_SOFT_EQ(1. / 3.e-4, to_cm(step.step));
     }
     {
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{1},
-                                                 &particle,
-                                                 "celeriton",
-                                                 MevEnergy{1e-3});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{1}, &particle, "celeriton", MevEnergy{1e-3});
 
         // Small energy: still range action
         StepLimit step
@@ -519,7 +486,7 @@ TEST_F(SplinePhysicsStepUtilsTest, calc_mean_energy_loss)
 
     {
         PhysicsTrackView phys = this->init_track(
-            &material, PhysicsMaterialId{0}, &particle, "gamma", MevEnergy{1});
+            &material, PhysMatId{0}, &particle, "gamma", MevEnergy{1});
         if (CELERITAS_DEBUG)
         {
             // Can't calc eloss for photons
@@ -527,11 +494,8 @@ TEST_F(SplinePhysicsStepUtilsTest, calc_mean_energy_loss)
         }
     }
     {
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{0},
-                                                 &particle,
-                                                 "celeriton",
-                                                 MevEnergy{10});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{0}, &particle, "celeriton", MevEnergy{10});
         real_type const eloss_rate = (0.2 + 0.4);  // MeV / cm
 
         // Tiny step: should still be linear loss (single process)
@@ -550,11 +514,8 @@ TEST_F(SplinePhysicsStepUtilsTest, calc_mean_energy_loss)
         EXPECT_SOFT_EQ(9.99, calc_eloss(phys, step));
     }
     {
-        PhysicsTrackView phys = this->init_track(&material,
-                                                 PhysicsMaterialId{0},
-                                                 &particle,
-                                                 "electron",
-                                                 MevEnergy{1e-3});
+        PhysicsTrackView phys = this->init_track(
+            &material, PhysMatId{0}, &particle, "electron", MevEnergy{1e-3});
         real_type const eloss_rate = 0.5;  // MeV / cm
 
         // Low energy particle which loses all its energy over the step will

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -57,7 +57,7 @@ class PhysicsStepUtilsTest : public MockTestBase
     RandomEngine& rng() { return rng_; }
 
     PhysicsTrackView init_track(MaterialTrackView* mat,
-                                MaterialId mid,
+                                PhysicsMaterialId mid,
                                 ParticleTrackView* par,
                                 char const* name,
                                 MevEnergy energy)
@@ -116,7 +116,7 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
     // Test a variety of energies and multiple material IDs
     {
         PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{0}, &particle, "gamma", MevEnergy{1});
+            &material, PhysicsMaterialId{0}, &particle, "gamma", MevEnergy{1});
         phys.interaction_mfp(1);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -124,8 +124,11 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
         EXPECT_SOFT_EQ(1. / 3.e-4, to_cm(step.step));
     }
     {
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{1}, &particle, "celeriton", MevEnergy{10});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{1},
+                                                 &particle,
+                                                 "celeriton",
+                                                 MevEnergy{10});
         phys.interaction_mfp(1e-4);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -139,8 +142,11 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
         EXPECT_SOFT_EQ(0.48856714661867118, to_cm(step.step));
     }
     {
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{1}, &particle, "celeriton", MevEnergy{1e-2});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{1},
+                                                 &particle,
+                                                 "celeriton",
+                                                 MevEnergy{1e-2});
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
         EXPECT_EQ(range_action, step.action);
@@ -148,7 +154,7 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
     }
     {
         PhysicsTrackView phys = this->init_track(&material,
-                                                 MaterialId{2},
+                                                 PhysicsMaterialId{2},
                                                  &particle,
                                                  "anti-celeriton",
                                                  MevEnergy{1e-2});
@@ -166,7 +172,7 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
     }
     {
         PhysicsTrackView phys = this->init_track(&material,
-                                                 MaterialId{2},
+                                                 PhysicsMaterialId{2},
                                                  &particle,
                                                  "anti-celeriton",
                                                  MevEnergy{10});
@@ -176,8 +182,11 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
         EXPECT_SOFT_EQ(0.014287142857142861, to_cm(step.step));
     }
     {
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{1}, &particle, "celeriton", MevEnergy{10});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{1},
+                                                 &particle,
+                                                 "celeriton",
+                                                 MevEnergy{10});
         phys.interaction_mfp(1e-4);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -192,8 +201,11 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
     }
     {
         // Test absurdly low energy (1 + E = 1)
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{1}, &particle, "celeriton", MevEnergy{1e-18});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{1},
+                                                 &particle,
+                                                 "celeriton",
+                                                 MevEnergy{1e-18});
         phys.interaction_mfp(1e-10);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -202,8 +214,11 @@ TEST_F(PhysicsStepUtilsTest, calc_physics_step_limit)
     }
     {
         // Celerino should have infinite step with no action
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{0}, &particle, "celerino", MevEnergy{1});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{0},
+                                                 &particle,
+                                                 "celerino",
+                                                 MevEnergy{1});
         phys.interaction_mfp(1.234);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -235,7 +250,7 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
 
     {
         PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{0}, &particle, "gamma", MevEnergy{1});
+            &material, PhysicsMaterialId{0}, &particle, "gamma", MevEnergy{1});
         if (CELERITAS_DEBUG)
         {
             // Can't calc eloss for photons
@@ -243,8 +258,11 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
         }
     }
     {
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{0}, &particle, "celeriton", MevEnergy{10});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{0},
+                                                 &particle,
+                                                 "celeriton",
+                                                 MevEnergy{10});
         real_type const eloss_rate = (0.2 + 0.4);  // MeV / cm
 
         // Tiny step: should still be linear loss (single process)
@@ -263,8 +281,11 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
         EXPECT_SOFT_EQ(9.99, calc_eloss(phys, step));
     }
     {
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{0}, &particle, "electron", MevEnergy{1e-3});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{0},
+                                                 &particle,
+                                                 "electron",
+                                                 MevEnergy{1e-3});
         real_type const eloss_rate = 0.5;  // MeV / cm
 
         // Low energy particle which loses all its energy over the step will
@@ -290,9 +311,10 @@ TEST_F(PhysicsStepUtilsTest,
 
     // Test a variety of energy ranges and multiple material IDs
     {
-        MaterialView mat_view(this->material()->host_ref(), MaterialId{0});
+        MaterialView mat_view(this->material()->host_ref(),
+                              PhysicsMaterialId{0});
         PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{0}, &particle, "gamma", MevEnergy{1});
+            &material, PhysicsMaterialId{0}, &particle, "gamma", MevEnergy{1});
         phys.interaction_mfp(1);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -316,9 +338,13 @@ TEST_F(PhysicsStepUtilsTest,
     }
 
     {
-        MaterialView mat_view(this->material()->host_ref(), MaterialId{1});
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{1}, &particle, "celeriton", MevEnergy{10});
+        MaterialView mat_view(this->material()->host_ref(),
+                              PhysicsMaterialId{1});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{1},
+                                                 &particle,
+                                                 "celeriton",
+                                                 MevEnergy{10});
         phys.interaction_mfp(1);
 
         StepLimit step
@@ -359,9 +385,10 @@ TEST_F(PhysicsStepUtilsTest,
 
         for (auto i : range(inc_energy.size()))
         {
-            MaterialView mat_view(this->material()->host_ref(), MaterialId{0});
+            MaterialView mat_view(this->material()->host_ref(),
+                                  PhysicsMaterialId{0});
             PhysicsTrackView phys = this->init_track(&material,
-                                                     MaterialId{0},
+                                                     PhysicsMaterialId{0},
                                                      &particle,
                                                      "electron",
                                                      MevEnergy{inc_energy[i]});
@@ -432,7 +459,7 @@ TEST_F(StepLimiterTest, calc_physics_step_limit)
         // Gammas should not be limited since they have no energy loss
         // processes
         PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{0}, &particle, "gamma", MevEnergy{1});
+            &material, PhysicsMaterialId{0}, &particle, "gamma", MevEnergy{1});
         phys.interaction_mfp(1);
         StepLimit step
             = calc_physics_step_limit(material, particle, phys, pstep);
@@ -440,8 +467,11 @@ TEST_F(StepLimiterTest, calc_physics_step_limit)
         EXPECT_SOFT_EQ(1. / 3.e-4, to_cm(step.step));
     }
     {
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{1}, &particle, "celeriton", MevEnergy{1e-3});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{1},
+                                                 &particle,
+                                                 "celeriton",
+                                                 MevEnergy{1e-3});
 
         // Small energy: still range action
         StepLimit step
@@ -489,7 +519,7 @@ TEST_F(SplinePhysicsStepUtilsTest, calc_mean_energy_loss)
 
     {
         PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{0}, &particle, "gamma", MevEnergy{1});
+            &material, PhysicsMaterialId{0}, &particle, "gamma", MevEnergy{1});
         if (CELERITAS_DEBUG)
         {
             // Can't calc eloss for photons
@@ -497,8 +527,11 @@ TEST_F(SplinePhysicsStepUtilsTest, calc_mean_energy_loss)
         }
     }
     {
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{0}, &particle, "celeriton", MevEnergy{10});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{0},
+                                                 &particle,
+                                                 "celeriton",
+                                                 MevEnergy{10});
         real_type const eloss_rate = (0.2 + 0.4);  // MeV / cm
 
         // Tiny step: should still be linear loss (single process)
@@ -517,8 +550,11 @@ TEST_F(SplinePhysicsStepUtilsTest, calc_mean_energy_loss)
         EXPECT_SOFT_EQ(9.99, calc_eloss(phys, step));
     }
     {
-        PhysicsTrackView phys = this->init_track(
-            &material, MaterialId{0}, &particle, "electron", MevEnergy{1e-3});
+        PhysicsTrackView phys = this->init_track(&material,
+                                                 PhysicsMaterialId{0},
+                                                 &particle,
+                                                 "electron",
+                                                 MevEnergy{1e-3});
         real_type const eloss_rate = 0.5;  // MeV / cm
 
         // Low energy particle which loses all its energy over the step will

--- a/test/celeritas/phys/ProcessBuilder.test.cc
+++ b/test/celeritas/phys/ProcessBuilder.test.cc
@@ -135,8 +135,7 @@ TEST_F(ProcessBuilderTest, compton)
     ASSERT_EQ(1, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -171,8 +170,7 @@ TEST_F(ProcessBuilderTest, e_ionization)
     auto all_applic = models.front()->applicability();
     ASSERT_EQ(2, all_applic.size());
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         for (auto applic : all_applic)
         {
@@ -210,8 +208,7 @@ TEST_F(ProcessBuilderTest, eplus_annihilation)
     auto all_applic = models.front()->applicability();
     ASSERT_EQ(1, all_applic.size());
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         for (auto applic : all_applic)
         {
@@ -250,8 +247,7 @@ TEST_F(ProcessBuilderTest, gamma_conversion)
     ASSERT_EQ(1, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -297,8 +293,7 @@ TEST_F(ProcessBuilderTest, photoelectric)
     ASSERT_EQ(1, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -342,8 +337,7 @@ TEST_F(ProcessBuilderTest, bremsstrahlung_multiple_models)
     ASSERT_EQ(2, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -395,8 +389,7 @@ TEST_F(ProcessBuilderTest, bremsstrahlung_combined_model)
     ASSERT_EQ(2, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -438,8 +431,7 @@ TEST_F(ProcessBuilderTest, rayleigh)
     ASSERT_EQ(1, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -487,8 +479,7 @@ TEST_F(ProcessBuilderTest, coulomb)
     EXPECT_EQ(100, value_as<units::MevEnergy>(applic.lower));
     EXPECT_EQ(1e8, value_as<units::MevEnergy>(applic.upper));
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -546,8 +537,7 @@ TEST_F(ProcessBuilderTest, neutron_elastic)
     ASSERT_EQ(1, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -591,8 +581,7 @@ TEST_F(ProcessBuilderTest, mu_ionization)
     auto all_applic = models[2]->applicability();
     ASSERT_EQ(2, all_applic.size());
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         for (auto applic : all_applic)
         {
@@ -632,8 +621,7 @@ TEST_F(ProcessBuilderTest, mu_bremsstrahlung)
     ASSERT_EQ(2, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id :
-         range(PhysicsMaterialId{this->material()->num_materials()}))
+    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {
         // Test step limits
         {

--- a/test/celeritas/phys/ProcessBuilder.test.cc
+++ b/test/celeritas/phys/ProcessBuilder.test.cc
@@ -135,7 +135,8 @@ TEST_F(ProcessBuilderTest, compton)
     ASSERT_EQ(1, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -170,7 +171,8 @@ TEST_F(ProcessBuilderTest, e_ionization)
     auto all_applic = models.front()->applicability();
     ASSERT_EQ(2, all_applic.size());
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         for (auto applic : all_applic)
         {
@@ -208,7 +210,8 @@ TEST_F(ProcessBuilderTest, eplus_annihilation)
     auto all_applic = models.front()->applicability();
     ASSERT_EQ(1, all_applic.size());
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         for (auto applic : all_applic)
         {
@@ -247,7 +250,8 @@ TEST_F(ProcessBuilderTest, gamma_conversion)
     ASSERT_EQ(1, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -293,7 +297,8 @@ TEST_F(ProcessBuilderTest, photoelectric)
     ASSERT_EQ(1, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -337,7 +342,8 @@ TEST_F(ProcessBuilderTest, bremsstrahlung_multiple_models)
     ASSERT_EQ(2, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -389,7 +395,8 @@ TEST_F(ProcessBuilderTest, bremsstrahlung_combined_model)
     ASSERT_EQ(2, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -431,7 +438,8 @@ TEST_F(ProcessBuilderTest, rayleigh)
     ASSERT_EQ(1, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -479,7 +487,8 @@ TEST_F(ProcessBuilderTest, coulomb)
     EXPECT_EQ(100, value_as<units::MevEnergy>(applic.lower));
     EXPECT_EQ(1e8, value_as<units::MevEnergy>(applic.upper));
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -537,7 +546,8 @@ TEST_F(ProcessBuilderTest, neutron_elastic)
     ASSERT_EQ(1, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         // Test step limits
         {
@@ -581,7 +591,8 @@ TEST_F(ProcessBuilderTest, mu_ionization)
     auto all_applic = models[2]->applicability();
     ASSERT_EQ(2, all_applic.size());
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         for (auto applic : all_applic)
         {
@@ -621,7 +632,8 @@ TEST_F(ProcessBuilderTest, mu_bremsstrahlung)
     ASSERT_EQ(2, all_applic.size());
     Applicability applic = *all_applic.begin();
 
-    for (auto mat_id : range(MaterialId{this->material()->num_materials()}))
+    for (auto mat_id :
+         range(PhysicsMaterialId{this->material()->num_materials()}))
     {
         // Test step limits
         {

--- a/test/celeritas/random/IsotopeSelector.test.cc
+++ b/test/celeritas/random/IsotopeSelector.test.cc
@@ -68,7 +68,7 @@ TEST_F(IsotopeSelectorTest, multiple_isotopes)
     std::size_t const num_loops = 1000;
 
     // Diatomic hydrogen: two isotopes (fractions 0.9 and 0.1)
-    MaterialView mat_h2(host_mats, PhysicsMaterialId{2});
+    MaterialView mat_h2(host_mats, PhysMatId{2});
     auto const& element_h = mat_h2.element_record(ElementComponentId{0});
     IsotopeSelector select_iso_h(element_h);
 

--- a/test/celeritas/random/IsotopeSelector.test.cc
+++ b/test/celeritas/random/IsotopeSelector.test.cc
@@ -68,7 +68,7 @@ TEST_F(IsotopeSelectorTest, multiple_isotopes)
     std::size_t const num_loops = 1000;
 
     // Diatomic hydrogen: two isotopes (fractions 0.9 and 0.1)
-    MaterialView mat_h2(host_mats, MaterialId{2});
+    MaterialView mat_h2(host_mats, PhysicsMaterialId{2});
     auto const& element_h = mat_h2.element_record(ElementComponentId{0});
     IsotopeSelector select_iso_h(element_h);
 

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -517,7 +517,7 @@ class CollectionTest : public Test
                                                 std::end(elements));
             EXPECT_EQ(3, m.elements.size());
             auto id = mat_builder.push_back(m);
-            EXPECT_EQ(MockMaterialId{0}, id);
+            EXPECT_EQ(MockPhysicsMaterialId{0}, id);
         }
         {
             MockMaterial m;
@@ -539,7 +539,7 @@ class CollectionTest : public Test
             auto const& host_data_const = host_data;
 
             MockMaterial const& m
-                = host_data_const.materials[MockMaterialId{0}];
+                = host_data_const.materials[MockPhysicsMaterialId{0}];
             EXPECT_EQ(3, m.elements.size());
             Span<MockElement const> els = host_data_const.elements[m.elements];
             EXPECT_EQ(3, els.size());
@@ -583,7 +583,7 @@ TEST_F(CollectionTest, host)
     HostVal<MockStateData> host_state;
     resize(&host_state, 1);
     auto host_state_ref = make_ref(host_state);
-    host_state_ref.matid[TrackSlotId{0}] = MockMaterialId{1};
+    host_state_ref.matid[TrackSlotId{0}] = MockPhysicsMaterialId{1};
 
     // Create view
     MockTrackView mock(mock_params.host_ref(), host_state_ref, TrackSlotId{0});
@@ -620,7 +620,7 @@ TEST_F(CollectionTest, TEST_IF_CELER_DEVICE(device))
         // Create a track view
         auto host_ref = make_ref(host_states);
         MockTrackView mtv{mock_params.host_ref(), host_ref, TrackSlotId{2}};
-        EXPECT_EQ(MockMaterialId{2}, mtv.matid());
+        EXPECT_EQ(MockPhysicsMaterialId{2}, mtv.matid());
     }
 
     // Check that we can copy back to the device

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -517,7 +517,7 @@ class CollectionTest : public Test
                                                 std::end(elements));
             EXPECT_EQ(3, m.elements.size());
             auto id = mat_builder.push_back(m);
-            EXPECT_EQ(MockPhysicsMaterialId{0}, id);
+            EXPECT_EQ(MockMaterialId{0}, id);
         }
         {
             MockMaterial m;
@@ -539,7 +539,7 @@ class CollectionTest : public Test
             auto const& host_data_const = host_data;
 
             MockMaterial const& m
-                = host_data_const.materials[MockPhysicsMaterialId{0}];
+                = host_data_const.materials[MockMaterialId{0}];
             EXPECT_EQ(3, m.elements.size());
             Span<MockElement const> els = host_data_const.elements[m.elements];
             EXPECT_EQ(3, els.size());
@@ -583,7 +583,7 @@ TEST_F(CollectionTest, host)
     HostVal<MockStateData> host_state;
     resize(&host_state, 1);
     auto host_state_ref = make_ref(host_state);
-    host_state_ref.matid[TrackSlotId{0}] = MockPhysicsMaterialId{1};
+    host_state_ref.matid[TrackSlotId{0}] = MockMaterialId{1};
 
     // Create view
     MockTrackView mock(mock_params.host_ref(), host_state_ref, TrackSlotId{0});
@@ -620,7 +620,7 @@ TEST_F(CollectionTest, TEST_IF_CELER_DEVICE(device))
         // Create a track view
         auto host_ref = make_ref(host_states);
         MockTrackView mtv{mock_params.host_ref(), host_ref, TrackSlotId{2}};
-        EXPECT_EQ(MockPhysicsMaterialId{2}, mtv.matid());
+        EXPECT_EQ(MockMaterialId{2}, mtv.matid());
     }
 
     // Check that we can copy back to the device

--- a/test/corecel/data/Collection.test.cu
+++ b/test/corecel/data/Collection.test.cu
@@ -30,14 +30,13 @@ __global__ void col_cuda_test_kernel(DeviceCRef<MockParamsData> const params,
         return;
 
     // Initialize local matid states
-    states.matid[tid]
-        = MockPhysicsMaterialId(tid.get() % params.materials.size());
+    states.matid[tid] = MockMaterialId(tid.get() % params.materials.size());
 
     // Construct track view
     MockTrackView mock(params, states, tid);
 
     // Access some values
-    MockPhysicsMaterialId matid = mock.matid();
+    MockMaterialId matid = mock.matid();
     CELER_ASSERT(matid);
     double nd = mock.number_density();
     CELER_ASSERT(nd >= 0);

--- a/test/corecel/data/Collection.test.cu
+++ b/test/corecel/data/Collection.test.cu
@@ -30,13 +30,14 @@ __global__ void col_cuda_test_kernel(DeviceCRef<MockParamsData> const params,
         return;
 
     // Initialize local matid states
-    states.matid[tid] = MockMaterialId(tid.get() % params.materials.size());
+    states.matid[tid]
+        = MockPhysicsMaterialId(tid.get() % params.materials.size());
 
     // Construct track view
     MockTrackView mock(params, states, tid);
 
     // Access some values
-    MockMaterialId matid = mock.matid();
+    MockPhysicsMaterialId matid = mock.matid();
     CELER_ASSERT(matid);
     double nd = mock.number_density();
     CELER_ASSERT(nd >= 0);

--- a/test/corecel/data/Collection.test.hh
+++ b/test/corecel/data/Collection.test.hh
@@ -31,7 +31,7 @@ struct MockMaterial
     ItemRange<MockElement> elements;
 };
 
-using MockMaterialId = ItemId<MockMaterial>;
+using MockPhysicsMaterialId = ItemId<MockMaterial>;
 
 template<Ownership W, MemSpace M>
 struct MockParamsData
@@ -71,7 +71,7 @@ struct MockStateData
 {
     //// DATA ////
 
-    StateCollection<MockMaterialId, W, M> matid;
+    StateCollection<MockPhysicsMaterialId, W, M> matid;
 
     //// MEMBER FUNCTIONS ////
 
@@ -106,7 +106,7 @@ class MockTrackView
         CELER_EXPECT(track_slot_ < states_.size());
     }
 
-    CELER_FUNCTION MockMaterialId matid() const
+    CELER_FUNCTION MockPhysicsMaterialId matid() const
     {
         return states_.matid[track_slot_];
     }
@@ -128,7 +128,7 @@ class MockTrackView
 
     CELER_FUNCTION MockMaterial const& mat() const
     {
-        MockMaterialId id = this->matid();
+        MockPhysicsMaterialId id = this->matid();
         CELER_ASSERT(id < params_.materials.size());
         return params_.materials[id];
     }

--- a/test/corecel/data/Collection.test.hh
+++ b/test/corecel/data/Collection.test.hh
@@ -31,7 +31,7 @@ struct MockMaterial
     ItemRange<MockElement> elements;
 };
 
-using MockPhysicsMaterialId = ItemId<MockMaterial>;
+using MockMaterialId = ItemId<MockMaterial>;
 
 template<Ownership W, MemSpace M>
 struct MockParamsData
@@ -71,7 +71,7 @@ struct MockStateData
 {
     //// DATA ////
 
-    StateCollection<MockPhysicsMaterialId, W, M> matid;
+    StateCollection<MockMaterialId, W, M> matid;
 
     //// MEMBER FUNCTIONS ////
 
@@ -106,7 +106,7 @@ class MockTrackView
         CELER_EXPECT(track_slot_ < states_.size());
     }
 
-    CELER_FUNCTION MockPhysicsMaterialId matid() const
+    CELER_FUNCTION MockMaterialId matid() const
     {
         return states_.matid[track_slot_];
     }
@@ -128,7 +128,7 @@ class MockTrackView
 
     CELER_FUNCTION MockMaterial const& mat() const
     {
-        MockPhysicsMaterialId id = this->matid();
+        MockMaterialId id = this->matid();
         CELER_ASSERT(id < params_.materials.size());
         return params_.materials[id];
     }

--- a/test/orange/g4org/ProtoConstructor.test.cc
+++ b/test/orange/g4org/ProtoConstructor.test.cc
@@ -119,7 +119,7 @@ TEST_F(ProtoConstructorTest, one_box)
         EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
         EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
         EXPECT_VEC_EQ(expected_md_strings, md_strings(u));
-        EXPECT_EQ(GeoMaterialId{}, u.background);
+        EXPECT_EQ(GeoMatId{}, u.background);
     }
 }
 
@@ -301,7 +301,7 @@ TEST_F(ProtoConstructorTest, simple_cms)
         EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
         EXPECT_VEC_EQ(expected_fill_strings, fill_strings(u));
         EXPECT_VEC_EQ(expected_volume_nodes, volume_nodes(u));
-        EXPECT_EQ(GeoMaterialId{0}, u.background);
+        EXPECT_EQ(GeoMatId{0}, u.background);
     }
 }
 
@@ -344,7 +344,7 @@ TEST_F(ProtoConstructorTest, testem3)
             "all(all(+0, -1, +2, -3, +4, -5), !all(+6, +8, -9, +10, -11, "
             "-84))",
             vols.back());
-        EXPECT_EQ(GeoMaterialId{}, u.background);
+        EXPECT_EQ(GeoMatId{}, u.background);
     }
     {
         SCOPED_TRACE("daughter");
@@ -425,7 +425,7 @@ TEST_F(ProtoConstructorTest, tilecal_plug)
         EXPECT_VEC_EQ(expected_fill_strings, fill_strings(u));
         EXPECT_VEC_EQ(expected_volume_nodes, volume_nodes(u));
         EXPECT_JSON_EQ(expected_tree_string, tree_string(u));
-        EXPECT_EQ(GeoMaterialId{}, u.background);
+        EXPECT_EQ(GeoMatId{}, u.background);
     }
 }
 
@@ -482,7 +482,7 @@ TEST_F(ProtoConstructorTest, znenv)
         EXPECT_VEC_EQ(expected_fill_strings, fill_strings(u));
         EXPECT_VEC_EQ(expected_volume_nodes, volume_nodes(u));
         EXPECT_JSON_EQ(expected_tree_string, tree_string(u));
-        EXPECT_EQ(GeoMaterialId{}, u.background);
+        EXPECT_EQ(GeoMatId{}, u.background);
     }
     {
         SCOPED_TRACE("ZNTX");
@@ -496,7 +496,7 @@ TEST_F(ProtoConstructorTest, znenv)
 
         EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
         EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
-        EXPECT_EQ(GeoMaterialId{}, u.background);
+        EXPECT_EQ(GeoMatId{}, u.background);
     }
     {
         SCOPED_TRACE("ZNST");
@@ -522,7 +522,7 @@ TEST_F(ProtoConstructorTest, znenv)
 
         EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
         EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
-        EXPECT_EQ(GeoMaterialId{2}, u.background);
+        EXPECT_EQ(GeoMatId{2}, u.background);
     }
     {
         SCOPED_TRACE("ZNG1");
@@ -533,7 +533,7 @@ TEST_F(ProtoConstructorTest, znenv)
 
         EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
         EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
-        EXPECT_EQ(GeoMaterialId{}, u.background);
+        EXPECT_EQ(GeoMatId{}, u.background);
     }
 }
 

--- a/test/orange/orangeinp/CsgTestUtils.cc
+++ b/test/orange/orangeinp/CsgTestUtils.cc
@@ -220,7 +220,7 @@ std::vector<std::string> fill_strings(CsgUnit const& u)
         {
             result.push_back("<UNASSIGNED>");
         }
-        else if (auto* mid = std::get_if<GeoMaterialId>(&f))
+        else if (auto* mid = std::get_if<GeoMatId>(&f))
         {
             result.push_back("m" + std::to_string(mid->unchecked_get()));
         }
@@ -297,7 +297,7 @@ EXPECT_VEC_EQ(expected_fill_strings, fill_strings(u));
 EXPECT_VEC_EQ(expected_volume_nodes, volume_nodes(u));
 EXPECT_JSON_EQ(expected_tree_string, tree_string(u));
 )cpp"
-              << "EXPECT_EQ(GeoMaterialId{";
+              << "EXPECT_EQ(GeoMatId{";
     if (u.background)
     {
         std::cout << u.background.unchecked_get();

--- a/test/orange/orangeinp/UnitProto.test.cc
+++ b/test/orange/orangeinp/UnitProto.test.cc
@@ -96,7 +96,7 @@ SPConstProto make_daughter(std::string label)
 {
     UnitProto::Input inp;
     inp.boundary.interior = make_sph(label + ":ext", 1);
-    inp.background.fill = GeoMaterialId{0};
+    inp.background.fill = GeoMatId{0};
     inp.label = std::move(label);
 
     return std::make_shared<UnitProto>(std::move(inp));
@@ -118,12 +118,12 @@ std::string proto_labels(ProtoInterface::VecProto const& vp)
 }
 
 UnitProto::MaterialInput
-make_material(SPConstObject&& obj, GeoMaterialId::size_type m)
+make_material(SPConstObject&& obj, GeoMatId::size_type m)
 {
     CELER_EXPECT(obj);
     UnitProto::MaterialInput result;
     result.interior = std::move(obj);
-    result.fill = GeoMaterialId{m};
+    result.fill = GeoMatId{m};
     return result;
 }
 
@@ -203,7 +203,7 @@ TEST_F(LeafTest, explicit_exterior)
         EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
         EXPECT_VEC_EQ(expected_md_strings, md_strings(u));
         EXPECT_VEC_EQ(expected_fill_strings, fill_strings(u));
-        EXPECT_EQ(GeoMaterialId{}, u.background);
+        EXPECT_EQ(GeoMatId{}, u.background);
     }
     {
         auto u = proto.build(tol_, BBox{{-2, -2, -1}, {2, 2, 1}});
@@ -219,7 +219,7 @@ TEST_F(LeafTest, implicit_exterior)
     UnitProto::Input inp;
     inp.boundary.interior = make_cyl("bound", 1.0, 1.0);
     inp.boundary.zorder = ZOrder::exterior;
-    inp.background.fill = GeoMaterialId{0};
+    inp.background.fill = GeoMatId{0};
     inp.label = "leaf";
     inp.materials.push_back(make_material(make_cyl("middle", 1, 0.5), 1));
     UnitProto const proto{std::move(inp)};
@@ -242,7 +242,7 @@ TEST_F(LeafTest, implicit_exterior)
         EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
         EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
         EXPECT_VEC_EQ(expected_fill_strings, fill_strings(u));
-        EXPECT_EQ(GeoMaterialId{0}, u.background);
+        EXPECT_EQ(GeoMatId{0}, u.background);
     }
     {
         auto u = proto.build(tol_, BBox{{-2, -2, -1}, {2, 2, 1}});
@@ -250,7 +250,7 @@ TEST_F(LeafTest, implicit_exterior)
         static char const* const expected_volume_strings[]
             = {"F", "all(+3, -4)"};
         EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
-        EXPECT_EQ(GeoMaterialId{0}, u.background);
+        EXPECT_EQ(GeoMatId{0}, u.background);
     }
 }
 
@@ -350,7 +350,7 @@ TEST_F(MotherTest, explicit_exterior)
         EXPECT_VEC_EQ(expected_trans_strings, transform_strings(u));
         EXPECT_VEC_EQ(expected_fill_strings, fill_strings(u));
         EXPECT_VEC_EQ(expected_volume_nodes, volume_nodes(u));
-        EXPECT_EQ(GeoMaterialId{}, u.background);
+        EXPECT_EQ(GeoMatId{}, u.background);
     }
     {
         auto u = proto.build(tol_, BBox{{-10, -10, -10}, {10, 10, 10}});
@@ -374,7 +374,7 @@ TEST_F(MotherTest, implicit_exterior)
     inp.daughters.push_back(
         {make_daughter("d2"),
          Transformation{make_rotation(Axis::x, Turn{0.25}), {0, -5, 0}}});
-    inp.background.fill = GeoMaterialId{3};
+    inp.background.fill = GeoMatId{3};
 
     UnitProto const proto{std::move(inp)};
 
@@ -388,7 +388,7 @@ TEST_F(MotherTest, implicit_exterior)
 
         EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
         EXPECT_VEC_EQ(expected_volume_nodes, volume_nodes(u));
-        EXPECT_EQ(GeoMaterialId{3}, u.background);
+        EXPECT_EQ(GeoMatId{3}, u.background);
     }
     {
         auto u = proto.build(tol_, BBox{{-10, -10, -10}, {10, 10, 10}});
@@ -529,7 +529,7 @@ TEST_F(InputBuilderTest, bgspheres)
             make_translated(make_sph("top", 2.0), {0, 0, 3}), 1));
         inp.materials.push_back(make_material(
             make_translated(make_sph("bottom", 3.0), {0, 0, -3}), 2));
-        inp.background.fill = GeoMaterialId{3};
+        inp.background.fill = GeoMatId{3};
         return inp;
     }()};
 
@@ -629,7 +629,7 @@ TEST_F(InputBuilderTest, hierarchy)
         inp.daughters.push_back(
             {make_daughter("d2"),
              Transformation{make_rotation(Axis::x, Turn{0.25}), {0, -5, 0}}});
-        inp.background.fill = GeoMaterialId{3};
+        inp.background.fill = GeoMatId{3};
         return inp;
     }());
 


### PR DESCRIPTION
At the very beginning of our project we made the mistake of not differentiating between material definitions and "material cuts couple" IDs, which have EM physics cross sections altered by physics cutoffs. We already defined a geometry material ID (#1288) and this one defines a physics material ID. I don't know if we want to do GeometryMaterialId/GeoMaterialId/GeoMatId; PhysicsMaterialId/PhysMaterialId/PhysMatId; OpticalMaterialId/OptMaterialId/OptMatId or what... so we can revert 5a32f7a52 if the names are too abbreviated (@pcanal )

This in preparation for work on #983 and wanted the big renaming done before 0.6.