### PR TITLE
Extend auxiliary data helpers to support aux state data without params

### DIFF
--- a/doc/_static/zotero.bib
+++ b/doc/_static/zotero.bib
@@ -1607,7 +1607,8 @@
   author = {Johnson, Seth R.},
   year = {2023},
   month = dec,
-  address = {CERN}
+  address = {CERN},
+  url = {https://indico.cern.ch/event/1332507/contributions/5630782/attachments/2771072/4828307/rd-review.pdf}
 }
 
 @misc{johnson-celeritasscientific-2024,

--- a/doc/implementation/data-model.rst
+++ b/doc/implementation/data-model.rst
@@ -103,6 +103,4 @@ Users and other parts of the code can add their own shared and stream-local
 
 .. doxygenclass:: celeritas::AuxStateData
 
-.. doxygenfunction:: celeritas::make_aux_state
-
 .. doxygenclass:: celeritas::AuxStateVec

--- a/src/corecel/data/AuxStateData.hh
+++ b/src/corecel/data/AuxStateData.hh
@@ -43,6 +43,9 @@ class AuxStateData final : public AuxStateInterface
                         StreamId stream_id,
                         size_type size);
 
+    // Construct by resizing without params
+    inline AuxStateData(StreamId stream_id, size_type size);
+
     //! Whether any data is being stored
     explicit operator bool() const { return static_cast<bool>(store_); }
 
@@ -61,7 +64,7 @@ class AuxStateData final : public AuxStateInterface
 
 //---------------------------------------------------------------------------//
 /*!
- * Create an auxiliary state given a runtime memory space.
+ * Create an auxiliary state given a runtime memory space and host params.
  *
  * Example:
  * \code
@@ -91,6 +94,32 @@ make_aux_state(ParamsDataInterface<P> const& params,
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Create an auxiliary state given a runtime memory space.
+ *
+ * Example:
+ * \code
+    return make_aux_state<ParticleTallyStateData>(memspace, stream, size);
+ * \endcode
+ */
+template<template<Ownership, MemSpace> class S>
+std::unique_ptr<AuxStateInterface>
+make_aux_state(MemSpace m, StreamId stream_id, size_type size)
+{
+    if (m == MemSpace::host)
+    {
+        using ASD = AuxStateData<S, MemSpace::host>;
+        return std::make_unique<ASD>(stream_id, size);
+    }
+    else if (m == MemSpace::device)
+    {
+        using ASD = AuxStateData<S, MemSpace::device>;
+        return std::make_unique<ASD>(stream_id, size);
+    }
+    CELER_ASSERT_UNREACHABLE();
+}
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
@@ -102,6 +131,16 @@ AuxStateData<S, M>::AuxStateData(HostCRef<P> const& p,
                                  StreamId stream_id,
                                  size_type size)
     : store_{p, stream_id, size}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct by resizing.
+ */
+template<template<Ownership, MemSpace> class S, MemSpace M>
+AuxStateData<S, M>::AuxStateData(StreamId stream_id, size_type size)
+    : store_{stream_id, size}
 {
 }
 

--- a/src/corecel/data/AuxStateData.hh
+++ b/src/corecel/data/AuxStateData.hh
@@ -25,7 +25,16 @@ namespace celeritas
  * \c AuxParamsInterface subclass.
  *
  * The state class \c S must have a \c resize method that's constructable with
- * a templated params data class \c P, a stream ID, and a state size.
+ * an optional templated params data class \c P, a stream ID, and a state size.
+ *
+ * The \c make_aux_state helper functions can be used to construct this class:
+ * \code
+    return make_aux_state<FooStateData>(*this, memspace, stream, size);
+ * \endcode
+ * or
+ * \code
+    return make_aux_state<BarStateData>(memspace, stream, size);
+ * \endcode
  */
 template<template<Ownership, MemSpace> class S, MemSpace M>
 class AuxStateData final : public AuxStateInterface
@@ -62,15 +71,10 @@ class AuxStateData final : public AuxStateInterface
     CollectionStateStore<S, M> store_;
 };
 
+//! \cond (CELERITAS_DOC_DEV)
 //---------------------------------------------------------------------------//
 /*!
  * Create an auxiliary state given a runtime memory space and host params.
- *
- * Example:
- * \code
-    return make_aux_state<ParticleTallyStateData>(
-        *this, memspace, stream, size);
- * \endcode
  */
 template<template<Ownership, MemSpace> class S,
          template<Ownership, MemSpace> class P>
@@ -96,11 +100,6 @@ make_aux_state(ParamsDataInterface<P> const& params,
 //---------------------------------------------------------------------------//
 /*!
  * Create an auxiliary state given a runtime memory space.
- *
- * Example:
- * \code
-    return make_aux_state<ParticleTallyStateData>(memspace, stream, size);
- * \endcode
  */
 template<template<Ownership, MemSpace> class S>
 std::unique_ptr<AuxStateInterface>
@@ -118,6 +117,7 @@ make_aux_state(MemSpace m, StreamId stream_id, size_type size)
     }
     CELER_ASSERT_UNREACHABLE();
 }
+//! \endcond
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/src/corecel/data/CollectionStateStore.hh
+++ b/src/corecel/data/CollectionStateStore.hh
@@ -62,6 +62,9 @@ class CollectionStateStore
     template<template<Ownership, MemSpace> class P>
     inline CollectionStateStore(HostCRef<P> const& p, size_type size);
 
+    // Construct without parameters and with stream ID
+    explicit inline CollectionStateStore(StreamId stream_id, size_type size);
+
     // Construct without parameters
     explicit inline CollectionStateStore(size_type size);
 
@@ -135,6 +138,24 @@ CollectionStateStore<S, M>::CollectionStateStore(HostCRef<P> const& p,
 {
     CELER_EXPECT(size > 0);
     resize(&val_, p, size);
+    CELER_ASSERT(val_);
+
+    // Save reference
+    ref_ = val_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with stream ID and without parameters.
+ *
+ * A few states are constructed with a \c resize function that doesn't depend
+ * on any parameter data.
+ */
+template<template<Ownership, MemSpace> class S, MemSpace M>
+CollectionStateStore<S, M>::CollectionStateStore(StreamId sid, size_type size)
+{
+    CELER_EXPECT(size > 0);
+    resize(&val_, sid, size);
     CELER_ASSERT(val_);
 
     // Save reference


### PR DESCRIPTION
This is a little update to the aux helpers in preparation for some optical refactoring.