### PR TITLE
Make Geant4 volume IDs consistent wrt load order

### DIFF
--- a/app/celer-g4/SensitiveDetector.cc
+++ b/app/celer-g4/SensitiveDetector.cc
@@ -62,6 +62,9 @@ void SensitiveDetector::Initialize(G4HCofThisEvent* hce)
 //---------------------------------------------------------------------------//
 /*!
  * Add hits to the current hit collection.
+ *
+ * \todo This should be rewritten/discarded/replaced with EDM4HEP or something
+ * else useful.
  */
 bool SensitiveDetector::ProcessHits(G4Step* g4step, G4TouchableHistory*)
 {
@@ -82,6 +85,8 @@ bool SensitiveDetector::ProcessHits(G4Step* g4step, G4TouchableHistory*)
 
     // Insert hit (use pre-step time since post-steps can be undefined)
     EventHitData hit;
+    // NOTE: instance ID will differ from volume ID if geometry has been
+    // reloaded
     hit.volume = log_vol->GetInstanceID();
     hit.copy_num = phys_vol->GetCopyNo();
     hit.energy_dep = convert_from_geant(edep, CLHEP::MeV);

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -37,7 +37,7 @@ struct GeantPhysicalInstance
 {
     using ReplicaId = OpaqueId<struct Replica_>;
 
-    //! Geant4 physical volume
+    //! Geant4 physical volume pointer
     G4VPhysicalVolume const* pv{nullptr};
     //! Replica/parameterisation instance
     ReplicaId replica;

--- a/src/geocel/g4/GeantGeoData.hh
+++ b/src/geocel/g4/GeantGeoData.hh
@@ -28,7 +28,13 @@ namespace celeritas
 template<Ownership W, MemSpace M>
 struct GeantGeoParamsData
 {
+    //! Pointer to the Geant4 world
     G4VPhysicalVolume* world{nullptr};
+
+    //! Instance ID of the first logical volume in the store
+    VolumeId::size_type lv_offset{0};
+    //! Instance ID of the first physical volume in the store
+    VolumeInstanceId::size_type pv_offset{0};
 
     //! Whether the interface is initialized
     explicit CELER_FUNCTION operator bool() const { return world != nullptr; }

--- a/test/geocel/GenericGeoTestInterface.cc
+++ b/test/geocel/GenericGeoTestInterface.cc
@@ -178,7 +178,7 @@ std::vector<std::string> GenericGeoTestInterface::get_volume_labels() const
     std::vector<std::string> result;
 
     auto const& volumes = this->geometry_interface()->volumes();
-    for (auto vidx : range(this->volume_offset(), volumes.size()))
+    for (auto vidx : range(volumes.size()))
     {
         Label const& lab = volumes.at(VolumeId{vidx});
         if (!lab.empty())
@@ -199,7 +199,7 @@ GenericGeoTestInterface::get_volume_instance_labels() const
     std::vector<std::string> result;
 
     auto const& vol_inst = this->geometry_interface()->volume_instances();
-    for (auto vidx : range(this->volume_instance_offset(), vol_inst.size()))
+    for (auto vidx : range(vol_inst.size()))
     {
         Label const& lab = vol_inst.at(VolumeInstanceId{vidx});
         if (!lab.empty())
@@ -227,7 +227,7 @@ std::vector<std::string> GenericGeoTestInterface::get_g4pv_labels() const
     auto const& vol_inst = geo.volume_instances();
 
     std::vector<std::string> result;
-    for (auto vidx : range(this->volume_instance_offset(), vol_inst.size()))
+    for (auto vidx : range(vol_inst.size()))
     {
         VolumeInstanceId vi_id{vidx};
         if (vol_inst.at(vi_id).empty())
@@ -273,18 +273,17 @@ std::vector<std::string> GenericGeoTestInterface::get_g4pv_labels() const
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the volume name, adjusting for offsets from loading multiple geo.
+ * Get the volume name.
  */
 std::string_view GenericGeoTestInterface::get_volume_name(VolumeId i) const
 {
     CELER_EXPECT(i);
     auto const& volumes = this->geometry_interface()->volumes();
-    auto index = this->volume_offset() + i.get();
-    if (index >= volumes.size())
+    if (i < volumes.size())
     {
-        return "<out of range>";
+        return volumes.at(VolumeId{i.get()}).name;
     }
-    return volumes.at(VolumeId{index}).name;
+    return "<out of range>";
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/GenericGeoTestInterface.hh
+++ b/test/geocel/GenericGeoTestInterface.hh
@@ -133,15 +133,6 @@ class GenericGeoTestInterface
     // Get the threshold in "unit lengths" for a movement being a "bump"
     virtual real_type bump_tol() const;
 
-    //! Ignore the first N VolumeId
-    virtual VolumeId::size_type volume_offset() const { return 0; }
-
-    //! Ignore the first N VolumeInstanceId
-    virtual VolumeInstanceId::size_type volume_instance_offset() const
-    {
-        return 0;
-    }
-
     //! Unit length for "track" testing and other results
     virtual Constant unit_length() const { return lengthunits::centimeter; }
 

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -572,7 +572,7 @@ TEST_F(SolidsTest, trace)
 TEST_F(SolidsTest, reflected_vol)
 {
     auto geo = this->make_geo_track_view({-500, -125, 0}, {0, 1, 0});
-    EXPECT_EQ(25, geo.volume_id().unchecked_get() - this->volume_offset());
+    EXPECT_EQ(25, geo.volume_id().unchecked_get());
     auto const& label = this->geometry()->volumes().at(geo.volume_id());
     EXPECT_EQ("trd3_refl", label.name);
     EXPECT_FALSE(ends_with(label.ext, "_refl"));

--- a/test/geocel/g4/GeantGeoTestBase.hh
+++ b/test/geocel/g4/GeantGeoTestBase.hh
@@ -20,18 +20,6 @@ namespace test
 class GeantGeoTestBase : public GenericGeoTestBase<GeantGeoParams>
 {
   public:
-    //! Ignore the first N VolumeId due to global int shenanigans
-    VolumeId::size_type volume_offset() const final
-    {
-        return this->geometry()->lv_offset();
-    }
-
-    //! Ignore the first N VolumeInstanceId due to global int shenanigans
-    VolumeInstanceId::size_type volume_instance_offset() const final
-    {
-        return this->geometry()->pv_offset();
-    }
-
     //! Get the world volume
     G4VPhysicalVolume const* g4world() const final
     {


### PR DESCRIPTION
This minor change updates the Geant4 geometry to keep volume IDs consistent for use in ORANGE volume ID mapping.