### PR TITLE
Fix and refactor maximum cross section energy calculation for integral approach

### DIFF
--- a/scripts/cmake-presets/jlse.json
+++ b/scripts/cmake-presets/jlse.json
@@ -77,6 +77,15 @@
       }
     },
     {
+      "name": "clhep",
+      "displayName": "Build with debug assertions and clhep units",
+      "inherits": [".base", "reldeb"],
+      "binaryDir": "${sourceDir}/build-clhep",
+      "cacheVariables": {
+        "CELERITAS_UNITS": "CLHEP"
+      }
+    },
+    {
       "name": "float",
       "displayName": "Build with single precision and disable VecGeom",
       "inherits": ["reldeb-orange"],
@@ -98,6 +107,7 @@
     {"name": "debug", "configurePreset": "debug", "inherits": "base"},
     {"name": "release-orange", "configurePreset": "release-orange", "inherits": "base"},
     {"name": "reldeb-orange", "configurePreset": "reldeb-orange", "inherits": "base"},
+    {"name": "clhep", "configurePreset": "clhep", "inherits": "base"},
     {"name": "float", "configurePreset": "float", "inherits": "base"}
   ],
   "testPresets": [
@@ -112,6 +122,7 @@
     {"name": "debug", "configurePreset": "debug", "inherits": "base"},
     {"name": "release-orange", "configurePreset": "release-orange", "inherits": "base"},
     {"name": "reldeb-orange", "configurePreset": "reldeb-orange", "inherits": "base"},
+    {"name": "clhep", "configurePreset": "clhep", "inherits": "base"},
     {"name": "float", "configurePreset": "float", "inherits": "base"}
   ]
 }

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -117,6 +117,7 @@ list(APPEND SOURCES
   optical/detail/OffloadParams.cc
   optical/detail/OpticalLaunchAction.cc
   phys/CutoffParams.cc
+  phys/detail/EnergyMaxXsCalculator.cc
   phys/ImportedModelAdapter.cc
   phys/ImportedProcessAdapter.cc
   phys/ParticleParams.cc

--- a/src/celeritas/phys/PhysicsOptions.hh
+++ b/src/celeritas/phys/PhysicsOptions.hh
@@ -1,0 +1,146 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/phys/PhysicsOptions.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Types.hh"
+#include "celeritas/Quantities.hh"
+#include "celeritas/Types.hh"
+#include "celeritas/Units.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Particle-dependent physics configuration options.
+ *
+ * These parameters have different values for light particles
+ * (electrons/positrons) and heavy particles (muons/hadrons).
+ *
+ * Input options are:
+ * - \c min_range: below this value, there is no extra transformation from
+ *   particle range to step length.
+ * - \c max_step_over_range: at higher energy (longer range), gradually
+ *   decrease the maximum step length until it's this fraction of the tabulated
+ *   range.
+ * - \c lowest_energy: tracking cutoff kinetic energy.
+ * - \c displaced: whether MSC lateral displacement is enabled for e-/e+
+ * - \c range_factor: used in the MSC step limitation algorithm to restrict the
+ *   step size to \f$ f_r \cdot max(r, \lambda) \f$ at the start of a track or
+ *   after entering a volume, where \f$ f_r \f$ is the range factor, \f$ r \f$
+ *   is the range, and \f$ \lambda \f$ is the mean free path.
+ * - \c step_limit_algorithm: algorithm used to determine the MSC step limit.
+ *
+ * NOTE: min_range/max_step_over_range are not accessible through Geant4, and
+ * they can also be set to be different for electrons, mu/hadrons, and ions
+ * (they are set in Geant4 with \c G4EmParameters::SetStepFunction()).
+ */
+struct ParticleOptions
+{
+    using Energy = units::MevEnergy;
+
+    //!@{
+    //! \name Range calculation
+    real_type min_range;
+    real_type max_step_over_range;
+    //!@}
+
+    //!@{
+    //! \name Energy loss
+    Energy lowest_energy;
+    //!@}
+
+    //!@{
+    //! \name Multiple scattering
+    bool displaced;
+    real_type range_factor;
+    MscStepLimitAlgorithm step_limit_algorithm;
+    //!@}
+
+    //! Default options for light particles (electrons/positrons)
+    static ParticleOptions default_light()
+    {
+        ParticleOptions opts;
+        opts.min_range = real_type{1} * units::millimeter;
+        opts.max_step_over_range = 0.2;
+        opts.lowest_energy = ParticleOptions::Energy{0.001};
+        opts.displaced = true;
+        opts.range_factor = 0.04;
+        opts.step_limit_algorithm = MscStepLimitAlgorithm::safety;
+        return opts;
+    };
+
+    //! Default options for heavy particles (muons/hadrons)
+    static ParticleOptions default_heavy()
+    {
+        ParticleOptions opts;
+        opts.min_range = 0.1 * units::millimeter;
+        opts.max_step_over_range = 0.2;
+        opts.lowest_energy = ParticleOptions::Energy{0.001};
+        opts.displaced = false;
+        opts.range_factor = 0.2;
+        opts.step_limit_algorithm = MscStepLimitAlgorithm::minimal;
+        return opts;
+    };
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Physics configuration options.
+ *
+ * Input options are:
+ * - \c fixed_step_limiter: if nonzero, prevent any tracks from taking a step
+ *   longer than this length.
+ * - \c min_eprime_over_e: energy scaling fraction used to estimate the maximum
+ *   cross section over the step in the integral approach for energy loss
+ *   processes.
+ * - \c linear_loss_limit: if the mean energy loss along a step is greater than
+ *   this fractional value of the pre-step kinetic energy, recalculate the
+ *   energy loss.
+ * - \c lambda_limit: limit on the MSC mean free path.
+ * - \c safety_factor: used in the MSC step limitation algorithm to restrict
+ *   the step size to \f$ f_s s \f$, where \f$ f_s \f$ is the safety factor and
+ *   \f$  s \f$ is the safety distance.
+ * - \c secondary_stack_factor: the number of secondary slots per track slot
+ *   allocated.
+ * - \c disable_integral_xs: for particles with energy loss processes, the
+ *   particle energy changes over the step, so the assumption that the cross
+ *   section is constant is no longer valid. By default, many charged particle
+ *   processes use MC integration to sample the discrete interaction length
+ *   with the correct probability. Disable this integral approach for all
+ *   processes.
+ */
+struct PhysicsOptions
+{
+    //!@{
+    //! \name Range calculation
+    real_type fixed_step_limiter{0};
+    //!@}
+
+    //!@{
+    //! \name Energy loss
+    real_type min_eprime_over_e{0.8};
+    real_type linear_loss_limit{0.01};
+    //!@}
+
+    //!@{
+    //! \name Multiple scattering
+    real_type lambda_limit{real_type{1} * units::millimeter};
+    real_type safety_factor{0.6};
+    //!@}
+
+    //!@{
+    //! \name Particle-dependent parameters
+    ParticleOptions light{ParticleOptions::default_light()};
+    ParticleOptions heavy{ParticleOptions::default_heavy()};
+    //!@}
+
+    real_type secondary_stack_factor{3};
+    bool disable_integral_xs{false};
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -53,16 +53,13 @@
 #include "Process.hh"
 
 #include "detail/DiscreteSelectAction.hh"
+#include "detail/EnergyMaxXsCalculator.hh"
 #include "detail/PreStepAction.hh"
 
 namespace celeritas
 {
 namespace
 {
-//---------------------------------------------------------------------------//
-using Values
-    = Collection<real_type, Ownership::const_reference, MemSpace::native>;
-
 //---------------------------------------------------------------------------//
 class ImplicitPhysicsAction final : public StaticConcreteAction
 {
@@ -76,47 +73,6 @@ class ImplicitPhysicsAction final : public StaticConcreteAction
 bool is_fake_particle(PDGNumber pdg)
 {
     return pdg.get() >= 81 && pdg.get() <= 100;
-}
-
-//---------------------------------------------------------------------------//
-//! Calculate the energy of the maximum cross section.
-real_type calc_energy_max_xs(UniformGridRecord const& data, Values const& reals)
-{
-    UniformGrid loge_grid(data.grid);
-    UniformLogGridCalculator calc_xs(data, reals);
-
-    real_type xs_max = 0;
-    real_type result = 0;
-    for (auto i : range(loge_grid.size()))
-    {
-        real_type xs = calc_xs[i];
-        if (xs > xs_max)
-        {
-            xs_max = xs;
-            result = std::exp(loge_grid[i]);
-        }
-    }
-    CELER_ENSURE(result > 0);
-    return result;
-}
-
-//---------------------------------------------------------------------------//
-//! Calculate the energy of the maximum cross section.
-real_type calc_energy_max_xs(XsGridRecord const& data, Values const& reals)
-{
-    CELER_EXPECT(data);
-
-    real_type result{0};
-    if (data.lower)
-    {
-        result = calc_energy_max_xs(data.lower, reals);
-    }
-    if (data.upper)
-    {
-        result = max(result, calc_energy_max_xs(data.upper, reals));
-    }
-    CELER_ENSURE(result > 0);
-    return result;
 }
 
 //---------------------------------------------------------------------------//
@@ -562,10 +518,9 @@ void PhysicsParams::build_tables(Options const& opts,
             std::vector<ValueGridId> inv_range_ids;
 
             // Energy of maximum cross section for each material
+            detail::EnergyMaxXsCalculator calc_integral_xs(opts, proc);
             std::vector<real_type> energy_max_xs;
-            bool use_integral_xs = !opts.disable_integral_xs
-                                   && proc.supports_integral_xs();
-            if (use_integral_xs)
+            if (calc_integral_xs)
             {
                 energy_max_xs.resize(mats.size());
             }
@@ -626,24 +581,11 @@ void PhysicsParams::build_tables(Options const& opts,
                     }
                 }
 
-                if (use_integral_xs)
+                if (calc_integral_xs)
                 {
                     // Find and store the energy of the largest cross section
                     // for this material if the integral approach is used
-
-                    if (process_ids[pp_idx]
-                        == data->hardwired.positron_annihilation)
-                    {
-                        // Annihilation cross section is maximum at zero and
-                        // decreases with increasing energy
-                        energy_max_xs[mat_idx] = 0;
-                    }
-                    else if (auto grid_id = macro_xs_ids[mat_idx])
-                    {
-                        energy_max_xs[mat_idx]
-                            = calc_energy_max_xs(data->value_grids[grid_id],
-                                                 make_const_ref(*data).reals);
-                    }
+                    energy_max_xs[mat_idx] = calc_integral_xs(macro_xs);
                 }
             }
 
@@ -684,11 +626,8 @@ void PhysicsParams::build_tables(Options const& opts,
             }
 
             // Store the energies of the maximum cross sections
-            if (!energy_max_xs.empty())
-            {
-                temp_integral_xs[pp_idx].energy_max_xs = reals.insert_back(
-                    energy_max_xs.begin(), energy_max_xs.end());
-            }
+            temp_integral_xs[pp_idx].energy_max_xs = reals.insert_back(
+                energy_max_xs.begin(), energy_max_xs.end());
         }
         // Construct energy loss process data
         process_group.integral_xs = integral_xs.insert_back(

--- a/src/celeritas/phys/PhysicsParams.hh
+++ b/src/celeritas/phys/PhysicsParams.hh
@@ -24,6 +24,7 @@
 
 #include "Model.hh"
 #include "PhysicsData.hh"
+#include "PhysicsOptions.hh"
 #include "Process.hh"
 
 namespace celeritas
@@ -32,135 +33,6 @@ class ActionRegistry;
 class AtomicRelaxationParams;
 class MaterialParams;
 class ParticleParams;
-
-//---------------------------------------------------------------------------//
-/*!
- * Particle-dependent physics configuration options.
- *
- * These parameters have different values for light particles
- * (electrons/positrons) and heavy particles (muons/hadrons).
- *
- * Input options are:
- * - \c min_range: below this value, there is no extra transformation from
- *   particle range to step length.
- * - \c max_step_over_range: at higher energy (longer range), gradually
- *   decrease the maximum step length until it's this fraction of the tabulated
- *   range.
- * - \c lowest_energy: tracking cutoff kinetic energy.
- * - \c displaced: whether MSC lateral displacement is enabled for e-/e+
- * - \c range_factor: used in the MSC step limitation algorithm to restrict the
- *   step size to \f$ f_r \cdot max(r, \lambda) \f$ at the start of a track or
- *   after entering a volume, where \f$ f_r \f$ is the range factor, \f$ r \f$
- *   is the range, and \f$ \lambda \f$ is the mean free path.
- * - \c step_limit_algorithm: algorithm used to determine the MSC step limit.
- *
- * NOTE: min_range/max_step_over_range are not accessible through Geant4, and
- * they can also be set to be different for electrons, mu/hadrons, and ions
- * (they are set in Geant4 with \c G4EmParameters::SetStepFunction()).
- */
-struct ParticleOptions
-{
-    using Energy = units::MevEnergy;
-
-    //!@{
-    //! \name Range calculation
-    real_type min_range;
-    real_type max_step_over_range;
-    //!@}
-
-    //!@{
-    //! \name Energy loss
-    Energy lowest_energy;
-    //!@}
-
-    //!@{
-    //! \name Multiple scattering
-    bool displaced;
-    real_type range_factor;
-    MscStepLimitAlgorithm step_limit_algorithm;
-    //!@}
-
-    //! Default options for light particles (electrons/positrons)
-    static ParticleOptions default_light()
-    {
-        ParticleOptions opts;
-        opts.min_range = real_type{1} * units::millimeter;
-        opts.max_step_over_range = 0.2;
-        opts.lowest_energy = ParticleOptions::Energy{0.001};
-        opts.displaced = true;
-        opts.range_factor = 0.04;
-        opts.step_limit_algorithm = MscStepLimitAlgorithm::safety;
-        return opts;
-    };
-
-    //! Default options for heavy particles (muons/hadrons)
-    static ParticleOptions default_heavy()
-    {
-        ParticleOptions opts;
-        opts.min_range = 0.1 * units::millimeter;
-        opts.max_step_over_range = 0.2;
-        opts.lowest_energy = ParticleOptions::Energy{0.001};
-        opts.displaced = false;
-        opts.range_factor = 0.2;
-        opts.step_limit_algorithm = MscStepLimitAlgorithm::minimal;
-        return opts;
-    };
-};
-
-//---------------------------------------------------------------------------//
-/*!
- * Physics configuration options.
- *
- * Input options are:
- * - \c fixed_step_limiter: if nonzero, prevent any tracks from taking a step
- *   longer than this length.
- * - \c min_eprime_over_e: energy scaling fraction used to estimate the maximum
- *   cross section over the step in the integral approach for energy loss
- *   processes.
- * - \c linear_loss_limit: if the mean energy loss along a step is greater than
- *   this fractional value of the pre-step kinetic energy, recalculate the
- *   energy loss.
- * - \c lambda_limit: limit on the MSC mean free path.
- * - \c safety_factor: used in the MSC step limitation algorithm to restrict
- *   the step size to \f$ f_s s \f$, where \f$ f_s \f$ is the safety factor and
- *   \f$  s \f$ is the safety distance.
- * - \c secondary_stack_factor: the number of secondary slots per track slot
- *   allocated.
- * - \c disable_integral_xs: for particles with energy loss processes, the
- *   particle energy changes over the step, so the assumption that the cross
- *   section is constant is no longer valid. By default, many charged particle
- *   processes use MC integration to sample the discrete interaction length
- *   with the correct probability. Disable this integral approach for all
- *   processes.
- */
-struct PhysicsParamsOptions
-{
-    //!@{
-    //! \name Range calculation
-    real_type fixed_step_limiter{0};
-    //!@}
-
-    //!@{
-    //! \name Energy loss
-    real_type min_eprime_over_e{0.8};
-    real_type linear_loss_limit{0.01};
-    //!@}
-
-    //!@{
-    //! \name Multiple scattering
-    real_type lambda_limit{real_type{1} * units::millimeter};
-    real_type safety_factor{0.6};
-    //!@}
-
-    //!@{
-    //! \name Particle-dependent parameters
-    ParticleOptions light{ParticleOptions::default_light()};
-    ParticleOptions heavy{ParticleOptions::default_heavy()};
-    //!@}
-
-    real_type secondary_stack_factor{3};
-    bool disable_integral_xs{false};
-};
 
 //---------------------------------------------------------------------------//
 /*!
@@ -197,7 +69,7 @@ class PhysicsParams final : public ParamsDataInterface<PhysicsParamsData>
     using VecProcess = std::vector<SPConstProcess>;
     using SpanConstProcessId = Span<ProcessId const>;
     using ActionIdRange = Range<ActionId>;
-    using Options = PhysicsParamsOptions;
+    using Options = PhysicsOptions;
     //!@}
 
     //! Physics parameter construction arguments

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -251,8 +251,6 @@ calc_mean_energy_loss(ParticleTrackView const& particle,
         // approximation is probably wrong. Use the definition of the range as
         // the integral of 1/loss to back-calculate the actual energy loss
         // along the curve given the actual step.
-        auto grid_id = physics.range_grid();
-        CELER_ASSERT(grid_id);
 
         // Use the range limit stored from calc_physics_step_limit
         real_type range = physics.dedx_range();

--- a/src/celeritas/phys/detail/EnergyMaxXsCalculator.cc
+++ b/src/celeritas/phys/detail/EnergyMaxXsCalculator.cc
@@ -1,0 +1,80 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/phys/detail/EnergyMaxXsCalculator.cc
+//---------------------------------------------------------------------------//
+#include "EnergyMaxXsCalculator.hh"
+
+#include <algorithm>
+#include <cmath>
+
+#include "corecel/grid/UniformGrid.hh"
+#include "corecel/math/SoftEqual.hh"
+#include "celeritas/em/process/EPlusAnnihilationProcess.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with physics options and process.
+ */
+EnergyMaxXsCalculator::EnergyMaxXsCalculator(PhysicsOptions const& opts,
+                                             Process const& proc)
+    : use_integral_xs_(!opts.disable_integral_xs && proc.supports_integral_xs())
+    , is_annihilation_(dynamic_cast<EPlusAnnihilationProcess const*>(&proc))
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the energy of the maximum cross section.
+ *
+ * The annihilation process calculates cross sections on the fly so does not
+ * have a macroscopic cross section grid: its cross section is maximum at zero
+ * and decreases with increasing energy.
+ */
+real_type EnergyMaxXsCalculator::operator()(inp::XsGrid const& macro_xs) const
+{
+    CELER_EXPECT(use_integral_xs_);
+    CELER_EXPECT(macro_xs || is_annihilation_);
+
+    real_type result = 0;
+    real_type max_xs = 0;
+    if (auto const& grid = macro_xs.lower)
+    {
+        // Find the index of the maximum cross section
+        size_type max_el = std::distance(
+            grid.y.begin(), std::max_element(grid.y.begin(), grid.y.end()));
+
+        // Get the energy and cross section value at that index
+        auto loge_data = UniformGridData::from_bounds(grid.x, grid.y.size());
+        result = std::exp(UniformGrid(loge_data)[max_el]);
+        max_xs = grid.y[max_el];
+    }
+    if (auto const& grid = macro_xs.upper)
+    {
+        // Find the index of the maximum cross section, scaling the cross
+        // section by the energy
+        auto loge_data = UniformGridData::from_bounds(grid.x, grid.y.size());
+        UniformGrid loge_grid(loge_data);
+        for (auto i : range(grid.y.size()))
+        {
+            real_type energy = std::exp(loge_grid[i]);
+            auto xs = grid.y[i] / energy;
+            if (xs > max_xs)
+            {
+                max_xs = xs;
+                result = energy;
+            }
+        }
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/celeritas/phys/detail/EnergyMaxXsCalculator.hh
+++ b/src/celeritas/phys/detail/EnergyMaxXsCalculator.hh
@@ -1,0 +1,43 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/phys/detail/EnergyMaxXsCalculator.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "celeritas/inp/Grid.hh"
+#include "celeritas/phys/PhysicsOptions.hh"
+#include "celeritas/phys/Process.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Find the energy where the macroscopic cross section is largest.
+ *
+ * This is used in the integral approach of sampling a discrete interaction
+ * length when a particle loses energy along a step.
+ */
+class EnergyMaxXsCalculator
+{
+  public:
+    // Construct with physics options and process
+    EnergyMaxXsCalculator(PhysicsOptions const&, Process const&);
+
+    // Calculate the energy of the maximum cross section in the grid
+    real_type operator()(inp::XsGrid const&) const;
+
+    //! Whether the integral approach is used
+    explicit operator bool() const { return use_integral_xs_; }
+
+  private:
+    bool use_integral_xs_;
+    bool is_annihilation_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/test/celeritas/ImportedDataTestBase.cc
+++ b/test/celeritas/ImportedDataTestBase.cc
@@ -17,6 +17,7 @@
 #include "celeritas/optical/ScintillationParams.hh"
 #include "celeritas/phys/CutoffParams.hh"
 #include "celeritas/phys/ParticleParams.hh"
+#include "celeritas/phys/PhysicsOptions.hh"
 #include "celeritas/phys/PhysicsParams.hh"
 #include "celeritas/phys/ProcessBuilder.hh"
 #include "celeritas/track/SimParams.hh"

--- a/test/celeritas/ImportedDataTestBase.hh
+++ b/test/celeritas/ImportedDataTestBase.hh
@@ -12,7 +12,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 struct ImportData;
-struct PhysicsParamsOptions;
+struct PhysicsOptions;
 struct ProcessBuilderOptions;
 
 namespace test
@@ -25,12 +25,6 @@ namespace test
  */
 class ImportedDataTestBase : virtual public GlobalGeoTestBase
 {
-  public:
-    //!@{
-    //! \name Type aliases
-    using PhysicsOptions = PhysicsParamsOptions;
-    //!@}
-
   public:
     //! Access lazily loaded problem-dependent data
     virtual ImportData const& imported_data() const = 0;

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -13,6 +13,7 @@
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/phys/CutoffParams.hh"
 #include "celeritas/phys/ParticleParams.hh"
+#include "celeritas/phys/PhysicsOptions.hh"
 #include "celeritas/phys/PhysicsParams.hh"
 #include "celeritas/track/SimParams.hh"
 #include "celeritas/track/TrackInitParams.hh"
@@ -223,8 +224,9 @@ auto MockTestBase::build_physics() -> SPConstPhysics
         inp.materials = this->material();
         inp.interact = interact;
         inp.label = "barks";
-        inp.applic = {make_applicability("electron", 1e-5, 10)};
+        inp.applic = {make_applicability("electron", 1e-5, 1e9)};
         inp.xs = {Barn{0}, Barn{6.0}, Barn{12.0}, Barn{6.0}};
+        inp.xs_scaled = {Barn{6.0}, Barn{4.0}, Barn{2.0}, Barn{1}, Barn{0}};
         inp.energy_loss = MevCmSqLossDens{0.5 * 1e-20};
         inp.interp = this->interpolation();
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -224,9 +224,9 @@ auto MockTestBase::build_physics() -> SPConstPhysics
         inp.materials = this->material();
         inp.interact = interact;
         inp.label = "barks";
-        inp.applic = {make_applicability("electron", 1e-5, 1e9)};
+        inp.applic = {make_applicability("electron", 1e-5, 1e3)};
         inp.xs = {Barn{0}, Barn{6.0}, Barn{12.0}, Barn{6.0}};
-        inp.xs_scaled = {Barn{6.0}, Barn{4.0}, Barn{2.0}, Barn{1}, Barn{0}};
+        inp.xs_scaled = {Barn{6.0}, Barn{0}};
         inp.energy_loss = MevCmSqLossDens{0.5 * 1e-20};
         inp.interp = this->interpolation();
         physics_inp.processes.push_back(std::make_shared<MockProcess>(inp));

--- a/test/celeritas/MockTestBase.hh
+++ b/test/celeritas/MockTestBase.hh
@@ -19,7 +19,7 @@
 namespace celeritas
 {
 struct Applicability;
-struct PhysicsParamsOptions;
+struct PhysicsOptions;
 }  // namespace celeritas
 
 namespace celeritas
@@ -49,7 +49,6 @@ class MockTestBase : virtual public GlobalGeoTestBase, public OnlyCoreTestBase
   public:
     //!@{
     //! \name Type aliases
-    using PhysicsOptions = PhysicsParamsOptions;
     using ModelCallback = std::function<void(ActionId)>;
     using SpanConstModel = Span<ModelId const>;
     //!@}

--- a/test/celeritas/global/StepperGeant.test.cc
+++ b/test/celeritas/global/StepperGeant.test.cc
@@ -234,7 +234,7 @@ class TestEm3MscNoIntegral : public TestEm3Msc
         return opts;
     }
 
-    PhysicsParamsOptions build_physics_options() const override
+    PhysicsOptions build_physics_options() const override
     {
         auto opts = ImportedDataTestBase::build_physics_options();
         opts.disable_integral_xs = true;

--- a/test/celeritas/phys/MockProcess.cc
+++ b/test/celeritas/phys/MockProcess.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 
+#include "corecel/grid/VectorUtils.hh"
 #include "corecel/sys/ActionRegistry.hh"
 
 #include "MockModel.hh"
@@ -55,17 +56,37 @@ auto MockProcess::macro_xs(Applicability applic) const -> XsGrid
     CELER_EXPECT(applic.material);
     CELER_EXPECT(applic.particle);
 
-    XsGrid grid;
-    if (!data_.xs.empty())
-    {
-        MaterialView mat(data_.materials->host_ref(), applic.material);
-        real_type numdens = mat.number_density();
+    MaterialView mat(data_.materials->host_ref(), applic.material);
+    real_type numdens = mat.number_density();
 
-        grid.lower.x
-            = {std::log(applic.lower.value()), std::log(applic.upper.value())};
+    auto lower_size = data_.xs.size();
+    auto upper_size = data_.xs_scaled.size();
+    CELER_ASSERT(lower_size + upper_size > 1);
+
+    // Get the energy grid values
+    auto size = lower_size && upper_size ? lower_size + upper_size - 1
+                                         : std::max(lower_size, upper_size);
+    auto energy = logspace(applic.lower.value(), applic.upper.value(), size);
+
+    XsGrid grid;
+    if (lower_size)
+    {
+        // Create the unscaled cross section grid
+        grid.lower.x = {std::log(energy[0]), std::log(energy[lower_size - 1])};
         for (auto xs : data_.xs)
         {
             grid.lower.y.push_back(native_value_from(xs) * numdens);
+        }
+    }
+    if (upper_size)
+    {
+        // Create the scaled cross section grid
+        auto start = lower_size ? lower_size - 1 : 0;
+        grid.upper.x = {std::log(energy[start]), std::log(energy[size - 1])};
+        for (auto i : range(upper_size))
+        {
+            grid.upper.y.push_back(native_value_from(data_.xs_scaled[i])
+                                   * numdens * energy[start + i]);
         }
     }
     return grid;

--- a/test/celeritas/phys/MockProcess.cc
+++ b/test/celeritas/phys/MockProcess.cc
@@ -109,7 +109,7 @@ auto MockProcess::energy_loss(Applicability applic) const -> EnergyLossGrid
 
         grid.x
             = {std::log(applic.lower.value()), std::log(applic.upper.value())};
-        grid.y = VecDbl(3, eloss_rate.value());
+        grid.y = VecDbl(2, eloss_rate.value());
     }
     return grid;
 }

--- a/test/celeritas/phys/MockProcess.cc
+++ b/test/celeritas/phys/MockProcess.cc
@@ -109,7 +109,7 @@ auto MockProcess::energy_loss(Applicability applic) const -> EnergyLossGrid
 
         grid.x
             = {std::log(applic.lower.value()), std::log(applic.upper.value())};
-        grid.y = VecDbl(2, eloss_rate.value());
+        grid.y = VecDbl(3, eloss_rate.value());
     }
     return grid;
 }

--- a/test/celeritas/phys/MockProcess.hh
+++ b/test/celeritas/phys/MockProcess.hh
@@ -78,6 +78,7 @@ class MockProcess : public Process
         VecApplicability applic;  //!< Applicablity per model
         ModelCallback interact;  //!< MockModel::interact callback
         VecMicroXs xs;  //!< Constant per atom [bn]
+        VecMicroXs xs_scaled;  //!< Scaled by E
         MevCmSqLossDens energy_loss{};  //!< Constant per atom
         inp::Interpolation interp{};
     };

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -108,7 +108,7 @@ TEST_F(PhysicsParamsTest, accessors)
            "MockModel(8, p=2, emin=1, emax=100)",
            "MockModel(9, p=1, emin=0.001, emax=10)",
            "MockModel(10, p=2, emin=0.001, emax=10)",
-           "MockModel(11, p=3, emin=1e-05, emax=1e+09)"};
+           "MockModel(11, p=3, emin=1e-05, emax=1000)"};
     EXPECT_VEC_EQ(expected_model_desc, model_desc);
 
     // Test host-accessible process map

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -24,6 +24,7 @@
 #include "celeritas/phys/PhysicsParams.hh"
 #include "celeritas/phys/PhysicsParamsOutput.hh"
 #include "celeritas/phys/PhysicsTrackView.hh"
+#include "celeritas/phys/detail/EnergyMaxXsCalculator.hh"
 
 #include "celeritas_test.hh"
 
@@ -107,7 +108,7 @@ TEST_F(PhysicsParamsTest, accessors)
            "MockModel(8, p=2, emin=1, emax=100)",
            "MockModel(9, p=1, emin=0.001, emax=10)",
            "MockModel(10, p=2, emin=0.001, emax=10)",
-           "MockModel(11, p=3, emin=1e-05, emax=10)"};
+           "MockModel(11, p=3, emin=1e-05, emax=1e+09)"};
     EXPECT_VEC_EQ(expected_model_desc, model_desc);
 
     // Test host-accessible process map
@@ -149,6 +150,51 @@ TEST_F(PhysicsParamsTest, output)
     EXPECT_JSON_EQ(
         R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":34}})json",
         j.dump());
+}
+
+TEST_F(PhysicsParamsTest, energy_max_xs)
+{
+    PhysicsOptions opts = this->build_physics_options();
+    PhysicsParams const& p = *this->physics();
+    auto const& data = p.host_ref();
+
+    Applicability applic;
+    std::vector<std::vector<real_type>> energy_max_xs;
+    for (auto par_id : Range(ParticleId(data.process_groups.size())))
+    {
+        applic.particle = par_id;
+        auto proc_group = data.process_groups[par_id];
+        auto proc_ids = data.process_ids[proc_group.processes];
+        for (auto pp_idx : range(proc_ids.size()))
+        {
+            auto model_group = data.model_groups[proc_group.models][pp_idx];
+            auto energy_grid = data.reals[model_group.energy];
+            applic.lower = MevEnergy{energy_grid.front()};
+            applic.upper = MevEnergy{energy_grid.back()};
+
+            auto const& proc = p.process(proc_ids[pp_idx]);
+            CELER_ASSERT(proc);
+            detail::EnergyMaxXsCalculator calc(opts, *proc);
+            std::vector<real_type> energy;
+            for (auto mat_id : range(PhysMatId(this->material()->size())))
+            {
+                applic.material = mat_id;
+                auto macro_xs = proc->macro_xs(applic);
+                energy.push_back(calc ? calc(macro_xs) : -1);
+            }
+            energy_max_xs.push_back(std::move(energy));
+        }
+    }
+    static std::vector<double> const expected_energy_max_xs[]
+        = {{-1, -1, -1, -1},
+           {-1, -1, -1, -1},
+           {-1, -1, -1, -1},
+           {0.001, 0.001, 0.001, 0.001},
+           {0.001, 0.001, 0.001, 0.001},
+           {0.001, 0.001, 0.001, 0.001},
+           {0.001, 0.001, 0.001, 0.001},
+           {0.1, 0.1, 0.1, 0.1}};
+    EXPECT_VEC_SOFT_EQ(expected_energy_max_xs, energy_max_xs);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -259,6 +259,7 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
         step = 0.999 * particle.energy().value() / eloss_rate;
         EXPECT_SOFT_EQ(9.99, calc_eloss(phys, step));
     }
