### PR TITLE
Complete optical stepping loop

### DIFF
--- a/src/celeritas/optical/SimData.hh
+++ b/src/celeritas/optical/SimData.hh
@@ -38,6 +38,7 @@ struct SimStateData
     Items<real_type> step_length;
     Items<TrackStatus> status;
     Items<ActionId> post_step_action;
+    Items<size_type> num_steps;  //!< Total number of steps taken
 
     //// METHODS ////
 
@@ -45,7 +46,7 @@ struct SimStateData
     explicit CELER_FUNCTION operator bool() const
     {
         return !time.empty() && !step_length.empty() && !status.empty()
-               && !post_step_action.empty();
+               && !post_step_action.empty() && !num_steps.empty();
     }
 
     //! State size
@@ -60,6 +61,7 @@ struct SimStateData
         step_length = other.step_length;
         status = other.status;
         post_step_action = other.post_step_action;
+        num_steps = other.num_steps;
         return *this;
     }
 };
@@ -80,6 +82,7 @@ inline void resize(SimStateData<Ownership::value, M>* data, size_type size)
     fill(TrackStatus::inactive, &data->status);
 
     resize(&data->post_step_action, size);
+    resize(&data->num_steps, size);
 
     CELER_ENSURE(*data);
 }

--- a/src/celeritas/optical/SimTrackView.hh
+++ b/src/celeritas/optical/SimTrackView.hh
@@ -43,6 +43,9 @@ class SimTrackView
     // Add the time change over the step
     inline CELER_FUNCTION void add_time(real_type delta);
 
+    // Increment the total number of steps
+    inline CELER_FUNCTION void increment_num_steps();
+
     // Reset step limiter
     inline CELER_FUNCTION void reset_step_limit();
 
@@ -59,6 +62,9 @@ class SimTrackView
     inline CELER_FUNCTION void post_step_action(ActionId action);
 
     //// DYNAMIC PROPERTIES ////
+
+    // Total number of steps taken by the track
+    inline CELER_FUNCTION size_type num_steps() const;
 
     // Time elapsed in the lab frame since the start of the event
     inline CELER_FUNCTION real_type time() const;
@@ -101,6 +107,7 @@ CELER_FUNCTION SimTrackView& SimTrackView::operator=(Initializer const& init)
     states_.step_length[track_slot_] = {};
     states_.status[track_slot_] = TrackStatus::initializing;
     states_.post_step_action[track_slot_] = {};
+    states_.num_steps[track_slot_] = 0;
     return *this;
 }
 
