### PR TITLE
Support material-dependent model applicability

### DIFF
--- a/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
+++ b/src/celeritas/em/interactor/MollerBhabhaInteractor.hh
@@ -103,6 +103,8 @@ CELER_FUNCTION MollerBhabhaInteractor::MollerBhabhaInteractor(
 {
     CELER_EXPECT(particle.particle_id() == shared_.ids.electron
                  || particle.particle_id() == shared_.ids.positron);
+    CELER_EXPECT(inc_energy_
+                 > (inc_particle_is_electron_ ? 2 : 1) * electron_cutoff_);
 }
 
 //---------------------------------------------------------------------------//
@@ -115,15 +117,6 @@ CELER_FUNCTION MollerBhabhaInteractor::MollerBhabhaInteractor(
 template<class Engine>
 CELER_FUNCTION Interaction MollerBhabhaInteractor::operator()(Engine& rng)
 {
-    if (inc_energy_ <= (inc_particle_is_electron_ ? 2 : 1) * electron_cutoff_)
-    {
-        /*!
-         * \todo Remove and replace with an assertion once material-dependent
-         * model bounds are supported
-         */
-        return Interaction::from_unchanged();
-    }
-
     // Allocate memory for the produced electron
     Secondary* electron_secondary = allocate_(1);
 

--- a/src/celeritas/em/interactor/SeltzerBergerInteractor.hh
+++ b/src/celeritas/em/interactor/SeltzerBergerInteractor.hh
@@ -128,6 +128,7 @@ CELER_FUNCTION SeltzerBergerInteractor::SeltzerBergerInteractor(
                  || particle.particle_id() == shared_.ids.positron);
     CELER_EXPECT(gamma_cutoff_ > zero_quantity());
     CELER_EXPECT(inc_energy_ < shared_.high_energy_limit);
+    CELER_EXPECT(inc_energy_ > gamma_cutoff_);
 }
 
 //---------------------------------------------------------------------------//
@@ -139,15 +140,6 @@ CELER_FUNCTION SeltzerBergerInteractor::SeltzerBergerInteractor(
 template<class Engine>
 CELER_FUNCTION Interaction SeltzerBergerInteractor::operator()(Engine& rng)
 {
-    if (inc_energy_ <= gamma_cutoff_)
-    {
-        /*!
-         * \todo Remove and replace with an assertion once material-dependent
-         * model bounds are supported
-         */
-        return Interaction::from_unchanged();
-    }
-
     // Allocate space for the brems photon
     Secondary* secondaries = allocate_(1);
     if (secondaries == nullptr)

--- a/src/celeritas/em/model/CoulombScatteringModel.cc
+++ b/src/celeritas/em/model/CoulombScatteringModel.cc
@@ -34,7 +34,6 @@ namespace celeritas
  */
 CoulombScatteringModel::CoulombScatteringModel(ActionId id,
                                                ParticleParams const& particles,
-                                               MaterialParams const& materials,
                                                SPConstImported data)
     : StaticConcreteAction(
           id, "coulomb-wentzel", "interact by Coulomb scattering (Wentzel)")
@@ -54,26 +53,6 @@ CoulombScatteringModel::CoulombScatteringModel(ActionId id,
         << R"(missing electron and/or positron particles (required for )"
         << this->description() << ")");
 
-    // Get high/low energy limits
-    energy_limit_
-        = imported_.energy_grid_bounds(data_.ids.electron, PhysMatId{0});
-
-    // Check that the bounds are the same for all particles/materials
-    // TODO: This is only expected when using Coulomb scattering with the
-    // Wentzel VI model above the MSC energy limit. When the MSC energy limit
-    // is not set, the model energy grid bounds are material dependent and
-    // require material-dependent applicability
-    for (auto pid : {data_.ids.electron, data_.ids.positron})
-    {
-        for (auto mid : range(PhysMatId{materials.num_materials()}))
-        {
-            CELER_VALIDATE(
-                energy_limit_ == imported_.energy_grid_bounds(pid, mid),
-                << "Coulomb scattering cross section energy limits are "
-                   "inconsistent across particles and/or materials");
-        }
-    }
-
     CELER_ENSURE(data_);
 }
 
@@ -83,15 +62,7 @@ CoulombScatteringModel::CoulombScatteringModel(ActionId id,
  */
 auto CoulombScatteringModel::applicability() const -> SetApplicability
 {
-    Applicability electron_applic;
-    electron_applic.particle = this->host_ref().ids.electron;
-    electron_applic.lower = energy_limit_[0];
-    electron_applic.upper = energy_limit_[1];
-
-    Applicability positron_applic = electron_applic;
-    positron_applic.particle = this->host_ref().ids.positron;
-
-    return {electron_applic, positron_applic};
+    return imported_.applicability();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/CoulombScatteringModel.hh
+++ b/src/celeritas/em/model/CoulombScatteringModel.hh
@@ -15,7 +15,6 @@
 
 namespace celeritas
 {
-class MaterialParams;
 class ParticleParams;
 class IsotopeView;
 
@@ -35,7 +34,6 @@ class CoulombScatteringModel final : public Model, public StaticConcreteAction
     // Construct from model ID and other necessary data
     CoulombScatteringModel(ActionId id,
                            ParticleParams const& particles,
-                           MaterialParams const& materials,
                            SPConstImported data);
 
     // Particle types and energy ranges that this model applies to
@@ -59,7 +57,6 @@ class CoulombScatteringModel final : public Model, public StaticConcreteAction
   private:
     CoulombScatteringData data_;
     ImportedModelAdapter imported_;
-    ImportedModelAdapter::EnergyBounds energy_limit_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/KleinNishinaModel.cc
+++ b/src/celeritas/em/model/KleinNishinaModel.cc
@@ -8,6 +8,7 @@
 
 #include "corecel/math/Quantity.hh"
 #include "celeritas/em/executor/KleinNishinaExecutor.hh"
+#include "celeritas/em/interactor/detail/PhysicsConstants.hh"
 #include "celeritas/global/ActionLauncher.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
@@ -48,12 +49,12 @@ KleinNishinaModel::KleinNishinaModel(ActionId id,
  */
 auto KleinNishinaModel::applicability() const -> SetApplicability
 {
-    Applicability photon_applic;
-    photon_applic.particle = data_.ids.gamma;
-    photon_applic.lower = zero_quantity();
-    photon_applic.upper = max_quantity();
+    Applicability applic;
+    applic.particle = data_.ids.gamma;
+    applic.lower = zero_quantity();
+    applic.upper = detail::high_energy_limit();
 
-    return {photon_applic};
+    return {applic};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/LivermorePEModel.cc
+++ b/src/celeritas/em/model/LivermorePEModel.cc
@@ -15,6 +15,7 @@
 #include "corecel/cont/Range.hh"
 #include "celeritas/em/data/LivermorePEData.hh"
 #include "celeritas/em/executor/LivermorePEExecutor.hh"
+#include "celeritas/em/interactor/detail/PhysicsConstants.hh"
 #include "celeritas/global/ActionLauncher.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
@@ -80,12 +81,12 @@ LivermorePEModel::LivermorePEModel(ActionId id,
  */
 auto LivermorePEModel::applicability() const -> SetApplicability
 {
-    Applicability photon_applic;
-    photon_applic.particle = this->host_ref().ids.gamma;
-    photon_applic.lower = zero_quantity();
-    photon_applic.upper = max_quantity();
+    Applicability applic;
+    applic.particle = this->host_ref().ids.gamma;
+    applic.lower = zero_quantity();
+    applic.upper = detail::high_energy_limit();
 
-    return {photon_applic};
+    return {applic};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/MollerBhabhaModel.cc
+++ b/src/celeritas/em/model/MollerBhabhaModel.cc
@@ -25,9 +25,15 @@ namespace celeritas
  * Construct from model ID and other necessary data.
  */
 MollerBhabhaModel::MollerBhabhaModel(ActionId id,
-                                     ParticleParams const& particles)
+                                     ParticleParams const& particles,
+                                     SPConstImported data)
     : StaticConcreteAction(
           id, "ioni-moller-bhabha", "interact by Moller+Bhabha ionization")
+    , imported_(data,
+                particles,
+                ImportProcessClass::e_ioni,
+                ImportModelClass::moller_bhabha,
+                {pdg::electron(), pdg::positron()})
 {
     CELER_EXPECT(id);
     data_.ids.electron = particles.find(pdg::electron());
@@ -49,23 +55,7 @@ MollerBhabhaModel::MollerBhabhaModel(ActionId id,
  */
 auto MollerBhabhaModel::applicability() const -> SetApplicability
 {
-    /*!
-     * \todo Set lower energy bound based on (material-dependent)
-     * IonizationProcess lambda table energy grid to avoid invoking the
-     * interactor for tracks with energy below the interaction threshold.
-     */
-
-    Applicability electron_applic, positron_applic;
-
-    electron_applic.particle = data_.ids.electron;
-    electron_applic.lower = zero_quantity();
-    electron_applic.upper = units::MevEnergy{data_.max_valid_energy()};
-
-    positron_applic.particle = data_.ids.positron;
-    positron_applic.lower = zero_quantity();
-    positron_applic.upper = electron_applic.upper;
-
-    return {electron_applic, positron_applic};
+    return imported_.applicability();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/MollerBhabhaModel.hh
+++ b/src/celeritas/em/model/MollerBhabhaModel.hh
@@ -7,6 +7,8 @@
 #pragma once
 
 #include "celeritas/em/data/MollerBhabhaData.hh"
+#include "celeritas/phys/ImportedModelAdapter.hh"
+#include "celeritas/phys/ImportedProcessAdapter.hh"
 #include "celeritas/phys/Model.hh"
 
 namespace celeritas
@@ -20,8 +22,14 @@ class ParticleParams;
 class MollerBhabhaModel final : public Model, public StaticConcreteAction
 {
   public:
+    //!@{
+    //! \name Type aliases
+    using SPConstImported = std::shared_ptr<ImportedProcesses const>;
+    //!@}
+
+  public:
     // Construct from model ID and other necessary data
-    MollerBhabhaModel(ActionId id, ParticleParams const& particles);
+    MollerBhabhaModel(ActionId, ParticleParams const&, SPConstImported);
 
     // Particle types and energy ranges that this model applies to
     SetApplicability applicability() const final;
@@ -43,6 +51,7 @@ class MollerBhabhaModel final : public Model, public StaticConcreteAction
 
   private:
     MollerBhabhaData data_;
+    ImportedModelAdapter imported_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/MuBremsstrahlungModel.cc
+++ b/src/celeritas/em/model/MuBremsstrahlungModel.cc
@@ -55,17 +55,7 @@ MuBremsstrahlungModel::MuBremsstrahlungModel(ActionId id,
  */
 auto MuBremsstrahlungModel::applicability() const -> SetApplicability
 {
-    Applicability mu_minus_applic, mu_plus_applic;
-
-    mu_minus_applic.particle = data_.mu_minus;
-    mu_minus_applic.lower = zero_quantity();
-    mu_minus_applic.upper = detail::high_energy_limit();
-
-    mu_plus_applic.particle = data_.mu_plus;
-    mu_plus_applic.lower = mu_minus_applic.lower;
-    mu_plus_applic.upper = mu_minus_applic.upper;
-
-    return {mu_minus_applic, mu_plus_applic};
+    return imported_.applicability();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/RayleighModel.cc
+++ b/src/celeritas/em/model/RayleighModel.cc
@@ -13,6 +13,7 @@
 #include "celeritas/Quantities.hh"
 #include "celeritas/em/data/RayleighData.hh"
 #include "celeritas/em/executor/RayleighExecutor.hh"  // IWYU pragma: associated
+#include "celeritas/em/interactor/detail/PhysicsConstants.hh"
 #include "celeritas/global/ActionLauncher.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/TrackExecutor.hh"
@@ -64,12 +65,12 @@ RayleighModel::RayleighModel(ActionId id,
  */
 auto RayleighModel::applicability() const -> SetApplicability
 {
-    Applicability rayleigh_scattering;
-    rayleigh_scattering.particle = this->host_ref().gamma;
-    rayleigh_scattering.lower = zero_quantity();
-    rayleigh_scattering.upper = units::MevEnergy{1e+8};
+    Applicability applic;
+    applic.particle = this->host_ref().gamma;
+    applic.lower = zero_quantity();
+    applic.upper = detail::high_energy_limit();
 
-    return {rayleigh_scattering};
+    return {applic};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -86,15 +86,7 @@ RelativisticBremModel::RelativisticBremModel(ActionId id,
  */
 auto RelativisticBremModel::applicability() const -> SetApplicability
 {
-    Applicability electron;
-    electron.particle = this->host_ref().ids.electron;
-    electron.lower = this->host_ref().low_energy_limit;
-    electron.upper = detail::high_energy_limit();
-
-    Applicability positron = electron;
-    positron.particle = this->host_ref().ids.positron;
-
-    return {electron, positron};
+    return imported_.applicability();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/SeltzerBergerModel.cc
+++ b/src/celeritas/em/model/SeltzerBergerModel.cc
@@ -112,21 +112,7 @@ SeltzerBergerModel::SeltzerBergerModel(ActionId id,
  */
 auto SeltzerBergerModel::applicability() const -> SetApplicability
 {
-    /*!
-     * \todo Set lower energy bound based on (material-dependent)
-     * BremsstrahlungProcess lambda table energy grid to avoid invoking the
-     * interactor for tracks with energy below the interaction threshold.
-     */
-
-    Applicability electron;
-    electron.particle = this->host_ref().ids.electron;
-    electron.lower = zero_quantity();
-    electron.upper = this->host_ref().high_energy_limit;
-
-    Applicability positron = electron;
-    positron.particle = this->host_ref().ids.positron;
-
-    return {electron, positron};
+    return imported_.applicability();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/CoulombScatteringProcess.cc
+++ b/src/celeritas/em/process/CoulombScatteringProcess.cc
@@ -19,17 +19,14 @@ namespace celeritas
  * Construct from host data.
  */
 CoulombScatteringProcess::CoulombScatteringProcess(SPConstParticles particles,
-                                                   SPConstMaterials materials,
                                                    SPConstImported process_data)
     : particles_(std::move(particles))
-    , materials_(std::move(materials))
     , imported_(process_data,
                 particles_,
                 ImportProcessClass::coulomb_scat,
                 {pdg::electron(), pdg::positron()})
 {
     CELER_EXPECT(particles_);
-    CELER_EXPECT(materials_);
 }
 
 //---------------------------------------------------------------------------//
@@ -40,7 +37,7 @@ auto CoulombScatteringProcess::build_models(ActionIdIter start_id) const
     -> VecModel
 {
     return {std::make_shared<CoulombScatteringModel>(
-        *start_id++, *particles_, *materials_, imported_.processes())};
+        *start_id++, *particles_, imported_.processes())};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/process/CoulombScatteringProcess.hh
+++ b/src/celeritas/em/process/CoulombScatteringProcess.hh
@@ -28,14 +28,12 @@ class CoulombScatteringProcess : public Process
     //!@{
     //! \name Type aliases
     using SPConstParticles = std::shared_ptr<ParticleParams const>;
-    using SPConstMaterials = std::shared_ptr<MaterialParams const>;
     using SPConstImported = std::shared_ptr<ImportedProcesses const>;
     //!@}
 
   public:
     // Construct from Coulomb scattering data
     CoulombScatteringProcess(SPConstParticles particles,
-                             SPConstMaterials materials,
                              SPConstImported process_data);
 
     // Construct the models associated with this process
@@ -58,7 +56,6 @@ class CoulombScatteringProcess : public Process
 
   private:
     SPConstParticles particles_;
-    SPConstMaterials materials_;
     ImportedProcessAdapter imported_;
 };
 

--- a/src/celeritas/em/process/EIonizationProcess.cc
+++ b/src/celeritas/em/process/EIonizationProcess.cc
@@ -37,7 +37,8 @@ EIonizationProcess::EIonizationProcess(SPConstParticles particles,
  */
 auto EIonizationProcess::build_models(ActionIdIter start_id) const -> VecModel
 {
-    return {std::make_shared<MollerBhabhaModel>(*start_id++, *particles_)};
+    return {std::make_shared<MollerBhabhaModel>(
+        *start_id++, *particles_, imported_.processes())};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/GeantProcessImporter.cc
+++ b/src/celeritas/ext/detail/GeantProcessImporter.cc
@@ -12,6 +12,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <unordered_set>
 #include <utility>
@@ -236,13 +237,23 @@ GeantProcessImporter::operator()(G4ParticleDefinition const& particle,
     GeantModelImporter convert_model(materials_,
                                      PDGNumber{result.particle_pdg},
                                      PDGNumber{result.secondary_pdg});
+
 #if G4VERSION_NUMBER < 1100
-    for (auto i : celeritas::range(process.GetNumberOfModels()))
+    std::vector<std::tuple<double, int>> models(process.GetNumberOfModels());
 #else
-    for (auto i : celeritas::range(process.NumberOfModels()))
+    std::vector<std::tuple<double, int>> models(process.NumberOfModels());
 #endif
+    for (auto i : range(models.size()))
     {
-        result.models.push_back(convert_model(*process.GetModelByIndex(i)));
+        models[i] = {process.GetModelByIndex(i)->LowEnergyLimit(), i};
+    }
+    // Sort models from lowest to highest energy region
+    std::sort(models.begin(), models.end());
+
+    for (auto const& m : models)
+    {
+        result.models.push_back(
+            convert_model(*process.GetModelByIndex(std::get<1>(m))));
         CELER_ASSERT(result.models.back());
     }
 

--- a/src/celeritas/phys/Applicability.hh
+++ b/src/celeritas/phys/Applicability.hh
@@ -50,14 +50,14 @@ struct Applicability
 //! Comparators
 inline bool operator==(Applicability const& lhs, Applicability const& rhs)
 {
-    return std::make_tuple(lhs.material, lhs.particle, lhs.lower, lhs.upper)
-           == std::make_tuple(rhs.material, rhs.particle, rhs.lower, rhs.upper);
+    return std::make_tuple(lhs.particle, lhs.material, lhs.lower, lhs.upper)
+           == std::make_tuple(rhs.particle, rhs.material, rhs.lower, rhs.upper);
 }
 
 inline bool operator<(Applicability const& lhs, Applicability const& rhs)
 {
-    return std::make_tuple(lhs.material, lhs.particle, lhs.lower, lhs.upper)
-           < std::make_tuple(rhs.material, rhs.particle, rhs.lower, rhs.upper);
+    return std::make_tuple(lhs.particle, lhs.material, lhs.lower, lhs.upper)
+           < std::make_tuple(rhs.particle, rhs.material, rhs.lower, rhs.upper);
 }
 //!@}
 

--- a/src/celeritas/phys/ImportedModelAdapter.cc
+++ b/src/celeritas/phys/ImportedModelAdapter.cc
@@ -7,6 +7,7 @@
 #include "ImportedModelAdapter.hh"
 
 #include <map>
+#include <set>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -95,7 +96,97 @@ auto ImportedModelAdapter::micro_xs(Applicability applic) const -> XsTable
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the xs energy grid bounds for the given material and particle.
+ * Get the applicable particle type and energy ranges of the model.
+ */
+auto ImportedModelAdapter::applicability() const -> SetApplicability
+{
+    std::set<double> unique_process_energy;
+    SetApplicability par_applic;
+    SetApplicability parmat_applic;
+    for (auto [particle_id, process_id] : particle_to_process_)
+    {
+        ImportModel const& model = this->get_model(particle_id);
+        ImportProcess const& process = imported_->get(process_id);
+
+        for (auto mat_id : range(PhysMatId(model.materials.size())))
+        {
+            Applicability applic;
+            applic.particle = particle_id;
+
+            // Get the model grid bounds
+            auto const& energy = model.materials[mat_id.get()].energy;
+            applic.lower = Energy(energy[Bound::lo]);
+            applic.upper = Energy(energy[Bound::hi]);
+
+            // If this is the lowest- or highest-energy model, make sure the
+            // grid bounds are consistent with the process macro xs grid bounds
+            auto process_energy = this->energy_grid_bounds(process, mat_id);
+            if (model.model_class == process.models.front().model_class
+                || process_energy.front() > applic.lower)
+            {
+                applic.lower = process_energy.front();
+            }
+            if (model.model_class == process.models.back().model_class
+                || process_energy.back() < applic.upper)
+            {
+                applic.upper = process_energy.back();
+            }
+
+            // Check that the energy range is valide. This can be false e.g. in
+            // materials with very high production cuts
+            if (applic.lower > applic.upper)
+            {
+                applic.upper = applic.lower;
+            }
+
+            // Check for material dependence
+            unique_process_energy.insert(process_energy.front().value());
+            par_applic.insert(applic);
+
+            applic.material = mat_id;
+            parmat_applic.insert(applic);
+        }
+    }
+    if (par_applic.size() == particle_to_process_.size()
+        && unique_process_energy.size() == 1)
+    {
+        // If none of the model or process bounds are material dependent,
+        // return material-independent applicability
+        return par_applic;
+    }
+    return parmat_applic;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the macro xs energy grid bounds for the given material and process.
+ */
+auto ImportedModelAdapter::energy_grid_bounds(ImportProcess const& proc,
+                                              PhysMatId mid) const
+    -> EnergyBounds
+{
+    CELER_EXPECT(proc.lambda || proc.lambda_prim);
+    CELER_EXPECT(!proc.lambda || mid < proc.lambda.grids.size());
+    CELER_EXPECT(!proc.lambda_prim || mid < proc.lambda_prim.grids.size());
+
+    auto const& lower = proc.lambda ? proc.lambda.grids[mid.get()]
+                                    : proc.lambda_prim.grids[mid.get()];
+    auto const& upper = proc.lambda_prim ? proc.lambda_prim.grids[mid.get()]
+                                         : proc.lambda.grids[mid.get()];
+
+    // Cross sections are nonzero below the lower grid bound
+    bool start_from_zero = lower.y.front() != 0;
+
+    auto emin = Energy(start_from_zero ? 0 : std::exp(lower.x[Bound::lo]));
+    auto emax = Energy(std::exp(upper.x[Bound::hi]));
+
+    CELER_ENSURE(emin < emax);
+    return {emin, emax};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the micro xs energy grid bounds for the given material and particle.
  */
 auto ImportedModelAdapter::energy_grid_bounds(ParticleId pid,
                                               PhysMatId mid) const

--- a/src/celeritas/phys/ImportedModelAdapter.hh
+++ b/src/celeritas/phys/ImportedModelAdapter.hh
@@ -38,6 +38,7 @@ class ImportedModelAdapter
     //!@{
     //! \name Type aliases
     using XsTable = Model::XsTable;
+    using SetApplicability = Model::SetApplicability;
     using SpanConstPDG = Span<PDGNumber const>;
     using SPConstImported = std::shared_ptr<ImportedProcesses const>;
     using Energy = units::MevEnergy;
@@ -62,6 +63,9 @@ class ImportedModelAdapter
     // Construct micro cross sections from the given particle/material type
     XsTable micro_xs(Applicability range) const;
 
+    // Get the applicable particle type and energy ranges of the model
+    SetApplicability applicability() const;
+
     // Get the xs energy grid bounds for the given material and particle
     EnergyBounds energy_grid_bounds(ParticleId, PhysMatId) const;
 
@@ -85,6 +89,7 @@ class ImportedModelAdapter
     //// HELPER FUNCTIONS ////
 
     ImportModel const& get_model(ParticleId) const;
+    EnergyBounds energy_grid_bounds(ImportProcess const&, PhysMatId) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PhysicsData.hh
+++ b/src/celeritas/phys/PhysicsData.hh
@@ -65,14 +65,14 @@ struct ModelCdfTable
 
 //---------------------------------------------------------------------------//
 /*!
- * Energy-dependent model IDs for a single process and particle type.
+ * Energy-to-model mapping for a single process, particle type and material.
  *
  * For a given particle type, a single process should be divided into multiple
- * models as a function of energy. The \c ModelGroup represents this with an
- * energy grid, and each cell of the grid corresponding to a particular
- * \c ParticleModelId.
+ * models as a function of energy, where the energy grid can be material
+ * dependent. The \c ModelGrid represents this with an energy grid, and each
+ * cell of the grid corresponding to a particular \c ParticleModelId.
  */
-struct ModelGroup
+struct ModelGrid
 {
     using Energy = units::MevEnergy;
 
@@ -83,6 +83,24 @@ struct ModelGroup
     explicit CELER_FUNCTION operator bool() const
     {
         return (energy.size() >= 2) && (model.size() + 1 == energy.size());
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Energy-dependent model IDs for a single process and particle type.
+ *
+ * If the model energy bounds are material dependent, a separate grid is stored
+ * for each material. If not, only one is stored.
+ */
+struct ModelGroup
+{
+    ItemRange<ModelGrid> materials;
+
+    //! True if assigned
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return !materials.empty();
     }
 };
 
@@ -342,6 +360,7 @@ struct PhysicsParamsData
     ParticleModelItems<ModelCdfTable> model_cdf;
 
     // Process and model storage
+    Items<ModelGrid> model_grids;
     Items<ModelGroup> model_groups;
     Items<IntegralXsProcess> integral_xs;
     ParticleItems<ProcessGroup> process_groups;
@@ -378,6 +397,7 @@ struct PhysicsParamsData
         uniform_tables = other.uniform_tables;
         model_cdf = other.model_cdf;
 
+        model_grids = other.model_grids;
         model_groups = other.model_groups;
         integral_xs = other.integral_xs;
         process_groups = other.process_groups;

--- a/src/celeritas/phys/PhysicsParams.cc
+++ b/src/celeritas/phys/PhysicsParams.cc
@@ -307,13 +307,14 @@ void PhysicsParams::build_ids(ParticleParams const& particles,
     CELER_EXPECT(!models_.empty());
 
     using ModelRange = std::tuple<real_type, real_type, ParticleModelId>;
-    using MapProcessModel = std::map<ProcessId, std::vector<ModelRange>>;
+    using VecMaterial = std::vector<ModelRange>;
+    using MapProcessModel = std::map<ProcessId, std::vector<VecMaterial>>;
 
     // Offset from the index in the list of models to a model's ActionId
     data->scalars.model_to_action = this->model(ModelId{0})->action_id().get();
 
-    // Note: use map to keep ProcessId sorted
-    std::vector<MapProcessModel> particle_models(particles.size());
+    // Note: use map to keep \c ParticleId and \c ProcessId sorted
+    std::map<ParticleId, MapProcessModel> particle_models;
     std::vector<ModelId> temp_model_ids;
     ParticleModelId::size_type pm_idx{0};
 
@@ -322,26 +323,34 @@ void PhysicsParams::build_ids(ParticleParams const& particles,
     {
         Model const& m = *this->model(mid);
         ProcessId const process_id = this->process_id(mid);
+        ParticleId prev;
         for (Applicability const& applic : m.applicability())
         {
-            if (applic.material)
-            {
-                CELER_NOT_IMPLEMENTED("material-dependent models");
-            }
             CELER_VALIDATE(applic.particle < particles.size(),
                            << "invalid particle ID "
                            << applic.particle.unchecked_get());
-            CELER_VALIDATE(applic.lower < applic.upper,
+            CELER_VALIDATE(applic.lower <= applic.upper,
                            << "expected lower energy limit ("
-                           << value_as<ModelGroup::Energy>(applic.lower)
+                           << value_as<ModelGrid::Energy>(applic.lower)
                            << " MeV) to be less than upper energy limit ("
-                           << value_as<ModelGroup::Energy>(applic.upper)
+                           << value_as<ModelGrid::Energy>(applic.upper)
                            << " MeV) for model " << m.label());
-            particle_models[applic.particle.get()][process_id].push_back(
-                {value_as<ModelGroup::Energy>(applic.lower),
-                 value_as<ModelGroup::Energy>(applic.upper),
-                 ParticleModelId{pm_idx++}});
-            temp_model_ids.push_back(mid);
+            if (applic.particle != prev)
+            {
+                prev = applic.particle;
+                temp_model_ids.push_back(mid);
+                ++pm_idx;
+            }
+            auto& mat_to_model = particle_models[applic.particle][process_id];
+            size_type mat_idx = applic.material ? applic.material.get() : 0;
+            if (mat_idx + 1 > mat_to_model.size())
+            {
+                mat_to_model.resize(mat_idx + 1);
+            }
+            mat_to_model[mat_idx].push_back(
+                {value_as<ModelGrid::Energy>(applic.lower),
+                 value_as<ModelGrid::Energy>(applic.upper),
+                 ParticleModelId{pm_idx - 1}});
         }
     }
     make_builder(&data->model_ids)
@@ -350,6 +359,7 @@ void PhysicsParams::build_ids(ParticleParams const& particles,
     CollectionBuilder process_groups(&data->process_groups);
     CollectionBuilder process_ids(&data->process_ids);
     CollectionBuilder model_groups(&data->model_groups);
+    CollectionBuilder model_grids(&data->model_grids);
     CollectionBuilder pmodel_ids(&data->pmodel_ids);
     DedupeCollectionBuilder reals(&data->reals);
 
@@ -359,7 +369,7 @@ void PhysicsParams::build_ids(ParticleParams const& particles,
     ProcessId::size_type max_particle_processes = 0;
     for (auto par_id : range(ParticleId{particles.size()}))
     {
-        auto& process_to_models = particle_models[par_id.get()];
+        auto& process_to_models = particle_models[par_id];
         if (process_to_models.empty()
             && !is_fake_particle(particles.id_to_pdg(par_id)))
         {
@@ -378,54 +388,66 @@ void PhysicsParams::build_ids(ParticleParams const& particles,
             // Add process ID
             temp_processes.push_back(pid_models.first);
 
-            std::vector<ModelRange>& models = pid_models.second;
-            CELER_ASSERT(!models.empty());
+            auto& mats = pid_models.second;
+            CELER_ASSERT(!mats.empty());
 
-            // Construct model data
-            std::vector<real_type> temp_energy_grid;
-            std::vector<ParticleModelId> temp_models;
-            temp_energy_grid.reserve(models.size() + 1);
-            temp_models.reserve(models.size());
-
-            // Sort, and add the first grid point
-            std::sort(models.begin(), models.end());
-            temp_energy_grid.push_back(std::get<0>(models[0]));
-
-            for (ModelRange const& r : models)
+            std::vector<ModelGrid> temp_model_grids;
+            temp_model_grids.reserve(mats.size());
+            for (auto& models : mats)
             {
-                CELER_VALIDATE(
-                    temp_energy_grid.back() == std::get<0>(r),
-                    << "models for process '"
-                    << this->process(pid_models.first)->label()
-                    << "' of particle type '" << particles.id_to_label(par_id)
-                    << "' has no data between energies of "
-                    << temp_energy_grid.back() << " and " << std::get<0>(r)
-                    << " (energy range must be contiguous)");
-                temp_energy_grid.push_back(std::get<1>(r));
-                temp_models.push_back(std::get<2>(r));
+                // Construct model data
+                std::vector<real_type> temp_energy;
+                std::vector<ParticleModelId> temp_model;
+                temp_energy.reserve(models.size() + 1);
+                temp_model.reserve(models.size());
+
+                // Sort, and add the first grid point
+                // TODO: are they already sorted?
+                std::sort(models.begin(), models.end());
+                temp_energy.push_back(std::get<0>(models[0]));
+
+                for (ModelRange const& r : models)
+                {
+                    CELER_VALIDATE(temp_energy.back() == std::get<0>(r),
+                                   << "models for process '"
+                                   << this->process(pid_models.first)->label()
+                                   << "' of particle type '"
+                                   << particles.id_to_label(par_id)
+                                   << "' has no data between energies of "
+                                   << temp_energy.back() << " and "
+                                   << std::get<0>(r)
+                                   << " (energy range must be contiguous)");
+                    temp_energy.push_back(std::get<1>(r));
+                    temp_model.push_back(std::get<2>(r));
+                }
+
+                ModelGrid mgrid;
+                mgrid.energy = reals.insert_back(temp_energy.begin(),
+                                                 temp_energy.end());
+                mgrid.model = pmodel_ids.insert_back(temp_model.begin(),
+                                                     temp_model.end());
+                CELER_ASSERT(mgrid);
+                temp_model_grids.push_back(mgrid);
             }
 
-            ModelGroup mdata;
-            mdata.energy = reals.insert_back(temp_energy_grid.begin(),
-                                             temp_energy_grid.end());
-            mdata.model = pmodel_ids.insert_back(temp_models.begin(),
-                                                 temp_models.end());
-            CELER_ASSERT(mdata);
-            temp_model_groups.push_back(mdata);
+            ModelGroup mgroup;
+            mgroup.materials = model_grids.insert_back(
+                temp_model_grids.begin(), temp_model_grids.end());
+            temp_model_groups.push_back(mgroup);
         }
 
-        ProcessGroup pdata;
-        pdata.processes = process_ids.insert_back(temp_processes.begin(),
-                                                  temp_processes.end());
-        pdata.models = model_groups.insert_back(temp_model_groups.begin(),
-                                                temp_model_groups.end());
+        ProcessGroup pgroup;
+        pgroup.processes = process_ids.insert_back(temp_processes.begin(),
+                                                   temp_processes.end());
+        pgroup.models = model_groups.insert_back(temp_model_groups.begin(),
+                                                 temp_model_groups.end());
 
         // It's ok to have particles defined in the problem that do not have
         // any processes (if they are ever created, they will just be
         // transported until they exit the geometry).
         // NOTE: data tables will be assigned later
-        CELER_ASSERT(process_to_models.empty() || pdata);
-        process_groups.push_back(pdata);
+        CELER_ASSERT(process_to_models.empty() || pgroup);
+        process_groups.push_back(pgroup);
     }
     data->scalars.max_particle_processes = max_particle_processes;
     data->scalars.num_models = this->num_models();
@@ -529,12 +551,6 @@ void PhysicsParams::build_tables(Options const& opts,
         // Loop over per-particle processes
         for (auto pp_idx : range(process_ids.size()))
         {
-            // Get energy bounds for this process
-            auto energy_grid = data->reals[model_groups[pp_idx].energy];
-            applic.lower = Energy{energy_grid.front()};
-            applic.upper = Energy{energy_grid.back()};
-            CELER_ASSERT(applic.lower < applic.upper);
-
             Process const& proc = *this->process(process_ids[pp_idx]);
 
             // Grid IDs for each grid type, each material
@@ -571,6 +587,15 @@ void PhysicsParams::build_tables(Options const& opts,
             for (auto mat_idx : range(mats.size()))
             {
                 applic.material = PhysMatId(mat_idx);
+
+                // Get energy bounds for this process and material
+                auto const& mats = model_groups[pp_idx].materials;
+                auto const& model_grid
+                    = data->model_grids[mats[mats.size() > 1 ? mat_idx : 0]];
+                auto energy_grid = data->reals[model_grid.energy];
+                applic.lower = Energy{energy_grid.front()};
+                applic.upper = Energy{energy_grid.back()};
+                CELER_ASSERT(applic.lower < applic.upper);
 
                 // Construct macroscopic cross section grid
                 auto macro_xs = proc.macro_xs(applic);
@@ -680,10 +705,17 @@ void PhysicsParams::build_model_tables(MaterialParams const& mats,
     for (auto model_idx : range(this->num_models()))
     {
         Model const& model = *models_[model_idx].first;
+        ParticleId prev{};
 
         // Loop over applicable particles
         for (Applicability applic : model.applicability())
         {
+            if (applic.particle == prev)
+            {
+                continue;
+            }
+            prev = applic.particle;
+
             std::vector<UniformTable> temp_tables(mats.size());
             for (auto mat_id : range(PhysMatId{mats.size()}))
             {

--- a/src/celeritas/phys/PhysicsParamsOutput.cc
+++ b/src/celeritas/phys/PhysicsParamsOutput.cc
@@ -107,6 +107,7 @@ void PhysicsParamsOutput::output(JsonPimpl* j) const
         PPO_SAVE_SIZE(uniform_tables);
         PPO_SAVE_SIZE(process_ids);
         PPO_SAVE_SIZE(integral_xs);
+        PPO_SAVE_SIZE(model_grids);
         PPO_SAVE_SIZE(model_groups);
         PPO_SAVE_SIZE(process_groups);
 #undef PPO_SAVE_SIZE

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -317,6 +317,12 @@ select_discrete_interaction(MaterialView const& material,
     // Find the model that applies at the particle energy
     auto find_model = physics.make_model_finder(ppid);
     auto pmid = find_model(particle.energy());
+    if (!pmid)
+    {
+        // The integral approach is disabled and no model applies for the
+        // sampled process at the pre-step energy
+        return physics.scalars().integral_rejection_action();
+    }
 
     ElementComponentId elcomp_id{};
     if (material.num_elements() == 1)

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -548,9 +548,20 @@ PhysicsTrackView::make_model_finder(ParticleProcessId ppid) const
     -> ModelFinder
 {
     CELER_EXPECT(ppid < this->num_particle_processes());
-    ModelGroup const& md
-        = params_.model_groups[this->process_group().models[ppid.get()]];
-    return ModelFinder(params_.reals[md.energy], params_.pmodel_ids[md.model]);
+
+    ModelGrid const& mg = [ppid, this] {
+        ModelGroup const& md
+            = params_.model_groups[this->process_group().models[ppid.get()]];
+        if (md.materials.size() > 1)
+        {
+            // Material-dependent energy bounds
+            CELER_ASSERT(material_ < md.materials.size());
+            return params_.model_grids[md.materials[material_.get()]];
+        }
+        CELER_ASSERT(!md.materials.empty());
+        return params_.model_grids[md.materials.front()];
+    }();
+    return ModelFinder(params_.reals[mg.energy], params_.pmodel_ids[mg.model]);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/ProcessBuilder.cc
+++ b/src/celeritas/phys/ProcessBuilder.cc
@@ -234,8 +234,8 @@ auto ProcessBuilder::build_annihilation() -> SPProcess
 //---------------------------------------------------------------------------//
 auto ProcessBuilder::build_coulomb() -> SPProcess
 {
-    return std::make_shared<CoulombScatteringProcess>(
-        this->particle(), this->material(), this->imported());
+    return std::make_shared<CoulombScatteringProcess>(this->particle(),
+                                                      this->imported());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/em/CoulombScattering.test.cc
+++ b/test/celeritas/em/CoulombScattering.test.cc
@@ -100,10 +100,7 @@ class CoulombScatteringTest : public InteractorHostTestBase
         }
 
         model_ = std::make_shared<CoulombScatteringModel>(
-            ActionId{0},
-            *this->particle_params(),
-            *this->material_params(),
-            this->imported_processes());
+            ActionId{0}, *this->particle_params(), this->imported_processes());
 
         // Set cutoffs
         CutoffParams::Input input;

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -148,7 +148,7 @@ TEST_F(PhysicsParamsTest, output)
     auto j = nlohmann::json::parse(to_string(out));
     j["sizes"].erase("reals");
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"uniform_grid_ids":57,"uniform_grids":57,"uniform_tables":44,"xs_grid_ids":32,"xs_grids":32,"xs_tables":8}})json",
+        R"json({"_category":"internal","_label":"physics","models":{"label":["mock-model-1","mock-model-2","mock-model-3","mock-model-4","mock-model-5","mock-model-6","mock-model-7","mock-model-8","mock-model-9","mock-model-10","mock-model-11"],"process_id":[0,0,1,2,2,2,3,3,4,4,5]},"options":{"fixed_step_limiter":0.0,"heavy.lowest_energy":[0.001,"MeV"],"heavy.max_step_over_range":0.2,"heavy.min_range":0.010000000000000002,"light.lowest_energy":[0.001,"MeV"],"light.max_step_over_range":0.2,"light.min_range":0.1,"linear_loss_limit":0.01,"min_eprime_over_e":0.8},"processes":{"label":["scattering","absorption","purrs","hisses","meows","barks"]},"sizes":{"integral_xs":8,"model_grids":8,"model_groups":8,"model_ids":11,"process_groups":5,"process_ids":8,"uniform_grid_ids":57,"uniform_grids":57,"uniform_tables":44,"xs_grid_ids":32,"xs_grids":32,"xs_tables":8}})json",
         j.dump());
 }
 
@@ -167,11 +167,6 @@ TEST_F(PhysicsParamsTest, energy_max_xs)
         auto proc_ids = data.process_ids[proc_group.processes];
         for (auto pp_idx : range(proc_ids.size()))
         {
-            auto model_group = data.model_groups[proc_group.models][pp_idx];
-            auto energy_grid = data.reals[model_group.energy];
-            applic.lower = MevEnergy{energy_grid.front()};
-            applic.upper = MevEnergy{energy_grid.back()};
-
             auto const& proc = p.process(proc_ids[pp_idx]);
             CELER_ASSERT(proc);
             detail::EnergyMaxXsCalculator calc(opts, *proc);
@@ -179,6 +174,15 @@ TEST_F(PhysicsParamsTest, energy_max_xs)
             for (auto mat_id : range(PhysMatId(this->material()->size())))
             {
                 applic.material = mat_id;
+
+                auto const& mats
+                    = data.model_groups[proc_group.models][pp_idx].materials;
+                auto const& model_grid
+                    = data.model_grids[mats[mats.size() > 1 ? mat_id.get() : 0]];
+                auto energy_grid = data.reals[model_grid.energy];
+                applic.lower = MevEnergy{energy_grid.front()};
+                applic.upper = MevEnergy{energy_grid.back()};
+
                 auto macro_xs = proc->macro_xs(applic);
                 energy.push_back(calc ? calc(macro_xs) : -1);
             }

--- a/test/celeritas/phys/ProcessBuilder.test.cc
+++ b/test/celeritas/phys/ProcessBuilder.test.cc
@@ -164,24 +164,21 @@ TEST_F(ProcessBuilderTest, e_ionization)
     ASSERT_TRUE(models.front());
     EXPECT_EQ("ioni-moller-bhabha", models.front()->label());
     auto all_applic = models.front()->applicability();
-    ASSERT_EQ(2, all_applic.size());
+    ASSERT_EQ(4, all_applic.size());
 
-    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
+    for (auto applic : all_applic)
     {
-        for (auto applic : all_applic)
+        // Test step limits
         {
-            // Test step limits
-            {
-                applic.material = mat_id;
-                EXPECT_TRUE(process->macro_xs(applic));
-                EXPECT_TRUE(process->energy_loss(applic));
-            }
+            EXPECT_TRUE(applic.material);
+            EXPECT_TRUE(process->macro_xs(applic));
+            EXPECT_TRUE(process->energy_loss(applic));
+        }
 
-            // Test micro xs
-            for (auto const& model : models)
-            {
-                EXPECT_TRUE(model->micro_xs(applic).empty());
-            }
+        // Test micro xs
+        for (auto const& model : models)
+        {
+            EXPECT_TRUE(model->micro_xs(applic).empty());
         }
     }
 }
@@ -302,7 +299,7 @@ TEST_F(ProcessBuilderTest, photoelectric)
     }
 }
 
-TEST_F(ProcessBuilderTest, bremsstrahlung_multiple_models)
+TEST_F(ProcessBuilderTest, bremsstrahlung)
 {
     if (!this->has_le_data())
     {
@@ -322,14 +319,13 @@ TEST_F(ProcessBuilderTest, bremsstrahlung_multiple_models)
     ASSERT_TRUE(models.front());
     EXPECT_EQ("brems-sb", models.front()->label());
     auto all_applic = models.front()->applicability();
-    ASSERT_EQ(2, all_applic.size());
-    Applicability applic = *all_applic.begin();
+    ASSERT_EQ(4, all_applic.size());
 
-    for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
+    for (auto applic : all_applic)
     {
         // Test step limits
         {
-            applic.material = mat_id;
+            EXPECT_TRUE(applic.material);
             EXPECT_TRUE(process->macro_xs(applic));
 
             // Only the ionization process has and energy loss table, which is
@@ -341,7 +337,7 @@ TEST_F(ProcessBuilderTest, bremsstrahlung_multiple_models)
         for (auto const& model : models)
         {
             auto micro_xs = model->micro_xs(applic);
-            auto material = this->material()->get(mat_id);
+            auto material = this->material()->get(applic.material);
             EXPECT_EQ(material.num_elements(), micro_xs.size());
             for (auto elcomp_idx : range(material.num_elements()))
             {
@@ -411,8 +407,8 @@ TEST_F(ProcessBuilderTest, coulomb)
     auto all_applic = models.front()->applicability();
     ASSERT_EQ(2, all_applic.size());
     Applicability applic = *all_applic.begin();
-    EXPECT_EQ(100, value_as<units::MevEnergy>(applic.lower));
-    EXPECT_EQ(1e8, value_as<units::MevEnergy>(applic.upper));
+    EXPECT_SOFT_EQ(0, value_as<units::MevEnergy>(applic.lower));
+    EXPECT_SOFT_EQ(1e8, value_as<units::MevEnergy>(applic.upper));
 
     for (auto mat_id : range(PhysMatId{this->material()->num_materials()}))
     {


### PR DESCRIPTION
Continuing with #907, I've started adding support for material-dependent model bounds. However, I'm not completely convinced we need or want this... it feels a little like we're adding extra work and complexity trying to explicitly specify something that's already implicitly handled. @sethrj before I keep going on this it could be helpful to discuss the motivation for it/why it's necessary.