+    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         PhysicsTrackView phys = this->init_track(
             &material, PhysMatId{0}, &particle, "electron", MevEnergy{1e-3});
@@ -514,6 +515,7 @@ TEST_F(SplinePhysicsStepUtilsTest, calc_mean_energy_loss)
         step = 0.999 * particle.energy().value() / eloss_rate;
         EXPECT_SOFT_EQ(9.99, calc_eloss(phys, step));
     }
+    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         PhysicsTrackView phys = this->init_track(
             &material, PhysMatId{0}, &particle, "electron", MevEnergy{1e-3});

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -220,13 +220,11 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
     // input: cm; output: MeV
     auto calc_eloss = [&](PhysicsTrackView& phys, real_type step) -> real_type {
         // Calculate and store the energy loss range to PhysicsTrackView
-        auto grid_id = phys.range_grid();
-        auto calc_range = phys.make_calculator<RangeCalculator>(grid_id);
-        real_type range = calc_range(particle.energy());
+        real_type range = phys.make_calculator<RangeCalculator>(
+            phys.range_grid())(particle.energy());
         phys.dedx_range(range);
 
-        auto result
-            = calc_mean_energy_loss(particle, phys, step * units::centimeter);
+        auto result = calc_mean_energy_loss(particle, phys, from_cm(step));
         return value_as<MevEnergy>(result);
     };
 
