### PR TITLE
Require a minimum number of volumes to build a BIH tree

### DIFF
--- a/src/orange/detail/BIHBuilder.cc
+++ b/src/orange/detail/BIHBuilder.cc
@@ -19,11 +19,12 @@ namespace detail
 /*!
  * Construct from a Storage object.
  */
-BIHBuilder::BIHBuilder(Storage* storage)
+BIHBuilder::BIHBuilder(Storage* storage, size_type min_bih_size)
     : bboxes_{&storage->bboxes}
     , local_volume_ids_{&storage->local_volume_ids}
     , inner_nodes_{&storage->inner_nodes}
     , leaf_nodes_{&storage->leaf_nodes}
+    , min_bih_size_{min_bih_size}
 {
     CELER_EXPECT(storage);
 }
@@ -40,38 +41,50 @@ BIHBuilder::operator()(VecBBox&& bboxes,
 
     // Store bounding boxes and their corresponding centers
     temp_.bboxes = std::move(bboxes);
-    temp_.centers.resize(temp_.bboxes.size());
-    std::transform(temp_.bboxes.begin(),
-                   temp_.bboxes.end(),
-                   temp_.centers.begin(),
-                   &celeritas::calc_center<fast_real_type>);
+    VecIndices tree_vol_ids;
+    VecIndices non_tree_vol_ids;
 
-    // Separate infinite bounding boxes from finite
-    VecIndices indices;
-    VecIndices inf_vol_ids;
-    for (auto i : range(temp_.bboxes.size()))
+    if (temp_.bboxes.size() < min_bih_size_)
     {
-        LocalVolumeId id(i);
+        for (auto i : range(temp_.bboxes.size()))
+        {
+            LocalVolumeId id(i);
+            non_tree_vol_ids.push_back(id);
+        }
+    }
+    else
+    {
+        temp_.centers.resize(temp_.bboxes.size());
+        std::transform(temp_.bboxes.begin(),
+                       temp_.bboxes.end(),
+                       temp_.centers.begin(),
+                       &celeritas::calc_center<fast_real_type>);
 
-        if (implicit_vol_ids.find(id) != implicit_vol_ids.end())
+        // Separate infinite bounding boxes from finite
+        for (auto i : range(temp_.bboxes.size()))
         {
-            // Background volume, do not include bbox in tree
-        }
-        else if (is_infinite(temp_.bboxes[i]))
-        {
-            // Infinite in *every* direction
-            /*!
-             * \todo make an exception for "EXTERIOR" volume and remove the
-             * "infinite volume" exceptions?
-             */
-            inf_vol_ids.push_back(id);
-        }
-        else
-        {
-            // Prohibit semi-infinite bounding boxes because those break the
-            // cost function
-            CELER_ASSERT(is_finite(temp_.bboxes[i]));
-            indices.push_back(id);
+            LocalVolumeId id(i);
+
+            if (implicit_vol_ids.find(id) != implicit_vol_ids.end())
+            {
+                // Background volume, do not include bbox in tree
+            }
+            else if (is_infinite(temp_.bboxes[i]))
+            {
+                // Infinite in *every* direction
+                /*!
+                 * \todo make an exception for "EXTERIOR" volume and remove the
+                 * "infinite volume" exceptions?
+                 */
+                non_tree_vol_ids.push_back(id);
+            }
+            else
+            {
+                // Prohibit semi-infinite bounding boxes because those break
+                // the cost function
+                CELER_ASSERT(is_finite(temp_.bboxes[i]));
+                tree_vol_ids.push_back(id);
+            }
         }
     }
 
@@ -80,14 +93,14 @@ BIHBuilder::operator()(VecBBox&& bboxes,
     tree.bboxes = ItemMap<LocalVolumeId, FastBBoxId>(
         bboxes_.insert_back(temp_.bboxes.begin(), temp_.bboxes.end()));
 
-    tree.inf_vol_ids = local_volume_ids_.insert_back(inf_vol_ids.begin(),
-                                                     inf_vol_ids.end());
+    tree.non_tree_vol_ids = local_volume_ids_.insert_back(
+        non_tree_vol_ids.begin(), non_tree_vol_ids.end());
 
-    if (!indices.empty())
+    if (!tree_vol_ids.empty())
     {
         VecNodes nodes;
-        auto inf_bbox = FastBBox::from_infinite();
-        this->construct_tree(indices, &nodes, BIHNodeId{}, inf_bbox);
+        auto non_tree_bbox = FastBBox::from_infinite();
+        this->construct_tree(tree_vol_ids, &nodes, BIHNodeId{}, non_tree_bbox);
         auto [inner_nodes, leaf_nodes] = this->arrange_nodes(std::move(nodes));
 
         tree.inner_nodes
@@ -98,7 +111,7 @@ BIHBuilder::operator()(VecBBox&& bboxes,
     }
     else
     {
-        // Degenerate case where all bounding boxes are infinite. Create a
+        // Degenerate case where we only have non_tree_vols. Create a
         // single empty leaf node, so that the existence of leaf nodes does not
         // need to be checked at runtime.
         BIHLeafNode const empty_nodes[] = {{}};

--- a/src/orange/detail/BIHBuilder.hh
+++ b/src/orange/detail/BIHBuilder.hh
@@ -22,24 +22,31 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
-/*!
- * Create a bounding interval hierarchy from supplied bounding boxes.
+/*!  Create a bounding interval hierarchy from supplied bounding boxes.
  *
- * This implementation matches the structure proposed in the original
- * paper \citep{wachter-bih-2006, https://doi.org/10.2312/EGWR/EGSR06/139-149}.
+ * This implementation matches the structure proposed in the original paper
+ * \citep{wachter-bih-2006, https://doi.org/10.2312/EGWR/EGSR06/139-149}.
  * Partitioning is done on the basis of bounding box centers using the "longest
- * dimension" heuristic. All leaf nodes contain either a single volume id, or
- * multiple volume ids if the volumes have bounding boxes that share the same
- * center. A tree may consist of a single leaf node if the tree contains only 1
- * volume, or multiple non-partitionable volumes. In the event that all
- * bounding boxes are infinite, the tree will consist of a single empty leaf
- * node with all volumes in the stored inf_vols. This final case is useful in
- * the event that an ORANGE geometry is created via a method where volume
- * bounding boxes are not availible.
+ * dimension" heuristic. Bounding boxes are assumed to correspond to local
+ * volumes. A BIH tree is only built if the number of bounding boxes is greater
+ * than or equal to the min_bih_size_ parameter. The idea behind this parameter
+ * is that if the number of volumes in a universe is small, it is more
+ * efficient to perform a linear search over volumes rather than using a BIH.
+ *
+ * After partitioning, all volumes that are not background volumes will be
+ * stored in either leaf nodes or as non-tree volumes. All leaf nodes contain
+ * either a single volume, or multiple volumes if the volumes have bounding
+ * boxes that share the same center. Volumes with infinite bounding boxes are
+ * stored as non-tree volumes. In the event that only a single bounding box is
+ * supplied, or all supplied bounding boxes are non-partitionable, the tree
+ * will consist of a single leaf node. In the event  that all volumes have
+ * infinite bounding boxes, or the number of volumes is less than the
+ * min_bih_vols parameter, the tree will consist of a single *empty* leaf with
+ * all volumes stored as non-tree volumes.
  *
  * Bounding boxes supplied to this builder should "bumped," i.e. expanded
- * outward by at least floating-point epsilson from the volumes they bound.
- * This eliminates the possiblity of accidently missing a volume during
+ * outward by at least floating-point epsilon from the volumes they bound.
+ * This eliminates the possibility of accidentally missing a volume during
  * tracking.
  */
 class BIHBuilder
@@ -54,7 +61,7 @@ class BIHBuilder
 
   public:
     // Construct from a Storage object
-    explicit BIHBuilder(Storage* storage);
+    explicit BIHBuilder(Storage* storage, size_type min_bih_size = 0);
 
     // Create BIH Nodes
     BIHTree operator()(VecBBox&& bboxes, SetLocalVolId const& implicit_vol_ids);
@@ -83,6 +90,7 @@ class BIHBuilder
     CollectionBuilder<LocalVolumeId> local_volume_ids_;
     CollectionBuilder<BIHInnerNode> inner_nodes_;
     CollectionBuilder<BIHLeafNode> leaf_nodes_;
+    size_type min_bih_size_;
 
     //// HELPER FUNCTIONS ////
 

--- a/src/orange/detail/BIHData.hh
+++ b/src/orange/detail/BIHData.hh
@@ -77,11 +77,10 @@ struct BIHLeafNode
 
 //---------------------------------------------------------------------------//
 /*!
- * Bounding Interval Hierarchy tree.
+ * Bounding Interval Hierarchy tree record.
  *
- * Infinite bounding boxes are not included in the main tree.
- *
- * \todo Rename BihTreeRecord
+ * Provides storage for inner nodes, leaf nodes, and volumes not part of the
+ * tree for a single universe.
  */
 struct BIHTree
 {
@@ -94,8 +93,8 @@ struct BIHTree
     //! Leaf nodes
     ItemRange<BIHLeafNode> leaf_nodes;
 
-    //! Local volumes that have infinite bounding boxes
-    ItemRange<LocalVolumeId> inf_vol_ids;
+    //! Local volumes that are not part of the tree itself
+    ItemRange<LocalVolumeId> non_tree_vol_ids;
 
     explicit CELER_FUNCTION operator bool() const
     {
@@ -109,7 +108,8 @@ struct BIHTree
             // contains either:
             // a) a single volume
             // b) muliple non-partitionable volumes,
-            // b) only infinite volumes.
+            // c) only infinite volumes.
+            // d) not enough volumes to meet BIHBuilder::min_bih_vols
             return !bboxes.empty() && leaf_nodes.size() == 1;
         }
     }

--- a/src/orange/detail/BIHEnclosingVolFinder.hh
+++ b/src/orange/detail/BIHEnclosingVolFinder.hh
@@ -66,9 +66,9 @@ class BIHEnclosingVolFinder
                                                    Real3 const& pos,
                                                    F&& is_inside) const;
 
-    // Determine if any inf_vols contain the point
+    // Determine if any non_tree_vols contain the point
     template<class F>
-    inline CELER_FUNCTION LocalVolumeId visit_inf_vols(F&& is_inside) const;
+    inline CELER_FUNCTION LocalVolumeId visit_non_tree_vols(F&& is_inside) const;
 
     // Determine if a single bbox contains the point
     inline CELER_FUNCTION bool
@@ -119,7 +119,7 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside) const
 
     } while (current_node);
 
-    return this->visit_inf_vols(is_inside);
+    return this->visit_non_tree_vols(is_inside);
 }
 
 //---------------------------------------------------------------------------//
