### PR TITLE
Move types around to fix ROOT error

### DIFF
--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -241,9 +241,6 @@ CELER_CONSTEXPR_FUNCTION bool is_track_valid(TrackStatus status)
 // HELPER FUNCTIONS (HOST)
 //---------------------------------------------------------------------------//
 
-// Get a string corresponding to an interpolation
-char const* to_cstring(Interp);
-
 // Get a string corresponding to a material state
 char const* to_cstring(MatterState);
 

--- a/src/celeritas/inp/Grid.hh
+++ b/src/celeritas/inp/Grid.hh
@@ -10,7 +10,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/cont/EnumArray.hh"
-#include "corecel/grid/SplineDerivCalculator.hh"
+#include "corecel/grid/GridTypes.hh"
 #include "celeritas/Types.hh"
 
 namespace celeritas
@@ -26,7 +26,7 @@ namespace inp
  */
 struct Interpolation
 {
-    using BC = SplineDerivCalculator::BoundaryCondition;
+    using BC = SplineBoundaryCondition;
 
     InterpolationType type{InterpolationType::linear};
     //! Polynomial order for spline interpolation

--- a/src/corecel/Types.cc
+++ b/src/corecel/Types.cc
@@ -24,16 +24,6 @@ char const* to_cstring(MemSpace value)
 
 //---------------------------------------------------------------------------//
 /*!
- * Get a string corresponding to an interpolation.
- */
-char const* to_cstring(Interp value)
-{
-    static EnumStringMapper<Interp> const to_cstring_impl{"linear", "log"};
-    return to_cstring_impl(value);
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Get a string corresponding to a unit system.
  */
 char const* to_cstring(UnitSystem value)

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -79,29 +79,6 @@ enum class UnitSystem
 };
 
 //---------------------------------------------------------------------------//
-//! Interpolation type
-enum class Interp
-{
-    linear,
-    log,
-    size_
-};
-
-//---------------------------------------------------------------------------//
-/*!
- * Which of two bounding points, faces, energies, etc.
- *
- * Here, lo/hi can correspond to left/right, back/front, bottom/top. It's used
- * for the two points in a bounding box.
- */
-enum class Bound : unsigned char
-{
-    lo,
-    hi,
-    size_
-};
-
-//---------------------------------------------------------------------------//
 //!@{
 //! \name Convenience typedefs for params and states.
 
@@ -153,12 +130,6 @@ char const* to_cstring(UnitSystem);
 
 // Get a unit system corresponding to a string
 UnitSystem to_unit_system(std::string const& s);
-
-//! Convert Bound enum value to int
-CELER_CONSTEXPR_FUNCTION int to_int(Bound b)
-{
-    return static_cast<int>(b);
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/grid/GridTypes.hh
+++ b/src/corecel/grid/GridTypes.hh
@@ -1,0 +1,55 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/grid/GridTypes.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Which of two bounding points, faces, energies, etc.
+ *
+ * Here, lo/hi can correspond to left/right, back/front, bottom/top. It's used
+ * for the two points in a bounding box.
+ */
+enum class Bound : unsigned char
+{
+    lo,
+    hi,
+    size_
+};
+
+//---------------------------------------------------------------------------//
+//! Interpolation type
+enum class Interp
+{
+    linear,
+    log,
+    size_
+};
+
+//---------------------------------------------------------------------------//
+//! Cubic spline interpolation boundary conditions
+enum class SplineBoundaryCondition
+{
+    natural = 0,
+    not_a_knot,
+    geant,  //!< Geant4's "not-a-knot"
+    size_
+};
+
+//---------------------------------------------------------------------------//
+// HELPER FUNCTIONS
+//---------------------------------------------------------------------------//
+
+//! Convert Bound enum value to int
+CELER_CONSTEXPR_FUNCTION int to_int(Bound b)
+{
+    return static_cast<int>(b);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/grid/Interpolator.hh
+++ b/src/corecel/grid/Interpolator.hh
@@ -13,6 +13,8 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 
+#include "GridTypes.hh"
+
 #include "detail/InterpolatorTraits.hh"
 
 namespace celeritas

--- a/src/corecel/grid/SplineDerivCalculator.hh
+++ b/src/corecel/grid/SplineDerivCalculator.hh
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Span.hh"
 
+#include "GridTypes.hh"
 #include "UniformGrid.hh"
 
 #include "detail/GridAccessor.hh"
@@ -77,16 +78,8 @@ class SplineDerivCalculator
     using SpanConstReal = detail::GridAccessor::SpanConstReal;
     using Values = detail::GridAccessor::Values;
     using VecReal = std::vector<real_type>;
+    using BoundaryCondition = SplineBoundaryCondition;
     //!@}
-
-    //! Cubic spline interpolation boundary conditions
-    enum class BoundaryCondition
-    {
-        natural = 0,
-        not_a_knot,
-        geant,  //!< Geant4's "not-a-knot"
-        size_
-    };
 
   public:
     // Construct with boundary conditions

--- a/src/corecel/grid/UniformGridData.hh
+++ b/src/corecel/grid/UniformGridData.hh
@@ -11,6 +11,8 @@
 #include "corecel/cont/EnumArray.hh"
 #include "corecel/data/Collection.hh"
 
+#include "GridTypes.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//

--- a/src/corecel/grid/detail/InterpolatorTraits.hh
+++ b/src/corecel/grid/detail/InterpolatorTraits.hh
@@ -9,6 +9,7 @@
 #include <cmath>
 
 #include "corecel/Macros.hh"
+#include "corecel/grid/GridTypes.hh"
 
 namespace celeritas
 {

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -13,6 +13,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
+#include "corecel/grid/GridTypes.hh"
 #include "corecel/math/NumericLimits.hh"
 
 #include "Types.hh"

--- a/test/corecel/random/Histogram.hh
+++ b/test/corecel/random/Histogram.hh
@@ -14,6 +14,7 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/EnumArray.hh"
+#include "corecel/grid/GridTypes.hh"
 
 namespace celeritas
 {


### PR DESCRIPTION
This change keeps ROOT from having to parse as much of the Celeritas implementation. I encountered this error on my mac (which may be due to updating the system without updating ROOT, but the point is that ROOT shouldn't be digging into this code).

```
In file included from input_line_9:3:
In file included from /Users/seth/Code/celeritas/src/celeritas/io/ImportData.hh:11:
In file included from /Users/seth/Code/celeritas/src/celeritas/inp/Grid.hh:13:
In file included from /Users/seth/Code/celeritas/src/corecel/grid/SplineDerivCalculator.hh:17:
In file included from /Users/seth/Code/celeritas/src/corecel/grid/UniformGrid.hh:13:
In file included from /Users/seth/Code/celeritas/src/corecel/grid/UniformGridData.hh:12:
In file included from /Users/seth/Code/celeritas/src/corecel/data/Collection.hh:15:
In file included from /Users/seth/Code/celeritas/src/corecel/data/ObserverPtr.hh:12:
/Users/seth/Code/celeritas/src/corecel/math/Algorithms.hh:763:12: error: use of undeclared identifier '__sincospif'
    return CELER_SINCOS_MANGLED(sincospif)(a, s, c);
           ^
/Users/seth/Code/celeritas/src/corecel/math/Algorithms.hh:720:9: note: expanded from macro 'CELER_SINCOS_MANGLED'
        CELER_CONCAT(CELERITAS_SINCOSPI_PREFIX, FUNC)
        ^
/Users/seth/Code/celeritas/src/corecel/math/Algorithms.hh:718:40: note: expanded from macro 'CELER_CONCAT'
                                       ^
/Users/seth/Code/celeritas/src/corecel/math/Algorithms.hh:717:45: note: expanded from macro 'CELER_CONCAT_IMPL'
                                            ^
<scratch space>:83:1: note: expanded from here
__sincospif
^
```