### PR TITLE
Store hardwired model data by reference

### DIFF
--- a/src/celeritas/em/data/BetheHeitlerData.hh
+++ b/src/celeritas/em/data/BetheHeitlerData.hh
@@ -59,8 +59,5 @@ struct BetheHeitlerData
     }
 };
 
-using BetheHeitlerHostRef = BetheHeitlerData;
-using BetheHeitlerDeviceRef = BetheHeitlerData;
-
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/data/CombinedBremData.hh
+++ b/src/celeritas/em/data/CombinedBremData.hh
@@ -46,9 +46,5 @@ struct CombinedBremData
     }
 };
 
-using CombinedBremDeviceRef = DeviceCRef<CombinedBremData>;
-using CombinedBremHostRef = HostCRef<CombinedBremData>;
-using CombinedBremRef = NativeCRef<CombinedBremData>;
-
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/data/EPlusGGData.hh
+++ b/src/celeritas/em/data/EPlusGGData.hh
@@ -35,8 +35,5 @@ struct EPlusGGData
     }
 };
 
-using EPlusGGHostRef = EPlusGGData;
-using EPlusGGDeviceRef = EPlusGGData;
-
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/data/KleinNishinaData.hh
+++ b/src/celeritas/em/data/KleinNishinaData.hh
@@ -47,8 +47,5 @@ struct KleinNishinaData
     }
 };
 
-using KleinNishinaDeviceRef = KleinNishinaData;
-using KleinNishinaHostRef = KleinNishinaData;
-
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/data/LivermorePEData.hh
+++ b/src/celeritas/em/data/LivermorePEData.hh
@@ -76,6 +76,12 @@ struct LivermoreElement
     Energy thresh_lo;  //!< Use tabulated XS below this energy
     Energy thresh_hi;  //!< Use lower parameterization below, upper above
 
+    //! Energy below which cross sections are calculated on the fly
+    static CELER_CONSTEXPR_FUNCTION Energy tabulated_threshold()
+    {
+        return Energy{0.2};
+    }
+
     //! Whether all data are assigned and valid
     explicit CELER_FUNCTION operator bool() const
     {
@@ -179,10 +185,6 @@ struct LivermorePEData
         return *this;
     }
 };
-
-using LivermorePEDeviceRef = DeviceCRef<LivermorePEData>;
-using LivermorePEHostRef = HostCRef<LivermorePEData>;
-using LivermorePERef = NativeCRef<LivermorePEData>;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/data/MollerBhabhaData.hh
+++ b/src/celeritas/em/data/MollerBhabhaData.hh
@@ -54,8 +54,5 @@ struct MollerBhabhaData
     }
 };
 
-using MollerBhabhaHostRef = MollerBhabhaData;
-using MollerBhabhaDeviceRef = MollerBhabhaData;
-
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/data/RayleighData.hh
+++ b/src/celeritas/em/data/RayleighData.hh
@@ -63,6 +63,5 @@ struct RayleighData
     }
 };
 
-using RayleighRef = NativeCRef<RayleighData>;
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/data/RelativisticBremData.hh
+++ b/src/celeritas/em/data/RelativisticBremData.hh
@@ -100,8 +100,4 @@ struct RelativisticBremData
     }
 };
 
-using RelativisticBremDeviceRef = DeviceCRef<RelativisticBremData>;
-using RelativisticBremHostRef = HostCRef<RelativisticBremData>;
-using RelativisticBremRef = NativeCRef<RelativisticBremData>;
-
 }  // namespace celeritas

--- a/src/celeritas/em/data/SeltzerBergerData.hh
+++ b/src/celeritas/em/data/SeltzerBergerData.hh
@@ -138,9 +138,5 @@ struct SeltzerBergerData
     }
 };
 
