### PR TITLE
Patch covfie shasum

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -44,7 +44,7 @@ if(CELERITAS_BUILTIN_covfie)
   celer_fetch_external(
     covfie
     "https://github.com/acts-project/covfie/archive/refs/tags/v0.14.0.tar.gz"
-    7a6331526a4870caa980959fdbd67057de0ef4665740ae81251e8310bf386bc6
+    b4d8afa712c6fc0e2bc6474367d65fad652864b18d0255c5f2c18fd4c6943993
   )
   set(COVFIE_PLATFORM_CPU ON)
   set(COVFIE_PLATFORM_CUDA ${CELERITAS_USE_CUDA})


### PR DESCRIPTION
The shasum for covfie tarball changed overnight. The current Github [policy](https://github.blog/open-source/git/update-on-the-future-stability-of-source-code-archives-and-hashes/#future-stability-of-archives-and-hashes) should have the hash stable for a year