### PR TITLE
Fix ROCTX find: hip not cuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,10 +307,6 @@ if(CELERITAS_USE_CUDA)
   endif()
   enable_language(CUDA)
   find_package(CUDAToolkit REQUIRED QUIET)
-  find_library(ROCTX_LIBRARY roctx64)
-  if(ROCTX_LIBRARY)
-    set(CELERITAS_HAVE_ROCTX ON)
-  endif()
 elseif(CELERITAS_USE_HIP)
   enable_language(HIP)
   # NOTE: known broken up to 5.6; unknown after
@@ -320,6 +316,10 @@ elseif(CELERITAS_USE_HIP)
       CELERITAS_DEBUG
       OFF
     )
+  endif()
+  find_library(ROCTX_LIBRARY roctx64)
+  if(ROCTX_LIBRARY)
+    set(CELERITAS_HAVE_ROCTX ON)
   endif()
 endif()
 


### PR DESCRIPTION
In #1694 I accidentally moved the ROCTX find into the wrong `if` block (maybe it was a rebase error?). I caught it due to our regression problems and the fact that we export our build configurations: thank goodness for that.