-using SeltzerBergerDeviceRef = DeviceCRef<SeltzerBergerData>;
-using SeltzerBergerHostRef = HostCRef<SeltzerBergerData>;
-using SeltzerBergerRef = NativeCRef<SeltzerBergerData>;
-
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/em/executor/CombinedBremExecutor.hh
+++ b/src/celeritas/em/executor/CombinedBremExecutor.hh
@@ -26,7 +26,7 @@ struct CombinedBremExecutor
     inline CELER_FUNCTION Interaction
     operator()(celeritas::CoreTrackView const& track);
 
-    CombinedBremRef params;
+    NativeCRef<CombinedBremData> params;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/executor/LivermorePEExecutor.hh
+++ b/src/celeritas/em/executor/LivermorePEExecutor.hh
@@ -22,7 +22,7 @@ struct LivermorePEExecutor
     inline CELER_FUNCTION Interaction
     operator()(celeritas::CoreTrackView const& track);
 
-    LivermorePERef params;
+    NativeCRef<LivermorePEData> params;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/executor/RayleighExecutor.hh
+++ b/src/celeritas/em/executor/RayleighExecutor.hh
@@ -26,7 +26,7 @@ struct RayleighExecutor
     inline CELER_FUNCTION Interaction
     operator()(celeritas::CoreTrackView const& track);
 
-    RayleighRef params;
+    NativeCRef<RayleighData> params;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/executor/RelativisticBremExecutor.hh
+++ b/src/celeritas/em/executor/RelativisticBremExecutor.hh
@@ -20,7 +20,7 @@ struct RelativisticBremExecutor
     inline CELER_FUNCTION Interaction
     operator()(celeritas::CoreTrackView const& track);
 
-    RelativisticBremRef params;
+    NativeCRef<RelativisticBremData> params;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/executor/SeltzerBergerExecutor.hh
+++ b/src/celeritas/em/executor/SeltzerBergerExecutor.hh
@@ -25,7 +25,7 @@ struct SeltzerBergerExecutor
     inline CELER_FUNCTION Interaction
     operator()(celeritas::CoreTrackView const& track);
 
-    SeltzerBergerRef params;
+    NativeCRef<SeltzerBergerData> params;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/interactor/CombinedBremInteractor.hh
+++ b/src/celeritas/em/interactor/CombinedBremInteractor.hh
@@ -54,7 +54,7 @@ class CombinedBremInteractor
   public:
     // Construct with shared and state data
     inline CELER_FUNCTION
