### PR TITLE
Fix orange polyhedron orientation and roundoff error

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -71,6 +71,25 @@ namespace
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Get a SolidEnclosedAngle, avoiding values slightly beyond 1 turn.
+ *
+ * This constructs from native Geant4 radians and truncates to \c real_type,
+ * ensuring that roundoff doesn't push the turn beyond a full one.
+ */
+SolidEnclosedAngle make_wedge(double start_rad, double delta_rad)
+{
+    auto start = native_value_to<RealTurn>(start_rad);
+    auto delta = native_value_to<RealTurn>(delta_rad);
+    if (soft_equal(delta.value(), real_type{1}))
+    {
+        // Avoid roundoff error
+        delta = RealTurn{1};
+    }
+    return SolidEnclosedAngle{start, delta};
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Get the enclosed azimuthal angle by a solid.
  *
  * This internally converts from native Geant4 radians.
@@ -78,8 +97,7 @@ namespace
 template<class S>
 SolidEnclosedAngle make_wedge_azimuthal(S const& solid)
 {
-    return SolidEnclosedAngle{native_value_to<Turn>(solid.GetStartPhiAngle()),
-                              native_value_to<Turn>(solid.GetDeltaPhiAngle())};
+    return make_wedge(solid.GetStartPhiAngle(), solid.GetDeltaPhiAngle());
 }
 
 //---------------------------------------------------------------------------//
@@ -93,8 +111,7 @@ SolidEnclosedAngle make_wedge_azimuthal(S const& solid)
 template<>
 SolidEnclosedAngle make_wedge_azimuthal<G4Torus>(G4Torus const& solid)
 {
-    return SolidEnclosedAngle{native_value_to<Turn>(solid.GetSPhi()),
-                              native_value_to<Turn>(solid.GetDPhi())};
+    return make_wedge(solid.GetSPhi(), solid.GetDPhi());
 }
 
 //---------------------------------------------------------------------------//
@@ -107,23 +124,19 @@ SolidEnclosedAngle make_wedge_azimuthal<G4Torus>(G4Torus const& solid)
 template<class S>
 SolidEnclosedAngle make_wedge_azimuthal_poly(S const& solid)
 {
-    auto start = native_value_to<Turn>(solid.GetStartPhi());
-    auto stop = native_value_to<Turn>(solid.GetEndPhi());
-    return SolidEnclosedAngle{start, stop - start};
+    auto start = solid.GetStartPhi();
+    auto stop = solid.GetEndPhi();
+    return make_wedge(start, stop - start);
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Get the enclosed polar angle by a solid.
- *
- * This internally converts from native Geant4 radians.
  */
 template<class S>
 SolidEnclosedAngle make_wedge_polar(S const& solid)
 {
-    return SolidEnclosedAngle{
-        native_value_to<Turn>(solid.GetStartThetaAngle()),
-        native_value_to<Turn>(solid.GetDeltaThetaAngle())};
+    return make_wedge(solid.GetStartThetaAngle(), solid.GetDeltaThetaAngle());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -1212,36 +1212,34 @@ void Prism::build(IntersectSurfaceBuilder& insert_surface) const
     insert_surface(Sense::outside, PlaneZ{-hh_});
     insert_surface(Sense::inside, PlaneZ{hh_});
 
-    // Offset (if user offset is zero) is calculated to put a plane on the
-    // -y face (sitting upright as visualized). An offset of 1 produces a
-    // shape congruent with an offset of zero, except that every face has
-    // an index that's decremented by 1.
+    // Offset (if user offset is zero) is calculated to put a point at y=0 on
+    // the +x axis. An offset of 1 would produce a shape congruent with an
+    // offset of zero, except that every face has an index that's decremented
+    // by 1. We prevent this by using fmod.
     real_type const offset
         = std::fmod(orientation_ + real_type{0.5}, real_type{1});
-
     CELER_ASSERT(offset >= 0 && offset < 1);
 
     // Change of angle in radians per side
-    real_type const delta_rad = 2 * pi / real_type(num_sides_);
+    Turn const delta{1 / static_cast<real_type>(num_sides_)};
 
     // Build prismatic sides
     for (auto n : range(num_sides_))
     {
         // Angle of outward normal, *not* of corner
-        real_type const theta = delta_rad * (n + offset);
+        auto theta = delta * (static_cast<real_type>(n) + offset);
 
-        // Create a normal vector along the X axis, then rotate it through
-        // the angle theta
+        // Create a normal vector with the given angle
         Real3 normal{0, 0, 0};
-        normal[to_int(Axis::x)] = std::cos(theta);
-        normal[to_int(Axis::y)] = std::sin(theta);
+        sincos(theta, &normal[to_int(Axis::y)], &normal[to_int(Axis::x)]);
 
+        // Distance from the plane to the origin is the apothem
         insert_surface(Plane{normal, apothem_});
     }
 
     // Apothem is interior, circumradius exterior
     insert_surface(Sense::inside,
-                   make_xyradial_bbox(apothem_ / std::cos(delta_rad / 2)));
+                   make_xyradial_bbox(apothem_ / cos(delta / 2)));
 
     auto interior_bbox = make_xyradial_bbox(apothem_);
     interior_bbox.shrink(Bound::lo, Axis::z, -hh_);

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -1216,8 +1216,9 @@ void Prism::build(IntersectSurfaceBuilder& insert_surface) const
     // -y face (sitting upright as visualized). An offset of 1 produces a
     // shape congruent with an offset of zero, except that every face has
     // an index that's decremented by 1.
-    real_type const offset = std::fmod(num_sides_ * 3 + 4 * orientation_, 4)
-                             / 4;
+    real_type const offset
+        = std::fmod(orientation_ + real_type{0.5}, real_type{1});
+
     CELER_ASSERT(offset >= 0 && offset < 1);
 
     // Change of angle in radians per side
@@ -1226,6 +1227,7 @@ void Prism::build(IntersectSurfaceBuilder& insert_surface) const
     // Build prismatic sides
     for (auto n : range(num_sides_))
     {
+        // Angle of outward normal, *not* of corner
         real_type const theta = delta_rad * (n + offset);
 
         // Create a normal vector along the X axis, then rotate it through

--- a/src/orange/orangeinp/IntersectRegion.hh
+++ b/src/orange/orangeinp/IntersectRegion.hh
@@ -672,19 +672,23 @@ class Parallelepiped final : public IntersectRegionInterface
  * A regular, z-extruded polygon centered on the origin.
  *
  * This is the base component of a G4Polyhedra (PGON). The default rotation is
- * to put a y-aligned plane on the bottom of the shape, so looking at an x-y
- * slice given an apothem \em a, every shape has a surface at \f$ y = -a \f$:
- * - n=3 is a triangle with a flat bottom, point up
- * - n=4 is a square with axis-aligned sides
- * - n=6 is a flat-top hexagon
+ * to put the first point at \f$ y = 0 \f$. Looking at an x-y
+ * slice for a prism with apothem \em a, odd-numbered prisms have a plane at
+ * \f$ x=-a \f$:
+ * - \f$ n=3 \f$ is a triangle pointing right,
+ * - \f$ n=4 \f$ is a diamond,
+ * - \f$ n=5 \f$ is a tilted pentagon (flat on the left), and
+ * - \f$ n=6 \f$ is a flat-top hexagon.
+ *
  *
  * The "orientation" parameter is a scaled counterclockwise rotation on
  * \f$[0, 1)\f$, where zero preserves the orientation described above, and
- * unity replicates the original shape but with the "p0" face being where the
- * "p1" originally was. With a value of 0.5:
- * - n=3 is a downward-pointing triangle
- * - n=4 is a diamond
- * - n=6 is a pointy-top hexagon
+ * unity would replicate the original shape but with the "p0" face being where
+ * the "p1" originally was. With a value of 0.5:
+ * - \f$ n=3 \f$ is a triangle pointing left
+ * - \f$ n=4 \f$ is an upright square,
+ * - \f$ n=5 \f$ is a tilted pentagon (flat on the right), and
+ * - \f$ n=6 \f$ is a pointy-top hexagon.
  */
 class Prism final : public IntersectRegionInterface
 {

--- a/src/orange/orangeinp/IntersectRegion.hh
+++ b/src/orange/orangeinp/IntersectRegion.hh
@@ -731,7 +731,7 @@ class Prism final : public IntersectRegionInterface
     // Half the z height
     real_type hh_;
 
-    // Rotational offset (0 has bottom face at -Y, 1 is congruent)
+    // Rotational offset: 0 has point at (r, 0), 1 is congruent with 0
     real_type orientation_;
 };
 

--- a/test/geocel/CMakeLists.txt
+++ b/test/geocel/CMakeLists.txt
@@ -81,6 +81,7 @@ if(CELERITAS_USE_VecGeom)
       "TwoBoxesVgdmlTest.*"
       "SimpleCmsVgdmlTest.*"
       "FourLevelsVgdmlTest.*"
+      # Polyhedra doesn't work because of anonymous postions
     )
     if(NOT VecGeom_SURF_FOUND)
       list(APPEND _vecgeom_tests "SolidsVgdmlTest.*" "MultiLevelVgdmlTest.*")
@@ -92,6 +93,7 @@ if(CELERITAS_USE_VecGeom)
       "CmsEeBackDeeTest.*"
       "FourLevelsTest.*"
       "MultiLevelTest.*"
+      "PolyhedraTest.*"
       "ReplicaTest.*"
       "TransformedBoxTest.*"
       "ZnenvTest.*"

--- a/test/geocel/CMakeLists.txt
+++ b/test/geocel/CMakeLists.txt
@@ -81,7 +81,7 @@ if(CELERITAS_USE_VecGeom)
       "TwoBoxesVgdmlTest.*"
       "SimpleCmsVgdmlTest.*"
       "FourLevelsVgdmlTest.*"
-      # Polyhedra doesn't work because of anonymous postions
+      # Polyhedra doesn't work because of anonymous position tags
     )
     if(NOT VecGeom_SURF_FOUND)
       list(APPEND _vecgeom_tests "SolidsVgdmlTest.*" "MultiLevelVgdmlTest.*")

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -528,6 +528,245 @@ void MultiLevelGeoTest::test_trace() const
 }
 
 //---------------------------------------------------------------------------//
