### PR TITLE
Fix table size in physics construction

### DIFF
--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -134,9 +134,9 @@ struct ProcessGroup
     ItemRange<ModelGroup> models;  //!< Model applicability [ppid]
     ItemRange<IntegralXsProcess> integral_xs;  //!< [ppid]
     ItemRange<ValueTable> macro_xs;  //!< [ppid]
-    ValueTableId energy_loss;  //!< Process-integrated energy loss
-    ValueTableId range;  //!< Process-integrated range
-    ValueTableId inverse_range;  //!< Inverse process-integrated range
+    ValueTable energy_loss;  //!< Process-integrated energy loss
+    ValueTable range;  //!< Process-integrated range
+    ValueTable inverse_range;  //!< Inverse process-integrated range
     ParticleProcessId at_rest;  //!< ID of the particle's at-rest process
 
     //! True if assigned and valid

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -56,16 +56,16 @@ struct ValueTable
  *
  * Each material has a set of value grids for its constituent elements; these
  * are used to sample an element from a material when required by a discrete
- * interaction. A null ValueTableId means the material only has a single
- * element, so no cross sections need to be stored. An empty ModelCdfTable
+ * interaction. A null \c ValueTableId means the material only has a single
+ * element, so no cross sections need to be stored. An empty \c ModelCdfTable
  * means no element selection is required for the model.
  */
 struct ModelCdfTable
 {
-    ItemRange<ValueTableId> material;  //!< Value table by material index
+    ItemRange<ValueTable> tables;  //!< Value table by material index
 
     //! True if assigned
-    explicit CELER_FUNCTION operator bool() const { return !material.empty(); }
+    explicit CELER_FUNCTION operator bool() const { return !tables.empty(); }
 };
 
 //---------------------------------------------------------------------------//
@@ -367,7 +367,6 @@ struct PhysicsParamsData
     Items<ValueGridId> value_grid_ids;
     Items<ProcessId> process_ids;
     Items<ValueTable> value_tables;
-    Items<ValueTableId> value_table_ids;
     Items<IntegralXsProcess> integral_xs;
     Items<ModelGroup> model_groups;
     ParticleItems<ProcessGroup> process_groups;
@@ -400,7 +399,6 @@ struct PhysicsParamsData
         value_grid_ids = other.value_grid_ids;
         process_ids = other.process_ids;
         value_tables = other.value_tables;
