### PR TITLE
Move optical photon generation to optical stepping loop

### DIFF
--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -188,7 +188,7 @@ if not use_device:
       }
 if not use_device and "lar" in geometry_filename:
     expected_opt_sizes = {
-       "generators": 0,
+       "generators": 24576,
        "initializers": 32,
        "tracks": 32
     }

--- a/src/celeritas/global/CoreState.cc
+++ b/src/celeritas/global/CoreState.cc
@@ -68,8 +68,8 @@ CoreState<M>::CoreState(CoreParams const& params,
     if (params.aux_reg())
     {
         // Allocate auxiliary data
-        aux_state_
-            = AuxStateVec{*params.aux_reg(), M, stream_id, num_track_slots};
+        aux_state_ = std::make_shared<AuxStateVec>(
+            *params.aux_reg(), M, stream_id, num_track_slots);
     }
 
     if (is_action_sorted(params.init()->track_order()))
@@ -80,6 +80,7 @@ CoreState<M>::CoreState(CoreParams const& params,
     CELER_LOG(status) << "Celeritas core state initialization complete";
     CELER_ENSURE(states_);
     CELER_ENSURE(ptr_);
+    CELER_ENSURE(aux_state_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/CoreState.hh
+++ b/src/celeritas/optical/CoreState.hh
@@ -8,6 +8,7 @@
 
 #include "corecel/cont/Span.hh"
 #include "corecel/data/AuxInterface.hh"
+#include "corecel/data/AuxStateVec.hh"
 #include "corecel/data/CollectionStateStore.hh"
 #include "corecel/data/ObserverPtr.hh"
 #include "celeritas/Types.hh"
@@ -102,6 +103,7 @@ class CoreState final : public CoreStateBase
     //! \name Type aliases
     template<template<Ownership, MemSpace> class S>
     using StateRef = S<Ownership::reference, M>;
+    using SPAuxStateVec = std::shared_ptr<AuxStateVec>;
 
     using Ref = StateRef<CoreStateData>;
     using Ptr = ObserverPtr<Ref, M>;
@@ -136,6 +138,14 @@ class CoreState final : public CoreStateBase
     // Inject primaries to be turned into TrackInitializers
     void insert_primaries(Span<TrackInitializer const> host_primaries) final;
 
+    //// AUXILIARY DATA ////
+
+    //! Access auxiliary core state data
+    SPAuxStateVec const& aux() const { return aux_state_; }
+
+    //! Access auxiliary core state data (mutable)
+    SPAuxStateVec& aux() { return aux_state_; }
+
   private:
     // State data
     CollectionStateStore<CoreStateData, M> states_;
@@ -145,6 +155,9 @@ class CoreState final : public CoreStateBase
 
     // Native pointer to ref or
     Ptr ptr_;
+
+    // Auxiliary data owned by the core state
+    SPAuxStateVec aux_state_;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -532,7 +532,7 @@ TEST_F(LArSphereOffloadTest, scintillation_distributions)
         // No steps ran
         EXPECT_EQ(0, result.accum.steps);
         EXPECT_EQ(0, result.accum.step_iters);
-        EXPECT_EQ(16, result.accum.flushes);
+        EXPECT_EQ(0, result.accum.flushes);
         EXPECT_EQ(0, result.accum.cherenkov.distributions);
         EXPECT_EQ(0, result.accum.scintillation.distributions);
         EXPECT_EQ(0, result.accum.cherenkov.photons);
@@ -556,14 +556,16 @@ TEST_F(LArSphereOffloadTest, host_generate_small)
     auto_flush_ = 1;
     this->build_optical_collector();
 
-    // Run with 2 core track slots and 32 optical track slots
-    auto result = this->run<MemSpace::host>(4, 2, 2);
+    size_type primaries = 4;
+    size_type core_track_slots = 2;
+    size_type steps = 2;
+    auto result = this->run<MemSpace::host>(primaries, core_track_slots, steps);
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
-        EXPECT_EQ(1655, result.accum.steps);
-        EXPECT_EQ(56, result.accum.step_iters);
-        EXPECT_EQ(2, result.accum.flushes);
+        EXPECT_EQ(1712, result.accum.steps);
+        EXPECT_EQ(57, result.accum.step_iters);
+        EXPECT_EQ(1, result.accum.flushes);
         EXPECT_EQ(0, result.accum.cherenkov.distributions);
         EXPECT_EQ(2, result.accum.scintillation.distributions);
         EXPECT_EQ(0, result.accum.cherenkov.photons);
@@ -579,19 +581,21 @@ TEST_F(LArSphereOffloadTest, host_generate)
     auto_flush_ = 16384;
     this->build_optical_collector();
 
-    // Run with 512 core track slots and 2^18 optical track slots
-    auto result = this->run<MemSpace::host>(1, 512, 4);
+    size_type primaries = 1;
+    size_type core_track_slots = 512;
+    size_type steps = 4;
+    auto result = this->run<MemSpace::host>(primaries, core_track_slots, steps);
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         EXPECT_SOFT_NEAR(
-            456183.0, static_cast<double>(result.accum.steps), 1e-4);
-        EXPECT_EQ(43, result.accum.step_iters);
-        EXPECT_EQ(4, result.accum.flushes);
+            462263.0, static_cast<double>(result.accum.steps), 1e-4);
+        EXPECT_EQ(37, result.accum.step_iters);
+        EXPECT_EQ(3, result.accum.flushes);
         EXPECT_EQ(4, result.accum.cherenkov.distributions);
-        EXPECT_EQ(5, result.accum.scintillation.distributions);
-        EXPECT_EQ(3810, result.accum.cherenkov.photons);
-        EXPECT_EQ(275932, result.accum.scintillation.photons);
+        EXPECT_EQ(6, result.accum.scintillation.distributions);
+        EXPECT_EQ(3835, result.accum.cherenkov.photons);
+        EXPECT_EQ(279898, result.accum.scintillation.photons);
     }
 
     EXPECT_EQ(2, result.optical_launch_step);
@@ -607,13 +611,16 @@ TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_generate))
     auto_flush_ = 262144;
     this->build_optical_collector();
 
-    auto result = this->run<MemSpace::device>(1, num_track_slots_, 16);
-    result.print_expected();
+    size_type primaries = 1;
+    size_type core_track_slots = 1024;
+    size_type steps = 16;
+    auto result
+        = this->run<MemSpace::device>(primaries, core_track_slots, steps);
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
-        EXPECT_EQ(218370, result.scintillation.total_num_photons);
-        EXPECT_EQ(1798, result.cherenkov.total_num_photons);
+        EXPECT_EQ(218314, result.scintillation.total_num_photons);
+        EXPECT_EQ(2236, result.cherenkov.total_num_photons);
     }
     EXPECT_EQ(7, result.optical_launch_step);
 }


### PR DESCRIPTION
Follow-on to #1800.

This moves the optical generator actions from the core to the optical loop. Currently track initializers are still created and buffered at the start of the first optical step, but as a next step we can explore generating the photons directly in the track slots.