@@ -112,6 +119,15 @@ CELER_FUNCTION void SimTrackView::status(TrackStatus status)
 {
     CELER_EXPECT(status != TrackStatus::size_);
     states_.status[track_slot_] = status;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Increment the total number of steps.
+ */
+CELER_FORCEINLINE_FUNCTION void SimTrackView::increment_num_steps()
+{
+    ++states_.num_steps[track_slot_];
 }
 
 //---------------------------------------------------------------------------//
@@ -198,6 +214,15 @@ CELER_FUNCTION bool SimTrackView::step_limit(StepLimit const& sl)
 
 //---------------------------------------------------------------------------//
 // DYNAMIC PROPERTIES
+//---------------------------------------------------------------------------//
+/*!
+ * Total number of steps taken by the track.
+ */
+CELER_FORCEINLINE_FUNCTION size_type SimTrackView::num_steps() const
+{
+    return states_.num_steps[track_slot_];
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Time elapsed in the lab frame since the start of the event [s].

--- a/src/celeritas/optical/gen/CherenkovGenerator.hh
+++ b/src/celeritas/optical/gen/CherenkovGenerator.hh
@@ -168,6 +168,7 @@ CherenkovGenerator::operator()(Generator& rng)
     // Photon polarization is perpendicular to the cone's surface
     photon.polarization
         = rotate(from_spherical(-std::sqrt(sin_theta_sq), phi), dir_);
+    CELER_ASSERT(soft_zero(dot_product(photon.polarization, photon.direction)));
 
     // Sample fraction along the step
     UniformRealDistribution<> sample_step_fraction;

--- a/src/celeritas/optical/gen/ScintillationGenerator.hh
+++ b/src/celeritas/optical/gen/ScintillationGenerator.hh
@@ -158,8 +158,11 @@ ScintillationGenerator::operator()(Generator& rng)
         {
             temp[j] = cosphi * temp[j] + sinphi * perp[j];
         }
+        // Enforce orthogonality
+        temp -= dot_product(temp, photon.direction) * photon.direction;
         return make_unit_vector(temp);
     }();
+    CELER_ASSERT(soft_zero(dot_product(photon.polarization, photon.direction)));
 
     // Sample position: endpoint (collision site) if neutral, else uniform
     real_type u = is_neutral_ ? 1 : UniformRealDist{}(rng);

--- a/src/celeritas/optical/gen/ScintillationGenerator.hh
+++ b/src/celeritas/optical/gen/ScintillationGenerator.hh
@@ -149,18 +149,18 @@ ScintillationGenerator::operator()(Generator& rng)
 
     // Sample polarization perpendicular to the photon direction
     photon.polarization = [&] {
-        Real3 temp = from_spherical(
+        Real3 pol = from_spherical(
             (cost > 0 ? -1 : 1) * std::sqrt(1 - ipow<2>(cost)), phi);
         Real3 perp = {-std::sin(phi), std::cos(phi), 0};
         real_type sinphi, cosphi;
         sincospi(UniformRealDist{}(rng), &sinphi, &cosphi);
         for (auto j : range(3))
         {
-            temp[j] = cosphi * temp[j] + sinphi * perp[j];
+            pol[j] = cosphi * pol[j] + sinphi * perp[j];
         }
         // Enforce orthogonality
-        temp -= dot_product(temp, photon.direction) * photon.direction;
-        return make_unit_vector(temp);
+        axpy(-dot_product(pol, photon.direction), photon.direction, &pol);
+        return make_unit_vector(pol);
     }();
     CELER_ASSERT(soft_zero(dot_product(photon.polarization, photon.direction)));
 

--- a/src/celeritas/optical/interactor/RayleighInteractor.hh
+++ b/src/celeritas/optical/interactor/RayleighInteractor.hh
@@ -92,13 +92,16 @@ CELER_FUNCTION Interaction RayleighInteractor::operator()(Engine& rng) const
         else
         {
             // Project polarization onto plane perpendicular to new direction
-            new_pol = make_unit_vector(inc_pol_ - projected_pol * new_dir);
+            new_pol = inc_pol_ - projected_pol * new_dir;
+            new_pol = make_unit_vector(
+                new_pol - dot_product(new_pol, new_dir) * new_dir);
             new_pol *= BernoulliDistribution{real_type{0.5}}(rng) ? 1 : -1;
         }
 
         // Accept with the probability of the scattered polarization overlap
         // squared
-    } while (RejectionSampler{ipow<2>(dot_product(new_pol, inc_pol_))}(rng));
+    } while (RejectionSampler{ipow<2>(
+        clamp<real_type>(dot_product(new_pol, inc_pol_), -1, 1))}(rng));
 
     CELER_ENSURE(is_soft_unit_vector(new_dir));
     CELER_ENSURE(is_soft_unit_vector(new_pol));

--- a/src/celeritas/optical/interactor/RayleighInteractor.hh
+++ b/src/celeritas/optical/interactor/RayleighInteractor.hh
@@ -93,9 +93,10 @@ CELER_FUNCTION Interaction RayleighInteractor::operator()(Engine& rng) const
         {
             // Project polarization onto plane perpendicular to new direction
             new_pol = inc_pol_ - projected_pol * new_dir;
+            // Enforce orthogonality
+            axpy(-dot_product(new_pol, new_dir), new_dir, &new_pol);
             new_pol = make_unit_vector(
-                new_pol - dot_product(new_pol, new_dir) * new_dir);
-            new_pol *= BernoulliDistribution{real_type{0.5}}(rng) ? 1 : -1;
+                BernoulliDistribution{0.5}(rng) ? new_pol : -new_pol);
         }
 
         // Accept with the probability of the scattered polarization overlap


### PR DESCRIPTION
This fills in the rest of the pre-step and along-step actions in the optical loop, enabling the volumetric models. It also fixes a few assertion failures that showed up in the process.