### PR TITLE
Use correct types for physics grids

### DIFF
--- a/src/celeritas/Types.hh
+++ b/src/celeritas/Types.hh
@@ -80,6 +80,12 @@ using ParticleModelId = OpaqueId<ModelId>;
 //! Opaque index of electron subshell
 using SubshellId = OpaqueId<struct Subshell_>;
 
+//! Opaque index of a uniform grid
+using UniformGridId = OpaqueId<struct UniformGridRecord>;
+
+//! Opaque index of a cross section grid
+using XsGridId = OpaqueId<struct XsGridRecord>;
+
 //---------------------------------------------------------------------------//
 // ENUMERATIONS
 //---------------------------------------------------------------------------//

--- a/src/celeritas/grid/ElementCdfCalculator.cc
+++ b/src/celeritas/grid/ElementCdfCalculator.cc
@@ -28,17 +28,17 @@ void ElementCdfCalculator::operator()(XsTable& grids)
 {
     CELER_EXPECT(grids.size() == elements_.size());
     CELER_EXPECT(std::all_of(grids.begin(), grids.end(), [](auto const& g) {
-        return g.lower && !g.upper;
+        return static_cast<bool>(g);
     }));
 
     // Outer loop over energy: the energy grid is the same for each element
-    for (auto i : range(grids.front().lower.y.size()))
+    for (auto i : range(grids.front().y.size()))
     {
         // Calculate the CDF in place
         double accum{0};
         for (auto j : range(elements_.size()))
         {
-            auto& value = grids[j].lower.y[i];
+            auto& value = grids[j].y[i];
             accum += value * elements_[j].fraction;
             value = accum;
         }
@@ -48,9 +48,9 @@ void ElementCdfCalculator::operator()(XsTable& grids)
             double norm = 1 / accum;
             for (auto j : range(elements_.size() - 1))
             {
-                grids[j].lower.y[i] *= norm;
+                grids[j].y[i] *= norm;
             }
-            grids.back().lower.y[i] = 1;
+            grids.back().y[i] = 1;
         }
     }
 }

