### PR TITLE
Adjust version compatibility for covfie

### DIFF
--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -131,7 +131,7 @@ jobs:
                  || matrix.geometry == 'vecgeom2'
                  || matrix.geometry == 'vgsurf')
                 && matrix.geant != ''}}; then
-            spack -e . add g4vg@1.0.3:
+            spack -e . add g4vg@1.0.4
           fi
           spack -vd -e . compiler find --mixed-toolchain
           # Add the spack ref so that updating spack will reconcretize

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -130,8 +130,8 @@ jobs:
           if ${{(matrix.geometry == 'vecgeom'
                  || matrix.geometry == 'vecgeom2'
                  || matrix.geometry == 'vgsurf')
-                && matrix.geant}}; then
-            spack -e . add g4vg@1.0.2:
+                && matrix.geant != ''}}; then
+            spack -e . add g4vg@1.0.3:
           fi
           spack -vd -e . compiler find --mixed-toolchain
           # Add the spack ref so that updating spack will reconcretize

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -13,7 +13,8 @@ concurrency:
   group: build-spack-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}-${{github.workflow}}
 
 env:
-  SPACK_REF: 38309ced3344d06168c25482083fc733bb654a63 # develop@2025-03-17
+  SPACK_REF: 84476f6f35ee367a3c8c4247edcde66441cee5e6 # ci @ 12 May 2025
+
 
 jobs:
   spack:
@@ -96,8 +97,9 @@ jobs:
       ### ENVIRONMENT ###
 
       - name: Check out Spack
-        uses: spack/setup-spack@5792f7c7055c3707819380b5e3831d2be6e64b6c # 2024/12
+        uses: sethrj/setup-spack@200141be54665bd75af4dbb131d08d24ea606a9c
         with:
+          repository: celeritas-project/spack
           ref: ${{env.SPACK_REF}}
           buildcache: true
           color: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,7 +409,12 @@ if(CELERITAS_USE_ROOT)
 endif()
 
 if(CELERITAS_USE_covfie)
-  celeritas_find_or_builtin_package(covfie 0.13.0)
+  if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
+    set(_min_covfie_version 0.14)
+  else()
+    set(_min_covfie_version 0.13)
+  endif()
+  celeritas_find_or_builtin_package(covfie ${_min_covfie_version})
 endif()
 
 if(CELERITAS_USE_VecGeom)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,7 +409,7 @@ if(CELERITAS_USE_ROOT)
 endif()
 
 if(CELERITAS_USE_covfie)
-  celeritas_find_or_builtin_package(covfie 0.14.0)
+  celeritas_find_or_builtin_package(covfie 0.13.0)
 endif()
 
 if(CELERITAS_USE_VecGeom)

--- a/scripts/ci/spack.yaml
+++ b/scripts/ci/spack.yaml
@@ -5,6 +5,7 @@ spack:
   view: /opt/spack-view
   specs:
   - ccache
+  - cli11
   - cmake
   - googletest
   - hepmc3

--- a/scripts/ci/spack.yaml
+++ b/scripts/ci/spack.yaml
@@ -5,7 +5,7 @@ spack:
   view: /opt/spack-view
   specs:
   - ccache
-  - cli11
+  - cli11 +pic ~ipo
   - cmake
   - googletest
   - hepmc3

--- a/scripts/ci/spack.yaml
+++ b/scripts/ci/spack.yaml
@@ -27,7 +27,7 @@ spack:
       variants: ~aqua ~davix ~examples ~opengl ~x ~tbb cxxstd=20
     all:
       require:
-      - "%clang@18 target=zen2" # FIXME: genericize on next rebuild
+      - "target=zen2 %clang@18" # FIXME: genericize on next rebuild
       - any_of: [+ipo, '@:']
       - any_of: [build_system=cmake, '@:']
       - any_of: [build_type=Release, '@:']

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -9,7 +9,6 @@
       "binaryDir": "${sourceDir}/build",
       "generator": "Ninja",
       "cacheVariables": {
-        "CELERITAS_BUILTIN_CLI11": {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_TEST_VERBOSE":{"type": "BOOL", "value": "OFF"},
@@ -50,6 +49,11 @@
       "inherits": ["base"],
       "displayName": "CONFIG: use full spack toolchain",
       "cacheVariables": {
+        "CELERITAS_BUILTIN_CLI11": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_G4VG": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_GTest": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_covfie": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_nlohmann_json": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_ROOT":    null,
@@ -87,6 +91,7 @@
       "inherits": ["type-reldeb", "base"],
       "displayName": "FINAL: fast build using apt-get",
       "cacheVariables": {
+        "CELERITAS_BUILTIN_CLI11": {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"}
       }
     },
@@ -96,6 +101,7 @@
       "displayName": "FINAL: ultralite build with no externals",
       "cacheVariables": {
         "BUILD_TESTING":         {"type": "BOOL", "value": "ON"},
+        "CELERITAS_BUILTIN_CLI11": {"type": "BOOL", "value": "ON"},
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
       }

--- a/scripts/docker/dev/rocky-cuda12.yaml
+++ b/scripts/docker/dev/rocky-cuda12.yaml
@@ -3,7 +3,7 @@ spack:
   - cli11
   - "covfie@0.14:"
   - cmake
-  - "g4vg@1.0.2:"
+  - "g4vg@1.0.3:"
   - "geant4@11.0 cxxstd=20"
   - git
   - "googletest@1.10:"

--- a/scripts/docker/dev/rocky-cuda12.yaml
+++ b/scripts/docker/dev/rocky-cuda12.yaml
@@ -1,6 +1,7 @@
 spack:
   specs:
   - cli11
+  - "covfie@0.14:"
   - cmake
   - "g4vg@1.0.2:"
   - "geant4@11.0 cxxstd=20"

--- a/scripts/docker/dev/ubuntu-rocm6.yaml
+++ b/scripts/docker/dev/ubuntu-rocm6.yaml
@@ -2,6 +2,7 @@ spack:
   specs:
     - adios2
     - cli11
+    - "covfie@0.14:"
     - cmake
     - "geant4@11.0"
     - git

--- a/scripts/docker/interactive/spack.yaml
+++ b/scripts/docker/interactive/spack.yaml
@@ -2,7 +2,7 @@ spack:
   specs:
     - cli11
     - "covfie@0.13:"
-    - "g4vg@1.0.2:"
+    - "g4vg@1.0.3:"
     - "geant4@11"
     - "googletest@1.10:"
     - hepmc3

--- a/scripts/docker/interactive/spack.yaml
+++ b/scripts/docker/interactive/spack.yaml
@@ -1,6 +1,7 @@
 spack:
   specs:
     - cli11
+    - "covfie@0.13:"
     - "g4vg@1.0.2:"
     - "geant4@11"
     - "googletest@1.10:"

--- a/scripts/spack.yaml
+++ b/scripts/spack.yaml
@@ -1,6 +1,7 @@
 spack:
   specs:
     - cli11
+    - "covfie@0.13:"
     - cmake
     - doxygen
     - "geant4@11"

--- a/scripts/spack.yaml
+++ b/scripts/spack.yaml
@@ -5,7 +5,7 @@ spack:
     - cmake
     - doxygen
     - "geant4@11"
-    - "g4vg@1.0.2:"
+    - "g4vg@1.0.3:"
     - git
     - git-lfs
     - "googletest@1.10:"


### PR DESCRIPTION
Following on to #1767: since covfie 0.13 still compiles with CPU-only, and 0.14 isn't yet available (see https://github.com/spack/spack/pull/50417 ), it would be good not to fail to configure on spack environments. Version minimum requirements should reflect a minimum capability. This updates the requirements so that CUDA/HIP need 0.14, but CPU only still works with 0.13. I also failed to update the g4vg spack files when updating in the main CMakelists, so those are now also built.