### PR TITLE
Fix `sincospi` on device

### DIFF
--- a/src/celeritas/optical/ParticleTrackView.hh
+++ b/src/celeritas/optical/ParticleTrackView.hh
@@ -81,6 +81,8 @@ CELER_FUNCTION ParticleTrackView&
 ParticleTrackView::operator=(Initializer const& init)
 {
     CELER_EXPECT(init.energy >= zero_quantity());
+    CELER_EXPECT(is_soft_unit_vector(init.polarization));
+
     states_.energy[track_slot_] = value_as<Energy>(init.energy);
     states_.polarization[track_slot_] = init.polarization;
     return *this;

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -706,24 +706,19 @@ CELER_FORCEINLINE_FUNCTION double rsqrt(double value)
 #endif
 }
 
-#if CELER_DEVICE_SOURCE
+#ifndef CELER_DEVICE_SOURCE
 // CUDA/HIP define sinpi, cospi, sinpif, cospif, ...
-#    undef CELERITAS_SINCOSPI_PREFIX
-#    define CELERITAS_SINCOSPI_PREFIX
-#endif
-
-#ifdef CELERITAS_SINCOSPI_PREFIX
+#    ifdef CELERITAS_SINCOSPI_PREFIX
 // Apple-supplied headers define __sinpi, __sinpif, __sincospi, ...
-#    define CELER_CONCAT_IMPL(PREFIX, FUNC) PREFIX##FUNC
-#    define CELER_CONCAT(PREFIX, FUNC) CELER_CONCAT_IMPL(PREFIX, FUNC)
-#    define CELER_SINCOS_MANGLED(FUNC) \
-        CELER_CONCAT(CELERITAS_SINCOSPI_PREFIX, FUNC)
-#else
+#        define CELER_CONCAT_IMPL(PREFIX, FUNC) PREFIX##FUNC
+#        define CELER_CONCAT(PREFIX, FUNC) CELER_CONCAT_IMPL(PREFIX, FUNC)
+#        define CELER_SINCOS_MANGLED(FUNC) \
+            CELER_CONCAT(CELERITAS_SINCOSPI_PREFIX, FUNC)
+#    else
 // Use implementations from detail/MathImpl.hh
-#    define CELERITAS_SINCOSPI_PREFIX ::celeritas::detail::
-#    define CELER_SINCOS_MANGLED(FUNC) ::celeritas::detail::FUNC
-#endif
-
+#        define CELERITAS_SINCOSPI_PREFIX ::celeritas::detail::
+#        define CELER_SINCOS_MANGLED(FUNC) ::celeritas::detail::FUNC
+#    endif
 //!@{
 //! Get the sine or cosine of a value multiplied by pi for increased precision
 CELER_FORCEINLINE_FUNCTION float sinpi(float a)
@@ -767,6 +762,7 @@ CELER_FORCEINLINE_FUNCTION void sincospi(double a, double* s, double* c)
     return CELER_SINCOS_MANGLED(sincospi)(a, s, c);
 }
 //!@}
+#endif
 
 //!@}
 

--- a/test/corecel/CMakeLists.txt
+++ b/test/corecel/CMakeLists.txt
@@ -76,7 +76,7 @@ celeritas_add_test(io/StringEnumMapper.test.cc)
 celeritas_add_test(io/StringUtils.test.cc)
 
 # Math
-celeritas_add_test(math/Algorithms.test.cc)
+celeritas_add_device_test(math/Algorithms)
 celeritas_add_test(math/ArrayOperators.test.cc)
 celeritas_add_test(math/ArrayUtils.test.cc)
 celeritas_add_test(math/PdfUtils.test.cc)