@@ -268,7 +266,7 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
         // equal to the pre-step energy.
         real_type range = phys.make_calculator<RangeCalculator>(
             phys.range_grid())(particle.energy());
-        real_type step = range - fine_eps;
+        real_type step = to_cm(range) - fine_eps;
         EXPECT_SOFT_EQ(1e-3, calc_eloss(phys, step));
     }
 }
@@ -475,13 +473,11 @@ TEST_F(SplinePhysicsStepUtilsTest, calc_mean_energy_loss)
     // input: cm; output: MeV
     auto calc_eloss = [&](PhysicsTrackView& phys, real_type step) -> real_type {
         // Calculate and store the energy loss range to PhysicsTrackView
-        auto grid_id = phys.range_grid();
-        auto calc_range = phys.make_calculator<RangeCalculator>(grid_id);
-        real_type range = calc_range(particle.energy());
+        real_type range = phys.make_calculator<RangeCalculator>(
+            phys.range_grid())(particle.energy());
         phys.dedx_range(range);
 
-        auto result
-            = calc_mean_energy_loss(particle, phys, step * units::centimeter);
+        auto result = calc_mean_energy_loss(particle, phys, from_cm(step));
         return value_as<MevEnergy>(result);
     };
 
@@ -523,7 +519,7 @@ TEST_F(SplinePhysicsStepUtilsTest, calc_mean_energy_loss)
         // equal to the pre-step energy.
         real_type range = phys.make_calculator<RangeCalculator>(
             phys.range_grid())(particle.energy());
