### PR TITLE
Add tests and documentation for Tsai nuclear screening functions

### DIFF
--- a/doc/development/style.rst
+++ b/doc/development/style.rst
@@ -50,7 +50,8 @@ Doxygen comments should be provided next to the *definition* of functions (both
 member and free) and classes. This means adding a one-line Doxygen comment for
 member functions defined inside the class's definition or multi-line Doxygen
 comments if a function is defined externally.
-Document the effect of a function-like class's "call" operator``()`` in the class's main definition rather than the operator
+Document the effect of a function-like class's ``operator()`` (aka the "call"
+operator) in the class's main definition rather than the operator
 itself, since this makes it easier and cleaner to document the class's behavior
 in the :ref:`api` documentation. Do the same for physics classes.
 

--- a/doc/implementation/em-physics/brems.rst
+++ b/doc/implementation/em-physics/brems.rst
@@ -34,6 +34,10 @@ cross section for low-energy gammas.
 
 .. doxygenclass:: celeritas::LPMCalculator
 
+They also use nuclear screening functions:
+
+.. doxygenclass:: celeritas::TsaiScreeningCalculator
+
 Muon bremsstrahlung calculates the differential cross section as part of
 rejection sampling.
 

--- a/src/celeritas/em/data/RelativisticBremData.hh
+++ b/src/celeritas/em/data/RelativisticBremData.hh
@@ -8,7 +8,6 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
-#include "corecel/cont/Array.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/math/Quantity.hh"
 #include "celeritas/Quantities.hh"
@@ -31,11 +30,14 @@ struct RelBremFormFactor
 
 //---------------------------------------------------------------------------//
 /*!
- * A special metadata structure per element used in the differential cross
- * section calculation.
+ * Per-element metadata used in the differential cross section calculation.
+ *
+ * Gamma and epsilon are in units of mass.
  */
 struct RelBremElementData
 {
+    using Mass = units::MevMass;
+
     real_type fz;  //!< \f$ \ln(Z)/3 + f_c (Coulomb correction) \f$
     real_type factor1;  //!< \f$ ((Fel-fc)+Finel*invZ)\f$
     real_type factor2;  //!< \f$ (1.0+invZ)/12 \f$

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -180,14 +180,13 @@ auto RelativisticBremModel::compute_element_data(ElementView const& elem,
 
     real_type fc = elem.coulomb_correction();
     real_type invz = real_type(1) / z.unchecked_get();
-    real_type z13 = elem.cbrt_z();
-    real_type z23 = ipow<2>(z13);
 
     data.fz = elem.log_z() / 3 + fc;
     data.factor1 = (ff_el - fc) + ff_inel * invz;
     data.factor2 = (1 + invz) / 12;
-    data.gamma_factor = 100 * electron_mass / z13;
-    data.epsilon_factor = 100 * electron_mass / z23;
+    // See Eq. 3.32 in tsai-1974
+    data.gamma_factor = 100 * electron_mass / elem.cbrt_z();
+    data.epsilon_factor = 100 * electron_mass / ipow<2>(elem.cbrt_z());
 
     return data;
 }

--- a/src/celeritas/em/xs/RBDiffXsCalculator.hh
+++ b/src/celeritas/em/xs/RBDiffXsCalculator.hh
@@ -11,12 +11,14 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/math/PolyEvaluator.hh"
 #include "corecel/math/Quantity.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/em/data/RelativisticBremData.hh"
 #include "celeritas/em/interactor/detail/PhysicsConstants.hh"
+#include "celeritas/phys/ParticleTrackView.hh"
 
 #include "LPMCalculator.hh"
 #include "ScreeningFunctions.hh"
@@ -152,13 +154,12 @@ real_type RBDiffXsCalculator::dxsec_per_atom(real_type gamma_energy)
     real_type dxsec{0};
 
     real_type y = gamma_energy / total_energy_;
-    real_type onemy = 1 - y;
-    real_type term0 = onemy + R(0.75) * ipow<2>(y);
+    real_type term0 = PolyEvaluator<real_type, 2>{1.0, -1.0, 0.75}(y);
 
     if (element_.atomic_number() < AtomicNumber{5})
     {
         // The Dirac-Fock model
-        dxsec = term0 * elem_data_.factor1 + onemy * elem_data_.factor2;
+        dxsec = term0 * elem_data_.factor1 + (1 - y) * elem_data_.factor2;
     }
     else
     {
@@ -176,10 +177,10 @@ real_type RBDiffXsCalculator::dxsec_per_atom(real_type gamma_energy)
                     * ((R(0.25) * sfunc.phi1 - elem_data_.fz)
                        + (R(0.25) * sfunc.psi1 - 2 * element_.log_z() / 3)
                              * invz)
-                + R(0.125) * onemy * (sfunc.phi2 + sfunc.psi2 * invz);
+                + R(0.125) * (1 - y) * (sfunc.dphi + sfunc.dpsi * invz);
     }
 
-    return celeritas::max(dxsec, R(0));
+    return clamp_to_nonneg(dxsec);
 }
 
 //---------------------------------------------------------------------------//