+// POLYHEDRA
+//---------------------------------------------------------------------------//
+void PolyhedraGeoTest::test_trace() const
+{
+    auto fixup_orange = [is_orange = test_->geometry_type() == "ORANGE"](
+                            GenericGeoTrackingResult& ref,
+                            GenericGeoTrackingResult& result) {
+        if (!is_orange)
+            return ref.volume_instances.clear();
+        // Delete PV (not implmented)
+        ref.volume_instances.clear();
+
+        // Delete within-world safeties
+        for (auto i :
+             range(std::max(ref.volumes.size(), result.volumes.size())))
+        {
+            if (ref.volumes[i] == "world")
+            {
+                result.halfway_safeties[i] = 0;
+                ref.halfway_safeties[i] = 0;
+            }
+        }
+    };
+
+    {
+        SCOPED_TRACE("tri");
+        auto result = test_->track({-6, 4.01, 0}, {1, 0, 0});
+        GenericGeoTrackingResult ref;
+        ref.volumes = {
+            "world",
+            "tri",
+            "world",
+            "tri_third",
+            "world",
+            "tri_half",
+            "world",
+            "tri_full",
+            "world",
+        };
+        ref.volume_instances = {
+            "world_PV",
+            "tri0_pv",
+            "world_PV",
+            "tri30_pv",
+            "world_PV",
+            "tri60_pv",
+            "world_PV",
+            "tri90_pv",
+            "world_PV",
+        };
+        ref.distances = {
+            1,
+            2.9826794919243,
+            0.70352222243164,
+            2.3816157604626,
+            0.94950303325711,
+            2.9826794919243,
+            2,
+            2.9826794919243,
+            10.017320508076,
+        };
+        ref.halfway_safeties = {
+            0.5,
+            0.74566987298108,
+            0.26946464455223,
+            0.91221175947349,
+            0.44612049688277,
+            0.74566987298108,
+            1,
+            0.74566987298108,
+            4.5,
+        };
+        ref.bumps = {};
+        fixup_orange(ref, result);
+        auto tol = GenericGeoTrackingTolerance::from_test(*test_);
+        EXPECT_RESULT_NEAR(ref, result, tol);
+    }
+    {
+        SCOPED_TRACE("quad");
+        auto result = test_->track({-6, 0.01, 0}, {1, 0, 0});
+        GenericGeoTrackingResult ref;
+        ref.volumes = {
+            "world",
+            "quad",
+            "world",
+            "quad_third",
+            "world",
+            "quad_half",
+            "world",
+            "quad_full",
+            "world",
+        };
+        ref.volume_instances = {
+            "world_PV",
+            "quad0_pv",
+            "world_PV",
+            "quad30_pv",
+            "world_PV",
+            "quad60_pv",
+            "world_PV",
+            "quad90_pv",
+            "world_PV",
+        };
+        ref.distances = {
+            0.5957864376269,
+            2.8084271247462,
+            1.5631897491411,
+            2.0705523608202,
+            1.9620443276656,
+            2,
+            1.5957864376269,
+            2.8084271247462,
+            10.595786437627,
+        };
+        ref.halfway_safeties = {
+            0.28806684196341,
+            0.99292893218813,
+            0.75496267504288,
+            0.9896472381959,
+            0.94759464420809,
+            0.99,
+            0.78795667663408,
+            0.99292893218813,
+            4.5,
+        };
+        ref.bumps = {};
+        fixup_orange(ref, result);
+        auto tol = GenericGeoTrackingTolerance::from_test(*test_);
+        EXPECT_RESULT_NEAR(ref, result, tol);
+    }
+    {
+        SCOPED_TRACE("penta");
+        auto result = test_->track({-6, -4.01, 0}, {1, 0, 0});
+        GenericGeoTrackingResult ref;
+        ref.volumes = {
+            "world",
+            "penta",
+            "world",
+            "penta_third",
+            "world",
+            "penta_half",
+            "world",
+            "penta_full",
+            "world",
+        };
+        ref.volume_instances = {
+            "world_PV",
+            "penta0_pv",
+            "world_PV",
+            "penta30_pv",
+            "world_PV",
+            "penta60_pv",
+            "world_PV",
+            "penta90_pv",
+            "world_PV",
+        };
+        ref.distances = {
+            1,
+            2.2288025522197,
+            1.6810134561273,
+            2.1103990209013,
+            1.7509824185319,
+            2.2288025522197,
+            2,
+            2.2288025522197,
+            10.77119744778,
+        };
+        ref.halfway_safeties = {
+            0.5,
+            0.90156957092601,
+            0.76944173562526,
+            0.96397271967888,
+            0.85635962580704,
+            0.90156957092601,
+            1,
+            0.90156957092601,
+            4.5,
+        };
+        ref.bumps = {};
+        fixup_orange(ref, result);
+        auto tol = GenericGeoTrackingTolerance::from_test(*test_);
+        EXPECT_RESULT_NEAR(ref, result, tol);
+    }
+    {
+        SCOPED_TRACE("hex");
+        auto result = test_->track({-6, -8.01, 0}, {1, 0, 0});
+        GenericGeoTrackingResult ref;
+        ref.volumes = {
+            "world",
+            "hex",
+            "world",
+            "hex_third",
+            "world",
+            "hex_half",
+            "world",
+            "hex_full",
+            "world",
+        };
+        ref.volume_instances = {
+            "world_PV",
+            "hex0_pv",
+            "world_PV",
+            "hex30_pv",
+            "world_PV",
+            "hex60_pv",
+            "world_PV",
+            "hex90_pv",
+            "world_PV",
+        };
+        ref.distances = {
+            0.85107296431264,
+            2.2978540713747,
+            1.8338830826198,
+            2.0308532237715,
+            1.9863366579213,
+            2,
+            1.8510729643126,
+            2.2978540713747,
+            10.851072964313,
+        };
+        ref.halfway_safeties = {
+            0.41988207740847,
+            0.99,
+            0.90301113894096,
+            0.99120614758428,
+            0.97807987040665,
+            0.99133974596216,
+            0.9198173396894,
+            0.99,
+            4.5,
+        };
+        ref.bumps = {};
+        fixup_orange(ref, result);
+        auto tol = GenericGeoTrackingTolerance::from_test(*test_);
+        EXPECT_RESULT_NEAR(ref, result, tol);
+    }
+}
+
+//---------------------------------------------------------------------------//
 // REPLICA
 //---------------------------------------------------------------------------//
 

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -532,11 +532,12 @@ void MultiLevelGeoTest::test_trace() const
 //---------------------------------------------------------------------------//
 void PolyhedraGeoTest::test_trace() const
 {
-    auto fixup_orange = [is_orange = test_->geometry_type() == "ORANGE"](
+    auto fixup_orange = [is_orange = (test_->geometry_type() == "ORANGE")](
                             GenericGeoTrackingResult& ref,
                             GenericGeoTrackingResult& result) {
         if (!is_orange)
-            return ref.volume_instances.clear();
+            return;
+        ref.volume_instances.clear();
         // Delete PV (not implmented)
         ref.volume_instances.clear();
 

--- a/test/geocel/GeoTests.hh
+++ b/test/geocel/GeoTests.hh
@@ -99,6 +99,24 @@ class MultiLevelGeoTest
 
 //---------------------------------------------------------------------------//
 /*!
+ * Test a bunch of polyhedra.
+ */
+class PolyhedraGeoTest
+{
+  public:
+    static std::string_view geometry_basename() { return "polyhedra"; }
+
+    //! Construct with a reference to the GoogleTest
+    PolyhedraGeoTest(GenericGeoTestInterface* geo_test) : test_{geo_test} {}
+
+    void test_trace() const;
+
+  private:
+    GenericGeoTestInterface* test_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Test the B5 (replica) geometry.
  */
 class ReplicaGeoTest

--- a/test/geocel/data/polyhedra.gdml
+++ b/test/geocel/data/polyhedra.gdml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+  <define/>
+
+  <materials>
+    <isotope N="40" Z="18" name="Ar40">
+      <atom unit="g/mole" value="39.9624"/>
+    </isotope>
+    <element name="Ar">
+      <fraction n="1.0" ref="Ar40"/>
+    </element>
+    <material name="lAr" state="liquid">
+      <T unit="K" value="293.15"/>
+      <D unit="g/cm3" value="1.396"/>
+      <fraction n="1" ref="Ar"/>
+    </material>
+    <isotope N="208" Z="82" name="Pb208">
+      <atom unit="g/mole" value="207.977"/>
+    </isotope>
+    <element name="Pb-el">
+      <fraction n="0.524" ref="Pb208"/>
+    </element>
+    <material name="Pb" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="823"/>
+      <D unit="g/cm3" value="11.35"/>
+      <fraction n="1" ref="Pb-el"/>
+    </material>
+  </materials>
+
+  <solids>
+    <polyhedra name="tri" aunit="deg" deltaphi="360" lunit="mm" numsides="3" startphi="0">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="tri_third" aunit="deg" deltaphi="360" lunit="mm" numsides="3" startphi="40">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="tri_half" aunit="deg" deltaphi="360" lunit="mm" numsides="3" startphi="60">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="tri_full" aunit="deg" deltaphi="360" lunit="mm" numsides="3" startphi="120">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="quad" aunit="deg" deltaphi="360" lunit="mm" numsides="4" startphi="0">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="quad_third" aunit="deg" deltaphi="360" lunit="mm" numsides="4" startphi="30">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="quad_half" aunit="deg" deltaphi="360" lunit="mm" numsides="4" startphi="45">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="quad_full" aunit="deg" deltaphi="360" lunit="mm" numsides="4" startphi="90">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="penta" aunit="deg" deltaphi="360" lunit="mm" numsides="5" startphi="0">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="penta_third" aunit="deg" deltaphi="360" lunit="mm" numsides="5" startphi="24">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="penta_half" aunit="deg" deltaphi="360" lunit="mm" numsides="5" startphi="36">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="penta_full" aunit="deg" deltaphi="360" lunit="mm" numsides="5" startphi="72">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="hex" aunit="deg" deltaphi="360" lunit="mm" numsides="6" startphi="0">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="hex_third" aunit="deg" deltaphi="360" lunit="mm" numsides="6" startphi="20">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="hex_half" aunit="deg" deltaphi="360" lunit="mm" numsides="6" startphi="30">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <polyhedra name="hex_full" aunit="deg" deltaphi="360" lunit="mm" numsides="6" startphi="60">
+      <zplane rmax="10" rmin="0" z="-20"/>
+      <zplane rmax="10" rmin="0" z="20"/>
+    </polyhedra>
+    <box lunit="mm" name="worldbox" x="400" y="400" z="90"/>
+  </solids>
+
+  <structure>
+    <volume name="tri">
+      <solidref ref="tri"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="tri_third">
+      <solidref ref="tri_third"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="tri_half">
+      <solidref ref="tri_half"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="tri_full">
+      <solidref ref="tri_full"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="quad">
+      <solidref ref="quad"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="quad_third">
+      <solidref ref="quad_third"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="quad_half">
+      <solidref ref="quad_half"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="quad_full">
+      <solidref ref="quad_full"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="penta">
+      <solidref ref="penta"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="penta_third">
+      <solidref ref="penta_third"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="penta_half">
+      <solidref ref="penta_half"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="penta_full">
+      <solidref ref="penta_full"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="hex">
+      <solidref ref="hex"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="hex_third">
+      <solidref ref="hex_third"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="hex_half">
+      <solidref ref="hex_half"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="hex_full">
+      <solidref ref="hex_full"/>
+      <materialref ref="Pb"/>
+    </volume>
+    <volume name="world">
+      <solidref ref="worldbox"/>
+      <materialref ref="lAr"/>
+      <physvol name="tri0_pv">
+        <volumeref ref="tri"/>
+        <position unit="mm" x="-40.0" y="40.0" z="0.0"/>
+      </physvol>
+      <physvol name="tri30_pv">
+        <volumeref ref="tri_third"/>
+        <position unit="mm" x="0.0" y="40.0" z="0.0"/>
+      </physvol>
+      <physvol name="tri60_pv">
+        <volumeref ref="tri_half"/>
+        <position unit="mm" x="40.0" y="40.0" z="0.0"/>
+      </physvol>
+      <physvol name="tri90_pv">
+        <volumeref ref="tri_full"/>
+        <position unit="mm" x="80.0" y="40.0" z="0.0"/>
+      </physvol>
+      <physvol name="quad0_pv">
+        <volumeref ref="quad"/>
+        <position unit="mm" x="-40.0" y="0.0" z="0.0"/>
+      </physvol>
+      <physvol name="quad30_pv">
+        <volumeref ref="quad_third"/>
+        <position unit="mm" x="0.0" y="0.0" z="0.0"/>
+      </physvol>
+      <physvol name="quad60_pv">
+        <volumeref ref="quad_half"/>
+        <position unit="mm" x="40.0" y="0.0" z="0.0"/>
+      </physvol>
+      <physvol name="quad90_pv">
+        <volumeref ref="quad_full"/>
+        <position unit="mm" x="80.0" y="0.0" z="0.0"/>
+      </physvol>
+      <physvol name="penta0_pv">
+        <volumeref ref="penta"/>
+        <position unit="mm" x="-40.0" y="-40.0" z="0.0"/>
+      </physvol>
+      <physvol name="penta30_pv">
+        <volumeref ref="penta_third"/>
+        <position unit="mm" x="0.0" y="-40.0" z="0.0"/>
+      </physvol>
+      <physvol name="penta60_pv">
+        <volumeref ref="penta_half"/>
+        <position unit="mm" x="40.0" y="-40.0" z="0.0"/>
+      </physvol>
+      <physvol name="penta90_pv">
+        <volumeref ref="penta_full"/>
+        <position unit="mm" x="80.0" y="-40.0" z="0.0"/>
+      </physvol>
+      <physvol name="hex0_pv">
+        <volumeref ref="hex"/>
+        <position unit="mm" x="-40.0" y="-80.0" z="0.0"/>
+      </physvol>
+      <physvol name="hex30_pv">
+        <volumeref ref="hex_third"/>
+        <position unit="mm" x="0.0" y="-80.0" z="0.0"/>
+      </physvol>
+      <physvol name="hex60_pv">
+        <volumeref ref="hex_half"/>
+        <position unit="mm" x="40.0" y="-80.0" z="0.0"/>
+      </physvol>
+      <physvol name="hex90_pv">
+        <volumeref ref="hex_full"/>
+        <position unit="mm" x="80.0" y="-80.0" z="0.0"/>
+      </physvol>
+    </volume>
+  </structure>
+
+  <setup name="Default" version="1.0">
+    <world ref="world"/>
+  </setup>
+
+</gdml>

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -443,6 +443,16 @@ TEST_F(PincellTest, imager)
 }
 
 //---------------------------------------------------------------------------//
+
+using PolyhedraTest
+    = GenericGeoParameterizedTest<GeantGeoTest, PolyhedraGeoTest>;
+
+TEST_F(PolyhedraTest, trace)
+{
+    TestImpl(this).test_trace();
+}
+
+//---------------------------------------------------------------------------//
 using ReplicaTest = GenericGeoParameterizedTest<GeantGeoTest, ReplicaGeoTest>;
 
 TEST_F(ReplicaTest, trace)

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -621,6 +621,16 @@ TEST_F(MultiLevelTest, trace)
 }
 
 //---------------------------------------------------------------------------//
+
+using PolyhedraTest
+    = GenericGeoParameterizedTest<VecgeomGeantTestBase, PolyhedraGeoTest>;
+
+TEST_F(PolyhedraTest, trace)
+{
+    TestImpl(this).test_trace();
+}
+
+//---------------------------------------------------------------------------//
 class ReplicaTest
     : public GenericGeoParameterizedTest<VecgeomGeantTestBase, ReplicaGeoTest>
 {

--- a/test/orange/OrangeGeant.test.cc
+++ b/test/orange/OrangeGeant.test.cc
@@ -51,16 +51,6 @@ class GeantOrangeTest : public OrangeGeoTestBase
 };
 
 //---------------------------------------------------------------------------//
-
-using PolyhedraTest
-    = GenericGeoParameterizedTest<GeantOrangeTest, PolyhedraGeoTest>;
-
-TEST_F(PolyhedraTest, trace)
-{
-    this->impl().test_trace();
-}
-
-//---------------------------------------------------------------------------//
 class PincellTest : public GeantOrangeTest
 {
     std::string geometry_basename() const final { return "pincell"; }
@@ -84,6 +74,16 @@ TEST_F(PincellTest, imager)
     inp.lower_left = from_cm({-12, 0, -12});
     inp.upper_right = from_cm({12, 0, 12});
     write_image(ImageParams{inp}, "org-pincell-xz-mid.jsonl");
+}
+
+//---------------------------------------------------------------------------//
+
+using PolyhedraTest
+    = GenericGeoParameterizedTest<GeantOrangeTest, PolyhedraGeoTest>;
+
+TEST_F(PolyhedraTest, trace)
+{
+    this->impl().test_trace();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeGeant.test.cc
+++ b/test/orange/OrangeGeant.test.cc
@@ -51,6 +51,16 @@ class GeantOrangeTest : public OrangeGeoTestBase
 };
 
 //---------------------------------------------------------------------------//
+
+using PolyhedraTest
+    = GenericGeoParameterizedTest<GeantOrangeTest, PolyhedraGeoTest>;
+
+TEST_F(PolyhedraTest, trace)
+{
+    this->impl().test_trace();
+}
+
+//---------------------------------------------------------------------------//
 class PincellTest : public GeantOrangeTest
 {
     std::string geometry_basename() const final { return "pincell"; }

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -186,6 +186,10 @@ void SolidConverterTest::build_and_test(G4VSolid const& solid,
 }
 
 //---------------------------------------------------------------------------//
+// SOLID TESTS
+// NOTE: keep these alphabetically ordered
+//---------------------------------------------------------------------------//
+
 TEST_F(SolidConverterTest, box)
 {
     this->build_and_test(
@@ -264,18 +268,6 @@ TEST_F(SolidConverterTest, ellipticalcone)
         G4EllipticalCone("testEllipticalCone", 0.4, 0.8, 50, 25),
         R"json({"_type":"shape","interior":{"_type":"ellipticalcone","halfheight":2.5,"lower_radii":[3.0,6.0],"upper_radii":[1.0,2.0]},"label":"testEllipticalCone"})json",
         {{0, 0, 0}, {0, 0, 24.9}, {0., 0, -24.9}});
-}
-
-TEST_F(SolidConverterTest, torus)
-{
-    G4Torus torus("testTorus", 0 * cm, 20 * cm, 50 * cm, 0 * deg, 270 * deg);
-    auto json_str
-        = R"json({"_type":"solid","enclosed_angle":{"interior":0.75,"start":0.0},"excluded":{"_type":"cylinder","halfheight":20.0,"radius":30.0},"interior":{"_type":"cylinder","halfheight":20.0,"radius":70.0},"label":"testTorus"})json";
-
-    SolidConverter convert{scale_, transform_};
-    auto obj = convert(torus);
-    CELER_ASSERT(obj);
-    EXPECT_JSON_EQ(json_str, to_string(*obj));
 }
 
 TEST_F(SolidConverterTest, generictrap)
@@ -540,6 +532,18 @@ TEST_F(SolidConverterTest, subtractionsolid)
         G4SubtractionSolid("t1Subtractionb3", &t1, &b3, transform),
         R"json({"_type":"all","daughters":[{"_type":"shape","interior":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"label":"Solid Tube #1"},{"_type":"negated","daughter":{"_type":"transformed","daughter":{"_type":"shape","interior":{"_type":"box","halfwidths":[1.0,2.0,5.0]},"label":"Test Box #3"},"transform":{"_type":"transformation","data":[-1.0,1.2246467991473532e-16,0.0,-1.2246467991473532e-16,-1.0,-0.0,0.0,0.0,1.0,0.0,3.0,0.0]}},"label":""}],"label":"t1Subtractionb3"})json",
         {{0, 0, 0}, {0, 0, 10}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1}});
+}
+
+TEST_F(SolidConverterTest, torus)
+{
+    G4Torus torus("testTorus", 0 * cm, 20 * cm, 50 * cm, 0 * deg, 270 * deg);
+    auto json_str
+        = R"json({"_type":"solid","enclosed_angle":{"interior":0.75,"start":0.0},"excluded":{"_type":"cylinder","halfheight":20.0,"radius":30.0},"interior":{"_type":"cylinder","halfheight":20.0,"radius":70.0},"label":"testTorus"})json";
+
+    SolidConverter convert{scale_, transform_};
+    auto obj = convert(torus);
+    CELER_ASSERT(obj);
+    EXPECT_JSON_EQ(json_str, to_string(*obj));
 }
 
 TEST_F(SolidConverterTest, trap)

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -484,6 +484,33 @@ TEST_F(SolidConverterTest, polyhedra)
          {7.15, 7.15, 0.05},
          {3.0, 6.01, 0},
          {6.18, 7.15, 0}});