-        real_type step = range - fine_eps;
+        real_type step = to_cm(range) - fine_eps;
         EXPECT_SOFT_EQ(1e-3, calc_eloss(phys, step));
     }
 }

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -259,17 +259,16 @@ TEST_F(PhysicsStepUtilsTest, calc_mean_energy_loss)
         step = 0.999 * particle.energy().value() / eloss_rate;
         EXPECT_SOFT_EQ(9.99, calc_eloss(phys, step));
     }
-    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         PhysicsTrackView phys = this->init_track(
             &material, PhysMatId{0}, &particle, "electron", MevEnergy{1e-3});
-        real_type const eloss_rate = 0.5;  // MeV / cm
 
         // Low energy particle which loses all its energy over the step will
         // call inverse lookup. Remaining range will be zero and eloss will be
         // equal to the pre-step energy.
-        real_type step = 1e-5 / eloss_rate
-                         + value_as<MevEnergy>(particle.energy()) / eloss_rate;
+        real_type range = phys.make_calculator<RangeCalculator>(
+            phys.range_grid())(particle.energy());
+        real_type step = range - fine_eps;
         EXPECT_SOFT_EQ(1e-3, calc_eloss(phys, step));
     }
 }
@@ -515,17 +514,16 @@ TEST_F(SplinePhysicsStepUtilsTest, calc_mean_energy_loss)
         step = 0.999 * particle.energy().value() / eloss_rate;
         EXPECT_SOFT_EQ(9.99, calc_eloss(phys, step));
     }
-    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         PhysicsTrackView phys = this->init_track(
             &material, PhysMatId{0}, &particle, "electron", MevEnergy{1e-3});
-        real_type const eloss_rate = 0.5;  // MeV / cm
 
         // Low energy particle which loses all its energy over the step will
         // call inverse lookup. Remaining range will be zero and eloss will be
         // equal to the pre-step energy.
-        real_type step = 1e-5 / eloss_rate
-                         + value_as<MevEnergy>(particle.energy()) / eloss_rate;
+        real_type range = phys.make_calculator<RangeCalculator>(
+            phys.range_grid())(particle.energy());
+        real_type step = range - fine_eps;
         EXPECT_SOFT_EQ(1e-3, calc_eloss(phys, step));
     }
 }


### PR DESCRIPTION
This moves the calculation of the maximum cross section for the integral approach from the physics params to a helper class and fixes a couple of bugs:
  - Scaled cross section wasn't being scaled by energy
  - Final comparison of upper and lower grid values was of energies, not xs

None of our processes that use the integral approach have scaled cross section grids, so we won't have run into this in practice, but I added a test that failed before the fixes.