@@ -196,12 +197,12 @@ real_type RBDiffXsCalculator::dxsec_per_atom_lpm(real_type gamma_energy)
     auto lpm = calc_lpm_functions(epsilon);
 
     real_type y = gamma_energy / total_energy_;
-    real_type onemy = 1 - y;
-    real_type y2 = R(0.25) * ipow<2>(y);
-    real_type term = lpm.xi * (y2 * lpm.g + (onemy + 2 * y2) * lpm.phi);
-    real_type dxsec = term * elem_data_.factor1 + onemy * elem_data_.factor2;
+    real_type hy_sq = R(0.25) * ipow<2>(y);
+    real_type term = lpm.xi * (hy_sq * lpm.g + (1 - y + 2 * hy_sq) * lpm.phi);
 
-    return max(dxsec, R(0));
+    real_type dxsec = term * elem_data_.factor1 + (1 - y) * elem_data_.factor2;
+
+    return clamp_to_nonneg(dxsec);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/xs/RBDiffXsCalculator.hh
+++ b/src/celeritas/em/xs/RBDiffXsCalculator.hh
@@ -19,6 +19,7 @@
 #include "celeritas/em/interactor/detail/PhysicsConstants.hh"
 
 #include "LPMCalculator.hh"
+#include "ScreeningFunctions.hh"
 
 namespace celeritas
 {
@@ -72,15 +73,6 @@ class RBDiffXsCalculator
   private:
     //// TYPES ////
 
-    //! Intermediate data for screening functions
-    struct ScreenFunctions
-    {
-        real_type phi1{0};
-        real_type phi2{0};
-        real_type psi1{0};
-        real_type psi2{0};
-    };
-
     using R = real_type;
 
     //// DATA ////
@@ -107,10 +99,6 @@ class RBDiffXsCalculator
 
     //! Calculate the differential cross section per atom with the LPM effect
     inline CELER_FUNCTION real_type dxsec_per_atom_lpm(real_type energy);
-
-    //! Compute screening functions
-    inline CELER_FUNCTION ScreenFunctions
-    compute_screen_functions(real_type gamma, real_type epsilon);
 };
 
 //---------------------------------------------------------------------------//
@@ -178,12 +166,11 @@ real_type RBDiffXsCalculator::dxsec_per_atom(real_type gamma_energy)
         real_type invz = 1
                          / static_cast<real_type>(
                              element_.atomic_number().unchecked_get());
-        real_type term1 = y / (total_energy_ - gamma_energy);
-        real_type gamma = term1 * elem_data_.gamma_factor;
-        real_type epsilon = term1 * elem_data_.epsilon_factor;
 
         // Evaluate the screening functions