--- a/test/corecel/math/Algorithms.test.cu
+++ b/test/corecel/math/Algorithms.test.cu
@@ -1,0 +1,56 @@
+//---------------------------------*-CUDA-*----------------------------------//
+// Copyright 2021-2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/math/Algorithms.test.cu
+//---------------------------------------------------------------------------//
+#include "Algorithms.test.hh"
+
+#include "corecel/DeviceRuntimeApi.hh"
+
+#include "corecel/sys/Device.hh"
+#include "corecel/sys/KernelParamCalculator.device.hh"
+
+namespace celeritas
+{
+namespace test
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+// KERNELS
+//---------------------------------------------------------------------------//
+
+__global__ void alg_test_kernel(AlgorithmTestData data)
+{
+    auto tid = KernelParamCalculator::thread_id();
+
+    auto const& inp = data.input;
+    auto const& out = data.output;
+
+    if (tid.get() < inp.pi_frac.size())
+    {
+        sincospi(inp.pi_frac[tid], &out.sinpi[tid], &out.cospi[tid]);
+    }
+    if (tid.get() < inp.a.size())
+    {
+        out.fastpow[tid] = fastpow(inp.a[tid], inp.b[tid]);
+        out.hypot[tid] = hypot(inp.a[tid], inp.b[tid]);
+    }
+}
+}  // namespace
+
+//---------------------------------------------------------------------------//
+// TESTING INTERFACE
+//---------------------------------------------------------------------------//
+//! Run on device
+void alg_test(AlgorithmTestData data)
+{
+    CELER_LAUNCH_KERNEL(alg_test, data.num_threads, 0, data);
+    CELER_DEVICE_API_CALL(DeviceSynchronize());
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/corecel/math/Algorithms.test.hh
+++ b/test/corecel/math/Algorithms.test.hh
@@ -1,0 +1,145 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/math/Algorithms.test.hh
+//---------------------------------------------------------------------------//
+
+#include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "corecel/math/Algorithms.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+// TESTING INTERFACE
+//---------------------------------------------------------------------------//
+/*!
+ * Input data for testing algorithms on device.
+ */
+template<Ownership W, MemSpace M>
+struct AlgorithmInputData
+{
+    template<class T>
+    using Items = Collection<T, W, M, ThreadId>;
+
+    // Test sincospi
+    Items<double> pi_frac;
+
+    // Test algorithms that take two floating point numbers
+    Items<double> a;
+    Items<double> b;
+
+    //! True if sizes are consistent and nonzero
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return !pi_frac.empty() && !a.empty() && a.size() == b.size();
+    }
+
+    //! Assign from another set of data
+    template<Ownership W2, MemSpace M2>
+    AlgorithmInputData& operator=(AlgorithmInputData<W2, M2>& other)
+    {
+        CELER_EXPECT(other);
+        pi_frac = other.pi_frac;
+        a = other.a;
+        b = other.b;
+        CELER_ENSURE(*this);
+        return *this;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Test results.
+ */
+template<Ownership W, MemSpace M>
+struct AlgorithmOutputData
+{
+    template<class T>
+    using Items = Collection<T, W, M, ThreadId>;
+
+    // Test sincospi
+    Items<double> sinpi;
+    Items<double> cospi;
+
+    // Test fastpow
+    Items<double> fastpow;
+
+    // Test hypot
+    Items<double> hypot;
+
+    //! True if sizes are consistent and nonzero
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return !sinpi.empty() && sinpi.size() == cospi.size()
+               && !fastpow.empty() && !hypot.empty();
+    }
+
+    //! Assign from another set of data
+    template<Ownership W2, MemSpace M2>
+    AlgorithmOutputData& operator=(AlgorithmOutputData<W2, M2>& other)
+    {
+        CELER_EXPECT(other);
+        sinpi = other.sinpi;
+        cospi = other.cospi;
+        fastpow = other.fastpow;
+        hypot = other.hypot;
+        CELER_ENSURE(*this);
+        return *this;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Resize states in host code.
+ */
+template<MemSpace M>
+inline void resize(AlgorithmOutputData<Ownership::value, M>* output,
+                   HostCRef<AlgorithmInputData> const input,
+                   size_type)
+{
+    CELER_EXPECT(output);
+    CELER_EXPECT(input);
+
+    resize(&output->sinpi, input.pi_frac.size());
+    resize(&output->cospi, input.pi_frac.size());
+
+    resize(&output->fastpow, input.a.size());
+
+    resize(&output->hypot, input.a.size());
+
+    CELER_ENSURE(*output);
+}
+
+//---------------------------------------------------------------------------//
+// TESTING INTERFACE
+//---------------------------------------------------------------------------//
+//! Input data
+struct AlgorithmTestData
+{
+    using InputRef = DeviceCRef<AlgorithmInputData>;
+    using OutputRef = DeviceRef<AlgorithmOutputData>;
+
+    InputRef input;
+    OutputRef output;
+    size_type num_threads{};
+};
+
+//---------------------------------------------------------------------------//
+//! Run on device
+void alg_test(AlgorithmTestData);
+
+#if !CELER_USE_DEVICE
+inline void alg_test(AlgorithmTestData)
+{
+    CELER_NOT_CONFIGURED("CUDA or HIP");
+}
+#endif
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
`sincospi` was producing garbage values on device: it looks like the only place it's currently used on the GPU is calculating the polarization in the scintillation generator, which wasn't previously checked. This fixes it and adds a device algorithms test.

Not directly related, but while working through this I came across this note in the [CUDA Math API](https://docs.nvidia.com/cuda/cuda-math-api/index.html):

> Note also that due to implementation constraints, certain math functions from std:: namespace may be callable in device code even via explicitly qualified std:: names. However, such use is discouraged, since this capability is unsupported, unverified, undocumented, not portable, and may change without notice.

Is this something we should worry about?