@@ -220,13 +220,13 @@ CELER_FUNCTION LocalVolumeId BIHEnclosingVolFinder::visit_leaf(
 
 //---------------------------------------------------------------------------//
 /*!
- * Determine if any volumes in inf_vols contain the point.
+ * Determine if any volumes in non_tree_vols contain the point.
  */
 template<class F>
 CELER_FUNCTION LocalVolumeId
-BIHEnclosingVolFinder::visit_inf_vols(F&& is_inside) const
+BIHEnclosingVolFinder::visit_non_tree_vols(F&& is_inside) const
 {
-    for (auto id : view_.inf_vol_ids())
+    for (auto id : view_.non_tree_vol_ids())
     {
         if (is_inside(id))
         {

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -92,10 +92,11 @@ class BIHIntersectingVolFinder
                                                   Intersection intersection,
                                                   F&& visit_vol) const;
 
-    // Calculate the current min intersection, which may/may not be in inf_vols
+    // Calculate the current min intersection, which may/may not be in
+    // non_tree_vols
     template<class F>
-    inline CELER_FUNCTION Intersection visit_inf_vols(Intersection intersection,
-                                                      F&& visit_vol) const;
+    inline CELER_FUNCTION Intersection
+    visit_non_tree_vols(Intersection intersection, F&& visit_vol) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -151,7 +152,7 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
 
     } while (current_node);
 
-    return this->visit_inf_vols(intersection, visit_vol);
+    return this->visit_non_tree_vols(intersection, visit_vol);
 }
 
 //---------------------------------------------------------------------------//
@@ -267,14 +268,16 @@ BIHIntersectingVolFinder::visit_leaf(BIHLeafNode const& leaf_node,
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate the current min intersection, which may/may not be in inf_vols.
+ * Calculate the current min intersection, which may/may not be in
+ * non_tree_vols.
  */
 template<class F>
 CELER_FUNCTION auto
-BIHIntersectingVolFinder::visit_inf_vols(Intersection min_intersection,
-                                         F&& visit_vol) const -> Intersection
+BIHIntersectingVolFinder::visit_non_tree_vols(Intersection min_intersection,
+                                              F&& visit_vol) const
+    -> Intersection
 {
-    for (auto id : view_.inf_vol_ids())
+    for (auto id : view_.non_tree_vol_ids())
     {
         auto intersection = visit_vol(id, min_intersection.distance);
         if (intersection && intersection.distance < min_intersection.distance)

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -45,8 +45,8 @@ class BIHView
     inline CELER_FUNCTION Span<LocalVolumeId const>
     leaf_vol_ids(BIHLeafNode const& leaf) const;
 
-    // Get the inf_vol_ids
-    inline CELER_FUNCTION Span<LocalVolumeId const> inf_vol_ids() const;
+    // Get the non_tree_vol_ids
+    inline CELER_FUNCTION Span<LocalVolumeId const> non_tree_vol_ids() const;
 
   private:
     //// DATA ////
@@ -122,11 +122,11 @@ BIHView::leaf_vol_ids(BIHLeafNode const& leaf) const
 
 //---------------------------------------------------------------------------//
 /*!
- *  Get the inf_vol_ids.
+ *  Get the non_tree_vol_ids.
  */
-CELER_FUNCTION Span<LocalVolumeId const> BIHView::inf_vol_ids() const
+CELER_FUNCTION Span<LocalVolumeId const> BIHView::non_tree_vol_ids() const
 {
-    return storage_.local_volume_ids[tree_.inf_vol_ids];
+    return storage_.local_volume_ids[tree_.non_tree_vol_ids];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -239,7 +239,7 @@ ForceMax const& forced_scalar_max()
  */
 UnitInserter::UnitInserter(UniverseInserter* insert_universe, Data* orange_data)
     : orange_data_(orange_data)
-    , build_bih_tree_{&orange_data_->bih_tree_data}
+    , build_bih_tree_{&orange_data_->bih_tree_data, 20}
     , insert_transform_{&orange_data_->transforms, &orange_data_->reals}
     , build_surfaces_{&orange_data_->surface_types,
                       &orange_data_->real_ids,

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -559,6 +559,29 @@ TEST_F(BIHBuilderTest, TEST_IF_CELERITAS_DEBUG(semi_finite_volumes))
     EXPECT_THROW(build(std::move(bboxes_), implicit_vol_ids_), DebugError);
 }
 
+TEST_F(BIHBuilderTest, min_bih_size_not_met)
+{
+    // Supply two bounding boxes with a minimum tree size of 3
+    bboxes_.push_back({{0.5, 0.5, 0.5}, {1.5, 1.5, 1.5}});
+    bboxes_.push_back({{1.5, 1.5, 1.5}, {2.5, 2.5, 2.5}});
+
+    BIHBuilder build(&storage_, 3);
+    auto bih_tree = build(std::move(bboxes_), implicit_vol_ids_);
+
+    ASSERT_EQ(2, bih_tree.non_tree_vol_ids.size());
+    ASSERT_EQ(0, bih_tree.inner_nodes.size());
+    ASSERT_EQ(1, bih_tree.leaf_nodes.size());
+
+    auto node = storage_.leaf_nodes[bih_tree.leaf_nodes[0]];
+    ASSERT_EQ(BIHNodeId{}, node.parent);
+    EXPECT_EQ(0, node.vol_ids.size());
+
+    EXPECT_EQ(LocalVolumeId{0},
+              storage_.local_volume_ids[bih_tree.non_tree_vol_ids[0]]);
+    EXPECT_EQ(LocalVolumeId{1},
+              storage_.local_volume_ids[bih_tree.non_tree_vol_ids[1]]);
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace detail

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -86,9 +86,9 @@ TEST_F(BIHBuilderTest, basic)
     BIHBuilder build(&storage_);
     auto bih_tree = build(std::move(bboxes_), implicit_vol_ids_);
 
-    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
+    ASSERT_EQ(1, bih_tree.non_tree_vol_ids.size());
     EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
+              storage_.local_volume_ids[bih_tree.non_tree_vol_ids[0]]);
 
     // Test bounding box storage
     auto bbox1 = storage_.bboxes[bih_tree.bboxes[LocalVolumeId{2}]];
@@ -274,9 +274,9 @@ TEST_F(BIHBuilderTest, grid)
 
     BIHBuilder build(&storage_);
     auto bih_tree = build(std::move(bboxes_), implicit_vol_ids_);
-    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
+    ASSERT_EQ(1, bih_tree.non_tree_vol_ids.size());
     EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
+              storage_.local_volume_ids[bih_tree.non_tree_vol_ids[0]]);
 
     // Test nodes
     auto inner_nodes = bih_tree.inner_nodes;
@@ -483,7 +483,7 @@ TEST_F(BIHBuilderTest, single_finite_volume)
     BIHBuilder build(&storage_);
     auto bih_tree = build(std::move(bboxes_), implicit_vol_ids_);
 
-    ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
+    ASSERT_EQ(0, bih_tree.non_tree_vol_ids.size());
     ASSERT_EQ(0, bih_tree.inner_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
 
@@ -501,7 +501,7 @@ TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
     BIHBuilder build(&storage_);
     auto bih_tree = build(std::move(bboxes_), implicit_vol_ids_);
 
-    ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
+    ASSERT_EQ(0, bih_tree.non_tree_vol_ids.size());
     ASSERT_EQ(0, bih_tree.inner_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
 
@@ -521,10 +521,10 @@ TEST_F(BIHBuilderTest, single_infinite_volume)
 
     ASSERT_EQ(0, bih_tree.inner_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
-    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
+    ASSERT_EQ(1, bih_tree.non_tree_vol_ids.size());
 
     EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
+              storage_.local_volume_ids[bih_tree.non_tree_vol_ids[0]]);
 }
 
 TEST_F(BIHBuilderTest, multiple_infinite_volumes)
@@ -537,12 +537,12 @@ TEST_F(BIHBuilderTest, multiple_infinite_volumes)
 
     ASSERT_EQ(0, bih_tree.inner_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
-    ASSERT_EQ(2, bih_tree.inf_vol_ids.size());
+    ASSERT_EQ(2, bih_tree.non_tree_vol_ids.size());
 
     EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
+              storage_.local_volume_ids[bih_tree.non_tree_vol_ids[0]]);
     EXPECT_EQ(LocalVolumeId{1},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[1]]);
+              storage_.local_volume_ids[bih_tree.non_tree_vol_ids[1]]);
 }
 
 TEST_F(BIHBuilderTest, TEST_IF_CELERITAS_DEBUG(semi_finite_volumes))


### PR DESCRIPTION
Analysis of the tilecal problem confirmed that the BIH is causing a 3x slowdown. Profiling revealed that this is due to increased branching (fewer active threads per warp) which leads to worse memory performance. The tilecal problem itself has a few universes with more than 100 volumes, but many more with fewer than 20. This MR adds a `bih_min_size` parameter that causes the BIH to only be built for universes with a sufficiently large number of volumes. If a universe has too few volumes, all volumes will be placed into "non-tree volumes," which was previously reserved for volumes with infinite bounding boxes. This results in the following performance on Wildstyle:

| Commit                              | Tilecal runtime on V100 (s) |
| -------------------------| ----------------------------|
| before BIH was merged: 09cbf5ba999 | 49.5                |
| after BIH was merged:    acf500714c27 | 146                 |
| develop:                           a4c469f7d42f | 146                 |
| this MR:                            c37d4d376c3 | 64.6                |

Likewise, this MR provides an 88% increase in active threads per warp w.r.t. `develop`, as well as the following improved memory behavior (also w.r.t. `develop`):

![Screenshot 2025-05-08 at 6 07 53 PM](https://github.com/user-attachments/assets/490e8db3-e04f-4b14-82b7-d0b093024fb0)

This MR is a draft for two reasons:

1) `bih_min_size` is a tuning parameter. We need to come up with a better system for incorporating these in the code.
2) It is not clear what to tune this parameter to. Obviously a single test on a V100 is not sufficient. Would the entire suite on an MI250X be sufficient? Can we define and overall FOM for the suite, in the event that performance gains for one problem are accompanied by performance losses in another?

Once we resolve these issues I will update this MR accordingly.