-        auto sfunc = compute_screen_functions(gamma, epsilon);
+        auto sfunc = TsaiScreeningCalculator{
+            elem_data_.gamma_factor,
+            elem_data_.epsilon_factor}(y / (total_energy_ - gamma_energy));
 
         dxsec = term0
                     * ((R(0.25) * sfunc.phi1 - elem_data_.fz)
@@ -215,31 +202,6 @@ real_type RBDiffXsCalculator::dxsec_per_atom_lpm(real_type gamma_energy)
     real_type dxsec = term * elem_data_.factor1 + onemy * elem_data_.factor2;
 
     return max(dxsec, R(0));
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Compute screen_functions.
- */
-CELER_FUNCTION auto
-RBDiffXsCalculator::compute_screen_functions(real_type gam, real_type eps)
-    -> ScreenFunctions
-{
-    ScreenFunctions func;
-    real_type gam2 = ipow<2>(gam);
-    real_type eps2 = ipow<2>(eps);
-
-    func.phi1 = R(16.863) - 2 * std::log(1 + R(0.311877) * gam2)
-                + R(2.4) * std::exp(R(-0.9) * gam)
-                + R(1.6) * std::exp(R(-1.5) * gam);
-    func.phi2 = 2 / (3 + R(19.5) * gam + 18 * gam2);
-
-    func.psi1 = R(24.34) - 2 * std::log(1 + R(13.111641) * eps2)
-                + R(2.8) * std::exp(R(-8) * eps)
-                + R(1.2) * std::exp(R(-29.2) * eps);
-    func.psi2 = 2 / (3 + 120 * eps + 1200 * eps2);
-
-    return func;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/xs/RBDiffXsCalculator.hh
+++ b/src/celeritas/em/xs/RBDiffXsCalculator.hh
@@ -18,6 +18,7 @@
 #include "celeritas/Types.hh"
 #include "celeritas/em/data/RelativisticBremData.hh"
 #include "celeritas/em/interactor/detail/PhysicsConstants.hh"
+#include "celeritas/mat/ElementView.hh"
 #include "celeritas/phys/ParticleTrackView.hh"
 
 #include "LPMCalculator.hh"
@@ -32,10 +33,8 @@ namespace celeritas
  * This accounts for the LPM effect if the option is enabled and the
  * electron energy is high enough.
  *
- * The screening function uses Tsai's analytical approximations of coherent and
- * incoherent screening function to the numerical screening functions computed
- * using the Thomas-Fermi model \citep{tsai-1974,
- * https://doi.org/10.1103/RevModPhys.46.815} .
+ * The screening functions are documented in \c
+ * celeritas::TsaiScreeningCalculator.
  *
  * \note This is currently used only as a shape function for rejection, so as
  * long as the resulting cross section is scaled by the maximum value the units
@@ -163,16 +162,16 @@ real_type RBDiffXsCalculator::dxsec_per_atom(real_type gamma_energy)
     }
     else
     {
-        // Tsai's analytical approximation.
+        // Tsai's analytical approximation
+        using Mass = ElementData::Mass;
+        using InvEnergy = RealQuantity<UnitInverse<Energy::unit_type>>;
+        auto sfunc = TsaiScreeningCalculator{Mass{elem_data_.gamma_factor},
+                                             Mass{elem_data_.epsilon_factor}}(
+            InvEnergy{y / (total_energy_ - gamma_energy)});
+
         real_type invz = 1
                          / static_cast<real_type>(
                              element_.atomic_number().unchecked_get());
-
-        // Evaluate the screening functions
-        auto sfunc = TsaiScreeningCalculator{
-            elem_data_.gamma_factor,
-            elem_data_.epsilon_factor}(y / (total_energy_ - gamma_energy));
-
         dxsec = term0
                     * ((R(0.25) * sfunc.phi1 - elem_data_.fz)
                        + (R(0.25) * sfunc.psi1 - 2 * element_.log_z() / 3)

--- a/src/celeritas/em/xs/ScreeningFunctions.hh
+++ b/src/celeritas/em/xs/ScreeningFunctions.hh
@@ -49,8 +49,9 @@ struct BhwlScreeningFactors
  * The calculator argument is the fraction \f[
  * \delta = \frac{k}{E(k - E)} \equiv \frac{2\delta_\mathrm{Tsai}}{m_e}
  * \f]
- * where \f$k\f$ is the kinetic plus rest mass energy of the incident electron
- * and \f$E\f$ is the exiting gamma energy.
+ * where \f$E\f$ is the kinetic plus rest mass energy of the electron
+ * and \f$k\f$ is the photon energy. (For Bremsstrahlung, the electron is
+ * incident and photon is exiting.)
  *
  * The calculated screening functions are:
  * \f[

--- a/src/celeritas/em/xs/ScreeningFunctions.hh
+++ b/src/celeritas/em/xs/ScreeningFunctions.hh
@@ -15,17 +15,21 @@ namespace celeritas
  * Bethe-Heitler-Wheeler-Lamb screening factors for use in atomic showers.
  *
  * These are derived from \citet{bethe-stopping-1934,
- * https://doi.org/10.1098/rspa.1934.0140} for the \f$ \phi\f$ (elastic)
- * components and \citet{wheeler-electrons-1939,
+ * https://doi.org/10.1098/rspa.1934.0140} (Eq. 31) for the \f$ \phi\f$
+ * (elastic) components and \citet{wheeler-electrons-1939,
  * https://doi.org/10.1103/PhysRev.55.858} for the \f$ \psi \f$ (inelastic)
  * components.
  */
 struct BhwlScreeningFactors
 {
     //! Elastic component, multiplied into Z^2
-    Array<real_type, 2> phi;
+    real_type phi1{};
+    //! \f$\phi_1 - \phi_2\f$ corrective term for low-energy secondary
+    real_type dphi{};
     //! Inelastic component, multiplied into Z
-    Array<real_type, 2> psi;
+    real_type psi1{};
+    //! \f$\psi_1 - \psi_2\f$ corrective term for low-energy secondary
+    real_type dpsi{};
 };
 
 //---------------------------------------------------------------------------//
@@ -125,19 +129,18 @@ CELER_FUNCTION auto TsaiScreeningCalculator::operator()(real_type delta) const
     real_type gam = delta * f_gamma_;
     real_type eps = delta * f_epsilon_;
 
-    ScreenFunctions func;
-    real_type gam2 = ipow<2>(gam);
-    real_type eps2 = ipow<2>(eps);
+    using PolyQuad = PolyEvaluator<real_type, 2>;
+    result_type func;
 
-    func.phi[1] = R(16.863) - 2 * std::log(1 + R(0.311877) * gam2)
-                  + R(2.4) * std::exp(R(-0.9) * gam)
-                  + R(1.6) * std::exp(R(-1.5) * gam);
-    func.phi[2] = 2 / (3 + R(19.5) * gam + 18 * gam2);
+    func.phi1 = R(20.863 - 4) - 2 * std::log(1 + ipow<2>(R(0.55846) * gam))
+                + R(-4 * -0.6) * std::exp(R(-0.9) * gam)
+                + R(-4 * -0.4) * std::exp(R(-1.5) * gam);
+    func.dphi = (R{2} / R{3}) / PolyQuad{1, 6.5, 6}(gam);
 
-    func.psi[1] = R(24.34) - 2 * std::log(1 + R(13.111641) * eps2)
-                  + R(2.8) * std::exp(R(-8) * eps)
-                  + R(1.2) * std::exp(R(-29.2) * eps);
-    func.psi[2] = 2 / (3 + 120 * eps + 1200 * eps2);
+    func.psi1 = R(28.340 - 4) - 2 * std::log(1 + ipow<2>(R(3.621) * eps))
+                + R(-4 * -0.7) * std::exp(R(-8) * eps)
+                + R(-4 * -0.3) * std::exp(R(-29.2) * eps);
+    func.dpsi = (R{2} / R{3}) / PolyQuad{1, 40, 400}(eps);
 
     return func;
 }

--- a/src/celeritas/em/xs/ScreeningFunctions.hh
+++ b/src/celeritas/em/xs/ScreeningFunctions.hh
@@ -1,0 +1,146 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/em/xs/ScreeningFunctions.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Array.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Bethe-Heitler-Wheeler-Lamb screening factors for use in atomic showers.
+ *
+ * These are derived from \citet{bethe-stopping-1934,
+ * https://doi.org/10.1098/rspa.1934.0140} for the \f$ \phi\f$ (elastic)
+ * components and \citet{wheeler-electrons-1939,
+ * https://doi.org/10.1103/PhysRev.55.858} for the \f$ \psi \f$ (inelastic)
+ * components.
+ */
+struct BhwlScreeningFactors
+{
+    //! Elastic component, multiplied into Z^2
+    Array<real_type, 2> phi;
+    //! Inelastic component, multiplied into Z
+    Array<real_type, 2> psi;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Thomas-Fermi screening functions from Tsai.
+ *
+ * This calculates atomic screening factors given by  \citet{tsai-1974,
+ * https://doi.org/10.1103/RevModPhys.46.815} Eq. 3.30-31:
+ *
+ * \f[
+ * \varphi_1(\gamma) = 20.863 - 2 \ln \left( 1 + (0.55846\gamma)^2 \right)
+ * - 4 \left( 1 - 0.6 \exp(-0.9\gamma) - 0.4 \exp(-1.5\gamma) \right),
+ * \f]
+ *
+ * \f[
+ * \varphi_2(\gamma) = \varphi_1(\gamma) - \frac{2}{3} \left( 1 + 6.5\gamma +
+ * 6\gamma^2 \right)^{-1}, \f]
+ *
+ * \f[
+ * \psi_1(\epsilon) = 28.340 - 2 \ln \left( 1 + (3.621\epsilon)^2 \right)
+ * - 4 \left( 1 - 0.7 \exp(-8\epsilon) - 0.3 \exp(-29.2\epsilon) \right),
+ * \f]
+ *
+ * \f[
+ * \psi_2(\epsilon) = \psi_1(\epsilon) - \frac{2}{3} \left( 1 + 40\epsilon +
+ * 400\epsilon^2 \right)^{-1}. \f]
+ *
+ * Here,
+ * \f[
+ * \gamma = \frac{100 m_e k}{E (k - E) Z^{1/3}}
+ * \f]
+ * and
+ * \f[
+ * f_\epsilon = \frac{100 m_e k}{E (k - E) Z^{2/3}}
+ * \f]
+ * from which we extract input factors preclaculated in
+ * celeritas::RelativisticBremModel as
+ * \f[
+ * f_\gamma = \frac{100 m_e}{Z^{1/3}}
+ * \f]
+ * and
+ * \f[
+ * f_\epsilon = \frac{100 m_e}{Z^{2/3}}
+ * \f]
+ *
+ * The calculator argument is the unitless fraction \f[
+ * \delta' = \frac{k}{E(k - E)} \equiv \frac{2\delta_\mathrm{Tsai}}{m_e}
+ * \f]
+ * where \f$k\f$ is the kinetic plus rest mass energy of the incident electron
+ * and \f$E\f$ is the exiting gamma energy.
+ * This model is valid for \f$Z \ge 5\f$.
+ */
+class TsaiScreeningCalculator
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using result_type = BhwlScreeningFactors;
+    //!@}
+
+  public:
+    // Construct with defaults
+    CELER_FUNCTION inline TsaiScreeningCalculator(real_type gamma_factor,
+                                                  real_type epsilon_factor);
+
+    // Calculate screening function from energy transfer
+    CELER_FUNCTION result_type operator()(real_type delta) const;
+
+  private:
+    real_type f_gamma_;
+    real_type f_epsilon_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with gamma and epsilon factors.
+ */
+CELER_FUNCTION
+TsaiScreeningCalculator::TsaiScreeningCalculator(real_type gamma_factor,
+                                                 real_type epsilon_factor)
+    : f_gamma_{gamma_factor}, f_epsilon_{epsilon_factor}
+{
+    CELER_EXPECT(epsilon_factor > 0);
+    CELER_EXPECT(gamma_factor > epsilon_factor);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate screening function from energy transfer.
+ */
+CELER_FUNCTION auto TsaiScreeningCalculator::operator()(real_type delta) const
+    -> result_type
+{
+    CELER_EXPECT(delta >= 0 && delta <= 1);
+    real_type gam = delta * f_gamma_;
+    real_type eps = delta * f_epsilon_;
+
+    ScreenFunctions func;
+    real_type gam2 = ipow<2>(gam);
+    real_type eps2 = ipow<2>(eps);
+
+    func.phi[1] = R(16.863) - 2 * std::log(1 + R(0.311877) * gam2)
+                  + R(2.4) * std::exp(R(-0.9) * gam)
+                  + R(1.6) * std::exp(R(-1.5) * gam);
+    func.phi[2] = 2 / (3 + R(19.5) * gam + 18 * gam2);
+
+    func.psi[1] = R(24.34) - 2 * std::log(1 + R(13.111641) * eps2)
+                  + R(2.8) * std::exp(R(-8) * eps)
+                  + R(1.2) * std::exp(R(-29.2) * eps);
+    func.psi[2] = 2 / (3 + 120 * eps + 1200 * eps2);
+
+    return func;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/em/xs/ScreeningFunctions.hh
+++ b/src/celeritas/em/xs/ScreeningFunctions.hh
@@ -9,6 +9,9 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/math/PolyEvaluator.hh"
+#include "corecel/math/Quantity.hh"
+#include "corecel/math/UnitUtils.hh"
+#include "celeritas/Quantities.hh"
 
 namespace celeritas
 {
@@ -39,36 +42,38 @@ struct BhwlScreeningFactors
  * Thomas-Fermi screening functions from Tsai.
  *
  * This calculates atomic screening factors given by  \citet{tsai-1974,
- * https://doi.org/10.1103/RevModPhys.46.815} Eq. 3.30-31:
+ * https://doi.org/10.1103/RevModPhys.46.815} Eq. 3.30-31, as part of the
+ * relativistic bremsstrahlung cross section calculation.
+ * This model is valid for \f$ Z \ge 5 \f$.
  *
- * \f[
- * \varphi_1(\gamma) = 20.863 - 2 \ln \left( 1 + (0.55846\gamma)^2 \right)
- * - 4 \left( 1 - 0.6 \exp(-0.9\gamma) - 0.4 \exp(-1.5\gamma) \right),
+ * The calculator argument is the fraction \f[
+ * \delta = \frac{k}{E(k - E)} \equiv \frac{2\delta_\mathrm{Tsai}}{m_e}
  * \f]
+ * where \f$k\f$ is the kinetic plus rest mass energy of the incident electron
+ * and \f$E\f$ is the exiting gamma energy.
  *
+ * The calculated screening functions are:
  * \f[
- * \varphi_2(\gamma) = \varphi_1(\gamma) - \frac{2}{3} \left( 1 + 6.5\gamma +
- * 6\gamma^2 \right)^{-1}, \f]
- *
- * \f[
- * \psi_1(\epsilon) = 28.340 - 2 \ln \left( 1 + (3.621\epsilon)^2 \right)
- * - 4 \left( 1 - 0.7 \exp(-8\epsilon) - 0.3 \exp(-29.2\epsilon) \right),
+   \begin{aligned}
+   \varphi_1(\gamma) &= 20.863 - 2 \ln \left( 1 + (0.55846\gamma)^2 \right)
+     - 4 \left( 1 - 0.6 \exp(-0.9\gamma) - 0.4 \exp(-1.5\gamma) \right), \\
+   \varphi_2(\gamma) = \varphi_1(\gamma)
+     - \frac{2}{3} \left( 1 + 6.5\gamma + 6\gamma^2 \right)^{-1}, \\
+   \psi_1(\epsilon) &= 28.340 - 2 \ln \left( 1 + (3.621\epsilon)^2 \right)
+     - 4 \left( 1 - 0.7 \exp(-8\epsilon) - 0.3 \exp(-29.2\epsilon) \right),
+   \psi_2(\epsilon) &= \psi_1(\epsilon)
+     - \frac{2}{3} \left( 1 + 40\epsilon + 400\epsilon^2 \right)^{-1}.
+   \end{aligned}
  * \f]
- *
- * \f[
- * \psi_2(\epsilon) = \psi_1(\epsilon) - \frac{2}{3} \left( 1 + 40\epsilon +
- * 400\epsilon^2 \right)^{-1}. \f]
  *
  * Here,
  * \f[
- * \gamma = \frac{100 m_e k}{E (k - E) Z^{1/3}}
+   \begin{aligned}
+   \gamma &= \frac{100 m_e k}{E (k - E) Z^{1/3}} \\
+   \epsilon &= \frac{100 m_e k}{E (k - E) Z^{2/3}}
  * \f]
- * and
- * \f[
- * f_\epsilon = \frac{100 m_e k}{E (k - E) Z^{2/3}}
- * \f]
- * from which we extract input factors preclaculated in
- * celeritas::RelativisticBremModel as
+ * from which we extract input factors precalculated in
+ * \c celeritas::RelativisticBremModel:
  * \f[
  * f_\gamma = \frac{100 m_e}{Z^{1/3}}
  * \f]
@@ -77,12 +82,7 @@ struct BhwlScreeningFactors
  * f_\epsilon = \frac{100 m_e}{Z^{2/3}}
  * \f]
  *
- * The calculator argument is the unitless fraction \f[
- * \delta' = \frac{k}{E(k - E)} \equiv \frac{2\delta_\mathrm{Tsai}}{m_e}
- * \f]
- * where \f$k\f$ is the kinetic plus rest mass energy of the incident electron
- * and \f$E\f$ is the exiting gamma energy.
- * This model is valid for \f$Z \ge 5\f$.
+ * \sa RBDiffXsCalculator
  */
 class TsaiScreeningCalculator
 {
@@ -90,15 +90,17 @@ class TsaiScreeningCalculator
     //!@{
     //! \name Type aliases
     using result_type = BhwlScreeningFactors;
+    using Mass = units::MevMass;
+    using InvEnergy = RealQuantity<UnitInverse<units::Mev>>;
     //!@}
 
   public:
     // Construct with defaults
-    CELER_FUNCTION inline TsaiScreeningCalculator(real_type gamma_factor,
-                                                  real_type epsilon_factor);
+    CELER_FUNCTION inline TsaiScreeningCalculator(Mass gamma_factor,
+                                                  Mass epsilon_factor);
 
     // Calculate screening function from energy transfer
-    CELER_FUNCTION inline result_type operator()(real_type delta) const;
+    CELER_FUNCTION inline result_type operator()(InvEnergy delta) const;
 
   private:
     real_type f_gamma_;
@@ -112,11 +114,11 @@ class TsaiScreeningCalculator
  * Construct with gamma and epsilon factors.
  */
 CELER_FUNCTION
-TsaiScreeningCalculator::TsaiScreeningCalculator(real_type gamma_factor,
-                                                 real_type epsilon_factor)
-    : f_gamma_{gamma_factor}, f_epsilon_{epsilon_factor}
+TsaiScreeningCalculator::TsaiScreeningCalculator(Mass gamma_factor,
+                                                 Mass epsilon_factor)
+    : f_gamma_{gamma_factor.value()}, f_epsilon_{epsilon_factor.value()}
 {
-    CELER_EXPECT(epsilon_factor > 0);
+    CELER_EXPECT(epsilon_factor > zero_quantity());
     CELER_EXPECT(gamma_factor > epsilon_factor);
 }
 
@@ -124,12 +126,11 @@ TsaiScreeningCalculator::TsaiScreeningCalculator(real_type gamma_factor,
 /*!
  * Calculate screening function from energy transfer.
  */
-CELER_FUNCTION auto TsaiScreeningCalculator::operator()(real_type delta) const
+CELER_FUNCTION auto TsaiScreeningCalculator::operator()(InvEnergy delta) const
     -> result_type
 {
-    CELER_EXPECT(delta >= 0 && delta <= 1);
-    real_type gam = delta * f_gamma_;
-    real_type eps = delta * f_epsilon_;
+    real_type gam = delta.value() * f_gamma_;
+    real_type eps = delta.value() * f_epsilon_;
 
     using PolyQuad = PolyEvaluator<real_type, 2>;
     using R = real_type;

--- a/src/celeritas/em/xs/ScreeningFunctions.hh
+++ b/src/celeritas/em/xs/ScreeningFunctions.hh
@@ -6,7 +6,9 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/Array.hh"
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/math/PolyEvaluator.hh"
 
 namespace celeritas
 {
@@ -22,11 +24,11 @@ namespace celeritas
  */
 struct BhwlScreeningFactors
 {
-    //! Elastic component, multiplied into Z^2
+    //! Elastic component, to be multiplied into Z^2
     real_type phi1{};
     //! \f$\phi_1 - \phi_2\f$ corrective term for low-energy secondary
     real_type dphi{};
-    //! Inelastic component, multiplied into Z
+    //! Inelastic component, to be multiplied into Z
     real_type psi1{};
     //! \f$\psi_1 - \psi_2\f$ corrective term for low-energy secondary
     real_type dpsi{};
@@ -96,7 +98,7 @@ class TsaiScreeningCalculator
                                                   real_type epsilon_factor);
 
     // Calculate screening function from energy transfer
-    CELER_FUNCTION result_type operator()(real_type delta) const;
+    CELER_FUNCTION inline result_type operator()(real_type delta) const;
 
   private:
     real_type f_gamma_;
@@ -130,6 +132,7 @@ CELER_FUNCTION auto TsaiScreeningCalculator::operator()(real_type delta) const
     real_type eps = delta * f_epsilon_;
 
     using PolyQuad = PolyEvaluator<real_type, 2>;
+    using R = real_type;
     result_type func;
 
     func.phi1 = R(20.863 - 4) - 2 * std::log(1 + ipow<2>(R(0.55846) * gam))

--- a/test/Test.hh
+++ b/test/Test.hh
@@ -55,6 +55,12 @@ class Test : public ::testing::Test
     // Define coarse epsilon (sqrt typical precision)
 
 #if CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
+    static constexpr double fine_eps = 1e-12;
+#elif CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_FLOAT
+    static constexpr float fine_eps = 1e-6f;
+#endif
+
+#if CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
     static constexpr double coarse_eps = 1e-6;
 #elif CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_FLOAT
     static constexpr float coarse_eps = 1e-3f;

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -148,6 +148,7 @@ celeritas_add_test(em/distribution/TsaiUrbanDistribution.test.cc ${_needs_double
 
 # Cross section calculation
 celeritas_add_test(em/xs/NuclearFormFactors.test.cc)
+celeritas_add_test(em/xs/ScreeningFunctions.test.cc)
 
 # Models
 celeritas_add_test(em/BetheHeitler.test.cc ${_needs_double})

--- a/test/celeritas/em/xs/ScreeningFunctions.test.cc
+++ b/test/celeritas/em/xs/ScreeningFunctions.test.cc
@@ -44,7 +44,7 @@ TEST_F(ScreeningFunctionsTest, all)
 
     for (auto z : all_z)
     {
-        auto cbrt_z = std::cbrt(static_cast<double>(z));
+        auto cbrt_z = std::cbrt(static_cast<real_type>(z));
         auto delta = emass * (100 / cbrt_z);
         auto epsilon = emass * (100 / ipow<2>(cbrt_z));
 
@@ -70,7 +70,7 @@ TEST_F(ScreeningFunctionsTest, all)
         psi1.push_back(std::move(el_psi1));
         dpsi.push_back(std::move(el_dpsi));
     }
-    static std::vector<double> const expected_phi1[] = {
+    static std::vector<real_type> const expected_phi1[] = {
         {-21.783857353441,
          -1.0608479235529,
          17.921623316243,
@@ -92,7 +92,7 @@ TEST_F(ScreeningFunctionsTest, all)
          20.853140248517,
          20.862944498335},
     };
-    static std::vector<double> const expected_dphi[] = {
+    static std::vector<real_type> const expected_dphi[] = {
         {1.404968089095e-10,
          4.4128108010779e-06,
          0.057844334589045,
@@ -114,7 +114,7 @@ TEST_F(ScreeningFunctionsTest, all)
          0.65739936870912,
          0.66661392713376},
     };
-    static std::vector<double> const expected_psi1[] = {
+    static std::vector<real_type> const expected_psi1[] = {
         {-19.395134777263,
          1.3281109201117,
          21.554317398657,
@@ -136,7 +136,7 @@ TEST_F(ScreeningFunctionsTest, all)
          28.310539210367,
          28.339833479292},
     };
-    static std::vector<double> const expected_dpsi[] = {
+    static std::vector<real_type> const expected_dpsi[] = {
         {6.9588767322661e-12,
          2.1980777911256e-07,
          0.0057285675287362,
@@ -159,7 +159,7 @@ TEST_F(ScreeningFunctionsTest, all)
          0.66658936348276},
     };
 
-    EXPECT_VEC_SOFT_EQ(expected_phi1, phi1);
+    EXPECT_VEC_NEAR(expected_phi1, phi1, 10 * fine_eps);
     EXPECT_VEC_SOFT_EQ(expected_dphi, dphi);
     EXPECT_VEC_SOFT_EQ(expected_psi1, psi1);
     EXPECT_VEC_SOFT_EQ(expected_dpsi, dpsi);

--- a/test/celeritas/em/xs/ScreeningFunctions.test.cc
+++ b/test/celeritas/em/xs/ScreeningFunctions.test.cc
@@ -1,0 +1,170 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/em/xs/ScreeningFunctions.test.cc
+//---------------------------------------------------------------------------//
+#include "celeritas/em/xs/ScreeningFunctions.hh"
+
+#include "corecel/grid/VectorUtils.hh"
+#include "celeritas/UnitTypes.hh"
+
+#include "TestMacros.hh"
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+class ScreeningFunctionsTest : public ::celeritas::test::Test
+{
+  protected:
+    void SetUp() override {}
+};
+
+TEST_F(ScreeningFunctionsTest, all)
+{
+    using Mass = units::MevMass;
+    using InvEnergy = RealQuantity<UnitInverse<units::Mev>>;
+
+    // Element abbreviations: C, Al, Fe, W
+    static int const all_z[] = {6, 13, 26, 74};
+    Mass const emass{0.511};
+
+    // Store the results for each element
+    std::vector<std::vector<real_type>> phi1;
+    std::vector<std::vector<real_type>> dphi;
+    std::vector<std::vector<real_type>> psi1;
+    std::vector<std::vector<real_type>> dpsi;
+
+    // Generate a sequence of energies to test
+    auto energies = geomspace(1e-3, 1e6, 5);
+
+    for (auto z : all_z)
+    {
+        auto cbrt_z = std::cbrt(static_cast<double>(z));
+        auto delta = emass * (100 / cbrt_z);
+        auto epsilon = emass * (100 / ipow<2>(cbrt_z));
+
+        TsaiScreeningCalculator calc_screening{delta, epsilon};
+
+        // Initialize vectors for this element
+        std::vector<real_type> el_phi1;
+        std::vector<real_type> el_dphi;
+        std::vector<real_type> el_psi1;
+        std::vector<real_type> el_dpsi;
+
+        for (auto e : energies)
+        {
+            auto f = calc_screening(InvEnergy{static_cast<real_type>(1 / e)});
+
+            el_phi1.push_back(f.phi1);
+            el_dphi.push_back(f.dphi);
+            el_psi1.push_back(f.psi1);
+            el_dpsi.push_back(f.dpsi);
+        }
+        phi1.push_back(std::move(el_phi1));
+        dphi.push_back(std::move(el_dphi));
+        psi1.push_back(std::move(el_psi1));
+        dpsi.push_back(std::move(el_dpsi));
+    }
+    static std::vector<double> const expected_phi1[] = {
+        {-21.783857353441,
+         -1.0608479235529,
+         17.921623316243,
+         20.840250048675,
+         20.862871768052},
+        {-20.752937507931,
+         -0.030100982565447,
+         18.451891110572,
+         20.845409362847,
+         20.862900901554},
+        {-19.828741275161,
+         0.89384311509174,
+         18.86045505191,
+         20.849033068662,
+         20.862921345345},
+        {-18.43411655665,
+         2.2877809333942,
+         19.368224153221,
+         20.853140248517,
+         20.862944498335},
+    };
+    static std::vector<double> const expected_dphi[] = {
+        {1.404968089095e-10,
+         4.4128108010779e-06,
+         0.057844334589045,
+         0.64558504095719,
+         0.66654482631556},
+        {2.3524637671483e-10,
+         7.3740645559725e-06,
+         0.080313479197815,
+         0.65027351743972,
+         0.66657250461478},
+        {3.7342550764018e-10,
+         1.1678849710456e-05,
+         0.10530772357891,
+         0.65359847700402,
+         0.66659192832806},
+        {7.4994863087583e-10,
+         2.3347205149048e-05,
+         0.15183621017018,
+         0.65739936870912,
+         0.66661392713376},
+    };
+    static std::vector<double> const expected_psi1[] = {
+        {-19.395134777263,
+         1.3281109201117,
+         21.554317398657,
+         28.186171200905,
+         28.339111207136},
+        {-17.333295076456,
+         3.3899142968228,
+         23.107550539419,
+         28.247122794382,
+         28.339469156808},
+        {-15.484902597677,
+         5.2382209627956,
+         24.251907855416,
+         28.281137641401,
+         28.339665578296},
+        {-12.695653130839,
+         8.0270389014542,
+         25.558168359864,
+         28.310539210367,
+         28.339833479292},
+    };
+    static std::vector<double> const expected_dpsi[] = {
+        {6.9588767322661e-12,
+         2.1980777911256e-07,
+         0.0057285675287362,
+         0.59892214515549,
+         0.66625416991133},
+        {1.9510125075465e-11,
+         6.1578565252681e-07,
+         0.014226492156761,
+         0.62490787178122,
+         0.66642026688189},
+        {4.9162122093685e-11,
+         1.5499321186881e-06,
+         0.030406389014177,
+         0.63989072947245,
+         0.66651142860458},
+        {1.9829005302547e-10,
+         6.2324110057565e-06,
+         0.083031377928627,
+         0.65312854821131,
+         0.66658936348276},
+    };
+
+    EXPECT_VEC_SOFT_EQ(expected_phi1, phi1);
+    EXPECT_VEC_SOFT_EQ(expected_dphi, dphi);
+    EXPECT_VEC_SOFT_EQ(expected_psi1, psi1);
+    EXPECT_VEC_SOFT_EQ(expected_dpsi, dpsi);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
This moves some screening functions out of the internals of the relative brems calculator. It documents the units, demonstrates exactly what equations the classes implement, and adds testing.