### PR TITLE
Require covfie v0.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,7 +409,7 @@ if(CELERITAS_USE_ROOT)
 endif()
 
 if(CELERITAS_USE_covfie)
-  celeritas_find_or_builtin_package(covfie)
+  celeritas_find_or_builtin_package(covfie 0.14.0)
 
   if(CELERITAS_USE_HIP AND covfie_VERSION VERSION_LESS "0.13.0")
     celeritas_error_incompatible_option("HIP support in Covfie is not available before 0.13.0"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,13 +410,6 @@ endif()
 
 if(CELERITAS_USE_covfie)
   celeritas_find_or_builtin_package(covfie 0.14.0)
-
-  if(CELERITAS_USE_HIP AND covfie_VERSION VERSION_LESS "0.13.0")
-    celeritas_error_incompatible_option("HIP support in Covfie is not available before 0.13.0"
-      CELERITAS_USE_covfie
-      OFF
-    )
-  endif()
 endif()
 
 if(CELERITAS_USE_VecGeom)

--- a/cmake/CeleritasConfig.cmake.in
+++ b/cmake/CeleritasConfig.cmake.in
@@ -145,8 +145,8 @@ if(CELERITAS_USE_Thrust)
   find_dependency(Thrust REQUIRED)
 endif()
 
-if(CELERITAS_USE_covfie)
-  find_dependency(covfie REQUIRED)
+if(CELERITAS_USE_covfie AND NOT CELERITAS_BUILTIN_covfie)
+  find_dependency(covfie @covfie_VERSION@ REQUIRED)
 endif()
 
 if(CELERITAS_USE_VecGeom)

--- a/cmake/CeleritasConfig.cmake.in
+++ b/cmake/CeleritasConfig.cmake.in
@@ -145,7 +145,7 @@ if(CELERITAS_USE_Thrust)
   find_dependency(Thrust REQUIRED)
 endif()
 
-if(CELERITAS_USE_covfie AND NOT CELERITAS_BUILTIN_covfie)
+if(CELERITAS_USE_covfie)
   find_dependency(covfie @covfie_VERSION@ REQUIRED)
 endif()
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -43,8 +43,8 @@ endif()
 if(CELERITAS_BUILTIN_covfie)
   celer_fetch_external(
     covfie
-    "https://github.com/acts-project/covfie/archive/refs/tags/v0.13.0.tar.gz"
-    e9cd0546c7bc9539f440273bbad303c97215ccd87403cedb4aa387a313938d57
+    "https://github.com/acts-project/covfie/archive/refs/tags/v0.14.0.tar.gz"
+    7a6331526a4870caa980959fdbd67057de0ef4665740ae81251e8310bf386bc6
   )
   set(COVFIE_PLATFORM_CPU ON)
   set(COVFIE_PLATFORM_CUDA ${CELERITAS_USE_CUDA})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,16 +135,16 @@ endif()
 celer_add_ext_library(covfie)
 if(CELERITAS_USE_covfie)
   set(_covfie_libs
-    $<BUILD_INTERFACE:covfie::core>
-    $<BUILD_INTERFACE:covfie::cpu>
+    $<COMPILE_ONLY:covfie::core>
+    $<COMPILE_ONLY:covfie::cpu>
   )
   if(CELERITAS_USE_CUDA)
     # Note that any header file including Covfie must also have CUDA headers
-    list(APPEND _covfie_libs $<BUILD_INTERFACE:covfie::cuda> Celeritas::ExtDeviceApi)
+    list(APPEND _covfie_libs $<COMPILE_ONLY:covfie::cuda> Celeritas::ExtDeviceApi)
   endif()
   if(CELERITAS_USE_HIP)
     # Note that any header file including Covfie must also have HIP headers
-    list(APPEND _covfie_libs $<BUILD_INTERFACE:covfie::hip> Celeritas::ExtDeviceApi)
+    list(APPEND _covfie_libs $<COMPILE_ONLY:covfie::hip> Celeritas::ExtDeviceApi)
   endif()
   target_link_libraries(Extcovfie INTERFACE ${_covfie_libs})
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,14 +141,10 @@ if(CELERITAS_USE_covfie)
   if(CELERITAS_USE_CUDA)
     # Note that any header file including Covfie must also have CUDA headers
     list(APPEND _covfie_libs covfie::cuda Celeritas::ExtDeviceApi)
-    # Needed for <= 0.13, see https://github.com/acts-project/covfie/pull/78
-    target_compile_features(Extcovfie INTERFACE cuda_std_20)
   endif()
   if(CELERITAS_USE_HIP)
     # Note that any header file including Covfie must also have HIP headers
     list(APPEND _covfie_libs covfie::hip Celeritas::ExtDeviceApi)
-    # Needed for <= 0.13, see https://github.com/acts-project/covfie/pull/78
-    target_compile_features(Extcovfie INTERFACE hip_std_20)
   endif()
   target_link_libraries(Extcovfie INTERFACE ${_covfie_libs})
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,16 +135,16 @@ endif()
 celer_add_ext_library(covfie)
 if(CELERITAS_USE_covfie)
   set(_covfie_libs
-    covfie::core
-    covfie::cpu
+    $<BUILD_INTERFACE:covfie::core>
+    $<BUILD_INTERFACE:covfie::cpu>
   )
   if(CELERITAS_USE_CUDA)
     # Note that any header file including Covfie must also have CUDA headers
-    list(APPEND _covfie_libs covfie::cuda Celeritas::ExtDeviceApi)
+    list(APPEND _covfie_libs $<BUILD_INTERFACE:covfie::cuda> Celeritas::ExtDeviceApi)
   endif()
   if(CELERITAS_USE_HIP)
     # Note that any header file including Covfie must also have HIP headers
-    list(APPEND _covfie_libs covfie::hip Celeritas::ExtDeviceApi)
+    list(APPEND _covfie_libs $<BUILD_INTERFACE:covfie::hip> Celeritas::ExtDeviceApi)
   endif()
   target_link_libraries(Extcovfie INTERFACE ${_covfie_libs})
 endif()


### PR DESCRIPTION
Covfie [v0.13](https://github.com/acts-project/covfie/releases/tag/v0.13.0), and [v0.14](https://github.com/acts-project/covfie/releases/tag/v0.14.0) both have many important bug fixes. Since this is an external dependency that will get downloaded if not found, we can require `v0.14.0`.

Once [this](https://github.com/acts-project/covfie/pull/85) is merged, we can move away from using `std::unique_ptr<field>` in the field params data, and instead use field move semantics.