+
+    // Triangle
+    static double const z2[] = {10, 50};
+    static double const rmin2[] = {0, 0};
+    static double const rmax2[] = {10, 10};
+    this->build_and_test(
+        G4Polyhedra(
+            "tri", 30 * deg, 360 * deg, 3, std::size(z2), z2, rmin2, rmax2),
+        R"json({"_type":"transformed","daughter":{"_type":"shape","interior":{"_type":"prism","apothem":0.9999999999999999,"halfheight":2.0,"num_sides":3,"orientation":0.25},"label":"tri"},"transform":{"_type":"translation","data":[0.0,0.0,3.0]}})json",
+        {
+            {0, 0, 0.9},
+            {0, 0, 1.1},
+            {0, 0, 4.9},
+            {0, 0, 5.1},
+            {0, 1.01, 1.1},
+            {0, -1.01, 1.1},
+        });
+    // Rotate 60 degrees
+    this->build_and_test(
+        G4Polyhedra(
+            "tri", 60 * deg, 360 * deg, 3, std::size(z2), z2, rmin2, rmax2),
+        R"json({"_type":"transformed","daughter":{"_type":"shape","interior":{"_type":"prism","apothem":0.9999999999999999,"halfheight":2.0,"num_sides":3,"orientation":0.5},"label":"tri"},"transform":{"_type":"translation","data":[0.0,0.0,3.0]}})json");
+    // Rotate 90 degrees
+    this->build_and_test(
+        G4Polyhedra(
+            "tri", 90 * deg, 360 * deg, 3, std::size(z2), z2, rmin2, rmax2),
+        R"json({"_type":"transformed","daughter":{"_type":"shape","interior":{"_type":"prism","apothem":0.9999999999999999,"halfheight":2.0,"num_sides":3,"orientation":0.75},"label":"tri"},"transform":{"_type":"translation","data":[0.0,0.0,3.0]}})json");
 }
 
 TEST_F(SolidConverterTest, sphere)

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -1885,69 +1885,68 @@ TEST_F(PrismTest, errors)
 TEST_F(PrismTest, triangle)
 {
     auto result = this->test(Prism(3, 1.0, 1.2, 0.0));
-
-    static char const expected_node[] = "all(+0, -1, -2, +3, +4)";
-    static char const* const expected_surfaces[] = {
-        "Plane: z=-1.2",
-        "Plane: z=1.2",
-        "Plane: n={0.86603,0.5,0}, d=1",
-        "Plane: n={0.86603,-0.5,0}, d=-1",
-        "Plane: y=-1",
-    };
+    static char const expected_node[] = "all(+0, -1, -2, +3, -4)";
+    static char const* const expected_surfaces[] = {"Plane: z=-1.2",
+                                                    "Plane: z=1.2",
+                                                    "Plane: "
+                                                    "n={0.5,0.86603,0}, d=1",
+                                                    "Plane: x=-1",
+                                                    "Plane: "
+                                                    "n={0.5,-0.86603,0}, d=1"};
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
     EXPECT_VEC_SOFT_EQ((Real3{-1, -1, -1.2}), result.interior.lower());
     EXPECT_VEC_SOFT_EQ((Real3{1, 1, 1.2}), result.interior.upper());
-    EXPECT_VEC_SOFT_EQ((Real3{-2, -1, -1.2}), result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{-1, -2, -1.2}), result.exterior.lower());
     EXPECT_VEC_SOFT_EQ((Real3{2, 2, 1.2}), result.exterior.upper());
 }
 
 TEST_F(PrismTest, rtriangle)
 {
     auto result = this->test(Prism(3, 1.0, 1.2, 0.5));
-
-    static char const expected_node[] = "all(+0, -1, -2, +3, -4)";
-    static char const* const expected_surfaces[] = {
-        "Plane: z=-1.2",
-        "Plane: z=1.2",
-        "Plane: y=1",
-        "Plane: n={0.86603,0.5,0}, d=-1",
-        "Plane: n={0.86603,-0.5,0}, d=1",
-    };
+    static char const expected_node[] = "all(+0, -1, -2, +3, +4)";
+    static char const* const expected_surfaces[] = {"Plane: z=-1.2",
+                                                    "Plane: z=1.2",
+                                                    "Plane: x=1",
+                                                    "Plane: "
+                                                    "n={0.5,-0.86603,0}, d=-1",
+                                                    "Plane: "
+                                                    "n={0.5,0.86603,0}, d=-1"};
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
     EXPECT_VEC_SOFT_EQ((Real3{-1, -1, -1.2}), result.interior.lower());
     EXPECT_VEC_SOFT_EQ((Real3{1, 1, 1.2}), result.interior.upper());
     EXPECT_VEC_SOFT_EQ((Real3{-2, -2, -1.2}), result.exterior.lower());
-    EXPECT_VEC_SOFT_EQ((Real3{2, 1, 1.2}), result.exterior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{1, 2, 1.2}), result.exterior.upper());
 }
 
 TEST_F(PrismTest, square)
 {
     auto result = this->test(Prism(4, 1.0, 2.0, 0.0));
-
-    static char const expected_node[] = "all(+0, -1, -2, -3, +4, +5)";
-    static char const* const expected_surfaces[] = {"Plane: z=-2",
-                                                    "Plane: z=2",
-                                                    "Plane: x=1",
-                                                    "Plane: y=1",
-                                                    "Plane: x=-1",
-                                                    "Plane: y=-1"};
+    static char const expected_node[] = "all(+0, -1, -2, +3, +4, -5)";
+    static char const* const expected_surfaces[]
+        = {"Plane: z=-2",
+           "Plane: z=2",
+           "Plane: n={0.70711,0.70711,0}, d=1",
+           "Plane: n={0.70711,-0.70711,0}, d=-1",
+           "Plane: n={0.70711,0.70711,0}, d=-1",
+           "Plane: n={0.70711,-0.70711,0}, d=1"};
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
     EXPECT_VEC_SOFT_EQ((Real3{-1, -1, -2}), result.interior.lower());
     EXPECT_VEC_SOFT_EQ((Real3{1, 1, 2}), result.interior.upper());
-    EXPECT_VEC_SOFT_EQ((Real3{-1, -1, -2}), result.exterior.lower());
-    EXPECT_VEC_SOFT_EQ((Real3{1, 1, 2}), result.exterior.upper());
+    EXPECT_VEC_SOFT_EQ((Real3{-1.4142135623731, -1.4142135623731, -2}),
+                       result.exterior.lower());
+    EXPECT_VEC_SOFT_EQ((Real3{1.4142135623731, 1.4142135623731, 2}),
+                       result.exterior.upper());
 }
 
 TEST_F(PrismTest, hex)
 {
     auto result = this->test(Prism(6, 1.0, 2.0, 0.0));
-
     static char const expected_node[] = "all(+0, -1, -2, -3, +4, +5, +6, -7)";
     static char const* const expected_surfaces[]
         = {"Plane: z=-2",
@@ -1971,7 +1970,6 @@ TEST_F(PrismTest, hex)
 TEST_F(PrismTest, rhex)
 {
     auto result = this->test(Prism(6, 1.0, 2.0, 0.5));
-
     static char const expected_node[] = "all(+0, -1, -2, -3, +4, +5, +6, -7)";
     static char const* const expected_surfaces[]
         = {"Plane: z=-2",

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -1532,11 +1532,12 @@ TEST_F(InfWedgeTest, quarter_turn)
         SCOPED_TRACE("west quadrant");
         auto result = this->test(InfWedge(Turn{0.375}, Turn{0.25}));
         static char const expected_node[] = "all(-2, -3)";
-        static char const* const expected_surfaces[]
-            = {"Plane: y=0",
-               "Plane: x=0",
-               "Plane: n={0.70711,-0.70711,0}, d=0",
-               "Plane: n={0.70711,0.70711,0}, d=0"};
+        static char const* const expected_surfaces[] = {
+            "Plane: y=0",
+            "Plane: x=0",
+            "Plane: n={0.70711,-0.70711,0}, d=0",
+            "Plane: n={0.70711,0.70711,0}, d=0",
+        };
 
         EXPECT_EQ(expected_node, result.node);
         EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -1781,12 +1782,14 @@ TEST_F(ParallelepipedTest, box)
         = this->test(Parallelepiped(sides, Turn(0.0), Turn(0.0), Turn(0.0)));
 
     static char const expected_node[] = "all(+0, -1, +2, -3, +4, -5)";
-    static char const* const expected_surfaces[] = {"Plane: z=-3",
-                                                    "Plane: z=3",
-                                                    "Plane: y=-2",
-                                                    "Plane: y=2",
-                                                    "Plane: x=-1",
-                                                    "Plane: x=1"};
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-3",
+        "Plane: z=3",
+        "Plane: y=-2",
+        "Plane: y=2",
+        "Plane: x=-1",
+        "Plane: x=1",
+    };
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -1803,13 +1806,14 @@ TEST_F(ParallelepipedTest, alpha)
         = this->test(Parallelepiped(sides, Turn(0.1), Turn(0.0), Turn(0.0)));
 
     static char const expected_node[] = "all(+0, -1, +2, -3, +4, -5)";
-    static char const* const expected_surfaces[]
-        = {"Plane: z=-3",
-           "Plane: z=3",
-           "Plane: y=-1.618",
-           "Plane: y=1.618",
-           "Plane: n={0.80902,-0.58779,0}, d=-0.80902",
-           "Plane: n={0.80902,-0.58779,0}, d=0.80902"};
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-3",
+        "Plane: z=3",
+        "Plane: y=-1.618",
+        "Plane: y=1.618",
+        "Plane: n={0.80902,-0.58779,0}, d=-0.80902",
+        "Plane: n={0.80902,-0.58779,0}, d=0.80902",
+    };
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -1827,13 +1831,14 @@ TEST_F(ParallelepipedTest, theta)
         = this->test(Parallelepiped(sides, Turn(0), Turn(0.1), Turn(0)));
 
     static char const expected_node[] = "all(+0, -1, +2, -3, +4, -5)";
-    static char const* const expected_surfaces[]
-        = {"Plane: z=-3",
-           "Plane: z=3",
-           "Plane: y=-2",
-           "Plane: y=2",
-           "Plane: n={0.80902,0,-0.58779}, d=-0.80902",
-           "Plane: n={0.80902,0,-0.58779}, d=0.80902"};
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-3",
+        "Plane: z=3",
+        "Plane: y=-2",
+        "Plane: y=2",
+        "Plane: n={0.80902,0,-0.58779}, d=-0.80902",
+        "Plane: n={0.80902,0,-0.58779}, d=0.80902",
+    };
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -1851,13 +1856,14 @@ TEST_F(ParallelepipedTest, full)
         = this->test(Parallelepiped(sides, Turn(0.1), Turn(0.05), Turn(0.15)));
 
     static char const expected_node[] = "all(+0, -1, +2, -3, +4, -5)";
-    static char const* const expected_surfaces[]
-        = {"Plane: z=-3",
-           "Plane: z=3",
-           "Plane: n={0,0.96714,-0.25423}, d=-1.5649",
-           "Plane: n={0,0.96714,-0.25423}, d=1.5649",
-           "Plane: n={0.80902,-0.58779,0}, d=-0.80902",
-           "Plane: n={0.80902,-0.58779,0}, d=0.80902"};
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-3",
+        "Plane: z=3",
+        "Plane: n={0,0.96714,-0.25423}, d=-1.5649",
+        "Plane: n={0,0.96714,-0.25423}, d=1.5649",
+        "Plane: n={0.80902,-0.58779,0}, d=-0.80902",
+        "Plane: n={0.80902,-0.58779,0}, d=0.80902",
+    };
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -1886,13 +1892,13 @@ TEST_F(PrismTest, triangle)
 {
     auto result = this->test(Prism(3, 1.0, 1.2, 0.0));
     static char const expected_node[] = "all(+0, -1, -2, +3, -4)";
-    static char const* const expected_surfaces[] = {"Plane: z=-1.2",
-                                                    "Plane: z=1.2",
-                                                    "Plane: "
-                                                    "n={0.5,0.86603,0}, d=1",
-                                                    "Plane: x=-1",
-                                                    "Plane: "
-                                                    "n={0.5,-0.86603,0}, d=1"};
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-1.2",
+        "Plane: z=1.2",
+        "Plane: n={0.5,0.86603,0}, d=1",
+        "Plane: x=-1",
+        "Plane: n={0.5,-0.86603,0}, d=1",
+    };
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -1906,13 +1912,13 @@ TEST_F(PrismTest, rtriangle)
 {
     auto result = this->test(Prism(3, 1.0, 1.2, 0.5));
     static char const expected_node[] = "all(+0, -1, -2, +3, +4)";
-    static char const* const expected_surfaces[] = {"Plane: z=-1.2",
-                                                    "Plane: z=1.2",
-                                                    "Plane: x=1",
-                                                    "Plane: "
-                                                    "n={0.5,-0.86603,0}, d=-1",
-                                                    "Plane: "
-                                                    "n={0.5,0.86603,0}, d=-1"};
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-1.2",
+        "Plane: z=1.2",
+        "Plane: x=1",
+        "Plane: n={0.5,-0.86603,0}, d=-1",
+        "Plane: n={0.5,0.86603,0}, d=-1",
+    };
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -1926,13 +1932,14 @@ TEST_F(PrismTest, square)
 {
     auto result = this->test(Prism(4, 1.0, 2.0, 0.0));
     static char const expected_node[] = "all(+0, -1, -2, +3, +4, -5)";
-    static char const* const expected_surfaces[]
-        = {"Plane: z=-2",
-           "Plane: z=2",
-           "Plane: n={0.70711,0.70711,0}, d=1",
-           "Plane: n={0.70711,-0.70711,0}, d=-1",
-           "Plane: n={0.70711,0.70711,0}, d=-1",
-           "Plane: n={0.70711,-0.70711,0}, d=1"};
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-2",
+        "Plane: z=2",
+        "Plane: n={0.70711,0.70711,0}, d=1",
+        "Plane: n={0.70711,-0.70711,0}, d=-1",
+        "Plane: n={0.70711,0.70711,0}, d=-1",
+        "Plane: n={0.70711,-0.70711,0}, d=1",
+    };
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -1948,15 +1955,16 @@ TEST_F(PrismTest, hex)
 {
     auto result = this->test(Prism(6, 1.0, 2.0, 0.0));
     static char const expected_node[] = "all(+0, -1, -2, -3, +4, +5, +6, -7)";
-    static char const* const expected_surfaces[]
-        = {"Plane: z=-2",
-           "Plane: z=2",
-           "Plane: n={0.86603,0.5,0}, d=1",
-           "Plane: y=1",
-           "Plane: n={0.86603,-0.5,0}, d=-1",
-           "Plane: n={0.86603,0.5,0}, d=-1",
-           "Plane: y=-1",
-           "Plane: n={0.86603,-0.5,0}, d=1"};
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-2",
+        "Plane: z=2",
+        "Plane: n={0.86603,0.5,0}, d=1",
+        "Plane: y=1",
+        "Plane: n={0.86603,-0.5,0}, d=-1",
+        "Plane: n={0.86603,0.5,0}, d=-1",
+        "Plane: y=-1",
+        "Plane: n={0.86603,-0.5,0}, d=1",
+    };
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -1971,15 +1979,16 @@ TEST_F(PrismTest, rhex)
 {
     auto result = this->test(Prism(6, 1.0, 2.0, 0.5));
     static char const expected_node[] = "all(+0, -1, -2, -3, +4, +5, +6, -7)";
-    static char const* const expected_surfaces[]
-        = {"Plane: z=-2",
-           "Plane: z=2",
-           "Plane: x=1",
-           "Plane: n={0.5,0.86603,0}, d=1",
-           "Plane: n={0.5,-0.86603,0}, d=-1",
-           "Plane: x=-1",
-           "Plane: n={0.5,0.86603,0}, d=-1",
-           "Plane: n={0.5,-0.86603,0}, d=1"};
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-2",
+        "Plane: z=2",
+        "Plane: x=1",
+        "Plane: n={0.5,0.86603,0}, d=1",
+        "Plane: n={0.5,-0.86603,0}, d=-1",
+        "Plane: x=-1",
+        "Plane: n={0.5,0.86603,0}, d=-1",
+        "Plane: n={0.5,-0.86603,0}, d=1",
+    };
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);

--- a/test/testdetail/TestMacrosImpl.hh
+++ b/test/testdetail/TestMacrosImpl.hh
@@ -250,10 +250,15 @@ struct FVIT
 
 //---------------------------------------------------------------------------//
 /*!
- * Check if type T is a container.
+ * Check if type T is a container that needs recursive checking.
  */
 template<class T, class = void>
 struct IsContainer : std::false_type
+{
+};
+
+template<>
+struct IsContainer<std::string> : std::false_type
 {
 };
 


### PR DESCRIPTION
This fixes two errors:
1. The orientation for polyhedra was calculated correctly only for hexes. Now it works for all polys, with extended testing.
2. Roundoff error sometimes caused solid construction to fail with errors such as `Failed to convert solid type 'G4Polyhedra' named 'quad_third': invalid interior angle 1 [turns]: must be in (0, 1]`. A new soft equivalence test fixes it.

Before (spheres are for where the assertion failed):
![polyhedra-old](https://github.com/user-attachments/assets/58f32bff-f391-4fc2-91a9-c7e97cad07d5)

After:
![polyhedra-new](https://github.com/user-attachments/assets/748342d8-574c-45dc-9a04-da454a8a5ab6)