--- a/src/celeritas/grid/EnergyLossCalculator.hh
+++ b/src/celeritas/grid/EnergyLossCalculator.hh
@@ -6,7 +6,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "XsCalculator.hh"
+#include "SplineCalculator.hh"
+#include "UniformLogGridCalculator.hh"
 
 namespace celeritas
 {
@@ -16,7 +17,56 @@ namespace celeritas
  *
  * The return value is [MeV / len] but isn't wrapped with a Quantity.
  */
-using EnergyLossCalculator = XsCalculator;
+class EnergyLossCalculator
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Energy = units::MevEnergy;
+    using Values
+        = Collection<real_type, Ownership::const_reference, MemSpace::native>;
+    //!@}
+
+    // Construct from state-independent data
+    inline CELER_FUNCTION
+    EnergyLossCalculator(UniformGridRecord const& grid, Values const& reals);
+
+    // Find and interpolate from the energy
+    inline CELER_FUNCTION real_type operator()(Energy energy) const;
+
+  private:
+    UniformGridRecord const& data_;
+    Values const& reals_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from cross section data.
+ */
+CELER_FUNCTION
+EnergyLossCalculator::EnergyLossCalculator(UniformGridRecord const& grid,
+                                           Values const& reals)
+    : data_(grid), reals_(reals)
+{
+    CELER_EXPECT(data_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the cross section using linear or spline interpolation.
+ */
+CELER_FUNCTION real_type EnergyLossCalculator::operator()(Energy energy) const
+{
+    if (data_.spline_order != 1)
+    {
+        // Spline interpolation without continuous derivatives
+        return SplineCalculator(data_, reals_)(energy);
+    }
+    // Linear or cubic spline interpolation
+    return UniformLogGridCalculator(data_, reals_)(energy);
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/grid/InverseRangeCalculator.hh
+++ b/src/celeritas/grid/InverseRangeCalculator.hh
@@ -14,10 +14,10 @@
 #include "corecel/grid/NonuniformGrid.hh"
 #include "corecel/grid/SplineInterpolator.hh"
 #include "corecel/grid/UniformGrid.hh"
+#include "corecel/grid/UniformGridData.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/Quantity.hh"
-
-#include "XsGridData.hh"
+#include "celeritas/Quantities.hh"
 
 namespace celeritas
 {
@@ -46,15 +46,15 @@ class InverseRangeCalculator
   public:
     //!@{
     //! \name Type aliases
-    using Energy = RealQuantity<XsGridRecord::EnergyUnits>;
+    using Energy = units::MevEnergy;
     using Values
         = Collection<real_type, Ownership::const_reference, MemSpace::native>;
     //!@}
 
   public:
     // Construct from state-independent data
-    inline CELER_FUNCTION
-    InverseRangeCalculator(XsGridRecord const& grid, Values const& values);
+    inline CELER_FUNCTION InverseRangeCalculator(UniformGridRecord const& grid,
+                                                 Values const& values);
 
     // Find and interpolate from the energy
     inline CELER_FUNCTION Energy operator()(real_type range) const;
@@ -75,14 +75,13 @@ class InverseRangeCalculator
  * Lower-energy particles have shorter ranges.
  */
 CELER_FUNCTION
-InverseRangeCalculator::InverseRangeCalculator(XsGridRecord const& grid,
+InverseRangeCalculator::InverseRangeCalculator(UniformGridRecord const& grid,
                                                Values const& values)
-    : log_energy_(grid.lower.grid)
-    , range_(grid.lower.value, values)
-    , deriv_(values[grid.lower.derivative])
+    : log_energy_(grid.grid)
+    , range_(grid.value, values)
+    , deriv_(values[grid.derivative])
 {
     CELER_EXPECT(range_.size() == log_energy_.size());
-    CELER_EXPECT(!grid.upper);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/grid/RangeCalculator.hh
+++ b/src/celeritas/grid/RangeCalculator.hh
@@ -12,9 +12,9 @@
 #include "corecel/grid/Interpolator.hh"
 #include "corecel/grid/SplineInterpolator.hh"
 #include "corecel/grid/UniformGrid.hh"
+#include "corecel/grid/UniformGridData.hh"
 #include "corecel/math/Quantity.hh"
-
-#include "XsGridData.hh"
+#include "celeritas/Quantities.hh"
 
 namespace celeritas
 {
@@ -39,7 +39,7 @@ class RangeCalculator
   public:
     //!@{
     //! \name Type aliases
-    using Energy = RealQuantity<XsGridRecord::EnergyUnits>;
+    using Energy = units::MevEnergy;
     using Values
         = Collection<real_type, Ownership::const_reference, MemSpace::native>;
     //!@}
@@ -47,7 +47,7 @@ class RangeCalculator
   public:
     // Construct from state-independent data
     inline CELER_FUNCTION
-    RangeCalculator(XsGridRecord const& grid, Values const& values);
+    RangeCalculator(UniformGridRecord const& grid, Values const& values);
 
     // Find and interpolate from the energy
     inline CELER_FUNCTION real_type operator()(Energy energy) const;
@@ -68,11 +68,11 @@ class RangeCalculator
  * Range tables should be uniform in energy, without extra scaling.
  */
 CELER_FUNCTION
-RangeCalculator::RangeCalculator(XsGridRecord const& grid, Values const& values)
-    : data_(grid.lower), reals_(values)
+RangeCalculator::RangeCalculator(UniformGridRecord const& grid,
+                                 Values const& values)
+    : data_(grid), reals_(values)
 {
     CELER_EXPECT(data_);
-    CELER_EXPECT(!grid.upper);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/ImportedModelAdapter.cc
+++ b/src/celeritas/phys/ImportedModelAdapter.cc
@@ -88,7 +88,7 @@ auto ImportedModelAdapter::micro_xs(Applicability applic) const -> XsTable
         auto grid = imm.micro_xs[elcomp_idx];
         CELER_ASSERT(grid);
         CELER_ASSERT(std::exp(grid.x[Bound::lo]) > 0 && grid.y.size() >= 2);
-        grids[elcomp_idx].lower = std::move(grid);
+        grids[elcomp_idx] = std::move(grid);
     }
     return grids;
 }

--- a/src/celeritas/phys/ImportedProcessAdapter.cc
+++ b/src/celeritas/phys/ImportedProcessAdapter.cc
@@ -240,7 +240,7 @@ auto ImportedProcessAdapter::energy_loss(Applicability const& applic) const
         auto grid = import_process.dedx.grids[applic.material.get()];
         CELER_ASSERT(grid);
         CELER_ASSERT(std::exp(grid.x[Bound::lo]) > 0 && grid.y.size() >= 2);
-        result.lower = std::move(grid);
+        result = std::move(grid);
     }
     return result;
 }

--- a/src/celeritas/phys/Model.hh
+++ b/src/celeritas/phys/Model.hh
@@ -44,15 +44,13 @@ namespace celeritas
  *
  * This class is similar to Geant4's G4VContinuousDiscrete process, but more
  * limited.
- *
- * \todo Microscopic cross sections should use a \c UniformGrid
  */
 class Model : public CoreStepActionInterface
 {
   public:
     //@{
     //! Type aliases
-    using XsTable = std::vector<inp::XsGrid>;
+    using XsTable = std::vector<inp::UniformGrid>;
     using SetApplicability = std::set<Applicability>;
     //@}
 

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -134,9 +134,9 @@ struct ProcessGroup
     ItemRange<ModelGroup> models;  //!< Model applicability [ppid]
     ItemRange<IntegralXsProcess> integral_xs;  //!< [ppid]
     ItemRange<ValueTable> macro_xs;  //!< [ppid]
-    ValueTableId energy_loss;  //!< Process-integrated energy loss
-    ValueTableId range;  //!< Process-integrated range
-    ValueTableId inverse_range;  //!< Inverse process-integrated range
+    ValueTable energy_loss;  //!< Process-integrated energy loss
+    ValueTable range;  //!< Process-integrated range
+    ValueTable inverse_range;  //!< Inverse process-integrated range
     ParticleProcessId at_rest;  //!< ID of the particle's at-rest process
 
     //! True if assigned and valid

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -56,16 +56,16 @@ struct ValueTable
  *
  * Each material has a set of value grids for its constituent elements; these
  * are used to sample an element from a material when required by a discrete
- * interaction. A null ValueTableId means the material only has a single
- * element, so no cross sections need to be stored. An empty ModelCdfTable
+ * interaction. A null \c ValueTableId means the material only has a single
+ * element, so no cross sections need to be stored. An empty \c ModelCdfTable
  * means no element selection is required for the model.
  */
 struct ModelCdfTable
 {
-    ItemRange<ValueTableId> material;  //!< Value table by material index
+    ItemRange<ValueTable> tables;  //!< Value table by material index
 
     //! True if assigned
-    explicit CELER_FUNCTION operator bool() const { return !material.empty(); }
+    explicit CELER_FUNCTION operator bool() const { return !tables.empty(); }
 };
 
 //---------------------------------------------------------------------------//
@@ -367,7 +367,6 @@ struct PhysicsParamsData
     Items<ValueGridId> value_grid_ids;
     Items<ProcessId> process_ids;
     Items<ValueTable> value_tables;
-    Items<ValueTableId> value_table_ids;
     Items<IntegralXsProcess> integral_xs;
     Items<ModelGroup> model_groups;
     ParticleItems<ProcessGroup> process_groups;
@@ -400,7 +399,6 @@ struct PhysicsParamsData
         value_grid_ids = other.value_grid_ids;
         process_ids = other.process_ids;
         value_tables = other.value_tables;
-        value_table_ids = other.value_table_ids;
         integral_xs = other.integral_xs;
         model_groups = other.model_groups;
         process_groups = other.process_groups;

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -708,7 +708,6 @@ void PhysicsParams::build_model_tables(MaterialParams const& mats,
     XsGridInserter insert(&data->reals, &data->value_grids);
     CollectionBuilder model_cdf(&data->model_cdf);
     CollectionBuilder tables(&data->value_tables);
-    CollectionBuilder table_ids(&data->value_table_ids);
     CollectionBuilder grid_ids(&data->value_grid_ids);
 
     for (auto model_idx : range(this->num_models()))
@@ -718,7 +717,7 @@ void PhysicsParams::build_model_tables(MaterialParams const& mats,
         // Loop over applicable particles
         for (Applicability applic : model.applicability())
         {
-            std::vector<ValueTableId> temp_table_ids(data->model_ids.size());
+            std::vector<ValueTable> temp_tables(data->model_ids.size());
             for (auto mat_id : range(PhysMatId{mats.size()}))
             {
                 // Construct microscopic cross sections
@@ -743,15 +742,13 @@ void PhysicsParams::build_model_tables(MaterialParams const& mats,
                 }
 
                 // Construct table for the material
-                ValueTable table;
-                table.grids = grid_ids.insert_back(temp_grid_ids.begin(),
-                                                   temp_grid_ids.end());
-                temp_table_ids[mat_id.get()] = tables.push_back(table);
+                temp_tables[mat_id.get()].grids = grid_ids.insert_back(
+                    temp_grid_ids.begin(), temp_grid_ids.end());
             }
             // Construct table for the model
             ModelCdfTable cdf;
-            cdf.material = table_ids.insert_back(temp_table_ids.begin(),
-                                                 temp_table_ids.end());
+            cdf.tables
+                = tables.insert_back(temp_tables.begin(), temp_tables.end());
             model_cdf.push_back(cdf);
         }
     }

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -717,7 +717,7 @@ void PhysicsParams::build_model_tables(MaterialParams const& mats,
         // Loop over applicable particles
         for (Applicability applic : model.applicability())
         {
-            std::vector<ValueTable> temp_tables(data->model_ids.size());
+            std::vector<ValueTable> temp_tables(mats.size());
             for (auto mat_id : range(PhysMatId{mats.size()}))
             {
                 // Construct microscopic cross sections

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -529,17 +529,13 @@ void PhysicsParams::build_tables(Options const& opts,
         applic.particle = particle_id;
 
         // Processes for this particle
-        ProcessGroup& process_group = data->process_groups[particle_id];
-        auto process_ids = data->process_ids[process_group.processes];
-        auto model_groups = data->model_groups[process_group.models];
+        ProcessGroup& pg = data->process_groups[particle_id];
+        auto process_ids = data->process_ids[pg.processes];
+        auto model_groups = data->model_groups[pg.models];
         CELER_ASSERT(process_ids.size() == model_groups.size());
 
-        // Material-dependent physics tables, one cross section table per
-        // particle-process and one dedx/range table per particle
+        // Material-dependent cross section tables (one per particle-process)
         std::vector<ValueTable> temp_macro_xs(process_ids.size());
-        ValueTable temp_energy_loss;
-        ValueTable temp_range;
-        ValueTable temp_inv_range;
 
         // Processes with dE/dx and macro xs tables
         std::vector<IntegralXsProcess> temp_integral_xs(process_ids.size());
@@ -578,12 +574,12 @@ void PhysicsParams::build_tables(Options const& opts,
                  * interaction and choose that process in \c
                  * select_discrete_interaction.
                  */
-                CELER_VALIDATE(!process_group.at_rest,
+                CELER_VALIDATE(!pg.at_rest,
                                << "particle ID " << particle_id.get()
                                << " has multiple at-rest processes");
 
                 // Discrete interaction can occur at rest
-                process_group.at_rest = ParticleProcessId(pp_idx);
+                pg.at_rest = ParticleProcessId(pp_idx);
             }
 
             // Loop over materials
@@ -664,23 +660,23 @@ void PhysicsParams::build_tables(Options const& opts,
             if (has_grids(energy_loss_ids))
             {
                 CELER_ASSERT(has_grids(range_ids));
-                CELER_VALIDATE(!temp_energy_loss && !temp_range,
+                CELER_VALIDATE(!pg.energy_loss && !pg.range,
                                << "more than one process for particle ID "
                                << particle_id.get()
                                << " has energy loss tables");
 
-                temp_energy_loss.grids = grid_ids.insert_back(
+                pg.energy_loss.grids = grid_ids.insert_back(
                     energy_loss_ids.begin(), energy_loss_ids.end());
-                CELER_ASSERT(temp_energy_loss.grids.size() == mats.size());
+                CELER_ASSERT(pg.energy_loss.grids.size() == mats.size());
 
-                temp_range.grids
+                pg.range.grids
                     = grid_ids.insert_back(range_ids.begin(), range_ids.end());
-                CELER_ASSERT(temp_range.grids.size() == mats.size());
+                CELER_ASSERT(pg.range.grids.size() == mats.size());
 
-                temp_inv_range.grids = grid_ids.insert_back(
+                pg.inverse_range.grids = grid_ids.insert_back(
                     inv_range_ids.begin(), inv_range_ids.end());
-                CELER_ASSERT(temp_inv_range.grids.size() == mats.size()
-                             || temp_inv_range.grids.empty());
+                CELER_ASSERT(pg.inverse_range.grids.size() == mats.size()
+                             || pg.inverse_range.grids.empty());
             }
 
             // Store the energies of the maximum cross sections
@@ -691,15 +687,12 @@ void PhysicsParams::build_tables(Options const& opts,
             }
         }
         // Construct energy loss process data
-        process_group.integral_xs = integral_xs.insert_back(
-            temp_integral_xs.begin(), temp_integral_xs.end());
+        pg.integral_xs = integral_xs.insert_back(temp_integral_xs.begin(),
+                                                 temp_integral_xs.end());
 
         // Construct value tables
-        process_group.macro_xs
+        pg.macro_xs
             = tables.insert_back(temp_macro_xs.begin(), temp_macro_xs.end());
-        process_group.energy_loss = tables.push_back(temp_energy_loss);
-        process_group.range = tables.push_back(temp_range);
-        process_group.inverse_range = tables.push_back(temp_inv_range);
     }
 }
 

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -529,9 +529,9 @@ void PhysicsParams::build_tables(Options const& opts,
         applic.particle = particle_id;
 
         // Processes for this particle
-        ProcessGroup& pg = data->process_groups[particle_id];
-        auto process_ids = data->process_ids[pg.processes];
-        auto model_groups = data->model_groups[pg.models];
+        ProcessGroup& process_group = data->process_groups[particle_id];
+        auto process_ids = data->process_ids[process_group.processes];
+        auto model_groups = data->model_groups[process_group.models];
         CELER_ASSERT(process_ids.size() == model_groups.size());
 
         // Material-dependent cross section tables (one per particle-process)
@@ -574,12 +574,12 @@ void PhysicsParams::build_tables(Options const& opts,
                  * interaction and choose that process in \c
                  * select_discrete_interaction.
                  */
-                CELER_VALIDATE(!pg.at_rest,
+                CELER_VALIDATE(!process_group.at_rest,
                                << "particle ID " << particle_id.get()
                                << " has multiple at-rest processes");
 
                 // Discrete interaction can occur at rest
-                pg.at_rest = ParticleProcessId(pp_idx);
+                process_group.at_rest = ParticleProcessId(pp_idx);
             }
 
             // Loop over materials
@@ -660,23 +660,25 @@ void PhysicsParams::build_tables(Options const& opts,
             if (has_grids(energy_loss_ids))
             {
                 CELER_ASSERT(has_grids(range_ids));
-                CELER_VALIDATE(!pg.energy_loss && !pg.range,
-                               << "more than one process for particle ID "
-                               << particle_id.get()
-                               << " has energy loss tables");
+                CELER_VALIDATE(
+                    !process_group.energy_loss && !process_group.range,
+                    << "more than one process for particle ID "
+                    << particle_id.get() << " has energy loss tables");
 
-                pg.energy_loss.grids = grid_ids.insert_back(
+                process_group.energy_loss.grids = grid_ids.insert_back(
                     energy_loss_ids.begin(), energy_loss_ids.end());
-                CELER_ASSERT(pg.energy_loss.grids.size() == mats.size());
+                CELER_ASSERT(process_group.energy_loss.grids.size()
+                             == mats.size());
 
-                pg.range.grids
+                process_group.range.grids
                     = grid_ids.insert_back(range_ids.begin(), range_ids.end());
-                CELER_ASSERT(pg.range.grids.size() == mats.size());
+                CELER_ASSERT(process_group.range.grids.size() == mats.size());
 
-                pg.inverse_range.grids = grid_ids.insert_back(
+                process_group.inverse_range.grids = grid_ids.insert_back(
                     inv_range_ids.begin(), inv_range_ids.end());
-                CELER_ASSERT(pg.inverse_range.grids.size() == mats.size()
-                             || pg.inverse_range.grids.empty());
+                CELER_ASSERT(process_group.inverse_range.grids.size()
+                                 == mats.size()
+                             || process_group.inverse_range.grids.empty());
             }
 
             // Store the energies of the maximum cross sections
@@ -687,11 +689,11 @@ void PhysicsParams::build_tables(Options const& opts,
             }
         }
         // Construct energy loss process data
-        pg.integral_xs = integral_xs.insert_back(temp_integral_xs.begin(),
-                                                 temp_integral_xs.end());
+        process_group.integral_xs = integral_xs.insert_back(
+            temp_integral_xs.begin(), temp_integral_xs.end());
 
         // Construct value tables
-        pg.macro_xs
+        process_group.macro_xs
             = tables.insert_back(temp_macro_xs.begin(), temp_macro_xs.end());
     }
 }

--- a/src/celeritas/phys/PhysicsParamsOutput.cc
+++ b/src/celeritas/phys/PhysicsParamsOutput.cc
@@ -99,10 +99,13 @@ void PhysicsParamsOutput::output(JsonPimpl* j) const
 #define PPO_SAVE_SIZE(NAME) sizes[#NAME] = data.NAME.size()
         PPO_SAVE_SIZE(reals);
         PPO_SAVE_SIZE(model_ids);
-        PPO_SAVE_SIZE(value_grids);
-        PPO_SAVE_SIZE(value_grid_ids);
+        PPO_SAVE_SIZE(xs_grids);
+        PPO_SAVE_SIZE(xs_grid_ids);
+        PPO_SAVE_SIZE(xs_tables);
+        PPO_SAVE_SIZE(uniform_grids);
+        PPO_SAVE_SIZE(uniform_grid_ids);
+        PPO_SAVE_SIZE(uniform_tables);
         PPO_SAVE_SIZE(process_ids);
-        PPO_SAVE_SIZE(value_tables);
         PPO_SAVE_SIZE(integral_xs);
         PPO_SAVE_SIZE(model_groups);
         PPO_SAVE_SIZE(process_groups);

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -231,9 +231,6 @@ calc_mean_energy_loss(ParticleTrackView const& particle,
 {
     CELER_EXPECT(step > 0);
     using Energy = ParticleTrackView::Energy;
-    static_assert(Energy::unit_type::value()
-                      == EnergyLossCalculator::Energy::unit_type::value(),
-                  "Incompatible energy types");
 
     Energy const pre_step_energy = particle.energy();
 
@@ -243,7 +240,8 @@ calc_mean_energy_loss(ParticleTrackView const& particle,
         auto grid_id = physics.energy_loss_grid();
         CELER_ASSERT(grid_id);
 
-        auto calc_eloss_rate = physics.make_calculator<XsCalculator>(grid_id);
+        auto calc_eloss_rate
+            = physics.make_calculator<EnergyLossCalculator>(grid_id);
         eloss = Energy{step * calc_eloss_rate(pre_step_energy)};
     }
 
@@ -330,7 +328,7 @@ select_discrete_interaction(MaterialView const& material,
     {
         elcomp_id = ElementComponentId{0};
     }
-    else if (auto table_id = physics.value_table(pmid))
+    else if (auto table_id = physics.cdf_table(pmid))
     {
         // Sample an element for discrete interactions that require it and for
         // materials with more than one element

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -183,7 +183,7 @@ class PhysicsTrackView
     CELER_FORCEINLINE_FUNCTION PhysicsTrackState& state();
     CELER_FORCEINLINE_FUNCTION PhysicsTrackState const& state() const;
     CELER_FORCEINLINE_FUNCTION ProcessGroup const& process_group() const;
-    inline CELER_FUNCTION ValueGridId value_grid(ValueTableId) const;
+    inline CELER_FUNCTION ValueGridId value_grid(ValueTable const&) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -345,7 +345,9 @@ CELER_FUNCTION auto
 PhysicsTrackView::macro_xs_grid(ParticleProcessId ppid) const -> ValueGridId
 {
     CELER_EXPECT(ppid < this->num_particle_processes());
-    return this->value_grid(this->process_group().macro_xs[ppid.get()]);
+    auto table_id = this->process_group().macro_xs[ppid.get()];
+    CELER_ASSERT(table_id);
+    return this->value_grid(params_.value_tables[table_id]);
 }
 
 //---------------------------------------------------------------------------//
@@ -727,12 +729,9 @@ CELER_FUNCTION T PhysicsTrackView::make_calculator(ValueGridId id) const
  * associated value (e.g. if the table type is "energy_loss" and the process is
  * not a slowing-down process).
  */
-CELER_FUNCTION auto PhysicsTrackView::value_grid(ValueTableId table_id) const
+CELER_FUNCTION auto PhysicsTrackView::value_grid(ValueTable const& table) const
     -> ValueGridId
 {
-    CELER_EXPECT(table_id);
-
-    ValueTable const& table = params_.value_tables[table_id];
     if (!table)
         return {};  // No table for this process
 

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -551,19 +551,24 @@ ValueTableId PhysicsTrackView::value_table(ParticleModelId pmid) const
 {
     CELER_EXPECT(pmid < params_.model_cdf.size());
 
-    // Get the model xs table for the given particle/model
+    // Get the CDF table for the given particle and model
     ModelCdfTable const& model_cdf = params_.model_cdf[pmid];
     if (!model_cdf)
-        return {};  // No tables stored for this model
+    {
+        // No tables stored for this model
+        return {};
+    }
 
-    // Get the value table for the current material
-    CELER_ASSERT(material_ < model_cdf.material.size());
-    auto const& table_id_ref = model_cdf.material[material_.get()];
-    if (!table_id_ref)
-        return {};  // Only one element in this material
-
-    CELER_ASSERT(table_id_ref < params_.value_table_ids.size());
-    return params_.value_table_ids[table_id_ref];
+    // Get the value table ID for the current material
+    CELER_ASSERT(material_ < model_cdf.tables.size());
+    auto table_id = model_cdf.tables[material_.get()];
+    CELER_ASSERT(table_id < params_.value_tables.size());
+    if (!params_.value_tables[table_id])
+    {
+        // No tables stored for this material
+        return {};
+    }
+    return table_id;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/Process.hh
+++ b/src/celeritas/phys/Process.hh
@@ -32,8 +32,6 @@ class Model;
  *
  * Each process has an interaction ("post step doit") and may have both energy
  * loss and range limiters.
- *
- * \todo energy loss should use a \c UniformGrid
  */
 class Process
 {
@@ -44,7 +42,7 @@ class Process
     using VecModel = std::vector<SPConstModel>;
     using ActionIdIter = RangeIter<ActionId>;
     using XsGrid = inp::XsGrid;
-    using EnergyLossGrid = inp::XsGrid;
+    using EnergyLossGrid = inp::UniformGrid;
     //!@}
 
   public:

--- a/test/celeritas/grid/CalculatorTestBase.cc
+++ b/test/celeritas/grid/CalculatorTestBase.cc
@@ -20,16 +20,16 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct from grid bounds and cross section values.
+ * Construct a cross section grid.
  */
-void CalculatorTestBase::build(inp::UniformGrid lower, inp::UniformGrid upper)
+void CalculatorTestBase::build(inp::XsGrid grid)
 {
-    return this->build_impl(lower, upper, false);
+    return this->build_impl(grid.lower, grid.upper, false);
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct without scaled values.
+ * Construct a uniform grid.
  */
 void CalculatorTestBase::build(inp::UniformGrid grid)
 {
@@ -38,7 +38,7 @@ void CalculatorTestBase::build(inp::UniformGrid grid)
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct an inverted grid.
+ * Construct an inverted uniform grid.
  */
 void CalculatorTestBase::build_inverted(inp::UniformGrid grid)
 {

--- a/test/celeritas/grid/CalculatorTestBase.hh
+++ b/test/celeritas/grid/CalculatorTestBase.hh
@@ -37,16 +37,17 @@ class CalculatorTestBase : public Test
     //!@}
 
   public:
-    // Construct from grid bounds and cross section values
-    void build(inp::UniformGrid lower, inp::UniformGrid upper);
+    // Construct a cross section grid
+    void build(inp::XsGrid grid);
 
-    // Construct without scaled values
+    // Construct a uniform grid
     void build(inp::UniformGrid grid);
 
-    // Construct inverted grid
+    // Construct an inverted uniform grid
     void build_inverted(inp::UniformGrid grid);
 
-    XsGridRecord const& data() const { return data_; }
+    XsGridRecord const& xs_grid() const { return data_; }
+    UniformGridRecord const& uniform_grid() const { return data_.lower; }
     Data const& values() const { return value_ref_; }
 
   private:

--- a/test/celeritas/grid/ElementCdfCalculator.test.cc
+++ b/test/celeritas/grid/ElementCdfCalculator.test.cc
@@ -42,22 +42,22 @@ class ElementCdfCalculatorTest : public Test
         grids = XsTable(xs.size());
         for (auto i : range(grids.size()))
         {
-            grids[i].lower.x = {0, 1e3};
-            grids[i].lower.y = xs[i];
+            grids[i].x = {0, 1e3};
+            grids[i].y = xs[i];
         }
     }
 
     //! Get the CDF values indexed as [energy][element]
     VecVecDbl get_cdf(XsTable const& cdf)
     {
-        auto grid_size = cdf.front().lower.y.size();
+        auto grid_size = cdf.front().y.size();
         VecVecDbl result(grid_size);
         for (auto i : range(grid_size))
         {
             result[i].resize(cdf.size());
             for (auto j : range(cdf.size()))
             {
-                result[i][j] = cdf[j].lower.y[i];
+                result[i][j] = cdf[j].y[i];
             }
         }
         return result;

--- a/test/celeritas/grid/InverseRangeCalculator.test.cc
+++ b/test/celeritas/grid/InverseRangeCalculator.test.cc
@@ -35,7 +35,7 @@ TEST_F(InverseRangeCalculatorTest, simple)
     grid.y = {0.5, 5, 50, 500};
     this->build(grid);
 
-    InverseRangeCalculator calc_energy(this->data(), this->values());
+    InverseRangeCalculator calc_energy(this->uniform_grid(), this->values());
 
     // Values below should be scaled below emin
     EXPECT_SOFT_EQ(1.0, calc_energy(.5 * std::sqrt(1. / 10.)).value());
@@ -91,7 +91,8 @@ TEST_F(InverseRangeCalculatorTest, interpolation)
         };
 
         this->build(grid);
-        InverseRangeCalculator calc_energy(this->data(), this->values());
+        InverseRangeCalculator calc_energy(this->uniform_grid(),
+                                           this->values());
         for (size_type i = 0; i < range.size(); ++i)
         {
             EXPECT_SOFT_NEAR(
@@ -99,7 +100,7 @@ TEST_F(InverseRangeCalculatorTest, interpolation)
         }
 
         // Linear interpolation is invertible
-        RangeCalculator calc_range(this->data(), this->values());
+        RangeCalculator calc_range(this->uniform_grid(), this->values());
         for (size_type i = 0; i < range.size(); ++i)
         {
             EXPECT_SOFT_NEAR(range[i], calc_range(Energy(energy[i])), tol);
@@ -121,7 +122,8 @@ TEST_F(InverseRangeCalculatorTest, interpolation)
         };
 
         this->build_inverted(grid);
-        InverseRangeCalculator calc_energy(this->data(), this->values());
+        InverseRangeCalculator calc_energy(this->uniform_grid(),
+                                           this->values());
         for (size_type i = 0; i < range.size(); ++i)
         {
             EXPECT_SOFT_EQ(energy[i], value_as<Energy>(calc_energy(range[i])));
@@ -139,7 +141,7 @@ TEST_F(InverseRangeCalculatorTest, interpolation)
         };
 
         this->build(grid);
-        RangeCalculator calc_range(this->data(), this->values());
+        RangeCalculator calc_range(this->uniform_grid(), this->values());
         for (size_type i = 0; i < range.size(); ++i)
         {
             EXPECT_SOFT_EQ(roundtrip_range[i], calc_range(Energy(energy[i])));

--- a/test/celeritas/grid/RangeCalculator.test.cc
+++ b/test/celeritas/grid/RangeCalculator.test.cc
@@ -32,7 +32,7 @@ class RangeCalculatorTest : public CalculatorTestBase
 
 TEST_F(RangeCalculatorTest, all)
 {
-    RangeCalculator calc_range(this->data(), this->values());
+    RangeCalculator calc_range(this->uniform_grid(), this->values());
 
     // "stopped" particle case should not calculate range
     if (CELERITAS_DEBUG)

--- a/test/celeritas/grid/SplineCalculator.test.cc
+++ b/test/celeritas/grid/SplineCalculator.test.cc
@@ -46,7 +46,7 @@ TEST_F(SplineCalculatorTest, simple)
         grid.interpolation.order = order;
         this->build(grid);
 
-        SplineCalculator calc(this->data().lower, this->values());
+        SplineCalculator calc(this->uniform_grid(), this->values());
 
         // Test on grid points
         EXPECT_SOFT_EQ(1.0, calc(Energy{1}));
@@ -89,7 +89,7 @@ TEST_F(SplineCalculatorTest, quadratic)
         grid.interpolation.order = order;
         this->build(grid);
 
-        SplineCalculator calc(this->data().lower, this->values());
+        SplineCalculator calc(this->uniform_grid(), this->values());
 
         for (real_type e : {1e-2, 5e-2, 1e-1, 5e-1, 1.0, 5.0, 1e1, 5e1, 1e2})
         {
@@ -134,7 +134,7 @@ TEST_F(SplineCalculatorTest, cubic)
         grid.interpolation.order = order;
         this->build(grid);
 
-        SplineCalculator calc(this->data().lower, this->values());
+        SplineCalculator calc(this->uniform_grid(), this->values());
 
         for (real_type e : {0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 1e2, 5e2, 1e3})
         {

--- a/test/celeritas/grid/UniformLogGridCalculator.test.cc
+++ b/test/celeritas/grid/UniformLogGridCalculator.test.cc
@@ -44,7 +44,7 @@ TEST_F(UniformLogGridCalculatorTest, simple)
     grid.y = {1, 10, 1e2, 1e3, 1e4, 1e5};
     this->build(grid);
 
-    UniformLogGridCalculator calc(this->data().lower, this->values());
+    UniformLogGridCalculator calc(this->uniform_grid(), this->values());
 
     // Test on grid points
     EXPECT_SOFT_EQ(1.0, calc(Energy{1}));
@@ -78,7 +78,7 @@ TEST_F(UniformLogGridCalculatorTest, spline)
     grid.interpolation.bc = BC::not_a_knot;
     this->build(grid);
 
-    UniformLogGridCalculator calc(this->data().lower, this->values());
+    UniformLogGridCalculator calc(this->uniform_grid(), this->values());
     EXPECT_SOFT_EQ(10, calc(Energy(0.1)));
     EXPECT_SOFT_EQ(-62.572615039281715, calc(Energy(0.2)));
     EXPECT_SOFT_EQ(1, calc(Energy(1)));
@@ -107,7 +107,7 @@ TEST_F(UniformLogGridCalculatorTest, spline_deriv)
         105520 / 33.0, 31880 / 11.0, -3160 / 33.0, -790 / 11.0, 5530 / 33.0};
 
     SplineDerivCalculator calc_deriv(BC::not_a_knot);
-    auto const& data = this->data().lower;
+    auto const& data = this->uniform_grid();
     {
         auto deriv = calc_deriv(data, this->values());
         EXPECT_VEC_SOFT_EQ(expected_deriv, deriv);

--- a/test/celeritas/grid/XsCalculator.test.cc
+++ b/test/celeritas/grid/XsCalculator.test.cc
@@ -39,12 +39,12 @@ TEST_F(XsCalculatorTest, simple)
 {
     // Energy from 1 to 1e5 MeV with 6 grid points; XS = E
     // *No* magical 1/E scaling
-    inp::UniformGrid lower;
-    lower.x = {1, 1e5};
-    lower.y = {1, 10, 1e2, 1e3, 1e4, 1e5};
-    this->build(lower, {});
+    inp::XsGrid grid;
+    grid.lower.x = {1, 1e5};
+    grid.lower.y = {1, 10, 1e2, 1e3, 1e4, 1e5};
+    this->build(grid);
 
-    XsCalculator calc(this->data(), this->values());
+    XsCalculator calc(this->xs_grid(), this->values());
 
     // Test on grid points
     EXPECT_SOFT_EQ(1.0, calc(Energy{1}));
@@ -67,12 +67,12 @@ TEST_F(XsCalculatorTest, simple)
 TEST_F(XsCalculatorTest, scaled_lowest)
 {
     // Energy from .1 to 1e4 MeV with 6 grid points and values of 1
-    inp::UniformGrid upper;
-    upper.x = {0.1, 1e4};
-    upper.y = {1, 1, 1, 1, 1, 1};
-    this->build({}, upper);
+    inp::XsGrid grid;
+    grid.upper.x = {0.1, 1e4};
+    grid.upper.y = {1, 1, 1, 1, 1, 1};
+    this->build(grid);
 
-    XsCalculator calc(this->data(), this->values());
+    XsCalculator calc(this->xs_grid(), this->values());
 
     // Test on grid points
     EXPECT_SOFT_EQ(1, calc(Energy{0.1}));
@@ -97,15 +97,14 @@ TEST_F(XsCalculatorTest, scaled_lowest)
 TEST_F(XsCalculatorTest, scaled_middle)
 {
     // Energy from .1 to 1e4 MeV with 6 grid points
-    inp::UniformGrid lower;
-    lower.x = {0.1, 10};
-    lower.y = {3, 3, 3};
-    inp::UniformGrid upper;
-    upper.x = {lower.x[Bound::hi], 1e4};
-    upper.y = {3, 3, 3, 3};
-    this->build(lower, upper);
+    inp::XsGrid grid;
+    grid.lower.x = {0.1, 10};
+    grid.lower.y = {3, 3, 3};
+    grid.upper.x = {grid.lower.x[Bound::hi], 1e4};
+    grid.upper.y = {3, 3, 3, 3};
+    this->build(grid);
 
-    XsCalculator calc(this->data(), this->values());
+    XsCalculator calc(this->xs_grid(), this->values());
 
     // Test on grid points
     EXPECT_SOFT_EQ(3, calc(Energy{0.1}));
@@ -137,15 +136,14 @@ TEST_F(XsCalculatorTest, scaled_linear)
         return result;
     };
 
-    inp::UniformGrid lower;
-    lower.x = {1e-3, 1};
-    lower.y = {xs(1e-3), xs(1e-2), xs(1e-1), xs(1)};
-    inp::UniformGrid upper;
-    upper.x = {lower.x[Bound::hi], 1e3};
-    upper.y = {xs(1), xs(1e1), xs(1e2), xs(1e3)};
-    this->build(lower, upper);
+    inp::XsGrid grid;
+    grid.lower.x = {1e-3, 1};
+    grid.lower.y = {xs(1e-3), xs(1e-2), xs(1e-1), xs(1)};
+    grid.upper.x = {grid.lower.x[Bound::hi], 1e3};
+    grid.upper.y = {xs(1), xs(1e1), xs(1e2), xs(1e3)};
+    this->build(grid);
 
-    XsCalculator interp_xs(this->data(), this->values());
+    XsCalculator interp_xs(this->xs_grid(), this->values());
 
     for (real_type e : {1e-3, 1e-1, 0.5, 1.0, 1.5, 10.0, 12.5, 1e3})
     {
@@ -156,17 +154,16 @@ TEST_F(XsCalculatorTest, scaled_linear)
 TEST_F(XsCalculatorTest, scaled_highest)
 {
     // values of 1, 10, 100 --> actual xs = {1, 10, 1}
-    inp::UniformGrid lower;
-    lower.x = {1, 100};
-    lower.y = {1, 10, 1};
-    inp::UniformGrid upper;
-    upper.x = {lower.x[Bound::hi], 100};
-    upper.y = {1, 1};
+    inp::XsGrid grid;
+    grid.lower.x = {1, 100};
+    grid.lower.y = {1, 10, 1};
+    grid.upper.x = {grid.lower.x[Bound::hi], 100};
+    grid.upper.y = {1, 1};
 
     // Can't have a single scaled value; only the lower grid is built
-    this->build(lower, upper);
-    EXPECT_TRUE(this->data().lower);
-    EXPECT_FALSE(this->data().upper);
+    this->build(grid);
+    EXPECT_TRUE(this->xs_grid().lower);
+    EXPECT_FALSE(this->xs_grid().upper);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/phys/MockModel.cc
+++ b/test/celeritas/phys/MockModel.cc
@@ -49,12 +49,11 @@ auto MockModel::micro_xs(Applicability range) const -> XsTable
         grids.resize(mat.num_elements());
         for (auto elcomp_idx : celeritas::range(mat.num_elements()))
         {
-            auto& grid = grids[elcomp_idx].lower;
-            grid.x = {std::log(range.lower.value()),
-                      std::log(range.upper.value())};
+            grids[elcomp_idx].x = {std::log(range.lower.value()),
+                                   std::log(range.upper.value())};
             for (auto xs : data_.xs)
             {
-                grid.y.push_back(native_value_from(xs));
+                grids[elcomp_idx].y.push_back(native_value_from(xs));
             }
         }
     }

--- a/test/celeritas/phys/MockProcess.cc
+++ b/test/celeritas/phys/MockProcess.cc
@@ -86,9 +86,9 @@ auto MockProcess::energy_loss(Applicability applic) const -> EnergyLossGrid
         auto eloss_rate = native_value_to<units::MevEnergy>(
             native_value_from(data_.energy_loss) * mat.number_density());
 
-        grid.lower.x
+        grid.x
             = {std::log(applic.lower.value()), std::log(applic.upper.value())};
-        grid.lower.y = VecDbl(3, eloss_rate.value());
+        grid.y = VecDbl(3, eloss_rate.value());
     }
     return grid;
 }

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -147,7 +147,7 @@ TEST_F(PhysicsParamsTest, output)
     auto j = nlohmann::json::parse(to_string(out));
     j["sizes"].erase("reals");
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":34}})json",
+        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":19}})json",
         j.dump());
 }
 

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -147,7 +147,7 @@ TEST_F(PhysicsParamsTest, output)
     auto j = nlohmann::json::parse(to_string(out));
     j["sizes"].erase("reals");
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":19}})json",
+        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":129}})json",
         j.dump());
 }
 

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -147,7 +147,7 @@ TEST_F(PhysicsParamsTest, output)
     auto j = nlohmann::json::parse(to_string(out));
     j["sizes"].erase("reals");
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":129}})json",
+        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"value_grid_ids":89,"value_grids":89,"value_tables":52}})json",
         j.dump());
 }
 

--- a/test/celeritas/phys/Physics.test.cu
+++ b/test/celeritas/phys/Physics.test.cu
@@ -38,11 +38,12 @@ __global__ void phys_test_kernel(PTestInput const inp)
     par = ParticleTrackView::Initializer_t{init.particle, init.energy};
     PhysicsTrackView phys(inp.params, inp.states, par, init.mat, tid);
     PhysicsStepView step(inp.params, inp.states, tid);
+    MaterialView mat(inp.mat_params, init.mat);
 
     phys = PhysicsTrackInitializer{};
-    inp.result[tid.get()]
-        = native_value_to<units::CmLength>(calc_step(phys, step, init.energy))
-              .value();
+    inp.result[tid.get()] = native_value_to<units::CmLength>(
+                                calc_step(phys, step, mat, init.energy))
+                                .value();
 }
 }  // namespace
 

--- a/test/celeritas/phys/Physics.test.hh
+++ b/test/celeritas/phys/Physics.test.hh
@@ -43,6 +43,7 @@ struct PTestInput
     DeviceRef<PhysicsStateData> states;
     DeviceCRef<ParticleParamsData> par_params;
     DeviceRef<ParticleStateData> par_states;
+    DeviceCRef<MaterialParamsData> mat_params;
     StateCollection<PhysTestInit, Ownership::const_reference, MemSpace::device>
         inits;
 
@@ -55,6 +56,7 @@ struct PTestInput
 //---------------------------------------------------------------------------//
 inline CELER_FUNCTION real_type calc_step(PhysicsTrackView& phys,
                                           PhysicsStepView& pstep,
+                                          MaterialView const& mat,
                                           units::MevEnergy energy)
 {
     // Calc total macro_xs over processes
@@ -64,8 +66,7 @@ inline CELER_FUNCTION real_type calc_step(PhysicsTrackView& phys,
         real_type process_xs = 0;
         if (auto id = phys.macro_xs_grid(ppid))
         {
-            auto calc_xs = phys.make_calculator<XsCalculator>(id);
-            process_xs = calc_xs(energy);
+            process_xs = phys.calc_xs(ppid, mat, energy);
         }
 
         // Zero cross section if outside of model range


### PR DESCRIPTION
Currently all physics grids use cross section grid data even though only macroscopic cross sections can have both scaled and unscaled values. This updates the physics data and classes so that energy loss, range, and microscopic cross sections use uniform grids instead.