-        value_table_ids = other.value_table_ids;
         integral_xs = other.integral_xs;
         model_groups = other.model_groups;
         process_groups = other.process_groups;

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -708,7 +708,6 @@ void PhysicsParams::build_model_tables(MaterialParams const& mats,
     XsGridInserter insert(&data->reals, &data->value_grids);
     CollectionBuilder model_cdf(&data->model_cdf);
     CollectionBuilder tables(&data->value_tables);
-    CollectionBuilder table_ids(&data->value_table_ids);
     CollectionBuilder grid_ids(&data->value_grid_ids);
 
     for (auto model_idx : range(this->num_models()))
@@ -718,7 +717,7 @@ void PhysicsParams::build_model_tables(MaterialParams const& mats,
         // Loop over applicable particles
         for (Applicability applic : model.applicability())
         {
-            std::vector<ValueTableId> temp_table_ids(data->model_ids.size());
+            std::vector<ValueTable> temp_tables(data->model_ids.size());
             for (auto mat_id : range(PhysMatId{mats.size()}))
             {
                 // Construct microscopic cross sections
@@ -743,15 +742,13 @@ void PhysicsParams::build_model_tables(MaterialParams const& mats,
                 }
 
                 // Construct table for the material
-                ValueTable table;
-                table.grids = grid_ids.insert_back(temp_grid_ids.begin(),
-                                                   temp_grid_ids.end());
-                temp_table_ids[mat_id.get()] = tables.push_back(table);
+                temp_tables[mat_id.get()].grids = grid_ids.insert_back(
+                    temp_grid_ids.begin(), temp_grid_ids.end());
             }
             // Construct table for the model
             ModelCdfTable cdf;
-            cdf.material = table_ids.insert_back(temp_table_ids.begin(),
-                                                 temp_table_ids.end());
+            cdf.tables
+                = tables.insert_back(temp_tables.begin(), temp_tables.end());
             model_cdf.push_back(cdf);
         }
     }

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -717,7 +717,7 @@ void PhysicsParams::build_model_tables(MaterialParams const& mats,
         // Loop over applicable particles
         for (Applicability applic : model.applicability())
         {
-            std::vector<ValueTable> temp_tables(data->model_ids.size());
+            std::vector<ValueTable> temp_tables(mats.size());
             for (auto mat_id : range(PhysMatId{mats.size()}))
             {
                 // Construct microscopic cross sections

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -529,17 +529,13 @@ void PhysicsParams::build_tables(Options const& opts,
         applic.particle = particle_id;
 
         // Processes for this particle
-        ProcessGroup& process_group = data->process_groups[particle_id];
-        auto process_ids = data->process_ids[process_group.processes];
-        auto model_groups = data->model_groups[process_group.models];
+        ProcessGroup& pg = data->process_groups[particle_id];
+        auto process_ids = data->process_ids[pg.processes];
+        auto model_groups = data->model_groups[pg.models];
         CELER_ASSERT(process_ids.size() == model_groups.size());
 
-        // Material-dependent physics tables, one cross section table per
-        // particle-process and one dedx/range table per particle
+        // Material-dependent cross section tables (one per particle-process)
         std::vector<ValueTable> temp_macro_xs(process_ids.size());
-        ValueTable temp_energy_loss;
-        ValueTable temp_range;
-        ValueTable temp_inv_range;
 
         // Processes with dE/dx and macro xs tables
         std::vector<IntegralXsProcess> temp_integral_xs(process_ids.size());
@@ -578,12 +574,12 @@ void PhysicsParams::build_tables(Options const& opts,
                  * interaction and choose that process in \c
                  * select_discrete_interaction.
                  */
-                CELER_VALIDATE(!process_group.at_rest,
+                CELER_VALIDATE(!pg.at_rest,
                                << "particle ID " << particle_id.get()
                                << " has multiple at-rest processes");
 
                 // Discrete interaction can occur at rest
-                process_group.at_rest = ParticleProcessId(pp_idx);
+                pg.at_rest = ParticleProcessId(pp_idx);
             }
 
             // Loop over materials
@@ -664,23 +660,23 @@ void PhysicsParams::build_tables(Options const& opts,
             if (has_grids(energy_loss_ids))
             {
                 CELER_ASSERT(has_grids(range_ids));
-                CELER_VALIDATE(!temp_energy_loss && !temp_range,
+                CELER_VALIDATE(!pg.energy_loss && !pg.range,
                                << "more than one process for particle ID "
                                << particle_id.get()
                                << " has energy loss tables");
 
-                temp_energy_loss.grids = grid_ids.insert_back(
+                pg.energy_loss.grids = grid_ids.insert_back(
                     energy_loss_ids.begin(), energy_loss_ids.end());
-                CELER_ASSERT(temp_energy_loss.grids.size() == mats.size());
+                CELER_ASSERT(pg.energy_loss.grids.size() == mats.size());
 
-                temp_range.grids
+                pg.range.grids
                     = grid_ids.insert_back(range_ids.begin(), range_ids.end());
-                CELER_ASSERT(temp_range.grids.size() == mats.size());
+                CELER_ASSERT(pg.range.grids.size() == mats.size());
 
-                temp_inv_range.grids = grid_ids.insert_back(
+                pg.inverse_range.grids = grid_ids.insert_back(
                     inv_range_ids.begin(), inv_range_ids.end());
-                CELER_ASSERT(temp_inv_range.grids.size() == mats.size()
-                             || temp_inv_range.grids.empty());
+                CELER_ASSERT(pg.inverse_range.grids.size() == mats.size()
+                             || pg.inverse_range.grids.empty());
             }
 
             // Store the energies of the maximum cross sections
@@ -691,15 +687,12 @@ void PhysicsParams::build_tables(Options const& opts,
             }
         }
         // Construct energy loss process data
-        process_group.integral_xs = integral_xs.insert_back(
-            temp_integral_xs.begin(), temp_integral_xs.end());
+        pg.integral_xs = integral_xs.insert_back(temp_integral_xs.begin(),
+                                                 temp_integral_xs.end());
 
         // Construct value tables
-        process_group.macro_xs
+        pg.macro_xs
             = tables.insert_back(temp_macro_xs.begin(), temp_macro_xs.end());
-        process_group.energy_loss = tables.push_back(temp_energy_loss);
-        process_group.range = tables.push_back(temp_range);
-        process_group.inverse_range = tables.push_back(temp_inv_range);
     }
 }
 

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -529,9 +529,9 @@ void PhysicsParams::build_tables(Options const& opts,
         applic.particle = particle_id;
 
         // Processes for this particle
-        ProcessGroup& pg = data->process_groups[particle_id];
-        auto process_ids = data->process_ids[pg.processes];
-        auto model_groups = data->model_groups[pg.models];
+        ProcessGroup& process_group = data->process_groups[particle_id];
+        auto process_ids = data->process_ids[process_group.processes];
+        auto model_groups = data->model_groups[process_group.models];
         CELER_ASSERT(process_ids.size() == model_groups.size());
 
         // Material-dependent cross section tables (one per particle-process)
@@ -574,12 +574,12 @@ void PhysicsParams::build_tables(Options const& opts,
                  * interaction and choose that process in \c
                  * select_discrete_interaction.
                  */
-                CELER_VALIDATE(!pg.at_rest,
+                CELER_VALIDATE(!process_group.at_rest,
                                << "particle ID " << particle_id.get()
                                << " has multiple at-rest processes");
 
                 // Discrete interaction can occur at rest
-                pg.at_rest = ParticleProcessId(pp_idx);
+                process_group.at_rest = ParticleProcessId(pp_idx);
             }
 
             // Loop over materials
@@ -660,23 +660,25 @@ void PhysicsParams::build_tables(Options const& opts,
             if (has_grids(energy_loss_ids))
             {
                 CELER_ASSERT(has_grids(range_ids));
-                CELER_VALIDATE(!pg.energy_loss && !pg.range,
-                               << "more than one process for particle ID "
-                               << particle_id.get()
-                               << " has energy loss tables");
+                CELER_VALIDATE(
+                    !process_group.energy_loss && !process_group.range,
+                    << "more than one process for particle ID "
+                    << particle_id.get() << " has energy loss tables");
 
-                pg.energy_loss.grids = grid_ids.insert_back(
+                process_group.energy_loss.grids = grid_ids.insert_back(
                     energy_loss_ids.begin(), energy_loss_ids.end());
-                CELER_ASSERT(pg.energy_loss.grids.size() == mats.size());
+                CELER_ASSERT(process_group.energy_loss.grids.size()
+                             == mats.size());
 
-                pg.range.grids
+                process_group.range.grids
                     = grid_ids.insert_back(range_ids.begin(), range_ids.end());
-                CELER_ASSERT(pg.range.grids.size() == mats.size());
+                CELER_ASSERT(process_group.range.grids.size() == mats.size());
 
-                pg.inverse_range.grids = grid_ids.insert_back(
+                process_group.inverse_range.grids = grid_ids.insert_back(
                     inv_range_ids.begin(), inv_range_ids.end());
-                CELER_ASSERT(pg.inverse_range.grids.size() == mats.size()
-                             || pg.inverse_range.grids.empty());
+                CELER_ASSERT(process_group.inverse_range.grids.size()
+                                 == mats.size()
+                             || process_group.inverse_range.grids.empty());
             }
 
             // Store the energies of the maximum cross sections
@@ -687,11 +689,11 @@ void PhysicsParams::build_tables(Options const& opts,
             }
         }
         // Construct energy loss process data
-        pg.integral_xs = integral_xs.insert_back(temp_integral_xs.begin(),
-                                                 temp_integral_xs.end());
+        process_group.integral_xs = integral_xs.insert_back(
+            temp_integral_xs.begin(), temp_integral_xs.end());
 
         // Construct value tables
-        pg.macro_xs
+        process_group.macro_xs
             = tables.insert_back(temp_macro_xs.begin(), temp_macro_xs.end());
     }
 }

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -183,7 +183,7 @@ class PhysicsTrackView
     CELER_FORCEINLINE_FUNCTION PhysicsTrackState& state();
     CELER_FORCEINLINE_FUNCTION PhysicsTrackState const& state() const;
     CELER_FORCEINLINE_FUNCTION ProcessGroup const& process_group() const;
-    inline CELER_FUNCTION ValueGridId value_grid(ValueTableId) const;
+    inline CELER_FUNCTION ValueGridId value_grid(ValueTable const&) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -345,7 +345,9 @@ CELER_FUNCTION auto
 PhysicsTrackView::macro_xs_grid(ParticleProcessId ppid) const -> ValueGridId
 {
     CELER_EXPECT(ppid < this->num_particle_processes());
-    return this->value_grid(this->process_group().macro_xs[ppid.get()]);
+    auto table_id = this->process_group().macro_xs[ppid.get()];
+    CELER_ASSERT(table_id);
+    return this->value_grid(params_.value_tables[table_id]);
 }
 
 //---------------------------------------------------------------------------//
@@ -727,12 +729,9 @@ CELER_FUNCTION T PhysicsTrackView::make_calculator(ValueGridId id) const
  * associated value (e.g. if the table type is "energy_loss" and the process is
  * not a slowing-down process).
  */
-CELER_FUNCTION auto PhysicsTrackView::value_grid(ValueTableId table_id) const
+CELER_FUNCTION auto PhysicsTrackView::value_grid(ValueTable const& table) const
     -> ValueGridId
 {
-    CELER_EXPECT(table_id);
-
-    ValueTable const& table = params_.value_tables[table_id];
     if (!table)
         return {};  // No table for this process
 

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -551,19 +551,24 @@ ValueTableId PhysicsTrackView::value_table(ParticleModelId pmid) const
 {
     CELER_EXPECT(pmid < params_.model_cdf.size());
 
-    // Get the model xs table for the given particle/model
+    // Get the CDF table for the given particle and model
     ModelCdfTable const& model_cdf = params_.model_cdf[pmid];
     if (!model_cdf)
-        return {};  // No tables stored for this model
+    {
+        // No tables stored for this model
+        return {};
+    }
 
-    // Get the value table for the current material
-    CELER_ASSERT(material_ < model_cdf.material.size());
-    auto const& table_id_ref = model_cdf.material[material_.get()];
-    if (!table_id_ref)
-        return {};  // Only one element in this material
-
-    CELER_ASSERT(table_id_ref < params_.value_table_ids.size());
-    return params_.value_table_ids[table_id_ref];
+    // Get the value table ID for the current material
+    CELER_ASSERT(material_ < model_cdf.tables.size());
+    auto table_id = model_cdf.tables[material_.get()];
+    CELER_ASSERT(table_id < params_.value_tables.size());
+    if (!params_.value_tables[table_id])
+    {
+        // No tables stored for this material
+        return {};
+    }
+    return table_id;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -147,7 +147,7 @@ TEST_F(PhysicsParamsTest, output)
     auto j = nlohmann::json::parse(to_string(out));
     j["sizes"].erase("reals");
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":34}})json",
+        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":19}})json",
         j.dump());
 }
 

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -147,7 +147,7 @@ TEST_F(PhysicsParamsTest, output)
     auto j = nlohmann::json::parse(to_string(out));
     j["sizes"].erase("reals");
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":19}})json",
+        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":129}})json",
         j.dump());
 }
 

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -147,7 +147,7 @@ TEST_F(PhysicsParamsTest, output)
     auto j = nlohmann::json::parse(to_string(out));
     j["sizes"].erase("reals");
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":129}})json",
+        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":52}})json",
         j.dump());
 }
 


### PR DESCRIPTION
This fixes the incorrect sizing of the model CDF table in the physics construction. It also reduces the complexity of the physics data/construction a bit by removing explicit storage of value table IDs.