-    CombinedBremInteractor(CombinedBremRef const& shared,
+    CombinedBremInteractor(NativeCRef<CombinedBremData> const& shared,
                            ParticleTrackView const& particle,
                            Real3 const& direction,
                            CutoffView const& cutoffs,
@@ -70,7 +70,7 @@ class CombinedBremInteractor
     //// DATA ////
 
     // SB and relativistic data
-    CombinedBremRef const& shared_;
+    NativeCRef<CombinedBremData> const& shared_;
     // Incident particle
     ParticleTrackView const& particle_;
     // Incident particle direction
@@ -97,7 +97,7 @@ class CombinedBremInteractor
  */
 CELER_FUNCTION
 CombinedBremInteractor::CombinedBremInteractor(
-    CombinedBremRef const& shared,
+    NativeCRef<CombinedBremData> const& shared,
     ParticleTrackView const& particle,
     Real3 const& direction,
     CutoffView const& cutoffs,

--- a/src/celeritas/em/interactor/LivermorePEInteractor.hh
+++ b/src/celeritas/em/interactor/LivermorePEInteractor.hh
@@ -58,7 +58,7 @@ class LivermorePEInteractor
   public:
     // Construct with shared and state data
     inline CELER_FUNCTION
-    LivermorePEInteractor(LivermorePERef const& shared,
+    LivermorePEInteractor(NativeCRef<LivermorePEData> const& shared,
                           AtomicRelaxationHelper const& relaxation,
                           ElementId el_id,
                           ParticleTrackView const& particle,
@@ -74,7 +74,7 @@ class LivermorePEInteractor
     //// DATA ////
 
     // Shared constant physics properties
-    LivermorePERef const& shared_;
+    NativeCRef<LivermorePEData> const& shared_;
     // Shared scratch space
     AtomicRelaxationHelper const& relaxation_;
     // Index in MaterialParams elements
@@ -114,7 +114,7 @@ class LivermorePEInteractor
  */
 CELER_FUNCTION
 LivermorePEInteractor::LivermorePEInteractor(
-    LivermorePERef const& shared,
+    NativeCRef<LivermorePEData> const& shared,
     AtomicRelaxationHelper const& relaxation,
     ElementId el_id,
     ParticleTrackView const& particle,

--- a/src/celeritas/em/interactor/RayleighInteractor.hh
+++ b/src/celeritas/em/interactor/RayleighInteractor.hh
@@ -35,10 +35,11 @@ class RayleighInteractor
 {
   public:
     // Construct with shared and state data
-    inline CELER_FUNCTION RayleighInteractor(RayleighRef const& shared,
-                                             ParticleTrackView const& particle,
-                                             Real3 const& inc_direction,
-                                             ElementId element_id);
+    inline CELER_FUNCTION
+    RayleighInteractor(NativeCRef<RayleighData> const& shared,
+                       ParticleTrackView const& particle,
+                       Real3 const& inc_direction,
+                       ElementId element_id);
 
     // Sample an interaction with the given RNG
     template<class Engine>
@@ -48,7 +49,7 @@ class RayleighInteractor
     //// DATA ////
 
     // Shared constant physics properties
-    RayleighRef const& shared_;
+    NativeCRef<RayleighData> const& shared_;
     // Incident gamma energy
     units::MevEnergy const inc_energy_;
     // Incident direction
@@ -84,7 +85,7 @@ class RayleighInteractor
  * Construct with shared and state data.
  */
 CELER_FUNCTION
-RayleighInteractor::RayleighInteractor(RayleighRef const& shared,
+RayleighInteractor::RayleighInteractor(NativeCRef<RayleighData> const& shared,
                                        ParticleTrackView const& particle,
                                        Real3 const& direction,
                                        ElementId el_id)

--- a/src/celeritas/em/interactor/RelativisticBremInteractor.hh
+++ b/src/celeritas/em/interactor/RelativisticBremInteractor.hh
@@ -54,7 +54,7 @@ class RelativisticBremInteractor
   public:
     // Construct with shared and state data
     inline CELER_FUNCTION
-    RelativisticBremInteractor(RelativisticBremRef const& shared,
+    RelativisticBremInteractor(NativeCRef<RelativisticBremData> const& shared,
                                ParticleTrackView const& particle,
                                Real3 const& direction,
                                CutoffView const& cutoffs,
@@ -70,7 +70,7 @@ class RelativisticBremInteractor
     //// DATA ////
 
     // Shared constant physics properties
-    RelativisticBremRef const& shared_;
+    NativeCRef<RelativisticBremData> const& shared_;
     // Incident particle energy
     Energy const inc_energy_;
     // Incident particle momentum
@@ -96,7 +96,7 @@ class RelativisticBremInteractor
  */
 CELER_FUNCTION
 RelativisticBremInteractor::RelativisticBremInteractor(
-    RelativisticBremRef const& shared,
+    NativeCRef<RelativisticBremData> const& shared,
     ParticleTrackView const& particle,
     Real3 const& direction,
     CutoffView const& cutoffs,

--- a/src/celeritas/em/interactor/SeltzerBergerInteractor.hh
+++ b/src/celeritas/em/interactor/SeltzerBergerInteractor.hh
@@ -56,7 +56,7 @@ class SeltzerBergerInteractor
   public:
     //! Construct sampler from device/shared and state data
     inline CELER_FUNCTION
-    SeltzerBergerInteractor(SeltzerBergerRef const& shared,
+    SeltzerBergerInteractor(NativeCRef<SeltzerBergerData> const& shared,
                             ParticleTrackView const& particle,
                             Real3 const& inc_direction,
                             CutoffView const& cutoffs,
@@ -71,7 +71,7 @@ class SeltzerBergerInteractor
   private:
     //// DATA ////
     // Device (host CPU or GPU device) references
-    SeltzerBergerRef const& shared_;
+    NativeCRef<SeltzerBergerData> const& shared_;
     // Incident particle energy
     Energy const inc_energy_;
     // Incident particle direction
@@ -102,7 +102,7 @@ class SeltzerBergerInteractor
  * must be handled in code *before* the interactor is constructed.
  */
 CELER_FUNCTION SeltzerBergerInteractor::SeltzerBergerInteractor(
-    SeltzerBergerRef const& shared,
+    NativeCRef<SeltzerBergerData> const& shared,
     ParticleTrackView const& particle,
     Real3 const& inc_direction,
     CutoffView const& cutoffs,

--- a/src/celeritas/em/interactor/detail/RBEnergySampler.hh
+++ b/src/celeritas/em/interactor/detail/RBEnergySampler.hh
@@ -42,11 +42,12 @@ class RBEnergySampler
 
   public:
     // Construct with shared and state data
-    inline CELER_FUNCTION RBEnergySampler(RelativisticBremRef const& shared,
-                                          ParticleTrackView const& particle,
-                                          CutoffView const& cutoffs,
-                                          MaterialView const& material,
-                                          ElementComponentId elcomp_id);
+    inline CELER_FUNCTION
+    RBEnergySampler(NativeCRef<RelativisticBremData> const& shared,
+                    ParticleTrackView const& particle,
+                    CutoffView const& cutoffs,
+                    MaterialView const& material,
+                    ElementComponentId elcomp_id);
 
     // Sample the bremsstrahlung photon energy with the given RNG
     template<class Engine>
@@ -70,7 +71,7 @@ class RBEnergySampler
  * Construct from incident particle and energy.
  */
 CELER_FUNCTION
-RBEnergySampler::RBEnergySampler(RelativisticBremRef const& shared,
+RBEnergySampler::RBEnergySampler(NativeCRef<RelativisticBremData> const& shared,
                                  ParticleTrackView const& particle,
                                  CutoffView const& cutoffs,
                                  MaterialView const& material,

--- a/src/celeritas/em/model/LivermorePEModel.cc
+++ b/src/celeritas/em/model/LivermorePEModel.cc
@@ -57,7 +57,7 @@ LivermorePEModel::LivermorePEModel(ActionId id,
     // Save particle properties
     host_data.inv_electron_mass
         = 1
-          / value_as<LivermorePERef::Mass>(
+          / value_as<units::MevMass>(
               particles.get(host_data.ids.electron).mass());
 
     // Load Livermore cross section data

--- a/src/celeritas/em/model/LivermorePEModel.hh
+++ b/src/celeritas/em/model/LivermorePEModel.hh
@@ -29,8 +29,8 @@ class LivermorePEModel final : public Model, public StaticConcreteAction
   public:
     //!@{
     using ReadData = std::function<ImportLivermorePE(AtomicNumber)>;
-    using HostRef = LivermorePEHostRef;
-    using DeviceRef = LivermorePEDeviceRef;
+    using HostRef = HostCRef<LivermorePEData>;
+    using DeviceRef = DeviceCRef<LivermorePEData>;
     //!@}
 
   public:

--- a/src/celeritas/em/xs/LivermorePEMicroXsCalculator.hh
+++ b/src/celeritas/em/xs/LivermorePEMicroXsCalculator.hh
@@ -30,7 +30,7 @@ class LivermorePEMicroXsCalculator
   public:
     //!@{
     //! \name Type aliases
-    using ParamsRef = LivermorePERef;
+    using ParamsRef = NativeCRef<LivermorePEData>;
     using Energy = RealQuantity<LivermoreSubshell::EnergyUnits>;
     using BarnXs = units::BarnXs;
     //!@}
@@ -45,7 +45,7 @@ class LivermorePEMicroXsCalculator
 
   private:
     // Shared constant physics properties
-    LivermorePERef const& shared_;
+    ParamsRef const& shared_;
     // Incident gamma energy
     Energy const inc_energy_;
 };

--- a/src/celeritas/em/xs/RBDiffXsCalculator.hh
+++ b/src/celeritas/em/xs/RBDiffXsCalculator.hh
@@ -51,10 +51,11 @@ class RBDiffXsCalculator
 
   public:
     // Construct with incident electron and current element
-    inline CELER_FUNCTION RBDiffXsCalculator(RelativisticBremRef const& shared,
-                                             ParticleTrackView const& particle,
-                                             MaterialView const& material,
-                                             ElementComponentId elcomp_id);
+    inline CELER_FUNCTION
+    RBDiffXsCalculator(NativeCRef<RelativisticBremData> const& shared,
+                       ParticleTrackView const& particle,
+                       MaterialView const& material,
+                       ElementComponentId elcomp_id);
 
     // Compute cross section of exiting gamma energy
     inline CELER_FUNCTION real_type operator()(Energy energy);
@@ -109,10 +110,11 @@ class RBDiffXsCalculator
  * Construct with incident electron and current element.
  */
 CELER_FUNCTION
-RBDiffXsCalculator::RBDiffXsCalculator(RelativisticBremRef const& shared,
-                                       ParticleTrackView const& particle,
-                                       MaterialView const& material,
-                                       ElementComponentId elcomp_id)
+RBDiffXsCalculator::RBDiffXsCalculator(
+    NativeCRef<RelativisticBremData> const& shared,
+    ParticleTrackView const& particle,
+    MaterialView const& material,
+    ElementComponentId elcomp_id)
     : elem_data_(shared.elem_data[material.element_id(elcomp_id)])
     , material_(material)
     , element_(material.element_record(elcomp_id))

--- a/src/celeritas/phys/PhysicsParams.hh
+++ b/src/celeritas/phys/PhysicsParams.hh
@@ -118,16 +118,17 @@ class PhysicsParams final : public ParamsDataInterface<PhysicsParamsData>
     SpanConstProcessId processes(ParticleId) const;
 
     //! Access physics properties on the host
-    HostRef const& host_ref() const final { return data_.host_ref(); }
+    HostRef const& host_ref() const final { return host_ref_; }
 
     //! Access physics properties on the device
-    DeviceRef const& device_ref() const final { return data_.device_ref(); }
+    DeviceRef const& device_ref() const final { return device_ref_; }
 
   private:
     using BC = SplineDerivCalculator::BoundaryCondition;
     using SPAction = std::shared_ptr<StaticConcreteAction>;
     using VecModel = std::vector<std::pair<SPConstModel, ProcessId>>;
     using HostValue = celeritas::HostVal<PhysicsParamsData>;
+    using DeviceValue = PhysicsParamsData<Ownership::value, MemSpace::device>;
 
     // Kernels/actions
     SPAction pre_step_action_;
@@ -144,7 +145,10 @@ class PhysicsParams final : public ParamsDataInterface<PhysicsParamsData>
     SPConstRelaxation relaxation_;
 
     // Host/device storage and reference
-    CollectionMirror<PhysicsParamsData> data_;
+    HostValue host_;
+    HostRef host_ref_;
+    DeviceValue device_;
+    DeviceRef device_ref_;
 
   private:
     VecModel build_models(ActionRegistry*) const;
@@ -153,6 +157,7 @@ class PhysicsParams final : public ParamsDataInterface<PhysicsParamsData>
     void build_ids(ParticleParams const&, HostValue*) const;
     void build_tables(Options const&, MaterialParams const&, HostValue*) const;
     void build_model_tables(MaterialParams const&, HostValue*) const;
+    void build_hardwired();
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsStepView.hh
+++ b/src/celeritas/phys/PhysicsStepView.hh
@@ -307,10 +307,8 @@ PhysicsStepView::make_relaxation_helper(ElementId el_id) const
     -> AtomicRelaxationHelper
 {
     CELER_ASSERT(el_id);
-    return AtomicRelaxationHelper{params_.hardwired.relaxation_data,
-                                  states_.relaxation,
-                                  el_id,
-                                  track_slot_};
+    return AtomicRelaxationHelper{
+        params_.hardwired.relaxation, states_.relaxation, el_id, track_slot_};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -452,23 +452,20 @@ CELER_FUNCTION real_type PhysicsTrackView::calc_xs(ParticleProcessId ppid,
     {
         // Calculate macroscopic cross section on the fly for special
         // hardwired processes.
-        if (model_id == params_.hardwired.livermore_pe)
+        if (model_id == params_.hardwired.ids.livermore_pe)
         {
-            auto calc_xs = MacroXsCalculator<LivermorePEMicroXsCalculator>(
-                params_.hardwired.livermore_pe_data, material);
-            result = calc_xs(energy);
+            result = MacroXsCalculator<LivermorePEMicroXsCalculator>(
+                params_.hardwired.livermore_pe, material)(energy);
         }
-        else if (model_id == params_.hardwired.eplusgg)
+        else if (model_id == params_.hardwired.ids.eplusgg)
         {
-            auto calc_xs = EPlusGGMacroXsCalculator(
-                params_.hardwired.eplusgg_data, material);
-            result = calc_xs(energy);
+            result = EPlusGGMacroXsCalculator(params_.hardwired.eplusgg,
+                                              material)(energy);
         }
-        else if (model_id == params_.hardwired.chips)
+        else if (model_id == params_.hardwired.ids.chips)
         {
-            auto calc_xs = MacroXsCalculator<NeutronElasticMicroXsCalculator>(
-                params_.hardwired.chips_data, material);
-            result = calc_xs(energy);
+            result = MacroXsCalculator<NeutronElasticMicroXsCalculator>(
+                params_.hardwired.chips, material)(energy);
         }
     }
     else if (auto grid_id = this->macro_xs_grid(ppid))
@@ -520,18 +517,20 @@ PhysicsTrackView::calc_max_xs(IntegralXsProcess const& process,
 
 //---------------------------------------------------------------------------//
 /*!
- * Return the model ID that applies to the given process ID and energy if the
- * process is hardwired to calculate macroscopic cross sections on the fly. If
- * the result is null, tables should be used for this process/energy.
+ * Get a hardwired model for on-the-fly cross section calculation.
+ *
+ * This returns the model ID that applies to the given process ID and energy if
+ * the process is hardwired to calculate macroscopic cross sections on the fly.
+ * If the result is null, tables should be used for this process/energy.
  */
 CELER_FUNCTION ModelId PhysicsTrackView::hardwired_model(ParticleProcessId ppid,
                                                          Energy energy) const
 {
     ProcessId process = this->process(ppid);
-    if ((process == params_.hardwired.photoelectric
-         && energy < params_.hardwired.photoelectric_table_thresh)
-        || (process == params_.hardwired.positron_annihilation)
-        || (process == params_.hardwired.neutron_elastic))
+    if ((process == params_.hardwired.ids.photoelectric
+         && energy < LivermoreElement::tabulated_threshold())
+        || (process == params_.hardwired.ids.annihilation)
+        || (process == params_.hardwired.ids.neutron_elastic))
     {
         auto find_model = this->make_model_finder(ppid);
         return this->model_id(find_model(energy));

--- a/test/celeritas/em/Rayleigh.test.cc
+++ b/test/celeritas/em/Rayleigh.test.cc
@@ -88,7 +88,7 @@ class RayleighInteractorTest : public InteractorHostTestBase
 
   protected:
     std::shared_ptr<RayleighModel> model_;
-    RayleighRef model_ref_;
+    NativeCRef<RayleighData> model_ref_;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -132,7 +132,7 @@ class SeltzerBergerTest : public InteractorHostTestBase
 
   protected:
     std::shared_ptr<SeltzerBergerModel> model_;
-    SeltzerBergerRef data_;
+    NativeCRef<SeltzerBergerData> data_;
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This updates the physics hardwired models so the model data is stored by reference rather than being duplicated. It also cleans up some of the old model data aliases.